### PR TITLE
repo: reject pre-#1806 route-only tags

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -74,6 +74,16 @@ The `role` field controls how the catalog generator treats an entry:
   so existing boxes can `pkg install`/`upgrade`. A truly dropped entry (no route at all) is
   simply absent from the JSON.
 
+Route-only starts with release assets produced by issue #1806. Older tags contain
+concrete-ABI `.pkg` files, but the current catalog is arch-less and cannot serve them safely.
+Those pre-#1806 tags are **unservable as route-only**: `build-repo-portable.py` rejects the
+asset explicitly instead of emitting a single-architecture catalog. Drop the matrix entry
+when no post-#1806 wildcard-ABI asset exists; do not repackage the frozen tag at EOL.
+
+> **KNOWN GAP / owner call:** a post-#1806 wildcard-ABI frozen `.pkg` may still declare
+> dependencies represented by the family's `extra_pkgs`. Route-only catalogs do not fold in
+> `--dep-pkgs`; whether they must do so remains undecided in issue #1828.
+
 `--print-route` emits the **ROUTE matrix** — build-role-eligible entries (one row per version,
 never deduped) UNION `role=route-only` entries. This is every entry with an actively served
 `release/<varver>/` catalog. The publish pipeline uses `--print-route` minus `--print-build`
@@ -105,8 +115,9 @@ default.
   status flip when it sees a final build). The matrix is the desired state; the box is
   the source of truth.
 - **Drop** an entry when it should be fully removed (no catalog served). For an EOL version
-  that still has users, set `role: "route-only"` instead of dropping it — the last `.pkg` keeps
-  being served. Drop only when you want a clean 404 (no route).
+  that still has users, set `role: "route-only"` only when its last tag has a post-#1806
+  wildcard-ABI `.pkg`; otherwise it is unservable and must be dropped. Drop also when you
+  intentionally want a clean 404 (no route).
 - **Plus** entries set `ci: true` to run the smoke fan-out from a **PRIVATE, licensed** GHCR
   image (`pfsense-plus`, ADR-24); their VM identity comes from the `SMOKE_PLUS_*` secrets,
   never the matrix, and is redacted from the uploaded diagnostics.
@@ -121,7 +132,7 @@ default.
 | --- | --- | --- | --- |
 | CE — `build` (default) | yes (portable Linux builder) | yes (`ci: true`) | yes |
 | Plus — `build` (default) | yes (portable Linux builder; build needs only the right FreeBSD-major target, no license) | yes (`ci: true`, from a private licensed image — ADR-24) | yes |
-| Any — `route-only` | **no** (frozen `.pkg` reused) | **no** | yes (from frozen `.pkg`) |
+| Any — `route-only` | **no** (post-#1806 frozen `.pkg` reused) | **no** | yes (wildcard-ABI asset required) |
 
 **Portable Linux builder** (`build-pkg-linux.yml` / `scripts/build-pkg-portable.py`) is the
 **sole** `.pkg` builder for both CI and releases: it runs on a plain Linux runner and

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -94,7 +94,9 @@ def _require_wildcard_abi(path: Path, abi: object) -> str:
             f"{path.name}: catalog requires a NO_ARCH (wildcard-ABI) package — got "
             f"concrete ABI {abi!r}. The catalog tree is arch-less (one directory serves "
             f"every arch of a FreeBSD major); a concrete-ABI package would silently "
-            f"install on only one arch. Ship a wildcard-ABI (NO_ARCH) build instead."
+            f"install on only one arch. For a frozen route-only package, a concrete ABI "
+            f"identifies a pre-#1806 tag; a pre-#1806 tag is unservable as route-only. "
+            f"Refusing to emit it."
         )
     return abi
 

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -81,22 +81,27 @@ class BuildRepoError(Exception):
     """A fatal, user-facing error (bad input / collision / missing tool)."""
 
 
-def _require_wildcard_abi(path: Path, abi: object) -> str:
+def _require_wildcard_abi(path: Path, abi: object, *, route_only: bool = False) -> str:
     """Validate ``abi`` is a NO_ARCH package's wildcard ABI, or raise ``BuildRepoError``.
 
     Shared by ``build_repo()`` and ``_emit_catalog_from_paths()`` so the reject wording
     (and the NO_ARCH policy behind it) has exactly one canonical source instead of two
     verbatim-duplicated copies. Returns the validated ABI as ``str`` (narrowed via
-    ``_is_wildcard_abi``'s ``TypeGuard``) so callers need no further cast.
+    ``_is_wildcard_abi``'s ``TypeGuard``) so callers need no further cast. ``route_only``
+    selects the settled pre-#1806 frozen-tag remedy without mislabeling other inputs.
     """
     if not _is_wildcard_abi(abi):
+        remedy = (
+            "For a frozen route-only package, a concrete ABI identifies a pre-#1806 tag; "
+            "a pre-#1806 tag is unservable as route-only. Refusing to emit it."
+            if route_only
+            else "Ship a wildcard-ABI (NO_ARCH) build instead."
+        )
         raise BuildRepoError(
             f"{path.name}: catalog requires a NO_ARCH (wildcard-ABI) package — got "
             f"concrete ABI {abi!r}. The catalog tree is arch-less (one directory serves "
             f"every arch of a FreeBSD major); a concrete-ABI package would silently "
-            f"install on only one arch. For a frozen route-only package, a concrete ABI "
-            f"identifies a pre-#1806 tag; a pre-#1806 tag is unservable as route-only. "
-            f"Refusing to emit it."
+            f"install on only one arch. {remedy}"
         )
     return abi
 
@@ -591,7 +596,7 @@ def _require_contained(root: Path, dest: Path) -> Path:
     return dest
 
 
-def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path], *, root: Path) -> int:
+def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path], *, root: Path, route_only: bool = False) -> int:
     """Read each .pkg's manifest, dedup by (name, version), collision-check, emit at dest.
 
     Every package here MUST carry a NO_ARCH (wildcard) ABI (``_is_wildcard_abi``,
@@ -611,7 +616,7 @@ def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path], *, root: Path) -
     entries: list[tuple[Path, dict]] = [(p, read_compact_manifest(p)) for p in sorted(set(pkg_paths))]
     _check_collisions(entries)
     for path, manifest in entries:
-        _require_wildcard_abi(path, manifest.get("abi"))
+        _require_wildcard_abi(path, manifest.get("abi"), route_only=route_only)
     items: dict[tuple[str, str], tuple[Path, dict]] = {}
     for path, manifest in entries:
         nv = (manifest["name"], manifest["version"])
@@ -946,7 +951,7 @@ def build_repo_matrix(
                     f"frozen .pkg, but none match ABI {abi!r} — supply a frozen .pkg for this ABI."
                 )
             release_dir = out_dir / "release" / varver
-            n_release = _emit_catalog_from_paths(release_dir, frozen, root=out_dir)
+            n_release = _emit_catalog_from_paths(release_dir, frozen, root=out_dir, route_only=True)
             built.append(str(release_dir))
             sys.stderr.write(f"==> route-only release catalog {release_dir} ({n_release} package(s), frozen)\n")
             # No nightly subtree — route-only entries never get a nightly build.

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1939,13 +1939,13 @@ def test_eol_route_only_install_from_frozen_catalog(repo_vm: SmokeVM, tmp_path: 
 
     # ---- Build the route-only (EOL) catalog ON THE RUNNER (no guest involved). ----
     # Uses --build-matrix + --route-only-pkgs — the exact CLI shape publish.yml will use.
-    # issue #1806 D3 KNOWN GAP (deliberately not addressed here): --dep-pkgs never
+    # issue #1828 KNOWN GAP / owner call (deliberately not addressed here): this
+    # post-#1806 wildcard-ABI asset is eligible for route-only, but --dep-pkgs never
     # folds into a route-only entry (test_dep_pkgs_route_only_entry_never_folds_
-    # dep_shared_major_build_entry_does pins that exclusion), so this frozen
-    # catalog cannot carry SMOKE_DEP_PKGS even though the frozen .pkg's payload
-    # (a reversion_pkg of the branch build) declares the SAME RUN_DEPENDS. If the
-    # branch's RUN_DEPENDS set ever needs a repo-supplied dep, an EOL/route-only
-    # install of it stays unresolved by design — a product question beyond D3.
+    # dep_shared_major_build_entry_does pins that exclusion). This frozen catalog
+    # therefore cannot carry SMOKE_DEP_PKGS even though the frozen .pkg declares the
+    # same RUN_DEPENDS. Whether such post-#1806 families need their dependencies
+    # frozen alongside the last .pkg remains an owner decision.
     eol_out_dir = tmp_path / "eol_catalog_out"
     local_release_dir = _build_eol_catalog_on_runner(
         frozen_pkg,

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1939,13 +1939,10 @@ def test_eol_route_only_install_from_frozen_catalog(repo_vm: SmokeVM, tmp_path: 
 
     # ---- Build the route-only (EOL) catalog ON THE RUNNER (no guest involved). ----
     # Uses --build-matrix + --route-only-pkgs — the exact CLI shape publish.yml will use.
-    # issue #1828 KNOWN GAP / owner call (deliberately not addressed here): this
-    # post-#1806 wildcard-ABI asset is eligible for route-only, but --dep-pkgs never
-    # folds into a route-only entry (test_dep_pkgs_route_only_entry_never_folds_
-    # dep_shared_major_build_entry_does pins that exclusion). This frozen catalog
-    # therefore cannot carry SMOKE_DEP_PKGS even though the frozen .pkg declares the
-    # same RUN_DEPENDS. Whether such post-#1806 families need their dependencies
-    # frozen alongside the last .pkg remains an owner decision.
+    # issue #1828: route-only catalogs accept post-#1806 wildcard-ABI assets, but
+    # --dep-pkgs never folds into a route-only entry. This frozen catalog therefore
+    # cannot carry SMOKE_DEP_PKGS even though the frozen .pkg declares the same
+    # RUN_DEPENDS.
     eol_out_dir = tmp_path / "eol_catalog_out"
     local_release_dir = _build_eol_catalog_on_runner(
         frozen_pkg,

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -2927,27 +2927,30 @@ def test_route_only_wildcard_frozen_pkg_serves_all_arch_rows_of_varver(tmp_path:
     assert [o["version"] for o in objs] == ["3.1.0_5"]
 
 
-def test_route_only_concrete_abi_frozen_pkg_rejected_at_emission(tmp_path: Path) -> None:
-    """A concrete-ABI frozen .pkg is a hard error — the arch-less catalog HARD-REQUIRES
-    a NO_ARCH (wildcard-ABI) package (issue #1806), even for a route-only (frozen
-    EOL) entry: a concrete one would silently install on only one arch.
+def test_route_only_pre_1806_concrete_abi_fails_explicitly(tmp_path: Path) -> None:
+    """A concrete-ABI frozen .pkg identifies a pre-#1806 tag, which is explicitly
+    unservable as route-only rather than emitted into an arch-less catalog.
 
     Scenario: a concrete FreeBSD:14:amd64 frozen .pkg served via route_only_pkgs
       When build_repo_matrix runs
-      Then it raises BuildRepoError naming the concrete ABI
+      Then it raises BuildRepoError naming the concrete ABI and settled policy
+       And it emits no route-only catalog
     """
     out = tmp_path / "site"
     frozen_pkg = tmp_path / "frozen" / "pfBlockerNG-devel-3.1.0_5.pkg"
     frozen_pkg.parent.mkdir()
     make_pkg(frozen_pkg, name="pfBlockerNG-devel", version="3.1.0_5", abi="FreeBSD:14:amd64")
 
-    with pytest.raises(brp.BuildRepoError, match="NO_ARCH"):
+    with pytest.raises(brp.BuildRepoError, match=r"pre-#1806 tag is unservable as route-only") as exc_info:
         brp.build_repo_matrix(
             [_CE_EOL],
             out,
             builder=_stub_builder,
             route_only_pkgs={"ce-2.7": [frozen_pkg]},
         )
+
+    assert "FreeBSD:14:amd64" in str(exc_info.value)
+    assert not (out / "release" / "ce-2.7").exists()
 
 
 def test_route_only_no_frozen_pkg_for_abi_raises(tmp_path: Path) -> None:

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -3206,7 +3206,8 @@ def test_consume_mode_concrete_abi_pkg_rejected_at_emission(tmp_path: Path) -> N
 
     Scenario: a concrete FreeBSD:16:amd64 devel .pkg served via release_pkgs
       When build_repo_matrix runs
-      Then it raises BuildRepoError naming the concrete ABI
+      Then it raises BuildRepoError with generic NO_ARCH guidance
+       And it does not mislabel the package as a pre-#1806 route-only asset
     """
     out = tmp_path / "site"
     pkg_dir = tmp_path / "pkgs"
@@ -3214,7 +3215,7 @@ def test_consume_mode_concrete_abi_pkg_rejected_at_emission(tmp_path: Path) -> N
     pkg = pkg_dir / "pfBlockerNG-devel-4.0.0_1.pkg"
     make_pkg(pkg, name="pfBlockerNG-devel", version="4.0.0_1", abi="FreeBSD:16:amd64")
 
-    with pytest.raises(brp.BuildRepoError, match="NO_ARCH"):
+    with pytest.raises(brp.BuildRepoError, match="NO_ARCH") as exc_info:
         brp.build_repo_matrix(
             [_PLUS],
             out,
@@ -3222,6 +3223,11 @@ def test_consume_mode_concrete_abi_pkg_rejected_at_emission(tmp_path: Path) -> N
             build_nightly=False,
             release_pkgs={"plus-26.03": [pkg]},
         )
+
+    message = str(exc_info.value)
+    assert "Ship a wildcard-ABI (NO_ARCH) build instead." in message
+    assert "pre-#1806" not in message
+    assert "route-only" not in message
 
 
 def test_consume_mode_devel_and_stable_both_retained(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- state the settled policy: pre-#1806 concrete-ABI tags are unservable route-only
- make the catalog emitter report that verdict only for route-only emission and refuse output
- document route-only eligibility and preserve the post-#1806 `extra_pkgs` KNOWN GAP without deciding it

## Verification

- policy RED→GREEN: `test_route_only_pre_1806_concrete_abi_fails_explicitly` fails against `origin/devel` source and passes on HEAD
- guidance-scope RED→GREEN: `test_consume_mode_concrete_abi_pkg_rejected_at_emission` fails against pre-fix `13466d0d` source and passes on HEAD
- final frozen test hash: `9b19cbbe7e41cd524170ad88f06285771d1e4961`
- `python3 -m pytest tests/test_build_repo_portable.py -k "route_only or concrete_abi" -q` — 15 passed
- `python3 -m pytest tests/smoke/test_repo_install.py::test_smoke_dep_pkg_paths_parses_env -q --override-ini=addopts=` — 1 passed
- both `scripts/agent/verify-red-proof.sh` runs — FREEZE-OK, RED-OK, GREEN-OK, PASS
- `scripts/agent/run-gates.sh --diff origin/devel` — pytest, ruff check, ruff format, mypy, markdownlint PASS after final commit

## Out of scope

The owner has not decided whether a post-#1806 family whose last `.pkg` declares dependencies represented by `extra_pkgs` needs those dependencies folded into its frozen catalog. This PR leaves the exclusion unchanged; the owner call is recorded on #1828.

Fixes #1828

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.