### PR TITLE
ci: close failure trackers on recovery

### DIFF
--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -67,10 +67,29 @@ jobs:
           fi
 
           FAILURE_RUN=$(gh issue view "$MATCH" --repo "$REPO" --json body \
-            --jq '.body | try capture("<!-- failure-run: (?<run>[0-9]+):(?<attempt>[0-9]+) -->") | "\(.run) \(.attempt)"')
-          if [ -n "$FAILURE_RUN" ]; then
+            --jq '(.body // "")
+              | if contains("<!-- failure-run:") | not then "legacy"
+                elif (split("<!-- failure-run:") | length) != 2 then "malformed"
+                else ([capture("<!-- failure-run: (?<run>[0-9]+):(?<attempt>[0-9]+) -->")]
+                  | if length == 1 then "\(.[0].run) \(.[0].attempt)" else "malformed" end)
+                end')
+          if [ "$FAILURE_RUN" = "malformed" ]; then
+            echo "[noop] Tracking issue has malformed failure-run metadata"
+            exit 0
+          fi
+          if [ -n "$FAILURE_RUN" ] && [ "$FAILURE_RUN" != "legacy" ]; then
             FAILURE_RUN_NUMBER=${FAILURE_RUN%% *}
             FAILURE_RUN_ATTEMPT=${FAILURE_RUN#* }
+            case "${FAILURE_RUN_NUMBER}${FAILURE_RUN_ATTEMPT}" in
+              ""|*[!0-9]*)
+                echo "[noop] Tracking issue has malformed failure-run metadata"
+                exit 0
+                ;;
+            esac
+            if [ "${#FAILURE_RUN_NUMBER}" -gt 18 ] || [ "${#FAILURE_RUN_ATTEMPT}" -gt 18 ]; then
+              echo "[noop] Tracking issue has oversized failure-run metadata"
+              exit 0
+            fi
             if [ "$RUN_NUMBER" -lt "$FAILURE_RUN_NUMBER" ] ||
               { [ "$RUN_NUMBER" -eq "$FAILURE_RUN_NUMBER" ] &&
                 [ "$RUN_ATTEMPT" -le "$FAILURE_RUN_ATTEMPT" ]; }; then
@@ -154,8 +173,12 @@ jobs:
                  | .[0].number // empty')
 
           if [ -n "$MATCH" ]; then
-            echo "[update] Updating tracking issue #${MATCH}"
-            gh issue edit "$MATCH" --repo "$REPO" --body-file "$BODY_FILE"
+            if [ -n "$DRILL" ]; then
+              echo "[noop] Manual drill did not overwrite tracking issue #${MATCH}"
+            else
+              echo "[update] Updating tracking issue #${MATCH}"
+              gh issue edit "$MATCH" --repo "$REPO" --body-file "$BODY_FILE"
+            fi
           else
             echo "[create] Opening tracking issue"
             gh issue create \

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -1,13 +1,9 @@
 name: Nightly failure alert
 
 # File ONE deduped tracking issue when a NIGHTLY (schedule-triggered) run of a
-# live-VM suite fails, then close it when that suite next passes, so a red
-# nightly becomes a work item instead of waiting for someone to notice. Issue
-# #820 sat red DAILY for 8 days (2026-06-26 ->
-# 07-04, a real config-loss bug shipping in alphas) precisely because nothing
-# watches these: smoke/ui/repo-install are schedule+dispatch only (no PR gate),
-# and dispatch failures are already watched by whoever dispatched them — so
-# this alerts on the `schedule` event only.
+# live-VM suite fails, then close it when that suite next passes. These suites
+# are schedule+dispatch only (no PR gate), and dispatch failures are already
+# watched by whoever dispatched them — so this alerts on `schedule` only.
 #
 # Pattern follows top1m-healthcheck.yml's alert job (dedup by label + exact
 # title, update-in-place). WHY workflow_run and not an `if: failure()` job in
@@ -51,6 +47,8 @@ jobs:
       REPO: ${{ github.repository }}
       WF_NAME: ${{ github.event.workflow_run.name }}
       RUN_URL: ${{ github.event.workflow_run.html_url }}
+      RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+      RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
       BRANCH: ${{ github.event.workflow_run.head_branch }}
     steps:
       - name: Close the recovered tracking issue
@@ -66,6 +64,19 @@ jobs:
           if [ -z "$MATCH" ]; then
             echo "[noop] No open tracking issue for ${WF_NAME}"
             exit 0
+          fi
+
+          FAILURE_RUN=$(gh issue view "$MATCH" --repo "$REPO" --json body \
+            --jq '.body | try capture("<!-- failure-run: (?<run>[0-9]+):(?<attempt>[0-9]+) -->") | "\(.run) \(.attempt)"')
+          if [ -n "$FAILURE_RUN" ]; then
+            FAILURE_RUN_NUMBER=${FAILURE_RUN%% *}
+            FAILURE_RUN_ATTEMPT=${FAILURE_RUN#* }
+            if [ "$RUN_NUMBER" -lt "$FAILURE_RUN_NUMBER" ] ||
+              { [ "$RUN_NUMBER" -eq "$FAILURE_RUN_NUMBER" ] &&
+                [ "$RUN_ATTEMPT" -le "$FAILURE_RUN_ATTEMPT" ]; }; then
+              echo "[noop] Successful run is not newer than tracking issue failure"
+              exit 0
+            fi
           fi
 
           echo "[close] Closing recovered tracking issue #${MATCH}"
@@ -94,6 +105,8 @@ jobs:
       # Dispatch drill: the run link points at THIS run, clearly labeled below.
       WF_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_name || github.event.workflow_run.name }}
       RUN_URL: ${{ github.event_name == 'workflow_dispatch' && format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) || github.event.workflow_run.html_url }}
+      RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+      RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
       HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
       # Nightlies run on the default branch; read it from the payload rather than
       # hardcoding it (PR #958 review) — the title doubles as the dedup key.
@@ -117,6 +130,9 @@ jobs:
 
           BODY_FILE=$(mktemp)
           {
+            if [ -n "${RUN_NUMBER:-}" ]; then
+              printf '<!-- failure-run: %s:%s -->\n\n' "$RUN_NUMBER" "${RUN_ATTEMPT:-}"
+            fi
             printf '## Nightly run failed: %s\n\n' "$WF_NAME"
             if [ -n "$DRILL" ]; then
               printf '**DRILL** — manual red-path test of the alert wiring, not a real failure. Close me.\n\n'

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -1,8 +1,9 @@
 name: Nightly failure alert
 
 # File ONE deduped tracking issue when a NIGHTLY (schedule-triggered) run of a
-# live-VM suite fails, so a red nightly becomes a work item instead of waiting
-# for someone to notice. Issue #820 sat red DAILY for 8 days (2026-06-26 ->
+# live-VM suite fails, then close it when that suite next passes, so a red
+# nightly becomes a work item instead of waiting for someone to notice. Issue
+# #820 sat red DAILY for 8 days (2026-06-26 ->
 # 07-04, a real config-loss bug shipping in alphas) precisely because nothing
 # watches these: smoke/ui/repo-install are schedule+dispatch only (no PR gate),
 # and dispatch failures are already watched by whoever dispatched them — so
@@ -35,6 +36,42 @@ permissions:
   contents: read
 
 jobs:
+  recovery:
+    name: Close the recovered nightly-red tracking issue
+    concurrency:
+      group: nightly-red-${{ github.event.workflow_run.name }}
+    if: >-
+      (github.event.workflow_run.event == 'schedule' &&
+       github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      WF_NAME: ${{ github.event.workflow_run.name }}
+      RUN_URL: ${{ github.event.workflow_run.html_url }}
+      BRANCH: ${{ github.event.workflow_run.head_branch }}
+    steps:
+      - name: Close the recovered tracking issue
+        run: |
+          set -euo pipefail
+          TITLE="[nightly-red] ${WF_NAME} failing on ${BRANCH}"
+          MATCH=$(gh issue list --repo "$REPO" --state open \
+            --label "nightly-red" --limit 500 --json number,title,state \
+            | jq -r --arg t "$TITLE" \
+                '[.[] | select(.title == $t)] | sort_by(.number)
+                 | .[0].number // empty')
+
+          if [ -z "$MATCH" ]; then
+            echo "[noop] No open tracking issue for ${WF_NAME}"
+            exit 0
+          fi
+
+          echo "[close] Closing recovered tracking issue #${MATCH}"
+          gh issue close "$MATCH" --repo "$REPO" --reason completed \
+            --comment "Recovered automatically after successful run: ${RUN_URL}"
+
   alert:
     name: Open/update the nightly-red tracking issue
     # Serialize per workflow name: the list-then-create dedup is check-then-act,
@@ -89,7 +126,7 @@ jobs:
             printf 'Triage: read the run'"'"'s failing job logs + its diagnostics artifact first '
             printf '(CLAUDE.md "Smoke tests"). If the failure is a devel regression, fix it on a '
             printf 'branch and close this; if flaky, say so here with the evidence.\n\n'
-            printf '_Opened automatically by the nightly-failure-alert workflow. Updated in place on every red nightly; closes manually with the fix._\n'
+            printf '_Opened automatically by the nightly-failure-alert workflow. Updated in place on every red nightly; closes automatically after the next successful scheduled run._\n'
           } > "$BODY_FILE"
 
           # Dedup open issues by label + exact title (top1m-healthcheck pattern,

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -95,11 +95,46 @@ jobs:
           fi
           python3 scripts/misc/check_top1m_providers.py "${args[@]}"
 
-  # ── 3. On any failed leg, open/update ONE deduped tracking issue ──────────
+  # ── 3. On a green run, close the matching open tracking issue ─────────────
+  recovery:
+    name: Close the recovered Top1M provider tracker
+    needs: check
+    if: success()
+    concurrency:
+      group: top1m-provider-alert
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Close the recovered tracking issue
+        run: |
+          set -euo pipefail
+          TITLE="[top1m-healthcheck] provider URL unhealthy"
+          MATCH=$(gh issue list --repo "$REPO" --state open \
+            --label "top1m-provider" --limit 500 --json number,title,state \
+            | jq -r --arg t "$TITLE" \
+                '[.[] | select(.title == $t)] | sort_by(.number)
+                 | .[0].number // empty')
+
+          if [ -z "$MATCH" ]; then
+            echo "[noop] No open Top1M provider tracking issue"
+            exit 0
+          fi
+
+          echo "[close] Closing recovered tracking issue #${MATCH}"
+          gh issue close "$MATCH" --repo "$REPO" --reason completed \
+            --comment "Recovered automatically after successful run: ${RUN_URL}"
+
   alert:
     name: Alert on unhealthy provider(s)
     needs: check
     if: failure()
+    concurrency:
+      group: top1m-provider-alert
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -163,7 +198,7 @@ jobs:
             fi
           done
 
-          printf '_Opened automatically by the top1m-healthcheck workflow._\n' >> "$BODY_FILE"
+          printf '_Opened automatically by the top1m-healthcheck workflow. Closes automatically after the next successful run._\n' >> "$BODY_FILE"
           echo "body_file=${BODY_FILE}" >> "$GITHUB_OUTPUT"
 
       - name: Ensure the tracking label exists

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -109,6 +109,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      RUN_NUMBER: ${{ github.run_number }}
+      RUN_ATTEMPT: ${{ github.run_attempt }}
     steps:
       - name: Close the recovered tracking issue
         run: |
@@ -123,6 +125,19 @@ jobs:
           if [ -z "$MATCH" ]; then
             echo "[noop] No open Top1M provider tracking issue"
             exit 0
+          fi
+
+          FAILURE_RUN=$(gh issue view "$MATCH" --repo "$REPO" --json body \
+            --jq '.body | try capture("<!-- failure-run: (?<run>[0-9]+):(?<attempt>[0-9]+) -->") | "\(.run) \(.attempt)"')
+          if [ -n "$FAILURE_RUN" ]; then
+            FAILURE_RUN_NUMBER=${FAILURE_RUN%% *}
+            FAILURE_RUN_ATTEMPT=${FAILURE_RUN#* }
+            if [ "$RUN_NUMBER" -lt "$FAILURE_RUN_NUMBER" ] ||
+              { [ "$RUN_NUMBER" -eq "$FAILURE_RUN_NUMBER" ] &&
+                [ "$RUN_ATTEMPT" -le "$FAILURE_RUN_ATTEMPT" ]; }; then
+              echo "[noop] Successful run is not newer than tracking issue failure"
+              exit 0
+            fi
           fi
 
           echo "[close] Closing recovered tracking issue #${MATCH}"
@@ -143,6 +158,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      RUN_NUMBER: ${{ github.run_number }}
+      RUN_ATTEMPT: ${{ github.run_attempt }}
       # See the "check" job -- same secret, same derivation rule.
       CLOUDFLARE_RADAR_TOKEN: ${{ secrets.CLOUDFLARE_RADAR_TOKEN }}
     steps:
@@ -163,6 +180,7 @@ jobs:
 
           BODY_FILE=$(mktemp)
           {
+            printf '<!-- failure-run: %s:%s -->\n\n' "$RUN_NUMBER" "$RUN_ATTEMPT"
             printf '## Top1M provider health check failed\n\n'
             printf 'Run: %s\n\n' "$RUN_URL"
           } > "$BODY_FILE"

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -128,10 +128,29 @@ jobs:
           fi
 
           FAILURE_RUN=$(gh issue view "$MATCH" --repo "$REPO" --json body \
-            --jq '.body | try capture("<!-- failure-run: (?<run>[0-9]+):(?<attempt>[0-9]+) -->") | "\(.run) \(.attempt)"')
-          if [ -n "$FAILURE_RUN" ]; then
+            --jq '(.body // "")
+              | if contains("<!-- failure-run:") | not then "legacy"
+                elif (split("<!-- failure-run:") | length) != 2 then "malformed"
+                else ([capture("<!-- failure-run: (?<run>[0-9]+):(?<attempt>[0-9]+) -->")]
+                  | if length == 1 then "\(.[0].run) \(.[0].attempt)" else "malformed" end)
+                end')
+          if [ "$FAILURE_RUN" = "malformed" ]; then
+            echo "[noop] Tracking issue has malformed failure-run metadata"
+            exit 0
+          fi
+          if [ -n "$FAILURE_RUN" ] && [ "$FAILURE_RUN" != "legacy" ]; then
             FAILURE_RUN_NUMBER=${FAILURE_RUN%% *}
             FAILURE_RUN_ATTEMPT=${FAILURE_RUN#* }
+            case "${FAILURE_RUN_NUMBER}${FAILURE_RUN_ATTEMPT}" in
+              ""|*[!0-9]*)
+                echo "[noop] Tracking issue has malformed failure-run metadata"
+                exit 0
+                ;;
+            esac
+            if [ "${#FAILURE_RUN_NUMBER}" -gt 18 ] || [ "${#FAILURE_RUN_ATTEMPT}" -gt 18 ]; then
+              echo "[noop] Tracking issue has oversized failure-run metadata"
+              exit 0
+            fi
             if [ "$RUN_NUMBER" -lt "$FAILURE_RUN_NUMBER" ] ||
               { [ "$RUN_NUMBER" -eq "$FAILURE_RUN_NUMBER" ] &&
                 [ "$RUN_ATTEMPT" -le "$FAILURE_RUN_ATTEMPT" ]; }; then

--- a/tests/test_workflow_issue_dedup_contract.py
+++ b/tests/test_workflow_issue_dedup_contract.py
@@ -46,7 +46,8 @@ def _run_script(
     extra_env: dict[str, str] | None = None,
 ) -> list[str]:
     source = path.read_text(encoding="utf-8")
-    step = source.split(f"      - name: {step_name}\n", 1)[1].split("\n      - name:", 1)[0]
+    tail = source.split(f"      - name: {step_name}\n", 1)[1]
+    step = re.split(r"\n(?:      - name:|  [a-z][a-z0-9_-]*:)", tail, maxsplit=1)[0]
     script = _script(step).replace("${{ steps.report.outputs.body_file }}", str(tmp_path / "body.md"))
     log = tmp_path / "gh.log"
     fake_gh = tmp_path / "gh"
@@ -57,6 +58,7 @@ case "$*" in
   "issue list "*) printf '%s\\n' "$GH_OPEN" ;;
   "issue edit "*) printf 'edit %s\\n' "$3" >> "$GH_LOG" ;;
   "issue create "*) printf 'create\\n' >> "$GH_LOG" ;;
+  "issue close "*) printf 'close %s\\n' "$3" >> "$GH_LOG" ;;
   "issue reopen "*) printf 'reopen %s\\n' "$3" >> "$GH_LOG" ;;
 esac
 """,
@@ -147,3 +149,71 @@ def test_top1m_open_match_updates_and_closed_only_creates(tmp_path: Path, opened
         )
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    ("workflow", "opened", "expected"),
+    [
+        (
+            "nightly-failure-alert.yml",
+            '[{"number":42,"title":"[nightly-red] Smoke failing on devel","state":"OPEN"}]',
+            ["close 42"],
+        ),
+        ("nightly-failure-alert.yml", '[{"number":42,"title":"different","state":"OPEN"}]', []),
+        (
+            "top1m-healthcheck.yml",
+            '[{"number":42,"title":"[top1m-healthcheck] provider URL unhealthy","state":"OPEN"}]',
+            ["close 42"],
+        ),
+        ("top1m-healthcheck.yml", '[{"number":42,"title":"different","state":"OPEN"}]', []),
+    ],
+)
+def test_success_closes_only_the_matching_open_tracker(
+    tmp_path: Path, workflow: str, opened: str, expected: list[str]
+) -> None:
+    assert (
+        _run_script(
+            WORKFLOWS / workflow,
+            "Close the recovered tracking issue",
+            tmp_path,
+            opened=opened,
+            extra_env={"WF_NAME": "Smoke", "BRANCH": "devel", "RUN_URL": "https://example.invalid/run"},
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("workflow", ["nightly-failure-alert.yml", "top1m-healthcheck.yml"])
+def test_success_without_an_open_tracker_is_a_no_op(tmp_path: Path, workflow: str) -> None:
+    assert (
+        _run_script(
+            WORKFLOWS / workflow,
+            "Close the recovered tracking issue",
+            tmp_path,
+            opened="[]",
+            extra_env={"WF_NAME": "Smoke", "BRANCH": "devel", "RUN_URL": "https://example.invalid/run"},
+        )
+        == []
+    )
+
+
+def test_recovery_runs_only_for_successful_matching_pipeline_events() -> None:
+    nightly = (WORKFLOWS / "nightly-failure-alert.yml").read_text(encoding="utf-8")
+    top1m = (WORKFLOWS / "top1m-healthcheck.yml").read_text(encoding="utf-8")
+
+    nightly_success = "\n".join(
+        (
+            "github.event.workflow_run.event == 'schedule' &&",
+            "       github.event.workflow_run.conclusion == 'success'",
+        )
+    )
+    assert nightly_success in nightly
+    assert "if: success()" in top1m
+
+
+def test_failure_and_recovery_reconciliation_are_serialized() -> None:
+    nightly = (WORKFLOWS / "nightly-failure-alert.yml").read_text(encoding="utf-8")
+    top1m = (WORKFLOWS / "top1m-healthcheck.yml").read_text(encoding="utf-8")
+
+    assert nightly.count("group: nightly-red-") == 2
+    assert top1m.count("group: top1m-provider-alert") == 2

--- a/tests/test_workflow_issue_lifecycle.py
+++ b/tests/test_workflow_issue_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -34,6 +35,7 @@ def test_issue_openers_never_reopen_closed_issues() -> None:
         creators.append(path.name)
         offenders.extend(f"{path.name}: {command}" for command in commands if command.startswith("gh issue reopen "))
         for step in creation_steps:
+            step = re.split(r"\n  [a-z][a-z0-9_-]*:", step, maxsplit=1)[0]
             dedup_commands = [
                 command
                 for command in _commands(step)

--- a/tests/test_workflow_issue_lifecycle.py
+++ b/tests/test_workflow_issue_lifecycle.py
@@ -26,22 +26,25 @@ def test_issue_openers_never_reopen_closed_issues() -> None:
     creators: list[str] = []
     offenders: list[str] = []
     for path in sorted((*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml"))):
-        commands = _commands(path.read_text(encoding="utf-8"))
-        create_count = sum(command.startswith("gh issue create ") for command in commands)
-        if not create_count:
+        source = path.read_text(encoding="utf-8")
+        commands = _commands(source)
+        creation_steps = [step for step in source.split("\n      - name:") if "gh issue create " in step]
+        if not creation_steps:
             continue
         creators.append(path.name)
         offenders.extend(f"{path.name}: {command}" for command in commands if command.startswith("gh issue reopen "))
-        dedup_commands = [
-            command for command in commands if "gh issue list " in command and "--json number,title,state" in command
-        ]
-        assert len(dedup_commands) == create_count, (
-            f"{path.name}: expected one exact-state dedup lookup per issue create; "
-            f"found {len(dedup_commands)} for {create_count} create command(s)"
-        )
-        assert all("--state open" in command for command in dedup_commands), (
-            f"{path.name}: issue dedup must query open issues only: {dedup_commands}"
-        )
+        for step in creation_steps:
+            dedup_commands = [
+                command
+                for command in _commands(step)
+                if "gh issue list " in command and "--json number,title,state" in command
+            ]
+            assert len(dedup_commands) == 1, (
+                f"{path.name}: expected one exact-state dedup lookup per issue create; found {dedup_commands}"
+            )
+            assert "--state open" in dedup_commands[0], (
+                f"{path.name}: issue dedup must query open issues only: {dedup_commands[0]}"
+            )
 
     assert creators, "found no issue-opening workflows"
     assert not offenders, "issue-opening workflows must never reopen closed issues:\n" + "\n".join(offenders)

--- a/tests/test_workflow_issue_recovery_marker.py
+++ b/tests/test_workflow_issue_recovery_marker.py
@@ -1,0 +1,38 @@
+"""Failure-run marker parsing distinguishes legacy and corrupt issue bodies."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+
+import pytest
+
+from tests.test_workflow_issue_dedup_contract import WORKFLOWS
+from tests.test_workflow_issue_recovery_order import _recovery_script
+
+
+@pytest.mark.parametrize("workflow", ["nightly-failure-alert.yml", "top1m-healthcheck.yml"])
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("<!-- failure-run: 101:2 -->", "101 2"),
+        ("legacy body", "legacy"),
+        (None, "legacy"),
+        ("<!-- failure-run: x:y -->", "malformed"),
+        ("<!-- failure-run: 99:1 --><!-- failure-run: 101:1 -->", "malformed"),
+    ],
+)
+def test_failure_run_marker_parser(body: str | None, expected: str, workflow: str) -> None:
+    script = _recovery_script(WORKFLOWS / workflow)
+    query = re.search(r"--jq '(.+?)'\)", script, re.DOTALL)
+
+    assert query is not None
+    result = subprocess.run(
+        ["jq", "-r", query.group(1)],
+        input=json.dumps({"body": body}),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == expected

--- a/tests/test_workflow_issue_recovery_order.py
+++ b/tests/test_workflow_issue_recovery_order.py
@@ -1,0 +1,113 @@
+"""A delayed success must not close a tracker updated by a newer failure."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _recovery_script(path: Path) -> str:
+    source = path.read_text(encoding="utf-8")
+    tail = source.split("      - name: Close the recovered tracking issue\n", 1)[1]
+    step = re.split(r"\n(?:      - name:|  [a-z][a-z0-9_-]*:)", tail, maxsplit=1)[0]
+    return "\n".join(line[10:] for line in step.split("        run: |\n", 1)[1].splitlines())
+
+
+def _run_recovery(
+    path: Path,
+    tmp_path: Path,
+    *,
+    title: str,
+    failure_run: str,
+    run_number: str,
+    run_attempt: str,
+) -> list[str]:
+    log = tmp_path / "gh.log"
+    fake_gh = tmp_path / "gh"
+    fake_gh.write_text(
+        """#!/bin/sh
+case "$*" in
+  "issue list "*) printf '%s\n' "$GH_OPEN" ;;
+  "issue view "*) printf '%s\n' "$GH_FAILURE_RUN" ;;
+  "issue close "*) printf 'close %s\n' "$3" >> "$GH_LOG" ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    env = os.environ | {
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "GH_FAILURE_RUN": failure_run,
+        "GH_LOG": str(log),
+        "GH_OPEN": json.dumps([{"number": 42, "title": title, "state": "OPEN"}]),
+        "REPO": "owner/repo",
+        "WF_NAME": "Smoke",
+        "BRANCH": "devel",
+        "RUN_URL": "https://example.invalid/run",
+        "RUN_NUMBER": run_number,
+        "RUN_ATTEMPT": run_attempt,
+    }
+    subprocess.run(
+        ["bash", "-c", _recovery_script(path)],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+
+
+@pytest.mark.parametrize(
+    ("workflow", "title"),
+    [
+        ("nightly-failure-alert.yml", "[nightly-red] Smoke failing on devel"),
+        ("top1m-healthcheck.yml", "[top1m-healthcheck] provider URL unhealthy"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("failure_run", "run_number", "run_attempt", "expected"),
+    [
+        ("101 1", "100", "1", []),
+        ("100 1", "100", "2", ["close 42"]),
+        ("100 2", "101", "1", ["close 42"]),
+        ("", "100", "1", ["close 42"]),
+    ],
+)
+def test_recovery_closes_only_when_not_older_than_the_recorded_failure(
+    tmp_path: Path,
+    workflow: str,
+    title: str,
+    failure_run: str,
+    run_number: str,
+    run_attempt: str,
+    expected: list[str],
+) -> None:
+    assert (
+        _run_recovery(
+            WORKFLOWS / workflow,
+            tmp_path,
+            title=title,
+            failure_run=failure_run,
+            run_number=run_number,
+            run_attempt=run_attempt,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("workflow", ["nightly-failure-alert.yml", "top1m-healthcheck.yml"])
+def test_failure_issue_body_records_the_run_order(workflow: str) -> None:
+    source = (WORKFLOWS / workflow).read_text(encoding="utf-8")
+
+    assert "<!-- failure-run: %s:%s -->" in source
+    assert "RUN_NUMBER:" in source
+    assert "RUN_ATTEMPT:" in source

--- a/tests/test_workflow_issue_recovery_safety.py
+++ b/tests/test_workflow_issue_recovery_safety.py
@@ -1,0 +1,54 @@
+"""Recovery ordering metadata fails closed and survives manual drills."""
+
+from pathlib import Path
+
+import pytest
+
+from tests.test_workflow_issue_dedup_contract import WORKFLOWS, _run_script
+from tests.test_workflow_issue_recovery_order import _run_recovery
+
+
+@pytest.mark.parametrize(
+    ("workflow", "title"),
+    [
+        ("nightly-failure-alert.yml", "[nightly-red] Smoke failing on devel"),
+        ("top1m-healthcheck.yml", "[top1m-healthcheck] provider URL unhealthy"),
+    ],
+)
+def test_malformed_failure_order_never_closes(
+    tmp_path: Path,
+    workflow: str,
+    title: str,
+) -> None:
+    assert (
+        _run_recovery(
+            WORKFLOWS / workflow,
+            tmp_path,
+            title=title,
+            failure_run="18446744073709551616 1",
+            run_number="100",
+            run_attempt="1",
+        )
+        == []
+    )
+
+
+def test_manual_drill_never_overwrites_a_real_failure_tracker(tmp_path: Path) -> None:
+    assert (
+        _run_script(
+            WORKFLOWS / "nightly-failure-alert.yml",
+            "Open or update the tracking issue",
+            tmp_path,
+            opened='[{"number":42,"title":"[nightly-red] Smoke failing on devel","state":"OPEN"}]',
+            extra_env={
+                "WF_NAME": "Smoke",
+                "RUN_URL": "https://example.invalid/run",
+                "HEAD_SHA": "deadbeef",
+                "BRANCH": "devel",
+                "DRILL": "1",
+                "RUN_NUMBER": "",
+                "RUN_ATTEMPT": "",
+            },
+        )
+        == []
+    )


### PR DESCRIPTION
## Summary

- close exact open `nightly-red` trackers after the watched scheduled fan-out next succeeds
- close the exact open Top1M provider tracker after a scheduled or dispatched health check succeeds
- keep failure and recovery issue mutations serialized per tracker
- record `run_number:run_attempt` on failures so a delayed older success cannot close a newer failure
- preserve open-only exact-title deduplication and never reopen closed history

## Root cause

Both issue-producing workflows only executed their failure paths. A later green run had no lifecycle path, leaving recovered incidents open indefinitely. Recovery also needs explicit run ordering because GitHub concurrency prevents overlap but does not guarantee event-age ordering.

## Verification

- Initial frozen RED on untouched `devel`: 8 recovery assertions failed; GREEN unchanged: 15 passed
- Frozen ordering RED against the pre-review-fix commit; GREEN unchanged: 10 passed for both producers
- Frozen review regressions: 3 safety assertions and 8 marker-parser assertions RED before their fixes; both files GREEN byte-identical
- Focused lifecycle/dedup/metadata suite: 43 passed
- `actionlint -ignore 'SC2016'` passed for both workflows
- Hermetic canonical gates after final rebase: pytest, Ruff check/format, and mypy all passed
- Exact-head GitHub Actions CI: all required checks passed

The first local full-suite run exposed unrelated global Git-signing leakage in one scratch-repo test; tracked separately in #1967.

Fixes #1966

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
