### PR TITLE
Isolate every scratch-repo git call from the developer's config

### DIFF
--- a/tests/gitenv.py
+++ b/tests/gitenv.py
@@ -1,0 +1,37 @@
+"""Hermetic environment for scratch-repo `git` calls in the unit suite.
+
+A test that builds a throwaway repository and commits into it must not inherit the
+developer's global/system Git configuration: `commit.gpgsign=true` makes the synthetic
+`user.name=t` identity attempt a signed commit it has no key for, and git exits 128 with
+`fatal: failed to write commit object` before the tool under test ever runs (issue #1967).
+The same class covers `init.defaultBranch`, `init.templateDir`, `core.hooksPath` and any
+`include.path` a developer has set — none of which the scratch repo asked for.
+
+Pointing both config scopes at `os.devnull` is the repo's established fix
+(`tests/test_agent_roles_check.py` shipped it first); this module is the single
+definition every scratch-git helper reuses so the scopes cannot drift apart.
+
+Deliberately NOT applied session-wide via a conftest fixture: that would also scrub the
+environment of the CHECKERS these suites run as subprocesses, and several of them exist
+precisely to prove a hostile Git configuration cannot blind the gate
+(`test_cli_hostile_git_configs_cannot_bypass_the_gate`). The scrub belongs to repo SETUP,
+not to the tool under test.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def scrubbed_git_env(**overrides: str) -> dict[str, str]:
+    """The process environment with both Git config scopes neutralised.
+
+    ``overrides`` are applied last, for a caller that needs an extra variable
+    (e.g. a fake ``PATH``) in the same environment.
+    """
+    return {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        **overrides,
+    }

--- a/tests/gitenv.py
+++ b/tests/gitenv.py
@@ -1,21 +1,28 @@
-"""Hermetic environment for scratch-repo `git` calls in the unit suite.
+"""Config-neutral environment for scratch-repo `git` calls in the unit suite.
 
 A test that builds a throwaway repository and commits into it must not inherit the
 developer's global/system Git configuration: `commit.gpgsign=true` makes the synthetic
 `user.name=t` identity attempt a signed commit it has no key for, and git exits 128 with
 `fatal: failed to write commit object` before the tool under test ever runs (issue #1967).
-The same class covers `init.defaultBranch`, `init.templateDir`, `core.hooksPath` and any
-`include.path` a developer has set — none of which the scratch repo asked for.
+`core.hooksPath` pointing at a real hook set is the same class — the scratch repo then
+runs hooks it never asked for. (Probed: a NONEXISTENT hooksPath/templateDir/excludesFile
+is ignored by git and harmless; it is a hooksPath that actually resolves that bites.)
 
 Pointing both config scopes at `os.devnull` is the repo's established fix
-(`tests/test_agent_roles_check.py` shipped it first); this module is the single
-definition every scratch-git helper reuses so the scopes cannot drift apart.
+(`tests/test_agent_roles_check.py` shipped it first); this module is the single definition
+every PYTEST scratch-git helper reuses so the two scopes cannot drift apart. The shellspec
+suite under `tests/shell/` has the same defect and its own mechanism — tracked separately,
+not covered here.
 
-Deliberately NOT applied session-wide via a conftest fixture: that would also scrub the
-environment of the CHECKERS these suites run as subprocesses, and several of them exist
-precisely to prove a hostile Git configuration cannot blind the gate
-(`test_cli_hostile_git_configs_cannot_bypass_the_gate`). The scrub belongs to repo SETUP,
-not to the tool under test.
+Scope note: this neutralises CONFIG, not the whole Git environment. `GIT_DIR`,
+`GIT_WORK_TREE`, `GIT_INDEX_FILE` and `GIT_PREFIX` are still inherited and would override
+`cwd`; a caller that runs under a Git hook wants ``drop_git_vars=True`` as well.
+
+Deliberately NOT applied session-wide via a conftest fixture. The scrub is a property of
+repository SETUP, and a session fixture would silently change the environment the
+CHECKER-under-test observes — several of these suites run that checker as a subprocess and
+assert on what it sees. (It would also miss the call sites that build their env from
+scratch rather than from ``os.environ``, so it is not even a complete substitute.)
 """
 
 from __future__ import annotations
@@ -23,15 +30,16 @@ from __future__ import annotations
 import os
 
 
-def scrubbed_git_env(**overrides: str) -> dict[str, str]:
+def scrubbed_git_env(*, drop_git_vars: bool = False) -> dict[str, str]:
     """The process environment with both Git config scopes neutralised.
 
-    ``overrides`` are applied last, for a caller that needs an extra variable
-    (e.g. a fake ``PATH``) in the same environment.
+    ``drop_git_vars`` additionally strips every inherited ``GIT_*`` variable. Needed when
+    the suite may run under a Git hook, which exports ``GIT_DIR``/``GIT_INDEX_FILE``/
+    ``GIT_WORK_TREE``/``GIT_PREFIX`` — those override ``cwd`` and would point every
+    invocation at the REAL repository instead of the throwaway one.
     """
-    return {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": os.devnull,
-        "GIT_CONFIG_SYSTEM": os.devnull,
-        **overrides,
-    }
+    base = {k: v for k, v in os.environ.items() if not (drop_git_vars and k.startswith("GIT_"))}
+    # After the strip, never before: these two ARE GIT_* variables and must survive it.
+    base["GIT_CONFIG_GLOBAL"] = os.devnull
+    base["GIT_CONFIG_SYSTEM"] = os.devnull
+    return base

--- a/tests/test_agent_roles_check.py
+++ b/tests/test_agent_roles_check.py
@@ -13,12 +13,13 @@ surface changed) is exercised through the CLI against real scratch git repos.
 from __future__ import annotations
 
 import importlib.util
-import os
 import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+from tests.gitenv import scrubbed_git_env
 
 _TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_agent_roles.py"
 _spec = importlib.util.spec_from_file_location("check_agent_roles", _TOOL)
@@ -436,7 +437,7 @@ def test_touches_role_surface_unit() -> None:
 
 
 def _git(root: Path, *args: str) -> None:
-    env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull}
+    env = scrubbed_git_env()
     subprocess.run(
         ["git", "-C", str(root), "-c", "user.name=t", "-c", "user.email=t@example.com", *args],
         check=True,

--- a/tests/test_comment_narration_check.py
+++ b/tests/test_comment_narration_check.py
@@ -18,6 +18,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from tests.gitenv import scrubbed_git_env
+
 _TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_comment_narration.py"
 _spec = importlib.util.spec_from_file_location("check_comment_narration", _TOOL)
 assert _spec is not None and _spec.loader is not None
@@ -284,11 +288,48 @@ def _git(repo: Path, *args: str) -> None:
         cwd=repo,
         check=True,
         capture_output=True,
+        env=scrubbed_git_env(),
     )
 
 
 def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run([sys.executable, str(_TOOL), *args], cwd=repo, capture_output=True, text=True)
+
+
+def test_scratch_git_helper_ignores_a_hostile_global_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A scratch commit must succeed on a machine whose global config signs commits.
+
+    With ``commit.gpgsign=true`` visible, the synthetic ``user.name=t`` identity attempts
+    a signed commit it has no key for and git exits 128 (``fatal: failed to write commit
+    object``) before the checker under test ever runs — the whole CLI section of this file
+    then fails for a reason that has nothing to do with narration (issue #1967).
+
+    Given a global Git config that forces signing with an unusable key,
+    When the scratch-repo helper initialises a repo and commits,
+    Then the commit succeeds and HEAD resolves — the helper neutralises both config scopes.
+    """
+    hostile = tmp_path / "hostile-gitconfig"
+    hostile.write_text("[commit]\n\tgpgsign = true\n[gpg]\n\tformat = ssh\n[user]\n\tsigningkey = /nonexistent/key\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(hostile))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(hostile))
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "devel")
+    (repo / "src").mkdir()
+    (repo / "src" / "thing.inc").write_text("// clean\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=scrubbed_git_env(),
+    ).stdout.strip()
+    assert len(head) == 40, f"scratch commit did not produce a resolvable HEAD: {head!r}"
 
 
 def test_cli_escape_requires_colon_and_reason(tmp_path: Path) -> None:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.gitenv import scrubbed_git_env
+
 _TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_context_budget.py"
 _spec = importlib.util.spec_from_file_location("check_context_budget", _TOOL)
 assert _spec is not None and _spec.loader is not None
@@ -88,13 +90,15 @@ def _scratch_repo(tmp_path: Path) -> Path:
     _write(root, ".agents/context/lang-php.md", f"# PHP\n\n{_HEADER}")
     _write(root, ".agents/context/lang-python.md", f"# Python\n\n{_HEADER}")
     _write(root, ".agents/context/lang-shell.md", f"# Shell\n\n{_HEADER}")
-    subprocess.run(["git", "init", "-q", root], check=True)
-    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    subprocess.run(["git", "init", "-q", root], check=True, env=scrubbed_git_env())
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True, env=scrubbed_git_env())
     return root
 
 
 def _tracked(root: Path) -> list[str]:
-    out = subprocess.run(["git", "-C", root, "ls-files"], capture_output=True, text=True, check=True).stdout
+    out = subprocess.run(
+        ["git", "-C", root, "ls-files"], capture_output=True, text=True, check=True, env=scrubbed_git_env()
+    ).stdout
     return [line for line in out.split("\n") if line]
 
 
@@ -794,10 +798,11 @@ def test_cli_staged_skips_when_no_context_surface_staged(tmp_path: Path) -> None
     subprocess.run(
         ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
         check=True,
+        env=scrubbed_git_env(),
     )
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
     _write(root, "src/thing.inc", "<?php\n")
-    subprocess.run(["git", "-C", root, "add", "src/thing.inc"], check=True)
+    subprocess.run(["git", "-C", root, "add", "src/thing.inc"], check=True, env=scrubbed_git_env())
     proc = _run_cli(root, "--staged")
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "skipped" in proc.stdout
@@ -808,9 +813,10 @@ def test_cli_staged_runs_and_fails_on_staged_over_budget_policy(tmp_path: Path) 
     subprocess.run(
         ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
         check=True,
+        env=scrubbed_git_env(),
     )
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
-    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True, env=scrubbed_git_env())
     proc = _run_cli(root, "--staged")
     assert proc.returncode == 1, proc.stdout + proc.stderr
     assert ".agents/policy/alpha.md" in proc.stdout and "> budget 12288" in proc.stdout
@@ -823,9 +829,10 @@ def test_cli_staged_checks_index_content_not_working_tree(tmp_path: Path) -> Non
     subprocess.run(
         ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
         check=True,
+        env=scrubbed_git_env(),
     )
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
-    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True, env=scrubbed_git_env())
     _write(root, ".agents/policy/alpha.md", f"# Alpha\n\n{_HEADER}")
     proc = _run_cli(root, "--staged")
     assert proc.returncode == 1, proc.stdout + proc.stderr
@@ -839,9 +846,10 @@ def test_cli_staged_ignores_unstaged_working_tree_violation(tmp_path: Path) -> N
     subprocess.run(
         ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
         check=True,
+        env=scrubbed_git_env(),
     )
     _write(root, ".agents/policy/alpha.md", f"# Alpha (tweaked)\n\n{_HEADER}")
-    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True, env=scrubbed_git_env())
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
     proc = _run_cli(root, "--staged")
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -850,10 +858,10 @@ def test_cli_staged_ignores_unstaged_working_tree_violation(tmp_path: Path) -> N
 def test_cli_diff_fires_on_over_budget_commit_vs_base(tmp_path: Path) -> None:
     root = _scratch_repo(tmp_path)
     git = ["git", "-C", str(root), "-c", "user.name=t", "-c", "user.email=t@example.com"]
-    subprocess.run([*git, "commit", "-qm", "base"], check=True)
+    subprocess.run([*git, "commit", "-qm", "base"], check=True, env=scrubbed_git_env())
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
-    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
-    subprocess.run([*git, "commit", "-qm", "bloat"], check=True)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True, env=scrubbed_git_env())
+    subprocess.run([*git, "commit", "-qm", "bloat"], check=True, env=scrubbed_git_env())
     proc = _run_cli(root, "--diff", "HEAD~1")
     assert proc.returncode == 1, proc.stdout + proc.stderr
     assert ".agents/policy/alpha.md" in proc.stdout and "> budget 12288" in proc.stdout
@@ -864,7 +872,7 @@ def test_cli_all_flags_non_ascii_named_policy_file(tmp_path: Path) -> None:
     # quoted string would match no budget — the checker must still see the file.
     root = _scratch_repo(tmp_path)
     _write(root, ".agents/policy/pölicy.md", "# P\n\n" + _HEADER + "x" * 20_000)
-    subprocess.run(["git", "-C", root, "add", "-A"], check=True)
+    subprocess.run(["git", "-C", root, "add", "-A"], check=True, env=scrubbed_git_env())
     proc = _run_cli(root, "--all")
     assert proc.returncode == 1, proc.stdout + proc.stderr
     # NFC/NFD filename normalization differs per OS — match the ASCII tail only.

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -784,6 +784,19 @@ def test_touches_context_surface_false_on_unrelated() -> None:
 # --- CLI against scratch repos -------------------------------------------------
 
 
+def _git_commit(root: str | Path, message: str) -> None:
+    """Commit everything staged in a scratch repo under a synthetic identity.
+
+    One definition rather than four copies, and the single place the config-scope scrub
+    has to be right for this file (issue #1967).
+    """
+    subprocess.run(
+        ["git", "-C", str(root), "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", message],
+        check=True,
+        env=scrubbed_git_env(),
+    )
+
+
 def _run_cli(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(_TOOL), *args, "--root", str(root)],
@@ -795,11 +808,7 @@ def _run_cli(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 def test_cli_staged_skips_when_no_context_surface_staged(tmp_path: Path) -> None:
     root = _scratch_repo(tmp_path)
-    subprocess.run(
-        ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
-        check=True,
-        env=scrubbed_git_env(),
-    )
+    _git_commit(root, "base")
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
     _write(root, "src/thing.inc", "<?php\n")
     subprocess.run(["git", "-C", root, "add", "src/thing.inc"], check=True, env=scrubbed_git_env())
@@ -810,11 +819,7 @@ def test_cli_staged_skips_when_no_context_surface_staged(tmp_path: Path) -> None
 
 def test_cli_staged_runs_and_fails_on_staged_over_budget_policy(tmp_path: Path) -> None:
     root = _scratch_repo(tmp_path)
-    subprocess.run(
-        ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
-        check=True,
-        env=scrubbed_git_env(),
-    )
+    _git_commit(root, "base")
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
     subprocess.run(["git", "-C", root, "add", "-A"], check=True, env=scrubbed_git_env())
     proc = _run_cli(root, "--staged")
@@ -826,11 +831,7 @@ def test_cli_staged_checks_index_content_not_working_tree(tmp_path: Path) -> Non
     # Staged over-budget + worktree fixed back under budget: the commit would
     # still ship the violation, so --staged must fail (index is the snapshot).
     root = _scratch_repo(tmp_path)
-    subprocess.run(
-        ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
-        check=True,
-        env=scrubbed_git_env(),
-    )
+    _git_commit(root, "base")
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)
     subprocess.run(["git", "-C", root, "add", "-A"], check=True, env=scrubbed_git_env())
     _write(root, ".agents/policy/alpha.md", f"# Alpha\n\n{_HEADER}")
@@ -843,11 +844,7 @@ def test_cli_staged_ignores_unstaged_working_tree_violation(tmp_path: Path) -> N
     # Staged content clean + worktree bloated: the commit ships the clean index,
     # so --staged must pass instead of false-failing on the dirty worktree.
     root = _scratch_repo(tmp_path)
-    subprocess.run(
-        ["git", "-C", root, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "base"],
-        check=True,
-        env=scrubbed_git_env(),
-    )
+    _git_commit(root, "base")
     _write(root, ".agents/policy/alpha.md", f"# Alpha (tweaked)\n\n{_HEADER}")
     subprocess.run(["git", "-C", root, "add", "-A"], check=True, env=scrubbed_git_env())
     _write(root, ".agents/policy/alpha.md", "# Alpha\n\n" + _HEADER + "x" * 20_000)

--- a/tests/test_gitenv.py
+++ b/tests/test_gitenv.py
@@ -1,0 +1,135 @@
+"""Every scratch-repo git helper stays usable on a hostile developer machine (issue #1967).
+
+The per-suite helpers each build a throwaway repository and commit into it. If any one of
+them inherits the developer's global/system Git configuration, that whole suite fails for a
+reason unrelated to what it tests — `commit.gpgsign=true` alone took out 55 tests across
+five files, and a global `core.hooksPath` that resolves makes a scratch commit run foreign
+hooks.
+
+Fixing the helpers is not enough on its own: deleting a single `env=scrubbed_git_env()`
+leaves the suite green on a clean CI machine, so the regression would sail back in. These
+cases are the pin — each exercises a real helper against a hostile config, so removing that
+helper's scrub turns THIS file red no matter how clean the environment running it is.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.gitenv import scrubbed_git_env
+
+_HOSTILE = "[commit]\n\tgpgsign = true\n[gpg]\n\tformat = ssh\n[user]\n\tsigningkey = /nonexistent/key\n"
+
+# Every module owning a scratch-repo helper of the shape ``_git(repo, *args)``.
+_GIT_HELPER_MODULES = (
+    "tests.test_agent_roles_check",
+    "tests.test_comment_narration_check",
+    "tests.test_release_tag_after_verify",
+    "tests.test_retired_token_check",
+    "tests.test_version_literal_check",
+)
+
+
+def _hostile_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point both Git config scopes at a config that demands an impossible signature."""
+    cfg = tmp_path / "hostile-gitconfig"
+    cfg.write_text(_HOSTILE)
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(cfg))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(cfg))
+
+
+def test_scrubbed_git_env_neutralises_both_config_scopes() -> None:
+    """Both scopes, always — one alone still lets the other's config through."""
+    env = scrubbed_git_env()
+    assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert env["GIT_CONFIG_SYSTEM"] == os.devnull
+
+
+def test_scrubbed_git_env_drop_git_vars_keeps_the_two_config_scopes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``drop_git_vars`` strips inherited GIT_* — but never the two keys it exists to set.
+
+    They are themselves ``GIT_*`` names, so a strip applied after them would silently
+    re-arm the very defect this module prevents.
+    """
+    monkeypatch.setenv("GIT_DIR", "/somewhere/.git")
+    monkeypatch.setenv("GIT_WORK_TREE", "/somewhere")
+
+    kept = scrubbed_git_env()
+    assert kept["GIT_DIR"] == "/somewhere/.git"
+
+    dropped = scrubbed_git_env(drop_git_vars=True)
+    assert "GIT_DIR" not in dropped
+    assert "GIT_WORK_TREE" not in dropped
+    assert dropped["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert dropped["GIT_CONFIG_SYSTEM"] == os.devnull
+
+
+@pytest.mark.parametrize("module_name", _GIT_HELPER_MODULES)
+def test_scratch_git_helper_commits_under_a_hostile_config(
+    module_name: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each suite's ``_git`` helper still reaches a commit when the global config signs.
+
+    Given a global+system config demanding a signature from an unusable key,
+    When the module's own scratch-repo helper inits, stages and commits,
+    Then the commit succeeds — the helper neutralised both scopes rather than inheriting.
+    """
+    _hostile_config(tmp_path, monkeypatch)
+    git = importlib.import_module(module_name)._git
+
+    repo = tmp_path / module_name.rsplit(".", 1)[-1]
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "devel")
+    (repo / "a.txt").write_text("one\n")
+    git(repo, "add", "a.txt")
+    git(repo, "commit", "-qm", "base")
+
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=scrubbed_git_env(),
+    ).stdout.strip()
+    assert len(head) == 40, f"{module_name}: scratch commit produced no HEAD ({head!r})"
+
+
+def test_context_budget_scratch_commit_survives_a_hostile_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``test_context_budget`` owns a differently-shaped helper; pin it the same way."""
+    _hostile_config(tmp_path, monkeypatch)
+    mod = importlib.import_module("tests.test_context_budget")
+
+    root = mod._scratch_repo(tmp_path)
+    mod._git_commit(root, "base")
+
+    head = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=scrubbed_git_env(),
+    ).stdout.strip()
+    assert len(head) == 40, f"context-budget scratch commit produced no HEAD ({head!r})"
+
+
+def test_read_version_matrix_env_neutralises_config_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The matrix suite's env helper strips GIT_* AND neutralises the config scopes.
+
+    It kept its own definition for the GIT_DIR/GIT_WORK_TREE strip its scratch repo needs;
+    stripping those alone still let a global ``core.hooksPath`` reach the scratch commit,
+    which repo-local ``commit.gpgsign false`` never covered.
+    """
+    monkeypatch.setenv("GIT_DIR", "/somewhere/.git")
+    env = importlib.import_module("tests.test_read_version_matrix")._clean_git_env()
+
+    assert "GIT_DIR" not in env
+    assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert env["GIT_CONFIG_SYSTEM"] == os.devnull

--- a/tests/test_gitenv.py
+++ b/tests/test_gitenv.py
@@ -78,6 +78,11 @@ def test_scratch_git_helper_commits_under_a_hostile_config(
     Given a global+system config demanding a signature from an unusable key,
     When the module's own scratch-repo helper inits, stages and commits,
     Then the commit succeeds — the helper neutralised both scopes rather than inheriting.
+
+    The identity is set repo-locally rather than relied upon: only some of these helpers
+    inject ``-c user.email``/``-c user.name`` themselves (the others configure it on the
+    scratch repo), and with both config scopes neutralised there is no global identity to
+    fall back on — git's implicit username@hostname guess is not available everywhere.
     """
     _hostile_config(tmp_path, monkeypatch)
     git = importlib.import_module(module_name)._git
@@ -85,6 +90,8 @@ def test_scratch_git_helper_commits_under_a_hostile_config(
     repo = tmp_path / module_name.rsplit(".", 1)[-1]
     repo.mkdir()
     git(repo, "init", "-q", "-b", "devel")
+    git(repo, "config", "user.email", "t@example.invalid")
+    git(repo, "config", "user.name", "t")
     (repo / "a.txt").write_text("one\n")
     git(repo, "add", "a.txt")
     git(repo, "commit", "-qm", "base")

--- a/tests/test_read_version_matrix.py
+++ b/tests/test_read_version_matrix.py
@@ -26,7 +26,6 @@ No network; needs git + jq (both present on the CI runner and locally).
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -34,11 +33,13 @@ from typing import Any
 
 import pytest
 
+from tests.gitenv import scrubbed_git_env
+
 _SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "read-version-matrix.sh"
 
 
 def _clean_git_env() -> dict[str, str]:
-    """Env with every GIT_* var stripped.
+    """Env with every GIT_* var stripped AND both Git config scopes neutralised.
 
     The test drives git in a throwaway repo (cwd=tmp_path) and the script itself
     shells out to git. When the suite runs under the pre-commit hook, git exports
@@ -47,8 +48,13 @@ def _clean_git_env() -> dict[str, str]:
     REAL repo (where a `ci-metadata` ref already exists — `git branch ci-metadata`
     then fails rc 128, and `git show` reads the wrong matrix). Scrub them so the
     temp repo is the sole git context, matching a clean standalone `pytest` run.
+
+    Delegates to ``scrubbed_git_env`` so the config-scope half has ONE definition
+    across the suite (issue #1967): stripping GIT_* alone still let the developer's
+    global config reach the scratch repo — a global ``core.hooksPath`` that resolves
+    makes every commit here run foreign hooks.
     """
-    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    return scrubbed_git_env(drop_git_vars=True)
 
 
 CE_DEFAULT_IMAGE_NAME = "pfsense-ce"

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -896,6 +896,7 @@ def _tag_still_there(tmp_path: Path, tag: str) -> bool:
             ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"],
             cwd=tmp_path / "work",
             capture_output=True,
+            env=scrubbed_git_env(),
         ).returncode
         == 0
     )

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -43,6 +43,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.gitenv import scrubbed_git_env
+
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
 PUBLISHED_WORKFLOW = ROOT / ".github/workflows/release-published.yml"
@@ -709,6 +711,7 @@ def _git(repo: Path, *args: str) -> str:
         capture_output=True,
         text=True,
         check=True,
+        env=scrubbed_git_env(),
     ).stdout.strip()
 
 
@@ -716,8 +719,8 @@ def _tag_repo(tmp_path: Path) -> tuple[Path, str, str]:
     """A work repo with a bare `origin`, two commits; returns (repo, head_sha, older_sha)."""
     origin = tmp_path / "origin.git"
     repo = tmp_path / "work"
-    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True)  # noqa: S603
-    subprocess.run(["git", "init", "-q", "-b", "devel", str(repo)], check=True)  # noqa: S603
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True, env=scrubbed_git_env())  # noqa: S603
+    subprocess.run(["git", "init", "-q", "-b", "devel", str(repo)], check=True, env=scrubbed_git_env())  # noqa: S603
     _git(repo, "config", "user.email", "t@example.invalid")
     _git(repo, "config", "user.name", "t")
     (repo / "a.txt").write_text("one\n")

--- a/tests/test_retired_token_check.py
+++ b/tests/test_retired_token_check.py
@@ -21,6 +21,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tests.gitenv import scrubbed_git_env
+
 _TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_retired_tokens.py"
 _spec = importlib.util.spec_from_file_location("check_retired_tokens", _TOOL)
 assert _spec is not None and _spec.loader is not None
@@ -75,7 +77,9 @@ def _retired(diff_text: str) -> list[str]:
 
 
 def _init_repo(repo: Path) -> None:
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main"], cwd=repo, check=True, capture_output=True, env=scrubbed_git_env()
+    )
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -84,6 +88,7 @@ def _git(repo: Path, *args: str) -> None:
         cwd=repo,
         check=True,
         capture_output=True,
+        env=scrubbed_git_env(),
     )
 
 

--- a/tests/test_retired_token_check.py
+++ b/tests/test_retired_token_check.py
@@ -103,7 +103,9 @@ def _run_hook(repo: Path, stdin_text: str) -> subprocess.CompletedProcess[str]:
 
 
 def _rev(repo: Path) -> str:
-    out = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True)
+    out = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True, env=scrubbed_git_env()
+    )
     return out.stdout.strip()
 
 

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -632,7 +632,9 @@ def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 
 def _rev(repo: Path) -> str:
-    out = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True)
+    out = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True, env=scrubbed_git_env()
+    )
     return out.stdout.strip()
 
 

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -21,6 +21,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from tests.gitenv import scrubbed_git_env
+
 _TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_version_literals.py"
 _spec = importlib.util.spec_from_file_location("check_version_literals", _TOOL)
 assert _spec is not None and _spec.loader is not None
@@ -621,6 +623,7 @@ def _git(repo: Path, *args: str) -> None:
         cwd=repo,
         check=True,
         capture_output=True,
+        env=scrubbed_git_env(),
     )
 
 


### PR DESCRIPTION
## Summary

The canonical Python gate failed on machines with `commit.gpgsign=true` set globally: the scratch repositories these suites build inherit the developer's global and system Git configuration, so their synthetic `user.name=t` identity attempts a signed commit it has no key for and git exits 128 with `fatal: failed to write commit object` — before the tool under test ever runs.

**#1967 reports one test; the defect is the whole class.** Reproduced with a global config forcing signing, **55 tests fail across five files**:

| File | Failures |
| --- | --- |
| `test_version_literal_check.py` | 17 |
| `test_retired_token_check.py` | 16 |
| `test_release_tag_after_verify.py` | 10 |
| `test_comment_narration_check.py` | 7 ← the reported one |
| `test_context_budget.py` | 5 |

Fixing only the reported file would have left 48 failures behind, so every **pytest** scratch-git call site is fixed — six helpers, one shared definition in `tests/gitenv.py`.

Review round 2 corrected the completeness claim in three ways:

- **A sixth helper was missed.** `tests/test_read_version_matrix.py` had a competing `_clean_git_env` that strips `GIT_*` but never neutralises the config scopes. It survived #1967 only by a point defence (repo-local `commit.gpgsign false`), which covers signing and nothing else: a global `core.hooksPath` that *resolves* makes every scratch commit run foreign hooks (probed — 21 passed clean, 21 failed with a real hook set; a *nonexistent* hooksPath/templateDir/excludesFile is ignored by git and harmless). It now delegates to the shared definition, which grew a `drop_git_vars` option for the `GIT_DIR`/`GIT_WORK_TREE` strip that file genuinely needs.
- **Five of six scrubs were unpinned.** Deleting `env=scrubbed_git_env()` from any of them left the suite green on a clean machine. `tests/test_gitenv.py` now exercises each helper against a hostile config, verified one helper at a time.
- **The shellspec suite has the identical defect** (0 failures clean → 92 under the same signing config) and its own mechanism. Filed as #1984 rather than left implied by "every scratch-git call site".

`tests/gitenv.py` holds the single definition (both config scopes pointed at `os.devnull` — the fix `tests/test_agent_roles_check.py` shipped first, which now imports it rather than keeping its own copy) so the two scopes cannot drift apart across six call sites.

**Deliberately not a session-wide conftest fixture.** The scrub is a property of repository **setup**, and a session fixture would silently change the environment a checker-under-test observes — several of these suites run that checker as a subprocess and assert on what it sees. (An earlier draft justified this by claiming `test_cli_hostile_git_configs_cannot_bypass_the_gate` depends on inherited config; review disproved that — it plants its knobs repo-locally — so the stated reason was replaced with the true one rather than left as something the next reader could refute in a minute.)

## Test evidence

`test_scratch_git_helper_ignores_a_hostile_global_config` pins the property in-suite rather than leaving it dependent on whoever happens to have signing enabled: it points `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at a config demanding a signature from an unusable key, then asserts the scratch commit still resolves a HEAD.

- **Red (executed, test-first):** authored before the helper change and run against the unscrubbed helper — `subprocess.CalledProcessError: Command '['git', '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'base']' returned non-zero exit status 128`.
- **Green (executed, unedited):** same file, `git hash-object` `7105a09af979fd48fceb11d82505bdd4be1a384b` on both sides.
- **Whole-suite proof under the same hostile config:** `55 failed, 3838 passed` before → `3910 passed, 4 skipped` after.
- **Gates:** `run-gates.sh` PASS.

Production narration-check behaviour is untouched; this is test-harness isolation only.

Fixes #1967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
