### PR TITLE
pfblockerng: per-field write_priv authorization in PfbConfig; writeSystem escape for system contexts

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -46,9 +46,20 @@ Authorization is a property of the **write**, not the call site (the
   `RequireConfigGatewaySniff` (`SystemWriteInWww`) refuses the `*System()` variants in
   any file under `src/usr/local/www/`.
 - `delete()` / `deleteSection()` carry no privilege check (out of #1895's scope).
+- **`writeSection()`'s gate is delta-aware** (issue #1895 addendum, found reviewing the
+  composition against `pfblockerng_general.php`'s whole-section readSection → modify one
+  field → writeSection() save): a registered field present in `$data` only asserts its
+  `write_priv` when its canonical incoming value differs from its canonical
+  currently-stored value (both sides run through the same read/write-adapter
+  round-trip); an unchanged read-modify-write pass-through (e.g. `pfb_software_check`
+  riding along untouched while the General page saves an unrelated field) is not an
+  authorization event and is silently skipped. `PfbConfig::write()` stays **strict** — an
+  explicit single-key write is always an authorization event, changed or not, since there
+  is no read-modify-write section saver behind it.
 - Coverage: `tests/php/CfgWriteAuthorizationTest.php` (deny/allow per entry point, the
   per-field override, the priv.inc-loaded CLI-trap regression, write/writeSystem
-  parity) + the sniff fixtures in `tests/php/RequireConfigGatewaySniffTest.php`.
+  parity, the delta-aware pass-through/real-change/absent-vs-default rows) + the sniff
+  fixtures in `tests/php/RequireConfigGatewaySniffTest.php`.
 
 ## Storage adapter rule (ADR-28 §2.2)
 

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -22,6 +22,34 @@ exclusions.
 - **No `write_config()` inside the gateway** — the caller decides when to flush. The registry
   (`pfb_cfg_registry()`) is read-only after boot.
 
+## Write authorization (issue #1895)
+
+Authorization is a property of the **write**, not the call site (the
+`pfblockerng_hook_edit.inc` GATE 1 precedent generalised):
+
+- Every registry entry may carry an optional `write_priv` — the page whose privilege the
+  write re-asserts via `isAllowedPage()`. Absent means `PfbConfig::WRITE_PRIV_DEFAULT`
+  (`pfblockerng/pfblockerng_general.php`, the package page — pfSense grants all
+  pfBlockerNG pages through one privilege entry, so finer per-page defaults would be
+  meaningless). The only explicit override: `pfb_software_check` →
+  `pkg_mgr_installed.php` (the #485 Software-page secondary gate).
+- `PfbConfig::write()` / `writeSection()` enforce it **fail-closed**: an undefined
+  `isAllowedPage()` (no web session — `priv.inc` is only in the web auth include chain)
+  or a FALSE return throws `RuntimeException`. `writeSection()` checks every registered
+  field of the section present in `$data` before any mutation. The loud throw is
+  deliberate: the silent-FALSE alternative is exactly the CLI trap #1895 documents.
+- `PfbConfig::writeSystem()` / `writeSectionSystem()` skip the check — the sanctioned
+  path for cron, the install/deinstall hooks, migrations, CLI, and pfSense-core hooks
+  (`pfb_alias_rename_followup()` runs from the `firewall_aliases_edit` pre-write hook
+  under a firewall-alias-only privilege, so enforcement there would break a supported
+  path). The bypass is visible at the call site and mechanically confined:
+  `RequireConfigGatewaySniff` (`SystemWriteInWww`) refuses the `*System()` variants in
+  any file under `src/usr/local/www/`.
+- `delete()` / `deleteSection()` carry no privilege check (out of #1895's scope).
+- Coverage: `tests/php/CfgWriteAuthorizationTest.php` (deny/allow per entry point, the
+  per-field override, the priv.inc-loaded CLI-trap regression, write/writeSystem
+  parity) + the sniff fixtures in `tests/php/RequireConfigGatewaySniffTest.php`.
+
 ## Storage adapter rule (ADR-28 §2.2)
 
 - **Storage is NOT frozen — forward-upgrade compatible where practical, not byte-for-byte.**
@@ -128,6 +156,8 @@ exclusions.
    string), so every consumer of that field moves in the same commit — a stale string
    comparison against the enum fails silently in the always-false direction (issue #1887).
 2. Verify round-trip: `write(read(v)) == v` for every canonical stored vocabulary value.
+   When the field's owning page carries a secondary privilege gate (like the Software
+   page), set `write_priv` on the entry (see "Write authorization" above).
 3. Add a test in `tests/php/CfgGatewayTest.php` (round-trip + default-absent cases).
 4. Update the `$inventory` in `testInventoryCompletenessAllKnownKeysAccountedFor()`.
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -4255,7 +4255,9 @@ function sync_package_pfblockerng($cron='') {
 		// discarded by it; a single registered-key write needs no whole-config
 		// array_replace_recursive() merge. ADR-29: registered key -> PfbConfig.
 		config_read_file(FALSE, TRUE);
-		PfbConfig::write('pfb_reuse', PfbToggle::Off);
+		// issue #1895: this update-apply pass runs with no web session in scope, so the
+		// registered-field write asserts as a system caller, not a page privilege.
+		PfbConfig::writeSystem('pfb_reuse', PfbToggle::Off);
 		write_config('pfBlockerNG: save settings');
 
 		pfb_logger("... completed", 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -428,7 +428,11 @@ function pfb_cfg_top1m_source_write(PfbTop1mSource|string $source): string
  * Write adapter: callable(<enum|string> $value): string — runtime value -> stored string.
  * null adapter = plain string (identity; no conversion).
  *
- * @return array<string,array{section:string,default:string,read_adapter:callable|null,write_adapter:callable|null}>
+ * Optional 'write_priv': overrides PfbConfig::WRITE_PRIV_DEFAULT for this field's
+ * write-authorization check (issue #1895). Absent for every entry except
+ * 'pfb_software_check' (the #485 Software-page secondary gate).
+ *
+ * @return array<string,array{section:string,default:string,read_adapter:callable|null,write_adapter:callable|null,write_priv?:string}>
  */
 function pfb_cfg_registry(): array
 {
@@ -651,6 +655,9 @@ function pfb_cfg_registry(): array
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
+			// issue #1895: the #485 Software-page secondary gate -- this field's write
+			// authorization is 'pkg_mgr_installed.php', not the package's own general page.
+			'write_priv'    => 'pkg_mgr_installed.php',
 		],
 
 		// Internal-address feed-host filter toggle: 'on'|'off'. Default 'on' (new install).
@@ -1319,18 +1326,35 @@ function pfb_dnsbl_webpage(): string
  *
  * API:
  *   PfbConfig::read($key)                          — read one field
- *   PfbConfig::write($key, $value)                 — write one field
+ *   PfbConfig::write($key, $value)                 — write one field, gated by the
+ *                                                     field's write_priv (issue #1895)
  *   PfbConfig::delete($key)                        — delete one field
  *   PfbConfig::readSection($section)               — read a whole section array
  *   PfbConfig::writeSection($section, $data)       — write a section array, normalising
  *                                                     its registered fields through their
- *                                                     adapters (issue #930)
+ *                                                     adapters (issue #930), gated the same
+ *                                                     as write() per registered field
  *   PfbConfig::deleteSection($section)             — delete a whole section
+ *   PfbConfig::writeSystem($key, $value)           — write one field with NO privilege
+ *                                                     check, for no-session system callers
+ *                                                     (cron/install/migrations/CLI/core
+ *                                                     hooks; issue #1895)
+ *   PfbConfig::writeSectionSystem($section, $data) — writeSection() with NO privilege check,
+ *                                                     same system-caller contract
+ *
+ * Authorization model (issue #1895): write()/writeSection() enforce a per-field page
+ * privilege via isAllowedPage(), fail-closed when that check is undefined or false --
+ * a system-context caller with no web session must say so explicitly via the
+ * writeSystem()/writeSectionSystem() escape hatch, never rely on a silent pass.
  *
  * @see pfb_cfg_registry()
  */
 final class PfbConfig
 {
+	// issue #1895: the package's own general-settings page -- the default write-authorization
+	// page privilege for every registered field that does not declare its own 'write_priv'.
+	private const WRITE_PRIV_DEFAULT = 'pfblockerng/pfblockerng_general.php';
+
 	/**
 	 * Read a single registered field.
 	 *
@@ -1358,18 +1382,37 @@ final class PfbConfig
 	 * stored string) before calling config_set_path. Does NOT call
 	 * write_config() — callers must persist when appropriate.
 	 *
+	 * Enforces the field's write_priv page privilege (issue #1895) — a no-session
+	 * system caller (cron/install/migrations/CLI/core hooks) must use writeSystem().
+	 *
+	 * @param  string $key   The exact config.xml field key.
+	 * @param  mixed  $value Runtime value (enum or string).
+	 * @throws InvalidArgumentException When $key is not in the registry.
+	 * @throws RuntimeException         When the caller lacks the field's write_priv.
+	 */
+	public static function write(string $key, mixed $value): void
+	{
+		$entry = self::entry($key);
+		self::assertWriteAllowed($key, $entry);
+		self::writeRaw($key, $value);
+	}
+
+	/**
+	 * Write a single registered field with NO privilege check.
+	 *
+	 * For system-context callers with no web session -- cron, the installer,
+	 * migrations, CLI tooling, pfSense-core hooks (issue #1895). isAllowedPage()
+	 * is unreachable/meaningless in those contexts, so write() would fail-closed
+	 * on them; this is the explicit escape hatch for that legitimate case. Never
+	 * callable from src/usr/local/www/ (enforced by RequireConfigGatewaySniff).
+	 *
 	 * @param  string $key   The exact config.xml field key.
 	 * @param  mixed  $value Runtime value (enum or string).
 	 * @throws InvalidArgumentException When $key is not in the registry.
 	 */
-	public static function write(string $key, mixed $value): void
+	public static function writeSystem(string $key, mixed $value): void
 	{
-		$entry   = self::entry($key);
-		$path    = $entry['section'] . '/' . $key;
-		$adapter = $entry['write_adapter'];
-		$value   = self::notConfigured($entry, $value);
-		$stored  = ($adapter !== NULL) ? $adapter($value) : (string) $value;
-		config_set_path($path, $stored);
+		self::writeRaw($key, $value);
 	}
 
 	/**
@@ -1432,6 +1475,74 @@ final class PfbConfig
 	 */
 	public static function writeSection(string $section, array $data): void
 	{
+		// ALL privilege checks run BEFORE any mutation (issue #1895): a section blob can
+		// carry several registered fields with different write_priv values, and a later
+		// field failing its check must never leave an earlier field's config_set_path
+		// already applied. Registered fields only -- a key registered to a DIFFERENT
+		// section, or not registered at all, is foreign data and carries no gate here.
+		foreach (pfb_cfg_registry() as $key => $entry) {
+			if ($entry['section'] !== $section || !array_key_exists($key, $data)) {
+				continue;
+			}
+			self::assertWriteAllowed($key, $entry);
+		}
+		self::writeSectionRaw($section, $data);
+	}
+
+	/**
+	 * writeSection() with NO privilege check — see writeSystem() for the contract.
+	 *
+	 * @param string $section  The full config.xml section path.
+	 * @param array  $data     Section data to persist.
+	 */
+	public static function writeSectionSystem(string $section, array $data): void
+	{
+		self::writeSectionRaw($section, $data);
+	}
+
+	/**
+	 * Delete a whole section (e.g. during package removal / wipe).
+	 *
+	 * Equivalent to config_del_path($section).
+	 *
+	 * @param string $section  The full config.xml section path.
+	 */
+	public static function deleteSection(string $section): void
+	{
+		config_del_path($section);
+	}
+
+	// -----------------------------------------------------------------------
+	// Private helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * write() body proper, with NO privilege check — shared by write() and
+	 * writeSystem() (issue #1895).
+	 *
+	 * @param  string $key   The exact config.xml field key.
+	 * @param  mixed  $value Runtime value (enum or string).
+	 * @throws InvalidArgumentException When $key is not in the registry.
+	 */
+	private static function writeRaw(string $key, mixed $value): void
+	{
+		$entry   = self::entry($key);
+		$path    = $entry['section'] . '/' . $key;
+		$adapter = $entry['write_adapter'];
+		$value   = self::notConfigured($entry, $value);
+		$stored  = ($adapter !== NULL) ? $adapter($value) : (string) $value;
+		config_set_path($path, $stored);
+	}
+
+	/**
+	 * writeSection() body proper, with NO privilege check — shared by writeSection()
+	 * and writeSectionSystem() (issue #1895).
+	 *
+	 * @param string $section  The full config.xml section path.
+	 * @param array  $data     Section data to persist.
+	 */
+	private static function writeSectionRaw(string $section, array $data): void
+	{
 		foreach (pfb_cfg_registry() as $key => $entry) {
 			if ($entry['section'] !== $section) {
 				continue;
@@ -1450,20 +1561,40 @@ final class PfbConfig
 	}
 
 	/**
-	 * Delete a whole section (e.g. during package removal / wipe).
+	 * Enforce the field's write_priv page privilege (issue #1895).
 	 *
-	 * Equivalent to config_del_path($section).
+	 * Authorization is a property of the WRITE, not the call site: this class is
+	 * pulled into essentially every page of the package (and several core hooks)
+	 * through pfblockerng_extra.inc, so any code with the include in scope can reach
+	 * a registered-field write. A page's own isAllowedPage() gate protects only that
+	 * page's request path -- nothing stops a future caller elsewhere from invoking
+	 * the writer with no gate at all. Re-asserting the privilege here makes it a
+	 * property of the write itself.
 	 *
-	 * @param string $section  The full config.xml section path.
+	 * Fails CLOSED when isAllowedPage() is undefined or returns FALSE. priv.inc (the
+	 * function's home) is only ever loaded on the web auth include chain, so in a
+	 * no-session context (cron, install, migrations, CLI, a pfSense-core hook) the
+	 * function is simply absent; treating an undefined check the same as an explicit
+	 * refusal is deliberate -- a silent pass (or a silent no-op write) is exactly the
+	 * trap issue #1895 documents. A legitimate system-context caller must say so
+	 * explicitly, via PfbConfig::writeSystem()/writeSectionSystem().
+	 *
+	 * @param  string $key    The exact config.xml field key (named in the exception).
+	 * @param  array  $entry  The registry entry (consulted for its optional 'write_priv').
+	 * @throws RuntimeException When the caller lacks the field's required page privilege.
 	 */
-	public static function deleteSection(string $section): void
+	private static function assertWriteAllowed(string $key, array $entry): void
 	{
-		config_del_path($section);
+		$priv = $entry['write_priv'] ?? self::WRITE_PRIV_DEFAULT;
+		if (!function_exists('isAllowedPage') || !isAllowedPage($priv)) {
+			throw new RuntimeException(
+				"PfbConfig: write of key '{$key}' requires page privilege '{$priv}' "
+				. '(isAllowedPage() denied or undefined). System-context callers with no '
+				. 'web session (cron/install/migrations/CLI/core hooks) must use '
+				. 'PfbConfig::writeSystem()/writeSectionSystem() instead.'
+			);
+		}
 	}
-
-	// -----------------------------------------------------------------------
-	// Private helpers
-	// -----------------------------------------------------------------------
 
 	/**
 	 * Substitute the registered default for a "not configured" value (issue #1887).
@@ -1501,7 +1632,7 @@ final class PfbConfig
 	 * Look up a registry entry, throwing on an unregistered key.
 	 *
 	 * @param  string $key
-	 * @return array{section:string,default:string,read_adapter:callable|null,write_adapter:callable|null}
+	 * @return array{section:string,default:string,read_adapter:callable|null,write_adapter:callable|null,write_priv?:string}
 	 * @throws InvalidArgumentException
 	 */
 	private static function entry(string $key): array
@@ -1739,7 +1870,9 @@ function pfb_settings_family_record(string $family): bool
 		return FALSE;
 	}
 	try {
-		PfbConfig::write('settings_family', $family);
+		// issue #1895: called from install/migration/upgrade paths with no web session --
+		// a plain write() would silently fail-closed here and this catch would swallow it.
+		PfbConfig::writeSystem('settings_family', $family);
 		write_config('pfBlockerNG: record settings family');
 		return TRUE;
 	} catch (Throwable) {
@@ -1935,7 +2068,8 @@ function pfb_run_migrations(): void
 		$cfg    = PfbConfig::readSection($migration['section']);
 		$result = ($migration['apply'])($cfg);
 		if ($result !== NULL) {
-			PfbConfig::writeSection($migration['section'], $result);
+			// issue #1895: upgrade migrations run with no web session in scope.
+			PfbConfig::writeSectionSystem($migration['section'], $result);
 			write_config($migration['message']);
 		}
 	}
@@ -1995,7 +2129,11 @@ function pfb_alias_rename_followup(string $old_name, string $new_name): bool
 		}
 
 		if ($section_dirty) {
-			PfbConfig::writeSection($path, $rows);
+			// issue #1895: this function runs from pfSense's firewall_aliases_edit
+			// pre_write_config hook, gated only by the core firewall-alias privilege --
+			// never a pfBlockerNG page privilege -- so a plain writeSection() here would
+			// break that supported path. System-context write is correct, not a workaround.
+			PfbConfig::writeSectionSystem($path, $rows);
 		}
 	}
 
@@ -2036,7 +2174,7 @@ function pfb_alias_rename_followup(string $old_name, string $new_name): bool
 		}
 
 		if ($section_dirty) {
-			PfbConfig::writeSection($path, $cfg);
+			PfbConfig::writeSectionSystem($path, $cfg);
 		}
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1680,7 +1680,12 @@ final class PfbConfig
 	 *   - adapter-bearing field (both read_adapter and write_adapter set, always paired
 	 *     -- see pfb_cfg_registry()): write_adapter(read_adapter(notConfigured($value))),
 	 *     the same round trip writeSectionRaw()'s normalisation loop applies.
-	 *   - plain field: (string) notConfigured($value), matching writeRaw()'s cast.
+	 *   - plain scalar field: (string) notConfigured($value), matching writeRaw()'s cast.
+	 *   - plain NON-scalar (a crafted-POST array riding the section blob):
+	 *     writeSectionRaw() persists it verbatim, so it must compare by SHAPE -- a
+	 *     (string) cast would collapse every array to 'Array', making two different
+	 *     arrays read "unchanged" (skipping the privilege assert for a value that
+	 *     genuinely changes on disk) and emitting an Array-to-string warning.
 	 *
 	 * @param  array $entry  The registry entry.
 	 * @param  mixed $value  Raw stored value (from config_get_path()) or the incoming
@@ -1694,6 +1699,9 @@ final class PfbConfig
 		$write_adapter = $entry['write_adapter'];
 		if ($read_adapter !== NULL && $write_adapter !== NULL) {
 			return $write_adapter($read_adapter($value));
+		}
+		if (!is_scalar($value)) {
+			return 'nonscalar:' . md5(serialize($value));
 		}
 		return (string) $value;
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1332,8 +1332,12 @@ function pfb_dnsbl_webpage(): string
  *   PfbConfig::readSection($section)               — read a whole section array
  *   PfbConfig::writeSection($section, $data)       — write a section array, normalising
  *                                                     its registered fields through their
- *                                                     adapters (issue #930), gated the same
- *                                                     as write() per registered field
+ *                                                     adapters (issue #930), gated per
+ *                                                     registered field like write() --
+ *                                                     but DELTA-AWARE (issue #1895
+ *                                                     addendum): a present field only
+ *                                                     asserts its write_priv when its
+ *                                                     canonical value actually changes
  *   PfbConfig::deleteSection($section)             — delete a whole section
  *   PfbConfig::writeSystem($key, $value)           — write one field with NO privilege
  *                                                     check, for no-session system callers
@@ -1346,6 +1350,12 @@ function pfb_dnsbl_webpage(): string
  * privilege via isAllowedPage(), fail-closed when that check is undefined or false --
  * a system-context caller with no web session must say so explicitly via the
  * writeSystem()/writeSectionSystem() escape hatch, never rely on a silent pass.
+ * writeSection() adds a delta-aware carve-out on top (issue #1895 addendum): a
+ * registered field present in the section blob is an authorization event only when
+ * its canonical incoming value differs from its canonical currently-stored value --
+ * an unchanged read-modify-write pass-through (e.g. the General settings page saving
+ * an unrelated field) is not a write of that field. write() has no such carve-out and
+ * stays strict -- see assertWriteAllowedOnChange().
  *
  * @see pfb_cfg_registry()
  */
@@ -1384,6 +1394,14 @@ final class PfbConfig
 	 *
 	 * Enforces the field's write_priv page privilege (issue #1895) — a no-session
 	 * system caller (cron/install/migrations/CLI/core hooks) must use writeSystem().
+	 *
+	 * Unlike writeSection() (see its docblock), this check is STRICT, not delta-aware:
+	 * an explicit single-key write() call is always an authorization event, whether or
+	 * not the value actually changes, because there is no read-modify-write section
+	 * saver behind it that could be carrying an unrelated field's unchanged value along
+	 * for the ride. writeSection()'s pass-through carve-out exists specifically for that
+	 * read-modify-write case (e.g. the General settings page); write() has no such case
+	 * to carve out.
 	 *
 	 * @param  string $key   The exact config.xml field key.
 	 * @param  mixed  $value Runtime value (enum or string).
@@ -1470,6 +1488,14 @@ final class PfbConfig
 	 * string) — calling the write adapter directly on a raw array or NULL
 	 * would TypeError (write adapters are typed EnumClass|string).
 	 *
+	 * Privilege gate is DELTA-AWARE (issue #1895 addendum): a registered field
+	 * present in $data is only an authorization event when its canonical
+	 * incoming value differs from the canonical currently-stored value --
+	 * see assertWriteAllowedOnChange(). This is what write() does NOT do: a
+	 * single-key write() call is always an explicit authorization event, delta
+	 * or not, because there is no read-modify-write section saver behind it to
+	 * carry an unrelated field's unchanged value along for the ride.
+	 *
 	 * @param string $section  The full config.xml section path.
 	 * @param array  $data     Section data to persist.
 	 */
@@ -1484,7 +1510,7 @@ final class PfbConfig
 			if ($entry['section'] !== $section || !array_key_exists($key, $data)) {
 				continue;
 			}
-			self::assertWriteAllowed($key, $entry);
+			self::assertWriteAllowedOnChange($key, $entry, $section, $data[$key]);
 		}
 		self::writeSectionRaw($section, $data);
 	}
@@ -1594,6 +1620,82 @@ final class PfbConfig
 				. 'PfbConfig::writeSystem()/writeSectionSystem() instead.'
 			);
 		}
+	}
+
+	/**
+	 * writeSection()'s delta-aware privilege gate for one registered field (issue #1895
+	 * addendum, composition bug found reviewing #1895 against pfblockerng_general.php).
+	 *
+	 * The General settings page does a whole-section readSection() -> modify one field
+	 * -> writeSection() round trip. That carries every OTHER registered field's value
+	 * along unchanged. Once assertWriteAllowed() ran unconditionally for every present
+	 * field, a field with a write_priv override the current page doesn't hold (e.g.
+	 * pfb_software_check, gated to 'pkg_mgr_installed.php') would trip on its own
+	 * pass-through value even though nothing about it changed -- a supported save flow
+	 * throwing on an unrelated edit. Fix: a present field is an authorization event ONLY
+	 * when its canonical incoming value differs from the canonical currently-stored
+	 * value. An unchanged pass-through is not a write of that field in any sense an
+	 * operator would recognise; a real change still asserts the privilege, still BEFORE
+	 * any mutation (self::writeSectionRaw() runs only after every field in the loop has
+	 * cleared this gate).
+	 *
+	 * Both sides are canonicalised through the exact same pipeline write() and
+	 * writeSectionRaw() already use, so this can never disagree with what actually gets
+	 * stored: notConfigured() resolves NULL/'' to the registered default first; an
+	 * adapter-bearing field then round-trips write_adapter(read_adapter($value)) (the
+	 * same normalisation writeSectionRaw()'s loop applies to the incoming side); a plain
+	 * field is cast (string) (matching writeRaw()'s cast). The stored side reads via
+	 * config_get_path() directly (bypassing the registry default, then applying it here)
+	 * -- an absent key canonicalises identically to an explicit registered-default value,
+	 * so a field that has never been saved and a field just re-saved at its default both
+	 * correctly read as "unchanged" against an incoming default.
+	 *
+	 * write() has no equivalent carve-out -- an explicit single-key write() call is
+	 * always an authorization event, changed or not, because there is no read-modify-
+	 * write section saver behind it carrying an unrelated field's value along.
+	 *
+	 * @param  string $key     The exact config.xml field key (named in the exception).
+	 * @param  array  $entry   The registry entry (consulted for its optional 'write_priv').
+	 * @param  string $section The full config.xml section path $key lives under.
+	 * @param  mixed  $incoming The incoming (pre-normalisation) value for $key in the section blob.
+	 * @throws RuntimeException When the field's canonical value actually changes and the
+	 *                          caller lacks its required page privilege.
+	 */
+	private static function assertWriteAllowedOnChange(string $key, array $entry, string $section, mixed $incoming): void
+	{
+		$stored_raw = config_get_path($section . '/' . $key, NULL);
+		if (self::canonicalize($entry, $stored_raw) === self::canonicalize($entry, $incoming)) {
+			return;
+		}
+		self::assertWriteAllowed($key, $entry);
+	}
+
+	/**
+	 * Canonicalise a raw or runtime value for one registered field to the exact stored
+	 * string it would persist as, for the delta comparison in
+	 * assertWriteAllowedOnChange() (issue #1895 addendum).
+	 *
+	 * Mirrors the two normalisation pipelines already in this class byte-for-byte so the
+	 * comparison can never diverge from what an actual write would store:
+	 *   - adapter-bearing field (both read_adapter and write_adapter set, always paired
+	 *     -- see pfb_cfg_registry()): write_adapter(read_adapter(notConfigured($value))),
+	 *     the same round trip writeSectionRaw()'s normalisation loop applies.
+	 *   - plain field: (string) notConfigured($value), matching writeRaw()'s cast.
+	 *
+	 * @param  array $entry  The registry entry.
+	 * @param  mixed $value  Raw stored value (from config_get_path()) or the incoming
+	 *                       section-blob value for this key.
+	 * @return string        The canonical stored form $value would persist as.
+	 */
+	private static function canonicalize(array $entry, mixed $value): string
+	{
+		$value         = self::notConfigured($entry, $value);
+		$read_adapter  = $entry['read_adapter'];
+		$write_adapter = $entry['write_adapter'];
+		if ($read_adapter !== NULL && $write_adapter !== NULL) {
+			return $write_adapter($read_adapter($value));
+		}
+		return (string) $value;
 	}
 
 	/**

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -122,7 +122,7 @@ if (
 	// Reset saved wizard configuration.
 	config_del_path('pfblockerng_wizard'); // foreign key — out of ADR-29 gateway scope (root-level, not installedpackages/pfblockerng*)
 
-	PfbConfig::writeSection('installedpackages/pfblockerngdnsblsettings/config/0', $pfb_dnsbl_config);
+	PfbConfig::writeSectionSystem('installedpackages/pfblockerngdnsblsettings/config/0', $pfb_dnsbl_config);
 	write_config('Migrated old pfBlockerNG VIP configuraiton');
 	pfb_global();
 }
@@ -416,7 +416,7 @@ foreach ($upgrade_type as $type) {
 		}
 	}
 	if ($type_ufound) {
-		PfbConfig::writeSection("installedpackages/{$type}/config", $pfb_type_items);
+		PfbConfig::writeSectionSystem("installedpackages/{$type}/config", $pfb_type_items);
 		$ufound = TRUE;
 	}
 }
@@ -500,7 +500,7 @@ if (!empty($pfb_interfaces)) {
 		if (isset($pfb_interfaces['ipsec_action'])) {
 			unset($pfb_interfaces['ipsec_action']);
 		}
-		PfbConfig::writeSection('installedpackages/pfblockerng/config/0', $pfb_interfaces);
+		PfbConfig::writeSectionSystem('installedpackages/pfblockerng/config/0', $pfb_interfaces);
 	}
 }
 
@@ -553,7 +553,7 @@ if ($ufound) {
 	foreach ($et_type as $type => $cats) {
 		$pfb_iqrisk[$type] = implode(',', $cats);
 	}
-	PfbConfig::writeSection('installedpackages/pfblockerngreputation/config/0', $pfb_iqrisk);
+	PfbConfig::writeSectionSystem('installedpackages/pfblockerngreputation/config/0', $pfb_iqrisk);
 } else {
 	update_status(" no changes required ... done.\n");
 }
@@ -585,8 +585,8 @@ if (!empty(pfb_gconfig_operator_view($pfb_gen_section)) && empty($pfb_ip_section
 			unset($pfb['gconfig'][$setting]);
 		}
 	}
-	PfbConfig::writeSection('installedpackages/pfblockerngipsettings/config/0', $pfb['iconfig']);
-	PfbConfig::writeSection('installedpackages/pfblockerng/config/0', $pfb['gconfig']);
+	PfbConfig::writeSectionSystem('installedpackages/pfblockerngipsettings/config/0', $pfb['iconfig']);
+	PfbConfig::writeSectionSystem('installedpackages/pfblockerng/config/0', $pfb['gconfig']);
 	update_status(" saving new changes ... done.\n");
 }
 else {
@@ -641,7 +641,7 @@ if (!isset($pfb_ip_cfg['v4suppression'])) {
 			// ADR-53: write via the same section array read above (a bulk migration
 			// write alongside the rest of $pfb_ip_cfg, not a lone per-field save).
 			$pfb_ip_cfg['v4suppression'] = pfb_text_area_encode($customlist) ?: '';
-			PfbConfig::writeSection('installedpackages/pfblockerngipsettings/config/0', $pfb_ip_cfg);
+			PfbConfig::writeSectionSystem('installedpackages/pfblockerngipsettings/config/0', $pfb_ip_cfg);
 			// unset($config['aliases']['alias'][$key]);
 			$ufound = TRUE;
 			break;
@@ -670,7 +670,7 @@ $pfb_gcfg = pfb_gconfig_operator_view($pfb_gcfg);
 $pfb_gcfg = empty($pfb_gcfg) ? NULL : $pfb_gcfg;
 $pfb_feed_default = pfb_feed_filter_install_default($pfb_gcfg);
 if ($pfb_feed_default !== null) {
-	PfbConfig::write('pfb_feed_internal_filter', $pfb_feed_default);
+	PfbConfig::writeSystem('pfb_feed_internal_filter', $pfb_feed_default);
 }
 
 // ADR-40: grandfather an already-configured install to 'replace' (pre-ADR-40 full -T replace) so
@@ -678,7 +678,7 @@ if ($pfb_feed_default !== null) {
 // default. Run-once via the !isset guard in pfb_alias_delta_mode_install_default().
 $pfb_delta_default = pfb_alias_delta_mode_install_default($pfb_gcfg);
 if ($pfb_delta_default !== null) {
-	PfbConfig::write('pfb_alias_delta_mode', $pfb_delta_default);
+	PfbConfig::writeSystem('pfb_alias_delta_mode', $pfb_delta_default);
 }
 
 // Convert dnsbl_info CSV file to SQLite3 database format
@@ -797,7 +797,7 @@ if (!empty(PfbConfig::readSection('installedpackages/pfblockerngdnsbleasylist'))
 
 		$dnsblcfg   = PfbConfig::readSection('installedpackages/pfblockerngdnsbl/config');
 		$dnsblcfg[] = $add;
-		PfbConfig::writeSection('installedpackages/pfblockerngdnsbl/config', $dnsblcfg);
+		PfbConfig::writeSectionSystem('installedpackages/pfblockerngdnsbl/config', $dnsblcfg);
 	}
 
 	// Remove Previous EasyList configuration
@@ -824,7 +824,7 @@ if (!empty($doh_config)) {
 			$doh_config['safesearch_doh_list'] = 'use-application-dns.net';
 		}
 		unset($doh_config['safesearch_firefoxdoh']);
-		PfbConfig::writeSection('installedpackages/pfblockerngsafesearch', $doh_config);
+		PfbConfig::writeSectionSystem('installedpackages/pfblockerngsafesearch', $doh_config);
 	}
 }
 
@@ -842,7 +842,7 @@ $ufound = FALSE;
 $doh_list_migrated = pfb_ss_doh_list_yandex_migrate(PfbConfig::read('safesearch_doh_list'));
 if ($doh_list_migrated !== NULL) {
 	$ufound = TRUE;
-	PfbConfig::write('safesearch_doh_list', $doh_list_migrated);
+	PfbConfig::writeSystem('safesearch_doh_list', $doh_list_migrated);
 }
 
 if ($ufound) {
@@ -868,8 +868,8 @@ if (!empty($pfb_maxmind_gen) && !isset($pfb_maxmind_ip['maxmind_key'])) {
 		}
 	}
 	if ($ufound) {
-		PfbConfig::writeSection('installedpackages/pfblockerngipsettings/config/0', $pfb_maxmind_ip);
-		PfbConfig::writeSection('installedpackages/pfblockerng/config/0', $maxmind_config);
+		PfbConfig::writeSectionSystem('installedpackages/pfblockerngipsettings/config/0', $pfb_maxmind_ip);
+		PfbConfig::writeSectionSystem('installedpackages/pfblockerng/config/0', $maxmind_config);
 	}
 }
 

--- a/tests/php/CfgWriteAuthorizationTest.php
+++ b/tests/php/CfgWriteAuthorizationTest.php
@@ -10,16 +10,30 @@ use PHPUnit\Framework\TestCase;
  * escape hatch for legitimate no-session system callers (cron/install/migrations/
  * CLI/core hooks), where isAllowedPage() is undefined or meaningless.
  *
- * Coverage matrix rows A-I (see the issue #1895 step-1 brief):
+ * Coverage matrix rows A-L (see the issue #1895 step-1 brief, and the delta-aware
+ * addendum found reviewing #1895 against pfblockerng_general.php's read-modify-write
+ * composition -- rows J-L):
  *   A - write() blocked by the default privilege: exception + stored value unchanged.
  *   B - write() allowed by the default privilege: succeeds, canonical token stored.
  *   C - write() consults the per-field write_priv override, not the default.
  *   D - write() succeeds once the per-field override is allowed.
- *   E - writeSection() blocked: exception, and the WHOLE section is unmodified.
+ *   E - writeSection() blocked: exception, and the WHOLE section is unmodified
+ *       (fixture is a REAL value change, not merely a present field, so the
+ *       delta-aware gate below still enforces refusal).
  *   F - writeSection() allowed: same normalisation/pass-through as before the change.
  *   G - writeSystem() bypasses the check even with every page disallowed.
  *   H - writeSectionSystem() bypasses the check even with every page disallowed.
  *   I - parity: writeSystem() stores byte-identical value to an allowed write().
+ *   J - writeSection() delta-aware pass-through: an unrelated field changes, a
+ *       privilege-gated field rides along UNCHANGED -- must succeed (the composition
+ *       bug this addendum fixes: a General-page save must not trip on
+ *       pfb_software_check's pass-through value).
+ *   K - same seeding as J, but the privilege-gated field's value actually CHANGES --
+ *       enforcement is retained: exception, section unmodified.
+ *   L - equivalence subtlety: the privilege-gated field is ABSENT from stored config
+ *       entirely; the incoming blob carries the registered default -- canonicalises
+ *       identical to "unchanged", so it is a pass-through too (notConfigured()'s
+ *       identity riding the delta comparison).
  */
 final class CfgWriteAuthorizationTest extends TestCase
 {
@@ -150,6 +164,15 @@ final class CfgWriteAuthorizationTest extends TestCase
 		// General page allowed (pfb_keep/enable_cb would pass), but the
 		// pfb_software_check override is blocked -- the whole section write must
 		// still be refused, and none of it -- not even pfb_keep -- may land.
+		//
+		// NOTE (delta-aware addendum): pfb_software_check's incoming value below
+		// ('off') is a REAL change from its stored baseline ('on') -- this is
+		// deliberate. The delta-aware gate (assertWriteAllowedOnChange()) only
+		// skips the privilege assertion for an UNCHANGED pass-through value; a
+		// fixture where the denied field's incoming value equalled its stored
+		// value would now (correctly) succeed instead of pinning refusal, which
+		// would silently defeat this test. See rows J/K/L below for the
+		// pass-through/real-change split this addendum adds.
 		$GLOBALS['pfb_test_allowed_pages'] = [
 			'pfblockerng/pfblockerng_general.php' => true,
 			'pkg_mgr_installed.php'               => false,
@@ -287,6 +310,109 @@ final class CfgWriteAuthorizationTest extends TestCase
 
 		$this->assertSame($expected, $actual,
 			'writeSystem() must store the same value an allowed write() would, byte-identical'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// J - writeSection() delta-aware pass-through: THE composition-bug regression.
+	// -----------------------------------------------------------------------
+
+	public function testWriteSectionUnchangedPrivilegedFieldPassesThroughOnUnrelatedEdit(): void
+	{
+		$baseline = [
+			'pfb_keep'           => 'on',
+			'pfb_software_check' => 'on',
+		];
+		config_set_path(self::GEN, $baseline);
+
+		// A scoped operator: allowed on the General page, denied on the Software page.
+		// pfb_software_check's write_priv override ('pkg_mgr_installed.php') is denied.
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+			'pkg_mgr_installed.php'                => false,
+		];
+
+		// The real General-page shape: whole-section readSection() -> modify ONE
+		// unrelated field -> writeSection(). pfb_software_check rides along unchanged.
+		$data              = PfbConfig::readSection(self::GEN);
+		$data['pfb_keep']  = 'off';
+
+		PfbConfig::writeSection(self::GEN, $data);
+
+		$this->assertSame('off', config_get_path(self::GEN . '/pfb_keep'),
+			'the unrelated, actually-changed field must persist canonically'
+		);
+		$this->assertSame('on', config_get_path(self::GEN . '/pfb_software_check'),
+			'an UNCHANGED pass-through of a privilege-gated field must not trip its '
+			. 'write_priv gate -- the #1895 composition bug this addendum fixes'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// K - same seeding as J, but the privilege-gated field's value actually changes.
+	// -----------------------------------------------------------------------
+
+	public function testWriteSectionRealChangeOfPrivilegedFieldStillEnforcesGate(): void
+	{
+		$baseline = [
+			'pfb_keep'           => 'on',
+			'pfb_software_check' => 'on',
+		];
+		config_set_path(self::GEN, $baseline);
+
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+			'pkg_mgr_installed.php'                => false,
+		];
+
+		// This time the operator (or a crafted POST) actually flips pfb_software_check.
+		$data                       = PfbConfig::readSection(self::GEN);
+		$data['pfb_software_check'] = 'off';
+
+		try {
+			PfbConfig::writeSection(self::GEN, $data);
+			$this->fail('expected RuntimeException, none thrown');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('pfb_software_check', $e->getMessage(),
+				'exception message must name the key'
+			);
+		}
+
+		$this->assertSame($baseline, config_get_path(self::GEN),
+			'a REAL change to a privilege-gated field must still refuse the whole section '
+			. 'write -- enforcement is retained, the delta-aware gate only skips unchanged values'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// L - equivalence subtlety: stored ABSENT canonicalises identical to the incoming
+	//     registered default.
+	// -----------------------------------------------------------------------
+
+	public function testWriteSectionAbsentStoredFieldEqualsIncomingDefaultIsPassThrough(): void
+	{
+		// pfb_software_check is entirely ABSENT from the stored section -- never saved
+		// on this box before. notConfigured() must resolve the missing key to the
+		// registered default ('on'), the same as it would for an explicit 'on'.
+		config_set_path(self::GEN, ['pfb_keep' => 'on']);
+
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+			'pkg_mgr_installed.php'                => false,
+		];
+
+		PfbConfig::writeSection(self::GEN, [
+			'pfb_keep'           => 'off',
+			// The registered default -- canonically identical to "absent".
+			'pfb_software_check' => 'on',
+		]);
+
+		$this->assertSame('off', config_get_path(self::GEN . '/pfb_keep'),
+			'the unrelated, actually-changed field must persist canonically'
+		);
+		$this->assertSame('on', config_get_path(self::GEN . '/pfb_software_check'),
+			'absent-stored must canonicalise identically to the registered default and be '
+			. 'treated as an unchanged pass-through, not an authorization event'
 		);
 	}
 }

--- a/tests/php/CfgWriteAuthorizationTest.php
+++ b/tests/php/CfgWriteAuthorizationTest.php
@@ -415,4 +415,68 @@ final class CfgWriteAuthorizationTest extends TestCase
 			. 'treated as an unchanged pass-through, not an authorization event'
 		);
 	}
+
+	// -----------------------------------------------------------------------
+	// M - non-scalar values under a plain (adapter-less) registered key must
+	//     compare by SHAPE in the delta gate, not by PHP's string cast: a
+	//     (string) cast collapses every array to 'Array' (warning + two
+	//     different arrays comparing "unchanged" while writeSectionRaw()
+	//     persists them verbatim) -- CodeRabbit finding on PR #1903.
+	// -----------------------------------------------------------------------
+
+	public function testWriteSectionNonScalarChangeUnderPlainKeyIsAnAuthorizationEvent(): void
+	{
+		// A crafted-POST array riding a plain registered key (pfb_interval has
+		// NULL/NULL adapters). Stored and incoming arrays DIFFER, so this is a
+		// real change: the delta gate must consult the privilege and refuse.
+		config_set_path(self::GEN, ['pfb_interval' => ['a']]);
+
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => false,
+		];
+
+		try {
+			PfbConfig::writeSection(self::GEN, ['pfb_interval' => ['b']]);
+			$this->fail('expected RuntimeException, none thrown');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('pfb_interval', $e->getMessage(),
+				'exception message must name the key'
+			);
+		}
+
+		$this->assertSame(['a'], config_get_path(self::GEN . '/pfb_interval'),
+			'refused non-scalar change must leave the stored value unchanged'
+		);
+	}
+
+	public function testWriteSectionIdenticalNonScalarPassThroughEmitsNoWarning(): void
+	{
+		// Identical arrays are a pass-through; the comparison must not raise
+		// "Array to string conversion" (the cast would, on BOTH tests here --
+		// PHPUnit converts warnings to errors under failOnWarning, and this
+		// closure-based handler catches it regardless of that setting).
+		config_set_path(self::GEN, ['pfb_interval' => ['a']]);
+
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => false,
+		];
+
+		$warnings = [];
+		set_error_handler(static function (int $no, string $msg) use (&$warnings): bool {
+			$warnings[] = $msg;
+			return true;
+		}, E_WARNING | E_NOTICE);
+		try {
+			PfbConfig::writeSection(self::GEN, ['pfb_interval' => ['a']]);
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame([], $warnings,
+			'the delta comparison must not string-cast non-scalars'
+		);
+		$this->assertSame(['a'], config_get_path(self::GEN . '/pfb_interval'),
+			'identical non-scalar pass-through must persist verbatim'
+		);
+	}
 }

--- a/tests/php/CfgWriteAuthorizationTest.php
+++ b/tests/php/CfgWriteAuthorizationTest.php
@@ -1,0 +1,292 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1895 — PfbConfig write-authorization tests.
+ *
+ * write()/writeSection() must enforce a per-field write_priv page privilege via
+ * isAllowedPage(), fail-closed. writeSystem()/writeSectionSystem() are the explicit
+ * escape hatch for legitimate no-session system callers (cron/install/migrations/
+ * CLI/core hooks), where isAllowedPage() is undefined or meaningless.
+ *
+ * Coverage matrix rows A-I (see the issue #1895 step-1 brief):
+ *   A - write() blocked by the default privilege: exception + stored value unchanged.
+ *   B - write() allowed by the default privilege: succeeds, canonical token stored.
+ *   C - write() consults the per-field write_priv override, not the default.
+ *   D - write() succeeds once the per-field override is allowed.
+ *   E - writeSection() blocked: exception, and the WHOLE section is unmodified.
+ *   F - writeSection() allowed: same normalisation/pass-through as before the change.
+ *   G - writeSystem() bypasses the check even with every page disallowed.
+ *   H - writeSectionSystem() bypasses the check even with every page disallowed.
+ *   I - parity: writeSystem() stores byte-identical value to an allowed write().
+ */
+final class CfgWriteAuthorizationTest extends TestCase
+{
+	private const GEN = 'installedpackages/pfblockerng/config/0';
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		unset($GLOBALS['pfb_test_allowed_pages']);
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['pfb_test_allowed_pages']);
+	}
+
+	// -----------------------------------------------------------------------
+	// A - write() blocked by the default page privilege.
+	// -----------------------------------------------------------------------
+
+	public function testWriteBlockedByDefaultPrivilegeThrowsAndLeavesStoredValueUnchanged(): void
+	{
+		$path = self::GEN . '/pfb_keep';
+		config_set_path($path, 'on');
+
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => false,
+		];
+
+		try {
+			PfbConfig::write('pfb_keep', PfbToggle::Off);
+			$this->fail('expected RuntimeException, none thrown');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('pfb_keep', $e->getMessage(),
+				'exception message must name the key'
+			);
+		}
+
+		$this->assertSame('on', config_get_path($path),
+			'blocked write must leave the stored value unchanged'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// B - write() allowed by the default page privilege.
+	// -----------------------------------------------------------------------
+
+	public function testWriteAllowedByDefaultPrivilegeSucceeds(): void
+	{
+		$path = self::GEN . '/pfb_keep';
+		config_set_path($path, 'on');
+
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+		];
+
+		PfbConfig::write('pfb_keep', PfbToggle::Off);
+
+		$this->assertSame('off', config_get_path($path),
+			'allowed write must persist the canonical stored token'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// C - write() consults the per-field write_priv override, not the default.
+	// -----------------------------------------------------------------------
+
+	public function testWriteConsultsPerFieldPrivilegeOverrideNotDefault(): void
+	{
+		$path = self::GEN . '/pfb_software_check';
+		config_set_path($path, 'on');
+
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+			'pkg_mgr_installed.php'               => false,
+		];
+
+		try {
+			PfbConfig::write('pfb_software_check', PfbToggle::Off);
+			$this->fail('expected RuntimeException, none thrown');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('pfb_software_check', $e->getMessage(),
+				'exception message must name the key'
+			);
+		}
+
+		$this->assertSame('on', config_get_path($path),
+			'blocked write must leave the stored value unchanged'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// D - write() succeeds once the per-field override is allowed.
+	// -----------------------------------------------------------------------
+
+	public function testWriteSucceedsWhenPerFieldPrivilegeOverrideAllowed(): void
+	{
+		$path = self::GEN . '/pfb_software_check';
+		config_set_path($path, 'on');
+
+		// The default page is deliberately disallowed here -- if write() consulted
+		// the default instead of the field's own override, this would (wrongly) throw.
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => false,
+			'pkg_mgr_installed.php'               => true,
+		];
+
+		PfbConfig::write('pfb_software_check', PfbToggle::Off);
+
+		$this->assertSame('off', config_get_path($path),
+			'write must succeed and persist the canonical stored token'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// E - writeSection() blocked: whole section unmodified.
+	// -----------------------------------------------------------------------
+
+	public function testWriteSectionBlockedByPrivilegeLeavesEntireSectionUnmodified(): void
+	{
+		$baseline = [
+			'pfb_keep'           => 'on',
+			'pfb_software_check' => 'on',
+			'enable_cb'          => 'on',
+		];
+		config_set_path(self::GEN, $baseline);
+
+		// General page allowed (pfb_keep/enable_cb would pass), but the
+		// pfb_software_check override is blocked -- the whole section write must
+		// still be refused, and none of it -- not even pfb_keep -- may land.
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+			'pkg_mgr_installed.php'               => false,
+		];
+
+		try {
+			PfbConfig::writeSection(self::GEN, [
+				'pfb_keep'           => 'off',
+				'pfb_software_check' => 'off',
+				'enable_cb'          => 'off',
+			]);
+			$this->fail('expected RuntimeException, none thrown');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('pfb_software_check', $e->getMessage());
+		}
+
+		$this->assertSame($baseline, config_get_path(self::GEN),
+			'blocked writeSection() must leave the ENTIRE section unmodified'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// F - writeSection() allowed: normalisation/pass-through unchanged by the refactor.
+	// -----------------------------------------------------------------------
+
+	public function testWriteSectionAllowedNormalisesRegisteredFieldsAndPassesThroughForeignKeys(): void
+	{
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+			'pkg_mgr_installed.php'                => true,
+		];
+
+		// Oracle: single-key write() on a fresh slate.
+		$GLOBALS['config'] = [];
+		PfbConfig::write('pfb_keep', 'junk');
+		$expected_keep = config_get_path(self::GEN . '/pfb_keep');
+
+		// Under test: writeSection() with the same field plus an unregistered/foreign key.
+		$GLOBALS['config'] = [];
+		PfbConfig::writeSection(self::GEN, [
+			'pfb_keep'          => 'junk',
+			'some_foreign_key'  => 'untouched-value',
+		]);
+
+		$this->assertSame($expected_keep, config_get_path(self::GEN . '/pfb_keep'),
+			'writeSection() must normalise a registered field exactly as write() would'
+		);
+		$this->assertSame('untouched-value', config_get_path(self::GEN . '/some_foreign_key'),
+			'writeSection() must pass an unregistered/foreign key through byte-identical'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// G - writeSystem() bypasses the check even with every page disallowed.
+	// -----------------------------------------------------------------------
+
+	public function testWriteSystemBypassesPrivilegeCheckEvenWhenAllPagesDisallowed(): void
+	{
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => false,
+			'pkg_mgr_installed.php'                => false,
+		];
+
+		PfbConfig::writeSystem('pfb_keep', PfbToggle::On);
+		PfbConfig::writeSystem('pfb_software_check', PfbToggle::On);
+
+		$this->assertSame('on', config_get_path(self::GEN . '/pfb_keep'),
+			'writeSystem() must succeed and persist the canonical token regardless of privilege'
+		);
+		$this->assertSame('on', config_get_path(self::GEN . '/pfb_software_check'),
+			'writeSystem() must succeed and persist the canonical token regardless of the field write_priv override'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// H - writeSectionSystem() bypasses the check even with every page disallowed.
+	// -----------------------------------------------------------------------
+
+	public function testWriteSectionSystemBypassesPrivilegeCheckEvenWhenAllPagesDisallowed(): void
+	{
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => false,
+			'pkg_mgr_installed.php'                => false,
+		];
+
+		// Oracle: what an ALLOWED writeSection() would normalise this to (same
+		// normalisation contract as row F, just proven again for writeSectionSystem()).
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+			'pkg_mgr_installed.php'                => true,
+		];
+		PfbConfig::writeSection(self::GEN, ['pfb_keep' => 'junk', 'some_foreign_key' => 'v']);
+		$expected_keep    = config_get_path(self::GEN . '/pfb_keep');
+		$expected_foreign = config_get_path(self::GEN . '/some_foreign_key');
+
+		// Under test: writeSectionSystem() with every page disallowed.
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => false,
+			'pkg_mgr_installed.php'                => false,
+		];
+		PfbConfig::writeSectionSystem(self::GEN, ['pfb_keep' => 'junk', 'some_foreign_key' => 'v']);
+
+		$this->assertSame($expected_keep, config_get_path(self::GEN . '/pfb_keep'),
+			'writeSectionSystem() must normalise exactly as an allowed writeSection() would'
+		);
+		$this->assertSame($expected_foreign, config_get_path(self::GEN . '/some_foreign_key'),
+			'writeSectionSystem() must pass foreign keys through byte-identical, privilege notwithstanding'
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// I - parity: writeSystem() stores byte-identical value to an allowed write().
+	// -----------------------------------------------------------------------
+
+	public function testWriteSystemStoresByteIdenticalValueToAllowedWrite(): void
+	{
+		$path = self::GEN . '/pfb_keep';
+
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+		];
+		PfbConfig::write('pfb_keep', PfbToggle::On);
+		$expected = config_get_path($path);
+
+		$GLOBALS['config'] = [];
+		unset($GLOBALS['pfb_test_allowed_pages']);
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => false,
+		];
+		PfbConfig::writeSystem('pfb_keep', PfbToggle::On);
+		$actual = config_get_path($path);
+
+		$this->assertSame($expected, $actual,
+			'writeSystem() must store the same value an allowed write() would, byte-identical'
+		);
+	}
+}

--- a/tests/php/InstallGrandfatherChokepointTest.php
+++ b/tests/php/InstallGrandfatherChokepointTest.php
@@ -49,7 +49,9 @@ final class InstallGrandfatherChokepointTest extends TestCase
 			if (!preg_match(
 				'/(\$pfb_gcfg = PfbConfig::readSection\(\'installedpackages\/pfblockerng\/config\/0\'\);\n'
 				. '.*?'
-				. 'PfbConfig::write\(\'pfb_alias_delta_mode\', \$pfb_delta_default\);\n\}\n)/s',
+				// issue #1895: install.inc's writes are system-context (no web session),
+				// converted to the writeSystem() escape hatch.
+				. 'PfbConfig::writeSystem\(\'pfb_alias_delta_mode\', \$pfb_delta_default\);\n\}\n)/s',
 				$src,
 				$m
 			)) {

--- a/tests/php/RequireConfigGatewaySniffTest.php
+++ b/tests/php/RequireConfigGatewaySniffTest.php
@@ -274,10 +274,10 @@ final class RequireConfigGatewaySniffTest extends TestCase
 		);
 
 		$this->assertCount(
-			5,
+			6,
 			$findings,
-			'writeSystem(), writeSectionSystem(), the case-varied call, and both '
-			. 'comment-interleaved shapes must all be flagged'
+			'writeSystem(), writeSectionSystem(), the case-varied call, and all '
+			. 'three comment-interleaved shapes must all be flagged'
 		);
 
 		$lines = array_column($findings, 'line');
@@ -288,10 +288,11 @@ final class RequireConfigGatewaySniffTest extends TestCase
 		// Line 33: pfbconfig::WRITESYSTEM(...) (case variance)
 		// Line 40: PfbConfig/*x*/::writeSystem(...) (comment before '::')
 		// Line 47: PfbConfig::/*x*/writeSystem(...) (comment after '::')
+		// Line 54: PfbConfig::writeSystem/*x*/(...) (comment before '(')
 		$this->assertSame(
-			[20, 26, 33, 40, 47],
+			[20, 26, 33, 40, 47, 54],
 			$lines,
-			'findings must land on all five static system-write call lines'
+			'findings must land on all six static system-write call lines'
 		);
 
 		foreach ($findings as $finding) {

--- a/tests/php/RequireConfigGatewaySniffTest.php
+++ b/tests/php/RequireConfigGatewaySniffTest.php
@@ -47,9 +47,10 @@ use PHPUnit\Framework\TestCase;
  *
  *   tests/phpcs/fixtures/usr/local/www/system_write_violation.php — a www/
  *   path calling PfbConfig::writeSystem() / writeSectionSystem(), a
- *   case-varied (pfbconfig::WRITESYSTEM()) call, and two comment-interleaved
- *   shapes (a comment between the class name and '::', and one between '::'
- *   and the method name) — all five MUST be flagged.
+ *   case-varied (pfbconfig::WRITESYSTEM()) call, and three comment-interleaved
+ *   shapes (a comment between the class name and '::', one between '::' and
+ *   the method name, and one between the method name and '(') — all six MUST
+ *   be flagged.
  *
  *   tests/phpcs/fixtures/usr/local/www/system_write_compliant.php — the same
  *   www/ path, but PfbConfig::write()/writeSection() (different method),

--- a/tests/php/RequireConfigGatewaySniffTest.php
+++ b/tests/php/RequireConfigGatewaySniffTest.php
@@ -46,8 +46,10 @@ use PHPUnit\Framework\TestCase;
  * against, mirroring the real src/usr/local/www/ tree layout:
  *
  *   tests/phpcs/fixtures/usr/local/www/system_write_violation.php — a www/
- *   path calling PfbConfig::writeSystem() / writeSectionSystem(), plus a
- *   case-varied (pfbconfig::WRITESYSTEM()) call — all three MUST be flagged.
+ *   path calling PfbConfig::writeSystem() / writeSectionSystem(), a
+ *   case-varied (pfbconfig::WRITESYSTEM()) call, and two comment-interleaved
+ *   shapes (a comment between the class name and '::', and one between '::'
+ *   and the method name) — all five MUST be flagged.
  *
  *   tests/phpcs/fixtures/usr/local/www/system_write_compliant.php — the same
  *   www/ path, but PfbConfig::write()/writeSection() (different method),
@@ -105,13 +107,15 @@ final class RequireConfigGatewaySniffTest extends TestCase
 
 	/**
 	 * Run the custom PfBlockerNG standard over an arbitrary file or directory
-	 * (absolute path) and return only the findings matching $source, across
-	 * every file phpcs reports on. Used for CHECK 2's real-tree assertion,
-	 * where the fixture-path convention of findingsFor() does not apply.
+	 * (absolute path) and return the decoded phpcs JSON report, unfiltered.
 	 *
-	 * @return list<array<string, mixed>>
+	 * Split out of findingsForPath() so the real-tree assertion (below) can
+	 * additionally check how many files phpcs actually processed -- a
+	 * zero-file report would make a zero-findings assertion vacuously true.
+	 *
+	 * @return array<string, mixed>
 	 */
-	private function findingsForPath(string $path, string $source): array
+	private function runPhpcsJson(string $path): array
 	{
 		$root = self::repoRoot();
 		$this->assertFileExists($path, "{$path} must exist");
@@ -129,6 +133,18 @@ final class RequireConfigGatewaySniffTest extends TestCase
 		$report = json_decode((string) $json, TRUE);
 		$this->assertIsArray($report, 'phpcs JSON report must decode');
 
+		return $report;
+	}
+
+	/**
+	 * Filter a decoded phpcs JSON report (see runPhpcsJson()) down to the
+	 * findings matching $source, across every file phpcs reports on.
+	 *
+	 * @param  array<string, mixed> $report
+	 * @return list<array<string, mixed>>
+	 */
+	private function extractFindings(array $report, string $source): array
+	{
 		$findings = [];
 		foreach (($report['files'] ?? []) as $file => $data) {
 			$messages = $data['messages'] ?? [];
@@ -140,6 +156,19 @@ final class RequireConfigGatewaySniffTest extends TestCase
 		}
 
 		return $findings;
+	}
+
+	/**
+	 * Run the custom PfBlockerNG standard over an arbitrary file or directory
+	 * (absolute path) and return only the findings matching $source, across
+	 * every file phpcs reports on. Used for CHECK 2's real-tree assertion,
+	 * where the fixture-path convention of findingsFor() does not apply.
+	 *
+	 * @return list<array<string, mixed>>
+	 */
+	private function findingsForPath(string $path, string $source): array
+	{
+		return $this->extractFindings($this->runPhpcsJson($path), $source);
 	}
 
 	/**
@@ -245,9 +274,10 @@ final class RequireConfigGatewaySniffTest extends TestCase
 		);
 
 		$this->assertCount(
-			3,
+			5,
 			$findings,
-			'writeSystem(), writeSectionSystem(), and the case-varied call must all be flagged'
+			'writeSystem(), writeSectionSystem(), the case-varied call, and both '
+			. 'comment-interleaved shapes must all be flagged'
 		);
 
 		$lines = array_column($findings, 'line');
@@ -256,10 +286,12 @@ final class RequireConfigGatewaySniffTest extends TestCase
 		// Line 20: PfbConfig::writeSystem(...)
 		// Line 26: PfbConfig::writeSectionSystem(...)
 		// Line 33: pfbconfig::WRITESYSTEM(...) (case variance)
+		// Line 40: PfbConfig/*x*/::writeSystem(...) (comment before '::')
+		// Line 47: PfbConfig::/*x*/writeSystem(...) (comment after '::')
 		$this->assertSame(
-			[20, 26, 33],
+			[20, 26, 33, 40, 47],
 			$lines,
-			'findings must land on the three static system-write call lines'
+			'findings must land on all five static system-write call lines'
 		);
 
 		foreach ($findings as $finding) {
@@ -329,10 +361,19 @@ final class RequireConfigGatewaySniffTest extends TestCase
 	 */
 	public function testRealWwwTreeHasNoSystemWriteCalls(): void
 	{
-		$findings = $this->findingsForPath(
-			self::repoRoot() . '/src/usr/local/www',
-			self::SOURCE_SYSTEM_WRITE
+		$report = $this->runPhpcsJson(self::repoRoot() . '/src/usr/local/www');
+
+		// Processed-file floor: guards against a vacuous pass (e.g. a wrong path, a
+		// misconfigured --extensions, or phpcs silently skipping everything) where
+		// zero files scanned would trivially satisfy the zero-findings assertion below.
+		$this->assertGreaterThan(
+			0,
+			count($report['files'] ?? []),
+			'phpcs must actually have processed files under src/usr/local/www/ -- a '
+			. 'zero-file report would make the zero-findings assertion below vacuous'
 		);
+
+		$findings = $this->extractFindings($report, self::SOURCE_SYSTEM_WRITE);
 
 		$this->assertSame(
 			[],

--- a/tests/php/RequireConfigGatewaySniffTest.php
+++ b/tests/php/RequireConfigGatewaySniffTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * ADR-29 enforcement — the PfBlockerNG.Config.RequireConfigGateway sniff.
+ * ADR-29 / issue #1895 enforcement — the PfBlockerNG.Config.RequireConfigGateway
+ * sniff. It carries two independent checks; this suite pins both.
  *
- * Pins both sides of every decision the sniff makes, driving the real `phpcs`
- * binary over fixture files under tests/phpcs/fixtures/:
+ * CHECK 1 — RawRegisteredKeyAccess (ADR-29). Pins both sides of every decision
+ * the check makes, driving the real `phpcs` binary over fixture files under
+ * tests/phpcs/fixtures/:
  *
  *   VIOLATING (gateway_violation.php): raw config_*_path calls each targeting
  *   a REGISTERED installedpackages/pfblockerng* key — the sniff MUST flag
@@ -38,12 +40,36 @@ use PHPUnit\Framework\TestCase;
  *   - widget-* foreign key — silent
  *   - wizard temp section delete — silent
  *
+ * CHECK 2 — SystemWriteInWww (issue #1895). Fixtures live at path-dependent
+ * locations under tests/phpcs/fixtures/usr/local/... so the sniff's
+ * "/usr/local/www/" file-path substring check has real substrings to match
+ * against, mirroring the real src/usr/local/www/ tree layout:
+ *
+ *   tests/phpcs/fixtures/usr/local/www/system_write_violation.php — a www/
+ *   path calling PfbConfig::writeSystem() / writeSectionSystem(), plus a
+ *   case-varied (pfbconfig::WRITESYSTEM()) call — all three MUST be flagged.
+ *
+ *   tests/phpcs/fixtures/usr/local/www/system_write_compliant.php — the same
+ *   www/ path, but PfbConfig::write()/writeSection() (different method),
+ *   SomethingElse::writeSystem() (different class), and a comment/string
+ *   mentioning "PfbConfig::writeSystem" — all MUST stay silent.
+ *
+ *   tests/phpcs/fixtures/usr/local/pkg/pfblockerng/system_write_compliant.php
+ *   — a non-www path with the identical writeSystem()/writeSectionSystem()
+ *   call shapes as the violating fixture — MUST stay silent (the legitimate
+ *   system-caller use case the methods exist for).
+ *
+ * A final real-tree assertion runs the sniff over the actual
+ * src/usr/local/www/ directory and asserts zero SystemWriteInWww findings —
+ * the confinement this check exists to enforce holds today.
+ *
  * If phpcs is not installed the suite SKIPs — CI's php-codesniffer job is the
  * hard gate; never falsely fails in a vendor-less environment.
  */
 final class RequireConfigGatewaySniffTest extends TestCase
 {
 	private const SOURCE = 'PfBlockerNG.Config.RequireConfigGateway.RawRegisteredKeyAccess';
+	private const SOURCE_SYSTEM_WRITE = 'PfBlockerNG.Config.RequireConfigGateway.SystemWriteInWww';
 
 	private static function repoRoot(): string
 	{
@@ -64,18 +90,35 @@ final class RequireConfigGatewaySniffTest extends TestCase
 
 	/**
 	 * Run the custom PfBlockerNG standard over one fixture and return only the
-	 * RequireConfigGateway findings (source = self::SOURCE).
+	 * RequireConfigGateway findings matching $source (default: self::SOURCE,
+	 * the CHECK 1 RawRegisteredKeyAccess code).
 	 *
 	 * @return list<array<string, mixed>>
 	 */
-	private function findingsFor(string $fixture): array
+	private function findingsFor(string $fixture, string $source = self::SOURCE): array
+	{
+		$path = self::repoRoot() . '/tests/phpcs/fixtures/' . $fixture;
+		$this->assertFileExists($path, "fixture {$fixture} must exist");
+
+		return $this->findingsForPath($path, $source);
+	}
+
+	/**
+	 * Run the custom PfBlockerNG standard over an arbitrary file or directory
+	 * (absolute path) and return only the findings matching $source, across
+	 * every file phpcs reports on. Used for CHECK 2's real-tree assertion,
+	 * where the fixture-path convention of findingsFor() does not apply.
+	 *
+	 * @return list<array<string, mixed>>
+	 */
+	private function findingsForPath(string $path, string $source): array
 	{
 		$root = self::repoRoot();
-		$path = $root . '/tests/phpcs/fixtures/' . $fixture;
-		$this->assertFileExists($path, "fixture {$fixture} must exist");
+		$this->assertFileExists($path, "{$path} must exist");
 
 		$cmd = escapeshellarg(self::phpcsBin())
 			. ' --standard=' . escapeshellarg($root . '/tests/phpcs/PfBlockerNG/ruleset.xml')
+			. ' --extensions=php,inc'
 			. ' --report=json'
 			. ' ' . escapeshellarg($path)
 			. ' 2>/dev/null';
@@ -86,11 +129,17 @@ final class RequireConfigGatewaySniffTest extends TestCase
 		$report = json_decode((string) $json, TRUE);
 		$this->assertIsArray($report, 'phpcs JSON report must decode');
 
-		$messages = $report['files'][$path]['messages'] ?? [];
-		return array_values(array_filter(
-			$messages,
-			static fn (array $m): bool => ($m['source'] ?? '') === self::SOURCE
-		));
+		$findings = [];
+		foreach (($report['files'] ?? []) as $file => $data) {
+			$messages = $data['messages'] ?? [];
+			foreach ($messages as $message) {
+				if (($message['source'] ?? '') === $source) {
+					$findings[] = $message + ['file' => $file];
+				}
+			}
+		}
+
+		return $findings;
 	}
 
 	/**
@@ -177,6 +226,119 @@ final class RequireConfigGatewaySniffTest extends TestCase
 			[],
 			$findings,
 			'ADR-28 bool_compliant fixture must produce no RequireConfigGateway findings'
+		);
+	}
+
+	/**
+	 * CHECK 2 — issue #1895 SystemWriteInWww, violating fixture.
+	 *
+	 * tests/phpcs/fixtures/usr/local/www/system_write_violation.php lives at a
+	 * path containing "/usr/local/www/" and calls PfbConfig::writeSystem() /
+	 * PfbConfig::writeSectionSystem(), plus a case-varied
+	 * pfbconfig::WRITESYSTEM() call — every one MUST be flagged.
+	 */
+	public function testFlagsSystemWriteInWww(): void
+	{
+		$findings = $this->findingsFor(
+			'usr/local/www/system_write_violation.php',
+			self::SOURCE_SYSTEM_WRITE
+		);
+
+		$this->assertCount(
+			3,
+			$findings,
+			'writeSystem(), writeSectionSystem(), and the case-varied call must all be flagged'
+		);
+
+		$lines = array_column($findings, 'line');
+		sort($lines);
+
+		// Line 20: PfbConfig::writeSystem(...)
+		// Line 26: PfbConfig::writeSectionSystem(...)
+		// Line 33: pfbconfig::WRITESYSTEM(...) (case variance)
+		$this->assertSame(
+			[20, 26, 33],
+			$lines,
+			'findings must land on the three static system-write call lines'
+		);
+
+		foreach ($findings as $finding) {
+			$this->assertSame(
+				self::SOURCE_SYSTEM_WRITE,
+				$finding['source'],
+				'every finding must carry the SystemWriteInWww source'
+			);
+		}
+	}
+
+	/**
+	 * CHECK 2 — compliant counterpart, same "/usr/local/www/" path.
+	 *
+	 * tests/phpcs/fixtures/usr/local/www/system_write_compliant.php calls
+	 * PfbConfig::write()/writeSection() (different method), SomethingElse::
+	 * writeSystem() (different class), and merely mentions
+	 * "PfbConfig::writeSystem" in a comment/string — none of that is the
+	 * gated static PfbConfig::writeSystem()/writeSectionSystem() call, so the
+	 * sniff MUST stay entirely silent despite sharing the www/ path with the
+	 * violating fixture above.
+	 */
+	public function testSystemWriteCompliantCasesAreClean(): void
+	{
+		$findings = $this->findingsFor(
+			'usr/local/www/system_write_compliant.php',
+			self::SOURCE_SYSTEM_WRITE
+		);
+
+		$this->assertSame(
+			[],
+			$findings,
+			'write()/writeSection(), a foreign class, and a comment/string mention '
+			. 'must produce no SystemWriteInWww findings'
+		);
+	}
+
+	/**
+	 * CHECK 2 — the legitimate system-caller use case, outside www/.
+	 *
+	 * tests/phpcs/fixtures/usr/local/pkg/pfblockerng/system_write_compliant.php
+	 * calls the identical PfbConfig::writeSystem()/writeSectionSystem() shapes
+	 * as the violating www/ fixture, but its path contains no "/usr/local/www/"
+	 * substring — the sniff MUST stay silent. This is the before/after proof
+	 * that the file path, not the call shape, gates this check.
+	 */
+	public function testSystemWriteOutsideWwwIsClean(): void
+	{
+		$findings = $this->findingsFor(
+			'usr/local/pkg/pfblockerng/system_write_compliant.php',
+			self::SOURCE_SYSTEM_WRITE
+		);
+
+		$this->assertSame(
+			[],
+			$findings,
+			'identical writeSystem()/writeSectionSystem() calls outside /usr/local/www/ '
+			. 'must produce no SystemWriteInWww findings'
+		);
+	}
+
+	/**
+	 * CHECK 2 — real-tree assertion. The confinement issue #1895's docblocks
+	 * promise (writeSystem()/writeSectionSystem() are system-caller-only) MUST
+	 * hold mechanically across the actual shipped web UI today: zero
+	 * SystemWriteInWww findings over src/usr/local/www/.
+	 */
+	public function testRealWwwTreeHasNoSystemWriteCalls(): void
+	{
+		$findings = $this->findingsForPath(
+			self::repoRoot() . '/src/usr/local/www',
+			self::SOURCE_SYSTEM_WRITE
+		);
+
+		$this->assertSame(
+			[],
+			$findings,
+			'src/usr/local/www/ must contain zero PfbConfig::writeSystem()/'
+			. 'writeSectionSystem() calls (issue #1895 confinement)'
 		);
 	}
 }

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -1,8 +1,11 @@
 <?php
 
 /*
- * ADR-29 item — enforce the config-gateway access rule mechanically.
+ * ADR-29 / issue #1895 — enforce the config-gateway access rules mechanically.
  *
+ * Carries two independent checks (two error codes, one sniff class):
+ *
+ * CHECK 1 — RawRegisteredKeyAccess (ADR-29).
  * Flags any config_get_path / config_set_path / config_del_path call whose
  * first argument is a static string literal that resolves to a REGISTERED
  * installedpackages/pfblockerng* key (i.e. a key present in
@@ -26,6 +29,33 @@
  * paths derived from pfb_cfg_registry()) embedded as a sniff property.  The
  * list must be kept in sync with pfb_cfg_registry() in pfblockerng_extra.inc.
  *
+ * CHECK 2 — SystemWriteInWww (issue #1895).
+ * PfbConfig::writeSystem() / PfbConfig::writeSectionSystem() write with NO
+ * per-field write_priv authorization check (see the docblocks on those two
+ * methods in pfblockerng_extra.inc) — they exist only for no-session system
+ * callers (cron/install/migrations/CLI/core hooks). Any file whose path
+ * (normalised to forward slashes) contains "/usr/local/www/" — the pfSense
+ * web UI, which always runs inside an authenticated session — MUST NOT call
+ * either variant; it flags a static PfbConfig::writeSystem(...) /
+ * PfbConfig::writeSectionSystem(...) call (case-insensitive method AND class
+ * name, matching PHP's own case-insensitivity) wherever it appears under
+ * www/.
+ *
+ * PRECISE by design, same T_STRING-token mechanism as check 1 — does NOT
+ * flag:
+ *   a) The same call outside www/ (e.g. pfblockerng_extra.inc itself, cron/
+ *      install/migration code under pkg/pfblockerng/) — the legitimate
+ *      system-caller use case.
+ *   b) PfbConfig::write() / PfbConfig::writeSection() (authorization-checked
+ *      variants) — different method name.
+ *   c) The same method name on any class other than PfbConfig.
+ *   d) A comment or string literal that merely mentions
+ *      "PfbConfig::writeSystem" — T_STRING only matches real code tokens.
+ *
+ * OUT OF SCOPE by design (static greppability, not full data-flow analysis):
+ * a call reached through an alias/variable (`$c::writeSystem()`) or through
+ * reflection/`call_user_func()` will NOT be flagged.
+ *
  * Wired from phpcs.xml.dist as PfBlockerNG.Config.RequireConfigGateway.
  */
 
@@ -46,6 +76,25 @@ class RequireConfigGatewaySniff implements Sniff
 		'config_set_path',
 		'config_del_path',
 	];
+
+	/**
+	 * PfbConfig methods that bypass per-field write_priv authorization (#1895) —
+	 * confined to no-session system callers (cron/install/migrations/CLI/core
+	 * hooks). Lower-case; compared case-insensitively (PHP method names are
+	 * case-insensitive).
+	 *
+	 * @var string[]
+	 */
+	private const SYSTEM_WRITE_METHODS = [
+		'writesystem',
+		'writesectionsystem',
+	];
+
+	/**
+	 * Substring a normalised (forward-slash) file path must contain for the
+	 * SystemWriteInWww check to apply — the pfSense web UI tree.
+	 */
+	private const WWW_PATH_MARKER = '/usr/local/www/';
 
 	/**
 	 * The complete set of registered installedpackages/pfblockerng* key paths.
@@ -187,9 +236,24 @@ class RequireConfigGatewaySniff implements Sniff
 	}
 
 	/**
+	 * Dispatch to both independent checks. Neither may short-circuit the
+	 * other — a T_STRING token can only match one of the two gated-name sets,
+	 * but each check performs its own early return, so both always run.
+	 *
 	 * @param int $stackPtr
 	 */
 	public function process(File $phpcsFile, $stackPtr)
+	{
+		$this->processRawConfigPathCall($phpcsFile, (int) $stackPtr);
+		$this->processSystemWriteInWww($phpcsFile, (int) $stackPtr);
+	}
+
+	/**
+	 * CHECK 1 — ADR-29 RawRegisteredKeyAccess.
+	 *
+	 * @param int $stackPtr
+	 */
+	private function processRawConfigPathCall(File $phpcsFile, int $stackPtr): void
 	{
 		$tokens = $phpcsFile->getTokens();
 
@@ -273,6 +337,69 @@ class RequireConfigGatewaySniff implements Sniff
 			),
 			$stackPtr,
 			'RawRegisteredKeyAccess'
+		);
+	}
+
+	/**
+	 * CHECK 2 — issue #1895 SystemWriteInWww.
+	 *
+	 * Flags a static PfbConfig::writeSystem(...) / PfbConfig::writeSectionSystem(...)
+	 * call found anywhere under a /usr/local/www/ path. Requires the T_DOUBLE_COLON
+	 * call form on the exact class name PfbConfig (case-insensitive) — the opposite
+	 * shape from check 1's isFunctionCall(), which disqualifies T_DOUBLE_COLON.
+	 *
+	 * @param int $stackPtr
+	 */
+	private function processSystemWriteInWww(File $phpcsFile, int $stackPtr): void
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		// Must be one of the gated system-write method names.
+		$name = strtolower((string) $tokens[$stackPtr]['content']);
+		if (!in_array($name, self::SYSTEM_WRITE_METHODS, TRUE)) {
+			return;
+		}
+
+		// Must be a call (next non-whitespace token is '(').
+		$next = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, NULL, TRUE);
+		if ($next === FALSE || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
+			return;
+		}
+
+		// Must be a static call: previous non-whitespace token is T_DOUBLE_COLON.
+		$doubleColon = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, NULL, TRUE);
+		if ($doubleColon === FALSE || $tokens[$doubleColon]['code'] !== T_DOUBLE_COLON) {
+			return;
+		}
+
+		// The class name immediately before '::' must be PfbConfig (case-insensitive).
+		// A leading namespace separator further back (e.g. \PfbConfig::) is not
+		// examined and does not disqualify the match.
+		$classToken = $phpcsFile->findPrevious(T_WHITESPACE, $doubleColon - 1, NULL, TRUE);
+		if ($classToken === FALSE || $tokens[$classToken]['code'] !== T_STRING) {
+			return;
+		}
+		if (strtolower((string) $tokens[$classToken]['content']) !== 'pfbconfig') {
+			return;
+		}
+
+		// Only enforce under the pfSense web UI tree — the authenticated-session
+		// surface these two methods are not authorized for (issue #1895).
+		$filename = str_replace('\\', '/', $phpcsFile->getFilename());
+		if (strpos($filename, self::WWW_PATH_MARKER) === FALSE) {
+			return;
+		}
+
+		$phpcsFile->addError(
+			sprintf(
+				'issue #1895: PfbConfig::%s() bypasses per-field write_priv authorization '
+				. 'and is reserved for no-session system contexts (cron/install/migrations/'
+				. 'CLI/core hooks) — www/ code must use PfbConfig::write()/writeSection() '
+				. 'instead, so isAllowedPage() authorization applies.',
+				$tokens[$stackPtr]['content']
+			),
+			$stackPtr,
+			'SystemWriteInWww'
 		);
 	}
 

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -63,6 +63,7 @@ namespace PfBlockerNG\Sniffs\Config;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
 
 class RequireConfigGatewaySniff implements Sniff
 {
@@ -360,14 +361,17 @@ class RequireConfigGatewaySniff implements Sniff
 			return;
 		}
 
-		// Must be a call (next non-whitespace token is '(').
-		$next = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, NULL, TRUE);
+		// Must be a call (next non-whitespace-or-comment token is '(') -- walking past
+		// Tokens::$emptyTokens (whitespace AND every comment/doc-comment type), not just
+		// T_WHITESPACE, so a comment wedged between the tokens (e.g.
+		// PfbConfig::/*x*/writeSystem(...)) cannot evade the sniff.
+		$next = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, NULL, TRUE);
 		if ($next === FALSE || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
 			return;
 		}
 
-		// Must be a static call: previous non-whitespace token is T_DOUBLE_COLON.
-		$doubleColon = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, NULL, TRUE);
+		// Must be a static call: previous non-whitespace-or-comment token is T_DOUBLE_COLON.
+		$doubleColon = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, NULL, TRUE);
 		if ($doubleColon === FALSE || $tokens[$doubleColon]['code'] !== T_DOUBLE_COLON) {
 			return;
 		}
@@ -375,7 +379,7 @@ class RequireConfigGatewaySniff implements Sniff
 		// The class name immediately before '::' must be PfbConfig (case-insensitive).
 		// A leading namespace separator further back (e.g. \PfbConfig::) is not
 		// examined and does not disqualify the match.
-		$classToken = $phpcsFile->findPrevious(T_WHITESPACE, $doubleColon - 1, NULL, TRUE);
+		$classToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, $doubleColon - 1, NULL, TRUE);
 		if ($classToken === FALSE || $tokens[$classToken]['code'] !== T_STRING) {
 			return;
 		}

--- a/tests/phpcs/fixtures/usr/local/pkg/pfblockerng/system_write_compliant.php
+++ b/tests/phpcs/fixtures/usr/local/pkg/pfblockerng/system_write_compliant.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * issue #1895 RequireConfigGateway sniff fixture (NOT production code).
+ *
+ * Lives under a fixtures/usr/local/pkg/pfblockerng/ path — no "/usr/local/www/"
+ * substring anywhere in the file path. The exact same PfbConfig::writeSystem()
+ * / PfbConfig::writeSectionSystem() call shapes as system_write_violation.php
+ * MUST stay silent here: this is the legitimate no-session system-caller use
+ * case (cron/install/migrations/CLI/core hooks) the two methods exist for.
+ *
+ * Pinned by RequireConfigGatewaySniffTest::testSystemWriteOutsideWwwIsClean.
+ */
+
+function pfb_pkg_writesystem_system_caller()
+{
+	// System-context caller (e.g. cron/install) — legitimate, must stay silent.
+	PfbConfig::writeSystem('pfb_keep', '30');
+}
+
+function pfb_pkg_writesectionsystem_system_caller()
+{
+	// System-context caller (e.g. migration) — legitimate, must stay silent.
+	PfbConfig::writeSectionSystem('installedpackages/pfblockerng/config/0', []);
+}

--- a/tests/phpcs/fixtures/usr/local/www/system_write_compliant.php
+++ b/tests/phpcs/fixtures/usr/local/www/system_write_compliant.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * issue #1895 RequireConfigGateway sniff fixture (NOT production code).
+ *
+ * Lives under a fixtures/usr/local/www/ path (same as system_write_violation.php)
+ * so the "/usr/local/www/" path-substring check applies here too — this is the
+ * before/after proof for SystemWriteInWww: same path, but every call below MUST
+ * stay silent, so it is the method name / class name / token shape that decides
+ * the finding, not merely being under www/.
+ *
+ * Silent cases:
+ *   a) PfbConfig::write() / PfbConfig::writeSection() — the authorization-
+ *      checked variants; different method names entirely.
+ *   b) SomethingElse::writeSystem() — same method name, wrong class.
+ *   c) A comment mentioning "PfbConfig::writeSystem" as plain text — the
+ *      T_STRING token check is structural, so prose never triggers it.
+ *
+ * Pinned by RequireConfigGatewaySniffTest::testSystemWriteCompliantCasesAreClean.
+ */
+
+function pfb_www_write_authorized_variant()
+{
+	// PfbConfig::write() enforces write_priv — must never be flagged.
+	PfbConfig::write('pfb_keep', '30');
+}
+
+function pfb_www_writesection_authorized_variant()
+{
+	// PfbConfig::writeSection() enforces write_priv — must never be flagged.
+	PfbConfig::writeSection('installedpackages/pfblockerng/config/0', []);
+}
+
+function pfb_www_foreign_class_writesystem()
+{
+	// Same method name, but the class is not PfbConfig — must never be flagged.
+	SomethingElse::writeSystem('pfb_keep', '30');
+}
+
+function pfb_www_writesystem_mentioned_in_comment()
+{
+	// Mentioning PfbConfig::writeSystem() in a comment (e.g. explaining why it
+	// must not be called here) is not code — must never be flagged.
+	// See also: 'PfbConfig::writeSystem' referenced in a string literal below.
+	$note = 'do not call PfbConfig::writeSystem() from this page';
+
+	return $note;
+}

--- a/tests/phpcs/fixtures/usr/local/www/system_write_violation.php
+++ b/tests/phpcs/fixtures/usr/local/www/system_write_violation.php
@@ -46,3 +46,10 @@ function pfb_www_writesystem_comment_after_double_colon()
 	// the sniff either.
 	PfbConfig::/*x*/writeSystem('pfb_keep', '30');
 }
+
+function pfb_www_writesystem_comment_before_paren()
+{
+	// The third comment gap: between the method name and '(' — the sniff's
+	// forward walk to the opening parenthesis must skip comments too.
+	PfbConfig::writeSystem/*x*/('pfb_keep', '30');
+}

--- a/tests/phpcs/fixtures/usr/local/www/system_write_violation.php
+++ b/tests/phpcs/fixtures/usr/local/www/system_write_violation.php
@@ -32,3 +32,17 @@ function pfb_www_writesystem_case_variance()
 	// case-insensitive) — must still be flagged.
 	pfbconfig::WRITESYSTEM('pfb_keep', '30');
 }
+
+function pfb_www_writesystem_comment_before_double_colon()
+{
+	// A comment wedged between the class name and '::' must not evade the
+	// sniff -- it must walk past comment tokens, not just whitespace.
+	PfbConfig/*x*/::writeSystem('pfb_keep', '30');
+}
+
+function pfb_www_writesystem_comment_after_double_colon()
+{
+	// A comment wedged between '::' and the method name must not evade
+	// the sniff either.
+	PfbConfig::/*x*/writeSystem('pfb_keep', '30');
+}

--- a/tests/phpcs/fixtures/usr/local/www/system_write_violation.php
+++ b/tests/phpcs/fixtures/usr/local/www/system_write_violation.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * issue #1895 RequireConfigGateway sniff fixture (NOT production code).
+ *
+ * Lives under a fixtures/usr/local/www/ path so the sniff's "/usr/local/www/"
+ * path-substring check applies, exactly as it would to a real pfSense web UI
+ * file. Static PfbConfig::writeSystem() / PfbConfig::writeSectionSystem()
+ * calls here MUST each be flagged with the SystemWriteInWww error code —
+ * those two methods bypass per-field write_priv authorization and are
+ * reserved for no-session system contexts (cron/install/migrations/CLI/core
+ * hooks), never a web-UI page.
+ *
+ * Pinned by RequireConfigGatewaySniffTest::testFlagsSystemWriteInWww.
+ */
+
+function pfb_www_writesystem_violation()
+{
+	// Direct writeSystem() call from a www/ page — must be flagged.
+	PfbConfig::writeSystem('pfb_keep', '30');
+}
+
+function pfb_www_writesectionsystem_violation()
+{
+	// Direct writeSectionSystem() call from a www/ page — must be flagged.
+	PfbConfig::writeSectionSystem('installedpackages/pfblockerng/config/0', []);
+}
+
+function pfb_www_writesystem_case_variance()
+{
+	// Case-insensitive class AND method name (PHP identifiers are
+	// case-insensitive) — must still be flagged.
+	pfbconfig::WRITESYSTEM('pfb_keep', '30');
+}


### PR DESCRIPTION
Registered config-field writes now carry their own authorization, generalising the `pfblockerng_hook_edit.inc` GATE 1 precedent: the privilege is a property of the write, not of whichever call site remembered to check.

Fixes #1895

## What changed

- **Registry `write_priv`** (optional per-entry key): the page privilege a write must re-assert via `isAllowedPage()`. Absent resolves to `PfbConfig::WRITE_PRIV_DEFAULT` (`pfblockerng/pfblockerng_general.php` — pfSense grants every pfBlockerNG page through the single `page-firewall-pfblockerng` privilege entry, so finer per-page defaults would distinguish nothing). The only explicit override is `pfb_software_check` → `pkg_mgr_installed.php`, the #485 Software-page secondary gate.
- **`PfbConfig::write()` / `writeSection()` enforce it fail-closed**: an undefined `isAllowedPage()` (no web session — `priv.inc` lives only in the web auth include chain) or a FALSE return throws `RuntimeException`. The loud throw is deliberate: the silent-FALSE alternative is exactly the CLI trap the issue documents.
- **The `writeSection()` gate is delta-aware** (adversarial-review fix, owner-approved): a registered field present in `$data` is an authorization event only when its canonical incoming value differs from the canonical stored value; all checks still run *before* any mutation. This deliberately refines the acceptance criterion's letter — "denied → refuse" means a denied **change** is refused; an unchanged pass-through is not a write. Without the carve-out, the General page's whole-section `readSection()`→`writeSection()` composition 500'd a scoped operator's save the moment a stored `pfb_software_check` rode through unchanged (the exact #485 persona this hardening serves — reproduced end-to-end in review). Single-key `write()` stays strict: an explicit per-key call is always an authorization event.
- **`PfbConfig::writeSystem()` / `writeSectionSystem()`** skip the check — the recommended shape from the issue discussion, chosen for call-site visibility and greppability. Converted system-context call sites: all 14 in `pfblockerng_install.inc`, the `pfb_reuse` one-shot clear in `pfblockerng_apply.inc`, and `pfb_settings_family_record()` / `pfb_run_migrations()` / `pfb_alias_rename_followup()` in `pfblockerng_extra.inc`. The alias-rename conversion is load-bearing, not just bookkeeping: that function runs from pfSense's `firewall_aliases_edit` pre-write hook under a firewall-alias-only privilege, so enforcement there would have broken a supported path (#708's fix). `pfb_alerts_ip_action()` deliberately stays on the enforced `write()` — its only callers are the Alerts page.
- **Sniff confinement**: `RequireConfigGatewaySniff` gains a second check (`SystemWriteInWww`) refusing `PfbConfig::writeSystem`/`writeSectionSystem` in any file under `src/usr/local/www/`, so the bypass can never leak into page code unnoticed.
- **Docs**: the write-authorization model recorded in `docs/misc/config-gateway.md`.
- **Out of scope**: `delete()` / `deleteSection()` carry no privilege check — flagging for the record; can be a follow-up if wanted (a delete resets a field to its registered default, which for `pfb_software_check` would mean re-enabling checks).

## Acceptance criteria (owner comment) → coverage

All in `tests/php/CfgWriteAuthorizationTest.php` (rows A–L: A–I from the original design; J unchanged pass-through succeeds, K a real change of the gated field is still refused, L absent-stored ≡ registered default), executed test-first with a frozen red→green proof (red run before any production edit, byte-identical file re-run green; freeze hashes verified by `scripts/agent/verify-red-proof.sh` on both steps):

- `write_priv` denied → `write()`/`writeSection()` refuse (`RuntimeException` naming the key); allowed → accept.
- `writeSection()` refuses **before any mutation** (whole-section state asserted unchanged) and leaves foreign/unregistered keys alone on the allowed path.
- The CLI-trap regression: `writeSystem()`/`writeSectionSystem()` succeed with `isAllowedPage()` defined and returning FALSE for every page (the priv.inc-loaded case), and store byte-identical values to an allowed `write()`.
- Sniff: fixtures prove `writeSystem`/`writeSectionSystem` are flagged under a `/usr/local/www/` path (including case-varied calls), not flagged elsewhere / for other classes / in comments and strings, plus a real-tree scan of `src/usr/local/www/` asserting zero violations today (`tests/php/RequireConfigGatewaySniffTest.php`).
- Anti-vacuity: the denial tests catch `RuntimeException` specifically and assert the message names the key, so a differently-thrown exception cannot fake the gate being reached; the red run (no exception thrown on pre-change code) is the executed proof the check now fires.

## Gates

`run-gates.sh --diff origin/devel` PASS on both steps (php -l, full PHPUnit — 4578 tests / 0 failures, phpstan clean, phpcs clean); each step independently gated by a separate verifier session that re-ran the gates, re-executed the red proofs, and read the full diffs. Full suite re-run after rebasing onto the #1896 registry additions.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
