### PR TITLE
pfblockerng: gate the iBlocklist line rewrite on its actual format

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -149,17 +149,12 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 	$parse_error = FALSE;
 
 	if ($vtype == '_v4' && $pftype == 'auto') {
-		// iBlocklist / PeerGuardian ".p2p" line: "<Org Name>:<start-ip>-<end-ip>"
-		// (sample: "JKS Media, LLC:4.53.2.12-4.53.2.15"). Strip the leading
-		// organisation name and hand the range to the '-' expander below.
-		// iBlocklist URLs resolve to the 'iblock' extension, which is NOT in the
-		// 'regex' parser list, so those feeds reach this branch and depend on it.
-		// Anchored on the WHOLE shape and split at the LAST colon, so an
-		// organisation name containing a colon survives. The former
-		// "contains '-' and ':'" test matched any unrelated line carrying both
-		// characters and rewrote it into a letter-free remnant -- a Maltrail
-		// URL-path trail signature became ")", which the closing gate then
-		// miscounted as a numeric parse failure (issue #1923).
+		// iBlocklist/PeerGuardian ".p2p": "<Org Name>:<start-ip>-<end-ip>" (sample
+		// "JKS Media, LLC:4.53.2.12-4.53.2.15") -- strip the org name, leaving the
+		// range for the '-' expander below. Reached because iBlocklist URLs map to
+		// the 'iblock' extension, absent from the 'regex' parser list. Anchored on
+		// the WHOLE shape, split at the LAST colon (issue #1923: a bare "contains
+		// '-' and ':'" test mangles unrelated lines; an org name may contain ':').
 		if (preg_match('/^.*:((?:\d{1,3}\.){3}\d{1,3}-(?:\d{1,3}\.){3}\d{1,3})$/', $line, $pfb_iblock)) {
 			$line = $pfb_iblock[1];
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -149,8 +149,19 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 	$parse_error = FALSE;
 
 	if ($vtype == '_v4' && $pftype == 'auto') {
-		if (strpos($line, '-') !== FALSE && strpos($line, ':') !== FALSE) {
-			$line = str_replace(':', '', strstr($line, ':', FALSE));
+		// iBlocklist / PeerGuardian ".p2p" line: "<Org Name>:<start-ip>-<end-ip>"
+		// (sample: "JKS Media, LLC:4.53.2.12-4.53.2.15"). Strip the leading
+		// organisation name and hand the range to the '-' expander below.
+		// iBlocklist URLs resolve to the 'iblock' extension, which is NOT in the
+		// 'regex' parser list, so those feeds reach this branch and depend on it.
+		// Anchored on the WHOLE shape and split at the LAST colon, so an
+		// organisation name containing a colon survives. The former
+		// "contains '-' and ':'" test matched any unrelated line carrying both
+		// characters and rewrote it into a letter-free remnant -- a Maltrail
+		// URL-path trail signature became ")", which the closing gate then
+		// miscounted as a numeric parse failure (issue #1923).
+		if (preg_match('/^.*:((?:\d{1,3}\.){3}\d{1,3}-(?:\d{1,3}\.){3}\d{1,3})$/', $line, $pfb_iblock)) {
+			$line = $pfb_iblock[1];
 		}
 		if (strpos($line, ' ') !== FALSE) {
 			$line = strstr($line, ' ', TRUE);

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -91,6 +91,64 @@ final class IpParseLineTest extends TestCase
 		));
 	}
 
+	/**
+	 * Scenario: an iBlocklist organisation name that itself contains a colon.
+	 *   Given a PeerGuardian line whose "<Org Name>" part contains ':'
+	 *   When the line is parsed
+	 *   Then the whole range is recovered, exactly as for a colon-free org name.
+	 * The separator is the LAST colon before the range, not the first (issue #1923).
+	 */
+	public function testIpv4AutoIblockOrgNameContainingColonStillYieldsTheRange(): void
+	{
+		$config = $this->config('_v4');
+		$this->assertLine('Foo: Bar Inc:4.53.2.12-4.53.2.15', $config, $this->expectedResult(
+			'4.53.2.12-4.53.2.15',
+			['entries' => ['4.53.2.12/30']]
+		));
+	}
+
+	/**
+	 * Scenario: a non-iBlocklist line that merely happens to contain both '-' and ':'.
+	 *   Given a Maltrail URL-path trail signature, which is not an address at all
+	 *   When the line is parsed
+	 *   Then the iBlocklist rewrite leaves it untouched, so the reported line is the
+	 *        offending input rather than a mangled remnant.
+	 * Before the gate, "…anti-sec:)" was rewritten to ")" (issue #1923).
+	 */
+	public function testIpv4AutoLeavesNonIblockLineWithDashAndColonIntact(): void
+	{
+		$config = $this->config('_v4');
+		$trail = '/w00tw00t.at.blackhats.romanian.anti-sec:)';
+		$this->assertLine($trail, $config, $this->expectedResult($trail));
+	}
+
+	/**
+	 * Scenario: two sibling trail signatures that differ only by containing a '-'.
+	 *   Given the two Maltrail w00tw00t trails, one with '-' and one without
+	 *   When both are parsed
+	 *   Then neither is counted as a parse failure, because neither is an address.
+	 * The '-'-bearing sibling used to be rewritten into a letter-free remnant, which
+	 * the final gate then mistook for a numeric parse failure (issue #1923).
+	 */
+	public function testIpv4AutoTrailSignaturesAreCountedSymmetrically(): void
+	{
+		$config = $this->config('_v4');
+		$withDash = pfb_ip_parse_line('/w00tw00t.at.blackhats.romanian.anti-sec:)', $config);
+		$withoutDash = pfb_ip_parse_line('/w00tw00t.at.ISC.SANS.DFind:)', $config);
+
+		$this->assertSame(0, $withoutDash['parse_fail_delta'], 'dash-free sibling must not count as a parse failure');
+		$this->assertSame(
+			$withoutDash['parse_fail_delta'],
+			$withDash['parse_fail_delta'],
+			'both trail signatures must be counted the same way'
+		);
+		$this->assertSame(
+			$withoutDash['detailed_parse_fail'],
+			$withDash['detailed_parse_fail'],
+			'both trail signatures must produce the same detailed-failure verdict'
+		);
+	}
+
 	public function testIpv4RegexDeduplicatesAndSkipsCloudflare(): void
 	{
 		$config = $this->config('_v4', 'regex');


### PR DESCRIPTION
Fixes #1923

## What

`pfb_ip_parse_line()` applied an iBlocklist-specific line rewrite to **every** `auto`-format
IPv4 feed line that happened to contain both a `-` and a `:`. The rewrite is correct for the
PeerGuardian `.p2p` format it was written for; it was simply ungated.

```php
// before
if (strpos($line, '-') !== FALSE && strpos($line, ':') !== FALSE) {
    $line = str_replace(':', '', strstr($line, ':', FALSE));
}
```

On Maltrail's `mass_scanner.txt` line 16347, the trail signature
`/w00tw00t.at.blackhats.romanian.anti-sec:)` was reduced to `)`. Consequences:

- `ip_parsed_error.log` recorded the mangled remnant, not the offending input, making the
  feed undiagnosable from the log alone.
- The closing gate (`pfblockerng_apply.inc:303`) skips counting a line that still contains
  `[a-zA-Z]`. Stripping the letters turned a plainly-not-an-address line into a spurious
  *numeric* parse failure, while its dash-free sibling `/w00tw00t.at.ISC.SANS.DFind:)` was
  silently dropped uncounted. `[!] Parse Errors [ Maltrail_Scanners_All_v4 ]: 1` where the
  honest answer is 0 or 2.
- `str_replace(':', '', ...)` stripped *every* colon, so an organisation name containing a
  colon corrupted the range instead of being stripped from it.

## How

Gate on the whole PeerGuardian shape rather than "contains `-` and `:`", splitting at the
**last** colon so a colon inside the organisation name survives:

```php
if (preg_match('/^.*:((?:\d{1,3}\.){3}\d{1,3}-(?:\d{1,3}\.){3}\d{1,3})$/', $line, $pfb_iblock)) {
    $line = $pfb_iblock[1];
}
```

The branch is **gated, not removed**: `pfblockerng_apply.inc:3318` maps iBlocklist URLs to
the `iblock` extension, which is not in the list selecting the `regex` parser, so those
feeds reach `auto` and genuinely depend on this rewrite.

The rationale comment lost when the parser was extracted in `16e9b506` is restored — the
upstream original (`git show 0846aa7c:usr/local/pkg/pfblockerng/pfblockerng.inc`, line 9528)
read `// IBlock - parser sample ( JKS Media, LLC:4.53.2.12-4.53.2.15 )`, which is why the
branch had become unreadable.

## Tests — red→green proof

Three reproduction tests were authored **before** any production edit and executed against
untouched code.

RED (`git hash-object tests/php/IpParseLineTest.php` = `5fd128b390af8747da2df618961d7490737554bb`):

```
1) testIpv4AutoIblockOrgNameContainingColonStillYieldsTheRange
-    'line' => '4.53.2.12-4.53.2.15'
+    'line' => ''

2) testIpv4AutoLeavesNonIblockLineWithDashAndColonIntact
-    'line' => '/w00tw00t.at.blackhats.romanian.anti-sec:)'
+    'line' => ')'
-    'parse_fail_delta' => 0,   'detailed_parse_fail' => false
+    'parse_fail_delta' => 1,   'detailed_parse_fail' => true

3) testIpv4AutoTrailSignaturesAreCountedSymmetrically
both trail signatures must be counted the same way
Failed asserting that 1 is identical to 0.

Tests: 19, Assertions: 37, Failures: 3.
```

GREEN, same file byte-identical (`git hash-object` still
`5fd128b390af8747da2df618961d7490737554bb`, verified after the production edit):

```
OK (19 tests, 38 assertions)
```

The pre-existing `testIpv4AutoIblockAndRangeExpand` is the behaviour-preserving oracle for
the format the branch exists for; it stays green across the change.

## Gates

```
GATE PASS: python3 scripts/check_composer_vendor.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
GATE PASS: php -l tests/php/IpParseLineTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

Full PHPUnit: 4618 tests, 25093 assertions, 0 failures. The `Undefined array key "base_rule"`
warnings come from `Issue1840SuppUpdateNullPostinstallTest`, which does not reach the parser
and is untouched by this diff.

## Context

Found while investigating #1922 (a URL path segment parsed as a CIDR mask, collapsing a feed
to `0.0.0.0/0` and silently emptying every lower-priority feed). That defect is separate and
is not addressed here. The Maltrail feed itself parses correctly — 100% of its 16854 source
addresses are covered by the produced snapshot; only the error reporting was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic IPv4 range parsing for iBlocklist and PeerGuardian entries.
  * Correctly handles organization names containing colons.
  * Prevents unrelated lines containing dashes and colons from being incorrectly rewritten.
  * Ensures related trail signatures are processed consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->