### PR TITLE
shell: retire the ':' builtin idioms and guard against their return

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,6 +7,6 @@ max_depth = 2
 
 [mcp_servers.token-savior-recall]
 command = "sh"
-args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 1349bdcaebf93cbaf90c174f212512652668c4c4bfb7ddd813438faa774d6069 && exec sh "$root/scripts/mcp-token-savior.sh"''']
+args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 5fe61f9ad422901154e1acec9162b732598964691e37a83d979091ff2ed3920b && exec sh "$root/scripts/mcp-token-savior.sh"''']
 env = { TOKEN_SAVIOR_CLIENT = "codex" }
 startup_timeout_sec = 120

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -133,7 +133,7 @@ main() {
 		# least settled -- must not kill the whole wait. Still capped by the
 		# wall-clock deadline via gh_bounded; a wait that still cannot pin a SHA
 		# after that tolerance is exhausted must fail loudly, never poll blind.
-		while :; do
+		while true; do
 			if sha=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid) && [ -n "$sha" ]; then
 				break
 			fi
@@ -183,7 +183,7 @@ main() {
 				# an otherwise-completed wait. An empty read is a hard failure, same
 				# as arm-time -- it is never proof the head moved, only that this
 				# read didn't land, so it is GH-ERROR, not STALE.
-				while :; do
+				while true; do
 					if live=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid) && [ -n "$live" ]; then
 						break
 					fi

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -28,7 +28,7 @@ venv="${TS_VENV:-${XDG_CACHE_HOME:-$HOME/.cache}/token-savior/venv}"
 # Trim trailing slashes so the lock and dirname derivations below treat $venv
 # as the final path component (a trailing slash once nested the lock inside
 # the not-yet-created venv and broke every fresh install).
-while :; do case "$venv" in */) venv="${venv%/}" ;; *) break ;; esac; done
+while true; do case "$venv" in */) venv="${venv%/}" ;; *) break ;; esac; done
 # The rebuild path below rm -rf's $venv — string checks never resolve '..'
 # (only the kernel does, at rm time), so refuse '..' segments and '//' along
 # with anything non-absolute ('.', '', '/', relative paths).

--- a/scripts/publish-smoke-image.sh
+++ b/scripts/publish-smoke-image.sh
@@ -43,7 +43,7 @@ ask() {
 
 # 1. Image type (drives all the derived fields downstream).
 TYPE=""
-while :; do
+while true; do
     ask TYPE "Image type (ce | plus | civm)"
     case "$TYPE" in
         ce|plus|civm) break ;;

--- a/tests/php/TickFeedPassDeferralTest.php
+++ b/tests/php/TickFeedPassDeferralTest.php
@@ -198,7 +198,7 @@ final class TickFeedPassDeferralTest extends TestCase
 active="${0}.active.$$"
 done="${0}.done.$$"
 tmp="${done}.tmp"
-: > "$active"
+true > "$active"
 trap 'rm -f "$active" "$tmp"' EXIT HUP INT TERM
 printf '%s\0' "$@" > "$tmp"
 mv "$tmp" "$done"

--- a/tests/shell/boot_vm_spec.sh
+++ b/tests/shell/boot_vm_spec.sh
@@ -16,7 +16,7 @@ Describe 'boot_vm.sh slirp netdev argv'
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/bootvmspec.XXXXXX")"
     ARGV_FILE="${WORK}/argv"
     IMG_ARGV_FILE="${WORK}/img-argv"
-    BASE="${WORK}/base.qcow2"; : > "$BASE"
+    BASE="${WORK}/base.qcow2"; true > "$BASE"
     OVERLAY="${WORK}/ovl.qcow2"
     BIN="${WORK}/bin"; mkdir -p "$BIN"
 
@@ -31,7 +31,7 @@ QEOF
 #!/bin/sh
 printf '%s\n' "$@" > "$IMG_ARGV_FILE"
 while [ "$#" -gt 1 ]; do shift; done
-: > "$1"
+true > "$1"
 QIEOF
     chmod +x "${BIN}/qemu-img"
 
@@ -48,8 +48,8 @@ QIEOF
   Describe 'role pfsense'
     It 'resolves absolute, basename, and nested-relative base images independently of CDPATH'
       mkdir -p "${WORK}/base-dir/nested" "${WORK}/decoy/nested"
-      : > "${WORK}/base-dir/base.qcow2"
-      : > "${WORK}/base-dir/nested/base.qcow2"
+      true > "${WORK}/base-dir/base.qcow2"
+      true > "${WORK}/base-dir/nested/base.qcow2"
       When run sh -c '
         unset CDPATH
         IMG_ARGV_FILE="$5/absolute" sh "$1" "$2" "$5/absolute-overlay"

--- a/tests/shell/image_lib_push_spec.sh
+++ b/tests/shell/image_lib_push_spec.sh
@@ -20,7 +20,7 @@ Describe 'image-lib.sh image_oci_push'
 printf '%s\n' "$@" > "$ARGV_FILE"
 OEOF
     chmod +x "${BIN}/oras"
-    : > "${WORK}/img.qcow2"
+    true > "${WORK}/img.qcow2"
     export WORK ARGV_FILE BIN
   }
   teardown() { rm -rf "$WORK"; }

--- a/tests/shell/install_pkg_spec.sh
+++ b/tests/shell/install_pkg_spec.sh
@@ -24,15 +24,15 @@ Describe 'install-pkg.sh'
     mkdir -p "$FAKE_BIN"
     SSH_LOG="${WORK}/ssh.log"
     SCP_LOG="${WORK}/scp.log"
-    : > "$SSH_LOG"
-    : > "$SCP_LOG"
+    true > "$SSH_LOG"
+    true > "$SCP_LOG"
 
     PKGFILE="${WORK}/pfBlockerNG-devel.pkg"
     DEP1="${WORK}/py311-charset-normalizer-1.pkg"
     DEP2="${WORK}/py311-idna-2.pkg"
-    : > "$PKGFILE"
-    : > "$DEP1"
-    : > "$DEP2"
+    true > "$PKGFILE"
+    true > "$DEP1"
+    true > "$DEP2"
 
     # Fake ssh: records the LAST arg (the wrapped `/bin/sh -c '<remote cmd>'`
     # string install-pkg.sh's ssh_t() builds) to $SSH_LOG, one per line.

--- a/tests/shell/local_smoke_spec.sh
+++ b/tests/shell/local_smoke_spec.sh
@@ -130,7 +130,7 @@ FAKEEOF
   # proves exit=0 when nothing fails, so THIS example genuinely proves the
   # failure path flips the aggregate result rather than always reporting 0.
   run_shards2_one_fails() {
-    : > "${WORK}/fail-1"   # shard index 1 fails; shard 0 must still run
+    true > "${WORK}/fail-1"   # shard index 1 fails; shard 0 must still run
     run_and_diag --ref dummy --shards 2
   }
 

--- a/tests/shell/pfblockerng_aggregate_v6_spec.sh
+++ b/tests/shell/pfblockerng_aggregate_v6_spec.sh
@@ -103,7 +103,7 @@ STUB
     # never invoked. Pre-seed stale content to prove the rebuild actually clears it.
     printf 'stale\n' > "${aggout}"
     printf 'stale\n' > "${consumer}"
-    : > "${memberlist}"
+    true > "${memberlist}"
 
     When call pfb_aggregate agg v6 "${memberlist}" "${aggout}" "${consumer}"
 

--- a/tests/shell/pfblockerng_cat_weld_more_spec.sh
+++ b/tests/shell/pfblockerng_cat_weld_more_spec.sh
@@ -56,8 +56,8 @@ Describe 'processet() etblock/etmatch tempfile accumulation: multi-category conc
     etdir="${work}/ET"; mkdir -p "$etdir"
     tempfile="${work}/t1"
     tempfile2="${work}/t2"
-    : > "$tempfile"
-    : > "$tempfile2"
+    true > "$tempfile"
+    true > "$tempfile2"
     # Two selected categories, the first unterminated -- deterministic single-line
     # weld pre-fix regardless of iteration order (both accumulators are seeded
     # identically so the same fixture drives both the block and match statements).

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -143,7 +143,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     echo 'rawdata' > "${pfbchroot}/${generation}/feed.raw"
     echo 'partial' > "${pfbchroot}/${stage}/feed.raw"
     echo "{\"feeds\":[{\"raw\":\"${generation}/feed.raw\"}]}" > "${pfbchroot}/pfb_py_sources.json"
-    : > "${pfbchroot}/pfb_py_sources.lock"
+    true > "${pfbchroot}/pfb_py_sources.lock"
     echo 'ini' > "${pfbchroot}/pfb_unbound.ini"
     When call dc save
     # An archive was written (codec-agnostic).

--- a/tests/shell/pfblockerng_fail_open_redirect_spec.sh
+++ b/tests/shell/pfblockerng_fail_open_redirect_spec.sh
@@ -97,9 +97,9 @@ SHIM
       tmpdir="${work}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="${work}/iprange"
       write_pathaggregate_shim "${pathaggregate}"
       livelist="${work}/${alias}.txt"
@@ -139,7 +139,7 @@ SHIM
       masterfile="${work}/master"; mastercat="${work}/mastercat"
       printf 'DedupList_v4 PRIOR-1\nDedupList_v4 PRIOR-2\nOtherList_v4 203.0.113.5\n' > "${masterfile}"
       dedup='on'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="${work}/iprange"
       write_pathaggregate_shim "${pathaggregate}"
       livelist="${work}/${alias}.txt"
@@ -190,7 +190,7 @@ SHIM
       awkshim="${work}/bin"
       setup_awk_shim "${awkshim}"
       printf 'RmList_v4 192.0.2.20\nOtherList_v4 203.0.113.9\n' > "${masterfile}"
-      : > "${pfborig}RmList_v4.txt"
+      true > "${pfborig}RmList_v4.txt"
     }
     cleanup() { rm -rf "${work}"; }
     Before 'setup'
@@ -257,11 +257,11 @@ SHIM
       pfbdeny="${work}/deny/"; pfbmatch="${work}/match/"; mkdir -p "${pfbdeny}" "${pfbmatch}"
       tempfile="${work}/r1"; tempfile2="${work}/r2"; dupfile="${work}/r3"
       matchfile="${work}/r4"; tempmatchfile="${work}/r5"
-      : > "${dupfile}"; : > "${matchfile}"; : > "${tempmatchfile}"
+      true > "${dupfile}"; true > "${matchfile}"; true > "${tempmatchfile}"
       max=253; cc='ZZ,'; ccwhite='block'; ccblack='block'; dedup='off'; count=0; countr=0
       # An empty GeoIP answer routes every repeat offender down the block/dupfile
       # path (the unknown-country branch), reaching the ccblack='block' dedup awk.
-      pathgeoip="${work}/mmdblookup"; pathgeoipdat="${work}/geo.mmdb"; : > "${pathgeoipdat}"
+      pathgeoip="${work}/mmdblookup"; pathgeoipdat="${work}/geo.mmdb"; true > "${pathgeoipdat}"
       make_geoip_stub "${pathgeoip}" ''
       { i=1; while [ "${i}" -le 254 ]; do echo "10.0.0.${i}"; i=$((i + 1)); done; echo 'PRIOR-MARKER'; } > "${pfbdeny}${alias}.txt"
       awkshim="${work}/bin"

--- a/tests/shell/pfblockerng_ip_dedup_oracle_spec.sh
+++ b/tests/shell/pfblockerng_ip_dedup_oracle_spec.sh
@@ -30,8 +30,8 @@ Describe "remove() masterfile row removal (suffix-sibling intact) + file cleanup
 		alias='Ads_v4'
 		cc='Ads_v4,'
 		printf 'Ads_v4 10.0.0.0/24\nBadAds_v4 20.0.0.0/24\n' > "$masterfile"
-		: > "${pfborig}Ads_v4.orig"; : > "${pfbdeny}Ads_v4.txt"; : > "${pfbmatch}Ads_v4.txt"
-		: > "${pfbdeny}BadAds_v4.txt"
+		true > "${pfborig}Ads_v4.orig"; true > "${pfbdeny}Ads_v4.txt"; true > "${pfbmatch}Ads_v4.txt"
+		true > "${pfbdeny}BadAds_v4.txt"
 
 		When call remove
 		The status should be success
@@ -49,7 +49,7 @@ Describe "remove() masterfile row removal (suffix-sibling intact) + file cleanup
 		alias='Solo_v4'
 		cc='Solo_v4,'
 		printf 'Solo_v4 30.0.0.0/24\n' > "$masterfile"
-		: > "${pfbdeny}Solo_v4.txt"
+		true > "${pfbdeny}Solo_v4.txt"
 
 		When call remove
 		The status should be success
@@ -67,7 +67,7 @@ Describe 'reputation_pmax() collapse (no GeoIP, block-only)'
 		mkdir -p "$pfbdeny"
 		tmpdir="${work}"
 		tempfile="${work}/t1"; tempfile2="${work}/t2"
-		dedupfile="${work}/d4"; addfile="${work}/d5"; : > "$dedupfile"; : > "$addfile"
+		dedupfile="${work}/d4"; addfile="${work}/d5"; true > "$dedupfile"; true > "$addfile"
 		masterfile="${work}/master"; mastercat="${work}/mastercat"
 		ip_placeholder='240.0.0.0'
 		ip_placeholder3="$(echo "${ip_placeholder}" | cut -d '.' -f 1-3)"

--- a/tests/shell/pfblockerng_recompute_dispatch_spec.sh
+++ b/tests/shell/pfblockerng_recompute_dispatch_spec.sh
@@ -10,8 +10,8 @@
 Describe 'pfblockerng.sh recompute dispatch (issue #1084 review: rc propagation)'
 	setup() {
 		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/recdispatch.XXXXXX")"
-		: > "${work}/memberlist"
-		: > "${work}/countsfile"
+		true > "${work}/memberlist"
+		true > "${work}/countsfile"
 	}
 	cleanup() { rm -rf "$work"; }
 	Before 'setup'

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -180,7 +180,7 @@ done
 "${realawk}" "\$@"
 rc=\$?
 if [ "\${window}" -eq 1 ]; then
-	: > "$1/window-hit"
+	true > "$1/window-hit"
 	[ "\${rc}" -eq 0 ] && exit 74
 fi
 exit "\${rc}"
@@ -275,7 +275,7 @@ Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 	It 'gives an IP back to the next-priority owner once the higher-priority feed is removed from the memberlist'
 		# Pre-existing state as the prior pass (High_v4 owning the IP) left it.
 		printf 'High_v4 192.0.2.77\n' > "$masterfile"
-		: > "${pfbdeny}Low_v4.txt"
+		true > "${pfbdeny}Low_v4.txt"
 		printf '192.0.2.77\n' > "${snap}/Low_v4.orig"
 		# High_v4 removed from the memberlist entirely (a genuine feed removal).
 		printf '%s\n' "${snap}/Low_v4.orig" > "$memberlist"
@@ -312,7 +312,7 @@ Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 	End
 
 	It 'a single-feed class is a plain copy (no grepcidr call needed), dedups an internal repeat, and still gets counted'
-		: > "${work}/grepcidr.never-called"
+		true > "${work}/grepcidr.never-called"
 		printf '#!/bin/sh\nrm -f "%s/grepcidr.never-called"\n' "$work" > "$pathgrepcidr"
 		chmod +x "$pathgrepcidr"
 		# issue #1084 review: an internal repeat (203.0.113.30 twice) discriminates the
@@ -329,7 +329,7 @@ Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 	End
 
 	It 'an alias whose snapshot is empty ends up with an empty (present, not missing) deny file'
-		: > "${snap}/Empty_v4.orig"
+		true > "${snap}/Empty_v4.orig"
 		printf '%s\n' "${snap}/Empty_v4.orig" > "$memberlist"
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
 		The status should be success
@@ -940,7 +940,7 @@ Describe 'pfb_recompute() hostile inputs'
 		# TRUNCATES an existing file (no directory-write needed), so emit
 		# succeeds while the later mv (a rename -- directory write required)
 		# still fails once pfbdeny itself goes read-only.
-		: > "${pfbdeny}Alpha_v4.txt.new"
+		true > "${pfbdeny}Alpha_v4.txt.new"
 		chmod 555 "$pfbdeny"
 
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
@@ -988,7 +988,7 @@ Describe 'pfb_recompute() mastercat consistency + empty-pass edges'
 	It 'swaps a consistent empty mastercat when a dedup=on pass emits zero rows'
 		printf 'Stale_v4 198.51.100.9\n' > "$masterfile"
 		printf '198.51.100.9\n' > "$mastercat"
-		: > "${snap}/Empty_v4.orig"
+		true > "${snap}/Empty_v4.orig"
 		printf '%s\n' "${snap}/Empty_v4.orig" > "$memberlist"
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
 		The status should be success
@@ -997,7 +997,7 @@ Describe 'pfb_recompute() mastercat consistency + empty-pass edges'
 	End
 
 	It 'completes an all-empty memberlist under repmode=dmax exactly like repmode=off'
-		: > "${snap}/Empty_v4.orig"
+		true > "${snap}/Empty_v4.orig"
 		printf '%s\n' "${snap}/Empty_v4.orig" > "$memberlist"
 		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on dmax 2 US off block
 		The status should be success
@@ -1271,7 +1271,7 @@ Describe 'pfb_recompute() renders a per-feed Original/Final stats table on stdou
 	End
 
 	It 'a zero-final-count feed still renders its row with Final 0 (Original also 0, from its .aggcount)'
-		: > "${snap}/ZeroFeed_v4.orig"
+		true > "${snap}/ZeroFeed_v4.orig"
 		printf '0\n' > "${pfborig}ZeroFeed_v4.aggcount"
 		printf '%s\n' "${snap}/ZeroFeed_v4.orig" > "$memberlist"
 		row="$(printf '%-36s %-10s %-10s' '  ZeroFeed_v4' '0' '0')"

--- a/tests/shell/pfblockerng_remove_guard_spec.sh
+++ b/tests/shell/pfblockerng_remove_guard_spec.sh
@@ -27,12 +27,12 @@ Describe 'pfblockerng.sh remove() entry guard'
     mastercat="${sandbox}/mastercat"
     tempfile="${sandbox}/t1"
     tempfile2="${sandbox}/t2"
-    : > "${masterfile}"
+    true > "${masterfile}"
     # A sentinel INSIDE the sandbox, one level above every ${pfb*} prefix dir
     # (they all live at "${sandbox}/<name>/") -- exactly where a single "../"
     # traversal in a header/alias lands, so an unguarded glob can delete it.
     sentinel="${sandbox}/SENTINEL"
-    : > "${sentinel}"
+    true > "${sentinel}"
   }
 
   cleanup_sandbox() {
@@ -106,7 +106,7 @@ Describe 'pfblockerng.sh remove() entry guard'
     alias='GoodList_v4'
     # shellcheck disable=SC2034
     cc='GoodList_v4,'
-    : > "${pfborig}GoodList_v4.txt"
+    true > "${pfborig}GoodList_v4.txt"
     When call remove_valid_and_report
     # Before-state: the file existed; After: it is gone (the valid path proceeds).
     The output should include 'PRE:exists'

--- a/tests/shell/pfblockerng_reputation_masterfile_grep_spec.sh
+++ b/tests/shell/pfblockerng_reputation_masterfile_grep_spec.sh
@@ -22,7 +22,7 @@ Describe 'reputation_pmax() masterfile block removal (#730)'
     mkdir -p "$pfbdeny"
     tmpdir="${work}"
     tempfile="${work}/t1"; tempfile2="${work}/t2"
-    dedupfile="${work}/d4"; addfile="${work}/d5"; : > "$dedupfile"; : > "$addfile"
+    dedupfile="${work}/d4"; addfile="${work}/d5"; true > "$dedupfile"; true > "$addfile"
     masterfile="${work}/master"; mastercat="${work}/mastercat"
     ip_placeholder='240.0.0.0'
     ip_placeholder3="$(echo "${ip_placeholder}" | cut -d '.' -f 1-3)"

--- a/tests/shell/pfblockerng_suppress_spec.sh
+++ b/tests/shell/pfblockerng_suppress_spec.sh
@@ -139,9 +139,9 @@ SHIM
       pfbsuppression="${work}/suppression.txt"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="${work}/iprange"
       write_pathaggregate_shim "${pathaggregate}"
       member="${work}/${alias}.txt"
@@ -160,7 +160,7 @@ SHIM
 
     It 'leaves the member file byte-identical when the suppression file exists but is empty'
       # Given: the file exists but is zero-length (the "-s" leg of the gate).
-      : > "${pfbsuppression}"
+      true > "${pfbsuppression}"
       When call silently suppress
       The status should be success
       The contents of file "${member}" should equal '203.0.113.5'
@@ -176,9 +176,9 @@ SHIM
       printf '203.0.113.7/32\n' > "${pfbsuppression}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="${work}/iprange"
       write_pathaggregate_shim "${pathaggregate}"
       member="${work}/${alias}.txt"
@@ -203,9 +203,9 @@ SHIM
       pfbsuppression="${work}/suppression.txt"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="$(pfb_real_iprange)"
       member="${work}/${alias}.txt"
       printf '10.9.8.0/24\n' > "${member}"
@@ -270,9 +270,9 @@ SHIM
       printf '10.0.3.4/32\n' > "${pfbsuppression}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="$(pfb_real_iprange)"
       member="${work}/${alias}.txt"
       # A /16 member entry containing the suppressed /32 host -- the OLD
@@ -319,7 +319,7 @@ SHIM
       # that must survive the resync untouched.
       printf 'DedupList_v4 PRIOR-1\nDedupList_v4 PRIOR-2\nOtherList_v4 198.51.100.5\n' > "${masterfile}"
       dedup='on'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="${work}/iprange"
       write_pathaggregate_shim "${pathaggregate}"
       member="${work}/${alias}.txt"
@@ -349,9 +349,9 @@ SHIM
       printf '203.0.113.7/32\n' > "${pfbsuppression}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="${work}/iprange"
       write_pathaggregate_shim "${pathaggregate}"
       alias='StatsList_v4'
@@ -390,9 +390,9 @@ SHIM
       pfbsuppression="${work}/suppression.txt"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="${work}/iprange"
       write_pathaggregate_identity_shim "${pathaggregate}"
       member="${work}/${alias}.txt"
@@ -429,9 +429,9 @@ SHIM
       printf '203.0.113.7/32\n' > "${pfbsuppression}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="${work}/iprange"
       write_pathaggregate_fail_shim "${pathaggregate}"
       member="${work}/${alias}.txt"
@@ -458,9 +458,9 @@ SHIM
       printf '203.0.113.7/32\n' > "${pfbsuppression}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="$(pfb_real_iprange)"
       member="${work}/${alias}.txt"
       printf '203.0.113.7\n' > "${member}"
@@ -487,9 +487,9 @@ SHIM
       printf '203.0.113.99/32\n' > "${pfbsuppression}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       pathaggregate="${work}/iprange"
       # Identity shim (echoes the haystack -- here the pre-filtered member
       # file -- back unchanged): isolates the member-file grep pre-filter
@@ -529,9 +529,9 @@ SHIM
       printf '203.0.113.7/32\n' > "${pfbsuppression}"
       tempfile="${work}/t1"; tempfile2="${work}/t2"; dupfile="${work}/t3"; dedupfile="${work}/t4"
       masterfile="${work}/master"; mastercat="${work}/mastercat"
-      : > "${masterfile}"
+      true > "${masterfile}"
       dedup='off'
-      errorlog="${work}/error.log"; : > "${errorlog}"
+      errorlog="${work}/error.log"; true > "${errorlog}"
       # A path that does not exist at all -- `[ ! -x "${pathaggregate}" ]`
       # (pfblockerng.sh's suppress()) must fire before ANY of the pre-filter
       # or iprange machinery runs. No coverage existed for this guard before

--- a/tests/shell/pfblockerng_truncate_survival_spec.sh
+++ b/tests/shell/pfblockerng_truncate_survival_spec.sh
@@ -22,7 +22,15 @@
 # covers any future shell source elsewhere under src/.
 _trunc_legacy_hits() {
 	git -C "${PFB_ROOT}" grep -nE '(^|[;&|({[:space:]]):[[:space:]]*>' -- \
-		src scripts
+		src scripts tests
+}
+
+# _colon_loop_hits — `while true` / `until true` spell an infinite loop with the
+# special builtin where the plain `true` word reads better and carries none of
+# `:`'s ash/dash baggage (owner rule, issue #1850).
+_colon_loop_hits() {
+	git -C "${PFB_ROOT}" grep -nE '(while|until)[[:space:]]+:' -- \
+		src scripts tests
 }
 
 # process255(): truncate the dedupfile, then signal survival. `silently` swallows
@@ -80,7 +88,7 @@ Describe 'legacy special-builtin truncate sites survive redirection failure (iss
       tempfile="${work}/t1"
       # Empty deny file -> data255 stays empty -> process255 never runs past the
       # truncate site under test into the octet-collapse body.
-      : > "${pfbdeny}${alias}.txt"
+      true > "${pfbdeny}${alias}.txt"
       # Crash-leftover DIRECTORY at the dedupfile truncate target.
       mkdir "${dedupfile}"
     }
@@ -106,7 +114,7 @@ Describe 'legacy special-builtin truncate sites survive redirection failure (iss
       consumer="${work}/agg.lst"
       # No members -> the empty-union branch fires, which is the one guarded by
       # the agg_tmp truncate site under test.
-      : > "${memberlist}"
+      true > "${memberlist}"
       printf 'stale\n' > "${aggout}"
       # Crash-leftover DIRECTORY at agg_tmp ("${aggout}.tmp").
       mkdir "${aggout}.tmp"
@@ -295,7 +303,7 @@ STUB
       mastercat="${work}/mastercat"
       tempfile="${work}/t1"; tempfile2="${work}/t2"
       dedupfile="${work}/dedup"; addfile="${work}/add"
-      : > "${dedupfile}"; : > "${addfile}"
+      true > "${dedupfile}"; true > "${addfile}"
       errorlog="${work}/err.log"
       i=1
       while [ "$i" -le 254 ]; do
@@ -357,14 +365,22 @@ STUB
   End
 End
 
-Describe 'structural retirement guard: no legacy ": >" truncate sites remain in shipped shell sources (issue #1172)'
+Describe 'structural retirement guard: no ":" special-builtin idioms remain (issues #1172, #1850)'
   # ADR-47 P5: scrub inherited GIT_* before the real `git grep` below -- an
   # inherited GIT_DIR (e.g. from the pre-commit hook) can override `-C` and
   # silently target the wrong repo.
   BeforeAll 'scrub_git_env'
 
+  # Both guards scan src + scripts + tests. Replacement in every case is the
+  # regular builtin `true` (`true > file`, `while true`).
   It 'has zero hits for the legacy special-builtin truncate pattern'
     When call _trunc_legacy_hits
+    The status should be failure
+    The output should equal ""
+  End
+
+  It 'has zero hits for a ":" infinite-loop condition'
+    When call _colon_loop_hits
     The status should be failure
     The output should equal ""
   End

--- a/tests/shell/pfblockerng_truncate_survival_spec.sh
+++ b/tests/shell/pfblockerng_truncate_survival_spec.sh
@@ -378,13 +378,13 @@ Describe 'structural retirement guard: no ":" special-builtin idioms remain (iss
 
   # Both guards scan src + scripts + tests. Replacement in every case is the
   # regular builtin `true` (`true > file`, `while true`).
-  It 'has zero hits for the legacy special-builtin truncate pattern'
+  It 'has zero hits for the legacy special-builtin truncate pattern (replace ": >" with "true >")'
     When call _trunc_legacy_hits
     The status should be failure
     The output should equal ""
   End
 
-  It 'has zero hits for a ":" infinite-loop condition'
+  It 'has zero hits for a ":" infinite-loop condition (replace with "while true" / "until true")'
     When call _colon_loop_hits
     The status should be failure
     The output should equal ""

--- a/tests/shell/pfblockerng_truncate_survival_spec.sh
+++ b/tests/shell/pfblockerng_truncate_survival_spec.sh
@@ -21,15 +21,20 @@
 # retirement). Scoped to the whole of src/ (not just pfblockerng/) so the guard also
 # covers any future shell source elsewhere under src/.
 _trunc_legacy_hits() {
-	git -C "${PFB_ROOT}" grep -nE '(^|[;&|({[:space:]]):[[:space:]]*>' -- \
+	git -C "${1:-${PFB_ROOT}}" grep -nE '(^|[;&|({[:space:]]):[[:space:]]*>' -- \
 		src scripts tests
 }
 
-# _colon_loop_hits — `while true` / `until true` spell an infinite loop with the
-# special builtin where the plain `true` word reads better and carries none of
-# `:`'s ash/dash baggage (owner rule, issue #1850).
+# _colon_loop_hits — a `while`/`until` whose condition is the `:` special builtin
+# spells an infinite loop where the plain `true` word reads better and carries
+# none of `:`'s ash/dash baggage (owner rule, issue #1850). Written that way
+# round because the literal idiom here would make this file its own hit.
+#
+# Both helpers take an optional repo root so the guards can be pointed at a
+# planted-violation fixture: a clean-tree assertion alone passes just as well
+# with a broken pattern as with a working one.
 _colon_loop_hits() {
-	git -C "${PFB_ROOT}" grep -nE '(while|until)[[:space:]]+:' -- \
+	git -C "${1:-${PFB_ROOT}}" grep -nE '(while|until)[[:space:]]+:' -- \
 		src scripts tests
 }
 
@@ -383,5 +388,37 @@ Describe 'structural retirement guard: no ":" special-builtin idioms remain (iss
     When call _colon_loop_hits
     The status should be failure
     The output should equal ""
+  End
+
+  # Positive path: a guard that only ever sees a clean tree cannot tell a working
+  # pattern from a broken one. Plant both violations in a throwaway repo of the
+  # same shape and demand the guards report them.
+  plant_violations() {
+    fixture="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/colonfix.XXXXXX")"
+    mkdir -p "${fixture}/src" "${fixture}/scripts" "${fixture}/tests"
+    # The retired idioms are assembled from a %s so this spec file does not
+    # itself become a hit for the guards it exercises.
+    printf '#!/bin/sh\n%s > "$1"\n' ':' > "${fixture}/src/truncate.sh"
+    printf '#!/bin/sh\nwhile %s; do sleep 1; done\n' ':' > "${fixture}/scripts/loop.sh"
+    git -C "${fixture}" init -q
+    git -C "${fixture}" add -A
+  }
+  drop_violations() { rm -rf "$fixture"; }
+
+  Context 'against a repo that does contain the retired idioms'
+    Before 'plant_violations'
+    After 'drop_violations'
+
+    It 'reports the legacy truncate site'
+      When call _trunc_legacy_hits "$fixture"
+      The status should be success
+      The output should include 'src/truncate.sh'
+    End
+
+    It 'reports the ":" loop condition'
+      When call _colon_loop_hits "$fixture"
+      The status should be success
+      The output should include 'scripts/loop.sh'
+    End
   End
 End

--- a/tests/shell/run_smoke_spec.sh
+++ b/tests/shell/run_smoke_spec.sh
@@ -336,7 +336,7 @@ VENVEOF
   make_shard_fixture() {
     mkdir -p "${WORK}/mods"
     for m in a b c d e; do
-      : > "${WORK}/mods/test_${m}.py"
+      true > "${WORK}/mods/test_${m}.py"
     done
   }
 

--- a/tests/shell/shard_modules_spec.sh
+++ b/tests/shell/shard_modules_spec.sh
@@ -43,14 +43,14 @@ Describe 'shard-modules.sh'
   #   - a non-matching file (conftest.py)
   setup() {
     fixture_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/shard-modules-fixture.XXXXXX")"
-    : > "${fixture_dir}/test_a.py"
-    : > "${fixture_dir}/test_b.py"
-    : > "${fixture_dir}/test_c.py"
-    : > "${fixture_dir}/test_d.py"
-    : > "${fixture_dir}/test_e.py"
-    : > "${fixture_dir}/conftest.py"
+    true > "${fixture_dir}/test_a.py"
+    true > "${fixture_dir}/test_b.py"
+    true > "${fixture_dir}/test_c.py"
+    true > "${fixture_dir}/test_d.py"
+    true > "${fixture_dir}/test_e.py"
+    true > "${fixture_dir}/conftest.py"
     mkdir -p "${fixture_dir}/ui"
-    : > "${fixture_dir}/ui/test_zz.py"
+    true > "${fixture_dir}/ui/test_zz.py"
   }
   cleanup() { rm -rf "${fixture_dir}"; }
   BeforeEach 'setup'
@@ -180,7 +180,7 @@ ${fixture_dir}/test_e.py"
     # depends on another's table content (self-encapsulated per the
     # test-coverage mandate).
     write_table() {
-      : > "${fixture_dir}/module-durations.txt"
+      true > "${fixture_dir}/module-durations.txt"
       for line in "$@"; do
         printf '%s\n' "$line" >> "${fixture_dir}/module-durations.txt"
       done
@@ -354,9 +354,9 @@ ${fixture_dir}/test_e.py"
       space_setup() {
         space_dir="${fixture_dir}/sub dir"
         mkdir -p "$space_dir"
-        : > "${space_dir}/test_a.py"
-        : > "${space_dir}/test_b.py"
-        : > "${space_dir}/test_c.py"
+        true > "${space_dir}/test_a.py"
+        true > "${space_dir}/test_b.py"
+        true > "${space_dir}/test_c.py"
         printf '%s\n' 'test_a.py 100.00' 'test_b.py 10.00' 'test_c.py 10.00' \
           > "${space_dir}/module-durations.txt"
       }
@@ -388,7 +388,7 @@ ${space_dir}/test_c.py"
     # in the fixture dir; every It calls it itself right before shard(), so
     # no example depends on another's table content.
     write_table() {
-      : > "${fixture_dir}/module-durations.txt"
+      true > "${fixture_dir}/module-durations.txt"
       for line in "$@"; do
         printf '%s\n' "$line" >> "${fixture_dir}/module-durations.txt"
       done
@@ -606,7 +606,7 @@ ${r}/test_a.py::test_1"
     # OUTER shard() (plain "sh $SCRIPT $fixture_dir ...") is what we want
     # here -- no override needed in this Describe.
     write_oversized_table() {
-      : > "${fixture_dir}/module-durations.txt"
+      true > "${fixture_dir}/module-durations.txt"
       printf '%s\n' 'test_a.py 100.00' 'test_a.py::test_1 40.00' \
         'test_a.py::test_2 30.00' 'test_a.py::test_3 30.00' \
         'test_b.py 5.00' 'test_c.py 5.00' 'test_d.py 5.00' 'test_e.py 5.00' \
@@ -636,7 +636,7 @@ ${fixture_dir}/test_e.py"
     # weights/tie-breaks unless every awk stage pins LC_ALL=C itself -- skip
     # (never fail) if this libc has none installed.
     write_table() {
-      : > "${fixture_dir}/module-durations.txt"
+      true > "${fixture_dir}/module-durations.txt"
       for line in "$@"; do
         printf '%s\n' "$line" >> "${fixture_dir}/module-durations.txt"
       done
@@ -694,7 +694,7 @@ ${fixture_dir}/test_e.py"
     # throughout (single-space nodeids were never broken), proving the
     # guard doesn't regress the legitimate #861 case.
     write_table() {
-      : > "${fixture_dir}/module-durations.txt"
+      true > "${fixture_dir}/module-durations.txt"
       for line in "$@"; do
         printf '%s\n' "$line" >> "${fixture_dir}/module-durations.txt"
       done

--- a/tests/shell/smoke_tier_spec.sh
+++ b/tests/shell/smoke_tier_spec.sh
@@ -156,7 +156,7 @@ Describe 'smoke-tier.sh'
     prov_setup() {
       CACHE="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pwprov.XXXXXX")"
       LOG="${CACHE}/calls"
-      : > "$LOG"
+      true > "$LOG"
       unset _pfb_cp_cache   # the leak probe below must measure THIS call, not a sibling's
     }
     prov_cleanup() { rm -rf "$CACHE"; }

--- a/tests/shell/sparse_clone_ports_spec.sh
+++ b/tests/shell/sparse_clone_ports_spec.sh
@@ -106,7 +106,7 @@ PYEOF
   End
 
   refuse_result() {
-    mkdir -p "$DEST" && : > "${DEST}/not-a-clone"
+    mkdir -p "$DEST" && true > "${DEST}/not-a-clone"
     run_clone 2>&1  # merge the refusal (stderr) into output for a single clean assertion
   }
   It 'refuse-foreign: a non-git DEST is refused, not overwritten'

--- a/tests/smoke/wait_ready.sh
+++ b/tests/smoke/wait_ready.sh
@@ -93,7 +93,7 @@ ATTEMPT=0
 # SSH liveness floor observed (web/pfSense role only); logged once.
 WEB_SSH_SEEN=""
 
-while :; do
+while true; do
     NOW="$(date +%s)"
     ELAPSED=$((NOW - START))
 

--- a/tests/test_version_tracker_reconcile_contract.py
+++ b/tests/test_version_tracker_reconcile_contract.py
@@ -103,7 +103,7 @@ case "$*" in
   "pr list "*)
     if [ -f "$GH_STATE_DIR/pr-created" ]; then printf '77\\n'; fi
     ;;
-  "pr create "*) printf 'pr create %s\\n' "$*" >> "$GH_LOG"; : > "$GH_STATE_DIR/pr-created" ;;
+  "pr create "*) printf 'pr create %s\\n' "$*" >> "$GH_LOG"; true > "$GH_STATE_DIR/pr-created" ;;
   "workflow run "*)
     printf 'workflow run %s\\n' "$*" >> "$GH_LOG"
     _prev=""
@@ -194,8 +194,8 @@ while [ "$#" -gt 0 ]; do [ "$1" = "--out-dir" ] && OUT="$2"; shift; done
 mkdir -p "$OUT"
 printf 'ok\\n' > "$OUT/status"
 printf '26.03.1-RELEASE\\n' > "$OUT/etc-version"
-: > "$OUT/repoc.txt"
-: > "$OUT/upgrade-check.txt"
+true > "$OUT/repoc.txt"
+true > "$OUT/upgrade-check.txt"
 exit 0
 """,
             encoding="utf-8",


### PR DESCRIPTION
Fixes #1850

## What

Owner rule (2026-07-29): stop using the `:` special builtin where a plain word works — `while true` reads better than `while :`, and `true > file` avoids the ash/dash hazard that made #1172 retire `: >` from shipped sources in the first place (a redirection error on a special builtin exits a non-interactive shell outright). Requested as a **mechanical rule, not a habit**.

- **Guard first** (`tests/shell/pfblockerng_truncate_survival_spec.sh`): the existing `: >` structural guard now scans `src scripts tests` (was `src scripts`), and a sibling guard rejects `while :` / `until :` over the same roots. Both name `true` as the replacement.
- **Then the sweep**: 25 files — three `scripts/` entries (the CI check-poller, the MCP launcher, the smoke-image publisher), `tests/smoke/wait_ready.sh`, 19 `tests/shell/*_spec.sh`, plus the embedded shell snippets inside `tests/php/TickFeedPassDeferralTest.php` and `tests/test_version_tracker_reconcile_contract.py`. Mechanical only: `: > FILE` → `true > FILE`, `while :;` → `while true;`.
- Refreshed the Codex `scripts/mcp-token-savior.sh` SHA-256 pin in `.codex/config.toml`, which the sweep necessarily invalidated (caught by `mcp_token_savior_spec.sh`'s integrity check).

## Evidence

- **Red path executed on the real violations**: with the guards extended and before the sweep, both examples failed against the tree's actual `: >` and `while :` sites. After the sweep: `12 examples, 0 failures` in that spec (12 after the review round added the fixture red-path examples).
- Every swept shell file passes `sh -n`; `shellcheck --severity=info` clean on the non-spec scripts.
- Full shellspec suite under dash: **1110 examples, 0 failures, 8 skips** (at the review-round head) (the one failure seen mid-sweep was the stale Codex pin, now refreshed).

`scripts/box-facts.sh` and `tests/shell/box_facts_spec.sh` were already converted with #1848 and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell-script portability and reliability by replacing legacy no-op commands in loops and file initialization.
  * Updated integrity validation for the token service startup script.

* **Tests**
  * Expanded checks to detect remaining legacy shell patterns.
  * Updated test fixtures and polling loops to use the more consistent shell syntax without changing tested behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
