### PR TITLE
pfblockerng: reject IDNA2008 CONTEXTJ-forbidden joiners in the hostname filter

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1748,9 +1748,14 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			// PFB_FILTER_TLD -- a non-ASCII (IDN) hostname converts to its
 			// punycode candidate before is_hostname(); on success the ORIGINAL
 			// input is returned (the read path IDN-converts separately).
+			// issue #1807: run nontransitional UTS46 with CONTEXTJ checks so a
+			// joiner placement IDNA2008 forbids is rejected. IDNA_CHECK_CONTEXTJ
+			// alone is a no-op here: default (transitional) processing DELETES
+			// ZWJ/ZWNJ before the check runs, silently accepting the forbidden
+			// placement and returning the joiner-bearing original.
 			$candidate = $input;
 			if (preg_match('/[^\x00-\x7F]/', $input)) {
-				$candidate = idn_to_ascii($input);
+				$candidate = idn_to_ascii($input, IDNA_CHECK_CONTEXTJ | IDNA_NONTRANSITIONAL_TO_ASCII);
 				$candidate = empty($candidate) ? FALSE : $candidate;
 			}
 			if (($candidate !== FALSE) && is_hostname($candidate)) {

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -287,6 +287,59 @@ final class PfbFilterContractTest extends TestCase
 		$this->assertSame('', pfb_filter('', PFB_FILTER_HOSTNAME, 'PFBL-01 contract', ''));
 	}
 
+	// --- PFB_FILTER_HOSTNAME: IDNA2008 CONTEXTJ joiner placements (issue #1807) --
+	//
+	// The entry gate deliberately admits Cf format characters (issue #1723) on the
+	// premise that "domain-shaped fields still exclude them via their type-specific
+	// validation below". For the HOSTNAME branch that premise does not hold:
+	// idn_to_ascii() under default (transitional) UTS46 processing silently DELETES
+	// ZWJ/ZWNJ instead of checking them, so a CONTEXTJ-forbidden placement IDNA2008
+	// rejects is accepted and the joiner-bearing ORIGINAL input is returned and
+	// persisted. The filter must run nontransitional processing with CONTEXTJ
+	// checks (probed: IDNA_CHECK_CONTEXTJ alone is a no-op -- transitional mapping
+	// removes the joiners before the check ever sees them) and reject on failure.
+
+	/** @return array<string, array{0: string}> label => CONTEXTJ-forbidden joiner placement */
+	public static function hostnameContextjRejectedProvider(): array
+	{
+		return [
+			// A leading joiner has no preceding character to join -- forbidden in
+			// every IDNA2008 CONTEXTJ rule; no conformant resolver produces it.
+			'leading ZWJ'  => ["\u{200D}example.com"],
+			'leading ZWNJ' => ["\u{200C}example.com"],
+			// ZWNJ between two non-joining Latin letters: fails the CONTEXTJ
+			// regional rule (needs a virama before it, or joining-type context).
+			'ZWNJ between non-joining latin letters' => ["a\u{200C}b\u{00E4}.example"],
+		];
+	}
+
+	#[DataProvider('hostnameContextjRejectedProvider')]
+	public function testHostnameFilterRejectsContextjForbiddenJoiners(string $input): void
+	{
+		$this->assertSame('', pfb_filter($input, PFB_FILTER_HOSTNAME, 'PFBL-01 contract'));
+	}
+
+	/** @return array<string, array{0: string}> label => CONTEXTJ-valid or deviation input kept */
+	public static function hostnameContextjAcceptedProvider(): array
+	{
+		return [
+			// Persian "nameh-i": ZWNJ in a valid joining context (CONTEXTJ-valid) --
+			// rejecting joiners wholesale would break real IDN hostnames, so this
+			// pins that the CONTEXTJ check is placement-aware, not a blanket strip.
+			'CONTEXTJ-valid ZWNJ (Persian)' => ["\u{0646}\u{0627}\u{0645}\u{0647}\u{200C}\u{0627}\u{06CC}.example"],
+			// Eszett is a UTS46 deviation character: transitional maps it to 'ss',
+			// nontransitional keeps it. ACCEPTANCE must be stable across the flag
+			// change (the filter returns the ORIGINAL input either way).
+			'eszett deviation character' => ["stra\u{00DF}e.example"],
+		];
+	}
+
+	#[DataProvider('hostnameContextjAcceptedProvider')]
+	public function testHostnameFilterKeepsContextjValidJoiners(string $hostname): void
+	{
+		$this->assertSame($hostname, pfb_filter($hostname, PFB_FILTER_HOSTNAME, 'PFBL-01 contract'));
+	}
+
 	// --- PFB_FILTER_WORD (feed headers + friendly interface names) ---------------
 
 	/** @return array<string, array{0: string}> label => valid \w-only value returned unchanged */


### PR DESCRIPTION
`PFB_FILTER_HOSTNAME` converted non-ASCII input with `idn_to_ascii()` under default (transitional) UTS46 processing, which silently **deletes** ZWJ/ZWNJ instead of validating their placement — so a CONTEXTJ-forbidden placement IDNA2008 rejects was accepted, and the joiner-bearing original was returned and persisted.

**Note on the issue's fix shape:** adding `IDNA_CHECK_CONTEXTJ` alone is a no-op — transitional mapping removes the joiners before the check ever sees them. Executed probe on PHP 8.x intl:

```text
default        leading ZWJ    => 'example.com'          (joiner deleted, accepted)
ctxj           leading ZWJ    => 'example.com'          (no-op)
ctxj|nontrans  leading ZWJ    => false                  (rejected)
ctxj|nontrans  ZWNJ valid ctx => 'xn--mgba3gch31f060k.com' (CONTEXTJ-valid kept)
```

The fix pairs `IDNA_CHECK_CONTEXTJ | IDNA_NONTRANSITIONAL_TO_ASCII` in the HOSTNAME branch and rejects on failure. CONTEXTJ-valid placements (Persian ZWNJ) and deviation characters (`straße`, acceptance-stable) stay accepted; scope is the hostname filter only, per the issue.

## Red→green proof (test-first)

- Red: 3 new reject cases fail on untouched code (joiner-bearing originals accepted), 2 accept pins green. Test file frozen at `git hash-object` `ccc4d3df4fce3d785003d33b08749f5ba8312c33`.
- Green: same file byte-identical (hash re-verified), `phpunit --filter Contextj` → OK (5 tests), full PHP suite → OK (4451 tests; 1 pre-existing curl deprecation + 1 pre-existing curl notice at `pfblockerng.inc:12617`/`:12402`, unrelated).
- `scripts/agent/run-gates.sh` → exit 0.

Fixes #1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hostname validation for internationalized domain names.
  * Invalid zero-width joiner placements are now rejected correctly.
  * Valid joiner contexts and supported international characters continue to be preserved.

* **Tests**
  * Added coverage for valid and invalid IDNA2008 joiner usage in hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->