### PR TITLE
scripts: reap a token-savior rebuild lock whose holder is dead (#1969)

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,6 +7,6 @@ max_depth = 2
 
 [mcp_servers.token-savior-recall]
 command = "sh"
-args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 5fe61f9ad422901154e1acec9162b732598964691e37a83d979091ff2ed3920b && exec sh "$root/scripts/mcp-token-savior.sh"''']
+args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 1c559e7500193959d29e1f72fe5954e0a067d8049a4654cad7a7200211761371 && exec sh "$root/scripts/mcp-token-savior.sh"''']
 env = { TOKEN_SAVIOR_CLIENT = "codex" }
 startup_timeout_sec = 120

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,6 +7,6 @@ max_depth = 2
 
 [mcp_servers.token-savior-recall]
 command = "sh"
-args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 1c559e7500193959d29e1f72fe5954e0a067d8049a4654cad7a7200211761371 && exec sh "$root/scripts/mcp-token-savior.sh"''']
+args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 514550277ce27b624cf8b5695d1c54e5f27aa5224ae480577482299827549e17 && exec sh "$root/scripts/mcp-token-savior.sh"''']
 env = { TOKEN_SAVIOR_CLIENT = "codex" }
 startup_timeout_sec = 120

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -49,32 +49,41 @@ TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector]==4.21.0}"
 if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then
 	lock="${venv}.rebuild.lock"
 	mkdir -p "$(dirname "$venv")"
-	if mkdir "$lock" 2>/dev/null; then
-		# set -e: a failed install still fires the trap, so a crashed rebuild
-		# never leaves the lock behind for the next session to time out on.
-		trap 'rmdir "$lock" 2>/dev/null' EXIT
-		# Re-check under the lock — a concurrent session may have finished the
-		# same rebuild while this one waited on mkdir.
-		if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then
-			rm -rf "$venv"
-			python3 -m venv "$venv" 1>&2
-			"$venv/bin/pip" install --quiet "$TS_SOURCE" 1>&2
-			printf '%s\n' "$TS_SOURCE" > "$stamp"
+	waited=0
+	max_wait="${TS_LOCK_WAIT:-300}"
+	# A SIGKILLed holder can never run its EXIT trap, so its lock outlived it and
+	# blocked every later session until max_wait expired — nine days, undiagnosed,
+	# in issue #1969. So the lock is not trusted on existence alone: the holder
+	# records its PID inside it, and a waiter that finds that PID dead reaps the
+	# lock and retries the acquisition. A lock carrying no readable PID is never
+	# reaped — that is a live holder caught between mkdir and the PID write.
+	while ! mkdir "$lock" 2>/dev/null; do
+		holder="$(cat "$lock/pid" 2>/dev/null || true)"
+		if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+			rm -rf "$lock"
+			continue
 		fi
-		rmdir "$lock" 2>/dev/null
-		trap - EXIT
-	else
-		waited=0
-		max_wait="${TS_LOCK_WAIT:-300}"
-		while [ -d "$lock" ] && [ "$waited" -lt "$max_wait" ]; do
-			sleep 1
-			waited=$((waited + 1))
-		done
-		if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then
+		if [ "$waited" -ge "$max_wait" ]; then
 			echo "mcp-token-savior: concurrent rebuild did not complete within ${max_wait}s — if no other session is installing, remove '$lock' and retry" >&2
 			exit 1
 		fi
+		sleep 1
+		waited=$((waited + 1))
+	done
+	# set -e: a failed install still fires the trap, so a crashed rebuild
+	# never leaves the lock behind for the next session to time out on.
+	trap 'rm -rf "$lock" 2>/dev/null' EXIT
+	printf '%s\n' "$$" > "$lock/pid"
+	# Re-check under the lock — a concurrent session may have finished the
+	# same rebuild while this one waited on mkdir.
+	if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then
+		rm -rf "$venv"
+		python3 -m venv "$venv" 1>&2
+		"$venv/bin/pip" install --quiet "$TS_SOURCE" 1>&2
+		printf '%s\n' "$TS_SOURCE" > "$stamp"
 	fi
+	rm -rf "$lock"
+	trap - EXIT
 fi
 
 workspace_root=$PWD

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -5,7 +5,8 @@
 # upstream token-savior-recall 4.21.0 with the MCP and vector-memory extras. A TS_SOURCE change
 # is detected via the .pfb-ts-source stamp and triggers a clean venv rebuild;
 # a mkdir lock serializes concurrent sessions racing that rebuild (the venv is one shared
-# per-user cache). Requires python3 >= 3.11.
+# per-user cache). The lock holder records its PID inside the lock so a waiter can reap a
+# lock whose holder died without releasing it. Requires python3 >= 3.11.
 # Env (all optional):
 #   WORKSPACE_ROOTS        comma-separated project roots (default: every usable worktree
 #                          of the current Git repository, otherwise current directory)
@@ -45,12 +46,30 @@ bin="$venv/bin/token-savior"
 stamp="$venv/.pfb-ts-source"
 TS_SOURCE="${TS_SOURCE:-token-savior-recall[mcp,memory-vector]==4.21.0}"
 
+holder_alive() {
+	kill -0 "$1" 2>/dev/null && return 0
+	# kill -0 also fails with EPERM for a LIVE process this user may not signal,
+	# so its failure is not proof of death. ps answers regardless of ownership;
+	# no ps at all is no evidence, and doubt must never reap a held lock.
+	command -v ps >/dev/null 2>&1 || return 0
+	ps -p "$1" >/dev/null 2>&1
+}
+
 # stdout is the MCP stdio channel — install chatter must stay on stderr
 if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ]; then
 	lock="${venv}.rebuild.lock"
 	mkdir -p "$(dirname "$venv")"
 	waited=0
 	max_wait="${TS_LOCK_WAIT:-300}"
+	# The cap below is an integer comparison, and a non-numeric bound makes it
+	# error every iteration without ever being true — an unbounded spin, the very
+	# hang this lock handling exists to remove. Refuse the bound instead.
+	case "$max_wait" in
+		''|*[!0-9]*)
+			echo "mcp-token-savior: refusing TS_LOCK_WAIT '$max_wait' — it must be a non-negative whole number of seconds" >&2
+			exit 1
+			;;
+	esac
 	# A SIGKILLed holder can never run its EXIT trap, so its lock outlived it and
 	# blocked every later session until max_wait expired — nine days, undiagnosed,
 	# in issue #1969. So the lock is not trusted on existence alone: the holder
@@ -59,7 +78,7 @@ if [ ! -x "$bin" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "$TS_SOURCE" ];
 	# reaped — that is a live holder caught between mkdir and the PID write.
 	while ! mkdir "$lock" 2>/dev/null; do
 		holder="$(cat "$lock/pid" 2>/dev/null || true)"
-		if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+		if [ -n "$holder" ] && ! holder_alive "$holder"; then
 			rm -rf "$lock"
 			continue
 		fi

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -287,6 +287,48 @@ EOF
     The stderr should include 'concurrent rebuild'
   End
 
+  It 'reaps a rebuild lock whose recorded holder PID is dead (issue #1969)'
+    # A SIGKILLed holder can never run its EXIT trap, so its lock outlives it and
+    # blocked every later session until TS_LOCK_WAIT expired (nine days, in the
+    # incident). A dead recorded PID proves the holder is gone: reap and rebuild.
+    # TS_LOCK_WAIT=2 keeps a non-reaping launcher failing fast instead of hanging.
+    sh -c 'exit 0' &
+    dead_pid=$!
+    wait "${dead_pid}"
+    mkdir -p "${WORK}/venv.rebuild.lock"
+    printf '%s\n' "${dead_pid}" > "${WORK}/venv.rebuild.lock/pid"
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" TS_LOCK_WAIT=2 sh "${SCRIPT}"
+    The status should be success
+    The output should equal 'INSTALLED'
+    The stderr should equal ''
+    The directory "${WORK}/venv.rebuild.lock" should not be exist
+  End
+
+  It 'records its own live PID in the lock it holds'
+    # Without this, the reap above would be unreachable in production: no holder
+    # would ever leave a PID for a later session to test. The python3 wrapper runs
+    # under the lock, i.e. exactly while the holder is installing.
+    mkdir -p "${WORK}/probe"
+    cat > "${WORK}/probe/python3" << EOF
+#!/bin/sh
+holder="\$(cat "${WORK}/venv.rebuild.lock/pid" 2>/dev/null || true)"
+if [ -z "\${holder}" ]; then
+	printf 'MISSING\n' > "${WORK}/observed"
+elif kill -0 "\${holder}" 2>/dev/null; then
+	printf 'LIVE\n' > "${WORK}/observed"
+else
+	printf 'DEAD\n' > "${WORK}/observed"
+fi
+exec "${WORK}/shim/python3" "\$@"
+EOF
+    chmod +x "${WORK}/probe/python3"
+    When run env PATH="${WORK}/probe:${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" sh "${SCRIPT}"
+    The status should be success
+    The output should equal 'INSTALLED'
+    The stderr should equal ''
+    The contents of file "${WORK}/observed" should equal 'LIVE'
+  End
+
   It 'refuses a non-absolute TS_VENV instead of rm -rf-ing a relative path'
     # Contained sandbox: an unguarded launcher would rm -rf . right here.
     mkdir -p "${WORK}/sandbox"

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -304,6 +304,34 @@ EOF
     The directory "${WORK}/venv.rebuild.lock" should not be exist
   End
 
+  It 'rejects a non-numeric TS_LOCK_WAIT instead of spinning on it forever'
+    # The cap check is an integer comparison: a non-numeric bound made it error
+    # every iteration without ever being true, so the launcher spun forever on an
+    # unreapable lock - the exact hang class #1969 exists to remove. The lock here
+    # carries no PID, so nothing can reap it; only a validated bound ends the run.
+    mkdir -p "${WORK}/venv.rebuild.lock"
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" TS_LOCK_WAIT='abc' timeout 15 sh "${SCRIPT}"
+    The status should be failure
+    The status should not equal 124
+    The stderr should include 'TS_LOCK_WAIT'
+  End
+
+  It 'keeps a lock whose holder PID is alive but unsignalable (EPERM)'
+    # kill -0 fails with EPERM for a live process this user may not signal, which
+    # is not proof of death: reaping on it destroys a running holder's lock. PID 1
+    # is the portable always-alive, never-ours case - unless this user IS root,
+    # where kill -0 1 succeeds and the example would assert the plain live-holder
+    # path instead, proving nothing about EPERM.
+    Skip if "running as root: kill -0 1 succeeds, so the fixture is not EPERM" [ "$(id -u)" -eq 0 ]
+    mkdir -p "${WORK}/venv.rebuild.lock"
+    printf '1\n' > "${WORK}/venv.rebuild.lock/pid"
+    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" TS_LOCK_WAIT=2 sh "${SCRIPT}"
+    The status should be failure
+    The stderr should include 'concurrent rebuild'
+    The directory "${WORK}/venv.rebuild.lock" should be exist
+    The file "${WORK}/venv/pip-args.log" should not be exist
+  End
+
   It 'records its own live PID in the lock it holds'
     # Without this, the reap above would be unreachable in production: no holder
     # would ever leave a PID for a later session to test. The python3 wrapper runs


### PR DESCRIPTION
## Problem

`scripts/mcp-token-savior.sh` serialized venv rebuilds with a `mkdir` lock released only by a `trap … EXIT`. A `SIGKILL`ed holder cannot run that trap, so the lock directory outlived it and blocked every later session that needed a rebuild: each waited out `TS_LOCK_WAIT` (default 300 s) and exited with `concurrent rebuild did not complete`, long after the MCP client had already given up with `-32001`.

Observed in the wild — the lock dated from the very first install and went undiagnosed for nine days:

```
$ ls -ld ~/.cache/token-savior/venv.rebuild.lock
drwxr-xr-x@ 2 andre staff 64 Jul 23 07:58 …/venv.rebuild.lock
```

The first install of the `[mcp,memory-vector]` extra is slow, the client's startup timeout killed the launcher mid-`pip install`, and the venv stayed frozen at the retired fork pin (`4.9.0`) even though the launcher's default `TS_SOURCE` had already moved to upstream `4.21.0` (#1829). The stamp mismatch correctly asked for a rebuild every session; the rebuild could never take the lock.

Two mechanisms were on the table — a signal the `EXIT` trap does not cover, or a launcher path that creates the lock and returns without releasing it. The discriminating probe (full transcript in #1969) settles it:

```
lock cleaned          # SIGTERM: EXIT trap runs
LOCK SURVIVED KILL    # SIGKILL: it cannot
```

No trap-based cleanup can close this hole, so the lock can no longer be trusted on existence alone.

## Fix

The holder records its PID inside the lock directory; a waiter that finds that PID dead (`kill -0` fails) reaps the lock and retries the acquisition. A lock carrying **no readable PID** keeps the previous conservative behaviour — wait, then fail loudly — so a holder caught in the window between `mkdir` and the PID write is never reaped out from under itself.

The separate acquire and wait branches collapse into one retry loop. That also removes an old asymmetry: a waiter previously never re-checked the venv under the lock, it only inspected the result the holder left behind.

Unchanged: a stale lock is still inert whenever no rebuild is needed — the launcher only touches the lock inside the rebuild branch, which is why the incident needed both an orphaned lock *and* a stamp mismatch to surface.

`.codex/config.toml` carries the launcher's SHA-256 integrity pin, re-pinned here; the existing spec example asserts that pin, so it moves in the same commit.

## Tests

Two examples in `tests/shell/mcp_token_savior_spec.sh`:

- **reaps a rebuild lock whose recorded holder PID is dead** — plants a lock naming a reaped PID and asserts the launcher installs instead of timing out, and that the lock is gone afterwards.
- **records its own live PID in the lock it holds** — a `python3` wrapper runs under the lock and asserts the recorded PID is that of a live process. Without it the reap would be unreachable in production, since no real holder would leave a PID behind for a later session to test.

Red → green, test bytes frozen across both runs (`sha256 8aec7515…d0b8`):

```
# RED (before the launcher edit)
28 examples, 2 failures
  got: "mcp-token-savior: concurrent rebuild did not complete within 2s …"
  expected: "LIVE"  got: "MISSING"

# GREEN (same test bytes, launcher fixed)
28 examples, 0 failures
```

Pre-commit ran the impacted spec under `dash` as well: `28 examples, 0 failures`.

Fixes #1969
