### PR TITLE
pfblockerng: tolerate the retired manifest top1m_list (#1841)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5348,13 +5348,17 @@ def _dnsbl_validate_manifest_raws(manifest: dict[str, Any], base_dir: str) -> No
         "tld_wildcard_exclusion",
         "user_whitelist",
         "user_unlock",
+        # issue #1841: ``top1m_list`` is RETIRED (#1542 moved TOP1M to the sidecar) but a
+        # box upgraded across that retirement still has a manifest carrying it until the
+        # next full update rewrites one. Rejecting the generation on the retired key left
+        # the resolver with NO DNSBL meanwhile, so it is tolerated and read as the TOP1M
+        # source of its own vintage (dnsbl_build_from_manifest) -- shape still checked.
+        "top1m_list",
     )
     for config_field in list_fields:
         value = config.get(config_field)
         if config_field in config and (not isinstance(value, list) or any(not isinstance(item, str) for item in value)):
             raise _DnsblGenerationError("DNSBL manifest/v1 config.{} must be list[str]".format(config_field))
-    if "top1m_list" in config:
-        raise _DnsblGenerationError("DNSBL manifest/v1 config.top1m_list is retired")
     for flag_field in ("top1m_enabled", "regex_cap"):
         if flag_field in config and not isinstance(config[flag_field], bool):
             raise _DnsblGenerationError("DNSBL manifest/v1 config.{} must be bool".format(flag_field))
@@ -5605,7 +5609,23 @@ def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
         manifest_config = manifest["config"]
         config = _dnsbl_config_from_manifest(manifest, base_dir)
         top1m_enabled = bool(manifest_config.get("top1m_enabled", False))
-        top1m_lines = _dnsbl_fixed_top1m_lines(base_dir) if top1m_enabled else ()
+        # issue #1841: a manifest still carrying the retired inline TOP1M list predates
+        # the sidecar (#1542), which therefore does not exist on that box yet -- read the
+        # list the manifest itself ships so an upgrade keeps the DNSBL it had, and warn
+        # so the retirement stays visible until the next full update rewrites the manifest.
+        legacy_top1m = manifest_config.get("top1m_list")
+        if legacy_top1m is not None:
+            sys.stderr.write(
+                "[pfBlockerNG]: DNSBL manifest '{}' still carries the retired "
+                "config.top1m_list -- reading TOP1M from it until the next full update "
+                "rewrites the manifest".format(manifest_path)
+            )
+        if not top1m_enabled:
+            top1m_lines: Iterable[str] = ()
+        elif legacy_top1m is not None:
+            top1m_lines = list(legacy_top1m)
+        else:
+            top1m_lines = _dnsbl_fixed_top1m_lines(base_dir)
         result = build(
             manifest,
             config,

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5617,8 +5617,10 @@ def dnsbl_build_from_manifest(manifest_path: str) -> BuildResult | None:
         if legacy_top1m is not None:
             sys.stderr.write(
                 "[pfBlockerNG]: DNSBL manifest '{}' still carries the retired "
-                "config.top1m_list -- reading TOP1M from it until the next full update "
-                "rewrites the manifest".format(manifest_path)
+                "config.top1m_list -- {} until the next full update rewrites the manifest".format(
+                    manifest_path,
+                    "reading TOP1M from it" if top1m_enabled else "ignoring it (TOP1M is disabled)",
+                )
             )
         if not top1m_enabled:
             top1m_lines: Iterable[str] = ()

--- a/tests/test_issue1841_legacy_manifest_top1m.py
+++ b/tests/test_issue1841_legacy_manifest_top1m.py
@@ -1,0 +1,110 @@
+"""Issue #1841 -- a package upgrade must never take DNSBL down just because the
+manifest schema moved.
+
+A box upgraded across the TOP1M externalisation (#1542) keeps its pre-retirement
+``pfb_py_sources.json`` until the next full update rewrites it. That manifest still
+carries ``config.top1m_list`` (the inline TOP1M whitelist) and predates the
+``pfb_py_top1m.txt`` sidecar. The manifest validator rejected the whole generation on
+the retired key, so the resolver served no DNSBL at all until a full sync succeeded.
+
+Intended behaviour pinned here: the retired key is TOLERATED with a one-line warning,
+the generation builds, and -- because the sidecar of that vintage does not exist -- the
+retired inline list is what feeds the TOP1M whitelist, so the box keeps exactly the
+DNSBL it had before the upgrade.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import pfb_unbound as P
+
+RETIRED_KEY_WARNING = "config.top1m_list"
+
+
+def _manifest(
+    tmp_path: Path,
+    *,
+    top1m_enabled: bool,
+    top1m_list: list[str] | None,
+) -> str:
+    """A manifest/v1 with one raw feed; ``top1m_list`` present == pre-#1542 vintage."""
+    (tmp_path / "feed.raw").write_text("blocked.example\npopularcdn.com\n", encoding="utf-8")
+    config: dict[str, object] = {"user_whitelist": [], "top1m_enabled": top1m_enabled}
+    if top1m_list is not None:
+        config["top1m_list"] = top1m_list
+    path = tmp_path / "pfb_py_sources.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "config": config,
+                "feeds": [{"raw": "feed.raw", "feed": "feed", "group": "g", "log_flag": "1"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def test_legacy_manifest_with_top1m_disabled_still_builds_its_feeds(tmp_path: Path) -> None:
+    """The retired key alone no longer costs the box its feed data."""
+    manifest = _manifest(tmp_path, top1m_enabled=False, top1m_list=["popularcdn.com"])
+
+    result = P.dnsbl_build_from_manifest(manifest)
+
+    assert result is not None, "retired config.top1m_list still fails the whole generation"
+    assert "blocked.example" in result.data_db
+    assert result.white_db == {}, "TOP1M is off -- the retired list must not whitelist anything"
+
+
+def test_legacy_manifest_with_top1m_enabled_keeps_its_top1m_whitelist(tmp_path: Path) -> None:
+    """TOP1M on + no sidecar of that vintage: the retired inline list is the source,
+    so a popular domain listed by a feed keeps resolving exactly as before the upgrade."""
+    manifest = _manifest(tmp_path, top1m_enabled=True, top1m_list=["popularcdn.com"])
+    assert not (tmp_path / "pfb_py_top1m.txt").exists(), "pre-#1542 manifests predate the sidecar"
+
+    result = P.dnsbl_build_from_manifest(manifest)
+
+    assert result is not None
+    assert "blocked.example" in result.data_db
+    assert P.whitelist_check_domain("popularcdn.com", result.white_db, 1)
+    assert result.white_db["popularcdn.com"]["important"] is True
+
+
+def test_legacy_manifest_warns_once_about_the_retired_key(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The tolerated retirement is operator-visible -- one warning, not silence."""
+    manifest = _manifest(tmp_path, top1m_enabled=True, top1m_list=["popularcdn.com"])
+
+    assert P.dnsbl_build_from_manifest(manifest) is not None
+
+    assert capsys.readouterr().err.count(RETIRED_KEY_WARNING) == 1
+
+
+def test_current_manifest_reads_the_sidecar_and_warns_about_nothing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Guard the flip: a post-#1542 manifest keeps the sidecar contract, no warning."""
+    manifest = _manifest(tmp_path, top1m_enabled=True, top1m_list=None)
+    (tmp_path / "pfb_py_top1m.txt").write_text("sidecar.example\n", encoding="utf-8")
+
+    result = P.dnsbl_build_from_manifest(manifest)
+
+    assert result is not None
+    assert set(result.white_db) == {"sidecar.example"}
+    assert RETIRED_KEY_WARNING not in capsys.readouterr().err
+
+
+def test_legacy_manifest_prefers_its_own_inline_list_over_a_stray_sidecar(tmp_path: Path) -> None:
+    """A manifest and its TOP1M snapshot are published together, so a manifest of the
+    retired vintage is read with the TOP1M data of that same vintage -- its inline list."""
+    manifest = _manifest(tmp_path, top1m_enabled=True, top1m_list=["popularcdn.com"])
+    (tmp_path / "pfb_py_top1m.txt").write_text("sidecar.example\n", encoding="utf-8")
+
+    result = P.dnsbl_build_from_manifest(manifest)
+
+    assert result is not None
+    assert set(result.white_db) == {"popularcdn.com"}

--- a/tests/test_issue1841_legacy_manifest_top1m.py
+++ b/tests/test_issue1841_legacy_manifest_top1m.py
@@ -29,7 +29,7 @@ def _manifest(
     tmp_path: Path,
     *,
     top1m_enabled: bool,
-    top1m_list: list[str] | None,
+    top1m_list: object | None,
 ) -> str:
     """A manifest/v1 with one raw feed; ``top1m_list`` present == pre-#1542 vintage."""
     (tmp_path / "feed.raw").write_text("blocked.example\npopularcdn.com\n", encoding="utf-8")
@@ -104,6 +104,20 @@ def test_current_manifest_reads_the_sidecar_and_warns_about_nothing(
     assert result is not None
     assert set(result.white_db) == {"sidecar.example"}
     assert RETIRED_KEY_WARNING not in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [["popularcdn.com", 42], "popularcdn.com", {"popularcdn.com": True}],
+    ids=["non-string-entry", "bare-string", "object"],
+)
+def test_malformed_legacy_top1m_list_still_fails_the_generation(tmp_path: Path, malformed: object) -> None:
+    """Tolerating the retired key does not tolerate a corrupt one: the ``list[str]``
+    shape contract of the sibling config lists still governs it, and a violation is a
+    generation failure, not a silently ignored field."""
+    manifest = _manifest(tmp_path, top1m_enabled=True, top1m_list=malformed)
+
+    assert P.dnsbl_build_from_manifest(manifest) is None
 
 
 def test_legacy_manifest_prefers_its_own_inline_list_over_a_stray_sidecar(tmp_path: Path) -> None:

--- a/tests/test_issue1841_legacy_manifest_top1m.py
+++ b/tests/test_issue1841_legacy_manifest_top1m.py
@@ -50,8 +50,11 @@ def _manifest(
     return str(path)
 
 
-def test_legacy_manifest_with_top1m_disabled_still_builds_its_feeds(tmp_path: Path) -> None:
-    """The retired key alone no longer costs the box its feed data."""
+def test_legacy_manifest_with_top1m_disabled_still_builds_its_feeds(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The retired key alone no longer costs the box its feed data, and the warning
+    says the list was ignored rather than claiming a TOP1M load that never happened."""
     manifest = _manifest(tmp_path, top1m_enabled=False, top1m_list=["popularcdn.com"])
 
     result = P.dnsbl_build_from_manifest(manifest)
@@ -59,6 +62,9 @@ def test_legacy_manifest_with_top1m_disabled_still_builds_its_feeds(tmp_path: Pa
     assert result is not None, "retired config.top1m_list still fails the whole generation"
     assert "blocked.example" in result.data_db
     assert result.white_db == {}, "TOP1M is off -- the retired list must not whitelist anything"
+    warning = capsys.readouterr().err
+    assert RETIRED_KEY_WARNING in warning
+    assert "ignoring it (TOP1M is disabled)" in warning
 
 
 def test_legacy_manifest_with_top1m_enabled_keeps_its_top1m_whitelist(tmp_path: Path) -> None:
@@ -81,7 +87,9 @@ def test_legacy_manifest_warns_once_about_the_retired_key(tmp_path: Path, capsys
 
     assert P.dnsbl_build_from_manifest(manifest) is not None
 
-    assert capsys.readouterr().err.count(RETIRED_KEY_WARNING) == 1
+    warning = capsys.readouterr().err
+    assert warning.count(RETIRED_KEY_WARNING) == 1
+    assert "reading TOP1M from it" in warning
 
 
 def test_current_manifest_reads_the_sidecar_and_warns_about_nothing(


### PR DESCRIPTION
## Problem

Part of #1841. A box upgraded across the TOP1M externalisation (#1542 / PR #1565) keeps its pre-retirement `pfb_py_sources.json` until the next full update rewrites one. That manifest carries `config.top1m_list`, and the ADR-65 validator rejected the entire generation on the retired key:

```text
DNSBL manifest not loaded: Failed to build DNSBL structures from raw:
DNSBL manifest/v1 config.top1m_list is retired
```

The resolver then serves no DNSBL at all until a full sync succeeds — on the reported box that window never closed, because POST-INSTALL died next.

## Change

- The validator treats `top1m_list` like its sibling list fields (shape checked, `list[str]`) instead of failing the build on its presence.
- `dnsbl_build_from_manifest()` reads TOP1M from that inline list when it is present. A manifest of the retired vintage also predates the `pfb_py_top1m.txt` sidecar, so simply dropping the key would have moved the failure to `TOP1M sidecar unavailable` for every box with TOP1M enabled — the same DNSBL-down outcome. Reading the list the manifest itself ships keeps the box on exactly the DNSBL it had before the upgrade.
- A one-line warning names the retirement until the next full update rewrites the manifest. Producers (`pfb_unbound_python_sources()`) already never emit the key, so this is a legacy-read path only.

Precedence when both exist (only reachable after a downgrade): the manifest's own inline list wins, since a manifest and its TOP1M snapshot are published together.

## Tests

New `tests/test_issue1841_legacy_manifest_top1m.py` pins: legacy manifest with TOP1M off still builds its feeds; with TOP1M on, the inline list becomes the whitelist; the warning is emitted exactly once; a current manifest keeps the sidecar contract and warns about nothing; the inline list wins over a stray sidecar.

Red→green proof, re-executed mechanically:

```text
FREEZE-OK: tests/test_issue1841_legacy_manifest_top1m.py
RED-OK: test fails against HEAD~1 src
GREEN-OK: test passes against HEAD
VERDICT: PASS
```

`scripts/agent/run-gates.sh`: `python3 -m pytest`, `ruff check .`, `ruff format --check .`, `mypy tests/` — all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with older DNS blocklist manifests that include the retired TOP1M list setting.
  - Legacy manifests now continue generating feeds instead of failing validation.
  - When TOP1M filtering is enabled, the preserved list from an older manifest is used correctly, including when no separate list is available.
  - Disabled TOP1M filtering remains unaffected.
  - Added a clear warning when the retired setting is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->