### PR TITLE
tests: pin the clean-filter stat-cache path in rtk_blob_identity_spec

### DIFF
--- a/tests/shell/rtk_blob_identity_spec.sh
+++ b/tests/shell/rtk_blob_identity_spec.sh
@@ -34,6 +34,19 @@ EOF
     env PATH="${shim}:${PATH}" RTK_LOG="${log}" CLAUDE_PROJECT_DIR="${project}" sh "${hook}"
   }
 
+  # Premise gate for the clean-filter example (#1883): the example only tests
+  # the hook when HEAD holds the CLEANED bytes. If `git add` skipped the clean
+  # filter, HEAD equals the worktree bytes and the hook would trust them
+  # legitimately — fail the premise loudly instead of flaking on the log check.
+  run_hook_with_cleaned_head() {
+    head_blob=$(git -C "${project}" cat-file -p HEAD:.rtk/filters.toml) || return 9
+    if [ "${head_blob}" != '[FILTERS]' ]; then
+      echo "premise failed: HEAD:.rtk/filters.toml is '${head_blob}', expected cleaned '[FILTERS]'" >&2
+      return 9
+    fi
+    run_hook
+  }
+
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
@@ -94,12 +107,19 @@ EOF
   End
 
   It 'does not trust changed bytes normalized by a Git clean filter'
+    # Pin the stat-cache skip deterministically (#1883): a backdated, re-added
+    # entry is definitively clean (entry mtime < index mtime), so a plain
+    # `git add` would trust the stat cache and never re-run the clean filter —
+    # the intermittent CI path. --renormalize forces the re-clean regardless.
+    touch -t 202001010000 "${project}/.rtk/filters.toml"
+    git -C "${project}" add .rtk/filters.toml
     git -C "${project}" config filter.upper.clean "tr '[:lower:]' '[:upper:]'"
     git -C "${project}" config filter.upper.smudge cat
     printf '*.toml filter=upper\n' > "${project}/.gitattributes"
-    git -C "${project}" add .gitattributes .rtk/filters.toml
+    git -C "${project}" add .gitattributes
+    git -C "${project}" add --renormalize .rtk/filters.toml
     git -C "${project}" commit -q -m clean-filter
-    When run run_hook
+    When run run_hook_with_cleaned_head
     The status should be success
     The file "${log}" should not be exist
   End


### PR DESCRIPTION
## What

Hardens the flaky `rtk committed filter identity — does not trust changed bytes normalized by a Git clean filter` example so its premise is established deterministically instead of inferred from git's stat-cache heuristics.

Fixes #1883

## Root cause (confirmed, not the issue's original theory)

The log path could never be hit by a stray writer — it is a per-example `mktemp -d`, and the shim only writes when the hook execs it. The fragility was in the **setup**: the example re-adds an *unchanged* `.rtk/filters.toml` after introducing a clean filter via `.gitattributes`. Whether `git add` re-runs the clean filter depends on the racily-clean heuristic:

- entry racily clean (entry mtime ≥ index mtime, the common same-second case) → git re-hashes, the filter runs, `HEAD` gets the cleaned bytes `[FILTERS]`, the hook correctly rejects — the assertion passes;
- entry definitively clean (entry mtime < index mtime) → the stat cache is trusted, the filter never runs, `HEAD` keeps the un-cleaned worktree bytes `[filters]`, and the hook then trusts them **legitimately** — the log appears and the assertion fails.

Timestamp granularity and sub-second ordering decide which path runs. Probes (executed, per-issue thread): ~1/200 spontaneous reproduction on a Linux box; backdating the entry's mtime before the first add pins the skip path **10/10 on Linux and 5/5 on macOS**.

## Fix

- Pin the stat-cache path deterministically in the example: backdate and re-add `.rtk/filters.toml` so the entry is definitively clean — the exact condition CI hit intermittently is now exercised on every run.
- Force the re-clean with `git add --renormalize`, which applies the clean filter regardless of stat state (verified 10/10 on Linux under the pinned skip condition).
- Gate the example on its premise via `run_hook_with_cleaned_head`: `HEAD:.rtk/filters.toml` must hold the cleaned bytes before the hook runs; otherwise it fails loudly with an expected-vs-actual message (status 9) instead of flaking on the negative log assertion.

## Red → green proof (executed)

- **RED**: the final spec with only `--renormalize` removed (assertions and premise gate byte-identical; `git hash-object` `8b8ec6b7f3d76e07d3f354b04287eff26049e886`) fails deterministically under dash: `status: 9`, stderr `premise failed: HEAD:.rtk/filters.toml is '[filters]', expected cleaned '[FILTERS]'`.
- **GREEN**: the committed spec (`ee8cf4e0c9ea8493c8a8ac66da26e0f0913df67a`), zero assertion edits, passes 3/3 consecutive runs under dash; all 5 `rtk_*` specs (18 examples) green.

The premise gate is the regression assertion: any future change that lets the setup skip the clean filter again trips it with a diagnostic instead of an intermittent negative-assertion failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for Git clean-filter and renormalization behavior.
  * Added validation to ensure hooks run only when the expected cleaned file content is present.
  * Made the related test scenario deterministic by configuring and applying content normalization before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->