### PR TITLE
tests: replace browser settle sleeps

### DIFF
--- a/tests/smoke/ui/test_browser_hook_tables.py
+++ b/tests/smoke/ui/test_browser_hook_tables.py
@@ -218,7 +218,7 @@ def test_dismissing_the_delete_confirmation_keeps_the_script(
 
     page.once("dialog", lambda dialog: dialog.dismiss())
     row.locator(".fa-trash-can").click()
-    page.wait_for_timeout(1000)
+    expect(row).to_be_visible(timeout=JS_TIMEOUT_MS)
 
     _open(page, webui, HOOKS_PAGE)
     expect(page.locator(f"tr[data-pfb-hook='{probe_hook}']")).to_have_count(1, timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_browser_hook_tables.py
+++ b/tests/smoke/ui/test_browser_hook_tables.py
@@ -35,7 +35,7 @@ sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not ins
 expect = sync_api.expect
 
 if TYPE_CHECKING:
-    from playwright.sync_api import Page
+    from playwright.sync_api import Dialog, Page
 
     from .webui import WebUI
 
@@ -216,8 +216,15 @@ def test_dismissing_the_delete_confirmation_keeps_the_script(
     row = page.locator(f"tr[data-pfb-hook='{probe_hook}']")
     expect(row).to_be_visible(timeout=JS_TIMEOUT_MS)
 
-    page.once("dialog", lambda dialog: dialog.dismiss())
+    dialogs: list[str] = []
+
+    def dismiss_dialog(dialog: Dialog) -> None:
+        dialogs.append(dialog.type)
+        dialog.dismiss()
+
+    page.once("dialog", dismiss_dialog)
     row.locator(".fa-trash-can").click()
+    assert dialogs == ["confirm"], "the delete action must show one confirmation dialog"
     expect(row).to_be_visible(timeout=JS_TIMEOUT_MS)
 
     _open(page, webui, HOOKS_PAGE)

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -403,9 +403,10 @@ def test_update_runnow_does_not_scroll_the_page(
     assert page.evaluate("window.pageYOffset") == 0, "the page should start at the top"
 
     page.locator('button[name="run"], #run').first.click()
-    # Bounded wait to prove ABSENCE of the scroll: outlast the old 2000ms animate window so a
-    # regression would have moved the page by the time we read the offset.
-    page.wait_for_timeout(2500)
+    page.wait_for_function(
+        "() => window.jQuery && window.jQuery(':animated').length === 0",
+        timeout=JS_TIMEOUT_MS,
+    )
 
     offset = page.evaluate("window.pageYOffset")
     assert offset == 0, f"Run Now must not auto-scroll the page; expected top (0), got pageYOffset={offset}"


### PR DESCRIPTION
## Summary

- wait on the hook row state after dismissing its delete confirmation
- wait for the Run Now page animation queue to settle before checking scroll position
- remove every `page.wait_for_timeout()` call from `tests/smoke/ui/`

## Verification

- RED: forbidden-sleep guard found both owned `page.wait_for_timeout()` sites and exited 1
- GREEN: the same guard reports zero sites under `tests/smoke/ui/`
- `scripts/agent/run-gates.sh --diff origin/devel` — PASS (pytest, Ruff check/format, mypy)
- `scripts/local-smoke.sh --ref issue/1997-tests-smoke-ui-two-page-wait --marker ui_browser --filter "browser_hook_tables or browser_misc" --no-two-vm` — 16 selected; 15 passed, 1 data-dependent skip

Fixes #1997
Parent: #1517

## Audit

Implemented with OpenAI Codex on behalf of @andrebrait.