### PR TITLE
tests: pin sniff registeredPaths to pfb_cfg_registry() parity (#1902)

### DIFF
--- a/tests/php/SniffRegistryParityTest.php
+++ b/tests/php/SniffRegistryParityTest.php
@@ -19,10 +19,10 @@ use PHPUnit\Framework\TestCase;
  * "<section>/<key>" per entry — and asserts set-equality against the sniff
  * property, naming any missing/extra path in the failure message.
  *
- * The sniff class implements PHP_CodeSniffer\Sniffs\Sniff. Under
- * vendor/bin/phpunit the composer autoloader provides it; a no-op stub is
- * declared otherwise so the class loads without the phpcs runtime (only the
- * property is inspected here — behaviour is pinned by
+ * The sniff class implements PHP_CodeSniffer\Sniffs\Sniff. phpcs ships no
+ * composer autoload metadata, so that interface is not autoloadable here;
+ * the guarded no-op stub below is what lets the class load without the
+ * phpcs runtime (only the property is inspected — behaviour is pinned by
  * RequireConfigGatewaySniffTest).
  */
 final class SniffRegistryParityTest extends TestCase

--- a/tests/php/SniffRegistryParityTest.php
+++ b/tests/php/SniffRegistryParityTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1902 — mechanical sync guard between the ADR-29 enforcement sniff and
+ * the config-gateway registry.
+ *
+ * RequireConfigGatewaySniff::$registeredPaths (tests/phpcs/.../Config/
+ * RequireConfigGatewaySniff.php) is a hand-maintained literal list of full
+ * config paths; pfb_cfg_registry() (pfblockerng_extra.inc) is the source of
+ * truth it mirrors. Before this test the sync was enforced only by a comment:
+ * a key registered in the gateway but missing from the sniff silently lost its
+ * mechanical enforcement (raw config_*_path on that key passed phpcs).
+ *
+ * This test derives the expected path set from pfb_cfg_registry() itself —
+ * "<section>/<key>" per entry — and asserts set-equality against the sniff
+ * property, naming any missing/extra path in the failure message.
+ *
+ * The sniff class implements PHP_CodeSniffer\Sniffs\Sniff. Under
+ * vendor/bin/phpunit the composer autoloader provides it; a no-op stub is
+ * declared otherwise so the class loads without the phpcs runtime (only the
+ * property is inspected here — behaviour is pinned by
+ * RequireConfigGatewaySniffTest).
+ */
+final class SniffRegistryParityTest extends TestCase
+{
+	public function testRegisteredPathsMatchCfgRegistry(): void
+	{
+		if (!interface_exists(\PHP_CodeSniffer\Sniffs\Sniff::class)) {
+			eval('namespace PHP_CodeSniffer\Sniffs; interface Sniff {}');
+		}
+		require_once dirname(__DIR__)
+			. '/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php';
+
+		$actual = (array) (new \PfBlockerNG\Sniffs\Config\RequireConfigGatewaySniff())->registeredPaths;
+
+		$expected = [];
+		foreach (pfb_cfg_registry() as $key => $entry) {
+			$expected[] = $entry['section'] . '/' . $key;
+		}
+
+		$missing = array_values(array_diff($expected, $actual));
+		$extra   = array_values(array_diff($actual, $expected));
+
+		$this->assertSame([], $missing,
+			'pfb_cfg_registry() paths missing from the sniff $registeredPaths (add them there): '
+			. implode(', ', $missing));
+		$this->assertSame([], $extra,
+			'sniff $registeredPaths entries absent from pfb_cfg_registry() (stale — remove or register): '
+			. implode(', ', $extra));
+
+		// Exactness (catches duplicates on either side, which the set diffs miss).
+		sort($expected);
+		sort($actual);
+		$this->assertSame($expected, $actual);
+	}
+}

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -110,6 +110,8 @@ class RequireConfigGatewaySniff implements Sniff
 	 */
 	public $registeredPaths = [
 		// installedpackages/pfblockerng/config/0 (general settings)
+		// Settings snapshot schema marker (drift caught by issue #1902 parity test).
+		'installedpackages/pfblockerng/config/0/settings_family',
 		'installedpackages/pfblockerng/config/0/enable_cb',
 		'installedpackages/pfblockerng/config/0/pfb_keep',
 		'installedpackages/pfblockerng/config/0/pfb_interval',


### PR DESCRIPTION
## What

Adds the mechanical sync guard requested by #1902: a PHPUnit test (`tests/php/SniffRegistryParityTest.php`) that derives the expected config-path set from `pfb_cfg_registry()` itself (`<section>/<key>` per entry) and asserts set-equality against `RequireConfigGatewaySniff::$registeredPaths`, naming any missing/extra path in the failure message. A final sorted `assertSame` also catches duplicates on either side, which the set diffs alone would miss.

The sniff class implements `PHP_CodeSniffer\Sniffs\Sniff`; under `vendor/bin/phpunit` the composer autoloader provides the interface, and a no-op stub is declared otherwise so only the property is inspected without the phpcs runtime.

## Drift caught on the first red run

The test's initial run against the unmodified tree failed with real drift: `installedpackages/pfblockerng/config/0/settings_family` is registered in the gateway but was absent from the sniff, so raw `config_*_path` access to it would have passed phpcs. This PR adds it to `$registeredPaths`. Its only accessors are the `pfb_settings_family_*` helpers inside `pfblockerng_extra.inc`, which the sniff excludes by design, so `composer phpcs -- --standard=phpcs.xml.dist src/` stays clean.

## Red→green proof (executed)

- RED (unmodified tree): `1) SniffRegistryParityTest::testRegisteredPathsMatchCfgRegistry` — "pfb_cfg_registry() paths missing from the sniff $registeredPaths (add them there): installedpackages/pfblockerng/config/0/settings_family" — `FAILURES! Tests: 1, Assertions: 1, Failures: 1.`
- GREEN (after the sniff edit, test byte-identical, sha256 `75643dab…`): `OK (1 test, 3 assertions)`

## Gates

`scripts/agent/run-gates.sh`: `GATES: PASS` (php -l, full `vendor/bin/phpunit`, `composer phpstan`, `composer phpcs -- --standard=phpcs.xml.dist src/`).

## Acceptance (issue #1902)

- WHEN a key exists in `pfb_cfg_registry()` but not in `$registeredPaths` (or vice versa) THEN the test fails naming the missing/extra path — pinned by the two diff-based assertions; demonstrated live by the `settings_family` red run above (a real drift scenario, not a synthetic mutation).

Fixes #1902

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for recognizing the `installedpackages/pfblockerng/config/0/settings_family` configuration path.
  * Added validation to ensure registered configuration paths remain synchronized with the available configuration registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->