### PR TITLE
tests/smoke: correct stale baseline contract

### DIFF
--- a/tests/smoke/ui/conftest.py
+++ b/tests/smoke/ui/conftest.py
@@ -493,17 +493,8 @@ def browser_context(webui: WebUI, smoke_vm: SmokeVM) -> Iterator[BrowserContext]
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: ARG001 - pytest hook signature
     """Report grandfathered diagnostics a FULL sweep never observed (#1218).
 
-    A baseline entry nobody sees any more is a site that got fixed, and leaving it in
-    ``php_diagnostic_baseline.txt`` would silently forgive that diagnostic if it ever came
-    back -- the same blindness this issue exists to remove. So the list has to shed entries
-    as the burn-down (#1712) lands them, and this names the candidates.
-
-    It REPORTS rather than fails, because one green sweep does not prove a fix: several
-    pages read config keys that exist only in some states (the Feeds catalogue loop is the
-    worst), so a given entry legitimately goes unobserved in a run that did not reach its
-    state. Deletion is confirmed the honest way instead -- a burn-down PR removes the entry
-    and the sweep goes RED if the diagnostic is still emitted, which is a stronger proof
-    than any single run's silence.
+    :func:`stale_baseline_entries` owns the report-not-fail rationale and confirmation
+    contract.
 
     Only a full sweep may report at all -- a ``--filter``ed or sharded run visits a subset
     of the pages, so nearly every entry would look stale. ``run-smoke.sh`` exports

--- a/tests/smoke/ui/render_oracle.py
+++ b/tests/smoke/ui/render_oracle.py
@@ -263,10 +263,9 @@ def load_baseline(path: Path | None = None) -> frozenset[str]:
     return frozenset(line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#"))
 
 
-# Fingerprints from the SHIPPED baseline actually seen during this session. A baseline
-# entry nobody observes any more is a site that got FIXED, and leaving it in the file
-# would silently forgive that diagnostic if it ever came back -- so a full sweep fails on
-# unobserved entries and the fix is to delete them (see stale_baseline_entries).
+# Fingerprints from the SHIPPED baseline actually seen during this session. A full,
+# successful sweep reports unobserved entries as removal candidates; see
+# stale_baseline_entries for why their absence does not fail the sweep.
 _observed_baseline: set[str] = set()
 
 
@@ -276,10 +275,14 @@ def observed_baseline_entries() -> frozenset[str]:
 
 
 def stale_baseline_entries(observed: frozenset[str], baseline: frozenset[str] | None = None) -> tuple[str, ...]:
-    """Baseline entries never observed -- fixed sites whose grandfathering must go.
+    """Baseline entries never observed -- candidates for removing grandfathering.
 
     Only meaningful after a FULL sweep: a filtered or sharded run visits a subset of the
     pages, so almost every entry would read as stale. The caller owns that condition.
+
+    These entries are reported, not gated: one green sweep does not prove a fix because
+    some config-dependent paths may not be reached. Confirm removal by deleting the entry;
+    the sweep then fails if that diagnostic is still emitted.
     """
     grandfathered = load_baseline() if baseline is None else baseline
     return tuple(sorted(grandfathered - observed))


### PR DESCRIPTION
## Summary

- correct the render oracle's stale-baseline documentation to match report-only behavior
- keep the rationale and removal-confirmation contract in `stale_baseline_entries`
- point the pytest session hook at that single authoritative contract

## Verification

- `python3 -m pytest tests/smoke/ui/test_render_oracle.py --override-ini=addopts= -q` — 43 passed
- `python3 -m pytest -qq` — 3909 passed, 4 skipped
- `scripts/agent/run-gates.sh --diff origin/devel` — GATES: PASS

Fixes #1790

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
