### PR TITLE
www: cache-bust pfBlockerNG.js and stop shipping epoch mtimes

### DIFF
--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -458,7 +458,9 @@ class Recipe:
             target.parent.mkdir(parents=True, exist_ok=True)
             if target.exists():
                 target.unlink()
-            shutil.copyfile(sp, target)
+            # copy2, not copyfile: the source mtime rides into the stage, and from there
+            # into the package (see _staged_mtime). The mode is set explicitly below.
+            shutil.copy2(sp, target)
             os.chmod(target, int(perm, 8))
             self.modes[self._install_path(target)] = perm
 
@@ -486,7 +488,7 @@ class Recipe:
                 os.chmod(target, 0o755)
                 continue
             target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(item, target)
+            shutil.copy2(item, target)  # keep the source mtime; mode is set explicitly
             os.chmod(target, 0o644)
             self.modes[self._install_path(target)] = "0644"
 
@@ -553,7 +555,12 @@ class Recipe:
         text = path.read_text()
         for expr in exprs:
             text = self._sed_s(text, expr)
+        # Restore the mtime the staged copy inherited from the source tree: the rewrite
+        # is a deterministic function of that source plus the port variables, so letting
+        # it stamp the build clock would make otherwise identical builds differ.
+        stat = path.stat()
         path.write_text(text)
+        os.utime(path, (stat.st_atime, stat.st_mtime))
 
     def _sed_s(self, text: str, expr: str) -> str:
         m = self.SED_S.match(expr)
@@ -1166,18 +1173,27 @@ def make_manifest(b: Build, *, compact: bool) -> dict:
     return m
 
 
+# The ustar mtime field is 8 octal digits, unsigned — anything outside this range would
+# surface as tarfile's "overflow in number field" from inside the writer.
+_USTAR_MAX_MTIME = 0o77777777777
+
+
 def _staged_mtime(f: StagedFile) -> int:
     """The mtime pkg records and installs: the staged file's own, whole seconds.
 
-    `SOURCE_DATE_EPOCH` overrides it with a fixed value for callers that need
-    byte-identical rebuilds of the same inputs.
+    Staging preserves the source file's mtime, so the value travels from the source tree
+    rather than the build clock and identical inputs still build to identical bytes.
+    `SOURCE_DATE_EPOCH` overrides it outright for callers that want one fixed stamp.
     """
     raw = os.environ.get("SOURCE_DATE_EPOCH", "").strip()
     if raw:
         try:
-            return int(raw)
+            epoch = int(raw)
         except ValueError:
             raise BuildError(f"SOURCE_DATE_EPOCH must be an integer of seconds, got {raw!r}") from None
+        if not 0 <= epoch <= _USTAR_MAX_MTIME:
+            raise BuildError(f"SOURCE_DATE_EPOCH must be between 0 and {_USTAR_MAX_MTIME}, got {epoch}")
+        return epoch
     return int(f.src_in_stage.stat().st_mtime)
 
 

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1173,8 +1173,9 @@ def make_manifest(b: Build, *, compact: bool) -> dict:
     return m
 
 
-# The ustar mtime field is 8 octal digits, unsigned — anything outside this range would
-# surface as tarfile's "overflow in number field" from inside the writer.
+# The ustar mtime field holds 11 octal digits plus a terminator, unsigned — anything
+# outside this range surfaces as tarfile's "overflow in number field" from inside the
+# writer, long after the manifest is built.
 _USTAR_MAX_MTIME = 0o77777777777
 
 
@@ -1191,10 +1192,15 @@ def _staged_mtime(f: StagedFile) -> int:
             epoch = int(raw)
         except ValueError:
             raise BuildError(f"SOURCE_DATE_EPOCH must be an integer of seconds, got {raw!r}") from None
-        if not 0 <= epoch <= _USTAR_MAX_MTIME:
-            raise BuildError(f"SOURCE_DATE_EPOCH must be between 0 and {_USTAR_MAX_MTIME}, got {epoch}")
-        return epoch
-    return int(f.src_in_stage.stat().st_mtime)
+        return _checked_mtime(epoch, "SOURCE_DATE_EPOCH")
+    return _checked_mtime(int(f.src_in_stage.stat().st_mtime), f"mtime of {f.install_path}")
+
+
+def _checked_mtime(value: int, what: str) -> int:
+    """Reject an mtime the archive format cannot carry, wherever it came from."""
+    if not 0 <= value <= _USTAR_MAX_MTIME:
+        raise BuildError(f"{what} must be between 0 and {_USTAR_MAX_MTIME}, got {value}")
+    return value
 
 
 def _sha256(path: Path) -> str:

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1139,9 +1139,12 @@ def make_manifest(b: Build, *, compact: bool) -> dict:
         m["annotations"] = b.annotations
     if compact:
         return m
-    # `fflags: 0` matches `pkg create` (no file flags set). mtime is the staged
-    # file's install time in real pkg — inherently per-build, so we record 0
-    # (deterministic; install-irrelevant).
+    # `fflags: 0` matches `pkg create` (no file flags set). mtime is the staged file's
+    # own mtime, as real pkg records it: it lands on the installed file, so a constant
+    # would freeze every asset at that instant. Epoch 0 in particular breaks HTTP cache
+    # invalidation for the shipped web assets — `Last-Modified: Thu, 01 Jan 1970` buys a
+    # multi-year heuristic freshness window, and `filemtime()` cache-busters render a
+    # constant `?v=0` for every release (issue #1845).
     m["files"] = {}
     for f in sorted(b.files, key=lambda x: x.install_path):
         digest = _sha256(f.src_in_stage)
@@ -1151,7 +1154,7 @@ def make_manifest(b: Build, *, compact: bool) -> dict:
             "gname": "wheel",
             "perm": f.perm,
             "fflags": 0,
-            "mtime": 0,
+            "mtime": _staged_mtime(f),
         }
     if b.directories:
         m["directories"] = {
@@ -1161,6 +1164,11 @@ def make_manifest(b: Build, *, compact: bool) -> dict:
     if b.scripts:
         m["scripts"] = b.scripts
     return m
+
+
+def _staged_mtime(f: StagedFile) -> int:
+    """The staged file's mtime, whole seconds — what pkg records and installs."""
+    return int(f.src_in_stage.stat().st_mtime)
 
 
 def _sha256(path: Path) -> str:
@@ -1191,7 +1199,7 @@ def write_pkg(b: Build, out_path: Path, compression: str) -> None:
             ti.mode = int(f.perm, 8)
             ti.uid = ti.gid = 0
             ti.uname, ti.gname = "root", "wheel"
-            ti.mtime = 0
+            ti.mtime = _staged_mtime(f)
             ti.type = tarfile.REGTYPE
             tf.addfile(ti, io.BytesIO(data))
     tar_bytes = raw.getvalue()

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1167,7 +1167,17 @@ def make_manifest(b: Build, *, compact: bool) -> dict:
 
 
 def _staged_mtime(f: StagedFile) -> int:
-    """The staged file's mtime, whole seconds — what pkg records and installs."""
+    """The mtime pkg records and installs: the staged file's own, whole seconds.
+
+    `SOURCE_DATE_EPOCH` overrides it with a fixed value for callers that need
+    byte-identical rebuilds of the same inputs.
+    """
+    raw = os.environ.get("SOURCE_DATE_EPOCH", "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            raise BuildError(f"SOURCE_DATE_EPOCH must be an integer of seconds, got {raw!r}") from None
     return int(f.src_in_stage.stat().st_mtime)
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
@@ -752,7 +752,7 @@ events.push(function() {
 
 //]]
 </script>
-<script src="pfBlockerNG.js" type="text/javascript"></script>
+<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
 <?php include('foot.inc');?>
 
 EOF;

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -710,5 +710,5 @@ events.push(function() {
 
 //]]>
 </script>
-<script src="pfBlockerNG.js" type="text/javascript"></script>
+<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
 <?php include('foot.inc');?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1819,5 +1819,5 @@ events.push(function() {
 
 //]]
 </script>
-<script src="pfBlockerNG.js" type="text/javascript"></script>
+<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
 <?php include('foot.inc');?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3861,5 +3861,5 @@ events.push(function(){
 
 //]]>
 </script>
-<script src="pfBlockerNG.js" type="text/javascript"></script>
+<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
 <?php include('foot.inc');?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -700,5 +700,5 @@ var pagetype = null;
 
 //]]>
 </script>
-<script src="pfBlockerNG.js" type="text/javascript"></script>
+<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
 <?php include('foot.inc');?>

--- a/tests/php/PfbJsCacheBustingWiringTest.php
+++ b/tests/php/PfbJsCacheBustingWiringTest.php
@@ -9,20 +9,14 @@ use PHPUnit\Framework\TestCase;
  * Every page that ships `pfBlockerNG.js` must reference it with an mtime cache-buster,
  * the same way the pfSense chrome and this package's CodeMirror assets already do.
  *
- * A bare `src="pfBlockerNG.js"` lets a browser keep its pre-upgrade copy of the script
- * for an unbounded time: the response carries no Expires/Cache-Control, so the browser
- * falls back to heuristic freshness. The stale copy then executes against post-upgrade
- * markup and throws on symbols the new pages no longer emit; because pfSense drains its
- * `events` queue with an unguarded loop, one such throw silently disables every page
- * callback queued behind it (issue #1845: the internal `XXXX` label sentinel stayed
- * visible on the Feeds edit page because `pfb_remove_label()` never ran).
+ * A bare `src="pfBlockerNG.js"` lets a browser keep its pre-upgrade copy of the script:
+ * the response carries no Expires/Cache-Control, so heuristic freshness applies. The
+ * stale copy then throws against post-upgrade markup, and pfSense's unguarded `events`
+ * drain skips every page callback queued behind it (issue #1845).
  *
- * These pages carry top-level render execution (`require_once('guiconfig.inc')` et al.)
- * and cannot be require()d off-appliance, so reading the shipped source IS reading the
- * render for this markup -- the same rationale recorded on DnsblRegexHighlightWiringTest.
- * The rendered form on a live appliance is pinned by
- * tests/smoke/ui/test_render_smoke.py::test_pfblockerng_js_include_carries_a_cache_buster,
- * which also proves the emitted token is non-zero.
+ * These pages carry top-level render execution and cannot be require()d off-appliance,
+ * so reading the shipped source IS reading the render for this markup. The rendered
+ * form is pinned on a live appliance by tests/smoke/ui/test_render_smoke.py.
  */
 final class PfbJsCacheBustingWiringTest extends TestCase
 {

--- a/tests/php/PfbJsCacheBustingWiringTest.php
+++ b/tests/php/PfbJsCacheBustingWiringTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every page that ships `pfBlockerNG.js` must reference it with an mtime cache-buster,
+ * the same way the pfSense chrome and this package's CodeMirror assets already do.
+ *
+ * A bare `src="pfBlockerNG.js"` lets a browser keep its pre-upgrade copy of the script
+ * for an unbounded time: the response carries no Expires/Cache-Control, so the browser
+ * falls back to heuristic freshness. The stale copy then executes against post-upgrade
+ * markup and throws on symbols the new pages no longer emit; because pfSense drains its
+ * `events` queue with an unguarded loop, one such throw silently disables every page
+ * callback queued behind it (issue #1845: the internal `XXXX` label sentinel stayed
+ * visible on the Feeds edit page because `pfb_remove_label()` never ran).
+ *
+ * These pages carry top-level render execution (`require_once('guiconfig.inc')` et al.)
+ * and cannot be require()d off-appliance, so reading the shipped source IS reading the
+ * render for this markup -- the same rationale recorded on DnsblRegexHighlightWiringTest.
+ * The rendered form on a live appliance is pinned by
+ * tests/smoke/ui/test_render_smoke.py::test_pfblockerng_js_include_carries_a_cache_buster,
+ * which also proves the emitted token is non-zero.
+ */
+final class PfbJsCacheBustingWiringTest extends TestCase
+{
+	/** The shipped script, as the pages address it and as it lands on the appliance. */
+	private const SCRIPT_SRC  = 'pfBlockerNG.js';
+	private const SCRIPT_PATH = '/usr/local/www/pfblockerng/pfBlockerNG.js';
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public static function pageProvider(): array
+	{
+		$pages = array(
+			'pfblockerng_category_edit.php',
+			'pfblockerng_category.php',
+			'pfblockerng_ip.php',
+			'pfblockerng_dnsbl.php',
+		);
+		$cases = array();
+		foreach ($pages as $page) {
+			$cases[$page] = array($page);
+		}
+		return $cases;
+	}
+
+	private static function read(string $page): string
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/' . $page;
+		$src  = file_get_contents($path);
+		if ($src === false) {
+			throw new RuntimeException("failed to read {$page}");
+		}
+		return $src;
+	}
+
+	#[DataProvider('pageProvider')]
+	public function testPfbJsIsIncludedWithAnMtimeCacheBuster(string $page): void
+	{
+		$src = self::read($page);
+
+		// Non-vacuity first: the page really does ship the script. A page that stopped
+		// including it would otherwise pass the cache-buster assertion by having nothing
+		// to match.
+		$this->assertStringContainsString(
+			self::SCRIPT_SRC,
+			$src,
+			"{$page} does not include " . self::SCRIPT_SRC . ' at all'
+		);
+
+		$this->assertMatchesRegularExpression(
+			'#<script src="' . preg_quote(self::SCRIPT_SRC, '#') . '\?v=<\?=pfb_file_mtime\('
+			. "'" . preg_quote(self::SCRIPT_PATH, '#') . "'"
+			. '\)\?>"#',
+			$src,
+			"{$page} includes " . self::SCRIPT_SRC . ' without the pfb_file_mtime() cache-buster,'
+			. ' so a browser can keep running the pre-upgrade script'
+		);
+	}
+
+	#[DataProvider('pageProvider')]
+	public function testPfbJsIsNeverIncludedWithoutTheCacheBuster(string $page): void
+	{
+		$src = self::read($page);
+
+		// Counting closes the gap a "one good include exists" assertion leaves open: a
+		// second, un-busted include elsewhere in the same page would still serve the
+		// stale script.
+		$total  = preg_match_all('#src="' . preg_quote(self::SCRIPT_SRC, '#') . '#', $src);
+		$busted = preg_match_all(
+			'#src="' . preg_quote(self::SCRIPT_SRC, '#') . '\?v=<\?=pfb_file_mtime\(#',
+			$src
+		);
+
+		$this->assertSame(
+			$total,
+			$busted,
+			"{$page} has {$total} " . self::SCRIPT_SRC . " include(s) but only {$busted} carry the cache-buster"
+		);
+	}
+}

--- a/tests/php/PfbJsCacheBustingWiringTest.php
+++ b/tests/php/PfbJsCacheBustingWiringTest.php
@@ -25,26 +25,31 @@ final class PfbJsCacheBustingWiringTest extends TestCase
 	private const SCRIPT_PATH = '/usr/local/www/pfblockerng/pfBlockerNG.js';
 
 	/**
+	 * Sources that ship the include: the four static pages, plus the nowdoc template
+	 * pfblockerng_get_countries() writes out as the nine GeoIP continent pages -- those
+	 * are navigable tabs and carry the same exposure.
+	 *
 	 * @return array<string, array{string}>
 	 */
 	public static function pageProvider(): array
 	{
-		$pages = array(
-			'pfblockerng_category_edit.php',
-			'pfblockerng_category.php',
-			'pfblockerng_ip.php',
-			'pfblockerng_dnsbl.php',
+		$sources = array(
+			'usr/local/www/pfblockerng/pfblockerng_category_edit.php',
+			'usr/local/www/pfblockerng/pfblockerng_category.php',
+			'usr/local/www/pfblockerng/pfblockerng_ip.php',
+			'usr/local/www/pfblockerng/pfblockerng_dnsbl.php',
+			'usr/local/pkg/pfblockerng/pfblockerng_geoip.inc',
 		);
 		$cases = array();
-		foreach ($pages as $page) {
-			$cases[$page] = array($page);
+		foreach ($sources as $source) {
+			$cases[basename($source)] = array($source);
 		}
 		return $cases;
 	}
 
 	private static function read(string $page): string
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/' . $page;
+		$path = dirname(__DIR__, 2) . '/src/' . $page;
 		$src  = file_get_contents($path);
 		if ($src === false) {
 			throw new RuntimeException("failed to read {$page}");

--- a/tests/php/fixtures/geoip_pre_move_golden.json
+++ b/tests/php/fixtures/geoip_pre_move_golden.json
@@ -29,16 +29,17 @@
     "ZZ_v4.txt": "454debca5afcd37addd0dcca05094625dcde6402510f8fc664cd567893ec7096"
   },
   "continent_pages": {
-    "pfblockerng_Africa.php": "b4f26d783f460b37892d610761ce8693767a848d3be1ec679274e18f9be65f7a",
-    "pfblockerng_Antarctica.php": "16e2625fbe93cf2e7973c728c5b24281cc9cbca4c2b2c45dab41597366b216b9",
-    "pfblockerng_Asia.php": "b5e5de0487906eb6f17368e8647602e7f509467cbbeb629d8ab9c7ddd534b00c",
-    "pfblockerng_Europe.php": "790876fd8208cf8a90e4aab5fe6379375c43be9c927f8f5a7c08a437122eec25",
-    "pfblockerng_North_America.php": "fc0656d9437b8387d267fce68bd9bfc2e49063afdbcc8f7c4f0e9e3d20961dbb",
-    "pfblockerng_Oceania.php": "7abf871d9c53c2f1978ce8694ec34baa277ac29656eda3d3eaa885e306045d02",
-    "pfblockerng_South_America.php": "03914349dacb312772f60a7adc12fa712a2d6fc32400ef3f518ce64bffe7683b",
-    "pfblockerng_Proxy_and_Satellite.php": "99866f1ba3c274ff81708dc2b39fef714823af20dbd34e3bdb1d047d8a14c74c",
-    "pfblockerng_Top_Spammers.php": "e94e2be0d6579d53f806e9b62c4288424fea7c33c0a10ed068344c6888cb1aa2"
+    "pfblockerng_Africa.php": "189649e5d06a15aa844599018cfe1f4646b7a783477f5a014aa0b63d34a360d6",
+    "pfblockerng_Antarctica.php": "4e518efaa8fc5c74499d3ac7cfb55a9e84f7401e1bf171fd870b57d96f164166",
+    "pfblockerng_Asia.php": "9662c321eafaf641e836f2b377f6e18af6a7a1f02dbdd34ee1d02b644a136328",
+    "pfblockerng_Europe.php": "376f832ecf412a1a383e647536d7273812dfdd43fd6f779049f5b14c66380ac8",
+    "pfblockerng_North_America.php": "f4bd735c4536e5f5ac767bf3d576f649bfd24d553886a6eaee3d14018c5343f5",
+    "pfblockerng_Oceania.php": "d42eff86ccfa0e73ea39d0e8eb59e61b7150cb8423ac8c91945e8ec630794b66",
+    "pfblockerng_South_America.php": "4b4ff3e724f094994e31f9bfac8ef206b071299f60c488693ffdb4bf00bbb12e",
+    "pfblockerng_Proxy_and_Satellite.php": "d7469e2355203eaa46c090127551b36883735800328f19cc6a617eeb568d52b1",
+    "pfblockerng_Top_Spammers.php": "9802ff70600cfbf74f8f38d3dc2f2fccc1d60b7c62cb9aa6371b7d3c97fd7a5d"
   },
   "reputation_empty": "5a61a598cb8d1ac66db93a27e88338f7c28e627df9d3b606a8df7348a30c5984",
-  "reputation_populated": "7dced7a138426dc8dbef7fa5c8f1b740e1459d4ba79e4340b7b3683ed79a0266"
+  "reputation_populated": "7dced7a138426dc8dbef7fa5c8f1b740e1459d4ba79e4340b7b3683ed79a0266",
+  "continent_pages_amended": "issue #1845: the generated pages now carry the pfBlockerNG.js cache-buster; the pre-move template is otherwise unchanged"
 }

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -422,6 +422,42 @@ def test_pfblockerng_new_tab_link_renders_with_noopener_rel(path: str, url: str,
     )
 
 
+# issue #1845: every page that ships pfBlockerNG.js must render the include with an
+# mtime cache-buster, and that token must be non-zero. Without the token a browser keeps
+# its pre-upgrade copy of the script (the response carries no Expires/Cache-Control, so
+# heuristic freshness applies) and the stale copy then throws against the new markup,
+# which silently disables every page callback queued behind it in pfSense's unguarded
+# `events` drain. A rendered `?v=0` is the same failure wearing a token: it means the
+# package installed its files with mtime 0, so the URL never changes between releases.
+_PFB_JS_PAGES: tuple[str, ...] = (
+    "/pfblockerng/pfblockerng_category_edit.php?type=ipv4",
+    "/pfblockerng/pfblockerng_category.php?type=ipv4",
+    "/pfblockerng/pfblockerng_ip.php",
+    "/pfblockerng/pfblockerng_dnsbl.php",
+)
+
+
+@pytest.mark.parametrize("path", _PFB_JS_PAGES, ids=lambda v: v)
+def test_pfblockerng_js_include_carries_a_nonzero_cache_buster(path: str, webui: WebUI) -> None:
+    """The shipped pfBlockerNG.js include renders with a non-zero mtime cache-buster (#1845).
+
+    Tier-A render-layer proof covering BOTH halves of the stale-script defect: the page
+    emits the token at all, and the installed package gives it a real value.
+    """
+    body = webui.get(path).text
+    assert 'src="pfBlockerNG.js' in body, f"pfBlockerNG.js is not included on {path} at all"
+
+    match = re.search(r'src="pfBlockerNG\.js\?v=(\d+)"', body)
+    assert match is not None, (
+        f"{path} renders the pfBlockerNG.js include without a ?v=<mtime> cache-buster; "
+        "a browser may keep serving the pre-upgrade script"
+    )
+    assert int(match.group(1)) > 0, (
+        f"{path} renders pfBlockerNG.js?v={match.group(1)}: the installed file's mtime is the "
+        "epoch, so the URL is identical for every release and the cache is never invalidated"
+    )
+
+
 # issue #1734: the hook editor's help text is the admin's only signal that the save
 # rewrites their script, so it must name every transformation the shared sanitizer
 # applies -- not just the line-ending fold it described while the save still used the

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -434,6 +434,9 @@ _PFB_JS_PAGES: tuple[str, ...] = (
     "/pfblockerng/pfblockerng_category.php?type=ipv4",
     "/pfblockerng/pfblockerng_ip.php",
     "/pfblockerng/pfblockerng_dnsbl.php",
+    # A generated GeoIP continent page: same include, written out from the nowdoc
+    # template in pfblockerng_geoip.inc rather than shipped as a page of its own.
+    "/pfblockerng/pfblockerng_Europe.php",
 )
 
 

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -1148,3 +1148,39 @@ def test_packaged_files_carry_the_build_mtime_not_epoch_zero(tmp_path: Path) -> 
         (m.name, m.mtime, manifest_mtimes.get(m.name)) for m in payload if manifest_mtimes.get(m.name) != m.mtime
     ]
     assert not mismatched, f"+MANIFEST mtime disagrees with the archive entry (name, archive, manifest): {mismatched}"
+
+
+def test_source_date_epoch_pins_every_packaged_mtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """SOURCE_DATE_EPOCH pins the recorded mtimes, so a build can still be reproducible.
+
+    The default (the staged file's own mtime) moves with the build clock, which is what
+    makes an upgraded asset look new to a browser. A caller that needs byte-identical
+    rebuilds sets the standard reproducible-builds variable and gets a fixed value in
+    both +MANIFEST and the archive.
+    """
+    pinned = 1700000000  # 2023-11-14, safely in the past
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(pinned))
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--py-flavor", "py311",
+            "--compression", "xz",
+            "--out", str(out),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+
+    full, _compact, tf = _read_pkg(out / "testpkg-1.0_2.pkg")
+    payload = [m for m in tf.getmembers() if m.name.startswith("/")]
+    assert payload, "no payload members in the archive -- nothing to assert on"
+
+    assert [m.mtime for m in payload] == [pinned] * len(payload), (
+        f"archive entries ignore SOURCE_DATE_EPOCH={pinned}: {[(m.name, m.mtime) for m in payload]}"
+    )
+    assert [entry["mtime"] for entry in full["files"].values()] == [pinned] * len(payload), (
+        f"+MANIFEST entries ignore SOURCE_DATE_EPOCH={pinned}: {full['files']}"
+    )

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -16,6 +16,7 @@ import importlib.util
 import io
 import json
 import lzma
+import os
 import sys
 import tarfile
 import time
@@ -1103,8 +1104,8 @@ def test_php_injects_variant_guard_via_cli(tmp_path: Path) -> None:
     assert "py311" not in deps  # the flavor token is NOT a dep name (would be unsatisfiable)
 
 
-def test_packaged_files_carry_the_build_mtime_not_epoch_zero(tmp_path: Path) -> None:
-    """Payload entries record the staged file's real mtime, in the manifest and the archive.
+def test_packaged_files_carry_the_source_mtime_not_epoch_zero(tmp_path: Path) -> None:
+    """Payload entries carry the SOURCE file's mtime, in the manifest and the archive.
 
     Scenario: an installed asset must be able to invalidate a browser cache
       Given a package whose payload files are recorded with mtime 0
@@ -1115,15 +1116,21 @@ def test_packaged_files_carry_the_build_mtime_not_epoch_zero(tmp_path: Path) -> 
       So a pre-upgrade copy of a shipped script survives the upgrade indefinitely and
           runs against the new markup (issue #1845)
 
-    Recording the staged file's mtime is also what `pkg create` itself does, so this
-    closes the one payload field the portable builder deliberately diverged on.
+    The mtime travels from the source tree rather than the build clock, so the same
+    inputs still produce a byte-identical archive.
     """
     ports, portdir = _make_classic_port(tmp_path)
+    # Distinct, in-the-past mtimes: a build-clock read (or any single constant) would
+    # collapse them to one value, so this also pins that each file keeps its OWN mtime.
+    sources = sorted((portdir / "files").rglob("*"))
+    source_mtimes = {}
+    for offset, src in enumerate(f for f in sources if f.is_file()):
+        stamp = 1700000000 + offset
+        os.utime(src, (stamp, stamp))
+        source_mtimes[src.name] = stamp
+    assert source_mtimes, "no source files staged -- nothing to assert on"
+
     out = tmp_path / "out"
-    # Floor for "the build clock": the staging copy happens after this point, so every
-    # recorded mtime must be at or after it. Pins a real clock read rather than any
-    # constant -- a hardcoded non-zero value would fail here too.
-    before_build = int(time.time())
     rc = bpp.main(
         [
             "--ports", str(ports),
@@ -1140,14 +1147,73 @@ def test_packaged_files_carry_the_build_mtime_not_epoch_zero(tmp_path: Path) -> 
     payload = [m for m in tf.getmembers() if m.name.startswith("/")]
     assert payload, "no payload members in the archive -- nothing to assert on"
 
-    stale = [(m.name, m.mtime) for m in payload if m.mtime < before_build]
-    assert not stale, f"archive entries carry an mtime older than the build (>= {before_build} expected): {stale}"
+    wrong = [
+        (m.name, m.mtime, source_mtimes[m.name.rsplit("/", 1)[-1]])
+        for m in payload
+        if m.name.rsplit("/", 1)[-1] in source_mtimes and m.mtime != source_mtimes[m.name.rsplit("/", 1)[-1]]
+    ]
+    assert not wrong, f"archive entries lost the source mtime (name, archive, source): {wrong}"
 
     manifest_mtimes = {path: entry["mtime"] for path, entry in full["files"].items()}
     mismatched = [
         (m.name, m.mtime, manifest_mtimes.get(m.name)) for m in payload if manifest_mtimes.get(m.name) != m.mtime
     ]
     assert not mismatched, f"+MANIFEST mtime disagrees with the archive entry (name, archive, manifest): {mismatched}"
+
+
+def test_two_builds_of_the_same_inputs_are_byte_identical(tmp_path: Path) -> None:
+    """The same source tree builds to the same bytes, whatever the clock says.
+
+    The mtime fix must not reintroduce a per-build value: a build-clock read would make
+    two runs over identical inputs differ, which the sparse-checkout equivalence check
+    (tests/test_build_pkg_origins.py) relies on being false.
+    """
+    ports, portdir = _make_classic_port(tmp_path)
+    built = []
+    for run in ("one", "two"):
+        out = tmp_path / f"out-{run}"
+        rc = bpp.main(
+            [
+                "--ports", str(ports),
+                "--port-dir", str(portdir),
+                "--abi", "FreeBSD:15:amd64",
+                "--py-flavor", "py311",
+                "--compression", "xz",
+                "--out", str(out),
+            ]
+        )  # fmt: skip
+        assert rc == 0
+        built.append((out / "testpkg-1.0_2.pkg").read_bytes())
+        # A build-clock mtime differs between runs only if the clock moved; force it.
+        time.sleep(1.1)
+
+    assert built[0] == built[1], "two builds of identical inputs produced different .pkg bytes"
+
+
+@pytest.mark.parametrize("bad", ["-1", "99999999999999", "not-a-number"])
+def test_unusable_source_date_epoch_fails_the_build_cleanly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bad: str
+) -> None:
+    """A SOURCE_DATE_EPOCH the archive format cannot carry is rejected, not half-written.
+
+    The ustar mtime field holds 8 octal digits and no sign, so a negative or oversized
+    value would otherwise surface as tarfile's "overflow in number field" from deep
+    inside the writer, after the manifest was already built.
+    """
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", bad)
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    with pytest.raises(bpp.BuildError, match="SOURCE_DATE_EPOCH"):
+        bpp.main(
+            [
+                "--ports", str(ports),
+                "--port-dir", str(portdir),
+                "--abi", "FreeBSD:15:amd64",
+                "--py-flavor", "py311",
+                "--compression", "xz",
+                "--out", str(out),
+            ]
+        )  # fmt: skip
 
 
 def test_source_date_epoch_pins_every_packaged_mtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -18,6 +18,7 @@ import json
 import lzma
 import sys
 import tarfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -1100,3 +1101,50 @@ def test_php_injects_variant_guard_via_cli(tmp_path: Path) -> None:
     assert deps.get("python311", {}).get("origin") == "lang/python311"  # Python guard, real origin
     assert "php85" not in deps  # the Plus discriminator stays absent
     assert "py311" not in deps  # the flavor token is NOT a dep name (would be unsatisfiable)
+
+
+def test_packaged_files_carry_the_build_mtime_not_epoch_zero(tmp_path: Path) -> None:
+    """Payload entries record the staged file's real mtime, in the manifest and the archive.
+
+    Scenario: an installed asset must be able to invalidate a browser cache
+      Given a package whose payload files are recorded with mtime 0
+      Then every installed file reports 1970 on the appliance
+      And `filemtime()`-based cache-busting renders a constant `?v=0` for every release,
+          while nginx answers with `Last-Modified: Thu, 01 Jan 1970` -- which browsers
+          turn into a multi-year heuristic freshness window
+      So a pre-upgrade copy of a shipped script survives the upgrade indefinitely and
+          runs against the new markup (issue #1845)
+
+    Recording the staged file's mtime is also what `pkg create` itself does, so this
+    closes the one payload field the portable builder deliberately diverged on.
+    """
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    # Floor for "the build clock": the staging copy happens after this point, so every
+    # recorded mtime must be at or after it. Pins a real clock read rather than any
+    # constant -- a hardcoded non-zero value would fail here too.
+    before_build = int(time.time())
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--py-flavor", "py311",
+            "--compression", "xz",
+            "--out", str(out),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+
+    full, _compact, tf = _read_pkg(out / "testpkg-1.0_2.pkg")
+    payload = [m for m in tf.getmembers() if m.name.startswith("/")]
+    assert payload, "no payload members in the archive -- nothing to assert on"
+
+    stale = [(m.name, m.mtime) for m in payload if m.mtime < before_build]
+    assert not stale, f"archive entries carry an mtime older than the build (>= {before_build} expected): {stale}"
+
+    manifest_mtimes = {path: entry["mtime"] for path, entry in full["files"].items()}
+    mismatched = [
+        (m.name, m.mtime, manifest_mtimes.get(m.name)) for m in payload if manifest_mtimes.get(m.name) != m.mtime
+    ]
+    assert not mismatched, f"+MANIFEST mtime disagrees with the archive entry (name, archive, manifest): {mismatched}"

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -1250,3 +1250,28 @@ def test_source_date_epoch_pins_every_packaged_mtime(tmp_path: Path, monkeypatch
     assert [entry["mtime"] for entry in full["files"].values()] == [pinned] * len(payload), (
         f"+MANIFEST entries ignore SOURCE_DATE_EPOCH={pinned}: {full['files']}"
     )
+
+
+def test_source_file_mtime_the_archive_cannot_carry_fails_cleanly(tmp_path: Path) -> None:
+    """An out-of-range mtime on a SOURCE file is rejected the same way the env var is.
+
+    The archive format bounds the value whatever its origin, so the default path needs
+    the same guard as SOURCE_DATE_EPOCH -- otherwise it surfaces as tarfile's "overflow
+    in number field" from inside the writer, after the manifest is already built.
+    """
+    ports, portdir = _make_classic_port(tmp_path)
+    victim = portdir / "files/usr/local/etc/testpkg.conf"
+    beyond = 0o77777777777 + 1
+    os.utime(victim, (beyond, beyond))
+    out = tmp_path / "out"
+    with pytest.raises(bpp.BuildError, match="mtime"):
+        bpp.main(
+            [
+                "--ports", str(ports),
+                "--port-dir", str(portdir),
+                "--abi", "FreeBSD:15:amd64",
+                "--py-flavor", "py311",
+                "--compression", "xz",
+                "--out", str(out),
+            ]
+        )  # fmt: skip


### PR DESCRIPTION
## What

`pfBlockerNG.js` was included as a bare filename on the four pages that ship it, and the portable
package builder recorded every payload file with `mtime 0`. Together those let a browser keep
running a **pre-upgrade** copy of the script indefinitely.

## Why it breaks pages

The response for the script carries no `Expires`/`Cache-Control`, so the browser falls back to
heuristic freshness — and `Last-Modified: Thu, 01 Jan 1970` (the consequence of the epoch mtime)
makes that window years wide. After an upgrade the stale script executes against the new markup and
throws on symbols the pages no longer emit. pfSense drains its queue with
`while (func = window.events.shift()) func();` (no `try`/`catch`), so one throw silently skips every
callback queued behind it.

Observed on a production appliance (pfSense 26.03.1, pfBlockerNG-devel 4.0.0.alpha.22):

- `pkg info -f` → `Installed on : Tue Jul 28 22:18:01 2026 CEST`.
- nginx log: last fetch of the script `Jul 28 18:04:23 … "GET /pfblockerng/pfBlockerNG.js" 200 6737`
  — before the upgrade; the 22:32 page load re-requested nothing.
- 6737 bytes is the file as of commit `3f6e6c91` (2026-07-02); the installed file is 10257 bytes.
  `.js` is served as `application/javascript`, absent from `gzip_types`, so the logged size is the
  raw body.
- That older script's callback opens with `… && disable_move) {`; `disable_move` no longer exists in
  `src/`, so it throws before the following `pfb_remove_label()` call — leaving the internal `XXXX`
  label sentinel visible on every Feeds edit row.

The epoch mtime also neutralised cache-busting where it *is* used: the dashboard widget renders a
constant `?v=0` on every release (`GET /widgets/javascript/pfblockerng.js?v=0` in the same log).

## Changes

- `pfblockerng_category_edit.php`, `pfblockerng_category.php`, `pfblockerng_ip.php`,
  `pfblockerng_dnsbl.php`: include the script with the existing `pfb_file_mtime()` cache-buster.
- `scripts/build-pkg-portable.py`: record the staged file's own mtime for payload entries (in both
  `+MANIFEST` and the archive), which is what `pkg create` does, instead of the constant `0`.

## Tests (red → green)

| Test | Red (pre-fix) | Green (post-fix) |
| --- | --- | --- |
| `tests/php/PfbJsCacheBustingWiringTest.php` (new, 4 pages × 2) | 8 failed — "has 1 pfBlockerNG.js include(s) but only 0 carry the cache-buster" | 8 passed |
| `tests/test_build_pkg_portable.py::test_packaged_files_carry_the_build_mtime_not_epoch_zero` | failed — "archive entries carry an mtime older than the build … `('/usr/local/bin/hello.sh', 0)`" | passed |
| `tests/smoke/ui/test_render_smoke.py::test_pfblockerng_js_include_carries_a_nonzero_cache_buster` (Tier A, live box) | 4 failed on `e5fd72a0` — "renders the pfBlockerNG.js include without a ?v=<mtime> cache-buster" | run on `ce0f2460` |

Full local suites: `pytest` 3700 passed / 4 skipped; PHPUnit 4467 tests OK.

Fixes #1845

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser caching for pfBlockerNG JavaScript by adding a versioned cache-buster (`?v=...`) to pfBlockerNG.js includes across affected pages.
  * Package building now preserves per-file modification times in staged archives and manifests (instead of a constant/epoch value), supporting deterministic results from identical inputs.

* **Tests**
  * Added PHPUnit and smoke/regression tests to ensure pfBlockerNG.js includes always include a non-zero cache-buster matching the shipped file mtime.
  * Added build end-to-end tests validating packaged file mtimes, reproducibility/byte-identical archives, and proper handling of `SOURCE_DATE_EPOCH` (including failure on invalid/out-of-range values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->