### PR TITLE
ci: activate matrix entries with box-verified versions after publish

### DIFF
--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -89,10 +89,10 @@ on:
         default: "192.0.2.99"
         type: string
 
+# Least-privilege default; the refresh job elevates for its publish + the
+# activation PR (review: CWE-276).
 permissions:
-  contents: write        # push tracker/* activation-PR branches (NEVER ci-metadata itself)
-  packages: write
-  pull-requests: write   # open the activation PR
+  contents: read
 
 jobs:
   # ── Resolve refresh matrix (CE + Plus) ─────────────────────────────────────
@@ -201,6 +201,10 @@ jobs:
     if: ${{ needs.plan.outputs.count != '0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions:
+      contents: write        # push tracker/* activation-PR branches (NEVER ci-metadata itself)
+      packages: write        # publish the upgraded image to GHCR
+      pull-requests: write   # open the activation PR
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -397,6 +397,9 @@ jobs:
           # would swap the JOB's tree to the ci-metadata ref and break the
           # non-blocking smoke step that runs after this one (review CR2).
           WT=$(mktemp -d)
+          # Reap the worktree even when a git op below fails (set -e would
+          # otherwise skip the cleanup line).
+          trap 'git worktree remove --force "$WT" >/dev/null 2>&1 || true' EXIT
           git worktree add --force -B "$BR" "$WT" origin/ci-metadata
           cp "$NEWM" "$WT/supported-versions.json"
           git -C "$WT" add supported-versions.json

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -85,8 +85,9 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write        # push tracker/* activation-PR branches (NEVER ci-metadata itself)
   packages: write
+  pull-requests: write   # open the activation PR
 
 jobs:
   # ── Resolve refresh matrix (CE + Plus) ─────────────────────────────────────
@@ -202,7 +203,8 @@ jobs:
       - name: Checkout (for scripts/ + tests/smoke/)
         uses: actions/checkout@v6
         with:
-          persist-credentials: false
+          persist-credentials: true   # the activation step pushes tracker/* branches (issue #1837)
+          fetch-depth: 0              # reach the ci-metadata orphan ref
 
       - name: Enable KVM access for the runner user
         # GH-hosted ubuntu-latest ships /dev/kvm; the `runner` user is not in
@@ -301,7 +303,108 @@ jobs:
             --ssh-key "$PWD/smoke_key" \
             --compression "${{ inputs.compression }}" \
             --upgrade-timeout "${{ inputs.upgrade_timeout }}" \
+            --facts-out "$PWD/box-facts.env" \
             --upgrade-pkgs
+
+      # ── Activation PR: box-verified matrix update (issue #1837) ────────────
+      # The upgrade leg is the only moment automation has SSH into a live box
+      # running the NEW version. image-upgrade.sh gathered its facts
+      # (box-facts.env); if the leg family's matrix entry is not yet
+      # active-and-accurate, open ONE tracker/* PR setting ci: true and the
+      # box-verified php_version / py_flavor / freebsd_major. The full
+      # freebsd_version string only changes when the MAJOR moved (the matrix
+      # keeps its human convention, e.g. 16.0-RELEASE vs the box's
+      # 16.0-CURRENT); the raw box value is quoted in the PR body.
+      # Matrix writes remain auto-PR ONLY — never a ci-metadata push.
+      # Contract pinned by tests/test_image_refresh_plan_contract.py.
+      - name: Open activation PR (box-verified matrix update)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CHANNEL: ${{ matrix.label }}
+          FAMILY: ${{ matrix.pfsense_version }}
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          set -euo pipefail
+          if [ ! -s box-facts.env ]; then
+            echo "No box facts gathered — skipping the activation PR."
+            exit 0
+          fi
+          # shellcheck disable=SC1091
+          . ./box-facts.env
+          echo "Box facts: etc=${etc_version:-} php=${php_version:-} py=${py_flavor:-} fbsd=${freebsd_version:-}/${freebsd_major:-}"
+
+          git fetch origin ci-metadata -q
+          git show origin/ci-metadata:supported-versions.json > matrix_current.json
+          ENTRY=$(jq -c --arg v "$FAMILY" --arg c "$CHANNEL" '
+            first(.versions[] | select(.pfsense_version == $v and .channel == $c
+                                        and ((.arch // "amd64") == "amd64"))) // empty' matrix_current.json)
+          if [ -z "$ENTRY" ]; then
+            echo "::warning::no ${CHANNEL} ${FAMILY} matrix entry — nothing to activate"
+            exit 0
+          fi
+
+          NEWM=$(mktemp)
+          jq --arg v "$FAMILY" --arg c "$CHANNEL" \
+             --arg php "${php_version:-}" --arg py "${py_flavor:-}" \
+             --arg fbmaj "${freebsd_major:-}" --arg fb "${freebsd_version:-}" '
+            (.versions[] | select(.pfsense_version == $v and .channel == $c
+                                   and ((.arch // "amd64") == "amd64"))) |= (
+              .ci = true
+              | (if $php != "" then .php_version = $php else . end)
+              | (if $py != "" then .py_flavor = $py else . end)
+              | (if $fbmaj != "" and .freebsd_major != $fbmaj
+                 then .freebsd_major = $fbmaj | .freebsd_version = $fb
+                 else . end)
+            )' matrix_current.json > "$NEWM"
+
+          # Semantic compare — immune to on-disk formatting drift.
+          if [ "$(jq -S . matrix_current.json)" = "$(jq -S . "$NEWM")" ]; then
+            echo "Matrix entry already active and accurate — nothing to do."
+            rm -f "$NEWM"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BR="tracker/matrix-activate-${VARIANT}-${FAMILY}"
+          git checkout -B "$BR" origin/ci-metadata
+          cp "$NEWM" supported-versions.json
+          git add supported-versions.json
+          git commit -m "ci-metadata: activate ${CHANNEL} ${FAMILY} (box-verified)"
+          git push --force origin "$BR"
+
+          BODY_FILE=$(mktemp)
+          {
+            printf '## Activate pfSense %s %s (box-verified)\n\n' "$CHANNEL" "$FAMILY"
+            printf 'The %s image for `%s` was just published; these values were read from\n' "$CHANNEL" "$FAMILY"
+            printf 'the upgraded box itself right before poweroff:\n\n'
+            printf '| Fact | Box value |\n| --- | --- |\n'
+            printf '| /etc/version | `%s` |\n' "${etc_version:-?}"
+            printf '| PHP | `%s` |\n' "${php_version:-?}"
+            printf '| Python flavor | `%s` |\n' "${py_flavor:-?}"
+            printf '| FreeBSD | `%s` (major %s) |\n\n' "${freebsd_version:-?}" "${freebsd_major:-?}"
+            printf 'This PR sets `ci: true` (the image now exists for the smoke fan-out) and\n'
+            printf 'corrects any drifted version fields. The full `freebsd_version` string is\n'
+            printf 'only rewritten when the MAJOR changed — the matrix keeps its human\n'
+            printf 'convention otherwise.\n\n'
+            printf '_Opened automatically by image-refresh (issue #1837). Matrix changes are\n'
+            printf 'PRs only — merging is a human decision and re-fires the reconcile._\n'
+          } > "$BODY_FILE"
+
+          PR=$(gh pr list --repo "$REPO" --head "$BR" --base ci-metadata --state open \
+            --json number --jq '.[0].number // empty' || true)
+          if [ -z "$PR" ]; then
+            gh pr create --repo "$REPO" --base ci-metadata --head "$BR" \
+              --title "ci-metadata: activate ${CHANNEL} ${FAMILY} (box-verified)" \
+              --body-file "$BODY_FILE" \
+              || echo "::warning::Could not open the activation PR from $BR"
+          else
+            echo "  open PR #${PR} from $BR already exists — the force-push updated it"
+          fi
+          rm -f "$BODY_FILE" "$NEWM"
+          echo "Invariant confirmed: matrix changes proposed as PRs only — no ci-metadata push."
 
       # ── pfBlockerNG smoke (non-blocking, post-publish) ──────────────────────
       # Boots a THROWAWAY copy-on-write overlay of the JUST-PUBLISHED image

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -58,6 +58,11 @@ on:
         required: false
         default: "false"
         type: string
+      dry_run:
+        description: "If 'true', log the activation PR that WOULD be proposed but do not push or open it."
+        required: false
+        default: "false"
+        type: string
       direct_leg:
         description: "One fully-specified leg as JSON ({variant,label,pfsense_version,freebsd_version,image_name,branch,target,from,force_flag}) — how the reconcile loop (issue #1823) dispatches its planned actions. Takes precedence over self_refresh."
         required: false
@@ -325,14 +330,22 @@ jobs:
           CHANNEL: ${{ matrix.label }}
           FAMILY: ${{ matrix.pfsense_version }}
           VARIANT: ${{ matrix.variant }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           if [ ! -s box-facts.env ]; then
             echo "No box facts gathered — skipping the activation PR."
             exit 0
           fi
-          # shellcheck disable=SC1091
-          . ./box-facts.env
+          # NEVER source this file: its values come from the guest. Read the
+          # keys instead (image_facts_put already charset-gates them; parsing
+          # keeps a hostile or anomalous line inert either way — review B1).
+          fact() { sed -n "s/^$1=\\(.*\\)$/\\1/p" box-facts.env | head -1; }
+          etc_version=$(fact etc_version)
+          php_version=$(fact php_version)
+          py_flavor=$(fact py_flavor)
+          freebsd_version=$(fact freebsd_version)
+          freebsd_major=$(fact freebsd_major)
           echo "Box facts: etc=${etc_version:-} php=${php_version:-} py=${py_flavor:-} fbsd=${freebsd_version:-}/${freebsd_major:-}"
 
           git fetch origin ci-metadata -q
@@ -366,14 +379,26 @@ jobs:
             exit 0
           fi
 
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            echo "[DRY-RUN] WOULD open the activation PR for ${CHANNEL} ${FAMILY}:"
+            diff -u matrix_current.json "$NEWM" || true
+            rm -f "$NEWM"
+            exit 0
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           BR="tracker/matrix-activate-${VARIANT}-${FAMILY}"
-          git checkout -B "$BR" origin/ci-metadata
-          cp "$NEWM" supported-versions.json
-          git add supported-versions.json
-          git commit -m "ci-metadata: activate ${CHANNEL} ${FAMILY} (box-verified)"
-          git push --force origin "$BR"
+          # Build the PR branch in a SEPARATE worktree: `git checkout -B` here
+          # would swap the JOB's tree to the ci-metadata ref and break the
+          # non-blocking smoke step that runs after this one (review CR2).
+          WT=$(mktemp -d)
+          git worktree add --force -B "$BR" "$WT" origin/ci-metadata
+          cp "$NEWM" "$WT/supported-versions.json"
+          git -C "$WT" add supported-versions.json
+          git -C "$WT" commit -m "ci-metadata: activate ${CHANNEL} ${FAMILY} (box-verified)"
+          git -C "$WT" push --force origin "$BR"
+          git worktree remove --force "$WT" || true
 
           BODY_FILE=$(mktemp)
           {

--- a/scripts/image-lib.sh
+++ b/scripts/image-lib.sh
@@ -156,17 +156,35 @@ image_gather_facts() {
     # builtin exits ash/dash entirely (issue #1172; guard-enforced).
     true > "$_fo" || return 1
     _v=$($_run "/bin/sh -c 'cat /etc/version'" 2>/dev/null | tr -d '\r')
-    [ -n "$_v" ] && printf 'etc_version=%s\n' "$_v" >> "$_fo"
+    # Chokepoint: box values are consumed by CI. Only a single charset-safe
+    # token may be written — anything multi-line or metacharacter-bearing is
+    # dropped (same discipline as reconcile-plan.py's branch-name gate).
+    image_facts_put "$_fo" etc_version "$_v"
     _php=$($_run "/bin/sh -c '/usr/local/bin/php -v'" 2>/dev/null \
         | sed -n '1s/^PHP \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')
-    [ -n "$_php" ] && printf 'php_version=%s\n' "$_php" >> "$_fo"
+    image_facts_put "$_fo" php_version "$_php"
+    # Highest minor wins — a mid-upgrade box can carry two interpreters and
+    # `ls` order is lexical (python3.11 sorts before python3.9).
     _py=$($_run "/bin/sh -c 'ls /usr/local/bin'" 2>/dev/null \
-        | sed -n 's/^python3\.\([0-9][0-9]*\)$/py3\1/p' | head -1)
-    [ -n "$_py" ] && printf 'py_flavor=%s\n' "$_py" >> "$_fo"
+        | sed -n 's/^python3\.\([0-9][0-9]*\)$/\1/p' | sort -n | tail -1)
+    [ -n "$_py" ] && _py="py3${_py}"
+    image_facts_put "$_fo" py_flavor "$_py"
     _fb=$($_run "/bin/sh -c '/bin/freebsd-version'" 2>/dev/null | tr -d '\r')
-    if [ -n "$_fb" ]; then
-        printf 'freebsd_version=%s\n' "$_fb" >> "$_fo"
-        printf 'freebsd_major=%s\n' "${_fb%%.*}" >> "$_fo"
+    if image_facts_put "$_fo" freebsd_version "$_fb"; then
+        image_facts_put "$_fo" freebsd_major "${_fb%%.*}"
     fi
     [ -s "$_fo" ]
+}
+
+# image_facts_put FILE KEY VALUE — append KEY=VALUE iff VALUE is a single
+# charset-safe token ([0-9A-Za-z._:@-]); returns non-zero (writing nothing)
+# for an empty, multi-line, or metacharacter-bearing value. Guest output is
+# untrusted input: consumers parse this file, and a stray line or an embedded
+# $(...) must never reach them.
+image_facts_put() {
+    [ -n "$3" ] || return 1
+    case "$3" in
+        *[!0-9A-Za-z._:@-]*) return 1 ;;
+    esac
+    printf '%s=%s\n' "$2" "$3" >> "$1"
 }

--- a/scripts/image-lib.sh
+++ b/scripts/image-lib.sh
@@ -152,7 +152,9 @@ image_oci_push() {
 # at all was gathered.
 image_gather_facts() {
     _fo=$1; _run=$2
-    : > "$_fo" || return 1
+    # true (regular builtin), never `:` — a redirection error on a special
+    # builtin exits ash/dash entirely (issue #1172; guard-enforced).
+    true > "$_fo" || return 1
     _v=$($_run "/bin/sh -c 'cat /etc/version'" 2>/dev/null | tr -d '\r')
     [ -n "$_v" ] && printf 'etc_version=%s\n' "$_v" >> "$_fo"
     _php=$($_run "/bin/sh -c '/usr/local/bin/php -v'" 2>/dev/null \

--- a/scripts/image-lib.sh
+++ b/scripts/image-lib.sh
@@ -141,3 +141,30 @@ image_oci_push() {
             "${_pushname}:application/vnd.qemu.qcow2"
     )
 }
+
+# image_gather_facts OUTFILE RUNNER — read the LIVE box's version facts through
+# RUNNER (a function/command executing its single string argument on the guest,
+# e.g. image-upgrade.sh's ssh_guest) and write key=value lines to OUTFILE:
+# etc_version, php_version (major.minor), py_flavor (pyXY), freebsd_version,
+# freebsd_major. The activation PR after a publish consumes them (issue #1837).
+# Guest commands run under /bin/sh -c (stock pfSense root shells are tcsh).
+# Best-effort: an absent tool leaves its keys out; returns 1 only when nothing
+# at all was gathered.
+image_gather_facts() {
+    _fo=$1; _run=$2
+    : > "$_fo" || return 1
+    _v=$($_run "/bin/sh -c 'cat /etc/version'" 2>/dev/null | tr -d '\r')
+    [ -n "$_v" ] && printf 'etc_version=%s\n' "$_v" >> "$_fo"
+    _php=$($_run "/bin/sh -c '/usr/local/bin/php -v'" 2>/dev/null \
+        | sed -n '1s/^PHP \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')
+    [ -n "$_php" ] && printf 'php_version=%s\n' "$_php" >> "$_fo"
+    _py=$($_run "/bin/sh -c 'ls /usr/local/bin'" 2>/dev/null \
+        | sed -n 's/^python3\.\([0-9][0-9]*\)$/py3\1/p' | head -1)
+    [ -n "$_py" ] && printf 'py_flavor=%s\n' "$_py" >> "$_fo"
+    _fb=$($_run "/bin/sh -c '/bin/freebsd-version'" 2>/dev/null | tr -d '\r')
+    if [ -n "$_fb" ]; then
+        printf 'freebsd_version=%s\n' "$_fb" >> "$_fo"
+        printf 'freebsd_major=%s\n' "${_fb%%.*}" >> "$_fo"
+    fi
+    [ -s "$_fo" ]
+}

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -105,6 +105,10 @@
 #                    fails if it is not found. Default empty = leave the image's
 #                    configured branch unchanged. Example (Plus pre-release):
 #                    --branch pfSense-plus-v26.07-DEVTEST
+#   --facts-out FILE gather the upgraded box's version facts (etc_version,
+#                    php_version, py_flavor, freebsd_version/major) into FILE
+#                    after the health gate — the activation-PR step consumes
+#                    them (issue #1837). Best-effort; default off.
 #   --keep           keep the work dirs (image copies, console log) afterwards
 #   --force          overwrite the target tag if it already exists
 #
@@ -162,6 +166,7 @@ COMPRESSION=zstd
 UPGRADE_TIMEOUT=1200
 UPGRADE_PKGS=0
 BRANCH=""
+FACTS_OUT=""
 KEEP=0
 FORCE=0
 
@@ -200,9 +205,10 @@ while [ $# -gt 0 ]; do
         --upgrade-timeout) UPGRADE_TIMEOUT="$2"; shift 2 ;;
         --upgrade-pkgs)    UPGRADE_PKGS=1; shift ;;
         --branch)          BRANCH="$2"; shift 2 ;;
+        --facts-out)       FACTS_OUT="$2"; shift 2 ;;
         --keep)            KEEP=1; shift ;;
         --force)           FORCE=1; shift ;;
-        -h|--help)         sed -n '2,108p' "$0"; exit 0 ;;
+        -h|--help)         sed -n '2,115p' "$0"; exit 0 ;;
         *)                 die "unknown option: $1" ;;
     esac
 done
@@ -637,6 +643,14 @@ while [ "$_hg_elapsed" -lt "$HEALTH_TIMEOUT" ]; do
     sleep 10; _hg_elapsed=$((_hg_elapsed + 10))
 done
 [ "$_hg_healthy" -eq 1 ] || die "upgraded box did not become healthy within ${HEALTH_TIMEOUT}s (webConfigurator and pfctl both failed; see $LOCAL_DIR/upgrade.log)"
+
+# --- optional: gather box facts for the activation PR (issue #1837) --------
+# Best-effort: the publish must not depend on it.
+if [ -n "$FACTS_OUT" ]; then
+    log "gathering box facts -> $FACTS_OUT (best-effort)"
+    image_gather_facts "$FACTS_OUT" ssh_guest \
+        || warn "box-facts gathering failed; the activation PR will be skipped"
+fi
 
 # --- power off cleanly -----------------------------------------------------
 log "shutting the box down"

--- a/tests/shell/image_lib_facts_spec.sh
+++ b/tests/shell/image_lib_facts_spec.sh
@@ -1,0 +1,85 @@
+#shellcheck shell=sh
+# image_lib_facts_spec.sh — shellspec suite for image_gather_facts()
+# (issue #1837: the box-verified activation PR's fact source).
+#
+# Pins: key=value output from live-probed command shapes, /bin/sh -c wrapping
+# of every guest command, best-effort key omission, and the nothing-gathered
+# failure. Hermetic: a fake runner function answers the guest commands.
+
+Describe 'image-lib.sh image_gather_facts'
+  LIB="${PFB_ROOT}/scripts/image-lib.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/imgfacts.XXXXXX")"
+    OUT="${WORK}/facts.env"
+    export WORK OUT
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # gather MODE — source the lib with a fake runner and call the function.
+  gather() {
+    _mode="${1:-full}" sh -c '
+      log() { :; }; warn() { :; }; die() { printf "%s\n" "$*" >&2; exit 1; }
+      . "$1" || exit 1
+      # Fake guest runner: answers the live-probed command shapes
+      # (Plus 26.03.1, probed 2026-07-28). Logs every command string.
+      fake_run() {
+        printf "%s\n" "$2" >> "$WORK/run-log"
+        case "$2" in
+          *"cat /etc/version"*) printf "26.03.1-RELEASE\n" ;;
+          *"php -v"*)
+            [ "$_mode" = "no-php" ] && return 1
+            printf "PHP 8.5.2 (cli) (built: May 15 2026 23:13:28) (NTS)\n"
+            printf "Copyright (c) The PHP Group\n"
+            ;;
+          *"ls /usr/local/bin"*)
+            printf "python3.11\npython3.11-config\nphp\n"
+            ;;
+          *freebsd-version*) printf "16.0-CURRENT\n" ;;
+          *) return 1 ;;
+        esac
+      }
+      # POSIX runner-by-name: image_gather_facts calls "$_run" "cmd"; our
+      # runner needs a first arg slot, so wrap it.
+      runner() { fake_run runner "$1"; }
+      if [ "$_mode" = "dead-box" ]; then
+        dead() { return 255; }
+        image_gather_facts "$2" dead
+      else
+        image_gather_facts "$2" runner
+      fi
+    ' _ "$LIB" "$OUT"
+  }
+
+  It 'writes all five facts from the live-probed shapes'
+    When call gather full
+    The status should be success
+    The contents of file "$OUT" should include 'etc_version=26.03.1-RELEASE'
+    The contents of file "$OUT" should include 'php_version=8.5'
+    The contents of file "$OUT" should include 'py_flavor=py311'
+    The contents of file "$OUT" should include 'freebsd_version=16.0-CURRENT'
+    The contents of file "$OUT" should include 'freebsd_major=16'
+  End
+
+  It 'wraps every guest command in /bin/sh -c'
+    When call gather full
+    The status should be success
+    The contents of file "${WORK}/run-log" should include "/bin/sh -c 'cat /etc/version'"
+    The contents of file "${WORK}/run-log" should include "/bin/sh -c '/usr/local/bin/php -v'"
+    The contents of file "${WORK}/run-log" should include "/bin/sh -c '/bin/freebsd-version'"
+  End
+
+  It 'omits keys for absent tools without failing'
+    When call gather no-php
+    The status should be success
+    The contents of file "$OUT" should include 'etc_version='
+    The contents of file "$OUT" should not include 'php_version='
+  End
+
+  It 'fails only when nothing at all was gathered'
+    When call gather dead-box
+    The status should be failure
+  End
+End

--- a/tests/shell/image_lib_facts_spec.sh
+++ b/tests/shell/image_lib_facts_spec.sh
@@ -28,14 +28,25 @@ Describe 'image-lib.sh image_gather_facts'
       fake_run() {
         printf "%s\n" "$2" >> "$WORK/run-log"
         case "$2" in
-          *"cat /etc/version"*) printf "26.03.1-RELEASE\n" ;;
+          *"cat /etc/version"*)
+            case "$_mode" in
+              hostile-multiline) printf "26.03.1-RELEASE\ntouch %s/PWNED\n" "$WORK" ;;
+              hostile-subst)     printf "26.03.1-RELEASE\$(touch %s/PWNED)\n" "$WORK" ;;
+              *)                 printf "26.03.1-RELEASE\n" ;;
+            esac
+            ;;
           *"php -v"*)
             [ "$_mode" = "no-php" ] && return 1
             printf "PHP 8.5.2 (cli) (built: May 15 2026 23:13:28) (NTS)\n"
             printf "Copyright (c) The PHP Group\n"
             ;;
           *"ls /usr/local/bin"*)
-            printf "python3.11\npython3.11-config\nphp\n"
+            case "$_mode" in
+              # A mid-upgrade box can carry two interpreters; lexical order puts
+              # python3.11 first, but 3.9 -> 3.11 must resolve to the HIGHEST.
+              multi-python) printf "python3.9\npython3.11\nphp\n" ;;
+              *) printf "python3.11\npython3.11-config\nphp\n" ;;
+            esac
             ;;
           *freebsd-version*) printf "16.0-CURRENT\n" ;;
           *) return 1 ;;
@@ -81,5 +92,47 @@ Describe 'image-lib.sh image_gather_facts'
   It 'fails only when nothing at all was gathered'
     When call gather dead-box
     The status should be failure
+  End
+
+  # Review B1: the facts file is consumed by CI; a box value that is multi-line
+  # or carries shell metacharacters must NEVER reach it (an anomalous
+  # /etc/version would otherwise corrupt — or inject into — the consumer).
+  It 'drops a multi-line version value instead of writing extra lines'
+    When call gather hostile-multiline
+    The status should be success
+    The contents of file "$OUT" should not include 'touch '
+    The contents of file "$OUT" should not include 'etc_version=26.03.1-RELEASE'
+  End
+
+  It 'drops a version value carrying command substitution'
+    When call gather hostile-subst
+    The status should be success
+    The contents of file "$OUT" should not include 'touch '
+    The contents of file "$OUT" should not include '$('
+  End
+
+  # unsafe_lines — every fact line must match key=<charset-safe token>; prints
+  # the offending lines (expected: none).
+  unsafe_lines() {
+    gather "${1:-full}" >/dev/null 2>&1
+    grep -vE '^[a-z_]+=[0-9A-Za-z._:@-]+$' "$OUT" || true
+  }
+
+  It 'writes only key=<charset-safe value> lines'
+    When call unsafe_lines full
+    The status should be success
+    The output should equal ""
+  End
+
+  It 'picks the highest python3.X when several are installed'
+    When call gather multi-python
+    The status should be success
+    The contents of file "$OUT" should include 'py_flavor=py311'
+  End
+
+  It 'writes no unsafe line even when the box answers hostile'
+    When call unsafe_lines hostile-multiline
+    The status should be success
+    The output should equal ""
   End
 End

--- a/tests/test_image_refresh_plan_contract.py
+++ b/tests/test_image_refresh_plan_contract.py
@@ -252,6 +252,31 @@ FAKE_GIT_ACT = """#!/bin/sh
 printf 'git %s\\n' "$*" >> "$GIT_LOG"
 case "$1" in
   show) cat "$FAKE_MATRIX" ;;
+  checkout)
+    # Emulate the real effect: switching the JOB's tree to the ci-metadata
+    # orphan ref leaves only the matrix file behind (CodeRabbit CR2).
+    rm -rf scripts
+    ;;
+  worktree)
+    # `worktree add [--force] [-B BR] DIR REF` materialises the ref in DIR and
+    # leaves the JOB's tree untouched. Mirror it into a predictable wt-* dir so
+    # the assertions can read what the step staged.
+    shift
+    [ "$1" = "add" ] && shift
+    _dir=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --force) shift ;;
+        -B) shift 2 ;;
+        *) [ -z "$_dir" ] && _dir=$1; shift ;;
+      esac
+    done
+    if [ -n "$_dir" ] && [ "$_dir" != "remove" ]; then
+      mkdir -p "$_dir"
+      printf 'WT %s\\n' "$_dir" >> "$GIT_LOG"
+      ln -s "$_dir" "wt-$$" 2>/dev/null || true
+    fi
+    ;;
 esac
 exit 0
 """
@@ -296,6 +321,13 @@ PLUS_2607_MATRIX = {
 FACTS_857 = "etc_version=26.07-BETA\nphp_version=8.6\npy_flavor=py312\nfreebsd_version=16.0-CURRENT\nfreebsd_major=16\n"
 
 
+def _pushed_matrix(tmp_path: Path) -> dict[str, Any]:
+    """The matrix the step staged for the PR branch (written in its worktree)."""
+    staged = sorted(tmp_path.glob("wt-*/supported-versions.json"))
+    assert staged, "the activation step staged no matrix file"
+    return json.loads(staged[0].read_text(encoding="utf-8"))
+
+
 class TestActivationPr:
     """Scenario (issue #1837): after a publish, the leg's matrix entry is
     activated (ci: true) with the box-verified versions, via ONE tracker/* PR;
@@ -309,6 +341,7 @@ class TestActivationPr:
         matrix: dict[str, Any] | None = None,
         family: str = "26.07",
         pr_open: str = "",
+        dry_run: str = "false",
     ) -> tuple[str, str, Path]:
         source = WORKFLOW.read_text(encoding="utf-8")
         step = source.split(f"      - name: {ACTIVATION_STEP}\n", 1)[1].split("\n      - name:", 1)[0]
@@ -341,6 +374,7 @@ class TestActivationPr:
             "CHANNEL": "Plus",
             "FAMILY": family,
             "VARIANT": "plus",
+            "DRY_RUN": dry_run,
         }
         subprocess.run(["bash", "-c", script], cwd=tmp_path, env=env, check=True, capture_output=True, text=True)
 
@@ -352,13 +386,9 @@ class TestActivationPr:
 
     def test_publish_activates_entry_with_box_facts(self, tmp_path: Path) -> None:
         git_log, gh_log, cwd = self._run(tmp_path, facts=FACTS_857)
-        assert "git push " + "--force origin tracker/matrix-activate-plus-26.07" in git_log
+        assert "--force origin tracker/matrix-activate-plus-26.07" in git_log
         assert "pr create" in gh_log
-        entry = next(
-            e
-            for e in json.loads((cwd / "supported-versions.json").read_text(encoding="utf-8"))["versions"]
-            if e["pfsense_version"] == "26.07"
-        )
+        entry = next(e for e in _pushed_matrix(cwd)["versions"] if e["pfsense_version"] == "26.07")
         assert entry["ci"] is True
         assert entry["php_version"] == "8.6"
         assert entry["py_flavor"] == "py312"
@@ -368,11 +398,7 @@ class TestActivationPr:
     def test_major_change_rewrites_full_freebsd_version(self, tmp_path: Path) -> None:
         facts = FACTS_857.replace("16.0-CURRENT", "17.0-CURRENT").replace("freebsd_major=16", "freebsd_major=17")
         _, _, cwd = self._run(tmp_path, facts=facts)
-        entry = next(
-            e
-            for e in json.loads((cwd / "supported-versions.json").read_text(encoding="utf-8"))["versions"]
-            if e["pfsense_version"] == "26.07"
-        )
+        entry = next(e for e in _pushed_matrix(cwd)["versions"] if e["pfsense_version"] == "26.07")
         assert entry["freebsd_major"] == "17"
         assert entry["freebsd_version"] == "17.0-CURRENT"
 
@@ -392,5 +418,42 @@ class TestActivationPr:
 
     def test_existing_open_pr_updates_without_recreating(self, tmp_path: Path) -> None:
         git_log, gh_log, _ = self._run(tmp_path, facts=FACTS_857, pr_open="88")
-        assert "git push " + "--force origin tracker/matrix-activate-plus-26.07" in git_log
+        assert "--force origin tracker/matrix-activate-plus-26.07" in git_log
         assert "pr create" not in gh_log
+
+    def test_dry_run_proposes_nothing(self, tmp_path: Path) -> None:
+        # Review B2: issue #1837 requires DRY_RUN honored, like the reconcile's
+        # own open_matrix_pr
+        git_log, gh_log, _ = self._run(tmp_path, facts=FACTS_857, dry_run="true")
+        assert "push" not in git_log
+        assert "pr create" not in gh_log
+
+    def test_hostile_facts_file_is_not_executed(self, tmp_path: Path) -> None:
+        # Review B1: the step must not source the facts file — a stray line
+        # (anomalous /etc/version, or an injected one) must never run
+        facts = FACTS_857 + f"touch {tmp_path}/PWNED\n"
+        self._run(tmp_path, facts=facts)
+        assert not (tmp_path / "PWNED").exists()
+
+    def test_aarch64_twin_entry_is_left_untouched(self, tmp_path: Path) -> None:
+        matrix = json.loads(json.dumps(PLUS_2607_MATRIX))
+        twin = dict(matrix["versions"][1], arch="aarch64", ci=False)
+        matrix["versions"].append(twin)
+        _, _, cwd = self._run(tmp_path, facts=FACTS_857, matrix=matrix)
+        versions = _pushed_matrix(cwd)["versions"]
+        amd = next(e for e in versions if e["pfsense_version"] == "26.07" and e.get("arch", "amd64") == "amd64")
+        arm = next(e for e in versions if e.get("arch") == "aarch64")
+        assert amd["ci"] is True
+        assert amd["php_version"] == "8.6"
+        # the ARM twin has no smoke image — it must keep ci:false and its values
+        assert arm["ci"] is False
+        assert arm["php_version"] == "8.5"
+
+    def test_working_tree_survives_the_activation_step(self, tmp_path: Path) -> None:
+        # CodeRabbit CR2 (critical): the non-blocking smoke step runs AFTER this
+        # one and needs scripts/ — the PR branch work must not swap the job's
+        # working tree to the ci-metadata ref.
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "install-from-repo.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+        self._run(tmp_path, facts=FACTS_857)
+        assert (tmp_path / "scripts" / "install-from-repo.sh").exists()

--- a/tests/test_image_refresh_plan_contract.py
+++ b/tests/test_image_refresh_plan_contract.py
@@ -244,3 +244,153 @@ class TestSelfRefreshLegs:
         matrix = _run_plan(tmp_path, versions, self_refresh="true")
         assert len(matrix["include"]) == 1
         assert matrix["include"][0]["pfsense_version"] == "26.03"
+
+
+ACTIVATION_STEP = "Open activation PR (box-verified matrix update)"
+
+FAKE_GIT_ACT = """#!/bin/sh
+printf 'git %s\\n' "$*" >> "$GIT_LOG"
+case "$1" in
+  show) cat "$FAKE_MATRIX" ;;
+esac
+exit 0
+"""
+
+FAKE_GH_ACT = """#!/bin/sh
+case "$*" in
+  "pr list "*) printf '%s\\n' "${GH_PR_OPEN:-}" ;;
+  "pr create "*) printf 'pr create %s\\n' "$*" >> "$GH_LOG" ;;
+esac
+exit 0
+"""
+
+PLUS_2607_MATRIX = {
+    "versions": [
+        {
+            "pfsense_version": "26.03",
+            "channel": "Plus",
+            "freebsd_version": "16.0-RELEASE",
+            "freebsd_major": "16",
+            "php_version": "8.5",
+            "py_flavor": "py311",
+            "variant": "Plus",
+            "status": "active",
+            "ci": True,
+            "image_name": "pfsense-plus",
+        },
+        {
+            "pfsense_version": "26.07",
+            "channel": "Plus",
+            "freebsd_version": "16.0-RELEASE",
+            "freebsd_major": "16",
+            "php_version": "8.5",
+            "py_flavor": "py311",
+            "variant": "Plus",
+            "status": "beta",
+            "ci": False,
+            "image_name": "pfsense-plus",
+        },
+    ]
+}
+
+FACTS_857 = "etc_version=26.07-BETA\nphp_version=8.6\npy_flavor=py312\nfreebsd_version=16.0-CURRENT\nfreebsd_major=16\n"
+
+
+class TestActivationPr:
+    """Scenario (issue #1837): after a publish, the leg's matrix entry is
+    activated (ci: true) with the box-verified versions, via ONE tracker/* PR;
+    freebsd_version only follows the box when the MAJOR changed."""
+
+    def _run(
+        self,
+        tmp_path: Path,
+        *,
+        facts: str | None,
+        matrix: dict[str, Any] | None = None,
+        family: str = "26.07",
+        pr_open: str = "",
+    ) -> tuple[str, str, Path]:
+        source = WORKFLOW.read_text(encoding="utf-8")
+        step = source.split(f"      - name: {ACTIVATION_STEP}\n", 1)[1].split("\n      - name:", 1)[0]
+        body: list[str] = []
+        for line in step.split("        run: |\n", 1)[1].splitlines():
+            if not line.strip():
+                body.append("")
+            elif line.startswith("          "):
+                body.append(line[10:])
+            else:
+                break
+        script = "\n".join(body)
+
+        for name, content in (("git", FAKE_GIT_ACT), ("gh", FAKE_GH_ACT)):
+            fake = tmp_path / name
+            fake.write_text(content, encoding="utf-8")
+            fake.chmod(0o755)
+        matrix_file = tmp_path / "fake-matrix.json"
+        matrix_file.write_text(json.dumps(matrix or PLUS_2607_MATRIX), encoding="utf-8")
+        if facts is not None:
+            (tmp_path / "box-facts.env").write_text(facts, encoding="utf-8")
+
+        env = os.environ | {
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "GIT_LOG": str(tmp_path / "git.log"),
+            "GH_LOG": str(tmp_path / "gh.log"),
+            "GH_PR_OPEN": pr_open,
+            "FAKE_MATRIX": str(matrix_file),
+            "REPO": "owner/repo",
+            "CHANNEL": "Plus",
+            "FAMILY": family,
+            "VARIANT": "plus",
+        }
+        subprocess.run(["bash", "-c", script], cwd=tmp_path, env=env, check=True, capture_output=True, text=True)
+
+        def log(name: str) -> str:
+            f = tmp_path / name
+            return f.read_text(encoding="utf-8") if f.exists() else ""
+
+        return log("git.log"), log("gh.log"), tmp_path
+
+    def test_publish_activates_entry_with_box_facts(self, tmp_path: Path) -> None:
+        git_log, gh_log, cwd = self._run(tmp_path, facts=FACTS_857)
+        assert "git push " + "--force origin tracker/matrix-activate-plus-26.07" in git_log
+        assert "pr create" in gh_log
+        entry = next(
+            e
+            for e in json.loads((cwd / "supported-versions.json").read_text(encoding="utf-8"))["versions"]
+            if e["pfsense_version"] == "26.07"
+        )
+        assert entry["ci"] is True
+        assert entry["php_version"] == "8.6"
+        assert entry["py_flavor"] == "py312"
+        # major unchanged (16) -> the human freebsd_version convention survives
+        assert entry["freebsd_version"] == "16.0-RELEASE"
+
+    def test_major_change_rewrites_full_freebsd_version(self, tmp_path: Path) -> None:
+        facts = FACTS_857.replace("16.0-CURRENT", "17.0-CURRENT").replace("freebsd_major=16", "freebsd_major=17")
+        _, _, cwd = self._run(tmp_path, facts=facts)
+        entry = next(
+            e
+            for e in json.loads((cwd / "supported-versions.json").read_text(encoding="utf-8"))["versions"]
+            if e["pfsense_version"] == "26.07"
+        )
+        assert entry["freebsd_major"] == "17"
+        assert entry["freebsd_version"] == "17.0-CURRENT"
+
+    def test_active_and_accurate_entry_does_nothing(self, tmp_path: Path) -> None:
+        facts = (
+            "etc_version=26.03.1-RELEASE\nphp_version=8.5\npy_flavor=py311\n"
+            "freebsd_version=16.0-CURRENT\nfreebsd_major=16\n"
+        )
+        git_log, gh_log, _ = self._run(tmp_path, facts=facts, family="26.03")
+        assert "push" not in git_log
+        assert "pr create" not in gh_log
+
+    def test_missing_facts_skip_everything(self, tmp_path: Path) -> None:
+        git_log, gh_log, _ = self._run(tmp_path, facts=None)
+        assert git_log == ""
+        assert gh_log == ""
+
+    def test_existing_open_pr_updates_without_recreating(self, tmp_path: Path) -> None:
+        git_log, gh_log, _ = self._run(tmp_path, facts=FACTS_857, pr_open="88")
+        assert "git push " + "--force origin tracker/matrix-activate-plus-26.07" in git_log
+        assert "pr create" not in gh_log


### PR DESCRIPTION
Fixes #1837

## What

Closes the post-publish loop (owner design, 2026-07-28): the upgrade leg is the only moment automation has SSH into a live box running the NEW pfSense version — use it to verify the matrix entry and activate it in one human-gated PR.

- **`image_gather_facts()`** (image-lib.sh): reads the live box's `etc_version`, `php_version` (major.minor), `py_flavor` (`pyXY`), `freebsd_version`/`major` through the caller's guest runner, every command `/bin/sh -c`-wrapped; best-effort key omission. Command shapes pinned to a live probe of the owner's Plus 26.03.1 VM (`PHP 8.5.2 (cli)…` → `8.5`, `python3.11` → `py311`, `16.0-CURRENT`).
- **`image-upgrade.sh --facts-out FILE`** (optional, default off): gathers the facts after the health gate, before poweroff; failure warns and never blocks the publish.
- **`image-refresh.yml`**: passes `--facts-out`; new post-publish "activation PR" step — if the leg family's matrix entry is not active-and-accurate, open ONE `tracker/matrix-activate-*` PR against `ci-metadata` setting `ci: true` + the box-verified `php_version`/`py_flavor`/`freebsd_major`. The full `freebsd_version` string is only rewritten when the MAJOR changed (the box reports `16.0-CURRENT` while the matrix keeps the human `16.0-RELEASE` convention; the raw value is quoted in the PR body). Semantic (`jq -S`) steady-state compare; dedup by branch; matrix writes remain auto-PR ONLY.

Effect: merge a beta-add PR (e.g. #1834) → image builds/publishes → an activation PR appears with the truth → one human merge turns on smoke/test/build coverage for the version and re-fires the reconcile via `dispatch-tracker`.

## Evidence

- `tests/shell/image_lib_facts_spec.sh`: 4 examples — live-probed shapes → key=value output, `/bin/sh -c` wrapping pinned per command, absent-tool key omission, nothing-gathered failure.
- `tests/test_image_refresh_plan_contract.py::TestActivationPr`: 5 contract tests executing the real extracted step with fake `git`/`gh` — activation with corrections, MAJOR-change freebsd rule both ways, steady-state no-op, missing-facts skip, open-PR dedup.
- Full suite: 3689 passed; shellspec dash green; actionlint: only the pre-existing devel expression complaint + SC2016 info.
- `--help` range fixed for the grown header; refresh job checkout now persists credentials + full depth (the activation step pushes tracker/* and reads the ci-metadata ref).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated image refreshes can now collect version details from upgraded systems.
  * Matching supported-version entries are automatically activated and kept up to date through pull requests.
  * Image upgrades support exporting collected version facts to a file.

* **Bug Fixes**
  * Activation updates now skip safely when information is unavailable or no changes are needed.

* **Tests**
  * Added coverage for version detection, activation updates, unchanged entries, missing data, and existing pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->