### PR TITLE
pfblockerng: keep the loaded script and buffer on a failed hook create

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
@@ -86,9 +86,10 @@ $pfb_eh_sel_script = '';
 $pfb_eh_content    = '';
 
 // Create-flow field echo -- only re-populated on a failed create POST, so the user
-// doesn't have to retype Name/Language after fixing a validation error.
-$pfb_eh_new_core_val = '';
-$pfb_eh_new_lang_val = 'sh';
+// doesn't have to retype When/Name/Language after fixing a validation error.
+$pfb_eh_new_core_val  = '';
+$pfb_eh_new_lang_val  = 'sh';
+$pfb_eh_new_when_echo = '';
 
 if ($_POST) {
 	if (isset($_POST['pfb_eh_create'])) {
@@ -150,10 +151,17 @@ if ($_POST) {
 
 		// Preserve the create-flow fields the user typed so a validation error doesn't
 		// silently clear the form.
-		$pfb_eh_sel_when     = $post_when;
-		$pfb_eh_content      = '';
-		$pfb_eh_new_core_val = $post_core;
-		$pfb_eh_new_lang_val = ($post_lang === 'py') ? 'py' : 'sh';
+		$pfb_eh_new_core_val  = $post_core;
+		$pfb_eh_new_lang_val  = ($post_lang === 'py') ? 'py' : 'sh';
+		$pfb_eh_new_when_echo = $post_when;
+
+		// issue #1884: a failed create must not cost the admin their unsaved edits --
+		// Enter in the Name field (the form's only text input) submits as Create, so
+		// this error path fires from a stray keypress. Same cur_-restore shape as the
+		// failed-delete branch below; the save branch re-validates both before writing.
+		$pfb_eh_sel_when   = (string) ($_POST['pfb_eh_cur_when'] ?? '');
+		$pfb_eh_sel_script = (string) ($_POST['pfb_eh_cur_script'] ?? '');
+		$pfb_eh_content    = pfb_sanitize_text_area((string) ($_POST['pfb_eh_content'] ?? ''));
 	} elseif (isset($_POST['pfb_eh_delete']) && $_POST['pfb_eh_delete'] !== '') {
 		// The emptiness check is load-bearing, not defensive: pfb_eh_delete is a
 		// hidden field rendered on EVERY request, and a browser submits hidden inputs
@@ -439,7 +447,10 @@ $section->addInput(new Form_StaticText(
 		'-- you never type a path or a full filename. Creation is rejected if that exact file already exists.') . '</small>'
 ));
 
-$pfb_eh_new_when_val = ($pfb_eh_sel_when === 'pre' || $pfb_eh_sel_when === 'post') ? $pfb_eh_sel_when : 'post';
+// The typed create-When echo (failed create) wins over the loaded script's own
+// when; a fresh render follows the loaded script, defaulting to 'post'.
+$pfb_eh_new_when_val = ($pfb_eh_new_when_echo === 'pre' || $pfb_eh_new_when_echo === 'post') ? $pfb_eh_new_when_echo
+	: (($pfb_eh_sel_when === 'pre' || $pfb_eh_sel_when === 'post') ? $pfb_eh_sel_when : 'post');
 $group = new Form_Group('New Hook');
 $group->add(new Form_Select(
 	'pfb_eh_new_when',

--- a/tests/php/EditHooksPageWiringTest.php
+++ b/tests/php/EditHooksPageWiringTest.php
@@ -426,6 +426,40 @@ final class EditHooksPageWiringTest extends TestCase
 		);
 	}
 
+	/**
+	 * issue #1884: Enter in the Name field submits as Create (only text input +
+	 * first submit button), so the create-failure path fires from a stray
+	 * keypress. It must restore the loaded script and the unsaved buffer from
+	 * the posted cur_ and content fields — the same shape the failed-delete
+	 * branch uses — instead of blanking the editor.
+	 */
+	public function testCreateFailureRestoresTheLoadedScriptAndBuffer(): void
+	{
+		$src = $this->readSource(self::PAGE_PATH);
+
+		$createPos = strpos($src, "isset(\$_POST['pfb_eh_create'])");
+		$this->assertNotFalse($createPos, 'vacuity: the create branch must exist');
+		$deletePos = strpos($src, "isset(\$_POST['pfb_eh_delete'])", $createPos);
+		$this->assertNotFalse($deletePos, 'vacuity: the delete branch must follow the create branch');
+
+		$branch = substr($src, $createPos, $deletePos - $createPos);
+		$this->assertStringContainsString("\$pfb_eh_sel_when   = (string) (\$_POST['pfb_eh_cur_when'] ?? '');", $branch,
+			'a failed create must restore the loaded Pre/Post from the posted cur_when');
+		$this->assertStringContainsString("\$pfb_eh_sel_script = (string) (\$_POST['pfb_eh_cur_script'] ?? '');", $branch,
+			'a failed create must restore the loaded script from the posted cur_script');
+		$this->assertStringContainsString("\$pfb_eh_content    = pfb_sanitize_text_area((string) (\$_POST['pfb_eh_content'] ?? ''));", $branch,
+			'a failed create must restore the unsaved buffer (sanitized at ingestion, #1723) instead of blanking it');
+		$this->assertStringNotContainsString("\$pfb_eh_content      = '';", $branch,
+			'the blanking assignment is the data-loss defect — it must be gone');
+
+		// The typed create-When echo must survive the restore: the create-When
+		// select prefers the explicit echo over the restored loaded-script when.
+		$this->assertStringContainsString('$pfb_eh_new_when_echo = $post_when;', $branch,
+			'the typed create-When choice must still echo after a validation error');
+		$this->assertStringContainsString("\$pfb_eh_new_when_val = (\$pfb_eh_new_when_echo === 'pre' || \$pfb_eh_new_when_echo === 'post')", $src,
+			'the create-When select must prefer the typed echo over the restored loaded-script when');
+	}
+
 	public function testEditHooksTabOnUpdatePage(): void
 	{
 		$this->assertEditHooksTabDirectlyAfterHooksTab($this->readSource(self::UPDATE_PAGE_PATH), 'pfblockerng_update.php');

--- a/tests/smoke/ui/test_browser_hook_tables.py
+++ b/tests/smoke/ui/test_browser_hook_tables.py
@@ -254,6 +254,10 @@ def test_enter_in_name_field_never_discards_unsaved_editor_content(
     page.keyboard.press("Delete")
     content.press_sequentially(f"#!/bin/sh\n{marker}\nexit 0", delay=20)
 
+    # The probe hook is a POST hook -- pick the OPPOSITE create-When so the echo
+    # assertion below cannot be satisfied by the restored loaded-script when.
+    page.select_option("#pfb_eh_new_when", "pre")
+
     # A hyphen fails the compose validation (letters/digits/underscores only),
     # and Enter submits the form as Create.
     name = page.locator("#pfb_eh_new_core")
@@ -271,3 +275,9 @@ def test_enter_in_name_field_never_discards_unsaved_editor_content(
         "a failed create must keep the loaded script loaded"
     )
     expect(page.locator("#pfb_hook_editor_content")).to_have_value(re.compile(re.escape(marker)), timeout=JS_TIMEOUT_MS)
+
+    # The typed create-When echo also survives the error -- distinct from the
+    # loaded script's own when (set to the opposite above).
+    assert page.locator("#pfb_eh_new_when").input_value() == "pre", (
+        "the typed create-When choice must still be selected after a validation error"
+    )

--- a/tests/smoke/ui/test_browser_hook_tables.py
+++ b/tests/smoke/ui/test_browser_hook_tables.py
@@ -222,3 +222,52 @@ def test_dismissing_the_delete_confirmation_keeps_the_script(
 
     _open(page, webui, HOOKS_PAGE)
     expect(page.locator(f"tr[data-pfb-hook='{probe_hook}']")).to_have_count(1, timeout=JS_TIMEOUT_MS)
+
+
+def test_enter_in_name_field_never_discards_unsaved_editor_content(
+    browser_page: Page,
+    webui: WebUI,
+    probe_hook: str,
+) -> None:
+    """A stray Enter in the Name field must not cost unsaved editor work (#1884).
+
+    ``#pfb_eh_new_core`` is the form's only text input and Create is its first
+    submit button, so the browser treats Enter there as a Create click. When
+    that create fails validation, the page must come back with the loaded
+    script still loaded and the unsaved buffer intact -- not the empty
+    "Load an existing script above" state.
+    """
+    page = browser_page
+    _open(page, webui, HOOKS_PAGE)
+
+    row = page.locator(f"tr[data-pfb-hook='{probe_hook}']")
+    expect(row).to_be_visible(timeout=JS_TIMEOUT_MS)
+    row.locator("a .fa-pencil").click()
+    page.wait_for_load_state("networkidle", timeout=JS_TIMEOUT_MS * 3)
+    assert page.locator("#pfb_eh_cur_script").input_value() == probe_hook, "precondition: the script is loaded"
+
+    marker = "# pfb-uitest-enter-keeps-buffer"
+    content = page.locator(".cm-content")
+    expect(content).to_be_visible(timeout=JS_TIMEOUT_MS)
+    content.click()
+    page.keyboard.press("ControlOrMeta+a")
+    page.keyboard.press("Delete")
+    content.press_sequentially(f"#!/bin/sh\n{marker}\nexit 0", delay=20)
+
+    # A hyphen fails the compose validation (letters/digits/underscores only),
+    # and Enter submits the form as Create.
+    name = page.locator("#pfb_eh_new_core")
+    name.click()
+    name.fill("bad-name")
+    name.press("Enter")
+    page.wait_for_load_state("networkidle", timeout=JS_TIMEOUT_MS * 3)
+
+    # Before-state of the defect: the create DID run and DID fail validation --
+    # so green proves the restore, not that the submit never happened.
+    expect(page.locator(".input-errors")).to_contain_text("Invalid new-hook fields", timeout=JS_TIMEOUT_MS)
+
+    # The data-loss pin: the loaded script and the unsaved buffer both survive.
+    assert page.locator("#pfb_eh_cur_script").input_value() == probe_hook, (
+        "a failed create must keep the loaded script loaded"
+    )
+    expect(page.locator("#pfb_hook_editor_content")).to_have_value(re.compile(re.escape(marker)), timeout=JS_TIMEOUT_MS)


### PR DESCRIPTION
## Summary

On the Edit Hooks page, Enter in the **Name** field (the form's only text input) submits as **Create**; a create that failed validation then blanked the editor and dropped the loaded script — an accidental keypress silently discarded unsaved work.

The create-failure path now restores the loaded script and the unsaved buffer from the posted `cur_*` and content fields (the same shape the failed-delete branch got in #1880; the save branch re-validates both before anything is written). The typed When/Name/Language echo survives via a dedicated When echo variable, so fixing the validation error doesn't cost the typed create fields either. Successful create is untouched (same PRG redirect).

Client-side Enter-suppression / pre-validation was deliberately not added: the server path must be loss-free anyway (crafted POSTs bypass any client check, and only the server knows about name collisions or an unwritable directory), and the naming rule intentionally lives only in `pfb_hook_editor_compose_filename()`.

## Evidence

Test-first, both tests authored and committed before the production edit (tests-only commit 27a10be9), byte-identical through green:

- **Wiring pin** (`EditHooksPageWiringTest::testCreateFailureRestoresTheLoadedScriptAndBuffer`, hash `34f68a01…`): RED on untouched code (restore lines absent) → GREEN after, `OK (21 tests, 144 assertions)`.
- **Browser repro** (`test_browser_hook_tables.py::test_enter_in_name_field_never_discards_unsaved_editor_content`, hash `29578ed9…`), executed on a live pfSense VM via `scripts/local-smoke.sh --marker ui_browser`:
  - RED at 27a10be9: `1 failed` — `assert '' == 'hook_post_pfb_uitest_hook.sh'` (loaded script discarded after the Enter-submitted create failed), with the validation-error banner asserted first so green proves the restore, not a suppressed submit.
  - GREEN at 971673ee: `1 passed, 580 deselected`.
- Gates: `scripts/agent/run-gates.sh` → `GATES: PASS`.

## Acceptance (issue #1884, owner comment)

- Load script → edit → Enter in Name with invalid core → validation error **and** prior editor content still present ✔ (browser test)
- Successful create path unchanged (PRG) ✔ (branch untouched above the fall-through)
- Red→green UI/wiring test on the create-failure restore ✔ (both, executed)

Fixes #1884

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed hook creation attempts now preserve the selected hook, unsaved editor content, and entered “When” value.
  * Pressing Enter in the new hook name field no longer discards unsaved changes when validation fails.

* **Tests**
  * Added regression coverage for failed hook creation and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->