### PR TITLE
pfblockerng: run feed pre-scripts on normalized output; execute DNSBL feed scripts

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4206,6 +4206,35 @@ function pfb_list_script_exec(string $script_path, string $script_name, string $
 }
 
 /*
+ * issue #1925: stage the normalized feed for a pre-script and run it. Copies
+ * $norm_path to $staged_path and hands the script the copy (in-place rewrite
+ * contract unchanged), so neither '.orig' nor '.norm' is ever touched. Honours
+ * the exit status (#1927): 'ok' FALSE on copy failure, non-zero exit, or the
+ * script deleting its input -- the staged copy is removed and the caller keeps
+ * its last known-good staging. On success 'path' is the staged copy to parse.
+ */
+function pfb_list_pre_script_run(string $norm_path, string $staged_path, string $script_path,
+    string $script_name, string $header, string $args_tail, ?string $tmo_prefix = NULL): array {
+
+	if (!@copy($norm_path, $staged_path)) {
+		pfb_logger("\n[ {$header} ] pre-script '{$script_name}' could not stage its input; skipping\n", 2);
+		return array('ok' => FALSE, 'path' => $norm_path);
+	}
+
+	if (pfb_list_script_exec($script_path, $script_name, 'pre', $header, $args_tail, $tmo_prefix) !== 0) {
+		unlink_if_exists($staged_path);
+		return array('ok' => FALSE, 'path' => $norm_path);
+	}
+
+	if (!file_exists($staged_path)) {
+		pfb_logger("\n[ {$header} ] pre-script '{$script_name}' deleted its staged input\n", 2);
+		return array('ok' => FALSE, 'path' => $norm_path);
+	}
+
+	return array('ok' => TRUE, 'path' => $staged_path);
+}
+
+/*
  * Setup-wizard decision helpers (pure; pinned by tests/php/WizardDecisionTest.php).
  * The pfblockerng_wizard.inc / pfblockerng_general.php controllers do the impure work
  * (read $_POST/$_GET/config, redirect, write_config, set $pfb_wizard); the branchy

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4220,6 +4220,7 @@ function pfb_list_pre_script_run(string $norm_path, string $staged_path, string 
 
 	if (!@copy($norm_path, $staged_path)) {
 		pfb_logger("\n[ {$header} ] pre-script '{$script_name}' could not stage its input; skipping\n", 2);
+		unlink_if_exists($staged_path);
 		return array('ok' => FALSE, 'path' => $norm_path);
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2484,12 +2484,14 @@ function pfb_dnsbl_verbatim_reuse_active(bool $txt_exists, bool $update_exists, 
 // completed non-custom download qualifies (a Reload/Force pass must keep its
 // reparse-everything semantics; a custom list re-synthesizes per pass; a
 // stale-.orig download-failure fallback stays fail-safe like #1022/#1031),
-// and only onto a current-generation staged '.txt' (#1083).
+// and only onto a current-generation staged '.txt' (#1083). issue #1926: a
+// configured pre/post script never skips either -- its contract is a full
+// pass over the normalized output every run.
 function pfb_dnsbl_norm_reuse_skip(bool $downloaded_fresh, bool $custom, bool $orig_content_stale,
-	bool $norm_changed, bool $txt_exists, bool $staging_current_generation): bool
+	bool $norm_changed, bool $txt_exists, bool $staging_current_generation, bool $has_user_script): bool
 {
 	return $downloaded_fresh && !$custom && !$orig_content_stale && !$norm_changed &&
-		$txt_exists && $staging_current_generation;
+		$txt_exists && $staging_current_generation && !$has_user_script;
 }
 
 // issue #1797: the IP-loop counterpart of pfb_dnsbl_norm_reuse_skip(). Feeds

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1827,7 +1827,8 @@ function sync_package_pfblockerng($cron='') {
 									    $pfb_dnsbl_script_pre, $list['script_pre'], $header,
 									    escapeshellarg("{$file_dwn}.pre") . " dnsbl {$elog}");
 									if (!$pfb_pre['ok']) {
-										if (file_exists("{$pfbfolder}/{$header}.txt")) {
+										// #1083: a stale-generation '.txt' never re-enters the manifest.
+										if ($staging_current_generation && file_exists("{$pfbfolder}/{$header}.txt")) {
 											$lists_dnsbl_all[]	= "{$row['header']}.txt";
 											$pfb_py_feeds[]		= pfb_feed_manifest_row(
 												$header, $alias, $logging_type,
@@ -2100,6 +2101,8 @@ function sync_package_pfblockerng($cron='') {
 										pfb_list_script_exec($pfb_dnsbl_script_post, $list['script_post'], 'post', $header,
 										    escapeshellarg("{$file_dwn}.post") . " dnsbl {$elog}");
 										unlink_if_exists("{$file_dwn}.post");
+									} else {
+										pfb_logger("\n[ {$header} ] post-script '{$list['script_post']}' could not stage its input; skipping\n", 2);
 									}
 								}
 
@@ -3470,8 +3473,6 @@ function sync_package_pfblockerng($cron='') {
 							if ($fhandle) {
 								@fclose($fhandle);
 							}
-							// issue #1925: the staged pre-script copy is transient -- parsed above.
-							unlink_if_exists("{$file_dwn}.pre");
 
 							// One summary line per feed with the final count (mirrors the DNSBL
 							// strict-scheme WARNING) -- was previously one spammed line PER failed
@@ -3502,10 +3503,13 @@ function sync_package_pfblockerng($cron='') {
 
 							if (!$custom) {
 								// Check to see if list actually failed download or has no IPs listed.
+								// issue #1925: probe the content the parse consumed -- a pre-script
+								// synthesizes or reduces entries, so the raw download's emptiness is
+								// not the feed's (post-script-only feeds still probe '.orig').
+								$pfb_probe = ($pfb_parse_path === $pfb_norm['path']) ? "{$file_dwn}.orig" : $pfb_parse_path;
 								$file_chk = '';
-								if (file_exists("{$file_dwn}.orig") && @filesize("{$file_dwn}.orig") > 0) {
-									$file_org_esc = escapeshellarg("{$file_dwn}.orig");
-									$file_chk = exec("{$pfb['grep']} -cv '^#\|^\$' {$file_org_esc}");
+								if (file_exists($pfb_probe) && @filesize($pfb_probe) > 0) {
+									$file_chk = exec("{$pfb['grep']} -cv '^#\|^\$' " . escapeshellarg($pfb_probe));
 								}
 
 								if ($file_chk == 0) {
@@ -3520,6 +3524,9 @@ function sync_package_pfblockerng($cron='') {
 									pfb_logger("{$log}", 1);
 								}
 							}
+							// issue #1925: the staged pre-script copy is transient -- parsed and
+							// probed above.
+							unlink_if_exists("{$file_dwn}.pre");
 
 							// All parsed IPv6 entries were suppressed; replace the list with the IPv6
 							// placeholder so stale (previously-loaded) entries are not left in the alias.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1590,6 +1590,17 @@ function sync_package_pfblockerng($cron='') {
 					// config with no srcint field warning-free.
 					$srcint = $list['srcint'] ?? '' ?: FALSE;
 
+					// DNSBL Advanced Tunable - (Pre/Post Script processing) — issue #1926:
+					// pickers were saved but never executed; mirrors the IP loop.
+					$pfb_dnsbl_script_pre  = FALSE;
+					$pfb_dnsbl_script_post = FALSE;
+					if (!empty($list['script_pre'])) {
+						$pfb_dnsbl_script_pre = pfb_resolve_list_script($list['script_pre']);
+					}
+					if (!empty($list['script_post'])) {
+						$pfb_dnsbl_script_post = pfb_resolve_list_script($list['script_post']);
+					}
+
 					foreach ($list['row'] as $key => $row) {
 						if (!empty($row['url']) && $row['state'] != 'Disabled') {
 
@@ -1788,8 +1799,11 @@ function sync_package_pfblockerng($cron='') {
 								// content is byte-identical to the previous pass reuses the staged
 								// '.txt' the same way the verbatim-reuse branch does.
 								$pfb_norm = pfb_feed_normalize("{$file_dwn}.orig");
+								$pfb_dnsbl_user_script = ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) ||
+								    ($pfb_dnsbl_script_post && is_file("{$pfb_dnsbl_script_post}"));
 								if (pfb_dnsbl_norm_reuse_skip($downloaded_fresh, (bool) $custom, $orig_content_stale,
-								    $pfb_norm['changed'], file_exists("{$pfbfolder}/{$header}.txt"), $staging_current_generation)) {
+								    $pfb_norm['changed'], file_exists("{$pfbfolder}/{$header}.txt"), $staging_current_generation,
+								    $pfb_dnsbl_user_script)) {
 									pfb_logger("\n[ {$header} ]{$logtab} unchanged after normalization.", 1);
 									$lists_dnsbl_all[]	= "{$row['header']}.txt";
 									// ADR-31: same manifest-row shape as the verbatim-reuse branch above.
@@ -1803,6 +1817,30 @@ function sync_package_pfblockerng($cron='') {
 									continue;
 								}
 
+								// issue #1926: DNSBL pre-script runs on a staged copy of the
+								// normalized output (#1925 shape); a failed transform keeps the
+								// last known-good staging and the '.update' marker for retry.
+								$pfb_parse_path = $pfb_norm['path'];
+								if ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) {
+									pfb_logger("\nExecuting pre-script: {$list['script_pre']}\n", 1);
+									$pfb_pre = pfb_list_pre_script_run($pfb_norm['path'], "{$file_dwn}.pre",
+									    $pfb_dnsbl_script_pre, $list['script_pre'], $header,
+									    escapeshellarg("{$file_dwn}.pre") . " dnsbl {$elog}");
+									if (!$pfb_pre['ok']) {
+										if (file_exists("{$pfbfolder}/{$header}.txt")) {
+											$lists_dnsbl_all[]	= "{$row['header']}.txt";
+											$pfb_py_feeds[]		= pfb_feed_manifest_row(
+												$header, $alias, $logging_type,
+												$custom ? 'user' : 'feed',
+												$mode);
+											$list_cnt		= pfb_count_lines("{$pfbfolder}/{$header}.txt") ?? 0;
+											$alias_cnt		= $alias_cnt + $list_cnt;
+										}
+										continue;
+									}
+									$pfb_parse_path = $pfb_pre['path'];
+								}
+
 								$run_once = $csv_parser = FALSE;
 								$csv_type = '';
 								$ipcount = $ip_cnt = $ip_cnt6 = 0;
@@ -1810,7 +1848,7 @@ function sync_package_pfblockerng($cron='') {
 								$dnsbl_lineno = 0;		// issue #1004: per-line counter for the parse-error detail sink
 
 								// Parse downloaded file for Domain names
-								if (($fhandle = @fopen($pfb_norm['path'], 'r')) !== FALSE) {
+								if (($fhandle = @fopen($pfb_parse_path, 'r')) !== FALSE) {
 									if (($dhandle = @fopen("{$pfbfolder}/{$header}.bk", 'w')) !== FALSE) {
 										while (($line = @fgets($fhandle)) !== FALSE) {
 
@@ -2039,6 +2077,8 @@ function sync_package_pfblockerng($cron='') {
 								if ($fhandle) {
 									@fclose($fhandle);
 								}
+								// issue #1926: the staged pre-script copy is transient -- parsed above.
+								unlink_if_exists("{$file_dwn}.pre");
 
 								// Close the "Reload . completed ." progress line with its trailing dot
 								// BEFORE the strict-parsing WARNING below, else the warning's own
@@ -2050,6 +2090,18 @@ function sync_package_pfblockerng($cron='') {
 								// ADR-22: one WARNING per feed summarising strict-mode skips (silent
 								// when none -- lenient never increments the counter).
 								pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);
+
+								// issue #1926: DNSBL post-script runs on a throwaway copy of the
+								// download — nothing downstream re-parses it (same observable as
+								// the IP loop, which discards post-script edits via restore).
+								if ($pfb_dnsbl_script_post && is_file("{$pfb_dnsbl_script_post}")) {
+									pfb_logger("\nExecuting post-script: {$list['script_post']}\n", 1);
+									if (@copy("{$file_dwn}.orig", "{$file_dwn}.post")) {
+										pfb_list_script_exec($pfb_dnsbl_script_post, $list['script_post'], 'post', $header,
+										    escapeshellarg("{$file_dwn}.post") . " dnsbl {$elog}");
+										unlink_if_exists("{$file_dwn}.post");
+									}
+								}
 
 								if (isset($csvline)) {
 									unset($csvline);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -3351,32 +3351,16 @@ function sync_package_pfblockerng($cron='') {
 								}
 							}
 
-							// IPv4/6 Advanced Tunable - (Pre Script processing)
-							$pfb_user_script = FALSE;
-							if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {
-								pfb_logger("\nExecuting pre-script: {$list['script_pre']}\n", 1);
-								$pfb_user_script = TRUE;
-								$file_dwn_esc = escapeshellarg("{$file_dwn}.orig");
-								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.pre"); // Save original file for restoration
-								if (pfb_list_script_exec($pfb_script_pre, $list['script_pre'], 'pre', $header,
-								    "{$file_dwn_esc} {$list['vtype']} {$elog}") !== 0) {
-									// issue #1927: restore the download over the failed script's
-									// leftovers and keep the last known-good staged list; '.update'
-									// stays so the next run retries the transform.
-									if (file_exists("{$file_dwn}.orig.pre")) {
-										@rename("{$file_dwn}.orig.pre", "{$file_dwn}.orig");
-									}
-									continue;
-								}
-							}
-							if ($pfb_script_post && is_file("{$pfb_script_post}")) {
-								$pfb_user_script = TRUE;
-							}
+							// IPv4/6 Advanced Tunable - a configured pre or post script means
+							// the feed must reparse every run (#1797 reuse-skip stays off).
+							$pfb_user_script = ($pfb_script_pre && is_file("{$pfb_script_pre}")) ||
+							    ($pfb_script_post && is_file("{$pfb_script_post}"));
 
-							// issue #1797: normalize once per file (after the pre-script has had its
-							// raw look at .orig); the parse below reads .norm (raw .orig on normalize
-							// failure). A fresh download whose NORMALIZED content is byte-identical
-							// to the previous pass keeps the staged '.txt' untouched.
+							// issue #1925: normalize once per file; the parse below reads .norm
+							// (raw .orig on normalize failure). A fresh download whose NORMALIZED
+							// content is byte-identical to the previous pass keeps the staged
+							// '.txt' untouched; any pre-script (below) runs on a staged copy of
+							// this normalized output, never on the raw download.
 							$pfb_norm = pfb_feed_normalize("{$file_dwn}.orig");
 							if (pfb_ip_norm_reuse_skip($downloaded_fresh, (bool) $custom, $orig_content_stale,
 							    $pfb_norm['changed'], file_exists("{$pfbfolder}/{$header}.txt"), $pfb_user_script)) {
@@ -3385,7 +3369,22 @@ function sync_package_pfblockerng($cron='') {
 								continue;
 							}
 
-							if (($fhandle = @fopen($pfb_norm['path'], 'r')) !== FALSE) {
+							// issue #1925: the pre-script runs on a staged copy of the
+							// normalized output -- '.orig' and '.norm' stay untouched; a
+							// failed transform keeps the last known-good staged list.
+							$pfb_parse_path = $pfb_norm['path'];
+							if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {
+								pfb_logger("\nExecuting pre-script: {$list['script_pre']}\n", 1);
+								$pfb_pre = pfb_list_pre_script_run($pfb_norm['path'], "{$file_dwn}.pre",
+								    $pfb_script_pre, $list['script_pre'], $header,
+								    escapeshellarg("{$file_dwn}.pre") . " {$list['vtype']} {$elog}");
+								if (!$pfb_pre['ok']) {
+									continue;
+								}
+								$pfb_parse_path = $pfb_pre['path'];
+							}
+
+							if (($fhandle = @fopen($pfb_parse_path, 'r')) !== FALSE) {
 								while (($line = @fgets($fhandle)) !== FALSE) {
 									// issue #1004: incremented every iteration, regardless of outcome
 									$ip_lineno++;
@@ -3419,6 +3418,8 @@ function sync_package_pfblockerng($cron='') {
 							if ($fhandle) {
 								@fclose($fhandle);
 							}
+							// issue #1925: the staged pre-script copy is transient -- parsed above.
+							unlink_if_exists("{$file_dwn}.pre");
 
 							// One summary line per feed with the final count (mirrors the DNSBL
 							// strict-scheme WARNING) -- was previously one spammed line PER failed
@@ -3546,10 +3547,6 @@ function sync_package_pfblockerng($cron='') {
 							// Restore Original Downloaded file after Post Script function
 							if (file_exists("{$file_dwn}.orig.post")) {
 								@rename("{$file_dwn}.orig.post", "{$file_dwn}.orig");
-							}
-							// Restore Original Downloaded file after Pre Script function
-							if (file_exists("{$file_dwn}.orig.pre")) {
-								@rename("{$file_dwn}.orig.pre", "{$file_dwn}.orig");
 							}
 						}
 					}

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -354,13 +354,8 @@ include_once('head.inc');
 // Collect pre/post processing scripts
 $options_script_pre = $options_script_post = array();
 $indexdir = '/usr/local/pkg/pfblockerng/';
+$list_prefix = ($gtype == 'ipv4' || $gtype == 'ipv6') ? 'ip' : 'dnsbl';
 if (is_dir("{$indexdir}")) {
-
-	if ($gtype == 'ipv4' || $gtype == 'ipv6') {
-		$list_prefix = 'ip';
-	} else {
-		$list_prefix = 'dnsbl';
-	}
 
 	// List scripts live under list_scripts/; also scan the legacy package root so
 	// a not-yet-migrated custom script still appears during the upgrade transition.
@@ -386,6 +381,13 @@ if (is_dir("{$indexdir}")) {
 }
 $options_script_pre		= array_merge(array('' => 'None'), $options_script_pre);
 $options_script_pre_cnt		= count($options_script_pre) ?: '1';
+
+// issue #1926: the DNSBLIP alias is synthesized from addresses extracted out of
+// domain feeds -- a pre-script that removes IP/ABP-shaped lines silently shrinks it.
+$script_dnsbl_note = ($list_prefix == 'dnsbl') ? "<br /><span class=\"text-danger\">Note:</span>&nbsp;"
+	. "A DNSBL pre-process script must not remove IP-shaped or ABP-shaped lines: the "
+	. "DNSBLIP alias is synthesized from addresses extracted out of domain feeds, and "
+	. "removed lines silently shrink it." : '';
 
 $options_script_post		= array_merge(array('' => 'None'), $options_script_post);
 $options_script_post_cnt	= count($options_script_post) ?: '1';
@@ -1674,7 +1676,8 @@ $section->addInput(new Form_Select(
 	$pconfig['script_pre'],
 	$options_script_pre
 ))->sethelp("Pre-processing Shell script after download.<br />"
-	. "Script location: /usr/local/pkg/pfblockerng/list_scripts/<strong>ip_pre_SCRIPT NAME.sh|py</strong> or <strong>dnsbl_pre_SCRIPT NAME.sh|py</strong>")
+	. "Script location: /usr/local/pkg/pfblockerng/list_scripts/<strong>ip_pre_SCRIPT NAME.sh|py</strong> or <strong>dnsbl_pre_SCRIPT NAME.sh|py</strong>"
+	. $script_dnsbl_note)
   ->setAttribute('style', 'width: auto')
   ->setAttribute('size', $options_script_pre_cnt);
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1675,7 +1675,9 @@ $section->addInput(new Form_Select(
 	'Pre-process Script',
 	$pconfig['script_pre'],
 	$options_script_pre
-))->sethelp("Pre-processing Shell script after download.<br />"
+))->sethelp("Pre-processing Shell script, run after download and charset normalization: "
+	. "it receives a staged copy of the normalized feed text (UTF-8, control characters stripped, "
+	. "lines right-trimmed) and rewrites that copy in place.<br />"
 	. "Script location: /usr/local/pkg/pfblockerng/list_scripts/<strong>ip_pre_SCRIPT NAME.sh|py</strong> or <strong>dnsbl_pre_SCRIPT NAME.sh|py</strong>"
 	. $script_dnsbl_note)
   ->setAttribute('style', 'width: auto')

--- a/tests/php/AliasCntGrepCountGuardTest.php
+++ b/tests/php/AliasCntGrepCountGuardTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
  * $alias_cnt accumulation from a per-file line count (issue #1162; issue
  * #1261: the exec("grep -c ^ <file>") fork is replaced by pfb_count_lines()).
  *
- * sync_package_pfblockerng() has two sites that feed a file's line count into
+ * sync_package_pfblockerng() has sites that feed a file's line count into
  * `+` arithmetic: `$alias_cnt = $alias_cnt + $list_cnt;`. Before #1261,
  * $list_cnt came from exec()'s raw output (a non-numeric string on a failed
  * grep, needing an inline (int) cast). Now pfb_count_lines() returns ?int
@@ -47,18 +47,19 @@ final class AliasCntGrepCountGuardTest extends TestCase
 	public function testVacuityExactlyThreeAccumulationSitesExist(): void
 	{
 		$count = preg_match_all(self::ACCUMULATION_RE, self::$src);
-		$this->assertSame(3, $count,
-			'expected exactly 3 $alias_cnt = $alias_cnt + $list_cnt; accumulation sites '
-			. '(list-reuse branch, the issue #1797 norm-unchanged skip branch, and the '
-			. "downloaded/rebuilt branch); found {$count}");
+		$this->assertSame(4, $count,
+			'expected exactly 4 $alias_cnt = $alias_cnt + $list_cnt; accumulation sites '
+			. '(list-reuse branch, the issue #1797 norm-unchanged skip branch, the '
+			. 'downloaded/rebuilt branch, and the issue #1926 DNSBL pre-script-failure '
+			. "manifest-kept branch); found {$count}");
 	}
 
 	public function testAllSitesAssignListCntFromPfbCountLinesWithNullFallback(): void
 	{
 		$count = preg_match_all(self::COUNT_ASSIGN_RE, self::$src);
-		$this->assertSame(3, $count,
-			'expected exactly 3 `$list_cnt = pfb_count_lines(...) ?? 0;` assignments feeding '
-			. "the accumulation sites (issue #1261); found {$count}");
+		$this->assertSame(4, $count,
+			'expected exactly 4 `$list_cnt = pfb_count_lines(...) ?? 0;` assignments feeding '
+			. "the accumulation sites (issue #1261, extended by issue #1926); found {$count}");
 	}
 
 	public function testNoExecGrepForkSurvivesForListCnt(): void

--- a/tests/php/AliasCntGrepCountGuardTest.php
+++ b/tests/php/AliasCntGrepCountGuardTest.php
@@ -44,7 +44,7 @@ final class AliasCntGrepCountGuardTest extends TestCase
 	private const ACCUMULATION_RE = '/\$alias_cnt\s*=\s*\$alias_cnt\s*\+\s*\$list_cnt\s*;/';
 	private const COUNT_ASSIGN_RE = '/\$list_cnt\s*=\s*pfb_count_lines\([^;]*\)\s*\?\?\s*0\s*;/';
 
-	public function testVacuityExactlyThreeAccumulationSitesExist(): void
+	public function testVacuityExactlyFourAccumulationSitesExist(): void
 	{
 		$count = preg_match_all(self::ACCUMULATION_RE, self::$src);
 		$this->assertSame(4, $count,

--- a/tests/php/DnsblListScriptWiringTest.php
+++ b/tests/php/DnsblListScriptWiringTest.php
@@ -139,7 +139,7 @@ final class DnsblListScriptWiringTest extends TestCase
 		$this->assertStringContainsString('pfb_feed_manifest_row(', $window,
 			'the failure branch must still emit a manifest row when a staged .txt exists -- '
 			. 'dropping it would relocate the outage (#1841 class), not fix it');
-		$this->assertStringContainsString('file_exists("{$pfbfolder}/{$header}.txt")', $window,
+		$this->assertStringContainsString('$staging_current_generation && file_exists("{$pfbfolder}/{$header}.txt")', $window,
 			'the manifest-on-failure emission must be guarded on an existing staged .txt');
 		$this->assertStringContainsString('" dnsbl {$elog}"', $window,
 			'the pre-script args tail must carry the stable "dnsbl" discriminator -- DNSBL has no vtype');
@@ -184,6 +184,8 @@ final class DnsblListScriptWiringTest extends TestCase
 			'the post-script must run on a throwaway copy of the download, not the .orig itself');
 		$this->assertStringContainsString('unlink_if_exists("{$file_dwn}.post");', $window,
 			'the throwaway post-script copy must be cleaned up -- nothing downstream re-parses it');
+		$this->assertStringContainsString('could not stage its input', $window,
+			'a post-script staging copy failure must be logged naming the script -- a silent skip is undebuggable');
 		$this->assertStringNotContainsString('.orig.post', $window,
 			'the IP loop\'s backup/restore machinery is deliberately NOT mirrored -- the post-script '
 			. 'edits a throwaway copy instead of an .orig that would be restored anyway');
@@ -207,16 +209,29 @@ final class DnsblListScriptWiringTest extends TestCase
 			'@@||allow.example.net^',
 			'another-domain.test',
 			'203.0.113.5',
+			'||192.0.2.9^',
+			'||2001:db8::9^',
 		];
 	}
 
-	/** @return array{v4: int, v6: int} */
+	/**
+	 * Mirrors the DNSBL loop's two collection sites: the ABP network anchor is
+	 * unwrapped by pfb_dnsbl_abp_extract_ip() first, plain lines go straight to
+	 * the collector.
+	 *
+	 * @return array{v4: int, v6: int}
+	 */
 	private function collectIpCounts(string $content): array
 	{
 		$ip4 = [];
 		$ip6 = [];
 		foreach (preg_split('/\R/', $content) as $line) {
 			if ($line === '') {
+				continue;
+			}
+			$abp_ip = pfb_dnsbl_abp_extract_ip($line);
+			if ($abp_ip !== '') {
+				pfb_dnsbl_collect_feed_ip($abp_ip, $abp_ip, FALSE, $ip4, $ip6);
 				continue;
 			}
 			pfb_dnsbl_collect_feed_ip($line, $line, FALSE, $ip4, $ip6);
@@ -229,10 +244,11 @@ final class DnsblListScriptWiringTest extends TestCase
 		$lines = $this->mixedFeedLines();
 		$content = implode("\n", $lines) . "\n";
 
-		// Before-state: the ORIGINAL content extracts exactly the 3 v4 + 2 v6 lines above.
+		// Before-state: the ORIGINAL content extracts exactly the 3 plain + 1 ABP v4
+		// lines and the 2 plain + 1 ABP v6 lines above.
 		$before = $this->collectIpCounts($content);
-		$this->assertSame(3, $before['v4'], 'sanity: fixture must carry exactly 3 v4-shaped lines');
-		$this->assertSame(2, $before['v6'], 'sanity: fixture must carry exactly 2 v6-shaped lines');
+		$this->assertSame(4, $before['v4'], 'sanity: fixture must carry exactly 4 v4-shaped lines (incl. one ABP-anchored)');
+		$this->assertSame(3, $before['v6'], 'sanity: fixture must carry exactly 3 v6-shaped lines (incl. one ABP-anchored)');
 
 		$norm = "{$this->tmp}/feed.norm";
 		file_put_contents($norm, $content);
@@ -259,11 +275,11 @@ final class DnsblListScriptWiringTest extends TestCase
 		$norm = "{$this->tmp}/feed.norm";
 		file_put_contents($norm, $content);
 		$staged = "{$this->tmp}/feed.pre";
-		// Strips every IP-shaped line (v4 or v6) -- the exact hazard the DNSBL
-		// help-text warning names: a careless pre-process script silently
-		// shrinks the DNSBLIP alias.
+		// Strips every IP-shaped line -- plain AND ABP-anchored (||IP^) -- the exact
+		// hazard the DNSBL help-text warning names: a careless pre-process script
+		// silently shrinks the DNSBLIP alias.
 		$script = $this->makeScript('dnsbl_pre_strip_ips.sh',
-			"grep -Ev '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\$|^[0-9a-fA-F:]+\$' \"\$1\" > \"\$1.tmp\" && mv \"\$1.tmp\" \"\$1\"");
+			"grep -Ev '^(\\|\\|)?[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\\^?\$|^(\\|\\|)?[0-9a-fA-F:]+\\^?\$' \"\$1\" > \"\$1.tmp\" && mv \"\$1.tmp\" \"\$1\"");
 
 		$result = pfb_list_pre_script_run($norm, $staged, $script, 'dnsbl_pre_strip_ips.sh', 'MyFeed',
 			escapeshellarg($staged) . ' dnsbl', '');

--- a/tests/php/DnsblListScriptWiringTest.php
+++ b/tests/php/DnsblListScriptWiringTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1926: DNSBL feeds save Pre/Post-process Script pickers that are never
+ * executed. Wiring mirrors the IP loop's #1925 shape (staged normalized copy,
+ * exit-status gated, manifest row kept on a pre-script failure with an existing
+ * '.txt'); the DNSBL parse loop sits inside the thousands-of-lines sync loop
+ * driving real appliance exec, so the call sites are pinned by source
+ * inspection (same technique as ListScriptExitStatusTest /
+ * GunzipTrailingNewlineWiringTest). The DNSBLIP mixed-feed fixture proves the
+ * hazard the new help-text warning names: a pre-script that strips IP-shaped
+ * lines silently shrinks the DNSBLIP alias.
+ */
+#[CoversFunction('pfb_dnsbl_norm_reuse_skip')]
+#[CoversFunction('pfb_list_pre_script_run')]
+#[CoversFunction('pfb_list_script_exec')]
+#[CoversFunction('pfb_dnsbl_collect_feed_ip')]
+final class DnsblListScriptWiringTest extends TestCase
+{
+	private static string $applySource;
+	private static string $categoryEditSource;
+
+	private string $tmp;
+	/** @var array<string, mixed> */
+	private array $originalPfb;
+	private bool $hadPfb;
+
+	public static function setUpBeforeClass(): void
+	{
+		$applySource = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		if ($applySource === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		}
+		self::$applySource = $applySource;
+
+		$categoryEditSource = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
+		);
+		if ($categoryEditSource === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
+		}
+		self::$categoryEditSource = $categoryEditSource;
+	}
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_dlsw_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		mkdir($this->tmp, 0755, TRUE);
+
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'log'    => "{$this->tmp}/pfblockerng.log",
+			'errlog' => "{$this->tmp}/error.log",
+			'supp'   => PfbToggle::Off,
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		exec('chmod -R u+rwx ' . escapeshellarg($this->tmp));
+		exec('rm -rf ' . escapeshellarg($this->tmp));
+	}
+
+	private function makeScript(string $name, string $body): string
+	{
+		$path = "{$this->tmp}/{$name}";
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	// -----------------------------------------------------------------
+	// (a) source-inspection wiring
+	// -----------------------------------------------------------------
+
+	public function testAliasHeadResolvesBothScriptsAfterSrcint(): void
+	{
+		$srcintPos = strpos(self::$applySource, "\$srcint = \$list['srcint'] ?? '' ?: FALSE;");
+		$this->assertNotFalse($srcintPos, 'vacuity: the DNSBL per-alias srcint assignment must exist');
+
+		$rowLoopPos = strpos(self::$applySource, "foreach (\$list['row'] as \$key => \$row) {", $srcintPos);
+		$this->assertNotFalse($rowLoopPos, 'vacuity: the per-row loop that follows must exist');
+
+		$between = substr(self::$applySource, $srcintPos, $rowLoopPos - $srcintPos);
+		$this->assertStringContainsString('$pfb_dnsbl_script_pre', $between,
+			'the pre-script must be resolved once per alias, mirroring the IP loop');
+		$this->assertStringContainsString('$pfb_dnsbl_script_post', $between,
+			'the post-script must be resolved once per alias, mirroring the IP loop');
+		$this->assertStringContainsString('pfb_resolve_list_script(', $between,
+			'resolution must go through the same containment-checked resolver as the IP loop');
+	}
+
+	public function testReuseSkipCallSitePassesTheUserScriptFlag(): void
+	{
+		$reuseSkipPos = strpos(self::$applySource, 'pfb_dnsbl_norm_reuse_skip(');
+		$this->assertNotFalse($reuseSkipPos, 'vacuity: the DNSBL normalize/reuse-skip call site must exist');
+
+		$callEnd = strpos(self::$applySource, 'unchanged after normalization.', $reuseSkipPos);
+		$this->assertNotFalse($callEnd, 'vacuity: the reuse-skip branch body must exist');
+
+		$call = substr(self::$applySource, $reuseSkipPos, $callEnd - $reuseSkipPos);
+		$this->assertStringContainsString('$pfb_dnsbl_user_script', $call,
+			'a configured pre/post script must force a full reparse every pass, same contract as the IP loop');
+
+		$userScriptPos = strpos(self::$applySource, '$pfb_dnsbl_user_script = ');
+		$this->assertNotFalse($userScriptPos, 'vacuity: the user-script computation must exist');
+		$this->assertLessThan($reuseSkipPos, $userScriptPos,
+			'$pfb_dnsbl_user_script must be computed before it is passed to the reuse-skip call');
+	}
+
+	public function testPreScriptWindowRunsAfterReuseSkipAndBeforeSchemeWarn(): void
+	{
+		$reuseSkipPos = strpos(self::$applySource, 'pfb_dnsbl_norm_reuse_skip(');
+		$this->assertNotFalse($reuseSkipPos, 'vacuity: the DNSBL normalize/reuse-skip call site must exist');
+
+		$schemeWarnPos = strpos(self::$applySource, 'pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);', $reuseSkipPos);
+		$this->assertNotFalse($schemeWarnPos, 'vacuity: the scheme-skip warning call must exist');
+		$this->assertGreaterThan($reuseSkipPos, $schemeWarnPos, 'the scheme-skip warning must sit after reuse-skip');
+
+		$window = substr(self::$applySource, $reuseSkipPos, $schemeWarnPos - $reuseSkipPos);
+
+		$this->assertStringContainsString('pfb_list_pre_script_run(', $window,
+			'the pre-script must run through the staged-copy runner, mirroring the IP loop');
+		$this->assertStringContainsString('continue;', $window,
+			'a pre-script failure must skip the parse, keeping the last known-good staging');
+		$this->assertStringContainsString('pfb_feed_manifest_row(', $window,
+			'the failure branch must still emit a manifest row when a staged .txt exists -- '
+			. 'dropping it would relocate the outage (#1841 class), not fix it');
+		$this->assertStringContainsString('file_exists("{$pfbfolder}/{$header}.txt")', $window,
+			'the manifest-on-failure emission must be guarded on an existing staged .txt');
+		$this->assertStringContainsString('" dnsbl {$elog}"', $window,
+			'the pre-script args tail must carry the stable "dnsbl" discriminator -- DNSBL has no vtype');
+
+		$fopenPos = strpos(self::$applySource, '@fopen($pfb_parse_path', $reuseSkipPos);
+		$this->assertNotFalse($fopenPos, 'vacuity: the parse open must read the (possibly staged) parse path');
+		$this->assertLessThan($schemeWarnPos, $fopenPos, 'the parse must happen before the scheme-skip warning');
+		$this->assertGreaterThan($reuseSkipPos, $fopenPos, 'the parse must happen after reuse-skip');
+
+		$this->assertStringNotContainsString('@fopen($pfb_norm[\'path\']', self::$applySource,
+			'the raw normalized path must no longer be the parse source -- the pre-script may have staged a copy');
+	}
+
+	public function testStagedPreScriptCopyIsUnlinkedAfterParsing(): void
+	{
+		$fopenPos = strpos(self::$applySource, '@fopen($pfb_parse_path');
+		$this->assertNotFalse($fopenPos, 'vacuity: the parse open must exist');
+
+		$schemeWarnPos = strpos(self::$applySource, 'pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);', $fopenPos);
+		$this->assertNotFalse($schemeWarnPos, 'vacuity: the scheme-skip warning must exist');
+
+		$window = substr(self::$applySource, $fopenPos, $schemeWarnPos - $fopenPos);
+		$this->assertStringContainsString('unlink_if_exists("{$file_dwn}.pre");', $window,
+			'the transient staged pre-script copy must be cleaned up once parsed, mirroring the IP loop');
+	}
+
+	public function testPostScriptWindowRunsAfterSchemeWarn(): void
+	{
+		$schemeWarnPos = strpos(self::$applySource, 'pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);');
+		$this->assertNotFalse($schemeWarnPos, 'vacuity: the scheme-skip warning call must exist');
+
+		$dedupPos = strpos(self::$applySource, 'Remove duplicates and save any IPs found', $schemeWarnPos);
+		$this->assertNotFalse($dedupPos, 'vacuity: the IP-dedup comment after parsing must exist');
+		$this->assertGreaterThan($schemeWarnPos, $dedupPos);
+
+		$window = substr(self::$applySource, $schemeWarnPos, $dedupPos - $schemeWarnPos);
+		$this->assertStringContainsString('pfb_list_script_exec(', $window,
+			'the post-script must run through the exit-status-honouring runner');
+		$this->assertStringContainsString('" dnsbl {$elog}"', $window,
+			'the post-script args tail must carry the stable "dnsbl" discriminator -- DNSBL has no vtype');
+		$this->assertStringContainsString('@copy("{$file_dwn}.orig", "{$file_dwn}.post")', $window,
+			'the post-script must run on a throwaway copy of the download, not the .orig itself');
+		$this->assertStringContainsString('unlink_if_exists("{$file_dwn}.post");', $window,
+			'the throwaway post-script copy must be cleaned up -- nothing downstream re-parses it');
+		$this->assertStringNotContainsString('.orig.post', $window,
+			'the IP loop\'s backup/restore machinery is deliberately NOT mirrored -- the post-script '
+			. 'edits a throwaway copy instead of an .orig that would be restored anyway');
+	}
+
+	// -----------------------------------------------------------------
+	// (b) DNSBLIP mixed-feed regression fixture
+	// -----------------------------------------------------------------
+
+	/** @return list<string> */
+	private function mixedFeedLines(): array
+	{
+		return [
+			'example.com',
+			'sub.example.org',
+			'192.0.2.10',
+			'198.51.100.20',
+			'2001:db8::1',
+			'2001:db8::dead:beef',
+			'||ads.example.net^',
+			'@@||allow.example.net^',
+			'another-domain.test',
+			'203.0.113.5',
+		];
+	}
+
+	/** @return array{v4: int, v6: int} */
+	private function collectIpCounts(string $content): array
+	{
+		$ip4 = [];
+		$ip6 = [];
+		foreach (preg_split('/\R/', $content) as $line) {
+			if ($line === '') {
+				continue;
+			}
+			pfb_dnsbl_collect_feed_ip($line, $line, FALSE, $ip4, $ip6);
+		}
+		return ['v4' => count($ip4), 'v6' => count($ip6)];
+	}
+
+	public function testIdentityPreScriptPreservesDnsblipExtractionCounts(): void
+	{
+		$lines = $this->mixedFeedLines();
+		$content = implode("\n", $lines) . "\n";
+
+		// Before-state: the ORIGINAL content extracts exactly the 3 v4 + 2 v6 lines above.
+		$before = $this->collectIpCounts($content);
+		$this->assertSame(3, $before['v4'], 'sanity: fixture must carry exactly 3 v4-shaped lines');
+		$this->assertSame(2, $before['v6'], 'sanity: fixture must carry exactly 2 v6-shaped lines');
+
+		$norm = "{$this->tmp}/feed.norm";
+		file_put_contents($norm, $content);
+		$staged = "{$this->tmp}/feed.pre";
+		$script = $this->makeScript('dnsbl_pre_identity.sh', 'exit 0');
+
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'dnsbl_pre_identity.sh', 'MyFeed',
+			escapeshellarg($staged) . ' dnsbl', '');
+		$this->assertTrue($result['ok'], 'an identity script must be honoured');
+
+		$after = $this->collectIpCounts((string) file_get_contents($result['path']));
+		$this->assertSame($before['v4'], $after['v4'],
+			'an identity pre-script must not change the extracted v4 DNSBLIP count');
+		$this->assertSame($before['v6'], $after['v6'],
+			'an identity pre-script must not change the extracted v6 DNSBLIP count');
+	}
+
+	public function testStrippingPreScriptShrinksDnsblipExtractionCounts(): void
+	{
+		$lines = $this->mixedFeedLines();
+		$content = implode("\n", $lines) . "\n";
+		$before = $this->collectIpCounts($content);
+
+		$norm = "{$this->tmp}/feed.norm";
+		file_put_contents($norm, $content);
+		$staged = "{$this->tmp}/feed.pre";
+		// Strips every IP-shaped line (v4 or v6) -- the exact hazard the DNSBL
+		// help-text warning names: a careless pre-process script silently
+		// shrinks the DNSBLIP alias.
+		$script = $this->makeScript('dnsbl_pre_strip_ips.sh',
+			"grep -Ev '^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\$|^[0-9a-fA-F:]+\$' \"\$1\" > \"\$1.tmp\" && mv \"\$1.tmp\" \"\$1\"");
+
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'dnsbl_pre_strip_ips.sh', 'MyFeed',
+			escapeshellarg($staged) . ' dnsbl', '');
+		$this->assertTrue($result['ok'], 'the stripping script itself must not fail (non-zero exit / delete)');
+
+		$after = $this->collectIpCounts((string) file_get_contents($result['path']));
+		$this->assertLessThan($before['v4'], $after['v4'],
+			'a script that strips IP-shaped lines must shrink the extracted v4 DNSBLIP count '
+			. '-- this is the failure the fixture must be able to detect');
+		$this->assertLessThan($before['v6'], $after['v6'],
+			'a script that strips IP-shaped lines must shrink the extracted v6 DNSBLIP count');
+		$this->assertSame(0, $after['v4']);
+		$this->assertSame(0, $after['v6']);
+	}
+
+	// -----------------------------------------------------------------
+	// (c) www/ help-note render pin
+	// -----------------------------------------------------------------
+
+	public function testHelpNoteIsConditionedOnTheDnsblPrefixAndConcatenatedIntoScriptPreHelp(): void
+	{
+		$notePos = strpos(self::$categoryEditSource, '$script_dnsbl_note');
+		$this->assertNotFalse($notePos, 'vacuity: the DNSBL-only help note assignment must exist');
+
+		// ";\n" (not a bare ";") skips the "&nbsp;" HTML entity's own semicolon --
+		// that entity sits mid-string, never followed by a newline.
+		$noteEnd = strpos(self::$categoryEditSource, ";\n", $notePos);
+		$this->assertNotFalse($noteEnd, 'vacuity: the note assignment must terminate');
+		$noteAssignment = substr(self::$categoryEditSource, $notePos, $noteEnd - $notePos);
+
+		$this->assertStringContainsString("\$list_prefix == 'dnsbl'", $noteAssignment,
+			'the note must be conditioned on the dnsbl prefix -- the IP tab must never render it');
+		$this->assertStringContainsString('DNSBLIP', $noteAssignment,
+			'the note must name the alias it warns about');
+		$this->assertStringContainsString('silently shrink', $noteAssignment,
+			'the note must name the failure mode the DNSBLIP fixture proves');
+
+		$fieldPos = strpos(self::$categoryEditSource, "'script_pre',");
+		$this->assertNotFalse($fieldPos, 'vacuity: the script_pre Form_Select must exist');
+
+		$sizePos = strpos(self::$categoryEditSource, "->setAttribute('size', \$options_script_pre_cnt);", $fieldPos);
+		$this->assertNotFalse($sizePos, 'vacuity: the script_pre field must terminate with its size attribute');
+
+		$fieldBlock = substr(self::$categoryEditSource, $fieldPos, $sizePos - $fieldPos);
+		$this->assertStringContainsString('$script_dnsbl_note', $fieldBlock,
+			'the note must be concatenated into the script_pre field\'s sethelp text');
+	}
+}

--- a/tests/php/ListPreScriptStageTest.php
+++ b/tests/php/ListPreScriptStageTest.php
@@ -43,8 +43,12 @@ final class ListPreScriptStageTest extends TestCase
 		} else {
 			unset($GLOBALS['pfb']);
 		}
-		exec('chmod -R u+rwx ' . escapeshellarg($this->tmp));
-		exec('rm -rf ' . escapeshellarg($this->tmp));
+		// A test may leave a 0555 dir behind (copy-failure case) -- restore write
+		// perms so the house cleanup helper can remove it.
+		foreach (glob("{$this->tmp}/*", GLOB_ONLYDIR) ?: [] as $d) {
+			@chmod($d, 0755);
+		}
+		rmdir_recursive($this->tmp);
 	}
 
 	private function makeScript(string $name, string $body): string

--- a/tests/php/ListPreScriptStageTest.php
+++ b/tests/php/ListPreScriptStageTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1925: pfb_list_pre_script_run() stages a COPY of the normalized feed
+ * for the per-feed pre-script — the script rewrites the copy in place; the
+ * normalized source ('.norm', and by extension '.orig') is never touched.
+ *
+ * Honours the #1927 exit-status contract via pfb_list_script_exec(): a copy
+ * failure, a non-zero exit, or the script deleting its staged input all
+ * return 'ok' FALSE (with the staged file removed where it exists), leaving
+ * the caller to keep its last known-good staged list.
+ */
+#[CoversFunction('pfb_list_pre_script_run')]
+final class ListPreScriptStageTest extends TestCase
+{
+	private string $tmp;
+	/** @var array<string, mixed> */
+	private array $originalPfb;
+	private bool $hadPfb;
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_lpss_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		mkdir($this->tmp, 0755, TRUE);
+
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'log'    => "{$this->tmp}/pfblockerng.log",
+			'errlog' => "{$this->tmp}/error.log",
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		exec('chmod -R u+rwx ' . escapeshellarg($this->tmp));
+		exec('rm -rf ' . escapeshellarg($this->tmp));
+	}
+
+	private function makeScript(string $name, string $body): string
+	{
+		$path = "{$this->tmp}/{$name}";
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	private function mainLog(): string
+	{
+		return (string) @file_get_contents("{$this->tmp}/pfblockerng.log");
+	}
+
+	public function testSuccessfulRewriteStagesTheCopyAndLeavesTheSourceUntouched(): void
+	{
+		$norm = "{$this->tmp}/feed.norm";
+		file_put_contents($norm, "original\n");
+		$staged = "{$this->tmp}/feed.pre";
+		$script = $this->makeScript('ip_pre_rewrite.sh', 'printf \'transformed\\n\' > "$1"');
+
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'ip_pre_rewrite.sh', 'MyFeed_v4',
+		    escapeshellarg($staged), '');
+
+		$this->assertTrue($result['ok'], 'a rewriting script must be honoured');
+		$this->assertSame($staged, $result['path']);
+		$this->assertSame("transformed\n", file_get_contents($staged),
+			'the staged copy must carry the script\'s rewrite');
+		$this->assertSame("original\n", file_get_contents($norm),
+			'the normalized source must stay byte-identical -- the script only ever sees the copy');
+		$this->assertNotSame(file_get_contents($norm), file_get_contents($staged),
+			'the script must have seen the normalized copy, not produced the source verbatim');
+	}
+
+	public function testIdentityScriptStagesContentByteIdenticalToTheNormalizedSource(): void
+	{
+		$norm = "{$this->tmp}/feed.norm";
+		file_put_contents($norm, "1.2.3.4\n5.6.7.8\n");
+		$staged = "{$this->tmp}/feed.pre";
+		$script = $this->makeScript('ip_pre_noop.sh', 'exit 0');
+
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'ip_pre_noop.sh', 'MyFeed_v4',
+		    escapeshellarg($staged), '');
+
+		$this->assertTrue($result['ok']);
+		$this->assertSame($staged, $result['path']);
+		$this->assertSame(file_get_contents($norm), file_get_contents($staged),
+			'a no-op script must leave the staged copy identical to the normalized source it received');
+	}
+
+	public function testNonZeroExitFailsRemovesTheStagedCopyAndLogs(): void
+	{
+		$norm = "{$this->tmp}/feed.norm";
+		file_put_contents($norm, "1.2.3.4\n");
+		$staged = "{$this->tmp}/feed.pre";
+		$script = $this->makeScript('ip_pre_fail.sh', 'exit 7');
+
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'ip_pre_fail.sh', 'MyFeed_v4',
+		    escapeshellarg($staged), '');
+
+		$this->assertFalse($result['ok'], 'a non-zero exit must fail the stage');
+		$this->assertFileDoesNotExist($staged, 'the staged copy must be removed on failure');
+		$log = $this->mainLog();
+		$this->assertStringContainsString("ip_pre_fail.sh", $log, 'the failure must name the script');
+		$this->assertStringContainsString('MyFeed_v4', $log, 'the failure must name the feed');
+	}
+
+	public function testScriptDeletingItsStagedInputFailsAndLogs(): void
+	{
+		$norm = "{$this->tmp}/feed.norm";
+		file_put_contents($norm, "1.2.3.4\n");
+		$staged = "{$this->tmp}/feed.pre";
+		$script = $this->makeScript('ip_pre_delete.sh', 'rm -f "$1"');
+
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'ip_pre_delete.sh', 'MyFeed_v4',
+		    escapeshellarg($staged), '');
+
+		$this->assertFalse($result['ok'], 'a script that deletes its input must not be treated as success');
+		$this->assertFileDoesNotExist($staged);
+		$log = $this->mainLog();
+		$this->assertStringContainsString('ip_pre_delete.sh', $log, 'the failure must name the script');
+		$this->assertStringContainsString('MyFeed_v4', $log, 'the failure must name the feed');
+	}
+
+	public function testCopyFailureFailsAndKeepsTheNormalizedPath(): void
+	{
+		if (function_exists('posix_getuid') && posix_getuid() === 0) {
+			$this->markTestSkipped('root bypasses directory permissions; cannot simulate an unwritable staging dir');
+		}
+
+		$norm = "{$this->tmp}/feed.norm";
+		file_put_contents($norm, "1.2.3.4\n");
+		$deniedDir = "{$this->tmp}/denied";
+		mkdir($deniedDir, 0755, TRUE);
+		chmod($deniedDir, 0555);
+		$staged = "{$deniedDir}/feed.pre";
+		$script = $this->makeScript('ip_pre_unreached.sh', 'exit 0');
+
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'ip_pre_unreached.sh', 'MyFeed_v4',
+		    escapeshellarg($staged), '');
+
+		$this->assertFalse($result['ok'], 'a copy failure must fail the stage');
+		$this->assertSame($norm, $result['path'],
+			'on copy failure the caller keeps the normalized path -- there is no staged copy');
+		$log = $this->mainLog();
+		$this->assertStringContainsString('ip_pre_unreached.sh', $log,
+			'the copy failure must be logged, naming the script');
+		$this->assertStringContainsString('MyFeed_v4', $log, 'the copy failure must be logged, naming the feed');
+	}
+}

--- a/tests/php/ListScriptExitStatusTest.php
+++ b/tests/php/ListScriptExitStatusTest.php
@@ -162,6 +162,28 @@ final class ListScriptExitStatusTest extends TestCase
 			'.orig.pre must be fully retired — the pre-script never touches the raw download');
 	}
 
+	public function testEmptyFeedProbeReadsTheContentTheParseConsumed(): void
+	{
+		$probePos = strpos(self::$applySource, 'Check to see if list actually failed download');
+		$this->assertNotFalse($probePos, 'vacuity: the empty-feed probe must exist');
+
+		$suppressedPos = strpos(self::$applySource, 'All parsed IPv6 entries were suppressed', $probePos);
+		$this->assertNotFalse($suppressedPos, 'vacuity: the v6-suppression block after the probe must exist');
+
+		$between = substr(self::$applySource, $probePos, $suppressedPos - $probePos);
+		$this->assertStringContainsString("\$pfb_parse_path === \$pfb_norm['path']", $between,
+			'the probe must select the content the parse consumed — a pre-script synthesizes or '
+			. 'reduces entries, so the raw download\'s emptiness is not the feed\'s');
+
+		// The staged copy must outlive the probe: its unlink sits after the probe
+		// block, not right after the parse loop.
+		$unlinkPos = strpos(self::$applySource, 'unlink_if_exists("{$file_dwn}.pre")', $probePos);
+		$this->assertNotFalse($unlinkPos,
+			'the staged pre-script copy must be unlinked AFTER the empty-feed probe consumed it');
+		$this->assertLessThan($suppressedPos, $unlinkPos,
+			'the staged-copy unlink must sit between the probe and the v6-suppression block');
+	}
+
 	public function testPostScriptCallSiteGatesOnExitStatus(): void
 	{
 		// issue #1926: the DNSBL loop now logs the same "Executing post-script:" line

--- a/tests/php/ListScriptExitStatusTest.php
+++ b/tests/php/ListScriptExitStatusTest.php
@@ -137,21 +137,29 @@ final class ListScriptExitStatusTest extends TestCase
 
 	public function testPreScriptCallSiteGatesOnExitStatus(): void
 	{
-		$prePos = strpos(self::$applySource, 'Executing pre-script:');
+		// issue #1925: the pre-script now runs AFTER normalize + reuse-skip, on a
+		// staged copy of the normalized output — never before it.
+		$reuseSkipPos = strpos(self::$applySource, 'pfb_ip_norm_reuse_skip(');
+		$this->assertNotFalse($reuseSkipPos, 'vacuity: the IP-loop normalize/reuse-skip step must exist');
+
+		$prePos = strpos(self::$applySource, 'Executing pre-script:', $reuseSkipPos);
 		$this->assertNotFalse($prePos, 'vacuity: the pre-script call site must exist');
+		$this->assertGreaterThan($reuseSkipPos, $prePos,
+			'the pre-script must run after normalize + reuse-skip, never before it');
 
-		$normPos = strpos(self::$applySource, 'pfb_feed_normalize(', $prePos);
-		$this->assertNotFalse($normPos, 'vacuity: the normalize step after the pre-script must exist');
+		$parsePos = strpos(self::$applySource, 'pfb_ip_parse_line(', $prePos);
+		$this->assertNotFalse($parsePos, 'vacuity: the parse step after the pre-script must exist');
 
-		$between = substr(self::$applySource, $prePos, $normPos - $prePos);
-		$this->assertStringContainsString('pfb_list_script_exec(', $between,
-			'the pre-script must run through the exit-status-honouring runner');
-		$this->assertStringContainsString('!== 0', $between,
-			'the pre-script exit status must gate the parse — a failed transform is not feed data');
-		$this->assertStringContainsString('@rename("{$file_dwn}.orig.pre", "{$file_dwn}.orig")', $between,
-			'on failure the saved download must be restored over the failed script\'s leftovers');
+		$between = substr(self::$applySource, $prePos, $parsePos - $prePos);
+		$this->assertStringContainsString('pfb_list_pre_script_run(', $between,
+			'the pre-script must run through the staged-copy runner');
 		$this->assertStringContainsString('continue;', $between,
 			'on failure the row must skip the parse, keeping the last known-good staged list');
+		$this->assertStringContainsString('{$list[\'vtype\']}', $between,
+			'v4/v6 vtype must pass through to the pre-script args');
+
+		$this->assertStringNotContainsString('.orig.pre', self::$applySource,
+			'.orig.pre must be fully retired — the pre-script never touches the raw download');
 	}
 
 	public function testPostScriptCallSiteGatesOnExitStatus(): void

--- a/tests/php/ListScriptExitStatusTest.php
+++ b/tests/php/ListScriptExitStatusTest.php
@@ -175,11 +175,19 @@ final class ListScriptExitStatusTest extends TestCase
 			'the probe must select the content the parse consumed — a pre-script synthesizes or '
 			. 'reduces entries, so the raw download\'s emptiness is not the feed\'s');
 
-		// The staged copy must outlive the probe: its unlink sits after the probe
-		// block, not right after the parse loop.
+		// The staged copy must outlive the probe READ: the grep on $pfb_probe comes
+		// first, the unlink after it — a cleanup hoisted above the read would probe
+		// a deleted file.
+		$readPos = strpos(self::$applySource, 'escapeshellarg($pfb_probe)', $probePos);
+		$this->assertNotFalse($readPos, 'vacuity: the probe must read $pfb_probe');
+		$this->assertLessThan($suppressedPos, $readPos,
+			'the probe read must sit inside the empty-feed block');
+
 		$unlinkPos = strpos(self::$applySource, 'unlink_if_exists("{$file_dwn}.pre")', $probePos);
 		$this->assertNotFalse($unlinkPos,
 			'the staged pre-script copy must be unlinked AFTER the empty-feed probe consumed it');
+		$this->assertGreaterThan($readPos, $unlinkPos,
+			'the staged-copy unlink must come after the probe read, never before it');
 		$this->assertLessThan($suppressedPos, $unlinkPos,
 			'the staged-copy unlink must sit between the probe and the v6-suppression block');
 	}

--- a/tests/php/ListScriptExitStatusTest.php
+++ b/tests/php/ListScriptExitStatusTest.php
@@ -164,7 +164,14 @@ final class ListScriptExitStatusTest extends TestCase
 
 	public function testPostScriptCallSiteGatesOnExitStatus(): void
 	{
-		$postPos = strpos(self::$applySource, 'Executing post-script:');
+		// issue #1926: the DNSBL loop now logs the same "Executing post-script:" line
+		// earlier in the file -- anchor past the IP-loop's own reuse-skip call site
+		// (same technique as testPreScriptCallSiteGatesOnExitStatus) so this finds the
+		// IP-loop's occurrence, not the DNSBL one.
+		$reuseSkipPos = strpos(self::$applySource, 'pfb_ip_norm_reuse_skip(');
+		$this->assertNotFalse($reuseSkipPos, 'vacuity: the IP-loop normalize/reuse-skip step must exist');
+
+		$postPos = strpos(self::$applySource, 'Executing post-script:', $reuseSkipPos);
 		$this->assertNotFalse($postPos, 'vacuity: the post-script call site must exist');
 
 		$chkPos = strpos(self::$applySource, 'if (!$custom) {', $postPos);

--- a/tests/php/PfbNormReuseSkipTest.php
+++ b/tests/php/PfbNormReuseSkipTest.php
@@ -18,28 +18,29 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_ip_norm_reuse_skip')]
 final class PfbNormReuseSkipTest extends TestCase
 {
-	public function testDnsblSkipsOnlyForAFreshUnchangedDownloadOntoCurrentStaging(): void
+	public function testDnsblSkipsOnlyForAFreshUnchangedDownloadOntoCurrentStagingWithoutAUserScript(): void
 	{
-		$this->assertTrue(pfb_dnsbl_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE));
+		$this->assertTrue(pfb_dnsbl_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE));
 	}
 
-	/** @return array<string, array{bool,bool,bool,bool,bool,bool}> */
+	/** @return array<string, array{bool,bool,bool,bool,bool,bool,bool}> */
 	public static function dnsblNoSkipRows(): array
 	{
 		return [
-			'no fresh download (Reload/Force reparses)' => [FALSE, FALSE, FALSE, FALSE, TRUE, TRUE],
-			'custom list (re-synthesized per pass)'     => [TRUE, TRUE, FALSE, FALSE, TRUE, TRUE],
-			'stale-.orig download-failure fallback'     => [TRUE, FALSE, TRUE, FALSE, TRUE, TRUE],
-			'normalized content changed'                => [TRUE, FALSE, FALSE, TRUE, TRUE, TRUE],
-			'no staged .txt to reuse'                   => [TRUE, FALSE, FALSE, FALSE, FALSE, TRUE],
-			'stale staging generation (#1083)'          => [TRUE, FALSE, FALSE, FALSE, TRUE, FALSE],
+			'no fresh download (Reload/Force reparses)' => [FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE],
+			'custom list (re-synthesized per pass)'     => [TRUE, TRUE, FALSE, FALSE, TRUE, TRUE, FALSE],
+			'stale-.orig download-failure fallback'     => [TRUE, FALSE, TRUE, FALSE, TRUE, TRUE, FALSE],
+			'normalized content changed'                => [TRUE, FALSE, FALSE, TRUE, TRUE, TRUE, FALSE],
+			'no staged .txt to reuse'                   => [TRUE, FALSE, FALSE, FALSE, FALSE, TRUE, FALSE],
+			'stale staging generation (#1083)'          => [TRUE, FALSE, FALSE, FALSE, TRUE, FALSE, FALSE],
+			'user pre/post script owns the full pass'   => [TRUE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE],
 		];
 	}
 
 	#[DataProvider('dnsblNoSkipRows')]
-	public function testDnsblNeverSkipsWhenAnyGuardFails(bool $fresh, bool $custom, bool $stale, bool $changed, bool $txt, bool $generation): void
+	public function testDnsblNeverSkipsWhenAnyGuardFails(bool $fresh, bool $custom, bool $stale, bool $changed, bool $txt, bool $generation, bool $script): void
 	{
-		$this->assertFalse(pfb_dnsbl_norm_reuse_skip($fresh, $custom, $stale, $changed, $txt, $generation));
+		$this->assertFalse(pfb_dnsbl_norm_reuse_skip($fresh, $custom, $stale, $changed, $txt, $generation, $script));
 	}
 
 	public function testIpSkipsOnlyForAFreshUnchangedDownloadWithoutUserScripts(): void

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -4915,6 +4915,61 @@
             }
         ]
     },
+    "pfb_list_pre_script_run": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "norm_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "staged_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "script_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "script_name",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "args_tail",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "tmo_prefix",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_list_script_exec": {
         "returnsRef": false,
         "returnType": "int",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -1782,6 +1782,13 @@
                 "variadic": false,
                 "type": "bool",
                 "default": null
+            },
+            {
+                "name": "has_user_script",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
             }
         ]
     },

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -175,7 +175,9 @@ PAGE_TABLE: tuple[Page, ...] = (
     # category_edit.php: default IP view AND the DNSBL view; Form_Section('Advanced Tuneables') is unique to it.
     Page("category_edit_ip", "/pfblockerng/pfblockerng_category_edit.php?type=ipv4", ("Advanced Tuneables",)),
     # issue #1926: the DNSBL-only pre-script warning (script_pre help text) must render
-    # on the dnsbl view and must NEVER leak onto the IP view above.
+    # on the dnsbl view. Markers assert presence only, so the IP view's tuple simply
+    # omits it; the DNSBL-only conditioning is pinned server-side by
+    # DnsblListScriptWiringTest's help-note test.
     Page(
         "category_edit_dnsbl",
         "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl",

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -174,7 +174,13 @@ PAGE_TABLE: tuple[Page, ...] = (
     Page("category_dnsbl", "/pfblockerng/pfblockerng_category.php?type=dnsbl", ("Summary", "DNSBL")),
     # category_edit.php: default IP view AND the DNSBL view; Form_Section('Advanced Tuneables') is unique to it.
     Page("category_edit_ip", "/pfblockerng/pfblockerng_category_edit.php?type=ipv4", ("Advanced Tuneables",)),
-    Page("category_edit_dnsbl", "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl", ("Advanced Tuneables",)),
+    # issue #1926: the DNSBL-only pre-script warning (script_pre help text) must render
+    # on the dnsbl view and must NEVER leak onto the IP view above.
+    Page(
+        "category_edit_dnsbl",
+        "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl",
+        ("Advanced Tuneables", "A DNSBL pre-process script must not remove"),
+    ),
     # ?type=ipv6 renders the issue-#760 §3 "Suppression CIDR Limit" select block (gated
     # `if ($gtype == 'ipv6')`, a code path the ipv4/dnsbl entries above never exercise) --
     # this entry guards it against a PHP render regression.


### PR DESCRIPTION
## Summary

Two commits, one per issue, sequenced as the owner requested on #1925 (exit-status capture #1927 landed first in PR #1956; this builds on it).

### Commit 1 — feed pre-scripts run on the normalized output (#1925)

- New `pfb_list_pre_script_run()`: stages a copy of the normalized output (`{header}.pre`), hands the script the copy (in-place rewrite contract unchanged, `$1` = file path), honours the exit status (#1927). `ok` is FALSE on copy failure, non-zero exit, or the script deleting its input; the staged copy is removed and the row keeps its last known-good staging.
- The IP-loop pre-script block moves from before `pfb_feed_normalize()` to after the reuse-skip; the parse loop reads the staged copy when a script ran, `$pfb_norm['path']` otherwise; the transient copy is unlinked after the parse.
- `.orig.pre` backup/restore fully retired (`git grep 'orig\.pre' src/` = zero hits): the script no longer touches `.orig`, so there is nothing to restore.
- `$pfb_user_script` computed before normalization; `pfb_ip_norm_reuse_skip()` unchanged — feeds with a script still never skip.
- Post-scripts untouched by this commit. The 25 shipped `ip_pre_AWS_*.sh` wrappers need no edit (they operate on `$1` only, per the issue's compatibility analysis).

### Commit 2 — DNSBL feeds execute their pre/post scripts (#1926, owner option 1)

- The DNSBL loop never executed the saved `script_pre`/`script_post` pickers. Now wired, mirroring the IP loop's shape above: per-alias `pfb_resolve_list_script()` resolution, staged-copy pre-script (second script arg is the literal `dnsbl`), exit-status gated.
- **Keep-last-known-good on failure:** with an existing staged `.txt`, the manifest row and counts are still emitted (dropping the row would relocate the outage) and the `.update` marker is kept for retry; without one, the feed is simply absent this pass, logged.
- `pfb_dnsbl_norm_reuse_skip()` gains the `has_user_script` term its IP counterpart already had — a feed with a configured script re-parses every pass, so script edits always take effect.
- Post-script runs on a throwaway copy of the download after the parse. Deliberate simplification vs the IP loop's `.orig.post` backup/restore: the IP loop discards post-script edits via restore anyway, so observable behaviour is identical with less state; exit status is logged the same way.
- Help-text note on the DNSBL Pre-process Script picker: a script must not remove IP-shaped/ABP-shaped lines — DNSBLIP is synthesized from addresses extracted out of domain feeds, and removed lines silently shrink it. Tier A pin: the `category_edit_dnsbl` render page asserts the note (IP page asserts its absence by omission).
- DNSBLIP regression fixtures: an identity pre-script preserves `pfb_dnsbl_collect_feed_ip()` v4+v6 extraction counts on a mixed domains+IPs+ABP feed (before-state asserted); a stripping pre-script measurably shrinks them (the hazard the help note warns about).

## Evidence

Both commits carry executed test-first red→green proofs, independently re-executed by a fresh verifier via `scripts/agent/verify-red-proof.sh` (FREEZE-OK / RED-OK / GREEN-OK / VERDICT: PASS for each commit against its true pre-fix baseline). One disclosed post-red edit in commit 2's new wiring test (a `strpos` window boundary hit `&nbsp;`'s semicolon; fixed to `";\n"`, red re-executed with the committed file — reproduced identically). Two pre-existing tests updated for real collisions the change caused: the IP post-script wiring pin gained an offset anchor (the DNSBL block introduced a second `Executing post-script:` occurrence), and `AliasCntGrepCountGuardTest`'s site-count pin moved 3→4 for the new manifest-kept branch.

Gates: `scripts/agent/run-gates.sh` → `GATES: PASS` after each commit (full PHPUnit incl. 30+ new/updated assertions, pytest, PHPStan, PHPCS, ruff/mypy); re-run independently by each step's verifier.

Fixes #1925
Fixes #1926

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-processing scripts now run safely on staged feed copies before DNSBL and IP parsing.
  * Failed pre-processing preserves the last known-good output and enables retry.
  * Post-processing changes are cleaned up after processing.
  * DNSBL configuration warns when pre-processing may remove supported lines.

* **Bug Fixes**
  * Normalized feed reuse is prevented when custom scripts are configured.

* **Tests**
  * Expanded coverage for script execution, failures, cleanup, parsing, and UI warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->