### PR TITLE
IP group edit: fix the Custom List heading, text-area width and stray separator

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -863,7 +863,10 @@ if (isset($_POST) && !empty($_POST)) {
 			}
 			$clists['dnsblwhitelist']['base64'] = pfb_text_area_encode($data);
 			PfbConfig::write('suppression', $clists['dnsblwhitelist']['base64']);
-			write_config("pfBlockerNG: Removed [ {$wl_base} ] from DNSBL Whitelist (added to Custom_List)", FALSE);
+			// issue #1872: this description is user-facing (Diagnostics > Config History),
+			// so it spells the field the way the UI does -- "Custom List", not the
+			// code-level "Custom_List".
+			write_config("pfBlockerNG: Removed [ {$wl_base} ] from DNSBL Whitelist (added to Custom List)", FALSE);
 
 			// Refresh the query-time whiteDB so the domain is no longer allowed.
 			pfb_unbound_python_whitelist('alerts');

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1706,7 +1706,11 @@ else {
 $custom_txt = '<div id="Customlist"></div>' . $custom_txt;
 
 // Print Custom List TextArea section
-$section = new Form_Section("{$type} Custom_List", str_replace(' ', '', $type) . 'customlist', COLLAPSIBLE|SEC_CLOSED);
+// issue #1872: the heading is user-facing text, so it reads "Custom List" -- "Custom_List"
+// is the code-level spelling. The section ID is derived from $type, not from this title,
+// so the #Customlist anchor that pfblockerng_category.php and pfblockerng_alerts.php link
+// to is unaffected.
+$section = new Form_Section("{$type} Custom List", str_replace(' ', '', $type) . 'customlist', COLLAPSIBLE|SEC_CLOSED);
 $section->addInput(new Form_StaticText(
 	NULL,
 	$custom_txt));
@@ -1727,11 +1731,17 @@ if ($gtype == 'ipv4' || $gtype == 'ipv6') {
 	}
 }
 
-// Create page anchor for IP Suppression List
-$section->addInput(new Form_StaticText(
-	NULL,
-	'<div id="Custom"></div>'));
-
+// issue #1873: the "#Custom" anchor that used to live here was its own Form_StaticText,
+// so it rendered as an empty .form-group -- invisible except for the bottom border the
+// theme puts on every row, which drew a separator with nothing above it. Nothing in the
+// package ever linked to "#Custom" (the Alerts and Category pages both target
+// "#Customlist", added to $custom_txt above), so the row is gone rather than relocated.
+//
+// The explicit width is load-bearing: col-sm-12 on the control itself contributes 15px of
+// horizontal padding at desktop widths, and BELOW Bootstrap's sm breakpoint the class
+// stops applying at all, leaving the textarea at its default ~20-column size -- 192px
+// inside a 378px column on a phone. This matches the DNSBL Regex List field, which
+// already carried width: 100% and never showed the defect.
 $section->addInput(new Form_Textarea(
 	'custom',
 	'',
@@ -1740,7 +1750,7 @@ $section->addInput(new Form_Textarea(
   ->addClass('row-fluid col-sm-12')
   ->setAttribute('rows', '30')
   ->setAttribute('wrap', 'off')
-  ->setAttribute('style', 'background:#fafafa;');
+  ->setAttribute('style', 'background:#fafafa; width: 100%');
 
 $form->add($section);
 print ($form);

--- a/tests/smoke/ui/test_browser_custom_list_layout.py
+++ b/tests/smoke/ui/test_browser_custom_list_layout.py
@@ -1,0 +1,199 @@
+"""Tier-B browser tests (issues #1872, #1873): the IP group edit Custom List section.
+
+Three defects in one collapsible section on ``pfblockerng_category_edit.php``,
+all of them observable only as rendered geometry or rendered text -- which is
+why they live in this tier (testing.md mandate 4: visual/structural changes to
+a ``www/`` surface).
+
+* **#1872** -- the section heading reads ``IPv4 Custom_List``. ``Custom_List``
+  with an underscore is a code-level identifier; every other reference on the
+  page, including the section's own help text, says "Custom List".
+
+* **#1873, narrow field** -- the text area does not fill the column it sits
+  in. It carries the Bootstrap grid class ``col-sm-12`` but no width of its
+  own, so at desktop widths the class's 15px horizontal padding leaves it 30px
+  short, and BELOW Bootstrap's ``sm`` breakpoint the class stops applying
+  altogether and the control falls back to its default ~20-column width --
+  about half the panel on a phone. The DNSBL Regex List field escapes this only
+  because it carries an inline ``width: 100%``.
+
+* **#1873, stray separator** -- the ``#Custom`` page anchor is added as its own
+  ``Form_StaticText`` row, so it renders as an empty ``.form-group``. Every
+  ``.form-group`` carries ``border-bottom: 1px solid`` from the pfSense theme,
+  so that empty row draws a horizontal rule with nothing above it.
+
+Both viewports are asserted for the width, because the two failure modes have
+different causes and a desktop-only test would miss the one the reporter
+actually hit.
+
+NOT in scope, deliberately: below the ``sm`` breakpoint the label column and
+the input column stack, so the "Enable Domain/AS" checkbox sits under its
+label. That is Bootstrap's ``col-sm-*`` behaviour and it applies to every
+field on every pfSense page, not to this section -- measured at 390px, the
+label lands at y=2231 and the checkbox at y=2267. Special-casing one checkbox
+against the framework's own responsive grid would be a local fix to a global
+convention.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .conftest import mask_page_identity
+
+sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
+expect = sync_api.expect
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from playwright.sync_api import Page, ViewportSize
+
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_browser
+
+IP_EDITOR = "/pfblockerng/pfblockerng_category_edit.php?type=ipv4"
+
+JS_TIMEOUT_MS = 10_000
+
+# A phone: below Bootstrap's 768px `sm` breakpoint, where col-sm-* stops
+# applying and a control with no width of its own collapses to its default size.
+PHONE: ViewportSize = {"width": 390, "height": 844}
+DESKTOP: ViewportSize = {"width": 1600, "height": 1000}
+
+# The text area is allowed to sit inside its column's padding, but not to give
+# up a meaningful share of it. 32px covers the theme's own box spacing on both
+# viewports; the observed defect was 30px short on desktop and 186px on phone.
+MAX_WIDTH_SHORTFALL_PX = 32
+
+
+def _open(page: Page, webui: WebUI, path: str) -> None:
+    page.goto(webui.url(path), wait_until="domcontentloaded", timeout=JS_TIMEOUT_MS * 3)
+    page.wait_for_load_state("networkidle", timeout=JS_TIMEOUT_MS * 3)
+    assert page.locator("#usernamefld").count() == 0, f"GET {path} showed the login form -- cookie not authenticated"
+
+
+def _open_custom_list(page: Page) -> None:
+    """Expand the Custom List section (COLLAPSIBLE|SEC_CLOSED) via its toggle anchor."""
+    body = page.locator("#IPv4customlist_panel-body")
+    expect(body).to_be_attached(timeout=JS_TIMEOUT_MS)
+    if "in" not in (body.get_attribute("class") or ""):
+        page.locator('a[data-toggle="collapse"][href="#IPv4customlist_panel-body"]').click()
+    expect(body).to_be_visible(timeout=JS_TIMEOUT_MS)
+
+
+def _shot(page: Page, screenshot_dir: Path, name: str) -> None:
+    mask_page_identity(page)
+    page.screenshot(path=str(screenshot_dir / f"{name}.png"), full_page=True)
+
+
+def test_section_heading_says_custom_list_not_the_internal_identifier(
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """The heading reads "IPv4 Custom List" -- no underscore, no code identifier."""
+    page = browser_page
+    page.set_viewport_size(DESKTOP)
+    _open(page, webui, IP_EDITOR)
+
+    # Located via the panel that OWNS the known body id rather than by guessing a
+    # heading id: Form/Section.class.php only guarantees the "<id>_panel-body"
+    # element, and a heading selector that matches nothing would fail this test for
+    # the wrong reason -- looking like the defect while proving nothing about it.
+    heading = page.locator("div.panel", has=page.locator("#IPv4customlist_panel-body")).locator(".panel-title")
+    expect(heading).to_be_attached(timeout=JS_TIMEOUT_MS)
+    text = (heading.text_content() or "").strip()
+
+    assert "Custom_List" not in text, f"the heading still shows the internal identifier: {text!r}"
+    assert "Custom List" in text, f"expected the heading to read 'IPv4 Custom List'; got {text!r}"
+
+
+@pytest.mark.parametrize(("label", "viewport"), [("desktop", DESKTOP), ("phone", PHONE)])
+def test_custom_list_textarea_fills_its_column(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+    label: str,
+    viewport: ViewportSize,
+) -> None:
+    """The text area spans its column at both viewports.
+
+    Parametrized rather than duplicated because the two viewports fail for
+    different reasons -- padding at desktop, a dropped grid class at phone --
+    and fixing only one of them is a partial fix that a single-viewport test
+    would sign off on.
+    """
+    page = browser_page
+    page.set_viewport_size(viewport)
+    _open(page, webui, IP_EDITOR)
+    _open_custom_list(page)
+
+    textarea = page.locator("#custom")
+    expect(textarea).to_be_visible(timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, f"custom_list_width_{label}")
+
+    measured = page.evaluate(
+        """
+        () => {
+          const ta = document.getElementById('custom');
+          const column = ta.closest('div[class*="col-sm-"]');
+          return {
+            textarea: Math.round(ta.getBoundingClientRect().width),
+            column: Math.round(column.getBoundingClientRect().width),
+          };
+        }
+        """
+    )
+    shortfall = measured["column"] - measured["textarea"]
+
+    assert shortfall <= MAX_WIDTH_SHORTFALL_PX, (
+        f"[{label} {viewport['width']}px] the Custom List text area is {measured['textarea']}px "
+        f"inside a {measured['column']}px column -- {shortfall}px short, over the "
+        f"{MAX_WIDTH_SHORTFALL_PX}px allowance"
+    )
+
+
+def test_custom_list_section_has_no_empty_separator_row(
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """No ``.form-group`` in the section is empty.
+
+    An empty row is invisible except for the bottom border the theme puts on
+    every ``.form-group``, which is what draws the stray rule the report
+    describes. Asserted as "no row is empty" rather than "the row count is N",
+    so it keeps holding when the section legitimately gains or loses a field.
+    """
+    page = browser_page
+    page.set_viewport_size(DESKTOP)
+    _open(page, webui, IP_EDITOR)
+    _open_custom_list(page)
+
+    empty_rows = page.evaluate(
+        """
+        () => {
+          const panel = document.querySelector('#IPv4customlist_panel-body');
+          return Array.from(panel.querySelectorAll('.form-group'))
+            .map((row) => {
+              const label = row.querySelector('label.control-label');
+              const labelText = (label ? label.textContent : '').trim();
+              const control = row.querySelector('textarea, input, select, button, a');
+              const bodyText = Array.from(row.children)
+                .filter((child) => child !== label)
+                .map((child) => (child.textContent || '').trim())
+                .join('');
+              return { labelText, hasControl: Boolean(control), bodyText, html: row.outerHTML.slice(0, 160) };
+            })
+            .filter((row) => !row.labelText && !row.hasControl && !row.bodyText);
+        }
+        """
+    )
+
+    assert empty_rows == [], (
+        "the Custom List section renders form rows with no label, no control and no text; "
+        "each draws the theme's bottom border as a stray separator:\n"
+        + "\n".join(f"  {row['html']}" for row in empty_rows)
+    )


### PR DESCRIPTION
Fixes #1872
Fixes #1873

Two QA findings against the **Custom List** section on the IP group edit page.

## What changed

**#1872 — the heading said `IPv4 Custom_List`.** `Custom_List` is the code-level spelling; every other reference on the page, including the section's own help text, says "Custom List". The section ID is derived from the type rather than the title, so the `#Customlist` anchor that `pfblockerng_category.php` and `pfblockerng_alerts.php` link to is unaffected.

The same underscore also reached **Diagnostics > Config History** through the whitelist-removal description, so that is corrected too.

**#1873 — the text area did not fill its column.** It carried the Bootstrap grid class `col-sm-12` but no width of its own. At desktop widths that class contributes 15px of horizontal padding per side; **below the `sm` breakpoint it stops applying entirely** and the control falls back to its default ~20-column size. Measured on a live VM:

| viewport | text area | column | short by |
| --- | --- | --- | --- |
| 1600px | 923px | 953px | 30px |
| 390px | **192px** | 378px | **186px** |

The DNSBL Regex List field never showed this because it already carried `width: 100%`.

**#1873 — the stray separator.** The `#Custom` page anchor was its own `Form_StaticText`, so it rendered as an empty `.form-group`. Every `.form-group` carries `border-bottom: 1px solid rgb(224,224,224)` from the theme, so that empty row drew a horizontal rule with nothing above it. `git grep` finds **no reference to `#Custom` anywhere** in the package — both call sites target `#Customlist` — so the row is deleted rather than relocated.

## Deliberately out of scope

The reporter also saw the **Enable Domain/AS** checkbox sitting under its label on a phone. Measured at 390px: label at y=2231, checkbox at y=2267 — it does stack. But that is Bootstrap's `col-sm-*` grid collapsing below 768px, which happens to **every field on every pfSense page**, not to this section. Special-casing one checkbox against the framework's own responsive grid would be a local fix to a global convention, so it is documented in the test module and left alone.

## Red → green evidence

Tier-B (`ui_browser`), executed on a live pfSense VM via `scripts/local-smoke.sh`.

RED, before the production edit — each assertion failing for its own defect:

```
E  AssertionError: the heading still shows the internal identifier: 'IPv4 Custom_List'
E  AssertionError: [phone 390px] the Custom List text area is 192px inside a 378px column -- 186px short, over the 32px allowance
E  AssertionError: the Custom List section renders form rows with no label, no control and no text; each draws the theme's bottom border as a stray separator
3 failed, 1 passed, 527 deselected in 72.18s
```

GREEN, same tests, zero edits:

```
4 passed, 527 deselected in 57.73s
```

Test file byte-identical across both runs: `42578a5512…` at red and at green.

### A correction worth recording

The first version of this test located the heading as `#IPv4customlist_panel-heading .panel-title`, which **matches nothing** — `Form/Section.class.php` only guarantees the `<id>_panel-body` element. That test failed identically before and after the fix, so it looked red while proving nothing about the heading. It now locates the heading through the panel that owns the known body id, and the red run above is from that corrected test. The desktop width row passes at 30px (inside the 32px allowance) and stands as a regression guard rather than part of the proof; the phone row carries it.

## Gates

```
GATES: PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
