### PR TITLE
pfblockerng: honour list pre/post-script exit status

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4191,8 +4191,9 @@ function pfb_list_script_exec(string $script_path, string $script_name, string $
 	exec("{$tmo_prefix}" . escapeshellarg($script_path) . " {$args_tail}", $discard, $retval);
 
 	if ($retval === 124) {
-		pfb_logger("\n[ {$header} ] {$stage}-script '{$script_name}' TIMED OUT after " . PFB_LIST_SCRIPT_TIMEOUT
-		    . "s (killed); discarding its output\n", 2);
+		// No duration in the message: the budget lives inside $tmo_prefix, so a
+		// restated constant would desync from an injected prefix.
+		pfb_logger("\n[ {$header} ] {$stage}-script '{$script_name}' TIMED OUT (killed); discarding its output\n", 2);
 	} elseif ($retval !== 0) {
 		pfb_logger("\n[ {$header} ] {$stage}-script '{$script_name}' exited non-zero [ {$retval} ]; discarding its output\n", 2);
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4170,6 +4170,36 @@ if (!defined('PFB_HOOK_SCRIPT_DIR')) {
 }
 
 /*
+ * issue #1927: run a per-feed list pre/post transform script and HONOUR its exit
+ * status — a failed transform's leftovers are not feed data; the caller decides
+ * what to keep. Non-zero (124 = timed out) is logged to the pfBlockerNG log AND
+ * the error log, naming the stage, script, and feed. timeout(1) stays in default
+ * (reaper) mode on purpose: a hung transform pipeline must die as a whole tree
+ * (docs/misc/external-process-waits.md "Choosing the mode"). $tmo_prefix is
+ * injectable for off-appliance tests. $args_tail (pre-escaped args + the log
+ * redirect) is appended verbatim.
+ */
+function pfb_list_script_exec(string $script_path, string $script_name, string $stage,
+    string $header, string $args_tail, ?string $tmo_prefix = NULL): int {
+
+	if ($tmo_prefix === NULL) {
+		$tmo_prefix = '/usr/bin/timeout -s TERM -k ' . PFB_HOOK_KILL_GRACE . ' ' . PFB_LIST_SCRIPT_TIMEOUT . ' ';
+	}
+
+	$discard = array();
+	$retval  = 0;
+	exec("{$tmo_prefix}" . escapeshellarg($script_path) . " {$args_tail}", $discard, $retval);
+
+	if ($retval === 124) {
+		pfb_logger("\n[ {$header} ] {$stage}-script '{$script_name}' TIMED OUT after " . PFB_LIST_SCRIPT_TIMEOUT
+		    . "s (killed); discarding its output\n", 2);
+	} elseif ($retval !== 0) {
+		pfb_logger("\n[ {$header} ] {$stage}-script '{$script_name}' exited non-zero [ {$retval} ]; discarding its output\n", 2);
+	}
+	return $retval;
+}
+
+/*
  * Setup-wizard decision helpers (pure; pinned by tests/php/WizardDecisionTest.php).
  * The pfblockerng_wizard.inc / pfblockerng_general.php controllers do the impure work
  * (read $_POST/$_GET/config, redirect, write_config, set $pfb_wizard); the branchy

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4188,7 +4188,12 @@ function pfb_list_script_exec(string $script_path, string $script_name, string $
 
 	$discard = array();
 	$retval  = 0;
-	exec("{$tmo_prefix}" . escapeshellarg($script_path) . " {$args_tail}", $discard, $retval);
+	if (exec("{$tmo_prefix}" . escapeshellarg($script_path) . " {$args_tail}", $discard, $retval) === FALSE &&
+	    $retval === 0) {
+		// exec() itself failed to launch (fork/pipe): a script that never ran
+		// must never read as success.
+		$retval = -1;
+	}
 
 	if ($retval === 124) {
 		// No duration in the message: the budget lives inside $tmo_prefix, so a

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -3358,8 +3358,16 @@ function sync_package_pfblockerng($cron='') {
 								$pfb_user_script = TRUE;
 								$file_dwn_esc = escapeshellarg("{$file_dwn}.orig");
 								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.pre"); // Save original file for restoration
-								$tmo = '/usr/bin/timeout -s TERM -k ' . PFB_HOOK_KILL_GRACE . ' ' . PFB_LIST_SCRIPT_TIMEOUT . ' ';
-								exec("{$tmo}" . escapeshellarg($pfb_script_pre) . " {$file_dwn_esc} {$list['vtype']} {$elog}");
+								if (pfb_list_script_exec($pfb_script_pre, $list['script_pre'], 'pre', $header,
+								    "{$file_dwn_esc} {$list['vtype']} {$elog}") !== 0) {
+									// issue #1927: restore the download over the failed script's
+									// leftovers and keep the last known-good staged list; '.update'
+									// stays so the next run retries the transform.
+									if (file_exists("{$file_dwn}.orig.pre")) {
+										@rename("{$file_dwn}.orig.pre", "{$file_dwn}.orig");
+									}
+									continue;
+								}
 							}
 							if ($pfb_script_post && is_file("{$pfb_script_post}")) {
 								$pfb_user_script = TRUE;
@@ -3429,8 +3437,14 @@ function sync_package_pfblockerng($cron='') {
 								pfb_logger("\nExecuting post-script: {$list['script_post']}\n", 1);
 								$file_org_esc = escapeshellarg("{$file_dwn}.orig");
 								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.post"); // Save original file for restoration
-								$tmo = '/usr/bin/timeout -s TERM -k ' . PFB_HOOK_KILL_GRACE . ' ' . PFB_LIST_SCRIPT_TIMEOUT . ' ';
-								exec("{$tmo}" . escapeshellarg($pfb_script_post) . " {$file_org_esc} {$list['vtype']} {$elog}");
+								if (pfb_list_script_exec($pfb_script_post, $list['script_post'], 'post', $header,
+								    "{$file_org_esc} {$list['vtype']} {$elog}") !== 0) {
+									// issue #1927: restore the download now so the empty-feed check
+									// below reads it, not the failed script's leftovers.
+									if (file_exists("{$file_dwn}.orig.post")) {
+										@rename("{$file_dwn}.orig.post", "{$file_dwn}.orig");
+									}
+								}
 							}
 
 							if (!$custom) {

--- a/tests/php/ListScriptExitStatusTest.php
+++ b/tests/php/ListScriptExitStatusTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1927: the per-feed list pre/post transform scripts' exit status must be
+ * honoured — a failed transform is not feed data.
+ *
+ * pfb_list_script_exec() runs a vetted list script under timeout(1) and returns
+ * its exit code; non-zero (124 = timed out) is logged to the pfBlockerNG log AND
+ * the error log, naming the stage, the script, and the feed. $tmo_prefix is
+ * injectable for off-appliance tests (the appliance default wraps /usr/bin/timeout).
+ *
+ * The apply-loop call sites gate on that code — a failed pre-script's leftovers
+ * are never parsed (the download is restored and the last known-good staged list
+ * kept), and a failed post-script's leftovers never feed the empty-feed check.
+ * Those sites sit inside the thousands-of-lines sync loop driving real appliance
+ * exec, so they are pinned by source inspection (same technique as
+ * GunzipTrailingNewlineWiringTest); the behaviour itself is proven on the helper.
+ */
+#[CoversFunction('pfb_list_script_exec')]
+final class ListScriptExitStatusTest extends TestCase
+{
+	private static string $applySource;
+
+	private string $tmp;
+	/** @var array<string, mixed> */
+	private array $originalPfb;
+	private bool $hadPfb;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		if ($source === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		}
+		self::$applySource = $source;
+	}
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_lse_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		mkdir($this->tmp, 0755, TRUE);
+
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'log'    => "{$this->tmp}/pfblockerng.log",
+			'errlog' => "{$this->tmp}/error.log",
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		foreach (glob("{$this->tmp}/*") ?: [] as $f) {
+			unlink($f);
+		}
+		rmdir($this->tmp);
+	}
+
+	private function makeScript(string $name, string $body): string
+	{
+		$path = "{$this->tmp}/{$name}";
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	private function mainLog(): string
+	{
+		return (string) @file_get_contents("{$this->tmp}/pfblockerng.log");
+	}
+
+	private function errorLog(): string
+	{
+		return (string) @file_get_contents("{$this->tmp}/error.log");
+	}
+
+	public function testZeroExitReturnsZeroAndLogsNoFailure(): void
+	{
+		$script = $this->makeScript('ip_pre_ok.sh', 'exit 0');
+
+		$ret = pfb_list_script_exec($script, 'ip_pre_ok.sh', 'pre', 'MyFeed_v4', '', '');
+
+		$this->assertSame(0, $ret, 'a successful script must report exit 0 to the caller');
+		$this->assertStringNotContainsString('exited non-zero', $this->mainLog(),
+			'a zero exit must not log a failure');
+		$this->assertStringNotContainsString('TIMED OUT', $this->mainLog(),
+			'a zero exit must not log a timeout');
+	}
+
+	public function testNonZeroExitIsReturnedAndLoggedNamingStageScriptAndFeed(): void
+	{
+		$script = $this->makeScript('ip_pre_AWS_fail.sh', 'exit 7');
+
+		$ret = pfb_list_script_exec($script, 'ip_pre_AWS_fail.sh', 'pre', 'MyFeed_v4', '', '');
+
+		$this->assertSame(7, $ret, 'the script exit code must be surfaced, not discarded');
+		$log = $this->mainLog();
+		$this->assertStringContainsString("pre-script 'ip_pre_AWS_fail.sh'", $log,
+			'the failure log line must name the stage and the script');
+		$this->assertStringContainsString('MyFeed_v4', $log,
+			'the failure log line must name the feed');
+		$this->assertStringContainsString('[ 7 ]', $log,
+			'the failure log line must carry the exit code');
+		$this->assertStringContainsString('exited non-zero', $this->errorLog(),
+			'the failure must also surface in the error log');
+	}
+
+	public function testExit124IsLoggedAsTimedOut(): void
+	{
+		// timeout(1) reports an overrun as exit 124 — indistinguishable from the
+		// script exiting 124 itself, which is exactly what the helper keys on.
+		$script = $this->makeScript('ip_post_slow.sh', 'exit 124');
+
+		$ret = pfb_list_script_exec($script, 'ip_post_slow.sh', 'post', 'SlowFeed_v6', '', '');
+
+		$this->assertSame(124, $ret);
+		$log = $this->mainLog();
+		$this->assertStringContainsString('TIMED OUT', $log,
+			'exit 124 must be reported as a timeout, not a generic non-zero');
+		$this->assertStringContainsString("post-script 'ip_post_slow.sh'", $log);
+		$this->assertStringContainsString('SlowFeed_v6', $log);
+		$this->assertStringContainsString('TIMED OUT', $this->errorLog(),
+			'the timeout must also surface in the error log');
+	}
+
+	public function testPreScriptCallSiteGatesOnExitStatus(): void
+	{
+		$prePos = strpos(self::$applySource, 'Executing pre-script:');
+		$this->assertNotFalse($prePos, 'vacuity: the pre-script call site must exist');
+
+		$normPos = strpos(self::$applySource, 'pfb_feed_normalize(', $prePos);
+		$this->assertNotFalse($normPos, 'vacuity: the normalize step after the pre-script must exist');
+
+		$between = substr(self::$applySource, $prePos, $normPos - $prePos);
+		$this->assertStringContainsString('pfb_list_script_exec(', $between,
+			'the pre-script must run through the exit-status-honouring runner');
+		$this->assertStringContainsString('!== 0', $between,
+			'the pre-script exit status must gate the parse — a failed transform is not feed data');
+		$this->assertStringContainsString('@rename("{$file_dwn}.orig.pre", "{$file_dwn}.orig")', $between,
+			'on failure the saved download must be restored over the failed script\'s leftovers');
+		$this->assertStringContainsString('continue;', $between,
+			'on failure the row must skip the parse, keeping the last known-good staged list');
+	}
+
+	public function testPostScriptCallSiteGatesOnExitStatus(): void
+	{
+		$postPos = strpos(self::$applySource, 'Executing post-script:');
+		$this->assertNotFalse($postPos, 'vacuity: the post-script call site must exist');
+
+		$chkPos = strpos(self::$applySource, 'if (!$custom) {', $postPos);
+		$this->assertNotFalse($chkPos, 'vacuity: the empty-feed check after the post-script must exist');
+
+		$between = substr(self::$applySource, $postPos, $chkPos - $postPos);
+		$this->assertStringContainsString('pfb_list_script_exec(', $between,
+			'the post-script must run through the exit-status-honouring runner');
+		$this->assertStringContainsString('!== 0', $between,
+			'the post-script exit status must be examined, not discarded');
+		$this->assertStringContainsString('@rename("{$file_dwn}.orig.post", "{$file_dwn}.orig")', $between,
+			'on failure the saved download must be restored before the empty-feed check reads it');
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -4915,6 +4915,54 @@
             }
         ]
     },
+    "pfb_list_script_exec": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "script_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "script_name",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "stage",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "args_tail",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "tmo_prefix",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_list_section_for_vtype": {
         "returnsRef": false,
         "returnType": "string",


### PR DESCRIPTION
## Summary

Both per-feed list pre/post-script `exec()` call sites discarded the script's exit status, so a failed transform was indistinguishable from success and the parser consumed whatever the failed script left behind (e.g. raw AWS `ip-ranges.json` parsed as an address feed).

- New `pfb_list_script_exec()` runs the script under `timeout(1)`, returns the exit code, and logs non-zero results (124 reported as TIMED OUT) to the pfBlockerNG log **and** the error log, naming the stage, script, and feed.
- **Pre-script failure:** the saved download (`.orig.pre`) is restored over the leftovers and the row skips the parse, keeping the last known-good staged `.txt`; the `.update` marker stays so the next run retries the transform (mirrors the #1022 download-failure semantics).
- **Post-script failure:** the saved download (`.orig.post`) is restored before the empty-feed check reads it.
- Zero exit is byte-for-byte the previous behaviour.

### The `--foreground` lead (issue "Related, unproven")

Deliberately **not** taken: `docs/misc/external-process-waits.md` ("Choosing the mode") documents the list-script default (reaper) mode as intentional — a hung transform pipeline must die as a whole tree; `--foreground` would orphan the inner stages. The hook runner's `--foreground` exists for daemon-restarting hooks, which list scripts must not be.

## Evidence

Red→green, test frozen byte-identical (`git hash-object` = `2d95c57cf48b906ffe9986fd7ea1f52711113953` at both runs):

- **RED** (untouched code): `vendor/bin/phpunit tests/php/ListScriptExitStatusTest.php` → `Tests: 5, Errors: 3, Failures: 2` — errors: `pfb_list_script_exec` undefined; failures: both call sites lack the exit-status gate.
- **GREEN** (after fix, zero test edits): `OK (5 tests, 24 assertions)`.
- Gates: `scripts/agent/run-gates.sh` → `GATES: PASS` (php -l, full PHPUnit 4738 tests, PHPStan, PHPCS).

`tests/php/fixtures/function_inventory.json` regenerated for the new function signature (guarded regen via `PFB_UPDATE_FUNCTION_INVENTORY=1`).

## Acceptance (issue #1927)

- Non-zero pre-script → logged + no parse of leftovers ✔ (helper behaviour tests + call-site wiring pins)
- Zero exit → identical to today ✔
- Timeout-flag alignment → evaluated, rejected with documented rationale (above)

Fixes #1927

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
