### PR TITLE
pfblockerng: type the Reputation toggle mirrors as PfbToggle

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -70,6 +70,13 @@ exclusions.
     adapter set moves all its consumers in the same commit (see below).
   - **`pfb_cache_flush` → `PfbToggle`**: default Off; enables the post-handshake full Unbound
     cache flush for bulk zero-downtime DNSBL data swaps.
+  - **`enable_rep`/`enable_pdup`/`enable_dedup` → `PfbToggle`** (issue #1896, the Reputation
+    "Max"/"pMax"/"dMax" toggles): default Off. The section
+    (`pfblockerngreputation/config/0`) also holds unregistered scalars (`p24_*_var`,
+    `ccwhite`/`ccblack`/`ccexclude`, `et_header`/`etblock`/`etmatch`) — only these three
+    toggles are registered; the whole-section read/write routes through
+    `PfbConfig::readSection()`/`writeSection()` so the three normalise while the rest pass
+    through byte-identical.
   - **`pfb_alias_delta_mode` → `PfbAliasDeltaMode`** (ADR-40, registry adapters
     `pfb_cfg_alias_delta_mode_read/write`): tokens `'auto'` (new-install default) / `'delta'` /
     `'replace'`. Unknown or absent token reads as `Auto`. **Grandfather seed:** an already-configured
@@ -206,7 +213,6 @@ registered path set). Each annotation is committed in the relevant source file.
 | `pfblockerngglobal` (section-level) | Dynamic feed-key section |
 | `pfblockerng_wizard/*` | Wizard temp section, entirely foreign |
 | `installedpackages` (bulk blob) | Bulk wizard init write, foreign structure |
-| `pfblockerngreputation/config/0` | Static display section, no registered keys |
 | `pfblockerng{continent}/config/0` | Dynamic per-continent structure |
 | `pfblockerngdnsblsettings/config/0/dnsbl_webpage` | Out-of-scope foreign key (ADR-29 §2.5); written directly by `pfblockerng_dnsbl.php`, read via `pfb_dnsbl_webpage()` (issue #713 removed the never-written `dnsblwebpage` registry mis-spelling) |
 | `pfblockerngdnsbl` / `pfblockernglistsv4/v6` (section-level reads) | Dynamic list sections |

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -73,10 +73,11 @@ exclusions.
   - **`enable_rep`/`enable_pdup`/`enable_dedup` → `PfbToggle`** (issue #1896, the Reputation
     "Max"/"pMax"/"dMax" toggles): default Off. The section
     (`pfblockerngreputation/config/0`) also holds unregistered scalars (`p24_*_var`,
-    `ccwhite`/`ccblack`/`ccexclude`, `et_header`/`etblock`/`etmatch`) — only these three
-    toggles are registered; the whole-section read/write routes through
-    `PfbConfig::readSection()`/`writeSection()` so the three normalise while the rest pass
-    through byte-identical.
+    `ccwhite`/`ccblack`/`ccexclude`, `et_update`, `et_header`/`etblock`/`etmatch`) — only
+    these three toggles are registered; the Reputation settings page's read/write routes
+    through `PfbConfig::readSection()`/`writeSection()` so the three normalise while the
+    rest pass through byte-identical (direct section-level reads elsewhere stay legal —
+    the sniff gates exact key paths only).
   - **`pfb_alias_delta_mode` → `PfbAliasDeltaMode`** (ADR-40, registry adapters
     `pfb_cfg_alias_delta_mode_read/write`): tokens `'auto'` (new-install default) / `'delta'` /
     `'replace'`. Unknown or absent token reads as `Auto`. **Grandfather seed:** an already-configured

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6023,8 +6023,8 @@ function pfb_ip_preprocess_args(bool $dup_on, bool $agg_on, bool $rep_on): strin
  *                          placeholder refill from the closing pass is never truncated away.
  * @param bool $rep_trigger dRep/pRep's shared "changes found" gate: $pfb['repcheck'] &&
  *                          !$pfb['save'] && $pfb['enable'] === PfbToggle::On.
- * @param bool $drep_on     $pfb['drep'] == 'on'.
- * @param bool $prep_on     $pfb['prep'] == 'on'.
+ * @param bool $drep_on     $pfb['drep'] === PfbToggle::On.
+ * @param bool $prep_on     $pfb['prep'] === PfbToggle::On.
  * @return array{invoke_v4:bool,invoke_v6:bool,dedup:string,repmode:string,legacy_pmax_followup:bool}
  */
 function pfb_ip_recompute_matrix(bool $dedup_on, bool $rep_trigger, bool $drep_on, bool $prep_on): array {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -525,9 +525,6 @@ function sync_package_pfblockerng($cron='') {
 
 	// Validate pfB Script variables
 	foreach (array(
-			'enable_rep'		=> 'rep',					// Enable/Disable 'Max' Reputation
-			'enable_pdup'		=> 'prep',					// Enable/Disable 'pRep' Reputation
-			'enable_dedup'		=> 'drep',					// Enable/Disable 'dRep' Reputation
 			'et_update'		=> 'etupdate',					// Perform a Force Update on ET categories
 			'ccwhite'		=> 'ccwhite',					// Action for whitelist Country category
 			'ccblack'		=> 'ccblack',					// Action for blacklist Country category
@@ -546,6 +543,14 @@ function sync_package_pfblockerng($cron='') {
 			$pfb[$pfb_value] = $pfb_variable;
 		}
 	}
+
+	// issue #1896: registered toggle mirrors -- typed PfbToggle via the gateway, not the
+	// loop's raw-string-or-'x' shape above (that placeholder exists for the numeric/CSV
+	// fields' shell-arg positional integrity; a toggle already has a well-formed enum for
+	// every input, so it never needs it).
+	$pfb['rep']	= PfbConfig::read('enable_rep');	// Enable/Disable 'Max' Reputation
+	$pfb['prep']	= PfbConfig::read('enable_pdup');	// Enable/Disable 'pRep' Reputation
+	$pfb['drep']	= PfbConfig::read('enable_dedup');	// Enable/Disable 'dRep' Reputation
 
 	// Starting variable to skip Reputation functions, if no changes are required
 	$pfb['repcheck'] = FALSE;
@@ -3441,9 +3446,12 @@ function sync_package_pfblockerng($cron='') {
 
 								// Call 'shell script' functions (Deny Actions only)
 								if ($pfbadv && $list['vtype'] == '_v4') {
-									$args = pfb_ip_preprocess_args($pfb['dup'] === PfbToggle::On, $pfb['agg'] === PfbToggle::On, $pfb['rep'] == 'on');
+									$args = pfb_ip_preprocess_args($pfb['dup'] === PfbToggle::On, $pfb['agg'] === PfbToggle::On, $pfb['rep'] === PfbToggle::On);
 									if (!empty($args)) {
-										exec("{$pfb['script']} {$args} {$header_esc} {$pfb['max']} {$pfb['drep']} {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} {$elog}");
+										// issue #1896: boundary conversion -- the shell script reads this
+										// positional token raw ('on'/'off'), never the enum itself.
+										$pfb_drep_token = $pfb['drep']->toStored();
+										exec("{$pfb['script']} {$args} {$header_esc} {$pfb['max']} {$pfb_drep_token} {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} {$elog}");
 									}
 
 									// issue #1084: snapshot the pristine post-preprocessing feed for the
@@ -3533,7 +3541,7 @@ function sync_package_pfblockerng($cron='') {
 	// follows memberlist order, so compare against the last recompute's memberlist and
 	// recompute on mismatch.
 	if (!$pfb['save'] && $pfb['enable'] === PfbToggle::On &&
-	    pfb_cross_list_scope($pfb['dup'] === PfbToggle::On, $pfb['drep'] == 'on' || $pfb['prep'] == 'on')) {
+	    pfb_cross_list_scope($pfb['dup'] === PfbToggle::On, $pfb['drep'] === PfbToggle::On || $pfb['prep'] === PfbToggle::On)) {
 		foreach (array('v4', 'v6') as $pfb_rec_family) {
 			if ($pfb_rec_family === 'v6' && $pfb['dup'] !== PfbToggle::On) {
 				continue;
@@ -3557,8 +3565,8 @@ function sync_package_pfblockerng($cron='') {
 	$pfb_rec_matrix  = pfb_ip_recompute_matrix(
 		$pfb['dup'] === PfbToggle::On && $pfb_rec_trigger,
 		$pfb_rec_trigger,
-		$pfb['drep'] == 'on',
-		$pfb['prep'] == 'on'
+		$pfb['drep'] === PfbToggle::On,
+		$pfb['prep'] === PfbToggle::On
 	);
 
 	// issue #1084 review: whether the recompute exec actually ran THIS pass, per family --
@@ -3627,7 +3635,7 @@ function sync_package_pfblockerng($cron='') {
 	// Avoids redundant recomputation on every list iteration.
 	$pfb_cross_list  = pfb_cross_list_scope(
 		$pfb['dup'] === PfbToggle::On,
-		$pfb['drep'] == 'on' || $pfb['prep'] == 'on'
+		$pfb['drep'] === PfbToggle::On || $pfb['prep'] === PfbToggle::On
 	);
 	// $final_alias_old: feed-changed aliases only (for suppression gate).
 	// Uses $pfb_feed_changed (the pre-write-loop snapshot) — not $pfb_alias_lists

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -457,6 +457,11 @@ function pfb_cfg_registry(): array
 	// -----------------------------------------------------------------------
 	$ip = 'installedpackages/pfblockerngipsettings/config/0';
 
+	// -----------------------------------------------------------------------
+	// Section: installedpackages/pfblockerngreputation/config/0
+	// -----------------------------------------------------------------------
+	$rep = 'installedpackages/pfblockerngreputation/config/0';
+
 	$registry = [
 
 		// -------------------------------------------------------------------
@@ -1257,6 +1262,36 @@ function pfb_cfg_registry(): array
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
+		],
+
+		// -------------------------------------------------------------------
+		// Reputation section (pfblockerngreputation/config/0)
+		// -------------------------------------------------------------------
+
+		// issue #1896: 'Max' per-list Reputation toggle: 'on' | 'off' | ''. Default '' (off).
+		'enable_rep' => [
+			'section'       => $rep,
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+		],
+
+		// issue #1896: 'pMax' collective Reputation toggle (no Country Exclusion):
+		// 'on' | 'off' | ''. Default '' (off).
+		'enable_pdup' => [
+			'section'       => $rep,
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+		],
+
+		// issue #1896: 'dMax' collective Reputation toggle (Country Exclusion applied):
+		// 'on' | 'off' | ''. Default '' (off).
+		'enable_dedup' => [
+			'section'       => $rep,
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 	];
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
@@ -835,7 +835,7 @@ require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 global $pfb;
 pfb_global();
 
-$pfb['repconfig'] = config_get_path('installedpackages/pfblockerngreputation/config/0', []);
+$pfb['repconfig'] = PfbConfig::readSection('installedpackages/pfblockerngreputation/config/0');
 
 $pconfig = array();
 $pconfig['enable_rep']		= $pfb['repconfig']['enable_rep'];
@@ -984,7 +984,7 @@ if ($_POST) {
 			// Set flag to update ET IQRisk on next Cron|Force update|Force reload
 			$pfb['repconfig']['et_update']	= 'enabled';
 
-			config_set_path('installedpackages/pfblockerngreputation/config/0', $pfb['repconfig']);
+			PfbConfig::writeSection('installedpackages/pfblockerngreputation/config/0', $pfb['repconfig']);
 			write_config('[pfBlockerNG] save Reputation settings');
 			pfb_mark_pending_changes();	// applies on the next Update, not on save
 			header('Location: /pfblockerng/pfblockerng_reputation.php');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -293,7 +293,7 @@ if (is_dir($pfb['matchdir'])) {
 	$pfb_deny_headers  = $pfb_headers['deny'];
 	$pfb_match_headers = $pfb_headers['match'];
 	$pfb_list_rows     = $pfb_headers['rows'];
-	$pfb_rep_config = config_get_path('installedpackages/pfblockerngreputation/config/0', []); // foreign key — out of ADR-29 gateway scope, static display section (no registered keys)
+	$pfb_rep_config = config_get_path('installedpackages/pfblockerngreputation/config/0', []); // section-level read (ccwhite is unregistered); issue #1896 registered the section's three Reputation toggles per-key, this whole-section read stays direct
 
 	$pfb_matchdir_listing = array();
 	foreach (glob("{$pfb['matchdir']}/*.txt") ?: [] as $pfb_f) {

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -1204,6 +1204,11 @@ final class CfgGatewayTest extends TestCase
 			'v4suppression',
 			'v6suppression',
 
+			// pfblockerngreputation/config/0 scalars (issue #1896)
+			'enable_rep',
+			'enable_pdup',
+			'enable_dedup',
+
 			// Out-of-scope keys (must also appear in $out_of_scope above)
 			'pfb_wizard_skip',
 			'hooks',
@@ -2625,6 +2630,45 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('lo0', $result['dnsbl_interface'], 'unadapted dnsbl_interface is byte-identical');
 		$this->assertSame('', $result['pfb_dnsvip4'], 'unadapted pfb_dnsvip4 is byte-identical');
 		$this->assertSame('QWJjMTIz', $result['top1m_token'], 'unadapted top1m_token is byte-identical');
+	}
+
+	/**
+	 * issue #1896: a realistic Reputation save blob (mirrors
+	 * pfblockerng_geoip.inc's Reputation save handler) mixing the three newly
+	 * registered toggles with unadapted plain fields. The unchecked toggle
+	 * ('') normalises to the canonical 'off' token; every unadapted field
+	 * (p24_dmax_var, et_header, ccexclude) is byte-identical.
+	 *
+	 * Scenario:
+	 *   Given a Reputation section blob with enable_rep checked ('on'),
+	 *     enable_pdup/enable_dedup unchecked (''), and unadapted plain fields.
+	 *   When PfbConfig::writeSection() persists it.
+	 *   Then enable_rep stays 'on', enable_pdup/enable_dedup normalise to
+	 *     'off', and every unadapted field is byte-identical to the input.
+	 */
+	public function testWriteSectionReputationBlobNormalisesAdaptedFieldsOnly(): void
+	{
+		$section = 'installedpackages/pfblockerngreputation/config/0';
+
+		$data = [
+			'enable_rep'    => 'on',     // adapted (toggle), canonical.
+			'enable_pdup'   => '',       // adapted (toggle), unchecked -> normalises to 'off'.
+			'enable_dedup'  => '',       // adapted (toggle), unchecked -> normalises to 'off'.
+			'p24_dmax_var'  => '5',      // unadapted, plain.
+			'et_header'     => '',       // unadapted, plain.
+			'ccexclude'     => 'US,CA',  // unadapted, plain.
+		];
+
+		PfbConfig::writeSection($section, $data);
+
+		$result = PfbConfig::readSection($section);
+
+		$this->assertSame('on', $result['enable_rep'], 'enable_rep canonical stays on');
+		$this->assertSame('off', $result['enable_pdup'], "unchecked enable_pdup ('') normalises to 'off'");
+		$this->assertSame('off', $result['enable_dedup'], "unchecked enable_dedup ('') normalises to 'off'");
+		$this->assertSame('5', $result['p24_dmax_var'], 'unadapted p24_dmax_var is byte-identical');
+		$this->assertSame('', $result['et_header'], 'unadapted et_header is byte-identical');
+		$this->assertSame('US,CA', $result['ccexclude'], 'unadapted ccexclude is byte-identical');
 	}
 
 	/**

--- a/tests/php/IpRecomputeOrderChangeTest.php
+++ b/tests/php/IpRecomputeOrderChangeTest.php
@@ -178,7 +178,7 @@ final class IpRecomputeOrderChangeTest extends TestCase
 	{
 		$needle = <<<'EOT'
 	if (!$pfb['save'] && $pfb['enable'] === PfbToggle::On &&
-	    pfb_cross_list_scope($pfb['dup'] === PfbToggle::On, $pfb['drep'] == 'on' || $pfb['prep'] == 'on')) {
+	    pfb_cross_list_scope($pfb['dup'] === PfbToggle::On, $pfb['drep'] === PfbToggle::On || $pfb['prep'] === PfbToggle::On)) {
 EOT;
 		$this->assertStringContainsString(
 			$needle,

--- a/tests/php/ToggleMirrorComparisonGuardTest.php
+++ b/tests/php/ToggleMirrorComparisonGuardTest.php
@@ -35,6 +35,7 @@ final class ToggleMirrorComparisonGuardTest extends TestCase
 		'dnsbl_cname', 'dnsbl_tld_allow', 'dnsbl_py_nolog', 'dnsbl_noaaaa', 'dnsbl_gp',
 		'float', 'dup', 'agg', 'global_log', 'dnsbl_control', 'dnsbl_control_legacy',
 		'dnsbl_idn_block_malicious', 'dnsbl_idn_escalate_suspicious',
+		'rep', 'prep', 'drep',
 	];
 
 	public function testNoTypedMirrorIsComparedAgainstAStringToken(): void
@@ -45,9 +46,7 @@ final class ToggleMirrorComparisonGuardTest extends TestCase
 		// missed. Comparisons against PfbToggle::* do not match: the token there is
 		// not quoted.
 		// Interstitial tolerance is deliberately narrow: an optional `?? <fallback>`
-		// plus closing parens — the shapes the fixed regexes actually missed. A wider
-		// [^;]*? scan bled across to the SAME LINE's untyped rep/drep/prep compares
-		// (#1896), which are legitimate string comparisons.
+		// plus closing parens — the shapes the fixed regexes actually missed.
 		$coalesce = '(?:\s*\?\?\s*(?:\'[a-z]*\'|PfbToggle::\w+))?';
 		$pattern = '/' . $mirror . $coalesce . '\s*\)*\s*(?:===|!==|==|!=)\s*\'(?:on|off|)\'/';
 		// The reverse orientation ('on' == $pfb[...]) has no in-tree precedent but

--- a/tests/php/fixtures/geoip_pre_move_golden.json
+++ b/tests/php/fixtures/geoip_pre_move_golden.json
@@ -39,7 +39,8 @@
     "pfblockerng_Proxy_and_Satellite.php": "d7469e2355203eaa46c090127551b36883735800328f19cc6a617eeb568d52b1",
     "pfblockerng_Top_Spammers.php": "9802ff70600cfbf74f8f38d3dc2f2fccc1d60b7c62cb9aa6371b7d3c97fd7a5d"
   },
-  "reputation_empty": "5a61a598cb8d1ac66db93a27e88338f7c28e627df9d3b606a8df7348a30c5984",
-  "reputation_populated": "7dced7a138426dc8dbef7fa5c8f1b740e1459d4ba79e4340b7b3683ed79a0266",
-  "continent_pages_amended": "issue #1845: the generated pages now carry the pfBlockerNG.js cache-buster; the pre-move template is otherwise unchanged"
+  "reputation_empty": "59a4fa81040c5691ddb1b13574dfe3669052530c0947535a74b30bb3af459b4e",
+  "reputation_populated": "dcfe541ef16a5c9c74e8692354351bd9a78b52a17f3f50ea9b1efde42b240568",
+  "continent_pages_amended": "issue #1845: the generated pages now carry the pfBlockerNG.js cache-buster; the pre-move template is otherwise unchanged",
+  "reputation_hashes_amended": "issue #1896: the Reputation section's config_get_path/config_set_path calls now route through PfbConfig::readSection()/writeSection(); the pre-move template is otherwise unchanged"
 }

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -172,6 +172,10 @@ class RequireConfigGatewaySniff implements Sniff
 		// ADR-53: installedpackages/pfblockerngipsettings/config/0 (IPv4/IPv6 suppression)
 		'installedpackages/pfblockerngipsettings/config/0/v4suppression',
 		'installedpackages/pfblockerngipsettings/config/0/v6suppression',
+		// issue #1896: installedpackages/pfblockerngreputation/config/0 (Reputation toggles)
+		'installedpackages/pfblockerngreputation/config/0/enable_rep',
+		'installedpackages/pfblockerngreputation/config/0/enable_pdup',
+		'installedpackages/pfblockerngreputation/config/0/enable_dedup',
 	];
 
 	/**

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -289,6 +289,21 @@ FLOWS: tuple[ToggleFlow, ...] = (
         # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
         off="off",
     ),
+    # ---- Reputation settings (installedpackages/pfblockerngreputation/config/0) -
+    # issue #1896: enable_dedup ("dMAX") joined the toggle-adapter registry
+    # alongside enable_rep/enable_pdup. The Reputation save only write_config()s +
+    # pfb_mark_pending_changes() (no reload, no egress), so it is as hermetic as
+    # the DNSBL group above; the save re-validates the page's select/multi-select
+    # fields (p24_*_var, ccwhite/ccblack, ccexclude/etblock/etmatch), which
+    # WebUI.post's re-scraped current-value POST satisfies without an override.
+    ToggleFlow(
+        name="reputation_dedup",
+        page="/pfblockerng/pfblockerng_reputation.php",
+        field="enable_dedup",
+        config_path="installedpackages/pfblockerngreputation/config/0/enable_dedup",
+        # issue #1896: toggle-adapter field — unchecked save stores the explicit 'off'.
+        off="off",
+    ),
 )
 
 


### PR DESCRIPTION
Fixes #1896

## What

Types the three reputation toggle mirrors — `$pfb['rep']`, `$pfb['prep']`, `$pfb['drep']` — as `PfbToggle`, completing the conversion #1887 deliberately deferred:

- `enable_rep` / `enable_pdup` / `enable_dedup` join `pfb_cfg_registry()` (section `installedpackages/pfblockerngreputation/config/0`, default `''`, toggle adapter pair) and the gateway-enforcement sniff.
- The three toggles leave the shared population loop in `sync_package_pfblockerng()` (the nine numeric/CSV/ET rows stay byte-identical, keeping the `'x'` placeholder they still need for shell positional integrity); the mirrors are now typed `PfbConfig::read()` results.
- Every consumer moves in the same commit: the five raw `== 'on'` comparisons become `=== PfbToggle::On`, and the `drep` shell boundary (positional arg 4 of `pfblockerng.sh`) emits `->toStored()` — `'on'`/`'off'`, never empty, so `ccexclude`/`ccwhite`/`ccblack` cannot shift.
- The Reputation save's section read/write routes through `PfbConfig::readSection()` / `writeSection()`, canonicalising the three toggles on save like every other adapter-bearing field.
- Docs: the section's foreign-key exclusion row is retired from `docs/misc/config-gateway.md`; stale comments/docblocks reconciled.

Behaviour-preserving except: an unchecked Reputation save now stores the explicit `'off'` token instead of `''` — equivalent, since `''` ≡ absent already resolves to the Off default at the gateway (#1887). `PFB_FILTER_ON_OFF` deliberately stays `{'on', ''}`: it guards the wire (browser checkboxes never send `'off'`), while canonicalisation lives in the write adapter — see the call-site sweep in the issue thread.

## Evidence

Investigation (posted in-thread on #1896): `'x'` is never persisted — the GUI save is the only writer of the three keys (vocabulary `{'on',''}` via `PFB_FILTER_ON_OFF`); `'x'` is runtime-only; only `drep` crosses the shell boundary and the script tests it exactly once against `'on'`.

Red→green (test-first, executed): `rep`/`prep`/`drep` added to `ToggleMirrorComparisonGuardTest::TYPED_MIRRORS` before any production edit — RED with 7 comparison offences (`pfblockerng_apply.inc` 3444/3536/3560/3561/3630 + two stale docblocks in `pfblockerng.inc`) and 1 string-context offence (the `exec` interpolation at 3446); GREEN after the conversion with the test file frozen byte-identical (`git hash-object` `baf31920…` at red and green). Independently re-executed by the verifier via `scripts/agent/verify-red-proof.sh` (`FREEZE-OK` / `RED-OK` / `GREEN-OK` / `VERDICT: PASS`).

Tests shipped: `CfgGatewayTest` inventory + a targeted `writeSection` reputation-blob test (toggles canonicalise `''`→`'off'`, foreign keys byte-identical); the registry-iterating property tests auto-cover the three new adapter-bearing fields; `IpRecomputeOrderChangeTest` source tripwire updated; the `geoip_pre_move_golden.json` reputation hashes re-blessed (generated-page delta is exactly the two gateway lines — nowdoc-structural proof); a Tier-B `reputation_dedup` ToggleFlow added for the Reputation page (live-VM dispatch post-merge, not PR-gating).

Gates: full `run-gates.sh --diff origin/devel` PASS (phpunit 4566 tests, phpstan, phpcs, pytest collection, ruff, mypy, markdownlint) — run by the implementer and re-derived independently by the verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Reputation settings so enabled, disabled, duplicate, and deduplication options are interpreted consistently.
  - Corrected Reputation-related processing and list recomputation when these options are changed.
  - Ensured disabled options are stored explicitly as “off” and enabled options retain their active state.

- **Tests**
  - Added coverage for Reputation setting persistence and toggle normalization.
  - Updated validation for Reputation configuration and processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->