### PR TITLE
pfblockerng: never let a total-range row act as a cumulative dedup pattern

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -969,11 +969,23 @@ pfb_recompute() {
 			# grepcidr with a pattern-free file, which prints NOTHING for -vf (not
 			# "keep everything"): it would wipe every row of every lower-priority
 			# feed sharing this pass.
-			if ! LC_ALL=C awk '{ sub(/\r$/, "") } NF' "${rec_ownedfile}" >> "${rec_cumulative}"; then
+			# issue #1929: a total-range row (0.0.0.0/0, ::/0) as a -vf pattern
+			# MATCHES everything -- the same silent wipe -- so keep it out of the
+			# cumulative stream; it still ships in this alias's own deny file.
+			if ! LC_ALL=C awk -v allnetflag="${rec_scratch}/allnet" '
+				{ sub(/\r$/, "") }
+				!NF { next }
+				$1 == "0.0.0.0/0" || $1 == "::/0" { print > allnetflag; next }
+				{ print }' "${rec_ownedfile}" >> "${rec_cumulative}"; then
 				log="recompute [ ${rec_family} ]: could not extend cumulative dedup stream for [ ${rec_alias} ]; aborting pass, cleaning up partial artifacts"
 				echo "${log}" | tee -a "${errorlog}"
 				pfb_recompute_clean_new
 				return 1
+			fi
+			if [ -s "${rec_scratch}/allnet" ]; then
+				log="recompute [ ${rec_family} ]: dropped total-range row(s) from [ ${rec_alias} ] before cumulative dedup (a 0.0.0.0/0 or ::/0 pattern would empty every lower-priority alias)"
+				echo "${log}" | tee -a "${errorlog}"
+				rm -f "${rec_scratch}/allnet"
 			fi
 		fi
 	done < "${rec_memberlist}"

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -217,6 +217,7 @@ Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 	After 'cleanup'
 
 	pfb_counts_line() { grep "^FeedB_v4 " "$countsfile"; }
+	pfb_allnet_log_count() { grep -c 'dropped total-range row(s) from \[ AllNet_v4 \]' "$errorlog"; }
 
 	It "keeps the first-priority feed's copy and prunes a later feed's exact repeat"
 		printf '192.0.2.10\n192.0.2.11\n' > "${snap}/FeedA_v4.orig"
@@ -437,7 +438,7 @@ Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 		The contents of file "$countsfile" should include 'AllNet_v4 2'
 		The contents of file "$countsfile" should include 'LowerA_v4 2'
 		The contents of file "$countsfile" should include 'LowerB_v4 1'
-		The contents of file "${errorlog}" should include 'AllNet_v4'
+		The result of "pfb_allnet_log_count()" should equal 1
 	End
 
 	It 'a broad-but-not-total prefix (10.0.0.0/8) still prunes contained lower rows -- the total-range guard never over-matches (issue #1929 negative control)'
@@ -555,6 +556,8 @@ Describe 'pfb_recompute() v6 dedup (same Stage A/B/D/E loop, per family)'
 	Before 'setup'
 	After 'cleanup'
 
+	pfb_allnet_v6_log_count() { grep -c 'dropped total-range row(s) from \[ AllNet_v6 \]' "$errorlog"; }
+
 	It 'dedups an exact cross-feed repeat and prunes via CIDR containment'
 		printf '2001:db8::/32\n' > "${snap}/SixA_v6.orig"
 		printf '2001:db8:dead:beef::1\nfd12:3456::1\n' > "${snap}/SixB_v6.orig"
@@ -605,7 +608,7 @@ Describe 'pfb_recompute() v6 dedup (same Stage A/B/D/E loop, per family)'
 		The contents of file "${pfbdeny}LowerB_v6.txt" should equal 'fd99::7'
 		The contents of file "$countsfile" should include 'LowerA_v6 1'
 		The contents of file "$countsfile" should include 'LowerB_v6 1'
-		The contents of file "${errorlog}" should include 'AllNet_v6'
+		The result of "pfb_allnet_v6_log_count()" should equal 1
 	End
 
 	It 'keeps v4 and v6 masterfile rows separate: a v6 recompute never touches v4 family rows and vice versa'

--- a/tests/shell/pfblockerng_recompute_spec.sh
+++ b/tests/shell/pfblockerng_recompute_spec.sh
@@ -420,6 +420,37 @@ Describe 'pfb_recompute() v4 cross-feed dedup (Stage A/B/D/E)'
 		The contents of file "${pfbdeny}PaddedLower_v4.txt" should equal '198.51.100.76'
 	End
 
+	It 'a 0.0.0.0/0 row never acts as a cumulative dedup pattern: lower-priority disjoint feeds survive, its own alias still ships it, and the drop is logged (issue #1929)'
+		printf '203.0.113.60\n0.0.0.0/0\n' > "${snap}/AllNet_v4.orig"
+		printf '198.51.100.80\n198.51.100.81\n' > "${snap}/LowerA_v4.orig"
+		# a lowest-priority repeat of AllNet's ORDINARY row: proves that row still
+		# reached rec_cumulative -- a bad fix that skips the whole owned file on a
+		# total-range row would leave this repeat undeduped instead of pruned.
+		printf '203.0.113.60\n192.0.2.90\n' > "${snap}/LowerB_v4.orig"
+		printf '%s\n%s\n%s\n' "${snap}/AllNet_v4.orig" "${snap}/LowerA_v4.orig" "${snap}/LowerB_v4.orig" > "$memberlist"
+
+		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		The contents of file "${pfbdeny}AllNet_v4.txt" should equal "$(printf '0.0.0.0/0\n203.0.113.60')"
+		The contents of file "${pfbdeny}LowerA_v4.txt" should equal "$(printf '198.51.100.80\n198.51.100.81')"
+		The contents of file "${pfbdeny}LowerB_v4.txt" should equal '192.0.2.90'
+		The contents of file "$countsfile" should include 'AllNet_v4 2'
+		The contents of file "$countsfile" should include 'LowerA_v4 2'
+		The contents of file "$countsfile" should include 'LowerB_v4 1'
+		The contents of file "${errorlog}" should include 'AllNet_v4'
+	End
+
+	It 'a broad-but-not-total prefix (10.0.0.0/8) still prunes contained lower rows -- the total-range guard never over-matches (issue #1929 negative control)'
+		printf '10.0.0.0/8\n' > "${snap}/Broad_v4.orig"
+		printf '10.1.2.3\n198.51.100.90\n' > "${snap}/UnderBroad_v4.orig"
+		printf '%s\n%s\n' "${snap}/Broad_v4.orig" "${snap}/UnderBroad_v4.orig" > "$memberlist"
+
+		When call silently pfb_recompute recompute v4 "$memberlist" "$countsfile" on off
+		The status should be success
+		The contents of file "${pfbdeny}UnderBroad_v4.txt" should equal '198.51.100.90'
+		The contents of file "$countsfile" should include 'UnderBroad_v4 1'
+	End
+
 	It 'dedups an internal repeat within a single feed snapshot (within-feed dupes, issue #1084 review)'
 		printf '192.0.2.9\n192.0.2.9\n192.0.2.10\n' > "${snap}/DupFeed_v4.orig"
 		printf '%s\n' "${snap}/DupFeed_v4.orig" > "$memberlist"
@@ -557,6 +588,24 @@ Describe 'pfb_recompute() v6 dedup (same Stage A/B/D/E loop, per family)'
 		The contents of file "${pfbdeny}Disjoint_v6.txt" should equal '2001:db8::71'
 		The contents of file "$countsfile" should include 'OnlySpaces_v6 0'
 		The contents of file "$countsfile" should include 'Disjoint_v6 1'
+	End
+
+	It 'a ::/0 row never acts as a cumulative dedup pattern: lower-priority disjoint v6 feeds survive, its own alias still ships it, and the drop is logged (issue #1929)'
+		printf '2001:db8::60\n::/0\n' > "${snap}/AllNet_v6.orig"
+		printf 'fd12:3456::2\n' > "${snap}/LowerA_v6.orig"
+		# a lowest-priority repeat of AllNet's ORDINARY row: proves it still
+		# reached rec_cumulative despite the total-range drop.
+		printf '2001:db8::60\nfd99::7\n' > "${snap}/LowerB_v6.orig"
+		printf '%s\n%s\n%s\n' "${snap}/AllNet_v6.orig" "${snap}/LowerA_v6.orig" "${snap}/LowerB_v6.orig" > "$memberlist"
+
+		When call silently pfb_recompute recompute v6 "$memberlist" "$countsfile" on off
+		The status should be success
+		The contents of file "${pfbdeny}AllNet_v6.txt" should equal "$(printf '2001:db8::60\n::/0')"
+		The contents of file "${pfbdeny}LowerA_v6.txt" should equal 'fd12:3456::2'
+		The contents of file "${pfbdeny}LowerB_v6.txt" should equal 'fd99::7'
+		The contents of file "$countsfile" should include 'LowerA_v6 1'
+		The contents of file "$countsfile" should include 'LowerB_v6 1'
+		The contents of file "${errorlog}" should include 'AllNet_v6'
 	End
 
 	It 'keeps v4 and v6 masterfile rows separate: a v6 recompute never touches v4 family rows and vice versa'


### PR DESCRIPTION
## Summary

`pfb_recompute()` Stage A's cumulative dedup failed open: a single `0.0.0.0/0` (or `::/0`) row entering the `cumulative` pattern file made `grepcidr -vf` match every subsequent input, so every lower-priority alias in the pass emitted zero rows — silently, with a "success" update summary (issue #1929's replayed production outage: eight feeds emptied by one malformed row).

This PR extends the existing blank/whitespace filter at the single cumulative-extension site to also drop total-range rows (`0.0.0.0/0`, `::/0`) before they reach the cumulative stream, and logs once per alias when one is dropped so the condition is no longer invisible. The row still ships in its own alias's deny file — this changes only what may act as a dedup **pattern** for later aliases.

## Test-first proof (executed)

Reproduction tests authored before any production edit in `tests/shell/pfblockerng_recompute_spec.sh`, frozen at `git hash-object` `a51c9963543ee3ffd646350d7731c2cad5680ae0`:

- **RED** on untouched code: 2 failures — the v4 `0.0.0.0/0` example (lower feeds emptied, `kept=0`, no log line) and the v6 `::/0` sibling.
- **GREEN** after the fix, spec byte-identical (same hash): `72 examples, 0 failures` under both bash-as-sh and dash (`shellspec --shell dash`).

Coverage per the issue's test plan:

- `0.0.0.0/0` in a high-priority feed: two lower-priority aliases assert their surviving row counts (not merely exit 0).
- `::/0` sibling in a v6-family pass, same assertions.
- The owning alias still emits the `/0` row in its own deny file.
- A lowest-priority repeat of the owning alias's *ordinary* row asserts empty — proving the valid row still reached the cumulative stream (guards against an over-fix that skips the whole owned file).
- Negative control: `10.0.0.0/8` still prunes contained lower rows (the guard never over-matches).
- The drop is logged to the error log (`should include 'AllNet_v4'` / `'AllNet_v6'`).
- Existing blank/whitespace-guard siblings at the same site stay green.

## Gates

- `scripts/agent/run-gates.sh --diff origin/devel`: PASS (`sh -n`, shellcheck, shellspec under dash).
- Pre-commit full impacted shellspec: `1108 examples, 0 failures, 8 skips` (skips are the usual environment-gated examples).

Fixes #1929

---

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Total-range IPv4 and IPv6 entries are retained in their owning alias output without suppressing disjoint lower-priority feeds during cumulative deduplication.
  * Ordinary duplicate entries continue to be deduplicated correctly.
  * Broad non-total network ranges retain their existing filtering behavior.

* **Tests**
  * Added regression coverage for IPv4 and IPv6 total-range handling, counts, and error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->