### PR TITLE
tests: make smoke waits event-driven

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1066,9 +1066,9 @@ class _MockCallbackSink:
         with self._condition:
             if self._condition.wait_for(lambda: len(self._callbacks) >= n, timeout=timeout):
                 return True
+            observed = len(self._callbacks)
         raise RuntimeError(
-            f"stuck/environment: callback count did not reach {n} before salvage cap {timeout}s "
-            f"(observed {len(self._callbacks)})"
+            f"stuck/environment: callback count did not reach {n} before salvage cap {timeout}s (observed {observed})"
         )
 
     def start(self) -> None:

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -43,7 +43,6 @@ import socket
 import subprocess
 import tempfile
 import threading
-import time
 from collections.abc import Generator, Iterator, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -1005,9 +1004,10 @@ class _MockCallbackSink:
 
     def __init__(self) -> None:
         self._callbacks: list[CallbackRecord] = []
-        self._lock = threading.Lock()
+        self._condition = threading.Condition()
+        self._lock = self._condition
         callbacks = self._callbacks
-        lock = self._lock
+        condition = self._condition
 
         class Handler(BaseHTTPRequestHandler):
             def _record(self) -> None:
@@ -1019,8 +1019,9 @@ class _MockCallbackSink:
                     form=parse_qs(body),
                     query=parse_qs(urlsplit(self.path).query),
                 )
-                with lock:
+                with condition:
                     callbacks.append(rec)
+                    condition.notify_all()
                 self.send_response(200)
                 self.send_header("Content-Length", "0")
                 self.end_headers()
@@ -1058,20 +1059,17 @@ class _MockCallbackSink:
         return f"http://{GUEST_TO_HOST_ALIAS}:{self.port}{path}"
 
     def wait_for(self, n: int, timeout: float = 10.0) -> bool:
-        """Poll until at least ``n`` callbacks are recorded, or time out.
+        """Wait for the callback-count event; timeout is a salvage cap only.
 
-        The hook ``curl`` is synchronous within the update pass, but the sink's
-        handler thread records a moment later — poll (no fixed sleep) so the
-        assertion is not racy. Returns True iff the count was reached.
+        Raises a loud ``stuck/environment`` failure when the event is not observed.
         """
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            with self._lock:
-                if len(self._callbacks) >= n:
-                    return True
-            time.sleep(0.1)
-        with self._lock:
-            return len(self._callbacks) >= n
+        with self._condition:
+            if self._condition.wait_for(lambda: len(self._callbacks) >= n, timeout=timeout):
+                return True
+        raise RuntimeError(
+            f"stuck/environment: callback count did not reach {n} before salvage cap {timeout}s "
+            f"(observed {len(self._callbacks)})"
+        )
 
     def start(self) -> None:
         self._thread.start()
@@ -1436,17 +1434,6 @@ def webhook_sink(smoke_vm: SmokeVM) -> Iterator[_MockCallbackSink]:
 # --------------------------------------------------------------------------- #
 # Small probe helpers shared by smoke tests
 # --------------------------------------------------------------------------- #
-
-
-def wait_for_tcp(host: str, port: int, timeout: float = 5.0) -> bool:
-    """Best-effort TCP reachability check (no fixed sleep elsewhere)."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        with contextlib.suppress(OSError):
-            with socket.create_connection((host, port), timeout=2.0):
-                return True
-        time.sleep(0.2)
-    return False
 
 
 def resolve_a(name: str, host: str, port: int, timeout: float = 5.0) -> list[str]:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3607,7 +3607,7 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
     Once observed, each readiness gate receives its own full ``timeout`` budget.
     """
     # Fail FAST on an unreadable before-side: without it the proof is already lost, so
-    # refusing to reboot saves the whole settle+readiness cycle and leaves the box up in
+    # refusing to reboot saves the whole reboot+readiness cycle and leaves the box up in
     # its pre-reboot state for diagnosis (#761 review).
     try:
         before_read = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0)
@@ -4948,8 +4948,7 @@ def wait_until(predicate: Callable[[], bool], *, timeout: float = 12.0, interval
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise RuntimeError(f"stuck/environment: wait_until predicate not observed before salvage cap {timeout}s")
-        # Clamp the sleep to the time left so the poll never overshoots `timeout` by a
-        # full interval (keeps the "well under the body timeout" guarantee in the docstring).
+        # Clamp the sleep to the time left so the salvage cap is not overshot by a full interval.
         time.sleep(min(interval, remaining))
 
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3603,8 +3603,8 @@ def _assert_boottime_advanced(before: str, after: str) -> None:
 def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
     """Reboot, observe a changed ``kern.boottime``, then await full readiness.
 
-    The boottime poll is the reboot event; ``timeout`` is only a salvage cap for a stuck guest.
-    Once observed, each readiness gate receives its own full ``timeout`` budget.
+    The boottime poll is the reboot event; ``timeout`` supplies independent salvage caps for
+    that event and the subsequent readiness gate. No duration is asserted.
     """
     # Fail FAST on an unreadable before-side: without it the proof is already lost, so
     # refusing to reboot saves the whole reboot+readiness cycle and leaves the box up in
@@ -4401,9 +4401,9 @@ def dns_probe_until(
     moment later (the watcher rebuilds + atomically swaps the snapshot once the sentinel
     advances — "briefly stale by design", ADR.md SS2). So the restart-era "first response
     is authoritative, never loop" rule does NOT apply to the swap transition: there is no
-    down/up edge to make the first post-readiness answer the new one. The guarantee under
-    test is "the new decision applies within a BOUNDED window WITHOUT a restart". The observed
-    predicate event decides success; expiry is a loud ``stuck/environment`` salvage failure.
+    down/up edge to make the first post-readiness answer the new one. The observed predicate
+    event decides success; expiry is only a loud ``stuck/environment`` salvage failure, not a
+    duration assertion.
 
     Use ONLY for the swap transition (a data update / #51 toggle whose decision must flip).
     Keep :func:`dns_probe` for steady-state and restart-class reads where the first answer

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3618,11 +3618,12 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
             f"reboot_vm: kern.boottime read timed out BEFORE the reboot ({exc}) -- refusing to "
             "reboot without the before-side of the proof"
         ) from exc
-    before_boottime = before_read.stdout
-    if not before_boottime.strip():
+    before_token = before_read.stdout.strip()
+    if before_read.returncode != 0 or not before_token:
         raise AssertionError(
             f"reboot_vm: kern.boottime unreadable BEFORE the reboot (rc={before_read.returncode} "
-            f"stderr={before_read.stderr!r}) -- refusing to reboot without the before-side of the proof"
+            f"stdout={before_read.stdout!r} stderr={before_read.stderr!r}) -- refusing to reboot "
+            "without the before-side of the proof"
         )
 
     # Issue the reboot; it drops our SSH connection, so a non-zero/dropped result is EXPECTED.
@@ -3637,13 +3638,13 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
         if remaining <= 0:
             raise RuntimeError(
                 "stuck/environment: reboot_vm kern.boottime did not change before salvage cap "
-                f"({timeout:.0f}s); before={before_boottime.strip()!r} last={last_boottime!r}"
+                f"({timeout:.0f}s); before={before_token!r} last={last_boottime!r}"
             )
         try:
             read = vm.ssh(_BOOTTIME_SYSCTL, timeout=min(15.0, max(1.0, remaining)))
             token = read.stdout.strip()
-            last_boottime = token or f"empty (rc={read.returncode} stderr={read.stderr!r})"
-            if token and token != before_boottime.strip():
+            last_boottime = f"rc={read.returncode} stdout={read.stdout!r} stderr={read.stderr!r}"
+            if read.returncode == 0 and token and token != before_token:
                 break
         except (OSError, subprocess.TimeoutExpired) as exc:
             last_boottime = f"{type(exc).__name__}: {exc}"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4935,27 +4935,11 @@ def rule_line_references(line: str, alias: str) -> bool:
 
 
 def wait_until(predicate: Callable[[], bool], *, timeout: float = 12.0, interval: float = 2.0) -> bool:
-    """Poll until the observed predicate event occurs; timeout is a salvage cap only.
+    """Poll until the predicate event is observed; expiry is salvage only.
 
-    A BOUNDED poll for the same documented
-    reason as :func:`rule_references` / :func:`wait_pfctl_table`: pfBlockerNG's
-    ``filter_configure`` is ASYNC (``send_event("filter reload")``), so a pf-level
-    rule (rdr / block) lands a few seconds AFTER ``reload()`` returns — a single-shot
-    ``pfctl -sr``/``-sn`` read right after the reload races the event and reads the
-    pre-reload ruleset. Wrap such an assertion in ``wait_until`` so green proves the
-    rule actually landed (and, for an absence check, that it was actually removed),
-    not that the read happened to win/lose the race.
-
-    Default ``timeout`` is deliberately well under the smoke harness's 30s per-test
-    body cap (``smoke-single.yml`` ``--timeout=30 --timeout-method=signal``,
-    ``timeout_func_only=true``): the test body has already spent time in ``reload()``,
-    so a 30s poll here would trip the body timeout FIRST and kill the test before its
-    assertion (and the ``pf_state_dump`` it prints) can run — turning a real "rule did
-    not load" into an opaque ``Timeout``. A short poll gives up in time for the
-    assertion to fire with diagnostics. The async lag is a few seconds; if the rule is
-    not present within this window it is genuinely absent, which is what we want to see.
-    Success requires an observed truthy predicate. Expiry raises ``stuck/environment`` rather
-    than returning a false verdict, distinguishing a stuck environment from a valid negative.
+    ``filter_configure`` is asynchronous (``send_event("filter reload")``), so a pf-level
+    rule can land after ``reload()`` returns. A truthy predicate observation is the verdict;
+    expiry raises ``stuck/environment`` and is never a false observation.
     """
     deadline = time.monotonic() + timeout
     while True:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3573,33 +3573,6 @@ def pfb_config_digest(vm: SmokeVM, *, timeout: float = 30.0) -> str:
 _BOOTTIME_SYSCTL = "sysctl -n kern.boottime"
 
 
-def _assert_boottime_advanced(before: str, after: str) -> None:
-    """Raise AssertionError unless ``kern.boottime`` genuinely changed across a reboot (#738 F4).
-
-    Pure comparison, no VM I/O, so it is unit-testable off-VM. ``before``/``after`` are the raw
-    ``sysctl -n kern.boottime`` output captured immediately before issuing ``/sbin/reboot`` and
-    immediately after the readiness gate clears. An unchanged value means the readiness gate
-    answered on the PRE-reboot instance -- the guest never actually went down and back up. An
-    empty side means the sysctl read itself failed (e.g. a dropped SSH connection mid-boot),
-    which is just as fatal to the proof, so it raises too, naming which side was empty.
-    """
-    before_val = before.strip()
-    after_val = after.strip()
-    if not before_val:
-        raise AssertionError(
-            "reboot_vm: could not read kern.boottime BEFORE the reboot (empty output) -- cannot prove a reboot happened"
-        )
-    if not after_val:
-        raise AssertionError(
-            "reboot_vm: could not read kern.boottime AFTER the reboot (empty output) -- cannot prove a reboot happened"
-        )
-    if before_val == after_val:
-        raise AssertionError(
-            f"reboot_vm: kern.boottime unchanged (before={before_val!r} after={after_val!r}) -- "
-            "the guest never rebooted; the readiness gate answered on the PRE-reboot instance"
-        )
-
-
 def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
     """Reboot, observe a changed ``kern.boottime``, then await full readiness.
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3570,13 +3570,6 @@ def pfb_config_digest(vm: SmokeVM, *, timeout: float = 30.0) -> str:
 # it must run in its own dispatch, not interleaved with the per-case smoke matrix.
 
 
-# Fixed settle after issuing /sbin/reboot, before probing readiness: long enough that the box
-# is actually shutting down (so we never read the still-up pre-reboot sshd as "ready"), short
-# relative to the boot it precedes. A deliberate shutdown wait -- not concurrency coordination
-# (issue #456's exception: we are waiting out a real OS shutdown we cannot signal, not
-# coordinating two sides of our own async code).
-_REBOOT_SETTLE_SECS = 30
-
 _BOOTTIME_SYSCTL = "sysctl -n kern.boottime"
 
 
@@ -3608,30 +3601,10 @@ def _assert_boottime_advanced(before: str, after: str) -> None:
 
 
 def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
-    """Reboot the guest OS and block until it is ready again, reusing the SAME readiness gate
-    as the initial boot.
+    """Reboot, observe a changed ``kern.boottime``, then await full readiness.
 
-      1. Read ``kern.boottime`` once, BEFORE issuing the reboot -- the "before" side of the
-         post-reboot proof (#738 F4).
-      2. Issue ``/sbin/reboot`` -- best-effort: the command tears down our SSH session, so a
-         non-zero / dropped result is EXPECTED, not an error.
-      3. Sleep a fixed SETTLE so the box is actually DOWN before we probe; otherwise the
-         still-up pre-reboot sshd answers and ``wait_ready.sh`` false-positives "ready" before
-         the reboot has even happened. This replaces the previous ``kern.boottime``-change poll,
-         which was fragile and consumed the readiness budget (timing out even when the box came
-         back fine). Deliberate shutdown wait, not concurrency coordination -- issue #456's
-         documented exception (no side of our own code to signal; we are waiting out a real OS
-         shutdown).
-      4. Run the SAME readiness gate the initial boot uses (conftest ``boot_vm``): ``wait_ready.sh``
-         (QEMU pid + web port: nginx + PHP up) with the FULL budget, then ``wait_boot_complete``
-         (``is_platform_booting()`` cleared, so a post-reboot pfBlockerNG sync cannot race boot --
-         the #559 guard). THEN ``wait_unbound_ready`` so DNS assertions are safe immediately (the
-         reboot tests probe DNS, which a bare boot does not).
-      5. Read ``kern.boottime`` once more, AFTER the full readiness gate completes, and compare
-         against the "before" reading (#738 F4) -- a SINGLE post-readiness check, so it consumes
-         no readiness budget (unlike the removed poll). If the value never changed (or either
-         side was unreadable), the readiness gate answered on the pre-reboot instance and this
-         raises loudly instead of letting the caller assert against stale state.
+    The boottime poll is the reboot event; ``timeout`` is only a salvage cap for a stuck guest.
+    Once observed, each readiness gate receives its own full ``timeout`` budget.
     """
     # Fail FAST on an unreadable before-side: without it the proof is already lost, so
     # refusing to reboot saves the whole settle+readiness cycle and leaves the box up in
@@ -3655,9 +3628,26 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
     # Issue the reboot; it drops our SSH connection, so a non-zero/dropped result is EXPECTED.
     vm.ssh("/sbin/reboot", timeout=30.0)
 
-    # Settle: let the box shut down before we probe, so we never read the still-up pre-reboot
-    # sshd as "ready". Deliberate shutdown wait -- see the docstring's step 3.
-    time.sleep(_REBOOT_SETTLE_SECS)
+    # Observe the reboot event. SSH failures while the guest is down are expected; only a
+    # non-empty token different from the pre-reboot value completes this gate.
+    deadline = time.monotonic() + timeout
+    last_boottime = "<not observed>"
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(
+                "stuck/environment: reboot_vm kern.boottime did not change before salvage cap "
+                f"({timeout:.0f}s); before={before_boottime.strip()!r} last={last_boottime!r}"
+            )
+        try:
+            read = vm.ssh(_BOOTTIME_SYSCTL, timeout=min(15.0, max(1.0, remaining)))
+            token = read.stdout.strip()
+            last_boottime = token or f"empty (rc={read.returncode} stderr={read.stderr!r})"
+            if token and token != before_boottime.strip():
+                break
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            last_boottime = f"{type(exc).__name__}: {exc}"
+        time.sleep(min(2.0, remaining))
 
     # Full readiness via the SAME shell gate the initial boot uses. wait_ready.sh's positional
     # args are <ssh-key> [host] [port] [timeout] [vm-pid] [web-port]; pass the vm-pid + web-port
@@ -3689,19 +3679,6 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
     wait_boot_complete(vm)
     # Extra over a bare boot: the reboot tests probe DNS, so wait for Unbound to answer.
     wait_unbound_ready(vm)
-
-    # Single post-readiness proof (#738 F4): the readiness gate above can false-positive on the
-    # still-up pre-reboot instance if shutdown outlasted the settle on a slow host. Compare
-    # kern.boottime now that readiness is fully established -- this is the ONE extra guest round
-    # trip, not a poll, so it never eats into the readiness budget.
-    try:
-        after_boottime = vm.ssh(_BOOTTIME_SYSCTL, timeout=15.0).stdout
-    except subprocess.TimeoutExpired as exc:
-        raise AssertionError(
-            f"reboot_vm: kern.boottime read timed out AFTER the readiness gate ({exc}) -- the boot "
-            f"proof is incomplete (before={before_boottime.strip()!r}); treat the reboot as unproven"
-        ) from exc
-    _assert_boottime_advanced(before_boottime, after_boottime)
 
 
 # pfBlockerNG archives its IP aliastables + DNSBL DB here for RAMDISK installs; the
@@ -4424,25 +4401,24 @@ def dns_probe_until(
     advances — "briefly stale by design", ADR.md SS2). So the restart-era "first response
     is authoritative, never loop" rule does NOT apply to the swap transition: there is no
     down/up edge to make the first post-readiness answer the new one. The guarantee under
-    test is "the new decision applies within a BOUNDED window WITHOUT a restart" — so we
-    poll until it does, and RAISE on timeout (a real failure: the swap did not apply in
-    budget — never a mask that loops forever).
+    test is "the new decision applies within a BOUNDED window WITHOUT a restart". The observed
+    predicate event decides success; expiry is a loud ``stuck/environment`` salvage failure.
 
     Use ONLY for the swap transition (a data update / #51 toggle whose decision must flip).
     Keep :func:`dns_probe` for steady-state and restart-class reads where the first answer
     is authoritative. Caller MUST pass a non-RFC-6761, non-HSTS-preload name (see
     :func:`unique_domain`).
     """
-    deadline = time.time() + timeout
+    deadline = time.monotonic() + timeout
     last: DnsAnswer | None = None
-    while time.time() < deadline:
+    while time.monotonic() < deadline:
         last = dns_probe(vm, name, rtype, timeout=15.0, attempts=2, delay=2.0)
         if predicate(last):
             return last
         time.sleep(interval)
     raise RuntimeError(
-        f"dns_probe_until({name}, {rtype}) predicate never held within {timeout}s "
-        f"(last answer: {last}) — the zero-downtime swap decision did not apply in budget"
+        f"stuck/environment: dns_probe_until({name}, {rtype}) observed no matching predicate "
+        f"before salvage cap {timeout}s (last answer: {last})"
     )
 
 
@@ -4545,25 +4521,25 @@ def dns_probe_client_until(
     timeout: float = 60.0,
     interval: float = 3.0,
 ) -> DnsAnswer:
-    """Poll ``dig @server <name> <rtype>`` from civm until ``predicate(answer)`` holds; raise on timeout.
+    """Poll until the observed client DNS answer satisfies ``predicate``; raise on salvage expiry.
 
     The client-side analog of :func:`dns_probe_until` — for the zero-downtime swap
-    transition (ADR-10) observed from a real LAN client. Polls with bounded backoff and
-    raises on timeout (a genuine failure, never a silent infinite loop).
+    transition (ADR-10) observed from a real LAN client. The observed predicate event decides
+    success; expiry is a loud ``stuck/environment`` salvage failure.
 
     Use ONLY for swap/toggle transitions. Keep :func:`dns_probe_client` for steady-state
     reads. Caller MUST pass a non-RFC-6761, non-HSTS-preload name (see :func:`unique_domain`).
     """
-    deadline = time.time() + timeout
+    deadline = time.monotonic() + timeout
     last: DnsAnswer | None = None
-    while time.time() < deadline:
+    while time.monotonic() < deadline:
         last = dns_probe_client(client_vm, name, rtype, server=server, timeout=15.0, attempts=2, delay=2.0)
         if predicate(last):
             return last
         time.sleep(interval)
     raise RuntimeError(
-        f"dns_probe_client_until({name}, {rtype}) predicate never held within {timeout}s "
-        f"(last answer: {last}) — the zero-downtime swap decision did not apply in budget"
+        f"stuck/environment: dns_probe_client_until({name}, {rtype}) observed no matching predicate "
+        f"before salvage cap {timeout}s (last answer: {last})"
     )
 
 
@@ -4959,9 +4935,9 @@ def rule_line_references(line: str, alias: str) -> bool:
 
 
 def wait_until(predicate: Callable[[], bool], *, timeout: float = 12.0, interval: float = 2.0) -> bool:
-    """Poll ``predicate()`` until it returns truthy, or until ``timeout`` elapses.
+    """Poll until the observed predicate event occurs; timeout is a salvage cap only.
 
-    Returns the final ``bool(predicate())``. A BOUNDED poll for the same documented
+    A BOUNDED poll for the same documented
     reason as :func:`rule_references` / :func:`wait_pfctl_table`: pfBlockerNG's
     ``filter_configure`` is ASYNC (``send_event("filter reload")``), so a pf-level
     rule (rdr / block) lands a few seconds AFTER ``reload()`` returns — a single-shot
@@ -4978,8 +4954,8 @@ def wait_until(predicate: Callable[[], bool], *, timeout: float = 12.0, interval
     not load" into an opaque ``Timeout``. A short poll gives up in time for the
     assertion to fire with diagnostics. The async lag is a few seconds; if the rule is
     not present within this window it is genuinely absent, which is what we want to see.
-    The predicate is re-evaluated once more at the deadline so a slow box still gets a
-    final, authoritative read.
+    Success requires an observed truthy predicate. Expiry raises ``stuck/environment`` rather
+    than returning a false verdict, distinguishing a stuck environment from a valid negative.
     """
     deadline = time.monotonic() + timeout
     while True:
@@ -4987,7 +4963,7 @@ def wait_until(predicate: Callable[[], bool], *, timeout: float = 12.0, interval
             return True
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            return bool(predicate())
+            raise RuntimeError(f"stuck/environment: wait_until predicate not observed before salvage cap {timeout}s")
         # Clamp the sleep to the time left so the poll never overshoots `timeout` by a
         # full interval (keeps the "well under the body timeout" guarantee in the docstring).
         time.sleep(min(interval, remaining))

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -918,11 +918,8 @@ def test_hooks_webhook_fires_on_ip_change(
     # PFB_CHANGED_IP_ALIASES empty ⇒ the guard short-circuits ⇒ curl never runs ⇒ no callback.
     webhook_sink.clear()
     h.reload(deployed_vm, "update")
-    # Give any (erroneous) in-flight callback a moment to land before asserting absence.
-    assert not webhook_sink.wait_for(1, timeout=3.0), (
-        "a webhook callback arrived on a no-op pass — the non-empty PFB_CHANGED_IP_ALIASES "
-        f"guard did not hold: {webhook_sink.callbacks}"
-    )
+    # reload is the synchronous barrier; the callback sink's post-request snapshot is
+    # authoritative for this no-op pass.
     assert webhook_sink.callbacks == [], f"unexpected callback(s) on the guard-off pass: {webhook_sink.callbacks}"
 
     # AFTER (guard on): rewrite the IP feed AND force a genuine re-fetch (bust the reuse

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -534,37 +534,33 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
     stall we are actually testing. Detaching removes that confound: this SSH call returns at
     once and we observe the pass purely through its on-disk log/markers.
 
-    Red→green WITHOUT a wall-clock assertion on the pass itself. The pre hook (fires at the
-    TOP of the pass) backgrounds a child that inherits its stdout/stderr and sleeps 60s
-    before writing ``CHILD_FINISHED``; its own ``timeout`` is 120s so a genuine overrun is
-    impossible. The post env-dump hook fires only at the closing tail, i.e. only if the pass
-    got PAST the pre hook:
+    The pre hook (fires at the TOP of the pass) backgrounds a child that inherits its
+    stdout/stderr and waits on an explicit release marker before writing ``CHILD_FINISHED``;
+    its own ``timeout`` is 120s. The post env-dump hook fires only at the closing tail, i.e.
+    only if the pass got PAST the pre hook:
 
-    * FIXED runner — the pre hook returns at once, the pass runs to its post hook within
-      seconds, so the post marker appears well inside the poll window while the orphaned
-      child is still sleeping (``CHILD_FINISHED`` absent).
-    * BROKEN (pipe-capture) runner — the pre hook's exec() blocks until the child exits
-      (~60s), so the pass never reaches the post hook inside the window: the post marker is
-      ABSENT — the failing discriminator.
+    * FIXED runner — the pre hook returns while the child is still waiting, so the post marker
+      appears before the release marker and ``CHILD_FINISHED`` remains absent.
+    * BROKEN (pipe-capture) runner — the pre hook's exec() waits for the child, so the post marker
+      remains absent until the release marker is created — the failing discriminator.
 
     Also asserts the hook logged ``completed`` and NOT ``TIMED OUT`` (the killpg/124 variant).
     """
     token = "bgdaemon"
-    sentinel = f"pfb_bg_{token}"  # unique argv tag so the finally can pkill the orphan
     pre_marker = h.hook_marker_path(token, "pre")
     child_marker = h.hook_marker_path(token, "child")
     post_marker = h.hook_marker_path(token, "post")
+    release_marker = h.hook_marker_path(token, "release")
     pre_hook = {
         # Background a child that INHERITS the hook's stdout/stderr (no redirect on it) and
-        # outlives the hook (sleep 60), only THEN writing CHILD_FINISHED. The hook finishes
-        # its own work (HOOK_DONE) and exits immediately. The child runs under
-        # ``sh -c '…' <sentinel>`` so <sentinel> rides its argv ($0) — pkill-able in the
-        # finally (the bare `sleep`'s argv would not carry the marker path).
+        # waits for release, only THEN writing CHILD_FINISHED. The hook finishes its own work
+        # (HOOK_DONE) and exits immediately.
         "script": f"hook_pre_{token}_bg.sh",
         "_body": (
             "#!/bin/sh\n"
             f"/bin/echo START > {pre_marker}\n"
-            f"/bin/sh -c '/bin/sleep 60; /bin/echo CHILD_FINISHED > {child_marker}' {sentinel} &\n"
+            f"/bin/sh -c 'while [ ! -f {release_marker} ]; do /bin/sleep 1; done; "
+            f"/bin/echo CHILD_FINISHED > {child_marker}' &\n"
             f"/bin/echo HOOK_DONE >> {pre_marker}\n"
         ),
         "when": "pre",
@@ -574,12 +570,12 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
     }
     h.set_update_hooks(deployed_vm, [pre_hook, h.env_dump_hook(token, "post")])
     h.clear_hook_markers(deployed_vm, token)
-    # Belt-and-braces: remove the child marker too (token clear covers pre/post/child).
-    deployed_vm.ssh("/bin/rm", "-f", child_marker)
+    deployed_vm.ssh("/bin/rm", "-f", child_marker, release_marker)
     h.wait_no_active_pfb_task(deployed_vm)  # a clean baseline — no prior pass in flight
     assert not h.hook_marker_exists(deployed_vm, pre_marker), "pre marker present before launch (stale state?)"
     assert not h.hook_marker_exists(deployed_vm, post_marker), "post marker present before launch (stale state?)"
     assert not h.hook_marker_exists(deployed_vm, child_marker), "child marker present before launch (stale state?)"
+    assert not h.hook_marker_exists(deployed_vm, release_marker), "release marker present before launch (stale state?)"
 
     try:
         # Launch the pass DETACHED (mirrors the GUI's mwexec_bg): this SSH call returns at
@@ -590,28 +586,20 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
         )
 
         # The post hook fires only at the closing tail — i.e. only if the pass got past the
-        # stalling pre hook. On the fixed runner it appears within seconds; on the broken
-        # runner the pass is stuck on the child for ~60s, so it stays absent for the window.
-        # Window assumption: an unchanged-feed force=false pass completes well under 22s
-        # (ADR-42 keeps it fast; observed ~3s on CE 2.8) — comfortably below the child's 60s
-        # stall. If a heavily loaded runner ever flakes here, raise this window AND the
-        # per-test pytest-timeout AND the child's sleep together (keep child >> window).
-        reached_post = h.wait_until(
+        # pre hook while the child remains blocked on the unreleased event.
+        h.wait_until(
             lambda: h.hook_marker_exists(deployed_vm, post_marker),
-            timeout=22.0,
+            timeout=30.0,
             interval=1.0,
         )
-        assert reached_post, (
-            "the pass never reached its post hook within 22s: the pre hook STALLED the pass on "
-            "its backgrounded child (exec() is still capturing via the inherited pipe, not a file)"
-        )
+        assert not h.hook_marker_exists(deployed_vm, release_marker), "release event fired before post marker"
 
         # The pre hook ran fully and exited (its own work is instant) — NOT killed mid-run.
         pre_body = deployed_vm.ssh("cat", pre_marker).stdout
         assert "START" in pre_body and "HOOK_DONE" in pre_body, (
             f"the bg-daemon pre hook did not run to its own completion: {pre_body!r}"
         )
-        # The pass did NOT wait for the orphaned child (still sleeping ~60s): proof it
+        # The pass did NOT wait for the background child (still waiting for release): proof it
         # returned rather than blocking on the inherited capture.
         assert not h.hook_marker_exists(deployed_vm, child_marker), (
             "the pass blocked until the hook's backgrounded child finished (CHILD_FINISHED present)"
@@ -622,10 +610,11 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
             f"the bg-daemon hook FALSELY timed out though its own work finished instantly: {log_grep.stdout!r}"
         )
     finally:
-        # Kill the orphaned child first (by its argv sentinel) — that also unblocks a pass
-        # still stalled on it (broken-runner path) — then let any pass settle before clearing.
-        deployed_vm.ssh("/bin/sh", "-c", f"/bin/pkill -f {sentinel} 2>/dev/null; /bin/rm -f {child_marker}")
+        # Release the child first — that also unblocks a pass still stalled on it (broken-runner
+        # path) — then let any pass settle before clearing.
+        deployed_vm.ssh("/bin/touch", release_marker)
         h.wait_no_active_pfb_task(deployed_vm, timeout=30.0)
+        deployed_vm.ssh("/bin/rm", "-f", child_marker, release_marker)
         h.clear_update_hooks(deployed_vm)
         h.clear_hook_markers(deployed_vm, token)
 
@@ -650,17 +639,15 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
     SSH-synchronous reload would confound the observation). The per-run log is truncated at run
     start (pfb_runlog_begin), so the slice we read is exactly this pass — no manual truncate.
 
-    Given an enabled post hook that emits a marker, sleeps 12s, then emits a closing marker,
+    Given an enabled post hook that emits a marker, waits on an explicit release marker, then
+        emits a closing marker,
     When a pass runs,
-    Then the leading marker is in the PER-RUN log within a few seconds of the hook starting —
-        while it is still sleeping (closing marker absent).
+    Then the leading marker is in the PER-RUN log before release (closing marker absent).
 
-    Red→green discriminator for Fix A: FIXED → the leading marker hits the per-run log a second
-    or two after the hook starts (inside the 5s window, closing marker still absent). PRE-FIX →
-    the hook's stdout went to the CUMULATIVE log, never the per-run log, so this window (and any
-    later read of the per-run log) sees NOTHING — the failing assertion, mirroring the missing
-    live-view output. (Window << the 12s sleep; if a loaded runner ever flakes, raise the sleep
-    AND the window together.)
+    Red→green discriminator for Fix A: FIXED → the leading marker reaches the per-run log while
+    the hook waits for release. PRE-FIX → the hook's stdout went to the CUMULATIVE log, never the
+    per-run log, so the marker is absent — the failing assertion, mirroring the missing live-view
+    output.
 
     Also proves (issue #988): the normal-pass branch's #973 persist call
     (``pfb_persist_hook_output``) fires exactly ONCE for this hook into the PERSISTED
@@ -670,18 +657,25 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
     token = "stream"
     stream_marker = f"STREAM_{token}_MARK"
     done_marker = f"DONE_{token}_MARK"
+    release_marker = h.hook_marker_path(token, "release")
     post_hook = {
         "script": f"hook_post_{token}_slow.sh",
-        # Emit the marker FIRST (streams immediately if live), then hold the hook open 12s
-        # before the closing marker + exit. Its own timeout (60) >> 12s, so no real overrun.
-        "_body": (f"#!/bin/sh\n/bin/echo {stream_marker}\n/bin/sleep 12\n/bin/echo {done_marker}\n"),
+        # Emit the marker FIRST (streams immediately if live), then hold the hook open until
+        # release before the closing marker + exit.
+        "_body": (
+            f"#!/bin/sh\n/bin/echo {stream_marker}\n"
+            f"while [ ! -f {release_marker} ]; do /bin/sleep 1; done\n"
+            f"/bin/echo {done_marker}\n"
+        ),
         "when": "post",
         "enabled": "on",
         "description": f"smoke {token} slow post",
         "timeout": "60",
     }
     h.set_update_hooks(deployed_vm, [post_hook])
+    deployed_vm.ssh("/bin/rm", "-f", release_marker)
     h.wait_no_active_pfb_task(deployed_vm)  # clean baseline — no prior pass in flight
+    assert not h.hook_marker_exists(deployed_vm, release_marker), "release marker present before launch (stale state?)"
     persisted_before = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker)
     persisted_before_done = h.count_log_marker(deployed_vm, h.PFB_LOG, done_marker)
 
@@ -695,55 +689,57 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
         )
 
         # Wait for the pass to REACH the post hook: its runner header is logged (by pfb_logger,
-        # mirrored into the per-run log) right before the hook's exec() in BOTH old and new code
-        # — so this marks t0 of the hook regardless of where the hook's own stdout goes.
-        hook_started = h.wait_until(
+        # mirrored into the per-run log) before the hook's exec() in BOTH old and new code.
+        h.wait_until(
             lambda: f"hook_post_{token}_slow.sh" in deployed_vm.ssh("cat", h.PFB_RUNLOG).stdout,
             timeout=30.0,
             interval=1.0,
         )
-        assert hook_started, (
-            "the pass never reached the post hook within 30s (its runner header never logged to "
-            f"the per-run log):\n{deployed_vm.ssh('cat', h.PFB_RUNLOG).stdout[-1500:]}"
-        )
 
-        # THE DISCRIMINATOR: within 5s of the hook starting (it sleeps 12s), its leading marker
-        # must already be in the PER-RUN log — proof the hook's output is routed there and streams.
-        # Pre-fix it went to the cumulative log only, so the per-run log would never see it.
-        streamed = h.wait_until(
+        # THE DISCRIMINATOR: while the hook waits for release, its leading marker must be in the
+        # PER-RUN log — proof the hook's output is routed there and streams. Pre-fix it went to
+        # the cumulative log only, so the per-run log would never see it.
+        h.wait_until(
             lambda: stream_marker in deployed_vm.ssh("cat", h.PFB_RUNLOG).stdout,
-            timeout=5.0,
-            interval=0.5,
+            timeout=30.0,
+            interval=1.0,
         )
+        assert not h.hook_marker_exists(deployed_vm, release_marker), "release event fired before stream marker"
         runlog_now = deployed_vm.ssh("cat", h.PFB_RUNLOG).stdout
-        assert streamed, (
-            f"hook marker {stream_marker!r} did not reach the PER-RUN log within 5s of the hook "
-            "starting — its output was not routed to the file the live tail reads (Fix A regressed):\n"
-            f"{runlog_now[-1500:]}"
+        assert stream_marker in runlog_now, (
+            f"hook marker {stream_marker!r} did not reach the PER-RUN log while waiting for release "
+            f"(Fix A regressed):\n{runlog_now[-1500:]}"
         )
-        # Caught it MID-RUN: the hook is still sleeping, so its closing marker is absent — proves
-        # we observed a live stream into the per-run log, not the post-exit flush.
+        # Caught it before release: the closing marker is absent — proves we observed a live
+        # stream into the per-run log, not the post-exit flush.
         assert done_marker not in runlog_now, (
             f"caught the marker only AFTER the hook finished ({done_marker!r} already present) — "
             f"not a live-stream proof:\n{runlog_now[-1500:]}"
         )
     finally:
-        h.wait_no_active_pfb_task(deployed_vm, timeout=40.0)
-        # issue #988: exactly ONE persisted copy per hook run — a duplicate here means
-        # pfb_persist_hook_output() double-fired on the normal-pass branch.
-        persisted_delta = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker) - persisted_before
+        # Release the hook first, then let the pass settle before cleanup and persistence checks.
+        deployed_vm.ssh("/bin/touch", release_marker)
+        persisted_delta = -1
+        persisted_delta_done = -1
+        try:
+            h.wait_no_active_pfb_task(deployed_vm, timeout=40.0)
+            # issue #988: exactly ONE persisted copy per hook run — a duplicate here means
+            # pfb_persist_hook_output() double-fired on the normal-pass branch.
+            persisted_delta = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker) - persisted_before
+            persisted_delta_done = h.count_log_marker(deployed_vm, h.PFB_LOG, done_marker) - persisted_before_done
+        finally:
+            h.clear_update_hooks(deployed_vm)
+            deployed_vm.ssh("/bin/rm", "-f", release_marker)
         assert persisted_delta == 1, (
             f"hook marker {stream_marker!r} was persisted into {h.PFB_LOG} {persisted_delta} time(s) "
             "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"
             f"{deployed_vm.ssh('cat', h.PFB_LOG).stdout[-4000:]}"
         )
-        persisted_delta_done = h.count_log_marker(deployed_vm, h.PFB_LOG, done_marker) - persisted_before_done
         assert persisted_delta_done == 1, (
             f"hook marker {done_marker!r} was persisted into {h.PFB_LOG} {persisted_delta_done} time(s) "
             "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"
             f"{deployed_vm.ssh('cat', h.PFB_LOG).stdout[-4000:]}"
         )
-        h.clear_update_hooks(deployed_vm)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -548,6 +548,7 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
     """
     token = "bgdaemon"
     pre_marker = h.hook_marker_path(token, "pre")
+    waiting_marker = h.hook_marker_path(token, "waiting")
     child_marker = h.hook_marker_path(token, "child")
     post_marker = h.hook_marker_path(token, "post")
     release_marker = h.hook_marker_path(token, "release")
@@ -559,7 +560,8 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
         "_body": (
             "#!/bin/sh\n"
             f"/bin/echo START > {pre_marker}\n"
-            f"/bin/sh -c 'while [ ! -f {release_marker} ]; do /bin/sleep 1; done; "
+            f"/bin/sh -c '/bin/touch {waiting_marker}; "
+            f"while [ ! -f {release_marker} ]; do /bin/sleep 1; done; "
             f"/bin/echo CHILD_FINISHED > {child_marker}' &\n"
             f"/bin/echo HOOK_DONE >> {pre_marker}\n"
         ),
@@ -570,9 +572,10 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
     }
     h.set_update_hooks(deployed_vm, [pre_hook, h.env_dump_hook(token, "post")])
     h.clear_hook_markers(deployed_vm, token)
-    deployed_vm.ssh("/bin/rm", "-f", child_marker, release_marker)
+    deployed_vm.ssh("/bin/rm", "-f", waiting_marker, child_marker, release_marker)
     h.wait_no_active_pfb_task(deployed_vm)  # a clean baseline — no prior pass in flight
     assert not h.hook_marker_exists(deployed_vm, pre_marker), "pre marker present before launch (stale state?)"
+    assert not h.hook_marker_exists(deployed_vm, waiting_marker), "waiting marker present before launch (stale state?)"
     assert not h.hook_marker_exists(deployed_vm, post_marker), "post marker present before launch (stale state?)"
     assert not h.hook_marker_exists(deployed_vm, child_marker), "child marker present before launch (stale state?)"
     assert not h.hook_marker_exists(deployed_vm, release_marker), "release marker present before launch (stale state?)"
@@ -589,6 +592,11 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
         # pre hook while the child remains blocked on the unreleased event.
         h.wait_until(
             lambda: h.hook_marker_exists(deployed_vm, post_marker),
+            timeout=30.0,
+            interval=1.0,
+        )
+        h.wait_until(
+            lambda: h.hook_marker_exists(deployed_vm, waiting_marker),
             timeout=30.0,
             interval=1.0,
         )
@@ -614,7 +622,7 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
         # path) — then let any pass settle before clearing.
         deployed_vm.ssh("/bin/touch", release_marker)
         h.wait_no_active_pfb_task(deployed_vm, timeout=30.0)
-        deployed_vm.ssh("/bin/rm", "-f", child_marker, release_marker)
+        deployed_vm.ssh("/bin/rm", "-f", waiting_marker, child_marker, release_marker)
         h.clear_update_hooks(deployed_vm)
         h.clear_hook_markers(deployed_vm, token)
 
@@ -658,13 +666,14 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
     token = "stream"
     stream_marker = f"STREAM_{token}_MARK"
     done_marker = f"DONE_{token}_MARK"
+    emitted_marker = h.hook_marker_path(token, "emitted")
     release_marker = h.hook_marker_path(token, "release")
     post_hook = {
         "script": f"hook_post_{token}_slow.sh",
         # Emit the marker FIRST (streams immediately if live), then hold the hook open until
         # release before the closing marker + exit.
         "_body": (
-            f"#!/bin/sh\n/bin/echo {stream_marker}\n"
+            f"#!/bin/sh\n/bin/echo {stream_marker}\n/bin/touch {emitted_marker}\n"
             f"while [ ! -f {release_marker} ]; do /bin/sleep 1; done\n"
             f"/bin/echo {done_marker}\n"
         ),
@@ -674,9 +683,10 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
         "timeout": "60",
     }
     h.set_update_hooks(deployed_vm, [post_hook])
-    deployed_vm.ssh("/bin/rm", "-f", release_marker)
+    deployed_vm.ssh("/bin/rm", "-f", emitted_marker, release_marker)
     h.wait_no_active_pfb_task(deployed_vm)  # clean baseline — no prior pass in flight
     assert not h.hook_marker_exists(deployed_vm, release_marker), "release marker present before launch (stale state?)"
+    assert not h.hook_marker_exists(deployed_vm, emitted_marker), "emitted marker present before launch (stale state?)"
     persisted_before = h.count_log_marker(deployed_vm, h.PFB_LOG, stream_marker)
     persisted_before_done = h.count_log_marker(deployed_vm, h.PFB_LOG, done_marker)
 
@@ -697,11 +707,11 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
             interval=1.0,
         )
 
-        # THE DISCRIMINATOR: while the hook waits for release, its leading marker must be in the
-        # PER-RUN log — proof the hook's output is routed there and streams. Pre-fix it went to
-        # the cumulative log only, so the per-run log would never see it.
+        # THE BARRIER: the script creates emitted_marker only after echo(1) has appended the
+        # leading marker. Once observed, the per-run log read is authoritative; elapsed time
+        # performs no assertion work.
         h.wait_until(
-            lambda: stream_marker in deployed_vm.ssh("cat", h.PFB_RUNLOG).stdout,
+            lambda: h.hook_marker_exists(deployed_vm, emitted_marker),
             timeout=30.0,
             interval=1.0,
         )
@@ -730,7 +740,7 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
             persisted_delta_done = h.count_log_marker(deployed_vm, h.PFB_LOG, done_marker) - persisted_before_done
         finally:
             h.clear_update_hooks(deployed_vm)
-            deployed_vm.ssh("/bin/rm", "-f", release_marker)
+            deployed_vm.ssh("/bin/rm", "-f", emitted_marker, release_marker)
         assert persisted_delta == 1, (
             f"hook marker {stream_marker!r} was persisted into {h.PFB_LOG} {persisted_delta} time(s) "
             "for one hook run (expected exactly 1 — pfb_persist_hook_output double-fired):\n"

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -560,7 +560,7 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
         "_body": (
             "#!/bin/sh\n"
             f"/bin/echo START > {pre_marker}\n"
-            f"/bin/sh -c '/bin/touch {waiting_marker}; "
+            f"/bin/sh -c '/usr/bin/touch {waiting_marker}; "
             f"while [ ! -f {release_marker} ]; do /bin/sleep 1; done; "
             f"/bin/echo CHILD_FINISHED > {child_marker}' &\n"
             f"/bin/echo HOOK_DONE >> {pre_marker}\n"
@@ -620,7 +620,7 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
     finally:
         # Release the child first — that also unblocks a pass still stalled on it (broken-runner
         # path) — then let any pass settle before clearing.
-        deployed_vm.ssh("/bin/touch", release_marker)
+        deployed_vm.ssh("/usr/bin/touch", release_marker)
         h.wait_no_active_pfb_task(deployed_vm, timeout=30.0)
         deployed_vm.ssh("/bin/rm", "-f", waiting_marker, child_marker, release_marker)
         h.clear_update_hooks(deployed_vm)
@@ -673,7 +673,7 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
         # Emit the marker FIRST (streams immediately if live), then hold the hook open until
         # release before the closing marker + exit.
         "_body": (
-            f"#!/bin/sh\n/bin/echo {stream_marker}\n/bin/touch {emitted_marker}\n"
+            f"#!/bin/sh\n/bin/echo {stream_marker}\n/usr/bin/touch {emitted_marker}\n"
             f"while [ ! -f {release_marker} ]; do /bin/sleep 1; done\n"
             f"/bin/echo {done_marker}\n"
         ),
@@ -729,7 +729,7 @@ def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -
         )
     finally:
         # Release the hook first, then let the pass settle before cleanup and persistence checks.
-        deployed_vm.ssh("/bin/touch", release_marker)
+        deployed_vm.ssh("/usr/bin/touch", release_marker)
         persisted_delta = -1
         persisted_delta_done = -1
         try:

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -624,6 +624,7 @@ def test_hooks_spawned_daemon_does_not_stall_pass(deployed_vm: SmokeVM) -> None:
 # --------------------------------------------------------------------------- #
 
 
+@pytest.mark.timeout(120)
 def test_post_hook_output_streams_into_runlog_during_run(deployed_vm: SmokeVM) -> None:
     """A post hook's output reaches the PER-RUN log WHILE it runs — the file the live tail reads.
 

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -445,20 +445,16 @@ def test_tick_dispatches_due_feed(deployed_vm: SmokeVM) -> None:
 
 @pytest.mark.smoke
 @pytest.mark.tick
-@pytest.mark.timeout(150)  # drain + bounded no-dispatch poll can exceed the 30s body cap
+@pytest.mark.timeout(150)
 def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer) -> None:
     """Tick does NOT dispatch a feed sync when the cron ledger entry is not yet due —
     yet the tick itself genuinely ran (issue #582 positive control).
 
-    The tick logs to syslog (not stdout), so observe the NON-dispatch via the
-    ' CRON  PROCESS  START' marker (logged only by pfblockerng_sync_cron): a non-due cron
-    must produce NO new marker. The explicit pre-baseline drain stabilizes marker attribution;
-    ``_run_tick`` drains again to close the pre-dispatch race. This is marker-based
-    (not ledger-value-based) so it is immune to a prior test's mark_ran overwriting
-    the cron entry — both values stay 'future' anyway.
+    The tick logs its dispatch decision before any background cron process starts, so observe
+    the synchronous ``Tick: dispatching feed cron.`` marker: a non-due cron must produce none.
 
-    On its own, "no CRON PROCESS marker" cannot distinguish "tick correctly skipped the
-    non-due cron" from "tick never ran at all" — both look identical. The positive control:
+    On its own, "no dispatch marker" cannot distinguish "tick correctly skipped the non-due
+    cron" from "tick never ran at all" — both look identical. The positive control:
     ss_refresh rides every tick unconditionally (pfblockerng_tick calls it regardless of what
     is due), so a SafeSearch CNAME row seeded with a STALE baked IP and a resolver (the
     'pfbextdns' setting) pointed at the hermetic stub DNS makes THIS tick's ss_refresh
@@ -469,11 +465,11 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
             Given the 'cron' ledger entry has next_due = now + 1 hour, and a SafeSearch
                 CNAME row is seeded with a baked IP the stub will not repeat.
             When pfblockerng.php tick runs.
-            Then NO new ' CRON  PROCESS  START' marker appears (the cron was skipped),
+            Then NO new 'Tick: dispatching feed cron.' marker appears (the cron was skipped),
             And  the ss_refresh marker DOES appear (the tick still ran).
     """
     vm = deployed_vm
-    marker = "CRON  PROCESS  START"
+    marker = "Tick: dispatching feed cron."
     ss_marker = "SafeSearch CNAME fallback IPs refreshed"
 
     now_ts = int(vm.ssh("date +%s").stdout.strip())
@@ -491,8 +487,8 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
         # When: tick fires — cron is not due, but ss_refresh always runs.
         _run_tick(vm)
 
-        # Then: no new CRON PROCESS pass appeared (cron skipped). _run_tick is the synchronous
-        # barrier, so the post-tick marker snapshot is authoritative.
+        # Then: no dispatch decision was logged (cron skipped). _run_tick returns after this
+        # synchronous decision log, so the post-tick marker snapshot is authoritative.
         after = h.count_log_marker(vm, h.PFB_LOG, marker)
         assert after == before, (
             f"tick dispatched a cron for a NON-due feed — ' {marker}' marker count rose from {before}"

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -474,6 +474,9 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
     now_ts = int(vm.ssh("date +%s").stdout.strip())
     _write_ledger_entry(vm, "cron", now_ts - 86400, now_ts + 3600)
     before_entry = _read_ledger(vm).get("cron")
+    assert before_entry is not None and before_entry.get("next_due", 0) > now_ts, (
+        f"test setup failed to arrange a future cron entry (now={now_ts}, entry={before_entry!r})"
+    )
     h.wait_no_active_pfb_task(vm)
 
     # Positive control: a resolvable CNAME target the stub answers, baked stale in the CSV.

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -450,11 +450,11 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
     """Tick does NOT dispatch a feed sync when the cron ledger entry is not yet due —
     yet the tick itself genuinely ran (issue #582 positive control).
 
-    The tick logs its dispatch decision before any background cron process starts, so observe
-    the synchronous ``Tick: dispatching feed cron.`` marker: a non-due cron must produce none.
+    The due ledger is the synchronous dispatch-decision observable: a non-due cron must leave
+    its entry exactly unchanged across the tick.
 
-    On its own, "no dispatch marker" cannot distinguish "tick correctly skipped the non-due
-    cron" from "tick never ran at all" — both look identical. The positive control:
+    On its own, "unchanged ledger" cannot distinguish "tick correctly skipped the non-due cron"
+    from "tick never ran at all" — both look identical. The positive control:
     ss_refresh rides every tick unconditionally (pfblockerng_tick calls it regardless of what
     is due), so a SafeSearch CNAME row seeded with a STALE baked IP and a resolver (the
     'pfbextdns' setting) pointed at the hermetic stub DNS makes THIS tick's ss_refresh
@@ -465,17 +465,16 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
             Given the 'cron' ledger entry has next_due = now + 1 hour, and a SafeSearch
                 CNAME row is seeded with a baked IP the stub will not repeat.
             When pfblockerng.php tick runs.
-            Then NO new 'Tick: dispatching feed cron.' marker appears (the cron was skipped),
+            Then the 'cron' ledger entry is exactly unchanged (the cron was skipped),
             And  the ss_refresh marker DOES appear (the tick still ran).
     """
     vm = deployed_vm
-    marker = "Tick: dispatching feed cron."
     ss_marker = "SafeSearch CNAME fallback IPs refreshed"
 
     now_ts = int(vm.ssh("date +%s").stdout.strip())
     _write_ledger_entry(vm, "cron", now_ts - 86400, now_ts + 3600)
+    before_entry = _read_ledger(vm).get("cron")
     h.wait_no_active_pfb_task(vm)
-    before = h.count_log_marker(vm, h.PFB_LOG, marker)
 
     # Positive control: a resolvable CNAME target the stub answers, baked stale in the CSV.
     target = h.unique_domain("tickssrefresh")
@@ -487,11 +486,11 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
         # When: tick fires — cron is not due, but ss_refresh always runs.
         _run_tick(vm)
 
-        # Then: no dispatch decision was logged (cron skipped). _run_tick returns after this
-        # synchronous decision log, so the post-tick marker snapshot is authoritative.
-        after = h.count_log_marker(vm, h.PFB_LOG, marker)
-        assert after == before, (
-            f"tick dispatched a cron for a NON-due feed — ' {marker}' marker count rose from {before}"
+        # Then: the synchronous ledger decision is unchanged (cron skipped).
+        after_entry = _read_ledger(vm).get("cron")
+        assert after_entry == before_entry, (
+            "tick dispatched a cron for a NON-due feed — cron ledger entry changed: "
+            f"before={before_entry!r}, after={after_entry!r}"
         )
 
         # Then: the ss_refresh marker DID appear — the tick genuinely ran; this is what

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -491,14 +491,12 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
         # When: tick fires — cron is not due, but ss_refresh always runs.
         _run_tick(vm)
 
-        # Then: no new CRON PROCESS pass appeared (cron skipped). The bounded poll gives any
-        # erroneous late dispatch a window to show; wait_until returns False (good) when the
-        # count never rises.
-        assert not h.wait_until(
-            lambda: h.count_log_marker(vm, h.PFB_LOG, marker) > before,
-            timeout=20,
-            interval=4,
-        ), f"tick dispatched a cron for a NON-due feed — ' {marker}' marker count rose from {before}"
+        # Then: no new CRON PROCESS pass appeared (cron skipped). _run_tick is the synchronous
+        # barrier, so the post-tick marker snapshot is authoritative.
+        after = h.count_log_marker(vm, h.PFB_LOG, marker)
+        assert after == before, (
+            f"tick dispatched a cron for a NON-due feed — ' {marker}' marker count rose from {before}"
+        )
 
         # Then: the ss_refresh marker DID appear — the tick genuinely ran; this is what
         # distinguishes "skipped correctly" from "never ran" above.

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -619,9 +619,8 @@ def mfs_var(deployed_vm: SmokeVM, request: pytest.FixtureRequest) -> Iterator[Sm
 @pytest.mark.reboot
 @pytest.mark.tick
 # Unlike the boot_reload siblings (which reboot in a FIXTURE, exempt from the workflow's
-# 30s func-only body cap), this test reboots in its BODY too: the 30s settle alone exhausts
-# the default cap, so it could never pass a dispatch without its own budget (#738 F4
-# validation run). Reboot ~90-150s (settle + readiness gate) + ledger checks + margin. The
+# 30s func-only body cap), this test reboots in its BODY too. The reboot helper first consumes
+# the observable boottime-change event, then runs readiness with its own full budget; the
 # mfs_var fixture reboots twice more (arrange + teardown) — exempt from the func-only cap,
 # same as boot_reload's fixture reboots — so the body still contains exactly ONE reboot.
 @pytest.mark.timeout(300)

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -108,7 +108,6 @@ def test_reboot_vm_waits_for_changed_boottime_before_readiness(monkeypatch: pyte
     fake_vm = FakeVM()
     vm = cast(helpers.SmokeVM, fake_vm)
     ready_calls: list[list[str]] = []
-    sleep_calls: list[float] = []
 
     def fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         ready_calls.append(argv)
@@ -116,7 +115,7 @@ def test_reboot_vm_waits_for_changed_boottime_before_readiness(monkeypatch: pyte
         return subprocess.CompletedProcess(argv, 0, "ready", "")
 
     monkeypatch.setattr(helpers.subprocess, "run", fake_run)
-    monkeypatch.setattr(helpers.time, "sleep", sleep_calls.append)
+    monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
     monkeypatch.setattr(helpers, "wait_boot_complete", lambda vm: None)
     monkeypatch.setattr(helpers, "wait_unbound_ready", lambda vm: None)
 
@@ -124,4 +123,3 @@ def test_reboot_vm_waits_for_changed_boottime_before_readiness(monkeypatch: pyte
 
     assert ready_calls
     assert fake_vm.boottime_reads == 4
-    assert all(delay < 30 for delay in sleep_calls)

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -16,8 +16,12 @@ mirrors the precedent in ``tests/test_smoke_diag_redaction.py``).
 
 from __future__ import annotations
 
+import subprocess
+from typing import cast
+
 import pytest
 
+from tests.smoke import helpers
 from tests.smoke.helpers import _assert_boottime_advanced
 
 _BEFORE = "{ sec = 1751500000, usec = 123456 }"
@@ -79,3 +83,48 @@ def test_assert_boottime_advanced_strips_whitespace_before_comparing() -> None:
     """
     with pytest.raises(AssertionError):
         _assert_boottime_advanced(_BEFORE, f"{_BEFORE}\n")
+
+
+def test_reboot_vm_waits_for_changed_boottime_before_readiness(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeVM:
+        ssh_key_path = "/tmp/id_ed25519"
+        host = "127.0.0.1"
+        ssh_port = 2222
+        vm_pid = None
+        web_port = 8080
+
+        def __init__(self) -> None:
+            self.boottime_reads = 0
+            self.calls: list[str] = []
+
+        def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            command = " ".join(remote)
+            self.calls.append(command)
+            if command == helpers._BOOTTIME_SYSCTL:
+                self.boottime_reads += 1
+                value = _BEFORE if self.boottime_reads <= 3 else _AFTER
+                return subprocess.CompletedProcess(remote, 0, value, "")
+            if command == "/sbin/reboot":
+                return subprocess.CompletedProcess(remote, 0, "", "")
+            raise AssertionError(f"unexpected ssh command: {command}")
+
+    fake_vm = FakeVM()
+    vm = cast(helpers.SmokeVM, fake_vm)
+    ready_calls: list[list[str]] = []
+    sleep_calls: list[float] = []
+
+    def fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        ready_calls.append(argv)
+        assert fake_vm.boottime_reads == 4, "changed boottime must be observed before readiness"
+        return subprocess.CompletedProcess(argv, 0, "ready", "")
+
+    monkeypatch.setattr(helpers.subprocess, "run", fake_run)
+    monkeypatch.setattr(helpers.time, "sleep", sleep_calls.append)
+    monkeypatch.setattr(helpers, "wait_boot_complete", lambda vm: None)
+    monkeypatch.setattr(helpers, "wait_unbound_ready", lambda vm: None)
+
+    helpers.reboot_vm(vm, timeout=5)
+
+    assert ready_calls
+    assert fake_vm.boottime_reads == 4
+    assert all(delay < 30 for delay in sleep_calls)

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -99,7 +99,11 @@ def test_reboot_vm_waits_for_changed_boottime_before_readiness(monkeypatch: pyte
             self.calls.append(command)
             if command == helpers._BOOTTIME_SYSCTL:
                 self.boottime_reads += 1
-                value = _BEFORE if self.boottime_reads <= 3 else _AFTER
+                if self.boottime_reads == 1:
+                    return subprocess.CompletedProcess(remote, 0, _BEFORE, "")
+                if self.boottime_reads == 2:
+                    return subprocess.CompletedProcess(remote, 1, _AFTER, "sysctl failed")
+                value = _BEFORE if self.boottime_reads == 3 else _AFTER
                 return subprocess.CompletedProcess(remote, 0, value, "")
             if command == "/sbin/reboot":
                 return subprocess.CompletedProcess(remote, 0, "", "")

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -1,12 +1,9 @@
 """Issue #738 finding F4 — ``reboot_vm`` must PROVE the guest actually rebooted.
 
-``tests/smoke/helpers.reboot_vm`` replaced the old ``kern.boottime``-change POLL with a fixed
-settle sleep (see ``_REBOOT_SETTLE_SECS``): if shutdown outlasts that settle on a slow host, the
-still-up PRE-reboot sshd answers the readiness gate as "ready", and every downstream assertion
-(the reboot-persistence tests in ``tests/smoke/test_smoke_boot_reload.py`` and
-``tests/smoke/test_smoke_tick.py``) silently runs against stale pre-reboot state. The fix restores
-proof WITHOUT restoring the poll: a single ``kern.boottime`` read before the reboot and a single
-read after the full readiness gate, compared by ``_assert_boottime_advanced``.
+``tests/smoke/helpers.reboot_vm`` now polls the observable ``kern.boottime`` token after issuing
+the reboot, tolerating SSH failures while the guest is down. A generous timeout is a salvage cap
+that raises loudly if the token never changes; once it does, the full readiness gate receives its
+own independent budget.
 
 This module pins that PURE comparison seam off-VM (no VM I/O, no network) — it lives under
 ``tests/`` (NOT ``tests/smoke/``) so it runs in the default suite. Importing

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -5,7 +5,7 @@ the reboot, tolerating SSH failures while the guest is down. A generous timeout 
 that raises loudly if the token never changes; once it does, the full readiness gate receives its
 own independent budget.
 
-This module pins that PURE comparison seam off-VM (no VM I/O, no network) — it lives under
+This module pins that reboot event flow off-VM with a fake VM (no network) — it lives under
 ``tests/`` (NOT ``tests/smoke/``) so it runs in the default suite. Importing
 ``tests.smoke.helpers`` itself needs no VM (its own module docstring guarantees import-safety;
 mirrors the precedent in ``tests/test_smoke_diag_redaction.py``).
@@ -19,67 +19,9 @@ from typing import cast
 import pytest
 
 from tests.smoke import helpers
-from tests.smoke.helpers import _assert_boottime_advanced
 
 _BEFORE = "{ sec = 1751500000, usec = 123456 }"
 _AFTER = "{ sec = 1751500090, usec = 654321 }"
-
-
-def test_assert_boottime_advanced_passes_when_value_changed() -> None:
-    """Given a kern.boottime reading that DIFFERS before vs. after the reboot
-    When _assert_boottime_advanced runs
-    Then it does not raise — this is the real-reboot case.
-    """
-    _assert_boottime_advanced(_BEFORE, _AFTER)  # must not raise
-
-
-def test_assert_boottime_advanced_raises_when_value_unchanged() -> None:
-    """LOAD-BEARING: an unchanged kern.boottime means the readiness gate answered on the
-    PRE-reboot instance (the guest never actually went down and back up).
-
-    Given the same kern.boottime reading before AND after
-    When _assert_boottime_advanced runs
-    Then it raises AssertionError naming BOTH the before and after value, so a maintainer never
-         has to guess which side is stale.
-    """
-    with pytest.raises(AssertionError) as exc_info:
-        _assert_boottime_advanced(_BEFORE, _BEFORE)
-    message = str(exc_info.value)
-    assert _BEFORE in message, f"expected the unchanged value {_BEFORE!r} in the message, got: {message!r}"
-    assert "never rebooted" in message
-
-
-def test_assert_boottime_advanced_raises_when_before_is_empty() -> None:
-    """Given an EMPTY pre-reboot reading (the sysctl read itself failed)
-    When _assert_boottime_advanced runs
-    Then it raises AssertionError naming the BEFORE side as the empty one — never silently
-         treats a failed read as "changed".
-    """
-    with pytest.raises(AssertionError) as exc_info:
-        _assert_boottime_advanced("", _AFTER)
-    message = str(exc_info.value)
-    assert "BEFORE" in message, f"expected the message to name the empty BEFORE side, got: {message!r}"
-
-
-def test_assert_boottime_advanced_raises_when_after_is_empty() -> None:
-    """Given an EMPTY post-reboot reading (the sysctl read itself failed)
-    When _assert_boottime_advanced runs
-    Then it raises AssertionError naming the AFTER side as the empty one.
-    """
-    with pytest.raises(AssertionError) as exc_info:
-        _assert_boottime_advanced(_BEFORE, "")
-    message = str(exc_info.value)
-    assert "AFTER" in message, f"expected the message to name the empty AFTER side, got: {message!r}"
-
-
-def test_assert_boottime_advanced_strips_whitespace_before_comparing() -> None:
-    """Given the same value but with SSH-transport-typical trailing newline/whitespace noise on
-         one side
-    When _assert_boottime_advanced runs
-    Then it still detects the values as unchanged (whitespace alone must not read as "advanced").
-    """
-    with pytest.raises(AssertionError):
-        _assert_boottime_advanced(_BEFORE, f"{_BEFORE}\n")
 
 
 def test_reboot_vm_waits_for_changed_boottime_before_readiness(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_smoke_wait_helpers.py
+++ b/tests/test_smoke_wait_helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import threading
 from collections.abc import Callable
 from typing import cast
+from urllib.error import URLError
 from urllib.request import urlopen
 
 import pytest
@@ -37,8 +38,22 @@ def test_dns_probe_client_until_expiry_is_loud_environment_failure(monkeypatch: 
 
 
 def _request_callback(sink: _MockCallbackSink, path: str = "/reload") -> None:
-    with urlopen(f"http://127.0.0.1:{sink.port}{path}", timeout=2.0):  # noqa: S310 - local test server
-        pass
+    try:
+        with urlopen(f"http://127.0.0.1:{sink.port}{path}", timeout=2.0):  # noqa: S310 - local test server
+            pass
+    except (OSError, URLError) as exc:
+        raise RuntimeError(f"stuck/environment: callback request {path} did not complete") from exc
+
+
+def _wait_event(event: threading.Event, label: str) -> None:
+    if not event.wait(timeout=2.0):
+        raise RuntimeError(f"stuck/environment: {label} event was not observed before salvage cap")
+
+
+def _join_thread(thread: threading.Thread, label: str) -> None:
+    thread.join(timeout=2.0)
+    if thread.is_alive():
+        raise RuntimeError(f"stuck/environment: {label} did not terminate before salvage cap")
 
 
 def test_callback_sink_wait_for_observes_existing_and_later_callbacks(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -68,15 +83,16 @@ def test_callback_sink_wait_for_observes_existing_and_later_callbacks(monkeypatc
 
         waiter = threading.Thread(target=wait_for_callback)
         waiter.start()
-        assert wait_entered.wait(timeout=2.0), "waiter did not enter Condition.wait_for"
+        _wait_event(wait_entered, "waiter-entry")
         _request_callback(sink, "/later")
-        waiter.join(timeout=2.0)
-        assert not waiter.is_alive(), "callback notification did not release waiter"
+        _join_thread(waiter, "callback waiter")
         assert outcome == [True]
     finally:
         if waiter is not None and waiter.is_alive():
-            _request_callback(sink, "/release")
-            waiter.join(timeout=2.0)
+            try:
+                _request_callback(sink, "/release")
+            finally:
+                _join_thread(waiter, "callback waiter cleanup")
         sink.stop()
 
 

--- a/tests/test_smoke_wait_helpers.py
+++ b/tests/test_smoke_wait_helpers.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import threading
-import time
+from collections.abc import Callable
 from typing import cast
+from urllib.request import urlopen
 
 import pytest
 
 from tests.smoke import helpers
-from tests.smoke.conftest import CallbackRecord, _MockCallbackSink
+from tests.smoke.conftest import _MockCallbackSink
 
 
 def _answer() -> helpers.DnsAnswer:
@@ -35,31 +36,47 @@ def test_dns_probe_client_until_expiry_is_loud_environment_failure(monkeypatch: 
         )
 
 
-def _record() -> CallbackRecord:
-    return CallbackRecord(method="POST", path="/reload", form={}, query={})
+def _request_callback(sink: _MockCallbackSink, path: str = "/reload") -> None:
+    with urlopen(f"http://127.0.0.1:{sink.port}{path}", timeout=2.0):  # noqa: S310 - local test server
+        pass
 
 
-def test_callback_sink_wait_for_observes_existing_and_later_callbacks() -> None:
+def test_callback_sink_wait_for_observes_existing_and_later_callbacks(monkeypatch: pytest.MonkeyPatch) -> None:
     sink = _MockCallbackSink()
     sink.start()
+    waiter: threading.Thread | None = None
     try:
-        sink._callbacks.append(_record())
+        _request_callback(sink)
         assert sink.wait_for(1, timeout=0.01)
 
         sink.clear()
+        wait_entered = threading.Event()
+        outcome: list[object] = []
+        original_wait_for = sink._condition.wait_for
 
-        def record_later() -> None:
-            time.sleep(0.01)
-            with sink._lock:
-                sink._callbacks.append(_record())
-                if hasattr(sink, "_condition"):
-                    sink._condition.notify_all()
+        def wrapped_wait_for(predicate: Callable[[], bool], timeout: float | None = None) -> bool:
+            wait_entered.set()
+            return original_wait_for(predicate, timeout=timeout)
 
-        thread = threading.Thread(target=record_later)
-        thread.start()
-        assert sink.wait_for(1, timeout=0.5)
-        thread.join()
+        monkeypatch.setattr(sink._condition, "wait_for", wrapped_wait_for)
+
+        def wait_for_callback() -> None:
+            try:
+                outcome.append(sink.wait_for(1, timeout=2.0))
+            except BaseException as exc:  # noqa: BLE001 - propagate through assertion below
+                outcome.append(exc)
+
+        waiter = threading.Thread(target=wait_for_callback)
+        waiter.start()
+        assert wait_entered.wait(timeout=2.0), "waiter did not enter Condition.wait_for"
+        _request_callback(sink, "/later")
+        waiter.join(timeout=2.0)
+        assert not waiter.is_alive(), "callback notification did not release waiter"
+        assert outcome == [True]
     finally:
+        if waiter is not None and waiter.is_alive():
+            _request_callback(sink, "/release")
+            waiter.join(timeout=2.0)
         sink.stop()
 
 

--- a/tests/test_smoke_wait_helpers.py
+++ b/tests/test_smoke_wait_helpers.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import cast
+
+import pytest
+
+from tests.smoke import helpers
+from tests.smoke.conftest import CallbackRecord, _MockCallbackSink
+
+
+def _answer() -> helpers.DnsAnswer:
+    return helpers.DnsAnswer(rcode="NOERROR", records=["198.51.100.7"])
+
+
+def test_wait_until_expiry_is_loud_environment_failure() -> None:
+    with pytest.raises(RuntimeError, match="stuck/environment"):
+        helpers.wait_until(lambda: False, timeout=0, interval=0)
+
+
+def test_dns_probe_until_expiry_is_loud_environment_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(helpers, "dns_probe", lambda *args, **kwargs: _answer())
+    with pytest.raises(RuntimeError, match="stuck/environment"):
+        helpers.dns_probe_until(
+            cast(helpers.SmokeVM, object()), "example.invalid", lambda answer: False, timeout=0, interval=0
+        )
+
+
+def test_dns_probe_client_until_expiry_is_loud_environment_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(helpers, "dns_probe_client", lambda *args, **kwargs: _answer())
+    with pytest.raises(RuntimeError, match="stuck/environment"):
+        helpers.dns_probe_client_until(
+            cast(helpers.SmokeVM, object()), "example.invalid", lambda answer: False, timeout=0, interval=0
+        )
+
+
+def _record() -> CallbackRecord:
+    return CallbackRecord(method="POST", path="/reload", form={}, query={})
+
+
+def test_callback_sink_wait_for_observes_existing_and_later_callbacks() -> None:
+    sink = _MockCallbackSink()
+    sink.start()
+    try:
+        sink._callbacks.append(_record())
+        assert sink.wait_for(1, timeout=0.01)
+
+        sink.clear()
+
+        def record_later() -> None:
+            time.sleep(0.01)
+            with sink._lock:
+                sink._callbacks.append(_record())
+                if hasattr(sink, "_condition"):
+                    sink._condition.notify_all()
+
+        thread = threading.Thread(target=record_later)
+        thread.start()
+        assert sink.wait_for(1, timeout=0.5)
+        thread.join()
+    finally:
+        sink.stop()
+
+
+def test_callback_sink_wait_for_expiry_is_loud_environment_failure() -> None:
+    sink = _MockCallbackSink()
+    sink.start()
+    try:
+        with pytest.raises(RuntimeError, match="stuck/environment"):
+            sink.wait_for(1, timeout=0)
+    finally:
+        sink.stop()


### PR DESCRIPTION
## Summary

- make shared smoke waits succeed only on observed events or conditions
- treat timeout expiry as a loud `stuck/environment` salvage failure
- replace reboot's fixed settle with a changed `kern.boottime` event before readiness
- notify callback waiters through `Condition` and delete unused `wait_for_tcp`
- replace helper-owned hook timing windows with explicit script/release events

Fixes #1988

## Evidence

- Original test-first RED: `6 failed, 5 passed`; initial GREEN: `11 passed`
- Final focused unit suite after deleting five orphan comparator tests: `6 passed`
- Hostile reboot proof: `rc=1` with changed stdout fails against the old helper and passes after the fix
- Current regression-test hashes: reboot `e3861a4e808c1bab114202545c3184b718308560fd7ddb3a608e577bd5f5bd49`; waits `ec08d244a1ade46a9721091ff22a609629917898111b3d74307997857564ff41`
- Canonical gates: pytest, Ruff check, Ruff format, and mypy passed
- Independent verifier and final adversarial reviewer: PASS
- Live smoke (`smoke`): DNS transition, callback sink, and tick barrier — `3 passed`
- Final ledger-oracle tick smoke — `1 passed`
- Final hook event barriers — `2 passed`
- Live smoke (`reboot`): standard + RAM-disk — `2 passed`

## Caller matrix

- `reboot_vm`: 7 callers
- `wait_until`: 14 rows; helper-owned hook/tick callers now consume explicit events or synchronous state
- `dns_probe_client_until`: 48 callers
- callback `wait_for`: 3 rows; its negative caller now uses a synchronous reload barrier
- `dns_probe_until`: no callers; contract corrected
- `wait_for_tcp`: no callers; deleted

## Audit

Implementation and review-fix commits were generated with OpenAI Codex. No Copilot review was requested; an unsolicited automatic comment was swept and addressed. CodeRabbit was quota-limited.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
