### PR TITLE
pfblockerng: normalize extras download credentials for every feed type (#1906)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12204,6 +12204,30 @@ function pfb_download_http_headers(array $extra_headers, string $conditional_hea
 }
 
 
+// Issue #1906: normalize an extras feed's download credentials for PfbDownloadRequest, whose
+// $username/$password are non-nullable strings. Each extras feed type carries its credentials
+// differently -- the MaxMind (geoip) feeds take them from the settings, a DNSBL Blacklist
+// category may carry its own, and the IPinfo ASN/TOP1M feeds carry none at all (they
+// authenticate by URL token / header, or not at all) -- so a per-type branch in the caller
+// left the credential-free types passing an undefined array key (NULL) straight into the
+// constructor, an uncaught TypeError that aborted the whole extras run. Normalizing every
+// type here keeps that class of crash out of the call sites. Pure/no I/O.
+//
+// Only NULL/absent means "no credential": unlike the `?: ''` this replaces, a literal "0"
+// password now survives instead of being silently blanked.
+//
+// $feed: one $pfb['extras'] entry. $maxmind_account/$maxmind_key: the settings' MaxMind
+//   credentials, already coerced to strings by pfb_global().
+// @return array{0: string, 1: string} the username and password to download this feed with.
+function pfb_extras_credentials(array $feed, string $maxmind_account, string $maxmind_key): array
+{
+	if (($feed['type'] ?? '') === 'geoip') {
+		return array($maxmind_account, $maxmind_key);
+	}
+	return array((string) ($feed['username'] ?? ''), (string) ($feed['password'] ?? ''));
+}
+
+
 final class PfbDownloadRequest
 {
 	public function __construct(

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12213,8 +12213,10 @@ function pfb_download_http_headers(array $extra_headers, string $conditional_hea
 // constructor, an uncaught TypeError that aborted the whole extras run. Normalizing every
 // type here keeps that class of crash out of the call sites. Pure/no I/O.
 //
-// Only NULL/absent means "no credential": unlike the `?: ''` this replaces, a literal "0"
-// password now survives instead of being silently blanked.
+// Only NULL/absent means "no credential" here: unlike the `?: ''` this replaces, a literal "0"
+// credential is reported faithfully rather than blanked. That is this helper's contract only --
+// pfb_download() still gates CURLOPT_USERPWD on !empty(), which drops a "0" credential before
+// curl either way, so no request on the wire changes (issue #1909).
 //
 // $feed: one $pfb['extras'] entry. $maxmind_account/$maxmind_key: the settings' MaxMind
 //   credentials, already coerced to strings by pfb_global().

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -492,21 +492,20 @@ function pfblockerng_download_extras($timeout=600, $type='') {
 			continue;
 		}
 
-		// Add Token/Credentials
-		if ($feed['type'] == 'geoip') {
-			$feed['username'] = $pfb['maxmind_account'];
-			$feed['password'] = $pfb['maxmind_key'];
-		}
-		elseif ($feed['type'] == 'asn') {
+		// Add Credentials. Issue #1906: normalized for EVERY feed type, not per branch --
+		// the ASN feeds carry no username/password keys at all, and the per-type branch this
+		// replaced left them undefined (NULL), fataling on PfbDownloadRequest's string
+		// parameters and aborting the whole extras run.
+		list($feed['username'], $feed['password']) =
+		    pfb_extras_credentials($feed, $pfb['maxmind_account'], $pfb['maxmind_key']);
+
+		// Add Token
+		if ($feed['type'] == 'asn') {
 			// rawurlencode the token so URL correctness does not depend on the input
 			// validator's strictness. Today's tokens are word chars only (rawurlencode
 			// is a no-op on them), but encoding here keeps the query well-formed if the
 			// token format ever changes (e.g. base64/JWT with '=' '.' '/').
 			$feed['url'] = "{$feed['url']}" . rawurlencode($pfb['asn_token']);
-		}
-		else {
-			$feed['username'] = $feed['username'] ?: '';
-			$feed['password'] = $feed['password'] ?: '';
 		}
 
 		$file_dwn = "{$feed['folder']}/{$feed['file_dwn']}";

--- a/tests/php/ExtrasFeedCredentialsTest.php
+++ b/tests/php/ExtrasFeedCredentialsTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1906 — every extras feed must reach PfbDownloadRequest with STRING credentials.
+ *
+ * pfblockerng_download_extras() normalized the per-feed credentials in a three-way branch
+ * that gave the IPinfo ASN feeds no normalization at all: the 'geoip' arm assigned the
+ * MaxMind account/key, the catch-all arm coerced whatever the feed carried, and the 'asn'
+ * arm only appended the token to the URL. The ASN extras are built with url/file_dwn/file/
+ * folder/type and nothing else, so $feed['username'] stayed an undefined array key — NULL —
+ * and PfbDownloadRequest's non-nullable `string $username` turned that into an uncaught
+ * TypeError that aborted the whole extras run (the reported crash: no ASN database refresh,
+ * and on the 'dcc' cron path no MaxMind country-ISO regeneration either, because the fatal
+ * lands before pfblockerng_uc_countries()).
+ *
+ * The normalization now happens ONCE, for every feed type, in pfb_extras_credentials() —
+ * hosted in pfblockerng.inc rather than the www/ dispatcher so it is loadable by the PHPUnit
+ * bootstrap (the ADR43-5 treatment pfblockerng_tick() received).
+ *
+ * Red→green: against the pre-change worktree every test below fails with
+ * "Call to undefined function pfb_extras_credentials()"; testAsnFeedWithoutCredentialKeys*
+ * are the defect's in-suite reproduction — the second one reconstructs the exact reported
+ * failure by feeding the result to a real PfbDownloadRequest.
+ *
+ * Branch coverage:
+ *   geoip            — credentials come from the MaxMind settings, not from the feed.
+ *   asn              — no credential keys at all (the bug): empty strings, never NULL.
+ *   blacklist w/ creds — a per-item username/password is passed through untouched.
+ *   blacklist w/o creds / top1m — absent keys: empty strings.
+ *   explicit NULLs   — a key present but NULL is coerced too, not just an absent key.
+ *   falsy-but-real   — a literal "0" password survives (the old `?:` arm blanked it).
+ */
+#[CoversFunction('pfb_extras_credentials')]
+final class ExtrasFeedCredentialsTest extends TestCase
+{
+	/** The MaxMind settings as pfb_global() leaves them for a configured box. */
+	private const MAXMIND_ACCOUNT = '123456';
+	private const MAXMIND_KEY     = 'aBcDeFgHiJkLmNoP';
+
+	/**
+	 * The reported defect, at the helper's boundary: $pfb['extras'][3]/[4] (IPinfo ASN)
+	 * carry no username/password keys whatsoever, so the credentials must come back as
+	 * empty STRINGS. assertSame pins the type — NULL is what crashed the extras run.
+	 */
+	public function testAsnFeedWithoutCredentialKeysYieldsEmptyStrings(): void
+	{
+		// Given: the ASN extras entry exactly as pfblockerng.php builds it.
+		$feed = [
+			'url'      => 'https://ipinfo.io/data/free/asn.mmdb?token=',
+			'file_dwn' => 'asn.mmdb',
+			'file'     => 'asn.mmdb',
+			'folder'   => '/usr/local/share/GeoIP',
+			'type'     => 'asn',
+		];
+
+		// When.
+		[$username, $password] = pfb_extras_credentials($feed, self::MAXMIND_ACCOUNT, self::MAXMIND_KEY);
+
+		// Then: strings, not NULL — and NOT the MaxMind credentials, which the ASN feed
+		// authenticates with a URL token instead.
+		$this->assertSame('', $username, 'an ASN feed carries no username; it must normalize to an empty string, never NULL');
+		$this->assertSame('', $password, 'an ASN feed carries no password; it must normalize to an empty string, never NULL');
+	}
+
+	/**
+	 * The same defect at the site that actually threw: PfbDownloadRequest's constructor.
+	 * Before the fix this is the reported
+	 * "Argument #10 ($username) must be of type string, null given" TypeError.
+	 */
+	public function testAsnFeedYieldsAConstructiblePfbDownloadRequest(): void
+	{
+		$feed = [
+			'url'      => 'https://ipinfo.io/data/free/asn.csv.gz?token=',
+			'file_dwn' => 'asn.csv.gz',
+			'file'     => 'asn.csv',
+			'folder'   => '/usr/local/share/GeoIP',
+			'type'     => 'asn',
+		];
+
+		[$username, $password] = pfb_extras_credentials($feed, self::MAXMIND_ACCOUNT, self::MAXMIND_KEY);
+
+		$request = new PfbDownloadRequest(
+			listUrl: $feed['url'],
+			downloadPath: "{$feed['folder']}/{$feed['file_dwn']}",
+			flex: FALSE,
+			header: "{$feed['folder']}/{$feed['file']}",
+			format: '',
+			logType: 3,
+			versionType: '',
+			timeout: 600,
+			type: $feed['type'],
+			username: $username,
+			password: $password,
+			sourceInterface: FALSE,
+			extraHeaders: [],
+		);
+
+		$this->assertSame('', $request->username, 'the ASN download request must construct with an empty username');
+		$this->assertSame('', $request->password, 'the ASN download request must construct with an empty password');
+	}
+
+	/**
+	 * The MaxMind feeds authenticate with the account/key from the settings, which the feed
+	 * array itself never carries — the helper must inject them, not read the feed.
+	 */
+	public function testGeoipFeedTakesTheMaxmindSettings(): void
+	{
+		$feed = [
+			'url'      => 'https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz',
+			'file_dwn' => 'GeoLite2-Country.tar.gz',
+			'file'     => 'GeoLite2-Country.mmdb',
+			'folder'   => '/usr/local/share/GeoIP',
+			'type'     => 'geoip',
+		];
+
+		[$username, $password] = pfb_extras_credentials($feed, self::MAXMIND_ACCOUNT, self::MAXMIND_KEY);
+
+		$this->assertSame(self::MAXMIND_ACCOUNT, $username, 'a GeoIP feed authenticates with the MaxMind account ID');
+		$this->assertSame(self::MAXMIND_KEY, $password, 'a GeoIP feed authenticates with the MaxMind license key');
+	}
+
+	/**
+	 * A DNSBL Blacklist category may carry its own credentials (pfblockerng.php copies them
+	 * from the catalog item under an isset() guard). Those must survive untouched — the ASN
+	 * fix must not start blanking real credentials.
+	 */
+	public function testBlacklistFeedKeepsItsOwnCredentials(): void
+	{
+		$feed = [
+			'url'      => 'https://example.invalid/list.tar.gz',
+			'name'     => 'ExampleCategory',
+			'type'     => 'blacklist',
+			'username' => 'feeduser',
+			'password' => 'feedpass',
+		];
+
+		[$username, $password] = pfb_extras_credentials($feed, self::MAXMIND_ACCOUNT, self::MAXMIND_KEY);
+
+		$this->assertSame('feeduser', $username, "a blacklist feed's own username must be passed through");
+		$this->assertSame('feedpass', $password, "a blacklist feed's own password must be passed through");
+	}
+
+	/**
+	 * The keyless feed types (TOP1M, and a blacklist category with no credentials in the
+	 * catalog) reach the helper with no credential keys either.
+	 */
+	public function testKeylessFeedTypesYieldEmptyStrings(): void
+	{
+		foreach (['top1m', 'blacklist'] as $type) {
+			[$username, $password] = pfb_extras_credentials(['type' => $type], self::MAXMIND_ACCOUNT, self::MAXMIND_KEY);
+
+			$this->assertSame('', $username, "a credential-free '{$type}' feed must normalize its username to an empty string");
+			$this->assertSame('', $password, "a credential-free '{$type}' feed must normalize its password to an empty string");
+		}
+	}
+
+	/**
+	 * A credential key that is PRESENT but NULL is the same TypeError as an absent one, so
+	 * the coercion must cover it — an absent-key test alone would pass against a `??`-free
+	 * isset() guard.
+	 */
+	public function testExplicitNullCredentialsAreCoerced(): void
+	{
+		$feed = ['type' => 'blacklist', 'username' => NULL, 'password' => NULL];
+
+		[$username, $password] = pfb_extras_credentials($feed, self::MAXMIND_ACCOUNT, self::MAXMIND_KEY);
+
+		$this->assertSame('', $username, 'a NULL username must be coerced to an empty string');
+		$this->assertSame('', $password, 'a NULL password must be coerced to an empty string');
+	}
+
+	/**
+	 * The replaced `?: ''` arm blanked every falsy value, so a literal "0" password was
+	 * silently sent as empty. Only NULL/absent means "no credential"; "0" is a credential.
+	 */
+	public function testFalsyButRealCredentialsSurvive(): void
+	{
+		$feed = ['type' => 'blacklist', 'username' => '0', 'password' => '0'];
+
+		[$username, $password] = pfb_extras_credentials($feed, self::MAXMIND_ACCOUNT, self::MAXMIND_KEY);
+
+		$this->assertSame('0', $username, 'a literal "0" username is a real credential, not an absent one');
+		$this->assertSame('0', $password, 'a literal "0" password is a real credential, not an absent one');
+	}
+}

--- a/tests/php/ExtrasFeedCredentialsTest.php
+++ b/tests/php/ExtrasFeedCredentialsTest.php
@@ -33,7 +33,8 @@ use PHPUnit\Framework\TestCase;
  *   blacklist w/ creds — a per-item username/password is passed through untouched.
  *   blacklist w/o creds / top1m — absent keys: empty strings.
  *   explicit NULLs   — a key present but NULL is coerced too, not just an absent key.
- *   falsy-but-real   — a literal "0" password survives (the old `?:` arm blanked it).
+ *   falsy-but-real   — a literal "0" credential is reported, not blanked (the helper's own
+ *                      contract; pfb_download() drops it downstream either way — issue #1909).
  */
 #[CoversFunction('pfb_extras_credentials')]
 final class ExtrasFeedCredentialsTest extends TestCase
@@ -175,8 +176,12 @@ final class ExtrasFeedCredentialsTest extends TestCase
 	}
 
 	/**
-	 * The replaced `?: ''` arm blanked every falsy value, so a literal "0" password was
-	 * silently sent as empty. Only NULL/absent means "no credential"; "0" is a credential.
+	 * The replaced `?: ''` arm blanked every falsy value. This pins the helper's own contract:
+	 * only NULL/absent means "no credential"; "0" is a credential and is reported as one.
+	 *
+	 * It does not change what reaches the network. pfb_download() gates CURLOPT_USERPWD on
+	 * !empty($username) && !empty($password), so a "0" credential is dropped before curl both
+	 * before and after this change — tracked separately as issue #1909.
 	 */
 	public function testFalsyButRealCredentialsSurvive(): void
 	{

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -2888,6 +2888,33 @@
         "returnType": "array",
         "params": []
     },
+    "pfb_extras_credentials": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "feed",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "maxmind_account",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "maxmind_key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_failures": {
         "returnsRef": false,
         "returnType": null,

--- a/tests/smoke/test_smoke_714_asn_geoip.py
+++ b/tests/smoke/test_smoke_714_asn_geoip.py
@@ -1,5 +1,6 @@
 """Live-VM smoke coverage for the #714 audit fixes: ASN log redirect (c1), GeoIP
-single-IP overwrite (c8), and the IP-side parse-fail counter (b2).
+single-IP overwrite (c8), and the IP-side parse-fail counter (b2) — plus the #1906
+credential-normalization crash on the same ASN extras path.
 
 All three fixes live in ``sync_package_pfblockerng()`` / ``pfb_download()``
 (``pfblockerng.inc``):
@@ -15,8 +16,17 @@ All three fixes live in ``sync_package_pfblockerng()`` / ``pfb_download()``
   OUTSIDE the ``while (fgets...)`` loop, so it evaluated only the LAST line read
   instead of running once per unparseable line. Moved inside the loop.
 
-**b2 is CI-runnable** (``test_714_b2_parse_fail_counts_every_bad_line``): a local feed
-+ a Force IP reload reproduce it deterministically, no external credentials needed.
+The fourth case is issue **#1906** (``test_1906_asn_dispatch_reaches_the_download``): the
+ASN extras entries carry no ``username``/``password`` keys, and the per-type credential
+branch in ``pfblockerng_download_extras()`` skipped normalizing them, so the undefined key
+(NULL) fataled on ``PfbDownloadRequest``'s ``string $username`` and aborted the run before
+any download. It is deliberately **token-free** — a bogus token still has to reach the
+network — because #1906 escaped exactly by being reachable only through c1's licensed,
+CI-absent token.
+
+**b2 and #1906 are CI-runnable**: a local feed + a Force IP reload
+(``test_714_b2_parse_fail_counts_every_bad_line``), respectively a staged dummy token, each
+reproduce deterministically with no external credentials needed.
 
 **c1 and c8 are OUT-OF-CI / dispatch-only**: c1 needs a real, licensed IPinfo ASN
 account token (``SMOKE_ASN_SRC``); c8 needs a real MaxMind GeoIP account
@@ -133,6 +143,83 @@ def test_714_c1_asn_table_logs_not_stray_file(deployed_vm: SmokeVM) -> None:
         assert table_after > table_before, (
             f"expected a new {_ASN_TABLE_MARKER!r} line in {_ASN_EXTRAS_LOG} after `pfblockerng.php asn` "
             f"(before={table_before}, after={table_after}) — asn_table must have actually run"
+        )
+    finally:
+        h.reset(deployed_vm)
+
+
+# --------------------------------------------------------------------------- #
+# #1906 — the ASN extras download must reach the network, not fatal on its own
+# missing credential keys.
+# --------------------------------------------------------------------------- #
+
+# pfblockerng_download_extras() brackets its per-feed loop with these two pfb_logger()
+# lines. The END line is the oracle: an uncaught TypeError inside the loop kills the
+# CLI, so the START line lands and the END line never does.
+_EXTRAS_START_MARKER = "Download Process Starting"
+_EXTRAS_END_MARKER = "Download Process Ended"
+# Any syntactically valid token: IPinfo rejects it, which is fine — the download only has
+# to be ATTEMPTED. Deliberately not a real token; see the module docstring.
+_ASN_DUMMY_TOKEN = "smoke1906dummytoken"  # noqa: S105 — not a credential, a rejected placeholder
+
+
+@pytest.mark.timeout(300)
+def test_1906_asn_dispatch_reaches_the_download(deployed_vm: SmokeVM) -> None:
+    """#1906: `pfblockerng.php asn` must survive its own extras-credential normalization.
+
+    Scenario: the ASN extras entries ($pfb['extras'][3] and [4]) are built with only
+      url/file_dwn/file/folder/type — no username/password keys at all.
+    Given  an ASN token is configured, so the ASN extras survive into the download loop,
+    When   the ASN CLI verb runs the extras download,
+    Then   the dispatcher exits 0 and the loop's closing "Download Process Ended" line
+      lands in the extras log.
+
+    Pre-fix, the per-type credential branch normalized every feed type EXCEPT 'asn', so
+    $feed['username'] reached PfbDownloadRequest's non-nullable `string $username` as an
+    undefined array key (NULL). The resulting uncaught TypeError exited 255 mid-loop:
+    no ASN database, and on the 'dcc' cron path no MaxMind country-ISO rebuild either.
+
+    The token is a rejected dummy on purpose: whether IPinfo accepts it decides only
+    whether the DOWNLOAD succeeds, not whether the request could be CONSTRUCTED — which
+    is the whole of #1906, and is what c1's licensed-token gate hid from CI.
+    """
+    try:
+        start_before = h.count_log_marker(deployed_vm, _ASN_EXTRAS_LOG, _EXTRAS_START_MARKER)
+        end_before = h.count_log_marker(deployed_vm, _ASN_EXTRAS_LOG, _EXTRAS_END_MARKER)
+
+        snippet = (
+            f"$c = config_get_path({h._php_str(h.CFG_IP_SETTINGS)}, array());\n"  # noqa: SLF001
+            f"$c['asn_token'] = {h._php_str(_ASN_DUMMY_TOKEN)};\n"  # noqa: SLF001
+            f"config_set_path({h._php_str(h.CFG_IP_SETTINGS)}, $c);\n"  # noqa: SLF001
+            "write_config('pfBlockerNG smoke #1906: dummy ASN token');\n"
+            "echo 'OK';"
+        )
+        res = h.php_eval(deployed_vm, snippet)
+        assert "OK" in res.stdout, f"could not stage the dummy ASN token: {res.stdout!r} {res.stderr!r}"
+
+        result = deployed_vm.ssh(h.PHP_BIN, h.PFB_CLI, "asn", timeout=180)
+        assert result.returncode == 0, (
+            f"`pfblockerng.php asn` must not fatal on a feed with no credential keys: "
+            f"rc={result.returncode} (255 = PHP fatal) stdout={result.stdout[-2000:]!r} "
+            f"stderr={result.stderr[-2000:]!r}"
+        )
+        assert "TypeError" not in f"{result.stdout}{result.stderr}", (
+            f"`pfblockerng.php asn` emitted a TypeError: stdout={result.stdout[-2000:]!r} "
+            f"stderr={result.stderr[-2000:]!r}"
+        )
+
+        start_after = h.count_log_marker(deployed_vm, _ASN_EXTRAS_LOG, _EXTRAS_START_MARKER)
+        end_after = h.count_log_marker(deployed_vm, _ASN_EXTRAS_LOG, _EXTRAS_END_MARKER)
+        assert start_after > start_before, (
+            f"expected a new {_EXTRAS_START_MARKER!r} line in {_ASN_EXTRAS_LOG} after "
+            f"`pfblockerng.php asn` (before={start_before}, after={start_after}) — the extras "
+            "download loop must have been entered at all"
+        )
+        assert end_after > end_before, (
+            f"expected a new {_EXTRAS_END_MARKER!r} line in {_ASN_EXTRAS_LOG} after "
+            f"`pfblockerng.php asn` (before={end_before}, after={end_after}) — the loop must run "
+            "to completion; a missing END line with a present START line is the #1906 fatal "
+            "killing the CLI mid-loop"
         )
     finally:
         h.reset(deployed_vm)

--- a/tests/smoke/test_smoke_714_asn_geoip.py
+++ b/tests/smoke/test_smoke_714_asn_geoip.py
@@ -183,6 +183,11 @@ def test_1906_asn_dispatch_reaches_the_download(deployed_vm: SmokeVM) -> None:
     whether the DOWNLOAD succeeds, not whether the request could be CONSTRUCTED — which
     is the whole of #1906, and is what c1's licensed-token gate hid from CI.
     """
+    # php_eval PERSISTS to config.xml and h.reset() only drops DERIVED state, so the dummy
+    # token would leak into every later case on this VM. Snapshot it now, restore it in the
+    # finally. An absent key reads back as '' and is restored as '': pfb_global() coerces the
+    # field with `?: ''` and the CLI gates on empty(), so the two are the same state.
+    prior_token = h.config_get(deployed_vm, f"{h.CFG_IP_SETTINGS}/asn_token")
     try:
         start_before = h.count_log_marker(deployed_vm, _ASN_EXTRAS_LOG, _EXTRAS_START_MARKER)
         end_before = h.count_log_marker(deployed_vm, _ASN_EXTRAS_LOG, _EXTRAS_END_MARKER)
@@ -222,6 +227,17 @@ def test_1906_asn_dispatch_reaches_the_download(deployed_vm: SmokeVM) -> None:
             "killing the CLI mid-loop"
         )
     finally:
+        restore = (
+            f"$c = config_get_path({h._php_str(h.CFG_IP_SETTINGS)}, array());\n"  # noqa: SLF001
+            f"$c['asn_token'] = {h._php_str(prior_token)};\n"  # noqa: SLF001
+            f"config_set_path({h._php_str(h.CFG_IP_SETTINGS)}, $c);\n"  # noqa: SLF001
+            "write_config('pfBlockerNG smoke #1906: restore ASN token');\n"
+            "echo 'OK';"
+        )
+        assert "OK" in h.php_eval(deployed_vm, restore).stdout, (
+            "could not restore the pre-test ASN token — later cases on this VM would inherit "
+            f"the dummy {_ASN_DUMMY_TOKEN!r}"
+        )
         h.reset(deployed_vm)
 
 


### PR DESCRIPTION
Fixes the `TypeError` reported in #1906: `pfblockerng.php asn` and the `dcc` extras cron abort with

```
Uncaught TypeError: PfbDownloadRequest::__construct(): Argument #10 ($username) must be of type string, null given
```

## Root cause

`pfblockerng_download_extras()` normalized each feed's credentials in a three-way branch. The
`geoip` arm assigned the MaxMind account/key, the catch-all arm coerced whatever the feed
carried, and the `asn` arm only appended the token to the URL — it never assigned
`username`/`password`. The IPinfo ASN extras (`$pfb['extras'][3]`/`[4]`) are built with only
`url`/`file_dwn`/`file`/`folder`/`type`, so the credentials reached `PfbDownloadRequest`'s
non-nullable `string $username` as an undefined array key, i.e. NULL.

The fatal is uncaught, so the dispatcher dies mid-loop. Beyond the missing ASN database, the
`dcc` cron path never reaches `pfblockerng_uc_countries()` / `pfblockerng_get_countries()`, so
the MaxMind country ISO files silently stop being regenerated even though the archives
downloaded fine (extras 0/1/2 are processed before the ASN entries).

Triggered whenever the ASN extras survive into the loop: verb `dcc` with an ASN token
configured (the `unset()` there only fires when the token is empty), and verbs `asn` /
`asn_shell`. The blacklist path unsets extras 3/4 first and is unaffected.

## Fix

Normalize once for every feed type, before the branch, via a new `pfb_extras_credentials()`.
That covers both `PfbDownloadRequest` construction sites in the loop (the TOP1M
change-detection probe and the main download) rather than the single reported call site.

The helper lives in `pfblockerng.inc` rather than the `www/` dispatcher so it is loadable by
the PHPUnit bootstrap — the same treatment `pfblockerng_tick()` received per ADR43-5.

One contract change beyond the crash, at the helper only: the replaced `?: ''` blanked every
falsy value, so only NULL or an absent key now means "no credential". This does not change what
reaches the network — `pfb_download()` gates `CURLOPT_USERPWD` on
`!empty($username) && !empty($password)` and `empty("0")` is TRUE, so a `"0"` credential was
dropped before curl both before and after this change. That downstream gate is tracked
separately as #1909.

## Coverage

* `tests/php/ExtrasFeedCredentialsTest.php` — hermetic, pins all five feed shapes (ASN with no
  credential keys, GeoIP taking the MaxMind settings, a blacklist category passing its own
  credentials through, keyless TOP1M/blacklist, explicit NULLs, and a falsy-but-real `"0"`).
  One case reconstructs the reported failure by feeding the result to a real
  `PfbDownloadRequest`. Red→green: every test fails against the pre-change worktree with
  `Call to undefined function pfb_extras_credentials()`; the file is byte-identical between the
  red and green runs (`git hash-object` = `fe0021e7b6b2b034cae772baf621080a91da2dc7`).
* `test_1906_asn_dispatch_reaches_the_download` — a token-free live-VM case on the ASN path.
  #1906 escaped because the only test driving `pfblockerng.php asn`
  (`test_714_c1_asn_table_logs_not_stray_file`) needs a licensed IPinfo token and skips in CI.
  This one stages a deliberately rejected dummy token: whether IPinfo accepts it decides only
  whether the download succeeds, not whether the request could be constructed. Its oracle is
  the loop's closing `Download Process Ended` line, which the pre-fix fatal prevents from ever
  being written.

Tier A is not applicable — `pfblockerng.php` is the CLI dispatcher, not a webConfigurator
page, and the changed lines are only reachable through the CLI verbs; the live-VM case above
is the reachable coverage for the `www/` change.

`scripts/agent/run-gates.sh`: PASS (pytest, ruff, mypy, php -l, PHPUnit 4591 tests, PHPStan,
phpcs). The function-inventory golden was regenerated for the new helper.

Part of #1906


no-test-needed: the `www/` file this touches, `pfblockerng.php`, is the CLI dispatcher, not a webConfigurator page — `pfblockerng_download_extras()` is reachable only through the `asn`, `asn_shell` and `dcc` verbs and renders nothing, so no Tier-A `ui_render` surface exists to pair with. The reachable coverage ships instead as `test_1906_asn_dispatch_reaches_the_download` (token-free live-VM case on the exact CLI path) plus the hermetic `tests/php/ExtrasFeedCredentialsTest.php`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed extras feed downloads failing when username or password settings were missing.
  - Ensured credential-free feeds complete successfully without download errors.
  - Preserved valid credential values, including `"0"`.
  - Improved ASN and GeoIP feed handling by consistently applying the appropriate configured credentials.
- **Reliability**
  - Added coverage confirming extras downloads start and finish successfully across supported feed types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->