### PR TITLE
build: frozen v3.2 package build and identity validation (#1676)

### DIFF
--- a/docs/build-pkg-portable.md
+++ b/docs/build-pkg-portable.md
@@ -124,6 +124,7 @@ interactive, the tool prompts; otherwise it exits with an error naming the flag.
 | `--py-flavor FLAVOR` | `py311` | The Python flavor used in dependency names (`py311-sqlite3`, …) and the `python<XY>` dep. |
 | `--php VERSION` | `8.3` | The PHP version for the `USES=php` dependency (`php83`, `php83-intl`). Asked **only** when the port uses PHP. |
 | `--freebsd-version N` | `1500068` | The build host's `__FreeBSD_version`, written to the manifest `annotations` block. Optional; the block is omitted if unset. |
+| `--no-arch` | off | Force the manifest `abi`/`arch` to the CPU-wildcarded form (`FreeBSD:<major>:*` / `freebsd:<major>:*`) even when the port Makefile has no `NO_ARCH=yes` — e.g. a frozen ports snapshot that predates that Makefile setting. Same effect as `NO_ARCH=yes`; an explicit `--arch` still overrides the derived wildcard. |
 
 ### Source (USE_GITHUB ports)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -284,6 +284,41 @@ plan (files, modes, deps) without writing the archive.
 Full reference (every option, the fidelity comparison, troubleshooting):
 [`../docs/build-pkg-portable.md`](../docs/build-pkg-portable.md).
 
+### Frozen v3.2 build (issue #1676)
+
+[`build-frozen-v3.py`](build-frozen-v3.py) builds and identity-validates the frozen pfBlockerNG
+`v3.2.15` (Stable) and `v3.2.16` (Devel) `.pkg` artifacts for every BUILD-matrix row, on top of
+`build-leg.sh`/`build-pkg-portable.py`. It exists because those two source tags predate the
+2026-06-05 `list_scripts/` move: a current `devel`-branch ports ref cannot build a v3.2 source
+tree, and a current source tree cannot be built by the frozen ports ref either. The tool
+therefore pins BOTH sides as module-level constants — an exact FreeBSD-ports commit
+(`FROZEN_PORTS_REF`) and, per channel, an exact source tag/commit (`FROZEN_TARGETS`) — and
+treats any drift from either as a hard error rather than silently rebuilding the wrong bits.
+
+Per artifact it exports the pinned tag with `git archive` into a fresh temp dir (clean by
+construction, never the working tree), builds one leg via `build-leg.sh`, and validates the
+result before staging anything: package name/origin/version, the wildcarded ABI (`--no-arch`
+is what keeps a single `.pkg` per FreeBSD major serving `aarch64` and every other arch — same
+as every other `NO_ARCH` pfBlockerNG port, see "ABI: what actually matters" above),
+matrix-derived dependency names, and byte-for-byte payload parity against the tag export. The
+**one** reviewed packaging divergence is `usr/local/share/<port>/info.xml`'s
+`%%PKGVERSION%%` substitution (the port's own `do-install` `REINPLACE_CMD`) — allowlisted
+exactly there and nowhere else; anything else that differs is a hard rejection, and a failed
+validation stages nothing. Unless `--no-deterministic-check`, every row is built twice and
+required to produce a byte-identical artifact.
+
+```sh
+python3 scripts/build-frozen-v3.py --out /tmp/frozen-v3-stage
+```
+
+Writes `<out>/fbsd<major>/<pkgname>-<version>.pkg` per row plus a JSON identity report
+(`<out>/frozen-v3-report.json`: source commit, artifact SHA-256, payload inventory with
+per-file SHA-256, dependency/ABI facts). `--verify-only DIR` re-validates an already-staged
+directory with no build seam invoked at all. See `--help` for the full flag set.
+
+**This tool never publishes anything** — no GitHub Release upload, no catalog write, no
+network write of any kind. Publication is a separate, maintainer-gated step.
+
 ## Image pipeline (ADR-04 smoke base)
 
 The CI smoke harness — see [`../.ADRs/ADR_04_VM_Smoke_Tests/`](../.ADRs/ADR_04_VM_Smoke_Tests/) —

--- a/scripts/build-frozen-v3.py
+++ b/scripts/build-frozen-v3.py
@@ -210,10 +210,14 @@ def export_tag(repo: Path, commit: str, dest: Path) -> None:
     if proc.returncode != 0:
         raise TagResolutionError(f"git archive {commit} failed: {proc.stderr.decode(errors='replace').strip()}")
     with tarfile.open(fileobj=io.BytesIO(proc.stdout)) as tf:
+        # Mirrors build-pkg-portable.py's _safe_extract: the stdlib 'data' filter (PEP 706,
+        # Python 3.11.4+ — the repo's floor is 3.11) rejects absolute paths, parent-dir
+        # traversal, and link-based escapes. There is deliberately NO unfiltered fallback:
+        # degrading to a bare extractall would silently drop that guard in a supply-chain step.
         try:
             tf.extractall(dest, filter="data")
-        except TypeError:  # pre-3.12 tarfile without the `filter` kwarg (PEP 706 backport absent)
-            tf.extractall(dest)
+        except tarfile.FilterError as e:
+            raise TagResolutionError(f"unsafe member in the {commit} tag export: {e}") from None
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/build-frozen-v3.py
+++ b/scripts/build-frozen-v3.py
@@ -138,6 +138,9 @@ def validate_matrix(obj: object) -> list[dict]:
         missing = [k for k in _REQUIRED_ROW_FIELDS if k not in row]
         if missing:
             raise MatrixError(f"BUILD matrix row {i} missing required field(s): {', '.join(missing)}")
+        for key in ("php_version", "py_flavor"):
+            if not isinstance(row[key], str):
+                raise MatrixError(f"BUILD matrix row {i}: {key} must be a string, got {row[key]!r}")
         major = row["freebsd_major"]
         if not isinstance(major, str) or not _MAJOR_RE.fullmatch(major):
             raise MatrixError(f"BUILD matrix row {i}: freebsd_major must be a positive-integer string, got {major!r}")
@@ -235,12 +238,26 @@ def _read_pkg(pkg_path: Path) -> tuple[dict, dict[str, bytes]]:
                 raise ArtifactValidationError(f"{pkg_path.name}: missing +COMPACT_MANIFEST")
             if "+MANIFEST" not in names:
                 raise ArtifactValidationError(f"{pkg_path.name}: missing +MANIFEST")
+            # libarchive/libpkg resolves a duplicated member name to the FIRST copy while
+            # Python's tarfile resolves it to the LAST, so a duplicate would let this
+            # validator and the installer read different bytes from one artifact.
+            duplicates = sorted({n for n in names if names.count(n) > 1})
+            if duplicates:
+                raise ArtifactValidationError(f"{pkg_path.name}: duplicate archive member(s): {', '.join(duplicates)}")
             compact_raw = tf.extractfile("+COMPACT_MANIFEST").read()  # type: ignore[union-attr]
             manifest_raw = tf.extractfile("+MANIFEST").read()  # type: ignore[union-attr]
             payload: dict[str, bytes] = {}
             for member in tf.getmembers():
-                if member.name in ("+MANIFEST", "+COMPACT_MANIFEST") or not member.isfile():
+                if member.name in ("+MANIFEST", "+COMPACT_MANIFEST"):
                     continue
+                # Only regular files are comparable against the tag export. A symlink,
+                # hardlink, dir or device would skip payload parity entirely, so refuse
+                # it rather than let it ride along unexamined.
+                if not member.isfile():
+                    raise ArtifactValidationError(
+                        f"{pkg_path.name}: payload member {member.name!r} is not a regular file "
+                        f"(tar type {member.type!r})"
+                    )
                 extracted = tf.extractfile(member)
                 payload[member.name] = extracted.read() if extracted is not None else b""
     except ArtifactValidationError:
@@ -260,6 +277,18 @@ def _read_pkg(pkg_path: Path) -> tuple[dict, dict[str, bytes]]:
         raise ArtifactValidationError(f"{pkg_path.name}: +MANIFEST is not valid JSON: {e}") from None
     if not isinstance(manifest, dict):
         raise ArtifactValidationError(f"{pkg_path.name}: +MANIFEST is not a JSON object")
+    # Identity is validated below against +MANIFEST, but the catalog generator
+    # (build-repo-portable.py, via pfb_pkg.read_compact_manifest) routes on
+    # +COMPACT_MANIFEST. Divergence would validate one identity and publish another.
+    disagreements = [
+        f"{key}: +MANIFEST={manifest.get(key)!r} vs +COMPACT_MANIFEST={compact_obj.get(key)!r}"
+        for key in ("name", "origin", "version", "abi", "arch")
+        if manifest.get(key) != compact_obj.get(key)
+    ]
+    if disagreements:
+        raise ArtifactValidationError(
+            f"{pkg_path.name}: +COMPACT_MANIFEST disagrees with +MANIFEST — {'; '.join(disagreements)}"
+        )
     return manifest, payload
 
 
@@ -479,6 +508,9 @@ def build_and_stage_one(
         leg_dir.mkdir(parents=True, exist_ok=True)
         staged_path = leg_dir / pkg_path.name
         shutil.copy2(pkg_path, staged_path)
+        # Re-hash the STAGED file: the report's checksum must describe the bytes a later
+        # publication step would upload, not the scratch copy they were taken from.
+        identity["artifact_sha256"] = hashlib.sha256(staged_path.read_bytes()).hexdigest()
         identity["staged_path"] = staged_path
         return identity
     finally:
@@ -541,7 +573,15 @@ def build_all(
                         ports_dir=ports_dir,
                     )
                     pkg2_path = Path(_invoke_build_leg(argv, cwd=repo))
-                    check_determinism(staged_path, pkg2_path)
+                    try:
+                        check_determinism(staged_path, pkg2_path)
+                    except DeterminismError:
+                        # Staging is what makes an artifact a publication candidate, so a
+                        # row that failed its re-build must not survive in the staging root
+                        # for a later --verify-only to bless.
+                        staged_path.unlink(missing_ok=True)
+                        staged.discard(staged_path)
+                        raise
                 finally:
                     shutil.rmtree(scratch2, ignore_errors=True)
 

--- a/scripts/build-frozen-v3.py
+++ b/scripts/build-frozen-v3.py
@@ -1,0 +1,716 @@
+#!/usr/bin/env python3
+# build-frozen-v3.py — build + identity-validate the FROZEN pfBlockerNG v3.2
+# Stable/Devel .pkg artifacts (issue #1676) for every BUILD-matrix row.
+#
+# The v3.2 sources predate the 2026-06-05 list_scripts/ move: a current-devel
+# ports ref cannot build them, and a current source tree cannot be built by
+# the frozen ports ref either. So this tool pins BOTH sides — an exact
+# FreeBSD-ports commit (FROZEN_PORTS_REF) and, per channel, an exact
+# pfBlockerNG source tag/commit (FROZEN_TARGETS) — and treats a mismatch on
+# either as a hard error rather than silently drifting.
+#
+# Per (frozen target x BUILD-matrix row) this:
+#   1. exports the pinned source tag with `git archive` into a fresh temp dir
+#      (never the working tree — the export is clean BY CONSTRUCTION, not
+#      merely by inspection);
+#   2. builds one .pkg leg via scripts/build-leg.sh (the shared build path);
+#   3. validates the artifact's identity (validate_artifact) — name, origin,
+#      version, wildcarded ABI/arch, matrix-derived dependency names, the one
+#      reviewed packaging divergence (info.xml's %%PKGVERSION%% substitution),
+#      and byte-exact payload parity against the tag export otherwise — and
+#      REFUSES to stage anything that fails;
+#   4. unless --no-deterministic-check, rebuilds the same row and requires a
+#      byte-identical second artifact;
+#   5. writes a JSON identity report.
+#
+# This tool NEVER publishes: no GitHub Release upload, no catalog write, no
+# network write of any kind. Publication is a separate, maintainer-gated step.
+#
+# Python 3.11+, standard library only. See --help for the full CLI.
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import io
+import json
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import pfb_pkg
+
+# --------------------------------------------------------------------------- #
+# Frozen identities — constants, not matrix-tracked. Never edit these to
+# "catch up" with a later tag; a new frozen build target is a new constant.
+# --------------------------------------------------------------------------- #
+
+FROZEN_PORTS_REF = "d30af128f456396a1cc961a10fdf23ad61bdfd58"
+
+
+@dataclass(frozen=True)
+class FrozenTarget:
+    channel: str  # "stable" | "devel"
+    tag: str
+    commit: str
+    portname: str
+    portversion: str
+
+
+FROZEN_TARGETS: tuple[FrozenTarget, ...] = (
+    FrozenTarget(
+        channel="stable",
+        tag="v3.2.15",
+        commit="0846aa7c090f96e62b5322d7dea70e80b1f31b63",
+        portname="pfSense-pkg-pfBlockerNG",
+        portversion="3.2.15",
+    ),
+    FrozenTarget(
+        channel="devel",
+        tag="v3.2.16",
+        commit="0676cd1c7ed79d49a0644070151c4fffa39ea409",
+        portname="pfSense-pkg-pfBlockerNG-devel",
+        portversion="3.2.16",
+    ),
+)
+
+
+class MatrixError(Exception):
+    """The BUILD matrix (or the command that produced it) is unusable."""
+
+
+class TagResolutionError(Exception):
+    """A frozen source tag could not be resolved to its expected commit."""
+
+
+class BuildLegError(Exception):
+    """scripts/build-leg.sh failed or violated its stdout contract."""
+
+
+class ArtifactValidationError(Exception):
+    """A built .pkg failed identity validation. Never staged when raised."""
+
+
+class DeterminismError(Exception):
+    """Two builds of the same row produced different artifacts."""
+
+
+# --------------------------------------------------------------------------- #
+# Matrix: read + validate (never infer a default for a missing/bad field).
+# --------------------------------------------------------------------------- #
+
+_MAJOR_RE = re.compile(r"^[1-9][0-9]*$")
+_REQUIRED_ROW_FIELDS = ("freebsd_major", "php_version", "py_flavor")
+
+
+def run_matrix_cmd(cmd: list[str], *, cwd: Path) -> object:
+    """Run the matrix command (never a shell string) and parse its stdout as JSON."""
+    proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise MatrixError(f"matrix command {cmd!r} failed (exit {proc.returncode}): {proc.stderr.strip()}")
+    try:
+        return json.loads(proc.stdout)
+    except ValueError as e:
+        raise MatrixError(
+            f"matrix command {cmd!r} did not print JSON: {e}; "
+            f"stdout={proc.stdout[:500]!r} stderr={proc.stderr.strip()!r}"
+        ) from None
+
+
+def validate_matrix(obj: object) -> list[dict]:
+    """Reject anything the BUILD-matrix contract does not guarantee — never infer."""
+    if not isinstance(obj, list):
+        raise MatrixError(f"BUILD matrix must be a JSON array, got {type(obj).__name__}")
+    if not obj:
+        raise MatrixError("BUILD matrix is empty")
+    seen_majors: set[str] = set()
+    rows: list[dict] = []
+    for i, row in enumerate(obj):
+        if not isinstance(row, dict):
+            raise MatrixError(f"BUILD matrix row {i} is not an object: {row!r}")
+        missing = [k for k in _REQUIRED_ROW_FIELDS if k not in row]
+        if missing:
+            raise MatrixError(f"BUILD matrix row {i} missing required field(s): {', '.join(missing)}")
+        major = row["freebsd_major"]
+        if not isinstance(major, str) or not _MAJOR_RE.fullmatch(major):
+            raise MatrixError(f"BUILD matrix row {i}: freebsd_major must be a positive-integer string, got {major!r}")
+        if major in seen_majors:
+            raise MatrixError(f"BUILD matrix has duplicate freebsd_major {major!r} (--print-build must dedupe)")
+        seen_majors.add(major)
+        role = row.get("role")
+        if role is not None and role != "build":
+            raise MatrixError(f"BUILD matrix row {i} (freebsd_major={major}) carries unexpected role {role!r}")
+        rows.append(row)
+    return rows
+
+
+def plan_artifacts(
+    rows: list[dict], *, target_filter: str | None, major_filter: str | None
+) -> list[tuple[FrozenTarget, dict]]:
+    targets = [t for t in FROZEN_TARGETS if target_filter is None or t.channel == target_filter]
+    rows = [r for r in rows if major_filter is None or r["freebsd_major"] == major_filter]
+    return [(t, r) for t in targets for r in rows]
+
+
+def _derive_deps(row: dict) -> set[str]:
+    php_key = "php" + row["php_version"].replace(".", "")
+    py_flavor = row["py_flavor"]
+    py_num = py_flavor[2:] if py_flavor.startswith("py") else ""
+    if not py_num.isdigit():
+        raise ArtifactValidationError(f"cannot derive a python dependency name from py_flavor {py_flavor!r}")
+    return {php_key, f"{php_key}-intl", f"python{py_num}", f"{py_flavor}-sqlite3", f"{py_flavor}-maxminddb"}
+
+
+# --------------------------------------------------------------------------- #
+# Safe path segments — a name/version/major that becomes a path component is
+# validated (no "/", no "..", no whitespace, non-empty) before it is ever
+# joined into a filesystem path.
+# --------------------------------------------------------------------------- #
+
+_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._,-]*$")
+
+
+def _safe_segment(value: object, what: str) -> str:
+    if not isinstance(value, str) or not _SAFE_SEGMENT_RE.fullmatch(value) or ".." in value:
+        raise ArtifactValidationError(f"unsafe path segment for {what}: {value!r}")
+    return value
+
+
+# --------------------------------------------------------------------------- #
+# Tag resolution + export — the export is clean by construction: `git archive`
+# into a fresh temp dir, never the working tree, so there is no dirty-tree
+# state to accidentally ship.
+# --------------------------------------------------------------------------- #
+
+
+def resolve_tag_commit(repo: Path, tag: str, expected_commit: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--verify", f"refs/tags/{tag}^{{commit}}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise TagResolutionError(f"tag {tag!r} not found in {repo}: {proc.stderr.strip()}")
+    actual = proc.stdout.strip()
+    if actual != expected_commit:
+        raise TagResolutionError(f"tag {tag!r} resolves to {actual}, expected {expected_commit}")
+    return actual
+
+
+def export_tag(repo: Path, commit: str, dest: Path) -> None:
+    proc = subprocess.run(["git", "-C", str(repo), "archive", "--format=tar", commit], capture_output=True, check=False)
+    if proc.returncode != 0:
+        raise TagResolutionError(f"git archive {commit} failed: {proc.stderr.decode(errors='replace').strip()}")
+    with tarfile.open(fileobj=io.BytesIO(proc.stdout)) as tf:
+        try:
+            tf.extractall(dest, filter="data")
+        except TypeError:  # pre-3.12 tarfile without the `filter` kwarg (PEP 706 backport absent)
+            tf.extractall(dest)
+
+
+# --------------------------------------------------------------------------- #
+# .pkg reading — corruption/malformed archives are a clean ArtifactValidationError,
+# never a raw traceback.
+# --------------------------------------------------------------------------- #
+
+
+def _read_pkg(pkg_path: Path) -> tuple[dict, dict[str, bytes]]:
+    try:
+        tar_bytes = pfb_pkg.zstd_decompress(pkg_path.read_bytes())
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+            names = tf.getnames()
+            if "+COMPACT_MANIFEST" not in names:
+                raise ArtifactValidationError(f"{pkg_path.name}: missing +COMPACT_MANIFEST")
+            if "+MANIFEST" not in names:
+                raise ArtifactValidationError(f"{pkg_path.name}: missing +MANIFEST")
+            compact_raw = tf.extractfile("+COMPACT_MANIFEST").read()  # type: ignore[union-attr]
+            manifest_raw = tf.extractfile("+MANIFEST").read()  # type: ignore[union-attr]
+            payload: dict[str, bytes] = {}
+            for member in tf.getmembers():
+                if member.name in ("+MANIFEST", "+COMPACT_MANIFEST") or not member.isfile():
+                    continue
+                extracted = tf.extractfile(member)
+                payload[member.name] = extracted.read() if extracted is not None else b""
+    except ArtifactValidationError:
+        raise
+    except Exception as e:
+        raise ArtifactValidationError(f"{pkg_path.name}: unreadable/corrupt .pkg ({e.__class__.__name__}: {e})") from e
+
+    try:
+        compact_obj = json.loads(compact_raw)
+    except ValueError as e:
+        raise ArtifactValidationError(f"{pkg_path.name}: +COMPACT_MANIFEST is not valid JSON: {e}") from None
+    if not isinstance(compact_obj, dict):
+        raise ArtifactValidationError(f"{pkg_path.name}: +COMPACT_MANIFEST is not a JSON object")
+    try:
+        manifest = json.loads(manifest_raw)
+    except ValueError as e:
+        raise ArtifactValidationError(f"{pkg_path.name}: +MANIFEST is not valid JSON: {e}") from None
+    if not isinstance(manifest, dict):
+        raise ArtifactValidationError(f"{pkg_path.name}: +MANIFEST is not a JSON object")
+    return manifest, payload
+
+
+# --------------------------------------------------------------------------- #
+# Artifact identity validation — pure, directly testable.
+# --------------------------------------------------------------------------- #
+
+
+def validate_artifact(pkg_path: Path, export_dir: Path, target: FrozenTarget, row: dict) -> dict:
+    manifest, payload = _read_pkg(pkg_path)
+
+    name = manifest.get("name")
+    if name != target.portname:
+        raise ArtifactValidationError(
+            f"{pkg_path.name}: manifest name {name!r} != expected {target.portname!r} for channel {target.channel!r}"
+        )
+    expected_origin = f"net/{target.portname}"
+    origin = manifest.get("origin")
+    if origin != expected_origin:
+        raise ArtifactValidationError(f"{pkg_path.name}: manifest origin {origin!r} != expected {expected_origin!r}")
+
+    version = manifest.get("version")
+    version_re = re.compile(rf"^{re.escape(target.portversion)}(_[0-9]+)?(,[0-9]+)?$")
+    if not isinstance(version, str) or not version_re.fullmatch(version):
+        raise ArtifactValidationError(
+            f"{pkg_path.name}: manifest version {version!r} does not match PORTVERSION {target.portversion!r} "
+            "(+ optional _PORTREVISION/,EPOCH)"
+        )
+    name = _safe_segment(name, "manifest name")
+    version = _safe_segment(version, "manifest version")
+
+    major = row["freebsd_major"]
+    expected_abi = f"FreeBSD:{major}:*"
+    expected_arch = f"freebsd:{major}:*"
+    abi = manifest.get("abi")
+    arch = manifest.get("arch")
+    if abi != expected_abi:
+        raise ArtifactValidationError(f"{pkg_path.name}: manifest abi {abi!r} != expected {expected_abi!r}")
+    if arch != expected_arch:
+        raise ArtifactValidationError(f"{pkg_path.name}: manifest arch {arch!r} != expected {expected_arch!r}")
+
+    expected_filename = f"{name}-{version}.pkg"
+    if pkg_path.name != expected_filename:
+        raise ArtifactValidationError(
+            f"{pkg_path.name}: filename disagrees with the manifest identity (expected {expected_filename!r})"
+        )
+
+    required_deps = _derive_deps(row)
+    deps = manifest.get("deps")
+    have_deps = set(deps) if isinstance(deps, dict) else set()
+    missing_deps = sorted(required_deps - have_deps)
+    if missing_deps:
+        raise ArtifactValidationError(f"{pkg_path.name}: missing derived dependency name(s): {', '.join(missing_deps)}")
+
+    scripts = manifest.get("scripts")
+    if not isinstance(scripts, dict) or not scripts.get("install") or not scripts.get("deinstall"):
+        raise ArtifactValidationError(f"{pkg_path.name}: manifest scripts.install/scripts.deinstall missing or empty")
+    install_sha = hashlib.sha256(scripts["install"].encode()).hexdigest()
+    deinstall_sha = hashlib.sha256(scripts["deinstall"].encode()).hexdigest()
+
+    files_manifest = manifest.get("files")
+    if not isinstance(files_manifest, dict) or not files_manifest:
+        raise ArtifactValidationError(f"{pkg_path.name}: manifest has no (non-empty) files section")
+
+    payload_names = set(payload)
+    manifest_names = set(files_manifest)
+    extra = sorted(payload_names - manifest_names)
+    if extra:
+        raise ArtifactValidationError(
+            f"{pkg_path.name}: payload has file(s) not listed in the manifest: {', '.join(extra)}"
+        )
+    missing_payload = sorted(manifest_names - payload_names)
+    if missing_payload:
+        raise ArtifactValidationError(
+            f"{pkg_path.name}: manifest lists file(s) missing from the payload: {', '.join(missing_payload)}"
+        )
+
+    info_xml_path = f"/usr/local/share/{name}/info.xml"
+    export_root = export_dir.resolve()
+    payload_inventory: dict[str, str] = {}
+    for member_name, data in sorted(payload.items()):
+        rel = member_name.lstrip("/")
+        export_path = (export_dir / rel).resolve()
+        if export_path != export_root and export_root not in export_path.parents:
+            raise ArtifactValidationError(f"{pkg_path.name}: payload path escapes the tag export: {member_name!r}")
+        if not export_path.is_file():
+            raise ArtifactValidationError(
+                f"{pkg_path.name}: payload file {member_name!r} not present in the tag export"
+            )
+        export_bytes = export_path.read_bytes()
+        if member_name == info_xml_path:
+            # issue #1676: the port's do-install REINPLACE_CMD on %%PKGVERSION%% is the
+            # ONE reviewed packaging divergence — allowlisted here and nowhere else.
+            expected_bytes = export_bytes.replace(b"%%PKGVERSION%%", version.encode())
+            if data != expected_bytes:
+                raise ArtifactValidationError(
+                    f"{pkg_path.name}: {member_name} diverges from the tag export beyond "
+                    "the %%PKGVERSION%% substitution"
+                )
+        elif data != export_bytes:
+            raise ArtifactValidationError(f"{pkg_path.name}: payload file {member_name!r} diverges from the tag export")
+        payload_inventory[member_name] = hashlib.sha256(data).hexdigest()
+
+    artifact_sha256 = hashlib.sha256(pkg_path.read_bytes()).hexdigest()
+
+    return {
+        "name": name,
+        "version": version,
+        "origin": origin,
+        "abi": abi,
+        "arch": arch,
+        "artifact_sha256": artifact_sha256,
+        "payload_file_count": len(payload_inventory),
+        "payload_files": payload_inventory,
+        "install_script_sha256": install_sha,
+        "deinstall_script_sha256": deinstall_sha,
+    }
+
+
+def check_determinism(pkg_a: Path, pkg_b: Path) -> None:
+    sha_a = hashlib.sha256(pkg_a.read_bytes()).hexdigest()
+    sha_b = hashlib.sha256(pkg_b.read_bytes()).hexdigest()
+    if sha_a == sha_b:
+        return
+    detail = []
+    try:
+        manifest_a, payload_a = _read_pkg(pkg_a)
+        manifest_b, payload_b = _read_pkg(pkg_b)
+        if manifest_a != manifest_b:
+            detail.append("manifest differs")
+        inv_a = {k: hashlib.sha256(v).hexdigest() for k, v in payload_a.items()}
+        inv_b = {k: hashlib.sha256(v).hexdigest() for k, v in payload_b.items()}
+        if inv_a != inv_b:
+            detail.append("payload inventory differs")
+    except ArtifactValidationError:
+        pass
+    suffix = f" ({'; '.join(detail)})" if detail else ""
+    raise DeterminismError(
+        f"non-deterministic build: {pkg_a.name} sha256={sha_a} vs {pkg_b.name} sha256={sha_b}{suffix}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# build-leg.sh invocation — ONE subprocess seam (stubbed by tests).
+# --------------------------------------------------------------------------- #
+
+
+def _build_leg_argv(
+    build_leg_sh: Path, *, target: FrozenTarget, row: dict, local_src: Path, out_dir: Path, ports_dir: str | None
+) -> list[str]:
+    # The concrete "amd64" here is an INERT placeholder (mirrors release.yml's "Compute
+    # this leg's LEG/ABI" step): --no-arch wildcards the manifest stamp regardless, so
+    # the one .pkg this leg builds serves every arch of this FreeBSD major.
+    argv = [
+        "sh",
+        str(build_leg_sh),
+        "--ports-ref",
+        FROZEN_PORTS_REF,
+        "--channel",
+        target.channel,
+        "--local-src",
+        str(local_src),
+        "--abi",
+        f"FreeBSD:{row['freebsd_major']}:amd64",
+        "--php",
+        row["php_version"],
+        "--py-flavor",
+        row["py_flavor"],
+        "--no-arch",
+        "--out-dir",
+        str(out_dir),
+    ]
+    if ports_dir:
+        argv += ["--ports-dir", ports_dir]
+    return argv
+
+
+def _invoke_build_leg(argv: list[str], *, cwd: Path) -> str:
+    """Run build-leg.sh and return its ONE stdout line (the resolved .pkg path).
+
+    The stubbable subprocess seam: tests monkeypatch this function's module
+    attribute rather than driving a real ports clone / package build.
+    """
+    proc = subprocess.run(argv, cwd=cwd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise BuildLegError(f"build-leg.sh failed (exit {proc.returncode}):\n{proc.stderr}")
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    if len(lines) != 1:
+        raise BuildLegError(f"build-leg.sh stdout contract violated (expected exactly one path line): {proc.stdout!r}")
+    return lines[0]
+
+
+# --------------------------------------------------------------------------- #
+# Per-row orchestration: build to scratch, validate, stage ONLY on success.
+# --------------------------------------------------------------------------- #
+
+
+def build_and_stage_one(
+    *,
+    target: FrozenTarget,
+    row: dict,
+    repo: Path,
+    export_dir: Path,
+    build_leg_sh: Path,
+    out_dir: Path,
+    ports_dir: str | None,
+) -> dict:
+    major = _safe_segment(row["freebsd_major"], "freebsd_major")
+    scratch = Path(tempfile.mkdtemp(prefix="pfb-frozen-scratch-"))
+    try:
+        argv = _build_leg_argv(
+            build_leg_sh, target=target, row=row, local_src=export_dir, out_dir=scratch, ports_dir=ports_dir
+        )
+        pkg_path = Path(_invoke_build_leg(argv, cwd=repo))
+        identity = validate_artifact(pkg_path, export_dir, target, row)  # raises; nothing staged below on failure
+        leg_dir = out_dir / f"fbsd{major}"
+        leg_dir.mkdir(parents=True, exist_ok=True)
+        staged_path = leg_dir / pkg_path.name
+        shutil.copy2(pkg_path, staged_path)
+        identity["staged_path"] = staged_path
+        return identity
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+def _assert_no_stray_pkgs(out_dir: Path, staged: set[Path]) -> None:
+    found = set(out_dir.glob("fbsd*/*.pkg"))
+    extra = sorted(p.name for p in found - staged)
+    if extra:
+        raise ArtifactValidationError(
+            f"{out_dir}: unexpected staged file(s) beyond the planned artifacts: {', '.join(extra)}"
+        )
+
+
+def build_all(
+    plan: list[tuple[FrozenTarget, dict]],
+    *,
+    repo: Path,
+    build_leg_sh: Path,
+    out_dir: Path,
+    ports_dir: str | None,
+    do_determinism: bool,
+) -> dict:
+    export_cache: dict[str, Path] = {}
+    artifacts: list[dict] = []
+    staged: set[Path] = set()
+    with contextlib.ExitStack() as stack:
+        for target, row in plan:
+            if target.commit not in export_cache:
+                resolve_tag_commit(repo, target.tag, target.commit)
+                export_dir = Path(
+                    stack.enter_context(tempfile.TemporaryDirectory(prefix=f"pfb-frozen-export-{target.channel}-"))
+                )
+                export_tag(repo, target.commit, export_dir)
+                export_cache[target.commit] = export_dir
+            export_dir = export_cache[target.commit]
+
+            identity = build_and_stage_one(
+                target=target,
+                row=row,
+                repo=repo,
+                export_dir=export_dir,
+                build_leg_sh=build_leg_sh,
+                out_dir=out_dir,
+                ports_dir=ports_dir,
+            )
+            staged_path = identity.pop("staged_path")
+            staged.add(staged_path)
+
+            if do_determinism:
+                scratch2 = Path(tempfile.mkdtemp(prefix="pfb-frozen-scratch2-"))
+                try:
+                    argv = _build_leg_argv(
+                        build_leg_sh,
+                        target=target,
+                        row=row,
+                        local_src=export_dir,
+                        out_dir=scratch2,
+                        ports_dir=ports_dir,
+                    )
+                    pkg2_path = Path(_invoke_build_leg(argv, cwd=repo))
+                    check_determinism(staged_path, pkg2_path)
+                finally:
+                    shutil.rmtree(scratch2, ignore_errors=True)
+
+            artifacts.append(
+                {
+                    "channel": target.channel,
+                    "tag": target.tag,
+                    "source_commit": target.commit,
+                    "ports_ref": FROZEN_PORTS_REF,
+                    "matrix_row": row,
+                    "staged_path": str(staged_path.relative_to(out_dir)),
+                    **identity,
+                }
+            )
+    _assert_no_stray_pkgs(out_dir, staged)
+    return {"ports_ref": FROZEN_PORTS_REF, "artifacts": artifacts}
+
+
+def verify_staged(dir_: Path, plan: list[tuple[FrozenTarget, dict]], *, repo: Path) -> dict:
+    export_cache: dict[str, Path] = {}
+    artifacts: list[dict] = []
+    staged: set[Path] = set()
+    with contextlib.ExitStack() as stack:
+        for target, row in plan:
+            if target.commit not in export_cache:
+                resolve_tag_commit(repo, target.tag, target.commit)
+                export_dir = Path(
+                    stack.enter_context(tempfile.TemporaryDirectory(prefix=f"pfb-frozen-verify-{target.channel}-"))
+                )
+                export_tag(repo, target.commit, export_dir)
+                export_cache[target.commit] = export_dir
+            export_dir = export_cache[target.commit]
+
+            major = _safe_segment(row["freebsd_major"], "freebsd_major")
+            leg_dir = dir_ / f"fbsd{major}"
+            # Require the char right after "<portname>-" to be a digit (a version), so
+            # stable's shorter portname never matches devel's "<portname>-devel-..." file.
+            name_re = re.compile(rf"^{re.escape(target.portname)}-\d[^/]*\.pkg$")
+            candidates = sorted(p for p in leg_dir.glob("*.pkg") if name_re.match(p.name)) if leg_dir.is_dir() else []
+            if len(candidates) != 1:
+                raise ArtifactValidationError(
+                    f"{leg_dir}: expected exactly one {target.channel} artifact matching "
+                    f"{target.portname}-<version>.pkg, found {len(candidates)}: {[c.name for c in candidates]}"
+                )
+            pkg_path = candidates[0]
+            identity = validate_artifact(pkg_path, export_dir, target, row)
+            staged.add(pkg_path)
+            artifacts.append(
+                {
+                    "channel": target.channel,
+                    "tag": target.tag,
+                    "source_commit": target.commit,
+                    "ports_ref": FROZEN_PORTS_REF,
+                    "matrix_row": row,
+                    "staged_path": str(pkg_path.relative_to(dir_)),
+                    **identity,
+                }
+            )
+    _assert_no_stray_pkgs(dir_, staged)
+    return {"ports_ref": FROZEN_PORTS_REF, "artifacts": artifacts}
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _default_repo() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="build-frozen-v3.py",
+        description=(
+            "Build and identity-validate the frozen pfBlockerNG v3.2 Stable (v3.2.15) and "
+            "Devel (v3.2.16) .pkg artifacts for every BUILD-matrix row. Never publishes anything: "
+            "no GitHub Release upload, no catalog write, no network write."
+        ),
+    )
+    p.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="staging root. Layout: DIR/fbsd<major>/<pkgname>-<version>.pkg, one leg dir per FreeBSD major.",
+    )
+    p.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="JSON identity report path (default: <out>/frozen-v3-report.json).",
+    )
+    p.add_argument(
+        "--ports-dir",
+        default=None,
+        help="FreeBSD-ports checkout dir, passed through to build-leg.sh (default: build-leg.sh keys its own).",
+    )
+    p.add_argument(
+        "--matrix-cmd",
+        type=shlex.split,
+        default=None,
+        help="override the BUILD-matrix command, as a single shell-quoted string parsed with shlex "
+        "(default: 'scripts/read-version-matrix.sh --print-build'). The test seam.",
+    )
+    p.add_argument(
+        "--repo",
+        type=Path,
+        default=None,
+        help="pfBlockerNG git checkout to export the frozen source tags from (default: this script's own repo root).",
+    )
+    p.add_argument(
+        "--no-deterministic-check",
+        action="store_true",
+        help="skip the double-build determinism proof (default: build every row twice, require byte-identical output).",
+    )
+    p.add_argument(
+        "--verify-only",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="validate an already-staged DIR against the BUILD matrix without building anything.",
+    )
+    p.add_argument(
+        "--target",
+        choices=sorted({t.channel for t in FROZEN_TARGETS}),
+        default=None,
+        help="build/verify only this channel (default: both stable and devel).",
+    )
+    p.add_argument(
+        "--major",
+        type=int,
+        default=None,
+        help="build/verify only this FreeBSD major (default: every BUILD-matrix row).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    repo = (args.repo or _default_repo()).resolve()
+    build_leg_sh = repo / "scripts" / "build-leg.sh"
+    matrix_cmd = args.matrix_cmd or [str(repo / "scripts" / "read-version-matrix.sh"), "--print-build"]
+    out_dir = args.out.resolve()
+    report_path = (args.report or (out_dir / "frozen-v3-report.json")).resolve()
+    major_filter = str(args.major) if args.major is not None else None
+
+    try:
+        rows = validate_matrix(run_matrix_cmd(matrix_cmd, cwd=repo))
+        plan = plan_artifacts(rows, target_filter=args.target, major_filter=major_filter)
+        if not plan:
+            raise MatrixError("nothing to do: --target/--major filters excluded every BUILD-matrix row")
+
+        if args.verify_only is not None:
+            report = verify_staged(args.verify_only.resolve(), plan, repo=repo)
+        else:
+            out_dir.mkdir(parents=True, exist_ok=True)
+            report = build_all(
+                plan,
+                repo=repo,
+                build_leg_sh=build_leg_sh,
+                out_dir=out_dir,
+                ports_dir=args.ports_dir,
+                do_determinism=not args.no_deterministic_check,
+            )
+
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        print(f"build-frozen-v3.py: wrote {report_path} ({len(report['artifacts'])} artifact(s))", file=sys.stderr)
+        return 0
+    except (MatrixError, TagResolutionError, BuildLegError, ArtifactValidationError, DeterminismError) as e:
+        print(f"build-frozen-v3.py: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build-leg.sh
+++ b/scripts/build-leg.sh
@@ -7,7 +7,7 @@
 #   build-leg.sh [--ports-repo OWNER/NAME|URL] [--ports-ref REF]
 #                [--channel devel|stable|nightly] [--abi ABI]
 #                [--py-flavor PYxx] [--php X.Y] [--local-src DIR]
-#                [--pkgversion V] [--annotate K=V]...
+#                [--pkgversion V] [--annotate K=V]... [--no-arch]
 #                [--ports-dir DEST] [--out-dir OUT]
 #
 # Prints the resolved absolute .pkg path (and NOTHING else) on stdout.
@@ -25,6 +25,7 @@
 #   --local-src   .              (→ builder --local-src)
 #   --pkgversion  (empty)        → flag omitted; builder derives from ports Makefile
 #   --annotate    (none)         repeatable; each → --annotate K=V to builder
+#   --no-arch     off            → passed through to the builder verbatim when given
 #   --ports-dir   (run-keyed)    ${PFB_PORTS_DIR:-$PFB_RUN_DIR/ports}
 #   --out-dir     (run-keyed)    ${PFB_OUT_DIR:-$PFB_RUN_DIR/out}
 #
@@ -68,6 +69,7 @@ LOCAL_SRC='.'
 PKGVERSION=''
 PORTS_DIR=''
 OUT_DIR=''
+NO_ARCH=''
 
 # Collect --annotate K=V items into a temp file (POSIX-clean repeatable accumulation).
 # ponytail: temp file for repeatable args — arrays don't exist in POSIX sh.
@@ -90,6 +92,7 @@ while [ $# -gt 0 ]; do
         --annotate)    printf '%s\n' "${1?build-leg.sh: --annotate requires an argument}" >> "$_BL_ANN_FILE"; shift ;;
         --ports-dir)   PORTS_DIR="${1?build-leg.sh: --ports-dir requires an argument}";  shift ;;
         --out-dir)     OUT_DIR="${1?build-leg.sh: --out-dir requires an argument}";       shift ;;
+        --no-arch)     NO_ARCH=1 ;;
         --) break ;;
         -*)
             printf '%s: unknown option: %s\n' "$0" "$_opt" >&2
@@ -165,6 +168,9 @@ set -- \
 
 # Append --pkgversion only when supplied (empty → omit so builder uses Makefile).
 [ -n "$PKGVERSION" ] && set -- "$@" --pkgversion "$PKGVERSION"
+
+# Append --no-arch only when the flag was given (default off).
+[ -n "$NO_ARCH" ] && set -- "$@" --no-arch
 
 # Append one --annotate K=V per collected item.
 while IFS= read -r _ann; do

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -1504,9 +1504,10 @@ def run_build(args: argparse.Namespace) -> Build:
     # --repo-catalogue's pkg.freebsd.org lookup below); only the MANIFEST
     # fields are wildcarded here. --arch's existing override precedence is
     # preserved: an explicit --arch is never wildcarded, only the derived
-    # default is.
+    # default is. --no-arch (issue #1676) forces the same wildcard for a port
+    # Makefile that predates NO_ARCH=yes.
     manifest_abi, manifest_arch = abi, arch
-    if _truthy(mk.get("NO_ARCH")):
+    if _truthy(mk.get("NO_ARCH")) or args.no_arch:
         major = abi.split(":")[1]
         manifest_abi = f"FreeBSD:{major}:*"
         if not args.arch:
@@ -1696,6 +1697,11 @@ def main(argv: list[str]) -> int:
     )
     g_target.add_argument(
         "--freebsd-version", default="", help="build host __FreeBSD_version for annotations, e.g. 1500068 (optional)"
+    )
+    g_target.add_argument(
+        "--no-arch",
+        action="store_true",
+        help="force the NO_ARCH manifest abi/arch wildcard even when the port Makefile lacks NO_ARCH=yes (issue #1676)",
     )
 
     g_snap = ap.add_argument_group("nightly overrides (ADR-18; default off — release build byte-identical)")

--- a/scripts/sparse-clone-ports.sh
+++ b/scripts/sparse-clone-ports.sh
@@ -10,7 +10,7 @@
 #   sparse-clone-ports.sh URL REF DEST CHANNEL PHP PYFLAVOR
 #
 #   URL        FreeBSD-ports HTTPS clone URL
-#   REF        branch or ref to fetch (e.g. pfblockerng/use-github)
+#   REF        branch, tag, or full 40-hex commit SHA to fetch (e.g. pfblockerng/use-github)
 #   DEST       destination directory — created (fresh clone) if absent; an EXISTING
 #              git work-tree is fetched + checked out at REF (idempotent reuse)
 #   CHANNEL    build-pkg-portable --channel value (devel|stable|nightly)
@@ -58,6 +58,16 @@ PORT_DIR="$(python3 "$BUILDER" --print-port-origin --channel "$CHANNEL")" || exi
 # 1. Acquire the tree at REF — fresh blobless clone if DEST is absent, else fetch REF
 #    into an EXISTING git work-tree and check it out (idempotent reuse). Either way the
 #    tree ends on REF; no blobs are fetched yet, git knows all tree paths.
+#
+# issue #1676: `-b REF` only accepts a branch/tag name; a bare 40-hex commit SHA fails
+# ("Remote branch <sha> not found") — fetch-by-oid instead (mirrors reuse below).
+_pfb_is_full_sha() {
+	[ "${#1}" -eq 40 ] || return 1
+	case "$1" in
+		*[!0-9a-f]*) return 1 ;;
+	esac
+}
+
 if [ -e "${DEST}/.git" ]; then
 	# Reuse an existing git work-tree (-e, not -d: a linked worktree's .git is a FILE). Point
 	# origin at the canonical URL (the clone's origin may differ) and fetch REF
@@ -70,6 +80,13 @@ if [ -e "${DEST}/.git" ]; then
 elif [ -e "$DEST" ]; then
 	printf '%s: %s exists but is not a git work-tree — refusing to overwrite\n' "$0" "$DEST" >&2
 	exit 1
+elif _pfb_is_full_sha "$REF"; then
+	# Fresh clone by SHA (issue #1676): init + fetch-by-oid; -b cannot take a SHA.
+	mkdir -p "$DEST"
+	git -C "$DEST" init -q
+	git -C "$DEST" remote add origin "$URL"
+	git -C "$DEST" fetch --depth 1 --filter=blob:none origin -- "$REF"
+	co_target=FETCH_HEAD
 else
 	git clone --depth 1 --filter=blob:none --no-checkout -b "$REF" "$URL" "$DEST"
 	co_target="$REF"

--- a/tests/shell/build_leg_spec.sh
+++ b/tests/shell/build_leg_spec.sh
@@ -192,6 +192,75 @@ SHEOF
     End
   End
 
+  # ── --no-arch passthrough (issue #1676) ───────────────────────────────────
+  Describe '--no-arch passthrough'
+    check_no_arch_given() {
+      sh "${FAKE_SCRIPTS}/build-leg.sh" --channel devel --no-arch 2>/dev/null
+      if grep -qF -- '--no-arch' "$BUILDER_ARGV_FILE" 2>/dev/null; then
+        echo "no_arch=present"
+      else
+        echo "no_arch=absent"
+      fi
+    }
+
+    It 'records --no-arch in builder argv when given'
+      # Scenario: caller passes --no-arch to build-leg.sh.
+      # Given: build-leg.sh called with --no-arch.
+      # When: builder argv is recorded by the fake.
+      # Then: --no-arch appears in the recorded builder argv.
+      When call check_no_arch_given
+      The output should include 'no_arch=present'
+    End
+
+    check_no_arch_omitted() {
+      sh "${FAKE_SCRIPTS}/build-leg.sh" --channel devel 2>/dev/null
+      if grep -qF -- '--no-arch' "$BUILDER_ARGV_FILE" 2>/dev/null; then
+        echo "no_arch=present"
+      else
+        echo "no_arch=absent"
+      fi
+    }
+
+    It 'omits --no-arch from builder argv when not given (the off side of the boolean)'
+      When call check_no_arch_omitted
+      The output should include 'no_arch=absent'
+    End
+
+    check_no_arch_combined() {
+      sh "${FAKE_SCRIPTS}/build-leg.sh" \
+        --channel devel \
+        --pkgversion '4.0.0.rc.1' \
+        --annotate 'created=1750000000' \
+        --annotate 'commit=abc1234567890abcdef' \
+        --no-arch \
+        2>/dev/null
+      if grep -qF -- '--no-arch' "$BUILDER_ARGV_FILE" 2>/dev/null; then
+        echo "no_arch=present"
+      else
+        echo "no_arch=absent"
+      fi
+      echo "pkgversion=$(arg_after '--pkgversion' "$BUILDER_ARGV_FILE")"
+      if grep -qF 'created=1750000000' "$BUILDER_ARGV_FILE" 2>/dev/null; then
+        echo "annotate_created=present"
+      else
+        echo "annotate_created=absent"
+      fi
+      if grep -qF 'commit=abc1234567890abcdef' "$BUILDER_ARGV_FILE" 2>/dev/null; then
+        echo "annotate_commit=present"
+      else
+        echo "annotate_commit=absent"
+      fi
+    }
+
+    It '--no-arch combined with --pkgversion and repeated --annotate: all present, arg order unbroken'
+      When call check_no_arch_combined
+      The output should include 'no_arch=present'
+      The output should include 'pkgversion=4.0.0.rc.1'
+      The output should include 'annotate_created=present'
+      The output should include 'annotate_commit=present'
+    End
+  End
+
   # ── Branch coverage: absence vs presence of --pkgversion ─────────────────
   # Proves the two paths are genuinely distinct — not always-absent or always-present.
   Describe 'branch coverage: --pkgversion absence vs presence'

--- a/tests/shell/sparse_clone_ports_spec.sh
+++ b/tests/shell/sparse_clone_ports_spec.sh
@@ -52,8 +52,10 @@ Describe 'sparse-clone-ports.sh'
       git checkout -q -b pfblockerng/use-github
       printf 'PORTNAME=pfBlockerNG-devel\nUSE_GITHUB=yes\n' > "${PORT_SUB}/Makefile"
       git add -A && git -c commit.gpgsign=false commit -qm use-github
+      git tag use-github-tag
       git checkout -q devel
     ) >/dev/null 2>&1
+    USE_GITHUB_SHA="$(cd "$REMOTE" && git rev-parse pfblockerng/use-github)"
     BIN="${WORK}/bin"
     mkdir -p "$BIN"
     cat > "${BIN}/python3" <<'PYEOF'
@@ -89,6 +91,55 @@ PYEOF
     The output should equal 'variant=usegithub'
   End
 
+  # issue #1676: `git clone -b REF` only accepts a branch/tag NAME — a bare 40-hex
+  # commit SHA fails ("fatal: Remote branch <sha> not found in upstream origin").
+  # Fresh clone with a full-SHA REF must still land on that commit.
+  run_clone_sha() { sh "$SCRIPT" "$URL" "$USE_GITHUB_SHA" "$DEST" devel 8.3 py311; }
+
+  fresh_sha_result() {
+    run_clone_sha >/dev/null 2>&1 || { echo "script-failed=$?"; return 1; }
+    if is_build_input_variant; then echo 'variant=usegithub'; else echo 'variant=stub'; fi
+    echo "head=$(git -C "$DEST" rev-parse HEAD)"
+  }
+  It 'fresh-clone-by-sha: DEST absent, REF a full 40-hex commit SHA -> clones + checks out that commit'
+    When call fresh_sha_result
+    The status should be success
+    The line 1 of output should equal 'variant=usegithub'
+    The line 2 of output should equal "head=${USE_GITHUB_SHA}"
+  End
+
+  run_clone_tag() { sh "$SCRIPT" "$URL" use-github-tag "$DEST" devel 8.3 py311; }
+  fresh_tag_result() {
+    run_clone_tag >/dev/null 2>&1 || { echo "script-failed=$?"; return 1; }
+    if is_build_input_variant; then echo 'variant=usegithub'; else echo 'variant=stub'; fi
+  }
+  It 'fresh-clone-by-tag: DEST absent, REF a tag name -> clones + checks out the tag commit'
+    When call fresh_tag_result
+    The status should be success
+    The output should equal 'variant=usegithub'
+  End
+
+  # REF is 40 chars but not hex ("z" is outside [0-9a-f]) -> not a SHA -> unchanged
+  # branch/tag fast path -> fails exactly as before (no branch named this).
+  run_clone_zzz() { sh "$SCRIPT" "$URL" 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' "$DEST" devel 8.3 py311 2>&1; }
+  It 'fresh-clone: a 40-char non-hex REF (40 zs) is not a SHA -> branch path, fails as before'
+    When call run_clone_zzz
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
+  # A short abbreviation of a real commit SHA is not a FULL SHA -> unchanged branch/tag
+  # fast path (git's fetch-by-oid needs the full oid, not an abbreviation) -> fails.
+  run_clone_short_sha() {
+    _short="$(printf '%.7s' "$USE_GITHUB_SHA")"
+    sh "$SCRIPT" "$URL" "$_short" "$DEST" devel 8.3 py311 2>&1
+  }
+  It 'fresh-clone: a short 7-hex SHA abbreviation is not a full SHA -> branch path, fails as before'
+    When call run_clone_short_sha
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
   # GIVEN an existing clone parked on the wrong branch (devel, the stub), WHEN the shared
   # prepare step runs, THEN the tree ends on REF (use-github). before/after both asserted so
   # green proves the switch caused it — and the old `git clone`-into-existing-DEST path is red.
@@ -105,6 +156,19 @@ PYEOF
     The line 2 of output should equal 'after=usegithub'
   End
 
+  # Regression guard: the reuse branch already fetches a full-SHA REF (fetch + FETCH_HEAD,
+  # not `-b`) — this must keep working unchanged by the fresh-clone REF-shape guard above.
+  reuse_sha_result() {
+    git clone -q "$URL" "$DEST" >/dev/null 2>&1            # full clone, checks out devel
+    run_clone_sha >/dev/null 2>&1 || { echo "script-failed=$?"; return 1; }
+    echo "head=$(git -C "$DEST" rev-parse HEAD)"
+  }
+  It 'reuse-by-sha: an existing work-tree fetches + checks out a full-SHA REF'
+    When call reuse_sha_result
+    The status should be success
+    The output should equal "head=${USE_GITHUB_SHA}"
+  End
+
   refuse_result() {
     mkdir -p "$DEST" && true > "${DEST}/not-a-clone"
     run_clone 2>&1  # merge the refusal (stderr) into output for a single clean assertion
@@ -113,5 +177,81 @@ PYEOF
     When call refuse_result
     The status should be failure
     The output should include 'not a git work-tree'
+  End
+
+  # ── REF-shape hostile inputs (issue #1676) ────────────────────────────────
+  #
+  # None of these REF values may be misclassified as a full 40-hex SHA — each must take
+  # the pre-existing `git clone -b REF` fast path unchanged (not the new fetch-by-oid
+  # path) and fail exactly as it always did. `git clone -b` prints "Remote branch ...
+  # not found" only on that fast path (the fetch-by-oid path, when reachable, prints a
+  # different message) — asserting that phrase proves the REF was NOT treated as a SHA.
+  run_clone_hostile() { sh "$SCRIPT" "$URL" "$1" "$DEST" devel 8.3 py311 2>&1; }
+
+  It 'empty REF is not a SHA -> branch path (not fetch-by-oid)'
+    When call run_clone_hostile ''
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
+  It '39-hex (one short) REF is not a SHA -> branch path'
+    When call run_clone_hostile '0123456789012345678901234567890123456'
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
+  It '41-hex (one long) REF is not a SHA -> branch path'
+    When call run_clone_hostile '012345678901234567890123456789012345678'
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
+  It '40 chars with one non-hex char is not a SHA -> branch path'
+    When call run_clone_hostile '012345678901234567890123456789012345678g'
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
+  # Decision (pinned): git object ids are lowercase hex only — an UPPERCASE 40-char
+  # hex string is deliberately NOT treated as a SHA and takes the branch/tag path.
+  It 'UPPERCASE 40-hex REF is not treated as a SHA (git object ids are lowercase) -> branch path'
+    When call run_clone_hostile 'ABCDEF0123456789ABCDEF0123456789ABCDEF01'
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
+  It "REF containing '/' is not a SHA -> branch path"
+    When call run_clone_hostile 'origin/main'
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
+  It 'REF containing whitespace is not a SHA -> branch path'
+    When call run_clone_hostile 'abc def'
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
+  It 'REF with a leading dash is never taken as a git option -> branch path, treated as literal data'
+    When call run_clone_hostile '--upload-pack=touch INJECTED'
+    The status should be failure
+    The output should include 'Remote branch'
+    The path "${WORK}/INJECTED" should not be exist
+  End
+
+  It "REF containing '..' is not a SHA -> branch path"
+    When call run_clone_hostile 'abc..def'
+    The status should be failure
+    The output should include 'Remote branch'
+  End
+
+  It 'REF containing shell metacharacters is treated as literal data, never interpolated/executed'
+    # Single-quoted on purpose: proves the shell never expands it.
+    # shellcheck disable=SC2016
+    When call run_clone_hostile '$(touch INJECTED); `touch INJECTED2`'
+    The status should be failure
+    The output should include 'Remote branch'
+    The path "${WORK}/INJECTED" should not be exist
+    The path "${WORK}/INJECTED2" should not be exist
   End
 End

--- a/tests/shell/sparse_clone_ports_spec.sh
+++ b/tests/shell/sparse_clone_ports_spec.sh
@@ -233,7 +233,9 @@ PYEOF
   End
 
   It 'REF with a leading dash is never taken as a git option -> branch path, treated as literal data'
-    When call run_clone_hostile '--upload-pack=touch INJECTED'
+    # Absolute payload path on purpose: a bare 'touch INJECTED' would land in the
+    # shellspec CWD, so asserting on ${WORK} would pass even if the option were honoured.
+    When call run_clone_hostile "--upload-pack=touch ${WORK}/INJECTED"
     The status should be failure
     The output should include 'Remote branch'
     The path "${WORK}/INJECTED" should not be exist
@@ -246,9 +248,10 @@ PYEOF
   End
 
   It 'REF containing shell metacharacters is treated as literal data, never interpolated/executed'
-    # Single-quoted on purpose: proves the shell never expands it.
-    # shellcheck disable=SC2016
-    When call run_clone_hostile '$(touch INJECTED); `touch INJECTED2`'
+    # The $( and backticks are escaped so THIS shell leaves them literal, while ${WORK}
+    # expands to an absolute path — so if anything downstream did evaluate the REF, the
+    # files below would really appear and these assertions would really fail.
+    When call run_clone_hostile "\$(touch ${WORK}/INJECTED); \`touch ${WORK}/INJECTED2\`"
     The status should be failure
     The output should include 'Remote branch'
     The path "${WORK}/INJECTED" should not be exist

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -1,0 +1,920 @@
+"""Tests for scripts/build-frozen-v3.py — the frozen pfBlockerNG v3.2 build+validate driver.
+
+Hermetic: no network, no real ports clone, no real .pkg build. Synthetic .pkg fixtures are
+built here (mirroring tests/test_build_repo_portable.py's make_pkg() tar+zstd construction,
+extended with +MANIFEST/files/scripts/payload — make_pkg() itself only writes
++COMPACT_MANIFEST, which every scenario here needs beyond). git-dependent behaviour
+(resolve_tag_commit) runs against small REAL local git repos created in tmp_path (no
+network); the build-leg.sh subprocess seam (_invoke_build_leg) and the tag-export step
+(resolve_tag_commit/export_tag) are monkeypatched for the full-pipeline tests.
+
+The tool is a hyphen-named CLI script, so it is loaded by path via importlib.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+from typing import Any
+
+import pfb_pkg
+import pytest
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "build-frozen-v3.py"
+_spec = importlib.util.spec_from_file_location("build_frozen_v3", _TOOL)
+assert _spec is not None and _spec.loader is not None
+bfv = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = bfv
+_spec.loader.exec_module(bfv)
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic .pkg + tag-export fixture builders.
+# --------------------------------------------------------------------------- #
+
+
+def _add_member(tf: tarfile.TarFile, name: str, data: bytes, mode: int = 0o644) -> None:
+    ti = tarfile.TarInfo(name=name)
+    ti.size = len(data)
+    ti.mode = mode
+    ti.uid = ti.gid = 0
+    ti.uname, ti.gname = "root", "wheel"
+    ti.mtime = 0
+    tf.addfile(ti, io.BytesIO(data))
+
+
+def _write_pkg(
+    path: Path,
+    *,
+    name: str,
+    version: str,
+    origin: str | None = None,
+    abi: str = "FreeBSD:15:*",
+    arch: str = "freebsd:15:*",
+    deps: dict[str, dict[str, str]] | None = None,
+    scripts: dict[str, str] | None = None,
+    files: dict[str, bytes] | None = None,
+    omit_compact: bool = False,
+    omit_manifest: bool = False,
+    corrupt_manifest_json: bool = False,
+    extra_manifest: dict | None = None,
+) -> None:
+    """Write a libpkg-shaped .pkg (zstd tar, +COMPACT_MANIFEST + +MANIFEST + payload)."""
+    manifest: dict = {
+        "name": name,
+        "origin": origin if origin is not None else f"net/{name}",
+        "version": version,
+        "comment": "demo package",
+        "maintainer": "dev@example.com",
+        "www": "https://example.com",
+        "abi": abi,
+        "arch": arch,
+        "prefix": "/usr/local",
+        "flatsize": sum(len(v) for v in (files or {}).values()),
+        "licenselogic": "single",
+        "desc": "demo",
+        "categories": ["net"],
+    }
+    if deps:
+        manifest["deps"] = deps
+    if extra_manifest:
+        manifest.update(extra_manifest)
+    compact_raw = json.dumps(manifest, separators=(",", ":")).encode() + b"\n"
+
+    full = dict(manifest)
+    full["files"] = {
+        p: {
+            "sum": f"1${hashlib.sha256(b).hexdigest()}",
+            "uname": "root",
+            "gname": "wheel",
+            "perm": "0644",
+            "fflags": 0,
+            "mtime": 0,
+        }
+        for p, b in (files or {}).items()
+    }
+    if scripts is not None:
+        full["scripts"] = scripts
+    full_raw = json.dumps(full, separators=(",", ":")).encode() + b"\n"
+    if corrupt_manifest_json:
+        full_raw = b"{not json"
+
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as tf:
+        if not omit_compact:
+            _add_member(tf, "+COMPACT_MANIFEST", compact_raw)
+        if not omit_manifest:
+            _add_member(tf, "+MANIFEST", full_raw)
+        for p, b in (files or {}).items():
+            _add_member(tf, p, b)
+    path.write_bytes(pfb_pkg.zstd_compress(raw.getvalue(), RuntimeError, "zstd unavailable for tests"))
+
+
+def _write_export(base: Path, files: dict[str, bytes]) -> Path:
+    root = base / "export"
+    for relpath, data in files.items():
+        p = root / relpath.lstrip("/")
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+    return root
+
+
+DEMO_SCRIPTS = {"install": "#!/bin/sh\necho install\n", "deinstall": "#!/bin/sh\necho deinstall\n"}
+ROW_15 = {"freebsd_major": "15", "php_version": "8.3", "py_flavor": "py311"}
+ROW_16 = {"freebsd_major": "16", "php_version": "8.5", "py_flavor": "py311"}
+STABLE = bfv.FrozenTarget(channel="stable", tag="v1.2.3", commit="c" * 40, portname="demo-pkg", portversion="1.2.3")
+DEVEL = bfv.FrozenTarget(channel="devel", tag="v1.3.0", commit="d" * 40, portname="demo-pkg-devel", portversion="1.3.0")
+
+
+def _deps_for(row: dict) -> dict[str, dict[str, str]]:
+    names = bfv._derive_deps(row)
+    deps = {n: {"origin": f"lang/{n}", "version": "1.0"} for n in names}
+    deps["extra-unrelated-dep"] = {"origin": "net/extra-unrelated-dep", "version": "1.0"}  # extras are tolerated
+    return deps
+
+
+def _demo_payload(portname: str) -> dict[str, bytes]:
+    return {
+        "/usr/local/pkg/pfblockerng/pfblockerng.inc": b"<?php // demo\n",
+        f"/usr/local/share/{portname}/info.xml": b"<xml><version>%%PKGVERSION%%</version></xml>\n",
+        "/usr/local/www/pfblockerng/index.php": b"<?php // www demo\n",
+    }
+
+
+def _packaged_payload(portname: str, version: str) -> dict[str, bytes]:
+    payload = _demo_payload(portname)
+    info_path = f"/usr/local/share/{portname}/info.xml"
+    payload[info_path] = payload[info_path].replace(b"%%PKGVERSION%%", version.encode())
+    return payload
+
+
+def _happy_fixture(
+    tmp_path: Path,
+    target: Any,
+    row: dict,
+    *,
+    version: str | None = None,
+    out_dir: Path | None = None,
+    **pkg_kwargs: Any,
+) -> tuple[Path, Path]:
+    version = version or target.portversion
+    export_dir = _write_export(tmp_path, _demo_payload(target.portname))
+    out_dir = out_dir or tmp_path
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pkg_path = out_dir / f"{target.portname}-{version}.pkg"
+    kwargs = dict(
+        name=target.portname,
+        version=version,
+        abi=f"FreeBSD:{row['freebsd_major']}:*",
+        arch=f"freebsd:{row['freebsd_major']}:*",
+        deps=_deps_for(row),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(target.portname, version),
+    )
+    kwargs.update(pkg_kwargs)
+    _write_pkg(pkg_path, **kwargs)
+    return pkg_path, export_dir
+
+
+# --------------------------------------------------------------------------- #
+# Row 1-2: happy path identity, stable + devel not interchangeable.
+# --------------------------------------------------------------------------- #
+
+
+def test_happy_path_stable_identity(tmp_path: Path) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15)
+    record = bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+    assert record["name"] == "demo-pkg"
+    assert record["version"] == "1.2.3"
+    assert record["origin"] == "net/demo-pkg"
+    assert record["abi"] == "FreeBSD:15:*"
+    assert record["arch"] == "freebsd:15:*"
+    assert record["payload_file_count"] == 3
+    assert set(record["payload_files"]) == {
+        "/usr/local/pkg/pfblockerng/pfblockerng.inc",
+        "/usr/local/share/demo-pkg/info.xml",
+        "/usr/local/www/pfblockerng/index.php",
+    }
+    assert record["install_script_sha256"] == hashlib.sha256(DEMO_SCRIPTS["install"].encode()).hexdigest()
+    assert record["deinstall_script_sha256"] == hashlib.sha256(DEMO_SCRIPTS["deinstall"].encode()).hexdigest()
+    assert record["artifact_sha256"] == hashlib.sha256(pkg_path.read_bytes()).hexdigest()
+
+
+def test_happy_path_devel_identity_not_interchangeable_with_stable(tmp_path: Path) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, DEVEL, ROW_15)
+    record = bfv.validate_artifact(pkg_path, export_dir, DEVEL, ROW_15)
+    assert record["name"] == "demo-pkg-devel"
+    assert record["origin"] == "net/demo-pkg-devel"
+
+    with pytest.raises(bfv.ArtifactValidationError, match="demo-pkg-devel"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+# --------------------------------------------------------------------------- #
+# Row 3-5: plan_artifacts cross-product — never hardcoded to 2.
+# --------------------------------------------------------------------------- #
+
+
+def test_plan_two_row_matrix_both_targets_yields_four_artifacts() -> None:
+    rows = [ROW_15, ROW_16]
+    plan = bfv.plan_artifacts(rows, target_filter=None, major_filter=None)
+    assert len(plan) == 4
+    assert {(t.channel, r["freebsd_major"]) for t, r in plan} == {
+        ("stable", "15"),
+        ("stable", "16"),
+        ("devel", "15"),
+        ("devel", "16"),
+    }
+
+
+def test_plan_three_row_matrix_yields_six_artifacts() -> None:
+    rows = [ROW_15, ROW_16, {"freebsd_major": "17", "php_version": "8.5", "py_flavor": "py312"}]
+    plan = bfv.plan_artifacts(rows, target_filter=None, major_filter=None)
+    assert len(plan) == 6
+
+
+def test_plan_one_row_matrix_yields_two_artifacts() -> None:
+    plan = bfv.plan_artifacts([ROW_15], target_filter=None, major_filter=None)
+    assert len(plan) == 2
+    assert {t.channel for t, _ in plan} == {"stable", "devel"}
+
+
+def test_plan_respects_target_and_major_filters() -> None:
+    plan = bfv.plan_artifacts([ROW_15, ROW_16], target_filter="stable", major_filter="16")
+    assert len(plan) == 1
+    assert plan[0][0].channel == "stable"
+    assert plan[0][1]["freebsd_major"] == "16"
+
+
+# --------------------------------------------------------------------------- #
+# Row 6: abi/arch wildcard assertion.
+# --------------------------------------------------------------------------- #
+
+
+def test_wildcard_abi_accepted_concrete_abi_rejected(tmp_path: Path) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15)
+    bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)  # FreeBSD:15:* — accepted
+
+    pkg_path2, export_dir2 = _happy_fixture(tmp_path, STABLE, ROW_15, version="1.2.3_9", abi="FreeBSD:15:amd64")
+    with pytest.raises(bfv.ArtifactValidationError, match="abi"):
+        bfv.validate_artifact(pkg_path2, export_dir2, STABLE, {**ROW_15})
+
+
+# --------------------------------------------------------------------------- #
+# Row 7: php/py dependency derivation.
+# --------------------------------------------------------------------------- #
+
+
+def test_dependency_derivation_matches_row_wrong_flavor_rejected(tmp_path: Path) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15)
+    bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)  # php83 present — accepted
+
+    wrong_deps = _deps_for(ROW_16)  # php85, not php83
+    pkg_path2, export_dir2 = _happy_fixture(tmp_path, STABLE, ROW_15, version="1.2.3_8", deps=wrong_deps)
+    with pytest.raises(bfv.ArtifactValidationError, match="php83"):
+        bfv.validate_artifact(pkg_path2, export_dir2, STABLE, ROW_15)
+
+
+def test_derive_deps_shape() -> None:
+    assert bfv._derive_deps(ROW_15) == {"php83", "php83-intl", "python311", "py311-sqlite3", "py311-maxminddb"}
+    assert bfv._derive_deps(ROW_16) == {"php85", "php85-intl", "python311", "py311-sqlite3", "py311-maxminddb"}
+
+
+# --------------------------------------------------------------------------- #
+# Row 12-13: tag resolution against a real (tiny, local, no-network) git repo.
+# --------------------------------------------------------------------------- #
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+
+
+@pytest.fixture
+def tiny_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", cwd=repo)
+    _git("config", "user.email", "test@example.com", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    (repo / "usr").mkdir()
+    (repo / "usr" / "marker").write_text("hi\n")
+    _git("add", ".", cwd=repo)
+    _git("commit", "-q", "-m", "init", cwd=repo)
+    commit = _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+    _git("tag", "v9.9.9", cwd=repo)
+    return repo, commit
+
+
+def test_resolve_tag_commit_happy_path(tiny_repo: tuple[Path, str]) -> None:
+    repo, commit = tiny_repo
+    assert bfv.resolve_tag_commit(repo, "v9.9.9", commit) == commit
+
+
+def test_resolve_tag_commit_missing_tag_rejected(tiny_repo: tuple[Path, str]) -> None:
+    repo, commit = tiny_repo
+    with pytest.raises(bfv.TagResolutionError, match="not-a-real-tag"):
+        bfv.resolve_tag_commit(repo, "not-a-real-tag", commit)
+
+
+def test_resolve_tag_commit_unexpected_commit_rejected_naming_both(tiny_repo: tuple[Path, str]) -> None:
+    repo, commit = tiny_repo
+    bogus = "f" * 40
+    with pytest.raises(bfv.TagResolutionError) as exc_info:
+        bfv.resolve_tag_commit(repo, "v9.9.9", bogus)
+    assert commit in str(exc_info.value)
+    assert bogus in str(exc_info.value)
+
+
+def test_export_tag_is_clean_and_matches_tree(tiny_repo: tuple[Path, str]) -> None:
+    repo, commit = tiny_repo
+    dest = repo.parent / "export-dest"
+    dest.mkdir()
+    bfv.export_tag(repo, commit, dest)
+    assert (dest / "usr" / "marker").read_text() == "hi\n"
+
+
+# --------------------------------------------------------------------------- #
+# Row 14-15: name/version identity rejection (PORTREVISION/epoch accepted).
+# --------------------------------------------------------------------------- #
+
+
+def test_wrong_package_name_rejected(tmp_path: Path) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, name="wrong-name", version="1.2.3")
+    with pytest.raises(bfv.ArtifactValidationError, match="name"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+@pytest.mark.parametrize("version", ["1.2.4", "1.2.2", "1.2"])
+def test_wrong_version_rejected(tmp_path: Path, version: str) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, version=version)
+    with pytest.raises(bfv.ArtifactValidationError, match="version"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+@pytest.mark.parametrize("version", ["1.2.3_2", "1.2.3_3", "1.2.3,1"])
+def test_portrevision_and_epoch_suffix_accepted(tmp_path: Path, version: str) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, version=version)
+    record = bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+    assert record["version"] == version
+
+
+# --------------------------------------------------------------------------- #
+# Row 16: malformed abi shapes — all rejected; nothing staged outside --out.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "bad_abi",
+    ["FreeBSD:15:..", "FreeBSD:15:/etc", "FreeBSD:15:am d64", "FreeBSD:16:*", "not-an-abi-at-all"],
+)
+def test_malformed_abi_rejected(tmp_path: Path, bad_abi: str) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, abi=bad_abi)
+    with pytest.raises(bfv.ArtifactValidationError, match="abi"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_rejected_artifact_stages_nothing_outside_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, abi="FreeBSD:15:amd64")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    def fake_invoke(argv: list[str], *, cwd: Path) -> str:
+        return str(pkg_path)
+
+    monkeypatch.setattr(bfv, "_invoke_build_leg", fake_invoke)
+    with pytest.raises(bfv.ArtifactValidationError):
+        bfv.build_and_stage_one(
+            target=STABLE,
+            row=ROW_15,
+            repo=tmp_path,
+            export_dir=export_dir,
+            build_leg_sh=tmp_path / "build-leg.sh",
+            out_dir=out_dir,
+            ports_dir=None,
+        )
+    assert list(out_dir.rglob("*.pkg")) == []
+
+
+# --------------------------------------------------------------------------- #
+# Row 17, 28: filename vs manifest identity; cross-channel rejection.
+# --------------------------------------------------------------------------- #
+
+
+def test_filename_disagreeing_with_manifest_rejected(tmp_path: Path) -> None:
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / "totally-different-filename-9.9.9.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        abi="FreeBSD:15:*",
+        arch="freebsd:15:*",
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(STABLE.portname, STABLE.portversion),
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="filename"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_stable_artifact_presented_as_devel_rejected(tmp_path: Path) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15)
+    with pytest.raises(bfv.ArtifactValidationError):
+        bfv.validate_artifact(pkg_path, export_dir, DEVEL, ROW_15)
+
+
+# --------------------------------------------------------------------------- #
+# Row 18-19: determinism — identical bytes pass, differing bytes fail loudly.
+# --------------------------------------------------------------------------- #
+
+
+def test_determinism_check_identical_bytes_passes(tmp_path: Path) -> None:
+    pkg_a, _ = _happy_fixture(tmp_path, STABLE, ROW_15, out_dir=tmp_path)
+    pkg_b = tmp_path / "copy.pkg"
+    pkg_b.write_bytes(pkg_a.read_bytes())
+    bfv.check_determinism(pkg_a, pkg_b)  # no raise
+
+
+def test_determinism_check_different_bytes_fails_naming_both_digests(tmp_path: Path) -> None:
+    pkg_a, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, out_dir=tmp_path / "a")
+    pkg_b, _ = _happy_fixture(tmp_path, STABLE, ROW_15, version="1.2.3_9", out_dir=tmp_path / "b")
+    sha_a = hashlib.sha256(pkg_a.read_bytes()).hexdigest()
+    sha_b = hashlib.sha256(pkg_b.read_bytes()).hexdigest()
+    assert sha_a != sha_b
+    with pytest.raises(bfv.DeterminismError) as exc_info:
+        bfv.check_determinism(pkg_a, pkg_b)
+    assert sha_a in str(exc_info.value)
+    assert sha_b in str(exc_info.value)
+
+
+# --------------------------------------------------------------------------- #
+# Row 20-23: hostile archive shapes.
+# --------------------------------------------------------------------------- #
+
+
+def test_truncated_pkg_rejected_cleanly(tmp_path: Path) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15)
+    truncated = tmp_path / "demo-pkg-1.2.3.pkg"
+    raw = pkg_path.read_bytes()
+    truncated.write_bytes(raw[: len(raw) // 2])
+    with pytest.raises(bfv.ArtifactValidationError, match="unreadable|corrupt"):
+        bfv.validate_artifact(truncated, export_dir, STABLE, ROW_15)
+
+
+def test_malformed_manifest_json_rejected(tmp_path: Path) -> None:
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(STABLE.portname, STABLE.portversion),
+        corrupt_manifest_json=True,
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="MANIFEST"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_missing_compact_manifest_rejected(tmp_path: Path) -> None:
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(STABLE.portname, STABLE.portversion),
+        omit_compact=True,
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="COMPACT_MANIFEST"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+@pytest.mark.parametrize("missing_key", ["install", "deinstall"])
+def test_missing_lifecycle_script_rejected(tmp_path: Path, missing_key: str) -> None:
+    scripts = dict(DEMO_SCRIPTS)
+    del scripts[missing_key]
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, scripts=scripts)
+    with pytest.raises(bfv.ArtifactValidationError, match="scripts"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_empty_lifecycle_script_rejected(tmp_path: Path) -> None:
+    scripts = {"install": "", "deinstall": "echo bye\n"}
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, scripts=scripts)
+    with pytest.raises(bfv.ArtifactValidationError, match="scripts"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+# --------------------------------------------------------------------------- #
+# Row 24-27: payload/export byte parity + the info.xml allowlist vacuity guard.
+# --------------------------------------------------------------------------- #
+
+
+def test_extra_payload_file_not_in_export_rejected(tmp_path: Path) -> None:
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    files = _packaged_payload(STABLE.portname, STABLE.portversion)
+    files["/usr/local/pkg/pfblockerng/extra_stray_file.php"] = b"<?php // not in export\n"
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=files,
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="extra_stray_file"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_modified_payload_file_rejected_naming_it(tmp_path: Path) -> None:
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    files = _packaged_payload(STABLE.portname, STABLE.portversion)
+    files["/usr/local/www/pfblockerng/index.php"] = b"<?php // TAMPERED\n"
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=files,
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="index.php"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_info_xml_modified_beyond_pkgversion_substitution_rejected(tmp_path: Path) -> None:
+    """Vacuity guard: the info.xml allowlist covers ONLY the %%PKGVERSION%% swap."""
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    files = _packaged_payload(STABLE.portname, STABLE.portversion)
+    info_path = f"/usr/local/share/{STABLE.portname}/info.xml"
+    files[info_path] = files[info_path].replace(b"</xml>", b"<!-- injected -->\n</xml>")
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=files,
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="info.xml"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_info_xml_unsubstituted_pkgversion_token_rejected(tmp_path: Path) -> None:
+    """Substitution didn't run: the packaged copy still literally says %%PKGVERSION%%."""
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    files = _demo_payload(STABLE.portname)  # packaged == export, unsubstituted
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=files,
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="info.xml"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+# --------------------------------------------------------------------------- #
+# Row 29-33: matrix validation.
+# --------------------------------------------------------------------------- #
+
+
+def test_matrix_not_a_list_rejected() -> None:
+    with pytest.raises(bfv.MatrixError, match="array"):
+        bfv.validate_matrix({"not": "a list"})
+
+
+def test_matrix_empty_rejected() -> None:
+    with pytest.raises(bfv.MatrixError, match="empty"):
+        bfv.validate_matrix([])
+
+
+@pytest.mark.parametrize("missing", ["freebsd_major", "php_version", "py_flavor"])
+def test_matrix_row_missing_required_field_rejected(missing: str) -> None:
+    row = dict(ROW_15)
+    del row[missing]
+    with pytest.raises(bfv.MatrixError, match=missing):
+        bfv.validate_matrix([row])
+
+
+@pytest.mark.parametrize("bad_major", ["fifteen", "-1", "0", "15.0", ""])
+def test_matrix_row_bad_freebsd_major_rejected(bad_major: str) -> None:
+    row = {**ROW_15, "freebsd_major": bad_major}
+    with pytest.raises(bfv.MatrixError, match="freebsd_major"):
+        bfv.validate_matrix([row])
+
+
+def test_matrix_duplicate_freebsd_major_rejected() -> None:
+    with pytest.raises(bfv.MatrixError, match="duplicate"):
+        bfv.validate_matrix([ROW_15, {**ROW_15, "php_version": "8.9"}])
+
+
+def test_matrix_unexpected_role_rejected() -> None:
+    with pytest.raises(bfv.MatrixError, match="role"):
+        bfv.validate_matrix([{**ROW_15, "role": "route-only"}])
+
+
+def test_matrix_role_build_is_accepted() -> None:
+    rows = bfv.validate_matrix([{**ROW_15, "role": "build"}])
+    assert len(rows) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Row 34: matrix command process failure surfaces stderr / rejects garbage stdout.
+# --------------------------------------------------------------------------- #
+
+
+def test_matrix_command_nonzero_exit_surfaces_stderr(tmp_path: Path) -> None:
+    with pytest.raises(bfv.MatrixError, match="boom"):
+        bfv.run_matrix_cmd(["sh", "-c", "echo boom 1>&2; exit 3"], cwd=tmp_path)
+
+
+def test_matrix_command_garbage_stdout_rejected(tmp_path: Path) -> None:
+    with pytest.raises(bfv.MatrixError, match="JSON"):
+        bfv.run_matrix_cmd(["echo", "not-json"], cwd=tmp_path)
+
+
+def test_matrix_command_happy_path(tmp_path: Path) -> None:
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+    obj = bfv.run_matrix_cmd(["cat", str(matrix_file)], cwd=tmp_path)
+    assert bfv.validate_matrix(obj) == [ROW_15]
+
+
+# --------------------------------------------------------------------------- #
+# Row 35: crafted manifest values are DATA, never interpreted — no shell/path escape.
+# --------------------------------------------------------------------------- #
+
+
+def test_crafted_package_name_shell_injection_is_inert(tmp_path: Path) -> None:
+    marker_dir = tmp_path / "marker"
+    marker_dir.mkdir()
+    hostile_name = f"$(touch {marker_dir}/PWNED_NAME)"
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / "hostile-name.pkg"
+    _write_pkg(
+        pkg_path,
+        name=hostile_name,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(STABLE.portname, STABLE.portversion),
+    )
+    with pytest.raises(bfv.ArtifactValidationError):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+    assert not (marker_dir / "PWNED_NAME").exists()
+
+
+def test_crafted_version_with_newline_is_rejected(tmp_path: Path) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, version="1.2.3\nEVIL")
+    with pytest.raises(bfv.ArtifactValidationError, match="version"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_crafted_abi_with_semicolon_is_rejected(tmp_path: Path) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, abi="FreeBSD:15:*; rm -rf /")
+    with pytest.raises(bfv.ArtifactValidationError, match="abi"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_safe_segment_rejects_path_traversal_and_whitespace() -> None:
+    for bad in ["../etc/passwd", "a/b", "a b", "", ".."]:
+        with pytest.raises(bfv.ArtifactValidationError):
+            bfv._safe_segment(bad, "test value")
+    assert bfv._safe_segment("3.2.15_2", "test value") == "3.2.15_2"
+
+
+# --------------------------------------------------------------------------- #
+# Full-pipeline integration: matrix -> plan -> build (stubbed) -> validate ->
+# stage -> determinism -> report. Row 8 (report shape), 9 (determinism, at the
+# orchestration level), 10 (--verify-only, no build seam), 11 (staging layout).
+# --------------------------------------------------------------------------- #
+
+
+def _fake_build_leg(targets_by_channel: dict[str, Any]) -> Any:
+    """Stand-in for build-leg.sh: mirrors whatever --local-src holds into a synthetic .pkg.
+    Deterministic given identical inputs (no timestamps, no randomness) — repeated calls with
+    the same export tree + target + row produce byte-identical archives.
+    """
+
+    def fake(argv: list[str], *, cwd: Path) -> str:
+        opts: dict[str, str] = {}
+        i = 0
+        while i < len(argv):
+            tok = argv[i]
+            if tok == "--no-arch":
+                i += 1
+                continue
+            if tok.startswith("--"):
+                opts[tok[2:]] = argv[i + 1]
+                i += 2
+            else:
+                i += 1
+        target = targets_by_channel[opts["channel"]]
+        major = opts["abi"].split(":")[1]
+        row = {"freebsd_major": major, "php_version": opts["php"], "py_flavor": opts["py-flavor"]}
+        export_dir = Path(opts["local-src"])
+        out_dir = Path(opts["out-dir"])
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        payload = {}
+        for f in sorted(export_dir.rglob("*")):
+            if f.is_file():
+                payload["/" + f.relative_to(export_dir).as_posix()] = f.read_bytes()
+        info_path = f"/usr/local/share/{target.portname}/info.xml"
+        if info_path in payload:
+            payload[info_path] = payload[info_path].replace(b"%%PKGVERSION%%", target.portversion.encode())
+
+        pkg_path = out_dir / f"{target.portname}-{target.portversion}.pkg"
+        _write_pkg(
+            pkg_path,
+            name=target.portname,
+            version=target.portversion,
+            abi=f"FreeBSD:{major}:*",
+            arch=f"freebsd:{major}:*",
+            deps=_deps_for(row),
+            scripts=DEMO_SCRIPTS,
+            files=payload,
+        )
+        return str(pkg_path)
+
+    return fake
+
+
+def _stub_git(monkeypatch: pytest.MonkeyPatch, export_dir_by_commit: dict[str, Path]) -> None:
+    def fake_resolve(repo: Path, tag: str, expected_commit: str) -> str:
+        return expected_commit
+
+    def fake_export(repo: Path, commit: str, dest: Path) -> None:
+        import shutil
+
+        shutil.copytree(export_dir_by_commit[commit], dest, dirs_exist_ok=True)
+
+    monkeypatch.setattr(bfv, "resolve_tag_commit", fake_resolve)
+    monkeypatch.setattr(bfv, "export_tag", fake_export)
+
+
+def test_full_pipeline_two_targets_two_rows_report_and_determinism(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    export_stable = _write_export(tmp_path / "src_stable", _demo_payload(STABLE.portname))
+    export_devel = _write_export(tmp_path / "src_devel", _demo_payload(DEVEL.portname))
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE, DEVEL))
+    _stub_git(monkeypatch, {STABLE.commit: export_stable, DEVEL.commit: export_devel})
+    monkeypatch.setattr(bfv, "_invoke_build_leg", _fake_build_leg({"stable": STABLE, "devel": DEVEL}))
+
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15, ROW_16]))
+    out_dir = tmp_path / "stage"
+
+    rc = bfv.main(["--out", str(out_dir), "--matrix-cmd", f"cat {matrix_file}", "--repo", str(tmp_path)])
+    assert rc == 0
+
+    staged = sorted(out_dir.glob("fbsd*/*.pkg"))
+    assert [p.relative_to(out_dir).as_posix() for p in staged] == [
+        "fbsd15/demo-pkg-1.2.3.pkg",
+        "fbsd15/demo-pkg-devel-1.3.0.pkg",
+        "fbsd16/demo-pkg-1.2.3.pkg",
+        "fbsd16/demo-pkg-devel-1.3.0.pkg",
+    ]
+
+    report = json.loads((out_dir / "frozen-v3-report.json").read_text())
+    assert report["ports_ref"] == bfv.FROZEN_PORTS_REF
+    assert len(report["artifacts"]) == 4
+    for artifact in report["artifacts"]:
+        assert artifact["channel"] in ("stable", "devel")
+        assert artifact["artifact_sha256"]
+        assert artifact["payload_file_count"] == 3
+        assert list(artifact["payload_files"]) == sorted(artifact["payload_files"])  # sorted inventory
+
+    # Deterministic report bytes: rerun into a fresh --out, compare byte-for-byte
+    # modulo the staged_path prefix (a different --out root).
+    out_dir_2 = tmp_path / "stage2"
+    rc2 = bfv.main(["--out", str(out_dir_2), "--matrix-cmd", f"cat {matrix_file}", "--repo", str(tmp_path)])
+    assert rc2 == 0
+    report2 = json.loads((out_dir_2 / "frozen-v3-report.json").read_text())
+    for a, b in zip(
+        sorted(report["artifacts"], key=lambda x: x["staged_path"]),
+        sorted(report2["artifacts"], key=lambda x: x["staged_path"]),
+    ):
+        assert a["artifact_sha256"] == b["artifact_sha256"]
+        assert a["payload_files"] == b["payload_files"]
+
+
+def test_verify_only_validates_staged_dir_without_invoking_build_seam(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    _stub_git(monkeypatch, {STABLE.commit: export_dir})
+
+    def boom(argv: list[str], *, cwd: Path) -> str:
+        raise AssertionError("build seam must not be invoked in --verify-only mode")
+
+    monkeypatch.setattr(bfv, "_invoke_build_leg", boom)
+
+    stage_dir = tmp_path / "stage"
+    (stage_dir / "fbsd15").mkdir(parents=True)
+    pkg_path = stage_dir / "fbsd15" / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(STABLE.portname, STABLE.portversion),
+    )
+
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+
+    rc = bfv.main(
+        [
+            "--out",
+            str(stage_dir),
+            "--verify-only",
+            str(stage_dir),
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+    report = json.loads((stage_dir / "frozen-v3-report.json").read_text())
+    assert len(report["artifacts"]) == 1
+
+
+def test_staging_layout_no_extra_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    _stub_git(monkeypatch, {STABLE.commit: export_dir})
+    monkeypatch.setattr(bfv, "_invoke_build_leg", _fake_build_leg({"stable": STABLE}))
+
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+    out_dir = tmp_path / "stage"
+    rc = bfv.main(
+        [
+            "--out",
+            str(out_dir),
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+            "--no-deterministic-check",
+        ]
+    )
+    assert rc == 0
+    all_pkgs = list(out_dir.glob("fbsd*/*.pkg"))
+    assert len(all_pkgs) == 1
+
+
+def test_nothing_to_build_when_filters_exclude_every_row(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+    rc = bfv.main(
+        ["--out", str(tmp_path / "out"), "--matrix-cmd", f"cat {matrix_file}", "--repo", str(tmp_path), "--major", "99"]
+    )
+    assert rc == 1
+
+
+# --------------------------------------------------------------------------- #
+# Production constants pinned — a regression here silently rebuilds the wrong bits.
+# --------------------------------------------------------------------------- #
+
+
+def test_frozen_constants_match_probed_facts() -> None:
+    assert bfv.FROZEN_PORTS_REF == "d30af128f456396a1cc961a10fdf23ad61bdfd58"
+    by_channel = {t.channel: t for t in bfv.FROZEN_TARGETS}
+    assert by_channel["stable"] == bfv.FrozenTarget(
+        channel="stable",
+        tag="v3.2.15",
+        commit="0846aa7c090f96e62b5322d7dea70e80b1f31b63",
+        portname="pfSense-pkg-pfBlockerNG",
+        portversion="3.2.15",
+    )
+    assert by_channel["devel"] == bfv.FrozenTarget(
+        channel="devel",
+        tag="v3.2.16",
+        commit="0676cd1c7ed79d49a0644070151c4fffa39ea409",
+        portname="pfSense-pkg-pfBlockerNG-devel",
+        portversion="3.2.16",
+    )

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -64,6 +64,9 @@ def _write_pkg(
     omit_manifest: bool = False,
     corrupt_manifest_json: bool = False,
     extra_manifest: dict | None = None,
+    compact_overrides: dict | None = None,
+    link_members: tuple[tuple[str, str, int], ...] = (),
+    duplicate_manifest: bool = False,
 ) -> None:
     """Write a libpkg-shaped .pkg (zstd tar, +COMPACT_MANIFEST + +MANIFEST + payload)."""
     manifest: dict = {
@@ -85,7 +88,10 @@ def _write_pkg(
         manifest["deps"] = deps
     if extra_manifest:
         manifest.update(extra_manifest)
-    compact_raw = json.dumps(manifest, separators=(",", ":")).encode() + b"\n"
+    compact_manifest = dict(manifest)
+    if compact_overrides:
+        compact_manifest.update(compact_overrides)
+    compact_raw = json.dumps(compact_manifest, separators=(",", ":")).encode() + b"\n"
 
     full = dict(manifest)
     full["files"] = {
@@ -111,8 +117,21 @@ def _write_pkg(
             _add_member(tf, "+COMPACT_MANIFEST", compact_raw)
         if not omit_manifest:
             _add_member(tf, "+MANIFEST", full_raw)
+        if duplicate_manifest:
+            # libarchive/libpkg reads the FIRST member of a duplicated name, Python's
+            # tarfile the LAST — so a second +MANIFEST is a validator/consumer split.
+            _add_member(tf, "+MANIFEST", full_raw)
         for p, b in (files or {}).items():
             _add_member(tf, p, b)
+        for link_name, link_target, link_type in link_members:
+            ti = tarfile.TarInfo(name=link_name)
+            ti.type = link_type  # type: ignore[assignment]
+            ti.linkname = link_target
+            ti.mode = 0o644
+            ti.uid = ti.gid = 0
+            ti.uname, ti.gname = "root", "wheel"
+            ti.mtime = 0
+            tf.addfile(ti)
     path.write_bytes(pfb_pkg.zstd_compress(raw.getvalue(), RuntimeError, "zstd unavailable for tests"))
 
 
@@ -550,6 +569,108 @@ def test_missing_compact_manifest_rejected(tmp_path: Path) -> None:
         bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
 
 
+@pytest.mark.parametrize(
+    ("label", "overrides"),
+    [
+        ("version", {"version": "4.9.9"}),
+        ("abi", {"abi": "FreeBSD:15:amd64"}),
+        ("arch", {"arch": "freebsd:15:amd64"}),
+        ("name", {"name": "pfSense-pkg-somethingelse"}),
+        ("origin", {"origin": "net/somethingelse"}),
+    ],
+)
+def test_compact_manifest_disagreeing_with_full_manifest_rejected(tmp_path: Path, label: str, overrides: dict) -> None:
+    """The two manifests must agree on identity, because consumers read different ones.
+
+    Intent: identity validation here reads +MANIFEST, but the catalog generator reads
+    +COMPACT_MANIFEST. A package whose two documents disagree would be validated as one
+    identity and published as another, so the divergence itself is the defect.
+    """
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(STABLE.portname, STABLE.portversion),
+        compact_overrides=overrides,
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="COMPACT_MANIFEST disagrees"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+@pytest.mark.parametrize(
+    ("label", "link_type"),
+    [("symlink", tarfile.SYMTYPE), ("hardlink", tarfile.LNKTYPE)],
+)
+def test_non_regular_payload_member_rejected(tmp_path: Path, label: str, link_type: int) -> None:
+    """A link member smuggled into the payload is rejected, not silently ignored.
+
+    Intent: payload parity compares regular files against the tag export, so a member
+    that is not a regular file would never enter the comparison at all — it must be
+    refused outright rather than travelling in the artifact unexamined.
+    """
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(STABLE.portname, STABLE.portversion),
+        link_members=(("/usr/local/pkg/pfblockerng/backdoor.inc", "../../../../etc/passwd", link_type),),
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="not a regular file"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+def test_duplicate_member_name_rejected(tmp_path: Path) -> None:
+    """A duplicated archive member is refused rather than resolved by reader order.
+
+    Intent: libpkg takes the first member of a duplicated name and Python's tarfile the
+    last, so tolerating duplicates lets the validator and the installer read different
+    documents from the same artifact.
+    """
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(STABLE.portname, STABLE.portversion),
+        duplicate_manifest=True,
+    )
+    with pytest.raises(bfv.ArtifactValidationError, match="duplicate archive member"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+@pytest.mark.parametrize("row", [ROW_15, ROW_16])
+def test_build_leg_argv_pins_the_frozen_ports_ref_and_forces_no_arch(tmp_path: Path, row: dict) -> None:
+    """The two arguments the frozen build cannot lose are pinned by an assertion.
+
+    Intent: dropping --no-arch yields a concrete-ABI package that leaves aarch64
+    unserved, and dropping the pinned ports ref builds the frozen payload against a
+    moving ports tree — the exact drift this tool exists to prevent.
+    """
+    argv = bfv._build_leg_argv(
+        tmp_path / "build-leg.sh",
+        target=STABLE,
+        row=row,
+        local_src=tmp_path / "src",
+        out_dir=tmp_path / "out",
+        ports_dir=None,
+    )
+
+    assert "--no-arch" in argv, f"--no-arch missing from {argv!r}"
+    assert "--ports-ref" in argv, f"--ports-ref missing from {argv!r}"
+    assert argv[argv.index("--ports-ref") + 1] == bfv.FROZEN_PORTS_REF
+
+
 @pytest.mark.parametrize("missing_key", ["install", "deinstall"])
 def test_missing_lifecycle_script_rejected(tmp_path: Path, missing_key: str) -> None:
     scripts = dict(DEMO_SCRIPTS)
@@ -850,7 +971,10 @@ def test_full_pipeline_two_targets_two_rows_report_and_determinism(
     assert len(report["artifacts"]) == 4
     for artifact in report["artifacts"]:
         assert artifact["channel"] in ("stable", "devel")
-        assert artifact["artifact_sha256"]
+        # The recorded checksum must be the STAGED bytes' — that is the file a later
+        # publication step uploads, so hashing anything else makes the report unverifiable.
+        staged_bytes = (out_dir / artifact["staged_path"]).read_bytes()
+        assert artifact["artifact_sha256"] == hashlib.sha256(staged_bytes).hexdigest()
         assert artifact["payload_file_count"] == 3
         assert list(artifact["payload_files"]) == sorted(artifact["payload_files"])  # sorted inventory
 
@@ -866,6 +990,52 @@ def test_full_pipeline_two_targets_two_rows_report_and_determinism(
     ):
         assert a["artifact_sha256"] == b["artifact_sha256"]
         assert a["payload_files"] == b["payload_files"]
+
+
+def test_determinism_failure_leaves_no_staged_artifact_behind(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A row that fails the determinism re-build must not leave a publish candidate.
+
+    Intent: staging is what makes an artifact eligible for the later publication step, so
+    a row whose second build disagreed must disappear from the staging root entirely —
+    otherwise a subsequent --verify-only would bless bytes this run rejected.
+    """
+    export_stable = _write_export(tmp_path / "src_stable", _demo_payload(STABLE.portname))
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    _stub_git(monkeypatch, {STABLE.commit: export_stable})
+
+    inner = _fake_build_leg({"stable": STABLE})
+    calls = {"n": 0}
+
+    def flaky(argv: list[str], *, cwd: Path) -> str:
+        produced = inner(argv, cwd=cwd)
+        calls["n"] += 1
+        if calls["n"] == 2:  # the determinism re-build disagrees by one byte
+            Path(produced).write_bytes(Path(produced).read_bytes() + b"\0")
+        return produced
+
+    monkeypatch.setattr(bfv, "_invoke_build_leg", flaky)
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+    out_dir = tmp_path / "stage"
+
+    rc = bfv.main(["--out", str(out_dir), "--matrix-cmd", f"cat {matrix_file}", "--repo", str(tmp_path)])
+
+    assert rc != 0, "a non-deterministic build must not exit 0"
+    assert sorted(out_dir.glob("fbsd*/*.pkg")) == [], "staged artifact left behind after a determinism failure"
+
+
+@pytest.mark.parametrize("field", ["php_version", "py_flavor"])
+def test_matrix_row_with_non_string_scalar_rejected_cleanly(field: str) -> None:
+    """A non-string matrix scalar is a named MatrixError, not a downstream crash.
+
+    Intent: the hostile-input contract requires malformed matrix input to be rejected in
+    the matrix validator, where the offending field can be named.
+    """
+    row: dict[str, Any] = dict(ROW_15)
+    row[field] = 8.3
+
+    with pytest.raises(bfv.MatrixError, match=field):
+        bfv.validate_matrix([row])
 
 
 def test_verify_only_validates_staged_dir_without_invoking_build_seam(

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -339,6 +339,57 @@ def test_export_tag_is_clean_and_matches_tree(tiny_repo: tuple[Path, str]) -> No
     assert (dest / "usr" / "marker").read_text() == "hi\n"
 
 
+def _tar_bytes_with(member: tarfile.TarInfo, payload: bytes = b"pwned\n") -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        member.size = len(payload)
+        tf.addfile(member, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+def _stub_git_archive(monkeypatch: pytest.MonkeyPatch, tar_bytes: bytes) -> None:
+    monkeypatch.setattr(
+        bfv.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(args=a, returncode=0, stdout=tar_bytes, stderr=b""),
+    )
+
+
+def test_export_tag_rejects_escaping_member_as_clean_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A tag export whose member would land outside the export dir is a clean refusal.
+
+    Intent: the frozen build is a supply-chain step, so an escaping member is reported as
+    the module's own named error — never a raw tarfile traceback — and nothing is written
+    outside the destination.
+    """
+    _stub_git_archive(monkeypatch, _tar_bytes_with(tarfile.TarInfo("../escaped")))
+    dest = tmp_path / "export-dest"
+    dest.mkdir()
+
+    with pytest.raises(bfv.TagResolutionError, match="unsafe member"):
+        bfv.export_tag(tmp_path / "repo", "0" * 40, dest)
+
+    assert not (tmp_path / "escaped").exists(), "wrote outside the export dir"
+    assert sorted(p.name for p in dest.iterdir()) == [], "extracted despite the escape"
+
+
+def test_export_tag_keeps_an_absolute_member_inside_the_export_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An absolute member name is contained, not honoured as an absolute write.
+
+    Intent: pins the PEP 706 `data` filter's containment guarantee, so a future change of
+    extraction strategy cannot silently regain the ability to write to `/`.
+    """
+    _stub_git_archive(monkeypatch, _tar_bytes_with(tarfile.TarInfo("/tmp/escaped")))
+    dest = tmp_path / "export-dest"
+    dest.mkdir()
+
+    bfv.export_tag(tmp_path / "repo", "0" * 40, dest)
+
+    assert (dest / "tmp" / "escaped").read_bytes() == b"pwned\n"
+
+
 # --------------------------------------------------------------------------- #
 # Row 14-15: name/version identity rejection (PORTREVISION/epoch accepted).
 # --------------------------------------------------------------------------- #

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -776,6 +776,107 @@ def test_end_to_end_no_arch_port_explicit_arch_override_wins(tmp_path: Path) -> 
     assert full["arch"] == "freebsd:99:custom"
 
 
+def test_end_to_end_no_arch_flag_forces_wildcard_on_a_port_without_no_arch(tmp_path: Path) -> None:
+    """--no-arch forces the NO_ARCH manifest wildcard even without NO_ARCH=yes (issue #1676).
+
+    Scenario: classic port (no NO_ARCH), --no-arch passed on the CLI
+      Given a port Makefile WITHOUT NO_ARCH=yes (the frozen v3.2 ports Makefile shape)
+       When build-pkg-portable.py runs with --abi FreeBSD:15:amd64 --no-arch (no --arch)
+      Then the manifest abi is "FreeBSD:15:*" and arch is "freebsd:15:*" — same wildcard
+           the port would get if it had declared NO_ARCH=yes.
+    """
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--py-flavor", "py311",
+            "--compression", "xz",
+            "--freebsd-version", "1500068",
+            "--no-arch",
+            "--out", str(out),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    full, _, _ = _read_pkg(out / "testpkg-1.0_2.pkg")
+    assert full["abi"] == "FreeBSD:15:*"
+    assert full["arch"] == "freebsd:15:*"
+
+
+def test_end_to_end_no_arch_flag_on_a_no_arch_port_is_idempotent(tmp_path: Path) -> None:
+    """--no-arch on a port that already declares NO_ARCH=yes double-applies harmlessly.
+
+    Given a port Makefile WITH NO_ARCH=yes AND --no-arch also passed
+     Then the manifest is still cleanly wildcarded (no double-mangled "FreeBSD:15:**").
+    """
+    ports, portdir = _make_no_arch_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--py-flavor", "py311",
+            "--compression", "xz",
+            "--freebsd-version", "1500068",
+            "--no-arch",
+            "--out", str(out),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    full, _, _ = _read_pkg(out / "testpkg-1.0_2.pkg")
+    assert full["abi"] == "FreeBSD:15:*"
+    assert full["arch"] == "freebsd:15:*"
+
+
+def test_end_to_end_no_arch_flag_explicit_arch_override_wins(tmp_path: Path) -> None:
+    """--no-arch's abi wildcard still yields to an explicit --arch (issue #1676).
+
+    Mirrors test_end_to_end_no_arch_port_explicit_arch_override_wins but drives the
+    wildcard via --no-arch instead of a Makefile NO_ARCH=yes — same precedence rule.
+    """
+    ports, portdir = _make_classic_port(tmp_path)
+    out = tmp_path / "out"
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--arch", "freebsd:99:custom",
+            "--py-flavor", "py311",
+            "--compression", "xz",
+            "--freebsd-version", "1500068",
+            "--no-arch",
+            "--out", str(out),
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    full, _, _ = _read_pkg(out / "testpkg-1.0_2.pkg")
+    assert full["abi"] == "FreeBSD:15:*"
+    assert full["arch"] == "freebsd:99:custom"
+
+
+def test_dry_run_no_arch_flag_prints_wildcarded_abi(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--dry-run + --no-arch: the printed plan reports the wildcarded manifest abi/arch."""
+    ports, portdir = _make_classic_port(tmp_path)
+    rc = bpp.main(
+        [
+            "--ports", str(ports),
+            "--port-dir", str(portdir),
+            "--abi", "FreeBSD:15:amd64",
+            "--py-flavor", "py311",
+            "--freebsd-version", "1500068",
+            "--no-arch",
+            "--dry-run",
+        ]
+    )  # fmt: skip
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "abi/arch    FreeBSD:15:*  /  freebsd:15:*" in out
+
+
 def test_end_to_end_dynamic_plist_uses_the_staged_payload(tmp_path: Path) -> None:
     ports, portdir = _make_classic_port(tmp_path)
     portdir.joinpath("pkg-plist").unlink()


### PR DESCRIPTION
## Summary

First implementation slice of the frozen v3.2 package build for #1676: a matrix-driven driver
that builds and identity-validates genuine Stable `v3.2.15` and Devel `v3.2.16` `.pkg`
artifacts for every `scripts/read-version-matrix.sh --print-build` row, plus the two shared
build-path capabilities it needs.

**This PR publishes nothing.** No Release upload, no catalog write, no remote mutation of any
kind. Publication remains gated on the maintainer approval named in the issue's Escalation
section; the staged artifacts and their checksums are presented in a comment for that decision.

Slice 1 (line-pin retention, #1785) already landed and is untouched here. The route-only
catalog curation and the `pfBlockerNG/pkg` retention wiring are later slices — this PR
deliberately does not touch `scripts/build-repo-portable.py`, which is owned by #1828 this
cycle.

## What landed

**`scripts/build-frozen-v3.py`** (new) — builds and identity-validates one frozen artifact per
(channel × BUILD-matrix row). It pins *both* sides of the build: an exact `FreeBSD-ports`
commit and, per channel, an exact source tag/commit. Per artifact it exports the pinned tag
with `git archive` into a fresh temp directory (clean by construction, never the working
tree), builds one leg through the shared `build-leg.sh` path, and validates before staging
anything:

- package name / origin / version (`PORTREVISION` and epoch suffixes accepted, a different
  `PORTVERSION` is not);
- wildcarded ABI and arch (`FreeBSD:<major>:*` / `freebsd:<major>:*`);
- dependency names derived from the matrix row (never hardcoded);
- byte-for-byte payload parity against the tag export, with exactly one allowlisted
  divergence — `usr/local/share/<port>/info.xml`'s `%%PKGVERSION%%` substitution, which is
  the port's own `do-install` `REINPLACE_CMD`. Anything else that differs is a hard
  rejection, and a failed validation stages nothing;
- presence and checksums of the install/deinstall lifecycle scripts.

Every row is built twice by default and required to produce a byte-identical artifact. The
run writes a JSON identity report (source commit, artifact SHA-256, payload inventory with
per-file SHA-256, dependency/ABI facts). `--verify-only DIR` re-validates a staged directory
with no build seam invoked at all.

**`scripts/sparse-clone-ports.sh`** — the fresh-clone branch now accepts a full 40-hex commit
SHA as `REF`. `git clone -b <sha>` cannot take one, so a frozen build pinned to a ports commit
previously failed with `fatal: Remote branch <sha> not found in upstream origin`. The
branch/tag fast path is unchanged; only a bare 40-hex SHA takes the new fetch-by-oid path.

**`scripts/build-pkg-portable.py --no-arch`** (+ `scripts/build-leg.sh` passthrough) — forces
the existing `NO_ARCH` manifest wildcarding even when the port `Makefile` does not declare it.
The frozen v3.2 ports Makefiles predate `NO_ARCH=yes` and would otherwise stamp a concrete
`FreeBSD:<major>:amd64`. Since #1806 a BUILD row carries no `arch` axis — one wildcard-ABI
`.pkg` per FreeBSD major serves every architecture — and `scripts/build-repo-portable.py`
rejects a concrete-ABI frozen `.pkg` for a route-only catalog. Without this flag `aarch64`
would be unserved, which the issue calls release blocking. `--repo-catalogue`'s concrete ABI
and the explicit `--arch` override precedence are both unchanged.

## Correction to the issue's recommended ports ref

The issue's second maintainer comment recommends pinning the frozen leg to
`16220fafe6bbb7e7ca50949e1351c7415b8e9384`. That ref was probed in this session and does not
work for the Devel leg: its `-devel` port added a `post-extract` that seds and `mv`s
`usr/local/share/pfSense-pkg-pfBlockerNG/`, a directory the `v3.2.16` payload does not have
(it already ships `usr/local/share/pfSense-pkg-pfBlockerNG-devel/`). The build hard-fails with
`build-pkg-portable: sed target missing: .../pfSense-pkg-pfBlockerNG/info.xml`.

The corrected pin is **`d30af128f456396a1cc961a10fdf23ad61bdfd58`** — the ports commit that is
contemporaneous with and version-aligned to the frozen tags (`PORTVERSION=3.2.15`/`PORTREVISION=2`
for Stable, `PORTVERSION=3.2.16` for Devel), still carrying zero `list_scripts` references.
Both channels build green at this ref. Details are in a comment on #1676.

## Tests

- `tests/test_build_frozen_v3.py` — hermetic suite covering the issue's artifact-production
  and hostile-input tables: identity fields, matrix validation, determinism, staging layout,
  and every rejection row (tag drift, wrong name/version, malformed ABI, filename/manifest
  disagreement, conflicting duplicate identity, truncated archive, malformed manifest,
  missing lifecycle script, extra/modified payload file, unsubstituted or over-substituted
  `info.xml`, cross-channel substitution, matrix defects, injection-shaped values).
- `tests/shell/sparse_clone_ports_spec.sh` (new) — REF-shape classification including the
  full hostile set (short/long/non-hex/uppercase/slash/whitespace/leading-dash/`..`/shell
  metacharacters), driven against a local `file://` fixture repo.
- `tests/shell/build_leg_spec.sh`, `tests/test_build_pkg_portable.py` — `--no-arch` on and off
  sides, idempotence on a real `NO_ARCH` port, and explicit `--arch` precedence.

No auto-closing keyword is set here on purpose: this PR is one slice, and issue #1676 stays
open for route-only curation and the maintainer-gated publication phase.

## Executed evidence

- Full matrix build at this branch head: 4 artifacts (2 BUILD rows × 2 channels), exit 0.
- Cross-run determinism: two independent full runs produced byte-identical artifacts for all
  four rows.
- Independent payload-genuineness probe (not the tool's own report): the built Stable package
  carries 66 payload files against 66 `usr/`+`etc/` files in the `v3.2.15` tag export — a 1:1
  set with nothing omitted or added — of which 65 are byte-identical and the sole divergence
  is `usr/local/share/pfSense-pkg-pfBlockerNG/info.xml` line 13,
  `%%PKGVERSION%%` → `3.2.15_2`.
- Frozen tags verified live: `v3.2.15` = `0846aa7c090f96e62b5322d7dea70e80b1f31b63`,
  `v3.2.16` = `0676cd1c7ed79d49a0644070151c4fffa39ea409`, both annotated-free commits matching
  the constants in the driver.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
