### PR TITLE
image-upgrade: publish the boot environment we verified

### DIFF
--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -20,7 +20,13 @@ name: Upgrade pfSense smoke images
 #   5. Health gate: poll up to 300 s for EITHER the webConfigurator to answer
 #      HTTP on-box (fetch https://127.0.0.1/) OR pfctl -sr to show a live ruleset.
 #      If NEITHER within 300 s → die, fail-closed, nothing is published.
-#   6. Clean shutdown → compress to qcow2 (zstd) → oras push new tag.
+#   6. Boot-environment promotion: wait for pfSense's own boot verification to
+#      make the new BE permanent on disk (fallback: explicit bectl activate);
+#      die if the disk would still boot the pre-upgrade system (issue #1858).
+#   7. Clean shutdown → compress to qcow2 (zstd) → stream back.
+#   8. Artifact verification: boot the exported qcow2 once and refuse to push
+#      it under a tag whose family it does not come up with (issue #1858).
+#   9. oras push new tag.
 #
 # pfBlockerNG SMOKE (non-blocking, after publish):
 #   A separate step with continue-on-error: true boots a throwaway copy-on-write

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -366,6 +366,19 @@ pfb_boot_artifact_version() {
         -e "s#${REMOTE_DIR}/work.qcow2#${_pbav_disk}#" \
         -e "s#${REMOTE_DIR}/qemu.pid#${REMOTE_DIR}/verify.pid#" \
         -e "s#${REMOTE_DIR}/console.log#${REMOTE_DIR}/verify-console.log#")
+    # The upgrade's command line is data, not a contract: if its shape drifts,
+    # the substitutions above silently no-op and this would re-boot the disk we
+    # already observed instead of the exported artifact. Every seam must take.
+    for _pbav_want in "$_pbav_disk" "${REMOTE_DIR}/verify.pid" "${REMOTE_DIR}/verify-console.log"; do
+        case $_pbav_cmd in
+            *"$_pbav_want"*) ;;
+            *) die "verification boot command does not carry '${_pbav_want}' — QEMU_CMD drifted from the shape the substitutions expect; refusing to boot the wrong disk" ;;
+        esac
+    done
+    case $_pbav_cmd in
+        *"${REMOTE_DIR}/work.qcow2"*|*"${REMOTE_DIR}/qemu.pid"*|*"${REMOTE_DIR}/console.log"*)
+            die "verification boot command still references the upgrade VM's files — refusing to boot the wrong disk" ;;
+    esac
     px "$_pbav_cmd" >&2
     QPID=$(px "cat '${REMOTE_DIR}/verify.pid'" | tr -d '\r')
     [ -n "$QPID" ] || die "verification boot did not write a pidfile (see ${REMOTE_DIR}/verify-console.log on the KVM host)"
@@ -396,11 +409,12 @@ pfb_boot_artifact_version() {
 # never gets there, and fail closed if the disk would still boot the old system.
 # PROMOTE_TIMEOUT / PROMOTE_INTERVAL are overridable for the spec.
 pfb_promote_be() {
-    # Parse locally: the guest side stays a plain `bectl list`, so this works
-    # the same on any pfSense and is drivable in the spec.
-    _pbe_running=$(ssh_guest 'bectl list' 2>/dev/null | tr -d '\r' \
+    # Parse locally (-H: headerless, script-stable fields), so this works the
+    # same on any pfSense and is drivable in the spec.
+    _pbe_running=$(ssh_guest 'bectl list -H' 2>/dev/null | tr -d '\r' \
         | awk '$2 ~ /N/ { print $1; exit }')
-    [ -n "$_pbe_running" ] || _pbe_running=default
+    [ -n "$_pbe_running" ] \
+        || die "could not identify the running boot environment from 'bectl list' — refusing to promote a guess"
     log "waiting for pfSense to make boot environment '${_pbe_running}' permanent"
     _pbe_elapsed=0
     while [ "$_pbe_elapsed" -lt "${PROMOTE_TIMEOUT:-300}" ]; do
@@ -422,7 +436,7 @@ pfb_promote_be() {
 
 # pfb_be_is_permanent BE — true when `bectl list` marks BE active on reboot (R).
 pfb_be_is_permanent() {
-    ssh_guest 'bectl list' 2>/dev/null | tr -d '\r' \
+    ssh_guest 'bectl list -H' 2>/dev/null | tr -d '\r' \
         | awk -v be="$1" '$1 == be && $2 ~ /R/ { found = 1 } END { exit !found }'
 }
 # pfb_promote_be END

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -29,9 +29,12 @@
 # after a py_flavor flip; shed stale old-flavor/extra packages; verify pkg info -e
 # + a python import probe, fail-closed) -> health-gate (webConfigurator HTTP
 # or pfctl live ruleset; confirms it boots and works on the NEW version) ->
-# power off cleanly -> compress on Proxmox -> stream back ->
-# push the new tag (local). The source tag is left untouched, so the old image
-# is always kept.
+# wait for pfSense's boot verification to make the new boot environment
+# permanent on disk (fall back to an explicit bectl activate; fail closed —
+# issue #1858) -> power off cleanly -> compress on Proxmox -> stream back ->
+# boot the exported artifact once and refuse to publish it under a tag whose
+# family it does not come up with (issue #1858) -> push the new tag (local).
+# The source tag is left untouched, so the old image is always kept.
 #
 # Usage:
 #   ./scripts/image-upgrade.sh --from <current-version> [--type ce|plus] [options]
@@ -55,7 +58,9 @@
 #
 # Options:
 #   --from VERSION   current published tag to upgrade (required)
-#   --to VERSION     tag to publish as (default: major.minor of the upgraded box)
+#   --to VERSION     tag to publish as, in major.minor form — the pre-push
+#                    artifact verification compares it against the booted
+#                    version's FAMILY (default: major.minor of the upgraded box)
 #   --type T         ce (default) | plus — derives the image name, description and
 #                    artifact-type (image-publish.sh's scheme)
 #   --registry REF   GHCR namespace for the derived --type ref (default:
@@ -86,6 +91,10 @@
 #                    (default: 1200). The poll exits the instant /etc/version
 #                    changes, so this only bounds how long a STUCK upgrade waits
 #                    before the run fails — it is not added to a successful run.
+#   Env knobs (mainly for the spec): VERIFY_BOOT_TIMEOUT — seconds to wait for
+#   the artifact-verification boot's SSH (default: 600); PROMOTE_TIMEOUT /
+#   PROMOTE_INTERVAL — seconds to wait / poll step for pfSense's own boot
+#   verification to promote the new BE (defaults: 300 / 10).
 #   --upgrade-pkgs   before pfSense-upgrade, run `pkg update -f` + `pkg upgrade -y`
 #                    to upgrade baked deps (qemu-guest-agent, etc.) to their latest
 #                    versions; reboots the guest and waits for SSH before proceeding.
@@ -344,7 +353,11 @@ pfb_call_site_upgrade() {
 pfb_verify_artifact() {
     _pva_file=$1; _pva_tag=$2
     log "verifying the exported artifact boots ${_pva_tag} before publishing"
-    _pva_ver=$(pfb_boot_artifact_version "$_pva_file" | tr -d '\r')
+    # Run the boot in THIS shell — never $() or a pipe: die() must abort the
+    # script (the #1844 rule above), and QPID must land in the top-level shell
+    # so cleanup() can reap a wedged verification QEMU.
+    pfb_boot_artifact_version "$_pva_file" > "${LOCAL_DIR}/verify-version"
+    _pva_ver=$(tr -d '\r' < "${LOCAL_DIR}/verify-version")
     [ -n "$_pva_ver" ] \
         || die "could not read a version from the exported artifact — refusing to publish"
     _pva_fam=$(image_version_tag "$_pva_ver")
@@ -382,7 +395,7 @@ pfb_boot_artifact_version() {
     px "$_pbav_cmd" >&2
     QPID=$(px "cat '${REMOTE_DIR}/verify.pid'" | tr -d '\r')
     [ -n "$QPID" ] || die "verification boot did not write a pidfile (see ${REMOTE_DIR}/verify-console.log on the KVM host)"
-    wait_guest_ssh "${VERIFY_BOOT_TIMEOUT:-600}" >&2
+    wait_guest_ssh "${VERIFY_BOOT_TIMEOUT:-600}" verify-console.log >&2
     _pbav_ver=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r')
     ssh_guest '/sbin/shutdown -p now' >/dev/null 2>&1 || true
     _pbav_elapsed=0
@@ -441,13 +454,16 @@ pfb_be_is_permanent() {
 }
 # pfb_promote_be END
 
-# wait_guest_ssh TIMEOUT — poll until root SSH answers or TIMEOUT seconds elapse.
+# wait_guest_ssh TIMEOUT [CONSOLE] — poll until root SSH answers or TIMEOUT
+# seconds elapse; CONSOLE names the boot's console log for the failure message
+# (the verification boot writes verify-console.log, not console.log).
 wait_guest_ssh() {
     _wgs_timeout="$1"
+    _wgs_console="${2:-console.log}"
     _wgs_elapsed=0
     while ! ssh_guest true 2>/dev/null; do
         [ "$_wgs_elapsed" -ge "$_wgs_timeout" ] && \
-            die "VM did not answer SSH within ${_wgs_timeout}s (see $REMOTE_DIR/console.log on the KVM host)"
+            die "VM did not answer SSH within ${_wgs_timeout}s (see $REMOTE_DIR/${_wgs_console} on the KVM host)"
         sleep 5; _wgs_elapsed=$((_wgs_elapsed + 5))
     done
 }

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -332,6 +332,101 @@ pfb_call_site_upgrade() {
 }
 # pfb_call_site END
 
+# pfb_verify_artifact BEGIN
+# pfb_verify_artifact FILE TAG — boot the EXPORTED qcow2 once and refuse to
+# publish it unless the version it actually comes up with belongs to TAG's
+# family. The running box is not proof: a box captured before its boot finished
+# made a 26.03.1 disk pass every in-run check and ship as :26.07 (issue #1858).
+# The artifact is the last word before a push.
+# FILE is the KVM host's out.qcow2 — the exact bytes the pushed local copy was
+# streamed from, so booting it there costs no second transfer. The boot writes
+# to that copy; the local one is already on disk and is what gets pushed.
+pfb_verify_artifact() {
+    _pva_file=$1; _pva_tag=$2
+    log "verifying the exported artifact boots ${_pva_tag} before publishing"
+    _pva_ver=$(pfb_boot_artifact_version "$_pva_file" | tr -d '\r')
+    [ -n "$_pva_ver" ] \
+        || die "could not read a version from the exported artifact — refusing to publish"
+    _pva_fam=$(image_version_tag "$_pva_ver")
+    if [ "$_pva_fam" != "$_pva_tag" ]; then
+        die "exported artifact boots ${_pva_ver} (family ${_pva_fam}), not ${_pva_tag} — refusing to publish a mislabelled image"
+    fi
+    log "artifact verified: boots ${_pva_ver}"
+}
+# pfb_verify_artifact END
+
+# pfb_boot_artifact_version DISK — boot DISK once with the SAME topology the
+# upgrade ran under (same MACs, same SMBIOS uuid, same mgmt hostfwd; the upgrade
+# VM is already gone, so GUEST_PORT is free) and echo the guest's /etc/version.
+# Everything but that version goes to stderr — the caller reads stdout.
+pfb_boot_artifact_version() {
+    _pbav_disk=$1
+    log "booting the exported artifact to read the version it really comes up with" >&2
+    _pbav_cmd=$(printf '%s' "$QEMU_CMD" | sed \
+        -e "s#${REMOTE_DIR}/work.qcow2#${_pbav_disk}#" \
+        -e "s#${REMOTE_DIR}/qemu.pid#${REMOTE_DIR}/verify.pid#" \
+        -e "s#${REMOTE_DIR}/console.log#${REMOTE_DIR}/verify-console.log#")
+    px "$_pbav_cmd" >&2
+    QPID=$(px "cat '${REMOTE_DIR}/verify.pid'" | tr -d '\r')
+    [ -n "$QPID" ] || die "verification boot did not write a pidfile (see ${REMOTE_DIR}/verify-console.log on the KVM host)"
+    wait_guest_ssh "${VERIFY_BOOT_TIMEOUT:-600}" >&2
+    _pbav_ver=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r')
+    ssh_guest '/sbin/shutdown -p now' >/dev/null 2>&1 || true
+    _pbav_elapsed=0
+    while px "kill -0 $QPID 2>/dev/null"; do
+        if [ "$_pbav_elapsed" -ge 120 ]; then
+            px "kill $QPID 2>/dev/null" || true
+            break
+        fi
+        sleep 3; _pbav_elapsed=$((_pbav_elapsed + 3))
+    done
+    QPID=""
+    printf '%s\n' "$_pbav_ver"
+}
+
+# pfb_promote_be BEGIN
+# pfb_promote_be — make the upgrade permanent on DISK before the box is captured.
+# pfSense-upgrade renames the running BE to <be>_<ts>, installs the new release
+# as <be>, activates it FOR THE NEXT BOOT ONLY and reboots; the permanent
+# activation happens at the END of that boot, in pfSense-rc's automatic boot
+# verification. The image job used to shut the box down seconds after its first
+# SSH answer — long before pfSense-rc got there — so the exported disk still
+# booted the archived pre-upgrade BE (issue #1858: :26.07 shipped a 26.03.1
+# disk). Wait for that promotion, fall back to doing it ourselves if the box
+# never gets there, and fail closed if the disk would still boot the old system.
+# PROMOTE_TIMEOUT / PROMOTE_INTERVAL are overridable for the spec.
+pfb_promote_be() {
+    # Parse locally: the guest side stays a plain `bectl list`, so this works
+    # the same on any pfSense and is drivable in the spec.
+    _pbe_running=$(ssh_guest 'bectl list' 2>/dev/null | tr -d '\r' \
+        | awk '$2 ~ /N/ { print $1; exit }')
+    [ -n "$_pbe_running" ] || _pbe_running=default
+    log "waiting for pfSense to make boot environment '${_pbe_running}' permanent"
+    _pbe_elapsed=0
+    while [ "$_pbe_elapsed" -lt "${PROMOTE_TIMEOUT:-300}" ]; do
+        pfb_be_is_permanent "$_pbe_running" && {
+            log "boot environment '${_pbe_running}' is active on reboot"
+            return 0
+        }
+        sleep "${PROMOTE_INTERVAL:-10}"
+        _pbe_elapsed=$((_pbe_elapsed + ${PROMOTE_INTERVAL:-10}))
+    done
+    # No automatic promotion (manual verification configured, or a boot that
+    # never finished): do what pfSense-rc would have done, then re-check.
+    warn "no automatic boot verification after ${PROMOTE_TIMEOUT:-300}s — activating '${_pbe_running}' explicitly"
+    ssh_guest "bectl activate '${_pbe_running}'" >/dev/null 2>&1 || true
+    pfb_be_is_permanent "$_pbe_running" \
+        || die "boot environment '${_pbe_running}' is not active on reboot — refusing to publish a disk that boots the pre-upgrade system"
+    log "boot environment '${_pbe_running}' is active on reboot"
+}
+
+# pfb_be_is_permanent BE — true when `bectl list` marks BE active on reboot (R).
+pfb_be_is_permanent() {
+    ssh_guest 'bectl list' 2>/dev/null | tr -d '\r' \
+        | awk -v be="$1" '$1 == be && $2 ~ /R/ { found = 1 } END { exit !found }'
+}
+# pfb_promote_be END
+
 # wait_guest_ssh TIMEOUT — poll until root SSH answers or TIMEOUT seconds elapse.
 wait_guest_ssh() {
     _wgs_timeout="$1"
@@ -699,6 +794,9 @@ while [ "$_hg_elapsed" -lt "$HEALTH_TIMEOUT" ]; do
 done
 [ "$_hg_healthy" -eq 1 ] || die "upgraded box did not become healthy within ${HEALTH_TIMEOUT}s (webConfigurator and pfctl both failed; see $LOCAL_DIR/upgrade.log)"
 
+# --- wait until the upgrade is permanent on disk (issue #1858) -------------
+pfb_promote_be
+
 # --- optional: gather box facts for the activation PR (issue #1837) --------
 # Best-effort: the publish must not depend on it.
 if [ -n "$FACTS_OUT" ]; then
@@ -750,6 +848,8 @@ OUT="$LOCAL_DIR/${QCOW_NAME}"
 log "streaming upgraded image back -> $(basename "$OUT")"
 px "cat '$REMOTE_DIR/out.qcow2'" > "$OUT"
 [ -s "$OUT" ] || die "streamed upgraded image is empty: $OUT"
+
+pfb_verify_artifact "$REMOTE_DIR/out.qcow2" "$TAG"
 
 log "pushing ${IMAGE}:${TAG} (local oras)"
 # Shared push — identical to image-publish.sh --type ${TYPE} ${TAG} (same image

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -120,6 +120,9 @@ Describe 'image-upgrade.sh boot-environment promotion'
         case "$*" in
           *"bectl activate"*) printf "activated\n" >> "$WORK/activated" ;;
           *"bectl list"*)
+            # garbled — the list never parses (ssh flake, unexpected output):
+            # there is nothing trustworthy to promote or verify against
+            [ "$_mode" = garbled ] && return 0
             _n=$(( $(cat "$POLLS" 2>/dev/null || echo 0) + 1 ))
             printf "%s" "$_n" > "$POLLS"
             _promoted=0
@@ -166,5 +169,82 @@ Describe 'image-upgrade.sh boot-environment promotion'
     The status should be failure
     The stderr should include 'boot environment'
     The output should not include 'REACHED-AFTER-PROMOTE'
+  End
+
+  It 'refuses to guess when the running BE cannot be identified'
+    # an empty/garbled `bectl list` must not degrade into activating a guessed
+    # name: on a lineage whose permanent BE happens to carry that name, the
+    # guess passes the permanence check and publishes a disk nobody verified
+    When call run_promote garbled
+    The status should be failure
+    The stderr should include 'could not identify the running boot environment'
+    The output should not include 'REACHED-AFTER-PROMOTE'
+    The contents of file "$CMDS" should not include 'bectl activate'
+  End
+End
+
+Describe 'image-upgrade.sh verification boot command'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgcmd.XXXXXX")"
+    PXCMDS="${WORK}/px-cmds"
+    export WORK PXCMDS
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # run_bootcmd DRIVE — drive the shipped pfb_boot_artifact_version with a stub
+  # KVM host (px) and guest. DRIVE is the `-drive file=` the upgrade's QEMU_CMD
+  # carries: the real work.qcow2 in the good case, something else to model the
+  # command's shape having drifted from what the sed seams expect.
+  run_bootcmd() {
+    _drive="$1" sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      warn() { printf "WARNING: %s\n" "$*" >&2; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      sleep() { true; }
+      REMOTE_DIR=/r
+      QEMU_CMD="qemu-kvm -drive file=${_drive},if=none,id=drive-scsi0 -display none -serial file:/r/console.log -pidfile /r/qemu.pid -daemonize"
+      eval "$(sed -n "/^pfb_boot_artifact_version()/,/^}/p" "$1")"
+      px() {
+        printf "%s\n" "$1" >> "$PXCMDS"
+        case "$1" in
+          "cat "*) printf "4242\n" ;;
+          "kill -0 "*) return 1 ;;   # the verify VM is already gone
+        esac
+      }
+      wait_guest_ssh() { true; }
+      ssh_guest() {
+        case "$*" in
+          *"/etc/version"*) printf "26.07-BETA\n" ;;
+        esac
+      }
+      pfb_boot_artifact_version /r/out.qcow2
+    ' _ "$SCRIPT"
+  }
+
+  It 'boots the exported artifact on the upgrade topology, swapping only the seams'
+    When call run_bootcmd /r/work.qcow2
+    The status should be success
+    The stderr should include 'booting the exported artifact'
+    The output should include '26.07-BETA'
+    The contents of file "$PXCMDS" should include '/r/out.qcow2'
+    The contents of file "$PXCMDS" should include '/r/verify.pid'
+    The contents of file "$PXCMDS" should include '/r/verify-console.log'
+    The contents of file "$PXCMDS" should not include 'work.qcow2'
+    The contents of file "$PXCMDS" should not include '/r/qemu.pid'
+    The contents of file "$PXCMDS" should not include '/r/console.log'
+  End
+
+  It 'refuses to boot when the substitutions do not take'
+    # QEMU_CMD drifted (no work.qcow2 seam): the old sed silently no-opped and
+    # re-booted the disk we already observed — the exact fail-open of #1858
+    When call run_bootcmd /r/box.qcow2
+    The status should be failure
+    The stderr should include 'refusing to boot'
+    The path "$PXCMDS" should not be exist
   End
 End

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -47,6 +47,7 @@ Describe 'image-upgrade.sh pre-push artifact verification'
       log()  { printf "==> %s\n" "$*"; }
       warn() { printf "WARNING: %s\n" "$*" >&2; }
       die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      LOCAL_DIR="$2"
       # the real tag rule, not a stub — the family comparison IS the guard
       . "$(dirname "$1")/image-lib.sh"
       eval "$(sed -n "/^# pfb_verify_artifact BEGIN/,/^# pfb_verify_artifact END/p" "$1")"
@@ -56,6 +57,54 @@ Describe 'image-upgrade.sh pre-push artifact verification'
       printf "REACHED-AFTER-VERIFY\n"
     ' _ "$SCRIPT" "$WORK"
   }
+
+  # run_verify_reap — drive the REAL boot helper (not the stub) into a wedged
+  # boot and show where the verify VM pid ends up. cleanup() reaps $QPID from
+  # the top-level shell: if the boot runs in a subshell/pipeline, the pid never
+  # reaches it and a wedged verification QEMU is unreapable (and die() cannot
+  # abort from the left side of a pipe — the #1844 rule in the script header).
+  run_verify_reap() {
+    sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      warn() { printf "WARNING: %s\n" "$*" >&2; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      sleep() { true; }
+      REMOTE_DIR=/r
+      LOCAL_DIR="$2"
+      QPID=""
+      at_exit() { printf "QPID-AT-EXIT=%s\n" "$QPID" >&2; }
+      trap at_exit EXIT
+      QEMU_CMD="qemu-kvm -drive file=/r/work.qcow2,if=none -display none -serial file:/r/console.log -pidfile /r/qemu.pid -daemonize"
+      . "$(dirname "$1")/image-lib.sh"
+      eval "$(sed -n "/^# pfb_verify_artifact BEGIN/,/^# pfb_verify_artifact END/p" "$1")"
+      eval "$(sed -n "/^pfb_boot_artifact_version()/,/^}/p" "$1")"
+      px() {
+        case "$1" in
+          "cat "*) printf "4242\n" ;;
+        esac
+      }
+      wait_guest_ssh() { die "SSH never answered"; }
+      ssh_guest() { true; }
+      pfb_verify_artifact "$2/out.qcow2" 26.07
+      printf "REACHED-AFTER-VERIFY\n"
+    ' _ "$SCRIPT" "$WORK"
+  }
+
+  It 'keeps the verify VM pid where cleanup can reap it when the boot wedges'
+    When call run_verify_reap
+    The status should be failure
+    The stderr should include 'SSH never answered'
+    The stderr should include 'QPID-AT-EXIT=4242'
+    The output should not include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'keeps both #1858 guards wired into the main flow'
+    # a guard nobody calls is not a guard: the bare call lines must exist —
+    # deleting either wiring line must turn a test red, not silently drop a layer
+    When call sh -c 'grep -cE "^pfb_promote_be$|^pfb_verify_artifact " "$1"' _ "$SCRIPT"
+    The output should equal 2
+  End
 
   It 'passes when the exported disk boots the family being published'
     When call run_verify 26.07-BETA 26.07
@@ -123,6 +172,19 @@ Describe 'image-upgrade.sh boot-environment promotion'
             # garbled — the list never parses (ssh flake, unexpected output):
             # there is nothing trustworthy to promote or verify against
             [ "$_mode" = garbled ] && return 0
+            if [ "$_mode" = named ]; then
+              if [ -f "$WORK/activated" ]; then
+                printf "pfSense_2603           NR     /          1.76G 2026-07-29 03:30\n"
+                printf "default                -      -          826M  2026-06-12 22:03\n"
+              else
+                # hostile shape: an old BE literally named `default` still owns
+                # the permanent bootfs while the running BE carries another
+                # name — promoting a guessed `default` would pass here
+                printf "pfSense_2603           N      /          1.76G 2026-07-29 03:30\n"
+                printf "default                R      -          826M  2026-06-12 22:03\n"
+              fi
+              return 0
+            fi
             _n=$(( $(cat "$POLLS" 2>/dev/null || echo 0) + 1 ))
             printf "%s" "$_n" > "$POLLS"
             _promoted=0
@@ -169,6 +231,15 @@ Describe 'image-upgrade.sh boot-environment promotion'
     The status should be failure
     The stderr should include 'boot environment'
     The output should not include 'REACHED-AFTER-PROMOTE'
+  End
+
+  It 'promotes the BE it detected, not a well-known name'
+    When call run_promote named
+    The status should be success
+    The stderr should include 'no automatic boot verification'
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The contents of file "$CMDS" should include "bectl activate 'pfSense_2603'"
+    The contents of file "$CMDS" should not include "bectl activate 'default'"
   End
 
   It 'refuses to guess when the running BE cannot be identified'

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -1,0 +1,170 @@
+#shellcheck shell=sh
+# image_upgrade_be_spec.sh — pins the two guards that keep image-upgrade.sh from
+# publishing a disk other than the one it verified (issue #1858).
+#
+# pfSense-upgrade renames the running BE to `default_<ts>`, installs the new
+# release as `default`, activates it FOR THE NEXT BOOT ONLY (`bectl activate
+# -t`) and reboots. Nothing on disk is permanent yet: the promotion happens at
+# the END of the next boot, where /etc/pfSense-rc's bootonce_verify_start()
+# runs `be_activate "$(be_active_name)"` ("Performing automatic boot
+# verification"). That is why a GUI upgrade needs no extra step.
+#
+# The image job never got that far. It shut the box down 4 seconds after its
+# first SSH answer (health gate satisfied by pfctl rules, which are up long
+# before pfSense-rc finishes), so the exported disk still booted the archived
+# pre-upgrade BE — which is how ghcr.io/pfblockerng/pfsense-plus:26.07 came to
+# hold a 26.03.1 system (published run 30419584790, 03:31:44 -> 03:31:48).
+#
+# Two layers, both pinned here:
+#   1. before shutdown, WAIT for that automatic promotion, fall back to an
+#      explicit `bectl activate` if it never comes, and refuse to continue
+#      unless `bectl list` then shows the running BE active-on-reboot;
+#   2. before the push, boot the EXPORTED artifact and refuse to publish it
+#      under a tag whose family it does not actually come up with — the guard
+#      that catches this whole class, not just the boot-environment case.
+#
+# Hermetic: drives the shipped helper with a stub guest — no VM.
+
+Describe 'image-upgrade.sh pre-push artifact verification'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgver.XXXXXX")"
+    export WORK
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # run_verify BOOTED TAG — drive the shipped verifier: it re-boots the EXPORTED
+  # artifact and compares the family it actually boots against the publish tag.
+  # This is the guard that catches the whole class, not just the one-shot-BE
+  # case: whatever makes the disk differ from the box we observed, the artifact
+  # itself is the last word before a push (issue #1858).
+  run_verify() {
+    _booted="$1" _tag="$2" sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      warn() { printf "WARNING: %s\n" "$*" >&2; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      # the real tag rule, not a stub — the family comparison IS the guard
+      . "$(dirname "$1")/image-lib.sh"
+      eval "$(sed -n "/^# pfb_verify_artifact BEGIN/,/^# pfb_verify_artifact END/p" "$1")"
+      # stub the boot: report the version the exported disk comes up with
+      pfb_boot_artifact_version() { printf "%s\n" "$_booted"; }
+      pfb_verify_artifact "$2/out.qcow2" "$_tag"
+      printf "REACHED-AFTER-VERIFY\n"
+    ' _ "$SCRIPT" "$WORK"
+  }
+
+  It 'passes when the exported disk boots the family being published'
+    When call run_verify 26.07-BETA 26.07
+    The status should be success
+    The output should include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'refuses to push a disk that boots a different family'
+    # exactly what shipped: tag 26.07, disk boots 26.03.1
+    When call run_verify 26.03.1-RELEASE 26.07
+    The status should be failure
+    The stderr should include '26.03.1'
+    The output should not include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'refuses to push when the artifact never reports a version'
+    # a boot that dies inside the command substitution surfaces here as empty;
+    # it must be named as such, not reported as a bogus family mismatch
+    When call run_verify '' 26.07
+    The status should be failure
+    The stderr should include 'could not read a version'
+    The output should not include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'accepts a patch-level difference inside the family'
+    When call run_verify 26.07.1-RELEASE 26.07
+    The status should be success
+    The output should include 'REACHED-AFTER-VERIFY'
+  End
+End
+
+Describe 'image-upgrade.sh boot-environment promotion'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgbe.XXXXXX")"
+    CMDS="${WORK}/guest-cmds"
+    POLLS="${WORK}/polls"
+    export WORK CMDS POLLS
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # run_promote MODE — extract the shipped helper and drive it with a stub
+  # guest. MODE shapes how `bectl list` evolves across polls:
+  #   auto  — pfSense's own boot verification promotes on the 3rd poll
+  #   slow  — never promotes on its own; the fallback activate makes it stick
+  #   stuck — never promotes, not even after the fallback activate
+  run_promote() {
+    _mode="$1" sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      warn() { printf "WARNING: %s\n" "$*" >&2; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      sleep() { true; }          # no real waiting in the spec
+      PROMOTE_TIMEOUT=30
+      PROMOTE_INTERVAL=10
+      eval "$(sed -n "/^# pfb_promote_be BEGIN/,/^# pfb_promote_be END/p" "$1")"
+      ssh_guest() {
+        printf "%s\n" "$*" >> "$CMDS"
+        case "$*" in
+          *"bectl activate"*) printf "activated\n" >> "$WORK/activated" ;;
+          *"bectl list"*)
+            _n=$(( $(cat "$POLLS" 2>/dev/null || echo 0) + 1 ))
+            printf "%s" "$_n" > "$POLLS"
+            _promoted=0
+            [ "$_mode" = auto ] && [ "$_n" -ge 3 ] && _promoted=1
+            [ "$_mode" = slow ] && [ -f "$WORK/activated" ] && _promoted=1
+            if [ "$_promoted" -eq 1 ]; then
+              printf "default                NR     /          1.76G 2026-07-29 03:30\n"
+              printf "default_20260729033017 -      -          826M  2026-06-12 22:03\n"
+            else
+              # the shape between the upgrade reboot and pfSense-rc finishing:
+              # the new BE is running (N) but the archived pre-upgrade BE still
+              # owns the permanent bootfs (R) — publish that disk and every
+              # later boot is the old system (the shape the :26.07 tag shipped)
+              printf "default                N      /          1.76G 2026-07-29 03:30\n"
+              printf "default_20260729033017 R      -          826M  2026-06-12 22:03\n"
+            fi
+            ;;
+        esac
+      }
+      pfb_promote_be
+      printf "REACHED-AFTER-PROMOTE\n"
+    ' _ "$SCRIPT"
+  }
+
+  It 'waits for pfSense to promote the BE itself and does not touch bectl activate'
+    # the box promotes its own running BE at the end of pfSense-rc; forcing an
+    # activate would mask a boot that never actually completed
+    When call run_promote auto
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The contents of file "$CMDS" should not include 'bectl activate'
+  End
+
+  It 'falls back to an explicit activate when the promotion never comes'
+    When call run_promote slow
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'no automatic boot verification'
+    The contents of file "$CMDS" should include 'bectl activate'
+  End
+
+  It 'refuses to publish when the BE stays activated for one boot only'
+    When call run_promote stuck
+    The status should be failure
+    The stderr should include 'boot environment'
+    The output should not include 'REACHED-AFTER-PROMOTE'
+  End
+End


### PR DESCRIPTION
Fixes #1858

## Root cause

`pfSense-upgrade` renames the running boot environment to `<be>_<ts>`, installs the new release as `<be>`, activates it **for the next boot only** (`be_activate -t`, `/usr/local/libexec/pfSense-upgrade:1117`) and reboots. Nothing on disk is permanent at that point. The promotion happens at the *end* of the next boot: `/etc/pfSense-rc`'s `bootonce_verify_start()` runs `be_activate "$(be_active_name)"` — "Performing automatic boot verification" — unless manual verification is configured. That is why an interactive upgrade needs no extra step from the operator.

The image job never got that far. In the run that published the bad tag (30419584790):

```
03:31:44  ==> upgraded: 26.03.1-RELEASE -> 26.07-BETA
03:31:47  ==> health gate PASS: pfctl shows 122 live rules
03:31:48  ==> shutting the box down
```

Four seconds after the first SSH answer. `pfctl` rules are live long before `pfSense-rc` finishes, so the health gate was satisfied mid-boot and the shutdown cut the boot off before the automatic verification. The one-shot activation was never made permanent, the exported disk still booted the archived pre-upgrade BE, and `ghcr.io/pfblockerng/pfsense-plus:26.07` shipped a 26.03.1 system.

## Fix — two fail-closed layers

1. **`pfb_promote_be`** (after the health gate): waits for pfSense's own boot verification to mark the running BE active-on-reboot; falls back to performing the activation itself if that never arrives (manual verification configured, or a boot that genuinely did not finish); dies if the disk would still boot the pre-upgrade system. Waiting rather than forcing is deliberate — it also stops us capturing a box whose boot never completed.
2. **`pfb_verify_artifact`** (after the export, before `oras push`): boots the exported qcow2 once and refuses to publish it under a tag whose family it does not actually come up with. This is the layer that covers the whole class — anything that makes the disk differ from the box we observed, not just this boot-environment case.

The verification boot reuses the upgrade's own QEMU command line (same MACs, same SMBIOS uuid, same mgmt host-forward), so the Plus identity rules and the 8-NIC topology cannot drift between the two boots. It boots the KVM host's `out.qcow2` — the exact bytes the pushed local copy was streamed from — so no second transfer is needed, and the pushed copy stays the clean pre-boot one.

## Evidence

Mechanism read off a live pfSense box (`pfSense-upgrade`, `/etc/pfSense-rc`, `/etc/rc.bootonce_verify`), timeline read off the publishing workflow run.

`tests/shell/image_upgrade_be_spec.sh` drives both shipped helpers with a stub guest (hermetic, no VM). Test-first: authored and executed RED before each production edit, frozen byte-identical, GREEN with zero edits.

Every guard mutation-verified — each pin fails when the behaviour it claims to protect is removed:

| Mutation | Result |
| --- | --- |
| skip the wait and always force-activate | KILLED |
| drop the fallback activate | KILLED |
| drop the final active-on-reboot check | KILLED |
| drop the artifact family comparison | KILLED |
| drop the empty-version guard | KILLED |

Full shellspec suite under dash: **1114 examples, 0 failures, 8 skips**. `shellcheck --severity=info` clean, `sh -n` clean.

## Follow-up

The current `pfsense-plus:26.07` tag holds a 26.03.1 disk and must not be trusted; PR #1851 (the 26.07 activation) should stay unmerged until a genuine image is republished with this fix in place. #1857 tracks the sibling planner guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgrade images now permanently activate the new boot environment before publishing.
  - Exported images are boot-tested before release to confirm they match the intended version family.
  - Added configurable timeouts for boot verification and boot-environment promotion.

- **Bug Fixes**
  - Prevents publishing artifacts with mismatched or missing guest versions.
  - Fails safely when the upgraded boot environment cannot be made permanent.

- **Tests**
  - Added coverage for artifact verification, boot-environment promotion, and verification-boot behavior.

- **Documentation**
  - Updated image refresh workflow documentation to reflect the expanded validation and promotion steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->