### PR TITLE
pfblockerng: preserve Basic auth credentials

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12410,9 +12410,6 @@ function pfb_download_http_headers(array $extra_headers, string $conditional_hea
 //
 // Only NULL/absent means "no credential" here: unlike the `?: ''` this replaces, a literal "0"
 // credential is reported faithfully rather than blanked. That is this helper's contract only --
-// pfb_download() still gates CURLOPT_USERPWD on !empty(), which drops a "0" credential before
-// curl either way, so no request on the wire changes (issue #1909).
-//
 // $feed: one $pfb['extras'] entry. $maxmind_account/$maxmind_key: the settings' MaxMind
 //   credentials, already coerced to strings by pfb_global().
 // @return array{0: string, 1: string} the username and password to download this feed with.
@@ -12732,7 +12729,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					}
 				}
 
-				if (!empty($username) && !empty($password)) {
+				if (!pfb_is_empty($username) || !pfb_is_empty($password)) {
 					curl_setopt($ch, CURLOPT_USERPWD, "{$username}:{$password}");
 					curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
 				}

--- a/tests/php/DownloadRetryBodyResetTest.php
+++ b/tests/php/DownloadRetryBodyResetTest.php
@@ -63,7 +63,7 @@ final class DownloadRetryBodyResetTest extends TestCase
 		];
 
 		foreach (['log', 'errlog', 'pnow', 'runlog', 'runlog_active'] as $k) {
-			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : FALSE;
 		}
 		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
 		$GLOBALS['pfb']['log']    = "{$workdir}/pfblockerng.log";
@@ -80,7 +80,7 @@ final class DownloadRetryBodyResetTest extends TestCase
 			proc_close($this->server);
 		}
 		foreach ($this->saved as $k => $prev) {
-			if ($prev === false) {
+			if ($prev === FALSE) {
 				unset($GLOBALS['pfb'][$k]);
 			} else {
 				$GLOBALS['pfb'][$k] = $prev;
@@ -107,6 +107,16 @@ final class DownloadRetryBodyResetTest extends TestCase
 		$this->assertSame(64, strlen($body));
 		$routerSrc = <<<PHP
 <?php
+\$authLog = getenv('AUTH_LOG');
+if (str_starts_with(\$_SERVER['REQUEST_URI'] ?? '', '/auth')) {
+	file_put_contents(\$authLog, json_encode([
+		\$_SERVER['PHP_AUTH_USER'] ?? null,
+		\$_SERVER['PHP_AUTH_PW'] ?? null,
+	]) . PHP_EOL, FILE_APPEND);
+	header('Content-Length: 64');
+	echo '{$body}';
+	return;
+}
 \$state = getenv('FLAKY_STATE');
 header('Content-Length: 64');
 if (!file_exists(\$state)) {
@@ -127,7 +137,11 @@ PHP;
 				$descriptors,
 				$pipes,
 				$this->workdir,
-				['FLAKY_STATE' => "{$this->workdir}/state.flag", 'PATH' => (string) getenv('PATH')]
+				[
+					'AUTH_LOG' => "{$this->workdir}/auth.log",
+					'FLAKY_STATE' => "{$this->workdir}/state.flag",
+					'PATH' => (string) getenv('PATH'),
+				]
 			);
 			if (!is_resource($proc)) {
 				continue;
@@ -135,7 +149,7 @@ PHP;
 			// Poll readiness instead of a fixed wait (up to ~2s).
 			for ($i = 0; $i < 40; $i++) {
 				$sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.05);
-				if ($sock !== false) {
+				if ($sock !== FALSE) {
 					fclose($sock);
 					$this->server = $proc;
 					$this->port = $port;
@@ -184,5 +198,47 @@ PHP;
 			$got,
 			'the retried download must contain only the final response body, got ' . strlen($got) . ' bytes'
 		);
+	}
+
+	/**
+	 * Scenario: HTTP Basic auth is enabled when either credential is present.
+	 * Given literal "0", username-only, and empty-pair credential cases,
+	 * when pfb_download() fetches each feed, the server sees every real value.
+	 */
+	public function testBasicAuthUsesAnyPresentCredentialWithoutDroppingZero(): void
+	{
+		$cases = [
+			['0', 'secret', ['0', 'secret']],
+			['feed', '0', ['feed', '0']],
+			['token', '', ['token', NULL]],
+			['', 'secret', ['', 'secret']],
+			['', '', [NULL, NULL]],
+		];
+
+		foreach ($cases as $index => [$username, $password]) {
+			$result = pfb_download(new PfbDownloadRequest(
+				listUrl: "http://flaky-feed.example:{$this->port}/auth/{$index}",
+				downloadPath: "{$this->workdir}/auth-{$index}.txt",
+				flex: FALSE,
+				header: "AuthFeed{$index}",
+				format: '',
+				logType: 1,
+				type: 'change_detect',
+				username: $username,
+				password: $password,
+			));
+			$this->assertTrue($result->success, "auth case {$index} download must succeed");
+		}
+
+		$lines = file("{$this->workdir}/auth.log", FILE_IGNORE_NEW_LINES);
+		$this->assertIsArray($lines, 'fixture server must record each request credential pair');
+		$this->assertCount(count($cases), $lines, 'fixture server must record exactly one request per auth case');
+		foreach ($cases as $index => [, , $expected]) {
+			$this->assertSame(
+				$expected,
+				json_decode($lines[$index], TRUE),
+				"auth case {$index} must reach the server as the expected credential pair"
+			);
+		}
 	}
 }

--- a/tests/php/ExtrasFeedCredentialsTest.php
+++ b/tests/php/ExtrasFeedCredentialsTest.php
@@ -33,8 +33,7 @@ use PHPUnit\Framework\TestCase;
  *   blacklist w/ creds — a per-item username/password is passed through untouched.
  *   blacklist w/o creds / top1m — absent keys: empty strings.
  *   explicit NULLs   — a key present but NULL is coerced too, not just an absent key.
- *   falsy-but-real   — a literal "0" credential is reported, not blanked (the helper's own
- *                      contract; pfb_download() drops it downstream either way — issue #1909).
+ *   falsy-but-real   — a literal "0" credential is reported, not blanked.
  */
 #[CoversFunction('pfb_extras_credentials')]
 final class ExtrasFeedCredentialsTest extends TestCase
@@ -178,10 +177,6 @@ final class ExtrasFeedCredentialsTest extends TestCase
 	/**
 	 * The replaced `?: ''` arm blanked every falsy value. This pins the helper's own contract:
 	 * only NULL/absent means "no credential"; "0" is a credential and is reported as one.
-	 *
-	 * It does not change what reaches the network. pfb_download() gates CURLOPT_USERPWD on
-	 * !empty($username) && !empty($password), so a "0" credential is dropped before curl both
-	 * before and after this change — tracked separately as issue #1909.
 	 */
 	public function testFalsyButRealCredentialsSurvive(): void
 	{


### PR DESCRIPTION
## Summary

- use `pfb_is_empty()` for the HTTP Basic credential presence gate
- send credentials when either username or password is present
- cover literal `"0"`, username-only, password-only, and the empty pair against a real loopback HTTP server

## Root cause

`empty()` treats the string `"0"` as empty, and the existing `&&` gate required both credential fields. As a result, valid zero-valued credentials and username-only authentication never reached cURL.

## Verification

- RED: frozen test hash `c1d65db0abdfcfa20d557a9a788dde83790e98ff`; server received `[null, null]` instead of `["0", "secret"]`
- GREEN: same test hash; focused matrix passed 1 test / 16 assertions
- `scripts/agent/run-gates.sh --diff origin/devel` — PASS

Fixes #1909

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP Basic Authentication handling when either the username or password is provided.
  * Preserved valid credential values, including `"0"` and empty strings, during download requests.
* **Tests**
  * Added coverage for credential handling across authenticated requests and retries.
  * Clarified documentation of credential behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->