### PR TITLE
mcp-token-savior: bump the Token Savior pin to 4.21.0

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,6 +7,6 @@ max_depth = 2
 
 [mcp_servers.token-savior-recall]
 command = "sh"
-args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 0e06c8f1bb1c685304170c615b06dea1ae4339ed22adbc8e7fc478a4eac33453 && exec sh "$root/scripts/mcp-token-savior.sh"''']
+args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 1349bdcaebf93cbaf90c174f212512652668c4c4bfb7ddd813438faa774d6069 && exec sh "$root/scripts/mcp-token-savior.sh"''']
 env = { TOKEN_SAVIOR_CLIENT = "codex" }
 startup_timeout_sec = 120

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -2,7 +2,7 @@
 # mcp-token-savior.sh — shared Claude/Codex stdio launcher for the token-savior MCP
 # server (wired via .mcp.json and .codex/config.toml).
 # Installs TS_SOURCE into a per-user cached venv, then execs it. The default TS_SOURCE pins
-# upstream token-savior-recall 4.20.0 with the MCP and vector-memory extras. A TS_SOURCE change
+# upstream token-savior-recall 4.21.0 with the MCP and vector-memory extras. A TS_SOURCE change
 # is detected via the .pfb-ts-source stamp and triggers a clean venv rebuild;
 # a mkdir lock serializes concurrent sessions racing that rebuild (the venv is one shared
 # per-user cache). Requires python3 >= 3.11.
@@ -15,7 +15,7 @@
 #                          passes codex explicitly)
 #   TOKEN_SAVIOR_PROFILE   server tool profile (default: optimized)
 #   TS_VENV                venv location (default: ${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv)
-#   TS_SOURCE              pip requirement to install (default: upstream 4.20.0)
+#   TS_SOURCE              pip requirement to install (default: upstream 4.21.0)
 #   TS_LOCK_WAIT           max seconds to wait on another session's rebuild (default 300)
 #   INCLUDE_PATTERNS       colon-separated index globs; the default below REPLACES the
 #                          server's built-in list, which lacks .php/.inc/.sh — this repo's
@@ -43,7 +43,7 @@ if [ "$venv_bad" = 1 ]; then
 fi
 bin="$venv/bin/token-savior"
 stamp="$venv/.pfb-ts-source"
-TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector]==4.20.0}"
+TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector]==4.21.0}"
 
 # stdout is the MCP stdio channel — install chatter must stay on stderr
 if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -232,12 +232,12 @@ EOF
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
-  It 'installs exact upstream Token Savior 4.20.0 on first run'
+  It 'installs exact upstream Token Savior 4.21.0 on first run'
     When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" sh "${SCRIPT}"
     The status should be success
     The output should equal 'INSTALLED'
     The stderr should equal ''
-    The contents of file "${WORK}/venv/pip-args.log" should equal 'token-savior-recall[mcp,memory-vector]==4.20.0'
+    The contents of file "${WORK}/venv/pip-args.log" should equal 'token-savior-recall[mcp,memory-vector]==4.21.0'
   End
 
   It 'rebuilds the venv when the recorded TS_SOURCE stamp no longer matches'


### PR DESCRIPTION
Bump the pinned upstream Token Savior release from 4.20.0 to 4.21.0 (released 2026-07-28).

## Changes

- `scripts/mcp-token-savior.sh`: `TS_SOURCE` default → `token-savior-recall[mcp,memory-vector]==4.21.0` (+ the two comment references).
- `tests/shell/mcp_token_savior_spec.sh`: pin expectations follow.
- `.codex/config.toml`: launcher SHA-256 integrity pin refreshed (`1349bdca…`), verified by executing the same hash check the Codex launcher runs.

## Upstream 4.21.0 highlights

MCP tool annotations: `readOnlyHint`/`destructiveHint` classification shipped via `list_tools()`, `read_only_tool_names()` exported, with a guard test against unclassified tools.

## Verification

- `shellspec tests/shell/mcp_token_savior_spec.sh` — 26 examples, 0 failures.
- `scripts/agent/run-gates.sh --diff origin/devel` — GATES: PASS (sh -n, shellcheck, shellspec under dash).
- PyPI release `4.21.0` confirmed present before pinning.

A `TS_SOURCE` change triggers the clean venv rebuild via the `.pfb-ts-source` stamp on next session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
