### PR TITLE
pfblockerng: stop the range regex slicing endpoints out of malformed lines

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -2962,7 +2962,10 @@ function sync_package_pfblockerng($cron='') {
 	#################################################
 
 	// IPv4 REGEX Definitions
-	$pfb['range']	= '/((?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))-((?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))/';
+	// issue #1934: same [\w.] boundary classes as $pfb['ipv4'] below, so a
+	// garbage-adjacent endpoint (999.1.2.3.4-5.6.7.8) drops the range instead
+	// of expanding fabricated endpoints into a subnet span.
+	$pfb['range']	= '/(?<![\w.])((?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))-((?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))(?![\w.])/';
 	// issue #1922: boundary class = word chars + the family's own separator
 	// ('.'), so a glued-on neighbour (v4.1.2.3.4, 999.1.2.3.4) drops instead of
 	// fabricating an address; the mask guard sits INSIDE the optional group so

--- a/tests/php/IpRegexBoundaryGuardTest.php
+++ b/tests/php/IpRegexBoundaryGuardTest.php
@@ -70,6 +70,12 @@ final class IpRegexBoundaryGuardTest extends TestCase
 		return preg_match_all($re, $line, $m) ? $m[0] : [];
 	}
 
+	/** Range extraction: the [start, end] capture pair, or the empty set. */
+	private function extractRange(string $line): array
+	{
+		return preg_match(self::$reRange, $line, $m) ? [$m[1], $m[2]] : [];
+	}
+
 	/**
 	 * The issue #1922 spec table for IPv4: line => [regex match set, parser entries].
 	 * A '-' spec row is the empty set. Parity rows pin today's behaviour as the
@@ -141,6 +147,46 @@ final class IpRegexBoundaryGuardTest extends TestCase
 			// rather than risking a wrong extraction from comment text
 			'trailing period'           => ['2001:db8::1.', [], []],
 		];
+	}
+
+	/**
+	 * The issue #1934 spec table for the v4 range regex: line => [[start, end]
+	 * capture pair, parser entries]. Same boundary rule as ipv4: a quad glued to
+	 * word chars or extra octets is not a range endpoint, so a malformed line
+	 * drops the range instead of expanding fabricated endpoints into a subnet
+	 * span; the ipv4 fallback still recovers any genuinely present address.
+	 */
+	public static function rangeRows(): array
+	{
+		return [
+			// CHANGED: garbage-adjacent endpoints no longer slice a range out of the line
+			'malformed octet 999.'      => ['999.1.2.3.4-5.6.7.8', [], ['5.6.7.8']],
+			'version label v4.'         => ['v4.1.2.3.4-5.6.7.8', [], ['5.6.7.8']],
+			'glued label foo.'          => ['foo.1.2.3.4-5.6.7.8', [], ['5.6.7.8']],
+			'glued letter start'        => ['x1.2.3.4-5.6.7.8', [], ['5.6.7.8']],
+			'five-octet end'            => ['1.2.3.4-5.6.7.8.9', [], ['1.2.3.4']],
+			'glued letter end'          => ['1.2.3.4-5.6.7.8beta', [], ['1.2.3.4']],
+			// Parity: genuine quad-quad ranges expand exactly as today
+			'plain range'               => ['10.0.0.0-10.0.0.3', ['10.0.0.0', '10.0.0.3'], ['10.0.0.0/30']],
+			'single-address range'      => ['10.0.0.1-10.0.0.1', ['10.0.0.1', '10.0.0.1'], ['10.0.0.1']],
+			'iblocklist range'          => ['4.53.2.12-4.53.2.15', ['4.53.2.12', '4.53.2.15'], ['4.53.2.12/30']],
+			'range then comment'        => ['10.0.0.0-10.0.0.3 # comment', ['10.0.0.0', '10.0.0.3'], ['10.0.0.0/30']],
+		];
+	}
+
+	#[DataProvider('rangeRows')]
+	public function testRangeRegexExtractionMatchesSpec(string $line, array $matches, array $entries): void
+	{
+		$this->assertSame($matches, $this->extractRange($line),
+			"range regex extraction differs from the issue #1934 spec for: {$line}");
+	}
+
+	#[DataProvider('rangeRows')]
+	public function testRangeParserEntriesMatchSpec(string $line, array $matches, array $entries): void
+	{
+		$result = pfb_ip_parse_line($line, $this->config('_v4'));
+		$this->assertSame($entries, $result['entries'],
+			"pfb_ip_parse_line() entries differ from the issue #1934 spec for: {$line}");
 	}
 
 	#[DataProvider('ipv4Rows')]


### PR DESCRIPTION
Fixes #1934

## What

`$pfb['range']` (the v4 range extraction regex in `pfblockerng_apply.inc`) had no boundary guards, so a malformed feed line like `999.1.2.3.4-5.6.7.8` sliced `1.2.3.4`–`5.6.7.8` out of the garbage and `ip_range_to_subnet_array()` expanded it into a 28-subnet block span covering addresses present nowhere in the input — the same silent address-fabrication class issue #1922 / PR #1932 closed for `$pfb['ipv4']` and `$pfb['ipv6']`.

This applies the same `[\w.]` boundary classes to the range regex: `(?<![\w.])` before the first endpoint, `(?![\w.])` after the second (the `-` separator sits between the capture groups, so genuine `quad-quad` ranges match unchanged). When the guarded range regex drops a malformed line, the guarded `$pfb['ipv4']` fallback still recovers any address genuinely present in the text.

## Test-first proof (executed)

New `rangeRows` spec table in `IpRegexBoundaryGuardTest` (regex-level extraction + parser-level entries, mirroring the #1922 tables): 6 CHANGED rows (garbage-prefixed/-suffixed endpoints) + 4 parity rows (plain, single-address, iBlocklist-shape, trailing comment).

- **RED** on untouched code: `12 failures` (6 CHANGED rows × 2 tests; parity rows green) — test file `git hash-object` `42c63b6352b281de44d07f413935d89291cd8fc2`.
- **GREEN** after the one-literal fix, test file byte-identical (same hash): `OK (104 tests, 115 assertions)`.
- Gates: `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (php -l, phpunit, phpstan, phpcs).

## Out of scope

`ip_range_to_subnet_array()` silently swapping a reversed range (upstream pfSense, catalogued in #1922) is untouched: both endpoints of a reversed range are genuinely present in the input, so it is not the fabrication class this issue gates.

---

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
