### PR TITLE
pfblockerng: stop sending Basic credentials to cross-host redirect targets

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12711,11 +12711,9 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				// destination address). The destination port is derived from the URL
 				// or its scheme when implicit.
 				$scheme_ports	= array('http' => 80, 'https' => 443, 'ftp' => 21, 'rsync' => 873);
-				if ($feed_pinned !== '' && $feed_host !== '' && !empty($feed_scheme)) {
-					$feed_port	= $url_parts['port'] ?? ($scheme_ports[$feed_scheme] ?? 0);
-					if ($feed_port > 0) {
-						curl_setopt($ch, CURLOPT_RESOLVE, array("{$feed_host}:{$feed_port}:{$feed_pinned}"));
-					}
+				$feed_port	= (int) ($url_parts['port'] ?? ($scheme_ports[$feed_scheme] ?? 0));
+				if ($feed_pinned !== '' && $feed_host !== '' && !empty($feed_scheme) && $feed_port > 0) {
+					curl_setopt($ch, CURLOPT_RESOLVE, array("{$feed_host}:{$feed_port}:{$feed_pinned}"));
 				}
 
 				$feed_has_creds = !pfb_is_empty($username) || !pfb_is_empty($password);
@@ -12828,14 +12826,19 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					ftruncate($fhandle, 0);
 					rewind($fhandle);
 
-					// Scope the Basic credentials to the ORIGINAL feed host
-					// (issue #1919) — libcurl's own FOLLOWLOCATION policy: a
-					// cross-host hop must not receive the origin's
-					// Authorization, and a hop back onto the origin host
-					// regains it. CURLAUTH_NONE (with the userpwd blanked)
-					// stops libcurl from sending any Authorization header.
+					// Scope the Basic credentials to the ORIGINAL feed origin —
+					// host AND scheme AND port (issue #1919) — libcurl's own
+					// FOLLOWLOCATION policy since 7.83.0 (CVE-2022-27774): a
+					// hop to any other origin must not receive the feed's
+					// Authorization (another port or a downgraded scheme on
+					// the same host is a different trust domain), and a hop
+					// back onto the origin regains it. CURLAUTH_NONE (with
+					// the userpwd blanked) stops libcurl from sending any
+					// Authorization header.
 					if ($feed_has_creds) {
-						if (strcasecmp($next['host'], $feed_host) === 0) {
+						if (strcasecmp($next['host'], $feed_host) === 0 &&
+						    $next['scheme'] === $feed_scheme &&
+						    $next['port'] === $feed_port) {
 							curl_setopt($ch, CURLOPT_USERPWD, "{$username}:{$password}");
 							curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
 						} else {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12718,7 +12718,8 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					}
 				}
 
-				if (!pfb_is_empty($username) || !pfb_is_empty($password)) {
+				$feed_has_creds = !pfb_is_empty($username) || !pfb_is_empty($password);
+				if ($feed_has_creds) {
 					curl_setopt($ch, CURLOPT_USERPWD, "{$username}:{$password}");
 					curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
 				}
@@ -12826,6 +12827,22 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					// remains in the feed file.
 					ftruncate($fhandle, 0);
 					rewind($fhandle);
+
+					// Scope the Basic credentials to the ORIGINAL feed host
+					// (issue #1919) — libcurl's own FOLLOWLOCATION policy: a
+					// cross-host hop must not receive the origin's
+					// Authorization, and a hop back onto the origin host
+					// regains it. CURLAUTH_NONE (with the userpwd blanked)
+					// stops libcurl from sending any Authorization header.
+					if ($feed_has_creds) {
+						if (strcasecmp($next['host'], $feed_host) === 0) {
+							curl_setopt($ch, CURLOPT_USERPWD, "{$username}:{$password}");
+							curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+						} else {
+							curl_setopt($ch, CURLOPT_USERPWD, '');
+							curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_NONE);
+						}
+					}
 
 					// Re-point cURL at the vetted target and re-pin its address. The
 					// '-host:port' entry removes any prior pin for the same host:port

--- a/tests/php/DownloadRedirectCredentialScopeTest.php
+++ b/tests/php/DownloadRedirectCredentialScopeTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_download() Basic-credential scope across manual redirect hops (issue #1919).
+ *
+ * The manual redirect loop keeps CURLOPT_USERPWD/CURLOPT_HTTPAUTH configured on
+ * the one cURL handle for every hop, so a credentialed feed that answers with a
+ * CROSS-HOST redirect leaks the operator's Basic username and password to the
+ * redirect target. Credentials must be scoped to the ORIGINAL feed host —
+ * libcurl's own FOLLOWLOCATION policy: a cross-host hop gets no Authorization,
+ * a hop back onto the origin host regains it, and a same-host redirect keeps it.
+ *
+ * Exercised through the REAL pfb_download() against TWO local `php -S` fixture
+ * servers on distinct hostnames (both resolved to 127.0.0.1 through the
+ * $GLOBALS['pfb_test_resolve_map'] hook and admitted by the self-IP carve-out;
+ * each map entry also lists a public address so the host is not classified
+ * self-hosted, which would take the localfile path instead of the cURL loop
+ * under test). Every request's PHP_AUTH_USER/PHP_AUTH_PW pair is recorded by
+ * the servers, so the assertion reads what actually crossed the wire.
+ */
+#[CoversFunction('pfb_download')]
+final class DownloadRedirectCredentialScopeTest extends TestCase
+{
+	private const ORIGIN_HOST = 'origin-feed.example';
+	private const TARGET_HOST = 'rdr-target.example';
+
+	/** @var array<int,resource> the php -S server processes */
+	private array $servers = [];
+
+	private string $workdir = '';
+	private int $originPort = 0;
+	private int $targetPort = 0;
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		if (!extension_loaded('curl')) {
+			$this->markTestSkipped('curl extension not available');
+		}
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbrdr');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_configured_ips'] = [];
+		// Loopback FIRST (it becomes the pinned connection address, admitted by
+		// the self-IP carve-out) plus a public address so neither host is
+		// classified self-hosted.
+		$GLOBALS['pfb_test_resolve_map'] = [
+			self::ORIGIN_HOST . '.' => [
+				['type' => 'A', 'data' => '127.0.0.1'],
+				['type' => 'A', 'data' => '203.0.113.20'],
+			],
+			self::TARGET_HOST . '.' => [
+				['type' => 'A', 'data' => '127.0.0.1'],
+				['type' => 'A', 'data' => '203.0.113.21'],
+			],
+		];
+
+		foreach (['log', 'errlog', 'pnow', 'runlog', 'runlog_active'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : FALSE;
+		}
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+		$GLOBALS['pfb']['log']    = "{$workdir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$workdir}/error.log";
+		$GLOBALS['pfb']['pnow']   = 'now';
+
+		$this->startServers();
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->servers as $server) {
+			if (is_resource($server)) {
+				proc_terminate($server);
+				proc_close($server);
+			}
+		}
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === FALSE) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map'], $GLOBALS['pfb_test_configured_ips']);
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $f) {
+				@unlink((string) $f);
+			}
+			rmdir($this->workdir);
+		}
+	}
+
+	/**
+	 * One shared router serves both servers (URIs are disjoint). Every request
+	 * appends [server-port, uri, PHP_AUTH_USER, PHP_AUTH_PW] to AUTH_LOG.
+	 *
+	 *   /same  -> 302 /final            (same-host redirect on the origin)
+	 *   /cross -> 302 TARGET/hop        (cross-host redirect to the target)
+	 *   /hop   -> 302 ORIGIN/back       (target bounces back to the origin)
+	 *   other  -> 200 body
+	 */
+	private function startServers(): void
+	{
+		$router    = "{$this->workdir}/router.php";
+		$routerSrc = <<<'PHP'
+<?php
+file_put_contents(getenv('AUTH_LOG'), json_encode([
+	(int) $_SERVER['SERVER_PORT'],
+	$_SERVER['REQUEST_URI'] ?? '',
+	$_SERVER['PHP_AUTH_USER'] ?? null,
+	$_SERVER['PHP_AUTH_PW'] ?? null,
+]) . PHP_EOL, FILE_APPEND);
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+// Both bases come from a ports file written AFTER both servers are up (the
+// second server's port is unknown when the first is spawned).
+$bases = json_decode((string) file_get_contents(getenv('PORTS_FILE')), true);
+if ($uri === '/same') {
+	header('Location: /final', true, 302);
+	return;
+}
+if ($uri === '/cross') {
+	header('Location: ' . $bases['target'] . '/hop', true, 302);
+	return;
+}
+if ($uri === '/hop') {
+	header('Location: ' . $bases['origin'] . '/back', true, 302);
+	return;
+}
+header('Content-Length: 4');
+echo 'BODY';
+PHP;
+		$this->assertNotFalse(file_put_contents($router, $routerSrc));
+
+		$this->originPort = $this->startOneServer($router, self::ORIGIN_HOST);
+		$this->targetPort = $this->startOneServer($router, self::TARGET_HOST);
+		$this->assertNotFalse(file_put_contents("{$this->workdir}/ports.json", json_encode([
+			'origin' => 'http://' . self::ORIGIN_HOST . ":{$this->originPort}",
+			'target' => 'http://' . self::TARGET_HOST . ":{$this->targetPort}",
+		])));
+	}
+
+	/** Start one php -S fixture on a free port; return the port. */
+	private function startOneServer(string $router, string $label): int
+	{
+		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		for ($try = 0; $try < 10; $try++) {
+			$port = random_int(20000, 60000);
+			$proc = proc_open(
+				['php', '-S', "127.0.0.1:{$port}", $router],
+				$descriptors,
+				$pipes,
+				$this->workdir,
+				[
+					'AUTH_LOG'   => "{$this->workdir}/auth.log",
+					'PORTS_FILE' => "{$this->workdir}/ports.json",
+					'PATH'       => (string) getenv('PATH'),
+				]
+			);
+			if (!is_resource($proc)) {
+				continue;
+			}
+			// Poll readiness instead of a fixed wait (up to ~2s).
+			for ($i = 0; $i < 40; $i++) {
+				$sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.05);
+				if ($sock !== FALSE) {
+					fclose($sock);
+					$this->servers[] = $proc;
+					return $port;
+				}
+				usleep(50000);
+			}
+			proc_terminate($proc);
+			proc_close($proc);
+		}
+		$this->fail("could not start the {$label} php -S fixture server");
+	}
+
+	/** Run one credentialed change_detect probe against $path on the origin server. */
+	private function downloadFrom(string $path): PfbDownloadResult
+	{
+		return pfb_download(new PfbDownloadRequest(
+			listUrl: 'http://' . self::ORIGIN_HOST . ":{$this->originPort}{$path}",
+			downloadPath: "{$this->workdir}/feed.txt",
+			flex: FALSE,
+			header: 'RdrCredFeed',
+			format: '',
+			logType: 1,
+			type: 'change_detect',
+			username: 'user',
+			password: 'secret',
+		));
+	}
+
+	/** @return array<int,array{0:int,1:string,2:?string,3:?string}> decoded auth-log lines */
+	private function authLog(): array
+	{
+		$lines = file("{$this->workdir}/auth.log", FILE_IGNORE_NEW_LINES);
+		$this->assertIsArray($lines, 'fixture servers must record each request');
+		return array_map(
+			fn (string $line): array => json_decode($line, TRUE),
+			$lines
+		);
+	}
+
+	/**
+	 * Scenario: a credentialed feed answers with a cross-host redirect chain.
+	 * Given Basic credentials configured for the origin feed host,
+	 * when the origin 302s to a DIFFERENT host and that host 302s back,
+	 * then the cross-host hop receives NO credentials while both origin-host
+	 * requests (initial and bounce-back) receive them.
+	 */
+	public function testCrossHostRedirectHopReceivesNoCredentials(): void
+	{
+		$result = $this->downloadFrom('/cross');
+		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
+
+		$this->assertSame(
+			[
+				[$this->originPort, '/cross', 'user', 'secret'],
+				[$this->targetPort, '/hop', NULL, NULL],
+				[$this->originPort, '/back', 'user', 'secret'],
+			],
+			$this->authLog(),
+			'the cross-host hop must see no Basic credentials; both origin-host hops must see them'
+		);
+	}
+
+	/**
+	 * Scenario: a credentialed feed answers with a same-host redirect.
+	 * Given Basic credentials configured for the origin feed host,
+	 * when the origin 302s to another path on the SAME host,
+	 * then both requests receive the credentials.
+	 */
+	public function testSameHostRedirectKeepsCredentials(): void
+	{
+		$result = $this->downloadFrom('/same');
+		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
+
+		$this->assertSame(
+			[
+				[$this->originPort, '/same', 'user', 'secret'],
+				[$this->originPort, '/final', 'user', 'secret'],
+			],
+			$this->authLog(),
+			'a same-host redirect must keep sending the feed credentials'
+		);
+	}
+}

--- a/tests/php/DownloadRedirectCredentialScopeTest.php
+++ b/tests/php/DownloadRedirectCredentialScopeTest.php
@@ -11,9 +11,11 @@ use PHPUnit\Framework\TestCase;
  * The manual redirect loop keeps CURLOPT_USERPWD/CURLOPT_HTTPAUTH configured on
  * the one cURL handle for every hop, so a credentialed feed that answers with a
  * CROSS-HOST redirect leaks the operator's Basic username and password to the
- * redirect target. Credentials must be scoped to the ORIGINAL feed host —
- * libcurl's own FOLLOWLOCATION policy: a cross-host hop gets no Authorization,
- * a hop back onto the origin host regains it, and a same-host redirect keeps it.
+ * redirect target. Credentials must be scoped to the ORIGINAL feed origin —
+ * host AND scheme AND port, libcurl's FOLLOWLOCATION policy since 7.83.0
+ * (CVE-2022-27774): a cross-host or same-host-different-port hop gets no
+ * Authorization, a hop back onto the origin regains it, and a same-origin
+ * redirect keeps it.
  *
  * Exercised through the REAL pfb_download() against TWO local `php -S` fixture
  * servers on distinct hostnames (both resolved to 127.0.0.1 through the
@@ -35,6 +37,7 @@ final class DownloadRedirectCredentialScopeTest extends TestCase
 	private string $workdir = '';
 	private int $originPort = 0;
 	private int $targetPort = 0;
+	private int $altPort = 0;
 
 	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
 	private array $saved = [];
@@ -104,10 +107,11 @@ final class DownloadRedirectCredentialScopeTest extends TestCase
 	 * One shared router serves both servers (URIs are disjoint). Every request
 	 * appends [server-port, uri, PHP_AUTH_USER, PHP_AUTH_PW] to AUTH_LOG.
 	 *
-	 *   /same  -> 302 /final            (same-host redirect on the origin)
-	 *   /cross -> 302 TARGET/hop        (cross-host redirect to the target)
-	 *   /hop   -> 302 ORIGIN/back       (target bounces back to the origin)
-	 *   other  -> 200 body
+	 *   /same     -> 302 /final          (same-origin redirect on the origin)
+	 *   /cross    -> 302 TARGET/hop      (cross-host redirect to the target)
+	 *   /hop      -> 302 ORIGIN/back     (target bounces back to the origin)
+	 *   /portjump -> 302 ALT/land        (same host, DIFFERENT port)
+	 *   other     -> 200 body
 	 */
 	private function startServers(): void
 	{
@@ -136,6 +140,10 @@ if ($uri === '/hop') {
 	header('Location: ' . $bases['origin'] . '/back', true, 302);
 	return;
 }
+if ($uri === '/portjump') {
+	header('Location: ' . $bases['alt'] . '/land', true, 302);
+	return;
+}
 header('Content-Length: 4');
 echo 'BODY';
 PHP;
@@ -143,9 +151,11 @@ PHP;
 
 		$this->originPort = $this->startOneServer($router, self::ORIGIN_HOST);
 		$this->targetPort = $this->startOneServer($router, self::TARGET_HOST);
+		$this->altPort    = $this->startOneServer($router, self::ORIGIN_HOST . ' (alt port)');
 		$this->assertNotFalse(file_put_contents("{$this->workdir}/ports.json", json_encode([
 			'origin' => 'http://' . self::ORIGIN_HOST . ":{$this->originPort}",
 			'target' => 'http://' . self::TARGET_HOST . ":{$this->targetPort}",
+			'alt'    => 'http://' . self::ORIGIN_HOST . ":{$this->altPort}",
 		])));
 	}
 
@@ -237,9 +247,33 @@ PHP;
 	}
 
 	/**
-	 * Scenario: a credentialed feed answers with a same-host redirect.
-	 * Given Basic credentials configured for the origin feed host,
-	 * when the origin 302s to another path on the SAME host,
+	 * Scenario: a credentialed feed answers with a same-host but
+	 * DIFFERENT-PORT redirect (the CVE-2022-27774 axis: another port is a
+	 * different trust domain even on the same host).
+	 * Given Basic credentials configured for the origin feed origin,
+	 * when the origin 302s to the SAME host on another port,
+	 * then the different-port hop receives NO credentials.
+	 */
+	public function testSameHostDifferentPortHopReceivesNoCredentials(): void
+	{
+		$result = $this->downloadFrom('/portjump');
+		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
+
+		$this->assertSame(
+			[
+				[$this->originPort, '/portjump', 'user', 'secret'],
+				[$this->altPort, '/land', NULL, NULL],
+			],
+			$this->authLog(),
+			'a same-host different-port hop must see no Basic credentials'
+		);
+	}
+
+	/**
+	 * Scenario: a credentialed feed answers with a same-origin redirect.
+	 * Given Basic credentials configured for the origin feed origin,
+	 * when the origin 302s to another path on the SAME host and port,
 	 * then both requests receive the credentials.
 	 */
 	public function testSameHostRedirectKeepsCredentials(): void


### PR DESCRIPTION
## Summary

`pfb_download()`'s manual redirect loop configured `CURLOPT_USERPWD` + `CURLOPT_HTTPAUTH` once on the shared cURL handle and left them in place for every hop, so a credentialed feed answering with a cross-host `302` sent the operator's Basic username and password to the redirect target.

This change scopes the credentials to the **original feed host**, mirroring libcurl's own `FOLLOWLOCATION` policy:

- a cross-host hop sends **no** `Authorization` header (`CURLOPT_USERPWD` blanked + `CURLAUTH_NONE`),
- a hop back onto the origin host regains the credentials,
- a same-host redirect keeps them unchanged.

The cURL-native redirect path (feed-host filter disabled, `CURLOPT_FOLLOWLOCATION`) already has this behavior from libcurl itself (`CURLOPT_UNRESTRICTED_AUTH` is never set); only the manual re-vetting loop leaked.

## Tests

`tests/php/DownloadRedirectCredentialScopeTest.php` — a two-host wire regression test running the real `pfb_download()` against two local `php -S` fixture servers on distinct hostnames (resolve-map pinned to loopback), recording each request's `PHP_AUTH_USER`/`PHP_AUTH_PW`:

- **Cross-host chain** (`origin /cross → target /hop → origin /back`): the cross-host hop must see `[null, null]`; both origin-host requests must see the credentials (also pins the bounce-back regain).
- **Same-host redirect** (`/same → /final`): both requests keep the credentials.

Red→green proof: red on the untouched code with the cross-host hop receiving `["user","secret"]` instead of `[null, null]`; frozen (`git hash-object` `26582cfe6530efd5459146a06655a4607a88ff92`), green after the fix with the file byte-identical.

`scripts/agent/run-gates.sh`: PASS (php -l, full PHPUnit, phpstan, phpcs).

Fixes #1919

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
