### PR TITLE
tests/smoke: publish locally built RUN_DEPENDS into the guest catalog

### DIFF
--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -262,6 +262,32 @@ def _ssh_check(vm: SmokeVM, *remote: str, timeout: float = 180.0) -> subprocess.
     return result
 
 
+def _extra_dep_pkgs(pkg_files: list[Path]) -> list[Path]:
+    """The locally built RUN_DEPENDS that must ride along in a guest catalog (issue #1914).
+
+    ``smoke-on-box.sh`` builds any dependency the Netgate repositories do not carry
+    (currently ``py311-charset-normalizer``) and exports their absolute paths as
+    ``SMOKE_DEP_PKGS``; ``scripts/install-pkg.sh`` already consumes it for the direct
+    ``pkg add`` path. A ``file://`` catalog that omits them resolves nothing at
+    ``pkg install`` time — the failure surfaces as "<package> has a missing
+    dependency", pointing at the package rather than at the staging gap.
+
+    Missing paths raise rather than being skipped, mirroring ``install-pkg.sh``'s own
+    ``[ -f "$_dep" ] || exit 1``: a catalog that is silently one package short fails
+    much later and much less legibly.
+    """
+    already = {pkg.name for pkg in pkg_files}
+    extra: list[Path] = []
+    for raw in os.environ.get("SMOKE_DEP_PKGS", "").split():
+        dep = Path(raw)
+        if not dep.is_file():
+            raise RuntimeError(f"SMOKE_DEP_PKGS names a file that does not exist: {dep}")
+        if dep.name not in already:
+            already.add(dep.name)
+            extra.append(dep)
+    return extra
+
+
 def build_guest_repo(vm: SmokeVM, repo_dir: str, pkg_files: list[Path]) -> None:
     """Lay ``pkg_files`` into a fresh ``repo_dir`` on the guest and ``pkg repo`` it.
 
@@ -269,10 +295,14 @@ def build_guest_repo(vm: SmokeVM, repo_dir: str, pkg_files: list[Path]) -> None:
     run on Linux — to turn the dir of ``.pkg`` files into a real catalog
     (``meta.conf`` / ``packagesite.pkg`` / ``data.pkg``). Built with NO signing,
     so the served catalog is NONE-signed (the trust model under test).
+
+    Any locally built RUN_DEPENDS named by ``SMOKE_DEP_PKGS`` is published beside
+    ``pkg_files`` before the catalog is indexed (issue #1914), so an install from the
+    resulting repo can resolve dependencies that exist in no upstream repository.
     """
     _ssh_check(vm, "/bin/rm", "-rf", repo_dir)
     _ssh_check(vm, "/bin/mkdir", "-p", repo_dir)
-    for pkg in pkg_files:
+    for pkg in [*pkg_files, *_extra_dep_pkgs(pkg_files)]:
         _scp_to_guest(vm, pkg, f"{repo_dir}/{pkg.name}")
     # `pkg repo <dir>` with no key argument => an unsigned catalog.
     _ssh_check(vm, "env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", repo_dir)

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -300,9 +300,13 @@ def build_guest_repo(vm: SmokeVM, repo_dir: str, pkg_files: list[Path]) -> None:
     ``pkg_files`` before the catalog is indexed (issue #1914), so an install from the
     resulting repo can resolve dependencies that exist in no upstream repository.
     """
+    # Resolve (and validate) the full package set BEFORE touching the guest: the rm -rf
+    # below is destructive, so a bad SMOKE_DEP_PKGS must fail with any existing catalog
+    # still intact rather than wiping it on the way out.
+    staged = [*pkg_files, *_extra_dep_pkgs(pkg_files)]
     _ssh_check(vm, "/bin/rm", "-rf", repo_dir)
     _ssh_check(vm, "/bin/mkdir", "-p", repo_dir)
-    for pkg in [*pkg_files, *_extra_dep_pkgs(pkg_files)]:
+    for pkg in staged:
         _scp_to_guest(vm, pkg, f"{repo_dir}/{pkg.name}")
     # `pkg repo <dir>` with no key argument => an unsigned catalog.
     _ssh_check(vm, "env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", repo_dir)

--- a/tests/test_smoke_guest_repo_dep_pkgs.py
+++ b/tests/test_smoke_guest_repo_dep_pkgs.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.smoke.test_repo_install import build_guest_repo
+
+_REPO_DIR = "/var/tmp/pfb-guest-repo"
+
+
+class _FakeVM:
+    """Records the guest commands ``build_guest_repo`` issues."""
+
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, ...]] = []
+
+    def ssh(self, *remote: str, timeout: float) -> subprocess.CompletedProcess[str]:
+        self.commands.append(remote)
+        return subprocess.CompletedProcess((), 0, "", "")
+
+
+@pytest.fixture
+def staged(monkeypatch: pytest.MonkeyPatch) -> list[tuple[Path, str]]:
+    """Capture every ``local -> remote`` copy instead of running scp."""
+    calls: list[tuple[Path, str]] = []
+
+    def _fake_scp(vm: object, local: Path, remote: str, **_kw: object) -> None:
+        calls.append((local, remote))
+
+    monkeypatch.setattr("tests.smoke.test_repo_install._scp_to_guest", _fake_scp)
+    return calls
+
+
+def _names(staged: list[tuple[Path, str]]) -> list[str]:
+    return [Path(remote).name for _local, remote in staged]
+
+
+def test_locally_built_run_depends_are_published_into_the_guest_catalog(
+    monkeypatch: pytest.MonkeyPatch, staged: list[tuple[Path, str]], tmp_path: Path
+) -> None:
+    """A RUN_DEPENDS built on the box must reach the catalog ``pkg install`` reads.
+
+    Scenario: issue #1914 — the guest ``file://`` repo served only the package under
+    test, so a dependency that exists in no Netgate repository (it is built locally
+    by ``smoke-on-box.sh``) was unresolvable and every ``-m repo`` install failed with
+    ``has a missing dependency: py311-charset-normalizer``. ``SMOKE_DEP_PKGS`` already
+    carries those paths — ``scripts/install-pkg.sh`` consumes it for the direct
+    ``pkg add`` path — so the catalog builder must honour it too.
+    """
+    dep = tmp_path / "py311-charset-normalizer-3.4.4.pkg"
+    dep.write_bytes(b"dep")
+    pkg = tmp_path / "pfSense-pkg-pfBlockerNG-devel-4.0.0.pkg"
+    pkg.write_bytes(b"pkg")
+    monkeypatch.setenv("SMOKE_DEP_PKGS", str(dep))
+    vm = _FakeVM()
+
+    build_guest_repo(vm, _REPO_DIR, [pkg])  # type: ignore[arg-type]
+
+    assert _names(staged) == [pkg.name, dep.name], (
+        f"catalog staged {_names(staged)!r}; the locally built RUN_DEPENDS must be published beside the package"
+    )
+    assert vm.commands[-1] == ("env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", _REPO_DIR), (
+        "the dep must be staged BEFORE `pkg repo` indexes the directory, or the catalog omits it"
+    )
+
+
+def test_catalog_is_unchanged_when_the_matrix_row_builds_no_dep_pkgs(
+    monkeypatch: pytest.MonkeyPatch, staged: list[tuple[Path, str]], tmp_path: Path
+) -> None:
+    """An empty/unset ``SMOKE_DEP_PKGS`` (the common row) stages exactly what it did before."""
+    pkg = tmp_path / "pfSense-pkg-pfBlockerNG-devel-4.0.0.pkg"
+    pkg.write_bytes(b"pkg")
+    monkeypatch.delenv("SMOKE_DEP_PKGS", raising=False)
+    vm = _FakeVM()
+
+    build_guest_repo(vm, _REPO_DIR, [pkg])  # type: ignore[arg-type]
+
+    assert _names(staged) == [pkg.name]
+
+    staged.clear()
+    monkeypatch.setenv("SMOKE_DEP_PKGS", "   ")
+    build_guest_repo(vm, _REPO_DIR, [pkg])  # type: ignore[arg-type]
+
+    assert _names(staged) == [pkg.name], "whitespace-only SMOKE_DEP_PKGS must not stage a phantom entry"
+
+
+def test_a_named_dep_pkg_that_does_not_exist_fails_loudly(
+    monkeypatch: pytest.MonkeyPatch, staged: list[tuple[Path, str]], tmp_path: Path
+) -> None:
+    """A missing dep path must raise, never yield a catalog that is silently short.
+
+    Mirrors ``scripts/install-pkg.sh``'s own ``[ -f "$_dep" ] || exit 1`` guard: a
+    catalog missing a dependency fails much later, at ``pkg install``, with an error
+    that points at the package rather than at the staging bug.
+    """
+    pkg = tmp_path / "pfSense-pkg-pfBlockerNG-devel-4.0.0.pkg"
+    pkg.write_bytes(b"pkg")
+    monkeypatch.setenv("SMOKE_DEP_PKGS", str(tmp_path / "absent-dep.pkg"))
+    vm = _FakeVM()
+
+    with pytest.raises(RuntimeError, match="absent-dep.pkg"):
+        build_guest_repo(vm, _REPO_DIR, [pkg])  # type: ignore[arg-type]
+
+
+def test_a_dep_already_passed_by_the_caller_is_not_staged_twice(
+    monkeypatch: pytest.MonkeyPatch, staged: list[tuple[Path, str]], tmp_path: Path
+) -> None:
+    """Callers that already pass a dep explicitly must not get a duplicate copy."""
+    dep = tmp_path / "py311-charset-normalizer-3.4.4.pkg"
+    dep.write_bytes(b"dep")
+    pkg = tmp_path / "pfSense-pkg-pfBlockerNG-devel-4.0.0.pkg"
+    pkg.write_bytes(b"pkg")
+    monkeypatch.setenv("SMOKE_DEP_PKGS", str(dep))
+    vm = _FakeVM()
+
+    build_guest_repo(vm, _REPO_DIR, [pkg, dep])  # type: ignore[arg-type]
+
+    assert _names(staged) == [pkg.name, dep.name]

--- a/tests/test_smoke_guest_repo_dep_pkgs.py
+++ b/tests/test_smoke_guest_repo_dep_pkgs.py
@@ -89,11 +89,15 @@ def test_catalog_is_unchanged_when_the_matrix_row_builds_no_dep_pkgs(
 def test_a_named_dep_pkg_that_does_not_exist_fails_loudly(
     monkeypatch: pytest.MonkeyPatch, staged: list[tuple[Path, str]], tmp_path: Path
 ) -> None:
-    """A missing dep path must raise, never yield a catalog that is silently short.
+    """A missing dep path must raise BEFORE any guest mutation, never yield a short catalog.
 
     Mirrors ``scripts/install-pkg.sh``'s own ``[ -f "$_dep" ] || exit 1`` guard: a
     catalog missing a dependency fails much later, at ``pkg install``, with an error
     that points at the package rather than at the staging bug.
+
+    Validation runs before the ``rm -rf repo_dir`` that opens the function, so a bad
+    ``SMOKE_DEP_PKGS`` leaves any existing guest catalog intact instead of destroying
+    it on the way out — failing closed means changing nothing, not changing less.
     """
     pkg = tmp_path / "pfSense-pkg-pfBlockerNG-devel-4.0.0.pkg"
     pkg.write_bytes(b"pkg")
@@ -102,6 +106,11 @@ def test_a_named_dep_pkg_that_does_not_exist_fails_loudly(
 
     with pytest.raises(RuntimeError, match="absent-dep.pkg"):
         build_guest_repo(vm, _REPO_DIR, [pkg])  # type: ignore[arg-type]
+
+    assert vm.commands == [], (
+        f"guest was mutated before validation failed: {vm.commands!r} — an existing catalog must survive"
+    )
+    assert staged == [], "nothing may be staged when the dep set does not validate"
 
 
 def test_a_dep_already_passed_by_the_caller_is_not_staged_twice(


### PR DESCRIPTION
Fixes #1914

## The break

Every live-VM test that installs the branch `.pkg` from a guest `file://` repo fails at `pkg install`:

```
pkg: pfSense-pkg-pfBlockerNG-devel has a missing dependency: py311-charset-normalizer
```

`repo-install.yml` has been red on `devel` for four consecutive nightlies (2026-07-27 → 07-30); last success 07-26.

## Cause

`smoke-on-box.sh` builds any dependency the Netgate repositories do not carry and exports the paths as `SMOKE_DEP_PKGS`; `scripts/install-pkg.sh` already consumes it for the direct `pkg add` path. That is why the `-m smoke` fan-out stayed green and only the `-m repo` leg went red — the `file://` catalog path is the half that never learned about it. `build_guest_repo()` staged only the packages it was handed, and all ~12 call sites hand it the pfBlockerNG package alone.

## Fix

Stage `SMOKE_DEP_PKGS` alongside `pkg_files` before `pkg repo` indexes the directory, correcting every caller at once with no call-site changes. A dep the caller already passed is not copied twice; a path that does not exist raises rather than yielding a catalog that is silently one package short — mirroring `install-pkg.sh`'s own `[ -f "$_dep" ] || exit 1`, because a short catalog fails much later and blames the package rather than the staging gap.

## Evidence

**Live red → green**, same command both sides:

```sh
PFB_BOXES=… scripts/local-smoke.sh --ref <SHA> --marker repo \
  --filter test_pkg_install_applies_config_migrations --no-two-vm
```

RED, on unmodified `devel` (`da344dde`):

```
E  RuntimeError: pkg install pfSense-pkg-pfBlockerNG-devel failed: rc=1
E  pkg: pfSense-pkg-pfBlockerNG-devel has a missing dependency: py311-charset-normalizer
FAILED tests/smoke/test_upgrade_config_stability.py::test_pkg_install_applies_config_migrations
1 failed, 922 deselected in 67.74s
```

GREEN, on this branch (`08004f26`):

```
tests/smoke/test_upgrade_config_stability.py::test_pkg_install_applies_config_migrations PASSED [100%]
1 passed, 922 deselected in 60.76s (0:01:00)
```

Same command, same test, same box pool — only the ref differs.

**Hermetic**, test-first, frozen `aabe4edba8d70bbf73ef26c6d5055c00ffeea1f8`:

```
RED:    2 failed, 2 passed   (the 2 passes are the unchanged-behaviour controls)
GREEN:  4 passed
```

`tests/test_smoke_guest_repo_dep_pkgs.py` covers: the dep reaching the catalog *before* `pkg repo` runs, an empty/whitespace-only `SMOKE_DEP_PKGS` staging exactly what it did before, a missing dep path failing loudly, and no duplicate copy when a caller already passed the dep.

`python3 -m pytest` 3852 passed / 4 skipped · `ruff check` · `ruff format --check` · `mypy tests/` all clean.

## Why now

This blocks the live post-install evidence issue #1898's risk triggers require. That PR (#1913) is otherwise green and adversarially reviewed; its migration smoke test ships and is structurally correct but fails at the same `pkg install` step as its unmodified neighbour. #1913 rebases onto this and re-runs its leg green before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Smoke-test guest repositories now include locally built dependency packages before catalog generation.
  * Duplicate dependency packages are avoided when already supplied.
  * Missing dependency package paths now produce a clear failure.
  * Empty or whitespace-only dependency settings leave repository behavior unchanged.

* **Tests**
  * Added coverage for dependency staging, duplicate handling, missing paths, and unchanged behavior when no dependencies are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
