### PR TITLE
pfblockerng: fresh-config chokepoints, honest string predicates, and the string-falsiness sweep (#1768/#1777/#1787/#1792)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,11 @@
         "phpunit/phpunit": "^12.5",
         "squizlabs/php_codesniffer": "^3.10"
     },
+    "autoload-dev": {
+        "psr-4": {
+            "PfBlockerNG\\PHPStan\\": "tests/phpstan/"
+        }
+    },
     "config": {
         "sort-packages": true
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,6 +7,12 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
 
 		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 4
+			path: src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
+
+		-
 			message: '#^Binary operation "\+" between string and 1 results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 2
@@ -28,30 +34,6 @@ parameters:
 			message: '#^Call to function unset\(\) contains undefined variable \$retval\.$#'
 			identifier: unset.variable
 			count: 3
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$filename_unlock follows optional parameter \$r_type\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$format follows optional parameter \$pflex\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$header follows optional parameter \$pflex\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-
-		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$logtype follows optional parameter \$pflex\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -91,12 +73,6 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
-
-		-
 			message: '#^Parameter \#3 \$value of function curl_setopt expects 0\|2, false given\.$#'
 			identifier: argument.type
 			count: 1
@@ -123,7 +99,7 @@ parameters:
 		-
 			message: '#^Variable \$line in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
-			count: 2
+			count: 1
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
@@ -139,12 +115,6 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
-			message: '#^Variable \$pfb_tables in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.variable
-			count: 1
-			path: src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
-
-		-
 			message: '#^Variable \$rs in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
@@ -157,9 +127,51 @@ parameters:
 			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
 
 		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 55
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+
+		-
+			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+
+		-
+			message: '#^Variable \$pfb_tables in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 22
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+
+		-
 			message: '#^Parameter \#1 \$string of function str_pad expects string, int given\.$#'
 			identifier: argument.type
 			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 27
 			path: src/usr/local/www/pfblockerng/pfblockerng.php
 
 		-
@@ -211,8 +223,20 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
 
 		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 5
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+
+		-
 			message: '#^Variable \$blacklist_types in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
 			count: 2
 			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
 
@@ -232,6 +256,12 @@ parameters:
 			message: '#^Variable \$rowid in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
 			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
 
 		-
@@ -259,6 +289,12 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
 
 		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 6
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+
+		-
 			message: '#^Parameter \#2 \$callback of function array_filter expects \(callable\(string\)\: bool\)\|null, ''strlen'' given\.$#'
 			identifier: argument.type
 			count: 1
@@ -271,15 +307,27 @@ parameters:
 			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
 
 		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$a_key follows optional parameter \$alt_register\.$#'
-			identifier: parameter.requiredAfterOptional
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
 			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 3
 			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
 
 		-
 			message: '#^Variable \$v4suppression in empty\(\) always exists and is not falsy\.$#'
 			identifier: empty.variable
 			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
+
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
 			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
 
 		-
@@ -298,6 +346,12 @@ parameters:
 			message: '#^Variable \$_REQUEST in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.variable
 			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_threats.php
+
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 3
 			path: src/usr/local/www/pfblockerng/pfblockerng_threats.php
 
 		-
@@ -331,10 +385,10 @@ parameters:
 			path: src/usr/local/www/pfblockerng/www/index.php
 
 		-
-			message: '#^Deprecated in PHP 8\.0\: Required parameter \$pfb_table follows optional parameter \$mode\.$#'
-			identifier: parameter.requiredAfterOptional
-			count: 1
-			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/www/pfblockerng/www/index.php
 
 		-
 			message: '#^Parameter \#1 \$num of function number_format expects float, string given\.$#'
@@ -347,78 +401,3 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 47
-			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 22
-			path: src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 2
-			path: src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 27
-			path: src/usr/local/www/pfblockerng/pfblockerng.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 7
-			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 5
-			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 1
-			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 2
-			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 3
-			path: src/usr/local/www/pfblockerng/pfblockerng_threats.php
-		-
-			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
-			identifier: pfBlockerNG.emptyOnString
-			count: 2
-			path: src/usr/local/www/pfblockerng/www/index.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -347,3 +347,78 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 47
+			path: src/usr/local/pkg/pfblockerng/pfblockerng.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 22
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 27
+			path: src/usr/local/www/pfblockerng/pfblockerng.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 7
+			path: src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_category.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 5
+			path: src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 1
+			path: src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/www/pfblockerng/pfblockerng_ip.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 3
+			path: src/usr/local/www/pfblockerng/pfblockerng_threats.php
+		-
+			message: '#^empty\(\) on a string operand lies\: empty\(''0''\) is TRUE\. Use pfb_is_empty\(\) for ''''/NULL or pfb_is_blank\(\) for whitespace\-only \(issue \#1787\)\.$#'
+			identifier: pfBlockerNG.emptyOnString
+			count: 2
+			path: src/usr/local/www/pfblockerng/www/index.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,11 @@
 includes:
     - phpstan-baseline.neon
 
+rules:
+    # Bans empty() on statically-string-typed operands (empty('0') is TRUE —
+    # issue #1787); the honest predicates are pfb_is_empty()/pfb_is_blank().
+    - PfBlockerNG\PHPStan\NoEmptyOnStringRule
+
 parameters:
     paths:
         - src

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1419,6 +1419,14 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		}
 	}
 
+	// issue #1768: ON_OFF/NUM skip the early return above (NULL==''/0 are legitimate
+	// stored values), but still flow into the scalar ops below (preg_match/htmlspecialchars).
+	// Coerce NULL -> '' here (not is_null-guard) so 'NULL==""' stays byte-identical while
+	// null-deprecations stop; caller-side Undefined-array-key warnings are untouched.
+	if (!is_array($input)) {
+		$input = (string) ($input ?? '');
+	}
+
 	// issue #1070: every non-FILE_MIME type runs scalar string ops below (htmlspecialchars/
 	// preg_match) that PHP 8 TypeErrors on an array -- reject an array up front, before any
 	// such op runs, for those types. issue #1139: must run before the control-char loop
@@ -2943,8 +2951,8 @@ function pfb_global() {
 		}
 	}
 
-	$pfb['supp']		= $pfb['ipconfig']['suppression'];			// Enable Suppression
-	$pfb['cc']		= $pfb['ipconfig']['database_cc'];			// Disable Country database CRON updates
+	$pfb['supp']		= $pfb['ipconfig']['suppression'] ?? '';		// Enable Suppression
+	$pfb['cc']		= $pfb['ipconfig']['database_cc'] ?? '';		// Disable Country database CRON updates
 	$pfb['maxmind_locale']	= $pfb['ipconfig']['maxmind_locale']	?: 'en';	// MaxMind Localized Language setting
 	$pfb['asn_reporting']	= $pfb['ipconfig']['asn_reporting']	?: 'disabled';	// ASN Reporting
 	$pfb['asn_token']	= $pfb['ipconfig']['asn_token']		?: '';		// ASN Token (IPinfo)
@@ -3013,16 +3021,16 @@ function pfb_global() {
 	$pfb['dnsbl_idn_block_malicious']	= PfbConfig::read('pfb_idn_block_malicious');		// Confusable: block malicious homoglyphs (default 'on')
 	$pfb['dnsbl_idn_escalate_suspicious']	= PfbConfig::read('pfb_idn_escalate_suspicious');	// Confusable: escalate suspicious mixed-script to block (opt-in)
 	$pfb['dnsbl_regex']	= $pfb['dnsblconfig']['pfb_regex'];			// DNSBL Resolver python regex
-	$pfb['dnsbl_regex_list']= $pfb['dnsblconfig']['pfb_regex_list'];		// DNSBL Resolver python regex list
+	$pfb['dnsbl_regex_list']= $pfb['dnsblconfig']['pfb_regex_list'] ?? '';	// DNSBL Resolver python regex list
 	$pfb['dnsbl_regex_cap']	= PfbConfig::read('pfb_regex_cap');			// DNSBL Resolver python opt-in "Limit long/complex regex" static cap
 	$pfb['dnsbl_cname']	= $pfb['dnsblconfig']['pfb_cname'];			// DNSBL Resolver python CNAME Validation
 	$pfb['dnsbl_tld_allow']	= $pfb['dnsblconfig']['pfb_pytld'];			// DNSBL Resolver TLD Allow option
 	$pfb['dnsbl_py_nolog']	= $pfb['dnsblconfig']['pfb_py_nolog'];			// DNSBL Resolver python - Log events via DNSBL Webserver vs python
 	$pfb['dnsbl_noaaaa']	= $pfb['dnsblconfig']['pfb_noaaaa'];			// DNSBL Resolver python no AAAA
-	$pfb['dnsbl_noaaaa_list']=$pfb['dnsblconfig']['pfb_noaaaa_list'];		// DNSBL Resolver python no AAAA list
+	$pfb['dnsbl_noaaaa_list']=$pfb['dnsblconfig']['pfb_noaaaa_list'] ?? '';	// DNSBL Resolver python no AAAA list
 
 	$pfb['dnsbl_gp']		= $pfb['dnsblconfig']['pfb_gp'];		// DNSBL Resolver python - DNSBL Bypass
-	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'];	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
+	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'] ?? '';	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
 
 	// SafeSearch — read via gateway (ADR-29).
 	$pfb['safesearch_enable']	= PfbConfig::read('safesearch_enable');
@@ -3380,6 +3388,10 @@ function pfb_sanitize_text_area(string $text): string {
 // Function to decode alias custom entry box.
 // Default (False, True): Return as string with comments
 function pfb_text_area_decode($text, $mode=FALSE, $type=TRUE, $idn=FALSE) {
+
+	// issue #1768: untyped $text feeds base64_decode() below; coerce NULL -> ''
+	// so an absent/unset caller stops emitting the null-deprecation.
+	$text = (string) ($text ?? '');
 
 	if ($mode) {
 		$custom = array();
@@ -15309,7 +15321,9 @@ function pfb_daemon_filterlog() {
 			if ($log_type == 'BSD' && empty($f[1])) {
 				array_splice($f, 1, 1);
 			}
-			$d = explode(',', $f[$f_pos]);
+			// issue #1768: a short/malformed filterlog line has no field at $f_pos --
+			// guard so explode() doesn't get NULL.
+			$d = explode(',', $f[$f_pos] ?? '');
 
 			// Resolve the Tracker ID: reparse at most once per unknown tracker; persistent
 			// negative cache prevents repeated reparses for anchor/trackerless rules.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3379,6 +3379,32 @@ function pfb_strip(string $value): string {
 
 
 /**
+ * Split a comma-joined config scalar into its list, honestly (issue #1792).
+ * Replaces the `explode(',', $x ?? '') ?: $default` idiom, whose elvis arm is
+ * unreachable -- explode() on a string subject always returns a non-empty
+ * (truthy) array, so an absent/empty scalar yielded [''] and the intended
+ * $default NEVER applied. Absent/empty ('' exactly -- pfb_is_empty, so a
+ * stored "0" is one real entry) now genuinely yields $default.
+ */
+function pfb_csv_list(?string $value, array $default = array()): array {
+	return pfb_is_empty($value) ? $default : explode(',', $value);
+}
+
+
+/**
+ * Decode a base64 config scalar for display/re-edit, honestly (issue #1792).
+ * Replaces the `base64_decode($x ?? '') ?: ''` idiom, whose elvis arm ate a
+ * stored "0" (base64_decode('MA==') === '0', falsy) along with the FALSE it
+ * was guarding against. Only a FALSE decode (malformed input) degrades to '';
+ * every decoded string -- "0" included -- survives verbatim.
+ */
+function pfb_b64_text(?string $value): string {
+	$decoded = base64_decode((string) ($value ?? ''));
+	return $decoded === FALSE ? '' : $decoded;
+}
+
+
+/**
  * Sanitize a single-line/scalar text field: converts legacy encodings to
  * UTF-8, strips every \p{C} character (Cc/Cf/Co/Cs/Cn -- includes CR/LF/TAB
  * and the BOM, since this contract is single-line), then trims (Unicode

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3350,6 +3350,35 @@ function pfb_rstrip(string $value): string {
 
 
 /**
+ * Left-strip counterpart of pfb_rstrip() — same whitespace class (ASCII,
+ * Unicode \s/\p{Z}, BOM), leading side only. Lets a caller ask what a line's
+ * first NONBLANK character is (e.g. comment detection when '#' hides behind
+ * indentation). Same fail-open degradation to the ASCII-ltrim'd value.
+ */
+function pfb_lstrip(string $value): string {
+	$value = ltrim($value);
+	return pfb_preg_replace_safe('/^[\s\p{Z}\x{FEFF}]+/u', '', $value);
+}
+
+
+/**
+ * Double-sided pfb_lstrip()+pfb_rstrip(): trim() with the same Unicode
+ * whitespace class the other issue-#1787 helpers use. The value "0" survives.
+ * ASCII fast path: after trim(), ASCII bytes at both ends prove no Unicode
+ * whitespace remains there (every \p{Z}/BOM codepoint is multi-byte), so the
+ * hot per-line callers skip the two preg passes entirely.
+ */
+function pfb_strip(string $value): string {
+	$value = trim($value);
+	if ($value === '' ||
+	    (ord($value[0]) < 0x80 && ord($value[strlen($value) - 1]) < 0x80)) {
+		return $value;
+	}
+	return pfb_lstrip(pfb_rstrip($value));
+}
+
+
+/**
  * Sanitize a single-line/scalar text field: converts legacy encodings to
  * UTF-8, strips every \p{C} character (Cc/Cf/Co/Cs/Cn -- includes CR/LF/TAB
  * and the BOM, since this contract is single-line), then trims (Unicode
@@ -7911,11 +7940,13 @@ function pfb_dnsbl_unbracket_ip6(string $line): string {
 // '!' (ABP/uBlock), '//' (C-style) -- the three conventions feeds in this ecosystem mix
 // together regardless of the list's own declared format. Callers whose '#' handling
 // carries side effects (hpHosts/Spamhaus/CSV-header sniffing in the DNSBL hosts-format
-// branch) check '#' themselves first and do not route it through here. Blank detection is
-// an exact '' match (empty() would eat the valid line "0" -- issue #1787) -- callers MUST
-// trim() first, or a whitespace-only line won't match.
+// branch) check '#' themselves first and do not route it through here. The helper strips
+// the line itself (pfb_strip, Unicode class -- issue #1787), so indentation the caller's
+// ASCII trim() can't remove (NBSP et al.) never hides a marker; blank detection is
+// pfb_is_empty()'s exact '' match (empty() would eat the valid line "0").
 function pfb_is_blank_or_comment_line(string $line): bool {
-	return $line === '' ||
+	$line = pfb_strip($line);
+	return pfb_is_empty($line) ||
 		str_starts_with($line, '#') ||
 		str_starts_with($line, '!') ||
 		str_starts_with($line, '//');
@@ -8127,12 +8158,14 @@ function pfb_dnsbl_csv_extract(string $line, array $csvline, string $csv_type, b
 
 
 // ADR-62 §2 Decision 4: the universal plain-path control-line skip. Mirrors
-// pfb_is_blank_or_comment_line's contract: blank detection is an exact '' match, so
-// the CALLER must trim() first. Deliberately excludes '#' -- pfb_dnsbl_hash_line_
+// pfb_is_blank_or_comment_line's contract: the helper strips the line itself
+// (pfb_strip, Unicode class -- issue #1787; blank = pfb_is_empty()'s exact '' match,
+// so the line "0" is data). Deliberately excludes '#' -- pfb_dnsbl_hash_line_
 // classify() owns it (side effects). A bracketed IPv6 literal is an ADDRESS, never
 // skipped as an ABP section marker.
 function pfb_dnsbl_is_skippable_control_line(string $line): bool {
-	if ($line === '' || str_starts_with($line, '!') || str_starts_with($line, '//')) {
+	$line = pfb_strip($line);
+	if (pfb_is_empty($line) || str_starts_with($line, '!') || str_starts_with($line, '//')) {
 		return TRUE;
 	}
 	if (str_starts_with($line, '[') && str_ends_with($line, ']')) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8214,6 +8214,10 @@ function pfb_dnsbl_is_skippable_control_line(string $line): bool {
 // convention, never '/re/' regex rules. A leading ',' is never valid ABP syntax (empty
 // first cosmetic domain-list entry), excluded up front. Kept in lockstep with
 // _dnsbl_is_abp_rule_line().
+// issue #1792: deliberately does NOT self-strip (unlike the pfb_is_blank_or_comment_line
+// family) -- its single caller sits in the parse loop after the per-line scrub, and the
+// Python mirror is pinned row-for-row by the ADR-62 parity oracle; a one-sided strip
+// here would be drift the oracle exists to prevent.
 function pfb_dnsbl_is_abp_rule_line(string $line): bool {
 	// issue #1067: a leading comma is never valid ABP syntax (empty first cosmetic
 	// domain-list entry) -- excluded up front regardless of downstream encoding.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3325,6 +3325,31 @@ function pfb_is_blank(?string $value): bool {
 
 
 /**
+ * TRUE iff $value is absent or the empty string — the actual "is this an empty
+ * string?" answer (issue #1787). Unlike empty(), the string "0" is NOT empty:
+ * it is a real value. Whitespace is content here; use pfb_is_blank() for the
+ * "nothing but whitespace" question.
+ */
+function pfb_is_empty(?string $value): bool {
+	return $value === NULL || $value === '';
+}
+
+
+/**
+ * Right-strip trailing whitespace — ASCII (rtrim()'s default set) plus Unicode
+ * whitespace/separators (\s under /u, \p{Z}) and the BOM — the same character
+ * class pfb_is_blank() calls blank (issue #1787). Leading whitespace and the
+ * value "0" survive untouched. A pathological preg_replace() failure degrades
+ * fail-open to the ASCII-rtrim'd value, so Unicode stripping may not apply for
+ * that call.
+ */
+function pfb_rstrip(string $value): string {
+	$value = rtrim($value);
+	return pfb_preg_replace_safe('/[\s\p{Z}\x{FEFF}]+$/u', '', $value);
+}
+
+
+/**
  * Sanitize a single-line/scalar text field: converts legacy encodings to
  * UTF-8, strips every \p{C} character (Cc/Cf/Co/Cs/Cn -- includes CR/LF/TAB
  * and the BOM, since this contract is single-line), then trims (Unicode
@@ -3356,8 +3381,8 @@ function pfb_sanitize_text(string $text): string {
  * normalizes CRLF/CR/LF line endings to LF, strips every \p{C} character
  * (Cc/Cf/Co/Cs/Cn, plus the BOM) except \n/\t -- so VT/FF/NEL/ZWJ/etc. never
  * become row separators or survive as data (issue #1795) -- then
- * right-strips trailing whitespace per line. The right-strip is
- * Unicode-aware (\p{Z} + tab), so NBSP/ideographic
+ * right-strips trailing whitespace per line (pfb_rstrip). The right-strip is
+ * Unicode-aware, so NBSP/ideographic
  * space/line-separator runs are stripped like ASCII space/tab, and a row of
  * only Unicode whitespace right-strips to '' same as an ASCII-blank row. Does
  * NOT drop blank lines; that is the caller's job (issue #1707). A
@@ -3377,8 +3402,7 @@ function pfb_sanitize_text_area(string $text): string {
 
 	$lines = explode("\n", $text);
 	foreach ($lines as &$line) {
-		$line = rtrim($line, " \t");
-		$line = pfb_preg_replace_safe('/[\p{Z}\t]+$/u', '', $line);
+		$line = pfb_rstrip($line);
 	}
 	unset($line);
 	return implode("\n", $lines);
@@ -4744,7 +4768,7 @@ function pfb_get_hooks($pfbconfig, $when) {
 		if (($hook['when'] ?? '') !== $when) {
 			continue;
 		}
-		if (trim((string) ($hook['script'] ?? '')) === '') {
+		if (pfb_is_blank((string) ($hook['script'] ?? ''))) {
 			continue;
 		}
 		$hooks[] = $hook;
@@ -7888,9 +7912,10 @@ function pfb_dnsbl_unbracket_ip6(string $line): string {
 // together regardless of the list's own declared format. Callers whose '#' handling
 // carries side effects (hpHosts/Spamhaus/CSV-header sniffing in the DNSBL hosts-format
 // branch) check '#' themselves first and do not route it through here. Blank detection is
-// empty($line) -- callers MUST trim() first, or a whitespace-only line won't match.
+// an exact '' match (empty() would eat the valid line "0" -- issue #1787) -- callers MUST
+// trim() first, or a whitespace-only line won't match.
 function pfb_is_blank_or_comment_line(string $line): bool {
-	return empty($line) ||
+	return $line === '' ||
 		str_starts_with($line, '#') ||
 		str_starts_with($line, '!') ||
 		str_starts_with($line, '//');
@@ -11868,7 +11893,7 @@ function pfb_feed_redirect_target($location, $current_url, &$reason, &$pinned) {
 	$reason = '';
 	$pinned = '';
 
-	if (!is_string($location) || trim($location) === '') {
+	if (!is_string($location) || pfb_is_blank($location)) {
 		$reason = 'feed redirect has no target';
 		return FALSE;
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3613,7 +3613,10 @@ function pfb_py_sync_status_list_open(string $status_dir): array
  */
 function pfb_validate_suppression_line(string $line, string $family): ?string
 {
-	if (str_starts_with($line, '#') || pfb_is_blank($line)) {
+	// Blank/comment no-op: judge by the first NONBLANK character, so an
+	// indented '#' (ASCII or Unicode whitespace) is still a comment.
+	$stripped = pfb_strip($line);
+	if (pfb_is_empty($stripped) || str_starts_with($stripped, '#')) {
 		return NULL;
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3613,7 +3613,7 @@ function pfb_py_sync_status_list_open(string $status_dir): array
  */
 function pfb_validate_suppression_line(string $line, string $family): ?string
 {
-	if (str_starts_with($line, '#') || trim($line) === '') {
+	if (str_starts_with($line, '#') || pfb_is_blank($line)) {
 		return NULL;
 	}
 
@@ -5044,7 +5044,7 @@ function pfb_lint_sh_diagnostics(string $content, string $sh = '/bin/sh', string
 		// sh exits at the FIRST syntax error -- an over-pipe-buffer body can EPIPE the
 		// stdin write loop (failure = 'stdin write failed') while stderr already holds a
 		// real line-mapped diagnostic; prefer that over the generic launch-failed warning.
-		if (trim($result['stderr']) !== '') {
+		if (!pfb_is_blank($result['stderr'])) {
 			return pfb_lint_parse_sh_stderr($result['stderr']);
 		}
 		return [['line' => 1, 'message' => 'sh syntax checker launch failed: ' . $result['failure'], 'severity' => 'warning']];
@@ -5052,7 +5052,7 @@ function pfb_lint_sh_diagnostics(string $content, string $sh = '/bin/sh', string
 	if ($result['exit'] === 0) {
 		return [];
 	}
-	if (trim($result['stderr']) === '') {
+	if (pfb_is_blank($result['stderr'])) {
 		return [['line' => 1, 'message' => "sh syntax checker exited {$result['exit']} with no diagnostic", 'severity' => 'warning']];
 	}
 	return pfb_lint_parse_sh_stderr($result['stderr']);
@@ -5088,7 +5088,7 @@ PYTHON;
 	if ($result['exit'] === 0) {
 		return [];
 	}
-	if ($result['exit'] === 1 && trim($result['stderr']) !== '') {
+	if ($result['exit'] === 1 && !pfb_is_blank($result['stderr'])) {
 		return pfb_lint_parse_py_stderr($result['stderr']);
 	}
 	return [['line' => 1, 'message' => "python syntax checker exited {$result['exit']} with no diagnostic", 'severity' => 'warning']];

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
@@ -286,8 +286,8 @@ foreach (array('Top Spammers', 'Africa', 'Antarctica', 'Asia', 'Europe', 'North 
 }
 
 $pconfig = array();
-$pconfig['countries4']		= explode(',', $pfb['geoipconfig']['countries4']);
-$pconfig['countries6']		= explode(',', $pfb['geoipconfig']['countries6']);
+$pconfig['countries4']		= explode(',', $pfb['geoipconfig']['countries4'] ?? '');
+$pconfig['countries6']		= explode(',', $pfb['geoipconfig']['countries6'] ?? '');
 $pconfig['action'] = pfb_group_action_valid($pfb['geoipconfig']['action'] ?? NULL, 'geoip') ? $pfb['geoipconfig']['action'] : 'Disabled';
 $pconfig['aliaslog']		= $pfb['geoipconfig']['aliaslog']			?: 'enabled';
 
@@ -846,10 +846,10 @@ $pconfig['enable_dedup']	= $pfb['repconfig']['enable_dedup'];
 $pconfig['p24_dmax_var']	= $pfb['repconfig']['p24_dmax_var'];
 $pconfig['ccwhite']		= $pfb['repconfig']['ccwhite'];
 $pconfig['ccblack']		= $pfb['repconfig']['ccblack'];
-$pconfig['ccexclude']		= explode(',', $pfb['repconfig']['ccexclude']);
+$pconfig['ccexclude']		= explode(',', $pfb['repconfig']['ccexclude'] ?? '');
 $pconfig['et_header']		= $pfb['repconfig']['et_header'];
-$pconfig['etblock']		= explode(',', $pfb['repconfig']['etblock']);
-$pconfig['etmatch']		= explode(',', $pfb['repconfig']['etmatch']);
+$pconfig['etblock']		= explode(',', $pfb['repconfig']['etblock'] ?? '');
+$pconfig['etmatch']		= explode(',', $pfb['repconfig']['etmatch'] ?? '');
 
 
 // Select field options

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -41,8 +41,8 @@ $pfb['aglobal'] = PfbConfig::readSection('installedpackages/pfblockerngglobal');
 $alertrefresh	= isset($pfb['aglobal']['alertrefresh'])	? $pfb['aglobal']['alertrefresh']	: 'on';
 $pfbpageload	= $pfb['aglobal']['pfbpageload']	!= ''	? $pfb['aglobal']['pfbpageload']	: 'unified';
 $pfbmaxtable	= $pfb['aglobal']['pfbmaxtable']	!= ''	? $pfb['aglobal']['pfbmaxtable']	: '1000';
-$pfbreplytypes	= explode(',', $pfb['aglobal']['pfbreplytypes'] ?? '')?: array();
-$pfbreplyrec	= explode(',', $pfb['aglobal']['pfbreplyrec'] ?? '')	?: array();
+$pfbreplytypes	= pfb_csv_list($pfb['aglobal']['pfbreplytypes'] ?? NULL);
+$pfbreplyrec	= pfb_csv_list($pfb['aglobal']['pfbreplyrec'] ?? NULL);
 
 // Unified Log - Light/Dark Theme colour keys: one registry drives the read defaults, the
 // save loops, and the render loops below. 'upstream' reads with null-coalescing because it
@@ -61,8 +61,10 @@ foreach ($uni_defaults as $u_type => $u_cfg) {
 	$u_light = "uni{$u_type}";
 	$u_dark  = "uni{$u_type}2";
 	if ($u_cfg['safe_read']) {
-		$pfb[$u_light]	= ($pfb['aglobal'][$u_light] ?? '')	?: $u_cfg['light_default'];
-		$pfb[$u_dark]	= ($pfb['aglobal'][$u_dark] ?? '')	?: $u_cfg['dark_default'];
+		// issue #1792: pfb_is_empty, not ?: -- a stored colour of literally
+		// '0' is the user's (odd) value, not an absence.
+		$pfb[$u_light]	= pfb_is_empty($pfb['aglobal'][$u_light] ?? NULL) ? $u_cfg['light_default'] : $pfb['aglobal'][$u_light];
+		$pfb[$u_dark]	= pfb_is_empty($pfb['aglobal'][$u_dark] ?? NULL) ? $u_cfg['dark_default'] : $pfb['aglobal'][$u_dark];
 	} else {
 		$pfb[$u_light]	= $pfb['aglobal'][$u_light]		?: $u_cfg['light_default'];
 		$pfb[$u_dark]	= $pfb['aglobal'][$u_dark]		?: $u_cfg['dark_default'];
@@ -73,11 +75,11 @@ $pfbchartcnt	= $pfb['aglobal']['pfbchartcnt']		?: '24';
 $pfbchartstyle	= $pfb['aglobal']['pfbchartstyle']		?: 'twotone';
 $pfbchart1	= $pfb['aglobal']['pfbchart1']			?: '#0C6197';
 $pfbchart2	= $pfb['aglobal']['pfbchart2']			?: '#7A7A7A';
-$pfbblockstat	= explode(',', $pfb['aglobal']['pfbblockstat'] ?? '') ?: array();
-$pfbpermitstat	= explode(',', $pfb['aglobal']['pfbpermitstat'] ?? '')?: array();
-$pfbmatchstat	= explode(',', $pfb['aglobal']['pfbmatchstat'] ?? '')	?: array();
-$pfbdnsblstat	= explode(',', $pfb['aglobal']['pfbdnsblstat'] ?? '')	?: array();
-$pfbdnsblreplystat = explode(',', $pfb['aglobal']['pfbdnsblreplystat'] ?? '') ?: array();
+$pfbblockstat	= pfb_csv_list($pfb['aglobal']['pfbblockstat'] ?? NULL);
+$pfbpermitstat	= pfb_csv_list($pfb['aglobal']['pfbpermitstat'] ?? NULL);
+$pfbmatchstat	= pfb_csv_list($pfb['aglobal']['pfbmatchstat'] ?? NULL);
+$pfbdnsblstat	= pfb_csv_list($pfb['aglobal']['pfbdnsblstat'] ?? NULL);
+$pfbdnsblreplystat = pfb_csv_list($pfb['aglobal']['pfbdnsblreplystat'] ?? NULL);
 
 // issue #1497: explicit assignments (was a ${"$type"} variable-variable loop
 // over $aglobal_array) -- PHPStan can't trace a variable-variable target, so
@@ -1781,7 +1783,9 @@ if ($alert_summary) {
 					}
 
 					$data = array_map('trim', explode(' ', trim($line), 2));
-					$alert_stats[$alert_view][$stat_type][($data[1] ?? '') ?: $unknown_msg] = $data[0] ?: 0;
+					// issue #1792: a stat label of literally '0' is a real
+					// label -- only a MISSING/empty field reads "Unknown".
+					$alert_stats[$alert_view][$stat_type][pfb_is_empty($data[1] ?? NULL) ? $unknown_msg : $data[1]] = (int) $data[0];
 				}
 			}
 			else {

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2497,11 +2497,28 @@ function convert_dns_reply_log($mode, $fields) {
 
 		// issue #1777: dnsbl_whitelist_type() unconditionally reads keys 5/7/8 too
 		// (DNSBL Mode / Evaluated Domain / Feed Name) -- a DNS reply row has no
-		// Mode or Feed, so '' preserves the pre-fix implicit-NULL branch selection
-		// (still != 'DNSBL_TLD') and leaves the (never-reached, group=='Unknown')
-		// Feed-name usage inert; the replied domain doubles as the "evaluated"
-		// domain, matching key 2 and the $qdomain argument below.
-		$dns_fields = array ('2' => $fields[6], '5' => '', '6' => 'Unknown', '7' => $fields[6], '8' => '');
+		// Mode, Evaluated Domain or Feed, so each key preserves the pre-fix
+		// implicit-NULL read at its own call site:
+		//   - key 5 (DNSBL Mode, gates the != 'DNSBL_TLD' branch split): '' keeps
+		//     the pre-fix branch selection byte-for-byte, since NULL != 'DNSBL_TLD'
+		//     is also TRUE.
+		//   - key 7 (Evaluated Domain): '' -- NOT $fields[6]. A prior fix set this
+		//     to $fields[6] (the replied domain) reasoning only about the
+		//     exclusion-icon id; it missed that dnsbl_whitelist_type() ALSO feeds
+		//     key 7 into the dot-prefixed wildcard-whitelist walk
+		//     (dnsbl_whitelist_type() ~:2056, `ltrim($fields[7], '.')`). A real
+		//     domain there enters that walk and can flip $isWhitelist_found to
+		//     TRUE for any dot-prefixed whitelist entry that is an ancestor
+		//     domain -- silently reclassifying an unrelated reply row as
+		//     already-whitelisted. '' is chosen because
+		//     ltrim(NULL, '.') === ltrim('', '.') === '', so it reproduces the
+		//     pre-fix NULL read exactly and never enters the walk.
+		//   - key 8 (Feed Name) is read only inside the `$fields[6] != 'Unknown'`
+		//     branch (dnsbl_whitelist_type() ~:2023), which the caller's own
+		//     hardcoded '6' => 'Unknown' provably never enters -- no reply-log
+		//     analogue exists and none is needed; '' is inert by construction.
+		// The replied domain doubles as key 2 and the $qdomain argument below.
+		$dns_fields = array ('2' => $fields[6], '5' => '', '6' => 'Unknown', '7' => '', '8' => '');
 		list($supp_dom, $ex_dom, $isWhitelist_found) = dnsbl_whitelist_type($dns_fields, $clists, $isExclusion, FALSE, $fields[6]);
 
 		// Threat Lookup Icon

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -41,8 +41,8 @@ $pfb['aglobal'] = PfbConfig::readSection('installedpackages/pfblockerngglobal');
 $alertrefresh	= isset($pfb['aglobal']['alertrefresh'])	? $pfb['aglobal']['alertrefresh']	: 'on';
 $pfbpageload	= $pfb['aglobal']['pfbpageload']	!= ''	? $pfb['aglobal']['pfbpageload']	: 'unified';
 $pfbmaxtable	= $pfb['aglobal']['pfbmaxtable']	!= ''	? $pfb['aglobal']['pfbmaxtable']	: '1000';
-$pfbreplytypes	= explode(',', $pfb['aglobal']['pfbreplytypes'])?: array();
-$pfbreplyrec	= explode(',', $pfb['aglobal']['pfbreplyrec'])	?: array();
+$pfbreplytypes	= explode(',', $pfb['aglobal']['pfbreplytypes'] ?? '')?: array();
+$pfbreplyrec	= explode(',', $pfb['aglobal']['pfbreplyrec'] ?? '')	?: array();
 
 // Unified Log - Light/Dark Theme colour keys: one registry drives the read defaults, the
 // save loops, and the render loops below. 'upstream' reads with null-coalescing because it
@@ -73,11 +73,11 @@ $pfbchartcnt	= $pfb['aglobal']['pfbchartcnt']		?: '24';
 $pfbchartstyle	= $pfb['aglobal']['pfbchartstyle']		?: 'twotone';
 $pfbchart1	= $pfb['aglobal']['pfbchart1']			?: '#0C6197';
 $pfbchart2	= $pfb['aglobal']['pfbchart2']			?: '#7A7A7A';
-$pfbblockstat	= explode(',', $pfb['aglobal']['pfbblockstat']) ?: array();
-$pfbpermitstat	= explode(',', $pfb['aglobal']['pfbpermitstat'])?: array();
-$pfbmatchstat	= explode(',', $pfb['aglobal']['pfbmatchstat'])	?: array();
-$pfbdnsblstat	= explode(',', $pfb['aglobal']['pfbdnsblstat'])	?: array();
-$pfbdnsblreplystat = explode(',', $pfb['aglobal']['pfbdnsblreplystat']) ?: array();
+$pfbblockstat	= explode(',', $pfb['aglobal']['pfbblockstat'] ?? '') ?: array();
+$pfbpermitstat	= explode(',', $pfb['aglobal']['pfbpermitstat'] ?? '')?: array();
+$pfbmatchstat	= explode(',', $pfb['aglobal']['pfbmatchstat'] ?? '')	?: array();
+$pfbdnsblstat	= explode(',', $pfb['aglobal']['pfbdnsblstat'] ?? '')	?: array();
+$pfbdnsblreplystat = explode(',', $pfb['aglobal']['pfbdnsblreplystat'] ?? '') ?: array();
 
 // issue #1497: explicit assignments (was a ${"$type"} variable-variable loop
 // over $aglobal_array) -- PHPStan can't trace a variable-variable target, so

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -121,7 +121,7 @@ foreach (array(2,7,8,13,15,17,19,20,99) as $field_1) {
 
 $filterfieldsarray[2]	= array();
 foreach (array(81,82,83,84,85,86,87,88,89) as $field_2) {
-	$filterfieldsarray[1][$field_2] = '';
+	$filterfieldsarray[2][$field_2] = '';
 }
 
 // $alert_log is set by the view handler below but read in the stats section much later;
@@ -1781,7 +1781,7 @@ if ($alert_summary) {
 					}
 
 					$data = array_map('trim', explode(' ', trim($line), 2));
-					$alert_stats[$alert_view][$stat_type][$data[1] ?: $unknown_msg] = $data[0] ?: 0;
+					$alert_stats[$alert_view][$stat_type][($data[1] ?? '') ?: $unknown_msg] = $data[0] ?: 0;
 				}
 			}
 			else {
@@ -2495,7 +2495,13 @@ function convert_dns_reply_log($mode, $fields) {
 	// Determine Whitelist type
 	else {
 
-		$dns_fields = array ('2' => $fields[6], '6' => 'Unknown');
+		// issue #1777: dnsbl_whitelist_type() unconditionally reads keys 5/7/8 too
+		// (DNSBL Mode / Evaluated Domain / Feed Name) -- a DNS reply row has no
+		// Mode or Feed, so '' preserves the pre-fix implicit-NULL branch selection
+		// (still != 'DNSBL_TLD') and leaves the (never-reached, group=='Unknown')
+		// Feed-name usage inert; the replied domain doubles as the "evaluated"
+		// domain, matching key 2 and the $qdomain argument below.
+		$dns_fields = array ('2' => $fields[6], '5' => '', '6' => 'Unknown', '7' => $fields[6], '8' => '');
 		list($supp_dom, $ex_dom, $isWhitelist_found) = dnsbl_whitelist_type($dns_fields, $clists, $isExclusion, FALSE, $fields[6]);
 
 		// Threat Lookup Icon
@@ -4935,7 +4941,7 @@ var pieChart_<?=$stat_type?> = new d3pie("pieChart_<?=$stat_type?>", {
 	$k = array_keys($summary);
 	$numentries = 0;
 	for ($i = 0; $i < ($numsegments-1); $i++) {
-		if ($k[$i]) {
+		if ($k[$i] ?? NULL) {
 			$numentries++;
 			if ($i > 0) {
 				print(",\r\n");

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -114,7 +114,7 @@ $pfb['bconfig']	= PfbConfig::readSection('installedpackages/pfblockerngblacklist
 $pconfig = array();
 $pconfig['blacklist_enable']		= $pfb['bconfig']['blacklist_enable']				?: 'Disable';
 $pconfig['blacklist_lang']		= $pfb['bconfig']['blacklist_lang']				?: 'EN';
-$pconfig['blacklist_selected']		= explode(',', $pfb['bconfig']['blacklist_selected'])		?: array();
+$pconfig['blacklist_selected']		= explode(',', $pfb['bconfig']['blacklist_selected'] ?? '')		?: array();
 $pconfig['blacklist_freq']		= $pfb['bconfig']['blacklist_freq']				?: 'Never';
 $pconfig['blacklist_logging']		= $pfb['bconfig']['blacklist_logging']				?: 'enabled';
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -114,7 +114,7 @@ $pfb['bconfig']	= PfbConfig::readSection('installedpackages/pfblockerngblacklist
 $pconfig = array();
 $pconfig['blacklist_enable']		= $pfb['bconfig']['blacklist_enable']				?: 'Disable';
 $pconfig['blacklist_lang']		= $pfb['bconfig']['blacklist_lang']				?: 'EN';
-$pconfig['blacklist_selected']		= explode(',', $pfb['bconfig']['blacklist_selected'] ?? '')		?: array();
+$pconfig['blacklist_selected']		= pfb_csv_list($pfb['bconfig']['blacklist_selected'] ?? NULL);
 $pconfig['blacklist_freq']		= $pfb['bconfig']['blacklist_freq']				?: 'Never';
 $pconfig['blacklist_logging']		= $pfb['bconfig']['blacklist_logging']				?: 'enabled';
 
@@ -484,11 +484,12 @@ foreach ($blacklist_types as $type => $setting) {
 
 		// issue #1777: most providers document a DESC/NAME line for only a
 		// subset of languages per category -- $l/$e guard the missing-index
-		// read; the ?: EN fallback below is load-bearing (an empty translation
-		// must still fall back to EN) and must stay ?:, never ??.
+		// read; the EN fallback below is load-bearing (an empty translation
+		// must still fall back to EN -- pfb_is_empty, issue #1792, so a
+		// translation of literally '0' is kept, never treated as absent).
 		$l = $info[$pconfig['blacklist_lang']] ?? array();
 		$e = $info['EN'] ?? array();
-		$category_lang = ($l[1] ?? '') ?: ($e[1] ?? '');
+		$category_lang = pfb_is_empty($l[1] ?? NULL) ? ($e[1] ?? '') : $l[1];
 
 		$selected = FALSE;
 		if (isset($_POST['enableall'][$type])) {
@@ -519,7 +520,8 @@ foreach ($blacklist_types as $type => $setting) {
 
 		$group->add(new Form_StaticText(
 			'',
-			($l[0] ?? '') ?: ($e[0] ?? '')
+			// issue #1792: same honest fallback as $category_lang above.
+			pfb_is_empty($l[0] ?? NULL) ? ($e[0] ?? '') : $l[0]
 		))->setWidth(7);
 
 		$section->add($group);

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -482,7 +482,13 @@ foreach ($blacklist_types as $type => $setting) {
 	ksort($data, SORT_NATURAL);
 	foreach ($data as $category => $info) {
 
-		$category_lang = $info[$pconfig['blacklist_lang']][1] ?: $info['EN'][1];
+		// issue #1777: most providers document a DESC/NAME line for only a
+		// subset of languages per category -- $l/$e guard the missing-index
+		// read; the ?: EN fallback below is load-bearing (an empty translation
+		// must still fall back to EN) and must stay ?:, never ??.
+		$l = $info[$pconfig['blacklist_lang']] ?? array();
+		$e = $info['EN'] ?? array();
+		$category_lang = ($l[1] ?? '') ?: ($e[1] ?? '');
 
 		$selected = FALSE;
 		if (isset($_POST['enableall'][$type])) {
@@ -513,7 +519,7 @@ foreach ($blacklist_types as $type => $setting) {
 
 		$group->add(new Form_StaticText(
 			'',
-			$info[$pconfig['blacklist_lang']][0] ?: $info['EN'][0]
+			($l[0] ?? '') ?: ($e[0] ?? '')
 		))->setWidth(7);
 
 		$section->add($group);

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -849,7 +849,8 @@ if ($_POST && isset($_POST['save'])) {
 
 		// Set flag to update CustomList on next Cron|Force update|Force reload
 		// foreign key: installedpackages/{conf_type} list structure not in registry
-		if (base64_decode(config_get_path("installedpackages/{$conf_type}/config/{$rowid}/custom")) != $_POST['custom']) {
+		// issue #1768: no default -> config_get_path() returns NULL on a fresh row -> base64_decode(NULL) deprecation.
+		if (base64_decode(config_get_path("installedpackages/{$conf_type}/config/{$rowid}/custom", '')) != $_POST['custom']) {
 			$action = $_POST['action'];
 			$aname  = $_POST['aliasname'];
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -862,7 +862,7 @@ if ($_POST && isset($_POST['save'])) {
 			}
 		}
 
-		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/custom", base64_encode($_POST['custom'] ?? '') ?: '');
+		config_set_path("installedpackages/{$conf_type}/config/{$rowid}/custom", base64_encode($_POST['custom'] ?? ''));
 
 		$rowhelper_exist = array();
 		foreach ($_POST as $key => $value) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -59,7 +59,7 @@ $pconfig['pfb_dnsport']		= $pfb['dconfig']['pfb_dnsport']			?: '8081';
 $pconfig['pfb_dnsport_ssl']	= $pfb['dconfig']['pfb_dnsport_ssl']			?: '8443';
 $pconfig['dnsbl_interface']	= $pfb['dconfig']['dnsbl_interface']			?: 'lo0';
 $pconfig['pfb_dnsbl_rule']	= $pfb['dconfig']['pfb_dnsbl_rule']			?: '';
-$pconfig['dnsbl_allow_int']	= explode(',', $pfb['dconfig']['dnsbl_allow_int'] ?? '')	?: array();
+$pconfig['dnsbl_allow_int']	= pfb_csv_list($pfb['dconfig']['dnsbl_allow_int'] ?? NULL);
 $pconfig['global_log']		= $pfb['dconfig']['global_log']				?: '';
 $pconfig['dnsbl_webpage']	= $pfb['dconfig']['dnsbl_webpage']			?: 'dnsbl_default.php';
 $pconfig['pfb_cache']		= isset($pfb['dconfig']['pfb_cache'])			? $pfb['dconfig']['pfb_cache'] : 'on';
@@ -86,14 +86,14 @@ $pconfig['pfb_noaaaa']		= $pfb['dconfig']['pfb_noaaaa']				?: '';
 $pconfig['pfb_gp']		= $pfb['dconfig']['pfb_gp']				?: '';
 $pconfig['pfb_pytld']		= $pfb['dconfig']['pfb_pytld']				?: '';
 $pconfig['pfb_pytld_sort']	= $pfb['dconfig']['pfb_pytld_sort']			?: '';
-$pconfig['pfb_pytlds_gtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_gtld'] ?? '')	?: $default_tlds;
-$pconfig['pfb_pytlds_cctld']	= explode(',', $pfb['dconfig']['pfb_pytlds_cctld'] ?? '')	?: array();
-$pconfig['pfb_pytlds_itld']	= explode(',', $pfb['dconfig']['pfb_pytlds_itld'] ?? '')	?: array();
-$pconfig['pfb_pytlds_bgtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_bgtld'] ?? '')	?: array();
+$pconfig['pfb_pytlds_gtld']	= pfb_csv_list($pfb['dconfig']['pfb_pytlds_gtld'] ?? NULL, $default_tlds);
+$pconfig['pfb_pytlds_cctld']	= pfb_csv_list($pfb['dconfig']['pfb_pytlds_cctld'] ?? NULL);
+$pconfig['pfb_pytlds_itld']	= pfb_csv_list($pfb['dconfig']['pfb_pytlds_itld'] ?? NULL);
+$pconfig['pfb_pytlds_bgtld']	= pfb_csv_list($pfb['dconfig']['pfb_pytlds_bgtld'] ?? NULL);
 $pconfig['pfb_py_nolog']	= $pfb['dconfig']['pfb_py_nolog']			?: '';
-$pconfig['pfb_regex_list']	= base64_decode($pfb['dconfig']['pfb_regex_list'] ?? '')	?: '';
-$pconfig['pfb_noaaaa_list']	= base64_decode($pfb['dconfig']['pfb_noaaaa_list'] ?? '')	?: '';
-$pconfig['pfb_gp_bypass_list']	= base64_decode($pfb['dconfig']['pfb_gp_bypass_list'] ?? '')	?: '';
+$pconfig['pfb_regex_list']	= pfb_b64_text($pfb['dconfig']['pfb_regex_list'] ?? NULL);
+$pconfig['pfb_noaaaa_list']	= pfb_b64_text($pfb['dconfig']['pfb_noaaaa_list'] ?? NULL);
+$pconfig['pfb_gp_bypass_list']	= pfb_b64_text($pfb['dconfig']['pfb_gp_bypass_list'] ?? NULL);
 $pconfig['action']		= $pfb['dconfig']['action']				?: 'Disabled';
 $pconfig['aliaslog']		= $pfb['dconfig']['aliaslog']				?: 'enabled';
 
@@ -115,7 +115,7 @@ $pconfig['aliasaddr_out']	= $pfb['dconfig']['aliasaddr_out']			?: '';
 $pconfig['autoproto_out']	= $pfb['dconfig']['autoproto_out']			?: 'any';
 $pconfig['agateway_out']	= $pfb['dconfig']['agateway_out']			?: 'default';
 
-$pconfig['suppression']		= base64_decode($pfb['dconfig']['suppression'] ?? '')		?: '';
+$pconfig['suppression']		= pfb_b64_text($pfb['dconfig']['suppression'] ?? NULL);
 
 $pconfig['alexa_enable']	= $pfb['dconfig']['alexa_enable']			?: '';
 // Routed via the gateway (not the section array) so a stored legacy 'alexa'
@@ -126,10 +126,10 @@ $pconfig['alexa_type']		= PfbConfig::read('alexa_type')->toStored();
 $pconfig['alexa_count']		= $pfb['dconfig']['alexa_count']			?: '1000';
 // 0 (unlimited) is meaningful, so don't use the ?: idiom (0 is falsy -> would reset to default).
 $pconfig['pfb_py_cache_max']	= (isset($pfb['dconfig']['pfb_py_cache_max']) && $pfb['dconfig']['pfb_py_cache_max'] !== '') ? $pfb['dconfig']['pfb_py_cache_max'] : '10000';
-$pconfig['alexa_inclusion']	= explode(',', $pfb['dconfig']['alexa_inclusion'] ?? '')	?: array('com','net','org','ca','co','io');
+$pconfig['alexa_inclusion']	= pfb_csv_list($pfb['dconfig']['alexa_inclusion'] ?? NULL, array('com','net','org','ca','co','io'));
 
-$pconfig['tldexclusion']	= base64_decode($pfb['dconfig']['tldexclusion'] ?? '')	?: '';
-$pconfig['tldblacklist']	= base64_decode($pfb['dconfig']['tldblacklist'] ?? '')	?: '';
+$pconfig['tldexclusion']	= pfb_b64_text($pfb['dconfig']['tldexclusion'] ?? NULL);
+$pconfig['tldblacklist']	= pfb_b64_text($pfb['dconfig']['tldblacklist'] ?? NULL);
 
 // DoH/DoT/DoQ blocking — stored in pfblockerngsafesearch; read via gateway (registered keys)
 $pconfig['safesearch_doh']		= PfbConfig::read('safesearch_doh');
@@ -897,12 +897,12 @@ if ($_POST) {
 			$pfb['dconfig']['alexa_enable']		= pfb_filter($_POST['alexa_enable'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 
 			// issue #1723: already sanitized by the ingestion prologue above -- plain encode.
-			$pfb['dconfig']['pfb_regex_list']	= base64_encode($_POST['pfb_regex_list'] ?? '')				?: '';
-			$pfb['dconfig']['pfb_noaaaa_list']	= base64_encode($_POST['pfb_noaaaa_list'] ?? '')				?: '';
-			$pfb['dconfig']['pfb_gp_bypass_list']	= base64_encode($_POST['pfb_gp_bypass_list'] ?? '')				?: '';
-			$pfb['dconfig']['suppression']		= base64_encode($_POST['suppression'] ?? '')					?: '';
-			$pfb['dconfig']['tldexclusion']		= base64_encode($_POST['tldexclusion'] ?? '')					?: '';
-			$pfb['dconfig']['tldblacklist']		= base64_encode($_POST['tldblacklist'] ?? '')					?: '';
+			$pfb['dconfig']['pfb_regex_list']	= base64_encode($_POST['pfb_regex_list'] ?? '');
+			$pfb['dconfig']['pfb_noaaaa_list']	= base64_encode($_POST['pfb_noaaaa_list'] ?? '');
+			$pfb['dconfig']['pfb_gp_bypass_list']	= base64_encode($_POST['pfb_gp_bypass_list'] ?? '');
+			$pfb['dconfig']['suppression']		= base64_encode($_POST['suppression'] ?? '');
+			$pfb['dconfig']['tldexclusion']		= base64_encode($_POST['tldexclusion'] ?? '');
+			$pfb['dconfig']['tldblacklist']		= base64_encode($_POST['tldblacklist'] ?? '');
 
 			// A provider/auth identity change invalidates only the download detector
 			// baseline. Keep the active source and derived whitelist available until

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -59,7 +59,7 @@ $pconfig['pfb_dnsport']		= $pfb['dconfig']['pfb_dnsport']			?: '8081';
 $pconfig['pfb_dnsport_ssl']	= $pfb['dconfig']['pfb_dnsport_ssl']			?: '8443';
 $pconfig['dnsbl_interface']	= $pfb['dconfig']['dnsbl_interface']			?: 'lo0';
 $pconfig['pfb_dnsbl_rule']	= $pfb['dconfig']['pfb_dnsbl_rule']			?: '';
-$pconfig['dnsbl_allow_int']	= explode(',', $pfb['dconfig']['dnsbl_allow_int'])	?: array();
+$pconfig['dnsbl_allow_int']	= explode(',', $pfb['dconfig']['dnsbl_allow_int'] ?? '')	?: array();
 $pconfig['global_log']		= $pfb['dconfig']['global_log']				?: '';
 $pconfig['dnsbl_webpage']	= $pfb['dconfig']['dnsbl_webpage']			?: 'dnsbl_default.php';
 $pconfig['pfb_cache']		= isset($pfb['dconfig']['pfb_cache'])			? $pfb['dconfig']['pfb_cache'] : 'on';
@@ -86,14 +86,14 @@ $pconfig['pfb_noaaaa']		= $pfb['dconfig']['pfb_noaaaa']				?: '';
 $pconfig['pfb_gp']		= $pfb['dconfig']['pfb_gp']				?: '';
 $pconfig['pfb_pytld']		= $pfb['dconfig']['pfb_pytld']				?: '';
 $pconfig['pfb_pytld_sort']	= $pfb['dconfig']['pfb_pytld_sort']			?: '';
-$pconfig['pfb_pytlds_gtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_gtld'])	?: $default_tlds;
-$pconfig['pfb_pytlds_cctld']	= explode(',', $pfb['dconfig']['pfb_pytlds_cctld'])	?: array();
-$pconfig['pfb_pytlds_itld']	= explode(',', $pfb['dconfig']['pfb_pytlds_itld'])	?: array();
-$pconfig['pfb_pytlds_bgtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_bgtld'])	?: array();
+$pconfig['pfb_pytlds_gtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_gtld'] ?? '')	?: $default_tlds;
+$pconfig['pfb_pytlds_cctld']	= explode(',', $pfb['dconfig']['pfb_pytlds_cctld'] ?? '')	?: array();
+$pconfig['pfb_pytlds_itld']	= explode(',', $pfb['dconfig']['pfb_pytlds_itld'] ?? '')	?: array();
+$pconfig['pfb_pytlds_bgtld']	= explode(',', $pfb['dconfig']['pfb_pytlds_bgtld'] ?? '')	?: array();
 $pconfig['pfb_py_nolog']	= $pfb['dconfig']['pfb_py_nolog']			?: '';
-$pconfig['pfb_regex_list']	= base64_decode($pfb['dconfig']['pfb_regex_list'])	?: '';
-$pconfig['pfb_noaaaa_list']	= base64_decode($pfb['dconfig']['pfb_noaaaa_list'])	?: '';
-$pconfig['pfb_gp_bypass_list']	= base64_decode($pfb['dconfig']['pfb_gp_bypass_list'])	?: '';
+$pconfig['pfb_regex_list']	= base64_decode($pfb['dconfig']['pfb_regex_list'] ?? '')	?: '';
+$pconfig['pfb_noaaaa_list']	= base64_decode($pfb['dconfig']['pfb_noaaaa_list'] ?? '')	?: '';
+$pconfig['pfb_gp_bypass_list']	= base64_decode($pfb['dconfig']['pfb_gp_bypass_list'] ?? '')	?: '';
 $pconfig['action']		= $pfb['dconfig']['action']				?: 'Disabled';
 $pconfig['aliaslog']		= $pfb['dconfig']['aliaslog']				?: 'enabled';
 
@@ -115,7 +115,7 @@ $pconfig['aliasaddr_out']	= $pfb['dconfig']['aliasaddr_out']			?: '';
 $pconfig['autoproto_out']	= $pfb['dconfig']['autoproto_out']			?: 'any';
 $pconfig['agateway_out']	= $pfb['dconfig']['agateway_out']			?: 'default';
 
-$pconfig['suppression']		= base64_decode($pfb['dconfig']['suppression'])		?: '';
+$pconfig['suppression']		= base64_decode($pfb['dconfig']['suppression'] ?? '')		?: '';
 
 $pconfig['alexa_enable']	= $pfb['dconfig']['alexa_enable']			?: '';
 // Routed via the gateway (not the section array) so a stored legacy 'alexa'
@@ -126,10 +126,10 @@ $pconfig['alexa_type']		= PfbConfig::read('alexa_type')->toStored();
 $pconfig['alexa_count']		= $pfb['dconfig']['alexa_count']			?: '1000';
 // 0 (unlimited) is meaningful, so don't use the ?: idiom (0 is falsy -> would reset to default).
 $pconfig['pfb_py_cache_max']	= (isset($pfb['dconfig']['pfb_py_cache_max']) && $pfb['dconfig']['pfb_py_cache_max'] !== '') ? $pfb['dconfig']['pfb_py_cache_max'] : '10000';
-$pconfig['alexa_inclusion']	= explode(',', $pfb['dconfig']['alexa_inclusion'])	?: array('com','net','org','ca','co','io');
+$pconfig['alexa_inclusion']	= explode(',', $pfb['dconfig']['alexa_inclusion'] ?? '')	?: array('com','net','org','ca','co','io');
 
-$pconfig['tldexclusion']	= base64_decode($pfb['dconfig']['tldexclusion'])	?: '';
-$pconfig['tldblacklist']	= base64_decode($pfb['dconfig']['tldblacklist'])	?: '';
+$pconfig['tldexclusion']	= base64_decode($pfb['dconfig']['tldexclusion'] ?? '')	?: '';
+$pconfig['tldblacklist']	= base64_decode($pfb['dconfig']['tldblacklist'] ?? '')	?: '';
 
 // DoH/DoT/DoQ blocking — stored in pfblockerngsafesearch; read via gateway (registered keys)
 $pconfig['safesearch_doh']		= PfbConfig::read('safesearch_doh');

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -61,19 +61,19 @@ $pconfig['maxmind_account']	= $pfb['iconfig']['maxmind_account']			?: '';
 // A GET renders blank; a validation-error redisplay preserves the just-typed $_POST value
 // (like every other field), never PfbConfig/iconfig.
 $pconfig['maxmind_key']		= $_POST['maxmind_key'] ?? '';
-$pconfig['inbound_interface']	= explode(',', $pfb['iconfig']['inbound_interface'] ?? '')	?: array();
+$pconfig['inbound_interface']	= pfb_csv_list($pfb['iconfig']['inbound_interface'] ?? NULL);
 $pconfig['inbound_deny_action']	= $pfb['iconfig']['inbound_deny_action']		?: 'block';
-$pconfig['outbound_interface']	= explode(',', $pfb['iconfig']['outbound_interface'] ?? '')	?: array();
+$pconfig['outbound_interface']	= pfb_csv_list($pfb['iconfig']['outbound_interface'] ?? NULL);
 $pconfig['outbound_deny_action']= $pfb['iconfig']['outbound_deny_action']		?: 'reject';
 $pconfig['enable_float']	= $pfb['iconfig']['enable_float']			?: '';
 $pconfig['pass_order']		= $pfb['iconfig']['pass_order']				?: 'order_0';
 $pconfig['autorule_suffix']	= $pfb['iconfig']['autorule_suffix']			?: 'autorule';
 $pconfig['killstates']		= $pfb['iconfig']['killstates']				?: '';
-$pconfig['v4suppression']	= base64_decode($pfb['iconfig']['v4suppression'] ?? '')	?: '';
+$pconfig['v4suppression']	= pfb_b64_text($pfb['iconfig']['v4suppression'] ?? NULL);
 // ADR-53 review finding B: '?? ""' on the array read -- v6suppression (unlike
 // v4suppression) is NEVER install-migrated, so it is absent from config.xml
 // on every install until this page's first post-upgrade save.
-$pconfig['v6suppression']	= base64_decode($pfb['iconfig']['v6suppression'] ?? '')	?: '';
+$pconfig['v6suppression']	= pfb_b64_text($pfb['iconfig']['v6suppression'] ?? NULL);
 
 // Select array options
 $options_asn_reporting 		= [	'disabled'	=> 'Disabled',
@@ -263,8 +263,8 @@ if ($_POST) {
 			$pfb['iconfig']['autorule_suffix']	= $_POST['autorule_suffix']					?: 'autorule';
 			$pfb['iconfig']['killstates']		= pfb_filter($_POST['killstates'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			// issue #1723: already sanitized by the ingestion prologue -- plain encode.
-			$pfb['iconfig']['v4suppression']	= base64_encode($_POST['v4suppression'] ?? '')			?: '';
-			$pfb['iconfig']['v6suppression']	= base64_encode($_POST['v6suppression'] ?? '')			?: '';
+			$pfb['iconfig']['v4suppression']	= base64_encode($_POST['v4suppression'] ?? '');
+			$pfb['iconfig']['v6suppression']	= base64_encode($_POST['v6suppression'] ?? '');
 
 			// ADR-11: per-type aggregate aliases multi-select -> CSV scalar (sanitised to the
 			// known option keys; default none). Gateway-registered in the general section, so

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -108,6 +108,17 @@ if ($_POST) {
 
 		unset($savemsg);
 
+		// issue #1777: reject an array-valued field ('asn_token[]=x') before any
+		// string sink below Array-to-string-converts on it -- same guard as
+		// pfblockerng_category_edit.php (issue #1106); every field here is
+		// scalar in normal use, no field is exempt.
+		foreach ($_POST as $pfb_post_key => $pfb_post_value) {
+			if (!is_scalar($pfb_post_value)) {
+				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars((string) $pfb_post_key);
+				$_POST[$pfb_post_key] = '';
+			}
+		}
+
 		// issue #1723: sanitize at ingestion -- first step, before any evaluation.
 		foreach (array('ip_placeholder', 'asn_token', 'autorule_suffix', 'maxmind_account', 'maxmind_key') as $pfb_text_field) {
 			$_POST[$pfb_text_field] = pfb_sanitize_text((string) ($_POST[$pfb_text_field] ?? ''));

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -112,17 +112,19 @@ if ($_POST) {
 		// string sink below Array-to-string-converts on it -- same idea as
 		// pfblockerng_category_edit.php (issue #1106), but NOT the same guard
 		// shape: unlike category_edit, this page has genuine multi-select fields
-		// (inbound_interface, outbound_interface, pfb_agg_types -- pfSense's
-		// Form_Select(..., TRUE) appends '[]' to the POST name for those, so a
-		// real browser legitimately posts them as arrays). A guard over every
-		// $_POST key would reject and blank all three on every save. So this
-		// guard is scoped to exactly the fields the #1723 sanitize loops below
-		// cast to (string) -- those are always scalar in normal use.
-		foreach (array('ip_placeholder', 'asn_token', 'autorule_suffix', 'maxmind_account', 'maxmind_key',
-				'v4suppression', 'v6suppression') as $pfb_text_field) {
-			if (isset($_POST[$pfb_text_field]) && !is_scalar($_POST[$pfb_text_field])) {
-				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars($pfb_text_field);
-				$_POST[$pfb_text_field] = '';
+		// -- pfSense's Form_Select(..., TRUE) appends '[]' to the POST name, so a
+		// real browser legitimately posts those as arrays and a guard over every
+		// $_POST key would reject and blank them on every save. Excluding the
+		// multi-selects (a small, stable set this page owns) rather than listing
+		// the scalar fields keeps every present and future scalar field covered:
+		// beyond the #1723 sanitize loops below, pfb_alias_delta_mode reaches
+		// array_key_exists(), which is a fatal TypeError on an array, and
+		// pfb_alias_delta_batch reaches a (string) cast.
+		$pfb_multiselect_fields = array('inbound_interface', 'outbound_interface', 'pfb_agg_types');
+		foreach (array_keys($_POST) as $pfb_post_field) {
+			if (!is_scalar($_POST[$pfb_post_field]) && !in_array($pfb_post_field, $pfb_multiselect_fields, TRUE)) {
+				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars($pfb_post_field);
+				$_POST[$pfb_post_field] = '';
 			}
 		}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -109,13 +109,20 @@ if ($_POST) {
 		unset($savemsg);
 
 		// issue #1777: reject an array-valued field ('asn_token[]=x') before any
-		// string sink below Array-to-string-converts on it -- same guard as
-		// pfblockerng_category_edit.php (issue #1106); every field here is
-		// scalar in normal use, no field is exempt.
-		foreach ($_POST as $pfb_post_key => $pfb_post_value) {
-			if (!is_scalar($pfb_post_value)) {
-				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars((string) $pfb_post_key);
-				$_POST[$pfb_post_key] = '';
+		// string sink below Array-to-string-converts on it -- same idea as
+		// pfblockerng_category_edit.php (issue #1106), but NOT the same guard
+		// shape: unlike category_edit, this page has genuine multi-select fields
+		// (inbound_interface, outbound_interface, pfb_agg_types -- pfSense's
+		// Form_Select(..., TRUE) appends '[]' to the POST name for those, so a
+		// real browser legitimately posts them as arrays). A guard over every
+		// $_POST key would reject and blank all three on every save. So this
+		// guard is scoped to exactly the fields the #1723 sanitize loops below
+		// cast to (string) -- those are always scalar in normal use.
+		foreach (array('ip_placeholder', 'asn_token', 'autorule_suffix', 'maxmind_account', 'maxmind_key',
+				'v4suppression', 'v6suppression') as $pfb_text_field) {
+			if (isset($_POST[$pfb_text_field]) && !is_scalar($_POST[$pfb_text_field])) {
+				$input_errors[] = gettext('Invalid value submitted for field:') . ' ' . htmlspecialchars($pfb_text_field);
+				$_POST[$pfb_text_field] = '';
 			}
 		}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -61,15 +61,15 @@ $pconfig['maxmind_account']	= $pfb['iconfig']['maxmind_account']			?: '';
 // A GET renders blank; a validation-error redisplay preserves the just-typed $_POST value
 // (like every other field), never PfbConfig/iconfig.
 $pconfig['maxmind_key']		= $_POST['maxmind_key'] ?? '';
-$pconfig['inbound_interface']	= explode(',', $pfb['iconfig']['inbound_interface'])	?: array();
+$pconfig['inbound_interface']	= explode(',', $pfb['iconfig']['inbound_interface'] ?? '')	?: array();
 $pconfig['inbound_deny_action']	= $pfb['iconfig']['inbound_deny_action']		?: 'block';
-$pconfig['outbound_interface']	= explode(',', $pfb['iconfig']['outbound_interface'])	?: array();
+$pconfig['outbound_interface']	= explode(',', $pfb['iconfig']['outbound_interface'] ?? '')	?: array();
 $pconfig['outbound_deny_action']= $pfb['iconfig']['outbound_deny_action']		?: 'reject';
 $pconfig['enable_float']	= $pfb['iconfig']['enable_float']			?: '';
 $pconfig['pass_order']		= $pfb['iconfig']['pass_order']				?: 'order_0';
 $pconfig['autorule_suffix']	= $pfb['iconfig']['autorule_suffix']			?: 'autorule';
 $pconfig['killstates']		= $pfb['iconfig']['killstates']				?: '';
-$pconfig['v4suppression']	= base64_decode($pfb['iconfig']['v4suppression'])	?: '';
+$pconfig['v4suppression']	= base64_decode($pfb['iconfig']['v4suppression'] ?? '')	?: '';
 // ADR-53 review finding B: '?? ""' on the array read -- v6suppression (unlike
 // v4suppression) is NEVER install-migrated, so it is absent from config.xml
 // on every install until this page's first post-upgrade save.

--- a/src/usr/local/www/pfblockerng/www/index.php
+++ b/src/usr/local/www/pfblockerng/www/index.php
@@ -34,7 +34,7 @@ if (strlen($_SERVER['REQUEST_TIME']) != 10 || !preg_match("/^[0-9]+$/", $_SERVER
 $ptype = array();
 $ptype['REQUEST_URI'] = htmlspecialchars(str_replace('|', '--', $_SERVER['REQUEST_URI']));
 foreach (array('HTTP_HOST', 'HTTP_REFERER', 'HTTP_USER_AGENT', 'REMOTE_ADDR') as $server_type) {
-	$ptype[$server_type] = htmlspecialchars($_SERVER[$server_type]) ?: 'Unknown';
+	$ptype[$server_type] = htmlspecialchars($_SERVER[$server_type] ?? '') ?: 'Unknown';
 }
 
 $ptype['type'] = $ptype['group'] = $ptype['evald'] = $ptype['feed'] = '-';

--- a/src/usr/local/www/pfblockerng/www/index.php
+++ b/src/usr/local/www/pfblockerng/www/index.php
@@ -34,7 +34,10 @@ if (strlen($_SERVER['REQUEST_TIME']) != 10 || !preg_match("/^[0-9]+$/", $_SERVER
 $ptype = array();
 $ptype['REQUEST_URI'] = htmlspecialchars(str_replace('|', '--', $_SERVER['REQUEST_URI']));
 foreach (array('HTTP_HOST', 'HTTP_REFERER', 'HTTP_USER_AGENT', 'REMOTE_ADDR') as $server_type) {
-	$ptype[$server_type] = htmlspecialchars($_SERVER[$server_type] ?? '') ?: 'Unknown';
+	// issue #1792: exact-'' compare, not ?: -- a literal `Host: 0` header is
+	// data, not an absence (this page is standalone under the sinkhole
+	// lighttpd; no pfblockerng.inc helpers here).
+	$ptype[$server_type] = ($server_value = htmlspecialchars($_SERVER[$server_type] ?? '')) === '' ? 'Unknown' : $server_value;
 }
 
 $ptype['type'] = $ptype['group'] = $ptype['evald'] = $ptype['feed'] = '-';

--- a/src/usr/local/www/widgets/include/widget-pfblockerng.inc
+++ b/src/usr/local/www/widgets/include/widget-pfblockerng.inc
@@ -23,6 +23,10 @@
 //set variables for custom title and link
 $pfblockerng_title = '<span title="Click to open Unified Log tab">pfBlockerNG</span>';
 $pfblockerng_title_link = 'pfblockerng/pfblockerng_alerts.php?view=unified';
+// issue #1777: pfSense dashboard widget-include convention (same family as
+// $widgetname/$pfblockerng_title above); the widget is a singleton (fixed POST
+// action URL, settings keyed off one installedpackages/pfblockerngglobal block).
+$pfblockerng_allow_multiple_widget_copies = FALSE;
 
 // issue #1050: the widget sets $nocsrf=TRUE (csrf-magic never runs here), so a
 // mutating POST handler gates on this instead. DEFAULT-DENY on an absent header

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -751,6 +751,14 @@ function pfBlockerNG_get_header($mode='') {
 				}
 				pfb_close_sqlite($db_handle);
 
+				// issue #1777: a fresh box has no $db_handle (SQLite DB not yet
+				// created) -- $resolver stays empty and every $resolver[0][...]
+				// read below hits an undefined array key. Seed the same shape the
+				// SELECT above produces (row 0, both counters absent/zero).
+				if (!isset($resolver[0])) {
+					$resolver[0] = array('totalqueries' => 0, 'queries' => 0);
+				}
+
 				if (!is_numeric($resolver[0]['totalqueries'])) {
 					$resolver[0]['totalqueries'] = 0;
 				}

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -756,9 +756,12 @@ function pfBlockerNG_get_header($mode='') {
 				// read below hits an undefined array key. Seed the same shape the
 				// SELECT above produces (row 0, both counters absent/zero).
 				// No off-appliance test: reaching here needs a real SQLite handle
-				// plus the enclosing stats walk, so the regression detector is the
-				// live functional-UI sweep plus the baseline entry this fix retires
-				// (a stale baseline line fails the render oracle by itself).
+				// plus the enclosing stats walk, so the named regression detector
+				// is the live functional-UI sweep (tests/smoke/ui) alone -- the
+				// baseline entry this fix retires is only REPORTED as stale by
+				// conftest.py's pytest_sessionfinish (tests/smoke/ui/conftest.py
+				// ~:501-506): a green sweep never proves a fix by itself, only a
+				// burn-down PR that deletes the entry and re-runs RED does.
 				if (!isset($resolver[0])) {
 					$resolver[0] = array('totalqueries' => 0, 'queries' => 0);
 				}

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -692,7 +692,7 @@ function pfBlockerNG_get_header($mode='') {
 				if (isset($pfb['dnsbl_missing'])) {
 					$stats[$key][$type] = "<span title='*** SQLite database 'pfb_py_dnsbl.sqlite' is missing, Force Reload DNSBL to recover! ***'>Unknown</span>";
 				} else {
-					$stats[$key][$type] = htmlspecialchars($pfb_table['stats']['DNSBL']);
+					$stats[$key][$type] = htmlspecialchars($pfb_table['stats']['DNSBL'] ?? '');
 				}
 			}
 

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -755,6 +755,10 @@ function pfBlockerNG_get_header($mode='') {
 				// created) -- $resolver stays empty and every $resolver[0][...]
 				// read below hits an undefined array key. Seed the same shape the
 				// SELECT above produces (row 0, both counters absent/zero).
+				// No off-appliance test: reaching here needs a real SQLite handle
+				// plus the enclosing stats walk, so the regression detector is the
+				// live functional-UI sweep plus the baseline entry this fix retires
+				// (a stale baseline line fails the render oracle by itself).
 				if (!isset($resolver[0])) {
 					$resolver[0] = array('totalqueries' => 0, 'queries' => 0);
 				}

--- a/tests/php/Adr62DnsblIsSkippableControlLineTest.php
+++ b/tests/php/Adr62DnsblIsSkippableControlLineTest.php
@@ -8,8 +8,9 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * pfb_dnsbl_is_skippable_control_line() -- ADR-62 P2 capture guard for the
- * (not-yet-wired) universal blank/comment/ABP-marker skip. Blank detection is an
- * exact '' match (caller trims first, mirroring pfb_is_blank_or_comment_line); a
+ * (not-yet-wired) universal blank/comment/ABP-marker skip. The helper strips the
+ * line itself (pfb_strip, Unicode class -- issue #1787; blank = exact '' match,
+ * mirroring pfb_is_blank_or_comment_line); a
  * bracketed IPv6 literal is never treated as an ABP section marker (ADR-62 Semantics
  * #3) -- it is an address, collected by pfb_dnsbl_collect_feed_ip() instead.
  */
@@ -51,21 +52,19 @@ final class Adr62DnsblIsSkippableControlLineTest extends TestCase
 		$this->assertFalse(pfb_dnsbl_is_skippable_control_line('[2001:db8::1]'));
 	}
 
-	public function testWhitespaceOnlyLineIsNotBlankPerThisHelpersContract(): void
+	public function testWhitespaceOnlyLineIsBlankPerThisHelpersContract(): void
 	{
-		// Probe (brief hostile row): the download loop trims $line (inc:~16389)
-		// BEFORE any capture-guard call, so a whitespace-only line never reaches a
-		// call site untrimmed in production. This helper follows the SAME contract
-		// as pfb_is_blank_or_comment_line -- the caller trims first; passed
-		// unTrimmed, three spaces is not the exact '' match, so it is NOT skippable.
-		$this->assertFalse(pfb_dnsbl_is_skippable_control_line('   '));
+		// Issue #1787 flipped the old caller-trims-first contract: the helper now
+		// strips the line itself (pfb_strip, Unicode class, mirroring
+		// pfb_is_blank_or_comment_line), so a whitespace-only line is blank and
+		// skippable even when a call site passes it untrimmed.
+		$this->assertTrue(pfb_dnsbl_is_skippable_control_line('   '));
 	}
 
-	public function testTabLedAbpAnchorIsNotSkippedUntrimmed(): void
+	public function testTabLedAbpAnchorIsNotSkipped(): void
 	{
-		// Probe (brief hostile row): a raw tab-led line, called directly (bypassing
-		// the loop's own trim at inc:~16389), does not start with '!'/'//'/'[' --
-		// consistent with the caller-trims-first contract, not a bug.
+		// A tab-led ABP anchor line self-strips to '||x^' -- an ABP rule, not a
+		// '!'/'//'/'[' control line, so it stays on the capture path.
 		$this->assertFalse(pfb_dnsbl_is_skippable_control_line("\t||x^"));
 	}
 

--- a/tests/php/AlertsDnsReplyWhitelistTypeTest.php
+++ b/tests/php/AlertsDnsReplyWhitelistTypeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: convert_dns_reply_log()'s call into dnsbl_whitelist_type()
+ * (:~2498) builds `$dns_fields` with only 2 of the 5 keys the callee reads
+ * (2 and 6) -- unlike its two convert_dnsbl_log() siblings (:2170/:2312),
+ * which pass the raw dnsbl.log $fields array carrying all of 2/5/6/7/8.
+ * dnsbl_whitelist_type() unconditionally reads $fields[5]/[7]/[8] at its top
+ * (pfb_hsc($fields[7]), pfb_hsc($fields[8]), then the != 'DNSBL_TLD' compare
+ * on $fields[5]) -- so every DNS-reply row rendered raises 3 "Undefined array
+ * key" diagnostics.
+ *
+ * Fix: supply keys 5/7/8 -- traced against the function's own read sites
+ * (dnsbl_whitelist_type() body, :1964-2111) rather than guessed:
+ *   - key 5 (DNSBL Mode, gates the != 'DNSBL_TLD' branch split) has no reply-
+ *     log analogue; '' preserves the CURRENT (pre-fix, implicit-NULL) branch
+ *     selection byte-for-byte, since NULL != 'DNSBL_TLD' is also true.
+ *   - key 7 (Evaluated Domain, folded into the exclusion-icon id and the
+ *     wildcard-whitelist walk) has no separate "evaluated" form for a reply
+ *     row -- reused as $fields[6] (the replied domain), the SAME value
+ *     already used for key 2 and the $qdomain argument, so all three referring
+ *     to "the domain this row is about" agree instead of drifting.
+ *   - key 8 (Feed Name) is read only inside the `$fields[6] != 'Unknown'`
+ *     branch (dnsbl_whitelist_type :2023), which the caller's own hardcoded
+ *     `'6' => 'Unknown'` provably never enters -- no reply-log analogue
+ *     exists and none is needed; '' is inert by construction, not a guess.
+ *
+ * Note: the $isExclusion branch (dnsbl_whitelist_type :1978, the OTHER
+ * reachable consumer of key 7) needs pfSense's array_get_path() to run --
+ * no test double exists for it and this fix's file scope does not extend to
+ * adding one to pfsense_doubles.php, so that branch is exercised live (the
+ * functional-UI sweep), not here; the diagnostic-elimination proof below
+ * covers the actual bug (undefined keys 5/7/8), independent of that branch.
+ *
+ * AlertsPageLoader.php (already used by AlertsRowOutputEncodingTest for the
+ * sibling convert_dnsbl_log() callers) defines both functions off-appliance
+ * from the REAL shipped source; the globals stood up in setUp() mirror
+ * convert_dns_reply_log()'s own `global` declaration (:2434).
+ */
+#[CoversFunction('convert_dns_reply_log')]
+#[CoversFunction('dnsbl_whitelist_type')]
+final class AlertsDnsReplyWhitelistTypeTest extends TestCase
+{
+	/** @var array<string, mixed> */
+	private array $savedGlobals = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		pfb_test_load_alerts_page_functions();
+	}
+
+	protected function setUp(): void
+	{
+		foreach ([
+			'pfb', 'local_hosts', 'filterfieldsarray', 'clists', 'counter',
+			'pfbentries', 'skipcount', 'dnsfilterlimit', 'dnsfilterlimitentries',
+		] as $g) {
+			$this->savedGlobals[$g] = $GLOBALS[$g] ?? null;
+		}
+
+		$GLOBALS['pfb'] = ['filterlogentries' => FALSE];
+		// Pre-seeded with the fixture's own SRC IP (below) so the UNRELATED,
+		// pre-existing local_hosts-miss warning never fires and pollutes the
+		// diagnostics list this test is scoped to.
+		$GLOBALS['local_hosts'] = ['10.0.0.9' => ''];
+		$GLOBALS['filterfieldsarray'] = [];
+		$GLOBALS['clists'] = [
+			'dnsbl'          => ['options' => []],
+			'dnsblwhitelist' => ['data' => []],
+			'tldexclusion'   => ['data' => []],
+		];
+		$GLOBALS['counter'] = ['DNS' => 0, 'Unified' => 0];
+		$GLOBALS['pfbentries'] = 1000;
+		$GLOBALS['skipcount'] = 0;
+		$GLOBALS['dnsfilterlimit'] = FALSE;
+		$GLOBALS['dnsfilterlimitentries'] = 100;
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedGlobals as $g => $v) {
+			if ($v === null) {
+				unset($GLOBALS[$g]);
+			} else {
+				$GLOBALS[$g] = $v;
+			}
+		}
+	}
+
+	/** DNS-reply $fields row per convert_dns_reply_log()'s own field-index comments (:2441-2449). */
+	private function replyFields(string $domain, string $srcIp): array
+	{
+		return [
+			0 => 'DNS-Reply',
+			1 => '2026-01-01 00:00:00',	// Timestamp
+			2 => 'Reply',			// DNS Reply Type
+			3 => 'A',			// DNS Reply Orig Type
+			4 => 'A',			// DNS Reply Final Type
+			5 => '300',			// DNS Reply TTL
+			6 => $domain,			// DNS Reply Domain
+			7 => $srcIp,			// DNS Reply SRC IP
+			8 => '198.51.100.9',		// DNS Reply DST IP
+			9 => 'US',			// DNS Reply GeoIP
+		];
+	}
+
+	private function runCapturing(callable $fn): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$fn();
+		} finally {
+			restore_error_handler();
+		}
+		return $diagnostics;
+	}
+
+	public function testConvertDnsReplyLogEmitsNoUndefinedArrayKeyDiagnostics(): void
+	{
+		$fields = $this->replyFields('reply.example.test', '10.0.0.9');
+
+		$diagnostics = $this->runCapturing(static function () use ($fields): void {
+			ob_start();
+			convert_dns_reply_log('Reports', $fields);
+			ob_get_clean();
+		});
+
+		$undefined = array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Undefined array key')
+		));
+		$this->assertSame(
+			[],
+			$undefined,
+			"convert_dns_reply_log() -> dnsbl_whitelist_type() must emit zero 'Undefined array key' diagnostics, got:\n"
+			. implode("\n", $undefined)
+		);
+	}
+}

--- a/tests/php/AlertsDnsReplyWhitelistTypeTest.php
+++ b/tests/php/AlertsDnsReplyWhitelistTypeTest.php
@@ -20,11 +20,19 @@ use PHPUnit\Framework\TestCase;
  *   - key 5 (DNSBL Mode, gates the != 'DNSBL_TLD' branch split) has no reply-
  *     log analogue; '' preserves the CURRENT (pre-fix, implicit-NULL) branch
  *     selection byte-for-byte, since NULL != 'DNSBL_TLD' is also true.
- *   - key 7 (Evaluated Domain, folded into the exclusion-icon id and the
- *     wildcard-whitelist walk) has no separate "evaluated" form for a reply
- *     row -- reused as $fields[6] (the replied domain), the SAME value
- *     already used for key 2 and the $qdomain argument, so all three referring
- *     to "the domain this row is about" agree instead of drifting.
+ *   - key 7 (Evaluated Domain): ''. A prior revision of this fix set key 7 to
+ *     $fields[6] (the replied domain), reasoning only about the
+ *     exclusion-icon id -- it missed that dnsbl_whitelist_type() ALSO feeds
+ *     key 7 into the dot-prefixed wildcard-whitelist walk
+ *     (dnsbl_whitelist_type() ~:2056, `ltrim($fields[7], '.')`). A real
+ *     domain there enters that walk and can flip $isWhitelist_found to TRUE
+ *     for any dot-prefixed whitelist entry that is an ancestor domain --
+ *     silently reclassifying an unrelated reply row as already-whitelisted
+ *     (issue #1777 review, BLOCKING; see
+ *     testConvertDnsReplyLogKeepsPreFixClassificationForDotPrefixedWhitelistEntry
+ *     below). '' is chosen because ltrim(NULL, '.') === ltrim('', '.') ===
+ *     '', so it reproduces the pre-fix NULL read exactly and never enters
+ *     the walk.
  *   - key 8 (Feed Name) is read only inside the `$fields[6] != 'Unknown'`
  *     branch (dnsbl_whitelist_type :2023), which the caller's own hardcoded
  *     `'6' => 'Unknown'` provably never enters -- no reply-log analogue
@@ -144,6 +152,54 @@ final class AlertsDnsReplyWhitelistTypeTest extends TestCase
 			$undefined,
 			"convert_dns_reply_log() -> dnsbl_whitelist_type() must emit zero 'Undefined array key' diagnostics, got:\n"
 			. implode("\n", $undefined)
+		);
+	}
+
+	/**
+	 * issue #1777 review (BLOCKING): a dot-prefixed DNSBL whitelist entry
+	 * ("[.]example.com") must NOT silently reclassify an unrelated DNS-reply
+	 * row for a descendant domain ("ads.example.com") as already-whitelisted.
+	 * Before this fix, $dns_fields['7'] was $fields[6] (the replied domain),
+	 * which entered dnsbl_whitelist_type()'s dot-prefixed wildcard-whitelist
+	 * walk (~:2054-2090) and matched "example.com" as an ancestor of
+	 * "ads.example.com", flipping $isWhitelist_found to TRUE and rendering
+	 * the "delete_domainwildcard" trash icon instead of the pre-fix
+	 * "add to DNSBL" icon (dnsbl_add).
+	 */
+	public function testConvertDnsReplyLogKeepsPreFixClassificationForDotPrefixedWhitelistEntry(): void
+	{
+		$GLOBALS['clists']['dnsblwhitelist']['data'] = ['.example.com' => 'entry'];
+
+		$fields = $this->replyFields('ads.example.com', '10.0.0.9');
+
+		$output = '';
+		$diagnostics = $this->runCapturing(function () use ($fields, &$output): void {
+			ob_start();
+			convert_dns_reply_log('Reports', $fields);
+			$output = ob_get_clean();
+		});
+
+		$undefined = array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Undefined array key')
+		));
+		$this->assertSame(
+			[],
+			$undefined,
+			"convert_dns_reply_log() -> dnsbl_whitelist_type() must emit zero 'Undefined array key' diagnostics, got:\n"
+			. implode("\n", $undefined)
+		);
+
+		$this->assertStringNotContainsString(
+			'delete_domainwildcard',
+			$output,
+			'a dot-prefixed DNSBL whitelist entry for "example.com" must not silently classify an unrelated '
+			. 'DNS-reply row for "ads.example.com" as already-whitelisted (isWhitelist_found must stay FALSE)'
+		);
+		$this->assertStringContainsString(
+			'dnsbl_add',
+			$output,
+			'the pre-fix classification renders the "Add Domain to DNSBL" icon, not the wildcard-whitelist delete icon'
 		);
 	}
 }

--- a/tests/php/AlertsFilterFieldsInitTest.php
+++ b/tests/php/AlertsFilterFieldsInitTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: pfblockerng_alerts.php's top-of-file $filterfieldsarray init
+ * block (:110-125) is 3 independent foreach loops seeding slots 0/1/2 with
+ * their own key set (blank placeholders later populated per-row). The slot-2
+ * loop is a copy-paste of the slot-1 loop with the assignment target never
+ * updated: it writes `$filterfieldsarray[1][$field_2]` instead of
+ * `$filterfieldsarray[2][$field_2]`. Two live consequences on a fresh box:
+ *
+ *   - $filterfieldsarray[2] never gets its 9 keys (81-89), so every
+ *     pfb_match_filter_field($pfbalertreply, $filterfieldsarray[2]) read in
+ *     convert_dns_reply_log() hits an undefined array key -- 9-10 of the
+ *     #1777 sweep's diagnostics.
+ *   - $filterfieldsarray[1] (the DNSBL slot) picks up 9 junk keys (81-89)
+ *     that don't belong to it and leak into the `?refresh=` JSON dump
+ *     (:~4907).
+ *
+ * The init block is pure array assignment with zero external dependencies
+ * (no $pfb/$_POST/DB), so -- unlike the page's request-scoped blocks -- it is
+ * eval-extracted and run standalone, guard-state-agnostic (matches whichever
+ * slot the RHS currently writes to, so this file is red pre-fix and green
+ * post-fix unchanged).
+ */
+final class AlertsFilterFieldsInitTest extends TestCase
+{
+	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_alerts_oracle_filterfieldsarray_init')) {
+			return;
+		}
+		$src = file_get_contents(self::ALERTS_PHP);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_alerts.php');
+		}
+		if (!preg_match(
+			'/\/\/ Initialize filterfieldsarray\n(.*?\$filterfieldsarray\[\d\]\[\$field_2\] = \'\';\n\})\n/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('test bootstrap: filterfieldsarray init block not found');
+		}
+		eval(
+			'function pfb_alerts_oracle_filterfieldsarray_init(): array {'
+			. $m[1]
+			. ' return $filterfieldsarray; }'
+		);
+	}
+
+	public function testSlotTwoIsSeededWithItsOwn81Through89KeySet(): void
+	{
+		$filterfieldsarray = pfb_alerts_oracle_filterfieldsarray_init();
+
+		$this->assertSame(
+			[81, 82, 83, 84, 85, 86, 87, 88, 89],
+			array_keys($filterfieldsarray[2]),
+			'$filterfieldsarray[2] must be seeded with its own 81-89 key set (the slot-2 loop must write to slot 2, not slot 1)'
+		);
+	}
+
+	public function testSlotOneKeepsExactlyItsOwnKeySetNoSlotTwoJunk(): void
+	{
+		$filterfieldsarray = pfb_alerts_oracle_filterfieldsarray_init();
+
+		$this->assertSame(
+			[2, 7, 8, 13, 15, 17, 19, 20, 99],
+			array_keys($filterfieldsarray[1]),
+			'$filterfieldsarray[1] must keep ONLY its own key set -- no 81-89 junk leaking in from the slot-2 loop'
+		);
+	}
+
+	public function testSlotZeroIsUnaffectedControl(): void
+	{
+		$filterfieldsarray = pfb_alerts_oracle_filterfieldsarray_init();
+
+		$this->assertSame(
+			[0, 2, 6, 7, 8, 9, 10, 12, 13, 15, 16, 17, 18, 99],
+			array_keys($filterfieldsarray[0]),
+			'$filterfieldsarray[0] is untouched by the bug -- control assertion'
+		);
+	}
+}

--- a/tests/php/AlertsFreshTopBlockTest.php
+++ b/tests/php/AlertsFreshTopBlockTest.php
@@ -48,7 +48,7 @@ final class AlertsFreshTopBlockTest extends TestCase
 
 		if (!function_exists('pfb_alerts_oracle_fresh_top')) {
 			if (!preg_match(
-				'/(\$aglobal_array\s*=\s*array\(.*?\n\$pfbdnsblreplystat\s*=\s*explode\([^\n]*\n)/s',
+				'/(\$aglobal_array\s*=\s*array\(.*?\n\$pfbdnsblreplystat\s*=\s*pfb_csv_list\([^\n]*\n)/s',
 				$src,
 				$m
 			)) {
@@ -125,9 +125,9 @@ final class AlertsFreshTopBlockTest extends TestCase
 			$nullDeprecations,
 			"fresh Alerts top-level block must emit zero 'Passing null' deprecations, got:\n" . implode("\n", $nullDeprecations)
 		);
-		// explode(',', '') yields a single empty-string element, not [] -- the
-		// caller-visible shape is unchanged by the guard (behaviour-preserving).
-		$this->assertSame([''], $vars['pfbreplytypes']);
+		// issue #1792: pfb_csv_list() answers an absent scalar with NO entries
+		// -- the phantom [''] the old explode(',', '') shape produced is gone.
+		$this->assertSame([], $vars['pfbreplytypes']);
 	}
 
 	public function testPopulatedAlertsTopBlockExplodeSitesPassThroughUnchanged(): void

--- a/tests/php/AlertsFreshTopBlockTest.php
+++ b/tests/php/AlertsFreshTopBlockTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fresh Alerts-page top-level block guard (issue #1768).
+ *
+ * A fresh install / first page load runs pfblockerng_alerts.php's top-level
+ * block (:35-80) -- $aglobal_array defaults, the PfbConfig::readSection()
+ * read that populates $pfb['aglobal'], and the explode() calls that derive
+ * $pfbreplytypes/$pfbreplyrec/$pfbblockstat/$pfbpermitstat/$pfbmatchstat/
+ * $pfbdnsblstat/$pfbdnsblreplystat from it -- against an EMPTY
+ * installedpackages/pfblockerngglobal section (the shape PfbConfig::readSection()
+ * returns when the section has never been saved, i.e. $GLOBALS['config'] has
+ * no such path). Each explode() reads its $pfb['aglobal'][...] operand
+ * directly; on an absent key that operand is NULL, and PHP 8.1+ deprecates
+ * passing NULL to explode()'s non-nullable string parameter -- these are the
+ * "Passing null" deprecations issue #1768 reports blocking the release
+ * functional-UI gate.
+ *
+ * Scope: the assertions below check only the "Passing null" deprecation
+ * class. The SAME block also has bare `$pfb['aglobal']['key'] != ''`/`?:`
+ * reads (e.g. $pfbpageload, $pfbmaxtable, the uni_defaults colour loop) that
+ * still emit "Undefined array key" warnings on an absent key -- those are
+ * the pre-existing, explicitly out-of-scope "3e bare-read class" (#1768
+ * brief); asserting the FULL diagnostics list empty would conflate the two
+ * and this test would never go green.
+ *
+ * AlertsPageLoader (tests/php/AlertsPageLoader.php) deliberately starts its
+ * eval at the first `function` keyword, EXCLUDING this top-level block -- so
+ * it is extracted directly here instead, anchored on the unique
+ * `$aglobal_array = array(` line through the last explode() assignment
+ * (`$pfbdnsblreplystat = explode(...)`), non-greedy so the regex matches
+ * whatever the RHS guard state is and survives the fix.
+ */
+final class AlertsFreshTopBlockTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
+		);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_alerts.php');
+		}
+
+		if (!function_exists('pfb_alerts_oracle_fresh_top')) {
+			if (!preg_match(
+				'/(\$aglobal_array\s*=\s*array\(.*?\n\$pfbdnsblreplystat\s*=\s*explode\([^\n]*\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: alerts fresh top-level block not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_fresh_top(): array {'
+				. ' global $pfb;'
+				. $m[1]
+				. ' return get_defined_vars(); }'
+			);
+		}
+	}
+
+	private $savedConfig;
+	private $savedPfb;
+
+	protected function setUp(): void
+	{
+		// Isolate from whatever a sibling test left in these globals.
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+		$this->savedPfb    = $GLOBALS['pfb'] ?? null;
+		unset($GLOBALS['config']);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->savedConfig === null) {
+			unset($GLOBALS['config']);
+		} else {
+			$GLOBALS['config'] = $this->savedConfig;
+		}
+		if ($this->savedPfb === null) {
+			unset($GLOBALS['pfb']);
+		} else {
+			$GLOBALS['pfb'] = $this->savedPfb;
+		}
+	}
+
+	/** @return array{0: array, 1: string[]} [$vars, $diagnostics] */
+	private function runCapturingDiagnostics(): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$vars = pfb_alerts_oracle_fresh_top();
+		} finally {
+			restore_error_handler();
+		}
+		return [$vars, $diagnostics];
+	}
+
+	/** @return string[] the diagnostics whose message is a "Passing null" deprecation */
+	private static function nullDeprecationsOnly(array $diagnostics): array
+	{
+		return array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Passing null')
+		));
+	}
+
+	public function testFreshAlertsTopBlockEmitsNoPassingNullDeprecations(): void
+	{
+		// No $GLOBALS['config'] -> PfbConfig::readSection() returns [] ->
+		// $pfb['aglobal'] = [] -- the fresh-install shape.
+		[$vars, $diagnostics] = $this->runCapturingDiagnostics();
+
+		$nullDeprecations = self::nullDeprecationsOnly($diagnostics);
+		$this->assertSame(
+			[],
+			$nullDeprecations,
+			"fresh Alerts top-level block must emit zero 'Passing null' deprecations, got:\n" . implode("\n", $nullDeprecations)
+		);
+		// explode(',', '') yields a single empty-string element, not [] -- the
+		// caller-visible shape is unchanged by the guard (behaviour-preserving).
+		$this->assertSame([''], $vars['pfbreplytypes']);
+	}
+
+	public function testPopulatedAlertsTopBlockExplodeSitesPassThroughUnchanged(): void
+	{
+		// Axis 2 (populated key): the guard must be a no-op when the field IS
+		// present -- proves the fix didn't clobber real explode() output.
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerngglobal' => [
+					'pfbreplytypes'      => 'A,AAAA',
+					'pfbreplyrec'        => '1,2',
+					'pfbblockstat'       => 'x,y',
+					'pfbpermitstat'      => 'p,q',
+					'pfbmatchstat'       => 'm,n',
+					'pfbdnsblstat'       => 'd1,d2',
+					'pfbdnsblreplystat'  => 'r1,r2',
+				],
+			],
+		];
+
+		[$vars, $diagnostics] = $this->runCapturingDiagnostics();
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertSame(['A', 'AAAA'], $vars['pfbreplytypes']);
+		$this->assertSame(['1', '2'], $vars['pfbreplyrec']);
+		$this->assertSame(['x', 'y'], $vars['pfbblockstat']);
+		$this->assertSame(['p', 'q'], $vars['pfbpermitstat']);
+		$this->assertSame(['m', 'n'], $vars['pfbmatchstat']);
+		$this->assertSame(['d1', 'd2'], $vars['pfbdnsblstat']);
+		$this->assertSame(['r1', 'r2'], $vars['pfbdnsblreplystat']);
+	}
+}

--- a/tests/php/AlertsPieBlockAndStatsGuardTest.php
+++ b/tests/php/AlertsPieBlockAndStatsGuardTest.php
@@ -63,7 +63,7 @@ final class AlertsPieBlockAndStatsGuardTest extends TestCase
 
 		if (!function_exists('pfb_alerts_oracle_stat_bucket_key')) {
 			if (!preg_match(
-				'/\$data = array_map\(\'trim\', explode\(\' \', trim\(\$line\), 2\)\);\n\t*'
+				'/\$data = array_map\(\'trim\', explode\(\' \', trim\(\$line\), 2\)\);\n(?:\t*\/\/[^\n]*\n)*\t*'
 				. '(\$alert_stats\[\$alert_view\]\[\$stat_type\]\[[^\n]*\n)/',
 				$src,
 				$m2
@@ -165,6 +165,7 @@ final class AlertsPieBlockAndStatsGuardTest extends TestCase
 		$this->assertSame([], self::undefinedKeyDiagnostics($diagnostics));
 		[$bucketKey, $bucketCount] = $result;
 		$this->assertSame('example.com', $bucketKey, 'a well-formed line must still bucket by its own key (behaviour-preserving)');
-		$this->assertSame('12', $bucketCount);
+		// issue #1792: the bucket count is a genuine int now ((int) cast at the site).
+		$this->assertSame(12, $bucketCount);
 	}
 }

--- a/tests/php/AlertsPieBlockAndStatsGuardTest.php
+++ b/tests/php/AlertsPieBlockAndStatsGuardTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: two narrow diagnostic-only guards in pfblockerng_alerts.php,
+ * each eval-extracted VERBATIM (pure array-index logic, no page state) and
+ * run standalone -- guard-state-agnostic, so this file is red pre-fix and
+ * green post-fix unchanged.
+ *
+ * (a) pie_block() (:4917-5052, mixed HTML/PHP template) segments the pie
+ *     chart over `for ($i = 0; $i < ($numsegments-1); $i++) { if ($k[$i]) ...`
+ *     -- $numsegments-1 can exceed count($k) (fewer real entries than pie
+ *     segments), so $k[$i] undefined-key warns on every trailing iteration.
+ *     The read is already effectively optional (falsy skips the segment) --
+ *     `?? NULL` silences the warning without changing which iterations build
+ *     a segment. The loop bound must NOT be shortened: $i survives the loop
+ *     and is read again (`$segcolors[$i % $numsegments]`) to colour the
+ *     trailing "Other" segment -- bounding the loop to count($k) would shift
+ *     $i and silently change that colour.
+ *
+ * (b) The alert-summary day/hour stat loop (:1774-1785) splits a shell stat
+ *     line on the first space (`explode(' ', trim($line), 2)`); a line with
+ *     no space at all (a stray/short summary row) yields a single-element
+ *     $data, so $data[1] is undefined -- `?? ''` keeps the existing `?:
+ *     $unknown_msg` fallback semantics (both '' and NULL are falsy) while
+ *     dropping the warning.
+ */
+final class AlertsPieBlockAndStatsGuardTest extends TestCase
+{
+	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(self::ALERTS_PHP);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_alerts.php');
+		}
+
+		if (!function_exists('pfb_alerts_oracle_pie_segment_loop')) {
+			// Anchored on the for-loop header through the "Other" segment block's
+			// closing brace -- captures BOTH the guarded $k[$i] read and the
+			// post-loop $i re-use verbatim, in one extraction.
+			if (!preg_match(
+				'/(for \(\$i = 0; \$i < \(\$numsegments-1\); \$i\+\+\) \{\n.*?\n\t\}\n\n'
+				. '\t\$balance = \$sumlines - \$numentries;\n'
+				. '\tif \(\$balance > 0\) \{\n.*?\n\t\})\n\?>/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: pie_block segment loop not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_pie_segment_loop(array $summary, int $numsegments, array $segcolors, int $sumlines): array {'
+				. ' $k = array_keys($summary); $numentries = 0; ob_start();'
+				. $m[1]
+				. ' $out = (string) ob_get_clean();'
+				. ' return [$out, $numentries, $i]; }'
+			);
+		}
+
+		if (!function_exists('pfb_alerts_oracle_stat_bucket_key')) {
+			if (!preg_match(
+				'/\$data = array_map\(\'trim\', explode\(\' \', trim\(\$line\), 2\)\);\n\t*'
+				. '(\$alert_stats\[\$alert_view\]\[\$stat_type\]\[[^\n]*\n)/',
+				$src,
+				$m2
+			)) {
+				throw new RuntimeException('test bootstrap: stat-bucket line not found');
+			}
+			eval(
+				'function pfb_alerts_oracle_stat_bucket_key(string $line, string $unknown_msg): array {'
+				. ' $alert_view = \'v\'; $stat_type = \'t\'; $alert_stats = [];'
+				. ' $data = array_map(\'trim\', explode(\' \', trim($line), 2));'
+				. $m2[1]
+				. ' return [array_key_first($alert_stats[\'v\'][\'t\']), reset($alert_stats[\'v\'][\'t\'])]; }'
+			);
+		}
+	}
+
+	private function runCapturing(callable $fn): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$result = $fn();
+		} finally {
+			restore_error_handler();
+		}
+		return [$result, $diagnostics];
+	}
+
+	/** @return string[] */
+	private static function undefinedKeyDiagnostics(array $diagnostics): array
+	{
+		return array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Undefined array key')));
+	}
+
+	// -----------------------------------------------------------------------
+	// (a) pie_block() segment loop.
+	// -----------------------------------------------------------------------
+
+	public function testPieSegmentLoopEmitsNoUndefinedArrayKeyWhenFewerEntriesThanSegments(): void
+	{
+		// 2 real entries, 5 pie segments -> the loop runs $i=0..3, and $k[2]/$k[3]
+		// are undefined (only $k[0]/$k[1] exist).
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_alerts_oracle_pie_segment_loop(
+			['a.example' => 10, 'b.example' => 5],
+			5,
+			['#111', '#222', '#333', '#444', '#555'],
+			15
+		));
+
+		$undefined = self::undefinedKeyDiagnostics($diagnostics);
+		$this->assertSame([], $undefined, "pie_block()'s segment loop must emit zero 'Undefined array key' diagnostics, got:\n" . implode("\n", $undefined));
+
+		[$out, $numentries, ] = $result;
+		$this->assertSame(2, $numentries, 'only the 2 real entries must build a segment (behaviour-preserving)');
+		$this->assertStringContainsString('a.example', $out);
+		$this->assertStringContainsString('b.example', $out);
+	}
+
+	public function testPieSegmentLoopPostLoopIndexIsUnchangedByTheGuard(): void
+	{
+		// Pins the "Other" segment colour derivation: $i must equal the loop's
+		// natural post-condition value ($numsegments-1), NOT be shortened by a
+		// count($k)-based bound -- the exact regression this fix must avoid.
+		$numsegments = 5;
+		[$result, ] = $this->runCapturing(static fn () => pfb_alerts_oracle_pie_segment_loop(
+			['a.example' => 10, 'b.example' => 5],
+			$numsegments,
+			['#111', '#222', '#333', '#444', '#555'],
+			15
+		));
+
+		[$out, , $finalI] = $result;
+		$this->assertSame($numsegments - 1, $finalI, '$i must survive the loop unshortened -- bounding to count($k) would change this');
+		// $segcolors[$i % $numsegments] with the unshortened $i=4 -> index 4 -> '#555'.
+		$this->assertStringContainsString('"color": "#555"', $out, 'the "Other" segment colour must use the UNSHORTENED post-loop $i');
+	}
+
+	// -----------------------------------------------------------------------
+	// (b) alert-summary stat bucket key.
+	// -----------------------------------------------------------------------
+
+	public function testStatBucketKeyEmitsNoUndefinedArrayKeyOnASpacelessLine(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_alerts_oracle_stat_bucket_key('14', 'Unknown'));
+
+		$undefined = self::undefinedKeyDiagnostics($diagnostics);
+		$this->assertSame([], $undefined, "the stat-bucket key build must emit zero 'Undefined array key' diagnostics on a spaceless line, got:\n" . implode("\n", $undefined));
+		[$bucketKey, ] = $result;
+		$this->assertSame('Unknown', $bucketKey, 'a spaceless line must still fall back to $unknown_msg (behaviour-preserving)');
+	}
+
+	public function testStatBucketKeyPassesThroughAWellFormedLineUnchanged(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_alerts_oracle_stat_bucket_key('  12 example.com', 'Unknown'));
+
+		$this->assertSame([], self::undefinedKeyDiagnostics($diagnostics));
+		[$bucketKey, $bucketCount] = $result;
+		$this->assertSame('example.com', $bucketKey, 'a well-formed line must still bucket by its own key (behaviour-preserving)');
+		$this->assertSame('12', $bucketCount);
+	}
+}

--- a/tests/php/BlacklistLangFallbackTest.php
+++ b/tests/php/BlacklistLangFallbackTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: pfblockerng_blacklist.php's per-category language render
+ * (:485/:516) reads $info[$pconfig['blacklist_lang']][1]/[0] directly. Most
+ * *_global_usage providers carry a DESC line (index [0]) only for a subset of
+ * languages (e.g. DE/IT/NL/ES/RU are frequently NAME-only, no DESC, for a
+ * given category) -- an absent index raises an "Undefined array key"
+ * diagnostic on every affected category/language combination, and the
+ * pre-existing `?:` fallback to EN silently degrades to warn-then-fall-back
+ * instead of a clean read.
+ *
+ * Both target expressions -- and the real parse loop that BUILDS $info
+ * (:456-481) -- are eval-extracted VERBATIM from the real shipped page
+ * source and exercised against the REAL shipped src/usr/local/pkg/
+ * pfblockerng/ut1_global_usage provider file (dependency-free: no Form_*
+ * pfSense UI classes are needed, since only the two bare expressions are
+ * extracted, not the Form_Group/Form_Checkbox rendering around them).
+ *
+ * The fix restructures the read into `$l = $info[lang] ?? array(); $e =
+ * $info['EN'] ?? array();` followed by `($l[i] ?? '') ?: ($e[i] ?? '')` --
+ * unlike the other #1777 sites, this is a SHAPE change (2 new lines), not an
+ * in-place `?? ''` insertion, so the extraction anchors on stable
+ * before/after markers with a free-form (non-greedy, DOTALL) middle instead
+ * of a single-line RHS pattern -- it captures 0 extra lines pre-fix and 2
+ * post-fix, so the same regex (and this file) is red before the fix and
+ * green after, unchanged.
+ */
+final class BlacklistLangFallbackTest extends TestCase
+{
+	private const BLACKLIST_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_blacklist.php';
+	private const UT1_FILE = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/ut1_global_usage';
+
+	/** Matches pfblockerng_blacklist.php's own $options_blacklist_lang (:143-144). */
+	private const LANGS = ['EN', 'DE', 'FR', 'IT', 'NL', 'PT', 'ES', 'RU'];
+
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(self::BLACKLIST_PHP);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_blacklist.php');
+		}
+
+		if (!function_exists('pfb_blacklist_oracle_parse_data')) {
+			if (!preg_match(
+				'/(\/\/ Build array of Blacklist categories and descriptions by language\n.*?\n\tksort\(\$data, SORT_NATURAL\);\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: blacklist category/description parse block not found');
+			}
+			eval(
+				'function pfb_blacklist_oracle_parse_data(array $contents): array {'
+				. ' $type = \'x\'; $blacklist_types = [\'x\' => [\'CONTENTS\' => $contents]];'
+				. $m[1]
+				. ' return $data; }'
+			);
+		}
+
+		if (!function_exists('pfb_blacklist_oracle_lang_fallback')) {
+			if (!preg_match(
+				'/foreach \(\$data as \$category => \$info\) \{\n(.*?\$category_lang = [^\n]*;\n)/s',
+				$src,
+				$m1
+			)) {
+				throw new RuntimeException('test bootstrap: $category_lang block not found');
+			}
+			// The SECOND Form_StaticText() call (identified by its ->setWidth(7)
+			// suffix -- the first, using $category_lang, has none) wraps the
+			// NAME-index (:0) expression as its bare 2nd constructor argument.
+			if (!preg_match(
+				'/Form_StaticText\(\s*\n\s*\'\',\s*\n\s*((?:(?!Form_StaticText).)*?)\n\s*\)\)->setWidth\(7\);/s',
+				$src,
+				$m2
+			)) {
+				throw new RuntimeException('test bootstrap: NAME-index Form_StaticText expression not found');
+			}
+			eval(
+				'function pfb_blacklist_oracle_lang_fallback(array $info, string $lang): array {'
+				. ' $pconfig = [\'blacklist_lang\' => $lang];'
+				. $m1[1]
+				. ' $name_lang = ' . $m2[1] . ';'
+				. ' return [$category_lang, $name_lang]; }'
+			);
+		}
+	}
+
+	/**
+	 * Replicates the provider-discovery loop's CONTENTS filtering (:52-101,
+	 * unaffected by this fix): drop comments/blanks and the metadata (TITLE/
+	 * DESCR/XML/FEED/SIZE/WEBSITE/LICENSE/REG) header lines, keeping the
+	 * NAME:/DESC LANG:/NAME LANG: category lines the parse loop under test reads.
+	 */
+	private static function loadRealProviderContents(): array
+	{
+		$raw = file(self::UT1_FILE, FILE_SKIP_EMPTY_LINES | FILE_IGNORE_NEW_LINES);
+		if ($raw === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read ut1_global_usage');
+		}
+		$contents = [];
+		foreach ($raw as $line) {
+			$trimmed = trim($line);
+			if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+				continue;
+			}
+			if (preg_match('/^(TITLE|DESCR|XML|FEED|SIZE|WEBSITE|LICENSE|REG):/', $trimmed)) {
+				continue;
+			}
+			$contents[] = $line;
+		}
+		return $contents;
+	}
+
+	public function testEveryCategoryAndLanguageEmitsZeroDiagnosticsAndEnFallbackHolds(): void
+	{
+		$data = pfb_blacklist_oracle_parse_data(self::loadRealProviderContents());
+		$this->assertNotEmpty($data, 'fixture sanity: the real ut1_global_usage must parse into at least one category');
+
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+
+		$missing0Proven = FALSE;
+		$missing1Proven = FALSE;
+		try {
+			foreach ($data as $category => $info) {
+				// fixture sanity: EN must be fully populated for every real category
+				// (the fallback target must itself never be the thing that's missing).
+				$this->assertArrayHasKey('EN', $info, "category '{$category}' has no EN entry at all");
+				$this->assertArrayHasKey(0, $info['EN'], "category '{$category}' EN has no DESC (index 0)");
+				$this->assertArrayHasKey(1, $info['EN'], "category '{$category}' EN has no NAME (index 1)");
+
+				foreach (self::LANGS as $lang) {
+					[$categoryLang, $nameLang] = pfb_blacklist_oracle_lang_fallback($info, $lang);
+
+					if (!isset($info[$lang][1])) {
+						$missing1Proven = TRUE;
+						$this->assertSame($info['EN'][1], $categoryLang, "category '{$category}'/{$lang}: missing index 1 must fall back to EN's NAME");
+					}
+					if (!isset($info[$lang][0])) {
+						$missing0Proven = TRUE;
+						$this->assertSame($info['EN'][0], $nameLang, "category '{$category}'/{$lang}: missing index 0 must fall back to EN's DESC");
+					}
+				}
+			}
+		} finally {
+			restore_error_handler();
+		}
+
+		// fixture sanity: the real provider file must actually exercise BOTH
+		// missing-index branches at least once, or the fallback assertions above
+		// never ran for real.
+		$this->assertTrue($missing0Proven, 'fixture sanity: no category/language combo in ut1_global_usage is missing index 0 -- the EN-DESC-fallback branch was never exercised');
+		$this->assertTrue($missing1Proven, 'fixture sanity: no category/language combo in ut1_global_usage is missing index 1 -- the EN-NAME-fallback branch was never exercised');
+
+		$undefined = array_values(array_filter(
+			$diagnostics,
+			static fn (string $d): bool => str_contains($d, 'Undefined array key')
+		));
+		$this->assertSame(
+			[],
+			$undefined,
+			"every category/language combination in the real ut1_global_usage must emit zero 'Undefined array key' diagnostics, got "
+			. count($undefined) . ' (first: ' . ($undefined[0] ?? '') . ')'
+		);
+	}
+}

--- a/tests/php/BlankOrCommentLineTest.php
+++ b/tests/php/BlankOrCommentLineTest.php
@@ -34,13 +34,13 @@ final class BlankOrCommentLineTest extends TestCase
 		$this->assertTrue(pfb_is_blank_or_comment_line(''));
 	}
 
-	public function testUntrimmedWhitespaceOnlyStringIsNotBlank(): void
+	public function testUntrimmedWhitespaceOnlyStringIsBlank(): void
 	{
-		// empty('   ') is FALSE in PHP -- this predicate relies on the caller having
-		// already trim()'d $line (its one call site does), matching every other
-		// empty($line) check in this file rather than reimplementing trim-and-check.
-		// Pins the contract explicitly instead of leaving it an unstated assumption.
-		$this->assertFalse(pfb_is_blank_or_comment_line('   '));
+		// Issue #1787 flipped the old caller-trims-first contract: the helper now
+		// strips the line itself (pfb_strip, Unicode class), so a whitespace-only
+		// line is blank whether or not the caller trimmed. Pins the contract
+		// explicitly instead of leaving it an unstated assumption.
+		$this->assertTrue(pfb_is_blank_or_comment_line('   '));
 	}
 
 	public function testHashCommentIsSkipped(): void

--- a/tests/php/DnsblFreshPconfigTest.php
+++ b/tests/php/DnsblFreshPconfigTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Fresh DNSBL-page $pconfig assembly guard (issue #1768).
+ *
+ * A fresh install / first page load runs pfblockerng_dnsbl.php's $pconfig
+ * assembly (:49-132) against an EMPTY installedpackages/pfblockerngdnsblsettings
+ * section ($pfb['dconfig'] = [] -- the shape PfbConfig::readSection() returns
+ * when the section has never been saved). Every explode()/base64_decode()
+ * call in that block reads its $pfb['dconfig'][...] operand directly; on an
+ * absent key that operand is NULL, and PHP 8.1+ deprecates passing NULL to
+ * explode()'s/base64_decode()'s non-nullable string parameter -- these are
+ * the "Passing null" deprecations issue #1768 reports blocking the release
+ * functional-UI gate.
+ *
+ * Scope: the assertions below check only the "Passing null" deprecation
+ * class. The SAME block also has ~20 untouched bare
+ * `$pfb['dconfig']['key'] ?: default` reads that still emit "Undefined array
+ * key" warnings on an absent key -- those are the pre-existing, explicitly
+ * out-of-scope "3e bare-read class" (#1768 brief); asserting the FULL
+ * diagnostics list empty would conflate the two and this test would never
+ * go green.
+ *
+ * The page carries top-level execution and cannot be require()d
+ * off-appliance, so the $pconfig block is eval-extracted verbatim from the
+ * REAL source (CategoryEditFreshRowPconfigTest's pattern, issue #1211),
+ * anchored on the unique `$pconfig = array();` line through the trailing
+ * `tldblacklist` assignment -- non-greedy, so the regex matches whatever the
+ * RHS guard state is (pre-fix bare read or post-fix `?? ''`-guarded) and
+ * survives the fix -- and run as a pure function of ($dconfig, $default_tlds).
+ */
+final class DnsblFreshPconfigTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php'
+		);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_dnsbl.php');
+		}
+
+		if (!function_exists('pfb_dnsbl_oracle_fresh_pconfig')) {
+			if (!preg_match(
+				'/\$pconfig\s*= array\(\);\n'
+				. '(.*?\n\s*\$pconfig\[\'tldblacklist\'\][^\n]*\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: dnsbl fresh $pconfig block not found');
+			}
+			eval(
+				'function pfb_dnsbl_oracle_fresh_pconfig(array $dconfig, array $default_tlds): array {'
+				. ' global $pfb; $pfb[\'dconfig\'] = $dconfig;'
+				. ' $pconfig = array();'
+				. $m[1]
+				. ' return $pconfig; }'
+			);
+		}
+	}
+
+	/** @return array{0: array, 1: string[]} [$pconfig, $diagnostics] */
+	private function runCapturingDiagnostics(array $dconfig, array $default_tlds): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$pconfig = pfb_dnsbl_oracle_fresh_pconfig($dconfig, $default_tlds);
+		} finally {
+			restore_error_handler();
+		}
+		return [$pconfig, $diagnostics];
+	}
+
+	/** @return string[] the diagnostics whose message is a "Passing null" deprecation */
+	private static function nullDeprecationsOnly(array $diagnostics): array
+	{
+		return array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Passing null')
+		));
+	}
+
+	public function testFreshDnsblPconfigEmitsNoPassingNullDeprecations(): void
+	{
+		[$pconfig, $diagnostics] = $this->runCapturingDiagnostics(
+			[],
+			['arpa', 'example.com', 'com', 'net', 'org', 'edu', 'ca', 'co', 'io']
+		);
+
+		$nullDeprecations = self::nullDeprecationsOnly($diagnostics);
+		$this->assertSame(
+			[],
+			$nullDeprecations,
+			"fresh-config \$pconfig assembly must emit zero 'Passing null' deprecations, got:\n" . implode("\n", $nullDeprecations)
+		);
+		$this->assertIsArray($pconfig);
+	}
+
+	public function testPopulatedDnsblPconfigDecodeExplodeSitesPassThroughUnchanged(): void
+	{
+		// Axis 2 (populated key): the guard must be a no-op when the field IS
+		// present -- proves the fix didn't clobber real decode/explode output.
+		$dconfig = [
+			'dnsbl_allow_int'    => 'wan,lan',
+			'pfb_pytlds_gtld'    => 'com,net',
+			'pfb_pytlds_cctld'   => 'uk,de',
+			'pfb_pytlds_itld'    => 'xn--p1ai',
+			'pfb_pytlds_bgtld'   => 'app,dev',
+			'pfb_regex_list'     => base64_encode("foo\nbar"),
+			'pfb_noaaaa_list'    => base64_encode('example.com'),
+			'pfb_gp_bypass_list' => base64_encode('192.0.2.1'),
+			'suppression'        => base64_encode('192.0.2.0/24'),
+			'alexa_inclusion'    => 'com,net,org',
+			'tldexclusion'       => base64_encode('example.test'),
+			'tldblacklist'       => base64_encode('bad.example'),
+		];
+
+		[$pconfig, $diagnostics] = $this->runCapturingDiagnostics(
+			$dconfig,
+			['arpa', 'lan.local', 'com', 'net', 'org', 'edu', 'ca', 'co', 'io']
+		);
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertSame(['wan', 'lan'], $pconfig['dnsbl_allow_int']);
+		$this->assertSame(['com', 'net'], $pconfig['pfb_pytlds_gtld']);
+		$this->assertSame(['uk', 'de'], $pconfig['pfb_pytlds_cctld']);
+		$this->assertSame(['xn--p1ai'], $pconfig['pfb_pytlds_itld']);
+		$this->assertSame(['app', 'dev'], $pconfig['pfb_pytlds_bgtld']);
+		$this->assertSame("foo\nbar", $pconfig['pfb_regex_list']);
+		$this->assertSame('example.com', $pconfig['pfb_noaaaa_list']);
+		$this->assertSame('192.0.2.1', $pconfig['pfb_gp_bypass_list']);
+		$this->assertSame('192.0.2.0/24', $pconfig['suppression']);
+		$this->assertSame(['com', 'net', 'org'], $pconfig['alexa_inclusion']);
+		$this->assertSame('example.test', $pconfig['tldexclusion']);
+		$this->assertSame('bad.example', $pconfig['tldblacklist']);
+	}
+}

--- a/tests/php/FilterlogFieldGuardTest.php
+++ b/tests/php/FilterlogFieldGuardTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_daemon_filterlog()'s CSV field-count guard (issue #1768).
+ *
+ * pfb_daemon_filterlog() reads php://stdin in an unbounded daemon loop and
+ * is not directly callable from a unit test (see LogTimestampBaselineTest's
+ * docblock -- the same constraint applies here; no test in this suite calls
+ * it directly, confirmed by grep). A short/malformed filterlog line (fewer
+ * space-separated fields than the BSD/syslog $f_pos offset expects) left
+ * $f[$f_pos] undefined, and `explode(',', $f[$f_pos])` on that undefined
+ * offset passed NULL to explode() -- a PHP 8.1+ deprecation, and part of the
+ * #1768 "Passing null" gate failure.
+ *
+ * This test extracts the exact field-split snippet verbatim from the real
+ * source (same eval-extraction technique as DnsblFreshPconfigTest/
+ * AlertsFreshTopBlockTest), anchored on the unique `$log_type = 'BSD';` line
+ * through the `$d = explode(',', $f[$f_pos]...)` line -- non-greedy, so the
+ * regex matches whatever the RHS guard state is and survives the fix -- and
+ * runs it as a pure function of $line.
+ */
+final class FilterlogFieldGuardTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+
+		if (!function_exists('pfb_filterlog_oracle_field_guard')) {
+			if (!preg_match(
+				'/(\$log_type = \'BSD\';\n.*?\n\s*\$d = explode\(\',\', \$f\[\$f_pos\][^\n]*\n)/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: filterlog field-split snippet not found');
+			}
+			eval(
+				'function pfb_filterlog_oracle_field_guard(string $line): array {'
+				. $m[1]
+				. ' return [$f_pos, $f, $d]; }'
+			);
+		}
+	}
+
+	/** @return array{0: array, 1: string[]} [[$f_pos, $f, $d], $diagnostics] */
+	private function runCapturingDiagnostics(string $line): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		}, E_WARNING | E_DEPRECATED);
+		try {
+			$result = pfb_filterlog_oracle_field_guard($line);
+		} finally {
+			restore_error_handler();
+		}
+		return [$result, $diagnostics];
+	}
+
+	public function testShortBsdLineDoesNotPassNullToExplode(): void
+	{
+		// BSD format: $f_pos = 5. Only 3 space-separated fields -- $f[5] is
+		// undefined.
+		[[$f_pos, $f, $d], $diagnostics] = $this->runCapturingDiagnostics('a b c');
+
+		$this->assertSame(5, $f_pos);
+		$this->assertArrayNotHasKey(5, $f);
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"short BSD-format line must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		$this->assertSame([''], $d);
+	}
+
+	public function testShortSyslogLineDoesNotPassNullToExplode(): void
+	{
+		// A leading '<' selects syslog format: $f_pos = 7. Only 3
+		// space-separated fields -- $f[7] is undefined.
+		[[$f_pos, $f, $d], $diagnostics] = $this->runCapturingDiagnostics('<14>a b c');
+
+		$this->assertSame(7, $f_pos);
+		$this->assertArrayNotHasKey(7, $f);
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"short syslog-format line must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		$this->assertSame([''], $d);
+	}
+
+	public function testLongEnoughBsdLineFieldPassesThroughUnchanged(): void
+	{
+		// Axis 2: a line WITH a field at $f_pos must still reach $d unchanged
+		// (the guard is a no-op when the field is present).
+		$line = 'a b c d e tracker,extra';
+		[[$f_pos, $f, $d], $diagnostics] = $this->runCapturingDiagnostics($line);
+
+		$this->assertSame(5, $f_pos);
+		$this->assertSame('tracker,extra', $f[5]);
+		$this->assertSame([], $diagnostics);
+		$this->assertSame(['tracker', 'extra'], $d);
+	}
+}

--- a/tests/php/FreshConfigNullGuardCloseoutTest.php
+++ b/tests/php/FreshConfigNullGuardCloseoutTest.php
@@ -43,7 +43,7 @@ final class FreshConfigNullGuardCloseoutTest extends TestCase
 				throw new RuntimeException('test bootstrap: failed to read www/index.php');
 			}
 			if (!preg_match(
-				'/\$ptype\[\$server_type\] = htmlspecialchars\(\$_SERVER\[\$server_type\][^\n]*\n/',
+				'/\$ptype\[\$server_type\] = \(\$server_value = htmlspecialchars\(\$_SERVER\[\$server_type\][^\n]*\n/',
 				$src,
 				$m
 			)) {

--- a/tests/php/FreshConfigNullGuardCloseoutTest.php
+++ b/tests/php/FreshConfigNullGuardCloseoutTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Closes out issue #1768: a live functional-UI render sweep (run 30249107774)
+ * found 2 "Passing null" deprecation sites the original #1768 commit missed.
+ * Both are single-argument string calls reading a value that is absent on a
+ * fresh box/request, exactly the same deprecation class #1768 already closed
+ * ~85 other call sites for.
+ *
+ * - www/index.php:37 -- the per-request $ptype[$server_type] build reads
+ *   $_SERVER[$server_type] directly for HTTP_REFERER/HTTP_USER_AGENT, which a
+ *   client is not required to send; an absent key is NULL, passed straight
+ *   into htmlspecialchars().
+ * - pfblockerng.widget.php:695 -- the DNSBL row of the "Queries" stat block
+ *   reads $pfb_table['stats']['DNSBL'], which is populated ONLY inside the
+ *   `if (!empty($pfb_table))` loop over update-table entries; on a fresh box
+ *   (no aliases/lists synced yet) that loop never runs and the key stays
+ *   unset.
+ *
+ * Neither file is require()-able off-appliance (index.php is top-level page
+ * execution; the widget file's stat block lives inside pfBlockerNG_get_header(),
+ * a page-scoped function with prior SQLite/session setup this test does not
+ * want to stand up) -- so, following DnsblFreshPconfigTest/AlertsFreshTopBlockTest's
+ * established idiom, each narrow region is eval-extracted VERBATIM from the
+ * real shipped source and run as a pure function of its inputs. The
+ * extraction regexes are non-greedy / guard-state-agnostic, so this same test
+ * file is red against the pre-fix source and green after the fix, unchanged.
+ */
+final class FreshConfigNullGuardCloseoutTest extends TestCase
+{
+	private const INDEX_PHP  = __DIR__ . '/../../src/usr/local/www/pfblockerng/www/index.php';
+	private const WIDGET_PHP = __DIR__ . '/../../src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		if (!function_exists('pfb_index_oracle_ptype_server_field')) {
+			$src = file_get_contents(self::INDEX_PHP);
+			if ($src === FALSE) {
+				throw new RuntimeException('test bootstrap: failed to read www/index.php');
+			}
+			if (!preg_match(
+				'/\$ptype\[\$server_type\] = htmlspecialchars\(\$_SERVER\[\$server_type\][^\n]*\n/',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: index.php $ptype server-field line not found');
+			}
+			eval(
+				'function pfb_index_oracle_ptype_server_field(bool $setKey, string $value = \'\'): string {'
+				. ' $ptype = array(); $server_type = \'HTTP_REFERER\';'
+				. ' if ($setKey) { $_SERVER[$server_type] = $value; } else { unset($_SERVER[$server_type]); }'
+				. $m[0]
+				. ' return $ptype[$server_type]; }'
+			);
+		}
+
+		if (!function_exists('pfb_widget_oracle_dnsbl_stat')) {
+			$src = file_get_contents(self::WIDGET_PHP);
+			if ($src === FALSE) {
+				throw new RuntimeException('test bootstrap: failed to read pfblockerng.widget.php');
+			}
+			if (!preg_match(
+				'/(if \(\$type == \'DNSBL\'\) \{\n.*?\n\t\t\t\})\n/s',
+				$src,
+				$m
+			)) {
+				throw new RuntimeException('test bootstrap: widget DNSBL stat block not found');
+			}
+			eval(
+				'function pfb_widget_oracle_dnsbl_stat(array $pfb, array $pfb_table): string {'
+				. ' $stats = array(); $key = 0; $type = \'DNSBL\';'
+				. $m[1]
+				. ' return $stats[$key][$type]; }'
+			);
+		}
+	}
+
+	private bool $hadServerReferer;
+	private mixed $savedServerReferer;
+
+	protected function setUp(): void
+	{
+		$this->hadServerReferer   = array_key_exists('HTTP_REFERER', $_SERVER);
+		$this->savedServerReferer = $_SERVER['HTTP_REFERER'] ?? null;
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadServerReferer) {
+			$_SERVER['HTTP_REFERER'] = $this->savedServerReferer;
+		} else {
+			unset($_SERVER['HTTP_REFERER']);
+		}
+	}
+
+	/** @return string[] the diagnostics whose message is a "Passing null" deprecation */
+	private static function nullDeprecationsOnly(array $diagnostics): array
+	{
+		return array_values(array_filter(
+			$diagnostics,
+			static fn(string $d): bool => str_contains($d, 'Passing null')
+		));
+	}
+
+	private function runCapturing(callable $fn): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$result = $fn();
+		} finally {
+			restore_error_handler();
+		}
+		return [$result, $diagnostics];
+	}
+
+	// -----------------------------------------------------------------------
+	// www/index.php:37 -- $ptype[$server_type] server-header read.
+	// -----------------------------------------------------------------------
+
+	public function testIndexPtypeServerFieldEmitsNoPassingNullDeprecationWhenHeaderAbsent(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_index_oracle_ptype_server_field(FALSE)
+		);
+
+		$this->assertSame(
+			[],
+			self::nullDeprecationsOnly($diagnostics),
+			"index.php's \$ptype server-field build must emit zero 'Passing null' deprecations when the client sends no Referer header, got:\n"
+			. implode("\n", self::nullDeprecationsOnly($diagnostics))
+		);
+		$this->assertSame('Unknown', $result, 'an absent header must still fall back to "Unknown" (behaviour-preserving)');
+	}
+
+	public function testIndexPtypeServerFieldPassesThroughAPopulatedHeaderUnchanged(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_index_oracle_ptype_server_field(TRUE, 'https://example.com/<script>')
+		);
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertSame(
+			'https://example.com/&lt;script&gt;',
+			$result,
+			'a present header must still pass through htmlspecialchars() unchanged (behaviour-preserving)'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// pfblockerng.widget.php:695 -- Queries/DNSBL stat read.
+	// -----------------------------------------------------------------------
+
+	public function testWidgetDnsblStatEmitsNoPassingNullDeprecationOnAFreshBox(): void
+	{
+		// Fresh box: pfBlockerNG_update_table() returned nothing to accumulate,
+		// so the 'DNSBL' key of $pfb_table['stats'] was never populated.
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_widget_oracle_dnsbl_stat([], ['stats' => []])
+		);
+
+		$this->assertSame(
+			[],
+			self::nullDeprecationsOnly($diagnostics),
+			"the widget's DNSBL 'Queries' stat read must emit zero 'Passing null' deprecations on a fresh box, got:\n"
+			. implode("\n", self::nullDeprecationsOnly($diagnostics))
+		);
+		$this->assertSame('', $result, 'an absent DNSBL stat must render as an empty string, not the literal "0" or a warning');
+	}
+
+	public function testWidgetDnsblStatPassesThroughAPopulatedCountUnchanged(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_widget_oracle_dnsbl_stat([], ['stats' => ['DNSBL' => 1500]])
+		);
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertSame('1500', $result, 'a real populated count must still render unchanged (behaviour-preserving)');
+	}
+
+	public function testWidgetDnsblStatSqliteMissingBranchIsUnaffectedByTheGuard(): void
+	{
+		// The 'dnsbl_missing' branch never reaches the guarded read at all --
+		// confirms the fix did not disturb the sibling branch.
+		[$result, $diagnostics] = $this->runCapturing(
+			static fn (): string => pfb_widget_oracle_dnsbl_stat(['dnsbl_missing' => TRUE], ['stats' => []])
+		);
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertStringContainsString('Unknown', $result);
+	}
+}

--- a/tests/php/IpArrayFieldIngressGuardTest.php
+++ b/tests/php/IpArrayFieldIngressGuardTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * issue #1777: pfblockerng_ip.php's save handler runs `pfb_sanitize_text((string)
- * ($_POST[$field] ?? ''))` over a fixed field list (:112-114) with no upstream
+ * ($_POST[$field] ?? ''))` over a fixed field list (:123-125) with no upstream
  * guard against an array-valued field ('asn_token[]=x', the shape
  * tests/smoke/ui/test_post_array_scalar_guards.py:92 already covers for the
  * graceful-reject/no-500 contract via pfb_filter()'s own array rejection at
@@ -14,10 +14,16 @@ use PHPUnit\Framework\TestCase;
  * -- a diagnostic-only regression, not a crash (already covered elsewhere).
  *
  * Fix: copy pfblockerng_category_edit.php's issue #1106 ingress guard (:473-478)
- * IN SHAPE -- reject every non-scalar $_POST field with an input error and
- * blank it, BEFORE the sanitize loop -- so no downstream (string) cast ever
- * sees an array. The (string) cast itself must stay: it is load-bearing for
- * genuinely scalar fields (int/bool/null POST values).
+ * IN INTENT -- reject a non-scalar text field with an input error and blank
+ * it, BEFORE the sanitize loop -- so no downstream (string) cast ever sees an
+ * array. NOT in shape: category_edit has zero multi-selects, so its guard
+ * covers every $_POST key; this page has three (inbound_interface,
+ * outbound_interface, pfb_agg_types -- pfSense's Form_Select(..., TRUE) posts
+ * those as arrays for real, browser-driven saves), so a blanket guard rejects
+ * and blanks all three on every save (issue #1777 review, BLOCKING). The
+ * guard here is scoped to exactly the fields the #1723 sanitize loops below
+ * cast to (string). The (string) cast itself must stay: it is load-bearing
+ * for genuinely scalar fields (int/bool/null POST values).
  *
  * The ingress+sanitize loops are eval-extracted as a pure function of $_POST
  * (top-level page script, not require()-able off-appliance) -- matching
@@ -36,33 +42,23 @@ final class IpArrayFieldIngressGuardTest extends TestCase
 		if ($src === FALSE) {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_ip.php');
 		}
-		// Anchored on the issue #1723 sanitize-loop comment through its closing
-		// brace -- non-greedy, so it matches whether or not the #1777 ingress
-		// guard has been inserted immediately before it yet.
+		// Anchored on the issue #1777 guard comment's stable opening line through
+		// to the stable "// Validate Select field options" comment that follows
+		// the whole ingress+sanitize prologue -- captures the region as raw text
+		// regardless of the guard's internal shape (unscoped pre-fix, field-list
+		// scoped post-fix), so the SAME oracle extraction works whether this
+		// runs before or after the #1777 review's scoping fix lands.
 		if (!preg_match(
-			'/(\/\/ issue #1723: sanitize at ingestion -- first step, before any evaluation\.\n'
-			. '\t\tforeach \(array\(\'ip_placeholder\', \'asn_token\', \'autorule_suffix\', \'maxmind_account\', \'maxmind_key\'\) as \$pfb_text_field\) \{\n'
-			. '.*?\n\t\t\})\n/s',
+			'/(\t\t\/\/ issue #1777: reject an array-valued field \(\'asn_token\[\]=x\'\) before any\n.*?\n)'
+			. '\n\t\t\/\/ Validate Select field options\n/s',
 			$src,
 			$m
 		)) {
-			throw new RuntimeException('test bootstrap: ip.php sanitize prologue not found');
-		}
-		// The (optional, guard-state-dependent) ingress guard directly precedes
-		// the anchor above -- captured separately so the oracle covers it
-		// whether or not it exists yet (pre-fix: absent; post-fix: present).
-		$guard = '';
-		if (preg_match(
-			'/(foreach \(\$_POST as \$pfb_post_key => \$pfb_post_value\) \{\n\t\t\tif \(!is_scalar\(\$pfb_post_value\)\) \{\n.*?\n\t\t\t\}\n\t\t\}\n)\n\t\t\/\/ issue #1723/s',
-			$src,
-			$gm
-		)) {
-			$guard = $gm[1];
+			throw new RuntimeException('test bootstrap: ip.php ingress guard + sanitize prologue not found');
 		}
 		eval(
 			'function pfb_ip_oracle_sanitize_prologue(array $post): array {'
 			. ' $_POST = $post; $input_errors = array();'
-			. $guard
 			. $m[1]
 			. ' return [$_POST, $input_errors]; }'
 		);
@@ -126,5 +122,45 @@ final class IpArrayFieldIngressGuardTest extends TestCase
 		[$post, $inputErrors] = $result;
 		$this->assertSame([], $inputErrors, 'an empty POST has nothing non-scalar to reject');
 		$this->assertSame('', $post['asn_token'], 'an absent field must still default to \'\' (the pre-existing ?? \'\' behaviour)');
+	}
+
+	/**
+	 * issue #1777 review (BLOCKING): a realistic browser save POSTs
+	 * inbound_interface / outbound_interface / pfb_agg_types as ARRAYS
+	 * (Form_Select(..., TRUE) appends '[]' to the POST name). The guard must
+	 * leave all three alone -- untouched, still arrays, same members, no
+	 * input error -- while an array-valued asn_token (never a legitimate
+	 * multi-select on this page) must still be rejected and blanked exactly
+	 * as before.
+	 */
+	public function testMultiSelectArrayFieldsSurviveTheGuardWhileAsnTokenArrayIsStillRejected(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([
+			'ip_placeholder'     => '198.51.100.1',
+			'asn_token'          => ['crafted'],
+			'autorule_suffix'    => 'autorule',
+			'maxmind_account'    => 'acct',
+			'maxmind_key'        => 'key',
+			'inbound_interface'  => ['wan', 'lan'],
+			'outbound_interface' => ['wan'],
+			'pfb_agg_types'      => ['ipv4', 'ipv6'],
+		]));
+
+		$arrayToString = array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion')));
+		$this->assertSame([], $arrayToString, "the three multi-selects must never Array-to-string-convert, got:\n" . implode("\n", $arrayToString));
+
+		[$post, $inputErrors] = $result;
+
+		$this->assertSame(['wan', 'lan'], $post['inbound_interface'], 'inbound_interface must survive the guard as an unmodified array');
+		$this->assertSame(['wan'], $post['outbound_interface'], 'outbound_interface must survive the guard as an unmodified array');
+		$this->assertSame(['ipv4', 'ipv6'], $post['pfb_agg_types'], 'pfb_agg_types must survive the guard as an unmodified array');
+
+		$multiSelectErrors = array_values(array_filter($inputErrors, static fn (string $e): bool =>
+			str_contains($e, 'inbound_interface') || str_contains($e, 'outbound_interface') || str_contains($e, 'pfb_agg_types')));
+		$this->assertSame([], $multiSelectErrors, "no multi-select field may raise 'Invalid value submitted for field', got:\n" . implode("\n", $multiSelectErrors));
+
+		$this->assertSame('', $post['asn_token'], 'asn_token must still be blanked when array-valued');
+		$asnTokenErrors = array_values(array_filter($inputErrors, static fn (string $e): bool => str_contains($e, 'asn_token')));
+		$this->assertNotEmpty($asnTokenErrors, 'asn_token must still raise its own input error when array-valued');
 	}
 }

--- a/tests/php/IpArrayFieldIngressGuardTest.php
+++ b/tests/php/IpArrayFieldIngressGuardTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,13 +18,14 @@ use PHPUnit\Framework\TestCase;
  * IN INTENT -- reject a non-scalar text field with an input error and blank
  * it, BEFORE the sanitize loop -- so no downstream (string) cast ever sees an
  * array. NOT in shape: category_edit has zero multi-selects, so its guard
- * covers every $_POST key; this page has three (inbound_interface,
- * outbound_interface, pfb_agg_types -- pfSense's Form_Select(..., TRUE) posts
- * those as arrays for real, browser-driven saves), so a blanket guard rejects
- * and blanks all three on every save (issue #1777 review, BLOCKING). The
- * guard here is scoped to exactly the fields the #1723 sanitize loops below
- * cast to (string). The (string) cast itself must stay: it is load-bearing
- * for genuinely scalar fields (int/bool/null POST values).
+ * covers every $_POST key unconditionally; this page has three
+ * (inbound_interface, outbound_interface, pfb_agg_types -- pfSense's
+ * Form_Select(..., TRUE) posts those as arrays for real, browser-driven
+ * saves), so an unconditional guard rejects and blanks all three on every
+ * save (issue #1777 review, BLOCKING). The guard here excludes those three
+ * and covers every other field, so scalar sinks outside the #1723 loops stay
+ * protected too. The (string) cast itself must stay: it is load-bearing for
+ * genuinely scalar fields (int/bool/null POST values).
  *
  * The ingress+sanitize loops are eval-extracted as a pure function of $_POST
  * (top-level page script, not require()-able off-appliance) -- matching
@@ -45,9 +47,9 @@ final class IpArrayFieldIngressGuardTest extends TestCase
 		// Anchored on the issue #1777 guard comment's stable opening line through
 		// to the stable "// Validate Select field options" comment that follows
 		// the whole ingress+sanitize prologue -- captures the region as raw text
-		// regardless of the guard's internal shape (unscoped pre-fix, field-list
-		// scoped post-fix), so the SAME oracle extraction works whether this
-		// runs before or after the #1777 review's scoping fix lands.
+		// regardless of the guard's internal shape (unconditional, allow-listed
+		// or multi-select-excluding), so the SAME oracle extraction works
+		// whichever shape the guard currently carries.
 		if (!preg_match(
 			'/(\t\t\/\/ issue #1777: reject an array-valued field \(\'asn_token\[\]=x\'\) before any\n.*?\n)'
 			. '\n\t\t\/\/ Validate Select field options\n/s',
@@ -162,5 +164,49 @@ final class IpArrayFieldIngressGuardTest extends TestCase
 		$this->assertSame('', $post['asn_token'], 'asn_token must still be blanked when array-valued');
 		$asnTokenErrors = array_values(array_filter($inputErrors, static fn (string $e): bool => str_contains($e, 'asn_token')));
 		$this->assertNotEmpty($asnTokenErrors, 'asn_token must still raise its own input error when array-valued');
+	}
+
+	/**
+	 * The guard must cover every scalar field on the page, not just the ones the
+	 * #1723 sanitize loops name. Scoping it to an allow-list of text fields left
+	 * the ADR-40 pair unguarded, and both have a scalar-only sink further down
+	 * the same save handler: pfb_alias_delta_mode reaches array_key_exists()
+	 * (:277), whose first parameter is int|string -- an array is a fatal
+	 * TypeError -- and pfb_alias_delta_batch reaches a (string) cast (:284),
+	 * which Array-to-string-converts and then silently resolves to the clamp
+	 * floor instead of the intended default. Same class for any scalar field
+	 * added to this page later, which is why the guard excludes the three known
+	 * multi-selects rather than enumerating the fields it protects.
+	 *
+	 */
+	#[DataProvider('provideUnlistedScalarFields')]
+	public function testScalarFieldsOutsideTheSanitizeLoopsAreAlsoRejectedWhenArrayValued(string $field): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([
+			'ip_placeholder'    => '198.51.100.1',
+			'asn_token'         => 'mytoken',
+			'inbound_interface' => ['wan'],
+			$field              => ['crafted'],
+		]));
+
+		$this->assertSame([], array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion'))));
+
+		[$post, $inputErrors] = $result;
+		$this->assertSame('', $post[$field], "an array-valued {$field} must be blanked before it reaches its scalar-only sink");
+		$this->assertNotEmpty(
+			array_values(array_filter($inputErrors, static fn (string $e): bool => str_contains($e, $field))),
+			"an array-valued {$field} must raise its own input error"
+		);
+		$this->assertSame(['wan'], $post['inbound_interface'], 'a legitimate multi-select must still survive alongside the rejection');
+	}
+
+	/** @return array<string, array{string}> */
+	public static function provideUnlistedScalarFields(): array
+	{
+		return [
+			'ADR-40 apply mode (array_key_exists sink, fatal TypeError)' => ['pfb_alias_delta_mode'],
+			'ADR-40 batch size ((string) cast sink)'                     => ['pfb_alias_delta_batch'],
+			'single-select locale (never posted as an array by a browser)' => ['maxmind_locale'],
+		];
 	}
 }

--- a/tests/php/IpArrayFieldIngressGuardTest.php
+++ b/tests/php/IpArrayFieldIngressGuardTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: pfblockerng_ip.php's save handler runs `pfb_sanitize_text((string)
+ * ($_POST[$field] ?? ''))` over a fixed field list (:112-114) with no upstream
+ * guard against an array-valued field ('asn_token[]=x', the shape
+ * tests/smoke/ui/test_post_array_scalar_guards.py:92 already covers for the
+ * graceful-reject/no-500 contract via pfb_filter()'s own array rejection at
+ * :161). The `(string)` cast on an ARRAY raises "Array to string conversion"
+ * -- a diagnostic-only regression, not a crash (already covered elsewhere).
+ *
+ * Fix: copy pfblockerng_category_edit.php's issue #1106 ingress guard (:473-478)
+ * IN SHAPE -- reject every non-scalar $_POST field with an input error and
+ * blank it, BEFORE the sanitize loop -- so no downstream (string) cast ever
+ * sees an array. The (string) cast itself must stay: it is load-bearing for
+ * genuinely scalar fields (int/bool/null POST values).
+ *
+ * The ingress+sanitize loops are eval-extracted as a pure function of $_POST
+ * (top-level page script, not require()-able off-appliance) -- matching
+ * DnsblFreshPconfigTest's convention for this same page family.
+ */
+final class IpArrayFieldIngressGuardTest extends TestCase
+{
+	private const IP_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_ip.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_ip_oracle_sanitize_prologue')) {
+			return;
+		}
+		$src = file_get_contents(self::IP_PHP);
+		if ($src === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_ip.php');
+		}
+		// Anchored on the issue #1723 sanitize-loop comment through its closing
+		// brace -- non-greedy, so it matches whether or not the #1777 ingress
+		// guard has been inserted immediately before it yet.
+		if (!preg_match(
+			'/(\/\/ issue #1723: sanitize at ingestion -- first step, before any evaluation\.\n'
+			. '\t\tforeach \(array\(\'ip_placeholder\', \'asn_token\', \'autorule_suffix\', \'maxmind_account\', \'maxmind_key\'\) as \$pfb_text_field\) \{\n'
+			. '.*?\n\t\t\})\n/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('test bootstrap: ip.php sanitize prologue not found');
+		}
+		// The (optional, guard-state-dependent) ingress guard directly precedes
+		// the anchor above -- captured separately so the oracle covers it
+		// whether or not it exists yet (pre-fix: absent; post-fix: present).
+		$guard = '';
+		if (preg_match(
+			'/(foreach \(\$_POST as \$pfb_post_key => \$pfb_post_value\) \{\n\t\t\tif \(!is_scalar\(\$pfb_post_value\)\) \{\n.*?\n\t\t\t\}\n\t\t\}\n)\n\t\t\/\/ issue #1723/s',
+			$src,
+			$gm
+		)) {
+			$guard = $gm[1];
+		}
+		eval(
+			'function pfb_ip_oracle_sanitize_prologue(array $post): array {'
+			. ' $_POST = $post; $input_errors = array();'
+			. $guard
+			. $m[1]
+			. ' return [$_POST, $input_errors]; }'
+		);
+	}
+
+	private function runCapturing(callable $fn): array
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$result = $fn();
+		} finally {
+			restore_error_handler();
+		}
+		return [$result, $diagnostics];
+	}
+
+	public function testArrayValuedAsnTokenIsRejectedAndBlankedWithNoArrayToStringDiagnostic(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([
+			'ip_placeholder'  => '198.51.100.1',
+			'asn_token'       => ['crafted'],
+			'autorule_suffix' => 'autorule',
+			'maxmind_account' => 'acct',
+			'maxmind_key'     => 'key',
+		]));
+
+		$arrayToString = array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion')));
+		$this->assertSame([], $arrayToString, "an array-valued asn_token must emit zero 'Array to string conversion' diagnostics, got:\n" . implode("\n", $arrayToString));
+
+		[$post, $inputErrors] = $result;
+		$this->assertSame('', $post['asn_token'], 'an array-valued field must be blanked, never left as an array or stringified "Array"');
+		$this->assertNotEmpty($inputErrors, 'an array-valued field must raise an input error');
+	}
+
+	public function testScalarFieldsStillSanitizeIdenticallyBeforeAndAfterTheGuard(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([
+			'ip_placeholder'  => ' 198.51.100.1 ',
+			'asn_token'       => ' mytoken ',
+			'autorule_suffix' => 'autorule',
+			'maxmind_account' => 'acct',
+			'maxmind_key'     => 'key',
+		]));
+
+		$this->assertSame([], array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion'))));
+		[$post, $inputErrors] = $result;
+		$this->assertSame([], $inputErrors, 'a fully scalar submission must raise no input error');
+		$this->assertSame('198.51.100.1', $post['ip_placeholder'], 'a scalar field must still sanitize (trim) identically -- the (string) cast must not be weakened');
+		$this->assertSame('mytoken', $post['asn_token']);
+	}
+
+	public function testMissingFieldsStillDefaultToEmptyStringUnchanged(): void
+	{
+		[$result, $diagnostics] = $this->runCapturing(static fn () => pfb_ip_oracle_sanitize_prologue([]));
+
+		$this->assertSame([], array_values(array_filter($diagnostics, static fn (string $d): bool => str_contains($d, 'Array to string conversion'))));
+		[$post, $inputErrors] = $result;
+		$this->assertSame([], $inputErrors, 'an empty POST has nothing non-scalar to reject');
+		$this->assertSame('', $post['asn_token'], 'an absent field must still default to \'\' (the pre-existing ?? \'\' behaviour)');
+	}
+}

--- a/tests/php/Issue1787BlankEmptyCallSitesTest.php
+++ b/tests/php/Issue1787BlankEmptyCallSitesTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1787: call sites that answered "is this string blank/empty?" with a
+ * flimsy idiom — empty() (which calls the valid row "0" empty) or
+ * trim() === '' (which misses Unicode whitespace such as NBSP) — must give the
+ * real answer via pfb_is_blank()/an exact '' match.
+ *
+ * Each test pins the corrected observable behaviour of one call site:
+ *   - pfb_is_blank_or_comment_line(): the literal line "0" is DATA, not blank.
+ *   - pfb_validate_suppression_line(): a Unicode-whitespace-only line is a
+ *     blank no-op, not an "invalid subnet" input error.
+ *   - pfb_get_hooks(): a hook whose script is only Unicode whitespace has no
+ *     script and is skipped like an empty one.
+ *   - pfb_feed_redirect_target(): a Location of only Unicode whitespace has no
+ *     target — refuse it up front instead of resolving it as a relative URL.
+ *   - pfb_lint_sh_diagnostics()/pfb_lint_py_diagnostics(): a stderr of only
+ *     Unicode whitespace carries no diagnostic — degrade to the no-diagnostic/
+ *     launch-failed warning instead of surfacing a whitespace "error".
+ */
+#[CoversFunction('pfb_is_blank_or_comment_line')]
+#[CoversFunction('pfb_validate_suppression_line')]
+#[CoversFunction('pfb_get_hooks')]
+#[CoversFunction('pfb_feed_redirect_target')]
+#[CoversFunction('pfb_lint_sh_diagnostics')]
+#[CoversFunction('pfb_lint_py_diagnostics')]
+final class Issue1787BlankEmptyCallSitesTest extends TestCase
+{
+	private const NBSP = "\u{00A0}";
+
+	/** @var list<string> tmp fixture paths to unlink in tearDown */
+	private array $fixtures = [];
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_resolve_map'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->fixtures as $path) {
+			@unlink($path);
+		}
+		$this->fixtures = [];
+		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map']);
+		parent::tearDown();
+	}
+
+	/** Writes an executable `#!/bin/sh` fixture that runs $body verbatim. */
+	private function fixture(string $body): string
+	{
+		$path = sys_get_temp_dir() . '/pfb_1787_fixture_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		chmod($path, 0700);
+		$this->fixtures[] = $path;
+		return $path;
+	}
+
+	// --- pfb_is_blank_or_comment_line ------------------------------------
+
+	public function testLiteralZeroLineIsNotBlank(): void
+	{
+		// The contract (and pfb_dnsbl_is_skippable_control_line, its ADR-62
+		// mirror) says blank detection is an exact '' match; empty('0') is TRUE,
+		// which silently drops a "0" feed line as blank (issue #1707 class).
+		$this->assertFalse(pfb_is_blank_or_comment_line('0'));
+		// The genuine blank/comment shapes still match.
+		$this->assertTrue(pfb_is_blank_or_comment_line(''));
+		$this->assertTrue(pfb_is_blank_or_comment_line('# comment'));
+	}
+
+	// --- pfb_validate_suppression_line -----------------------------------
+
+	public function testSuppressionLineOfOnlyUnicodeWhitespaceIsBlankNoOp(): void
+	{
+		// Given an ASCII-blank line is already a no-op
+		$this->assertNull(pfb_validate_suppression_line('   ', 'ipv4'));
+		// Then a Unicode-whitespace-only line is the same blank no-op, not an
+		// input error naming an "invalid subnet".
+		$this->assertNull(pfb_validate_suppression_line(self::NBSP, 'ipv4'));
+		$this->assertNull(pfb_validate_suppression_line(self::NBSP . "\u{3000}", 'ipv6'));
+	}
+
+	// --- pfb_get_hooks ----------------------------------------------------
+
+	public function testHookWithUnicodeWhitespaceOnlyScriptIsSkipped(): void
+	{
+		$pfbconfig = ['hooks' => ['row' => [
+			['enabled' => 'on', 'when' => 'pre', 'script' => 'echo ok'],
+			['enabled' => 'on', 'when' => 'pre', 'script' => self::NBSP],
+		]]];
+		$hooks = pfb_get_hooks($pfbconfig, 'pre');
+		// Only the hook with a real script survives; a Unicode-whitespace-only
+		// script is as script-less as an empty one.
+		$this->assertCount(1, $hooks);
+		$this->assertSame('echo ok', $hooks[0]['script']);
+	}
+
+	// --- pfb_feed_redirect_target -----------------------------------------
+
+	public function testRedirectLocationOfOnlyUnicodeWhitespaceHasNoTarget(): void
+	{
+		$reason = '';
+		$pinned = '';
+		$result = pfb_feed_redirect_target(self::NBSP, 'https://feed.example/list.txt', $reason, $pinned);
+		// A whitespace-only Location is "no target" — refused before any
+		// relative-URL resolution or host re-vetting runs.
+		$this->assertFalse($result);
+		$this->assertSame('feed redirect has no target', $reason);
+		$this->assertSame('', $pinned);
+	}
+
+	// --- pfb_lint_sh_diagnostics / pfb_lint_py_diagnostics ----------------
+
+	public function testShUnicodeWhitespaceOnlyStderrIsNoDiagnosticWarning(): void
+	{
+		// Nonzero exit, stderr = NBSP + newline: no diagnostic to parse.
+		$timeoutFixture = $this->fixture('printf "\302\240\n" 1>&2' . "\n" . 'exit 1');
+		$shFixture = $this->fixture('exit 0'); // never exec'd — fake timeout ignores argv
+		$diagnostics = pfb_lint_sh_diagnostics("echo ok\n", $shFixture, $timeoutFixture);
+		$this->assertCount(1, $diagnostics);
+		$this->assertSame(1, $diagnostics[0]['line']);
+		$this->assertSame('warning', $diagnostics[0]['severity']);
+		$this->assertStringContainsString('exited 1 with no diagnostic', $diagnostics[0]['message']);
+	}
+
+	public function testShStdinWriteFailureWithWhitespaceOnlyStderrIsLaunchFailedWarning(): void
+	{
+		// The fake "timeout_bin" closes stdin immediately (EPIPEs the write loop
+		// for an over-pipe-buffer body) and leaves only whitespace on stderr —
+		// there is no parseable diagnostic to prefer, so the generic
+		// launch-failed warning must win.
+		$timeoutFixture = $this->fixture(
+			'exec 0<&-' . "\n" .
+			'printf "\302\240\n" 1>&2' . "\n" .
+			'exit 2'
+		);
+		$shFixture = $this->fixture('exit 0');
+		// ~256KiB: over the OS pipe buffer, under the endpoint's 1MiB cap.
+		$content = str_repeat('x', 300000) . "\n";
+		$diagnostics = pfb_lint_sh_diagnostics($content, $shFixture, $timeoutFixture);
+		$this->assertCount(1, $diagnostics);
+		$this->assertSame(1, $diagnostics[0]['line']);
+		$this->assertSame('warning', $diagnostics[0]['severity']);
+		$this->assertStringContainsString('launch failed', $diagnostics[0]['message']);
+	}
+
+	public function testPyUnicodeWhitespaceOnlyStderrIsNoDiagnosticWarning(): void
+	{
+		$timeoutFixture = $this->fixture('printf "\302\240\n" 1>&2' . "\n" . 'exit 1');
+		$pythonFixture = $this->fixture('exit 0'); // never exec'd — fake timeout ignores argv
+		$diagnostics = pfb_lint_py_diagnostics("print('ok')\n", $pythonFixture, $timeoutFixture);
+		$this->assertCount(1, $diagnostics);
+		$this->assertSame(1, $diagnostics[0]['line']);
+		$this->assertSame('warning', $diagnostics[0]['severity']);
+		$this->assertStringContainsString('exited 1 with no diagnostic', $diagnostics[0]['message']);
+	}
+}

--- a/tests/php/Issue1787BlankEmptyCallSitesTest.php
+++ b/tests/php/Issue1787BlankEmptyCallSitesTest.php
@@ -75,6 +75,33 @@ final class Issue1787BlankEmptyCallSitesTest extends TestCase
 		$this->assertTrue(pfb_is_blank_or_comment_line('# comment'));
 	}
 
+	public function testBlankOrCommentLineStripsItsOwnWhitespace(): void
+	{
+		// The helper strips the line itself (Unicode class included), so a
+		// whitespace-only line is blank and a comment marker behind
+		// indentation — which the caller's ASCII trim() cannot remove when
+		// the whitespace is NBSP — is still a comment.
+		$this->assertTrue(pfb_is_blank_or_comment_line('   '));
+		$this->assertTrue(pfb_is_blank_or_comment_line(self::NBSP));
+		$this->assertTrue(pfb_is_blank_or_comment_line(self::NBSP . '# comment'));
+		$this->assertTrue(pfb_is_blank_or_comment_line(self::NBSP . '! ABP comment'));
+		// Data behind the same indentation is still data.
+		$this->assertFalse(pfb_is_blank_or_comment_line(self::NBSP . 'example.com'));
+	}
+
+	public function testSkippableControlLineStripsItsOwnWhitespace(): void
+	{
+		// Same self-stripping contract for the ADR-62 mirror: blank lines,
+		// indented '!'/'//' comments, and an ABP section marker with trailing
+		// whitespace are all control lines; a bracketed IPv6 literal and a
+		// domain stay data.
+		$this->assertTrue(pfb_dnsbl_is_skippable_control_line('   '));
+		$this->assertTrue(pfb_dnsbl_is_skippable_control_line(self::NBSP . '! ABP comment'));
+		$this->assertTrue(pfb_dnsbl_is_skippable_control_line('[Adblock Plus 2.0]' . self::NBSP));
+		$this->assertFalse(pfb_dnsbl_is_skippable_control_line(self::NBSP . '[2604:2dc0::]'));
+		$this->assertFalse(pfb_dnsbl_is_skippable_control_line(self::NBSP . 'example.com'));
+	}
+
 	// --- pfb_validate_suppression_line -----------------------------------
 
 	public function testSuppressionLineOfOnlyUnicodeWhitespaceIsBlankNoOp(): void
@@ -85,6 +112,15 @@ final class Issue1787BlankEmptyCallSitesTest extends TestCase
 		// input error naming an "invalid subnet".
 		$this->assertNull(pfb_validate_suppression_line(self::NBSP, 'ipv4'));
 		$this->assertNull(pfb_validate_suppression_line(self::NBSP . "\u{3000}", 'ipv6'));
+	}
+
+	public function testSuppressionCommentBehindLeadingWhitespaceIsStillAComment(): void
+	{
+		// A comment line is one whose first NONBLANK character is '#' —
+		// leading whitespace (ASCII or Unicode) must not turn it into a
+		// malformed "address".
+		$this->assertNull(pfb_validate_suppression_line('  # ASCII-indented comment', 'ipv4'));
+		$this->assertNull(pfb_validate_suppression_line(self::NBSP . '# NBSP-indented comment', 'ipv4'));
 	}
 
 	// --- pfb_get_hooks ----------------------------------------------------

--- a/tests/php/Issue1792SinkholeLabelTest.php
+++ b/tests/php/Issue1792SinkholeLabelTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1792, sweep family 5 — the sinkhole block page's request-attribute
+ * labels (`www/index.php`, standalone under the DNSBL VIP lighttpd, so no
+ * pfblockerng.inc helpers there). The `htmlspecialchars($_SERVER[...] ?? '')
+ * ?: 'Unknown'` idiom read a literal `Host: 0` / `User-Agent: 0` header as an
+ * ABSENCE and labelled it "Unknown"; only a genuinely missing/empty attribute
+ * may do that. Hermetic (page is Tier-A-unreachable per
+ * `EXCLUDED_FROM_TIER_A["dnsbl_vip_sinkhole_pages"]`; the live VIP-sinkhole
+ * leg covers the page render itself) — evals the REAL foreach statement out
+ * of the page via Issue1792SweepSiteLoader.php.
+ */
+#[CoversNothing]
+final class Issue1792SinkholeLabelTest extends TestCase
+{
+	private const SINKHOLE_PAGE = 'src/usr/local/www/pfblockerng/www/index.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/Issue1792SweepSiteLoader.php';
+	}
+
+	/**
+	 * Run the loop body's REAL label statement for one attribute with
+	 * $_SERVER seeded. (The statement -- not the enclosing foreach -- is the
+	 * site under test; the loader is line-scoped.)
+	 */
+	private function runLabelStatement(string $server_type, ?string $value): string
+	{
+		$prev = $_SERVER;
+		if ($value === null) {
+			unset($_SERVER[$server_type]);
+		} else {
+			$_SERVER[$server_type] = $value;
+		}
+		try {
+			$out = pfb_test_1792_eval_site(self::SINKHOLE_PAGE, "\$ptype[\$server_type] = ", [
+				'ptype'       => [],
+				'server_type' => $server_type,
+			]);
+			return $out['ptype'][$server_type];
+		} finally {
+			$_SERVER = $prev;
+		}
+	}
+
+	public function testLiteralZeroHeaderIsDataNotUnknown(): void
+	{
+		$this->assertSame('0', $this->runLabelStatement('HTTP_HOST', '0'),
+			'a literal `Host: 0` header is data, never the "Unknown" absence label');
+		$this->assertSame('0', $this->runLabelStatement('HTTP_USER_AGENT', '0'));
+		$this->assertSame('192.0.2.9', $this->runLabelStatement('REMOTE_ADDR', '192.0.2.9'));
+	}
+
+	public function testMissingAndEmptyHeadersStillReadUnknown(): void
+	{
+		$this->assertSame('Unknown', $this->runLabelStatement('HTTP_REFERER', ''),
+			'an EMPTY header must still read "Unknown" -- the load-bearing fallback survives');
+		$this->assertSame('Unknown', $this->runLabelStatement('HTTP_USER_AGENT', null),
+			'a MISSING header must still read "Unknown"');
+	}
+}

--- a/tests/php/Issue1792SweepSiteLoader.php
+++ b/tests/php/Issue1792SweepSiteLoader.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Issue #1792: eval REAL single-statement sites straight out of the www pages
+ * -- not hand-copied stand-ins -- so a red run against the pre-sweep
+ * `?: `-idiom sites genuinely exercises the buggy statement, and the SAME test
+ * goes green once the site is swept, with zero test edits (the same rationale
+ * as AlertsCustomlistDecodeLoader.php, which evals brace blocks; these sites
+ * are one-line assignments, so the extractor here is line-scoped).
+ */
+
+/**
+ * Extract the single full statement starting at $marker (through the first
+ * ';' at line end) from $relpath and eval it with $vars in scope; returns the
+ * eval scope's variables afterwards (get_defined_vars minus the plumbing).
+ *
+ * @param array<string, mixed> $vars
+ * @return array<string, mixed>
+ */
+function pfb_test_1792_eval_site(string $relpath, string $marker, array $vars): array
+{
+	$src = file_get_contents(dirname(__DIR__, 2) . '/' . $relpath);
+	if ($src === false) {
+		throw new RuntimeException("failed to read {$relpath}");
+	}
+	$start = strpos($src, $marker);
+	if ($start === false) {
+		throw new RuntimeException("could not locate marker in {$relpath}: {$marker}");
+	}
+	$end = strpos($src, ";\n", $start);
+	if ($end === false) {
+		throw new RuntimeException("no statement end after marker in {$relpath}: {$marker}");
+	}
+	$statement = substr($src, $start, $end - $start + 1);
+
+	return (static function (string $pfb_test_1792_statement, array $pfb_test_1792_vars): array {
+		extract($pfb_test_1792_vars);
+		eval($pfb_test_1792_statement);
+		$result = get_defined_vars();
+		unset($result['pfb_test_1792_statement'], $result['pfb_test_1792_vars']);
+		return $result;
+	})($statement, $vars);
+}

--- a/tests/php/Issue1792SweepSitesTest.php
+++ b/tests/php/Issue1792SweepSitesTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1792 sweep — site-level pins over the REAL statements (evaled out of
+ * the www pages by Issue1792SweepSiteLoader.php), one representative per
+ * defect family the sweep fixes:
+ *
+ *  1. `explode(',', $x ?? '') ?: $default` — the elvis arm is UNREACHABLE
+ *     (explode() on a string subject is always truthy), so an empty scalar
+ *     yielded [''] and an intended non-empty default NEVER applied.
+ *  2. `base64_decode($x ?? '') ?: ''` — the arm eats a stored "0"
+ *     (base64_decode('MA==') === '0', falsy) along with the FALSE it guards.
+ *  3. `($data[1] ?? '') ?: $unknown_msg` — a stat label of literally '0'
+ *     renders as "Unknown".
+ *  4. `($l[1] ?? '') ?: ($e[1] ?? '')` — a category translation of literally
+ *     '0' falls back to EN (the EMPTY-translation → EN fallback is
+ *     load-bearing and must survive, pinned here too).
+ *
+ * Red against the pre-sweep sites, green after they move onto
+ * pfb_csv_list()/pfb_b64_text()/pfb_is_empty() — zero test edits either side.
+ */
+#[CoversNothing]
+final class Issue1792SweepSitesTest extends TestCase
+{
+	private const DNSBL_PAGE = 'src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php';
+	private const IP_PAGE = 'src/usr/local/www/pfblockerng/pfblockerng_ip.php';
+	private const ALERTS_PAGE = 'src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+	private const BLACKLIST_PAGE = 'src/usr/local/www/pfblockerng/pfblockerng_blacklist.php';
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/Issue1792SweepSiteLoader.php';
+	}
+
+	// --- family 1: csv list with an intended (but dead) non-empty default --
+
+	public function testEmptyGtldConfigYieldsTheIntendedDefaultTlds(): void
+	{
+		$default_tlds = ['com', 'net', 'org'];
+		$out = pfb_test_1792_eval_site(self::DNSBL_PAGE, "\$pconfig['pfb_pytlds_gtld']", [
+			'pfb'          => ['dconfig' => []],
+			'pconfig'      => [],
+			'default_tlds' => $default_tlds,
+		]);
+		$this->assertSame($default_tlds, $out['pconfig']['pfb_pytlds_gtld'],
+			'an absent pfb_pytlds_gtld scalar must yield the intended default TLD set, never [\'\']');
+	}
+
+	public function testEmptyAlexaInclusionYieldsItsInlineDefault(): void
+	{
+		$out = pfb_test_1792_eval_site(self::DNSBL_PAGE, "\$pconfig['alexa_inclusion']", [
+			'pfb'     => ['dconfig' => ['alexa_inclusion' => '']],
+			'pconfig' => [],
+		]);
+		$this->assertSame(['com', 'net', 'org', 'ca', 'co', 'io'], $out['pconfig']['alexa_inclusion'],
+			'an empty alexa_inclusion scalar must yield the inline default list, never [\'\']');
+	}
+
+	// --- family 1b: csv list whose downstream wants "no entries" -----------
+
+	public function testEmptyInboundInterfaceYieldsNoEntries(): void
+	{
+		$out = pfb_test_1792_eval_site(self::IP_PAGE, "\$pconfig['inbound_interface']", [
+			'pfb'     => ['iconfig' => []],
+			'pconfig' => [],
+		]);
+		$this->assertSame([], $out['pconfig']['inbound_interface'],
+			'an absent inbound_interface scalar must yield NO entries, not the phantom [\'\']');
+	}
+
+	public function testZeroIsARealCsvEntryNotAnAbsence(): void
+	{
+		$out = pfb_test_1792_eval_site(self::IP_PAGE, "\$pconfig['inbound_interface']", [
+			'pfb'     => ['iconfig' => ['inbound_interface' => '0']],
+			'pconfig' => [],
+		]);
+		$this->assertSame(['0'], $out['pconfig']['inbound_interface']);
+	}
+
+	// --- family 2: base64 text field eats a stored "0" ---------------------
+
+	public function testStoredZeroSuppressionSurvivesToTheForm(): void
+	{
+		$out = pfb_test_1792_eval_site(self::DNSBL_PAGE, "\$pconfig['suppression']", [
+			'pfb'     => ['dconfig' => ['suppression' => base64_encode('0')]],
+			'pconfig' => [],
+		]);
+		$this->assertSame('0', $out['pconfig']['suppression'],
+			'a suppression textarea holding exactly "0" must re-render as "0", not empty');
+	}
+
+	public function testAbsentSuppressionStillRendersEmpty(): void
+	{
+		$out = pfb_test_1792_eval_site(self::DNSBL_PAGE, "\$pconfig['suppression']", [
+			'pfb'     => ['dconfig' => []],
+			'pconfig' => [],
+		]);
+		$this->assertSame('', $out['pconfig']['suppression']);
+	}
+
+	// --- family 3: alerts stat label '0' reads as "Unknown" ----------------
+
+	public function testZeroStatLabelIsNotUnknown(): void
+	{
+		$out = pfb_test_1792_eval_site(self::ALERTS_PAGE, '$alert_stats[$alert_view][$stat_type][', [
+			'alert_stats' => [],
+			'alert_view'  => 'ip_block_stat',
+			'stat_type'   => 'interface',
+			'data'        => ['3', '0'],
+			'unknown_msg' => 'Unknown',
+		]);
+		$stats = $out['alert_stats']['ip_block_stat']['interface'];
+		$this->assertArrayHasKey('0', $stats,
+			'a stat label of literally "0" must key as "0", never collapse into "Unknown"');
+		$this->assertArrayNotHasKey('Unknown', $stats);
+		$this->assertSame(3, (int) $stats['0']);
+	}
+
+	public function testEmptyStatLabelStillReadsUnknown(): void
+	{
+		$out = pfb_test_1792_eval_site(self::ALERTS_PAGE, '$alert_stats[$alert_view][$stat_type][', [
+			'alert_stats' => [],
+			'alert_view'  => 'ip_block_stat',
+			'stat_type'   => 'interface',
+			'data'        => ['3'],
+			'unknown_msg' => 'Unknown',
+		]);
+		$this->assertArrayHasKey('Unknown', $out['alert_stats']['ip_block_stat']['interface'],
+			'the load-bearing empty-label -> "Unknown" fallback must survive the sweep');
+	}
+
+	// --- family 4: blacklist category translation '0' falls back to EN -----
+
+	public function testZeroCategoryTranslationSurvives(): void
+	{
+		$out = pfb_test_1792_eval_site(self::BLACKLIST_PAGE, '$category_lang = ', [
+			'l' => ['cat_key', '0'],
+			'e' => ['cat_key', 'English name'],
+		]);
+		$this->assertSame('0', $out['category_lang'],
+			'a category translation of literally "0" is a real translation, not an absence');
+	}
+
+	public function testEmptyCategoryTranslationStillFallsBackToEn(): void
+	{
+		$out = pfb_test_1792_eval_site(self::BLACKLIST_PAGE, '$category_lang = ', [
+			'l' => ['cat_key', ''],
+			'e' => ['cat_key', 'English name'],
+		]);
+		$this->assertSame('English name', $out['category_lang'],
+			'the load-bearing EMPTY-translation -> EN fallback must survive the sweep');
+	}
+}

--- a/tests/php/NoEmptyOnStringRuleTest.php
+++ b/tests/php/NoEmptyOnStringRuleTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1787 — the custom PHPStan rule (PfBlockerNG\PHPStan\NoEmptyOnStringRule)
+ * that mechanically bans empty() on statically-string-typed operands, because
+ * empty('0') is TRUE and a valid "0" value reads as absent (issue #1707 class).
+ *
+ * A linter that never fires is worthless, so this suite pins BOTH sides of the
+ * rule's decision, driving the real `phpstan` binary (the repo config, so the
+ * exact CI wiring) over fixture files under tests/phpstan/fixtures/:
+ *
+ *   - it FLAGS empty() on string, ?string, and string|false operands (the
+ *     null/false wrappers still lie about '0');
+ *   - it STAYS SILENT for empty() on arrays and untyped/mixed operands (the
+ *     legacy config-read idiom), and for the honest `$value === ''` check.
+ *
+ * The rule is dev-only tooling; if phpstan is not installed the suite SKIPs
+ * (CI's phpstan job is the hard gate), it never falsely fails.
+ */
+final class NoEmptyOnStringRuleTest extends TestCase
+{
+	private const IDENTIFIER = 'pfBlockerNG.emptyOnString';
+
+	/** @var array<string, list<array{line: int, identifier: string}>>|null keyed by fixture basename */
+	private static ?array $findings = null;
+
+	private static function repoRoot(): string
+	{
+		return dirname(__DIR__, 2);
+	}
+
+	protected function setUp(): void
+	{
+		if (!is_file(self::repoRoot() . '/vendor/bin/phpstan')) {
+			$this->markTestSkipped('phpstan not installed (composer install) — CI phpstan job is the gate.');
+		}
+	}
+
+	/**
+	 * One shared phpstan run over both fixtures (analysis is the slow part),
+	 * returning per-file emptyOnString findings.
+	 *
+	 * @return array<string, list<array{line: int, identifier: string}>>
+	 */
+	private function findings(): array
+	{
+		if (self::$findings !== null) {
+			return self::$findings;
+		}
+		$root = self::repoRoot();
+		$cmd = escapeshellarg($root . '/vendor/bin/phpstan')
+			. ' analyse --no-progress --memory-limit=1G --error-format=json'
+			. ' -c ' . escapeshellarg($root . '/phpstan.neon')
+			. ' ' . escapeshellarg($root . '/tests/phpstan/fixtures')
+			. ' 2>/dev/null';
+		exec($cmd, $output, $status);
+		$report = json_decode(implode("\n", $output), true);
+		$this->assertIsArray($report, 'phpstan produced no parseable JSON report');
+
+		$byFile = [];
+		foreach (($report['files'] ?? []) as $path => $file) {
+			foreach (($file['messages'] ?? []) as $message) {
+				if (($message['identifier'] ?? '') !== self::IDENTIFIER) {
+					continue;
+				}
+				$byFile[basename((string) $path)][] = [
+					'line'       => (int) $message['line'],
+					'identifier' => (string) $message['identifier'],
+				];
+			}
+		}
+		return self::$findings = $byFile;
+	}
+
+	public function testFlagsEmptyOnStringTypedOperands(): void
+	{
+		$flagged = array_column($this->findings()['empty_on_string_violation.php'] ?? [], 'line');
+		sort($flagged);
+		// string / ?string / string|false — one finding per fixture function.
+		$this->assertSame([8, 12, 17], $flagged);
+	}
+
+	public function testStaysSilentOnArraysUntypedAndExactComparison(): void
+	{
+		$this->assertArrayNotHasKey(
+			'empty_on_string_compliant.php',
+			$this->findings(),
+			'rule must not fire on array/untyped operands or exact comparisons'
+		);
+	}
+}

--- a/tests/php/NoEmptyOnStringRuleTest.php
+++ b/tests/php/NoEmptyOnStringRuleTest.php
@@ -80,8 +80,9 @@ final class NoEmptyOnStringRuleTest extends TestCase
 	{
 		$flagged = array_column($this->findings()['empty_on_string_violation.php'] ?? [], 'line');
 		sort($flagged);
-		// string / ?string / string|false — one finding per fixture function.
-		$this->assertSame([8, 12, 17], $flagged);
+		// string / ?string / string|false, plus (issue #1792 N1) string|int and
+		// a literal-string union — one finding per fixture function.
+		$this->assertSame([8, 12, 17, 22, 27], $flagged);
 	}
 
 	public function testStaysSilentOnArraysUntypedAndExactComparison(): void

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -480,6 +480,59 @@ final class PfbFilterContractTest extends TestCase
 		$this->assertSame('DEF', pfb_filter("\xC3\x28", PFB_FILTER_HTML, 'ref', 'DEF'));
 	}
 
+	// --- PFB_FILTER_ON_OFF / PFB_FILTER_NUM: NULL input (issue #1768) -------------
+	//
+	// Both constants are deliberately exempt from the early
+	// empty($input)||is_null($input) return (NULL=='' / a legitimate stored
+	// default must still validate), so a caller passing NULL (e.g. an absent
+	// POST/config field) previously flowed unguarded into preg_match()/
+	// htmlspecialchars() -- PHP 8.1+ deprecates passing NULL to a non-nullable
+	// string parameter. pfb_filter() now coerces a non-array $input to a
+	// string immediately after that early-return guard, preserving the
+	// NULL==''/NUM-no-match-default return shape byte-identically.
+
+	public function testOnOffFilterAcceptsNullWithNoDiagnostics(): void
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		}, E_WARNING | E_DEPRECATED);
+		try {
+			$result = pfb_filter(NULL, PFB_FILTER_ON_OFF, 'PFBL-01 contract');
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"pfb_filter(NULL, PFB_FILTER_ON_OFF) must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		// NULL == '' -- same accepted-empty shape as an explicit '' input.
+		$this->assertSame('', $result);
+	}
+
+	public function testNumFilterAcceptsNullWithNoDiagnostics(): void
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		}, E_WARNING | E_DEPRECATED);
+		try {
+			$result = pfb_filter(NULL, PFB_FILTER_NUM, 'PFBL-01 contract');
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"pfb_filter(NULL, PFB_FILTER_NUM) must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		// No digits matched -> caller-supplied default ('').
+		$this->assertSame('', $result);
+	}
+
 	// --- Array-input branch: the same gate, applied per element --------------------
 
 	/**

--- a/tests/php/PfbIsEmptyRstripTest.php
+++ b/tests/php/PfbIsEmptyRstripTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_is_empty() / pfb_rstrip() (issue #1787) — the honest "is this an empty
+ * string?" answer and the Unicode-aware right-strip.
+ *
+ * pfb_is_empty() exists because empty() lies: empty('0') is TRUE, but "0" is a
+ * real value (issue #1707). Absent (NULL) and '' are empty; everything else —
+ * including whitespace — is content (blankness is pfb_is_blank()'s question).
+ *
+ * pfb_rstrip() strips trailing ASCII whitespace like rtrim(), and additionally
+ * the Unicode whitespace/separator class pfb_is_blank() calls blank (NBSP,
+ * ideographic space, line/paragraph separators, the BOM). Leading whitespace
+ * is preserved — it is a right-strip, not a trim.
+ */
+#[CoversFunction('pfb_is_empty')]
+#[CoversFunction('pfb_rstrip')]
+final class PfbIsEmptyRstripTest extends TestCase
+{
+	// --- pfb_is_empty -----------------------------------------------------
+
+	public function testAbsentAndEmptyStringAreEmpty(): void
+	{
+		$this->assertTrue(pfb_is_empty(NULL));
+		$this->assertTrue(pfb_is_empty(''));
+	}
+
+	public function testZeroStringIsNotEmpty(): void
+	{
+		// The whole reason this helper exists instead of empty(): "0" is a
+		// real value, and empty('0') is TRUE.
+		$this->assertFalse(pfb_is_empty('0'));
+	}
+
+	public function testWhitespaceIsContentNotEmptiness(): void
+	{
+		// Emptiness is exact; a whitespace-only string is BLANK (pfb_is_blank),
+		// not empty.
+		$this->assertFalse(pfb_is_empty(' '));
+		$this->assertFalse(pfb_is_empty("\u{00A0}"));
+		$this->assertFalse(pfb_is_empty('a'));
+	}
+
+	// --- pfb_rstrip -------------------------------------------------------
+
+	public function testStripsTrailingAsciiWhitespace(): void
+	{
+		$this->assertSame('value', pfb_rstrip("value \t\r\n"));
+	}
+
+	public function testStripsTrailingUnicodeWhitespaceAndBom(): void
+	{
+		// NBSP, ideographic space, line separator, BOM — all trailing
+		// whitespace-class characters rtrim() misses.
+		$this->assertSame('value', pfb_rstrip("value\u{00A0}\u{3000}\u{2028}\u{FEFF}"));
+		// Mixed ASCII/Unicode runs strip in one pass too.
+		$this->assertSame('value', pfb_rstrip("value \u{00A0}\t\u{3000} "));
+	}
+
+	public function testPreservesLeadingWhitespaceAndInnerContent(): void
+	{
+		// A right-strip, not a trim: the left side and inner whitespace stay.
+		$this->assertSame("\u{00A0} a b", pfb_rstrip("\u{00A0} a b \u{00A0}"));
+	}
+
+	public function testWhitespaceOnlyStringStripsToEmpty(): void
+	{
+		$this->assertSame('', pfb_rstrip(" \t\u{00A0}\u{3000}"));
+		$this->assertSame('', pfb_rstrip(''));
+	}
+
+	public function testZeroSurvives(): void
+	{
+		// The issue-#1707 row: "0" is data, never stripped to nothing.
+		$this->assertSame('0', pfb_rstrip('0 '));
+	}
+}

--- a/tests/php/PfbSanitizeTextTest.php
+++ b/tests/php/PfbSanitizeTextTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_sanitize_text')]
 #[CoversFunction('pfb_sanitize_text_area')]
 #[CoversFunction('pfb_text_area_encode')]
+#[CoversFunction('pfb_text_area_decode')]
 final class PfbSanitizeTextTest extends TestCase
 {
 	// --- pfb_sanitize_text() ---
@@ -279,5 +280,30 @@ final class PfbSanitizeTextTest extends TestCase
 		$raw = "A\r\nB\xC2\xA0 \n\x07C";
 		$encoded = pfb_text_area_encode($raw);
 		$this->assertSame(['a', 'b', 'c'], pfb_text_area_decode($encoded, TRUE, FALSE));
+	}
+
+	// --- pfb_text_area_decode() ---
+
+	public function testTextAreaDecodeAcceptsNullWithNoDiagnostics(): void
+	{
+		// issue #1768: untyped $text flows into base64_decode(); an absent
+		// caller-side value (NULL) previously deprecated (PHP 8.1+: passing
+		// NULL to a non-nullable string parameter). Coerced to '' at entry now.
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		}, E_WARNING | E_DEPRECATED);
+		try {
+			$result = pfb_text_area_decode(NULL);
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame(
+			[],
+			$diagnostics,
+			"pfb_text_area_decode(NULL) must emit zero diagnostics, got:\n" . implode("\n", $diagnostics)
+		);
+		$this->assertSame('', $result);
 	}
 }

--- a/tests/php/PfbStringHelpersTest.php
+++ b/tests/php/PfbStringHelpersTest.php
@@ -117,4 +117,14 @@ final class PfbStringHelpersTest extends TestCase
 	{
 		$this->assertSame('0', pfb_strip(" 0\u{00A0}"));
 	}
+
+	public function testInvalidUtf8DegradesFailOpen(): void
+	{
+		// A truncated multibyte sequence makes the /u preg pass return NULL;
+		// the strips must degrade to the ASCII-trimmed bytes, never to NULL
+		// or wiped data (same fail-open contract as pfb_preg_replace_safe).
+		$this->assertSame("abc\xC2", pfb_rstrip("abc\xC2"));
+		$this->assertSame("abc\xC2", pfb_lstrip("abc\xC2"));
+		$this->assertSame("abc\xC2", pfb_strip("abc\xC2"));
+	}
 }

--- a/tests/php/PfbStringHelpersTest.php
+++ b/tests/php/PfbStringHelpersTest.php
@@ -24,8 +24,50 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_rstrip')]
 #[CoversFunction('pfb_lstrip')]
 #[CoversFunction('pfb_strip')]
+#[CoversFunction('pfb_csv_list')]
+#[CoversFunction('pfb_b64_text')]
 final class PfbStringHelpersTest extends TestCase
 {
+	// --- pfb_csv_list (issue #1792) ---------------------------------------
+
+	public function testCsvListSplitsEntriesAndKeepsZero(): void
+	{
+		$this->assertSame(['a', 'b'], pfb_csv_list('a,b'));
+		// "0" is one real entry, never the default (the empty('0') lie again).
+		$this->assertSame(['0'], pfb_csv_list('0'));
+	}
+
+	public function testCsvListAbsentOrEmptyYieldsDefault(): void
+	{
+		// The `explode(...) ?: $default` idiom this replaces NEVER produced
+		// the default -- explode() on a string is always truthy, so '' gave
+		// [''] and NULL gave [''] too. The default must now genuinely apply.
+		$this->assertSame([], pfb_csv_list(NULL));
+		$this->assertSame([], pfb_csv_list(''));
+		$this->assertSame(['x', 'y'], pfb_csv_list('', ['x', 'y']));
+		$this->assertSame(['x', 'y'], pfb_csv_list(NULL, ['x', 'y']));
+	}
+
+	// --- pfb_b64_text (issue #1792) ---------------------------------------
+
+	public function testB64TextDecodesAndKeepsZero(): void
+	{
+		$this->assertSame('abc', pfb_b64_text(base64_encode('abc')));
+		// 'MA==' decodes to '0' -- falsy, eaten by the `?: ''` idiom this
+		// replaces; a stored "0" must survive to the re-rendered form.
+		$this->assertSame('0', pfb_b64_text('MA=='));
+	}
+
+	public function testB64TextAbsentEmptyOrMalformedYieldsEmptyString(): void
+	{
+		$this->assertSame('', pfb_b64_text(NULL));
+		$this->assertSame('', pfb_b64_text(''));
+		// base64_decode() returns FALSE only in strict mode; the non-strict
+		// default never does -- pinned so the FALSE guard is provably the
+		// only degradation path and '' stays the worst case.
+		$this->assertSame('', pfb_b64_text(base64_encode('')));
+	}
+
 	// --- pfb_is_empty -----------------------------------------------------
 
 	public function testAbsentAndEmptyStringAreEmpty(): void

--- a/tests/php/PfbStringHelpersTest.php
+++ b/tests/php/PfbStringHelpersTest.php
@@ -6,8 +6,8 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_is_empty() / pfb_rstrip() (issue #1787) — the honest "is this an empty
- * string?" answer and the Unicode-aware right-strip.
+ * pfb_is_empty() / pfb_rstrip() / pfb_lstrip() / pfb_strip() (issue #1787) —
+ * the honest "is this an empty string?" answer and the Unicode-aware strips.
  *
  * pfb_is_empty() exists because empty() lies: empty('0') is TRUE, but "0" is a
  * real value (issue #1707). Absent (NULL) and '' are empty; everything else —
@@ -16,11 +16,15 @@ use PHPUnit\Framework\TestCase;
  * pfb_rstrip() strips trailing ASCII whitespace like rtrim(), and additionally
  * the Unicode whitespace/separator class pfb_is_blank() calls blank (NBSP,
  * ideographic space, line/paragraph separators, the BOM). Leading whitespace
- * is preserved — it is a right-strip, not a trim.
+ * is preserved — it is a right-strip, not a trim. pfb_lstrip() is its leading
+ * mirror (so "what is the first NONBLANK character?" is answerable), and
+ * pfb_strip() is the double-sided combination — trim() over the same class.
  */
 #[CoversFunction('pfb_is_empty')]
 #[CoversFunction('pfb_rstrip')]
-final class PfbIsEmptyRstripTest extends TestCase
+#[CoversFunction('pfb_lstrip')]
+#[CoversFunction('pfb_strip')]
+final class PfbStringHelpersTest extends TestCase
 {
 	// --- pfb_is_empty -----------------------------------------------------
 
@@ -78,5 +82,39 @@ final class PfbIsEmptyRstripTest extends TestCase
 	{
 		// The issue-#1707 row: "0" is data, never stripped to nothing.
 		$this->assertSame('0', pfb_rstrip('0 '));
+	}
+
+	// --- pfb_lstrip -------------------------------------------------------
+
+	public function testLstripStripsLeadingAsciiAndUnicodeWhitespace(): void
+	{
+		$this->assertSame('value', pfb_lstrip(" \t\u{00A0}\u{3000}\u{FEFF}value"));
+	}
+
+	public function testLstripPreservesTrailingWhitespaceAndInnerContent(): void
+	{
+		// A left-strip, not a trim: the right side and inner whitespace stay.
+		$this->assertSame("a b \u{00A0}", pfb_lstrip("\u{00A0} a b \u{00A0}"));
+	}
+
+	public function testLstripExposesFirstNonblankCharacter(): void
+	{
+		// The comment-detection use: '#' hiding behind indentation is still
+		// the first nonblank character.
+		$this->assertTrue(str_starts_with(pfb_lstrip("\u{00A0} # comment"), '#'));
+		$this->assertSame('', pfb_lstrip(" \u{00A0}"));
+	}
+
+	// --- pfb_strip --------------------------------------------------------
+
+	public function testStripTrimsBothSidesAcrossAsciiAndUnicode(): void
+	{
+		$this->assertSame('a b', pfb_strip("\u{FEFF}\u{00A0} a b \t\u{3000}\r\n"));
+		$this->assertSame('', pfb_strip(" \u{00A0}\u{2029} "));
+	}
+
+	public function testStripZeroSurvives(): void
+	{
+		$this->assertSame('0', pfb_strip(" 0\u{00A0}"));
 	}
 }

--- a/tests/php/WidgetIncludeConventionTest.php
+++ b/tests/php/WidgetIncludeConventionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1777: pfSense's dashboard widget-include convention reads a small
+ * set of `$pfblockerng_*`-prefixed variables from widget-pfblockerng.inc
+ * (`$widgetname`/`$pfblockerng_title`/`$pfblockerng_title_link` are the
+ * already-baselined siblings -- see tests/smoke/ui/php_diagnostic_baseline.txt).
+ * `$pfblockerng_allow_multiple_widget_copies` was never set, so pfSense's own
+ * dashboard.php reads it undefined on every render. The widget is a
+ * singleton by construction (a fixed POST action URL, settings keyed off one
+ * `installedpackages/pfblockerngglobal` config block) -- FALSE is correct,
+ * not a placeholder.
+ *
+ * Only the variable-assignment prologue (before the `pfb_widget_post_allowed()`
+ * function definition, already covered by WidgetPostAllowedTest/
+ * WidgetSubmitPostGuardTest's own require_once of this same file) is
+ * eval-extracted -- a bare `include` would risk a "Cannot redeclare function"
+ * fatal if PHPUnit runs this in the same process after those sibling tests
+ * have already required the file.
+ */
+final class WidgetIncludeConventionTest extends TestCase
+{
+	private const WIDGET_INC = __DIR__ . '/../../src/usr/local/www/widgets/include/widget-pfblockerng.inc';
+
+	public function testAllowMultipleWidgetCopiesConventionVariableIsDefinedFalse(): void
+	{
+		$src = file_get_contents(self::WIDGET_INC);
+		$this->assertNotFalse($src, 'failed to read widget-pfblockerng.inc');
+
+		if (!preg_match('/<\?php\n(.*?)\nfunction pfb_widget_post_allowed/s', $src, $m)) {
+			$this->fail('could not locate the variable-assignment prologue before pfb_widget_post_allowed()');
+		}
+		eval($m[1]);
+
+		$this->assertTrue(isset($pfblockerng_allow_multiple_widget_copies), '$pfblockerng_allow_multiple_widget_copies must be defined');
+		$this->assertFalse($pfblockerng_allow_multiple_widget_copies, 'the widget is a singleton (fixed POST action URL, one config block) -- must be FALSE');
+
+		// Control: the pre-existing sibling convention variables must still be
+		// defined too (this fix must not disturb them).
+		$this->assertTrue(isset($pfblockerng_title), '$pfblockerng_title must still be defined');
+		$this->assertTrue(isset($pfblockerng_title_link), '$pfblockerng_title_link must still be defined');
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5504,6 +5504,19 @@
             }
         ]
     },
+    "pfb_lstrip": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_manage_dnsbl_vip": {
         "returnsRef": false,
         "returnType": "void",
@@ -7319,6 +7332,19 @@
                 "byRef": false,
                 "variadic": false,
                 "type": null,
+                "default": null
+            }
+        ]
+    },
+    "pfb_strip": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
                 "default": null
             }
         ]

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -619,6 +619,19 @@
             }
         ]
     },
+    "pfb_b64_text": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
     "pfb_build_aggregate_aliases": {
         "returnsRef": false,
         "returnType": null,
@@ -1156,6 +1169,26 @@
                 "variadic": false,
                 "type": "bool",
                 "default": null
+            }
+        ]
+    },
+    "pfb_csv_list": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "default",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
             }
         ]
     },

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -4656,6 +4656,19 @@
             }
         ]
     },
+    "pfb_is_empty": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
     "pfb_is_managed_obj": {
         "returnsRef": false,
         "returnType": "bool",
@@ -6707,6 +6720,19 @@
                 "variadic": false,
                 "type": "?callable",
                 "default": "NULL"
+            }
+        ]
+    },
+    "pfb_rstrip": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
             }
         ]
     },

--- a/tests/php/fixtures/geoip_pre_move_golden.json
+++ b/tests/php/fixtures/geoip_pre_move_golden.json
@@ -29,16 +29,16 @@
     "ZZ_v4.txt": "454debca5afcd37addd0dcca05094625dcde6402510f8fc664cd567893ec7096"
   },
   "continent_pages": {
-    "pfblockerng_Africa.php": "b840456e93df26b037e4f0546698a145e1fb4636e48ffba25804ca8ff0262170",
-    "pfblockerng_Antarctica.php": "33323a3ecb0afecdd3152ca92c562ec8255c0e670b109df0a84b218d75059146",
-    "pfblockerng_Asia.php": "8794cdb38c042926021de06d6feb823d1b5e7982f284ba90f3d1c78b6833e8f1",
-    "pfblockerng_Europe.php": "2c662ebf8a781a0888abc2d4a663335e875c6a9cb2633c1f8186ddef88550003",
-    "pfblockerng_North_America.php": "1365778df351ea7cec0a400f96d815a2d1f194a14b193e9c025a496589fe0ddd",
-    "pfblockerng_Oceania.php": "82ce0e433beeab561aeb9ddd479fd526349eb20a3d385676ba14e2bd4b8c41db",
-    "pfblockerng_South_America.php": "81c3d6c4e6d9fbbcaa488f0f31d9adc459dd418d170808ccf648be18f3d52dd7",
-    "pfblockerng_Proxy_and_Satellite.php": "530895710dad9fc39e44ce7e0b0f4f41296c2e4c512bb4dcf68218430d7bec9e",
-    "pfblockerng_Top_Spammers.php": "0e092bed5d860e5b7c81ebd79db0120676f5b044c23d3d2a1966cbddd979b27c"
+    "pfblockerng_Africa.php": "b4f26d783f460b37892d610761ce8693767a848d3be1ec679274e18f9be65f7a",
+    "pfblockerng_Antarctica.php": "16e2625fbe93cf2e7973c728c5b24281cc9cbca4c2b2c45dab41597366b216b9",
+    "pfblockerng_Asia.php": "b5e5de0487906eb6f17368e8647602e7f509467cbbeb629d8ab9c7ddd534b00c",
+    "pfblockerng_Europe.php": "790876fd8208cf8a90e4aab5fe6379375c43be9c927f8f5a7c08a437122eec25",
+    "pfblockerng_North_America.php": "fc0656d9437b8387d267fce68bd9bfc2e49063afdbcc8f7c4f0e9e3d20961dbb",
+    "pfblockerng_Oceania.php": "7abf871d9c53c2f1978ce8694ec34baa277ac29656eda3d3eaa885e306045d02",
+    "pfblockerng_South_America.php": "03914349dacb312772f60a7adc12fa712a2d6fc32400ef3f518ce64bffe7683b",
+    "pfblockerng_Proxy_and_Satellite.php": "99866f1ba3c274ff81708dc2b39fef714823af20dbd34e3bdb1d047d8a14c74c",
+    "pfblockerng_Top_Spammers.php": "e94e2be0d6579d53f806e9b62c4288424fea7c33c0a10ed068344c6888cb1aa2"
   },
-  "reputation_empty": "49a41197673a6ccbfb5b4600f0236deca79f0672ba5b7b4dd51bdbe52dd64669",
-  "reputation_populated": "e63bba64de32da7bf5507cfbc728b8a4fe293a8a2e957bc27407b094f721e6da"
+  "reputation_empty": "5a61a598cb8d1ac66db93a27e88338f7c28e627df9d3b606a8df7348a30c5984",
+  "reputation_populated": "7dced7a138426dc8dbef7fa5c8f1b740e1459d4ba79e4340b7b3683ed79a0266"
 }

--- a/tests/phpstan/NoEmptyOnStringRule.php
+++ b/tests/phpstan/NoEmptyOnStringRule.php
@@ -40,7 +40,7 @@ final class NoEmptyOnStringRule implements Rule
 		// with empty()'s '0' lie — strip the wrappers before deciding.
 		$bare = TypeCombinator::removeNull($type);
 		$bare = TypeCombinator::remove($bare, new ConstantBooleanType(false));
-		if ($bare instanceof NeverType || !$bare->isString()->yes()) {
+		if ($bare instanceof NeverType || !$this->hasStringConstituent($bare)) {
 			return [];
 		}
 		return [
@@ -49,5 +49,28 @@ final class NoEmptyOnStringRule implements Rule
 				"Use pfb_is_empty() for ''/NULL or pfb_is_blank() for whitespace-only (issue #1787)."
 			)->identifier('pfBlockerNG.emptyOnString')->build(),
 		];
+	}
+
+	/**
+	 * TRUE when the (null/false-stripped) type is a string, or a union with a
+	 * string member (issue #1792 N1: `string|int` etc. still hit empty()'s
+	 * '0' lie through the string member). Mixed stays exempt — it is not a
+	 * UnionType and isString() answers maybe(), never yes(), so the
+	 * deliberately-silent legacy surface is untouched.
+	 */
+	private function hasStringConstituent(\PHPStan\Type\Type $type): bool
+	{
+		if ($type->isString()->yes()) {
+			return true;
+		}
+		if (!$type instanceof \PHPStan\Type\UnionType) {
+			return false;
+		}
+		foreach ($type->getTypes() as $member) {
+			if ($member->isString()->yes()) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/tests/phpstan/NoEmptyOnStringRule.php
+++ b/tests/phpstan/NoEmptyOnStringRule.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PfBlockerNG\PHPStan;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Empty_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Issue #1787: empty() on a string operand lies — empty('0') is TRUE, so a
+ * valid "0" value reads as absent (the issue-#1707 bug class). Whenever the
+ * operand's statically-known type is a string (nullable/string|false wrappers
+ * included), the honest predicates are pfb_is_empty() (exact ''/NULL) and
+ * pfb_is_blank() (nothing but whitespace).
+ *
+ * Deliberately silent on mixed/untyped operands (most legacy config-array
+ * reads): the gate stops NEW typed-string empty() calls without flagging the
+ * whole legacy surface. As annotations tighten, coverage grows for free.
+ *
+ * @implements Rule<Empty_>
+ */
+final class NoEmptyOnStringRule implements Rule
+{
+	public function getNodeType(): string
+	{
+		return Empty_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$type = $scope->getType($node->expr);
+		// ?string and string|false still answer "is this an empty string?"
+		// with empty()'s '0' lie — strip the wrappers before deciding.
+		$bare = TypeCombinator::removeNull($type);
+		$bare = TypeCombinator::remove($bare, new ConstantBooleanType(false));
+		if ($bare instanceof NeverType || !$bare->isString()->yes()) {
+			return [];
+		}
+		return [
+			RuleErrorBuilder::message(
+				"empty() on a string operand lies: empty('0') is TRUE. " .
+				"Use pfb_is_empty() for ''/NULL or pfb_is_blank() for whitespace-only (issue #1787)."
+			)->identifier('pfBlockerNG.emptyOnString')->build(),
+		];
+	}
+}

--- a/tests/phpstan/fixtures/empty_on_string_compliant.php
+++ b/tests/phpstan/fixtures/empty_on_string_compliant.php
@@ -1,0 +1,17 @@
+<?php
+
+// Fixture for NoEmptyOnStringRuleTest: none of the empty() calls below sit on
+// a statically-string-typed operand, so NoEmptyOnStringRule MUST stay silent —
+// the gate bans the string lie, not empty() itself (issue #1787).
+
+function pfb_fixture_empty_on_array(array $rows): bool {
+	return empty($rows); // arrays are empty()'s legitimate use
+}
+
+function pfb_fixture_empty_on_untyped($config): bool {
+	return empty($config); // mixed/untyped legacy reads stay un-flagged
+}
+
+function pfb_fixture_exact_comparison(string $value): bool {
+	return $value === ''; // the honest check needs no helper to pass the gate
+}

--- a/tests/phpstan/fixtures/empty_on_string_violation.php
+++ b/tests/phpstan/fixtures/empty_on_string_violation.php
@@ -1,0 +1,18 @@
+<?php
+
+// Fixture for NoEmptyOnStringRuleTest: every empty() below sits on a
+// statically-string-typed operand and MUST be flagged by
+// PfBlockerNG\PHPStan\NoEmptyOnStringRule (issue #1787).
+
+function pfb_fixture_empty_on_string_param(string $value): bool {
+	return empty($value); // line 8: plain string
+}
+
+function pfb_fixture_empty_on_nullable_string(?string $value): bool {
+	return empty($value); // line 12: ?string still lies about '0'
+}
+
+function pfb_fixture_empty_on_string_or_false($haystack): bool {
+	$pos = strstr((string) $haystack, '/');
+	return empty($pos); // line 17: string|false — the false wrapper is stripped
+}

--- a/tests/phpstan/fixtures/empty_on_string_violation.php
+++ b/tests/phpstan/fixtures/empty_on_string_violation.php
@@ -16,3 +16,13 @@ function pfb_fixture_empty_on_string_or_false($haystack): bool {
 	$pos = strstr((string) $haystack, '/');
 	return empty($pos); // line 17: string|false — the false wrapper is stripped
 }
+
+/** @param string|int $value */
+function pfb_fixture_empty_on_string_int_union($value): bool {
+	return empty($value); // line 22: string|int — the string member still lies about '0' (issue #1792 N1)
+}
+
+/** @param 'a'|'b'|'' $value */
+function pfb_fixture_empty_on_string_literal_union(string $value): bool {
+	return empty($value); // line 27: literal-string union is still a string operand
+}

--- a/tests/smoke/ui/php_diagnostic_baseline.txt
+++ b/tests/smoke/ui/php_diagnostic_baseline.txt
@@ -39,5 +39,4 @@
 /usr/local/www/pfblockerng/pfblockerng_ip.php|Deprecated|explode(): Passing null to parameter #2 ($string) of type string is deprecated
 /usr/local/www/pfblockerng/pfblockerng_reputation.php|Deprecated|explode(): Passing null to parameter #2 ($string) of type string is deprecated
 /usr/local/www/widgets/widgets/pfblockerng.widget.php|Deprecated|htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated
-/usr/local/www/widgets/widgets/pfblockerng.widget.php|Warning|Trying to access array offset on null
 /usr/local/www/widgets/widgets/pfblockerng.widget.php|Warning|Undefined variable $widgetname

--- a/tests/smoke/ui/test_dnsbl_zero_prefill_render.py
+++ b/tests/smoke/ui/test_dnsbl_zero_prefill_render.py
@@ -1,0 +1,84 @@
+"""Tier-A ``ui_render`` coverage for issue #1792: a stored textarea value of
+literally ``"0"`` survives to the re-rendered form.
+
+The DNSBL page prefilled its base64 textareas through
+``base64_decode($x) ?: ''`` — and ``base64_decode('MA==') === '0'``, which is
+falsy, so a Suppression list holding exactly ``0`` re-rendered as an EMPTY
+textarea (saving the form again would then silently erase the stored value).
+The #1792 sweep moved the prefill onto ``pfb_b64_text()``, which only degrades
+to ``''`` on a FALSE (malformed) decode.
+
+Self-encapsulated: the config node is restored to its exact prior value in
+teardown. ``"0"`` is inert here — the page render never resolves it.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+DNSBL_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
+CFG_SUPPRESSION = "installedpackages/pfblockerngdnsblsettings/config/0/suppression"
+ZERO_B64 = "MA=="  # base64_encode('0')
+
+
+@pytest.fixture
+def _seeded_zero_suppression(smoke_vm: SmokeVM) -> Iterator[None]:
+    vm = smoke_vm
+    prior = helpers.config_get(vm, CFG_SUPPRESSION)
+    write = helpers.php_eval(
+        vm,
+        f"config_set_path('{CFG_SUPPRESSION}', '{ZERO_B64}');\n"
+        "write_config('pfBlockerNG smoke #1792: seed zero suppression');\n"
+        "echo 'SEED-OK';\n",
+    )
+    assert write.returncode == 0 and "SEED-OK" in write.stdout, (
+        f"failed to seed the suppression node: stdout={write.stdout!r} stderr={write.stderr!r}"
+    )
+    yield
+    restore = helpers.php_eval(
+        vm,
+        f"config_set_path('{CFG_SUPPRESSION}', '{prior}');\n"
+        "write_config('pfBlockerNG smoke #1792: restore suppression');\n"
+        "echo 'RESTORE-OK';\n",
+    )
+    assert restore.returncode == 0 and "RESTORE-OK" in restore.stdout, (
+        f"failed to restore the suppression node: stdout={restore.stdout!r} stderr={restore.stderr!r}"
+    )
+    assert helpers.config_get(vm, CFG_SUPPRESSION) == prior, (
+        "suppression config restore did not take -- the seeded '0' leaked to sibling tests"
+    )
+
+
+def test_stored_zero_suppression_prefills_the_textarea(
+    smoke_vm: SmokeVM, webui: WebUI, _seeded_zero_suppression: None
+) -> None:
+    """A DNSBL Whitelist holding exactly "0" re-renders as "0", never empty."""
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(DNSBL_PAGE)
+    result = evaluate_render(DNSBL_PAGE, resp.status_code, resp.text, ("DNSBL",))
+    assert result.ok, f"Tier-A render oracle failed for the DNSBL page: {result.detail}"
+
+    m = re.search(r'name="suppression"[^>]*>(.*?)</textarea>', resp.text, re.DOTALL)
+    assert m is not None, "suppression textarea not found on the DNSBL page -- fixture broken, not a #1792 signal"
+    assert m.group(1).strip() == "0", (
+        f"a stored '0' suppression list must prefill as '0', got {m.group(1).strip()!r} "
+        "-- the base64 prefill is eating falsy decodes again (issue #1792)"
+    )
+
+    guard.assert_no_growth()

--- a/tests/smoke/ui/test_post_array_scalar_guards.py
+++ b/tests/smoke/ui/test_post_array_scalar_guards.py
@@ -90,6 +90,11 @@ _ARRAY_FIELD_CASES: list[tuple[str, str, dict[str, str] | None]] = [
     ("/pfblockerng/pfblockerng_sync.php", "varsynctimeout", None),  # pfb_filter NUM (pre-loop)
     ("/pfblockerng/pfblockerng_ip.php", "enable_dup", None),  # pfb_filter ON_OFF
     ("/pfblockerng/pfblockerng_ip.php", "asn_token", None),  # pfb_filter WORD
+    # issue #1777: ip.php's own ingress guard, on the two ADR-40 fields whose
+    # sinks sit below the #1723 sanitize loops -- array_key_exists() (a fatal
+    # TypeError on an array) and a (string) cast.
+    ("/pfblockerng/pfblockerng_ip.php", "pfb_alias_delta_mode", None),
+    ("/pfblockerng/pfblockerng_ip.php", "pfb_alias_delta_batch", None),
     ("/pfblockerng/pfblockerng_general.php", "enable_cb", None),  # pfb_filter ON_OFF
     ("/pfblockerng/pfblockerng_general.php", "pfb_log_trim_margin_pct", None),  # is_array/ctype_digit
     # issue #1106: category_edit's own ingress guard (bypasses pfb_filter entirely).


### PR DESCRIPTION
## Summary

Consolidates the sequenced falsiness stack into one rebase-only PR, per the owner's consolidation authorization — three topics, per-topic commits:

**1. Fresh-config null-deprecation chokepoints (#1768, #1777)** — the six commits from PR #1774, unchanged in substance: stop fresh-config null deprecations at the filter/decode chokepoints, close the last two sites, silence fresh-config undefined-key/null-offset diagnostics, widen the IP ingress guard to every non-multi-select IP field (scoped to text fields, keeping the DNSBL page's own guards), and record the widget resolver-seed rationale.

**2. Honest string predicates + CI gate (#1787)** — the four commits from PR #1789, rebased over the merged #1795/#1797 sanitizer work: `pfb_is_empty()`/`pfb_is_blank()`, the Unicode `pfb_lstrip`/`pfb_rstrip`/`pfb_strip` family (ASCII fast path), self-stripping line classifiers, the `pfBlockerNG.emptyOnString` PHPStan rule, and the invalid-UTF-8 fail-open pins.

**3. The #1792 sweep** — new work on top:
- `pfb_csv_list()` / `pfb_b64_text()` chokepoints, then all 39 `?:` sites across six pages swept onto them. Fixed en route: the `pfb_pytlds_gtld`/`alexa_inclusion` defaults were **dead** (unreachable elvis arm — an empty scalar yielded `['']`, never the default); a stored textarea of literally `"0"` re-rendered **empty** through `base64_decode(...) ?: ''` (re-saving would erase it); a stat label / category translation / sinkhole request label of `'0'` read as absent. Every load-bearing empty→fallback (EN translation, "Unknown") is pinned surviving.
- The provably-dead `base64_encode(...) ?: ''` arms are deleted outright.
- **N1**: the `emptyOnString` rule now flags unions with a string member (`string|int` still lies about `'0'`); the 14 legacy hits are baseline-absorbed (net baseline shrink — entries the sweep fixed drop out).
- `pfb_dnsbl_is_abp_rule_line()`'s no-self-strip contract documented as deliberate (single scrubbed-input caller; the ADR-62 parity oracle pins the Python mirror row-for-row).

## Evidence

- Site-level red→green executed via the real evaled statements (`Issue1792SweepSitesTest` + `Issue1792SinkholeLabelTest`: 7 RED on the pre-sweep sites, GREEN after, test files byte-identical — `c7fa60a6`/`a828e3a9`/`cbdf7bc9`).
- Rule-widening red→green executed (`NoEmptyOnStringRuleTest`: union fixture RED, GREEN after — `007bd101`/`5b8c667f`).
- Live-box red→green for the www pairing (`test_dnsbl_zero_prefill_render.py`, Tier-A `ui_render`): RED on `origin/devel` (empty textarea), GREEN on this branch, file byte-identical (`a1acfc41`).
- Full local gate suite PASS (PHPUnit 4400+, PHPStan clean, PHPCS, pytest, ruff, mypy, shellspec, markdownlint).
- The #1774/#1789 commits carry their original executed proofs; their extractor tests' contracts updated where the sweep changed the pinned shapes (`[''] → []`, string→int stat counts).

Supersedes #1774 and #1789 (same commits, rebased/reconciled here).

Fixes #1768
Fixes #1777
Fixes #1787
Fixes #1792

🤖 Generated with [Claude Code](https://claude.com/claude-code)
