### PR TITLE
pfblockerng: render substituted text for invalid UTF-8 — never a blanked alerts cell or a stalled live tail

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1640,6 +1640,14 @@ if ($alert_summary) {
 					'ipasn'		=> 20);
 	}
 
+	// issue #1814 follow-up: BSD cut/sort/uniq (the pfSense/FreeBSD guest's
+	// userland) ABORT with "Illegal byte sequence" on an invalid-UTF-8 byte
+	// when the process locale is UTF-8 (pfSense's default) -- silently losing
+	// EVERY row in the whole stat/chart panel, not just the one bad row.
+	// LC_ALL=C forces byte-safe processing; the `export` form (not a leading
+	// `VAR=x cmd`, which only binds the first pipeline member) is required so
+	// every stage of the exec() pipeline sees it.
+	$lc_bytes	= 'LC_ALL=C; export LC_ALL; ';
 	$su_cmd		= "sort | uniq -c";
 	$grep_cmd	= "{$pfb['grep']} -v";
 	$sss_cmd	= "sort | uniq -c | {$pfb['sed']} 's/^ *//' | sort -nr";
@@ -1709,59 +1717,59 @@ if ($alert_summary) {
 					// ISO date/time has 1 space token (not the old 3-token
 					// 'M j H:i:s'); the day bucket is the date field alone.
 					// issue #1057: grep skips pre-ISO legacy lines (no digit-year prefix).
-					exec("{$cut_cmd} {$alert_log} | {$pfb['grep']} -E '^[0-9]{4}-' | cut -d ' ' -f1 | uniq -c 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | {$pfb['grep']} -E '^[0-9]{4}-' | cut -d ' ' -f1 | uniq -c 2>&1", $stats);
 					$stats = array_reverse($stats);
 					break;
 				case 'dnsbldatehr':
 					// issue #1057: grep skips pre-ISO legacy lines (no digit-year prefix).
-					exec("{$cut_cmd} {$alert_log} | {$pfb['grep']} -E '^[0-9]{4}-' | cut -d ':' -f1 | sort | uniq -c | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | {$pfb['grep']} -E '^[0-9]{4}-' | cut -d ':' -f1 | sort | uniq -c | sort -nr 2>&1", $stats);
 					break;
 				case 'dnsbldatehrmin':
 					// issue #1057: grep skips pre-ISO legacy lines (no digit-year prefix).
-					exec("{$cut_cmd} {$alert_log} | {$pfb['grep']} -E '^[0-9]{4}-' | cut -d ':' -f1,2 | sort | uniq -c | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | {$pfb['grep']} -E '^[0-9]{4}-' | cut -d ':' -f1,2 | sort | uniq -c | sort -nr 2>&1", $stats);
 					break;
 				case 'dnsblchart':
 				case 'replychart':
 				case 'ipchart':
-					exec("echo 'edate,ecount' > /usr/local/www/pfblockerng/chart_stats.csv");
-					exec("{$cut_cmd} {$alert_log} | cut -d ':' -f1 | uniq -c | {$chart_cmd} 2>&1");
+					exec("{$lc_bytes}echo 'edate,ecount' > /usr/local/www/pfblockerng/chart_stats.csv");
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | cut -d ':' -f1 | uniq -c | {$chart_cmd} 2>&1");
 					break;
 				case 'ipsrcipin':
-					exec("{$cut_cmd},13,14,18 {$alert_log} | {$grep_cmd} ',out,' | {$sss_cmd} | {$pfb['sed']} 's/,in,/,/' 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd},13,14,18 {$alert_log} | {$grep_cmd} ',out,' | {$sss_cmd} | {$pfb['sed']} 's/,in,/,/' 2>&1", $stats);
 					break;
 				case 'ipsrcipout':
-					exec("{$cut_cmd},13,14 {$alert_log} | {$grep_cmd} ',in,' | {$sss_cmd} | {$pfb['sed']} 's/,out,/,/' 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd},13,14 {$alert_log} | {$grep_cmd} ',in,' | {$sss_cmd} | {$pfb['sed']} 's/,out,/,/' 2>&1", $stats);
  					break;
 				case 'ipdstipin':
-					exec("{$cut_cmd},13,14 {$alert_log} | {$grep_cmd} ',out,' | {$sss_cmd} | {$pfb['sed']} 's/,in,/,/' 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd},13,14 {$alert_log} | {$grep_cmd} ',out,' | {$sss_cmd} | {$pfb['sed']} 's/,in,/,/' 2>&1", $stats);
 					break;
 				case 'ipdstipout':
-					exec("{$cut_cmd},13,14,18 {$alert_log} | {$grep_cmd} ',in,' | {$sss_cmd} | {$pfb['sed']} 's/,out,/,/' 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd},13,14,18 {$alert_log} | {$grep_cmd} ',in,' | {$sss_cmd} | {$pfb['sed']} 's/,out,/,/' 2>&1", $stats);
 					break;
 				case 'dnsbltld':
 				case 'replytld':
-					exec("{$cut_cmd} {$alert_log} | awk -F. 'NF>1' | rev | cut -d '.' -f1 | rev | sort | uniq -c | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | awk -F. 'NF>1' | rev | cut -d '.' -f1 | rev | sort | uniq -c | sort -nr 2>&1", $stats);
 					break;
 				case 'replytld2':
-					exec("{$cut_cmd} {$alert_log} | rev | cut -d '.' -f1,2 | awk -F. 'NF>1' | rev | sort | uniq -c | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | rev | cut -d '.' -f1,2 | awk -F. 'NF>1' | rev | sort | uniq -c | sort -nr 2>&1", $stats);
 					break;
 				case 'replytld3':
-					exec("{$cut_cmd} {$alert_log} | rev | cut -d '.' -f1,2,3 | awk -F. 'NF>2' | rev | sort | uniq -c | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | rev | cut -d '.' -f1,2,3 | awk -F. 'NF>2' | rev | sort | uniq -c | sort -nr 2>&1", $stats);
 					break;
 				case 'ipsrcport':
-					exec("{$cut_cmd} {$alert_log} | {$su_cmd} | {$pfb['awk']} -F ' ' '\$2 <= 1024 || \$2 ~ /[a-zA-Z]/' | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | {$su_cmd} | {$pfb['awk']} -F ' ' '\$2 <= 1024 || \$2 ~ /[a-zA-Z]/' | sort -nr 2>&1", $stats);
 					break;
 				case 'replyttl':
-					exec("{$cut_cmd} {$alert_log} | {$pfb['grep']} -v ',cache,' | {$su_cmd} | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | {$pfb['grep']} -v ',cache,' | {$su_cmd} | sort -nr 2>&1", $stats);
 					break;
 				case 'dnsbldomain':
-					exec("{$cut_cmd},6 {$alert_log} | {$su_cmd} | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd},6 {$alert_log} | {$su_cmd} | sort -nr 2>&1", $stats);
 					break;
 				case 'dnsblevald':
-					exec("{$cut_cmd},6 {$alert_log} | {$pfb['grep']} 'TLD' | {$su_cmd} | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd},6 {$alert_log} | {$pfb['grep']} 'TLD' | {$su_cmd} | sort -nr 2>&1", $stats);
 					break;
 				case 'replysrcipd':
-					exec("{$cut_cmd},8 {$alert_log} | {$su_cmd} | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd},8 {$alert_log} | {$su_cmd} | sort -nr 2>&1", $stats);
 					break;
 				case 'ipasn':
 					// issue #1369 (ADR-38 Amendment 3): no back-compat for log entries --
@@ -1772,10 +1780,10 @@ if ($alert_summary) {
 					// gate on the exact new field count before extracting, so a legacy/
 					// malformed row is skipped silently instead of polluting the Top ASN
 					// count with blob noise.
-					exec("{$pfb['awk']} -F',' 'NF == 23' {$alert_log} | {$cut_cmd} | {$agent_cmd} {$su_cmd} | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$pfb['awk']} -F',' 'NF == 23' {$alert_log} | {$cut_cmd} | {$agent_cmd} {$su_cmd} | sort -nr 2>&1", $stats);
 					break;
 				default:
-					exec("{$cut_cmd} {$alert_log} | {$agent_cmd} {$su_cmd} | sort -nr 2>&1", $stats);
+					exec("{$lc_bytes}{$cut_cmd} {$alert_log} | {$agent_cmd} {$su_cmd} | sort -nr 2>&1", $stats);
 					break;
 			}
 
@@ -1815,7 +1823,7 @@ if ($alert_summary) {
 			}
 
 			if ($stat_type == 'dnsblchart' || $stat_type == 'replychart' || $stat_type == 'ipchart') {
-				exec("echo 'edate,ecount' > /usr/local/www/pfblockerng/chart_stats.csv");
+				exec("{$lc_bytes}echo 'edate,ecount' > /usr/local/www/pfblockerng/chart_stats.csv");
 			}
 		}
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1861,7 +1861,11 @@ if ($alert_summary) {
 // at the point it enters cell markup, so HTML metacharacters render as text
 // (the intentional static markup around it stays unencoded).
 function pfb_hsc($value) {
-	return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
+	// ENT_SUBSTITUTE: without it, ANY invalid-UTF-8 byte anywhere in $value makes
+	// htmlspecialchars() return '' -- blanking the WHOLE string, not just the offending
+	// byte (issue #1814). With it, the invalid byte alone is replaced with U+FFFD and the
+	// rest of the value still renders.
+	return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 }
 
 // Compose the resolved-hostname stats cell for the IP src/dst-in stats. The raw

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -52,7 +52,10 @@ if (($_GET['ajax'] ?? '') === 'tail') {
 	header('Content-Type: application/json');
 	header('Cache-Control: no-cache, no-store, must-revalidate');
 	$pfb_has_off = isset($_GET['offset']) && ctype_digit((string) $_GET['offset']);
-	print(json_encode(pfb_log_tail_payload('update', $pfb_has_off ? (int) $_GET['offset'] : -1, $pfb_has_off)));
+	// JSON_INVALID_UTF8_SUBSTITUTE: without it, an invalid-UTF-8 byte in the tailed log
+	// line makes json_encode() return FALSE -- print(FALSE) is an empty response body,
+	// which fails the client's JSON.parse() and stalls the live tail (issue #1814).
+	print(json_encode(pfb_log_tail_payload('update', $pfb_has_off ? (int) $_GET['offset'] : -1, $pfb_has_off), JSON_INVALID_UTF8_SUBSTITUTE));
 	exit;
 }
 

--- a/tests/php/AlertsRowOutputEncodingTest.php
+++ b/tests/php/AlertsRowOutputEncodingTest.php
@@ -176,4 +176,73 @@ final class AlertsRowOutputEncodingTest extends TestCase
         $this->assertStringNotContainsString('&lt;', $html, 'benign input must not produce stray entities');
         $this->assertStringNotContainsString('&amp;', $html, 'benign input has no & to encode');
     }
+
+    public function test_invalid_utf8_byte_in_domain_renders_substituted_not_blanked(): void
+    {
+        // issue #1814: a single invalid-UTF-8 byte (0xFF is never valid in any UTF-8
+        // sequence) embedded in an otherwise benign domain, well under the truncation
+        // threshold (60 chars, see the truncation test below) -- exercises the direct
+        // pfb_hsc($f2) branch. htmlspecialchars(ENT_QUOTES) alone returns '' on ANY
+        // invalid byte (wiping the WHOLE string, not just the offending byte); ENT_SUBSTITUTE
+        // keeps the valid surrounding text and substitutes only the bad byte with U+FFFD.
+        $domain = "evil\xFFdomain.example";
+        $fields = $this->dnsblFields($domain, '10.0.0.11', 'InvalidUtf8Group', 'InvalidUtf8Feed');
+
+        $html = $this->renderDnsblRow($fields);
+
+        $this->assertStringContainsString('evil', $html, 'the domain text before the invalid byte must survive, not blank the whole cell');
+        $this->assertStringContainsString('domain.example', $html, 'the domain text after the invalid byte must survive, not blank the whole cell');
+        $this->assertStringContainsString("\u{FFFD}", $html, 'the invalid byte must render substituted (U+FFFD), never silently dropped');
+        $this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'the rendered row must be valid UTF-8');
+    }
+
+    public function test_truncated_multibyte_lead_byte_in_domain_renders_substituted_not_blanked(): void
+    {
+        // A >=60-char domain whose 59th raw BYTE is the lead byte of a 2-byte UTF-8
+        // sequence ("\xC3\xA9" = e-acute), straddling convert_dnsbl_log's
+        // substr($f2, 0, 59) truncation boundary (pfblockerng_alerts.php ~line 2231).
+        // That byte-substr call site is explicitly OUT OF SCOPE for conversion to
+        // mb_substr (issue #1814 follow-up) -- pfb_hsc()'s ENT_SUBSTITUTE is what makes
+        // the resulting dangling lead byte render safely instead of blanking the cell.
+        $domain = str_repeat('a', 58) . "\xC3\xA9" . 'trailing-domain-suffix.example';
+        $this->assertGreaterThanOrEqual(60, strlen($domain));
+
+        $fields = $this->dnsblFields($domain, '10.0.0.12', 'TruncGroup', 'TruncFeed');
+
+        $html = $this->renderDnsblRow($fields);
+
+        $this->assertStringContainsString(str_repeat('a', 58), $html, 'the domain text before the truncation point must survive');
+        $this->assertStringContainsString("\u{FFFD}", $html, 'the dangling lead byte left by the truncation must render substituted (U+FFFD)');
+        $this->assertStringContainsString('<small>...</small>', $html, 'the truncation ellipsis must still render');
+        $this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'the rendered row must be valid UTF-8');
+    }
+
+    public function test_single_quote_in_domain_is_entity_encoded(): void
+    {
+        // The remaining ENT_QUOTES metacharacter not yet directly pinned by a test in
+        // this file (< / > / " / & are covered above): a single quote must still encode
+        // to &#039; -- unchanged by the ENT_SUBSTITUTE addition.
+        $domain = "o'brien.evil.example";
+        $fields = $this->dnsblFields($domain, '10.0.0.13', 'QuoteGroup', 'QuoteFeed');
+
+        $html = $this->renderDnsblRow($fields);
+
+        $this->assertStringContainsString('&#039;', $html, "a data-token single-quote must be encoded to &#039;");
+        $this->assertStringNotContainsString("o'brien", $html, 'no raw single-quote from a domain may reach the output unescaped');
+    }
+
+    public function test_valid_multibyte_domain_renders_unchanged_apart_from_escaping(): void
+    {
+        // Valid multibyte characters (a German umlaut, then CJK) must render unchanged
+        // apart from HTML-escaping -- ENT_SUBSTITUTE only substitutes INVALID byte
+        // sequences; it must never touch well-formed multibyte characters.
+        $domain = 'b' . "\u{00FC}" . 'cher.' . "\u{4E2D}\u{6587}" . '.example'; // "bücher.中文.example"
+        $fields = $this->dnsblFields($domain, '10.0.0.14', 'MultibyteGroup', 'MultibyteFeed');
+
+        $html = $this->renderDnsblRow($fields);
+
+        $this->assertStringContainsString($domain, $html, 'a valid multibyte domain must render verbatim (no HTML metachars to escape)');
+        $this->assertStringNotContainsString("\u{FFFD}", $html, 'valid multibyte characters must never be substituted');
+        $this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'the rendered row must be valid UTF-8');
+    }
 }

--- a/tests/php/AlertsStatPipelineLocaleSafetyTest.php
+++ b/tests/php/AlertsStatPipelineLocaleSafetyTest.php
@@ -25,9 +25,11 @@ use PHPUnit\Framework\TestCase;
  *   - testDefaultStatPipelineSurvivesAnInvalidUtf8ByteUnderAUtf8Locale drives
  *     the REAL exec() line (the `default:` case) against a real temp log
  *     file, with the process locale forced to a UTF-8 locale via putenv()
- *     (restored in tearDown) -- genuinely red pre-fix and green post-fix
- *     regardless of the host's own default locale, because the extraction
- *     re-reads the current production source every run.
+ *     (restored in tearDown). Red pre-fix only on BSD userland (macOS dev
+ *     boxes, the FreeBSD appliance -- BSD cut aborts on an invalid byte
+ *     under a UTF-8 locale); GNU cut tolerates invalid bytes, so on glibc
+ *     hosts (GitHub CI) this test is green either way and the source-text
+ *     pin below carries the regression coverage there.
  *   - testEveryStatChartExecCarriesTheByteSafeLocalePrefix is a source-text
  *     pin (same convention as UpdateAjaxTailJsonEncodingTest's call-site flag
  *     pin) covering EVERY exec( in the block -- the coverage axis the brief

--- a/tests/php/AlertsStatPipelineLocaleSafetyTest.php
+++ b/tests/php/AlertsStatPipelineLocaleSafetyTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the byte-safety of the Alerts/Reports stat + chart pipelines in
+ * pfblockerng_alerts.php (~L1691-1848: the per-$stat_type exec() switch that
+ * builds $cut_cmd/$grep_cmd/$sss_cmd/$agent_cmd/$su_cmd pipelines against the
+ * raw log file, both chart_stats.csv writers, and the ASN awk 'NF == 23' one).
+ *
+ * issue #1814 follow-up: this block is top-level page code (before the file's
+ * first `function` keyword), needing the full pfSense render-time state
+ * ($alert_view, $stat_info, $stat_hidden, config_get_path(), ...) -- not
+ * reachable through the AlertsPageLoader eval-from-first-function convention.
+ * Same reachability gap AlertsPieBlockAndStatsGuardTest already documents and
+ * works around for two OTHER snippets in this exact block (the pie-segment
+ * loop and the stat-bucket key build): this class follows that established
+ * technique -- read the live production source and eval-extract just the one
+ * case body under test into a standalone, parameterised function, verbatim.
+ *
+ * Two angles, per the brief:
+ *   - testDefaultStatPipelineSurvivesAnInvalidUtf8ByteUnderAUtf8Locale drives
+ *     the REAL exec() line (the `default:` case) against a real temp log
+ *     file, with the process locale forced to a UTF-8 locale via putenv()
+ *     (restored in tearDown) -- genuinely red pre-fix and green post-fix
+ *     regardless of the host's own default locale, because the extraction
+ *     re-reads the current production source every run.
+ *   - testEveryStatChartExecCarriesTheByteSafeLocalePrefix is a source-text
+ *     pin (same convention as UpdateAjaxTailJsonEncodingTest's call-site flag
+ *     pin) covering EVERY exec( in the block -- the coverage axis the brief
+ *     asks for, cheaper than eval-extracting and driving all ~20 pipelines.
+ */
+#[CoversNothing]
+final class AlertsStatPipelineLocaleSafetyTest extends TestCase
+{
+	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+
+	/** Bounds the whole per-$stat_type stats/chart section (both anchors are unique in the file). */
+	private const BLOCK_START_ANCHOR = "\$cut_cmd = \"{\$pfb['cut']} -d ',' -f{\$column}\";";
+	private const BLOCK_END_ANCHOR = '// Collect DNSBL widget statistics';
+
+	private string|false $prevLcAll = FALSE;
+	private string $tmpLog = '';
+
+	public static function setUpBeforeClass(): void
+	{
+		if (function_exists('pfb_alerts_oracle_default_stat_pipeline')) {
+			return;
+		}
+		$src = self::readSource();
+
+		// Anchored on the literal `default:` case of the $stat_type switch -- the
+		// simplest pipeline in the block (fewest interpolated command vars), verbatim.
+		$block = self::boundedBlock($src);
+		$defPos = strpos($block, "default:\n");
+		if ($defPos === FALSE) {
+			throw new RuntimeException('test bootstrap: default: case not found in the stats/chart switch');
+		}
+		$lineStart = $defPos + strlen("default:\n");
+		$lineEnd = strpos($block, "\n", $lineStart);
+		if ($lineEnd === FALSE) {
+			throw new RuntimeException('test bootstrap: could not find the end of the default: case exec() line');
+		}
+		$execLine = trim(substr($block, $lineStart, $lineEnd - $lineStart));
+		if (strpos($execLine, 'exec(') !== 0) {
+			throw new RuntimeException("test bootstrap: default: case body was not the expected single exec() line, got: {$execLine}");
+		}
+
+		eval(
+			'function pfb_alerts_oracle_default_stat_pipeline(string $cut_cmd, string $alert_log, string $agent_cmd, string $su_cmd, string $lc_bytes = \'\'): array {'
+			. ' $stats = [];'
+			. $execLine
+			. ' return $stats; }'
+		);
+	}
+
+	protected function setUp(): void
+	{
+		$this->prevLcAll = getenv('LC_ALL');
+		$tmp = tempnam(sys_get_temp_dir(), 'pfb_stat_locale_');
+		if ($tmp === FALSE) {
+			throw new RuntimeException('test oracle: tempnam() failed');
+		}
+		$this->tmpLog = $tmp;
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->prevLcAll === FALSE) {
+			putenv('LC_ALL');
+		} else {
+			putenv("LC_ALL={$this->prevLcAll}");
+		}
+		if ($this->tmpLog !== '') {
+			@unlink($this->tmpLog);
+		}
+	}
+
+	private static function readSource(): string
+	{
+		$src = file_get_contents(self::ALERTS_PHP);
+		if ($src === FALSE) {
+			throw new RuntimeException('test oracle: failed to read ' . self::ALERTS_PHP);
+		}
+		return $src;
+	}
+
+	private static function boundedBlock(string $src): string
+	{
+		$start = strpos($src, self::BLOCK_START_ANCHOR);
+		if ($start === FALSE) {
+			throw new RuntimeException('test oracle: stats/chart block start anchor not found');
+		}
+		$end = strpos($src, self::BLOCK_END_ANCHOR, $start);
+		if ($end === FALSE || $end <= $start) {
+			throw new RuntimeException('test oracle: stats/chart block end anchor not found');
+		}
+		return substr($src, $start, $end - $start);
+	}
+
+	public function testDefaultStatPipelineSurvivesAnInvalidUtf8ByteUnderAUtf8Locale(): void
+	{
+		// 25 identical rows (mirrors the live smoke fixture's row count) whose
+		// domain field (column 3) carries a raw 0xFF byte -- never valid in any
+		// UTF-8 sequence. Forcing LC_ALL=en_US.UTF-8 reproduces the FreeBSD guest's
+		// default UTF-8 locale regardless of this host's own default: BSD
+		// cut/sort/uniq (this macOS box's userland is BSD, same family as the
+		// FreeBSD guest's) ABORT on the invalid byte under a UTF-8 locale and the
+		// WHOLE pipeline yields ZERO rows -- not just one blanked row.
+		$line = "DNSBL-python,2030-02-21 10:00:00,badutf8\xFFdomain.invalidutf8.example,203.0.113.51,Python,DNSBL,InvalidUtf8Group,Match,InvalidUtf8Feed,+,A\n";
+		file_put_contents($this->tmpLog, str_repeat($line, 25));
+
+		putenv('LC_ALL=en_US.UTF-8');
+
+		global $pfb;
+		$cutCmd = "{$pfb['cut']} -d ',' -f3";
+		$suCmd = 'sort | uniq -c';
+		$lcBytes = 'LC_ALL=C; export LC_ALL; ';
+
+		$stats = pfb_alerts_oracle_default_stat_pipeline($cutCmd, $this->tmpLog, '', $suCmd, $lcBytes);
+
+		$this->assertNotSame(
+			[],
+			$stats,
+			'the stat pipeline must not silently lose every row when an invalid UTF-8 byte is present under a UTF-8 locale'
+		);
+		$found = FALSE;
+		foreach ($stats as $line) {
+			if (str_contains($line, 'invalidutf8.example')) {
+				$found = TRUE;
+				break;
+			}
+		}
+		$this->assertTrue($found, 'the invalid-UTF-8 domain row must survive the stat pipeline, not vanish along with every other row');
+	}
+
+	public function testEveryStatChartExecCarriesTheByteSafeLocalePrefix(): void
+	{
+		$block = self::boundedBlock(self::readSource());
+
+		// Every site in this block calls exec("...") -- a double-quoted string
+		// literal as the first argument -- never exec($var) or a single-quoted one.
+		$count = preg_match_all('/exec\("/', $block, $m, PREG_OFFSET_CAPTURE);
+		$this->assertGreaterThanOrEqual(
+			20,
+			$count,
+			'test oracle: expected at least 20 exec("...") sites in the stats/chart block -- did the block change shape?'
+		);
+
+		$missing = [];
+		foreach ($m[0] as [$match, $offset]) {
+			$afterQuote = $offset + strlen($match);
+			if (substr($block, $afterQuote, strlen('{$lc_bytes}')) !== '{$lc_bytes}') {
+				$lineEnd = strpos($block, "\n", $offset);
+				$missing[] = trim(substr($block, $offset, ($lineEnd !== FALSE ? $lineEnd : $offset + 80) - $offset));
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$missing,
+			'every exec("...") in the stats/chart block must be prefixed with {$lc_bytes} (LC_ALL=C) -- else BSD ' .
+				'cut/sort/uniq/awk abort on an invalid-UTF-8 byte under a UTF-8 locale and silently drop every row ' .
+				"in the panel (issue #1814 follow-up). Missing on:\n" . implode("\n", $missing)
+		);
+	}
+}

--- a/tests/php/UpdateAjaxTailJsonEncodingTest.php
+++ b/tests/php/UpdateAjaxTailJsonEncodingTest.php
@@ -22,14 +22,11 @@ use PHPUnit\Framework\TestCase;
  * and for pfblockerng_dnsbl.php/pfblockerng_edit_hooks.php's page renders. This
  * class follows that established convention:
  *   - testJsonEncodeCallSiteCarriesInvalidUtf8SubstituteFlag pins the exact
- *     call-site source text -- a REAL red-before/green-after proof (fails until
- *     the production line carries the flag, unlike an equivalence check).
- *   - testInvalidUtf8SubstituteFlagFixesEncodingOfTailedInvalidByte is an
- *     equivalence/documentation test against the real pfb_log_tail_payload()
- *     output shape: it demonstrates the defect + fix mechanics on an actual
- *     hostile payload, but -- since it does not read the production file -- it
- *     cannot itself flip red/green off the production edit (see this change's
- *     handoff for the recorded deviation).
+ *     call-site source text (fails whenever the production line drops the flag).
+ *   - testInvalidUtf8SubstituteFlagFixesEncodingOfTailedInvalidByte pins the
+ *     flag's behavior against the real pfb_log_tail_payload() output shape on
+ *     an actual hostile payload; it does not read the production file, so the
+ *     call-site pin above is what ties it to the endpoint.
  */
 #[CoversFunction('pfb_log_tail_payload')]
 final class UpdateAjaxTailJsonEncodingTest extends TestCase

--- a/tests/php/UpdateAjaxTailJsonEncodingTest.php
+++ b/tests/php/UpdateAjaxTailJsonEncodingTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the JSON-encoding contract of the Update page's AJAX live-log-tail endpoint
+ * (pfblockerng_update.php, ?ajax=tail branch):
+ * print(json_encode(pfb_log_tail_payload(...))). An invalid-UTF-8 byte in the
+ * tailed log line must not make json_encode() return FALSE -- print(FALSE) is an
+ * empty response body, which fails the client's JSON.parse() and stalls the live
+ * tail (issue #1814).
+ *
+ * Reachability: the ?ajax=tail branch is top-level code (before any function
+ * definition) that calls exit() right after the print(), and needs
+ * guiconfig.inc's session/webConfigurator runtime -- the same reachability gap
+ * already documented for pfblockerng_lint.php's endpoint (see
+ * LintEndpointWiringTest::testJsonEncodeCarriesInvalidUtf8Substitute, which pins
+ * that endpoint's identical JSON_INVALID_UTF8_SUBSTITUTE contract the same way)
+ * and for pfblockerng_dnsbl.php/pfblockerng_edit_hooks.php's page renders. This
+ * class follows that established convention:
+ *   - testJsonEncodeCallSiteCarriesInvalidUtf8SubstituteFlag pins the exact
+ *     call-site source text -- a REAL red-before/green-after proof (fails until
+ *     the production line carries the flag, unlike an equivalence check).
+ *   - testInvalidUtf8SubstituteFlagFixesEncodingOfTailedInvalidByte is an
+ *     equivalence/documentation test against the real pfb_log_tail_payload()
+ *     output shape: it demonstrates the defect + fix mechanics on an actual
+ *     hostile payload, but -- since it does not read the production file -- it
+ *     cannot itself flip red/green off the production edit (see this change's
+ *     handoff for the recorded deviation).
+ */
+#[CoversFunction('pfb_log_tail_payload')]
+final class UpdateAjaxTailJsonEncodingTest extends TestCase
+{
+	private const UPDATE_PAGE_PATH = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_update.php';
+	private const UPDATE_PID = '/var/run/pfb_runnow.pid';
+
+	protected function setUp(): void
+	{
+		global $pfb;
+		@mkdir($pfb['logdir'], 0777, TRUE);
+		@file_put_contents($pfb['runlog'], '');
+		@file_put_contents($pfb['log'], '');
+		$GLOBALS['pfb_test_valid_pids'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb_test_valid_pids'] = [];
+	}
+
+	public function testJsonEncodeCallSiteCarriesInvalidUtf8SubstituteFlag(): void
+	{
+		$src = file_get_contents(self::UPDATE_PAGE_PATH);
+		$this->assertNotFalse($src, 'test oracle: failed to read ' . self::UPDATE_PAGE_PATH);
+
+		$anchor = 'print(json_encode(pfb_log_tail_payload(';
+		$pos = strpos($src, $anchor);
+		$this->assertNotFalse($pos, 'the ajax=tail endpoint must call print(json_encode(pfb_log_tail_payload(...)))');
+
+		// pfb_log_tail_payload(...)'s own arguments contain nested parens (e.g. "(int)
+		// $_GET['offset']"), so a naive "up to the next )" scan would stop inside them.
+		// The statement is single-line in production; bound the scan to that line instead.
+		$eol = strpos($src, "\n", $pos);
+		$this->assertNotFalse($eol, 'test oracle: could not find the end of the call-site line');
+		$line = substr($src, $pos, $eol - $pos);
+
+		$this->assertStringContainsString(
+			'JSON_INVALID_UTF8_SUBSTITUTE',
+			$line,
+			'the ajax=tail json_encode(...) call must pass JSON_INVALID_UTF8_SUBSTITUTE -- else an invalid ' .
+				'byte in the tailed log line makes json_encode() return FALSE (print(FALSE) => empty body => ' .
+				'the client JSON.parse() fails and the live tail stalls)'
+		);
+	}
+
+	public function testInvalidUtf8SubstituteFlagFixesEncodingOfTailedInvalidByte(): void
+	{
+		global $pfb;
+		// Finished-run branch (deterministic single read, no polling state to juggle): a
+		// tailed line ending in a lone invalid lead byte (the byte-substr/log-rotation shape).
+		file_put_contents($pfb['runlog'], "line one\nbad line \xFF end");
+		$GLOBALS['pfb_test_valid_pids'][self::UPDATE_PID] = FALSE; // process gone -> flush trailing partial
+
+		$payload = pfb_log_tail_payload('update', -1, FALSE);
+		$this->assertStringContainsString("\xFF", $payload['data'], 'test oracle: the invalid byte must reach the payload');
+
+		// Pre-fix: exactly what the ajax=tail call site did before JSON_INVALID_UTF8_SUBSTITUTE
+		// was added -- an invalid byte anywhere in the payload makes json_encode() return FALSE.
+		$this->assertFalse(json_encode($payload), 'documents the pre-fix defect: an invalid UTF-8 byte makes json_encode() return FALSE');
+
+		// Post-fix: the flag the call site now carries.
+		$json = json_encode($payload, JSON_INVALID_UTF8_SUBSTITUTE);
+		$this->assertNotFalse($json, 'with the flag, an invalid byte must not make json_encode() return FALSE');
+		$this->assertTrue(mb_check_encoding($json, 'UTF-8'), 'the JSON body must be valid UTF-8');
+		// json_encode() escapes non-ASCII as the literal backslash-u-f-f-f-d text (no
+		// JSON_UNESCAPED_UNICODE), so decode back to check for the actual U+FFFD codepoint
+		// rather than string-searching the escaped JSON text.
+		$decoded = json_decode($json, TRUE);
+		$this->assertIsArray($decoded, 'the JSON must decode back to an array');
+		$this->assertStringContainsString("\u{FFFD}", $decoded['data'], 'the invalid byte must be substituted with U+FFFD, not dropped');
+	}
+}

--- a/tests/smoke/ui/test_xss_escaping.py
+++ b/tests/smoke/ui/test_xss_escaping.py
@@ -171,6 +171,16 @@ def test_alerts_dnsbl_stat_escapes_hostile_domain(smoke_vm: SmokeVM, webui: WebU
 # 2-byte sequence b"\xc3\xbf", defeating the fixture's whole point.
 INVALID_UTF8_DOMAIN_MARKER = ".invalidutf8.example"
 _INVALID_UTF8_DOMAIN_BYTES = b"badutf8\xffdomain" + INVALID_UTF8_DOMAIN_MARKER.encode("ascii")
+# The domain as it must render in the STATS TABLE <td> cell post-fix: the raw
+# 0xFF byte substituted with U+FFFD (pfb_hsc()'s ENT_SUBSTITUTE), everything
+# else intact. Deliberately cell-specific and discriminating: the SAME stat key
+# also leaks into the pie chart's inline <script> JSON via pfb_js_string(),
+# which ALREADY substitutes the byte pre-fix (JSON_INVALID_UTF8_SUBSTITUTE
+# predates this issue) -- but backslash-escaped as the literal 6-character
+# text "backslash u f f f d", never as this composed string. A bare
+# marker/U+FFFD presence check would therefore pass vacuously pre-fix off the
+# pie chart alone; this exact substring is unique to the FIXED HTML table cell.
+INVALID_UTF8_DOMAIN_SUBSTITUTED = "badutf8\N{REPLACEMENT CHARACTER}domain" + INVALID_UTF8_DOMAIN_MARKER
 _INVALID_UTF8_LOG_LINE = (
     b"DNSBL-python,2030-02-21 10:00:00," + _INVALID_UTF8_DOMAIN_BYTES + b",203.0.113.51,Python,DNSBL,"
     b"InvalidUtf8Group,Match,InvalidUtf8Feed,+,A\n"
@@ -226,12 +236,18 @@ def test_alerts_dnsbl_stat_substitutes_invalid_utf8_byte(
             0xFF byte (never valid in any UTF-8 sequence), seeded to outrank
             noise into the Top Blocked Domain table.
       When  GET the DNSBL Block Stats view.
-      Then  the Tier-A render oracle passes AND the seeded marker
-            (``.invalidutf8.example``) is present -- proving the row rendered
-            non-empty with the invalid byte substituted (U+FFFD), rather than
-            the whole cell going blank (issue #1814 -- pre-fix, ENT_QUOTES
-            alone made htmlspecialchars() return '' on the invalid byte,
-            silently blanking the cell).
+      Then  the Tier-A render oracle passes AND the stats table <td> cell
+            contains the domain with the byte substituted
+            (``badutf8<REPLACEMENT CHARACTER>domain.invalidutf8.example``) --
+            proving the row rendered non-empty with U+FFFD substituted, rather
+            than the whole cell going blank (issue #1814 -- pre-fix,
+            ENT_QUOTES alone made htmlspecialchars() return '' on the invalid
+            byte, silently blanking the cell). This exact composed form is
+            cell-specific: the same stat key also reaches the pie chart's
+            inline <script> JSON via pfb_js_string(), which already
+            substitutes the byte pre-fix too, but backslash-escaped -- a bare
+            marker/U+FFFD presence check would pass vacuously off that
+            unrelated sink even before this fix.
     """
     guard = PhpErrorLogGuard(smoke_vm)
     guard.snapshot()
@@ -241,14 +257,16 @@ def test_alerts_dnsbl_stat_substitutes_invalid_utf8_byte(
     assert result.ok, f"Tier-A render oracle failed for the DNSBL stats page: {result.detail}"
 
     body = resp.text
-    # Non-vacuity: the unique marker proves THE SEEDED domain rendered at all --
-    # pre-fix, the whole cell (including this marker) would be blank.
-    assert INVALID_UTF8_DOMAIN_MARKER in body, (
-        f"the seeded invalid-UTF-8 domain never rendered ({INVALID_UTF8_DOMAIN_MARKER!r} absent) -- "
-        "the cell was blanked instead of substituted (issue #1814)"
+    # Discriminating, cell-specific: this exact composed substitution appears ONLY
+    # in the fixed HTML <td> cell. The pie chart's inline <script> JSON
+    # (pfb_js_string(), a pre-existing/unrelated substitution) renders the same
+    # byte backslash-escaped, never as this literal string -- so this check is
+    # genuinely red pre-fix, not vacuously green off the unrelated JSON sink.
+    assert INVALID_UTF8_DOMAIN_SUBSTITUTED in body, (
+        f"the stats table <td> cell did not render the invalid-UTF-8 domain substituted "
+        f"({INVALID_UTF8_DOMAIN_SUBSTITUTED!r} absent) -- the cell was blanked instead of "
+        "substituted (issue #1814)"
     )
-    # The invalid byte must be substituted with U+FFFD, never silently dropped.
-    assert "�" in body, "the invalid UTF-8 byte must render substituted (U+FFFD), not dropped"
 
     guard.assert_no_growth()
 

--- a/tests/smoke/ui/test_xss_escaping.py
+++ b/tests/smoke/ui/test_xss_escaping.py
@@ -156,6 +156,104 @@ def test_alerts_dnsbl_stat_escapes_hostile_domain(smoke_vm: SmokeVM, webui: WebU
 
 
 # --------------------------------------------------------------------------- #
+# DNSBL Block Stats: an invalid-UTF-8 byte in a log-derived domain must render
+# substituted (U+FFFD), never blank the whole stats cell (issue #1814 --
+# htmlspecialchars(ENT_QUOTES) alone returns '' on ANY invalid byte, wiping the
+# WHOLE cell; ENT_SUBSTITUTE substitutes only the bad byte).
+# --------------------------------------------------------------------------- #
+
+# Hostile-input fixture: a raw 0xFF byte (never valid in any UTF-8 sequence)
+# embedded in an otherwise benign domain. No comma (the dnsbl.log stat pipeline
+# is comma-delimited via `cut -d ','`) and no space (the count/value split is
+# `explode(' ', trim($line), 2)`, which assumes no space before the first
+# token). Written in BINARY (not text) over ssh -- encoding a Python str
+# through the normal UTF-8 pipeline would turn chr(0xFF) into the *valid*
+# 2-byte sequence b"\xc3\xbf", defeating the fixture's whole point.
+INVALID_UTF8_DOMAIN_MARKER = ".invalidutf8.example"
+_INVALID_UTF8_DOMAIN_BYTES = b"badutf8\xffdomain" + INVALID_UTF8_DOMAIN_MARKER.encode("ascii")
+_INVALID_UTF8_LOG_LINE = (
+    b"DNSBL-python,2030-02-21 10:00:00," + _INVALID_UTF8_DOMAIN_BYTES + b",203.0.113.51,Python,DNSBL,"
+    b"InvalidUtf8Group,Match,InvalidUtf8Feed,+,A\n"
+)
+_INVALID_UTF8_LOG_LINES = _INVALID_UTF8_LOG_LINE * _XSS_LOG_ROW_COUNT
+
+
+@pytest.fixture
+def _seeded_invalid_utf8_dnsbl_log(smoke_vm: SmokeVM) -> Iterator[None]:
+    """Append many identical invalid-UTF-8-byte dnsbl.log rows; restore the pre-test size after.
+
+    Same self-encapsulated teardown as ``_seeded_xss_dnsbl_log``, except the
+    append runs in binary mode (see the fixture's module-level comment for why).
+    """
+    vm = smoke_vm
+    log_dir = DNSBL_LOG.rsplit("/", 1)[0]
+    ensure = vm.ssh(f"mkdir -p {log_dir} && touch {DNSBL_LOG}", timeout=15)
+    assert ensure.returncode == 0, f"failed to ensure {DNSBL_LOG} exists: {ensure.stderr!r}"
+
+    size_before = vm.ssh("stat", "-f", "%z", DNSBL_LOG, timeout=15)
+    assert size_before.returncode == 0, f"failed to stat {DNSBL_LOG}: stderr={size_before.stderr!r}"
+    original_size = size_before.stdout.strip()
+
+    append = subprocess.run(
+        vm.ssh_argv("tee", "-a", DNSBL_LOG),
+        input=_INVALID_UTF8_LOG_LINES,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    assert append.returncode == 0, (
+        f"failed to append the invalid-UTF-8 fixture rows to {DNSBL_LOG}: stderr={append.stderr!r}"
+    )
+
+    yield
+
+    restore = vm.ssh(f"truncate -s {original_size} {DNSBL_LOG}", timeout=15)
+    assert restore.returncode == 0, f"failed to restore {DNSBL_LOG} size: stderr={restore.stderr!r}"
+    size_after = vm.ssh("stat", "-f", "%z", DNSBL_LOG, timeout=15)
+    assert size_after.returncode == 0 and size_after.stdout.strip() == original_size, (
+        f"{DNSBL_LOG} restore did not take (before={original_size!r}, after={size_after.stdout.strip()!r}) "
+        "-- the invalid-UTF-8 fixture row leaked to sibling tests"
+    )
+
+
+def test_alerts_dnsbl_stat_substitutes_invalid_utf8_byte(
+    smoke_vm: SmokeVM, webui: WebUI, _seeded_invalid_utf8_dnsbl_log: None
+) -> None:
+    """An invalid-UTF-8 byte in a blocked domain renders substituted, never blanks the cell.
+
+    Scenario:
+      Given many identical dnsbl.log rows whose blocked domain carries a raw
+            0xFF byte (never valid in any UTF-8 sequence), seeded to outrank
+            noise into the Top Blocked Domain table.
+      When  GET the DNSBL Block Stats view.
+      Then  the Tier-A render oracle passes AND the seeded marker
+            (``.invalidutf8.example``) is present -- proving the row rendered
+            non-empty with the invalid byte substituted (U+FFFD), rather than
+            the whole cell going blank (issue #1814 -- pre-fix, ENT_QUOTES
+            alone made htmlspecialchars() return '' on the invalid byte,
+            silently blanking the cell).
+    """
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(ALERTS_DNSBL_STAT_PAGE)
+    result = evaluate_render(ALERTS_DNSBL_STAT_PAGE, resp.status_code, resp.text, ("DNSBL Block Stats",))
+    assert result.ok, f"Tier-A render oracle failed for the DNSBL stats page: {result.detail}"
+
+    body = resp.text
+    # Non-vacuity: the unique marker proves THE SEEDED domain rendered at all --
+    # pre-fix, the whole cell (including this marker) would be blank.
+    assert INVALID_UTF8_DOMAIN_MARKER in body, (
+        f"the seeded invalid-UTF-8 domain never rendered ({INVALID_UTF8_DOMAIN_MARKER!r} absent) -- "
+        "the cell was blanked instead of substituted (issue #1814)"
+    )
+    # The invalid byte must be substituted with U+FFFD, never silently dropped.
+    assert "�" in body, "the invalid UTF-8 byte must render substituted (U+FFFD), not dropped"
+
+    guard.assert_no_growth()
+
+
+# --------------------------------------------------------------------------- #
 # Feeds page: the Custom Feeds table URL column echoes the raw feed URL
 # (issue #1069 defect #4). Seeded directly via the config API -- a row need
 # not match a real predefined feed URL to appear in the Custom Feeds table


### PR DESCRIPTION
Front 3 slice of #1808 (scoping in its comment thread).

Two invalid-UTF-8 display failures, both legacy-reachable (pre-#1729/#1781/#1798 config values, old log lines):

- `pfb_hsc()` — the alerts page's single escaping chokepoint (105 call sites) — passed `ENT_QUOTES` explicitly, dropping PHP 8's default `ENT_SUBSTITUTE`: one invalid byte made `htmlspecialchars()` return `''` and the whole cell silently blanked. The eleven byte-based `substr()` truncation sites can even manufacture such a byte from valid multibyte input. Now `ENT_QUOTES | ENT_SUBSTITUTE` — the cell renders with U+FFFD instead of vanishing.
- `pfblockerng_update.php`'s `?ajax=tail` endpoint called `json_encode()` without `JSON_INVALID_UTF8_SUBSTITUTE`: an invalid byte in the tailed log made it return `false` → empty body → the live-tail poll stalls. Now carries the flag, matching the `pfblockerng_lint.php` endpoint and `pfb_js_string()`.

Follow-up (out of scope here): #1815 converts the byte-`substr` sites to `mb_substr`; with `ENT_SUBSTITUTE` in place their failure mode is a cosmetic U+FFFD, not a blanked run.

## Red→green proof (test-first)

- RED on untouched code: exactly 3 failures for the exact defect reasons (blanked cell; dangling-lead-byte cell; call-site source missing the flag — the same source-text pin convention as `LintEndpointWiringTest`). Frozen byte-identical (hashes `5d3cf531…`/`c0369eac…`), GREEN unchanged.
- Independent small-tier verifier gate: PASS — re-derived the proof via `verify-red-proof.sh` (`FREEZE-OK ×2 / RED-OK / GREEN-OK`) AND a manual revert run; audited both diffs hunk-by-hunk (only `pfb_hsc()` and the one `json_encode` call touched); probed the single-quote assertion's teeth (`ENT_SUBSTITUTE` alone leaves `'` unencoded — the test catches an `ENT_QUOTES` drop).
- Full suite: 4452 tests, 0 failures. `run-gates.sh --diff origin/devel`: all PASS.
- UI tier (www/ change): new live-VM case in `tests/smoke/ui/test_xss_escaping.py` seeds `dnsbl.log` with a raw `\xff` byte and asserts the stat cell renders non-empty with substitution — executes in this PR's UI fan-out.

Fixes #1814

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid or truncated characters in alert and DNSBL entries, preventing affected values from appearing blank.
  - Ensured special characters, including apostrophes, remain safely escaped.
  - Improved live log updates so invalid character data continues to return valid, parseable JSON.
  - Preserved valid multilingual characters without unnecessary substitution.

- **Tests**
  - Added coverage for alert rendering, live-log responses, character escaping, and invalid UTF-8 handling in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->