### PR TITLE
pfblockerng: gate the General→IP migration on operator data; copy with ?? (#1772)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -563,7 +563,11 @@ update_status(" General Tab -> IP Tab settings...");
 
 $pfb_gen_section  = PfbConfig::readSection('installedpackages/pfblockerng/config/0');
 $pfb_ip_section   = PfbConfig::readSection('installedpackages/pfblockerngipsettings/config/0');
-if (!empty($pfb_gen_section) && empty($pfb_ip_section)) {
+// issue #1772: gate on the OPERATOR view -- a marker-only General section (only
+// the installer's own settings_family, seeded before this region on every
+// install) is a genuinely fresh install; migrating it seeded 14 phantom blank
+// keys into the IP section. Same chokepoint as the #1770/#1771/#1775 reads.
+if (!empty(pfb_gconfig_operator_view($pfb_gen_section)) && empty($pfb_ip_section)) {
 
 	$pfb['gconfig'] = $pfb_gen_section;
 	$pfb['iconfig'] = $pfb_ip_section;
@@ -573,7 +577,10 @@ if (!empty($pfb_gen_section) && empty($pfb_ip_section)) {
 				'enable_float', 'pass_order', 'autorule_suffix', 'killstates' );
 
 	foreach ($settings as $setting) {
-		$pfb['iconfig'][$setting] = $pfb['gconfig'][$setting] ?: '';
+		// issue #1772: ?? -- an absent key copies as '' with no
+		// Undefined-array-key warning, and a stored '0' migrates as '0'
+		// (the empty('0') falsiness class, issues #1787/#1792).
+		$pfb['iconfig'][$setting] = $pfb['gconfig'][$setting] ?? '';
 		if (isset($pfb['gconfig'][$setting])) {
 			unset($pfb['gconfig'][$setting]);
 		}

--- a/tests/php/InstallGeneralToIpMigrationTest.php
+++ b/tests/php/InstallGeneralToIpMigrationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1772 — the installer's "General Tab -> IP Tab settings" migration
+ * (pfblockerng_install.inc) evaled verbatim, InstallGrandfatherChokepointTest's
+ * extraction idiom.
+ *
+ * On a genuinely fresh install the General section holds ONLY the installer's
+ * own `settings_family` schema marker (seeded by pfb_settings_family_replace()
+ * before this region runs). The `!empty($pfb_gen_section)` gate read that
+ * marker as "pre-existing config", fired the migration, and wrote 14
+ * blank-string keys into installedpackages/pfblockerngipsettings/config/0 —
+ * phantom "migrated" keys a truly fresh install never has (the #1770
+ * contamination class; gate must read the pfb_gconfig_operator_view()).
+ */
+#[CoversNothing]
+final class InstallGeneralToIpMigrationTest extends TestCase
+{
+	private ?array $savedConfig = null;
+
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_install_oracle_gen_to_ip_region')) {
+			return;
+		}
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc'
+		);
+		if ($src === false) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_install.inc');
+		}
+		// The migration region: from the General-section read through the
+		// closing brace of its else-arm.
+		if (!preg_match(
+			'/(\$pfb_gen_section  = PfbConfig::readSection\(\'installedpackages\/pfblockerng\/config\/0\'\);\n'
+			. '.*?'
+			. 'else \{\n\tupdate_status\(" no changes required \.\.\. done\.\\\\n"\);\n\}\n)/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('test bootstrap: General->IP migration region not found');
+		}
+		eval(
+			'function pfb_install_oracle_gen_to_ip_region(): void {'
+			. ' global $pfb;'
+			. $m[1]
+			. ' }'
+		);
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = $this->savedConfig;
+	}
+
+	private function seedGeneralSection(array $section): void
+	{
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerng' => [
+					'config' => [0 => $section],
+				],
+			],
+		];
+	}
+
+	private function ipSection(): array
+	{
+		return $GLOBALS['config']['installedpackages']['pfblockerngipsettings']['config'][0] ?? [];
+	}
+
+	public function testMarkerOnlyGeneralSectionDoesNotSeedIpKeys(): void
+	{
+		// Genuine fresh install: General holds ONLY the installer's marker.
+		$this->seedGeneralSection(['settings_family' => 'v4']);
+
+		pfb_install_oracle_gen_to_ip_region();
+
+		$this->assertSame([], $this->ipSection(),
+			'a marker-only General section is a FRESH install -- the migration must not seed '
+			. 'phantom blank keys into the IP section (issue #1772)');
+		$this->assertSame('v4',
+			$GLOBALS['config']['installedpackages']['pfblockerng']['config'][0]['settings_family'] ?? null,
+			'the installer marker itself must survive untouched');
+	}
+
+	public function testRealLegacyGeneralSettingsStillMigrate(): void
+	{
+		// Genuine v2-era config: operator data present -> migration must still
+		// fire, moving the value and leaving the marker in place.
+		$this->seedGeneralSection([
+			'settings_family' => 'v4',
+			'pass_order'      => 'order_1',
+			'enable_dup'      => 'on',
+		]);
+
+		pfb_install_oracle_gen_to_ip_region();
+
+		$ip = $this->ipSection();
+		$this->assertSame('order_1', $ip['pass_order'] ?? null,
+			'a real legacy General->IP setting must still migrate');
+		$this->assertSame('on', $ip['enable_dup'] ?? null);
+		$gen = $GLOBALS['config']['installedpackages']['pfblockerng']['config'][0];
+		$this->assertArrayNotHasKey('pass_order', $gen, 'migrated keys must leave the General section');
+		$this->assertSame('v4', $gen['settings_family'] ?? null,
+			'the installer marker must survive a real migration untouched');
+	}
+}

--- a/tests/php/InstallGeneralToIpMigrationZeroTest.php
+++ b/tests/php/InstallGeneralToIpMigrationZeroTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1772 companion — the migration body's per-key copy used
+ * `$pfb['gconfig'][$setting] ?: ''`, which (a) emits an Undefined-array-key
+ * warning for every key the legacy section does not hold and (b) migrates a
+ * stored '0' as '' (the empty('0') falsiness class, issue #1787/#1792).
+ * Same extraction oracle as InstallGeneralToIpMigrationTest.
+ */
+#[CoversNothing]
+final class InstallGeneralToIpMigrationZeroTest extends TestCase
+{
+	private ?array $savedConfig = null;
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/InstallGeneralToIpMigrationTest.php';
+		InstallGeneralToIpMigrationTest::setUpBeforeClass();
+	}
+
+	protected function setUp(): void
+	{
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = $this->savedConfig;
+	}
+
+	public function testZeroValuedLegacySettingMigratesAsZeroWithoutWarnings(): void
+	{
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerng' => [
+					'config' => [0 => [
+						'settings_family' => 'v4',
+						'killstates'      => '0',
+					]],
+				],
+			],
+		];
+
+		$warnings = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+			$warnings[] = $errstr;
+			return TRUE;
+		});
+		try {
+			pfb_install_oracle_gen_to_ip_region();
+		} finally {
+			restore_error_handler();
+		}
+
+		$ip = $GLOBALS['config']['installedpackages']['pfblockerngipsettings']['config'][0] ?? [];
+		$this->assertSame('0', $ip['killstates'] ?? null,
+			"a stored '0' is the operator's value -- it must migrate as '0', never collapse to ''");
+		$undefined = array_values(array_filter($warnings,
+			static fn (string $w): bool => str_contains($w, 'Undefined array key')));
+		$this->assertSame([], $undefined,
+			"the per-key copy must not emit Undefined-array-key warnings for keys the legacy section lacks, got:\n"
+			. implode("\n", $undefined));
+	}
+}


### PR DESCRIPTION
## Summary

- Gate the installer's "General Tab → IP Tab settings" migration on the **operator view** of the General section (`pfb_gconfig_operator_view()`, the #1770/#1771/#1775 chokepoint): a marker-only section — just the installer's own `settings_family`, seeded before this region on every install — is a genuinely fresh install, and the old `!empty($pfb_gen_section)` gate fired the migration on it, writing 14 phantom blank keys into `installedpackages/pfblockerngipsettings/config/0`.
- The per-key copy moves from `?:` to `??`: an absent key copies as `''` without an `Undefined array key` warning, and a stored `'0'` migrates as `'0'` instead of collapsing to `''` (the `empty('0')` falsiness class, #1787/#1792).

## Test plan

- [x] Red→green executed via the `InstallGrandfatherChokepointTest` extraction idiom (the real region evaled out of `pfblockerng_install.inc`):
  - marker-only cell RED (14 phantom keys + 14 warnings), GREEN after — `InstallGeneralToIpMigrationTest`, byte-identical (`e3e3f7de`).
  - `'0'`-migration/warning cell RED, GREEN after — `InstallGeneralToIpMigrationZeroTest`, byte-identical (`d25ad14c`).
  - Real legacy sections still migrate (value moved, key removed from General, marker intact) — pinned.
- [x] `./scripts/agent/run-gates.sh --diff origin/devel` PASS; rebased onto post-#1805 devel and re-run green.

Fixes #1772

🤖 Generated with [Claude Code](https://claude.com/claude-code)
