### PR TITLE
tests/smoke: restore captured config tokens verbatim in teardown

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1075,6 +1075,24 @@ def config_get(vm: SmokeVM, path: str, *, timeout: float = 60.0) -> str:
     return out[start + len(_CFG_VAL_OPEN) : end]
 
 
+def config_set(vm: SmokeVM, path: str, value: str, *, timeout: float = 60.0) -> None:
+    """Write one scalar config value back VERBATIM (the restore half of config_get).
+
+    Restores must preserve the stored token exactly: a captured canonical ``'off'``
+    round-trips as ``'off'``, never degraded to the raw ``''`` the boolean toggle
+    helpers write (issue #1947 — ``'' != 'off'`` fails a strict restore assert even
+    though both mean Off under the #1887 toggle vocabulary).
+    """
+    snippet = (
+        f"config_set_path({_php_str(path)}, {_php_str(value)});\n"
+        "write_config('pfBlockerNG smoke: restore config value verbatim');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(f"config_set({path!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}")
+
+
 def _php_str(value: str) -> str:
     """Render a Python str as a single-quoted PHP string literal."""
     return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -285,7 +285,7 @@ def test_tick_cron_entry_installed(deployed_vm: SmokeVM) -> None:
             f"the legacy 'pfblockerng.php tick' entry must not survive; got {after[0]!r}"
         )
     finally:
-        h.set_package_enabled(vm, original_enabled == "on")
+        h.config_set(vm, _ENABLE_CB_CFG, original_enabled)
         h.reload(vm, "update")
 
 

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -904,7 +904,7 @@ def test_ip_attribution_cache_invalidated_after_feed_ownership_change(deployed_v
                 header="pfb_syslog_ip",
             ),
         )
-        _set_syslog_enabled(vm, on=original_syslog == "on")
+        h.config_set(vm, CFG_GENERAL + "/log_syslog", original_syslog)
         h.force_ip_refetch(vm, feed_a_header)
         h.reload(vm, "update")
         vm.ssh(

--- a/tests/smoke/ui/test_alerts_idn_exclusion_render.py
+++ b/tests/smoke/ui/test_alerts_idn_exclusion_render.py
@@ -129,7 +129,10 @@ def _seeded_idn_exclusion(smoke_vm: SmokeVM) -> Iterator[None]:
         "tld_wildcard_exclusion config restore did not take -- the seeded IDN row leaked to sibling tests"
     )
 
-    helpers.set_dnsbl_enabled(vm, prior_dnsbl == "on")
+    # Restore VERBATIM, not through the boolean helper: the box may hold the
+    # canonical 'off' token, which set_dnsbl_enabled would degrade to the raw ''
+    # and fail the strict round-trip assert below (issue #1947).
+    helpers.config_set(vm, CFG_DNSBL_ENABLE, prior_dnsbl)
     assert helpers.config_get(vm, CFG_DNSBL_ENABLE) == prior_dnsbl, (
         f"pfb_dnsbl toggle restore did not take (wanted {prior_dnsbl!r}) -- leaked to sibling tests"
     )


### PR DESCRIPTION
Fixes #1947

## What

The `_seeded_idn_exclusion` fixture captured `pfb_dnsbl` verbatim (possibly the canonical `'off'` token) but restored through `helpers.set_dnsbl_enabled(vm, prior_dnsbl == "on")`, which writes the raw `''` for off. The strict round-trip assert then failed with `assert '' == 'off'` on every leased box holding a canonical `'off'`, erroring the teardown.

- New `helpers.config_set()` — the verbatim-write half of `config_get()`: writes one scalar config value back exactly as captured.
- The IDN-exclusion fixture restores `pfb_dnsbl` through it; the strict assert now holds for any captured token.
- Sibling sweep (same capture-verbatim/restore-through-boolean shape, per the issue): `test_smoke_tick.py` (`enable_cb`) and `test_syslog_export.py` (`log_syslog`) teardowns now also restore verbatim. `test_browser_dnsbl.py`'s gateway test was checked and is not affected — it asserts against the canonical stored-token map, not the verbatim capture.

## Evidence (executed on leased boxes)

**RED** — devel `8a7b872f`, `--marker ui_render --filter idn_exclusion`:

```
E       AssertionError: pfb_dnsbl toggle restore did not take (wanted 'off') -- leaked to sibling tests
E       assert '' == 'off'
ERROR tests/smoke/ui/test_alerts_idn_exclusion_render.py::test_idn_tld_exclusion_row_renders_delete_not_duplicate_add
================= 1 passed, 568 deselected, 1 error in 55.87s ==================
```

**GREEN** — fix `b09763c3`, same filter:

```
====================== 1 passed, 568 deselected in 56.20s ======================
```

**GREEN (siblings)** — fix `b09763c3`, `--marker "smoke or tick" --filter "test_tick_cron_entry_installed or test_ip_attribution_cache_invalidated_after_feed_ownership_change"`:

```
================ 2 passed, 927 deselected in 113.60s (0:01:53) =================
```

**Gates** — `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS` (pytest, ruff check, ruff format, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
