### PR TITLE
tests: align Tier-B smoke expectations with the #1907 suppression/cache defaults

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -429,6 +429,23 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
     # Re-assert after POST-INSTALL: idempotent, and it fails loudly if the install removed dbdir.
     _write_cron_disable_flag(vm, timeout=timeout)
 
+    # issue #1946: the install-time registry pass seeds ip/suppression at its #1907
+    # default 'on', and Suppression drops the RFC 5737 documentation ranges (issue
+    # #760) the fixture policy mandates — IP tables would never populate. Pin the
+    # operator-uncheck baseline; suppression-semantics tests arrange the toggle
+    # themselves. (reset_pfb_baseline() re-pins it after each module wipe.)
+    pin = php_eval(
+        vm,
+        f"$ipcfg = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
+        "$ipcfg['suppression'] = 'off';\n"
+        f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ipcfg);\n"
+        "write_config('pfBlockerNG smoke: pin suppression off baseline');\n"
+        "echo 'OK';",
+        timeout=timeout,
+    )
+    if pin.returncode != 0 or "OK" not in pin.stdout:
+        raise RuntimeError(f"suppression-off baseline pin failed: rc={pin.returncode} {pin.stderr!r} {pin.stdout!r}")
+
 
 def _write_cron_disable_flag(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     """Write the cron-disable sentinel on the guest, raising loudly on failure.
@@ -3376,6 +3393,14 @@ def reset_pfb_baseline(vm: SmokeVM, *, timeout: float = 300.0) -> None:
         f"  return ($r['descr'] ?? '') !== {_php_str(CONTROL_DESCR)};\n"
         "}));\n"
         f"config_set_path({_php_str(CFG_UNBOUND_HOSTS)}, $hosts);\n"
+        # issue #1946: with the ip section wiped, an absent 'suppression' resolves to the
+        # #1907 registry default ON, and Suppression drops the RFC 5737 documentation
+        # ranges (issue #760) the fixture policy mandates — every IP table would come up
+        # empty. Pin the operator-uncheck baseline so inert fixtures keep populating;
+        # suppression-semantics tests arrange the toggle themselves.
+        f"$ipcfg = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
+        "$ipcfg['suppression'] = 'off';\n"
+        f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ipcfg);\n"
         "write_config('pfBlockerNG smoke: reset to clean baseline');\n"
         # Regenerate host_entries.conf so the live resolver matches the emptied config —
         # the control-record removal only takes effect after an unbound reconfigure.

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -162,6 +162,10 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page=IP_PAGE,
         field="suppression",
         config_path="installedpackages/pfblockerngipsettings/config/0/suppression",
+        # issue #1907: toggle-adapter field -- unchecked save stores the explicit 'off'.
+        off="off",
+        # Registry default 'on': an absent key means the feature is ON.
+        absent="on",
     ),
     ToggleFlow(
         name="ip_global_logging",
@@ -219,6 +223,8 @@ FLOWS: tuple[ToggleFlow, ...] = (
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts",
         # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
         off="off",
+        # Registry default 'on' since issue #1907: an absent key means the feature is ON.
+        absent="on",
     ),
     ToggleFlow(
         name="dnsbl_regex",
@@ -243,6 +249,10 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page="/pfblockerng/pfblockerng_dnsbl.php",
         field="pfb_cache",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache",
+        # issue #1907: toggle-adapter field -- unchecked save stores the explicit 'off'.
+        off="off",
+        # Registry default 'on': an absent key means the feature is ON.
+        absent="on",
     ),
     ToggleFlow(
         name="dnsbl_cache_flush",


### PR DESCRIPTION
## Summary

Two smoke-harness follow-ups to PR #1943 (#1907's default flips), both found by post-merge live-VM validation on leased boxes:

1. **Stale toggle-flow rows** (`1da4bccd`) — `test_functional.py`'s `ip_suppression` and `dnsbl_cache` `ToggleFlow` rows still expected the pre-#1907 unchecked-save `''`; the pages now stage explicit `'off'`. Rows gain `off="off"` + `absent="on"` (the `general_keep_settings` precedent); `dnsbl_hsts_mode` gains `absent="on"` for its #1907-flipped default.
2. **Suppression-On baseline starves IP fixtures** (`300a3bd2`) — the install-time registry pass seeds `ip/suppression` at its #1907 default `'on'`, and after every `reset_pfb_baseline()` wipe the absent key resolves On through the gateway. Under Suppression, `pfb_sanitize_ipaddr()` drops the RFC 5737 documentation ranges (issue #760) that the fixture policy mandates — so IP alias tables never populate (`pfB_uihostile_v4` empty). Product behaviour is correct; the harness now pins the operator-uncheck baseline (`suppression='off'`) at both chokepoints: `deploy()` post-install and `reset_pfb_baseline()` post-wipe. Suppression-semantics tests arrange the toggle themselves and are unaffected.

## Verification (executed on leased PFB boxes)

- RED: `test_toggle_flow_changes_effective_config[ip_suppression]` failed on merged devel `b32c799b` (`'off' != ''`), and `test_alerts_invalid_actions_leave_state_unchanged_and_addsuppress_writes_exact_host` failed isolated on `b32c799b` while passing isolated on pre-merge `8582a1b9` (the discriminating probe pair).
- GREEN on this branch (`300a3bd2`): `7 passed` — the invalid-actions table-population test, all three suppression/cache toggle flows, both #1907 polarity render tests, and the validation-error re-render test.
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS.
- The unrelated pre-existing `_seeded_idn_exclusion` restore failure reproduced on BOTH refs and is tracked separately as #1947.

Fixes #1945
Fixes #1946

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of guest IP suppression settings during deployment and environment resets.
  * Ensured disabled toggles save explicitly as “off.”
  * Ensured missing configuration values correctly use their default “on” state for DNSBL and IP suppression settings.
  * Added validation to detect failed configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->