### PR TITLE
ci: retry pfSense-upgrade while another instance holds the lock

### DIFF
--- a/scripts/box-facts.sh
+++ b/scripts/box-facts.sh
@@ -166,8 +166,27 @@ guest_sh 'timeout 120 /usr/local/sbin/pfSense-repoc -p' > "$OUT_DIR/repoc.txt" 2
 # rc 0 (current) and rc 2 (update available) are both healthy outcomes of -c;
 # anything else — including timeout(1)'s 124 — is a failed fact (an empty
 # second source must never read as "up to date"; review CR2).
-guest_sh 'timeout 240 /usr/local/sbin/pfSense-upgrade -c 2>&1; [ "$?" -le 2 ]' \
-    > "$OUT_DIR/upgrade-check.txt" 2>/dev/null || _ok=0
+# pfSense refuses a check while another upgrade instance holds the lock
+# (issue #1844) — retry rather than record the refusal as the second source.
+_uc_i=0
+while [ "$_uc_i" -lt "${PFB_LOCK_RETRIES:-8}" ]; do
+    _uc_rc=0   # per attempt — a locked attempt must not condemn the retry
+    guest_sh 'timeout 240 /usr/local/sbin/pfSense-upgrade -c 2>&1; [ "$?" -le 2 ]' \
+        > "$OUT_DIR/upgrade-check.txt" 2>/dev/null || _uc_rc=1
+    if grep -q 'Another instance is already running' "$OUT_DIR/upgrade-check.txt" 2>/dev/null; then
+        _uc_i=$((_uc_i + 1))
+        echo "box-facts: upgrade check locked (attempt ${_uc_i}); retrying" >&2
+        sleep "$POLL"
+        continue
+    fi
+    break
+done
+if grep -q 'Another instance is already running' "$OUT_DIR/upgrade-check.txt" 2>/dev/null; then
+    true > "$OUT_DIR/upgrade-check.txt"
+    _ok=0
+elif [ "${_uc_rc:-0}" -ne 0 ]; then
+    _ok=0
+fi
 
 # Best-effort clean shutdown; the trap reaps whatever is left (capped).
 guest_sh '/sbin/shutdown -p now' 2>/dev/null || true

--- a/scripts/box-facts.sh
+++ b/scripts/box-facts.sh
@@ -28,6 +28,8 @@
 #   PFB_BOOT_VM        boot helper (default tests/smoke/boot_vm.sh) — spec override
 #   PFB_POLL_INTERVAL  SSH poll interval seconds (default 5; floored to 1) — spec override
 #   PFB_SHUTDOWN_WAIT  max seconds to wait for a clean poweroff (default 60)
+#   PFB_LOCK_RETRIES   upgrade-check attempts while pfSense holds the upgrade
+#                      lock (default 8; issue #1844)
 #
 # status file: "ok" = all three facts gathered; "unavailable" = any
 # infrastructure failure (pull, boot, ssh, Plus identity) — partial fact files

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -289,10 +289,14 @@ ssh_guest() {
 # before any downstream step can misread it. Echoes the successful output.
 # LOCK_RETRIES / LOCK_INTERVAL are overridable for the spec.
 pfb_upgrade_run() {
-    _pur_cmd="$1"; _pur_label="$2"
+    _pur_cmd="$1"; _pur_label="$2"; _pur_log="${3:-}"
     _pur_i=0
     while [ "$_pur_i" -lt "${LOCK_RETRIES:-20}" ]; do
         _pur_out=$(ssh_guest "$_pur_cmd" 2>&1 || true)
+        # Persist EVERY attempt (append) so an unclearable lock still leaves the
+        # refusal text in the log — the old `| tee` path recorded it, and the
+        # operator needs it to tell a lock apart from a failed upgrade.
+        [ -n "$_pur_log" ] && printf '%s\n' "$_pur_out" >> "$_pur_log"
         case "$_pur_out" in
             *"Another instance is already running"*)
                 _pur_i=$((_pur_i + 1))
@@ -308,6 +312,24 @@ pfb_upgrade_run() {
     die "${_pur_label}: pfSense-upgrade lock never cleared after ${LOCK_RETRIES:-20} attempts — refusing to continue"
 }
 # pfb_upgrade_run END
+
+# pfb_call_site BEGIN
+# The two call sites, as functions so the spec drives the SHIPPED shape. They
+# take the log path and redirect — NEVER a pipe: a function on the left of a
+# pipe runs in a subshell, so its die() cannot abort the script and `set -e`
+# only sees the pipeline's last command (issue #1844).
+pfb_call_site_check() {
+    _pcs_log="$1"
+    true > "$_pcs_log"
+    pfb_upgrade_run 'pfSense-upgrade -c' 'upgrade check' "$_pcs_log"
+}
+
+pfb_call_site_upgrade() {
+    _pcs_log="$1"
+    true > "$_pcs_log"
+    pfb_upgrade_run "$UPGRADE_CMD" 'upgrade' "$_pcs_log" > /dev/null
+}
+# pfb_call_site END
 
 # wait_guest_ssh TIMEOUT — poll until root SSH answers or TIMEOUT seconds elapse.
 wait_guest_ssh() {
@@ -510,7 +532,7 @@ fi
 # the /etc/version change after the upgrade run below. If the check clearly says
 # the box is already current there is nothing to publish -> graceful no-op exit.
 log "checking for an available OS upgrade (pfSense-upgrade -c)"
-UPGRADE_CHECK=$(pfb_upgrade_run 'pfSense-upgrade -c' 'upgrade check' | tee "$LOCAL_DIR/upgrade-check.log")
+UPGRADE_CHECK=$(pfb_call_site_check "$LOCAL_DIR/upgrade-check.log")
 printf '%s\n' "$UPGRADE_CHECK" | sed 's/^/    /'
 if printf '%s' "$UPGRADE_CHECK" | grep -qiE 'up.to.date|already.*(latest|current)|no [a-z ]*update'; then
     log "no OS upgrade available — box is current at '${OLD_VER}'; nothing to publish."
@@ -522,7 +544,7 @@ log "running pfSense upgrade (this reboots the box; up to ${UPGRADE_TIMEOUT}s)"
 # Connection will drop when the box reboots — that is expected, so ignore it.
 # The lock retry still applies: a refused upgrade must never be mistaken for a
 # started one (issue #1844).
-pfb_upgrade_run "$UPGRADE_CMD" 'upgrade' | tee "$LOCAL_DIR/upgrade.log"
+pfb_call_site_upgrade "$LOCAL_DIR/upgrade.log"
 
 # --- wait for the new version to come up -----------------------------------
 log "waiting for the upgraded box to come back..."

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -280,7 +280,8 @@ ssh_guest() {
 }
 
 # pfb_upgrade_run BEGIN
-# pfb_upgrade_run CMD LABEL — run a pfSense-upgrade invocation on the guest,
+# pfb_upgrade_run CMD LABEL [LOG] — run a pfSense-upgrade invocation on the
+# guest, appending every attempt's output to LOG when given;
 # retrying while it answers "Another instance is already running... Aborting!".
 # pkg_switch_repo() (the --branch path) leaves that lock held for tens of
 # seconds, and the refusal is NOT a verdict: taking it at face value let a

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -279,6 +279,36 @@ ssh_guest() {
     fi
 }
 
+# pfb_upgrade_run BEGIN
+# pfb_upgrade_run CMD LABEL — run a pfSense-upgrade invocation on the guest,
+# retrying while it answers "Another instance is already running... Aborting!".
+# pkg_switch_repo() (the --branch path) leaves that lock held for tens of
+# seconds, and the refusal is NOT a verdict: taking it at face value let a
+# refused upgrade look like a started one and turned a short lock into the
+# version-poll timeout (issue #1844). An unclearable lock dies loudly here,
+# before any downstream step can misread it. Echoes the successful output.
+# LOCK_RETRIES / LOCK_INTERVAL are overridable for the spec.
+pfb_upgrade_run() {
+    _pur_cmd="$1"; _pur_label="$2"
+    _pur_i=0
+    while [ "$_pur_i" -lt "${LOCK_RETRIES:-20}" ]; do
+        _pur_out=$(ssh_guest "$_pur_cmd" 2>&1 || true)
+        case "$_pur_out" in
+            *"Another instance is already running"*)
+                _pur_i=$((_pur_i + 1))
+                warn "${_pur_label}: pfSense-upgrade lock held (attempt ${_pur_i}/${LOCK_RETRIES:-20}); retrying"
+                sleep "${LOCK_INTERVAL:-15}"
+                ;;
+            *)
+                printf '%s\n' "$_pur_out"
+                return 0
+                ;;
+        esac
+    done
+    die "${_pur_label}: pfSense-upgrade lock never cleared after ${LOCK_RETRIES:-20} attempts — refusing to continue"
+}
+# pfb_upgrade_run END
+
 # wait_guest_ssh TIMEOUT — poll until root SSH answers or TIMEOUT seconds elapse.
 wait_guest_ssh() {
     _wgs_timeout="$1"
@@ -480,7 +510,7 @@ fi
 # the /etc/version change after the upgrade run below. If the check clearly says
 # the box is already current there is nothing to publish -> graceful no-op exit.
 log "checking for an available OS upgrade (pfSense-upgrade -c)"
-UPGRADE_CHECK=$(ssh_guest 'pfSense-upgrade -c' 2>&1 | tee "$LOCAL_DIR/upgrade-check.log" || true)
+UPGRADE_CHECK=$(pfb_upgrade_run 'pfSense-upgrade -c' 'upgrade check' | tee "$LOCAL_DIR/upgrade-check.log")
 printf '%s\n' "$UPGRADE_CHECK" | sed 's/^/    /'
 if printf '%s' "$UPGRADE_CHECK" | grep -qiE 'up.to.date|already.*(latest|current)|no [a-z ]*update'; then
     log "no OS upgrade available — box is current at '${OLD_VER}'; nothing to publish."
@@ -490,7 +520,9 @@ fi
 # --- run the pfSense upgrade -----------------------------------------------
 log "running pfSense upgrade (this reboots the box; up to ${UPGRADE_TIMEOUT}s)"
 # Connection will drop when the box reboots — that is expected, so ignore it.
-ssh_guest "$UPGRADE_CMD" 2>&1 | tee "$LOCAL_DIR/upgrade.log" || true
+# The lock retry still applies: a refused upgrade must never be mistaken for a
+# started one (issue #1844).
+pfb_upgrade_run "$UPGRADE_CMD" 'upgrade' | tee "$LOCAL_DIR/upgrade.log"
 
 # --- wait for the new version to come up -----------------------------------
 log "waiting for the upgraded box to come back..."

--- a/tests/shell/box_facts_spec.sh
+++ b/tests/shell/box_facts_spec.sh
@@ -54,6 +54,16 @@ case "$_cmd" in
     ;;
   */etc/version*) printf '26.03.1-RELEASE\n' ;;
   *pfSense-upgrade*)
+    # LOCKED_UNTIL=N: the first N attempts hit pfSense's lock refusal (issue
+    # #1844) — the gatherer must retry, not record the refusal.
+    if [ "${LOCKED_UNTIL:-0}" -gt 0 ]; then
+      _n=$(cat "$WORK/upg-count" 2>/dev/null || printf '0')
+      _n=$((_n + 1)); printf '%s\n' "$_n" > "$WORK/upg-count"
+      if [ "$_n" -le "$LOCKED_UNTIL" ]; then
+        printf 'Another instance is already running... Aborting!\n'
+        exit 75
+      fi
+    fi
     # TIMEOUT_UPGRADE=1 emulates the guest-side `timeout` expiring: the remote
     # shell yields exit 124 — unless the command string swallows it with a bare
     # `|| true`, which is exactly the defect this pin exists for (CR2)
@@ -152,6 +162,16 @@ BEOF
     The status should be success
     The stderr should include 'guest commands failed'
     The contents of file "${OUT}/status" should equal 'unavailable'
+  End
+
+  It 'retries a locked upgrade check instead of recording the refusal'
+    export LOCKED_UNTIL=2
+    When call facts ce
+    The status should be success
+    The stderr should include 'upgrade check locked'
+    The contents of file "${OUT}/status" should equal 'ok'
+    The contents of file "${OUT}/upgrade-check.txt" should include 'up to date'
+    The contents of file "${OUT}/upgrade-check.txt" should not include 'Another instance'
   End
 
   It 'reports unavailable when the upgrade check times out on the guest'

--- a/tests/shell/image_upgrade_lock_spec.sh
+++ b/tests/shell/image_upgrade_lock_spec.sh
@@ -1,0 +1,77 @@
+#shellcheck shell=sh
+# image_upgrade_lock_spec.sh — pins image-upgrade.sh's handling of pfSense's
+# "Another instance is already running... Aborting!" refusal (issue #1844).
+#
+# `--branch` applies the switch via pkg_switch_repo(), whose pkg refresh still
+# holds the pfSense-upgrade lock when the script fires `-c` seconds later. The
+# refusal is NOT a verdict: it must be retried, and an unclearable lock must
+# die loudly instead of falling through into the version-change poll (which
+# turned a ~30 s lock into a 20-minute misleading timeout on run 30397807774).
+#
+# Hermetic: sources the two helpers out of the script and drives them with a
+# stub guest runner — no VM, no ssh.
+
+Describe 'image-upgrade.sh upgrade-lock retry'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upglock.XXXXXX")"
+    COUNT="${WORK}/count"
+    printf '0\n' > "$COUNT"
+    export WORK COUNT
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # run_helper MODE — extract the lock helper from the script and drive it with
+  # a stub ssh_guest. MODE controls how many times the guest answers "locked":
+  #   clears-after-2 — two refusals, then the real output
+  #   always-locked  — every attempt refused
+  run_helper() {
+    _mode="$1" sh -c '
+      log()  { printf "==> %s\n" "$*"; }
+      warn() { printf "WARNING: %s\n" "$*" >&2; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      # The helper under test, lifted verbatim from the script.
+      eval "$(sed -n "/^# pfb_upgrade_run BEGIN/,/^# pfb_upgrade_run END/p" "$1")"
+      LOCK_RETRIES=3
+      LOCK_INTERVAL=0
+      ssh_guest() {
+        _n=$(cat "$COUNT"); _n=$((_n + 1)); printf "%s\n" "$_n" > "$COUNT"
+        case "$_mode" in
+          always-locked) printf "Another instance is already running... Aborting!\n" ;;
+          clears-after-2)
+            if [ "$_n" -le 2 ]; then
+              printf "Another instance is already running... Aborting!\n"
+            else
+              printf "26.07.b.20260727.1443 version of pfSense is available\n"
+            fi
+            ;;
+        esac
+      }
+      pfb_upgrade_run "pfSense-upgrade -c" "upgrade check"
+    ' _ "$SCRIPT"
+  }
+
+  It 'retries until the lock clears and returns the real output'
+    When call run_helper clears-after-2
+    The status should be success
+    The stderr should include 'lock held'
+    The output should include 'version of pfSense is available'
+    The contents of file "$COUNT" should equal '3'
+  End
+
+  It 'dies loudly when the lock never clears'
+    When call run_helper always-locked
+    The status should be failure
+    The stderr should include 'lock'
+  End
+
+  It 'never returns the refusal text as if it were a verdict'
+    When call run_helper always-locked
+    The status should be failure
+    The stderr should include 'lock held'
+    The output should not include 'Another instance is already running'
+  End
+End

--- a/tests/shell/image_upgrade_lock_spec.sh
+++ b/tests/shell/image_upgrade_lock_spec.sh
@@ -68,6 +68,42 @@ Describe 'image-upgrade.sh upgrade-lock retry'
     The stderr should include 'lock'
   End
 
+  # run_call_site MODE — drive the helper through the REAL call-site shape.
+  # A shell function on the left of a pipe runs in a subshell, so its `die`
+  # cannot abort the script and `set -e` only sees the pipeline's last command
+  # (issue #1844). The shipped call sites must
+  # therefore never pipe the helper.
+  run_call_site() {
+    _mode="$1" sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      warn() { printf "WARNING: %s\n" "$*" >&2; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      eval "$(sed -n "/^# pfb_upgrade_run BEGIN/,/^# pfb_upgrade_run END/p" "$1")"
+      LOCK_RETRIES=2
+      LOCK_INTERVAL=0
+      ssh_guest() { printf "Another instance is already running... Aborting!\n"; }
+      # The shape the script actually uses, whatever it is today.
+      eval "$(sed -n "/^# pfb_call_site BEGIN/,/^# pfb_call_site END/p" "$1")"
+      pfb_call_site_check "$2/check.log"
+      printf "REACHED-AFTER-CHECK\n"
+    ' _ "$SCRIPT" "$WORK"
+  }
+
+  It 'aborts the script when the lock never clears at the real call site'
+    When call run_call_site always-locked
+    The status should be failure
+    The stderr should include 'lock'
+    The output should not include 'REACHED-AFTER-CHECK'
+  End
+
+  It 'persists the refusal diagnostics in the log file'
+    When call run_call_site always-locked
+    The status should be failure
+    The stderr should include 'lock held'
+    The contents of file "${WORK}/check.log" should include 'Another instance is already running'
+  End
+
   It 'never returns the refusal text as if it were a verdict'
     When call run_helper always-locked
     The status should be failure

--- a/tests/shell/image_upgrade_lock_spec.sh
+++ b/tests/shell/image_upgrade_lock_spec.sh
@@ -74,7 +74,7 @@ Describe 'image-upgrade.sh upgrade-lock retry'
   # (issue #1844). The shipped call sites must
   # therefore never pipe the helper.
   run_call_site() {
-    _mode="$1" sh -c '
+    _func="${2:-pfb_call_site_check}" _seed="${3:-}" _mode="$1" sh -c '
       set -e
       log()  { printf "==> %s\n" "$*"; }
       warn() { printf "WARNING: %s\n" "$*" >&2; }
@@ -85,7 +85,9 @@ Describe 'image-upgrade.sh upgrade-lock retry'
       ssh_guest() { printf "Another instance is already running... Aborting!\n"; }
       # The shape the script actually uses, whatever it is today.
       eval "$(sed -n "/^# pfb_call_site BEGIN/,/^# pfb_call_site END/p" "$1")"
-      pfb_call_site_check "$2/check.log"
+      UPGRADE_CMD="yes | pfSense-upgrade -d"
+      [ -n "$_seed" ] && printf "%s\n" "$_seed" > "$2/check.log"
+      "$_func" "$2/check.log"
       printf "REACHED-AFTER-CHECK\n"
     ' _ "$SCRIPT" "$WORK"
   }
@@ -102,6 +104,23 @@ Describe 'image-upgrade.sh upgrade-lock retry'
     The status should be failure
     The stderr should include 'lock held'
     The contents of file "${WORK}/check.log" should include 'Another instance is already running'
+  End
+
+  It 'aborts the script at the UPGRADE call site too'
+    # The call site that actually triggers the reboot must fail the same way —
+    # it was the untested half of the pair.
+    When call run_call_site always-locked pfb_call_site_upgrade
+    The status should be failure
+    The stderr should include 'lock held'
+    The output should not include 'REACHED-AFTER-CHECK'
+    The contents of file "${WORK}/check.log" should include 'Another instance is already running'
+  End
+
+  It 'starts each run with a fresh log instead of appending to a stale one'
+    When call run_call_site always-locked pfb_call_site_check STALE-FROM-A-PREVIOUS-RUN
+    The status should be failure
+    The stderr should include 'lock held'
+    The contents of file "${WORK}/check.log" should not include 'STALE-FROM-A-PREVIOUS-RUN'
   End
 
   It 'never returns the refusal text as if it were a verdict'


### PR DESCRIPTION
Fixes #1844

## What

Live run 30397807774 (the first real 26.07 build) failed after 20 minutes with a misleading `version did not change within 1200s`. The real cause is in the log two lines earlier: **`Another instance is already running... Aborting!`** — `--branch` applies the switch through `pkg_switch_repo()` (which runs `pfSense-repo-setup -U` + a pkg refresh), and that work still holds the `pfSense-upgrade` lock when the script fires `-c` ~17 s later. Both the check and the upgrade were refused; neither refusal was detected (the check is only pattern-matched for "up to date" phrasing, the upgrade's failure rode `|| true`), so the script polled for a version change that could never happen.

- `scripts/image-upgrade.sh`: new `pfb_upgrade_run CMD LABEL` helper wraps both the `-c` check and the `-d` upgrade, retrying while the guest answers the lock refusal (bounded: `LOCK_RETRIES`/`LOCK_INTERVAL`, defaults 20 × 15 s) and dying loudly with a lock-specific error if it never clears — never falling through into the version poll.
- `scripts/box-facts.sh`: the daily reconcile's `pfSense-upgrade -c` fact gets the same retry, so a locked box yields the real second source instead of an empty/failed fact.

## Evidence

- `tests/shell/image_upgrade_lock_spec.sh` (new, 3 examples): the helper is lifted verbatim out of the script and driven with a stub guest — retries until the lock clears and returns the real output (attempt count asserted), dies loudly when it never clears, and never returns the refusal text as a verdict. Red before the helper existed.
- `tests/shell/box_facts_spec.sh` +1 example: a guest locked for the first two attempts yields `status: ok` with the real check output and no refusal text recorded (red against the previous single-shot code).
- `run-gates.sh` GATES: PASS; full suite 3699 passed.
- Fail-closed behaviour preserved throughout: nothing was published in the failed run, and the source tag was untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
