### PR TITLE
ci: remove the GitHub Models changelog/notes drafts from the release flow

### DIFF
--- a/.agents/context/release.md
+++ b/.agents/context/release.md
@@ -20,30 +20,25 @@ bump on our **`pfBlockerNG/FreeBSD-ports` fork** (self-hosted distribution, no u
 
 ## Release notes pipeline
 
-Body precedence: a **committed `docs/release-notes/TAG.md` wins** (curated, or persisted from
-a prior run) — when present the Models step is skipped; else **GitHub Models**
-(`actions/ai-inference`, model `openai/gpt-4.1` — no secret, the built-in token +
-`permissions: models:read`, free tier) drafts it; else a placeholder (the release never blocks
-on the generator). When Models runs, a shell step gathers the commits since the previous
-same-channel release (`prev_tag` classifies each tag's channel via `release-version.sh`) and
-feeds them with the static system prompt in `scripts/release-notes-prompt.txt`; the model
-returns a `SUMMARY:` line (→ the Release title suffix; the title is
-`YYYY-MM-DD - VER — 3-word summary`, ISO date prefixed so GitHub's alphabetical release sort
-stays chronological) plus a Markdown block grouping user-facing changes under
-**Features / Improvements / Bug Fixes** with PR/issue links (CI/test/tooling/ADR noise
-filtered), ending with the compare link. A committed file carries the same notes; its title
-summary rides in an optional first-line `<!-- SUMMARY: … -->` marker (stripped from the
-rendered body). Generated notes are **persisted** to `docs/release-notes/TAG.md` by the
-`persist-notes` job (committed to the channel branch; docs-only ⇒ CI-skipped); a pre-committed
-file is left untouched. To author notes by hand, commit `docs/release-notes/TAG.md` — same
-format. To swap models, change the `model:` input; to use Claude Haiku on a Max plan, flip the
-step to the Claude CLI with `CLAUDE_CODE_OAUTH_TOKEN` (prompt file + parser reused).
+Body precedence: a **committed `docs/release-notes/TAG.md` wins** (curated, or committed by
+`prepare-release`'s own placeholder writer) — otherwise the workflow writes a **deterministic
+placeholder** ending in the compare link (`prev_tag` classifies each tag's channel via
+`release-version.sh` to find the previous same-channel release for that link). GitHub Models
+drafting was removed (`ci: remove the GitHub Models changelog/notes drafts from the release
+flow`, release run 30379645002) — it never produced a working result. A committed file's
+title summary rides in an optional first-line `<!-- SUMMARY: … -->` marker (stripped from the
+rendered body; the title is `YYYY-MM-DD - VER — summary`, ISO date prefixed so GitHub's
+alphabetical release sort stays chronological). To author real notes, commit
+`docs/release-notes/TAG.md` before dispatching — the **`/release-with-changelog`** skill does
+this for you, applying the same prompt template `scripts/release-notes-prompt.txt` used to
+describe the desired shape (group user-facing changes under **Features / Improvements /
+Bug Fixes** with PR/issue links, CI/test/tooling/ADR noise filtered).
 **Nightly builds get no GitHub Release.**
 
 **Dry-run.** `release.yml`'s `workflow_dispatch` is a no-publish harness: pass the `tag` to
 simulate with `dry_run=true` (default) to validate the scheme, build the `.pkg` artifacts, and
-render the body (the Models draft runs; the real body shows in the run summary) — publishing
-nothing. Dispatchable only from the default branch once merged.
+render the body (the real body shows in the run summary) — publishing nothing. Dispatchable
+only from the default branch once merged.
 
 ## Self-hosted pkg repository (ADR-17)
 

--- a/.agents/skills/release-with-changelog/SKILL.md
+++ b/.agents/skills/release-with-changelog/SKILL.md
@@ -1,27 +1,29 @@
 ---
 name: release-with-changelog
 description: >
-  Cut a pfBlockerNG release WITH hand-authored release notes: play the role of the
-  GitHub Models step — write docs/release-notes/<tag>.md from the commit range using the
-  same prompt the workflow feeds the model — commit it on the channel branch, then hand
-  off to the /release skill to validate the scheme + dispatch the release workflow (which
-  creates+pushes the tag and publishes; no tag is pushed by hand). Because the file is committed, the
-  workflow's GitHub Models step is skipped and the release body comes from your file. Use
-  this when Models is unavailable (e.g. the org hasn't enabled it), when you want curated
-  notes, or when the user says "write the changelog and release", "release with notes",
-  "play the model and cut the release", or invokes /release-with-changelog.
+  Cut a pfBlockerNG release WITH hand-authored release notes: write
+  docs/release-notes/<tag>.md from the commit range following the same prompt template the
+  workflow used to feed a model — commit it on the channel branch, then hand off to the
+  /release skill to validate the scheme + dispatch the release workflow (which
+  creates+pushes the tag and publishes; no tag is pushed by hand). Because the file is
+  committed, the release body comes from your file instead of the deterministic
+  placeholder. This is the recommended way to produce real release notes (the workflow no
+  longer drafts them — GitHub Models never produced a working result), or when the user
+  says "write the changelog and release", "release with notes", or invokes
+  /release-with-changelog.
   Args: <tag> (e.g. v4.0.0.alpha.1).
 ---
 
 You author the release notes yourself, commit them, then cut the release. The release
-workflow uses a committed `docs/release-notes/<tag>.md` **in preference to** GitHub Models
-(it skips the Models step when the file exists), so providing the file IS "playing the
-model". The actual scheme validation + workflow dispatch (the workflow creates+pushes the
-tag and publishes — you never push a tag by hand) is delegated to **`/release`** — do not
-re-implement it.
+workflow uses a committed `docs/release-notes/<tag>.md` **in preference to** its
+deterministic placeholder, so providing the file is how real release notes happen — the
+workflow itself no longer drafts anything (GitHub Models drafting was removed; it never
+produced a working result). The actual scheme validation + workflow dispatch (the workflow
+creates+pushes the tag and publishes — you never push a tag by hand) is delegated to
+**`/release`** — do not re-implement it.
 
-`scripts/release-notes-prompt.txt` is the **same system prompt** the workflow feeds the
-model; you apply it by hand here. `scripts/release-version.sh` classifies the tag/channel.
+`scripts/release-notes-prompt.txt` is the prompt template the workflow used to feed a
+model; apply it by hand here. `scripts/release-version.sh` classifies the tag/channel.
 
 ## Arguments
 
@@ -41,14 +43,14 @@ model; you apply it by hand here. `scripts/release-version.sh` classifies the ta
    `https://github.com/<owner>/<repo>/compare/<PREV>...<tag>` (or `…/commits/<tag>` when there
    is no `PREV`).
 
-3. **Gather the commits the "model" sees.**
+3. **Gather the commits the notes cover.**
    `git log <PREV>..origin/<branch> --no-merges --pretty='%h %s' -- src/ scripts/`.
    For a **genesis release of a new series** (the first `X.0.0.alpha.1`, whose `PREV` is an
    old-scheme tag), also describe the headline features of the whole series — the narrow
    `PREV..HEAD` range alone undersells it; read prior notes / ADR titles for the arc.
 
-4. **Author the notes by applying `scripts/release-notes-prompt.txt`.** Produce exactly what
-   the model would: keep only user-relevant changes (drop CI / tests / tooling / lint /
+4. **Author the notes by applying `scripts/release-notes-prompt.txt`.** Follow its shape:
+   keep only user-relevant changes (drop CI / tests / tooling / lint /
    internal refactors / dev-docs); group under `## Features`, `## Improvements`, `## Bug Fixes`
    (omit an empty group); link each item's PR/issue as `([#N](…/issues/N))` when the subject
    references `#N` (the `/issues/` path resolves for PRs too); **never name internal ADRs** —
@@ -73,14 +75,14 @@ model; you apply it by hand here. `scripts/release-version.sh` classifies the ta
    the channel↔branch scheme, checks CI is green on the release commit (now including the notes
    commit), and **dispatches `release.yml` with `dry_run=false`** — the workflow then creates and
    pushes the tag on the channel-branch tip itself (no hand-pushed tag), sees the committed notes
-   file, **skips the Models step**, and publishes the Release with your notes as the body and the
-   `SUMMARY` as the title suffix.
+   file, and publishes the Release with your notes as the body and the `SUMMARY` as the title
+   suffix.
 
 ## Guardrails
 
 - **The notes file must land on the channel branch before the tag** — a tag whose commit
-  predates the file means the workflow won't see it (it would fall through to Models, or a
-  placeholder). Order matters: notes commit first, tag second.
+  predates the file means the workflow won't see it (it would fall through to the
+  deterministic placeholder). Order matters: notes commit first, tag second.
 - **Inherit every `/release` guardrail** — channel↔branch enforcement, immutable tags (cut the
   next `.N` instead of moving one), tag-only pushes (never a direct `main`/`devel` push). This
   skill only adds the notes-authoring + commit in front.

--- a/.agents/skills/release-with-changelog/SKILL.md
+++ b/.agents/skills/release-with-changelog/SKILL.md
@@ -45,6 +45,8 @@ model; apply it by hand here. `scripts/release-version.sh` classifies the tag/ch
 
 3. **Gather the commits the notes cover.**
    `git log <PREV>..origin/<branch> --no-merges --pretty='%h %s' -- src/ scripts/`.
+   When **no prior tag exists** (`PREV` empty — the very first release), drop the range:
+   `git log origin/<branch> --no-merges --pretty='%h %s' -- src/ scripts/`.
    For a **genesis release of a new series** (the first `X.0.0.alpha.1`, whose `PREV` is an
    old-scheme tag), also describe the headline features of the whole series — the narrow
    `PREV..HEAD` range alone undersells it; read prior notes / ADR titles for the arc.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -86,12 +86,12 @@ devel" guard, applied before the tag exists.
      is armed.
 
 5. **Notes source.** The release body comes from `docs/release-notes/<tag>.md` when that file
-   is committed on the channel branch — it is **authoritative**, and the GitHub Models step is
-   **skipped** (an optional first-line `<!-- SUMMARY: … -->` marker becomes the title suffix,
-   stripped from the body). When no file exists, GitHub Models (`openai/gpt-4.1`) drafts it from
-   the commit range and the `persist-notes` job records it. To author/curate the notes yourself
-   (or to "play the model" when Models is unavailable), use **`/release-with-changelog`** — it
-   writes the file, commits it, then calls this skill. Don't author notes here unless asked.
+   is committed on the channel branch — it is **authoritative** (an optional first-line
+   `<!-- SUMMARY: … -->` marker becomes the title suffix, stripped from the body). When no file
+   exists, the workflow writes a deterministic placeholder body instead (GitHub Models drafting
+   was removed — it never produced a working result; release run 30379645002). To author the
+   real notes, use **`/release-with-changelog`** — it writes the file, commits it, then calls
+   this skill. Don't author notes here unless asked.
 
 6. **Confirm, then dispatch.** Dispatching with `dry_run=false` is **irreversible and
    public** (the workflow creates+pushes the tag, cuts a GitHub Release, publishes the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,6 @@ jobs:
     if: ${{ github.event.inputs.dry_run == 'false' }}
     permissions:
       contents: write
-      models: read    # actions/ai-inference for the changelog draft
       checks: read    # gh api /commits/<sha>/check-runs to assert CI green
 
     outputs:
@@ -167,10 +166,11 @@ jobs:
       - name: Detect committed changelog
         id: detect
         # A committed docs/release-notes/<tag>.md is the curated/authoritative notes;
-        # when it exists the Models draft is skipped and the commit step is a no-op.
-        # When absent, also prepare the prompt inputs (prev-tag range + user prompt file)
-        # so the Models step can draft the notes inline here — mirroring the same logic
-        # as the release job's prev_tag + notes_prep steps.
+        # when it exists the write step below is a no-op. When absent, the write step's
+        # deterministic placeholder is the ONLY notes path — GitHub Models drafting was
+        # removed (it never produced a working result; release run 30379645002); use
+        # /release-with-changelog to author real notes before dispatching. Compute the
+        # compare-link inputs the placeholder needs either way.
         env:
           TAG:     ${{ steps.resolve.outputs.tag }}
           CHANNEL: ${{ steps.resolve.outputs.channel }}
@@ -206,93 +206,38 @@ jobs:
               | awk -v cur="$TAG" 'found{print; exit} $0==cur{found=1}' ) || true
           fi
 
-          # Commit range + compare link.
+          # Compare link the placeholder body ends with.
           if [ -n "$PREV" ]; then
-            RANGE="${PREV}..HEAD"
             CMP_URL="https://github.com/${REPO}/compare/${PREV}...${TAG}"
             FULL_LINK="**Full changelog:** [\`${PREV}\` → \`${TAG}\`](${CMP_URL})"
           else
-            RANGE="HEAD"
             CMP_URL="https://github.com/${REPO}/commits/${TAG}"
             FULL_LINK="**Full changelog:** [commits in \`${TAG}\`](${CMP_URL})"
           fi
 
-          COMMITS=$(git log "$RANGE" --no-merges --pretty=format:'%h %s' -- src/ scripts/)
-          [ -n "$COMMITS" ] || COMMITS="(no src/ or scripts/ changes in range)"
-
-          PROMPT_FILE="${RUNNER_TEMP}/notes_user_prompt.txt"
-          {
-            printf 'Context:\n'
-            printf -- '- Repository (OWNER/REPO): %s\n' "$REPO"
-            printf -- '- Release tag: %s\n' "$TAG"
-            printf -- '- Previous %s release: %s\n' "$CHANNEL" "${PREV:-<none>}"
-            printf -- '- Final line (use verbatim): %s\n\n' "$FULL_LINK"
-            printf 'Commits:\n%s\n' "$COMMITS"
-          } > "$PROMPT_FILE"
-
-          echo "cmp_url=${CMP_URL}" >> "$GITHUB_OUTPUT"
           {
             echo "full_link<<__FL__"
             printf '%s\n' "$FULL_LINK"
             echo "__FL__"
           } >> "$GITHUB_OUTPUT"
-          echo "prompt_file=${PROMPT_FILE}" >> "$GITHUB_OUTPUT"
-
-      - name: Draft changelog (GitHub Models)
-        id: ai
-        # Single-shot inference; skipped when a committed notes file already exists.
-        # continue-on-error so a Models hiccup falls through to the write step which
-        # will emit a minimal placeholder instead.
-        if: ${{ steps.detect.outputs.has_file != 'true' }}
-        continue-on-error: true
-        uses: actions/ai-inference@v1
-        with:
-          model: openai/gpt-4.1
-          max-tokens: 2000
-          system-prompt-file: scripts/release-notes-prompt.txt
-          prompt-file: ${{ steps.detect.outputs.prompt_file }}
 
       - name: Write + commit the changelog
         id: write-changelog
-        # Parse the model response (SUMMARY line + first ```-fenced block) and write
-        # docs/release-notes/<tag>.md, then commit it.  If the model produced nothing,
-        # write a minimal placeholder (so the tag always carries a notes file).
-        # Skipped when a committed file already exists (has_file=true).
+        # No committed notes file (has_file=false): write the deterministic placeholder
+        # — the ONLY path here now that GitHub Models drafting is gone (it never produced
+        # a working result; release run 30379645002). Use /release-with-changelog to
+        # author real notes before dispatching. Skipped when a committed file already
+        # exists (has_file=true).
         if: ${{ steps.detect.outputs.has_file != 'true' }}
         env:
           TAG:       ${{ steps.resolve.outputs.tag }}
           FULL_LINK: ${{ steps.detect.outputs.full_link }}
-          CMP_URL:   ${{ steps.detect.outputs.cmp_url }}
-          RESP_FILE: ${{ steps.ai.outputs['response-file'] }}
         run: |
           set -u
           NOTES_FILE="docs/release-notes/${TAG}.md"
           mkdir -p docs/release-notes
-          SUMMARY=""
-          BODY=""
-
-          if [ -n "${RESP_FILE:-}" ] && [ -s "${RESP_FILE}" ]; then
-            SUMMARY=$(grep -m1 '^SUMMARY:' "$RESP_FILE" | sed 's/^SUMMARY:[[:space:]]*//' | tr -d '\r') || true
-            BODY=$(awk '/^```/{fence++; next} fence==1{print}' "$RESP_FILE")
-          fi
-
-          if [ -z "$BODY" ]; then
-            echo "No model response — writing a placeholder notes file."
-            BODY=$(printf '_Release notes unavailable; see the full changelog below._\n\n%s' "$FULL_LINK")
-          fi
-
-          # Guarantee the compare link is present (append if the source omitted it).
-          case "$BODY" in
-            *"${CMP_URL}"*) ;;
-            *) BODY=$(printf '%s\n\n%s' "$BODY" "$FULL_LINK") ;;
-          esac
-
-          # Write the file: optional SUMMARY marker as first line, then the body.
-          if [ -n "$SUMMARY" ]; then
-            printf '<!-- SUMMARY: %s -->\n%s\n' "$SUMMARY" "$BODY" > "$NOTES_FILE"
-          else
-            printf '%s\n' "$BODY" > "$NOTES_FILE"
-          fi
+          echo "No committed release notes — writing a placeholder notes file."
+          printf '_Release notes unavailable; see the full changelog below._\n\n%s\n' "$FULL_LINK" > "$NOTES_FILE"
 
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -483,7 +428,6 @@ jobs:
     if: ${{ always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') && needs.read-matrix.result == 'success' }}
     permissions:
       contents: write
-      models: read   # actions/ai-inference (GitHub Models) for the release-notes draft
 
     outputs:
       tag:         ${{ steps.meta.outputs.tag }}
@@ -601,47 +545,25 @@ jobs:
 
       - name: Prepare release-notes inputs
         id: notes_prep
-        # Gather the commit range + the user prompt for the model. GitHub Models does a
-        # single prompt→completion (it cannot run git itself), so we collect the commits
-        # here and feed them in. Emits the compare link + the assembled prompt-file path.
+        # Compute the compare-link inputs the placeholder/committed-notes body needs.
+        # GitHub Models drafting was removed (it never produced a working result;
+        # release run 30379645002) — a committed docs/release-notes/<tag>.md is now the
+        # only real notes source; the assemble-body step below falls back to a
+        # deterministic placeholder ending in this compare link. Use
+        # /release-with-changelog to author real notes before dispatching.
         env:
-          REPO:    ${{ github.repository }}
-          TAG:     ${{ steps.meta.outputs.tag }}
-          PREV:    ${{ steps.prev_tag.outputs.tag }}
-          CHANNEL: ${{ steps.meta.outputs.channel }}
-          DRY_RUN: ${{ steps.meta.outputs.dry_run }}
+          REPO: ${{ github.repository }}
+          TAG:  ${{ steps.meta.outputs.tag }}
+          PREV: ${{ steps.prev_tag.outputs.tag }}
         run: |
           set -u
-          # dry_run=true: operate off HEAD (tag does not exist yet).
-          # dry_run=false: operate off the tag (the just-created tag, already checked out).
-          if [ "$DRY_RUN" = "true" ]; then HEAD_REF="HEAD"; else HEAD_REF="$TAG"; fi
-
-          # Commit range + the compare/changelog link the notes end with.
           if [ -n "$PREV" ]; then
-            RANGE="${PREV}..${HEAD_REF}"
             CMP_URL="https://github.com/${REPO}/compare/${PREV}...${TAG}"
             FULL_LINK="**Full changelog:** [\`${PREV}\` → \`${TAG}\`](${CMP_URL})"
           else
-            RANGE="$HEAD_REF"
             CMP_URL="https://github.com/${REPO}/commits/${TAG}"
             FULL_LINK="**Full changelog:** [commits in \`${TAG}\`](${CMP_URL})"
           fi
-
-          COMMITS=$(git log "$RANGE" --no-merges --pretty=format:'%h %s' -- src/ scripts/)
-          [ -n "$COMMITS" ] || COMMITS="(no src/ or scripts/ changes in range)"
-
-          # Assemble the user prompt (Context + commit list); the static instructions are
-          # the system prompt (scripts/release-notes-prompt.txt). Written to a file so the
-          # model-generated content is never interpolated through the shell.
-          PROMPT_FILE="${RUNNER_TEMP}/notes_user_prompt.txt"
-          {
-            printf 'Context:\n'
-            printf -- '- Repository (OWNER/REPO): %s\n' "$REPO"
-            printf -- '- Release tag: %s\n' "$TAG"
-            printf -- '- Previous %s release: %s\n' "$CHANNEL" "${PREV:-<none>}"
-            printf -- '- Final line (use verbatim): %s\n\n' "$FULL_LINK"
-            printf 'Commits:\n%s\n' "$COMMITS"
-          } > "$PROMPT_FILE"
 
           echo "cmp_url=${CMP_URL}" >> "$GITHUB_OUTPUT"
           {
@@ -649,68 +571,36 @@ jobs:
             printf '%s\n' "$FULL_LINK"
             echo "__FL__"
           } >> "$GITHUB_OUTPUT"
-          echo "prompt_file=${PROMPT_FILE}" >> "$GITHUB_OUTPUT"
-          # A committed docs/release-notes/<tag>.md is the curated/authoritative notes for
-          # this release; when present it WINS and the Models step is skipped (below).
-          # On dry_run=false the checkout is the tag, which now contains the file committed
-          # by prepare-release — so this is the normal real-publish path.
-          if [ -f "docs/release-notes/${TAG}.md" ]; then HAS_FILE=true; else HAS_FILE=false; fi
-          echo "has_file=${HAS_FILE}" >> "$GITHUB_OUTPUT"
-          echo "Range: ${RANGE}  (committed notes file: ${HAS_FILE})"
-
-      - name: Draft release notes (GitHub Models)
-        id: ai
-        # Single-shot inference on GitHub Models with the built-in token (no secret, free
-        # tier; needs permissions: models:read on this job). The system prompt is the
-        # static instruction file; the user prompt is the Context + commit list above.
-        # SKIPPED when a committed docs/release-notes/<tag>.md already exists — a curated
-        # (or prepare-release-committed) file is authoritative. continue-on-error so a
-        # Models hiccup/rate-limit falls through to the fallback when it does run.
-        if: ${{ steps.notes_prep.outputs.has_file != 'true' }}
-        continue-on-error: true
-        uses: actions/ai-inference@v1
-        with:
-          model: openai/gpt-4.1
-          max-tokens: 2000
-          system-prompt-file: scripts/release-notes-prompt.txt
-          prompt-file: ${{ steps.notes_prep.outputs.prompt_file }}
 
       - name: Assemble release body
         id: changelog
-        # Parse the model output (SUMMARY line + the first ```-fenced block) into the
-        # release title + body. Resilient: if inference was skipped/failed/empty, fall
-        # back to a committed docs/release-notes/<tag>.md, else a placeholder. Always
-        # guarantees the compare link is present. Runs on every event, so a dry-run
-        # shows the real body that would be published.
+        # Precedence: a committed docs/release-notes/<tag>.md (curated, or committed by
+        # prepare-release's placeholder writer) wins; otherwise a deterministic
+        # placeholder — GitHub Models drafting was removed (it never produced a working
+        # result; release run 30379645002); use /release-with-changelog to author real
+        # notes before dispatching. Always guarantees the compare link is present. Runs
+        # on every event, so a dry-run shows the real body that would be published.
         env:
           TAG:       ${{ steps.meta.outputs.tag }}
           VERSION:   ${{ steps.meta.outputs.version }}
           CMP_URL:   ${{ steps.notes_prep.outputs.cmp_url }}
           FULL_LINK: ${{ steps.notes_prep.outputs.full_link }}
-          RESP_FILE: ${{ steps.ai.outputs['response-file'] }}
         run: |
           set -u
           SUMMARY=""
           BODY=""
           NOTES_FILE="docs/release-notes/${TAG}.md"
 
-          # Precedence: a committed notes file wins (curated, or committed by prepare-release);
-          # else the GitHub Models response; else a placeholder.
           if [ -f "$NOTES_FILE" ]; then
             echo "Using committed ${NOTES_FILE}"
             # Optional first-line marker '<!-- SUMMARY: ... -->' becomes the title suffix
             # and is stripped from the rendered body.
             SUMMARY=$(sed -n 's/^<!-- SUMMARY:[[:space:]]*\(.*[^[:space:]]\)[[:space:]]*-->[[:space:]]*$/\1/p' "$NOTES_FILE" | head -1 | tr -d '\r') || true
             BODY=$(sed '/^<!-- SUMMARY:.*-->[[:space:]]*$/d' "$NOTES_FILE")
-          elif [ -n "${RESP_FILE:-}" ] && [ -s "${RESP_FILE}" ]; then
-            echo "Using the GitHub Models draft."
-            SUMMARY=$(grep -m1 '^SUMMARY:' "$RESP_FILE" | sed 's/^SUMMARY:[[:space:]]*//' | tr -d '\r') || true
-            # Extract the content of the FIRST ```-fenced block (the description).
-            BODY=$(awk '/^```/{fence++; next} fence==1{print}' "$RESP_FILE")
           fi
 
           if [ -z "$BODY" ]; then
-            echo "No committed notes and no model response — using a placeholder."
+            echo "No committed notes — using a placeholder."
             BODY=$(printf '_Release notes unavailable; see the full changelog below._\n\n%s' "$FULL_LINK")
           fi
 


### PR DESCRIPTION
Owner order (release run 30379645002: the Models step failed again — it has never produced a working draft). Both `actions/ai-inference` steps go away along with their `models: read` permissions, prompt-assembly glue and comments; the committed `docs/release-notes/<tag>.md` stays authoritative and the deterministic placeholder body (compare link) becomes the only no-notes fallback. Skills + `.agents/context/release.md` reconciled — including removing references to a `persist-notes` job that never existed in the workflow (doc fiction; the real thing is the `Write + commit the changelog` step, which stays).

Verified: `actionlint` zero findings (baseline had 2 pre-existing in the rewritten steps), release test suite 118 passed untouched (no test pins any removed step), full gates PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes now use committed notes files when available.
  * Releases without authored notes receive consistent placeholder content with a full changelog link.
  * Optional summary markers are handled automatically in release descriptions.

* **Documentation**
  * Updated release guidance to reflect deterministic note generation.
  * Clarified how to author and commit release notes before tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->