### PR TITLE
www: preserve invalid UTF-8 custom-feed cells

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -893,7 +893,7 @@ print ($section);
 								// http(s):// scheme becomes a clickable <a href> -- htmlspecialchars
 								// does not neutralise a `javascript:` scheme, so a bare strpos('http')
 								// would render `javascript:...http...` as an executable link.
-								$url_hsc = htmlspecialchars($row['url'], ENT_QUOTES, 'UTF-8');
+								$url_hsc = htmlspecialchars($row['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 								if (str_starts_with($row['url'], 'http://') || str_starts_with($row['url'], 'https://')) {
 									print ("<a target=\"_blank\" href=\"{$url_hsc}\">{$url_hsc}</a>");
 								} else {
@@ -906,7 +906,7 @@ print ($section);
 					<?php
 								// issue #1069: the header is another raw feed-derived sink in
 								// this same table row -- HTML-encode it before it enters markup.
-								print (htmlspecialchars($row['header'], ENT_QUOTES, 'UTF-8'));
+								print (htmlspecialchars($row['header'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
 					?>
 				</td>
 			</tr>

--- a/tests/php/FeedsCustomOutputEncodingTest.php
+++ b/tests/php/FeedsCustomOutputEncodingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Render pins for legacy custom-feed text containing invalid UTF-8 (#1819).
+ * The page cannot be required off-appliance, so this extracts its custom-row
+ * template and evaluates it with the same page-scope inputs.
+ */
+final class FeedsCustomOutputEncodingTest extends TestCase
+{
+	private function renderCustomRow(string $url, string $header): string
+	{
+		$src = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_feeds.php'
+		);
+		if ($src === false) {
+			throw new RuntimeException('failed to read pfblockerng_feeds.php');
+		}
+
+		$start = strpos($src, "\t\t\t\t<?php\n\t\t\t\t// issue #1496:");
+		$end   = strpos($src, "\n\t\t\t<tbody>\n\t\t\t</table>", $start === false ? 0 : $start);
+		if ($start === false || $end === false || $end <= $start) {
+			throw new RuntimeException('could not locate the custom-feed row template');
+		}
+
+		$ex_feeds = ['ipv4' => [[
+			'aliasname' => 'InvalidUtf8Feed',
+			'url'       => $url,
+			'header'    => $header,
+			'rowid'     => 17,
+		]]];
+		$gtype      = 'ipv4';
+		$type_label = ['ipv4' => 'IPv4'];
+
+		ob_start();
+		eval('?>' . substr($src, $start, $end - $start));
+		return (string) ob_get_clean();
+	}
+
+	public function testInvalidUtf8ByteInUrlRendersSubstitutedNotBlanked(): void
+	{
+		$html     = $this->renderCustomRow("https://before\xFFafter.invalid-url.example/list.txt", 'SafeHeader');
+		$expected = "https://before\u{FFFD}after.invalid-url.example/list.txt";
+
+		$this->assertStringContainsString($expected, $html, 'the custom-feed URL must survive with only its invalid byte substituted');
+		$this->assertStringNotContainsString("\xFF", $html, 'the rendered row must not retain the invalid byte');
+		$this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'the rendered row must be valid UTF-8');
+	}
+
+	public function testInvalidUtf8ByteInHeaderRendersSubstitutedNotBlanked(): void
+	{
+		$html     = $this->renderCustomRow('https://safe.invalid-header.example/list.txt', "before\xFFafter-header");
+		$expected = "before\u{FFFD}after-header";
+
+		$this->assertStringContainsString($expected, $html, 'the custom-feed header must survive with only its invalid byte substituted');
+		$this->assertStringNotContainsString("\xFF", $html, 'the rendered row must not retain the invalid byte');
+		$this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'the rendered row must be valid UTF-8');
+	}
+}

--- a/tests/smoke/ui/test_xss_escaping.py
+++ b/tests/smoke/ui/test_xss_escaping.py
@@ -289,6 +289,8 @@ XSS_FEED_URL = 'http://a"><script>xss</script>.evil.example/list.txt'
 # encoded URL (not a fragment) proves the seeded row rendered, encoded.
 XSS_FEED_URL_ENCODED = "http://a&quot;&gt;&lt;script&gt;xss&lt;/script&gt;.evil.example/list.txt"
 XSS_FEED_URL_MARKER = "evil.example/list.txt"
+XSS_FEED_HEADER = "<header>\"'.header.evil.example"
+XSS_FEED_HEADER_ENCODED = "&lt;header&gt;&quot;&#039;.header.evil.example"
 
 # A "javascript:" scheme URL that still contains "http": the pre-fix
 # strpos('http') gate would have wrapped it in <a href="javascript:...">, and
@@ -316,7 +318,7 @@ def _seed_custom_feed_row(vm: helpers.SmokeVM, cfg_root: str, rowid: int, aliasn
     render-path seed, mirroring ``test_category_edit.py``'s config-injection
     idiom (``_mk_alias``).
     """
-    row = {"state": "Enabled", "url": url, "header": "xss-header"}
+    row = {"state": "Enabled", "url": url, "header": XSS_FEED_HEADER}
     snippet = (
         f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/aliasname')}, {helpers._php_str(aliasname)});\n"
         f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/action')}, {helpers._php_str('Deny_Both')});\n"
@@ -352,9 +354,9 @@ def test_feeds_custom_url_escapes_hostile_input(webui: WebUI, smoke_vm: helpers.
             ``url_compare`` never marks it ``found``).
       Then  the Tier-A render oracle passes AND the FULLY-encoded URL
             (``http://a&quot;&gt;&lt;script&gt;xss&lt;/script&gt;.evil.example/list.txt``)
-            appears in the body AND the raw breakout (``a"><script>``) never
-            appears anywhere (issue #1069 -- pre-fix, the URL printed raw in
-            both the href attribute and the link text).
+            and header appear in the body AND their raw markup never appears,
+            preserving the existing escaping while exercising both reachable
+            cells alongside issue #1819's exact invalid-byte PHPUnit proof.
     """
     vm = smoke_vm
     rowid = _free_rowid(vm, CFG_IPV4_FEEDS)
@@ -376,6 +378,11 @@ def test_feeds_custom_url_escapes_hostile_input(webui: WebUI, smoke_vm: helpers.
         )
         assert XSS_FEED_URL_ENCODED in body, (
             f"the Custom Feeds URL column did not HTML-encode the whole hostile URL (expected {XSS_FEED_URL_ENCODED!r})"
+        )
+        assert XSS_FEED_HEADER not in body, "the raw Custom Feeds header rendered verbatim"
+        assert XSS_FEED_HEADER_ENCODED in body, (
+            f"the Custom Feeds header column did not HTML-encode the whole hostile header "
+            f"(expected {XSS_FEED_HEADER_ENCODED!r})"
         )
     finally:
         _del_rowid(vm, CFG_IPV4_FEEDS, rowid)


### PR DESCRIPTION
## Summary

- preserve valid URL/header text when a legacy custom-feed value contains invalid UTF-8
- substitute only the invalid byte with U+FFFD
- pin both custom-feed table cells through the rendered page template

Fixes #1819

## Verification

- RED: `vendor/bin/phpunit tests/php/FeedsCustomOutputEncodingTest.php` — 2 failures; URL and header cells blank
- freeze: `f51bdb2e45617fddae963039ef87d53f365bc133`
- GREEN: same command — 2 tests, 6 assertions
- `scripts/agent/verify-red-proof.sh ...` — `VERDICT: PASS`
- `vendor/bin/phpunit` — 4,778 tests, 26,020 assertions
- `composer phpstan` — pass
- `composer phpcs -- --standard=phpcs.xml.dist src/` — pass
- `php -l` — changed PHP files pass

Existing Tier-A `test_feeds_custom_url_escapes_hostile_input` keeps the changed Custom Feeds render path live-reachable; the focused PHPUnit renderer covers both invalid-byte sinks.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid characters in custom feed URLs and headers.
  * Invalid UTF-8 bytes are now safely replaced instead of being silently removed, while preserving quote escaping.

* **Tests**
  * Added coverage to verify valid UTF-8 output and correct replacement behavior for invalid feed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->