### PR TITLE
pfblockerng: scope extra Authorization headers to the feed origin

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12699,6 +12699,15 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					curl_setopt($ch, CURLOPT_HTTPHEADER, $http_headers);
 				}
 
+				// Issue #1953: a caller-supplied Authorization header (the TOP1M
+				// Radar Bearer token) is an origin credential like CURLOPT_USERPWD
+				// and must not ride an off-origin redirect hop; the redirect loop
+				// below swaps between the full list and this one. Non-credential
+				// headers (e.g. If-None-Match) stay on every hop.
+				$offorigin_http_headers = array_values(array_filter($http_headers,
+					fn (string $hdr): bool => stripos($hdr, 'Authorization:') !== 0));
+				$headers_have_auth = count($offorigin_http_headers) !== count($http_headers);
+
 				if ($srcint) {
 					curl_setopt($ch, CURLOPT_INTERFACE, $srcint);	// Use a specific interface when downloading lists
 					pfb_logger("\nList: {$header} will be downloaded via interface: {$srcint}\n", 1);
@@ -12835,16 +12844,24 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					// back onto the origin regains it. CURLAUTH_NONE (with
 					// the userpwd blanked) stops libcurl from sending any
 					// Authorization header.
+					$hop_on_origin = (strcasecmp($next['host'], $feed_host) === 0 &&
+							  $next['scheme'] === $feed_scheme &&
+							  $next['port'] === $feed_port);
 					if ($feed_has_creds) {
-						if (strcasecmp($next['host'], $feed_host) === 0 &&
-						    $next['scheme'] === $feed_scheme &&
-						    $next['port'] === $feed_port) {
+						if ($hop_on_origin) {
 							curl_setopt($ch, CURLOPT_USERPWD, "{$username}:{$password}");
 							curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
 						} else {
 							curl_setopt($ch, CURLOPT_USERPWD, '');
 							curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_NONE);
 						}
+					}
+					// Issue #1953: the caller-supplied Authorization header gets
+					// the same origin scope (an empty off-origin list resets
+					// CURLOPT_HTTPHEADER to cURL defaults).
+					if ($headers_have_auth) {
+						curl_setopt($ch, CURLOPT_HTTPHEADER,
+							$hop_on_origin ? $http_headers : $offorigin_http_headers);
 					}
 
 					// Re-point cURL at the vetted target and re-pin its address. The

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12703,7 +12703,11 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				// Radar Bearer token) is an origin credential like CURLOPT_USERPWD
 				// and must not ride an off-origin redirect hop; the redirect loop
 				// below swaps between the full list and this one. Non-credential
-				// headers (e.g. If-None-Match) stay on every hop.
+				// headers (e.g. If-None-Match) stay on every hop. The literal
+				// prefix matches the only credential header any caller passes
+				// today (pfb_top1m_auth_headers); a provider descriptor
+				// introducing a different credential header name must extend
+				// this filter.
 				$offorigin_http_headers = array_values(array_filter($http_headers,
 					fn (string $hdr): bool => stripos($hdr, 'Authorization:') !== 0));
 				$headers_have_auth = count($offorigin_http_headers) !== count($http_headers);

--- a/tests/php/DownloadRedirectCredentialScopeTest.php
+++ b/tests/php/DownloadRedirectCredentialScopeTest.php
@@ -105,9 +105,10 @@ final class DownloadRedirectCredentialScopeTest extends TestCase
 
 	/**
 	 * One shared router serves both servers (URIs are disjoint). Every request
-	 * appends [server-port, uri, PHP_AUTH_USER, PHP_AUTH_PW, HTTP_AUTHORIZATION]
-	 * to AUTH_LOG (the raw Authorization header covers non-Basic credentials —
-	 * the issue #1953 Bearer-token axis).
+	 * appends [server-port, uri, PHP_AUTH_USER, PHP_AUTH_PW, HTTP_AUTHORIZATION,
+	 * HTTP_X_FEED_PROBE] to AUTH_LOG (the raw Authorization header covers
+	 * non-Basic credentials — the issue #1953 Bearer-token axis; X-Feed-Probe
+	 * stands in for a non-credential extra header that must ride every hop).
 	 *
 	 *   /same     -> 302 /final          (same-origin redirect on the origin)
 	 *   /cross    -> 302 TARGET/hop      (cross-host redirect to the target)
@@ -126,6 +127,7 @@ file_put_contents(getenv('AUTH_LOG'), json_encode([
 	$_SERVER['PHP_AUTH_USER'] ?? null,
 	$_SERVER['PHP_AUTH_PW'] ?? null,
 	$_SERVER['HTTP_AUTHORIZATION'] ?? null,
+	$_SERVER['HTTP_X_FEED_PROBE'] ?? null,
 ]) . PHP_EOL, FILE_APPEND);
 $uri = $_SERVER['REQUEST_URI'] ?? '';
 // Both bases come from a ports file written AFTER both servers are up (the
@@ -225,7 +227,7 @@ PHP;
 		return 'Basic ' . base64_encode('user:secret');
 	}
 
-	/** @return array<int,array{0:int,1:string,2:?string,3:?string,4:?string}> decoded auth-log lines */
+	/** @return array<int,array{0:int,1:string,2:?string,3:?string,4:?string,5:?string}> decoded auth-log lines */
 	private function authLog(): array
 	{
 		$lines = file("{$this->workdir}/auth.log", FILE_IGNORE_NEW_LINES);
@@ -251,9 +253,9 @@ PHP;
 
 		$this->assertSame(
 			[
-				[$this->originPort, '/cross', 'user', 'secret', $this->basicHeader()],
-				[$this->targetPort, '/hop', NULL, NULL, NULL],
-				[$this->originPort, '/back', 'user', 'secret', $this->basicHeader()],
+				[$this->originPort, '/cross', 'user', 'secret', $this->basicHeader(), NULL],
+				[$this->targetPort, '/hop', NULL, NULL, NULL, NULL],
+				[$this->originPort, '/back', 'user', 'secret', $this->basicHeader(), NULL],
 			],
 			$this->authLog(),
 			'the cross-host hop must see no Basic credentials; both origin-host hops must see them'
@@ -277,12 +279,41 @@ PHP;
 
 		$this->assertSame(
 			[
-				[$this->originPort, '/cross', NULL, NULL, 'Bearer SECRET-TOKEN'],
-				[$this->targetPort, '/hop', NULL, NULL, NULL],
-				[$this->originPort, '/back', NULL, NULL, 'Bearer SECRET-TOKEN'],
+				[$this->originPort, '/cross', NULL, NULL, 'Bearer SECRET-TOKEN', NULL],
+				[$this->targetPort, '/hop', NULL, NULL, NULL, NULL],
+				[$this->originPort, '/back', NULL, NULL, 'Bearer SECRET-TOKEN', NULL],
 			],
 			$this->authLog(),
 			'the cross-host hop must see no Authorization header; both origin-host hops must see the token'
+		);
+	}
+
+	/**
+	 * Scenario: the extra-header list mixes a credential and a non-credential
+	 * header (the real shape: the Radar Bearer token beside an ADR-42
+	 * conditional-GET header).
+	 * Given both an Authorization header and a non-credential extra header,
+	 * when the origin 302s cross-host and that host 302s back,
+	 * then the off-origin hop keeps the non-credential header while losing
+	 * ONLY the Authorization header (the filter must not drop the whole list).
+	 */
+	public function testCrossHostRedirectKeepsNonCredentialExtraHeaders(): void
+	{
+		$result = $this->downloadFrom('/cross', '', '', [
+			'Authorization: Bearer SECRET-TOKEN',
+			'X-Feed-Probe: keep',
+		]);
+		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
+
+		$this->assertSame(
+			[
+				[$this->originPort, '/cross', NULL, NULL, 'Bearer SECRET-TOKEN', 'keep'],
+				[$this->targetPort, '/hop', NULL, NULL, NULL, 'keep'],
+				[$this->originPort, '/back', NULL, NULL, 'Bearer SECRET-TOKEN', 'keep'],
+			],
+			$this->authLog(),
+			'the off-origin hop must keep non-credential extra headers while losing only Authorization'
 		);
 	}
 
@@ -302,8 +333,8 @@ PHP;
 
 		$this->assertSame(
 			[
-				[$this->originPort, '/portjump', 'user', 'secret', $this->basicHeader()],
-				[$this->altPort, '/land', NULL, NULL, NULL],
+				[$this->originPort, '/portjump', 'user', 'secret', $this->basicHeader(), NULL],
+				[$this->altPort, '/land', NULL, NULL, NULL, NULL],
 			],
 			$this->authLog(),
 			'a same-host different-port hop must see no Basic credentials'
@@ -324,8 +355,8 @@ PHP;
 
 		$this->assertSame(
 			[
-				[$this->originPort, '/same', 'user', 'secret', $this->basicHeader()],
-				[$this->originPort, '/final', 'user', 'secret', $this->basicHeader()],
+				[$this->originPort, '/same', 'user', 'secret', $this->basicHeader(), NULL],
+				[$this->originPort, '/final', 'user', 'secret', $this->basicHeader(), NULL],
 			],
 			$this->authLog(),
 			'a same-host redirect must keep sending the feed credentials'

--- a/tests/php/DownloadRedirectCredentialScopeTest.php
+++ b/tests/php/DownloadRedirectCredentialScopeTest.php
@@ -105,7 +105,9 @@ final class DownloadRedirectCredentialScopeTest extends TestCase
 
 	/**
 	 * One shared router serves both servers (URIs are disjoint). Every request
-	 * appends [server-port, uri, PHP_AUTH_USER, PHP_AUTH_PW] to AUTH_LOG.
+	 * appends [server-port, uri, PHP_AUTH_USER, PHP_AUTH_PW, HTTP_AUTHORIZATION]
+	 * to AUTH_LOG (the raw Authorization header covers non-Basic credentials —
+	 * the issue #1953 Bearer-token axis).
 	 *
 	 *   /same     -> 302 /final          (same-origin redirect on the origin)
 	 *   /cross    -> 302 TARGET/hop      (cross-host redirect to the target)
@@ -123,6 +125,7 @@ file_put_contents(getenv('AUTH_LOG'), json_encode([
 	$_SERVER['REQUEST_URI'] ?? '',
 	$_SERVER['PHP_AUTH_USER'] ?? null,
 	$_SERVER['PHP_AUTH_PW'] ?? null,
+	$_SERVER['HTTP_AUTHORIZATION'] ?? null,
 ]) . PHP_EOL, FILE_APPEND);
 $uri = $_SERVER['REQUEST_URI'] ?? '';
 // Both bases come from a ports file written AFTER both servers are up (the
@@ -196,8 +199,12 @@ PHP;
 	}
 
 	/** Run one credentialed change_detect probe against $path on the origin server. */
-	private function downloadFrom(string $path): PfbDownloadResult
-	{
+	private function downloadFrom(
+		string $path,
+		string $username = 'user',
+		string $password = 'secret',
+		array $extraHeaders = []
+	): PfbDownloadResult {
 		return pfb_download(new PfbDownloadRequest(
 			listUrl: 'http://' . self::ORIGIN_HOST . ":{$this->originPort}{$path}",
 			downloadPath: "{$this->workdir}/feed.txt",
@@ -206,12 +213,19 @@ PHP;
 			format: '',
 			logType: 1,
 			type: 'change_detect',
-			username: 'user',
-			password: 'secret',
+			username: $username,
+			password: $password,
+			extraHeaders: $extraHeaders,
 		));
 	}
 
-	/** @return array<int,array{0:int,1:string,2:?string,3:?string}> decoded auth-log lines */
+	/** The Authorization header value cURL derives from the Basic credentials. */
+	private function basicHeader(): string
+	{
+		return 'Basic ' . base64_encode('user:secret');
+	}
+
+	/** @return array<int,array{0:int,1:string,2:?string,3:?string,4:?string}> decoded auth-log lines */
 	private function authLog(): array
 	{
 		$lines = file("{$this->workdir}/auth.log", FILE_IGNORE_NEW_LINES);
@@ -237,12 +251,38 @@ PHP;
 
 		$this->assertSame(
 			[
-				[$this->originPort, '/cross', 'user', 'secret'],
-				[$this->targetPort, '/hop', NULL, NULL],
-				[$this->originPort, '/back', 'user', 'secret'],
+				[$this->originPort, '/cross', 'user', 'secret', $this->basicHeader()],
+				[$this->targetPort, '/hop', NULL, NULL, NULL],
+				[$this->originPort, '/back', 'user', 'secret', $this->basicHeader()],
 			],
 			$this->authLog(),
 			'the cross-host hop must see no Basic credentials; both origin-host hops must see them'
+		);
+	}
+
+	/**
+	 * Scenario: a feed authenticated via a caller-supplied Authorization header
+	 * (the TOP1M Radar Bearer token, issue #1953) answers with a cross-host
+	 * redirect chain.
+	 * Given an extra "Authorization: Bearer" header configured for the feed,
+	 * when the origin 302s to a DIFFERENT host and that host 302s back,
+	 * then the cross-host hop receives NO Authorization header while both
+	 * origin-host requests (initial and bounce-back) receive the token.
+	 */
+	public function testCrossHostRedirectHopReceivesNoAuthorizationHeader(): void
+	{
+		$result = $this->downloadFrom('/cross', '', '', ['Authorization: Bearer SECRET-TOKEN']);
+		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
+
+		$this->assertSame(
+			[
+				[$this->originPort, '/cross', NULL, NULL, 'Bearer SECRET-TOKEN'],
+				[$this->targetPort, '/hop', NULL, NULL, NULL],
+				[$this->originPort, '/back', NULL, NULL, 'Bearer SECRET-TOKEN'],
+			],
+			$this->authLog(),
+			'the cross-host hop must see no Authorization header; both origin-host hops must see the token'
 		);
 	}
 
@@ -262,8 +302,8 @@ PHP;
 
 		$this->assertSame(
 			[
-				[$this->originPort, '/portjump', 'user', 'secret'],
-				[$this->altPort, '/land', NULL, NULL],
+				[$this->originPort, '/portjump', 'user', 'secret', $this->basicHeader()],
+				[$this->altPort, '/land', NULL, NULL, NULL],
 			],
 			$this->authLog(),
 			'a same-host different-port hop must see no Basic credentials'
@@ -284,8 +324,8 @@ PHP;
 
 		$this->assertSame(
 			[
-				[$this->originPort, '/same', 'user', 'secret'],
-				[$this->originPort, '/final', 'user', 'secret'],
+				[$this->originPort, '/same', 'user', 'secret', $this->basicHeader()],
+				[$this->originPort, '/final', 'user', 'secret', $this->basicHeader()],
 			],
 			$this->authLog(),
 			'a same-host redirect must keep sending the feed credentials'


### PR DESCRIPTION
## Summary

`pfb_download()` sent caller-supplied extra HTTP headers (`CURLOPT_HTTPHEADER`) on every hop of the manual redirect loop, so the TOP1M Cloudflare Radar provider's `Authorization: Bearer <token>` header rode cross-host redirects to the redirect target — the same defect class PR #1950 (issue #1919) fixed for `CURLOPT_USERPWD` Basic credentials, on the extra-headers axis. Wire-proven during that PR's adversarial review.

The fix splits the merged header list once before the loop and swaps it per hop using the same origin comparison (host AND scheme AND port) introduced in #1919:

- an on-origin hop gets the full list,
- an off-origin hop gets the list with `Authorization` headers removed (an empty list resets `CURLOPT_HTTPHEADER` to cURL defaults),
- non-credential headers (e.g. the ADR-42 `If-None-Match`) stay on every hop,
- feeds with no `Authorization` extra header keep byte-identical behaviour (the per-hop swap is skipped entirely).

## Tests

Extends `tests/php/DownloadRedirectCredentialScopeTest.php`: the fixture servers now record the raw `HTTP_AUTHORIZATION` header as a fifth column (pinning the Basic header on the existing chains), and a new Bearer-token cross-host chain case (`origin /cross → target /hop → origin /back`) asserts the cross-host hop sees no `Authorization` header while both origin-host requests carry the token (bounce-back regain included).

Red→green proof: red on the untouched code with the cross-host hop receiving `Bearer SECRET-TOKEN` instead of `null`; frozen (`git hash-object` `93cae9541f1839dbddc623e6263c364b664c01d1`), green after the fix with the file byte-identical.

`scripts/agent/run-gates.sh --diff origin/devel`: PASS (php -l, full PHPUnit, phpstan, phpcs).

Fixes #1953

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect handling for caller-supplied authorization headers.
  * Authorization credentials are withheld when requests follow redirects to a different host or port.
  * Credentials are restored when redirects return to the original destination.
  * Other non-sensitive headers continue to follow redirects as expected.
  * Basic and Bearer authentication behavior is now more consistently validated across redirect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->