### PR TITLE
pfblockerng: stop the auto parser reading a URL path segment as a CIDR mask

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10610,7 +10610,7 @@ function sanitize_ipaddr($ipaddr, $custom, $pfbcidr) {
 function pfb_sanitize_ipaddr($ipaddr, $custom, $pfbcidr, PfbToggle $supp): array {
 	$messages = [];
 
-	$parts	= explode('/', $ipaddr);
+	$parts	= explode('/', $ipaddr, 3);
 	$subnet	= $parts[0];
 	// issue #1933: with more than one '/', $parts[1] is a URL path segment, not
 	// a mask — recover the bare host (the issue #1922 regex mask-guard outcome);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10612,7 +10612,10 @@ function pfb_sanitize_ipaddr($ipaddr, $custom, $pfbcidr, PfbToggle $supp): array
 
 	$parts	= explode('/', $ipaddr);
 	$subnet	= $parts[0];
-	$mask	= $parts[1] ?? '';	// '' (not undef) when no CIDR
+	// issue #1933: with more than one '/', $parts[1] is a URL path segment, not
+	// a mask — recover the bare host (the issue #1922 regex mask-guard outcome);
+	// discarding $parts[2..] read the first path segment as the prefix length.
+	$mask	= isset($parts[2]) ? '' : ($parts[1] ?? '');	// '' (not undef) when no CIDR
 
 	// An IPv4 prefix length must be 0..32; drop the line outright. A substring
 	// strip here (str_replace('32', '')) used to rewrite an invalid mask into a

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -149,6 +149,23 @@ final class IpParseLineTest extends TestCase
 		);
 	}
 
+	/**
+	 * Scenario: an auto-typed feed ships a bare "IP/path" URL line (issue #1933).
+	 *   Given the exact line shape that caused the issue #1922 outage
+	 *   When the auto (non-regex) parser path handles it
+	 *   Then the bare host is recovered — the first path segment is never read
+	 *        as a CIDR mask (the regex path's owner-ruled outcome, PR #1932).
+	 * Before, the auto path emitted '84.38.133.113/1' (= 0.0.0.0/1 aggregated).
+	 */
+	public function testIpv4AutoUrlPathSegmentIsNotACidrMask(): void
+	{
+		$line = '84.38.133.113/1/webpanel/login.php';
+		$this->assertLine($line, $this->config('_v4', 'auto', FALSE), $this->expectedResult(
+			$line,
+			['entries' => ['84.38.133.113']]
+		));
+	}
+
 	public function testIpv4RegexDeduplicatesAndSkipsCloudflare(): void
 	{
 		$config = $this->config('_v4', 'regex');

--- a/tests/php/SanitizeIpaddrCoreTest.php
+++ b/tests/php/SanitizeIpaddrCoreTest.php
@@ -81,6 +81,56 @@ final class SanitizeIpaddrCoreTest extends TestCase
 		);
 	}
 
+	/**
+	 * Scenario: an auto-typed feed ships a bare "IP/path" URL line.
+	 *   Given a line whose first path segment is a small number (the #1922 shape)
+	 *   When the IPv4 core sanitizer splits on '/'
+	 *   Then the path segment is NOT read as a CIDR mask — the bare host is
+	 *        recovered, matching the regex path's mask-internal guard outcome.
+	 * Before, parts[2..] were silently discarded and '/1' became the prefix
+	 * length (= 0.0.0.0/1 after aggregation — the issue #1922 outage shape).
+	 */
+	public function testIpv4CorePathSegmentsRecoverBareHostNotMask(): void
+	{
+		$this->assertSame(
+			['address' => '84.38.133.113', 'messages' => []],
+			pfb_sanitize_ipaddr('84.38.133.113/1/webpanel/login.php', FALSE, 'Disabled', PfbToggle::Off)
+		);
+	}
+
+	// A '/0' path segment is path junk, not a feed /0 — the bare host comes
+	// back WITHOUT the issue #744 clamp message (no mask was ever present).
+	public function testIpv4CoreZeroPathSegmentIsNotAFeedZeroClamp(): void
+	{
+		$this->assertSame(
+			['address' => '1.2.3.4', 'messages' => []],
+			pfb_sanitize_ipaddr('1.2.3.4/0/path', FALSE, 'Disabled', PfbToggle::Off)
+		);
+	}
+
+	// Custom lists get the same bare-host recovery: a path segment is never a
+	// user-authored mask, so the custom /0-honor rule does not apply either.
+	public function testIpv4CorePathSegmentsRecoverBareHostOnCustomList(): void
+	{
+		$this->assertSame(
+			['address' => '1.2.3.4', 'messages' => []],
+			pfb_sanitize_ipaddr('1.2.3.4/8/junk', TRUE, 'Disabled', PfbToggle::Off)
+		);
+	}
+
+	// Degenerate multi-slash shapes: an empty middle part or a trailing slash
+	// also recover the bare host — only a genuine two-part 'addr/<n>' is a CIDR.
+	public function testIpv4CoreDegenerateSlashShapesRecoverBareHost(): void
+	{
+		foreach (['1.2.3.4//24', '1.2.3.4/24/'] as $shape) {
+			$this->assertSame(
+				['address' => '1.2.3.4', 'messages' => []],
+				pfb_sanitize_ipaddr($shape, FALSE, 'Disabled', PfbToggle::Off),
+				"{$shape} must recover the bare host"
+			);
+		}
+	}
+
 	public function testIpv4CoreSuppressesReservedClassesWithoutMessages(): void
 	{
 		$addresses = [

--- a/tests/php/SanitizeIpaddrCoreTest.php
+++ b/tests/php/SanitizeIpaddrCoreTest.php
@@ -109,12 +109,17 @@ final class SanitizeIpaddrCoreTest extends TestCase
 	}
 
 	// Custom lists get the same bare-host recovery: a path segment is never a
-	// user-authored mask, so the custom /0-honor rule does not apply either.
+	// user-authored mask, so the custom /0-honor rule (issue #744) does not
+	// apply either — a '/0' path segment on a custom list is still path junk.
 	public function testIpv4CorePathSegmentsRecoverBareHostOnCustomList(): void
 	{
 		$this->assertSame(
 			['address' => '1.2.3.4', 'messages' => []],
 			pfb_sanitize_ipaddr('1.2.3.4/8/junk', TRUE, 'Disabled', PfbToggle::Off)
+		);
+		$this->assertSame(
+			['address' => '1.2.3.4', 'messages' => []],
+			pfb_sanitize_ipaddr('1.2.3.4/0/path', TRUE, 'Disabled', PfbToggle::Off)
 		);
 	}
 


### PR DESCRIPTION
## Summary

Closes the auto-parser sibling of issue #1922. `pfb_sanitize_ipaddr()`'s mask split (`explode('/')`) took `$parts[1]` as the CIDR prefix length and silently discarded `$parts[2..]`, so an auto-typed feed shipping a bare `IP/path` URL line like `84.38.133.113/1/webpanel/login.php` produced `84.38.133.113/1` — `0.0.0.0/1` after aggregation, the #1922 outage shape. PR #1932 fixed this in the **regex** extraction path only, deliberately leaving the auto path out of its settled spec (issue #1933 split it out).

The fix recovers the bare host whenever the split yields more than two parts, mirroring the regex path's owner-ruled mask-internal-guard outcome: `/<n>` is a mask only when the line genuinely is `addr/<n>`.

## Behaviour deltas (v4 sanitizer, all callers)

| Input | Before | After |
| --- | --- | --- |
| `84.38.133.113/1/webpanel/login.php` | `84.38.133.113/1` | `84.38.133.113` |
| `1.2.3.4/0/path` (feed) | `1.2.3.4` + issue #744 clamp message (fired by accident of the same split) | `1.2.3.4`, no message |
| `1.2.3.4/8/junk` (custom list) | `1.2.3.4/8` | `1.2.3.4` |
| `1.2.3.4/24/` | `1.2.3.0/24` (the /24 normalization then widened it to the network) | `1.2.3.4` |
| genuine two-part `addr/<n>` | unchanged | unchanged (existing suite rows byte-identical) |

## Sibling axes (enumerated from source)

- **v6 (`pfb_sanitize_ipaddr_v6`)** — no change needed: every caller gates on `validate_ipv6()` first, and `is_subnetv6()` explodes with limit 2, so `'addr/64/path'` fails `ctype_digit('64/path')` before the sanitizer runs. The shape is unreachable.
- **Regex path** — already fixed by PR #1932; a regex match contains at most one `/` by construction.
- **`pfb_dnsbl_collect_feed_ip()`** — routes through the same shared function; covered by this fix (previously reachable with the same fabricated mask via `sanitize_ipaddr()`).
- **Range-expander call sites** — inputs are `ip_range_to_subnet_array()`-generated `x.x.x.x/nn`, never more than two parts.

## Test-first proof

Reproduction tests authored before the production edit and executed RED on the untouched code (5 failures, each the fabricated-mask shape):

```text
1) IpParseLineTest::testIpv4AutoUrlPathSegmentIsNotACidrMask   entries ['84.38.133.113/1'] not ['84.38.133.113']
2) SanitizeIpaddrCoreTest::testIpv4CorePathSegmentsRecoverBareHostNotMask   '84.38.133.113/1'
3) SanitizeIpaddrCoreTest::testIpv4CoreZeroPathSegmentIsNotAFeedZeroClamp   clamp message present
4) SanitizeIpaddrCoreTest::testIpv4CorePathSegmentsRecoverBareHostOnCustomList   '1.2.3.4/8'
5) SanitizeIpaddrCoreTest::testIpv4CoreDegenerateSlashShapesRecoverBareHost   '1.2.3.0/24'
```

Frozen at red (`git hash-object`): `tests/php/SanitizeIpaddrCoreTest.php` = `0482359ae5ed2333111b42ad1529a688aa9946da`, `tests/php/IpParseLineTest.php` = `c05cbed8014f9c72a47fc6185eaf382fdbc9d963`. After the one-line production change the same bytes ran GREEN; full PHPUnit suite: 4730 tests, 25836 assertions, 0 failures. `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS` (php -l, PHPUnit, PHPStan, PHPCS).

Fixes #1933

---

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IPv4 address handling for URL-like entries containing multiple path segments.
  - Prevented path values such as `/1` or `/0` from being misinterpreted as CIDR masks.
  - Preserved correct handling of legitimate feed CIDR ranges and custom lists.

- **Tests**
  - Added regression coverage for URL paths, zero-valued segments, custom lists, and unusual slash patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->