### PR TITLE
pfblockerng: guard the pfctl-show capture generator's finally; treat an absent table as no live members

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4139,6 +4139,16 @@ function pfb_ip_suppressed_match(string $ip, array $entries): ?string
  * capture failure as "not currently blocked". The throw fires lazily, on the
  * generator's first iteration.
  *
+ * Issue #1852 -- ONE exception to the above: a table absent from the loaded
+ * ruleset (a fresh alias not yet referenced by any rule/reload -- verified
+ * on pfSense CE 2.8 / PHP 8.3: `pfctl -t <absent> -T show` exits rc=255,
+ * stderr "pfctl: Table does not exist.") yields EMPTY rather than throwing --
+ * that condition genuinely means "no live members", not a capture failure,
+ * and a user clicking Alerts "+" on such a host must not fatal. Distinguished
+ * by classifying `pfctl`'s own stderr (captured to a SEPARATE temp file, per
+ * ADR-53 below, never merged into the stdout membership parse); any other
+ * non-zero exit still throws.
+ *
  * NOT pure -- execs pfctl.
  *
  * @param  string $pfctl    Absolute path to the pfctl binary ($pfb['pfctl']).
@@ -4156,18 +4166,41 @@ function pfb_live_table_snapshot(string $pfctl, string $aliasdir, string $dbdir,
 	if ($scan_tmp === FALSE) {
 		throw new \RuntimeException("table={$table}: tempnam() failed in dbdir={$dbdir}");
 	}
+	$err_tmp = tempnam($dbdir, 'pfb_punch_err_');
+	if ($err_tmp === FALSE) {
+		@unlink($scan_tmp);
+		throw new \RuntimeException("table={$table}: tempnam() failed in dbdir={$dbdir}");
+	}
 
-	// ADR-53: stderr -> /dev/null, NOT 2>&1 -- the
-	// capture file is parsed line-by-line as membership entries below;
-	// merging stderr into it would feed any pfctl diagnostic line into
-	// that parse as if it were a table member.
+	// ADR-53/#1852: stdout and stderr capture to SEPARATE temp files -- NOT
+	// 2>&1 -- the stdout file is parsed line-by-line as membership entries
+	// below; merging stderr into it would feed any pfctl diagnostic line
+	// into that parse as if it were a table member. stderr is classified
+	// below on a non-zero exit, to tell an absent table (benign) from a
+	// genuine pfctl failure (loud).
 	$exec_out = [];
 	$rc       = 0;
-	exec("{$pfctl} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>/dev/null', $exec_out, $rc);
+	exec(
+		"{$pfctl} -t {$table_esc} -T show > " . escapeshellarg($scan_tmp) . ' 2>' . escapeshellarg($err_tmp),
+		$exec_out,
+		$rc
+	);
 	if ($rc !== 0) {
+		$stderr_text = (string) @file_get_contents($err_tmp);
 		@unlink($scan_tmp);
-		throw new \RuntimeException("table={$table}: pfctl -T show exited rc={$rc}");
+		@unlink($err_tmp);
+		// pfctl's own wording for a table absent from the loaded ruleset
+		// (probed on pfSense CE 2.8 / PHP 8.3.19: rc=255, stderr
+		// "pfctl: Table does not exist."). A fresh alias not yet referenced
+		// by any rule/reload is "no live members", not a capture failure --
+		// yield nothing rather than throw. Any other non-zero exit (a
+		// genuine pfctl failure) still throws loudly.
+		if (str_contains($stderr_text, 'Table does not exist')) {
+			return;
+		}
+		throw new \RuntimeException("table={$table}: pfctl -T show exited rc={$rc}: " . trim($stderr_text));
 	}
+	@unlink($err_tmp);
 
 	$handle = @fopen($scan_tmp, 'r');
 	if ($handle === FALSE) {
@@ -4179,7 +4212,14 @@ function pfb_live_table_snapshot(string $pfctl, string $aliasdir, string $dbdir,
 			yield trim($line);
 		}
 	} finally {
-		fclose($handle);
+		// Issue #1852: an abandoned (never-fully-drained) generator's finally
+		// only runs at the tail of request shutdown (bugs.php.net #76006), by
+		// which point $handle can already be an invalid resource -- guard
+		// instead of a bare fclose(). @unlink() still runs unconditionally so
+		// the scratch file is never leaked either way.
+		if (is_resource($handle)) {
+			fclose($handle);
+		}
 		@unlink($scan_tmp);
 	}
 }

--- a/tests/php/LiveTableSnapshotAbandonedFcloseTest.php
+++ b/tests/php/LiveTableSnapshotAbandonedFcloseTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1852: a live CE 2.8 UI-render run hit
+ * `TypeError: fclose(): Argument #1 ($stream) must be of type resource, null
+ * given in pfblockerng_extra.inc:4182` -- pfb_live_table_snapshot()'s
+ * `finally { fclose($handle); ... }`.
+ *
+ * Root cause: pfb_live_table_snapshot() is a \Generator. Its only production
+ * consumer, pfb_live_punch_plan(), drains it with a plain foreach and no
+ * break/return -- but a foreach that exits early via an UNCAUGHT exception
+ * thrown from the loop BODY (e.g. a malformed table entry reaching
+ * ip_in_subnet()/pfb_v4_carve_single()) abandons the generator mid-try
+ * without a normal return. Per bugs.php.net #76006 ("PHP engine execute the
+ * code after shutdown_function by finally block" -- WONTFIX/expected), a
+ * generator that never finishes has its pending `finally` run only at the
+ * LAST step of request shutdown, strictly AFTER every registered shutdown
+ * function and after PHP's own resource-list teardown for the request. On
+ * the PHP builds pfSense CE 2.8 ships (8.1.x/8.2.x -- both predate the
+ * upstream fix for php-src GH-19844, "Don't bail when closing resources on
+ * shutdown", landed only in 8.3.28/8.4.15/8.5.0), that ordering means the
+ * scratch-file resource is already gone by the time this finally finally
+ * runs, and the unguarded `fclose($handle)` throws.
+ *
+ * The dev sandbox only has PHP >= 8.3.28 (already carrying the GH-19844
+ * fix), so the exact shutdown-ordering race cannot be coaxed out of gc
+ * timing alone here (confirmed: unset()+gc_collect_cycles() on an abandoned
+ * generator alone stays green on this interpreter). This test instead
+ * forces the REAL precondition PHP's own request shutdown creates on the
+ * affected builds -- the SAME underlying stream resource the still-suspended
+ * generator holds gets closed by something else first -- via the standard,
+ * version-independent get_resources()/stream_get_meta_data() introspection,
+ * against the real, unmodified production function. That reliably reproduces
+ * the same fclose() TypeError class from the same finally block (message
+ * text differs by PHP-internal detail -- "must be an open stream resource"
+ * here vs "null given" in the field report -- both are fclose() rejecting an
+ * already-invalid $handle; both are fixed by the same is_resource() guard).
+ */
+#[CoversFunction('pfb_live_table_snapshot')]
+final class LiveTableSnapshotAbandonedFcloseTest extends TestCase
+{
+	private string $tmpDir;
+	private string $aliasdir;
+	private string $dbdir;
+
+	protected function setUp(): void
+	{
+		$this->tmpDir   = sys_get_temp_dir() . '/pfb_live_table_snapshot_fclose_' . bin2hex(random_bytes(6));
+		$this->aliasdir = "{$this->tmpDir}/alias";
+		$this->dbdir    = "{$this->tmpDir}/db";
+		mkdir($this->aliasdir, 0777, TRUE);
+		mkdir($this->dbdir, 0777, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->tmpDir);
+	}
+
+	private function writeShim(string $body): string
+	{
+		$shim = "{$this->tmpDir}/pfctl-shim-" . bin2hex(random_bytes(4)) . '.sh';
+		file_put_contents($shim, "#!/bin/sh\n{$body}\n");
+		chmod($shim, 0755);
+		return $shim;
+	}
+
+	/**
+	 * Abandon the generator after one entry (same shape as
+	 * LiveTableSnapshotTest::testTempFileCleanedUpAfterAbandonedIteration()),
+	 * then close the scratch-file resource it still holds from OUTSIDE --
+	 * emulating PHP's own request-shutdown resource teardown racing ahead of
+	 * the deferred `finally` on an abandoned generator (bugs.php.net #76006).
+	 * The finally's fclose() must tolerate that: no TypeError, and the
+	 * scratch file is still unlinked (never leaked).
+	 */
+	public function testAbandonedGeneratorFinallyToleratesResourceClosedByShutdownFirst(): void
+	{
+		$shim = $this->writeShim("printf '10.0.0.1\\n10.0.0.2\\n10.0.0.3\\n'");
+
+		$gen = pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_ShutdownRace_v4');
+		foreach ($gen as $entry) {
+			break; // take exactly one entry, then abandon -- same as the sibling test
+		}
+
+		$scratch_before = glob("{$this->dbdir}/pfb_punch_*");
+		$this->assertCount(1, $scratch_before, 'setup: exactly one scratch file must be open at this point');
+
+		// realpath() on both sides -- macOS resolves sys_get_temp_dir() through a
+		// /var -> /private/var symlink, so tempnam()'s path and the stream's own
+		// reported 'uri' meta can differ by that symlink even though they name the
+		// same file.
+		$scratch_real = realpath($scratch_before[0]);
+		$closed       = 0;
+		foreach (get_resources('stream') as $res) {
+			$meta = stream_get_meta_data($res);
+			if (isset($meta['uri']) && realpath($meta['uri']) === $scratch_real) {
+				fclose($res);
+				$closed++;
+			}
+		}
+		$this->assertSame(1, $closed, 'setup: expected to find and externally close exactly the scratch-file resource');
+
+		try {
+			unset($gen);
+			gc_collect_cycles();
+		} catch (\TypeError $e) {
+			$this->fail(
+				"abandoned generator's finally must not let fclose() throw when the handle is already invalid: "
+				. $e->getMessage()
+			);
+		}
+
+		$this->assertSame(
+			[],
+			glob("{$this->dbdir}/pfb_punch_*"),
+			'the scratch temp file must still be unlinked even when fclose() is skipped as already-invalid'
+		);
+	}
+}

--- a/tests/php/LiveTableSnapshotTest.php
+++ b/tests/php/LiveTableSnapshotTest.php
@@ -94,6 +94,42 @@ final class LiveTableSnapshotTest extends TestCase
 	}
 
 	/**
+	 * Issue #1852: a table absent from the loaded ruleset (a fresh alias not
+	 * yet referenced by any rule/reload -- exactly the state a user hits
+	 * clicking Alerts "+" right after creating a Suppression/DNSBL alias)
+	 * must NOT throw -- it is "no live members", not a capture failure.
+	 * Stderr text probed for real on a leased pfSense CE 2.8 pool box (PHP
+	 * 8.3.19): `pfctl -t <absent> -T show` exits rc=255 with stderr
+	 * "pfctl: Table does not exist.". This shim reproduces that exact rc +
+	 * stderr pairing.
+	 */
+	public function testAbsentTableYieldsEmptyInsteadOfThrowing(): void
+	{
+		$shim = $this->writeShim("printf 'pfctl: Table does not exist.\\n' 1>&2\nexit 255");
+
+		$entries = self::collect(pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_Absent_v4'));
+
+		$this->assertSame([], $entries, 'an absent table must yield an empty membership set, not throw');
+	}
+
+	/**
+	 * Issue #1852: the absent-table carve-out is narrow -- ANY other
+	 * non-zero exit (a genuine pfctl failure, distinguished by stderr NOT
+	 * matching "Table does not exist") still throws loudly, same as before.
+	 */
+	public function testGenuinePfctlFailureStillThrows(): void
+	{
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessageMatches('/pfctl -T show exited rc=1/');
+
+		$shim = $this->writeShim("printf 'pfctl: some other genuine failure\\n' 1>&2\nexit 1");
+
+		foreach (pfb_live_table_snapshot($shim, $this->aliasdir, $this->dbdir, 'pfB_GenuineFail_v4') as $entry) {
+			// the throw fires lazily -- iterating is what triggers the generator body
+		}
+	}
+
+	/**
 	 * Issue #1467: a mirror file present does NOT win -- it is never read at
 	 * all. The mirror holds a stale set A; live pfctl reports a different
 	 * set B, exactly as it would after a first live punch that never


### PR DESCRIPTION
Fixes #1852 — the two defects that failed the v4.0.0.alpha.23 release gate (CE UI legs red on a gated `php_error.log` diagnostic; the tag/draft Release is held and resumable).

1. **`fclose()` on a dead handle.** `pfb_live_table_snapshot()` is a generator; when it is abandoned mid-iteration its `finally` runs at request shutdown, after the stream is gone → `TypeError: fclose(): Argument #1 ($stream) must be of type resource, null given`. Guarded with `is_resource()`; `@unlink($scan_tmp)` stays unconditional.
2. **An unloaded pf table read as a failure.** `pfctl -t <table> -T show` exits 255 when the table is not in the loaded ruleset (fresh install, alias not yet referenced by a rule) — the Alerts "+" action reported `failed` instead of "nothing to punch". stdout/stderr now capture to **separate** temp files (ADR-53: never merged, so a diagnostic line can never be parsed as a table member) and rc≠0 is classified from stderr: absent table → empty generator; anything else still throws, with the stderr appended. No caller changes — the existing `not_blocked` path already renders the page's "Not currently blocked by Table [ … ]" notice.

Classification comes from probes on a real CE 2.8 pool box (not guessed): absent → `rc=255`/`pfctl: Table does not exist.`; existing-but-emptied → `rc=0`/empty; argument rejection → `rc=1`/usage text. End-to-end on the same box: pre-fix `{"status":"failed",…}`, post-fix `{"status":"not_blocked",…}`.

Note for the record: an earlier reading of mine (an *uncaught* fatal from the action) was refuted by that probe — `pfb_live_punch_run()`'s catch does fire; the single fatal was the shutdown-time `fclose` TypeError whose log entry chains the already-handled RuntimeException. Correction is on the issue.

Red→green: 2 new tests (absent-table empty, genuine failure still throws) + the frozen abandonment test, both hashes byte-identical red→green, re-derived by the verifier gate; full suite 4474 exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alerts “+” actions and live table updates now work correctly when a referenced firewall table is not currently loaded.
  * Missing tables are handled without generating errors or disrupting the operation.
  * Genuine firewall command failures continue to report meaningful error details.
  * Improved cleanup prevents errors and temporary-file leaks when live table processing is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->