### PR TITLE
pfblockerng: validate IDNA joiners and pin emoji labels

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1447,8 +1447,8 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 	// issue #1723: narrowed from \p{C} (Cc+Cf+Co+Cs+Cn) to \p{Cc}+BOM (\x{FEFF}).
 	// Unicode format characters (Cf: ZWJ/ZWNJ, bidi marks, zero-width) are no
 	// longer grounds to reject a whole field -- free-text fields must accept
-	// Unicode; domain-shaped fields still exclude them via their type-specific
-	// validation below (ASCII regex or IDNA). Cc and the BOM stay rejected;
+	// Unicode; domain-shaped fields validate them via their type-specific
+	// ASCII/IDNA rules below. Cc and the BOM stay rejected;
 	// invalid UTF-8 stays fail-closed.
 	if (is_array($input)) {
 		foreach ($input as $vline) {
@@ -1708,10 +1708,11 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 		case PFB_FILTER_TLD:
 			// Validate TLD. issue #1723: a non-ASCII (IDN) TLD is converted to its
 			// punycode candidate before the charset check; on success the ORIGINAL
-			// input is returned (the read path IDN-converts separately).
+			// input is returned (the read path IDN-converts separately). issue #1812:
+			// nontransitional CONTEXTJ validation rejects forbidden joiner placements.
 			$candidate = $input;
 			if (preg_match('/[^\x00-\x7F]/', $input)) {
-				$candidate = idn_to_ascii($input);
+				$candidate = idn_to_ascii($input, IDNA_CHECK_CONTEXTJ | IDNA_NONTRANSITIONAL_TO_ASCII);
 				$candidate = empty($candidate) ? FALSE : $candidate;
 			}
 			if (($candidate !== FALSE) && preg_match("/^[a-zA-Z0-9_\.\-]+$/", $candidate)) {
@@ -1725,11 +1726,19 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 			// input is returned (htmlspecialchars'd) -- callers use the return as
 			// a pass/fail gate and persist the raw text, the read path
 			// (pfb_text_area_decode()'s IDN branch) IDN-converts separately at
-			// read time, so what is returned on success must not change.
+			// read time, so what is returned on success must not change. issue #1812:
+			// validation uses nontransitional CONTEXTJ checks; read conversion stays
+			// on pfb_idn_to_ascii_wildcard()'s existing default semantics.
 			$candidate = $input;
 			if (preg_match('/[^\x00-\x7F]/', $input)) {
-				$candidate = pfb_idn_to_ascii_wildcard($input);
-				$candidate = ($candidate === '') ? FALSE : $candidate;
+				$wildcard = str_starts_with($input, '.');
+				$host      = $wildcard ? substr($input, 1) : $input;
+				if (pfb_is_blank($host)) {
+					$candidate = FALSE;
+				} else {
+					$ascii = idn_to_ascii($host, IDNA_CHECK_CONTEXTJ | IDNA_NONTRANSITIONAL_TO_ASCII);
+					$candidate = empty($ascii) ? FALSE : ($wildcard ? ".{$ascii}" : $ascii);
+				}
 			}
 			if (($candidate !== FALSE) &&
 			    (strpos($candidate, '.') !== FALSE) &&			// Exclude no dots

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -145,6 +145,29 @@ final class PfbFilterContractTest extends TestCase
 		$this->assertSame("\u{0646}\u{0627}\u{0645}\u{0647}\u{200C}\u{0627}\u{06CC}", pfb_filter("\u{0646}\u{0627}\u{0645}\u{0647}\u{200C}\u{0627}\u{06CC}", PFB_FILTER_TLD, 'PFBL-01 contract'));
 	}
 
+	// --- PFB_FILTER_{TLD,DOMAIN,HOSTNAME}: emoji label acceptance (issue #1779) --
+	// Pin both the Unicode representation and its accepted A-label equivalent;
+	// successful filtering preserves whichever representation the caller supplied.
+
+	/** @return array<string, array{0: string, 1: int}> label => input and filter type */
+	public static function emojiLabelAcceptedProvider(): array
+	{
+		return [
+			'TLD Unicode emoji'          => ['😀', PFB_FILTER_TLD],
+			'TLD equivalent A-label'     => ['xn--e28h', PFB_FILTER_TLD],
+			'DOMAIN Unicode emoji'       => ['😀.example', PFB_FILTER_DOMAIN],
+			'DOMAIN equivalent A-label'  => ['xn--e28h.example', PFB_FILTER_DOMAIN],
+			'HOSTNAME Unicode emoji'     => ['😀.example', PFB_FILTER_HOSTNAME],
+			'HOSTNAME equivalent A-label' => ['xn--e28h.example', PFB_FILTER_HOSTNAME],
+		];
+	}
+
+	#[DataProvider('emojiLabelAcceptedProvider')]
+	public function testEmojiLabelsAcceptedAndPreserved(string $input, int $filterType): void
+	{
+		$this->assertSame($input, pfb_filter($input, $filterType, 'PFBL-01 contract'));
+	}
+
 	/** @return array<string, array{0: string}> label => CONTEXTJ-forbidden TLD */
 	public static function tldContextjRejectedProvider(): array
 	{

--- a/tests/php/PfbFilterContractTest.php
+++ b/tests/php/PfbFilterContractTest.php
@@ -117,14 +117,9 @@ final class PfbFilterContractTest extends TestCase
 			'IDN domain (latin)'        => ['bücher.de'],
 			'IDN domain (CJK)'          => ['日本語.example'],
 			'IDN leading-dot wildcard'  => ['.bücher.de'],
-			// PR #1729 review: ZWNJ/ZWJ (U+200C/U+200D) are UTS46 CONTEXTJ/
-			// deviation characters, contextually legal in real IDNA labels
-			// (e.g. Persian); PHP's idn_to_ascii(IDNA_DEFAULT) has no
-			// CHECK_CONTEXTJ, so the punycode candidate validates and the
-			// original Unicode is returned -- same stance as mixed-script
-			// acceptance above.
-			'ZWNJ inside a label'       => ["exam\xE2\x80\x8Cple.com"],
-			'ZWJ inside a label'        => ["exam\xE2\x80\x8Dple.com"],
+			// Persian "nameh-i": ZWNJ in a valid joining context (CONTEXTJ-valid).
+			'CONTEXTJ-valid ZWNJ (Persian)' => ["\u{0646}\u{0627}\u{0645}\u{0647}\u{200C}\u{0627}\u{06CC}.example"],
+			'CONTEXTJ-valid ZWNJ leading-dot wildcard' => [".\u{0646}\u{0627}\u{0645}\u{0647}\u{200C}\u{0627}\u{06CC}.example"],
 			// Mid-label U+200B (ZWSP) is silently MAPPED AWAY by UTS46 --
 			// probed: idn_to_ascii("exam\u{200B}ple.com") === 'example.com' --
 			// so the row is accepted and blocks the mapped target; an invisible
@@ -145,11 +140,23 @@ final class PfbFilterContractTest extends TestCase
 		$this->assertSame('рф', pfb_filter('рф', PFB_FILTER_TLD, 'PFBL-01 contract'));
 	}
 
-	public function testTldFilterAcceptsZeroWidthJoiner(): void
+	public function testTldFilterAcceptsContextjValidPersianZwnj(): void
 	{
-		// PR #1729 review: same ZWJ-accepted-by-design stance as the domain
-		// pins above, pinned for PFB_FILTER_TLD too.
-		$this->assertSame("\xD1\x80\xE2\x80\x8D\xD1\x84", pfb_filter("\xD1\x80\xE2\x80\x8D\xD1\x84", PFB_FILTER_TLD, 'PFBL-01 contract'));
+		$this->assertSame("\u{0646}\u{0627}\u{0645}\u{0647}\u{200C}\u{0627}\u{06CC}", pfb_filter("\u{0646}\u{0627}\u{0645}\u{0647}\u{200C}\u{0627}\u{06CC}", PFB_FILTER_TLD, 'PFBL-01 contract'));
+	}
+
+	/** @return array<string, array{0: string}> label => CONTEXTJ-forbidden TLD */
+	public static function tldContextjRejectedProvider(): array
+	{
+		return [
+			'leading ZWJ' => ["\u{200D}рф"],
+		];
+	}
+
+	#[DataProvider('tldContextjRejectedProvider')]
+	public function testTldFilterRejectsContextjForbiddenJoiners(string $input): void
+	{
+		$this->assertSame('', pfb_filter($input, PFB_FILTER_TLD, 'PFBL-01 contract'));
 	}
 
 	/** @return array<string, array{0: string}> label => hostile/boundary value the DOMAIN filter must still reject */
@@ -174,6 +181,9 @@ final class PfbFilterContractTest extends TestCase
 			// returns FALSE (UTS46 rejects it), so the candidate stays FALSE and
 			// the domain is rejected before the charset/label checks run.
 			'zero-width leading label'    => ["\xE2\x80\x8B.com"],
+			// A leading ZWJ is forbidden by IDNA2008 CONTEXTJ; nontransitional
+			// conversion must reject it instead of deleting it.
+			'leading ZWJ'                 => ["\u{200D}example.com"],
 			// U+202E (RIGHT-TO-LEFT OVERRIDE) inside a label -- probed:
 			// idn_to_ascii() returns FALSE (UTS46 disallows bidi control
 			// characters), so the candidate stays FALSE and the domain is
@@ -495,13 +505,10 @@ final class PfbFilterContractTest extends TestCase
 		//
 		// PR #1729 review: in domain-shaped input, ZWSP as an entire label
 		// ("​.com") IS rejected -- idn_to_ascii() itself refuses it, UTS46
-		// disallows it (see 'zero-width leading label' below). ZWNJ/ZWJ
-		// (U+200C/U+200D) are ACCEPTED by design in domain-shaped input --
-		// both are UTS46 CONTEXTJ/deviation characters, contextually legal in
-		// real IDNA labels (e.g. Persian), and PHP's idn_to_ascii(IDNA_DEFAULT)
-		// has no CHECK_CONTEXTJ, so the punycode candidate is exactly what the
-		// resolver queries (same stance as mixed-script acceptance, see
-		// domainUnicodeAcceptedProvider). Free-text keeps all of them.
+		// disallows it (see 'zero-width leading label' below). In
+		// domain-shaped input, CONTEXTJ-valid ZWNJ/ZWJ placements (e.g. Persian)
+		// remain accepted, while IDNA2008-forbidden placements are rejected by
+		// nontransitional CHECK_CONTEXTJ validation. Free-text keeps all of them.
 		$this->assertSame("\xE2\x80\x8B", pfb_filter("\xE2\x80\x8B", PFB_FILTER_HTML, 'ref', 'DEF'));
 	}
 


### PR DESCRIPTION
## Summary

- Reject IDNA2008 CONTEXTJ-forbidden joiner placements in the `PFB_FILTER_TLD` and `PFB_FILTER_DOMAIN` validation branches.
- Keep CONTEXTJ-valid Persian ZWNJ labels accepted and returned in their original representation.
- Pin the existing owner-approved emoji-label behavior for TLD, DOMAIN, and HOSTNAME, paired with each accepted `xn--` representation.

## Flag-scoping decision

`IDNA_CHECK_CONTEXTJ | IDNA_NONTRANSITIONAL_TO_ASCII` applies only while constructing the TLD and DOMAIN **validation candidates**. I left `pfb_idn_to_ascii_wildcard()` and its read/conversion callers on their existing default conversion semantics, so this PR does not silently change deviation-character conversion on `pfb_text_area_decode()`, category edit, or `pfblockerng_apply.inc` read paths.

## Verification

- #1812 test-first RED: the frozen contract file produced exactly two failures on untouched production code—leading ZWJ was accepted by TLD and DOMAIN—while valid Persian and existing HOSTNAME CONTEXTJ rows stayed green.
- #1812 GREEN: the byte-identical test file passed; independent verifier re-executed `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS` and confirmed every matrix row.
- #1779 behavior-preserving oracle: `OK (6 tests, 6 assertions)` for Unicode emoji and A-label representations across TLD, DOMAIN, and HOSTNAME; no rejection policy added.
- Canonical `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS` after the rebased two-commit stack (`php -l`, full PHPUnit, PHPStan, PHPCS).
- Final focused contract run after the last live-base rebase: `OK (26 tests, 26 assertions)`.

Fixes #1812
Fixes #1779

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
