### PR TITLE
pfblockerng: extract the shared DNSBL regex admission rules (#1765)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ ignore = [
 "tests/smoke/ui/test_category_ledger_close.py"  = ["F811"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["pfb_unbound"]
+known-first-party = ["pfb_unbound", "pfb_dnsbl_regex_rules"]
 
 [tool.mypy]
 python_version       = "3.11"

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -1,0 +1,181 @@
+"""pfb_dnsbl_regex_rules.py -- DNSBL regex admission rules (issue #1765 / #1711).
+
+Single source of the pure static predicates that decide whether a DNSBL regex
+pattern is admitted: the catastrophic-shape gate, the complexity-budget
+backstop, the opt-in length cap, and the pattern/description line-splitter.
+Two consumers share this ONE module instead of duplicating the literals:
+
+  - pfb_unbound.py imports it at load (Unbound's pythonmod loader `chdir()`s
+    into the script directory and appends '.' to sys.path before running
+    pfb_unbound.py, so a plain module-scope import resolves).
+  - pfblockerng_extra.inc's pfb_dnsbl_regex_validation_errors() runs it
+    standalone as the save-time probe (this file's ``main()``).
+
+Stdlib only, no ``unboundmodule`` reference at module scope or in any
+function here -- import-safe standalone in a plain interpreter.
+
+Probe usage: <pfb_python_interpreter()> pfb_dnsbl_regex_rules.py [1]
+  argv[1] == "1" enables the opt-in length cap (absent argv -> cap off).
+  Reads regex-list lines from stdin; each rejected line is reported on
+  stderr as ``line <n>: <pattern!r>: <message>``. Exits 1 if any line
+  failed, else 0.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+# Length ceiling (heuristic): a pattern over this many characters is dropped
+# at load ONLY when the opt-in "Limit long/complex regex" setting is enabled.
+# Length alone is a tunable convenience cap, NOT a safety gate -- a long
+# pattern is not inherently pathological -- so it stays behind the flag.
+REGEX_STATIC_LEN_CAP = 200
+
+# A quantified group that itself sits inside a quantifier: (a+)+, (a*)*, (\w+\.)+,
+# ([a-z]+)*, (.*a){20}. Measured to catch 1/1 catastrophic patterns in
+# the corpus with no false-negatives and no false-positives on the cap-passing set.
+_REGEX_NESTED_QUANTIFIER = re.compile(r"\([^()]*[+*][^()]*\)\s*[+*{]")
+
+# Alternation-overlap: a quantified group whose body contains an alternation `|`,
+# e.g. (a|a)+, (a|ab)*, (foo|foobar)+. Overlapping/ambiguous alternatives under a
+# quantifier backtrack catastrophically just like a nested quantifier, yet the
+# nested-quantifier shape above does not catch them (no inner quantifier). Kept
+# conservative: a single `(...)` (no inner parens) with a `|`, then a quantifier.
+_REGEX_ALTERNATION_OVERLAP = re.compile(r"\([^()]*\|[^()]*\)\s*[+*{]")
+
+# Multi-group adjacent quantified groups: (a+)(a+)+, (a+)(b+)*, (...)(...)+ -- two
+# back-to-back groups where the SECOND carries a trailing quantifier. The first
+# group's unbounded body and the quantified second group share input, so the engine
+# explores an exponential partition of the matched span. The single-group
+# _REGEX_NESTED_QUANTIFIER above misses this (the outer quantifier sits on a sibling
+# group, not the enclosing one). Each group body is paren-free (kept conservative).
+_REGEX_ADJACENT_GROUP_QUANTIFIER = re.compile(r"\([^()]*[+*][^()]*\)\([^()]*\)\s*[+*]")
+
+# Stacked bounded repeats: a{1000}{1000}, (x){500}{500}, [a-z]{50}{50} -- a `{m}`/`{m,n}`
+# repeat immediately followed by another `{...}`. Python's re multiplies the bounds, so a
+# pair of large counts is a polynomial/exponential blow-up with a tiny source string. A
+# group/atom (optionally already quantified) then two consecutive brace quantifiers.
+_REGEX_STACKED_BOUNDED_REPEAT = re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?:,\d*)?\}")
+
+# Complexity-budget backstop: cap the combined count of unbounded quantifiers (`+`/`*`,
+# unescaped) and alternations (`|`, unescaped) in one pattern. The structural regexes
+# above catch KNOWN bad shapes; this catches novel compositions of many quantifiers /
+# alternatives that together create a large backtracking surface even when no single
+# pair matches a structural template. The threshold (12) is generous: realistic ABP/DNS
+# feed regex carries a handful of anchors + one or two trailing quantifiers (a domain
+# pattern like `^(.+\.)?ads?[0-9]*\.example\.(com|net|org)$` counts ~5), so 12 clears
+# every benign pattern in the corpus while still bounding adversarial stacking.
+_REGEX_BUDGET_MAX = 12
+_REGEX_UNBOUNDED_QUANTIFIER = re.compile(r"(?<!\\)[+*]")
+_REGEX_ALTERNATION = re.compile(r"(?<!\\)\|")
+
+# The four structural shapes, tried in the order above.
+_REGEX_SHAPE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    _REGEX_NESTED_QUANTIFIER,
+    _REGEX_ALTERNATION_OVERLAP,
+    _REGEX_ADJACENT_GROUP_QUANTIFIER,
+    _REGEX_STACKED_BOUNDED_REPEAT,
+)
+
+
+def _regex_has_catastrophic_shape(pattern: str) -> bool:
+    """True when ``pattern`` matches any of the four structural shapes above."""
+    return any(shape.search(pattern) is not None for shape in _REGEX_SHAPE_PATTERNS)
+
+
+def _regex_complexity_budget(pattern: str) -> int:
+    """Combined count of unbounded quantifiers + alternations in ``pattern``
+    (the complexity-budget backstop's input; compare against ``_REGEX_BUDGET_MAX``)."""
+    return len(_REGEX_UNBOUNDED_QUANTIFIER.findall(pattern)) + len(_REGEX_ALTERNATION.findall(pattern))
+
+
+def _regex_is_catastrophic_shape(pattern: str) -> bool:
+    """Pure static analysis (NO execution): True when ``pattern`` carries a structurally
+    catastrophic shape -- a nested / adjacent / overlapping unbounded quantifier, a
+    stacked bounded repeat, or so many unbounded quantifiers + alternations combined that
+    its backtracking surface is unsafe. This is the SAFETY gate: it is applied to FEED and
+    user regex UNCONDITIONALLY at load (independent of the opt-in length cap) because these
+    shapes drive catastrophic backtracking in the `re` engine. It only inspects the pattern
+    STRING -- it never runs the candidate against any input -- so it is itself cheap and
+    safe. Length is deliberately NOT part of this gate (a long pattern is not inherently
+    catastrophic; the length ceiling is the separate opt-in convenience cap)."""
+    return _regex_has_catastrophic_shape(pattern) or _regex_complexity_budget(pattern) > _REGEX_BUDGET_MAX
+
+
+def pfb_split_regex_line(line: str) -> tuple[str, str | None]:
+    """Split a regex-list line into (pattern, description) at the first UNESCAPED '#'.
+
+    issue #1867: a '#' preceded by an ODD number of backslashes is escaped and
+    belongs to the pattern; an EVEN run (including none) leaves it as the
+    description marker. The escaped form is returned verbatim -- Python's ``re``
+    already reads "\\#" as a literal '#', so no unescaping step is needed and the
+    pattern half reaches ``re.compile`` unchanged.
+
+    Returns ``(line, None)`` when the line carries no description marker at all;
+    the caller distinguishes that from an empty description ("pattern#").
+
+    The PHP twin is ``pfb_split_regex_line()`` in pfblockerng_extra.inc and the
+    editor twin is the ``Pattern``/``Comment`` token pair in
+    tools/webassets/lezer-pfb-regex-list/src/pfb-regex-list.grammar -- all three
+    implement this one rule and their tests reference each other.
+    """
+    backslashes = 0
+    for index, character in enumerate(line):
+        if character == "\\":
+            backslashes += 1
+            continue
+        if character == "#" and backslashes % 2 == 0:
+            return line[:index], line[index + 1 :]
+        backslashes = 0
+    return line, None
+
+
+def _report(line_number: int, pattern: str, message: str) -> None:
+    print(f"line {line_number}: {pattern!r}: {message}", file=sys.stderr)
+
+
+def main(argv: list[str]) -> int:
+    """Save-time probe: read a regex-list body from stdin, report every entry the
+    resolver's admission rules would reject. ``argv[1] == "1"`` enables the
+    opt-in length cap (absent -> cap off), mirroring the resolver's ``regex_cap``
+    setting. Returns 1 if any line failed, else 0."""
+    regex_cap = len(argv) > 1 and argv[1] == "1"
+    failed = False
+    for line_number, raw_line in enumerate(sys.stdin, start=1):
+        line = raw_line.rstrip("\r\n")
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        pattern = pfb_split_regex_line(line)[0].strip().lower()
+        if not pattern:
+            continue
+        if any(ord(character) < 0x20 or ord(character) == 0x7F for character in pattern):
+            _report(line_number, pattern, "contains ASCII control character")
+            failed = True
+            continue
+        if _regex_has_catastrophic_shape(pattern):
+            _report(line_number, pattern, "catastrophic-backtracking shape")
+            failed = True
+            continue
+        if _regex_complexity_budget(pattern) > _REGEX_BUDGET_MAX:
+            _report(line_number, pattern, "too many quantifiers/alternations")
+            failed = True
+            continue
+        if regex_cap and len(pattern) > REGEX_STATIC_LEN_CAP:
+            _report(
+                line_number,
+                pattern,
+                f'over the {REGEX_STATIC_LEN_CAP}-character length cap ("Limit long/complex regex")',
+            )
+            failed = True
+            continue
+        try:
+            re.compile(pattern)
+        except Exception as error:
+            _report(line_number, pattern, f"Python regex compile error: {error}")
+            failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import re
 import sys
+import warnings
 
 # Length ceiling (heuristic): a pattern over this many characters is dropped
 # at load ONLY when the opt-in "Limit long/complex regex" setting is enabled.
@@ -170,7 +171,16 @@ def main(argv: list[str]) -> int:
             failed = True
             continue
         try:
-            re.compile(pattern)
+            # Only real "line N:" diagnostics may reach stderr: PHP turns EVERY
+            # non-empty stderr line into an admin-facing validation error. A pattern
+            # that compiles but warns (e.g. "[[a]]" -> FutureWarning "Possible nested
+            # set") would otherwise leak this file's absolute path AND its source line
+            # as two bogus errors -- warnings can resolve the source now that the probe
+            # runs as a FILE rather than via ``python -c``. The resolver compiles the
+            # same patterns at load without surfacing warnings either.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                re.compile(pattern)
         except Exception as error:
             _report(line_number, pattern, f"Python regex compile error: {error}")
             failed = True

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -51,6 +51,14 @@ try:
 except Exception:
     _sre_parse = None  # type: ignore[assignment]
 
+# issue #1765: single source of the DNSBL regex admission rules, shared with the
+# save-time probe (pfb_dnsbl_regex_validation_errors() in pfblockerng_extra.inc).
+from pfb_dnsbl_regex_rules import (
+    REGEX_STATIC_LEN_CAP,
+    _regex_is_catastrophic_shape,
+    pfb_split_regex_line,
+)
+
 if TYPE_CHECKING:
     # Symbols injected by Unbound's embedded Python interpreter (pythonmod) into
     # this script's globals at runtime. They are imported here only so static
@@ -1108,34 +1116,6 @@ def _load_ini_config() -> ConfigParser | None:
         sys.stderr.write("[pfBlockerNG]: Failed to load ini configuration: {}".format(e))
         pfb_py_status_open("dnsbl", pfb["pfb_unbound.ini"], "parse", "Failed to load ini configuration: {}".format(e))
     return config
-
-
-def pfb_split_regex_line(line: str) -> tuple[str, str | None]:
-    """Split a regex-list line into (pattern, description) at the first UNESCAPED '#'.
-
-    issue #1867: a '#' preceded by an ODD number of backslashes is escaped and
-    belongs to the pattern; an EVEN run (including none) leaves it as the
-    description marker. The escaped form is returned verbatim -- Python's ``re``
-    already reads "\\#" as a literal '#', so no unescaping step is needed and the
-    pattern half reaches ``re.compile`` unchanged.
-
-    Returns ``(line, None)`` when the line carries no description marker at all;
-    the caller distinguishes that from an empty description ("pattern#").
-
-    The PHP twin is ``pfb_split_regex_line()`` in pfblockerng_extra.inc and the
-    editor twin is the ``Pattern``/``Comment`` token pair in
-    tools/webassets/lezer-pfb-regex-list/src/pfb-regex-list.grammar -- all three
-    implement this one rule and their tests reference each other.
-    """
-    backslashes = 0
-    for index, character in enumerate(line):
-        if character == "\\":
-            backslashes += 1
-            continue
-        if character == "#" and backslashes % 2 == 0:
-            return line[:index], line[index + 1 :]
-        backslashes = 0
-    return line, None
 
 
 def _load_user_regex_entries(config: ConfigParser) -> list[tuple[str, str]]:
@@ -4731,49 +4711,8 @@ def _dnsbl_normalise_whitelist(
 # evicts a pattern from the live regexDB/allowRegexDB over an EVICT ceiling
 # (snapshot-iterate, evict-after-loop; dict.pop is atomic under the GIL).
 
-# Length ceiling (heuristic): a pattern over this many characters is dropped
-# at load ONLY when the opt-in "Limit long/complex regex" setting is enabled.
-# Length alone is a tunable convenience cap, NOT a safety gate -- a long
-# pattern is not inherently pathological -- so it stays behind the flag.
-REGEX_STATIC_LEN_CAP = 200
-
-# A quantified group that itself sits inside a quantifier: (a+)+, (a*)*, (\w+\.)+,
-# ([a-z]+)*, (.*a){20}. Measured to catch 1/1 catastrophic patterns in
-# the corpus with no false-negatives and no false-positives on the cap-passing set.
-_REGEX_NESTED_QUANTIFIER = re.compile(r"\([^()]*[+*][^()]*\)\s*[+*{]")
-
-# Alternation-overlap: a quantified group whose body contains an alternation `|`,
-# e.g. (a|a)+, (a|ab)*, (foo|foobar)+. Overlapping/ambiguous alternatives under a
-# quantifier backtrack catastrophically just like a nested quantifier, yet the
-# nested-quantifier shape above does not catch them (no inner quantifier). Kept
-# conservative: a single `(...)` (no inner parens) with a `|`, then a quantifier.
-_REGEX_ALTERNATION_OVERLAP = re.compile(r"\([^()]*\|[^()]*\)\s*[+*{]")
-
-# Multi-group adjacent quantified groups: (a+)(a+)+, (a+)(b+)*, (...)(...)+ -- two
-# back-to-back groups where the SECOND carries a trailing quantifier. The first
-# group's unbounded body and the quantified second group share input, so the engine
-# explores an exponential partition of the matched span. The single-group
-# _REGEX_NESTED_QUANTIFIER above misses this (the outer quantifier sits on a sibling
-# group, not the enclosing one). Each group body is paren-free (kept conservative).
-_REGEX_ADJACENT_GROUP_QUANTIFIER = re.compile(r"\([^()]*[+*][^()]*\)\([^()]*\)\s*[+*]")
-
-# Stacked bounded repeats: a{1000}{1000}, (x){500}{500}, [a-z]{50}{50} -- a `{m}`/`{m,n}`
-# repeat immediately followed by another `{...}`. Python's re multiplies the bounds, so a
-# pair of large counts is a polynomial/exponential blow-up with a tiny source string. A
-# group/atom (optionally already quantified) then two consecutive brace quantifiers.
-_REGEX_STACKED_BOUNDED_REPEAT = re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?:,\d*)?\}")
-
-# Complexity-budget backstop: cap the combined count of unbounded quantifiers (`+`/`*`,
-# unescaped) and alternations (`|`, unescaped) in one pattern. The structural regexes
-# above catch KNOWN bad shapes; this catches novel compositions of many quantifiers /
-# alternatives that together create a large backtracking surface even when no single
-# pair matches a structural template. The threshold (12) is generous: realistic ABP/DNS
-# feed regex carries a handful of anchors + one or two trailing quantifiers (a domain
-# pattern like `^(.+\.)?ads?[0-9]*\.example\.(com|net|org)$` counts ~5), so 12 clears
-# every benign pattern in the corpus while still bounding adversarial stacking.
-_REGEX_BUDGET_MAX = 12
-_REGEX_UNBOUNDED_QUANTIFIER = re.compile(r"(?<!\\)[+*]")
-_REGEX_ALTERNATION = re.compile(r"(?<!\\)\|")
+# The catastrophic-shape gate, the complexity budget, and REGEX_STATIC_LEN_CAP
+# live in pfb_dnsbl_regex_rules.py (issue #1765), imported above.
 
 # Runtime warn/evict ceilings (milliseconds of per-match thread CPU; measured
 # defaults, ADR.md SS2). Overridable via the pfb_unbound.ini MAIN section
@@ -4881,29 +4820,6 @@ def _build_regex_index(
                 buckets[ch] = []
             buckets[ch].append((name, lit))
     return buckets, always
-
-
-def _regex_is_catastrophic_shape(pattern: str) -> bool:
-    """Pure static analysis (NO execution): True when ``pattern`` carries a structurally
-    catastrophic shape -- a nested / adjacent / overlapping unbounded quantifier, a
-    stacked bounded repeat, or so many unbounded quantifiers + alternations combined that
-    its backtracking surface is unsafe. This is the SAFETY gate: it is applied to FEED and
-    user regex UNCONDITIONALLY at load (independent of the opt-in length cap) because these
-    shapes drive catastrophic backtracking in the `re` engine. It only inspects the pattern
-    STRING -- it never runs the candidate against any input -- so it is itself cheap and
-    safe. Length is deliberately NOT part of this gate (a long pattern is not inherently
-    catastrophic; the length ceiling is the separate opt-in convenience cap)."""
-    if _REGEX_NESTED_QUANTIFIER.search(pattern) is not None:
-        return True
-    if _REGEX_ALTERNATION_OVERLAP.search(pattern) is not None:
-        return True
-    if _REGEX_ADJACENT_GROUP_QUANTIFIER.search(pattern) is not None:
-        return True
-    if _REGEX_STACKED_BOUNDED_REPEAT.search(pattern) is not None:
-        return True
-    # Budget backstop: total unbounded quantifiers + alternations over the threshold.
-    budget = len(_REGEX_UNBOUNDED_QUANTIFIER.findall(pattern)) + len(_REGEX_ALTERNATION.findall(pattern))
-    return budget > _REGEX_BUDGET_MAX
 
 
 def _regex_timed_search(pattern: Any, q_name: str) -> tuple[Any, float]:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7769,6 +7769,7 @@ function pfb_unbound_dnsbl($mode) {
 			exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache stage >/dev/null 2>&1');
 		} else {
 			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
+			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_dnsbl_regex_rules.py");
 			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
 			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
 			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_tld.txt");
@@ -17739,6 +17740,7 @@ function pfblockerng_php_pre_deinstall_command() {
 	}
 
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
+	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_dnsbl_regex_rules.py");
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
 	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_tld.txt");

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -334,7 +334,7 @@ dnsbl_cache() {
 	pathtar="${pathtar:-/usr/bin/tar}"
 
 	# The shipped (static) DNSBL python files -- the ONE definition of the set.
-	PFB_PY_SHIPPED='pfb_unbound.py pfb_unbound_include.inc pfb_py_hsts.txt'
+	PFB_PY_SHIPPED='pfb_unbound.py pfb_dnsbl_regex_rules.py pfb_unbound_include.inc pfb_py_hsts.txt'
 
 	dnsbl_cache_stage() {
 		mkdir -p "${pfbchroot}"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -322,9 +322,12 @@ aliastables() {
 # (re-run on every save/restore, never restored stale); save = stage then archive the
 # GENERATED set plus exact TOP1M detector sidecars; restore = boot earlyshellcmd, untar
 # the cached files THEN stage. Naming contract: a new generated file MUST keep the
-# pfb_unbound*/pfb_py_* prefix; a new shipped file goes in PFB_PY_SHIPPED + pkg-plist wiring
-# (a NAME-MAPPED shipped file -- source basename != chroot basename -- is the sole
-# exception: it needs its own explicit stage/save handling instead; see pfb_py_tld.txt).
+# pfb_unbound*/pfb_py_* prefix; a new shipped file goes in PFB_PY_SHIPPED and in the two
+# chroot teardown lists in pfblockerng.inc (the port's plist is GENERATED from the stagedir,
+# so packaging needs nothing) -- a NAME-MAPPED shipped file (source basename != chroot
+# basename) is the sole exception: it needs its own explicit stage/save handling instead;
+# see pfb_py_tld.txt. Order matters: a module goes BEFORE the file that imports it, so a
+# load racing the staging loop never sees the importer without its dependency.
 dnsbl_cache() {
 	# Overridable for unit tests; default to the live locations.
 	pfbchroot="${pfbchroot:-/var/unbound}"
@@ -334,7 +337,7 @@ dnsbl_cache() {
 	pathtar="${pathtar:-/usr/bin/tar}"
 
 	# The shipped (static) DNSBL python files -- the ONE definition of the set.
-	PFB_PY_SHIPPED='pfb_unbound.py pfb_dnsbl_regex_rules.py pfb_unbound_include.inc pfb_py_hsts.txt'
+	PFB_PY_SHIPPED='pfb_dnsbl_regex_rules.py pfb_unbound.py pfb_unbound_include.inc pfb_py_hsts.txt'
 
 	dnsbl_cache_stage() {
 		mkdir -p "${pfbchroot}"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2556,8 +2556,8 @@ const PFB_REGEX_DESCRIPTION_MAX = 15;
  * way to re.compile().
  *
  * Twins that must agree, each with its own tests: pfb_split_regex_line() in
- * pfb_unbound.py (the resolver's load path), the split_line() helper inside this
- * file's validator probe, and the Pattern/Comment token pair in
+ * pfb_dnsbl_regex_rules.py (the ONE Python copy -- the resolver imports it and this
+ * file's validator probe runs it), and the Pattern/Comment token pair in
  * tools/webassets/lezer-pfb-regex-list/src/pfb-regex-list.grammar (the editor).
  *
  * @return array{0: string, 1: ?string} [pattern, description]; description NULL
@@ -2637,9 +2637,11 @@ function pfb_dnsbl_regex_description_warnings(string $contents): array
  *
  * @param bool $regex_cap Mirrors the "Limit long/complex regex" toggle: gates the
  *     save-time length-cap diagnostic so it agrees with the resolver's load-time drop.
+ * @param ?string $script Test seam, like $python and $timeout_bin: NULL resolves the
+ *     shipped module beside this file, which is what production always uses.
  * @return array<int, string> Non-empty validation or infrastructure diagnostics.
  */
-function pfb_dnsbl_regex_validation_errors(string $contents, string $python, bool $regex_cap, string $timeout_bin = '/usr/bin/timeout'): array
+function pfb_dnsbl_regex_validation_errors(string $contents, string $python, bool $regex_cap, string $timeout_bin = '/usr/bin/timeout', ?string $script = NULL): array
 {
 	if ($contents === '') {
 		return [];
@@ -2650,8 +2652,10 @@ function pfb_dnsbl_regex_validation_errors(string $contents, string $python, boo
 	if ($timeout_bin === '' || !is_executable($timeout_bin)) {
 		return ['Python regex validator: timeout launcher unavailable'];
 	}
-	$script = __DIR__ . '/pfb_dnsbl_regex_rules.py';
-	if (!is_readable($script)) {
+	$script = $script ?? __DIR__ . '/pfb_dnsbl_regex_rules.py';
+	// is_file() as well as is_readable(): a directory is readable, and handing one to
+	// the interpreter would surface a generic launcher diagnostic instead of this one.
+	if (!is_file($script) || !is_readable($script)) {
 		return ['Python regex validator: rules module unavailable'];
 	}
 	$stderr = tmpfile();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2632,6 +2632,8 @@ function pfb_dnsbl_regex_description_warnings(string $contents): array
 /**
  * pfb_dnsbl_regex_validation_errors — validate the DNSBL regex form in one
  * bounded Python pass, preserving source line numbers and resolver semantics.
+ * Runs pfb_dnsbl_regex_rules.py (issue #1765) as the save-time probe -- the
+ * SAME module pfb_unbound.py imports, not a duplicated nowdoc.
  *
  * @param bool $regex_cap Mirrors the "Limit long/complex regex" toggle: gates the
  *     save-time length-cap diagnostic so it agrees with the resolver's load-time drop.
@@ -2648,78 +2650,16 @@ function pfb_dnsbl_regex_validation_errors(string $contents, string $python, boo
 	if ($timeout_bin === '' || !is_executable($timeout_bin)) {
 		return ['Python regex validator: timeout launcher unavailable'];
 	}
+	$script = __DIR__ . '/pfb_dnsbl_regex_rules.py';
+	if (!is_readable($script)) {
+		return ['Python regex validator: rules module unavailable'];
+	}
 	$stderr = tmpfile();
 	if ($stderr === FALSE) {
 		return ['Python regex validator: unable to create diagnostics file'];
 	}
 	$stderr_path = stream_get_meta_data($stderr)['uri'];
-	$probe = <<<'PYTHON'
-import re
-import sys
-
-shapes = (
-    re.compile(r"\([^()]*[+*][^()]*\)\s*[+*{]"),  # _REGEX_NESTED_QUANTIFIER mirror (pfb_unbound.py)
-    re.compile(r"\([^()]*\|[^()]*\)\s*[+*{]"),  # _REGEX_ALTERNATION_OVERLAP mirror (pfb_unbound.py)
-    re.compile(r"\([^()]*[+*][^()]*\)\([^()]*\)\s*[+*]"),  # _REGEX_ADJACENT_GROUP_QUANTIFIER mirror (pfb_unbound.py)
-    re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?:,\d*)?\}"),  # _REGEX_STACKED_BOUNDED_REPEAT mirror (pfb_unbound.py)
-)
-
-failed = False
-
-def report(line_number, pattern, message):
-    print(f"line {line_number}: {pattern!r}: {message}", file=sys.stderr)
-
-regex_cap = len(sys.argv) > 1 and sys.argv[1] == "1"
-
-
-def split_line(line):
-    # issue #1867 mirror of pfb_split_regex_line() (PHP) and pfb_unbound.py's
-    # twin: the description starts at the first '#' preceded by an EVEN number
-    # of backslashes, so an escaped "\#" stays in the pattern.
-    backslashes = 0
-    for index, character in enumerate(line):
-        if character == "\\":
-            backslashes += 1
-            continue
-        if character == "#" and backslashes % 2 == 0:
-            return line[:index]
-        backslashes = 0
-    return line
-
-
-for line_number, line in enumerate(sys.stdin, start=1):
-    line = line.rstrip("\r\n")
-    if not line.strip() or line.lstrip().startswith("#"):
-        continue
-    pattern = split_line(line).strip().lower()
-    if not pattern:
-        continue
-    if any(ord(character) < 0x20 or ord(character) == 0x7f for character in pattern):
-        report(line_number, pattern, "contains ASCII control character")
-        failed = True
-        continue
-    if any(shape.search(pattern) is not None for shape in shapes):
-        report(line_number, pattern, "catastrophic-backtracking shape")
-        failed = True
-        continue
-    budget = len(re.findall(r"(?<!\\)[+*]", pattern)) + len(re.findall(r"(?<!\\)\|", pattern))  # _REGEX_UNBOUNDED_QUANTIFIER + _REGEX_ALTERNATION mirror (pfb_unbound.py)
-    if budget > 12:  # _REGEX_BUDGET_MAX mirror (pfb_unbound.py)
-        report(line_number, pattern, "too many quantifiers/alternations")
-        failed = True
-        continue
-    if regex_cap and len(pattern) > 200:  # REGEX_STATIC_LEN_CAP mirror (pfb_unbound.py)
-        report(line_number, pattern, 'over the 200-character length cap ("Limit long/complex regex")')
-        failed = True
-        continue
-    try:
-        re.compile(pattern)
-    except Exception as error:
-        report(line_number, pattern, f"Python regex compile error: {error}")
-        failed = True
-
-raise SystemExit(1 if failed else 0)
-PYTHON;
-	$command = array($timeout_bin, '-s', 'TERM', '-k', '1', '5', $python, '-c', $probe, $regex_cap ? '1' : '0');
+	$command = array($timeout_bin, '-s', 'TERM', '-k', '1', '5', $python, $script, $regex_cap ? '1' : '0');
 	$descriptors = array(
 		0 => array('pipe', 'r'),
 		1 => array('file', '/dev/null', 'w'),

--- a/tests/php/DnsblRegexEntryErrorTest.php
+++ b/tests/php/DnsblRegexEntryErrorTest.php
@@ -237,6 +237,24 @@ final class DnsblRegexEntryErrorTest extends TestCase
 		$this->assertStringContainsString('Python', implode('\n', $missingTimeout));
 	}
 
+	public function testMissingRulesModuleFailsClosedWithoutSpawningAPythonProcess(): void
+	{
+		// issue #1765: the probe is now a shipped script ($script = __DIR__ .
+		// '/pfb_dnsbl_regex_rules.py'), not an embedded nowdoc -- pin the guard
+		// that fires when it is absent/unreadable. The real shipped file is
+		// never deleted: rename it out of the way for the duration of the call.
+		$script = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py';
+		$this->assertFileIsReadable($script);
+		$hidden = $script . '.hidden-for-test';
+		$this->assertTrue(rename($script, $hidden));
+		try {
+			$errors = self::errors("^ads\\.example\\.com$\n");
+		} finally {
+			$this->assertTrue(rename($hidden, $script));
+		}
+		$this->assertSame(['Python regex validator: rules module unavailable'], $errors);
+	}
+
 	public function testBatchUsesOnePythonLaunch(): void
 	{
 		$dir = sys_get_temp_dir() . '/pfb_regex_wrapper_' . getmypid() . '_' . bin2hex(random_bytes(3));
@@ -403,15 +421,13 @@ final class DnsblRegexEntryErrorTest extends TestCase
 
 	public function testProbeDefaultsCapOffWhenTheArgvFlagIsAbsent(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
-		$source = file_get_contents($path);
-		$this->assertNotFalse($source);
-		$this->assertMatchesRegularExpression("/\\\$probe = <<<'PYTHON'\\n(.*?)\\nPYTHON;/s", $source);
-		preg_match("/\\\$probe = <<<'PYTHON'\\n(.*?)\\nPYTHON;/s", $source, $matches);
-		$probe = $matches[1];
+		// issue #1765: the probe is the shipped pfb_dnsbl_regex_rules.py script now,
+		// not an embedded nowdoc -- invoke it directly, with no argv[1].
+		$script = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py';
+		$this->assertFileIsReadable($script);
 
 		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
-		$process = proc_open([self::$python, '-c', $probe], $descriptors, $pipes);
+		$process = proc_open([self::$python, $script], $descriptors, $pipes);
 		$this->assertIsResource($process);
 		fwrite($pipes[0], self::anchoredPattern(300) . "\n");
 		fclose($pipes[0]);

--- a/tests/php/DnsblRegexEntryErrorTest.php
+++ b/tests/php/DnsblRegexEntryErrorTest.php
@@ -38,13 +38,14 @@ final class DnsblRegexEntryErrorTest extends TestCase
 	}
 
 	/** @return array<int, string> */
-	private static function errors(string $contents, bool $regexCap = FALSE, ?string $python = null, ?string $timeout = null): array
+	private static function errors(string $contents, bool $regexCap = FALSE, ?string $python = null, ?string $timeout = null, ?string $script = null): array
 	{
 		return pfb_dnsbl_regex_validation_errors(
 			$contents,
 			$python ?? self::$python,
 			$regexCap,
-			$timeout ?? self::$timeout
+			$timeout ?? self::$timeout,
+			$script
 		);
 	}
 
@@ -237,22 +238,37 @@ final class DnsblRegexEntryErrorTest extends TestCase
 		$this->assertStringContainsString('Python', implode('\n', $missingTimeout));
 	}
 
-	public function testMissingRulesModuleFailsClosedWithoutSpawningAPythonProcess(): void
+	public function testMissingRulesModuleFailsClosed(): void
 	{
-		// issue #1765: the probe is now a shipped script ($script = __DIR__ .
-		// '/pfb_dnsbl_regex_rules.py'), not an embedded nowdoc -- pin the guard
-		// that fires when it is absent/unreadable. The real shipped file is
-		// never deleted: rename it out of the way for the duration of the call.
-		$script = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py';
-		$this->assertFileIsReadable($script);
-		$hidden = $script . '.hidden-for-test';
-		$this->assertTrue(rename($script, $hidden));
+		// issue #1765: the probe is a shipped script now, not an embedded nowdoc --
+		// pin the guard that fires when it is absent. Injected through the same
+		// test seam the interpreter and the timeout launcher already use, so the
+		// tracked production file is never touched (an interrupted run must not be
+		// able to leave the shipped module renamed out of the tree).
+		$missing = sys_get_temp_dir() . '/pfb_absent_rules_' . bin2hex(random_bytes(6)) . '.py';
+		$this->assertFileDoesNotExist($missing);
+		$this->assertSame(
+			['Python regex validator: rules module unavailable'],
+			self::errors("^ads\\.example\\.com$\n", FALSE, null, null, $missing)
+		);
+	}
+
+	public function testUnusableRulesModulePathFailsClosedInsteadOfSpawningPython(): void
+	{
+		// A DIRECTORY is readable, so an is_readable()-only guard would fall through
+		// and hand the path to the interpreter, surfacing a generic launcher/exit
+		// diagnostic instead of the specific one. The guard must require a FILE.
+		$directory = sys_get_temp_dir() . '/pfb_rules_dir_' . bin2hex(random_bytes(6));
+		$this->assertTrue(mkdir($directory));
 		try {
-			$errors = self::errors("^ads\\.example\\.com$\n");
+			$this->assertDirectoryIsReadable($directory);
+			$this->assertSame(
+				['Python regex validator: rules module unavailable'],
+				self::errors("^ads\\.example\\.com$\n", FALSE, null, null, $directory)
+			);
 		} finally {
-			$this->assertTrue(rename($hidden, $script));
+			rmdir($directory);
 		}
-		$this->assertSame(['Python regex validator: rules module unavailable'], $errors);
 	}
 
 	public function testBatchUsesOnePythonLaunch(): void

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -1896,6 +1896,13 @@
                 "variadic": false,
                 "type": "string",
                 "default": "'/usr/bin/timeout'"
+            },
+            {
+                "name": "script",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
             }
         ]
     },

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -43,6 +43,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     mkdir -p "${pfbpkgdir}" "${pfbdb}"
     # The shipped files (current code in /usr/local).
     echo 'PY-CODE-v1' > "${pfbpkgdir}/pfb_unbound.py"
+    echo 'RULES-CODE-v1' > "${pfbpkgdir}/pfb_dnsbl_regex_rules.py"
     echo 'INC-CODE-v1' > "${pfbpkgdir}/pfb_unbound_include.inc"
     echo 'HSTS-v1' > "${pfbpkgdir}/pfb_py_hsts.txt"
     # issue #1255: the TLD-Wildcard public-suffix oracle -- name-mapped (source
@@ -87,6 +88,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     When call dc stage
     # The shipped files landed in the chroot.
     The path "${pfbchroot}/pfb_unbound.py" should be exist
+    The path "${pfbchroot}/pfb_dnsbl_regex_rules.py" should be exist
     The path "${pfbchroot}/pfb_unbound_include.inc" should be exist
     The path "${pfbchroot}/pfb_py_hsts.txt" should be exist
     # The mount-point dirs exist (the fresh-MFS fix).
@@ -158,6 +160,10 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     # ... and NOT the shipped files (re-staged from /usr/local on restore).
     The result of "tar_list()" should not include 'pfb_py_hsts.txt'
     The result of "tar_list()" should not include 'pfb_unbound_include.inc'
+    # ... nor pfb_dnsbl_regex_rules.py (issue #1765): its basename matches
+    # neither the pfb_unbound*/pfb_py_* archive glob, so it is shipped, not
+    # generated -- re-staged from /usr/local on restore, same as the others.
+    The result of "tar_list()" should not include 'pfb_dnsbl_regex_rules.py'
     # ... nor the name-mapped TLD oracle (issue #1255: matches the pfb_py_* glob
     # but is shipped, not generated -- archiving it would reinstate a stale oracle).
     The result of "tar_list()" should not include 'pfb_py_tld.txt'

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -262,8 +262,8 @@ class DnsblCase:
                        len > REGEX_STATIC_LEN_CAP check), so it never enters regexDB
                        or the admitted count. Catastrophic shapes (nested-quantifier
                        / alternation-overlap) are dropped always-on via
-                       pfb_unbound.py:_regex_is_catastrophic_shape, independent of
-                       this flag.
+                       pfb_dnsbl_regex_rules.py:_regex_is_catastrophic_shape (which
+                       pfb_unbound.py imports), independent of this flag.
       custom_domains -> the DNSBL Group "Custom_List" (the list's base64 'custom'
                        field). pfBlockerNG auto-generates a synthetic
                        '{aliasname}_custom' row from it (inc:7752) which the manifest

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3059,7 +3059,8 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
     if spec.regex_cap:
         # Opt-in length cap (inc:2685 -> ini regex_cap=on). Drops over-LENGTH feed AND
         # user regex at load. The catastrophic-SHAPE gate is separate and ALWAYS on
-        # (pfb_unbound.py:_regex_is_catastrophic_shape), independent of this flag.
+        # (pfb_dnsbl_regex_rules.py:_regex_is_catastrophic_shape, imported by
+        # pfb_unbound.py), independent of this flag.
         settings["pfb_regex_cap"] = "on"
     if spec.cname_validation:
         # "CNAME Validation" (inc:852 -> ini python_cname). Walk a resolved answer's

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -27,12 +27,12 @@ design accepts but the tests must not pay).
 
 from __future__ import annotations
 
-import ast
 import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+import pfb_dnsbl_regex_rules
 import pfb_unbound
 from pfb_unbound import (
     DNSBL_KIND_BLOCK,
@@ -151,7 +151,7 @@ class TestCatastrophicShapeHeuristic:
     def test_complexity_budget_backstop_flagged(self) -> None:
         # A pattern with no single matching structural template but a large combined
         # count of unbounded quantifiers + alternations is caught by the budget backstop.
-        over_budget = "".join(f"a{i}*|" for i in range(pfb_unbound._REGEX_BUDGET_MAX + 2))
+        over_budget = "".join(f"a{i}*|" for i in range(pfb_dnsbl_regex_rules._REGEX_BUDGET_MAX + 2))
         assert _regex_is_catastrophic_shape(over_budget) is True
 
     def test_complexity_budget_at_threshold_not_flagged(self) -> None:
@@ -160,12 +160,12 @@ class TestCatastrophicShapeHeuristic:
         # would flag this). Build a pattern whose budget is EXACTLY MAX -- `_REGEX_BUDGET_MAX`
         # unbounded `*` quantifiers, zero alternations, and no other catastrophic shape (no
         # nested/adjacent quantified group, no stacked bounded repeat).
-        at_budget = "a*" * pfb_unbound._REGEX_BUDGET_MAX
+        at_budget = "a*" * pfb_dnsbl_regex_rules._REGEX_BUDGET_MAX
         # Compute the budget the SAME way the code does and pin it to MAX before asserting.
-        budget = len(pfb_unbound._REGEX_UNBOUNDED_QUANTIFIER.findall(at_budget)) + len(
-            pfb_unbound._REGEX_ALTERNATION.findall(at_budget)
+        budget = len(pfb_dnsbl_regex_rules._REGEX_UNBOUNDED_QUANTIFIER.findall(at_budget)) + len(
+            pfb_dnsbl_regex_rules._REGEX_ALTERNATION.findall(at_budget)
         )
-        assert budget == pfb_unbound._REGEX_BUDGET_MAX
+        assert budget == pfb_dnsbl_regex_rules._REGEX_BUDGET_MAX
         assert _regex_is_catastrophic_shape(at_budget) is False
 
     # --- false-positive guard: realistic benign feed regex must NOT be flagged ----- #
@@ -266,129 +266,32 @@ class TestStaticCapAtLoad:
         assert cap_on.regex_count < cap_off.regex_count
 
 
-def test_save_time_probe_length_cap_matches_runtime_constant() -> None:
-    """Issue #1688 parity: pfblockerng_extra.inc's embedded save-time probe rejects a
-    pattern the SAME length that this module's REGEX_STATIC_LEN_CAP drops at load, so
-    the save-time verdict cannot silently drift from the resolver's."""
-    inc_path = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
-    source = inc_path.read_text()
-    match = re.search(r"len\(pattern\)\s*>\s*(\d+):\s*#\s*REGEX_STATIC_LEN_CAP", source)
-    assert match is not None, (
-        "expected the PHP probe's length-cap comparison, tagged '# REGEX_STATIC_LEN_CAP', in pfblockerng_extra.inc"
-    )
-    php_cap = int(match.group(1))
-    runtime_cap = pfb_unbound.REGEX_STATIC_LEN_CAP
-    assert php_cap == runtime_cap, f"probe cap={php_cap} != pfb_unbound.REGEX_STATIC_LEN_CAP={runtime_cap}"
-
-
 # --------------------------------------------------------------------------- #
-# Issue #1711: extend #1688 parity pinning to EVERY rule the save-time probe
-# duplicates from the resolver -- the four shape literals, the two budget
-# literals, the budget threshold, the length-cap comparator strictness, and the
-# runtime's exact-boundary admission behaviour.
+# Issue #1765: the admission rules moved to pfb_dnsbl_regex_rules.py, imported
+# by pfb_unbound.py -- ONE literal now, not two, so the #1688/#1711 duplication
+# pins above (deleted) are unsatisfiable and their drift class cannot occur.
+# This pin replaces them: pfb_unbound's imported names are the SAME objects as
+# the module's, not a copy.
 # --------------------------------------------------------------------------- #
-def _probe_source() -> str:
-    """Extract pfblockerng_extra.inc's embedded save-time probe nowdoc verbatim (the
-    text between <<<'PYTHON' and the closing PYTHON; delimiter) so probe/runtime parity
-    is pinned against the actual nowdoc bytes. Anchored past the function name because a
-    second, unrelated nowdoc probe exists later in the file."""
-    inc_path = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
-    source = inc_path.read_text()
-    anchor = source.index("function pfb_dnsbl_regex_validation_errors")
-    match = re.search(r"<<<'PYTHON'\n(.*?)\nPYTHON;", source[anchor:], re.S)
-    assert match is not None, "expected the probe's <<<'PYTHON' nowdoc after pfb_dnsbl_regex_validation_errors"
-    return match.group(1)
-
-
-_PROBE_SINGLE_TAG_RE = re.compile(r'r"((?:[^"\\]|\\.)*)"\s*\)?,?\s*#\s*(_REGEX_\w+) mirror \(pfb_unbound\.py\)')
-_PROBE_COMBINED_TAG_RE = re.compile(r"#\s*(_REGEX_\w+)\s*\+\s*(_REGEX_\w+) mirror \(pfb_unbound\.py\)")
-
-
-def _runtime_admission_regex_names() -> set[str]:
-    """Issue #1711 completeness pin: the set of module-level `_REGEX_*` compiled
-    patterns actually used as admission checks inside `_regex_is_catastrophic_shape`
-    -- the shape patterns invoked via `.search(` plus the budget patterns invoked via
-    `.findall(` in that same function's complexity-budget backstop.
-
-    Extracted from the FUNCTION BODY TEXT (anchored on the `def` line, not a
-    hardcoded name list and not a line-number offset) so this stays robust to
-    unrelated edits elsewhere in the file: a NEW `_REGEX_*` pattern wired into the
-    guard via `.search(`/`.findall(` is picked up automatically, and the parity
-    test below then requires the probe to tag-mirror it too -- a 7th runtime shape
-    added without a matching probe tag makes this set diverge from the probe's
-    tagged literals and fails loudly instead of the previous hardcoded six staying
-    silently in sync with nothing."""
-    unbound_path = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfb_unbound.py"
-    source = unbound_path.read_text()
-    start = source.index("def _regex_is_catastrophic_shape")
-    next_def = re.search(r"\ndef ", source[start + 1 :])
-    body = source[start : start + 1 + next_def.start()] if next_def else source[start:]
-    names = set(re.findall(r"(_REGEX_\w+)\.(?:search|findall)\(", body))
-    assert names, "expected at least one _REGEX_*.search(/.findall( admission check in _regex_is_catastrophic_shape"
-    return names
-
-
-def test_probe_regex_literals_match_runtime_shape_and_budget_patterns() -> None:
-    """Issue #1711: every regex LITERAL the save-time probe duplicates from the
-    resolver's shape gate + complexity budget is tagged '<name> mirror (pfb_unbound.py)'
-    in the probe source. Extract each tagged literal and assert it is byte-identical to
-    the runtime pattern of the same name -- and that the tagged set is EXACTLY the set
-    of `_REGEX_*` patterns `_regex_is_catastrophic_shape` actually consults (extracted
-    from source, not hardcoded -- see `_runtime_admission_regex_names()`), so a
-    renamed/added/removed runtime pattern that forgets to update the probe tag fails
-    loudly instead of silently drifting."""
-    probe = _probe_source()
-
-    literals: dict[str, str] = {}
-    for match in _PROBE_SINGLE_TAG_RE.finditer(probe):
-        literals[match.group(2)] = match.group(1)
-
-    combined = _PROBE_COMBINED_TAG_RE.search(probe)
-    assert combined is not None, "expected the combined budget-literal tag comment in the probe"
-    combined_line = next(line for line in probe.splitlines() if combined.group(0) in line)
-    raw_literals = re.findall(r'r"((?:[^"\\]|\\.)*)"', combined_line)
-    assert len(raw_literals) == 2, (
-        f"expected exactly 2 raw-string literals on the combined-tag line, got {raw_literals}"
-    )
-    literals[combined.group(1)] = raw_literals[0]
-    literals[combined.group(2)] = raw_literals[1]
-
-    expected_names = _runtime_admission_regex_names()
-    assert set(literals) == expected_names, (
-        f"probe mirror tags drifted: extracted={sorted(literals)} expected={sorted(expected_names)}"
-    )
-
-    for name, raw in literals.items():
-        pattern = ast.literal_eval(f'r"{raw}"')
-        runtime_pattern = getattr(pfb_unbound, name).pattern
-        assert pattern == runtime_pattern, f"{name}: probe={pattern!r} != runtime={runtime_pattern!r}"
-
-
-def test_probe_budget_threshold_matches_runtime_budget_max() -> None:
-    """Issue #1711: the probe's complexity-budget threshold (tagged '_REGEX_BUDGET_MAX
-    mirror') must match pfb_unbound._REGEX_BUDGET_MAX, and the comparison on both sides
-    must be a STRICT '>' -- a '>=' regression would silently shift the admissible budget
-    down by one."""
-    probe = _probe_source()
-    match = re.search(r"if budget > (\d+):\s*#\s*_REGEX_BUDGET_MAX mirror \(pfb_unbound\.py\)", probe)
-    assert match is not None, "expected the probe's tagged budget threshold comparison"
-    probe_budget_max = int(match.group(1))
-    assert probe_budget_max == pfb_unbound._REGEX_BUDGET_MAX, (
-        f"probe budget max={probe_budget_max} != pfb_unbound._REGEX_BUDGET_MAX={pfb_unbound._REGEX_BUDGET_MAX}"
-    )
-    assert "budget >=" not in probe, "probe budget threshold regressed from strict '>' to '>='"
+def test_pfb_unbound_reexports_are_the_same_objects_as_pfb_dnsbl_regex_rules() -> None:
+    for name in ("REGEX_STATIC_LEN_CAP", "_regex_is_catastrophic_shape", "pfb_split_regex_line"):
+        assert getattr(pfb_unbound, name) is getattr(pfb_dnsbl_regex_rules, name), (
+            f"pfb_unbound.{name} is not the same object as pfb_dnsbl_regex_rules.{name} -- single-source broken"
+        )
 
 
 def test_runtime_length_cap_comparator_is_strict_at_every_site() -> None:
-    """Issue #1711: pin the runtime's exact-200-character admission boundary. All three
-    REGEX_STATIC_LEN_CAP comparisons in pfb_unbound.py (the build-time compile helper
-    plus the two save-time www/ probes) use a STRICT '>' -- a '>=' regression at any site
-    would silently drop a pattern exactly at the cap, which the resolver, this probe, and
-    the PHP DnsblRegexEntryErrorTest suite all admit."""
+    """Issue #1711/#1765: pin the runtime's exact-200-character admission boundary. All
+    FOUR REGEX_STATIC_LEN_CAP comparisons -- the three call sites left in pfb_unbound.py
+    (the build-time compile helper plus the two save-time-mirroring load paths) and the
+    one inside pfb_dnsbl_regex_rules.py's save-time probe ``main()`` -- use a STRICT '>':
+    a '>=' regression at any site would silently drop a pattern exactly at the cap, which
+    the resolver, the probe, and the PHP DnsblRegexEntryErrorTest suite all admit."""
     unbound_path = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfb_unbound.py"
-    source = unbound_path.read_text()
+    rules_path = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py"
+    source = unbound_path.read_text() + "\n" + rules_path.read_text()
     strict = re.findall(r"len\([^)\n]*\)\s*>\s*REGEX_STATIC_LEN_CAP", source)
-    assert len(strict) == 3, f"expected exactly 3 strict '>' comparisons, found {len(strict)}: {strict}"
+    assert len(strict) == 4, f"expected exactly 4 strict '>' comparisons, found {len(strict)}: {strict}"
     non_strict = re.findall(r"len\([^)\n]*\)\s*>=\s*REGEX_STATIC_LEN_CAP", source)
     assert non_strict == [], f"found a non-strict '>=' REGEX_STATIC_LEN_CAP comparison: {non_strict}"
 

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -274,6 +274,10 @@ class TestStaticCapAtLoad:
 # the module's, not a copy.
 # --------------------------------------------------------------------------- #
 def test_pfb_unbound_reexports_are_the_same_objects_as_pfb_dnsbl_regex_rules() -> None:
+    # Known limit of the `is` check on REGEX_STATIC_LEN_CAP: CPython interns small ints,
+    # so a re-introduced duplicate literal of the SAME value would still pass here. That
+    # case is behaviourally identical, and any DIFFERING value (the drift that matters)
+    # fails, as does a re-defined function -- both mutation-checked.
     for name in ("REGEX_STATIC_LEN_CAP", "_regex_is_catastrophic_shape", "pfb_split_regex_line"):
         assert getattr(pfb_unbound, name) is getattr(pfb_dnsbl_regex_rules, name), (
             f"pfb_unbound.{name} is not the same object as pfb_dnsbl_regex_rules.{name} -- single-source broken"

--- a/tests/test_dnsbl_chroot_teardown_parity.py
+++ b/tests/test_dnsbl_chroot_teardown_parity.py
@@ -1,0 +1,85 @@
+"""Every shipped DNSBL Python file staged into Unbound's chroot must also be torn
+down when DNSBL Python mode is disabled and when the package is uninstalled.
+
+`dnsbl_cache stage` in pfblockerng.sh owns the shipped-file set as ONE list
+(``PFB_PY_SHIPPED``) and pfblockerng.inc's *enable* branch defers to it by shelling
+out. The *teardown* side does not: `pfb_unbound_dnsbl()`'s disable branch and
+`pfblockerng_php_pre_deinstall_command()` each carry their own hardcoded
+`unlink_if_exists()` list, so a newly shipped file is staged into `/var/unbound` by
+the single source and then left orphaned there by both teardown paths.
+
+Issue #1765 hit exactly that: `pfb_dnsbl_regex_rules.py` was added to
+``PFB_PY_SHIPPED`` and neither teardown list. This pins the invariant until the
+teardown lists are derived from the single source too (tracked separately) --
+adding a file to ``PFB_PY_SHIPPED`` without updating both lists fails here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PKG_DIR = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng"
+SHELL = PKG_DIR / "pfblockerng.sh"
+INC = PKG_DIR / "pfblockerng.inc"
+
+# The TLD-Wildcard oracle is shipped under a DIFFERENT name than its chroot copy
+# (issue #1255: source basename 'dnsbl_tld', chroot copy 'pfb_py_tld.txt'), so it is
+# deliberately absent from PFB_PY_SHIPPED while still needing teardown. It is listed
+# here so the teardown lists can be checked for it too, not just for the shipped set.
+NAME_MAPPED_CHROOT_FILES = ("pfb_py_tld.txt",)
+
+
+def _shipped_files() -> list[str]:
+    """The basenames in pfblockerng.sh's PFB_PY_SHIPPED -- the single source of the
+    shipped (static) DNSBL python file set."""
+    match = re.search(r"^\s*PFB_PY_SHIPPED='([^']*)'", SHELL.read_text(), re.MULTILINE)
+    assert match is not None, "PFB_PY_SHIPPED assignment not found in pfblockerng.sh"
+    files = match.group(1).split()
+    assert files, "PFB_PY_SHIPPED parsed as empty -- the parser, not the code, is wrong"
+    return files
+
+
+def _teardown_blocks() -> dict[str, set[str]]:
+    """Every run of consecutive ``unlink_if_exists("{$g['unbound_chroot_path']}/...")``
+    calls in pfblockerng.inc, keyed by the line number the run starts at, mapped to the
+    set of chroot basenames it removes."""
+    source = INC.read_text().splitlines()
+    call = re.compile(r"""unlink_if_exists\("\{\$g\['unbound_chroot_path'\]\}/([^"]+)"\)""")
+    blocks: dict[str, set[str]] = {}
+    current: set[str] = set()
+    start = 0
+    for number, line in enumerate(source, start=1):
+        found = call.search(line)
+        if found:
+            if not current:
+                start = number
+            current.add(found.group(1))
+        elif current:
+            blocks[f"pfblockerng.inc:{start}"] = current
+            current = set()
+    if current:
+        blocks[f"pfblockerng.inc:{start}"] = current
+    return blocks
+
+
+def test_both_chroot_teardown_lists_cover_every_shipped_python_file() -> None:
+    blocks = _teardown_blocks()
+    # The disable branch of pfb_unbound_dnsbl() and pfblockerng_php_pre_deinstall_command().
+    assert len(blocks) == 2, f"expected exactly 2 chroot teardown blocks, found: {sorted(blocks)}"
+
+    expected = set(_shipped_files()) | set(NAME_MAPPED_CHROOT_FILES)
+    for location, removed in blocks.items():
+        missing = expected - removed
+        assert not missing, (
+            f"{location}: staged into the chroot but never torn down: {sorted(missing)}. "
+            "Add an unlink_if_exists() line for each, or derive the list from PFB_PY_SHIPPED."
+        )
+
+
+def test_the_shipped_set_actually_reaches_the_parity_check() -> None:
+    """Guard against the check above passing vacuously: the shipped set must be
+    non-trivial and must really contain the resolver's own entry point."""
+    shipped = _shipped_files()
+    assert "pfb_unbound.py" in shipped
+    assert len(shipped) >= 3, shipped

--- a/tests/test_dnsbl_chroot_teardown_parity.py
+++ b/tests/test_dnsbl_chroot_teardown_parity.py
@@ -77,6 +77,15 @@ def test_both_chroot_teardown_lists_cover_every_shipped_python_file() -> None:
         )
 
 
+def test_an_imported_module_is_staged_before_the_file_that_imports_it() -> None:
+    """`pfb_unbound.py` imports `pfb_dnsbl_regex_rules` at module scope and
+    `dnsbl_cache_stage()` copies `PFB_PY_SHIPPED` in list order, so the dependency has
+    to be staged first: a resolver load landing between the two copies would otherwise
+    find the importer without its module and die with `ModuleNotFoundError`."""
+    shipped = _shipped_files()
+    assert shipped.index("pfb_dnsbl_regex_rules.py") < shipped.index("pfb_unbound.py"), shipped
+
+
 def test_the_shipped_set_actually_reaches_the_parity_check() -> None:
     """Guard against the check above passing vacuously: the shipped set must be
     non-trivial and must really contain the resolver's own entry point."""

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -11,6 +11,7 @@ pinned in DnsblRegexEntryErrorTest -- not duplicated here.
 
 from __future__ import annotations
 
+import itertools
 import os
 import subprocess
 import sys
@@ -65,6 +66,84 @@ def test_main_defaults_cap_off_when_argv_is_absent() -> None:
     proc = run_probe((pattern + "\n").encode("utf-8"))
     assert proc.returncode == 0, f"stderr: {proc.stderr!r}"
     assert proc.stderr == b""
+
+
+def test_main_reports_only_its_own_diagnostics_for_a_pattern_that_warns() -> None:
+    """A pattern that COMPILES but makes ``re`` emit a warning (e.g. ``[[a]]`` ->
+    FutureWarning "Possible nested set") must not add anything to stderr.
+
+    Every non-empty stderr line becomes an admin-facing validation error
+    (pfb_dnsbl_regex_validation_errors() -> $input_errors on pfblockerng_dnsbl.php,
+    and a line-1 lint diagnostic via pfb_lint_parse_regex_errors()). Running the
+    rules module as a FILE rather than ``python -c`` lets ``warnings`` resolve the
+    source, so an unsuppressed warning would leak BOTH this module's absolute path
+    and a bare ``re.compile(pattern)`` source line to the admin as bogus errors.
+    Only real ``line N:`` diagnostics may reach stderr.
+    """
+    # Line 1 warns but compiles (accepted); line 2 is a genuine rejection, so the
+    # process exits 1 and PHP reads stderr -- the case where a leak would surface.
+    proc = run_probe(b"[[a]]\n(a+)+\n", "0")
+    assert proc.returncode == 1
+    assert proc.stderr.decode("utf-8").splitlines() == ["line 2: '(a+)+': catastrophic-backtracking shape"], proc.stderr
+
+
+def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
+    """The save-time probe and the resolver's load-time gate are two INDEPENDENT
+    compositions over the shared literals: ``main()`` tests the shape and the budget
+    as two separate branches (it needs the two distinct diagnostics), while the
+    resolver calls the single composed ``_regex_is_catastrophic_shape``.
+
+    Sharing the literals only closes the literal-drift row. This closes the row the
+    #1711 parity tests actually existed for: a rule wired into one composition and
+    not the other silently reopens "the save page accepts it, the resolver drops it".
+    """
+    from pfb_dnsbl_regex_rules import (
+        _REGEX_BUDGET_MAX,
+        _regex_complexity_budget,
+        _regex_has_catastrophic_shape,
+        _regex_is_catastrophic_shape,
+    )
+
+    corpus = [
+        "^ads\\.example\\.com$",
+        "^(.+\\.)?ads?[0-9]*\\.example\\.(com|net|org)$",
+        "(a+)+",
+        "(a*)*",
+        "(\\w+\\.)+",
+        "(.*a){20}",
+        "(a|a)+",
+        "(foo|foobar)*",
+        "(a+)(a+)+",
+        "(a+)(b+)*",
+        "a{1000}{1000}",
+        "(x){500}{500}",
+        "[a-z]{50}{50}",
+        "|" * _REGEX_BUDGET_MAX,
+        "|" * (_REGEX_BUDGET_MAX + 1),
+        "+" * _REGEX_BUDGET_MAX,
+        "\\|" * (_REGEX_BUDGET_MAX + 2),
+        "^" + "a" * 300 + "$",
+        "",
+        "^$",
+    ]
+    # The hand-written rows above only cover rules that exist TODAY, so they cannot
+    # catch a FUTURE rule wired into one composition and not the other. Enumerate every
+    # 4-way combination of the regex building blocks a shape rule can be written over,
+    # so a new rule of ANY structural shape lands in this corpus. Combination, not
+    # random fuzz: a rule keyed on a 3-character construct like "(?:" is astronomically
+    # unlikely to be produced by random sampling, and would slip through unnoticed.
+    blocks = ("(", ")", "(?:", "[a-z]", "a", ".", "+", "*", "{2}", "|", "\\", "$")
+    corpus += ["".join(combination) for combination in itertools.product(blocks, repeat=4)]
+
+    for pattern in corpus:
+        probe_rejects = _regex_has_catastrophic_shape(pattern) or _regex_complexity_budget(pattern) > _REGEX_BUDGET_MAX
+        assert probe_rejects == _regex_is_catastrophic_shape(pattern), (
+            f"probe and resolver disagree on {pattern!r}: "
+            f"probe rejects={probe_rejects}, resolver rejects={_regex_is_catastrophic_shape(pattern)}"
+        )
+    # Guard against a vacuously one-sided corpus.
+    assert any(_regex_is_catastrophic_shape(pattern) for pattern in corpus)
+    assert any(not _regex_is_catastrophic_shape(pattern) for pattern in corpus)
 
 
 def test_main_treats_crlf_terminated_lines_like_lf() -> None:

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -1,0 +1,96 @@
+"""pfb_dnsbl_regex_rules.py (issue #1765): single-source DNSBL regex admission
+rules, shared by pfb_unbound.py and the save-time probe.
+
+Covers what the PHP suite (tests/php/DnsblRegexEntryErrorTest.php, which drives
+the probe through pfb_dnsbl_regex_validation_errors()) cannot reach directly:
+standalone import-safety (the #1711 pythonmod-globals regression guard), the
+probe's argv-absent default, and stdin line-ending edge cases. The five
+diagnostic-message classes and the shape-vs-budget distinction are already
+pinned in DnsblRegexEntryErrorTest -- not duplicated here.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PKG_DIR = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng"
+SCRIPT = PKG_DIR / "pfb_dnsbl_regex_rules.py"
+
+
+def _anchored_pattern(length: int) -> str:
+    """An anchored, structurally benign pattern of EXACTLY the requested length
+    (mirror of DnsblRegexEntryErrorTest::anchoredPattern / test_adr07's twin)."""
+    return "^" + "a" * (length - 2) + "$"
+
+
+def run_probe(stdin_bytes: bytes, *args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        input=stdin_bytes,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_import_is_standalone_with_no_pythonmod_globals() -> None:
+    """issue #1711/#1765 regression guard: the module imports clean in a bare
+    interpreter -- only the pkg dir on sys.path (cwd, mirroring Unbound's
+    pythonmod chdir() + sys.path.append('.')), a stripped env, no unboundmodule
+    stub. Fails the moment a pythonmod-injected name (log_info, RR_TYPE_*, ...)
+    lands at module scope."""
+    proc = subprocess.run(
+        [sys.executable, "-c", "import pfb_dnsbl_regex_rules"],
+        cwd=str(PKG_DIR),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"PATH": os.environ.get("PATH", "")},
+        check=False,
+    )
+    assert proc.returncode == 0, f"stderr: {proc.stderr!r}"
+    assert proc.stderr == ""
+
+
+def test_main_defaults_cap_off_when_argv_is_absent() -> None:
+    """The nowdoc this module replaced used ``len(sys.argv) > 1 and sys.argv[1] ==
+    "1"`` -- pin that the missing-argv case is cap OFF: a long-but-benign pattern
+    is accepted with no argv[1] at all."""
+    from pfb_dnsbl_regex_rules import REGEX_STATIC_LEN_CAP
+
+    pattern = _anchored_pattern(REGEX_STATIC_LEN_CAP + 100)
+    proc = run_probe((pattern + "\n").encode("utf-8"))
+    assert proc.returncode == 0, f"stderr: {proc.stderr!r}"
+    assert proc.stderr == b""
+
+
+def test_main_treats_crlf_terminated_lines_like_lf() -> None:
+    """A regex-list body with CRLF line endings splits into the same lines (and
+    reports the same line numbers) as an LF-only body."""
+    body = b"^ads\x01$\r\n(a+)+\r\n^ok$\r\n"
+    proc = run_probe(body)
+    assert proc.returncode == 1
+    stderr = proc.stderr.decode("utf-8")
+    assert "line 1:" in stderr and "control character" in stderr
+    assert "line 2:" in stderr and "catastrophic-backtracking shape" in stderr
+    assert "line 3:" not in stderr
+
+
+def test_main_does_not_hang_on_a_lone_cr_with_no_newline() -> None:
+    """A regex-list body using bare CR (old-Mac style) line endings with no '\\n'
+    anywhere is NOT split by ``sys.stdin`` (unlike CRLF, which still carries a
+    real '\\n' for the line-terminator search) -- Python's text stdin only treats
+    '\\n' as a line boundary here, so the whole blob is read as ONE line. Pin
+    the safe outcome: no hang, and the embedded control byte (CR itself is
+    0x0D, an ASCII control character) still trips the control-character
+    diagnostic on that one line -- never a crash, never a silent pass."""
+    body = b"^ads\x01$\r(a+)+\r^ok$\r"
+    proc = run_probe(body)
+    assert proc.returncode == 1
+    stderr = proc.stderr.decode("utf-8")
+    assert stderr.startswith("line 1:")
+    assert stderr.count("line ") == 1, f"expected the whole blob read as one line, got: {stderr!r}"
+    assert "control character" in stderr

--- a/tools/webassets/lezer-pfb-regex-list/src/pfb-regex-list.grammar
+++ b/tools/webassets/lezer-pfb-regex-list/src/pfb-regex-list.grammar
@@ -40,7 +40,7 @@ line { (Pattern Comment? | Comment)? }
   // char and the "#" never reaches Comment -- while "\\#" (an escaped BACKSLASH) leaves
   // the following "#" free to start the Comment, because the first alternative already
   // ate both backslashes as a pair. That parity is the whole rule, and it matches
-  // pfb_split_regex_line() in PHP and pfb_unbound.py byte for byte.
+  // pfb_split_regex_line() in PHP and pfb_dnsbl_regex_rules.py byte for byte.
   //
   // The dangling-backslash case (a line ENDING in "\\") is a trailing OPTION on Pattern,
   // never a patternChar alternative: as an alternative it would let the tokenizer take a


### PR DESCRIPTION
## What this does

Closes #1765 by taking option 2 from #1711: the DNSBL regex **admission rules** now live in
exactly one place instead of two.

Before this change the catastrophic-shape gate, the complexity budget, the length cap and the
pattern/description line-splitter existed twice — once as module-level code in `pfb_unbound.py`
(the resolver, load time) and once as an embedded Python nowdoc inside
`pfb_dnsbl_regex_validation_errors()` in `pfblockerng_extra.inc` (the save-time probe). The two
copies had to be kept byte-identical by hand, which is exactly the drift class #1711 was opened
about.

They are now one shipped module, `src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py`:

- `pfb_unbound.py` **imports** it at module scope (`REGEX_STATIC_LEN_CAP`,
  `_regex_is_catastrophic_shape`, `pfb_split_regex_line`) instead of defining them.
- `pfb_dnsbl_regex_validation_errors()` **runs the same file** as the save-time probe
  (`$python <__DIR__>/pfb_dnsbl_regex_rules.py <0|1>`) instead of piping a nowdoc through
  `python -c`. The module's `main()` is that probe; its argv/stdin/stderr contract and every
  diagnostic string are unchanged.

The module is stdlib-only and carries no `unboundmodule` reference at module scope or inside any
function, so it is import-safe in a plain interpreter — that was the real blocker identified on
#1711 (module-level `log_info`, a pythonmod-injected global), not the `TYPE_CHECKING`-only
`unboundmodule` import.

## Correction to the issue: chroot staging DOES need wiring

The issue states that **no plist wiring is needed**. That is true — and it has been verified for
this PR rather than taken on trust: the port at `pfBlockerNG/FreeBSD-ports`
(`net/pfSense-pkg-pfBlockerNG-devel`, branch `pfblockerng/use-github`) carries **no `pkg-plist`**;
its `Makefile` generates the plist dynamically with `FIND -s ${STAGEDIR}${PREFIX} -type f | SED`,
so a newly shipped file is picked up automatically.

**But "no plist wiring" is not the same as "no wiring".** Unbound runs `pfb_unbound.py` inside its
chroot at `/var/unbound`, and the shipped Python files are staged into that chroot by
`dnsbl_cache()` in `pfblockerng.sh` from **one hardcoded list**:

```sh
PFB_PY_SHIPPED='pfb_dnsbl_regex_rules.py pfb_unbound.py pfb_unbound_include.inc pfb_py_hsts.txt'
```

The order in that list is load-bearing: `dnsbl_cache_stage()` copies the entries in list order, so
the imported module is staged **before** the file that imports it — a resolver load landing between
the two copies would otherwise find `pfb_unbound.py` without `pfb_dnsbl_regex_rules.py` and die
with `ModuleNotFoundError`. A test pins the ordering.

Without adding the new file to `PFB_PY_SHIPPED` (`pfblockerng.sh:340`), the module would ship into
`/usr/local/pkg/pfblockerng/` correctly, the PHP save-time probe would keep working (it runs from
`__DIR__`), and the resolver would fail at load with `ImportError` inside the chroot — a
DNSBL-wide outage that no plist check would have caught.

Calling this out explicitly so the next person shipping a new Python file into the DNSBL path does
not repeat the omission: **plist = automatic, chroot staging = manual.**

## Why the module-scope import is safe inside Unbound

`import pfb_dnsbl_regex_rules` at module scope in `pfb_unbound.py` only resolves if the script's
own directory is on `sys.path`. This was probed against a live appliance rather than assumed:

```
$ unbound -V | head -1
Version 1.25.1

$ strings /usr/local/sbin/unbound | grep -i "sys.path"
sys.path.append('/usr/local/etc/unbound')
sys.path.append('.')
sys.path.extend(site.getsitepackages())
sys.path.append('%s')

$ grep -nE "^(directory|chroot|python-script)" /var/unbound/unbound.conf
10:chroot: /var/unbound
12:directory: "/var/unbound"
122:python-script: pfb_unbound.py

$ procstat -f $(pgrep -x unbound | head -1) | awk '$3=="cwd"'
77295 unbound  cwd  v d r-------  -  -  -  /var/unbound
```

The shipped Unbound binary appends `'.'` to `sys.path`, and the running daemon's working directory
is `/var/unbound` — the same directory the script itself is loaded from by relative path (which is
why `python-script: pfb_unbound.py` resolves at all today). A sibling module in that directory
therefore imports cleanly. `tests/test_pfb_dnsbl_regex_rules.py::test_import_is_standalone_with_no_pythonmod_globals`
pins the other half of that contract — the module imports in a bare interpreter with a stripped
environment and no `unboundmodule` stub, so a future pythonmod-injected name at module scope fails
the suite instead of the resolver.

## Tests

**Deleted** (three tests in `tests/test_adr07_regex_safety.py`, all added by #1764 to pin the
duplication this PR removes):

- `test_save_time_probe_length_cap_matches_runtime_constant`
- `test_probe_regex_literals_match_runtime_shape_and_budget_patterns`
- `test_probe_budget_threshold_matches_runtime_budget_max`

Each worked by extracting the `<<<'PYTHON' … PYTHON;` nowdoc out of `pfblockerng_extra.inc` with a
regex and byte-comparing its literals against `pfb_unbound.py`'s. With the nowdoc gone there is no
second literal to compare, so the tests are not merely redundant — they are unsatisfiable, and the
drift class they guarded cannot occur any more: the probe and the resolver now read the *same*
`REGEX_STATIC_LEN_CAP`, the same four shape patterns and the same `_REGEX_BUDGET_MAX` from one
module. This is exactly the outcome #1765 predicted ("parity tests then stop being necessary at
all"). `testProbeDefaultsCapOffWhenTheArgvFlagIsAbsent` in the PHP suite was rewritten the same way
— it used to scrape the nowdoc, it now invokes the shipped script directly.

**Added:**

- `tests/test_pfb_dnsbl_regex_rules.py` — standalone import-safety (the #1711 regression guard),
  the probe's argv-absent cap-off default, CRLF line handling, and the bare-CR blob case (Python's
  `sys.stdin` is created with `newline="\n"` on POSIX, so a lone `\r` is not a line boundary; the
  test pins that this is safe and diagnosed, not a hang).
- `tests/test_adr07_regex_safety.py::test_pfb_unbound_reexports_are_the_same_objects_as_pfb_dnsbl_regex_rules`
  — an identity pin (`is`) proving `pfb_unbound`'s names are the module's own objects, not a copy.
  This is the structural replacement for the three deleted byte-comparison tests.
- `tests/php/DnsblRegexEntryErrorTest.php::testMissingRulesModuleFailsClosedWithoutSpawningAPythonProcess`
  — the new failure mode introduced by this PR (the script is absent/unreadable) fails closed with
  `Python regex validator: rules module unavailable` and never spawns an interpreter.
- `tests/shell/pfblockerng_dnsbl_cache_spec.sh` — the new file is staged into the chroot, and is
  *not* swept into the cache archive (its basename matches neither the `pfb_unbound*` nor the
  `pfb_py_*` archive glob, so it is correctly treated as shipped-and-restaged, not generated).

The rest of the behaviour is pinned as-is by the pre-existing oracle: `DnsblRegexEntryErrorTest`
drives the probe end to end through `pfb_dnsbl_regex_validation_errors()` and stayed green
unchanged across the extraction, which is the red-proof exception for behaviour-preserving work in
`.agents/policy/testing.md` (existing behaviour as the oracle, green before and after).

## Gates

`scripts/agent/run-gates.sh --diff origin/devel` — all green:

```
GATE PASS: python3 -m pytest
GATE PASS: ruff check .
GATE PASS: ruff format --check .
GATE PASS: mypy tests/
GATE PASS: python3 scripts/check_composer_vendor.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
GATE PASS: php -l tests/php/DnsblRegexEntryErrorTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATE PASS: sh -n src/usr/local/pkg/pfblockerng/pfblockerng.sh
GATE PASS: shellcheck src/usr/local/pkg/pfblockerng/pfblockerng.sh
GATE PASS: sh -n tests/shell/pfblockerng_dnsbl_cache_spec.sh
GATE PASS: shellspec --shell $(command -v dash || command -v sh)
GATES: PASS
```

Fixes #1765

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

