### PR TITLE
ci: watch all scheduled workflow failures

### DIFF
--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -1,15 +1,13 @@
 name: Nightly failure alert
 
-# File ONE deduped tracking issue when a NIGHTLY (schedule-triggered) run of a
-# live-VM suite fails, then close it when that suite next passes. These suites
-# are schedule+dispatch only (no PR gate), and dispatch failures are already
-# watched by whoever dispatched them — so this alerts on `schedule` only.
+# File ONE deduped tracking issue when a schedule-triggered run of any watched
+# workflow fails, then close it when that workflow next passes. This shared
+# workflow_run alert owns the issue lifecycle for all watched schedules.
 #
 # Pattern follows top1m-healthcheck.yml's alert job (dedup by label + exact
-# title, update-in-place). WHY workflow_run and not an `if: failure()` job in
-# each suite: one file, no edits to the three fan-out matrices, and it runs
-# with its own token even when the failing run's jobs are all red (see
-# module-durations.yml for the same trigger shape).
+# title, update-in-place). WHY workflow_run and not a failure job in each
+# producer: one file, and it runs with its own token even when the failing
+# run's jobs are all red.
 
 on:
   workflow_run:

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -14,8 +14,12 @@ name: Nightly failure alert
 on:
   workflow_run:
     workflows:
+      - "HSTS preload refresh (pfb_py_hsts)"
+      - "PSL Refresh (dnsbl_tld)"
       - "Smoke fan-out (all CI legs, live pfSense VM)"
+      - "TLD List Refresh"
       - "UI tests fan-out (all CI legs, live pfSense VM)"
+      - "Version Tracker"
       - "Repo install (live pfSense VM)"
     types: [completed]
   # Red-path test handle (CLAUDE.md: a newly wired gate demonstrates its red

--- a/tests/test_nightly_failure_alert_coverage.py
+++ b/tests/test_nightly_failure_alert_coverage.py
@@ -1,0 +1,214 @@
+"""Every scheduled workflow is watched by the nightly failure alert or exempt."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = ROOT / ".github" / "workflows"
+_WORKFLOW_GLOBS = ("*.yml", "*.yaml")
+
+_TOP_LEVEL_KEY_RE = re.compile(r"^(?P<key>[A-Za-z0-9_.-]+|['\"](?P<quoted>[^'\"]+)['\"]):(?:\s|$)")
+_SCHEDULE_RE = re.compile(r"^  schedule:\s*(?:#.*)?$")
+_WORKFLOW_RUN_RE = re.compile(r"^  workflow_run:\s*(?:#.*)?$")
+_WORKFLOWS_RE = re.compile(r"^    workflows:\s*(?:#.*)?$")
+_WORKFLOW_ITEM_RE = re.compile(r"^      -\s*(?P<value>.+?)\s*$")
+
+EXEMPT_SCHEDULED_WORKFLOWS: dict[str, str] = {
+    "Top1M Provider Health Check": ("top1m-healthcheck.yml owns its alert and recovery issue lifecycle."),
+}
+
+
+def _is_comment(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _block_end(lines: list[str], start: int, indent: int) -> int:
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if not line.strip() or _is_comment(line):
+            continue
+        if _indent(line) <= indent:
+            return index
+    return len(lines)
+
+
+def _top_level_block(lines: list[str], key: str) -> tuple[int, int] | None:
+    for index, line in enumerate(lines):
+        if _is_comment(line) or _indent(line) != 0:
+            continue
+        match = _TOP_LEVEL_KEY_RE.match(line)
+        if match and (match.group("key") or match.group("quoted")) == key:
+            return index, _block_end(lines, index, 0)
+    return None
+
+
+def _has_schedule_trigger(text: str) -> bool:
+    lines = text.splitlines()
+    block = _top_level_block(lines, "on")
+    if block is None:
+        return False
+    start, end = block
+    return any(_SCHEDULE_RE.fullmatch(lines[index]) for index in range(start + 1, end))
+
+
+def _normalize_scalar(raw: str, *, source: str) -> str:
+    value = raw.strip()
+    if not value:
+        raise ValueError(f"{source}: empty scalar")
+    if value[0] in "'\"":
+        quote = value[0]
+        closing = value.find(quote, 1)
+        if closing < 0 or value[closing + 1 :].strip() not in ("",):
+            trailing = value[closing + 1 :].strip() if closing >= 0 else value
+            if not trailing.startswith("#"):
+                raise ValueError(f"{source}: malformed quoted scalar")
+        if closing <= 1:
+            raise ValueError(f"{source}: empty or malformed quoted scalar")
+        return value[1:closing]
+    return value.split(" #", 1)[0].rstrip()
+
+
+def _top_level_workflow_name(text: str, *, source: str) -> str:
+    for line in text.splitlines():
+        if _is_comment(line) or _indent(line) != 0:
+            continue
+        if not line.startswith("name:"):
+            continue
+        return _normalize_scalar(line.partition(":")[2], source=source)
+    raise ValueError(f"{source}: scheduled workflow missing top-level name")
+
+
+def _scheduled_workflow_names(paths: list[Path]) -> set[str]:
+    names: set[str] = set()
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        if _has_schedule_trigger(text):
+            names.add(_top_level_workflow_name(text, source=str(path)))
+    return names
+
+
+def _nightly_watched_workflows(text: str) -> set[str]:
+    lines = text.splitlines()
+    on_block = _top_level_block(lines, "on")
+    if on_block is None:
+        raise ValueError("nightly alert: missing top-level on block")
+    on_start, on_end = on_block
+    workflow_run = next(
+        (index for index in range(on_start + 1, on_end) if _WORKFLOW_RUN_RE.fullmatch(lines[index])),
+        None,
+    )
+    if workflow_run is None:
+        raise ValueError("nightly alert: missing on.workflow_run block")
+    workflow_run_end = _block_end(lines, workflow_run, 2)
+    workflows = next(
+        (index for index in range(workflow_run + 1, workflow_run_end) if _WORKFLOWS_RE.fullmatch(lines[index])),
+        None,
+    )
+    if workflows is None:
+        raise ValueError("nightly alert: missing on.workflow_run.workflows block")
+    names: set[str] = set()
+    for index in range(workflows + 1, workflow_run_end):
+        line = lines[index]
+        if not line.strip() or _is_comment(line):
+            continue
+        if _indent(line) <= 4:
+            break
+        match = _WORKFLOW_ITEM_RE.fullmatch(line)
+        if match:
+            names.add(_normalize_scalar(match.group("value"), source=f"nightly alert line {index + 1}"))
+    if not names:
+        raise ValueError("nightly alert: on.workflow_run.workflows is empty")
+    return names
+
+
+def _workflow_files(directory: Path = WORKFLOWS_DIR) -> list[Path]:
+    by_name: dict[str, Path] = {}
+    for pattern in _WORKFLOW_GLOBS:
+        for path in directory.glob(pattern):
+            by_name.setdefault(path.name, path)
+    return [by_name[name] for name in sorted(by_name)]
+
+
+def test_every_scheduled_workflow_is_watched_or_explicitly_exempt() -> None:
+    scheduled = _scheduled_workflow_names(_workflow_files())
+    watched = _nightly_watched_workflows((WORKFLOWS_DIR / "nightly-failure-alert.yml").read_text(encoding="utf-8"))
+    exempt = set(EXEMPT_SCHEDULED_WORKFLOWS)
+
+    assert all(reason.strip() for reason in EXEMPT_SCHEDULED_WORKFLOWS.values())
+    assert exempt <= scheduled, f"stale scheduled-workflow exemptions: {sorted(exempt - scheduled)}"
+    assert watched <= scheduled, f"nightly alert watches non-scheduled workflows: {sorted(watched - scheduled)}"
+    overlap = watched & exempt
+    assert not overlap, f"workflows cannot be both watched and exempt: {sorted(overlap)}"
+    missing = scheduled - watched - exempt
+    assert not missing, f"uncovered scheduled workflows: {sorted(missing)}"
+    assert scheduled == watched | exempt, (
+        f"scheduled={sorted(scheduled)} watched={sorted(watched)} exempt={sorted(exempt)}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("on:\n  # schedule:\n  push:\n", False),
+        ("name: Plain\non:\n  schedule:\n    - cron: x\n", True),
+        ("name: Outside\non:\n  push:\njobs:\n  schedule:\n", False),
+    ],
+)
+def test_schedule_parser_uses_only_top_level_on(text: str, expected: bool) -> None:
+    assert _has_schedule_trigger(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("name: Plain\non:\n  schedule:\n", "Plain"),
+        ("name: 'Single quoted'\non:\n  schedule:\n", "Single quoted"),
+        ('name: "Double quoted"\non:\n  schedule:\n', "Double quoted"),
+    ],
+)
+def test_top_level_workflow_name_normalizes_outer_quotes(text: str, expected: str) -> None:
+    assert _top_level_workflow_name(text, source="fixture") == expected
+
+
+def test_scheduled_workflow_name_must_be_top_level_and_well_formed() -> None:
+    with pytest.raises(ValueError, match="missing top-level name"):
+        _top_level_workflow_name("on:\n  schedule:\n", source="missing")
+    with pytest.raises(ValueError, match="malformed quoted scalar"):
+        _top_level_workflow_name("name: 'broken\non:\n  schedule:\n", source="malformed")
+
+
+def test_workflow_files_scan_both_yaml_extensions(tmp_path: Path) -> None:
+    (tmp_path / "scheduled.yml").write_text("name: YML\non:\n  schedule:\n", encoding="utf-8")
+    (tmp_path / "scheduled.yaml").write_text("name: YAML\non:\n  schedule:\n", encoding="utf-8")
+
+    paths = _workflow_files(tmp_path)
+    assert {path.suffix for path in paths} == {".yml", ".yaml"}
+    assert _scheduled_workflow_names(paths) == {"YML", "YAML"}
+
+
+def test_nightly_workflow_run_parser_ignores_decoy_workflow_lists() -> None:
+    text = """\
+name: Synthetic nightly alert
+on:
+  workflow_run:
+    workflows:
+      - "Watched workflow"
+    types: [completed]
+  workflow_dispatch:
+    workflows:
+      - "Decoy dispatch list"
+jobs:
+  decoy:
+    workflows:
+      - "Decoy job list"
+"""
+
+    assert _nightly_watched_workflows(text) == {"Watched workflow"}

--- a/tests/test_nightly_failure_alert_coverage.py
+++ b/tests/test_nightly_failure_alert_coverage.py
@@ -12,6 +12,8 @@ WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 _WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 
 _MAPPING_KEY_RE = re.compile(r"^(?P<key>[A-Za-z0-9_.-]+|'[^']*'|\"[^\"]*\")\s*:(?P<rest>.*)$")
+_CANONICAL_ON_RE = re.compile(r"^on:\s*(?:#.*)?$")
+_CANONICAL_EVENT_RE = re.compile(r"^  [A-Za-z0-9_.-]+:")
 _WORKFLOW_RUN_RE = re.compile(r"^  workflow_run:\s*(?:#.*)?$")
 _WORKFLOWS_RE = re.compile(r"^    workflows:\s*(?:#.*)?$")
 _WORKFLOW_ITEM_RE = re.compile(r"^      -\s*(?P<value>.+?)\s*$")
@@ -49,53 +51,6 @@ def _mapping_key(line: str) -> tuple[str, str] | None:
     return raw_key, match.group("rest")
 
 
-def _flow_mapping_keys(value: str) -> set[str]:
-    opening = value.find("{")
-    if opening < 0:
-        return set()
-    keys: set[str] = set()
-    brace_depth = 0
-    bracket_depth = 0
-    quote: str | None = None
-    escaped = False
-    key_start: int | None = None
-    for index in range(opening, len(value)):
-        char = value[index]
-        if quote is not None:
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == quote:
-                quote = None
-            continue
-        if char in "'\"":
-            quote = char
-        elif char == "{":
-            brace_depth += 1
-            if brace_depth == 1 and bracket_depth == 0:
-                key_start = index + 1
-        elif char == "}":
-            if brace_depth == 1 and bracket_depth == 0:
-                key_start = None
-            brace_depth -= 1
-            if brace_depth <= 0:
-                break
-        elif char == "[" and brace_depth:
-            bracket_depth += 1
-        elif char == "]" and bracket_depth:
-            bracket_depth -= 1
-        elif brace_depth == 1 and bracket_depth == 0:
-            if char == ":" and key_start is not None:
-                parsed = _mapping_key(value[key_start:index].strip() + ":")
-                if parsed is not None:
-                    keys.add(parsed[0])
-                key_start = None
-            elif char == ",":
-                key_start = index + 1
-    return keys
-
-
 def _top_level_block(lines: list[str], key: str) -> tuple[int, int] | None:
     for index, line in enumerate(lines):
         if _is_comment(line) or _indent(line) != 0:
@@ -106,33 +61,52 @@ def _top_level_block(lines: list[str], key: str) -> tuple[int, int] | None:
     return None
 
 
+def _canonical_on_block(lines: list[str], *, source: str) -> tuple[int, int]:
+    on_index = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if not _is_comment(line) and _indent(line) == 0 and (_mapping_key(line) or (None, ""))[0] == "on"
+        ),
+        None,
+    )
+    if on_index is None:
+        raise ValueError(f"{source}: missing canonical top-level on:")
+    if _CANONICAL_ON_RE.fullmatch(lines[on_index]) is None:
+        raise ValueError(f"{source}: noncanonical top-level on: syntax")
+    end = _block_end(lines, on_index, 0)
+    direct_child_seen = False
+    for index in range(on_index + 1, end):
+        line = lines[index]
+        if not line.strip() or _is_comment(line):
+            continue
+        indent = _indent(line)
+        if indent < 2:
+            raise ValueError(f"{source}: noncanonical on child indentation")
+        if not direct_child_seen:
+            if indent != 2:
+                raise ValueError(f"{source}: noncanonical on child indentation")
+            direct_child_seen = True
+        if indent == 2 and _CANONICAL_EVENT_RE.match(line) is None:
+            raise ValueError(f"{source}: noncanonical on child key")
+    return on_index, end
+
+
 def _has_schedule_trigger(text: str) -> bool:
     lines = text.splitlines()
-    block = _top_level_block(lines, "on")
-    if block is None:
-        return False
-    start, end = block
-    on_mapping = _mapping_key(lines[start])
-    if on_mapping is not None and "schedule" in _flow_mapping_keys(on_mapping[1]):
-        return True
-    child_indents = [
-        _indent(lines[index])
-        for index in range(start + 1, end)
-        if lines[index].strip() and not _is_comment(lines[index]) and _indent(lines[index]) > 0
-    ]
-    if not child_indents:
-        return False
-    child_indent = min(child_indents)
+    start, end = _canonical_on_block(lines, source="workflow")
     return any(
-        _indent(lines[index]) == child_indent and (_mapping_key(lines[index]) or (None, ""))[0] == "schedule"
+        _indent(lines[index]) == 2
+        and _CANONICAL_EVENT_RE.match(lines[index]) is not None
+        and lines[index].partition(":")[0].strip() == "schedule"
         for index in range(start + 1, end)
     )
 
 
 def _normalize_scalar(raw: str, *, source: str) -> str:
     value = raw.strip()
-    if not value:
-        raise ValueError(f"{source}: empty scalar")
+    if not value or value.startswith("#"):
+        raise ValueError(f"{source}: invalid workflow name")
     if value[0] in "'\"":
         quote = value[0]
         closing = value.find(quote, 1)
@@ -143,7 +117,10 @@ def _normalize_scalar(raw: str, *, source: str) -> str:
         if closing <= 1:
             raise ValueError(f"{source}: empty or malformed quoted scalar")
         return value[1:closing]
-    return value.split(" #", 1)[0].rstrip()
+    value = value.split(" #", 1)[0].rstrip()
+    if not value or value in {"null", "Null", "NULL", "~"} or value.startswith(("!", "&")):
+        raise ValueError(f"{source}: invalid workflow name")
+    return value
 
 
 def _top_level_workflow_name(text: str, *, source: str) -> str:
@@ -153,6 +130,8 @@ def _top_level_workflow_name(text: str, *, source: str) -> str:
         parsed = _mapping_key(line)
         if parsed is None or parsed[0] != "name":
             continue
+        if not line.startswith("name:"):
+            raise ValueError(f"{source}: noncanonical top-level name: key")
         return _normalize_scalar(parsed[1], source=source)
     raise ValueError(f"{source}: scheduled workflow missing top-level name")
 
@@ -161,8 +140,9 @@ def _scheduled_workflow_names(paths: list[Path]) -> set[str]:
     names: set[str] = set()
     for path in paths:
         text = path.read_text(encoding="utf-8")
+        name = _top_level_workflow_name(text, source=str(path))
         if _has_schedule_trigger(text):
-            names.add(_top_level_workflow_name(text, source=str(path)))
+            names.add(name)
     return names
 
 
@@ -229,10 +209,12 @@ def test_every_scheduled_workflow_is_watched_or_explicitly_exempt() -> None:
     ("text", "expected"),
     [
         ("on:\n  # schedule:\n  push:\n", False),
+        ("on: # {schedule: fake}\n  push:\n", False),
         ("name: Plain\non:\n  schedule:\n    - cron: x\n", True),
+        ('name: Inline schedule\non:\n  schedule: [{cron: "0 0 * * *"}]\n', True),
         ("name: Outside\non:\n  push:\njobs:\n  schedule:\n", False),
         (
-            'name: Nested flow\non: {workflow_dispatch: {inputs: {schedule: {description: "x", required: false}}}}\n',
+            "name: Nested input\non:\n  workflow_dispatch:\n    inputs:\n      schedule:\n        description: x\n",
             False,
         ),
     ],
@@ -245,15 +227,20 @@ def test_schedule_parser_uses_only_top_level_on(text: str, expected: bool) -> No
     "text",
     [
         'name: Flow\non: {schedule: [{cron: "0 0 * * *"}]}\n',
-        'name: Block\non:\n  schedule: [{cron: "0 0 * * *"}]\n',
         'name: Quoted top level\n"on":\n  schedule:\n    - cron: "0 0 * * *"\n',
+        'name: Tagged top level\n!!str on:\n  schedule:\n    - cron: "0 0 * * *"\n',
+        'name: Aliased top level\n&trigger on:\n  schedule:\n    - cron: "0 0 * * *"\n',
         'name: Quoted event\non:\n  "schedule":\n    - cron: "0 0 * * *"\n',
+        'name: Tagged event\non:\n  !!str schedule:\n    - cron: "0 0 * * *"\n',
+        'name: Aliased event\non:\n  &trigger schedule:\n    - cron: "0 0 * * *"\n',
+        'name: Alternate indentation\non:\n    schedule:\n      - cron: "0 0 * * *"\n',
         'name: Whitespace event\non:\n  schedule :\n    - cron: "0 0 * * *"\n',
         'name: Whitespace quoted event\non:\n  "schedule" :\n    - cron: "0 0 * * *"\n',
     ],
 )
-def test_schedule_parser_accepts_valid_schedule_forms(text: str) -> None:
-    assert _has_schedule_trigger(text)
+def test_noncanonical_schedule_forms_fail_closed(text: str) -> None:
+    with pytest.raises(ValueError, match="canonical"):
+        _has_schedule_trigger(text)
 
 
 @pytest.mark.parametrize(
@@ -262,7 +249,6 @@ def test_schedule_parser_accepts_valid_schedule_forms(text: str) -> None:
         ("name: Plain\non:\n  schedule:\n", "Plain"),
         ("name: 'Single quoted'\non:\n  schedule:\n", "Single quoted"),
         ('name: "Double quoted"\non:\n  schedule:\n', "Double quoted"),
-        ('"name": "Quoted key"\non:\n  schedule:\n', "Quoted key"),
     ],
 )
 def test_top_level_workflow_name_normalizes_outer_quotes(text: str, expected: str) -> None:
@@ -274,6 +260,23 @@ def test_scheduled_workflow_name_must_be_top_level_and_well_formed() -> None:
         _top_level_workflow_name("on:\n  schedule:\n", source="missing")
     with pytest.raises(ValueError, match="malformed quoted scalar"):
         _top_level_workflow_name("name: 'broken\non:\n  schedule:\n", source="malformed")
+    with pytest.raises(ValueError, match="canonical"):
+        _top_level_workflow_name('"name": "Quoted key"\non:\n  schedule:\n', source="quoted-key")
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "name:\non:\n  push:\n",
+        "name: # comment\non:\n  push:\n",
+        "name: null\non:\n  push:\n",
+        "name: ~\non:\n  push:\n",
+        "name: !!str\non:\n  push:\n",
+    ],
+)
+def test_workflow_name_rejects_null_comment_and_tag_only_values(text: str) -> None:
+    with pytest.raises(ValueError, match="name"):
+        _top_level_workflow_name(text, source="invalid-name")
 
 
 def test_workflow_files_scan_both_yaml_extensions(tmp_path: Path) -> None:

--- a/tests/test_nightly_failure_alert_coverage.py
+++ b/tests/test_nightly_failure_alert_coverage.py
@@ -11,8 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 _WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 
-_TOP_LEVEL_KEY_RE = re.compile(r"^(?P<key>[A-Za-z0-9_.-]+|['\"](?P<quoted>[^'\"]+)['\"]):(?:\s|$)")
-_SCHEDULE_RE = re.compile(r"^  schedule:\s*(?:#.*)?$")
+_MAPPING_KEY_RE = re.compile(r"^(?P<key>[A-Za-z0-9_.-]+|'[^']*'|\"[^\"]*\")\s*:(?P<rest>.*)$")
 _WORKFLOW_RUN_RE = re.compile(r"^  workflow_run:\s*(?:#.*)?$")
 _WORKFLOWS_RE = re.compile(r"^    workflows:\s*(?:#.*)?$")
 _WORKFLOW_ITEM_RE = re.compile(r"^      -\s*(?P<value>.+?)\s*$")
@@ -40,12 +39,69 @@ def _block_end(lines: list[str], start: int, indent: int) -> int:
     return len(lines)
 
 
+def _mapping_key(line: str) -> tuple[str, str] | None:
+    match = _MAPPING_KEY_RE.match(line.lstrip(" "))
+    if match is None:
+        return None
+    raw_key = match.group("key")
+    if raw_key[0] in "'\"":
+        return raw_key[1:-1], match.group("rest")
+    return raw_key, match.group("rest")
+
+
+def _flow_mapping_keys(value: str) -> set[str]:
+    opening = value.find("{")
+    if opening < 0:
+        return set()
+    keys: set[str] = set()
+    brace_depth = 0
+    bracket_depth = 0
+    quote: str | None = None
+    escaped = False
+    key_start: int | None = None
+    for index in range(opening, len(value)):
+        char = value[index]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in "'\"":
+            quote = char
+        elif char == "{":
+            brace_depth += 1
+            if brace_depth == 1 and bracket_depth == 0:
+                key_start = index + 1
+        elif char == "}":
+            if brace_depth == 1 and bracket_depth == 0:
+                key_start = None
+            brace_depth -= 1
+            if brace_depth <= 0:
+                break
+        elif char == "[" and brace_depth:
+            bracket_depth += 1
+        elif char == "]" and bracket_depth:
+            bracket_depth -= 1
+        elif brace_depth == 1 and bracket_depth == 0:
+            if char == ":" and key_start is not None:
+                parsed = _mapping_key(value[key_start:index].strip() + ":")
+                if parsed is not None:
+                    keys.add(parsed[0])
+                key_start = None
+            elif char == ",":
+                key_start = index + 1
+    return keys
+
+
 def _top_level_block(lines: list[str], key: str) -> tuple[int, int] | None:
     for index, line in enumerate(lines):
         if _is_comment(line) or _indent(line) != 0:
             continue
-        match = _TOP_LEVEL_KEY_RE.match(line)
-        if match and (match.group("key") or match.group("quoted")) == key:
+        parsed = _mapping_key(line)
+        if parsed is not None and parsed[0] == key:
             return index, _block_end(lines, index, 0)
     return None
 
@@ -56,7 +112,21 @@ def _has_schedule_trigger(text: str) -> bool:
     if block is None:
         return False
     start, end = block
-    return any(_SCHEDULE_RE.fullmatch(lines[index]) for index in range(start + 1, end))
+    on_mapping = _mapping_key(lines[start])
+    if on_mapping is not None and "schedule" in _flow_mapping_keys(on_mapping[1]):
+        return True
+    child_indents = [
+        _indent(lines[index])
+        for index in range(start + 1, end)
+        if lines[index].strip() and not _is_comment(lines[index]) and _indent(lines[index]) > 0
+    ]
+    if not child_indents:
+        return False
+    child_indent = min(child_indents)
+    return any(
+        _indent(lines[index]) == child_indent and (_mapping_key(lines[index]) or (None, ""))[0] == "schedule"
+        for index in range(start + 1, end)
+    )
 
 
 def _normalize_scalar(raw: str, *, source: str) -> str:
@@ -80,9 +150,10 @@ def _top_level_workflow_name(text: str, *, source: str) -> str:
     for line in text.splitlines():
         if _is_comment(line) or _indent(line) != 0:
             continue
-        if not line.startswith("name:"):
+        parsed = _mapping_key(line)
+        if parsed is None or parsed[0] != "name":
             continue
-        return _normalize_scalar(line.partition(":")[2], source=source)
+        return _normalize_scalar(parsed[1], source=source)
     raise ValueError(f"{source}: scheduled workflow missing top-level name")
 
 
@@ -160,10 +231,29 @@ def test_every_scheduled_workflow_is_watched_or_explicitly_exempt() -> None:
         ("on:\n  # schedule:\n  push:\n", False),
         ("name: Plain\non:\n  schedule:\n    - cron: x\n", True),
         ("name: Outside\non:\n  push:\njobs:\n  schedule:\n", False),
+        (
+            'name: Nested flow\non: {workflow_dispatch: {inputs: {schedule: {description: "x", required: false}}}}\n',
+            False,
+        ),
     ],
 )
 def test_schedule_parser_uses_only_top_level_on(text: str, expected: bool) -> None:
     assert _has_schedule_trigger(text) is expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        'name: Flow\non: {schedule: [{cron: "0 0 * * *"}]}\n',
+        'name: Block\non:\n  schedule: [{cron: "0 0 * * *"}]\n',
+        'name: Quoted top level\n"on":\n  schedule:\n    - cron: "0 0 * * *"\n',
+        'name: Quoted event\non:\n  "schedule":\n    - cron: "0 0 * * *"\n',
+        'name: Whitespace event\non:\n  schedule :\n    - cron: "0 0 * * *"\n',
+        'name: Whitespace quoted event\non:\n  "schedule" :\n    - cron: "0 0 * * *"\n',
+    ],
+)
+def test_schedule_parser_accepts_valid_schedule_forms(text: str) -> None:
+    assert _has_schedule_trigger(text)
 
 
 @pytest.mark.parametrize(
@@ -172,6 +262,7 @@ def test_schedule_parser_uses_only_top_level_on(text: str, expected: bool) -> No
         ("name: Plain\non:\n  schedule:\n", "Plain"),
         ("name: 'Single quoted'\non:\n  schedule:\n", "Single quoted"),
         ('name: "Double quoted"\non:\n  schedule:\n', "Double quoted"),
+        ('"name": "Quoted key"\non:\n  schedule:\n', "Quoted key"),
     ],
 )
 def test_top_level_workflow_name_normalizes_outer_quotes(text: str, expected: str) -> None:

--- a/tests/test_nightly_failure_alert_coverage.py
+++ b/tests/test_nightly_failure_alert_coverage.py
@@ -282,8 +282,15 @@ def test_workflow_name_rejects_null_comment_and_tag_only_values(text: str) -> No
 
 
 def test_workflow_files_scan_both_yaml_extensions(tmp_path: Path) -> None:
-    (tmp_path / "scheduled.yml").write_text("name: YML\non:\n  schedule:\n", encoding="utf-8")
-    (tmp_path / "scheduled.yaml").write_text("name: YAML\non:\n  schedule:\n", encoding="utf-8")
+    workflow_tail = "jobs:\n  check:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+    (tmp_path / "scheduled.yml").write_text(
+        "name: YML\non:\n  schedule:\n" + workflow_tail,
+        encoding="utf-8",
+    )
+    (tmp_path / "scheduled.yaml").write_text(
+        "name: YAML\non:\n  schedule:\n" + workflow_tail,
+        encoding="utf-8",
+    )
 
     paths = _workflow_files(tmp_path)
     assert {path.suffix for path in paths} == {".yml", ".yaml"}
@@ -291,12 +298,47 @@ def test_workflow_files_scan_both_yaml_extensions(tmp_path: Path) -> None:
 
 
 def test_duplicate_scheduled_workflow_names_fail_closed(tmp_path: Path) -> None:
-    workflow = 'name: Top1M Provider Health Check\non:\n  schedule:\n    - cron: "0 0 * * *"\n'
+    workflow = (
+        'name: Top1M Provider Health Check\non:\n  schedule:\n    - cron: "0 0 * * *"\n'
+        "jobs:\n  check:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+    )
+    first = tmp_path / "first.yml"
+    second = tmp_path / "second.yml"
+    first.write_text(workflow, encoding="utf-8")
+    second.write_text(workflow, encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc_info:
+        _scheduled_workflow_names(_workflow_files(tmp_path))
+    message = str(exc_info.value)
+    assert "duplicate scheduled workflow name 'Top1M Provider Health Check'" in message
+    assert str(first) in message
+    assert str(second) in message
+
+
+def test_duplicate_manual_workflow_names_are_allowed(tmp_path: Path) -> None:
+    workflow = (
+        "name: Manual duplicate\non:\n  workflow_dispatch:\n"
+        "jobs:\n  check:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+    )
     (tmp_path / "first.yml").write_text(workflow, encoding="utf-8")
     (tmp_path / "second.yml").write_text(workflow, encoding="utf-8")
 
-    with pytest.raises(ValueError, match="duplicate scheduled workflow name.*Top1M Provider Health Check"):
-        _scheduled_workflow_names(_workflow_files(tmp_path))
+    assert _scheduled_workflow_names(_workflow_files(tmp_path)) == set()
+
+
+def test_manual_and_scheduled_name_collision_is_allowed(tmp_path: Path) -> None:
+    manual = (
+        "name: Mixed trigger\non:\n  workflow_dispatch:\n"
+        "jobs:\n  check:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+    )
+    scheduled = (
+        'name: Mixed trigger\non:\n  schedule:\n    - cron: "0 0 * * *"\n'
+        "jobs:\n  check:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+    )
+    (tmp_path / "manual.yml").write_text(manual, encoding="utf-8")
+    (tmp_path / "scheduled.yml").write_text(scheduled, encoding="utf-8")
+
+    assert _scheduled_workflow_names(_workflow_files(tmp_path)) == {"Mixed trigger"}
 
 
 def test_nightly_workflow_run_parser_ignores_decoy_workflow_lists() -> None:

--- a/tests/test_nightly_failure_alert_coverage.py
+++ b/tests/test_nightly_failure_alert_coverage.py
@@ -137,13 +137,15 @@ def _top_level_workflow_name(text: str, *, source: str) -> str:
 
 
 def _scheduled_workflow_names(paths: list[Path]) -> set[str]:
-    names: set[str] = set()
+    scheduled_owners: dict[str, Path] = {}
     for path in paths:
         text = path.read_text(encoding="utf-8")
         name = _top_level_workflow_name(text, source=str(path))
         if _has_schedule_trigger(text):
-            names.add(name)
-    return names
+            if name in scheduled_owners:
+                raise ValueError(f"duplicate scheduled workflow name {name!r}: {scheduled_owners[name]} and {path}")
+            scheduled_owners[name] = path
+    return set(scheduled_owners)
 
 
 def _nightly_watched_workflows(text: str) -> set[str]:
@@ -286,6 +288,15 @@ def test_workflow_files_scan_both_yaml_extensions(tmp_path: Path) -> None:
     paths = _workflow_files(tmp_path)
     assert {path.suffix for path in paths} == {".yml", ".yaml"}
     assert _scheduled_workflow_names(paths) == {"YML", "YAML"}
+
+
+def test_duplicate_scheduled_workflow_names_fail_closed(tmp_path: Path) -> None:
+    workflow = 'name: Top1M Provider Health Check\non:\n  schedule:\n    - cron: "0 0 * * *"\n'
+    (tmp_path / "first.yml").write_text(workflow, encoding="utf-8")
+    (tmp_path / "second.yml").write_text(workflow, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate scheduled workflow name.*Top1M Provider Health Check"):
+        _scheduled_workflow_names(_workflow_files(tmp_path))
 
 
 def test_nightly_workflow_run_parser_ignores_decoy_workflow_lists() -> None:


### PR DESCRIPTION
## Summary

- Watch TLD, PSL, HSTS, and Version Tracker scheduled failures through the existing nightly alert workflow.
- Assert every schedule-triggered workflow is either watched or explicitly exempt.
- Enforce canonical workflow trigger syntax so alternate YAML cannot evade enumeration, and reject duplicate scheduled display names before exemptions are applied.

## Schedule decisions

- `Top1M Provider Health Check` remains exempt because its workflow already opens, updates, and closes its own tracking issue.
- `Module-durations table refresh` is not directly scheduled; it is triggered by `workflow_run` after a successful scheduled smoke run, so it is outside this invariant.
- `Version Tracker` has no equivalent failure tracker and is now watched.

## Verification

- Final RED: same frozen test against rebased pre-fix workflow → 1 failed, with HSTS, PSL, TLD, and Version Tracker uncovered.
- Final GREEN: `python3 -m pytest -q tests/test_nightly_failure_alert_coverage.py` → 31 passed.
- Frozen test hash: `6e45f3dd822654ce553700acce1f27f54256e667`.
- `scripts/agent/verify-red-proof.sh ... --base-ref 9baf7930` → FREEZE-OK, RED-OK, GREEN-OK, VERDICT PASS.
- `scripts/agent/run-gates.sh --diff origin/devel` → pytest, Ruff check, Ruff format, mypy, GATES PASS.
- Independent implementation gate, full PR review, and top-tier final pass: PASS.

Fixes #1800

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
