### PR TITLE
pfblockerng: normalize downloaded feed text once per file (.norm); scrub invalid UTF-8 deterministically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,9 @@ jobs:
         # import-time dep tests/test_shard_union.py needs to actually run here
         # instead of importorskip-skipping (issue #861) -- it's the splitter's
         # sole end-to-end correctness gate, so it must execute in this job.
-        run: pip install pytest pytest-cov dnspython==2.8.0
+        # charset-normalizer lets tests/test_feed_normalize_script.py execute the
+        # issue #1797 feed-encoding converter here instead of importorskip-skipping.
+        run: pip install pytest pytest-cov dnspython==2.8.0 charset-normalizer
 
       - name: Run tests
         # testpaths and addopts are configured in pyproject.toml

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1261,6 +1261,16 @@ FreeBSD-ports RUN_DEPENDS so its presence is contractual, not incidental. PHP ne
 / `pfb_hash_write` / `pfb_local_feed_changed` / `pfb_validator_read` / `pfb_validator_write` /
 `pfb_conditional_get_decision`; `pfb_download`) and `pfblockerng_cron.inc`
 (`pfb_update_check`; `pfblockerng_sync_cron`).
+
+**Normalize layer (issue #1797)** — a second, *processing-level* change-detection point sits
+ABOVE the wire-byte sidecar: `pfb_feed_normalize()` derives `{header}.norm` from
+`{header}.orig` on demand (iconv UTF-8 validity gate → charset_normalizer conversion only for
+invalid files → one `C.UTF-8 sed` control-strip + per-line rtrim), keyed by
+`{header}.norm.src.xxhash128` (the xxh128 of the source `.orig`). Both parse loops read
+`.norm` (raw `.orig` on failure), and a fresh download whose `.norm` is byte-identical skips
+the reparse (`pfb_dnsbl_norm_reuse_skip` / `pfb_ip_norm_reuse_skip`). The wire-byte
+`.orig.xxhash128` sidecar and the #946 UTF-16 transcode are unchanged; the ADR-43 Force
+clear-hashes sweep also removes the `.norm.src` baselines so a forced pass always reprocesses.
 Off-appliance pinned by `tests/php/FeedChangeHashHelpersTest.php` +
 `tests/php/ConditionalGetHelpersTest.php`; the live `304`/ETag + same-second detection legs are
 ADR-04 smoke (`tests/smoke/test_smoke_feeds.py`).

--- a/scripts/misc/install_deps_CE_2.8.sh
+++ b/scripts/misc/install_deps_CE_2.8.sh
@@ -18,19 +18,21 @@
 set -eu
 
 # Package names map 1:1 to the port RUN_DEPENDS origins:
-#   libmaxminddb     net/libmaxminddb        (mmdblookup — GeoIP)
-#   py311-maxminddb  net/py-maxminddb        (GeoIP reader in pfb_unbound.py)
-#   py311-sqlite3    databases/py-sqlite3    (DNSBL / reports DB)
-#   lighttpd         www/lighttpd            (DNSBL sinkhole webserver)
-#   jq               textproc/jq             (feeds, AWS IP-prefix pre-scripts)
-#   rsync            net/rsync               (rsync-format feed lists)
-#   grepcidr         net-mgmt/grepcidr       (IP path)
-#   iprange          net-mgmt/iprange        (IP path)
-#   gnugrep          textproc/gnugrep        (ggrep — list pipeline)
+#   libmaxminddb             net/libmaxminddb              (mmdblookup — GeoIP)
+#   py311-maxminddb          net/py-maxminddb              (GeoIP reader in pfb_unbound.py)
+#   py311-sqlite3            databases/py-sqlite3          (DNSBL / reports DB)
+#   py311-charset-normalizer textproc/py-charset-normalizer (feed encoding detection, issue #1797)
+#   lighttpd                 www/lighttpd                  (DNSBL sinkhole webserver)
+#   jq                       textproc/jq                   (feeds, AWS IP-prefix pre-scripts)
+#   rsync                    net/rsync                     (rsync-format feed lists)
+#   grepcidr                 net-mgmt/grepcidr             (IP path)
+#   iprange                  net-mgmt/iprange              (IP path)
+#   gnugrep                  textproc/gnugrep              (ggrep — list pipeline)
 env ASSUME_ALWAYS_YES=yes pkg install -y \
     libmaxminddb \
     py311-maxminddb \
     py311-sqlite3 \
+    py311-charset-normalizer \
     lighttpd \
     jq \
     rsync \

--- a/src/usr/local/pkg/pfblockerng/pfb_feed_normalize.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_feed_normalize.py
@@ -1,0 +1,68 @@
+"""Detect a downloaded feed file's encoding and convert it to UTF-8 (issue #1797).
+
+Usage: <pfb_python_interpreter()> pfb_feed_normalize.py <src> <dst>
+
+Runs only for files that already FAILED the iconv UTF-8 validity gate in
+pfb_feed_normalize_generate(); the caller never hands it valid UTF-8.
+Detection reads the WHOLE file via charset_normalizer.from_path() (a bounded
+prefix mis-detects a long-ASCII-header file as ascii and loses every high
+byte); conversion streams chunk-wise with errors='replace' so memory stays
+bounded on multi-megabyte feeds.
+
+stdout on success: "<detected-encoding> <replacement-count>\n", exit 0.
+A nonzero replacement count means bytes the detected codec could not decode
+were replaced with U+FFFD -- the caller logs it as a wrong-detection signal
+(pre-existing U+FFFD in the input counts too; the signal stays a signal).
+Any failure: message on stderr, exit 1, dst content undefined.
+"""
+
+from __future__ import annotations
+
+import codecs
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print("usage: pfb_feed_normalize.py <src> <dst>", file=sys.stderr)
+        return 1
+    src, dst = argv[1], argv[2]
+
+    try:
+        from charset_normalizer import from_path
+    except ImportError:
+        print("charset_normalizer is not installed", file=sys.stderr)
+        return 1
+
+    try:
+        best = from_path(src).best()
+    except OSError as exc:
+        print(f"detection failed: {exc}", file=sys.stderr)
+        return 1
+    if best is None:
+        print("no encoding match", file=sys.stderr)
+        return 1
+
+    encoding = best.encoding
+    replaced = 0
+    try:
+        decoder = codecs.getincrementaldecoder(encoding)("replace")
+        with open(src, "rb") as fin, open(dst, "wb") as fout:
+            while True:
+                chunk = fin.read(1 << 20)
+                text = decoder.decode(chunk, final=not chunk)
+                if text:
+                    replaced += text.count("\ufffd")
+                    fout.write(text.encode("utf-8"))
+                if not chunk:
+                    break
+    except (LookupError, OSError, ValueError) as exc:
+        print(f"conversion failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"{encoding} {replaced}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7653,6 +7653,19 @@ function pfb_dnsbl_strip_bom(string $line): string {
 }
 
 
+// Per-line scrub for the DNSBL feed parse loop, extracted verbatim from the loop.
+// Contract pinned by DnsblScrubLineTest.
+function pfb_dnsbl_scrub_line(string $line): string {
+	// Remove any '^M' characters
+	if (strpos($line, "\r") !== FALSE) {
+		$line = rtrim($line, "\x00..\x1F");
+	}
+
+	// Remove invalid charaters
+	return trim($line, " \t\n\r\0\x0B\xC2\xA0");
+}
+
+
 // Issue #938: unwrap a bracketed IPv6 literal ('[2604:2dc0:100:4ed8::]' -> '2604:2dc0:100:4ed8::')
 // so the existing is_ipaddrv6($line) collection branch (feeding $domain_data_ip6) recognises it.
 // is_ipaddrv6() rejects the brackets outright and pfb_filter() rejects it as a domain, so today

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1115,6 +1115,164 @@ function pfb_ensure_trailing_newline(string $path): bool {
 	return $written !== FALSE && $written === 1;
 }
 
+
+/**
+ * issue #1797: on-demand text normalization of a downloaded feed baseline.
+ * {base}.orig -> {base}.norm, regenerated ONLY when {base}.norm is missing or
+ * the recorded source digest ({base}.norm.src.xxhash128, the xxh128 of the
+ * .orig the .norm was built FROM) no longer matches the current .orig -- so
+ * custom-list re-synthesis, reload-without-refetch, user pre-script mutation
+ * and a first upgrade (populated orig dir, zero .norm) all converge without a
+ * download-time hook having to see them. Written tmp + atomic rename in the
+ * same directory; the #1263 trailing-newline guarantee is re-applied (the sed
+ * pass never adds one). The wire-byte ADR-42 sidecar ({base}.orig.xxhash128)
+ * is a DIFFERENT, untouched artifact.
+ *
+ * Returns array{path:string, changed:bool, normalized:bool}:
+ *   path       -- file the caller should parse: .norm, or .orig on any failure
+ *                 (fallback: a feed must degrade to raw parsing, never to empty).
+ *   changed    -- FALSE only when the normalized CONTENT is proven unchanged
+ *                 against a recorded baseline (fresh sidecar match, or a
+ *                 regeneration that produced byte-identical .norm). A missing/
+ *                 corrupt baseline reports TRUE (fail-safe, ADR-42 semantics;
+ *                 the Force clear-hashes sweep relies on this to defeat the
+ *                 downstream-skip gate).
+ *   normalized -- TRUE iff path points at a usable .norm.
+ *
+ * @return array{path:string, changed:bool, normalized:bool}
+ */
+function pfb_feed_normalize(string $orig_path, ?string $interpreter = NULL): array {
+	$fallback = array('path' => $orig_path, 'changed' => TRUE, 'normalized' => FALSE);
+	if (!str_ends_with($orig_path, '.orig') || !file_exists($orig_path)) {
+		return $fallback;
+	}
+	$base      = substr($orig_path, 0, -strlen('.orig'));
+	$norm_path = "{$base}.norm";
+	$src_base  = "{$base}.norm.src";
+
+	// Hash the source BEFORE generating: a mid-run .orig replacement then reads
+	// as stale next pass and re-normalizes (fail-safe), never as falsely fresh.
+	$src_digest = pfb_content_hash($orig_path, TRUE);
+	if ($src_digest === FALSE) {
+		return $fallback;
+	}
+
+	$sidecar = pfb_hash_read($src_base);
+	if ($sidecar['algo'] === 'xxh128' && $sidecar['digest'] === $src_digest && file_exists($norm_path)) {
+		return array('path' => $norm_path, 'changed' => FALSE, 'normalized' => TRUE);
+	}
+
+	$prev_digest  = file_exists($norm_path) ? pfb_content_hash($norm_path, TRUE) : FALSE;
+	$had_baseline = ($sidecar['algo'] === 'xxh128' && $prev_digest !== FALSE);
+
+	// Exclusive-create the tmp IN the target directory: tempnam() silently
+	// falls back to the system tmp dir when the target is unwritable, and a
+	// cross-filesystem rename() is not atomic (or fails outright).
+	$tmp = dirname($norm_path) . '/.pfbnorm_' . getmypid() . '_' . bin2hex(random_bytes(4));
+	$th  = @fopen($tmp, 'x');
+	if ($th === FALSE) {
+		return $fallback;
+	}
+	fclose($th);
+
+	if (!pfb_feed_normalize_generate($orig_path, $tmp, $interpreter)) {
+		@unlink($tmp);
+		pfb_logger("\n[ pfb_feed_normalize ] normalization failed for {$orig_path} -- parsing the raw .orig\n", 2);
+		return $fallback;
+	}
+	pfb_ensure_trailing_newline($tmp);
+
+	$new_digest = pfb_content_hash($tmp, TRUE);
+	if ($new_digest === FALSE || !@rename($tmp, $norm_path)) {
+		@unlink($tmp);
+		return $fallback;
+	}
+	@file_put_contents("{$src_base}.xxhash128", $src_digest, LOCK_EX);
+
+	return array(
+		'path'       => $norm_path,
+		'changed'    => !($had_baseline && $new_digest === $prev_digest),
+		'normalized' => TRUE,
+	);
+}
+
+
+// issue #1797: the normalize pipeline body -- $src (.orig bytes) -> $dst (UTF-8,
+// control-stripped, per-line right-trimmed). Ordering is load-bearing:
+//   (b) whole-file iconv validity gate first -- a server-declared charset is
+//       NOT trusted over provable UTF-8 validity (a wrong ISO-8859-1 label on
+//       a UTF-8 body would double-encode it), and iconv -c can never be the
+//       converter (it DELETES undecodable bytes silently, no signal);
+//   (c) only an invalid file reaches the Python detector/converter
+//       (charset_normalizer whole-file detection + errors='replace' decode,
+//       U+FFFD replacements counted and logged as the wrong-guess signal);
+//       if conversion is unavailable the raw bytes fall through to (d) --
+//       sed passes invalid sequences through untouched while still stripping
+//       controls, graceful degradation rather than an empty feed;
+//   (d) one C.UTF-8 sed pass strips every non-printable except tab (Cc, Cf
+//       incl. BOM/ZWJ, C1, NUL, mid-line CR) and right-trims [[:space:]] runs
+//       per line -- interior tabs (hosts/TSV) and interior NBSP survive as
+//       data. Membership probed on CE 2.8 (FreeBSD 15) and Plus (FreeBSD 16).
+function pfb_feed_normalize_generate(string $src, string $dst, ?string $interpreter = NULL): bool {
+	$src_esc = escapeshellarg($src);
+	$dst_esc = escapeshellarg($dst);
+
+	$ret = 1;
+	exec("/usr/bin/iconv -f UTF-8 -t UTF-8 < {$src_esc} > /dev/null 2>&1", $unused_out, $ret);
+
+	$strip_src = $src;
+	$conv_tmp  = '';
+	if ($ret !== 0) {
+		$conv_tmp = "{$dst}.conv";
+		if (pfb_feed_convert_encoding($src, $conv_tmp, $interpreter)) {
+			$strip_src = $conv_tmp;
+		} else {
+			pfb_logger("\n[ pfb_feed_normalize ] encoding conversion unavailable for {$src} -- stripping raw bytes\n", 2);
+		}
+	}
+
+	$sed_expr = "s/[^[:print:]\t]+|[[:space:]]+\$//g";
+	$ret2 = 1;
+	exec('LC_ALL=C.UTF-8 /usr/bin/sed -E ' . escapeshellarg($sed_expr) . ' < ' .
+		escapeshellarg($strip_src) . " > {$dst_esc} 2>/dev/null", $unused_out2, $ret2);
+	if ($conv_tmp !== '') {
+		@unlink($conv_tmp);
+	}
+	return $ret2 === 0 && file_exists($dst);
+}
+
+
+// issue #1797: detect + convert a non-UTF-8 feed file to UTF-8 via
+// pfb_feed_normalize.py (charset_normalizer, a RUN_DEPENDS). The interpreter
+// comes ONLY from pfb_python_interpreter() on the appliance ($interpreter is
+// a test seam). U+FFFD replacements reported by the script are logged: a high
+// count means the detection was probably wrong, and silence here would be
+// silent data corruption.
+function pfb_feed_convert_encoding(string $src, string $dst, ?string $interpreter = NULL): bool {
+	$py = $interpreter ?? pfb_python_interpreter();
+	if ($py === '') {
+		return FALSE;
+	}
+	$script = __DIR__ . '/pfb_feed_normalize.py';
+	$out = array();
+	$ret = 1;
+	exec(escapeshellarg($py) . ' ' . escapeshellarg($script) . ' ' .
+		escapeshellarg($src) . ' ' . escapeshellarg($dst) . ' 2>&1', $out, $ret);
+	if ($ret !== 0 || !file_exists($dst)) {
+		pfb_logger("\n[ pfb_feed_normalize ] encoding detection failed for {$src}: " . implode(' | ', $out) . "\n", 2);
+		return FALSE;
+	}
+	$fields   = explode(' ', trim((string) end($out)));
+	$encoding = $fields[0] ?? '?';
+	$replaced = (int) ($fields[1] ?? 0);
+	pfb_logger("\n[ pfb_feed_normalize ] converted {$src} from '{$encoding}' to UTF-8\n", 1);
+	if ($replaced > 0) {
+		pfb_logger("[ pfb_feed_normalize ] {$replaced} undecodable byte sequence(s) replaced with U+FFFD in {$src} -- the detected encoding '{$encoding}' may be wrong\n", 2);
+	}
+	return TRUE;
+}
+
+
 // ADR-49: content-sanity gate for a downloaded text feed's first 64-KiB chunk; pinned by
 // PfbTextSanityTest. Reason order (first hit wins): 'nul_bytes' (any NUL byte) >
 // 'html_error_page' (opens as HTML AND no line is blocklist-shaped: an IPv4/IPv6/CIDR

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3328,9 +3328,14 @@ function pfb_is_blank(?string $value): bool {
  * same way, so Unicode-whitespace stripping may not apply for that call.
  */
 function pfb_sanitize_text(string $text): string {
+	// issue #1797 (A6): browser-fed input is UTF-8 by construction; the old
+	// mb_detect_encoding() recovery could never fail (every byte sequence is
+	// valid ISO-8859-1) and only manufactured mojibake. Scrub deterministically
+	// instead -- the valid-UTF-8 output invariant is load-bearing:
+	// pfb_preg_replace_safe()'s /u patterns return the subject UNCHANGED on
+	// invalid UTF-8, so without it the strips below silently degrade to trim().
 	if (!mb_check_encoding($text, 'UTF-8')) {
-		$text = mb_convert_encoding($text, 'UTF-8',
-			mb_detect_encoding($text, 'UTF-8, ASCII, ISO-8859-1'));
+		$text = mb_convert_encoding($text, 'UTF-8', 'UTF-8');
 	}
 	$text = pfb_preg_replace_safe('/\p{C}+/u', '', $text);
 	$text = pfb_preg_replace_safe('/^[\p{Z}\t]+|[\p{Z}\t]+$/u', '', $text);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2465,6 +2465,30 @@ function pfb_dnsbl_verbatim_reuse_active(bool $txt_exists, bool $update_exists, 
 	return $txt_exists && !$update_exists && !$fail_exists && $reuse_unset && $staging_current_generation;
 }
 
+// issue #1797: skip the DNSBL reparse when a FRESH download normalized to
+// byte-identical content -- upstream churn that normalizes away (CRLF flips,
+// trailing whitespace, a BOM) rebuilds nothing. Deliberately narrow: only a
+// completed non-custom download qualifies (a Reload/Force pass must keep its
+// reparse-everything semantics; a custom list re-synthesizes per pass; a
+// stale-.orig download-failure fallback stays fail-safe like #1022/#1031),
+// and only onto a current-generation staged '.txt' (#1083).
+function pfb_dnsbl_norm_reuse_skip(bool $downloaded_fresh, bool $custom, bool $orig_content_stale,
+	bool $norm_changed, bool $txt_exists, bool $staging_current_generation): bool
+{
+	return $downloaded_fresh && !$custom && !$orig_content_stale && !$norm_changed &&
+		$txt_exists && $staging_current_generation;
+}
+
+// issue #1797: the IP-loop counterpart of pfb_dnsbl_norm_reuse_skip(). Feeds
+// carrying a user pre/post script never skip -- the scripts' contract is a
+// full pass over the downloaded file every run.
+function pfb_ip_norm_reuse_skip(bool $downloaded_fresh, bool $custom, bool $orig_content_stale,
+	bool $norm_changed, bool $txt_exists, bool $has_user_script): bool
+{
+	return $downloaded_fresh && !$custom && !$orig_content_stale && !$norm_changed &&
+		$txt_exists && !$has_user_script;
+}
+
 // issue #1083: a stale-generation rebuild ($stale_generation_rebuild, above) that
 // reparses '.orig' and finds ZERO domains must converge staging to empty -- else the
 // pre-NDJSON '.txt' is never touched, its stale lines are silently double-counted, and
@@ -13136,6 +13160,13 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// the transcode-ordering comment above).
 			pfb_ensure_trailing_newline("{$orig_download}");
 
+			// issue #1797: eagerly normalize the finalized plain .orig so the parse
+			// pass finds a fresh .norm. Correctness never depends on this call --
+			// the consumer regenerates on demand keyed by the source digest -- and
+			// the geoip/asn/top1m/blacklist archive paths early-return above, so a
+			// compressed artifact can never reach the text pipeline.
+			pfb_feed_normalize("{$orig_download}");
+
 			// Process Emerging Threats IQRisk if required
 			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {
 				exec("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}");
@@ -14806,6 +14837,16 @@ function pfb_force_clear_validators(array $dirs, bool $clear_hashes): int {
 	foreach ($dirs as $dir) {
 		foreach ($suffixes as $sfx) {
 			foreach (glob("{$dir}/*.orig.{$sfx}") ?: array() as $sidecar) {
+				if (unlink_if_exists($sidecar)) {
+					$removed++;
+				}
+			}
+		}
+		// issue #1797: also clear the normalize-stage source-digest baselines so
+		// pfb_feed_normalize() fail-safes to 'changed' and the downstream norm-skip
+		// gate cannot defeat a forced reprocess.
+		if ($clear_hashes) {
+			foreach (glob("{$dir}/*.norm.src.xxhash128") ?: array() as $sidecar) {
 				if (unlink_if_exists($sidecar)) {
 					$removed++;
 				}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7653,16 +7653,16 @@ function pfb_dnsbl_strip_bom(string $line): string {
 }
 
 
-// Per-line scrub for the DNSBL feed parse loop, extracted verbatim from the loop.
-// Contract pinned by DnsblScrubLineTest.
+// Per-line scrub for the DNSBL feed parse loop (issue #1797). CR is removed
+// EVERYWHERE (a lone CR embeds mid-row after fgets()); the trim charlist is
+// ASCII-only so a byte-wise trim can never slice a multi-byte character and
+// create invalid UTF-8. Unicode whitespace hygiene (trailing NBSP etc.) is
+// the whole-file normalize stage's job. Contract pinned by DnsblScrubLineTest.
 function pfb_dnsbl_scrub_line(string $line): string {
-	// Remove any '^M' characters
 	if (strpos($line, "\r") !== FALSE) {
-		$line = rtrim($line, "\x00..\x1F");
+		$line = str_replace("\r", '', $line);
 	}
-
-	// Remove invalid charaters
-	return trim($line, " \t\n\r\0\x0B\xC2\xA0");
+	return trim($line, " \t\n\0\x0B");
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -13165,12 +13165,13 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// the transcode-ordering comment above).
 			pfb_ensure_trailing_newline("{$orig_download}");
 
-			// issue #1797: eagerly normalize the finalized plain .orig so the parse
-			// pass finds a fresh .norm. Correctness never depends on this call --
-			// the consumer regenerates on demand keyed by the source digest -- and
-			// the geoip/asn/top1m/blacklist archive paths early-return above, so a
-			// compressed artifact can never reach the text pipeline.
-			pfb_feed_normalize("{$orig_download}");
+			// issue #1797: normalization deliberately does NOT run here. Only the
+			// parse-loop consumers normalize: the helper's changed-verdict means
+			// "changed since the last CONSUMER normalize", so a download-time call
+			// would consume the change signal and make the loops' norm-skip gate
+			// wrongly reuse stale staging (caught live by
+			// test_cron_detects_changed_local_feed). The geoip/asn/top1m/blacklist
+			// archive paths early-return above and never reach the text pipeline.
 
 			// Process Emerging Threats IQRisk if required
 			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1690,6 +1690,7 @@ function sync_package_pfblockerng($cron='') {
 								pfb_logger("{$log}", 1);
 								$file_dwn = "{$pfborig}/{$header}";
 								$orig_content_stale = FALSE;
+								$downloaded_fresh = FALSE;
 
 								// issue #1278: Hold means "download once, never again" -- skip the network
 								// fallback entirely and retry next pass; staging stays untouched.
@@ -1750,6 +1751,7 @@ function sync_package_pfblockerng($cron='') {
 										else {
 											// Clear any previous download fail marker
 											unlink_if_exists("{$pfbfolder}/{$header}.fail");
+											$downloaded_fresh = TRUE;
 										}
 									}
 								}
@@ -1760,6 +1762,26 @@ function sync_package_pfblockerng($cron='') {
 									unset($custom_list);
 								}
 
+								// issue #1797: normalize once per file; the parse below reads .norm
+								// (raw .orig on normalize failure). A fresh download whose NORMALIZED
+								// content is byte-identical to the previous pass reuses the staged
+								// '.txt' the same way the verbatim-reuse branch does.
+								$pfb_norm = pfb_feed_normalize("{$file_dwn}.orig");
+								if (pfb_dnsbl_norm_reuse_skip($downloaded_fresh, (bool) $custom, $orig_content_stale,
+								    $pfb_norm['changed'], file_exists("{$pfbfolder}/{$header}.txt"), $staging_current_generation)) {
+									pfb_logger("\n[ {$header} ]{$logtab} unchanged after normalization.", 1);
+									$lists_dnsbl_all[]	= "{$row['header']}.txt";
+									// ADR-31: same manifest-row shape as the verbatim-reuse branch above.
+									$pfb_py_feeds[]		= pfb_feed_manifest_row(
+										$header, $alias, $logging_type,
+										$custom ? 'user' : 'feed',
+										$mode);
+									$list_cnt		= pfb_count_lines("{$pfbfolder}/{$header}.txt") ?? 0;
+									$alias_cnt		= $alias_cnt + $list_cnt;
+									unlink_if_exists("{$pfbfolder}/{$header}.update");
+									continue;
+								}
+
 								$run_once = $csv_parser = FALSE;
 								$csv_type = '';
 								$ipcount = $ip_cnt = $ip_cnt6 = 0;
@@ -1767,7 +1789,7 @@ function sync_package_pfblockerng($cron='') {
 								$dnsbl_lineno = 0;		// issue #1004: per-line counter for the parse-error detail sink
 
 								// Parse downloaded file for Domain names
-								if (($fhandle = @fopen("{$file_dwn}.orig", 'r')) !== FALSE) {
+								if (($fhandle = @fopen($pfb_norm['path'], 'r')) !== FALSE) {
 									if (($dhandle = @fopen("{$pfbfolder}/{$header}.bk", 'w')) !== FALSE) {
 										while (($line = @fgets($fhandle)) !== FALSE) {
 
@@ -3132,6 +3154,7 @@ function sync_package_pfblockerng($cron='') {
 							pfb_logger("{$log}", 1);
 							$file_dwn = "{$pfborig}/{$header}";
 							$orig_content_stale = FALSE;
+							$downloaded_fresh = FALSE;
 
 							// Force 'Alias Native' setting to any Alias with 'Advanced Inbound/Outbound -Invert src/dst' settings.
 							// This will bypass Deduplication and Reputation features.
@@ -3235,6 +3258,7 @@ function sync_package_pfblockerng($cron='') {
 									else {
 										// Clear any previous download fail marker
 										unlink_if_exists("{$pfbfolder}/{$header}.fail");
+										$downloaded_fresh = TRUE;
 										pfb_logger('.', 1);
 									}
 								}
@@ -3290,15 +3314,32 @@ function sync_package_pfblockerng($cron='') {
 							}
 
 							// IPv4/6 Advanced Tunable - (Pre Script processing)
+							$pfb_user_script = FALSE;
 							if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {
 								pfb_logger("\nExecuting pre-script: {$list['script_pre']}\n", 1);
+								$pfb_user_script = TRUE;
 								$file_dwn_esc = escapeshellarg("{$file_dwn}.orig");
 								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.pre"); // Save original file for restoration
 								$tmo = '/usr/bin/timeout -s TERM -k ' . PFB_HOOK_KILL_GRACE . ' ' . PFB_LIST_SCRIPT_TIMEOUT . ' ';
 								exec("{$tmo}" . escapeshellarg($pfb_script_pre) . " {$file_dwn_esc} {$list['vtype']} {$elog}");
 							}
+							if ($pfb_script_post && is_file("{$pfb_script_post}")) {
+								$pfb_user_script = TRUE;
+							}
 
-							if (($fhandle = @fopen("{$file_dwn}.orig", 'r')) !== FALSE) {
+							// issue #1797: normalize once per file (after the pre-script has had its
+							// raw look at .orig); the parse below reads .norm (raw .orig on normalize
+							// failure). A fresh download whose NORMALIZED content is byte-identical
+							// to the previous pass keeps the staged '.txt' untouched.
+							$pfb_norm = pfb_feed_normalize("{$file_dwn}.orig");
+							if (pfb_ip_norm_reuse_skip($downloaded_fresh, (bool) $custom, $orig_content_stale,
+							    $pfb_norm['changed'], file_exists("{$pfbfolder}/{$header}.txt"), $pfb_user_script)) {
+								pfb_logger("\n[ {$header} ]{$logtab} unchanged after normalization.\n", 1);
+								unlink_if_exists("{$pfbfolder}/{$header}.update");
+								continue;
+							}
+
+							if (($fhandle = @fopen($pfb_norm['path'], 'r')) !== FALSE) {
 								while (($line = @fgets($fhandle)) !== FALSE) {
 									// issue #1004: incremented every iteration, regardless of outcome
 									$ip_lineno++;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1786,13 +1786,7 @@ function sync_package_pfblockerng($cron='') {
 											// harmless (Python's parser is byte-oriented too).
 											$line = pfb_dnsbl_strip_bom($line);
 
-											// Remove any '^M' characters
-											if (strpos($line, "\r") !== FALSE) {
-												$line = rtrim($line, "\x00..\x1F");
-											}
-
-											// Remove invalid charaters
-											$line = trim($line, " \t\n\r\0\x0B\xC2\xA0");
+											$line = pfb_dnsbl_scrub_line($line);
 
 											// ADR-06 fact 7 / ADR-62: an ABP network anchor or
 											// hosts-line target that is itself an IP address is

--- a/tests/php/AliasCntGrepCountGuardTest.php
+++ b/tests/php/AliasCntGrepCountGuardTest.php
@@ -44,19 +44,20 @@ final class AliasCntGrepCountGuardTest extends TestCase
 	private const ACCUMULATION_RE = '/\$alias_cnt\s*=\s*\$alias_cnt\s*\+\s*\$list_cnt\s*;/';
 	private const COUNT_ASSIGN_RE = '/\$list_cnt\s*=\s*pfb_count_lines\([^;]*\)\s*\?\?\s*0\s*;/';
 
-	public function testVacuityExactlyTwoAccumulationSitesExist(): void
+	public function testVacuityExactlyThreeAccumulationSitesExist(): void
 	{
 		$count = preg_match_all(self::ACCUMULATION_RE, self::$src);
-		$this->assertSame(2, $count,
-			'expected exactly 2 $alias_cnt = $alias_cnt + $list_cnt; accumulation sites '
-			. "(list-reuse branch and downloaded/rebuilt branch); found {$count}");
+		$this->assertSame(3, $count,
+			'expected exactly 3 $alias_cnt = $alias_cnt + $list_cnt; accumulation sites '
+			. '(list-reuse branch, the issue #1797 norm-unchanged skip branch, and the '
+			. "downloaded/rebuilt branch); found {$count}");
 	}
 
-	public function testBothSitesAssignListCntFromPfbCountLinesWithNullFallback(): void
+	public function testAllSitesAssignListCntFromPfbCountLinesWithNullFallback(): void
 	{
 		$count = preg_match_all(self::COUNT_ASSIGN_RE, self::$src);
-		$this->assertSame(2, $count,
-			'expected exactly 2 `$list_cnt = pfb_count_lines(...) ?? 0;` assignments feeding '
+		$this->assertSame(3, $count,
+			'expected exactly 3 `$list_cnt = pfb_count_lines(...) ?? 0;` assignments feeding '
 			. "the accumulation sites (issue #1261); found {$count}");
 	}
 

--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -714,15 +714,16 @@ final class CategoryEditPostGuardTest extends TestCase
 		]);
 	}
 
-	public function testUrlInvalidUtf8LegacyConvertedAtIngestion(): void
+	public function testUrlInvalidUtf8ScrubbedToValidUtf8AtIngestion(): void
 	{
-		// issue #1737 contract update: pfb_sanitize_text() legacy-encoding-
-		// converts invalid UTF-8 to valid UTF-8 at ingestion, before the state
-		// loop's /u guard ever runs -- the raw bytes never reach the guard as
-		// invalid UTF-8. Downstream format validators (PFB_FILTER_URL, here)
-		// still run on the converted bytes -- an unrelated "Invalid URL" error
-		// from that check is not this guard's concern (assertGuardAccepts
-		// filters for the character guard's own message only).
+		// issue #1737/#1797 (A6) contract update: pfb_sanitize_text() scrubs
+		// invalid UTF-8 deterministically at ingestion (no ISO-8859-1
+		// guessing), before the state loop's /u guard ever runs -- the raw
+		// bytes never reach the guard as invalid UTF-8. Downstream format
+		// validators (PFB_FILTER_URL, here) still run on the scrubbed bytes --
+		// an unrelated "Invalid URL" error from that check is not this guard's
+		// concern (assertGuardAccepts filters for the character guard's own
+		// message only).
 		$value = "\xFF\xFE";
 		$post = [
 			'aliasname' => 'validname',
@@ -732,7 +733,8 @@ final class CategoryEditPostGuardTest extends TestCase
 			'format-0'  => 'auto',
 		];
 		$this->assertGuardAccepts($post);
-		$this->assertSame("\xC3\xBF\xC3\xBE", $_POST['url-0'], 'invalid UTF-8 must be legacy-converted (ISO-8859-1 -> UTF-8) at ingestion');
+		$this->assertSame('??', $_POST['url-0'], 'invalid UTF-8 must be scrubbed to valid UTF-8 at ingestion, never guessed into mojibake');
+		$this->assertTrue(mb_check_encoding((string) $_POST['url-0'], 'UTF-8'));
 	}
 
 	public function testUrlSaveGuardAcceptsSingleQuoteSubDelim(): void

--- a/tests/php/ConditionalGetHelpersTest.php
+++ b/tests/php/ConditionalGetHelpersTest.php
@@ -562,6 +562,32 @@ final class ConditionalGetHelpersTest extends TestCase
 	}
 
 	/**
+	 * issue #1797: clear_hashes=TRUE also removes the normalize-stage source-digest
+	 * baseline (.norm.src.xxhash128) so a forced pass regenerates and fail-safes to
+	 * 'changed' (the downstream norm-skip gate must not survive a Force). The .norm
+	 * content file itself is kept, mirroring how .orig is kept.
+	 */
+	public function test_force_clear_validators_clears_norm_source_baseline_only_with_hashes(): void
+	{
+		$dir = $this->dir;
+		file_put_contents("{$dir}/feedA.orig",                'content');
+		file_put_contents("{$dir}/feedA.norm",                'content');
+		file_put_contents("{$dir}/feedA.norm.src.xxhash128",  'deadbeef');
+
+		$removed = pfb_force_clear_validators([$dir], FALSE);
+		$this->assertFileExists("{$dir}/feedA.norm.src.xxhash128",
+			'clear_hashes=FALSE must NOT remove the .norm.src baseline');
+		$this->assertSame(0, $removed);
+
+		$removed = pfb_force_clear_validators([$dir], TRUE);
+		$this->assertFileDoesNotExist("{$dir}/feedA.norm.src.xxhash128",
+			'clear_hashes=TRUE must remove the .norm.src baseline');
+		$this->assertFileExists("{$dir}/feedA.norm", 'the .norm content file itself must be kept');
+		$this->assertFileExists("{$dir}/feedA.orig", 'the .orig content file itself must be kept');
+		$this->assertSame(1, $removed);
+	}
+
+	/**
 	 * Two dirs each with one .orig.etag → returns 2.
 	 *
 	 *  GIVEN dirA with feedA.orig.etag and dirB with feedB.orig.etag;

--- a/tests/php/DnsblScrubLineTest.php
+++ b/tests/php/DnsblScrubLineTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract for the per-line scrub the DNSBL feed parse loop applies to every
+ * row read from the normalized feed file (issue #1797). The scrub owns
+ * line-END hygiene only; whole-file concerns (mid-line controls, Unicode
+ * whitespace) are the normalize stage's job.
+ */
+#[CoversFunction('pfb_dnsbl_scrub_line')]
+final class DnsblScrubLineTest extends TestCase
+{
+	public function testPlainRowTrimsAsciiWhitespaceAtBothEnds(): void
+	{
+		$this->assertSame('example.com', pfb_dnsbl_scrub_line("  example.com \n"));
+	}
+
+	public function testTrailingCrlfIsRemoved(): void
+	{
+		$this->assertSame('example.com', pfb_dnsbl_scrub_line("example.com\r\n"));
+	}
+
+	public function testTabSeparatedHostsRowKeepsInteriorTab(): void
+	{
+		// hosts-format rows use tab as the separator; only the ENDS are trimmed.
+		$this->assertSame("127.0.0.1\tads.example.com", pfb_dnsbl_scrub_line("\t127.0.0.1\tads.example.com\t\n"));
+	}
+
+	public function testEmptyAndWhitespaceOnlyRowsScrubToEmpty(): void
+	{
+		$this->assertSame('', pfb_dnsbl_scrub_line(''));
+		$this->assertSame('', pfb_dnsbl_scrub_line(" \t\n"));
+	}
+
+	public function testInteriorUnicodeTextSurvives(): void
+	{
+		$this->assertSame('bücher.example', pfb_dnsbl_scrub_line("bücher.example\n"));
+	}
+}

--- a/tests/php/DnsblScrubLineTest.php
+++ b/tests/php/DnsblScrubLineTest.php
@@ -40,4 +40,32 @@ final class DnsblScrubLineTest extends TestCase
 	{
 		$this->assertSame('bücher.example', pfb_dnsbl_scrub_line("bücher.example\n"));
 	}
+
+	public function testMidLineCrIsRemovedNotJustAtLineEnds(): void
+	{
+		// issue #1797: a lone CR is a line separator to nothing -- fgets() hands
+		// the loop one row containing an embedded CR, and an ends-only trim
+		// leaves it inside what is then treated as a single feed entry.
+		$this->assertSame('ads.example.comevil', pfb_dnsbl_scrub_line("ads.example.com\revil\n"));
+	}
+
+	public function testScrubNeverCreatesInvalidUtf8(): void
+	{
+		// issue #1797: a byte-wise trim charlist containing "\xC2\xA0" strips
+		// those BYTES individually, slicing the final byte off an unrelated
+		// multi-byte character (U+0EA0 = E0 BA A0) and CREATING invalid UTF-8.
+		$in  = "bad\xE0\xBA\xA0";
+		$out = pfb_dnsbl_scrub_line($in);
+		$this->assertTrue(mb_check_encoding($out, 'UTF-8'),
+			'scrub output must stay valid UTF-8, got bytes: ' . bin2hex($out));
+		$this->assertSame($in, $out, 'a well-formed trailing multi-byte character must survive the scrub');
+	}
+
+	public function testTrailingNbspIsLineDataAtThisSeam(): void
+	{
+		// issue #1797: Unicode whitespace hygiene (trailing NBSP and friends)
+		// belongs to the whole-file normalize stage; the per-line scrub is
+		// ASCII-only so it can never slice a multi-byte sequence.
+		$this->assertSame("x\xC2\xA0", pfb_dnsbl_scrub_line("x\xC2\xA0\n"));
+	}
 }

--- a/tests/php/HooksSanitizeIngestionTest.php
+++ b/tests/php/HooksSanitizeIngestionTest.php
@@ -140,20 +140,22 @@ final class HooksSanitizeIngestionTest extends TestCase
 		$this->assertSame('30', $result['hooks'][0]['timeout'], 'the sanitized timeout must persist as the plain digit string');
 	}
 
-	// --- description: legacy (ISO-8859-1) byte converts to valid UTF-8 ---
+	// --- description: an invalid UTF-8 byte is scrubbed, not guessed at ---
 
-	public function testDescriptionLegacyEncodingByteConvertsToUtf8(): void
+	public function testDescriptionInvalidUtf8ByteScrubsToValidUtf8(): void
 	{
-		// RED today: "caf\xE9" is invalid UTF-8, so preg_match(...,'/u') on the
-		// RAW value returns FALSE (not 0); the validator's `!== 0` fail-closed
-		// compare treats that as a reject too, so the row never reaches
-		// persist. GREEN: sanitize converts the legacy byte to UTF-8 first, so
-		// the validator sees valid text and passes.
+		// issue #1797 (A6): the sanitizer no longer guesses ISO-8859-1 for a
+		// browser-fed field (UI pages are UTF-8; the old recovery could only
+		// manufacture mojibake). The invalid byte is substituted
+		// deterministically, the value stays valid UTF-8, and the \p{C}
+		// validator passes on the already-clean text -- so the row persists
+		// the scrubbed value instead of being rejected.
 		$result = $this->runSave([
 			'hook_description-0' => "caf\xE9",
 		]);
-		$this->assertSame([], $result['errors'], 'a legacy-encoded description must not be rejected once sanitized to UTF-8');
-		$this->assertSame('café', $result['hooks'][0]['description'], 'an ISO-8859-1 byte must convert to valid UTF-8, not survive as invalid bytes');
+		$this->assertSame([], $result['errors'], 'a scrubbed description must not be rejected');
+		$this->assertSame('caf?', $result['hooks'][0]['description'], 'the invalid byte must be substituted, never guessed into mojibake');
+		$this->assertTrue(mb_check_encoding($result['hooks'][0]['description'], 'UTF-8'));
 	}
 
 	// --- description: an all-Unicode-whitespace value trims to '' ---

--- a/tests/php/PfbFeedNormalizeTest.php
+++ b/tests/php/PfbFeedNormalizeTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1797: the on-demand feed normalize stage ({base}.orig -> {base}.norm).
+ *
+ * Executes the REAL pipeline (iconv validity gate, C.UTF-8 sed strip+rtrim,
+ * optional Python converter) against temp files. Character-class membership
+ * for multi-byte codepoints (BOM/ZWJ as non-printable, NBSP in [:space:]) is
+ * locale-DATA-defined and can lag on non-BSD userlands; those legs first
+ * probe the platform's raw sed tables and skip with a reason where the data
+ * diverges — the appliance behaviour itself is probe-pinned on CE 2.8
+ * (FreeBSD 15) and Plus (FreeBSD 16). Everything ASCII is asserted
+ * unconditionally on every platform.
+ */
+#[CoversFunction('pfb_feed_normalize')]
+#[CoversFunction('pfb_feed_normalize_generate')]
+#[CoversFunction('pfb_feed_convert_encoding')]
+final class PfbFeedNormalizeTest extends TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_norm_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		mkdir($this->dir, 0777, true);
+	}
+
+	protected function tearDown(): void
+	{
+		@chmod($this->dir, 0755);
+		foreach (glob("{$this->dir}/*") ?: [] as $f) {
+			@chmod($f, 0644);
+			@unlink($f);
+		}
+		foreach (glob("{$this->dir}/.pfbnorm_*") ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dir);
+	}
+
+	private function writeOrig(string $content, string $name = 'feed'): string
+	{
+		$orig = "{$this->dir}/{$name}.orig";
+		file_put_contents($orig, $content);
+		return $orig;
+	}
+
+	/** Interpreter that would fail loudly if the converter were ever consulted. */
+	private const NO_CONVERTER = '/nonexistent/pfb-test-python';
+
+	private static function platformSedStrips(string $probe_in, string $expected): bool
+	{
+		$out = shell_exec('printf %s ' . escapeshellarg($probe_in) .
+			" | LC_ALL=C.UTF-8 /usr/bin/sed -E 's/[^[:print:]\t]+|[[:space:]]+\$//g'");
+		return $out === $expected;
+	}
+
+	// --- the pipeline core, ASCII-stable on every platform ---
+
+	public function testValidUtf8FileNormalizesWithoutConsultingTheConverter(): void
+	{
+		// The iconv validity gate must decide BEFORE any detection: a valid
+		// UTF-8 file reaches sed directly, so 'café' can never be
+		// double-encoded to 'cafÃ©' by a wrong external charset declaration.
+		$orig = $this->writeOrig("café\r\nx\n");
+		$res  = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertTrue($res['normalized']);
+		$this->assertSame("{$this->dir}/feed.norm", $res['path']);
+		$this->assertSame("café\nx\n", file_get_contents($res['path']));
+		$this->assertTrue($res['changed'], 'first normalization has no baseline and must report changed');
+		$this->assertFileExists("{$this->dir}/feed.norm.src.xxhash128");
+	}
+
+	public function testMidLineCrIsRemovedAtTheFileLevel(): void
+	{
+		$orig = $this->writeOrig("ads.example.com\revil\n");
+		$res  = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertSame("ads.example.comevil\n", file_get_contents($res['path']));
+	}
+
+	public function testTabSeparatedHostsRowKeepsInteriorTabs(): void
+	{
+		$orig = $this->writeOrig("127.0.0.1\tads.example.com\t\t\n");
+		$res  = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertSame("127.0.0.1\tads.example.com\n", file_get_contents($res['path']));
+	}
+
+	public function testControlCharactersAreStrippedEverywhereAndTrailingWhitespaceTrimmed(): void
+	{
+		$orig = $this->writeOrig("a\x00b\x07c   \nkeep\n");
+		$res  = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertSame("abc\nkeep\n", file_get_contents($res['path']));
+	}
+
+	public function testTrailingNewlineGuaranteeIsReapplied(): void
+	{
+		// BSD sed adds no trailing newline; .norm must re-apply the #1263
+		// guarantee itself or downstream concatenation welds rows.
+		$orig = $this->writeOrig('nolf.example.com');
+		$res  = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertSame("nolf.example.com\n", file_get_contents($res['path']));
+	}
+
+	// --- multi-byte class membership: locale-data-gated legs ---
+
+	public function testBomAndZwjAreStrippedAsNonPrintable(): void
+	{
+		if (!self::platformSedStrips("\xEF\xBB\xBFa\xE2\x80\x8Db", 'ab')) {
+			$this->markTestSkipped('platform locale data does not class BOM/ZWJ as non-printable; appliance behaviour probe-pinned on CE 2.8 + Plus');
+		}
+		$orig = $this->writeOrig("\xEF\xBB\xBFbom\xE2\x80\x8Dzwj\n");
+		$res  = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertSame("bomzwj\n", file_get_contents($res['path']));
+	}
+
+	public function testInteriorNbspIsDataWhileTrailingNbspIsTrimmed(): void
+	{
+		if (!self::platformSedStrips("end\xC2\xA0", 'end')) {
+			$this->markTestSkipped('platform locale data does not class NBSP as [:space:]; appliance behaviour probe-pinned on CE 2.8 + Plus');
+		}
+		$orig = $this->writeOrig("mid\xC2\xA0dle\ntrail\xC2\xA0\n");
+		$res  = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertSame("mid\xC2\xA0dle\ntrail\n", file_get_contents($res['path']));
+	}
+
+	// --- regeneration keyed by the recorded source digest ---
+
+	public function testFreshNormIsReusedWithoutRegeneration(): void
+	{
+		$orig = $this->writeOrig("a.example.com\n");
+		pfb_feed_normalize($orig, self::NO_CONVERTER);
+		// Plant a sentinel: a reused .norm is NOT rewritten, so the sentinel
+		// must survive a second call against the unchanged .orig.
+		file_put_contents("{$this->dir}/feed.norm", "sentinel\n");
+		$res = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertFalse($res['changed']);
+		$this->assertSame("sentinel\n", file_get_contents($res['path']),
+			'a source-digest-fresh .norm must be reused, not regenerated');
+	}
+
+	public function testOrigChurnThatNormalizesAwayReportsUnchanged(): void
+	{
+		// The processing-level gate's whole point: upstream CRLF churn changes
+		// .orig but yields a byte-identical .norm -> downstream may skip.
+		$orig = $this->writeOrig("a.example.com\nb.example.com\n");
+		$first = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertTrue($first['changed']);
+		$this->writeOrig("a.example.com\r\nb.example.com\r\n");
+		$res = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertTrue($res['normalized']);
+		$this->assertFalse($res['changed'],
+			'a changed .orig with identical normalized content must report unchanged');
+		$this->assertSame("a.example.com\nb.example.com\n", file_get_contents($res['path']));
+	}
+
+	public function testOrigChangeWithNewContentReportsChanged(): void
+	{
+		$orig = $this->writeOrig("a.example.com\n");
+		pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->writeOrig("c.example.com\n");
+		$res = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertTrue($res['changed']);
+		$this->assertSame("c.example.com\n", file_get_contents($res['path']));
+	}
+
+	public function testMissingNormRegeneratesAndFailSafesToChanged(): void
+	{
+		$orig = $this->writeOrig("a.example.com\n");
+		pfb_feed_normalize($orig, self::NO_CONVERTER);
+		unlink("{$this->dir}/feed.norm");
+		$res = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertTrue($res['normalized']);
+		$this->assertSame("a.example.com\n", file_get_contents($res['path']));
+		$this->assertTrue($res['changed'], 'no previous .norm to compare against -> fail-safe changed');
+	}
+
+	public function testTruncatedNormWithStaleSidecarRegenerates(): void
+	{
+		$orig = $this->writeOrig("a.example.com\nb.example.com\n");
+		pfb_feed_normalize($orig, self::NO_CONVERTER);
+		file_put_contents("{$this->dir}/feed.norm", 'a.exam');	// simulated partial write
+		$this->writeOrig("a.example.com\nb.example.com\nc.example.com\n");
+		$res = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertTrue($res['changed']);
+		$this->assertSame("a.example.com\nb.example.com\nc.example.com\n", file_get_contents($res['path']));
+	}
+
+	public function testMissingBaselineSidecarFailSafesToChangedEvenWhenBytesMatch(): void
+	{
+		// The ADR-43 Force clear-hashes sweep removes the .norm.src sidecar so
+		// the downstream-skip gate cannot fire on a forced pass.
+		$orig = $this->writeOrig("a.example.com\n");
+		pfb_feed_normalize($orig, self::NO_CONVERTER);
+		unlink("{$this->dir}/feed.norm.src.xxhash128");
+		$res = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertTrue($res['changed'],
+			'a missing source-digest baseline must never report unchanged');
+	}
+
+	// --- fallback: parse .orig rather than yield an empty feed ---
+
+	public function testMissingOrigFallsBackToTheOrigPath(): void
+	{
+		$res = pfb_feed_normalize("{$this->dir}/absent.orig", self::NO_CONVERTER);
+		$this->assertSame("{$this->dir}/absent.orig", $res['path']);
+		$this->assertFalse($res['normalized']);
+		$this->assertTrue($res['changed']);
+	}
+
+	public function testUnwritableDirectoryFallsBackToParsingOrig(): void
+	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('root bypasses file permissions; the unwritable-dir denial cannot be simulated');
+		}
+		$orig = $this->writeOrig("a.example.com\n");
+		chmod($this->dir, 0555);
+		$res = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$this->assertSame($orig, $res['path'], 'normalize failure must fall back to the raw .orig');
+		$this->assertFalse($res['normalized']);
+		$this->assertTrue($res['changed']);
+	}
+
+	// --- the Python converter leg (real charset_normalizer where available) ---
+
+	private static function converterInterpreter(): ?string
+	{
+		$py = trim((string) shell_exec('command -v python3 2>/dev/null'));
+		if ($py === '') {
+			return null;
+		}
+		exec(escapeshellarg($py) . ' -c "import charset_normalizer" 2>/dev/null', $o, $ret);
+		return $ret === 0 ? $py : null;
+	}
+
+	public function testNonUtf8FeedIsDetectedAndConvertedToUtf8(): void
+	{
+		$py = self::converterInterpreter();
+		if ($py === null) {
+			$this->markTestSkipped('no python3 with charset_normalizer available for the converter leg');
+		}
+		// A realistic Latin-1 body: enough text for deterministic detection.
+		$body = str_repeat("b\xFCcher-stra\xDFe.example.com\ncaf\xE9.example.com\n", 200);
+		$orig = $this->writeOrig($body);
+		$res  = pfb_feed_normalize($orig, $py);
+		$this->assertTrue($res['normalized']);
+		$norm = file_get_contents($res['path']);
+		$this->assertTrue(mb_check_encoding($norm, 'UTF-8'), 'converted output must be valid UTF-8');
+		$this->assertStringContainsString('bücher', $norm);
+		$this->assertStringContainsString('café', $norm);
+	}
+
+	public function testConversionUnavailableDegradesGracefullyNeverToAnEmptyFeed(): void
+	{
+		// With no interpreter resolvable ('' is the resolver's on-failure
+		// value) an invalid-UTF-8 file reaches sed raw. FreeBSD sed passes the
+		// invalid bytes through while still stripping controls; other libcs
+		// (macOS) abort the regex on an illegal byte sequence, in which case
+		// the helper must fall back to the raw .orig -- either way the feed is
+		// parseable, never empty.
+		$raw  = "caf\xE9\x07.example.com\n";
+		$orig = $this->writeOrig($raw);
+		$res  = pfb_feed_normalize($orig, '');
+		if ($res['normalized']) {
+			$norm = (string) file_get_contents($res['path']);
+			$this->assertStringStartsWith('caf', $norm);
+			$this->assertStringNotContainsString("\x07", $norm, 'the BEL control must be stripped in degraded mode');
+		} else {
+			$this->assertSame($orig, $res['path'], 'a failed normalization must fall back to the raw .orig');
+			$this->assertSame($raw, file_get_contents($orig), 'the .orig baseline must stay untouched');
+		}
+		$this->assertTrue($res['changed'], 'degraded handling must never report a skippable unchanged verdict');
+	}
+}

--- a/tests/php/PfbFeedNormalizeTest.php
+++ b/tests/php/PfbFeedNormalizeTest.php
@@ -225,6 +225,23 @@ final class PfbFeedNormalizeTest extends TestCase
 		$this->assertTrue($res['changed']);
 	}
 
+	// --- wiring guard: only the parse-loop consumers normalize ---
+
+	public function testOnlyTheParseLoopConsumersCallNormalize(): void
+	{
+		// The changed-verdict means "changed since the last CONSUMER normalize".
+		// A download-time (pfb_download finalize) call records the fresh source
+		// digest first, so the consumer then reads 'unchanged' for genuinely-new
+		// content and the norm-skip gate strands stale staging -- caught live by
+		// tests/smoke/test_smoke_feeds.py::test_cron_detects_changed_local_feed.
+		$inc = (string) file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+		$this->assertSame(0, preg_match_all('/=\s*pfb_feed_normalize\(/', $inc),
+			'pfblockerng.inc must contain no pfb_feed_normalize() call site -- never a download-time call');
+		$apply = (string) file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertSame(2, preg_match_all('/=\s*pfb_feed_normalize\(/', $apply),
+			'exactly the two parse loops (DNSBL + IP) consume pfb_feed_normalize');
+	}
+
 	// --- the Python converter leg (real charset_normalizer where available) ---
 
 	private static function converterInterpreter(): ?string

--- a/tests/php/PfbNormReuseSkipTest.php
+++ b/tests/php/PfbNormReuseSkipTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1797: the downstream-skip decision after normalization. Both loops
+ * skip ONLY when a fresh non-custom download normalized to byte-identical
+ * content over a reusable staged '.txt'; every other condition fail-safes to
+ * a full reparse (Reload/Force semantics, custom re-synthesis, the
+ * stale-.orig download-failure fallback of #1022/#1031, stale staging
+ * generation of #1083, user pre/post scripts).
+ */
+#[CoversFunction('pfb_dnsbl_norm_reuse_skip')]
+#[CoversFunction('pfb_ip_norm_reuse_skip')]
+final class PfbNormReuseSkipTest extends TestCase
+{
+	public function testDnsblSkipsOnlyForAFreshUnchangedDownloadOntoCurrentStaging(): void
+	{
+		$this->assertTrue(pfb_dnsbl_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE));
+	}
+
+	/** @return array<string, array{bool,bool,bool,bool,bool,bool}> */
+	public static function dnsblNoSkipRows(): array
+	{
+		return [
+			'no fresh download (Reload/Force reparses)' => [FALSE, FALSE, FALSE, FALSE, TRUE, TRUE],
+			'custom list (re-synthesized per pass)'     => [TRUE, TRUE, FALSE, FALSE, TRUE, TRUE],
+			'stale-.orig download-failure fallback'     => [TRUE, FALSE, TRUE, FALSE, TRUE, TRUE],
+			'normalized content changed'                => [TRUE, FALSE, FALSE, TRUE, TRUE, TRUE],
+			'no staged .txt to reuse'                   => [TRUE, FALSE, FALSE, FALSE, FALSE, TRUE],
+			'stale staging generation (#1083)'          => [TRUE, FALSE, FALSE, FALSE, TRUE, FALSE],
+		];
+	}
+
+	#[DataProvider('dnsblNoSkipRows')]
+	public function testDnsblNeverSkipsWhenAnyGuardFails(bool $fresh, bool $custom, bool $stale, bool $changed, bool $txt, bool $generation): void
+	{
+		$this->assertFalse(pfb_dnsbl_norm_reuse_skip($fresh, $custom, $stale, $changed, $txt, $generation));
+	}
+
+	public function testIpSkipsOnlyForAFreshUnchangedDownloadWithoutUserScripts(): void
+	{
+		$this->assertTrue(pfb_ip_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, FALSE));
+	}
+
+	/** @return array<string, array{bool,bool,bool,bool,bool,bool}> */
+	public static function ipNoSkipRows(): array
+	{
+		return [
+			'no fresh download (Reload/Force reparses)' => [FALSE, FALSE, FALSE, FALSE, TRUE, FALSE],
+			'custom list (re-synthesized per pass)'     => [TRUE, TRUE, FALSE, FALSE, TRUE, FALSE],
+			'stale-.orig download-failure fallback'     => [TRUE, FALSE, TRUE, FALSE, TRUE, FALSE],
+			'normalized content changed'                => [TRUE, FALSE, FALSE, TRUE, TRUE, FALSE],
+			'no staged .txt to reuse'                   => [TRUE, FALSE, FALSE, FALSE, FALSE, FALSE],
+			'user pre/post script owns the full pass'   => [TRUE, FALSE, FALSE, FALSE, TRUE, TRUE],
+		];
+	}
+
+	#[DataProvider('ipNoSkipRows')]
+	public function testIpNeverSkipsWhenAnyGuardFails(bool $fresh, bool $custom, bool $stale, bool $changed, bool $txt, bool $script): void
+	{
+		$this->assertFalse(pfb_ip_norm_reuse_skip($fresh, $custom, $stale, $changed, $txt, $script));
+	}
+}

--- a/tests/php/PfbSanitizeTextTest.php
+++ b/tests/php/PfbSanitizeTextTest.php
@@ -99,18 +99,24 @@ final class PfbSanitizeTextTest extends TestCase
 		// excludes it) -- PCRE's /u modifier refuses to even run \p{C} over a
 		// subject containing raw surrogate-shaped bytes (probed: preg_replace()
 		// returns NULL, not a Cs match), so the \p{C} strip itself never sees
-		// one. The legacy-encoding recovery step upstream reinterprets the raw
-		// bytes \xED\xA0\x80 as ISO-8859-1 (-> U+00ED U+00A0 U+0080) first; the
-		// resulting U+0080 (a *different* char, category Cc) is then stripped
-		// by the same \p{C} pass -- so no Cs codepoint ever reaches the
-		// output, and the byte that came along with it does not survive
-		// either. Probed exact result (issue #1795), not predicted.
-		$this->assertSame("a\xC3\xAD\xC2\xA0b", pfb_sanitize_text("a\xED\xA0\x80b"));
+		// one. The issue #1797 (A6) deterministic scrub upstream substitutes
+		// each of the raw bytes \xED\xA0\x80 with '?' first -- so no Cs
+		// codepoint ever reaches the output, and the bytes that came along
+		// with it do not survive either. Probed exact result (issues
+		// #1795/#1797), not predicted.
+		$this->assertSame('a???b', pfb_sanitize_text("a\xED\xA0\x80b"));
 	}
 
-	public function testSanitizeTextConvertsInvalidUtf8FromIso88591(): void
+	public function testSanitizeTextScrubsInvalidUtf8Deterministically(): void
 	{
-		$this->assertSame('bücher', pfb_sanitize_text("b\xFCcher"));
+		// issue #1797 (A6): no ISO-8859-1 guessing -- mb_detect_encoding() can
+		// never fail (every byte sequence is valid ISO-8859-1), so the old
+		// branch silently produced mojibake. Invalid sequences are substituted
+		// deterministically instead; the output-is-valid-UTF-8 invariant is
+		// what pfb_preg_replace_safe()'s /u patterns depend on.
+		$out = pfb_sanitize_text("b\xFCcher");
+		$this->assertSame('b?cher', $out);
+		$this->assertTrue(mb_check_encoding($out, 'UTF-8'));
 	}
 
 	public function testSanitizeTextRemovesC1ControlChars(): void
@@ -197,6 +203,11 @@ final class PfbSanitizeTextTest extends TestCase
 
 	public function testSanitizeTextAreaConvertsInvalidUtf8FromIso88591(): void
 	{
+		// issue #1797 (A6): the textarea helper KEEPS its legacy-encoding
+		// conversion -- pfb_text_area_decode() feeds it config.xml blobs
+		// written by older versions / restores / XMLRPC sync, and its docblock
+		// promises legacy conversion. Only browser-fed pfb_sanitize_text()
+		// dropped the guessing branch.
 		$this->assertSame('bücher', pfb_sanitize_text_area("b\xFCcher"));
 	}
 

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -2007,6 +2007,19 @@
             }
         ]
     },
+    "pfb_dnsbl_scrub_line": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_dnsbl_service": {
         "returnsRef": false,
         "returnType": null,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -1777,6 +1777,54 @@
             }
         ]
     },
+    "pfb_dnsbl_norm_reuse_skip": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "downloaded_fresh",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "orig_content_stale",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "norm_changed",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "txt_exists",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "staging_current_generation",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
     "pfb_dnsbl_publish_result": {
         "returnsRef": false,
         "returnType": "bool",
@@ -4020,6 +4068,54 @@
         "returnsRef": false,
         "returnType": "string",
         "params": []
+    },
+    "pfb_ip_norm_reuse_skip": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "downloaded_fresh",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "orig_content_stale",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "norm_changed",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "txt_exists",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "has_user_script",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
     },
     "pfb_ip_parse_fail_warn": {
         "returnsRef": false,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -2841,6 +2841,33 @@
         "returnType": null,
         "params": []
     },
+    "pfb_feed_convert_encoding": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "src",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "dst",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "interpreter",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_feed_filter_enabled": {
         "returnsRef": false,
         "returnType": null,
@@ -2937,6 +2964,53 @@
                 "variadic": false,
                 "type": "string",
                 "default": "'deny'"
+            }
+        ]
+    },
+    "pfb_feed_normalize": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "orig_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "interpreter",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_feed_normalize_generate": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "src",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "dst",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "interpreter",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
             }
         ]
     },

--- a/tests/smoke/ui/test_hooks.py
+++ b/tests/smoke/ui/test_hooks.py
@@ -368,7 +368,7 @@ def test_reject_invalid_script_leaves_config_unchanged(webui: WebUI, smoke_vm: h
 
 
 def test_control_char_description_is_cleaned_and_saved(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
-    """A \\p{C}-bearing description is sanitized at ingestion and SAVED, not rejected (#756/#1795).
+    """A \\p{C}-bearing description is sanitized at ingestion and SAVED, not rejected (#756/#1795/#1797).
 
     issue #1795 widened ``pfb_sanitize_text()`` (single-line fields, called on
     ``hook_description-N`` before any validation runs) from stripping only
@@ -381,10 +381,10 @@ def test_control_char_description_is_cleaned_and_saved(webui: WebUI, smoke_vm: h
     This is also the FLIP of the old red/green cell for issue #756 (the
     validator's ``!== 0`` compare, which fails closed on a ``FALSE``
     ``preg_match()`` return -- invalid UTF-8 under the ``/u`` modifier -- not
-    just a real match). Probed (issue #1795): after sanitize, the value handed
-    to the validator is ALWAYS well-formed UTF-8 (the legacy-encoding-recovery
-    step converts any invalid input via ISO-8859-1, which is total over the
-    byte range) and the ``\\p{C}+`` strip does not degrade under PCRE's
+    just a real match). Probed (issues #1795/#1797): after sanitize, the value
+    handed to the validator is ALWAYS well-formed UTF-8 (the issue #1797 (A6)
+    deterministic scrub substitutes every invalid byte, total over any byte
+    sequence) and the ``\\p{C}+`` strip does not degrade under PCRE's
     backtrack limit at any realistic size (tested to 10M chars) -- so no
     POSTed input can make ``preg_match()`` return ``FALSE`` here anymore, and
     fuzzing 20,000 random byte strings through the sanitizer found zero
@@ -393,24 +393,22 @@ def test_control_char_description_is_cleaned_and_saved(webui: WebUI, smoke_vm: h
     test asserts it directly and end to end via :func:`_assert_no_p_c_codepoint`
     instead of via a reject, for all three sub-cases below.
 
-    Three sub-cases, all now landing cleaned in config.xml -- NOTE (issue
-    #1795 finding): (a) and (b) already saved clean on the UNWIDENED
-    sanitizer too, since issue #1761 made ingestion-sanitize run before this
-    validator, and neither a real Cc byte nor invalid UTF-8 needs the
-    Cf/Co/Cs/Cn widening to be defused (Cc was always stripped; the
-    legacy-encoding recovery that neutralizes invalid UTF-8 predates #1795
-    and is untouched by it). They are pinned here as REGRESSION guards, not
-    #1795 discriminators. (c) is the actual #1795 red/green cell: a Cf
-    (format) character survives the unwidened sanitizer and trips the
-    validator's reject, RED on old code:
+    Three sub-cases, all now landing cleaned in config.xml -- (a) is a pure
+    regression guard (already saved clean on the unwidened sanitizer, since
+    issue #1761 made ingestion-sanitize run before this validator and Cc was
+    always stripped); (c) is the issue #1795 red/green cell; (b) is the issue
+    #1797 (A6) red/green cell:
       (a) a REAL control character (BEL, ``\\x07``) -- stripped with no
           replacement, so ``"smoke\\x07desc"`` saves as ``"smokedesc"``.
       (b) INVALID UTF-8 -- the two raw bytes ``0xC3 0x28`` (a UTF-8 lead byte
-          followed by a non-continuation byte) -- legacy-encoding-recovered
-          (ISO-8859-1 -> UTF-8) to ``"Ã("``. ``requests`` would re-encode a
-          Python ``str`` as valid UTF-8 (the two bytes above would become
+          followed by a non-continuation byte). THIS is the #1797 (A6)
+          red/green cell: the old recovery guessed ISO-8859-1 (total over any
+          byte sequence) and persisted the mojibake ``Ã(``; the deterministic
+          scrub substitutes the invalid byte and persists ``?(`` -- valid
+          UTF-8 with the data loss made visible. ``requests`` would re-encode
+          a Python ``str`` as valid UTF-8 (the two bytes above would become
           ``%C3%83%28``, itself already valid UTF-8, never exercising the
-          legacy-recovery path) -- so, mirroring
+          scrub) -- so, mirroring
           ``test_remove_to_empty_deletes_node``'s manual-POST escape hatch, the
           request body is built and percent-encoded by hand to put the literal
           invalid bytes on the wire. The rest of the row stays VALID so the
@@ -418,8 +416,8 @@ def test_control_char_description_is_cleaned_and_saved(webui: WebUI, smoke_vm: h
       (c) U+200D ZERO WIDTH JOINER (category Cf) -- NOT stripped by the
           unwidened sanitizer (only \\p{Cc}+BOM), so it reaches the
           validator's ``\\p{C}`` gate intact and trips a real (``1``, not
-          ``FALSE``) reject on old code; issue #1795 strips it at ingestion,
-          so it never reaches the validator on new code. ``"a\\u200Db"``
+          ``FALSE``) reject on pre-#1795 code; issue #1795 strips it at
+          ingestion, so it never reaches the validator. ``"a\\u200Db"``
           saves as ``"ab"``.
     """
     vm = smoke_vm
@@ -441,10 +439,10 @@ def test_control_char_description_is_cleaned_and_saved(webui: WebUI, smoke_vm: h
         assert persisted_a == "smokedesc", f"control char was not cleanly stripped -- got {persisted_a!r}"
         _assert_no_p_c_codepoint(persisted_a)
 
-        # (b) Invalid UTF-8 (0xC3 0x28) -- legacy-recovered to valid UTF-8.
-        # Build the raw percent-encoded body by hand (see docstring) so the
-        # literal invalid bytes reach the wire instead of a re-encoded
-        # valid-UTF-8 substitute.
+        # (b) Invalid UTF-8 (0xC3 0x28) -- deterministically scrubbed to
+        # valid UTF-8 (issue #1797 A6). Build the raw percent-encoded body by
+        # hand (see docstring) so the literal invalid bytes reach the wire
+        # instead of a re-encoded valid-UTF-8 substitute.
         from urllib.parse import quote
 
         from .webui import extract_csrf_token
@@ -472,17 +470,18 @@ def test_control_char_description_is_cleaned_and_saved(webui: WebUI, smoke_vm: h
         )
         assert not looks_like_login_page(resp.text), "invalid-UTF-8 POST returned the login form"
 
-        # AFTER (accept): the node still exists and the description holds the
-        # legacy-recovered, control-byte-free text -- #756's guarantee (no
-        # malformed byte in config.xml) proven directly, not via a reject.
+        # AFTER: the node exists and the persisted value is the DETERMINISTIC
+        # scrub of the invalid byte -- '?(' -- never the ISO-8859-1 mojibake
+        # the old guessing recovery manufactured, and never raw bytes.
+        # #756's guarantee (no malformed byte in config.xml) proven directly.
         assert _hooks_node_exists(vm), "hooks node deleted by an ACCEPTED invalid-UTF-8-description save"
         persisted_b = helpers.config_get(vm, ROW0_DESCRIPTION)
-        assert persisted_b == "Ã(", f"invalid UTF-8 was not legacy-recovered as expected -- got {persisted_b!r}"
+        assert persisted_b == "?(", f"invalid UTF-8 must persist as the deterministic scrub '?(' -- got {persisted_b!r}"
         _assert_no_p_c_codepoint(persisted_b)
 
-        # (c) A Cf (format) character -- the actual issue #1795 discriminator
-        # (see docstring): stripped at ingestion on new code, still reaches
-        # the validator's \p{C} gate unstripped on old code.
+        # (c) A Cf (format) character -- the issue #1795 discriminator
+        # (see docstring): stripped at ingestion, never reaches the
+        # validator's \p{C} gate.
         resp = webui.post(HOOKS_PAGE, {"hook_description-0": "a\u200db"}, timeout=120.0)
         assert not looks_like_login_page(resp.text), "Cf-character POST returned the login form"
         assert _hooks_node_exists(vm), "hooks node deleted by an ACCEPTED Cf-character-description save"

--- a/tests/test_feed_normalize_script.py
+++ b/tests/test_feed_normalize_script.py
@@ -1,0 +1,70 @@
+"""pfb_feed_normalize.py (issue #1797): detection + conversion contract.
+
+Runs the shipped script under the DEV interpreter (sys.executable — dev/CI
+tooling; the appliance reaches it only through pfb_python_interpreter()).
+Skips when charset_normalizer is not installed in the dev environment.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("charset_normalizer")
+
+SCRIPT = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfb_feed_normalize.py"
+
+
+def run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_latin1_body_converts_to_utf8_with_zero_replacements(tmp_path: Path) -> None:
+    src = tmp_path / "feed.orig"
+    dst = tmp_path / "feed.conv"
+    # A realistic Latin-1 body — large enough for deterministic detection.
+    src.write_bytes(b"b\xfccher-stra\xdfe.example.com\ncaf\xe9.example.com\n" * 200)
+
+    proc = run_script(str(src), str(dst))
+
+    assert proc.returncode == 0, f"stderr: {proc.stderr!r}"
+    encoding, count = proc.stdout.split()
+    assert int(count) == 0, f"a total single-byte codec must decode every byte, got {count} replacements ({encoding})"
+    out = dst.read_bytes().decode("utf-8")  # must not raise
+    assert "bücher" in out
+    assert "café" in out
+
+
+def test_replacement_count_is_reported_on_stdout(tmp_path: Path) -> None:
+    src = tmp_path / "feed.orig"
+    dst = tmp_path / "feed.conv"
+    # A pre-existing U+FFFD rides through the count — the wrong-guess signal
+    # channel itself is what this pins.
+    src.write_bytes(("ok.example.com\n" * 50 + "bad�.example.com\n").encode("utf-8"))
+
+    proc = run_script(str(src), str(dst))
+
+    assert proc.returncode == 0, f"stderr: {proc.stderr!r}"
+    _encoding, count = proc.stdout.split()
+    assert int(count) == 1, f"expected exactly the one U+FFFD to be counted, got {count}"
+
+
+def test_missing_source_file_fails_loudly(tmp_path: Path) -> None:
+    proc = run_script(str(tmp_path / "absent.orig"), str(tmp_path / "out"))
+    assert proc.returncode == 1
+    assert proc.stderr != ""
+
+
+def test_wrong_argument_count_fails_with_usage(tmp_path: Path) -> None:
+    proc = run_script(str(tmp_path / "only-one"))
+    assert proc.returncode == 1
+    assert "usage" in proc.stderr


### PR DESCRIPTION
## Summary

Implements #1797 Front 4 (the download text-normalization pipeline) and the Front 1 sanitizer amendment (A6), per the "final" specification comment as superseded by the adversarial-review amendment (items A1-A10).

### The normalize stage (`.norm`)

- `pfb_feed_normalize()`: `{header}.orig` → `{header}.norm`, regenerated **on demand at the consumer**, keyed by a recorded source digest (`{header}.norm.src.xxhash128` = xxh128 of the `.orig` the `.norm` was built from), written tmp + atomic rename in the same directory, with the #1263 trailing-newline guarantee re-applied (sed adds none). On any failure the caller parses the raw `.orig` — a feed degrades to raw parsing, never to empty (A3/A4).
- Pipeline order (load-bearing): whole-file `iconv -f UTF-8 -t UTF-8` **validity gate** first (a wrong server charset declaration can never double-encode provable UTF-8; `iconv -c` is never the converter — it deletes bytes silently, A1); only an invalid file reaches the Python detector/converter (`charset_normalizer.from_path()` over the whole file — no hand-rolled prefix, A2 — then a chunk-streamed `errors='replace'` decode with the U+FFFD replacement count logged as the wrong-detection signal, A1); then one `LC_ALL=C.UTF-8 sed -E "s/[^[:print:]\t]+|[[:space:]]+$//g"` pass (strip + per-line rtrim; interior tabs and interior NBSP survive as data).
- Both parse loops — DNSBL and IP — read `.norm` with `.orig` fallback (A9). The IP loop normalizes **after** the user pre-script has seen the raw `.orig` (A4).
- Processing-level gate (§4): a fresh non-custom download whose normalized content is byte-identical skips the reparse (mirroring the verbatim-reuse branch's bookkeeping, clearing `.update`); upstream CRLF/whitespace/BOM churn no longer triggers rebuilds. Reload/Force passes, custom lists, stale-`.orig` download-failure fallbacks, stale staging generations (#1083), and feeds with user pre/post scripts never skip. The ADR-43 Force clear-hashes sweep also removes the `.norm.src` baselines, so `pfb_feed_normalize()` fail-safes to *changed* and a forced pass always reprocesses.
- The normalize hook in `pfb_download()` is pinned to the plain-`.orig` finalize path; GeoIP/ASN/TOP1M/Blacklist archives early-return before it (A7). The ADR-42 wire-byte sidecar (`{header}.orig.xxhash128`) is untouched, and the #946 UTF-16 transcode is **kept** (A5 — `.orig` consumers, including user scripts and the empty-file `grep` check, keep seeing UTF-8).
- Per-line: the DNSBL scrub (extracted as `pfb_dnsbl_scrub_line()`) removes CR **everywhere** and trims an ASCII-only charlist — the byte-wise `"\xC2\xA0"` trim that could slice a multi-byte character and create invalid UTF-8 is gone. `rtrim`-vs-`fgets` is handled (A8): the scrub still trims the line terminator; leading ASCII whitespace stays trimmed (decided policy), leading *Unicode* whitespace is now data for the validators to judge.

### Front 1 (A6)

`pfb_sanitize_text()`'s guessing recovery (`mb_detect_encoding(..., 'UTF-8, ASCII, ISO-8859-1')` — a detection that can never fail) is replaced with `mb_convert_encoding($t, 'UTF-8', 'UTF-8')`: deterministic substitution, visible data loss, and the output-is-valid-UTF-8 invariant preserved (which `pfb_preg_replace_safe()`'s `/u` patterns depend on). `pfb_sanitize_text_area()` **keeps** its legacy conversion (config-fed via `pfb_text_area_decode()` — old configs, restores, XMLRPC sync).

## Red-before → green-after proofs (files byte-identical between runs)

| Reproduction | Red evidence | Test file hash (red = green) |
| --- | --- | --- |
| mid-line CR survives the ends-only scrub | embedded `\r` in `'ads.example.comevil'` diff | `tests/php/DnsblScrubLineTest.php` `5b90628e4ff3a6d79f4fd204a068a70d9743308c` |
| byte-wise trim creates invalid UTF-8 | `got bytes: 626164e0ba`, `mb_check_encoding` false | same file/hash |
| trailing NBSP no longer line-scrub's job | `'x '` vs `'x'` | same file/hash |
| sanitizer mojibake (`"b\xFCcher"` → `'bücher'`) | expected `'b?cher'`, actual `'bücher'` | `tests/php/PfbSanitizeTextTest.php` `42285c9361f875981d68e8bbb9470796f84baac5` |
| hooks description mojibake (`"caf\xE9"` → `'café'`) | expected `'caf?'`, actual `'café'` | `tests/php/HooksSanitizeIngestionTest.php` `787117dd7308b95f5ebf80d9030014eb93dced5f` |

New-code reproductions the spec requires (brand-new pipeline, shipped with failable assertions): wrong-charset ordering (`café` never double-encoded — the converter is provably not consulted for valid UTF-8), tab-separated hosts row survival, `.orig`-changed-`.norm`-identical → *unchanged* verdict + skip predicate, `.norm` missing/stale/truncated → regeneration, normalize failure → `.orig` fallback — all in `PfbFeedNormalizeTest` / `PfbNormReuseSkipTest` / `ConditionalGetHelpersTest`.

A live ui_e2e red→green of the hooks invalid-UTF-8 flip is executing on the PFB_BOXES pool (red ref: `issue/1797-a6-redproof` — production reverted, tests byte-identical); results will be posted as a comment.

## Benchmark (CE 2.8 / FreeBSD 15 guest, 36 MB hosts-format feed, 1M rows)

| Step | Time | Rate | Baseline (Plus/FreeBSD 16) |
| --- | --- | --- | --- |
| iconv validity gate | 0.83 s | ~0.023 s/MB | ~0.04 s/MB |
| sed strip+rtrim | 4.80 s (4.83 s warm) | ~0.13 s/MB | ~0.21 s/MB |
| xxh128 of the 36 MB `.orig` | 0.01 s | negligible | — |

No CR survives, interior tabs survive, trailing whitespace trimmed (36.0 MB → 33.0 MB, exactly the 3 bytes/row of CRLF + trailing spaces). No regression against the measured baseline.

## CE 2.8 `[:print:]` / `[:space:]` probe (FreeBSD 15, live VM)

Byte-for-byte parity with the FreeBSD 16 measurements: BEL/ZWJ/BOM/NEL stripped while tab/`é`/`日` survive (`61 09 62 63 c3 a9 e6 97 a5 7a 0a`); NBSP printable mid-line but trimmed as trailing `[:space:]`; NUL removed without truncation; sed adds no trailing newline (hence the re-applied #1263 guarantee); **invalid UTF-8 passes through sed untouched with controls still stripped** (`63 61 66 e9 ...`, exit 0) — the degraded-mode design holds on the appliance. (macOS BSD sed aborts on invalid bytes instead; the unit test accepts both platform-real outcomes.)

## Decisions on the explicitly-open questions

- **UTF-16 transcode (#946): kept** at download finalize. Retiring it into the normalize stage would hand user pre/post scripts and the `.orig`-reading empty-file check raw UTF-16 and change their contract; with it kept, step (a)'s BOM branch collapses into the validity gate (a UTF-8 BOM is valid UTF-8; a UTF-16 BOM fails the gate and the detector reads it), so no separate BOM sniffer exists.
- **Leading whitespace (A8):** ASCII leading whitespace stays trimmed per line (historic acceptance of indented rows, byte-safe charlist); leading Unicode whitespace is data — file-level normalization right-trims only, per the hardware-verified expression.
- **BOM present, body invalid (A10):** neither strict-fail nor `iconv -c` — the file takes the same detector/convert path as any invalid file, keeping the U+FFFD replacement-count signal alive.
- **Declared HTTP charset as a detection candidate:** dropped. The on-demand consumer-side regeneration (A3/A4 — the amendment's own fix direction) has no HTTP context (reloads, custom lists, script-mutated `.orig`, first upgrade), so detection is content-only via whole-file `charset_normalizer`.

## Cross-repo / rollout ordering

- FreeBSD-ports (`pfblockerng/use-github`): `py311-charset-normalizer` RUN_DEPENDS added to `net/pfSense-pkg-pfBlockerNG-{devel,nightly}` — **committed locally, deliberately NOT pushed**: the ADR-04 smoke images resolve RUN_DEPENDS offline from the baked-in pkg db, so pushing before an image rebake (now covered by `scripts/misc/install_deps_CE_2.8.sh`) would fail every `pkg add` in the pool. The runtime degrades gracefully meanwhile (conversion skipped + logged; iconv gate and sed strip still run).

## Follow-ups (out of scope here)

- Front 2 — `pfb_unbound.py` DNS-side sanitization.
- Front 3 — display-side (Alerts/Reports/logs) defence in depth.
- Smoke-image rebake with `py311-charset-normalizer`, then push the prepared FreeBSD-ports commit.
- PR #1798 (`\p{C}` widening) touches the same sanitizer and tests; whichever lands second rebases (the A6 scrub and the `\p{C}` widening compose cleanly).

## Test plan

- [x] `vendor/bin/phpunit` — full suite green (4352 tests).
- [x] `python3 -m pytest` — full suite green (3595 passed).
- [x] `./scripts/agent/run-gates.sh --diff origin/devel` — GATES: PASS (pytest, ruff, mypy, php -l, PHPUnit, PHPStan, PHPCS, shellcheck/shellspec, markdownlint).
- [x] Red→green executed for every behaviour change, test files byte-identical (hashes above).
- [x] Benchmark on a live CE 2.8 VM (numbers above).
- [x] CE 2.8 locale-class probe (parity confirmed).
- [x] Live ui_e2e red→green + `test_smoke_feeds` module (50 passed) on the branch — results in the comment below.

Fixes #1797

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic feed normalization to handle invalid or non-UTF-8 content.
  * Enhanced DNSBL feed cleanup by removing unwanted control characters while preserving intended whitespace.
  * Introduced normalization-aware reuse to avoid reprocessing when content is effectively unchanged.
* **Bug Fixes**
  * Improved sanitization so invalid UTF-8/control characters submitted via supported interfaces are cleaned and persisted as valid UTF-8.
  * Ensured forced reprocessing clears normalization baselines so skipped updates don’t occur.
* **Documentation**
  * Updated architecture notes to cover normalization and reuse behavior.
* **Tests**
  * Expanded encoding, normalization, reuse decision, and sanitization test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
