### PR TITLE
tests: remove log-test wall-clock waits

### DIFF
--- a/tests/php/LogMgmtAgeCutoffTest.php
+++ b/tests/php/LogMgmtAgeCutoffTest.php
@@ -251,10 +251,10 @@ final class LogMgmtAgeCutoffTest extends TestCase
 			$this->now()       . ' e',
 		]) . "\n";
 		file_put_contents($logPath, $content);
-		$mtimeBefore = filemtime($logPath);
-
-		// A real filesystem mtime tick so an accidental touch would be visible.
-		usleep(1_100_000);
+		$mtimeBefore = time() - 3600;
+		touch($logPath, $mtimeBefore);
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($mtimeBefore, filemtime($logPath), 'before: forced mtime must take');
 
 		pfb_log_mgmt();
 
@@ -344,10 +344,10 @@ final class LogMgmtAgeCutoffTest extends TestCase
 			$this->now() . ' e',
 		]) . "\n";
 		file_put_contents($logPath, $content);
-		$mtimeBefore = filemtime($logPath);
-
-		// A real filesystem mtime tick so an accidental rewrite would be visible.
-		usleep(1_100_000);
+		$mtimeBefore = time() - 3600;
+		touch($logPath, $mtimeBefore);
+		clearstatcache(TRUE, $logPath);
+		$this->assertSame($mtimeBefore, filemtime($logPath), 'before: forced mtime must take');
 
 		pfb_log_mgmt();
 

--- a/tests/php/LogTimestampBaselineTest.php
+++ b/tests/php/LogTimestampBaselineTest.php
@@ -40,7 +40,7 @@ final class LogTimestampBaselineTest extends TestCase
 
 	protected function setUp(): void
 	{
-		foreach (['log', 'errlog', 'extraslog', 'runlog', 'runlog_active'] as $k) {
+		foreach (['log', 'errlog', 'extraslog', 'pnow', 'runlog', 'runlog_active'] as $k) {
 			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
 		}
 		// The syslog-branch reproduction below reformats a fixed instant -- pin the
@@ -121,6 +121,7 @@ final class LogTimestampBaselineTest extends TestCase
 	{
 		$log = $this->tempFile('pfb_log_now_');
 		$GLOBALS['pfb']['log'] = $log;
+		unset($GLOBALS['pfb']['pnow']);
 
 		pfb_logger("SNOWSHOE feed KNOWN issue [ NOW ]\n", 1);
 
@@ -130,6 +131,7 @@ final class LogTimestampBaselineTest extends TestCase
 			$written,
 			"a message containing 'NOW' must be preserved verbatim (no scrub) after the prefix; got: {$written}"
 		);
+		$this->assertArrayNotHasKey('pnow', $GLOBALS['pfb'], 'pfb_logger() must not recreate retired same-second global state');
 	}
 
 	/**

--- a/tests/php/LogTimestampBaselineTest.php
+++ b/tests/php/LogTimestampBaselineTest.php
@@ -133,25 +133,16 @@ final class LogTimestampBaselineTest extends TestCase
 	}
 
 	/**
-	 * The dedup bug (ADR.md §1.4) is retired: two calls landing in the SAME
-	 * wall-clock second must BOTH carry a real, non-blank ISO timestamp --
-	 * neither strips the other's.
-	 *
-	 * Bounded retry: only proves the same-second premise if the wall-clock
-	 * second does not roll over between the two calls -- an inherent race
-	 * with no injectable clock in production code today.
+	 * The dedup bug (ADR.md §1.4) is retired: repeated calls must each carry
+	 * a real, non-blank ISO timestamp -- neither strips the other's.
 	 */
-	public function testLogRepeatedSameSecondCallsBothStamped(): void
+	public function testLogRepeatedCallsAreIndependentlyStamped(): void
 	{
 		$log = $this->tempFile('pfb_log_dedup_');
 		$GLOBALS['pfb']['log'] = $log;
 
-		[$before, $after] = $this->runWithinSameSecond(function () use ($log) {
-			file_put_contents($log, '');
-			pfb_logger("pfb-baseline dedup line\n", 1);
-			pfb_logger("pfb-baseline dedup line\n", 1);
-		});
-		$this->assertSame($before, $after, 'wall-clock second rolled over on every retry attempt (flaky env)');
+		pfb_logger("pfb-baseline dedup line\n", 1);
+		pfb_logger("pfb-baseline dedup line\n", 1);
 
 		$lines = explode("\n", rtrim((string) file_get_contents($log), "\n"));
 		$this->assertCount(2, $lines, 'expected two independently-stamped lines');
@@ -159,7 +150,7 @@ final class LogTimestampBaselineTest extends TestCase
 			$this->assertMatchesRegularExpression(
 				'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} pfb-baseline dedup line$/',
 				$line,
-				"line {$i} must carry its own real ISO timestamp even though both calls landed in the same second; got: {$line}"
+				"line {$i} must carry its own real ISO timestamp; got: {$line}"
 			);
 		}
 	}
@@ -167,8 +158,7 @@ final class LogTimestampBaselineTest extends TestCase
 	/**
 	 * ADR.md §1.4's 'pnow' was a single process-global shared across every
 	 * logtype; it is deleted, so a log (logtype 1) call can no longer poison
-	 * a LATER, same-second extraslog (logtype 3) call -- each is now stamped
-	 * independently.
+	 * a later extraslog (logtype 3) call -- each is now stamped independently.
 	 */
 	public function testLogAndExtrasLogCallsAreIndependent(): void
 	{
@@ -177,13 +167,8 @@ final class LogTimestampBaselineTest extends TestCase
 		$GLOBALS['pfb']['log'] = $log;
 		$GLOBALS['pfb']['extraslog'] = $extraslog;
 
-		[$before, $after] = $this->runWithinSameSecond(function () use ($log, $extraslog) {
-			file_put_contents($log, '');
-			file_put_contents($extraslog, '');
-			pfb_logger("pfb-cross-a\n", 1);
-			pfb_logger("pfb-cross-b\n", 3);
-		});
-		$this->assertSame($before, $after, 'wall-clock second rolled over on every retry attempt (flaky env)');
+		pfb_logger("pfb-cross-a\n", 1);
+		pfb_logger("pfb-cross-b\n", 3);
 
 		$logWritten    = (string) file_get_contents($log);
 		$extrasWritten = (string) file_get_contents($extraslog);
@@ -596,22 +581,4 @@ final class LogTimestampBaselineTest extends TestCase
 		);
 	}
 
-	/**
-	 * Runs $work() with a best-effort guarantee that no wall-clock second
-	 * boundary was crossed during it, retrying up to 5 times.
-	 *
-	 * @return array{0:string,1:string} [$before, $after] -- equal on success.
-	 */
-	private function runWithinSameSecond(callable $work): array {
-		$before = $after = '';
-		for ($attempt = 0; $attempt < 5; $attempt++) {
-			$before = date('Y-m-d H:i:s', time());
-			$work();
-			$after = date('Y-m-d H:i:s', time());
-			if ($before === $after) {
-				break;
-			}
-		}
-		return [$before, $after];
-	}
 }


### PR DESCRIPTION
## Summary

- remove the wall-clock-second retry/assertion from the logger timestamp tests
- force a known old mtime before the two untouched-file assertions instead of sleeping for a filesystem tick
- keep the existing behavioural assertions while removing 2.2 seconds of fixed waiting

## Verification

- `vendor/bin/phpunit tests/php/LogTimestampBaselineTest.php tests/php/LogMgmtAgeCutoffTest.php` — `OK (57 tests, 139 assertions)`; 0.273 s after versus 2.517 s before
- `python3 -m pytest` — `3921 passed, 4 skipped`
- `scripts/agent/run-gates.sh --diff origin/devel` — Composer vendor, PHP lint, PHPStan, and PHPCS pass; full PHPUnit is currently false-red on the shared host through #2006's host-process-table tripwire (reproduced in isolation, outside this two-file diff)

Fixes #1995

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
