### PR TITLE
pfblockerng: write logs as UTF-8 and reconcile DNSBL comments

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -2966,7 +2966,7 @@ def _log_entry_direct(line: str, log: str) -> None:
     # init, in the test suite, or if it failed to start): open/append/close per line.
     for i in range(1, 5):
         try:
-            with open(log, "a") as append_log:
+            with open(log, "a", encoding="utf-8") as append_log:
                 append_log.write(line + "\n")
         except Exception as e:
             if i == 4:
@@ -3021,7 +3021,7 @@ def pfb_setup_logging() -> None:
             logger.handlers = [_PfbDropQueueHandler(pfb_log_queue)]
             pfb_loggers[path] = logger
 
-            handler = logging.handlers.WatchedFileHandler(path, mode="a", delay=True)
+            handler = logging.handlers.WatchedFileHandler(path, mode="a", encoding="utf-8", delay=True)
             handler.setFormatter(logging.Formatter("%(message)s"))
             handler.addFilter(_PfbLogFilter(name))
             handlers.append(handler)

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1367,11 +1367,9 @@ def init_standard(id: int, env: module_env) -> bool:
     # dnsbl_cache_stage() exactly like pfb_py_hsts above.
     pfb["pfb_py_tld"] = "pfb_py_tld.txt"
     pfb["pfb_py_ss"] = "pfb_py_ss.txt"
-    # ADR-06: per-feed manifest (the new shell->Python boundary) and the
-    # Python-emitted entry count. When the manifest is present, init builds the
-    # DNSBL structures from the raw feeds via the pure build() layer; otherwise
-    # it falls back to the legacy data/zone CSV load (shell/PHP still produce
-    # those files for that fallback).
+    # ADR-65: the per-feed manifest is the sole DNSBL source. Init builds matcher
+    # structures from its raw feed snapshots; a missing/invalid manifest fails loud
+    # and leaves them empty. Python emits the loaded entry count separately.
     pfb["pfb_py_sources"] = "pfb_py_sources.json"
     # ADR-10: the zero-downtime RELOAD SENTINEL. Path is chroot-relative (Unbound
     # is chrooted at /var/unbound, the module's CWD) -- so the in-chroot absolute path
@@ -1750,7 +1748,7 @@ def init_standard(id: int, env: module_env) -> bool:
                 dnsbl_emit_reject_stats(pfb["pfb_py_reject_stats"], build_result.rejects)
                 dnsbl_built = True
 
-            # While reading 'data|zone' CSV files: Replace 'Feed/Group' pairs with an index value (Memory performance)
+            # ADR-65: seed the pass-through index for the retired CSV loader's close-only compatibility call.
             feedGroup_index = 0
 
             # Zone/Data dicts -- or close their entries when the manifest built them.

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -30,6 +30,7 @@ outcome is identical.
 
 from __future__ import annotations
 
+import builtins
 import json
 import os
 import shutil
@@ -300,6 +301,42 @@ class TestInitFromRawCounts:
 # --------------------------------------------------------------------------- #
 # Wiring robustness: absent / broken manifest -> None (init falls back to legacy).
 # --------------------------------------------------------------------------- #
+
+
+class TestLogWriterEncoding:
+    def test_direct_writer_opens_with_explicit_utf8(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        log = os.path.join(str(tmp_path), "dnsbl.log")
+        encodings: list[str | None] = []
+        real_open = builtins.open
+
+        def spy_open(file: Any, mode: str = "r", *, encoding: str | None = None, **kwargs: Any) -> Any:
+            encodings.append(encoding)
+            return real_open(file, mode, encoding=encoding, **kwargs)
+
+        monkeypatch.setattr(pfb_unbound, "open", spy_open, raising=False)
+        pfb_unbound._log_entry_direct("Grüppe", log)
+
+        assert encodings == ["utf-8"]
+        assert open(log, "rb").read() == "Grüppe\n".encode()
+
+    def test_watched_file_handlers_open_with_explicit_utf8(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        paths = (str(tmp_path / "dnsbl.log"), str(tmp_path / "dns_reply.log"))
+        encodings: list[str] = []
+        real_handler = pfb_unbound.logging.handlers.WatchedFileHandler
+
+        def spy_handler(path: str, *, mode: str, encoding: str, delay: bool) -> Any:
+            encodings.append(encoding)
+            return real_handler(path, mode=mode, encoding=encoding, delay=delay)
+
+        monkeypatch.setattr(pfb_unbound, "PFB_LOG_FILES", paths)
+        monkeypatch.setattr(pfb_unbound.logging.handlers, "WatchedFileHandler", spy_handler)
+        pfb_unbound.pfb_setup_logging()
+        pfb_unbound.pfb_log_listener.stop()
+        pfb_unbound.pfb["log_listener"] = False
+
+        assert encodings == ["utf-8", "utf-8"]
 
 
 class TestManifestFallback:

--- a/tests/test_adr06_init_from_raw.py
+++ b/tests/test_adr06_init_from_raw.py
@@ -19,8 +19,8 @@ no-IP-leak guarantee. It also pins the on-box wiring:
   * ``top1m_enabled`` is driven by ``config["top1m_enabled"]`` in the manifest;
   * ``dnsbl_emit_count`` writes the LOADED total (len(dataDB)+len(zoneDB)) to
     ``pfb_py_count`` in the format the UI reads (pfblockerng.inc:3149); and
-  * a missing/broken manifest yields ``None`` (init falls back to the legacy CSV
-    load -- shell/PHP still produce those files until Phase 5).
+  * a missing/broken manifest yields ``None``; manifest-only init fails loud and
+    leaves the matcher databases empty.
 
 The contract is DECISIONS, not list contents/counts (ADR.md SS2): the build's
 dicts differ from today's pruned lists by design (no dedup/collapse/whitelist/
@@ -299,7 +299,7 @@ class TestInitFromRawCounts:
 
 
 # --------------------------------------------------------------------------- #
-# Wiring robustness: absent / broken manifest -> None (init falls back to legacy).
+# Wiring robustness: absent / broken manifest -> None (manifest-only init fails loud).
 # --------------------------------------------------------------------------- #
 
 


### PR DESCRIPTION
## Summary

- Make the synchronous and queued DNSBL/DNS-reply log writers explicitly encode UTF-8.
- Reconcile stale comments with ADR-65's manifest-only DNSBL initialization behavior.
- Keep the two issues as separate commits in this PR.

## Verification

- RED: `python3 -m pytest -q tests/test_adr06_init_from_raw.py::TestLogWriterEncoding` — 2 failed before production changes.
- GREEN: same frozen test block (`385c907004339d5c7727337970b9bef8da4e82097282680fc43e638e52c3801d`) — 2 passed.
- `python3 -m pytest -q tests/test_adr06_init_from_raw.py tests/test_adr61_py_status.py tests/test_adr65_fallback_characterization.py` — 66 passed.
- `scripts/agent/run-gates.sh --diff origin/devel` — PASS (pytest, Ruff check/format, mypy).

Fixes #1818
Fixes #1726

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log handling to consistently support UTF-8 text, including non-ASCII characters.
  * Clarified behavior when DNS blocklist manifests are missing or invalid: initialization now fails cleanly without creating incomplete matcher data.

* **Documentation**
  * Updated technical documentation to describe the manifest as the sole DNS blocklist source and note the retired CSV loader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->