### PR TITLE
Contain the catalog destination inside the output root

### DIFF
--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -451,7 +451,7 @@ def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) 
     return sorted(abis)
 
 
-def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict]]) -> int:
+def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict]], *, root: Path) -> int:
     """Write one pkg catalog at ``dest`` from a ``{(name, version): (path, manifest)}`` map.
 
     Wipes + rebuilds ``dest`` for determinism (a removed .pkg never lingers), copies each
@@ -472,6 +472,11 @@ def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict
         canonical = f"{name}-{version}.pkg"
         staged.append((canonical, path.read_bytes(), path.stat().st_mtime, manifest))
 
+    # Re-checked HERE, immediately before the wipe, not only at the caller: staging above
+    # reads every input .pkg, and a layout that changed under us in that window would
+    # otherwise be acted on. This narrows the race to no intervening I/O; it does not
+    # eliminate it (only an O_NOFOLLOW/dir_fd walk would). Issue #1972.
+    _require_contained(root, dest)
     if dest.exists():
         shutil.rmtree(dest)
     dest.mkdir(parents=True)
@@ -564,6 +569,11 @@ def _require_contained(root: Path, dest: Path) -> Path:
             f"catalog destination {str(dest)!r} is a symlink — the catalog directory is wiped "
             f"and rebuilt, so it must be a real directory"
         )
+    if dest.exists() and not dest.is_dir():
+        raise BuildRepoError(
+            f"catalog destination {str(dest)!r} exists and is not a directory — the catalog "
+            f"directory is wiped and rebuilt, so it cannot be an existing file"
+        )
     return dest
 
 
@@ -578,10 +588,10 @@ def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path], *, root: Path) -
     tripwire that forces a conscious layout decision if a compiled, per-arch
     dependency is ever added.
 
-    ``root`` is the output root ``dest`` must stay inside. This is the single
-    destructive choke point (``_write_catalog_dir`` is reached only from here), so the
-    containment check lives here rather than at each composition site — a future
-    caller cannot forget it (issue #1972).
+    ``root`` is the output root ``dest`` must stay inside. Checked here to fail before
+    reading every input package, and again in ``_write_catalog_dir`` immediately before
+    the wipe — that second one is authoritative, so the guard holds even for a future
+    caller that reaches the writer by another route (issue #1972).
     """
     _require_contained(root, dest)
     entries: list[tuple[Path, dict]] = [(p, read_compact_manifest(p)) for p in sorted(set(pkg_paths))]
@@ -595,7 +605,7 @@ def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path], *, root: Path) -
             sys.stderr.write(f"==> dedup: {path.name} duplicates {items[nv][0].name} ({nv[0]}-{nv[1]})\n")
             continue
         items[nv] = (path, manifest)
-    return _write_catalog_dir(dest, items)
+    return _write_catalog_dir(dest, items, root=root)
 
 
 def _retain_newest(pkg_paths: list[Path], keep: int) -> list[Path]:

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -573,8 +573,12 @@ def _require_contained(root: Path, dest: Path) -> Path:
     # file (it does not raise), and resolve() passes straight through such a component, so
     # a leaf-only check lets `mkdir(parents=True)` raise a raw NotADirectoryError from
     # inside the writer. Walk from the root outwards so the message names the real culprit.
+    # `is_relative_to` alone is the stop condition: the root IS a component that must be a
+    # real directory (without a catalog name the destination simply IS the root), and the
+    # first ancestor ABOVE it is not relative to it, so the walk never inspects anything
+    # outside the output root.
     for component in (dest, *dest.parents):
-        if not component.is_relative_to(root) or component == root:
+        if not component.is_relative_to(root):
             break
         if component.exists() and not component.is_dir():
             raise BuildRepoError(

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -569,11 +569,19 @@ def _require_contained(root: Path, dest: Path) -> Path:
             f"catalog destination {str(dest)!r} is a symlink — the catalog directory is wiped "
             f"and rebuilt, so it must be a real directory"
         )
-    if dest.exists() and not dest.is_dir():
-        raise BuildRepoError(
-            f"catalog destination {str(dest)!r} exists and is not a directory — the catalog "
-            f"directory is wiped and rebuilt, so it cannot be an existing file"
-        )
+    # Every component, not just the leaf: `dest.exists()` is False when an ANCESTOR is a
+    # file (it does not raise), and resolve() passes straight through such a component, so
+    # a leaf-only check lets `mkdir(parents=True)` raise a raw NotADirectoryError from
+    # inside the writer. Walk from the root outwards so the message names the real culprit.
+    for component in (dest, *dest.parents):
+        if not component.is_relative_to(root) or component == root:
+            break
+        if component.exists() and not component.is_dir():
+            raise BuildRepoError(
+                f"catalog destination {str(dest)!r} is unusable: {str(component)!r} exists and is "
+                f"not a directory — the catalog directory is wiped and rebuilt, so every component "
+                f"of its path must be a real directory"
+            )
     return dest
 
 

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -446,7 +446,7 @@ def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) 
         )
 
     catalog_root = out_dir / catalog_name if catalog_name else out_dir
-    n = _emit_catalog_from_paths(catalog_root, pkgs)
+    n = _emit_catalog_from_paths(catalog_root, pkgs, root=out_dir)
     sys.stderr.write(f"==> built catalog {catalog_root} ({n} package(s))\n")
     return sorted(abis)
 
@@ -537,7 +537,37 @@ def _pkg_version_key(version: str) -> tuple[list[int], int, int]:
     return pkg_version_sort_key(version)
 
 
-def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path]) -> int:
+def _require_contained(root: Path, dest: Path) -> Path:
+    """Return ``dest`` if it really lands inside ``root``, else raise (issue #1972).
+
+    ``_validate_catalog_name`` checks the catalog name as a STRING; the FILESYSTEM
+    decides where that string lands. A symlink at any component — including an
+    intermediate one, which ``shutil.rmtree`` follows happily — redirects the
+    wipe-and-rebuild outside the output root while every segment still looks like a
+    legitimate varver. Resolving both sides and requiring containment is the check the
+    name guard structurally cannot make.
+
+    A symlinked LEAF is refused outright even when it points back inside the root: the
+    catalog directory is wiped and recreated, so it has to be a real directory this
+    tool owns (``rmtree`` declines a symlink, which would surface as a raw ``OSError``).
+    """
+    resolved_root = root.resolve()
+    resolved_dest = dest.resolve()
+    if not resolved_dest.is_relative_to(resolved_root):
+        raise BuildRepoError(
+            f"catalog destination {str(dest)!r} escapes the output root {str(root)!r} "
+            f"(resolves to {str(resolved_dest)!r}) — a symlinked path component redirects "
+            f"the rmtree+rebuild outside --out"
+        )
+    if dest.is_symlink():
+        raise BuildRepoError(
+            f"catalog destination {str(dest)!r} is a symlink — the catalog directory is wiped "
+            f"and rebuilt, so it must be a real directory"
+        )
+    return dest
+
+
+def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path], *, root: Path) -> int:
     """Read each .pkg's manifest, dedup by (name, version), collision-check, emit at dest.
 
     Every package here MUST carry a NO_ARCH (wildcard) ABI (``_is_wildcard_abi``,
@@ -547,7 +577,13 @@ def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path]) -> int:
     one. A concrete ABI reaching catalog emission is a hard error — the
     tripwire that forces a conscious layout decision if a compiled, per-arch
     dependency is ever added.
+
+    ``root`` is the output root ``dest`` must stay inside. This is the single
+    destructive choke point (``_write_catalog_dir`` is reached only from here), so the
+    containment check lives here rather than at each composition site — a future
+    caller cannot forget it (issue #1972).
     """
+    _require_contained(root, dest)
     entries: list[tuple[Path, dict]] = [(p, read_compact_manifest(p)) for p in sorted(set(pkg_paths))]
     _check_collisions(entries)
     for path, manifest in entries:
@@ -886,7 +922,7 @@ def build_repo_matrix(
                     f"frozen .pkg, but none match ABI {abi!r} — supply a frozen .pkg for this ABI."
                 )
             release_dir = out_dir / "release" / varver
-            n_release = _emit_catalog_from_paths(release_dir, frozen)
+            n_release = _emit_catalog_from_paths(release_dir, frozen, root=out_dir)
             built.append(str(release_dir))
             sys.stderr.write(f"==> route-only release catalog {release_dir} ({n_release} package(s), frozen)\n")
             # No nightly subtree — route-only entries never get a nightly build.
@@ -920,7 +956,7 @@ def build_repo_matrix(
                 )
                 if kept_release:
                     # dep_for_abi folds in AFTER retention (never competes for a slot).
-                    n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi)
+                    n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi, root=out_dir)
                     built.append(str(release_dir))
                     sys.stderr.write(f"==> release catalog {release_dir} ({n_release} package(s), consumed)\n")
                     dep_pkgs_matched.update(dep_for_abi)
@@ -952,7 +988,7 @@ def build_repo_matrix(
                         keep_stable=release_keep_stable,
                     )
                     # dep_for_abi folds in AFTER retention (never competes for a slot).
-                    n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi)
+                    n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi, root=out_dir)
                 built.append(str(release_dir))
                 sys.stderr.write(f"==> release catalog {release_dir} ({n_release} package(s))\n")
                 dep_pkgs_matched.update(dep_for_abi)
@@ -976,7 +1012,7 @@ def build_repo_matrix(
                     kept = _retain_newest([*existing, new_nightly], nightly_keep)
                     # dep_for_abi folds in AFTER retention here too — the SAME dep pkg
                     # belongs in both the release and nightly catalogs of this ABI train.
-                    n = _emit_catalog_from_paths(nightly_dir, kept + dep_for_abi)
+                    n = _emit_catalog_from_paths(nightly_dir, kept + dep_for_abi, root=out_dir)
                 built.append(str(nightly_dir))
                 sys.stderr.write(f"==> nightly catalog {nightly_dir} ({n} package(s), kept ≤{nightly_keep})\n")
                 dep_pkgs_matched.update(dep_for_abi)

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -838,6 +838,27 @@ def test_catalog_dest_that_is_a_plain_file_is_refused(tmp_path: Path) -> None:
     assert (out / "ce-2.8").read_text() == "not a directory"
 
 
+def test_catalog_dest_with_a_non_directory_parent_is_refused(tmp_path: Path) -> None:
+    """A plain FILE at an INTERMEDIATE component is refused, like one at the leaf.
+
+    ``dest.exists()`` is False when an ancestor is a file (it does not raise), and
+    ``resolve()`` passes straight through such a component, so a leaf-only check misses
+    this — ``mkdir(parents=True)`` then raises a raw NotADirectoryError from inside the
+    writer. Same contract hole as the leaf case, one path level up (issue #1972).
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "release").write_text("not a directory")
+
+    with pytest.raises(brp.BuildRepoError, match="not a directory"):
+        brp.build_repo(in_dir, out, catalog_name="release/ce-2.8")
+
+    assert (out / "release").read_text() == "not a directory"
+
+
 def test_catalog_dest_containment_allows_a_real_nested_dir(tmp_path: Path) -> None:
     """The containment guard must not refuse the layout the publisher actually writes.
 

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -859,6 +859,25 @@ def test_catalog_dest_with_a_non_directory_parent_is_refused(tmp_path: Path) -> 
     assert (out / "release").read_text() == "not a directory"
 
 
+def test_output_root_that_is_not_a_directory_is_refused(tmp_path: Path) -> None:
+    """The output ROOT is a component too — a file there is refused, with or without a name.
+
+    The root is where the walk stops, so it is the component most easily excluded from
+    its own check. Both shapes reach it: without a catalog name the destination IS the
+    root, and with one the root is its furthest ancestor (issue #1972).
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
+
+    for catalog_name in (None, "release/ce-2.8"):
+        out = tmp_path / f"out_{catalog_name or 'bare'}".replace("/", "_")
+        out.write_text("not a directory")
+        with pytest.raises(brp.BuildRepoError, match="not a directory"):
+            brp.build_repo(in_dir, out, catalog_name=catalog_name)
+        assert out.read_text() == "not a directory"
+
+
 def test_catalog_dest_containment_allows_a_real_nested_dir(tmp_path: Path) -> None:
     """The containment guard must not refuse the layout the publisher actually writes.
 

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -793,6 +793,51 @@ def test_catalog_dest_symlinked_leaf_cannot_escape_out(tmp_path: Path) -> None:
     assert sorted(p.name for p in outside.iterdir()) == ["precious.txt"]
 
 
+def test_catalog_dest_symlinked_leaf_inside_root_is_still_refused(tmp_path: Path) -> None:
+    """A symlinked leaf is refused even when it points back INSIDE the output root.
+
+    Containment cannot decide this one — the target is legitimately inside --out — but
+    the catalog directory is wiped and recreated, so it has to be a real directory this
+    tool owns. ``shutil.rmtree`` declines to follow a symlink, which would otherwise
+    surface as a raw OSError instead of a BuildRepoError (issue #1972).
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    out.mkdir()
+    real = out / "real"
+    real.mkdir()
+    (real / "keep.txt").write_text("must survive")
+    (out / "ce-2.8").symlink_to(real, target_is_directory=True)
+
+    with pytest.raises(brp.BuildRepoError, match="is a symlink"):
+        brp.build_repo(in_dir, out, catalog_name="ce-2.8")
+
+    assert (real / "keep.txt").read_text() == "must survive"
+    assert not list(real.glob("*.pkg")), f"the symlinked leaf was written through: {list(real.iterdir())}"
+
+
+def test_catalog_dest_that_is_a_plain_file_is_refused(tmp_path: Path) -> None:
+    """A catalog name naming an existing FILE is refused, not a raw traceback.
+
+    ``_RESERVED_CATALOG_NAMES`` covers only the four pkg(8) plumbing names, but any
+    regular file at the destination (a stray published .pkg, say) hits the same path:
+    ``mkdir`` on it raises NotADirectoryError, escaping the BuildRepoError contract.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "ce-2.8").write_text("not a directory")
+
+    with pytest.raises(brp.BuildRepoError, match="not a directory"):
+        brp.build_repo(in_dir, out, catalog_name="ce-2.8")
+
+    assert (out / "ce-2.8").read_text() == "not a directory"
+
+
 def test_catalog_dest_containment_allows_a_real_nested_dir(tmp_path: Path) -> None:
     """The containment guard must not refuse the layout the publisher actually writes.
 

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -736,6 +736,84 @@ def test_catalog_name_rejects_pkg_catalog_plumbing_names(tmp_path: Path) -> None
         assert (out / reserved).is_file(), f"{reserved} must survive the rejected call"
 
 
+def test_catalog_dest_symlinked_prefix_cannot_escape_out(tmp_path: Path) -> None:
+    """A symlink at an INTERMEDIATE path component must not steer the write out of --out.
+
+    The catalog name is validated as a string, so every component is a legitimate
+    varver token — but the filesystem decides where that string lands. With
+    ``<out>/nightly`` a symlink to a directory outside ``--out``, the whole catalog
+    (which is rmtree'd and rebuilt) is written through it (issue #1972).
+
+    Scenario: an attacker plants a symlink inside the CI output root
+      Given <out>/nightly is a symlink to an outside directory holding a file
+       When build_repo() is called with the legitimate name 'nightly/ce-2.8'
+       Then BuildRepoError is raised
+        And the outside directory keeps its file and gains no catalog.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    out.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "precious.txt").write_text("must survive")
+    (out / "nightly").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(brp.BuildRepoError, match="escapes"):
+        brp.build_repo(in_dir, out, catalog_name="nightly/ce-2.8")
+
+    assert (outside / "precious.txt").read_text() == "must survive"
+    assert sorted(p.name for p in outside.iterdir()) == ["precious.txt"], (
+        f"the write escaped --out: {sorted(p.name for p in outside.iterdir())}"
+    )
+
+
+def test_catalog_dest_symlinked_leaf_cannot_escape_out(tmp_path: Path) -> None:
+    """The LEAF is a symlink too: rmtree refuses it, but with a raw OSError.
+
+    ``shutil.rmtree`` declines to follow a symlinked leaf, so nothing outside is
+    deleted — but the failure escapes this module's BuildRepoError contract, and the
+    caller cannot tell a hostile layout from a bad input. Refuse it up front instead
+    (issue #1972).
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    out.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "precious.txt").write_text("must survive")
+    (out / "ce-2.8").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(brp.BuildRepoError, match="escapes"):
+        brp.build_repo(in_dir, out, catalog_name="ce-2.8")
+
+    assert sorted(p.name for p in outside.iterdir()) == ["precious.txt"]
+
+
+def test_catalog_dest_containment_allows_a_real_nested_dir(tmp_path: Path) -> None:
+    """The containment guard must not refuse the layout the publisher actually writes.
+
+    ``release/<varver>/`` and ``nightly/<varver>/`` are ordinary nested directories
+    under --out; only a symlink escaping the root is hostile. Pins that the guard
+    added for issue #1972 costs the legitimate case nothing.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "ce-pkg.pkg", name="pfBlockerNG-devel", abi="FreeBSD:15:*")
+    out = tmp_path / "out"
+    out.mkdir()
+
+    brp.build_repo(in_dir, out, catalog_name="release/ce-2.8")
+    assert (out / "release" / "ce-2.8" / "meta.conf").is_file()
+
+    # Idempotent: a rebuild over the existing (real) directory still works.
+    brp.build_repo(in_dir, out, catalog_name="release/ce-2.8")
+    assert (out / "release" / "ce-2.8" / "meta.conf").is_file()
+
+
 def test_build_repo_rejects_unsafe_catalog_name(tmp_path: Path) -> None:
     """``--catalog-name`` is an rmtree'd path segment — traversal/absolute/foreign chars refused.
 


### PR DESCRIPTION
## Summary

Closes the one finding from #1965's adversarial review that was deliberately left unfixed there: `_validate_catalog_name` checks the catalog name as a **string**, but the **filesystem** decides where that string lands.

With `<out>/nightly` a symlink to a directory outside `--out`, every segment of `nightly/ce-2.8` still looks like a legitimate varver, so the name guard passes — and the wipe-and-rebuild follows the symlink straight out of the output root:

```
build_repo(..., catalog_name="nightly/ce-2.8")   # no error
outside/ -> ['ce-2.8', 'precious.txt']
```

`_require_contained` resolves both sides and requires the destination to stay under the root — the check a string guard structurally cannot make. Two design points:

- **It lives in `_emit_catalog_from_paths`, not at each composition site.** That is the single destructive choke point (`_write_catalog_dir` is reached only from there), so a future caller that composes a new destination cannot forget the check. The output root is threaded in from each of the five call sites.
- **A symlinked LEAF is refused too,** even when it points back inside the root. The catalog directory is wiped and recreated, so it has to be a real directory this tool owns. `shutil.rmtree` already declined that case, but as a raw `OSError` escaping this module's `BuildRepoError` contract — the same class of hole as the pkg(8)-plumbing-name collision fixed in #1971.

## Test evidence

- **Red (executed, test-first):** both reproduction tests were authored before any production edit and run against the untouched guard — the symlinked **prefix** as `Failed: DID NOT RAISE BuildRepoError`, with the package written into the outside directory, and the symlinked **leaf** as the raw `OSError: [Errno None] None: .../out/ce-2.8`.
- **Green (executed, unedited):** same file, `git hash-object` `ffc406e2282d116438c1207abb9c1e29d0cce650` across both runs — 125 passed.
- **No false positive:** a third test pins that the legitimate `release/<varver>/` layout still builds, including an idempotent rebuild over an existing real directory, so the tightening costs the real publisher nothing.
- **Gates:** `run-gates.sh` PASS; `mypy scripts/build-repo-portable.py` clean (the threaded `root` parameter is checked at every call site).

Fixes #1972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection when rebuilding catalogs to prevent writes outside the intended output directory.
  * Added safeguards against symlink-based paths, files, and invalid directories that could redirect or disrupt catalog output.
  * Valid nested catalog directories continue to rebuild successfully and consistently.

* **Tests**
  * Added coverage for unsafe paths, preservation of files outside the output directory, clear error reporting, and repeatable rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->