### PR TITLE
tests/ui: judge category-edit bodies by the diagnostic-shape oracle (#1856)

### DIFF
--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from .. import helpers
+from .render_oracle import body_has_php_error
 from .webui import extract_csrf_token, looks_like_login_page
 
 if TYPE_CHECKING:
@@ -1082,8 +1083,8 @@ def test_ipv6_suppression_cidr_select_persists_and_reloads(
             "category GET (reload) returned the login form (session lost)"
         )
         body = reload_resp.text
-        for bad in ("Fatal error", "Parse error", "Warning", "Notice", "Uncaught"):
-            assert bad not in body, f"reloaded v6 edit page contains PHP error: {bad!r}"
+        diag = body_has_php_error(body)
+        assert diag is None, f"reloaded v6 edit page contains PHP diagnostic: {diag!r}"
         assert 'name="suppression_cidr_v6"' in body, "reloaded v6 form has no suppression_cidr_v6 select"
         assert _option_selected(body, "32"), (
             "reloaded v6 form did not render suppression_cidr_v6 option '32' as selected"
@@ -1103,8 +1104,8 @@ def test_ipv6_suppression_cidr_select_persists_and_reloads(
             _post_form(webui, _ipv4_payload(v4_rowid, "smokeip4sym", action="Deny_Both"))
             v4_resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4", "rowid": str(v4_rowid)})
             assert not looks_like_login_page(v4_resp.text), "v4 category GET returned the login form (session lost)"
-            for bad in ("Fatal error", "Parse error", "Warning", "Notice", "Uncaught"):
-                assert bad not in v4_resp.text, f"existing-row v4 edit page contains PHP error: {bad!r}"
+            v4_diag = body_has_php_error(v4_resp.text)
+            assert v4_diag is None, f"existing-row v4 edit page contains PHP diagnostic: {v4_diag!r}"
             assert 'name="suppression_cidr_v6"' not in v4_resp.text, (
                 "v4 edit page must not render the v6-only 'suppression_cidr_v6' select"
             )
@@ -1150,15 +1151,16 @@ def test_ipv4_category_edit_renders_alias_type_help_text(
         - HTTP 200.
         - Body contains ``Must be a Port-type alias.``
         - Body contains ``Must be an address-type (Host, Network, URL or URL Table) alias.``
-        - Body free of ``Fatal error``, ``Parse error``, ``Warning``, ``Notice``,
-          ``Uncaught`` (standard ui_render guarantee).
+        - Body free of any rendered PHP-diagnostic SHAPE (:func:`body_has_php_error`;
+          the standard ui_render guarantee -- never a bare level-word substring,
+          which false-positives on the pfSense Notices chrome, #1856).
     """
     resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4"})
     assert resp.status_code == 200, f"IPv4 category-edit GET returned HTTP {resp.status_code} (expected 200)"
     body = resp.text
     assert not looks_like_login_page(body), "IPv4 category-edit GET returned the login form (session lost)"
-    for bad in ("Fatal error", "Parse error", "Warning", "Notice", "Uncaught"):
-        assert bad not in body, f"IPv4 category-edit page contains PHP error: {bad!r}"
+    diag = body_has_php_error(body)
+    assert diag is None, f"IPv4 category-edit page contains PHP diagnostic: {diag!r}"
     assert "Must be a Port-type alias." in body, (
         "IPv4 category-edit page is missing help text 'Must be a Port-type alias.'"
     )
@@ -1189,7 +1191,7 @@ def test_ipv4_category_edit_renders_four_alias_select_fields(
     When:
         GET ``pfblockerng_category_edit.php?type=ipv4``.
     Then:
-        - HTTP 200, no PHP errors.
+        - HTTP 200, no rendered PHP-diagnostic shape (:func:`body_has_php_error`).
         - Each of ``aliasports_in``, ``aliasports_out``, ``aliasaddr_in``,
           ``aliasaddr_out`` appears as a ``<select name="...">`` in the body.
     """
@@ -1197,7 +1199,61 @@ def test_ipv4_category_edit_renders_four_alias_select_fields(
     assert resp.status_code == 200, f"IPv4 category-edit GET returned HTTP {resp.status_code} (expected 200)"
     body = resp.text
     assert not looks_like_login_page(body), "IPv4 category-edit GET returned the login form (session lost)"
-    for bad in ("Fatal error", "Parse error", "Warning", "Notice", "Uncaught"):
-        assert bad not in body, f"IPv4 category-edit page contains PHP error: {bad!r}"
+    diag = body_has_php_error(body)
+    assert diag is None, f"IPv4 category-edit page contains PHP diagnostic: {diag!r}"
     for field in ("aliasports_in", "aliasports_out", "aliasaddr_in", "aliasaddr_out"):
         assert f'name="{field}"' in body, f'IPv4 category-edit page is missing <select name="{field}"> field'
+
+
+@pytest.mark.ui_render
+def test_ipv4_category_edit_renders_clean_with_a_pending_system_notice(
+    webui: "WebUI",
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A pending pfSense system notice must not fail the category-edit render tests.
+
+    Scenario: issue #1856 -- a box carrying a pending system notice renders the
+    Notices bell chrome and the notice text into EVERY page (release run
+    30424647767: the mislabeled 26.07 box held a "Boot verification failed"
+    notice, and a naive ``'Notice' not in body`` assert tripped on the chrome
+    with zero PHP diagnostics on the page). This pins the fixed oracle: with a
+    notice pending, the page still renders clean under the SHAPE check.
+
+    Given:
+        A pfSense system notice is filed on the box (``file_notice``).
+    When:
+        GET ``pfblockerng_category_edit.php?type=ipv4``.
+    Then:
+        - The notice text is IN the body (the collision condition is real,
+          not vacuously absent).
+        - HTTP 200, page marker present, and no rendered PHP-diagnostic shape
+          (:func:`body_has_php_error`) -- the chrome must not read as an error.
+    """
+    vm = smoke_vm
+    notice_text = "pfBlockerNG smoke notice fixture (#1856)"
+    try:
+        res = helpers.php_eval(
+            vm,
+            f"require_once('notices.inc');\nfile_notice('pfb-smoke-1856', '{notice_text}', 'pfBlockerNG');\necho 'OK';",
+        )
+        assert res.returncode == 0 and "OK" in res.stdout, (
+            f"file_notice fixture failed: rc={res.returncode} stdout={res.stdout!r} stderr={res.stderr!r}"
+        )
+
+        resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4"})
+        assert resp.status_code == 200, f"IPv4 category-edit GET returned HTTP {resp.status_code} (expected 200)"
+        body = resp.text
+        assert not looks_like_login_page(body), "IPv4 category-edit GET returned the login form (session lost)"
+
+        # BEFORE-state: the pending notice actually reached the page chrome --
+        # otherwise the oracle assertion below would pass vacuously.
+        assert notice_text in body, "pending system notice did not surface in the page chrome"
+
+        diag = body_has_php_error(body)
+        assert diag is None, f"notice-bearing category-edit page reads as a PHP diagnostic: {diag!r}"
+        assert "Must be a Port-type alias." in body, "category-edit page marker missing with a notice pending"
+    finally:
+        clear = helpers.php_eval(vm, "require_once('notices.inc');\nclose_notice('all');\necho 'OK';")
+        assert clear.returncode == 0 and "OK" in clear.stdout, (
+            f"close_notice teardown failed: rc={clear.returncode} stdout={clear.stdout!r} stderr={clear.stderr!r}"
+        )

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -1234,7 +1234,9 @@ def test_ipv4_category_edit_renders_clean_with_a_pending_system_notice(
     try:
         res = helpers.php_eval(
             vm,
-            f"require_once('notices.inc');\nfile_notice('pfb-smoke-1856', '{notice_text}', 'pfBlockerNG');\necho 'OK';",
+            "require_once('notices.inc');\n"
+            f"file_notice('pfb-smoke-1856', {helpers._php_str(notice_text)}, 'pfBlockerNG');\n"
+            "echo 'OK';",
         )
         assert res.returncode == 0 and "OK" in res.stdout, (
             f"file_notice fixture failed: rc={res.returncode} stdout={res.stdout!r} stderr={res.stderr!r}"
@@ -1253,7 +1255,9 @@ def test_ipv4_category_edit_renders_clean_with_a_pending_system_notice(
         assert diag is None, f"notice-bearing category-edit page reads as a PHP diagnostic: {diag!r}"
         assert "Must be a Port-type alias." in body, "category-edit page marker missing with a notice pending"
     finally:
-        clear = helpers.php_eval(vm, "require_once('notices.inc');\nclose_notice('all');\necho 'OK';")
+        # Scope the teardown to OUR notice id -- 'all' would also erase any genuine
+        # pre-existing system notice on the shared session VM.
+        clear = helpers.php_eval(vm, "require_once('notices.inc');\nclose_notice('pfb-smoke-1856');\necho 'OK';")
         assert clear.returncode == 0 and "OK" in clear.stdout, (
             f"close_notice teardown failed: rc={clear.returncode} stdout={clear.stdout!r} stderr={clear.stderr!r}"
         )

--- a/tests/smoke/ui/test_render_oracle.py
+++ b/tests/smoke/ui/test_render_oracle.py
@@ -170,6 +170,9 @@ def test_pending_system_notices_chrome_is_not_rejected() -> None:
     diagnostics on the page); the shape oracle must accept it -- and must still
     reject a real diagnostic rendered alongside the same chrome.
     """
+    # Premise pin: the chrome really carries the bare level word that tripped the
+    # old substring assert -- an edit dropping it would leave this test vacuous.
+    assert "Notice" in NOTICES_CHROME
     chrome_body = GOOD_BODY.replace("<body>", f"<body>{NOTICES_CHROME}")
     assert body_has_php_error(chrome_body) is None, "pending-notices chrome wrongly flagged as a PHP diagnostic"
     assert evaluate_render("/p", 200, chrome_body, (GOOD_MARKER,)).ok

--- a/tests/smoke/ui/test_render_oracle.py
+++ b/tests/smoke/ui/test_render_oracle.py
@@ -148,6 +148,41 @@ def test_level_words_in_legit_copy_are_not_rejected(copy: str) -> None:
     assert evaluate_render("/p", 200, body, (GOOD_MARKER,)).ok, f"oracle wrongly rejected legit copy: {copy!r}"
 
 
+# The chrome pfSense renders into EVERY page while a system notice is pending --
+# captured from issue #1856's failing leg (release run 30424647767): the notice
+# bell, the Notices modal, and the pending notice's own text. No PHP diagnostic
+# anywhere in it.
+NOTICES_CHROME = (
+    '<i class="fa-solid fa-bell text-danger" title="Notices"></i>'
+    '<h3 class="modal-title" id="myModalLabel">Notices</h3>'
+    "<h4>warning</h4><ul><li><b></b>"
+    "Boot verification failed for default. Netgate pfSense Plus was automatically "
+    "rebooted back into default_20260729033017.<i>@ 2026-07-29 05:20:16</i></li></ul>"
+)
+
+
+def test_pending_system_notices_chrome_is_not_rejected() -> None:
+    """(b) false-positive guard (#1856): the pending-notices chrome PASSES.
+
+    A box with a pending pfSense system notice renders 'Notices' (bell title +
+    modal heading) plus the notice text into every page. A bare-substring
+    'Notice' assert trips on that chrome (how #1856 failed, with zero PHP
+    diagnostics on the page); the shape oracle must accept it -- and must still
+    reject a real diagnostic rendered alongside the same chrome.
+    """
+    chrome_body = GOOD_BODY.replace("<body>", f"<body>{NOTICES_CHROME}")
+    assert body_has_php_error(chrome_body) is None, "pending-notices chrome wrongly flagged as a PHP diagnostic"
+    assert evaluate_render("/p", 200, chrome_body, (GOOD_MARKER,)).ok
+
+    # Branch coverage: the chrome must not MASK a real diagnostic either.
+    broken = chrome_body.replace(
+        "<body>", "<body>Notice: Undefined variable $x in /usr/local/www/pfblockerng/x.php on line 3<br />"
+    )
+    result = evaluate_render("/p", 200, broken, (GOOD_MARKER,))
+    assert not result.ok, "a real diagnostic next to the Notices chrome must still be rejected"
+    assert any("PHP diagnostic" in r for r in result.reasons)
+
+
 def test_non_200_is_rejected() -> None:
     """(a): a 500 fails even with a clean, marker-bearing body (200-vs-not is a real branch)."""
     assert evaluate_render("/p", 200, GOOD_BODY, (GOOD_MARKER,)).ok  # before: 200 passes


### PR DESCRIPTION
The IPv4 category-edit render failures in release run 30424647767 (the `plus-26.07` leg) were never a PHP `Notice`. The flagged string was pfSense's **Notices bell chrome** — `<i ... title="Notices">` plus the `<h3>Notices</h3>` modal — rendered into every page because the box held a pending system notice: *"Boot verification failed for default. Netgate pfSense Plus was automatically rebooted back into default_20260729033017"*, i.e. the #1858 boot-environment fallback's own notice on the mislabeled 26.03.1 box. The page carried zero PHP diagnostics; four assertions in `test_category_edit.py` used bare level-word substring checks (`assert "Notice" not in body`) and tripped on the chrome (the #791 class).

## Changes

- Route all four naive substring sites in `tests/smoke/ui/test_category_edit.py` through the shared Tier-A shape oracle `render_oracle.body_has_php_error`, which matches rendered PHP-diagnostic *shapes* and is already immune to level words in page copy.
- Pin the pending-notices chrome (captured from the failing leg's page dump) as legit copy in `test_render_oracle.py`, with branch coverage that a real diagnostic rendered beside the same chrome is still rejected.
- Add a live `ui_render` pin: file a real system notice (`file_notice`), GET the category-edit page, assert the notice text actually surfaced in the chrome (non-vacuous), and assert the page still renders clean under the shape oracle; teardown clears notices.

## Evidence

- **Red (executed, recorded):** release run 30424647767 — both category-edit render tests failed with `AssertionError: IPv4 category-edit page contains PHP error: 'Notice'`; the job log's quoted body shows the match sites are the bell `title="Notices"` and the modal heading, and the only pending notice is the #1858 boot-verification warning.
- **Discriminating probe (executed, off-box):** the old tuple loop trips exactly on `'Notice'` against the captured chrome fixture while `body_has_php_error` returns `None`; the same fixture plus a real `Notice: ... on line N` diagnostic is rejected.
- **Green (executed, live box):** `scripts/local-smoke.sh --ref issue/1856-category-edit-render-oracle --marker ui_render --filter "category_edit or render_oracle"` → **55 passed** (box `10.0.0.35` pool, run `local-100038-1785570634-ab3b09a30765e3f8`), including the new pending-notice pin (notice injected, chrome present, page clean).
- Latest nightly UI run on `devel` (30689628782, 2026-08-01): all three render legs green including the genuine 26.07 image (republished via #1858 / PR #1876) — confirming the Notice was box state, not a page defect.

Fixes #1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page rendering reliability when pending system notices are displayed.
  * Prevented normal notice messages from being misidentified as PHP diagnostic errors.

* **Tests**
  * Added coverage for IPv4, IPv6, and alias category-edit pages with pending notices.
  * Added regression checks to distinguish legitimate system notices from genuine PHP errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->