### PR TITLE
pfblockerng: CSV-quote the host fields in the alert details join (#1784)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15713,7 +15713,11 @@ function pfb_daemon_filterlog() {
 					// CR/LF normalized to spaces first) -- see ADR-38 Amendment 3. The raw
 					// $asn blob itself is untouched and still feeds the syslog asn= value
 					// below + the asncache.asn row.
-					$details	= "{$dir},{$geoip},{$pfb_alias},{$pfb_query[1]},{$pfb_query[0]},{$resolved_host},{$hostname}," . pfb_asn_csv_fields($asn);
+					// issue #1784: $resolved_host/$hostname carry admin-authored
+					// descr/hostname text (NAT rules, host aliases, static maps) --
+					// CSV-quote them at the join (pfb_csv_field, the #1369 contract
+					// every reader parses under) so a comma never shifts the row.
+					$details	= "{$dir},{$geoip},{$pfb_alias},{$pfb_query[1]},{$pfb_query[0]}," . pfb_csv_field($resolved_host) . ',' . pfb_csv_field($hostname) . ',' . pfb_asn_csv_fields($asn);
 
 					// Reverse Match text
 					if ($d[6] == 'match') {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2520,6 +2520,24 @@ function pfb_asn_csv_fields(string $blob): string
 }
 
 /**
+ * pfb_csv_field — one CSV field under the same issue-#1369 contract
+ * pfb_asn_csv_fields() writes (fputcsv semantics, explicit empty escape,
+ * CR/LF normalized to spaces): quoted ONLY when the value needs it, so
+ * well-formed values serialize byte-identically to the bare join they
+ * replace. issue #1784: admin-authored descr/hostname values reach the
+ * comma-joined alert $details line unfiltered; quoting at the join is the
+ * single guard (every reader is already fgetcsv-quote-aware).
+ */
+function pfb_csv_field(string $value): string
+{
+	$value = str_replace(["\r\n", "\r", "\n"], ' ', $value);
+	if (strpbrk($value, ",\"") === FALSE) {
+		return $value;
+	}
+	return '"' . str_replace('"', '""', $value) . '"';
+}
+
+/**
  * pfb_ip_log_row_schema_ok — exact field-count schema gate for a raw
  * (pre-timestamp-shift) IP feature-log row as delivered to convert_ip_log().
  * Only the current 23-field feature-row / 24-field Unified-row schema (see

--- a/tests/php/AlertDetailsCsvFieldTest.php
+++ b/tests/php/AlertDetailsCsvFieldTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1784 — the comma-joined IP alert `$details` line, evaled verbatim out
+ * of pfblockerng.inc (Issue1792SweepSiteLoader's line-scoped extractor).
+ *
+ * Admin-authored descr/hostname values (NAT rules, host aliases, DHCP static
+ * maps) reach `$hostname`/`$resolved_host` UNfiltered and were bare-joined
+ * into the CSV `$details` line — a comma in a description shifted every
+ * subsequent field for that row in the Alerts/Reports rendering and the
+ * ipcache table. Every reader of these logs is already quote-aware
+ * (`fgetcsv(..., ',', '"', '')`, the issue #1369 contract pfb_asn_csv_fields()
+ * writes under), so the fix is the same CSV quoting at the join — one guard
+ * instead of five producer filters.
+ */
+#[CoversNothing]
+final class AlertDetailsCsvFieldTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/Issue1792SweepSiteLoader.php';
+	}
+
+	/** Build the real $details line with the given host fields seeded. */
+	private function buildDetails(string $resolved_host, string $hostname): string
+	{
+		$out = pfb_test_1792_eval_site(
+			'src/usr/local/pkg/pfblockerng/pfblockerng.inc',
+			"\$details\t= \"{\$dir},{\$geoip}",
+			[
+				'dir'           => 'Inbound',
+				'geoip'         => 'US',
+				'pfb_alias'     => 'pfB_Test',
+				'pfb_query'     => ['TestFeed', '192.0.2.9'],
+				'resolved_host' => $resolved_host,
+				'hostname'      => $hostname,
+				'asn'           => 'asn: AS64500 | domain: example.net | name: Example AS',
+			]
+		);
+		return $out['details'];
+	}
+
+	/** Parse exactly like every log reader does (issue #1369 contract). */
+	private static function fields(string $line): array
+	{
+		return str_getcsv($line, ',', '"', '');
+	}
+
+	public function testCommaBearingHostnameDoesNotShiftFields(): void
+	{
+		$fields = self::fields($this->buildDetails('host.example.lan', 'Bob, den PC'));
+
+		$this->assertSame('host.example.lan', $fields[5], 'resolved-host field must stay in column 5');
+		$this->assertSame('Bob, den PC', $fields[6],
+			'a comma-bearing client hostname/descr must survive as ONE field, never shift the row (issue #1784)');
+		$this->assertSame('AS64500', $fields[7], 'the ASN column must still follow the hostname field');
+	}
+
+	public function testCommaBearingResolvedHostDoesNotShiftFields(): void
+	{
+		$fields = self::fields($this->buildDetails('weird, rdns', 'client-pc'));
+
+		$this->assertSame('weird, rdns', $fields[5]);
+		$this->assertSame('client-pc', $fields[6]);
+		$this->assertSame('AS64500', $fields[7]);
+	}
+
+	public function testPlainHostFieldsStayByteIdentical(): void
+	{
+		// The quoting guard must be invisible for well-formed values -- the
+		// existing on-disk format is pinned byte-identical.
+		$details = $this->buildDetails('host.example.lan', 'client-pc');
+		$this->assertStringStartsWith(
+			'Inbound,US,pfB_Test,192.0.2.9,TestFeed,host.example.lan,client-pc,',
+			$details,
+			'clean values must serialize unquoted -- no format change for existing rows'
+		);
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -1172,6 +1172,19 @@
             }
         ]
     },
+    "pfb_csv_field": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_csv_list": {
         "returnsRef": false,
         "returnType": "array",


### PR DESCRIPTION
## Summary

- Add `pfb_csv_field()` — one CSV field under the same issue-#1369 contract `pfb_asn_csv_fields()` writes (fputcsv semantics, empty escape, CR/LF→space), quoted **only** when the value needs it — and route `$resolved_host`/`$hostname` through it at the IP alert `$details` join.
- One guard at the join instead of five producer filters (the issue's preferred direction): every reader of these logs is already quote-aware (`fgetcsv(..., ',', '"', '')`, all five #1369 read sites), and clean values serialize byte-identically, so existing on-disk rows are format-unchanged (pinned).

## Test plan

- [x] Red→green executed over the REAL `$details` statement (evaled out of `pfblockerng.inc` via the `Issue1792SweepSiteLoader` line extractor): both comma-bearing cells (client hostname, resolved host) RED on the bare join — the row shifted and the ASN column misaligned — GREEN after, test file byte-identical (`git hash-object c249f400`).
- [x] Byte-identity control: a clean row's prefix serializes identically before and after (no format change).
- [x] `./scripts/agent/run-gates.sh --diff origin/devel` PASS (function inventory regenerated for the new helper).

Fixes #1784

🤖 Generated with [Claude Code](https://claude.com/claude-code)
