### PR TITLE
tests: isolate tick process snapshots

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3727,8 +3727,11 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir): bool
  * $pfb['log']/$pfb['extraslog'] for potentially minutes; pfb_log_mgmt()'s
  * tail-to-temp-then-cat-over trim is a read/truncate/rewrite window that would lose any
  * lines the concurrent writer appends during it.
+ *
+ * $ps_lines is injectable for hermetic off-appliance tests; NULL preserves the
+ * appliance's host process-table scan.
  */
-function pfblockerng_tick(): void
+function pfblockerng_tick(?array $ps_lines = NULL): void
 {
 	global $pfb;
 
@@ -3861,7 +3864,7 @@ function pfblockerng_tick(): void
 	// (pfb_update_pass_running()) -- both append to the same log files pfb_log_mgmt()'s
 	// tail-to-temp-then-cat-over trim reads/truncates/rewrites, and racing that window
 	// against a live writer loses whatever it appends meanwhile.
-	if (!$dispatched && !pfb_update_pass_running()) {
+	if (!$dispatched && !pfb_update_pass_running($ps_lines)) {
 		pfb_log_mgmt();
 	} elseif ($dispatched) {
 		// Skip is observable on the pfblockerng_syslog.log surface (issue #1769

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -1057,8 +1057,8 @@ final class TickEntrypointTest extends TestCase
 	 * Scenario:
 	 *   Given pfb_interval='Disabled' and a PENDING 'cron' ledger entry
 	 *   (pfb_due_ledger_set_pending -- e.g. left behind by an install-time feed
-	 *   pass that lost the pfb_feed_pass_begin() race); dcc/bl future-seeded; NO
-	 *   stray process anywhere.
+	 *   pass that lost the pfb_feed_pass_begin() race); dcc/bl future-seeded; no
+	 *   worker owned by this PHPUnit run.
 	 *   When  pfblockerng_tick() is called.
 	 *   Then  the pending 'cron' entry IS dispatched despite $cron_disabled (its
 	 *         pending_apply flag is cleared by the dispatch branch).

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -285,17 +285,23 @@ final class TickEntrypointTest extends TestCase
 		));
 	}
 
-	/** Allow a background recorder one second to exit; persistent workers remain visible. */
-	private function settledSuiteWorkerPsLines(): array
+	/**
+	 * Allow a background recorder one second to exit; persistent workers remain visible.
+	 *
+	 * @param null|callable(): int $clock
+	 * @param null|list<string> $psLinesOverride
+	 */
+	private function settledSuiteWorkerPsLines(?callable $clock = NULL, ?array $psLinesOverride = NULL): array
 	{
+		$clock ??= fn (): int => $this->monotonicTime();
 		$psLines = [];
-		$deadline = $this->monotonicTime() + 1_000_000_000;
+		$deadline = $clock() + 1_000_000_000;
 		for ($attempt = 0; $attempt < 50; $attempt++) {
-			$psLines = $this->suiteWorkerPsLines();
+			$psLines = $psLinesOverride ?? $this->suiteWorkerPsLines();
 			if (!pfb_update_pass_running($psLines)) {
 				return $psLines;
 			}
-			$now = $this->monotonicTime();
+			$now = $clock();
 			if ($attempt === 49 || $now >= $deadline) {
 				break;
 			}
@@ -599,23 +605,28 @@ final class TickEntrypointTest extends TestCase
 		}
 	}
 
-	public function testPersistentSuiteWorkerSettlingHasHardDeadline(): void
+	public function testPersistentSuiteWorkerSettlingHonorsDeadlineAndIterationCap(): void
 	{
-		[$proc, $pid, $stdin] = $this->spawnStrayUpdatePassProcess();
-		try {
-			$started = hrtime(TRUE);
-			$this->assertIsInt($started, 'monotonic clock is unavailable');
-			$psLines = $this->settledSuiteWorkerPsLines();
-			$finished = hrtime(TRUE);
-			$this->assertIsInt($finished, 'monotonic clock is unavailable');
+		$workerLines = ['  1234  -  Ss  0:00 /usr/local/www/pfblockerng/pfblockerng.php cron'];
 
-			$this->assertTrue(pfb_update_pass_running($psLines),
-				'a persistent worker must remain visible after the settling deadline');
-			$this->assertLessThan(2.0, ($finished - $started) / 1_000_000_000,
-				'settling must stop near its one-second monotonic deadline');
-		} finally {
-			$this->killStrayUpdatePassProcess($proc, $pid, $stdin);
-		}
+		$deadlineReads = 0;
+		$deadlineClock = static function () use (&$deadlineReads): int {
+			return $deadlineReads++ === 0 ? 0 : 1_000_000_000;
+		};
+		$psLines = $this->settledSuiteWorkerPsLines($deadlineClock, $workerLines);
+		$this->assertSame(2, $deadlineReads, 'deadline arm must stop after its second clock read');
+		$this->assertTrue(pfb_update_pass_running($psLines),
+			'a persistent worker must remain visible after the settling deadline');
+
+		$capReads = 0;
+		$fixedClock = static function () use (&$capReads): int {
+			$capReads++;
+			return 0;
+		};
+		$psLines = $this->settledSuiteWorkerPsLines($fixedClock, $workerLines);
+		$this->assertSame(51, $capReads, 'iteration-cap arm must stop after 50 observations');
+		$this->assertTrue(pfb_update_pass_running($psLines),
+			'a persistent worker must remain visible after the iteration cap');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -145,7 +145,7 @@ final class TickEntrypointTest extends TestCase
 		$this->hadUnboundChroot      = array_key_exists('unbound_chroot_path', $GLOBALS['g'] ?? []);
 		$this->originalUnboundChroot = $GLOBALS['g']['unbound_chroot_path'] ?? NULL;
 
-		$this->dbdir = sys_get_temp_dir() . '/pfb_tick_entrypoint_' . uniqid('', TRUE);
+		$this->dbdir = $this->dbdirPrefix() . uniqid('', TRUE);
 		mkdir($this->dbdir, 0755, TRUE);
 		$GLOBALS['pfb']['dbdir']     = $this->dbdir;
 		$GLOBALS['pfb']['runlog']    = "{$this->dbdir}/pfblockerng_run.log";
@@ -226,17 +226,8 @@ final class TickEntrypointTest extends TestCase
 	 * "pfblockerng.php cron" background process. Mirrors
 	 * TickFeedPassDeferralTest::installPhpArgvRecorder().
 	 *
-	 * Unavoidable residual race: pfblockerng_tick() execs the stub as
-	 * "{$pfb['php']} /usr/local/www/pfblockerng/pfblockerng.php cron ... &" --
-	 * production builds that argv, so the stub's own `ps -wax` command line
-	 * still CONTAINS the literal substring "pfblockerng.php cron" for the
-	 * stub's brief (sub-ms to low-ms) lifetime. pfb_update_pass_running()'s
-	 * precondition assert below scans the real process table and cannot
-	 * distinguish this from a genuine dispatch, so a phpunit run of THIS suite
-	 * happening concurrently with another checkout's run through this same
-	 * dispatch path could cross-trip that precondition. Not fixable from the
-	 * test side without faking argv; accepted because suites are never run
-	 * concurrently against one checkout (see .agents/policy/testing.md).
+	 * issue #2006: suite process-table checks retain only this PHPUnit process's
+	 * sandbox prefix, so another checkout's recorder cannot cross-trip them.
 	 */
 	private function installPhpArgvRecorder(): string
 	{
@@ -245,6 +236,37 @@ final class TickEntrypointTest extends TestCase
 		file_put_contents($path, "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> {$log}\n");
 		chmod($path, 0755);
 		return $path;
+	}
+
+	private function dbdirPrefix(): string
+	{
+		return sys_get_temp_dir() . '/pfb_tick_entrypoint_' . (int) getmypid() . '_';
+	}
+
+	/** Return only worker command lines carrying this PHPUnit process's sandbox prefix. */
+	private function suiteWorkerPsLines(): array
+	{
+		$psLines = [];
+		exec('/bin/ps -wax', $psLines);
+		$prefix = $this->dbdirPrefix();
+		return array_values(array_filter(
+			$psLines,
+			static fn (string $line): bool => str_contains($line, $prefix)
+		));
+	}
+
+	/** Allow a background recorder one second to exit; persistent workers remain visible. */
+	private function settledSuiteWorkerPsLines(): array
+	{
+		$psLines = [];
+		for ($attempt = 0; $attempt < 50; $attempt++) {
+			$psLines = $this->suiteWorkerPsLines();
+			if (!pfb_update_pass_running($psLines)) {
+				return $psLines;
+			}
+			usleep(20000);
+		}
+		return $psLines;
 	}
 
 	private function rrmdir(string $dir): void
@@ -393,7 +415,7 @@ final class TickEntrypointTest extends TestCase
 			. '  content=' . var_export(file_get_contents($logPath), TRUE));
 
 		// Act.
-		pfblockerng_tick();
+		pfblockerng_tick($this->settledSuiteWorkerPsLines());
 
 		// After: pfb_log_mgmt() trimmed 'log' to its last 3 lines.
 		clearstatcache(TRUE, $logPath);
@@ -444,19 +466,14 @@ final class TickEntrypointTest extends TestCase
 		$this->assertSame(5, $linesBefore,
 			"Before: expected 'log' to have 5 lines, got {$linesBefore}");
 
-		// Ordering-regression tripwire (issue #1666): pfb_update_pass_running()
-		// scans the REAL `ps -wax` table for a "pfblockerng.php <verb>" line -- a
-		// process leaked from an earlier, un-neutered sibling test would make this
-		// test's own tick() wrongly skip pfb_log_mgmt() below, exactly reproducing
-		// the flake. Assert the process table is clean BEFORE the tick so a leak
-		// fails loudly here instead of silently failing the trim assertion after.
-		// NOTE: this scan can also cross-trip on the recorder stub's own brief
-		// command line -- see installPhpArgvRecorder()'s docblock.
-		$this->assertFalse(pfb_update_pass_running(),
-			'a pfblockerng.php worker process leaked from an earlier test -- see issue #1666');
+		// Ordering-regression tripwire (issue #1666/#2006): reject workers leaked
+		// by this PHPUnit run without consulting unrelated host workers.
+		$psLines = $this->settledSuiteWorkerPsLines();
+		$this->assertFalse(pfb_update_pass_running($psLines),
+			'a pfblockerng.php worker owned by this PHPUnit run leaked from an earlier test');
 
 		// Act.
-		pfblockerng_tick();
+		pfblockerng_tick($psLines);
 
 		// The feed cron ledger entry must be unchanged (no mark_ran) -- confirms
 		// the tick genuinely treated 'cron' as not-due this pass.
@@ -473,6 +490,37 @@ final class TickEntrypointTest extends TestCase
 			"After tick with feed cron NOT due: expected 'log' still trimmed to [l3,l4,l5], got "
 			. var_export($linesAfter, TRUE)
 			. ' -- log maintenance must be unconditional, not gated behind the feed-cron due check');
+	}
+
+	/** issue #2006: an injected empty process snapshot isolates an idle tick from host workers. */
+	public function testIdleTickIgnoresUnrelatedHostWorker(): void
+	{
+		$this->seedTickPrereqs('Disabled');
+		pfb_global();
+		$this->ensureLogDir();
+
+		$now = time();
+		$this->seedFutureLedgerEntry('cron', $now);
+		$this->seedFutureLedgerEntry('dcc',  $now);
+		$this->seedFutureLedgerEntry('bl',   $now);
+
+		$logPath = $this->logPath('log');
+		file_put_contents($logPath, implode("\n", ['l1', 'l2', 'l3', 'l4', 'l5']) . "\n");
+
+		[$proc, $pid, $stdin] = $this->spawnStrayUpdatePassProcess();
+		try {
+			$this->assertTrue(pfb_update_pass_running(), 'fixture worker must be visible in the host process table');
+			pfblockerng_tick([]);
+
+			$linesAfter = array_values(array_filter(
+				explode("\n", (string) file_get_contents($logPath)),
+				'strlen'
+			));
+			$this->assertSame(['l3', 'l4', 'l5'], $linesAfter,
+				'an injected empty process snapshot must keep an unrelated host worker out of the idle tick');
+		} finally {
+			$this->killStrayUpdatePassProcess($proc, $pid, $stdin);
+		}
 	}
 
 	// -----------------------------------------------------------------------
@@ -527,7 +575,7 @@ final class TickEntrypointTest extends TestCase
 		$this->seedFutureLedgerEntry('bl',  $now);
 
 		// Act.
-		pfblockerng_tick();
+		pfblockerng_tick($this->suiteWorkerPsLines());
 
 		$cronEntry = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
 		$expected  = $oldNextDue + $interval;
@@ -596,7 +644,7 @@ final class TickEntrypointTest extends TestCase
 			"Before: expected 'log' to have 5 lines, got {$linesBefore}");
 
 		// Act.
-		pfblockerng_tick();
+		pfblockerng_tick($this->suiteWorkerPsLines());
 
 		// The feed cron WAS dispatched -- mark_ran_anchored advanced 'cron' past its
 		// pre-tick next_due, proving this tick genuinely took the dispatch branch.
@@ -622,9 +670,9 @@ final class TickEntrypointTest extends TestCase
 	// SILENT on skip: a stray process matching the ps-scan regex closed the
 	// gate with zero trace, which cost a live-tier diagnosis (the smoke suite's
 	// seeded log rode this same unsynchronized gate). This test drives a REAL
-	// background process through the REAL, uninjected pfb_update_pass_running()
-	// ps scan (PfbUpdatePassRunningTest covers the regex itself via an injected
-	// array; this pins the live gate) and asserts BOTH halves of the fix: the
+	// background process through a REAL, suite-scoped `ps` snapshot
+	// (PfbUpdatePassRunningTest covers the regex itself via synthetic arrays) and
+	// asserts BOTH halves of the fix: the
 	// skip still holds (log untrimmed) AND it is no longer silent (a
 	// deferred-maintenance line lands in the log).
 	// -----------------------------------------------------------------------
@@ -675,9 +723,9 @@ final class TickEntrypointTest extends TestCase
 
 		[$proc, $pid, $stdin] = $this->spawnStrayUpdatePassProcess();
 		try {
-			// Prove the fixture BEFORE trusting the tick's own scan of it: a real,
-			// uninjected pfb_update_pass_running() call must see this process.
-			$this->assertTrue(pfb_update_pass_running(),
+			// Prove this PHPUnit run's filtered process snapshot sees its fixture.
+			$psLines = $this->suiteWorkerPsLines();
+			$this->assertTrue(pfb_update_pass_running($psLines),
 				'fixture process does not satisfy pfb_update_pass_running() -- ps line does not '
 				. 'match; see spawnStrayUpdatePassProcess()');
 
@@ -686,7 +734,7 @@ final class TickEntrypointTest extends TestCase
 			$this->assertSame(5, $linesBefore, "Before: expected 'log' to have 5 lines, got {$linesBefore}");
 
 			// Act.
-			pfblockerng_tick();
+			pfblockerng_tick($psLines);
 
 			// (a) 'log' was NOT trimmed -- the original 5 lines are all still present
 			// (pfb_log_mgmt()'s tail-to-3 trim never ran).
@@ -751,10 +799,9 @@ final class TickEntrypointTest extends TestCase
 		$status = proc_get_status($proc);
 		$pid    = $status['pid'];
 
-		// Give the ps table a moment to pick the new process up before the caller
-		// trusts it.
+		// Give the ps table a moment to pick the new process up before the caller trusts it.
 		for ($i = 0; $i < 50; $i++) {
-			if (pfb_update_pass_running()) {
+			if (pfb_update_pass_running($this->suiteWorkerPsLines())) {
 				break;
 			}
 			usleep(20000);
@@ -772,7 +819,7 @@ final class TickEntrypointTest extends TestCase
 		if (is_resource($stdin)) {
 			fclose($stdin);
 		}
-		$reaped = false;
+		$reaped = FALSE;
 		if (is_resource($proc)) {
 			proc_terminate($proc, 9);	// SIGKILL: no cleanup path runs in the child
 			// proc_close() BLOCKS until the process changes state (waitpid()
@@ -780,7 +827,7 @@ final class TickEntrypointTest extends TestCase
 			// probe below, or a not-yet-reaped zombie reads as "still alive"
 			// (kill(pid, 0) succeeds against a zombie; bit this fix once).
 			proc_close($proc);
-			$reaped = true;
+			$reaped = TRUE;
 		}
 		// Assert it is actually gone. posix_kill(pid, 0) is the standard "is this
 		// pid alive" probe (no signal sent, just an existence check) -- guarded by
@@ -850,7 +897,7 @@ final class TickEntrypointTest extends TestCase
 		$this->seedFutureLedgerEntry('bl',  $now);
 
 		// Act.
-		pfblockerng_tick();
+		pfblockerng_tick($this->suiteWorkerPsLines());
 
 		// The feed cron WAS dispatched -- same tripwire as Case D.
 		$cronEntry = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
@@ -902,9 +949,7 @@ final class TickEntrypointTest extends TestCase
 	 *         pending_apply flag is cleared by the dispatch branch).
 	 *   And   'log' is NOT trimmed -- log maintenance was skipped this tick, caused
 	 *         by $dispatched (pfb_update_pass_running() was FALSE going in, per the
-	 *         precondition below -- not re-checked after the tick, since the
-	 *         dispatch's own recorder-stub argv line would then race the same regex;
-	 *         see installPhpArgvRecorder()'s docblock).
+	 *         precondition below).
 	 */
 	public function testPendingCronApplyBypassesDisabledIntervalAndSkipsLogMaintenance(): void
 	{
@@ -918,7 +963,8 @@ final class TickEntrypointTest extends TestCase
 		$this->seedFutureLedgerEntry('dcc', $now);
 		$this->seedFutureLedgerEntry('bl',  $now);
 
-		$this->assertFalse(pfb_update_pass_running(),
+		$psLines = $this->settledSuiteWorkerPsLines();
+		$this->assertFalse(pfb_update_pass_running($psLines),
 			'precondition: no stray/leaked process may satisfy pfb_update_pass_running() -- '
 			. 'this test isolates to the $dispatched half of the gate (issue #1769)');
 
@@ -930,7 +976,7 @@ final class TickEntrypointTest extends TestCase
 		$this->assertSame(5, $linesBefore, "Before: expected 'log' to have 5 lines, got {$linesBefore}");
 
 		// Act.
-		pfblockerng_tick();
+		pfblockerng_tick($psLines);
 
 		// The pending cron entry WAS dispatched despite pfb_interval='Disabled' --
 		// pending_apply bypasses $cron_disabled (pfblockerng_extra.inc).
@@ -940,12 +986,7 @@ final class TickEntrypointTest extends TestCase
 			'pending_apply must have been cleared by the dispatch branch -- proves the pending '
 			. 'entry genuinely dispatched, not merely persisted untouched');
 
-		// NOT re-checked here: installPhpArgvRecorder()'s docblock above documents why --
-		// the recorder stub's OWN "pfblockerng.php pfb_trigger ..." argv line matches
-		// pfb_update_pass_running()'s regex for its brief post-exec() lifetime, so a
-		// check placed here races that stub, not a real update pass. The precondition
-		// assertion above (BEFORE the tick) is what proves this test isolates to the
-		// $dispatched half of the gate -- pfb_update_pass_running() was FALSE going in.
+		// The precondition above proves this test entered through the $dispatched half.
 		// After: log maintenance was skipped -- 'log' still has its original 5 lines.
 		clearstatcache(TRUE, $logPath);
 		$linesAfter = count(array_filter(explode("\n", (string) file_get_contents($logPath)), 'strlen'));
@@ -985,11 +1026,12 @@ final class TickEntrypointTest extends TestCase
 		$logPath = $this->logPath('log');
 		file_put_contents($logPath, implode("\n", ['l1', 'l2', 'l3', 'l4', 'l5']) . "\n");
 
-		$this->assertFalse(pfb_update_pass_running(),
-			'a pfblockerng.php worker process leaked from an earlier test -- see issue #1666');
+		$psLines = $this->settledSuiteWorkerPsLines();
+		$this->assertFalse(pfb_update_pass_running($psLines),
+			'a pfblockerng.php worker owned by this PHPUnit run leaked from an earlier test');
 
 		// Act.
-		pfblockerng_tick();
+		pfblockerng_tick($psLines);
 
 		$cronEntry = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
 		$this->assertNotNull($cronEntry, 'cron ledger entry must still exist after the tick');

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -240,18 +240,48 @@ final class TickEntrypointTest extends TestCase
 
 	private function dbdirPrefix(): string
 	{
-		return sys_get_temp_dir() . '/pfb_tick_entrypoint_' . (int) getmypid() . '_';
+		$pid = getmypid();
+		if (!is_int($pid)) {
+			throw new RuntimeException('PHPUnit process PID is unavailable');
+		}
+		return sys_get_temp_dir() . '/pfb_tick_entrypoint_' . $pid . '_';
+	}
+
+	private function hostPsLines(): array
+	{
+		$psLines = [];
+		exec('/bin/ps -wax', $psLines, $rc);
+		if ($rc !== 0) {
+			throw new RuntimeException('/bin/ps -wax failed while inspecting test workers');
+		}
+		return $psLines;
+	}
+
+	private function monotonicTime(): int
+	{
+		$now = hrtime(TRUE);
+		if (!is_int($now)) {
+			throw new RuntimeException('monotonic clock is unavailable');
+		}
+		return $now;
 	}
 
 	/** Return only worker command lines carrying this PHPUnit process's sandbox prefix. */
 	private function suiteWorkerPsLines(): array
 	{
-		$psLines = [];
-		exec('/bin/ps -wax', $psLines);
 		$prefix = $this->dbdirPrefix();
 		return array_values(array_filter(
-			$psLines,
+			$this->hostPsLines(),
 			static fn (string $line): bool => str_contains($line, $prefix)
+		));
+	}
+
+	private function workerPsLines(int $pid): array
+	{
+		$pidPattern = '/^\s*' . preg_quote((string) $pid, '/') . '\s/';
+		return array_values(array_filter(
+			$this->hostPsLines(),
+			static fn (string $line): bool => preg_match($pidPattern, $line) === 1
 		));
 	}
 
@@ -259,12 +289,17 @@ final class TickEntrypointTest extends TestCase
 	private function settledSuiteWorkerPsLines(): array
 	{
 		$psLines = [];
+		$deadline = $this->monotonicTime() + 1_000_000_000;
 		for ($attempt = 0; $attempt < 50; $attempt++) {
 			$psLines = $this->suiteWorkerPsLines();
 			if (!pfb_update_pass_running($psLines)) {
 				return $psLines;
 			}
-			usleep(20000);
+			$now = $this->monotonicTime();
+			if ($attempt === 49 || $now >= $deadline) {
+				break;
+			}
+			usleep((int) min(20000, intdiv($deadline - $now, 1000)));
 		}
 		return $psLines;
 	}
@@ -414,8 +449,12 @@ final class TickEntrypointTest extends TestCase
 			"Before: expected 'log' to have 5 lines, got {$linesBefore};\n"
 			. '  content=' . var_export(file_get_contents($logPath), TRUE));
 
+		$psLines = $this->settledSuiteWorkerPsLines();
+		$this->assertFalse(pfb_update_pass_running($psLines),
+			'a pfblockerng.php worker owned by this PHPUnit run leaked from an earlier test');
+
 		// Act.
-		pfblockerng_tick($this->settledSuiteWorkerPsLines());
+		pfblockerng_tick($psLines);
 
 		// After: pfb_log_mgmt() trimmed 'log' to its last 3 lines.
 		clearstatcache(TRUE, $logPath);
@@ -518,6 +557,62 @@ final class TickEntrypointTest extends TestCase
 			));
 			$this->assertSame(['l3', 'l4', 'l5'], $linesAfter,
 				'an injected empty process snapshot must keep an unrelated host worker out of the idle tick');
+		} finally {
+			$this->killStrayUpdatePassProcess($proc, $pid, $stdin);
+		}
+	}
+
+	/** issue #2006: the suite snapshot excludes matching workers from another run. */
+	public function testSuiteSnapshotExcludesForeignHostWorker(): void
+	{
+		$this->seedTickPrereqs('Disabled');
+		pfb_global();
+		$this->ensureLogDir();
+
+		$now = time();
+		$this->seedFutureLedgerEntry('cron', $now);
+		$this->seedFutureLedgerEntry('dcc',  $now);
+		$this->seedFutureLedgerEntry('bl',   $now);
+
+		$logPath = $this->logPath('log');
+		file_put_contents($logPath, implode("\n", ['l1', 'l2', 'l3', 'l4', 'l5']) . "\n");
+
+		$foreignDir = sys_get_temp_dir() . '/pfb_tick_foreign_' . uniqid('', TRUE);
+		[$proc, $pid, $stdin] = $this->spawnStrayUpdatePassProcess($foreignDir);
+		try {
+			$this->assertTrue(pfb_update_pass_running($this->workerPsLines($pid)),
+				'foreign fixture worker must match pfb_update_pass_running()');
+			$psLines = $this->suiteWorkerPsLines();
+			$this->assertFalse(pfb_update_pass_running($psLines),
+				'this PHPUnit run snapshot must exclude the foreign fixture worker');
+			pfblockerng_tick($psLines);
+
+			$linesAfter = array_values(array_filter(
+				explode("\n", (string) file_get_contents($logPath)),
+				'strlen'
+			));
+			$this->assertSame(['l3', 'l4', 'l5'], $linesAfter,
+				'a foreign host worker must not close this PHPUnit run idle-tick gate');
+		} finally {
+			$this->killStrayUpdatePassProcess($proc, $pid, $stdin);
+			$this->rrmdir($foreignDir);
+		}
+	}
+
+	public function testPersistentSuiteWorkerSettlingHasHardDeadline(): void
+	{
+		[$proc, $pid, $stdin] = $this->spawnStrayUpdatePassProcess();
+		try {
+			$started = hrtime(TRUE);
+			$this->assertIsInt($started, 'monotonic clock is unavailable');
+			$psLines = $this->settledSuiteWorkerPsLines();
+			$finished = hrtime(TRUE);
+			$this->assertIsInt($finished, 'monotonic clock is unavailable');
+
+			$this->assertTrue(pfb_update_pass_running($psLines),
+				'a persistent worker must remain visible after the settling deadline');
+			$this->assertLessThan(2.0, ($finished - $started) / 1_000_000_000,
+				'settling must stop near its one-second monotonic deadline');
 		} finally {
 			$this->killStrayUpdatePassProcess($proc, $pid, $stdin);
 		}
@@ -787,9 +882,13 @@ final class TickEntrypointTest extends TestCase
 	 *         the write end of the piped stdin descriptor; the caller must fclose()
 	 *         it (see killStrayUpdatePassProcess()).
 	 */
-	private function spawnStrayUpdatePassProcess(): array
+	private function spawnStrayUpdatePassProcess(?string $dir = NULL): array
 	{
-		$script = "{$this->dbdir}/pfblockerng.php";
+		$dir ??= $this->dbdir;
+		if (!is_dir($dir)) {
+			mkdir($dir, 0755, TRUE);
+		}
+		$script = "{$dir}/pfblockerng.php";
 		file_put_contents($script, "#!/bin/sh\nread x\n");
 
 		$descriptors = [0 => ['pipe', 'r'], 1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
@@ -800,11 +899,16 @@ final class TickEntrypointTest extends TestCase
 		$pid    = $status['pid'];
 
 		// Give the ps table a moment to pick the new process up before the caller trusts it.
+		$deadline = $this->monotonicTime() + 1_000_000_000;
 		for ($i = 0; $i < 50; $i++) {
-			if (pfb_update_pass_running($this->suiteWorkerPsLines())) {
+			if (pfb_update_pass_running($this->workerPsLines($pid))) {
 				break;
 			}
-			usleep(20000);
+			$now = $this->monotonicTime();
+			if ($i === 49 || $now >= $deadline) {
+				break;
+			}
+			usleep((int) min(20000, intdiv($deadline - $now, 1000)));
 		}
 
 		return [$proc, $pid, $pipes[0]];

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -9917,7 +9917,15 @@
     "pfblockerng_tick": {
         "returnsRef": false,
         "returnType": "void",
-        "params": []
+        "params": [
+            {
+                "name": "ps_lines",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            }
+        ]
     },
     "pfblockerng_top1m": {
         "returnsRef": false,


### PR DESCRIPTION
## Summary

- let the real tick entrypoint accept an optional process snapshot while preserving the appliance host scan by default
- scope TickEntrypointTest process lines to workers carrying this PHPUnit run sandbox prefix
- bound fixture settling by both a monotonic one-second deadline and 50 observations
- pin the optional parameter in the function inventory

## Red to green

Foreign-worker isolation RED before the production seam:

```text
vendor/bin/phpunit tests/php/TickEntrypointTest.php --filter testIdleTickIgnoresUnrelatedHostWorker
FAIL: expected [l3,l4,l5], got [l1,l2,l3,l4,l5]
Tests: 1, Assertions: 4, Failures: 1
```

The committed foreign-worker filter test also went RED when its prefix filter was removed, then GREEN after restoration.

The deterministic stop-arm test went RED before clock/snapshot injection:

```text
Failed asserting that 0 is identical to 2.
```

GREEN beside an unrelated host process matching `pfblockerng.php cron`:

```text
vendor/bin/phpunit tests/php/TickEntrypointTest.php
OK (11 tests, 46 assertions)
```

Canonical local gates:

```text
scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: python3 scripts/check_composer_vendor.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
GATE PASS: php -l tests/php/TickEntrypointTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

Exact pushed head `55bef9e6f854b3d32f9cb221598aeca4e7f72eaa`: all required GitHub checks passed, including PHPUnit on PHP 8.3 and 8.5.

Fixes #2006

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

