### PR TITLE
matrix: retire arch, add extra_pkgs (issue #1806)

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -5,7 +5,8 @@
     "add": "Add an entry when a new pfSense beta or GA lands (curated — a human edits this file). Set status='beta' until the release is GA.",
     "drop_ce": "Drop the oldest CE entry only when the newest CE goes GA. The supported window is always (previous GA CE + current GA CE), transiently +1 during an active beta.",
     "plus": "Plus runs in CI from a PRIVATE, licensed GHCR image (ghcr.io/pfblockerng/pfsense-plus). To enable: set ci=true + image_name=pfsense-plus. The VM identity (NIC MAC + SMBIOS uuid, which the Netgate Device ID is keyed to) comes from the SMOKE_PLUS_MAC + SMOKE_PLUS_SMBIOS_UUID repo secrets, NEVER this matrix; the smoke harness redacts that identity from the uploaded diagnostics. Image refresh covers CE AND Plus (image-refresh.yml is a CE+Plus matrix gated per variant on upgrade.available); scripts/image-publish.sh remains the manual fallback (gate failure, or the initial Plus image seed) (ADR-24).",
-    "arm": "ARM (aarch64) is Plus-only (Netgate ARM appliances; pfSense CE is amd64-only). Add an entry with arch='aarch64' to produce a FreeBSD:<major>:aarch64 .pkg alongside the amd64 build (the build keys on (freebsd_major, arch)). There is no aarch64 CI image yet, so an aarch64 entry MUST be build-only (ci=false); promote to ci=true only once a licensed aarch64 Plus smoke image is baked (issue #199).",
+    "arm": "RETIRED (issue #1806): there is no `arch` field any more. Every pfSense-pkg-pfBlockerNG port is NO_ARCH, so one wildcard-ABI .pkg build already serves every CPU arch (incl. aarch64) of a FreeBSD major — a separate ARM entry/build was never actually needed. Netgate ARM appliances run pfSense Plus on the SAME freebsd_major as its amd64 build; no matrix change is required to support them.",
+    "extra_pkgs": "Optional array of port origins (e.g. [\"textproc/py-charset-normalizer\"]) this entry's edition needs that its OWN upstream pkg repo does not carry (issue #1806 — e.g. Netgate builds some py3xx-* ports for Plus only). scripts/build-dep-pkg-portable.py builds each as a NO_ARCH .pkg straight from the FreeBSD-ports port definition; build-repo-portable.py --dep-pkgs folds the result into the release/nightly catalogs of every entry sharing that freebsd_major. Omit or [] when the edition's own repo already carries everything.",
     "eol_route_only": "ADR-27 Part 2: when a pfSense version is EOL'd but still has installs in the field, set role='route-only' (instead of dropping the entry) + ci=false + last_tag=<the GitHub Release tag holding its last .pkg>. It is then no longer built or smoked, but its last .pkg stays served from a frozen catalog so existing installs keep receiving it; the reader keeps it out of --print-build/-ci/-test and only in --print-route. Absent role = 'build' (normal). No route-only entry exists yet — this is forward-looking.",
     "image_upgrade": "Set upgrade.available=true on an entry to make image-refresh.yml (Upgrade pfSense smoke images) upgrade that variant's published GHCR image. 'available' does NOT mean 'this version is released' — it means a NEWER public build (pre-release/GA/patch) exists than the image we currently publish for this floating tag; set it when such a build appears and reset to false once the refresh has published it (so most days the refresh is a no-op). Optional sub-fields: upgrade.branch = a pfSense update-branch name (from pkg_list_repos()) to switch to for a pre-release/development build (omit = stay on the configured stable branch); upgrade.target = informational target version; upgrade.from = source floating tag to upgrade FROM (defaults to this entry's own tag = self-replace; set to the prior Major.Minor only when bootstrapping a brand-new image). Absent block or available=false => the variant is skipped.",
     "ci_metadata_pr": "Changes to this file should be made via a PR against ci-metadata (branch-protected) so there is a git audit trail (diff/blame/rollback) without touching main/devel.",
@@ -22,6 +23,7 @@
       "variant": "CE",
       "status": "active",
       "ci": true,
+      "extra_pkgs": ["textproc/py-charset-normalizer"],
       "upgrade": { "available": false }
     },
     {
@@ -35,19 +37,7 @@
       "status": "active",
       "ci": true,
       "image_name": "pfsense-plus",
-      "upgrade": { "available": false }
-    },
-    {
-      "pfsense_version": "26.03",
-      "channel": "Plus",
-      "freebsd_version": "16.0-RELEASE",
-      "freebsd_major": "16",
-      "php_version": "8.5",
-      "py_flavor": "py311",
-      "variant": "Plus",
-      "status": "active",
-      "ci": false,
-      "arch": "aarch64",
+      "extra_pkgs": [],
       "upgrade": { "available": false }
     }
   ]

--- a/supported-versions.schema.json
+++ b/supported-versions.schema.json
@@ -35,15 +35,15 @@
           },
           "freebsd_major": {
             "type": "string",
-            "description": "FreeBSD major version digit only, e.g. '15'. Used to construct the ABI tag FreeBSD:<major>:<arch> for build-pkg-linux.yml and for artifact dedup (one .pkg per distinct (major, arch) pair)."
+            "description": "FreeBSD major version digit only, e.g. '15'. Every pfSense-pkg-pfBlockerNG port is NO_ARCH (issue #1806): one wildcard-ABI .pkg build (FreeBSD:<major>:*) serves every CPU arch AND every edition/version sharing this major, so the BUILD matrix (read-version-matrix.sh --print-build) dedupes to one row per distinct freebsd_major."
           },
           "php_version": {
             "type": "string",
-            "description": "PHP version string, e.g. '8.3'. Passed to both builders to pin USES=php so dep names match the target pfSense."
+            "description": "PHP version string, e.g. '8.3'. Passed to both builders to pin USES=php so dep names match the target pfSense. Entries sharing a freebsd_major MUST agree on php_version (the BUILD-matrix dedup hard-errors otherwise)."
           },
           "py_flavor": {
             "type": "string",
-            "description": "Python flavor string, e.g. 'py311'. Passed to build-pkg-linux.yml (portable builder). build-pkg.yml derives it from the VM's installed Python."
+            "description": "Python flavor string, e.g. 'py311'. Passed to build-pkg-linux.yml (portable builder). build-pkg.yml derives it from the VM's installed Python. Entries sharing a freebsd_major MUST agree on py_flavor (the BUILD-matrix dedup hard-errors otherwise)."
           },
           "status": {
             "type": "string",
@@ -57,17 +57,17 @@
           },
           "ci": {
             "type": "boolean",
-            "description": "true = include in the CI smoke matrix (CE, or Plus from its private licensed image). false = build-only (use for a beta, or an arch/platform with no CI image yet, e.g. aarch64)."
+            "description": "true = include in the CI smoke matrix (CE, or Plus from its private licensed image). false = build-only (e.g. a beta with no smoke image yet)."
           },
           "image_name": {
             "type": "string",
             "description": "GHCR image name for the smoke leg, e.g. 'pfsense-ce' (default if omitted) or 'pfsense-plus'. For a Plus leg the VM identity (MAC + SMBIOS uuid) is NOT carried here — it comes from the SMOKE_PLUS_MAC + SMOKE_PLUS_SMBIOS_UUID repo secrets (ADR-24)."
           },
-          "arch": {
-            "type": "string",
-            "enum": ["amd64", "aarch64"],
-            "default": "amd64",
-            "description": "Target ABI architecture. Omit (or 'amd64') for the standard amd64 build; the reader resolves missing/empty to 'amd64'. 'aarch64' = Netgate ARM appliances (Plus-only); the build keys on (freebsd_major, arch) so an aarch64 entry yields a FreeBSD:<major>:aarch64 .pkg. No ARM CI image exists yet, so an aarch64 entry must be build-only (ci=false)."
+          "extra_pkgs": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": [],
+            "description": "Port origins (e.g. 'textproc/py-charset-normalizer') this entry's edition needs that its OWN upstream pkg repo does not carry (issue #1806 — e.g. Netgate builds some py3xx-* ports for Plus only). scripts/build-dep-pkg-portable.py builds each as a NO_ARCH .pkg straight from the FreeBSD-ports port definition; build-repo-portable.py --dep-pkgs folds the result into the release/nightly catalogs of every entry sharing this freebsd_major. Omit or [] when the edition's own repo already carries everything; entries sharing a freebsd_major union their extra_pkgs in the BUILD matrix."
           },
           "role": {
             "type": "string",


### PR DESCRIPTION
Every pfSense-pkg-pfBlockerNG port is NO_ARCH now: one wildcard-ABI package per FreeBSD major serves every arch, catalogs are arch-less, and the aarch64 entry is retired. `extra_pkgs` lists port origins an edition needs that its own upstream repo does not carry (CE 2.8: `textproc/py-charset-normalizer`; Netgate ships it for Plus only). Schema updated in lockstep. Compatible both ways: the current devel reader defaults absent arch→amd64 and ignores extra_pkgs; the #1806 branch reader consumes it.

Part of #1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)