### PR TITLE
pfblockerng: pin the real legacy TOP1M vintage on the inline path (#1841)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5050,7 +5050,9 @@ def build(
     ``config`` carries the classification + whitelist inputs (``tld_wildcard_master``
     suffix lines, ``tld_wildcard_blacklist``, ``tld_wildcard_exclusion``,
     ``user_whitelist``, ``user_unlock``). TOP1M is streamed from the fixed
-    ``pfb_py_top1m.txt`` sidecar by ``dnsbl_build_from_manifest``.
+    ``pfb_py_top1m.txt`` sidecar by ``dnsbl_build_from_manifest``, except for a
+    pre-#1542 manifest that predates that sidecar and still carries the retired
+    ``config.top1m_list`` -- issue #1841 reads TOP1M from that inline list instead.
     ``line_reader`` yields the raw lines for a feed's ``raw`` reference -- injected so
     this stays pure and side-effect-free (no filesystem coupling, unit-testable; the
     init wiring supplies a file-backed reader).

--- a/tests/test_issue1841_legacy_manifest_top1m.py
+++ b/tests/test_issue1841_legacy_manifest_top1m.py
@@ -81,6 +81,30 @@ def test_legacy_manifest_with_top1m_enabled_keeps_its_top1m_whitelist(tmp_path: 
     assert result.white_db["popularcdn.com"]["important"] is True
 
 
+@pytest.mark.parametrize(
+    "comma_framed",
+    [".legacy.example,,", ",legacy.example,,", ",www.legacy.example,,"],
+    ids=["wildcard-record", "exact-record", "www-record"],
+)
+def test_real_legacy_vintage_records_build_and_whitelist_nothing(
+    tmp_path: Path, comma_framed: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The producer vintage that emitted ``top1m_list`` wrote comma-framed records, and
+    the consumer of that vintage stored them as exact keys no query could ever match.
+    Reading the inline list reproduces that inert whitelist rather than inventing
+    coverage: the generation builds, the retirement is announced, nothing is allowed --
+    the same outcome the sidecar path pins for these records
+    (test_issue1542_top1m_fixed_file.py::test_enabled_rejects_retired_comma_framed_top1m_lines)."""
+    manifest = _manifest(tmp_path, top1m_enabled=True, top1m_list=[comma_framed])
+
+    result = P.dnsbl_build_from_manifest(manifest)
+
+    assert result is not None, "a real legacy manifest must still load its feeds"
+    assert "blocked.example" in result.data_db
+    assert result.white_db == {}, f"retired TOP1M record became a whitelist key: {result.white_db!r}"
+    assert RETIRED_KEY_WARNING in capsys.readouterr().err
+
+
 def test_legacy_manifest_warns_once_about_the_retired_key(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """The tolerated retirement is operator-visible -- one warning, not silence."""
     manifest = _manifest(tmp_path, top1m_enabled=True, top1m_list=["popularcdn.com"])


### PR DESCRIPTION
## Why

Follow-up to #1894 (merged, `50c4a237`), handling the findings of the post-merge adversarial review of that PR. Part of #1841.

That review returned **0 blocking, 3 nitpick**. Verdicts:

1. **Applied** — `tests/test_issue1841_legacy_manifest_top1m.py`: the compatibility fixtures used bare-domain inline entries, a shape no `top1m_list`-emitting producer vintage ever wrote. That producer emitted comma-framed records (`.d,,`, `,d,,`, `,www.d,,`) and the consumer of the same vintage stored them as exact keys no query could match, so a real legacy manifest builds and warns but whitelists nothing. That outcome is now pinned on the inline path. No production behaviour changes — the outcome was already correct, just untested.
2. **Applied** — `build()`'s docstring still said TOP1M is streamed from the `pfb_py_top1m.txt` sidecar, which is now true only for post-#1542 manifests. It names the inline exception.
3. **Skipped (reason)** — the warning says "reading TOP1M from it" even when every inline record is normalise-rejected. The same silence exists on the sidecar path: `_dnsbl_normalise_whitelist()` drops `normalise()`-rejected entries untallied for both sources, and `build()`'s reject tally is scoped to the ABP/plain parse paths by design. Fixing it only on the legacy path would make the two sources disagree for no operator benefit; the real fix is an admission count across both, worth doing if it ever bites.

## Tests

`tests/test_issue1841_legacy_manifest_top1m.py` gains three parametrized cases (wildcard / exact / www record). Behaviour-preserving pin, so it is green across the change by design — its failable assertion is `white_db == {}`, which fails the moment a retired comma-framed record becomes a whitelist key.

Scope of what that adds, measured by mutation rather than asserted: the `wildcard-record` case is the one that catches a bug no pre-existing test does — a naive comma-salvage in the legacy branch (`d.split(",")[0].lstrip(".")`) leaks `legacy.example` into `white_db` and only this case fails. The `exact-record` and `www-record` cases are failable but redundant: every mutation that trips them also trips a pre-existing test. They stay because they document all three legacy record shapes, not because they add unique coverage.

`scripts/agent/run-gates.sh`: `python3 -m pytest`, `ruff check .`, `ruff format --check .`, `mypy tests/` — all PASS. Delta-scoped adversarial review of this PR (`50c4a237..c735fddd`): SOUND, 0 blocking, 1 nitpick — the overstated "mirrors the sidecar-side pin" framing, corrected in this body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
