### PR TITLE
Reconcile repo-install smoke and generators with arch-less catalogs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,19 +316,26 @@ The self-hosted repository (installed per the [README](README.md#option-2--this-
 is a **derived index** — there is no stateful store to maintain. It is hosted and
 deployed by the **separate [`pfBlockerNG/pkg`](https://github.com/pfBlockerNG/pkg) repo**
 (its `publish.yml`), which deploys to **its own** GitHub Pages via same-repo OIDC — no
-cross-repo deploy key. On each run it builds the current **devel** `.pkg` (running this
-repo's `scripts/build-pkg-portable.py` against a checkout of the source), folds in the
-`.pkg` assets of **all** GitHub Releases, buckets by ABI, **regenerates** a fresh `pkg`
-catalog (`meta.conf`/`packagesite.pkg`/`data.pkg`) per ABI, and deploys the whole
-`${ABI}/` tree. The site is replaced each run (no history), so every published version/ABI
-is retained for free and a rollback is a re-deploy.
+cross-repo deploy key. On each run it builds the current **devel** `.pkg` per matrix entry
+(running this repo's `scripts/build-pkg-portable.py` against a checkout of the source),
+folds in the `.pkg` assets of **all** GitHub Releases, buckets by `<varver>` (edition +
+pfSense major.minor, e.g. `ce-2.8` / `plus-26.03` — **arch-less**: every pfBlockerNG `.pkg`
+is NO_ARCH, so one directory serves every CPU arch of a FreeBSD major; issue #1806),
+**regenerates** a fresh `pkg` catalog (`meta.conf`/`packagesite.pkg`/`data.pkg`) per
+varver, and deploys the whole `release/<varver>/` (+ `nightly/<varver>/`) tree. The site is
+replaced each run (no history), so every published version is retained for free and a
+rollback is a re-deploy.
 
-- **Per-`${ABI}` tree.** One catalog under `…/<ABI>/` per ABI present in the ci-metadata
-  version matrix (`supported-versions.json`). The client conf's literal `${ABI}` lets one
-  conf follow the box across a pfSense OS upgrade.
+- **Per-`<varver>` tree, arch-less.** One catalog under `release/<varver>/` (and
+  `nightly/<varver>/` for the nightly channel) per edition + pfSense major.minor present in
+  the ci-metadata version matrix (`supported-versions.json`) — no per-ABI/arch subdirectory.
+  The client conf's `url:` is fully resolved for the box's own edition/version at bootstrap
+  time — there is no `${ABI}` pkg(8) variable any more; a boot-time `rc.d` hook
+  (`pfblockerng_repo_generate.sh`, ADR-39) rewrites the conf on a pfSense OS upgrade that
+  moves the box to a different varver.
 - **NONE-signed, TLS-anchored.** No signing key in CI; trust is HTTPS to the Pages host. The
-  catalog is served at the project's GitHub Pages URL
-  **`https://pfblockerng.github.io/pkg/${ABI}`**.
+  catalog is served at the project's GitHub Pages URL, e.g.
+  **`https://pfblockerng.github.io/pkg/release/ce-2.8`**.
 - **Generators.** `scripts/build-repo-portable.py` is the primary — pure Python (stdlib +
   `zstd`), no libpkg, run on a plain Linux runner. `scripts/build-repo.sh` (real `pkg repo`
   in a FreeBSD VM) is the fidelity fallback, and is also the single `--print-conf` source the

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -991,11 +991,14 @@ never wrong. Key properties:
   by the time the box first reaches for a catalog. Running this early is safe precisely because it
   is local-file-only (no network, no daemon).
 - **Folded detection (KISS):** edition = "`/etc/product_label` contains `Plus`" → `plus`, else
-  `ce`; version = major.minor of `/etc/version`. This mirrors `catalog_name_from_version()` in
-  `scripts/build-repo-portable.py`; there is **no** separate `/lib` detection helper (it is folded
-  into the one self-contained hook file). **issue #1806:** the catalog is arch-less, so the hook no
-  longer calls `pkg config abi` at all (it used to read the arch leaf; there is no arch leaf to
-  read any more) — one fewer moving part, and it no longer needs `pkg` on the PATH.
+  `ce`; version = major.minor of `/etc/version`, with any dash suffix (e.g. `-BETA`/`-RC`)
+  stripped FIRST. This deliberately **diverges** from `catalog_name_from_version()` in
+  `scripts/build-repo-portable.py` by that one strip — a live box's `/etc/version` can carry a
+  pre-release suffix the matrix's version never does (issue #1786) — otherwise it is the same
+  edition + major.minor derivation; there is **no** separate `/lib` detection helper (it is
+  folded into the one self-contained hook file). **issue #1806:** the catalog is arch-less, so
+  the hook no longer calls `pkg config abi` at all (it used to read the arch leaf; there is no
+  arch leaf to read any more) — one fewer moving part, and it no longer needs `pkg` on the PATH.
 - **Byte-identical output:** the conf body the hook writes is byte-for-byte identical to
   `add-repo.sh --print-conf`, `build-repo.sh --print-conf`, and `build-repo-portable.py
   --print-conf` (drift-pinned by `tests/test_add_repo_conf.py` across all four producers).

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
-# build-repo-portable.py — turn a directory of pfBlockerNG .pkg files into a
-# per-ABI FreeBSD `pkg` repository tree WITHOUT libpkg, in pure Python (ADR-17):
-# for a plain Linux CI runner with no real `pkg` binary, hand-rolling the same
-# catalog `pkg repo` produces (meta.conf/packagesite.pkg/data.pkg, incl. the
-# libpkg `sum` checksum — see pkg_checksum()) from each .pkg's manifest,
-# deterministically and without network. (scripts/build-repo.sh drives a real
-# `pkg repo` and stays the FreeBSD/pfSense-side fallback; this is the CI/release
-# builder.) FLAVOR-COLLISION GUARD, version-keyed catalogs (ADR-20), the
-# matrix-driven build, and release retention are each documented at their own
-# function; see --help for full CLI usage.
+# build-repo-portable.py — turn a directory of pfBlockerNG .pkg files into an
+# ARCH-LESS FreeBSD `pkg` repository catalog WITHOUT libpkg, in pure Python
+# (ADR-17): for a plain Linux CI runner with no real `pkg` binary, hand-rolling
+# the same catalog `pkg repo` produces (meta.conf/packagesite.pkg/data.pkg,
+# incl. the libpkg `sum` checksum — see pkg_checksum()) from each .pkg's
+# manifest, deterministically and without network. Every pfBlockerNG .pkg is
+# NO_ARCH (issue #1806): its manifest ABI is CPU-wildcarded (e.g.
+# "FreeBSD:15:*"), so the catalog has no per-ABI subdirectory — one directory
+# serves every arch of a FreeBSD major (see _is_wildcard_abi / build_repo).
+# (scripts/build-repo.sh drives a real `pkg repo` and stays the FreeBSD/
+# pfSense-side fallback; this is the CI/release builder.) FLAVOR-COLLISION
+# GUARD, version-keyed catalogs (ADR-20), the matrix-driven build, and release
+# retention are each documented at their own function; see --help for full CLI
+# usage.
 
 from __future__ import annotations
 
@@ -52,12 +56,6 @@ META_CONF = (
 # (ADR-39; the Cloudflare Worker has been retired).
 DEFAULT_BASE_URL = "https://pfblockerng.github.io/pkg"
 CONF_PRIORITY = 100
-
-# A safe single path segment: an ABI is used UNVALIDATED from manifest data as a
-# directory name (out_dir / abi) that is rmtree'd + rebuilt, so reject anything
-# that could escape out_dir. FreeBSD ABIs look like `FreeBSD:15:amd64` (the `:` is
-# allowed); `/`, `\`, whitespace, and traversal are not.
-_ABI_RE = re.compile(r"^[A-Za-z0-9:._+-]+$")
 
 # A NO_ARCH package's manifest ABI wildcards ONLY the final CPU segment — e.g.
 # "FreeBSD:15:*" (probed live against a real Netgate noarch package; issue
@@ -298,53 +296,53 @@ def catalog_name_from_version(pfsense_version: str, variant: str, *, channel: st
 
 
 def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) -> list[str]:
-    """Build the per-ABI catalog tree. Returns the list of ABIs built (sorted).
+    """Build the arch-less (NO_ARCH-only) catalog from a directory of .pkg files.
 
-    When ``catalog_name`` is supplied (e.g. ``"ce-2.8"``), the ABI subtrees are
-    written under ``out_dir / catalog_name / <ABI>/`` instead of ``out_dir / <ABI>/``.
-    When absent, the legacy ``out_dir / <ABI>/`` layout is used (unchanged behaviour).
+    Every pfBlockerNG .pkg is NO_ARCH (issue #1806): its manifest ABI is
+    CPU-wildcarded (e.g. ``"FreeBSD:15:*"``, see ``_is_wildcard_abi``), so the
+    catalog has no per-ABI subdirectory to bucket into — one directory serves
+    every CPU arch of a FreeBSD major (mirrors ``scripts/build-repo.sh``'s
+    ``require_noarch_abi``). A concrete-ABI package is a hard error — the
+    tripwire that would otherwise let it install silently on only one arch.
+    Mixing more than one ABI in a single call is also a hard error: filter
+    ``in_dir`` to one ABI and invoke once per major (mirrors build-repo.sh's
+    "mixed ABIs in one run" guard).
+
+    The catalog is written DIRECTLY at ``out_dir`` (or ``out_dir / catalog_name``
+    when supplied, e.g. ``"ce-2.8"``) — meta.conf, meta, packagesite.pkg, data.pkg,
+    plus each canonically-named ``<name>-<version>.pkg``. Emission (dedup by
+    (name, version), the flavor-collision guard, the catalog descriptor) is
+    delegated to ``_emit_catalog_from_paths``. Returns the single wildcard ABI
+    built, as a one-element sorted list.
     """
     pkgs = sorted(p for p in in_dir.glob("*.pkg") if p.is_file())
     if not pkgs:
         raise BuildRepoError(f"no .pkg files in {in_dir}")
 
-    # Read every manifest ONCE (the ABI/name/version/flavor source of truth).
-    entries: list[tuple[Path, dict]] = [(p, read_compact_manifest(p)) for p in pkgs]
-
-    # Collision guard before laying anything out (fail-closed, never a silent drop).
-    _check_collisions(entries)
-
-    # Bucket by ABI, deduping by (name, version). The same package from multiple
-    # sources (e.g. the branch build + a release artifact) is interchangeable —
-    # `_check_collisions` already rejected a same-name+version+ABI/different-flavor
-    # clash — so keep ONE. The published .pkg is named CANONICALLY
-    # (`<name>-<version>.pkg`), never the staging input filename, so the catalog path
-    # is clean + stable regardless of how the publish job staged the inputs.
-    by_abi: dict[str, dict[tuple[str, str], tuple[Path, dict]]] = {}
-    for path, manifest in entries:
-        abi = manifest["abi"]
-        # Validate before it becomes a filesystem path segment (rmtree target below).
-        if not isinstance(abi, str) or not _ABI_RE.fullmatch(abi) or ".." in abi:
-            raise BuildRepoError(f"{path.name}: unsafe or invalid ABI segment {abi!r}")
-        nv = (manifest["name"], manifest["version"])
-        bucket_nv = by_abi.setdefault(abi, {})
-        if nv in bucket_nv:
-            sys.stderr.write(
-                f"==> dedup: {path.name} duplicates {bucket_nv[nv][0].name} "
-                f"({nv[0]}-{nv[1]}, {abi}) — keeping the first\n"
+    # Validate every input is NO_ARCH and shares one ABI BEFORE emitting anything
+    # (fail-closed; mirrors build-repo.sh's require_noarch_abi + mixed-ABI guard).
+    abis: set[str] = set()
+    for path in pkgs:
+        manifest = read_compact_manifest(path)
+        abi = manifest.get("abi")
+        if not _is_wildcard_abi(abi):
+            raise BuildRepoError(
+                f"{path.name}: catalog requires a NO_ARCH (wildcard-ABI) package — got "
+                f"concrete ABI {abi!r}. The catalog tree is arch-less (one directory serves "
+                f"every arch of a FreeBSD major); a concrete-ABI package would silently "
+                f"install on only one arch. Ship a wildcard-ABI (NO_ARCH) build instead."
             )
-            continue
-        bucket_nv[nv] = (path, manifest)
+        abis.add(abi)
+    if len(abis) > 1:
+        raise BuildRepoError(
+            f"mixed ABIs in one build_repo() call: {sorted(abis)} — filter in_dir to one "
+            f"ABI and invoke once per major (mirrors build-repo.sh's per-run ABI requirement)."
+        )
 
-    # When catalog_name is given, place all ABI subtrees under out_dir/catalog_name/.
     catalog_root = out_dir / catalog_name if catalog_name else out_dir
-    catalog_root.mkdir(parents=True, exist_ok=True)
-    for abi in sorted(by_abi):
-        bucket = catalog_root / abi
-        n = _write_catalog_dir(bucket, by_abi[abi])
-        sys.stderr.write(f"==> built catalog {bucket} ({n} package(s))\n")
-
-    return sorted(by_abi)
+    n = _emit_catalog_from_paths(catalog_root, pkgs)
+    sys.stderr.write(f"==> built catalog {catalog_root} ({n} package(s))\n")
+    return sorted(abis)
 
 
 def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict]]) -> int:
@@ -924,7 +922,7 @@ def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(
         prog="build-repo-portable.py",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="Generate a per-ABI FreeBSD pkg repository catalog in pure Python (no libpkg). ADR-17.",
+        description="Generate an arch-less FreeBSD pkg repository catalog in pure Python (no libpkg). ADR-17.",
         epilog=(
             "examples:\n"
             "  # build a catalog tree from a dir of release .pkg\n"
@@ -940,7 +938,7 @@ def main(argv: list[str]) -> int:
         ),
     )
     ap.add_argument("--in", dest="in_dir", help="directory holding the input .pkg files (searched, non-recursive)")
-    ap.add_argument("--out", dest="out_dir", help="output root; one <ABI>/ catalog subtree is created per ABI")
+    ap.add_argument("--out", dest="out_dir", help="output root; the flat, arch-less catalog is written directly here")
     ap.add_argument("--print-conf", action="store_true", help="print the client repo-conf template to stdout and exit")
     ap.add_argument(
         "--base-url",
@@ -963,9 +961,11 @@ def main(argv: list[str]) -> int:
         dest="catalog_name",
         default=None,
         help=(
-            "when supplied, write the per-ABI tree under <out>/<catalog-name>/<ABI>/ "
-            "instead of the legacy <out>/<ABI>/ path (e.g. 'ce-2.8', 'plus-26.03'). "
-            "Derive from pfsense_version + variant via catalog_name_from_version()."
+            "when supplied, write the flat catalog under <out>/<catalog-name>/ "
+            "instead of directly at <out>/ (e.g. 'ce-2.8', 'plus-26.03'); the "
+            "catalog is arch-less (NO_ARCH; issue #1806), so there is no <ABI>/ "
+            "subdir either way. Derive from pfsense_version + variant via "
+            "catalog_name_from_version()."
         ),
     )
     g_matrix = ap.add_argument_group("matrix-driven build (ADR-20 routing rework)")
@@ -1172,7 +1172,7 @@ def main(argv: list[str]) -> int:
     except (BuildRepoError, PkgError) as e:
         sys.stderr.write(f"build-repo-portable: {e}\n")
         return 1
-    sys.stderr.write(f"==> built catalogs for ABI: {' '.join(abis)}\n")
+    sys.stderr.write(f"==> built catalog for ABI: {' '.join(abis)}\n")
     return 0
 
 

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -29,6 +29,7 @@ import tarfile
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
+from typing import TypeGuard
 
 from pfb_pkg import PkgError, pkg_version_sort_key, read_compact_manifest, zstd_compress
 
@@ -64,13 +65,31 @@ CONF_PRIORITY = 100
 _ABI_WILDCARD_RE = re.compile(r"^[A-Za-z0-9._+-]+:[A-Za-z0-9._+-]+:\*$")
 
 
-def _is_wildcard_abi(abi: object) -> bool:
+def _is_wildcard_abi(abi: object) -> TypeGuard[str]:
     """True if ``abi`` is a NO_ARCH package's tight, CPU-wildcarded ABI string."""
     return isinstance(abi, str) and bool(_ABI_WILDCARD_RE.fullmatch(abi))
 
 
 class BuildRepoError(Exception):
     """A fatal, user-facing error (bad input / collision / missing tool)."""
+
+
+def _require_wildcard_abi(path: Path, abi: object) -> str:
+    """Validate ``abi`` is a NO_ARCH package's wildcard ABI, or raise ``BuildRepoError``.
+
+    Shared by ``build_repo()`` and ``_emit_catalog_from_paths()`` so the reject wording
+    (and the NO_ARCH policy behind it) has exactly one canonical source instead of two
+    verbatim-duplicated copies. Returns the validated ABI as ``str`` (narrowed via
+    ``_is_wildcard_abi``'s ``TypeGuard``) so callers need no further cast.
+    """
+    if not _is_wildcard_abi(abi):
+        raise BuildRepoError(
+            f"{path.name}: catalog requires a NO_ARCH (wildcard-ABI) package — got "
+            f"concrete ABI {abi!r}. The catalog tree is arch-less (one directory serves "
+            f"every arch of a FreeBSD major); a concrete-ABI package would silently "
+            f"install on only one arch. Ship a wildcard-ABI (NO_ARCH) build instead."
+        )
+    return abi
 
 
 # --------------------------------------------------------------------------- #
@@ -294,6 +313,26 @@ def catalog_name_from_version(pfsense_version: str, variant: str, *, channel: st
 # Orchestration
 # --------------------------------------------------------------------------- #
 
+# A catalog_name segment is a rm-rf'd + rebuilt path component (_write_catalog_dir
+# shutil.rmtree()s it) — same safety rule as build-repo.sh's --varver guard, tightened
+# to lowercase-only. '/' is allowed only BETWEEN segments (a legitimate catalog_name
+# carries a channel prefix, e.g. "nightly/plus-26.03").
+_CATALOG_NAME_SEGMENT_RE = re.compile(r"[a-z0-9.-]+")
+
+
+def _validate_catalog_name(name: str) -> None:
+    """Reject an unsafe ``catalog_name`` before it becomes ``out_dir / catalog_name``
+    (issue #1786): a ``".."`` segment escapes sideways/upward, and an ABSOLUTE value
+    makes ``Path.__truediv__`` discard ``out_dir`` entirely — either lets a caller
+    point ``_write_catalog_dir``'s ``shutil.rmtree()`` at an arbitrary directory.
+    """
+    segments = name.split("/")
+    if any(not seg or seg in (".", "..") or not _CATALOG_NAME_SEGMENT_RE.fullmatch(seg) for seg in segments):
+        raise BuildRepoError(
+            f"unsafe catalog_name {name!r}: each '/'-separated segment must be non-empty, "
+            f"not '.'/'..', and match [a-z0-9.-]+ (e.g. 'ce-2.8', 'release/ce-2.8')"
+        )
+
 
 def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) -> list[str]:
     """Build the arch-less (NO_ARCH-only) catalog from a directory of .pkg files.
@@ -310,11 +349,16 @@ def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) 
 
     The catalog is written DIRECTLY at ``out_dir`` (or ``out_dir / catalog_name``
     when supplied, e.g. ``"ce-2.8"``) — meta.conf, meta, packagesite.pkg, data.pkg,
-    plus each canonically-named ``<name>-<version>.pkg``. Emission (dedup by
+    plus each canonically-named ``<name>-<version>.pkg``. ``catalog_name`` is
+    validated (``_validate_catalog_name``, issue #1786) before anything is read or
+    written — it becomes a ``shutil.rmtree()``d path segment. Emission (dedup by
     (name, version), the flavor-collision guard, the catalog descriptor) is
     delegated to ``_emit_catalog_from_paths``. Returns the single wildcard ABI
     built, as a one-element sorted list.
     """
+    if catalog_name:
+        _validate_catalog_name(catalog_name)
+
     pkgs = sorted(p for p in in_dir.glob("*.pkg") if p.is_file())
     if not pkgs:
         raise BuildRepoError(f"no .pkg files in {in_dir}")
@@ -324,15 +368,7 @@ def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) 
     abis: set[str] = set()
     for path in pkgs:
         manifest = read_compact_manifest(path)
-        abi = manifest.get("abi")
-        if not _is_wildcard_abi(abi):
-            raise BuildRepoError(
-                f"{path.name}: catalog requires a NO_ARCH (wildcard-ABI) package — got "
-                f"concrete ABI {abi!r}. The catalog tree is arch-less (one directory serves "
-                f"every arch of a FreeBSD major); a concrete-ABI package would silently "
-                f"install on only one arch. Ship a wildcard-ABI (NO_ARCH) build instead."
-            )
-        abis.add(abi)
+        abis.add(_require_wildcard_abi(path, manifest.get("abi")))
     if len(abis) > 1:
         raise BuildRepoError(
             f"mixed ABIs in one build_repo() call: {sorted(abis)} — filter in_dir to one "
@@ -441,14 +477,7 @@ def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path]) -> int:
     entries: list[tuple[Path, dict]] = [(p, read_compact_manifest(p)) for p in sorted(set(pkg_paths))]
     _check_collisions(entries)
     for path, manifest in entries:
-        abi = manifest.get("abi")
-        if not _is_wildcard_abi(abi):
-            raise BuildRepoError(
-                f"{path.name}: catalog requires a NO_ARCH (wildcard-ABI) package — got "
-                f"concrete ABI {abi!r}. The catalog tree is arch-less (one directory serves "
-                f"every arch of a FreeBSD major); a concrete-ABI package would silently "
-                f"install on only one arch. Ship a wildcard-ABI (NO_ARCH) build instead."
-            )
+        _require_wildcard_abi(path, manifest.get("abi"))
     items: dict[tuple[str, str], tuple[Path, dict]] = {}
     for path, manifest in entries:
         nv = (manifest["name"], manifest["version"])

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -22,11 +22,14 @@
 # HARD RULE: every path ends in `exit 0`. This hook MUST NEVER wedge boot.
 #
 # Detection (KISS): edition = "/etc/product_label contains 'Plus'" -> plus, else
-# ce; version = major.minor of /etc/version. This mirrors
-# catalog_name_from_version() in scripts/build-repo-portable.py. Arch-less
-# since issue #1806 (NO_ARCH) — the catalog no longer has a per-arch leaf, so
-# this hook no longer calls `pkg` at all (it used to read `pkg config abi`
-# only to derive that leaf).
+# ce; version = major.minor of /etc/version, with any dash suffix (e.g.
+# "-BETA"/"-RC") stripped FIRST. This deliberately DIVERGES from
+# catalog_name_from_version() in scripts/build-repo-portable.py by that one
+# strip: a live box's /etc/version can carry a pre-release suffix the matrix's
+# version never does (issue #1786) — otherwise it is the same edition +
+# major.minor derivation. Arch-less since issue #1806 (NO_ARCH) — the catalog
+# no longer has a per-arch leaf, so this hook no longer calls `pkg` at all (it
+# used to read `pkg config abi` only to derive that leaf).
 #
 # The emitted conf body is BYTE-IDENTICAL to `add-repo.sh --print-conf`,
 # `build-repo.sh --print-conf`, and `build-repo-portable.py --print-conf`

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -68,10 +68,13 @@ _detect_catalog() {
     else
         _dc_edition='ce'
     fi
-    # Version: major.minor of /etc/version (e.g. "2.8.1" -> "2.8").
+    # Version: major.minor of /etc/version, pre-release suffix stripped first
+    # (e.g. "2.8.1" -> "2.8"; "26.07-BETA" -> "26.07"; issue #1786: a dash
+    # suffix sitting inside the minor field, e.g. "-BETA"/"-RC"/"-RELEASE",
+    # must not leak into the catalog varver — cut on '-' before cut on '.').
     _dc_ver=''
     [ -r "${PFB_VERSION_FILE}" ] && IFS= read -r _dc_ver < "${PFB_VERSION_FILE}"
-    _dc_mm="$(printf '%s' "${_dc_ver}" | cut -d. -f1,2)"
+    _dc_mm="$(printf '%s' "${_dc_ver}" | cut -d- -f1 | cut -d. -f1,2)"
     [ -n "${_dc_mm}" ] || return 1
     printf '%s-%s' "${_dc_edition}" "${_dc_mm}"
 }

--- a/tests/shell/generate_hook_spec.sh
+++ b/tests/shell/generate_hook_spec.sh
@@ -176,6 +176,55 @@ Describe 'generate hook — regenerate nightly conf (Plus)'
     End
 End
 
+# ── PRE-RELEASE SUFFIX STRIP: a dash-suffixed /etc/version must not leak into
+#    the varver (issue #1786) ────────────────────────────────────────────────
+
+Describe 'generate hook — pre-release suffix strip (Plus BETA)'
+    setup() {
+        _pb_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_plusbeta.XXXXXX")"
+        _make_box "${_pb_dir}" "pfSense Plus" "26.07-BETA"
+        printf '# stub pending\n' > "${PFB_RELEASE_CONF}"
+    }
+    cleanup() { rm -rf "${_pb_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: release conf is the unresolved stub'
+      The contents of file "${PFB_RELEASE_CONF}" should include "pending"
+    End
+
+    It 'strips the -BETA suffix before major.minor, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_RELEASE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/release/plus-26.07"'
+      The contents of file "${PFB_RELEASE_CONF}" should not include "plus-26.07-BETA"
+    End
+End
+
+Describe 'generate hook — pre-release suffix strip (CE RC)'
+    setup() {
+        _cr_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_cerc.XXXXXX")"
+        _make_box "${_cr_dir}" "pfSense" "2.9-RC"
+        printf '# stub pending\n' > "${PFB_RELEASE_CONF}"
+    }
+    cleanup() { rm -rf "${_cr_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: release conf is the unresolved stub'
+      The contents of file "${PFB_RELEASE_CONF}" should include "pending"
+    End
+
+    It 'strips the -RC suffix before major.minor, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_RELEASE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/release/ce-2.9"'
+      The contents of file "${PFB_RELEASE_CONF}" should not include "ce-2.9-RC"
+    End
+End
+
 # ── UNCONDITIONAL: a STALE-varver conf is rewritten to the current varver ──────
 
 Describe 'generate hook — unconditional rewrite of a stale-varver conf'

--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -42,9 +42,9 @@ from pathlib import Path
 import pytest
 
 from . import helpers as h
-from ._matrix import own_variant
 from .conftest import SmokeVM
 from .test_repo_install import (
+    _box_real_varver,
     _ensure_egress_open,
     _ssh_check,
     build_guest_repo,
@@ -373,8 +373,12 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
 
     # BACKSTOP: prove the deploy actually serves the nightly catalog from the runner
     # first (independent of the guest) — polls through first-deploy / DNS / cert lag.
-    # This base already ends in /nightly, so the full subtree is the bare varver.
-    varver = own_variant().catalog
+    # The varver to poll is read from the BOX itself via the _box_real_varver oracle —
+    # NEVER own_variant().catalog / the matrix: matrix_variants() dedupes by (abi,
+    # variant), so two same-major editions collapse onto the first, which would
+    # poll/serve the wrong catalog for this leg. This base already ends in /nightly,
+    # so the full subtree is the bare varver.
+    varver = _box_real_varver(smoke_vm)
     poll_catalog_served(base_url, varver)
 
     _ensure_egress_open()

--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -42,7 +42,7 @@ from pathlib import Path
 import pytest
 
 from . import helpers as h
-from ._matrix import matrix_abi
+from ._matrix import own_variant
 from .conftest import SmokeVM
 from .test_repo_install import (
     _ensure_egress_open,
@@ -351,10 +351,10 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
     nightly publish dispatch has deployed the catalog.
 
     Given the nightly publish pipeline has DEPLOYED the catalog to Pages (runner-side
-      backstop: ``<base>/<ABI>/meta.conf`` + ``packagesite.pkg`` serve 200), the guest
-      has the Pages IPs pinned for the host (its DNS is sandboxed), the package is
-      ABSENT, and our nightly conf points at the live ``nightly/${ABI}`` URL above the
-      Netgate ``pfSense`` repo,
+      backstop: ``<base>/<varver>/meta.conf`` + ``packagesite.pkg`` serve 200), the
+      guest has the Pages IPs pinned for the host (its DNS is sandboxed), the package
+      is ABSENT, and our nightly conf points at the live ``nightly/<varver>`` URL
+      above the Netgate ``pfSense`` repo,
     When ``pkg update`` reads the live nightly catalog and ``pkg install -y`` runs
       (NO ``-r``, NO ``-f``),
     Then the install comes from our nightly repo (``pkg query %R`` ==
@@ -373,7 +373,9 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
 
     # BACKSTOP: prove the deploy actually serves the nightly catalog from the runner
     # first (independent of the guest) — polls through first-deploy / DNS / cert lag.
-    poll_catalog_served(base_url, matrix_abi())
+    # This base already ends in /nightly, so the full subtree is the bare varver.
+    varver = own_variant().catalog
+    poll_catalog_served(base_url, varver)
 
     _ensure_egress_open()
 
@@ -393,10 +395,11 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
         pkg_delete(smoke_vm, NIGHTLY_NAME)
 
         # Write the production nightly conf: pfblockerng-nightly, HTTPS live URL, NONE-signed.
-        # ${ABI} is a pkg(8) variable — must survive in the file as-is (not shell-expanded).
+        # The URL is fully resolved (arch-less, NO_ARCH — issue #1806): no ${ABI} pkg(8)
+        # variable any more, just the box's own varver under the nightly base.
         conf = (
             f"{NIGHTLY_REPO}: {{\n"
-            f'  url: "{base_url}/${{ABI}}",\n'
+            f'  url: "{base_url}/{varver}",\n'
             "  mirror_type: none,\n"
             "  signature_type: none,\n"
             f"  priority: {pfsense_prio + 100},\n"

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1384,10 +1384,12 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
 
     # BACKSTOP: prove the deploy actually serves the catalog from the RUNNER first
     # (independent of the guest) — polls through first-deploy / DNS / cert lag. The
-    # varver to poll is this leg's own, derived from the matrix (own_variant().catalog
-    # — the published catalogs are keyed from the matrix; needs no VM round-trip). This
+    # varver to poll is read from the BOX itself via the _box_real_varver oracle —
+    # NEVER own_variant().catalog / the matrix: matrix_variants() dedupes by (abi,
+    # variant), so two same-major editions (e.g. Plus 26.03 + 26.07) collapse onto
+    # the first, which would poll/serve the wrong catalog for this leg. This
     # release check's base is the pkg root, so the full subtree is "release/<varver>".
-    varver = own_variant().catalog
+    varver = _box_real_varver(repo_vm)
     poll_catalog_served(base_url, f"release/{varver}")
 
     # GIVEN: Pages IPs pinned (guest DNS is sandboxed), package absent, our conf at

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -89,7 +89,6 @@ import pytest
 
 from . import helpers as h
 from ._matrix import (
-    matrix_abi,
     matrix_py_flavor,
     opposite_variant,
     own_variant,
@@ -118,8 +117,9 @@ GUEST_FILE_LIST = f"{GUEST_SPIKE_DIR}/installed_files.txt"
 
 # Phase-2 (ADR-17) catalog generator under test. ``build-repo.sh`` is the real,
 # reusable catalog fallback tool; here it is staged to the guest and run with the
-# guest's libpkg to prove the SCRIPT's output (the release/<varver>/<arch>/ tree
-# it lays out, ADR-20) is accepted by a real pfSense ``pkg update`` + install.
+# guest's libpkg to prove the SCRIPT's output (the release/<varver>/ tree it
+# lays out, arch-less NO_ARCH — issue #1806) is accepted by a real pfSense
+# ``pkg update`` + install.
 # (The libpkg-on-Linux half of the build-side premise — that the SAME script +
 # the SAME ``pkg repo`` op runs on a Linux runner — is proven locally in
 # RESULTS/02; the script is identical regardless of which libpkg invokes it.)
@@ -132,11 +132,13 @@ SCRIPT_REPO_ROOT = f"{GUEST_SPIKE_DIR}/script_catalog"  # build-repo.sh --out (v
 # (which needs a libpkg ``pkg`` binary), ``build-repo-portable.py`` builds the
 # catalog WITHOUT libpkg — the way the Phase-3b publish job will, on a plain Linux
 # runner with no ``pkg``. Here it is run ON THE RUNNER (this test process's python,
-# no guest involvement) over the branch ``.pkg``; only the produced ``<ABI>/`` tree
-# is shipped to the guest, proving a real pfSense ``pkg update``/``install`` accepts
+# no guest involvement) over the branch ``.pkg``; a plain run (no ``--catalog-name``)
+# emits the catalog directly at ``--out`` (arch-less, NO_ARCH — issue #1806; a
+# wildcard ABI is required, a concrete ABI is a hard error), and only those files
+# are shipped to the guest, proving a real pfSense ``pkg update``/``install`` accepts
 # the pure-Python catalog. This is the load-bearing fidelity gate for the generator.
 BUILD_REPO_PORTABLE = Path(__file__).resolve().parents[2] / "scripts" / "build-repo-portable.py"
-PORTABLE_REPO_ROOT = f"{GUEST_SPIKE_DIR}/portable_catalog"  # where the portable <ABI>/ tree is shipped
+PORTABLE_REPO_ROOT = f"{GUEST_SPIKE_DIR}/portable_catalog"  # where the flat portable catalog is shipped
 
 # Phase-4 (ADR-17) SHIPPED client bootstrap under test. ``add-repo.sh`` is the real
 # user-facing script: it writes the production repo conf, runs ``pkg update``, and
@@ -318,17 +320,17 @@ def build_repo_via_script(vm: SmokeVM, pkg_files: list[Path]) -> str:
     Stages the real ``build-repo.sh`` and the input ``.pkg`` to the guest, runs
     ``build-repo.sh --in <pkg_in> --out <script_catalog> --varver <varver>`` with
     the guest's own libpkg, then returns the catalog directory it produced. The
-    script lays the release channel under ``<out>/release/<varver>/<arch>/``
-    (ADR-20 varver keying, issue #1081 — matching ``build-repo-portable.py`` and
+    script lays the release channel directly under ``<out>/release/<varver>/``
+    (arch-less, NO_ARCH — issue #1806; matching ``build-repo-portable.py`` and
     the printed conf), so ``<out>`` is the base a ``file://`` repo conf points at
-    and the conf's ``release/<varver>/<arch>`` url resolves to the returned dir.
-    The varver/arch come from the box itself via the ``_box_real_catalog`` oracle.
+    and the conf's ``release/<varver>`` url resolves to the returned dir. The
+    varver comes from the box itself via the ``_box_real_varver`` oracle.
 
-    This validates the SCRIPT's output (the ``release/<varver>/<arch>/`` tree +
-    the catalog triple ``pkg repo`` emits) is accepted by a real pfSense box, the
+    This validates the SCRIPT's output (the ``release/<varver>/`` tree + the
+    catalog triple ``pkg repo`` emits) is accepted by a real pfSense box, the
     live half of the build-side premise.
     """
-    real_varver, real_arch = _box_real_catalog(vm).rsplit("/", 1)
+    real_varver = _box_real_varver(vm)
     _ssh_check(vm, "/bin/rm", "-rf", GUEST_PKG_IN_DIR, SCRIPT_REPO_ROOT)
     _ssh_check(vm, "/bin/mkdir", "-p", GUEST_PKG_IN_DIR, GUEST_SPIKE_DIR)
     _scp_to_guest(vm, BUILD_REPO_SH, GUEST_BUILD_REPO_SH)
@@ -350,9 +352,11 @@ def build_repo_via_script(vm: SmokeVM, pkg_files: list[Path]) -> str:
         real_varver,
         timeout=240.0,
     )
-    catalog_dir = f"{SCRIPT_REPO_ROOT}/release/{real_varver}/{real_arch}"
-    # The catalog triple must be present (what `pkg update` consumes).
-    for fname in ("meta.conf", "packagesite.pkg", "data.pkg"):
+    catalog_dir = f"{SCRIPT_REPO_ROOT}/release/{real_varver}"
+    # The catalog quadruple must be present (what `pkg update` consumes) — real `pkg
+    # repo` emits the bare `meta` alongside `meta.conf` (ADR-17 RESULTS/02), matching
+    # the portable generator's own byte-parity claim.
+    for fname in ("meta.conf", "meta", "packagesite.pkg", "data.pkg"):
         present = vm.ssh("/bin/test", "-f", f"{catalog_dir}/{fname}")
         assert present.returncode == 0, f"build-repo.sh did not emit {fname} under {catalog_dir}"
     return catalog_dir
@@ -365,18 +369,13 @@ def build_repo_via_portable(vm: SmokeVM, pkg_files: list[Path], tmp_path: Path) 
     (no libpkg, no guest involvement) exactly as the Phase-3b publish job will, then its
     catalog files are copied to the guest. A real pfSense ``pkg update``/``install`` then
     has to accept it — the fidelity gate that the pure-Python catalog is byte-compatible
-    with what real ``pkg repo`` emits. The generator is driven with ``--catalog-name
-    release`` so it produces ``out/release/<ABI>/`` locally.
+    with what real ``pkg repo`` emits. A PLAIN run (no ``--catalog-name``) emits the
+    catalog DIRECTLY at ``--out`` (arch-less, NO_ARCH — issue #1806; every
+    pfSense-pkg-pfBlockerNG ``.pkg`` carries a wildcard ABI, and the generator hard-rejects
+    a concrete one), so there is no per-ABI bucket to discover any more.
 
-    The catalog files are then staged to a FLAT on-guest path, ``PORTABLE_REPO_ROOT/<ABI>/``
-    — the ``release/`` segment is intentionally dropped. That flat ``<ABI>/`` layout is
-    also the legacy "no variant prefix" path that ``test_legacy_abi_path_still_upgrades``
-    (ADR-20 Case 3) reuses this helper to produce, so it must stay flat. The literal
-    ``/release`` end-to-end symmetry is exercised by ``build_repo_via_portable_named``,
-    not here.
-
-    Returns the on-guest flat ``<ABI>/`` directory (the branch ``.pkg`` is one ABI,
-    ``FreeBSD:15:amd64``) that the ``file://`` repo conf points at.
+    The catalog files are then shipped FLAT to ``PORTABLE_REPO_ROOT`` itself. Returns
+    ``PORTABLE_REPO_ROOT`` — the on-guest directory the ``file://`` repo conf points at.
     """
     in_dir = tmp_path / "portable_in"
     out_dir = tmp_path / "portable_out"
@@ -386,7 +385,7 @@ def build_repo_via_portable(vm: SmokeVM, pkg_files: list[Path], tmp_path: Path) 
         (in_dir / pkg.name).write_bytes(pkg.read_bytes())
 
     # Run the pure-Python generator with THIS process's interpreter — no `pkg`/libpkg.
-    # --catalog-name release nests the channel under out/release/<ABI>/ (literal /release).
+    # No --catalog-name: a plain run emits the catalog directly at --out (arch-less).
     proc = subprocess.run(
         [
             sys.executable,
@@ -395,8 +394,6 @@ def build_repo_via_portable(vm: SmokeVM, pkg_files: list[Path], tmp_path: Path) 
             str(in_dir),
             "--out",
             str(out_dir),
-            "--catalog-name",
-            "release",
         ],
         capture_output=True,
         text=True,
@@ -408,26 +405,17 @@ def build_repo_via_portable(vm: SmokeVM, pkg_files: list[Path], tmp_path: Path) 
             f"build-repo-portable.py failed on the runner: rc={proc.returncode}\n"
             f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
         )
-    release_root = out_dir / "release"
-    abi_buckets = sorted(p for p in release_root.iterdir() if p.is_dir()) if release_root.is_dir() else []
-    assert len(abi_buckets) == 1, f"portable generator produced {[p.name for p in abi_buckets]} ABI buckets, expected 1"
-    local_abi_dir = abi_buckets[0]
-    # The catalog triple must be present locally before shipping.
+    # The catalog triple must be present locally, directly at out_dir, before shipping.
     for fname in ("meta.conf", "meta", "packagesite.pkg", "data.pkg"):
-        assert (local_abi_dir / fname).is_file(), f"portable generator did not emit {fname} under {local_abi_dir}"
+        assert (out_dir / fname).is_file(), f"portable generator did not emit {fname} under {out_dir}"
 
-    # Ship the catalog files to a FLAT on-guest <ABI>/ path (fresh dir per run). The
-    # release/ segment is intentionally dropped so this doubles as the legacy "no variant
-    # prefix" ${ABI}/ layout that test_legacy_abi_path_still_upgrades (ADR-20 Case 3)
-    # reuses this helper to produce; the /release symmetry is covered by
-    # build_repo_via_portable_named.
-    guest_abi_dir = f"{PORTABLE_REPO_ROOT}/{local_abi_dir.name}"
+    # Ship the catalog files FLAT to PORTABLE_REPO_ROOT itself (fresh dir per run).
     _ssh_check(vm, "/bin/rm", "-rf", PORTABLE_REPO_ROOT)
-    _ssh_check(vm, "/bin/mkdir", "-p", guest_abi_dir)
-    for f in sorted(local_abi_dir.iterdir()):
+    _ssh_check(vm, "/bin/mkdir", "-p", PORTABLE_REPO_ROOT)
+    for f in sorted(out_dir.iterdir()):
         if f.is_file():
-            _scp_to_guest(vm, f, f"{guest_abi_dir}/{f.name}")
-    return guest_abi_dir
+            _scp_to_guest(vm, f, f"{PORTABLE_REPO_ROOT}/{f.name}")
+    return PORTABLE_REPO_ROOT
 
 
 def run_add_repo_sh(vm: SmokeVM, base_url: str, *, timeout: float = 300.0) -> subprocess.CompletedProcess[str]:
@@ -440,8 +428,8 @@ def run_add_repo_sh(vm: SmokeVM, base_url: str, *, timeout: float = 300.0) -> su
     update``, and VERIFIES the package is visible from OUR repo. A non-zero exit (its
     verify step failing) raises with the captured output. ``base_url`` points at the
     catalog ROOT; add-repo.sh installs+runs the generator hook, which resolves the
-    box's ``<channel>/<varver>/<arch>`` subtree, so the catalog MUST live under
-    ``<base_url>/<channel>/<varver>/<arch>/``.
+    box's ``<channel>/<varver>`` subtree (arch-less, NO_ARCH — issue #1806), so the
+    catalog MUST live under ``<base_url>/<channel>/<varver>/``.
     """
     _ssh_check(vm, "/bin/mkdir", "-p", GUEST_SPIKE_DIR, GUEST_ADD_REPO_RCD_DIR)
     _scp_to_guest(vm, ADD_REPO_SH, GUEST_ADD_REPO_SH)
@@ -1024,8 +1012,8 @@ def test_build_repo_script_catalog_is_accepted(repo_vm: SmokeVM) -> None:
     ``pkg repo`` op are identical regardless of which libpkg runs them).
 
     Given the package ABSENT and a catalog produced by ``build-repo.sh`` over the
-      branch ``.pkg`` (its ``release/<varver>/<arch>/`` bucket holds
-      meta.conf/packagesite.pkg/data.pkg),
+      branch ``.pkg`` (its ``release/<varver>/`` bucket holds
+      meta.conf/packagesite.pkg/data.pkg — arch-less, NO_ARCH, issue #1806),
       enabled via a NONE-signed ``file://`` repo above the pfSense repo,
     When ``pkg update`` reads it and ``pkg install -y`` runs (NO ``-r``, NO ``-f``),
     Then ``pkg update`` accepts the script-generated catalog AND the install comes
@@ -1036,11 +1024,11 @@ def test_build_repo_script_catalog_is_accepted(repo_vm: SmokeVM) -> None:
     assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
 
     # GIVEN: build the catalog with the Phase-2 SCRIPT (not the inline pkg repo), then
-    # point a NONE-signed file:// repo at the produced <ABI>/ dir, above pfSense.
-    abi_dir = build_repo_via_script(repo_vm, [Path(pkg), *_smoke_dep_pkg_paths()])
+    # point a NONE-signed file:// repo at the produced release/<varver>/ dir, above pfSense.
+    catalog_dir = build_repo_via_script(repo_vm, [Path(pkg), *_smoke_dep_pkg_paths()])
     pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
     pkg_delete(repo_vm)
-    write_repo_conf(repo_vm, abi_dir, ours_priority=pfsense_prio + 100)
+    write_repo_conf(repo_vm, catalog_dir, ours_priority=pfsense_prio + 100)
 
     # WHEN: pkg update must ACCEPT the script-generated catalog (rc=0; a rejected
     # catalog would fail here — that is the build-side premise under test).
@@ -1065,13 +1053,13 @@ def test_shipped_add_repo_sh_bootstrap_installs(repo_vm: SmokeVM, tmp_path: Path
     add-repo.sh is run hermetically against a LOCAL ``file://`` catalog via its own
     ``--base-url`` override; the github.io default + a live HTTPS add-repo.sh run are
     the post-deploy/Phase-6 note. The hook resolves the conf to the PRODUCTION layout
-    ``release/<varver>/<arch>`` (ADR-39 — the bare arch leaf, not the full ABI), so the
-    catalog must be laid out the same way for ``--base-url file://<root>`` to resolve;
-    we build it at ``<root>/release/<varver>/<arch>/`` with the pure-Python generator
-    (the production ``build_repo_matrix`` layout). The script ships priority 100, above
-    the Netgate ``pfSense`` repo (0), so cross-repo install picks ours.
+    ``release/<varver>`` (ADR-39, arch-less — issue #1806), so the catalog must be
+    laid out the same way for ``--base-url file://<root>`` to resolve; we build it at
+    ``<root>/release/<varver>/`` with the pure-Python generator (the production
+    ``build_repo_matrix`` layout). The script ships priority 100, above the Netgate
+    ``pfSense`` repo (0), so cross-repo install picks ours.
 
-    Given the package ABSENT and a catalog under ``<root>/release/<varver>/<arch>/``,
+    Given the package ABSENT and a catalog under ``<root>/release/<varver>/``,
     When ``add-repo.sh --base-url file://<root>`` runs (default release repo: installs +
       runs the hook, ``pkg update``, verifies) and then ``pkg install -y`` runs (NO -r, NO -f),
     Then add-repo.sh exits 0 (its own verify found the package in our repo), it wrote
@@ -1081,19 +1069,18 @@ def test_shipped_add_repo_sh_bootstrap_installs(repo_vm: SmokeVM, tmp_path: Path
     pkg = os.environ.get("SMOKE_PKG")
     assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
 
-    # GIVEN: a catalog at <SCRIPT_REPO_ROOT>/release/<varver>/<arch>/ matching the box's
-    # variant — the exact path add-repo.sh's hook resolves the conf to (ADR-39). The
-    # bare-arch leaf (not the full ABI) mirrors the production build_repo_matrix layout.
-    real_varver, real_arch = _box_real_catalog(repo_vm).rsplit("/", 1)
-    abi_dir = build_repo_via_portable_named(
+    # GIVEN: a catalog at <SCRIPT_REPO_ROOT>/release/<varver>/ matching the box's
+    # variant — the exact path add-repo.sh's hook resolves the conf to (ADR-39,
+    # arch-less — issue #1806).
+    real_varver = _box_real_varver(repo_vm)
+    catalog_dir = build_repo_via_portable_named(
         repo_vm,
         [Path(pkg), *_smoke_dep_pkg_paths()],
         tmp_path,
         catalog_name=f"release/{real_varver}",
         guest_root=SCRIPT_REPO_ROOT,
-        arch_leaf=real_arch,
     )
-    assert abi_dir == f"{SCRIPT_REPO_ROOT}/release/{real_varver}/{real_arch}", f"unexpected catalog dir {abi_dir!r}"
+    assert catalog_dir == f"{SCRIPT_REPO_ROOT}/release/{real_varver}", f"unexpected catalog dir {catalog_dir!r}"
     pkg_delete(repo_vm)
 
     # WHEN: run the SHIPPED bootstrap against the local catalog root. Its verify step
@@ -1129,9 +1116,9 @@ def test_portable_catalog_is_accepted(repo_vm: SmokeVM, tmp_path: Path) -> None:
     ``data.pkg`` AND its blake2b/z-base-32 ``sum`` (the .pkg integrity check passes).
 
     Given the package ABSENT and a catalog produced by ``build-repo-portable.py`` over
-      the branch ``.pkg`` — generated ENTIRELY on the runner in pure Python, then its
-      ``<ABI>/`` tree shipped to the guest — enabled via a NONE-signed ``file://`` repo
-      above the pfSense repo,
+      the branch ``.pkg`` — generated ENTIRELY on the runner in pure Python, then
+      shipped FLAT to the guest (arch-less, NO_ARCH — issue #1806) — enabled via a
+      NONE-signed ``file://`` repo above the pfSense repo,
     When ``pkg update`` reads the pure-Python catalog and ``pkg install -y`` runs
       (NO ``-r``, NO ``-f``),
     Then ``pkg update`` accepts it AND the install comes from OUR repo
@@ -1142,11 +1129,11 @@ def test_portable_catalog_is_accepted(repo_vm: SmokeVM, tmp_path: Path) -> None:
     assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
 
     # GIVEN: build the catalog with the PURE-PYTHON generator on the runner (no libpkg),
-    # ship its <ABI>/ tree to the guest, point a NONE-signed file:// repo above pfSense.
-    abi_dir = build_repo_via_portable(repo_vm, [Path(pkg), *_smoke_dep_pkg_paths()], tmp_path)
+    # ship it flat to the guest, point a NONE-signed file:// repo above pfSense.
+    catalog_dir = build_repo_via_portable(repo_vm, [Path(pkg), *_smoke_dep_pkg_paths()], tmp_path)
     pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
     pkg_delete(repo_vm)
-    write_repo_conf(repo_vm, abi_dir, ours_priority=pfsense_prio + 100)
+    write_repo_conf(repo_vm, catalog_dir, ours_priority=pfsense_prio + 100)
 
     # WHEN: pkg update must ACCEPT the pure-Python catalog (rc=0; a rejected catalog —
     # bad meta.conf, malformed packagesite, or a mismatched sum — would fail here).
@@ -1196,11 +1183,11 @@ def test_portable_catalog_dedups_duplicate_sources(repo_vm: SmokeVM, tmp_path: P
     # assertion below counts EXACTLY one package .pkg in the bucket (the dedup
     # proof); a dep .pkg would be a second, distinct-named entry and break that
     # count. It has no "Missing dependency" assertion (not this test's concern).
-    abi_dir = build_repo_via_portable(repo_vm, [a, b], tmp_path)
+    catalog_dir = build_repo_via_portable(repo_vm, [a, b], tmp_path)
 
     # THEN (catalog shape): exactly ONE package .pkg, canonically named (no prefix) — the
     # catalog files (packagesite.pkg/data.pkg) also end in .pkg, so exclude them.
-    listing = _ssh_check(repo_vm, "/bin/ls", "-1", abi_dir).stdout.split()
+    listing = _ssh_check(repo_vm, "/bin/ls", "-1", catalog_dir).stdout.split()
     catalog_files = {"packagesite.pkg", "data.pkg", "meta.pkg"}
     pkgs = [n for n in listing if n.endswith(".pkg") and n not in catalog_files]
     assert len(pkgs) == 1, f"expected ONE deduped package .pkg in the bucket, got {pkgs}"
@@ -1211,7 +1198,7 @@ def test_portable_catalog_dedups_duplicate_sources(repo_vm: SmokeVM, tmp_path: P
     # WHEN/THEN (install): a real pkg installs the deduped catalog from OUR repo.
     pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
     pkg_delete(repo_vm)
-    write_repo_conf(repo_vm, abi_dir, ours_priority=pfsense_prio + 100)
+    write_repo_conf(repo_vm, catalog_dir, ours_priority=pfsense_prio + 100)
     pkg_update(repo_vm)
     assert pkg_installed_version(repo_vm) is None, f"{PKG_NAME} unexpectedly present before the dedup install"
     pkg_install_from_repo(repo_vm)
@@ -1239,11 +1226,16 @@ def _live_base_url() -> str | None:
     return val.rstrip("/")
 
 
-def poll_catalog_served(base_url: str, abi: str, *, attempts: int = 30, delay: float = 10.0) -> None:
-    """Poll the live ``<base>/<ABI>/meta.conf`` until it serves (first deploy + DNS/cert lag).
+def poll_catalog_served(base_url: str, catalog_path: str, *, attempts: int = 30, delay: float = 10.0) -> None:
+    """Poll the live ``<base>/<catalog_path>/meta.conf`` until it serves (first deploy + DNS/cert lag).
 
-    The catalog files a client ``pkg update`` consumes are ``meta.conf`` +
-    ``packagesite.pkg``; a 200 on both is the runner-side BACKSTOP that the deploy
+    Arch-less (NO_ARCH — issue #1806): a published catalog is keyed by varver alone,
+    no ``${ABI}``/CPU segment. ``catalog_path`` is the caller's full subtree UNDER
+    ``base_url`` — no channel is hardcoded here, since callers' bases differ (the
+    release check's base is the pkg root, so it passes ``f"release/{varver}"``; the
+    nightly check's base already ends in ``/nightly``, so it passes the bare
+    ``varver``). The catalog files a client ``pkg update`` consumes are ``meta.conf``
+    + ``packagesite.pkg``; a 200 on both is the runner-side BACKSTOP that the deploy
     actually published a usable tree, independent of the guest. Raises with the last
     error if the URL never serves within the budget.
     """
@@ -1251,7 +1243,7 @@ def poll_catalog_served(base_url: str, abi: str, *, attempts: int = 30, delay: f
     for _ in range(attempts):
         try:
             for fname in ("meta.conf", "packagesite.pkg"):
-                url = f"{base_url}/{abi}/{fname}"
+                url = f"{base_url}/{catalog_path}/{fname}"
                 with urllib.request.urlopen(url, timeout=15) as resp:  # noqa: S310 (fixed https Pages URL)
                     if resp.status != 200:
                         raise RuntimeError(f"{url} -> HTTP {resp.status}")
@@ -1261,7 +1253,7 @@ def poll_catalog_served(base_url: str, abi: str, *, attempts: int = 30, delay: f
         except (urllib.error.URLError, RuntimeError, TimeoutError) as exc:
             last_err = f"{type(exc).__name__}: {exc}"
             time.sleep(delay)
-    raise AssertionError(f"live catalog never served {base_url}/{abi}/ within budget; last error: {last_err}")
+    raise AssertionError(f"live catalog never served {base_url}/{catalog_path}/ within budget; last error: {last_err}")
 
 
 def pin_pages_hosts(vm: SmokeVM, host: str, *, timeout: float = 60.0) -> str:
@@ -1319,16 +1311,26 @@ def restore_pages_hosts(vm: SmokeVM, prior_hosts: str, *, timeout: float = 60.0)
         raise RuntimeError(f"restore_pages_hosts failed: rc={result.returncode} {result.stderr!r}")
 
 
-def write_live_repo_conf(vm: SmokeVM, base_url: str, *, priority: int, timeout: float = 60.0) -> None:
-    """Write OUR production conf pointing at the LIVE ``<base>/${ABI}`` Pages URL.
+def write_live_repo_conf(vm: SmokeVM, base_url: str, varver: str, *, priority: int, timeout: float = 60.0) -> None:
+    """Write OUR production conf pointing at the LIVE ``<base>/release/<varver>`` Pages URL.
 
     Built from the SAME generator the publish job emits (``build-repo-portable.py
-    --print-conf --base-url <base>``), but with the ``priority:`` raised above the
-    Netgate ``pfSense`` repo so cross-repo resolution favours ours. The literal
-    ``${ABI}`` is expanded by pkg(8) (not the shell) and follows the box's ABI.
+    --print-conf --base-url <base> --catalog-path <varver>``), but with the
+    ``priority:`` raised above the Netgate ``pfSense`` repo so cross-repo resolution
+    favours ours. The conf URL is fully resolved (``<base>/release/<varver>`` —
+    arch-less, NO_ARCH, issue #1806): there is no ``${ABI}`` pkg(8) variable any
+    more, the caller supplies the concrete varver.
     """
     proc = subprocess.run(
-        [sys.executable, str(BUILD_REPO_PORTABLE), "--print-conf", "--base-url", base_url],
+        [
+            sys.executable,
+            str(BUILD_REPO_PORTABLE),
+            "--print-conf",
+            "--base-url",
+            base_url,
+            "--catalog-path",
+            varver,
+        ],
         capture_output=True,
         text=True,
         timeout=timeout,
@@ -1354,16 +1356,18 @@ def write_live_repo_conf(vm: SmokeVM, base_url: str, *, priority: int, timeout: 
 @pytest.mark.timeout(900)  # live deploy/DNS/cert can lag + pkg update + install over the public URL.
 def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     """PHASE-3b LIVE URL: a real pfSense box installs from the DEPLOYED Pages catalog
-    over its public HTTPS ``https://pfblockerng.github.io/pkg/${ABI}`` URL (no ``-f``).
+    over its public HTTPS ``https://pfblockerng.github.io/pkg/release/<varver>`` URL
+    (no ``-f``).
 
     DISPATCH-ONLY + GATED on ``SMOKE_REPO_LIVE_URL`` (unset -> SKIP). The always-on
     proof is the file:// VM-acceptance above; this exercises the REAL transport the
     publish pipeline serves, so it can only run after a publish dispatch has deployed.
 
     Given the publish job has DEPLOYED the catalog to Pages (runner-side backstop:
-      ``<base>/<ABI>/meta.conf`` + ``packagesite.pkg`` serve 200), the guest has the
-      Pages IPs pinned for the host (its DNS is sandboxed), the package is ABSENT, and
-      OUR conf points at the live ``${ABI}`` URL above the Netgate ``pfSense`` repo,
+      ``<base>/release/<varver>/meta.conf`` + ``packagesite.pkg`` serve 200), the guest
+      has the Pages IPs pinned for the host (its DNS is sandboxed), the package is
+      ABSENT, and OUR conf points at the live ``release/<varver>`` URL above the
+      Netgate ``pfSense`` repo,
     When ``pkg update`` reads the live catalog and ``pkg install -y`` runs (NO ``-r``,
       NO ``-f``),
     Then ``pkg update`` accepts the deployed catalog AND the install comes from OUR
@@ -1379,9 +1383,12 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     assert host, f"could not parse a host from {base_url!r}"
 
     # BACKSTOP: prove the deploy actually serves the catalog from the RUNNER first
-    # (independent of the guest) — polls through first-deploy / DNS / cert lag. The ABI to
-    # poll is this leg's own, derived from the matrix (the CE box for the live-pages check).
-    poll_catalog_served(base_url, matrix_abi())
+    # (independent of the guest) — polls through first-deploy / DNS / cert lag. The
+    # varver to poll is this leg's own, derived from the matrix (own_variant().catalog
+    # — the published catalogs are keyed from the matrix; needs no VM round-trip). This
+    # release check's base is the pkg root, so the full subtree is "release/<varver>".
+    varver = own_variant().catalog
+    poll_catalog_served(base_url, f"release/{varver}")
 
     # GIVEN: Pages IPs pinned (guest DNS is sandboxed), package absent, our conf at
     # the LIVE url above pfSense.
@@ -1389,7 +1396,7 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     try:
         pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
         pkg_delete(repo_vm)
-        write_live_repo_conf(repo_vm, base_url, priority=pfsense_prio + 100)
+        write_live_repo_conf(repo_vm, base_url, varver, priority=pfsense_prio + 100)
 
         # WHEN: pkg update must ACCEPT the live HTTPS catalog (a rejected catalog — bad
         # meta.conf, malformed packagesite, mismatched sum, or an unreachable URL — fails here).
@@ -1410,7 +1417,7 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
 
 # =========================================================================== #
 # ADR-20 Phase 6 — variant-catalog live-VM cases (CE install, wrong-variant   #
-# guard, legacy path, routing URL).                                            #
+# guard, routing URL).                                                        #
 #                                                                              #
 # Marker: @pytest.mark.repo  (inherited from pytestmark = pytest.mark.repo).  #
 # Deselected from default `python -m pytest` — dispatched via:                #
@@ -1436,26 +1443,18 @@ def build_repo_via_portable_named(
     *,
     catalog_name: str,
     guest_root: str,
-    arch_leaf: str | None = None,
 ) -> str:
-    """Like ``build_repo_via_portable`` but writes under ``<out>/<catalog-name>/<dir>/``.
+    """Like ``build_repo_via_portable`` but writes under ``<out>/<catalog-name>/``.
 
     Uses ``build-repo-portable.py --catalog-name <catalog_name>`` to place the catalog
-    under the named variant directory. The on-guest leaf directory is chosen by
-    ``arch_leaf``:
-
-    * ``arch_leaf=None`` (default) ships under the builder's ``<ABI>/`` bucket
-      (``ce-2.8/FreeBSD:15:amd64/``) and returns that ABI path — for tests whose conf
-      points directly at the returned dir.
-    * ``arch_leaf="amd64"`` ships under the bare-arch leaf (``ce-2.8/amd64/``),
-      mirroring the PRODUCTION ``build_repo_matrix`` layout (release/<varver>/<arch>) —
-      for tests driven by add-repo.sh / the rc.d hook, whose conf resolves to the bare
-      arch leaf (ADR-39), not the full ABI.
+    DIRECTLY under the named variant directory (arch-less, NO_ARCH — issue #1806; no
+    per-ABI bucket any more, ``catalog_name`` may itself contain ``/``, e.g.
+    ``"release/ce-2.8"``). Ships those files to ``<guest_root>/<catalog_name>/``.
 
     Returns the on-guest path the repo conf should point at.
     """
-    in_dir = tmp_path / f"in_{catalog_name}"
-    out_dir = tmp_path / f"out_{catalog_name}"
+    in_dir = tmp_path / f"in_{catalog_name.replace('/', '_')}"
+    out_dir = tmp_path / f"out_{catalog_name.replace('/', '_')}"
     in_dir.mkdir(parents=True, exist_ok=True)
     for pkg in pkg_files:
         (in_dir / pkg.name).write_bytes(pkg.read_bytes())
@@ -1482,26 +1481,20 @@ def build_repo_via_portable_named(
             f"rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
         )
 
-    catalog_root = out_dir / catalog_name
-    abi_buckets = sorted(p for p in catalog_root.iterdir() if p.is_dir())
-    assert len(abi_buckets) == 1, (
-        f"portable generator produced {[p.name for p in abi_buckets]} ABI buckets under {catalog_name}/, expected 1"
-    )
-    local_abi_dir = abi_buckets[0]
+    local_catalog_dir = out_dir / catalog_name
     for fname in ("meta.conf", "meta", "packagesite.pkg", "data.pkg"):
-        assert (local_abi_dir / fname).is_file(), f"portable generator did not emit {fname} under {local_abi_dir}"
+        assert (local_catalog_dir / fname).is_file(), (
+            f"portable generator did not emit {fname} under {local_catalog_dir}"
+        )
 
-    # Ship the catalog tree to the guest under the chosen leaf dir: the builder's
-    # <ABI>/ bucket by default, or the bare-arch leaf when arch_leaf is given (the
-    # production release/<varver>/<arch> layout the ADR-39 conf resolves to).
-    leaf = arch_leaf if arch_leaf is not None else local_abi_dir.name
-    guest_leaf_dir = f"{guest_root}/{catalog_name}/{leaf}"
-    _ssh_check(vm, "/bin/rm", "-rf", f"{guest_root}/{catalog_name}")
-    _ssh_check(vm, "/bin/mkdir", "-p", guest_leaf_dir)
-    for f in sorted(local_abi_dir.iterdir()):
+    # Ship the catalog files to the guest under <guest_root>/<catalog_name>/.
+    guest_catalog_dir = f"{guest_root}/{catalog_name}"
+    _ssh_check(vm, "/bin/rm", "-rf", guest_catalog_dir)
+    _ssh_check(vm, "/bin/mkdir", "-p", guest_catalog_dir)
+    for f in sorted(local_catalog_dir.iterdir()):
         if f.is_file():
-            _scp_to_guest(vm, f, f"{guest_leaf_dir}/{f.name}")
-    return guest_leaf_dir
+            _scp_to_guest(vm, f, f"{guest_catalog_dir}/{f.name}")
+    return guest_catalog_dir
 
 
 def forge_variant_pkg(src_pkg: Path, out_dir: Path, *, target_php: str, target_abi: str) -> Path:
@@ -1538,7 +1531,10 @@ def forge_variant_pkg(src_pkg: Path, out_dir: Path, *, target_php: str, target_a
                         else:
                             new_deps[key] = val
                     obj["deps"] = new_deps
-                # Set the target ABI so the portable generator buckets it correctly.
+                # Set the target ABI: the box's own `pkg install` ABI-compatibility check is
+                # the guard under test (a concrete-vs-wildcard bucket no longer exists —
+                # issue #1806 — so this must be a wildcard ABI or the portable generator
+                # itself hard-rejects it; callers pass "FreeBSD:<opp_major>:*").
                 obj["abi"] = target_abi
                 pkg_name = obj.get("name", pkg_name)
                 data = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode() + b"\n"
@@ -1579,15 +1575,17 @@ def pkg_query_deps(vm: SmokeVM, *, timeout: float = 60.0) -> str:
 @pytest.mark.timeout(600)
 def test_install_from_variant_catalog(repo_vm: SmokeVM, tmp_path: Path) -> None:
     """ADR-20 P6 CASE 1 — the box's package installs from its variant-keyed
-    ``<variant>/${ABI}`` catalog; its own php + Python deps resolve; origin is our repo.
+    ``<variant>/`` catalog (arch-less, NO_ARCH — issue #1806); its own php + Python
+    deps resolve; origin is our repo.
 
     Scenario: package installed from the variant-correct catalog for THIS box.
-      Background: hermetic file:// catalog at ``<own.catalog>/<own.abi>/``. The variant
-      (ABI / php / Python flavor) comes from the ci-metadata matrix (SMOKE_ABI /
-      SMOKE_PHP_VERSION / SMOKE_PY_FLAVOR), so the CE leg asserts php83/FreeBSD:15 and the
-      Plus leg asserts php85/FreeBSD:16 — no hardcoded flavor.
+      Background: hermetic file:// catalog at ``<own.catalog>/`` directly (no ABI
+      leaf). The variant (ABI / php / Python flavor) comes from the ci-metadata
+      matrix (SMOKE_ABI / SMOKE_PHP_VERSION / SMOKE_PY_FLAVOR), so the CE leg
+      asserts php83/FreeBSD:15 and the Plus leg asserts php85/FreeBSD:16 — no
+      hardcoded flavor.
 
-    Given the package ABSENT and a variant-keyed catalog under ``<variant>/${ABI}/``
+    Given the package ABSENT and a variant-keyed catalog under ``<variant>/``
       built from the branch .pkg by the pure-Python generator,
     When ``pkg install -y <pkgname>`` resolves from this catalog,
     Then ``pkg query '%dn %dv' <pkgname>`` shows the box's OWN php dep AND the matrix
@@ -1605,7 +1603,7 @@ def test_install_from_variant_catalog(repo_vm: SmokeVM, tmp_path: Path) -> None:
 
     # GIVEN: build the box's variant catalog with the variant-keyed dir on the runner,
     # ship to guest, write a NONE-signed file:// repo conf above pfSense.
-    abi_dir = build_repo_via_portable_named(
+    catalog_dir = build_repo_via_portable_named(
         repo_vm,
         [Path(pkg), *_smoke_dep_pkg_paths()],
         tmp_path,
@@ -1614,7 +1612,7 @@ def test_install_from_variant_catalog(repo_vm: SmokeVM, tmp_path: Path) -> None:
     )
     pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
     pkg_delete(repo_vm)
-    write_repo_conf(repo_vm, abi_dir, ours_priority=pfsense_prio + 100)
+    write_repo_conf(repo_vm, catalog_dir, ours_priority=pfsense_prio + 100)
 
     # Before-state: package absent.
     pkg_update(repo_vm)
@@ -1667,9 +1665,9 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
     (php83/FreeBSD:15) package — no hardcoded direction.
 
     Scenario: installing the opposite-variant package fails with an unsatisfied dep.
-      Background: hermetic file:// catalog at ``<opp.catalog>/<opp.abi>/``.
+      Background: hermetic file:// catalog at ``<opp.catalog>/`` directly (no ABI leaf).
 
-    Before-state ASSERT: the box's OWN package (``<own.catalog>/${ABI}``) installs CLEANLY
+    Before-state ASSERT: the box's OWN package (``<own.catalog>/``) installs CLEANLY
       (own php dep satisfied) — proves the own path is correct and the AFTER failure is
       caused by the variant mismatch, not an unrelated setup issue.
     Given the own package uninstalled and the repo conf pointing at the opposite-variant
@@ -1686,7 +1684,7 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
     opp = opposite_variant()
 
     # ---- Before-state: prove the box's OWN path works (the guard control) ----
-    own_abi_dir = build_repo_via_portable_named(
+    own_catalog_dir = build_repo_via_portable_named(
         repo_vm,
         [src, *_smoke_dep_pkg_paths()],
         tmp_path,
@@ -1695,7 +1693,7 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
     )
     pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
     pkg_delete(repo_vm)
-    write_repo_conf(repo_vm, own_abi_dir, ours_priority=pfsense_prio + 100)
+    write_repo_conf(repo_vm, own_catalog_dir, ours_priority=pfsense_prio + 100)
     pkg_update(repo_vm)
 
     # Assert before-state: absent before the own-variant control install.
@@ -1710,16 +1708,21 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
     assert own.php in own_deps, f"Control ({own.abi}) install: {own.php} not in deps; pkg query '%dn %dv':\n{own_deps}"
     # Own install succeeded — this is the before-state anchor.
 
-    # ---- Forge the OPPOSITE variant's .pkg (opp.php dep, opp.abi ABI) ----
-    opp_pkg = forge_variant_pkg(src, tmp_path / "opp_forge", target_php=opp.php, target_abi=opp.abi)
+    # ---- Forge the OPPOSITE variant's .pkg (opp.php dep, opp's freebsd_major ABI) ----
+    # The portable generator now hard-rejects a concrete ABI (issue #1806 — production
+    # catalogs only ever hold wildcard/NO_ARCH pkgs), so the forged ABI must be
+    # wildcarded to the opposite major: "FreeBSD:<opp_major>:*". This still exercises
+    # the guard under test (the box's own OS-major mismatch), just with the ABI shape
+    # a real catalog would actually carry.
+    opp_major = opp.abi.split(":")[1]
+    opp_pkg = forge_variant_pkg(src, tmp_path / "opp_forge", target_php=opp.php, target_abi=f"FreeBSD:{opp_major}:*")
 
-    # ---- Build the opposite-variant catalog in <opp.catalog>/<opp.abi>/ ----
-    # Deliberately NOT folding _smoke_dep_pkg_paths() here: this leg's dep .pkgs
-    # are built for the box's OWN freebsd_major, which by definition mismatches
-    # opp.abi — adding them would open a SECOND ABI bucket and break the
-    # generator's own `len(abi_buckets) == 1` invariant. This catalog exists to
-    # be REJECTED (wrong variant), not to prove dep resolution.
-    opp_abi_dir = build_repo_via_portable_named(
+    # ---- Build the opposite-variant catalog in <opp.catalog>/ directly (no ABI leaf) ----
+    # Deliberately NOT folding _smoke_dep_pkg_paths() here: this catalog exists only to
+    # be REJECTED (wrong variant, not dep resolution), and its one package already
+    # belongs to the box's own freebsd_major — the dep .pkgs built for this leg would be
+    # redundant, not a second competing ABI (the generator's per-run major is now single).
+    opp_catalog_dir = build_repo_via_portable_named(
         repo_vm,
         [opp_pkg],
         tmp_path,
@@ -1730,7 +1733,7 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
     # Remove the own install; point conf at the opposite-variant catalog.
     pkg_delete(repo_vm)
     assert vm_pkg_query_name(repo_vm) == "", "package still present after pkg_delete"
-    write_repo_conf(repo_vm, opp_abi_dir, ours_priority=pfsense_prio + 100)
+    write_repo_conf(repo_vm, opp_catalog_dir, ours_priority=pfsense_prio + 100)
 
     try:
         pkg_update(repo_vm)
@@ -1769,110 +1772,10 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
     )
 
 
-# --------------------------------------------------------------------------- #
-# ADR-20 Case 3 — legacy ${ABI}/ path still serves CE build                   #
-# --------------------------------------------------------------------------- #
-
-
-@pytest.mark.timeout(900)
-def test_legacy_abi_path_still_upgrades(repo_vm: SmokeVM, tmp_path: Path) -> None:
-    """ADR-20 P6 CASE 3 — Old-conf CE box (legacy ``${ABI}/`` path, no variant
-    prefix) still upgrades from N to N+1 during the ADR-20 transition window.
-
-    Scenario: Old-conf CE box (legacy ABI/ path) still upgrades.
-      Background: hermetic file:// legacy catalog at FreeBSD:15:amd64/ (no variant prefix).
-
-    Given version N installed from the legacy (no-prefix) ``${ABI}/`` path,
-    When the catalog is rebuilt with version N+1 and ``pkg upgrade -y`` runs,
-    Then the box moves to N+1, still from our repo.
-    Assert BEFORE: version N installed, N+1 available from catalog.
-    Assert AFTER: version N+1 installed.
-    """
-    pkg = os.environ.get("SMOKE_PKG")
-    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"
-    src = Path(pkg)
-
-    base_version = read_compact_version(src)
-    low_version = f"{base_version}_1"
-    high_version = f"{base_version}_9"
-    assert low_version != high_version
-
-    low_pkg = reversion_pkg(src, low_version, tmp_path / "legacy_low")
-    high_pkg = reversion_pkg(src, high_version, tmp_path / "legacy_high")
-
-    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
-
-    try:
-        # ---- GIVEN: legacy catalog (no variant prefix) with the LOWER build ----
-        # build_repo_via_portable produces <out>/<ABI>/ (no catalog-name prefix).
-        dep_pkgs = _smoke_dep_pkg_paths()
-        legacy_abi_dir = build_repo_via_portable(repo_vm, [low_pkg, *dep_pkgs], tmp_path)
-        pkg_delete(repo_vm)
-        write_repo_conf(repo_vm, legacy_abi_dir, ours_priority=pfsense_prio + 100)
-        pkg_update(repo_vm)
-        assert vm_pkg_query_name(repo_vm) == "", f"{PKG_NAME} unexpectedly present before legacy upgrade test"
-
-        # Install the LOWER version from the legacy path.
-        pkg_install_from_repo(repo_vm)
-
-        # Assert BEFORE: N installed, from our repo.
-        installed_low = pkg_installed_version(repo_vm)
-        assert installed_low == low_version, (
-            f"Legacy path: expected {low_version!r} installed first, got {installed_low!r}"
-        )
-        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, (
-            f"Legacy low build came from {pkg_repo_origin(repo_vm)!r}, expected our repo"
-        )
-
-        # ---- WHEN: rebuild legacy catalog with HIGHER build, upgrade ----
-        # Must rebuild into the SAME on-guest dir so the existing conf still points at it.
-        # Re-run portable generator into a new runner tmp, ship to the same guest dir.
-        in_high = tmp_path / "legacy_high_in"
-        out_high = tmp_path / "legacy_high_out"
-        in_high.mkdir(parents=True, exist_ok=True)
-        (in_high / high_pkg.name).write_bytes(high_pkg.read_bytes())
-        for _dep in dep_pkgs:
-            (in_high / _dep.name).write_bytes(_dep.read_bytes())
-        proc_high = subprocess.run(
-            [sys.executable, str(BUILD_REPO_PORTABLE), "--in", str(in_high), "--out", str(out_high)],
-            capture_output=True,
-            text=True,
-            timeout=180.0,
-            check=False,
-        )
-        if proc_high.returncode != 0:
-            raise RuntimeError(
-                f"build-repo-portable.py (legacy high) failed: rc={proc_high.returncode}\n"
-                f"stdout:\n{proc_high.stdout}\nstderr:\n{proc_high.stderr}"
-            )
-        high_abi_dirs = sorted(p for p in out_high.iterdir() if p.is_dir())
-        assert len(high_abi_dirs) == 1, (
-            f"legacy high catalog produced {[p.name for p in high_abi_dirs]} ABI dirs, expected 1"
-        )
-        high_local_abi = high_abi_dirs[0]
-
-        # Ship the updated catalog to the SAME guest ABI dir (overwrite in place).
-        for f in sorted(high_local_abi.iterdir()):
-            if f.is_file():
-                _scp_to_guest(repo_vm, f, f"{legacy_abi_dir}/{f.name}")
-
-        pkg_update(repo_vm)
-        proc_upg = pkg_upgrade(repo_vm)
-
-        # THEN: box moves to N+1, still from our repo.
-        upg_combined = proc_upg.stdout + proc_upg.stderr
-        assert "Missing dependency" not in upg_combined, f"Legacy upgrade: RUN_DEPENDS did not resolve:\n{upg_combined}"
-        installed_high = pkg_installed_version(repo_vm)
-        assert installed_high == high_version, (
-            f"Legacy upgrade: expected {high_version!r} after upgrade, got {installed_high!r}"
-        )
-        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME, (
-            f"Legacy upgrade: origin {pkg_repo_origin(repo_vm)!r}, expected our repo"
-        )
-    finally:
-        pkg_delete(repo_vm)
-        repo_vm.ssh("/bin/rm", "-rf", VARIANT_REPO_ROOT, timeout=60.0)
-
+# ADR-20 Case 3 (legacy ${ABI}/ conf transition window) retired: issue #1806 made
+# every catalog arch-less and deliberately broke existing alpha confs (owner decision).
+# N -> N+1 upgrade coverage is retained by test_pkg_upgrade_moves_to_our_newer_build
+# above (uses build_guest_repo, untouched by the arch-less rework).
 
 # =========================================================================== #
 # ADR-27 Phase 10 — EOL route-only install from a frozen catalog              #
@@ -1895,7 +1798,6 @@ def _build_eol_catalog_on_runner(
     eol_pfsense_version: str,
     variant: str,
     freebsd_major: str,
-    arch: str,
     php_version: str,
     py_flavor: str,
     out_dir: Path,
@@ -1905,16 +1807,16 @@ def _build_eol_catalog_on_runner(
     Runs ``build-repo-portable.py --build-matrix`` with a synthetic route-only
     matrix entry and ``--route-only-pkgs <eol_varver>:<frozen_pkg>``.  The new
     Phase-10 CLI flag is exercised end-to-end here — this is the exact invocation
-    shape publish.yml uses for real EOL versions.
+    shape publish.yml uses for real EOL versions. The matrix carries no ``arch`` key
+    any more (retired by issue #1806 — every catalog is arch-less/NO_ARCH).
 
-    Returns the runner-side ``release/<eol_varver>/<arch>/`` directory whose files
-    will be shipped to the guest.
+    Returns the runner-side ``release/<eol_varver>/`` directory whose files will be
+    shipped to the guest.
     """
     matrix_entry = {
         "pfsense_version": eol_pfsense_version,
         "variant": variant,
         "freebsd_major": freebsd_major,
-        "arch": arch,
         "php_version": php_version,
         "py_flavor": py_flavor,
         "status": "EOL",
@@ -1944,8 +1846,8 @@ def _build_eol_catalog_on_runner(
             f"build-repo-portable.py --build-matrix (route-only) failed: rc={proc.returncode}\n"
             f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
         )
-    release_dir = out_dir / "release" / eol_varver / arch
-    assert release_dir.is_dir(), f"route-only generator did not emit release/{eol_varver}/{arch}/ under {out_dir}"
+    release_dir = out_dir / "release" / eol_varver
+    assert release_dir.is_dir(), f"route-only generator did not emit release/{eol_varver}/ under {out_dir}"
     for fname in ("meta.conf", "meta", "packagesite.pkg", "data.pkg"):
         assert (release_dir / fname).is_file(), f"route-only generator did not emit {fname} under {release_dir}"
     return release_dir
@@ -1994,8 +1896,10 @@ def test_eol_route_only_install_from_frozen_catalog(repo_vm: SmokeVM, tmp_path: 
     eol_pfsense_version = "1.99"
     eol_varver = f"{own.variant.lower()}-1.99"
 
-    # Split the ABI string "FreeBSD:<major>:<arch>" into its components.
-    _proto, freebsd_major, arch = own.abi.split(":", 2)
+    # Split the ABI string "FreeBSD:<major>:<arch>" to get the major (the arch
+    # segment is no longer needed anywhere — the catalog is arch-less, NO_ARCH,
+    # issue #1806).
+    freebsd_major = own.abi.split(":")[1]
 
     # Derive the PHP version string expected by the matrix entry (e.g. "8.3" from "php83").
     # own.php is "php83" / "php85" — strip "php" and re-insert the dot: "83" → "8.3".
@@ -2025,7 +1929,6 @@ def test_eol_route_only_install_from_frozen_catalog(repo_vm: SmokeVM, tmp_path: 
         eol_pfsense_version,
         own.variant,
         freebsd_major,
-        arch,
         php_version,
         own.py,
         eol_out_dir,
@@ -2042,18 +1945,18 @@ def test_eol_route_only_install_from_frozen_catalog(repo_vm: SmokeVM, tmp_path: 
 
     try:
         # ---- Ship the EOL catalog tree to the guest. ----
-        # Ship only the release/<eol_varver>/<arch>/ files (the ABI subtree); the
-        # guest conf points directly at the on-guest ABI directory.
-        guest_abi_dir = f"{EOL_REPO_ROOT}/{eol_varver}/{arch}"
+        # Ship the release/<eol_varver>/ files directly (arch-less, NO_ARCH — issue
+        # #1806); the guest conf points directly at the on-guest varver directory.
+        guest_catalog_dir = f"{EOL_REPO_ROOT}/{eol_varver}"
         _ssh_check(repo_vm, "/bin/rm", "-rf", EOL_REPO_ROOT)
-        _ssh_check(repo_vm, "/bin/mkdir", "-p", guest_abi_dir)
+        _ssh_check(repo_vm, "/bin/mkdir", "-p", guest_catalog_dir)
         for f in sorted(local_release_dir.iterdir()):
             if f.is_file():
-                _scp_to_guest(repo_vm, f, f"{guest_abi_dir}/{f.name}")
+                _scp_to_guest(repo_vm, f, f"{guest_catalog_dir}/{f.name}")
 
         # --- GIVEN: package absent; EOL catalog enabled above the pfSense repo. ---
         pkg_delete(repo_vm)
-        write_repo_conf(repo_vm, guest_abi_dir, ours_priority=pfsense_prio + 100)
+        write_repo_conf(repo_vm, guest_catalog_dir, ours_priority=pfsense_prio + 100)
         pkg_update(repo_vm)
         before_version = pkg_installed_version(repo_vm)
         assert before_version is None, (
@@ -2089,9 +1992,10 @@ def test_eol_route_only_install_from_frozen_catalog(repo_vm: SmokeVM, tmp_path: 
 #   1. ORPHAN path: no conf -> hook exits 0, writes nothing (boot-safe).      #
 #   2. REGENERATE path: a conf carrying a STALE varver (as after an OS        #
 #      upgrade) is unconditionally overwritten with the box's CURRENT         #
-#      <varver>/<arch>; the corrected conf then resolves our package via      #
-#      pkg update + install (end-to-end, file:// catalog). The hook's folded  #
-#      detection is cross-checked against an independent Python oracle.        #
+#      <varver> (arch-less, NO_ARCH — issue #1806); the corrected conf then   #
+#      resolves our package via pkg update + install (end-to-end, file://    #
+#      catalog). The hook's folded detection is cross-checked against an     #
+#      independent Python oracle.                                            #
 #   3. IDEMPOTENCE: a second run leaves the conf byte-identical (pure regen).  #
 #                                                                              #
 # The hook runs as a POSIX-sh rc.d script. Off the rc(8) framework it runs    #
@@ -2121,21 +2025,24 @@ def _stage_generate_hook(vm: SmokeVM, *, guest_hook: str) -> None:
     _ssh_check(vm, "/bin/chmod", "755", guest_hook)
 
 
-def _box_real_catalog(vm: SmokeVM) -> str:
-    """Independent Python oracle for the box's ``<varver>/<arch>`` (cross-checks the hook).
+def _box_real_varver(vm: SmokeVM) -> str:
+    """Independent Python oracle for the box's ``<varver>`` (cross-checks the hook).
 
     Mirrors the hook's folded detection: edition = "/etc/product_label contains 'Plus'"
     (absent file -> CE, matching the hook's grep-on-missing-file = CE), version =
-    major.minor of /etc/version, arch = the leaf of ``pkg config abi``.
+    major.minor of /etc/version with any ``-BETA``-style dash suffix stripped FIRST
+    (mirrors the production hook's own strip, issue #1806: a bare ``ver.split(".")[:2]``
+    over ``"26.07-BETA"`` yields ``"plus-26.07-BETA"``, a varver ``build-repo.sh``'s
+    lowercase-varver guard rejects). The catalog is arch-less (NO_ARCH; issue #1806) —
+    there is no ``arch`` component any more.
     """
     label = vm.ssh("/bin/cat", "/etc/product_label", timeout=30.0)
     edition = "plus" if (label.returncode == 0 and "Plus" in label.stdout) else "ce"
     ver = _ssh_check(vm, "/bin/cat", "/etc/version").stdout.strip()
+    ver = ver.split("-", 1)[0]
     mm = ".".join(ver.split(".")[:2])
-    abi = _ssh_check(vm, "/usr/local/sbin/pkg", "config", "abi").stdout.strip()
-    arch = abi.rsplit(":", 1)[-1]
-    assert mm and arch, f"oracle could not resolve box catalog: ver={ver!r} abi={abi!r}"
-    return f"{edition}-{mm}/{arch}"
+    assert mm, f"oracle could not resolve box varver: ver={ver!r}"
+    return f"{edition}-{mm}"
 
 
 def _read_conf_url_on_guest(vm: SmokeVM, conf_path: str) -> str:
@@ -2236,16 +2143,17 @@ def test_generate_hook_rewrites_stale_varver_and_resolves(repo_vm: SmokeVM, tmp_
     """ADR-39 REGENERATE PATH: a stale ``<varver>`` in the conf is rewritten to the box's current one.
 
     Simulates a post-OS-upgrade boot where the conf still points at an OLD varver. The
-    hook unconditionally REGENERATES the conf for the box's CURRENT ``<varver>/<arch>``
-    (folded detection), and the corrected conf then resolves our package end-to-end via
-    ``pkg update`` + ``pkg install`` against a file:// catalog. The hook's detection is
-    cross-checked against an independent Python oracle (``_box_real_catalog``) — if they
-    disagree the catalog is not found and ``pkg install`` fails loud. A second run leaves
-    the conf byte-identical (pure regenerate, no patching).
+    hook unconditionally REGENERATES the conf for the box's CURRENT ``<varver>``
+    (folded detection; arch-less, NO_ARCH — issue #1806), and the corrected conf then
+    resolves our package end-to-end via ``pkg update`` + ``pkg install`` against a
+    file:// catalog. The hook's detection is cross-checked against an independent
+    Python oracle (``_box_real_varver``) — if they disagree the catalog is not found
+    and ``pkg install`` fails loud. A second run leaves the conf byte-identical (pure
+    regenerate, no patching).
 
     Scenario:
-      Background: a file:// catalog at ``<base>/release/<real_varver>/<arch>/``; the
-        seeded conf url initially points at ``<base>/release/stale-9.9/<arch>`` (wrong).
+      Background: a file:// catalog at ``<base>/release/<real_varver>/``; the seeded
+        conf url initially points at ``<base>/release/stale-9.9`` (wrong).
       Given the conf carries the stale varver (BEFORE asserted),
       When  the generator hook runs with ``PFB_BASE_URL=<file:// base>``,
       Then  the conf url contains the box's REAL varver (stale gone) and the canonical
@@ -2257,31 +2165,27 @@ def test_generate_hook_rewrites_stale_varver_and_resolves(repo_vm: SmokeVM, tmp_
 
     _stage_generate_hook(repo_vm, guest_hook=GUEST_HOOK_PATH)
 
-    # Independent oracle for the box's real <varver>/<arch> (cross-checks the hook's
-    # folded detection — a disagreement makes the catalog unreachable below).
-    real_catalog = _box_real_catalog(repo_vm)
-    real_varver, real_arch = real_catalog.rsplit("/", 1)
+    # Independent oracle for the box's real <varver> (cross-checks the hook's folded
+    # detection — a disagreement makes the catalog unreachable below).
+    real_varver = _box_real_varver(repo_vm)
 
     STALE_VARVER = "stale-9.9"
-    stale_catalog = f"{STALE_VARVER}/{real_arch}"
 
     catalog_base = f"{GENERATE_DIR}/catalog"
     base_url = f"file://{catalog_base}"
-    guest_real_dir = f"{catalog_base}/release/{real_catalog}"
+    guest_real_dir = f"{catalog_base}/release/{real_varver}"
     test_conf_path = f"{GENERATE_DIR}/pfblockerng_test.conf"
 
     try:
-        # 1. Build the real catalog on the guest under release/<real_varver>/<arch-leaf>/
-        #    — the PRODUCTION layout (build_repo_matrix) that the hook's regenerated conf
-        #    resolves to (the bare arch leaf, NOT the full ABI). arch_leaf pins the leaf
-        #    dir so the file:// URL the hook writes actually finds the catalog.
+        # 1. Build the real catalog on the guest under release/<real_varver>/ — the
+        #    PRODUCTION layout (build_repo_matrix, arch-less — issue #1806) that the
+        #    hook's regenerated conf resolves to.
         shipped_dir = build_repo_via_portable_named(
             repo_vm,
             [Path(pkg), *_smoke_dep_pkg_paths()],
             tmp_path,
             catalog_name=f"release/{real_varver}",
             guest_root=catalog_base,
-            arch_leaf=real_arch,
         )
         assert shipped_dir == guest_real_dir, f"catalog shipped to {shipped_dir!r}, expected {guest_real_dir!r}"
         assert _ssh_check(repo_vm, "/bin/test", "-d", guest_real_dir).returncode == 0, (
@@ -2289,7 +2193,7 @@ def test_generate_hook_rewrites_stale_varver_and_resolves(repo_vm: SmokeVM, tmp_
         )
 
         # 2. Seed the TEST conf with a STALE varver url (canonical body shape).
-        stale_url = f"{base_url}/release/{stale_catalog}"
+        stale_url = f"{base_url}/release/{STALE_VARVER}"
         stale_conf_body = (
             "# pending boot-time generation\n"
             "pfblockerng: {\n"
@@ -2313,11 +2217,9 @@ def test_generate_hook_rewrites_stale_varver_and_resolves(repo_vm: SmokeVM, tmp_
 
         # BEFORE: conf carries the stale varver, not the real one.
         url_before = _read_conf_url_on_guest(repo_vm, test_conf_path)
-        assert stale_catalog in url_before, (
-            f"BEFORE: expected stale catalog {stale_catalog!r} in url, got {url_before!r}"
-        )
-        assert real_catalog not in url_before, (
-            f"BEFORE: conf url already contains the real catalog {real_catalog!r}: {url_before!r}"
+        assert STALE_VARVER in url_before, f"BEFORE: expected stale varver {STALE_VARVER!r} in url, got {url_before!r}"
+        assert real_varver not in url_before, (
+            f"BEFORE: conf url already contains the real varver {real_varver!r}: {url_before!r}"
         )
 
         # WHEN: run the generator hook (file:// base) — it regenerates the conf.
@@ -2325,12 +2227,12 @@ def test_generate_hook_rewrites_stale_varver_and_resolves(repo_vm: SmokeVM, tmp_
 
         # AFTER: conf url has the box's REAL varver (stale gone) + the canonical marker.
         url_after = _read_conf_url_on_guest(repo_vm, test_conf_path)
-        assert real_catalog in url_after, (
-            f"AFTER: hook did not regenerate to {real_catalog!r}, got {url_after!r}\n"
+        assert real_varver in url_after, (
+            f"AFTER: hook did not regenerate to {real_varver!r}, got {url_after!r}\n"
             f"Hook stdout:\n{hook_result.stdout}\nHook stderr:\n{hook_result.stderr}"
         )
-        assert stale_catalog not in url_after, (
-            f"AFTER: stale catalog {stale_catalog!r} still in conf url after hook ran: {url_after!r}"
+        assert STALE_VARVER not in url_after, (
+            f"AFTER: stale varver {STALE_VARVER!r} still in conf url after hook ran: {url_after!r}"
         )
         marker = _ssh_check(repo_vm, "grep", "-q", "Generated at boot by pfblockerng_repo_generate", test_conf_path)
         assert marker.returncode == 0, "AFTER: regenerated conf is missing the marker line"

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -362,6 +362,57 @@ def test_catalog_name_places_flat_catalog_under_out_dir(tmp_path: Path) -> None:
     assert not (bucket / "FreeBSD:15:*").exists()
 
 
+@pytest.mark.parametrize("kind", ["traversal", "absolute", "empty-segment", "bare-dotdot"])
+def test_catalog_name_rejects_unsafe_paths(tmp_path: Path, kind: str) -> None:
+    """An unsafe ``--catalog-name`` is rejected BEFORE it becomes ``out_dir / catalog_name``
+    (issue #1786): ``_write_catalog_dir`` ``shutil.rmtree()``s that path, so an unvalidated
+    segment lets a caller wipe an arbitrary directory — ``"../victim"`` escapes sideways to a
+    sibling of ``out_dir``, and an ABSOLUTE value makes ``Path.__truediv__`` discard ``out_dir``
+    entirely, replacing it outright. A sentinel file OUTSIDE ``out_dir`` must survive every one
+    of these attempts, and every one of them must raise ``BuildRepoError`` (never silently
+    proceed, even the ones that happen not to escape, like a doubled-slash empty segment)."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    out.mkdir()
+
+    # A sentinel directory the traversal/absolute/bare-".." cases must never touch.
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    sentinel = victim / "sentinel.txt"
+    sentinel.write_text("do not delete me")
+
+    bad = {
+        "traversal": "../victim",
+        "absolute": str(victim),
+        "empty-segment": "a//b",
+        "bare-dotdot": "..",
+    }[kind]
+
+    exc: Exception | None = None
+    try:
+        brp.build_repo(in_dir, out, catalog_name=bad)
+    except Exception as e:  # capture ANY failure mode, including an unvalidated crash
+        exc = e
+
+    assert sentinel.is_file(), f"catalog_name={bad!r} ({kind}) let the catalog write escape out_dir"
+    assert isinstance(exc, brp.BuildRepoError) and "unsafe" in str(exc).lower(), (
+        f"catalog_name={bad!r} ({kind}) must be rejected with a clear BuildRepoError; got {exc!r}"
+    )
+
+
+def test_catalog_name_with_channel_prefix_still_works(tmp_path: Path) -> None:
+    """A legitimate channel-prefixed catalog_name ("release/ce-2.8") still works — the
+    traversal guard must allow '/' BETWEEN segments (issue #1786), never just a bare varver."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out, catalog_name="release/ce-2.8")
+    assert (out / "release" / "ce-2.8" / "meta.conf").is_file()
+
+
 def test_concrete_abi_pkg_is_rejected(tmp_path: Path) -> None:
     """A CONCRETE-ABI package (not NO_ARCH) is rejected — the catalog is
     arch-less/NO_ARCH-only since issue #1806; a concrete-ABI .pkg would silently
@@ -482,8 +533,10 @@ def test_unsafe_abi_is_rejected(tmp_path: Path) -> None:
     catalog), but every one of these shapes still fails ``_is_wildcard_abi`` and
     is rejected by the NO_ARCH gate — the valid wildcard form (`FreeBSD:15:*`) is
     accepted by every other test, so this pins the reject side of the branch."""
-    # Non-empty but unsafe/non-wildcard values (traversal / slash / space) — an
-    # empty ABI is already rejected upstream by the missing-name/version/abi guard.
+    # Non-empty but unsafe/non-wildcard values (traversal / slash / space). A
+    # missing/empty ABI is rejected by this SAME NO_ARCH gate (_require_wildcard_abi),
+    # not by some separate upstream guard — build_repo()'s ABI loop runs before
+    # _emit_catalog_from_paths ever reaches _check_collisions' missing-field check.
     out = tmp_path / "out"
     for i, bad in enumerate(("../../evil", "FreeBSD/15/amd64", "a b")):
         in_dir = tmp_path / f"in{i}"
@@ -569,7 +622,8 @@ def test_print_conf_matches_template(capsys: pytest.CaptureFixture[str]) -> None
     """--print-conf emits the NONE-signed direct Pages URL / priority-100 client stanza (ADR-39).
 
     ADR-39: the url is fully resolved (no ${ABI} token) — supply --catalog-path to
-    determine the <varver>/<arch> segment.  The default base is the direct GitHub Pages URL.
+    determine the <varver> segment (arch-less; issue #1806). The default base is the
+    direct GitHub Pages URL.
     """
     rc = brp.main(["--print-conf", "--catalog-path", "ce-2.8/amd64"])
     assert rc == 0
@@ -583,7 +637,7 @@ def test_print_conf_matches_template(capsys: pytest.CaptureFixture[str]) -> None
 
 
 def test_print_conf_base_url_override(capsys: pytest.CaptureFixture[str]) -> None:
-    """--base-url overrides the host; --catalog-path supplies the varver/arch segment."""
+    """--base-url overrides the host; --catalog-path supplies the varver segment (arch-less)."""
     rc = brp.main(["--print-conf", "--base-url", "https://fork.example.io/p/", "--catalog-path", "ce-2.8/amd64"])
     assert rc == 0
     out = capsys.readouterr().out
@@ -2278,7 +2332,7 @@ def test_cli_release_extra_pkgs_newest_wins(tmp_path: Path, monkeypatch: pytest.
 # .pkg is served from a frozen GitHub Release asset — no fresh build, no nightly.
 #
 # These tests pin every guarantee of the route-only path:
-#   * release/<varver>/<arch>/ catalog lists exactly the frozen .pkg version(s)
+#   * release/<varver>/ catalog lists exactly the frozen .pkg version(s)
 #   * NO nightly/<varver>/ subtree ever exists for a route-only entry
 #   * build-entry parity: with route-only entries added, the build entry's release
 #     + nightly subtrees are BYTE-IDENTICAL to a run without the route-only entries
@@ -2317,7 +2371,7 @@ def test_route_only_release_catalog_contains_exactly_frozen_pkg(tmp_path: Path) 
     Scenario: EOL CE 2.7 with one frozen .pkg
       Given a frozen CE 2.7 .pkg (version 3.1.0_5) in route_only_pkgs
        When build_repo_matrix runs with role=route-only for CE 2.7
-      Then release/ce-2.7/amd64/packagesite.pkg lists exactly that one package
+      Then release/ce-2.7/packagesite.pkg lists exactly that one package
        And the name is pfBlockerNG-devel and the version is 3.1.0_5
     """
     out = tmp_path / "site"
@@ -2420,8 +2474,8 @@ def test_route_only_ce_and_plus_both_served(tmp_path: Path) -> None:
     Scenario: one build CE 2.8 + route-only CE 2.7 + route-only Plus 25.03
       Given separate frozen .pkg for each route-only entry
        When build_repo_matrix runs
-      Then release/ce-2.7/amd64/ catalog lists the frozen CE pkg
-       And release/plus-25.03/amd64/ catalog lists the frozen Plus pkg
+      Then release/ce-2.7/ catalog lists the frozen CE pkg
+       And release/plus-25.03/ catalog lists the frozen Plus pkg
        And NO nightly/ subtrees exist for either route-only entry
     """
     out = tmp_path / "site"
@@ -2631,7 +2685,7 @@ def test_cli_route_only_pkgs_flag_builds_frozen_catalog(tmp_path: Path) -> None:
         And --route-only-pkgs ce-2.7:<path> passed on the CLI
       When ``brp.main(["--build-matrix", ...])`` is called
       Then rc == 0
-       And release/ce-2.7/amd64/ catalog exists with the frozen version
+       And release/ce-2.7/ catalog exists with the frozen version
        And nightly/ce-2.7/ does NOT exist (no nightly for route-only)
     """
     out = tmp_path / "site"
@@ -2740,14 +2794,14 @@ def test_cli_route_only_pkgs_bad_format_errors(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------- #
 # Consume-mode: release_pkgs= parameter
 #
-# When release_pkgs is supplied to build_repo_matrix, the release/<varver>/<arch>/
+# When release_pkgs is supplied to build_repo_matrix, the release/<varver>/
 # catalog is served from caller-supplied pre-built .pkg files (ABI-filtered, pruned
 # via retain_by_channel) instead of rebuilding devel+stable from source.
 # Nightly is always built from source regardless.
 #
 # These tests pin every guarantee of the consume-mode path:
-#   * release/<varver>/<arch>/ catalog lists exactly the consumed .pkg(s)
-#   * ABI filter: a mixed-ABI pool yields arch-specific catalogs
+#   * release/<varver>/ catalog lists exactly the consumed .pkg(s)
+#   * ABI filter: a mixed-ABI pool is filtered to the matching FreeBSD major
 #   * devel + stable both present in one pool -> retain_by_channel keeps both
 #   * empty pool for a varver -> no release catalog emitted, no exception, nightly OK
 #   * nightly is still built from source when build_nightly=True
@@ -2758,13 +2812,13 @@ def test_cli_route_only_pkgs_bad_format_errors(tmp_path: Path) -> None:
 
 
 def test_consume_mode_release_catalog_contains_consumed_pkg(tmp_path: Path) -> None:
-    """Consume mode places the pool into release/<varver>/<arch>/ under the canonical name.
+    """Consume mode places the pool into release/<varver>/ under the canonical name.
 
     Scenario: CE 2.8 build entry + one pre-built devel .pkg supplied via release_pkgs
       Given a pre-built pfBlockerNG-devel 4.0.0_1 .pkg (amd64)
         And release_pkgs={"ce-2.8": [pkg]} passed to build_repo_matrix
        When build_repo_matrix runs with build_nightly=False
-      Then release/ce-2.8/amd64/packagesite.pkg lists that package
+      Then release/ce-2.8/packagesite.pkg lists that package
        And the catalog entry name is pfBlockerNG-devel and version is 4.0.0_1
        And the builder was NOT called for devel/stable (consume, not rebuild)
     """
@@ -2873,7 +2927,7 @@ def test_consume_mode_devel_and_stable_both_retained(tmp_path: Path) -> None:
     Scenario: pool carries one devel and one stable .pkg for ce-2.8
       Given pfBlockerNG-devel (devel channel) + pfBlockerNG (stable channel) .pkg in pool
        When build_repo_matrix runs in consume mode (release_keep_devel=1, release_keep_stable=1)
-      Then release/ce-2.8/amd64 catalog lists BOTH the devel and stable packages
+      Then release/ce-2.8 catalog lists BOTH the devel and stable packages
     """
     out = tmp_path / "site"
     pkg_dir = tmp_path / "pkgs"
@@ -2958,7 +3012,7 @@ def test_consume_mode_empty_pool_skips_release_catalog_no_exception(tmp_path: Pa
        When build_repo_matrix runs with build_nightly=True
       Then NO release catalog is emitted (the release dir is absent or has no packagesite)
        And NO exception is raised
-       And the nightly/ce-2.8/amd64/ catalog IS still built from source
+       And the nightly/ce-2.8/ catalog IS still built from source
     """
     out = tmp_path / "site"
 
@@ -2991,8 +3045,8 @@ def test_consume_mode_nightly_still_built_from_source(tmp_path: Path) -> None:
       Given a pre-built devel .pkg in release_pkgs for ce-2.8
         And build_nightly=True
        When build_repo_matrix runs
-      Then nightly/ce-2.8/amd64/ catalog exists (builder called for 'nightly')
-       And release/ce-2.8/amd64/ catalog lists only the consumed pkg (not a nightly build)
+      Then nightly/ce-2.8/ catalog exists (builder called for 'nightly')
+       And release/ce-2.8/ catalog lists only the consumed pkg (not a nightly build)
     """
     out = tmp_path / "site"
     pkg_dir = tmp_path / "pkgs"
@@ -3037,8 +3091,8 @@ def test_consume_mode_none_reproduces_source_build_path(tmp_path: Path) -> None:
     Scenario: CE 2.8 entry, release_pkgs omitted
       Given build_repo_matrix called WITHOUT release_pkgs (default None)
        When the matrix runs with the stub builder
-      Then release/ce-2.8/amd64/ catalog exists (built via _stub_builder for 'devel')
-       And nightly/ce-2.8/amd64/ catalog exists (built via _stub_builder for 'nightly')
+      Then release/ce-2.8/ catalog exists (built via _stub_builder for 'devel')
+       And nightly/ce-2.8/ catalog exists (built via _stub_builder for 'nightly')
     """
     out = tmp_path / "site"
 
@@ -3067,7 +3121,7 @@ def test_cli_release_pkgs_flag_serves_consumed_catalog(tmp_path: Path) -> None:
         And --release-pkgs ce-2.8:<path> passed on the CLI
        When brp.main is called with --no-nightly
       Then rc == 0
-       And release/ce-2.8/amd64/ catalog exists with the consumed version
+       And release/ce-2.8/ catalog exists with the consumed version
     """
     out = tmp_path / "site"
     pkg_dir = tmp_path / "pkgs"

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -64,7 +64,7 @@ def make_pkg(
     *,
     name: str = "demo",
     version: str = "1.0_1",
-    abi: str = "FreeBSD:15:amd64",
+    abi: str = "FreeBSD:15:*",
     deps: dict[str, dict[str, str]] | None = None,
     extra: dict[str, Any] | None = None,
 ) -> dict:
@@ -190,7 +190,7 @@ def test_meta_conf_is_byte_exact(tmp_path: Path) -> None:
     make_pkg(in_dir / "demo-1.0_1.pkg")
     out = tmp_path / "out"
     brp.build_repo(in_dir, out)
-    bucket = out / "FreeBSD:15:amd64"
+    bucket = out  # arch-less (issue #1806/#1786): catalog lands directly at out_dir
     expected = (
         "version = 2;\n"
         'packing_format = "tzst";\n'
@@ -222,7 +222,7 @@ def test_published_pkg_preserves_source_mtime(tmp_path: Path) -> None:
     out = tmp_path / "out"
     brp.build_repo(in_dir, out)
 
-    dest = out / "FreeBSD:15:amd64" / "demo-1.0_1.pkg"
+    dest = out / "demo-1.0_1.pkg"  # arch-less (issue #1806/#1786): no ABI subdir
     assert dest.is_file()
     assert int(dest.stat().st_mtime) == build_mtime
 
@@ -245,7 +245,7 @@ def test_packagesite_object_order_and_injected_fields(tmp_path: Path) -> None:
     out = tmp_path / "out"
     brp.build_repo(in_dir, out)
 
-    raw = _read_member(out / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml")
+    raw = _read_member(out / "packagesite.pkg", "packagesite.yaml")  # arch-less: flat at out_dir
     assert raw.endswith(b"\n"), "packagesite.yaml is newline-delimited JSON"
     lines = [ln for ln in raw.decode().splitlines() if ln]
     assert len(lines) == 1
@@ -290,7 +290,7 @@ def test_packagesite_is_compact_json_no_spaces(tmp_path: Path) -> None:
     make_pkg(in_dir / "demo-1.0_1.pkg")
     out = tmp_path / "out"
     brp.build_repo(in_dir, out)
-    raw = _read_member(out / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml").decode()
+    raw = _read_member(out / "packagesite.pkg", "packagesite.yaml").decode()
     assert '", "' not in raw and '": "' not in raw  # no ", " / ": " separators
 
 
@@ -306,79 +306,106 @@ def test_data_blob_shape_and_no_trailing_newline(tmp_path: Path) -> None:
     make_pkg(in_dir / "demo-1.0_1.pkg")
     out = tmp_path / "out"
     brp.build_repo(in_dir, out)
-    raw = _read_member(out / "FreeBSD:15:amd64" / "data.pkg", "data")
+    raw = _read_member(out / "data.pkg", "data")  # arch-less: flat at out_dir
     assert not raw.endswith(b"\n"), "data has no trailing newline (matches real pkg repo)"
     obj = json.loads(raw)
     assert obj["groups"] == []
     assert obj["expired_packages"] == []
     assert len(obj["packages"]) == 1
     # The package object equals the packagesite object.
-    psite = json.loads(_read_member(out / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml").decode())
+    psite = json.loads(_read_member(out / "packagesite.pkg", "packagesite.yaml").decode())
     assert obj["packages"][0] == psite
 
 
 # --------------------------------------------------------------------------- #
-# Layout + ABI bucketing + the verbatim .pkg copy
+# Arch-less catalog contract (issue #1786): plain build_repo() is now NO_ARCH-only
+# and flat — every real pfBlockerNG .pkg carries a wildcard ABI (issue #1806), so
+# there is no per-ABI subdirectory to bucket into; a concrete ABI or a mixed-major
+# run is a hard error, mirroring build-repo.sh's require_noarch_abi + "mixed ABIs
+# in one run" guards.
 # --------------------------------------------------------------------------- #
 
 
 def test_layout_and_verbatim_pkg_copy(tmp_path: Path) -> None:
-    """Each <ABI>/ holds the .pkg (byte-verbatim) + the catalog triple + meta."""
+    """A NO_ARCH (wildcard-ABI) pkg emits the catalog DIRECTLY at out_dir — no
+    per-ABI subdirectory — holding the .pkg (byte-verbatim) + the catalog triple
+    + meta."""
     in_dir = tmp_path / "in"
     in_dir.mkdir()
     pkg = in_dir / "demo-1.0_1.pkg"
-    original = make_pkg(pkg)
+    original = make_pkg(pkg, abi="FreeBSD:15:*")
     del original
     out = tmp_path / "out"
     abis = brp.build_repo(in_dir, out)
-    assert abis == ["FreeBSD:15:amd64"]
-    bucket = out / "FreeBSD:15:amd64"
+    assert abis == ["FreeBSD:15:*"]
     for fname in ("meta.conf", "meta", "packagesite.pkg", "data.pkg", "demo-1.0_1.pkg"):
-        assert (bucket / fname).is_file(), f"missing {fname}"
+        assert (out / fname).is_file(), f"missing {fname}"
     # The .pkg is copied verbatim (no re-archiving).
-    assert (bucket / "demo-1.0_1.pkg").read_bytes() == pkg.read_bytes()
+    assert (out / "demo-1.0_1.pkg").read_bytes() == pkg.read_bytes()
+    # No per-ABI subdirectory of any shape is created.
+    assert not (out / "FreeBSD:15:amd64").exists()
+    assert not (out / "FreeBSD:15:*").exists()
 
 
-def test_per_abi_bucketing(tmp_path: Path) -> None:
-    """Two ABIs -> two <ABI>/ subtrees, each catalog scoped to its own ABI's pkg."""
+def test_catalog_name_places_flat_catalog_under_out_dir(tmp_path: Path) -> None:
+    """catalog_name="release/ce-2.8" writes the flat catalog at out_dir/release/ce-2.8/
+    — still no ABI subdir beneath it."""
     in_dir = tmp_path / "in"
     in_dir.mkdir()
-    make_pkg(in_dir / "a15.pkg", name="a", abi="FreeBSD:15:amd64")
-    make_pkg(in_dir / "b16.pkg", name="b", abi="FreeBSD:16:amd64")
+    make_pkg(in_dir / "demo-1.0_1.pkg", abi="FreeBSD:15:*")
     out = tmp_path / "out"
-    abis = brp.build_repo(in_dir, out)
-    assert abis == ["FreeBSD:15:amd64", "FreeBSD:16:amd64"]
-    # Each bucket's packagesite names exactly its own package; its .pkg lands there
-    # under the CANONICAL `<name>-<version>.pkg` (NOT the staging input filename
-    # `a15.pkg`/`b16.pkg`).
-    for abi, pkgname, fname in (("FreeBSD:15:amd64", "a", "a-1.0_1.pkg"), ("FreeBSD:16:amd64", "b", "b-1.0_1.pkg")):
-        raw = _read_member(out / abi / "packagesite.pkg", "packagesite.yaml").decode()
-        objs = [json.loads(ln) for ln in raw.splitlines() if ln]
-        assert [o["name"] for o in objs] == [pkgname]
-        assert [o["path"] for o in objs] == [fname]
-        assert (out / abi / fname).is_file()
+    brp.build_repo(in_dir, out, catalog_name="release/ce-2.8")
+    bucket = out / "release" / "ce-2.8"
+    for fname in ("meta.conf", "meta", "packagesite.pkg", "data.pkg", "demo-1.0_1.pkg"):
+        assert (bucket / fname).is_file(), f"missing {fname}"
+    assert not (bucket / "FreeBSD:15:amd64").exists()
+    assert not (bucket / "FreeBSD:15:*").exists()
+
+
+def test_concrete_abi_pkg_is_rejected(tmp_path: Path) -> None:
+    """A CONCRETE-ABI package (not NO_ARCH) is rejected — the catalog is
+    arch-less/NO_ARCH-only since issue #1806; a concrete-ABI .pkg would silently
+    install on only one arch."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg", abi="FreeBSD:15:amd64")
+    out = tmp_path / "out"
+    with pytest.raises(brp.BuildRepoError, match="NO_ARCH"):
+        brp.build_repo(in_dir, out)
+
+
+def test_mixed_majors_in_one_run_are_rejected(tmp_path: Path) -> None:
+    """Two wildcard-ABI pkgs of DIFFERENT FreeBSD majors in one build_repo() call
+    is a hard error (mirrors build-repo.sh's "mixed ABIs in one run" guard): the
+    caller must filter the input to one major and invoke once per major."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "a15.pkg", name="a", abi="FreeBSD:15:*")
+    make_pkg(in_dir / "b16.pkg", name="b", abi="FreeBSD:16:*")
+    out = tmp_path / "out"
+    with pytest.raises(brp.BuildRepoError, match="mixed"):
+        brp.build_repo(in_dir, out)
 
 
 def test_duplicate_sources_dedup_to_one_canonical(tmp_path: Path) -> None:
     """The SAME package staged from two sources (the publish job's `built-<source>-`
     prefixed copies of the branch build + a release artifact) publishes exactly ONE
     canonical `.pkg` + ONE catalog entry — not two prefixed duplicates (the bug the
-    first live deploy surfaced)."""
+    first live deploy surfaced) — flat at out_dir (arch-less, issue #1806/#1786)."""
     in_dir = tmp_path / "in"
     in_dir.mkdir()
     # Same name+version+ABI+flavor; different staging input filenames.
-    make_pkg(in_dir / "built-incoming_branch-pfb.pkg", name="pfb", version="3.2.16")
-    make_pkg(in_dir / "built-incoming_release-freebsd-pfb.pkg", name="pfb", version="3.2.16")
+    make_pkg(in_dir / "built-incoming_branch-pfb.pkg", name="pfb", version="3.2.16", abi="FreeBSD:15:*")
+    make_pkg(in_dir / "built-incoming_release-freebsd-pfb.pkg", name="pfb", version="3.2.16", abi="FreeBSD:15:*")
     out = tmp_path / "out"
     brp.build_repo(in_dir, out)
-    bucket = out / "FreeBSD:15:amd64"
     # Exactly one package .pkg on disk, canonically named (no `built-incoming_*`
     # prefix); the catalog files (packagesite.pkg/data.pkg) also end in `.pkg`.
     catalog_files = {"packagesite.pkg", "data.pkg", "meta.pkg"}
-    pkgs = sorted(p.name for p in bucket.glob("*.pkg") if p.name not in catalog_files)
+    pkgs = sorted(p.name for p in out.glob("*.pkg") if p.name not in catalog_files)
     assert pkgs == ["pfb-3.2.16.pkg"]
     # The catalog lists it once, at the canonical path/repopath.
-    raw = _read_member(bucket / "packagesite.pkg", "packagesite.yaml").decode()
+    raw = _read_member(out / "packagesite.pkg", "packagesite.yaml").decode()
     objs = [json.loads(ln) for ln in raw.splitlines() if ln]
     assert len(objs) == 1
     assert objs[0]["path"] == "pfb-3.2.16.pkg"
@@ -399,8 +426,8 @@ def test_deterministic_two_runs_byte_identical(tmp_path: Path) -> None:
     brp.build_repo(in_dir, out1)
     brp.build_repo(in_dir, out2)
     for rel in ("meta.conf", "meta", "packagesite.pkg", "data.pkg", "demo-1.0_1.pkg"):
-        a = (out1 / "FreeBSD:15:amd64" / rel).read_bytes()
-        b = (out2 / "FreeBSD:15:amd64" / rel).read_bytes()
+        a = (out1 / rel).read_bytes()
+        b = (out2 / rel).read_bytes()
         assert a == b, f"{rel} differs between runs"
 
 
@@ -412,12 +439,12 @@ def test_rebuild_wipes_removed_pkg(tmp_path: Path) -> None:
     make_pkg(in_dir / "b-1.0.pkg", name="b")
     out = tmp_path / "out"
     brp.build_repo(in_dir, out)
-    assert (out / "FreeBSD:15:amd64" / "b-1.0_1.pkg").is_file()  # canonical <name>-<version>
+    assert (out / "b-1.0_1.pkg").is_file()  # canonical <name>-<version>, flat at out_dir
     # Remove one input and rebuild.
     (in_dir / "b-1.0.pkg").unlink()
     brp.build_repo(in_dir, out)
-    assert not (out / "FreeBSD:15:amd64" / "b-1.0_1.pkg").exists(), "stale .pkg lingered after rebuild"
-    raw = _read_member(out / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml").decode()
+    assert not (out / "b-1.0_1.pkg").exists(), "stale .pkg lingered after rebuild"
+    raw = _read_member(out / "packagesite.pkg", "packagesite.yaml").decode()
     assert [json.loads(ln)["name"] for ln in raw.splitlines() if ln] == ["a"]
 
 
@@ -446,22 +473,23 @@ def test_same_flavor_duplicate_passes(tmp_path: Path) -> None:
     make_pkg(in_dir / "x-b.pkg", name="x", version="1.0", deps=deps)
     out = tmp_path / "out"
     abis = brp.build_repo(in_dir, out)  # must not raise
-    assert abis == ["FreeBSD:15:amd64"]
+    assert abis == ["FreeBSD:15:*"]
 
 
 def test_unsafe_abi_is_rejected(tmp_path: Path) -> None:
-    """A traversal/odd ABI in manifest data is rejected BEFORE it becomes a path
-    segment — `out_dir / abi` is rmtree'd + rebuilt, so an unsafe value could escape
-    out_dir. The valid form (`FreeBSD:15:amd64`, with colons) is accepted by every
-    other test, so this pins the reject side of the branch."""
-    # Non-empty but unsafe values (traversal / slash / space) — an empty ABI is
-    # already rejected upstream by the missing-name/version/abi guard.
+    """A traversal/odd (and, since issue #1786, any non-wildcard) ABI in manifest
+    data is rejected. The ABI is no longer used as a directory name (arch-less
+    catalog), but every one of these shapes still fails ``_is_wildcard_abi`` and
+    is rejected by the NO_ARCH gate — the valid wildcard form (`FreeBSD:15:*`) is
+    accepted by every other test, so this pins the reject side of the branch."""
+    # Non-empty but unsafe/non-wildcard values (traversal / slash / space) — an
+    # empty ABI is already rejected upstream by the missing-name/version/abi guard.
     out = tmp_path / "out"
     for i, bad in enumerate(("../../evil", "FreeBSD/15/amd64", "a b")):
         in_dir = tmp_path / f"in{i}"
         in_dir.mkdir()
         make_pkg(in_dir / "p.pkg", name="p", version="1.0", abi=bad)
-        with pytest.raises(brp.BuildRepoError, match="unsafe or invalid ABI"):
+        with pytest.raises(brp.BuildRepoError, match="NO_ARCH"):
             brp.build_repo(in_dir, out)
 
 
@@ -590,17 +618,17 @@ def test_catalog_name_from_version() -> None:
 
 
 def test_catalog_under_versioned_subdir(tmp_path: Path) -> None:
-    """--catalog-name writes the ABI tree under <out>/<catalog-name>/<ABI>/, not <out>/<ABI>/.
+    """--catalog-name writes the FLAT catalog directly at <out>/<catalog-name>/, no ABI subdir.
 
     Scenario: CE 2.8 build
       Given no ce-2.8/ dir exists in <out>
-      When build_repo(catalog_name="ce-2.8") is called with a CE pkg (ABI=FreeBSD:15:amd64)
-      Then meta.conf exists at ce-2.8/FreeBSD:15:amd64/meta.conf
-      And no meta.conf exists at the plain FreeBSD:15:amd64/meta.conf (root-level)
+      When build_repo(catalog_name="ce-2.8") is called with a CE NO_ARCH pkg (ABI=FreeBSD:15:*)
+      Then meta.conf exists at ce-2.8/meta.conf
+      And no meta.conf exists at the plain root-level out/meta.conf
     """
     in_dir = tmp_path / "in"
     in_dir.mkdir()
-    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:amd64")
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
     out = tmp_path / "out"
     out.mkdir()
 
@@ -609,24 +637,24 @@ def test_catalog_under_versioned_subdir(tmp_path: Path) -> None:
 
     brp.build_repo(in_dir, out, catalog_name="ce-2.8")
 
-    # Versioned path exists
-    assert (out / "ce-2.8" / "FreeBSD:15:amd64" / "meta.conf").is_file()
-    # Legacy root-level path does NOT exist
-    assert not (out / "FreeBSD:15:amd64" / "meta.conf").exists()
+    # Versioned path exists, flat (no ABI subdir)
+    assert (out / "ce-2.8" / "meta.conf").is_file()
+    # Root-level path does NOT exist
+    assert not (out / "meta.conf").exists()
 
 
 def test_plus_catalog_under_versioned_subdir(tmp_path: Path) -> None:
-    """--catalog-name plus-26.03 writes under plus-26.03/<ABI>/, no ce-2.8/ dir created.
+    """--catalog-name plus-26.03 writes flat under plus-26.03/, no ce-2.8/ dir created.
 
     Scenario: Plus 26.03 build
       Given no plus-26.03/ or ce-2.8/ dir exists
-      When build_repo(catalog_name="plus-26.03") with Plus pkg (ABI=FreeBSD:16:amd64)
-      Then meta.conf at plus-26.03/FreeBSD:16:amd64/meta.conf
+      When build_repo(catalog_name="plus-26.03") with Plus NO_ARCH pkg (ABI=FreeBSD:16:*)
+      Then meta.conf at plus-26.03/meta.conf
       And no ce-2.8/ dir exists
     """
     in_dir = tmp_path / "in"
     in_dir.mkdir()
-    make_pkg(in_dir / "plus-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:16:amd64")
+    make_pkg(in_dir / "plus-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:16:*")
     out = tmp_path / "out"
     out.mkdir()
 
@@ -636,24 +664,25 @@ def test_plus_catalog_under_versioned_subdir(tmp_path: Path) -> None:
 
     brp.build_repo(in_dir, out, catalog_name="plus-26.03")
 
-    assert (out / "plus-26.03" / "FreeBSD:16:amd64" / "meta.conf").is_file()
+    assert (out / "plus-26.03" / "meta.conf").is_file()
     # CE dir must NOT have been created as a side-effect
     assert not (out / "ce-2.8").exists()
 
 
 def test_legacy_path_retained(tmp_path: Path) -> None:
-    """Without --catalog-name, meta.conf lands at <out>/<ABI>/meta.conf (legacy layout unchanged).
+    """Without --catalog-name, meta.conf lands DIRECTLY at <out>/meta.conf (flat, arch-less).
 
-    This is the regression guard: passing catalog_name=None must NOT change existing behaviour.
+    This is the regression guard: passing catalog_name=None must NOT change existing behaviour
+    beyond the arch-less layout change (issue #1806/#1786).
     """
     in_dir = tmp_path / "in"
     in_dir.mkdir()
-    make_pkg(in_dir / "demo.pkg", abi="FreeBSD:15:amd64")
+    make_pkg(in_dir / "demo.pkg", abi="FreeBSD:15:*")
     out = tmp_path / "out"
 
     brp.build_repo(in_dir, out)  # no catalog_name
 
-    assert (out / "FreeBSD:15:amd64" / "meta.conf").is_file()
+    assert (out / "meta.conf").is_file()
     # No versioned subdirs created
     assert not (out / "ce-2.8").exists()
     assert not (out / "plus-26.03").exists()
@@ -663,8 +692,8 @@ def test_wrong_variant_pkg_excluded(tmp_path: Path) -> None:
     """A CE pkg built into ce-2.8/ does NOT appear in plus-26.03/ and vice-versa.
 
     Scenario: cross-variant contamination guard
-      Given a CE pkg named "pfBlockerNG-ce" (ABI FreeBSD:15:amd64)
-        And a Plus pkg named "pfBlockerNG-plus" (ABI FreeBSD:16:amd64)
+      Given a CE pkg named "pfBlockerNG-ce" (NO_ARCH ABI FreeBSD:15:*)
+        And a Plus pkg named "pfBlockerNG-plus" (NO_ARCH ABI FreeBSD:16:*)
       When each is built into its own versioned catalog dir
       Then the CE packagesite contains only "pfBlockerNG-ce"
        And the Plus packagesite contains only "pfBlockerNG-plus"
@@ -675,43 +704,43 @@ def test_wrong_variant_pkg_excluded(tmp_path: Path) -> None:
     ce_dir.mkdir()
     plus_dir = tmp_path / "plus_in"
     plus_dir.mkdir()
-    make_pkg(ce_dir / "ce.pkg", name="pfBlockerNG-ce", abi="FreeBSD:15:amd64")
-    make_pkg(plus_dir / "plus.pkg", name="pfBlockerNG-plus", abi="FreeBSD:16:amd64")
+    make_pkg(ce_dir / "ce.pkg", name="pfBlockerNG-ce", abi="FreeBSD:15:*")
+    make_pkg(plus_dir / "plus.pkg", name="pfBlockerNG-plus", abi="FreeBSD:16:*")
     out = tmp_path / "out"
 
     brp.build_repo(ce_dir, out, catalog_name="ce-2.8")
     brp.build_repo(plus_dir, out, catalog_name="plus-26.03")
 
     # CE packagesite names
-    ce_raw = _read_member(out / "ce-2.8" / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml").decode()
+    ce_raw = _read_member(out / "ce-2.8" / "packagesite.pkg", "packagesite.yaml").decode()
     ce_names = {json.loads(ln)["name"] for ln in ce_raw.splitlines() if ln}
     assert "pfBlockerNG-ce" in ce_names
     assert "pfBlockerNG-plus" not in ce_names
 
     # Plus packagesite names
-    plus_raw = _read_member(out / "plus-26.03" / "FreeBSD:16:amd64" / "packagesite.pkg", "packagesite.yaml").decode()
+    plus_raw = _read_member(out / "plus-26.03" / "packagesite.pkg", "packagesite.yaml").decode()
     plus_names = {json.loads(ln)["name"] for ln in plus_raw.splitlines() if ln}
     assert "pfBlockerNG-plus" in plus_names
     assert "pfBlockerNG-ce" not in plus_names
 
 
 def test_two_ce_entries_produce_two_versioned_dirs(tmp_path: Path) -> None:
-    """Two CE builds (different versions, different ABIs) each get their own versioned dir.
+    """Two CE builds (different versions, different majors) each get their own flat versioned dir.
 
     Scenario: transition window with two active CE versions
       Given no ce-2.8/ or ce-2.9/ dir exists
-      When build_repo(catalog_name="ce-2.8") with ABI=FreeBSD:15:amd64
-       And build_repo(catalog_name="ce-2.9") with ABI=FreeBSD:16:amd64
-      Then ce-2.8/FreeBSD:15:amd64/meta.conf exists
-       And ce-2.9/FreeBSD:16:amd64/meta.conf exists
+      When build_repo(catalog_name="ce-2.8") with NO_ARCH ABI=FreeBSD:15:*
+       And build_repo(catalog_name="ce-2.9") with NO_ARCH ABI=FreeBSD:16:*
+      Then ce-2.8/meta.conf exists
+       And ce-2.9/meta.conf exists
        And each packagesite contains only its own pkg (no cross-contamination)
     """
     in28 = tmp_path / "in28"
     in28.mkdir()
     in29 = tmp_path / "in29"
     in29.mkdir()
-    make_pkg(in28 / "pkg28.pkg", name="pfBlockerNG-2.8", abi="FreeBSD:15:amd64")
-    make_pkg(in29 / "pkg29.pkg", name="pfBlockerNG-2.9", abi="FreeBSD:16:amd64")
+    make_pkg(in28 / "pkg28.pkg", name="pfBlockerNG-2.8", abi="FreeBSD:15:*")
+    make_pkg(in29 / "pkg29.pkg", name="pfBlockerNG-2.9", abi="FreeBSD:16:*")
     out = tmp_path / "out"
 
     # Before-state: neither dir exists
@@ -721,15 +750,15 @@ def test_two_ce_entries_produce_two_versioned_dirs(tmp_path: Path) -> None:
     brp.build_repo(in28, out, catalog_name="ce-2.8")
     brp.build_repo(in29, out, catalog_name="ce-2.9")
 
-    assert (out / "ce-2.8" / "FreeBSD:15:amd64" / "meta.conf").is_file()
-    assert (out / "ce-2.9" / "FreeBSD:16:amd64" / "meta.conf").is_file()
+    assert (out / "ce-2.8" / "meta.conf").is_file()
+    assert (out / "ce-2.9" / "meta.conf").is_file()
 
     # No cross-contamination: each packagesite has only its pkg
-    raw28 = _read_member(out / "ce-2.8" / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml").decode()
+    raw28 = _read_member(out / "ce-2.8" / "packagesite.pkg", "packagesite.yaml").decode()
     names28 = [json.loads(ln)["name"] for ln in raw28.splitlines() if ln]
     assert names28 == ["pfBlockerNG-2.8"]
 
-    raw29 = _read_member(out / "ce-2.9" / "FreeBSD:16:amd64" / "packagesite.pkg", "packagesite.yaml").decode()
+    raw29 = _read_member(out / "ce-2.9" / "packagesite.pkg", "packagesite.yaml").decode()
     names29 = [json.loads(ln)["name"] for ln in raw29.splitlines() if ln]
     assert names29 == ["pfBlockerNG-2.9"]
 
@@ -759,18 +788,18 @@ def test_catalog_name_from_version_nightly() -> None:
 
 
 def test_nightly_catalog_under_versioned_subdir(tmp_path: Path) -> None:
-    """build_repo with catalog_name="nightly/ce-2.8" writes tree under nightly/ce-2.8/<ABI>/.
+    """build_repo with catalog_name="nightly/ce-2.8" writes the flat tree under nightly/ce-2.8/.
 
     Scenario: nightly CE build
       Given no nightly/ dir exists in <out>
-      When build_repo(catalog_name="nightly/ce-2.8") with a CE pkg (ABI=FreeBSD:15:amd64)
-      Then meta.conf exists at nightly/ce-2.8/FreeBSD:15:amd64/meta.conf
-       And no meta.conf exists at ce-2.8/FreeBSD:15:amd64/meta.conf (release path untouched)
-       And no meta.conf exists at FreeBSD:15:amd64/meta.conf (legacy root untouched)
+      When build_repo(catalog_name="nightly/ce-2.8") with a CE NO_ARCH pkg (ABI=FreeBSD:15:*)
+      Then meta.conf exists at nightly/ce-2.8/meta.conf
+       And no meta.conf exists at ce-2.8/meta.conf (release path untouched)
+       And no meta.conf exists at the legacy root out/meta.conf
     """
     in_dir = tmp_path / "in"
     in_dir.mkdir()
-    make_pkg(in_dir / "nightly-ce.pkg", name="pfBlockerNG-nightly", abi="FreeBSD:15:amd64")
+    make_pkg(in_dir / "nightly-ce.pkg", name="pfBlockerNG-nightly", abi="FreeBSD:15:*")
     out = tmp_path / "out"
     out.mkdir()
 
@@ -779,31 +808,31 @@ def test_nightly_catalog_under_versioned_subdir(tmp_path: Path) -> None:
 
     brp.build_repo(in_dir, out, catalog_name="nightly/ce-2.8")
 
-    # Nightly versioned path exists
-    assert (out / "nightly" / "ce-2.8" / "FreeBSD:15:amd64" / "meta.conf").is_file()
+    # Nightly versioned path exists, flat (no ABI subdir)
+    assert (out / "nightly" / "ce-2.8" / "meta.conf").is_file()
     # Release path NOT created as side-effect
     assert not (out / "ce-2.8").exists()
-    # Legacy root-level ABI path NOT created
-    assert not (out / "FreeBSD:15:amd64" / "meta.conf").exists()
+    # Legacy root-level path NOT created
+    assert not (out / "meta.conf").exists()
 
 
 def test_nightly_plus_catalog_under_versioned_subdir(tmp_path: Path) -> None:
-    """build_repo with catalog_name="nightly/plus-26.03" writes under nightly/plus-26.03/<ABI>/.
+    """build_repo with catalog_name="nightly/plus-26.03" writes flat under nightly/plus-26.03/.
 
     Scenario: nightly Plus build, nightly CE build in same output tree
       Given no nightly/ dir exists
-      When build_repo(catalog_name="nightly/ce-2.8") with CE pkg (FreeBSD:15:amd64)
-       And build_repo(catalog_name="nightly/plus-26.03") with Plus pkg (FreeBSD:16:amd64)
-      Then nightly/ce-2.8/FreeBSD:15:amd64/meta.conf exists
-       And nightly/plus-26.03/FreeBSD:16:amd64/meta.conf exists
+      When build_repo(catalog_name="nightly/ce-2.8") with CE NO_ARCH pkg (FreeBSD:15:*)
+       And build_repo(catalog_name="nightly/plus-26.03") with Plus NO_ARCH pkg (FreeBSD:16:*)
+      Then nightly/ce-2.8/meta.conf exists
+       And nightly/plus-26.03/meta.conf exists
        And the CE and Plus nightly packagesite contents do not cross-contaminate
     """
     ce_dir = tmp_path / "ce_in"
     ce_dir.mkdir()
     plus_dir = tmp_path / "plus_in"
     plus_dir.mkdir()
-    make_pkg(ce_dir / "ce-nightly.pkg", name="pfBlockerNG-nightly-ce", abi="FreeBSD:15:amd64")
-    make_pkg(plus_dir / "plus-nightly.pkg", name="pfBlockerNG-nightly-plus", abi="FreeBSD:16:amd64")
+    make_pkg(ce_dir / "ce-nightly.pkg", name="pfBlockerNG-nightly-ce", abi="FreeBSD:15:*")
+    make_pkg(plus_dir / "plus-nightly.pkg", name="pfBlockerNG-nightly-plus", abi="FreeBSD:16:*")
     out = tmp_path / "out"
 
     # Before-state: no nightly dir
@@ -812,19 +841,15 @@ def test_nightly_plus_catalog_under_versioned_subdir(tmp_path: Path) -> None:
     brp.build_repo(ce_dir, out, catalog_name="nightly/ce-2.8")
     brp.build_repo(plus_dir, out, catalog_name="nightly/plus-26.03")
 
-    assert (out / "nightly" / "ce-2.8" / "FreeBSD:15:amd64" / "meta.conf").is_file()
-    assert (out / "nightly" / "plus-26.03" / "FreeBSD:16:amd64" / "meta.conf").is_file()
+    assert (out / "nightly" / "ce-2.8" / "meta.conf").is_file()
+    assert (out / "nightly" / "plus-26.03" / "meta.conf").is_file()
 
-    ce_raw = _read_member(
-        out / "nightly" / "ce-2.8" / "FreeBSD:15:amd64" / "packagesite.pkg", "packagesite.yaml"
-    ).decode()
+    ce_raw = _read_member(out / "nightly" / "ce-2.8" / "packagesite.pkg", "packagesite.yaml").decode()
     ce_names = {json.loads(ln)["name"] for ln in ce_raw.splitlines() if ln}
     assert "pfBlockerNG-nightly-ce" in ce_names
     assert "pfBlockerNG-nightly-plus" not in ce_names
 
-    plus_raw = _read_member(
-        out / "nightly" / "plus-26.03" / "FreeBSD:16:amd64" / "packagesite.pkg", "packagesite.yaml"
-    ).decode()
+    plus_raw = _read_member(out / "nightly" / "plus-26.03" / "packagesite.pkg", "packagesite.yaml").decode()
     plus_names = {json.loads(ln)["name"] for ln in plus_raw.splitlines() if ln}
     assert "pfBlockerNG-nightly-plus" in plus_names
     assert "pfBlockerNG-nightly-ce" not in plus_names


### PR DESCRIPTION
## Summary

Fixes the red nightly repo-install smoke (run [30694709784](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/30694709784), all three legs) — triage evidence on the issue. Two devel regressions plus the stale Tier-B suite:

1. **`build-repo-portable.py` plain (`--in`/`--out`) mode** still bucketed catalogs per-ABI and rejected the NO_ARCH wildcard ABI (`FreeBSD:<major>:*`) every real package carries since #1806 (`unsafe or invalid ABI segment 'FreeBSD:16:*'`). Plain mode now mirrors `build-repo.sh`: wildcard ABI required, mixed majors rejected loudly, catalog emitted flat at `<out>[/<catalog-name>]/` via `_emit_catalog_from_paths`. `_ABI_RE` is removed — an ABI is no longer a path segment anywhere in plain mode.
2. **Pre-release varver defect (production, consumer side):** on a `26.07-BETA` box the rc.d repo-generate hook derived `plus-26.07-BETA` (`cut -d. -f1,2` keeps a dash suffix inside the minor field), mismatching the matrix-keyed published catalog (`plus-26.07`) and `build-repo.sh`'s varver guard. The hook now strips the dash suffix before taking major.minor.
3. **`tests/smoke/test_repo_install.py` (+ the live-nightly URL test)** reconciled with the arch-less layout: varver oracle mirrors the fixed hook (varver only, dash-strip), helpers expect `release/<varver>/` directly, wrong-variant forge uses a wildcard ABI, EOL/generate-hook/live-Pages tests drop the arch segment, `poll_catalog_served` takes the caller's catalog path, and the retired `${ABI}` conf template in `test_nightly_install.py` is replaced with the fully resolved URL. `test_legacy_abi_path_still_upgrades` is deleted — its premise (legacy `${ABI}/` conf transition window) was explicitly retired by #1806; N→N+1 upgrade coverage remains in `test_pkg_upgrade_moves_to_our_newer_build`.

## Test evidence

- **Red (executed):** nightly run 30694709784 is the executed red for the suite rework; the two production fixes carry their own red→green proofs — 5 plain-mode contract tests red on the untouched script (`unsafe or invalid ABI segment` / `DID NOT RAISE`), and shellspec cases `26.07-BETA` + `2.9-RC` proven discriminating against the pre-fix `cut` (run against a reverted copy).
- **Green (hermetic):** `run-gates.sh` PASS (pytest 4801-suite, ruff, mypy, shellcheck, shellspec 34/34).
- **Green (live):** local live-VM run of the `repo` marker on a leased box is in flight; result will be posted as a comment before merge.

Part of #1786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Architecture-independent packages now use a single, flat repository catalog.
  * Catalog paths now use clean major/minor release versions without pre-release suffixes such as `-BETA` or `-RC`.

* **Bug Fixes**
  * Invalid architecture combinations are rejected during catalog generation.
  * Repository installation and nightly catalog resolution now work with the updated layout.

* **Tests**
  * Expanded coverage for version handling, catalog generation, validation, and installation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->