### PR TITLE
pfblockerng: show initial Logs status

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -483,7 +483,7 @@ if ($clearable) {
 $section = new Form_Section('Log/File Details');
 $section->addInput(new Form_StaticText(
 	NULL,
-	'<div style="display:none;" id="fileStatusBox"><strong id="fileStatus"></strong></div>'
+	'<div id="fileStatusBox"><strong id="fileStatus">' . gettext('Select Log/File to load') . '</strong></div>'
 	. '<div style="display:none;" id="filePathBox"><strong>Log/File Path:&emsp;</strong>'
 	. '<div style="display:inline;" id="fbTarget"></div>'
 	. '<div style="display:inline; margin-right:10px;" class="pull-right" id="fileRefreshBtn">'

--- a/tests/smoke/ui/test_browser_anchor_rows.py
+++ b/tests/smoke/ui/test_browser_anchor_rows.py
@@ -93,6 +93,37 @@ def test_page_renders_no_empty_separator_rows(
     )
 
 
+def test_log_status_row_has_visible_initial_content(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """The Logs status row has visible content before a file is selected."""
+    page = browser_page
+    page.set_viewport_size(DESKTOP)
+    _open(page, webui, LOG_PAGE)
+    _shot(page, screenshot_dir, "anchor_rows_log_initial_status")
+
+    status = page.evaluate(
+        """
+        () => {
+          const el = document.getElementById('fileStatus');
+          if (!el) return { exists: false, visible: false, text: '' };
+          return {
+            exists: true,
+            visible: el.getClientRects().length > 0,
+            text: (el.textContent || '').trim(),
+          };
+        }
+        """
+    )
+    assert status["exists"], "the Logs page has no #fileStatus target"
+    assert status["visible"] and status["text"], (
+        "the initial #fileStatus is hidden or empty, leaving its bordered .form-group "
+        f"as a separator-only row: {status!r}"
+    )
+
+
 @pytest.mark.parametrize(
     ("path", "section_id"),
     [(DNSBL_PAGE, "DNSBL_Whitelist_customlist"), (IP_PAGE, "IPv4_Suppression_customlist")],


### PR DESCRIPTION
## Summary

- render a visible “Select Log/File to load” status on the Logs page’s cold state
- keep the existing `#fileStatus` target and AJAX updates unchanged
- add live-browser coverage proving the bordered row is never empty or hidden initially

The issue’s “auto-load” description is stale: `loadFile()` runs after the file selector changes and writes the loading message before starting AJAX. The defect remains valid on cold load; the initial prompt fixes that state without adding new show/hide wiring.

## Verification

- Red, before production edit: `scripts/local-smoke.sh --ref issue/1891-logs-page-filestatusbox-draws --marker ui_browser --filter log_status_row_has_visible_initial_content --no-two-vm`
  - `1 failed, 561 deselected`
  - observed `{'exists': True, 'visible': False, 'text': ''}`
- Frozen test hash: `55a7551403b22cd4724d71ee505e08e67af9341d`
- Green, unchanged test: same live-smoke command
  - `1 passed, 561 deselected`
- Tier A: `scripts/local-smoke.sh --ref issue/1891-logs-page-filestatusbox-draws --marker ui_render --filter 'test_page_renders_clean and log' --no-two-vm`
  - `1 passed, 561 deselected`
- `scripts/agent/run-gates.sh --diff origin/devel`
  - full pytest, Ruff, format, mypy, PHP lint, PHPUnit, PHPStan, and PHPCS passed

Fixes #1891

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
