### PR TITLE
pfblockerng: ship the CE python dep from our repo; NO_ARCH ports, arch-less catalogs, per-major builds

### DIFF
--- a/.ADRs/ADR_24_Plus_CI_Smoke/ADR.md
+++ b/.ADRs/ADR_24_Plus_CI_Smoke/ADR.md
@@ -286,3 +286,31 @@ Evidence in `RESULTS/05_Results.txt` (and per-phase RESULTS):
 - The Plus leg cannot pass without per-test special-casing that diverges from CE
   semantics — that is a product finding, not a harness patch; stop and file issues.
 - Any §2.2 contract item fails after Phase 3 (pre-flip).
+
+## 8. Post-merge amendment (2026-07-28 — issue #1806)
+
+The `arch` field this ADR's matrix schema assumed (§2.2 "carrying its resolved `arch`") is
+**retired**. Every `pfSense-pkg-pfBlockerNG` port is `NO_ARCH` (issue #1806, superseding the
+issue #199 ARM/aarch64 plan this ADR's schema left room for): a real package's manifest ABI is
+CPU-wildcarded (`FreeBSD:<major>:*`), so `supported-versions.json` entries no longer carry an
+`arch` field at all — a stray one on an old row is tolerated-ignored, never resurrected as a
+default. This does not touch this ADR's CE+Plus fan-out decision, the CI matrix shape (still one
+row per version, `image_name`/`mac` resolution unchanged), or the Plus identity/redaction design
+(§2.7) — those are unaffected. What changed:
+
+1. **The BUILD matrix (`--print-build`) now dedupes to one row per distinct `freebsd_major`.**
+   One wildcard-ABI `.pkg` build serves every arch AND every edition/version sharing a major, so
+   the release-artifact fan-out (`release.yml`) collapses from one leg per (variant, version) to
+   one leg per major, named `pfBlockerNG-relpkg-fbsd<major>`. The CI matrix this ADR defines
+   stays **one row per version** (never deduped) — a smoke leg still boots one VM per pfSense
+   version, exactly as this ADR specifies.
+2. **A new `extra_pkgs` field** (array of port origins) lets an entry declare a RUN_DEPENDS its
+   own edition's upstream repo doesn't carry (e.g. CE's `textproc/py-charset-normalizer`, absent
+   from Netgate's CE mirror but present in Plus's). Orthogonal to this ADR's CE/Plus CI design.
+3. **`tests/smoke/_matrix.py`'s `_own_entry()` gained a `SMOKE_IMAGE_REF`-based disambiguator.**
+   With `arch` gone, two editions sharing a `freebsd_major` (a real shape now, not just this
+   ADR's §1 transition-window note) can both match a `SMOKE_ABI` lookup; the topology now breaks
+   the tie by image name and refuses loudly rather than silently picking one when it can't.
+
+See `docs/misc/architecture-notes.md` "Self-hosted pkg distribution — ABI is NOT 1:1..." for the
+full design and `scripts/README.md` "Supported-version matrix" for the current schema.

--- a/.github/actions/read-version-matrix/action.yml
+++ b/.github/actions/read-version-matrix/action.yml
@@ -1,11 +1,11 @@
 name: Read version matrix
 description: >
   Read supported-versions.json from the ci-metadata orphan ref and emit
-  the workflow output matrices: the BUILD matrix (all entries with their
-  (freebsd_version, php_version) pair), the CI matrix (ci:true CE entries
-  only), and the derived test matrices python_versions / php_versions
-  (the distinct, supported-only python + php versions test.yml fans out
-  over). Pure read — no writes anywhere.
+  the workflow output matrices: the BUILD matrix (deduped to one row per
+  freebsd_major, issue #1806), the CI matrix (ci:true entries of any
+  channel, one row per version), and the derived test matrices
+  python_versions / php_versions (the distinct, supported-only python +
+  php versions test.yml fans out over). Pure read — no writes anywhere.
 
 inputs:
   ref:
@@ -31,17 +31,22 @@ inputs:
 outputs:
   build_matrix:
     description: >
-      JSON array of all supported entries (optionally filtered by variant),
-      each carrying its full (freebsd_version, php_version) pair plus
-      pfsense_version, channel, freebsd_major, py_flavor, variant, status,
-      and ci. Artifacts dedup by distinct freebsd_major (one .pkg per ABI)
-      — that dedup is the caller's job.
+      JSON array of build-role entries, ALREADY DEDUPED to one row per
+      distinct freebsd_major (issue #1806: every pfSense-pkg-pfBlockerNG port
+      is NO_ARCH, so one wildcard-ABI .pkg build serves every arch and every
+      edition/version sharing a major — no separate per-caller dedup needed).
+      Each row carries freebsd_major, php_version, py_flavor, extra_pkgs
+      (deduped union across merged rows), plus pfsense_version/channel/
+      freebsd_version/variant/status/ci/... inherited from whichever merged
+      row is last in matrix order. There is no `arch` field. A consumer
+      needing every distinct version (never deduped) reads ci_matrix instead.
     value: ${{ steps.read.outputs.build_matrix }}
   ci_matrix:
     description: >
-      JSON array of the ci:true CE entries only. Feed this into a
-      strategy.matrix job to fan out the smoke suite across all supported
-      CE versions.
+      JSON array of the ci:true entries (any channel), ONE ROW PER VERSION
+      (never deduped by freebsd_major — a smoke/UI leg boots one VM per
+      pfSense version). Feed this into a strategy.matrix job to fan out the
+      smoke suite across all supported versions.
     value: ${{ steps.read.outputs.ci_matrix }}
   variant:
     description: >

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -60,6 +60,10 @@ on:
         description: "Name of the uploaded .pkg artifact. Override to keep per-leg builds distinct in one run (the smoke fan-out builds a CE + a Plus .pkg in the same workflow run)."
         required: false
         default: "pfBlockerNG-pkg"
+      extra_pkgs:
+        description: "JSON array of FreeBSD port origins (the matrix row's extra_pkgs) pfSense's own repo doesn't carry, e.g. [\"textproc/py-charset-normalizer\"]. Each is built as a dep .pkg from the SAME ports checkout and uploaded as pfBlockerNG-deppkgs-fbsd<freebsd_major> (skipped when empty)."
+        required: false
+        default: "[]"
   workflow_call:
     inputs:
       channel:
@@ -90,6 +94,11 @@ on:
         required: false
         type: string
         default: "pfBlockerNG-pkg"
+      extra_pkgs:
+        description: "JSON array of FreeBSD port origins (the matrix row's extra_pkgs) pfSense's own repo doesn't carry, e.g. [\"textproc/py-charset-normalizer\"]. Each is built as a dep .pkg from the SAME ports checkout and uploaded as pfBlockerNG-deppkgs-fbsd<freebsd_major> (skipped when empty)."
+        required: false
+        type: string
+        default: "[]"
     outputs:
       artifact:
         description: "Name of the uploaded package artifact"
@@ -134,6 +143,7 @@ jobs:
           ABI:          ${{ inputs.abi }}
           PY_FLAVOR:    ${{ inputs.py_flavor }}
           PHP_VERSION:  ${{ inputs.php_version }}
+          EXTRA_PKGS:   ${{ inputs.extra_pkgs }}
           PFB_RUN_ROOT: ${{ github.workspace }}/out
         run: |
           set -eu
@@ -158,11 +168,67 @@ jobs:
           echo "pkg_dir=$(dirname "$PKG")" >> "$GITHUB_OUTPUT"
           ls -l "$(dirname "$PKG")"
 
+          FREEBSD_MAJOR="$(printf '%s' "$ABI" | cut -d: -f2)"
+          echo "freebsd_major=${FREEBSD_MAJOR}" >> "$GITHUB_OUTPUT"
+
+          # issue #1806 D1: build the row's extra_pkgs (RUN_DEPENDS ports pfSense's
+          # own repo doesn't carry, e.g. textproc/py-charset-normalizer) from the
+          # SAME ports checkout build-leg.sh just prepared above — never a second
+          # clone. build-leg.sh's own DEST formula (no --ports-dir/PFB_PORTS_DIR/
+          # PFB_RUN_DIR override in scope here) is
+          # ${PFB_RUN_ROOT:-/var/tmp/pfb-runs}/${RUN_ID}/ports; PFB_RUN_ROOT is set
+          # above, so it resolves the same way here.
+          DEP_PKG_DIR="${PFB_RUN_ROOT}/${RUN_ID}/deppkgs"
+          HAS_DEP_PKGS=0
+          ORIGIN_COUNT="$(printf '%s' "$EXTRA_PKGS" | jq 'length')"
+          if [ "$ORIGIN_COUNT" -gt 0 ]; then
+            PORTS_DIR="${PFB_RUN_ROOT}/${RUN_ID}/ports"
+            mkdir -p "$DEP_PKG_DIR"
+            # The target's own lang/python<NNN> PORTVERSION, from the SAME ports
+            # tree — the honest source for the python<NNN> RUN_DEPENDS version
+            # build-dep-pkg-portable.py records (never a fixed/guessed literal).
+            PYNNN="$(printf '%s' "$PY_FLAVOR" | sed 's/^py//')"
+            PYTHON_DEP_VERSION="$(sed -n 's/^PORTVERSION=[[:space:]]*//p' "${PORTS_DIR}/lang/python${PYNNN}/Makefile" | head -1)"
+            if [ -z "$PYTHON_DEP_VERSION" ]; then
+              echo "::error::cannot derive PORTVERSION from ${PORTS_DIR}/lang/python${PYNNN}/Makefile"
+              exit 1
+            fi
+            I=0
+            while [ "$I" -lt "$ORIGIN_COUNT" ]; do
+              ORIGIN="$(printf '%s' "$EXTRA_PKGS" | jq -r ".[$I]")"
+              python3 scripts/build-dep-pkg-portable.py \
+                --ports "$PORTS_DIR" \
+                --port "$ORIGIN" \
+                --py-flavor "$PY_FLAVOR" \
+                --freebsd-major "$FREEBSD_MAJOR" \
+                --python-dep-version "$PYTHON_DEP_VERSION" \
+                --out-dir "$DEP_PKG_DIR"
+              I=$((I + 1))
+            done
+            HAS_DEP_PKGS=1
+          fi
+          echo "dep_pkg_dir=${DEP_PKG_DIR}" >> "$GITHUB_OUTPUT"
+          echo "has_dep_pkgs=${HAS_DEP_PKGS}" >> "$GITHUB_OUTPUT"
+
       - name: Upload package
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ steps.build.outputs.pkg_dir }}/*.pkg
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload dep packages
+        # Never uploaded when extra_pkgs is empty (no empty artifacts) — a SEPARATE
+        # artifact from the branch .pkg above, keyed by freebsd_major only (dep
+        # .pkgs are wildcard-ABI, shared across every edition/version on this
+        # major): smoke-single.yml/ui-tests.yml/repo-install.yml download it as
+        # pfBlockerNG-deppkgs-fbsd<freebsd_major>.
+        if: steps.build.outputs.has_dep_pkgs == '1'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pfBlockerNG-deppkgs-fbsd${{ steps.build.outputs.freebsd_major }}
+          path: ${{ steps.build.outputs.dep_pkg_dir }}/*.pkg
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -137,6 +137,11 @@ jobs:
           PFB_RUN_ROOT: ${{ github.workspace }}/out
         run: |
           set -eu
+          # issue #1806: the ABI's cpu segment (e.g. "amd64") is INERT for a
+          # NO_ARCH port — build-pkg-portable.py wildcards the stamp regardless
+          # of what's given, so callers that only care about the FreeBSD major
+          # (e.g. release.yml's deduped-by-major fan-out) can pass any concrete
+          # placeholder here; it never affects the produced .pkg's real ABI.
           # AMENDMENT 7: slug ABI into a path-safe LEG token (FreeBSD:15:amd64 →
           # freebsd-15-amd64) so the RUN_ID never carries raw colon path components.
           LEG="$(printf '%s' "$ABI" | tr '[:upper:]' '[:lower:]' | tr ':' '-')"

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -64,6 +64,10 @@ on:
         description: "JSON array of FreeBSD port origins (the matrix row's extra_pkgs) pfSense's own repo doesn't carry, e.g. [\"textproc/py-charset-normalizer\"]. Each is built as a dep .pkg from the SAME ports checkout and uploaded as pfBlockerNG-deppkgs-fbsd<freebsd_major> (skipped when empty)."
         required: false
         default: "[]"
+      dep_artifact_name:
+        description: "Name for the uploaded dep-pkgs artifact (ignored when extra_pkgs is empty). Blank (default) -> pfBlockerNG-deppkgs-fbsd<freebsd_major>, the self-build convention (one per major, safe when the caller's fan-out never builds two same-major rows in one run). A caller whose fan-out IS per-version (e.g. smoke.yml/ui-tests.yml matrixing over leg rows) must override this with a per-row-unique name (e.g. append -<image_name>) or two same-major rows collide on upload."
+        required: false
+        default: ""
   workflow_call:
     inputs:
       channel:
@@ -99,6 +103,11 @@ on:
         required: false
         type: string
         default: "[]"
+      dep_artifact_name:
+        description: "Name for the uploaded dep-pkgs artifact (ignored when extra_pkgs is empty). Blank (default) -> pfBlockerNG-deppkgs-fbsd<freebsd_major>, the self-build convention (one per major, safe when the caller's fan-out never builds two same-major rows in one run). A caller whose fan-out IS per-version (e.g. smoke.yml/ui-tests.yml matrixing over leg rows) must override this with a per-row-unique name (e.g. append -<image_name>) or two same-major rows collide on upload."
+        required: false
+        type: string
+        default: ""
     outputs:
       artifact:
         description: "Name of the uploaded package artifact"
@@ -144,6 +153,7 @@ jobs:
           PY_FLAVOR:    ${{ inputs.py_flavor }}
           PHP_VERSION:  ${{ inputs.php_version }}
           EXTRA_PKGS:   ${{ inputs.extra_pkgs }}
+          DEP_ARTIFACT_NAME: ${{ inputs.dep_artifact_name }}
           PFB_RUN_ROOT: ${{ github.workspace }}/out
         run: |
           set -eu
@@ -180,7 +190,9 @@ jobs:
           # above, so it resolves the same way here.
           DEP_PKG_DIR="${PFB_RUN_ROOT}/${RUN_ID}/deppkgs"
           HAS_DEP_PKGS=0
-          ORIGIN_COUNT="$(printf '%s' "$EXTRA_PKGS" | jq 'length')"
+          # CodeRabbit: guard an empty/unset EXTRA_PKGS env (jq errors parsing "" as
+          # JSON) rather than trusting the caller always supplies "[]".
+          ORIGIN_COUNT="$(printf '%s' "${EXTRA_PKGS:-[]}" | jq 'length // 0')"
           if [ "$ORIGIN_COUNT" -gt 0 ]; then
             PORTS_DIR="${PFB_RUN_ROOT}/${RUN_ID}/ports"
             mkdir -p "$DEP_PKG_DIR"
@@ -205,6 +217,12 @@ jobs:
           fi
           echo "dep_pkg_dir=${DEP_PKG_DIR}" >> "$GITHUB_OUTPUT"
           echo "has_dep_pkgs=${HAS_DEP_PKGS}" >> "$GITHUB_OUTPUT"
+          # W1: a caller whose fan-out is per-version (smoke.yml/ui-tests.yml) must
+          # override --dep-artifact-name so two same-major rows don't collide on
+          # upload; blank (the default, safe for a per-major-deduped caller like
+          # release.yml or a single-invocation caller) falls back to the plain
+          # per-major name.
+          echo "dep_artifact_name=${DEP_ARTIFACT_NAME:-pfBlockerNG-deppkgs-fbsd${FREEBSD_MAJOR}}" >> "$GITHUB_OUTPUT"
 
       - name: Upload package
         if: always()
@@ -217,14 +235,14 @@ jobs:
 
       - name: Upload dep packages
         # Never uploaded when extra_pkgs is empty (no empty artifacts) — a SEPARATE
-        # artifact from the branch .pkg above, keyed by freebsd_major only (dep
-        # .pkgs are wildcard-ABI, shared across every edition/version on this
-        # major): smoke-single.yml/ui-tests.yml/repo-install.yml download it as
-        # pfBlockerNG-deppkgs-fbsd<freebsd_major>.
+        # artifact from the branch .pkg above, keyed by freebsd_major by default
+        # (dep .pkgs are wildcard-ABI, shared across every edition/version on this
+        # major) — or by the caller-supplied dep_artifact_name (W1) when the
+        # caller's own fan-out is per-version and needs a per-row-unique name.
         if: steps.build.outputs.has_dep_pkgs == '1'
         uses: actions/upload-artifact@v7
         with:
-          name: pfBlockerNG-deppkgs-fbsd${{ steps.build.outputs.freebsd_major }}
+          name: ${{ steps.build.outputs.dep_artifact_name }}
           path: ${{ steps.build.outputs.dep_pkg_dir }}/*.pkg
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -184,24 +184,20 @@ jobs:
           if [ "$ORIGIN_COUNT" -gt 0 ]; then
             PORTS_DIR="${PFB_RUN_ROOT}/${RUN_ID}/ports"
             mkdir -p "$DEP_PKG_DIR"
-            # The target's own lang/python<NNN> PORTVERSION, from the SAME ports
-            # tree — the honest source for the python<NNN> RUN_DEPENDS version
-            # build-dep-pkg-portable.py records (never a fixed/guessed literal).
-            PYNNN="$(printf '%s' "$PY_FLAVOR" | sed 's/^py//')"
-            PYTHON_DEP_VERSION="$(sed -n 's/^PORTVERSION=[[:space:]]*//p' "${PORTS_DIR}/lang/python${PYNNN}/Makefile" | head -1)"
-            if [ -z "$PYTHON_DEP_VERSION" ]; then
-              echo "::error::cannot derive PORTVERSION from ${PORTS_DIR}/lang/python${PYNNN}/Makefile"
-              exit 1
-            fi
             I=0
             while [ "$I" -lt "$ORIGIN_COUNT" ]; do
               ORIGIN="$(printf '%s' "$EXTRA_PKGS" | jq -r ".[$I]")"
+              # sparse-clone-ports.sh's checkout only includes the pfBlockerNG
+              # port's OWN RUN_DEPENDS -- extra_pkgs is a matrix-level concept
+              # it doesn't know about, so this origin's dir was never
+              # materialized. Add it explicitly (idempotent; cone mode already
+              # set by sparse-clone-ports.sh).
+              git -C "$PORTS_DIR" sparse-checkout add "$ORIGIN"
               python3 scripts/build-dep-pkg-portable.py \
                 --ports "$PORTS_DIR" \
                 --port "$ORIGIN" \
                 --py-flavor "$PY_FLAVOR" \
                 --freebsd-major "$FREEBSD_MAJOR" \
-                --python-dep-version "$PYTHON_DEP_VERSION" \
                 --out-dir "$DEP_PKG_DIR"
               I=$((I + 1))
             done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -894,6 +894,7 @@ jobs:
           PHP:          ${{ matrix.php_version }}
           PY:           ${{ matrix.py_flavor }}
           MAJOR:        ${{ matrix.freebsd_major }}
+          EXTRA_PKGS:   ${{ toJson(matrix.extra_pkgs) }}
           # Place the run-keyed out dir under $GITHUB_WORKSPACE/out so the
           # rename step below finds this leg's .pkg without any path remapping.
           PFB_RUN_ROOT: ${{ github.workspace }}/out
@@ -926,6 +927,40 @@ jobs:
           echo "Renamed: ${BASE}.pkg -> $(basename "$RENAMED")"
           echo "PKG_PATH=${RENAMED}" >> "$GITHUB_ENV"
 
+          # issue #1806 B1: this row's extra_pkgs (RUN_DEPENDS ports pfSense's
+          # own repo doesn't carry, e.g. textproc/py-charset-normalizer) --
+          # SAME loop as build-pkg-linux.yml, from the SAME ports checkout
+          # build-leg.sh just prepared above (never a second clone).
+          # read-matrix's build_matrix is already deduped one row per major, so
+          # this leg is the only one ever building this major's dep .pkgs.
+          DEP_PKG_DIR="${PFB_RUN_ROOT}/${RUN_ID}/deppkgs"
+          HAS_DEP_PKGS=0
+          ORIGIN_COUNT="$(printf '%s' "${EXTRA_PKGS:-[]}" | jq 'length // 0')"
+          if [ "$ORIGIN_COUNT" -gt 0 ]; then
+            PORTS_DIR="${PFB_RUN_ROOT}/${RUN_ID}/ports"
+            mkdir -p "$DEP_PKG_DIR"
+            I=0
+            while [ "$I" -lt "$ORIGIN_COUNT" ]; do
+              ORIGIN="$(printf '%s' "$EXTRA_PKGS" | jq -r ".[$I]")"
+              # sparse-clone-ports.sh's checkout only includes the pfBlockerNG
+              # port's OWN RUN_DEPENDS -- extra_pkgs is a matrix-level concept
+              # it doesn't know about, so this origin's dir was never
+              # materialized. Add it explicitly (idempotent; cone mode already
+              # set by sparse-clone-ports.sh).
+              git -C "$PORTS_DIR" sparse-checkout add "$ORIGIN"
+              python3 scripts/build-dep-pkg-portable.py \
+                --ports "$PORTS_DIR" \
+                --port "$ORIGIN" \
+                --py-flavor "$PY" \
+                --freebsd-major "$MAJOR" \
+                --out-dir "$DEP_PKG_DIR"
+              I=$((I + 1))
+            done
+            HAS_DEP_PKGS=1
+          fi
+          echo "DEP_PKG_DIR=${DEP_PKG_DIR}" >> "$GITHUB_ENV"
+          echo "HAS_DEP_PKGS=${HAS_DEP_PKGS}" >> "$GITHUB_ENV"
+
       - name: Upload this leg's .pkg artifact (exact-name contract, issue #1806)
         # Name MUST equal pfBlockerNG-relpkg-fbsd<freebsd_major> -- the EXACT
         # name ui-tests.yml's/smoke.yml's pkg_artifact_prefix download step
@@ -938,6 +973,21 @@ jobs:
         with:
           name: pfBlockerNG-relpkg-fbsd${{ matrix.freebsd_major }}
           path: ${{ env.PKG_PATH }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload this leg's dep .pkg artifact (issue #1806 B1)
+        # Name MUST equal pfBlockerNG-relpkg-deppkgs-fbsd<freebsd_major> -- the
+        # EXACT name smoke.yml's/ui-tests.yml's pkg_artifact_prefix ==
+        # 'pfBlockerNG-relpkg' download steps compose (dep_pkg_artifact /
+        # the "Download dep packages" ternary). Never uploaded when
+        # extra_pkgs is empty (no empty artifacts) -- a SEPARATE artifact
+        # from the branch .pkg above, never folded into it.
+        if: env.HAS_DEP_PKGS == '1'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pfBlockerNG-relpkg-deppkgs-fbsd${{ matrix.freebsd_major }}
+          path: ${{ env.DEP_PKG_DIR }}/*.pkg
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1025,7 +1025,12 @@ jobs:
         # Each build-pkgs-portable leg uploads its OWN artifact, named
         # pfBlockerNG-relpkg-fbsd<freebsd_major> (issue #1806); merge every
         # leg's artifact into pkgs/ (each holds exactly one .pkg, already
-        # carrying -FreeBSD-<major> in the filename).
+        # carrying -FreeBSD-<major> in the filename). The pattern also sweeps
+        # up each leg's pfBlockerNG-relpkg-deppkgs-fbsd<major> artifact
+        # (issue #1806 B1) -- INTENTIONAL: dep .pkgs (e.g. CE's
+        # py311-charset-normalizer) are deliberate release assets, frozen
+        # alongside the branch .pkgs for the pkg-repo publish + EOL/route-only
+        # story. publish-release's healthcheck counts them (EXPECTED_PKGS).
         uses: actions/download-artifact@v4
         with:
           pattern: pfBlockerNG-relpkg-*
@@ -1086,8 +1091,12 @@ jobs:
       - name: Health-check the draft release is complete
         # Verify completeness BEFORE the irreversible publish. Expected assets: the
         # source archive + exactly one .pkg per build-matrix entry (one per distinct
-        # FreeBSD major, issue #1806). Anything missing → fail, leaving the draft
-        # intact for a resume. Already-published (idempotent re-run) short-circuits OK.
+        # FreeBSD major, issue #1806) PLUS one dep .pkg per extra_pkgs entry across
+        # every (deduped) build-matrix row (issue #1806 B1: attach-pkgs's
+        # pfBlockerNG-relpkg-* sweep also picks up each major's
+        # pfBlockerNG-relpkg-deppkgs-fbsd<major> artifact -- a deliberate release
+        # asset, not a leak). Anything missing → fail, leaving the draft intact for
+        # a resume. Already-published (idempotent re-run) short-circuits OK.
         env:
           GH_TOKEN:     ${{ github.token }}
           TAG:          ${{ needs.release.outputs.tag }}
@@ -1103,7 +1112,10 @@ jobs:
             exit 0
           fi
 
-          EXPECTED_PKGS=$(printf '%s' "$BUILD_MATRIX" | jq 'length')
+          # issue #1806 B1: the distinct-major count PLUS the total number of
+          # extra_pkgs entries across the (deduped) build-matrix rows -- each
+          # dep .pkg is its own release asset (see attach-pkgs's comment).
+          EXPECTED_PKGS=$(printf '%s' "$BUILD_MATRIX" | jq '(length) + ([.[] | (.extra_pkgs // []) | length] | add // 0)')
           PKG_COUNT=$(printf '%s' "$META" | jq '[.assets[] | select(.name | endswith(".pkg"))] | length')
           SRC_COUNT=$(printf '%s' "$META" | jq '[.assets[] | select(.name | endswith(".tar.gz"))] | length')
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,10 +402,13 @@ jobs:
     secrets: inherit
 
   # ── 1c. Read version matrix ──────────────────────────────────────────────
-  # Read the supported-versions matrix from ci-metadata and compute a
-  # deduped build matrix (one entry per distinct FreeBSD major — one .pkg
-  # per ABI). Runs after prepare-release (or in parallel with its skip on dry-run);
-  # build-pkgs-portable needs both.
+  # Read the supported-versions matrix from ci-metadata. read-version-matrix.sh
+  # (issue #1806) already dedupes the BUILD matrix to one row per distinct
+  # freebsd_major — every pfSense-pkg-pfBlockerNG port is NO_ARCH, so one
+  # wildcard-ABI .pkg build serves every edition/version sharing a major — so
+  # this job passes the reader's build_matrix output straight through; no
+  # override step needed. Runs after prepare-release (or in parallel with its
+  # skip on dry-run); build-pkgs-portable needs both.
   read-matrix:
     name: Read version matrix
     runs-on: ubuntu-latest
@@ -414,7 +417,7 @@ jobs:
     # If prepare-release failed for any reason, do NOT build or publish.
     if: ${{ always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') }}
     outputs:
-      build_matrix: ${{ steps.matrix.outputs.build_matrix }}
+      build_matrix: ${{ steps.matrices.outputs.build_matrix }}
       pkg_channel:  ${{ steps.channel.outputs.pkg_channel }}
       portversion:  ${{ steps.channel.outputs.portversion }}
     steps:
@@ -440,27 +443,6 @@ jobs:
       - name: Read matrix from ci-metadata
         id: matrices
         uses: ./.github/actions/read-version-matrix
-
-      - name: Use the full build matrix (every variant)
-        id: matrix
-        # The Release must carry the FULL version matrix — one .pkg per build entry
-        # (every CE/Plus variant × FreeBSD major × arch), NOT a per-ABI dedup. So pass
-        # the build matrix through verbatim; build-pkgs-portable names each artifact by
-        # variant + pfSense version + ABI, so two variants sharing a FreeBSD major × arch
-        # (e.g. CE and Plus on the same major with different php/python deps) each produce
-        # their own, distinctly-named .pkg instead of one shadowing the other. The reader
-        # already excludes role=route-only entries (served from a frozen catalog).
-        # The matrix rides in via env (never inlined into the script) and is written with a
-        # heredoc block, so its content can't template-inject into the shell.
-        env:
-          FULL_MATRIX: ${{ steps.matrices.outputs.build_matrix }}
-        run: |
-          {
-            echo "build_matrix<<__MATRIX__"
-            printf '%s\n' "$FULL_MATRIX"
-            echo "__MATRIX__"
-          } >> "$GITHUB_OUTPUT"
-          echo "Full build matrix: $FULL_MATRIX"
 
   # ── 1d. Resolve build stamp ──────────────────────────────────────────────
   # Checks out the SAME ref as build-pkgs-portable so that `created` (epoch of the
@@ -820,20 +802,22 @@ jobs:
           files: ${{ env.ARCHIVE }}
 
   # ── 2b. Build .pkg artifacts (portable Linux builder) ────────────────────
-  # Builds one .pkg per build-matrix entry (every CE/Plus variant × FreeBSD
-  # major × arch). Runs the portable Linux builder steps inline (no FreeBSD
-  # VM, ~3 min/entry). This is the SOLE release .pkg builder: pfBlockerNG is a
-  # NO_BUILD port, so the portable builder reproduces `make package`
-  # byte-for-byte (validated against it over every smoke + Web-UI run on CE
-  # and Plus) and `pkg add` checks a dep is PRESENT, not its version — so the
-  # portable artifact installs identically.
+  # Builds ONE .pkg per DISTINCT FreeBSD major (issue #1806): read-matrix's
+  # build_matrix is already deduped by read-version-matrix.sh -- every
+  # pfSense-pkg-pfBlockerNG port is NO_ARCH, so one wildcard-ABI build serves
+  # every arch AND every edition/version sharing a major. Runs the portable
+  # Linux builder steps inline (no FreeBSD VM, ~3 min/leg). This is the SOLE
+  # release .pkg builder: pfBlockerNG is a NO_BUILD port, so the portable
+  # builder reproduces `make package` byte-for-byte (validated against it over
+  # every smoke + Web-UI run on CE and Plus) and `pkg add` checks a dep is
+  # PRESENT, not its version — so the portable artifact installs identically.
   #
-  # ONE JOB PER LEG (strategy.matrix over read-matrix's build_matrix,
+  # ONE JOB PER MAJOR (strategy.matrix over read-matrix's build_matrix,
   # fail-fast: false): each leg uploads its OWN artifact, named exactly
-  # `pfBlockerNG-relpkg-<variant_lc>-<pfsense_version>-<arch>` (issue #1662) —
-  # the EXACT name ui-tests.yml's/smoke.yml's pkg_artifact_prefix consumer side
-  # downloads, so ui-suite/smoke-suite below gate on the SAME bits this job
-  # built, not a fresh rebuild of their own.
+  # `pfBlockerNG-relpkg-fbsd<freebsd_major>` — the EXACT name ui-tests.yml's/
+  # smoke.yml's pkg_artifact_prefix consumer side downloads, so ui-suite/
+  # smoke-suite below gate on the SAME bits this job built, not a fresh
+  # rebuild of their own.
   #
   # A leg's build failure surfaces as a red leg (fail-fast: false keeps the
   # others going). sync-ports-fork's own `needs:` list is [prepare-release,
@@ -847,7 +831,7 @@ jobs:
   # chain; a failed leg simply uploads nothing, so its .pkg is absent from the
   # merged download and the publish-release healthcheck fails closed.
   build-pkgs-portable:
-    name: "build .pkg — ${{ matrix.variant }}-${{ matrix.pfsense_version }} (FreeBSD ${{ matrix.freebsd_major }}/${{ matrix.arch }})"
+    name: "build .pkg — FreeBSD ${{ matrix.freebsd_major }}"
     runs-on: ubuntu-latest
     needs: [prepare-release, read-matrix, resolve-stamp]
     # Same gate as release: run in both dry-run (skipped) and real (succeeded) modes.
@@ -876,42 +860,25 @@ jobs:
       - name: Ensure zstd encoder is present
         run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
 
-      - name: Compute this leg's VARSLUG/ABI (variant slug == pkg repo's catalog dir name)
+      - name: Compute this leg's LEG/ABI (one .pkg per FreeBSD major)
         id: leg
-        # Variant slug == the pkg repo's catalog dir name (build-repo-portable.py
-        # catalog_name_from_version): "<variant_lc>-<major.minor>", e.g. ce-2.8 /
-        # plus-26.03. VARSLUG (major.minor-truncated) drives the .pkg FILENAME and
-        # the catalog path; it stays untouched. ARTSLUG (issue #1662 M1) is the
-        # SAME lower(variant) but keyed on the FULL pfsense_version (no cut) and
-        # is used ONLY for the per-leg ARTIFACT NAME below -- both consumer sides
-        # (ui-tests.yml/smoke.yml) format their download name from the full
-        # matrix.pfsense_version, so a future 3-component version (e.g. 2.8.1)
-        # would otherwise truncate on the producer side only and 404 the download.
+        # issue #1806: the leg key is freebsd_major ALONE -- read-matrix's
+        # build_matrix is already deduped to one row per major, so there is no
+        # variant/version/arch left to slug. ABI's cpu segment ("amd64") is an
+        # INERT placeholder: build-pkg-portable.py wildcards the stamp for any
+        # NO_ARCH port regardless of what's given, so the one .pkg this leg
+        # builds serves every arch of this FreeBSD major.
         env:
-          VARIANT: ${{ matrix.variant }}
-          CHANNEL_FALLBACK: ${{ matrix.channel }}
-          PFV: ${{ matrix.pfsense_version }}
           MAJOR: ${{ matrix.freebsd_major }}
-          ARCH: ${{ matrix.arch }}
         run: |
           set -eu
-          V="${VARIANT:-${CHANNEL_FALLBACK:-CE}}"
-          MM=$(printf '%s' "$PFV" | cut -d. -f1-2)
-          V_LC="$(printf '%s' "$V" | tr '[:upper:]' '[:lower:]')"
-          VARSLUG="${V_LC}-${MM}"
-          ARTSLUG="${V_LC}-${PFV}"
-          ABI="FreeBSD:${MAJOR}:${ARCH}"
-          # AMENDMENT 7: slug this leg from VARSLUG + major + arch so it lands in
-          # a distinct RUN_ID-keyed out dir. Colons in ABI are path-unsafe; the
-          # slug uses only safe chars.
-          LEG="${VARSLUG}-${MAJOR}-${ARCH}"
+          ABI="FreeBSD:${MAJOR}:amd64"
+          LEG="fbsd${MAJOR}"
           {
-            echo "varslug=${VARSLUG}"
-            echo "artslug=${ARTSLUG}"
             echo "abi=${ABI}"
             echo "leg=${LEG}"
           } >> "$GITHUB_OUTPUT"
-          echo "leg ${LEG}: variant=${V} ABI=${ABI}"
+          echo "leg ${LEG}: ABI=${ABI}"
 
       - name: Build the .pkg via build-leg.sh
         # build-leg.sh is the shared build path (local/CI/release parity — ADR-47 P3).
@@ -923,12 +890,10 @@ jobs:
           CREATED:      ${{ needs.resolve-stamp.outputs.created }}
           COMMIT:       ${{ needs.resolve-stamp.outputs.commit }}
           ABI:          ${{ steps.leg.outputs.abi }}
-          VARSLUG:      ${{ steps.leg.outputs.varslug }}
           LEG:          ${{ steps.leg.outputs.leg }}
           PHP:          ${{ matrix.php_version }}
           PY:           ${{ matrix.py_flavor }}
           MAJOR:        ${{ matrix.freebsd_major }}
-          ARCH:         ${{ matrix.arch }}
           # Place the run-keyed out dir under $GITHUB_WORKSPACE/out so the
           # rename step below finds this leg's .pkg without any path remapping.
           PFB_RUN_ROOT: ${{ github.workspace }}/out
@@ -938,7 +903,7 @@ jobs:
           RUN_ID="$(sh scripts/select-box.sh --print-id)"
           export RUN_ID
 
-          echo "--- Building .pkg for ${VARSLUG} FreeBSD ${MAJOR}/${ARCH}, PHP ${PHP}, ${PY} ---"
+          echo "--- Building .pkg for FreeBSD ${MAJOR}, PHP ${PHP}, ${PY} ---"
 
           PKG="$(sh scripts/build-leg.sh \
             --channel    "$PKG_CHANNEL" \
@@ -950,31 +915,28 @@ jobs:
             --annotate   "commit=${COMMIT}")"
 
           PKG_DIR="$(dirname "$PKG")"
-          echo "Built for ${VARSLUG} FreeBSD ${MAJOR}/${ARCH}:"
+          echo "Built for FreeBSD ${MAJOR}:"
           ls -l "${PKG_DIR}"
 
-          # Rename to embed variant + pfSense version + FreeBSD major + arch, so
-          # this leg's .pkg filename stays unambiguous inside its own artifact.
+          # Rename to embed the FreeBSD major, so this leg's .pkg filename
+          # stays unambiguous inside its own artifact.
           BASE="$(basename "$PKG" .pkg)"
-          RENAMED="${PKG_DIR}/${BASE}-${VARSLUG}-FreeBSD-${MAJOR}-${ARCH}.pkg"
+          RENAMED="${PKG_DIR}/${BASE}-FreeBSD-${MAJOR}.pkg"
           mv "$PKG" "$RENAMED"
           echo "Renamed: ${BASE}.pkg -> $(basename "$RENAMED")"
           echo "PKG_PATH=${RENAMED}" >> "$GITHUB_ENV"
 
-      - name: Upload this leg's .pkg artifact (exact-name contract, issue #1662)
-        # Name MUST equal pfBlockerNG-relpkg-<variant_lc>-<pfsense_version>-<arch>
-        # -- the EXACT name ui-tests.yml's/smoke.yml's pkg_artifact_prefix download
-        # step composes when pkg_artifact_prefix: pfBlockerNG-relpkg is set (see
-        # ui-suite/smoke-suite below). Uses ARTSLUG (full pfsense_version, issue
-        # #1662 M1), NOT VARSLUG (major.minor-truncated) -- the consumer sides
-        # format the full matrix.pfsense_version into the name, so this must match
-        # byte-for-byte even once a 3-component version ships. Upload only on
-        # success: fail-fast: false already isolates a failed leg, so it simply
-        # uploads nothing and attach-pkgs/the publish healthcheck fail closed on
-        # the missing asset.
+      - name: Upload this leg's .pkg artifact (exact-name contract, issue #1806)
+        # Name MUST equal pfBlockerNG-relpkg-fbsd<freebsd_major> -- the EXACT
+        # name ui-tests.yml's/smoke.yml's pkg_artifact_prefix download step
+        # composes when pkg_artifact_prefix: pfBlockerNG-relpkg is set (see
+        # ui-suite/smoke-suite below). Upload only on success: fail-fast:
+        # false already isolates a failed leg, so it simply uploads nothing
+        # and attach-pkgs/the publish healthcheck fail closed on the missing
+        # asset.
         uses: actions/upload-artifact@v7
         with:
-          name: pfBlockerNG-relpkg-${{ steps.leg.outputs.artslug }}-${{ matrix.arch }}
+          name: pfBlockerNG-relpkg-fbsd${{ matrix.freebsd_major }}
           path: ${{ env.PKG_PATH }}
           if-no-files-found: error
           retention-days: 7
@@ -1011,9 +973,9 @@ jobs:
 
       - name: Download .pkg artifacts from portable builder
         # Each build-pkgs-portable leg uploads its OWN artifact, named
-        # pfBlockerNG-relpkg-<variant_lc>-<pfsense_version>-<arch> (issue #1662);
-        # merge every leg's artifact into pkgs/ (each holds exactly one .pkg,
-        # already carrying -FreeBSD-<major> in the filename).
+        # pfBlockerNG-relpkg-fbsd<freebsd_major> (issue #1806); merge every
+        # leg's artifact into pkgs/ (each holds exactly one .pkg, already
+        # carrying -FreeBSD-<major> in the filename).
         uses: actions/download-artifact@v4
         with:
           pattern: pfBlockerNG-relpkg-*
@@ -1073,8 +1035,8 @@ jobs:
     steps:
       - name: Health-check the draft release is complete
         # Verify completeness BEFORE the irreversible publish. Expected assets: the
-        # source archive + exactly one .pkg per build-matrix entry (every CE/Plus
-        # variant × FreeBSD major × arch). Anything missing → fail, leaving the draft
+        # source archive + exactly one .pkg per build-matrix entry (one per distinct
+        # FreeBSD major, issue #1806). Anything missing → fail, leaving the draft
         # intact for a resume. Already-published (idempotent re-run) short-circuits OK.
         env:
           GH_TOKEN:     ${{ github.token }}
@@ -1140,8 +1102,9 @@ jobs:
   # ── 2d. Poke the self-hosted pkg repository to republish (ADR-17) ──────────
   # The pkg catalog is hosted + deployed by the SEPARATE pfBlockerNG/pkg repo:
   # its own publish.yml enumerates this repo's Releases (the durable store),
-  # CONSUMES the Release .pkg assets for the release/<varver>/<arch>/ subtree (devel
-  # = latest prerelease, stable = latest stable; nightly still built from devel HEAD),
+  # CONSUMES the Release .pkg assets for the release/<varver>/ subtree (arch-less;
+  # issue #1806 — devel = latest prerelease, stable = latest stable; nightly still
+  # built from devel HEAD),
   # and deploys to its OWN GitHub Pages via same-repo OIDC — no cross-repo deploy key.
   # On a release we just trigger it so the new Release appears at
   # pfblockerng.github.io/pkg within seconds (its daily schedule is the backstop).

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -169,6 +169,13 @@ jobs:
       py_flavor: ${{ matrix.py_flavor }}
       # The distribution flow — not the runtime smoke matrix.
       pytest_marker: repo
+      # issue #1806 D1/D3: this leg's dep .pkgs — smoke-single.yml's own
+      # build-if-absent build-pkg job (pkg_artifact is blank here) builds +
+      # uploads them, then exports SMOKE_DEP_PKGS; test_repo_install.py folds
+      # them into the staged guest catalog so `pkg install` resolves
+      # RUN_DEPENDS pfSense's own repo doesn't carry (e.g. CE's
+      # textproc/py-charset-normalizer) from OUR catalog.
+      extra_pkgs: ${{ toJson(matrix.extra_pkgs) }}
     secrets: inherit
 
   # AND-gate: green only if ALL legs passed. Runs regardless of the matrix outcome

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -100,6 +100,10 @@ on:
         description: "Name of a pre-built .pkg artifact to download instead of building one here. The smoke.yml fan-out builds one .pkg per version leg and passes its artifact name in; blank = build the .pkg in this workflow (bare dispatch + repo-install path)."
         required: false
         default: ""
+      extra_pkgs:
+        description: "JSON array of FreeBSD port origins for this leg (the matrix row's extra_pkgs, e.g. [\"textproc/py-charset-normalizer\"]). Non-empty -> download pfBlockerNG-deppkgs-fbsd<freebsd_major> and export SMOKE_DEP_PKGS (space-separated absolute .pkg paths) for install-pkg.sh. Empty/blank -> SMOKE_DEP_PKGS stays unset."
+        required: false
+        default: "[]"
   workflow_call:
     inputs:
       image_ref:
@@ -177,6 +181,11 @@ on:
         required: false
         type: string
         default: ""
+      extra_pkgs:
+        description: "JSON array of FreeBSD port origins for this leg (the matrix row's extra_pkgs, e.g. [\"textproc/py-charset-normalizer\"]). Non-empty -> download pfBlockerNG-deppkgs-fbsd<freebsd_major> and export SMOKE_DEP_PKGS (space-separated absolute .pkg paths) for install-pkg.sh. Empty/blank -> SMOKE_DEP_PKGS stays unset."
+        required: false
+        type: string
+        default: "[]"
   # Nightly gated run — enable once the wall-time is confirmed within budget.
   # schedule:
   #   - cron: "0 5 * * *"
@@ -230,6 +239,12 @@ jobs:
       # (pfBlockerNG/FreeBSD-ports @ pfblockerng/use-github), so a normal run is unchanged.
       ports_repo: ${{ inputs.ports_repo || 'pfBlockerNG/FreeBSD-ports' }}
       ports_ref: ${{ inputs.ports_ref || 'pfblockerng/use-github' }}
+      # issue #1806 D1/D2: this leg's extra_pkgs, straight through — this build-pkg
+      # job only runs on the build-if-absent path (bare dispatch / repo-install.yml),
+      # so it is the SOLE builder for this leg; if extra_pkgs is non-empty it also
+      # uploads pfBlockerNG-deppkgs-fbsd<freebsd_major>, which the "Download dep
+      # packages" step below (same workflow, same run) then downloads.
+      extra_pkgs: ${{ inputs.extra_pkgs }}
 
   smoke:
     name: pytest -m smoke (live pfSense VM)
@@ -430,6 +445,41 @@ jobs:
           name: ${{ inputs.pkg_artifact != '' && inputs.pkg_artifact || needs.build-pkg.outputs.artifact }}
           path: pkg
 
+      # issue #1806 D2: this leg's extra_pkgs (e.g. py311-charset-normalizer for
+      # CE) — a SEPARATE artifact from the branch .pkg above (never folded into
+      # `pkg/`, so the N_PKG -eq 1 guard below stays exactly one .pkg). Named by
+      # freebsd_major only (dep .pkgs are wildcard-ABI, shared by every
+      # edition/version on this major) — parsed from the SAME `abi` input the
+      # build-pkg job above was called with.
+      - name: Resolve dep-pkg artifact name
+        id: depmajor
+        if: ${{ inputs.extra_pkgs != '' && inputs.extra_pkgs != '[]' }}
+        env:
+          ABI: ${{ inputs.abi }}
+        run: |
+          set -eu
+          echo "freebsd_major=$(printf '%s' "$ABI" | cut -d: -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Download dep packages
+        if: ${{ inputs.extra_pkgs != '' && inputs.extra_pkgs != '[]' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: pfBlockerNG-deppkgs-fbsd${{ steps.depmajor.outputs.freebsd_major }}
+          path: deppkgs
+
+      - name: Export SMOKE_DEP_PKGS
+        if: ${{ inputs.extra_pkgs != '' && inputs.extra_pkgs != '[]' }}
+        run: |
+          set -eu
+          N_DEP="$(find deppkgs -type f -name '*.pkg' | wc -l | tr -d ' ')"
+          [ "$N_DEP" -ge 1 ] || { echo "::error::extra_pkgs was non-empty but the deppkgs artifact carried no .pkg"; ls -lR deppkgs || true; exit 1; }
+          DEP_PATHS=""
+          for f in $(find deppkgs -type f -name '*.pkg' | sort); do
+            DEP_PATHS="${DEP_PATHS}$(cd "$(dirname "$f")" && pwd)/$(basename "$f") "
+          done
+          echo "SMOKE_DEP_PKGS=${DEP_PATHS% }" >> "$GITHUB_ENV"
+          echo "resolved SMOKE_DEP_PKGS=${DEP_PATHS% }"
+
       - name: Locate the .pkg + the pulled .qcow2
         id: paths
         run: |
@@ -554,6 +604,10 @@ jobs:
           SMOKE_CLIENT_MAC_ADDRESS: ${{ secrets.SMOKE_CLIENT_MAC_ADDRESS }}
           SMOKE_SSH_KEY: smoke_key
           SMOKE_PKG: ${{ steps.paths.outputs.pkg }}
+          # issue #1806 D2: this leg's dep .pkgs (space-separated absolute paths),
+          # set by "Export SMOKE_DEP_PKGS" above when extra_pkgs is non-empty;
+          # stays unset (empty) otherwise — install-pkg.sh skips deps entirely then.
+          SMOKE_DEP_PKGS: ${{ env.SMOKE_DEP_PKGS }}
           # Matrix-derived build target (ADR-24): the per-leg ABI / PHP / Python flavor
           # the .pkg was built for, straight from the ci-metadata matrix (the fan-out
           # passes them as inputs; a bare dispatch defaults to the CE values). The ADR-20

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -219,6 +219,11 @@ jobs:
       # The `-s<shard>` suffix (issue #797) keys it further: two shards of the SAME
       # leg each build their own .pkg on THIS path — only reached when pkg_artifact
       # is blank, so it never collides with the shared per-leg artifact smoke.yml builds.
+      # issue #1806: deliberately NOT the fbsd<major> convention — this artifact is
+      # produced and consumed entirely within THIS run (via build-pkg.outputs.artifact,
+      # the dynamic name GH assigned, never matched by this literal elsewhere), so the
+      # major-collapse naming that matters for cross-workflow/cross-run consumers
+      # (release.yml/smoke.yml) buys nothing here.
       artifact_name: pfBlockerNG-pkg-${{ inputs.image_name }}-s${{ inputs.shard }}
       # Optional Option-A validation: point the .pkg build at a FreeBSD-ports branch
       # carrying a new plist entry. Blank -> build-pkg-linux's own defaults

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -101,9 +101,13 @@ on:
         required: false
         default: ""
       extra_pkgs:
-        description: "JSON array of FreeBSD port origins for this leg (the matrix row's extra_pkgs, e.g. [\"textproc/py-charset-normalizer\"]). Non-empty -> download pfBlockerNG-deppkgs-fbsd<freebsd_major> and export SMOKE_DEP_PKGS (space-separated absolute .pkg paths) for install-pkg.sh. Empty/blank -> SMOKE_DEP_PKGS stays unset."
+        description: "JSON array of FreeBSD port origins for this leg (the matrix row's extra_pkgs, e.g. [\"textproc/py-charset-normalizer\"]). Non-empty -> download the dep-pkgs artifact (dep_artifact, or this workflow's own self-built default) and export SMOKE_DEP_PKGS (space-separated absolute .pkg paths) for install-pkg.sh. Empty/blank -> SMOKE_DEP_PKGS stays unset."
         required: false
         default: "[]"
+      dep_artifact:
+        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<image_name>-s<shard>."
+        required: false
+        default: ""
   workflow_call:
     inputs:
       image_ref:
@@ -182,10 +186,15 @@ on:
         type: string
         default: ""
       extra_pkgs:
-        description: "JSON array of FreeBSD port origins for this leg (the matrix row's extra_pkgs, e.g. [\"textproc/py-charset-normalizer\"]). Non-empty -> download pfBlockerNG-deppkgs-fbsd<freebsd_major> and export SMOKE_DEP_PKGS (space-separated absolute .pkg paths) for install-pkg.sh. Empty/blank -> SMOKE_DEP_PKGS stays unset."
+        description: "JSON array of FreeBSD port origins for this leg (the matrix row's extra_pkgs, e.g. [\"textproc/py-charset-normalizer\"]). Non-empty -> download the dep-pkgs artifact (dep_artifact, or this workflow's own self-built default) and export SMOKE_DEP_PKGS (space-separated absolute .pkg paths) for install-pkg.sh. Empty/blank -> SMOKE_DEP_PKGS stays unset."
         required: false
         type: string
         default: "[]"
+      dep_artifact:
+        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<image_name>-s<shard>."
+        required: false
+        type: string
+        default: ""
   # Nightly gated run — enable once the wall-time is confirmed within budget.
   # schedule:
   #   - cron: "0 5 * * *"
@@ -242,9 +251,14 @@ jobs:
       # issue #1806 D1/D2: this leg's extra_pkgs, straight through — this build-pkg
       # job only runs on the build-if-absent path (bare dispatch / repo-install.yml),
       # so it is the SOLE builder for this leg; if extra_pkgs is non-empty it also
-      # uploads pfBlockerNG-deppkgs-fbsd<freebsd_major>, which the "Download dep
-      # packages" step below (same workflow, same run) then downloads.
+      # uploads its dep artifact, which the "Download dep packages" step below
+      # (same workflow, same run) then downloads.
       extra_pkgs: ${{ inputs.extra_pkgs }}
+      # W1: mirror artifact_name's OWN discriminator (image_name + shard) — this
+      # build-pkg job's matrix (indirectly, one invocation per caller-side leg)
+      # can share a run with sibling invocations of THIS reusable workflow (e.g.
+      # repo-install.yml's fan-out); the plain per-major default would collide.
+      dep_artifact_name: pfBlockerNG-deppkgs-${{ inputs.image_name }}-s${{ inputs.shard }}
 
   smoke:
     name: pytest -m smoke (live pfSense VM)
@@ -292,14 +306,22 @@ jobs:
         # the test falls back to running this script itself, which needs network the pytest
         # phase may not have. Best-effort: on failure the topology cases SKIP, never fail the
         # whole smoke job. (read-version-matrix.sh self-fetches the ci-metadata orphan ref.)
+        # W3: --print-ci (ONE ROW PER VERSION, never deduped by major), not --print-build
+        # (issue #1806 dedupes BUILD to one row per freebsd_major) -- a deduped feed means
+        # _matrix.py's matrix_variants() can never see two editions sharing a major at once,
+        # so its SMOKE_IMAGE_REF disambiguator (own_entry()) can never actually fire, and a
+        # merged row's last-wins fields could misreport which edition is booted. --print-ci
+        # is also the honest source here: every leg this topology ever runs against IS a
+        # ci:true leg (a live VM only ever boots for one), so nothing --print-ci excludes was
+        # ever reachable by this topology anyway.
         run: |
           set -u
-          if matrix="$(sh scripts/read-version-matrix.sh --print-build 2>/dev/null)" && [ -n "$matrix" ]; then
-            # --print-build emits pretty (multi-line) JSON, so write it via the heredoc
+          if matrix="$(sh scripts/read-version-matrix.sh --print-ci 2>/dev/null)" && [ -n "$matrix" ]; then
+            # --print-ci emits pretty (multi-line) JSON, so write it via the heredoc
             # delimiter form (as RESOLVED_REDACT below does): a single-line KEY=value write
             # of a multi-line value errors the step ("Invalid format") and drops the matrix.
             { printf 'SMOKE_MATRIX_JSON<<__EOF__\n%s\n__EOF__\n' "$matrix"; } >> "$GITHUB_ENV"
-            echo "Resolved $(printf '%s' "$matrix" | jq 'length') build-matrix entries for the smoke topology."
+            echo "Resolved $(printf '%s' "$matrix" | jq 'length') CI-matrix entries for the smoke topology."
           else
             echo "::warning::could not resolve the version matrix — ADR-20 variant-topology cases will SKIP"
           fi
@@ -445,26 +467,17 @@ jobs:
           name: ${{ inputs.pkg_artifact != '' && inputs.pkg_artifact || needs.build-pkg.outputs.artifact }}
           path: pkg
 
-      # issue #1806 D2: this leg's extra_pkgs (e.g. py311-charset-normalizer for
+      # issue #1806 D2/B1: this leg's extra_pkgs (e.g. py311-charset-normalizer for
       # CE) — a SEPARATE artifact from the branch .pkg above (never folded into
-      # `pkg/`, so the N_PKG -eq 1 guard below stays exactly one .pkg). Named by
-      # freebsd_major only (dep .pkgs are wildcard-ABI, shared by every
-      # edition/version on this major) — parsed from the SAME `abi` input the
-      # build-pkg job above was called with.
-      - name: Resolve dep-pkg artifact name
-        id: depmajor
-        if: ${{ inputs.extra_pkgs != '' && inputs.extra_pkgs != '[]' }}
-        env:
-          ABI: ${{ inputs.abi }}
-        run: |
-          set -eu
-          echo "freebsd_major=$(printf '%s' "$ABI" | cut -d: -f2)" >> "$GITHUB_OUTPUT"
-
+      # `pkg/`, so the N_PKG -eq 1 guard below stays exactly one .pkg). dep_artifact
+      # set (smoke.yml's fan-out, either self-build or release-prefix path):
+      # download that exact name. Blank: fall back to THIS workflow's own
+      # build-pkg job's dep_artifact_name above (bare dispatch / repo-install.yml).
       - name: Download dep packages
         if: ${{ inputs.extra_pkgs != '' && inputs.extra_pkgs != '[]' }}
         uses: actions/download-artifact@v8
         with:
-          name: pfBlockerNG-deppkgs-fbsd${{ steps.depmajor.outputs.freebsd_major }}
+          name: ${{ inputs.dep_artifact != '' && inputs.dep_artifact || format('pfBlockerNG-deppkgs-{0}-s{1}', inputs.image_name, inputs.shard) }}
           path: deppkgs
 
       - name: Export SMOKE_DEP_PKGS

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -261,9 +261,14 @@ jobs:
       ports_repo: pfBlockerNG/FreeBSD-ports
       ports_ref: pfblockerng/use-github
       # issue #1806 D1: this leg's dep .pkgs (e.g. textproc/py-charset-normalizer
-      # for CE), uploaded separately as pfBlockerNG-deppkgs-fbsd<freebsd_major>
-      # when non-empty — smoke-single.yml downloads + installs them (D2/D3).
+      # for CE), uploaded separately when non-empty — smoke-single.yml downloads
+      # + installs them (D2/D3).
       extra_pkgs: ${{ toJson(matrix.extra_pkgs) }}
+      # W1: this job matrixes over leg_matrix (one row PER VERSION, never
+      # deduped by major) -- the plain per-major default name would collide if
+      # two same-major rows both carry extra_pkgs. Discriminate by image_name,
+      # matching the branch artifact's own discriminator (artifact_name above).
+      dep_artifact_name: pfBlockerNG-deppkgs-fbsd${{ matrix.freebsd_major }}-${{ matrix.image_name }}
 
   # ── 3. Per-leg smoke run (parallel, fail-fast: false) ────────────────────────
   #
@@ -319,14 +324,16 @@ jobs:
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
       php_version: ${{ matrix.php_version }}
       py_flavor: ${{ matrix.py_flavor }}
-      # issue #1806 D1/D2: this leg's dep .pkgs — smoke-single.yml downloads
-      # pfBlockerNG-deppkgs-fbsd<freebsd_major> (the build-pkg job above
-      # uploaded it) and exports SMOKE_DEP_PKGS when non-empty. Gated the SAME
-      # way as build-pkg's own `if:` above: pkg_artifact_prefix set means THIS
-      # job never ran (a release.yml-style caller supplies its own prebuilt
-      # per-major artifact and, for now, no matching deppkgs artifact — that's
-      # step E) — so there is no deppkgs artifact to download in that case.
-      extra_pkgs: ${{ inputs.pkg_artifact_prefix == '' && toJson(matrix.extra_pkgs) || '[]' }}
+      # issue #1806 D1/D2/B1: this leg's dep .pkgs. extra_pkgs flows regardless
+      # of pkg_artifact_prefix (B1 fix): release.yml's build-pkgs-portable job
+      # now builds + uploads them too, so the release-verification path has a
+      # real deppkgs artifact to download -- it no longer needs forcing to '[]'.
+      extra_pkgs: ${{ toJson(matrix.extra_pkgs) }}
+      # dep_artifact composes the SAME way pkg_artifact does just below:
+      # pkg_artifact_prefix set -> '<prefix>-deppkgs-fbsd<major>' (release.yml's
+      # build-pkgs-portable is per-major-deduped, no image_name discriminator
+      # needed there); blank -> this job's own per-row dep_artifact_name above.
+      dep_artifact: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-deppkgs-fbsd{1}', inputs.pkg_artifact_prefix, matrix.freebsd_major) || format('pfBlockerNG-deppkgs-fbsd{0}-{1}', matrix.freebsd_major, matrix.image_name) }}
       # pkg_artifact_prefix set: the prebuilt artifact a caller (e.g. release.yml)
       # already published, named '<prefix>-fbsd<freebsd_major>' (issue #1806 --
       # release.yml builds ONE .pkg per major, shared by every variant/version on

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -260,6 +260,10 @@ jobs:
       artifact_name: pfBlockerNG-pkg-fbsd${{ matrix.freebsd_major }}-${{ matrix.image_name }}
       ports_repo: pfBlockerNG/FreeBSD-ports
       ports_ref: pfblockerng/use-github
+      # issue #1806 D1: this leg's dep .pkgs (e.g. textproc/py-charset-normalizer
+      # for CE), uploaded separately as pfBlockerNG-deppkgs-fbsd<freebsd_major>
+      # when non-empty — smoke-single.yml downloads + installs them (D2/D3).
+      extra_pkgs: ${{ toJson(matrix.extra_pkgs) }}
 
   # ── 3. Per-leg smoke run (parallel, fail-fast: false) ────────────────────────
   #
@@ -315,6 +319,14 @@ jobs:
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
       php_version: ${{ matrix.php_version }}
       py_flavor: ${{ matrix.py_flavor }}
+      # issue #1806 D1/D2: this leg's dep .pkgs — smoke-single.yml downloads
+      # pfBlockerNG-deppkgs-fbsd<freebsd_major> (the build-pkg job above
+      # uploaded it) and exports SMOKE_DEP_PKGS when non-empty. Gated the SAME
+      # way as build-pkg's own `if:` above: pkg_artifact_prefix set means THIS
+      # job never ran (a release.yml-style caller supplies its own prebuilt
+      # per-major artifact and, for now, no matching deppkgs artifact — that's
+      # step E) — so there is no deppkgs artifact to download in that case.
+      extra_pkgs: ${{ inputs.pkg_artifact_prefix == '' && toJson(matrix.extra_pkgs) || '[]' }}
       # pkg_artifact_prefix set: the prebuilt artifact a caller (e.g. release.yml)
       # already published, named '<prefix>-fbsd<freebsd_major>' (issue #1806 --
       # release.yml builds ONE .pkg per major, shared by every variant/version on

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -91,7 +91,7 @@ on:
         required: false
         default: "3"
       pkg_artifact_prefix:
-        description: "Name prefix of prebuilt per-leg package artifacts (e.g. from release.yml); each leg downloads '<prefix>-<variant>-<version>-<arch>'. Empty = build internally (the build-pkg job runs as before)."
+        description: "Name prefix of prebuilt package artifacts (e.g. from release.yml); each leg downloads '<prefix>-fbsd<freebsd_major>' (one .pkg per FreeBSD major, shared across editions/versions). Empty = build internally (the build-pkg job runs as before)."
         required: false
         default: ""
   # Called by other workflows. A callee sees the CALLER's event_name, so scope
@@ -125,7 +125,7 @@ on:
         type: string
         default: "3"
       pkg_artifact_prefix:
-        description: "Name prefix of prebuilt per-leg package artifacts (e.g. from release.yml); each leg downloads '<prefix>-<variant>-<version>-<arch>'. Empty = build internally."
+        description: "Name prefix of prebuilt package artifacts (e.g. from release.yml); each leg downloads '<prefix>-fbsd<freebsd_major>' (one .pkg per FreeBSD major, shared across editions/versions). Empty = build internally."
         required: false
         type: string
         default: ""
@@ -251,10 +251,13 @@ jobs:
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
       php_version: ${{ matrix.php_version }}
       py_flavor: ${{ matrix.py_flavor }}
-      # Keyed on image_name + pfsense_version (unique per version leg, stable
-      # across its shards) — the smoke job below passes the SAME name as
-      # pkg_artifact so every shard of this leg downloads this one build.
-      artifact_name: pfBlockerNG-pkg-${{ matrix.image_name }}-${{ matrix.pfsense_version }}
+      # fbsd<major>-<image_name> (issue #1806 naming convention; image_name keeps
+      # this leg's artifact distinct from a same-major sibling leg in the SAME
+      # run — this job matrixes over leg_matrix, one row per VERSION, never
+      # deduped by major) — unique per version leg, stable across its shards,
+      # so the smoke job below passes the SAME name as pkg_artifact and every
+      # shard of this leg downloads this one build.
+      artifact_name: pfBlockerNG-pkg-fbsd${{ matrix.freebsd_major }}-${{ matrix.image_name }}
       ports_repo: pfBlockerNG/FreeBSD-ports
       ports_ref: pfblockerng/use-github
 
@@ -312,16 +315,15 @@ jobs:
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64
       php_version: ${{ matrix.php_version }}
       py_flavor: ${{ matrix.py_flavor }}
-      # pkg_artifact_prefix set: the prebuilt per-leg artifact a caller (e.g.
-      # release.yml) already published, named '<prefix>-<variant>-<version>-<arch>'
-      # -- the SAME template ui-tests.yml's ui job downloads (both fan-outs
-      # consume one shared release build). image_name is only ever
-      # pfsense-ce/pfsense-plus today (ponytail: hardcoded 2-way ternary, not a
-      # generic prefix strip -- widen if a 3rd variant ships).
+      # pkg_artifact_prefix set: the prebuilt artifact a caller (e.g. release.yml)
+      # already published, named '<prefix>-fbsd<freebsd_major>' (issue #1806 --
+      # release.yml builds ONE .pkg per major, shared by every variant/version on
+      # it) -- the SAME template ui-tests.yml's ui job downloads (both fan-outs
+      # consume one shared release build).
       # Blank: the .pkg build-pkg already produced for this version leg (issue
       # #857) -- identical to that job's artifact_name, so every shard of this
       # leg finds the SAME shared artifact and downloads it instead of rebuilding.
-      pkg_artifact: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-{1}-{2}-{3}', inputs.pkg_artifact_prefix, (matrix.image_name == 'pfsense-plus' && 'plus' || 'ce'), matrix.pfsense_version, matrix.arch) || format('pfBlockerNG-pkg-{0}-{1}', matrix.image_name, matrix.pfsense_version) }}
+      pkg_artifact: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-fbsd{1}', inputs.pkg_artifact_prefix, matrix.freebsd_major) || format('pfBlockerNG-pkg-fbsd{0}-{1}', matrix.freebsd_major, matrix.image_name) }}
       # Resolved by the prepare step: the marker, and the effective -k (an explicit
       # input, else the impacted auto-derivation, else blank = whole marker).
       pytest_marker: ${{ needs.prepare.outputs.pytest_marker || 'smoke' }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -199,6 +199,11 @@ jobs:
       # normal run is byte-identical.
       ports_repo: ${{ inputs.ports_repo || 'pfBlockerNG/FreeBSD-ports' }}
       ports_ref: ${{ inputs.ports_ref || 'pfblockerng/use-github' }}
+      # issue #1806 D1/D2: this leg's dep .pkgs — uploaded separately as
+      # pfBlockerNG-deppkgs-fbsd<freebsd_major>; the ui job below downloads it
+      # when non-empty (this job only runs when pkg_artifact_prefix is empty,
+      # so no ternary needed here).
+      extra_pkgs: ${{ toJson(matrix.extra_pkgs) }}
 
   # Compute the (tier × version) matrix and the nightly no-commit guard. Emits a
   # JSON `include` list so each leg is a distinct, independently-re-runnable job.
@@ -283,7 +288,7 @@ jobs:
           # Build matrix: ONE .pkg per distinct leg (version/ABI), independent of
           # the tier axis — the tiers for a version all install the SAME package.
           BUILD_INCLUDE="$(printf '%s\n' "$LEGS" | jq -c \
-            '[ .[] | {version: .pfsense_version, image_name, freebsd_major, php_version, py_flavor} ]')"
+            '[ .[] | {version: .pfsense_version, image_name, freebsd_major, php_version, py_flavor, extra_pkgs: (.extra_pkgs // [])} ]')"
           printf 'build_matrix={"include":%s}\n' "$BUILD_INCLUDE" >> "$GITHUB_OUTPUT"
 
           # Cross the tier set with the legs: one matrix item per (tier × leg),
@@ -297,7 +302,8 @@ jobs:
             '($tiers | split(" ")) as $ts
              | [ $ts[] as $t | .[]
                  | {tier: $t, version: .pfsense_version, variant: (.image_name | ltrimstr("pfsense-")),
-                    image_name: .image_name, channel: .channel, freebsd_major: .freebsd_major} ]')"
+                    image_name: .image_name, channel: .channel, freebsd_major: .freebsd_major,
+                    extra_pkgs: (.extra_pkgs // [])} ]')"
           printf 'matrix={"include":%s}\n' "$INCLUDE" >> "$GITHUB_OUTPUT"
           # leg_count = the (tier x leg) matrix size, for the all-ui-passed AND
           # gate's zero-leg guard (distinct from $LEGS' own leg count -- one
@@ -476,6 +482,45 @@ jobs:
           name: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-fbsd{1}', inputs.pkg_artifact_prefix, matrix.freebsd_major) || format('pfBlockerNG-pkg-{0}', matrix.version) }}
           path: pkg
 
+      # issue #1806 D1/D2: this leg's extra_pkgs (e.g. py311-charset-normalizer
+      # for CE) — a SEPARATE artifact from the branch .pkg above (never folded
+      # into `pkg/`, so the N_PKG -eq 1 guard below stays exactly one .pkg).
+      # Skipped when pkg_artifact_prefix is set: that path (e.g. release.yml)
+      # never built a matching deppkgs-fbsd<major> artifact (step E's concern).
+      - name: Resolve dep-pkg artifact need
+        id: depmajor
+        env:
+          EXTRA_PKGS: ${{ toJson(matrix.extra_pkgs) }}
+          PKG_ARTIFACT_PREFIX: ${{ inputs.pkg_artifact_prefix }}
+        run: |
+          set -eu
+          N="$(printf '%s' "$EXTRA_PKGS" | jq 'length')"
+          if [ "$N" -gt 0 ] && [ -z "${PKG_ARTIFACT_PREFIX}" ]; then
+            echo "needed=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download dep packages
+        if: steps.depmajor.outputs.needed == '1'
+        uses: actions/download-artifact@v8
+        with:
+          name: pfBlockerNG-deppkgs-fbsd${{ matrix.freebsd_major }}
+          path: deppkgs
+
+      - name: Export SMOKE_DEP_PKGS
+        if: steps.depmajor.outputs.needed == '1'
+        run: |
+          set -eu
+          N_DEP="$(find deppkgs -type f -name '*.pkg' | wc -l | tr -d ' ')"
+          [ "$N_DEP" -ge 1 ] || { echo "::error::extra_pkgs was non-empty but the deppkgs artifact carried no .pkg"; ls -lR deppkgs || true; exit 1; }
+          DEP_PATHS=""
+          for f in $(find deppkgs -type f -name '*.pkg' | sort); do
+            DEP_PATHS="${DEP_PATHS}$(cd "$(dirname "$f")" && pwd)/$(basename "$f") "
+          done
+          echo "SMOKE_DEP_PKGS=${DEP_PATHS% }" >> "$GITHUB_ENV"
+          echo "resolved SMOKE_DEP_PKGS=${DEP_PATHS% }"
+
       - name: Locate the .pkg + the pulled .qcow2
         id: paths
         run: |
@@ -518,6 +563,10 @@ jobs:
           SMOKE_IMAGE_REF: ${{ steps.ref.outputs.ref }}
           SMOKE_SSH_KEY: smoke_key
           SMOKE_PKG: ${{ steps.paths.outputs.pkg }}
+          # issue #1806 D2: this leg's dep .pkgs (space-separated absolute paths),
+          # set by "Export SMOKE_DEP_PKGS" above when non-empty; stays unset
+          # (empty) otherwise — install-pkg.sh skips deps entirely then.
+          SMOKE_DEP_PKGS: ${{ env.SMOKE_DEP_PKGS }}
           # QEMU NIC MAC + SMBIOS uuid for the VM boot (ADR-24): conftest passes
           # these through to boot_vm.sh. RESOLVED_* come from the "Resolve VM
           # identity" step — the CE pin for a CE image (byte-identical to today),

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -102,7 +102,7 @@ on:
         type: string
         default: ""
       pkg_artifact_prefix:
-        description: "Name prefix of prebuilt per-leg package artifacts (e.g. from release.yml); each leg downloads '<prefix>-<variant>-<version>-<arch>'. Empty = build internally (the build-pkg job runs as before)."
+        description: "Name prefix of prebuilt package artifacts (e.g. from release.yml); each leg downloads '<prefix>-fbsd<freebsd_major>' (one .pkg per FreeBSD major, shared across editions/versions). Empty = build internally (the build-pkg job runs as before)."
         required: false
         type: string
         default: ""
@@ -147,7 +147,7 @@ on:
         required: false
         default: ""
       pkg_artifact_prefix:
-        description: "Name prefix of prebuilt per-leg package artifacts (e.g. from release.yml); each leg downloads '<prefix>-<variant>-<version>-<arch>'. Empty = build internally."
+        description: "Name prefix of prebuilt package artifacts (e.g. from release.yml); each leg downloads '<prefix>-fbsd<freebsd_major>' (one .pkg per FreeBSD major, shared across editions/versions). Empty = build internally."
         required: false
         default: ""
   # Daily run: Tier A render + Tier B (functional + browser). Non-PR-blocking
@@ -288,13 +288,16 @@ jobs:
 
           # Cross the tier set with the legs: one matrix item per (tier × leg),
           # each carrying tier + version (= pfsense_version) + a lowercased `variant`
-          # (ce / plus, from image_name) for a variant-qualified artifact name + image_name + channel.
+          # (ce / plus, from image_name) for a variant-qualified artifact name +
+          # image_name + channel + freebsd_major (issue #1806: the download-name
+          # discriminator when pkg_artifact_prefix is set -- release.yml builds one
+          # .pkg per freebsd_major, no `arch` field exists anywhere any more).
           INCLUDE="$(printf '%s\n' "$LEGS" | jq -c \
             --arg tiers "${TIERS}" \
             '($tiers | split(" ")) as $ts
              | [ $ts[] as $t | .[]
                  | {tier: $t, version: .pfsense_version, variant: (.image_name | ltrimstr("pfsense-")),
-                    image_name: .image_name, channel: .channel, arch: .arch} ]')"
+                    image_name: .image_name, channel: .channel, freebsd_major: .freebsd_major} ]')"
           printf 'matrix={"include":%s}\n' "$INCLUDE" >> "$GITHUB_OUTPUT"
           # leg_count = the (tier x leg) matrix size, for the all-ui-passed AND
           # gate's zero-leg guard (distinct from $LEGS' own leg count -- one
@@ -462,13 +465,15 @@ jobs:
       - name: Download the built pfBlockerNG package
         uses: actions/download-artifact@v8
         with:
-          # pkg_artifact_prefix set: download the prebuilt per-leg artifact a
-          # caller (e.g. release.yml) already published, named
-          # '<prefix>-<variant>-<version>-<arch>' (e.g. myprefix-ce-2.8-amd64).
-          # Blank: the per-version artifact THIS run's build-pkg job just built
-          # (matrix is by version; this leg installs the package matching its
-          # own pfSense base).
-          name: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-{1}-{2}-{3}', inputs.pkg_artifact_prefix, matrix.variant, matrix.version, matrix.arch) || format('pfBlockerNG-pkg-{0}', matrix.version) }}
+          # pkg_artifact_prefix set: download the prebuilt artifact a caller
+          # (e.g. release.yml) already published, named
+          # '<prefix>-fbsd<freebsd_major>' (e.g. myprefix-fbsd15) -- issue #1806:
+          # release.yml builds ONE .pkg per FreeBSD major, shared by every
+          # edition/version on it, so no variant/version/arch discriminator is
+          # needed here. Blank: the per-version artifact THIS run's build-pkg
+          # job just built (matrix is by version; this leg installs the
+          # package matching its own pfSense base).
+          name: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-fbsd{1}', inputs.pkg_artifact_prefix, matrix.freebsd_major) || format('pfBlockerNG-pkg-{0}', matrix.version) }}
           path: pkg
 
       - name: Locate the .pkg + the pulled .qcow2

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -199,11 +199,14 @@ jobs:
       # normal run is byte-identical.
       ports_repo: ${{ inputs.ports_repo || 'pfBlockerNG/FreeBSD-ports' }}
       ports_ref: ${{ inputs.ports_ref || 'pfblockerng/use-github' }}
-      # issue #1806 D1/D2: this leg's dep .pkgs — uploaded separately as
-      # pfBlockerNG-deppkgs-fbsd<freebsd_major>; the ui job below downloads it
-      # when non-empty (this job only runs when pkg_artifact_prefix is empty,
-      # so no ternary needed here).
+      # issue #1806 D1/D2: this leg's dep .pkgs — uploaded separately; the ui
+      # job below downloads it when non-empty (this job only runs when
+      # pkg_artifact_prefix is empty, so no ternary needed here).
       extra_pkgs: ${{ toJson(matrix.extra_pkgs) }}
+      # W1: this job matrixes over build_matrix (one row PER VERSION, never
+      # deduped by major) -- the plain per-major default name would collide if
+      # two same-major rows both carry extra_pkgs. Discriminate by image_name.
+      dep_artifact_name: pfBlockerNG-deppkgs-fbsd${{ matrix.freebsd_major }}-${{ matrix.image_name }}
 
   # Compute the (tier × version) matrix and the nightly no-commit guard. Emits a
   # JSON `include` list so each leg is a distinct, independently-re-runnable job.
@@ -482,30 +485,35 @@ jobs:
           name: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-fbsd{1}', inputs.pkg_artifact_prefix, matrix.freebsd_major) || format('pfBlockerNG-pkg-{0}', matrix.version) }}
           path: pkg
 
-      # issue #1806 D1/D2: this leg's extra_pkgs (e.g. py311-charset-normalizer
+      # issue #1806 D1/D2/B1: this leg's extra_pkgs (e.g. py311-charset-normalizer
       # for CE) — a SEPARATE artifact from the branch .pkg above (never folded
       # into `pkg/`, so the N_PKG -eq 1 guard below stays exactly one .pkg).
-      # Skipped when pkg_artifact_prefix is set: that path (e.g. release.yml)
-      # never built a matching deppkgs-fbsd<major> artifact (step E's concern).
+      # No longer gated on pkg_artifact_prefix being blank (B1 fix): release.yml's
+      # build-pkgs-portable job now builds + uploads the matching dep artifact
+      # too, so the release-verification path (prefix set) has one to download.
       - name: Resolve dep-pkg artifact need
         id: depmajor
         env:
           EXTRA_PKGS: ${{ toJson(matrix.extra_pkgs) }}
-          PKG_ARTIFACT_PREFIX: ${{ inputs.pkg_artifact_prefix }}
         run: |
           set -eu
           N="$(printf '%s' "$EXTRA_PKGS" | jq 'length')"
-          if [ "$N" -gt 0 ] && [ -z "${PKG_ARTIFACT_PREFIX}" ]; then
+          if [ "$N" -gt 0 ]; then
             echo "needed=1" >> "$GITHUB_OUTPUT"
           else
             echo "needed=0" >> "$GITHUB_OUTPUT"
           fi
 
+      # dep-pkg artifact name mirrors the branch pkg's OWN pkg_artifact_prefix
+      # ternary just above: prefix set -> '<prefix>-deppkgs-fbsd<major>'
+      # (release.yml's build-pkgs-portable is per-major-deduped, no image_name
+      # discriminator needed there); blank -> this run's own build-pkg job's
+      # dep_artifact_name (W1, discriminated by image_name).
       - name: Download dep packages
         if: steps.depmajor.outputs.needed == '1'
         uses: actions/download-artifact@v8
         with:
-          name: pfBlockerNG-deppkgs-fbsd${{ matrix.freebsd_major }}
+          name: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-deppkgs-fbsd{1}', inputs.pkg_artifact_prefix, matrix.freebsd_major) || format('pfBlockerNG-deppkgs-fbsd{0}-{1}', matrix.freebsd_major, matrix.image_name) }}
           path: deppkgs
 
       - name: Export SMOKE_DEP_PKGS

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -153,18 +153,24 @@ jobs:
             MAJOR=$(printf '%s\n' "$ENTRY" | jq -r '.freebsd_major')
             PHP=$(printf '%s\n' "$ENTRY" | jq -r '.php_version')
             PY=$(printf '%s\n' "$ENTRY" | jq -r '.py_flavor')
-            ARCH=$(printf '%s\n' "$ENTRY" | jq -r '.arch')
 
-            # Filter to target version if specified
+            # Filter to target version if specified. issue #1806: BUILD_MATRIX is
+            # now deduped to one row per freebsd_major, so PFSENSE/CHANNEL are
+            # whichever merged version last wrote that major's row — a
+            # target_version naming the OTHER version sharing that major won't
+            # match (no live collision today; both would build byte-identically
+            # anyway, since the reader hard-errors on a php/py mismatch).
             if [ -n "$TARGET_VERSION" ] && [ "$PFSENSE" != "$TARGET_VERSION" ]; then
               echo "  [skip] ${PFSENSE} (${CHANNEL}) — does not match target '${TARGET_VERSION}'"
               continue
             fi
 
-            # The reader resolves arch (default amd64) on every build entry, so an
-            # aarch64 entry (Plus-only, issue #199) dispatches a FreeBSD:N:aarch64
-            # build; every existing amd64 entry is unchanged.
-            ABI="FreeBSD:${MAJOR}:${ARCH}"
+            # issue #1806: NO_ARCH packages are arch-less; the matrix no longer
+            # carries `arch` at all. "amd64" here is an INERT cpu placeholder —
+            # build-pkg-portable.py wildcards the stamp for any NO_ARCH port
+            # regardless of what's given, so every arch of this FreeBSD major
+            # is served by the one build this triggers.
+            ABI="FreeBSD:${MAJOR}:amd64"
             # Channel maps to pkg channel: CE on devel branch -> devel, main -> stable
             # For standalone tracker runs we use 'devel' as the pkg channel by default.
             # A real release tag push always uses release.yml; this is a build smoke-check.
@@ -172,10 +178,10 @@ jobs:
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "  [DRY-RUN] WOULD dispatch build-pkg-linux.yml:"
-              echo "    pfsense_version=${PFSENSE} (${CHANNEL})  freebsd_major=${MAJOR}  arch=${ARCH}"
+              echo "    pfsense_version=${PFSENSE} (${CHANNEL})  freebsd_major=${MAJOR}"
               echo "    abi=${ABI}  php=${PHP}  py_flavor=${PY}  pkg_channel=${PKG_CHANNEL}"
             else
-              echo "  [TRIGGER] build-pkg-linux.yml for ${PFSENSE} (${CHANNEL}) FreeBSD ${MAJOR}/${ARCH}"
+              echo "  [TRIGGER] build-pkg-linux.yml for ${PFSENSE} (${CHANNEL}) FreeBSD ${MAJOR}"
               # Dispatch the portable Linux builder for this matrix entry.
               # build-pkg-linux.yml expects: channel, abi, php_version, py_flavor.
               # INVARIANT: we dispatch a build-only workflow — no commits, no pushes.

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -924,15 +924,30 @@ pfb_resolve_utf8_ctype() {
 **Load-bearing invariant. Do not "simplify" it away** (it keeps getting wrongly re-derived). The
 self-hosted catalog (ADR-17/20) is keyed by a **varver** — the pfSense edition+version slug
 `ce-2.8` / `plus-26.03` (`catalog_name_from_version()` in `scripts/build-repo-portable.py`) —
-**never** by the pkg `${ABI}` (`FreeBSD:<major>:<arch>`).
+**never** by the pkg `${ABI}`.
 
-**Why (the trap).** pkg's `${ABI}` carries only the FreeBSD major + arch. A pfSense `${ABI}` is
-**NOT in 1:1 correspondence** with a pfSense version or its package-build inputs (the `php<XY>` /
-`py3<XY>` flavors). Multiple pfSense versions/editions can share one FreeBSD major — hence one
-`${ABI}` — while shipping **different** PHP/Python. So `FreeBSD:16:amd64` does not tell you whether
-the box needs the php8.5 build or some later/other php build; an `${ABI}`-keyed conf would serve the
-wrong package. The varver encodes exactly the `(edition, version) → (php, py)` mapping that `${ABI}`
-cannot.
+**2026-07-28 update (issue #1806): `arch` is retired — the invariant gets STRONGER, not weaker.**
+Every `pfSense-pkg-pfBlockerNG` port is `NO_ARCH`, so a real package's manifest ABI is
+CPU-wildcarded (`FreeBSD:<major>:*`) and the catalog is arch-less (`release/<varver>/` directly,
+no arch subdirectory — one varver directory serves every arch of its FreeBSD major). This does
+**not** change the varver-keying conclusion below — a *box's own* concrete ABI (`pkg config abi`
+→ `FreeBSD:<major>:<arch>`) still carries only the FreeBSD major (the arch segment was never the
+load-bearing part of the trap; see "Why" next), so the same "multiple editions can share one major"
+collision still applies, one field narrower than before. The BUILD matrix
+(`scripts/read-version-matrix.sh --print-build`) now dedupes to **one row per freebsd_major**
+(hard-erroring if two versions sharing a major disagree on `php_version`/`py_flavor`) purely as a
+**build-efficiency** optimization (one wildcard-ABI `.pkg` build serves every edition/version on
+that major) — it changes nothing about how the catalog is *keyed* or *served*: the CI matrix and
+ROUTE matrix stay one row per version, and every served catalog path is still `release/<varver>/`,
+never `release/<freebsd_major>/`.
+
+**Why (the trap).** A box's own `${ABI}` (`pkg config abi`) carries only the FreeBSD major (+ its
+own concrete arch, irrelevant to our NO_ARCH package). It is **NOT in 1:1 correspondence** with a
+pfSense version or its package-build inputs (the `php<XY>` / `py3<XY>` flavors). Multiple pfSense
+versions/editions can share one FreeBSD major — hence one `${ABI}` major — while shipping
+**different** PHP/Python. So `FreeBSD:16` does not tell you whether the box needs the php8.5 build
+or some later/other php build; an `${ABI}`-keyed conf would serve the wrong package. The varver
+encodes exactly the `(edition, version) → (php, py)` mapping that `${ABI}` cannot.
 
 **Proof (live, 2026-06, Plus 26.03.1).** `pkg config abi` → `FreeBSD:16:amd64`, but **Netgate's own
 repo URL** is
@@ -943,9 +958,11 @@ version-pinned conf on each upgrade (server-side) instead.
 
 **Do NOT conclude "the current matrix is 1:1, so `${ABI}` suffices."** That 1:1 (CE→FreeBSD15,
 Plus→FreeBSD16) is **incidental and not guaranteed** — CE and Plus have shared FreeBSD bases before,
-and the supported window can hold two versions on one major with different deps at any time. A
-fail-closed CI guard may reject a matrix that introduces such a collision, but the design **stays
-varver-keyed regardless**.
+and the supported window can hold two versions on one major with different deps at any time. That
+fail-closed CI guard now EXISTS: `read-version-matrix.sh`'s BUILD-matrix dedup hard-errors when two
+entries share a `freebsd_major` with disagreeing `php_version`/`py_flavor` (issue #1806) — but the
+design **stays varver-keyed regardless**; the guard only rejects an *unresolvable* collision, it
+does not make `${ABI}` (or `freebsd_major`) a valid catalog key.
 
 **Upgrade consequence (verified — libpkg + `pfSense-upgrade`).** Because the conf is version-pinned it
 cannot auto-follow a version-crossing upgrade the way an `${ABI}` template would, and there is **no
@@ -959,8 +976,8 @@ one-pkg-run lag. The boot-time generator hook below closes that lag.
 
 **`rc.d` generator hook (`scripts/rc.d/pfblockerng_repo_generate.sh`).** Installed on-box by
 `add-repo.sh` into `/usr/local/etc/rc.d/`; runs at every boot. It is a pure conf **regenerator**:
-for each of our conf files that exists, it detects the box's `<varver>/<arch>` and
-**unconditionally overwrites** the conf with the canonical body (channel-correct URL + a marker
+for each of our conf files that exists, it detects the box's `<varver>` (arch-less, issue #1806)
+and **unconditionally overwrites** the conf with the canonical body (channel-correct URL + a marker
 comment). **No `pkg` call, no network, no snapshot, no reconcile, no parse-and-compare** —
 re-deriving the conf from scratch is strictly simpler than diffing and patching one in place, and
 never wrong. Key properties:
@@ -973,13 +990,15 @@ never wrong. Key properties:
   by the time the box first reaches for a catalog. Running this early is safe precisely because it
   is local-file-only (no network, no daemon).
 - **Folded detection (KISS):** edition = "`/etc/product_label` contains `Plus`" → `plus`, else
-  `ce`; version = major.minor of `/etc/version`; arch = the leaf of `pkg config abi`. This mirrors
-  `catalog_name_from_version()` in `scripts/build-repo-portable.py`; there is **no** separate
-  `/lib` detection helper (it is folded into the one self-contained hook file).
+  `ce`; version = major.minor of `/etc/version`. This mirrors `catalog_name_from_version()` in
+  `scripts/build-repo-portable.py`; there is **no** separate `/lib` detection helper (it is folded
+  into the one self-contained hook file). **issue #1806:** the catalog is arch-less, so the hook no
+  longer calls `pkg config abi` at all (it used to read the arch leaf; there is no arch leaf to
+  read any more) — one fewer moving part, and it no longer needs `pkg` on the PATH.
 - **Byte-identical output:** the conf body the hook writes is byte-for-byte identical to
   `add-repo.sh --print-conf`, `build-repo.sh --print-conf`, and `build-repo-portable.py
   --print-conf` (drift-pinned by `tests/test_add_repo_conf.py` across all four producers).
-- **Detection-failure safety:** if version or arch cannot be resolved the hook leaves the existing
+- **Detection-failure safety:** if the version cannot be resolved the hook leaves the existing
   conf **unchanged** (warns) rather than writing a malformed URL.
 - **Always `exit 0`:** every code path ends in `exit 0`. A non-zero exit would wedge the rc.d
   chain; this hook must never do that.
@@ -1015,8 +1034,8 @@ Full design: ADR-39.
   repo** (its `.github/workflows/publish.yml`), NOT this repo. Each run it builds the current
   **devel** `.pkg` by running this repo's own `scripts/build-pkg-portable.py` against a checkout
   of the source (a reusable workflow can't be reused cross-repo — it runs in the caller's context
-  — so it runs the *script*), folds in **every** Release `.pkg`, regenerates the per-ABI catalog
-  with `scripts/build-repo-portable.py`, and deploys to its **own** GitHub Pages via same-repo
+  — so it runs the *script*), folds in **every** Release `.pkg`, regenerates the arch-less
+  per-varver catalog (issue #1806) with `scripts/build-repo-portable.py`, and deploys to its **own** GitHub Pages via same-repo
   OIDC `actions/deploy-pages` → `pfblockerng.github.io/pkg`. **No deploy key, no cross-repo
   secret** — everything it reads from here is public. Triggers: daily `schedule` +
   `workflow_dispatch`. This repo's `release.yml` `repo-publish` job just fires `gh workflow run
@@ -1042,9 +1061,13 @@ Full design: ADR-39.
   hardcoded CE/Plus: `tests/smoke/_matrix.py` (unit-tested off-box by `tests/test_smoke_matrix.py`)
   reads `SMOKE_MATRIX_JSON` (smoke-single.yml injects `read-version-matrix.sh --print-build` at job start,
   egress open), falls back to running that script, and SKIPs the topology cases when neither is
-  available. Per-leg `SMOKE_ABI`/`SMOKE_PHP_VERSION`/`SMOKE_PY_FLAVOR` select within it; adding a
-  pfSense version needs no edit here. (`scripts/install-from-repo.sh` likewise derives its
-  `py3xx-*` deps from the matrix via the box's ABI.) Dispatch: `gh workflow run smoke-single.yml -f
+  available. Per-leg `SMOKE_ABI`/`SMOKE_PHP_VERSION`/`SMOKE_PY_FLAVOR` select within it (SMOKE_ABI
+  stays a CONCRETE guest ABI); when it matches more than one edition sharing a `freebsd_major`
+  (issue #1806 — no `arch` left to disambiguate by), `SMOKE_IMAGE_REF` (already exported by
+  smoke-single.yml) breaks the tie by image name, and `_own_entry()` refuses loudly rather than
+  silently picking one when it can't. Adding a pfSense version needs no edit here.
+  (`scripts/install-from-repo.sh` likewise derives its `py3xx-*` deps from the matrix, matching the
+  box's FreeBSD major.) Dispatch: `gh workflow run smoke-single.yml -f
   pytest_marker=repo` (or `repo-install.yml` once it lands on `devel`). The gated
   `test_install_from_live_pages_url` (`SMOKE_REPO_LIVE_URL`) hits the real `pfblockerng.github.io`
   URL — post-merge (a new `workflow_dispatch` workflow is only dispatchable from the default

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1045,11 +1045,16 @@ Full design: ADR-39.
   publishes within seconds; additive + isolated (`needs: [release]`), so its failure never breaks
   `release`/`sync-ports-fork`/`attach-pkgs`. The FreeBSD `pkg repo` fidelity path
   (`scripts/build-repo.sh`) is retained as a script only. **extra_pkgs dep .pkgs (issue #1806,
-  e.g. CE's `textproc/py-charset-normalizer`) are not yet part of this real publish flow** —
-  `release.yml`'s `build-pkgs-portable` job builds + uploads them and the release-verification
-  gate (smoke-suite/ui-suite) installs from them, proving the mechanism, but `attach-pkgs`
-  attaching the dep `.pkg` to the GitHub Release AND `pfBlockerNG/pkg`'s `publish.yml` folding
-  it into the live served catalog are a tracked follow-up, not yet wired.
+  e.g. CE's `textproc/py-charset-normalizer`) ARE deliberate release assets** —
+  `release.yml`'s `build-pkgs-portable` job builds + uploads each major's dep .pkg as its own
+  `pfBlockerNG-relpkg-deppkgs-fbsd<major>` artifact; `attach-pkgs`'s existing
+  `pfBlockerNG-relpkg-*` sweep picks it up and attaches it to the GitHub Release alongside the
+  branch `.pkg`s (frozen together — the EOL/route-only story wants this); `publish-release`'s
+  healthcheck counts them explicitly (`EXPECTED_PKGS` = distinct-major count + the total
+  extra_pkgs entries across the build matrix). The remaining follow-up is narrower: the
+  separate `pfBlockerNG/pkg` repo's `publish.yml` folding the attached dep `.pkg` into the live
+  served catalog (via `build-repo-portable.py --dep-pkgs`, already built for this) is not yet
+  wired there.
 - **Generators + bootstrap:** `scripts/build-repo-portable.py` (primary catalog gen),
   `scripts/build-repo.sh` (fallback + the single `--print-conf` conf template),
   `scripts/add-repo.sh` (client bootstrap — channel is a FLAG: no-arg = release repo, `--nightly`

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1044,7 +1044,12 @@ Full design: ADR-39.
   **`PKG_GITHUB_APP_PRIVATE_KEY`** — `Actions:write` on `pfBlockerNG/pkg` only) so a release
   publishes within seconds; additive + isolated (`needs: [release]`), so its failure never breaks
   `release`/`sync-ports-fork`/`attach-pkgs`. The FreeBSD `pkg repo` fidelity path
-  (`scripts/build-repo.sh`) is retained as a script only.
+  (`scripts/build-repo.sh`) is retained as a script only. **extra_pkgs dep .pkgs (issue #1806,
+  e.g. CE's `textproc/py-charset-normalizer`) are not yet part of this real publish flow** —
+  `release.yml`'s `build-pkgs-portable` job builds + uploads them and the release-verification
+  gate (smoke-suite/ui-suite) installs from them, proving the mechanism, but `attach-pkgs`
+  attaching the dep `.pkg` to the GitHub Release AND `pfBlockerNG/pkg`'s `publish.yml` folding
+  it into the live served catalog are a tracked follow-up, not yet wired.
 - **Generators + bootstrap:** `scripts/build-repo-portable.py` (primary catalog gen),
   `scripts/build-repo.sh` (fallback + the single `--print-conf` conf template),
   `scripts/add-repo.sh` (client bootstrap — channel is a FLAG: no-arg = release repo, `--nightly`
@@ -1059,8 +1064,10 @@ Full design: ADR-39.
   accepted from both generators. The ADR-20 **variant topology** (each leg's ABI / PHP / Python /
   catalog, and the opposite-edition guard) is **derived entirely from the version matrix** — never
   hardcoded CE/Plus: `tests/smoke/_matrix.py` (unit-tested off-box by `tests/test_smoke_matrix.py`)
-  reads `SMOKE_MATRIX_JSON` (smoke-single.yml injects `read-version-matrix.sh --print-build` at job start,
-  egress open), falls back to running that script, and SKIPs the topology cases when neither is
+  reads `SMOKE_MATRIX_JSON` (smoke-single.yml injects `read-version-matrix.sh --print-ci` at job start —
+  issue #1806 W3: never `--print-build`, which dedupes by `freebsd_major` and would hide a same-major
+  second edition from this topology entirely — egress open), falls back to running that script, and
+  SKIPs the topology cases when neither is
   available. Per-leg `SMOKE_ABI`/`SMOKE_PHP_VERSION`/`SMOKE_PY_FLAVOR` select within it (SMOKE_ABI
   stays a CONCRETE guest ABI); when it matches more than one edition sharing a `freebsd_major`
   (issue #1806 — no `arch` left to disambiguate by), `SMOKE_IMAGE_REF` (already exported by

--- a/docs/misc/pfSense_versions.md
+++ b/docs/misc/pfSense_versions.md
@@ -39,6 +39,14 @@ Observed on a CE **2.8.1** box; 2.8.0 shares the same base toolchain.
 > (`scripts/read-version-matrix.sh`). `scripts/check_version_literals.py`
 > (pre-commit + CI) enforces this; escape a genuine one-off with an inline
 > `# version-literal-ok: <reason>` comment.
+>
+> **`arch` is retired from the matrix (issue #1806).** Every
+> `pfSense-pkg-pfBlockerNG` port is `NO_ARCH`, so one wildcard-ABI `.pkg`
+> build serves every CPU arch of a FreeBSD major — `supported-versions.json`
+> entries no longer carry an `arch` field at all (a stray one on an old row
+> is tolerated-ignored, never resurrected as a default). The BUILD matrix
+> (`read-version-matrix.sh --print-build`) dedupes to one row per distinct
+> `freebsd_major` and gains `extra_pkgs` — see below.
 
 ### pfBlockerNG runtime dependencies (port `RUN_DEPENDS`)
 
@@ -47,12 +55,14 @@ smoke image **bakes** them so the harness `pkg add` of the branch `.pkg` resolve
 them from the local pkg db **offline** (see `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_RUNBOOK.md`
 §3). A missing dep → `pkg add` "Missing dependency" → bad image, re-bake.
 
-These are the port's explicit `RUN_DEPENDS` (9 packages), verified against
-`net/pfSense-pkg-pfBlockerNG-devel/Makefile`. To bake them onto an image, run
+These are the port's explicit `RUN_DEPENDS` (10 packages, issue #1806 — fixes a
+pre-existing drift against the port Makefile: this table had stopped at 9),
+verified against `net/pfSense-pkg-pfBlockerNG-devel/Makefile`. To bake them
+onto an image, run
 [`scripts/misc/install_deps_CE_2.8.sh`](../../scripts/misc/install_deps_CE_2.8.sh)
 on the box (as root):
 
-> **The built `.pkg` records 12 dependencies, not 9.** Besides these 9,
+> **The built `.pkg` records 13 dependencies, not 10.** Besides these 10,
 > `make package` records the three that `USES=php` (`USE_PHP=intl`) and
 > `USES=python` inject: `php83` (`lang/php83`), `php83-intl` (`devel/php83-intl`)
 > and `python311` (`lang/python311`) on 2.8.x. They are *not* literal
@@ -72,6 +82,7 @@ on the box (as root):
 | `net-mgmt/grepcidr` | `bin/grepcidr` | CIDR matching on the IP path |
 | `net-mgmt/iprange` | `bin/iprange` | IP-range aggregation on the IP path |
 | `textproc/gnugrep` | `bin/ggrep` | GNU grep (vs base BSD grep) for the list-processing pipeline |
+| `textproc/py-charset-normalizer` (`py311-charset-normalizer`) | — | Character-encoding detection (issue #1806) — see the CE-only note below |
 
 Notes:
 
@@ -85,3 +96,13 @@ Notes:
   but the built `.pkg` still depends on `php83` + `php83-intl` + `python311`
   because `USES=php`/`USES=python` inject them (see the note above). Unbound is a
   base component and is not a package dependency at all.
+- **`py311-charset-normalizer` is CE-only from OUR repo (issue #1806).** Netgate's
+  own pfSense CE package repo does not carry it (they build it for Plus only), so
+  `pkg install pfSense-pkg-pfBlockerNG` on a stock CE box cannot resolve that
+  RUN_DEPENDS from Netgate's mirror. Our self-hosted pkg repo (ADR-17) builds and
+  serves it itself: `supported-versions.json`'s CE entry carries
+  `extra_pkgs: ["textproc/py-charset-normalizer"]` (Plus's entry carries
+  `extra_pkgs: []` — Netgate already ships it there), `scripts/build-dep-pkg-portable.py`
+  builds a NO_ARCH `.pkg` for it straight from the FreeBSD-ports port definition
+  (no FreeBSD host needed), and `build-repo-portable.py --dep-pkgs` folds the
+  result into the release/nightly catalogs of every matching FreeBSD major.

--- a/docs/misc/pfSense_versions.md
+++ b/docs/misc/pfSense_versions.md
@@ -107,7 +107,9 @@ Notes:
   (no FreeBSD host needed), and `build-repo-portable.py --dep-pkgs` folds the
   result into the release/nightly catalogs of every matching FreeBSD major. The
   release-verification CI gate (release.yml's smoke-suite/ui-suite) proves this
-  end to end against the built artifacts; wiring the REAL published catalog —
-  attaching the dep `.pkg` to the GitHub Release and having the separate
-  `pfBlockerNG/pkg` repo's `publish.yml` carry it into the live served tree — is
-  a tracked follow-up, not yet done.
+  end to end against the built artifacts, and the dep `.pkg` IS a deliberate
+  GitHub Release asset — `attach-pkgs`'s existing `pfBlockerNG-relpkg-*` sweep
+  attaches it alongside the branch `.pkg`s, and `publish-release`'s healthcheck
+  counts it explicitly. The remaining follow-up is narrower: the separate
+  `pfBlockerNG/pkg` repo's `publish.yml` folding the attached dep `.pkg` into
+  the live served catalog is not yet wired there.

--- a/docs/misc/pfSense_versions.md
+++ b/docs/misc/pfSense_versions.md
@@ -99,10 +99,15 @@ Notes:
 - **`py311-charset-normalizer` is CE-only from OUR repo (issue #1806).** Netgate's
   own pfSense CE package repo does not carry it (they build it for Plus only), so
   `pkg install pfSense-pkg-pfBlockerNG` on a stock CE box cannot resolve that
-  RUN_DEPENDS from Netgate's mirror. Our self-hosted pkg repo (ADR-17) builds and
-  serves it itself: `supported-versions.json`'s CE entry carries
+  RUN_DEPENDS from Netgate's mirror. Our self-hosted pkg repo (ADR-17) builds it
+  and is designed to serve it itself: `supported-versions.json`'s CE entry carries
   `extra_pkgs: ["textproc/py-charset-normalizer"]` (Plus's entry carries
   `extra_pkgs: []` — Netgate already ships it there), `scripts/build-dep-pkg-portable.py`
   builds a NO_ARCH `.pkg` for it straight from the FreeBSD-ports port definition
   (no FreeBSD host needed), and `build-repo-portable.py --dep-pkgs` folds the
-  result into the release/nightly catalogs of every matching FreeBSD major.
+  result into the release/nightly catalogs of every matching FreeBSD major. The
+  release-verification CI gate (release.yml's smoke-suite/ui-suite) proves this
+  end to end against the built artifacts; wiring the REAL published catalog —
+  attaching the dep `.pkg` to the GitHub Release and having the separate
+  `pfBlockerNG/pkg` repo's `publish.yml` carry it into the live served tree — is
+  a tracked follow-up, not yet done.

--- a/docs/misc/version-bump-runbook.md
+++ b/docs/misc/version-bump-runbook.md
@@ -45,8 +45,12 @@ entry — no new shipped file, no extra deploy wiring.
    **`ci-metadata` orphan branch** via a PR against `ci-metadata`. Single source of truth for
    supported versions + their `(freebsd_version, php_version)` build pair; workflows read it at
    runtime via `scripts/read-version-matrix.sh` + `.github/actions/read-version-matrix/` (see
-   `scripts/README.md`). Build + CI: every `ci: true` entry — **CE and Plus** (ADR-24) — gets
-   `.pkg` builds **and** live-VM smoke. Plus runs from a **PRIVATE, licensed** GHCR image
+   `scripts/README.md`). **No `arch` field** (issue #1806 — every port is `NO_ARCH`); if the new
+   entry shares a `freebsd_major` with an existing one, its `php_version`/`py_flavor` MUST match
+   (the BUILD matrix dedupes by major and hard-errors on a mismatch) and add `extra_pkgs` only
+   for a dependency this edition's own upstream repo doesn't carry (e.g. CE's
+   `textproc/py-charset-normalizer`). Build + CI: every `ci: true` entry — **CE and Plus**
+   (ADR-24) — gets `.pkg` builds **and** live-VM smoke. Plus runs from a **PRIVATE, licensed** GHCR image
    (`pfsense-plus`); its VM identity (NIC MAC + SMBIOS uuid, keying the Netgate Device ID) comes
    from the `SMOKE_PLUS_MAC`/`SMOKE_PLUS_SMBIOS_UUID` (+ optional `SMOKE_PLUS_NDI`) secrets —
    **never** the matrix — and the harness redacts it from diagnostics. Adding the entry + letting

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,10 +48,10 @@ for the ROUTE matrix (see below).
   "pfsense_version": "2.8",          # pfSense Major.Minor family (CE: Y.Z; Plus: YY.MM)
   "channel":         "CE",           # CE | Plus
   "freebsd_version": "15.0-RELEASE", # full FreeBSD version string (build env)
-  "freebsd_major":   "15",           # FreeBSD major (ABI dedup key; artifact suffix)
+  "freebsd_major":   "15",           # FreeBSD major (BUILD-matrix dedup key)
   "php_version":     "8.3",          # PHP version (pinned so USES=php dep names match)
   "py_flavor":       "py311",        # Python flavor for build-pkg-linux.yml
-  "arch":            "amd64",        # OPTIONAL; ABI arch (amd64 | aarch64). Omit => amd64. aarch64 = Netgate ARM appliances, Plus-only (issue #199)
+  "extra_pkgs":      [],             # OPTIONAL; port origins to build+fold in as deps (issue #1806, e.g. ["textproc/py-charset-normalizer"] for CE). Omit => []
   "status":          "active",       # beta | active (legacy alias: GA) — the reconcile flip PR writes "active"
   "ci":              true,           # include in the smoke CI fan-out (CE + Plus; Plus from a private licensed image, ADR-24)
   "role":            "build"         # OPTIONAL; "build" (default, absent => build) | "route-only"
@@ -61,30 +61,35 @@ for the ROUTE matrix (see below).
 The `role` field controls how the catalog generator treats an entry:
 
 - **Absent or `"build"`** (today's behaviour; back-compat): the entry is built, smoke-tested,
-  and its `release/<varver>/<arch>/` catalog is regenerated from the fresh build each run. An
+  and its `release/<varver>/` catalog is regenerated from the fresh build each run. An
   absent `role` is always treated as `"build"` — no existing entry needs to change.
 - **`"route-only"`**: the entry's release catalog is regenerated from its **last frozen `.pkg`**
-  (a GitHub Release asset) and served at `release/<varver>/<arch>/` — but it is **not** rebuilt,
+  (a GitHub Release asset) and served at `release/<varver>/` — but it is **not** rebuilt,
   not included in `--print-build` / `--print-ci` / `--print-test`, and not smoke-tested. This
   is the EOL state: a pfSense version that has left the build matrix still gets its route served
   so existing boxes can `pkg install`/`upgrade`. A truly dropped entry (no route at all) is
   simply absent from the JSON.
 
-`--print-route` emits the **ROUTE matrix** — the BUILD matrix UNION `role=route-only` entries.
-This is every entry with an actively served `release/<varver>/<arch>/` catalog. The publish
-pipeline uses `--print-route` minus `--print-build` to enumerate the `route-only` entries whose
-frozen `.pkg` it needs to feed to the catalog generator.
+`--print-route` emits the **ROUTE matrix** — build-role-eligible entries (one row per version,
+never deduped) UNION `role=route-only` entries. This is every entry with an actively served
+`release/<varver>/` catalog. The publish pipeline uses `--print-route` minus `--print-build`
+to enumerate the `route-only` entries whose frozen `.pkg` it needs to feed to the catalog
+generator.
 
 > **`ci-metadata` schema note:** the `role` field is applied by a PR against the `ci-metadata`
 > orphan branch (edit `supported-versions.json` there, same as adding/dropping a version). No
 > real version is currently `route-only` — the field is added to the schema so the machinery is
 > in place when the min supported pfSense first advances (ADR-27 Part 2).
 
-The reader resolves `arch` to `amd64` when omitted (or empty), so a pre-#199 matrix
-builds exactly as before. The build path keys on `(freebsd_major, arch)`, so an
-`aarch64` entry produces its own `FreeBSD:N:aarch64` `.pkg` alongside the amd64 one.
-ARM is **Plus-only** (pfSense CE is amd64-only). Live-VM smoke stays amd64 — no ARM
-image yet, so an `aarch64` entry should set `ci: false` (build + distribute only).
+**There is no `arch` field (issue #1806 — supersedes issue #199's ARM/aarch64 plan).** Every
+`pfSense-pkg-pfBlockerNG` port is `NO_ARCH`: one wildcard-ABI `.pkg` build serves every CPU
+arch of a FreeBSD major, so the catalog is arch-less and the BUILD matrix (`--print-build`)
+dedupes to **one row per distinct `freebsd_major`** — `php_version`/`py_flavor` must agree
+across every version sharing a major (a mismatch is a hard reader error), and `extra_pkgs`
+unions across the merged rows. The CI matrix (`--print-ci`) and ROUTE matrix (`--print-route`)
+stay **one row per version** (never deduped — a smoke/UI leg needs every version's own
+identity). A stray `arch` key on an old row is tolerated-ignored, never resurrected as a
+default.
 
 ### Lifecycle policy
 
@@ -123,10 +128,11 @@ pfBlockerNG is a `NO_BUILD` port (nothing compiles) and `pkg add` checks a depen
 
 ### Where `.pkg` artifacts land
 
-A tag push (`vX.Y.Z[-devel]`) triggers `release.yml`, which reads `build_matrix` and
-builds one `.pkg` per entry against its `(freebsd_version, php_version)` pair. Artifacts
-are attached to the **GitHub Release**, deduplicated by FreeBSD major × arch — one `.pkg`
-per distinct `(major, arch)` covers every pfSense version on that major. A build failure surfaces in CI
+A tag push (`vX.Y.Z[-devel]`) triggers `release.yml`, which reads `build_matrix` — already
+deduplicated by `read-version-matrix.sh` to one row per distinct FreeBSD major (issue #1806) —
+and builds one `.pkg` per row against its `(freebsd_version, php_version)` pair. Artifacts
+are attached to the **GitHub Release** named `pfBlockerNG-relpkg-fbsd<major>`; one `.pkg`
+per distinct major covers every pfSense edition/version on it. A build failure surfaces in CI
 but must **not** block the `ports-pr` step (the ports PR is the real distribution path).
 
 The `sync-ports-fork` job in `release.yml` also updates `PORTREVISION` on the ports fork using
@@ -376,20 +382,28 @@ For the smoke matrix, `install-from-repo.sh` is enough and faster. Build the rea
 
 ## ABI: what actually matters for the `.pkg`
 
-pfBlockerNG ships no compiled files, but the port (`net/pfSense-pkg-pfBlockerNG-devel`)
-**run-depends on `net/libmaxminddb`** (a compiled C lib, `mmdblookup`) and does **not**
-set `NO_ARCH`, so the package is ABI-tagged `FreeBSD:<major>:<arch>` (e.g.
-`FreeBSD:15:amd64`).
+pfBlockerNG ships no compiled files of its own — every `net/pfSense-pkg-pfBlockerNG*`
+port sets `NO_ARCH` (issue #1806). A `RUN_DEPENDS` on a compiled C lib (`net/libmaxminddb`,
+`mmdblookup`) doesn't change that: `NO_ARCH` describes THIS port's own payload
+(scripts/PHP/Python, no arch-specific files), and `pkg` resolves that dependency
+separately against the box's own arch. A real package's manifest ABI is therefore
+CPU-wildcarded — `FreeBSD:<major>:*` (e.g. `FreeBSD:15:*`) — never a concrete
+`FreeBSD:<major>:<arch>`.
 
-- `pkg` gates installs on the **OS major**. A `FreeBSD:15` package on a `FreeBSD:16`
-  system is **refused by default**; `pkg add -f` forces it — functionally safe here
-  (no binaries of ours; the smoke image bakes pfBlockerNG's run-deps incl.
-  `libmaxminddb`, so `pkg add` resolves them locally/offline).
-- So **build one `.pkg` per distinct FreeBSD major**, on a FreeBSD VM pinned to that
-  major. One build covers every pfSense version on that major. Rebuild only on a
+- `pkg` gates installs on the **OS major**; the wildcarded CPU segment matches every
+  arch of that major. A `FreeBSD:15` package on a `FreeBSD:16` system is **refused by
+  default**; `pkg add -f` forces it — functionally safe here (no binaries of ours; the
+  smoke image bakes pfBlockerNG's run-deps incl. `libmaxminddb`, so `pkg add` resolves
+  them locally/offline).
+- So **build one `.pkg` per distinct FreeBSD major** — `build-pkg-portable.py --abi
+  FreeBSD:<major>:<cpu>` on ANY host (no FreeBSD VM needed; the portable Linux builder
+  is the sole builder). The `<cpu>` segment is an INERT placeholder for a NO_ARCH port
+  (the builder wildcards the stamp regardless of what's given); one build covers every
+  arch AND every pfSense edition/version on that major. Rebuild only on a
   **FreeBSD-major jump** (rare; coincides with raising the minimum supported version).
-- `NO_ARCH` would wildcard the **arch**, not the OS major — it does not make the
-  package cross-major.
+- The self-hosted catalog (ADR-17) is **arch-less**: `release/<varver>/` holds the
+  catalog directly (no arch subdirectory) — one varver directory serves every arch of
+  its FreeBSD major.
 - pfSense **Plus** artifacts build fine without a Plus license (you only need the
   right FreeBSD-major build env); Plus is also **smoke-tested in CI** from a private,
   licensed GHCR image (ADR-24).
@@ -408,13 +422,14 @@ The scheduled version-tracking + release-automation design is its own ADR.
 ## Catalog generator — release retention
 
 `build-repo-portable.py --build-matrix` generates the self-hosted `pkg` repository tree
-(ADR-17). By default it keeps only the **latest** release of each channel per
-`(version, arch)`, plus the newest package of each major/minor line (line pins, below) —
-the window itself is identical to the pre-ADR-27 behaviour. Three flags control retention:
+(ADR-17; arch-less catalogs, issue #1806). By default it keeps only the **latest** release
+of each channel per varver, plus the newest package of each major/minor line (line pins,
+below) — the window itself is identical to the pre-ADR-27 behaviour. Three flags control
+retention:
 
 | Flag | Default | Purpose |
 | ---- | ------- | ------- |
-| `--release-keep-devel N` | `1` (latest-only) | Retain the N newest devel releases per `(version, arch)` in the `release/` catalog. |
+| `--release-keep-devel N` | `1` (latest-only) | Retain the N newest devel releases per varver in the `release/` catalog. |
 | `--release-keep-stable M` | `1` (latest-only) | Same for the stable channel. |
 | `--release-extra-pkgs PATH` | (none) | Pre-built older-release `.pkg` to fold into the release pool alongside the fresh build (repeatable — pass one per file). The generator prunes the merged pool to `N` / `M` after folding. |
 

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -2,7 +2,7 @@
 # add-repo.sh — bootstrap pfBlockerNG's self-hosted pkg repository on a pfSense
 # box (ADR-17, the client side). Run it ON the pfSense box. It installs the
 # boot-time repo-conf generator rc.d hook (ADR-39), stubs the repo conf so the
-# hook regenerates it for THIS box's edition/version/arch, runs the hook once
+# hook regenerates it for THIS box's edition/version, runs the hook once
 # to resolve the conf now, then runs `pkg update` and VERIFIES the package is
 # visible from the pfBlockerNG repo — after which
 #   pkg install pfSense-pkg-pfBlockerNG-devel   (or -y, no -f, no -r)
@@ -11,7 +11,7 @@
 # install is not repo-locked). Invocation forms: see --help.
 #
 # WHY A HOOK DOES THE DETECTION: a pfSense OS upgrade can change the box's
-# edition/version/arch (which moves the catalog subtree). The rc.d hook
+# edition/version (which moves the catalog subtree). The rc.d hook
 # regenerates the conf every boot, so the URL self-corrects after an upgrade
 # with no work here. add-repo.sh therefore does NO detection itself — it installs
 # the hook and runs it; the hook is the single source of the resolved conf.
@@ -32,8 +32,9 @@
 #
 # THE CONF (single source of truth — byte-identical to `build-repo.sh --print-conf`,
 # `build-repo-portable.py --print-conf`, and what the rc.d hook writes):
-#   url:            Direct GitHub Pages URL, fully resolved by the hook for this box:
-#                   https://pfblockerng.github.io/pkg/<channel>/<varver>/<arch>
+#   url:            Direct GitHub Pages URL, fully resolved by the hook for this box
+#                   (arch-less; NO_ARCH, issue #1806):
+#                   https://pfblockerng.github.io/pkg/<channel>/<varver>
 #   mirror_type:    none.
 #   signature_type: none — NONE-signed; trust anchor is HTTPS to the host (no CI
 #                   signing key). pfSense honors per-repo `none` (ADR §1 Context 4).
@@ -105,7 +106,7 @@ add-repo.sh — bootstrap pfBlockerNG's self-hosted pkg repository (run ON the p
 Usage:
   add-repo.sh                                set up the release repo (stable + devel), pkg update, verify
   add-repo.sh --nightly                      set up the nightly repo instead (bleeding edge; not for daily use)
-  add-repo.sh --print-conf [--nightly] [--catalog-path <varver>/<arch>]
+  add-repo.sh --print-conf [--nightly] [--catalog-path <varver>]
                                              print the repo conf to stdout and exit (no writes)
   add-repo.sh --base-url <url> [--nightly]   override the catalog base (forks/staging)
 
@@ -166,8 +167,8 @@ print_conf() {
 # ${CONF_MARKER} (ADR-39) — do not edit; re-run add-repo.sh to change.
 # pfBlockerNG (${CHANNEL} channel) — self-hosted pkg repository (ADR-17).
 # NONE-signed: trust anchor is HTTPS to the host (no signing key). The URL is
-# fully resolved for this box's edition/version/arch (ADR-39); the boot
-# rc.d hook updates it on a pfSense OS upgrade.
+# fully resolved for this box's edition/version (ADR-39; arch-less/NO_ARCH,
+# issue #1806); the boot rc.d hook updates it on a pfSense OS upgrade.
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
 # resolution (pkg install/upgrade, GUI Install) selects the pfBlockerNG build.
 ${REPO_NAME}: {
@@ -181,11 +182,11 @@ EOF
 }
 
 # ── --print-conf: emit and exit, no side effects (the test + a dry-run use this) ─
-# A resolved URL needs --catalog-path <varver>/<arch> (the live bootstrap leaves
+# A resolved URL needs --catalog-path <varver> (the live bootstrap leaves
 # detection to the hook; --print-conf is a documentation/dry-run aid).
 if [ "$PRINT_CONF" -eq 1 ]; then
     [ -n "${CATALOG_PATH}" ] || {
-        printf 'add-repo: --catalog-path <varver>/<arch> is required with --print-conf\n' >&2
+        printf 'add-repo: --catalog-path <varver> is required with --print-conf\n' >&2
         exit 2
     }
     _url="${BASE_URL%/}/${CHANNEL}/${CATALOG_PATH}"
@@ -226,7 +227,6 @@ printf '==> Running the generator hook to resolve the conf now\n'
 PFB_RELEASE_CONF="${REPOS_DIR}/pfblockerng.conf" \
 PFB_NIGHTLY_CONF="${REPOS_DIR}/pfblockerng-nightly.conf" \
 PFB_BASE_URL="${BASE_URL}" \
-PFB_PKG_BIN="${PKG_BIN}" \
 PFB_PRODUCT_LABEL="${ROOT}/etc/product_label" \
 PFB_VERSION_FILE="${ROOT}/etc/version" \
     sh "${ON_BOX_HOOK}" onestart || true

--- a/scripts/build-dep-pkg-portable.py
+++ b/scripts/build-dep-pkg-portable.py
@@ -423,7 +423,7 @@ def main(argv: list[str]) -> int:
             "example:\n"
             "  build-dep-pkg-portable.py --ports ../FreeBSD-ports \\\n"
             "      --port textproc/py-charset-normalizer --py-flavor py311 \\\n"
-            "      --freebsd-major 15 --python-dep-version 3.11.13 --out-dir /tmp\n"
+            "      --freebsd-major 15 --out-dir /tmp\n"
         ),
     )
     ap.add_argument("--ports", required=True, help="FreeBSD-ports checkout root")
@@ -434,9 +434,17 @@ def main(argv: list[str]) -> int:
     )
     ap.add_argument(
         "--python-dep-version",
-        required=True,
+        default="0",
         dest="python_dep_version",
-        help="version recorded for the python<NNN> RUN_DEPENDS (the target's installed lang/python<NNN> version)",
+        help=(
+            "version recorded for the python<NNN> RUN_DEPENDS. Informational only -- "
+            "pkg(8) resolves a dependency by NAME, never by the version recorded in "
+            "another package's manifest, so this is never enforced at install. Default "
+            "'0' (unknown at build time): lang/python<NNN>'s real PORTVERSION is not a "
+            "literal in its Makefile (it's ${PYTHON_DISTVERSION}, indirect via Mk/Uses/"
+            "python.mk) and deriving it honestly needs the ports framework this tool "
+            "deliberately avoids. Pass an explicit version only if a caller has one."
+        ),
     )
     ap.add_argument("--out-dir", required=True, dest="out_dir", help="output directory for the .pkg")
     ap.add_argument("--compression", choices=("zstd", "xz"), default="zstd", help="output compression (default: zstd)")

--- a/scripts/build-dep-pkg-portable.py
+++ b/scripts/build-dep-pkg-portable.py
@@ -236,10 +236,33 @@ def fetch_verified_sdist(port: PortFacts, dest_dir: Path, *, sha256: str, size: 
 # --------------------------------------------------------------------------- #
 
 
+def _pip_python(work_dir: Path) -> str:
+    """A python executable with a working ``pip`` module.
+
+    ``sys.executable`` (the fast path — true on every CI runner) when it
+    already has one. Some build hosts (the PFB_BOXES minimal Debian pool) ship
+    ``python3-venv`` but not ``pip`` on the system interpreter; there, bootstrap
+    a throwaway venv under ``work_dir`` (a venv's own pip is always present)
+    and return ITS python instead. A venv-creation failure too is a loud
+    refusal, never a silent fall-through.
+    """
+    probe = subprocess.run([sys.executable, "-m", "pip", "--version"], capture_output=True)
+    if probe.returncode == 0:
+        return sys.executable
+    venv_dir = work_dir / "pip-venv"
+    sys.stderr.write(f"==> {sys.executable} has no pip module; bootstrapping a venv at {venv_dir}\n")
+    try:
+        subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+    except subprocess.CalledProcessError as e:
+        raise DepPkgError(f"{sys.executable} has no pip and venv creation failed: {e}") from e
+    return str(venv_dir / "bin" / "python")
+
+
 def build_wheel(sdist: Path, work_dir: Path) -> Path:
     wheel_dir = work_dir / "wheel"
     wheel_dir.mkdir(parents=True, exist_ok=True)
-    cmd = [sys.executable, "-m", "pip", "wheel", "--no-deps", str(sdist), "-w", str(wheel_dir)]
+    python = _pip_python(work_dir)
+    cmd = [python, "-m", "pip", "wheel", "--no-deps", str(sdist), "-w", str(wheel_dir)]
     sys.stderr.write(f"==> building wheel: {' '.join(cmd)}\n")
     subprocess.run(cmd, check=True)
     wheels = sorted(wheel_dir.glob("*.whl"))

--- a/scripts/build-dep-pkg-portable.py
+++ b/scripts/build-dep-pkg-portable.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+# build-dep-pkg-portable.py — build a pfSense-installable FreeBSD .pkg for a
+# single RUN_DEPENDS dependency port DIRECTLY FROM ITS PORT DEFINITION, without
+# a FreeBSD host or the ports framework. Companion to build-pkg-portable.py
+# (which builds the pfBlockerNG port itself); this tool is deliberately narrow:
+# it only understands a pure-Python, NO_ARCH, USE_PYTHON=pep517 port (e.g.
+# textproc/py-charset-normalizer) — anything else is a hard refusal, not a
+# best-effort guess.
+#
+# pfSense CE's own repo does not carry every py3xx- dependency our port needs
+# (Netgate builds some only for Plus). Rather than vendor the wheel, this tool
+# builds the REAL upstream sdist the port's distinfo pins (verified sha256+size),
+# via the port's own BUILD_DEPENDS toolchain (pip wheel, using py-setuptools/
+# py-wheel exactly like `make package` would), and emits a libpkg archive with
+# a real ${PYTHON_PKGNAMEPREFIX}-prefixed name — so a real pfSense box's
+# `pkg install` resolves the RUN_DEPENDS from OUR repo (build-repo-portable.py
+# --dep-pkgs folds the result into the release/nightly catalogs).
+#
+# Steps: (1) parse the port Makefile (reusing build-pkg-portable.py's Makefile
+# class) for PORTNAME/PORTVERSION/DISTNAME/COMMENT/WWW/LICENSE/MASTER_SITES,
+# requiring NO_ARCH=yes + USE_PYTHON containing pep517; (2) read distinfo for
+# the pinned sha256+size; (3) fetch the sdist from a MASTER_SITES-derived URL
+# (PYPI -> the pypi.io redirector; anything else -> the literal site + distfile)
+# and verify it byte-for-byte against distinfo; (4) `pip wheel --no-deps` the
+# sdist and assert the result is a single pure (py3-none-any) wheel; (5) unzip
+# it to its site-packages install paths + generate the wheel's [console_scripts]
+# entry-point stubs; (6) emit via build-pkg-portable.py's Build/Dep/StagedFile/
+# write_pkg (NO_ARCH -> abi/arch wildcarded on CPU, python<NNN> RUN_DEPENDS).
+#
+# Requires: python3 (stdlib) + pip (BUILD_DEPENDS equivalent) + a zstd encoder
+# (see build-pkg-portable.py). Network is required (sdist fetch + pip's own
+# fetch of its build backend). Developer tool — not shipped in release archives.
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_THIS_DIR = Path(__file__).resolve().parent
+_BUILD_PKG_PATH = _THIS_DIR / "build-pkg-portable.py"
+
+
+def _load_build_pkg_portable() -> Any:
+    """Load build-pkg-portable.py (hyphen-named, not import-able normally) as a
+    library, reusing its Makefile parser + Build/Dep/StagedFile/write_pkg —
+    the SAME manifest/archive emission the pfBlockerNG port build uses, so the
+    two tools stay byte-format-identical. Registering in sys.modules BEFORE
+    exec_module (not after) matters: its @dataclass classes need the module
+    resolvable in sys.modules while they're being defined, or dataclass's
+    field-type resolution breaks (the loader convention pinned by
+    tests/test_build_repo_portable.py:49-54).
+    """
+    spec = importlib.util.spec_from_file_location("build_pkg_portable", _BUILD_PKG_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bpp = _load_build_pkg_portable()
+
+
+class DepPkgError(Exception):
+    """A fatal, user-facing error (bad port shape / checksum mismatch / bad wheel)."""
+
+
+# --------------------------------------------------------------------------- #
+# Port parsing — deliberately narrow: refuse anything not NO_ARCH + pep517.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class PortFacts:
+    portname: str
+    portversion: str
+    distname: str
+    comment: str
+    maintainer: str
+    www: str
+    license: str
+    categories: list[str]
+    master_sites: list[str]
+
+
+def read_port(port_dir: Path) -> PortFacts:
+    makefile = port_dir / "Makefile"
+    if not makefile.is_file():
+        raise DepPkgError(f"port Makefile not found: {makefile}")
+    mk = bpp.Makefile(makefile, {})
+
+    no_arch = mk.get("NO_ARCH").strip().lower()
+    if no_arch not in ("yes", "true", "1", "on"):
+        raise DepPkgError(
+            f"{port_dir}: NO_ARCH is not set (got {mk.get('NO_ARCH')!r}) — this tool only "
+            f"builds pure-Python NO_ARCH ports; teach it (or use build-pkg-portable.py's "
+            f"recipe machinery) for anything else"
+        )
+    use_python = mk.get("USE_PYTHON").split()
+    if "pep517" not in use_python:
+        raise DepPkgError(
+            f"{port_dir}: USE_PYTHON does not contain pep517 (got {use_python!r}) — this "
+            f"tool only builds USE_PYTHON=pep517 ports"
+        )
+
+    portname = mk.get("PORTNAME")
+    portversion = mk.get("PORTVERSION")
+    if not portname or not portversion:
+        raise DepPkgError(f"{port_dir}: Makefile missing PORTNAME/PORTVERSION")
+    distname = mk.get("DISTNAME") or f"{portname}-{portversion}"
+
+    www_all = mk.get("WWW").split()
+    licenses = mk.get("LICENSE").split()
+    if not licenses:
+        raise DepPkgError(f"{port_dir}: Makefile has no LICENSE set")
+    master_sites = mk.get("MASTER_SITES").split()
+    if not master_sites:
+        raise DepPkgError(f"{port_dir}: Makefile has no MASTER_SITES set")
+
+    return PortFacts(
+        portname=portname,
+        portversion=portversion,
+        distname=distname,
+        comment=mk.get("COMMENT"),
+        maintainer=mk.get("MAINTAINER"),
+        www=www_all[0] if www_all else "",
+        license=" ".join(licenses),
+        categories=mk.get("CATEGORIES").split(),
+        master_sites=master_sites,
+    )
+
+
+def read_descr(port_dir: Path, fallback: str) -> str:
+    """The pkg-descr body (verbatim, like make package's `desc`), or ``fallback``
+    (COMMENT) when the port has none — reuses build-pkg-portable.py's parser."""
+    descr_path = port_dir / "pkg-descr"
+    if not descr_path.is_file():
+        return fallback
+    desc, _www = bpp.parse_descr(descr_path.read_text())
+    return desc or fallback
+
+
+# --------------------------------------------------------------------------- #
+# distinfo — the pinned sha256 + size for ${DISTNAME}.tar.gz.
+# --------------------------------------------------------------------------- #
+
+
+def read_distinfo(port_dir: Path, distfile: str) -> tuple[str, int]:
+    distinfo = port_dir / "distinfo"
+    if not distinfo.is_file():
+        raise DepPkgError(f"distinfo not found: {distinfo}")
+    text = distinfo.read_text()
+    sha_m = re.search(rf"^SHA256 \({re.escape(distfile)}\) = ([0-9a-f]{{64}})$", text, re.M)
+    size_m = re.search(rf"^SIZE \({re.escape(distfile)}\) = (\d+)$", text, re.M)
+    if not sha_m or not size_m:
+        raise DepPkgError(f"distinfo has no SHA256/SIZE entry for {distfile!r} in {distinfo}")
+    return sha_m.group(1), int(size_m.group(1))
+
+
+# --------------------------------------------------------------------------- #
+# Source acquisition — MASTER_SITES-derived URL(s), sha256+size verified.
+# --------------------------------------------------------------------------- #
+
+
+def candidate_urls(port: PortFacts, distfile: str) -> list[str]:
+    """URL(s) to try, in MASTER_SITES order.
+
+    A bare ``PYPI`` entry is the ports-framework macro (expanded by
+    Mk/bsd.sites.mk, which this tool's Makefile evaluator does not model) —
+    resolved here as the canonical https://pypi.io/packages/source/<letter>/
+    <pypi-name>/<distfile> redirector (the pypi-name is DISTNAME with its
+    trailing "-<version>" stripped: PyPI sdist filenames use the underscore-
+    normalized project name, e.g. "charset_normalizer" for PORTNAME
+    "charset-normalizer"). Any other entry is used literally + distfile.
+    """
+    pypi_name = port.distname
+    suffix = f"-{port.portversion}"
+    if pypi_name.endswith(suffix):
+        pypi_name = pypi_name[: -len(suffix)]
+
+    urls: list[str] = []
+    for site in port.master_sites:
+        if site.strip().upper() == "PYPI":
+            first_letter = (pypi_name[:1] or "_").lower()
+            urls.append(f"https://pypi.io/packages/source/{first_letter}/{pypi_name}/{distfile}")
+        else:
+            urls.append(site.rstrip("/") + "/" + distfile)
+    return urls
+
+
+def _urlopen(url: str):
+    req = urllib.request.Request(url, headers={"User-Agent": "build-dep-pkg-portable"})
+    return urllib.request.urlopen(req)
+
+
+def fetch_verified_sdist(port: PortFacts, dest_dir: Path, *, sha256: str, size: int) -> Path:
+    """Fetch ${DISTNAME}.tar.gz from a MASTER_SITES candidate and verify it
+    against distinfo. A connection failure falls through to the next candidate;
+    a checksum/size MISMATCH is a hard refusal (never silently tried elsewhere —
+    that would mask a poisoned or wrong-version mirror)."""
+    distfile = f"{port.distname}.tar.gz"
+    dest = dest_dir / distfile
+    errors: list[str] = []
+    for url in candidate_urls(port, distfile):
+        try:
+            with _urlopen(url) as r, open(dest, "wb") as f:
+                shutil.copyfileobj(r, f)
+        except OSError as e:
+            errors.append(f"{url}: {e}")
+            continue
+        got_sha = hashlib.sha256(dest.read_bytes()).hexdigest()
+        got_size = dest.stat().st_size
+        if got_sha != sha256 or got_size != size:
+            raise DepPkgError(
+                f"{distfile} fetched from {url} does not match distinfo — refusing "
+                f"(sha256 expected {sha256} got {got_sha}; size expected {size} got {got_size})"
+            )
+        sys.stderr.write(f"==> fetched + verified {url}\n")
+        return dest
+    raise DepPkgError(f"failed to fetch {distfile} from any MASTER_SITES candidate:\n  " + "\n  ".join(errors))
+
+
+# --------------------------------------------------------------------------- #
+# Wheel build — BUILD_DEPENDS py-setuptools/py-wheel equivalent: `pip wheel`.
+# --------------------------------------------------------------------------- #
+
+
+def build_wheel(sdist: Path, work_dir: Path) -> Path:
+    wheel_dir = work_dir / "wheel"
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [sys.executable, "-m", "pip", "wheel", "--no-deps", str(sdist), "-w", str(wheel_dir)]
+    sys.stderr.write(f"==> building wheel: {' '.join(cmd)}\n")
+    subprocess.run(cmd, check=True)
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        raise DepPkgError(f"expected exactly one wheel from `pip wheel`, got {[w.name for w in wheels]}")
+    wheel = wheels[0]
+    if not wheel.name.endswith("-py3-none-any.whl"):
+        raise DepPkgError(
+            f"{wheel.name}: not a pure-Python wheel (expected *-py3-none-any.whl) — "
+            f"this tool refuses to package a platform-specific wheel"
+        )
+    return wheel
+
+
+# --------------------------------------------------------------------------- #
+# Staging: unzip the wheel to its site-packages install paths, generate
+# [console_scripts] entry-point stubs. No .pyc compilation: the build host's
+# python is not necessarily the target's python3.11 (the magic number in a
+# .pyc header is interpreter-version-specific), so a build-host-compiled .pyc
+# would silently fail to load / get ignored on the target — ship .py only,
+# same as a real pep517 port's staged (uncompiled) payload.
+# --------------------------------------------------------------------------- #
+
+_PY_FLAVOR_RE = re.compile(r"^py(\d)(\d+)$")
+
+
+def python_dotted_version(py_flavor: str) -> str:
+    """``py311`` -> ``"3.11"`` (the site-packages dir + shebang interpreter
+    version). Refuses anything that doesn't look like a pyNNN flavor."""
+    m = _PY_FLAVOR_RE.match(py_flavor)
+    if not m:
+        raise DepPkgError(f"unknown --py-flavor {py_flavor!r} (expected pyNNN, e.g. py311)")
+    return f"{m.group(1)}.{m.group(2)}"
+
+
+_ENTRY_POINT_RE = re.compile(r"^([^=\s]+)\s*=\s*([A-Za-z0-9_.]+):([A-Za-z0-9_.]+)\s*$")
+
+
+def parse_console_scripts(entry_points_text: str) -> dict[str, tuple[str, str]]:
+    """Return ``{script_name: (module, function)}`` for the wheel's
+    ``[console_scripts]`` entry_points.txt section. Empty dict if the wheel
+    carries no entry_points.txt or no such section (a library-only wheel)."""
+    scripts: dict[str, tuple[str, str]] = {}
+    section: str | None = None
+    for raw in entry_points_text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip()
+            continue
+        if section != "console_scripts":
+            continue
+        m = _ENTRY_POINT_RE.match(line)
+        if not m:
+            raise DepPkgError(f"unparseable entry_points.txt console_scripts line: {raw!r}")
+        scripts[m.group(1)] = (m.group(2), m.group(3))
+    return scripts
+
+
+# The standard pip/setuptools console-script launcher shape (8 lines incl.
+# shebang) — what a real `pip install` of this wheel would generate.
+_SCRIPT_STUB = """#!/usr/local/bin/python{py_dotted}
+# -*- coding: utf-8 -*-
+import re
+import sys
+from {module} import {func}
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\\.pyw|\\.exe)?$', '', sys.argv[0])
+    sys.exit({func}())
+"""
+
+
+def stage_wheel(wheel: Path, stage_dir: Path, py_dotted: str) -> tuple[list[Path], list[Path]]:
+    """Unzip ``wheel`` into ``stage_dir`` at its real install paths (site-packages
+    for every wheel member, ``/usr/local/bin/<name>`` for each console-script
+    entry point). Returns ``(site_package_files, script_files)`` — absolute
+    Paths under ``stage_dir`` the caller turns into ``StagedFile`` entries."""
+    site_root = stage_dir / "usr/local/lib" / f"python{py_dotted}" / "site-packages"
+    site_root.mkdir(parents=True, exist_ok=True)
+
+    site_files: list[Path] = []
+    entry_points_text = ""
+    with zipfile.ZipFile(wheel) as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            target = site_root / info.filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            data = zf.read(info.filename)
+            target.write_bytes(data)
+            site_files.append(target)
+            if info.filename.endswith(".dist-info/entry_points.txt"):
+                entry_points_text = data.decode("utf-8")
+
+    bin_root = stage_dir / "usr/local/bin"
+    script_files: list[Path] = []
+    for name, (module, func) in parse_console_scripts(entry_points_text).items():
+        bin_root.mkdir(parents=True, exist_ok=True)
+        script = bin_root / name
+        script.write_text(_SCRIPT_STUB.format(py_dotted=py_dotted, module=module, func=func))
+        script.chmod(0o555)
+        script_files.append(script)
+
+    return site_files, script_files
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration + manifest emission (reuses build-pkg-portable.py's Build/Dep/
+# StagedFile/write_pkg — same libpkg archive format, same checksum/tar framing).
+# --------------------------------------------------------------------------- #
+
+
+def build_dep_pkg(args: argparse.Namespace) -> Path:
+    port_dir = Path(args.ports).resolve() / args.port
+    port = read_port(port_dir)
+    py_dotted = python_dotted_version(args.py_flavor)  # validates the flavor too
+
+    distfile = f"{port.distname}.tar.gz"
+    sha256, size = read_distinfo(port_dir, distfile)
+
+    with tempfile.TemporaryDirectory(prefix="pfbng-deppkg-") as td:
+        tmp = Path(td)
+        sdist = fetch_verified_sdist(port, tmp, sha256=sha256, size=size)
+        wheel = build_wheel(sdist, tmp)
+
+        stage = tmp / "stage"
+        site_files, script_files = stage_wheel(wheel, stage, py_dotted)
+        if not site_files:
+            raise DepPkgError(f"{wheel.name}: wheel contained no files")
+
+        portname = f"{args.py_flavor}-{port.portname}"
+        pyv = args.py_flavor[2:]  # "py311" -> "311"
+
+        files: list[Any] = []
+        for f in site_files:
+            files.append(bpp.StagedFile(install_path="/" + str(f.relative_to(stage)), src_in_stage=f, perm="0644"))
+        for f in script_files:
+            files.append(bpp.StagedFile(install_path="/" + str(f.relative_to(stage)), src_in_stage=f, perm="0555"))
+
+        build = bpp.Build(
+            portname=portname,
+            pkgversion=port.portversion,
+            origin=args.port,
+            comment=port.comment,
+            maintainer=port.maintainer,
+            categories=port.categories,
+            licenses=port.license.split(),
+            www=port.www,
+            desc=read_descr(port_dir, port.comment),
+            prefix="/usr/local",
+            # NO_ARCH: wildcard the CPU so one build serves every arch on this
+            # FreeBSD major (real `pkg create` does the same for a NO_ARCH port).
+            abi=f"FreeBSD:{args.freebsd_major}:*",
+            arch=f"freebsd:{args.freebsd_major}:*",
+            deps=[
+                bpp.Dep(name=f"python{pyv}", origin=f"lang/python{pyv}", version=args.python_dep_version),
+            ],
+            files=files,
+        )
+
+        out_dir = Path(args.out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{build.pkgname}.pkg"
+        bpp.write_pkg(build, out_path, args.compression)
+        sys.stderr.write(f"==> wrote {out_path}  ({out_path.stat().st_size} bytes, {len(build.files)} files)\n")
+        return out_path
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(
+        prog="build-dep-pkg-portable.py",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "Build a pfSense-installable, pure-Python NO_ARCH FreeBSD .pkg for a single "
+            "RUN_DEPENDS port, straight from its FreeBSD ports definition — no FreeBSD "
+            "host, no ports framework. Narrow by design: refuses anything that isn't "
+            "NO_ARCH + USE_PYTHON=pep517."
+        ),
+        epilog=(
+            "example:\n"
+            "  build-dep-pkg-portable.py --ports ../FreeBSD-ports \\\n"
+            "      --port textproc/py-charset-normalizer --py-flavor py311 \\\n"
+            "      --freebsd-major 15 --python-dep-version 3.11.13 --out-dir /tmp\n"
+        ),
+    )
+    ap.add_argument("--ports", required=True, help="FreeBSD-ports checkout root")
+    ap.add_argument("--port", required=True, help="port origin, e.g. textproc/py-charset-normalizer")
+    ap.add_argument("--py-flavor", required=True, dest="py_flavor", help="Python flavor, e.g. py311 (pyNNN)")
+    ap.add_argument(
+        "--freebsd-major", required=True, dest="freebsd_major", help="target FreeBSD major, e.g. 15 (CE 2.8)"
+    )
+    ap.add_argument(
+        "--python-dep-version",
+        required=True,
+        dest="python_dep_version",
+        help="version recorded for the python<NNN> RUN_DEPENDS (the target's installed lang/python<NNN> version)",
+    )
+    ap.add_argument("--out-dir", required=True, dest="out_dir", help="output directory for the .pkg")
+    ap.add_argument("--compression", choices=("zstd", "xz"), default="zstd", help="output compression (default: zstd)")
+    args = ap.parse_args(argv)
+
+    try:
+        out_path = build_dep_pkg(args)
+    except (DepPkgError, bpp.BuildError, subprocess.CalledProcessError) as e:
+        sys.stderr.write(f"build-dep-pkg-portable: {e}\n")
+        return 1
+    print(out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/build-dep-pkg-portable.py
+++ b/scripts/build-dep-pkg-portable.py
@@ -236,6 +236,27 @@ def fetch_verified_sdist(port: PortFacts, dest_dir: Path, *, sha256: str, size: 
 # --------------------------------------------------------------------------- #
 
 
+def _run_relayed(cmd: list[str]) -> None:
+    """Run ``cmd`` with its stdout+stderr CAPTURED (never inherited) and relayed
+    to OUR stderr, then raise ``CalledProcessError`` on a nonzero exit — same
+    contract as ``subprocess.run(cmd, check=True)`` for the caller.
+
+    A tool this script shells out to (pip, venv) is chatty on stdout
+    ("Processing ...", "Created wheel ..."). ``main()``'s stdout contract is
+    exactly one line — the emitted .pkg path — because an on-box caller
+    captures this whole process's stdout as that path (``PKG="$(python3
+    build-dep-pkg-portable.py ...)"``); an inherited child stdout leaks that
+    chatter into the captured value and word-splits it into garbage.
+    """
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        sys.stderr.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr)
+
+
 def _pip_python(work_dir: Path) -> str:
     """A python executable with a working ``pip`` module.
 
@@ -252,7 +273,7 @@ def _pip_python(work_dir: Path) -> str:
     venv_dir = work_dir / "pip-venv"
     sys.stderr.write(f"==> {sys.executable} has no pip module; bootstrapping a venv at {venv_dir}\n")
     try:
-        subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+        _run_relayed([sys.executable, "-m", "venv", str(venv_dir)])
     except subprocess.CalledProcessError as e:
         raise DepPkgError(f"{sys.executable} has no pip and venv creation failed: {e}") from e
     return str(venv_dir / "bin" / "python")
@@ -264,7 +285,7 @@ def build_wheel(sdist: Path, work_dir: Path) -> Path:
     python = _pip_python(work_dir)
     cmd = [python, "-m", "pip", "wheel", "--no-deps", str(sdist), "-w", str(wheel_dir)]
     sys.stderr.write(f"==> building wheel: {' '.join(cmd)}\n")
-    subprocess.run(cmd, check=True)
+    _run_relayed(cmd)
     wheels = sorted(wheel_dir.glob("*.whl"))
     if len(wheels) != 1:
         raise DepPkgError(f"expected exactly one wheel from `pip wheel`, got {[w.name for w in wheels]}")

--- a/scripts/build-dep-pkg-portable.py
+++ b/scripts/build-dep-pkg-portable.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import importlib.util
+import os
 import re
 import shutil
 import subprocess
@@ -236,10 +237,11 @@ def fetch_verified_sdist(port: PortFacts, dest_dir: Path, *, sha256: str, size: 
 # --------------------------------------------------------------------------- #
 
 
-def _run_relayed(cmd: list[str]) -> None:
+def _run_relayed(cmd: list[str], **kwargs: Any) -> None:
     """Run ``cmd`` with its stdout+stderr CAPTURED (never inherited) and relayed
     to OUR stderr, then raise ``CalledProcessError`` on a nonzero exit — same
-    contract as ``subprocess.run(cmd, check=True)`` for the caller.
+    contract as ``subprocess.run(cmd, check=True)`` for the caller. Extra
+    ``kwargs`` (e.g. ``env=``) pass through to ``subprocess.run`` verbatim.
 
     A tool this script shells out to (pip, venv) is chatty on stdout
     ("Processing ...", "Created wheel ..."). ``main()``'s stdout contract is
@@ -248,13 +250,24 @@ def _run_relayed(cmd: list[str]) -> None:
     build-dep-pkg-portable.py ...)"``); an inherited child stdout leaks that
     chatter into the captured value and word-splits it into garbage.
     """
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
     if result.stdout:
         sys.stderr.write(result.stdout)
     if result.stderr:
         sys.stderr.write(result.stderr)
     if result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr)
+
+
+# W4 (supply chain, honest middle ground): `pip wheel` builds the sdist's
+# pep517 backend in an ISOLATED build env by default — with no pin, that env
+# fetches whatever is newest on PyPI for the backend itself (setuptools/wheel),
+# a version-drift supply-chain gap this narrows. PIP_CONSTRAINT (below) makes
+# pip apply this EXACT-version pin to the isolated build env too, not just the
+# top-level install. This does NOT close the gap: PyPI is still trusted to
+# serve these exact, named versions honestly (no hash pin) — a deliberate
+# middle ground, not a hermetic build. Bump these periodically.
+_BUILD_BACKEND_CONSTRAINTS = "setuptools==75.6.0\nwheel==0.45.1\n"
 
 
 def _pip_python(work_dir: Path) -> str:
@@ -283,9 +296,15 @@ def build_wheel(sdist: Path, work_dir: Path) -> Path:
     wheel_dir = work_dir / "wheel"
     wheel_dir.mkdir(parents=True, exist_ok=True)
     python = _pip_python(work_dir)
+    # W4: PIP_CONSTRAINT applies to pip's OWN isolated pep517 build env too (not
+    # just this top-level install), pinning the sdist's build backend
+    # (setuptools/wheel) to the exact versions above.
+    constraints_file = work_dir / "build-constraints.txt"
+    constraints_file.write_text(_BUILD_BACKEND_CONSTRAINTS)
+    env = dict(os.environ, PIP_CONSTRAINT=str(constraints_file))
     cmd = [python, "-m", "pip", "wheel", "--no-deps", str(sdist), "-w", str(wheel_dir)]
     sys.stderr.write(f"==> building wheel: {' '.join(cmd)}\n")
-    _run_relayed(cmd)
+    _run_relayed(cmd, env=env)
     wheels = sorted(wheel_dir.glob("*.whl"))
     if len(wheels) != 1:
         raise DepPkgError(f"expected exactly one wheel from `pip wheel`, got {[w.name for w in wheels]}")

--- a/scripts/build-leg.sh
+++ b/scripts/build-leg.sh
@@ -115,6 +115,10 @@ if [ -z "${RUN_ID:-}" ]; then
     if [ -n "${GITHUB_RUN_ID:-}" ]; then
         # CI: slug the ABI into a path-safe LEG token if not externally set.
         # FreeBSD:15:amd64 → freebsd-15-amd64 (colons → dashes; no path separators).
+        # issue #1806: --abi stays a CONCRETE guest/builder ABI here regardless of
+        # the arch-less matrix -- this fallback slug is unaffected by the
+        # major-collapse (callers that want the fbsd<major>-only naming set LEG
+        # explicitly before calling, e.g. release.yml/smoke.yml).
         if [ -z "${LEG:-}" ]; then
             LEG="$(printf '%s' "$ABI" | tr '[:upper:]' '[:lower:]' | tr ':' '-')"
             export LEG

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1457,6 +1457,21 @@ def run_build(args: argparse.Namespace) -> Build:
     seed = seed_vars(portdir, workdir, py_flavor)
     mk = Makefile(makefile, seed)
 
+    # NO_ARCH (issue #1806): a real Netgate noarch package's manifest stamps a
+    # CPU-wildcarded abi/arch (e.g. "FreeBSD:15:*" / "freebsd:15:*") — probed
+    # live — because the package works on every arch of that FreeBSD major.
+    # `abi`/`arch` above stay CONCRETE (still needed verbatim for
+    # --repo-catalogue's pkg.freebsd.org lookup below); only the MANIFEST
+    # fields are wildcarded here. --arch's existing override precedence is
+    # preserved: an explicit --arch is never wildcarded, only the derived
+    # default is.
+    manifest_abi, manifest_arch = abi, arch
+    if _truthy(mk.get("NO_ARCH")):
+        major = abi.split(":")[1]
+        manifest_abi = f"FreeBSD:{major}:*"
+        if not args.arch:
+            manifest_arch = f"freebsd:{major}:*"
+
     prefix = mk.get("PREFIX")
     portname = mk.get("PORTNAME")
     # The version is computed from the Makefile by default; a nightly build overrides
@@ -1504,8 +1519,8 @@ def run_build(args: argparse.Namespace) -> Build:
         www=www,
         desc=desc,
         prefix=prefix,
-        abi=abi,
-        arch=arch,
+        abi=manifest_abi,
+        arch=manifest_arch,
     )
 
     # --- source + recipe -------------------------------------------------- #

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -664,9 +664,12 @@ def build_repo_matrix(
     varver directory serves every arch of that FreeBSD major, so there is
     nothing left to bucket by arch. ``_emit_catalog_from_paths`` hard-rejects a
     concrete-ABI package at emission (never a silent single-arch install).
-    Each matrix row still carries ``arch`` (it drives CI legs and the
-    concrete ``--abi`` fed to the builder, per-row, so build-pkg-portable.py
-    can derive the FreeBSD major — it no longer selects a catalog bucket).
+    ``arch`` is retired from the matrix (issue #1806) — a row no longer carries
+    it. This function still needs a literal CPU segment for the concrete
+    ``--abi`` fed to the builder, per-row, so build-pkg-portable.py can derive
+    the FreeBSD major: it defaults to ``"amd64"`` (a stray legacy ``arch`` key,
+    if a row still carries one, is honored instead) — either way it no longer
+    selects a catalog bucket.
 
     For each matrix entry (each carrying pfsense_version, variant, freebsd_major,
     php_version, py_flavor, optionally arch, and optionally role):

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -59,6 +59,17 @@ CONF_PRIORITY = 100
 # allowed); `/`, `\`, whitespace, and traversal are not.
 _ABI_RE = re.compile(r"^[A-Za-z0-9:._+-]+$")
 
+# A NO_ARCH package's manifest ABI wildcards ONLY the final CPU segment — e.g.
+# "FreeBSD:15:*" (probed live against a real Netgate noarch package; issue
+# #1806). Tight: '*' is valid ONLY as the whole final segment, never elsewhere
+# and never partial — "FreeBSD:*:amd64" / "*" / "FreeBSD:15:*extra" are not ABIs.
+_ABI_WILDCARD_RE = re.compile(r"^[A-Za-z0-9._+-]+:[A-Za-z0-9._+-]+:\*$")
+
+
+def _is_wildcard_abi(abi: object) -> bool:
+    """True if ``abi`` is a NO_ARCH package's tight, CPU-wildcarded ABI string."""
+    return isinstance(abi, str) and bool(_ABI_WILDCARD_RE.fullmatch(abi))
+
 
 class BuildRepoError(Exception):
     """A fatal, user-facing error (bad input / collision / missing tool)."""
@@ -213,18 +224,21 @@ def _flavor_signature(manifest: dict) -> str:
     return ",".join(sorted(flavored))
 
 
-def _dep_pkg_matches_abi(dep_manifest: dict, catalog_abi: str) -> bool:
-    """True if a --dep-pkgs manifest is compatible with ``catalog_abi``.
+def _pkg_matches_abi(manifest: dict, row_abi: str) -> bool:
+    """True if a pre-supplied package's manifest ABI belongs to ``row_abi``'s
+    FreeBSD major (OS+major only — the CPU/arch segment is never compared).
 
-    A NO_ARCH dependency package (build-dep-pkg-portable.py) records a CPU-
-    WILDCARDED abi — e.g. ``"FreeBSD:15:*"`` — because it works on every arch
-    of that FreeBSD major. So it is matched by OS+major only, NOT by exact
-    string equality like the existing per-arch release_extra_pkgs/release_pkgs
-    candidates (:706/:725/:757) — an exact-string compare would never match a
-    wildcarded abi against a catalog's concrete ``"FreeBSD:15:amd64"``.
+    Every package the matrix-driven catalog handles is NO_ARCH (issue #1806):
+    its manifest abi is CPU-wildcarded (e.g. ``"FreeBSD:15:*"``, see
+    ``_is_wildcard_abi``), so an exact string compare against a matrix row's
+    concrete ``"FreeBSD:15:amd64"`` abi would never match. Matching by OS+major
+    is what decides which VARVER catalog(s) a pre-built/frozen/dep package
+    lands in (``route_only_pkgs``/``release_pkgs``/``release_extra_pkgs``/
+    ``dep_pkgs``) — the catalog tree is arch-less, so there is no arch bucket
+    to route into, only a varver.
     """
-    dep_abi = dep_manifest.get("abi", "")
-    return isinstance(dep_abi, str) and dep_abi.split(":")[:2] == catalog_abi.split(":")[:2]
+    abi = manifest.get("abi", "")
+    return isinstance(abi, str) and abi.split(":")[:2] == row_abi.split(":")[:2]
 
 
 def _check_collisions(entries: list[tuple[Path, dict]]) -> None:
@@ -379,10 +393,12 @@ def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict
 # --------------------------------------------------------------------------- #
 # ADR-20: the matrix-driven BRAIN. build_repo_matrix() drives the DUMB
 # build-pkg-portable.py builder per (ci-metadata entry x channel) and projects
-# the matrix 1:1 onto release/<variant>-<major.minor>/<arch>/... (stable+devel,
-# one catalog) and nightly/<variant>-<major.minor>/<arch>/... (retained to N).
-# The leaf is the bare ARCH, not the full ABI (the version segment already
-# implies the FreeBSD major; each .pkg's real ABI lives in its own manifest).
+# the matrix onto release/<variant>-<major.minor>/... (stable+devel, one
+# catalog) and nightly/<variant>-<major.minor>/... (retained to N). Arch-less
+# since issue #1806 (NO_ARCH): the leaf is the varver, not an ABI/arch — every
+# package here is CPU-wildcarded, so one directory serves every arch of that
+# FreeBSD major (each .pkg's real, wildcarded ABI still lives in its own
+# manifest; see _is_wildcard_abi / _emit_catalog_from_paths).
 # FULL MATRIX, NO DEDUP: every entry gets its own subtree.
 # --------------------------------------------------------------------------- #
 
@@ -414,9 +430,27 @@ def _pkg_version_key(version: str) -> tuple[list[int], int, int]:
 
 
 def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path]) -> int:
-    """Read each .pkg's manifest, dedup by (name, version), collision-check, emit at dest."""
+    """Read each .pkg's manifest, dedup by (name, version), collision-check, emit at dest.
+
+    Every package here MUST carry a NO_ARCH (wildcard) ABI (``_is_wildcard_abi``,
+    issue #1806) — the matrix-driven catalog tree is arch-less: one directory
+    (``release/<varver>/`` / ``nightly/<varver>/``) serves every arch of a
+    FreeBSD major, so a concrete-ABI package would silently install on only
+    one. A concrete ABI reaching catalog emission is a hard error — the
+    tripwire that forces a conscious layout decision if a compiled, per-arch
+    dependency is ever added.
+    """
     entries: list[tuple[Path, dict]] = [(p, read_compact_manifest(p)) for p in sorted(set(pkg_paths))]
     _check_collisions(entries)
+    for path, manifest in entries:
+        abi = manifest.get("abi")
+        if not _is_wildcard_abi(abi):
+            raise BuildRepoError(
+                f"{path.name}: catalog requires a NO_ARCH (wildcard-ABI) package — got "
+                f"concrete ABI {abi!r}. The catalog tree is arch-less (one directory serves "
+                f"every arch of a FreeBSD major); a concrete-ABI package would silently "
+                f"install on only one arch. Ship a wildcard-ABI (NO_ARCH) build instead."
+            )
     items: dict[tuple[str, str], tuple[Path, dict]] = {}
     for path, manifest in entries:
         nv = (manifest["name"], manifest["version"])
@@ -620,30 +654,43 @@ def build_repo_matrix(
     dep_pkgs: list[Path] | None = None,
     **builder_kwargs: object,
 ) -> dict:
-    """Build the full variant/arch repository tree from the version matrix.
+    """Build the full variant repository tree from the version matrix.
 
-    For each matrix entry (each carrying pfsense_version, variant, freebsd_major, arch,
-    php_version, py_flavor, and optionally role):
+    issue #1806: the catalog tree is ARCH-LESS — ``release/<varver>/`` and
+    ``nightly/<varver>/`` hold the catalog directly (meta.conf, packagesite.pkg,
+    data.pkg, the .pkg files), with NO per-arch subdirectory. All three
+    pfSense-pkg-pfBlockerNG ports are NO_ARCH: a real package's manifest abi is
+    CPU-wildcarded (``"FreeBSD:<major>:*"``, see ``_is_wildcard_abi``) — one
+    varver directory serves every arch of that FreeBSD major, so there is
+    nothing left to bucket by arch. ``_emit_catalog_from_paths`` hard-rejects a
+    concrete-ABI package at emission (never a silent single-arch install).
+    Each matrix row still carries ``arch`` (it drives CI legs and the
+    concrete ``--abi`` fed to the builder, per-row, so build-pkg-portable.py
+    can derive the FreeBSD major — it no longer selects a catalog bucket).
+
+    For each matrix entry (each carrying pfsense_version, variant, freebsd_major,
+    php_version, py_flavor, optionally arch, and optionally role):
 
     **build entries** (``role`` absent or ``"build"`` — the default, unchanged path):
 
-      * RELEASE subtree ``release/<varver>/<arch>/`` — the devel .pkg, plus the stable
+      * RELEASE subtree ``release/<varver>/`` — the devel .pkg, plus the stable
         .pkg built from ``stable_tag`` (skipped when no stable tag exists), optionally
         folded with pre-built older-release .pkg from ``release_extra_pkgs``, pruned to
         the ``release_keep_devel`` newest devel + ``release_keep_stable`` newest stable.
         Defaults (1/1) reproduce today's latest-only behaviour; setting higher values
         retains older artifacts in the catalog for diagnostics and reproducibility.
-      * NIGHTLY subtree ``nightly/<varver>/<arch>/`` — the freshly built nightly folded in
+      * NIGHTLY subtree ``nightly/<varver>/`` — the freshly built nightly folded in
         with any pre-existing nightlies in that subtree (cache-restored by the caller),
         pruned to the ``nightly_keep`` newest. Skipped when ``build_nightly`` is False.
     **route-only entries** (``role == "route-only"`` — EOL versions served from frozen .pkg):
 
       * NO builder call for a fresh devel-HEAD .pkg — the version is EOL, no new build.
       * NO nightly subtree — a route-only entry never gets a nightly build.
-      * RELEASE subtree ``release/<varver>/<arch>/`` — built EXCLUSIVELY from the frozen
-        .pkg supplied in ``route_only_pkgs[varver]`` (a list of pre-downloaded Release
-        assets, one per arch entry, provided by publish.yml). The existing
-        ``_emit_catalog_from_paths`` machinery handles the rest.
+      * RELEASE subtree ``release/<varver>/`` — built EXCLUSIVELY from the frozen
+        .pkg supplied in ``route_only_pkgs[varver]`` (pre-downloaded Release assets
+        provided by publish.yml — must be NO_ARCH/wildcard-ABI, same as every other
+        catalog input; a concrete-ABI frozen .pkg is rejected at emission). The
+        existing ``_emit_catalog_from_paths`` machinery handles the rest.
       * If ``route_only_pkgs`` has no entry for this ``varver`` (or is ``None``), the call
         raises ``BuildRepoError`` — a route-only entry with no frozen .pkg is a hard error.
 
@@ -651,21 +698,21 @@ def build_repo_matrix(
       Callers (e.g. publish.yml) supply a ``dict[varver, list[Path]]`` mapping the
       ``catalog_name_from_version()`` key (e.g. ``"ce-2.7"``) to the ordered list of
       pre-downloaded .pkg files for that version. publish.yml downloads these from the
-      corresponding GitHub Release tag and passes them here. Each path must be a valid
-      .pkg (readable by ``read_compact_manifest``). The mapping is keyed by ``varver``
-      so multiple arch entries for the same version can share the same frozen .pkg pool
-      (``_emit_catalog_from_paths`` deduplicates by (name, version), so arch-specific
-      or duplicate entries are handled safely).
+      corresponding GitHub Release tag and passes them here. Each path must be a valid,
+      NO_ARCH .pkg (readable by ``read_compact_manifest``). The mapping is keyed by
+      ``varver`` so multiple matrix rows of the same version share the same frozen .pkg
+      pool (``_emit_catalog_from_paths`` deduplicates by (name, version)).
 
     ``release_pkgs`` (optional) — consume pre-built Release .pkg files instead of
       rebuilding devel/stable from source for build-entry matrix rows:
       ``dict[varver, list[Path]]`` mapping ``catalog_name_from_version()`` keys to lists
       of pre-built Release .pkg paths (e.g. all assets downloaded from GitHub Releases
-      by publish.yml). When provided, the ``release/<varver>/<arch>/`` catalog is SERVED
-      from these (ABI-filtered, then pruned by ``retain_by_channel`` with
-      ``release_keep_devel`` / ``release_keep_stable``) instead of calling the builder
-      for devel/stable. ``release_extra_pkgs`` is still folded in after the pool.
-      An empty pool for a (varver, arch) pair skips that release catalog with a warning
+      by publish.yml). When provided, the ``release/<varver>/`` catalog is SERVED
+      from these (matched by OS+major via ``_pkg_matches_abi``, then pruned by
+      ``retain_by_channel`` with ``release_keep_devel`` / ``release_keep_stable``)
+      instead of calling the builder for devel/stable. ``release_extra_pkgs`` is
+      still folded in after the pool.
+      An empty pool for a varver skips that release catalog with a warning
       (no exception raised — a newly-added version with no Release asset yet simply has
       no release-channel package until the next release covers it; nightly still covers
       it from HEAD). Nightly is unaffected — the nightly subtree is always built from
@@ -675,12 +722,15 @@ def build_repo_matrix(
     ``dep_pkgs`` (optional, issue #1806) — pre-built dependency .pkg files (e.g.
       py311-charset-normalizer, built by build-dep-pkg-portable.py) folded into BOTH
       the release AND nightly catalogs of every build-role matrix entry whose ABI
-      matches (OS+major; see ``_dep_pkg_matches_abi`` — a NO_ARCH dep's abi is CPU-
+      matches (OS+major; see ``_pkg_matches_abi`` — a NO_ARCH dep's abi is CPU-
       wildcarded). Folded AFTER retention (``retain_by_channel`` / ``_retain_newest``)
       — NEVER before, or a dep would compete with real releases/nightlies for a
       retention slot. Route-only (frozen EOL) entries never receive a dep pkg. A
-      dep pkg whose ABI matches no emitted catalog is a hard ``BuildRepoError``
-      (fail loud, never a silent drop).
+      dep pkg whose ABI matches no catalog it actually landed in is a hard
+      ``BuildRepoError`` (fail loud, never a silent drop) — matched is tracked only
+      at the point a dep is folded into an EMITTED catalog, never merely because its
+      ABI matched a row (issue #1806 gate-A finding: a matched-but-unemitted dep must
+      still raise).
 
     ``builder`` is injectable (tests pass a stub); the default drives build-pkg-portable.py.
     Extra ``builder_kwargs`` pass through to every builder call. Returns a summary dict.
@@ -722,16 +772,16 @@ def build_repo_matrix(
                     f"A route-only entry without a frozen .pkg would produce an empty or stale "
                     f"catalog; refusing to proceed."
                 )
-            # A varver's frozen pool may carry multiple ABIs (e.g. a Plus amd64 + aarch64
-            # pair). Each (varver, arch) catalog must hold ONLY its own ABI — _emit_catalog
-            # dedups by (name, version), not ABI, so an unfiltered pool would cross-contaminate.
-            frozen = [p for p in frozen_pool if read_compact_manifest(p).get("abi") == abi]
+            # A varver's frozen pool may carry entries for other majors too (matched by
+            # OS+major, never exact-string — every catalog input is NO_ARCH/wildcard-ABI;
+            # _emit_catalog_from_paths hard-rejects a concrete one at emission).
+            frozen = [p for p in frozen_pool if _pkg_matches_abi(read_compact_manifest(p), abi)]
             if not frozen:
                 raise BuildRepoError(
                     f"route-only entry for {varver!r} (version {version}, variant {variant}) has "
                     f"frozen .pkg, but none match ABI {abi!r} — supply a frozen .pkg for this ABI."
                 )
-            release_dir = out_dir / "release" / varver / arch
+            release_dir = out_dir / "release" / varver
             n_release = _emit_catalog_from_paths(release_dir, frozen)
             built.append(str(release_dir))
             sys.stderr.write(f"==> route-only release catalog {release_dir} ({n_release} package(s), frozen)\n")
@@ -740,24 +790,24 @@ def build_repo_matrix(
         else:
             # --- build entry (role absent or "build") ---
 
-            release_dir = out_dir / "release" / varver / arch
+            release_dir = out_dir / "release" / varver
 
-            # --dep-pkgs (issue #1806) ABI-filtered for THIS entry's ABI train
-            # (OS+major; _dep_pkg_matches_abi tolerates a NO_ARCH dep's CPU
-            # wildcard). Folded into release/nightly AFTER retention below —
-            # never before, see build_repo_matrix's docstring.
-            dep_for_abi = [p for p, m in dep_entries if _dep_pkg_matches_abi(m, abi)]
-            dep_pkgs_matched.update(dep_for_abi)
+            # --dep-pkgs (issue #1806) ABI-filtered for THIS entry's ABI train (OS+major;
+            # _pkg_matches_abi tolerates a NO_ARCH dep's CPU wildcard). Folded into
+            # release/nightly AFTER retention below — never before, see build_repo_matrix's
+            # docstring. dep_pkgs_matched is updated ONLY where dep_for_abi actually lands
+            # in an emitted catalog (below), never merely because it matched this row —
+            # marking it matched here unconditionally would let a matched-but-never-emitted
+            # dep escape the end-of-run unmatched check (issue #1806 gate-A finding).
+            dep_for_abi = [p for p, m in dep_entries if _pkg_matches_abi(m, abi)]
 
             if release_pkgs is not None:
-                # --- consume mode: serve release/<varver>/<arch>/ from caller-supplied pre-built .pkg ---
-                # ABI-filtered exactly like the route-only branch; release_extra_pkgs still folded in.
+                # --- consume mode: serve release/<varver>/ from caller-supplied pre-built .pkg ---
+                # Matched exactly like the route-only branch; release_extra_pkgs still folded in.
                 # An empty pool is a warning + skip (not an error) — a newly-added version with no
                 # Release asset yet simply has no release-channel package until the next release.
-                pool = [p for p in (release_pkgs.get(varver) or []) if read_compact_manifest(p).get("abi") == abi]
-                # ABI-filter the extras too: _emit_catalog_from_paths dedups by (name, version),
-                # NOT by ABI, so a wrong-ABI extra would cross-contaminate this arch's catalog.
-                extras = [p for p in (release_extra_pkgs or []) if read_compact_manifest(p).get("abi") == abi]
+                pool = [p for p in (release_pkgs.get(varver) or []) if _pkg_matches_abi(read_compact_manifest(p), abi)]
+                extras = [p for p in (release_extra_pkgs or []) if _pkg_matches_abi(read_compact_manifest(p), abi)]
                 candidates = pool + extras
                 kept_release = retain_by_channel(
                     candidates,
@@ -769,6 +819,7 @@ def build_repo_matrix(
                     n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi)
                     built.append(str(release_dir))
                     sys.stderr.write(f"==> release catalog {release_dir} ({n_release} package(s), consumed)\n")
+                    dep_pkgs_matched.update(dep_for_abi)
                 else:
                     sys.stderr.write(f"==> WARNING: no Release .pkg for {varver} {abi} — release catalog skipped\n")
             else:
@@ -788,9 +839,8 @@ def build_repo_matrix(
                             builder("stable", out_dir=staging, ports=ports, local_src=stable_src or local_src, **common)
                         )
                     # Fold in pre-built older-release candidates (caller-provided, e.g. from GitHub
-                    # Releases), ABI-filtered to this arch — _emit_catalog_from_paths dedups by
-                    # (name, version), not ABI, so a wrong-ABI extra would cross-contaminate.
-                    extras = [p for p in (release_extra_pkgs or []) if read_compact_manifest(p).get("abi") == abi]
+                    # Releases), matched by OS+major (see _pkg_matches_abi).
+                    extras = [p for p in (release_extra_pkgs or []) if _pkg_matches_abi(read_compact_manifest(p), abi)]
                     all_release_pkgs = built_pkgs + extras
                     kept_release = retain_by_channel(
                         all_release_pkgs,
@@ -801,10 +851,11 @@ def build_repo_matrix(
                     n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi)
                 built.append(str(release_dir))
                 sys.stderr.write(f"==> release catalog {release_dir} ({n_release} package(s))\n")
+                dep_pkgs_matched.update(dep_for_abi)
 
             # --- nightly subtree: fold the new build in with retained prior nightlies ---
             if build_nightly:
-                nightly_dir = out_dir / "nightly" / varver / arch
+                nightly_dir = out_dir / "nightly" / varver
                 # Glob the retained package files, EXCLUDING the catalog files (which are also
                 # named *.pkg: packagesite.pkg / data.pkg) — they are not libpkg archives.
                 existing = (
@@ -824,6 +875,7 @@ def build_repo_matrix(
                     n = _emit_catalog_from_paths(nightly_dir, kept + dep_for_abi)
                 built.append(str(nightly_dir))
                 sys.stderr.write(f"==> nightly catalog {nightly_dir} ({n} package(s), kept ≤{nightly_keep})\n")
+                dep_pkgs_matched.update(dep_for_abi)
 
     # A --dep-pkgs entry whose ABI matched no build-role matrix entry is a hard
     # error — never a silent drop (it would otherwise mean a real user's
@@ -841,17 +893,18 @@ def build_repo_matrix(
 def print_conf(resolved_url: str) -> None:
     """Emit the release-channel repo-conf stanza.
 
-    ``resolved_url`` is the fully-resolved URL for the box's edition/version/arch
-    (ADR-39): ``<base>/release/<varver>/<arch>`` — no ``${ABI}`` token.
-    Supply ``--catalog-path <varver>/<arch>`` so tests can pin the exact bytes.
+    ``resolved_url`` is the fully-resolved URL for the box's edition/version
+    (ADR-39; arch-less since issue #1806 — the catalog is NO_ARCH):
+    ``<base>/release/<varver>`` — no ``${ABI}`` token.
+    Supply ``--catalog-path <varver>`` so tests can pin the exact bytes.
     """
     url = resolved_url.rstrip("/")
     sys.stdout.write(
         "# Generated at boot by pfblockerng_repo_generate (ADR-39) — do not edit; re-run add-repo.sh to change.\n"
         "# pfBlockerNG (release channel) — self-hosted pkg repository (ADR-17).\n"
         "# NONE-signed: trust anchor is HTTPS to the host (no signing key). The URL is\n"
-        "# fully resolved for this box's edition/version/arch (ADR-39); the boot\n"
-        "# rc.d hook updates it on a pfSense OS upgrade.\n"
+        "# fully resolved for this box's edition/version (ADR-39; arch-less/NO_ARCH,\n"
+        "# issue #1806); the boot rc.d hook updates it on a pfSense OS upgrade.\n"
         f"# priority {CONF_PRIORITY} sits above the base Netgate `pfSense` repo so cross-repo\n"
         "# resolution (pkg install/upgrade, GUI Install) selects the pfBlockerNG build.\n"
         "pfblockerng: {\n"
@@ -877,7 +930,7 @@ def main(argv: list[str]) -> int:
             "  build-repo-portable.py --in ./pkgs --out ./site --catalog-name ce-2.8\n\n"
             "  # print the client repo-conf (add-repo.sh + README reuse it)\n"
             "  build-repo-portable.py --print-conf --base-url https://example.github.io/pkg\n\n"
-            "  # matrix-driven: build the full variant/arch tree (ADR-20)\n"
+            "  # matrix-driven: build the full variant tree, arch-less (ADR-20; issue #1806)\n"
             "  read-version-matrix.sh --print-build | build-repo-portable.py --build-matrix \\\n"
             "    --matrix-json - --out ./site --ports ./ports --local-src . \\\n"
             "    --nightly-pkgversion 3.2.16.20260615.1\n"
@@ -896,10 +949,10 @@ def main(argv: list[str]) -> int:
         default="",
         dest="catalog_path",
         help=(
-            "catalog subtree for --print-conf, in '<varver>/<arch>' form "
-            "(e.g. 'ce-2.8/amd64', 'plus-26.03/aarch64'). "
+            "catalog subtree for --print-conf, a bare '<varver>' (e.g. 'ce-2.8', "
+            "'plus-26.03') — the catalog is arch-less (NO_ARCH; issue #1806). "
             "When supplied, the emitted url is <base-url>/release/<catalog-path>. "
-            "Required for byte-identical output across all three generators."
+            "Required for byte-identical output across all four generators."
         ),
     )
     ap.add_argument(
@@ -917,9 +970,9 @@ def main(argv: list[str]) -> int:
         "--build-matrix",
         action="store_true",
         help=(
-            "drive build-pkg-portable.py per (matrix entry × channel), lay out the "
-            "release/<varver>/<arch>/ + nightly/<varver>/<arch>/ tree under --out. "
-            "Requires --matrix-json + --out."
+            "drive build-pkg-portable.py per (matrix entry x channel), lay out the "
+            "release/<varver>/ + nightly/<varver>/ tree under --out (arch-less; NO_ARCH, "
+            "issue #1806). Requires --matrix-json + --out."
         ),
     )
     g_matrix.add_argument(
@@ -939,9 +992,7 @@ def main(argv: list[str]) -> int:
     g_matrix.add_argument(
         "--stable-src", default=None, help="source tree checked out at --stable-tag (defaults to --local-src)"
     )
-    g_matrix.add_argument(
-        "--nightly-keep", type=int, default=14, help="nightlies retained per (version, arch) (default 14)"
-    )
+    g_matrix.add_argument("--nightly-keep", type=int, default=14, help="nightlies retained per varver (default 14)")
     g_matrix.add_argument(
         "--nightly-pkgversion",
         default=None,
@@ -954,7 +1005,7 @@ def main(argv: list[str]) -> int:
         default=1,
         dest="release_keep_devel",
         help=(
-            "devel releases retained per (version, arch) in the release catalog (default 1 = latest-only). "
+            "devel releases retained per varver in the release catalog (default 1 = latest-only). "
             "Set >1 to retain multiple devel artifacts for diagnostics and reproducibility. "
             "The publish job must supply the older .pkg via --release-extra-pkgs. "
             "The newest package of every major/minor line is pinned on top of this window, "
@@ -967,7 +1018,7 @@ def main(argv: list[str]) -> int:
         default=1,
         dest="release_keep_stable",
         help=(
-            "stable releases retained per (version, arch) in the release catalog (default 1 = latest-only). "
+            "stable releases retained per varver in the release catalog (default 1 = latest-only). "
             "Set >1 to retain multiple stable artifacts for diagnostics and reproducibility. "
             "The publish job must supply the older .pkg via --release-extra-pkgs. "
             "The newest package of every major/minor line is pinned on top of this window, "
@@ -1021,10 +1072,10 @@ def main(argv: list[str]) -> int:
         dest="release_pkgs",
         metavar="VARVER:PATH",
         help=(
-            "pre-built Release .pkg to SERVE the release/<varver>/<arch>/ catalog from, "
-            "in VARVER:PATH form (repeatable; arch derived from the .pkg manifest ABI). "
+            "pre-built Release .pkg to SERVE the release/<varver>/ catalog from, "
+            "in VARVER:PATH form (repeatable; matched by OS+major, arch-less; issue #1806). "
             "When supplied, devel+stable are consumed from these instead of rebuilt from source. "
-            "An empty pool for a (varver, arch) skips that release catalog (no error)."
+            "An empty pool for a varver skips that release catalog (no error)."
         ),
     )
     g_matrix.add_argument(
@@ -1038,7 +1089,7 @@ def main(argv: list[str]) -> int:
 
     if args.print_conf:
         if not args.catalog_path or not args.catalog_path.strip("/"):
-            ap.error("--print-conf requires --catalog-path <varver>/<arch>")
+            ap.error("--print-conf requires --catalog-path <varver>")
         _base = args.base_url.rstrip("/")
         _cat = args.catalog_path.strip("/")
         print_conf(f"{_base}/release/{_cat}")

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -213,6 +213,20 @@ def _flavor_signature(manifest: dict) -> str:
     return ",".join(sorted(flavored))
 
 
+def _dep_pkg_matches_abi(dep_manifest: dict, catalog_abi: str) -> bool:
+    """True if a --dep-pkgs manifest is compatible with ``catalog_abi``.
+
+    A NO_ARCH dependency package (build-dep-pkg-portable.py) records a CPU-
+    WILDCARDED abi — e.g. ``"FreeBSD:15:*"`` — because it works on every arch
+    of that FreeBSD major. So it is matched by OS+major only, NOT by exact
+    string equality like the existing per-arch release_extra_pkgs/release_pkgs
+    candidates (:706/:725/:757) — an exact-string compare would never match a
+    wildcarded abi against a catalog's concrete ``"FreeBSD:15:amd64"``.
+    """
+    dep_abi = dep_manifest.get("abi", "")
+    return isinstance(dep_abi, str) and dep_abi.split(":")[:2] == catalog_abi.split(":")[:2]
+
+
 def _check_collisions(entries: list[tuple[Path, dict]]) -> None:
     """Fail loud if two .pkg share name+version+ABI but differ in php/py flavor."""
     seen: dict[str, str] = {}  # "name|version|ABI" -> flavor signature
@@ -603,6 +617,7 @@ def build_repo_matrix(
     release_extra_pkgs: list[Path] | None = None,
     route_only_pkgs: dict[str, list[Path]] | None = None,
     release_pkgs: dict[str, list[Path]] | None = None,
+    dep_pkgs: list[Path] | None = None,
     **builder_kwargs: object,
 ) -> dict:
     """Build the full variant/arch repository tree from the version matrix.
@@ -657,12 +672,25 @@ def build_repo_matrix(
       source when ``build_nightly`` is True, regardless of ``release_pkgs``.
       When ``None`` (the default), the existing build-from-source path is used unchanged.
 
+    ``dep_pkgs`` (optional, issue #1806) — pre-built dependency .pkg files (e.g.
+      py311-charset-normalizer, built by build-dep-pkg-portable.py) folded into BOTH
+      the release AND nightly catalogs of every build-role matrix entry whose ABI
+      matches (OS+major; see ``_dep_pkg_matches_abi`` — a NO_ARCH dep's abi is CPU-
+      wildcarded). Folded AFTER retention (``retain_by_channel`` / ``_retain_newest``)
+      — NEVER before, or a dep would compete with real releases/nightlies for a
+      retention slot. Route-only (frozen EOL) entries never receive a dep pkg. A
+      dep pkg whose ABI matches no emitted catalog is a hard ``BuildRepoError``
+      (fail loud, never a silent drop).
+
     ``builder`` is injectable (tests pass a stub); the default drives build-pkg-portable.py.
     Extra ``builder_kwargs`` pass through to every builder call. Returns a summary dict.
     """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     built: list[str] = []
+
+    dep_entries: list[tuple[Path, dict]] = [(p, read_compact_manifest(p)) for p in (dep_pkgs or [])]
+    dep_pkgs_matched: set[Path] = set()
 
     for entry in matrix:
         version = entry["pfsense_version"]
@@ -714,6 +742,13 @@ def build_repo_matrix(
 
             release_dir = out_dir / "release" / varver / arch
 
+            # --dep-pkgs (issue #1806) ABI-filtered for THIS entry's ABI train
+            # (OS+major; _dep_pkg_matches_abi tolerates a NO_ARCH dep's CPU
+            # wildcard). Folded into release/nightly AFTER retention below —
+            # never before, see build_repo_matrix's docstring.
+            dep_for_abi = [p for p, m in dep_entries if _dep_pkg_matches_abi(m, abi)]
+            dep_pkgs_matched.update(dep_for_abi)
+
             if release_pkgs is not None:
                 # --- consume mode: serve release/<varver>/<arch>/ from caller-supplied pre-built .pkg ---
                 # ABI-filtered exactly like the route-only branch; release_extra_pkgs still folded in.
@@ -730,7 +765,8 @@ def build_repo_matrix(
                     keep_stable=release_keep_stable,
                 )
                 if kept_release:
-                    n_release = _emit_catalog_from_paths(release_dir, kept_release)
+                    # dep_for_abi folds in AFTER retention (never competes for a slot).
+                    n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi)
                     built.append(str(release_dir))
                     sys.stderr.write(f"==> release catalog {release_dir} ({n_release} package(s), consumed)\n")
                 else:
@@ -761,7 +797,8 @@ def build_repo_matrix(
                         keep_devel=release_keep_devel,
                         keep_stable=release_keep_stable,
                     )
-                    n_release = _emit_catalog_from_paths(release_dir, kept_release)
+                    # dep_for_abi folds in AFTER retention (never competes for a slot).
+                    n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi)
                 built.append(str(release_dir))
                 sys.stderr.write(f"==> release catalog {release_dir} ({n_release} package(s))\n")
 
@@ -782,9 +819,21 @@ def build_repo_matrix(
                         "nightly", out_dir=staging, ports=ports, local_src=local_src, pkgversion=pkgver, **common
                     )
                     kept = _retain_newest([*existing, new_nightly], nightly_keep)
-                    n = _emit_catalog_from_paths(nightly_dir, kept)
+                    # dep_for_abi folds in AFTER retention here too — the SAME dep pkg
+                    # belongs in both the release and nightly catalogs of this ABI train.
+                    n = _emit_catalog_from_paths(nightly_dir, kept + dep_for_abi)
                 built.append(str(nightly_dir))
                 sys.stderr.write(f"==> nightly catalog {nightly_dir} ({n} package(s), kept ≤{nightly_keep})\n")
+
+    # A --dep-pkgs entry whose ABI matched no build-role matrix entry is a hard
+    # error — never a silent drop (it would otherwise mean a real user's
+    # `pkg install` never sees the dependency it was built for).
+    unmatched = [p for p, _m in dep_entries if p not in dep_pkgs_matched]
+    if unmatched:
+        raise BuildRepoError(
+            "--dep-pkgs ABI matches no emitted catalog (checked every build-role matrix "
+            "entry's ABI; route-only entries never receive a dep pkg): " + ", ".join(str(p) for p in unmatched)
+        )
 
     return {"built": built}
 
@@ -938,6 +987,21 @@ def main(argv: list[str]) -> int:
         ),
     )
     g_matrix.add_argument(
+        "--dep-pkgs",
+        action="append",
+        default=[],
+        dest="dep_pkgs",
+        metavar="PATH",
+        help=(
+            "pre-built dependency .pkg (e.g. py311-charset-normalizer, built by "
+            "build-dep-pkg-portable.py) to fold into BOTH the release AND nightly catalogs "
+            "of every matrix entry whose ABI matches (repeatable). Folded in AFTER "
+            "--release-keep-*/--nightly-keep retention runs — NEVER before, or the dep would "
+            "compete with real releases/nightlies for a retention slot. A dep whose ABI "
+            "matches no emitted catalog is a hard error."
+        ),
+    )
+    g_matrix.add_argument(
         "--route-only-pkgs",
         action="append",
         default=[],
@@ -1001,6 +1065,7 @@ def main(argv: list[str]) -> int:
             k, v = item.split("=", 1)
             annotate[k] = v
         extra_pkgs = [Path(p) for p in args.release_extra_pkgs] if args.release_extra_pkgs else None
+        dep_pkgs_arg = [Path(p) for p in args.dep_pkgs] if args.dep_pkgs else None
         route_only: dict[str, list[Path]] | None = None
         if args.route_only_pkgs:
             route_only = {}
@@ -1031,6 +1096,7 @@ def main(argv: list[str]) -> int:
                 release_keep_devel=args.release_keep_devel,
                 release_keep_stable=args.release_keep_stable,
                 release_extra_pkgs=extra_pkgs,
+                dep_pkgs=dep_pkgs_arg,
                 route_only_pkgs=route_only,
                 release_pkgs=release_pkgs_arg,
                 annotate=annotate or None,

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -194,6 +194,28 @@ for f in "$@"; do
     fi
 done
 
+# True (status 0) iff $1 is EXACTLY the tight NO_ARCH wildcard shape
+# "OS:major:*" (issue #1806) — '*' as the WHOLE final segment, preceded by
+# EXACTLY one colon-separated, non-empty, safe-charset "OS:major" pair.
+# gate-B finding: a charset-only check on `rest` (everything but the trailing
+# ':*') wrongly accepted 'FreeBSD:*' (0 colons in rest — no major segment) and
+# 'FreeBSD:15:16:*' (2 colons in rest — an extra segment); counting colons via
+# LC_ALL=C tr -cd closes both. Shared by validate_abi() and require_noarch_abi()
+# so the tight shape is defined once (ladder rung 2: reuse, not two copies).
+_abi_is_tight_wildcard() {
+    case "$1" in
+        *:\*) : ;;
+        *) return 1 ;;
+    esac
+    rest="${1%:*}"
+    case "$rest" in
+        :*|*:) return 1 ;;
+    esac
+    ncolons="$(printf '%s' "$rest" | LC_ALL=C tr -cd ':')"
+    [ "${#ncolons}" -eq 1 ] || return 1
+    [ "$(printf '%s/' "$rest" | LC_ALL=C tr -d 'A-Za-z0-9:._+-')" = '/' ]
+}
+
 # Reject an ABI that is not a single safe path segment or, when it wildcards
 # the CPU segment (a NO_ARCH package; issue #1806), not in the TIGHT
 # "OS:major:*" shape. The ABI is never used as a directory name any more
@@ -210,14 +232,11 @@ validate_abi() {
     fi
     last="${1##*:}"
     if [ "$last" = "*" ]; then
-        # Tight wildcard: validate the OS:major prefix (everything but the
-        # trailing ':*') against the same safe charset — no '*' anywhere in it.
-        rest="${1%:*}"
-        if [ "$(printf '%s/' "$rest" | LC_ALL=C tr -d 'A-Za-z0-9:._+-')" != '/' ]; then
-            echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
-            exit 1
+        if _abi_is_tight_wildcard "$1"; then
+            return 0
         fi
-        return 0
+        echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
+        exit 1
     fi
     if [ "$(printf '%s/' "$1" | LC_ALL=C tr -d 'A-Za-z0-9:._+-')" != '/' ]; then
         echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
@@ -231,9 +250,9 @@ validate_abi() {
 # silently install on only one arch — the tripwire that forces a conscious
 # layout decision if a compiled, per-arch dependency is ever added.
 require_noarch_abi() {
-    case "$1" in
-        *:\*) return 0 ;;
-    esac
+    if _abi_is_tight_wildcard "$1"; then
+        return 0
+    fi
     echo "build-repo: catalog requires a NO_ARCH (wildcard-ABI) package — got concrete ABI '$1'." >&2
     echo "  The catalog tree is arch-less (one directory serves every arch of a FreeBSD major);" >&2
     echo "  a concrete-ABI package would silently install on only one arch. Ship a wildcard-ABI" >&2

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -1,26 +1,30 @@
 #!/bin/sh
 # build-repo.sh — turn a directory of ONE variant/version's pfBlockerNG .pkg
 # files into a FreeBSD `pkg` repository tree (ADR-17): reads each .pkg's ABI
-# FROM THE PACKAGE (never the filename), lays the catalog out under
-# <out>/release/<varver>/<arch>/ (the ADR-20 varver keying — an ABI is NOT
+# FROM THE PACKAGE (never the filename), lays the catalog out DIRECTLY under
+# <out>/release/<varver>/ — arch-less (issue #1806: all three
+# pfSense-pkg-pfBlockerNG ports are NO_ARCH, so one varver directory serves
+# every arch of its FreeBSD major; the ADR-20 varver keying — an ABI is NOT
 # 1:1 with an edition/version, so the varver cannot be derived from the
-# package and is supplied by the caller), and runs unsigned `pkg repo` on the
-# bucket (NONE-signed trust model, ADR §2). Deterministic + re-runnable + no
-# network: the bucket is wiped and rebuilt every run. A flavor collision
-# (same name+version+ABI, different php/py flavor) or a mixed-ABI input
-# fails loud — see the guards below. `pkg` must be a real libpkg build on
-# PATH (override PKG_BIN).
+# package and is supplied by the caller) — and runs unsigned `pkg repo` on
+# the bucket (NONE-signed trust model, ADR §2). Deterministic + re-runnable +
+# no network: the bucket is wiped and rebuilt every run. A flavor collision
+# (same name+version+ABI, different php/py flavor), a mixed-ABI input, or a
+# CONCRETE (non-NO_ARCH) package ABI all fail loud — see the guards below
+# (arch-less catalogs serve every arch, so a concrete package would silently
+# install on only one). `pkg` must be a real libpkg build on PATH (override
+# PKG_BIN).
 #
 # Usage:
 #   build-repo.sh --in <dir-of-.pkg> --out <dir> --varver <varver>
-#   build-repo.sh --print-conf --catalog-path <varver>/<arch> [--base-url <url>]
+#   build-repo.sh --print-conf --catalog-path <varver> [--base-url <url>]
 #
 # Options:
 #   --in DIR          directory holding the input .pkg files (searched, non-recursive)
-#   --out DIR         output root; the catalog is created at release/<varver>/<arch>/
+#   --out DIR         output root; the catalog is created at release/<varver>/
 #   --varver NAME     catalog key, e.g. ce-2.8 / plus-26.03 (ADR-20; required with --in)
 #   --print-conf      print the client repo-conf template to stdout and exit
-#   --catalog-path P  <varver>/<arch> path the printed conf's url resolves to
+#   --catalog-path P  <varver> path the printed conf's url resolves to
 #   --base-url URL    base URL for --print-conf (default: the ADR Pages base)
 #
 # Env:
@@ -43,16 +47,16 @@ CONF_PRIORITY=100
 
 print_conf() {
     # $1 = fully-resolved URL (no trailing slash). The URL is a STATIC, directly-resolved
-    # string for the box's edition/version/arch — no ${ABI} token (ADR-39).
-    # Supply --catalog-path <varver>/<arch> (e.g. "ce-2.8/amd64") so the test can
-    # pin the exact resolved conf; the url is then base/release/<varver>/<arch>.
+    # string for the box's edition/version — no ${ABI} token (ADR-39), arch-less
+    # since issue #1806 (NO_ARCH). Supply --catalog-path <varver> (e.g. "ce-2.8")
+    # so the test can pin the exact resolved conf; the url is then base/release/<varver>.
     base="$1"
     cat <<EOF
 # Generated at boot by pfblockerng_repo_generate (ADR-39) — do not edit; re-run add-repo.sh to change.
 # pfBlockerNG (release channel) — self-hosted pkg repository (ADR-17).
 # NONE-signed: trust anchor is HTTPS to the host (no signing key). The URL is
-# fully resolved for this box's edition/version/arch (ADR-39); the boot
-# rc.d hook updates it on a pfSense OS upgrade.
+# fully resolved for this box's edition/version (ADR-39; arch-less/NO_ARCH,
+# issue #1806); the boot rc.d hook updates it on a pfSense OS upgrade.
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
 # resolution (pkg install/upgrade, GUI Install) selects the pfBlockerNG build.
 pfblockerng: {
@@ -84,7 +88,7 @@ while [ $# -gt 0 ]; do
         --base-url)      BASE_URL="$2"; shift 2 ;;
         --catalog-path)  CATALOG_PATH="$2"; shift 2 ;;
         -h|--help)
-            sed -n '14,29p' "$0"   # the Usage/Options/Env block from the header
+            sed -n '18,31p' "$0"   # the Usage/Options/Env block from the header
             exit 0 ;;
         *) echo "build-repo: unknown arg: $1" >&2; exit 2 ;;
     esac
@@ -92,7 +96,7 @@ done
 
 if [ "$PRINT_CONF" -eq 1 ]; then
     [ -n "${CATALOG_PATH}" ] || {
-        echo "build-repo: --catalog-path <varver>/<arch> is required with --print-conf" >&2
+        echo "build-repo: --catalog-path <varver> is required with --print-conf" >&2
         exit 2
     }
     _full_url="${BASE_URL%/}/release/${CATALOG_PATH}"
@@ -104,7 +108,7 @@ fi
 # the && chain is side-effect-free, so SC2015's caveat does not apply.
 # shellcheck disable=SC2015
 [ -n "$IN" ] && [ -n "$OUT" ] && [ -n "$VARVER" ] || {
-    echo "Usage: $0 --in <dir-of-.pkg> --out <dir> --varver <varver>   |   $0 --print-conf --catalog-path <varver>/<arch> [--base-url <url>]" >&2
+    echo "Usage: $0 --in <dir-of-.pkg> --out <dir> --varver <varver>   |   $0 --print-conf --catalog-path <varver> [--base-url <url>]" >&2
     exit 2
 }
 [ -d "$IN" ] || { echo "build-repo: --in is not a directory: $IN" >&2; exit 1; }
@@ -190,36 +194,71 @@ for f in "$@"; do
     fi
 done
 
-# Reject an ABI that is not a single safe path segment — it becomes a directory
-# name (${OUT}/${abi}) that is `rm -rf`'d + rebuilt, so `..` / `/` / odd chars could
-# escape $OUT. FreeBSD ABIs look like `FreeBSD:15:amd64` (the `:` is allowed).
+# Reject an ABI that is not a single safe path segment or, when it wildcards
+# the CPU segment (a NO_ARCH package; issue #1806), not in the TIGHT
+# "OS:major:*" shape. The ABI is never used as a directory name any more
+# (arch-less catalog), but package metadata still lands verbatim in error
+# messages, so it stays validated before any of it is trusted.
+# FreeBSD ABIs look like `FreeBSD:15:amd64` (the `:` is allowed); a NO_ARCH
+# package's is `FreeBSD:15:*` — '*' is valid ONLY as the WHOLE final segment.
 validate_abi() {
     # issue #1148: LC_ALL=C tr + '/' sentinel, not a `case` range — see the
     # --varver guard for both traps (locale collation; trailing-newline strip).
-    if [ -z "$1" ] || [ "${1#*..}" != "$1" ] || \
-       [ "$(printf '%s/' "$1" | LC_ALL=C tr -d 'A-Za-z0-9:._+-')" != '/' ]; then
+    if [ -z "$1" ] || [ "${1#*..}" != "$1" ]; then
+        echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
+        exit 1
+    fi
+    last="${1##*:}"
+    if [ "$last" = "*" ]; then
+        # Tight wildcard: validate the OS:major prefix (everything but the
+        # trailing ':*') against the same safe charset — no '*' anywhere in it.
+        rest="${1%:*}"
+        if [ "$(printf '%s/' "$rest" | LC_ALL=C tr -d 'A-Za-z0-9:._+-')" != '/' ]; then
+            echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
+            exit 1
+        fi
+        return 0
+    fi
+    if [ "$(printf '%s/' "$1" | LC_ALL=C tr -d 'A-Za-z0-9:._+-')" != '/' ]; then
         echo "build-repo: unsafe or invalid ABI in package metadata: '$1'" >&2
         exit 1
     fi
 }
 
+# Hard-require a NO_ARCH (CPU-wildcarded) ABI at catalog-emission time
+# (issue #1806): the catalog is arch-less (release/<varver>/ serves every arch
+# of a FreeBSD major from ONE directory), so a concrete-ABI package would
+# silently install on only one arch — the tripwire that forces a conscious
+# layout decision if a compiled, per-arch dependency is ever added.
+require_noarch_abi() {
+    case "$1" in
+        *:\*) return 0 ;;
+    esac
+    echo "build-repo: catalog requires a NO_ARCH (wildcard-ABI) package — got concrete ABI '$1'." >&2
+    echo "  The catalog tree is arch-less (one directory serves every arch of a FreeBSD major);" >&2
+    echo "  a concrete-ABI package would silently install on only one arch. Ship a wildcard-ABI" >&2
+    echo "  (NO_ARCH) build instead." >&2
+    exit 1
+}
+
 # ── Lay out the varver bucket + run `pkg repo` ─────────────────────────────────
-# issue #1081: the catalog lives at <out>/release/<varver>/<arch>/ (ADR-20 varver
-# keying, matching build-repo-portable.py and this script's own --print-conf
-# url); one ABI per invocation — a mixed input would silently mix editions.
+# issue #1081/#1806: the catalog lives DIRECTLY at <out>/release/<varver>/ —
+# arch-less (ADR-20 varver keying, matching build-repo-portable.py and this
+# script's own --print-conf url); one (wildcarded) ABI per invocation — a
+# mixed input would silently mix editions.
 bucket_abi=""
 for f in "$@"; do
     abi="$(pkg_abi "$f")"
     validate_abi "$abi"
+    require_noarch_abi "$abi"
     if [ -z "$bucket_abi" ]; then
         bucket_abi="$abi"
     elif [ "$abi" != "$bucket_abi" ]; then
-        echo "build-repo: mixed ABIs in one run ('$bucket_abi' vs '$abi') — filter --in to one ABI and invoke once per ABI/arch (keep the same --varver for one edition)" >&2
+        echo "build-repo: mixed ABIs in one run ('$bucket_abi' vs '$abi') — filter --in to one ABI and invoke once per major (keep the same --varver for one edition)" >&2
         exit 1
     fi
 done
-arch="${bucket_abi##*:}"
-dir="${OUT}/release/${VARVER}/${arch}"
+dir="${OUT}/release/${VARVER}"
 rm -rf "$dir"
 mkdir -p "$dir"
 for f in "$@"; do
@@ -236,4 +275,4 @@ echo "==> pkg repo ${dir}" >&2
 # pkg never prompts in CI.
 env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir"
 
-echo "==> built catalog (release channel) at release/${VARVER}/${arch}" >&2
+echo "==> built catalog (release channel) at release/${VARVER}" >&2

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -87,7 +87,7 @@ from pathlib import Path
 _TOKEN_ALTERNATIVES = (
     r"2\.[89]",  # CE version window: 2.8 / 2.9 (tripwired)
     r"2[56]\.[0-9]{2}",  # Plus version window: 25.NN / 26.NN (tripwired)
-    r"FreeBSD:[0-9]+(?::[a-z0-9_]+)?",  # FreeBSD ABI, any major, optional :arch
+    r"FreeBSD:[0-9]+(?::(?:[a-z0-9_]+|\*))?",  # FreeBSD ABI, any major, optional :arch or NO_ARCH :* (#1806)
     r"php[0-9]{2}",  # php flavor: php74..php99
     r"py3[0-9]{2}",  # py flavor: py310..py399
     r"ce-[0-9]+\.[0-9]+",  # varver: ce-X.Y
@@ -593,8 +593,11 @@ def _matrix_tokens(matrix: dict) -> list[str]:
     """Derive every version-shaped token a ``supported-versions.json`` entry implies.
 
     Per entry: the bare pfSense version (a trailing ``.x`` stripped), its
-    ``ce-``/``plus-`` varver, the ``FreeBSD:<major>`` ABI prefix, the php
-    flavor (``php_version`` with the dot dropped), and the py flavor verbatim.
+    ``ce-``/``plus-`` varver, the ``FreeBSD:<major>`` ABI prefix AND its
+    NO_ARCH wildcard form ``FreeBSD:<major>:*`` (issue #1806: every active
+    pfSense-pkg-pfBlockerNG port is NO_ARCH, so a real package's manifest ABI
+    is CPU-wildcarded), the php flavor (``php_version`` with the dot dropped),
+    and the py flavor verbatim.
 
     ``role=route-only`` entries (ADR-27: EOL'd but still served, frozen
     catalog, no longer built/tested) are excluded, mirroring
@@ -616,6 +619,7 @@ def _matrix_tokens(matrix: dict) -> list[str]:
             tokens.append(("ce-" if channel == "ce" else "plus-") + version)
         if major:
             tokens.append(f"FreeBSD:{major}")
+            tokens.append(f"FreeBSD:{major}:*")
         if php:
             tokens.append("php" + php.replace(".", ""))
         if py:

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -42,9 +42,10 @@ SOURCE_REPO_URL = "https://github.com/pfBlockerNG/pfBlockerNG"
 CATALOG_META = ("packagesite.pkg", "data.pkg")
 
 # Placeholder catalog-path passed to add-repo.sh --print-conf for the manual-conf
-# snippet on the landing page.  The rc.d hook resolves the box's real varver/arch
-# at boot; a hand-written conf must substitute a concrete value (e.g. ce-2.8/amd64).
-_CONF_PLACEHOLDER_PATH = "<varver>/<arch>"
+# snippet on the landing page.  The rc.d hook resolves the box's real varver at
+# boot (arch-less; issue #1806 NO_ARCH); a hand-written conf must substitute a
+# concrete value (e.g. ce-2.8).
+_CONF_PLACEHOLDER_PATH = "<varver>"
 
 
 def channel_of(name: str) -> str:
@@ -313,10 +314,9 @@ def _manual_conf_details(conf_fn: Callable[[str], str], repo: str) -> str:
     """
     return (
         "<details><summary>Manual conf (advanced)</summary>"
-        '<p class="blurb">The bootstrap auto-detects these; in a hand-written conf, replace '
-        "<code>&lt;varver&gt;</code> (the edition-version: <code>ce-2.8</code>, <code>plus-26.03</code>, &hellip;) and "
-        "<code>&lt;arch&gt;</code> (the CPU architecture: <code>amd64</code> or <code>aarch64</code>) "
-        "with your box's values.</p>"
+        '<p class="blurb">The bootstrap auto-detects this; in a hand-written conf, replace '
+        "<code>&lt;varver&gt;</code> (the edition-version: <code>ce-2.8</code>, <code>plus-26.03</code>, &hellip;) "
+        "with your box's value.</p>"
         f"{_copyable(_esc(conf_fn(repo)))}</details>"
     )
 
@@ -365,6 +365,24 @@ def _nightly_card(base: str, latest: dict[str, str], conf_fn: Callable[[str], st
     )
 
 
+def _is_wildcard_abi(abi: str) -> bool:
+    """True if ``abi`` is a NO_ARCH package's CPU-wildcarded ABI (e.g. "FreeBSD:16:*",
+    issue #1806) — probed live against a real Netgate noarch package."""
+    return isinstance(abi, str) and abi.endswith(":*")
+
+
+def _abi_matches(a: str, b: str) -> bool:
+    """True if two ABI strings denote the same catalog placement: exact string
+    equality, OR either side is a NO_ARCH package's wildcarded ABI sharing the
+    other's OS+major (the CPU/arch segment is never compared in that case;
+    issue #1806 — mirrors build-repo-portable.py's ``_pkg_matches_abi``)."""
+    if a == b:
+        return True
+    if not (_is_wildcard_abi(a) or _is_wildcard_abi(b)):
+        return False
+    return a.split(":")[:2] == b.split(":")[:2]
+
+
 def matrix_index(matrix: list[dict] | None) -> dict[str, list[dict]]:
     """Map each ABI to its matrix entries (edition / pfSense version / php / py).
 
@@ -397,11 +415,19 @@ def _join_matrix(rows: list[dict], matrix: list[dict] | None) -> list[tuple[str,
     one row per match (the same .pkg installs on each); an ABI with no matrix entry
     yields a single ("Other") row with a blank pfSense version + manifest-derived
     php/py, so nothing published is ever hidden. Input order is preserved.
+
+    A NO_ARCH package's manifest ABI is CPU-wildcarded (issue #1806, e.g.
+    "FreeBSD:16:*") — the exact-string index never hits it (a matrix row's own
+    ABI is always concrete), so a wildcarded row falls back to an OS+major scan
+    across every matrix entry (``_abi_matches``), joining EVERY row of that
+    major instead of dropping to "Other".
     """
     idx = matrix_index(matrix)
     out: list[tuple[str, dict]] = []
     for r in rows:
         entries = idx.get(r["abi"], [])
+        if not entries and _is_wildcard_abi(r["abi"]):
+            entries = [e for e in (matrix or []) if _abi_matches(e.get("abi", ""), r["abi"])]
         if entries:
             for e in entries:
                 row = dict(r)
@@ -618,7 +644,9 @@ def eol_versions(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str,
             continue
         seen.add(dedup_key)
 
-        pool = [p for p in varver_pkgs.get(varver, []) if p["abi"] == abi]
+        # Matched via _abi_matches (OS+major, issue #1806): the served .pkg may be
+        # NO_ARCH/wildcarded even when the matrix still records a concrete ABI.
+        pool = [p for p in varver_pkgs.get(varver, []) if _abi_matches(p["abi"], abi)]
         if not pool:
             continue  # no .pkg served for this (varver, abi) — skip silently
 
@@ -845,7 +873,7 @@ def _conf_via_addrepo(addrepo: str, base: str, channel: str) -> str:
     # --nightly picks the nightly repo. Anything other than "nightly" => the release conf.
     # --catalog-path is required by --print-conf; we pass a literal placeholder here
     # because the landing page shows a generic snippet — the rc.d hook resolves the
-    # box's real varver/arch at boot (see _CONF_PLACEHOLDER_PATH).
+    # box's real varver at boot (see _CONF_PLACEHOLDER_PATH).
     extra = ["--nightly"] if channel == "nightly" else []
     out = subprocess.run(
         ["sh", addrepo, "--print-conf", "--base-url", base, "--catalog-path", _CONF_PLACEHOLDER_PATH, *extra],

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -619,8 +619,10 @@ def eol_versions(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str,
     # Group pkgs by path prefix release/<varver>/, so each EOL varver's pool is isolated.
     varver_pkgs: dict[str, list[dict]] = {}
     for p in pkgs:
-        # rel format: release/<varver>/<arch>/name.pkg (always forward-slash, os.path.relpath
-        # normalises to the OS separator, so normalise here too).
+        # rel format: release/<varver>/name.pkg — arch-less (issue #1806: NO_ARCH
+        # packages, one varver directory serves every arch of its FreeBSD major).
+        # Always forward-slash; os.path.relpath normalises to the OS separator,
+        # so normalise here too.
         rel = p["rel"].replace(os.sep, "/")
         parts = rel.split("/")
         if len(parts) >= 2 and parts[0] == "release":

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -24,7 +24,10 @@
 # [optional: pkg update -f + pkg upgrade, reboot, wait SSH back] ->
 # check for an available OS upgrade (pfSense-upgrade -c); if the box is already
 # current, exit 0 WITHOUT publishing -> else run pfSense-upgrade over an SSH jump
-# -> wait for /etc/version to change + reboot -> health-gate (webConfigurator HTTP
+# -> wait for /etc/version to change + reboot -> reconcile pfBlockerNG's baked
+# RUN_DEPENDS against the NEW version's matrix row (install what's missing, e.g.
+# after a py_flavor flip; shed stale old-flavor/extra packages; verify pkg info -e
+# + a python import probe, fail-closed) -> health-gate (webConfigurator HTTP
 # or pfctl live ruleset; confirms it boots and works on the NEW version) ->
 # power off cleanly -> compress on Proxmox -> stream back ->
 # push the new tag (local). The source tag is left untouched, so the old image
@@ -119,6 +122,10 @@ SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 [ -f "$SCRIPT_DIR/image-lib.sh" ] || die "image-lib.sh not found next to this script: $SCRIPT_DIR/image-lib.sh"
 # shellcheck source=scripts/image-lib.sh
 . "$SCRIPT_DIR/image-lib.sh"
+# Post-upgrade dependency reconcile+shed decision logic (issue #1806 final
+# step) — pure functions, tested by tests/shell/dep_reconcile_spec.sh.
+# shellcheck source=scripts/lib/dep-reconcile.sh
+. "$SCRIPT_DIR/lib/dep-reconcile.sh"
 
 FROM=""
 TO=""
@@ -504,6 +511,98 @@ if [ -z "$NEW_VER" ]; then
     die "version did not change within ${UPGRADE_TIMEOUT}s (still '${OLD_VER}'; see $LOCAL_DIR/upgrade.log)"
 fi
 log "upgraded: ${OLD_VER} -> ${NEW_VER}"
+
+# --- post-upgrade dependency reconcile + shed (issue #1806 final step) -----
+# Repair pfBlockerNG's baked RUN_DEPENDS set for the box's NEW version before
+# the health gate/publish below: most notably a py_flavor flip (e.g. py311 ->
+# py312) strands every old-flavor package. Matrix-driven off the CI matrix's
+# per-pfsense_version rows (--print-ci; one row per version, unlike the
+# per-freebsd_major-deduped BUILD matrix); best-effort when the NEW version
+# has no matrix row yet (a version not yet added) — warn + skip the
+# install/shed plan, but still verify the OLD row's own deps so a genuinely
+# broken set (e.g. a flip that already happened) is still caught. Fail-closed
+# like the health gate below: a verify failure aborts BEFORE publish.
+# scripts/lib/dep-reconcile.sh's pfb_dep_* functions are the tested, pure
+# needed-set/diff logic (tests/shell/dep_reconcile_spec.sh); everything below
+# is the live ssh/pkg(8) wiring around them (live-proof-only).
+_DEP_MATRIX="$(sh "$SCRIPT_DIR/read-version-matrix.sh" --print-ci 2>/dev/null)" \
+    || { warn "could not read the version matrix — skipping dependency reconcile"; _DEP_MATRIX="[]"; }
+
+# _dep_row VERSION — echo the CI-matrix row (compact JSON) whose pfsense_version
+# equals VERSION and whose channel matches this run's --type (case-insensitive
+# — the matrix spells it "CE"/"Plus"), or empty when none matches.
+_dep_row() {
+    printf '%s' "$_DEP_MATRIX" | jq -c --arg v "$1" --arg t "$TYPE" \
+        '[.[] | select(.pfsense_version == $v and ((.channel // "") | ascii_downcase) == $t)][0] // empty'
+}
+
+_DEP_OLD_ROW="$(_dep_row "$FROM")"
+_DEP_NEW_MATRIX_VER="$(image_version_tag "$NEW_VER")"
+_DEP_NEW_ROW="$(_dep_row "$_DEP_NEW_MATRIX_VER")"
+
+if [ -z "$_DEP_OLD_ROW" ]; then
+    warn "no matrix row for ${TYPE} ${FROM} — skipping dependency reconcile (no known baseline to diff against)"
+else
+    _DEP_OLD_FLAVOR="$(printf '%s' "$_DEP_OLD_ROW" | jq -r '.py_flavor')"
+    _DEP_OLD_EXTRA="$(printf '%s' "$_DEP_OLD_ROW" | jq -r '.extra_pkgs[]? // empty')"
+    _DEP_INSTALLED="$(ssh_guest "pkg query '%n'" 2>/dev/null || true)"
+
+    if [ -z "$_DEP_NEW_ROW" ]; then
+        # Best-effort: a version not yet added to the matrix. NEVER attempt an
+        # install/shed plan against an unknown target (nothing to diff against) —
+        # only verify the OLD row's own expectations are still met, so a genuine
+        # break (e.g. a py_flavor flip the box already went through) is still
+        # caught rather than silently waved through.
+        warn "no matrix row for ${TYPE} ${_DEP_NEW_MATRIX_VER} yet — skipping install/shed plan; verifying ${FROM}'s own deps only"
+        _DEP_VERIFY_FLAVOR="$_DEP_OLD_FLAVOR"
+        _DEP_VERIFY_EXTRA="$_DEP_OLD_EXTRA"
+    else
+        _DEP_NEW_FLAVOR="$(printf '%s' "$_DEP_NEW_ROW" | jq -r '.py_flavor')"
+        _DEP_NEW_EXTRA="$(printf '%s' "$_DEP_NEW_ROW" | jq -r '.extra_pkgs[]? // empty')"
+
+        log "reconciling pfBlockerNG dependencies (${_DEP_OLD_FLAVOR} -> ${_DEP_NEW_FLAVOR})"
+        _DEP_PLAN="$(pfb_dep_plan "$_DEP_OLD_FLAVOR" "$_DEP_OLD_EXTRA" "$_DEP_NEW_FLAVOR" "$_DEP_NEW_EXTRA" "$_DEP_INSTALLED")"
+        _DEP_INSTALL_LIST="$(printf '%s\n' "$_DEP_PLAN" | sed -n 's/^install //p')"
+        _DEP_SHED_LIST="$(printf '%s\n' "$_DEP_PLAN" | sed -n 's/^shed //p')"
+
+        if [ -n "$_DEP_INSTALL_LIST" ]; then
+            log "installing missing dependencies: $(printf '%s' "$_DEP_INSTALL_LIST" | tr '\n' ' ')"
+            ssh_guest "env ASSUME_ALWAYS_YES=yes pkg install -y $(printf '%s' "$_DEP_INSTALL_LIST" | tr '\n' ' ')" \
+                2>&1 | tee "$LOCAL_DIR/dep-install.log" || true
+        fi
+
+        if [ -n "$_DEP_SHED_LIST" ]; then
+            log "shedding stale dependencies: $(printf '%s' "$_DEP_SHED_LIST" | tr '\n' ' ')"
+            ssh_guest "pkg delete -y $(printf '%s' "$_DEP_SHED_LIST" | tr '\n' ' ')" \
+                2>&1 | tee "$LOCAL_DIR/dep-shed.log" \
+                || warn "pkg delete of stale deps reported a non-zero exit (see $LOCAL_DIR/dep-shed.log)"
+        fi
+
+        _DEP_VERIFY_FLAVOR="$_DEP_NEW_FLAVOR"
+        _DEP_VERIFY_EXTRA="$_DEP_NEW_EXTRA"
+    fi
+
+    # Verify (always, whether or not a plan ran above): every needed package
+    # resolves in the pkg db (pkg info -e — one round trip per package, as
+    # specified), and the python import probe succeeds for the python-module
+    # deps — fail-closed: a bad dependency set must never be published (same
+    # shape as the health gate below).
+    _DEP_VERIFY_FAIL=0
+    for _dep_pkg in $(pfb_dep_needed_pkgs "$_DEP_VERIFY_FLAVOR" "$_DEP_VERIFY_EXTRA"); do
+        ssh_guest "pkg info -e '$_dep_pkg'" >/dev/null 2>&1 || {
+            warn "dependency verify: ${_dep_pkg} not resolved on the guest"
+            _DEP_VERIFY_FAIL=1
+        }
+    done
+    _DEP_PY_DOTTED="$(pfb_dep_python_dotted "$_DEP_VERIFY_FLAVOR")"
+    _DEP_PY_MODULES="$(pfb_dep_python_modules "$_DEP_VERIFY_FLAVOR" "$_DEP_VERIFY_EXTRA" | tr '\n' ',' | sed 's/,$//;s/,/, /g')"
+    ssh_guest "/usr/local/bin/python${_DEP_PY_DOTTED} -c 'import ${_DEP_PY_MODULES}'" >/dev/null 2>&1 || {
+        warn "dependency verify: python${_DEP_PY_DOTTED} import probe failed (${_DEP_PY_MODULES})"
+        _DEP_VERIFY_FAIL=1
+    }
+    [ "$_DEP_VERIFY_FAIL" -eq 0 ] || die "post-upgrade dependency verify failed — refusing to publish (see warnings above)"
+    log "dependency verify OK"
+fi
 
 # --- health gate: wait until box is "working fine" -------------------------
 # Poll up to HEALTH_TIMEOUT seconds. The box is considered healthy when EITHER:

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -513,15 +513,21 @@ fi
 log "upgraded: ${OLD_VER} -> ${NEW_VER}"
 
 # --- post-upgrade dependency reconcile + shed (issue #1806 final step) -----
-# Repair pfBlockerNG's baked RUN_DEPENDS set for the box's NEW version before
-# the health gate/publish below: most notably a py_flavor flip (e.g. py311 ->
-# py312) strands every old-flavor package. Matrix-driven off the CI matrix's
-# per-pfsense_version rows (--print-ci; one row per version, unlike the
-# per-freebsd_major-deduped BUILD matrix); best-effort when the NEW version
-# has no matrix row yet (a version not yet added) — warn + skip the
+# Repair pfBlockerNG's baked CORE RUN_DEPENDS set for the box's NEW version
+# before the health gate/publish below: most notably a py_flavor flip (e.g.
+# py311 -> py312) strands every old-flavor package. Matrix-driven off the CI
+# matrix's per-pfsense_version rows (--print-ci; one row per version, unlike
+# the per-freebsd_major-deduped BUILD matrix); best-effort when the NEW
+# version has no matrix row yet (a version not yet added) — warn + skip the
 # install/shed plan, but still verify the OLD row's own deps so a genuinely
 # broken set (e.g. a flip that already happened) is still caught. Fail-closed
 # like the health gate below: a verify failure aborts BEFORE publish.
+# A matrix row's extra_pkgs (e.g. CE's textproc/py-charset-normalizer) NEVER
+# enter install/verify — that package is deliberately not baked into the
+# image (per-leg smoke harness installs it; a real install resolves it from
+# our self-hosted repo as an ordinary RUN_DEPENDS). extra_pkgs participate
+# ONLY in shed, and only once genuinely dropped by the NEW row — see
+# scripts/lib/dep-reconcile.sh's header for the full rationale.
 # scripts/lib/dep-reconcile.sh's pfb_dep_* functions are the tested, pure
 # needed-set/diff logic (tests/shell/dep_reconcile_spec.sh); everything below
 # is the live ssh/pkg(8) wiring around them (live-proof-only).
@@ -555,7 +561,6 @@ else
         # caught rather than silently waved through.
         warn "no matrix row for ${TYPE} ${_DEP_NEW_MATRIX_VER} yet — skipping install/shed plan; verifying ${FROM}'s own deps only"
         _DEP_VERIFY_FLAVOR="$_DEP_OLD_FLAVOR"
-        _DEP_VERIFY_EXTRA="$_DEP_OLD_EXTRA"
     else
         _DEP_NEW_FLAVOR="$(printf '%s' "$_DEP_NEW_ROW" | jq -r '.py_flavor')"
         _DEP_NEW_EXTRA="$(printf '%s' "$_DEP_NEW_ROW" | jq -r '.extra_pkgs[]? // empty')"
@@ -579,25 +584,27 @@ else
         fi
 
         _DEP_VERIFY_FLAVOR="$_DEP_NEW_FLAVOR"
-        _DEP_VERIFY_EXTRA="$_DEP_NEW_EXTRA"
     fi
 
-    # Verify (always, whether or not a plan ran above): every needed package
-    # resolves in the pkg db (pkg info -e — one round trip per package, as
-    # specified), and the python import probe succeeds for the python-module
-    # deps — fail-closed: a bad dependency set must never be published (same
-    # shape as the health gate below).
+    # Verify (always, whether or not a plan ran above): every CORE needed
+    # package resolves in the pkg db (pkg info -e — one round trip per
+    # package, as specified), and the core python import probe succeeds —
+    # fail-closed: a bad dependency set must never be published (same shape
+    # as the health gate below). extra_pkgs are DELIBERATELY excluded from
+    # verify (contract correction — see scripts/lib/dep-reconcile.sh's header
+    # and pfSense_versions.md's CE-only note): CE's charset-normalizer is not
+    # baked into the image, so demanding it here would fail-close every
+    # healthy CE image upgrade.
     _DEP_VERIFY_FAIL=0
-    for _dep_pkg in $(pfb_dep_needed_pkgs "$_DEP_VERIFY_FLAVOR" "$_DEP_VERIFY_EXTRA"); do
+    for _dep_pkg in $(pfb_dep_core_pkgs "$_DEP_VERIFY_FLAVOR"); do
         ssh_guest "pkg info -e '$_dep_pkg'" >/dev/null 2>&1 || {
             warn "dependency verify: ${_dep_pkg} not resolved on the guest"
             _DEP_VERIFY_FAIL=1
         }
     done
     _DEP_PY_DOTTED="$(pfb_dep_python_dotted "$_DEP_VERIFY_FLAVOR")"
-    _DEP_PY_MODULES="$(pfb_dep_python_modules "$_DEP_VERIFY_FLAVOR" "$_DEP_VERIFY_EXTRA" | tr '\n' ',' | sed 's/,$//;s/,/, /g')"
-    ssh_guest "/usr/local/bin/python${_DEP_PY_DOTTED} -c 'import ${_DEP_PY_MODULES}'" >/dev/null 2>&1 || {
-        warn "dependency verify: python${_DEP_PY_DOTTED} import probe failed (${_DEP_PY_MODULES})"
+    ssh_guest "/usr/local/bin/python${_DEP_PY_DOTTED} -c 'import maxminddb, sqlite3'" >/dev/null 2>&1 || {
+        warn "dependency verify: python${_DEP_PY_DOTTED} import probe failed (maxminddb, sqlite3)"
         _DEP_VERIFY_FAIL=1
     }
     [ "$_DEP_VERIFY_FAIL" -eq 0 ] || die "post-upgrade dependency verify failed — refusing to publish (see warnings above)"

--- a/scripts/install-from-repo.sh
+++ b/scripts/install-from-repo.sh
@@ -79,15 +79,20 @@ if ! ssh_t 'command -v rsync >/dev/null 2>&1'; then
 fi
 
 # The Python flavor for the py3xx-* RUN_DEPENDS is DERIVED FROM THE VERSION MATRIX (no
-# hardcoded py311): match the box's ABI (FreeBSD:major:arch) to its matrix entry's py_flavor.
-# Fallbacks keep the installer working when the matrix/jq is unavailable: the box's OWN
-# installed py3xx flavor, then py311. (read-version-matrix.sh self-fetches the ci-metadata ref.)
+# hardcoded py311): match the box's FreeBSD major (parsed from its concrete ABI, e.g.
+# FreeBSD:15:amd64) to its matrix entry's py_flavor. issue #1806: the matrix is arch-less
+# (no `arch` field) and the BUILD matrix dedupes to one row per freebsd_major with
+# php_version/py_flavor asserted identical across any merged versions, so matching by major
+# alone is exact — not just a fallback. Fallbacks keep the installer working when the
+# matrix/jq is unavailable: the box's OWN installed py3xx flavor, then py311.
+# (read-version-matrix.sh self-fetches the ci-metadata ref.)
 PY_FLAVOR=""
 BOX_ABI="$(ssh_t 'pkg config ABI 2>/dev/null' | tr -d '\r')"
-if [ -n "$BOX_ABI" ] && command -v jq >/dev/null 2>&1; then
+BOX_MAJOR="$(printf '%s' "$BOX_ABI" | cut -d: -f2)"
+if [ -n "$BOX_MAJOR" ] && command -v jq >/dev/null 2>&1; then
     PY_FLAVOR="$(sh "${REPO_ROOT}/scripts/read-version-matrix.sh" --print-build 2>/dev/null \
-        | jq -r --arg abi "$BOX_ABI" \
-            '[ .[] | select("FreeBSD:\(.freebsd_major):\(.arch // "amd64")" == $abi) ][0].py_flavor // empty' \
+        | jq -r --arg major "$BOX_MAJOR" \
+            '[ .[] | select(.freebsd_major == $major) ][0].py_flavor // empty' \
         2>/dev/null || true)"
 fi
 if [ -z "$PY_FLAVOR" ]; then

--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -5,15 +5,24 @@
 # The .pkg is produced by the portable Linux builder (scripts/build-pkg-portable.py,
 # driven by build-pkg-linux.yml) for the exact branch commit.
 #
-# RUN_DEPENDS: NOT fetched here. By convention the pre-baked smoke image ships
-# pfBlockerNG's runtime dependencies, so `pkg add` of the local .pkg resolves
-# them from the local pkg db and runs fully OFFLINE (no egress, no repo-catalogue
-# round-trip — a more stable deploy). If a dependency is missing, `pkg add` fails
-# loudly with "Missing dependency": that means the image is bad — fix the image
-# (re-bake with the deps), don't paper over it with a repo install here.
+# RUN_DEPENDS: resolved from the LOCAL pkg db, either because the pre-baked smoke
+# image ships them (convention), OR because SMOKE_DEP_PKGS names extra dep .pkgs
+# this script installs FIRST (issue #1806: pfSense CE's own repo does not carry
+# every RUN_DEPENDS a port needs, e.g. textproc/py-charset-normalizer, so its dep
+# .pkg ships alongside the branch build instead of being baked into the image).
+# Either way, `pkg add` of the local .pkg then resolves fully OFFLINE (no egress,
+# no repo-catalogue round-trip — a more stable deploy). If a dependency is still
+# missing, `pkg add` fails loudly with "Missing dependency": that means it is
+# missing from BOTH the image AND SMOKE_DEP_PKGS — fix one of those, don't paper
+# over it with a repo install here.
 #
 # Usage:
 #   install-pkg.sh <ssh-target> --pkg <local .pkg> [--port N] [--ssh-key PATH]
+#
+# Env:
+#   SMOKE_DEP_PKGS   space-separated absolute paths of extra dep .pkg files,
+#                    scp'd + `pkg add`ed BEFORE the branch .pkg, in the given
+#                    order. Unset/empty (the default) -> skipped entirely.
 #
 # POSIX sh; quoted expansions; absolute binary paths where it matters.
 
@@ -74,6 +83,20 @@ ssh_t() {
 }
 
 REMOTE="/tmp/$(basename "$PKGFILE")"
+
+# issue #1806 D2: install any SMOKE_DEP_PKGS FIRST, in the given order. `set -eu`
+# already makes a dep `pkg add` failure abort the whole script right here — the
+# SAME loud error contract as the branch .pkg add below, and the branch .pkg is
+# never reached (not even copied).
+for _dep in ${SMOKE_DEP_PKGS:-}; do
+    [ -f "$_dep" ] || { echo "install-pkg: SMOKE_DEP_PKGS file not found: ${_dep}" >&2; exit 1; }
+    _dep_remote="/tmp/$(basename "$_dep")"
+    echo "==> Copying dep $(basename "$_dep") to ${SSH_TARGET}:${_dep_remote}"
+    # shellcheck disable=SC2086
+    scp ${SCP_OPTS} "$_dep" "${SSH_TARGET}:${_dep_remote}"
+    echo "==> pkg add ${_dep_remote} (dep, from SMOKE_DEP_PKGS)"
+    ssh_t "env ASSUME_ALWAYS_YES=yes pkg add '${_dep_remote}'"
+done
 
 echo "==> Copying $(basename "$PKGFILE") to ${SSH_TARGET}:${REMOTE}"
 # shellcheck disable=SC2086

--- a/scripts/lib/dep-reconcile.sh
+++ b/scripts/lib/dep-reconcile.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# scripts/lib/dep-reconcile.sh — post-upgrade dependency reconcile+shed decision
+# logic (issue #1806 final step).
+#
+# Sourced by scripts/image-upgrade.sh once the box reports the NEW version, so a
+# baked-dependency break (most notably a py_flavor flip, e.g. py311 -> py312
+# stranding every old-flavor package) is repaired before the health gate/publish
+# instead of shipping a broken image. Pure functions only — no ssh, no pkg(8), no
+# side effects — so the plan is unit-testable without a live box; the actual
+# `pkg install`/`pkg delete`/`pkg info -e`/python import-probe execution against
+# the plan this emits lives in image-upgrade.sh itself (live-proof-only).
+#
+# The needed-package set is the port's explicit RUN_DEPENDS (docs/misc/
+# pfSense_versions.md "pfBlockerNG runtime dependencies"): a FLAVOR-INDEPENDENT
+# core (libmaxminddb, lighttpd, jq, rsync, grepcidr, iprange, gnugrep) plus two
+# python packages whose name tracks the base Python (py<flavor>-maxminddb,
+# py<flavor>-sqlite3), plus zero or more EXTRA python packages the matrix row's
+# extra_pkgs carries (port origins pfSense's own repo doesn't serve for that
+# channel, e.g. CE's textproc/py-charset-normalizer — see the CE-only note in
+# pfSense_versions.md; scripts/build-dep-pkg-portable.py is the same "pyNNN"
+# naming convention this file's extra-pkg-name transform mirrors).
+#
+# POSIX sh; shellcheck clean; no bashisms.
+
+# pfb_dep_core_pkgs FLAVOR — echo the flavor-independent + flavor-tracking core
+# RUN_DEPENDS package names, one per line, in the docs/misc/pfSense_versions.md
+# table's order. FLAVOR must look like pyNNN (py311, py39, py312, ...).
+pfb_dep_core_pkgs() {
+    case "$1" in
+        py[0-9][0-9]*) ;;
+        *) printf 'pfb_dep_core_pkgs: invalid py_flavor: %s\n' "$1" >&2; return 1 ;;
+    esac
+    printf '%s\n' \
+        libmaxminddb \
+        lighttpd \
+        jq \
+        rsync \
+        grepcidr \
+        iprange \
+        gnugrep \
+        "${1}-maxminddb" \
+        "${1}-sqlite3"
+}
+
+# pfb_dep_python_dotted FLAVOR — echo the dotted python version for a pyNNN
+# flavor (py311 -> 3.11, py39 -> 3.9, py312 -> 3.12). Mirrors
+# build-dep-pkg-portable.py's python_dotted_version().
+pfb_dep_python_dotted() {
+    case "$1" in
+        py[0-9][0-9]*) ;;
+        *) printf 'pfb_dep_python_dotted: invalid py_flavor: %s\n' "$1" >&2; return 1 ;;
+    esac
+    _pdd_digits="${1#py}"
+    _pdd_maj="${_pdd_digits%"${_pdd_digits#?}"}"
+    _pdd_min="${_pdd_digits#?}"
+    printf '%s.%s\n' "$_pdd_maj" "$_pdd_min"
+    unset _pdd_digits _pdd_maj _pdd_min
+}
+
+# pfb_dep_extra_pkg_name ORIGIN FLAVOR — echo the package name for a port
+# ORIGIN (e.g. "textproc/py-charset-normalizer") under python FLAVOR, e.g.
+# "py311-charset-normalizer". The "py-" PKGNAMEPREFIX is a FreeBSD python-port
+# convention (stripped and replaced by pyNNN-); every current/known extra_pkgs
+# entry is a python port (build-dep-pkg-portable.py requires --py-flavor).
+pfb_dep_extra_pkg_name() {
+    _depn_base="${1##*/}"
+    case "$_depn_base" in
+        py-*) _depn_base="${_depn_base#py-}" ;;
+    esac
+    printf '%s-%s\n' "$2" "$_depn_base"
+    unset _depn_base
+}
+
+# pfb_dep_needed_pkgs FLAVOR EXTRA_ORIGINS — echo the FULL needed package set
+# for FLAVOR: the core list, then one pfb_dep_extra_pkg_name line per non-empty
+# line of EXTRA_ORIGINS (newline-separated port origins; empty string = none).
+pfb_dep_needed_pkgs() {
+    pfb_dep_core_pkgs "$1" || return 1
+    [ -n "$2" ] || return 0
+    printf '%s\n' "$2" | while IFS= read -r _needp_origin; do
+        [ -n "$_needp_origin" ] || continue
+        pfb_dep_extra_pkg_name "$_needp_origin" "$1"
+    done
+}
+
+# pfb_dep_python_modules FLAVOR EXTRA_ORIGINS — echo the python import-probe
+# module names for FLAVOR's needed set: the two core modules (maxminddb,
+# sqlite3) plus one per EXTRA_ORIGINS entry, with its package-name dashes
+# turned into the underscores python's import name uses (charset-normalizer ->
+# charset_normalizer).
+pfb_dep_python_modules() {
+    printf '%s\n' maxminddb sqlite3
+    [ -n "$2" ] || return 0
+    printf '%s\n' "$2" | while IFS= read -r _modp_origin; do
+        [ -n "$_modp_origin" ] || continue
+        _modp_base="${_modp_origin##*/}"
+        case "$_modp_base" in
+            py-*) _modp_base="${_modp_base#py-}" ;;
+        esac
+        printf '%s\n' "$_modp_base" | tr '-' '_'
+    done
+    unset _modp_base
+}
+
+# pfb_dep_plan OLD_FLAVOR OLD_EXTRA NEW_FLAVOR NEW_EXTRA INSTALLED — echo the
+# reconcile plan as lines "install <pkg>" / "shed <pkg>":
+#   install = NEW's needed set minus what INSTALLED (newline-separated package
+#             names, e.g. `pkg query '%n'`) already has.
+#   shed    = OLD's needed set minus NEW's needed set, INTERSECTED with
+#             INSTALLED (never a general autoremove — only a package this
+#             function itself considers part of the known pfBlockerNG dep
+#             namespace, and only if actually present).
+# A same-row call (OLD==NEW) is the "verify only" shape (e.g. the new version
+# has no matrix row yet): shed is always empty and install is exactly the
+# currently-missing packages.
+pfb_dep_plan() {
+    _planp_old_needed="$(pfb_dep_needed_pkgs "$1" "$2")" || return 1
+    _planp_new_needed="$(pfb_dep_needed_pkgs "$3" "$4")" || return 1
+    _planp_installed="$5"
+
+    printf '%s\n' "$_planp_new_needed" | while IFS= read -r _planp_pkg; do
+        [ -n "$_planp_pkg" ] || continue
+        if ! printf '%s\n' "$_planp_installed" | grep -qxF "$_planp_pkg"; then
+            printf 'install %s\n' "$_planp_pkg"
+        fi
+    done
+
+    printf '%s\n' "$_planp_old_needed" | while IFS= read -r _planp_pkg; do
+        [ -n "$_planp_pkg" ] || continue
+        if printf '%s\n' "$_planp_new_needed" | grep -qxF "$_planp_pkg"; then
+            continue
+        fi
+        if printf '%s\n' "$_planp_installed" | grep -qxF "$_planp_pkg"; then
+            printf 'shed %s\n' "$_planp_pkg"
+        fi
+    done
+
+    unset _planp_old_needed _planp_new_needed _planp_installed
+}

--- a/scripts/lib/dep-reconcile.sh
+++ b/scripts/lib/dep-reconcile.sh
@@ -10,21 +10,28 @@
 # `pkg install`/`pkg delete`/`pkg info -e`/python import-probe execution against
 # the plan this emits lives in image-upgrade.sh itself (live-proof-only).
 #
-# The needed-package set is the port's explicit RUN_DEPENDS (docs/misc/
+# The image's NEEDED/INSTALL/VERIFY set is the CORE RUN_DEPENDS ONLY (docs/misc/
 # pfSense_versions.md "pfBlockerNG runtime dependencies"): a FLAVOR-INDEPENDENT
 # core (libmaxminddb, lighttpd, jq, rsync, grepcidr, iprange, gnugrep) plus two
 # python packages whose name tracks the base Python (py<flavor>-maxminddb,
-# py<flavor>-sqlite3), plus zero or more EXTRA python packages the matrix row's
-# extra_pkgs carries (port origins pfSense's own repo doesn't serve for that
-# channel, e.g. CE's textproc/py-charset-normalizer — see the CE-only note in
-# pfSense_versions.md; scripts/build-dep-pkg-portable.py is the same "pyNNN"
-# naming convention this file's extra-pkg-name transform mirrors).
+# py<flavor>-sqlite3). A matrix row's extra_pkgs (e.g. CE's
+# textproc/py-charset-normalizer) NEVER enter needed/install/verify — that
+# package is DELIBERATELY not baked into the image (the per-leg smoke harness
+# ships+installs it via SMOKE_DEP_PKGS, and a real install resolves it from our
+# self-hosted repo as an ordinary RUN_DEPENDS; see the CE-only note in
+# pfSense_versions.md). extra_pkgs participate ONLY in shed: a package matching
+# an extra_pkgs-derived name (at ANY py-flavor) is shed if OLD_EXTRA carried its
+# origin and NEW_EXTRA has since dropped it — i.e. a genuinely stale stray, not
+# every image that happens to have Netgate's own copy of it (Plus's extra_pkgs
+# is [] on every row, so its baked charset-normalizer is never recognised as
+# extra-derived and stays untouched).
 #
 # POSIX sh; shellcheck clean; no bashisms.
 
 # pfb_dep_core_pkgs FLAVOR — echo the flavor-independent + flavor-tracking core
 # RUN_DEPENDS package names, one per line, in the docs/misc/pfSense_versions.md
-# table's order. FLAVOR must look like pyNNN (py311, py39, py312, ...).
+# table's order. FLAVOR must look like pyNNN (py311, py39, py312, ...). This IS
+# the image's full needed/install/verify set — extra_pkgs never add to it.
 pfb_dep_core_pkgs() {
     case "$1" in
         py[0-9][0-9]*) ;;
@@ -57,66 +64,55 @@ pfb_dep_python_dotted() {
     unset _pdd_digits _pdd_maj _pdd_min
 }
 
-# pfb_dep_extra_pkg_name ORIGIN FLAVOR — echo the package name for a port
-# ORIGIN (e.g. "textproc/py-charset-normalizer") under python FLAVOR, e.g.
-# "py311-charset-normalizer". The "py-" PKGNAMEPREFIX is a FreeBSD python-port
-# convention (stripped and replaced by pyNNN-); every current/known extra_pkgs
-# entry is a python port (build-dep-pkg-portable.py requires --py-flavor).
-pfb_dep_extra_pkg_name() {
-    _depn_base="${1##*/}"
-    case "$_depn_base" in
-        py-*) _depn_base="${_depn_base#py-}" ;;
+# pfb_dep_extra_basename ORIGIN — echo the basename of a port ORIGIN with its
+# "py-" PKGNAMEPREFIX stripped (FreeBSD python-port convention), e.g.
+# "textproc/py-charset-normalizer" -> "charset-normalizer". SHED-recognition
+# only (see file header) — never used to add anything to needed/install/verify.
+pfb_dep_extra_basename() {
+    _extb_base="${1##*/}"
+    case "$_extb_base" in
+        py-*) _extb_base="${_extb_base#py-}" ;;
     esac
-    printf '%s-%s\n' "$2" "$_depn_base"
-    unset _depn_base
+    printf '%s\n' "$_extb_base"
+    unset _extb_base
 }
 
-# pfb_dep_needed_pkgs FLAVOR EXTRA_ORIGINS — echo the FULL needed package set
-# for FLAVOR: the core list, then one pfb_dep_extra_pkg_name line per non-empty
-# line of EXTRA_ORIGINS (newline-separated port origins; empty string = none).
-pfb_dep_needed_pkgs() {
-    pfb_dep_core_pkgs "$1" || return 1
-    [ -n "$2" ] || return 0
-    printf '%s\n' "$2" | while IFS= read -r _needp_origin; do
-        [ -n "$_needp_origin" ] || continue
-        pfb_dep_extra_pkg_name "$_needp_origin" "$1"
+# pfb_dep_extra_basenames EXTRA_ORIGINS — pfb_dep_extra_basename for each
+# non-empty line of EXTRA_ORIGINS (newline-separated port origins; empty
+# string = none, echoes nothing).
+pfb_dep_extra_basenames() {
+    [ -n "$1" ] || return 0
+    printf '%s\n' "$1" | while IFS= read -r _extbs_origin; do
+        [ -n "$_extbs_origin" ] || continue
+        pfb_dep_extra_basename "$_extbs_origin"
     done
-}
-
-# pfb_dep_python_modules FLAVOR EXTRA_ORIGINS — echo the python import-probe
-# module names for FLAVOR's needed set: the two core modules (maxminddb,
-# sqlite3) plus one per EXTRA_ORIGINS entry, with its package-name dashes
-# turned into the underscores python's import name uses (charset-normalizer ->
-# charset_normalizer).
-pfb_dep_python_modules() {
-    printf '%s\n' maxminddb sqlite3
-    [ -n "$2" ] || return 0
-    printf '%s\n' "$2" | while IFS= read -r _modp_origin; do
-        [ -n "$_modp_origin" ] || continue
-        _modp_base="${_modp_origin##*/}"
-        case "$_modp_base" in
-            py-*) _modp_base="${_modp_base#py-}" ;;
-        esac
-        printf '%s\n' "$_modp_base" | tr '-' '_'
-    done
-    unset _modp_base
 }
 
 # pfb_dep_plan OLD_FLAVOR OLD_EXTRA NEW_FLAVOR NEW_EXTRA INSTALLED — echo the
 # reconcile plan as lines "install <pkg>" / "shed <pkg>":
-#   install = NEW's needed set minus what INSTALLED (newline-separated package
+#   install = the NEW row's CORE needed set (pfb_dep_core_pkgs; extra_pkgs
+#             never included) minus what INSTALLED (newline-separated package
 #             names, e.g. `pkg query '%n'`) already has.
-#   shed    = OLD's needed set minus NEW's needed set, INTERSECTED with
-#             INSTALLED (never a general autoremove — only a package this
-#             function itself considers part of the known pfBlockerNG dep
-#             namespace, and only if actually present).
+#   shed    = two sources, both INTERSECTED with INSTALLED (never a general
+#             autoremove):
+#             (1) CORE packages the OLD row needed that the NEW row no longer
+#                 does (a py_flavor flip strands the old-flavor ones), and
+#             (2) any installed package matching pyNNN-<basename> (any
+#                 py-flavor) for a basename OLD_EXTRA carried that NEW_EXTRA
+#                 has since dropped — a genuinely stale extra_pkgs stray. A
+#                 basename still listed by NEW_EXTRA is NEVER shed here, even
+#                 across a py_flavor flip (that transition is the per-leg
+#                 harness's job, not the image's).
 # A same-row call (OLD==NEW) is the "verify only" shape (e.g. the new version
-# has no matrix row yet): shed is always empty and install is exactly the
-# currently-missing packages.
+# has no matrix row yet): both shed sources are empty and install is exactly
+# the currently-missing CORE packages.
 pfb_dep_plan() {
-    _planp_old_needed="$(pfb_dep_needed_pkgs "$1" "$2")" || return 1
-    _planp_new_needed="$(pfb_dep_needed_pkgs "$3" "$4")" || return 1
+    _planp_old_flavor="$1"; _planp_old_extra="$2"
+    _planp_new_flavor="$3"; _planp_new_extra="$4"
     _planp_installed="$5"
+
+    _planp_old_needed="$(pfb_dep_core_pkgs "$_planp_old_flavor")" || return 1
+    _planp_new_needed="$(pfb_dep_core_pkgs "$_planp_new_flavor")" || return 1
 
     printf '%s\n' "$_planp_new_needed" | while IFS= read -r _planp_pkg; do
         [ -n "$_planp_pkg" ] || continue
@@ -135,5 +131,25 @@ pfb_dep_plan() {
         fi
     done
 
-    unset _planp_old_needed _planp_new_needed _planp_installed
+    # Extra-derived shed: basenames OLD_EXTRA carried that NEW_EXTRA dropped.
+    _planp_old_basenames="$(pfb_dep_extra_basenames "$_planp_old_extra")"
+    _planp_new_basenames="$(pfb_dep_extra_basenames "$_planp_new_extra")"
+    _planp_dropped_basenames="$(printf '%s\n' "$_planp_old_basenames" | while IFS= read -r _b; do
+        [ -n "$_b" ] || continue
+        printf '%s\n' "$_planp_new_basenames" | grep -qxF "$_b" || printf '%s\n' "$_b"
+    done)"
+
+    printf '%s\n' "$_planp_installed" | while IFS= read -r _planp_pkg; do
+        [ -n "$_planp_pkg" ] || continue
+        printf '%s\n' "$_planp_dropped_basenames" | while IFS= read -r _planp_base; do
+            [ -n "$_planp_base" ] || continue
+            case "$_planp_pkg" in
+                py[0-9][0-9]*-"$_planp_base") printf 'shed %s\n' "$_planp_pkg" ;;
+            esac
+        done
+    done
+
+    unset _planp_old_flavor _planp_old_extra _planp_new_flavor _planp_new_extra \
+        _planp_installed _planp_old_needed _planp_new_needed \
+        _planp_old_basenames _planp_new_basenames _planp_dropped_basenames
 }

--- a/scripts/lib/dep-reconcile.sh
+++ b/scripts/lib/dep-reconcile.sh
@@ -141,6 +141,14 @@ pfb_dep_plan() {
 
     printf '%s\n' "$_planp_installed" | while IFS= read -r _planp_pkg; do
         [ -n "$_planp_pkg" ] || continue
+        # CR-3: never shed a package the NEW core needed set still requires --
+        # a dropped extra_pkgs basename can collide with a core package name
+        # (e.g. net/py-maxminddb's basename "maxminddb" collides with the
+        # CORE py<flavor>-maxminddb dependency); the core requirement always
+        # wins over an extra_pkgs-derived shed.
+        if printf '%s\n' "$_planp_new_needed" | grep -qxF "$_planp_pkg"; then
+            continue
+        fi
         printf '%s\n' "$_planp_dropped_basenames" | while IFS= read -r _planp_base; do
             [ -n "$_planp_base" ] || continue
             case "$_planp_pkg" in

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -3,16 +3,16 @@
 # regenerator (ADR-39). Installed by add-repo.sh.
 #
 # WHAT IT DOES (and nothing more): for each pfBlockerNG pkg-repo conf file that
-# EXISTS, it detects this box's pfSense edition/version/arch and UNCONDITIONALLY
+# EXISTS, it detects this box's pfSense edition/version and UNCONDITIONALLY
 # overwrites the conf with the canonical body — a fully-resolved GitHub Pages
 # catalog URL for the box's variant (ADR-17 / ADR-20) plus a marker comment.
 # No pkg call, no network fetch, no snapshot, no parse-and-compare, no
 # reconcile. It is a pure conf REGENERATOR: re-deriving the conf from scratch is
 # strictly simpler — and never wrong — than diffing and patching one in place.
 #
-# WHY AT BOOT: a pfSense OS upgrade can change the box's edition/version/arch
-# (all of which require a reboot), which moves the catalog subtree. Regenerating
-# every boot keeps the conf aligned with no upgrade hook to register.
+# WHY AT BOOT: a pfSense OS upgrade can change the box's edition/version (which
+# requires a reboot), which moves the catalog subtree. Regenerating every boot
+# keeps the conf aligned with no upgrade hook to register.
 #
 # rc.d ordering: REQUIRE FILESYSTEMS (so /usr/local is mounted) and
 # BEFORE NETWORKING (so the conf is correct before anything that could invoke
@@ -22,8 +22,11 @@
 # HARD RULE: every path ends in `exit 0`. This hook MUST NEVER wedge boot.
 #
 # Detection (KISS): edition = "/etc/product_label contains 'Plus'" -> plus, else
-# ce; version = major.minor of /etc/version; arch = the leaf of `pkg config abi`.
-# This mirrors catalog_name_from_version() in scripts/build-repo-portable.py.
+# ce; version = major.minor of /etc/version. This mirrors
+# catalog_name_from_version() in scripts/build-repo-portable.py. Arch-less
+# since issue #1806 (NO_ARCH) — the catalog no longer has a per-arch leaf, so
+# this hook no longer calls `pkg` at all (it used to read `pkg config abi`
+# only to derive that leaf).
 #
 # The emitted conf body is BYTE-IDENTICAL to `add-repo.sh --print-conf`,
 # `build-repo.sh --print-conf`, and `build-repo-portable.py --print-conf`
@@ -50,14 +53,14 @@ name="pfblockerng_repo_generate"
 : "${PFB_NIGHTLY_CONF:=/usr/local/etc/pkg/repos/pfblockerng-nightly.conf}"
 : "${PFB_PRODUCT_LABEL:=/etc/product_label}"
 : "${PFB_VERSION_FILE:=/etc/version}"
-: "${PFB_PKG_BIN:=/usr/local/sbin/pkg}"
 : "${PFB_BASE_URL:=https://pfblockerng.github.io/pkg}"
 
 CONF_PRIORITY=100
 
-# Detect this box's catalog subtree "<varver>/<arch>" (e.g. "ce-2.8/amd64").
-# Returns 1 (no output) if version or arch can't be resolved — the caller then
-# leaves the existing conf untouched rather than writing a malformed URL.
+# Detect this box's catalog subtree "<varver>" (e.g. "ce-2.8") — arch-less
+# since issue #1806 (NO_ARCH). Returns 1 (no output) if the version can't be
+# resolved — the caller then leaves the existing conf untouched rather than
+# writing a malformed URL.
 _detect_catalog() {
     # Edition: lowercase prefix matching build-repo-portable.py (ce | plus).
     if grep -q 'Plus' "${PFB_PRODUCT_LABEL}" 2>/dev/null; then
@@ -69,11 +72,8 @@ _detect_catalog() {
     _dc_ver=''
     [ -r "${PFB_VERSION_FILE}" ] && IFS= read -r _dc_ver < "${PFB_VERSION_FILE}"
     _dc_mm="$(printf '%s' "${_dc_ver}" | cut -d. -f1,2)"
-    # Arch: leaf of `pkg config abi` ("FreeBSD:15:amd64" -> "amd64").
-    _dc_abi="$("${PFB_PKG_BIN}" config abi 2>/dev/null)"
-    _dc_arch="${_dc_abi##*:}"
-    [ -n "${_dc_mm}" ] && [ -n "${_dc_arch}" ] || return 1
-    printf '%s-%s/%s' "${_dc_edition}" "${_dc_mm}" "${_dc_arch}"
+    [ -n "${_dc_mm}" ] || return 1
+    printf '%s-%s' "${_dc_edition}" "${_dc_mm}"
 }
 
 # Emit the canonical conf body. $1 = channel word, $2 = repo name, $3 = url.
@@ -86,8 +86,8 @@ _emit_conf() {
 # Generated at boot by pfblockerng_repo_generate (ADR-39) — do not edit; re-run add-repo.sh to change.
 # pfBlockerNG (${_ec_channel} channel) — self-hosted pkg repository (ADR-17).
 # NONE-signed: trust anchor is HTTPS to the host (no signing key). The URL is
-# fully resolved for this box's edition/version/arch (ADR-39); the boot
-# rc.d hook updates it on a pfSense OS upgrade.
+# fully resolved for this box's edition/version (ADR-39; arch-less/NO_ARCH,
+# issue #1806); the boot rc.d hook updates it on a pfSense OS upgrade.
 # priority ${CONF_PRIORITY} sits above the base Netgate \`pfSense\` repo so cross-repo
 # resolution (pkg install/upgrade, GUI Install) selects the pfBlockerNG build.
 ${_ec_repo}: {

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -25,7 +25,8 @@
 #   --print-all          Print both BUILD and CI matrices to stdout (labelled).
 #   --print-route        Print ROUTE matrix JSON to stdout — every entry with a live
 #                        catalog: role=build (or absent) UNION role=route-only. This
-#                        is the set whose release/<varver>/<arch>/ catalog is served.
+#                        is the set whose release/<varver>/ catalog is served (one row
+#                        per pfSense version — never deduped, unlike --print-build).
 #                        Excludes truly-dropped entries (those are simply absent from
 #                        supported-versions.json).
 #   --variant CE|Plus    Filter both matrices to entries whose `variant` field
@@ -35,29 +36,42 @@
 #                        this flag all entries are returned (backward-compatible).
 #
 # Outputs:
-#   BUILD matrix     — role=build entries (absent role treated as build; back-compat).
-#     Each entry carries: pfsense_version, channel, freebsd_version, freebsd_major,
-#     php_version, py_flavor, variant, status, ci, arch. `arch` is resolved
-#     (default "amd64"), so the build fans out version × arch — an entry that
-#     omits arch (every entry today) stays amd64, while an aarch64 entry
-#     (Plus-only, Netgate ARM appliances) builds a FreeBSD:N:aarch64 .pkg
-#     (issue #199). role=route-only entries are EXCLUDED: they are served from a
-#     frozen .pkg but never built or smoked.
-#   CI matrix        — the ci:true entries (ANY channel), subset of BUILD matrix.
-#     Inherits the resolved `arch` from the BUILD matrix, and additionally carries
-#     a resolved image_name (default "pfsense-ce") and mac (default the CE pin
-#     "BC:24:11:37:9C:AC"), so an entry that omits them — every CE entry today —
-#     keeps the CE image + MAC, while a ci:true Plus entry can carry its own
-#     image_name/mac (ADR-24). role=route-only entries are EXCLUDED (same as BUILD).
-#   ROUTE matrix     — BUILD matrix UNION role=route-only entries. Every entry whose
-#     release/<varver>/<arch>/ catalog is actively served. The generator uses this
-#     to determine which varver paths to build (route-only from frozen .pkg, build
-#     entries from the fresh build). Absent role == build (fully back-compat).
-#   python_versions  — DISTINCT python versions derived from each BUILD-matrix
+#   BUILD matrix     — role=build entries (absent role treated as build; back-compat),
+#     DEDUPED to one row per distinct freebsd_major (issue #1806): every
+#     pfSense-pkg-pfBlockerNG port is NO_ARCH, so one wildcard-ABI .pkg build
+#     serves every arch AND every edition/version sharing a FreeBSD major — the
+#     BUILD matrix is the CI fan-out that actually BUILDS a .pkg, so it collapses
+#     to that one-build-per-major granularity. Each row carries: freebsd_major,
+#     php_version, py_flavor, extra_pkgs (deduped union across merged rows;
+#     default [] when every merged row omits it), plus pfsense_version/channel/
+#     freebsd_version/variant/status/ci/image_name/mac/... inherited from
+#     whichever merged row is LAST in matrix order (fine for a build TARGET; a
+#     consumer needing every distinct version sharing a major reads --print-ci
+#     or --print-route instead, both one row per version, never deduped).
+#     php_version/py_flavor drive the real build and MUST agree across every row
+#     sharing a major — disagreement is a hard error (an unresolvable ambiguity,
+#     never silently picking one side). There is no `arch` field anywhere: the
+#     catalog is arch-less (a stray `arch` key on an input row is tolerated and
+#     ignored, never resurrected as a default). role=route-only entries are
+#     EXCLUDED: they are served from a frozen .pkg but never built or smoked.
+#   CI matrix        — the ci:true entries (ANY channel), ONE ROW PER VERSION
+#     (never deduped by freebsd_major — a smoke/UI leg boots one VM per pfSense
+#     version, so it needs every version's own identity). Carries extra_pkgs
+#     (default [] when absent) and a resolved image_name (default "pfsense-ce")
+#     + mac (default the CE pin "BC:24:11:37:9C:AC"), so an entry that omits them
+#     — every CE entry today — keeps the CE image + MAC, while a ci:true Plus
+#     entry can carry its own image_name/mac (ADR-24). role=route-only entries
+#     are EXCLUDED (same as BUILD).
+#   ROUTE matrix     — BUILD-role-eligible entries (one row per version, never
+#     deduped) UNION role=route-only entries. Every entry whose release/<varver>/
+#     catalog is actively served. The generator uses this to determine which
+#     varver paths to build (route-only from frozen .pkg, build entries from the
+#     fresh build). Absent role == build (fully back-compat).
+#   python_versions  — DISTINCT python versions derived from every build-role
 #     entry's py_flavor (`pyN` + `MM` => `N.MM`, e.g. py311 => 3.11; py39 => 3.9),
 #     sorted + deduped. test.yml's pytest matrix (supported-only — only the
 #     pythons the matrix actually ships). Excludes route-only (no build, no test leg).
-#   php_versions     — DISTINCT php_version across the BUILD-matrix entries,
+#   php_versions     — DISTINCT php_version across every build-role entry,
 #     sorted + deduped. test.yml's PHP-jobs matrix (supported-only).
 #     Excludes route-only (no build, no test leg).
 #
@@ -137,6 +151,9 @@ fi
 # ── Route matrix: ALL entries with a live catalog (build ∪ route-only) ───────
 # role absent/build/route-only all have a served catalog. A truly dropped version
 # is simply absent from the JSON. Absent role defaults to "build" (back-compat).
+# issue #1806: no `arch` normalization here (or anywhere in this script) — the
+# catalog is arch-less. A stray `arch` key on an input row rides through
+# untouched (tolerated, never inspected); this script never adds one.
 if [ -n "$VARIANT_FILTER" ]; then
   # Case-insensitive match: compare lowercase of both sides.
   _VF_LOWER="$(printf '%s' "$VARIANT_FILTER" | tr '[:upper:]' '[:lower:]')"
@@ -147,10 +164,6 @@ else
   ROUTE_MATRIX="$(printf '%s' "$RAW_JSON" | jq -c '.versions')"
 fi
 
-# Normalise arch in the ROUTE matrix (same rule as BUILD: absent/empty => amd64).
-ROUTE_MATRIX="$(printf '%s' "$ROUTE_MATRIX" | jq -c '
-  [ .[] | . + { arch: (if ((.arch // "") == "") then "amd64" else .arch end) } ]')"
-
 # Fail closed on an unknown role (allowed: absent, "build", "route-only") so a typo
 # like "route_only" cannot silently re-enable build/CI/smoke for an EOL version.
 if [ "$(printf '%s' "$ROUTE_MATRIX" | jq '[.[] | select(has("role") and (.role != "build" and .role != "route-only"))] | length')" -gt 0 ]; then
@@ -158,27 +171,78 @@ if [ "$(printf '%s' "$ROUTE_MATRIX" | jq '[.[] | select(has("role") and (.role !
   exit 1
 fi
 
-# ── Build matrix: role=build entries only (excludes role=route-only) ──────────
-# An absent role is treated as "build" ((.role // "build") == "build") so with
-# today's matrices — no route-only entries — the BUILD matrix is byte-identical to
-# the old full .versions[] output (fully back-compat).
-BUILD_MATRIX="$(printf '%s' "$ROUTE_MATRIX" | jq -c \
+# ── Build-role entries: role=build (or absent), ONE ROW PER VERSION ──────────
+# An absent role is treated as "build" ((.role // "build") == "build"). This is
+# the per-version pool the CI matrix (below) and VARIANT_ARRAY read — never
+# deduped, so every distinct version/variant stays visible.
+_BUILD_ROLE_ENTRIES="$(printf '%s' "$ROUTE_MATRIX" | jq -c \
   '[.[] | select((.role // "build") != "route-only")]')"
 
-# BUILD_MATRIX inherits already-normalised arch from ROUTE_MATRIX (absent/empty =>
-# amd64, done above). The CI matrix inherits this resolved arch verbatim.
+# ── Build matrix: _BUILD_ROLE_ENTRIES DEDUPED to one row per freebsd_major ────
+# issue #1806: every pfSense-pkg-pfBlockerNG port is NO_ARCH, so one wildcard-ABI
+# .pkg build serves every arch AND every edition/version sharing a FreeBSD
+# major — the BUILD matrix (what actually drives a .pkg build) collapses to
+# that granularity. php_version/py_flavor drive the real build and MUST agree
+# across every row sharing a major; a disagreement is a hard error (never
+# silently picking one side) rather than a silently wrong dep set. Grouping
+# key is `.freebsd_major // ""` but the EMPTY-major group is deliberately never
+# merged/asserted (`.[0].freebsd_major // "" == ""` guards both jq calls below):
+# every REAL matrix entry always carries freebsd_major, so an empty-major row
+# only ever shows up in a synthetic fixture exercising unrelated derivations
+# (e.g. python_versions/php_versions) that never intended those rows to
+# represent the same build target.
+_BUILD_MAJOR_MISMATCH="$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq -c '
+  group_by(.freebsd_major // "")
+  | map(select(
+      (.[0].freebsd_major // "") != ""
+      and ((map(.php_version) | unique | length) > 1 or (map(.py_flavor) | unique | length) > 1)
+    ))
+  | map({freebsd_major: .[0].freebsd_major,
+         php_version: (map(.php_version) | unique),
+         py_flavor: (map(.py_flavor) | unique)})')"
+if [ "$(printf '%s' "$_BUILD_MAJOR_MISMATCH" | jq 'length')" -gt 0 ]; then
+  printf '::error::BUILD matrix: freebsd_major with disagreeing php_version/py_flavor across merged rows in %s: %s\n' \
+    "$MATRIX_FILE" "$(printf '%s' "$_BUILD_MAJOR_MISMATCH" | jq -c '.')" >&2
+  exit 1
+fi
 
-# ── CI matrix: the ci:true entries (ANY channel) within the variant-filtered set ──
-# The channel no longer filters (ADR-24): a ci:true Plus entry is a first-class CI
-# leg. Each entry gains a resolved image_name (default "pfsense-ce") and mac (default
-# the CE pin) — an entry that omits them keeps the CE image + MAC, while a Plus entry
-# carries its own. The MAC is load-bearing for a Plus image (license/NDI keyed to it).
-CI_MATRIX="$(printf '%s' "$BUILD_MATRIX" | jq -c '
+# Merge each REAL freebsd_major group into ONE row: identity fields
+# (pfsense_version, channel, variant, status, image_name, mac, ci, ...) come
+# from whichever row is LAST in matrix order (jq's `+` — later keys win) —
+# fine for a build TARGET; a consumer needing every distinct version reads
+# --print-ci/--print-route instead. extra_pkgs unions + dedupes + sorts across
+# every merged row (default [] when every one omits it), so e.g. CE's
+# textproc/py-charset-normalizer survives the merge even if a same-major
+# sibling entry carries none. An empty-major row (see above) passes through
+# UNMERGED, one row per input entry — never grouped with its empty-major peers.
+BUILD_MATRIX="$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq -c '
+  group_by(.freebsd_major // "")
+  | map(
+      if (.[0].freebsd_major // "") == "" then
+        .[]
+      else
+        (reduce .[] as $row ({}; . + $row)) as $merged
+        | $merged + {extra_pkgs: ([.[] | (.extra_pkgs // [])] | add | unique | sort)}
+      end
+    )
+  | sort_by(.freebsd_major // "")')"
+
+# ── CI matrix: the ci:true entries (ANY channel), ONE ROW PER VERSION ─────────
+# Derived from _BUILD_ROLE_ENTRIES (never the deduped BUILD_MATRIX): a smoke/UI
+# leg boots one VM per pfSense version, so it needs every version's own
+# identity, never collapsed by freebsd_major. The channel no longer filters
+# (ADR-24): a ci:true Plus entry is a first-class CI leg. Each entry gains a
+# resolved image_name (default "pfsense-ce"), mac (default the CE pin), and
+# extra_pkgs (default []) — an entry that omits them keeps the CE image + MAC
+# and an empty dep list, while a Plus entry can carry its own. The MAC is
+# load-bearing for a Plus image (license/NDI keyed to it).
+CI_MATRIX="$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq -c '
   [ .[]
     | select(.ci == true)
     | . + {
         image_name: (if ((.image_name // "") == "") then "pfsense-ce" else .image_name end),
-        mac: (if ((.mac // "") == "") then "BC:24:11:37:9C:AC" else .mac end)
+        mac: (if ((.mac // "") == "") then "BC:24:11:37:9C:AC" else .mac end),
+        extra_pkgs: (.extra_pkgs // [])
       }
   ]')"
 
@@ -194,34 +258,38 @@ if [ "${_VF_LOWER:-}" != "plus" ]; then
 fi
 
 # ── Emit ──────────────────────────────────────────────────────────────────────
-# Variant JSON array: distinct variant values present in the BUILD matrix.
-VARIANT_ARRAY="$(printf '%s' "$BUILD_MATRIX" | jq -c '[.[].variant // empty] | unique')"
+# Variant JSON array: distinct variant values present among build-role entries
+# (_BUILD_ROLE_ENTRIES, never the deduped BUILD_MATRIX — a variant sharing a
+# freebsd_major with another must still be visible here).
+VARIANT_ARRAY="$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq -c '[.[].variant // empty] | unique')"
 
 # ── Derived test matrices (test.yml — supported-only) ─────────────────────────
 # python_versions: map each entry's py_flavor ("pyN" + "MM") to "N.MM"
 #   (py311 => 3.11, py39 => 3.9), then dedup + sort. The regex captures the
 #   single major digit and the remaining minor digits, joined with a dot.
 # php_versions: distinct php_version values, deduped + sorted.
-# Both feed test.yml's strategy.matrix unfiltered (CE + Plus) so the pytest /
-# PHP gates only ever run a version the matrix actually ships.
-PYTHON_VERSIONS="$(printf '%s' "$BUILD_MATRIX" | jq -c '
+# Both derive from _BUILD_ROLE_ENTRIES (equivalent distinct-value set to the
+# deduped BUILD_MATRIX, computed pre-dedup for directness) and feed test.yml's
+# strategy.matrix unfiltered (CE + Plus) so the pytest / PHP gates only ever
+# run a version the matrix actually ships.
+PYTHON_VERSIONS="$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq -c '
   [ .[].py_flavor
     | capture("^py(?<maj>[0-9])(?<min>[0-9]+)$")
     | "\(.maj).\(.min)"
   ] | unique')"
-PHP_VERSIONS="$(printf '%s' "$BUILD_MATRIX" | jq -c '[.[].php_version] | unique')"
+PHP_VERSIONS="$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq -c '[.[].php_version] | unique')"
 
-# Fail-closed: every entry in a non-empty BUILD matrix must yield a python AND a php
+# Fail-closed: every entry in a non-empty build-role set must yield a python AND a php
 # version. The py_flavor map above already aborts on a malformed flavor (jq capture()
 # errors under set -e); guard the php side SYMMETRICALLY — a null/empty php_version on
 # any entry must fail HERE, not slip through as a [null] matrix leg (a bare length check
 # would pass [null], whose length is 1, straight into test.yml's strategy.matrix).
-if [ "$(printf '%s' "$BUILD_MATRIX" | jq 'length')" -gt 0 ]; then
+if [ "$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq 'length')" -gt 0 ]; then
   if [ "$(printf '%s' "$PYTHON_VERSIONS" | jq 'length')" -eq 0 ]; then
     printf '::error::no python versions derived from py_flavor in %s (malformed py_flavor?)\n' "$MATRIX_FILE" >&2
     exit 1
   fi
-  if [ "$(printf '%s' "$BUILD_MATRIX" | jq '[.[].php_version | select(. == null or . == "")] | length')" -gt 0 ]; then
+  if [ "$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq '[.[].php_version | select(. == null or . == "")] | length')" -gt 0 ]; then
     printf '::error::an entry has a missing/empty php_version in %s\n' "$MATRIX_FILE" >&2
     exit 1
   fi

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -44,15 +44,19 @@
 #     to that one-build-per-major granularity. Each row carries: freebsd_major,
 #     php_version, py_flavor, extra_pkgs (deduped union across merged rows;
 #     default [] when every merged row omits it), plus pfsense_version/channel/
-#     freebsd_version/variant/status/ci/image_name/mac/... inherited from
-#     whichever merged row is LAST in matrix order (fine for a build TARGET; a
-#     consumer needing every distinct version sharing a major reads --print-ci
-#     or --print-route instead, both one row per version, never deduped).
+#     freebsd_version/variant/status/image_name/mac/... inherited from whichever
+#     merged row is LAST in matrix order (fine for a build TARGET; a consumer
+#     needing every distinct version sharing a major reads --print-ci or
+#     --print-route instead, both one row per version, never deduped).
 #     php_version/py_flavor drive the real build and MUST agree across every row
 #     sharing a major — disagreement is a hard error (an unresolvable ambiguity,
-#     never silently picking one side). There is no `arch` field anywhere: the
-#     catalog is arch-less (a stray `arch` key on an input row is tolerated and
-#     ignored, never resurrected as a default). role=route-only entries are
+#     never silently picking one side). There is no `arch` OR `ci` field on a
+#     merged BUILD row, ever: both are explicitly deleted post-merge (a stray
+#     `arch`/`ci` key on any contributing row — even a non-representative one —
+#     would otherwise ride through via the last-wins `reduce`, e.g. a
+#     non-last row's `arch` never gets overwritten by a last row that lacks
+#     it). BUILD consumers never read either key; --print-ci is the leg/arch
+#     source. role=route-only entries are
 #     EXCLUDED: they are served from a frozen .pkg but never built or smoked.
 #   CI matrix        — the ci:true entries (ANY channel), ONE ROW PER VERSION
 #     (never deduped by freebsd_major — a smoke/UI leg boots one VM per pfSense
@@ -223,6 +227,7 @@ BUILD_MATRIX="$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq -c '
       else
         (reduce .[] as $row ({}; . + $row)) as $merged
         | $merged + {extra_pkgs: ([.[] | (.extra_pkgs // [])] | add | unique | sort)}
+        | del(.arch, .ci)
       end
     )
   | sort_by(.freebsd_major // "")')"

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -258,12 +258,18 @@ if [ "$_EXTRA_PKGS_COUNT" -gt 0 ]; then
         # explicitly (idempotent; cone mode already set by sparse-clone-ports.sh).
         git -C "$PORTS_DIR" sparse-checkout add "$_origin"
         printf 'smoke-on-box: building dep pkg %s...\n' "$_origin" >&2
-        _dep_pkg="$(python3 scripts/build-dep-pkg-portable.py \
+        # Capture WITHOUT a pipe first -- a pipe inside `$(...)` would take the
+        # PIPELINE's exit status (tail's, always 0) instead of the builder's,
+        # masking a real build failure under `set -e`. Then tail -n 1 as
+        # belt-and-braces on top of the script's own stdout=path-only contract
+        # (take only the LAST line no matter what).
+        _dep_pkg_out="$(python3 scripts/build-dep-pkg-portable.py \
             --ports "$PORTS_DIR" \
             --port "$_origin" \
             --py-flavor "$_py_flavor" \
             --freebsd-major "$_freebsd_major" \
             --out-dir "$_DEP_PKG_DIR")"
+        _dep_pkg="$(printf '%s\n' "$_dep_pkg_out" | tail -n 1)"
         SMOKE_DEP_PKGS="${SMOKE_DEP_PKGS:+$SMOKE_DEP_PKGS }${_dep_pkg}"
         _i=$((_i + 1))
     done

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -249,26 +249,20 @@ SMOKE_DEP_PKGS=""
 if [ "$_EXTRA_PKGS_COUNT" -gt 0 ]; then
     _DEP_PKG_DIR="${REPO_ROOT}/out/deppkgs"
     mkdir -p "$_DEP_PKG_DIR"
-    # The target's own lang/python<NNN> PORTVERSION, from the SAME ports tree —
-    # the honest source for the python<NNN> RUN_DEPENDS version
-    # build-dep-pkg-portable.py records (never a fixed/guessed literal).
-    _PYNNN="$(printf '%s' "$_py_flavor" | sed 's/^py//')"
-    _PYTHON_DEP_VERSION="$(sed -n 's/^PORTVERSION=[[:space:]]*//p' "${PORTS_DIR}/lang/python${_PYNNN}/Makefile" | head -1)"
-    if [ -z "$_PYTHON_DEP_VERSION" ]; then
-        printf 'smoke-on-box: cannot derive PORTVERSION from %s/lang/python%s/Makefile\n' \
-            "$PORTS_DIR" "$_PYNNN" >&2
-        exit 1
-    fi
     _i=0
     while [ "$_i" -lt "$_EXTRA_PKGS_COUNT" ]; do
         _origin="$(printf '%s' "$_EXTRA_PKGS_JSON" | jq -r ".[$_i]")"
+        # sparse-clone-ports.sh's checkout only includes the pfBlockerNG port's
+        # OWN RUN_DEPENDS -- extra_pkgs is a matrix-level concept it doesn't
+        # know about, so this origin's dir was never materialized. Add it
+        # explicitly (idempotent; cone mode already set by sparse-clone-ports.sh).
+        git -C "$PORTS_DIR" sparse-checkout add "$_origin"
         printf 'smoke-on-box: building dep pkg %s...\n' "$_origin" >&2
         _dep_pkg="$(python3 scripts/build-dep-pkg-portable.py \
             --ports "$PORTS_DIR" \
             --port "$_origin" \
             --py-flavor "$_py_flavor" \
             --freebsd-major "$_freebsd_major" \
-            --python-dep-version "$_PYTHON_DEP_VERSION" \
             --out-dir "$_DEP_PKG_DIR")"
         SMOKE_DEP_PKGS="${SMOKE_DEP_PKGS:+$SMOKE_DEP_PKGS }${_dep_pkg}"
         _i=$((_i + 1))

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -245,6 +245,14 @@ _BUILD_ROW="$(sh scripts/read-version-matrix.sh --print-build)" \
 _EXTRA_PKGS_JSON="$(printf '%s' "$_BUILD_ROW" | jq -c --arg maj "$_freebsd_major" \
     '([.[] | select(.freebsd_major == $maj)][0].extra_pkgs) // []')"
 _EXTRA_PKGS_COUNT="$(printf '%s' "$_EXTRA_PKGS_JSON" | jq 'length')"
+# This leg's OWN py_flavor from the SAME matrix row (already read above for
+# extra_pkgs) -- never the top-level hardcoded default: a dep .pkg's
+# python<NNN> RUN_DEPENDS must match the box's REAL flavor, which the matrix
+# already knows precisely, even while the branch-.pkg build above still uses
+# the hardcoded ceiling (see its own comment).
+_dep_py_flavor="$(printf '%s' "$_BUILD_ROW" | jq -r --arg maj "$_freebsd_major" \
+    '([.[] | select(.freebsd_major == $maj)][0].py_flavor) // ""')"
+[ -n "$_dep_py_flavor" ] || _dep_py_flavor="$_py_flavor"
 SMOKE_DEP_PKGS=""
 if [ "$_EXTRA_PKGS_COUNT" -gt 0 ]; then
     _DEP_PKG_DIR="${REPO_ROOT}/out/deppkgs"
@@ -266,7 +274,7 @@ if [ "$_EXTRA_PKGS_COUNT" -gt 0 ]; then
         _dep_pkg_out="$(python3 scripts/build-dep-pkg-portable.py \
             --ports "$PORTS_DIR" \
             --port "$_origin" \
-            --py-flavor "$_py_flavor" \
+            --py-flavor "$_dep_py_flavor" \
             --freebsd-major "$_freebsd_major" \
             --out-dir "$_DEP_PKG_DIR")"
         _dep_pkg="$(printf '%s\n' "$_dep_pkg_out" | tail -n 1)"

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -34,7 +34,10 @@
 #   3. Refresh /root/images/{pfsense,civm} via oras (digest-compare; pull when absent).
 #   4. Host prep: ip_unprivileged_port_start sysctl + pkill stale qemu.
 #   5. Build .pkg via build-leg.sh → SMOKE_PKG.
-#   6. Run: run-smoke.sh with the configured lane/marker/-k.
+#   6. Build this leg's extra_pkgs (per the CURRENT ref's version matrix) via
+#      build-dep-pkg-portable.py → SMOKE_DEP_PKGS (issue #1806 D2; empty when
+#      the leg's extra_pkgs is empty).
+#   7. Run: run-smoke.sh with the configured lane/marker/-k.
 #
 # POSIX sh; shellcheck clean; all expansions quoted.
 
@@ -231,6 +234,49 @@ SMOKE_PKG="$(sh scripts/build-leg.sh \
 export SMOKE_PKG
 printf 'smoke-on-box: pkg built: %s\n' "$SMOKE_PKG" >&2
 
+# ── Step 5b: this leg's dep pkgs (issue #1806 D2) ──────────────────────────── #
+# Look up this leg's freebsd_major row in the CURRENT ref's BUILD matrix
+# (read-version-matrix.sh --print-build is deduped one row per major) for its
+# extra_pkgs (port origins pfSense's own repo doesn't carry, e.g.
+# textproc/py-charset-normalizer for CE) and build each as a dep .pkg, from the
+# SAME ports tree build-leg.sh above just prepared/reused (no second clone).
+_BUILD_ROW="$(sh scripts/read-version-matrix.sh --print-build)" \
+    || { printf 'smoke-on-box: could not read the version matrix for extra_pkgs\n' >&2; exit 1; }
+_EXTRA_PKGS_JSON="$(printf '%s' "$_BUILD_ROW" | jq -c --arg maj "$_freebsd_major" \
+    '([.[] | select(.freebsd_major == $maj)][0].extra_pkgs) // []')"
+_EXTRA_PKGS_COUNT="$(printf '%s' "$_EXTRA_PKGS_JSON" | jq 'length')"
+SMOKE_DEP_PKGS=""
+if [ "$_EXTRA_PKGS_COUNT" -gt 0 ]; then
+    _DEP_PKG_DIR="${REPO_ROOT}/out/deppkgs"
+    mkdir -p "$_DEP_PKG_DIR"
+    # The target's own lang/python<NNN> PORTVERSION, from the SAME ports tree —
+    # the honest source for the python<NNN> RUN_DEPENDS version
+    # build-dep-pkg-portable.py records (never a fixed/guessed literal).
+    _PYNNN="$(printf '%s' "$_py_flavor" | sed 's/^py//')"
+    _PYTHON_DEP_VERSION="$(sed -n 's/^PORTVERSION=[[:space:]]*//p' "${PORTS_DIR}/lang/python${_PYNNN}/Makefile" | head -1)"
+    if [ -z "$_PYTHON_DEP_VERSION" ]; then
+        printf 'smoke-on-box: cannot derive PORTVERSION from %s/lang/python%s/Makefile\n' \
+            "$PORTS_DIR" "$_PYNNN" >&2
+        exit 1
+    fi
+    _i=0
+    while [ "$_i" -lt "$_EXTRA_PKGS_COUNT" ]; do
+        _origin="$(printf '%s' "$_EXTRA_PKGS_JSON" | jq -r ".[$_i]")"
+        printf 'smoke-on-box: building dep pkg %s...\n' "$_origin" >&2
+        _dep_pkg="$(python3 scripts/build-dep-pkg-portable.py \
+            --ports "$PORTS_DIR" \
+            --port "$_origin" \
+            --py-flavor "$_py_flavor" \
+            --freebsd-major "$_freebsd_major" \
+            --python-dep-version "$_PYTHON_DEP_VERSION" \
+            --out-dir "$_DEP_PKG_DIR")"
+        SMOKE_DEP_PKGS="${SMOKE_DEP_PKGS:+$SMOKE_DEP_PKGS }${_dep_pkg}"
+        _i=$((_i + 1))
+    done
+    printf 'smoke-on-box: dep pkgs built: %s\n' "$SMOKE_DEP_PKGS" >&2
+fi
+export SMOKE_DEP_PKGS
+
 # SSH key for the pfSense guest (baked into the image).
 export SMOKE_SSH_KEY="${SMOKE_SSH_KEY:-/root/smoke-ssh-key}"
 if [ ! -f "$SMOKE_SSH_KEY" ]; then
@@ -239,7 +285,7 @@ if [ ! -f "$SMOKE_SSH_KEY" ]; then
     exit 2
 fi
 
-# ── Step 5b: provision the Python test deps into a repo-root venv ──────────── #
+# ── Step 5c: provision the Python test deps into a repo-root venv ──────────── #
 # The box ships python3 but not pytest; install the harness deps (version-pinned
 # by the checked-out ref's tests/smoke/requirements.txt, + pytest explicitly, the
 # same set CI installs) into ${REPO_ROOT}/.venv so run-smoke.sh's non-CI .venv
@@ -258,7 +304,7 @@ if pfb_smoke_tier_needs_browser "$_MARKER"; then
     pfb_chromium_provision "$(pfb_playwright_cache_root)" "${REPO_ROOT}/.venv/bin/python" -m playwright
 fi
 
-# ── Step 6: run smoke ─────────────────────────────────────────────────────── #
+# ── Step 7: run smoke ─────────────────────────────────────────────────────── #
 # Paths + per-test timeout follow the marker: a UI tier scopes to tests/smoke/ui
 # with the 300s ceiling (matching ui-tests.yml); everything else keeps the
 # whole-suite tests/smoke + 30s default.

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -82,6 +82,12 @@ EOF
     The path "${work}/out/release/ce-2.8/packagesite.pkg" should be exist
     The path "${work}/out/release/FreeBSD:15:amd64" should not be exist
     The path "${work}/out/release/ce-2.8/amd64" should not be exist
+    # CR-4 (strengthen): the ABI is never used as a directory name any more
+    # (arch-less catalog) -- assert the ACTUAL wildcard-ABI value the fake
+    # packages carry (FreeBSD:15:*), not just a made-up "amd64" placeholder,
+    # never becomes a path segment either.
+    The path "${work}/out/release/FreeBSD:15:*" should not be exist
+    The path "${work}/out/release/ce-2.8/FreeBSD:15:*" should not be exist
   End
 
   It 'requires --varver in build mode (the key cannot be derived from the package)'

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -136,6 +136,13 @@ EOF
       'FreeBSD:*:amd64'
       '*'
       'FreeBSD:15:*extra'
+      # gate-B finding (issue #1806 step C0): the wildcard branch's charset-only
+      # check on `rest` (everything but the trailing ':*') accepted these two
+      # malformed shapes — 'FreeBSD:*' has NO major segment (0 colons in rest)
+      # and 'FreeBSD:15:16:*' has an EXTRA segment (2 colons in rest); the tight
+      # wildcard shape is EXACTLY "OS:major:*" (one colon in rest).
+      'FreeBSD:*'
+      'FreeBSD:15:16:*'
     End
 
     It "rejects hostile ABI metadata: $1"

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -1,17 +1,25 @@
 #shellcheck shell=sh
-# build-repo.sh fallback catalog layout (issue #1081).
+# build-repo.sh fallback catalog layout (issue #1081; arch-less/NO_ARCH #1806).
 #
-# Two defects are pinned here:
+# Defects/contracts pinned here:
 #
 #   1) The canonical .pkg copy was named "<name> <version>.pkg" (a SPACE --
 #      pkg_nv used '%n %v'), but `pkg repo` records and clients fetch the
 #      hyphenated "<name>-<version>.pkg"; the served path never resolved.
 #
 #   2) The catalog was laid out under release/<ABI>/, contradicting ADR-20's
-#      varver keying AND this script's own --print-conf url
-#      (release/<varver>/<arch>). The varver cannot be derived from the
-#      package (an ABI is not 1:1 with an edition/version), so the build mode
-#      now REQUIRES --varver and lays out release/<varver>/<arch>/.
+#      varver keying AND this script's own --print-conf url. The varver
+#      cannot be derived from the package (an ABI is not 1:1 with an
+#      edition/version), so the build mode REQUIRES --varver.
+#
+#   3) issue #1806: all three pfSense-pkg-pfBlockerNG ports are NO_ARCH — the
+#      catalog is now ARCH-LESS (release/<varver>/ holds the catalog
+#      DIRECTLY, no arch subdirectory) and HARD-REQUIRES every package's ABI
+#      to be CPU-wildcarded (e.g. "FreeBSD:15:*", probed live against a real
+#      Netgate noarch package) — a concrete-ABI package would silently
+#      install on only one arch, so validate_abi() accepts the tight wildcard
+#      shape (and ONLY that shape as the final segment) and the layout loop
+#      hard-rejects any package whose ABI isn't wildcarded.
 #
 # The pkg(8) stub serves `query -F` from key=value lines inside the fake .pkg
 # and materialises `pkg repo <dir>` as a packagesite.pkg marker, so the layout
@@ -61,25 +69,35 @@ EOF
       sh "${PFB_ROOT}/scripts/build-repo.sh" --in "${work}/in" --out "${work}/out" "$@"
   }
 
-  It 'lays the catalog out under release/<varver>/<arch>/ with hyphenated names'
-    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
-    fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.2 FreeBSD:15:amd64 php83
+  It 'lays the catalog out under release/<varver>/ DIRECTLY, arch-less, with hyphenated names'
+    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:* php83
+    fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.2 FreeBSD:15:* php83
     When call run_build --varver ce-2.8
     The status should be success
-    The stderr should include 'release/ce-2.8/amd64'
-    # Hyphenated canonical names (defect 1) in the varver bucket (defect 2)...
-    The path "${work}/out/release/ce-2.8/amd64/pfSense-pkg-pfBlockerNG-4.0.1.pkg" should be exist
-    The path "${work}/out/release/ce-2.8/amd64/pfSense-pkg-pfBlockerNG-4.0.2.pkg" should be exist
-    # ...pkg repo ran on the bucket, and no ABI-keyed dir was created.
-    The path "${work}/out/release/ce-2.8/amd64/packagesite.pkg" should be exist
+    The stderr should include 'release/ce-2.8'
+    # Hyphenated canonical names (defect 1) DIRECTLY in the varver dir (no arch leaf)...
+    The path "${work}/out/release/ce-2.8/pfSense-pkg-pfBlockerNG-4.0.1.pkg" should be exist
+    The path "${work}/out/release/ce-2.8/pfSense-pkg-pfBlockerNG-4.0.2.pkg" should be exist
+    # ...pkg repo ran on the bucket, no ABI-keyed dir, and no arch subdirectory either.
+    The path "${work}/out/release/ce-2.8/packagesite.pkg" should be exist
     The path "${work}/out/release/FreeBSD:15:amd64" should not be exist
+    The path "${work}/out/release/ce-2.8/amd64" should not be exist
   End
 
   It 'requires --varver in build mode (the key cannot be derived from the package)'
-    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
+    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:* php83
     When call run_build
     The status should equal 2
     The stderr should include '--varver'
+  End
+
+  It 'hard-rejects a concrete-ABI package — the arch-less catalog requires NO_ARCH'
+    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
+    When call run_build --varver ce-2.8
+    The status should equal 1
+    The stderr should include 'NO_ARCH'
+    # No filesystem layout may happen for a rejected concrete-ABI package.
+    The path "${work}/out/release" should not be exist
   End
 
   Describe 'hostile --varver values'
@@ -107,10 +125,17 @@ EOF
     # validate_abi(): the ABI becomes a path segment that is rm -rf'd +
     # rebuilt. The guard must reject under ANY ambient locale (issue #1148: a
     # collating UTF-8 locale lets a case-range class admit accented letters).
+    # The tight wildcard shapes (issue #1806) are hostile too: '*' is valid
+    # ONLY as the WHOLE final segment — elsewhere, alone, or partial is not
+    # an ABI at all and must still be rejected as "unsafe or invalid ABI"
+    # (a DIFFERENT, earlier gate than the "requires NO_ARCH" check below).
     Parameters
       'FreeBSD:15:amdé64'
       'FreeBSD/15/amd64'
       'FreeBSD:..:amd64'
+      'FreeBSD:*:amd64'
+      '*'
+      'FreeBSD:15:*extra'
     End
 
     It "rejects hostile ABI metadata: $1"
@@ -132,7 +157,7 @@ EOF
     # one — validate_abi() carries the same sentinel purely as parity.
     It 'rejects a --varver with a trailing newline'
       hostile="$(printf 'ce-2.8\nZ')"; hostile="${hostile%Z}"
-      fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
+      fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:* php83
       When call run_build --varver "$hostile"
       The status should equal 2
       The stderr should include 'unsafe or invalid --varver'
@@ -141,16 +166,16 @@ EOF
   End
 
   It 'fails loud on a mixed-ABI input instead of mixing editions in one bucket'
-    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
-    fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.1_1 FreeBSD:16:amd64 php85
+    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:* php83
+    fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.1_1 FreeBSD:16:* php85
     When call run_build --varver ce-2.8
     The status should equal 1
     The stderr should include 'mixed ABIs'
   End
 
   It 'still fails loud on a same-name+version+ABI flavor collision'
-    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php83
-    fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:amd64 php85
+    fake_pkg a.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:* php83
+    fake_pkg b.pkg pfSense-pkg-pfBlockerNG 4.0.1 FreeBSD:15:* php85
     When call run_build --varver ce-2.8
     The status should equal 1
     The stderr should include 'FLAVOR COLLISION'

--- a/tests/shell/dep_reconcile_spec.sh
+++ b/tests/shell/dep_reconcile_spec.sh
@@ -1,0 +1,231 @@
+#shellcheck shell=sh
+# dep_reconcile_spec.sh — shellspec suite for scripts/lib/dep-reconcile.sh
+# (issue #1806 final step: post-upgrade dependency reconcile + shed).
+#
+# Pins the pure needed-set derivation + install/shed diff that
+# scripts/image-upgrade.sh's post-upgrade phase drives: a py_flavor flip
+# (py311 -> py312) must install the new-flavor core pkgs and shed the
+# old-flavor ones; a missing package surfaces in the install list; a healthy
+# (already-reconciled) set produces two empty lists; a same-row call (the
+# "no matrix row for the new version yet" shape) never sheds and only
+# reports genuinely missing packages; and a matrix row's extra_pkgs is
+# excluded from shed while still needed, included once dropped.
+#
+# RED->GREEN: before scripts/lib/dep-reconcile.sh exists, every `.` (source)
+# below fails (ENOENT) and every function call is "command not found" —
+# these assertions FAIL. After the helper lands they PASS. Pure functions;
+# no ssh, no pkg(8), no VM — fully hermetic.
+
+Describe 'dep-reconcile.sh'
+  setup() {
+    scrub_git_env
+    # shellcheck source=scripts/lib/dep-reconcile.sh
+    . "${PFB_ROOT}/scripts/lib/dep-reconcile.sh"
+  }
+  BeforeEach 'setup'
+
+  Describe 'pfb_dep_core_pkgs'
+    It 'lists the 7 flavor-independent + 2 flavor-tracking RUN_DEPENDS packages for py311'
+      # Scenario: docs/misc/pfSense_versions.md's 9-row table (minus the
+      # extra_pkgs-derived charset-normalizer, which is NOT core).
+      When call pfb_dep_core_pkgs py311
+      The lines of output should equal 9
+      The output should include 'libmaxminddb'
+      The output should include 'lighttpd'
+      The output should include 'jq'
+      The output should include 'rsync'
+      The output should include 'grepcidr'
+      The output should include 'iprange'
+      The output should include 'gnugrep'
+      The output should include 'py311-maxminddb'
+      The output should include 'py311-sqlite3'
+    End
+
+    It 'tracks a different flavor (py312) on the two python packages'
+      # Branch coverage: the flavor prefix must actually vary, not be hardcoded.
+      When call pfb_dep_core_pkgs py312
+      The output should include 'py312-maxminddb'
+      The output should include 'py312-sqlite3'
+      The output should not include 'py311-maxminddb'
+    End
+
+    It 'rejects a malformed py_flavor (fail-closed, never a silent default)'
+      When call pfb_dep_core_pkgs python3
+      The status should be failure
+      The stderr should include 'invalid py_flavor'
+    End
+  End
+
+  Describe 'pfb_dep_python_dotted'
+    It 'maps py311 -> 3.11'
+      When call pfb_dep_python_dotted py311
+      The output should equal '3.11'
+    End
+
+    It 'maps py39 -> 3.9 (single-digit minor)'
+      When call pfb_dep_python_dotted py39
+      The output should equal '3.9'
+    End
+
+    It 'maps py312 -> 3.12'
+      When call pfb_dep_python_dotted py312
+      The output should equal '3.12'
+    End
+
+    It 'rejects a malformed flavor'
+      When call pfb_dep_python_dotted notaflavor
+      The status should be failure
+      The stderr should include 'invalid py_flavor'
+    End
+  End
+
+  Describe 'pfb_dep_extra_pkg_name'
+    It 'strips the py- PKGNAMEPREFIX and applies the target flavor'
+      # Scenario: the one currently-known extra_pkgs entry (CE's charset-normalizer).
+      When call pfb_dep_extra_pkg_name 'textproc/py-charset-normalizer' py311
+      The output should equal 'py311-charset-normalizer'
+    End
+
+    It 'applies a different flavor to the same origin'
+      When call pfb_dep_extra_pkg_name 'textproc/py-charset-normalizer' py312
+      The output should equal 'py312-charset-normalizer'
+    End
+  End
+
+  Describe 'pfb_dep_needed_pkgs'
+    It 'is exactly the core set when EXTRA_ORIGINS is empty'
+      When call pfb_dep_needed_pkgs py311 ''
+      The lines of output should equal 9
+      The output should not include 'charset-normalizer'
+    End
+
+    It 'appends the extra_pkgs-derived name when EXTRA_ORIGINS is non-empty'
+      When call pfb_dep_needed_pkgs py311 'textproc/py-charset-normalizer'
+      The lines of output should equal 10
+      The output should include 'py311-charset-normalizer'
+    End
+  End
+
+  Describe 'pfb_dep_python_modules'
+    It 'is maxminddb + sqlite3 with no extras'
+      When call pfb_dep_python_modules py311 ''
+      The lines of output should equal 2
+      The output should include 'maxminddb'
+      The output should include 'sqlite3'
+    End
+
+    It 'turns an extra package name dash into the python import underscore'
+      When call pfb_dep_python_modules py311 'textproc/py-charset-normalizer'
+      The lines of output should equal 3
+      The output should include 'charset_normalizer'
+      The output should not include 'charset-normalizer'
+    End
+  End
+
+  Describe 'pfb_dep_plan'
+    # installed_of <flavor> [extra] — the exact needed set for FLAVOR (+ optional
+    # extra origin), i.e. a box that is FULLY reconciled for that row already.
+    installed_of() {
+      pfb_dep_needed_pkgs "$1" "${2:-}"
+    }
+
+    It 'a py311->py312 flip: installs every py312-* core pkg, sheds every py311-* one'
+      # Scenario: the box was baked/left on py311 (old row); the new version
+      # flipped to py312 (new row). Given the box has the full OLD needed set
+      # installed; When planned against py311->py312; Then every NEW-flavor
+      # python package is queued to install and every OLD-flavor one to shed —
+      # the non-flavored core packages (already shared) appear in neither list.
+      flip() {
+        old_installed="$(installed_of py311)"
+        pfb_dep_plan py311 '' py312 '' "$old_installed"
+      }
+      When call flip
+      The output should include 'install py312-maxminddb'
+      The output should include 'install py312-sqlite3'
+      The output should include 'shed py311-maxminddb'
+      The output should include 'shed py311-sqlite3'
+      The output should not include 'install libmaxminddb'
+      The output should not include 'shed libmaxminddb'
+      The output should not include 'install lighttpd'
+      The output should not include 'shed lighttpd'
+    End
+
+    It 'a genuinely missing package surfaces only in the install list'
+      # Given an installed set missing py311-sqlite3 (everything else present,
+      # same row old==new); Then install lists exactly the missing package and
+      # shed is empty (nothing is stale — the row did not change).
+      missing_one() {
+        full="$(installed_of py311)"
+        partial="$(printf '%s\n' "$full" | grep -vxF 'py311-sqlite3')"
+        pfb_dep_plan py311 '' py311 '' "$partial"
+      }
+      When call missing_one
+      The output should equal 'install py311-sqlite3'
+    End
+
+    It 'a healthy (already-reconciled) set produces two empty lists'
+      # Given the installed set is EXACTLY the needed set (old==new, nothing
+      # missing, nothing stale); Then the plan is empty end to end.
+      healthy() {
+        full="$(installed_of py311)"
+        pfb_dep_plan py311 '' py311 '' "$full"
+      }
+      When call healthy
+      The output should equal ''
+    End
+
+    It 'a same-row call (unknown-new-version verify shape) never sheds'
+      # Scenario: image-upgrade.sh's "no matrix row for the new version yet"
+      # path calls pfb_dep_plan with the SAME row on both sides (verify-only).
+      # Given the box is missing one package; Then shed is empty regardless
+      # (old_needed - new_needed is empty when old==new) and install lists
+      # exactly the gap — this is the "warn + skip reconcile, still verify"
+      # semantics pinned at the pure-function level (the warn message itself
+      # and the exit-code routing in image-upgrade.sh are live-proof-only).
+      verify_only_missing() {
+        full="$(installed_of py311)"
+        partial="$(printf '%s\n' "$full" | grep -vxF 'jq')"
+        pfb_dep_plan py311 '' py311 '' "$partial"
+      }
+      When call verify_only_missing
+      The output should equal 'install jq'
+    End
+
+    It 'excludes a still-needed extra_pkgs entry from shed (same flavor, unchanged extra)'
+      # Given the box has the extra pkg installed and BOTH rows still carry it;
+      # Then it is in neither list (still needed -> never shed; already
+      # installed -> never queued to install).
+      extra_kept() {
+        old_installed="$(installed_of py311 'textproc/py-charset-normalizer')"
+        pfb_dep_plan py311 'textproc/py-charset-normalizer' \
+                     py311 'textproc/py-charset-normalizer' \
+                     "$old_installed"
+      }
+      When call extra_kept
+      The output should equal ''
+    End
+
+    It 'sheds an extra_pkgs entry the NEW row no longer carries'
+      # Given the OLD row needed the extra pkg (and it is installed) but the
+      # NEW row's extra_pkgs dropped it (e.g. upstream now covers it); Then it
+      # moves to the shed list, and nothing else changes.
+      extra_dropped() {
+        old_installed="$(installed_of py311 'textproc/py-charset-normalizer')"
+        pfb_dep_plan py311 'textproc/py-charset-normalizer' py311 '' "$old_installed"
+      }
+      When call extra_dropped
+      The output should equal 'shed py311-charset-normalizer'
+    End
+
+    It 'queues a NEWLY-added extra_pkgs entry for install, never shed'
+      # Given the OLD row carried no extra pkg (not installed) and the NEW row
+      # adds one; Then it is queued to install, and the shed list stays empty.
+      extra_added() {
+        old_installed="$(installed_of py311)"
+        pfb_dep_plan py311 '' py311 'textproc/py-charset-normalizer' "$old_installed"
+      }
+      When call extra_added
+      The output should equal 'install py311-charset-normalizer'
+    End
+  End
+End

--- a/tests/shell/dep_reconcile_spec.sh
+++ b/tests/shell/dep_reconcile_spec.sh
@@ -4,12 +4,28 @@
 #
 # Pins the pure needed-set derivation + install/shed diff that
 # scripts/image-upgrade.sh's post-upgrade phase drives: a py_flavor flip
-# (py311 -> py312) must install the new-flavor core pkgs and shed the
+# (py311 -> py312) must install the new-flavor CORE pkgs and shed the
 # old-flavor ones; a missing package surfaces in the install list; a healthy
 # (already-reconciled) set produces two empty lists; a same-row call (the
 # "no matrix row for the new version yet" shape) never sheds and only
-# reports genuinely missing packages; and a matrix row's extra_pkgs is
-# excluded from shed while still needed, included once dropped.
+# reports genuinely missing packages.
+#
+# CONTRACT (corrected — a matrix row's extra_pkgs, e.g. CE's
+# textproc/py-charset-normalizer, NEVER enter needed/install/verify: that
+# package is deliberately NOT baked into the image — the per-leg smoke
+# harness ships+installs it, and a real install resolves it from our
+# self-hosted repo as an ordinary RUN_DEPENDS. Baking/demanding it here would
+# (a) violate that dep-free-image decision and (b) fail-close every CE image
+# upgrade on a healthy, correctly dep-free image. extra_pkgs participate ONLY
+# in shed, and only for a basename NEW_EXTRA has genuinely dropped — never
+# merely because its flavor changed):
+#   (a) a CE-shaped row's extra_pkgs NEVER put that package in install (or, by
+#       construction, verify — verify walks the same core-only set as install).
+#   (b) an extra-derived stray already on the box gets shed once the NEW row's
+#       extra_pkgs drops its origin.
+#   (c) a Plus-shaped pair (extra_pkgs=[] on BOTH rows) never recognises its
+#       baked (Netgate-provided) charset-normalizer as extra-derived at all —
+#       neither installed nor shed; untouched end to end.
 #
 # RED->GREEN: before scripts/lib/dep-reconcile.sh exists, every `.` (source)
 # below fails (ENOENT) and every function call is "command not found" —
@@ -27,7 +43,8 @@ Describe 'dep-reconcile.sh'
   Describe 'pfb_dep_core_pkgs'
     It 'lists the 7 flavor-independent + 2 flavor-tracking RUN_DEPENDS packages for py311'
       # Scenario: docs/misc/pfSense_versions.md's 9-row table (minus the
-      # extra_pkgs-derived charset-normalizer, which is NOT core).
+      # extra_pkgs-derived charset-normalizer, which is NOT core). This IS the
+      # image's full needed/install/verify set — extra_pkgs never add to it.
       When call pfb_dep_core_pkgs py311
       The lines of output should equal 9
       The output should include 'libmaxminddb'
@@ -79,54 +96,30 @@ Describe 'dep-reconcile.sh'
     End
   End
 
-  Describe 'pfb_dep_extra_pkg_name'
-    It 'strips the py- PKGNAMEPREFIX and applies the target flavor'
+  Describe 'pfb_dep_extra_basename'
+    # SHED-recognition only (see file header) — never feeds needed/install/verify.
+    It 'strips the py- PKGNAMEPREFIX'
       # Scenario: the one currently-known extra_pkgs entry (CE's charset-normalizer).
-      When call pfb_dep_extra_pkg_name 'textproc/py-charset-normalizer' py311
-      The output should equal 'py311-charset-normalizer'
+      When call pfb_dep_extra_basename 'textproc/py-charset-normalizer'
+      The output should equal 'charset-normalizer'
     End
 
-    It 'applies a different flavor to the same origin'
-      When call pfb_dep_extra_pkg_name 'textproc/py-charset-normalizer' py312
-      The output should equal 'py312-charset-normalizer'
-    End
-  End
-
-  Describe 'pfb_dep_needed_pkgs'
-    It 'is exactly the core set when EXTRA_ORIGINS is empty'
-      When call pfb_dep_needed_pkgs py311 ''
-      The lines of output should equal 9
-      The output should not include 'charset-normalizer'
-    End
-
-    It 'appends the extra_pkgs-derived name when EXTRA_ORIGINS is non-empty'
-      When call pfb_dep_needed_pkgs py311 'textproc/py-charset-normalizer'
-      The lines of output should equal 10
-      The output should include 'py311-charset-normalizer'
-    End
-  End
-
-  Describe 'pfb_dep_python_modules'
-    It 'is maxminddb + sqlite3 with no extras'
-      When call pfb_dep_python_modules py311 ''
-      The lines of output should equal 2
-      The output should include 'maxminddb'
-      The output should include 'sqlite3'
-    End
-
-    It 'turns an extra package name dash into the python import underscore'
-      When call pfb_dep_python_modules py311 'textproc/py-charset-normalizer'
-      The lines of output should equal 3
-      The output should include 'charset_normalizer'
-      The output should not include 'charset-normalizer'
+    It 'passes a non-py- basename through unchanged (branch coverage)'
+      When call pfb_dep_extra_basename 'net/foo-bar'
+      The output should equal 'foo-bar'
     End
   End
 
   Describe 'pfb_dep_plan'
-    # installed_of <flavor> [extra] — the exact needed set for FLAVOR (+ optional
-    # extra origin), i.e. a box that is FULLY reconciled for that row already.
+    # installed_of FLAVOR [EXTRA_PKG_NAME] — FLAVOR's core needed set, an
+    # already-reconciled box, plus an optional literal extra-derived package
+    # name (simulating a stray/baked extra actually present on the box —
+    # never derived via the production needed-set logic, since extra_pkgs
+    # deliberately never feed that).
     installed_of() {
-      pfb_dep_needed_pkgs "$1" "${2:-}"
+      _flavor="$1"; _extra_pkg="${2:-}"
+      pfb_dep_core_pkgs "$_flavor"
+      [ -z "$_extra_pkg" ] || printf '%s\n' "$_extra_pkg"
     }
 
     It 'a py311->py312 flip: installs every py312-* core pkg, sheds every py311-* one'
@@ -191,12 +184,39 @@ Describe 'dep-reconcile.sh'
       The output should equal 'install jq'
     End
 
+    It 'CONTRACT (a): a CE-shaped extra_pkgs entry never enters install (only the per-leg harness installs it)'
+      # DISCRIMINATING RED: the pre-correction implementation put the
+      # extra_pkgs-derived name straight into the install list here (it folded
+      # extra_pkgs into the "needed" set). Given a healthy, correctly
+      # dep-free CE image (installed = core only) and a NEW row that carries
+      # extra_pkgs; Then the plan is EMPTY — nothing is installed and nothing
+      # verifies-missing for it (verify walks this same core-only set).
+      ce_extra_never_installed() {
+        core_only_installed="$(installed_of py311)"
+        pfb_dep_plan py311 '' py311 'textproc/py-charset-normalizer' "$core_only_installed"
+      }
+      When call ce_extra_never_installed
+      The output should equal ''
+    End
+
+    It 'CONTRACT (b): an extra-derived stray is shed once the NEW row drops its origin'
+      # Given the OLD row needed the extra pkg (and a stray is actually
+      # installed) but the NEW row's extra_pkgs dropped it (e.g. upstream now
+      # covers it); Then it moves to the shed list, and nothing else changes.
+      extra_dropped() {
+        old_installed="$(installed_of py311 'py311-charset-normalizer')"
+        pfb_dep_plan py311 'textproc/py-charset-normalizer' py311 '' "$old_installed"
+      }
+      When call extra_dropped
+      The output should equal 'shed py311-charset-normalizer'
+    End
+
     It 'excludes a still-needed extra_pkgs entry from shed (same flavor, unchanged extra)'
-      # Given the box has the extra pkg installed and BOTH rows still carry it;
-      # Then it is in neither list (still needed -> never shed; already
-      # installed -> never queued to install).
+      # Given a stray is installed and BOTH rows still carry its origin; Then
+      # it is in neither list (never installed — extra_pkgs never is; never
+      # shed — its basename was not dropped).
       extra_kept() {
-        old_installed="$(installed_of py311 'textproc/py-charset-normalizer')"
+        old_installed="$(installed_of py311 'py311-charset-normalizer')"
         pfb_dep_plan py311 'textproc/py-charset-normalizer' \
                      py311 'textproc/py-charset-normalizer' \
                      "$old_installed"
@@ -205,27 +225,30 @@ Describe 'dep-reconcile.sh'
       The output should equal ''
     End
 
-    It 'sheds an extra_pkgs entry the NEW row no longer carries'
-      # Given the OLD row needed the extra pkg (and it is installed) but the
-      # NEW row's extra_pkgs dropped it (e.g. upstream now covers it); Then it
-      # moves to the shed list, and nothing else changes.
-      extra_dropped() {
-        old_installed="$(installed_of py311 'textproc/py-charset-normalizer')"
-        pfb_dep_plan py311 'textproc/py-charset-normalizer' py311 '' "$old_installed"
+    It 'CONTRACT (c): a Plus-shaped pair (extra_pkgs=[] both sides) leaves its baked charset-normalizer untouched'
+      # Scenario: Plus's own pfSense repo already carries charset-normalizer
+      # (Netgate-provided, a real RUN_DEPENDS resolution) — the matrix's
+      # extra_pkgs is [] on BOTH rows (docs/misc/pfSense_versions.md). Given
+      # it is installed; Then it is recognised as neither core nor
+      # extra-derived (no basename in either row's extra_pkgs to match) —
+      # neither installed (redundant — already there) nor shed.
+      plus_baked_charset_untouched() {
+        installed="$(installed_of py311 'py311-charset-normalizer')"
+        pfb_dep_plan py311 '' py311 '' "$installed"
       }
-      When call extra_dropped
-      The output should equal 'shed py311-charset-normalizer'
+      When call plus_baked_charset_untouched
+      The output should equal ''
     End
 
-    It 'queues a NEWLY-added extra_pkgs entry for install, never shed'
+    It 'a newly-added extra_pkgs entry is untouched (never installed — the per-leg harness handles it)'
       # Given the OLD row carried no extra pkg (not installed) and the NEW row
-      # adds one; Then it is queued to install, and the shed list stays empty.
+      # adds one; Then the plan is EMPTY — extra_pkgs never enters install.
       extra_added() {
         old_installed="$(installed_of py311)"
         pfb_dep_plan py311 '' py311 'textproc/py-charset-normalizer' "$old_installed"
       }
       When call extra_added
-      The output should equal 'install py311-charset-normalizer'
+      The output should equal ''
     End
   End
 End

--- a/tests/shell/dep_reconcile_spec.sh
+++ b/tests/shell/dep_reconcile_spec.sh
@@ -240,6 +240,27 @@ Describe 'dep-reconcile.sh'
       The output should equal ''
     End
 
+    It 'CR-3: a dropped extra_pkgs basename never sheds a same-named CORE package (net/py-maxminddb collision)'
+      # DISCRIMINATING RED: the extra-derived shed loop matched by BASENAME
+      # alone (py[0-9][0-9]*-<basename> against $_planp_installed), with no
+      # check against the NEW core needed set -- a dropped extra_pkgs origin
+      # whose basename collides with a CORE package (net/py-maxminddb's
+      # basename "maxminddb" collides with the CORE py<flavor>-maxminddb
+      # dependency every row needs) would shed the STILL-NEEDED core pkg.
+      # Given the OLD row carried net/py-maxminddb as an extra_pkgs entry and
+      # the box has the full core set installed (incl. py311-maxminddb, which
+      # is core-needed regardless), but the NEW row (same flavor) dropped that
+      # extra origin; Then py311-maxminddb must NOT be shed -- the plan is
+      # empty (nothing to install, already-core-satisfied; nothing genuinely
+      # stale to shed).
+      core_collision() {
+          old_installed="$(installed_of py311)"
+          pfb_dep_plan py311 'net/py-maxminddb' py311 '' "$old_installed"
+      }
+      When call core_collision
+      The output should equal ''
+    End
+
     It 'a newly-added extra_pkgs entry is untouched (never installed — the per-leg harness handles it)'
       # Given the OLD row carried no extra pkg (not installed) and the NEW row
       # adds one; Then the plan is EMPTY — extra_pkgs never enters install.

--- a/tests/shell/generate_hook_spec.sh
+++ b/tests/shell/generate_hook_spec.sh
@@ -1,9 +1,12 @@
 #shellcheck shell=sh
-# pfblockerng_repo_generate.sh — boot-time repo-conf regenerator (ADR-39).
+# pfblockerng_repo_generate.sh — boot-time repo-conf regenerator (ADR-39;
+# arch-less/NO_ARCH since issue #1806).
 #
 # The hook is a pure REGENERATOR: for each of our conf files that EXISTS, it
-# detects the box's <varver>/<arch> and unconditionally overwrites the conf with
-# the canonical body. No pkg call, no network, no snapshot, no reconcile.
+# detects the box's <varver> and unconditionally overwrites the conf with the
+# canonical body. No pkg call at all (issue #1806 retired the `pkg config abi`
+# read — arch-less catalogs have no per-arch leaf left to detect), no network,
+# no snapshot, no reconcile.
 #
 # Behavioural contracts pinned here:
 #   orphan      — neither conf present → nothing written, pkg never invoked, exit 0.
@@ -12,11 +15,13 @@
 #   unconditional — a STALE-varver conf is rewritten to the box's current varver
 #                 (before: stale present; after: stale gone, current present).
 #   detection   — edition = "/etc/product_label contains 'Plus'": Plus vs CE; the
-#                 varver prefix and the catalog path follow.
-#   no-network  — the hook calls `pkg config abi` for arch ONLY; it NEVER runs
-#                 pkg update/install/upgrade (no reconcile, no fetch).
-#   fail-proof  — detection failure (empty version / broken pkg) leaves the conf
-#                 UNCHANGED, warns on stderr, and still exits 0 (never wedge boot).
+#                 varver prefix and the catalog path follow. Version-only —
+#                 arch-less (issue #1806): the hook never calls `pkg` at all.
+#   no-pkg      — the hook NEVER invokes `pkg`, under any invocation mechanism
+#                 (bare PATH lookup or PFB_PKG_BIN) — no arch detection to read,
+#                 no reconcile, no fetch.
+#   fail-proof  — detection failure (empty version) leaves the conf UNCHANGED,
+#                 warns on stderr, and still exits 0 (never wedge boot).
 #
 # Before-and-after mandate (CLAUDE.md): the regenerate/unconditional/fail-proof
 # examples assert the before-state before the after-state, so green proves the
@@ -33,48 +38,47 @@ HOOK="${PFB_ROOT}/scripts/rc.d/pfblockerng_repo_generate.sh"
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
-# Write a pkg stub at $1 whose `config abi` prints $2 (e.g. "FreeBSD:15:amd64").
-# Every invocation is logged to PKG_STUB_LOG so a test can assert which
-# subcommands ran (the hook must touch ONLY `config abi`).
-# Pass abi="" to simulate a broken pkg (config abi prints nothing → arch empty).
+# Write a pkg stub at $1 that LOGS every invocation to PKG_STUB_LOG — a pure
+# regression guard (issue #1806: the hook never calls `pkg` for anything; a
+# stub that would log a call, combined with asserting the log never appears,
+# catches a regression that reintroduces one).
 _make_pkg_stub() {
     _mps_path="$1"
-    _mps_abi="$2"
     cat > "${_mps_path}" <<EOF
 #!/bin/sh
 printf 'pkg %s\n' "\$*" >> "\${PKG_STUB_LOG:-/dev/null}"
-case "\$*" in
-    'config abi') printf '%s' '${_mps_abi}' ;;
-esac
 exit 0
 EOF
     chmod +x "${_mps_path}"
-    unset _mps_path _mps_abi
+    unset _mps_path
 }
 
-# Stand up a stubbed box in dir $1: product_label=$2, version=$3, abi=$4.
-# Exports every PFB_* override the hook reads. Conf files are NOT created here —
-# each example stages the conf(s) it wants the hook to (not) regenerate.
+# Stand up a stubbed box in dir $1: product_label=$2, version=$3.
+# Exports every PFB_* override the hook reads. A logging `pkg` stub is placed
+# BOTH on PATH and it would be picked up if anything ever read PFB_PKG_BIN
+# again — pure regression guard, the hook calls neither (issue #1806). Conf
+# files are NOT created here — each example stages the conf(s) it wants the
+# hook to (not) regenerate.
 _make_box() {
     _mb_dir="$1"
-    mkdir -p "${_mb_dir}/repos"
+    mkdir -p "${_mb_dir}/repos" "${_mb_dir}/bin"
     printf '%s\n' "$2" > "${_mb_dir}/product_label"
     printf '%s\n' "$3" > "${_mb_dir}/version"
-    _make_pkg_stub "${_mb_dir}/pkg" "$4"
+    _make_pkg_stub "${_mb_dir}/bin/pkg"
 
     PFB_RELEASE_CONF="${_mb_dir}/repos/pfblockerng.conf"
     PFB_NIGHTLY_CONF="${_mb_dir}/repos/pfblockerng-nightly.conf"
     PFB_PRODUCT_LABEL="${_mb_dir}/product_label"
     PFB_VERSION_FILE="${_mb_dir}/version"
-    PFB_PKG_BIN="${_mb_dir}/pkg"
     PKG_STUB_LOG="${_mb_dir}/pkg_calls.log"
+    PATH="${_mb_dir}/bin:${PATH}"
     export PFB_RELEASE_CONF PFB_NIGHTLY_CONF PFB_PRODUCT_LABEL PFB_VERSION_FILE \
-           PFB_PKG_BIN PKG_STUB_LOG
+           PKG_STUB_LOG PATH
 }
 
 _unset_box() {
     unset PFB_RELEASE_CONF PFB_NIGHTLY_CONF PFB_PRODUCT_LABEL PFB_VERSION_FILE \
-          PFB_PKG_BIN PKG_STUB_LOG
+          PKG_STUB_LOG
 }
 
 # ── ORPHAN: neither conf present → nothing written, pkg never invoked ──────────
@@ -82,7 +86,7 @@ _unset_box() {
 Describe 'generate hook — orphan: no conf present'
     setup() {
         _o_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_orphan.XXXXXX")"
-        _make_box "${_o_dir}" "pfSense" "2.8.1" "FreeBSD:15:amd64"
+        _make_box "${_o_dir}" "pfSense" "2.8.1"
     }
     cleanup() { rm -rf "${_o_dir}"; _unset_box; }
     Before 'setup'
@@ -98,17 +102,18 @@ Describe 'generate hook — orphan: no conf present'
       The status should be success
       The path "${PFB_RELEASE_CONF}" should not be exist
       The path "${PFB_NIGHTLY_CONF}" should not be exist
-      # The orphan guard returns before detection, so pkg is never even called.
+      # The orphan guard returns before detection, and detection itself never
+      # touches pkg (arch-less; issue #1806).
       The path "${PKG_STUB_LOG}" should not be exist
     End
 End
 
-# ── REGENERATE release (CE 2.8.1/amd64) ───────────────────────────────────────
+# ── REGENERATE release (CE 2.8.1) ─────────────────────────────────────────────
 
 Describe 'generate hook — regenerate release conf (CE)'
     setup() {
         _r_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_rel.XXXXXX")"
-        _make_box "${_r_dir}" "pfSense" "2.8.1" "FreeBSD:15:amd64"
+        _make_box "${_r_dir}" "pfSense" "2.8.1"
         printf '# stub pending\n' > "${PFB_RELEASE_CONF}"
     }
     cleanup() { rm -rf "${_r_dir}"; _unset_box; }
@@ -124,7 +129,7 @@ Describe 'generate hook — regenerate release conf (CE)'
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PFB_RELEASE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/release/ce-2.8/amd64"'
+      The contents of file "${PFB_RELEASE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/release/ce-2.8"'
       The contents of file "${PFB_RELEASE_CONF}" should include "Generated at boot by pfblockerng_repo_generate"
       The contents of file "${PFB_RELEASE_CONF}" should include "pfblockerng: {"
       # The stub line is gone (full overwrite, not a patch).
@@ -133,23 +138,20 @@ Describe 'generate hook — regenerate release conf (CE)'
       The path "${PFB_NIGHTLY_CONF}" should not be exist
     End
 
-    It 'calls pkg config abi for arch but NEVER pkg update/install/upgrade'
+    It 'never invokes pkg at all (arch-less; issue #1806)'
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PKG_STUB_LOG}" should include "pkg config abi"
-      The contents of file "${PKG_STUB_LOG}" should not include "pkg update"
-      The contents of file "${PKG_STUB_LOG}" should not include "pkg install"
-      The contents of file "${PKG_STUB_LOG}" should not include "pkg upgrade"
+      The path "${PKG_STUB_LOG}" should not be exist
     End
 End
 
-# ── REGENERATE nightly (Plus 26.03.1/aarch64) — detection: Plus + channel keying ─
+# ── REGENERATE nightly (Plus 26.03.1) — detection: Plus + channel keying ──────
 
 Describe 'generate hook — regenerate nightly conf (Plus)'
     setup() {
         _n_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_nightly.XXXXXX")"
-        _make_box "${_n_dir}" "pfSense Plus" "26.03.1" "FreeBSD:15:aarch64"
+        _make_box "${_n_dir}" "pfSense Plus" "26.03.1"
         printf '# stub pending\n' > "${PFB_NIGHTLY_CONF}"
     }
     cleanup() { rm -rf "${_n_dir}"; _unset_box; }
@@ -165,7 +167,7 @@ Describe 'generate hook — regenerate nightly conf (Plus)'
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PFB_NIGHTLY_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/nightly/plus-26.03/aarch64"'
+      The contents of file "${PFB_NIGHTLY_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/nightly/plus-26.03"'
       The contents of file "${PFB_NIGHTLY_CONF}" should include "pfblockerng-nightly: {"
       The contents of file "${PFB_NIGHTLY_CONF}" should include "nightly channel"
       The path "${PFB_RELEASE_CONF}" should not be exist
@@ -177,12 +179,12 @@ End
 Describe 'generate hook — unconditional rewrite of a stale-varver conf'
     setup() {
         _s_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_stale.XXXXXX")"
-        _make_box "${_s_dir}" "pfSense" "2.8.1" "FreeBSD:15:amd64"
+        _make_box "${_s_dir}" "pfSense" "2.8.1"
         # Seed a conf carrying a STALE varver (as if from before an OS upgrade).
         cat > "${PFB_RELEASE_CONF}" <<'EOF'
 # old generated body
 pfblockerng: {
-  url: "https://pfblockerng.github.io/pkg/release/ce-2.7/amd64",
+  url: "https://pfblockerng.github.io/pkg/release/ce-2.7",
   enabled: yes
 }
 EOF
@@ -192,28 +194,30 @@ EOF
     After  'cleanup'
 
     It 'before-state: conf carries the stale ce-2.7 varver, not the current ce-2.8'
-      The contents of file "${PFB_RELEASE_CONF}" should include "ce-2.7/amd64"
-      The contents of file "${PFB_RELEASE_CONF}" should not include "ce-2.8/amd64"
+      The contents of file "${PFB_RELEASE_CONF}" should include "ce-2.7"
+      The contents of file "${PFB_RELEASE_CONF}" should not include "ce-2.8"
     End
 
     It 'rewrites the conf to the current ce-2.8 varver (stale gone), exit 0'
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PFB_RELEASE_CONF}" should include "ce-2.8/amd64"
-      The contents of file "${PFB_RELEASE_CONF}" should not include "ce-2.7/amd64"
+      The contents of file "${PFB_RELEASE_CONF}" should include "ce-2.8"
+      The contents of file "${PFB_RELEASE_CONF}" should not include "ce-2.7"
       # No pkg reconcile on an upgrade-driven varver change.
-      The contents of file "${PKG_STUB_LOG}" should not include "pkg update"
+      The path "${PKG_STUB_LOG}" should not be exist
     End
 End
 
 # ── FAIL-PROOF: detection failure leaves the conf unchanged, still exit 0 ──────
 
 Describe 'generate hook — fail-proof: detection failure leaves conf unchanged'
-    # Case A: empty /etc/version → varver unresolvable.
+    # Empty /etc/version → varver unresolvable. Arch-less (issue #1806) means
+    # there is no second, pkg-dependent detection failure mode any more (the
+    # old "broken pkg config abi" case was retired along with the arch read).
     setup_ev() {
         _ev_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_emptyver.XXXXXX")"
-        _make_box "${_ev_dir}" "pfSense" "" "FreeBSD:15:amd64"
+        _make_box "${_ev_dir}" "pfSense" ""
         printf '# UNCHANGED-STUB\n' > "${PFB_RELEASE_CONF}"
     }
     cleanup_ev() { rm -rf "${_ev_dir}"; _unset_box; }
@@ -225,26 +229,6 @@ Describe 'generate hook — fail-proof: detection failure leaves conf unchanged'
         It 'before-state: conf is the unchanged stub'
           The contents of file "${PFB_RELEASE_CONF}" should include "UNCHANGED-STUB"
         End
-
-        It 'leaves the conf byte-unchanged, warns, and exits 0'
-          When run sh "${HOOK}" onestart
-          The status should be success
-          The stderr should include "WARNING"
-          The contents of file "${PFB_RELEASE_CONF}" should include "UNCHANGED-STUB"
-        End
-    End
-
-    # Case B: broken pkg (config abi prints nothing) → arch unresolvable.
-    setup_ba() {
-        _ba_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_badabi.XXXXXX")"
-        _make_box "${_ba_dir}" "pfSense" "2.8.1" ""
-        printf '# UNCHANGED-STUB\n' > "${PFB_RELEASE_CONF}"
-    }
-    cleanup_ba() { rm -rf "${_ba_dir}"; _unset_box; }
-
-    Describe 'broken pkg config abi'
-        Before 'setup_ba'
-        After  'cleanup_ba'
 
         It 'leaves the conf byte-unchanged, warns, and exits 0'
           When run sh "${HOOK}" onestart

--- a/tests/shell/generate_hook_spec.sh
+++ b/tests/shell/generate_hook_spec.sh
@@ -17,9 +17,11 @@
 #   detection   — edition = "/etc/product_label contains 'Plus'": Plus vs CE; the
 #                 varver prefix and the catalog path follow. Version-only —
 #                 arch-less (issue #1806): the hook never calls `pkg` at all.
-#   no-pkg      — the hook NEVER invokes `pkg`, under any invocation mechanism
-#                 (bare PATH lookup or PFB_PKG_BIN) — no arch detection to read,
-#                 no reconcile, no fetch.
+#   no-pkg      — the hook NEVER invokes `pkg` at all (it has no configurable
+#                 pkg-binary override, unlike e.g. build-repo.sh's PKG_BIN) —
+#                 no arch detection to read, no reconcile, no fetch. The stub
+#                 below only intercepts a BARE PATH `pkg` lookup, which is the
+#                 only mechanism there is to catch.
 #   fail-proof  — detection failure (empty version) leaves the conf UNCHANGED,
 #                 warns on stderr, and still exits 0 (never wedge boot).
 #
@@ -55,10 +57,10 @@ EOF
 
 # Stand up a stubbed box in dir $1: product_label=$2, version=$3.
 # Exports every PFB_* override the hook reads. A logging `pkg` stub is placed
-# BOTH on PATH and it would be picked up if anything ever read PFB_PKG_BIN
-# again — pure regression guard, the hook calls neither (issue #1806). Conf
-# files are NOT created here — each example stages the conf(s) it wants the
-# hook to (not) regenerate.
+# on PATH so a BARE `pkg` invocation is caught — the hook has no PFB_PKG_BIN-
+# style override to intercept separately, and calls it under no mechanism at
+# all (issue #1806) — pure regression guard. Conf files are NOT created here —
+# each example stages the conf(s) it wants the hook to (not) regenerate.
 _make_box() {
     _mb_dir="$1"
     mkdir -p "${_mb_dir}/repos" "${_mb_dir}/bin"

--- a/tests/shell/install_pkg_spec.sh
+++ b/tests/shell/install_pkg_spec.sh
@@ -1,0 +1,118 @@
+#shellcheck shell=sh
+# install_pkg_spec.sh — shellspec suite for scripts/install-pkg.sh
+#
+# Net-new (nothing covered install-pkg.sh before issue #1806). Pins:
+#   (a) SMOKE_DEP_PKGS unset -> single scp+pkg add (current behaviour, regression pin).
+#   (b) two dep paths set -> deps scp'd + pkg add'd BEFORE the branch pkg, in order.
+#   (c) a dep pkg-add failure -> nonzero exit, branch pkg never installed (not even copied).
+#
+# Hermetic: stubs ssh + scp via a PATH-prepended fake bin dir (same pattern as
+# run_smoke_spec.sh's fake python). The ssh stub answers the unbound-control
+# readiness poll immediately (exit 0) so the script never enters the sleep loop,
+# and fails any `pkg add` whose wrapped remote command matches $FAIL_PKG_ADD_MATCH
+# (unset -> never matches, i.e. every pkg add succeeds). The scp stub just logs
+# its source file. Both stubs record the FULL invocation so ORDER is assertable.
+
+Describe 'install-pkg.sh'
+  SCRIPT="${PFB_ROOT}/scripts/install-pkg.sh"
+
+  setup() {
+    scrub_git_env
+    unset SMOKE_DEP_PKGS FAIL_PKG_ADD_MATCH
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/instpkgspec.XXXXXX")"
+    FAKE_BIN="${WORK}/bin"
+    mkdir -p "$FAKE_BIN"
+    SSH_LOG="${WORK}/ssh.log"
+    SCP_LOG="${WORK}/scp.log"
+    : > "$SSH_LOG"
+    : > "$SCP_LOG"
+
+    PKGFILE="${WORK}/pfBlockerNG-devel.pkg"
+    DEP1="${WORK}/py311-charset-normalizer-1.pkg"
+    DEP2="${WORK}/py311-idna-2.pkg"
+    : > "$PKGFILE"
+    : > "$DEP1"
+    : > "$DEP2"
+
+    # Fake ssh: records the LAST arg (the wrapped `/bin/sh -c '<remote cmd>'`
+    # string install-pkg.sh's ssh_t() builds) to $SSH_LOG, one per line.
+    # unbound-control status -> always "ready" (exit 0), so the readiness loop
+    # never sleeps. A pkg-add line matching $FAIL_PKG_ADD_MATCH -> exit 1.
+    cat > "${FAKE_BIN}/ssh" << 'SSHEOF'
+#!/bin/sh
+for _a in "$@"; do :; done
+printf '%s\n' "$_a" >> "$SSH_LOG"
+case "$_a" in
+    *unbound-control*) exit 0 ;;
+esac
+case "$_a" in
+    *"${FAIL_PKG_ADD_MATCH:-__pfb_never_match__}"*) exit 1 ;;
+esac
+exit 0
+SSHEOF
+    chmod +x "${FAKE_BIN}/ssh"
+
+    # Fake scp: records its SRC (second-to-last positional arg; last is
+    # "$SSH_TARGET:$REMOTE") to $SCP_LOG, one per line.
+    cat > "${FAKE_BIN}/scp" << 'SCPEOF'
+#!/bin/sh
+_src=""
+_prev=""
+for _a in "$@"; do
+    _src="$_prev"
+    _prev="$_a"
+done
+printf '%s\n' "$_src" >> "$SCP_LOG"
+exit 0
+SCPEOF
+    chmod +x "${FAKE_BIN}/scp"
+
+    PATH="${FAKE_BIN}:${PATH}"
+    export PATH WORK FAKE_BIN SSH_LOG SCP_LOG PKGFILE DEP1 DEP2
+  }
+
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # Count lines in $SSH_LOG whose wrapped remote command contains `pkg add`.
+  pkg_add_count() { grep -c 'pkg add' "$SSH_LOG"; }
+
+  It 'SMOKE_DEP_PKGS unset -> exactly one scp + one pkg add (regression pin)'
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be success
+    The contents of file "$SCP_LOG" should equal "$PKGFILE"
+    The result of function pkg_add_count should equal 1
+    The contents of file "$SSH_LOG" should include "$(basename "$PKGFILE")"
+  End
+
+  It 'two SMOKE_DEP_PKGS entries: deps scp'"'"'d + pkg add'"'"'d before the branch pkg, in order'
+    SMOKE_DEP_PKGS="${DEP1} ${DEP2}"
+    export SMOKE_DEP_PKGS
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be success
+    # scp order: dep1, dep2, branch pkg -- exactly 3 copies, that order.
+    The line 1 of contents of file "$SCP_LOG" should equal "$DEP1"
+    The line 2 of contents of file "$SCP_LOG" should equal "$DEP2"
+    The line 3 of contents of file "$SCP_LOG" should equal "$PKGFILE"
+    The result of function pkg_add_count should equal 3
+    # pkg-add order in the raw ssh log mirrors the scp order (dep1, dep2, branch);
+    # the only other ssh_t call (unbound-control) always comes after all three.
+    The line 1 of contents of file "$SSH_LOG" should include "$(basename "$DEP1")"
+    The line 2 of contents of file "$SSH_LOG" should include "$(basename "$DEP2")"
+    The line 3 of contents of file "$SSH_LOG" should include "$(basename "$PKGFILE")"
+  End
+
+  It 'a dep pkg-add failure aborts before the branch pkg is even copied'
+    SMOKE_DEP_PKGS="${DEP1} ${DEP2}"
+    FAIL_PKG_ADD_MATCH="$(basename "$DEP1")"
+    export SMOKE_DEP_PKGS FAIL_PKG_ADD_MATCH
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be failure
+    # dep1 was copied (its pkg add is what fails); dep2 and the branch pkg never are.
+    The contents of file "$SCP_LOG" should include "$DEP1"
+    The contents of file "$SCP_LOG" should not include "$DEP2"
+    The contents of file "$SCP_LOG" should not include "$PKGFILE"
+    The result of function pkg_add_count should equal 1
+  End
+End

--- a/tests/smoke/_matrix.py
+++ b/tests/smoke/_matrix.py
@@ -5,8 +5,10 @@ literal. The whole BUILD matrix is read from ``SMOKE_MATRIX_JSON`` (injected by 
 ``read-version-matrix.sh --print-build``); a local run falls back to running that script itself;
 when neither is available the variant-topology cases SKIP. Per-leg selection still honours
 ``SMOKE_ABI`` / ``SMOKE_PHP_VERSION`` / ``SMOKE_PY_FLAVOR`` (the fan-out exports them per matrix
-entry); a bare dispatch defaults to the matrix's CE entry. So adding a pfSense version to the
-matrix needs no edit here.
+entry) plus ``SMOKE_IMAGE_REF`` (issue #1806: disambiguates two editions sharing a freebsd_major,
+now that the matrix carries no ``arch`` column) — SMOKE_ABI itself stays a CONCRETE guest ABI env
+var; a bare dispatch defaults to the matrix's CE entry. So adding a pfSense version to the matrix
+needs no edit here.
 
 Kept in its own stdlib-only module (no intra-package smoke imports) so the derivation is
 unit-testable off-box — see ``tests/test_smoke_matrix.py``.
@@ -93,8 +95,10 @@ def matrix_variants() -> list[Variant]:
     out: dict[tuple[str, str], Variant] = {}
     for e in entries:
         major = str(e.get("freebsd_major", "")).strip()
-        arch = str(e.get("arch", "")).strip() or "amd64"
-        abi = f"FreeBSD:{major}:{arch}"
+        # issue #1806: the matrix carries no `arch` field at all any more (every
+        # pfSense-pkg-pfBlockerNG port is NO_ARCH, the catalog is arch-less) —
+        # "amd64" here is an inert CPU placeholder, never read from the entry.
+        abi = f"FreeBSD:{major}:amd64"
         variant = str(e.get("variant", "")).strip()
         out.setdefault(
             (abi, variant),
@@ -110,7 +114,16 @@ def matrix_variants() -> list[Variant]:
 
 
 def _own_entry() -> Variant:
-    """This leg's variant: matched by SMOKE_ABI, else the matrix CE entry (bare dispatch)."""
+    """This leg's variant: matched by SMOKE_ABI, else the matrix CE entry (bare dispatch).
+
+    issue #1806: with `arch` retired, two editions CAN share a freebsd_major (not just an
+    ADR-24 transition-window hypothetical) — SMOKE_ABI alone (a CONCRETE guest ABI env var;
+    that contract is unchanged) then matches more than one Variant. Disambiguate via
+    SMOKE_IMAGE_REF (already exported by smoke-single.yml as the resolved GHCR ref, e.g.
+    ".../pfsense-plus:15.1.0") by checking which candidate's "pfsense-<variant>" image name
+    it names; refuse (loudly) rather than silently pick matches[0] when it doesn't resolve to
+    exactly one — a gate-A-era hazard this closes.
+    """
     variants = matrix_variants()
     abi = os.environ.get("SMOKE_ABI")
     if not abi:
@@ -119,7 +132,17 @@ def _own_entry() -> Variant:
     matches = [v for v in variants if v.abi == abi]
     if not matches:
         raise RuntimeError(f"no matrix variant for ABI {abi!r} (known: {sorted(v.abi for v in variants)})")
-    return matches[0]
+    if len(matches) == 1:
+        return matches[0]
+    image_ref = os.environ.get("SMOKE_IMAGE_REF", "")
+    disambiguated = [v for v in matches if f"pfsense-{v.variant.lower()}" in image_ref]
+    if len(disambiguated) == 1:
+        return disambiguated[0]
+    raise RuntimeError(
+        f"ABI {abi!r} matches {len(matches)} variants ({[v.variant for v in matches]!r}) and "
+        f"SMOKE_IMAGE_REF={image_ref!r} does not disambiguate to exactly one — refusing to "
+        f"silently pick one (set SMOKE_IMAGE_REF to the resolved image ref)"
+    )
 
 
 def matrix_php_dep() -> str:

--- a/tests/smoke/_matrix.py
+++ b/tests/smoke/_matrix.py
@@ -1,14 +1,16 @@
 """Per-leg variant topology for the ADR-20 repo smoke — DERIVED FROM THE VERSION MATRIX.
 
 Every ABI / PHP / Python / catalog fact comes from the ci-metadata version matrix, never a
-literal. The whole BUILD matrix is read from ``SMOKE_MATRIX_JSON`` (injected by smoke-single.yml from
-``read-version-matrix.sh --print-build``); a local run falls back to running that script itself;
-when neither is available the variant-topology cases SKIP. Per-leg selection still honours
-``SMOKE_ABI`` / ``SMOKE_PHP_VERSION`` / ``SMOKE_PY_FLAVOR`` (the fan-out exports them per matrix
-entry) plus ``SMOKE_IMAGE_REF`` (issue #1806: disambiguates two editions sharing a freebsd_major,
-now that the matrix carries no ``arch`` column) — SMOKE_ABI itself stays a CONCRETE guest ABI env
-var; a bare dispatch defaults to the matrix's CE entry. So adding a pfSense version to the matrix
-needs no edit here.
+literal. The whole CI matrix (ONE ROW PER VERSION, never deduped by freebsd_major) is read from
+``SMOKE_MATRIX_JSON`` (injected by smoke-single.yml from ``read-version-matrix.sh --print-ci`` —
+issue #1806 W3: --print-build dedupes to one row per major, which would hide a second edition
+sharing a major from matrix_variants() entirely and make the SMOKE_IMAGE_REF disambiguation below
+unreachable); a local run falls back to running that script itself; when neither is available the
+variant-topology cases SKIP. Per-leg selection still honours ``SMOKE_ABI`` / ``SMOKE_PHP_VERSION``
+/ ``SMOKE_PY_FLAVOR`` (the fan-out exports them per matrix entry) plus ``SMOKE_IMAGE_REF``
+(issue #1806: disambiguates two editions sharing a freebsd_major, now that the matrix carries no
+``arch`` column) — SMOKE_ABI itself stays a CONCRETE guest ABI env var; a bare dispatch defaults to
+the matrix's CE entry. So adding a pfSense version to the matrix needs no edit here.
 
 Kept in its own stdlib-only module (no intra-package smoke imports) so the derivation is
 unit-testable off-box — see ``tests/test_smoke_matrix.py``.
@@ -52,18 +54,21 @@ def catalog_name(pfsense_version: str, variant: str) -> str:
 
 @functools.lru_cache(maxsize=1)
 def build_matrix() -> tuple[dict, ...] | None:
-    """The whole BUILD matrix (every CE+Plus entry), or None when unavailable.
+    """The whole CI matrix (every CE+Plus ci:true entry, one row per version), or None when
+    unavailable.
 
-    Prefers ``SMOKE_MATRIX_JSON`` (smoke-single.yml injects ``read-version-matrix.sh --print-build``);
-    falls back to running that script on the runner; None when neither yields a non-empty JSON
-    array (the caller then SKIPs the topology cases)."""
+    Prefers ``SMOKE_MATRIX_JSON`` (smoke-single.yml injects ``read-version-matrix.sh --print-ci``
+    — issue #1806 W3, never ``--print-build``: that dedupes by freebsd_major, which would hide a
+    same-major second edition from this topology entirely); falls back to running that script on
+    the runner; None when neither yields a non-empty JSON array (the caller then SKIPs the
+    topology cases)."""
     raw = os.environ.get("SMOKE_MATRIX_JSON", "").strip()
     if not raw:
         script = _REPO_ROOT / "scripts" / "read-version-matrix.sh"
         if script.is_file():
             try:
                 proc = subprocess.run(
-                    ["sh", str(script), "--print-build"],
+                    ["sh", str(script), "--print-ci"],
                     capture_output=True,
                     text=True,
                     timeout=30.0,

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -193,6 +193,39 @@ def _ensure_egress_open() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# issue #1806 D3 — SMOKE_DEP_PKGS (extra dep .pkgs shipped alongside the branch
+# build; folded into the catalog(s) below so `pkg install` resolves RUN_DEPENDS
+# pfSense's own repo doesn't carry, e.g. textproc/py-charset-normalizer for CE)
+# --------------------------------------------------------------------------- #
+
+
+def _smoke_dep_pkg_paths() -> list[Path]:
+    """Extra dep ``.pkg`` paths for THIS leg (``SMOKE_DEP_PKGS`` — space-separated
+    absolute paths, set by smoke-single.yml/smoke-on-box.sh when the leg's
+    ``extra_pkgs`` is non-empty). Folded into the catalog(s) built from the REAL
+    branch ``.pkg`` so `pkg install` resolves RUN_DEPENDS pfSense's own repo
+    doesn't carry FROM OUR CATALOG — the true user-facing install path. Unset or
+    empty -> ``[]`` (deps assumed baked into the image, or this leg carries none;
+    never a hard requirement)."""
+    return [Path(p) for p in os.environ.get("SMOKE_DEP_PKGS", "").split() if p]
+
+
+def test_smoke_dep_pkg_paths_parses_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hermetic (no VM): ``_smoke_dep_pkg_paths()`` parses ``SMOKE_DEP_PKGS``.
+
+    Unset/empty -> []. A space-separated list -> one ``Path`` per entry, in order.
+    """
+    monkeypatch.delenv("SMOKE_DEP_PKGS", raising=False)
+    assert _smoke_dep_pkg_paths() == []
+
+    monkeypatch.setenv("SMOKE_DEP_PKGS", "")
+    assert _smoke_dep_pkg_paths() == []
+
+    monkeypatch.setenv("SMOKE_DEP_PKGS", "/tmp/a.pkg /tmp/b.pkg")
+    assert _smoke_dep_pkg_paths() == [Path("/tmp/a.pkg"), Path("/tmp/b.pkg")]
+
+
+# --------------------------------------------------------------------------- #
 # On-guest catalog build + repo conf + pkg ops (over SSH)
 # --------------------------------------------------------------------------- #
 
@@ -738,8 +771,9 @@ def repo_vm(smoke_vm: SmokeVM) -> Iterator[SmokeVM]:
     # Build BOTH catalogs from the same branch .pkg: ours and a controlled decoy that
     # serves the identical package, so the precedence cases compare two genuine
     # providers and the winner is decided purely by `priority:`.
-    build_guest_repo(smoke_vm, OURS_REPO_DIR, [src])
-    build_guest_repo(smoke_vm, DECOY_REPO_DIR, [src])
+    dep_pkgs = _smoke_dep_pkg_paths()
+    build_guest_repo(smoke_vm, OURS_REPO_DIR, [src, *dep_pkgs])
+    build_guest_repo(smoke_vm, DECOY_REPO_DIR, [src, *dep_pkgs])
     try:
         yield smoke_vm
     finally:
@@ -831,8 +865,9 @@ def test_pkg_upgrade_moves_to_our_newer_build(repo_vm: SmokeVM, tmp_path: Path) 
     try:
         # GIVEN: a clean before-state — package absent; our repo carries ONLY the
         # LOWER build, enabled ABOVE the Netgate `pfSense` repo.
+        dep_pkgs = _smoke_dep_pkg_paths()
         pkg_delete(repo_vm)
-        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [low_pkg])
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [low_pkg, *dep_pkgs])
         write_repo_conf(repo_vm, UPGRADE_REPO_DIR, ours_priority=pfsense_prio + 100)
         pkg_update(repo_vm)
         assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the upgrade test"
@@ -849,7 +884,7 @@ def test_pkg_upgrade_moves_to_our_newer_build(repo_vm: SmokeVM, tmp_path: Path) 
         )
 
         # WHEN (2): publish the HIGHER build into the SAME repo dir, re-read it, upgrade.
-        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [high_pkg])
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [high_pkg, *dep_pkgs])
         pkg_update(repo_vm)
         proc = pkg_upgrade(repo_vm)
 
@@ -968,7 +1003,7 @@ def test_build_repo_script_catalog_is_accepted(repo_vm: SmokeVM) -> None:
 
     # GIVEN: build the catalog with the Phase-2 SCRIPT (not the inline pkg repo), then
     # point a NONE-signed file:// repo at the produced <ABI>/ dir, above pfSense.
-    abi_dir = build_repo_via_script(repo_vm, [Path(pkg)])
+    abi_dir = build_repo_via_script(repo_vm, [Path(pkg), *_smoke_dep_pkg_paths()])
     pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
     pkg_delete(repo_vm)
     write_repo_conf(repo_vm, abi_dir, ours_priority=pfsense_prio + 100)
@@ -1018,7 +1053,7 @@ def test_shipped_add_repo_sh_bootstrap_installs(repo_vm: SmokeVM, tmp_path: Path
     real_varver, real_arch = _box_real_catalog(repo_vm).rsplit("/", 1)
     abi_dir = build_repo_via_portable_named(
         repo_vm,
-        [Path(pkg)],
+        [Path(pkg), *_smoke_dep_pkg_paths()],
         tmp_path,
         catalog_name=f"release/{real_varver}",
         guest_root=SCRIPT_REPO_ROOT,
@@ -1074,7 +1109,7 @@ def test_portable_catalog_is_accepted(repo_vm: SmokeVM, tmp_path: Path) -> None:
 
     # GIVEN: build the catalog with the PURE-PYTHON generator on the runner (no libpkg),
     # ship its <ABI>/ tree to the guest, point a NONE-signed file:// repo above pfSense.
-    abi_dir = build_repo_via_portable(repo_vm, [Path(pkg)], tmp_path)
+    abi_dir = build_repo_via_portable(repo_vm, [Path(pkg), *_smoke_dep_pkg_paths()], tmp_path)
     pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
     pkg_delete(repo_vm)
     write_repo_conf(repo_vm, abi_dir, ours_priority=pfsense_prio + 100)
@@ -1123,6 +1158,10 @@ def test_portable_catalog_dedups_duplicate_sources(repo_vm: SmokeVM, tmp_path: P
     b = tmp_path / "built-incoming_release-freebsd-pfb.pkg"
     a.write_bytes(src.read_bytes())
     b.write_bytes(src.read_bytes())
+    # NOTE: deliberately NOT folding _smoke_dep_pkg_paths() here — this test's own
+    # assertion below counts EXACTLY one package .pkg in the bucket (the dedup
+    # proof); a dep .pkg would be a second, distinct-named entry and break that
+    # count. It has no "Missing dependency" assertion (not this test's concern).
     abi_dir = build_repo_via_portable(repo_vm, [a, b], tmp_path)
 
     # THEN (catalog shape): exactly ONE package .pkg, canonically named (no prefix) — the
@@ -1534,7 +1573,7 @@ def test_install_from_variant_catalog(repo_vm: SmokeVM, tmp_path: Path) -> None:
     # ship to guest, write a NONE-signed file:// repo conf above pfSense.
     abi_dir = build_repo_via_portable_named(
         repo_vm,
-        [Path(pkg)],
+        [Path(pkg), *_smoke_dep_pkg_paths()],
         tmp_path,
         catalog_name=own.catalog,
         guest_root=VARIANT_REPO_ROOT,
@@ -1615,7 +1654,7 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
     # ---- Before-state: prove the box's OWN path works (the guard control) ----
     own_abi_dir = build_repo_via_portable_named(
         repo_vm,
-        [src],
+        [src, *_smoke_dep_pkg_paths()],
         tmp_path,
         catalog_name=own.catalog,
         guest_root=VARIANT_REPO_ROOT,
@@ -1641,6 +1680,11 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
     opp_pkg = forge_variant_pkg(src, tmp_path / "opp_forge", target_php=opp.php, target_abi=opp.abi)
 
     # ---- Build the opposite-variant catalog in <opp.catalog>/<opp.abi>/ ----
+    # Deliberately NOT folding _smoke_dep_pkg_paths() here: this leg's dep .pkgs
+    # are built for the box's OWN freebsd_major, which by definition mismatches
+    # opp.abi — adding them would open a SECOND ABI bucket and break the
+    # generator's own `len(abi_buckets) == 1` invariant. This catalog exists to
+    # be REJECTED (wrong variant), not to prove dep resolution.
     opp_abi_dir = build_repo_via_portable_named(
         repo_vm,
         [opp_pkg],
@@ -1727,7 +1771,8 @@ def test_legacy_abi_path_still_upgrades(repo_vm: SmokeVM, tmp_path: Path) -> Non
     try:
         # ---- GIVEN: legacy catalog (no variant prefix) with the LOWER build ----
         # build_repo_via_portable produces <out>/<ABI>/ (no catalog-name prefix).
-        legacy_abi_dir = build_repo_via_portable(repo_vm, [low_pkg], tmp_path)
+        dep_pkgs = _smoke_dep_pkg_paths()
+        legacy_abi_dir = build_repo_via_portable(repo_vm, [low_pkg, *dep_pkgs], tmp_path)
         pkg_delete(repo_vm)
         write_repo_conf(repo_vm, legacy_abi_dir, ours_priority=pfsense_prio + 100)
         pkg_update(repo_vm)
@@ -1752,6 +1797,8 @@ def test_legacy_abi_path_still_upgrades(repo_vm: SmokeVM, tmp_path: Path) -> Non
         out_high = tmp_path / "legacy_high_out"
         in_high.mkdir(parents=True, exist_ok=True)
         (in_high / high_pkg.name).write_bytes(high_pkg.read_bytes())
+        for _dep in dep_pkgs:
+            (in_high / _dep.name).write_bytes(_dep.read_bytes())
         proc_high = subprocess.run(
             [sys.executable, str(BUILD_REPO_PORTABLE), "--in", str(in_high), "--out", str(out_high)],
             capture_output=True,
@@ -1930,6 +1977,13 @@ def test_eol_route_only_install_from_frozen_catalog(repo_vm: SmokeVM, tmp_path: 
 
     # ---- Build the route-only (EOL) catalog ON THE RUNNER (no guest involved). ----
     # Uses --build-matrix + --route-only-pkgs — the exact CLI shape publish.yml will use.
+    # issue #1806 D3 KNOWN GAP (deliberately not addressed here): --dep-pkgs never
+    # folds into a route-only entry (test_dep_pkgs_route_only_entry_never_folds_
+    # dep_shared_major_build_entry_does pins that exclusion), so this frozen
+    # catalog cannot carry SMOKE_DEP_PKGS even though the frozen .pkg's payload
+    # (a reversion_pkg of the branch build) declares the SAME RUN_DEPENDS. If the
+    # branch's RUN_DEPENDS set ever needs a repo-supplied dep, an EOL/route-only
+    # install of it stays unresolved by design — a product question beyond D3.
     eol_out_dir = tmp_path / "eol_catalog_out"
     local_release_dir = _build_eol_catalog_on_runner(
         frozen_pkg,
@@ -2189,7 +2243,7 @@ def test_generate_hook_rewrites_stale_varver_and_resolves(repo_vm: SmokeVM, tmp_
         #    dir so the file:// URL the hook writes actually finds the catalog.
         shipped_dir = build_repo_via_portable_named(
             repo_vm,
-            [Path(pkg)],
+            [Path(pkg), *_smoke_dep_pkg_paths()],
             tmp_path,
             catalog_name=f"release/{real_varver}",
             guest_root=catalog_base,

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -6,22 +6,24 @@ ALL emit the pkg(8) repo-conf the user ends up with.  They MUST never disagree
 on ANY load-bearing field.
 
 ADR-39 rework: the conf URL is now a DIRECT, fully-resolved GitHub Pages URL
-(no Cloudflare Worker, no ``${ABI}`` token):
+(no Cloudflare Worker, no ``${ABI}`` token). Arch-less since issue #1806
+(NO_ARCH — all three pfSense-pkg-pfBlockerNG ports are NO_ARCH, so one varver
+serves every arch of its FreeBSD major):
 
-    https://pfblockerng.github.io/pkg/<channel>/<varver>/<arch>
+    https://pfblockerng.github.io/pkg/<channel>/<varver>
 
-The ``<varver>/<arch>`` segment is resolved by the boot-time ``rc.d`` generator hook
+The ``<varver>`` segment is resolved by the boot-time ``rc.d`` generator hook
 (``pfblockerng_repo_generate.sh``), whose detection is folded in (ADR-39): edition =
-"/etc/product_label contains 'Plus'", version = major.minor of /etc/version, arch =
-the leaf of ``pkg config abi``.  The hook regenerates the whole conf each boot, so the
-URL self-corrects after a pfSense OS upgrade.
+"/etc/product_label contains 'Plus'", version = major.minor of /etc/version.  The
+hook regenerates the whole conf each boot, so the URL self-corrects after a pfSense
+OS upgrade.
 
 Tests below pin:
 
 * **byte-identity** across all FOUR producers — the three ``--print-conf`` generators
-  AND the hook (release conf, ``--catalog-path ce-2.8/amd64`` so the URL is
+  AND the hook (release conf, ``--catalog-path ce-2.8`` so the URL is
   deterministic);
-* **resolved URL shape** for representative ``<varver>/<arch>`` values;
+* **resolved URL shape** for representative ``<varver>`` values;
 * **no ``${ABI}``** in any generated conf;
 * **idempotence** (re-running add-repo.sh produces an identical conf file);
 * **release / nightly non-clobber** (the two channels write distinct files that
@@ -50,8 +52,8 @@ _PAGES_BASE = "https://pfblockerng.github.io/pkg"
 _OLD_WORKER_URL = "https://pkg.pfblockerng.workers.dev"
 
 # Representative catalog paths for byte-identity and URL-shape tests.
-_CE_28_AMD64 = "ce-2.8/amd64"
-_PLUS_2603_AMD64 = "plus-26.03/amd64"
+_CE_28 = "ce-2.8"
+_PLUS_2603 = "plus-26.03"
 
 
 # --------------------------------------------------------------------------- #
@@ -59,7 +61,7 @@ _PLUS_2603_AMD64 = "plus-26.03/amd64"
 # --------------------------------------------------------------------------- #
 
 
-def _print_conf_portable(catalog_path: str = _CE_28_AMD64, base_url: str = _PAGES_BASE) -> str:
+def _print_conf_portable(catalog_path: str = _CE_28, base_url: str = _PAGES_BASE) -> str:
     """Run ``build-repo-portable.py --print-conf`` and return stdout."""
     proc = subprocess.run(
         [
@@ -78,7 +80,7 @@ def _print_conf_portable(catalog_path: str = _CE_28_AMD64, base_url: str = _PAGE
     return proc.stdout
 
 
-def _print_conf_sh(script: Path, catalog_path: str = _CE_28_AMD64, base_url: str = _PAGES_BASE, *extra: str) -> str:
+def _print_conf_sh(script: Path, catalog_path: str = _CE_28, base_url: str = _PAGES_BASE, *extra: str) -> str:
     """Run ``<script> --print-conf --catalog-path <path>`` and return stdout."""
     proc = subprocess.run(
         [
@@ -101,27 +103,23 @@ def _print_conf_sh(script: Path, catalog_path: str = _CE_28_AMD64, base_url: str
 def _run_add_repo(root: str, *, nightly: bool = False) -> None:
     """Run add-repo.sh with PFBLOCKERNG_ROOT=root.
 
-    PKG_BIN is overridden to a stub that exits 0 for every subcommand; for
-    ``pkg config abi`` it prints a real ABI (``FreeBSD:15:amd64``). add-repo.sh
-    installs the generator hook into ``root`` and runs it; the hook resolves the
-    conf from ``root/etc/product_label`` (CE here — no "Plus") and
-    ``root/etc/version`` (2.8.1). We assert only that the conf file was written;
-    exit code is irrelevant (the rquery verify fails because the stub is empty).
+    PKG_BIN is overridden to a stub that exits 0 (no output) for every
+    subcommand — add-repo.sh's own live-bootstrap steps (`pkg update`, `pkg
+    rquery`) tolerate that; the generator hook no longer calls `pkg` at all
+    (arch-less catalog; issue #1806 — it used to read `pkg config abi` only to
+    derive the now-retired per-arch leaf). add-repo.sh installs the generator
+    hook into ``root`` and runs it; the hook resolves the conf from
+    ``root/etc/product_label`` (CE here — no "Plus") and ``root/etc/version``
+    (2.8.1). We assert only that the conf file was written; exit code is
+    irrelevant (the rquery verify fails because the stub is empty).
     """
     bin_dir = os.path.join(root, "bin")
     os.makedirs(bin_dir, exist_ok=True)
 
-    # pkg stub: exits 0 for everything; for `pkg config abi` prints a real ABI.
+    # pkg stub: exits 0 (no output) for every subcommand.
     fake_pkg = os.path.join(bin_dir, "pkg")
     with open(fake_pkg, "w") as fh:
-        fh.write(
-            "#!/bin/sh\n"
-            "# fake pkg stub for tests\n"
-            'case "$*" in\n'
-            "  'config abi') printf 'FreeBSD:15:amd64' ;;\n"
-            "esac\n"
-            "exit 0\n"
-        )
+        fh.write("#!/bin/sh\n# fake pkg stub for tests\nexit 0\n")
     os.chmod(fake_pkg, 0o755)
 
     # CE 2.8.1 box fixture: /etc/version + /etc/product_label (no "Plus" → CE).
@@ -175,33 +173,27 @@ def test_release_conf_byte_identical_across_all_three_generators() -> None:
     assert add == portable, f"add-repo.sh and build-repo-portable.py drifted:\nadd:\n{add}\nportable:\n{portable}"
 
 
-def test_release_conf_byte_identical_plus_26_03_amd64() -> None:
-    """Byte-identity holds for a Plus 26.03/amd64 box (second representative case)."""
-    cat = _PLUS_2603_AMD64
+def test_release_conf_byte_identical_plus_26_03() -> None:
+    """Byte-identity holds for a Plus 26.03 box (second representative case)."""
+    cat = _PLUS_2603
     add = _print_conf_sh(_ADD_REPO, cat)
     build = _print_conf_sh(_BUILD_REPO, cat)
     portable = _print_conf_portable(cat)
 
-    assert add == build, f"add-repo.sh vs build-repo.sh mismatch (plus-26.03/amd64):\nadd:\n{add}\nbuild:\n{build}"
-    assert add == portable, f"add-repo.sh vs portable mismatch (plus-26.03/amd64):\nadd:\n{add}\nportable:\n{portable}"
+    assert add == build, f"add-repo.sh vs build-repo.sh mismatch (plus-26.03):\nadd:\n{add}\nbuild:\n{build}"
+    assert add == portable, f"add-repo.sh vs portable mismatch (plus-26.03):\nadd:\n{add}\nportable:\n{portable}"
 
 
-def _run_hook(root: str, *, edition_label: str, version: str, abi: str, channel: str) -> str:
+def _run_hook(root: str, *, edition_label: str, version: str, channel: str) -> str:
     """Run the generator hook off-box against a stubbed box; return the conf it wrote.
 
     ``channel`` selects which conf the hook regenerates (release|nightly): we stage
     only that one so the orphan guard leaves the other absent. The hook runs the
-    *_start path directly off-box (no /etc/rc.subr present).
+    *_start path directly off-box (no /etc/rc.subr present). No `pkg` stub needed —
+    the hook is arch-less (issue #1806) and no longer calls `pkg` at all.
     """
-    bin_dir = os.path.join(root, "bin")
     repos = os.path.join(root, "repos")
-    os.makedirs(bin_dir, exist_ok=True)
     os.makedirs(repos, exist_ok=True)
-
-    fake_pkg = os.path.join(bin_dir, "pkg")
-    with open(fake_pkg, "w") as fh:
-        fh.write(f"#!/bin/sh\ncase \"$*\" in 'config abi') printf '{abi}' ;; esac\nexit 0\n")
-    os.chmod(fake_pkg, 0o755)
 
     label = os.path.join(root, "product_label")
     ver = os.path.join(root, "version")
@@ -221,7 +213,6 @@ def _run_hook(root: str, *, edition_label: str, version: str, abi: str, channel:
         "PFB_NIGHTLY_CONF": os.path.join(repos, "pfblockerng-nightly.conf"),
         "PFB_PRODUCT_LABEL": label,
         "PFB_VERSION_FILE": ver,
-        "PFB_PKG_BIN": fake_pkg,
     }
     subprocess.run(["sh", str(_HOOK), "onestart"], env=env, capture_output=True, text=True, check=False)
     return Path(conf_path).read_text()
@@ -231,21 +222,19 @@ def test_hook_output_byte_identical_to_print_conf_release() -> None:
     """The rc.d hook writes the SAME bytes as ``add-repo.sh --print-conf`` (release).
 
     This is the 4th producer of the conf — the boot-time generator. It MUST match
-    the three ``--print-conf`` generators byte-for-byte for a CE 2.8.1/amd64 box.
+    the three ``--print-conf`` generators byte-for-byte for a CE 2.8.1 box.
     """
     with tempfile.TemporaryDirectory() as root:
-        hook_conf = _run_hook(root, edition_label="pfSense", version="2.8.1", abi="FreeBSD:15:amd64", channel="release")
-    print_conf = _print_conf_sh(_ADD_REPO, _CE_28_AMD64)
+        hook_conf = _run_hook(root, edition_label="pfSense", version="2.8.1", channel="release")
+    print_conf = _print_conf_sh(_ADD_REPO, _CE_28)
     assert hook_conf == print_conf, f"hook vs --print-conf drift:\nhook:\n{hook_conf}\nprint-conf:\n{print_conf}"
 
 
 def test_hook_output_byte_identical_to_print_conf_nightly_plus() -> None:
-    """The hook's nightly conf for a Plus 26.03/amd64 box matches --print-conf --nightly."""
+    """The hook's nightly conf for a Plus 26.03 box matches --print-conf --nightly."""
     with tempfile.TemporaryDirectory() as root:
-        hook_conf = _run_hook(
-            root, edition_label="pfSense Plus", version="26.03.1", abi="FreeBSD:15:amd64", channel="nightly"
-        )
-    print_conf = _print_conf_sh(_ADD_REPO, _PLUS_2603_AMD64, _PAGES_BASE, "--nightly")
+        hook_conf = _run_hook(root, edition_label="pfSense Plus", version="26.03.1", channel="nightly")
+    print_conf = _print_conf_sh(_ADD_REPO, _PLUS_2603, _PAGES_BASE, "--nightly")
     assert hook_conf == print_conf, (
         f"hook nightly vs --print-conf drift:\nhook:\n{hook_conf}\nprint-conf:\n{print_conf}"
     )
@@ -259,33 +248,33 @@ def test_hook_output_byte_identical_to_print_conf_nightly_plus() -> None:
 @pytest.mark.parametrize(
     ("catalog_path", "channel_args", "repo_name", "expected_url"),
     [
-        # CE 2.8 / amd64 — release channel
+        # CE 2.8 — release channel
         (
-            _CE_28_AMD64,
+            _CE_28,
             (),
             "pfblockerng",
-            f"{_PAGES_BASE}/release/{_CE_28_AMD64}",
+            f"{_PAGES_BASE}/release/{_CE_28}",
         ),
-        # CE 2.8 / amd64 — nightly channel
+        # CE 2.8 — nightly channel
         (
-            _CE_28_AMD64,
+            _CE_28,
             ("--nightly",),
             "pfblockerng-nightly",
-            f"{_PAGES_BASE}/nightly/{_CE_28_AMD64}",
+            f"{_PAGES_BASE}/nightly/{_CE_28}",
         ),
-        # Plus 26.03 / amd64 — release channel
+        # Plus 26.03 — release channel
         (
-            _PLUS_2603_AMD64,
+            _PLUS_2603,
             (),
             "pfblockerng",
-            f"{_PAGES_BASE}/release/{_PLUS_2603_AMD64}",
+            f"{_PAGES_BASE}/release/{_PLUS_2603}",
         ),
-        # Plus 26.03 / amd64 — nightly channel
+        # Plus 26.03 — nightly channel
         (
-            _PLUS_2603_AMD64,
+            _PLUS_2603,
             ("--nightly",),
             "pfblockerng-nightly",
-            f"{_PAGES_BASE}/nightly/{_PLUS_2603_AMD64}",
+            f"{_PAGES_BASE}/nightly/{_PLUS_2603}",
         ),
     ],
 )
@@ -295,7 +284,7 @@ def test_add_repo_conf_resolved_url_shape(
     repo_name: str,
     expected_url: str,
 ) -> None:
-    """The resolved url: is base/channel/varver/arch — no ${ABI}, no Worker URL.
+    """The resolved url: is base/channel/varver — no ${ABI}, no Worker URL.
 
     Scenario: given the specified catalog_path and channel,
     When  add-repo.sh --print-conf is run,
@@ -333,7 +322,7 @@ def test_no_abi_placeholder_in_any_generator_output(generator: str, channel_args
     trick from ADR-17/20 is retired because one ABI can map to multiple pfSense
     versions (varver keying is mandatory).
     """
-    cat = _CE_28_AMD64
+    cat = _CE_28
     if generator == "add-repo.sh":
         conf = _print_conf_sh(_ADD_REPO, cat, _PAGES_BASE, *channel_args)
     elif generator == "build-repo.sh":
@@ -371,7 +360,7 @@ def test_add_repo_conf_fields_per_channel(
     Default (no arg) -> ``pfblockerng`` (stable + devel); --nightly ->
     ``pfblockerng-nightly``.  The OTHER repo name must not appear as a stanza key.
     """
-    conf = _print_conf_sh(_ADD_REPO, _CE_28_AMD64, _PAGES_BASE, *channel_args)
+    conf = _print_conf_sh(_ADD_REPO, _CE_28, _PAGES_BASE, *channel_args)
 
     # The stanza is keyed by the expected repo name.
     assert re.search(rf"^{re.escape(repo_name)}:\s*\{{", conf, re.MULTILINE), conf
@@ -544,7 +533,7 @@ def test_print_conf_requires_catalog_path(argv: list[str], needle: str) -> None:
     """All three generators FAIL `--print-conf` without `--catalog-path` (no unresolved URL).
 
     A bare `--print-conf` would otherwise emit a URL ending at the channel (no
-    `<varver>/<arch>`), violating the ADR-39 resolved-URL contract. Each generator must
+    `<varver>`), violating the ADR-39 resolved-URL contract. Each generator must
     error loud instead of emitting an unusable conf.
     """
     proc = subprocess.run(argv, capture_output=True, text=True, check=False)

--- a/tests/test_build_dep_pkg_portable.py
+++ b/tests/test_build_dep_pkg_portable.py
@@ -1,14 +1,13 @@
 """Tests for scripts/build-dep-pkg-portable.py — the port-driven dependency
 package builder (issue #1806 step A).
 
-Brand-new code (no pre-existing behaviour to be wrong), so no red-vs-existing
-proof is required — but every assertion here is real (fails on a regression),
-per testing.md principle 3. The fixture Makefile/distinfo/pkg-descr mirror the
-REAL textproc/py-charset-normalizer port (captured 2026-07-28 from the
+The fixture Makefile/distinfo/pkg-descr mirror the REAL
+textproc/py-charset-normalizer port (captured 2026-07-28 from the
 pfBlockerNG/FreeBSD-ports fork, commit 3a57c58d82c8's parent). Network (sdist
 fetch, `pip wheel`) is mocked everywhere here — see the module docstring in
-build-dep-pkg-portable.py and the handoff for the one real, network-using,
-manually-executed end-to-end run against the actual ports checkout.
+build-dep-pkg-portable.py for the tool's real network behavior; a real build
+against an actual ports checkout (genuine sdist fetch + pip wheel) is
+validated separately, outside this hermetic suite.
 """
 
 from __future__ import annotations
@@ -337,6 +336,38 @@ def test_build_wheel_refuses_platform_wheel(tmp_path: Path, monkeypatch: pytest.
     (wheel_dir / "charset_normalizer-3.4.4-cp311-cp311-macosx_11_0_arm64.whl").write_bytes(b"")
     with pytest.raises(bdp.DepPkgError, match="not a pure-Python wheel"):
         bdp.build_wheel(tmp_path / "sdist.tar.gz", tmp_path)
+
+
+def test_build_wheel_sets_pip_constraint_pinning_setuptools_and_wheel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """W4 (supply chain, honest middle ground): `pip wheel`'s pep517 isolated
+    build env otherwise fetches whatever's newest on PyPI for the build backend
+    itself (setuptools/wheel) -- PIP_CONSTRAINT pins it to exact versions.
+    Assert the env var is actually passed on the pip call, pointing at a real
+    constraints file naming both packages."""
+    captured_envs: list[dict[str, str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured_envs.append(kwargs.get("env") or {})
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(bdp.subprocess, "run", fake_run)
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    (wheel_dir / "charset_normalizer-3.4.4-py3-none-any.whl").write_bytes(b"")
+
+    bdp.build_wheel(tmp_path / "sdist.tar.gz", tmp_path)
+
+    # The pip-wheel call (the last of the two subprocess.run calls: the pip
+    # probe in _pip_python, then the actual build) carries PIP_CONSTRAINT.
+    pip_wheel_env = captured_envs[-1]
+    assert "PIP_CONSTRAINT" in pip_wheel_env, "pip wheel call was not given PIP_CONSTRAINT"
+    constraints_path = Path(pip_wheel_env["PIP_CONSTRAINT"])
+    assert constraints_path.is_file(), f"PIP_CONSTRAINT points at a nonexistent file: {constraints_path}"
+    text = constraints_path.read_text()
+    assert "setuptools==" in text
+    assert "wheel==" in text
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_build_dep_pkg_portable.py
+++ b/tests/test_build_dep_pkg_portable.py
@@ -614,6 +614,80 @@ def test_main_prints_out_path_as_last_stdout_line(
     assert last_line == str(out_dir / "py311-charset-normalizer-3.4.4.pkg")
 
 
+def test_main_stdout_is_only_the_pkg_path_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """main()'s ENTIRE stdout is the emitted .pkg path + newline -- NOTHING else,
+    even when a shelled-out tool (pip) is chatty on ITS OWN stdout. An on-box
+    caller captures this whole process's stdout as the path (``PKG="$(python3
+    build-dep-pkg-portable.py ...)"``); pip's "Processing ...", "Created wheel
+    ..." lines leaking onto an inherited stdout got word-split into that
+    captured value as garbage (issue #1806 live-leg RED #4). The real
+    build_wheel()/_pip_python() run here (not mocked out) so the actual
+    subprocess-output-relay path is exercised; ``--compression xz`` sidesteps
+    the ALSO-real zstd_compress() subprocess call (stdlib lzma, no subprocess)
+    so only the two calls under test need a fake.
+    """
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+
+    def fake_fetch(port: Any, dest_dir: Path, *, sha256: str, size: int) -> Path:
+        dest = dest_dir / f"{port.distname}.tar.gz"
+        dest.write_bytes(b"mocked sdist bytes")
+        return dest
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Simulates a REAL child's fd-inheritance semantics (not just a canned
+        return value): with ``capture_output=True`` its chatter comes back on
+        ``.stdout``/``.stderr`` (what a fixed caller relays itself); WITHOUT it,
+        a real child would write straight through the inherited fd -- so this
+        writes directly to ``sys.stdout``, reproducing the pre-fix leak if the
+        caller ever regresses to an uncaptured ``subprocess.run(cmd, check=True)``.
+        """
+        if cmd[1:3] == ["-m", "pip"] and cmd[3:] == ["--version"]:
+            chatter = "pip 24.0\n"
+        elif cmd[1:3] == ["-m", "pip"] and "wheel" in cmd:
+            wheel_dir = Path(cmd[cmd.index("-w") + 1])
+            wheel_dir.mkdir(parents=True, exist_ok=True)
+            _write_wheel(
+                wheel_dir / "charset_normalizer-3.4.4-py3-none-any.whl",
+                files={"charset_normalizer/__init__.py": b"__version__ = '3.4.4'\n"},
+                entry_points=None,
+            )
+            chatter = "Processing /tmp/x.tar.gz\nCreated wheel for charset-normalizer\n"
+        else:
+            raise AssertionError(f"unexpected subprocess.run call: {cmd}")
+
+        if kwargs.get("capture_output"):
+            return subprocess.CompletedProcess(cmd, 0, stdout=chatter, stderr="")
+        sys.stdout.write(chatter)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(bdp, "fetch_verified_sdist", fake_fetch)
+    monkeypatch.setattr(bdp.subprocess, "run", fake_run)
+
+    out_dir = tmp_path / "out"
+    rc = bdp.main(
+        [
+            "--ports", str(ports_root),
+            "--port", "textproc/py-charset-normalizer",
+            "--py-flavor", "py311",
+            "--freebsd-major", "15",
+            "--compression", "xz",
+            "--out-dir", str(out_dir),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == f"{out_dir / 'py311-charset-normalizer-3.4.4.pkg'}\n", (
+        f"stdout must be ONLY the .pkg path line; got {captured.out!r}"
+    )
+    # The pip chatter must still be VISIBLE -- relayed to stderr, never dropped.
+    assert "Processing /tmp/x.tar.gz" in captured.err
+    assert "Created wheel for charset-normalizer" in captured.err
+
+
 def test_main_defaults_python_dep_version_to_0_when_omitted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """--python-dep-version is optional (issue #1806 D-fix): pkg(8) resolves a
     dependency by NAME, never by the version recorded in another package's

--- a/tests/test_build_dep_pkg_portable.py
+++ b/tests/test_build_dep_pkg_portable.py
@@ -566,6 +566,34 @@ def test_main_prints_out_path_as_last_stdout_line(
     assert last_line == str(out_dir / "py311-charset-normalizer-3.4.4.pkg")
 
 
+def test_main_defaults_python_dep_version_to_0_when_omitted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--python-dep-version is optional (issue #1806 D-fix): pkg(8) resolves a
+    dependency by NAME, never by the version recorded in another package's
+    manifest, so this field is never enforced at install. lang/python<NNN>'s
+    real PORTVERSION also isn't a literal in its Makefile (it's
+    ${PYTHON_DISTVERSION}, indirect via Mk/Uses/python.mk) -- deriving it
+    honestly needs the ports framework this tool deliberately avoids.
+    Omitting the flag must not error, and must record version "0"
+    (unknown-at-build), not silently invent a plausible-looking value."""
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+    _mock_network(monkeypatch, console_scripts=None)
+
+    out_dir = tmp_path / "out"
+    rc = bdp.main(
+        [
+            "--ports", str(ports_root),
+            "--port", "textproc/py-charset-normalizer",
+            "--py-flavor", "py311",
+            "--freebsd-major", "15",
+            "--out-dir", str(out_dir),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    manifest = pfb_pkg.read_compact_manifest(out_dir / "py311-charset-normalizer-3.4.4.pkg")
+    assert manifest["deps"] == {"python311": {"origin": "lang/python311", "version": "0"}}
+
+
 def test_main_returns_1_and_reports_refusal_on_stderr(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     ports_root = tmp_path / "ports"
     _write_port(ports_root, no_arch_line="")  # missing NO_ARCH -> refusal, no network involved

--- a/tests/test_build_dep_pkg_portable.py
+++ b/tests/test_build_dep_pkg_portable.py
@@ -18,6 +18,7 @@ import hashlib
 import importlib.util
 import io
 import json
+import subprocess
 import sys
 import tarfile
 import zipfile
@@ -304,7 +305,7 @@ def test_fetch_verified_sdist_all_mirrors_failing_raises(tmp_path: Path, monkeyp
 
 
 def test_build_wheel_accepts_single_pure_wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(bdp.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(bdp.subprocess, "run", lambda cmd, **k: subprocess.CompletedProcess(cmd, 0))
     wheel_dir = tmp_path / "wheel"
     wheel_dir.mkdir()
     wheel = wheel_dir / "charset_normalizer-3.4.4-py3-none-any.whl"
@@ -314,13 +315,13 @@ def test_build_wheel_accepts_single_pure_wheel(tmp_path: Path, monkeypatch: pyte
 
 
 def test_build_wheel_refuses_zero_wheels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(bdp.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(bdp.subprocess, "run", lambda cmd, **k: subprocess.CompletedProcess(cmd, 0))
     with pytest.raises(bdp.DepPkgError, match="exactly one wheel"):
         bdp.build_wheel(tmp_path / "sdist.tar.gz", tmp_path)
 
 
 def test_build_wheel_refuses_multiple_wheels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(bdp.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(bdp.subprocess, "run", lambda cmd, **k: subprocess.CompletedProcess(cmd, 0))
     wheel_dir = tmp_path / "wheel"
     wheel_dir.mkdir()
     (wheel_dir / "a-1.0-py3-none-any.whl").write_bytes(b"")
@@ -330,12 +331,59 @@ def test_build_wheel_refuses_multiple_wheels(tmp_path: Path, monkeypatch: pytest
 
 
 def test_build_wheel_refuses_platform_wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(bdp.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(bdp.subprocess, "run", lambda cmd, **k: subprocess.CompletedProcess(cmd, 0))
     wheel_dir = tmp_path / "wheel"
     wheel_dir.mkdir()
     (wheel_dir / "charset_normalizer-3.4.4-cp311-cp311-macosx_11_0_arm64.whl").write_bytes(b"")
     with pytest.raises(bdp.DepPkgError, match="not a pure-Python wheel"):
         bdp.build_wheel(tmp_path / "sdist.tar.gz", tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# _pip_python — venv fallback when the interpreter has no pip module
+# (issue #1806: the PFB_BOXES minimal Debian pool ships python3-venv but not
+# pip on /usr/bin/python3; a venv's own bootstrapped pip is always present).
+# --------------------------------------------------------------------------- #
+
+
+def test_pip_python_falls_back_to_venv_when_direct_pip_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        calls.append(cmd)
+        if cmd[1:3] == ["-m", "pip"]:
+            return subprocess.CompletedProcess(cmd, 1)  # no pip module on sys.executable
+        if cmd[1:3] == ["-m", "venv"]:
+            return subprocess.CompletedProcess(cmd, 0)  # venv created fine
+        raise AssertionError(f"unexpected subprocess.run call: {cmd}")
+
+    monkeypatch.setattr(bdp.subprocess, "run", fake_run)
+    python = bdp._pip_python(tmp_path)
+
+    assert python == str(tmp_path / "pip-venv" / "bin" / "python")
+    assert python != sys.executable
+    assert any(c[1:3] == ["-m", "venv"] for c in calls), f"venv path was not exercised: {calls}"
+
+
+def test_pip_python_uses_sys_executable_when_pip_already_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fast path (CI runners): a direct pip probe success skips the venv entirely."""
+    monkeypatch.setattr(bdp.subprocess, "run", lambda cmd, **k: subprocess.CompletedProcess(cmd, 0))
+    assert bdp._pip_python(tmp_path) == sys.executable
+
+
+def test_pip_python_raises_when_venv_creation_also_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        if cmd[1:3] == ["-m", "pip"]:
+            return subprocess.CompletedProcess(cmd, 1)
+        if cmd[1:3] == ["-m", "venv"]:
+            raise subprocess.CalledProcessError(1, cmd)
+        raise AssertionError(f"unexpected subprocess.run call: {cmd}")
+
+    monkeypatch.setattr(bdp.subprocess, "run", fake_run)
+    with pytest.raises(bdp.DepPkgError, match="no pip"):
+        bdp._pip_python(tmp_path)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_build_dep_pkg_portable.py
+++ b/tests/test_build_dep_pkg_portable.py
@@ -1,0 +1,583 @@
+"""Tests for scripts/build-dep-pkg-portable.py — the port-driven dependency
+package builder (issue #1806 step A).
+
+Brand-new code (no pre-existing behaviour to be wrong), so no red-vs-existing
+proof is required — but every assertion here is real (fails on a regression),
+per testing.md principle 3. The fixture Makefile/distinfo/pkg-descr mirror the
+REAL textproc/py-charset-normalizer port (captured 2026-07-28 from the
+pfBlockerNG/FreeBSD-ports fork, commit 3a57c58d82c8's parent). Network (sdist
+fetch, `pip wheel`) is mocked everywhere here — see the module docstring in
+build-dep-pkg-portable.py and the handoff for the one real, network-using,
+manually-executed end-to-end run against the actual ports checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import io
+import json
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pfb_pkg
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Load the hyphen-named tool as a module (same convention as
+# tests/test_build_repo_portable.py:49-54 — register in sys.modules BEFORE
+# exec_module, or the tool's own dataclass-based import of build-pkg-portable.py
+# breaks).
+# --------------------------------------------------------------------------- #
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "build-dep-pkg-portable.py"
+_spec = importlib.util.spec_from_file_location("build_dep_pkg_portable", _TOOL)
+assert _spec is not None and _spec.loader is not None
+bdp = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = bdp
+_spec.loader.exec_module(bdp)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture port dir — the REAL textproc/py-charset-normalizer Makefile/distinfo/
+# pkg-descr shape, with two knobs (`use_python`, `no_arch_line`) for the
+# refusal tests.
+# --------------------------------------------------------------------------- #
+
+
+def _port_makefile(*, use_python: str = "autoplist concurrent pep517", no_arch_line: str = "NO_ARCH=\tyes") -> str:
+    return (
+        "PORTNAME=\tcharset-normalizer\n"
+        "PORTVERSION=\t3.4.4\n"
+        "CATEGORIES=\ttextproc python\n"
+        "MASTER_SITES=\tPYPI \\\n"
+        "\t\thttps://github.com/jawah/charset_normalizer/releases/download/${PORTVERSION}/\n"
+        "PKGNAMEPREFIX=\t${PYTHON_PKGNAMEPREFIX}\n"
+        "DISTNAME=\tcharset_normalizer-${PORTVERSION}\n"
+        "\n"
+        "MAINTAINER=\tsunpoet@FreeBSD.org\n"
+        "COMMENT=\tReal First Universal Charset Detector\n"
+        "WWW=\t\thttps://charset-normalizer.readthedocs.io/en/latest/ \\\n"
+        "\t\thttps://github.com/Ousret/charset_normalizer\n"
+        "\n"
+        "LICENSE=\tMIT\n"
+        "LICENSE_FILE=\t${WRKSRC}/LICENSE\n"
+        "\n"
+        "BUILD_DEPENDS=\t${PYTHON_PKGNAMEPREFIX}setuptools>=61:devel/py-setuptools@${PY_FLAVOR} \\\n"
+        "\t\t${PYTHON_PKGNAMEPREFIX}wheel>=0:devel/py-wheel@${PY_FLAVOR}\n"
+        "\n"
+        "USES=\t\tpython\n"
+        f"USE_PYTHON=\t{use_python}\n"
+        "\n"
+        f"{no_arch_line}\n"
+        "\n"
+        ".include <bsd.port.mk>\n"
+    )
+
+
+_REAL_DISTINFO = (
+    "TIMESTAMP = 1759774719\n"
+    "SHA256 (charset_normalizer-3.4.4.tar.gz) = 94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a\n"
+    "SIZE (charset_normalizer-3.4.4.tar.gz) = 129418\n"
+)
+
+_REAL_PKG_DESCR = (
+    "A library that helps you read text from an unknown charset encoding. Motivated\n"
+    "by chardet, I'm trying to resolve the issue by taking a new approach. All IANA\n"
+    "character set names for which the Python core library provides codecs are\n"
+    "supported.\n"
+)
+
+
+def _write_port(
+    ports_root: Path,
+    *,
+    use_python: str = "autoplist concurrent pep517",
+    no_arch_line: str = "NO_ARCH=\tyes",
+    with_descr: bool = True,
+) -> Path:
+    port_dir = ports_root / "textproc" / "py-charset-normalizer"
+    port_dir.mkdir(parents=True)
+    (port_dir / "Makefile").write_text(_port_makefile(use_python=use_python, no_arch_line=no_arch_line))
+    (port_dir / "distinfo").write_text(_REAL_DISTINFO)
+    if with_descr:
+        (port_dir / "pkg-descr").write_text(_REAL_PKG_DESCR)
+    return port_dir
+
+
+def _write_wheel(path: Path, *, files: dict[str, bytes], entry_points: str | None) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in files.items():
+            zf.writestr(name, data)
+        if entry_points is not None:
+            zf.writestr("mypkg-1.0.dist-info/entry_points.txt", entry_points)
+
+
+def _read_full_manifest(pkg_path: Path) -> dict:
+    """Read the +MANIFEST (file listing + perms) of a .pkg written by write_pkg."""
+    tar_bytes = pfb_pkg.zstd_decompress(pkg_path.read_bytes())
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+        member = tf.extractfile("+MANIFEST")
+        assert member is not None
+        return json.loads(member.read())
+
+
+# --------------------------------------------------------------------------- #
+# Makefile parsing — every extracted field, and the two hard refusals.
+# --------------------------------------------------------------------------- #
+
+
+def test_read_port_extracts_facts(tmp_path: Path) -> None:
+    port_dir = _write_port(tmp_path)
+    facts = bdp.read_port(port_dir)
+    assert facts.portname == "charset-normalizer"
+    assert facts.portversion == "3.4.4"
+    assert facts.distname == "charset_normalizer-3.4.4"
+    assert facts.comment == "Real First Universal Charset Detector"
+    assert facts.maintainer == "sunpoet@FreeBSD.org"
+    # WWW carries the FIRST url only, even though the port lists two.
+    assert facts.www == "https://charset-normalizer.readthedocs.io/en/latest/"
+    assert facts.license == "MIT"
+    assert facts.categories == ["textproc", "python"]
+    assert facts.master_sites == [
+        "PYPI",
+        "https://github.com/jawah/charset_normalizer/releases/download/3.4.4/",
+    ]
+
+
+def test_read_port_refuses_missing_no_arch(tmp_path: Path) -> None:
+    port_dir = _write_port(tmp_path, no_arch_line="")
+    with pytest.raises(bdp.DepPkgError, match="NO_ARCH"):
+        bdp.read_port(port_dir)
+
+
+def test_read_port_refuses_no_arch_explicitly_no(tmp_path: Path) -> None:
+    port_dir = _write_port(tmp_path, no_arch_line="NO_ARCH=\tno")
+    with pytest.raises(bdp.DepPkgError, match="NO_ARCH"):
+        bdp.read_port(port_dir)
+
+
+def test_read_port_refuses_non_pep517(tmp_path: Path) -> None:
+    port_dir = _write_port(tmp_path, use_python="autoplist concurrent distutils")
+    with pytest.raises(bdp.DepPkgError, match="pep517"):
+        bdp.read_port(port_dir)
+
+
+def test_read_port_requires_makefile(tmp_path: Path) -> None:
+    missing = tmp_path / "textproc" / "does-not-exist"
+    with pytest.raises(bdp.DepPkgError, match="Makefile"):
+        bdp.read_port(missing)
+
+
+# --------------------------------------------------------------------------- #
+# distinfo parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_read_distinfo_parses_sha256_and_size(tmp_path: Path) -> None:
+    port_dir = _write_port(tmp_path)
+    sha, size = bdp.read_distinfo(port_dir, "charset_normalizer-3.4.4.tar.gz")
+    assert sha == "94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a"
+    assert size == 129418
+
+
+def test_read_distinfo_missing_entry_raises(tmp_path: Path) -> None:
+    port_dir = _write_port(tmp_path)
+    with pytest.raises(bdp.DepPkgError, match="distinfo"):
+        bdp.read_distinfo(port_dir, "nonexistent-9.9.9.tar.gz")
+
+
+def test_read_descr_uses_pkg_descr_when_present(tmp_path: Path) -> None:
+    port_dir = _write_port(tmp_path)
+    assert bdp.read_descr(port_dir, "fallback").startswith("A library that helps you read text")
+
+
+def test_read_descr_falls_back_to_comment_when_missing(tmp_path: Path) -> None:
+    port_dir = _write_port(tmp_path, with_descr=False)
+    assert bdp.read_descr(port_dir, "fallback comment") == "fallback comment"
+
+
+# --------------------------------------------------------------------------- #
+# URL derivation (MASTER_SITES -> candidate download URLs)
+# --------------------------------------------------------------------------- #
+
+
+def _demo_port(**overrides: object) -> Any:
+    base: dict[str, Any] = dict(
+        portname="charset-normalizer",
+        portversion="3.4.4",
+        distname="charset_normalizer-3.4.4",
+        comment="x",
+        maintainer="",
+        www="",
+        license="MIT",
+        categories=["textproc", "python"],
+        master_sites=["PYPI", "https://github.com/jawah/charset_normalizer/releases/download/3.4.4/"],
+    )
+    base.update(overrides)
+    return bdp.PortFacts(**base)  # type: ignore[arg-type]
+
+
+def test_candidate_urls_pypi_redirector_then_literal_fallback() -> None:
+    port = _demo_port()
+    urls = bdp.candidate_urls(port, "charset_normalizer-3.4.4.tar.gz")
+    assert urls == [
+        "https://pypi.io/packages/source/c/charset_normalizer/charset_normalizer-3.4.4.tar.gz",
+        "https://github.com/jawah/charset_normalizer/releases/download/3.4.4/charset_normalizer-3.4.4.tar.gz",
+    ]
+
+
+def test_candidate_urls_literal_only_site_has_no_pypi_entry() -> None:
+    port = _demo_port(master_sites=["https://example.com/dist/"])
+    urls = bdp.candidate_urls(port, "charset_normalizer-3.4.4.tar.gz")
+    assert urls == ["https://example.com/dist/charset_normalizer-3.4.4.tar.gz"]
+
+
+# --------------------------------------------------------------------------- #
+# Source acquisition — verify-or-refuse, mismatch never retried, connection
+# failure DOES fall through to the next mirror.
+# --------------------------------------------------------------------------- #
+
+
+def test_fetch_verified_sdist_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data = b"a fake sdist tarball payload"
+    sha = hashlib.sha256(data).hexdigest()
+    monkeypatch.setattr(bdp, "_urlopen", lambda url: io.BytesIO(data))
+    got = bdp.fetch_verified_sdist(_demo_port(), tmp_path, sha256=sha, size=len(data))
+    assert got.read_bytes() == data
+
+
+def test_fetch_verified_sdist_mismatch_refuses_without_trying_other_mirrors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A checksum/size MISMATCH is a hard refusal — it must NOT silently fall
+    through to the next MASTER_SITES candidate (that would mask a poisoned or
+    wrong-version mirror). Only the connection-failure branch falls through."""
+    good = b"correct payload"
+    bad = b"WRONG payload!!"
+    calls: list[str] = []
+
+    def fake_urlopen(url: str) -> io.BytesIO:
+        calls.append(url)
+        return io.BytesIO(bad)
+
+    monkeypatch.setattr(bdp, "_urlopen", fake_urlopen)
+    port = _demo_port(master_sites=["PYPI", "https://example.com/fallback/"])
+    with pytest.raises(bdp.DepPkgError, match="does not match distinfo"):
+        bdp.fetch_verified_sdist(port, tmp_path, sha256=hashlib.sha256(good).hexdigest(), size=len(good))
+    assert len(calls) == 1, "a checksum mismatch must refuse immediately, never retry another mirror"
+
+
+def test_fetch_verified_sdist_connection_failure_falls_through_to_next_mirror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    good = b"correct payload"
+    calls: list[str] = []
+
+    def fake_urlopen(url: str) -> io.BytesIO:
+        calls.append(url)
+        if len(calls) == 1:
+            raise OSError("connection refused")
+        return io.BytesIO(good)
+
+    monkeypatch.setattr(bdp, "_urlopen", fake_urlopen)
+    port = _demo_port(master_sites=["PYPI", "https://example.com/fallback/"])
+    got = bdp.fetch_verified_sdist(port, tmp_path, sha256=hashlib.sha256(good).hexdigest(), size=len(good))
+    assert got.read_bytes() == good
+    assert len(calls) == 2
+
+
+def test_fetch_verified_sdist_all_mirrors_failing_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bdp, "_urlopen", lambda url: (_ for _ in ()).throw(OSError("unreachable")))
+    port = _demo_port(master_sites=["PYPI"])
+    with pytest.raises(bdp.DepPkgError, match="failed to fetch"):
+        bdp.fetch_verified_sdist(port, tmp_path, sha256="0" * 64, size=1)
+
+
+# --------------------------------------------------------------------------- #
+# Wheel build — exactly one PURE wheel, or refuse.
+# --------------------------------------------------------------------------- #
+
+
+def test_build_wheel_accepts_single_pure_wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bdp.subprocess, "run", lambda *a, **k: None)
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    wheel = wheel_dir / "charset_normalizer-3.4.4-py3-none-any.whl"
+    wheel.write_bytes(b"")
+    got = bdp.build_wheel(tmp_path / "sdist.tar.gz", tmp_path)
+    assert got == wheel
+
+
+def test_build_wheel_refuses_zero_wheels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bdp.subprocess, "run", lambda *a, **k: None)
+    with pytest.raises(bdp.DepPkgError, match="exactly one wheel"):
+        bdp.build_wheel(tmp_path / "sdist.tar.gz", tmp_path)
+
+
+def test_build_wheel_refuses_multiple_wheels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bdp.subprocess, "run", lambda *a, **k: None)
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    (wheel_dir / "a-1.0-py3-none-any.whl").write_bytes(b"")
+    (wheel_dir / "b-1.0-py3-none-any.whl").write_bytes(b"")
+    with pytest.raises(bdp.DepPkgError, match="exactly one wheel"):
+        bdp.build_wheel(tmp_path / "sdist.tar.gz", tmp_path)
+
+
+def test_build_wheel_refuses_platform_wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bdp.subprocess, "run", lambda *a, **k: None)
+    wheel_dir = tmp_path / "wheel"
+    wheel_dir.mkdir()
+    (wheel_dir / "charset_normalizer-3.4.4-cp311-cp311-macosx_11_0_arm64.whl").write_bytes(b"")
+    with pytest.raises(bdp.DepPkgError, match="not a pure-Python wheel"):
+        bdp.build_wheel(tmp_path / "sdist.tar.gz", tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# [console_scripts] entry_points.txt parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_console_scripts_basic() -> None:
+    text = (
+        "[console_scripts]\n"
+        "normalizer = charset_normalizer.cli:cli_detect\n"
+        "\n"
+        "[some.other.group]\n"
+        "plugin = charset_normalizer.plugins:register\n"
+    )
+    assert bdp.parse_console_scripts(text) == {"normalizer": ("charset_normalizer.cli", "cli_detect")}
+
+
+def test_parse_console_scripts_ignores_comments_and_blank_lines() -> None:
+    text = "# a comment\n\n[console_scripts]\n; also a comment\nnormalizer = charset_normalizer.cli:cli_detect\n"
+    assert bdp.parse_console_scripts(text) == {"normalizer": ("charset_normalizer.cli", "cli_detect")}
+
+
+def test_parse_console_scripts_empty_when_no_section() -> None:
+    assert bdp.parse_console_scripts("[some.other.group]\nx = y:z\n") == {}
+
+
+def test_parse_console_scripts_unparseable_line_raises() -> None:
+    with pytest.raises(bdp.DepPkgError, match="unparseable"):
+        bdp.parse_console_scripts("[console_scripts]\nthis line has no colon target\n")
+
+
+# --------------------------------------------------------------------------- #
+# --py-flavor -> python3.NN dotted version
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("flavor", "dotted"),
+    [("py311", "3.11"), ("py310", "3.10"), ("py39", "3.9")],
+)
+def test_python_dotted_version_derives_from_flavor(flavor: str, dotted: str) -> None:
+    assert bdp.python_dotted_version(flavor) == dotted
+
+
+def test_python_dotted_version_refuses_unknown_flavor() -> None:
+    with pytest.raises(bdp.DepPkgError, match="py-flavor"):
+        bdp.python_dotted_version("cp311")
+
+
+# --------------------------------------------------------------------------- #
+# Staging: wheel -> site-packages files + console-script stub(s)
+# --------------------------------------------------------------------------- #
+
+
+def test_stage_wheel_lays_out_site_packages_and_console_script(tmp_path: Path) -> None:
+    wheel = tmp_path / "mypkg-1.0-py3-none-any.whl"
+    _write_wheel(
+        wheel,
+        files={"mypkg/__init__.py": b"X = 1\n", "mypkg-1.0.dist-info/METADATA": b"Metadata-Version: 2.1\n"},
+        entry_points="[console_scripts]\nmycli = mypkg.cli:main\n",
+    )
+    stage = tmp_path / "stage"
+    site_files, script_files = bdp.stage_wheel(wheel, stage, "3.11")
+
+    site_pkg_init = stage / "usr/local/lib/python3.11/site-packages/mypkg/__init__.py"
+    assert site_pkg_init in site_files
+    assert site_pkg_init.read_bytes() == b"X = 1\n"
+    dist_info_meta = stage / "usr/local/lib/python3.11/site-packages/mypkg-1.0.dist-info/METADATA"
+    assert dist_info_meta in site_files
+
+    script = stage / "usr/local/bin/mycli"
+    assert script_files == [script]
+    # Compare against the SAME stub template the production code fills in — a
+    # single source of truth, and it never re-embeds the appliance interpreter
+    # path as a literal in test code (scripts/check_appliance_python.py scans
+    # tests/ for exactly that; the production template lives in scripts/,
+    # which is intentionally out of its scope).
+    expected = bdp._SCRIPT_STUB.format(py_dotted="3.11", module="mypkg.cli", func="main")
+    assert script.read_text() == expected
+    assert expected.count("\n") == 8, "the console-script stub must be the standard 8-line launcher"
+    assert (script.stat().st_mode & 0o777) == 0o555
+
+
+def test_stage_wheel_without_entry_points_yields_no_scripts(tmp_path: Path) -> None:
+    wheel = tmp_path / "mypkg-1.0-py3-none-any.whl"
+    _write_wheel(wheel, files={"mypkg/__init__.py": b"X = 1\n"}, entry_points=None)
+    stage = tmp_path / "stage"
+    site_files, script_files = bdp.stage_wheel(wheel, stage, "3.11")
+    assert script_files == []
+    assert len(site_files) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Full orchestration: manifest correctness of the emitted .pkg, read back via
+# pfb_pkg.read_compact_manifest (the SAME contract tests/test_pfb_pkg.py pins).
+# Network (fetch + `pip wheel`) is mocked; the staging/manifest/write_pkg path
+# is REAL.
+# --------------------------------------------------------------------------- #
+
+
+def _mock_network(monkeypatch: pytest.MonkeyPatch, *, console_scripts: str | None) -> None:
+    def fake_fetch(port: Any, dest_dir: Path, *, sha256: str, size: int) -> Path:
+        dest = dest_dir / f"{port.distname}.tar.gz"
+        dest.write_bytes(b"mocked sdist bytes -- fetch is not exercised here")
+        return dest
+
+    def fake_build_wheel(sdist: Path, work_dir: Path) -> Path:
+        wheel_dir = work_dir / "wheel"
+        wheel_dir.mkdir(parents=True, exist_ok=True)
+        wheel = wheel_dir / "charset_normalizer-3.4.4-py3-none-any.whl"
+        _write_wheel(
+            wheel,
+            files={
+                "charset_normalizer/__init__.py": b"__version__ = '3.4.4'\n",
+                "charset_normalizer-3.4.4.dist-info/METADATA": b"Metadata-Version: 2.1\n",
+            },
+            entry_points=console_scripts,
+        )
+        return wheel
+
+    monkeypatch.setattr(bdp, "fetch_verified_sdist", fake_fetch)
+    monkeypatch.setattr(bdp, "build_wheel", fake_build_wheel)
+
+
+def _build_args(ports_root: Path, out_dir: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        ports=str(ports_root),
+        port="textproc/py-charset-normalizer",
+        py_flavor="py311",
+        freebsd_major="15",
+        python_dep_version="3.11.13",
+        out_dir=str(out_dir),
+        compression="zstd",
+    )
+
+
+def test_build_dep_pkg_emits_correct_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+    _mock_network(monkeypatch, console_scripts="[console_scripts]\nnormalizer = charset_normalizer.cli:cli_detect\n")
+
+    out_dir = tmp_path / "out"
+    out_path = bdp.build_dep_pkg(_build_args(ports_root, out_dir))
+
+    # Canonical <name>-<version>.pkg output filename.
+    assert out_path == out_dir / "py311-charset-normalizer-3.4.4.pkg"
+    assert out_path.is_file()
+
+    manifest = pfb_pkg.read_compact_manifest(out_path)
+    assert manifest["name"] == "py311-charset-normalizer"
+    assert manifest["version"] == "3.4.4"
+    assert manifest["origin"] == "textproc/py-charset-normalizer"
+    assert manifest["abi"] == "FreeBSD:15:*"
+    assert manifest["arch"] == "freebsd:15:*"
+    assert manifest["categories"] == ["textproc", "python"]
+    assert manifest["licenses"] == ["MIT"]
+    assert manifest["deps"] == {"python311": {"origin": "lang/python311", "version": "3.11.13"}}
+
+    # File listing + perms live in the FULL +MANIFEST, not the compact one.
+    full = _read_full_manifest(out_path)
+    files = full["files"]
+    assert "/usr/local/lib/python3.11/site-packages/charset_normalizer/__init__.py" in files
+    assert "/usr/local/bin/normalizer" in files
+    assert files["/usr/local/bin/normalizer"]["perm"] == "0555"
+    assert files["/usr/local/lib/python3.11/site-packages/charset_normalizer/__init__.py"]["perm"] == "0644"
+
+
+def test_build_dep_pkg_no_console_scripts_still_emits_valid_pkg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pure-library dependency (no entry points) still produces a valid .pkg
+    with no /usr/local/bin files — the console-script stage is optional."""
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+    _mock_network(monkeypatch, console_scripts=None)
+
+    out_dir = tmp_path / "out"
+    out_path = bdp.build_dep_pkg(_build_args(ports_root, out_dir))
+
+    full = _read_full_manifest(out_path)
+    assert not any(p.startswith("/usr/local/bin/") for p in full["files"])
+
+
+def test_build_dep_pkg_derives_portname_from_flavor_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """portname = PKGNAMEPREFIX (from --py-flavor) + PORTNAME — never hardcoded."""
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+    _mock_network(monkeypatch, console_scripts=None)
+
+    out_dir = tmp_path / "out"
+    args = _build_args(ports_root, out_dir)
+    args.py_flavor = "py310"
+    args.python_dep_version = "3.10.9"
+    out_path = bdp.build_dep_pkg(args)
+
+    assert out_path.name == "py310-charset-normalizer-3.4.4.pkg"
+    manifest = pfb_pkg.read_compact_manifest(out_path)
+    assert manifest["name"] == "py310-charset-normalizer"
+    assert manifest["deps"] == {"python310": {"origin": "lang/python310", "version": "3.10.9"}}
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring
+# --------------------------------------------------------------------------- #
+
+
+def test_main_prints_out_path_as_last_stdout_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+    _mock_network(monkeypatch, console_scripts=None)
+
+    out_dir = tmp_path / "out"
+    rc = bdp.main(
+        [
+            "--ports", str(ports_root),
+            "--port", "textproc/py-charset-normalizer",
+            "--py-flavor", "py311",
+            "--freebsd-major", "15",
+            "--python-dep-version", "3.11.13",
+            "--out-dir", str(out_dir),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    last_line = capsys.readouterr().out.strip().splitlines()[-1]
+    assert last_line == str(out_dir / "py311-charset-normalizer-3.4.4.pkg")
+
+
+def test_main_returns_1_and_reports_refusal_on_stderr(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root, no_arch_line="")  # missing NO_ARCH -> refusal, no network involved
+    rc = bdp.main(
+        [
+            "--ports", str(ports_root),
+            "--port", "textproc/py-charset-normalizer",
+            "--py-flavor", "py311",
+            "--freebsd-major", "15",
+            "--python-dep-version", "3.11.13",
+            "--out-dir", str(tmp_path / "out"),
+        ]
+    )  # fmt: skip
+    assert rc == 1
+    assert "NO_ARCH" in capsys.readouterr().err

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -701,6 +701,79 @@ def test_end_to_end_classic_build(tmp_path: Path) -> None:
     assert info == "<version>1.0_2</version>\n"
 
 
+def _make_no_arch_port(tmp_path: Path) -> tuple[Path, Path]:
+    """The same minimal classic port as _make_classic_port, with NO_ARCH=yes set —
+    simulates the FreeBSD-ports fork's staged NO_ARCH Makefile change (issue #1806;
+    not visible to this repo — this fixture simulates it)."""
+    ports, portdir = _make_classic_port(tmp_path)
+    makefile = portdir / "Makefile"
+    makefile.write_text(makefile.read_text().replace("NO_BUILD=\tyes\n", "NO_BUILD=\tyes\nNO_ARCH=\tyes\n"))
+    return ports, portdir
+
+
+def test_end_to_end_no_arch_port_stamps_wildcard_abi_and_arch(tmp_path: Path) -> None:
+    """A NO_ARCH port's manifest stamps a CPU-wildcarded abi/arch (issue #1806 B1).
+
+    Scenario: NO_ARCH port, concrete --abi input, no --arch override
+      Given a port Makefile with NO_ARCH=yes
+       When build-pkg-portable.py runs with --abi FreeBSD:15:amd64 (no --arch)
+      Then the manifest abi is "FreeBSD:15:*" (major derived from --abi, CPU wildcarded)
+       And the manifest arch is "freebsd:15:*" (same wildcard, lowercase per the
+           existing arch triplet convention)
+    """
+    ports, portdir = _make_no_arch_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--py-flavor", "py311",
+            "--compression", "xz",
+            "--freebsd-version", "1500068",
+            "--out", str(out),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    full, _, _ = _read_pkg(out / "testpkg-1.0_2.pkg")
+    assert full["abi"] == "FreeBSD:15:*"
+    assert full["arch"] == "freebsd:15:*"
+
+
+def test_end_to_end_no_arch_port_explicit_arch_override_wins(tmp_path: Path) -> None:
+    """An explicit --arch still wins over the NO_ARCH wildcard default (issue #1806 B1).
+
+    The manifest ABI is ALWAYS wildcarded for a NO_ARCH port (it is a fact about the
+    package, probed live against a real Netgate build) — but --arch's existing
+    override precedence (``args.arch or abi_to_arch(abi)``) is preserved: when the
+    caller passes --arch explicitly, that concrete value is used verbatim, never
+    wildcarded.
+
+    Scenario: NO_ARCH port, explicit --arch override
+      When build-pkg-portable.py runs with --abi FreeBSD:15:amd64 --arch freebsd:99:custom
+      Then the manifest abi is STILL "FreeBSD:15:*" (unconditional NO_ARCH fact)
+       And the manifest arch is the EXPLICIT "freebsd:99:custom" (not wildcarded)
+    """
+    ports, portdir = _make_no_arch_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--arch", "freebsd:99:custom",
+            "--py-flavor", "py311",
+            "--compression", "xz",
+            "--freebsd-version", "1500068",
+            "--out", str(out),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    full, _, _ = _read_pkg(out / "testpkg-1.0_2.pkg")
+    assert full["abi"] == "FreeBSD:15:*"
+    assert full["arch"] == "freebsd:99:custom"
+
+
 def test_end_to_end_dynamic_plist_uses_the_staged_payload(tmp_path: Path) -> None:
     ports, portdir = _make_classic_port(tmp_path)
     portdir.joinpath("pkg-plist").unlink()

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -3114,8 +3114,9 @@ def test_cli_release_pkgs_bad_format_errors(tmp_path: Path) -> None:
 # per-arch release_extra_pkgs/release_pkgs candidates.
 #
 # These tests pin:
-#   * the dep lands in BOTH release/<varver>/<arch>/ and nightly/<varver>/<arch>/
-#     of its OWN ABI train (source-build mode + the nightly fold)
+#   * the dep lands in BOTH release/<varver>/ and nightly/<varver>/ (arch-less;
+#     issue #1806 — no <arch> leaf) of its OWN ABI train (source-build mode +
+#     the nightly fold)
 #   * it is ABSENT from a different variant's catalogs (different FreeBSD major)
 #   * it does NOT consume a --release-keep-stable retention slot (folded AFTER
 #     retain_by_channel, not before — the bug this design deliberately avoids:

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -2986,3 +2986,173 @@ def test_cli_release_pkgs_bad_format_errors(tmp_path: Path) -> None:
                 "ce-2.8-no-colon",  # missing ':' separator
             ]
         )
+
+
+# --------------------------------------------------------------------------- #
+# issue #1806 step A2: --dep-pkgs — fold a pre-built dependency .pkg (e.g.
+# py311-charset-normalizer, built by build-dep-pkg-portable.py) into BOTH the
+# release AND nightly catalogs of its matching ABI train, AFTER retention.
+#
+# A NO_ARCH dependency package records a CPU-wildcarded ABI (e.g.
+# "FreeBSD:15:*") — it works on every arch of that FreeBSD major — so the fold
+# matches by OS+major, not exact ABI string equality like the existing
+# per-arch release_extra_pkgs/release_pkgs candidates.
+#
+# These tests pin:
+#   * the dep lands in BOTH release/<varver>/<arch>/ and nightly/<varver>/<arch>/
+#     of its OWN ABI train (source-build mode + the nightly fold)
+#   * it is ABSENT from a different variant's catalogs (different FreeBSD major)
+#   * it does NOT consume a --release-keep-stable retention slot (folded AFTER
+#     retain_by_channel, not before — the bug this design deliberately avoids:
+#     folding pre-retention would let the dep's version compete for the window
+#     and evict a real release) — covers consume mode's fold point
+#   * --dep-pkgs is repeatable (mirrors --release-extra-pkgs's arg style)
+#   * a dep pkg whose ABI matches no emitted catalog is a hard error
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_dep_pkgs_lands_in_release_and_nightly_same_abi_train(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--dep-pkgs folds a NO_ARCH dependency .pkg into BOTH the release and
+    nightly catalogs of its OWN ABI train (CE, FreeBSD 15) and NEITHER of a
+    different variant's catalogs (Plus, FreeBSD 16).
+
+    Scenario: CE + Plus entries, one CE-major dep pkg (source-build mode, the
+              default path with no --release-pkgs/--release-extra-pkgs)
+      Given a py311-charset-normalizer dep .pkg with a NO_ARCH-wildcarded ABI
+            "FreeBSD:15:*" (matches CE's FreeBSD major, not Plus's 16)
+       When brp.main([--build-matrix, --dep-pkgs <path>, ...]) runs for [CE, Plus]
+      Then release/ce-2.8/amd64 AND nightly/ce-2.8/amd64 both list the dep pkg
+       And release/plus-26.03/amd64 and nightly/plus-26.03/amd64 do NOT
+    """
+    _with_stub_builder(monkeypatch)
+
+    dep_dir = tmp_path / "deps"
+    dep_dir.mkdir()
+    dep_pkg = dep_dir / "py311-charset-normalizer-3.4.4.pkg"
+    make_pkg(dep_pkg, name="py311-charset-normalizer", version="3.4.4", abi="FreeBSD:15:*")
+
+    out = tmp_path / "site"
+    mfile = tmp_path / "matrix.json"
+    mfile.write_text(json.dumps({"versions": [_CE, _PLUS]}))
+
+    # Before-state: nothing built yet.
+    assert not out.exists()
+
+    rc = brp.main(
+        [
+            "--build-matrix",
+            "--matrix-json",
+            str(mfile),
+            "--out",
+            str(out),
+            "--dep-pkgs",
+            str(dep_pkg),
+        ]
+    )
+    assert rc == 0
+
+    ce_release = _names_in(out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
+    ce_nightly = _names_in(out / "nightly" / "ce-2.8" / "amd64" / "packagesite.pkg")
+    plus_release = _names_in(out / "release" / "plus-26.03" / "amd64" / "packagesite.pkg")
+    plus_nightly = _names_in(out / "nightly" / "plus-26.03" / "amd64" / "packagesite.pkg")
+
+    assert "py311-charset-normalizer" in ce_release, "dep must land in the release catalog of its own ABI train"
+    assert "py311-charset-normalizer" in ce_nightly, "dep must ALSO land in the nightly catalog of its own ABI train"
+    assert "py311-charset-normalizer" not in plus_release, "dep must be absent from a different FreeBSD major"
+    assert "py311-charset-normalizer" not in plus_nightly, "dep must be absent from a different FreeBSD major"
+
+
+def test_cli_dep_pkgs_flag_is_repeatable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--dep-pkgs is repeatable (mirrors --release-extra-pkgs's arg style):
+    multiple dependency packages all fold into the matching catalog."""
+    _with_stub_builder(monkeypatch)
+
+    dep_dir = tmp_path / "deps"
+    dep_dir.mkdir()
+    dep_a = dep_dir / "py311-charset-normalizer-3.4.4.pkg"
+    make_pkg(dep_a, name="py311-charset-normalizer", version="3.4.4", abi="FreeBSD:15:*")
+    dep_b = dep_dir / "py311-idna-3.7.pkg"
+    make_pkg(dep_b, name="py311-idna", version="3.7", abi="FreeBSD:15:*")
+
+    out = tmp_path / "site"
+    mfile = tmp_path / "matrix.json"
+    mfile.write_text(json.dumps({"versions": [_CE]}))
+
+    rc = brp.main(
+        [
+            "--build-matrix",
+            "--matrix-json",
+            str(mfile),
+            "--out",
+            str(out),
+            "--no-nightly",
+            "--dep-pkgs",
+            str(dep_a),
+            "--dep-pkgs",
+            str(dep_b),
+        ]
+    )
+    assert rc == 0
+    names = _names_in(out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
+    assert {"py311-charset-normalizer", "py311-idna"} <= names
+
+
+def test_dep_pkgs_fold_after_retention_stable_pin_survives(tmp_path: Path) -> None:
+    """--dep-pkgs folds AFTER retain_by_channel — it never competes for a
+    --release-keep-stable slot (consume mode's fold point).
+
+    If the dep pkg were folded BEFORE retention, its version (3.4.4 —
+    numerically higher than the real stable's 3.0.1) would win the keep=1
+    window and EVICT the real pfBlockerNG stable release. It must not.
+
+    Scenario: keep_stable=1, one real stable release, one higher-version dep pkg
+      Given a pfBlockerNG stable .pkg at version 3.0.1 (consume-mode pool)
+        And a py311-charset-normalizer dep .pkg at version 3.4.4 (same ABI train)
+       When build_repo_matrix runs with release_keep_stable=1 (default)
+      Then release/ce-2.8/amd64 lists BOTH the stable pin (3.0.1, intact) AND
+           the dep pkg — the stable pin was never evicted by the dep's higher
+           version number
+    """
+    out = tmp_path / "site"
+    pkg_dir = tmp_path / "pkgs"
+    pkg_dir.mkdir()
+    stable_pkg = pkg_dir / "pfBlockerNG-3.0.1.pkg"
+    make_pkg(stable_pkg, name="pfBlockerNG", version="3.0.1", abi="FreeBSD:15:amd64")
+    dep_pkg = pkg_dir / "py311-charset-normalizer-3.4.4.pkg"
+    make_pkg(dep_pkg, name="py311-charset-normalizer", version="3.4.4", abi="FreeBSD:15:*")
+
+    # Before-state: confirm the dep's version really is higher (the scenario's
+    # premise) — a pre-retention fold would let this version win the window.
+    assert brp._pkg_version_key("3.4.4") > brp._pkg_version_key("3.0.1")
+
+    brp.build_repo_matrix(
+        [_CE],
+        out,
+        builder=_stub_builder,
+        build_nightly=False,
+        release_pkgs={"ce-2.8": [stable_pkg]},
+        dep_pkgs=[dep_pkg],
+    )
+
+    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    names_versions = _names_versions_in_release(rel)
+    assert ("pfBlockerNG", "3.0.1") in names_versions, "the real stable pin must survive intact"
+    assert ("py311-charset-normalizer", "3.4.4") in names_versions, "the dep pkg must still be present"
+    assert len(names_versions) == 2, "no other package should have appeared or been evicted"
+
+
+def test_dep_pkgs_mismatched_abi_raises_hard_error(tmp_path: Path) -> None:
+    """A --dep-pkgs entry whose ABI matches NO emitted catalog is a hard error
+    (never a silent drop) — e.g. built for a FreeBSD major nothing in the
+    matrix targets."""
+    out = tmp_path / "site"
+    pkg_dir = tmp_path / "pkgs"
+    pkg_dir.mkdir()
+    # FreeBSD major 99 never appears in [_CE] (major 15) — matches no catalog.
+    dep_pkg = pkg_dir / "py311-charset-normalizer-3.4.4.pkg"
+    make_pkg(dep_pkg, name="py311-charset-normalizer", version="3.4.4", abi="FreeBSD:99:*")
+
+    with pytest.raises(brp.BuildRepoError, match="dep"):
+        brp.build_repo_matrix([_CE], out, builder=_stub_builder, dep_pkgs=[dep_pkg])

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -465,6 +465,39 @@ def test_unsafe_abi_is_rejected(tmp_path: Path) -> None:
             brp.build_repo(in_dir, out)
 
 
+@pytest.mark.parametrize(
+    ("abi", "expected"),
+    [
+        ("FreeBSD:15:*", True),
+        ("FreeBSD:16:*", True),
+        ("FreeBSD:15:amd64", False),  # concrete — not wildcarded at all
+        ("FreeBSD:*:amd64", False),  # '*' not in the final segment
+        ("*", False),  # bare '*' — not a 3-part ABI
+        ("FreeBSD:15:*extra", False),  # '*' not the WHOLE final segment
+        (None, False),  # non-string
+        (123, False),  # non-string
+    ],
+)
+def test_is_wildcard_abi_tight_shape(abi: object, expected: bool) -> None:
+    """``_is_wildcard_abi`` accepts '*' ONLY as the whole final (CPU) segment —
+    tight, per issue #1806 (a real Netgate NO_ARCH package's manifest ABI)."""
+    assert brp._is_wildcard_abi(abi) is expected
+
+
+def test_pkg_matches_abi_by_os_and_major_only() -> None:
+    """``_pkg_matches_abi`` compares OS+major ONLY — the CPU/arch segment (concrete
+    or wildcarded) never affects the match; a different major never matches."""
+    # A wildcarded manifest matches any row of the same major, any arch.
+    assert brp._pkg_matches_abi({"abi": "FreeBSD:15:*"}, "FreeBSD:15:amd64") is True
+    assert brp._pkg_matches_abi({"abi": "FreeBSD:15:*"}, "FreeBSD:15:aarch64") is True
+    # A concrete manifest also matches by major only (arch segment ignored).
+    assert brp._pkg_matches_abi({"abi": "FreeBSD:15:amd64"}, "FreeBSD:15:aarch64") is True
+    # A different major never matches, wildcard or not.
+    assert brp._pkg_matches_abi({"abi": "FreeBSD:16:*"}, "FreeBSD:15:amd64") is False
+    # A missing/non-string abi never matches.
+    assert brp._pkg_matches_abi({}, "FreeBSD:15:amd64") is False
+
+
 def test_flavor_signature_classifies_dep_names() -> None:
     """The flavor signature picks ONLY php*/python*/py*- dep names, sorted."""
     assert brp._flavor_signature({"deps": {}}) == ""
@@ -800,15 +833,19 @@ def test_nightly_plus_catalog_under_versioned_subdir(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------- #
 # ADR-20 routing rework: the matrix-driven brain (build_repo_matrix + helpers)
 #
-# These pin the LITERAL 1:1 projection of the version matrix onto the tree
-# (release/<varver>/<arch>/ + nightly/<varver>/<arch>/, arch leaf — NOT full ABI),
-# the release channel-group (devel + stable in one catalog), full-matrix/no-dedup
-# placement, and nightly retention. The DUMB pkg builder is stubbed so the tests
-# exercise the BRAIN (arrangement) without a ports tree — build-pkg-portable.py's
-# own behaviour is covered by its own suite.
+# These pin the LITERAL projection of the version matrix onto the tree
+# (release/<varver>/ + nightly/<varver>/ — arch-less since issue #1806: all
+# three pfSense-pkg-pfBlockerNG ports are NO_ARCH, so one varver directory
+# serves every arch of its FreeBSD major), the release channel-group (devel +
+# stable in one catalog), full-matrix/no-dedup placement, and nightly
+# retention. The DUMB pkg builder is stubbed so the tests exercise the BRAIN
+# (arrangement) without a ports tree — build-pkg-portable.py's own behaviour
+# (including the NO_ARCH wildcard stamp) is covered by its own suite.
 # --------------------------------------------------------------------------- #
 
-# The live matrix shape (subset of fields build_repo_matrix consumes).
+# The live matrix shape (subset of fields build_repo_matrix consumes). `arch`
+# still drives which concrete --abi the (stubbed) builder receives per row —
+# it no longer selects a catalog bucket (arch-less; issue #1806).
 _CE = {
     "pfsense_version": "2.8",
     "variant": "CE",
@@ -847,8 +884,11 @@ def _stub_builder(
     """Stand-in for build-pkg-portable.py: drop a libpkg-shaped .pkg, return its path.
 
     The package NAME encodes the channel (so a subtree's catalog reveals which channels
-    landed there); the manifest carries the requested ABI + a versioned php guard dep
-    (so a wrong-flavor mix would trip the collision guard, as in a real build).
+    landed there); the manifest carries a versioned php guard dep (so a wrong-flavor mix
+    would trip the collision guard, as in a real build). The manifest ABI is stamped
+    CPU-WILDCARDED (``FreeBSD:<major>:*``) regardless of the incoming concrete ``abi``'s
+    CPU segment — a real build-pkg-portable.py run does exactly this for a NO_ARCH port
+    (issue #1806 B1), and the catalog now hard-requires it (``_is_wildcard_abi``).
     """
     name = _CHANNEL_NAME[channel]
     version = pkgversion or "1.0_1"
@@ -857,10 +897,12 @@ def _stub_builder(
         php_dep: {"origin": f"lang/{php_dep}", "version": "0"},
         py_flavor: {"origin": f"lang/{py_flavor}", "version": "0"},
     }
+    major = abi.split(":")[1]
+    wildcard_abi = f"FreeBSD:{major}:*"
     # Distinct on-disk filename per (channel, varver, arch) so concurrent staging never clashes;
     # the catalog copies it CANONICALLY as <name>-<version>.pkg regardless.
     out = out_dir / f"{name}-{version}-{varver}-{arch}-{channel}.pkg"
-    make_pkg(out, name=name, version=version, abi=abi, deps=deps)
+    make_pkg(out, name=name, version=version, abi=wildcard_abi, deps=deps)
     return out
 
 
@@ -978,14 +1020,14 @@ def test_retain_by_channel_devel_retains_prerelease_stages_in_pkg_order(tmp_path
     assert "4.0.0.alpha.1" not in kept_versions
 
 
-def test_build_matrix_tree_layout_arch_leaf(tmp_path: Path) -> None:
-    """build_repo_matrix projects the matrix 1:1 with the bare ARCH as the leaf.
+def test_build_matrix_tree_layout_arch_less(tmp_path: Path) -> None:
+    """build_repo_matrix projects the matrix onto an ARCH-LESS tree (issue #1806).
 
     Scenario: a CE + a Plus entry
       Given an empty output root
       When build_repo_matrix runs over [CE, Plus]
-      Then release/ce-2.8/amd64/ and release/plus-26.03/amd64/ catalogs exist
-       And the leaf is the bare arch — NOT the full ABI (no FreeBSD:NN:amd64 dir)
+      Then release/ce-2.8/ and release/plus-26.03/ catalogs exist DIRECTLY
+       And there is NO arch subdirectory, and NO full-ABI subdirectory either
        And the matching nightly subtrees exist
     """
     out = tmp_path / "site"
@@ -994,13 +1036,15 @@ def test_build_matrix_tree_layout_arch_leaf(tmp_path: Path) -> None:
 
     brp.build_repo_matrix([_CE, _PLUS], out, builder=_stub_builder)
 
-    # Arch leaf, version segment implies the FreeBSD major.
-    assert (out / "release" / "ce-2.8" / "amd64" / "meta.conf").is_file()
-    assert (out / "release" / "plus-26.03" / "amd64" / "meta.conf").is_file()
-    assert (out / "nightly" / "ce-2.8" / "amd64" / "meta.conf").is_file()
-    assert (out / "nightly" / "plus-26.03" / "amd64" / "meta.conf").is_file()
-    # The full ABI must NOT appear as a path segment (this is the arch-leaf reconciliation).
+    # The catalog lives directly at release/<varver>/ — no arch leaf.
+    assert (out / "release" / "ce-2.8" / "meta.conf").is_file()
+    assert (out / "release" / "plus-26.03" / "meta.conf").is_file()
+    assert (out / "nightly" / "ce-2.8" / "meta.conf").is_file()
+    assert (out / "nightly" / "plus-26.03" / "meta.conf").is_file()
+    # Neither an arch leaf nor the full ABI ever appears as a path segment.
+    assert not (out / "release" / "ce-2.8" / "amd64").exists()
     assert not (out / "release" / "ce-2.8" / "FreeBSD:15:amd64").exists()
+    assert not (out / "release" / "plus-26.03" / "amd64").exists()
     assert not (out / "release" / "plus-26.03" / "FreeBSD:16:amd64").exists()
 
 
@@ -1009,7 +1053,7 @@ def test_build_matrix_release_holds_devel_and_stable(tmp_path: Path) -> None:
 
     Scenario: stable tag absent -> present (the branch + the before/after)
       Given build_repo_matrix([CE]) with NO stable_tag
-      Then release/ce-2.8/amd64 holds ONLY the devel package
+      Then release/ce-2.8 holds ONLY the devel package
       When re-run WITH stable_tag set
       Then the release catalog holds BOTH the devel and the stable package
     """
@@ -1017,7 +1061,7 @@ def test_build_matrix_release_holds_devel_and_stable(tmp_path: Path) -> None:
 
     # Off branch: no stable tag -> devel only.
     brp.build_repo_matrix([_CE], out, builder=_stub_builder)
-    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    rel = out / "release" / "ce-2.8" / "packagesite.pkg"
     assert _names_in(rel) == {"pfBlockerNG-devel"}
 
     # On branch: a stable tag -> devel + stable coexist in ONE catalog.
@@ -1032,23 +1076,37 @@ def test_build_matrix_full_matrix_no_dedup(tmp_path: Path) -> None:
     out = tmp_path / "site"
     brp.build_repo_matrix([ce_28, ce_29], out, builder=_stub_builder)
     # Distinct version segments, each populated independently.
-    assert (out / "release" / "ce-2.8" / "amd64" / "meta.conf").is_file()
-    assert (out / "release" / "ce-2.9" / "amd64" / "meta.conf").is_file()
+    assert (out / "release" / "ce-2.8" / "meta.conf").is_file()
+    assert (out / "release" / "ce-2.9" / "meta.conf").is_file()
 
 
-def test_build_matrix_aarch64_distinct_leaf(tmp_path: Path) -> None:
-    """An aarch64 Plus entry lands under its own arch leaf, separate from amd64."""
+def test_build_matrix_multi_arch_rows_share_one_varver_catalog(tmp_path: Path) -> None:
+    """Multiple arch rows of the SAME varver converge on ONE catalog (arch-less; issue #1806).
+
+    Before the redesign, an aarch64 Plus entry landed under its own arch leaf,
+    separate from amd64. Under the arch-less contract every arch row of a
+    varver targets the SAME ``release/<varver>/`` directory — there is no
+    per-arch leaf left to be distinct.
+
+    Scenario: a Plus amd64 row + a Plus aarch64 row, same varver
+      When build_repo_matrix runs over [Plus(amd64), Plus(aarch64)]
+      Then exactly ONE release/plus-26.03/ catalog exists (no amd64/aarch64 subdirs)
+       And it carries the (wildcard-ABI) devel package
+    """
     out = tmp_path / "site"
-    brp.build_repo_matrix([_PLUS, _PLUS_ARM], out, builder=_stub_builder)
-    assert (out / "release" / "plus-26.03" / "amd64" / "meta.conf").is_file()
-    assert (out / "release" / "plus-26.03" / "aarch64" / "meta.conf").is_file()
+    brp.build_repo_matrix([_PLUS, _PLUS_ARM], out, builder=_stub_builder, build_nightly=False)
+    rel = out / "release" / "plus-26.03"
+    assert (rel / "meta.conf").is_file()
+    assert not (rel / "amd64").exists()
+    assert not (rel / "aarch64").exists()
+    assert _names_in(rel / "packagesite.pkg") == {"pfBlockerNG-devel"}
 
 
 def test_build_matrix_no_nightly(tmp_path: Path) -> None:
     """build_nightly=False builds the release subtree but NO nightly/ tree."""
     out = tmp_path / "site"
     brp.build_repo_matrix([_CE], out, builder=_stub_builder, build_nightly=False)
-    assert (out / "release" / "ce-2.8" / "amd64" / "meta.conf").is_file()
+    assert (out / "release" / "ce-2.8" / "meta.conf").is_file()
     assert not (out / "nightly").exists()
 
 
@@ -1061,7 +1119,7 @@ def test_build_matrix_nightly_retention(tmp_path: Path) -> None:
        When build #3 (.3) lands -> it is pruned back to 2, keeping the 2 NEWEST (.2, .3)
     """
     out = tmp_path / "site"
-    nl = out / "nightly" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    nl = out / "nightly" / "ce-2.8" / "packagesite.pkg"
 
     def run(counter: int) -> None:
         brp.build_repo_matrix(
@@ -1181,9 +1239,15 @@ def _make_pkg_channel(
     name: str,
     version: str,
     *,
-    abi: str = "FreeBSD:15:amd64",
+    abi: str = "FreeBSD:15:*",
 ) -> Path:
-    """Write a minimal .pkg and return its path (name encodes the channel)."""
+    """Write a minimal .pkg and return its path (name encodes the channel).
+
+    Default ABI is wildcard (NO_ARCH; issue #1806) — most callers feed these
+    paths through build_repo_matrix, whose catalog now hard-requires it. The
+    pure retention-helper tests (_retain_newest/retain_by_channel/_line_pins)
+    never inspect the abi field, so the wildcard default is harmless there too.
+    """
     p = tmp_path / f"{name}-{version}.pkg"
     make_pkg(p, name=name, version=version, abi=abi)
     return p
@@ -1765,7 +1829,7 @@ def test_release_default_is_latest_only(tmp_path: Path) -> None:
 
     brp.build_repo_matrix([_CE], out, builder=_stub_builder, stable_tag="v3.2.15")
 
-    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    rel = out / "release" / "ce-2.8" / "packagesite.pkg"
     assert rel.is_file()
 
     objs = _catalog_objects(rel)
@@ -1793,7 +1857,7 @@ def test_release_subtree_retains_devel_and_stable(tmp_path: Path) -> None:
     """
     extras = tmp_path / "extras"
     extras.mkdir()
-    abi = "FreeBSD:15:amd64"
+    abi = "FreeBSD:15:*"
 
     # 4 pre-built devel candidates (the fresh build will be version "1.0_1" from the
     # stub, so all 4 extras sit below "1.0_1" as older versions). Use 3.0.1..3.0.4 as
@@ -1815,7 +1879,7 @@ def test_release_subtree_retains_devel_and_stable(tmp_path: Path) -> None:
         release_keep_devel=1,
         release_keep_stable=1,
     )
-    rel_before = out_before / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    rel_before = out_before / "release" / "ce-2.8" / "packagesite.pkg"
     objs_before = _catalog_objects(rel_before)
     # 1 window + 1 line pin per channel: the stub's fresh build is version "1.0_1",
     # a major/minor line ("1.0") distinct from the 3.0.x/2.0.x extras, so it survives
@@ -1833,7 +1897,7 @@ def test_release_subtree_retains_devel_and_stable(tmp_path: Path) -> None:
         release_keep_devel=3,
         release_keep_stable=3,
     )
-    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    rel = out / "release" / "ce-2.8" / "packagesite.pkg"
     nv_set = _names_versions_in_release(rel)
 
     # Devel: 3.0.2, 3.0.3, 3.0.4 present; 3.0.1 dropped (4th/oldest).
@@ -1868,7 +1932,7 @@ def test_release_catalog_lists_all_kept_versions(tmp_path: Path) -> None:
     """
     extras = tmp_path / "extras"
     extras.mkdir()
-    abi = "FreeBSD:15:amd64"
+    abi = "FreeBSD:15:*"
 
     # 3 extras each channel; with keep=2 only the newest 2 survive per channel.
     devel_extras = [_make_pkg_channel(extras, "pfBlockerNG-devel", f"3.0.{i}", abi=abi) for i in range(1, 4)]
@@ -1885,7 +1949,7 @@ def test_release_catalog_lists_all_kept_versions(tmp_path: Path) -> None:
         release_keep_stable=2,
     )
 
-    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    rel = out / "release" / "ce-2.8" / "packagesite.pkg"
     objs = _catalog_objects(rel)
 
     # 6 catalog entries: (2-window + 1 line-pin) devel + (2-window + 1 line-pin) stable.
@@ -1995,7 +2059,7 @@ def test_cli_release_extra_pkgs_default_keeps_latest_plus_line_pins(
     )
     assert rc == 0
 
-    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    rel = out / "release" / "ce-2.8" / "packagesite.pkg"
     assert rel.is_file()
     objs = _catalog_objects(rel)
 
@@ -2063,7 +2127,7 @@ def test_cli_release_extra_pkgs_keeps_newest_n(tmp_path: Path, monkeypatch: pyte
         + extra_flags
     )
     assert rc_before == 0
-    before_objs = _catalog_objects(out_before / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
+    before_objs = _catalog_objects(out_before / "release" / "ce-2.8" / "packagesite.pkg")
     before_devel = [o for o in before_objs if o["name"] == "pfBlockerNG-devel"]
     before_stable = [o for o in before_objs if o["name"] == "pfBlockerNG"]
     # No --stable-tag on this CLI path, so only devel gets a fresh build: default
@@ -2090,7 +2154,7 @@ def test_cli_release_extra_pkgs_keeps_newest_n(tmp_path: Path, monkeypatch: pyte
     )
     assert rc == 0
 
-    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    rel = out / "release" / "ce-2.8" / "packagesite.pkg"
     assert rel.is_file()
     objs = _catalog_objects(rel)
     nv = {(o["name"], o["version"]) for o in objs}
@@ -2160,7 +2224,7 @@ def test_cli_release_extra_pkgs_newest_wins(tmp_path: Path, monkeypatch: pytest.
     )
     assert rc == 0
 
-    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    rel = out / "release" / "ce-2.8" / "packagesite.pkg"
     objs = _catalog_objects(rel)
 
     devel_objs = [o for o in objs if o["name"] == "pfBlockerNG-devel"]
@@ -2234,7 +2298,7 @@ def test_route_only_release_catalog_contains_exactly_frozen_pkg(tmp_path: Path) 
     out = tmp_path / "site"
     frozen_pkg = tmp_path / "frozen" / "pfBlockerNG-devel-3.1.0_5.pkg"
     frozen_pkg.parent.mkdir()
-    make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:amd64")
+    make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:*")
 
     # Before-state: no release subtree yet.
     assert not (out / "release" / "ce-2.7").exists()
@@ -2246,7 +2310,7 @@ def test_route_only_release_catalog_contains_exactly_frozen_pkg(tmp_path: Path) 
         route_only_pkgs={"ce-2.7": [frozen_pkg]},
     )
 
-    rel = out / "release" / "ce-2.7" / "amd64" / "packagesite.pkg"
+    rel = out / "release" / "ce-2.7" / "packagesite.pkg"
     assert rel.is_file(), "release catalog must exist for a route-only entry"
     objs = _catalog_objects(rel)
 
@@ -2268,7 +2332,7 @@ def test_route_only_no_nightly_subtree(tmp_path: Path) -> None:
     out = tmp_path / "site"
     frozen_pkg = tmp_path / "frozen" / "pfBlockerNG-devel-3.1.0_5.pkg"
     frozen_pkg.parent.mkdir()
-    make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:amd64")
+    make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:*")
 
     # Before-state: neither nightly subtree exists.
     assert not (out / "nightly" / "ce-2.7").exists()
@@ -2284,7 +2348,7 @@ def test_route_only_no_nightly_subtree(tmp_path: Path) -> None:
     # Route-only entry: NO nightly subtree.
     assert not (out / "nightly" / "ce-2.7").exists(), "route-only must never produce a nightly/"
     # Build entry: nightly subtree present as normal.
-    assert (out / "nightly" / "ce-2.8" / "amd64" / "meta.conf").is_file()
+    assert (out / "nightly" / "ce-2.8" / "meta.conf").is_file()
 
 
 def test_route_only_additive_parity_build_entry_unchanged(tmp_path: Path) -> None:
@@ -2300,12 +2364,12 @@ def test_route_only_additive_parity_build_entry_unchanged(tmp_path: Path) -> Non
     out = tmp_path / "site"
     frozen_ce = tmp_path / "frozen_ce" / "pfBlockerNG-devel-3.1.0_5.pkg"
     frozen_ce.parent.mkdir()
-    make_pkg(frozen_ce, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:amd64")
+    make_pkg(frozen_ce, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:*")
 
     # BEFORE: build-only matrix (CE 2.8 only).
     brp.build_repo_matrix([_CE], out, builder=_stub_builder)
-    rel_before = (out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg").read_bytes()
-    nightly_before = (out / "nightly" / "ce-2.8" / "amd64" / "packagesite.pkg").read_bytes()
+    rel_before = (out / "release" / "ce-2.8" / "packagesite.pkg").read_bytes()
+    nightly_before = (out / "nightly" / "ce-2.8" / "packagesite.pkg").read_bytes()
 
     # AFTER: same matrix + route-only CE 2.7 added.
     brp.build_repo_matrix(
@@ -2314,15 +2378,15 @@ def test_route_only_additive_parity_build_entry_unchanged(tmp_path: Path) -> Non
         builder=_stub_builder,
         route_only_pkgs={"ce-2.7": [frozen_ce]},
     )
-    rel_after = (out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg").read_bytes()
-    nightly_after = (out / "nightly" / "ce-2.8" / "amd64" / "packagesite.pkg").read_bytes()
+    rel_after = (out / "release" / "ce-2.8" / "packagesite.pkg").read_bytes()
+    nightly_after = (out / "nightly" / "ce-2.8" / "packagesite.pkg").read_bytes()
 
     # Build-entry subtrees are byte-identical — route-only is additive, not a regression.
     assert rel_after == rel_before, "route-only must not alter the build entry's release catalog"
     assert nightly_after == nightly_before, "route-only must not alter the build entry's nightly catalog"
 
     # Route-only CE 2.7 release catalog now exists (the additive part).
-    assert (out / "release" / "ce-2.7" / "amd64" / "packagesite.pkg").is_file()
+    assert (out / "release" / "ce-2.7" / "packagesite.pkg").is_file()
 
 
 def test_route_only_ce_and_plus_both_served(tmp_path: Path) -> None:
@@ -2338,11 +2402,11 @@ def test_route_only_ce_and_plus_both_served(tmp_path: Path) -> None:
     out = tmp_path / "site"
     frozen_ce = tmp_path / "frozen_ce" / "pfBlockerNG-devel-3.1.0_5.pkg"
     frozen_ce.parent.mkdir()
-    make_pkg(frozen_ce, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:amd64")
+    make_pkg(frozen_ce, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:*")
 
     frozen_plus = tmp_path / "frozen_plus" / "pfBlockerNG-devel-3.0.9_1.pkg"
     frozen_plus.parent.mkdir()
-    make_pkg(frozen_plus, name="pfBlockerNG-devel", version="3.0.9_1", abi="FreeBSD:15:amd64")
+    make_pkg(frozen_plus, name="pfBlockerNG-devel", version="3.0.9_1", abi="FreeBSD:15:*")
 
     brp.build_repo_matrix(
         [_CE, _CE_EOL, _PLUS_EOL],
@@ -2355,12 +2419,12 @@ def test_route_only_ce_and_plus_both_served(tmp_path: Path) -> None:
     )
 
     # CE route-only: correct frozen version served.
-    ce_objs = _catalog_objects(out / "release" / "ce-2.7" / "amd64" / "packagesite.pkg")
+    ce_objs = _catalog_objects(out / "release" / "ce-2.7" / "packagesite.pkg")
     assert len(ce_objs) == 1
     assert ce_objs[0]["version"] == "3.1.0_5"
 
     # Plus route-only: correct frozen version served.
-    plus_objs = _catalog_objects(out / "release" / "plus-25.03" / "amd64" / "packagesite.pkg")
+    plus_objs = _catalog_objects(out / "release" / "plus-25.03" / "packagesite.pkg")
     assert len(plus_objs) == 1
     assert plus_objs[0]["version"] == "3.0.9_1"
 
@@ -2417,8 +2481,8 @@ def test_route_only_multiple_frozen_pkgs_all_indexed(tmp_path: Path) -> None:
     frozen_dir.mkdir()
     frozen_a = frozen_dir / "pfBlockerNG-devel-3.1.0_4.pkg"
     frozen_b = frozen_dir / "pfBlockerNG-devel-3.1.0_5.pkg"
-    make_pkg(frozen_a, name="pfBlockerNG-devel", version="3.1.0_4", abi="FreeBSD:14:amd64")
-    make_pkg(frozen_b, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:amd64")
+    make_pkg(frozen_a, name="pfBlockerNG-devel", version="3.1.0_4", abi="FreeBSD:14:*")
+    make_pkg(frozen_b, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:*")
 
     brp.build_repo_matrix(
         [_CE_EOL],
@@ -2427,7 +2491,7 @@ def test_route_only_multiple_frozen_pkgs_all_indexed(tmp_path: Path) -> None:
         route_only_pkgs={"ce-2.7": [frozen_a, frozen_b]},
     )
 
-    objs = _catalog_objects(out / "release" / "ce-2.7" / "amd64" / "packagesite.pkg")
+    objs = _catalog_objects(out / "release" / "ce-2.7" / "packagesite.pkg")
     versions = {o["version"] for o in objs}
     assert versions == {"3.1.0_4", "3.1.0_5"}
 
@@ -2446,40 +2510,65 @@ def test_invalid_role_raises_build_repo_error(tmp_path: Path) -> None:
         brp.build_repo_matrix([typo_entry], out, builder=_stub_builder)
 
 
-def test_route_only_frozen_pkg_filtered_by_abi(tmp_path: Path) -> None:
-    """A varver's frozen pool spanning multiple ABIs is filtered per (varver, arch).
+def test_route_only_wildcard_frozen_pkg_serves_all_arch_rows_of_varver(tmp_path: Path) -> None:
+    """ONE wildcard-ABI frozen .pkg serves EVERY arch row of a route-only varver
+    (arch-less; issue #1806) — matched by OS+major, never exact-string.
 
-    Scenario: Plus 25.03 EOL on BOTH amd64 and aarch64 (one varver, two arch entries),
-      route_only_pkgs carrying one frozen .pkg per ABI.
-      Given the pool [plus amd64 .pkg, plus aarch64 .pkg] under "plus-25.03"
-       When build_repo_matrix runs for both arch entries
-      Then release/plus-25.03/amd64 holds ONLY the amd64 .pkg
-       And release/plus-25.03/aarch64 holds ONLY the aarch64 .pkg
-      (a pool dedups by (name, version), so without an ABI filter each arch catalog
-       would cross-contaminate with the other ABI's build).
+    Before the redesign, a per-arch frozen pool was filtered into SEPARATE
+    arch-specific catalogs. Under the arch-less contract there is only ONE
+    release catalog per varver: a single NO_ARCH frozen package serves both
+    the amd64 AND the aarch64 route-only matrix row.
+
+    Scenario: Plus 25.03 EOL on BOTH amd64 and aarch64 (one varver, two arch rows)
+      Given ONE wildcard-ABI (FreeBSD:15:*) frozen .pkg under "plus-25.03"
+       When build_repo_matrix runs for both arch rows
+      Then release/plus-25.03/ (no arch subdir) holds exactly that one package
     """
     out = tmp_path / "site"
     plus_amd64 = {**_PLUS_EOL, "freebsd_major": "15", "arch": "amd64"}
     plus_arm = {**_PLUS_EOL, "freebsd_major": "15", "arch": "aarch64"}
     frozen_dir = tmp_path / "frozen"
     frozen_dir.mkdir()
-    pkg_amd64 = frozen_dir / "plus-amd64.pkg"
-    pkg_arm = frozen_dir / "plus-aarch64.pkg"
-    make_pkg(pkg_amd64, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:15:amd64")
-    make_pkg(pkg_arm, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:15:aarch64")
+    frozen_pkg = frozen_dir / "plus-devel.pkg"
+    make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:15:*")
 
     brp.build_repo_matrix(
         [plus_amd64, plus_arm],
         out,
         builder=_stub_builder,
         build_nightly=False,
-        route_only_pkgs={"plus-25.03": [pkg_amd64, pkg_arm]},
+        route_only_pkgs={"plus-25.03": [frozen_pkg]},
     )
 
-    amd64_objs = _catalog_objects(out / "release" / "plus-25.03" / "amd64" / "packagesite.pkg")
-    arm_objs = _catalog_objects(out / "release" / "plus-25.03" / "aarch64" / "packagesite.pkg")
-    assert [o["abi"] for o in amd64_objs] == ["FreeBSD:15:amd64"]
-    assert [o["abi"] for o in arm_objs] == ["FreeBSD:15:aarch64"]
+    rel = out / "release" / "plus-25.03"
+    assert not (rel / "amd64").exists()
+    assert not (rel / "aarch64").exists()
+    objs = _catalog_objects(rel / "packagesite.pkg")
+    assert [o["abi"] for o in objs] == ["FreeBSD:15:*"]
+    assert [o["version"] for o in objs] == ["3.1.0_5"]
+
+
+def test_route_only_concrete_abi_frozen_pkg_rejected_at_emission(tmp_path: Path) -> None:
+    """A concrete-ABI frozen .pkg is a hard error — the arch-less catalog HARD-REQUIRES
+    a NO_ARCH (wildcard-ABI) package (issue #1806), even for a route-only (frozen
+    EOL) entry: a concrete one would silently install on only one arch.
+
+    Scenario: a concrete FreeBSD:14:amd64 frozen .pkg served via route_only_pkgs
+      When build_repo_matrix runs
+      Then it raises BuildRepoError naming the concrete ABI
+    """
+    out = tmp_path / "site"
+    frozen_pkg = tmp_path / "frozen" / "pfBlockerNG-devel-3.1.0_5.pkg"
+    frozen_pkg.parent.mkdir()
+    make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:amd64")
+
+    with pytest.raises(brp.BuildRepoError, match="NO_ARCH"):
+        brp.build_repo_matrix(
+            [_CE_EOL],
+            out,
+            builder=_stub_builder,
+            route_only_pkgs={"ce-2.7": [frozen_pkg]},
+        )
 
 
 def test_route_only_no_frozen_pkg_for_abi_raises(tmp_path: Path) -> None:
@@ -2524,7 +2613,7 @@ def test_cli_route_only_pkgs_flag_builds_frozen_catalog(tmp_path: Path) -> None:
     frozen_dir = tmp_path / "frozen"
     frozen_dir.mkdir()
     frozen_pkg = frozen_dir / "pfBlockerNG-devel-3.1.0_5.pkg"
-    make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:amd64")
+    make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:*")
 
     matrix_json = json.dumps([_CE_EOL])
     matrix_file = tmp_path / "matrix.json"
@@ -2548,7 +2637,7 @@ def test_cli_route_only_pkgs_flag_builds_frozen_catalog(tmp_path: Path) -> None:
 
     # THEN: CLI exits 0, catalog present, no nightly.
     assert rc == 0
-    catalog = out / "release" / "ce-2.7" / "amd64" / "packagesite.pkg"
+    catalog = out / "release" / "ce-2.7" / "packagesite.pkg"
     assert catalog.is_file(), f"route-only release catalog not emitted: {catalog}"
     objs = _catalog_objects(catalog)
     assert len(objs) == 1
@@ -2570,8 +2659,8 @@ def test_cli_route_only_pkgs_flag_repeatable_for_multiple_frozen(tmp_path: Path)
     frozen_dir.mkdir()
     frozen_a = frozen_dir / "pfBlockerNG-devel-3.1.0_4.pkg"
     frozen_b = frozen_dir / "pfBlockerNG-devel-3.1.0_5.pkg"
-    make_pkg(frozen_a, name="pfBlockerNG-devel", version="3.1.0_4", abi="FreeBSD:14:amd64")
-    make_pkg(frozen_b, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:amd64")
+    make_pkg(frozen_a, name="pfBlockerNG-devel", version="3.1.0_4", abi="FreeBSD:14:*")
+    make_pkg(frozen_b, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:*")
 
     matrix_file = tmp_path / "matrix.json"
     matrix_file.write_text(json.dumps([_CE_EOL]))
@@ -2592,7 +2681,7 @@ def test_cli_route_only_pkgs_flag_repeatable_for_multiple_frozen(tmp_path: Path)
     )
 
     assert rc == 0
-    objs = _catalog_objects(out / "release" / "ce-2.7" / "amd64" / "packagesite.pkg")
+    objs = _catalog_objects(out / "release" / "ce-2.7" / "packagesite.pkg")
     assert {o["version"] for o in objs} == {"3.1.0_4", "3.1.0_5"}
 
 
@@ -2658,7 +2747,7 @@ def test_consume_mode_release_catalog_contains_consumed_pkg(tmp_path: Path) -> N
     pkg_dir = tmp_path / "pkgs"
     pkg_dir.mkdir()
     prebuilt = pkg_dir / "pfBlockerNG-devel-4.0.0_1.pkg"
-    make_pkg(prebuilt, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:amd64")
+    make_pkg(prebuilt, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:*")
 
     # Before-state: no release subtree yet.
     assert not (out / "release" / "ce-2.8").exists()
@@ -2678,7 +2767,7 @@ def test_consume_mode_release_catalog_contains_consumed_pkg(tmp_path: Path) -> N
     )
 
     # Catalog must exist and list the consumed package.
-    catalog = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    catalog = out / "release" / "ce-2.8" / "packagesite.pkg"
     assert catalog.is_file(), "release catalog must exist in consume mode"
     objs = _catalog_objects(catalog)
     assert len(objs) == 1
@@ -2690,25 +2779,26 @@ def test_consume_mode_release_catalog_contains_consumed_pkg(tmp_path: Path) -> N
     assert "stable" not in builder_calls, "builder must not be called for stable in consume mode"
 
 
-def test_consume_mode_abi_filter_yields_arch_specific_catalogs(tmp_path: Path) -> None:
-    """A mixed-ABI pool filtered per (varver, arch) yields separate arch-specific catalogs.
+def test_consume_mode_wildcard_pkg_serves_all_arch_rows_of_varver(tmp_path: Path) -> None:
+    """ONE wildcard-ABI pool entry serves EVERY arch row of a varver (arch-less; issue #1806).
 
-    Scenario: Plus 26.03 on amd64 + aarch64 (two arch entries, one varver)
-      Given a pool with one amd64 .pkg and one aarch64 .pkg under "plus-26.03"
+    Before the redesign, a mixed-ABI pool was filtered per (varver, arch) into
+    SEPARATE arch-specific catalogs. Under the arch-less contract there is only
+    ONE catalog per varver — a single NO_ARCH package (matched by OS+major)
+    serves both the amd64 AND the aarch64 matrix row.
+
+    Scenario: Plus 26.03 on amd64 + aarch64 (two arch rows, one varver)
+      Given a pool with ONE wildcard-ABI (FreeBSD:16:*) devel .pkg under "plus-26.03"
        When build_repo_matrix runs for both _PLUS (amd64) + _PLUS_ARM (aarch64)
-      Then release/plus-26.03/amd64/ holds ONLY the amd64 .pkg
-       And release/plus-26.03/aarch64/ holds ONLY the aarch64 .pkg
-      (without ABI filter each catalog would cross-contaminate with the other ABI's build)
+      Then release/plus-26.03/ (no arch subdir) holds exactly that one package
     """
     out = tmp_path / "site"
     pkg_dir = tmp_path / "pkgs"
     pkg_dir.mkdir()
-    pkg_amd64 = pkg_dir / "pfBlockerNG-devel-4.0.0_1-amd64.pkg"
-    pkg_aarch64 = pkg_dir / "pfBlockerNG-devel-4.0.0_1-aarch64.pkg"
-    make_pkg(pkg_amd64, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:16:amd64")
-    make_pkg(pkg_aarch64, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:16:aarch64")
+    pkg = pkg_dir / "pfBlockerNG-devel-4.0.0_1.pkg"
+    make_pkg(pkg, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:16:*")
 
-    # Before-state: no catalogs exist.
+    # Before-state: no catalog exists.
     assert not (out / "release" / "plus-26.03").exists()
 
     brp.build_repo_matrix(
@@ -2716,15 +2806,40 @@ def test_consume_mode_abi_filter_yields_arch_specific_catalogs(tmp_path: Path) -
         out,
         builder=_stub_builder,
         build_nightly=False,
-        release_pkgs={"plus-26.03": [pkg_amd64, pkg_aarch64]},
+        release_pkgs={"plus-26.03": [pkg]},
     )
 
-    amd64_objs = _catalog_objects(out / "release" / "plus-26.03" / "amd64" / "packagesite.pkg")
-    arm_objs = _catalog_objects(out / "release" / "plus-26.03" / "aarch64" / "packagesite.pkg")
+    rel = out / "release" / "plus-26.03"
+    assert not (rel / "amd64").exists()
+    assert not (rel / "aarch64").exists()
+    objs = _catalog_objects(rel / "packagesite.pkg")
+    assert [o["abi"] for o in objs] == ["FreeBSD:16:*"]
+    assert [o["version"] for o in objs] == ["4.0.0_1"]
 
-    # Each arch catalog contains ONLY its own ABI's package.
-    assert [o["abi"] for o in amd64_objs] == ["FreeBSD:16:amd64"]
-    assert [o["abi"] for o in arm_objs] == ["FreeBSD:16:aarch64"]
+
+def test_consume_mode_concrete_abi_pkg_rejected_at_emission(tmp_path: Path) -> None:
+    """A concrete-ABI pool entry is a hard error — the arch-less catalog HARD-REQUIRES
+    a NO_ARCH (wildcard-ABI) package (issue #1806): a concrete one would silently
+    install on only one arch.
+
+    Scenario: a concrete FreeBSD:16:amd64 devel .pkg served via release_pkgs
+      When build_repo_matrix runs
+      Then it raises BuildRepoError naming the concrete ABI
+    """
+    out = tmp_path / "site"
+    pkg_dir = tmp_path / "pkgs"
+    pkg_dir.mkdir()
+    pkg = pkg_dir / "pfBlockerNG-devel-4.0.0_1.pkg"
+    make_pkg(pkg, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:16:amd64")
+
+    with pytest.raises(brp.BuildRepoError, match="NO_ARCH"):
+        brp.build_repo_matrix(
+            [_PLUS],
+            out,
+            builder=_stub_builder,
+            build_nightly=False,
+            release_pkgs={"plus-26.03": [pkg]},
+        )
 
 
 def test_consume_mode_devel_and_stable_both_retained(tmp_path: Path) -> None:
@@ -2741,9 +2856,9 @@ def test_consume_mode_devel_and_stable_both_retained(tmp_path: Path) -> None:
     devel_pkg = pkg_dir / "pfBlockerNG-devel-4.0.0_1.pkg"
     stable_pkg = pkg_dir / "pfBlockerNG-4.0.0.pkg"
     # devel channel: name ends in "-devel" (retain_by_channel uses the name to classify)
-    make_pkg(devel_pkg, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:amd64")
+    make_pkg(devel_pkg, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:*")
     # stable channel: base name without "-devel" suffix
-    make_pkg(stable_pkg, name="pfBlockerNG", version="4.0.0", abi="FreeBSD:15:amd64")
+    make_pkg(stable_pkg, name="pfBlockerNG", version="4.0.0", abi="FreeBSD:15:*")
 
     # Before-state: no release catalog.
     assert not (out / "release" / "ce-2.8").exists()
@@ -2756,7 +2871,7 @@ def test_consume_mode_devel_and_stable_both_retained(tmp_path: Path) -> None:
         release_pkgs={"ce-2.8": [devel_pkg, stable_pkg]},
     )
 
-    catalog = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    catalog = out / "release" / "ce-2.8" / "packagesite.pkg"
     assert catalog.is_file()
     objs = _catalog_objects(catalog)
     names = {o["name"] for o in objs}
@@ -2770,14 +2885,14 @@ def test_consume_mode_devel_and_stable_both_retained(tmp_path: Path) -> None:
 def test_consume_mode_release_extra_pkgs_abi_filtered(tmp_path: Path) -> None:
     """release_extra_pkgs is ABI-filtered before channel retention in consume mode.
 
-    Scenario: a wrong-ABI extra with a HIGHER version must not contaminate this arch's catalog
-      Given a ce-2.8 amd64 entry, a correct-ABI devel pkg in the pool, and release_extra_pkgs
-            carrying a correct-ABI stable pkg PLUS a wrong-ABI (FreeBSD:16) devel pkg whose
-            version (9.9.9) is higher than the pool's devel (4.0.0_1)
+    Scenario: a wrong-major extra with a HIGHER version must not contaminate this catalog
+      Given a ce-2.8 (FreeBSD major 15) entry, a correct-major devel pkg in the pool, and
+            release_extra_pkgs carrying a correct-major stable pkg PLUS a wrong-major
+            (FreeBSD:16) devel pkg whose version (9.9.9) is higher than the pool's devel (4.0.0_1)
        When build_repo_matrix runs in consume mode (keep_devel=1, keep_stable=1)
-      Then the release catalog holds ONLY the FreeBSD:15:amd64 packages — the higher-version
-           wrong-ABI devel is excluded by the ABI filter, not retained over the right-ABI devel
-           (without the filter, retain_by_channel would pick the 9.9.9 wrong-ABI devel).
+      Then the release catalog holds ONLY the FreeBSD:15:* packages — the higher-version
+           wrong-major devel is excluded by the ABI filter, not retained over the right-major devel
+           (without the filter, retain_by_channel would pick the 9.9.9 wrong-major devel).
     """
     out = tmp_path / "site"
     pkg_dir = tmp_path / "pkgs"
@@ -2785,9 +2900,9 @@ def test_consume_mode_release_extra_pkgs_abi_filtered(tmp_path: Path) -> None:
     devel_pkg = pkg_dir / "pfBlockerNG-devel-4.0.0_1.pkg"
     stable_extra = pkg_dir / "pfBlockerNG-4.0.0.pkg"
     wrong_abi_devel = pkg_dir / "pfBlockerNG-devel-9.9.9.pkg"
-    make_pkg(devel_pkg, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:amd64")
-    make_pkg(stable_extra, name="pfBlockerNG", version="4.0.0", abi="FreeBSD:15:amd64")
-    make_pkg(wrong_abi_devel, name="pfBlockerNG-devel", version="9.9.9", abi="FreeBSD:16:amd64")
+    make_pkg(devel_pkg, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:*")
+    make_pkg(stable_extra, name="pfBlockerNG", version="4.0.0", abi="FreeBSD:15:*")
+    make_pkg(wrong_abi_devel, name="pfBlockerNG-devel", version="9.9.9", abi="FreeBSD:16:*")
 
     assert not (out / "release" / "ce-2.8").exists()
 
@@ -2800,10 +2915,10 @@ def test_consume_mode_release_extra_pkgs_abi_filtered(tmp_path: Path) -> None:
         release_extra_pkgs=[stable_extra, wrong_abi_devel],
     )
 
-    objs = _catalog_objects(out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
+    objs = _catalog_objects(out / "release" / "ce-2.8" / "packagesite.pkg")
     abis = {o["abi"] for o in objs}
     versions = {(o["name"], o["version"]) for o in objs}
-    assert abis == {"FreeBSD:15:amd64"}, "only this arch's ABI may appear in the catalog"
+    assert abis == {"FreeBSD:15:*"}, "only this major's ABI may appear in the catalog"
     assert ("pfBlockerNG-devel", "4.0.0_1") in versions, "right-ABI devel must be kept"
     assert ("pfBlockerNG", "4.0.0") in versions, "right-ABI stable extra must be kept"
     assert ("pfBlockerNG-devel", "9.9.9") not in versions, "wrong-ABI extra must be filtered out"
@@ -2836,11 +2951,11 @@ def test_consume_mode_empty_pool_skips_release_catalog_no_exception(tmp_path: Pa
     )
 
     # Release catalog must NOT be emitted for an empty pool.
-    release_catalog = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    release_catalog = out / "release" / "ce-2.8" / "packagesite.pkg"
     assert not release_catalog.exists(), "release catalog must not be emitted for empty pool"
 
     # Nightly must still be built.
-    nightly_catalog = out / "nightly" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    nightly_catalog = out / "nightly" / "ce-2.8" / "packagesite.pkg"
     assert nightly_catalog.is_file(), "nightly catalog must still be built in consume mode"
 
 
@@ -2858,7 +2973,7 @@ def test_consume_mode_nightly_still_built_from_source(tmp_path: Path) -> None:
     pkg_dir = tmp_path / "pkgs"
     pkg_dir.mkdir()
     prebuilt = pkg_dir / "pfBlockerNG-devel-4.0.0_1.pkg"
-    make_pkg(prebuilt, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:amd64")
+    make_pkg(prebuilt, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:*")
 
     builder_channels: list[str] = []
 
@@ -2879,10 +2994,10 @@ def test_consume_mode_nightly_still_built_from_source(tmp_path: Path) -> None:
     assert "devel" not in builder_channels, "builder must NOT be called for devel in consume mode"
 
     # Nightly catalog exists.
-    assert (out / "nightly" / "ce-2.8" / "amd64" / "packagesite.pkg").is_file()
+    assert (out / "nightly" / "ce-2.8" / "packagesite.pkg").is_file()
 
     # Release catalog exists and lists the consumed pkg (not the nightly build).
-    rel_objs = _catalog_objects(out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
+    rel_objs = _catalog_objects(out / "release" / "ce-2.8" / "packagesite.pkg")
     assert len(rel_objs) == 1
     assert rel_objs[0]["name"] == "pfBlockerNG-devel"
     assert rel_objs[0]["version"] == "4.0.0_1"
@@ -2909,11 +3024,11 @@ def test_consume_mode_none_reproduces_source_build_path(tmp_path: Path) -> None:
     brp.build_repo_matrix([_CE], out, builder=_stub_builder)
 
     # Both subtrees present, built from source via stub.
-    assert (out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg").is_file()
-    assert (out / "nightly" / "ce-2.8" / "amd64" / "packagesite.pkg").is_file()
+    assert (out / "release" / "ce-2.8" / "packagesite.pkg").is_file()
+    assert (out / "nightly" / "ce-2.8" / "packagesite.pkg").is_file()
 
     # Verify the catalog lists the stub-built devel package (confirms source-build path ran).
-    rel_objs = _catalog_objects(out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
+    rel_objs = _catalog_objects(out / "release" / "ce-2.8" / "packagesite.pkg")
     assert any(o["name"] == "pfBlockerNG-devel" for o in rel_objs), (
         "devel package from stub builder must appear in release catalog on source-build path"
     )
@@ -2933,7 +3048,7 @@ def test_cli_release_pkgs_flag_serves_consumed_catalog(tmp_path: Path) -> None:
     pkg_dir = tmp_path / "pkgs"
     pkg_dir.mkdir()
     prebuilt = pkg_dir / "pfBlockerNG-devel-4.0.0_1.pkg"
-    make_pkg(prebuilt, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:amd64")
+    make_pkg(prebuilt, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:15:*")
 
     matrix_file = tmp_path / "matrix.json"
     matrix_file.write_text(json.dumps([_CE]))
@@ -2955,7 +3070,7 @@ def test_cli_release_pkgs_flag_serves_consumed_catalog(tmp_path: Path) -> None:
     )
 
     assert rc == 0
-    catalog = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    catalog = out / "release" / "ce-2.8" / "packagesite.pkg"
     assert catalog.is_file(), f"consumed release catalog not emitted: {catalog}"
     objs = _catalog_objects(catalog)
     assert len(objs) == 1
@@ -3053,10 +3168,10 @@ def test_cli_dep_pkgs_lands_in_release_and_nightly_same_abi_train(
     )
     assert rc == 0
 
-    ce_release = _names_in(out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
-    ce_nightly = _names_in(out / "nightly" / "ce-2.8" / "amd64" / "packagesite.pkg")
-    plus_release = _names_in(out / "release" / "plus-26.03" / "amd64" / "packagesite.pkg")
-    plus_nightly = _names_in(out / "nightly" / "plus-26.03" / "amd64" / "packagesite.pkg")
+    ce_release = _names_in(out / "release" / "ce-2.8" / "packagesite.pkg")
+    ce_nightly = _names_in(out / "nightly" / "ce-2.8" / "packagesite.pkg")
+    plus_release = _names_in(out / "release" / "plus-26.03" / "packagesite.pkg")
+    plus_nightly = _names_in(out / "nightly" / "plus-26.03" / "packagesite.pkg")
 
     assert "py311-charset-normalizer" in ce_release, "dep must land in the release catalog of its own ABI train"
     assert "py311-charset-normalizer" in ce_nightly, "dep must ALSO land in the nightly catalog of its own ABI train"
@@ -3095,7 +3210,7 @@ def test_cli_dep_pkgs_flag_is_repeatable(tmp_path: Path, monkeypatch: pytest.Mon
         ]
     )
     assert rc == 0
-    names = _names_in(out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg")
+    names = _names_in(out / "release" / "ce-2.8" / "packagesite.pkg")
     assert {"py311-charset-normalizer", "py311-idna"} <= names
 
 
@@ -3103,15 +3218,23 @@ def test_dep_pkgs_fold_after_retention_stable_pin_survives(tmp_path: Path) -> No
     """--dep-pkgs folds AFTER retain_by_channel — it never competes for a
     --release-keep-stable slot (consume mode's fold point).
 
-    If the dep pkg were folded BEFORE retention, its version (3.4.4 —
-    numerically higher than the real stable's 3.0.1) would win the keep=1
-    window and EVICT the real pfBlockerNG stable release. It must not.
+    issue #1806 gate-A finding: the ORIGINAL version of this test used a dep
+    version (3.4.4) on a DIFFERENT major/minor line ("3.4") than the real
+    stable's (3.0.1, line "3.0") — vacuous, because ``_line_pins`` pins the
+    newest package of EVERY line on top of the retention window regardless of
+    fold order, so the stable pin would survive even under a (buggy)
+    pre-retention fold. This version uses a dep version on the SAME line
+    ("3.0") as the real stable, which DOES discriminate: proven below by
+    directly simulating a pre-retention fold via ``retain_by_channel`` and
+    showing it evicts the real stable pin (a real production bug would look
+    like this) — then showing ``build_repo_matrix``'s actual AFTER-retention
+    fold point does not.
 
-    Scenario: keep_stable=1, one real stable release, one higher-version dep pkg
+    Scenario: keep_stable=1, one real stable release, one same-line dep pkg
       Given a pfBlockerNG stable .pkg at version 3.0.1 (consume-mode pool)
-        And a py311-charset-normalizer dep .pkg at version 3.4.4 (same ABI train)
+        And a py311-charset-normalizer dep .pkg at version 3.0.5 (SAME line "3.0")
        When build_repo_matrix runs with release_keep_stable=1 (default)
-      Then release/ce-2.8/amd64 lists BOTH the stable pin (3.0.1, intact) AND
+      Then release/ce-2.8 lists BOTH the stable pin (3.0.1, intact) AND
            the dep pkg — the stable pin was never evicted by the dep's higher
            version number
     """
@@ -3119,14 +3242,29 @@ def test_dep_pkgs_fold_after_retention_stable_pin_survives(tmp_path: Path) -> No
     pkg_dir = tmp_path / "pkgs"
     pkg_dir.mkdir()
     stable_pkg = pkg_dir / "pfBlockerNG-3.0.1.pkg"
-    make_pkg(stable_pkg, name="pfBlockerNG", version="3.0.1", abi="FreeBSD:15:amd64")
-    dep_pkg = pkg_dir / "py311-charset-normalizer-3.4.4.pkg"
-    make_pkg(dep_pkg, name="py311-charset-normalizer", version="3.4.4", abi="FreeBSD:15:*")
+    make_pkg(stable_pkg, name="pfBlockerNG", version="3.0.1", abi="FreeBSD:15:*")
+    dep_pkg = pkg_dir / "py311-charset-normalizer-3.0.5.pkg"
+    make_pkg(dep_pkg, name="py311-charset-normalizer", version="3.0.5", abi="FreeBSD:15:*")
 
-    # Before-state: confirm the dep's version really is higher (the scenario's
-    # premise) — a pre-retention fold would let this version win the window.
-    assert brp._pkg_version_key("3.4.4") > brp._pkg_version_key("3.0.1")
+    # Before-state: confirm the dep's version really is higher AND on the SAME
+    # major/minor line as the stable's — the scenario's discriminating premise.
+    assert brp._pkg_version_key("3.0.5") > brp._pkg_version_key("3.0.1")
+    assert brp._line_key("3.0.5", "dep") == brp._line_key("3.0.1", "stable") == "3.0"
 
+    # Simulated pre-retention fold (the bug this design deliberately avoids):
+    # folding the dep into the candidate pool BEFORE retain_by_channel runs lets
+    # its higher version win the keep=1 window; the line-pin logic then finds
+    # NOTHING left outside the window for line "3.0" (the dep IS that line's
+    # newest) — so the real stable pin is evicted. This proves the scenario
+    # actually discriminates between fold-before and fold-after.
+    pre_retention_result = brp.retain_by_channel([stable_pkg, dep_pkg], keep_devel=1, keep_stable=1)
+    pre_retention_versions = {brp.read_compact_manifest(p)["version"] for p in pre_retention_result}
+    assert "3.0.1" not in pre_retention_versions, (
+        "simulated pre-retention fold must evict the stable pin (proves the scenario discriminates)"
+    )
+
+    # The ACTUAL production fold point: dep_pkgs never enters retain_by_channel's
+    # candidate pool — it folds in strictly AFTER, so the stable pin is untouched.
     brp.build_repo_matrix(
         [_CE],
         out,
@@ -3136,10 +3274,10 @@ def test_dep_pkgs_fold_after_retention_stable_pin_survives(tmp_path: Path) -> No
         dep_pkgs=[dep_pkg],
     )
 
-    rel = out / "release" / "ce-2.8" / "amd64" / "packagesite.pkg"
+    rel = out / "release" / "ce-2.8" / "packagesite.pkg"
     names_versions = _names_versions_in_release(rel)
     assert ("pfBlockerNG", "3.0.1") in names_versions, "the real stable pin must survive intact"
-    assert ("py311-charset-normalizer", "3.4.4") in names_versions, "the dep pkg must still be present"
+    assert ("py311-charset-normalizer", "3.0.5") in names_versions, "the dep pkg must still be present"
     assert len(names_versions) == 2, "no other package should have appeared or been evicted"
 
 
@@ -3156,3 +3294,92 @@ def test_dep_pkgs_mismatched_abi_raises_hard_error(tmp_path: Path) -> None:
 
     with pytest.raises(brp.BuildRepoError, match="dep"):
         brp.build_repo_matrix([_CE], out, builder=_stub_builder, dep_pkgs=[dep_pkg])
+
+
+def test_dep_pkgs_matched_but_never_emitted_still_raises(tmp_path: Path) -> None:
+    """issue #1806 gate-A finding: a dep whose ABI MATCHES a row must still raise
+    if it never actually lands in an EMITTED catalog for that row — a matched-but-
+    unemitted dep is exactly as silent a drop as an unmatched one.
+
+    The gap: ``dep_pkgs_matched`` was updated unconditionally the moment a dep's
+    ABI matched a row's major, even on the consume-mode branch that can skip
+    emitting the release catalog entirely (an empty pool -> ``if kept_release:``
+    warns and skips). Combined with ``build_nightly=False`` on that SAME entry,
+    the dep landed in NEITHER catalog, yet was marked "matched" — so the
+    end-of-run unmatched check never fired. The fix tracks ``dep_pkgs_matched``
+    only at each site that actually folds the dep into an emitted catalog.
+
+    Scenario: consume mode, EMPTY pool (release skipped), nightly off
+      Given the CE 2.8 entry, release_pkgs={"ce-2.8": []} (nothing serves this
+            major, so kept_release is empty and the release catalog is skipped)
+        And build_nightly=False (no nightly catalog either)
+        And a dep pkg whose ABI matches CE 2.8's major (FreeBSD:15)
+       When build_repo_matrix runs
+      Then it raises BuildRepoError — the dep never landed in ANY catalog, even
+           though its ABI matched this entry
+    """
+    out = tmp_path / "site"
+    pkg_dir = tmp_path / "pkgs"
+    pkg_dir.mkdir()
+    dep_pkg = pkg_dir / "py311-charset-normalizer-3.4.4.pkg"
+    make_pkg(dep_pkg, name="py311-charset-normalizer", version="3.4.4", abi="FreeBSD:15:*")
+
+    with pytest.raises(brp.BuildRepoError, match="dep"):
+        brp.build_repo_matrix(
+            [_CE],
+            out,
+            builder=_stub_builder,
+            build_nightly=False,
+            release_pkgs={"ce-2.8": []},  # empty pool -> kept_release empty -> release skipped
+            dep_pkgs=[dep_pkg],
+        )
+
+
+def test_dep_pkgs_route_only_entry_never_folds_dep_shared_major_build_entry_does(
+    tmp_path: Path,
+) -> None:
+    """A route-only (frozen EOL) entry NEVER receives a dep pkg, even when it shares
+    its FreeBSD major with a build entry that DOES (issue #1806 coverage gap: B0.3).
+
+    Scenario: a route-only CE 2.7 entry (FreeBSD major 15) + a build Plus entry
+              ALSO on FreeBSD major 15, one dep pkg wildcarded to FreeBSD:15:*
+      Given a frozen CE 2.7 .pkg served via route_only_pkgs
+        And a py311-charset-normalizer dep pkg matching major 15 by OS+major
+       When build_repo_matrix runs over [route-only CE 2.7, build Plus-on-15]
+      Then the dep lands in the BUILD entry's release catalog (release/plus-15/)
+       And the route-only entry's release catalog (release/ce-2.7/) holds ONLY
+           the frozen .pkg — never the dep
+       And no error is raised (the dep WAS emitted somewhere)
+    """
+    out = tmp_path / "site"
+    frozen_pkg = tmp_path / "frozen" / "pfBlockerNG-devel-3.1.0_5.pkg"
+    frozen_pkg.parent.mkdir()
+    make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:15:*")
+
+    dep_pkg = tmp_path / "py311-charset-normalizer-3.4.4.pkg"
+    make_pkg(dep_pkg, name="py311-charset-normalizer", version="3.4.4", abi="FreeBSD:15:*")
+
+    # A route-only entry pinned to major 15 (CE 2.7 is major 14 by default; override
+    # so it shares its major with the build entry below) + a build entry that shares
+    # that SAME major (hypothetical: a Plus edition also targeting major 15).
+    ce_eol_on_15 = {**_CE_EOL, "freebsd_major": "15"}
+    plus_on_15 = {**_PLUS, "pfsense_version": "15.0", "freebsd_major": "15"}
+
+    brp.build_repo_matrix(
+        [ce_eol_on_15, plus_on_15],
+        out,
+        builder=_stub_builder,
+        build_nightly=False,
+        route_only_pkgs={"ce-2.7": [frozen_pkg]},
+        dep_pkgs=[dep_pkg],
+    )
+
+    # Build entry: dep folded in alongside the fresh devel build.
+    build_names = _names_in(out / "release" / "plus-15.0" / "packagesite.pkg")
+    assert "py311-charset-normalizer" in build_names, "dep must land in the build entry's release catalog"
+
+    # Route-only entry: frozen .pkg ONLY — the dep must never be folded in.
+    route_only_objs = _catalog_objects(out / "release" / "ce-2.7" / "packagesite.pkg")
+    assert {o["name"] for o in route_only_objs} == {"pfBlockerNG-devel"}, (
+        "a route-only entry must never receive a dep pkg, even sharing a major with a build entry"
+    )

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -323,6 +323,35 @@ def test_build_edition_sections_splits_and_shares_abi_across_versions() -> None:
     assert (ce_29["pfsense_version"], ce_29["php"], ce_29["py"]) == ("2.9", "8.4", "3.11")
 
 
+def test_build_edition_sections_wildcard_abi_joins_every_row_of_its_major() -> None:
+    """A NO_ARCH package's manifest ABI is CPU-wildcarded (issue #1806, e.g.
+    "FreeBSD:16:*") — it must join the matrix by OS+major, landing under EVERY
+    edition/arch row of that major, never dropping to the unmatched "Other"
+    section (the bug: an exact-string join misses it entirely).
+
+    Scenario: one wildcard-ABI devel build, matrix has CE 2.9 (FreeBSD 16 amd64)
+              AND Plus 26.03 (FreeBSD 16 amd64) — both major 16
+      Given a devel .pkg whose manifest abi is "FreeBSD:16:*"
+       When the edition sections are built
+      Then it appears under BOTH CE and Plus (not "Other"), each carrying that
+           edition's own matrix-joined pfSense version/php/py
+    """
+    p_wild = _pkg("devel", "d", "3.2.16", "FreeBSD:16:*", "w.pkg")
+    matrix = [
+        _mx("FreeBSD:16:amd64", "2.9", "CE", "8.4", "py311"),
+        _mx("FreeBSD:16:amd64", "26.03", "Plus", "8.5", "py312"),
+    ]
+
+    sections = dict(gl.build_edition_sections([p_wild], matrix))
+
+    assert "Other" not in sections, "a wildcard-ABI build must join the matrix, never fall to Other"
+    assert set(sections) == {"CE", "Plus"}
+    ce = sections["CE"][0]
+    assert (ce["pfsense_version"], ce["php"], ce["py"]) == ("2.9", "8.4", "3.11")
+    plus = sections["Plus"][0]
+    assert (plus["pfsense_version"], plus["php"], plus["py"]) == ("26.03", "8.5", "3.12")
+
+
 def test_older_nightlies_lists_retained_excludes_latest() -> None:
     """Scenario: surface the retained older nightlies, never the current one.
 
@@ -771,15 +800,15 @@ def _mx_eol(abi: str, ver: str, variant: str, php: str, py: str) -> dict[str, st
 def _eol_pkg(version: str, abi: str, varver: str) -> dict[str, Any]:
     """A package row as collect_packages would produce for a route-only (EOL) catalog entry.
 
-    rel is under release/<varver>/<arch>/ — exactly where build-repo-portable.py places them.
+    rel is DIRECTLY under release/<varver>/ — arch-less (issue #1806 NO_ARCH), exactly
+    where build-repo-portable.py places them.
     """
-    arch = abi.split(":")[-1]
     return {
         "channel": "stable",
         "name": "pfSense-pkg-pfBlockerNG",
         "version": version,
         "abi": abi,
-        "rel": f"release/{varver}/{arch}/pfSense-pkg-pfBlockerNG-{version}.pkg",
+        "rel": f"release/{varver}/pfSense-pkg-pfBlockerNG-{version}.pkg",
         "size": 42,
         "published": "2026-01-10 08:00 UTC",
         "commit": "aabbcc1122334455667788990011223344556677",
@@ -844,6 +873,28 @@ def test_eol_versions_lists_newest_served_pkg_per_eol_version() -> None:
     # Live build version never appears in the EOL result.
     all_versions = {r["version"] for _, _, r in result}
     assert "3.2.16" not in all_versions
+
+
+def test_eol_versions_wildcard_served_pkg_matches_concrete_matrix_entry() -> None:
+    """A served EOL .pkg with a NO_ARCH (wildcard) manifest ABI still joins a
+    route-only matrix entry recorded with a CONCRETE ABI (issue #1806) — matched
+    by OS+major, never exact-string equality.
+
+    Scenario: route-only CE 2.7 (matrix records concrete FreeBSD:14:amd64), but
+              the actually-served .pkg is wildcard-ABI'd (FreeBSD:14:*)
+      When eol_versions is called
+      Then CE 2.7 still appears, carrying the served (wildcard-ABI) package
+    """
+    eol_pkg = _eol_pkg("3.1.0_5", "FreeBSD:14:*", "ce-2.7")
+    matrix = [_mx_eol("FreeBSD:14:amd64", "2.7", "CE", "8.2", "py311")]
+
+    result = gl.eol_versions([eol_pkg], matrix)
+
+    assert len(result) == 1
+    ekey, ver, row = result[0]
+    assert ekey == "CE"
+    assert ver == "2.7"
+    assert row["version"] == "3.1.0_5"
 
 
 def test_eol_versions_ce_and_plus_split_into_separate_tables() -> None:
@@ -977,17 +1028,18 @@ def test_conf_via_addrepo_matches_real_add_repo_contract() -> None:
     addrepo: str = str(Path(__file__).resolve().parent.parent / "scripts" / "add-repo.sh")
     base: str = "https://pfblockerng.github.io/pkg"
 
-    # release channel: repo name `pfblockerng` and URL contains /release/<varver>/<arch>
+    # release channel: repo name `pfblockerng` and URL contains /release/<varver>
+    # (arch-less; issue #1806 NO_ARCH)
     release_conf: str = gl._conf_via_addrepo(addrepo, base, "release")
     assert release_conf, "release conf must be non-empty"
     assert "pfblockerng: {" in release_conf
-    assert f"{base}/release/<varver>/<arch>" in release_conf
+    assert f"{base}/release/<varver>" in release_conf
 
-    # nightly channel: repo name `pfblockerng-nightly` and URL contains /nightly/<varver>/<arch>
+    # nightly channel: repo name `pfblockerng-nightly` and URL contains /nightly/<varver>
     nightly_conf: str = gl._conf_via_addrepo(addrepo, base, "nightly")
     assert nightly_conf, "nightly conf must be non-empty"
     assert "pfblockerng-nightly: {" in nightly_conf
-    assert f"{base}/nightly/<varver>/<arch>" in nightly_conf
+    assert f"{base}/nightly/<varver>" in nightly_conf
 
 
 # ── Piped-invocation: published add-repo.sh embeds hook + installs correctly ─

--- a/tests/test_matrix_collision_guard.py
+++ b/tests/test_matrix_collision_guard.py
@@ -1,19 +1,23 @@
 """Matrix collision guard — fail closed on ambiguous varver keying.
 
-ADR-39 §1.3 / architecture-notes "ABI is NOT 1:1": a FreeBSD (major, arch) pair can
-appear in multiple pfSense versions (e.g. CE 2.8 and CE 2.9 both on FreeBSD 15/amd64).
-``build_repo_matrix`` keys catalog dirs by varver (``ce-2.8``, ``ce-2.9``) so each gets
-its own subtree — but IF two entries in the same matrix share the same (freebsd_major, arch)
-with DIFFERENT (php_version, py_flavor), the build would silently use the wrong PHP/Python dep
-for one of them (the collision poisons whichever entry is processed second).
+ADR-39 §1.3 / architecture-notes "ABI is NOT 1:1": a FreeBSD major can appear in
+multiple pfSense versions (e.g. CE 2.8 and CE 2.9 both on FreeBSD 15). ``build_repo_matrix``
+keys catalog dirs by varver (``ce-2.8``, ``ce-2.9``) so each gets its own subtree — but IF
+two entries in the same matrix share the same freebsd_major with DIFFERENT (php_version,
+py_flavor), the build would silently use the wrong PHP/Python dep for one of them (the
+collision poisons whichever entry is processed second). issue #1806: the collision key is
+freebsd_major ALONE — the catalog is arch-less (every pfSense-pkg-pfBlockerNG port is
+NO_ARCH), so `arch` is retired and never part of the key.
 
 This test fails the suite immediately when the real supported-versions matrix contains such
 a collision so that no release can ship an ambiguous keying.
 
-Two assertions — both required per the test-coverage mandate:
+Three assertions — required per the test-coverage mandate:
   1. PASSES the real matrix (the current supported-versions.json has no collision).
-  2. FAILS a deliberately colliding in-test fixture (two entries with the same freebsd_major +
-     arch but different php_version / py_flavor) — proving the guard is live, not a no-op.
+  2. FAILS a deliberately colliding in-test fixture (two entries with the same freebsd_major
+     but different php_version / py_flavor) — proving the guard is live, not a no-op.
+  3. FAILS even when the colliding pair carries different (now-retired) `arch` values —
+     proving the key dropped arch, not just tolerates it when absent.
 """
 
 from __future__ import annotations
@@ -57,29 +61,31 @@ def _load_build_matrix() -> list[dict] | None:
 
 
 def _collision_pairs(matrix: list[dict]) -> list[tuple[dict, dict]]:
-    """Return pairs of entries that share (freebsd_major, arch) but differ in (php_version, py_flavor).
+    """Return pairs of entries that share freebsd_major but differ in (php_version, py_flavor).
 
-    ADR-39 §1.3: a (freebsd_major, arch) pair is NOT 1:1 with a pfSense version, so
-    the catalog must key on varver (ce-2.8, plus-26.03 …), not ABI alone.  When two
-    entries share the same (freebsd_major, arch) but carry DIFFERENT (php_version,
-    py_flavor) the build cannot safely assign a single PHP/Python dep to that ABI
-    pair — the second entry silently inherits the first entry's deps, producing a
-    mis-built package.  Fail closed.
+    issue #1806: the catalog is arch-less (every pfSense-pkg-pfBlockerNG port is
+    NO_ARCH) and the BUILD matrix collapses to one row per freebsd_major, so the
+    collision key is freebsd_major ALONE now — `arch` no longer exists on a real
+    matrix entry and is never consulted here even if a stray one lingers. When two
+    entries share a freebsd_major but carry DIFFERENT (php_version, py_flavor) the
+    build cannot safely assign a single PHP/Python dep to that major — the second
+    entry silently inherits the first entry's deps, producing a mis-built package
+    (read-version-matrix.sh's own BUILD-matrix dedup hard-errors on exactly this;
+    this guard is the Python-side belt-and-braces check against the live data).
+    Fail closed.
     """
-    # Map (freebsd_major, arch) -> first entry seen with that (php, py) combo.
-    seen: dict[tuple[str, str], dict] = {}
+    # Map freebsd_major -> first entry seen with that (php, py) combo.
+    seen: dict[str, dict] = {}
     collisions: list[tuple[dict, dict]] = []
     for entry in matrix:
         major = str(entry.get("freebsd_major", ""))
-        arch = str(entry.get("arch", "amd64"))
         php = str(entry.get("php_version", ""))
         py = str(entry.get("py_flavor", ""))
-        key = (major, arch)
         sig = (php, py)
-        if key not in seen:
-            seen[key] = entry
+        if major not in seen:
+            seen[major] = entry
         else:
-            prior = seen[key]
+            prior = seen[major]
             prior_sig = (str(prior.get("php_version", "")), str(prior.get("py_flavor", "")))
             if prior_sig != sig:
                 collisions.append((prior, entry))
@@ -92,11 +98,16 @@ def _collision_pairs(matrix: list[dict]) -> list[tuple[dict, dict]]:
 
 
 def test_real_matrix_has_no_abi_php_py_collision() -> None:
-    """The live supported-versions matrix has no (freebsd_major, arch) collision.
+    """The live supported-versions matrix has no freebsd_major collision.
 
-    ADR-39 §1.3: (freebsd_major, arch) is NOT 1:1 with a pfSense version, so two
-    matrix entries may legitimately share the same ABI — but they MUST carry the same
+    ADR-39 §1.3: freebsd_major is NOT 1:1 with a pfSense version, so two
+    matrix entries may legitimately share the same major — but they MUST carry the same
     (php_version, py_flavor), otherwise the build silently mis-keys the PHP/Python dep.
+    Note: read-version-matrix.sh's own BUILD-matrix dedup already hard-errors on exactly
+    this mismatch, so a real collision here would make _load_build_matrix() return None
+    (nonzero exit) and this test SKIP rather than fail — this remains a belt-and-braces
+    check for any caller that runs _collision_pairs() against a differently-sourced matrix
+    (e.g. --print-route, which is never deduped).
 
     Scenario: load the real BUILD matrix
       Given the ci-metadata supported-versions.json via read-version-matrix.sh
@@ -110,7 +121,7 @@ def test_real_matrix_has_no_abi_php_py_collision() -> None:
 
     collisions = _collision_pairs(matrix)
     assert collisions == [], (
-        "supported-versions.json contains (freebsd_major, arch) entries with DIFFERENT "
+        "supported-versions.json contains freebsd_major entries with DIFFERENT "
         "(php_version, py_flavor) — this would silently mis-key the PHP/Python dep for "
         "one of the variants.  Fix the matrix or split the entry into distinct freebsd_major "
         "values.  Colliding pairs:\n"
@@ -118,8 +129,7 @@ def test_real_matrix_has_no_abi_php_py_collision() -> None:
             f"  {a.get('pfsense_version')} {a.get('variant')} (php={a.get('php_version')}, "
             f"py={a.get('py_flavor')}) vs "
             f"{b.get('pfsense_version')} {b.get('variant')} (php={b.get('php_version')}, "
-            f"py={b.get('py_flavor')}) — shared ABI freebsd_major={a.get('freebsd_major')}, "
-            f"arch={a.get('arch', 'amd64')}"
+            f"py={b.get('py_flavor')}) — shared freebsd_major={a.get('freebsd_major')}"
             for a, b in collisions
         )
     )
@@ -133,8 +143,8 @@ def test_real_matrix_has_no_abi_php_py_collision() -> None:
 def test_collision_guard_detects_colliding_fixture() -> None:
     """_collision_pairs() fires on a deliberately mismatched in-test fixture.
 
-    Scenario: two entries share freebsd_major=15 / arch=amd64 but differ in php_version
-      Given a two-entry matrix where both have freebsd_major=15, arch=amd64
+    Scenario: two entries share freebsd_major=15 but differ in php_version
+      Given a two-entry matrix where both have freebsd_major=15
         And the first has php_version=8.3 / py_flavor=py311
         And the second has php_version=8.5 / py_flavor=py311  ← different PHP
       When _collision_pairs() inspects the matrix
@@ -144,13 +154,12 @@ def test_collision_guard_detects_colliding_fixture() -> None:
     Before-state assertion: with matching entries, the guard is silent.
     After-state assertion: with mismatched entries, the guard fires.
     """
-    # BEFORE: no collision — two entries, same (freebsd_major, arch), SAME (php, py).
+    # BEFORE: no collision — two entries, same freebsd_major, SAME (php, py).
     clean_matrix = [
         {
             "pfsense_version": "2.8",
             "variant": "CE",
             "freebsd_major": "15",
-            "arch": "amd64",
             "php_version": "8.3",
             "py_flavor": "py311",
         },
@@ -158,20 +167,18 @@ def test_collision_guard_detects_colliding_fixture() -> None:
             "pfsense_version": "2.9",
             "variant": "CE",
             "freebsd_major": "15",
-            "arch": "amd64",
             "php_version": "8.3",  # same PHP — no collision
             "py_flavor": "py311",
         },
     ]
     assert _collision_pairs(clean_matrix) == [], "BEFORE: identical (php, py) entries should not trigger the guard"
 
-    # AFTER: collision — same (freebsd_major, arch), DIFFERENT php_version.
+    # AFTER: collision — same freebsd_major, DIFFERENT php_version.
     colliding_matrix = [
         {
             "pfsense_version": "2.8",
             "variant": "CE",
             "freebsd_major": "15",
-            "arch": "amd64",
             "php_version": "8.3",
             "py_flavor": "py311",
         },
@@ -179,7 +186,6 @@ def test_collision_guard_detects_colliding_fixture() -> None:
             "pfsense_version": "2.9",
             "variant": "CE",
             "freebsd_major": "15",
-            "arch": "amd64",
             "php_version": "8.5",  # ← DIFFERENT PHP — collision
             "py_flavor": "py311",
         },
@@ -189,3 +195,32 @@ def test_collision_guard_detects_colliding_fixture() -> None:
     a, b = pairs[0]
     assert a.get("php_version") == "8.3"
     assert b.get("php_version") == "8.5"
+
+
+def test_collision_guard_keys_on_freebsd_major_alone_ignoring_arch() -> None:
+    """issue #1806: the collision key dropped `arch` — two entries sharing a
+    freebsd_major but carrying DIFFERENT (now-retired) `arch` values must still
+    collide when their (php, py) disagree. Under the old (freebsd_major, arch)
+    key these would NOT have compared at all (distinct keys, no pair ever built)
+    — this is the discriminating case the key change fixes.
+    """
+    matrix = [
+        {
+            "pfsense_version": "2.8",
+            "variant": "CE",
+            "freebsd_major": "15",
+            "arch": "amd64",
+            "php_version": "8.3",
+            "py_flavor": "py311",
+        },
+        {
+            "pfsense_version": "2.9",
+            "variant": "CE",
+            "freebsd_major": "15",
+            "arch": "aarch64",  # different arch — must NOT create a distinct key
+            "php_version": "8.5",  # ← different PHP — must still collide
+            "py_flavor": "py311",
+        },
+    ]
+    pairs = _collision_pairs(matrix)
+    assert len(pairs) == 1, f"same-major entries must collide regardless of differing arch; got {pairs!r}"

--- a/tests/test_read_version_matrix.py
+++ b/tests/test_read_version_matrix.py
@@ -293,55 +293,148 @@ def test_build_and_test_matrices_unchanged_by_new_fields(tmp_path: Path) -> None
 
 
 # --------------------------------------------------------------------------- #
-# Scenario f — arch defaults to amd64 when omitted (issue #199).
-# A pre-#199 matrix has no `arch` field; every entry must resolve to amd64 so the
-# build path emits the unchanged FreeBSD:N:amd64 ABI. RED before the reader injects
-# arch (the field would simply be absent).
+# Scenario f — arch is NEVER emitted/resurrected (issue #1806 supersedes #199).
+# The catalog is arch-less: every pfSense-pkg-pfBlockerNG port is NO_ARCH, so
+# ARM support is dropped and the reader must not inject a synthetic "arch"
+# default anywhere. RED before the change (the old reader injected arch:
+# "amd64" into every BUILD/CI/ROUTE row).
 # --------------------------------------------------------------------------- #
-def test_build_matrix_defaults_arch_to_amd64_when_omitted(tmp_path: Path) -> None:
-    """An entry without an `arch` field resolves to amd64 in the BUILD matrix (and CI inherits it)."""
+def test_build_and_ci_matrices_never_carry_an_arch_key_when_omitted(tmp_path: Path) -> None:
+    """An entry without `arch` yields NO `arch` key in BUILD or CI output (never resurrected)."""
     repo = _make_matrix_ref(tmp_path, [_ce_entry()])  # omits arch
     build = _build_matrix(repo)
     assert len(build) == 1
-    assert build[0]["arch"] == "amd64", f"omitted arch must default to amd64; got {build[0].get('arch')!r}"
-    # CI matrix inherits the resolved arch (no separate injection).
+    assert "arch" not in build[0], f"BUILD matrix must never carry a synthetic arch key; got {build[0]!r}"
     ci = _ci_matrix(repo)
-    assert len(ci) == 1 and ci[0]["arch"] == "amd64"
+    assert len(ci) == 1
+    assert "arch" not in ci[0], f"CI matrix must never carry a synthetic arch key; got {ci[0]!r}"
+    route = _route_matrix(repo)
+    assert len(route) == 1
+    assert "arch" not in route[0], f"ROUTE matrix must never carry a synthetic arch key; got {route[0]!r}"
 
 
 # --------------------------------------------------------------------------- #
-# Scenario g — explicit aarch64 passes through verbatim (issue #199 — the point).
-# An aarch64 Plus entry (Netgate ARM appliances) must carry arch=aarch64 into both
-# the BUILD and CI matrices so release.yml/version-tracker build a FreeBSD:N:aarch64
-# .pkg. RED before #199 (no arch field is propagated at all).
+# Scenario g — a stray `arch` key on an input row is TOLERATED-IGNORED, not an
+# error and not amplified into anything: it rides through verbatim on the row
+# it came from, but the reader never reads or branches on it. This lets a
+# stale ci-metadata push (still carrying the retired column) coexist with this
+# reader without racing the data-flip landing.
 # --------------------------------------------------------------------------- #
-def test_build_matrix_passes_through_explicit_aarch64(tmp_path: Path) -> None:
-    """An explicit arch=aarch64 is emitted verbatim in the BUILD matrix and inherited by CI."""
-    repo = _make_matrix_ref(
-        tmp_path,
-        [_ce_entry(), _plus_entry(ci=True, arch="aarch64", image_name="pfsense-plus", mac=FAKE_DOC_MAC)],
-    )
-    build = _build_matrix(repo)
-    arches = {e["pfsense_version"]: e["arch"] for e in build}
-    assert arches == {"2.8": "amd64", "26.03": "aarch64"}, f"explicit aarch64 must pass through; got {arches!r}"
-    # The ci:true aarch64 Plus entry carries aarch64 into the CI matrix too.
-    ci = _ci_matrix(repo)
-    plus = [e for e in ci if e["channel"] == "Plus"]
-    assert len(plus) == 1 and plus[0]["arch"] == "aarch64"
-
-
-# --------------------------------------------------------------------------- #
-# Scenario h — empty-string arch normalizes to amd64 (the other invalid input).
-# `//` alone treats only null/missing as absent, so a literal "" would otherwise
-# flow through and a downstream ABI build would emit `FreeBSD:N:` (no arch) — the
-# same trap guarded for image_name/mac. The reader must coerce "" to amd64.
-# --------------------------------------------------------------------------- #
-def test_build_matrix_empty_string_arch_normalizes_to_amd64(tmp_path: Path) -> None:
-    """An empty-string arch is treated as absent → amd64 (never a bare `FreeBSD:N:` ABI)."""
-    repo = _make_matrix_ref(tmp_path, [_ce_entry(arch="")])
+def test_stray_arch_key_on_input_row_is_tolerated_and_passed_through_verbatim(tmp_path: Path) -> None:
+    """A leftover `arch` field on an input row does not error and rides through as-is."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry(arch="aarch64")])
     build = _build_matrix(repo)
     assert len(build) == 1
-    assert build[0]["arch"] == "amd64", f"empty arch must default to amd64; got {build[0]['arch']!r}"
+    assert build[0]["arch"] == "aarch64", f"a stray arch key must pass through verbatim; got {build[0]!r}"
+    ci = _ci_matrix(repo)
+    assert len(ci) == 1 and ci[0]["arch"] == "aarch64"
+
+
+# --------------------------------------------------------------------------- #
+# extra_pkgs (issue #1806): defaults to [] when absent, passes through
+# verbatim when present, on both BUILD and CI matrices.
+# --------------------------------------------------------------------------- #
+def test_extra_pkgs_defaults_to_empty_list_when_absent(tmp_path: Path) -> None:
+    """An entry with no extra_pkgs field yields extra_pkgs: [] in BUILD and CI."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry()])
+    build = _build_matrix(repo)
+    assert len(build) == 1 and build[0]["extra_pkgs"] == []
+    ci = _ci_matrix(repo)
+    assert len(ci) == 1 and ci[0]["extra_pkgs"] == []
+
+
+def test_extra_pkgs_passes_through_verbatim_on_a_single_entry_major(tmp_path: Path) -> None:
+    """An explicit extra_pkgs list survives into BUILD and CI when its major has no sibling."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry(extra_pkgs=["textproc/py-charset-normalizer"]), _plus_entry(ci=True)])
+    build = _build_matrix(repo)
+    by_major = {e["freebsd_major"]: e["extra_pkgs"] for e in build}
+    assert by_major == {"15": ["textproc/py-charset-normalizer"], "16": []}
+    ci = _ci_matrix(repo)
+    ce = next(e for e in ci if e["channel"] == "CE")
+    assert ce["extra_pkgs"] == ["textproc/py-charset-normalizer"]
+
+
+# --------------------------------------------------------------------------- #
+# BUILD-matrix dedup by freebsd_major (issue #1806): two build-role entries
+# sharing a freebsd_major collapse to ONE BUILD-matrix row (CI matrix stays
+# one row per version — no arch, never deduped).
+# --------------------------------------------------------------------------- #
+def test_build_matrix_dedupes_two_versions_sharing_a_freebsd_major(tmp_path: Path) -> None:
+    """Two CE entries on the same freebsd_major collapse to one BUILD row; CI keeps both."""
+    repo = _make_matrix_ref(
+        tmp_path,
+        [
+            _ce_entry(pfsense_version="2.8"),
+            _ce_entry(pfsense_version="2.9", ci=False),
+        ],
+    )
+    build = _build_matrix(repo)
+    assert len(build) == 1, f"same-major entries must collapse to one BUILD row; got {build!r}"
+    assert build[0]["freebsd_major"] == "15"
+    # CI matrix is never deduped — the ci:true entry still appears on its own.
+    ci = _ci_matrix(repo)
+    assert [e["pfsense_version"] for e in ci] == ["2.8"]
+
+
+def test_build_matrix_dedup_unions_and_dedupes_extra_pkgs_across_merged_rows(tmp_path: Path) -> None:
+    """extra_pkgs from every same-major row unions (deduped + sorted) onto the merged BUILD row."""
+    repo = _make_matrix_ref(
+        tmp_path,
+        [
+            _ce_entry(pfsense_version="2.8", extra_pkgs=["textproc/py-charset-normalizer"]),
+            _ce_entry(pfsense_version="2.9", ci=False, extra_pkgs=["textproc/py-charset-normalizer", "net/py-foo"]),
+        ],
+    )
+    build = _build_matrix(repo)
+    assert len(build) == 1
+    assert build[0]["extra_pkgs"] == ["net/py-foo", "textproc/py-charset-normalizer"]
+
+
+def test_build_matrix_dedup_hard_errors_on_php_version_mismatch(tmp_path: Path) -> None:
+    """Two same-major entries with DIFFERENT php_version abort the reader (never silently pick one)."""
+    repo = _make_matrix_ref(
+        tmp_path,
+        [
+            _ce_entry(pfsense_version="2.8", php_version="8.3"),
+            _ce_entry(pfsense_version="2.9", ci=False, php_version="8.4"),
+        ],
+    )
+    proc = subprocess.run(
+        ["sh", str(_SCRIPT), "--ref", "ci-metadata", "--file", "supported-versions.json", "--print-build"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=_clean_git_env(),
+    )
+    assert proc.returncode != 0, f"a php_version mismatch across merged rows must abort; stdout:\n{proc.stdout}"
+    assert "disagreeing php_version" in proc.stderr, proc.stderr
+
+
+def test_build_matrix_dedup_hard_errors_on_py_flavor_mismatch(tmp_path: Path) -> None:
+    """Two same-major entries with DIFFERENT py_flavor abort the reader too."""
+    repo = _make_matrix_ref(
+        tmp_path,
+        [
+            _ce_entry(pfsense_version="2.8", py_flavor="py311"),
+            _ce_entry(pfsense_version="2.9", ci=False, py_flavor="py312"),
+        ],
+    )
+    proc = subprocess.run(
+        ["sh", str(_SCRIPT), "--ref", "ci-metadata", "--file", "supported-versions.json", "--print-build"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=_clean_git_env(),
+    )
+    assert proc.returncode != 0, f"a py_flavor mismatch across merged rows must abort; stdout:\n{proc.stdout}"
+    assert "disagreeing php_version" in proc.stderr, proc.stderr
+
+
+def test_build_matrix_no_dedup_when_majors_differ(tmp_path: Path) -> None:
+    """Distinct majors (today's real CE/Plus split) never merge — one BUILD row each."""
+    repo = _make_matrix_ref(tmp_path, [_ce_entry(), _plus_entry(ci=True)])
+    build = _build_matrix(repo)
+    assert sorted(e["freebsd_major"] for e in build) == ["15", "16"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_read_version_matrix.py
+++ b/tests/test_read_version_matrix.py
@@ -321,11 +321,13 @@ def test_build_and_ci_matrices_never_carry_an_arch_key_when_omitted(tmp_path: Pa
 # reader without racing the data-flip landing.
 # --------------------------------------------------------------------------- #
 def test_stray_arch_key_on_input_row_is_tolerated_and_passed_through_verbatim(tmp_path: Path) -> None:
-    """A leftover `arch` field on an input row does not error and rides through as-is."""
+    """A leftover `arch` field on an input row does not error. CI/ROUTE ride through it
+    verbatim; BUILD drops it (issue #1806 D0 — arch is never a BUILD-matrix key, merged
+    or not — CI matrix is the leg source for anything arch/ci-shaped)."""
     repo = _make_matrix_ref(tmp_path, [_ce_entry(arch="aarch64")])
     build = _build_matrix(repo)
     assert len(build) == 1
-    assert build[0]["arch"] == "aarch64", f"a stray arch key must pass through verbatim; got {build[0]!r}"
+    assert "arch" not in build[0], f"BUILD must never carry arch, even a passthrough stray; got {build[0]!r}"
     ci = _ci_matrix(repo)
     assert len(ci) == 1 and ci[0]["arch"] == "aarch64"
 
@@ -435,6 +437,33 @@ def test_build_matrix_no_dedup_when_majors_differ(tmp_path: Path) -> None:
     repo = _make_matrix_ref(tmp_path, [_ce_entry(), _plus_entry(ci=True)])
     build = _build_matrix(repo)
     assert sorted(e["freebsd_major"] for e in build) == ["15", "16"]
+
+
+# --------------------------------------------------------------------------- #
+# issue #1806 D0 — a stray arch/ci on a NON-representative (non-last) same-major
+# row must not leak into the merged BUILD row via the last-wins `reduce` merge.
+# Live-reproduced on origin/ci-metadata: the freebsd_major=16 group holds a
+# `ci:true, image_name:pfsense-plus` row followed by a `ci:false, arch:aarch64`
+# row; `--print-build` emits `"ci":false,"image_name":"pfsense-plus",...,
+# "arch":"aarch64"` on the merged row — the representative (last) row IS
+# ci:true, yet the merged BUILD row says ci:false and carries an arch key that
+# contradicts the script's own "the catalog is arch-less" header. BUILD
+# consumers never read arch or ci (CI matrix is the leg source) — the merged
+# row must carry neither key, from any contributing row.
+# --------------------------------------------------------------------------- #
+def test_build_matrix_dedup_drops_arch_and_ci_keys_from_non_representative_row(tmp_path: Path) -> None:
+    """A stray arch/ci key on a same-major row must never leak into the merged BUILD row."""
+    repo = _make_matrix_ref(
+        tmp_path,
+        [
+            _plus_entry(pfsense_version="26.03", ci=True, image_name="pfsense-plus"),
+            _plus_entry(pfsense_version="26.03", ci=False, arch="aarch64"),
+        ],
+    )
+    build = _build_matrix(repo)
+    assert len(build) == 1, f"same-major rows must still collapse to one BUILD row; got {build!r}"
+    assert "arch" not in build[0], f"BUILD row must never carry a leaked arch key; got {build[0]!r}"
+    assert "ci" not in build[0], f"BUILD row must never carry a leaked/stale ci key; got {build[0]!r}"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_read_version_matrix.py
+++ b/tests/test_read_version_matrix.py
@@ -429,7 +429,11 @@ def test_build_matrix_dedup_hard_errors_on_py_flavor_mismatch(tmp_path: Path) ->
         env=_clean_git_env(),
     )
     assert proc.returncode != 0, f"a py_flavor mismatch across merged rows must abort; stdout:\n{proc.stdout}"
-    assert "disagreeing php_version" in proc.stderr, proc.stderr
+    # CR-8: this test is about py_flavor, not php_version — assert ITS OWN field
+    # token (production emits one combined "disagreeing php_version/py_flavor"
+    # message for either mismatch; the sibling php_version test above asserts
+    # "disagreeing php_version" for the same reason, on its own field).
+    assert "disagreeing" in proc.stderr and "py_flavor" in proc.stderr, proc.stderr
 
 
 def test_build_matrix_no_dedup_when_majors_differ(tmp_path: Path) -> None:

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -24,11 +24,19 @@ sys.modules[_SPEC.name] = mx
 _SPEC.loader.exec_module(mx)
 
 
-# A representative multi-edition, multi-arch matrix (CE amd64 + Plus amd64 + Plus aarch64).
+# A representative multi-edition matrix (CE + Plus, distinct FreeBSD majors — no
+# `arch` field: issue #1806 retires it, the catalog is arch-less).
 _MATRIX = (
-    '[{"pfsense_version":"2.8.0","freebsd_major":"15","arch":"amd64","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
-    '{"pfsense_version":"26.03.1","freebsd_major":"16","arch":"amd64","php_version":"8.5","py_flavor":"py311","variant":"Plus"},'
-    '{"pfsense_version":"26.03.1","freebsd_major":"16","arch":"aarch64","php_version":"8.5","py_flavor":"py311","variant":"Plus"}]'
+    '[{"pfsense_version":"2.8.0","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
+    '{"pfsense_version":"26.03.1","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"Plus"}]'
+)
+
+# Two editions sharing the SAME freebsd_major (issue #1806: with `arch` retired,
+# this is a real possible shape now, not just an ADR-24 transition-window
+# hypothetical) — exercises the SMOKE_IMAGE_REF disambiguation in _own_entry().
+_COLLIDING_MATRIX = (
+    '[{"pfsense_version":"2.8.0","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
+    '{"pfsense_version":"15.1.0","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"Plus"}]'
 )
 
 
@@ -41,7 +49,7 @@ def _clear_matrix_cache() -> Any:
 
 
 def _set_env(monkeypatch: pytest.MonkeyPatch, **kv: str | None) -> None:
-    for k in ("SMOKE_MATRIX_JSON", "SMOKE_ABI", "SMOKE_PHP_VERSION", "SMOKE_PY_FLAVOR"):
+    for k in ("SMOKE_MATRIX_JSON", "SMOKE_ABI", "SMOKE_PHP_VERSION", "SMOKE_PY_FLAVOR", "SMOKE_IMAGE_REF"):
         monkeypatch.delenv(k, raising=False)
     for k, v in kv.items():
         if v is not None:
@@ -59,7 +67,7 @@ def test_build_matrix_parses_env_json(monkeypatch: pytest.MonkeyPatch) -> None:
     """A well-formed SMOKE_MATRIX_JSON array is returned as a tuple of entries."""
     _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX)
     m = mx.build_matrix()
-    assert m is not None and len(m) == 3 and m[0]["variant"] == "CE"
+    assert m is not None and len(m) == 2 and m[0]["variant"] == "CE"
 
 
 def test_build_matrix_none_on_malformed_or_empty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -74,9 +82,9 @@ def test_variants_derived_per_abi_edition(monkeypatch: pytest.MonkeyPatch) -> No
     """One Variant per (ABI, edition), php/catalog/py derived from the matrix entry."""
     _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX)
     by_abi = {v.abi: v for v in mx.matrix_variants()}
-    assert set(by_abi) == {"FreeBSD:15:amd64", "FreeBSD:16:amd64", "FreeBSD:16:aarch64"}
+    assert set(by_abi) == {"FreeBSD:15:amd64", "FreeBSD:16:amd64"}
     assert by_abi["FreeBSD:15:amd64"] == mx.Variant("php83", "FreeBSD:15:amd64", "ce-2.8", "py311", "CE")
-    assert by_abi["FreeBSD:16:aarch64"].php == "php85" and by_abi["FreeBSD:16:aarch64"].catalog == "plus-26.03"
+    assert by_abi["FreeBSD:16:amd64"].php == "php85" and by_abi["FreeBSD:16:amd64"].catalog == "plus-26.03"
 
 
 def test_own_and_opposite_follow_smoke_abi(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -103,8 +111,8 @@ def test_bare_dispatch_defaults_to_ce_entry(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_env_overrides_win_over_matrix(monkeypatch: pytest.MonkeyPatch) -> None:
     """SMOKE_* env values override the derived matrix defaults (the per-leg injection)."""
-    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX, SMOKE_ABI="FreeBSD:16:aarch64", SMOKE_PY_FLAVOR="py312")
-    assert mx.matrix_abi() == "FreeBSD:16:aarch64"
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX, SMOKE_ABI="FreeBSD:16:amd64", SMOKE_PY_FLAVOR="py312")
+    assert mx.matrix_abi() == "FreeBSD:16:amd64"
     assert mx.matrix_py_flavor() == "py312"  # env wins
     assert mx.matrix_php_dep() == "php85"  # derived from the matched entry (no SMOKE_PHP_VERSION)
 
@@ -114,6 +122,37 @@ def test_php_version_mismatch_is_a_wiring_error(monkeypatch: pytest.MonkeyPatch)
     (a CI-wiring bug), never silently passes."""
     _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX, SMOKE_ABI="FreeBSD:15:amd64", SMOKE_PHP_VERSION="8.5")
     with pytest.raises(AssertionError, match="matrix inconsistency"):
+        mx.own_variant()
+
+
+# --------------------------------------------------------------------------- #
+# gate-A-era hazard (issue #1806): with `arch` retired, two editions CAN share
+# a freebsd_major (not just an ADR-24 transition-window hypothetical), so
+# SMOKE_ABI alone no longer uniquely selects a variant. SMOKE_IMAGE_REF (already
+# exported by smoke-single.yml as the resolved GHCR ref, e.g.
+# .../pfsense-plus:15.1.0) disambiguates by image name; when it can't, own_entry
+# must refuse to silently pick one rather than guess.
+# --------------------------------------------------------------------------- #
+def test_own_entry_disambiguates_same_major_variants_via_smoke_image_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SMOKE_ABI matches both CE and Plus on freebsd_major=15; SMOKE_IMAGE_REF picks the right one."""
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_COLLIDING_MATRIX, SMOKE_ABI="FreeBSD:15:amd64")
+    monkeypatch.setenv("SMOKE_IMAGE_REF", "ghcr.io/pfblockerng/pfsense-plus:15.1.0")
+    assert mx.own_variant().variant == "Plus"
+
+    monkeypatch.setenv("SMOKE_IMAGE_REF", "ghcr.io/pfblockerng/pfsense-ce:2.8.0")
+    assert mx.own_variant().variant == "CE"
+
+
+def test_own_entry_refuses_to_silently_pick_when_image_ref_cannot_disambiguate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No SMOKE_IMAGE_REF (or one naming neither edition) -> a loud RuntimeError, never a guess."""
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_COLLIDING_MATRIX, SMOKE_ABI="FreeBSD:15:amd64")
+    with pytest.raises(RuntimeError, match="does not disambiguate"):
+        mx.own_variant()
+
+    monkeypatch.setenv("SMOKE_IMAGE_REF", "ghcr.io/pfblockerng/pfsense-somethingelse:1.0")
+    with pytest.raises(RuntimeError, match="does not disambiguate"):
         mx.own_variant()
 
 
@@ -136,8 +175,7 @@ def test_topology_skips_when_matrix_absent(monkeypatch: pytest.MonkeyPatch) -> N
 # The _matrix.py:build_matrix() function trusts the injected JSON, so CI-injected
 # SMOKE_MATRIX_JSON (from --print-build) is always free of route-only entries.
 _BUILD_ONLY_MATRIX = (
-    '[{"pfsense_version":"2.8.0","freebsd_major":"15","arch":"amd64",'
-    '"php_version":"8.3","py_flavor":"py311","variant":"CE"}]'
+    '[{"pfsense_version":"2.8.0","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"}]'
 )
 
 
@@ -167,8 +205,8 @@ def test_smoke_topology_excludes_route_only_via_build_matrix_injection(monkeypat
 
     # AFTER: add a second build CE entry → two variants; the topology mirrors its input.
     two_ce = (
-        '[{"pfsense_version":"2.8.0","freebsd_major":"15","arch":"amd64","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
-        '{"pfsense_version":"2.9.0","freebsd_major":"16","arch":"amd64","php_version":"8.5","py_flavor":"py311","variant":"CE"}]'
+        '[{"pfsense_version":"2.8.0","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
+        '{"pfsense_version":"2.9.0","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"CE"}]'
     )
     _set_env(monkeypatch, SMOKE_MATRIX_JSON=two_ce)
     mx.build_matrix.cache_clear()

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -169,41 +169,42 @@ def test_topology_skips_when_matrix_absent(monkeypatch: pytest.MonkeyPatch) -> N
         mx.matrix_variants()
 
 
-# Build-only matrix (the shape smoke-single.yml always injects via --print-build, which excludes
-# route-only entries). This documents how route-only entries are kept out of the topology:
-# they never reach SMOKE_MATRIX_JSON because --print-build filters them at the reader level.
-# The _matrix.py:build_matrix() function trusts the injected JSON, so CI-injected
-# SMOKE_MATRIX_JSON (from --print-build) is always free of route-only entries.
-_BUILD_ONLY_MATRIX = (
+# CI-matrix shape (the shape smoke-single.yml always injects via --print-ci, which excludes
+# role=route-only entries, same as --print-build — issue #1806 W3). This documents how
+# route-only entries are kept out of the topology: they never reach SMOKE_MATRIX_JSON because
+# --print-ci filters them at the reader level. The _matrix.py:build_matrix() function trusts
+# the injected JSON, so CI-injected SMOKE_MATRIX_JSON (from --print-ci) is always free of
+# route-only entries.
+_CI_ONLY_MATRIX = (
     '[{"pfsense_version":"2.8.0","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"}]'
 )
 
 
-def test_smoke_topology_excludes_route_only_via_build_matrix_injection(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_smoke_topology_excludes_route_only_via_ci_matrix_injection(monkeypatch: pytest.MonkeyPatch) -> None:
     """The smoke topology never produces a variant for a route-only pfSense version.
 
     Protection mechanism: smoke-single.yml injects SMOKE_MATRIX_JSON from
-    ``read-version-matrix.sh --print-build``, which excludes ``role=route-only``
+    ``read-version-matrix.sh --print-ci`` (issue #1806 W3), which excludes ``role=route-only``
     entries. _matrix.py:build_matrix() reads the injected JSON as-is. So the
     topology never sees route-only entries — the exclusion is at the reader level.
 
-    Before/after: with a build-only matrix (no route-only), the topology produces
-    a CE variant. Adding a second build CE entry (e.g. the next version) produces two
+    Before/after: with a CI-only matrix (no route-only), the topology produces
+    a CE variant. Adding a second CI entry (e.g. the next version) produces two
     variants — proving the topology faithfully mirrors its input, so the only way
     a route-only entry would appear is if the wrong --print-* mode were injected
-    (documented: always use --print-build for SMOKE_MATRIX_JSON).
+    (documented: always use --print-ci for SMOKE_MATRIX_JSON).
     """
-    # BEFORE: single-entry build matrix → one CE variant (FreeBSD:15:amd64).
-    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_BUILD_ONLY_MATRIX)
+    # BEFORE: single-entry CI matrix → one CE variant (FreeBSD:15:amd64).
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_CI_ONLY_MATRIX)
     variants_before = mx.matrix_variants()
     abis_before = {v.abi for v in variants_before}
     assert "FreeBSD:15:amd64" in abis_before, f"before: CE 2.8 variant expected; got {abis_before!r}"
     # The route-only 2.7 ABI must NOT appear (it is absent from the injected JSON).
     assert "FreeBSD:14:amd64" not in abis_before, (
-        f"before: route-only 2.7 ABI must not appear (not in build matrix); got {abis_before!r}"
+        f"before: route-only 2.7 ABI must not appear (not in the CI matrix); got {abis_before!r}"
     )
 
-    # AFTER: add a second build CE entry → two variants; the topology mirrors its input.
+    # AFTER: add a second CI CE entry → two variants; the topology mirrors its input.
     two_ce = (
         '[{"pfsense_version":"2.8.0","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
         '{"pfsense_version":"2.9.0","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"CE"}]'
@@ -214,7 +215,7 @@ def test_smoke_topology_excludes_route_only_via_build_matrix_injection(monkeypat
     abis_after = {v.abi for v in variants_after}
     assert "FreeBSD:15:amd64" in abis_after, f"after: 2.8 CE still present; got {abis_after!r}"
     assert "FreeBSD:16:amd64" in abis_after, f"after: 2.9 CE present; got {abis_after!r}"
-    # Still no route-only 2.7 ABI (never injected via --print-build).
+    # Still no route-only 2.7 ABI (never injected via --print-ci).
     assert "FreeBSD:14:amd64" not in abis_after, (
         f"after: route-only ABI must remain absent from smoke topology; got {abis_after!r}"
     )

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -394,8 +394,16 @@ def test_build_pkgs_portable_per_leg_upload_name_is_the_exact_contract() -> None
     jobs = _jobs(RELEASE_WORKFLOW)
     steps = _split_into_steps(jobs["build-pkgs-portable"])
     upload_steps = [s for s in steps if any("uses: actions/upload-artifact" in line for line in s)]
-    assert len(upload_steps) == 1, "expected exactly one upload-artifact step in build-pkgs-portable"
-    name_line = next(line for line in upload_steps[0] if line.strip().startswith("name:"))
+    # issue #1806 B1: TWO upload steps now -- the branch .pkg (this test) and,
+    # gated on this major's extra_pkgs being non-empty, its dep .pkg as a
+    # SEPARATE artifact (see test_build_pkgs_portable_dep_pkg_upload_name_is_the_exact_contract).
+    assert len(upload_steps) == 2, (
+        f"expected exactly two upload-artifact steps in build-pkgs-portable, got {len(upload_steps)}"
+    )
+    pkg_step = next(
+        s for s in upload_steps if any("pfBlockerNG-relpkg-fbsd" in line and "deppkgs" not in line for line in s)
+    )
+    name_line = next(line for line in pkg_step if line.strip().startswith("name:"))
     assert "pfBlockerNG-relpkg-fbsd" in name_line, (
         f"per-leg upload name must start pfBlockerNG-relpkg-fbsd, got: {name_line}"
     )
@@ -406,6 +414,27 @@ def test_build_pkgs_portable_per_leg_upload_name_is_the_exact_contract() -> None
     assert not any(tok in name_line for tok in stale_tokens), (
         f"the deduped-by-major upload name must reference no variant/version/arch, got: {name_line}"
     )
+
+
+def test_build_pkgs_portable_dep_pkg_upload_name_is_the_exact_contract() -> None:
+    """issue #1806 B1: the dep-pkg artifact name mirrors the branch pkg's own
+    per-major contract, with a 'deppkgs' segment inserted -- smoke.yml's/
+    ui-tests.yml's pkg_artifact_prefix == 'pfBlockerNG-relpkg' download steps
+    compose this exact literal. Gated (never an empty artifact when a major's
+    extra_pkgs is empty)."""
+    jobs = _jobs(RELEASE_WORKFLOW)
+    steps = _split_into_steps(jobs["build-pkgs-portable"])
+    upload_steps = [s for s in steps if any("uses: actions/upload-artifact" in line for line in s)]
+    dep_step = next(s for s in upload_steps if any("deppkgs" in line for line in s))
+    name_line = next(line for line in dep_step if line.strip().startswith("name:"))
+    assert "pfBlockerNG-relpkg-deppkgs-fbsd" in name_line, (
+        f"dep-pkg upload name must be pfBlockerNG-relpkg-deppkgs-fbsd<major>, got: {name_line}"
+    )
+    assert "matrix.freebsd_major" in name_line, (
+        f"dep-pkg upload name must key on matrix.freebsd_major, got: {name_line}"
+    )
+    if_line = next((line for line in dep_step if line.strip().startswith("if:")), "")
+    assert "HAS_DEP_PKGS" in if_line, f"dep-pkg upload must be gated (never an empty artifact), got: {if_line!r}"
 
 
 def test_build_pkgs_portable_leg_step_needs_no_variant_version_or_arch() -> None:

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -6,9 +6,11 @@ fix -- and the ui tier's pytest-exit-5 mapper stops silently passing a full, unf
 that selected zero tests.
 
 Part 2 (release.yml side): build-pkgs-portable matrix-ifies over the read-matrix build_matrix
-(one job per leg) and uploads one EXACT-named artifact per leg
-(`pfBlockerNG-relpkg-<variant_lc>-<pfsense_version>-<arch>`); attach-pkgs merges them by
-pattern; ui-suite/smoke-suite are re-enabled, consume those exact artifacts, and gate
+-- ALREADY DEDUPED to one row per distinct freebsd_major (issue #1806: every
+pfSense-pkg-pfBlockerNG port is NO_ARCH, so one wildcard-ABI .pkg build serves every
+arch and edition/version sharing a major) -- and uploads one EXACT-named artifact per
+major (`pfBlockerNG-relpkg-fbsd<freebsd_major>`); attach-pkgs merges them by pattern;
+ui-suite/smoke-suite are re-enabled, consume those exact artifacts, and gate
 publish-release (never `release`/`attach-pkgs` -- ADR-14 D1).
 """
 
@@ -143,10 +145,9 @@ def test_ui_download_step_uses_the_prefix_when_set() -> None:
     target = [s for s in steps if any("Download the built pfBlockerNG package" in line for line in s)]
     assert len(target) == 1, "ui job must have exactly one 'Download the built pfBlockerNG package' step"
     step_text = "\n".join(target[0])
-    assert (
-        "format('{0}-{1}-{2}-{3}', inputs.pkg_artifact_prefix, matrix.variant, matrix.version, matrix.arch)"
-        in step_text
-    ), f"ui download step must build the prefixed artifact name from prefix/variant/version/arch, got:\n{step_text}"
+    assert "format('{0}-fbsd{1}', inputs.pkg_artifact_prefix, matrix.freebsd_major)" in step_text, (
+        f"ui download step must build the prefixed artifact name from prefix/freebsd_major, got:\n{step_text}"
+    )
     assert "inputs.pkg_artifact_prefix != ''" in step_text
     assert "format('pfBlockerNG-pkg-{0}', matrix.version)" in step_text, (
         "the blank-prefix fallback must stay byte-identical to the pre-#1662 literal name"
@@ -161,9 +162,12 @@ def test_smoke_job_threads_the_prefix_into_pkg_artifact() -> None:
     assert "inputs.pkg_artifact_prefix != ''" in pkg_artifact_line, (
         f"smoke job's pkg_artifact: must branch on inputs.pkg_artifact_prefix, got: {pkg_artifact_line}"
     )
-    assert "inputs.pkg_artifact_prefix" in pkg_artifact_line and "matrix.pfsense_version" in pkg_artifact_line
-    assert "format('pfBlockerNG-pkg-{0}-{1}', matrix.image_name, matrix.pfsense_version)" in pkg_artifact_line, (
-        "the blank-prefix fallback must stay byte-identical to the pre-#1662 literal name"
+    assert "format('{0}-fbsd{1}', inputs.pkg_artifact_prefix, matrix.freebsd_major)" in pkg_artifact_line, (
+        f"the prefix-set branch must key on freebsd_major alone (issue #1806), got: {pkg_artifact_line}"
+    )
+    assert "format('pfBlockerNG-pkg-fbsd{0}-{1}', matrix.freebsd_major, matrix.image_name)" in pkg_artifact_line, (
+        f"the blank-prefix fallback must match build-pkg's own artifact_name (fbsd<major>-<image_name>), "
+        f"got: {pkg_artifact_line}"
     )
 
 
@@ -384,28 +388,35 @@ def test_build_pkgs_portable_matrixes_over_read_matrix_build_matrix() -> None:
 
 
 def test_build_pkgs_portable_per_leg_upload_name_is_the_exact_contract() -> None:
+    """issue #1806: the artifact name keys on freebsd_major ALONE -- read-matrix's
+    build_matrix is already deduped to one row per major, so there is no
+    variant/version/arch left to slug (and no lowercasing needed)."""
     jobs = _jobs(RELEASE_WORKFLOW)
     steps = _split_into_steps(jobs["build-pkgs-portable"])
     upload_steps = [s for s in steps if any("uses: actions/upload-artifact" in line for line in s)]
     assert len(upload_steps) == 1, "expected exactly one upload-artifact step in build-pkgs-portable"
-    step_text = "\n".join(upload_steps[0])
     name_line = next(line for line in upload_steps[0] if line.strip().startswith("name:"))
-    assert "pfBlockerNG-relpkg-" in name_line, f"per-leg upload name must start pfBlockerNG-relpkg-, got: {name_line}"
-    # issue #1662 M1: the artifact NAME keys off artslug (full pfsense_version), not
-    # varslug (major.minor-truncated, reserved for the .pkg FILENAME/catalog path) --
-    # see test_release_side_artifact_name_matches_both_consumer_sides below for why.
-    assert "artslug" in name_line and "matrix.arch" in name_line, (
-        f"per-leg upload name must be pfBlockerNG-relpkg-<artslug>-<matrix.arch>, got: {name_line}"
+    assert "pfBlockerNG-relpkg-fbsd" in name_line, (
+        f"per-leg upload name must start pfBlockerNG-relpkg-fbsd, got: {name_line}"
     )
-    # variant-lowercasing (shared by varslug and artslug):
-    assert "tr '[:upper:]' '[:lower:]'" in step_text or "tr '[:upper:]' '[:lower:]'" in "\n".join(
-        jobs["build-pkgs-portable"]
-    ), "varslug must lowercase the variant"
+    assert "matrix.freebsd_major" in name_line, (
+        f"per-leg upload name must key on matrix.freebsd_major, got: {name_line}"
+    )
+    stale_tokens = ("matrix.arch", "matrix.variant", "matrix.pfsense_version")
+    assert not any(tok in name_line for tok in stale_tokens), (
+        f"the deduped-by-major upload name must reference no variant/version/arch, got: {name_line}"
+    )
 
 
-def test_build_pkgs_portable_varslug_derives_from_pfsense_version() -> None:
+def test_build_pkgs_portable_leg_step_needs_no_variant_version_or_arch() -> None:
+    """issue #1806: the leg-naming job body no longer needs matrix.variant/.pfsense_version/
+    .arch at all -- read-matrix's build_matrix is already deduped by freebsd_major, so those
+    per-version fields are meaningless on a build TARGET row."""
     job_text = "\n".join(_jobs(RELEASE_WORKFLOW)["build-pkgs-portable"])
-    assert "matrix.pfsense_version" in job_text
+    assert "matrix.freebsd_major" in job_text
+    assert "matrix.variant" not in job_text
+    assert "matrix.pfsense_version" not in job_text
+    assert "matrix.arch" not in job_text
 
 
 # --------------------------------------------------------------------------- #
@@ -517,70 +528,35 @@ def test_publish_release_if_gates_on_both_suite_results_and_retains_dry_run_fals
 # --------------------------------------------------------------------------- #
 # Cross-contract consistency: release-side naming == part-1 consumer-side naming
 #
-# Issue #1662 B1: the old version of this test built BOTH "sides" as Python
-# literals in the test body (a tautology -- it could never fail on a workflow
-# mutation) and never modelled the producer's real `cut -d. -f1-2` truncation.
-# This replaces it with a test that LIFTS the leg-naming step's `run:` body
-# straight out of release.yml and executes it under sh for every row of the real
-# build matrix plus one synthetic 3-component-version row, comparing the emitted
-# artifact name against the consumer-side format(...) templates parsed out of the
-# real ui-tests.yml / smoke.yml text.
+# issue #1806: the release-side artifact name is now a DIRECT
+# `pfBlockerNG-relpkg-fbsd${{ matrix.freebsd_major }}` template (no per-leg
+# step-output slug, no variant/version/arch at all -- read-matrix's
+# build_matrix is already deduped to one row per freebsd_major). This test
+# LIFTS the leg-naming step's `run:` body straight out of release.yml and
+# executes it under sh for every DISTINCT freebsd_major in the real build
+# matrix, comparing the emitted ABI + LEG shape and the release/ui/smoke
+# artifact names against the consumer-side format(...) templates parsed out
+# of the real ui-tests.yml / smoke.yml text.
 # --------------------------------------------------------------------------- #
-
-
-def _upload_artifact_name_line() -> str:
-    jobs = _jobs(RELEASE_WORKFLOW)
-    steps = _split_into_steps(jobs["build-pkgs-portable"])
-    upload_steps = [s for s in steps if any("uses: actions/upload-artifact" in line for line in s)]
-    assert len(upload_steps) == 1, "expected exactly one upload-artifact step in build-pkgs-portable"
-    return next(line for line in upload_steps[0] if line.strip().startswith("name:"))
-
-
-_UPLOAD_NAME_FIELD_RE = re.compile(r"steps\.leg\.outputs\.(\w+)")
-
-
-def _upload_artifact_name_output_field() -> str:
-    """Which `steps.leg.outputs.<field>` the upload-artifact `name:` references --
-    read from the file, not assumed, so this test tracks whichever field the
-    producer actually uses (varslug pre-fix, artslug post-fix)."""
-    name_line = _upload_artifact_name_line()
-    m = _UPLOAD_NAME_FIELD_RE.search(name_line)
-    assert m is not None, f"upload-artifact name: must reference steps.leg.outputs.<field>, got: {name_line}"
-    return m.group(1)
-
-
-def test_build_pkgs_portable_upload_name_references_artslug_output() -> None:
-    """Structural pin (issue #1662 M1): the per-leg upload-artifact `name:` must key
-    off the FULL-pfsense_version artslug output, not the major.minor-truncated
-    varslug -- the consumer sides (ui-tests.yml/smoke.yml) format the full
-    matrix.pfsense_version into their download name, so a 3-component version would
-    otherwise silently desync the producer name from what they request."""
-    assert _upload_artifact_name_output_field() == "artslug", (
-        f"upload-artifact name: must reference steps.leg.outputs.artslug, got: {_upload_artifact_name_line()}"
-    )
 
 
 def _leg_step() -> list[str]:
     jobs = _jobs(RELEASE_WORKFLOW)
     steps = _split_into_steps(jobs["build-pkgs-portable"])
-    target = [s for s in steps if any("Compute this leg's VARSLUG/ABI" in line for line in s)]
-    assert len(target) == 1, 'expected exactly one "Compute this leg\'s VARSLUG/ABI" step'
+    target = [s for s in steps if any("Compute this leg's LEG/ABI" in line for line in s)]
+    assert len(target) == 1, 'expected exactly one "Compute this leg\'s LEG/ABI" step'
     return target[0]
 
 
-def _run_leg_step(tmp_path: Path, variant: str, pfsense_version: str, freebsd_major: str, arch: str) -> dict[str, str]:
+def _run_leg_step(tmp_path: Path, freebsd_major: str) -> dict[str, str]:
     """Execute the REAL leg-naming step's `run:` body (lifted verbatim) under sh,
     with a real $GITHUB_OUTPUT file, and return the parsed step outputs."""
     script = _step_run_script(_leg_step())
-    output_file = tmp_path / f"github_output_{variant}_{pfsense_version}_{arch}".replace(".", "_")
+    output_file = tmp_path / f"github_output_fbsd{freebsd_major}"
     output_file.write_text("")
     env = {
         "PATH": os.environ.get("PATH", ""),
-        "VARIANT": variant,
-        "CHANNEL_FALLBACK": variant,
-        "PFV": pfsense_version,
         "MAJOR": freebsd_major,
-        "ARCH": arch,
         "GITHUB_OUTPUT": str(output_file),
     }
     completed = subprocess.run(  # noqa: S603
@@ -625,24 +601,15 @@ def _resolve_matrix_arg(expr: str, row: dict[str, str]) -> str:
     ui-tests.yml/smoke.yml text -- to the string it evaluates to for `row`."""
     if expr == "inputs.pkg_artifact_prefix":
         return "pfBlockerNG-relpkg"
-    if expr == "matrix.variant":
-        return row["variant"].lower()
-    if expr in ("matrix.version", "matrix.pfsense_version"):
-        return row["pfsense_version"]
-    if expr == "matrix.arch":
-        return row["arch"]
-    ternary = re.match(r"\(matrix\.image_name == '([^']*)' && '([^']*)' \|\| '([^']*)'\)$", expr)
-    if ternary is not None:
-        plus_image_name, when_true, when_false = ternary.groups()
-        image_name = "pfsense-" + row["variant"].lower()
-        return when_true if image_name == plus_image_name else when_false
+    if expr == "matrix.freebsd_major":
+        return row["freebsd_major"]
     raise AssertionError(f"unrecognised matrix arg expression in a consumer-side format(...) call: {expr!r}")
 
 
 def _consumer_side_names(row: dict[str, str]) -> tuple[str, str]:
-    """(ui-tests.yml download name, smoke.yml pkg_artifact) for `row`, computed
-    from the format(...) templates parsed out of the REAL workflow text -- never
-    a hardcoded literal."""
+    """(ui-tests.yml download name, smoke.yml pkg_artifact prefix-set branch) for
+    `row`, computed from the format(...) templates parsed out of the REAL workflow
+    text -- never a hardcoded literal."""
     ui_jobs = _jobs(UI_WORKFLOW)
     ui_steps = _split_into_steps(ui_jobs["ui"])
     dl_step = next(s for s in ui_steps if any("Download the built pfBlockerNG package" in line for line in s))
@@ -659,12 +626,11 @@ def _consumer_side_names(row: dict[str, str]) -> tuple[str, str]:
 
 
 def _cross_contract_rows() -> list[dict[str, str]] | None:
-    """Real BUILD-matrix rows (read-version-matrix.sh --print-build -- reads the
-    already-fetched origin/ci-metadata ref, no network needed once it's present)
-    PLUS one synthetic 3-component-version row that exercises the truncation bug
-    directly. Returns None when the ref is unreachable in this environment
-    (mirrors tests/test_matrix_collision_guard.py's _load_build_matrix skip
-    contract) -- callers must skip, never fabricate rows."""
+    """Real (deduped-by-major) BUILD-matrix rows, read via read-version-matrix.sh
+    --print-build (reads the already-fetched origin/ci-metadata ref, no network
+    needed once it's present). Returns None when the ref is unreachable in this
+    environment (mirrors tests/test_matrix_collision_guard.py's _load_build_matrix
+    skip contract) -- callers must skip, never fabricate rows."""
     try:
         proc = subprocess.run(  # noqa: S603
             ["sh", "scripts/read-version-matrix.sh", "--print-build"],
@@ -684,43 +650,28 @@ def _cross_contract_rows() -> list[dict[str, str]] | None:
         return None
     if not isinstance(matrix, list) or not matrix:
         return None
-    rows = [
-        {
-            "variant": str(entry["variant"]),
-            "pfsense_version": str(entry["pfsense_version"]),
-            "freebsd_major": str(entry["freebsd_major"]),
-            "arch": str(entry["arch"]),
-        }
-        for entry in matrix
-    ]
-    # Synthetic row (issue #1662 M1): every REAL row today is 2-component
-    # (2.8, 26.03) so MM == pfsense_version and the truncation bug is invisible --
-    # this row is what makes it visible.
-    rows.append({"variant": "CE", "pfsense_version": "2.8.1", "freebsd_major": "15", "arch": "amd64"})
-    return rows
+    return [{"freebsd_major": str(entry["freebsd_major"])} for entry in matrix]
 
 
 def test_release_side_artifact_name_matches_both_consumer_sides(tmp_path: Path) -> None:
-    """For every real build-matrix row plus the synthetic 3-component-version row,
-    execute the REAL leg-naming step and assert the artifact name it emits equals
-    BOTH ui-tests.yml's download name AND smoke.yml's pkg_artifact -- computed from
-    the real format(...) templates in those files. Issue #1662 M1: this is RED
-    before the fix on the synthetic row (producer truncates to ce-2.8, both
-    consumers expect ce-2.8.1) and on every row if the upload step still points at
-    a field that never gets emitted."""
+    """For every distinct freebsd_major in the real (deduped) build matrix, execute
+    the REAL leg-naming step (a sanity check that it still runs + emits a usable
+    ABI/LEG) and assert the LITERAL release-side artifact name
+    (pfBlockerNG-relpkg-fbsd<major>) equals BOTH ui-tests.yml's download name AND
+    smoke.yml's pkg_artifact prefix-set branch -- computed from the real
+    format(...) templates in those files."""
     rows = _cross_contract_rows()
     if rows is None:
         pytest.skip("ci-metadata matrix not available in this environment -- skipping real-matrix rows")
         return
 
-    field = _upload_artifact_name_output_field()
     failures: list[str] = []
     for row in rows:
-        outputs = _run_leg_step(tmp_path, row["variant"], row["pfsense_version"], row["freebsd_major"], row["arch"])
-        if field not in outputs:
-            failures.append(f"row {row}: leg step did not emit outputs.{field} (got {sorted(outputs)})")
-            continue
-        release_side_name = f"pfBlockerNG-relpkg-{outputs[field]}-{row['arch']}"
+        outputs = _run_leg_step(tmp_path, row["freebsd_major"])
+        assert outputs.get("abi") == f"FreeBSD:{row['freebsd_major']}:amd64", (
+            f"row {row}: leg step emitted an unexpected abi: {outputs!r}"
+        )
+        release_side_name = f"pfBlockerNG-relpkg-fbsd{row['freebsd_major']}"
         ui_name, smoke_name = _consumer_side_names(row)
         if not (release_side_name == ui_name == smoke_name):
             failures.append(f"row {row}: release={release_side_name!r} ui={ui_name!r} smoke={smoke_name!r}")

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -770,3 +770,32 @@ def test_healthcheck_nonempty_matrix_with_matching_pkgs_still_passes(tmp_path: P
         assets_json='[{"name":"pfBlockerNG-src.tar.gz"},{"name":"pfBlockerNG-relpkg-ce-2.8-amd64.pkg"}]',
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_healthcheck_counts_extra_pkgs_dep_assets_too(tmp_path: Path) -> None:
+    """issue #1806 B1 (delta review finding): attach-pkgs's pfBlockerNG-relpkg-*
+    sweep ALSO attaches each major's dep .pkg artifact
+    (pfBlockerNG-relpkg-deppkgs-fbsd<major>) -- a deliberate release asset, not
+    a leak. EXPECTED_PKGS must count those too, or a release with any major's
+    extra_pkgs non-empty (CE today) fails this healthcheck and gets stuck as a
+    draft even though every expected asset IS present (dry-run CI never
+    exercises attach/publish, so no workflow run catches this pre-merge).
+
+    Two build-matrix rows: major 15 with one extra_pkgs entry, major 16 with
+    none. Draft carries exactly 2 branch .pkgs + 1 dep .pkg (the CE dep) + the
+    source archive -- a fully complete, correct draft. Must pass.
+    """
+    completed = _run_healthcheck(
+        tmp_path,
+        build_matrix=(
+            '[{"freebsd_major":"15","extra_pkgs":["textproc/py-charset-normalizer"]},'
+            '{"freebsd_major":"16","extra_pkgs":[]}]'
+        ),
+        assets_json=(
+            '[{"name":"pfBlockerNG-src.tar.gz"},'
+            '{"name":"pfBlockerNG-relpkg-fbsd15.pkg"},'
+            '{"name":"pfBlockerNG-relpkg-fbsd16.pkg"},'
+            '{"name":"py311-charset-normalizer-3.4.4.pkg"}]'
+        ),
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -32,6 +32,8 @@ _spec.loader.exec_module(cvl)
 _FREEBSD15 = "FreeBSD" + ":15:amd64"
 _FREEBSD14 = "FreeBSD" + ":14"
 _FREEBSD17 = "FreeBSD" + ":17"
+# NO_ARCH wildcard ABI (issue #1806) — a real Netgate noarch package's manifest.
+_FREEBSD15_WILDCARD = "FreeBSD" + ":15:*"
 _PY311 = "py3" + "11"
 _PY311_PKG = _PY311 + "-sqlite3"
 _PY3110_LOOKALIKE = _PY311 + "0"
@@ -54,6 +56,16 @@ def test_flags_freebsd_abi_exact_quoted_value(tmp_path: Path) -> None:
     line = f'_ABI="{_FREEBSD15}"\n'
     violations = _find(tmp_path, line)
     assert len(violations) == 1, f"exact quoted FreeBSD ABI must be flagged; got {violations}"
+    assert violations[0][1] == 1
+
+
+def test_flags_wildcard_freebsd_abi_exact_quoted_value(tmp_path: Path) -> None:
+    """A NO_ARCH package's wildcard ABI (issue #1806, e.g. "FreeBSD:15:*") gets the
+    SAME allow-list treatment as a concrete one — restating it as a literal is the
+    same drift hazard, so it must be flagged too."""
+    line = f'_ABI="{_FREEBSD15_WILDCARD}"\n'
+    violations = _find(tmp_path, line)
+    assert len(violations) == 1, f"exact quoted wildcard FreeBSD ABI must be flagged; got {violations}"
     assert violations[0][1] == 1
 
 
@@ -488,6 +500,19 @@ def _current_shape_matrix() -> dict[str, Any]:
 def test_matrix_tokens_current_shape_covered() -> None:
     uncovered = cvl.uncovered_matrix_tokens(_current_shape_matrix())
     assert uncovered == [], f"the live-shape matrix must be fully covered; got {uncovered}"
+
+
+def test_matrix_tokens_emit_and_cover_wildcard_abi() -> None:
+    """_matrix_tokens ALSO emits the wildcard-ABI form (FreeBSD:<major>:*) for every
+    active entry (issue #1806: all pfSense-pkg-pfBlockerNG ports are NO_ARCH), and
+    the detection regex covers it — so a new wildcard literal in source/docs gets
+    the same allow-list treatment as a concrete one, exercised by the tripwire."""
+    m = _current_shape_matrix()
+    tokens = cvl._matrix_tokens(m)
+    assert _FREEBSD15_WILDCARD in tokens
+    assert "FreeBSD" + ":16:*" in tokens
+    uncovered = cvl.uncovered_matrix_tokens(m)
+    assert uncovered == [], f"wildcard-ABI matrix tokens must be covered; got {uncovered}"
 
 
 def test_matrix_tokens_dot_x_suffix_stripped() -> None:


### PR DESCRIPTION
Closes the CE dependency gap for `py311-charset-normalizer` (issue #1806) and, per owner direction, retires the arch dimension from the whole package pipeline while it's open: NO_ARCH ports, arch-less catalogs, per-major builds, matrix-driven extra dependencies, harness install-like-a-user, and post-upgrade dependency reconciliation.

## Why

Netgate builds `py311-charset-normalizer` (needed by #1797's feed-encoding converter) for **Plus only**; no CE 2.8.1 package exists anywhere public (probed: fresh guest catalogs, the mirror's `packagesite.pkg`, pkg.FreeBSD.org's py312-only flavor set). The FreeBSD-ports `RUN_DEPENDS` is pushed, so CE smoke legs were red until this branch: the dependency now ships from **our** pkg repository, and the harness installs it the way a real user's `pkg install` would — the CE image stays deliberately dep-free.

## What (by layer, each step independently verifier-gated)

- **A — dep-package builder + catalog fold**: `scripts/build-dep-pkg-portable.py` builds a NO_ARCH `.pkg` straight from the port definition (distinfo-pinned sdist, pep517 via pip, entry-point stub parity, `FreeBSD:<major>:*` stamp — matching Netgate's own noarch convention, probed live); `build-repo-portable.py --dep-pkgs` folds dep packages into release+nightly catalogs **post-retention** (pre-retention folding would compete with the stable pins — pinned by test).
- **B — NO_ARCH everywhere**: the three `pfSense-pkg-pfBlockerNG*` ports are `NO_ARCH` (pushed to the ports fork); `build-pkg-portable.py` stamps wildcard abi/arch for NO_ARCH ports; catalogs are **arch-less** (`release/<varver>/` directly) and hard-require wildcard packages (loud tripwire if a compiled dep ever appears); all four repo-conf producers emit arch-less URLs byte-identically.
- **C — per-major collapse + matrix schema**: the version matrix drops `arch` (an arch-less catalog of wildcard packages serves every CPU arch by construction — the aarch64 row is retired) and gains `extra_pkgs` (port origins per edition); BUILD matrix dedups to one row per FreeBSD major (php/py mismatch = hard error, extra_pkgs union, stray-key strip); artifact naming collapses to `…-fbsd<major>`; release healthcheck counts distinct majors; docs + prose mirror swept (including the pre-existing 9-vs-10 RUN_DEPENDS drift), ADR-24 amended (append-only).
- **D — harness ships + installs the dep like a user**: per-major `pfBlockerNG-deppkgs-fbsd<major>` artifact (never inside the branch-pkg artifact — the N_PKG=1 guards stay); `SMOKE_DEP_PKGS` → `install-pkg.sh` installs deps in order before the branch pkg (net-new shellspec: order, fail-loud, regression pin); on-box path builds deps from the current ref's matrix row; the repo-install leg stages them in the guest catalog, so its `"Missing dependency"` assertions prove the real user path.
- **E — post-upgrade reconcile + shed** (owner request): `scripts/image-upgrade.sh` gains a phase between the version-poll and the health gate: install/verify the **core** RUN_DEPENDS set for the new version's row (py-flavor-flip aware; fail-closed, no publish on a miss); shed old-flavor core strays and extra-derived packages whose origin the new row dropped. Extras never enter the image's install/verify set — they're a per-leg harness concern (CE image stays dep-free; Plus's Netgate-baked copy provably untouched).

## Proof

- **Every step**: red→green test-first (frozen hashes), independent small-tier verifier gate (re-derived red proofs, per-hunk revert matrices, live-data probes) — six gate records in the session.
- **Live end-to-end** (leased pool box, this branch): dep pkg built on-box from the port definition → `SMOKE_DEP_PKGS` → dep-first install → branch pkg (new RUN_DEPENDS, wildcard-stamped from the NO_ARCH ports) deployed on the **dep-free** CE image → **50/50 smoke tests green**. The leg burned down four real wiring defects on the way (indirect `DISTVERSION`, sparse-checkout gap, pip-less box python, stdout-contract leak) — each fixed red-first.
- **Already landed around this PR**: ci-metadata #1826 (arch retired, `extra_pkgs` added — compatible both ways with old/new readers); ports fork NO_ARCH + RUN_DEPENDS commits pushed; smoke images republished (Plus with the real Netgate dep baked; CE clean + dep-free; both minus 7-Zip).

## After merge (tracked on #1806)

`pfBlockerNG/pkg`'s `publish.yml` gains the dep-pkg build + `--dep-pkgs` pass (it consumes this repo's scripts at run time, so it inherits everything else); until then a `pkg_artifact_prefix` release-verification run stays dep-free by design (documented in the workflow).

Fixes #1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for supplying and building extra runtime dependency package artifacts when upstream copies are missing.
  * Added dependency reconciliation after upgrades, including verification and shedding of outdated packages.

* **Improvements**
  * Simplified package releases and repositories to an arch-less layout with one package/catalog per FreeBSD major.
  * Updated artifact naming and smoke/UI package reuse to match the new FreeBSD-major conventions.
  * Improved edition selection when multiple editions share the same FreeBSD major.

* **Documentation**
  * Updated architecture notes, version guidance, and runbooks for arch-less catalogs and the new artifact behavior.

* **Tests**
  * Expanded coverage for the revised matrices, NO_ARCH wildcard behavior, repo layout, and dependency packaging flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->