### PR TITLE
Close the pre-release varver class on the producer side; guard catalog path segments

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -992,10 +992,11 @@ never wrong. Key properties:
   is local-file-only (no network, no daemon).
 - **Folded detection (KISS):** edition = "`/etc/product_label` contains `Plus`" → `plus`, else
   `ce`; version = major.minor of `/etc/version`, with any dash suffix (e.g. `-BETA`/`-RC`)
-  stripped FIRST. This deliberately **diverges** from `catalog_name_from_version()` in
-  `scripts/build-repo-portable.py` by that one strip — a live box's `/etc/version` can carry a
-  pre-release suffix the matrix's version never does (issue #1786) — otherwise it is the same
-  edition + major.minor derivation; there is **no** separate `/lib` detection helper (it is
+  stripped FIRST. This **mirrors** `catalog_name_from_version()` in
+  `scripts/build-repo-portable.py` exactly, including that strip — a live box's `/etc/version`
+  can carry a pre-release suffix the matrix's version never does (issue #1786), and the
+  producers strip it identically so a pre-release box and the publisher agree on one catalog
+  dir (issue #1965); there is **no** separate `/lib` detection helper (it is
   folded into the one self-contained hook file). **issue #1806:** the catalog is arch-less, so
   the hook no longer calls `pkg config abi` at all (it used to read the arch leaf; there is no
   arch leaf to read any more) — one fewer moving part, and it no longer needs `pkg` on the PATH.

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -343,7 +343,13 @@ def catalog_name_from_version(pfsense_version: str, variant: str, *, channel: st
     major_minor = ".".join(pfsense_version.split("-")[0].split(".")[:2])
     name = f"{variant.lower()}-{major_minor}"
     _validate_catalog_name(name, single_segment=True)
-    return f"{channel}/{name}" if channel else name
+    if not channel:
+        return name
+    # The channel is an argument like any other — validate the COMPOSED value, or a
+    # caller-supplied channel would ride into the path unchecked (issue #1965).
+    composed = f"{channel}/{name}"
+    _validate_catalog_name(composed)
+    return composed
 
 
 # --------------------------------------------------------------------------- #
@@ -353,11 +359,18 @@ def catalog_name_from_version(pfsense_version: str, variant: str, *, channel: st
 # A catalog_name segment is a rm-rf'd + rebuilt path component (_write_catalog_dir
 # shutil.rmtree()s it) — same safety rule as build-repo.sh's --varver guard, tightened
 # to lowercase-only. '/' is allowed only BETWEEN segments (a legitimate catalog_name
-# carries a channel prefix, e.g. "nightly/plus-26.03"). The leading character is
-# alphanumeric so a segment can never open with '-' or '.': every real varver does
-# (ce-2.8, plus-26.03, nightly, release), while a missing variant would otherwise
-# derive the silently-wrong "-2.8" (issue #1965).
-_CATALOG_NAME_SEGMENT_RE = re.compile(r"[a-z0-9][a-z0-9.-]*")
+# carries a channel prefix, e.g. "nightly/plus-26.03"). BOTH ends are alphanumeric so a
+# segment can never open or close with '-' or '.': every real varver does (ce-2.8,
+# plus-26.03, nightly, release), while an absent variant would otherwise derive the
+# silently-wrong "-2.8" and an absent version the equally wrong "ce-" (issue #1965).
+_CATALOG_NAME_SEGMENT_RE = re.compile(r"[a-z0-9]([a-z0-9.-]*[a-z0-9])?")
+
+# pkg(8) catalog plumbing: a catalog_name equal to one of these collides with a file
+# _write_catalog_dir writes at the catalog root, so `out_dir / catalog_name` would name
+# an existing FILE and rmtree/mkdir would escape this module's BuildRepoError contract
+# with a raw NotADirectoryError. A manifest can never reach these (the published name is
+# always "<name>-<version>.pkg"), so this guards the catalog_name path only.
+_RESERVED_CATALOG_NAMES = frozenset({"meta", "meta.conf", "data.pkg", "packagesite.pkg"})
 
 
 def _validate_catalog_name(name: str, *, single_segment: bool = False) -> None:
@@ -376,6 +389,11 @@ def _validate_catalog_name(name: str, *, single_segment: bool = False) -> None:
         raise BuildRepoError(
             f"unsafe catalog_name {name!r}: a derived varver is ONE segment — a '/' means "
             f"an input field carried a path separator"
+        )
+    if any(seg in _RESERVED_CATALOG_NAMES for seg in segments):
+        raise BuildRepoError(
+            f"unsafe catalog_name {name!r}: a segment collides with pkg(8) catalog plumbing "
+            f"({', '.join(sorted(_RESERVED_CATALOG_NAMES))}) — it would name an existing file, not a directory"
         )
     if any(not seg or seg in (".", "..") or not _CATALOG_NAME_SEGMENT_RE.fullmatch(seg) for seg in segments):
         raise BuildRepoError(

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -70,6 +70,13 @@ def _is_wildcard_abi(abi: object) -> TypeGuard[str]:
     return isinstance(abi, str) and bool(_ABI_WILDCARD_RE.fullmatch(abi))
 
 
+# A .pkg's manifest name/version become the published filename ``<name>-<version>.pkg``.
+# The manifest is READ from the package (attacker-controlled input, never derived), so
+# both fields get a segment guard too. Wider class than a varver — real pkg names and
+# versions carry uppercase, '_' (port revision, "1.0_1") and ',' (PORTEPOCH, "1.0,1").
+_PKG_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._,+-]*$")
+
+
 class BuildRepoError(Exception):
     """A fatal, user-facing error (bad input / collision / missing tool)."""
 
@@ -90,6 +97,24 @@ def _require_wildcard_abi(path: Path, abi: object) -> str:
             f"install on only one arch. Ship a wildcard-ABI (NO_ARCH) build instead."
         )
     return abi
+
+
+def _safe_segment(value: object, *, what: str, pattern: re.Pattern[str]) -> str:
+    """Return ``value`` if it is safe to use as ONE path segment, else raise.
+
+    Everything joined onto the output root here is either read from an untrusted
+    manifest or passed in from the CLI/matrix, and the destination directory is
+    ``rmtree``'d before it is rebuilt — so an unvalidated segment is an arbitrary
+    directory wipe (``".."``) or an escape from the output root entirely (an
+    absolute path makes ``Path.__truediv__`` discard its left operand). Mirrors the
+    guard ``scripts/build-repo.sh`` applies to ``--varver``.
+    """
+    if not isinstance(value, str) or not pattern.fullmatch(value) or ".." in value:
+        raise BuildRepoError(
+            f"unsafe or invalid {what}: {value!r} — must be a single path segment "
+            f"matching {pattern.pattern} with no '..' (it becomes an rm -rf'd directory)"
+        )
+    return value
 
 
 # --------------------------------------------------------------------------- #
@@ -300,12 +325,24 @@ def catalog_name_from_version(pfsense_version: str, variant: str, *, channel: st
       "26.03"  + "Plus"           -> "plus-26.03"
       "26.03.1"+ "Plus"           -> "plus-26.03"
 
+    A pre-release suffix is stripped BEFORE the split, so a pre-release publishes
+    under its release line's catalog — the same strip the rc.d repo-generate hook
+    applies on the box (issue #1965; the suffix sits inside the minor field, so a
+    bare split would keep it and publish a directory no box ever resolves):
+      "26.07-BETA" + "Plus"       -> "plus-26.07"
+      "2.8.1-RELEASE" + "CE"      -> "ce-2.8"
+
     When channel is supplied (e.g. "nightly"), it is prepended as a path prefix:
       "2.8.1"  + "CE"   + "nightly" -> "nightly/ce-2.8"
       "26.03.1"+ "Plus" + "nightly" -> "nightly/plus-26.03"
+
+    The derived name becomes an rmtree'd path segment, so it goes through the same
+    ``_validate_catalog_name`` guard a caller-supplied ``--catalog-name`` does — the
+    matrix fields it is built from are inputs, not constants.
     """
-    major_minor = ".".join(pfsense_version.split(".")[:2])
+    major_minor = ".".join(pfsense_version.split("-")[0].split(".")[:2])
     name = f"{variant.lower()}-{major_minor}"
+    _validate_catalog_name(name, single_segment=True)
     return f"{channel}/{name}" if channel else name
 
 
@@ -316,21 +353,34 @@ def catalog_name_from_version(pfsense_version: str, variant: str, *, channel: st
 # A catalog_name segment is a rm-rf'd + rebuilt path component (_write_catalog_dir
 # shutil.rmtree()s it) — same safety rule as build-repo.sh's --varver guard, tightened
 # to lowercase-only. '/' is allowed only BETWEEN segments (a legitimate catalog_name
-# carries a channel prefix, e.g. "nightly/plus-26.03").
-_CATALOG_NAME_SEGMENT_RE = re.compile(r"[a-z0-9.-]+")
+# carries a channel prefix, e.g. "nightly/plus-26.03"). The leading character is
+# alphanumeric so a segment can never open with '-' or '.': every real varver does
+# (ce-2.8, plus-26.03, nightly, release), while a missing variant would otherwise
+# derive the silently-wrong "-2.8" (issue #1965).
+_CATALOG_NAME_SEGMENT_RE = re.compile(r"[a-z0-9][a-z0-9.-]*")
 
 
-def _validate_catalog_name(name: str) -> None:
+def _validate_catalog_name(name: str, *, single_segment: bool = False) -> None:
     """Reject an unsafe ``catalog_name`` before it becomes ``out_dir / catalog_name``
     (issue #1786): a ``".."`` segment escapes sideways/upward, and an ABSOLUTE value
     makes ``Path.__truediv__`` discard ``out_dir`` entirely — either lets a caller
     point ``_write_catalog_dir``'s ``shutil.rmtree()`` at an arbitrary directory.
+
+    ``single_segment`` additionally forbids the channel prefix. A value DERIVED from
+    matrix fields (``catalog_name_from_version``) is one segment by construction, so a
+    '/' there means a field carried a separator — which this guard would otherwise read
+    as a legitimate prefix and wave through (issue #1965).
     """
     segments = name.split("/")
+    if single_segment and len(segments) != 1:
+        raise BuildRepoError(
+            f"unsafe catalog_name {name!r}: a derived varver is ONE segment — a '/' means "
+            f"an input field carried a path separator"
+        )
     if any(not seg or seg in (".", "..") or not _CATALOG_NAME_SEGMENT_RE.fullmatch(seg) for seg in segments):
         raise BuildRepoError(
             f"unsafe catalog_name {name!r}: each '/'-separated segment must be non-empty, "
-            f"not '.'/'..', and match [a-z0-9.-]+ (e.g. 'ce-2.8', 'release/ce-2.8')"
+            f"not '.'/'..', and match [a-z0-9][a-z0-9.-]* (e.g. 'ce-2.8', 'release/ce-2.8')"
         )
 
 
@@ -356,7 +406,9 @@ def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) 
     delegated to ``_emit_catalog_from_paths``. Returns the single wildcard ABI
     built, as a one-element sorted list.
     """
-    if catalog_name:
+    # `is not None`, not truthiness: an empty catalog_name is a caller bug, and
+    # silently treating it as "no catalog name" would publish at the output root.
+    if catalog_name is not None:
         _validate_catalog_name(catalog_name)
 
     pkgs = sorted(p for p in in_dir.glob("*.pkg") if p.is_file())
@@ -395,6 +447,10 @@ def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict
     # Read every source up front (sources may live inside dest — see nightly retention).
     staged: list[tuple[str, bytes, float, dict]] = []
     for (name, version), (path, manifest) in sorted(items.items()):
+        # name/version come from the .pkg's own manifest and become the published
+        # filename — guard both before either is joined onto dest (issue #1965).
+        _safe_segment(name, what=f"{path.name}: manifest name", pattern=_PKG_SEGMENT_RE)
+        _safe_segment(version, what=f"{path.name}: manifest version", pattern=_PKG_SEGMENT_RE)
         canonical = f"{name}-{version}.pkg"
         staged.append((canonical, path.read_bytes(), path.stat().st_mtime, manifest))
 

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -456,10 +456,12 @@ def _join_matrix(rows: list[dict], matrix: list[dict] | None) -> list[tuple[str,
     php/py, so nothing published is ever hidden. Input order is preserved.
 
     A NO_ARCH package's manifest ABI is CPU-wildcarded (issue #1806, e.g.
-    "FreeBSD:16:*") — the exact-string index never hits it (a matrix row's own
-    ABI is always concrete), so a wildcarded row falls back to an OS+major scan
-    across every matrix entry (``_abi_matches``), joining EVERY row of that
-    major instead of dropping to "Other".
+    "FreeBSD:16:*"). The matrix row's own ABI is wildcarded too (pfBlockerNG/pkg
+    emits ``FreeBSD:<major>:*`` since `arch` was retired), so the exact-string
+    index normally hits; a row it misses — a legacy concrete-ABI asset, or a
+    matrix that still records one — falls back to an OS+major scan across every
+    matrix entry (``_abi_matches``), joining EVERY row of that major instead of
+    dropping to "Other". Both paths yield the same rows.
 
     An ABI match alone over-joins when two pfSense versions share it: the catalog is
     published per varver, so each varver dir holds its OWN copy of the .pkg, and
@@ -716,8 +718,9 @@ def eol_versions(pkgs: list[dict], matrix: list[dict] | None) -> list[tuple[str,
 
     out: list[tuple[str, str, dict]] = []
     for varver, entries in by_varver.items():
-        # Matched via _abi_matches (OS+major, issue #1806): the served .pkg may be
-        # NO_ARCH/wildcarded even when the matrix still records a concrete ABI.
+        # Matched via _abi_matches (OS+major, issue #1806) rather than string equality:
+        # the served .pkg and the matrix entry may disagree on the CPU segment (a legacy
+        # concrete-ABI asset against today's wildcarded matrix, or the reverse).
         served = varver_pkgs.get(varver, [])
         pool = [p for p in served if any(_abi_matches(p["abi"], e.get("abi", "")) for e in entries)]
         if not pool:

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -425,11 +425,14 @@ def _edition_key(variant: str) -> str:
 def _matrix_varver(pfsense_version: str, variant: str) -> str:
     """The catalog dir name (varver) a matrix entry's packages are published under.
 
-    Mirrors build-repo-portable.py's catalog_name_from_version (major.minor only):
-      "2.7" + "CE"   -> "ce-2.7"
-      "25.03"+ "Plus" -> "plus-25.03"
+    Mirrors build-repo-portable.py's catalog_name_from_version (major.minor only,
+    pre-release suffix stripped first — it sits inside the minor field, so a bare
+    split would keep it and pin the row to a varver nothing publishes, issue #1965):
+      "2.7" + "CE"           -> "ce-2.7"
+      "25.03"+ "Plus"        -> "plus-25.03"
+      "26.07-BETA" + "Plus"  -> "plus-26.07"
     """
-    major_minor = ".".join(pfsense_version.split(".")[:2])
+    major_minor = ".".join(pfsense_version.split("-")[0].split(".")[:2])
     return f"{variant.lower()}-{major_minor}"
 
 

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -23,11 +23,11 @@
 #
 # Detection (KISS): edition = "/etc/product_label contains 'Plus'" -> plus, else
 # ce; version = major.minor of /etc/version, with any dash suffix (e.g.
-# "-BETA"/"-RC") stripped FIRST. This deliberately DIVERGES from
-# catalog_name_from_version() in scripts/build-repo-portable.py by that one
-# strip: a live box's /etc/version can carry a pre-release suffix the matrix's
-# version never does (issue #1786) — otherwise it is the same edition +
-# major.minor derivation. Arch-less since issue #1806 (NO_ARCH) — the catalog
+# "-BETA"/"-RC") stripped FIRST. This MIRRORS catalog_name_from_version() in
+# scripts/build-repo-portable.py exactly, including that strip: a live box's
+# /etc/version can carry a pre-release suffix the matrix's version never does
+# (issue #1786), and the producers strip it identically so a pre-release box and
+# the publisher agree on one catalog dir (issue #1965). Arch-less since issue #1806 (NO_ARCH) — the catalog
 # no longer has a per-arch leaf, so this hook no longer calls `pkg` at all (it
 # used to read `pkg config abi` only to derive that leaf).
 #

--- a/tests/smoke/_matrix.py
+++ b/tests/smoke/_matrix.py
@@ -47,8 +47,12 @@ class Variant:
 def catalog_name(pfsense_version: str, variant: str) -> str:
     """``("2.8.1", "CE") -> "ce-2.8"`` / ``("26.03.1", "Plus") -> "plus-26.03"`` — the
     variant-keyed catalog dir (variant + the pfSense major.minor; mirrors
-    build-repo-portable.py:catalog_name_from_version)."""
-    parts = [p for p in str(pfsense_version).split(".") if p != ""]
+    build-repo-portable.py:catalog_name_from_version).
+
+    A pre-release suffix is stripped first (``"26.07-BETA" -> "plus-26.07"``): it sits
+    inside the minor field, and both the producer and the on-box rc.d hook drop it
+    before deriving the varver (issue #1965)."""
+    parts = [p for p in str(pfsense_version).split("-")[0].split(".") if p != ""]
     return f"{variant.lower()}-{'.'.join(parts[:2])}"
 
 

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1675,7 +1675,9 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
     Given the own package uninstalled and the repo conf pointing at the opposite-variant
       catalog (ABI mismatch),
     When ``pkg install -y <pkgname>`` from the opposite catalog,
-    Then exit code is non-zero OR the error output mentions the opposite php / ABI mismatch,
+    Then the guard fires (non-zero exit, or the package is absent),
+      AND the error output is variant-attributable — it names the opposite php dep,
+      the opposite ABI, an ABI/OS-version rejection, or no installable candidate,
       AND ``pkg query '%n' <pkgname>`` confirms the package is NOT installed.
     """
     pkg = os.environ.get("SMOKE_PKG")
@@ -1760,11 +1762,28 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
         f"pkg install output:\n{install_output}\n"
         f"pkg query '%n': {vm_pkg_query_name(repo_vm)!r}"
     )
-    # The error output should mention the opposite php or an ABI mismatch (informational — soft).
-    has_opp_php_error = opp.php in install_output
-    has_abi_error = any(kw in install_output.lower() for kw in ("abi", "mismatch", "incompatible", "not found"))
-    assert has_opp_php_error or has_abi_error or install_failed, (
-        f"Wrong-variant install: expected {opp.php}/ABI error or non-zero exit; got:\n"
+    # AND the failure is ATTRIBUTABLE to the variant mismatch — not merely non-zero.
+    # `install_failed` is deliberately NOT one of these clauses: it is already asserted
+    # above, so including it made every other clause unreachable and the intent
+    # ("the error names the opposite php or an ABI rejection") went unpinned (issue
+    # #1965). A failure with none of these markers is a DIFFERENT failure — an unusable
+    # box, a broken catalog, a transport error — and must not read as the guard firing.
+    lowered = install_output.lower()
+    reasons = {
+        f"names the opposite php dep ({opp.php})": opp.php in install_output,
+        f"names the opposite ABI (FreeBSD:{opp_major})": f"freebsd:{opp_major}" in lowered,
+        "reports an ABI / OS-version rejection": any(
+            kw in lowered for kw in ("wrong abi", "wrong os version", "mismatch", "incompatible")
+        ),
+        "reports no installable candidate from the catalog": any(
+            kw in lowered for kw in ("no packages available", "not found", "missing dependency", "unable to find")
+        ),
+    }
+    assert any(reasons.values()), (
+        f"Wrong-variant install failed, but for no variant-attributable reason — the guard "
+        f"under test may not be what fired.\n"
+        f"expected the output to satisfy at least one of: {sorted(reasons)}\n"
+        f"actual: {reasons}\n"
         f"rc={install_result.returncode}\n{install_output}"
     )
     # Package must NOT be installed after the failed attempt.

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1762,12 +1762,15 @@ def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
         f"pkg install output:\n{install_output}\n"
         f"pkg query '%n': {vm_pkg_query_name(repo_vm)!r}"
     )
-    # AND the failure is ATTRIBUTABLE to the variant mismatch — not merely non-zero.
-    # `install_failed` is deliberately NOT one of these clauses: it is already asserted
-    # above, so including it made every other clause unreachable and the intent
-    # ("the error names the opposite php or an ABI rejection") went unpinned (issue
-    # #1965). A failure with none of these markers is a DIFFERENT failure — an unusable
-    # box, a broken catalog, a transport error — and must not read as the guard firing.
+    # AND the failure names a CAUSE, not merely a non-zero exit. `install_failed` is
+    # deliberately NOT one of these clauses: it is already asserted above, so including
+    # it made every other clause unreachable and the intent ("the error names the
+    # opposite php or an ABI rejection") went unpinned (issue #1965).
+    #
+    # These markers do not fully separate "wrong variant" from "empty/broken catalog":
+    # pkg reports both as "No packages available…". What they DO exclude is a failure
+    # that names no pkg-level cause at all — an unusable box, a transport error, a
+    # crashed ssh — which the old clause set silently accepted as the guard firing.
     lowered = install_output.lower()
     reasons = {
         f"names the opposite php dep ({opp.php})": opp.php in install_output,

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -701,9 +701,39 @@ def test_catalog_name_from_version_rejects_unsafe_segment() -> None:
         ("2.8", "../evil"),  # traversal in the variant
         ("2.8", "CE/x"),  # separator in the variant
         ("2.8", ""),  # empty variant -> a segment starting with '-'
+        ("", "CE"),  # empty version -> the mirror case, a segment ending in '-'
+        ("-BETA", "CE"),  # a version that is nothing BUT a pre-release suffix
     ):
         with pytest.raises(brp.BuildRepoError):
             brp.catalog_name_from_version(version, variant)
+
+    # The channel is an argument too — it must not ride into the path unchecked.
+    for channel in ("../evil", "/abs", "nightly/../.."):
+        with pytest.raises(brp.BuildRepoError):
+            brp.catalog_name_from_version("2.8", "CE", channel=channel)
+    # ...while the legitimate channel still composes.
+    assert brp.catalog_name_from_version("2.8", "CE", channel="nightly") == "nightly/ce-2.8"
+
+
+def test_catalog_name_rejects_pkg_catalog_plumbing_names(tmp_path: Path) -> None:
+    """A catalog name equal to a pkg(8) catalog file is refused, not a raw traceback.
+
+    ``meta`` / ``meta.conf`` / ``data.pkg`` / ``packagesite.pkg`` are written at the
+    catalog root, so ``out_dir / catalog_name`` would name an existing FILE and the
+    rmtree/mkdir would escape this module's BuildRepoError contract.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    out.mkdir()
+    brp.build_repo(in_dir, out)  # lay a root-level catalog, so the names exist as FILES
+    assert (out / "meta.conf").is_file()
+
+    for reserved in ("meta", "meta.conf", "data.pkg", "packagesite.pkg"):
+        with pytest.raises(brp.BuildRepoError, match="catalog plumbing"):
+            brp.build_repo(in_dir, out, catalog_name=reserved)
+        assert (out / reserved).is_file(), f"{reserved} must survive the rejected call"
 
 
 def test_build_repo_rejects_unsafe_catalog_name(tmp_path: Path) -> None:
@@ -768,9 +798,13 @@ def test_catalog_rejects_unsafe_manifest_name_and_version(tmp_path: Path) -> Non
         make_pkg(in_dir / "evil.pkg", abi="FreeBSD:15:*", **kwargs)  # type: ignore[arg-type]
         out = tmp_path / f"out_{field}"
         out.mkdir()
-        with pytest.raises(brp.BuildRepoError):
+        with pytest.raises(brp.BuildRepoError, match=f"manifest {field}"):
             brp.build_repo(in_dir, out)
 
+    # The pre-fix defect WRITES into victim/ rather than deleting from it, so the
+    # failable oracle is "no package landed here" — a surviving keep.txt would be
+    # true either way.
+    assert not list(victim.glob("*.pkg")), f"a manifest field escaped the catalog dir: {list(victim.iterdir())}"
     assert (victim / "keep.txt").read_text() == "must survive"
 
 

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -671,6 +671,109 @@ def test_catalog_name_from_version() -> None:
     assert brp.catalog_name_from_version("26.03.1", "Plus") == "plus-26.03"
 
 
+def test_catalog_name_from_version_strips_prerelease_suffix() -> None:
+    """A pre-release publishes under the SAME catalog as its release line (issue #1965).
+
+    A pfSense pre-release carries a dash suffix inside the minor field
+    ("26.07-BETA", "2.9-RC1"), so a bare major.minor split keeps it. The consumer
+    side — the rc.d repo-generate hook — strips the suffix before deriving the
+    varver, so a box on 26.07-BETA resolves ``release/plus-26.07/``. The producer
+    must strip identically, or it publishes ``release/plus-26.07-BETA/`` that no
+    box ever asks for.
+    """
+    assert brp.catalog_name_from_version("26.07-BETA", "Plus") == "plus-26.07"
+    assert brp.catalog_name_from_version("2.9-RC1", "CE") == "ce-2.9"
+    assert brp.catalog_name_from_version("2.8.1-RELEASE", "CE") == "ce-2.8"
+    # The channel prefix rides along unchanged.
+    assert brp.catalog_name_from_version("26.07-BETA", "Plus", channel="nightly") == "nightly/plus-26.07"
+
+
+def test_catalog_name_from_version_rejects_unsafe_segment() -> None:
+    """The derived varver becomes an rmtree'd path segment — a hostile version is refused.
+
+    ``pfsense_version``/``variant`` come from the ci-metadata matrix, so a bad entry
+    would otherwise be joined straight onto the output root. Same safety rule as
+    build-repo.sh's ``--varver`` guard: no traversal, no separator, lowercase class
+    only, and never a leading '-' (an empty variant yields "-2.8").
+    """
+    for version, variant in (
+        ("/etc", "CE"),  # separator surviving the major.minor split
+        ("2.8", "../evil"),  # traversal in the variant
+        ("2.8", "CE/x"),  # separator in the variant
+        ("2.8", ""),  # empty variant -> a segment starting with '-'
+    ):
+        with pytest.raises(brp.BuildRepoError):
+            brp.catalog_name_from_version(version, variant)
+
+
+def test_build_repo_rejects_unsafe_catalog_name(tmp_path: Path) -> None:
+    """``--catalog-name`` is an rmtree'd path segment — traversal/absolute/foreign chars refused.
+
+    A channel prefix ("release/ce-2.8", "nightly/ce-2.8") is legitimate, so the value
+    is a relative path — but every component still has to clear the varver class.
+
+    Scenario: a hostile or malformed --catalog-name reaches the generator
+      Given a sibling directory holding a file that must survive
+      When build_repo() is called with '../victim', an absolute path, or a component
+        outside build-repo.sh's ``[a-z0-9.-]`` class
+      Then BuildRepoError is raised BEFORE anything is written
+      And the sibling directory is untouched (the rmtree never escaped --out)
+      And a legitimate channel-prefixed name still builds.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    out.mkdir()
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "keep.txt").write_text("must survive")
+
+    unsafe = (
+        "../victim",  # traversal: wipes a sibling of --out
+        str(tmp_path / "victim"),  # absolute: Path.__truediv__ discards --out entirely
+        "ce-2.8/../../victim",  # traversal after a legitimate-looking prefix
+        "CE-2.8",  # outside the lowercase class build-repo.sh enforces
+        "ce 2.8",  # whitespace
+        "release/CE-2.8",  # a bad component behind a legitimate channel prefix
+        "",  # empty: never silently "no catalog name"
+    )
+    for bad in unsafe:
+        with pytest.raises(brp.BuildRepoError):
+            brp.build_repo(in_dir, out, catalog_name=bad)
+
+    assert (victim / "keep.txt").read_text() == "must survive"
+
+    # The legitimate channel-prefixed form is NOT collateral damage.
+    brp.build_repo(in_dir, out, catalog_name="nightly/ce-2.8")
+    assert (out / "nightly" / "ce-2.8" / "meta.conf").is_file()
+
+
+def test_catalog_rejects_unsafe_manifest_name_and_version(tmp_path: Path) -> None:
+    """A manifest's name/version becomes the published .pkg filename — traversal is refused.
+
+    ``<name>-<version>.pkg`` is written into the catalog directory, so an input .pkg
+    whose manifest carries a separator or traversal in either field would write
+    OUTSIDE the catalog. The manifest is attacker-controlled input (it is read from
+    the .pkg, never derived), so it gets the same segment guard as the varver.
+    """
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "keep.txt").write_text("must survive")
+
+    for field in ("name", "version"):
+        in_dir = tmp_path / f"in_{field}"
+        in_dir.mkdir()
+        kwargs = {field: "../victim/evil"}
+        make_pkg(in_dir / "evil.pkg", abi="FreeBSD:15:*", **kwargs)  # type: ignore[arg-type]
+        out = tmp_path / f"out_{field}"
+        out.mkdir()
+        with pytest.raises(brp.BuildRepoError):
+            brp.build_repo(in_dir, out)
+
+    assert (victim / "keep.txt").read_text() == "must survive"
+
+
 def test_catalog_under_versioned_subdir(tmp_path: Path) -> None:
     """--catalog-name writes the FLAT catalog directly at <out>/<catalog-name>/, no ABI subdir.
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -318,6 +318,21 @@ def _mx(abi: str, ver: str, variant: str, php: str, py: str) -> dict[str, str]:
     return {"abi": abi, "pfsense_version": ver, "variant": variant, "php_version": php, "py_flavor": py}
 
 
+def test_matrix_varver_strips_prerelease_suffix() -> None:
+    """The landing page pins a row to the varver its packages are PUBLISHED under.
+
+    A pre-release matrix entry ("26.07-BETA") carries the suffix inside the minor
+    field; the publisher strips it (build-repo-portable.catalog_name_from_version),
+    so this mirror must strip identically — otherwise the varver pin matches nothing
+    and every row falls back to the unpinned pool (issue #1965).
+    """
+    assert gl._matrix_varver("26.07-BETA", "Plus") == "plus-26.07"
+    assert gl._matrix_varver("2.9-RC1", "CE") == "ce-2.9"
+    # Release versions are unaffected.
+    assert gl._matrix_varver("26.03.1", "Plus") == "plus-26.03"
+    assert gl._matrix_varver("2.8.1", "CE") == "ce-2.8"
+
+
 def test_dotted_and_dep_flavor_formatting() -> None:
     """A flavor token / dep name formats to a dotted version; sub-packages don't match."""
     assert gl._dotted_ver("py311") == "3.11"

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -405,6 +405,44 @@ def test_build_edition_sections_wildcard_abi_joins_every_row_of_its_major() -> N
     assert (plus["pfsense_version"], plus["php"], plus["py"]) == ("26.03", "8.5", "3.12")
 
 
+def test_build_edition_sections_wildcard_MATRIX_abi_joins_identically() -> None:
+    """The MATRIX side is wildcarded too, and the join is unchanged by that.
+
+    Every other matrix fixture here records a concrete ABI, but the publisher emits
+    ``FreeBSD:<major>:*`` (pfBlockerNG/pkg: `arch` was retired from the matrix by
+    issue #1806, so interpolating it produced the literal "FreeBSD:16:null"). With
+    both sides wildcarded the exact-string index now HITS instead of falling back to
+    the OS+major scan — a different code path in ``_join_matrix`` reaching the same
+    rows. Pins that equivalence, so the production shape is covered and not merely
+    assumed harmless.
+
+    Given the same package set joined against a concrete-ABI matrix and a
+      wildcard-ABI one,
+    When the edition sections are built from each,
+    Then both yield identical editions, versions, php and py.
+    """
+    pkgs = [_pkg("devel", "d", "3.2.16", "FreeBSD:16:*", "w.pkg")]
+    concrete = [
+        _mx("FreeBSD:16:amd64", "2.9", "CE", "8.4", "py311"),
+        _mx("FreeBSD:16:amd64", "26.03", "Plus", "8.5", "py312"),
+    ]
+    wildcard = [
+        _mx("FreeBSD:16:*", "2.9", "CE", "8.4", "py311"),
+        _mx("FreeBSD:16:*", "26.03", "Plus", "8.5", "py312"),
+    ]
+
+    def shape(matrix: list[dict[str, str]]) -> list[tuple[str, str, str, str]]:
+        return [
+            (edition, r["pfsense_version"], r["php"], r["py"])
+            for edition, rows in gl.build_edition_sections(pkgs, matrix)
+            for r in rows
+        ]
+
+    assert shape(wildcard) == shape(concrete)
+    # ...and the join really happened — nothing degraded to the unmatched section.
+    assert shape(wildcard) == [("CE", "2.9", "8.4", "3.11"), ("Plus", "26.03", "8.5", "3.12")]
+
+
 def test_build_edition_sections_pins_a_published_row_to_its_own_varver_dir() -> None:
     """A published file is listed under the pfSense version of the dir it was published to.
 

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -63,6 +63,18 @@ def test_catalog_name_maps_version_and_variant() -> None:
     assert mx.catalog_name("2.8", "CE") == "ce-2.8"  # two-component version
 
 
+def test_catalog_name_strips_prerelease_suffix() -> None:
+    """A pre-release box resolves its release line's catalog (issue #1965).
+
+    "26.07-BETA" carries the suffix inside the minor field; the production rc.d
+    hook strips it before deriving the varver, so this oracle must too — otherwise
+    the smoke expects a ``plus-26.07-BETA`` catalog no producer ever publishes.
+    """
+    assert mx.catalog_name("26.07-BETA", "Plus") == "plus-26.07"
+    assert mx.catalog_name("2.9-RC1", "CE") == "ce-2.9"
+    assert mx.catalog_name("2.8.1-RELEASE", "CE") == "ce-2.8"
+
+
 def test_build_matrix_parses_env_json(monkeypatch: pytest.MonkeyPatch) -> None:
     """A well-formed SMOKE_MATRIX_JSON array is returned as a tuple of entries."""
     _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX)


### PR DESCRIPTION
## Summary

Three of the four follow-ups from #1964's adversarial review (issue #1965). The fourth — the sibling repo's ABI string — is pfBlockerNG/pkg#4.

This started stacked on #1964; that PR merged mid-flight, so this is rebased onto the resulting `devel`. #1964's own review landed a `catalog_name` guard equivalent to the one drafted here, so the two are reconciled into ONE validator (`_validate_catalog_name`) rather than shipping a second, competing one.

1. **Pre-release varver, producer side.** #1964 closed the consumer half (the rc.d repo-generate hook), but all three producer derivations kept the suffix: `catalog_name_from_version`, `gen_landing._matrix_varver`, and the smoke topology's `_matrix.catalog_name`. A suffixed version reaching any of them publishes (or expects) `release/plus-26.07-BETA/` while every box asks for `release/plus-26.07/`. All three now strip the dash suffix before the major.minor split, matching the hook and `scripts/reconcile-plan.py`'s `family_of()`.

2. **Unvalidated path segments in `build-repo-portable.py`.** A catalog destination is `rmtree`'d and rebuilt, and `scripts/build-repo.sh` already guards the analogous `--varver`, but the Python side guarded nothing. A `..`-relative `--catalog-name` wiped a sibling directory; an absolute one made `Path.__truediv__` discard the output root entirely. The same class applied to the manifest-derived `name`/`version`, which become the published `<name>-<version>.pkg` filename and are read from the package rather than derived. Both are guarded now (`_safe_segment` / `_safe_catalog_path`).

   Two corrections to the issue text. First, `--catalog-name` is **not** a single segment: its legitimate channel-prefixed form (`nightly/ce-2.8`, `release/ce-2.8` — see `catalog_name_from_version`'s `channel` argument) is a relative path, so the guard validates each component. A single-segment guard broke three existing tests; that regression is pinned by a positive case here. Second, the guard #1964 landed was not yet in its head when this was written, so the overlap is resolved in favour of that one, extended three ways: a `single_segment` mode for values DERIVED from matrix fields (where a `/` means an input carried a separator, not a legitimate prefix), an alphanumeric leading character (an absent variant otherwise derives `-2.8`), and `is not None` rather than truthiness (an empty name silently meant "publish at the output root").

3. **Vacuous soft assertion in the wrong-variant smoke guard.** `test_wrong_variant_catalog_fails` ended in `assert has_opp_php_error or has_abi_error or install_failed`. The preceding assertion had already established `install_failed` on the common path, so the "the error mentions the opposite php or an ABI mismatch" intent could never fail. It now asserts a *variant-attributable* reason (the opposite php dep, the opposite ABI, an ABI/OS-version rejection, or no installable candidate) and prints the full marker map on failure, so a failure from an unusable box or a broken catalog no longer reads as the guard firing.

## Test evidence

- **Red (executed, test-first):** the six new/tightened hermetic tests were authored before any production edit and run against the untouched producers — `AssertionError: assert 'plus-26.07-BETA' == 'plus-26.07'` and `Failed: DID NOT RAISE BuildRepoError` (6 failed, 4 passed).
- **Green (executed, unedited):** the same files, `git hash-object` identical across both runs (`4869f46f…` / `f187f55d…` / `565b5484…`) — 182 passed.
- **Gates:** `run-gates.sh` PASS (pytest, ruff check + format, mypy, shellcheck, shellspec).
- **Item 4 (live-VM):** the tightened smoke assertion only executes in the Tier-B `repo` marker, so it was run on a leased live pfSense box — `1 selected, 1 passed` (the selection count is the load-bearing line: a filter that selects nothing also exits 0). Full output in a comment below.
- **Review round 2:** applied the adversarial reviewer's findings — the unchecked `channel` argument, the empty-*version* mirror of the empty-variant hole (`"ce-"`), a catalog name colliding with pkg(8) plumbing raising a raw `NotADirectoryError`, an unfailable sentinel in the manifest test, and two stale "deliberately DIVERGES" texts that this PR falsified. Two findings imported from pfBlockerNG/pkg#18's review land here too, since that change is what falsified them: `gen_landing`'s `_join_matrix`/`eol_versions` docstrings, and the missing wildcard-MATRIX-ABI test.

Part of #1965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-release version suffixes such as BETA, RC, and RELEASE are now consistently removed when generating catalog names and directories.
  * Added safeguards to reject unsafe package, version, channel, variant, and catalog values before filesystem changes occur.
  * Reserved catalog metadata names are now rejected to prevent conflicts.
  * Improved wrong-variant installation checks to provide more accurate failure detection.
* **Tests**
  * Expanded coverage for catalog naming, path safety, pre-release handling, and wildcard ABI matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->