### PR TITLE
ci: feed the reconcile the never-deduped route matrix

### DIFF
--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -129,6 +129,8 @@ jobs:
       - name: Plan reactions (dry-run log or live dispatch)
         env:
           GH_TOKEN: ${{ github.token }}
+          # react builds one .pkg per ABI — the freebsd_major-deduped view is
+          # the correct source here (unlike the reconcile job, issue #1839).
           BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
           CI_MATRIX: ${{ needs.read-matrix.outputs.ci_matrix }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
@@ -266,6 +268,18 @@ jobs:
           persist-credentials: true   # push the tracker/* matrix-PR branches
           fetch-depth: 0
 
+      # The reconcile needs EVERY family, one row per version: build_matrix is
+      # deduped to one row per freebsd_major (issue #1806), which hides a
+      # same-major family (26.03 vs 26.07) and blinds the boot source + the
+      # branch lookup (issue #1839). The route matrix is the never-deduped view.
+      - name: Resolve the route matrix (never deduped)
+        id: matrix
+        run: |
+          set -eu
+          ROUTE="$(sh scripts/read-version-matrix.sh --ref origin/ci-metadata --print-route)"
+          printf 'route=%s\n' "$ROUTE" >> "$GITHUB_OUTPUT"
+          printf '%s' "$ROUTE" | jq -r '.[] | "  \(.channel) \(.pfsense_version) (status \(.status // "active"))"'
+
       - name: Check if the reconcile is disabled via repo label
         id: probe_gate
         env:
@@ -295,7 +309,7 @@ jobs:
         if: steps.probe_gate.outputs.probe_disabled != 'true'
         continue-on-error: true
         env:
-          BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
+          ROUTE_MATRIX: ${{ steps.matrix.outputs.route }}
           SMOKE_IMAGE_REPO: ${{ vars.SMOKE_IMAGE_REPO }}
           SMOKE_SSH_PRIV_KEY: ${{ secrets.SMOKE_SSH_PRIV_KEY }}
           SMOKE_PLUS_MAC: ${{ secrets.SMOKE_PLUS_MAC }}
@@ -324,14 +338,14 @@ jobs:
           REPO_NS="${SMOKE_IMAGE_REPO:-ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')}"
           mkdir -p facts
 
-          CHANNELS=$(printf '%s\n' "$BUILD_MATRIX" | jq -r '[.[].channel] | unique[]')
+          CHANNELS=$(printf '%s\n' "$ROUTE_MATRIX" | jq -r '[.[].channel] | unique[]')
           for CHANNEL in $CHANNELS; do
             VARIANT=$(printf '%s' "$CHANNEL" | tr '[:upper:]' '[:lower:]')
             mkdir -p "facts/${CHANNEL}"
 
             # Published map: does the family's floating tag exist on GHCR?
             printf '{}' > "facts/${CHANNEL}-published.json"
-            ENTRIES=$(printf '%s\n' "$BUILD_MATRIX" | jq -c --arg ch "$CHANNEL" '
+            ENTRIES=$(printf '%s\n' "$ROUTE_MATRIX" | jq -c --arg ch "$CHANNEL" '
               [ .[] | select(.channel == $ch)
                     | select((.role // "build") != "route-only")
                     | select((.arch // "amd64") == "amd64") ]')
@@ -392,15 +406,15 @@ jobs:
         if: steps.probe_gate.outputs.probe_disabled != 'true' && steps.facts.outcome == 'success'
         continue-on-error: true
         env:
-          BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
+          ROUTE_MATRIX: ${{ steps.matrix.outputs.route }}
         run: |
           set -euo pipefail
           [ -d facts ] || { echo "No facts gathered — nothing to plan."; exit 0; }
-          CHANNELS=$(printf '%s\n' "$BUILD_MATRIX" | jq -r '[.[].channel] | unique[]')
+          CHANNELS=$(printf '%s\n' "$ROUTE_MATRIX" | jq -r '[.[].channel] | unique[]')
           for CHANNEL in $CHANNELS; do
             [ -f "facts/${CHANNEL}-published.json" ] || continue
             set -- --channel "$CHANNEL" \
-              --matrix-json "$BUILD_MATRIX" \
+              --matrix-json "$ROUTE_MATRIX" \
               --published-json "$(cat "facts/${CHANNEL}-published.json")"
             for D in "facts/${CHANNEL}"/*/; do
               [ -f "${D}status" ] || continue
@@ -422,14 +436,14 @@ jobs:
           REPO: ${{ github.repository }}
           REF: ${{ github.ref_name }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
-          BUILD_MATRIX: ${{ needs.read-matrix.outputs.build_matrix }}
+          ROUTE_MATRIX: ${{ steps.matrix.outputs.route }}
         run: |
           set -euo pipefail
           for PLAN in facts/plan-*.json; do
             [ -f "$PLAN" ] || continue
             CHANNEL=$(basename "$PLAN" .json)
             CHANNEL=${CHANNEL#plan-}
-            LEGS=$(jq -c --argjson bm "$BUILD_MATRIX" --arg ch "$CHANNEL" '
+            LEGS=$(jq -c --argjson bm "$ROUTE_MATRIX" --arg ch "$CHANNEL" '
               [ .actions[]
                 | select(.type == "republish" or .type == "publish_new") as $a
                 | (first($bm[] | select(.channel == $ch)

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -276,7 +276,9 @@ jobs:
         id: matrix
         run: |
           set -eu
-          ROUTE="$(sh scripts/read-version-matrix.sh --ref origin/ci-metadata --print-route)"
+          # The reader pretty-prints; compact it — a multi-line step output
+          # silently truncates at the first newline.
+          ROUTE="$(sh scripts/read-version-matrix.sh --ref origin/ci-metadata --print-route | jq -c '.')"
           printf 'route=%s\n' "$ROUTE" >> "$GITHUB_OUTPUT"
           printf '%s' "$ROUTE" | jq -r '.[] | "  \(.channel) \(.pfsense_version) (status \(.status // "active"))"'
 

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -252,7 +252,8 @@ jobs:
   reconcile:
     name: Daily image reconcile (box as source of truth)
     runs-on: ubuntu-latest
-    needs: read-matrix
+    # No `needs:` — the job resolves its own matrix (issue #1839), so an
+    # unrelated read-matrix failure must not skip the reconcile.
     if: github.event.inputs.skip_probe != 'true'
     # A wedged guest must not hold a runner for the 360-minute default (review F2);
     # the whole loop (2-3 boots + facts + PRs) fits comfortably in 90.
@@ -274,6 +275,7 @@ jobs:
       # branch lookup (issue #1839). The route matrix is the never-deduped view.
       - name: Resolve the route matrix (never deduped)
         id: matrix
+        continue-on-error: true   # best-effort, like every data step in this job
         run: |
           set -eu
           # The reader pretty-prints; compact it — a multi-line step output

--- a/tests/test_version_tracker_reconcile_contract.py
+++ b/tests/test_version_tracker_reconcile_contract.py
@@ -503,3 +503,38 @@ class TestReconcileMatrixSource:
         reconcile = source.split("\n  reconcile:\n", 1)[1]
         assert "BUILD_MATRIX" not in reconcile
         assert reconcile.count("ROUTE_MATRIX:") >= 3
+
+    def test_resolve_step_emits_single_line_json(self, tmp_path: Path) -> None:
+        # CodeRabbit: the reader pretty-prints, so a bare `printf key=%s` would
+        # corrupt GITHUB_OUTPUT and hand the reconcile a truncated matrix.
+        matrix_file = tmp_path / "matrix.json"
+        matrix_file.write_text(json.dumps(self.SAME_MAJOR_MATRIX), encoding="utf-8")
+        fake_git = tmp_path / "git"
+        fake_git.write_text(
+            '#!/bin/sh\ncase "$1" in\n  fetch) exit 0 ;;\n  show) cat "$FAKE_MATRIX" ;;\nesac\n',
+            encoding="utf-8",
+        )
+        fake_git.chmod(0o755)
+        (tmp_path / "scripts").mkdir(exist_ok=True)
+        (tmp_path / "scripts" / "read-version-matrix.sh").write_text(
+            (ROOT / "scripts" / "read-version-matrix.sh").read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        out = tmp_path / "gh-output"
+        out.write_text("", encoding="utf-8")
+        subprocess.run(
+            ["bash", "-c", _step_script("Resolve the route matrix (never deduped)")],
+            cwd=tmp_path,
+            env=os.environ
+            | {
+                "PATH": f"{tmp_path}:{os.environ['PATH']}",
+                "FAKE_MATRIX": str(matrix_file),
+                "GITHUB_OUTPUT": str(out),
+            },
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        lines = [ln for ln in out.read_text(encoding="utf-8").splitlines() if ln.startswith("route=")]
+        assert len(lines) == 1, "the route output must be one line"
+        entries = json.loads(lines[0][len("route=") :])
+        assert sorted(e["pfsense_version"] for e in entries if e["channel"] == "Plus") == ["26.03", "26.07"]

--- a/tests/test_version_tracker_reconcile_contract.py
+++ b/tests/test_version_tracker_reconcile_contract.py
@@ -538,3 +538,14 @@ class TestReconcileMatrixSource:
         assert len(lines) == 1, "the route output must be one line"
         entries = json.loads(lines[0][len("route=") :])
         assert sorted(e["pfsense_version"] for e in entries if e["channel"] == "Plus") == ["26.03", "26.07"]
+
+    def test_reconcile_job_is_independent_and_best_effort(self) -> None:
+        # Review follow-ups: the reconcile resolves its own matrix, so the
+        # read-matrix dependency is dead coupling (an unrelated failure there
+        # would skip this job); and the resolve step must degrade like every
+        # other data step in this best-effort job.
+        source = WORKFLOW.read_text(encoding="utf-8")
+        reconcile = source.split("\n  reconcile:\n", 1)[1].split("\n  probe:", 1)[0]
+        assert "needs: read-matrix" not in reconcile
+        resolve = reconcile.split("- name: Resolve the route matrix", 1)[1].split("\n      - name:", 1)[0]
+        assert "continue-on-error: true" in resolve

--- a/tests/test_version_tracker_reconcile_contract.py
+++ b/tests/test_version_tracker_reconcile_contract.py
@@ -204,7 +204,7 @@ exit 0
             tmp_path,
             GATHER_STEP,
             {
-                "BUILD_MATRIX": json.dumps(matrix),
+                "ROUTE_MATRIX": json.dumps(matrix),
                 "SMOKE_SSH_PRIV_KEY": "dummy-key",
                 "SMOKE_GHCR_USER": "u",
                 "SMOKE_GHCR_TOKEN": "t",
@@ -294,7 +294,7 @@ class TestPlanStep:
         )
         # An unavailable boot must be EXCLUDED from the planner's input
         self._facts(tmp_path, "Plus", "26.09", "unavailable", "junk\t\tJunk (26.99)\n", "26.09-BETA")
-        _run_step(tmp_path, PLAN_STEP, {"BUILD_MATRIX": json.dumps(BUILD_MATRIX)})
+        _run_step(tmp_path, PLAN_STEP, {"ROUTE_MATRIX": json.dumps(BUILD_MATRIX)})
         plan = json.loads((tmp_path / "facts" / "plan-Plus.json").read_text(encoding="utf-8"))
         assert {"type": "matrix_pr_add", "family": "26.07", "branch": "26.07", "status": "beta"} in plan["actions"]
         assert all(a.get("family") != "26.99" for a in plan["actions"])
@@ -309,7 +309,7 @@ class TestDispatchStep:
         _run_step(
             tmp_path,
             DISPATCH_STEP,
-            {"BUILD_MATRIX": json.dumps(BUILD_MATRIX + [BETA_2607]), "DRY_RUN": dry_run},
+            {"ROUTE_MATRIX": json.dumps(BUILD_MATRIX + [BETA_2607]), "DRY_RUN": dry_run},
         )
         return _log(tmp_path, "gh.log"), _log(tmp_path, "gh-fields.log")
 
@@ -418,3 +418,88 @@ class TestMatrixPrStep:
         git_log, gh_log, _ = self._run(tmp_path, self.ADD_2607, dry_run="true")
         assert "push" not in git_log
         assert "pr create" not in gh_log
+
+
+class TestReconcileMatrixSource:
+    """Scenario (issue #1839): the reconcile must see EVERY version, one row per
+    family. `build_matrix` is deduped to one row per freebsd_major (issue #1806),
+    which hid Plus 26.03 the moment 26.07 (same major 16) joined the matrix —
+    the boot source vanished and the planner could not resolve the new family's
+    branch. The route matrix is the never-deduped view."""
+
+    SAME_MAJOR_MATRIX = {
+        "versions": [
+            {
+                "pfsense_version": "2.8",
+                "channel": "CE",
+                "freebsd_version": "15.0-RELEASE",
+                "freebsd_major": "15",
+                "php_version": "8.3",
+                "py_flavor": "py311",
+                "variant": "CE",
+                "status": "active",
+                "ci": True,
+            },
+            {
+                "pfsense_version": "26.03",
+                "channel": "Plus",
+                "freebsd_version": "16.0-RELEASE",
+                "freebsd_major": "16",
+                "php_version": "8.5",
+                "py_flavor": "py311",
+                "variant": "Plus",
+                "status": "active",
+                "ci": True,
+                "image_name": "pfsense-plus",
+            },
+            {
+                "pfsense_version": "26.07",
+                "channel": "Plus",
+                "freebsd_version": "16.0-RELEASE",
+                "freebsd_major": "16",
+                "php_version": "8.5",
+                "py_flavor": "py311",
+                "variant": "Plus",
+                "status": "beta",
+                "ci": False,
+                "image_name": "pfsense-plus",
+            },
+        ]
+    }
+
+    def _reader(self, tmp_path: Path, mode: str) -> list[dict[str, Any]]:
+        """Run the REAL reader against the fixture matrix."""
+        matrix_file = tmp_path / "matrix.json"
+        matrix_file.write_text(json.dumps(self.SAME_MAJOR_MATRIX), encoding="utf-8")
+        fake_git = tmp_path / "git"
+        fake_git.write_text(
+            '#!/bin/sh\ncase "$1" in\n  fetch) exit 0 ;;\n  show) cat "$FAKE_MATRIX" ;;\nesac\n',
+            encoding="utf-8",
+        )
+        fake_git.chmod(0o755)
+        proc = subprocess.run(
+            ["sh", str(ROOT / "scripts" / "read-version-matrix.sh"), "--ref", "origin/ci-metadata", mode],
+            cwd=tmp_path,
+            env=os.environ | {"PATH": f"{tmp_path}:{os.environ['PATH']}", "FAKE_MATRIX": str(matrix_file)},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return json.loads(proc.stdout)
+
+    def test_build_matrix_hides_a_same_major_family(self, tmp_path: Path) -> None:
+        # The documented ABI dedup — correct for .pkg builds, wrong for the
+        # reconcile. Pins WHY the source had to change.
+        plus = [e for e in self._reader(tmp_path, "--print-build") if e["channel"] == "Plus"]
+        assert len(plus) == 1
+
+    def test_route_matrix_keeps_every_family(self, tmp_path: Path) -> None:
+        plus = sorted(e["pfsense_version"] for e in self._reader(tmp_path, "--print-route") if e["channel"] == "Plus")
+        assert plus == ["26.03", "26.07"]
+
+    def test_reconcile_steps_consume_the_route_matrix(self) -> None:
+        # Wiring pin: every reconcile step reads the never-deduped view.
+        source = WORKFLOW.read_text(encoding="utf-8")
+        reconcile = source.split("\n  reconcile:\n", 1)[1]
+        assert "BUILD_MATRIX" not in reconcile
+        assert reconcile.count("ROUTE_MATRIX:") >= 3


### PR DESCRIPTION
Fixes #1839

## What

The reconcile job consumed `build_matrix`, which is deduped to one row per `freebsd_major` (issue #1806). The moment Plus 26.07 joined the matrix alongside Plus 26.03 (both FreeBSD 16), the dedup collapsed them and **26.03 disappeared from the reconcile's view** — so no Plus box was booted, no repoc branches were gathered, and the new family's `publish_new` degraded to `warn: no repo branch found for unpublished matrix entry` (live run 30395340168, right after #1834 merged).

This wires the reconcile to the **route matrix** (`read-version-matrix.sh --print-route`): BUILD-eligible entries, one row per version, never deduped, route-only excluded. A new `Resolve the route matrix` step emits it once per run; the gather / plan / dispatch steps consume it. The **react** job keeps `build_matrix` — its `.pkg` dispatches are exactly what the ABI dedup is for (comment added at the seam).

## Evidence

- `TestReconcileMatrixSource` (new, 3 tests): the REAL reader over a fixture with two same-major Plus families — `--print-build` collapses them to one row (pinning *why* the source had to change), `--print-route` keeps both, and a wiring assertion that no reconcile step reads `BUILD_MATRIX` and all three read `ROUTE_MATRIX`. The wiring test was red before this change.
- Existing 16 reconcile step-contract tests re-pointed to the new variable; all 19 green.
- Full suite 3697 passed; `run-gates.sh` GATES: PASS; actionlint clean (SC2016 info only).
- Post-fix YAML audit confirms the per-job split: react → `build_matrix`, reconcile → `steps.matrix.outputs.route` (×3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily version reconciliation to consider all applicable release routes, including families sharing the same major version.
  * Updated planning, boot, published-image checks, and image-refresh selection to use the complete route information.

* **Tests**
  * Added coverage to verify same-major release families are retained during reconciliation.
  * Added checks confirming reconciliation consistently uses the complete route data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->