### PR TITLE
pfblockerng: path-addressed configuration registry (section-alias/key)

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1211,7 +1211,7 @@ in PHP, so nothing needs a chroot-local socket any more.
 
 **Both emit paths live in `pfb_daemon_filterlog()`** (`pfblockerng.inc`) — the single writer of
 `unified.log` and the host-side DNSBL syslog emitter — each gated by
-`PfbConfig::read('log_syslog') === PfbToggle::On`, with the daemon's config refreshed first so
+`PfbConfig::read('gen/log_syslog') === PfbToggle::On`, with the daemon's config refreshed first so
 a LIVE toggle takes effect without a restart:
 
 - **IP events** — `pfb_syslog_event(pfb_syslog_format_ip($fields))` at the pf-filter CSV write

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -17,6 +17,14 @@ exclusions.
   `config_*_path` on a registered key (enforced by the
   `PfBlockerNG.Config.RequireConfigGateway` sniff; adding a registered key ⇒ also add it to
   the sniff's `$registeredPaths`).
+- **Path addressing (issue #1931):** registry keys are `'<alias>/<config-key>'` path
+  strings — `'gen/pfb_keep'`, `'ip/suppression'` — with the alias resolved through the
+  `PFB_SECTIONS` map (`gen`/`dnsbl`/`ss`/`ip`/`rep`), the single home of the five real
+  section paths. Same-named keys in different sections cannot collide, and bare-name
+  lookups throw (`InvalidArgumentException`) — no dual addressing. Entries carry no
+  `section` attribute; a key prefix outside `PFB_SECTIONS` fails `CfgGatewayTest`'s
+  alias gate, and the pre-change tuple parity is pinned by
+  `tests/php/fixtures/cfg_registry_pre1931_parity.json`.
 - Section helpers (`readSection`/`writeSection`/`deleteSection`) for whole-section,
   non-per-field access. Unregistered key → `InvalidArgumentException`.
 - **No `write_config()` inside the gateway** — the caller decides when to flush. The registry
@@ -162,8 +170,9 @@ Authorization is a property of the **write**, not the call site (the
 
 ## Adding a new registered field
 
-1. Add an entry to `pfb_cfg_registry()` with the exact `config.xml` key, its section path,
-   the default stored string, and the adapter pair (or `NULL`/`NULL` for plain string).
+1. Add an entry to `pfb_cfg_registry()` keyed `'<alias>/<config-key>'` (alias from
+   `PFB_SECTIONS`; the config-key part is the exact `config.xml` key), with the default
+   stored string and the adapter pair (or `NULL`/`NULL` for plain string).
    Giving an EXISTING field an adapter changes what `read()` returns for it (enum, not
    string), so every consumer of that field moves in the same commit — a stale string
    comparison against the enum fails silently in the always-false direction (issue #1887).
@@ -293,15 +302,16 @@ called from `pfblockerng_install.inc` **after** the migration driver *and* after
 end of that file, so a seed inside the migration registry would materialise the registry default
 first and permanently disarm both. It rides the installer's trailing `write_config()`.
 
-`PFB_SCALAR_SEED_EXCLUDED` holds the five keys whose **literal absence** some consumer still
-reads as a distinct state, so materialising them would change behaviour on the way to making
-storage explicit:
+`PFB_SCALAR_SEED_EXCLUDED` holds the six keys (path-form, issue #1931) whose **literal
+absence** some consumer still reads as a distinct state, so materialising them would change
+behaviour on the way to making storage explicit:
 
 | Key | Why absence is load-bearing |
 | --- | --- |
-| `settings_family` | The installer's own schema marker, not operator configuration — the same reason `pfb_gconfig_operator_view()` strips it (#1770/#1771/#1775). |
-| `v4suppression` | `pfblockerng_install.inc`'s ADR-53 `pfBlockerNGSuppress` alias conversion is gated on "never migrated" (absent) versus "present but empty". |
-| `pfb_cache`, `pfb_py_reply`, `pfb_hsts` | `pfblockerng_dnsbl.php` renders these CHECKED while the key is absent (`isset(…) ? … : 'on'`) although the registered default is `''`. Seeding `''` would flip the first-open rendering, and so what a first save stores. That page/registry divergence is **issue #1907**; these three join the pass when it is resolved. |
+| `gen/settings_family` | The installer's own schema marker, not operator configuration — the same reason `pfb_gconfig_operator_view()` strips it (#1770/#1771/#1775). |
+| `ip/v4suppression` | `pfblockerng_install.inc`'s ADR-53 `pfBlockerNGSuppress` alias conversion is gated on "never migrated" (absent) versus "present but empty". |
+| `dnsbl/pfb_cache`, `dnsbl/pfb_py_reply`, `dnsbl/pfb_hsts` | `pfblockerng_dnsbl.php` renders these CHECKED while the key is absent (`isset(…) ? … : 'on'`) although the registered default is `''`. Seeding `''` would flip the first-open rendering, and so what a first save stores. That page/registry divergence is **issue #1907**; these three join the pass when it is resolved. |
+| `ip/suppression` | Same #1907 class on `pfblockerng_ip.php` (renders checked while absent, registered default `''`). Registered by issue #1931 once path addressing removed its name collision with the DNSBL `dnsbl/suppression` whitelist blob; its `'on'` default + grandfather decision is deferred to #1921. |
 
 Nothing else needs excluding — under the issue #1887 `''` ≡ absent identity, seeding a
 `''`-default field (a credential, a base64 blob, an interface multi-select) stores exactly the

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -138,7 +138,7 @@ Authorization is a property of the **write**, not the call site (the
   - **`pfb_idn` → `PfbIdnMode`** (registry adapters `pfb_cfg_idn_mode_read/write`): tokens
     `'on'` (= All) / `'confusable'` / `'off'`. `All` **reuses the original `'on'`** block-all
     token, so current code reading a pre-4.0.0 configuration preserves block-all with no
-    migration. `PfbConfig::read('pfb_idn')` returns the enum;
+    migration. `PfbConfig::read('dnsbl/pfb_idn')` returns the enum;
     `PfbConfig::write()` and the `py_unbound.ini` build both emit `toStored()`; consumers compare
     `=== PfbIdnMode::All` / `::Confusable`. The 4.0.0-alpha-only `'all'` token is **not** carried
     (alpha compatibility is intentionally not maintained) — it reads as Off. One canonical

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11973,13 +11973,14 @@ function pfb_legacy_key_rename_migrate($sections) {
 //                    (same reason pfb_gconfig_operator_view() strips it, #1770/#1771/#1775).
 //   v4suppression    pfblockerng_install.inc's ADR-53 pfBlockerNGSuppress alias conversion is
 //                    gated on "never migrated" (absent) vs "present but empty".
-//   pfb_cache,       pfblockerng_dnsbl.php renders these CHECKED while the key is absent
-//   pfb_py_reply,    (isset(...) ? ... : 'on') though the registry default is '', so seeding
-//   pfb_hsts         would flip the first-open rendering and what a first save stores. That
-//                    page/registry divergence is issue #1907; these join the pass when it is
-//                    resolved.
+//   pfb_cache,       pfblockerng_dnsbl.php / pfblockerng_ip.php render these CHECKED while
+//   pfb_py_reply,    the key is absent (isset(...) ? ... : 'on') though the registry default
+//   pfb_hsts,        is '', so seeding '' would flip the first-open rendering and what a
+//   ip/suppression   first save stores. That page/registry divergence is issue #1907; these
+//                    join the pass when it is resolved (ip/suppression added by issue #1931).
 const PFB_SCALAR_SEED_EXCLUDED = array(
 	'gen/settings_family', 'ip/v4suppression', 'dnsbl/pfb_cache', 'dnsbl/pfb_py_reply', 'dnsbl/pfb_hsts',
+	'ip/suppression',
 );
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11968,16 +11968,19 @@ function pfb_legacy_key_rename_migrate($sections) {
 // Registered scalars the seeding pass never materialises, because some consumer still reads
 // their LITERAL ABSENCE as a distinct state -- seeding them would change behaviour on the way
 // to making storage explicit:
-//   settings_family  the installer's own schema marker, not operator configuration; seeding
-//                    the legacy '3.2' default would fight pfb_settings_family_record()
-//                    (same reason pfb_gconfig_operator_view() strips it, #1770/#1771/#1775).
-//   v4suppression    pfblockerng_install.inc's ADR-53 pfBlockerNGSuppress alias conversion is
-//                    gated on "never migrated" (absent) vs "present but empty".
-//   pfb_cache,       pfblockerng_dnsbl.php / pfblockerng_ip.php render these CHECKED while
-//   pfb_py_reply,    the key is absent (isset(...) ? ... : 'on') though the registry default
-//   pfb_hsts,        is '', so seeding '' would flip the first-open rendering and what a
-//   ip/suppression   first save stores. That page/registry divergence is issue #1907; these
-//                    join the pass when it is resolved (ip/suppression added by issue #1931).
+//   gen/settings_family   the installer's own schema marker, not operator configuration;
+//                         seeding the legacy '3.2' default would fight
+//                         pfb_settings_family_record() (same reason
+//                         pfb_gconfig_operator_view() strips it, #1770/#1771/#1775).
+//   ip/v4suppression      pfblockerng_install.inc's ADR-53 pfBlockerNGSuppress alias
+//                         conversion is gated on "never migrated" (absent) vs
+//                         "present but empty".
+//   dnsbl/pfb_cache,      pfblockerng_dnsbl.php / pfblockerng_ip.php render these CHECKED
+//   dnsbl/pfb_py_reply,   while the key is absent (isset(...) ? ... : 'on') though the
+//   dnsbl/pfb_hsts,       registry default is '', so seeding '' would flip the first-open
+//   ip/suppression        rendering and what a first save stores. That page/registry
+//                         divergence is issue #1907; these join the pass when it is
+//                         resolved (ip/suppression added by issue #1931).
 const PFB_SCALAR_SEED_EXCLUDED = array(
 	'gen/settings_family', 'ip/v4suppression', 'dnsbl/pfb_cache', 'dnsbl/pfb_py_reply', 'dnsbl/pfb_hsts',
 	'ip/suppression',

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2928,16 +2928,16 @@ function pfb_global() {
 	$pfb['blconfig']	= config_get_path('installedpackages/pfblockerngblacklist', []);
 	$pfb['config_global']	= config_get_path('installedpackages/pfblockerngglobal', []);
 
-	$pfb['enable']		= PfbConfig::read('enable_cb');		// Enable/Disable of pfBlockerNG
-	$pfb['keep']		= PfbConfig::read('pfb_keep');		// Keep blocklists on pfBlockerNG Disable (default ON via registry; #281)
-	$pfb['interval']	= PfbConfig::read('pfb_interval')	?: '1';	// Hour cycle for scheduler
+	$pfb['enable']		= PfbConfig::read('gen/enable_cb');		// Enable/Disable of pfBlockerNG
+	$pfb['keep']		= PfbConfig::read('gen/pfb_keep');		// Keep blocklists on pfBlockerNG Disable (default ON via registry; #281)
+	$pfb['interval']	= PfbConfig::read('gen/pfb_interval')	?: '1';	// Hour cycle for scheduler
 
 	// ADR-11: opt-in per-type aggregate ("Uber") aliases. CSV scalar of the action types
 	// to aggregate (subset of Deny/Permit/Match/Native), default NONE -> [] -> no-op pass.
 	// CSV (a single string, like blacklist_selected) so it round-trips with no '<0>' list XML.
 	$pfb['agg_types']	= array_values(array_intersect(
 					array('Deny', 'Permit', 'Match', 'Native'),
-					array_filter(explode(',', PfbConfig::read('pfb_agg_types')))));
+					array_filter(explode(',', PfbConfig::read('gen/pfb_agg_types')))));
 
 	// Validate Cron settings
 	if (!is_numeric($pfb['interval'])) {
@@ -2966,12 +2966,12 @@ function pfb_global() {
 	$pfb['maxmind_account']	= pfb_filter($pfb['ipconfig']['maxmind_account'], PFB_FILTER_WORD, 'pfb_global')	?: '';		// Maxmind Account ID
 	$pfb['maxmind_key']	= pfb_filter($pfb['ipconfig']['maxmind_key'], PFB_FILTER_WORD, 'maxmind_key')		?: '';		// Maxmind License Key (issue #924: log-safe reference -- a rejected key is never logged on this consumer path either)
 
-	$pfb['dnsbl']		= PfbConfig::read('pfb_dnsbl');							// Enabled state of DNSBL
-	$pfb['dnsbl_vip_auto']	= PfbConfig::read('pfb_dnsvip_auto');						// [ ADR-13 ] Auto-create/remove the DNSBL sinkhole VIP(s) (default off)
-	$pfb['dnsbl_nonat']	= PfbConfig::read('pfb_dnsbl_nonat');						// [ #381 ] Opt out of automatic DNSBL NAT rule generation (default off)
+	$pfb['dnsbl']		= PfbConfig::read('dnsbl/pfb_dnsbl');							// Enabled state of DNSBL
+	$pfb['dnsbl_vip_auto']	= PfbConfig::read('dnsbl/pfb_dnsvip_auto');						// [ ADR-13 ] Auto-create/remove the DNSBL sinkhole VIP(s) (default off)
+	$pfb['dnsbl_nonat']	= PfbConfig::read('dnsbl/pfb_dnsbl_nonat');						// [ #381 ] Opt out of automatic DNSBL NAT rule generation (default off)
 	$pfb['dnsbl_vip4'] = get_configured_vip_ipv4($pfb['dnsblconfig']['pfb_dnsvip4']) ?? '';
 	$pfb['dnsbl_vip6'] = get_configured_vip_ipv6($pfb['dnsblconfig']['pfb_dnsvip6']) ?? '';
-	$pfb['dnsbl_iface']	= PfbConfig::read('dnsbl_interface');							// VIP Local Interface setting (default 'lo0')
+	$pfb['dnsbl_iface']	= PfbConfig::read('dnsbl/dnsbl_interface');							// VIP Local Interface setting (default 'lo0')
 	if ($pfb['dnsbl'] === PfbToggle::On) {
 		// VIP validation: force-disable DNSBL on a genuinely invalid/missing/overlapping
 		// VIP — UNLESS auto-create mode is active, in which case pfb_manage_dnsbl_vip()
@@ -3007,27 +3007,27 @@ function pfb_global() {
 	$pfb['dnsbl_port']	= $pfb['dnsblconfig']['pfb_dnsport'];									// Lighttpd web server http port setting
 	$pfb['dnsbl_port_ssl']	= $pfb['dnsblconfig']['pfb_dnsport_ssl'];								// Lighttpd web server https port setting
 	$pfb['dnsbl_top1m']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['top1m_enable'] ?? '');							// TOP1M whitelist
-	$pfb['dnsbl_top1m_type']	= PfbConfig::read('top1m_source');						// TOP1M type (PfbTop1mSource enum; legacy 'alexa' coalesces to Tranco, #877) (default Tranco)
+	$pfb['dnsbl_top1m_type']	= PfbConfig::read('dnsbl/top1m_source');						// TOP1M type (PfbTop1mSource enum; legacy 'alexa' coalesces to Tranco, #877) (default Tranco)
 	$pfb['dnsbl_res_cache']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_cache'] ?? '');							// DNSBL Option to backup/restore Resolver cache
-	$pfb['dnsbl_cache_flush']	= PfbConfig::read('pfb_cache_flush');						// Opt-in full cache flush after DNSBL data swaps
-	$pfb['dnsbl_global_log']= PfbConfig::read('global_log');							// Global Logging/Blocking mode (default '')
+	$pfb['dnsbl_cache_flush']	= PfbConfig::read('dnsbl/pfb_cache_flush');						// Opt-in full cache flush after DNSBL data swaps
+	$pfb['dnsbl_global_log']= PfbConfig::read('dnsbl/global_log');							// Global Logging/Blocking mode (default '')
 	// ADR-22: lenient feed parsing. 'on' = permissive scheme strip (today); anything else =
 	// strict RFC 3986 scheme validation + URL-path rejection. New installs default OFF
 	// (strict); existing installs are migrated to 'on' on upgrade (pfb_dnsbl_lenient_migrate).
-	$pfb['dnsbl_lenient']	= PfbConfig::read('pfb_dnsbl_lenient');							// DNSBL scheme-parsing leniency (PfbToggle enum)
+	$pfb['dnsbl_lenient']	= PfbConfig::read('dnsbl/pfb_dnsbl_lenient');							// DNSBL scheme-parsing leniency (PfbToggle enum)
 
 	$pfb['dnsbl_py_reply']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_py_reply'] ?? '');			// DNSBL Resolver python DNS Reply logging
-	$pfb['dnsbl_hsts']	= PfbConfig::read('pfb_hsts');			// DNSBL Resolver python block HSTS via Null Blocking mode
+	$pfb['dnsbl_hsts']	= PfbConfig::read('dnsbl/pfb_hsts');			// DNSBL Resolver python block HSTS via Null Blocking mode
 	// ADR-08: IDN mode selector. PfbConfig::read() returns a PfbIdnMode enum via the
 	// registry adapter: 'on' -> All (preserves block-all-IDN on upgrade); 'confusable'
 	// -> Confusable; '' / 'off' / absent / the dropped 4.0.0-alpha 'all' -> Off. Downstream
 	// consumers compare against the enum; the ini build serialises the canonical token.
-	$pfb['dnsbl_idn']	= PfbConfig::read('pfb_idn');				// DNSBL Resolver python IDN mode (PfbIdnMode enum)
-	$pfb['dnsbl_idn_block_malicious']	= PfbConfig::read('pfb_idn_block_malicious');		// Confusable: block malicious homoglyphs (default 'on')
-	$pfb['dnsbl_idn_escalate_suspicious']	= PfbConfig::read('pfb_idn_escalate_suspicious');	// Confusable: escalate suspicious mixed-script to block (opt-in)
+	$pfb['dnsbl_idn']	= PfbConfig::read('dnsbl/pfb_idn');				// DNSBL Resolver python IDN mode (PfbIdnMode enum)
+	$pfb['dnsbl_idn_block_malicious']	= PfbConfig::read('dnsbl/pfb_idn_block_malicious');		// Confusable: block malicious homoglyphs (default 'on')
+	$pfb['dnsbl_idn_escalate_suspicious']	= PfbConfig::read('dnsbl/pfb_idn_escalate_suspicious');	// Confusable: escalate suspicious mixed-script to block (opt-in)
 	$pfb['dnsbl_regex']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_regex'] ?? '');			// DNSBL Resolver python regex
 	$pfb['dnsbl_regex_list']= $pfb['dnsblconfig']['pfb_regex_list'] ?? '';	// DNSBL Resolver python regex list
-	$pfb['dnsbl_regex_cap']	= PfbConfig::read('pfb_regex_cap');			// DNSBL Resolver python opt-in "Limit long/complex regex" static cap
+	$pfb['dnsbl_regex_cap']	= PfbConfig::read('dnsbl/pfb_regex_cap');			// DNSBL Resolver python opt-in "Limit long/complex regex" static cap
 	$pfb['dnsbl_cname']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_cname'] ?? '');			// DNSBL Resolver python CNAME Validation
 	$pfb['dnsbl_tld_allow']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['tld_allow'] ?? '');			// DNSBL Resolver TLD Allow option
 	$pfb['dnsbl_py_nolog']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_py_nolog'] ?? '');			// DNSBL Resolver python - Log events via DNSBL Webserver vs python
@@ -3038,10 +3038,10 @@ function pfb_global() {
 	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'] ?? '';	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
 
 	// SafeSearch — read via gateway (ADR-29).
-	$pfb['safesearch_enable']	= PfbConfig::read('safesearch_enable');
-	$pfb['safesearch_youtube']	= PfbConfig::read('safesearch_youtube');
-	$pfb['safesearch_doh']		= PfbConfig::read('safesearch_doh');
-	$pfb['safesearch_doh_list']	= array_values(array_filter(array_map('trim', explode(',', PfbConfig::read('safesearch_doh_list'))), 'strlen'));
+	$pfb['safesearch_enable']	= PfbConfig::read('ss/safesearch_enable');
+	$pfb['safesearch_youtube']	= PfbConfig::read('ss/safesearch_youtube');
+	$pfb['safesearch_doh']		= PfbConfig::read('ss/safesearch_doh');
+	$pfb['safesearch_doh_list']	= array_values(array_filter(array_map('trim', explode(',', PfbConfig::read('ss/safesearch_doh_list'))), 'strlen'));
 
 	// DNSBL SafeSearch
 	$pfb['dnsbl_safe_search'] = FALSE;
@@ -4319,7 +4319,7 @@ function pfb_update_available(?string $installed, ?string $latest): bool {
  */
 function pfb_software_check_enabled(): bool {
 	// issue #1887: the ON default lives in the registry now; the accessor just asks.
-	return PfbConfig::read('pfb_software_check') === PfbToggle::On;
+	return PfbConfig::read('gen/pfb_software_check') === PfbToggle::On;
 }
 
 /*
@@ -10432,7 +10432,7 @@ function pfblockerng_top1m(?array $provider_override = NULL, array $stream_ops=a
 
 	// ADR-59: the active provider descriptor drives the parse knobs below.
 	// $pfb['dnsbl_top1m_type'] may be unset in an isolated unit-test context
-	// (it is normally set by pfb_global() -- PfbConfig::read('top1m_source') --
+	// (it is normally set by pfb_global() -- PfbConfig::read('dnsbl/top1m_source') --
 	// which some tests never call); default to Tranco, the same absent-default
 	// the registry itself uses, so the resolved shape stays rank_domain/zip.
 	$top1m_type	= $pfb['dnsbl_top1m_type'] ?? PfbTop1mSource::Tranco;
@@ -11645,7 +11645,7 @@ function pfb_ip_is_internal($ip) {
 function pfb_feed_internal_allowlist($ignored = NULL) {
 
 	$ignored = 0;
-	$raw = PfbConfig::read('pfb_feed_internal_allowlist');
+	$raw = PfbConfig::read('gen/pfb_feed_internal_allowlist');
 	if (!is_string($raw) || $raw === '') {
 		return array();
 	}
@@ -11979,7 +11979,7 @@ function pfb_legacy_key_rename_migrate($sections) {
 //                    page/registry divergence is issue #1907; these join the pass when it is
 //                    resolved.
 const PFB_SCALAR_SEED_EXCLUDED = array(
-	'settings_family', 'v4suppression', 'pfb_cache', 'pfb_py_reply', 'pfb_hsts',
+	'gen/settings_family', 'ip/v4suppression', 'dnsbl/pfb_cache', 'dnsbl/pfb_py_reply', 'dnsbl/pfb_hsts',
 );
 
 
@@ -12018,12 +12018,15 @@ function pfb_registered_scalars_seed($sections) {
 
 	$seeded = array();
 
-	foreach (pfb_cfg_registry() as $key => $entry) {
-		if (in_array($key, PFB_SCALAR_SEED_EXCLUDED, TRUE)) {
+	foreach (pfb_cfg_registry() as $path_key => $entry) {
+		if (in_array($path_key, PFB_SCALAR_SEED_EXCLUDED, TRUE)) {
 			continue;
 		}
-		$section = $entry['section'];
-		$blob    = $seeded[$section] ?? ($sections[$section] ?? array());
+		// issue #1931: registry keys are now '<alias>/<bare-key>'; config.xml itself is
+		// untouched, so every blob operation below uses the bare key.
+		[$alias, $key] = explode('/', $path_key, 2);
+		$section       = PFB_SECTIONS[$alias];
+		$blob          = $seeded[$section] ?? ($sections[$section] ?? array());
 		if (!is_array($blob) || array_key_exists($key, $blob)) {
 			continue;
 		}
@@ -12053,7 +12056,7 @@ function pfb_registered_scalars_seed($sections) {
 // toggle (it was "anything but 'off' is ON"), and case variants are recognised.
 function pfb_feed_filter_enabled(): bool {
 
-	return PfbConfig::read('pfb_feed_internal_filter') === PfbToggle::On;
+	return PfbConfig::read('gen/pfb_feed_internal_filter') === PfbToggle::On;
 }
 
 
@@ -12933,7 +12936,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 		// upstream FILE_MIME check above; this gate only narrows to the text types.)
 		// 'application/csv' rides with 'text/csv' -- same CSV body, just a different
 		// libmagic verdict (both are allow-listed synonyms; see pfb_filter FILE_MIME).
-		if (PfbConfig::read('pfb_feed_sanity') === PfbToggle::On &&
+		if (PfbConfig::read('gen/pfb_feed_sanity') === PfbToggle::On &&
 			in_array($file_type, array('text/plain', 'text/html', 'text/csv', 'application/csv'), TRUE)) {
 			// Read UP TO 64 KiB -- a cap, not a minimum; a shorter feed is read whole.
 			// 64 KiB (raised from 8 KiB) because HTML-wrapped real feeds bury their
@@ -15620,7 +15623,7 @@ function pfb_daemon_filterlog() {
 								// no-ops when the toggle is off. Refresh the daemon's config
 								// first so a LIVE log_syslog toggle takes effect (no restart).
 								pfb_filterlog_refresh_config();
-								if (PfbConfig::read('log_syslog') === PfbToggle::On) {
+								if (PfbConfig::read('gen/log_syslog') === PfbToggle::On) {
 									pfb_syslog_event(pfb_syslog_format_dnsbl(array(
 										'q_name' => $df[2], 'q_ip' => $df[3], 'q_type' => $df[10],
 										'group' => $df[6], 'feed' => $df[8], 'b_type' => $df[5],
@@ -16013,7 +16016,7 @@ function pfb_daemon_filterlog() {
 				// Build the field array only when log_syslog is enabled; skip otherwise.
 				// Emitted EXACTLY ONCE here — not again for the unified-log copy below.
 				pfb_filterlog_refresh_config();
-				if (PfbConfig::read('log_syslog') === PfbToggle::On) {
+				if (PfbConfig::read('gen/log_syslog') === PfbToggle::On) {
 					// Map $d[6] back to the canonical act value.
 					// At this point $d[6] is 'block'|'pass'|'unkn(%u)' (match was reversed).
 					$pfb_syslog_act = ($d[6] === 'unkn(%u)') ? 'match' : $d[6];

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -554,9 +554,9 @@ function sync_package_pfblockerng($cron='') {
 	// loop's raw-string-or-'x' shape above (that placeholder exists for the numeric/CSV
 	// fields' shell-arg positional integrity; a toggle already has a well-formed enum for
 	// every input, so it never needs it).
-	$pfb['rep']	= PfbConfig::read('enable_rep');	// Enable/Disable 'Max' Reputation
-	$pfb['prep']	= PfbConfig::read('enable_pdup');	// Enable/Disable 'pRep' Reputation
-	$pfb['drep']	= PfbConfig::read('enable_dedup');	// Enable/Disable 'dRep' Reputation
+	$pfb['rep']	= PfbConfig::read('rep/enable_rep');	// Enable/Disable 'Max' Reputation
+	$pfb['prep']	= PfbConfig::read('rep/enable_pdup');	// Enable/Disable 'pRep' Reputation
+	$pfb['drep']	= PfbConfig::read('rep/enable_dedup');	// Enable/Disable 'dRep' Reputation
 
 	// Starting variable to skip Reputation functions, if no changes are required
 	$pfb['repcheck'] = FALSE;
@@ -2432,7 +2432,7 @@ function sync_package_pfblockerng($cron='') {
 	// are NOT required — only the DNSBL toggle + resolver state.
 	{
 		$redir_changed = FALSE;
-		$redir_toggle  = PfbConfig::read('dnsbl_redir');
+		$redir_toggle  = PfbConfig::read('dnsbl/dnsbl_redir');
 		$redir_enabled = ($mode === 'enabled') && ($redir_toggle instanceof PfbToggle && $redir_toggle === PfbToggle::On);
 
 		if (!$redir_enabled) {
@@ -2442,8 +2442,8 @@ function sync_package_pfblockerng($cron='') {
 			}
 		} else {
 			// ENABLED: read interfaces (comma-separated) and exception alias.
-			$redir_iface_raw = (string) PfbConfig::read('dnsbl_redir_int');
-			$redir_exception = trim((string) PfbConfig::read('dnsbl_redir_exclude'));
+			$redir_iface_raw = (string) PfbConfig::read('dnsbl/dnsbl_redir_int');
+			$redir_exception = trim((string) PfbConfig::read('dnsbl/dnsbl_redir_exclude'));
 
 			$redir_ifaces_raw = array_filter(array_map('trim', explode(',', $redir_iface_raw)), 'strlen');
 			$redir_ifaces     = [];
@@ -2542,7 +2542,7 @@ function sync_package_pfblockerng($cron='') {
 	// are NOT required — only the DNSBL toggle + resolver state.
 	{
 		$dot_changed = FALSE;
-		$dot_toggle  = PfbConfig::read('dnsbl_dot_block');
+		$dot_toggle  = PfbConfig::read('dnsbl/dnsbl_dot_block');
 		$dot_enabled = ($mode === 'enabled') && ($dot_toggle instanceof PfbToggle && $dot_toggle === PfbToggle::On);
 
 		if (!$dot_enabled) {
@@ -2552,10 +2552,10 @@ function sync_package_pfblockerng($cron='') {
 			}
 		} else {
 			// ENABLED: read interfaces (comma-separated), exception alias, rule action, floating mode.
-			$dot_iface_raw    = (string) PfbConfig::read('dnsbl_dot_block_int');
-			$dot_exclude_alias = trim((string) PfbConfig::read('dnsbl_dot_block_exclude'));
-			$dot_action       = pfb_dot_block_action((string) PfbConfig::read('dnsbl_dot_block_action'));
-			$dot_floating_cfg = PfbConfig::read('dnsbl_dot_block_floating');
+			$dot_iface_raw    = (string) PfbConfig::read('dnsbl/dnsbl_dot_block_int');
+			$dot_exclude_alias = trim((string) PfbConfig::read('dnsbl/dnsbl_dot_block_exclude'));
+			$dot_action       = pfb_dot_block_action((string) PfbConfig::read('dnsbl/dnsbl_dot_block_action'));
+			$dot_floating_cfg = PfbConfig::read('dnsbl/dnsbl_dot_block_floating');
 			$dot_floating     = ($dot_floating_cfg instanceof PfbToggle && $dot_floating_cfg === PfbToggle::On);
 
 			$dot_ifaces_raw = array_filter(array_map('trim', explode(',', $dot_iface_raw)), 'strlen');
@@ -4209,8 +4209,8 @@ function sync_package_pfblockerng($cron='') {
 				pfb_logger(localize_text("Alias table changes detected, updating:") . "\n", 1);
 
 				// ADR-40: read mode/batch once for the loop (PfbConfig gateway).
-				$pfb_delta_mode  = (string) PfbConfig::read('pfb_alias_delta_mode')->toStored();
-				$pfb_delta_batch = pfb_alias_delta_batch_clamp((string) PfbConfig::read('pfb_alias_delta_batch'));
+				$pfb_delta_mode  = (string) PfbConfig::read('gen/pfb_alias_delta_mode')->toStored();
+				$pfb_delta_batch = pfb_alias_delta_batch_clamp((string) PfbConfig::read('gen/pfb_alias_delta_batch'));
 
 				foreach ($final_alias as $final) {
 					if (file_exists("{$pfb['aliasdir']}/{$final}.txt")) {
@@ -4276,7 +4276,7 @@ function sync_package_pfblockerng($cron='') {
 		config_read_file(FALSE, TRUE);
 		// issue #1895: this update-apply pass runs with no web session in scope, so the
 		// registered-field write asserts as a system caller, not a page privilege.
-		PfbConfig::writeSystem('pfb_reuse', PfbToggle::Off);
+		PfbConfig::writeSystem('gen/pfb_reuse', PfbToggle::Off);
 		write_config('pfBlockerNG: save settings');
 
 		pfb_logger("... completed", 1);
@@ -4382,7 +4382,7 @@ function sync_package_pfblockerng($cron='') {
 	// A single */pfb_tick_interval cron entry fires; the tick reads the due-ledger
 	// and dispatches each job only when its entry says "due". clearip/cleardnsbl
 	// are out of scope (ADR-30 territory) and remain as separate jobs below.
-	pfblockerng_configure_tick_cron($pfb['enable'] === PfbToggle::On, pfb_tick_interval_clamp(PfbConfig::read('pfb_tick_interval')), $pfb['log']);
+	pfblockerng_configure_tick_cron($pfb['enable'] === PfbToggle::On, pfb_tick_interval_clamp(PfbConfig::read('gen/pfb_tick_interval')), $pfb['log']);
 
 	// Define pfBlockerNG clear [ dnsbl and/or IP ] counter CRON job
 	foreach (array( 'clearip', 'cleardnsbl') as $type) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -358,7 +358,7 @@ function pfb_cfg_alias_delta_mode_write(PfbAliasDeltaMode|string $mode): string
  */
 function pfb_editor_enabled(): bool
 {
-	return PfbConfig::read('pfb_syntax_highlight') === PfbToggle::On;
+	return PfbConfig::read('gen/pfb_syntax_highlight') === PfbToggle::On;
 }
 
 /** Read a PfbToggle from a raw stored value. */
@@ -418,12 +418,23 @@ function pfb_cfg_top1m_source_write(PfbTop1mSource|string $source): string
 // Tests: tests/php/CfgGatewayTest.php (round-trip, default, inventory).
 // ---------------------------------------------------------------------------
 
+// issue #1931: the one greppable home of every real config.xml section path. Registry
+// keys below are '<alias>/<bare-key>'; PfbConfig resolves the alias through this map.
+const PFB_SECTIONS = [
+	'gen'   => 'installedpackages/pfblockerng/config/0',
+	'dnsbl' => 'installedpackages/pfblockerngdnsblsettings/config/0',
+	'ss'    => 'installedpackages/pfblockerngsafesearch',
+	'ip'    => 'installedpackages/pfblockerngipsettings/config/0',
+	'rep'   => 'installedpackages/pfblockerngreputation/config/0',
+];
+
 /**
  * pfb_cfg_registry — the declarative field registry for all registered
  * installedpackages/pfblockerng* scalar keys.
  *
- * Returns a flat map of config-key => descriptor. Keys are the exact strings
- * used in config.xml, grouped loosely by config section.
+ * Returns a flat map of path-key => descriptor. A path key is '<alias>/<bare-key>',
+ * where <alias> indexes PFB_SECTIONS for the real config.xml section path and
+ * <bare-key> is the exact field name used in config.xml.
  *
  * Read adapter: callable(mixed $stored): <enum|string>  — stored string -> runtime value.
  * Write adapter: callable(<enum|string> $value): string — runtime value -> stored string.
@@ -431,9 +442,9 @@ function pfb_cfg_top1m_source_write(PfbTop1mSource|string $source): string
  *
  * Optional 'write_priv': overrides PfbConfig::WRITE_PRIV_DEFAULT for this field's
  * write-authorization check (issue #1895). Absent for every entry except
- * 'pfb_software_check' (the #485 Software-page secondary gate).
+ * 'gen/pfb_software_check' (the #485 Software-page secondary gate).
  *
- * @return array<string,array{section:string,default:string,read_adapter:callable|null,write_adapter:callable|null,write_priv?:string}>
+ * @return array<string,array{default:string,read_adapter:callable|null,write_adapter:callable|null,write_priv?:string}>
  */
 function pfb_cfg_registry(): array
 {
@@ -442,31 +453,6 @@ function pfb_cfg_registry(): array
 		return $registry;
 	}
 
-	// -----------------------------------------------------------------------
-	// Section: installedpackages/pfblockerng/config/0  (general settings)
-	// -----------------------------------------------------------------------
-	$gen = 'installedpackages/pfblockerng/config/0';
-
-	// -----------------------------------------------------------------------
-	// Section: installedpackages/pfblockerngdnsblsettings/config/0
-	// -----------------------------------------------------------------------
-	$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
-
-	// -----------------------------------------------------------------------
-	// Section: installedpackages/pfblockerngsafesearch  (flat, no /config/0)
-	// -----------------------------------------------------------------------
-	$ss = 'installedpackages/pfblockerngsafesearch';
-
-	// -----------------------------------------------------------------------
-	// Section: installedpackages/pfblockerngipsettings/config/0
-	// -----------------------------------------------------------------------
-	$ip = 'installedpackages/pfblockerngipsettings/config/0';
-
-	// -----------------------------------------------------------------------
-	// Section: installedpackages/pfblockerngreputation/config/0
-	// -----------------------------------------------------------------------
-	$rep = 'installedpackages/pfblockerngreputation/config/0';
-
 	$registry = [
 
 		// -------------------------------------------------------------------
@@ -474,16 +460,14 @@ function pfb_cfg_registry(): array
 		// -------------------------------------------------------------------
 
 		// Settings snapshot schema marker. Missing installs are the legacy 3.2 family.
-		'settings_family' => [
-			'section'       => $gen,
+		'gen/settings_family' => [
 			'default'       => '3.2',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Master enable/disable: 'on' | '' (checkbox).
-		'enable_cb' => [
-			'section'       => $gen,
+		'gen/enable_cb' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -496,124 +480,106 @@ function pfb_cfg_registry(): array
 		// (key absent) which the registry default returns as 'on'. The empty-string
 		// '' is a LEGACY READ token for installs written before this fix; it maps
 		// to Off on read, same as 'off'. Write always emits canonical 'off'.
-		'pfb_keep' => [
-			'section'       => $gen,
+		'gen/pfb_keep' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// Update interval: numeric hour string | 'Disabled'. Default '1'.
-		'pfb_interval' => [
-			'section'       => $gen,
+		'gen/pfb_interval' => [
 			'default'       => '1',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Cron start minute ('0'|'15'|'30'|'45'). Default '0'.
-		'pfb_min' => [
-			'section'       => $gen,
+		'gen/pfb_min' => [
 			'default'       => '0',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Cron start hour (0-23 as string). Default '0'.
-		'pfb_hour' => [
-			'section'       => $gen,
+		'gen/pfb_hour' => [
 			'default'       => '0',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Once-a-day start hour (0-23 as string). Default '0'.
-		'pfb_dailystart' => [
-			'section'       => $gen,
+		'gen/pfb_dailystart' => [
 			'default'       => '0',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Max daily download failure threshold ('0' = unlimited). Default '0'.
-		'skipfeed' => [
-			'section'       => $gen,
+		'gen/skipfeed' => [
 			'default'       => '0',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// ADR-11: CSV of active aggregate alias types (e.g. 'Deny,Permit'). Default ''.
-		'pfb_agg_types' => [
-			'section'       => $gen,
+		'gen/pfb_agg_types' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Log rotation limits (all numeric strings; default '20000').
-		'log_max_log' => [
-			'section'       => $gen,
+		'gen/log_max_log' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_errlog' => [
-			'section'       => $gen,
+		'gen/log_max_errlog' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_extraslog' => [
-			'section'       => $gen,
+		'gen/log_max_extraslog' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_ip_blocklog' => [
-			'section'       => $gen,
+		'gen/log_max_ip_blocklog' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_ip_permitlog' => [
-			'section'       => $gen,
+		'gen/log_max_ip_permitlog' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_ip_matchlog' => [
-			'section'       => $gen,
+		'gen/log_max_ip_matchlog' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_ip_parse_err' => [
-			'section'       => $gen,
+		'gen/log_max_ip_parse_err' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_dnslog' => [
-			'section'       => $gen,
+		'gen/log_max_dnslog' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_dnsbl_parse_err' => [
-			'section'       => $gen,
+		'gen/log_max_dnsbl_parse_err' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_dnsreplylog' => [
-			'section'       => $gen,
+		'gen/log_max_dnsreplylog' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
-		'log_max_unilog' => [
-			'section'       => $gen,
+		'gen/log_max_unilog' => [
 			'default'       => '20000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -628,8 +594,7 @@ function pfb_cfg_registry(): array
 	// ADR-60: per-log age-based retention cap (days; '0' = off), independent of
 	// log_max_<type>'s line-count cap and its 'nolimit' opt-out (S2.2/S2.3 item 3).
 	foreach ($log_types as $log_type) {
-		$registry['log_max_days_' . $log_type] = [
-			'section'       => $gen,
+		$registry['gen/log_max_days_' . $log_type] = [
 			'default'       => '0',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -640,8 +605,7 @@ function pfb_cfg_registry(): array
 
 		// issue #1109: log-retention trim hysteresis margin percent (global,
 		// applies uniformly to both the line-count and age caps). Default '0'.
-		'pfb_log_trim_margin_pct' => [
-			'section'       => $gen,
+		'gen/pfb_log_trim_margin_pct' => [
 			'default'       => '0',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -651,8 +615,7 @@ function pfb_cfg_registry(): array
 		// issue #1887: toggle adapter adopted, and the effective ON default moves from
 		// the hand-written reader (`!== 'off'`) into the registry where every other
 		// toggle keeps its default. Absent behaves exactly as before (enabled).
-		'pfb_software_check' => [
-			'section'       => $gen,
+		'gen/pfb_software_check' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -664,16 +627,14 @@ function pfb_cfg_registry(): array
 		// Internal-address feed-host filter toggle: 'on'|'off'. Default 'on' (new install).
 		// issue #1887: toggle adapter adopted; the #1770 install seed still pins 'off'
 		// once on an already-configured box (see pfb_feed_filter_install_default()).
-		'pfb_feed_internal_filter' => [
-			'section'       => $gen,
+		'gen/pfb_feed_internal_filter' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// Allowlist for internal-feed hosts (base64-encoded). Default ''.
-		'pfb_feed_internal_allowlist' => [
-			'section'       => $gen,
+		'gen/pfb_feed_internal_allowlist' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -681,16 +642,14 @@ function pfb_cfg_registry(): array
 
 		// ADR-49: opt-in plain-text feed sanity scan. Checkbox 'on'|''(off).
 		// Default off (absent = off = today's behaviour: the scan never runs).
-		'pfb_feed_sanity' => [
-			'section'       => $gen,
+		'gen/pfb_feed_sanity' => [
 			'default'       => '',                       // absent -> Off (new-install default too)
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// Reuse blocklists across updates: 'on' | '' (checkbox). Default ''.
-		'pfb_reuse' => [
-			'section'       => $gen,
+		'gen/pfb_reuse' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -702,8 +661,7 @@ function pfb_cfg_registry(): array
 		// 'replace' = always full -T replace (pre-ADR-40 behaviour).
 		// Existing installs are grandfather-seeded to 'replace' at install/upgrade
 		// (pfb_alias_delta_mode_install_default); only brand-new installs take the 'auto' default.
-		'pfb_alias_delta_mode' => [
-			'section'       => $gen,
+		'gen/pfb_alias_delta_mode' => [
 			'default'       => 'auto',
 			'read_adapter'  => 'pfb_cfg_alias_delta_mode_read',
 			'write_adapter' => 'pfb_cfg_alias_delta_mode_write',
@@ -712,8 +670,7 @@ function pfb_cfg_registry(): array
 		// ADR-40: alias-table delta batch size (integer as string). Default '512'.
 		// Clamped to [64, 4096] on read. Batch=512 is optimal for sub-1M tables
 		// (zero ICMP stalls at 100k/1k-churn); batch=1024+ for 1M+ tables.
-		'pfb_alias_delta_batch' => [
-			'section'       => $gen,
+		'gen/pfb_alias_delta_batch' => [
 			'default'       => '512',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -722,8 +679,7 @@ function pfb_cfg_registry(): array
 		// ADR-43: tick-cron dispatch interval in minutes (1–60). Default '15'.
 		// One cron tick fires every */pfb_tick_interval; jobs run only when due
 		// per the due-ledger. Default 15 matches the tightest existing job (ss_refresh).
-		'pfb_tick_interval' => [
-			'section'       => $gen,
+		'gen/pfb_tick_interval' => [
 			'default'       => '15',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -733,8 +689,7 @@ function pfb_cfg_registry(): array
 		// When set: detected changes outside the window are deferred (pending); the first tick
 		// inside the window applies them. Empty string (default) = apply immediately (no deferral).
 		// Wrapping windows (e.g. "23:00-03:00") span midnight. Malformed = fail-safe (apply now).
-		'pfb_quiet_hours' => [
-			'section'       => $gen,
+		'gen/pfb_quiet_hours' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -750,8 +705,7 @@ function pfb_cfg_registry(): array
 		// default is 'on' (absent collapses back to the default, silently re-enabling a
 		// deliberate off; the #484 pfb_keep bug class, enforced by
 		// CfgGatewayTest::testNoToggleFieldDefaultsToOn). Mirrors pfb_keep exactly.
-		'pfb_syntax_highlight' => [
-			'section'       => $gen,
+		'gen/pfb_syntax_highlight' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -762,16 +716,14 @@ function pfb_cfg_registry(): array
 		// -------------------------------------------------------------------
 
 		// DNSBL master enable: 'on' | '' (checkbox).
-		'pfb_dnsbl' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_dnsbl' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// ADR-13: auto-create/remove DNSBL sinkhole VIPs: 'on' | '' (checkbox).
-		'pfb_dnsvip_auto' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_dnsvip_auto' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -779,56 +731,49 @@ function pfb_cfg_registry(): array
 
 		// [ #381 ] Opt out of automatic DNSBL sinkhole NAT rule generation: 'on' | '' (checkbox).
 		// Default '' = NAT generated (current behaviour); 'on' = user manages NAT manually.
-		'pfb_dnsbl_nonat' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_dnsbl_nonat' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// VIP interface for DNSBL sinkhole. Default 'lo0'.
-		'dnsbl_interface' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_interface' => [
 			'default'       => 'lo0',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DNSBL IPv4 sinkhole VIP id string. Default ''.
-		'pfb_dnsvip4' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_dnsvip4' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DNSBL IPv6 sinkhole VIP id string. Default ''.
-		'pfb_dnsvip6' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_dnsvip6' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DNSBL lighttpd HTTP port. Default '' (system default).
-		'pfb_dnsport' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_dnsport' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DNSBL lighttpd HTTPS port. Default ''.
-		'pfb_dnsport_ssl' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_dnsport_ssl' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// TOP1M whitelist enable. Default ''.
-		'top1m_enable' => [
-			'section'       => $dnsbl,
+		'dnsbl/top1m_enable' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -838,24 +783,21 @@ function pfb_cfg_registry(): array
 		// Legacy 'alexa' (dead service, #872) coalesces to 'tranco', and legacy 'domcop'
 		// (list moved hosting, #928) coalesces to 'openpagerank', at the read boundary
 		// via pfb_cfg_top1m_source_read(). Default 'tranco'.
-		'top1m_source' => [
-			'section'       => $dnsbl,
+		'dnsbl/top1m_source' => [
 			'default'       => 'tranco',
 			'read_adapter'  => 'pfb_cfg_top1m_source_read',
 			'write_adapter' => 'pfb_cfg_top1m_source_write',
 		],
 
 		// TOP1M domain count (numeric string). Default '1000'.
-		'top1m_count' => [
-			'section'       => $dnsbl,
+		'dnsbl/top1m_count' => [
 			'default'       => '1000',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// TOP1M TLD inclusions for whitelisting. Default ''.
-		'top1m_inclusion' => [
-			'section'       => $dnsbl,
+		'dnsbl/top1m_inclusion' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -868,32 +810,28 @@ function pfb_cfg_registry(): array
 		// on GET, and a blank POST preserves the existing value rather than clearing it
 		// (pfblockerng_dnsbl.php's save handler) -- see PFB_FILTER_TOKEN (pfblockerng.inc)
 		// for the accepted charset. Default ''.
-		'top1m_token' => [
-			'section'       => $dnsbl,
+		'dnsbl/top1m_token' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Resolver cache backup/restore option. Default ''.
-		'pfb_cache' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_cache' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Full resolver-cache flush after a successful DNSBL data swap. Default off.
-		'pfb_cache_flush' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_cache_flush' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// Global logging/blocking mode. Default ''.
-		'global_log' => [
-			'section'       => $dnsbl,
+		'dnsbl/global_log' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -901,24 +839,21 @@ function pfb_cfg_registry(): array
 
 		// ADR-22: scheme-parsing leniency: 'on' | 'off' | ''. Default 'off'.
 		// Toggle adapter: Off stores the explicit 'off' token.
-		'pfb_dnsbl_lenient' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_dnsbl_lenient' => [
 			'default'       => 'off',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// Python DNS reply logging. Default ''.
-		'pfb_py_reply' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_py_reply' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// HSTS null-blocking mode: 'on' | ''. Default ''.
-		'pfb_hsts' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_hsts' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -931,8 +866,7 @@ function pfb_cfg_registry(): array
 		// round-trips with zero migration. Legacy '' and the 4.0.0-alpha 'all' token
 		// read as Off; unknown tokens also fall through to Off.
 		// See ADR-28 §2.2 + CfgAdaptersTest.
-		'pfb_idn' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_idn' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_idn_mode_read',
 			'write_adapter' => 'pfb_cfg_idn_mode_write',
@@ -941,232 +875,203 @@ function pfb_cfg_registry(): array
 		// Confusable: block malicious homoglyphs (default on). Default 'on'.
 		// issue #1887: toggle adapter — without it, read() resolving a stored '' to the
 		// default 'on' made the page's old ?: '' unchecked save impossible to turn off.
-		'pfb_idn_block_malicious' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_idn_block_malicious' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// Confusable: escalate suspicious mixed-script to block (opt-in). Default ''.
-		'pfb_idn_escalate_suspicious' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_idn_escalate_suspicious' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// Python regex: 'on' | ''. Default ''.
-		'pfb_regex' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_regex' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Python regex list (textarea). Default ''.
-		'pfb_regex_list' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_regex_list' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Python regex static cap ('on'|''). Default ''.
-		'pfb_regex_cap' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_regex_cap' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// CNAME validation. Default ''.
-		'pfb_cname' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_cname' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// TLD Allow option. Default ''.
-		'tld_allow' => [
-			'section'       => $dnsbl,
+		'dnsbl/tld_allow' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Log events via DNSBL Webserver vs python. Default ''.
-		'pfb_py_nolog' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_py_nolog' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// No AAAA blocking: 'on' | ''. Default ''.
-		'pfb_noaaaa' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_noaaaa' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// No AAAA list (textarea). Default ''.
-		'pfb_noaaaa_list' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_noaaaa_list' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DNSBL bypass enable: 'on' | ''. Default ''.
-		'pfb_gp' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_gp' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DNSBL bypass local IP list (textarea). Default ''.
-		'pfb_gp_bypass_list' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_gp_bypass_list' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// TLD blacklist (textarea). Default ''.
-		'tld_wildcard_blacklist' => [
-			'section'       => $dnsbl,
+		'dnsbl/tld_wildcard_blacklist' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// TLD exclusion (textarea). Default ''.
-		'tld_wildcard_exclusion' => [
-			'section'       => $dnsbl,
+		'dnsbl/tld_wildcard_exclusion' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DNSBL suppression/whitelist (base64). Default ''.
-		'suppression' => [
-			'section'       => $dnsbl,
+		'dnsbl/suppression' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DNSBL action for IP blocking. Default 'Disabled'.
-		'action' => [
-			'section'       => $dnsbl,
+		'dnsbl/action' => [
 			'default'       => 'Disabled',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Auto-create floating pass rule. Default 'Disabled'.
-		'pfb_dnsbl_rule' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_dnsbl_rule' => [
 			'default'       => 'Disabled',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Allow-interface for DNSBL (multi-select). Default ''.
-		'dnsbl_allow_int' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_allow_int' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Python control integration. Default ''.
-		'pfb_control' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_control' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Legacy DNS-TXT control transport (deprecated). Default ''.
-		'pfb_control_legacy' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_control_legacy' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Python cache max (numeric string). Default '' (unlimited).
-		'pfb_py_cache_max' => [
-			'section'       => $dnsbl,
+		'dnsbl/pfb_py_cache_max' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// TLD blocking enable. Default ''.
-		'tld_wildcard' => [
-			'section'       => $dnsbl,
+		'dnsbl/tld_wildcard' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// Aliaslog (logging mode). Default ''.
-		'aliaslog' => [
-			'section'       => $dnsbl,
+		'dnsbl/aliaslog' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// ADR-36: NAT DNS-redirect enable: 'on' | '' (checkbox). Default '' (off).
-		'dnsbl_redir' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_redir' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// ADR-36: NAT DNS-redirect interface multi-select (comma-joined string). Default ''.
-		'dnsbl_redir_int' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_redir_int' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// ADR-36: NAT DNS-redirect exception alias/IP string. Default ''.
-		'dnsbl_redir_exclude' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_redir_exclude' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// ADR-37: DoT/DoQ block enable: 'on' | '' (checkbox). Default '' (off).
-		'dnsbl_dot_block' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_dot_block' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 		],
 
 		// ADR-37: DoT/DoQ block interface multi-select (comma-joined string). Default ''.
-		'dnsbl_dot_block_int' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_dot_block_int' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// ADR-37: DoT/DoQ block exception alias/IP string. Default ''.
-		'dnsbl_dot_block_exclude' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_dot_block_exclude' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -1175,8 +1080,7 @@ function pfb_cfg_registry(): array
 		// ADR-37: DoT/DoQ block rule action: 'reject' (default) | 'block'.
 		// Mirrors the IP-settings inbound/outbound Rule Action selector. Reject
 		// fast-fails the client (outbound LAN->WAN rule); block silently drops.
-		'dnsbl_dot_block_action' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_dot_block_action' => [
 			'default'       => 'reject',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -1185,8 +1089,7 @@ function pfb_cfg_registry(): array
 		// ADR-37: DoT/DoQ block floating mode: 'on' | '' (checkbox). Default '' (off).
 		// On = a single floating rule (direction 'in') over the selected interfaces
 		// instead of one rule per interface. Off preserves the per-interface default.
-		'dnsbl_dot_block_floating' => [
-			'section'       => $dnsbl,
+		'dnsbl/dnsbl_dot_block_floating' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -1203,8 +1106,7 @@ function pfb_cfg_registry(): array
 		// pfb_syslog_event() — events route to the dedicated pfblockerng_syslog.log
 		// by program name, so facility never affects routing, and every event is
 		// the same class of informational record, so a severity picker is moot.
-		'log_syslog' => [
-			'section'       => $gen,
+		'gen/log_syslog' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -1215,32 +1117,28 @@ function pfb_cfg_registry(): array
 		// -------------------------------------------------------------------
 
 		// SafeSearch enable mode. Default 'Disable'.
-		'safesearch_enable' => [
-			'section'       => $ss,
+		'ss/safesearch_enable' => [
 			'default'       => 'Disable',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// YouTube SafeSearch mode. Default 'Disable'.
-		'safesearch_youtube' => [
-			'section'       => $ss,
+		'ss/safesearch_youtube' => [
 			'default'       => 'Disable',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DNS-over-HTTPS blocking mode. Default 'Disable'.
-		'safesearch_doh' => [
-			'section'       => $ss,
+		'ss/safesearch_doh' => [
 			'default'       => 'Disable',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
 		],
 
 		// DoH domain exclusion list (CSV). Default ''.
-		'safesearch_doh_list' => [
-			'section'       => $ss,
+		'ss/safesearch_doh_list' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -1256,8 +1154,7 @@ function pfb_cfg_registry(): array
 		// every call site routes through the gateway; this is a legacy key
 		// from the original addon (mirrors the '1.0.0' vintage of the sibling
 		// DNSBL blob fields). Default ''.
-		'v4suppression' => [
-			'section'       => $ip,
+		'ip/v4suppression' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -1265,8 +1162,7 @@ function pfb_cfg_registry(): array
 
 		// ADR-53: IPv6 suppression customlist -- the v4 blob's v6 sibling
 		// (same base64/newline-separated shape). Default ''.
-		'v6suppression' => [
-			'section'       => $ip,
+		'ip/v6suppression' => [
 			'default'       => '',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
@@ -1277,8 +1173,7 @@ function pfb_cfg_registry(): array
 		// -------------------------------------------------------------------
 
 		// issue #1896: 'Max' per-list Reputation toggle: 'on' | 'off' | ''. Default '' (off).
-		'enable_rep' => [
-			'section'       => $rep,
+		'rep/enable_rep' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -1286,8 +1181,7 @@ function pfb_cfg_registry(): array
 
 		// issue #1896: 'pMax' collective Reputation toggle (no Country Exclusion):
 		// 'on' | 'off' | ''. Default '' (off).
-		'enable_pdup' => [
-			'section'       => $rep,
+		'rep/enable_pdup' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -1295,8 +1189,7 @@ function pfb_cfg_registry(): array
 
 		// issue #1896: 'dMax' collective Reputation toggle (Country Exclusion applied):
 		// 'on' | 'off' | ''. Default '' (off).
-		'enable_dedup' => [
-			'section'       => $rep,
+		'rep/enable_dedup' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
@@ -1372,14 +1265,14 @@ final class PfbConfig
 	 * Returns the registered default when the key is absent/null; applies
 	 * the registered read adapter (stored string -> runtime enum/string).
 	 *
-	 * @param  string $key  The exact config.xml field key (e.g. 'pfb_keep').
+	 * @param  string $key  The registered path-form field key (e.g. 'gen/pfb_keep').
 	 * @return mixed        Runtime value (enum or string).
 	 * @throws InvalidArgumentException When $key is not in the registry.
 	 */
 	public static function read(string $key): mixed
 	{
 		$entry   = self::entry($key);
-		$path    = $entry['section'] . '/' . $key;
+		$path    = self::sectionPath($key);
 		$raw     = config_get_path($path, NULL);
 		$stored  = (string) self::notConfigured($entry, $raw);
 		$adapter = $entry['read_adapter'];
@@ -1404,7 +1297,7 @@ final class PfbConfig
 	 * read-modify-write case (e.g. the General settings page); write() has no such case
 	 * to carve out.
 	 *
-	 * @param  string $key   The exact config.xml field key.
+	 * @param  string $key   The registered path-form field key.
 	 * @param  mixed  $value Runtime value (enum or string).
 	 * @throws InvalidArgumentException When $key is not in the registry.
 	 * @throws RuntimeException         When the caller lacks the field's write_priv.
@@ -1425,7 +1318,7 @@ final class PfbConfig
 	 * on them; this is the explicit escape hatch for that legitimate case. Never
 	 * callable from src/usr/local/www/ (enforced by RequireConfigGatewaySniff).
 	 *
-	 * @param  string $key   The exact config.xml field key.
+	 * @param  string $key   The registered path-form field key.
 	 * @param  mixed  $value Runtime value (enum or string).
 	 * @throws InvalidArgumentException When $key is not in the registry.
 	 */
@@ -1437,13 +1330,13 @@ final class PfbConfig
 	/**
 	 * Delete a single registered field.
 	 *
-	 * @param  string $key  The exact config.xml field key.
+	 * @param  string $key  The registered path-form field key.
 	 * @throws InvalidArgumentException When $key is not in the registry.
 	 */
 	public static function delete(string $key): void
 	{
-		$entry = self::entry($key);
-		$path  = $entry['section'] . '/' . $key;
+		self::entry($key);
+		$path = self::sectionPath($key);
 		config_del_path($path);
 	}
 
@@ -1507,11 +1400,12 @@ final class PfbConfig
 		// field failing its check must never leave an earlier field's config_set_path
 		// already applied. Registered fields only -- a key registered to a DIFFERENT
 		// section, or not registered at all, is foreign data and carries no gate here.
-		foreach (pfb_cfg_registry() as $key => $entry) {
-			if ($entry['section'] !== $section || !array_key_exists($key, $data)) {
+		foreach (pfb_cfg_registry() as $reg_key => $entry) {
+			[$alias, $bare] = explode('/', $reg_key, 2);
+			if ((PFB_SECTIONS[$alias] ?? NULL) !== $section || !array_key_exists($bare, $data)) {
 				continue;
 			}
-			self::assertWriteAllowedOnChange($key, $entry, $section, $data[$key]);
+			self::assertWriteAllowedOnChange($bare, $entry, $section, $data[$bare]);
 		}
 		self::writeSectionRaw($section, $data);
 	}
@@ -1544,17 +1438,35 @@ final class PfbConfig
 	// -----------------------------------------------------------------------
 
 	/**
+	 * Resolve a path-form registry key ('<alias>/<bare-key>') to the real
+	 * config.xml field path via PFB_SECTIONS (issue #1931). Defensive only --
+	 * unreachable for a registered key (CfgGatewayTest's alias-prefix gate).
+	 *
+	 * @param  string $key  A registered path-form key (e.g. 'gen/pfb_keep').
+	 * @return string       The real config.xml field path.
+	 * @throws InvalidArgumentException When $key is malformed or its alias is unknown.
+	 */
+	private static function sectionPath(string $key): string
+	{
+		$slash = strpos($key, '/');
+		if ($slash === FALSE || !array_key_exists(substr($key, 0, $slash), PFB_SECTIONS)) {
+			throw new InvalidArgumentException("PfbConfig: malformed registry key '{$key}'.");
+		}
+		return PFB_SECTIONS[substr($key, 0, $slash)] . substr($key, $slash);
+	}
+
+	/**
 	 * write() body proper, with NO privilege check — shared by write() and
 	 * writeSystem() (issue #1895).
 	 *
-	 * @param  string $key   The exact config.xml field key.
+	 * @param  string $key   The registered path-form field key.
 	 * @param  mixed  $value Runtime value (enum or string).
 	 * @throws InvalidArgumentException When $key is not in the registry.
 	 */
 	private static function writeRaw(string $key, mixed $value): void
 	{
 		$entry   = self::entry($key);
-		$path    = $entry['section'] . '/' . $key;
+		$path    = self::sectionPath($key);
 		$adapter = $entry['write_adapter'];
 		$value   = self::notConfigured($entry, $value);
 		$stored  = ($adapter !== NULL) ? $adapter($value) : (string) $value;
@@ -1570,8 +1482,9 @@ final class PfbConfig
 	 */
 	private static function writeSectionRaw(string $section, array $data): void
 	{
-		foreach (pfb_cfg_registry() as $key => $entry) {
-			if ($entry['section'] !== $section) {
+		foreach (pfb_cfg_registry() as $reg_key => $entry) {
+			[$alias, $bare] = explode('/', $reg_key, 2);
+			if ((PFB_SECTIONS[$alias] ?? NULL) !== $section) {
 				continue;
 			}
 			$read_adapter  = $entry['read_adapter'];
@@ -1579,10 +1492,10 @@ final class PfbConfig
 			if ($read_adapter === NULL || $write_adapter === NULL) {
 				continue;
 			}
-			if (!array_key_exists($key, $data)) {
+			if (!array_key_exists($bare, $data)) {
 				continue;
 			}
-			$data[$key] = $write_adapter($read_adapter(self::notConfigured($entry, $data[$key])));
+			$data[$bare] = $write_adapter($read_adapter(self::notConfigured($entry, $data[$bare])));
 		}
 		config_set_path($section, $data);
 	}
@@ -1606,7 +1519,8 @@ final class PfbConfig
 	 * trap issue #1895 documents. A legitimate system-context caller must say so
 	 * explicitly, via PfbConfig::writeSystem()/writeSectionSystem().
 	 *
-	 * @param  string $key    The exact config.xml field key (named in the exception).
+	 * @param  string $key    The field key, named in the exception exactly as the caller
+	 *                        passed it (path-form from write(); bare from writeSection()).
 	 * @param  array  $entry  The registry entry (consulted for its optional 'write_priv').
 	 * @throws RuntimeException When the caller lacks the field's required page privilege.
 	 */
@@ -1655,7 +1569,8 @@ final class PfbConfig
 	 * always an authorization event, changed or not, because there is no read-modify-
 	 * write section saver behind it carrying an unrelated field's value along.
 	 *
-	 * @param  string $key     The exact config.xml field key (named in the exception).
+	 * @param  string $key     The bare field key (named in the exception; $section . '/' .
+	 *                         $key must be the real config.xml field path).
 	 * @param  array  $entry   The registry entry (consulted for its optional 'write_priv').
 	 * @param  string $section The full config.xml section path $key lives under.
 	 * @param  mixed  $incoming The incoming (pre-normalisation) value for $key in the section blob.
@@ -1730,7 +1645,7 @@ final class PfbConfig
 	 * An enum cannot do this itself — fromStored() has no access to the per-field
 	 * default, which is precisely why the resolution belongs to the gateway.
 	 *
-	 * @param  array{section:string,default:string,read_adapter:callable|null,write_adapter:callable|null} $entry
+	 * @param  array{default:string,read_adapter:callable|null,write_adapter:callable|null} $entry
 	 * @param  mixed $value  Raw stored value, or the runtime value on the write paths.
 	 * @return mixed         $entry['default'] when $value is NULL or '', else $value verbatim.
 	 */
@@ -1740,10 +1655,10 @@ final class PfbConfig
 	}
 
 	/**
-	 * Look up a registry entry, throwing on an unregistered key.
+	 * Look up a registry entry by its path-form key, throwing on an unregistered key.
 	 *
-	 * @param  string $key
-	 * @return array{section:string,default:string,read_adapter:callable|null,write_adapter:callable|null,write_priv?:string}
+	 * @param  string $key  A path-form key (e.g. 'gen/pfb_keep').
+	 * @return array{default:string,read_adapter:callable|null,write_adapter:callable|null,write_priv?:string}
 	 * @throws InvalidArgumentException
 	 */
 	private static function entry(string $key): array
@@ -1775,7 +1690,7 @@ function pfb_settings_family_from_version(string $version): ?string
 
 function pfb_settings_family_current(): ?string
 {
-	$value = PfbConfig::read('settings_family');
+	$value = PfbConfig::read('gen/settings_family');
 	return is_string($value) && isset(PFB_SETTINGS_FAMILY_RANK[$value]) ? $value : NULL;
 }
 
@@ -1983,7 +1898,7 @@ function pfb_settings_family_record(string $family): bool
 	try {
 		// issue #1895: called from install/migration/upgrade paths with no web session --
 		// a plain write() would silently fail-closed here and this catch would swallow it.
-		PfbConfig::writeSystem('settings_family', $family);
+		PfbConfig::writeSystem('gen/settings_family', $family);
 		write_config('pfBlockerNG: record settings family');
 		return TRUE;
 	} catch (Throwable) {
@@ -3088,7 +3003,7 @@ function pfb_syslog_event(string $body): void
 	unset($GLOBALS['pfb_test_syslog_reset']);
 
 	// Fresh gate: read the current toggle on every call.
-	if (PfbConfig::read('log_syslog') !== PfbToggle::On) {
+	if (PfbConfig::read('gen/log_syslog') !== PfbToggle::On) {
 		return;
 	}
 
@@ -3399,7 +3314,7 @@ function pfb_due_ledger_mark_ran_anchored(
 /**
  * pfb_tick_interval_clamp — clamp a raw pfb_tick_interval config value to a valid cron minute.
  *
- * Accepts the raw string from PfbConfig::read('pfb_tick_interval') and returns an int
+ * Accepts the raw string from PfbConfig::read('gen/pfb_tick_interval') and returns an int
  * suitable for use as the cron minute field (1–60). Non-numeric or out-of-range values
  * are clamped: 0 → 1, >60 → 60, non-int (e.g. 'abc') → 1.
  *
@@ -3590,7 +3505,7 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir): bool
  * inside the window applies it. Default '' = apply immediately on every due tick.
  *
  * Cadence seeding from legacy knobs (§2.G — no config.xml migration):
- *   feed cron : PfbConfig::read('pfb_interval') hours; skip scheduled runs when 'Disabled'.
+ *   feed cron : PfbConfig::read('gen/pfb_interval') hours; skip scheduled runs when 'Disabled'.
  *   dcc       : 86400 s daily, jitter = seeded_jitter (stable per install).
  *   bl        : 86400 or 604800 s, jitter = seeded_jitter (stable per install).
  *
@@ -3616,7 +3531,7 @@ function pfblockerng_tick(): void
 	$dispatched = FALSE;
 
 	// --- Cadence from legacy knobs ---
-	$raw_interval  = PfbConfig::read('pfb_interval');
+	$raw_interval  = PfbConfig::read('gen/pfb_interval');
 	$cron_disabled = ($raw_interval === 'Disabled');
 	$cron_secs     = $cron_disabled ? 0 : (max(1, (int)$raw_interval) * 3600);
 
@@ -3630,7 +3545,7 @@ function pfblockerng_tick(): void
 
 	// --- Apply-on-change window (ADR-43) ---
 	// Empty window = apply immediately (default). Non-empty = defer outside window.
-	$window = (string) PfbConfig::read('pfb_quiet_hours');
+	$window = (string) PfbConfig::read('gen/pfb_quiet_hours');
 	$in_win = pfb_quiet_hours_in_window($now, $window);
 
 	// --- Dispatch due (or pending) jobs; defer when outside the apply window ---
@@ -5020,7 +4935,8 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 		}
 
 		$supp_key       = $is_v6 ? 'ipsuppression_v6' : 'ipsuppression';
-		$cfg_key        = $is_v6 ? 'v6suppression' : 'v4suppression';
+		$cfg_key        = $is_v6 ? 'v6suppression' : 'v4suppression';	// bare -- blob index
+		$cfg_key_path   = $is_v6 ? 'ip/v6suppression' : 'ip/v4suppression';	// issue #1931: gateway key
 		$host_line      = $is_v6 ? "{$ip}/128" : "{$ip}/32";
 		$supp_data      = isset($clists[$supp_key]['data']) && is_array($clists[$supp_key]['data'])
 			? $clists[$supp_key]['data'] : [];
@@ -5042,7 +4958,7 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 			}
 			$data .= "{$supp_dat}\r\n";
 			$clists[$supp_key]['base64'] = pfb_text_area_encode($data);
-			PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
+			PfbConfig::write($cfg_key_path, $clists[$supp_key]['base64']);
 			write_config("pfBlockerNG: Added {$ip} to the IPv{$family} Suppression customlist", FALSE);
 			$refresh_suppfile = TRUE;
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1168,6 +1168,15 @@ function pfb_cfg_registry(): array
 			'write_adapter' => NULL,
 		],
 
+		// issue #1931: IP page "Enable Suppression" toggle -- path-addressed, no longer
+		// collides with dnsbl/suppression. Page renders 'on' while absent (#1907-class
+		// divergence); 'on'-default + grandfather decision deferred to #1921.
+		'ip/suppression' => [
+			'default'       => '',
+			'read_adapter'  => NULL,
+			'write_adapter' => NULL,
+		],
+
 		// -------------------------------------------------------------------
 		// Reputation section (pfblockerngreputation/config/0)
 		// -------------------------------------------------------------------

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -670,7 +670,7 @@ $pfb_gcfg = pfb_gconfig_operator_view($pfb_gcfg);
 $pfb_gcfg = empty($pfb_gcfg) ? NULL : $pfb_gcfg;
 $pfb_feed_default = pfb_feed_filter_install_default($pfb_gcfg);
 if ($pfb_feed_default !== null) {
-	PfbConfig::writeSystem('pfb_feed_internal_filter', $pfb_feed_default);
+	PfbConfig::writeSystem('gen/pfb_feed_internal_filter', $pfb_feed_default);
 }
 
 // ADR-40: grandfather an already-configured install to 'replace' (pre-ADR-40 full -T replace) so
@@ -678,7 +678,7 @@ if ($pfb_feed_default !== null) {
 // default. Run-once via the !isset guard in pfb_alias_delta_mode_install_default().
 $pfb_delta_default = pfb_alias_delta_mode_install_default($pfb_gcfg);
 if ($pfb_delta_default !== null) {
-	PfbConfig::writeSystem('pfb_alias_delta_mode', $pfb_delta_default);
+	PfbConfig::writeSystem('gen/pfb_alias_delta_mode', $pfb_delta_default);
 }
 
 // Convert dnsbl_info CSV file to SQLite3 database format
@@ -839,10 +839,10 @@ if ($ufound) {
 update_status(" Migrating legacy Yandex DoH token...");
 $ufound = FALSE;
 
-$doh_list_migrated = pfb_ss_doh_list_yandex_migrate(PfbConfig::read('safesearch_doh_list'));
+$doh_list_migrated = pfb_ss_doh_list_yandex_migrate(PfbConfig::read('ss/safesearch_doh_list'));
 if ($doh_list_migrated !== NULL) {
 	$ufound = TRUE;
-	PfbConfig::writeSystem('safesearch_doh_list', $doh_list_migrated);
+	PfbConfig::writeSystem('ss/safesearch_doh_list', $doh_list_migrated);
 }
 
 if ($ufound) {
@@ -931,13 +931,15 @@ if ($ufound) {
 // trailing write_config() below rather than adding a flush of its own.
 update_status("Recording default settings...");
 $pfb_seed_sections = array();
-foreach (pfb_cfg_registry() as $pfb_seed_entry) {
-	$pfb_seed_sections[$pfb_seed_entry['section']] ??= PfbConfig::readSection($pfb_seed_entry['section']);
+foreach (pfb_cfg_registry() as $pfb_seed_key => $pfb_seed_entry) {
+	// issue #1931: registry keys are '<alias>/<bare-key>'; resolve the real section path.
+	$pfb_seed_section = PFB_SECTIONS[explode('/', $pfb_seed_key, 2)[0]];
+	$pfb_seed_sections[$pfb_seed_section] ??= PfbConfig::readSection($pfb_seed_section);
 }
 foreach (pfb_registered_scalars_seed($pfb_seed_sections) as $pfb_seed_path => $pfb_seed_blob) {
 	PfbConfig::writeSectionSystem($pfb_seed_path, $pfb_seed_blob);
 }
-unset($pfb_seed_sections, $pfb_seed_entry, $pfb_seed_path, $pfb_seed_blob);
+unset($pfb_seed_sections, $pfb_seed_key, $pfb_seed_entry, $pfb_seed_section, $pfb_seed_path, $pfb_seed_blob);
 update_status(" done.\n");
 
 unset($g['pfblockerng_install']);	// Remove 'Install flag'

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -178,7 +178,7 @@ $pfb['extras'][2]['provider']	= $pfb['dnsbl_top1m_type']->value;
 // An empty/absent top1m_token also yields array() -- no Authorization header is sent,
 // so a missing token fails the download safely (pfblockerng_top1m()'s #886 preserve+warn
 // path keeps the previous TOP1M whitelist) rather than sending a malformed header.
-$pfb['extras'][2]['headers']	= pfb_top1m_auth_headers($pfb_top1m_provider, (string) PfbConfig::read('top1m_token'));
+$pfb['extras'][2]['headers']	= pfb_top1m_auth_headers($pfb_top1m_provider, (string) PfbConfig::read('dnsbl/top1m_token'));
 
 // IPinfo ASN databases
 $pfb['extras'][3]		= array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -223,7 +223,7 @@ if (!$alert_summary) {
 						$clists[$type][$lname]['base64_idx'] = $row;
 
 						// Collect Global DNSBL Logging type, or Group logging setting
-						$g_log = PfbConfig::read('global_log');
+						$g_log = PfbConfig::read('dnsbl/global_log');
 						if (empty($g_log)) {
 							// foreign structure: pfblockerngdnsbl/config/{row}/logging is a dynamic per-row key, not in registry
 							$d_log = config_get_path("installedpackages/pfblockerngdnsbl/config/{$row}/logging");
@@ -285,14 +285,14 @@ if (!$alert_summary) {
 		}
 	}
 
-	PfbConfig::write('v4suppression', PfbConfig::read('v4suppression') ?: '');
+	PfbConfig::write('ip/v4suppression', PfbConfig::read('ip/v4suppression') ?: '');
 
 	// ADR-53: v6 sibling -- same absent-key normalisation as v4suppression above.
-	PfbConfig::write('v6suppression', PfbConfig::read('v6suppression') ?: '');
+	PfbConfig::write('ip/v6suppression', PfbConfig::read('ip/v6suppression') ?: '');
 
-	PfbConfig::write('suppression', PfbConfig::read('suppression') ?: '');
+	PfbConfig::write('dnsbl/suppression', PfbConfig::read('dnsbl/suppression') ?: '');
 
-	PfbConfig::write('tld_wildcard_exclusion', PfbConfig::read('tld_wildcard_exclusion') ?: '');
+	PfbConfig::write('dnsbl/tld_wildcard_exclusion', PfbConfig::read('dnsbl/tld_wildcard_exclusion') ?: '');
 
 	// ADR-53: 'ipsuppression_v6' is the new v6suppression sibling of
 	// 'ipsuppression' (v4) -- same collection shape, keyed separately so the
@@ -305,13 +305,13 @@ if (!$alert_summary) {
 		}
 
 		if ($key == 0) {
-			$clists[$type]['base64'] = PfbConfig::read('v4suppression');
+			$clists[$type]['base64'] = PfbConfig::read('ip/v4suppression');
 		} elseif ($key == 1) {
-			$clists[$type]['base64'] = PfbConfig::read('v6suppression');
+			$clists[$type]['base64'] = PfbConfig::read('ip/v6suppression');
 		} elseif ($key == 2) {
-			$clists[$type]['base64'] = PfbConfig::read('suppression');
+			$clists[$type]['base64'] = PfbConfig::read('dnsbl/suppression');
 		} elseif ($key == 3) {
-			$clists[$type]['base64'] = PfbConfig::read('tld_wildcard_exclusion');
+			$clists[$type]['base64'] = PfbConfig::read('dnsbl/tld_wildcard_exclusion');
 		}
 
 		$clists[$type]['data']		= array();
@@ -862,7 +862,7 @@ if (isset($_POST) && !empty($_POST)) {
 				}
 			}
 			$clists['dnsblwhitelist']['base64'] = pfb_text_area_encode($data);
-			PfbConfig::write('suppression', $clists['dnsblwhitelist']['base64']);
+			PfbConfig::write('dnsbl/suppression', $clists['dnsblwhitelist']['base64']);
 			// issue #1872: this description is user-facing (Diagnostics > Config History),
 			// so it spells the field the way the UI does -- "Custom List", not the
 			// code-level "Custom_List".
@@ -1032,7 +1032,7 @@ if (isset($_POST) && !empty($_POST)) {
 				}
 				$data .= "{$whitelist}\r\n";
 				$clists['dnsblwhitelist']['base64'] = pfb_text_area_encode($data);
-				PfbConfig::write('suppression', $clists['dnsblwhitelist']['base64']);
+				PfbConfig::write('dnsbl/suppression', $clists['dnsblwhitelist']['base64']);
 				write_config("pfBlockerNG: Added [ {$domain} ] to DNSBL Whitelist", FALSE);
 			}
 
@@ -1132,7 +1132,7 @@ if (isset($_POST) && !empty($_POST)) {
 				}
 				$data .= "{$exclude_string}\r\n";
 				$clists['tld_wildcard_exclusion']['base64'] = pfb_text_area_encode($data);
-				PfbConfig::write('tld_wildcard_exclusion', $clists['tld_wildcard_exclusion']['base64']);
+				PfbConfig::write('dnsbl/tld_wildcard_exclusion', $clists['tld_wildcard_exclusion']['base64']);
 				write_config("pfBlockerNG: Added [ {$domain} ] to DNSBL TLD Exclusion customlist.", FALSE);
 			}
 		}
@@ -1233,7 +1233,7 @@ if (isset($_POST) && !empty($_POST)) {
 					}
 				}
 				$clists['dnsblwhitelist']['base64'] = pfb_text_area_encode($data);
-				PfbConfig::write('suppression', $clists['dnsblwhitelist']['base64']);
+				PfbConfig::write('dnsbl/suppression', $clists['dnsblwhitelist']['base64']);
 				break;
 			case 'delete_exclusion':
 				$type = 'TLD Exclusion';
@@ -1246,7 +1246,7 @@ if (isset($_POST) && !empty($_POST)) {
 					$data .= "{$line}";
 				}
 				$clists['tld_wildcard_exclusion']['base64'] = pfb_text_area_encode($data);
-				PfbConfig::write('tld_wildcard_exclusion', $clists['tld_wildcard_exclusion']['base64']);
+				PfbConfig::write('dnsbl/tld_wildcard_exclusion', $clists['tld_wildcard_exclusion']['base64']);
 				break;
 			case 'delete_ip':
 				// ADR-53 un-suppress rework (#422): the old flow only understood an
@@ -1263,7 +1263,8 @@ if (isset($_POST) && !empty($_POST)) {
 				$type	= "IPv{$family} Suppression";
 
 				$supp_key	= $is_v6 ? 'ipsuppression_v6' : 'ipsuppression';
-				$cfg_key	= $is_v6 ? 'v6suppression' : 'v4suppression';
+				$cfg_key	= $is_v6 ? 'v6suppression' : 'v4suppression';	// bare -- blob index
+				$cfg_key_path	= $is_v6 ? 'ip/v6suppression' : 'ip/v4suppression';	// issue #1931: gateway key
 
 				// Longest-prefix pick: when both a '/32' and a broader entry cover
 				// the host, remove the most specific one -- deterministic, mirrors
@@ -1281,7 +1282,7 @@ if (isset($_POST) && !empty($_POST)) {
 							$data .= "{$line}";
 						}
 						$clists[$supp_key]['base64'] = pfb_text_area_encode($data);
-						PfbConfig::write($cfg_key, $clists[$supp_key]['base64']);
+						PfbConfig::write($cfg_key_path, $clists[$supp_key]['base64']);
 
 						// Keep pfbsuppression(_v6).txt in step with the config edit --
 						// same in-memory refresh the addsuppress handler applies.

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -63,18 +63,18 @@ $pconfig['dnsbl_allow_int']	= pfb_csv_list($pfb['dconfig']['dnsbl_allow_int'] ??
 $pconfig['global_log']		= $pfb['dconfig']['global_log']				?: '';
 $pconfig['dnsbl_webpage']	= $pfb['dconfig']['dnsbl_webpage']			?: 'dnsbl_default.php';
 $pconfig['pfb_cache']		= isset($pfb['dconfig']['pfb_cache'])			? $pfb['dconfig']['pfb_cache'] : 'on';
-$pconfig['pfb_cache_flush']	= PfbConfig::read('pfb_cache_flush');
+$pconfig['pfb_cache_flush']	= PfbConfig::read('dnsbl/pfb_cache_flush');
 
 $pconfig['pfb_py_reply']	= isset($pfb['dconfig']['pfb_py_reply'])		? $pfb['dconfig']['pfb_py_reply'] : 'on';
 $pconfig['pfb_hsts']		= isset($pfb['dconfig']['pfb_hsts'])			? $pfb['dconfig']['pfb_hsts'] : 'on';
 // ADR-08: IDN mode selector (Off | All-IDN | Confusable). PfbConfig::read() returns a
 // PfbIdnMode enum (legacy 'on' -> All; alpha-only 'all' and '' -> Off); toStored() gives the
 // canonical config token ('on' | 'confusable' | 'off') that the <select> options below carry.
-$pconfig['pfb_idn']		= PfbConfig::read('pfb_idn')->toStored();
+$pconfig['pfb_idn']		= PfbConfig::read('dnsbl/pfb_idn')->toStored();
 // Confusable-mode sub-toggles: block clearly-malicious homoglyphs is default-on;
 // escalate suspicious mixed-script (else alert only) is opt-in (default off).
 // Default 'on' owned by the registry (ADR-29); PfbConfig::read applies it when absent.
-$pconfig['pfb_idn_block_malicious']	= PfbConfig::read('pfb_idn_block_malicious');
+$pconfig['pfb_idn_block_malicious']	= PfbConfig::read('dnsbl/pfb_idn_block_malicious');
 $pconfig['pfb_idn_escalate_suspicious']	= $pfb['dconfig']['pfb_idn_escalate_suspicious']		?: '';
 $pconfig['pfb_regex']		= $pfb['dconfig']['pfb_regex']				?: '';
 $pconfig['pfb_regex_cap']	= $pfb['dconfig']['pfb_regex_cap']			?: '';
@@ -122,7 +122,7 @@ $pconfig['top1m_enable']	= $pfb['dconfig']['top1m_enable']			?: '';
 // (dead TOP1M source, #872/#877) coalesces to 'tranco' for the form select.
 // ->toStored() unwraps the PfbTop1mSource enum to its scalar option key (a
 // Form_Select selected-value must be the scalar, not the enum instance).
-$pconfig['top1m_source']		= PfbConfig::read('top1m_source')->toStored();
+$pconfig['top1m_source']		= PfbConfig::read('dnsbl/top1m_source')->toStored();
 $pconfig['top1m_count']		= $pfb['dconfig']['top1m_count']			?: '1000';
 // 0 (unlimited) is meaningful, so don't use the ?: idiom (0 is falsy -> would reset to default).
 $pconfig['pfb_py_cache_max']	= (isset($pfb['dconfig']['pfb_py_cache_max']) && $pfb['dconfig']['pfb_py_cache_max'] !== '') ? $pfb['dconfig']['pfb_py_cache_max'] : '10000';
@@ -132,22 +132,22 @@ $pconfig['tld_wildcard_exclusion']	= pfb_b64_text($pfb['dconfig']['tld_wildcard_
 $pconfig['tld_wildcard_blacklist']	= pfb_b64_text($pfb['dconfig']['tld_wildcard_blacklist'] ?? NULL);
 
 // DoH/DoT/DoQ blocking — stored in pfblockerngsafesearch; read via gateway (registered keys)
-$pconfig['safesearch_doh']		= PfbConfig::read('safesearch_doh');
-$pconfig['safesearch_doh_list']		= explode(',', PfbConfig::read('safesearch_doh_list'));
+$pconfig['safesearch_doh']		= PfbConfig::read('ss/safesearch_doh');
+$pconfig['safesearch_doh_list']		= explode(',', PfbConfig::read('ss/safesearch_doh_list'));
 
 // [ ADR-36 ] DNS Redirect — stored in pfblockerngdnsblsettings; read via gateway.
-$pconfig['dnsbl_redir']			= PfbConfig::read('dnsbl_redir');
-$pfb_redir_int_raw			= (string) PfbConfig::read('dnsbl_redir_int');
+$pconfig['dnsbl_redir']			= PfbConfig::read('dnsbl/dnsbl_redir');
+$pfb_redir_int_raw			= (string) PfbConfig::read('dnsbl/dnsbl_redir_int');
 $pconfig['dnsbl_redir_int']		= ($pfb_redir_int_raw !== '') ? explode(',', $pfb_redir_int_raw) : [];
-$pconfig['dnsbl_redir_exclude']		= (string) PfbConfig::read('dnsbl_redir_exclude');
+$pconfig['dnsbl_redir_exclude']		= (string) PfbConfig::read('dnsbl/dnsbl_redir_exclude');
 
 // [ ADR-37 ] DoT/DoQ Block — stored in pfblockerngdnsblsettings; read via gateway.
-$pconfig['dnsbl_dot_block']		= PfbConfig::read('dnsbl_dot_block');
-$pfb_dot_block_int_raw			= (string) PfbConfig::read('dnsbl_dot_block_int');
+$pconfig['dnsbl_dot_block']		= PfbConfig::read('dnsbl/dnsbl_dot_block');
+$pfb_dot_block_int_raw			= (string) PfbConfig::read('dnsbl/dnsbl_dot_block_int');
 $pconfig['dnsbl_dot_block_int']		= ($pfb_dot_block_int_raw !== '') ? explode(',', $pfb_dot_block_int_raw) : [];
-$pconfig['dnsbl_dot_block_exclude']	= (string) PfbConfig::read('dnsbl_dot_block_exclude');
-$pconfig['dnsbl_dot_block_action']	= (string) PfbConfig::read('dnsbl_dot_block_action');
-$pconfig['dnsbl_dot_block_floating']	= PfbConfig::read('dnsbl_dot_block_floating');
+$pconfig['dnsbl_dot_block_exclude']	= (string) PfbConfig::read('dnsbl/dnsbl_dot_block_exclude');
+$pconfig['dnsbl_dot_block_action']	= (string) PfbConfig::read('dnsbl/dnsbl_dot_block_action');
+$pconfig['dnsbl_dot_block_floating']	= PfbConfig::read('dnsbl/dnsbl_dot_block_floating');
 
 // Select field options
 
@@ -963,20 +963,20 @@ if ($_POST) {
 			PfbConfig::writeSection('installedpackages/pfblockerngdnsblsettings/config/0', $pfb['dconfig']);
 
 			// Save DoH/DoT/DoQ blocking fields via gateway (registered keys in pfblockerngsafesearch)
-			PfbConfig::write('safesearch_doh', $_POST['safesearch_doh'] ?: 'Disable');
-			PfbConfig::write('safesearch_doh_list', implode(',', (array)$_POST['safesearch_doh_list']) ?: '');
+			PfbConfig::write('ss/safesearch_doh', $_POST['safesearch_doh'] ?: 'Disable');
+			PfbConfig::write('ss/safesearch_doh_list', implode(',', (array)$_POST['safesearch_doh_list']) ?: '');
 
 			// [ ADR-36 ] Save DNS Redirect fields via gateway (registered keys in pfblockerngdnsblsettings)
-			PfbConfig::write('dnsbl_redir', pfb_filter($_POST['dnsbl_redir'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '');
-			PfbConfig::write('dnsbl_redir_int', implode(',', $redir_ifaces_raw));
-			PfbConfig::write('dnsbl_redir_exclude', $redir_alias_raw);
+			PfbConfig::write('dnsbl/dnsbl_redir', pfb_filter($_POST['dnsbl_redir'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '');
+			PfbConfig::write('dnsbl/dnsbl_redir_int', implode(',', $redir_ifaces_raw));
+			PfbConfig::write('dnsbl/dnsbl_redir_exclude', $redir_alias_raw);
 
 			// [ ADR-37 ] Save DoT/DoQ Block fields via gateway (registered keys in pfblockerngdnsblsettings)
-			PfbConfig::write('dnsbl_dot_block', pfb_filter($_POST['dnsbl_dot_block'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '');
-			PfbConfig::write('dnsbl_dot_block_int', implode(',', $dot_block_ifaces_raw));
-			PfbConfig::write('dnsbl_dot_block_exclude', $dot_block_alias_raw);
-			PfbConfig::write('dnsbl_dot_block_action', pfb_dot_block_action($dot_block_action_raw));
-			PfbConfig::write('dnsbl_dot_block_floating', pfb_filter($_POST['dnsbl_dot_block_floating'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '');
+			PfbConfig::write('dnsbl/dnsbl_dot_block', pfb_filter($_POST['dnsbl_dot_block'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '');
+			PfbConfig::write('dnsbl/dnsbl_dot_block_int', implode(',', $dot_block_ifaces_raw));
+			PfbConfig::write('dnsbl/dnsbl_dot_block_exclude', $dot_block_alias_raw);
+			PfbConfig::write('dnsbl/dnsbl_dot_block_action', pfb_dot_block_action($dot_block_action_raw));
+			PfbConfig::write('dnsbl/dnsbl_dot_block_floating', pfb_filter($_POST['dnsbl_dot_block_floating'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '');
 
 			write_config('[pfBlockerNG] save DNSBL settings');
 			pfb_mark_pending_changes();	// applies on the next Update, not on save

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -51,11 +51,11 @@ $pconfig = array();
 $pconfig['enable_cb']			= $pfb['gconfig']['enable_cb']				?: '';
 
 // Default 'on' — owned by the registry (ADR-29); PfbConfig::read applies it when absent.
-$pconfig['pfb_keep']			= PfbConfig::read('pfb_keep')->value;
+$pconfig['pfb_keep']			= PfbConfig::read('gen/pfb_keep')->value;
 
 // Default 'on' — owned by the registry (ADR-29); PfbConfig::read applies it when absent.
 // Pinned 'off' on existing installs by the upgrade migration in pfblockerng_install.inc.
-$pconfig['pfb_feed_internal_filter']	= PfbConfig::read('pfb_feed_internal_filter')->value;
+$pconfig['pfb_feed_internal_filter']	= PfbConfig::read('gen/pfb_feed_internal_filter')->value;
 
 // Exemptions from the internal-address feed-host check: IP addresses / CIDR ranges
 // (one per line) whose feeds are allowed even when they resolve internally.
@@ -80,22 +80,22 @@ foreach ($log_suffixes as $log_suffix) {
 // ADR-60: per-log age-based retention (days; '0' = disabled). Read via PfbConfig::read
 // so the registered default applies when the key is absent (new install / upgrade).
 foreach ($log_suffixes as $log_suffix) {
-	$pconfig['log_max_days_' . $log_suffix]	= PfbConfig::read('log_max_days_' . $log_suffix);
+	$pconfig['log_max_days_' . $log_suffix]	= PfbConfig::read('gen/log_max_days_' . $log_suffix);
 }
 
 // ADR-38: syslog export toggle. Read via PfbConfig::read so registered default applies.
 // log_syslog uses the PfbToggle adapter — extract the scalar .value for pfb_cfg_toggle_read().
-$pconfig['log_syslog']			= PfbConfig::read('log_syslog')->value;
+$pconfig['log_syslog']			= PfbConfig::read('gen/log_syslog')->value;
 
 // issue #1109: log-trim hysteresis margin (percent, global). Read via PfbConfig::read so
 // the registered default ('0') applies when the key is absent (new install / upgrade).
-$pconfig['pfb_log_trim_margin_pct']	= PfbConfig::read('pfb_log_trim_margin_pct');
+$pconfig['pfb_log_trim_margin_pct']	= PfbConfig::read('gen/pfb_log_trim_margin_pct');
 
 // issue #1669 slice C / #1888: client-side editor toggle (default on). Read via
 // PfbConfig::read so the registered default applies; pfb_syntax_highlight is a
 // default-on toggle field (merged PfbToggle, issue #1887; mirrors pfb_keep) --
 // extract the scalar .value for pfb_cfg_toggle_read() at render.
-$pconfig['pfb_syntax_highlight']	= PfbConfig::read('pfb_syntax_highlight')->value;
+$pconfig['pfb_syntax_highlight']	= PfbConfig::read('gen/pfb_syntax_highlight')->value;
 
 // issue #1875 step 2b: gate the CM6 live-highlight overlay for pfb_feed_internal_allowlist,
 // same $pfb_syntaxhl_on idiom pfblockerng_dnsbl.php establishes at its line 38.

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -43,12 +43,12 @@ $pconfig['enable_agg']		= $pfb['iconfig']['enable_agg']				?: '';
 // save-time sanitiser and the rendered select share one source of allowed values.
 // Stored VALUES are Deny/Permit/Match/Native; the labels show the reference-only alias.
 $options_pfb_agg_types		= [ 'Deny' => 'Alias Deny', 'Permit' => 'Alias Permit', 'Match' => 'Alias Match', 'Native' => 'Alias Native' ];
-$pconfig['pfb_agg_types']	= explode(',', (string) PfbConfig::read('pfb_agg_types'));
+$pconfig['pfb_agg_types']	= explode(',', (string) PfbConfig::read('gen/pfb_agg_types'));
 
 // ADR-40: alias-table apply mode (gateway-registered, general section).
 $options_pfb_alias_delta_mode	= [ 'auto' => 'Auto (delta for small churn, replace for large)', 'delta' => 'Delta (-T add/-T delete)', 'replace' => 'Replace (-T replace, pre-4.0 behaviour)' ];
-$pconfig['pfb_alias_delta_mode']	= (string) PfbConfig::read('pfb_alias_delta_mode')->toStored();
-$pconfig['pfb_alias_delta_batch']	= pfb_alias_delta_batch_clamp((string) PfbConfig::read('pfb_alias_delta_batch'));
+$pconfig['pfb_alias_delta_mode']	= (string) PfbConfig::read('gen/pfb_alias_delta_mode')->toStored();
+$pconfig['pfb_alias_delta_batch']	= pfb_alias_delta_batch_clamp((string) PfbConfig::read('gen/pfb_alias_delta_batch'));
 
 // Default to 'on' for new installation only
 $pconfig['suppression']		= isset($pfb['iconfig']['suppression'])			? $pfb['iconfig']['suppression'] : 'on';
@@ -277,18 +277,18 @@ if ($_POST) {
 			$agg_types_post	= array_values(array_intersect(
 						array_keys($options_pfb_agg_types),
 						(array) ($_POST['pfb_agg_types'] ?? array())));
-			PfbConfig::write('pfb_agg_types', implode(',', $agg_types_post));
+			PfbConfig::write('gen/pfb_agg_types', implode(',', $agg_types_post));
 
 			// ADR-40: alias-table apply mode (gateway-registered scalar).
 			$delta_mode_post = array_key_exists($_POST['pfb_alias_delta_mode'] ?? '', $options_pfb_alias_delta_mode)
 				? $_POST['pfb_alias_delta_mode']
 				: 'auto';
-			PfbConfig::write('pfb_alias_delta_mode', $delta_mode_post);
+			PfbConfig::write('gen/pfb_alias_delta_mode', $delta_mode_post);
 
 			// ADR-40: batch size — clamp to [64, 4096].  An empty field (user
 			// cleared the value) must default to 512, not cast to 0 and clamp to 64.
 			$_pfb_batch_raw = trim((string) ($_POST['pfb_alias_delta_batch'] ?? ''));
-			PfbConfig::write('pfb_alias_delta_batch', (string) pfb_alias_delta_batch_resolve($_pfb_batch_raw));
+			PfbConfig::write('gen/pfb_alias_delta_batch', (string) pfb_alias_delta_batch_resolve($_pfb_batch_raw));
 
 			PfbConfig::writeSection('installedpackages/pfblockerngipsettings/config/0', $pfb['iconfig']);
 			write_config('[pfBlockerNG] save IP settings');

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -79,7 +79,7 @@ if ($_POST && !empty($_POST['pfb_sw_action'])) {
 // unticked, so persist an explicit 'on'/'off' — an unset value defaults to enabled, an
 // explicit 'off' is the user opting out.
 if ($_POST && isset($_POST['save'])) {
-	PfbConfig::write('pfb_software_check', isset($_POST['pfb_software_check']) ? 'on' : 'off');
+	PfbConfig::write('gen/pfb_software_check', isset($_POST['pfb_software_check']) ? 'on' : 'off');
 	write_config('[pfBlockerNG] save Software settings');
 	header('Location: /pfblockerng/pfblockerng_software.php');
 	exit;

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -229,7 +229,7 @@ pfb_print_pending_changes_box(TRUE);
 // installed iff pfBlockerNG is enabled (the feed `interval` only gates the feed job *inside* the
 // tick, not the tick itself). So the "NEXT Scheduled CRON Event" tracks the tick boundary; the
 // per-feed cadence lives in the Schedule view below.
-$pfb_tick_min = pfb_tick_interval_clamp(PfbConfig::read('pfb_tick_interval'));
+$pfb_tick_min = pfb_tick_interval_clamp(PfbConfig::read('gen/pfb_tick_interval'));
 
 if ($pfb['enable'] === PfbToggle::On) {
 	list($next_hour, $next_min, $sec_remain) =

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -670,7 +670,7 @@ SH
 		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
 		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
-		$this->assertSame("198.51.100.40/32 # note\n", base64_decode(PfbConfig::read('v4suppression')));
+		$this->assertSame("198.51.100.40/32 # note\n", base64_decode(PfbConfig::read('ip/v4suppression')));
 		$this->assertFileExists($GLOBALS['pfb']['supptxt']);
 	}
 
@@ -684,7 +684,7 @@ SH
 		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
 		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
-		$this->assertSame("198.51.100.45/32\n", base64_decode(PfbConfig::read('v4suppression')));
+		$this->assertSame("198.51.100.45/32\n", base64_decode(PfbConfig::read('ip/v4suppression')));
 		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
 		$this->assertDirectoryExists($suppression_file, 'suppression-file persistence failure must leave the target directory untouched');
 	}
@@ -698,7 +698,7 @@ SH
 		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
 		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
-		$this->assertSame("2001:db8::40/128\n", base64_decode(PfbConfig::read('v6suppression')));
+		$this->assertSame("2001:db8::40/128\n", base64_decode(PfbConfig::read('ip/v6suppression')));
 		$this->assertFileExists($GLOBALS['pfb']['supptxt_v6']);
 	}
 
@@ -712,7 +712,7 @@ SH
 		$this->assertStringContainsString('Removed 1 entry, added 0 covering CIDRs', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
 		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
-		$this->assertSame("198.51.100.42/32\n", base64_decode(PfbConfig::read('v4suppression')));
+		$this->assertSame("198.51.100.42/32\n", base64_decode(PfbConfig::read('ip/v4suppression')));
 	}
 
 	public function testAddSuppressFailedStillPersistsStandingSuppression(): void
@@ -725,7 +725,7 @@ SH
 		$this->assertStringContainsString('Live punch failed', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
 		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
-		$this->assertSame("198.51.100.43/32\n", base64_decode(PfbConfig::read('v4suppression')));
+		$this->assertSame("198.51.100.43/32\n", base64_decode(PfbConfig::read('ip/v4suppression')));
 	}
 
 	public function testAddSuppressBusyStillPersistsStandingSuppression(): void
@@ -744,7 +744,7 @@ SH
 		$this->assertStringContainsString('update/reload pass', $result['savemsg']);
 		$this->assertTrue($result['redirect']);
 		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
-		$this->assertSame("198.51.100.44/32\n", base64_decode(PfbConfig::read('v4suppression')));
+		$this->assertSame("198.51.100.44/32\n", base64_decode(PfbConfig::read('ip/v4suppression')));
 	}
 
 	public function testAddSuppressExactDuplicateSkipsConfigRefresh(): void

--- a/tests/php/AliasDeltaApplyTest.php
+++ b/tests/php/AliasDeltaApplyTest.php
@@ -582,8 +582,8 @@ SH
 	{
 		$GLOBALS['config'] = [];
 		foreach (['auto', 'delta', 'replace'] as $token) {
-			PfbConfig::write('pfb_alias_delta_mode', $token);
-			$read = PfbConfig::read('pfb_alias_delta_mode');
+			PfbConfig::write('gen/pfb_alias_delta_mode', $token);
+			$read = PfbConfig::read('gen/pfb_alias_delta_mode');
 			$this->assertInstanceOf(PfbAliasDeltaMode::class, $read,
 				"expected: PfbAliasDeltaMode instance; got: " . get_class($read));
 			$written = $read->toStored();
@@ -598,7 +598,7 @@ SH
 	public function testAliasDeltaBatchAbsentDefaultIs512(): void
 	{
 		$GLOBALS['config'] = [];
-		$value = (string) PfbConfig::read('pfb_alias_delta_batch');
+		$value = (string) PfbConfig::read('gen/pfb_alias_delta_batch');
 		$this->assertSame('512', $value,
 			"expected: absent pfb_alias_delta_batch default = '512'; actual: '{$value}'");
 	}

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -699,6 +699,85 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// issue #1931 — ip/suppression (IP page "Enable Suppression" toggle;
+	// path-addressed so it no longer collides with dnsbl/suppression)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * ip/suppression absent key returns the registered default '' -- NOT the
+	 * page's 'on' render fallback. pfblockerng_ip.php keeps its own
+	 * isset(...) ? ... : 'on' rendering (the #1907-class page/registry
+	 * divergence); the 'on'-default + grandfather decision is deferred to #1921.
+	 *
+	 * Scenario:
+	 *   Background: ip/suppression is plain (NULL/NULL adapters), default ''.
+	 *     Given no stored value.
+	 *     When PfbConfig::read('ip/suppression').
+	 *     Then '' is returned (registered default).
+	 *
+	 * Red->green: before this step, 'ip/suppression' was not registered ->
+	 *   PfbConfig::read('ip/suppression') threw InvalidArgumentException.
+	 */
+	public function testIpSuppressionAbsentKeyReturnsDefaultEmptyString(): void
+	{
+		$path = 'installedpackages/pfblockerngipsettings/config/0/suppression';
+
+		// Before: absent.
+		$this->assertNull(config_get_path($path), 'before: ip suppression must be absent');
+
+		// When/Then.
+		$this->assertSame('', PfbConfig::read('ip/suppression'), 'ip/suppression absent -> ""');
+	}
+
+	/**
+	 * writeSystem('ip/suppression', 'on') stores 'on' at the exact ipsettings
+	 * path -- proves the path-addressed registry entry routes to
+	 * pfblockerngipsettings/config/0, never pfblockerngdnsblsettings/config/0.
+	 *
+	 * Scenario:
+	 *   Given no stored value.
+	 *   When PfbConfig::writeSystem('ip/suppression', 'on').
+	 *   Then the ipsettings path stores 'on' and the DNSBL suppression path
+	 *     stays untouched (still absent).
+	 */
+	public function testIpSuppressionWriteStoresAtIpsettingsPath(): void
+	{
+		$ip_path    = 'installedpackages/pfblockerngipsettings/config/0/suppression';
+		$dnsbl_path = 'installedpackages/pfblockerngdnsblsettings/config/0/suppression';
+
+		PfbConfig::writeSystem('ip/suppression', 'on');
+
+		$this->assertSame('on', config_get_path($ip_path),
+			"writeSystem('ip/suppression') must store at the ipsettings path");
+		$this->assertNull(config_get_path($dnsbl_path),
+			'dnsbl/suppression must stay untouched by an ip/suppression write');
+	}
+
+	/**
+	 * 'ip/suppression' and 'dnsbl/suppression' share the same bare key name but
+	 * resolve to different config.xml sections -- the #1931 path-addressing fix
+	 * for their pre-step-A collision. Both stay independently registered and
+	 * readable, each at its own default.
+	 *
+	 * Scenario:
+	 *   When PFB_SECTIONS resolves each alias's section path.
+	 *   Then the two full paths differ, and writing one leaves the other's
+	 *     value untouched.
+	 */
+	public function testIpSuppressionAndDnsblSuppressionResolveToDifferentPaths(): void
+	{
+		$ip_path    = PFB_SECTIONS['ip'] . '/suppression';
+		$dnsbl_path = PFB_SECTIONS['dnsbl'] . '/suppression';
+
+		$this->assertNotSame($ip_path, $dnsbl_path,
+			"'ip/suppression' and 'dnsbl/suppression' must resolve to different config.xml paths");
+
+		PfbConfig::writeSystem('ip/suppression', 'on');
+		$this->assertSame('on', PfbConfig::read('ip/suppression'));
+		$this->assertSame('', PfbConfig::read('dnsbl/suppression'), 'dnsbl/suppression stays at its own default');
+	}
+
+	// -----------------------------------------------------------------------
 	// ADR-43 — pfb_tick_interval (plain string; tick-cron dispatch interval)
 	// -----------------------------------------------------------------------
 
@@ -999,11 +1078,11 @@ final class CfgGatewayTest extends TestCase
 	 *     pfblockerngantartica (typo in old data), pfblockerng{continent}
 	 *   - Dynamic feed/continent keys: feed_alt_*, widget-{type}
 	 *   - pfblockerngipsettings sub-keys (all section-level, handled together):
-	 *     maxmind_key, etc. (suppression key in ipsettings is a distinct concept
-	 *     from pfblockerngdnsblsettings/suppression which IS registered).
-	 *     ADR-53: v4suppression + v6suppression are now registered (see the registered
-	 *     inventory below) -- they are the two ipsettings scalars NOT on this
-	 *     out-of-scope list.
+	 *     maxmind_key, etc. ADR-53 registered v4suppression + v6suppression; issue
+	 *     #1931 registers 'suppression' too, as path-addressed 'ip/suppression' --
+	 *     distinct storage from the already-registered 'dnsbl/suppression' despite
+	 *     the shared bare name. All three are NOT on this out-of-scope list; only
+	 *     their still-foreign ipsettings siblings are.
 	 *   - pfblockerngreputation sub-keys: et_header
 	 *   - pfblockerngsync sub-keys: syncinterfaces, varsynconchanges, row/*
 	 *   - pfblockerngblacklist sub-keys: blacklist_enable, blacklist_freq,
@@ -1015,6 +1094,13 @@ final class CfgGatewayTest extends TestCase
 	public function testInventoryCompletenessAllKnownKeysAccountedFor(): void
 	{
 		$registry = pfb_cfg_registry();
+
+		// issue #1931: 'ip/suppression' shares its bare key with the already-registered
+		// 'dnsbl/suppression', so the bare-key inventory below can't distinguish the two --
+		// assert the alias-qualified registration directly.
+		$this->assertArrayHasKey('ip/suppression', $registry,
+			"'ip/suppression' must be registered (issue #1931)");
+
 		// issue #1931: registry keys are now '<alias>/<bare-key>'; this inventory compares
 		// against the bare config.xml names below, so strip the alias prefix back off.
 		$registered_keys = array_map(

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -71,14 +71,14 @@ final class CfgGatewayTest extends TestCase
 	{
 		// Representative toggle-adapted fields (pfb_keep is now lenient — see below).
 		$toggle_fields = [
-			'enable_cb'        => 'installedpackages/pfblockerng/config/0/enable_cb',
-			'pfb_dnsbl'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
-			'pfb_dnsvip_auto'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
-			'pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
-			'pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
-			'pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
-			'pfb_cache_flush'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush',
-			'pfb_feed_sanity'  => 'installedpackages/pfblockerng/config/0/pfb_feed_sanity',
+			'gen/enable_cb'        => 'installedpackages/pfblockerng/config/0/enable_cb',
+			'dnsbl/pfb_dnsbl'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
+			'dnsbl/pfb_dnsvip_auto'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
+			'dnsbl/pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
+			'gen/pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
+			'dnsbl/pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
+			'dnsbl/pfb_cache_flush'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush',
+			'gen/pfb_feed_sanity'  => 'installedpackages/pfblockerng/config/0/pfb_feed_sanity',
 		];
 
 		foreach ($toggle_fields as $key => $path) {
@@ -102,14 +102,14 @@ final class CfgGatewayTest extends TestCase
 	{
 		// pfb_keep is default-on — see testPfbKeepRoundTrip*() below.
 		$toggle_fields = [
-			'enable_cb'        => 'installedpackages/pfblockerng/config/0/enable_cb',
-			'pfb_dnsbl'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
-			'pfb_dnsvip_auto'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
-			'pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
-			'pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
-			'pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
-			'pfb_cache_flush'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush',
-			'pfb_feed_sanity'  => 'installedpackages/pfblockerng/config/0/pfb_feed_sanity',
+			'gen/enable_cb'        => 'installedpackages/pfblockerng/config/0/enable_cb',
+			'dnsbl/pfb_dnsbl'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
+			'dnsbl/pfb_dnsvip_auto'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto',
+			'dnsbl/pfb_dnsbl_nonat'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat',
+			'gen/pfb_reuse'        => 'installedpackages/pfblockerng/config/0/pfb_reuse',
+			'dnsbl/pfb_hsts'         => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts',
+			'dnsbl/pfb_cache_flush'  => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush',
+			'gen/pfb_feed_sanity'  => 'installedpackages/pfblockerng/config/0/pfb_feed_sanity',
 		];
 
 		foreach ($toggle_fields as $key => $path) {
@@ -149,10 +149,10 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('on', config_get_path($path));
 
 		// When/After.
-		$enum = PfbConfig::read('pfb_dnsbl_lenient');
+		$enum = PfbConfig::read('dnsbl/pfb_dnsbl_lenient');
 		$this->assertSame(PfbToggle::On, $enum);
 
-		PfbConfig::write('pfb_dnsbl_lenient', $enum);
+		PfbConfig::write('dnsbl/pfb_dnsbl_lenient', $enum);
 		$this->assertSame('on', config_get_path($path));
 	}
 
@@ -167,10 +167,10 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('off', config_get_path($path));
 
 		// When/After.
-		$enum = PfbConfig::read('pfb_dnsbl_lenient');
+		$enum = PfbConfig::read('dnsbl/pfb_dnsbl_lenient');
 		$this->assertSame(PfbToggle::Off, $enum);
 
-		PfbConfig::write('pfb_dnsbl_lenient', $enum);
+		PfbConfig::write('dnsbl/pfb_dnsbl_lenient', $enum);
 		$this->assertSame('off', config_get_path($path));
 	}
 
@@ -185,10 +185,10 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('', config_get_path($path));
 
 		// When/After: normalised to 'off' (documented, matches pfb_global() behaviour).
-		$enum = PfbConfig::read('pfb_dnsbl_lenient');
+		$enum = PfbConfig::read('dnsbl/pfb_dnsbl_lenient');
 		$this->assertSame(PfbToggle::Off, $enum);
 
-		PfbConfig::write('pfb_dnsbl_lenient', $enum);
+		PfbConfig::write('dnsbl/pfb_dnsbl_lenient', $enum);
 		// Normalised: stored as 'off', NOT ''.
 		$this->assertSame('off', config_get_path($path));
 	}
@@ -213,10 +213,10 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('on', config_get_path($path), 'before: pfb_keep seed is on');
 
 		// When/After: read -> PfbToggle::On; write -> 'on'.
-		$enum = PfbConfig::read('pfb_keep');
+		$enum = PfbConfig::read('gen/pfb_keep');
 		$this->assertSame(PfbToggle::On, $enum, "read: pfb_keep 'on' -> PfbToggle::On");
 
-		PfbConfig::write('pfb_keep', $enum);
+		PfbConfig::write('gen/pfb_keep', $enum);
 		$this->assertSame('on', config_get_path($path), "write(read('on'))==on for pfb_keep");
 	}
 
@@ -231,10 +231,10 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('off', config_get_path($path), 'before: pfb_keep seed is off');
 
 		// When/After: read -> PfbToggle::Off; write -> 'off'.
-		$enum = PfbConfig::read('pfb_keep');
+		$enum = PfbConfig::read('gen/pfb_keep');
 		$this->assertSame(PfbToggle::Off, $enum, "read: pfb_keep 'off' -> PfbToggle::Off");
 
-		PfbConfig::write('pfb_keep', $enum);
+		PfbConfig::write('gen/pfb_keep', $enum);
 		$this->assertSame('off', config_get_path($path), "write(read('off'))==off for pfb_keep");
 	}
 
@@ -249,11 +249,11 @@ final class CfgGatewayTest extends TestCase
 
 		$this->assertSame('', config_get_path($path), 'before: pfb_keep seed is empty string');
 
-		$enum = PfbConfig::read('pfb_keep');
+		$enum = PfbConfig::read('gen/pfb_keep');
 		$this->assertSame(PfbToggle::On, $enum, "read: pfb_keep '' -> registered default On");
 
 		// After: write emits the canonical token of the default.
-		PfbConfig::write('pfb_keep', $enum);
+		PfbConfig::write('gen/pfb_keep', $enum);
 		$this->assertSame('on', config_get_path($path), "write(read(''))=='on' for pfb_keep");
 	}
 
@@ -280,10 +280,10 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('on', config_get_path($path), 'before: pfb_syntax_highlight seed is on');
 
 		// When/After: read -> PfbToggle::On; write -> 'on'.
-		$enum = PfbConfig::read('pfb_syntax_highlight');
+		$enum = PfbConfig::read('gen/pfb_syntax_highlight');
 		$this->assertSame(PfbToggle::On, $enum, "read: pfb_syntax_highlight 'on' -> PfbToggle::On");
 
-		PfbConfig::write('pfb_syntax_highlight', $enum);
+		PfbConfig::write('gen/pfb_syntax_highlight', $enum);
 		$this->assertSame('on', config_get_path($path), "write(read('on'))==on for pfb_syntax_highlight");
 	}
 
@@ -298,10 +298,10 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('off', config_get_path($path), 'before: pfb_syntax_highlight seed is off');
 
 		// When/After: read -> PfbToggle::Off; write -> 'off'.
-		$enum = PfbConfig::read('pfb_syntax_highlight');
+		$enum = PfbConfig::read('gen/pfb_syntax_highlight');
 		$this->assertSame(PfbToggle::Off, $enum, "read: pfb_syntax_highlight 'off' -> PfbToggle::Off");
 
-		PfbConfig::write('pfb_syntax_highlight', $enum);
+		PfbConfig::write('gen/pfb_syntax_highlight', $enum);
 		$this->assertSame('off', config_get_path($path), "write(read('off'))==off for pfb_syntax_highlight");
 	}
 
@@ -324,7 +324,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/enable_cb'));
 
 		// When/Then: returns Off (default '').
-		$result = PfbConfig::read('enable_cb');
+		$result = PfbConfig::read('gen/enable_cb');
 		$this->assertSame(PfbToggle::Off, $result, 'enable_cb absent -> Off (default)');
 	}
 
@@ -336,7 +336,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: config[.../pfb_feed_sanity] is unset (feature is new).
 	 *     Given no seed.
-	 *     When PfbConfig::read('pfb_feed_sanity').
+	 *     When PfbConfig::read('gen/pfb_feed_sanity').
 	 *     Then PfbToggle::Off is returned (default '').
 	 */
 	public function testReadReturnsRegisteredDefaultForPfbFeedSanityAbsentKey(): void
@@ -345,7 +345,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_feed_sanity'));
 
 		// When/Then: returns Off (default '').
-		$result = PfbConfig::read('pfb_feed_sanity');
+		$result = PfbConfig::read('gen/pfb_feed_sanity');
 		$this->assertSame(PfbToggle::Off, $result, 'pfb_feed_sanity absent -> Off (default)');
 	}
 
@@ -353,7 +353,7 @@ final class CfgGatewayTest extends TestCase
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush';
 		$this->assertNull(config_get_path($path));
-		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_cache_flush'),
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('dnsbl/pfb_cache_flush'),
 			'pfb_cache_flush absent -> Off (default)');
 	}
 
@@ -369,14 +369,14 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: config[.../pfb_syntax_highlight] is unset.
 	 *     Given no seed.
-	 *     When PfbConfig::read('pfb_syntax_highlight').
+	 *     When PfbConfig::read('gen/pfb_syntax_highlight').
 	 *     Then PfbToggle::On is returned (default 'on').
 	 */
 	public function testReadReturnsOnDefaultForPfbSyntaxHighlightAbsentKey(): void
 	{
 		$path = 'installedpackages/pfblockerng/config/0/pfb_syntax_highlight';
 		$this->assertNull(config_get_path($path));
-		$this->assertSame(PfbToggle::On, PfbConfig::read('pfb_syntax_highlight'),
+		$this->assertSame(PfbToggle::On, PfbConfig::read('gen/pfb_syntax_highlight'),
 			'pfb_syntax_highlight absent -> On (default)');
 	}
 
@@ -388,7 +388,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_keep'));
 
 		// When: read with no seed.
-		$result = PfbConfig::read('pfb_keep');
+		$result = PfbConfig::read('gen/pfb_keep');
 
 		// Then: returns On (the registered default 'on', applied through lenient adapter).
 		$this->assertSame(PfbToggle::On, $result, 'pfb_keep absent -> PfbToggle::On (default on)');
@@ -403,7 +403,7 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When.
-		$result = PfbConfig::read('pfb_dnsbl_lenient');
+		$result = PfbConfig::read('dnsbl/pfb_dnsbl_lenient');
 
 		// Then: Off.
 		$this->assertSame(PfbToggle::Off, $result, 'pfb_dnsbl_lenient absent -> Off');
@@ -414,7 +414,7 @@ final class CfgGatewayTest extends TestCase
 		// pfb_interval default is '1'.
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_interval'));
 
-		$result = PfbConfig::read('pfb_interval');
+		$result = PfbConfig::read('gen/pfb_interval');
 		$this->assertSame('1', $result, 'pfb_interval absent -> "1"');
 	}
 
@@ -425,7 +425,7 @@ final class CfgGatewayTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/top1m_source')
 		);
 
-		$result = PfbConfig::read('top1m_source');
+		$result = PfbConfig::read('dnsbl/top1m_source');
 		$this->assertInstanceOf(PfbTop1mSource::class, $result, 'top1m_source must return a PfbTop1mSource enum');
 		$this->assertSame(PfbTop1mSource::Tranco, $result);
 	}
@@ -437,7 +437,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario: the dropped Alexa TOP1M option still reads safely on an existing
 	 * install that had it selected.
 	 *   Given top1m_source stored as the legacy 'alexa' token.
-	 *   When PfbConfig::read('top1m_source').
+	 *   When PfbConfig::read('dnsbl/top1m_source').
 	 *   Then the result is PfbTop1mSource::Tranco, not the dead 'alexa' token.
 	 */
 	public function testReadCoalescesLegacyAlexaTypeToTranco(): void
@@ -449,7 +449,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('alexa', config_get_path($path), 'before: top1m_source seed is legacy alexa');
 
 		// When/Then: coalesced to PfbTop1mSource::Tranco.
-		$this->assertSame(PfbTop1mSource::Tranco, PfbConfig::read('top1m_source'), "legacy 'alexa' coalesces to Tranco");
+		$this->assertSame(PfbTop1mSource::Tranco, PfbConfig::read('dnsbl/top1m_source'), "legacy 'alexa' coalesces to Tranco");
 	}
 
 	/**
@@ -459,7 +459,7 @@ final class CfgGatewayTest extends TestCase
 	 *
 	 * Scenario: an existing install with DomCop selected still reads safely.
 	 *   Given top1m_source stored as the legacy 'domcop' token.
-	 *   When PfbConfig::read('top1m_source').
+	 *   When PfbConfig::read('dnsbl/top1m_source').
 	 *   Then the result is PfbTop1mSource::OpenPageRank, not the dead 'domcop' token.
 	 */
 	public function testReadCoalescesLegacyDomCopTypeToOpenPageRank(): void
@@ -473,7 +473,7 @@ final class CfgGatewayTest extends TestCase
 		// When/Then: coalesced to PfbTop1mSource::OpenPageRank.
 		$this->assertSame(
 			PfbTop1mSource::OpenPageRank,
-			PfbConfig::read('top1m_source'),
+			PfbConfig::read('dnsbl/top1m_source'),
 			"legacy 'domcop' coalesces to OpenPageRank"
 		);
 	}
@@ -487,19 +487,19 @@ final class CfgGatewayTest extends TestCase
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/top1m_source';
 
 		$this->seedConfig($path, 'cisco');
-		$this->assertSame(PfbTop1mSource::Cisco, PfbConfig::read('top1m_source'), "'cisco' passes through as Cisco");
+		$this->assertSame(PfbTop1mSource::Cisco, PfbConfig::read('dnsbl/top1m_source'), "'cisco' passes through as Cisco");
 
 		$this->seedConfig($path, 'tranco');
-		$this->assertSame(PfbTop1mSource::Tranco, PfbConfig::read('top1m_source'), "'tranco' passes through as Tranco");
+		$this->assertSame(PfbTop1mSource::Tranco, PfbConfig::read('dnsbl/top1m_source'), "'tranco' passes through as Tranco");
 
 		$this->seedConfig($path, 'openpagerank');
-		$this->assertSame(PfbTop1mSource::OpenPageRank, PfbConfig::read('top1m_source'), "'openpagerank' passes through as OpenPageRank");
+		$this->assertSame(PfbTop1mSource::OpenPageRank, PfbConfig::read('dnsbl/top1m_source'), "'openpagerank' passes through as OpenPageRank");
 
 		$this->seedConfig($path, 'majestic');
-		$this->assertSame(PfbTop1mSource::Majestic, PfbConfig::read('top1m_source'), "'majestic' passes through as Majestic");
+		$this->assertSame(PfbTop1mSource::Majestic, PfbConfig::read('dnsbl/top1m_source'), "'majestic' passes through as Majestic");
 
 		$this->seedConfig($path, 'cloudflare');
-		$this->assertSame(PfbTop1mSource::Cloudflare, PfbConfig::read('top1m_source'), "'cloudflare' passes through as Cloudflare");
+		$this->assertSame(PfbTop1mSource::Cloudflare, PfbConfig::read('dnsbl/top1m_source'), "'cloudflare' passes through as Cloudflare");
 	}
 
 	/**
@@ -509,7 +509,7 @@ final class CfgGatewayTest extends TestCase
 	 *
 	 * Scenario: top1m_token default-absent + round-trip.
 	 *   Given the key is absent from config.xml.
-	 *   When PfbConfig::read('top1m_token').
+	 *   When PfbConfig::read('dnsbl/top1m_token').
 	 *   Then the result is '' (the registered default).
 	 *   And when a real-looking token is written then read back, it comes back verbatim.
 	 */
@@ -519,13 +519,13 @@ final class CfgGatewayTest extends TestCase
 
 		// Given/When: absent key.
 		$this->assertNull(config_get_path($path));
-		$this->assertSame('', PfbConfig::read('top1m_token'), 'top1m_token absent -> default ""');
+		$this->assertSame('', PfbConfig::read('dnsbl/top1m_token'), 'top1m_token absent -> default ""');
 
 		// Round-trip: write(read(v)) == v for a real-looking base64url/JWT-charset token.
 		$token = 'cf-abc123._~+/=-XYZ';
-		PfbConfig::write('top1m_token', $token);
+		PfbConfig::write('dnsbl/top1m_token', $token);
 		$this->assertSame($token, config_get_path($path), 'top1m_token write() must store the token verbatim');
-		$this->assertSame($token, PfbConfig::read('top1m_token'), 'top1m_token read() must return the stored token verbatim');
+		$this->assertSame($token, PfbConfig::read('dnsbl/top1m_token'), 'top1m_token read() must return the stored token verbatim');
 	}
 
 	public function testReadReturnsRegisteredDefaultForDnsblInterfaceAbsentKey(): void
@@ -535,7 +535,7 @@ final class CfgGatewayTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_interface')
 		);
 
-		$result = PfbConfig::read('dnsbl_interface');
+		$result = PfbConfig::read('dnsbl/dnsbl_interface');
 		$this->assertSame('lo0', $result);
 	}
 
@@ -547,7 +547,7 @@ final class CfgGatewayTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_action')
 		);
 
-		$result = PfbConfig::read('dnsbl_dot_block_action');
+		$result = PfbConfig::read('dnsbl/dnsbl_dot_block_action');
 		$this->assertSame('reject', $result, 'dnsbl_dot_block_action absent -> reject (default)');
 	}
 
@@ -559,7 +559,7 @@ final class CfgGatewayTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_dot_block_floating')
 		);
 
-		$result = PfbConfig::read('dnsbl_dot_block_floating');
+		$result = PfbConfig::read('dnsbl/dnsbl_dot_block_floating');
 		$this->assertSame(PfbToggle::Off, $result, 'dnsbl_dot_block_floating absent -> Off (per-interface default)');
 	}
 
@@ -568,7 +568,7 @@ final class CfgGatewayTest extends TestCase
 		// safesearch_enable default is 'Disable'.
 		$this->assertNull(config_get_path('installedpackages/pfblockerngsafesearch/safesearch_enable'));
 
-		$result = PfbConfig::read('safesearch_enable');
+		$result = PfbConfig::read('ss/safesearch_enable');
 		$this->assertSame('Disable', $result);
 	}
 
@@ -580,7 +580,7 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// issue #1887: the field carries the toggle adapter now, so the enum comes back.
-		$result = PfbConfig::read('pfb_idn_block_malicious');
+		$result = PfbConfig::read('dnsbl/pfb_idn_block_malicious');
 		$this->assertSame(PfbToggle::On, $result);
 	}
 
@@ -595,11 +595,11 @@ final class CfgGatewayTest extends TestCase
 	 *   Background: v4suppression is a plain base64-blob field; default = '' --
 	 *     mirrors the DNSBL 'suppression' sibling shape.
 	 *     Given no stored value.
-	 *     When PfbConfig::read('v4suppression').
+	 *     When PfbConfig::read('ip/v4suppression').
 	 *     Then '' is returned (registered default).
 	 *
 	 * Red->green: before this phase, 'v4suppression' was not registered ->
-	 *   PfbConfig::read('v4suppression') threw InvalidArgumentException.
+	 *   PfbConfig::read('ip/v4suppression') threw InvalidArgumentException.
 	 */
 	public function testV4SuppressionAbsentKeyReturnsDefaultEmptyString(): void
 	{
@@ -609,7 +609,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'before: v4suppression must be absent');
 
 		// When/Then.
-		$this->assertSame('', PfbConfig::read('v4suppression'), 'v4suppression absent -> ""');
+		$this->assertSame('', PfbConfig::read('ip/v4suppression'), 'v4suppression absent -> ""');
 	}
 
 	/**
@@ -618,7 +618,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: v4suppression stores a base64-encoded CIDR/host customlist.
 	 *     Given stored = base64_encode("192.168.1.1/32\r\n").
-	 *     When PfbConfig::write('v4suppression', PfbConfig::read('v4suppression')).
+	 *     When PfbConfig::write('ip/v4suppression', PfbConfig::read('ip/v4suppression')).
 	 *     Then the stored string is unchanged (byte-identical round-trip).
 	 */
 	public function testV4SuppressionRoundTrips(): void
@@ -633,11 +633,11 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame($blob, config_get_path($path), 'before: v4suppression seed matches blob');
 
 		// When: read -> write.
-		$val = PfbConfig::read('v4suppression');
+		$val = PfbConfig::read('ip/v4suppression');
 		$this->assertSame($blob, $val, 'read: v4suppression round-trips the blob unchanged');
 
 		// After: write back produces the identical stored string.
-		PfbConfig::write('v4suppression', $val);
+		PfbConfig::write('ip/v4suppression', $val);
 		$this->assertSame($blob, config_get_path($path), 'write(read(blob))==blob for v4suppression');
 	}
 
@@ -652,11 +652,11 @@ final class CfgGatewayTest extends TestCase
 	 *   Background: v6suppression is a plain base64-blob field; default = '' --
 	 *     mirrors the v4suppression sibling shape (this section, above).
 	 *     Given no stored value.
-	 *     When PfbConfig::read('v6suppression').
+	 *     When PfbConfig::read('ip/v6suppression').
 	 *     Then '' is returned (registered default).
 	 *
 	 * Red->green: before Phase 6, 'v6suppression' was not registered at all ->
-	 *   PfbConfig::read('v6suppression') threw InvalidArgumentException.
+	 *   PfbConfig::read('ip/v6suppression') threw InvalidArgumentException.
 	 */
 	public function testV6SuppressionAbsentKeyReturnsDefaultEmptyString(): void
 	{
@@ -666,7 +666,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'before: v6suppression must be absent');
 
 		// When/Then.
-		$this->assertSame('', PfbConfig::read('v6suppression'), 'v6suppression absent -> ""');
+		$this->assertSame('', PfbConfig::read('ip/v6suppression'), 'v6suppression absent -> ""');
 	}
 
 	/**
@@ -675,7 +675,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: v6suppression stores a base64-encoded CIDR customlist.
 	 *     Given stored = base64_encode("2001:db8::1/128\r\n").
-	 *     When PfbConfig::write('v6suppression', PfbConfig::read('v6suppression')).
+	 *     When PfbConfig::write('ip/v6suppression', PfbConfig::read('ip/v6suppression')).
 	 *     Then the stored string is unchanged (byte-identical round-trip).
 	 */
 	public function testV6SuppressionRoundTrips(): void
@@ -690,11 +690,11 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame($blob, config_get_path($path), 'before: v6suppression seed matches blob');
 
 		// When: read -> write.
-		$val = PfbConfig::read('v6suppression');
+		$val = PfbConfig::read('ip/v6suppression');
 		$this->assertSame($blob, $val, 'read: v6suppression round-trips the blob unchanged');
 
 		// After: write back produces the identical stored string.
-		PfbConfig::write('v6suppression', $val);
+		PfbConfig::write('ip/v6suppression', $val);
 		$this->assertSame($blob, config_get_path($path), 'write(read(blob))==blob for v6suppression');
 	}
 
@@ -708,7 +708,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: pfb_tick_interval is a plain-string field; default = '15'.
 	 *     Given no stored value.
-	 *     When PfbConfig::read('pfb_tick_interval').
+	 *     When PfbConfig::read('gen/pfb_tick_interval').
 	 *     Then '15' is returned (registered default).
 	 */
 	public function testPfbTickIntervalAbsentKeyReturnsDefault(): void
@@ -719,7 +719,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'before: pfb_tick_interval must be absent');
 
 		// When/Then: absent → default '15'.
-		$result = PfbConfig::read('pfb_tick_interval');
+		$result = PfbConfig::read('gen/pfb_tick_interval');
 		$this->assertSame('15', $result, 'pfb_tick_interval absent -> default 15');
 	}
 
@@ -729,7 +729,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: pfb_tick_interval is a plain-string field.
 	 *     Given stored = '30'.
-	 *     When PfbConfig::write('pfb_tick_interval', PfbConfig::read('pfb_tick_interval')).
+	 *     When PfbConfig::write('gen/pfb_tick_interval', PfbConfig::read('gen/pfb_tick_interval')).
 	 *     Then stored string == '30' (write(read('30')) == '30').
 	 */
 	public function testPfbTickIntervalRoundTrip(): void
@@ -743,11 +743,11 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('30', config_get_path($path), "before: pfb_tick_interval seed is '30'");
 
 		// When: read -> write.
-		$val = PfbConfig::read('pfb_tick_interval');
+		$val = PfbConfig::read('gen/pfb_tick_interval');
 		$this->assertSame('30', $val, "read: pfb_tick_interval '30' -> '30'");
 
 		// After: write back produces '30'.
-		PfbConfig::write('pfb_tick_interval', $val);
+		PfbConfig::write('gen/pfb_tick_interval', $val);
 		$this->assertSame('30', config_get_path($path), "write(read('30'))=='30' for pfb_tick_interval");
 	}
 
@@ -761,11 +761,11 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: pfb_quiet_hours is a plain-string field; default = '' (apply immediately).
 	 *     Given no stored value.
-	 *     When PfbConfig::read('pfb_quiet_hours').
+	 *     When PfbConfig::read('gen/pfb_quiet_hours').
 	 *     Then '' is returned (registered default = no window, apply immediately).
 	 *
 	 * Red→green: before Phase 5, 'pfb_quiet_hours' was not registered →
-	 *   PfbConfig::read('pfb_quiet_hours') threw InvalidArgumentException.
+	 *   PfbConfig::read('gen/pfb_quiet_hours') threw InvalidArgumentException.
 	 */
 	public function testPfbQuietHoursAbsentKeyReturnsDefault(): void
 	{
@@ -775,7 +775,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'before: pfb_quiet_hours must be absent');
 
 		// When/Then: absent → default '' (no window).
-		$result = PfbConfig::read('pfb_quiet_hours');
+		$result = PfbConfig::read('gen/pfb_quiet_hours');
 		$this->assertSame('', $result, 'pfb_quiet_hours absent -> default empty string');
 	}
 
@@ -785,7 +785,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: pfb_quiet_hours is a plain-string field (no adapter).
 	 *     Given stored = '02:00-06:00'.
-	 *     When PfbConfig::write('pfb_quiet_hours', PfbConfig::read('pfb_quiet_hours')).
+	 *     When PfbConfig::write('gen/pfb_quiet_hours', PfbConfig::read('gen/pfb_quiet_hours')).
 	 *     Then stored string == '02:00-06:00' (lossless round-trip).
 	 *
 	 * Red→green: before Phase 5, read/write threw InvalidArgumentException.
@@ -802,12 +802,12 @@ final class CfgGatewayTest extends TestCase
 			"before: pfb_quiet_hours seed is '02:00-06:00'");
 
 		// When: read -> write.
-		$val = PfbConfig::read('pfb_quiet_hours');
+		$val = PfbConfig::read('gen/pfb_quiet_hours');
 		$this->assertSame('02:00-06:00', $val,
 			"read: pfb_quiet_hours '02:00-06:00' -> '02:00-06:00'");
 
 		// After: write back produces '02:00-06:00'.
-		PfbConfig::write('pfb_quiet_hours', $val);
+		PfbConfig::write('gen/pfb_quiet_hours', $val);
 		$this->assertSame('02:00-06:00', config_get_path($path),
 			"write(read('02:00-06:00'))=='02:00-06:00' for pfb_quiet_hours");
 	}
@@ -823,7 +823,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: pfb_log_trim_margin_pct is a plain-string field; default = '0'.
 	 *     Given no stored value.
-	 *     When PfbConfig::read('pfb_log_trim_margin_pct').
+	 *     When PfbConfig::read('gen/pfb_log_trim_margin_pct').
 	 *     Then '0' is returned.
 	 */
 	public function testPfbLogTrimMarginPctAbsentKeyReturnsDefaultZero(): void
@@ -834,7 +834,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'before: pfb_log_trim_margin_pct must be absent');
 
 		// When/Then: absent -> default '0'.
-		$result = PfbConfig::read('pfb_log_trim_margin_pct');
+		$result = PfbConfig::read('gen/pfb_log_trim_margin_pct');
 		$this->assertSame('0', $result, 'pfb_log_trim_margin_pct absent -> default 0');
 	}
 
@@ -844,7 +844,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: pfb_log_trim_margin_pct is a plain-string field (no adapter).
 	 *     Given stored = '50'.
-	 *     When PfbConfig::write('pfb_log_trim_margin_pct', PfbConfig::read('pfb_log_trim_margin_pct')).
+	 *     When PfbConfig::write('gen/pfb_log_trim_margin_pct', PfbConfig::read('gen/pfb_log_trim_margin_pct')).
 	 *     Then stored string == '50' (write(read('50')) == '50').
 	 */
 	public function testPfbLogTrimMarginPctRoundTrip(): void
@@ -858,11 +858,11 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('50', config_get_path($path), "before: pfb_log_trim_margin_pct seed is '50'");
 
 		// When: read -> write.
-		$val = PfbConfig::read('pfb_log_trim_margin_pct');
+		$val = PfbConfig::read('gen/pfb_log_trim_margin_pct');
 		$this->assertSame('50', $val, "read: pfb_log_trim_margin_pct '50' -> '50'");
 
 		// After: write back produces '50'.
-		PfbConfig::write('pfb_log_trim_margin_pct', $val);
+		PfbConfig::write('gen/pfb_log_trim_margin_pct', $val);
 		$this->assertSame('50', config_get_path($path), "write(read('50'))=='50' for pfb_log_trim_margin_pct");
 	}
 
@@ -885,7 +885,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('50', config_get_path($path),
 			'the section write must carry pfb_log_trim_margin_pct -- a key dropped here saves nothing from the UI'
 		);
-		$this->assertSame('50', PfbConfig::read('pfb_log_trim_margin_pct'), 'and the gateway must read it back');
+		$this->assertSame('50', PfbConfig::read('gen/pfb_log_trim_margin_pct'), 'and the gateway must read it back');
 	}
 
 	// ADR-38 — log_syslog (toggle; Amendment 1: facility/priority removed)
@@ -897,7 +897,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: log_syslog is a PfbToggle field; vocabulary = {'on', ''}.
 	 *     Given stored = 'on'.
-	 *     When PfbConfig::write('log_syslog', PfbConfig::read('log_syslog')).
+	 *     When PfbConfig::write('gen/log_syslog', PfbConfig::read('gen/log_syslog')).
 	 *     Then stored string == 'on' (write(read('on')) == 'on').
 	 */
 	public function testLogSyslogRoundTripOn(): void
@@ -911,11 +911,11 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('on', config_get_path($path), "before: log_syslog seed is 'on'");
 
 		// When: read -> write.
-		$enum = PfbConfig::read('log_syslog');
+		$enum = PfbConfig::read('gen/log_syslog');
 		$this->assertSame(PfbToggle::On, $enum, "read: log_syslog 'on' -> PfbToggle::On");
 
 		// After: write back produces 'on'.
-		PfbConfig::write('log_syslog', $enum);
+		PfbConfig::write('gen/log_syslog', $enum);
 		$this->assertSame('on', config_get_path($path), "write(read('on'))==on for log_syslog");
 	}
 
@@ -925,7 +925,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: log_syslog vocabulary = {'on', ''}.
 	 *     Given stored = '' (unchecked / off).
-	 *     When PfbConfig::write('log_syslog', PfbConfig::read('log_syslog')).
+	 *     When PfbConfig::write('gen/log_syslog', PfbConfig::read('gen/log_syslog')).
 	 *     Then stored string == '' (write(read('')) == '').
 	 */
 	public function testLogSyslogRoundTripOff(): void
@@ -939,11 +939,11 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('', config_get_path($path), "before: log_syslog seed is ''");
 
 		// When: read -> write.
-		$enum = PfbConfig::read('log_syslog');
+		$enum = PfbConfig::read('gen/log_syslog');
 		$this->assertSame(PfbToggle::Off, $enum, "read: log_syslog '' -> PfbToggle::Off");
 
 		// After: write back emits the canonical explicit 'off' (issue #1887).
-		PfbConfig::write('log_syslog', $enum);
+		PfbConfig::write('gen/log_syslog', $enum);
 		$this->assertSame('off', config_get_path($path), "write(read(''))=='off' for log_syslog");
 	}
 
@@ -953,7 +953,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: log_syslog registered default is '' (off).
 	 *     Given no stored value.
-	 *     When PfbConfig::read('log_syslog').
+	 *     When PfbConfig::read('gen/log_syslog').
 	 *     Then PfbToggle::Off is returned (registered default '').
 	 */
 	public function testLogSyslogAbsentKeyReturnsOffDefault(): void
@@ -964,7 +964,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'before: log_syslog must be absent');
 
 		// When/Then: default '' → PfbToggle::Off.
-		$result = PfbConfig::read('log_syslog');
+		$result = PfbConfig::read('gen/log_syslog');
 		$this->assertSame(PfbToggle::Off, $result, 'log_syslog absent -> Off (default)');
 	}
 
@@ -1015,7 +1015,12 @@ final class CfgGatewayTest extends TestCase
 	public function testInventoryCompletenessAllKnownKeysAccountedFor(): void
 	{
 		$registry = pfb_cfg_registry();
-		$registered_keys = array_keys($registry);
+		// issue #1931: registry keys are now '<alias>/<bare-key>'; this inventory compares
+		// against the bare config.xml names below, so strip the alias prefix back off.
+		$registered_keys = array_map(
+			static fn (string $path_key): string => substr($path_key, strpos($path_key, '/') + 1),
+			array_keys($registry)
+		);
 
 		// Out-of-scope keys — foreign, structural, or section-level (§2.5 ADR-29).
 		// Any key listed here must NOT be in the registry (it stays foreign).
@@ -1274,15 +1279,15 @@ final class CfgGatewayTest extends TestCase
 	{
 		// General section key.
 		$this->seedConfig('installedpackages/pfblockerng/config/0/pfb_interval', '6');
-		$this->assertSame('6', PfbConfig::read('pfb_interval'));
+		$this->assertSame('6', PfbConfig::read('gen/pfb_interval'));
 
 		// DNSBL settings section key.
 		$this->seedConfig('installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsport', '8080');
-		$this->assertSame('8080', PfbConfig::read('pfb_dnsport'));
+		$this->assertSame('8080', PfbConfig::read('dnsbl/pfb_dnsport'));
 
 		// SafeSearch section key (flat, no /config/0).
 		$this->seedConfig('installedpackages/pfblockerngsafesearch/safesearch_enable', 'Google');
-		$this->assertSame('Google', PfbConfig::read('safesearch_enable'));
+		$this->assertSame('Google', PfbConfig::read('ss/safesearch_enable'));
 	}
 
 	/**
@@ -1300,7 +1305,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_interval'));
 
 		// When.
-		PfbConfig::write('pfb_interval', '12');
+		PfbConfig::write('gen/pfb_interval', '12');
 
 		// After: stored.
 		$this->assertSame('12', config_get_path('installedpackages/pfblockerng/config/0/pfb_interval'));
@@ -1315,7 +1320,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path));
 
 		// When: write enum value.
-		PfbConfig::write('enable_cb', PfbToggle::On);
+		PfbConfig::write('gen/enable_cb', PfbToggle::On);
 
 		// After: stored as the string 'on', not an enum object.
 		$this->assertSame('on', config_get_path($path));
@@ -1324,7 +1329,7 @@ final class CfgGatewayTest extends TestCase
 	public function testWriteToggleFieldAcceptsLegacyStringValue(): void
 	{
 		// Regression: pfblockerng_update.php Force Reload calls
-		// PfbConfig::write('pfb_reuse', 'on') with a raw string. The toggle
+		// PfbConfig::write('gen/pfb_reuse', 'on') with a raw string. The toggle
 		// write adapter must accept it (enum-or-string contract) and store
 		// the exact legacy token — previously a TypeError.
 		$path = 'installedpackages/pfblockerng/config/0/pfb_reuse';
@@ -1333,7 +1338,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path));
 
 		// When: write the raw legacy string (not the enum).
-		PfbConfig::write('pfb_reuse', 'on');
+		PfbConfig::write('gen/pfb_reuse', 'on');
 
 		// After: stored as the string 'on'.
 		$this->assertSame('on', config_get_path($path));
@@ -1347,7 +1352,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path));
 
 		// When: write Off enum.
-		PfbConfig::write('pfb_dnsbl_lenient', PfbToggle::Off);
+		PfbConfig::write('dnsbl/pfb_dnsbl_lenient', PfbToggle::Off);
 
 		// After: stored as 'off' (not '' — PfbToggle::Off = 'off').
 		$this->assertSame('off', config_get_path($path));
@@ -1370,7 +1375,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('3', config_get_path($path), 'before: key is set');
 
 		// When.
-		PfbConfig::delete('pfb_interval');
+		PfbConfig::delete('gen/pfb_interval');
 
 		// After.
 		$this->assertNull(config_get_path($path), 'after delete: key is gone');
@@ -1489,7 +1494,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: pfb_idn stored as 'on' (canonical, = All).
 	 *     Given pfb_idn = 'on'.
-	 *     When PfbConfig::read('pfb_idn').
+	 *     When PfbConfig::read('dnsbl/pfb_idn').
 	 *     Then PfbIdnMode::All is returned (adapter is wired).
 	 *     And write(read('on')) stores 'on' (canonical identity — the backing value).
 	 */
@@ -1504,14 +1509,14 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('on', config_get_path($path));
 
 		// When: read.
-		$result = PfbConfig::read('pfb_idn');
+		$result = PfbConfig::read('dnsbl/pfb_idn');
 
 		// Then: PfbIdnMode::All (adapter IS wired — NOT raw string).
 		$this->assertInstanceOf(PfbIdnMode::class, $result, 'pfb_idn must return a PfbIdnMode enum');
 		$this->assertSame(PfbIdnMode::All, $result, "pfb_idn 'on' -> PfbIdnMode::All");
 
 		// And: write(read('on')) stores 'on' — canonical identity.
-		PfbConfig::write('pfb_idn', $result);
+		PfbConfig::write('dnsbl/pfb_idn', $result);
 		$this->assertSame('on', config_get_path($path), "write(read('on')) == 'on' for pfb_idn");
 	}
 
@@ -1526,12 +1531,12 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('all', config_get_path($path));
 
 		// When/Then: 'all' is unrecognised -> PfbIdnMode::Off (canonical block-all is 'on').
-		$result = PfbConfig::read('pfb_idn');
+		$result = PfbConfig::read('dnsbl/pfb_idn');
 		$this->assertInstanceOf(PfbIdnMode::class, $result, 'pfb_idn must return a PfbIdnMode enum');
 		$this->assertSame(PfbIdnMode::Off, $result, "pfb_idn 'all' (dropped alpha token) -> PfbIdnMode::Off");
 
 		// Write emits the canonical 'off' — 'all' is not re-emitted.
-		PfbConfig::write('pfb_idn', $result);
+		PfbConfig::write('dnsbl/pfb_idn', $result);
 		$stored = config_get_path($path);
 		$this->assertSame('off', $stored, "write(read('all')) == 'off' for pfb_idn");
 		$this->assertNotSame('all', $stored, "'all' must not be re-emitted");
@@ -1548,7 +1553,7 @@ final class CfgGatewayTest extends TestCase
 	public function testRegistryEntriesHaveRequiredShape(): void
 	{
 		$registry       = pfb_cfg_registry();
-		$required_keys  = ['section', 'default', 'read_adapter', 'write_adapter'];
+		$required_keys  = ['default', 'read_adapter', 'write_adapter'];
 
 		$this->assertNotEmpty($registry, 'Registry must not be empty');
 
@@ -1559,9 +1564,9 @@ final class CfgGatewayTest extends TestCase
 				);
 			}
 
-			// section must be a non-empty string.
-			$this->assertIsString($entry['section'],  "'{$field_key}'.section must be a string");
-			$this->assertNotEmpty($entry['section'],  "'{$field_key}'.section must not be empty");
+			// issue #1931: entries no longer carry a 'section' -- the path key's alias
+			// prefix resolves through PFB_SECTIONS instead.
+			$this->assertArrayNotHasKey('section', $entry, "'{$field_key}' must not carry a 'section' field");
 
 			// default must be a string.
 			$this->assertIsString($entry['default'],  "'{$field_key}'.default must be a string");
@@ -1640,7 +1645,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNotEmpty($log_types, 'pfb_test_log_types() must not be empty');
 
 		foreach ($log_types as $type) {
-			$key = 'log_max_days_' . $type;
+			$key = 'gen/log_max_days_' . $type;
 			$this->assertArrayHasKey($key, $registry,
 				"log_max_days_{$type} must be in the registry"
 			);
@@ -1675,7 +1680,7 @@ final class CfgGatewayTest extends TestCase
 		$cases  = [];
 		foreach ($log_types as $type) {
 			foreach ($vocab as $token) {
-				$cases["log_max_days_{$type}/{$token}"] = ["log_max_days_{$type}", $token];
+				$cases["log_max_days_{$type}/{$token}"] = ["gen/log_max_days_{$type}", $token];
 			}
 		}
 		return $cases;
@@ -1695,7 +1700,7 @@ final class CfgGatewayTest extends TestCase
 		string $key,
 		string $token
 	): void {
-		$path = 'installedpackages/pfblockerng/config/0/' . $key;
+		$path = 'installedpackages/pfblockerng/config/0/' . substr($key, strlen('gen/'));
 
 		// Given: a vocabulary token stored.
 		$this->seedConfig($path, $token);
@@ -1736,18 +1741,18 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNotEmpty($log_types, 'pfb_test_log_types() must not be empty');
 
 		foreach ($log_types as $type) {
-			$key  = 'log_max_days_' . $type;
-			$path = 'installedpackages/pfblockerng/config/0/' . $key;
+			$bare = 'log_max_days_' . $type;
+			$path = 'installedpackages/pfblockerng/config/0/' . $bare;
 
 			// Before: absent.
 			$this->assertNull(config_get_path($path),
-				"before: {$key} must be absent"
+				"before: {$bare} must be absent"
 			);
 
 			// When/Then: default '0' returned.
-			$result = PfbConfig::read($key);
+			$result = PfbConfig::read('gen/' . $bare);
 			$this->assertSame('0', $result,
-				"{$key} absent must return '0' (registered default)"
+				"{$bare} absent must return '0' (registered default)"
 			);
 		}
 	}
@@ -1759,7 +1764,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: key entirely absent from config.xml.
 	 *     Given no value seeded.
-	 *     When PfbConfig::read('log_max_ip_parse_err').
+	 *     When PfbConfig::read('gen/log_max_ip_parse_err').
 	 *     Then '20000' is returned (registered default; matches every sibling log_max_<type>).
 	 */
 	public function testLogMaxIpParseErrAbsentKeyReturnsDefault20000(): void
@@ -1770,7 +1775,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'before: log_max_ip_parse_err must be absent');
 
 		// When/Then: default '20000' returned.
-		$this->assertSame('20000', PfbConfig::read('log_max_ip_parse_err'),
+		$this->assertSame('20000', PfbConfig::read('gen/log_max_ip_parse_err'),
 			'log_max_ip_parse_err absent must return \'20000\' (registered default)'
 		);
 	}
@@ -1785,7 +1790,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: dnsbl_redir stored as 'on' (enabled) or '' (disabled).
 	 *     Given canonical stored value v in {'on', ''}.
-	 *     When PfbConfig::write('dnsbl_redir', PfbConfig::read('dnsbl_redir')).
+	 *     When PfbConfig::write('dnsbl/dnsbl_redir', PfbConfig::read('dnsbl/dnsbl_redir')).
 	 *     Then stored string equals v (write(read(v)) == v).
 	 */
 	public function testDnsblRedirToggleRoundTripOn(): void
@@ -1801,10 +1806,10 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When: read -> write.
-		$enum = PfbConfig::read('dnsbl_redir');
+		$enum = PfbConfig::read('dnsbl/dnsbl_redir');
 		$this->assertSame(PfbToggle::On, $enum, 'read: on -> PfbToggle::On');
 
-		PfbConfig::write('dnsbl_redir', $enum);
+		PfbConfig::write('dnsbl/dnsbl_redir', $enum);
 
 		// After: stored as 'on'.
 		$this->assertSame('on', config_get_path($path),
@@ -1825,10 +1830,10 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When: read -> write.
-		$enum = PfbConfig::read('dnsbl_redir');
+		$enum = PfbConfig::read('dnsbl/dnsbl_redir');
 		$this->assertSame(PfbToggle::Off, $enum, "read: '' -> PfbToggle::Off");
 
-		PfbConfig::write('dnsbl_redir', $enum);
+		PfbConfig::write('dnsbl/dnsbl_redir', $enum);
 
 		// After: stored as the canonical explicit 'off' (issue #1887).
 		$this->assertSame('off', config_get_path($path),
@@ -1842,7 +1847,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: key absent from config.
 	 *     Given no seed.
-	 *     When PfbConfig::read('dnsbl_redir').
+	 *     When PfbConfig::read('dnsbl/dnsbl_redir').
 	 *     Then PfbToggle::Off is returned (default '').
 	 */
 	public function testDnsblRedirAbsentKeyReturnsOff(): void
@@ -1855,7 +1860,7 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When/Then.
-		$result = PfbConfig::read('dnsbl_redir');
+		$result = PfbConfig::read('dnsbl/dnsbl_redir');
 		$this->assertSame(PfbToggle::Off, $result,
 			"dnsbl_redir absent -> PfbToggle::Off (default '')"
 		);
@@ -1867,7 +1872,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: plain adapter — any stored string passes through unchanged.
 	 *     Given stored value v.
-	 *     When PfbConfig::write('dnsbl_redir_int', PfbConfig::read('dnsbl_redir_int')).
+	 *     When PfbConfig::write('dnsbl/dnsbl_redir_int', PfbConfig::read('dnsbl/dnsbl_redir_int')).
 	 *     Then stored string equals v (write(read(v)) == v).
 	 */
 	public function testDnsblRedirIntPlainRoundTripNonEmpty(): void
@@ -1883,12 +1888,12 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When.
-		$value = PfbConfig::read('dnsbl_redir_int');
+		$value = PfbConfig::read('dnsbl/dnsbl_redir_int');
 		$this->assertSame('lan,opt1', $value,
 			'read: plain adapter returns raw stored string'
 		);
 
-		PfbConfig::write('dnsbl_redir_int', $value);
+		PfbConfig::write('dnsbl/dnsbl_redir_int', $value);
 
 		// After.
 		$this->assertSame('lan,opt1', config_get_path($path),
@@ -1909,10 +1914,10 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When.
-		$value = PfbConfig::read('dnsbl_redir_int');
+		$value = PfbConfig::read('dnsbl/dnsbl_redir_int');
 		$this->assertSame('', $value, "read: '' returns ''");
 
-		PfbConfig::write('dnsbl_redir_int', $value);
+		PfbConfig::write('dnsbl/dnsbl_redir_int', $value);
 
 		// After.
 		$this->assertSame('', config_get_path($path),
@@ -1926,7 +1931,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: key absent from config.
 	 *     Given no seed.
-	 *     When PfbConfig::read('dnsbl_redir_int').
+	 *     When PfbConfig::read('dnsbl/dnsbl_redir_int').
 	 *     Then '' is returned (registered default).
 	 */
 	public function testDnsblRedirIntAbsentKeyReturnsDefaultEmpty(): void
@@ -1939,7 +1944,7 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When/Then.
-		$result = PfbConfig::read('dnsbl_redir_int');
+		$result = PfbConfig::read('dnsbl/dnsbl_redir_int');
 		$this->assertSame('', $result,
 			"dnsbl_redir_int absent -> '' (registered default)"
 		);
@@ -1951,7 +1956,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: plain adapter — any stored string passes through unchanged.
 	 *     Given stored value v.
-	 *     When PfbConfig::write('dnsbl_redir_exclude', PfbConfig::read('dnsbl_redir_exclude')).
+	 *     When PfbConfig::write('dnsbl/dnsbl_redir_exclude', PfbConfig::read('dnsbl/dnsbl_redir_exclude')).
 	 *     Then stored string equals v (write(read(v)) == v).
 	 */
 	public function testDnsblRedirExcludePlainRoundTripNonEmpty(): void
@@ -1967,12 +1972,12 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When.
-		$value = PfbConfig::read('dnsbl_redir_exclude');
+		$value = PfbConfig::read('dnsbl/dnsbl_redir_exclude');
 		$this->assertSame('DNS_Whitelist', $value,
 			'read: plain adapter returns raw stored string'
 		);
 
-		PfbConfig::write('dnsbl_redir_exclude', $value);
+		PfbConfig::write('dnsbl/dnsbl_redir_exclude', $value);
 
 		// After.
 		$this->assertSame('DNS_Whitelist', config_get_path($path),
@@ -1993,10 +1998,10 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When.
-		$value = PfbConfig::read('dnsbl_redir_exclude');
+		$value = PfbConfig::read('dnsbl/dnsbl_redir_exclude');
 		$this->assertSame('', $value, "read: '' returns ''");
 
-		PfbConfig::write('dnsbl_redir_exclude', $value);
+		PfbConfig::write('dnsbl/dnsbl_redir_exclude', $value);
 
 		// After.
 		$this->assertSame('', config_get_path($path),
@@ -2010,7 +2015,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: key absent from config.
 	 *     Given no seed.
-	 *     When PfbConfig::read('dnsbl_redir_exclude').
+	 *     When PfbConfig::read('dnsbl/dnsbl_redir_exclude').
 	 *     Then '' is returned (registered default).
 	 */
 	public function testDnsblRedirExcludeAbsentKeyReturnsDefaultEmpty(): void
@@ -2023,7 +2028,7 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When/Then.
-		$result = PfbConfig::read('dnsbl_redir_exclude');
+		$result = PfbConfig::read('dnsbl/dnsbl_redir_exclude');
 		$this->assertSame('', $result,
 			"dnsbl_redir_exclude absent -> '' (registered default)"
 		);
@@ -2039,7 +2044,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: dnsbl_dot_block stored as 'on' (enabled) or '' (disabled).
 	 *     Given canonical stored value v in {'on', ''}.
-	 *     When PfbConfig::write('dnsbl_dot_block', PfbConfig::read('dnsbl_dot_block')).
+	 *     When PfbConfig::write('dnsbl/dnsbl_dot_block', PfbConfig::read('dnsbl/dnsbl_dot_block')).
 	 *     Then stored string equals v (write(read(v)) == v).
 	 */
 	public function testDnsblDotBlockToggleRoundTripOn(): void
@@ -2055,10 +2060,10 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When: read -> write.
-		$enum = PfbConfig::read('dnsbl_dot_block');
+		$enum = PfbConfig::read('dnsbl/dnsbl_dot_block');
 		$this->assertSame(PfbToggle::On, $enum, 'read: on -> PfbToggle::On');
 
-		PfbConfig::write('dnsbl_dot_block', $enum);
+		PfbConfig::write('dnsbl/dnsbl_dot_block', $enum);
 
 		// After: stored as 'on'.
 		$this->assertSame('on', config_get_path($path),
@@ -2079,10 +2084,10 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When: read -> write.
-		$enum = PfbConfig::read('dnsbl_dot_block');
+		$enum = PfbConfig::read('dnsbl/dnsbl_dot_block');
 		$this->assertSame(PfbToggle::Off, $enum, "read: '' -> PfbToggle::Off");
 
-		PfbConfig::write('dnsbl_dot_block', $enum);
+		PfbConfig::write('dnsbl/dnsbl_dot_block', $enum);
 
 		// After: stored as the canonical explicit 'off' (issue #1887).
 		$this->assertSame('off', config_get_path($path),
@@ -2096,7 +2101,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: key absent from config (feature never enabled).
 	 *     Given no seed.
-	 *     When PfbConfig::read('dnsbl_dot_block').
+	 *     When PfbConfig::read('dnsbl/dnsbl_dot_block').
 	 *     Then PfbToggle::Off is returned (default '').
 	 */
 	public function testDnsblDotBlockAbsentKeyReturnsOff(): void
@@ -2109,7 +2114,7 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When/Then.
-		$result = PfbConfig::read('dnsbl_dot_block');
+		$result = PfbConfig::read('dnsbl/dnsbl_dot_block');
 		$this->assertSame(PfbToggle::Off, $result,
 			"dnsbl_dot_block absent -> PfbToggle::Off (default '')"
 		);
@@ -2121,7 +2126,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: plain adapter — any stored string passes through unchanged.
 	 *     Given stored value v.
-	 *     When PfbConfig::write('dnsbl_dot_block_int', PfbConfig::read('dnsbl_dot_block_int')).
+	 *     When PfbConfig::write('dnsbl/dnsbl_dot_block_int', PfbConfig::read('dnsbl/dnsbl_dot_block_int')).
 	 *     Then stored string equals v (write(read(v)) == v).
 	 */
 	public function testDnsblDotBlockIntPlainRoundTripNonEmpty(): void
@@ -2137,12 +2142,12 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When.
-		$value = PfbConfig::read('dnsbl_dot_block_int');
+		$value = PfbConfig::read('dnsbl/dnsbl_dot_block_int');
 		$this->assertSame('lan,opt1', $value,
 			'read: plain adapter returns raw stored string'
 		);
 
-		PfbConfig::write('dnsbl_dot_block_int', $value);
+		PfbConfig::write('dnsbl/dnsbl_dot_block_int', $value);
 
 		// After.
 		$this->assertSame('lan,opt1', config_get_path($path),
@@ -2156,7 +2161,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: key absent from config.
 	 *     Given no seed.
-	 *     When PfbConfig::read('dnsbl_dot_block_int').
+	 *     When PfbConfig::read('dnsbl/dnsbl_dot_block_int').
 	 *     Then '' is returned (registered default).
 	 */
 	public function testDnsblDotBlockIntAbsentKeyReturnsDefaultEmpty(): void
@@ -2169,7 +2174,7 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When/Then.
-		$result = PfbConfig::read('dnsbl_dot_block_int');
+		$result = PfbConfig::read('dnsbl/dnsbl_dot_block_int');
 		$this->assertSame('', $result,
 			"dnsbl_dot_block_int absent -> '' (registered default)"
 		);
@@ -2181,7 +2186,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: plain adapter — any stored string passes through unchanged.
 	 *     Given stored value v.
-	 *     When PfbConfig::write('dnsbl_dot_block_exclude', PfbConfig::read('dnsbl_dot_block_exclude')).
+	 *     When PfbConfig::write('dnsbl/dnsbl_dot_block_exclude', PfbConfig::read('dnsbl/dnsbl_dot_block_exclude')).
 	 *     Then stored string equals v (write(read(v)) == v).
 	 */
 	public function testDnsblDotBlockExcludePlainRoundTripNonEmpty(): void
@@ -2197,12 +2202,12 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When.
-		$value = PfbConfig::read('dnsbl_dot_block_exclude');
+		$value = PfbConfig::read('dnsbl/dnsbl_dot_block_exclude');
 		$this->assertSame('DoT_Exceptions', $value,
 			'read: plain adapter returns raw stored string'
 		);
 
-		PfbConfig::write('dnsbl_dot_block_exclude', $value);
+		PfbConfig::write('dnsbl/dnsbl_dot_block_exclude', $value);
 
 		// After.
 		$this->assertSame('DoT_Exceptions', config_get_path($path),
@@ -2216,7 +2221,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: key absent from config.
 	 *     Given no seed.
-	 *     When PfbConfig::read('dnsbl_dot_block_exclude').
+	 *     When PfbConfig::read('dnsbl/dnsbl_dot_block_exclude').
 	 *     Then '' is returned (registered default).
 	 */
 	public function testDnsblDotBlockExcludeAbsentKeyReturnsDefaultEmpty(): void
@@ -2229,7 +2234,7 @@ final class CfgGatewayTest extends TestCase
 		);
 
 		// When/Then.
-		$result = PfbConfig::read('dnsbl_dot_block_exclude');
+		$result = PfbConfig::read('dnsbl/dnsbl_dot_block_exclude');
 		$this->assertSame('', $result,
 			"dnsbl_dot_block_exclude absent -> '' (registered default)"
 		);
@@ -2280,8 +2285,11 @@ final class CfgGatewayTest extends TestCase
 				"no sample set registered for adapter type '{$read_adapter}' (field '{$key}') -- extend the sample map"
 			);
 
-			$section = $entry['section'];
-			$path    = $section . '/' . $key;
+			// issue #1931: $key is now '<alias>/<bare>'; resolve the real section path
+			// via PFB_SECTIONS and use the bare part for the section-blob key.
+			[$alias, $bare] = explode('/', $key, 2);
+			$section = PFB_SECTIONS[$alias];
+			$path    = $section . '/' . $bare;
 
 			foreach ($samples_by_read_adapter[$read_adapter] as $raw) {
 				// Oracle: PfbConfig::write() on a fresh slate.
@@ -2291,7 +2299,7 @@ final class CfgGatewayTest extends TestCase
 
 				// Under test: PfbConfig::writeSection() on a fresh slate.
 				$GLOBALS['config'] = [];
-				PfbConfig::writeSection($section, [$key => $raw]);
+				PfbConfig::writeSection($section, [$bare => $raw]);
 				$actual = config_get_path($path);
 
 				$this->assertSame($expected, $actual,
@@ -2313,7 +2321,7 @@ final class CfgGatewayTest extends TestCase
 	 * THE pinning red test (mirrors the issue #930 repro): a legacy 'domcop'
 	 * top1m_source token riding a section blob write is no longer re-emitted raw --
 	 * it is coalesced to the canonical 'openpagerank' token, same as a single-key
-	 * PfbConfig::write('top1m_source', 'domcop') would.
+	 * PfbConfig::write('dnsbl/top1m_source', 'domcop') would.
 	 *
 	 * Scenario:
 	 *   Given a DNSBL settings blob with the legacy 'domcop' top1m_source token.
@@ -2689,9 +2697,9 @@ final class CfgGatewayTest extends TestCase
 	{
 		$GLOBALS['pfb_test_write_config_calls'] = [];
 
-		PfbConfig::write('pfb_keep', 'on');
-		PfbConfig::read('pfb_keep');
-		PfbConfig::delete('pfb_keep');
+		PfbConfig::write('gen/pfb_keep', 'on');
+		PfbConfig::read('gen/pfb_keep');
+		PfbConfig::delete('gen/pfb_keep');
 		PfbConfig::readSection('installedpackages/pfblockerng/config/0');
 		PfbConfig::writeSection('installedpackages/pfblockerng/config/0', ['pfb_keep' => '', 'pfb_interval' => '1']);
 		PfbConfig::deleteSection('installedpackages/pfblockerng/config/0');
@@ -2700,5 +2708,120 @@ final class CfgGatewayTest extends TestCase
 			'PfbConfig must never call write_config() -- the caller flushes');
 
 		unset($GLOBALS['pfb_test_write_config_calls']);
+	}
+
+	// -----------------------------------------------------------------------
+	// F — issue #1931: path-addressed registry parity oracle + alias-prefix gate
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Parity oracle: every fixture entry (bare key -> {section, default,
+	 * read_adapter, write_adapter, write_priv?}), captured from the pre-#1931
+	 * registry, must still resolve identically once its section is flipped to
+	 * an alias via PFB_SECTIONS and joined onto the bare key. Iterates the
+	 * FIXTURE, never the live registry -- additions to the registry stay
+	 * legal; only a removal or a changed field on an existing entry fails.
+	 */
+	public function testPathKeyedRegistryMatchesPre1931ParityFixture(): void
+	{
+		$fixture_path = __DIR__ . '/fixtures/cfg_registry_pre1931_parity.json';
+		$fixture      = json_decode((string) file_get_contents($fixture_path), TRUE);
+		$this->assertIsArray($fixture, 'parity fixture must decode to an array');
+		$this->assertCount(103, $fixture, 'parity fixture must carry exactly 103 entries (guards a truncated oracle)');
+
+		$alias_of_section = array_flip(PFB_SECTIONS);
+		$registry         = pfb_cfg_registry();
+
+		foreach ($fixture as $bare => $expected) {
+			$this->assertArrayHasKey($expected['section'], $alias_of_section,
+				"fixture entry '{$bare}': section '{$expected['section']}' has no PFB_SECTIONS alias"
+			);
+			$path_key = $alias_of_section[$expected['section']] . '/' . $bare;
+
+			$this->assertArrayHasKey($path_key, $registry,
+				"registry must still carry '{$path_key}' (fixture bare key '{$bare}')"
+			);
+			$actual = $registry[$path_key];
+
+			$this->assertSame($expected['default'], $actual['default'], "{$path_key}: default must match the fixture");
+			$this->assertSame($expected['read_adapter'], $actual['read_adapter'], "{$path_key}: read_adapter must match the fixture");
+			$this->assertSame($expected['write_adapter'], $actual['write_adapter'], "{$path_key}: write_adapter must match the fixture");
+			$this->assertSame(
+				array_key_exists('write_priv', $expected),
+				array_key_exists('write_priv', $actual),
+				"{$path_key}: write_priv presence must match the fixture"
+			);
+			if (array_key_exists('write_priv', $expected)) {
+				$this->assertSame($expected['write_priv'], $actual['write_priv'], "{$path_key}: write_priv value must match the fixture");
+			}
+		}
+	}
+
+	/**
+	 * Pure helper: one violation message per registry key that is not exactly
+	 * '<alias>/<bare>' with alias in PFB_SECTIONS and bare non-empty containing
+	 * no '/'. A typo'd alias or a bare (unprefixed) key must fail this gate
+	 * instead of silently minting a new section.
+	 *
+	 * @param  array<string,mixed> $registry
+	 * @return list<string>
+	 */
+	private static function violations(array $registry): array
+	{
+		$violations = [];
+		foreach (array_keys($registry) as $key) {
+			$slash = strpos($key, '/');
+			if ($slash === FALSE) {
+				$violations[] = "'{$key}': no alias prefix";
+				continue;
+			}
+			$alias = substr($key, 0, $slash);
+			$bare  = substr($key, $slash + 1);
+			if (!array_key_exists($alias, PFB_SECTIONS)) {
+				$violations[] = "'{$key}': unknown alias '{$alias}'";
+				continue;
+			}
+			if ($bare === '' || str_contains($bare, '/')) {
+				$violations[] = "'{$key}': malformed bare key '{$bare}'";
+			}
+		}
+		return $violations;
+	}
+
+	public function testRegistryHasNoAliasPrefixViolations(): void
+	{
+		$this->assertSame([], self::violations(pfb_cfg_registry()));
+	}
+
+	/**
+	 * Vacuity proof: violations() actually fires on the three ways a registry
+	 * key can be malformed, so testRegistryHasNoAliasPrefixViolations() is not
+	 * passing by never exercising the check.
+	 */
+	public function testViolationsHelperFiresOnEachMalformedKeyShape(): void
+	{
+		$this->assertNotEmpty(self::violations(['bogus/x' => []]), "a typo'd alias must be a violation");
+		$this->assertNotEmpty(self::violations(['nokey' => []]), 'a bare (unprefixed) key must be a violation');
+		$this->assertNotEmpty(self::violations(['gen/' => []]), 'an empty bare part must be a violation');
+	}
+
+	/**
+	 * PFB_SECTIONS integrity: its values are unique (no two aliases collide on
+	 * one section) and every value is scoped to a pfBlockerNG-owned section.
+	 */
+	public function testPfbSectionsValuesAreUniqueAndScopedToThePackage(): void
+	{
+		$this->assertSame(
+			count(PFB_SECTIONS),
+			count(array_unique(PFB_SECTIONS)),
+			'PFB_SECTIONS values must be unique'
+		);
+		foreach (PFB_SECTIONS as $alias => $path) {
+			$this->assertStringStartsWith(
+				'installedpackages/pfblockerng',
+				$path,
+				"PFB_SECTIONS['{$alias}'] must be a pfBlockerNG-owned installedpackages path"
+			);
+		}
 	}
 }

--- a/tests/php/CfgWriteAuthorizationTest.php
+++ b/tests/php/CfgWriteAuthorizationTest.php
@@ -64,7 +64,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 		];
 
 		try {
-			PfbConfig::write('pfb_keep', PfbToggle::Off);
+			PfbConfig::write('gen/pfb_keep', PfbToggle::Off);
 			$this->fail('expected RuntimeException, none thrown');
 		} catch (RuntimeException $e) {
 			$this->assertStringContainsString('pfb_keep', $e->getMessage(),
@@ -90,7 +90,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 			'pfblockerng/pfblockerng_general.php' => true,
 		];
 
-		PfbConfig::write('pfb_keep', PfbToggle::Off);
+		PfbConfig::write('gen/pfb_keep', PfbToggle::Off);
 
 		$this->assertSame('off', config_get_path($path),
 			'allowed write must persist the canonical stored token'
@@ -112,7 +112,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 		];
 
 		try {
-			PfbConfig::write('pfb_software_check', PfbToggle::Off);
+			PfbConfig::write('gen/pfb_software_check', PfbToggle::Off);
 			$this->fail('expected RuntimeException, none thrown');
 		} catch (RuntimeException $e) {
 			$this->assertStringContainsString('pfb_software_check', $e->getMessage(),
@@ -141,7 +141,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 			'pkg_mgr_installed.php'               => true,
 		];
 
-		PfbConfig::write('pfb_software_check', PfbToggle::Off);
+		PfbConfig::write('gen/pfb_software_check', PfbToggle::Off);
 
 		$this->assertSame('off', config_get_path($path),
 			'write must succeed and persist the canonical stored token'
@@ -207,7 +207,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 
 		// Oracle: single-key write() on a fresh slate.
 		$GLOBALS['config'] = [];
-		PfbConfig::write('pfb_keep', 'junk');
+		PfbConfig::write('gen/pfb_keep', 'junk');
 		$expected_keep = config_get_path(self::GEN . '/pfb_keep');
 
 		// Under test: writeSection() with the same field plus an unregistered/foreign key.
@@ -236,8 +236,8 @@ final class CfgWriteAuthorizationTest extends TestCase
 			'pkg_mgr_installed.php'                => false,
 		];
 
-		PfbConfig::writeSystem('pfb_keep', PfbToggle::On);
-		PfbConfig::writeSystem('pfb_software_check', PfbToggle::On);
+		PfbConfig::writeSystem('gen/pfb_keep', PfbToggle::On);
+		PfbConfig::writeSystem('gen/pfb_software_check', PfbToggle::On);
 
 		$this->assertSame('on', config_get_path(self::GEN . '/pfb_keep'),
 			'writeSystem() must succeed and persist the canonical token regardless of privilege'
@@ -297,7 +297,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 		$GLOBALS['pfb_test_allowed_pages'] = [
 			'pfblockerng/pfblockerng_general.php' => true,
 		];
-		PfbConfig::write('pfb_keep', PfbToggle::On);
+		PfbConfig::write('gen/pfb_keep', PfbToggle::On);
 		$expected = config_get_path($path);
 
 		$GLOBALS['config'] = [];
@@ -305,7 +305,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 		$GLOBALS['pfb_test_allowed_pages'] = [
 			'pfblockerng/pfblockerng_general.php' => false,
 		];
-		PfbConfig::writeSystem('pfb_keep', PfbToggle::On);
+		PfbConfig::writeSystem('gen/pfb_keep', PfbToggle::On);
 		$actual = config_get_path($path);
 
 		$this->assertSame($expected, $actual,

--- a/tests/php/DnsblRegexHighlightWiringTest.php
+++ b/tests/php/DnsblRegexHighlightWiringTest.php
@@ -45,7 +45,7 @@ final class DnsblRegexHighlightWiringTest extends TestCase
 	public function testGatingBooleanReadsThePfbSyntaxHighlightToggle(): void
 	{
 		// The single PHP boolean gating BOTH the asset include and the JS init must be
-		// derived from PfbConfig::read('pfb_syntax_highlight') compared against
+		// derived from PfbConfig::read('gen/pfb_syntax_highlight') compared against
 		// pfb_editor_enabled() -- the issue #1887 named accessor every editor page's
 		// pfb_cache_flush read already establishes (PfbConfig::read() returns the enum
 		// directly here, not ->value). LENIENT, not PfbToggle -- see the class docblock.

--- a/tests/php/DnsblVipDisableNoticeTest.php
+++ b/tests/php/DnsblVipDisableNoticeTest.php
@@ -93,9 +93,9 @@ final class DnsblVipDisableNoticeTest extends TestCase
 			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
 		}
 
-		PfbConfig::write('pfb_dnsbl', 'on');
-		PfbConfig::write('pfb_dnsvip_auto', '');
-		PfbConfig::write('dnsbl_interface', 'lo0');
+		PfbConfig::write('dnsbl/pfb_dnsbl', 'on');
+		PfbConfig::write('dnsbl/pfb_dnsvip_auto', '');
+		PfbConfig::write('dnsbl/dnsbl_interface', 'lo0');
 	}
 
 	public function testManualModeInvalidVipSurfacesFileNotice(): void
@@ -103,7 +103,7 @@ final class DnsblVipDisableNoticeTest extends TestCase
 		// Given: manual mode (auto='off'), a VIP id on the matching (doubled) interface
 		// but absent from the (empty) seeded vip list -> pfb_validate_vips() passes the
 		// interface check, then fails "invalid IPv4 VIP" (unresolved).
-		PfbConfig::write('dnsbl_interface', 'opt-double');
+		PfbConfig::write('dnsbl/dnsbl_interface', 'opt-double');
 		config_set_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip4', '_vip_test_missing');
 
 		// Before: no notices raised yet.
@@ -128,7 +128,7 @@ final class DnsblVipDisableNoticeTest extends TestCase
 	{
 		// Given: the SAME invalid VIP, but auto-create mode owns provisioning.
 		config_set_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip4', '_vip_test_missing');
-		PfbConfig::write('pfb_dnsvip_auto', 'on');
+		PfbConfig::write('dnsbl/pfb_dnsvip_auto', 'on');
 
 		// When
 		pfb_global();
@@ -145,7 +145,7 @@ final class DnsblVipDisableNoticeTest extends TestCase
 		// pfb_get_vips() finds it, and use the doubled 'opt-double' interface so the
 		// interface check passes too (see pfsense_doubles.php get_configured_vip_interface).
 		$GLOBALS['pfb_test_vip_list'] = ['_vip_test_valid' => '203.0.113.10'];
-		PfbConfig::write('dnsbl_interface', 'opt-double');
+		PfbConfig::write('dnsbl/dnsbl_interface', 'opt-double');
 		config_set_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip4', '_vip_test_valid');
 
 		// When

--- a/tests/php/DnsblWildcardRowValidationTest.php
+++ b/tests/php/DnsblWildcardRowValidationTest.php
@@ -83,9 +83,9 @@ final class DnsblWildcardRowValidationTest extends TestCase
 			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
 		}
 
-		PfbConfig::write('pfb_dnsbl', 'on');
-		PfbConfig::write('pfb_dnsvip_auto', '');
-		PfbConfig::write('dnsbl_interface', 'lo0');
+		PfbConfig::write('dnsbl/pfb_dnsbl', 'on');
+		PfbConfig::write('dnsbl/pfb_dnsvip_auto', '');
+		PfbConfig::write('dnsbl/dnsbl_interface', 'lo0');
 	}
 
 	private function setSuppression(string $decoded): void

--- a/tests/php/GeneralSyntaxHighlightToggleWiringTest.php
+++ b/tests/php/GeneralSyntaxHighlightToggleWiringTest.php
@@ -38,9 +38,9 @@ final class GeneralSyntaxHighlightToggleWiringTest extends TestCase
 	public function testLoadReadsThroughThePfbConfigGateway(): void
 	{
 		$this->assertMatchesRegularExpression(
-			"#\\\$pconfig\\['pfb_syntax_highlight'\\]\\s*=\\s*PfbConfig::read\\(\\s*'pfb_syntax_highlight'\\s*\\)->value#",
+			"#\\\$pconfig\\['pfb_syntax_highlight'\\]\\s*=\\s*PfbConfig::read\\(\\s*'gen/pfb_syntax_highlight'\\s*\\)->value#",
 			self::$src,
-			'expected $pconfig[\'pfb_syntax_highlight\'] to be loaded via PfbConfig::read(\'pfb_syntax_highlight\')->value, matching the log_syslog precedent'
+			'expected $pconfig[\'pfb_syntax_highlight\'] to be loaded via PfbConfig::read(\'gen/pfb_syntax_highlight\')->value, matching the log_syslog precedent'
 		);
 	}
 

--- a/tests/php/InstallGrandfatherChokepointTest.php
+++ b/tests/php/InstallGrandfatherChokepointTest.php
@@ -51,7 +51,7 @@ final class InstallGrandfatherChokepointTest extends TestCase
 				. '.*?'
 				// issue #1895: install.inc's writes are system-context (no web session),
 				// converted to the writeSystem() escape hatch.
-				. 'PfbConfig::writeSystem\(\'pfb_alias_delta_mode\', \$pfb_delta_default\);\n\}\n)/s',
+				. 'PfbConfig::writeSystem\(\'gen\/pfb_alias_delta_mode\', \$pfb_delta_default\);\n\}\n)/s',
 				$src,
 				$m
 			)) {

--- a/tests/php/LegacyKeyRenameMigrationTest.php
+++ b/tests/php/LegacyKeyRenameMigrationTest.php
@@ -174,17 +174,18 @@ final class LegacyKeyRenameMigrationTest extends TestCase
 
 		foreach (self::EXPECTED_DNSBL_RENAMES as $old => $new) {
 			$this->assertArrayNotHasKey(
-				$old,
+				'dnsbl/' . $old,
 				$registry,
 				"retired key '{$old}' must no longer be registered (it would keep a compatibility path alive)"
 			);
 		}
 
-		// The eight rows that were registered before the rename stay registered.
+		// The eight rows that were registered before the rename stay registered, under
+		// the same 'dnsbl' alias (issue #1931: PFB_SECTIONS['dnsbl'] is that real path).
+		$this->assertSame(self::DNSBL_SECTION, PFB_SECTIONS['dnsbl']);
 		foreach (['top1m_enable', 'top1m_source', 'top1m_count', 'top1m_inclusion',
 			'tld_allow', 'tld_wildcard', 'tld_wildcard_blacklist', 'tld_wildcard_exclusion'] as $new) {
-			$this->assertArrayHasKey($new, $registry, "renamed key '{$new}' must stay registered");
-			$this->assertSame(self::DNSBL_SECTION, $registry[$new]['section']);
+			$this->assertArrayHasKey('dnsbl/' . $new, $registry, "renamed key '{$new}' must stay registered");
 		}
 	}
 

--- a/tests/php/LegacyKeyRenameMigrationTest.php
+++ b/tests/php/LegacyKeyRenameMigrationTest.php
@@ -421,13 +421,21 @@ final class LegacyKeyRenameMigrationTest extends TestCase
 	 *   - `v4suppression` — pfblockerng_install.inc's ADR-53 pfBlockerNGSuppress
 	 *     alias conversion is gated on "never migrated" (absent) versus "present but
 	 *     empty", a distinction its own comment calls out;
-	 *   - `pfb_cache`, `pfb_py_reply`, `pfb_hsts` — pfblockerng_dnsbl.php renders
-	 *     these CHECKED when the key is absent (`isset(...) ? ... : 'on'`) while the
-	 *     registry default is '', so seeding '' would silently flip the first-open
-	 *     rendering, and therefore what a first save stores (issue #1907).
+	 *   - `pfb_cache`, `pfb_py_reply`, `pfb_hsts`, and (issue #1931) ip/suppression's
+	 *     `suppression` — the owning page renders CHECKED when the key is absent
+	 *     (`isset(...) ? ... : 'on'`) while the registry default is '', so seeding ''
+	 *     would silently flip the first-open rendering, and therefore what a first
+	 *     save stores (issue #1907).
 	 */
 	public function testSeedSkipsKeysWhoseAbsenceIsLoadBearing(): void
 	{
+		// issue #1931: 'ip/suppression' must be registered before the seed-exclusion
+		// guard has anything to skip -- read() throwing here means the registry entry
+		// does not exist yet (this precondition is RED for the registration reason,
+		// not only the seed-exclusion reason below).
+		$this->assertSame('', PfbConfig::read('ip/suppression'),
+			"'ip/suppression' must be registered (issue #1931)");
+
 		$changed = pfb_registered_scalars_seed([]);
 
 		$this->assertArrayNotHasKey('v4suppression', $changed[self::IP_SECTION] ?? [],
@@ -436,6 +444,14 @@ final class LegacyKeyRenameMigrationTest extends TestCase
 			$this->assertArrayNotHasKey($key, $changed[self::DNSBL_SECTION] ?? [],
 				"seeding '{$key}' would flip the DNSBL page's absent-default rendering (issue #1907)");
 		}
+		// issue #1931: ip/suppression joins the #1907-class exclusion -- same rendering
+		// hazard, different section/page.
+		$this->assertArrayNotHasKey('suppression', $changed[self::IP_SECTION] ?? [],
+			"seeding ip 'suppression' would flip the IP page's absent-default rendering (issue #1931)");
+		// Control (proves the seed actually ran over the ipsettings section instead of
+		// skipping it wholesale): v6suppression is NOT excluded and still seeds normally.
+		$this->assertSame('', $changed[self::IP_SECTION]['v6suppression'] ?? NULL,
+			'control: v6suppression still seeds normally in the ipsettings section');
 	}
 
 	/**

--- a/tests/php/LogTypesFixture.php
+++ b/tests/php/LogTypesFixture.php
@@ -14,8 +14,8 @@ function pfb_test_log_types(): array
 {
 	$types = [];
 	foreach (array_keys(pfb_cfg_registry()) as $key) {
-		if (str_starts_with($key, 'log_max_') && !str_starts_with($key, 'log_max_days_')) {
-			$types[] = substr($key, strlen('log_max_'));
+		if (str_starts_with($key, 'gen/log_max_') && !str_starts_with($key, 'gen/log_max_days_')) {
+			$types[] = substr($key, strlen('gen/log_max_'));
 		}
 	}
 	return $types;

--- a/tests/php/PfbGlobalParityTest.php
+++ b/tests/php/PfbGlobalParityTest.php
@@ -40,7 +40,7 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * enable_cb: OLD pfb_global() = $pfb['config']['enable_cb'] = null when absent.
-	 * Via gateway: PfbConfig::read('enable_cb')->value = '' (PfbToggle::Off).
+	 * Via gateway: PfbConfig::read('gen/enable_cb')->value = '' (PfbToggle::Off).
 	 * PARITY: null and '' are both falsy; downstream checks == 'on' — equivalent.
 	 * Gateway form emits '' (the registered default), which is the canonical off value.
 	 */
@@ -50,7 +50,7 @@ final class PfbGlobalParityTest extends TestCase
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/enable_cb'));
 
 		// When: gateway read.
-		$result = PfbConfig::read('enable_cb');
+		$result = PfbConfig::read('gen/enable_cb');
 
 		// Then: PfbToggle::Off -> value ''.
 		$this->assertSame(PfbToggle::Off, $result);
@@ -59,7 +59,7 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * pfb_keep: OLD pfb_global() = $pfb['config']['pfb_keep'] ?? 'on' = 'on' when absent.
-	 * Via gateway: PfbConfig::read('pfb_keep')->value = 'on' (PfbToggle::On, #484 fix).
+	 * Via gateway: PfbConfig::read('gen/pfb_keep')->value = 'on' (PfbToggle::On, #484 fix).
 	 *
 	 * #281 DEFAULT REPAIR: This is the canonical defect class. The registry default
 	 * is 'on', matching the old ?? 'on' fallback. Both old code and gateway agree.
@@ -75,7 +75,7 @@ final class PfbGlobalParityTest extends TestCase
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_keep'));
 
 		// When: gateway read (the #281-repaired registry default).
-		$result = PfbConfig::read('pfb_keep');
+		$result = PfbConfig::read('gen/pfb_keep');
 
 		// Then: 'on' — matches OLD ?? 'on' AND the repaired registry default.
 		// The merged PfbToggle adapter (issue #1887); the value is unchanged.
@@ -85,65 +85,65 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * pfb_interval: OLD = $pfb['config']['pfb_interval'] ?: '1' = '1' when absent.
-	 * Via gateway: PfbConfig::read('pfb_interval') = '1' (registered default).
+	 * Via gateway: PfbConfig::read('gen/pfb_interval') = '1' (registered default).
 	 */
 	public function testParityPfbIntervalAbsentYieldsOne(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_interval'));
 
-		$result = PfbConfig::read('pfb_interval');
+		$result = PfbConfig::read('gen/pfb_interval');
 
 		$this->assertSame('1', $result, 'pfb_interval absent -> "1"');
 	}
 
 	/**
 	 * pfb_agg_types: OLD = $pfb['config']['pfb_agg_types'] ?? '' = '' when absent.
-	 * Via gateway: PfbConfig::read('pfb_agg_types') = '' (registered default).
+	 * Via gateway: PfbConfig::read('gen/pfb_agg_types') = '' (registered default).
 	 */
 	public function testParityPfbAggTypesAbsentYieldsEmpty(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_agg_types'));
 
-		$result = PfbConfig::read('pfb_agg_types');
+		$result = PfbConfig::read('gen/pfb_agg_types');
 
 		$this->assertSame('', $result, 'pfb_agg_types absent -> ""');
 	}
 
 	/**
 	 * pfb_min: OLD = $pfb['config']['pfb_min'] ?: '0' = '0' when absent.
-	 * Via gateway: PfbConfig::read('pfb_min') = '0' (registered default).
+	 * Via gateway: PfbConfig::read('gen/pfb_min') = '0' (registered default).
 	 */
 	public function testParityPfbMinAbsentYieldsZero(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_min'));
 
-		$result = PfbConfig::read('pfb_min');
+		$result = PfbConfig::read('gen/pfb_min');
 
 		$this->assertSame('0', $result, 'pfb_min absent -> "0"');
 	}
 
 	/**
 	 * pfb_hour: OLD = $pfb['config']['pfb_hour'] ?: '0' = '0' when absent.
-	 * Via gateway: PfbConfig::read('pfb_hour') = '0' (registered default).
+	 * Via gateway: PfbConfig::read('gen/pfb_hour') = '0' (registered default).
 	 */
 	public function testParityPfbHourAbsentYieldsZero(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_hour'));
 
-		$result = PfbConfig::read('pfb_hour');
+		$result = PfbConfig::read('gen/pfb_hour');
 
 		$this->assertSame('0', $result, 'pfb_hour absent -> "0"');
 	}
 
 	/**
 	 * pfb_dailystart: OLD = $pfb['config']['pfb_dailystart'] ?: '0' = '0' when absent.
-	 * Via gateway: PfbConfig::read('pfb_dailystart') = '0' (registered default).
+	 * Via gateway: PfbConfig::read('gen/pfb_dailystart') = '0' (registered default).
 	 */
 	public function testParityPfbDailystartAbsentYieldsZero(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_dailystart'));
 
-		$result = PfbConfig::read('pfb_dailystart');
+		$result = PfbConfig::read('gen/pfb_dailystart');
 
 		$this->assertSame('0', $result, 'pfb_dailystart absent -> "0"');
 	}
@@ -151,14 +151,14 @@ final class PfbGlobalParityTest extends TestCase
 	/**
 	 * skipfeed: OLD = $pfb['config']['skipfeed'] != '' ? ... : 0 = 0 when absent
 	 * (absent key = null; null == '' in PHP, so the else branch runs -> 0).
-	 * Via gateway: PfbConfig::read('skipfeed') = '0' (registered default).
+	 * Via gateway: PfbConfig::read('gen/skipfeed') = '0' (registered default).
 	 * PARITY: '0' and 0 are equivalent for the downstream numeric comparisons.
 	 */
 	public function testParitySkipfeedAbsentYieldsZeroString(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/skipfeed'));
 
-		$result = PfbConfig::read('skipfeed');
+		$result = PfbConfig::read('gen/skipfeed');
 
 		// Registry default '0'; old code: null -> 0 (int). Numeric equivalence.
 		$this->assertSame('0', $result, 'skipfeed absent -> "0" (parity with pfb_global null->0)');
@@ -166,14 +166,14 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * pfb_reuse: OLD = $pfb['config']['pfb_reuse'] (null when absent — no adapter call in old code).
-	 * Via gateway: PfbConfig::read('pfb_reuse')->value = '' (PfbToggle::Off, default '').
+	 * Via gateway: PfbConfig::read('gen/pfb_reuse')->value = '' (PfbToggle::Off, default '').
 	 * PARITY: null and '' are both falsy; downstream checks == 'on'.
 	 */
 	public function testParityPfbReuseAbsentYieldsOff(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_reuse'));
 
-		$result = PfbConfig::read('pfb_reuse');
+		$result = PfbConfig::read('gen/pfb_reuse');
 
 		$this->assertSame(PfbToggle::Off, $result);
 		$this->assertSame('off', $result->value, 'pfb_reuse absent -> off token');
@@ -185,7 +185,7 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * pfb_dnsbl: OLD = $pfb['dnsblconfig']['pfb_dnsbl'] = null when absent.
-	 * Via gateway: PfbConfig::read('pfb_dnsbl')->value = '' (PfbToggle::Off).
+	 * Via gateway: PfbConfig::read('dnsbl/pfb_dnsbl')->value = '' (PfbToggle::Off).
 	 * PARITY: null and '' are both falsy; downstream checks !empty() or == 'on'.
 	 */
 	public function testParityPfbDnsblAbsentYieldsOff(): void
@@ -194,7 +194,7 @@ final class PfbGlobalParityTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl')
 		);
 
-		$result = PfbConfig::read('pfb_dnsbl');
+		$result = PfbConfig::read('dnsbl/pfb_dnsbl');
 
 		$this->assertSame(PfbToggle::Off, $result);
 		$this->assertSame('off', $result->value, 'pfb_dnsbl absent -> off token');
@@ -203,7 +203,7 @@ final class PfbGlobalParityTest extends TestCase
 	/**
 	 * pfb_dnsvip_auto: OLD = pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_dnsvip_auto'] ?? '')->value.
 	 * When absent: pfb_cfg_toggle_read('')->value = ''.
-	 * Via gateway: PfbConfig::read('pfb_dnsvip_auto')->value = '' (default '').
+	 * Via gateway: PfbConfig::read('dnsbl/pfb_dnsvip_auto')->value = '' (default '').
 	 * PARITY: identical.
 	 */
 	public function testParityPfbDnsvipAutoAbsentYieldsOff(): void
@@ -217,7 +217,7 @@ final class PfbGlobalParityTest extends TestCase
 		$this->assertSame('off', $old_result);
 
 		// When: gateway read.
-		$result = PfbConfig::read('pfb_dnsvip_auto');
+		$result = PfbConfig::read('dnsbl/pfb_dnsvip_auto');
 
 		// Then: same value.
 		$this->assertSame(PfbToggle::Off, $result);
@@ -228,7 +228,7 @@ final class PfbGlobalParityTest extends TestCase
 	 * dnsbl_interface: OLD = isset($pfb['dnsblconfig']['dnsbl_interface'])
 	 *                        ? $pfb['dnsblconfig']['dnsbl_interface'] : 'lo0'.
 	 * When absent: 'lo0'.
-	 * Via gateway: PfbConfig::read('dnsbl_interface') = 'lo0' (registered default).
+	 * Via gateway: PfbConfig::read('dnsbl/dnsbl_interface') = 'lo0' (registered default).
 	 * PARITY: identical.
 	 */
 	public function testParityDnsblInterfaceAbsentYieldsLo0(): void
@@ -237,7 +237,7 @@ final class PfbGlobalParityTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/dnsbl_interface')
 		);
 
-		$result = PfbConfig::read('dnsbl_interface');
+		$result = PfbConfig::read('dnsbl/dnsbl_interface');
 
 		$this->assertSame('lo0', $result, 'dnsbl_interface absent -> "lo0"');
 	}
@@ -246,7 +246,7 @@ final class PfbGlobalParityTest extends TestCase
 	 * top1m_source: OLD = isset($pfb['dnsblconfig']['top1m_source'])
 	 *                   ? $pfb['dnsblconfig']['top1m_source'] : 'tranco'.
 	 * When absent: 'tranco'.
-	 * Via gateway: PfbConfig::read('top1m_source') = PfbTop1mSource::Tranco (registered
+	 * Via gateway: PfbConfig::read('dnsbl/top1m_source') = PfbTop1mSource::Tranco (registered
 	 * default 'tranco', adapted through the PfbTop1mSource enum, issue #877 review).
 	 * PARITY: same runtime meaning ('tranco'), now enum-typed instead of a raw string.
 	 */
@@ -256,7 +256,7 @@ final class PfbGlobalParityTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/top1m_source')
 		);
 
-		$result = PfbConfig::read('top1m_source');
+		$result = PfbConfig::read('dnsbl/top1m_source');
 
 		$this->assertSame(PfbTop1mSource::Tranco, $result, 'top1m_source absent -> PfbTop1mSource::Tranco');
 	}
@@ -265,7 +265,7 @@ final class PfbGlobalParityTest extends TestCase
 	 * global_log: OLD = isset($pfb['dnsblconfig']['global_log'])
 	 *                   ? $pfb['dnsblconfig']['global_log'] : ''.
 	 * When absent: ''.
-	 * Via gateway: PfbConfig::read('global_log') = '' (registered default).
+	 * Via gateway: PfbConfig::read('dnsbl/global_log') = '' (registered default).
 	 * PARITY: identical.
 	 */
 	public function testParityGlobalLogAbsentYieldsEmpty(): void
@@ -274,7 +274,7 @@ final class PfbGlobalParityTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/global_log')
 		);
 
-		$result = PfbConfig::read('global_log');
+		$result = PfbConfig::read('dnsbl/global_log');
 
 		$this->assertSame('', $result, 'global_log absent -> ""');
 	}
@@ -282,7 +282,7 @@ final class PfbGlobalParityTest extends TestCase
 	/**
 	 * pfb_dnsbl_lenient: OLD = pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_dnsbl_lenient'] ?? '')->value.
 	 * When absent: pfb_cfg_toggle_read('')->value = 'off'.
-	 * Via gateway: PfbConfig::read('pfb_dnsbl_lenient')->value = 'off' (default 'off', lenient adapter).
+	 * Via gateway: PfbConfig::read('dnsbl/pfb_dnsbl_lenient')->value = 'off' (default 'off', lenient adapter).
 	 * PARITY: identical.
 	 */
 	public function testParityPfbDnsblLenientAbsentYieldsOff(): void
@@ -296,7 +296,7 @@ final class PfbGlobalParityTest extends TestCase
 		$this->assertSame('off', $old_result);
 
 		// When: gateway read.
-		$result = PfbConfig::read('pfb_dnsbl_lenient');
+		$result = PfbConfig::read('dnsbl/pfb_dnsbl_lenient');
 
 		// Then: same value.
 		$this->assertSame(PfbToggle::Off, $result);
@@ -305,7 +305,7 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * pfb_hsts: OLD = $pfb['dnsblconfig']['pfb_hsts'] (null when absent).
-	 * Via gateway: PfbConfig::read('pfb_hsts')->value = '' (PfbToggle::Off, default '').
+	 * Via gateway: PfbConfig::read('dnsbl/pfb_hsts')->value = '' (PfbToggle::Off, default '').
 	 * PARITY: null and '' both falsy; downstream checks == 'on'.
 	 */
 	public function testParityPfbHstsAbsentYieldsOff(): void
@@ -314,7 +314,7 @@ final class PfbGlobalParityTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts')
 		);
 
-		$result = PfbConfig::read('pfb_hsts');
+		$result = PfbConfig::read('dnsbl/pfb_hsts');
 
 		$this->assertSame(PfbToggle::Off, $result);
 		$this->assertSame('off', $result->value, 'pfb_hsts absent -> off token');
@@ -322,7 +322,7 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * pfb_idn: OLD = $pfb['dnsblconfig']['pfb_idn'] ?? '' = '' when absent (null-coalesce).
-	 * Via gateway (ADR-28 reframe): PfbConfig::read('pfb_idn') = PfbIdnMode::Off when absent.
+	 * Via gateway (ADR-28 reframe): PfbConfig::read('dnsbl/pfb_idn') = PfbIdnMode::Off when absent.
 	 *
 	 * PARITY: the registry default is '' which the PfbIdnMode adapter normalises to Off.
 	 * OLD code compared the raw string against 'on'/'all'/'confusable' — Off ('off') and
@@ -342,7 +342,7 @@ final class PfbGlobalParityTest extends TestCase
 		$this->assertSame('', $old_result, 'before: old code produces empty string for absent pfb_idn');
 
 		// When: gateway read.
-		$result = PfbConfig::read('pfb_idn');
+		$result = PfbConfig::read('dnsbl/pfb_idn');
 
 		// Then: PfbIdnMode::Off (adapted; '' normalises to Off — IDN disabled).
 		// Effective behaviour unchanged: both '' (old) and Off (new) mean IDN disabled.
@@ -355,7 +355,7 @@ final class PfbGlobalParityTest extends TestCase
 	 * pfb_idn_block_malicious: OLD = isset($pfb['dnsblconfig']['pfb_idn_block_malicious'])
 	 *                                ? $pfb['dnsblconfig']['pfb_idn_block_malicious'] : 'on'.
 	 * When absent: 'on'.
-	 * Via gateway: PfbConfig::read('pfb_idn_block_malicious') = 'on' (registered default).
+	 * Via gateway: PfbConfig::read('dnsbl/pfb_idn_block_malicious') = 'on' (registered default).
 	 * PARITY: identical.
 	 */
 	public function testParityPfbIdnBlockMaliciousAbsentYieldsOn(): void
@@ -364,14 +364,14 @@ final class PfbGlobalParityTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_block_malicious')
 		);
 
-		$result = PfbConfig::read('pfb_idn_block_malicious');
+		$result = PfbConfig::read('dnsbl/pfb_idn_block_malicious');
 
 		$this->assertSame(PfbToggle::On, $result, 'pfb_idn_block_malicious absent -> On (default-on; enum since #1887)');
 	}
 
 	/**
 	 * pfb_idn_escalate_suspicious: OLD = $pfb['dnsblconfig']['pfb_idn_escalate_suspicious'] ?? '' = '' when absent.
-	 * Via gateway: PfbConfig::read('pfb_idn_escalate_suspicious') = '' (registered default).
+	 * Via gateway: PfbConfig::read('dnsbl/pfb_idn_escalate_suspicious') = '' (registered default).
 	 * PARITY: identical.
 	 */
 	public function testParityPfbIdnEscalateSuspiciousAbsentYieldsOff(): void
@@ -380,14 +380,14 @@ final class PfbGlobalParityTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_escalate_suspicious')
 		);
 
-		$result = PfbConfig::read('pfb_idn_escalate_suspicious');
+		$result = PfbConfig::read('dnsbl/pfb_idn_escalate_suspicious');
 
 		$this->assertSame(PfbToggle::Off, $result, 'pfb_idn_escalate_suspicious absent -> Off (enum since #1887)');
 	}
 
 	/**
 	 * pfb_regex_cap: OLD = $pfb['dnsblconfig']['pfb_regex_cap'] ?? '' = '' when absent.
-	 * Via gateway: PfbConfig::read('pfb_regex_cap') = '' (registered default).
+	 * Via gateway: PfbConfig::read('dnsbl/pfb_regex_cap') = '' (registered default).
 	 * PARITY: identical.
 	 */
 	public function testParityPfbRegexCapAbsentYieldsOff(): void
@@ -396,7 +396,7 @@ final class PfbGlobalParityTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_regex_cap')
 		);
 
-		$result = PfbConfig::read('pfb_regex_cap');
+		$result = PfbConfig::read('dnsbl/pfb_regex_cap');
 
 		// issue #1887: the field gained the toggle adapter pair, so the gateway returns
 		// the enum; absent still means the feature is off, just as the raw '' did.
@@ -409,7 +409,7 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * safesearch_enable: OLD = config_get_path('installedpackages/pfblockerngsafesearch/safesearch_enable', 'Disable') = 'Disable'.
-	 * Via gateway: PfbConfig::read('safesearch_enable') = 'Disable' (registered default).
+	 * Via gateway: PfbConfig::read('ss/safesearch_enable') = 'Disable' (registered default).
 	 * PARITY: identical.
 	 */
 	public function testParitySafesearchEnableAbsentYieldsDisable(): void
@@ -421,7 +421,7 @@ final class PfbGlobalParityTest extends TestCase
 		$this->assertSame('Disable', $old_result);
 
 		// When: gateway read.
-		$result = PfbConfig::read('safesearch_enable');
+		$result = PfbConfig::read('ss/safesearch_enable');
 
 		// Then: same value.
 		$this->assertSame('Disable', $result, 'safesearch_enable absent -> "Disable"');
@@ -429,42 +429,42 @@ final class PfbGlobalParityTest extends TestCase
 
 	/**
 	 * safesearch_youtube: OLD = config_get_path(..., 'Disable') = 'Disable'.
-	 * Via gateway: PfbConfig::read('safesearch_youtube') = 'Disable'.
+	 * Via gateway: PfbConfig::read('ss/safesearch_youtube') = 'Disable'.
 	 * PARITY: identical.
 	 */
 	public function testParitySafesearchYoutubeAbsentYieldsDisable(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerngsafesearch/safesearch_youtube'));
 
-		$result = PfbConfig::read('safesearch_youtube');
+		$result = PfbConfig::read('ss/safesearch_youtube');
 
 		$this->assertSame('Disable', $result, 'safesearch_youtube absent -> "Disable"');
 	}
 
 	/**
 	 * safesearch_doh: OLD = config_get_path(..., 'Disable') = 'Disable'.
-	 * Via gateway: PfbConfig::read('safesearch_doh') = 'Disable'.
+	 * Via gateway: PfbConfig::read('ss/safesearch_doh') = 'Disable'.
 	 * PARITY: identical.
 	 */
 	public function testParitySafesearchDohAbsentYieldsDisable(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerngsafesearch/safesearch_doh'));
 
-		$result = PfbConfig::read('safesearch_doh');
+		$result = PfbConfig::read('ss/safesearch_doh');
 
 		$this->assertSame('Disable', $result, 'safesearch_doh absent -> "Disable"');
 	}
 
 	/**
 	 * safesearch_doh_list: OLD = config_get_path(..., '') = '' -> explode -> [''].
-	 * Via gateway: PfbConfig::read('safesearch_doh_list') = '' -> explode -> [''].
+	 * Via gateway: PfbConfig::read('ss/safesearch_doh_list') = '' -> explode -> [''].
 	 * PARITY: identical.
 	 */
 	public function testParitySafesearchDohListAbsentYieldsEmpty(): void
 	{
 		$this->assertNull(config_get_path('installedpackages/pfblockerngsafesearch/safesearch_doh_list'));
 
-		$result = PfbConfig::read('safesearch_doh_list');
+		$result = PfbConfig::read('ss/safesearch_doh_list');
 
 		$this->assertSame('', $result, 'safesearch_doh_list absent -> ""');
 
@@ -483,7 +483,7 @@ final class PfbGlobalParityTest extends TestCase
 	 *
 	 * The old pfb_global() code: $pfb['keep'] = $pfb['config']['pfb_keep'] ?? 'on'.
 	 * The registry default: 'on'.
-	 * After routing to PfbConfig::read('pfb_keep')->value: 'on'.
+	 * After routing to PfbConfig::read('gen/pfb_keep')->value: 'on'.
 	 * RESULT: no behaviour change — both old code and gateway agree on 'on'.
 	 *
 	 * The structural fix: the default is now FORMAL (in the registry) instead of
@@ -500,7 +500,7 @@ final class PfbGlobalParityTest extends TestCase
 		$this->assertNull(config_get_path('installedpackages/pfblockerng/config/0/pfb_keep'));
 
 		// When: gateway read (the formal registry default).
-		$result = PfbConfig::read('pfb_keep');
+		$result = PfbConfig::read('gen/pfb_keep');
 
 		// Then: value is 'on' — same as old ?? 'on' fallback.
 		// The #281 class is now structurally closed: the default is formal,
@@ -514,7 +514,7 @@ final class PfbGlobalParityTest extends TestCase
 		// resolves to the registered default 'on'. A deliberate opt-out is the explicit
 		// 'off' token, which round-trips (testPfbKeepRoundTrip* in CfgGatewayTest).
 		config_set_path('installedpackages/pfblockerng/config/0/pfb_keep', '');
-		$result_empty = PfbConfig::read('pfb_keep');
+		$result_empty = PfbConfig::read('gen/pfb_keep');
 		$this->assertSame(PfbToggle::On, $result_empty, "stored '' pfb_keep resolves to the registered default On");
 	}
 }

--- a/tests/php/PfbSettingsFamilyTest.php
+++ b/tests/php/PfbSettingsFamilyTest.php
@@ -37,15 +37,15 @@ final class PfbSettingsFamilyTest extends TestCase
 	public function testMissingMarkerDefaultsToThreeTwoAndRecordUsesGateway(): void
 	{
 		$this->assertSame('3.2', pfb_settings_family_current());
-		$this->assertSame('3.2', PfbConfig::read('settings_family'));
+		$this->assertSame('3.2', PfbConfig::read('gen/settings_family'));
 		$this->assertTrue(pfb_settings_family_record('4.0'));
 		$this->assertSame('4.0', pfb_settings_family_current());
-		$this->assertSame('4.0', PfbConfig::read('settings_family'));
+		$this->assertSame('4.0', PfbConfig::read('gen/settings_family'));
 	}
 
 	public function testInvalidMarkerAndUnknownVersionFailClosed(): void
 	{
-		PfbConfig::write('settings_family', '9.0');
+		PfbConfig::write('gen/settings_family', '9.0');
 		$this->assertNull(pfb_settings_family_current());
 		$this->assertSame('3.2', pfb_settings_family_from_version('3.2.0'));
 		$this->assertSame('4.0', pfb_settings_family_from_version('4.0.0'));
@@ -158,9 +158,9 @@ final class PfbSettingsFamilyTest extends TestCase
 
 	public function testKeepOffIsPreservedAtLegacyBoundary(): void
 	{
-		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_keep'));
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('gen/pfb_keep'));
 		$this->assertTrue(pfb_settings_family_save('3.2'));
-		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_keep'));
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('gen/pfb_keep'));
 	}
 
 	public function testSaveWithNoOwnedConfigIsNoOpWithoutCreatingSlot(): void

--- a/tests/php/PythonWhitelistTldSegTest.php
+++ b/tests/php/PythonWhitelistTldSegTest.php
@@ -80,9 +80,9 @@ final class PythonWhitelistTldSegTest extends TestCase
 			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
 		}
 
-		PfbConfig::write('pfb_dnsbl', 'on');
-		PfbConfig::write('pfb_dnsvip_auto', '');
-		PfbConfig::write('dnsbl_interface', 'lo0');
+		PfbConfig::write('dnsbl/pfb_dnsbl', 'on');
+		PfbConfig::write('dnsbl/pfb_dnsvip_auto', '');
+		PfbConfig::write('dnsbl/dnsbl_interface', 'lo0');
 	}
 
 	private function setSuppression(string $decoded): void

--- a/tests/php/QuietHoursApplyTest.php
+++ b/tests/php/QuietHoursApplyTest.php
@@ -30,7 +30,7 @@ use PHPUnit\Framework\TestCase;
  *   pfb_quiet_hours_in_window()  → "Call to undefined function pfb_quiet_hours_in_window()"
  *   pfb_due_ledger_set_pending() → "Call to undefined function pfb_due_ledger_set_pending()"
  *   pfb_due_ledger_is_pending()  → "Call to undefined function pfb_due_ledger_is_pending()"
- *   PfbConfig::read('pfb_quiet_hours') → InvalidArgumentException (key not registered)
+ *   PfbConfig::read('gen/pfb_quiet_hours') → InvalidArgumentException (key not registered)
  */
 final class QuietHoursApplyTest extends TestCase
 {

--- a/tests/php/SniffRegistryParityTest.php
+++ b/tests/php/SniffRegistryParityTest.php
@@ -38,8 +38,11 @@ final class SniffRegistryParityTest extends TestCase
 		$actual = (array) (new \PfBlockerNG\Sniffs\Config\RequireConfigGatewaySniff())->registeredPaths;
 
 		$expected = [];
-		foreach (pfb_cfg_registry() as $key => $entry) {
-			$expected[] = $entry['section'] . '/' . $key;
+		foreach (pfb_cfg_registry() as $path_key => $entry) {
+			// issue #1931: $path_key is '<alias>/<bare-key>'; resolve the alias to the
+			// real section path via PFB_SECTIONS.
+			[$alias, $bare] = explode('/', $path_key, 2);
+			$expected[] = PFB_SECTIONS[$alias] . '/' . $bare;
 		}
 
 		$missing = array_values(array_diff($expected, $actual));

--- a/tests/php/SniffRegistryParityTest.php
+++ b/tests/php/SniffRegistryParityTest.php
@@ -38,7 +38,7 @@ final class SniffRegistryParityTest extends TestCase
 		$actual = (array) (new \PfBlockerNG\Sniffs\Config\RequireConfigGatewaySniff())->registeredPaths;
 
 		$expected = [];
-		foreach (pfb_cfg_registry() as $path_key => $entry) {
+		foreach (array_keys(pfb_cfg_registry()) as $path_key) {
 			// issue #1931: $path_key is '<alias>/<bare-key>'; resolve the alias to the
 			// real section path via PFB_SECTIONS.
 			[$alias, $bare] = explode('/', $path_key, 2);

--- a/tests/php/ToggleAdapterAdoptionTest.php
+++ b/tests/php/ToggleAdapterAdoptionTest.php
@@ -45,7 +45,7 @@ final class ToggleAdapterAdoptionTest extends TestCase
 		$this->assertNull(config_get_path(self::FEED));
 		$this->assertSame(
 			PfbToggle::On,
-			PfbConfig::read('pfb_feed_internal_filter'),
+			PfbConfig::read('gen/pfb_feed_internal_filter'),
 			'absent pfb_feed_internal_filter must read as the registered default On, as the enum'
 		);
 	}
@@ -93,7 +93,7 @@ final class ToggleAdapterAdoptionTest extends TestCase
 		$this->assertNull(config_get_path(self::SW));
 		$this->assertSame(
 			PfbToggle::On,
-			PfbConfig::read('pfb_software_check'),
+			PfbConfig::read('gen/pfb_software_check'),
 			'absent pfb_software_check must read as the registered default On, as the enum'
 		);
 	}
@@ -123,7 +123,7 @@ final class ToggleAdapterAdoptionTest extends TestCase
 	 */
 	public function testSoftwareCheckUncheckedSaveRoundTrips(): void
 	{
-		PfbConfig::write('pfb_software_check', PfbToggle::Off);
+		PfbConfig::write('gen/pfb_software_check', PfbToggle::Off);
 		$this->assertSame('off', config_get_path(self::SW), 'Off must persist as the explicit off token');
 		$this->assertFalse(pfb_software_check_enabled(), 'the persisted off must read back as disabled');
 	}

--- a/tests/php/ToggleCaseInsensitiveTest.php
+++ b/tests/php/ToggleCaseInsensitiveTest.php
@@ -73,10 +73,10 @@ final class ToggleCaseInsensitiveTest extends TestCase
 		config_set_path(self::KEEP, 'ON');
 		$this->assertSame('ON', config_get_path(self::KEEP), "before: pfb_keep seed is 'ON'");
 
-		$enum = PfbConfig::read('pfb_keep');
+		$enum = PfbConfig::read('gen/pfb_keep');
 		$this->assertSame(PfbToggle::On, $enum, "stored 'ON' must read as On, not fall back to Off");
 
-		PfbConfig::write('pfb_keep', $enum);
+		PfbConfig::write('gen/pfb_keep', $enum);
 		$this->assertSame('on', config_get_path(self::KEEP), "write must re-emit the canonical lowercase 'on'");
 	}
 

--- a/tests/php/ToggleEmptyPreservationTest.php
+++ b/tests/php/ToggleEmptyPreservationTest.php
@@ -55,7 +55,7 @@ final class ToggleEmptyPreservationTest extends TestCase
 
 		$this->assertSame('off', config_get_path(self::KEEP),
 			"a pre-#1887 stored '' on pfb_keep must be rewritten to the explicit 'off' it meant");
-		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_keep'),
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('gen/pfb_keep'),
 			'the preserved opt-out must read as Off, not resolve to the default-on');
 	}
 
@@ -71,7 +71,7 @@ final class ToggleEmptyPreservationTest extends TestCase
 
 		$this->assertSame('off', config_get_path(self::IDN),
 			"a pre-#1887 stored '' on pfb_idn_block_malicious must be preserved as 'off'");
-		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_idn_block_malicious'),
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('dnsbl/pfb_idn_block_malicious'),
 			'the preserved opt-out must read as Off');
 	}
 
@@ -94,8 +94,8 @@ final class ToggleEmptyPreservationTest extends TestCase
 		$this->assertSame('on', config_get_path(self::KEEP),
 			'absent pfb_keep on an existing install is seeded on by the #281 migration, as before');
 		$this->assertNull(config_get_path(self::IDN), 'absent pfb_idn_block_malicious must stay absent');
-		$this->assertSame(PfbToggle::On, PfbConfig::read('pfb_keep'));
-		$this->assertSame(PfbToggle::On, PfbConfig::read('pfb_idn_block_malicious'));
+		$this->assertSame(PfbToggle::On, PfbConfig::read('gen/pfb_keep'));
+		$this->assertSame(PfbToggle::On, PfbConfig::read('dnsbl/pfb_idn_block_malicious'));
 	}
 
 	/**
@@ -133,7 +133,7 @@ final class ToggleEmptyPreservationTest extends TestCase
 
 		$this->assertSame('off', config_get_path(self::IDN),
 			'an unchecked save must persist the explicit off token');
-		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_idn_block_malicious'),
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('dnsbl/pfb_idn_block_malicious'),
 			'an unchecked save must read back as disabled — not resolve to the default-on');
 	}
 

--- a/tests/php/ToggleMergeTest.php
+++ b/tests/php/ToggleMergeTest.php
@@ -59,7 +59,7 @@ final class ToggleMergeTest extends TestCase
 	 */
 	public function testWritingOffStoresTheExplicitOffToken(): void
 	{
-		foreach (['pfb_keep' => self::KEEP, 'enable_cb' => self::ENABLE] as $key => $path) {
+		foreach (['gen/pfb_keep' => self::KEEP, 'gen/enable_cb' => self::ENABLE] as $key => $path) {
 			PfbConfig::write($key, PfbToggle::Off);
 			$this->assertSame(
 				'off',
@@ -78,7 +78,7 @@ final class ToggleMergeTest extends TestCase
 	 */
 	public function testStoredOffReadsAsOffAndRoundTrips(): void
 	{
-		foreach (['pfb_keep' => self::KEEP, 'enable_cb' => self::ENABLE] as $key => $path) {
+		foreach (['gen/pfb_keep' => self::KEEP, 'gen/enable_cb' => self::ENABLE] as $key => $path) {
 			config_set_path($path, 'off');
 			$this->assertSame('off', config_get_path($path), "before: {$key} seed is 'off'");
 
@@ -100,11 +100,11 @@ final class ToggleMergeTest extends TestCase
 	 */
 	public function testExplicitOffOnDefaultOnFieldSurvives(): void
 	{
-		PfbConfig::write('pfb_syntax_highlight', PfbToggle::Off);
+		PfbConfig::write('gen/pfb_syntax_highlight', PfbToggle::Off);
 
 		$this->assertSame(
 			PfbToggle::Off,
-			PfbConfig::read('pfb_syntax_highlight'),
+			PfbConfig::read('gen/pfb_syntax_highlight'),
 			'a deliberate Off on a default-on field must not read back as On'
 		);
 	}
@@ -127,14 +127,14 @@ final class ToggleMergeTest extends TestCase
 		$this->assertSame('', config_get_path(self::KEEP), "before: pfb_keep seed is ''");
 		$this->assertSame(
 			PfbToggle::On,
-			PfbConfig::read('pfb_keep'),
+			PfbConfig::read('gen/pfb_keep'),
 			"pfb_keep: stored '' must resolve to the registered default 'on', as an absent key does"
 		);
 
 		config_set_path(self::ENABLE, '');
 		$this->assertSame(
 			PfbToggle::Off,
-			PfbConfig::read('enable_cb'),
+			PfbConfig::read('gen/enable_cb'),
 			"enable_cb: stored '' must resolve to the registered default '', i.e. Off"
 		);
 	}
@@ -147,10 +147,10 @@ final class ToggleMergeTest extends TestCase
 	 */
 	public function testStoredEmptyStringIsIndistinguishableFromAbsent(): void
 	{
-		$absent = PfbConfig::read('pfb_keep');
+		$absent = PfbConfig::read('gen/pfb_keep');
 
 		config_set_path(self::KEEP, '');
-		$empty = PfbConfig::read('pfb_keep');
+		$empty = PfbConfig::read('gen/pfb_keep');
 
 		$this->assertSame($absent, $empty, "pfb_keep: stored '' must read identically to an absent key");
 	}
@@ -169,14 +169,14 @@ final class ToggleMergeTest extends TestCase
 	{
 		config_set_path(self::KEEP, '');
 
-		$read_before = PfbConfig::read('pfb_keep');
+		$read_before = PfbConfig::read('gen/pfb_keep');
 
 		// A save of the section exactly as loaded — the shape every www/ save handler uses.
 		PfbConfig::writeSection(self::GENERAL_SECTION, PfbConfig::readSection(self::GENERAL_SECTION));
 
 		$this->assertSame(
 			$read_before,
-			PfbConfig::read('pfb_keep'),
+			PfbConfig::read('gen/pfb_keep'),
 			'pfb_keep: a section save must not change what the field reads as'
 		);
 		$this->assertSame(
@@ -195,7 +195,7 @@ final class ToggleMergeTest extends TestCase
 	 */
 	public function testWriteResolvesLegacyEmptyStringToTheDefault(): void
 	{
-		PfbConfig::write('pfb_keep', '');
+		PfbConfig::write('gen/pfb_keep', '');
 
 		$this->assertSame(
 			'on',
@@ -232,9 +232,9 @@ final class ToggleMergeTest extends TestCase
 	public function testExLenientFieldsUseTheToggleAdapter(): void
 	{
 		$fields = [
-			'pfb_keep'             => ['path' => self::KEEP,   'default' => PfbToggle::On],
-			'pfb_syntax_highlight' => ['path' => self::SYNTAX, 'default' => PfbToggle::On],
-			'pfb_dnsbl_lenient'    => [
+			'gen/pfb_keep'             => ['path' => self::KEEP,   'default' => PfbToggle::On],
+			'gen/pfb_syntax_highlight' => ['path' => self::SYNTAX, 'default' => PfbToggle::On],
+			'dnsbl/pfb_dnsbl_lenient'  => [
 				'path'    => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_lenient',
 				'default' => PfbToggle::Off,
 			],

--- a/tests/php/ToggleMirrorTypeTest.php
+++ b/tests/php/ToggleMirrorTypeTest.php
@@ -94,7 +94,7 @@ final class ToggleMirrorTypeTest extends TestCase
 			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
 		}
 
-		PfbConfig::write('dnsbl_interface', 'lo0');
+		PfbConfig::write('dnsbl/dnsbl_interface', 'lo0');
 	}
 
 	/**
@@ -105,8 +105,8 @@ final class ToggleMirrorTypeTest extends TestCase
 	 */
 	public function testEveryToggleMirrorIsAPfbToggleInstance(): void
 	{
-		PfbConfig::write('enable_cb', PfbToggle::On);
-		PfbConfig::write('pfb_dnsbl', PfbToggle::On);
+		PfbConfig::write('gen/enable_cb', PfbToggle::On);
+		PfbConfig::write('dnsbl/pfb_dnsbl', PfbToggle::On);
 
 		pfb_global();
 
@@ -128,15 +128,15 @@ final class ToggleMirrorTypeTest extends TestCase
 	 */
 	public function testEnabledStateSurfacesAsOn(): void
 	{
-		PfbConfig::write('enable_cb', PfbToggle::On);
-		PfbConfig::write('pfb_dnsbl', PfbToggle::On);
+		PfbConfig::write('gen/enable_cb', PfbToggle::On);
+		PfbConfig::write('dnsbl/pfb_dnsbl', PfbToggle::On);
 
 		// A resolvable VIP on the doubled interface, so pfb_global()'s VIP validation
 		// does not force-disable DNSBL — otherwise this asserts On against a value the
 		// production code is right to have turned Off, and proves nothing about typing.
 		// Same setup as DnsblVipDisableNoticeTest::testValidVipDoesNotSurfaceNotice().
 		$GLOBALS['pfb_test_vip_list'] = ['_vip_test_valid' => '203.0.113.10'];
-		PfbConfig::write('dnsbl_interface', 'opt-double');
+		PfbConfig::write('dnsbl/dnsbl_interface', 'opt-double');
 		config_set_path(
 			'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip4',
 			'_vip_test_valid'
@@ -153,8 +153,8 @@ final class ToggleMirrorTypeTest extends TestCase
 	 */
 	public function testDisabledStateSurfacesAsOff(): void
 	{
-		PfbConfig::write('enable_cb', PfbToggle::Off);
-		PfbConfig::write('pfb_dnsbl', PfbToggle::Off);
+		PfbConfig::write('gen/enable_cb', PfbToggle::Off);
+		PfbConfig::write('dnsbl/pfb_dnsbl', PfbToggle::Off);
 
 		pfb_global();
 
@@ -173,10 +173,10 @@ final class ToggleMirrorTypeTest extends TestCase
 	 */
 	public function testForceDisableOnInvalidVipPublishesOffNotEmptyString(): void
 	{
-		PfbConfig::write('enable_cb', PfbToggle::On);
-		PfbConfig::write('pfb_dnsbl', PfbToggle::On);
-		PfbConfig::write('pfb_dnsvip_auto', PfbToggle::Off);
-		PfbConfig::write('dnsbl_interface', 'opt-double');
+		PfbConfig::write('gen/enable_cb', PfbToggle::On);
+		PfbConfig::write('dnsbl/pfb_dnsbl', PfbToggle::On);
+		PfbConfig::write('dnsbl/pfb_dnsvip_auto', PfbToggle::Off);
+		PfbConfig::write('dnsbl/dnsbl_interface', 'opt-double');
 		config_set_path(
 			'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip4',
 			'_vip_test_missing'
@@ -201,8 +201,8 @@ final class ToggleMirrorTypeTest extends TestCase
 	 */
 	public function testNoToggleMirrorHoldsARawToken(): void
 	{
-		PfbConfig::write('enable_cb', PfbToggle::On);
-		PfbConfig::write('pfb_dnsbl', PfbToggle::On);
+		PfbConfig::write('gen/enable_cb', PfbToggle::On);
+		PfbConfig::write('dnsbl/pfb_dnsbl', PfbToggle::On);
 
 		pfb_global();
 

--- a/tests/php/ToggleSectionMirrorTypeTest.php
+++ b/tests/php/ToggleSectionMirrorTypeTest.php
@@ -95,7 +95,7 @@ final class ToggleSectionMirrorTypeTest extends TestCase
 			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
 		}
 
-		PfbConfig::write('dnsbl_interface', 'lo0');
+		PfbConfig::write('dnsbl/dnsbl_interface', 'lo0');
 	}
 
 	/** Seed every section-mirror key to one raw token. */

--- a/tests/php/Top1mDownloadSemanticValidationTest.php
+++ b/tests/php/Top1mDownloadSemanticValidationTest.php
@@ -75,7 +75,7 @@ final class Top1mDownloadSemanticValidationTest extends TestCase
 		$before = $this->seedLastGoodState($base, $active);
 		$body = "<!doctype html>\n<html><body><h1>503 Service Unavailable</h1></body></html>\n";
 
-		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_feed_sanity'), 'sanity setting must be off for this gate proof');
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('gen/pfb_feed_sanity'), 'sanity setting must be off for this gate proof');
 		$result = $this->downloadBody($body, $base, $active);
 
 		$this->assertFalse($result->success, 'HTML 200 must fail TOP1M semantic publication even with sanity disabled');

--- a/tests/php/WwwGroupAGatewayTest.php
+++ b/tests/php/WwwGroupAGatewayTest.php
@@ -55,7 +55,7 @@ final class WwwGroupAGatewayTest extends TestCase
 	 * pfb_keep: page used `isset($pfb['gconfig']['pfb_keep']) ? ... : 'on'` — default 'on'.
 	 * Registry default = 'on' (PfbToggle::On after #484 fix). Page default REMOVED; gateway owns it.
 	 *
-	 * Parity: absent key → PfbConfig::read('pfb_keep')->value === 'on' (was: 'on').
+	 * Parity: absent key → PfbConfig::read('gen/pfb_keep')->value === 'on' (was: 'on').
 	 * (#484 gave pfb_keep an explicit-off adapter; #1887 merged it back into PfbToggle,
 	 * whose Off now stores 'off' — the value is unchanged throughout.)
 	 */
@@ -67,7 +67,7 @@ final class WwwGroupAGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'pfb_keep must be absent for this test');
 
 		// When: gateway read (replaces the removed isset() ? ... : 'on').
-		$result = PfbConfig::read('pfb_keep');
+		$result = PfbConfig::read('gen/pfb_keep');
 
 		// Then: PfbToggle::On, value 'on' — matches prior page default 'on'.
 		// (#484 fix: pfb_keep now uses the lenient adapter; the value is unchanged.)
@@ -79,7 +79,7 @@ final class WwwGroupAGatewayTest extends TestCase
 	 * pfb_feed_internal_filter: page used `isset(...) ? ... : 'on'` — default 'on'.
 	 * Registry default = 'on'. Page default REMOVED; gateway owns it.
 	 *
-	 * Parity: absent key → PfbConfig::read('pfb_feed_internal_filter') === 'on'.
+	 * Parity: absent key → PfbConfig::read('gen/pfb_feed_internal_filter') === 'on'.
 	 */
 	public function testGeneralPfbFeedInternalFilterAbsentDefaultMatchesPriorPageDefault(): void
 	{
@@ -89,7 +89,7 @@ final class WwwGroupAGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'pfb_feed_internal_filter must be absent');
 
 		// When: gateway read (replaces the removed isset() ? ... : 'on').
-		$result = PfbConfig::read('pfb_feed_internal_filter');
+		$result = PfbConfig::read('gen/pfb_feed_internal_filter');
 
 		// Then: On — matches prior page default ('on'); the enum since issue #1887.
 		$this->assertSame(PfbToggle::On, $result, 'pfb_feed_internal_filter absent -> On (parity with prior isset default)');
@@ -105,17 +105,17 @@ final class WwwGroupAGatewayTest extends TestCase
 	{
 		// pfb_cache: registry default = '' (mismatch with page default 'on').
 		$this->assertNull(config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache'));
-		$pfb_cache_registry_default = PfbConfig::read('pfb_cache');
+		$pfb_cache_registry_default = PfbConfig::read('dnsbl/pfb_cache');
 		$this->assertSame('', $pfb_cache_registry_default, 'pfb_cache registry default is "" — page isset default "on" was correctly kept');
 
 		// pfb_py_reply: registry default = '' (mismatch with page default 'on').
 		$this->assertNull(config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_py_reply'));
-		$pfb_py_reply_registry_default = PfbConfig::read('pfb_py_reply');
+		$pfb_py_reply_registry_default = PfbConfig::read('dnsbl/pfb_py_reply');
 		$this->assertSame('', $pfb_py_reply_registry_default, 'pfb_py_reply registry default is "" — page isset default "on" was correctly kept');
 
 		// pfb_hsts: registry default = '' (mismatch with page default 'on').
 		$this->assertNull(config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts'));
-		$pfb_hsts_registry_default = PfbConfig::read('pfb_hsts');
+		$pfb_hsts_registry_default = PfbConfig::read('dnsbl/pfb_hsts');
 		$this->assertInstanceOf(PfbToggle::class, $pfb_hsts_registry_default, 'pfb_hsts is toggle-adapted');
 		$this->assertSame(PfbToggle::Off, $pfb_hsts_registry_default, 'pfb_hsts registry default is Off ("") — page isset default "on" was correctly kept');
 	}
@@ -128,7 +128,7 @@ final class WwwGroupAGatewayTest extends TestCase
 	 * pfb_idn_block_malicious: page used `isset(...) ? ... : 'on'` — default 'on'.
 	 * Registry default = 'on'. Page default REMOVED; gateway owns it.
 	 *
-	 * Parity: absent key → PfbConfig::read('pfb_idn_block_malicious') === 'on'.
+	 * Parity: absent key → PfbConfig::read('dnsbl/pfb_idn_block_malicious') === 'on'.
 	 */
 	public function testDnsblPfbIdnBlockMaliciousAbsentDefaultMatchesPriorPageDefault(): void
 	{
@@ -138,7 +138,7 @@ final class WwwGroupAGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'pfb_idn_block_malicious must be absent');
 
 		// When: gateway read (replaces the removed isset() ? ... : 'on').
-		$result = PfbConfig::read('pfb_idn_block_malicious');
+		$result = PfbConfig::read('dnsbl/pfb_idn_block_malicious');
 
 		// Then: 'on' — matches prior page default.
 		$this->assertSame(PfbToggle::On, $result, 'pfb_idn_block_malicious absent -> On (parity with prior isset default)');

--- a/tests/php/WwwGroupBGatewayTest.php
+++ b/tests/php/WwwGroupBGatewayTest.php
@@ -68,7 +68,7 @@ final class WwwGroupBGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'safesearch_enable must be absent for this test');
 
 		// When: gateway read.
-		$result = PfbConfig::read('safesearch_enable');
+		$result = PfbConfig::read('ss/safesearch_enable');
 
 		// Then: 'Disable' — matches prior page default '?: Disable'.
 		$this->assertSame('Disable', $result, 'safesearch_enable absent -> "Disable" (parity with prior page default)');
@@ -86,7 +86,7 @@ final class WwwGroupBGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'safesearch_youtube must be absent');
 
 		// When: gateway read.
-		$result = PfbConfig::read('safesearch_youtube');
+		$result = PfbConfig::read('ss/safesearch_youtube');
 
 		// Then: 'Disable' — matches prior page default.
 		$this->assertSame('Disable', $result, 'safesearch_youtube absent -> "Disable" (parity with prior page default)');
@@ -104,7 +104,7 @@ final class WwwGroupBGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'safesearch_doh must be absent');
 
 		// When: gateway read.
-		$result = PfbConfig::read('safesearch_doh');
+		$result = PfbConfig::read('ss/safesearch_doh');
 
 		// Then: 'Disable' — matches prior page default.
 		$this->assertSame('Disable', $result, 'safesearch_doh absent -> "Disable" (parity with prior page default)');
@@ -124,7 +124,7 @@ final class WwwGroupBGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'safesearch_doh_list must be absent');
 
 		// When: gateway read returns the registry default string.
-		$result = PfbConfig::read('safesearch_doh_list');
+		$result = PfbConfig::read('ss/safesearch_doh_list');
 
 		// Then: '' — the page's ?: array() guard on explode('', '') protects the UI;
 		// the stored/registry value is '' confirming no divergence.

--- a/tests/php/WwwGroupCGatewayTest.php
+++ b/tests/php/WwwGroupCGatewayTest.php
@@ -69,7 +69,7 @@ final class WwwGroupCGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'pfb_software_check must be absent before read');
 
 		// When: gateway read.
-		$result = PfbConfig::read('pfb_software_check');
+		$result = PfbConfig::read('gen/pfb_software_check');
 
 		// Then: On — issue #1887 moved the effective ON default from the hand-written
 		// reader (`!== 'off'`) into the registry; absent still means enabled.
@@ -82,19 +82,19 @@ final class WwwGroupCGatewayTest extends TestCase
 	public function testSoftwareCheckToggleRoundTrips(): void
 	{
 		// Before: absent → the registered default On (issue #1887).
-		$this->assertSame(PfbToggle::On, PfbConfig::read('pfb_software_check'), 'initial absent -> On');
+		$this->assertSame(PfbToggle::On, PfbConfig::read('gen/pfb_software_check'), 'initial absent -> On');
 
 		// When: write 'on'.
-		PfbConfig::write('pfb_software_check', 'on');
+		PfbConfig::write('gen/pfb_software_check', 'on');
 
 		// Then: read back On.
-		$this->assertSame(PfbToggle::On, PfbConfig::read('pfb_software_check'), 'after write "on" -> On');
+		$this->assertSame(PfbToggle::On, PfbConfig::read('gen/pfb_software_check'), 'after write "on" -> On');
 
 		// When: write 'off'.
-		PfbConfig::write('pfb_software_check', 'off');
+		PfbConfig::write('gen/pfb_software_check', 'off');
 
 		// Then: read back Off.
-		$this->assertSame(PfbToggle::Off, PfbConfig::read('pfb_software_check'), 'after write "off" -> Off');
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('gen/pfb_software_check'), 'after write "off" -> Off');
 	}
 
 	/**
@@ -108,7 +108,7 @@ final class WwwGroupCGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'global_log must be absent before read');
 
 		// When: gateway read.
-		$result = PfbConfig::read('global_log');
+		$result = PfbConfig::read('dnsbl/global_log');
 
 		// Then: '' — prior page did `config_get_path(...) ?: ''`.
 		$this->assertSame('', $result, 'global_log absent -> "" (parity with prior page fallback)');
@@ -120,19 +120,19 @@ final class WwwGroupCGatewayTest extends TestCase
 	public function testGlobalLogRoundTrips(): void
 	{
 		// Before: absent → ''.
-		$this->assertSame('', PfbConfig::read('global_log'), 'initial absent -> ""');
+		$this->assertSame('', PfbConfig::read('dnsbl/global_log'), 'initial absent -> ""');
 
 		// When: write 'enabled'.
-		PfbConfig::write('global_log', 'enabled');
+		PfbConfig::write('dnsbl/global_log', 'enabled');
 
 		// Then: read back 'enabled'.
-		$this->assertSame('enabled', PfbConfig::read('global_log'), 'after write "enabled" -> "enabled"');
+		$this->assertSame('enabled', PfbConfig::read('dnsbl/global_log'), 'after write "enabled" -> "enabled"');
 
 		// When: write 'disabled_log'.
-		PfbConfig::write('global_log', 'disabled_log');
+		PfbConfig::write('dnsbl/global_log', 'disabled_log');
 
 		// Then: read back 'disabled_log'.
-		$this->assertSame('disabled_log', PfbConfig::read('global_log'), 'after write "disabled_log" -> "disabled_log"');
+		$this->assertSame('disabled_log', PfbConfig::read('dnsbl/global_log'), 'after write "disabled_log" -> "disabled_log"');
 	}
 
 	/**
@@ -146,7 +146,7 @@ final class WwwGroupCGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'suppression must be absent before read');
 
 		// When: gateway read.
-		$result = PfbConfig::read('suppression');
+		$result = PfbConfig::read('dnsbl/suppression');
 
 		// Then: '' — parity with prior page coalesce `?: ''`.
 		$this->assertSame('', $result, 'suppression absent -> "" (parity with prior page fallback)');
@@ -160,13 +160,13 @@ final class WwwGroupCGatewayTest extends TestCase
 		$blob = base64_encode("example.com\r\n.blocked.net\r\n");
 
 		// Before: absent → ''.
-		$this->assertSame('', PfbConfig::read('suppression'), 'initial absent -> ""');
+		$this->assertSame('', PfbConfig::read('dnsbl/suppression'), 'initial absent -> ""');
 
 		// When: write a base64 blob.
-		PfbConfig::write('suppression', $blob);
+		PfbConfig::write('dnsbl/suppression', $blob);
 
 		// Then: read back byte-identically.
-		$this->assertSame($blob, PfbConfig::read('suppression'), 'suppression after write round-trips byte-identically');
+		$this->assertSame($blob, PfbConfig::read('dnsbl/suppression'), 'suppression after write round-trips byte-identically');
 	}
 
 	/**
@@ -180,7 +180,7 @@ final class WwwGroupCGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'tld_wildcard_exclusion must be absent before read');
 
 		// When: gateway read.
-		$result = PfbConfig::read('tld_wildcard_exclusion');
+		$result = PfbConfig::read('dnsbl/tld_wildcard_exclusion');
 
 		// Then: '' — parity with prior page coalesce `?: ''`.
 		$this->assertSame('', $result, 'tld_wildcard_exclusion absent -> "" (parity with prior page fallback)');
@@ -194,13 +194,13 @@ final class WwwGroupCGatewayTest extends TestCase
 		$blob = base64_encode("example.com\r\n.test.org\r\n");
 
 		// Before: absent → ''.
-		$this->assertSame('', PfbConfig::read('tld_wildcard_exclusion'), 'initial absent -> ""');
+		$this->assertSame('', PfbConfig::read('dnsbl/tld_wildcard_exclusion'), 'initial absent -> ""');
 
 		// When: write a base64 blob.
-		PfbConfig::write('tld_wildcard_exclusion', $blob);
+		PfbConfig::write('dnsbl/tld_wildcard_exclusion', $blob);
 
 		// Then: read back byte-identically.
-		$this->assertSame($blob, PfbConfig::read('tld_wildcard_exclusion'), 'tld_wildcard_exclusion after write round-trips byte-identically');
+		$this->assertSame($blob, PfbConfig::read('dnsbl/tld_wildcard_exclusion'), 'tld_wildcard_exclusion after write round-trips byte-identically');
 	}
 
 	/**
@@ -209,7 +209,7 @@ final class WwwGroupCGatewayTest extends TestCase
 	 * page's `config_get_path(...) ?: ''` fallback).
 	 *
 	 * Red->green: before this phase, v4suppression was a foreign key and
-	 * PfbConfig::read('v4suppression') threw InvalidArgumentException (the former
+	 * PfbConfig::read('ip/v4suppression') threw InvalidArgumentException (the former
 	 * testV4SuppressionIsNotInRegistry pin this test-pair replaces).
 	 */
 	public function testV4SuppressionAbsentDefaultIsEmptyString(): void
@@ -220,7 +220,7 @@ final class WwwGroupCGatewayTest extends TestCase
 		$this->assertNull(config_get_path($path), 'v4suppression must be absent before read');
 
 		// When: gateway read.
-		$result = PfbConfig::read('v4suppression');
+		$result = PfbConfig::read('ip/v4suppression');
 
 		// Then: '' — parity with prior page coalesce `?: ''`.
 		$this->assertSame('', $result, 'v4suppression absent -> "" (parity with prior page fallback)');
@@ -234,13 +234,13 @@ final class WwwGroupCGatewayTest extends TestCase
 		$blob = base64_encode("192.168.1.1/32\r\n192.168.1.2/32\r\n");
 
 		// Before: absent → ''.
-		$this->assertSame('', PfbConfig::read('v4suppression'), 'initial absent -> ""');
+		$this->assertSame('', PfbConfig::read('ip/v4suppression'), 'initial absent -> ""');
 
 		// When: write a base64 blob.
-		PfbConfig::write('v4suppression', $blob);
+		PfbConfig::write('ip/v4suppression', $blob);
 
 		// Then: read back byte-identically.
-		$this->assertSame($blob, PfbConfig::read('v4suppression'), 'v4suppression after write round-trips byte-identically');
+		$this->assertSame($blob, PfbConfig::read('ip/v4suppression'), 'v4suppression after write round-trips byte-identically');
 	}
 
 	/**
@@ -429,11 +429,11 @@ final class WwwGroupCGatewayTest extends TestCase
 		$tldblob  = base64_encode(".test.org\r\n");
 
 		// When: write both registered keys.
-		PfbConfig::write('suppression', $suppblob);
-		PfbConfig::write('tld_wildcard_exclusion', $tldblob);
+		PfbConfig::write('dnsbl/suppression', $suppblob);
+		PfbConfig::write('dnsbl/tld_wildcard_exclusion', $tldblob);
 
 		// Then: each reads back independently and byte-identically.
-		$this->assertSame($suppblob, PfbConfig::read('suppression'), 'suppression after write');
-		$this->assertSame($tldblob, PfbConfig::read('tld_wildcard_exclusion'), 'tld_wildcard_exclusion after write');
+		$this->assertSame($suppblob, PfbConfig::read('dnsbl/suppression'), 'suppression after write');
+		$this->assertSame($tldblob, PfbConfig::read('dnsbl/tld_wildcard_exclusion'), 'tld_wildcard_exclusion after write');
 	}
 }

--- a/tests/php/fixtures/cfg_registry_pre1931_parity.json
+++ b/tests/php/fixtures/cfg_registry_pre1931_parity.json
@@ -1,0 +1,621 @@
+{
+    "settings_family": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "3.2",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "enable_cb": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_keep": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "on",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_interval": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "1",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_min": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_hour": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_dailystart": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "skipfeed": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_agg_types": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_log": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_errlog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_extraslog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_ip_blocklog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_ip_permitlog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_ip_matchlog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_ip_parse_err": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_dnslog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_dnsbl_parse_err": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_dnsreplylog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_unilog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "20000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_log": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_errlog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_extraslog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_ip_blocklog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_ip_permitlog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_ip_matchlog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_ip_parse_err": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_dnslog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_dnsbl_parse_err": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_dnsreplylog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "log_max_days_unilog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_log_trim_margin_pct": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_software_check": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "on",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write",
+        "write_priv": "pkg_mgr_installed.php"
+    },
+    "pfb_feed_internal_filter": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "on",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_feed_internal_allowlist": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_feed_sanity": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_reuse": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_alias_delta_mode": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "auto",
+        "read_adapter": "pfb_cfg_alias_delta_mode_read",
+        "write_adapter": "pfb_cfg_alias_delta_mode_write"
+    },
+    "pfb_alias_delta_batch": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "512",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_tick_interval": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "15",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_quiet_hours": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_syntax_highlight": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "on",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_dnsbl": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_dnsvip_auto": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_dnsbl_nonat": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "dnsbl_interface": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "lo0",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_dnsvip4": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_dnsvip6": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_dnsport": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_dnsport_ssl": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "top1m_enable": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "top1m_source": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "tranco",
+        "read_adapter": "pfb_cfg_top1m_source_read",
+        "write_adapter": "pfb_cfg_top1m_source_write"
+    },
+    "top1m_count": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "1000",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "top1m_inclusion": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "top1m_token": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_cache": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_cache_flush": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "global_log": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_dnsbl_lenient": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "off",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_py_reply": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_hsts": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_idn": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_idn_mode_read",
+        "write_adapter": "pfb_cfg_idn_mode_write"
+    },
+    "pfb_idn_block_malicious": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "on",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_idn_escalate_suspicious": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_regex": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_regex_list": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_regex_cap": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "pfb_cname": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "tld_allow": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_py_nolog": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_noaaaa": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_noaaaa_list": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_gp": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_gp_bypass_list": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "tld_wildcard_blacklist": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "tld_wildcard_exclusion": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "suppression": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "action": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "Disabled",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_dnsbl_rule": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "Disabled",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "dnsbl_allow_int": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_control": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_control_legacy": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "pfb_py_cache_max": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "tld_wildcard": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "aliaslog": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "dnsbl_redir": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "dnsbl_redir_int": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "dnsbl_redir_exclude": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "dnsbl_dot_block": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "dnsbl_dot_block_int": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "dnsbl_dot_block_exclude": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "dnsbl_dot_block_action": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "reject",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "dnsbl_dot_block_floating": {
+        "section": "installedpackages/pfblockerngdnsblsettings/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "log_syslog": {
+        "section": "installedpackages/pfblockerng/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "safesearch_enable": {
+        "section": "installedpackages/pfblockerngsafesearch",
+        "default": "Disable",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "safesearch_youtube": {
+        "section": "installedpackages/pfblockerngsafesearch",
+        "default": "Disable",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "safesearch_doh": {
+        "section": "installedpackages/pfblockerngsafesearch",
+        "default": "Disable",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "safesearch_doh_list": {
+        "section": "installedpackages/pfblockerngsafesearch",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "v4suppression": {
+        "section": "installedpackages/pfblockerngipsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "v6suppression": {
+        "section": "installedpackages/pfblockerngipsettings/config/0",
+        "default": "",
+        "read_adapter": null,
+        "write_adapter": null
+    },
+    "enable_rep": {
+        "section": "installedpackages/pfblockerngreputation/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "enable_pdup": {
+        "section": "installedpackages/pfblockerngreputation/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    },
+    "enable_dedup": {
+        "section": "installedpackages/pfblockerngreputation/config/0",
+        "default": "",
+        "read_adapter": "pfb_cfg_toggle_read",
+        "write_adapter": "pfb_cfg_toggle_write"
+    }
+}

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -224,6 +224,8 @@ class RequireConfigGatewaySniff implements Sniff
 		// ADR-53: installedpackages/pfblockerngipsettings/config/0 (IPv4/IPv6 suppression)
 		'installedpackages/pfblockerngipsettings/config/0/v4suppression',
 		'installedpackages/pfblockerngipsettings/config/0/v6suppression',
+		// issue #1931: IP page "Enable Suppression" toggle
+		'installedpackages/pfblockerngipsettings/config/0/suppression',
 		// issue #1896: installedpackages/pfblockerngreputation/config/0 (Reputation toggles)
 		'installedpackages/pfblockerngreputation/config/0/enable_rep',
 		'installedpackages/pfblockerngreputation/config/0/enable_pdup',

--- a/tests/phpcs/fixtures/gateway_compliant.php
+++ b/tests/phpcs/fixtures/gateway_compliant.php
@@ -44,8 +44,8 @@ function pfb_gateway_compliant_v4suppression_via_gateway()
 	// ADR-53: v4suppression is registered — access via PfbConfig::read/write, never
 	// raw config_get_path/config_set_path. Neither call here is one of the sniff's
 	// gated function names, so this stays silent regardless of the key.
-	$v4 = PfbConfig::read('v4suppression');
-	PfbConfig::write('v4suppression', $v4);
+	$v4 = PfbConfig::read('ip/v4suppression');
+	PfbConfig::write('ip/v4suppression', $v4);
 
 	return $v4;
 }

--- a/tests/phpcs/fixtures/usr/local/pkg/pfblockerng/system_write_compliant.php
+++ b/tests/phpcs/fixtures/usr/local/pkg/pfblockerng/system_write_compliant.php
@@ -15,7 +15,7 @@
 function pfb_pkg_writesystem_system_caller()
 {
 	// System-context caller (e.g. cron/install) — legitimate, must stay silent.
-	PfbConfig::writeSystem('pfb_keep', '30');
+	PfbConfig::writeSystem('gen/pfb_keep', '30');
 }
 
 function pfb_pkg_writesectionsystem_system_caller()

--- a/tests/phpcs/fixtures/usr/local/www/system_write_compliant.php
+++ b/tests/phpcs/fixtures/usr/local/www/system_write_compliant.php
@@ -22,7 +22,7 @@
 function pfb_www_write_authorized_variant()
 {
 	// PfbConfig::write() enforces write_priv — must never be flagged.
-	PfbConfig::write('pfb_keep', '30');
+	PfbConfig::write('gen/pfb_keep', '30');
 }
 
 function pfb_www_writesection_authorized_variant()
@@ -34,7 +34,7 @@ function pfb_www_writesection_authorized_variant()
 function pfb_www_foreign_class_writesystem()
 {
 	// Same method name, but the class is not PfbConfig — must never be flagged.
-	SomethingElse::writeSystem('pfb_keep', '30');
+	SomethingElse::writeSystem('gen/pfb_keep', '30');
 }
 
 function pfb_www_writesystem_mentioned_in_comment()

--- a/tests/phpcs/fixtures/usr/local/www/system_write_violation.php
+++ b/tests/phpcs/fixtures/usr/local/www/system_write_violation.php
@@ -17,7 +17,7 @@
 function pfb_www_writesystem_violation()
 {
 	// Direct writeSystem() call from a www/ page — must be flagged.
-	PfbConfig::writeSystem('pfb_keep', '30');
+	PfbConfig::writeSystem('gen/pfb_keep', '30');
 }
 
 function pfb_www_writesectionsystem_violation()
@@ -30,26 +30,26 @@ function pfb_www_writesystem_case_variance()
 {
 	// Case-insensitive class AND method name (PHP identifiers are
 	// case-insensitive) — must still be flagged.
-	pfbconfig::WRITESYSTEM('pfb_keep', '30');
+	pfbconfig::WRITESYSTEM('gen/pfb_keep', '30');
 }
 
 function pfb_www_writesystem_comment_before_double_colon()
 {
 	// A comment wedged between the class name and '::' must not evade the
 	// sniff -- it must walk past comment tokens, not just whitespace.
-	PfbConfig/*x*/::writeSystem('pfb_keep', '30');
+	PfbConfig/*x*/::writeSystem('gen/pfb_keep', '30');
 }
 
 function pfb_www_writesystem_comment_after_double_colon()
 {
 	// A comment wedged between '::' and the method name must not evade
 	// the sniff either.
-	PfbConfig::/*x*/writeSystem('pfb_keep', '30');
+	PfbConfig::/*x*/writeSystem('gen/pfb_keep', '30');
 }
 
 function pfb_www_writesystem_comment_before_paren()
 {
 	// The third comment gap: between the method name and '(' — the sniff's
 	// forward walk to the opening parenthesis must skip comments too.
-	PfbConfig::writeSystem/*x*/('pfb_keep', '30');
+	PfbConfig::writeSystem/*x*/('gen/pfb_keep', '30');
 }

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2104,7 +2104,7 @@ def set_feed_sanity(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     value = "PfbToggle::On" if on else "PfbToggle::Off"
     snippet = (
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        f"PfbConfig::write('pfb_feed_sanity', {value});\n"
+        f"PfbConfig::write('gen/pfb_feed_sanity', {value});\n"
         "write_config('pfBlockerNG smoke: set pfb_feed_sanity');\n"
         "echo 'OK';"
     )

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -346,11 +346,11 @@ def _set_delta_mode(vm: h.SmokeVM, mode: str, *, timeout: float = 60.0) -> None:
     the stored value is unambiguous.
 
     Call BEFORE the reload under test.  The next ``reload()`` reads this value
-    once per pass via ``PfbConfig::read('pfb_alias_delta_mode')``.
+    once per pass via ``PfbConfig::read('gen/pfb_alias_delta_mode')``.
     """
     snippet = (
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        f"PfbConfig::write('pfb_alias_delta_mode', {h._php_str(mode)});\n"
+        f"PfbConfig::write('gen/pfb_alias_delta_mode', {h._php_str(mode)});\n"
         "write_config('pfBlockerNG smoke: set pfb_alias_delta_mode');\n"
         "echo 'OK';"
     )

--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -126,7 +126,7 @@ def _set_quiet_hours(vm: SmokeVM, window: str) -> None:
     # Use the config gateway rather than direct xml munging.
     snippet = (
         f"require_once('{_PFB_EXTRA}');"
-        f"PfbConfig::write('pfb_quiet_hours', {json.dumps(window)});"
+        f"PfbConfig::write('gen/pfb_quiet_hours', {json.dumps(window)});"
         "write_config('ADR-43 smoke: set quiet-hours');"
         "echo 'OK';"
     )

--- a/tests/smoke/test_top1m_fixed_file.py
+++ b/tests/smoke/test_top1m_fixed_file.py
@@ -347,10 +347,10 @@ def _configure_top1m(vm: SmokeVM) -> None:
     result = h.php_eval(
         vm,
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        "PfbConfig::write('top1m_enable', 'on');\n"
-        "PfbConfig::write('top1m_source', PfbTop1mSource::Tranco);\n"
-        "PfbConfig::write('top1m_count', '1');\n"
-        "PfbConfig::write('top1m_inclusion', 'com');\n"
+        "PfbConfig::write('dnsbl/top1m_enable', 'on');\n"
+        "PfbConfig::write('dnsbl/top1m_source', PfbTop1mSource::Tranco);\n"
+        "PfbConfig::write('dnsbl/top1m_count', '1');\n"
+        "PfbConfig::write('dnsbl/top1m_inclusion', 'com');\n"
         "write_config('pfBlockerNG #1542 smoke: enable deterministic TOP1M fixture');\n"
         "echo 'OK';",
     )
@@ -371,7 +371,7 @@ def _stage_top1m_source(vm: SmokeVM, body: str) -> None:
         "$provider = pfb_top1m_active_provider();\n"
         "$source = $pfb['dnsbl_top1m_type'];\n"
         "$source_key = $source instanceof PfbTop1mSource ? $source->value : (string) $source;\n"
-        "$headers = pfb_top1m_auth_headers($provider, (string) PfbConfig::read('top1m_token'));\n"
+        "$headers = pfb_top1m_auth_headers($provider, (string) PfbConfig::read('dnsbl/top1m_token'));\n"
         "$identity = pfb_top1m_source_identity($source_key, $provider['url'], $headers);\n"
         "$source_written = @file_put_contents($base . '.source', $identity, LOCK_EX) !== FALSE;\n"
         "$hash = pfb_hash_read($base);\n"
@@ -400,7 +400,7 @@ def _complete_detector_sidecars(vm: SmokeVM) -> dict:
         "$provider = pfb_top1m_active_provider();\n"
         "$source = $pfb['dnsbl_top1m_type'];\n"
         "$source_key = $source instanceof PfbTop1mSource ? $source->value : (string) $source;\n"
-        "$headers = pfb_top1m_auth_headers($provider, (string) PfbConfig::read('top1m_token'));\n"
+        "$headers = pfb_top1m_auth_headers($provider, (string) PfbConfig::read('dnsbl/top1m_token'));\n"
         "$identity = pfb_top1m_source_identity($source_key, $provider['url'], $headers);\n"
         "$hash = pfb_hash_read($base);\n"
         "$validators = pfb_validator_read($base . '.orig');\n"
@@ -556,11 +556,11 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     teardown = _json_eval(
         vm,
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
-        "PfbConfig::write('pfb_keep', PfbToggle::On);\n"
+        "PfbConfig::write('gen/pfb_keep', PfbToggle::On);\n"
         "write_config('pfBlockerNG #1542 smoke: keep-on callable teardown');\n"
         "pfb_global();\n"
         "$ok = pfb_unbound_py_teardown_raw_set();\n"
-        "$keep = PfbConfig::read('pfb_keep');\n"
+        "$keep = PfbConfig::read('gen/pfb_keep');\n"
         "$out = array('ok' => $ok, 'keep' => $keep instanceof PfbToggle ? $keep->value : (string) $keep);",
         "PFB1542TEARDOWN",
     )

--- a/tests/smoke/ui/test_general_scoped_operator.py
+++ b/tests/smoke/ui/test_general_scoped_operator.py
@@ -167,7 +167,7 @@ $before = (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_k
 
 $caught = 'NO_EXCEPTION';
 try {
-    PfbConfig::write('pfb_keep', 'off');
+    PfbConfig::write('gen/pfb_keep', 'off');
 } catch (\\RuntimeException $e) {
     $caught = 'RuntimeException';
 } catch (\\Throwable $e) {
@@ -178,12 +178,12 @@ echo "PFB1904:WRITE_CAUGHT:{$caught}\\n";
 $afterWrite = (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_keep', '');
 echo 'PFB1904:AFTER_WRITE_UNCHANGED:' . (($afterWrite === $before) ? 'YES' : 'NO') . "\\n";
 
-PfbConfig::writeSystem('pfb_keep', 'off');
+PfbConfig::writeSystem('gen/pfb_keep', 'off');
 write_config('[pfBlockerNG] smoke #1904: CLI gateway probe writeSystem off');
 $stored = (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_keep', '');
 echo "PFB1904:WRITESYSTEM_STORED:{$stored}\\n";
 
-PfbConfig::writeSystem('pfb_keep', $before);
+PfbConfig::writeSystem('gen/pfb_keep', $before);
 write_config('[pfBlockerNG] smoke #1904: CLI gateway probe writeSystem restore');
 echo 'PFB1904:RESTORED:OK';
 """
@@ -441,10 +441,10 @@ def test_cli_gateway_write_fails_closed_writesystem_succeeds(
         is genuinely UNDEFINED there, matching the bare pfSsh.php bootstrap --
         see the module docstring for which CAUTION arm this box exercises),
 
-      When ``PfbConfig::write('pfb_keep', 'off')`` is called,
+      When ``PfbConfig::write('gen/pfb_keep', 'off')`` is called,
 
       Then it throws ``RuntimeException`` (fail-closed) and the stored value is
-        UNCHANGED; and ``PfbConfig::writeSystem('pfb_keep', 'off')`` -- the
+        UNCHANGED; and ``PfbConfig::writeSystem('gen/pfb_keep', 'off')`` -- the
         explicit system-caller escape hatch -- succeeds and persists the
         canonical ``'off'`` token.
 


### PR DESCRIPTION
Fixes #1931

## What

Keys `pfb_cfg_registry()` by **section-alias/key** path strings (`gen/pfb_keep`, `ip/suppression`) resolved through the new `PFB_SECTIONS` map, so the registry's address space matches the hierarchy `config.xml` actually has.

- **`PFB_SECTIONS`** (`gen`/`dnsbl`/`ss`/`ip`/`rep`) becomes the single source for the five real section paths; the per-entry `section` attribute is deleted, along with the five section locals it replaced.
- **No dual addressing:** bare-name lookups throw `InvalidArgumentException` — every per-key `PfbConfig::read/write/writeSystem/delete` call site in `src/` (11 files) and `tests/` moved to the path form in the same commit.
- **`PfbConfig` internals** resolve the section from the alias prefix (`sectionPath()`); section-blob writes (`writeSection`/`writeSectionRaw`) filter by resolved section and index the blob by the bare key, so `config.xml` storage is byte-for-byte unchanged.
- **`pfb_registered_scalars_seed()`** and `PFB_SCALAR_SEED_EXCLUDED` move to path-form keys; blob keys stay bare.
- **`ip/suppression` registered** (second commit): with the collision against the DNSBL `dnsbl/suppression` whitelist blob gone, the IP page's "Enable Suppression" toggle joins the registry — default `''`, plain adapters, seed-excluded (the page renders checked while the key is absent: the #1907 divergence class). The `'on'`-default + grandfather decision stays deferred to #1921, per the issue's separability note.

## Verification (issue acceptance criteria)

1. **Parity fixture** — `tests/php/fixtures/cfg_registry_pre1931_parity.json` was generated from the untouched pre-change registry (103 entries, frozen at `376b40bf`) and independently re-derived by the step verifier from `origin/devel`; the new `testPathKeyedRegistryMatchesPre1931ParityFixture` pins every field's (section, default, adapters, write_priv) tuple byte-identical across the re-keying.
2. **Alias gate** — a registry key with a prefix outside `PFB_SECTIONS` (or a bare key) fails the suite; vacuity-proven with synthetic bad registries. `PFB_SECTIONS` values are unique and pinned to the `installedpackages/pfblockerng*` namespace.
3. **`ip/suppression`** — red-first proof executed (registration tests + inventory failed on the pre-change code, frozen byte-identical, green after; re-executed independently via `scripts/agent/verify-red-proof.sh`, VERDICT: PASS). The inventory out-of-scope list drops it; the gateway serves the registered default.
4. Full gates green: `vendor/bin/phpunit` (4718 tests, 0 failures), `composer phpstan`, `composer phpcs`, `python3 -m pytest` (3852 passed), `php -l` on every touched file.

`RequireConfigGatewaySniff::$registeredPaths` keeps full real paths (unchanged by the re-keying; +1 for the new registration), and `SniffRegistryParityTest` now joins alias-resolved paths — same set equality, one line different. The DNSBL `suppression` → `whitelist` vocabulary rename is #1921 `old_name` mechanics, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized configuration handling across General, DNSBL, SafeSearch, IP, and Reputation settings.
  * Preserved existing defaults, validation, toggles, feeds, logging, suppression, and blocking behavior.
  * Improved TOP1M provider support with authentication details for OpenPageRank, Majestic, and Cloudflare.
  * Enhanced configuration migration and compatibility for existing installations.
* **Tests**
  * Expanded coverage for configuration persistence, migration, defaults, permissions, and section-specific settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->