### PR TITLE
pfblockerng: decode unbound aux data files as explicit UTF-8; keep decode errors inside the watcher guards

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -333,7 +333,7 @@ def _reload_read_generation(sentinel_path: str) -> int | None:
     try:
         with open(sentinel_path, encoding="utf-8") as fh:
             line = fh.readline().strip()
-    except OSError:
+    except (OSError, ValueError):
         return None
     if not line:
         return None
@@ -502,7 +502,7 @@ def _build_swap_snapshot() -> Snapshot | None:
     if os.path.isfile(pfb["pfb_unbound.ini"]):
         config = ConfigParser()
         try:
-            config.read(pfb["pfb_unbound.ini"])
+            config.read(pfb["pfb_unbound.ini"], encoding="utf-8")
             r_count = 1
             for name, pattern in _load_user_regex_entries(config):
                 if _regex_is_catastrophic_shape(pattern):
@@ -539,7 +539,7 @@ def _build_swap_snapshot() -> Snapshot | None:
     hsts_db: dict[str, Any] = {}
     if pfb["python_hsts"] and os.path.isfile(pfb["pfb_py_hsts"]):
         try:
-            with open(pfb["pfb_py_hsts"]) as hsts:
+            with open(pfb["pfb_py_hsts"], encoding="utf-8", errors="replace") as hsts:
                 for line in hsts:
                     # match _dnsbl_load_tld_wildcard_master(): skip comment/whitespace-only lines; '0' stays a valid key
                     key = line.strip()
@@ -737,7 +737,7 @@ def _control_read_record(path: str) -> dict[str, Any] | None:
     try:
         with open(path, encoding="utf-8") as fh:
             raw = fh.read()
-    except OSError:
+    except (OSError, ValueError):
         return None
     if not raw.strip():
         return None
@@ -1044,7 +1044,7 @@ def _load_hsts_db() -> None:
         pfb_py_status_close("dnsbl", pfb["pfb_py_hsts"], "parse")
         return
     try:
-        with open(pfb["pfb_py_hsts"]) as hsts:
+        with open(pfb["pfb_py_hsts"], encoding="utf-8", errors="replace") as hsts:
             for line in hsts:
                 # match _dnsbl_load_tld_wildcard_master(): skip comment/whitespace-only lines; '0' stays a valid key
                 key = line.strip()
@@ -1102,7 +1102,7 @@ def _load_ini_config() -> ConfigParser | None:
         return None
     config = ConfigParser()
     try:
-        config.read(pfb["pfb_unbound.ini"])
+        config.read(pfb["pfb_unbound.ini"], encoding="utf-8")
         pfb_py_status_close("dnsbl", pfb["pfb_unbound.ini"], "parse")
     except Exception as e:
         sys.stderr.write("[pfBlockerNG]: Failed to load ini configuration: {}".format(e))
@@ -6593,7 +6593,7 @@ def _load_safesearch_db() -> None:
     """
     if os.path.isfile(pfb["pfb_py_ss"]):
         try:
-            with open(pfb["pfb_py_ss"]) as csv_file:
+            with open(pfb["pfb_py_ss"], encoding="utf-8", errors="replace") as csv_file:
                 csv_reader = csv.reader(csv_file, delimiter=",")
                 for row in csv_reader:
                     # 3 cols: domain,A,AAAA (A/AAAA rewrite or nxdomain).

--- a/tests/test_issue1813_unbound_aux_reader_encoding.py
+++ b/tests/test_issue1813_unbound_aux_reader_encoding.py
@@ -1,0 +1,249 @@
+"""issue #1813 (Front 2 of #1808): every file pfb_unbound.py reads at runtime must
+decode as explicit UTF-8 with a defined failure mode, never depend on the process
+locale.
+
+Covers: the two HSTS preload loaders (_build_swap_snapshot's inline block -- site A --
+and _load_hsts_db -- site B), the SafeSearch CSV loader (_load_safesearch_db), both
+ConfigParser.read() call sites (the inline user-regex block in _build_swap_snapshot and
+_load_ini_config), and the two watcher readers (_reload_read_generation,
+_control_read_record) whose narrow ``except OSError:`` must widen to
+``except (OSError, ValueError):`` -- a UnicodeDecodeError IS a ValueError and currently
+escapes past their "best-effort, never raise" contract.
+
+Small fixtures (well under one text-I/O read buffer) decode the WHOLE file in one shot
+before yielding any line, so a bad byte anywhere aborts the parse with ZERO lines seen.
+A bad byte needs to sit past the first buffer refill (~thousands of short lines in) to
+actually reproduce a genuine *partial*-dict failure -- hence the large fixtures below.
+"""
+
+from __future__ import annotations
+
+from configparser import ConfigParser
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+import pfb_unbound
+
+_BAD_BYTE = b"\xff"  # never valid as a UTF-8 start/continuation byte.
+_MULTIBYTE_DOMAIN = "bücher.example"  # 'bücher.example' -- must survive unmangled.
+
+
+def _big_valid_prefix(n: int) -> bytes:
+    return "".join("valid{}.example\n".format(i) for i in range(n)).encode("utf-8")
+
+
+# --------------------------------------------------------------------------------- #
+# HSTS loaders: site A = _build_swap_snapshot's inline block, site B = _load_hsts_db.
+# --------------------------------------------------------------------------------- #
+
+
+def _load_hsts_site_b(hsts_path: Path) -> dict[str, Any]:
+    pfb_unbound.pfb["python_hsts"] = True
+    pfb_unbound.pfb["pfb_py_hsts"] = str(hsts_path)
+    pfb_unbound.pfb["pfb_py_status"] = str(hsts_path.parent / "pfb_py_status.json")
+    pfb_unbound._load_hsts_db()
+    return dict(pfb_unbound.hstsDB)
+
+
+def _load_hsts_site_a(hsts_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, Any]:
+    stub_result = pfb_unbound.BuildResult(data_db={}, zone_db={}, feed_group_index_db={}, white_db={}, counts=0)
+    monkeypatch.setattr(pfb_unbound, "dnsbl_build_from_manifest", lambda _path: stub_result)
+    pfb_unbound.pfb["pfb_py_sources"] = str(tmp_path / "unused_manifest.json")
+    pfb_unbound.pfb["pfb_unbound.ini"] = str(tmp_path / "no_such.ini")
+    pfb_unbound.pfb["python_hsts"] = True
+    pfb_unbound.pfb["pfb_py_hsts"] = str(hsts_path)
+    snap = pfb_unbound._build_swap_snapshot()
+    assert snap is not None, "stubbed manifest build must not itself fail the swap"
+    return dict(snap.hsts_db)
+
+
+_HstsLoader = Callable[[Path, pytest.MonkeyPatch, Path], dict[str, Any]]
+_HSTS_SITES: list[tuple[str, _HstsLoader]] = [
+    ("site_a_build_swap_snapshot", lambda p, mp, tp: _load_hsts_site_a(p, mp, tp)),
+    ("site_b_load_hsts_db", lambda p, mp, tp: _load_hsts_site_b(p)),
+]
+
+
+@pytest.mark.parametrize("site_name,loader", _HSTS_SITES, ids=[s[0] for s in _HSTS_SITES])
+def test_hsts_loader_invalid_byte_mid_file_replaces_not_partial(
+    site_name: str,
+    loader: _HstsLoader,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bad byte past the first read buffer must not truncate the load: lines before
+    AND after it end up in the dict, the bad byte itself surfaces as U+FFFD, and a
+    valid multibyte domain right after it survives unmangled."""
+    hsts_path = tmp_path / "pfb_py_hsts.txt"
+    body = _big_valid_prefix(2000) + _BAD_BYTE + b"badline.example\n" + _MULTIBYTE_DOMAIN.encode("utf-8") + b"\n"
+    hsts_path.write_bytes(body)
+
+    keys = set(loader(hsts_path, monkeypatch, tmp_path))
+
+    assert "valid0.example" in keys, "{}: lines before the bad byte must load".format(site_name)
+    assert "valid1999.example" in keys, "{}: lines after the bad byte's buffer must still load".format(site_name)
+    assert "�badline.example" in keys, "{}: the bad byte must surface as U+FFFD, not abort".format(site_name)
+    assert _MULTIBYTE_DOMAIN in keys, "{}: valid multibyte UTF-8 must survive unmangled".format(site_name)
+
+
+@pytest.mark.parametrize("site_name,loader", _HSTS_SITES, ids=[s[0] for s in _HSTS_SITES])
+def test_hsts_loader_invalid_byte_on_first_line(
+    site_name: str,
+    loader: _HstsLoader,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hsts_path = tmp_path / "pfb_py_hsts.txt"
+    hsts_path.write_bytes(_BAD_BYTE + b"firstline.example\nsecond.example\n")
+
+    keys = set(loader(hsts_path, monkeypatch, tmp_path))
+
+    assert "�firstline.example" in keys, "{}: got {}".format(site_name, keys)
+    assert "second.example" in keys, "{}: got {}".format(site_name, keys)
+
+
+def test_load_hsts_db_ready_flag_set_after_invalid_byte(tmp_path: Path) -> None:
+    """site B's pfb['hstsDB'] readiness flag only flips True once the for-loop
+    completes -- with a bad byte it must still complete (replace, not abort)."""
+    hsts_path = tmp_path / "pfb_py_hsts.txt"
+    hsts_path.write_bytes(_BAD_BYTE + b"only.example\n")
+    pfb_unbound.pfb["python_hsts"] = True
+    pfb_unbound.pfb["pfb_py_hsts"] = str(hsts_path)
+    pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+    pfb_unbound._load_hsts_db()
+
+    assert pfb_unbound.pfb["hstsDB"] is True
+
+
+# --------------------------------------------------------------------------------- #
+# SafeSearch loader (_load_safesearch_db).
+# --------------------------------------------------------------------------------- #
+
+
+def _big_valid_ss_prefix(n: int) -> bytes:
+    return "".join("valid{}.example,1.2.3.4,::1\n".format(i) for i in range(n)).encode("utf-8")
+
+
+def test_safesearch_loader_invalid_byte_mid_file_replaces_not_partial(tmp_path: Path) -> None:
+    ss_path = tmp_path / "pfb_py_ss.txt"
+    body = (
+        _big_valid_ss_prefix(2000)
+        + _BAD_BYTE
+        + "badrow.example,1.2.3.4,::1\n".encode("utf-8")
+        + "{},5.6.7.8,::2\n".format(_MULTIBYTE_DOMAIN).encode("utf-8")
+    )
+    ss_path.write_bytes(body)
+    pfb_unbound.pfb["pfb_py_ss"] = str(ss_path)
+    pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+    pfb_unbound._load_safesearch_db()
+
+    db = pfb_unbound.safeSearchDB
+    assert db["valid0.example"] == {"A": "1.2.3.4", "AAAA": "::1"}, "lines before the bad byte must load"
+    assert db["valid1999.example"] == {"A": "1.2.3.4", "AAAA": "::1"}, "lines past the bad byte's buffer must load"
+    assert db["�badrow.example"] == {"A": "1.2.3.4", "AAAA": "::1"}, "the bad byte must surface as U+FFFD"
+    assert db[_MULTIBYTE_DOMAIN] == {"A": "5.6.7.8", "AAAA": "::2"}, "valid multibyte UTF-8 must survive unmangled"
+
+
+def test_safesearch_loader_invalid_byte_on_first_line(tmp_path: Path) -> None:
+    ss_path = tmp_path / "pfb_py_ss.txt"
+    ss_path.write_bytes(_BAD_BYTE + b"firstrow.example,1.2.3.4,::1\nsecond.example,5.6.7.8,::2\n")
+    pfb_unbound.pfb["pfb_py_ss"] = str(ss_path)
+    pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+    pfb_unbound._load_safesearch_db()
+
+    db = pfb_unbound.safeSearchDB
+    assert db["�firstrow.example"] == {"A": "1.2.3.4", "AAAA": "::1"}
+    assert db["second.example"] == {"A": "5.6.7.8", "AAAA": "::2"}
+
+
+def test_safesearch_load_ready_flag_set_after_invalid_byte(tmp_path: Path) -> None:
+    ss_path = tmp_path / "pfb_py_ss.txt"
+    ss_path.write_bytes(_BAD_BYTE + b"only.example,1.2.3.4,::1\n")
+    pfb_unbound.pfb["pfb_py_ss"] = str(ss_path)
+    pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+
+    pfb_unbound._load_safesearch_db()
+
+    assert pfb_unbound.pfb["safeSearchDB"] is True
+
+
+# --------------------------------------------------------------------------------- #
+# ConfigParser.read() sites: the ini file gates through the SAME broad except at both
+# call sites already, so a decode failure's fallback is already exercised by that
+# broad except (mirrors the SafeSearch/HSTS mechanism above). What's new here is only
+# that the read is deterministic (pinned utf-8) regardless of process locale -- proven
+# by asserting the actual encoding= kwarg .read() is invoked with.
+# --------------------------------------------------------------------------------- #
+
+
+def _drive_ini_site_load_ini_config(ini_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pfb_unbound.pfb["pfb_unbound.ini"] = str(ini_path)
+    pfb_unbound.pfb["pfb_py_status"] = str(tmp_path / "pfb_py_status.json")
+    pfb_unbound._load_ini_config()
+
+
+def _drive_ini_site_build_swap_snapshot(ini_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    stub_result = pfb_unbound.BuildResult(data_db={}, zone_db={}, feed_group_index_db={}, white_db={}, counts=0)
+    monkeypatch.setattr(pfb_unbound, "dnsbl_build_from_manifest", lambda _path: stub_result)
+    pfb_unbound.pfb["pfb_py_sources"] = str(tmp_path / "unused_manifest.json")
+    pfb_unbound.pfb["pfb_unbound.ini"] = str(ini_path)
+    pfb_unbound.pfb["python_hsts"] = False
+    snap = pfb_unbound._build_swap_snapshot()
+    assert snap is not None, "stubbed manifest build must not itself fail the swap"
+
+
+_IniDriver = Callable[[Path, pytest.MonkeyPatch, Path], None]
+_INI_SITES: list[tuple[str, _IniDriver]] = [
+    ("site_load_ini_config", _drive_ini_site_load_ini_config),
+    ("site_build_swap_snapshot_user_regex", _drive_ini_site_build_swap_snapshot),
+]
+
+
+@pytest.mark.parametrize("site_name,driver", _INI_SITES, ids=[s[0] for s in _INI_SITES])
+def test_ini_configparser_read_called_with_explicit_utf8_encoding(
+    site_name: str,
+    driver: _IniDriver,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ini_path = tmp_path / "pfb_unbound.ini"
+    ini_path.write_text("[MAIN]\n", encoding="utf-8")
+
+    calls: list[Any] = []
+    orig_read = ConfigParser.read
+
+    def _spy_read(self: ConfigParser, filenames: Any, encoding: Any = None) -> Any:
+        calls.append(encoding)
+        return orig_read(self, filenames, encoding=encoding)
+
+    monkeypatch.setattr(ConfigParser, "read", _spy_read)
+
+    driver(ini_path, monkeypatch, tmp_path)
+
+    assert calls, "{}: ConfigParser.read() must have been called".format(site_name)
+    assert calls[-1] == "utf-8", "{}: expected encoding='utf-8', got {!r}".format(site_name, calls[-1])
+
+
+# --------------------------------------------------------------------------------- #
+# Watcher readers: except OSError: currently lets a UnicodeDecodeError (a ValueError)
+# escape past the "absent/unreadable -> None" best-effort contract.
+# --------------------------------------------------------------------------------- #
+
+
+def test_reload_read_generation_invalid_utf8_byte_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / "sentinel"
+    p.write_bytes(_BAD_BYTE + b"42\n")
+
+    assert pfb_unbound._reload_read_generation(str(p)) is None
+
+
+def test_control_read_record_invalid_utf8_byte_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / "ctl"
+    p.write_bytes(_BAD_BYTE + b'{"seq": 1, "cmd": "enable"}\n')
+
+    assert pfb_unbound._control_read_record(str(p)) is None


### PR DESCRIPTION
Front 2 slice of #1808 (scoping in its comment thread).

Three `pfb_unbound.py` readers — both HSTS loaders, the SafeSearch loader — opened their files with the locale default encoding, and both `ConfigParser.read()` sites likewise; an invalid-UTF-8 byte mid-file raised mid-loop and left partially-populated state (e.g. `hstsDB` filled but the ready flag unset). The sentinel/control watcher reads decode strict UTF-8 but caught only `OSError`, so a `UnicodeDecodeError` escaped the watcher guards and killed the thread.

Fix: explicit `encoding="utf-8", errors="replace"` on the three data-file readers (matching the feed-reader convention at the `_dnsbl_file_line_reader` site), `encoding="utf-8"` on both `ConfigParser.read()` calls, and `except (OSError, ValueError)` on the sentinel/control reads. TOP1M/manifest/feed readers deliberately untouched — their strict/replace semantics are pinned (#1542).

## Red→green proof (test-first)

- 12 new tests (`tests/test_issue1813_unbound_aux_reader_encoding.py`) executed RED on untouched code — each failing for its exact expected reason (partial dict, ready-flag unset, `UnicodeDecodeError` escaping, missing `encoding=` kwarg). Red-time hash `0dc825b8…`; a post-green `ruff format` reflow (cosmetic line-wrap) moved the committed hash to `98f4cfd8…` — the independent verifier re-executed the full proof on the committed bytes: `FREEZE-OK / RED-OK / GREEN-OK / VERDICT: PASS` via `verify-red-proof.sh`, plus a manual per-test revert run (12/12 individually red).
- Full suite: 3607 passed, 4 skipped. `run-gates.sh --diff origin/devel`: all PASS.
- Independent small-tier verifier gate record: PASS, no findings (diff audited hunk-by-hunk: exactly the 7 claimed edits; TextIOWrapper chunk-decode fixture rationale probed and confirmed).

Fixes #1813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
