### PR TITLE
tests: synchronize wait-check deadline fixtures

### DIFF
--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -474,7 +474,11 @@ count=0
 count=$((count + 1))
 [ -z "${GH_STUB_COUNT_FILE:-}" ] || printf '%s\n' "$count" > "$GH_STUB_COUNT_FILE"
 case " ${GH_STUB_FAIL_CALLS:-} " in
-	*" $count "*) printf '%s\n' "${GH_STUB_FAIL_OUTPUT:-HTTP 404}"; exit 1 ;;
+	*" $count "*)
+		printf '%s\n' "${GH_STUB_FAIL_OUTPUT:-HTTP 404}"
+		[ -z "${GH_STUB_MARK_FAILURE:-}" ] || true > "$GH_STUB_POLL_MARKER"
+		exit 1
+		;;
 esac
 case "$*" in
 	*"pr view "*)
@@ -482,7 +486,10 @@ case "$*" in
 		[ -z "${GH_STUB_ARMED_MARKER:-}" ] || true > "$GH_STUB_ARMED_MARKER"
 		;;
 	*"/check-runs"*) printf '%s\n' "$GH_STUB_CHECK_RUNS" ;;
-	*"/status"*) printf '%s\n' "$GH_STUB_STATUS_PAYLOAD" ;;
+	*"/status"*)
+		printf '%s\n' "$GH_STUB_STATUS_PAYLOAD"
+		[ -z "${GH_STUB_MARK_STATUS:-}" ] || true > "$GH_STUB_POLL_MARKER"
+		;;
 esac
 STUB
     chmod +x "$stubdir/gh"
@@ -501,13 +508,18 @@ STUB
   setup_near_deadline() {
     cat > "$stubdir/date" <<'STUB'
 #!/bin/sh
-printf '100\n'
+if [ -e "$GH_STUB_POLL_MARKER" ]; then
+	printf '100\n'
+else
+	printf '0\n'
+fi
 STUB
     cat > "$stubdir/sleep" <<'STUB'
 #!/bin/sh
 printf '%s\n' "$1" >> "$WAIT_SLEEP_FILE"
 STUB
     chmod +x "$stubdir/date" "$stubdir/sleep"
+    export GH_STUB_POLL_MARKER="$stubdir/polled"
     export PFB_WAIT_DEADLINE=103 WAIT_SLEEP_FILE="$stubdir/sleeps"
   }
 
@@ -623,6 +635,7 @@ STUB
 
   It 'caps sleep after a successful pending poll at the remaining deadline'
     setup_near_deadline
+    export GH_STUB_MARK_STATUS=1
     pending_fixture
     When run sh "$script" --repo o/r --pr 1 --interval 99 --max-iter 1
     The line 1 of output should equal 'TIMEOUT'
@@ -631,6 +644,7 @@ STUB
 
   It 'caps sleep after a failed poll at the remaining deadline'
     setup_near_deadline
+    export GH_STUB_MARK_FAILURE=1
     export GH_STUB_COUNT_FILE="$stubdir/count"
     # call 1 = arm `pr view` (must succeed so the loop is reached at all); call 2 =
     # the single iteration's check-runs read, which fails.

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -286,13 +286,52 @@ printf '%s' "${GH_STUB_STDOUT-partial stdout}"
 printf '%s' "${GH_STUB_STDERR- + stderr}" >&2
 if [ -n "${GH_STUB_HANG:-}" ]; then
 	[ -z "${GH_STUB_IGNORE_TERM:-}" ] || trap '' TERM
-	sleep "${GH_STUB_HANG_SECONDS:-4}"
+	printf 'ready\n' > "$GH_STUB_READY_FIFO"
+	exec 9< "$GH_STUB_RELEASE_FIFO"
 	[ -z "${GH_STUB_HANG_MARKER:-}" ] || printf done > "$GH_STUB_HANG_MARKER"
 fi
 exit "${GH_STUB_STATUS:-0}"
 STUB
     chmod +x "$stubdir/gh"
     PATH="$stubdir:$PATH"
+  }
+
+  setup_synchronised_timeout() {
+    export REAL_TIMEOUT
+    REAL_TIMEOUT=$(command -v timeout)
+    mkfifo "$stubdir/ready" "$stubdir/release"
+    export GH_STUB_READY_FIFO="$stubdir/ready" GH_STUB_RELEASE_FIFO="$stubdir/release"
+    export TIMEOUT_STUB_ARGS="$stubdir/timeout-args"
+    cat > "$stubdir/date" <<'STUB'
+#!/bin/sh
+printf '100\n'
+STUB
+    cat > "$stubdir/timeout" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$*" > "$TIMEOUT_STUB_ARGS"
+case "$1" in
+	-k|-s) shift 2 ;;
+esac
+shift
+"$@" &
+child=$!
+if ! "$REAL_TIMEOUT" 10 sh -c 'IFS= read -r event < "$GH_STUB_READY_FIFO"'; then
+	echo 'stuck/environment: gh stub did not signal readiness' >&2
+	kill -KILL "$child" 2>/dev/null || :
+	wait "$child" 2>/dev/null || :
+	exit 125
+fi
+kill -TERM "$child"
+if [ -n "${GH_STUB_IGNORE_TERM:-}" ]; then
+	kill -0 "$child" || exit 125
+	[ -z "${TIMEOUT_STUB_KILL_MARKER:-}" ] || true > "$TIMEOUT_STUB_KILL_MARKER"
+	kill -KILL "$child"
+fi
+wait "$child" 2>/dev/null || :
+exit 124
+STUB
+    chmod +x "$stubdir/date" "$stubdir/timeout"
+    deadline=102
   }
   cleanup_stub() { rm -rf "$stubdir"; }
   Before 'setup_stub'
@@ -337,20 +376,23 @@ STUB
   End
 
   It 'returns timeout status with partial output when the remaining deadline expires'
-    deadline=$(( $(date +%s) + 2 ))
+    setup_synchronised_timeout
     export GH_STUB_HANG=1
     When call gh_bounded api endpoint
     The status should equal 124
     The output should equal 'partial stdout + stderr'
+    The contents of file "$TIMEOUT_STUB_ARGS" should equal '-k 1 1 gh api endpoint'
   End
 
   It 'kills a TERM-ignoring gh child before it can outlive the deadline'
-    deadline=$(( $(date +%s) + 2 ))
-    export GH_STUB_HANG=1 GH_STUB_IGNORE_TERM=1 GH_STUB_HANG_SECONDS=3
+    setup_synchronised_timeout
+    export GH_STUB_HANG=1 GH_STUB_IGNORE_TERM=1
     export GH_STUB_HANG_MARKER="$stubdir/outlived"
+    export TIMEOUT_STUB_KILL_MARKER="$stubdir/killed"
     When call gh_bounded api endpoint
-    The status should not equal 0
+    The status should equal 124
     The output should include 'partial stdout + stderr'
+    The file "$TIMEOUT_STUB_KILL_MARKER" should be exist
     The file "$GH_STUB_HANG_MARKER" should not be exist
   End
 End
@@ -435,7 +477,10 @@ case " ${GH_STUB_FAIL_CALLS:-} " in
 	*" $count "*) printf '%s\n' "${GH_STUB_FAIL_OUTPUT:-HTTP 404}"; exit 1 ;;
 esac
 case "$*" in
-	*"pr view "*) printf '%s\n' "${GH_STUB_SHA:-deadbeef}" ;;
+	*"pr view "*)
+		printf '%s\n' "${GH_STUB_SHA:-deadbeef}"
+		[ -z "${GH_STUB_ARMED_MARKER:-}" ] || true > "$GH_STUB_ARMED_MARKER"
+		;;
 	*"/check-runs"*) printf '%s\n' "$GH_STUB_CHECK_RUNS" ;;
 	*"/status"*) printf '%s\n' "$GH_STUB_STATUS_PAYLOAD" ;;
 esac
@@ -546,23 +591,18 @@ STUB
   It 'honours the wall-clock deadline even when a verdict would be reached'
     export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
     export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
-    # date returns "100" for the arm-time gh_bounded call (deadline 101 still ahead of
-    # it) then "200" for the loop's own check -- the loop must break on ITS deadline
-    # check even though the (unfetched) checks would otherwise pass.
+    # Advance the fake clock only after the gh stub signals that SHA arming completed.
+    # The loop must then break on its own deadline check before fetching the checks.
     cat > "$stubdir/date" <<'STUB'
 #!/bin/sh
-n=0
-[ ! -f "${DATE_COUNT_FILE:-}" ] || n=$(cat "$DATE_COUNT_FILE")
-n=$((n + 1))
-[ -z "${DATE_COUNT_FILE:-}" ] || printf '%s\n' "$n" > "$DATE_COUNT_FILE"
-if [ "$n" -le 1 ]; then
-	printf '100\n'
-else
+if [ -e "$GH_STUB_ARMED_MARKER" ]; then
 	printf '200\n'
+else
+	printf '0\n'
 fi
 STUB
     chmod +x "$stubdir/date"
-    export DATE_COUNT_FILE="$stubdir/date-count"
+    export GH_STUB_ARMED_MARKER="$stubdir/armed"
     export PFB_WAIT_DEADLINE=101
     When run sh "$script" --repo o/r --pr 1 --interval 0 --max-iter 3
     The line 1 of output should equal 'TIMEOUT'


### PR DESCRIPTION
## Summary

- replace scheduler-sensitive real-time races in the `gh_bounded` examples with FIFO readiness events and a deterministic timeout stub
- advance the loop fixture's fake clock only after the `gh` stub signals that SHA arming completed
- advance two near-deadline sleep-cap fixtures only after their successful or failed poll event, preventing arm-time retries from changing the assertion
- keep timeout solely as a loud `stuck/environment` salvage cap; production wait code is unchanged

## Red/green evidence

- RED on `origin/devel`: four concurrent canonical dash runs each failed the three target examples under load (90 examples, 3 failures per run)
- GREEN: `shellspec -j 8 --shell /opt/homebrew/bin/dash tests/shell/agent_wait_checks_spec.sh` (90 examples, 0 failures)
- GREEN: `shellspec -j 8 --shell /bin/sh tests/shell/agent_wait_checks_spec.sh` (90 examples, 0 failures)

## Verification

- `scripts/agent/run-gates.sh --diff origin/devel` (PASS)
- pre-commit impacted ShellSpec gate (90 examples, 0 failures)
- exact-head GitHub Actions is re-running after the final push

The production wait helper is unchanged; all conversions synchronize fixture time to explicit events instead of widening deadlines.

Closes #1981

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for command timeouts, forced termination, and wait-loop behavior.
  - Added validation for polling deadlines, capped delays, and failures after both successful and unsuccessful checks.
  - Improved test synchronization to make timing-related scenarios more reliable and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->