### PR TITLE
pfblockerng: bound every blocking flock() acquire (#1780)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8554,7 +8554,14 @@ function pfb_unbound_py_top1m_atomic_copy(string $source, string $path, array $s
 // issue #1780: bounded flock() acquire -- a wall-clock deadline AND an independent
 // poll cap both bound the wait (a stalled/backward clock still terminates). ORs in
 // LOCK_NB itself; never fclose()s -- the caller owns the handle.
-function pfb_flock_bounded($fp, int $operation, float $timeout_s): bool {
+//
+// issue #1780: $timed_out distinguishes a genuine flock() error (would-block
+// byref never reaches 1 -- not a contention signal at all) from a genuine
+// deadline/poll-cap expiry, so a caller can log the correct one instead of a
+// single ambiguous FALSE. Set TRUE ONLY when the wait genuinely expired; left
+// FALSE on every other return (a real flock() error, or success).
+function pfb_flock_bounded($fp, int $operation, float $timeout_s, ?bool &$timed_out = NULL): bool {
+	$timed_out = FALSE;
 	$wait_s = max($timeout_s, 0.0);
 	$deadline = microtime(TRUE) + $wait_s;
 	// Independent poll cap bounds the wait if the wall clock stalls or moves backward.
@@ -8576,6 +8583,7 @@ function pfb_flock_bounded($fp, int $operation, float $timeout_s): bool {
 			return TRUE;
 		}
 		if ($would_block !== 1) {
+			// A real flock() error -- never a timeout/contention signal.
 			return FALSE;
 		}
 		$polls++;
@@ -8586,6 +8594,7 @@ function pfb_flock_bounded($fp, int $operation, float $timeout_s): bool {
 		usleep((int) min(20000, ceil($remaining_s * 1000000)));
 	} while (TRUE);
 
+	$timed_out = TRUE;
 	return FALSE;
 }
 
@@ -8616,12 +8625,15 @@ function pfb_unbound_py_publication_lock(?float $timeout_s=NULL) {
 		$timeout_s = pfb_unbound_py_publication_lock_timeout();
 	}
 
-	if (pfb_flock_bounded($lock, LOCK_EX, $timeout_s)) {
+	$timed_out = FALSE;
+	if (pfb_flock_bounded($lock, LOCK_EX, $timeout_s, $timed_out)) {
 		return $lock;
 	}
 
 	@fclose($lock);
-	pfb_logger("\nDNSBL publication lock timed out", 2);
+	// issue #1780: "timed out" only on a genuine deadline expiry; a real
+	// flock() error is "unavailable", matching every other hard failure above.
+	pfb_logger($timed_out ? "\nDNSBL publication lock timed out" : "\nDNSBL publication lock unavailable", 2);
 	return FALSE;
 }
 
@@ -8961,9 +8973,14 @@ function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '', $wait_time
 		pfb_logger("\nPFBL-03: control channel lock open failed [ {$lockpath} ]", 2);
 		return FALSE;
 	}
-	if (!pfb_flock_bounded($lock, LOCK_EX, 5.0)) {
+	$timed_out = FALSE;
+	if (!pfb_flock_bounded($lock, LOCK_EX, 5.0, $timed_out)) {
 		@fclose($lock);
-		pfb_logger("\nPFBL-03: control channel lock acquire timed out [ {$lockpath} ]", 2);
+		// issue #1780: "timed out" only on a genuine deadline expiry; a real
+		// flock() error is "acquire failed", matching every other hard failure above.
+		pfb_logger($timed_out
+			? "\nPFBL-03: control channel lock acquire timed out [ {$lockpath} ]"
+			: "\nPFBL-03: control channel lock acquire failed [ {$lockpath} ]", 2);
 		return FALSE;
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8551,6 +8551,51 @@ function pfb_unbound_py_top1m_atomic_copy(string $source, string $path, array $s
 	return TRUE;
 }
 
+// issue #1780: bounded flock() acquire -- a wall-clock deadline AND an independent
+// poll cap both bound the wait (a stalled/backward clock still terminates). ORs in
+// LOCK_NB itself; never fclose()s -- the caller owns the handle.
+function pfb_flock_bounded($fp, int $operation, float $timeout_s): bool {
+	$wait_s = max($timeout_s, 0.0);
+	$deadline = microtime(TRUE) + $wait_s;
+	// Independent poll cap bounds the wait if the wall clock stalls or moves backward.
+	$max_polls = (int) ceil($wait_s / 0.02) + 2;
+	$polls = 0;
+	$first_attempt = TRUE;
+	do {
+		$allow_expired_attempt = $first_attempt && $wait_s <= 0.0;
+		$first_attempt = FALSE;
+		if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
+			break;
+		}
+		$would_block = 0;
+		if (@flock($fp, $operation | LOCK_NB, $would_block)) {
+			if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
+				@flock($fp, LOCK_UN);
+				break;
+			}
+			return TRUE;
+		}
+		if ($would_block !== 1) {
+			return FALSE;
+		}
+		$polls++;
+		$remaining_s = $deadline - microtime(TRUE);
+		if ($polls >= $max_polls || $remaining_s <= 0.0) {
+			break;
+		}
+		usleep((int) min(20000, ceil($remaining_s * 1000000)));
+	} while (TRUE);
+
+	return FALSE;
+}
+
+// issue #1780: the bounded default every NULL caller of the publication lock
+// resolves to. 60s -- the holders are local manifest/GC/teardown file writes,
+// far beyond any legitimate hold, but still finite.
+function pfb_unbound_py_publication_lock_timeout(): float {
+	return 60.0;
+}
+
 // #1357: one exclusive lock serializes full-set publication, scalar manifest patches,
 // convergence-gated generation GC, and teardown. Python readers never take this lock.
 function pfb_unbound_py_publication_lock(?float $timeout_s=NULL) {
@@ -8568,46 +8613,12 @@ function pfb_unbound_py_publication_lock(?float $timeout_s=NULL) {
 	}
 
 	if ($timeout_s === NULL) {
-		if (!@flock($lock, LOCK_EX)) {
-			@fclose($lock);
-			pfb_logger("\nDNSBL publication lock unavailable", 2);
-			return FALSE;
-		}
-		return $lock;
+		$timeout_s = pfb_unbound_py_publication_lock_timeout();
 	}
 
-	$wait_s = max($timeout_s, 0.0);
-	$deadline = microtime(TRUE) + $wait_s;
-	// Independent poll cap bounds the wait if the wall clock stalls or moves backward.
-	$max_polls = (int) ceil($wait_s / 0.02) + 2;
-	$polls = 0;
-	$first_attempt = TRUE;
-	do {
-		$allow_expired_attempt = $first_attempt && $wait_s <= 0.0;
-		$first_attempt = FALSE;
-		if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
-			break;
-		}
-		$would_block = 0;
-		if (@flock($lock, LOCK_EX | LOCK_NB, $would_block)) {
-			if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
-				@flock($lock, LOCK_UN);
-				break;
-			}
-			return $lock;
-		}
-		if ($would_block !== 1) {
-			@fclose($lock);
-			pfb_logger("\nDNSBL publication lock unavailable", 2);
-			return FALSE;
-		}
-		$polls++;
-		$remaining_s = $deadline - microtime(TRUE);
-		if ($polls >= $max_polls || $remaining_s <= 0.0) {
-			break;
-		}
-		usleep((int) min(20000, ceil($remaining_s * 1000000)));
-	} while (TRUE);
+	if (pfb_flock_bounded($lock, LOCK_EX, $timeout_s)) {
+		return $lock;
+	}
 
 	@fclose($lock);
 	pfb_logger("\nDNSBL publication lock timed out", 2);
@@ -8950,9 +8961,9 @@ function pfb_unbound_py_write_control($cmd, $ip = '', $duration = '', $wait_time
 		pfb_logger("\nPFBL-03: control channel lock open failed [ {$lockpath} ]", 2);
 		return FALSE;
 	}
-	if (!@flock($lock, LOCK_EX)) {
+	if (!pfb_flock_bounded($lock, LOCK_EX, 5.0)) {
 		@fclose($lock);
-		pfb_logger("\nPFBL-03: control channel lock acquire failed [ {$lockpath} ]", 2);
+		pfb_logger("\nPFBL-03: control channel lock acquire timed out [ {$lockpath} ]", 2);
 		return FALSE;
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8599,8 +8599,9 @@ function pfb_flock_bounded($fp, int $operation, float $timeout_s, ?bool &$timed_
 }
 
 // issue #1780: the bounded default every NULL caller of the publication lock
-// resolves to. 60s -- the holders are local manifest/GC/teardown file writes,
-// far beyond any legitimate hold, but still finite.
+// resolves to. Holders are local manifest/GC/teardown file writes; the worst-case
+// hold is unmeasured, so 60s is a deliberately loose finite cap -- it exists to
+// terminate a wedged acquire, not to time a healthy one.
 function pfb_unbound_py_publication_lock_timeout(): float {
 	return 60.0;
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8562,7 +8562,9 @@ function pfb_unbound_py_top1m_atomic_copy(string $source, string $path, array $s
 // FALSE on every other return (a real flock() error, or success).
 function pfb_flock_bounded($fp, int $operation, float $timeout_s, ?bool &$timed_out = NULL): bool {
 	$timed_out = FALSE;
-	$wait_s = max($timeout_s, 0.0);
+	// Clamp before the poll-cap cast below: a budget whose /0.02 quotient overflows int
+	// makes that cast warn and yield 0, collapsing the cap to 2 attempts (unbounding it).
+	$wait_s = min(max($timeout_s, 0.0), 3600.0);
 	$deadline = microtime(TRUE) + $wait_s;
 	// Independent poll cap bounds the wait if the wall clock stalls or moves backward.
 	$max_polls = (int) ceil($wait_s / 0.02) + 2;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3257,8 +3257,10 @@ function pfb_due_ledger_is_due_from_entry(?array $entry, int $now): bool
 /**
  * pfb_due_ledger_read_entry — read one job entry from the on-disk ledger.
  *
- * Returns NULL on absent file, I/O error, or any corruption (fail-safe: absent
- * is always treated as "due now" by pfb_due_ledger_is_due_from_entry).
+ * Returns NULL on absent file, I/O error, any corruption, OR a lock-acquire
+ * timeout (fail-safe: absent is always treated as "due now" by
+ * pfb_due_ledger_is_due_from_entry). Only the timeout also sets $unavailable --
+ * see below, and never conflate the two.
  *
  * issue #1780: a bounded lock acquire can also EXPIRE -- that is NOT the
  * same as "absent" (NULL already means "absent / corrupt" to every existing
@@ -3891,8 +3893,10 @@ function pfblockerng_tick(?array $ps_lines = NULL): void
 /**
  * pfb_sync_status_read_all — read the full ledger as a nested array.
  *
- * Absent file, unreadable file, or corrupt/non-object JSON all read as an
- * empty ledger (fail-open for display), never throws.
+ * Absent file, unreadable file, corrupt/non-object JSON, or a lock-acquire
+ * timeout all read as an empty ledger (fail-open for display), never throws.
+ * Only the timeout also sets $unavailable -- see below, and never conflate the
+ * two: [] alone cannot tell a caller which happened.
  *
  * issue #1780: a bounded lock acquire can also EXPIRE -- that is NOT the
  * same as "empty" ([] already means "empty ledger" to every existing caller),

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3457,6 +3457,12 @@ function pfb_due_ledger_mark_ran(
  *     boundary by a fraction of a tick" case this fix targets ⇒ base = the entry's
  *     next_due, so the new next_due advances by exactly $interval every cycle.
  *
+ * issue #1780: deliberately takes NO $unavailable channel, unlike its sibling
+ * readers. Its own read is a best-effort ANCHOR lookup, not a dispatch or
+ * persistence decision: an unreadable entry falls through to the base = $now
+ * branch above, which is the same conservative catch-up-from-now the NULL case
+ * already takes. There is no "looks due when it is not" collision to close here.
+ *
  * @param string $job_key     Job identifier (e.g. 'cron').
  * @param int    $interval    Job cadence in seconds.
  * @param int    $now         Current epoch timestamp (injectable in tests).

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3274,8 +3274,9 @@ function pfb_due_ledger_read_entry(string $job_key, string $ledger_dir): ?array
 	if ($fp === FALSE) {
 		return NULL;
 	}
-	if (!flock($fp, LOCK_SH)) {
+	if (!pfb_flock_bounded($fp, LOCK_SH, 5.0)) {
 		fclose($fp);
+		pfb_logger("\nADR-43: due-ledger read lock timed out [ {$path} ]", 2);
 		return NULL;
 	}
 	$raw = stream_get_contents($fp);
@@ -3851,8 +3852,9 @@ function pfb_sync_status_read_all(string $ledger_dir): array
 	if ($fp === FALSE) {
 		return [];
 	}
-	if (!flock($fp, LOCK_SH)) {
+	if (!pfb_flock_bounded($fp, LOCK_SH, 5.0)) {
 		fclose($fp);
+		pfb_logger("\nADR-61: sync-status ledger read lock timed out [ {$path} ]", 2);
 		return [];
 	}
 	$raw = stream_get_contents($fp);
@@ -3903,17 +3905,23 @@ function pfb_sync_status_write_all(array $data, string $ledger_dir): void
  *
  * @param string   $ledger_dir Directory that contains pfb_sync_status.json.
  * @param callable $fn         The read-modify-write body to run under the lock.
+ * @param float    $timeout_s  Bounded EX-acquire budget in seconds (issue #1780).
  * @return void
  */
-function pfb_sync_status_locked(string $ledger_dir, callable $fn): void
+function pfb_sync_status_locked(string $ledger_dir, callable $fn, float $timeout_s = 5.0): void
 {
 	$lock_path = $ledger_dir . '/pfb_sync_status.json.lock';
 	$fp        = @fopen($lock_path, 'c');
-	if ($fp === FALSE || !flock($fp, LOCK_EX)) {
-		if ($fp !== FALSE) {
-			fclose($fp);
-		}
-		$fn();	// can't lock (unwritable dir) -- degrade to best-effort, same fail-open contract as write_all()
+	if ($fp === FALSE) {
+		$fn();	// can't open (unwritable dir) -- degrade to best-effort, same fail-open contract as write_all()
+		return;
+	}
+	if (!pfb_flock_bounded($fp, LOCK_EX, $timeout_s)) {
+		fclose($fp);
+		// issue #1780: the acquire timed out -- log it loudly (observable, was
+		// silent) before degrading to the same fail-open contract as above.
+		pfb_logger("\nADR-61: sync-status ledger lock timed out [ {$lock_path} ] -- proceeding unlocked", 2);
+		$fn();
 		return;
 	}
 	try {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3260,12 +3260,26 @@ function pfb_due_ledger_is_due_from_entry(?array $entry, int $now): bool
  * Returns NULL on absent file, I/O error, or any corruption (fail-safe: absent
  * is always treated as "due now" by pfb_due_ledger_is_due_from_entry).
  *
- * @param string $job_key     Job identifier (e.g. 'dcc', 'bl').
- * @param string $ledger_dir  Directory that contains pfb_due_ledger.json.
- * @return array|null         {last_run: int, next_due: int, jitter: int} or NULL.
+ * issue #1780: a bounded lock acquire can also EXPIRE -- that is NOT the
+ * same as "absent" (NULL already means "absent / corrupt" to every existing
+ * caller), so it is signalled out-of-band via $unavailable, never via the
+ * return value (the public return type/contract is unchanged, so every www/
+ * consumer keeps compiling and rendering exactly as before). $unavailable is
+ * set TRUE ONLY when the lock acquire itself timed out; every other path
+ * (success, absent file, corrupt JSON, unreadable file) sets it FALSE. A
+ * caller that gates a dispatch or persistence decision on this read MUST
+ * treat $unavailable===TRUE as "I do not know" -- fail closed, never write
+ * back, never treat it as "due" or "absent".
+ *
+ * @param string    $job_key      Job identifier (e.g. 'dcc', 'bl').
+ * @param string    $ledger_dir   Directory that contains pfb_due_ledger.json.
+ * @param float     $timeout_s    Bounded SH-acquire budget in seconds (issue #1780).
+ * @param bool|null $unavailable  Out param: TRUE iff the lock acquire expired.
+ * @return array|null             {last_run: int, next_due: int, jitter: int} or NULL.
  */
-function pfb_due_ledger_read_entry(string $job_key, string $ledger_dir): ?array
+function pfb_due_ledger_read_entry(string $job_key, string $ledger_dir, float $timeout_s = 5.0, ?bool &$unavailable = NULL): ?array
 {
+	$unavailable = FALSE;
 	$path = $ledger_dir . '/pfb_due_ledger.json';
 	if (!is_file($path)) {
 		return NULL;
@@ -3274,9 +3288,10 @@ function pfb_due_ledger_read_entry(string $job_key, string $ledger_dir): ?array
 	if ($fp === FALSE) {
 		return NULL;
 	}
-	if (!pfb_flock_bounded($fp, LOCK_SH, 5.0)) {
+	if (!pfb_flock_bounded($fp, LOCK_SH, $timeout_s)) {
 		fclose($fp);
 		pfb_logger("\nADR-43: due-ledger read lock timed out [ {$path} ]", 2);
+		$unavailable = TRUE;
 		return NULL;
 	}
 	$raw = stream_get_contents($fp);
@@ -3347,12 +3362,18 @@ function pfb_due_ledger_write_entry(string $job_key, array $entry, string $ledge
  * next_due ≤ $now         ⇒ TRUE (catch-up: missed window runs on the next tick).
  * next_due >  $now        ⇒ FALSE (not yet due).
  *
+ * issue #1780: a lock-acquire expiry on the underlying read must fail
+ * CLOSED (FALSE), never fall through to is_due_from_entry(NULL, ...)'s
+ * "absent ⇒ due" rule -- an unreadable (but not actually absent) ledger must
+ * never look spuriously due.
+ *
  * @param string $job_key     Job identifier (e.g. 'dcc', 'bl_weekly').
  * @param int    $interval    Job cadence in seconds (for API parity; not used here).
  * @param int    $now         Current epoch timestamp (injectable in tests).
  * @param string $seed        Per-install seed (for API parity; not used here).
  * @param int    $jitter_max  Max jitter in seconds (for API parity; not used here).
  * @param string $ledger_dir  Directory that contains pfb_due_ledger.json.
+ * @param float  $timeout_s   Bounded lock-acquire budget in seconds (issue #1780; injectable for tests).
  * @return bool               TRUE iff the job should run this tick.
  */
 function pfb_due_ledger_is_due(
@@ -3361,12 +3382,15 @@ function pfb_due_ledger_is_due(
 	int    $now,
 	string $seed,
 	int    $jitter_max,
-	string $ledger_dir
+	string $ledger_dir,
+	float  $timeout_s = 5.0
 ): bool {
-	return pfb_due_ledger_is_due_from_entry(
-		pfb_due_ledger_read_entry($job_key, $ledger_dir),
-		$now
-	);
+	$unavailable = FALSE;
+	$entry = pfb_due_ledger_read_entry($job_key, $ledger_dir, $timeout_s, $unavailable);
+	if ($unavailable) {
+		return FALSE;
+	}
+	return pfb_due_ledger_is_due_from_entry($entry, $now);
 }
 
 /**
@@ -3606,13 +3630,27 @@ function pfb_quiet_hours_in_window(int $now, string $window): bool
  * The pending flag is cleared implicitly when pfb_due_ledger_mark_ran() writes a clean
  * {last_run, next_due, jitter} entry (no pending_apply key).
  *
+ * issue #1780: a lock-acquire expiry on the underlying read must ABORT
+ * this write entirely -- falling through to the "absent" placeholder branch
+ * would persist a ZEROED {last_run:0, next_due:0, jitter:0} entry over a REAL
+ * (but momentarily unreadable) schedule, since write_entry()'s own unlocked
+ * merge-read would pick the real entry back up off disk and stomp its
+ * next_due/last_run to 0 with the placeholder.
+ *
  * @param string $job_key    Job identifier (e.g. 'cron', 'dcc', 'bl').
  * @param string $ledger_dir Directory that contains pfb_due_ledger.json.
+ * @param float  $timeout_s  Bounded lock-acquire budget in seconds (issue #1780; injectable for tests).
  * @return void
  */
-function pfb_due_ledger_set_pending(string $job_key, string $ledger_dir): void
+function pfb_due_ledger_set_pending(string $job_key, string $ledger_dir, float $timeout_s = 5.0): void
 {
-	$entry = pfb_due_ledger_read_entry($job_key, $ledger_dir);
+	$unavailable = FALSE;
+	$entry = pfb_due_ledger_read_entry($job_key, $ledger_dir, $timeout_s, $unavailable);
+	if ($unavailable) {
+		// The read already logged the expiry loudly -- abort, never persist a
+		// zeroed placeholder over a real entry we simply could not read this instant.
+		return;
+	}
 	if ($entry === NULL) {
 		$entry = ['last_run' => 0, 'next_due' => 0, 'jitter' => 0];
 	}
@@ -3626,13 +3664,21 @@ function pfb_due_ledger_set_pending(string $job_key, string $ledger_dir): void
  * Returns TRUE iff pfb_due_ledger_set_pending() has been called for this job and
  * pfb_due_ledger_mark_ran() has not yet cleared it.
  *
+ * issue #1780: a lock-acquire expiry on the underlying read must return
+ * FALSE -- an unreadable ledger is not evidence of a pending deferred apply.
+ *
  * @param string $job_key    Job identifier (e.g. 'cron', 'dcc', 'bl').
  * @param string $ledger_dir Directory that contains pfb_due_ledger.json.
+ * @param float  $timeout_s  Bounded lock-acquire budget in seconds (issue #1780; injectable for tests).
  * @return bool              TRUE when pending_apply is set and not yet cleared.
  */
-function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir): bool
+function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir, float $timeout_s = 5.0): bool
 {
-	$entry = pfb_due_ledger_read_entry($job_key, $ledger_dir);
+	$unavailable = FALSE;
+	$entry = pfb_due_ledger_read_entry($job_key, $ledger_dir, $timeout_s, $unavailable);
+	if ($unavailable) {
+		return FALSE;
+	}
 	return $entry !== NULL && !empty($entry['pending_apply']);
 }
 
@@ -3716,9 +3762,18 @@ function pfblockerng_tick(?array $ps_lines = NULL): void
 	// (IP) + ADR-10 (DNSBL) inside that final sync. Backgrounded so the tick stays
 	// fast. The scheduled log trim no longer rides this dispatch (issue #573) --
 	// see pfb_log_mgmt() at the end of this function.
-	$cron_entry   = pfb_due_ledger_read_entry('cron', $dbdir);
-	$cron_pending = $cron_entry !== NULL && !empty($cron_entry['pending_apply']);
-	if ((!$cron_disabled && $due['cron']) || $cron_pending) {
+	// issue #1780: a lock-acquire expiry on this read must NOT dispatch,
+	// NOT mark ran, and must leave the ledger untouched -- $cron_unavailable
+	// gates the whole decision below regardless of what $due['cron'] (a
+	// SEPARATE read, inside pfb_tick_due_jobs() above) came back as, so a
+	// timeout here can never be raced into a spurious dispatch by that other
+	// read having happened to succeed. $dispatched stays FALSE, so log
+	// maintenance below still runs; the read itself already logged the expiry
+	// loudly. The next tick retries.
+	$cron_unavailable = FALSE;
+	$cron_entry        = pfb_due_ledger_read_entry('cron', $dbdir, 5.0, $cron_unavailable);
+	$cron_pending      = !$cron_unavailable && $cron_entry !== NULL && !empty($cron_entry['pending_apply']);
+	if (!$cron_unavailable && ((!$cron_disabled && $due['cron']) || $cron_pending)) {
 		if ($in_win && pfb_feed_pass_busy()) {
 			// issue #1175: a running feed pass would race the shared recompute staging --
 			// defer via pending so the NEXT tick retries. busy() is advisory only: the
@@ -3839,11 +3894,25 @@ function pfblockerng_tick(?array $ps_lines = NULL): void
  * Absent file, unreadable file, or corrupt/non-object JSON all read as an
  * empty ledger (fail-open for display), never throws.
  *
- * @param string $ledger_dir Directory that contains pfb_sync_status.json.
+ * issue #1780: a bounded lock acquire can also EXPIRE -- that is NOT the
+ * same as "empty" ([] already means "empty ledger" to every existing caller),
+ * so it is signalled out-of-band via $unavailable, never via the return value
+ * (the public return type/contract is unchanged, so every www/ consumer keeps
+ * compiling and rendering exactly as before). $unavailable is set TRUE ONLY
+ * when the lock acquire itself timed out; every other path (success, absent
+ * file, corrupt JSON, unreadable file) sets it FALSE. A caller that performs a
+ * read-modify-write on this data (open/close, below) MUST treat
+ * $unavailable===TRUE as "I do not know" -- abort, never write back an
+ * apparently-empty (in truth just-unreadable) ledger over intact data.
+ *
+ * @param string    $ledger_dir   Directory that contains pfb_sync_status.json.
+ * @param float     $timeout_s    Bounded SH-acquire budget in seconds (issue #1780).
+ * @param bool|null $unavailable  Out param: TRUE iff the lock acquire expired.
  * @return array<string,array<string,array<string,array{message:string,first_seen:int,last_seen:int}>>>
  */
-function pfb_sync_status_read_all(string $ledger_dir): array
+function pfb_sync_status_read_all(string $ledger_dir, float $timeout_s = 5.0, ?bool &$unavailable = NULL): array
 {
+	$unavailable = FALSE;
 	$path = $ledger_dir . '/pfb_sync_status.json';
 	if (!is_file($path)) {
 		return [];
@@ -3852,9 +3921,10 @@ function pfb_sync_status_read_all(string $ledger_dir): array
 	if ($fp === FALSE) {
 		return [];
 	}
-	if (!pfb_flock_bounded($fp, LOCK_SH, 5.0)) {
+	if (!pfb_flock_bounded($fp, LOCK_SH, $timeout_s)) {
 		fclose($fp);
 		pfb_logger("\nADR-61: sync-status ledger read lock timed out [ {$path} ]", 2);
+		$unavailable = TRUE;
 		return [];
 	}
 	$raw = stream_get_contents($fp);
@@ -3938,12 +4008,19 @@ function pfb_sync_status_locked(string $ledger_dir, callable $fn, float $timeout
  * Idempotent by key: opening an already-open key updates message/last_seen in
  * place and preserves the original first_seen — it never duplicates the entry.
  *
+ * issue #1780: if the read-modify-write's own read of the ledger
+ * (pfb_sync_status_read_all(), a SEPARATE lock from this function's outer EX
+ * span below) expires, this call ABORTS -- it never persists an
+ * apparently-empty (in truth just-unreadable) ledger over intact data, and
+ * never adds the new key it was asked to open either.
+ *
  * @param string        $facility   'ip' | 'dnsbl'.
  * @param string        $item       The alias/group/feed name the entry is about.
  * @param string        $stage      'download' | 'parse' | 'apply' | 'dedup'.
  * @param string        $message    Human-readable failure description.
  * @param string        $ledger_dir Directory that contains pfb_sync_status.json.
  * @param callable|null $clock_fn   Returns the current epoch timestamp; defaults to time().
+ * @param float         $timeout_s  Bounded lock-acquire budget in seconds (issue #1780; injectable for tests).
  * @return void
  */
 function pfb_sync_status_open(
@@ -3952,11 +4029,18 @@ function pfb_sync_status_open(
 	string    $stage,
 	string    $message,
 	string    $ledger_dir,
-	?callable $clock_fn = null
+	?callable $clock_fn = null,
+	float     $timeout_s = 5.0
 ): void {
 	$now = ($clock_fn !== NULL) ? $clock_fn() : time();
-	pfb_sync_status_locked($ledger_dir, function () use ($facility, $item, $stage, $message, $now, $ledger_dir) {
-		$data       = pfb_sync_status_read_all($ledger_dir);
+	pfb_sync_status_locked($ledger_dir, function () use ($facility, $item, $stage, $message, $now, $ledger_dir, $timeout_s) {
+		$unavailable = FALSE;
+		$data = pfb_sync_status_read_all($ledger_dir, $timeout_s, $unavailable);
+		if ($unavailable) {
+			// The read already logged the expiry loudly -- abort the read-modify-write
+			// rather than risk persisting an empty-looking ledger over intact data.
+			return;
+		}
 		$existing   = $data[$facility][$item][$stage] ?? NULL;
 		$first_seen = (is_array($existing) && isset($existing['first_seen'])) ? $existing['first_seen'] : $now;
 
@@ -3966,7 +4050,7 @@ function pfb_sync_status_open(
 			'last_seen'  => $now,
 		];
 		pfb_sync_status_write_all($data, $ledger_dir);
-	});
+	}, $timeout_s);
 }
 
 /**
@@ -3974,16 +4058,24 @@ function pfb_sync_status_open(
  *
  * Closing an absent key is a safe no-op — no write, no exception.
  *
+ * issue #1780: if the read-modify-write's own read of the ledger
+ * expires, this call ABORTS -- same rationale as pfb_sync_status_open() above.
+ *
  * @param string $facility   'ip' | 'dnsbl'.
  * @param string $item       The alias/group/feed name the entry is about.
  * @param string $stage      'download' | 'parse' | 'apply' | 'dedup'.
  * @param string $ledger_dir Directory that contains pfb_sync_status.json.
+ * @param float  $timeout_s  Bounded lock-acquire budget in seconds (issue #1780; injectable for tests).
  * @return void
  */
-function pfb_sync_status_close(string $facility, string $item, string $stage, string $ledger_dir): void
+function pfb_sync_status_close(string $facility, string $item, string $stage, string $ledger_dir, float $timeout_s = 5.0): void
 {
-	pfb_sync_status_locked($ledger_dir, function () use ($facility, $item, $stage, $ledger_dir) {
-		$data = pfb_sync_status_read_all($ledger_dir);
+	pfb_sync_status_locked($ledger_dir, function () use ($facility, $item, $stage, $ledger_dir, $timeout_s) {
+		$unavailable = FALSE;
+		$data = pfb_sync_status_read_all($ledger_dir, $timeout_s, $unavailable);
+		if ($unavailable) {
+			return;
+		}
 		if (!isset($data[$facility][$item][$stage])) {
 			return;	// absent key -- safe no-op
 		}
@@ -3995,7 +4087,7 @@ function pfb_sync_status_close(string $facility, string $item, string $stage, st
 			unset($data[$facility]);
 		}
 		pfb_sync_status_write_all($data, $ledger_dir);
-	});
+	}, $timeout_s);
 }
 
 /**

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -490,4 +490,68 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			$this->assertSame('keep', file_get_contents($decoy));
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// issue #1780 F4 (review round) — restore the error-vs-timeout distinction
+	// the bounded refactor collapsed: pfb_unbound_py_publication_lock() must
+	// still log "timed out" (not "unavailable") on a genuine lock-acquire
+	// expiry.
+	//
+	// This does NOT by itself discriminate the F4 defect: the pre-refactor code
+	// already logged "timed out" unconditionally on ANY pfb_flock_bounded()
+	// failure (timeout or a real flock() error alike), so a genuine timeout
+	// scenario produces the SAME message before and after this fix -- it is a
+	// regression guard confirming the restored $timed_out-based branching did
+	// not swap the two messages. The genuine discriminating proof (a REAL
+	// flock() error, as opposed to a timeout) lives at the shared helper level:
+	// PfbFlockBoundedTest::testBoundedAcquireRealErrorReturnsFalsePromptlyWithTimedOutFalse
+	// forces an actual (non-would-block) flock() failure via a php://memory
+	// stream (portable across platforms, verified). Forcing that SAME kind of
+	// failure through this consumer's own fopen() of a real regular file is not
+	// portably/deterministically reproducible without new dependency injection
+	// this fix does not add (documented as a deviation in the PR handoff).
+	// -----------------------------------------------------------------------
+
+	public function testPublicationLockTimeoutLogsTimedOutNotUnavailable(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+
+		$lockPath   = dirname($GLOBALS['pfb']['unbound_py_sources']) . '/pfb_py_sources.lock';
+		$markerPath = "{$this->tmp}/publock_timeout.marker";
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->markTestSkipped('pcntl_fork() failed.');
+		}
+		if ($pid === 0) {
+			$fp = fopen($lockPath, 'c');
+			flock($fp, LOCK_EX);
+			touch($markerPath);
+			usleep(400000);
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			exit(0);
+		}
+		$deadline = microtime(TRUE) + 2.0;
+		while (!file_exists($markerPath)) {
+			if (microtime(TRUE) >= $deadline) {
+				pcntl_waitpid($pid, $waitStatus);
+				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
+			}
+			usleep(1000);
+		}
+
+		$result = pfb_unbound_py_publication_lock(0.15);
+		pcntl_waitpid($pid, $waitStatus);
+
+		$this->assertFalse($result, 'a contended publication lock acquire past its own budget must return FALSE');
+
+		$log = (string) file_get_contents($GLOBALS['pfb']['errlog']);
+		$this->assertStringContainsString('DNSBL publication lock timed out', $log,
+			'a genuine lock-acquire expiry must log "timed out", got errlog=' . var_export($log, TRUE));
+		$this->assertStringNotContainsString('DNSBL publication lock unavailable', $log,
+			'a genuine expiry must NOT log "unavailable" -- that string is reserved for a real flock() '
+			. 'error or an fopen() failure, never a mere timeout');
+	}
 }

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -526,7 +526,11 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		}
 		if ($pid === 0) {
 			$fp = fopen($lockPath, 'c');
-			flock($fp, LOCK_EX);
+			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
+				exit(1);	// never signal readiness without a REAL hold -- the parent
+					// would then run with no contention and a negative assertion
+					// ("no dispatch", "entry survived") would pass for the wrong reason
+			}
 			touch($markerPath);
 			usleep(400000);
 			flock($fp, LOCK_UN);

--- a/tests/php/DueLedgerTest.php
+++ b/tests/php/DueLedgerTest.php
@@ -997,7 +997,11 @@ final class DueLedgerTest extends TestCase
 		}
 		if ($pid === 0) {
 			$fp = fopen($lockPath, 'c');
-			flock($fp, LOCK_EX);
+			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
+				exit(1);	// never signal readiness without a REAL hold -- the parent
+					// would then run with no contention and a negative assertion
+					// ("no dispatch", "entry survived") would pass for the wrong reason
+			}
 			touch($markerPath);
 			usleep($holdMicros);
 			flock($fp, LOCK_UN);

--- a/tests/php/DueLedgerTest.php
+++ b/tests/php/DueLedgerTest.php
@@ -14,10 +14,14 @@ use PHPUnit\Framework\TestCase;
  * Functions under test:
  *   pfb_due_ledger_seeded_jitter(string $job_key, string $seed, int $max): int
  *   pfb_due_ledger_is_due_from_entry(?array $entry, int $now): bool
- *   pfb_due_ledger_read_entry(string $job_key, string $ledger_dir): ?array
+ *   pfb_due_ledger_read_entry(string $job_key, string $ledger_dir, float $timeout_s = 5.0,
+ *                          ?bool &$unavailable = NULL): ?array
  *   pfb_due_ledger_write_entry(string $job_key, array $entry, string $ledger_dir): void
  *   pfb_due_ledger_is_due(string $job_key, int $interval, int $now,
- *                          string $seed, int $jitter_max, string $ledger_dir): bool
+ *                          string $seed, int $jitter_max, string $ledger_dir,
+ *                          float $timeout_s = 5.0): bool
+ *   pfb_due_ledger_is_pending(string $job_key, string $ledger_dir, float $timeout_s = 5.0): bool
+ *   pfb_due_ledger_set_pending(string $job_key, string $ledger_dir, float $timeout_s = 5.0): void
  *   pfb_due_ledger_mark_ran(string $job_key, int $interval, int $now,
  *                            string $seed, int $jitter_max, string $ledger_dir): void
  *   pfb_due_ledger_mark_ran_anchored(string $job_key, int $interval, int $now,
@@ -42,6 +46,18 @@ use PHPUnit\Framework\TestCase;
  * Fixed constants used throughout (pre-verified by unit, not re-derived at runtime):
  *   seed='test-seed', job='dcc', max=86400  ⇒  seeded_jitter = 35079
  *   seed='test-seed', job='bl',  max=86400  ⇒  seeded_jitter = 79870
+ *
+ * issue #1780 F1/F2/F9 — a bounded lock acquire that EXPIRES is NOT the same as
+ * "absent" or "corrupt" (NULL already means both of those to every existing
+ * caller): read_entry signals it out-of-band via $unavailable, and every
+ * dispatch/persistence-critical caller (is_due, is_pending, set_pending) must
+ * fail closed on it ("I do not know") rather than fall into read_entry's
+ * existing NULL-is-absent handling (which would otherwise make an unreadable
+ * ledger look due-now / not-pending's opposite / safe-to-clobber). $timeout_s
+ * is injectable end-to-end (is_due/is_pending/set_pending gained an optional
+ * trailing param alongside the two low-level readers) so every expiry branch
+ * below is driven deterministically with a REAL second process (pcntl_fork),
+ * never a guessed sleep, mirroring PfbFlockBoundedTest.php's harness shape.
  */
 final class DueLedgerTest extends TestCase
 {
@@ -955,5 +971,217 @@ final class DueLedgerTest extends TestCase
 			"{$entry['next_due']} -- set_pending must not prevent anchoring on a REAL prior schedule");
 		$this->assertArrayNotHasKey('pending_apply', $entry,
 			'mark_ran_anchored must clear pending_apply by writing a clean entry');
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #1780 F1/F2/F9 — lock-acquire expiry: $unavailable discrimination,
+	// and every fail-closed caller (is_due / is_pending / set_pending).
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Fork a child that opens $lockPath fresh (never an inherited fd -- a genuine
+	 * second, independent lock holder), takes LOCK_EX, signals readiness via a
+	 * marker file, holds for $holdMicros, then releases. Mirrors
+	 * PfbFlockBoundedTest::forkRealLockHolder().
+	 *
+	 * @return int the child pid (caller must pcntl_waitpid it).
+	 */
+	private function forkRealLockHolder(string $lockPath, string $markerPath, int $holdMicros): int
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->markTestSkipped('pcntl_fork() failed.');
+		}
+		if ($pid === 0) {
+			$fp = fopen($lockPath, 'c');
+			flock($fp, LOCK_EX);
+			touch($markerPath);
+			usleep($holdMicros);
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			exit(0);
+		}
+		return $pid;
+	}
+
+	private function waitForMarker(string $markerPath, int $pid): void
+	{
+		$deadline = microtime(TRUE) + 2.0;
+		while (!file_exists($markerPath)) {
+			if (microtime(TRUE) >= $deadline) {
+				pcntl_waitpid($pid, $waitStatus);
+				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
+			}
+			usleep(1000);
+		}
+	}
+
+	/**
+	 * $unavailable discriminates: TRUE only on a genuine lock-acquire expiry;
+	 * FALSE on every other path (absent file, corrupt JSON, success). An
+	 * always-TRUE or always-FALSE flag must fail this test.
+	 *
+	 * Scenario:
+	 *   Given a real second process holding LOCK_EX on pfb_due_ledger.json past
+	 *   the parent's small injected budget.
+	 *   When  read_entry runs with that small budget.
+	 *   Then  it returns NULL (same as absent) AND $unavailable = TRUE.
+	 *   And   an absent file / corrupt JSON / a genuine success all set
+	 *         $unavailable = FALSE.
+	 */
+	public function testReadEntryUnavailableDiscriminatesLockTimeoutFromEveryOtherPath(): void
+	{
+		pfb_due_ledger_write_entry('dcc', [
+			'last_run' => self::NOW, 'next_due' => self::NOW + 1, 'jitter' => 0,
+		], $this->dir);
+
+		$lockPath   = $this->dir . '/pfb_due_ledger.json';
+		$markerPath = $this->dir . '/read_entry_timeout.marker';
+		// Holder keeps the lock for 400ms -- well past the 150ms budget under test.
+		$pid = $this->forkRealLockHolder($lockPath, $markerPath, 400000);
+		$this->waitForMarker($markerPath, $pid);
+
+		$unavailable = FALSE;
+		$entry = pfb_due_ledger_read_entry('dcc', $this->dir, 0.15, $unavailable);
+		pcntl_waitpid($pid, $waitStatus);
+
+		$this->assertNull($entry, 'an expired read must still return NULL (same as absent), never a stale/partial entry');
+		$this->assertTrue($unavailable, 'a genuine lock-acquire expiry must set $unavailable = TRUE');
+
+		// FALSE: absent ledger file (no is_file() match -- never even attempts the lock).
+		$absentDir = $this->dir . '/absent_subdir';
+		mkdir($absentDir, 0777, TRUE);
+		$absentUnavailable = TRUE;	// deliberately wrong initial value
+		$absentEntry = pfb_due_ledger_read_entry('dcc', $absentDir, 5.0, $absentUnavailable);
+		$this->assertNull($absentEntry);
+		$this->assertFalse($absentUnavailable, 'an absent ledger file must never report $unavailable = TRUE');
+
+		// FALSE: corrupt JSON.
+		$corruptDir = $this->dir . '/corrupt_subdir';
+		mkdir($corruptDir, 0777, TRUE);
+		file_put_contents($corruptDir . '/pfb_due_ledger.json', 'not valid json {{{{');
+		$corruptUnavailable = TRUE;
+		$corruptEntry = pfb_due_ledger_read_entry('dcc', $corruptDir, 5.0, $corruptUnavailable);
+		$this->assertNull($corruptEntry);
+		$this->assertFalse($corruptUnavailable, 'a corrupt JSON ledger must never report $unavailable = TRUE');
+
+		// FALSE: genuine success (the lock was released -- read the real entry).
+		$successUnavailable = TRUE;
+		$successEntry = pfb_due_ledger_read_entry('dcc', $this->dir, 5.0, $successUnavailable);
+		$this->assertNotNull($successEntry, 'the lock was released by the child above -- this read must succeed');
+		$this->assertFalse($successUnavailable, 'a successful read must never report $unavailable = TRUE');
+	}
+
+	/**
+	 * is_due() must fail CLOSED (not due) on a lock-acquire expiry, even for an
+	 * entry that IS genuinely due on disk -- the whole point of failing closed
+	 * is that the tick cannot safely confirm that on this read, so it must never
+	 * dispatch on a guess. The entry is seeded genuinely DUE (next_due in the
+	 * past) specifically so this test discriminates a real fix from a no-op:
+	 * code that merely waits out the contention and then reads the real (due)
+	 * entry would return TRUE here, not FALSE.
+	 *
+	 * Scenario:
+	 *   Given an entry that IS due (next_due in the past), and a real lock
+	 *   holder past is_due's injected budget.
+	 *   When  is_due() runs.
+	 *   Then  it returns FALSE (fail closed) -- NOT the TRUE the on-disk entry
+	 *         actually calls for.
+	 */
+	public function testIsDueFailsClosedOnLockTimeoutEvenWhenGenuinelyDue(): void
+	{
+		pfb_due_ledger_write_entry('dcc', [
+			'last_run' => self::NOW - self::INTERVAL_DAILY - 1, 'next_due' => self::NOW - 1, 'jitter' => 0,
+		], $this->dir);
+
+		$lockPath   = $this->dir . '/pfb_due_ledger.json';
+		$markerPath = $this->dir . '/is_due_timeout.marker';
+		$pid = $this->forkRealLockHolder($lockPath, $markerPath, 400000);
+		$this->waitForMarker($markerPath, $pid);
+
+		$result = pfb_due_ledger_is_due('dcc', self::INTERVAL_DAILY, self::NOW, self::SEED, self::MAX, $this->dir, 0.15);
+		pcntl_waitpid($pid, $waitStatus);
+
+		$this->assertFalse($result,
+			'is_due() must fail CLOSED (FALSE) on a lock-acquire expiry, even though the on-disk entry is '
+			. 'genuinely due -- treating an unreadable ledger as "absent" (is_due_from_entry(NULL, ...) '
+			. 'reads absent as due-now) or simply waiting out the contention and reading the real (due) '
+			. 'entry would both spuriously dispatch the job');
+	}
+
+	/**
+	 * is_pending() must return FALSE (not pending) on a lock-acquire expiry: an
+	 * unreadable ledger is not evidence of a pending deferred apply.
+	 *
+	 * Scenario:
+	 *   Given a REAL pending entry (pending_apply=TRUE) -- so, absent lock
+	 *   contention, is_pending() would return TRUE -- and a real lock holder
+	 *   past the injected budget.
+	 *   When  is_pending() runs.
+	 *   Then  it returns FALSE (fail closed), not the TRUE the on-disk entry
+	 *         actually holds -- proving this is genuinely the lock-timeout path,
+	 *         not an accidental "never was pending" result.
+	 */
+	public function testIsPendingReturnsFalseOnLockTimeout(): void
+	{
+		pfb_due_ledger_set_pending('cron', $this->dir);
+		$pending = pfb_due_ledger_read_entry('cron', $this->dir);
+		$this->assertTrue($pending['pending_apply'] ?? FALSE, 'precondition: the entry must genuinely be pending');
+
+		$lockPath   = $this->dir . '/pfb_due_ledger.json';
+		$markerPath = $this->dir . '/is_pending_timeout.marker';
+		$pid = $this->forkRealLockHolder($lockPath, $markerPath, 400000);
+		$this->waitForMarker($markerPath, $pid);
+
+		$result = pfb_due_ledger_is_pending('cron', $this->dir, 0.15);
+		pcntl_waitpid($pid, $waitStatus);
+
+		$this->assertFalse($result,
+			'is_pending() must return FALSE on a lock-acquire expiry, even though the on-disk entry is '
+			. 'genuinely pending_apply=TRUE -- an unreadable ledger must never be reported as pending');
+	}
+
+	/**
+	 * set_pending() must ABORT (write nothing) on a lock-acquire expiry, never
+	 * fall into read_entry's "absent ⇒ NULL" branch and persist a zeroed
+	 * {last_run:0, next_due:0, jitter:0, pending_apply:TRUE} placeholder over a
+	 * REAL, intact entry that merely could not be read this instant --
+	 * write_entry's own unlocked merge-read would otherwise pick the real entry
+	 * back up off disk and stomp its next_due/last_run to 0 with the placeholder.
+	 *
+	 * Scenario:
+	 *   Given a REAL entry with non-zero last_run/next_due, and a real lock
+	 *   holder past set_pending's injected budget.
+	 *   When  set_pending() runs.
+	 *   Then  the on-disk entry is BYTE-IDENTICAL afterwards -- no placeholder
+	 *         was written, the real schedule survives untouched.
+	 */
+	public function testSetPendingAbortsWriteOnLockTimeoutPreservingRealEntry(): void
+	{
+		$real = ['last_run' => self::NOW, 'next_due' => self::NOW + self::INTERVAL_DAILY, 'jitter' => 4242];
+		pfb_due_ledger_write_entry('cron', $real, $this->dir);
+		$ledgerPath = $this->dir . '/pfb_due_ledger.json';
+		$before     = file_get_contents($ledgerPath);
+
+		$markerPath = $this->dir . '/set_pending_timeout.marker';
+		$pid = $this->forkRealLockHolder($ledgerPath, $markerPath, 400000);
+		$this->waitForMarker($markerPath, $pid);
+
+		pfb_due_ledger_set_pending('cron', $this->dir, 0.15);
+		pcntl_waitpid($pid, $waitStatus);
+
+		$after = file_get_contents($ledgerPath);
+		$this->assertSame($before, $after,
+			'set_pending() must abort its write on a lock-acquire expiry -- the real entry must survive '
+			. 'byte-identical, never overwritten by a zeroed placeholder');
+
+		$entry = pfb_due_ledger_read_entry('cron', $this->dir);
+		$this->assertSame($real['next_due'], $entry['next_due'] ?? NULL,
+			'the real next_due must survive the aborted set_pending() call');
+		$this->assertArrayNotHasKey('pending_apply', $entry ?? [],
+			'set_pending() must not have applied pending_apply when it aborted');
 	}
 }

--- a/tests/php/PfbFlockBoundedTest.php
+++ b/tests/php/PfbFlockBoundedTest.php
@@ -12,13 +12,31 @@ use PHPUnit\Framework\TestCase;
  * capped") was refuted for five blocking flock() acquires with no bound. This
  * suite pins the shared helper those five call sites were rewritten to use:
  *
- *   pfb_flock_bounded($fp, int $operation, float $timeout_s): bool
+ *   pfb_flock_bounded($fp, int $operation, float $timeout_s, ?bool &$timed_out = NULL): bool
  *   pfb_unbound_py_publication_lock_timeout(): float
  *
  * Contention tests use a REAL second process (pcntl_fork), not a single-process
  * simulation, mirroring the harness shape in PfbSyncStatusLedgerTest.php: a child
  * takes a real flock() on a temp file, signals readiness via a marker file (never
  * a guessed sleep), and holds the lock LONGER than the parent's injected budget.
+ *
+ * F4 review round (issue #1780): the helper originally collapsed "a genuine
+ * flock() error" (would-block byref stays 0 -- not a contention signal at all)
+ * and "the wait genuinely expired" into the same bare FALSE, so every caller lost
+ * the ability to tell them apart (the pre-refactor code DID distinguish: see
+ * pfb_unbound_py_publication_lock()'s "unavailable" vs "timed out" messages).
+ * $timed_out is the restored signal: TRUE only when the deadline/poll-cap
+ * genuinely elapsed; FALSE on every other return (a real flock() error, or
+ * success). testBoundedAcquireRealErrorReturnsFalsePromptlyWithTimedOutFalse
+ * proves the FALSE side with a real, portable flock() error (a php://memory
+ * stream, whose stream wrapper never implements locking -- verified on both
+ * Linux and macOS, unlike a FIFO, which is lockable on Linux) instead of a
+ * contended wait.
+ *
+ * F7: the two contention tests below now also assert a LOWER bound on elapsed
+ * time (previously upper-bound-only) -- a broken helper that returned FALSE
+ * instantly, without ever attempting the lock, would have passed the old
+ * assertions.
  */
 #[CoversFunction('pfb_flock_bounded')]
 #[CoversFunction('pfb_unbound_py_publication_lock_timeout')]
@@ -95,16 +113,23 @@ final class PfbFlockBoundedTest extends TestCase
 		$this->waitForMarker($markerPath, $pid);
 
 		$fp = fopen($lockPath, 'c');	// fresh handle -- genuine second contender
-		$start   = microtime(TRUE);
-		$ok      = pfb_flock_bounded($fp, LOCK_EX, 0.2);
-		$elapsed = microtime(TRUE) - $start;
+		$start     = microtime(TRUE);
+		$timedOut  = FALSE;
+		$ok        = pfb_flock_bounded($fp, LOCK_EX, 0.2, $timedOut);
+		$elapsed   = microtime(TRUE) - $start;
 		fclose($fp);
 
 		pcntl_waitpid($pid, $waitStatus);
 
 		$this->assertFalse($ok, 'a bounded LOCK_EX acquire against a real, still-held lock must return FALSE, not block');
+		// F7: LOWER bound -- a helper that returned FALSE instantly, never actually
+		// attempting/polling the lock, must not pass. 0.15s (budget 0.2s minus margin).
+		$this->assertGreaterThanOrEqual(0.15, $elapsed,
+			'bounded acquire must have actually waited ~its budget (0.2s), not returned instantly; elapsed=' . $elapsed);
 		$this->assertLessThan(0.6, $elapsed,
 			'bounded acquire must expire near its own budget (0.2s), not wait out the holder\'s 0.8s hold; elapsed=' . $elapsed);
+		// F4: a genuine expiry must set the out-param TRUE.
+		$this->assertTrue($timedOut, 'a genuine deadline expiry must set $timed_out = TRUE');
 	}
 
 	public function testBoundedShAcquireExpiresAtBudgetNotAtRealHolderRelease(): void
@@ -120,16 +145,22 @@ final class PfbFlockBoundedTest extends TestCase
 		$this->waitForMarker($markerPath, $pid);
 
 		$fp = fopen($lockPath, 'c');
-		$start   = microtime(TRUE);
-		$ok      = pfb_flock_bounded($fp, LOCK_SH, 0.2);
-		$elapsed = microtime(TRUE) - $start;
+		$start    = microtime(TRUE);
+		$timedOut = FALSE;
+		$ok       = pfb_flock_bounded($fp, LOCK_SH, 0.2, $timedOut);
+		$elapsed  = microtime(TRUE) - $start;
 		fclose($fp);
 
 		pcntl_waitpid($pid, $waitStatus);
 
 		$this->assertFalse($ok, 'a bounded LOCK_SH acquire against a real EX holder must return FALSE, not block');
+		// F7: LOWER bound -- see the EX test above for rationale.
+		$this->assertGreaterThanOrEqual(0.15, $elapsed,
+			'bounded SH acquire must have actually waited ~its budget (0.2s), not returned instantly; elapsed=' . $elapsed);
 		$this->assertLessThan(0.6, $elapsed,
 			'bounded SH acquire must expire near its own budget (0.2s), not wait out the holder\'s 0.8s hold; elapsed=' . $elapsed);
+		// F4: a genuine expiry must set the out-param TRUE.
+		$this->assertTrue($timedOut, 'a genuine deadline expiry must set $timed_out = TRUE');
 	}
 
 	// -----------------------------------------------------------------------
@@ -142,13 +173,16 @@ final class PfbFlockBoundedTest extends TestCase
 		$path = $this->dir . '/uncontended.lock';
 		$fp   = fopen($path, 'c');
 
-		$start   = microtime(TRUE);
-		$ok      = pfb_flock_bounded($fp, LOCK_EX, 5.0);
-		$elapsed = microtime(TRUE) - $start;
+		$start    = microtime(TRUE);
+		$timedOut = TRUE;	// deliberately wrong initial value -- success must flip it to FALSE
+		$ok       = pfb_flock_bounded($fp, LOCK_EX, 5.0, $timedOut);
+		$elapsed  = microtime(TRUE) - $start;
 
 		$this->assertTrue($ok, 'an uncontended acquire must succeed');
 		$this->assertLessThan(0.5, $elapsed,
 			'an uncontended acquire must return promptly, not consume the full 5.0s budget; elapsed=' . $elapsed);
+		// F4 discrimination: success must never report a timeout.
+		$this->assertFalse($timedOut, 'an uncontended success must never set $timed_out = TRUE');
 
 		// Prove the lock is REALLY held: an independent second handle on the
 		// SAME file must fail a non-blocking probe while $fp still holds it.
@@ -161,6 +195,47 @@ final class PfbFlockBoundedTest extends TestCase
 		flock($fp, LOCK_UN);
 		fclose($fp);
 		fclose($probe);
+	}
+
+	// -----------------------------------------------------------------------
+	// C. F4 — a genuine flock() ERROR (not contention) must be distinguishable
+	// from a genuine timeout: $timed_out stays FALSE, and the call returns
+	// immediately (it never entered the poll-wait loop at all).
+	//
+	// A php://memory stream is the portable way to force this deterministically:
+	// its stream wrapper implements no locking at all, so flock() on it fails
+	// immediately with the would-block byref left at 0 (verified on both Linux
+	// and macOS) -- a REAL, non-contention error, unlike e.g. a FIFO, which is
+	// lockable (and so merely contends, never errors) on Linux.
+	// -----------------------------------------------------------------------
+
+	public function testBoundedAcquireRealErrorReturnsFalsePromptlyWithTimedOutFalse(): void
+	{
+		$fp = fopen('php://memory', 'r+');
+
+		// Pre-flight: confirm this environment's flock() really does treat
+		// php://memory as a genuine error (would-block byref stays 0), not
+		// would-block -- otherwise this test would silently prove nothing.
+		$probeWouldBlock = 99;
+		$probeOk = @flock($fp, LOCK_EX | LOCK_NB, $probeWouldBlock);
+		if ($probeOk !== FALSE || $probeWouldBlock === 1) {
+			$this->markTestSkipped('this PHP build\'s php://memory does not fail flock() as a real error -- cannot force the scenario this test needs.');
+		}
+
+		$start    = microtime(TRUE);
+		$timedOut = TRUE;	// deliberately wrong initial value -- a real error must set it FALSE
+		$ok       = pfb_flock_bounded($fp, LOCK_EX, 5.0, $timedOut);
+		$elapsed  = microtime(TRUE) - $start;
+		fclose($fp);
+
+		$this->assertFalse($ok, 'a genuine flock() error must return FALSE');
+		$this->assertFalse($timedOut,
+			'a genuine flock() error (not a would-block/timeout) must leave $timed_out = FALSE -- '
+			. 'collapsing it into TRUE is exactly the F4 defect (both consumer sites would then '
+			. 'misreport a real error as "timed out")');
+		$this->assertLessThan(0.5, $elapsed,
+			'a genuine flock() error must be reported immediately, never after waiting out the '
+			. "budget (5.0s) as if it were contention; elapsed={$elapsed}");
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbFlockBoundedTest.php
+++ b/tests/php/PfbFlockBoundedTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1780 — the shared bounded flock() acquire helper.
+ *
+ * The owner's premise ("an update pass cannot hang forever, since every wait is
+ * capped") was refuted for five blocking flock() acquires with no bound. This
+ * suite pins the shared helper those five call sites were rewritten to use:
+ *
+ *   pfb_flock_bounded($fp, int $operation, float $timeout_s): bool
+ *   pfb_unbound_py_publication_lock_timeout(): float
+ *
+ * Contention tests use a REAL second process (pcntl_fork), not a single-process
+ * simulation, mirroring the harness shape in PfbSyncStatusLedgerTest.php: a child
+ * takes a real flock() on a temp file, signals readiness via a marker file (never
+ * a guessed sleep), and holds the lock LONGER than the parent's injected budget.
+ */
+#[CoversFunction('pfb_flock_bounded')]
+#[CoversFunction('pfb_unbound_py_publication_lock_timeout')]
+final class PfbFlockBoundedTest extends TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_flock_bounded_test_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0777, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->dir . '/*') ?: [] as $file) {
+			@unlink($file);
+		}
+		@rmdir($this->dir);
+	}
+
+	/**
+	 * Fork a child that opens $lockPath fresh (never an inherited fd -- a genuine
+	 * second, independent lock holder), takes LOCK_EX, signals readiness via a
+	 * marker file, holds for $holdMicros, then releases.
+	 *
+	 * @return int the child pid (caller must pcntl_waitpid it).
+	 */
+	private function forkRealLockHolder(string $lockPath, string $markerPath, int $holdMicros): int
+	{
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->markTestSkipped('pcntl_fork() failed.');
+		}
+		if ($pid === 0) {
+			$fp = fopen($lockPath, 'c');
+			flock($fp, LOCK_EX);
+			touch($markerPath);
+			usleep($holdMicros);
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			exit(0);
+		}
+		return $pid;
+	}
+
+	private function waitForMarker(string $markerPath, int $pid): void
+	{
+		$deadline = microtime(TRUE) + 2.0;
+		while (!file_exists($markerPath)) {
+			if (microtime(TRUE) >= $deadline) {
+				pcntl_waitpid($pid, $waitStatus);
+				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
+			}
+			usleep(1000);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// A. Real contention -- the bounded acquire returns FALSE at ~budget, not
+	// at the holder's release, for BOTH LOCK_EX and LOCK_SH.
+	// -----------------------------------------------------------------------
+
+	public function testBoundedExAcquireExpiresAtBudgetNotAtRealHolderRelease(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+
+		$lockPath   = $this->dir . '/ex_contended.lock';
+		$markerPath = $this->dir . '/ex_contended.marker';
+		// Holder keeps the lock for 800ms -- well past the 200ms budget under test.
+		$pid = $this->forkRealLockHolder($lockPath, $markerPath, 800000);
+		$this->waitForMarker($markerPath, $pid);
+
+		$fp = fopen($lockPath, 'c');	// fresh handle -- genuine second contender
+		$start   = microtime(TRUE);
+		$ok      = pfb_flock_bounded($fp, LOCK_EX, 0.2);
+		$elapsed = microtime(TRUE) - $start;
+		fclose($fp);
+
+		pcntl_waitpid($pid, $waitStatus);
+
+		$this->assertFalse($ok, 'a bounded LOCK_EX acquire against a real, still-held lock must return FALSE, not block');
+		$this->assertLessThan(0.6, $elapsed,
+			'bounded acquire must expire near its own budget (0.2s), not wait out the holder\'s 0.8s hold; elapsed=' . $elapsed);
+	}
+
+	public function testBoundedShAcquireExpiresAtBudgetNotAtRealHolderRelease(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+
+		$lockPath   = $this->dir . '/sh_contended.lock';
+		$markerPath = $this->dir . '/sh_contended.marker';
+		// An EX holder blocks a SH waiter too -- reuse the same holder shape.
+		$pid = $this->forkRealLockHolder($lockPath, $markerPath, 800000);
+		$this->waitForMarker($markerPath, $pid);
+
+		$fp = fopen($lockPath, 'c');
+		$start   = microtime(TRUE);
+		$ok      = pfb_flock_bounded($fp, LOCK_SH, 0.2);
+		$elapsed = microtime(TRUE) - $start;
+		fclose($fp);
+
+		pcntl_waitpid($pid, $waitStatus);
+
+		$this->assertFalse($ok, 'a bounded LOCK_SH acquire against a real EX holder must return FALSE, not block');
+		$this->assertLessThan(0.6, $elapsed,
+			'bounded SH acquire must expire near its own budget (0.2s), not wait out the holder\'s 0.8s hold; elapsed=' . $elapsed);
+	}
+
+	// -----------------------------------------------------------------------
+	// B. Uncontended success -- returns TRUE promptly, and the lock is REALLY
+	// held (proven by a second independent handle failing a non-blocking probe).
+	// -----------------------------------------------------------------------
+
+	public function testBoundedAcquireSucceedsPromptlyAndActuallyHoldsTheLock(): void
+	{
+		$path = $this->dir . '/uncontended.lock';
+		$fp   = fopen($path, 'c');
+
+		$start   = microtime(TRUE);
+		$ok      = pfb_flock_bounded($fp, LOCK_EX, 5.0);
+		$elapsed = microtime(TRUE) - $start;
+
+		$this->assertTrue($ok, 'an uncontended acquire must succeed');
+		$this->assertLessThan(0.5, $elapsed,
+			'an uncontended acquire must return promptly, not consume the full 5.0s budget; elapsed=' . $elapsed);
+
+		// Prove the lock is REALLY held: an independent second handle on the
+		// SAME file must fail a non-blocking probe while $fp still holds it.
+		$probe = fopen($path, 'c');
+		$wouldBlock = 0;
+		$probeOk = @flock($probe, LOCK_EX | LOCK_NB, $wouldBlock);
+		$this->assertFalse($probeOk, 'a second independent handle must be unable to acquire while the first still holds the lock');
+		$this->assertSame(1, $wouldBlock, 'the second handle\'s failure must be a real contention (would-block), not some other flock() error');
+
+		flock($fp, LOCK_UN);
+		fclose($fp);
+		fclose($probe);
+	}
+
+	// -----------------------------------------------------------------------
+	// D. Publication-lock NULL default resolves to a finite, positive budget.
+	// (Never actually waits 60s -- only the accessor's return value is checked.)
+	// -----------------------------------------------------------------------
+
+	public function testPublicationLockDefaultTimeoutIsFiniteAndPositive(): void
+	{
+		$timeout = pfb_unbound_py_publication_lock_timeout();
+
+		$this->assertIsFloat($timeout);
+		$this->assertTrue(is_finite($timeout), 'the default publication-lock timeout must be finite -- got ' . var_export($timeout, TRUE));
+		$this->assertGreaterThan(0.0, $timeout, 'the default publication-lock timeout must be strictly positive -- got ' . $timeout);
+	}
+}

--- a/tests/php/PfbFlockBoundedTest.php
+++ b/tests/php/PfbFlockBoundedTest.php
@@ -251,4 +251,45 @@ final class PfbFlockBoundedTest extends TestCase
 		$this->assertTrue(is_finite($timeout), 'the default publication-lock timeout must be finite -- got ' . var_export($timeout, TRUE));
 		$this->assertGreaterThan(0.0, $timeout, 'the default publication-lock timeout must be strictly positive -- got ' . $timeout);
 	}
+
+	// -----------------------------------------------------------------------
+	// E. A budget that is not representable as an int must not silently UNBIND
+	// the poll cap. $timeout_s is a public float parameter, so INF (or any float
+	// whose /0.02 quotient overflows int) reaches the `(int) ceil(...)` poll-cap
+	// computation; that cast raises "not representable as an int" and yields 0,
+	// collapsing the cap from "one poll per 20ms of budget" to 2 attempts total.
+	// The second of the two independent bounds then stops bounding anything.
+	// -----------------------------------------------------------------------
+
+	public function testNonRepresentableBudgetRaisesNoDiagnosticAndStillAcquires(): void
+	{
+		foreach (['INF' => INF, 'huge' => 1e300] as $label => $budget) {
+			$path = tempnam(sys_get_temp_dir(), 'pfbflock');
+			$fp   = fopen($path, 'c');
+
+			$diagnostics = [];
+			set_error_handler(function (int $no, string $str) use (&$diagnostics): bool {
+				$diagnostics[] = "[{$no}] {$str}";
+				return TRUE;
+			});
+			try {
+				$acquired = pfb_flock_bounded($fp, LOCK_EX, $budget);
+			} finally {
+				restore_error_handler();
+			}
+
+			$this->assertSame(
+				[],
+				$diagnostics,
+				"a {$label} budget must not raise a PHP diagnostic: the poll-cap cast warns and "
+				. 'collapses the cap to 2 attempts, so the wait is no longer bounded by polls -- got '
+				. implode('; ', $diagnostics)
+			);
+			$this->assertTrue($acquired, "an uncontended acquire must still succeed with a {$label} budget");
+
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			@unlink($path);
+		}
+	}
 }

--- a/tests/php/PfbFlockBoundedTest.php
+++ b/tests/php/PfbFlockBoundedTest.php
@@ -73,7 +73,11 @@ final class PfbFlockBoundedTest extends TestCase
 		}
 		if ($pid === 0) {
 			$fp = fopen($lockPath, 'c');
-			flock($fp, LOCK_EX);
+			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
+				exit(1);	// never signal readiness without a REAL hold -- the parent
+					// would then run with no contention and a negative assertion
+					// ("no dispatch", "entry survived") would pass for the wrong reason
+			}
 			touch($markerPath);
 			usleep($holdMicros);
 			flock($fp, LOCK_UN);

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -13,9 +13,12 @@ use PHPUnit\Framework\TestCase;
  *
  * Functions under test:
  *   pfb_sync_status_open(string $facility, string $item, string $stage,
- *                          string $message, string $ledger_dir, ?callable $clock_fn = null): void
- *   pfb_sync_status_close(string $facility, string $item, string $stage, string $ledger_dir): void
+ *                          string $message, string $ledger_dir, ?callable $clock_fn = null,
+ *                          float $timeout_s = 5.0): void
+ *   pfb_sync_status_close(string $facility, string $item, string $stage, string $ledger_dir,
+ *                          float $timeout_s = 5.0): void
  *   pfb_sync_status_list_open(string $ledger_dir, ?string $facility = null): array
+ *   pfb_sync_status_read_all(string $ledger_dir, float $timeout_s = 5.0, ?bool &$unavailable = NULL): array
  *   pfb_sync_status_locked(string $ledger_dir, callable $fn, float $timeout_s = 5.0): void
  *
  * Coverage mandate (CLAUDE.md "Test coverage") — every branch:
@@ -36,6 +39,19 @@ use PHPUnit\Framework\TestCase;
  *          acquire is now BOUNDED -- a real, still-held lock past the budget
  *          logs an observable timeout and still runs $fn() (fail-open), and
  *          that signal discriminates (never fires on an uncontended success).
+ *
+ * issue #1780 F1/F2/F9 (review round) — unlike pfb_sync_status_locked() above
+ * (whose EX acquire on pfb_sync_status.json.lock keeps its EXISTING fail-open
+ * contract: still runs $fn() after a timeout), read_all()'s OWN SH acquire on
+ * the DATA file (pfb_sync_status.json) itself is a SEPARATE lock. A bounded
+ * expiry there returns [] — a value that already means "empty ledger" to every
+ * caller — so open()/close() (both read-modify-write through read_all() inside
+ * the _locked() span) must fail closed on it: ABORT, never write back an
+ * (apparently empty, actually just-unreadable) ledger over intact data. The
+ * signal is the read_all() out-param $unavailable — never conflated with []'s
+ * existing "empty" meaning. $timeout_s is injectable end-to-end (open/close
+ * gained an optional trailing param alongside read_all itself) so the expiry
+ * branch is driven deterministically with a REAL second process (pcntl_fork).
  */
 #[CoversFunction('pfb_sync_status_open')]
 #[CoversFunction('pfb_sync_status_close')]
@@ -484,5 +500,154 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		$open = pfb_sync_status_list_open($this->dir, 'ip');
 		$this->assertCount(1, $open, 'closing Foo must close only its exact key, leaving prefix-adjacent FooBar open');
 		$this->assertSame('pfB_FooBar_v4', $open[0]['item']);
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #1780 F1/F2/F9 — read_all()'s $unavailable discrimination, and the
+	// two read-modify-write callers (open/close) failing closed on it.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Fork a child that opens $lockPath fresh (never an inherited fd -- a genuine
+	 * second, independent lock holder), takes LOCK_EX, signals readiness via a
+	 * marker file, holds for $holdMicros, then releases.
+	 *
+	 * @return int the child pid (caller must pcntl_waitpid it).
+	 */
+	private function forkRealDataFileHolder(string $lockPath, string $markerPath, int $holdMicros): int
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->markTestSkipped('pcntl_fork() failed.');
+		}
+		if ($pid === 0) {
+			$fp = fopen($lockPath, 'c');
+			flock($fp, LOCK_EX);
+			touch($markerPath);
+			usleep($holdMicros);
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			exit(0);
+		}
+		return $pid;
+	}
+
+	private function waitForDataFileMarker(string $markerPath, int $pid): void
+	{
+		$deadline = microtime(TRUE) + 2.0;
+		while (!file_exists($markerPath)) {
+			if (microtime(TRUE) >= $deadline) {
+				pcntl_waitpid($pid, $waitStatus);
+				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
+			}
+			usleep(1000);
+		}
+	}
+
+	/**
+	 * read_all()'s $unavailable discriminates: TRUE only on a genuine
+	 * lock-acquire expiry against the DATA file (pfb_sync_status.json) itself --
+	 * a SEPARATE lock from pfb_sync_status_locked()'s .json.lock EX acquire.
+	 * FALSE on every other path (absent file, corrupt JSON, success). An
+	 * always-TRUE or always-FALSE flag must fail this test.
+	 */
+	public function testReadAllUnavailableDiscriminatesLockTimeoutFromEveryOtherPath(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+
+		$dataPath   = $this->dir . '/pfb_sync_status.json';
+		$markerPath = $this->dir . '/read_all_timeout.marker';
+		// Holder keeps the lock for 400ms -- well past the 150ms budget under test.
+		$pid = $this->forkRealDataFileHolder($dataPath, $markerPath, 400000);
+		$this->waitForDataFileMarker($markerPath, $pid);
+
+		$unavailable = FALSE;
+		$data = pfb_sync_status_read_all($this->dir, 0.15, $unavailable);
+		pcntl_waitpid($pid, $waitStatus);
+
+		$this->assertSame([], $data, 'an expired read must still return [] (same as empty), never a stale/partial ledger');
+		$this->assertTrue($unavailable, 'a genuine lock-acquire expiry must set $unavailable = TRUE');
+
+		// FALSE: absent ledger file.
+		$absentDir = $this->dir . '/absent_subdir';
+		mkdir($absentDir, 0777, TRUE);
+		$absentUnavailable = TRUE;	// deliberately wrong initial value
+		$absentData = pfb_sync_status_read_all($absentDir, 5.0, $absentUnavailable);
+		$this->assertSame([], $absentData);
+		$this->assertFalse($absentUnavailable, 'an absent ledger file must never report $unavailable = TRUE');
+
+		// FALSE: corrupt JSON.
+		$corruptDir = $this->dir . '/corrupt_subdir';
+		mkdir($corruptDir, 0777, TRUE);
+		file_put_contents($corruptDir . '/pfb_sync_status.json', 'not valid json {{{{');
+		$corruptUnavailable = TRUE;
+		$corruptData = pfb_sync_status_read_all($corruptDir, 5.0, $corruptUnavailable);
+		$this->assertSame([], $corruptData);
+		$this->assertFalse($corruptUnavailable, 'a corrupt JSON ledger must never report $unavailable = TRUE');
+
+		// FALSE: genuine success (the lock was released -- read the real data).
+		$successUnavailable = TRUE;
+		$successData = pfb_sync_status_read_all($this->dir, 5.0, $successUnavailable);
+		$this->assertNotSame([], $successData, 'the lock was released by the child above -- this read must succeed');
+		$this->assertFalse($successUnavailable, 'a successful read must never report $unavailable = TRUE');
+	}
+
+	/**
+	 * pfb_sync_status_open() must ABORT its read-modify-write on a lock-acquire
+	 * expiry against the DATA file -- never persist an apparently-empty (in
+	 * truth just-unreadable) ledger over an intact pre-existing entry, and never
+	 * add the NEW key it was asked to open either (the read it needed to merge
+	 * against never completed). Discriminates a real fix from a no-op: code
+	 * that merely waits out the contention and then reads the real ledger would
+	 * successfully add the new key here, not abort.
+	 */
+	public function testSyncStatusOpenAbortsRmwOnDataFileLockTimeout(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Existing_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir), 'precondition: one entry exists before the contended open()');
+
+		$dataPath   = $this->dir . '/pfb_sync_status.json';
+		$markerPath = $this->dir . '/open_abort_timeout.marker';
+		$pid = $this->forkRealDataFileHolder($dataPath, $markerPath, 400000);
+		$this->waitForDataFileMarker($markerPath, $pid);
+
+		pfb_sync_status_open('dnsbl', 'SomeGroup', 'apply', 'should never persist', $this->dir, self::clockAt(2000), 0.15);
+		pcntl_waitpid($pid, $waitStatus);
+
+		$open = pfb_sync_status_list_open($this->dir);
+		$this->assertCount(1, $open,
+			'open() must have aborted on the lock-acquire expiry -- the new key must NOT have been added, '
+			. 'got ' . var_export($open, TRUE));
+		$this->assertSame('pfB_Existing_v4', $open[0]['item'],
+			'the pre-existing entry must survive an aborted open() untouched');
+	}
+
+	/**
+	 * pfb_sync_status_close() must ABORT its read-modify-write on a lock-acquire
+	 * expiry against the DATA file -- the entry it was asked to close must
+	 * still be OPEN afterwards (the read it needed never completed, so it never
+	 * learned the key was even there to remove).
+	 */
+	public function testSyncStatusCloseAbortsRmwOnDataFileLockTimeout(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_StillOpen_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir), 'precondition: the entry must be open before the contended close()');
+
+		$dataPath   = $this->dir . '/pfb_sync_status.json';
+		$markerPath = $this->dir . '/close_abort_timeout.marker';
+		$pid = $this->forkRealDataFileHolder($dataPath, $markerPath, 400000);
+		$this->waitForDataFileMarker($markerPath, $pid);
+
+		pfb_sync_status_close('ip', 'pfB_StillOpen_v4', 'download', $this->dir, 0.15);
+		pcntl_waitpid($pid, $waitStatus);
+
+		$open = pfb_sync_status_list_open($this->dir);
+		$this->assertCount(1, $open,
+			'close() must have aborted on the lock-acquire expiry -- the entry must still be OPEN, '
+			. 'got ' . var_export($open, TRUE));
+		$this->assertSame('pfB_StillOpen_v4', $open[0]['item']);
 	}
 }

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  *                          string $message, string $ledger_dir, ?callable $clock_fn = null): void
  *   pfb_sync_status_close(string $facility, string $item, string $stage, string $ledger_dir): void
  *   pfb_sync_status_list_open(string $ledger_dir, ?string $facility = null): array
- *   pfb_sync_status_locked(string $ledger_dir, callable $fn): void
+ *   pfb_sync_status_locked(string $ledger_dir, callable $fn, float $timeout_s = 5.0): void
  *
  * Coverage mandate (CLAUDE.md "Test coverage") — every branch:
  *   open:  new key creates an entry; an already-open key refreshes message/
@@ -32,7 +32,10 @@ use PHPUnit\Framework\TestCase;
  *          exclusive lock (proven against an actual second process, not a
  *          single-process simulation) — closes the TOCTOU window between a
  *          read and its paired write that would otherwise let two concurrent
- *          writers silently discard one another's update.
+ *          writers silently discard one another's update. issue #1780: the
+ *          acquire is now BOUNDED -- a real, still-held lock past the budget
+ *          logs an observable timeout and still runs $fn() (fail-open), and
+ *          that signal discriminates (never fires on an uncontended success).
  */
 #[CoversFunction('pfb_sync_status_open')]
 #[CoversFunction('pfb_sync_status_close')]
@@ -297,6 +300,97 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			$elapsed,
 			'pfb_sync_status_open() must block on the lock file until the real concurrent holder releases it -- a near-instant return means the read-modify-write span is not actually protected'
 		);
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #1780 — pfb_sync_status_locked()'s EX acquire must be BOUNDED: on a
+	// real, still-held lock it logs the timeout loudly (observable) and still
+	// runs $fn() (fail-open contract unchanged), and that signal must
+	// DISCRIMINATE -- never fire on an ordinary uncontended success.
+	// -----------------------------------------------------------------------
+
+	public function testSyncStatusLockedExpiryIsObservableAndStillRunsFn(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+
+		$originalPfb = $GLOBALS['pfb'] ?? [];
+		$GLOBALS['pfb'] = array_merge($originalPfb, [
+			'log'    => $this->dir . '/pfblockerng.log',
+			'errlog' => $this->dir . '/error.log',
+		]);
+
+		$lockPath   = $this->dir . '/pfb_sync_status.json.lock';
+		$markerPath = $this->dir . '/child_locked_expiry.marker';
+		$pid        = pcntl_fork();
+		if ($pid === -1) {
+			$GLOBALS['pfb'] = $originalPfb;
+			$this->markTestSkipped('pcntl_fork() failed.');
+		}
+
+		if ($pid === 0) {
+			// Child: fresh fopen() (not an inherited fd) -- a genuine second,
+			// independent lock holder. Holds well past the parent's small budget.
+			$fp = fopen($lockPath, 'c');
+			flock($fp, LOCK_EX);
+			touch($markerPath);
+			usleep(500000);
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			exit(0);
+		}
+
+		$deadline = microtime(TRUE) + 2.0;
+		while (!file_exists($markerPath)) {
+			if (microtime(TRUE) >= $deadline) {
+				pcntl_waitpid($pid, $waitStatus);
+				$GLOBALS['pfb'] = $originalPfb;
+				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
+			}
+			usleep(1000);
+		}
+
+		try {
+			$fnRan = FALSE;
+			pfb_sync_status_locked($this->dir, function () use (&$fnRan) {
+				$fnRan = TRUE;
+			}, 0.1);
+
+			$this->assertTrue($fnRan,
+				'the callable must still run under the fail-open contract even after the lock acquire times out');
+
+			$log = (string) file_get_contents($GLOBALS['pfb']['log']);
+			$this->assertStringContainsString('sync-status ledger lock timed out', $log,
+				'a timed-out acquire must be logged loudly -- an operator-observable signal, never silent');
+		} finally {
+			pcntl_waitpid($pid, $waitStatus);
+			$GLOBALS['pfb'] = $originalPfb;
+		}
+	}
+
+	public function testSyncStatusLockedSuccessDoesNotEmitTimeoutSignal(): void
+	{
+		$originalPfb = $GLOBALS['pfb'] ?? [];
+		$GLOBALS['pfb'] = array_merge($originalPfb, [
+			'log'    => $this->dir . '/pfblockerng_success.log',
+			'errlog' => $this->dir . '/error_success.log',
+		]);
+
+		try {
+			$fnRan = FALSE;
+			pfb_sync_status_locked($this->dir, function () use (&$fnRan) {
+				$fnRan = TRUE;
+			}, 5.0);
+
+			$this->assertTrue($fnRan, 'the callable must run on the ordinary uncontended success path');
+
+			$log = file_exists($GLOBALS['pfb']['log']) ? (string) file_get_contents($GLOBALS['pfb']['log']) : '';
+			$this->assertStringNotContainsString('lock timed out', $log,
+				'the timeout signal must DISCRIMINATE -- it must never fire on an uncontended success');
+		} finally {
+			$GLOBALS['pfb'] = $originalPfb;
+		}
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -285,7 +285,11 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			// read-modify-write), then release. A fresh fopen() (not an inherited fd)
 			// makes this a genuine second, independent lock holder.
 			$fp = fopen($lockPath, 'c');
-			flock($fp, LOCK_EX);
+			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
+				exit(1);	// never signal readiness without a REAL hold -- the parent
+					// would then run with no contention and a negative assertion
+					// ("no dispatch", "entry survived") would pass for the wrong reason
+			}
 			touch($markerPath);
 			usleep(500000);
 			flock($fp, LOCK_UN);
@@ -349,7 +353,11 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			// Child: fresh fopen() (not an inherited fd) -- a genuine second,
 			// independent lock holder. Holds well past the parent's small budget.
 			$fp = fopen($lockPath, 'c');
-			flock($fp, LOCK_EX);
+			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
+				exit(1);	// never signal readiness without a REAL hold -- the parent
+					// would then run with no contention and a negative assertion
+					// ("no dispatch", "entry survived") would pass for the wrong reason
+			}
 			touch($markerPath);
 			usleep(500000);
 			flock($fp, LOCK_UN);
@@ -525,7 +533,11 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		}
 		if ($pid === 0) {
 			$fp = fopen($lockPath, 'c');
-			flock($fp, LOCK_EX);
+			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
+				exit(1);	// never signal readiness without a REAL hold -- the parent
+					// would then run with no contention and a negative assertion
+					// ("no dispatch", "entry survived") would pass for the wrong reason
+			}
 			touch($markerPath);
 			usleep($holdMicros);
 			flock($fp, LOCK_UN);

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -1189,7 +1189,11 @@ final class TickEntrypointTest extends TestCase
 		}
 		if ($pid === 0) {
 			$fp = fopen($lockPath, 'c');
-			flock($fp, LOCK_EX);
+			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
+				exit(1);	// never signal readiness without a REAL hold -- the parent
+					// would then run with no contention and a negative assertion
+					// ("no dispatch", "entry survived") would pass for the wrong reason
+			}
 			touch($markerPath);
 			usleep($holdMicros);
 			flock($fp, LOCK_UN);

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -1162,4 +1162,127 @@ final class TickEntrypointTest extends TestCase
 			. 'expected \'log\' trimmed to [l3,l4,l5] (genuinely idle tick), got '
 			. var_export($linesAfter, TRUE));
 	}
+
+	// -----------------------------------------------------------------------
+	// issue #1780 F1/F2 (review round) — a bounded due-ledger lock acquire that
+	// EXPIRES must not be treated as "absent" (pfb_due_ledger_is_due_from_entry
+	// reads absent as due-now): a lock timeout must never spuriously dispatch a
+	// job that is NOT actually due, and the resulting $dispatched=TRUE must not
+	// suppress log maintenance (the whole point of this ticket).
+	//
+	// pfblockerng_tick() itself takes no injectable timeout override -- by
+	// design, it is the real, un-parameterized entrypoint, same as every other
+	// case in this suite -- so proving a genuine expiry needs the holder to
+	// outlive every read's production 5.0s default. This is the one genuinely
+	// slow (~5.5s) test in the issue #1780 suite; every other review-round test
+	// drives an injectable low-level budget directly and stays fast.
+	// -----------------------------------------------------------------------
+
+	private function forkRealDueLedgerHolder(string $lockPath, string $markerPath, int $holdMicros): int
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->markTestSkipped('pcntl_fork() failed.');
+		}
+		if ($pid === 0) {
+			$fp = fopen($lockPath, 'c');
+			flock($fp, LOCK_EX);
+			touch($markerPath);
+			usleep($holdMicros);
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			exit(0);
+		}
+		return $pid;
+	}
+
+	private function waitForDueLedgerMarker(string $markerPath, int $pid): void
+	{
+		$deadline = microtime(TRUE) + 2.0;
+		while (!file_exists($markerPath)) {
+			if (microtime(TRUE) >= $deadline) {
+				pcntl_waitpid($pid, $waitStatus);
+				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
+			}
+			usleep(1000);
+		}
+	}
+
+	/**
+	 * Red->green (this is the review-round defect on top of #573/#1769, not
+	 * either of those originals): before this fix, a due-ledger lock timeout
+	 * made pfb_due_ledger_is_due() fall through to
+	 * pfb_due_ledger_is_due_from_entry(NULL, ...)'s "absent ⇒ due" rule, so a
+	 * job that was NOT actually due got dispatched anyway -- and the resulting
+	 * $dispatched=TRUE then suppressed the very log maintenance this ticket
+	 * exists to unblock.
+	 *
+	 * Scenario:
+	 *   Given NOT-due cron/dcc/bl ledger entries, and a real second process
+	 *   holding an exclusive flock() on pfb_due_ledger.json for 5.5s (past
+	 *   every read's 5.0s production budget) for the whole tick.
+	 *   When  pfblockerng_tick() runs.
+	 *   Then  no job is dispatched (the ledger file is byte-identical before
+	 *         and after), $dispatched stayed FALSE so log maintenance still
+	 *         ran (no "skipped"/"deferred" syslog line), and the lock-acquire
+	 *         expiry was logged loudly.
+	 */
+	public function testDueLedgerLockTimeoutFailsClosedAndStillRunsLogMaintenance(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+
+		$this->seedTickPrereqs('24');
+		// Mirrors src/usr/local/www/pfblockerng/pfblockerng.php:63 -- see Case A.
+		pfb_global();
+		$this->ensureLogDir();
+
+		$now = time();
+		$this->seedFutureLedgerEntry('cron', $now);
+		$this->seedFutureLedgerEntry('dcc',  $now);
+		$this->seedFutureLedgerEntry('bl',   $now);
+
+		$this->assertFalse(pfb_update_pass_running(),
+			'a pfblockerng.php worker process leaked from an earlier test -- see issue #1666');
+
+		$ledgerPath = $GLOBALS['pfb']['dbdir'] . '/pfb_due_ledger.json';
+		$before     = (string) file_get_contents($ledgerPath);
+
+		$markerPath = $GLOBALS['pfb']['dbdir'] . '/due_ledger_lock_holder.marker';
+		// 5.5s: past every read's production 5.0s default (see suite-level comment above).
+		$pid = $this->forkRealDueLedgerHolder($ledgerPath, $markerPath, 5500000);
+		$this->waitForDueLedgerMarker($markerPath, $pid);
+
+		// Act.
+		pfblockerng_tick();
+
+		pcntl_waitpid($pid, $waitStatus);
+
+		// No dispatch: the ledger file must be byte-identical (no mark_ran/
+		// mark_ran_anchored write, no set_pending write).
+		clearstatcache(TRUE, $ledgerPath);
+		$after = (string) file_get_contents($ledgerPath);
+		$this->assertSame($before, $after,
+			'a due-ledger lock timeout must never dispatch -- the ledger file must be byte-identical '
+			. 'before and after the tick (a spurious dispatch would have rewritten cron\'s next_due)');
+
+		// $dispatched stayed FALSE: log maintenance still ran (no skip/defer message).
+		$skippedOrDeferred = array_values(array_filter(
+			$GLOBALS['pfb_test_syslog_calls'] ?? [],
+			static fn (array $c) => str_contains($c['body'], 'log maintenance skipped')
+				|| str_contains($c['body'], 'log maintenance deferred')
+		));
+		$this->assertSame([], $skippedOrDeferred,
+			'a due-ledger lock timeout must NOT dispatch, so it must NOT suppress log maintenance either '
+			. '($dispatched must stay FALSE) -- got ' . var_export($GLOBALS['pfb_test_syslog_calls'] ?? [], TRUE));
+
+		// The expiry was logged loudly (pfb_due_ledger_read_entry's own ADR-43 message).
+		$errLog = (string) @file_get_contents($GLOBALS['pfb']['errlog']);
+		$this->assertStringContainsString('due-ledger read lock timed out', $errLog,
+			'the lock-acquire expiry must be logged loudly, got errlog=' . var_export($errLog, TRUE));
+	}
 }

--- a/tests/php/UnboundPyControlWriteTest.php
+++ b/tests/php/UnboundPyControlWriteTest.php
@@ -441,7 +441,11 @@ final class UnboundPyControlWriteTest extends TestCase
 		}
 		if ($pid === 0) {
 			$fp = fopen($lockPath, 'c');
-			flock($fp, LOCK_EX);
+			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
+				exit(1);	// never signal readiness without a REAL hold -- the parent
+					// would then run with no contention and a negative assertion
+					// ("no dispatch", "entry survived") would pass for the wrong reason
+			}
 			touch($markerPath);
 			usleep(5500000);	// past the hardcoded 5.0s lock-acquire budget
 			flock($fp, LOCK_UN);

--- a/tests/php/UnboundPyControlWriteTest.php
+++ b/tests/php/UnboundPyControlWriteTest.php
@@ -401,4 +401,72 @@ final class UnboundPyControlWriteTest extends TestCase
 		$this->assertSame(2, $seq2);
 		$this->assertSame(2, $this->readRecord()['seq']);
 	}
+
+	// -----------------------------------------------------------------------
+	// issue #1780 F4 (review round) — restore the error-vs-timeout distinction
+	// the bounded refactor collapsed: the PFBL-03 control-channel lock must
+	// still log "acquire timed out" (not "acquire failed") on a genuine
+	// lock-acquire expiry.
+	//
+	// This does NOT by itself discriminate the F4 defect for the same reason as
+	// DnsblManifestAtomicGenerationTest::testPublicationLockTimeoutLogsTimedOutNotUnavailable
+	// (the pre-refactor code already logged "timed out" unconditionally on ANY
+	// pfb_flock_bounded() failure) -- it is a regression guard confirming the
+	// restored $timed_out-based branching did not swap the messages. See that
+	// test's docblock for why the genuine discriminating proof lives at the
+	// shared helper level instead, and why this consumer's own real-flock-error
+	// branch is not portably testable without new scope.
+	//
+	// pfb_unbound_py_write_control() has no injectable lock-acquire budget of
+	// its own (unlike pfb_unbound_py_publication_lock()) -- $wait_timeout is a
+	// SEPARATE concept (how long to wait for the watcher to APPLY the command
+	// after it publishes, not the lock acquire itself) -- so proving a genuine
+	// expiry here needs the holder to outlive the hardcoded 5.0s lock budget.
+	// -----------------------------------------------------------------------
+
+	public function testWriteControlLockTimeoutLogsTimedOutNotFailed(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+
+		$GLOBALS['pfb']['log']    = "{$this->tmp}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$this->tmp}/error.log";
+
+		$lockPath   = "{$this->tmp}/pfb_py_control.lock";
+		$markerPath = "{$this->tmp}/control_lock_timeout.marker";
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->markTestSkipped('pcntl_fork() failed.');
+		}
+		if ($pid === 0) {
+			$fp = fopen($lockPath, 'c');
+			flock($fp, LOCK_EX);
+			touch($markerPath);
+			usleep(5500000);	// past the hardcoded 5.0s lock-acquire budget
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			exit(0);
+		}
+		$deadline = microtime(TRUE) + 2.0;
+		while (!file_exists($markerPath)) {
+			if (microtime(TRUE) >= $deadline) {
+				pcntl_waitpid($pid, $waitStatus);
+				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
+			}
+			usleep(1000);
+		}
+
+		$result = pfb_unbound_py_write_control('enable');
+		pcntl_waitpid($pid, $waitStatus);
+
+		$this->assertFalse($result, 'a contended control-channel lock acquire must return FALSE');
+
+		$log = (string) file_get_contents($GLOBALS['pfb']['errlog']);
+		$this->assertStringContainsString('PFBL-03: control channel lock acquire timed out', $log,
+			'a genuine lock-acquire expiry must log "acquire timed out", got errlog=' . var_export($log, TRUE));
+		$this->assertStringNotContainsString('PFBL-03: control channel lock acquire failed', $log,
+			'a genuine expiry must NOT log "acquire failed" -- that string is reserved for a real '
+			. 'flock() error, never a mere timeout');
+	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -3490,6 +3490,33 @@
             }
         ]
     },
+    "pfb_flock_bounded": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "fp",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "operation",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": null
+            }
+        ]
+    },
     "pfb_force_clear_validators": {
         "returnsRef": false,
         "returnType": "int",
@@ -7788,6 +7815,13 @@
                 "variadic": false,
                 "type": "callable",
                 "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
             }
         ]
     },
@@ -8582,6 +8616,11 @@
                 "default": "NULL"
             }
         ]
+    },
+    "pfb_unbound_py_publication_lock_timeout": {
+        "returnsRef": false,
+        "returnType": "float",
+        "params": []
     },
     "pfb_unbound_py_publication_unlock": {
         "returnsRef": false,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -2594,6 +2594,13 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
             }
         ]
     },
@@ -2634,6 +2641,13 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
             }
         ]
     },
@@ -2750,6 +2764,20 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
+            },
+            {
+                "name": "unavailable",
+                "byRef": true,
+                "variadic": false,
+                "type": "?bool",
+                "default": "NULL"
             }
         ]
     },
@@ -2797,6 +2825,13 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
             }
         ]
     },
@@ -3514,6 +3549,13 @@
                 "variadic": false,
                 "type": "float",
                 "default": null
+            },
+            {
+                "name": "timed_out",
+                "byRef": true,
+                "variadic": false,
+                "type": "?bool",
+                "default": "NULL"
             }
         ]
     },
@@ -7728,6 +7770,13 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
             }
         ]
     },
@@ -7870,6 +7919,13 @@
                 "variadic": false,
                 "type": "?callable",
                 "default": "NULL"
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
             }
         ]
     },
@@ -7883,6 +7939,20 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
+            },
+            {
+                "name": "unavailable",
+                "byRef": true,
+                "variadic": false,
+                "type": "?bool",
+                "default": "NULL"
             }
         ]
     },

--- a/tests/test_bounded_flock.py
+++ b/tests/test_bounded_flock.py
@@ -22,7 +22,13 @@ needs no bound). A call written as plain `flock($fp, LOCK_EX)` /
 The scan is intentionally low-false-positive: it only inspects the literal text
 inside a `flock(...)` call's parentheses on the line where the call starts (every
 call in this codebase is single-line, no call nests parentheses in its argument
-list), so it cannot mis-flag unrelated code and needs no PHP parser.
+list), so it needs no PHP parser. It is comment-BLIND, not comment-aware: it does
+not parse `//`/`#`/`/* */` at all, so a comment line containing a literal
+`flock($var, LOCK_EX)`-shaped example (a `$`-prefixed first argument, no
+LOCK_NB/LOCK_UN) would match exactly like real code -- the false-positive floor
+comes solely from requiring that `$`-prefixed first argument, which rules out an
+argument-less prose mention like "...deadline check and flock()." (no `$` inside
+the parens at all), not from any code/comment distinction.
 """
 
 from __future__ import annotations
@@ -65,8 +71,19 @@ def _scanned_files() -> list[Path]:
 
 
 def test_real_source_tree_has_no_unbounded_flock_calls() -> None:
+    scanned = _scanned_files()
+
+    # issue #1780 F8: a tree relocation (src/ renamed, .inc/.php files moved out from
+    # under _SCAN_ROOT) would silently shrink the scan to an empty list -- offenders
+    # would then vacuously stay [] and this pin would "pass" while checking nothing.
+    # Guard the scan itself, not just its output.
+    assert len(scanned) > 0, (
+        f"expected at least one .inc/.php file under {_SCAN_ROOT} -- got zero; "
+        "the scan root or suffix filter has rotted (issue #1780 F8), or src/ moved"
+    )
+
     offenders: list[str] = []
-    for path in _scanned_files():
+    for path in scanned:
         text = path.read_text(encoding="utf-8", errors="replace")
         for line_no, line in find_unbounded_flock_calls(text):
             offenders.append(f"{path.relative_to(_REPO_ROOT)}:{line_no}: {line}")

--- a/tests/test_bounded_flock.py
+++ b/tests/test_bounded_flock.py
@@ -1,0 +1,106 @@
+"""Regression pin (issue #1780): every blocking flock() acquire in src/ is bounded.
+
+The owner's premise for deferring log maintenance across a running update pass is
+"an update pass cannot hang forever, since every wait is capped." An audit found
+five flock() acquires that violated that premise -- plain blocking LOCK_EX/LOCK_SH
+calls with no LOCK_NB and no deadline, so a wedged holder (a crashed writer that
+never released, a stuck NFS mount, ...) hung the caller forever. All five were
+rewritten to go through the shared bounded helper (pfb_flock_bounded() in
+pfblockerng.inc), which ORs in LOCK_NB itself and polls against a wall-clock
+deadline.
+
+This module scans the SHIPPED source tree (scan roots: every ``*.inc``/``*.php``
+file under ``src/`` -- that is the whole `src/usr/local/pkg/pfblockerng/` package
+plus the `src/usr/local/www/` Web UI; nothing under `tests/`, `stubs/`, or
+`.agents/` is in scope) and fails if it finds a `flock()` call whose argument list
+contains neither `LOCK_NB` (a bounded, non-blocking attempt -- how every acquire
+must be spelled from now on) nor `LOCK_UN` (a release, which never blocks and so
+needs no bound). A call written as plain `flock($fp, LOCK_EX)` /
+`flock($fp, LOCK_SH)` -- the exact shape of all five pre-#1780 defects -- trips it;
+`flock($fp, LOCK_EX | LOCK_NB, $would_block)` and `flock($fp, LOCK_UN)` do not.
+
+The scan is intentionally low-false-positive: it only inspects the literal text
+inside a `flock(...)` call's parentheses on the line where the call starts (every
+call in this codebase is single-line, no call nests parentheses in its argument
+list), so it cannot mis-flag unrelated code and needs no PHP parser.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCAN_ROOT = _REPO_ROOT / "src"
+_SCAN_SUFFIXES = {".inc", ".php"}
+
+# Captures the raw argument list of one flock(...) call. Requiring the first
+# argument to start with "$" (every real call passes a resource variable) is
+# what keeps this low-false-positive: it skips prose mentions of "flock()"
+# in comments (e.g. "...deadline check and flock()."), which have no argument
+# at all. Every real call in this codebase is single-line with no nested
+# parentheses in its arguments, so a non-nesting character class is sufficient
+# -- no PHP parser needed.
+_FLOCK_CALL_RE = re.compile(r"flock\s*\(\s*(\$[^()]*)\)")
+
+
+def find_unbounded_flock_calls(text: str) -> list[tuple[int, str]]:
+    """Return (1-based line_no, stripped line) for every unbounded flock() call.
+
+    A call is UNBOUNDED iff its argument list contains neither ``LOCK_NB``
+    (bounded, non-blocking attempt) nor ``LOCK_UN`` (release -- never blocks).
+    """
+    violations: list[tuple[int, str]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for match in _FLOCK_CALL_RE.finditer(line):
+            args = match.group(1)
+            if "LOCK_NB" in args or "LOCK_UN" in args:
+                continue
+            violations.append((line_no, line.strip()))
+    return violations
+
+
+def _scanned_files() -> list[Path]:
+    return sorted(path for path in _SCAN_ROOT.rglob("*") if path.is_file() and path.suffix in _SCAN_SUFFIXES)
+
+
+def test_real_source_tree_has_no_unbounded_flock_calls() -> None:
+    offenders: list[str] = []
+    for path in _scanned_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for line_no, line in find_unbounded_flock_calls(text):
+            offenders.append(f"{path.relative_to(_REPO_ROOT)}:{line_no}: {line}")
+
+    assert offenders == [], (
+        "found flock() acquire(s) with no LOCK_NB and no LOCK_UN release -- every "
+        "blocking acquire must go through the bounded helper (issue #1780):\n" + "\n".join(offenders)
+    )
+
+
+def test_scanner_flags_synthetic_unbounded_lock_ex(tmp_path: Path) -> None:
+    """Self-check: the scanner can actually fail, not just always pass."""
+    synthetic = tmp_path / "synthetic.inc"
+    synthetic.write_text("<?php\nflock($fp, LOCK_EX);\n")
+
+    violations = find_unbounded_flock_calls(synthetic.read_text())
+
+    assert len(violations) == 1
+    line_no, line = violations[0]
+    assert line_no == 2
+    assert "flock($fp, LOCK_EX);" == line
+
+
+def test_scanner_does_not_flag_bounded_synthetic_call() -> None:
+    """Discrimination check: the nearest CLEAN sibling of the flagged call above
+    must not be flagged -- proving the scanner tells bounded and unbounded apart
+    rather than flagging every flock() call unconditionally."""
+    text = "<?php\n@flock($fp, LOCK_EX | LOCK_NB, $would_block);\n"
+
+    assert find_unbounded_flock_calls(text) == []
+
+
+def test_scanner_does_not_flag_lock_un_release() -> None:
+    """A release never blocks, so it needs no bound and must not be flagged."""
+    text = "<?php\n@flock($lock, LOCK_UN);\n"
+
+    assert find_unbounded_flock_calls(text) == []


### PR DESCRIPTION
## Summary

Issue #1780 asked for a bound on log-maintenance deferral. The owner's ruling (2026-08-01) reshaped it: keep the gate exactly as it is — no run-anyway override, no `LOG_WARNING` escalation knob — because an update pass "cannot hang forever, since everything has a timeout there".

That premise was audited rather than assumed, and it did not hold. Five `flock()` acquires in the package block with **no** deadline:

| # | Site | Function | Op |
| --- | --- | --- | --- |
| 1 | `pfblockerng.inc:8561` | `pfb_unbound_py_publication_lock()`, `$timeout_s === NULL` branch | `LOCK_EX` |
| 2 | `pfblockerng.inc:8943` | PFBL-03 control-channel publish | `LOCK_EX` |
| 3 | `pfblockerng_extra.inc:3333` | `pfb_due_ledger_read_entry()` | `LOCK_SH` |
| 4 | `pfblockerng_extra.inc:3907` | `pfb_sync_status_read_all()` | `LOCK_SH` |
| 5 | `pfblockerng_extra.inc:3965` | `pfb_sync_status_locked()` | `LOCK_EX` |

(Line numbers are pre-change.) Rows 3-5 are reachable from `pfblockerng_tick()` itself — it reads the due ledger, iterates the sync-status ledger, and drives the apply-retry steps — so the exposure was not confined to the update pass: the very tick that runs log maintenance could block before reaching its gate.

This PR makes the owner's premise true by construction for that class.

## What changed

- **New shared helper** `pfb_flock_bounded($fp, int $operation, float $timeout_s): bool` in `pfblockerng.inc`. It is the loop that `pfb_unbound_py_publication_lock()` already used correctly for its `0.25`-second callers, extracted and generalised over `LOCK_EX`/`LOCK_SH`. It keeps both of that loop's independent bounds — a wall-clock deadline **and** a poll cap, so a stalled or backward clock still terminates — plus the real-error exit and the post-acquire deadline recheck. It never closes the handle; callers keep ownership.
- **All five sites** now acquire through it. `pfb_unbound_py_publication_lock()` no longer has any indefinitely blocking path; its `NULL` default resolves to a finite budget exposed through `pfb_unbound_py_publication_lock_timeout()` (60 s — the holders are local manifest/GC/teardown writes). The ledger sites use 5 s; their critical sections are a single small JSON read-modify-write.
- **Every expiry is observable.** No path proceeds silently as though the lock were held. `pfb_sync_status_locked()` keeps its documented fail-open contract — on expiry it logs loudly and *then* runs the callable unlocked — rather than silently dropping a ledger update.

## What deliberately did not change

`pfblockerng_tick()`'s log-maintenance gate is byte-identical. Maintenance still never runs concurrently with an update pass, and still runs on the next available tick.

## Tests

- `tests/php/PfbFlockBoundedTest.php` — a real second process (`pcntl_fork`, readiness signalled by a marker file, never a guessed sleep) holds the lock **longer than the budget under test**; the acquire must return on its own deadline rather than when the holder releases. Covers `LOCK_EX` and `LOCK_SH`, plus the uncontended success path and the finite-default assertion.
- `tests/php/PfbSyncStatusLedgerTest.php` — extended: on expiry the callable still runs (fail-open preserved) **and** the expiry signal fires; on success that same signal stays silent, so the assertion discriminates instead of always firing.
- `tests/test_bounded_flock.py` — scans `src/` and fails if any `flock()` call ever again acquires without `LOCK_NB`, with a self-check proving the scanner flags a synthetic unbounded call. This is what makes a future regression fail loudly.

## Review outcome

The first round of this PR bounded the locks but gave the two READERS an expiry value that collided with an existing meaning (`NULL` = "absent", `[]` = "empty"), which executed probes showed could cause a spurious dispatch and could persist an empty ledger over intact data. That is fixed: each reader now carries an explicit `?bool &$unavailable` signal and every dispatch/persistence caller fails closed. Public return types are unchanged, so no `www/` consumer is disturbed.

Deferred deliberately: consolidating the ADR-65 query-channel twin into the shared helper. It is outside the five-site class this PR addresses; with the error-vs-timeout distinction restored in place, the helper is no longer less informative than the code it would replace; and folding in a second mechanism during a fix round adds risk for no correctness gain.

Full findings ledger, measured budget evidence, and review provenance are in the audit comment.

## Follow-ups filed

The audit also found unbounded external children reachable from a gate-holding pass. Out of scope here (one class lives in `pfblockerng_apply.inc`, owned by other in-flight work) and tracked separately: #2014 (`drill(1)` in `pfb_ss_resolve_target()`, reachable from every tick), #2015 (`host(1)` in `whoisconvert()`), #2016 (nested `bls`/`dc`/`asn_shell` re-entries).

Part of #1780 — that ticket stays open until those three land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
