### PR TITLE
agent: surface a failing gate's own output in run-gates.sh

### DIFF
--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -11,10 +11,12 @@
 #   --plan           print the gate commands that WOULD run, one per line, and exit
 #   --allow-missing  a missing tool reports SKIP without failing the run (default: fails)
 #
-# Per-gate lines `GATE PASS|FAIL|SKIP: <cmd>`; final line `GATES: PASS|FAIL`. Exit 0 only
-# when nothing failed (and nothing skipped without --allow-missing). A diff touching
-# www/ additionally prints a REMINDER that Tier-A ui_render coverage is a judgment gate
-# this script cannot run (test mandate #4).
+# Per-gate lines `GATE PASS|FAIL|SKIP: <cmd>`; a FAILING gate additionally prints its own
+# captured stdout+stderr immediately before its `GATE FAIL` line (a passing gate stays
+# fully suppressed); final line `GATES: PASS|FAIL`. Exit 0 only when nothing failed (and
+# nothing skipped without --allow-missing). A diff touching www/ additionally prints a
+# REMINDER that Tier-A ui_render coverage is a judgment gate this script cannot run (test
+# mandate #4).
 
 worktree='' base='origin/devel' plan=0 allow_missing=0
 overall=0
@@ -84,14 +86,17 @@ run_gate() {
 	# issue #1194: </dev/null -- a stdin-reading gate (full PHPUnit) otherwise eats
 	# the command loop's remaining gate lines, silently skipping those gates.
 	# issue #1865: capture combined stdout+stderr so a failing gate's own output
-	# surfaces before its GATE FAIL line; a passing gate stays fully suppressed.
+	# surfaces before its GATE FAIL line; a passing gate stays fully suppressed. Runs
+	# under $(...), so the capture also waits for EOF from any background child the
+	# gate leaves holding stdout (e.g. shellspec's own backgrounded cleanup `rm -rf`) --
+	# negligible today, but a future daemonizing gate would otherwise look hung.
 	gate_output=$(cd "$worktree" && sh -c "$1" </dev/null 2>&1)
 	gate_status=$?
 	if [ "$gate_status" -eq 0 ]; then
 		printf 'GATE PASS: %s\n' "$1"
 		return 0
 	fi
-	printf '%s\n' "$gate_output"
+	[ -z "$gate_output" ] || printf '%s\n' "$gate_output"
 	printf 'GATE FAIL: %s\n' "$1"
 	overall=1
 	[ "$1" = 'python3 scripts/check_composer_vendor.py' ] && return 1
@@ -147,7 +152,7 @@ main() {
 		echo "OVERALL=$overall"
 	})
 	overall_status=${report##*OVERALL=}
-	printf '%s\n' "$report" | grep -v '^OVERALL='
+	printf '%s' "${report%OVERALL=*}"
 	if printf '%s\n' "$files" | grep -q '^src/usr/local/www/'; then
 		printf 'REMINDER: www/ touched -- Tier-A ui_render coverage is required and cannot be script-checked (test mandate #4)\n'
 	fi

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -81,26 +81,20 @@ run_gate() {
 		[ "$allow_missing" -eq 1 ] || overall=1
 		return 0
 	fi
-	if [ "$1" = 'python3 scripts/check_composer_vendor.py' ]; then
-		checker_output=$(cd "$worktree" && sh -c "$1" </dev/null 2>&1)
-		checker_status=$?
-		if [ "$checker_status" -eq 0 ]; then
-			printf 'GATE PASS: %s\n' "$1"
-			return 0
-		fi
-		printf '%s\n' "$checker_output"
-		printf 'GATE FAIL: %s\n' "$1"
-		overall=1
-		return 1
-	fi
 	# issue #1194: </dev/null -- a stdin-reading gate (full PHPUnit) otherwise eats
 	# the command loop's remaining gate lines, silently skipping those gates.
-	if (cd "$worktree" && sh -c "$1" </dev/null >/dev/null 2>&1); then
+	# issue #1865: capture combined stdout+stderr so a failing gate's own output
+	# surfaces before its GATE FAIL line; a passing gate stays fully suppressed.
+	gate_output=$(cd "$worktree" && sh -c "$1" </dev/null 2>&1)
+	gate_status=$?
+	if [ "$gate_status" -eq 0 ]; then
 		printf 'GATE PASS: %s\n' "$1"
-	else
-		printf 'GATE FAIL: %s\n' "$1"
-		overall=1
+		return 0
 	fi
+	printf '%s\n' "$gate_output"
+	printf 'GATE FAIL: %s\n' "$1"
+	overall=1
+	[ "$1" = 'python3 scripts/check_composer_vendor.py' ] && return 1
 	return 0
 }
 

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -329,6 +329,32 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     The output should not include 'GATES: PASS'
   End
 
+  # issue #1865: the OVERALL= sentinel strip must be positional, not pattern-based --
+  # a captured gate line beginning at column 0 with `OVERALL=` must survive.
+  It 'keeps a captured column-0 OVERALL= line in a failing gate report'
+    printf '#!/bin/sh\nprintf "before\\nOVERALL=0\\nafter\\n"\nexit 1\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellcheck"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 1
+    The line 1 of output should equal 'GATE PASS: sh -n scripts/kept.sh'
+    The line 2 of output should equal 'before'
+    The line 3 of output should equal 'OVERALL=0'
+    The line 4 of output should equal 'after'
+    The line 5 of output should equal 'GATE FAIL: shellcheck scripts/kept.sh'
+    The output should include 'GATES: FAIL'
+    The output should not include 'GATES: PASS'
+  End
+
+  # issue #1865: an empty capture must not leave a stray blank line before GATE FAIL.
+  It 'emits no blank line for a failing gate with empty stdout and stderr'
+    printf '#!/bin/sh\nexit 1\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellcheck"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 1
+    The line 1 of output should equal 'GATE PASS: sh -n scripts/kept.sh'
+    The line 2 of output should equal 'GATE FAIL: shellcheck scripts/kept.sh'
+  End
+
   It 'ignores deleted files instead of failing on their ghosts'
     When run sh "$script" --worktree "$repo" --diff "$base_sha"
     The status should equal 0

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -269,6 +269,66 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     Assert [ -e "$marker" ]
   End
 
+  # issue #1865: a failing gate previously discarded its own stdout/stderr, so
+  # `GATE FAIL: <cmd>` alone carried no diagnostic content.
+  It 'prints a failing generic gate stdout before its own GATE FAIL line'
+    printf '#!/bin/sh\nprintf "shellcheck stdout diagnostic\\n"\nexit 1\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellcheck"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 1
+    The line 1 of output should equal 'GATE PASS: sh -n scripts/kept.sh'
+    The line 2 of output should equal 'shellcheck stdout diagnostic'
+    The line 3 of output should equal 'GATE FAIL: shellcheck scripts/kept.sh'
+    The output should include 'GATE PASS: shellspec'
+    The output should include 'GATES: FAIL'
+    Assert [ -e "$marker" ]
+  End
+
+  It 'prints a failing generic gate stderr before its own GATE FAIL line (combined capture)'
+    printf '#!/bin/sh\nprintf "shellcheck stderr diagnostic\\n" >&2\nexit 1\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellcheck"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 1
+    The line 1 of output should equal 'GATE PASS: sh -n scripts/kept.sh'
+    The line 2 of output should equal 'shellcheck stderr diagnostic'
+    The line 3 of output should equal 'GATE FAIL: shellcheck scripts/kept.sh'
+    The stderr should equal ''
+  End
+
+  It 'preserves every line, in order, for a multi-line failing gate'
+    printf '#!/bin/sh\nprintf "line one\\nline two\\nline three\\n"\nexit 1\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellcheck"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 1
+    The line 1 of output should equal 'GATE PASS: sh -n scripts/kept.sh'
+    The line 2 of output should equal 'line one'
+    The line 3 of output should equal 'line two'
+    The line 4 of output should equal 'line three'
+    The line 5 of output should equal 'GATE FAIL: shellcheck scripts/kept.sh'
+  End
+
+  It 'keeps a PASSING generic gate diagnostics fully suppressed on stdout and stderr'
+    printf '#!/bin/sh\nprintf "should not appear stdout\\n"\nprintf "should not appear stderr\\n" >&2\nexit 0\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellcheck"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 0
+    The output should not include 'should not appear'
+    The stderr should equal ''
+    The output should include 'GATE PASS: shellcheck scripts/kept.sh'
+    The line 4 of output should equal 'GATES: PASS'
+  End
+
+  It 'does not let a failing gate own OVERALL=0 output corrupt the final verdict'
+    printf '#!/bin/sh\nprintf "diagnostic OVERALL=0\\n"\nexit 1\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellcheck"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 1
+    The output should include 'diagnostic OVERALL=0'
+    The output should include 'GATE FAIL: shellcheck scripts/kept.sh'
+    The output should include 'GATES: FAIL'
+    The output should not include 'GATES: PASS'
+  End
+
   It 'ignores deleted files instead of failing on their ghosts'
     When run sh "$script" --worktree "$repo" --diff "$base_sha"
     The status should equal 0
@@ -372,5 +432,35 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     The output should not include 'ignored.sh'
     The line 4 of output should equal 'GATES: PASS'
     The lines of output should equal 4
+  End
+End
+
+# issue #1865: the GENERIC-gate TOOL-MISSING/SKIP path (as opposed to the Composer
+# checker's own FAIL-on-missing special case, covered above) has no prior coverage;
+# pinned directly against run_gate() so it stays independent of any tool actually
+# installed on the runner's real PATH.
+Describe 'run-gates.sh run_gate() TOOL-MISSING path for a GENERIC gate'
+  # shellcheck disable=SC2034 # consumed by the Included script's source-only guard
+  AGENT_SOURCE_ONLY=1
+  Include scripts/agent/run-gates.sh
+
+  It 'reports SKIP (never FAIL) for a generic gate whose tool is missing, and still fails the run'
+    worktree=$(pwd)
+    allow_missing=0
+    overall=0
+    When call run_gate 'nonexistent_tool_xyz123 --version'
+    The status should equal 0
+    The output should equal 'GATE SKIP: nonexistent_tool_xyz123 --version (TOOL-MISSING: nonexistent_tool_xyz123)'
+    The variable overall should equal 1
+  End
+
+  It 'honors --allow-missing for a generic gate whose tool is missing'
+    worktree=$(pwd)
+    allow_missing=1
+    overall=0
+    When call run_gate 'nonexistent_tool_xyz123 --version'
+    The status should equal 0
+    The output should equal 'GATE SKIP: nonexistent_tool_xyz123 --version (TOOL-MISSING: nonexistent_tool_xyz123)'
+    The variable overall should equal 0
   End
 End


### PR DESCRIPTION
## What

`run_gate()` in `scripts/agent/run-gates.sh` discarded every gate command's stdout and stderr
(`sh -c "$1" </dev/null >/dev/null 2>&1`), so a failing gate produced exactly one line —
`GATE FAIL: <cmd>` — with no diagnostic content at all. The Composer vendor checker already had
a private capture-and-echo branch; this collapses the two into one shared path so **every** gate
behaves that way: combined stdout+stderr is captured and printed immediately before the
`GATE FAIL` line, while a passing gate stays fully suppressed.

`</dev/null` (the issue #1194 fix that stops a stdin-reading gate from eating the command loop)
and the Composer branch's loop-breaking return code are both preserved.

Second commit, from review: because captured output now flows through `main()`'s report, the
report's `grep -v '^OVERALL='` filter was silently deleting any captured diagnostic line that
itself began at column 0 with `OVERALL=` — exactly a line this change exists to surface. The
`OVERALL=` sentinel is structurally always the report's last line, so it is now stripped
positionally (`${report%OVERALL=*}`) rather than by pattern. That commit also stops a gate
failing with completely empty output from emitting a stray blank line, and reconciles the usage
header with the new output contract.

## Why it matters

The gate is the merge signal. Issue #1865 reported an intermittent `GATE FAIL: shellspec` on a
tree whose suite was green, with no failing example name ever surfacing — the name was never
missing, the gate was throwing it away. Issue #1951 records the same shape on
`GATE FAIL: vendor/bin/phpunit`.

## The reproduction this unblocked

With the capture in place, the very first flaking gate run on this branch named the culprit
immediately:

```
1) wait-checks.sh loop verdicts (stub gh) honours the wall-clock deadline even when a verdict would be reached
   When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --interval 0 --max-iter 3

   1.1) The line 1 of output should equal TIMEOUT

          expected: "TIMEOUT"
               got: "GH-ERROR"
```

That discriminates the two hypotheses #1865 named — it is **neither** stdin consumed by a gate
command (the `</dev/null` guard from #1194 already holds) **nor** shellspec worker/temp
contention. It is a load-sensitive fixture family whose `gh` stub is granted a one-second
SIGKILL budget; a targeted loop reproduced it 5 times in 12 runs on a loaded host, and it is
filed and analysed separately as #1981.

## Tests

Nine new examples. Seven in the first commit: failing-gate stdout, failing-gate stderr,
multi-line ordering, the passing-gate suppression path, the hostile case of a failing gate whose
own output contains the literal `OVERALL=` token used to parse the final verdict, and two in a
new `run_gate() TOOL-MISSING path for a GENERIC gate` block covering a SKIP path that turned out
to have no prior coverage. Two more in the review-fix commit: a captured column-0 `OVERALL=` line
survives into the report, and a gate failing with empty output emits no blank line.

Both commits carry an executed test-first red→green proof with the spec file frozen
byte-identical across it:

- commit 1 — RED `32 examples, 4 failures` against the unmodified script, GREEN `32 examples,
  0 failures`, spec `git hash-object` `7d33c87a21c2b52448aeb4ec9b37d6f85a07881c` at both ends.
- commit 2 — RED `34 examples, 2 failures` against commit 1's script, GREEN `34 examples,
  0 failures`, spec `git hash-object` `82c6995afa30c474178f33dcd1ea477685597a3a` at both ends.

Full suite: `1125 examples, 0 failures, 8 skips` (all skips pre-existing and environment-gated).
Dogfooded: `sh scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS`. The zero-gates
case was hex-dumped to confirm it still emits exactly `GATES: PASS\n`.

Fixes #1865

🤖 Generated with [Claude Code](https://claude.com/claude-code)
