### PR TITLE
tests/smoke: correct stale-baseline test documentation

### DIFF
--- a/tests/smoke/ui/test_render_oracle.py
+++ b/tests/smoke/ui/test_render_oracle.py
@@ -545,11 +545,9 @@ def test_the_shipped_baseline_parses_and_is_burning_down() -> None:
 
 
 def test_stale_baseline_entries_names_what_a_full_sweep_never_saw() -> None:
-    """A grandfathered site nobody observes any more is a FIXED site -- and its entry has
-    to go, or a regression there would be silently forgiven again.
+    """A grandfathered site unobserved in a full sweep is a removal candidate.
 
-    That is the failure mode the whole issue is about, reintroduced through the back door
-    by a baseline nobody prunes.
+    One green sweep does not prove a fix because config-dependent paths may not be reached.
     """
     baseline = frozenset({"a|Warning|gone", "b|Warning|still here"})
     assert stale_baseline_entries(frozenset({"b|Warning|still here"}), baseline=baseline) == ("a|Warning|gone",)


### PR DESCRIPTION
## Summary

- describe unobserved stale-baseline entries as removal candidates, not proven fixes
- keep stale-baseline calculation and report-only behavior unchanged
- avoid a prose assertion, as required by the issue

## Verification

- pre-edit `rg -n "FIXED site|has to go" tests/smoke/ui/test_render_oracle.py` — contradictory claim reproduced at line 548
- post-edit same `rg` — no matches
- `python3 -m pytest tests/smoke/ui/test_render_oracle.py --override-ini=addopts= -q` — 43 passed
- `python3 -m pytest` — 3921 passed, 4 skipped
- `scripts/agent/run-gates.sh --diff origin/devel` — GATES: PASS after final rebase

Fixes #1977

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that unobserved grandfathered diagnostics are candidates for removal rather than confirmed fixes.
  * Noted that a single successful test sweep may not cover configuration-dependent paths.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->