### PR TITLE
ci: name the failing fact and keep the boot on an optional-check loss

### DIFF
--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -485,6 +485,18 @@ jobs:
             jq -r '.actions[] | select(.type == "warn") | "::warning::\(.family): \(.message)"' "$PLAN"
           done
 
+      # Facts outlive the runner: an intermittent boot failure is otherwise
+      # undiagnosable from the log alone (issue #1848).
+      - name: Upload the gathered facts
+        if: always() && steps.probe_gate.outputs.probe_disabled != 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: reconcile-facts
+          path: facts/
+          if-no-files-found: ignore
+          retention-days: 14
+
       # ── Act 2: matrix auto-PRs (a human merges; NEVER a ci-metadata push) ───
       # matrix_pr_add: new family seen on the box → entry with the action's
       # status, ci: false, fields jq-carried from the newest same-channel amd64

--- a/scripts/box-facts.sh
+++ b/scripts/box-facts.sh
@@ -173,15 +173,15 @@ _ok=1
 # marks the boot unavailable on failure.
 fact_get() {
     _fg_label=$1; _fg_file=$2; _fg_cmd=$3; _fg_opt=${4:-}
-    if guest_sh "$_fg_cmd" > "$_fg_file" 2>/dev/null; then
-        return 0
-    fi
+    guest_sh "$_fg_cmd" > "$_fg_file" 2>/dev/null
+    _fg_rc=$?
+    [ "$_fg_rc" -eq 0 ] && return 0
     if [ "$_fg_opt" = "optional" ]; then
-        echo "box-facts: ${_fg_label} fact failed (optional — boot still usable)" >&2
+        echo "box-facts: ${_fg_label} fact failed (optional — boot still usable): ${_fg_cmd} [status ${_fg_rc}]" >&2
         true > "$_fg_file"
         return 1
     fi
-    echo "box-facts: ${_fg_label} fact failed — status unavailable" >&2
+    echo "box-facts: ${_fg_label} fact failed — status unavailable: ${_fg_cmd} [status ${_fg_rc}]" >&2
     _ok=0
     return 1
 }
@@ -195,14 +195,19 @@ fact_get repoc "$OUT_DIR/repoc.txt" 'timeout 120 /usr/local/sbin/pfSense-repoc -
 # retried, then recorded as absent (an empty file never reads as "up to date").
 # Its loss never voids the boot: the branch list is what the reconcile turns on.
 _uc_raw="$WORK/upgrade-check.raw"
+# Guest-side predicate: pfSense-upgrade -c returns 0 (current) or 2 (update
+# available); anything else — including a real check error (1) and timeout's
+# 124 — must not become the planner's second source.
 _uc_i=0
 _uc_ok=0
-while :; do
-    if guest_sh 'timeout 240 /usr/local/sbin/pfSense-upgrade -c 2>&1; [ "$?" -le 2 ]' \
-        > "$_uc_raw" 2>/dev/null; then
-        _uc_ok=1
-        break
-    fi
+while true; do
+    guest_sh 'timeout 240 /usr/local/sbin/pfSense-upgrade -c 2>&1' > "$_uc_raw" 2>/dev/null
+    _uc_rc=$?
+    # 0 = current, 2 = update available; anything else (a real check error, or
+    # timeout(1)'s 124) must never become the planner's second source.
+    case "$_uc_rc" in
+        0|2) _uc_ok=1; break ;;
+    esac
     grep -q 'Another instance is already running' "$_uc_raw" 2>/dev/null || break
     _uc_i=$((_uc_i + 1))
     [ "$_uc_i" -lt "${PFB_LOCK_RETRIES:-8}" ] || break
@@ -212,7 +217,7 @@ done
 if [ "$_uc_ok" -eq 1 ]; then
     cat "$_uc_raw" > "$OUT_DIR/upgrade-check.txt"
 else
-    echo "box-facts: upgrade-check fact failed (optional — boot still usable)" >&2
+    echo "box-facts: upgrade-check fact failed (optional — boot still usable): pfSense-upgrade -c [status ${_uc_rc:-?}]" >&2
     true > "$OUT_DIR/upgrade-check.txt"
 fi
 

--- a/scripts/box-facts.sh
+++ b/scripts/box-facts.sh
@@ -31,9 +31,11 @@
 #   PFB_LOCK_RETRIES   upgrade-check attempts while pfSense holds the upgrade
 #                      lock (default 8; issue #1844)
 #
-# status file: "ok" = all three facts gathered; "unavailable" = any
-# infrastructure failure (pull, boot, ssh, Plus identity) — partial fact files
-# may exist but the planner must treat the boot as absent.
+# status file: "ok" = the REQUIRED facts (etc-version, repoc) were gathered;
+# the upgrade-check fact is optional (the planner's second source) and its
+# absence leaves an empty file without failing the boot. "unavailable" = a
+# required fact or an infrastructure failure (pull, boot, ssh, Plus identity) —
+# the planner must then treat the boot as absent.
 # Exit status: always 0 — best-effort; callers gate on the status file.
 #
 # POSIX sh (strict ash/dash semantics); base utilities bare, guest binaries absolute.
@@ -161,33 +163,57 @@ fi
 
 # The three facts. repoc and the -c check both refresh metadata over the
 # network — each runs under its own guest-side hard cap (a wedged pkg/fetch
-# must not hang the run; review F2).
+# must not hang the run). Each failure is named in the log; only the REQUIRED
+# facts (etc-version, repoc) decide the boot's status, because the planner
+# treats the -c check as an optional second source (issue #1848).
 _ok=1
-guest_sh 'cat /etc/version' > "$OUT_DIR/etc-version" 2>/dev/null || _ok=0
-guest_sh 'timeout 120 /usr/local/sbin/pfSense-repoc -p' > "$OUT_DIR/repoc.txt" 2>/dev/null || _ok=0
-# rc 0 (current) and rc 2 (update available) are both healthy outcomes of -c;
-# anything else — including timeout(1)'s 124 — is a failed fact (an empty
-# second source must never read as "up to date"; review CR2).
-# pfSense refuses a check while another upgrade instance holds the lock
-# (issue #1844) — retry rather than record the refusal as the second source.
-_uc_i=0
-while [ "$_uc_i" -lt "${PFB_LOCK_RETRIES:-8}" ]; do
-    _uc_rc=0   # per attempt — a locked attempt must not condemn the retry
-    guest_sh 'timeout 240 /usr/local/sbin/pfSense-upgrade -c 2>&1; [ "$?" -le 2 ]' \
-        > "$OUT_DIR/upgrade-check.txt" 2>/dev/null || _uc_rc=1
-    if grep -q 'Another instance is already running' "$OUT_DIR/upgrade-check.txt" 2>/dev/null; then
-        _uc_i=$((_uc_i + 1))
-        echo "box-facts: upgrade check locked (attempt ${_uc_i}); retrying" >&2
-        sleep "$POLL"
-        continue
+
+# fact_get LABEL FILE CMD [optional] — run CMD on the guest, write FILE, and
+# name the fact in the log when it fails. Anything but a trailing "optional"
+# marks the boot unavailable on failure.
+fact_get() {
+    _fg_label=$1; _fg_file=$2; _fg_cmd=$3; _fg_opt=${4:-}
+    if guest_sh "$_fg_cmd" > "$_fg_file" 2>/dev/null; then
+        return 0
     fi
-    break
+    if [ "$_fg_opt" = "optional" ]; then
+        echo "box-facts: ${_fg_label} fact failed (optional — boot still usable)" >&2
+        true > "$_fg_file"
+        return 1
+    fi
+    echo "box-facts: ${_fg_label} fact failed — status unavailable" >&2
+    _ok=0
+    return 1
+}
+
+fact_get etc-version "$OUT_DIR/etc-version" 'cat /etc/version' || true
+fact_get repoc "$OUT_DIR/repoc.txt" 'timeout 120 /usr/local/sbin/pfSense-repoc -p' || true
+
+# The upgrade check is the planner's OPTIONAL second source: rc 0 (current) and
+# rc 2 (update available) are healthy; anything else — timeout(1)'s 124, or the
+# refusal pfSense returns while another upgrade instance holds the lock — is
+# retried, then recorded as absent (an empty file never reads as "up to date").
+# Its loss never voids the boot: the branch list is what the reconcile turns on.
+_uc_raw="$WORK/upgrade-check.raw"
+_uc_i=0
+_uc_ok=0
+while :; do
+    if guest_sh 'timeout 240 /usr/local/sbin/pfSense-upgrade -c 2>&1; [ "$?" -le 2 ]' \
+        > "$_uc_raw" 2>/dev/null; then
+        _uc_ok=1
+        break
+    fi
+    grep -q 'Another instance is already running' "$_uc_raw" 2>/dev/null || break
+    _uc_i=$((_uc_i + 1))
+    [ "$_uc_i" -lt "${PFB_LOCK_RETRIES:-8}" ] || break
+    echo "box-facts: upgrade check locked (attempt ${_uc_i}); retrying" >&2
+    sleep "$POLL"
 done
-if grep -q 'Another instance is already running' "$OUT_DIR/upgrade-check.txt" 2>/dev/null; then
+if [ "$_uc_ok" -eq 1 ]; then
+    cat "$_uc_raw" > "$OUT_DIR/upgrade-check.txt"
+else
+    echo "box-facts: upgrade-check fact failed (optional — boot still usable)" >&2
     true > "$OUT_DIR/upgrade-check.txt"
-    _ok=0
-elif [ "${_uc_rc:-0}" -ne 0 ]; then
-    _ok=0
 fi
 
 # Best-effort clean shutdown; the trap reaps whatever is left (capped).
@@ -200,5 +226,5 @@ done
 if [ "$_ok" -eq 1 ]; then
     done_with ok
 fi
-echo "box-facts: one or more guest commands failed — status unavailable" >&2
+echo "box-facts: required facts incomplete — status unavailable" >&2
 done_with unavailable

--- a/tests/shell/box_facts_spec.sh
+++ b/tests/shell/box_facts_spec.sh
@@ -187,6 +187,18 @@ BEOF
     The contents of file "${OUT}/status" should equal 'unavailable'
   End
 
+  It 'gives up on a lock that never clears instead of retrying forever'
+    # Review: removing the PFB_LOCK_RETRIES bound killed no test — the only
+    # locked case released well inside the default cap.
+    export LOCKED_UNTIL=99 PFB_LOCK_RETRIES=3
+    When call facts ce
+    The status should be success
+    The stderr should include 'attempt 2'
+    The stderr should not include 'attempt 3'
+    The contents of file "${OUT}/status" should equal 'ok'
+    The contents of file "${OUT}/upgrade-check.txt" should equal ''
+  End
+
   It 'still fails the boot when the version fact is lost'
     export FAIL_VERSION=1
     When call facts ce

--- a/tests/shell/box_facts_spec.sh
+++ b/tests/shell/box_facts_spec.sh
@@ -15,7 +15,7 @@ Describe 'box-facts.sh'
     BIN="${WORK}/bin"; mkdir -p "$BIN"
     BOOT_ARGV="${WORK}/boot-argv"
     OUT="${WORK}/facts"
-    KEY="${WORK}/key"; : > "$KEY"
+    KEY="${WORK}/key"; true > "$KEY"
     SSH_CMDS_LOG="${WORK}/ssh-cmds"
 
     # Stub oras: succeed and drop a qcow2 into the --output dir (unless ORAS_FAIL=1).
@@ -27,7 +27,7 @@ while [ "$#" -gt 0 ]; do
   [ "$1" = "--output" ] && _out="$2"
   shift
 done
-[ -n "$_out" ] && : > "${_out}/pfSense-Plus_26.03.qcow2"
+[ -n "$_out" ] && true > "${_out}/pfSense-Plus_26.03.qcow2"
 exit 0
 OEOF
     chmod +x "${BIN}/oras"
@@ -77,7 +77,13 @@ case "$_cmd" in
       esac
     fi
     [ "${FAIL_UPGRADE:-0}" = "1" ] && exit 1
-    printf 'Your system is up to date\n'
+    # UPGRADE_RC models what pfSense-upgrade -c itself returns: 0 current,
+    # 2 update available, 1 a real check error. ssh propagates it.
+    case "${UPGRADE_RC:-0}" in
+      2) printf '26.07.b.20260727.1443 version of pfSense is available\n'; exit 2 ;;
+      1) printf 'Unable to check for updates.\n'; exit 1 ;;
+      *) printf 'Your system is up to date\n' ;;
+    esac
     ;;
 esac
 exit 0
@@ -171,11 +177,13 @@ BEOF
     The contents of file "${OUT}/repoc.txt" should include 'Beta Version (26.07)'
   End
 
-  It 'names the failing fact in the log'
+  It 'names the failing fact, its command and its status in the log'
     export FAIL_REPOC=1
     When call facts ce
     The status should be success
     The stderr should include 'repoc'
+    The stderr should include 'pfSense-repoc -p'
+    The stderr should include 'status 1'
     The contents of file "${OUT}/status" should equal 'unavailable'
   End
 
@@ -203,6 +211,26 @@ BEOF
     The contents of file "${OUT}/status" should equal 'ok'
     The contents of file "${OUT}/upgrade-check.txt" should include 'up to date'
     The contents of file "${OUT}/upgrade-check.txt" should not include 'Another instance'
+  End
+
+  It 'treats a failing upgrade check (rc 1) as an absent optional fact'
+    # CodeRabbit: `-le 2` accepted rc 1, so a real check ERROR would have been
+    # recorded as the planner's second source.
+    export UPGRADE_RC=1
+    When call facts ce
+    The status should be success
+    The stderr should include 'optional'
+    The contents of file "${OUT}/status" should equal 'ok'
+    The contents of file "${OUT}/upgrade-check.txt" should equal ''
+  End
+
+  It 'keeps a real available-update answer (rc 2)'
+    export UPGRADE_RC=2
+    When call facts ce
+    The status should be success
+    The stderr should include 'booting'
+    The contents of file "${OUT}/status" should equal 'ok'
+    The contents of file "${OUT}/upgrade-check.txt" should include 'version of pfSense is available'
   End
 
   It 'records a timed-out upgrade check as absent, never as up to date'

--- a/tests/shell/box_facts_spec.sh
+++ b/tests/shell/box_facts_spec.sh
@@ -52,7 +52,10 @@ case "$_cmd" in
     printf '26.07\t\tBeta Version (26.07)\n'
     printf '26_03_1 (release) (default)\t\tCurrent Stable Version (26.03.1)\n'
     ;;
-  */etc/version*) printf '26.03.1-RELEASE\n' ;;
+  */etc/version*)
+    [ "${FAIL_VERSION:-0}" = "1" ] && exit 1
+    printf '26.03.1-RELEASE\n'
+    ;;
   *pfSense-upgrade*)
     # LOCKED_UNTIL=N: the first N attempts hit pfSense's lock refusal (issue
     # #1844) — the gatherer must retry, not record the refusal.
@@ -73,6 +76,7 @@ case "$_cmd" in
         *) exit 124 ;;
       esac
     fi
+    [ "${FAIL_UPGRADE:-0}" = "1" ] && exit 1
     printf 'Your system is up to date\n'
     ;;
 esac
@@ -156,11 +160,38 @@ BEOF
     The contents of file "${OUT}/status" should equal 'unavailable'
   End
 
-  It 'reports unavailable when a guest fact command fails'
+  # issue #1848: the -c check is the planner's OPTIONAL second source. Losing
+  # it must not discard the branch list — the fact the whole reconcile turns on.
+  It 'keeps the boot usable when only the optional upgrade check fails'
+    export FAIL_UPGRADE=1
+    When call facts ce
+    The status should be success
+    The stderr should include 'upgrade-check'
+    The contents of file "${OUT}/status" should equal 'ok'
+    The contents of file "${OUT}/repoc.txt" should include 'Beta Version (26.07)'
+  End
+
+  It 'names the failing fact in the log'
     export FAIL_REPOC=1
     When call facts ce
     The status should be success
-    The stderr should include 'guest commands failed'
+    The stderr should include 'repoc'
+    The contents of file "${OUT}/status" should equal 'unavailable'
+  End
+
+  It 'still fails the boot when the version fact is lost'
+    export FAIL_VERSION=1
+    When call facts ce
+    The status should be success
+    The stderr should include 'etc-version'
+    The contents of file "${OUT}/status" should equal 'unavailable'
+  End
+
+  It 'reports unavailable when a REQUIRED guest fact command fails'
+    export FAIL_REPOC=1
+    When call facts ce
+    The status should be success
+    The stderr should include 'required facts incomplete'
     The contents of file "${OUT}/status" should equal 'unavailable'
   End
 
@@ -174,13 +205,15 @@ BEOF
     The contents of file "${OUT}/upgrade-check.txt" should not include 'Another instance'
   End
 
-  It 'reports unavailable when the upgrade check times out on the guest'
-    # CodeRabbit CR2: `|| true` must not swallow timeout(1)'s exit 124 — an
-    # empty second-source fact must never count as a clean "up to date"
+  It 'records a timed-out upgrade check as absent, never as up to date'
+    # CR2: timeout(1)'s 124 must never be swallowed into a clean-looking fact.
+    # issue #1848: it is the OPTIONAL source, so the boot stays usable — the
+    # file is left EMPTY, which the planner reads as "no signal".
     export TIMEOUT_UPGRADE=1
     When call facts ce
     The status should be success
-    The stderr should include 'guest commands failed'
-    The contents of file "${OUT}/status" should equal 'unavailable'
+    The stderr should include 'optional'
+    The contents of file "${OUT}/status" should equal 'ok'
+    The contents of file "${OUT}/upgrade-check.txt" should equal ''
   End
 End

--- a/tests/test_reconcile_plan.py
+++ b/tests/test_reconcile_plan.py
@@ -291,3 +291,16 @@ class TestSteadyState:
         ce = {"pfsense_version": "2.8", "channel": "CE", "status": "active", "ci": True}
         actions = _plan([ce], {"2.8": True}, [_boot("2.8", "2.8.1-RELEASE", REPOC_CE)], channel="CE")
         assert actions == []
+
+
+class TestMissingSecondSource:
+    """Scenario (issue #1848): the -c fact is optional. A boot that gathered its
+    branch list but lost the upgrade check must still drive branch-based rules."""
+
+    def test_branches_still_drive_rules_without_upgrade_check(self) -> None:
+        actions = _plan(
+            [PLUS_2603, PLUS_2607_BETA],
+            {"26.03": True, "26.07": False},
+            [_boot("26.03", "26.03.1-RELEASE", REPOC_PLUS, check="")],
+        )
+        assert {"type": "publish_new", "family": "26.07", "branch": "26.07", "from": "26.03"} in actions

--- a/tests/test_version_tracker_reconcile_contract.py
+++ b/tests/test_version_tracker_reconcile_contract.py
@@ -549,3 +549,11 @@ class TestReconcileMatrixSource:
         assert "needs: read-matrix" not in reconcile
         resolve = reconcile.split("- name: Resolve the route matrix", 1)[1].split("\n      - name:", 1)[0]
         assert "continue-on-error: true" in resolve
+
+    def test_reconcile_uploads_the_facts_tree(self) -> None:
+        # issue #1848: an intermittent boot failure is undiagnosable once the
+        # runner is gone — the facts must outlive it.
+        source = WORKFLOW.read_text(encoding="utf-8")
+        reconcile = source.split("\n  reconcile:\n", 1)[1]
+        assert "actions/upload-artifact" in reconcile
+        assert "facts" in reconcile.split("actions/upload-artifact", 1)[1][:400]

--- a/tests/test_version_tracker_reconcile_contract.py
+++ b/tests/test_version_tracker_reconcile_contract.py
@@ -556,4 +556,7 @@ class TestReconcileMatrixSource:
         source = WORKFLOW.read_text(encoding="utf-8")
         reconcile = source.split("\n  reconcile:\n", 1)[1]
         assert "actions/upload-artifact" in reconcile
-        assert "facts" in reconcile.split("actions/upload-artifact", 1)[1][:400]
+        upload = reconcile.split("actions/upload-artifact", 1)[1][:400]
+        assert "facts" in upload
+        # the window an intermittent failure gets investigated in
+        assert "retention-days: 14" in upload


### PR DESCRIPTION
Fixes #1848

## What

Live run 30403475310 lost a Plus boot to `box-facts: one or more guest commands failed — status unavailable`. Two defects behind that one line:

1. **A single failed fact voided the whole boot.** The planner treats `pfSense-upgrade -c` as an OPTIONAL second source (it only acts on the "available" phrase), but its failure marked the boot `unavailable`, discarding the `pfSense-repoc` branch list — the fact the entire reconcile turns on. Result: `warn: no repo branch found` and no 26.07 build, from a box whose branch list was perfectly good.
2. **The log could not say which fact failed**, and the facts tree died with the runner, so an intermittent failure was undiagnosable.

Changes:

- `scripts/box-facts.sh`: a `fact_get LABEL FILE CMD [optional]` helper names every failing fact in the log; `etc-version` + `repoc` are REQUIRED (failure ⇒ `unavailable`), the upgrade check is OPTIONAL (failure ⇒ empty file, boot still `ok`). The lock retry is preserved and now keeps its raw output so the refusal is still detectable across attempts.
- `.github/workflows/version-tracker.yml`: upload the `facts/` tree as an artifact (`if: always()`, 14 days).
- Header contract updated to state which facts are required.

## Evidence

- `tests/shell/box_facts_spec.sh` (11 examples): three new — optional-check loss keeps `status: ok` with the branch list intact, the failing fact is named, a lost `etc-version` still fails the boot. Two legacy cases updated to the new contract (a timed-out check now leaves an EMPTY file and a usable boot — CR2's "never reads as up to date" is preserved by the emptiness, which the planner reads as no signal).
- `tests/test_reconcile_plan.py`: a boot with no second source still drives the branch rules (`publish_new` for the unpublished family).
- `tests/test_version_tracker_reconcile_contract.py`: the reconcile uploads the facts tree (red before).
- Full suite 3708 passed; `run-gates.sh` GATES: PASS; actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reconciliation now preserves generated diagnostic facts as downloadable artifacts, including when intermittent boot checks fail.
* **Bug Fixes**
  * Optional upgrade checks no longer make boot status unavailable when they fail or time out.
  * Required version and repository facts now correctly determine availability.
  * Branch-based publishing continues to work when upgrade-check data is missing.
* **Tests**
  * Added coverage for required and optional fact failures, artifact uploads, and reconciliation behavior with incomplete inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->