### PR TITLE
pfblockerng: relocate the three page anchors that drew empty separator rows

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3275,11 +3275,10 @@ $section->addInput(new Form_Input(
 	. 'Roughly under 1 KB of RAM per entry. Set to <strong>0</strong> for unlimited (no eviction). '
 	. 'Takes effect on the next DNSBL Reload.');
 
-// Create page anchor for DNSBL Whitelist
-$section->addInput(new Form_StaticText(
-	NULL,
-	'<div id="Whitelist"></div>'));
-
+// issue #1881: the "#Whitelist" page anchor that used to live here was its own empty
+// Form_StaticText row -- every .form-group carries a theme border-bottom, so it drew a
+// separator with nothing above it. Its only consumer, the dashboard widget, now links
+// the DNSBL Whitelist section's own id (#DNSBL_Whitelist_customlist) instead.
 $form->add($section);
 
 $suppression_text = 'No Regex Entries Allowed!&emsp;

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -541,11 +541,9 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ))->setHelp('This will disable the MaxMind monthly CSV GeoIP database cron update. This does not affect the MaxMind binary cron update that is used for other GeoIP funcionality in the package.');
 
-// Create page anchor for IP Suppression List
-$section->addInput(new Form_StaticText(
-	NULL,
-	'<div id="Suppression"></div>'));
-
+// issue #1881: the "#Suppression" page anchor that used to live here was its own empty
+// Form_StaticText row drawing a stray separator. Its only consumer, the dashboard
+// widget, now links the IPv4 Suppression section's own id (#IPv4_Suppression_customlist).
 $form->add($section);
 
 // Print Custom List TextArea section

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -500,11 +500,6 @@ $section->addInput(new Form_Textarea(
 ))->removeClass('form-control')->addClass('row-fluid col-sm-12')->setAttribute('rows', '30')->setAttribute('wrap', 'off')
   ->setAttribute('readonly', 'readonly')->setAttribute('style', 'background:#fafafa; width: 100%');
 
-// Scroll to end of page when loading logs
-$section->addInput(new Form_StaticText(
-	NULL,
-	'<div id="endofpage"></div>'));
-
 $form->add($section);
 
 $form->addGlobal(new Form_Input('download', 'download', 'hidden', ''));
@@ -516,6 +511,9 @@ $form->addGlobal(new Form_Input('file', 'file', 'hidden', ''));
 
 print($form);
 ?>
+<!-- issue #1881: the auto-scroll target lives OUTSIDE the form -- as a Form_StaticText
+     row it was an empty .form-group whose theme border drew a stray separator. -->
+<div id="endofpage"></div>
 
 <script type="text/javascript">	
 //<![CDATA[

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -935,8 +935,12 @@ function pfBlockerNG_get_header($mode='') {
 
 				if ($data == 'Suppression' || $data == 'Whitelist') {
 					$d_type = ($data == 'Suppression') ? 'ip' : 'dnsbl';
+					// issue #1881: link the target section's own id -- the dedicated
+					// "#Suppression"/"#Whitelist" anchor rows were empty form rows
+					// drawing stray separators and are gone.
+					$d_anchor = ($data == 'Suppression') ? 'IPv4_Suppression_customlist' : 'DNSBL_Whitelist_customlist';
 					print("{$tab5}<td {$tdl} title=\"{$titles[$key][$data]}\"><i class=\"{$faicon[$key][$col]}\"></i>&nbsp;&nbsp;"
-						. "<a target=\"_blank\" href=\"/pfblockerng/pfblockerng_{$d_type}.php#{$data}\" title=\"Link to {$data}\">"
+						. "<a target=\"_blank\" href=\"/pfblockerng/pfblockerng_{$d_type}.php#{$d_anchor}\" title=\"Link to {$data}\">"
 						. "<small><span class=\"pfb_{$data}\">{$value}</span></small></a></td>\n");
 				}
 				else {

--- a/tests/php/AnchorRowRelocationWiringTest.php
+++ b/tests/php/AnchorRowRelocationWiringTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1881 -- three page anchors used to be their own empty Form_StaticText rows, each
+ * drawing a stray horizontal separator (every .form-group carries a theme border-bottom).
+ * The issue's original "all three are dead, delete them" premise was falsified on the
+ * issue: the dashboard widget builds "#Suppression"/"#Whitelist" links dynamically
+ * (pfblockerng.widget.php, href=".../pfblockerng_{$d_type}.php#{$data}"), and
+ * "#endofpage" is pfblockerng_log.php's own scrollIntoView() target. So the fix is
+ * RELOCATION, not deletion:
+ *
+ *  - the widget links retarget the existing Form_Section ids
+ *    (#IPv4_Suppression_customlist / #DNSBL_Whitelist_customlist -- section ids render as
+ *    DOM ids, e.g. the dnsbl page's own $('#Python_Group_Policy') JS relies on that), and
+ *    the two empty anchor rows are deleted;
+ *  - the log page's #endofpage div moves out of the form (raw HTML after print($form)),
+ *    so the scroll target survives with no .form-group around it.
+ *
+ * Source pins are the Tier-A coverage for pages carrying top-level render execution
+ * (DnsblRegexHighlightWiringTest precedent); the visual empty-row absence and the live
+ * scroll behaviour are Tier-B browser coverage.
+ */
+final class AnchorRowRelocationWiringTest extends TestCase
+{
+	private static function src(string $rel): string
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/' . $rel;
+		$src  = file_get_contents($path);
+		if ($src === false) {
+			throw new RuntimeException("failed to read {$rel}");
+		}
+		return $src;
+	}
+
+	public function testDnsblPageNoLongerRendersTheEmptyWhitelistAnchorRow(): void
+	{
+		$this->assertStringNotContainsString(
+			'<div id="Whitelist"></div>',
+			self::src('pfblockerng/pfblockerng_dnsbl.php'),
+			'expected the empty #Whitelist Form_StaticText anchor row to be gone from the DNSBL page'
+		);
+	}
+
+	public function testIpPageNoLongerRendersTheEmptySuppressionAnchorRow(): void
+	{
+		$this->assertStringNotContainsString(
+			'<div id="Suppression"></div>',
+			self::src('pfblockerng/pfblockerng_ip.php'),
+			'expected the empty #Suppression Form_StaticText anchor row to be gone from the IP page'
+		);
+	}
+
+	public function testWidgetLinksTargetTheSectionIdsInsteadOfTheDeletedAnchors(): void
+	{
+		$widget = self::src('widgets/widgets/pfblockerng.widget.php');
+		$this->assertStringContainsString(
+			'IPv4_Suppression_customlist',
+			$widget,
+			'expected the widget Suppression link to target the IPv4 Suppression section id'
+		);
+		$this->assertStringContainsString(
+			'DNSBL_Whitelist_customlist',
+			$widget,
+			'expected the widget Whitelist link to target the DNSBL Whitelist section id'
+		);
+		$this->assertStringNotContainsString(
+			'.php#{$data}',
+			$widget,
+			'expected the raw #{$data} fragment (which produced the now-deleted #Suppression/#Whitelist anchors) to be gone'
+		);
+	}
+
+	public function testLogPageEndofpageAnchorSurvivesOutsideTheForm(): void
+	{
+		$log = self::src('pfblockerng/pfblockerng_log.php');
+
+		// The scroll target must still exist -- the page's own JS scrolls to it...
+		$this->assertStringContainsString(
+			'<div id="endofpage"></div>',
+			$log,
+			'expected the #endofpage scroll target to still exist on the Logs page'
+		);
+		$this->assertStringContainsString(
+			'getElementById("endofpage")',
+			$log,
+			'expected the auto-scroll JS consumer of #endofpage to remain'
+		);
+
+		// ...but no longer as a Form_StaticText row inside the form: the div must render
+		// AFTER print($form), where no .form-group (and thus no bordered row) wraps it.
+		$divPos   = strpos($log, '<div id="endofpage"></div>');
+		$printPos = strpos($log, 'print($form);');
+		$this->assertNotFalse($printPos, 'expected print($form); in pfblockerng_log.php');
+		$this->assertGreaterThan(
+			$printPos,
+			$divPos,
+			'expected the #endofpage div to render after print($form) -- inside the form it is an '
+			. 'empty Form_StaticText row drawing a stray separator'
+		);
+		// Vacuity guard for the relocation: the old in-form Form_StaticText carrier is gone.
+		$this->assertSame(
+			1,
+			substr_count($log, '<div id="endofpage"></div>'),
+			'expected exactly one #endofpage div (the relocated one) -- a leftover in-form copy would keep the stray row'
+		);
+	}
+}

--- a/tests/smoke/ui/test_browser_anchor_rows.py
+++ b/tests/smoke/ui/test_browser_anchor_rows.py
@@ -1,0 +1,162 @@
+"""Tier-B browser tests (issue #1881): page anchors stop rendering empty separator rows.
+
+Three page anchors were each their own empty ``Form_StaticText`` row -- ``#Whitelist``
+(DNSBL settings), ``#Suppression`` (IP settings), ``#endofpage`` (Logs). Every
+``.form-group`` carries ``border-bottom: 1px solid`` from the pfSense theme, so each drew
+a horizontal rule with nothing above it. The issue's original "all three are dead, delete
+them" premise was falsified on the issue thread: the dashboard widget links
+``#Suppression``/``#Whitelist`` dynamically, and ``#endofpage`` is the Logs page's own
+auto-scroll target. The fix relocates instead of deleting: the widget now links the target
+sections' own ids, and ``#endofpage`` renders outside the form.
+
+This is rendered-geometry behaviour (testing.md mandate 4): a source pin proves the rows'
+markup is gone, but only a browser proves no empty bordered row actually renders and the
+relocated scroll target still has a box to scroll to.
+
+Red/green split: the empty-row scans and the endofpage-outside-form/scroll tests are the
+red-first proof (red on devel, where the anchor rows still render). The section-id
+existence tests are green-by-design -- those ids predate this change; they pin the
+contract that the widget's retargeted hrefs (pinned hermetically in
+``AnchorRowRelocationWiringTest``) resolve to real elements, so either side regressing
+turns one of the two suites red.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .test_browser_custom_list_layout import DESKTOP, JS_TIMEOUT_MS, _open, _shot
+
+sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
+expect = sync_api.expect
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from playwright.sync_api import Page
+
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_browser
+
+DNSBL_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
+IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
+LOG_PAGE = "/pfblockerng/pfblockerng_log.php"
+
+# The empty-row scan from test_browser_custom_list_layout, widened to the whole page:
+# the anchor rows sat at the END of the section PRECEDING the one they named, so a scan
+# scoped to the named section would never have seen them.
+_EMPTY_ROW_SCAN = """
+() => Array.from(document.querySelectorAll('form .form-group'))
+  .map((row) => {
+    const label = row.querySelector('label.control-label');
+    const labelText = (label ? label.textContent : '').trim();
+    const control = row.querySelector('textarea, input, select, button, a');
+    const bodyText = Array.from(row.children)
+      .filter((child) => child !== label)
+      .map((child) => (child.textContent || '').trim())
+      .join('');
+    return { labelText, hasControl: Boolean(control), bodyText, html: row.outerHTML.slice(0, 160) };
+  })
+  .filter((row) => !row.labelText && !row.hasControl && !row.bodyText)
+"""
+
+
+@pytest.mark.parametrize(
+    ("path", "name"),
+    [(DNSBL_PAGE, "dnsbl"), (IP_PAGE, "ip"), (LOG_PAGE, "log")],
+    ids=["dnsbl", "ip", "log"],
+)
+def test_page_renders_no_empty_separator_rows(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+    path: str,
+    name: str,
+) -> None:
+    """No ``.form-group`` on the page is empty -- nothing draws a stray separator.
+
+    Whole-page rather than per-section, so the assertion also keeps holding if a future
+    anchor row appears anywhere else on these pages.
+    """
+    page = browser_page
+    page.set_viewport_size(DESKTOP)
+    _open(page, webui, path)
+    _shot(page, screenshot_dir, f"anchor_rows_{name}")
+
+    empty_rows = page.evaluate(_EMPTY_ROW_SCAN)
+    assert empty_rows == [], (
+        f"{path} renders form rows with no label, no control and no text; each draws the "
+        "theme's bottom border as a stray separator:\n" + "\n".join(f"  {row['html']}" for row in empty_rows)
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "section_id"),
+    [(DNSBL_PAGE, "DNSBL_Whitelist_customlist"), (IP_PAGE, "IPv4_Suppression_customlist")],
+    ids=["dnsbl-whitelist", "ip-v4suppression"],
+)
+def test_widget_link_target_section_id_exists(
+    browser_page: Page,
+    webui: WebUI,
+    path: str,
+    section_id: str,
+) -> None:
+    """The section id the dashboard widget now links to resolves to a real element.
+
+    Green-by-design (the ids predate this change) -- this is the browser half of the
+    widget-retarget contract; the widget's href side is pinned in
+    ``AnchorRowRelocationWiringTest``.
+    """
+    page = browser_page
+    page.set_viewport_size(DESKTOP)
+    _open(page, webui, path)
+
+    target = page.locator(f"#{section_id}")
+    expect(target).to_be_attached(timeout=JS_TIMEOUT_MS)
+    count = target.count()
+    assert count == 1, f"{path}: expected exactly one #{section_id} element for the widget link to land on; got {count}"
+
+
+def test_log_endofpage_target_lives_outside_the_form_and_scrolls(
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """``#endofpage`` survives outside any ``.form-group`` and is still scrollable-to.
+
+    Before-state first: the element exists. Then placement (no ``.form-group`` ancestor --
+    inside one it IS the stray-separator row), then behaviour: ``scrollIntoView()`` on it
+    moves the viewport, proving the relocated div still has a box the page's own
+    auto-scroll JS can land on (a removed or display-none target would no-op).
+    """
+    page = browser_page
+    page.set_viewport_size(DESKTOP)
+    _open(page, webui, LOG_PAGE)
+
+    in_form_group = page.evaluate(
+        """
+        () => {
+          const el = document.getElementById('endofpage');
+          if (!el) return 'MISSING';
+          return el.closest('.form-group') !== null;
+        }
+        """
+    )
+    assert in_form_group != "MISSING", "the #endofpage scroll target is gone from the Logs page"
+    assert in_form_group is False, "#endofpage still renders inside a .form-group -- that row is the stray separator"
+
+    scrolled = page.evaluate(
+        """
+        () => {
+          window.scrollTo(0, 0);
+          document.getElementById('endofpage').scrollIntoView();
+          return window.scrollY;
+        }
+        """
+    )
+    assert scrolled > 0, (
+        f"scrollIntoView() on #endofpage left the viewport at scrollY={scrolled} -- "
+        "the auto-scroll target has no box to scroll to"
+    )


### PR DESCRIPTION
## What

Three page anchors — `#Whitelist` (DNSBL settings), `#Suppression` (IP settings), `#endofpage` (Logs) — each rendered as an empty `Form_StaticText` row, and the theme's `border-bottom` on every `.form-group` turned each into a horizontal rule with nothing above it (#1881, same defect class as #1873).

The issue's original "all three are dead, delete them" premise was falsified on the thread ([evidence](https://github.com/pfBlockerNG/pfBlockerNG/issues/1881#issuecomment-5123987639)): the dashboard widget builds `#Suppression`/`#Whitelist` links dynamically (`href=".../pfblockerng_{$d_type}.php#{$data}"` — invisible to a literal grep), and `#endofpage` is the Logs page's own `scrollIntoView()` target. So this PR relocates instead of deleting:

- **Widget links retarget the sections' own ids** (`#IPv4_Suppression_customlist`, `#DNSBL_Whitelist_customlist`) and the two empty anchor rows are deleted. Section ids render as DOM ids (the dnsbl page's `$('#Python_Group_Policy')` JS already relies on that), and landing on the section header beats the old anchors, which sat one section above their targets.
- **`#endofpage` moves outside the form** — raw HTML right after `print($form)`, no `.form-group` wrapper, auto-scroll JS untouched.

## Test evidence (executed, frozen-hash red→green)

| Proof | Red | Green |
| --- | --- | --- |
| `AnchorRowRelocationWiringTest` (source pins: rows gone, widget retargeted, endofpage after `print($form)` + exactly-once) | 4/4 fail against origin/devel | 4/4 pass, file frozen `bad70753` (re-executed by the independent verifier via `verify-red-proof.sh`: FREEZE-OK/RED-OK/GREEN-OK) |
| Tier-B `test_browser_anchor_rows.py` (whole-page empty-row scan ×3 pages, widget-target ids resolve, endofpage outside any `.form-group` + `scrollIntoView` moves the viewport) | 6 selected / 4 failed on origin/devel (box 10.0.0.36) — failures capture the literal anchor divs inside empty rows | 6 selected / 6 passed on this branch (same box), module frozen `1a13c8f2` |

Retired-anchor sweep: `git grep -nE 'php#Whitelist|php#Suppression|#\{\$data\}' -- src/` → zero hits; `#endofpage`'s JS consumer intact (`pfblockerng_log.php:555`).

Fixes #1881

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard links for DNSBL Whitelist and IP Suppression now navigate directly to the correct sections.
  * Removed empty separator rows from DNSBL, IP, and Logs pages.
  * Improved Logs page scrolling by relocating the end-of-page target outside the form.

* **Tests**
  * Added automated coverage for section links, anchor placement, empty-row removal, and scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->