### PR TITLE
pfblockerng: sanitize XMLRPC sync row text

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -67,6 +67,9 @@ if ($_POST) {
 			// Parse 'rowhelper' fields and save new values
 			if (strpos($key, '-') !== FALSE) {
 				$k_field = explode('-', $key);
+				if (in_array($k_field[0], array('varsyncipaddress', 'varsyncusername', 'varsyncpassword'), TRUE)) {
+					$value = pfb_sanitize_text((string) $value);
+				}
 
 				// Collect all rowhelper keys
 				$rowhelper_exist[$k_field[1]] = '';

--- a/tests/smoke/ui/test_sync.py
+++ b/tests/smoke/ui/test_sync.py
@@ -335,6 +335,43 @@ def test_sync_target_row_add_persists(webui: WebUI, smoke_vm: helpers.SmokeVM) -
         _seed_sync(vm)
 
 
+def test_sync_free_text_row_fields_sanitize_before_validation_and_persist(
+    webui: WebUI, smoke_vm: helpers.SmokeVM
+) -> None:
+    """Free-text target columns sanitize once before validation and storage.
+
+    The hostname and username arrive with Unicode boundary whitespace that their
+    validators reject unless ingestion sanitization runs first. The password
+    carries a Unicode format control plus HTML-special characters: only the
+    control is removed, while the credential's remaining bytes persist verbatim.
+    """
+    vm = smoke_vm
+    _seed_sync(vm)
+    try:
+        assert helpers.config_get(vm, _row_path(0, "varsyncipaddress")) == "", "row/0 already present"
+
+        _post_sync(
+            webui,
+            {
+                "varsynconchanges": "manual",
+                "varsynctimeout": "150",
+                "syncinterfaces": "",
+                "varsyncprotocol-0": "https",
+                "varsyncipaddress-0": " example.com ",
+                "varsyncport-0": "443",
+                "varsyncusername-0": "\u3000syncuser\u00a0",
+                "varsyncpassword-0": "P@ss&\u200dword<>'",
+                "varsyncdestinenable-0": "on",
+            },
+        )
+
+        assert helpers.config_get(vm, _row_path(0, "varsyncipaddress")) == "example.com"
+        assert helpers.config_get(vm, _row_path(0, "varsyncusername")) == "syncuser"
+        assert helpers.config_get(vm, _row_path(0, "varsyncpassword")) == "P@ss&word<>'"
+    finally:
+        _seed_sync(vm)
+
+
 # --------------------------------------------------------------------------- #
 # 3) Undefined/empty-row prune -- a config row absent from the POST is deleted.
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- sanitize the XMLRPC target hostname, username, and password once at rowhelper ingestion
- validate and persist the sanitized hostname/username while keeping password HTML-special characters verbatim
- add Tier-B persisted-state coverage for whitespace trimming, Unicode control removal, and password non-escaping

Fixes #1783

## Verification

- RED: focused Tier-B test failed against the untouched handler; the appliance logged `PFB_FILTER - 7 | Sync Failed validation [  example.com  ]`
- GREEN: `scripts/local-smoke.sh --ref issue/1783-pfblockerng-sync-php-rowhelper --marker ui_e2e --filter test_sync_free_text_row_fields_sanitize_before_validation_and_persist --no-two-vm` — `1 passed, 583 deselected`
- Tier A: `scripts/local-smoke.sh --ref issue/1783-pfblockerng-sync-php-rowhelper --marker ui_render --filter "test_page_render and sync" --no-two-vm` — `1 passed, 583 deselected`
- `scripts/agent/run-gates.sh --diff origin/devel` — pytest, Ruff, mypy, composer-vendor, PHP lint, PHPStan, and PHPCS passed; local full PHPUnit collided with concurrent agents' process-sensitive tests (the failures explicitly cite leaked workers / issue #1666). The isolated failing test passed; exact-head CI remains authoritative.

Test freeze hash: `f92e19ffdf928b7556bc7aefd88e41e2e66a7220`

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
