### PR TITLE
landing: keep dependency packages and duplicate matrix flavors out of the channel tables

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -468,11 +468,13 @@ def _join_matrix(rows: list[dict], matrix: list[dict] | None) -> list[tuple[str,
     A pfSense minor is then listed ONCE per channel and package version, however many
     matrix entries it has: those entries enumerate build flavors (arch, FreeBSD, PHP,
     Python), while the arch-less catalog (issue #1806) serves one file per minor. The
-    first entry of a minor supplies the displayed flavors.
+    first entry of a minor supplies the displayed flavors. The dedup is per published
+    FILE, so a legacy per-ABI layout — which publishes one file per arch and pins to no
+    varver — still lists each of them; only flavor duplicates of one file collapse.
     """
     idx = matrix_index(matrix)
     out: list[tuple[str, dict]] = []
-    seen: set[tuple[str, str, str, str]] = set()  # (edition, pfSense minor, channel, version)
+    seen: set[tuple[str, str, str, str, str]] = set()  # (edition, minor, channel, version, file)
     for r in rows:
         entries = idx.get(r["abi"], [])
         if not entries and _is_wildcard_abi(r["abi"]):
@@ -483,7 +485,7 @@ def _join_matrix(rows: list[dict], matrix: list[dict] | None) -> list[tuple[str,
         if entries:
             for e in entries:
                 ekey = _edition_key(e.get("variant", ""))
-                key = (ekey, e.get("pfsense_version", ""), r["channel"], r["version"])
+                key = (ekey, e.get("pfsense_version", ""), r["channel"], r["version"], r["rel"])
                 if key in seen:
                     continue
                 seen.add(key)

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -62,6 +62,18 @@ def is_package_file(fname: str) -> bool:
     return fname.endswith(".pkg") and fname not in CATALOG_META
 
 
+def is_pfblockerng_package(name: str) -> bool:
+    """True for one of OUR three channel packages, False for anything else.
+
+    Dependency packages we publish alongside them (the CE-only
+    ``py311-charset-normalizer``, issue #1806) share the catalog dirs but are not
+    pfBlockerNG builds. They carry neither channel suffix, so ``channel_of`` would call
+    them stable and the page would advertise the dependency's own version as the stable
+    pfBlockerNG release (issue #1863). They stay browsable; they are never a channel row.
+    """
+    return name in (_PKG_STABLE, _PKG_DEVEL, _PKG_NIGHTLY)
+
+
 def human_size(n: int) -> str:
     f = float(n)
     for unit in ("B", "KiB", "MiB", "GiB"):
@@ -166,6 +178,8 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
             path = os.path.join(dirpath, fname)
             man = read_manifest(path)
             name, ver, abi = man.get("name", ""), man.get("version", ""), man.get("abi", "")
+            if not is_pfblockerng_package(name):
+                continue  # a published dependency (issue #1806) — browsable, never a channel row
             deps = man.get("deps") or {}
             pkgs.append(
                 {
@@ -408,6 +422,28 @@ def _edition_key(variant: str) -> str:
     return variant.strip() or "Other"
 
 
+def _matrix_varver(pfsense_version: str, variant: str) -> str:
+    """The catalog dir name (varver) a matrix entry's packages are published under.
+
+    Mirrors build-repo-portable.py's catalog_name_from_version (major.minor only):
+      "2.7" + "CE"   -> "ce-2.7"
+      "25.03"+ "Plus" -> "plus-25.03"
+    """
+    major_minor = ".".join(pfsense_version.split(".")[:2])
+    return f"{variant.lower()}-{major_minor}"
+
+
+def _row_varver(rel: str) -> str:
+    """The varver dir a published package sits in, read from its site-relative path.
+
+    ``release/plus-26.03/x.pkg`` -> ``plus-26.03`` (arch-less since issue #1806: one varver
+    dir per FreeBSD major). A legacy per-ABI path yields that dir name instead, which
+    matches no matrix varver — callers treat that as "no varver pin".
+    """
+    parts = rel.replace(os.sep, "/").split("/")
+    return parts[-2] if len(parts) >= 2 else ""
+
+
 def _join_matrix(rows: list[dict], matrix: list[dict] | None) -> list[tuple[str, dict]]:
     """Enrich each row with the pfSense version + PHP/Python from the matrix join.
 
@@ -421,20 +457,41 @@ def _join_matrix(rows: list[dict], matrix: list[dict] | None) -> list[tuple[str,
     ABI is always concrete), so a wildcarded row falls back to an OS+major scan
     across every matrix entry (``_abi_matches``), joining EVERY row of that
     major instead of dropping to "Other".
+
+    An ABI match alone over-joins when two pfSense versions share it: the catalog is
+    published per varver, so each varver dir holds its OWN copy of the .pkg, and
+    broadcasting every copy to every matching entry cross-products them (issue #1863 —
+    a 26.03 row linking the plus-26.07 file and vice versa). When the row's path names a
+    varver that some matched entry is published under, that entry wins; a path naming no
+    known varver (a legacy per-ABI dir) keeps the broadcast, so nothing is ever hidden.
+
+    A pfSense minor is then listed ONCE per channel and package version, however many
+    matrix entries it has: those entries enumerate build flavors (arch, FreeBSD, PHP,
+    Python), while the arch-less catalog (issue #1806) serves one file per minor. The
+    first entry of a minor supplies the displayed flavors.
     """
     idx = matrix_index(matrix)
     out: list[tuple[str, dict]] = []
+    seen: set[tuple[str, str, str, str]] = set()  # (edition, pfSense minor, channel, version)
     for r in rows:
         entries = idx.get(r["abi"], [])
         if not entries and _is_wildcard_abi(r["abi"]):
             entries = [e for e in (matrix or []) if _abi_matches(e.get("abi", ""), r["abi"])]
+        vv = _row_varver(r["rel"])
+        pinned = [e for e in entries if _matrix_varver(e.get("pfsense_version", ""), e.get("variant", "")) == vv]
+        entries = pinned or entries
         if entries:
             for e in entries:
+                ekey = _edition_key(e.get("variant", ""))
+                key = (ekey, e.get("pfsense_version", ""), r["channel"], r["version"])
+                if key in seen:
+                    continue
+                seen.add(key)
                 row = dict(r)
                 row["pfsense_version"] = e.get("pfsense_version", "")
                 row["php"] = e.get("php_version") or e.get("php") or r.get("php", "")
                 row["py"] = _dotted_ver(e.get("py_flavor", "")) or r.get("py", "")
-                out.append((_edition_key(e.get("variant", "")), row))
+                out.append((ekey, row))
         else:
             row = dict(r)
             row["pfsense_version"] = ""
@@ -590,17 +647,6 @@ def _older_releases_details(rows: list[dict]) -> str:
     )
 
 
-def _eol_varver(pfsense_version: str, variant: str) -> str:
-    """The catalog dir name (varver) for a route-only matrix entry.
-
-    Mirrors build-repo-portable.py's catalog_name_from_version (major.minor only):
-      "2.7" + "CE"   -> "ce-2.7"
-      "25.03"+ "Plus" -> "plus-25.03"
-    """
-    major_minor = ".".join(pfsense_version.split(".")[:2])
-    return f"{variant.lower()}-{major_minor}"
-
-
 def eol_versions(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str, str, dict]]:
     """The last-served .pkg for each EOL (route-only) pfSense version.
 
@@ -629,10 +675,13 @@ def eol_versions(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str,
             vv = parts[1]
             varver_pkgs.setdefault(vv, []).append(p)
 
-    # For each EOL matrix entry, find the newest pkg per ABI in its varver pool.
-    # One matrix entry = one (pfsense_version, variant, abi) combination.
+    # For each EOL matrix entry, find the newest pkg in its varver pool. A varver is
+    # emitted at most ONCE (issue #1863): its several matrix entries enumerate build
+    # flavors (arch, FreeBSD, PHP, Python), but the frozen catalog serves one file. The
+    # first entry that has a served .pkg supplies the displayed flavors — an entry whose
+    # ABI nothing matches never claims the varver.
     out: list[tuple[str, str, dict]] = []
-    seen: set[tuple[str, str]] = set()  # (varver, abi) already emitted — dedup multi-arch entries
+    seen: set[str] = set()
     for e in eol_entries:
         version = e.get("pfsense_version", "")
         variant = e.get("variant", "")
@@ -640,17 +689,16 @@ def eol_versions(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str,
         php = e.get("php_version") or e.get("php", "")
         py = _dotted_ver(e.get("py_flavor", "")) or e.get("py", "")
         ekey = _edition_key(variant)
-        varver = _eol_varver(version, variant)
-        dedup_key = (varver, abi)
-        if dedup_key in seen:
+        varver = _matrix_varver(version, variant)
+        if varver in seen:
             continue
-        seen.add(dedup_key)
 
         # Matched via _abi_matches (OS+major, issue #1806): the served .pkg may be
         # NO_ARCH/wildcarded even when the matrix still records a concrete ABI.
         pool = [p for p in varver_pkgs.get(varver, []) if _abi_matches(p["abi"], abi)]
         if not pool:
             continue  # no .pkg served for this (varver, abi) — skip silently
+        seen.add(varver)
 
         # Newest served version = highest ver_key.
         best = max(pool, key=lambda p: ver_key(p["version"]))

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -499,6 +499,19 @@ def _join_matrix(rows: list[dict], matrix: list[dict] | None) -> list[tuple[str,
     return out
 
 
+def sort_table_rows(rows: list[dict]) -> None:
+    """Order one table's rows in place: the display rule every packages table follows.
+
+    pfBlockerNG version desc, then pfSense version desc, then channel (issue #1863). Both
+    versions compare number-aware (``ver_key``), never as strings. Editions are already
+    separate tables ordered CE before Plus (``_order_edition_keys``), which is where the
+    edition rank of the rule lives. Written as stable passes, least significant first.
+    """
+    rows.sort(key=lambda p: CH_ORDER.index(p["channel"]))
+    rows.sort(key=lambda p: ver_key(p.get("pfsense_version", "")), reverse=True)
+    rows.sort(key=lambda p: ver_key(p["version"]), reverse=True)
+
+
 def _order_edition_keys(sections: dict[str, list[dict]]) -> list[str]:
     """Edition display order: CE, then Plus, then any other variant alphabetically,
     with "Other" (unmatched ABIs) always last."""
@@ -515,7 +528,8 @@ def build_edition_sections(pkgs: list[dict], matrix: list[dict] | None) -> list[
     Each row is the newest version per (channel, ABI) (build_table), enriched with the
     pfSense version + PHP/Python from the matrix join. A build whose ABI has no matrix
     entry falls into a trailing "Other" section using its manifest-derived php/py, so
-    nothing published is ever hidden. Editions sort CE, then Plus, then the rest.
+    nothing published is ever hidden. Editions sort CE, then Plus, then the rest; rows
+    within each follow the shared table order (``sort_table_rows``).
     """
     sections: dict[str, list[dict]] = {}
     for ekey, row in _join_matrix(build_table(pkgs), matrix):
@@ -523,7 +537,7 @@ def build_edition_sections(pkgs: list[dict], matrix: list[dict] | None) -> list[
     out: list[tuple[str, list[dict]]] = []
     for k in _order_edition_keys(sections):
         rows = sections[k]
-        rows.sort(key=lambda p: (ver_key(p.get("pfsense_version", "")), CH_ORDER.index(p["channel"]), p["abi"]))
+        sort_table_rows(rows)
         out.append((k, rows))
     return out
 
@@ -594,10 +608,16 @@ def older_nightlies(pkgs: list[dict]) -> list[dict]:
 
 def _older_nightlies_by_edition(pkgs: list[dict], matrix: list[dict] | None) -> dict[str, list[dict]]:
     """The retained older nightlies grouped by edition key (matrix-joined by ABI), so each
-    edition's disclosure folds in directly under that edition's table. Empty when none."""
+    edition's disclosure folds in directly under that edition's table. Empty when none.
+
+    Retention keeps several nightly versions, so an edition lists one row per retained
+    version per pfSense version it was built for, in the shared table order (issue #1863).
+    """
     by_edition: dict[str, list[dict]] = {}
     for ekey, row in _join_matrix(older_nightlies(pkgs), matrix):
         by_edition.setdefault(ekey, []).append(row)
+    for rows in by_edition.values():
+        sort_table_rows(rows)
     return by_edition
 
 
@@ -629,10 +649,16 @@ def older_releases(pkgs: list[dict]) -> list[dict]:
 
 def _older_releases_by_edition(pkgs: list[dict], matrix: list[dict] | None) -> dict[str, list[dict]]:
     """The retained older releases grouped by edition key (matrix-joined by ABI), so each
-    edition's disclosure folds in directly under that edition's table. Empty when none."""
+    edition's disclosure folds in directly under that edition's table. Empty when none.
+
+    Rows follow the shared table order (issue #1863): pfBlockerNG version desc, then
+    pfSense version desc, then channel.
+    """
     by_edition: dict[str, list[dict]] = {}
     for ekey, row in _join_matrix(older_releases(pkgs), matrix):
         by_edition.setdefault(ekey, []).append(row)
+    for rows in by_edition.values():
+        sort_table_rows(rows)
     return by_edition
 
 
@@ -708,14 +734,13 @@ def eol_versions(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str,
         row["py"] = py
         out.append((ekey, version, row))
 
-    # Sort: edition order (CE < Plus < Other), then pfSense version newest-first, then ABI.
+    # Sort: edition order (CE < Plus < Other) — each edition is its own table — then the
+    # shared table order within it: pfBlockerNG version desc, then pfSense version desc
+    # (issue #1863). Stable passes, least significant first.
     edition_rank = {k: i for i, k in enumerate(EDITION_ORDER)}
-
-    def _sort_key(t: tuple[str, str, dict]) -> tuple[int, tuple[list[int], int, int], str]:
-        ekey, ver, row = t
-        return (edition_rank.get(ekey, len(EDITION_ORDER)), ver_key(ver), row["abi"])
-
-    out.sort(key=_sort_key)
+    out.sort(key=lambda t: ver_key(t[1]), reverse=True)
+    out.sort(key=lambda t: ver_key(t[2]["version"]), reverse=True)
+    out.sort(key=lambda t: edition_rank.get(t[0], len(EDITION_ORDER)))
     return out
 
 

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -703,38 +703,35 @@ def eol_versions(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str,
             vv = parts[1]
             varver_pkgs.setdefault(vv, []).append(p)
 
-    # For each EOL matrix entry, find the newest pkg in its varver pool. A varver is
-    # emitted at most ONCE (issue #1863): its several matrix entries enumerate build
-    # flavors (arch, FreeBSD, PHP, Python), but the frozen catalog serves one file. The
-    # first entry that has a served .pkg supplies the displayed flavors — an entry whose
-    # ABI nothing matches never claims the varver.
-    out: list[tuple[str, str, dict]] = []
-    seen: set[str] = set()
+    # Group the entries by varver: a varver is emitted at most ONCE (issue #1863), since its
+    # several matrix entries enumerate build flavors (arch, FreeBSD, PHP, Python) of ONE
+    # frozen catalog. They therefore share one pool — taking the newest from a single
+    # entry's slice would report a stale last-served version.
+    by_varver: dict[str, list[dict]] = {}
     for e in eol_entries:
-        version = e.get("pfsense_version", "")
-        variant = e.get("variant", "")
-        abi = e.get("abi", "")
-        php = e.get("php_version") or e.get("php", "")
-        py = _dotted_ver(e.get("py_flavor", "")) or e.get("py", "")
-        ekey = _edition_key(variant)
-        varver = _matrix_varver(version, variant)
-        if varver in seen:
-            continue
+        by_varver.setdefault(_matrix_varver(e.get("pfsense_version", ""), e.get("variant", "")), []).append(e)
 
+    out: list[tuple[str, str, dict]] = []
+    for varver, entries in by_varver.items():
         # Matched via _abi_matches (OS+major, issue #1806): the served .pkg may be
         # NO_ARCH/wildcarded even when the matrix still records a concrete ABI.
-        pool = [p for p in varver_pkgs.get(varver, []) if _abi_matches(p["abi"], abi)]
+        served = varver_pkgs.get(varver, [])
+        pool = [p for p in served if any(_abi_matches(p["abi"], e.get("abi", "")) for e in entries)]
         if not pool:
-            continue  # no .pkg served for this (varver, abi) — skip silently
-        seen.add(varver)
+            continue  # nothing served for this varver — skip silently
+
+        # The displayed flavors come from an entry that actually matches a served file, so
+        # an unserved flavor never speaks for the varver.
+        entry = next(e for e in entries if any(_abi_matches(p["abi"], e.get("abi", "")) for p in pool))
+        version = entry.get("pfsense_version", "")
 
         # Newest served version = highest ver_key.
         best = max(pool, key=lambda p: ver_key(p["version"]))
         row = dict(best)
         row["pfsense_version"] = version
-        row["php"] = php
-        row["py"] = py
-        out.append((ekey, version, row))
+        row["php"] = entry.get("php_version") or entry.get("php", "")
+        row["py"] = _dotted_ver(entry.get("py_flavor", "")) or entry.get("py", "")
+        out.append((_edition_key(entry.get("variant", "")), version, row))
 
     # Sort: edition order (CE < Plus < Other) — each edition is its own table — then the
     # shared table order within it: pfBlockerNG version desc, then pfSense version desc
@@ -965,7 +962,8 @@ def write_site(site: str, base: str, addrepo: str, matrix: list[dict] | None = N
     """Generate the human landing page (root index.html), a browsable autoindex at EVERY
     directory level (so the whole tree is folder-navigable on GitHub Pages, which has no
     autoindex), and a root ``browse.html`` entry point the landing page links to. Returns the
-    package count."""
+    count of pfBlockerNG packages indexed — published dependencies are browsable but not
+    ours to count (issue #1863)."""
     base = base.rstrip("/")
     pkgs = collect_packages(site)
 
@@ -1005,7 +1003,10 @@ def main(argv: list[str] | None = None) -> int:
         with open(args.matrix) as fh:
             matrix = json.load(fh)
     n = write_site(args.site, args.base_url, args.add_repo, matrix)
-    print(f"landing page + browse.html + {len(all_dirs(args.site))} dir index(es) written; {n} package(s) indexed")
+    print(
+        f"landing page + browse.html + {len(all_dirs(args.site))} dir index(es) written; "
+        f"{n} pfBlockerNG package(s) indexed"
+    )
     return 0
 
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -445,6 +445,99 @@ def test_build_edition_sections_one_row_per_pfsense_minor_whatever_the_flavor_se
     assert [r["pfsense_version"] for r in sections["CE"]] == ["2.8"]
 
 
+def test_build_edition_sections_sorted_by_pkg_version_then_pfsense_version_desc() -> None:
+    """Table order: pfBlockerNG version desc, then pfSense version desc (issue #1863).
+
+    Editions are already separate tables (CE before Plus), so within one table the
+    pfBlockerNG version leads and the pfSense version breaks its ties — both newest-first.
+    A pfSense-version-first order interleaves channels instead, burying the newest build.
+
+    Given a devel and a nightly build, each published for CE 2.8 and CE 2.9,
+    When the edition sections are built,
+    Then the nightly rows come first (higher pfBlockerNG version), 2.9 before 2.8 in each.
+    """
+    pkgs = [
+        _pkg("devel", "d", "4.0.0.alpha.22", "FreeBSD:15:*", "release/ce-2.8/d.pkg"),
+        _pkg("devel", "d", "4.0.0.alpha.22", "FreeBSD:15:*", "release/ce-2.9/d.pkg"),
+        _pkg("nightly", "n", "4.0.0.alpha.22.20260729.1", "FreeBSD:15:*", "nightly/ce-2.8/n.pkg"),
+        _pkg("nightly", "n", "4.0.0.alpha.22.20260729.1", "FreeBSD:15:*", "nightly/ce-2.9/n.pkg"),
+    ]
+    matrix = [
+        _mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311"),
+        _mx("FreeBSD:15:amd64", "2.9", "CE", "8.4", "py311"),
+    ]
+
+    sections = dict(gl.build_edition_sections(pkgs, matrix))
+
+    assert [(r["version"], r["pfsense_version"]) for r in sections["CE"]] == [
+        ("4.0.0.alpha.22.20260729.1", "2.9"),
+        ("4.0.0.alpha.22.20260729.1", "2.8"),
+        ("4.0.0.alpha.22", "2.9"),
+        ("4.0.0.alpha.22", "2.8"),
+    ]
+
+
+def test_older_nightlies_one_row_per_nightly_version_per_pfsense_version() -> None:
+    """Retention keeps several nightlies, so the disclosure lists one row per retained
+    nightly version per pfSense version it was built for — same order rule as the main
+    table: pfBlockerNG version desc, then pfSense version desc (issue #1863).
+
+    Given two retained nightly versions, each published for CE 2.8 and CE 2.9,
+    When the older-nightlies rows are grouped per edition,
+    Then there are four rows, the newer nightly's pair first, 2.9 before 2.8 within each.
+    """
+    latest = _pkg("nightly", "n", "4.0.0.alpha.22.20260729.1", "FreeBSD:15:*", "nightly/ce-2.8/n3.pkg")
+    pkgs = [
+        latest,
+        _pkg("nightly", "n", "4.0.0.alpha.22.20260728.1", "FreeBSD:15:*", "nightly/ce-2.8/n2.pkg"),
+        _pkg("nightly", "n", "4.0.0.alpha.22.20260728.1", "FreeBSD:15:*", "nightly/ce-2.9/n2.pkg"),
+        _pkg("nightly", "n", "4.0.0.alpha.22.20260727.1", "FreeBSD:15:*", "nightly/ce-2.8/n1.pkg"),
+        _pkg("nightly", "n", "4.0.0.alpha.22.20260727.1", "FreeBSD:15:*", "nightly/ce-2.9/n1.pkg"),
+    ]
+    matrix = [
+        _mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311"),
+        _mx("FreeBSD:15:amd64", "2.9", "CE", "8.4", "py311"),
+    ]
+
+    rows = gl._older_nightlies_by_edition(pkgs, matrix)["CE"]
+
+    assert [(r["version"], r["pfsense_version"]) for r in rows] == [
+        ("4.0.0.alpha.22.20260728.1", "2.9"),
+        ("4.0.0.alpha.22.20260728.1", "2.8"),
+        ("4.0.0.alpha.22.20260727.1", "2.9"),
+        ("4.0.0.alpha.22.20260727.1", "2.8"),
+    ]
+
+
+def test_older_releases_sorted_by_pkg_version_then_pfsense_version_desc() -> None:
+    """The retained older releases obey the same order rule (issue #1863).
+
+    Given two retained devel versions, each published for CE 2.8 and CE 2.9,
+    When the older-releases rows are grouped per edition,
+    Then the newer version's pair leads, 2.9 before 2.8 within each.
+    """
+    pkgs = [
+        _pkg("devel", "d", "4.0.0.alpha.22", "FreeBSD:15:*", "release/ce-2.8/d3.pkg"),
+        _pkg("devel", "d", "4.0.0.alpha.21", "FreeBSD:15:*", "release/ce-2.8/d2.pkg"),
+        _pkg("devel", "d", "4.0.0.alpha.21", "FreeBSD:15:*", "release/ce-2.9/d2.pkg"),
+        _pkg("devel", "d", "4.0.0.alpha.20", "FreeBSD:15:*", "release/ce-2.8/d1.pkg"),
+        _pkg("devel", "d", "4.0.0.alpha.20", "FreeBSD:15:*", "release/ce-2.9/d1.pkg"),
+    ]
+    matrix = [
+        _mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311"),
+        _mx("FreeBSD:15:amd64", "2.9", "CE", "8.4", "py311"),
+    ]
+
+    rows = gl._older_releases_by_edition(pkgs, matrix)["CE"]
+
+    assert [(r["version"], r["pfsense_version"]) for r in rows] == [
+        ("4.0.0.alpha.21", "2.9"),
+        ("4.0.0.alpha.21", "2.8"),
+        ("4.0.0.alpha.20", "2.9"),
+        ("4.0.0.alpha.20", "2.8"),
+    ]
+
+
 def test_older_nightlies_lists_retained_excludes_latest() -> None:
     """Scenario: surface the retained older nightlies, never the current one.
 
@@ -988,6 +1081,27 @@ def test_eol_versions_wildcard_served_pkg_matches_concrete_matrix_entry() -> Non
     assert ekey == "CE"
     assert ver == "2.7"
     assert row["version"] == "3.1.0_5"
+
+
+def test_eol_versions_sorted_by_pkg_version_then_pfsense_version_desc() -> None:
+    """The EOL table obeys the same order rule as the live tables (issue #1863):
+    pfBlockerNG version desc, then pfSense version desc — within each edition's table.
+
+    Given route-only CE 2.6 and CE 2.7, where 2.7 was frozen at the HIGHER pfBlockerNG
+      version (so pfSense-version order and package-version order disagree),
+    When eol_versions is called,
+    Then the higher pfBlockerNG version leads.
+    """
+    served_27 = _eol_pkg("3.1.9", "FreeBSD:14:*", "ce-2.7")
+    served_26 = _eol_pkg("3.1.0_5", "FreeBSD:13:*", "ce-2.6")
+    matrix = [
+        _mx_eol("FreeBSD:13:amd64", "2.6", "CE", "8.1", "py311"),
+        _mx_eol("FreeBSD:14:amd64", "2.7", "CE", "8.2", "py311"),
+    ]
+
+    result = gl.eol_versions([served_26, served_27], matrix)
+
+    assert [(ver, row["version"]) for _, ver, row in result] == [("2.7", "3.1.9"), ("2.6", "3.1.0_5")]
 
 
 def test_eol_versions_one_row_per_pfsense_minor_whatever_the_flavor_set() -> None:

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -445,6 +445,34 @@ def test_build_edition_sections_one_row_per_pfsense_minor_whatever_the_flavor_se
     assert [r["pfsense_version"] for r in sections["CE"]] == ["2.8"]
 
 
+def test_build_edition_sections_keeps_distinct_files_a_legacy_layout_cannot_pin() -> None:
+    """The one-row-per-minor rule collapses matrix flavors, never distinct published files.
+
+    One pfSense minor serves one file only because the catalog is arch-less (issue #1806).
+    A legacy per-ABI layout publishes a separate file per arch, and no such path names a
+    varver, so those rows keep the matrix broadcast — they must also keep their own rows,
+    or a published package silently disappears from the page (issue #1863).
+
+    Given two per-arch files published for one pfSense minor under legacy per-ABI dirs,
+      and a matrix entry per arch for that minor,
+    When the edition sections are built,
+    Then both files are listed.
+    """
+    p_amd64 = _pkg("devel", "d", "4.0.0.alpha.22", "FreeBSD:16:amd64", "release/FreeBSD:16:amd64/d.pkg")
+    p_arm64 = _pkg("devel", "d", "4.0.0.alpha.22", "FreeBSD:16:aarch64", "release/FreeBSD:16:aarch64/d.pkg")
+    matrix = [
+        _mx("FreeBSD:16:amd64", "26.03", "Plus", "8.5", "py311"),
+        _mx("FreeBSD:16:aarch64", "26.03", "Plus", "8.5", "py311"),
+    ]
+
+    sections = dict(gl.build_edition_sections([p_amd64, p_arm64], matrix))
+
+    assert {r["rel"] for r in sections["Plus"]} == {
+        "release/FreeBSD:16:amd64/d.pkg",
+        "release/FreeBSD:16:aarch64/d.pkg",
+    }
+
+
 def test_build_edition_sections_sorted_by_pkg_version_then_pfsense_version_desc() -> None:
     """Table order: pfBlockerNG version desc, then pfSense version desc (issue #1863).
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -228,6 +228,44 @@ def test_collect_packages_walks_and_excludes_metadata(tmp_path: Path) -> None:
     assert {p["py"] for p in pkgs} == {"3.11"}
 
 
+def test_collect_packages_excludes_dependency_packages(tmp_path: Path) -> None:
+    """A dependency package we publish is never treated as a pfBlockerNG build (issue #1863).
+
+    The CE-only `py311-charset-normalizer` (issue #1806) ships in the same catalog dirs as
+    our own packages. Its name carries neither the `-devel` nor the `-nightly` suffix, so a
+    name-suffix channel classifier drops it into `stable` — which made the live landing page
+    advertise `Latest 3.4.4` (charset-normalizer's own version) as the stable pfBlockerNG
+    release, and list a package living under `nightly/` as a stable row.
+
+    Given a catalog tree holding a devel pfBlockerNG build plus the dependency package under
+      BOTH the release and the nightly varver dirs,
+    When the packages are collected,
+    Then only the pfBlockerNG build is returned and no channel claims the dependency version.
+    """
+    site = tmp_path / "site"
+    layout = {
+        "release/ce-2.8/pfSense-pkg-pfBlockerNG-devel-4.0.0.alpha.22.pkg": (
+            "pfSense-pkg-pfBlockerNG-devel",
+            "4.0.0.alpha.22",
+        ),
+        "release/ce-2.8/py311-charset-normalizer-3.4.4.pkg": ("py311-charset-normalizer", "3.4.4"),
+        "nightly/ce-2.8/py311-charset-normalizer-3.4.4.pkg": ("py311-charset-normalizer", "3.4.4"),
+    }
+    for rel in layout:
+        _touch(site / rel)
+
+    def fake_read(path: str) -> dict[str, Any]:
+        name, ver = layout[os.path.relpath(path, site)]
+        return {"name": name, "version": ver, "abi": "FreeBSD:15:*", "annotations": {}, "deps": {}}
+
+    pkgs = gl.collect_packages(str(site), read_manifest=fake_read)
+
+    assert {p["name"] for p in pkgs} == {"pfSense-pkg-pfBlockerNG-devel"}
+    assert not any(p["version"] == "3.4.4" for p in pkgs)
+    # The card-driving consequence: stable stays unpublished instead of borrowing 3.4.4.
+    assert gl.latest_versions(pkgs) == {"devel": "4.0.0.alpha.22"}
+
+
 # ── build_table: newest version per (channel, ABI) ────────────────────────────
 
 
@@ -350,6 +388,61 @@ def test_build_edition_sections_wildcard_abi_joins_every_row_of_its_major() -> N
     assert (ce["pfsense_version"], ce["php"], ce["py"]) == ("2.9", "8.4", "3.11")
     plus = sections["Plus"][0]
     assert (plus["pfsense_version"], plus["php"], plus["py"]) == ("26.03", "8.5", "3.12")
+
+
+def test_build_edition_sections_pins_a_published_row_to_its_own_varver_dir() -> None:
+    """A published file is listed under the pfSense version of the dir it was published to.
+
+    Two pfSense Plus varvers share one FreeBSD major, so a NO_ARCH package's wildcarded ABI
+    (issue #1806) matches BOTH matrix rows. The catalog is published per varver, so each
+    varver dir holds its own copy — broadcasting every copy to every matching matrix row
+    cross-products them (issue #1863: a 26.03 row linking the plus-26.07 file and vice
+    versa). The varver dir in the row's own path decides which pfSense version it belongs to.
+
+    Given one wildcard-ABI devel build published under BOTH plus-26.03/ and plus-26.07/,
+      and a matrix whose 26.03 and 26.07 Plus rows share FreeBSD major 16,
+    When the edition sections are built,
+    Then each file appears exactly once, under the pfSense version of its own varver dir.
+    """
+    p_2603 = _pkg("devel", "d", "4.0.0.alpha.22", "FreeBSD:16:*", "release/plus-26.03/d.pkg")
+    p_2607 = _pkg("devel", "d", "4.0.0.alpha.22", "FreeBSD:16:*", "release/plus-26.07/d.pkg")
+    matrix = [
+        _mx("FreeBSD:16:amd64", "26.03", "Plus", "8.5", "py311"),
+        _mx("FreeBSD:16:amd64", "26.07", "Plus", "8.5", "py311"),
+    ]
+
+    sections = dict(gl.build_edition_sections([p_2603, p_2607], matrix))
+
+    assert set(sections) == {"Plus"}
+    assert {(r["pfsense_version"], r["rel"]) for r in sections["Plus"]} == {
+        ("26.03", "release/plus-26.03/d.pkg"),
+        ("26.07", "release/plus-26.07/d.pkg"),
+    }
+
+
+def test_build_edition_sections_one_row_per_pfsense_minor_whatever_the_flavor_set() -> None:
+    """One row per pfSense minor release per table, each linking a single .pkg (issue #1863).
+
+    A pfSense minor can appear in the matrix several times — one entry per arch, and in
+    general per FreeBSD/PHP/Python combination. Those are build-matrix facts, not separate
+    downloads: since issue #1806 the catalog is arch-less, so a minor serves exactly ONE
+    file per channel. Joining a published file to every matching entry would list that same
+    minor once per flavor combination.
+
+    Given a devel build published under release/ce-2.8/,
+      and a matrix carrying CE 2.8 twice (amd64 and aarch64),
+    When the edition sections are built,
+    Then CE 2.8 is listed exactly once.
+    """
+    p = _pkg("devel", "d", "4.0.0.alpha.22", "FreeBSD:15:*", "release/ce-2.8/d.pkg")
+    matrix = [
+        _mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311"),
+        _mx("FreeBSD:15:aarch64", "2.8", "CE", "8.3", "py311"),
+    ]
+
+    sections = dict(gl.build_edition_sections([p], matrix))
+
+    assert [r["pfsense_version"] for r in sections["CE"]] == ["2.8"]
 
 
 def test_older_nightlies_lists_retained_excludes_latest() -> None:
@@ -895,6 +988,28 @@ def test_eol_versions_wildcard_served_pkg_matches_concrete_matrix_entry() -> Non
     assert ekey == "CE"
     assert ver == "2.7"
     assert row["version"] == "3.1.0_5"
+
+
+def test_eol_versions_one_row_per_pfsense_minor_whatever_the_flavor_set() -> None:
+    """The EOL table obeys the same one-row-per-minor rule as the live tables (issue #1863).
+
+    A route-only pfSense minor can hold several matrix entries (one per arch, and in general
+    per FreeBSD/PHP/Python combination), but its frozen catalog serves a single .pkg.
+
+    Given a route-only CE 2.7 recorded twice in the matrix (amd64 and aarch64),
+      and one .pkg served under release/ce-2.7/,
+    When eol_versions is called,
+    Then CE 2.7 is listed exactly once.
+    """
+    served = _eol_pkg("3.1.0_5", "FreeBSD:14:*", "ce-2.7")
+    matrix = [
+        _mx_eol("FreeBSD:14:amd64", "2.7", "CE", "8.2", "py311"),
+        _mx_eol("FreeBSD:14:aarch64", "2.7", "CE", "8.2", "py311"),
+    ]
+
+    result = gl.eol_versions([served], matrix)
+
+    assert [(ekey, ver) for ekey, ver, _ in result] == [("CE", "2.7")]
 
 
 def test_eol_versions_ce_and_plus_split_into_separate_tables() -> None:

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -445,6 +445,25 @@ def test_build_edition_sections_one_row_per_pfsense_minor_whatever_the_flavor_se
     assert [r["pfsense_version"] for r in sections["CE"]] == ["2.8"]
 
 
+def test_sort_table_rows_breaks_a_version_tie_by_channel() -> None:
+    """Rows tying on both versions still land in a fixed order — stable, devel, nightly.
+
+    Without the tie-break the order would depend on collection order, so the same catalog
+    could render two different pages.
+    """
+    rows = [
+        _pkg("nightly", "n", "3.2.16", "FreeBSD:15:*", "nightly/ce-2.8/n.pkg"),
+        _pkg("stable", "s", "3.2.16", "FreeBSD:15:*", "release/ce-2.8/s.pkg"),
+        _pkg("devel", "d", "3.2.16", "FreeBSD:15:*", "release/ce-2.8/d.pkg"),
+    ]
+    for r in rows:
+        r["pfsense_version"] = "2.8"
+
+    gl.sort_table_rows(rows)
+
+    assert [r["channel"] for r in rows] == ["stable", "devel", "nightly"]
+
+
 def test_build_edition_sections_keeps_distinct_files_a_legacy_layout_cannot_pin() -> None:
     """The one-row-per-minor rule collapses matrix flavors, never distinct published files.
 
@@ -906,6 +925,39 @@ def test_render_autoindex_root_has_no_parent_and_is_colon_safe() -> None:
     assert 'href="./FreeBSD:16:aarch64/"' in deep
 
 
+def test_write_site_keeps_dependency_packages_browsable(tmp_path: Path, monkeypatch: Any) -> None:
+    """A dependency package stays in the directory listing while leaving the page alone.
+
+    Filtering it out of the channel tables (issue #1863) must not make it unreachable: the
+    autoindex is how a user gets at everything we publish, including the CE-only
+    `py311-charset-normalizer` (issue #1806). The returned count is OUR packages.
+    """
+    site = tmp_path / "site"
+    _touch(site / "release" / "ce-2.8" / "pfSense-pkg-pfBlockerNG-devel-4.0.0.alpha.22.pkg")
+    _touch(site / "release" / "ce-2.8" / "py311-charset-normalizer-3.4.4.pkg")
+    manifests = {
+        "pfSense-pkg-pfBlockerNG-devel-4.0.0.alpha.22.pkg": {
+            "name": "pfSense-pkg-pfBlockerNG-devel",
+            "version": "4.0.0.alpha.22",
+            "abi": "FreeBSD:15:*",
+        },
+        "py311-charset-normalizer-3.4.4.pkg": {
+            "name": "py311-charset-normalizer",
+            "version": "3.4.4",
+            "abi": "FreeBSD:15:*",
+        },
+    }
+    monkeypatch.setattr(gl, "read_compact_manifest", lambda p: manifests[os.path.basename(p)])
+    monkeypatch.setattr(gl, "_conf_via_addrepo", lambda addrepo, base, ch: f"{ch}-conf")
+
+    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_ADD_REPO_REAL))
+
+    assert n == 1  # the count is pfBlockerNG packages, not everything published
+    listing = (site / "release" / "ce-2.8" / "index.html").read_text()
+    assert "py311-charset-normalizer-3.4.4.pkg" in listing  # still reachable by browsing
+    assert "3.4.4" not in (site / "index.html").read_text()  # but never on the landing page
+
+
 def test_write_site_emits_browse_and_autoindex_at_every_level(tmp_path: Path, monkeypatch: Any) -> None:
     """write_site emits the landing page, browse.html, and an autoindex index.html at EVERY
     directory level (intermediate dirs too) so the whole tree is folder-navigable."""
@@ -1109,6 +1161,55 @@ def test_eol_versions_wildcard_served_pkg_matches_concrete_matrix_entry() -> Non
     assert ekey == "CE"
     assert ver == "2.7"
     assert row["version"] == "3.1.0_5"
+
+
+def test_eol_versions_newest_is_taken_across_every_entry_of_the_varver() -> None:
+    """The last-served version is the newest in the varver's WHOLE pool (issue #1863).
+
+    One row per EOL pfSense minor means its several matrix entries (arch/FreeBSD/PHP/Python
+    flavors) share one pool: taking the newest from only the first matching entry's slice
+    reports a stale "last served" version and hides the file that really is the last one.
+
+    Given route-only CE 2.7 recorded per arch, and a frozen catalog whose amd64 file is
+      3.1.9 while its aarch64 file is the newer 3.2.0,
+    When eol_versions is called,
+    Then the single CE 2.7 row reports 3.2.0.
+    """
+    served_amd64 = _eol_pkg("3.1.9", "FreeBSD:14:amd64", "ce-2.7")
+    served_arm64 = _eol_pkg("3.2.0", "FreeBSD:14:aarch64", "ce-2.7")
+    matrix = [
+        _mx_eol("FreeBSD:14:amd64", "2.7", "CE", "8.2", "py311"),
+        _mx_eol("FreeBSD:14:aarch64", "2.7", "CE", "8.2", "py311"),
+    ]
+
+    result = gl.eol_versions([served_amd64, served_arm64], matrix)
+
+    assert [(ver, row["version"]) for _, ver, row in result] == [("2.7", "3.2.0")]
+
+
+def test_eol_versions_flavor_entry_without_a_served_pkg_does_not_claim_the_varver() -> None:
+    """A matrix entry whose ABI nothing serves must not consume its varver's single row.
+
+    The varver is emitted once, so the entry that supplies the displayed flavors has to be
+    one that actually matches a served file — otherwise an unserved flavor row silently
+    swallows the minor and the frozen package disappears from the EOL table (issue #1863).
+
+    Given route-only CE 2.7 recorded for two FreeBSD majors, only the second of which has
+      a served file,
+    When eol_versions is called,
+    Then CE 2.7 is still listed, carrying the served file and that entry's PHP/Python.
+    """
+    served = _eol_pkg("3.1.9", "FreeBSD:14:amd64", "ce-2.7")
+    matrix = [
+        _mx_eol("FreeBSD:13:amd64", "2.7", "CE", "8.1", "py310"),
+        _mx_eol("FreeBSD:14:amd64", "2.7", "CE", "8.2", "py311"),
+    ]
+
+    result = gl.eol_versions([served], matrix)
+
+    assert len(result) == 1
+    _, ver, row = result[0]
+    assert (ver, row["version"], row["php"], row["py"]) == ("2.7", "3.1.9", "8.2", "3.11")
 
 
 def test_eol_versions_sorted_by_pkg_version_then_pfsense_version_desc() -> None:


### PR DESCRIPTION
## What

The pkg landing page presented the CE-only dependency package as the Stable pfBlockerNG release (`Latest 3.4.4`) and cross-producted the Plus rows across varvers. Both defects were row derivation in `scripts/gen_landing.py`.

Fixes #1863

## Why it happened

`channel_of()` reads the channel from the package-name suffix, so `py311-charset-normalizer` (published for CE per #1806) fell through to `stable`. With no stable pfBlockerNG package on the repo, that dependency alone defined the Stable card and produced two `stable` table rows — one of them for a file living under `nightly/`.

Separately, a NO_ARCH package's manifest ABI is CPU-wildcarded (`FreeBSD:16:*`, #1806), so `_join_matrix()` fell back to an OS+major scan and joined every matrix entry of that major. The two pfSense Plus varvers share `FreeBSD:16:*`, so the two published files were emitted under both varvers: a `26.03` row linking `release/plus-26.07/…` and vice versa.

## Changes

- `collect_packages()` keeps only the three pfBlockerNG channel packages (`is_pfblockerng_package()`); dependencies stay reachable through `browse.html` but never reach a channel card or version table. With the stable bucket genuinely empty, the Stable card falls back to its existing "not yet published" state.
- `_join_matrix()` pins a row to the varver directory it was published to, then emits each pfSense minor once per channel and package version — matrix entries enumerate build flavors (arch, FreeBSD, PHP, Python), while the arch-less catalog serves one file per minor. A path naming no known varver (a legacy per-ABI dir) keeps the previous broadcast, so nothing published is hidden.
- `eol_versions()` applies the same one-row-per-minor rule to the frozen route-only catalogs, and no longer lets a flavor entry with no served `.pkg` claim its varver.

## Tests

Four tests added, each authored and executed RED before the fix:

- `test_collect_packages_excludes_dependency_packages` — the dependency package under both `release/ce-2.8/` and `nightly/ce-2.8/` is collected as nothing, and `latest_versions` reports no stable channel.
- `test_build_edition_sections_pins_a_published_row_to_its_own_varver_dir` — the plus-26.03 and plus-26.07 copies each appear once, under their own pfSense version.
- `test_build_edition_sections_one_row_per_pfsense_minor_whatever_the_flavor_set` — CE 2.8 recorded twice in the matrix yields one row.
- `test_eol_versions_one_row_per_pfsense_minor_whatever_the_flavor_set` — same rule for the EOL table.

```
$ python3 -m pytest tests/test_gen_landing.py
43 passed in 0.29s

$ bash scripts/agent/run-gates.sh
GATE PASS: python3 -m pytest
GATE PASS: ruff check .
GATE PASS: ruff format --check .
GATE PASS: mypy tests/
GATES: PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected landing-page version listings so dependency packages aren’t presented as pfBlockerNG releases.
  * Improved pfSense version matching to prevent releases from appearing under the wrong version or being duplicated.
  * Ensured end-of-life listings show one entry per pfSense minor version.
* **Tests**
  * Added coverage for dependency filtering, version-directory matching, duplicate prevention, and end-of-life listing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->