### PR TITLE
tests: mirror config path append semantics

### DIFF
--- a/tests/php/ConfigPathDoublesTest.php
+++ b/tests/php/ConfigPathDoublesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ConfigPathDoublesTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	public function testTrailingSlashAppendsToExistingLeafArray(): void
+	{
+		$GLOBALS['config'] = ['items' => ['first']];
+		$this->assertSame(['first'], config_get_path('items'));
+
+		$this->assertSame('second', config_set_path('items/', 'second'));
+
+		$this->assertSame(['first', 'second'], config_get_path('items'));
+	}
+
+	public function testPlainPathReplacesExistingLeafArray(): void
+	{
+		$GLOBALS['config'] = ['items' => ['first']];
+		$this->assertSame(['first'], config_get_path('items'));
+
+		$this->assertSame('second', config_set_path('items', 'second'));
+
+		$this->assertSame('second', config_get_path('items'));
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -324,6 +324,7 @@ if (!function_exists('config_set_path')) {
 	// pfSense config.lib.inc: set the value at a '/'-separated path (creating
 	// intermediate arrays), returning the value set.
 	function config_set_path(string $path, $value, $default = null) {
+		$append = ($path !== '' && str_ends_with($path, '/'));
 		$node = &$GLOBALS['config'];
 		if (!is_array($node)) {
 			$node = [];
@@ -337,7 +338,11 @@ if (!function_exists('config_set_path')) {
 			}
 			$node = &$node[$key];
 		}
-		$node = $value;
+		if ($append) {
+			$node[] = $value;
+		} else {
+			$node = $value;
+		}
 		return $value;
 	}
 }


### PR DESCRIPTION
## Summary

- Preserve trailing-slash intent before normalizing config paths in the pfSense test double.
- Append values for trailing-slash paths while retaining plain-path replacement semantics.
- Add a focused doubles self-test for both behaviors.

## Root cause

The double removed trailing slashes with `rtrim()` before selecting its write behavior, so append-style writes silently became replacements off-appliance. Upstream `array_set_path()` preserves the slash as an append signal; the behavior is identical in the checked CE 2.8-era, Plus 26.03-era, and current pfSense sources.

## Verification

- RED: `vendor/bin/phpunit tests/php/ConfigPathDoublesTest.php` — 2 tests, 6 assertions, 1 expected failure; frozen test hash `68ae74f758cf20e78b4acd7d56ecb879b2552d4a`.
- GREEN: same command and unchanged hash — 2 tests, 6 assertions, pass.
- `scripts/agent/run-gates.sh --diff origin/devel` — composer vendor check, PHP lint, PHPUnit, PHPStan, and PHPCS all pass.

Fixes #1912

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
