### PR TITLE
tests: pin config_set_path double to upstream parity (#1918)

### DIFF
--- a/tests/php/ConfigSetPathParityTest.php
+++ b/tests/php/ConfigSetPathParityTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Upstream parity matrix for the config_set_path() double (issue #1918).
+ *
+ * Pins tests/php/pfsense_doubles.php's config_set_path() against pfSense
+ * config.lib.inc's config_set_path() + util.inc's array_set_path() it wraps.
+ * array_set_path() is byte-identical across all three refs checked:
+ * pfsense/pfsense `master`, `ed6c2eb8` (CE 2.8.0), `9363ac5b`.
+ *
+ * Every row asserts BOTH the return value and the resulting whole
+ * $GLOBALS['config'] with assertSame, except row "NOTE-A" (config unset,
+ * plain path) -- see the relaxed-assertion comment on that row below.
+ * $default is always the distinguishable sentinel 'DEFAULT' (never null),
+ * so a null return can never fake a "returns $default" pass.
+ */
+final class ConfigSetPathParityTest extends TestCase
+{
+	// Sentinel marking "the initial $GLOBALS['config'] is UNSET" in a
+	// provider row -- distinct from any real value (array/string/null) any
+	// row here uses, so it can share the provider's $initial slot.
+	private const CONFIG_UNSET = "\0__CONFIG_UNSET__\0";
+
+	// Sentinel marking "skip the assertSame(cfg after) check, use the NOTE-A
+	// relaxed check instead" -- see testConfigSetPathMatchesUpstreamParity().
+	private const NOTE_A_RELAXED_CHECK = "\0__NOTE_A_RELAXED_CHECK__\0";
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	public static function parityProvider(): array
+	{
+		$default = 'DEFAULT';
+
+		return [
+			'append: trailing slash onto existing leaf array (#1912)' => [
+				['items' => ['first']], 'items/', 'second', $default,
+				'second', ['items' => ['first', 'second']],
+			],
+			'replace: plain path onto existing leaf array (#1912)' => [
+				['items' => ['first']], 'items', 'second', $default,
+				'second', ['items' => 'second'],
+			],
+			'non-empty scalar intermediate, append path' => [
+				['group' => 'occupied'], 'group/items/', 'second', $default,
+				$default, ['group' => 'occupied'],
+			],
+			'non-empty scalar intermediate, plain path' => [
+				['group' => 'occupied'], 'group/items', 'second', $default,
+				$default, ['group' => 'occupied'],
+			],
+			'non-empty scalar intermediate, deep path' => [
+				['a' => ['b' => 'occupied']], 'a/b/c/d', 'v', $default,
+				$default, ['a' => ['b' => 'occupied']],
+			],
+			'empty-string intermediate is overwritten' => [
+				['group' => ''], 'group/items', 'second', $default,
+				'second', ['group' => ['items' => 'second']],
+			],
+			"string-'0' intermediate is overwritten (upstream empty() quirk)" => [
+				['group' => '0'], 'group/items', 'second', $default,
+				'second', ['group' => ['items' => 'second']],
+			],
+			'int-0 intermediate is overwritten' => [
+				['group' => 0], 'group/items', 'second', $default,
+				'second', ['group' => ['items' => 'second']],
+			],
+			'false intermediate is overwritten' => [
+				['group' => false], 'group/items', 'second', $default,
+				'second', ['group' => ['items' => 'second']],
+			],
+			'null intermediate is overwritten' => [
+				['group' => null], 'group/items', 'second', $default,
+				'second', ['group' => ['items' => 'second']],
+			],
+			'empty-array intermediate is reset to [] then descended' => [
+				['group' => []], 'group/items', 'second', $default,
+				'second', ['group' => ['items' => 'second']],
+			],
+			'non-empty-array intermediate is descended, siblings preserved' => [
+				['group' => ['keep' => 'x']], 'group/items', 'second', $default,
+				'second', ['group' => ['keep' => 'x', 'items' => 'second']],
+			],
+			// Row 13 (scalar intermediate, no $default arg) is its own test
+			// method -- the 2-arg call is a different shape than this
+			// provider's rows, not a bent version of it.
+			'append onto non-empty scalar leaf wraps it' => [
+				['items' => 'scalar'], 'items/', 'x', $default,
+				'x', ['items' => ['x']],
+			],
+			'append onto missing leaf creates a list' => [
+				[], 'items/', 'x', $default,
+				'x', ['items' => ['x']],
+			],
+			'append onto empty-string leaf wraps it' => [
+				['items' => ''], 'items/', 'x', $default,
+				'x', ['items' => ['x']],
+			],
+			'plain path creates missing intermediates' => [
+				[], 'a/b/c', 'v', $default,
+				'v', ['a' => ['b' => ['c' => 'v']]],
+			],
+			'array value onto missing path' => [
+				[], 'a/b', ['k' => 'v'], $default,
+				['k' => 'v'], ['a' => ['b' => ['k' => 'v']]],
+			],
+			"'//' mid-path rejected, no mutation" => [
+				['a' => ['b' => 'keep']], 'a//b', 'v', $default,
+				$default, ['a' => ['b' => 'keep']],
+			],
+			"'//' leading rejected, no mutation" => [
+				['a' => ['b' => 'keep']], '//a/b', 'v', $default,
+				$default, ['a' => ['b' => 'keep']],
+			],
+			"'//' trailing rejected, no mutation" => [
+				['a' => ['b' => 'keep']], 'a/b//', 'v', $default,
+				$default, ['a' => ['b' => 'keep']],
+			],
+			"'///' rejected, no mutation" => [
+				['a' => 'keep'], '///', 'v', $default,
+				$default, ['a' => 'keep'],
+			],
+			'empty path + array value replaces the whole config' => [
+				['old' => 1], '', ['new' => 2], $default,
+				['new' => 2], ['new' => 2],
+			],
+			'empty path + scalar value rejected, no mutation' => [
+				['old' => 1], '', 'scalar', $default,
+				$default, ['old' => 1],
+			],
+			"'/' + array value rejected, no mutation" => [
+				['old' => 1], '/', ['new' => 2], $default,
+				$default, ['old' => 1],
+			],
+			"'/' + scalar value rejected, no mutation" => [
+				['old' => 1], '/', 'scalar', $default,
+				$default, ['old' => 1],
+			],
+			'single leading slash is ignored (existing path)' => [
+				['a' => ['b' => 'keep']], '/a/b', 'v', $default,
+				'v', ['a' => ['b' => 'v']],
+			],
+			'single leading slash is ignored (missing path)' => [
+				[], '/a/b', 'v', $default,
+				'v', ['a' => ['b' => 'v']],
+			],
+			'leading slash + trailing slash = ignore + append' => [
+				['a' => ['b' => ['keep']]], '/a/b/', 'v', $default,
+				'v', ['a' => ['b' => ['keep', 'v']]],
+			],
+			'numeric-string key leaf' => [
+				['a' => [0 => 'old']], 'a/0', 'v', $default,
+				'v', ['a' => [0 => 'v']],
+			],
+			'numeric-0 intermediate array is descended, not treated as root' => [
+				['a' => [0 => ['x' => 1]]], 'a/0/y', 'v', $default,
+				'v', ['a' => [0 => ['x' => 1, 'y' => 'v']]],
+			],
+			// NOTE-A: upstream's `global $config;` itself materialises
+			// $GLOBALS['config'] = null when the global did not exist, so
+			// upstream leaves it present-and-null. The double reads the
+			// global without `global`, so it leaves it absent. Behaviourally
+			// identical for every consumer (config_get_path() returns its
+			// default either way) -- the ONLY row where a literal-parity
+			// assertion is relaxed (see the NOTE_A_RELAXED_CHECK handling
+			// below).
+			'$config unset -> $default, no config fabricated (NOTE-A)' => [
+				self::CONFIG_UNSET, 'a/b', 'v', $default,
+				$default, self::NOTE_A_RELAXED_CHECK,
+			],
+			'$config is a scalar string -> $default, preserved' => [
+				'notanarray', 'a/b', 'v', $default,
+				$default, 'notanarray',
+			],
+			'$config is null -> $default, preserved' => [
+				null, 'a/b', 'v', $default,
+				$default, null,
+			],
+			'$config unset + empty path + array value -> initialised and replaced' => [
+				self::CONFIG_UNSET, '', ['new' => 2], $default,
+				['new' => 2], ['new' => 2],
+			],
+			'$config scalar + empty path + array value -> initialised and replaced' => [
+				'notanarray', '', ['new' => 2], $default,
+				['new' => 2], ['new' => 2],
+			],
+		];
+	}
+
+	#[DataProvider('parityProvider')]
+	public function testConfigSetPathMatchesUpstreamParity(
+		mixed $initial,
+		string $path,
+		mixed $value,
+		mixed $default,
+		mixed $expectedReturn,
+		mixed $expectedConfigAfter
+	): void {
+		$label = (string) $this->dataName();
+
+		if ($initial === self::CONFIG_UNSET) {
+			unset($GLOBALS['config']);
+		} else {
+			$GLOBALS['config'] = $initial;
+		}
+
+		$actualReturn = config_set_path($path, $value, $default);
+
+		$this->assertSame($expectedReturn, $actualReturn, "{$label}: return value mismatch");
+
+		if ($expectedConfigAfter === self::NOTE_A_RELAXED_CHECK) {
+			// The ONLY relaxation in this matrix, and only in one direction:
+			// absent and present-and-null are the two states this row accepts,
+			// because upstream's `global $config;` materialises the null while
+			// the double leaves the global absent. Any OTHER config the double
+			// might invent -- a scalar, an array, an empty string -- still fails.
+			$this->assertNull(
+				$GLOBALS['config'] ?? null,
+				"{$label}: double must not fabricate a config"
+			);
+
+			return;
+		}
+
+		// Read through array_key_exists(), not `?? null`: the "$config is null"
+		// row expects a present-and-null config, and `??` would collapse an
+		// erroneously unset() config onto that same null -- passing a row whose
+		// whole point is that the rejection branch mutates nothing.
+		$actualConfigAfter = array_key_exists('config', $GLOBALS)
+			? $GLOBALS['config']
+			: self::CONFIG_UNSET;
+		$this->assertSame($expectedConfigAfter, $actualConfigAfter, "{$label}: \$GLOBALS['config'] after mismatch");
+	}
+
+	/**
+	 * Row 13: a scalar intermediate with NO $default argument returns null
+	 * (the 2-arg call) -- kept out of parityProvider() because its call
+	 * shape differs from every other row (no 4th argument), not because its
+	 * assertions differ.
+	 */
+	public function testScalarIntermediateWithNoDefaultArgReturnsNull(): void
+	{
+		$GLOBALS['config'] = ['group' => 'occupied'];
+
+		$this->assertNull(config_set_path('group/items', 'second'));
+		$this->assertSame(['group' => 'occupied'], $GLOBALS['config']);
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -321,28 +321,107 @@ if (!function_exists('config_get_path')) {
 }
 
 if (!function_exists('config_set_path')) {
-	// pfSense config.lib.inc: set the value at a '/'-separated path (creating
-	// intermediate arrays), returning the value set.
+	// pfSense config.lib.inc config_set_path() wrapping util.inc array_set_path()
+	// (issue #1918) -- ported onto $GLOBALS['config'] directly (the double has no
+	// separate array_set_path()/$config global to pass by reference).
+	// array_set_path() verified byte-identical across three refs on the public
+	// pfsense/pfsense mirror (.agents/context/lang-php.md "Resolving pfSense-provided
+	// PHP functions from upstream"): `master`, `ed6c2eb8` (CE 2.8.0), `9363ac5b`.
+	//
+	// Departures from a byte-for-byte transcription, each probed inert: upstream's
+	// loose `==`/`!=` on $path/$vkey and its `mb_strlen(...) == 0` are strict here
+	// ($path and $vkey are always strings, mb_strlen() always an int), and
+	// upstream's log_invalid_config_path() side effect is dropped -- pure logging,
+	// with no double in this file and no caller that observes it.
+	//
+	// Deliberately NOT `global $config;`: upstream's `global` statement itself
+	// materialises $GLOBALS['config'] = null the first time it runs, so a config
+	// that never existed still ends up present-and-null upstream. Reading
+	// $GLOBALS['config'] directly here instead leaves it genuinely absent when
+	// unset -- identical to every consumer in this tree, since config_get_path(),
+	// config_del_path() and config_path_enabled() all treat absent and null the
+	// same; only array_key_exists('config', $GLOBALS) tells the two apart. Pinned
+	// by ConfigSetPathParityTest's "$config unset" row (NOTE-A: the one relaxed
+	// assertion in that matrix).
+	//
+	// The `!empty($el[$key])` intermediate check below is deliberate, upstream
+	// verbatim: it is what makes a '', '0', 0, false, null or [] intermediate get
+	// OVERWRITTEN rather than descended into. PHPStan's NoEmptyOnStringRule does
+	// not analyse tests/, so it does not flag it here.
 	function config_set_path(string $path, $value, $default = null) {
-		$append = ($path !== '' && str_ends_with($path, '/'));
-		$node = &$GLOBALS['config'];
-		if (!is_array($node)) {
-			$node = [];
+		// config_set_path() wrapper.
+		if (str_contains($path, '//')) {
+			return $default;
 		}
-		foreach (explode('/', rtrim($path, '/')) as $key) {
-			if (!is_array($node)) {
+		if ($path === '') {
+			if (!is_array($value)) {
 				return $default;
 			}
-			if (!array_key_exists($key, $node) || !is_array($node[$key])) {
-				$node[$key] = [];
+			if (!is_array($GLOBALS['config'] ?? null)) {
+				// initialize config when it's being completely replaced
+				$GLOBALS['config'] = [];
 			}
-			$node = &$node[$key];
+		} elseif ($path === '/') {
+			// prevent unintentionally treating $config as a list array
+			return $default;
 		}
+		if (!is_array($GLOBALS['config'] ?? null)) {
+			return $default;
+		}
+
+		// array_set_path() body, operating on $GLOBALS['config'] as the root array.
+		$vpath = explode('/', $path);
+		// check for trailing forward-slash
+		$append = ($path !== '' && $vpath[array_key_last($vpath)] === '');
+
+		// get the path's leaf node; ignore trailing and contiguous forward-slashes
+		do {
+			$vkey = array_pop($vpath);
+		} while (isset($vkey) && mb_strlen($vkey) === 0);
+
+		$arr = &$GLOBALS['config'];
+
+		// path is root, make sure $arr is always an array
+		if ($vkey === null) {
+			// avoid creating a single-element root (e.g. [0 => []])
+			if ($append) {
+				$arr[] = is_array($value) ? $value : [$value];
+			} else {
+				$arr = is_array($value) ? $value : [$value];
+			}
+			return $value;
+		}
+
+		// traverse the array and get a reference to the leaf node
+		$el = &$arr;
+		foreach ($vpath as $key) {
+			if (mb_strlen($key) === 0) {
+				continue;
+			}
+			if (array_key_exists($key, $el) && !empty($el[$key])) {
+				if (!is_array($el[$key])) {
+					return $default;
+				}
+			} else {
+				$el[$key] = [];
+			}
+			$el = &$el[$key];
+		}
+
+		// set the leaf node value
 		if ($append) {
-			$node[] = $value;
+			// upstream reads bare `is_array($el[$vkey])`; `?? null` avoids an
+			// "Undefined array key" warning under PHPUnit for the same branch
+			// when $vkey is not yet a key of $el.
+			if (is_array($el[$vkey] ?? null)) {
+				$el[$vkey][] = $value;
+			} else {
+				$el[$vkey] = [$value];
+			}
 		} else {
-			$node = $value;
+			$el[$vkey] = $value;
 		}
+
 		return $value;
 	}
 }


### PR DESCRIPTION
## Summary

Ports `tests/php/pfsense_doubles.php`'s `config_set_path()` double to upstream pfSense semantics — both the `config.lib.inc` wrapper and the `util.inc` `array_set_path()` walker it wraps — and pins all of it with a new 36-row upstream-parity matrix.

Before this change the double was a permissive walker: it created intermediate arrays over any non-array node, `rtrim()`ed the path before deciding anything, and never applied the wrapper's rejections. Off-appliance tests could therefore mutate configuration on paths where pfSense returns `$default` and writes nothing — a false pass.

## What the double now matches

- **Non-empty scalar intermediate** → returns `$default`, config preserved. This is the headline defect from the issue: `config_set_path('group/items/', 'second', 'DEFAULT')` against `['group' => 'occupied']` used to return `'second'` and rewrite `group`; it now returns `'DEFAULT'` and leaves `group` alone.
- **Falsy intermediates** (`''`, `'0'`, `0`, `false`, `null`, `[]`) are still overwritten — upstream's `!empty()` check, reproduced verbatim, quirk included.
- **Wrapper rejections**: any path containing `//` returns `$default` with no mutation; `'/'` returns `$default`; `''` replaces the whole config when the value is an array and returns `$default` when it is not.
- **Non-array `$config`** returns `$default` instead of silently initialising, except on the empty-path replacement where upstream does initialise.
- **A single leading slash is ignored**, matching `array_set_path()`'s zero-length-segment skip, so `/a/b` resolves like `a/b`.
- #1912's trailing-slash append and plain-path replacement are preserved (rows 1 and 2 of the matrix, and `ConfigPathDoublesTest` is untouched).

## Upstream provenance

`array_set_path()` was fetched and diffed at three `pfsense/pfsense` refs — `master`, `ed6c2eb8` (CE 2.8 era), `9363ac5b` (Plus 26.03 era) — and is byte-identical across all three. `config_set_path()`'s wrapper comes from `config.lib.inc` at the same refs.

## One documented deviation

Upstream's `global $config;` statement itself materialises `$GLOBALS['config'] = null` when the global does not exist, so upstream leaves it present-and-null after a rejected write. The double reads the global without `global`, leaving it genuinely absent. That is identical for every consumer in this tree — `config_get_path()`, `config_del_path()` and `config_path_enabled()` all treat absent and null the same, and only `array_key_exists('config', $GLOBALS)` can tell them apart. It is the one row of the matrix whose assertion is relaxed, and it is relaxed in exactly one direction: absent and present-and-null both pass, any other fabricated config still fails.

## Verification

- **RED** (test authored first, executed against the untouched double): `vendor/bin/phpunit tests/php/ConfigSetPathParityTest.php` → `Tests: 36, Assertions: 58, Failures: 20` — exactly the 20 rows the differential oracle marked divergent.
- **GREEN** (same command, test file byte-identical between the red and green runs): `OK (36 tests, 72 assertions)`. The proof was re-executed mechanically after each review round via `scripts/agent/verify-red-proof.sh --base-ref origin/devel`, which reverts only the double, requires the test to FAIL, restores, and requires PASS — `FREEZE-OK` / `RED-OK` / `GREEN-OK` / `VERDICT: PASS`, against the shipped test blob `62358a95b90c7dc3796f85eb50063e503348a2c1`.
- **Full PHPUnit suite** — `pfsense_doubles.php` loads into every PHPUnit test in the tree and this change makes it stricter, so the whole suite was run repeatedly, not just the new file: `Tests: 4822, Assertions: 26100` with no new failures, the delta over the current base being exactly this PR's 36 tests and 72 assertions. An instrumented differential run over the rest of the suite recorded 3699 `config_set_path()` calls with **zero** taking a new rejection path and zero divergences in return value or resulting config, so the stricter double is outcome-identical for every call the existing tree makes.
- `scripts/agent/run-gates.sh --diff origin/devel` → PASS (composer vendor check, PHP lint, PHPUnit, PHPStan, PHPCS).

## Follow-ups filed, deliberately not fixed here

The same file's other config-path doubles diverge from upstream too. Each got its own issue rather than being folded into this PR: #1999 (`config_get_path`), #2000 (`config_del_path`), #2001 (`config_path_enabled`).

Two pre-existing PHP-suite flakes surfaced while running the gates for this PR and were reproduced against the unchanged base, so they are not caused by it: #2006 (`TickEntrypointTest`'s ordering tripwire scans the host process table) and #2024 (`TickFeedPassDeferralTest` turns a 2-second wall-clock cap into a behavioural assertion).

Fixes #1918

🤖 Generated with [Claude Code](https://claude.com/claude-code)
