### PR TITLE
pfblockerng: truncate Alerts row cells on characters, not bytes

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2227,7 +2227,7 @@ function convert_dnsbl_log($mode, $fields) {
 		$h_title		= '';
 		if (strlen($hostname) >= 25) {
 			$h_title	= pfb_hsc($hostname);
-			$hostname	= pfb_hsc(substr($hostname, 0, 24)) . "<small>...</small>";
+			$hostname	= pfb_hsc(mb_substr($hostname, 0, 24, 'UTF-8')) . "<small>...</small>";
 		} else {
 			$hostname	= pfb_hsc($hostname);
 		}
@@ -2244,7 +2244,7 @@ function convert_dnsbl_log($mode, $fields) {
 		$f2 = "{$f2} [" . idn_to_utf8($f2) . "]";
 	}
 	if (strlen($f2) >= ($mode != 'unified' ? 60 : 40)) {
-		$f2 = pfb_hsc(substr($f2, 0, ($mode != 'unified' ? 59 : 39))) . "<small>...</small>";
+		$f2 = pfb_hsc(mb_substr($f2, 0, ($mode != 'unified' ? 59 : 39), 'UTF-8')) . "<small>...</small>";
 	} else {
 		$f2 = pfb_hsc($f2);
 	}
@@ -2255,7 +2255,7 @@ function convert_dnsbl_log($mode, $fields) {
 			$f7		= "{$f7} [" . idn_to_utf8($f7) . "]";
 		}
 		if (strlen($f7) >= ($mode != 'unified' ? 52 : 32)) {
-			$f7		= pfb_hsc(substr($f7, 0, ($mode != 'unified' ? 51 : 31))) . "<small>...</small>";
+			$f7		= pfb_hsc(mb_substr($f7, 0, ($mode != 'unified' ? 51 : 31), 'UTF-8')) . "<small>...</small>";
 		} else {
 			$f7		= pfb_hsc($f7);
 		}
@@ -2303,7 +2303,7 @@ function convert_dnsbl_log($mode, $fields) {
 
 	if (!empty($fields[4])) {
 		if (strlen($fields[4]) >= 25) {
-			$f4 = pfb_hsc(substr($fields[4], 0, 24)) . "<small>...</small>";
+			$f4 = pfb_hsc(mb_substr($fields[4], 0, 24, 'UTF-8')) . "<small>...</small>";
 			$fields[4] = "<span title=\"" . pfb_hsc($fields[4]) . "\">{$f4}</span>";
 		} else {
 			$fields[4] = pfb_hsc($fields[4]);
@@ -2498,7 +2498,7 @@ function convert_dns_reply_log($mode, $fields) {
 	$title_hostname = '';
 	if (!empty($hostname) && strlen($hostname) >= 25) {
 		$title_hostname = pfb_hsc($hostname);
-		$hostname	= pfb_hsc(substr($hostname, 0, 24)) . "<small>...</small>";
+		$hostname	= pfb_hsc(mb_substr($hostname, 0, 24, 'UTF-8')) . "<small>...</small>";
 	} else {
 		$hostname	= pfb_hsc($hostname);
 	}
@@ -2580,7 +2580,7 @@ function convert_dns_reply_log($mode, $fields) {
 	$pfb_title5 = '';
 	if (strlen($fields[5]) >= 6) {
 		$pfb_title5	= pfb_hsc($fields[5]);
-		$fields[5]	= pfb_hsc(substr($fields[5], 0, 5)) . "<small>...</small>";
+		$fields[5]	= pfb_hsc(mb_substr($fields[5], 0, 5, 'UTF-8')) . "<small>...</small>";
 	} else {
 		$fields[5]	= pfb_hsc($fields[5]);
 	}
@@ -2589,7 +2589,7 @@ function convert_dns_reply_log($mode, $fields) {
 	$pfb_title6 = '';
 	if (strlen($fields[6]) >= ($mode != 'unified' ? 45 : 30)) {
 		$pfb_title6	= pfb_hsc($fields[6]);
-		$fields[6]	= pfb_hsc(substr($fields[6], 0, ($mode != 'unified' ? 44 : 29))) . "<small>...</small>";
+		$fields[6]	= pfb_hsc(mb_substr($fields[6], 0, ($mode != 'unified' ? 44 : 29), 'UTF-8')) . "<small>...</small>";
 	} else {
 		$fields[6]	= pfb_hsc($fields[6]);
 	}
@@ -2598,7 +2598,7 @@ function convert_dns_reply_log($mode, $fields) {
 	$pfb_title8 = '';
 	if (strlen($fields[8]) >= 17) {
 		$pfb_title8	= pfb_hsc($fields[8]);
-		$fields[8]	= pfb_hsc(substr($fields[8], 0, 16)) . "<small>...</small>";
+		$fields[8]	= pfb_hsc(mb_substr($fields[8], 0, 16, 'UTF-8')) . "<small>...</small>";
 	} else {
 		$fields[8]	= pfb_hsc($fields[8]);
 	}
@@ -3064,7 +3064,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			$pfb_matchtitle .= '&#013;';
 		}
 		$pfb_matchtitle .= "Feed: " . pfb_hsc($fields[15]);
-		$fields[15]	= pfb_hsc(substr($fields[15], 0, 16)) . "<small>...</small>";
+		$fields[15]	= pfb_hsc(mb_substr($fields[15], 0, 16, 'UTF-8')) . "<small>...</small>";
 	} else {
 		$fields[15]	= pfb_hsc($fields[15]);
 	}
@@ -3073,7 +3073,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			$pfb_matchtitle .= '&#013;';
 		}
 		$pfb_matchtitle .= "Feed new: " . pfb_hsc($feed_new);
-		$feed_new	= pfb_hsc(substr($feed_new, 0, 16)) . "<small>...</small>";
+		$feed_new	= pfb_hsc(mb_substr($feed_new, 0, 16, 'UTF-8')) . "<small>...</small>";
 	} else {
 		$feed_new	= pfb_hsc($feed_new);
 	}
@@ -3085,7 +3085,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		$fields[16] = 'Unknown';
 	}
 	elseif (strlen($fields[16]) >= 22) {
-		$fields[16] = "<span title=\"" . pfb_hsc($fields[16]) . "\">" . pfb_hsc(substr($fields[16], 0, 21)) . "<small>...</small></span>";
+		$fields[16] = "<span title=\"" . pfb_hsc($fields[16]) . "\">" . pfb_hsc(mb_substr($fields[16], 0, 21, 'UTF-8')) . "<small>...</small></span>";
 	}
 
 	// Interface / Protocol / GeoIP code / Timestamp printed verbatim

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1880,6 +1880,24 @@ function pfb_hsc($value) {
 	return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 }
 
+// Truncate a RAW log/host-derived token to $length CHARACTERS (never bytes), so a
+// multibyte character straddling the cut survives whole instead of leaving a
+// dangling lead byte for pfb_hsc()'s ENT_SUBSTITUTE to replace (issue #1815). An
+// invalid byte within the kept prefix is still replaced with U+FFFD -- the same
+// symbol pfb_hsc()'s ENT_SUBSTITUTE produces (issue #1814) -- by pinning
+// mb_substitute_character() for the duration of the call; mb_substr()'s own
+// default substitute ('?') would otherwise fabricate a character the input never
+// carried. mb_substitute_character() is request-global state, so the prior value
+// is always restored before returning, even though this file never changes it
+// elsewhere.
+function pfb_truncate($value, $length) {
+	$prev = mb_substitute_character();
+	mb_substitute_character(0xFFFD);
+	$cut = mb_substr((string) $value, 0, $length, 'UTF-8');
+	mb_substitute_character($prev);
+	return $cut;
+}
+
 // Compose the resolved-hostname stats cell for the IP src/dst-in stats. The raw
 // hostname is attacker-influenceable, so HTML-encode it; a >=45-char value is
 // truncated for display with the full value kept in the title attribute.
@@ -2227,7 +2245,7 @@ function convert_dnsbl_log($mode, $fields) {
 		$h_title		= '';
 		if (strlen($hostname) >= 25) {
 			$h_title	= pfb_hsc($hostname);
-			$hostname	= pfb_hsc(mb_substr($hostname, 0, 24, 'UTF-8')) . "<small>...</small>";
+			$hostname	= pfb_hsc(pfb_truncate($hostname, 24)) . "<small>...</small>";
 		} else {
 			$hostname	= pfb_hsc($hostname);
 		}
@@ -2244,7 +2262,7 @@ function convert_dnsbl_log($mode, $fields) {
 		$f2 = "{$f2} [" . idn_to_utf8($f2) . "]";
 	}
 	if (strlen($f2) >= ($mode != 'unified' ? 60 : 40)) {
-		$f2 = pfb_hsc(mb_substr($f2, 0, ($mode != 'unified' ? 59 : 39), 'UTF-8')) . "<small>...</small>";
+		$f2 = pfb_hsc(pfb_truncate($f2, ($mode != 'unified' ? 59 : 39))) . "<small>...</small>";
 	} else {
 		$f2 = pfb_hsc($f2);
 	}
@@ -2255,7 +2273,7 @@ function convert_dnsbl_log($mode, $fields) {
 			$f7		= "{$f7} [" . idn_to_utf8($f7) . "]";
 		}
 		if (strlen($f7) >= ($mode != 'unified' ? 52 : 32)) {
-			$f7		= pfb_hsc(mb_substr($f7, 0, ($mode != 'unified' ? 51 : 31), 'UTF-8')) . "<small>...</small>";
+			$f7		= pfb_hsc(pfb_truncate($f7, ($mode != 'unified' ? 51 : 31))) . "<small>...</small>";
 		} else {
 			$f7		= pfb_hsc($f7);
 		}
@@ -2303,7 +2321,7 @@ function convert_dnsbl_log($mode, $fields) {
 
 	if (!empty($fields[4])) {
 		if (strlen($fields[4]) >= 25) {
-			$f4 = pfb_hsc(mb_substr($fields[4], 0, 24, 'UTF-8')) . "<small>...</small>";
+			$f4 = pfb_hsc(pfb_truncate($fields[4], 24)) . "<small>...</small>";
 			$fields[4] = "<span title=\"" . pfb_hsc($fields[4]) . "\">{$f4}</span>";
 		} else {
 			$fields[4] = pfb_hsc($fields[4]);
@@ -2498,7 +2516,7 @@ function convert_dns_reply_log($mode, $fields) {
 	$title_hostname = '';
 	if (!empty($hostname) && strlen($hostname) >= 25) {
 		$title_hostname = pfb_hsc($hostname);
-		$hostname	= pfb_hsc(mb_substr($hostname, 0, 24, 'UTF-8')) . "<small>...</small>";
+		$hostname	= pfb_hsc(pfb_truncate($hostname, 24)) . "<small>...</small>";
 	} else {
 		$hostname	= pfb_hsc($hostname);
 	}
@@ -2580,7 +2598,7 @@ function convert_dns_reply_log($mode, $fields) {
 	$pfb_title5 = '';
 	if (strlen($fields[5]) >= 6) {
 		$pfb_title5	= pfb_hsc($fields[5]);
-		$fields[5]	= pfb_hsc(mb_substr($fields[5], 0, 5, 'UTF-8')) . "<small>...</small>";
+		$fields[5]	= pfb_hsc(pfb_truncate($fields[5], 5)) . "<small>...</small>";
 	} else {
 		$fields[5]	= pfb_hsc($fields[5]);
 	}
@@ -2589,7 +2607,7 @@ function convert_dns_reply_log($mode, $fields) {
 	$pfb_title6 = '';
 	if (strlen($fields[6]) >= ($mode != 'unified' ? 45 : 30)) {
 		$pfb_title6	= pfb_hsc($fields[6]);
-		$fields[6]	= pfb_hsc(mb_substr($fields[6], 0, ($mode != 'unified' ? 44 : 29), 'UTF-8')) . "<small>...</small>";
+		$fields[6]	= pfb_hsc(pfb_truncate($fields[6], ($mode != 'unified' ? 44 : 29))) . "<small>...</small>";
 	} else {
 		$fields[6]	= pfb_hsc($fields[6]);
 	}
@@ -2598,7 +2616,7 @@ function convert_dns_reply_log($mode, $fields) {
 	$pfb_title8 = '';
 	if (strlen($fields[8]) >= 17) {
 		$pfb_title8	= pfb_hsc($fields[8]);
-		$fields[8]	= pfb_hsc(mb_substr($fields[8], 0, 16, 'UTF-8')) . "<small>...</small>";
+		$fields[8]	= pfb_hsc(pfb_truncate($fields[8], 16)) . "<small>...</small>";
 	} else {
 		$fields[8]	= pfb_hsc($fields[8]);
 	}
@@ -3064,7 +3082,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			$pfb_matchtitle .= '&#013;';
 		}
 		$pfb_matchtitle .= "Feed: " . pfb_hsc($fields[15]);
-		$fields[15]	= pfb_hsc(mb_substr($fields[15], 0, 16, 'UTF-8')) . "<small>...</small>";
+		$fields[15]	= pfb_hsc(pfb_truncate($fields[15], 16)) . "<small>...</small>";
 	} else {
 		$fields[15]	= pfb_hsc($fields[15]);
 	}
@@ -3073,7 +3091,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 			$pfb_matchtitle .= '&#013;';
 		}
 		$pfb_matchtitle .= "Feed new: " . pfb_hsc($feed_new);
-		$feed_new	= pfb_hsc(mb_substr($feed_new, 0, 16, 'UTF-8')) . "<small>...</small>";
+		$feed_new	= pfb_hsc(pfb_truncate($feed_new, 16)) . "<small>...</small>";
 	} else {
 		$feed_new	= pfb_hsc($feed_new);
 	}
@@ -3085,7 +3103,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		$fields[16] = 'Unknown';
 	}
 	elseif (strlen($fields[16]) >= 22) {
-		$fields[16] = "<span title=\"" . pfb_hsc($fields[16]) . "\">" . pfb_hsc(mb_substr($fields[16], 0, 21, 'UTF-8')) . "<small>...</small></span>";
+		$fields[16] = "<span title=\"" . pfb_hsc($fields[16]) . "\">" . pfb_hsc(pfb_truncate($fields[16], 21)) . "<small>...</small></span>";
 	}
 
 	// Interface / Protocol / GeoIP code / Timestamp printed verbatim

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1888,14 +1888,16 @@ function pfb_hsc($value) {
 // mb_substitute_character() for the duration of the call; mb_substr()'s own
 // default substitute ('?') would otherwise fabricate a character the input never
 // carried. mb_substitute_character() is request-global state, so the prior value
-// is always restored before returning, even though this file never changes it
-// elsewhere.
+// is restored on every exit path -- the finally is what makes that true for a
+// throwing $value cast as well as the normal return.
 function pfb_truncate($value, $length) {
 	$prev = mb_substitute_character();
 	mb_substitute_character(0xFFFD);
-	$cut = mb_substr((string) $value, 0, $length, 'UTF-8');
-	mb_substitute_character($prev);
-	return $cut;
+	try {
+		return mb_substr((string) $value, 0, $length, 'UTF-8');
+	} finally {
+		mb_substitute_character($prev);
+	}
 }
 
 // Compose the resolved-hostname stats cell for the IP src/dst-in stats. The raw

--- a/tests/php/AlertsMultibyteTruncationTest.php
+++ b/tests/php/AlertsMultibyteTruncationTest.php
@@ -646,15 +646,31 @@ final class AlertsMultibyteTruncationTest extends TestCase
 		// A bare '?' is NOT a discriminating assertion -- the static template markup
 		// already contains literal '?' characters elsewhere (e.g. "from DNSBL?").
 		// Pin the substitute character AT the exact position the invalid byte occupied.
+		// This site also emits a title="" attribute carrying the FULL, UNTRUNCATED
+		// value (pfb_hsc($fields[4]) on the raw string, line ~2307) -- that copy never
+		// goes through mb_substr at all, so its own raw 0xFF byte is still substituted
+		// by pfb_hsc()'s ENT_SUBSTITUTE the #1814 way (U+FFFD) -- expected, unrelated to
+		// this fix, and asserted explicitly so it is not mistaken for a regression.
+		$this->assertStringContainsString(
+			"\u{FFFD}",
+			$html,
+			'the UNTRUNCATED title="" copy of the value must still substitute the raw invalid byte as U+FFFD (#1814, unaffected by this fix)'
+		);
+		// The DISPLAYED (truncated) span content is the part this fix touches: pin the
+		// exact substitute character mb_substr() produces AT the invalid byte's position.
 		$this->assertStringContainsString(
 			'R14Agent?aaaaaaaaaaaaaaa',
 			$html,
 			"mb_substr replaces the invalid byte with its own substitute character (default '?') at that exact position, not U+FFFD"
 		);
+		// Anchored with the immediately-following ellipsis marker so this checks ONLY the
+		// DISPLAYED (truncated) span text, never the title="" attribute above (which
+		// legitimately contains this same "R14Agent<FFFD>aaa..." prefix, followed by
+		// ".trailing-tail" instead of "<small>...</small>").
 		$this->assertStringNotContainsString(
-			"\u{FFFD}",
+			'R14Agent' . "\u{FFFD}" . 'aaaaaaaaaaaaaaa<small>...</small>',
 			$html,
-			'post-fix, U+FFFD is NOT produced for this byte -- mb_substr already consumed it before pfb_hsc() ran (see this test\'s docblock deviation note)'
+			'the DISPLAYED (truncated) span content must never show U+FFFD at this position -- mb_substr already consumed the byte before pfb_hsc() ran (see this test\'s docblock deviation note)'
 		);
 	}
 

--- a/tests/php/AlertsMultibyteTruncationTest.php
+++ b/tests/php/AlertsMultibyteTruncationTest.php
@@ -615,25 +615,21 @@ final class AlertsMultibyteTruncationTest extends TestCase
 	}
 
 	// =========================================================================
-	// Row 14: invalid UTF-8 byte before the cut -- DEVIATION from the literal
-	// issue #1815 coverage-matrix wording (see docblock below for the evidence).
+	// Row 14: invalid UTF-8 byte before the cut -- the #1814 contract (invalid byte
+	// substituted with U+FFFD, never blanked/fabricated) must survive truncation.
 	// =========================================================================
 
 	/**
-	 * DEVIATION (recorded in the #1815 handoff): the coverage matrix expected an
-	 * invalid byte positioned before the cut to still render as U+FFFD after the
-	 * fix (mirroring pfb_hsc()'s #1814 ENT_SUBSTITUTE contract). Empirically it does
-	 * NOT: mb_substr() itself decodes the string to count characters up to the
-	 * requested length, and a byte it cannot decode is replaced INLINE by
-	 * mb_substitute_character() (default ASCII '?', confirmed via
-	 * `php -r 'var_dump(mb_substitute_character());'` => int(63)) BEFORE pfb_hsc()'s
-	 * htmlspecialchars(ENT_SUBSTITUTE) ever sees the string -- so this call site's
-	 * invalid byte never reaches the #1814 substitution path at all once it falls
-	 * inside a truncated (mb_substr'd) prefix. What DOES survive, and what this test
-	 * proves instead: the byte is never dropped/blanked and the surrounding text is
-	 * untouched -- pinned below as the actual, verified post-fix contract.
+	 * A raw 0xFF byte (never valid in any UTF-8 sequence) sitting inside the
+	 * truncated prefix must still render as U+FFFD -- the exact symbol pfb_hsc()'s
+	 * ENT_SUBSTITUTE produces for it elsewhere (issue #1814) -- and must NEVER
+	 * render as a literal '?': mb_substr()'s own default substitute character
+	 * would otherwise fabricate a character the input never carried, before
+	 * pfb_hsc() ever sees the string. pfb_truncate() pins
+	 * mb_substitute_character(0xFFFD) around its mb_substr() call for exactly this
+	 * reason (issue #1815 review).
 	 */
-	public function test_row14_dnsbl_agent_field_invalid_byte_before_cut_is_substituted_by_mb_substr_not_pfb_hsc(): void
+	public function test_row14_dnsbl_agent_field_invalid_byte_before_cut_renders_fffd_not_a_fabricated_question_mark(): void
 	{
 		$agent  = 'R14Agent' . "\xFF" . str_repeat('a', 30) . '.trailing-tail';
 		$fields = $this->dnsblFields('benign-domain-15.example', '10.1.0.15', 'Grp15', 'Feed15', $agent);
@@ -643,34 +639,21 @@ final class AlertsMultibyteTruncationTest extends TestCase
 		$this->assertStringContainsString('<small>...</small>', $html, 'the value must actually be truncated');
 		$this->assertStringContainsString('R14Agent', $html, 'the text before the invalid byte must survive');
 		$this->assertStringContainsString('aaaaaaaaaaaaaaa', $html, 'the text after the invalid byte must survive (not blanked)');
-		// A bare '?' is NOT a discriminating assertion -- the static template markup
-		// already contains literal '?' characters elsewhere (e.g. "from DNSBL?").
-		// Pin the substitute character AT the exact position the invalid byte occupied.
-		// This site also emits a title="" attribute carrying the FULL, UNTRUNCATED
-		// value (pfb_hsc($fields[4]) on the raw string, line ~2307) -- that copy never
-		// goes through mb_substr at all, so its own raw 0xFF byte is still substituted
-		// by pfb_hsc()'s ENT_SUBSTITUTE the #1814 way (U+FFFD) -- expected, unrelated to
-		// this fix, and asserted explicitly so it is not mistaken for a regression.
-		$this->assertStringContainsString(
-			"\u{FFFD}",
-			$html,
-			'the UNTRUNCATED title="" copy of the value must still substitute the raw invalid byte as U+FFFD (#1814, unaffected by this fix)'
-		);
-		// The DISPLAYED (truncated) span content is the part this fix touches: pin the
-		// exact substitute character mb_substr() produces AT the invalid byte's position.
-		$this->assertStringContainsString(
-			'R14Agent?aaaaaaaaaaaaaaa',
-			$html,
-			"mb_substr replaces the invalid byte with its own substitute character (default '?') at that exact position, not U+FFFD"
-		);
 		// Anchored with the immediately-following ellipsis marker so this checks ONLY the
-		// DISPLAYED (truncated) span text, never the title="" attribute above (which
-		// legitimately contains this same "R14Agent<FFFD>aaa..." prefix, followed by
-		// ".trailing-tail" instead of "<small>...</small>").
-		$this->assertStringNotContainsString(
+		// DISPLAYED (truncated) span text, never the title="" attribute (which carries the
+		// FULL, untruncated value and legitimately shows this same U+FFFD substitution
+		// regardless -- pfb_hsc() alone, unaffected by truncation).
+		$this->assertStringContainsString(
 			'R14Agent' . "\u{FFFD}" . 'aaaaaaaaaaaaaaa<small>...</small>',
 			$html,
-			'the DISPLAYED (truncated) span content must never show U+FFFD at this position -- mb_substr already consumed the byte before pfb_hsc() ran (see this test\'s docblock deviation note)'
+			'the invalid byte inside the truncated prefix must render substituted as U+FFFD (issue #1814 contract), not silently dropped'
+		);
+		$this->assertStringNotContainsString(
+			'R14Agent?aaaaaaaaaaaaaaa<small>...</small>',
+			$html,
+			"the truncated span must never show a literal '?' at this position -- that character was NOT in the input; "
+				. 'mb_substr()\'s own default substitute character would fabricate it if pfb_truncate() did not pin '
+				. 'mb_substitute_character(0xFFFD) around the cut'
 		);
 	}
 
@@ -716,5 +699,62 @@ final class AlertsMultibyteTruncationTest extends TestCase
 		$this->assertStringContainsString('<small>...</small>', $html);
 		$this->assertStringNotContainsString("\u{FFFD}", $html, 'the idn_to_utf8()-produced text must not dangle at the cut');
 		$this->assertStringContainsString('тест', $html, 'the whole IDN-converted Cyrillic word must survive the cut');
+	}
+
+	// =========================================================================
+	// State restoration: pfb_truncate() pins mb_substitute_character(0xFFFD)
+	// around its mb_substr() call (issue #1815 review) -- mb_substitute_character()
+	// is REQUEST-GLOBAL state, so a row render must never leave it changed for
+	// whatever renders next on the same page load.
+	// =========================================================================
+
+	public function test_truncation_sites_restore_prior_mb_substitute_character_across_all_three_builders(): void
+	{
+		// A conspicuously non-default sentinel: if pfb_truncate() ever failed to
+		// restore this, every OTHER render in the same request would silently start
+		// substituting invalid bytes with 'Z' instead of the caller's own setting.
+		$sentinel = ord('Z');
+		$original = mb_substitute_character();
+
+		try {
+			$cases = [
+				'convert_dnsbl_log' => function (): string {
+					$fields = $this->dnsblFields(
+						str_repeat('a', 70) . 'é' . 'trailing-domain.example',
+						'10.1.0.18', 'GrpRestore', 'FeedRestore'
+					);
+					return $this->renderDnsblRow($fields);
+				},
+				'convert_dns_reply_log' => function (): string {
+					$srcIp = '10.1.0.19';
+					$GLOBALS['local_hosts'] = [$srcIp => ''];
+					$fields = $this->replyFields(str_repeat('a', 50) . 'é' . 'trailing-domain.example', $srcIp);
+					return $this->renderReplyRow($fields);
+				},
+				'convert_ip_log' => function (): string {
+					$fields = $this->ipRawFields([
+						8 => '192.0.2.130', 15 => '192.0.2.130',
+						14 => 'pfB_RowRestore_v4', 16 => str_repeat('a', 20) . 'é' . 'trailing-feed',
+					]);
+					return $this->renderIpRow($fields, 'Block');
+				},
+			];
+
+			foreach ($cases as $builder => $render) {
+				mb_substitute_character($sentinel);
+				$html = $render();
+
+				$this->assertNotSame('', $html, "fixture sanity: {$builder} must actually render a row");
+				$this->assertSame(
+					$sentinel,
+					mb_substitute_character(),
+					"pfb_truncate() must restore mb_substitute_character() to its caller's prior value -- "
+						. "a {$builder} row render leaked a changed request-global substitute-character state"
+				);
+			}
+		} finally {
+			// Never leak a changed global state to sibling tests in this same process.
+			mb_substitute_character($original);
+		}
 	}
 }

--- a/tests/php/AlertsMultibyteTruncationTest.php
+++ b/tests/php/AlertsMultibyteTruncationTest.php
@@ -1,0 +1,704 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1815: the 11 byte-substr() display-truncation sites in
+ * pfblockerng_alerts.php's row builders (convert_dnsbl_log / convert_dns_reply_log /
+ * convert_ip_log) cut on BYTES, not characters. A multibyte character straddling the
+ * cut leaves a dangling lead byte; pfb_hsc()'s ENT_SUBSTITUTE (issue #1814) then
+ * renders that dangling byte as a spurious U+FFFD instead of keeping the character
+ * whole. This file pins every site converted to mb_substr(..., 'UTF-8') (the #1069
+ * exemplar's own form, pfb_stat_hostname_cell()).
+ *
+ * Coverage matrix (rows 1-11 = the 11 sites; 12-16 = branch/hostile-input axes):
+ *   1  convert_dnsbl_log     $hostname (SRC-IP resolved name)          cut=24
+ *   2  convert_dnsbl_log     $f2 (blocked domain)                      cut=59 (wide arm)
+ *   3  convert_dnsbl_log     $f7 (CNAME evaluated domain)              cut=51 (wide arm)
+ *   4  convert_dnsbl_log     $fields[4] (DNSBL Type / agent string)    cut=24
+ *   5  convert_dns_reply_log $hostname (SRC-IP resolved name)          cut=24
+ *   6  convert_dns_reply_log $fields[5] (TTL)                         cut=5
+ *   7  convert_dns_reply_log $fields[6] (replied domain)                cut=44 (wide arm)
+ *   8  convert_dns_reply_log $fields[8] (resolved value)               cut=16
+ *   9  convert_ip_log        $fields[15] (logged Feed Name)             cut=16
+ *   10 convert_ip_log        $feed_new (re-attributed feed)             cut=16
+ *   11 convert_ip_log        $fields[16] (gethostbyaddr hostname)       cut=21
+ *   12 short-side branch coverage, one per builder (no truncation, no U+FFFD)
+ *   13 4-byte character (emoji) straddling the cut
+ *   14 invalid UTF-8 byte before the cut -- DEVIATION, see that test's docblock
+ *   15 HTML metacharacter at the character-cut boundary -- entity stays complete
+ *   16 punycode/xn-- domain whose idn_to_utf8()-produced text straddles the cut
+ *
+ * DEFERRED (not tested here): the mode=='unified' (lowercase) narrow-arm ternaries
+ * on sites 2/3/7 are unreachable in production (callers only ever pass the literals
+ * 'Unified'/'non_unified' -- never lowercase 'unified' -- so `$mode != 'unified'` is
+ * always TRUE). Tracked separately by the issue #1815 planner; out of scope here.
+ *
+ * Every test drives the value through the row builder's OWN production surface
+ * (convert_dnsbl_log() / convert_dns_reply_log() / convert_ip_log()), capturing
+ * printed output via ob_start()/ob_get_clean() -- never asserts against a
+ * hand-built string. Harness combines AlertsRowOutputEncodingTest's dnsbl globals,
+ * AlertsDnsReplyWhitelistTypeTest's dns-reply globals, and
+ * AlertsIpConvertPrefetchParityTest/AlertsIpUnlockIconTest's real fixture-dir IP
+ * harness (find/grep exec() calls against a temp sandbox, no mocking of the lookup
+ * layer) into one setUp() so all three builders are available to every test method.
+ */
+#[CoversFunction('convert_dnsbl_log')]
+#[CoversFunction('convert_dns_reply_log')]
+#[CoversFunction('convert_ip_log')]
+#[CoversFunction('pfb_hsc')]
+#[CoversFunction('dnsbl_log_details')]
+#[CoversFunction('pfb_ip_render_attribution')]
+#[CoversFunction('pfb_ip_feed_match_cell')]
+final class AlertsMultibyteTruncationTest extends TestCase
+{
+	private string $tmpDir;
+	private string $denydir;
+	private string $nativedir;
+	private string $ccdir;
+	private string $etdir;
+	private string $aliasdir;
+	private string $matchdir;
+	private string $matchgendir;
+
+	/** @var array<string, mixed> */
+	private array $savedGlobals = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		pfb_test_load_alerts_page_functions();
+	}
+
+	protected function setUp(): void
+	{
+		foreach ([
+			'pfb', 'local_hosts', 'dnsbl_int', 'filterfieldsarray', 'clists',
+			'dnsbl_unlock', 'dup', 'counter', 'pfbentries', 'skipcount',
+			'dnsblfilterlimit', 'dnsblfilterlimitentries',
+			'dnsfilterlimit', 'dnsfilterlimitentries',
+			'continents', 'ip_unlock', 'ipfilterlimit', 'ipfilterlimitentries',
+		] as $g) {
+			$this->savedGlobals[$g] = $GLOBALS[$g] ?? null;
+		}
+
+		$this->tmpDir       = sys_get_temp_dir() . '/pfb_alerts_mb_truncation_' . bin2hex(random_bytes(6));
+		$this->denydir      = "{$this->tmpDir}/deny";
+		$this->nativedir    = "{$this->tmpDir}/native";
+		$this->ccdir        = "{$this->tmpDir}/geoip";
+		$this->etdir        = "{$this->tmpDir}/et";
+		$this->aliasdir     = "{$this->tmpDir}/alias";
+		$this->matchdir     = "{$this->tmpDir}/match";
+		$this->matchgendir  = "{$this->matchdir}/generated";
+		foreach ([
+			$this->denydir, $this->nativedir, $this->ccdir, $this->etdir, $this->aliasdir,
+			$this->matchdir, $this->matchgendir,
+		] as $d) {
+			mkdir($d, 0777, TRUE);
+		}
+		// Keeps multi-glob dirs non-empty so grep's output carries the "path:" prefix
+		// (see AlertsIpConvertPrefetchParityTest's setUp() for the full rationale).
+		file_put_contents("{$this->nativedir}/NativePlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchdir}/MatchPlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchgendir}/MatchGenPlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->aliasdir}/AliasPlaceholder.txt", "10.0.0.3\n");
+
+		$GLOBALS['pfb'] = [
+			'filterlogentries' => FALSE,
+			'grep'             => '/usr/bin/grep',
+			'denydir'          => $this->denydir,
+			'nativedir'        => $this->nativedir,
+			'permitdir'        => "{$this->tmpDir}/permit",
+			'matchdir'         => $this->matchdir,
+			'matchgendir'      => $this->matchgendir,
+			'etdir'            => $this->etdir,
+			'ccdir'            => $this->ccdir,
+			'aliasdir'         => $this->aliasdir,
+			'asn_reporting'    => 'disabled',
+			'supp'             => '',	// PfbToggle::Off -- suppression-list lookup skipped
+		];
+		$GLOBALS['local_hosts']              = [];
+		$GLOBALS['dnsbl_int']                = [];
+		$GLOBALS['filterfieldsarray']        = [];
+		$GLOBALS['clists']                   = [
+			'dnsbl'                  => ['options' => []],
+			'dnsblwhitelist'         => ['data' => []],
+			'tld_wildcard_exclusion' => ['data' => []],
+			'ipwhitelist4'           => [],
+			'ipwhitelist6'           => [],
+		];
+		$GLOBALS['dnsbl_unlock']             = [];
+		$GLOBALS['dup']                      = ['DNSBL' => 0, 'DNS' => 0, 'Block' => 0];
+		$GLOBALS['counter']                  = ['DNSBL' => 0, 'DNS' => 0, 'Unified' => 0, 'Block' => 0];
+		$GLOBALS['pfbentries']               = 1000;
+		$GLOBALS['skipcount']                = 0;
+		$GLOBALS['dnsblfilterlimit']         = FALSE;
+		$GLOBALS['dnsblfilterlimitentries']  = 100;
+		$GLOBALS['dnsfilterlimit']           = FALSE;
+		$GLOBALS['dnsfilterlimitentries']    = 100;
+		$GLOBALS['continents']               = array_flip(array(
+			'pfB_Africa', 'pfB_Antarctica', 'pfB_Asia', 'pfB_Europe',
+			'pfB_NAmerica', 'pfB_Oceania', 'pfB_SAmerica', 'pfB_Top',
+		));
+		$GLOBALS['ip_unlock']                = [];
+		$GLOBALS['ipfilterlimit']            = FALSE;
+		$GLOBALS['ipfilterlimitentries']     = 0;
+
+		pfb_ip_render_memos_reset();
+	}
+
+	protected function tearDown(): void
+	{
+		pfb_ip_render_memos_reset();
+
+		foreach ($this->savedGlobals as $g => $v) {
+			if ($v === null) {
+				unset($GLOBALS[$g]);
+			} else {
+				$GLOBALS[$g] = $v;
+			}
+		}
+
+		rmdir_recursive($this->tmpDir);
+	}
+
+	// -----------------------------------------------------------------------
+	// Straddle-string builders
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A byte string whose CUT-th byte (0-based index CUT-1) is the LEAD byte of
+	 * $mbChar: a byte-based substr($v, 0, CUT) keeps that lead byte alone (a
+	 * dangling, invalid sequence), while a character-based mb_substr($v, 0, CUT,
+	 * 'UTF-8') keeps $mbChar whole. $marker is a short ASCII prefix that survives
+	 * inside the retained text, proving THIS seeded value produced the cell.
+	 */
+	private function mbStraddle(int $cut, string $marker, string $mbChar, string $tail): string
+	{
+		return $marker . str_repeat('a', $cut - 1 - strlen($marker)) . $mbChar . $tail;
+	}
+
+	/**
+	 * Two copies of $mbChar followed by $metachar, sized so a CHARACTER cut of
+	 * length CUT keeps all of "$marker + a's + $mbChar + $mbChar + $metachar"
+	 * whole (metachar included) while a BYTE cut of the same numeric length
+	 * dangles mid-SECOND $mbChar and never reaches $metachar at all -- proving
+	 * both that the multibyte run survives AND that the truncate-raw-then-encode
+	 * ordering (#1069) still yields a COMPLETE entity for $metachar, never split.
+	 */
+	private function doubleMbStraddle(int $cut, string $marker, string $mbChar, string $metachar, string $tail): string
+	{
+		return $marker . str_repeat('a', $cut - 3 - strlen($marker)) . $mbChar . $mbChar . $metachar . $tail;
+	}
+
+	// -----------------------------------------------------------------------
+	// convert_dnsbl_log() harness
+	// -----------------------------------------------------------------------
+
+	/** Field layout per convert_dnsbl_log()'s own "dnsbl.log Fields Reference" comment. */
+	private function dnsblFields(
+		string $domain,
+		string $srcIp,
+		string $group,
+		string $feed,
+		string $agent = '',
+		string $btype = 'Python A',
+		?string $evalDomain = null
+	): array {
+		return [
+			0  => 'DNSBL-python',
+			1  => '2026-01-01 00:00:00',
+			2  => $domain,
+			3  => $srcIp,
+			4  => $agent,
+			5  => $btype,
+			6  => $group,
+			7  => $evalDomain ?? $domain,
+			8  => $feed,
+			9  => 0,
+			10 => 'A',
+		];
+	}
+
+	private function renderDnsblRow(array $fields): string
+	{
+		ob_start();
+		convert_dnsbl_log('Reports', $fields);
+		return (string) ob_get_clean();
+	}
+
+	// -----------------------------------------------------------------------
+	// convert_dns_reply_log() harness
+	// -----------------------------------------------------------------------
+
+	/** Field layout per AlertsDnsReplyWhitelistTypeTest::replyFields(). */
+	private function replyFields(string $domain, string $srcIp): array
+	{
+		return [
+			0 => 'DNS-Reply',
+			1 => '2026-01-01 00:00:00',
+			2 => 'Reply',
+			3 => 'A',
+			4 => 'A',
+			5 => '300',
+			6 => $domain,
+			7 => $srcIp,
+			8 => '198.51.100.9',
+			9 => 'US',
+		];
+	}
+
+	private function renderReplyRow(array $fields): string
+	{
+		ob_start();
+		convert_dns_reply_log('Reports', $fields);
+		return (string) ob_get_clean();
+	}
+
+	// -----------------------------------------------------------------------
+	// convert_ip_log() harness
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Raw, PRE-reorder $fields row -- same 22-element shape/reference as
+	 * AlertsIpConvertPrefetchParityTest::rawFields() / AlertsIpUnlockIconTest::rawFields().
+	 */
+	private function ipRawFields(array $overrides): array
+	{
+		$base = [
+			0  => '2026-08-01 00:00:00',	// Date/Timestamp
+			1  => 'rule1',			// Rulenum
+			2  => 'em0',			// Real Interface
+			3  => 'WAN',			// Friendly Interface name
+			4  => 'block',			// Action
+			5  => 4,			// Version
+			6  => 'tcp',			// Protocol ID
+			7  => 'TCP',			// Protocol
+			8  => '192.0.2.11',		// SRC IP
+			9  => '198.51.100.1',		// DST IP
+			10 => '12345',			// SRC Port
+			11 => '443',			// DST Port
+			12 => 'in',			// Direction
+			13 => 'US',			// GeoIP code
+			14 => 'pfB_Default_v4',	// IP Alias Name
+			15 => '192.0.2.11',		// IP evaluated
+			16 => 'DefaultFeed',		// Feed Name
+			17 => '',			// gethostbyaddr resolved hostname
+			18 => '',			// Client Hostname
+			19 => 'Unknown',		// ASN
+			20 => '',			// ASN Domain
+			21 => '',			// ASN Name
+		];
+		return array_replace($base, $overrides);
+	}
+
+	private function renderIpRow(array $fields, string $rtype): string
+	{
+		$GLOBALS['dup'][$rtype]     = 0;
+		$GLOBALS['counter'][$rtype] = 0;
+		$GLOBALS['ipfilterlimit']   = FALSE;
+
+		ob_start();
+		convert_ip_log('non_unified', $fields, '', $rtype);
+		return (string) ob_get_clean();
+	}
+
+	// =========================================================================
+	// Rows 1-11: the 11 truncation sites
+	// =========================================================================
+
+	public function test_row01_dnsbl_srcip_hostname_truncation_keeps_multibyte_char_whole(): void
+	{
+		$srcIp = '10.1.0.1';
+		$value = $this->mbStraddle(24, 'R01', 'é', 'trailing-host.example');
+		$GLOBALS['local_hosts'] = [$srcIp => $value];
+		$fields = $this->dnsblFields('benign-domain-01.example', $srcIp, 'Grp01', 'Feed01');
+
+		$html = $this->renderDnsblRow($fields);
+
+		$this->assertStringContainsString('R01', $html, 'the seeded marker must reach the rendered cell');
+		$this->assertStringContainsString('<small>...</small>', $html, 'the value must actually be truncated');
+		$this->assertStringNotContainsString("\u{FFFD}", $html, 'mb_substr must keep the multibyte char whole, not dangle its lead byte');
+		$this->assertStringContainsString('é', $html, 'the straddling multibyte character must survive intact');
+	}
+
+	public function test_row02_dnsbl_domain_truncation_keeps_multibyte_char_whole(): void
+	{
+		$domain = $this->mbStraddle(59, 'R02', 'é', 'trailing-domain-suffix.example');
+		$fields = $this->dnsblFields($domain, '10.1.0.2', 'Grp02', 'Feed02');
+
+		$html = $this->renderDnsblRow($fields);
+
+		$this->assertStringContainsString('R02', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+		$this->assertStringContainsString('é', $html);
+	}
+
+	public function test_row03_dnsbl_cname_truncation_keeps_multibyte_char_whole(): void
+	{
+		$cname  = $this->mbStraddle(51, 'R03', 'é', 'trailing-cname-suffix.example');
+		// 'DNSBL_CNAME' trips dnsbl_log_details()'s isCNAME gate (strpos '_CNAME'),
+		// which routes $fields[7] (here $cname) into the $f7 truncation site.
+		$fields = $this->dnsblFields('blocked-domain-03.example', '10.1.0.3', 'Grp03', 'Feed03', '', 'DNSBL_CNAME', $cname);
+
+		$html = $this->renderDnsblRow($fields);
+
+		$this->assertStringContainsString('R03', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+		$this->assertStringContainsString('é', $html);
+	}
+
+	public function test_row04_dnsbl_agent_field_truncation_keeps_multibyte_char_whole(): void
+	{
+		$agent  = $this->mbStraddle(24, 'R04', 'é', 'trailing-agent-suffix');
+		$fields = $this->dnsblFields('benign-domain-04.example', '10.1.0.4', 'Grp04', 'Feed04', $agent);
+
+		$html = $this->renderDnsblRow($fields);
+
+		$this->assertStringContainsString('R04', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+		$this->assertStringContainsString('é', $html);
+	}
+
+	public function test_row05_dnsreply_srcip_hostname_truncation_keeps_multibyte_char_whole(): void
+	{
+		$srcIp = '10.1.0.5';
+		$value = $this->mbStraddle(24, 'R05', 'é', 'trailing-host.example');
+		$GLOBALS['local_hosts'] = [$srcIp => $value];
+		$fields = $this->replyFields('reply-domain-05.example', $srcIp);
+
+		$html = $this->renderReplyRow($fields);
+
+		$this->assertStringContainsString('R05', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+		$this->assertStringContainsString('é', $html);
+	}
+
+	public function test_row06_dnsreply_ttl_truncation_keeps_multibyte_char_whole(): void
+	{
+		$srcIp = '10.1.0.6';
+		$GLOBALS['local_hosts'] = [$srcIp => ''];
+		$fields    = $this->replyFields('reply-domain-06.example', $srcIp);
+		$fields[5] = $this->mbStraddle(5, 'R06', 'é', '0000');
+
+		$html = $this->renderReplyRow($fields);
+
+		$this->assertStringContainsString('R06', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+		$this->assertStringContainsString('é', $html);
+	}
+
+	public function test_row07_dnsreply_domain_truncation_keeps_multibyte_char_whole(): void
+	{
+		$srcIp = '10.1.0.7';
+		$GLOBALS['local_hosts'] = [$srcIp => ''];
+		$domain = $this->mbStraddle(44, 'R07', 'é', 'trailing-domain-suffix.example');
+		$fields = $this->replyFields($domain, $srcIp);
+
+		$html = $this->renderReplyRow($fields);
+
+		$this->assertStringContainsString('R07', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+		$this->assertStringContainsString('é', $html);
+	}
+
+	public function test_row08_dnsreply_resolved_value_truncation_keeps_multibyte_char_whole(): void
+	{
+		$srcIp = '10.1.0.8';
+		$GLOBALS['local_hosts'] = [$srcIp => ''];
+		$fields    = $this->replyFields('reply-domain-08.example', $srcIp);
+		$fields[8] = $this->mbStraddle(16, 'R08', 'é', 'trailing-suffix');
+
+		$html = $this->renderReplyRow($fields);
+
+		$this->assertStringContainsString('R08', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+		$this->assertStringContainsString('é', $html);
+	}
+
+	/** "Still-listed" shape (AlertsIpConvertPrefetchParityTest case 1): the reported IP is
+	 * still an exact line in its OWN logged feed file, so $feed_new stays empty and only
+	 * the logged $fields[15] (site 9) is exercised. */
+	public function test_row09_ip_feed_name_truncation_keeps_multibyte_char_whole(): void
+	{
+		$feed = $this->mbStraddle(16, 'R09', 'é', 'trailing-feed');
+		file_put_contents("{$this->denydir}/{$feed}.txt", "192.0.2.90\n");
+
+		$fields = $this->ipRawFields([
+			8 => '192.0.2.90', 15 => '192.0.2.90',
+			14 => 'pfB_Row09_v4', 16 => $feed,
+		]);
+
+		$html = $this->renderIpRow($fields, 'Block');
+
+		$this->assertStringContainsString('R09', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+		$this->assertStringContainsString('é', $html);
+	}
+
+	/** "Moved-feed" shape (AlertsIpConvertPrefetchParityTest case 3): the logged feed name
+	 * has no on-disk file, forcing the attribution seam's miss path to re-locate the IP
+	 * under a DIFFERENT feed file -- driving $feed_new (site 10) non-empty for real. */
+	public function test_row10_ip_feed_new_truncation_keeps_multibyte_char_whole(): void
+	{
+		$newFeed = $this->mbStraddle(16, 'R10', 'é', 'trailing-feed-new');
+		file_put_contents("{$this->denydir}/{$newFeed}.txt", "192.0.2.100\n");
+
+		// Kept under the site-9 gate (17 chars) so the OLD feed name itself renders
+		// verbatim in the struck-through markup below, not ALSO truncated -- that
+		// would make the non-vacuity assertion fail for the wrong reason.
+		$oldFeed = 'R10OldFeed';
+		$this->assertLessThan(17, strlen($oldFeed), 'fixture sanity: the OLD feed name must not itself trip the site-9 gate');
+
+		$fields = $this->ipRawFields([
+			8 => '192.0.2.100', 15 => '192.0.2.100',
+			14 => 'pfB_Row10_v4', 16 => $oldFeed,
+		]);
+
+		$html = $this->renderIpRow($fields, 'Block');
+
+		// Non-vacuity: the attribution seam actually re-attributed to a new feed
+		// (the struck-through old-feed markup pfb_ip_feed_match_cell() emits) --
+		// otherwise $feed_new would still be empty and site 10 never exercised.
+		$this->assertStringContainsString(
+			"<s>{$oldFeed}</s>",
+			$html,
+			'the attribution seam must have produced a non-empty feed_new to exercise this site'
+		);
+
+		$this->assertStringContainsString('R10', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+		$this->assertStringContainsString('é', $html);
+	}
+
+	/**
+	 * DEVIATION (recorded in the #1815 handoff): row 11's site --
+	 * `$fields[16] = "<span title=\"...\">" . pfb_hsc(substr($fields[16], 0, 21)) . ...`
+	 * (pfblockerng_alerts.php ~:3088) -- is DEAD CODE in the current production
+	 * source, discovered empirically while writing this test (the content
+	 * assertion the other 10 rows use never passed, in EITHER direction). Verified
+	 * via `grep -n '\$fields\[16\]' pfblockerng_alerts.php`: the ONLY two hits are
+	 * the assignment itself (:3084/:3087-3088); the value that variable holds is
+	 * never read again anywhere in the function or its two <tr> print templates.
+	 * What the row actually PRINTS for the resolved hostname is
+	 * `$hostname['src']`/`$hostname['dst']` (pfblockerng_alerts.php :3118/:3120,
+	 * :3149/:3153) -- a SEPARATE copy captured earlier by pfb_ip_render_query()
+	 * (via pfb_ip_render_attribution(), called BEFORE this site runs) straight from
+	 * the ORIGINAL, untruncated $fields[16]/[17] -- so mutating $fields[16] here
+	 * has zero effect on the rendered output, before or after this fix.
+	 *
+	 * Consequence: the rendered-HTML oracle every other row uses (no U+FFFD,
+	 * multibyte char present) cannot discriminate this site at all -- both the
+	 * byte-substr() original and the mb_substr() fix produce IDENTICAL rendered
+	 * output (the computed span never reaches it). This test instead proves the
+	 * one thing that IS observable: the conversion executes cleanly (no PHP
+	 * warning/notice) against both a short and a straddling-multibyte value. The
+	 * src edit at this site is still applied, per the issue's literal "convert all
+	 * 11 sites" scope and because it is a safe, behaviour-preserving textual
+	 * change regardless of reachability.
+	 */
+	public function test_row11_ip_resolved_hostname_truncation_executes_without_warning_dead_code(): void
+	{
+		file_put_contents("{$this->denydir}/Row11Feed.txt", "192.0.2.110\n192.0.2.111\n");
+		$rdnsLong  = $this->mbStraddle(21, 'R11', 'é', 'trailing-rdns.example');
+		$rdnsShort = 'short-rdns.example';
+		$this->assertLessThan(22, strlen($rdnsShort), 'fixture sanity: must be under the 22-char gate');
+
+		foreach ([$rdnsLong, $rdnsShort] as $rdns) {
+			$fields = $this->ipRawFields([
+				8 => '192.0.2.110', 15 => '192.0.2.110',
+				14 => 'pfB_Row11_v4', 16 => 'Row11Feed', 17 => $rdns,
+			]);
+
+			$warnings = [];
+			set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
+				$warnings[] = $errstr;
+				return TRUE;
+			});
+			try {
+				$html = $this->renderIpRow($fields, 'Block');
+			} finally {
+				restore_error_handler();
+			}
+
+			$this->assertSame(
+				[],
+				$warnings,
+				"convert_ip_log() must render {$rdns} at the fields[16] site without a PHP warning/notice, got:\n" . implode("\n", $warnings)
+			);
+			$this->assertNotSame('', $html, 'the row must still render (this site being dead code must not break the rest of the row)');
+		}
+	}
+
+	// =========================================================================
+	// Row 12: branch coverage, SHORT side (one per builder) -- proves the fix is
+	// not an always-truncate/always-mangle path.
+	// =========================================================================
+
+	public function test_row12_dnsbl_short_hostname_renders_verbatim_no_truncation(): void
+	{
+		$srcIp = '10.1.0.12';
+		$value = 'short-host.example';
+		$this->assertLessThan(25, strlen($value), 'fixture sanity: must be under the 25-char gate');
+		$GLOBALS['local_hosts'] = [$srcIp => $value];
+		$fields = $this->dnsblFields('benign-domain-12.example', $srcIp, 'Grp12', 'Feed12');
+
+		$html = $this->renderDnsblRow($fields);
+
+		$this->assertStringContainsString($value, $html, 'a short value must render verbatim');
+		$this->assertStringNotContainsString('<small>...</small>', $html, 'a short value must not be truncated');
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+	}
+
+	public function test_row12_dnsreply_short_resolved_value_renders_verbatim_no_truncation(): void
+	{
+		$srcIp = '10.1.0.13';
+		$GLOBALS['local_hosts'] = [$srcIp => ''];
+		$fields    = $this->replyFields('reply-domain-13.example', $srcIp);
+		$fields[8] = 'short-val';
+		$this->assertLessThan(17, strlen($fields[8]), 'fixture sanity: must be under the 17-char gate');
+
+		$html = $this->renderReplyRow($fields);
+
+		$this->assertStringContainsString('short-val', $html);
+		$this->assertStringNotContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+	}
+
+	public function test_row12_ip_short_feed_name_renders_verbatim_no_truncation(): void
+	{
+		file_put_contents("{$this->denydir}/ShortFeed12.txt", "192.0.2.120\n");
+		$this->assertLessThan(17, strlen('ShortFeed12'), 'fixture sanity: must be under the 17-char gate');
+
+		$fields = $this->ipRawFields([
+			8 => '192.0.2.120', 15 => '192.0.2.120',
+			14 => 'pfB_Row12_v4', 16 => 'ShortFeed12',
+		]);
+
+		$html = $this->renderIpRow($fields, 'Block');
+
+		$this->assertStringContainsString('ShortFeed12', $html);
+		$this->assertStringNotContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html);
+	}
+
+	// =========================================================================
+	// Row 13: 4-byte character (emoji) straddling the cut -- a 2-byte char alone
+	// does not prove the fix handles every multibyte width.
+	// =========================================================================
+
+	public function test_row13_dnsbl_hostname_truncation_keeps_4byte_emoji_whole(): void
+	{
+		$srcIp = '10.1.0.14';
+		$value = $this->mbStraddle(24, 'R13', "\u{1F600}", 'trailing-host.example');
+		$GLOBALS['local_hosts'] = [$srcIp => $value];
+		$fields = $this->dnsblFields('benign-domain-14.example', $srcIp, 'Grp14', 'Feed14');
+
+		$html = $this->renderDnsblRow($fields);
+
+		$this->assertStringContainsString('R13', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html, 'a byte-based cut dangles mid-emoji (4 bytes) and renders substituted');
+		$this->assertStringContainsString("\u{1F600}", $html, 'the whole 4-byte emoji must survive the cut');
+	}
+
+	// =========================================================================
+	// Row 14: invalid UTF-8 byte before the cut -- DEVIATION from the literal
+	// issue #1815 coverage-matrix wording (see docblock below for the evidence).
+	// =========================================================================
+
+	/**
+	 * DEVIATION (recorded in the #1815 handoff): the coverage matrix expected an
+	 * invalid byte positioned before the cut to still render as U+FFFD after the
+	 * fix (mirroring pfb_hsc()'s #1814 ENT_SUBSTITUTE contract). Empirically it does
+	 * NOT: mb_substr() itself decodes the string to count characters up to the
+	 * requested length, and a byte it cannot decode is replaced INLINE by
+	 * mb_substitute_character() (default ASCII '?', confirmed via
+	 * `php -r 'var_dump(mb_substitute_character());'` => int(63)) BEFORE pfb_hsc()'s
+	 * htmlspecialchars(ENT_SUBSTITUTE) ever sees the string -- so this call site's
+	 * invalid byte never reaches the #1814 substitution path at all once it falls
+	 * inside a truncated (mb_substr'd) prefix. What DOES survive, and what this test
+	 * proves instead: the byte is never dropped/blanked and the surrounding text is
+	 * untouched -- pinned below as the actual, verified post-fix contract.
+	 */
+	public function test_row14_dnsbl_agent_field_invalid_byte_before_cut_is_substituted_by_mb_substr_not_pfb_hsc(): void
+	{
+		$agent  = 'R14Agent' . "\xFF" . str_repeat('a', 30) . '.trailing-tail';
+		$fields = $this->dnsblFields('benign-domain-15.example', '10.1.0.15', 'Grp15', 'Feed15', $agent);
+
+		$html = $this->renderDnsblRow($fields);
+
+		$this->assertStringContainsString('<small>...</small>', $html, 'the value must actually be truncated');
+		$this->assertStringContainsString('R14Agent', $html, 'the text before the invalid byte must survive');
+		$this->assertStringContainsString('aaaaaaaaaaaaaaa', $html, 'the text after the invalid byte must survive (not blanked)');
+		// A bare '?' is NOT a discriminating assertion -- the static template markup
+		// already contains literal '?' characters elsewhere (e.g. "from DNSBL?").
+		// Pin the substitute character AT the exact position the invalid byte occupied.
+		$this->assertStringContainsString(
+			'R14Agent?aaaaaaaaaaaaaaa',
+			$html,
+			"mb_substr replaces the invalid byte with its own substitute character (default '?') at that exact position, not U+FFFD"
+		);
+		$this->assertStringNotContainsString(
+			"\u{FFFD}",
+			$html,
+			'post-fix, U+FFFD is NOT produced for this byte -- mb_substr already consumed it before pfb_hsc() ran (see this test\'s docblock deviation note)'
+		);
+	}
+
+	// =========================================================================
+	// Row 15: HTML metacharacter landing exactly at the character-cut boundary --
+	// the truncate-RAW-then-encode ordering (#1069) must still yield a COMPLETE
+	// entity, never a split "&qu".
+	// =========================================================================
+
+	public function test_row15_dnsreply_resolved_value_truncation_keeps_html_entity_complete(): void
+	{
+		$srcIp = '10.1.0.16';
+		$GLOBALS['local_hosts'] = [$srcIp => ''];
+		$fields    = $this->replyFields('reply-domain-16.example', $srcIp);
+		$fields[8] = $this->doubleMbStraddle(16, 'R15', 'é', '"', 'trailing-tail-suffix');
+
+		$html = $this->renderReplyRow($fields);
+
+		$this->assertStringContainsString('R15', $html);
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html, 'the earlier straddling multibyte char must not dangle');
+		$this->assertStringContainsString('éé', $html, 'both multibyte characters ahead of the metacharacter must survive intact');
+		$this->assertStringContainsString('&quot;', $html, 'the HTML metacharacter at the character-cut boundary must render as a COMPLETE entity');
+		$this->assertStringNotContainsString('&qu<', $html, 'the entity must never be split mid-sequence');
+	}
+
+	// =========================================================================
+	// Row 16: punycode/xn-- domain whose idn_to_utf8()-produced text (appended in
+	// brackets at ~:2244) is what straddles the cut, not the raw ASCII label.
+	// =========================================================================
+
+	public function test_row16_dnsbl_idn_domain_conversion_truncation_keeps_multibyte_char_whole(): void
+	{
+		// idn_to_utf8('xn--e1aybc') => 'тест' (Cyrillic, 2 bytes/char); the leading
+		// 15-char ASCII label positions the appended bracketed conversion so its
+		// SECOND Cyrillic character's lead byte lands exactly on the cut.
+		$domain = 'R16' . str_repeat('a', 12) . '.xn--e1aybc.example';
+		$fields = $this->dnsblFields($domain, '10.1.0.17', 'Grp17', 'Feed17');
+
+		$html = $this->renderDnsblRow($fields);
+
+		$this->assertStringContainsString('xn--e1aybc', $html, 'the raw punycode label must still render before the appended bracket');
+		$this->assertStringContainsString('<small>...</small>', $html);
+		$this->assertStringNotContainsString("\u{FFFD}", $html, 'the idn_to_utf8()-produced text must not dangle at the cut');
+		$this->assertStringContainsString('тест', $html, 'the whole IDN-converted Cyrillic word must survive the cut');
+	}
+}

--- a/tests/php/AlertsMultibyteTruncationTest.php
+++ b/tests/php/AlertsMultibyteTruncationTest.php
@@ -757,4 +757,39 @@ final class AlertsMultibyteTruncationTest extends TestCase
 			mb_substitute_character($original);
 		}
 	}
+
+	/**
+	 * The pinned substitute character is restored even when the truncation itself
+	 * throws. pfb_truncate() casts $value to string INSIDE the pinned region, so an
+	 * object with no __toString() raises after the pin and before any ordinary
+	 * return -- without the finally, the caller's setting stays clobbered for the
+	 * rest of the request and every later render silently substitutes the wrong
+	 * symbol.
+	 */
+	public function test_pfb_truncate_restores_substitute_character_when_the_cut_throws(): void
+	{
+		$sentinel = ord('Z');
+		$original = mb_substitute_character();
+
+		try {
+			mb_substitute_character($sentinel);
+
+			$threw = FALSE;
+			try {
+				pfb_truncate(new stdClass(), 10);
+			} catch (Throwable $e) {
+				$threw = TRUE;
+			}
+
+			$this->assertTrue($threw, 'fixture sanity: casting a stdClass to string must raise, or this proves nothing');
+			$this->assertSame(
+				$sentinel,
+				mb_substitute_character(),
+				'pfb_truncate() must restore mb_substitute_character() on the throwing path too, '
+					. 'not just on a normal return'
+			);
+		} finally {
+			mb_substitute_character($original);
+		}
+	}
 }

--- a/tests/php/AlertsMultibyteTruncationTest.php
+++ b/tests/php/AlertsMultibyteTruncationTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
  *   11 convert_ip_log        $fields[16] (gethostbyaddr hostname)       cut=21
  *   12 short-side branch coverage, one per builder (no truncation, no U+FFFD)
  *   13 4-byte character (emoji) straddling the cut
- *   14 invalid UTF-8 byte before the cut -- DEVIATION, see that test's docblock
+ *   14 invalid UTF-8 byte before the cut -- see that test's docblock
  *   15 HTML metacharacter at the character-cut boundary -- entity stays complete
  *   16 punycode/xn-- domain whose idn_to_utf8()-produced text straddles the cut
  *
@@ -484,20 +484,19 @@ final class AlertsMultibyteTruncationTest extends TestCase
 	}
 
 	/**
-	 * DEVIATION (recorded in the #1815 handoff): row 11's site --
-	 * `$fields[16] = "<span title=\"...\">" . pfb_hsc(substr($fields[16], 0, 21)) . ...`
-	 * (pfblockerng_alerts.php ~:3088) -- is DEAD CODE in the current production
-	 * source, discovered empirically while writing this test (the content
-	 * assertion the other 10 rows use never passed, in EITHER direction). Verified
-	 * via `grep -n '\$fields\[16\]' pfblockerng_alerts.php`: the ONLY two hits are
-	 * the assignment itself (:3084/:3087-3088); the value that variable holds is
-	 * never read again anywhere in the function or its two <tr> print templates.
-	 * What the row actually PRINTS for the resolved hostname is
-	 * `$hostname['src']`/`$hostname['dst']` (pfblockerng_alerts.php :3118/:3120,
-	 * :3149/:3153) -- a SEPARATE copy captured earlier by pfb_ip_render_query()
-	 * (via pfb_ip_render_attribution(), called BEFORE this site runs) straight from
-	 * the ORIGINAL, untruncated $fields[16]/[17] -- so mutating $fields[16] here
-	 * has zero effect on the rendered output, before or after this fix.
+	 * Row 11's site -- convert_ip_log()'s rDNS-hostname cell, which wraps a
+	 * truncated `$fields[16]` in a `<span title="...">` -- is DEAD CODE in the
+	 * current production source, discovered empirically while writing this test
+	 * (the content assertion the other 10 rows use never passed, in EITHER
+	 * direction). Verified via `grep -n '\$fields\[16\]'`: inside convert_ip_log()
+	 * the only hits are the 'Unknown' default and this truncating assignment; the
+	 * value that variable holds is never read again in the function or in either of
+	 * its <tr> print templates. What the row actually PRINTS for the resolved
+	 * hostname is `$hostname['src']`/`$hostname['dst']` -- a SEPARATE copy captured
+	 * earlier by pfb_ip_render_query() (via pfb_ip_render_attribution(), called
+	 * BEFORE this site runs) straight from the ORIGINAL, untruncated
+	 * $fields[16]/[17] -- so mutating $fields[16] here has zero effect on the
+	 * rendered output, before or after this fix. Tracked as issue #2008.
 	 *
 	 * Consequence: the rendered-HTML oracle every other row uses (no U+FFFD,
 	 * multibyte char present) cannot discriminate this site at all -- both the
@@ -627,7 +626,7 @@ final class AlertsMultibyteTruncationTest extends TestCase
 	 * would otherwise fabricate a character the input never carried, before
 	 * pfb_hsc() ever sees the string. pfb_truncate() pins
 	 * mb_substitute_character(0xFFFD) around its mb_substr() call for exactly this
-	 * reason (issue #1815 review).
+	 * reason.
 	 */
 	public function test_row14_dnsbl_agent_field_invalid_byte_before_cut_renders_fffd_not_a_fabricated_question_mark(): void
 	{
@@ -682,7 +681,8 @@ final class AlertsMultibyteTruncationTest extends TestCase
 
 	// =========================================================================
 	// Row 16: punycode/xn-- domain whose idn_to_utf8()-produced text (appended in
-	// brackets at ~:2244) is what straddles the cut, not the raw ASCII label.
+	// brackets by convert_dnsbl_log() just before the cut) is what straddles the
+	// cut, not the raw ASCII label.
 	// =========================================================================
 
 	public function test_row16_dnsbl_idn_domain_conversion_truncation_keeps_multibyte_char_whole(): void
@@ -703,7 +703,7 @@ final class AlertsMultibyteTruncationTest extends TestCase
 
 	// =========================================================================
 	// State restoration: pfb_truncate() pins mb_substitute_character(0xFFFD)
-	// around its mb_substr() call (issue #1815 review) -- mb_substitute_character()
+	// around its mb_substr() call -- mb_substitute_character()
 	// is REQUEST-GLOBAL state, so a row render must never leave it changed for
 	// whatever renders next on the same page load.
 	// =========================================================================

--- a/tests/php/AlertsRowOutputEncodingTest.php
+++ b/tests/php/AlertsRowOutputEncodingTest.php
@@ -204,9 +204,9 @@ final class AlertsRowOutputEncodingTest extends TestCase
         // byte substr() -- explicitly OUT OF SCOPE when this test was first written
         // (issue #1814 follow-up) -- and pfb_hsc()'s ENT_SUBSTITUTE made the resulting
         // dangling lead byte render safely (U+FFFD) instead of blanking the cell.
-        // #1815 IS that follow-up: the site is now mb_substr(..., 'UTF-8'), which keeps
-        // the character whole instead of ever leaving a dangling lead byte, so no
-        // substitution is needed here anymore.
+        // #1815 IS that follow-up: the site now calls pfb_truncate() (a character-based
+        // mb_substr() wrapper), which keeps the character whole instead of ever leaving
+        // a dangling lead byte, so no substitution is needed here anymore.
         $domain = str_repeat('a', 58) . "\xC3\xA9" . 'trailing-domain-suffix.example';
         $this->assertGreaterThanOrEqual(60, strlen($domain));
 

--- a/tests/php/AlertsRowOutputEncodingTest.php
+++ b/tests/php/AlertsRowOutputEncodingTest.php
@@ -199,8 +199,8 @@ final class AlertsRowOutputEncodingTest extends TestCase
     public function test_truncated_multibyte_char_in_domain_survives_whole_after_mb_substr_conversion(): void
     {
         // issue #1815: a >=60-char domain whose 59th raw BYTE is the lead byte of a
-        // 2-byte UTF-8 sequence ("\xC3\xA9" = e-acute), straddling convert_dnsbl_log's
-        // truncation boundary (pfblockerng_alerts.php ~line 2247). This call site was
+        // 2-byte UTF-8 sequence ("\xC3\xA9" = e-acute), straddling the blocked-domain
+        // ($f2) truncation boundary in convert_dnsbl_log(). This call site was
         // byte substr() -- explicitly OUT OF SCOPE when this test was first written
         // (issue #1814 follow-up) -- and pfb_hsc()'s ENT_SUBSTITUTE made the resulting
         // dangling lead byte render safely (U+FFFD) instead of blanking the cell.

--- a/tests/php/AlertsRowOutputEncodingTest.php
+++ b/tests/php/AlertsRowOutputEncodingTest.php
@@ -196,14 +196,17 @@ final class AlertsRowOutputEncodingTest extends TestCase
         $this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'the rendered row must be valid UTF-8');
     }
 
-    public function test_truncated_multibyte_lead_byte_in_domain_renders_substituted_not_blanked(): void
+    public function test_truncated_multibyte_char_in_domain_survives_whole_after_mb_substr_conversion(): void
     {
-        // A >=60-char domain whose 59th raw BYTE is the lead byte of a 2-byte UTF-8
-        // sequence ("\xC3\xA9" = e-acute), straddling convert_dnsbl_log's
-        // substr($f2, 0, 59) truncation boundary (pfblockerng_alerts.php ~line 2231).
-        // That byte-substr call site is explicitly OUT OF SCOPE for conversion to
-        // mb_substr (issue #1814 follow-up) -- pfb_hsc()'s ENT_SUBSTITUTE is what makes
-        // the resulting dangling lead byte render safely instead of blanking the cell.
+        // issue #1815: a >=60-char domain whose 59th raw BYTE is the lead byte of a
+        // 2-byte UTF-8 sequence ("\xC3\xA9" = e-acute), straddling convert_dnsbl_log's
+        // truncation boundary (pfblockerng_alerts.php ~line 2247). This call site was
+        // byte substr() -- explicitly OUT OF SCOPE when this test was first written
+        // (issue #1814 follow-up) -- and pfb_hsc()'s ENT_SUBSTITUTE made the resulting
+        // dangling lead byte render safely (U+FFFD) instead of blanking the cell.
+        // #1815 IS that follow-up: the site is now mb_substr(..., 'UTF-8'), which keeps
+        // the character whole instead of ever leaving a dangling lead byte, so no
+        // substitution is needed here anymore.
         $domain = str_repeat('a', 58) . "\xC3\xA9" . 'trailing-domain-suffix.example';
         $this->assertGreaterThanOrEqual(60, strlen($domain));
 
@@ -212,7 +215,8 @@ final class AlertsRowOutputEncodingTest extends TestCase
         $html = $this->renderDnsblRow($fields);
 
         $this->assertStringContainsString(str_repeat('a', 58), $html, 'the domain text before the truncation point must survive');
-        $this->assertStringContainsString("\u{FFFD}", $html, 'the dangling lead byte left by the truncation must render substituted (U+FFFD)');
+        $this->assertStringContainsString('é', $html, 'the whole multibyte character must survive the cut intact');
+        $this->assertStringNotContainsString("\u{FFFD}", $html, 'mb_substr must keep the character whole -- U+FFFD must not appear');
         $this->assertStringContainsString('<small>...</small>', $html, 'the truncation ellipsis must still render');
         $this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'the rendered row must be valid UTF-8');
     }

--- a/tests/smoke/ui/test_alerts_multibyte_truncation.py
+++ b/tests/smoke/ui/test_alerts_multibyte_truncation.py
@@ -1,0 +1,178 @@
+"""Tier-A ``ui_render`` coverage for issue #1815: the Alerts page's row-cell
+display-truncation sites cut on CHARACTERS (``mb_substr(..., 'UTF-8')``), not
+BYTES, so a multibyte character straddling the cut renders whole instead of
+leaving a dangling lead byte for ``pfb_hsc()``'s ``ENT_SUBSTITUTE`` to replace
+with a spurious U+FFFD.
+
+Scenario (self-encapsulated: log truncated back to its exact pre-test byte
+size in teardown, loud assertion that the restore took):
+  Given three ``unified.log`` rows -- one ``Block,``-prefixed IP row, one
+        verbatim DNSBL row, one verbatim DNS-reply row -- each carrying a
+        value shaped ``<marker><'a' padding><'é'><tail>`` so its multibyte
+        character's lead byte lands exactly on that row's truncation cut
+        (see ``pfblockerng_alerts.php``'s ``convert_ip_log`` /
+        ``convert_dnsbl_log`` / ``convert_dns_reply_log``)
+  When  GET ``pfblockerng_alerts.php?view=unified``
+  Then  the Tier-A render oracle passes
+  And   each row is truncated (the ``<small>...</small>`` ellipsis renders)
+  And   each row's multibyte character survives WHOLE (no U+FFFD, 'é' present)
+
+``?view=unified`` needs no config precondition (no ``pfb_dnsbl`` toggle, no
+sinkhole VIP): the Unified loop reads only ``unified.log``, and its
+``$pfbunicnt`` render cap defaults to 200 (pfblockerng_alerts.php, `case
+'unified'`). The IP row's logged Feed Name (site 9, ``$fields[15]``) is
+written into the row UNCONDITIONALLY from the raw CSV value regardless of
+whether the underlying feed/alias re-attribution lookup hits or misses
+(pfblockerng_alerts.php, `$fields[15] = $attribution['field15'];`) -- so no
+on-disk feed-file fixture is needed for this row to exercise its truncation
+site; the row renders a delisted/"Not listed!" state harmlessly either way.
+
+DEVIATION from the issue's coverage-matrix wording (recorded in the #1815
+implementer handoff): the matrix asked for the IP row's straddling value to
+sit in the ``rhost`` (gethostbyaddr-resolved hostname) field -- site 11. That
+site was found to be DEAD CODE while writing ``AlertsMultibyteTruncationTest``
+(tests/php/): ``convert_ip_log()`` computes the truncated/wrapped value into
+``$fields[16]`` (pfblockerng_alerts.php ~:3088) but never reads that variable
+again -- the row's actually-rendered resolved-hostname cell comes from
+``$hostname['src']``/``$hostname['dst']``, a SEPARATE copy captured earlier,
+straight from the untruncated original. Asserting on ``rhost`` here would be a
+vacuous check this module cannot even execute to catch, so the IP row instead
+targets site 9 (logged Feed Name, ``$fields[15]``), which the same PHPUnit
+suite proved observable end-to-end.
+
+HONESTY NOTE (no local smoke VM in this environment, precedent: commit
+9fd4bfce, issue #1814): this module has NOT been executed against a live
+smoke VM. It is proven ``--collect-only`` clean and ruff/mypy clean only. Do
+not read a green run into this report -- there isn't one yet.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+from .webui import row_containing
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+PFB_LOGDIR = "/var/log/pfblockerng"
+UNIFIED_LOG = f"{PFB_LOGDIR}/unified.log"
+ALERTS_PAGE = "/pfblockerng/pfblockerng_alerts.php"
+UNIFIED_VIEW = f"{ALERTS_PAGE}?view=unified"
+
+FIXED_TS = "2030-06-01 00:00:00"
+
+
+def _mb_straddle(cut: int, marker: str, tail: str, mb_char: str = "é") -> str:
+    """A string whose CUT-th byte (index CUT-1) is the LEAD byte of ``mb_char``.
+
+    A byte-based ``substr($v, 0, cut)`` keeps that lead byte alone (a dangling,
+    invalid sequence); a character-based ``mb_substr($v, 0, cut, 'UTF-8')``
+    keeps ``mb_char`` whole. ``marker`` is a short ASCII prefix that survives
+    inside the retained text, so :func:`row_containing` can locate the row.
+    """
+    return marker + "a" * (cut - 1 - len(marker)) + mb_char + tail
+
+
+# Site 9 (convert_ip_log, logged Feed Name $fields[15]): cut=16, gate >=17.
+IP_MARKER = "SMKIP09"
+IP_FEED = _mb_straddle(16, IP_MARKER, "trailingfeed")
+
+# Site 2 (convert_dnsbl_log, blocked domain $f2): wide-gate cut=59 (mode
+# 'Unified' != 'unified', see FACT C -- the narrow arm is unreachable).
+DNSBL_MARKER = "SMKDNSBL02"
+DNSBL_DOMAIN = _mb_straddle(59, DNSBL_MARKER, "trailing-domain-suffix.example")
+
+# Site 7 (convert_dns_reply_log, replied domain $fields[6]): wide-gate cut=44.
+REPLY_MARKER = "SMKREPLY07"
+REPLY_DOMAIN = _mb_straddle(44, REPLY_MARKER, "trailing-domain-suffix.example")
+
+# unified.log row shapes (test_alerts_render_verify.py's _ip_line/_dnsbl_line/
+# _dns_reply_line document the exact CSV layouts these mirror):
+#   IP:         Block,ts,rule,real_iface,friendly_iface,action,ipv,proto_id,proto,
+#               src_ip,dst_ip,src_port,dst_port,dir,geoip,alias,ip_eval,feed,
+#               rhost,chost,asn,asn_domain,asn_name,dup
+#   DNSBL:      DNSBL-python,ts,domain,src_ip,agent,block_mode,group,final_domain,feed,dup,qtype
+#   DNS-reply:  DNS-reply,ts,reply_type,orig_record,final_record,ttl,domain,src_ip,dst,geoip
+_IP_LINE = (
+    f"Block,{FIXED_TS},100,em0,WAN,block,4,6,TCP,"
+    f"192.0.2.201,10.0.0.5,12345,443,in,US,RVMbAlias,192.0.2.201,{IP_FEED},"
+    "Unknown,Unknown,Unknown,,,+\n"
+)
+_DNSBL_LINE = f"DNSBL-python,{FIXED_TS},{DNSBL_DOMAIN},127.0.0.1,Python,DNSBL,RVMbGroup,{DNSBL_DOMAIN},RVMbFeed,+,A\n"
+_DNS_REPLY_LINE = f"DNS-reply,{FIXED_TS},A,A,A,300,{REPLY_DOMAIN},127.0.0.1,203.0.113.9,US\n"
+
+_ALL_LINES = _IP_LINE + _DNSBL_LINE + _DNS_REPLY_LINE
+
+
+@pytest.fixture
+def _seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[None]:
+    """Append the three straddling rows to ``unified.log``; restore its exact byte size after.
+
+    Self-encapsulated (this module is ``ui_render``-only, so the shared
+    ``_ui_pfb_isolation`` restore fixture does not run for it): the log
+    truncates back to its exact pre-test size, failing loudly if the restore
+    did not take.
+    """
+    vm = smoke_vm
+
+    ensure = vm.ssh(f"mkdir -p {PFB_LOGDIR} && touch {UNIFIED_LOG}", timeout=15)
+    assert ensure.returncode == 0, f"failed to ensure {UNIFIED_LOG} exists: {ensure.stderr!r}"
+
+    size_before = vm.ssh("stat", "-f", "%z", UNIFIED_LOG, timeout=15)
+    assert size_before.returncode == 0, f"failed to stat {UNIFIED_LOG}: stderr={size_before.stderr!r}"
+    original_size = size_before.stdout.strip()
+
+    append = subprocess.run(
+        vm.ssh_argv("tee", "-a", UNIFIED_LOG),
+        input=_ALL_LINES,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert append.returncode == 0, f"failed to append the fixture rows to {UNIFIED_LOG}: stderr={append.stderr!r}"
+
+    yield
+
+    restore = vm.ssh(f"truncate -s {original_size} {UNIFIED_LOG}", timeout=15)
+    assert restore.returncode == 0, f"failed to restore {UNIFIED_LOG} size: stderr={restore.stderr!r}"
+    size_after = vm.ssh("stat", "-f", "%z", UNIFIED_LOG, timeout=15)
+    assert size_after.returncode == 0 and size_after.stdout.strip() == original_size, (
+        f"{UNIFIED_LOG} restore did not take (before={original_size!r}, after={size_after.stdout.strip()!r})"
+    )
+
+
+def test_unified_rows_keep_straddling_multibyte_char_whole(
+    smoke_vm: SmokeVM, webui: WebUI, _seeded_unified_rows: None
+) -> None:
+    """Every seeded row's straddling character survives whole; none renders U+FFFD."""
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(UNIFIED_VIEW)
+    result = evaluate_render(UNIFIED_VIEW, resp.status_code, resp.text, ("Alert Settings",))
+    assert result.ok, f"Tier-A render oracle failed for the Alerts Unified view: {result.detail}"
+
+    body = resp.text
+    for marker in (IP_MARKER, DNSBL_MARKER, REPLY_MARKER):
+        row = row_containing(body, marker)
+        assert "�" not in row, (
+            f"row for marker {marker!r} rendered U+FFFD -- a byte-based cut dangled the "
+            f"straddling multibyte character's lead byte instead of keeping it whole:\n{row}"
+        )
+        assert "é" in row, f"row for marker {marker!r} lost its straddling multibyte character entirely:\n{row}"
+        assert "<small>...</small>" in row, (
+            f"row for marker {marker!r} did not truncate at all -- fixture broken, not a #1815 signal:\n{row}"
+        )
+
+    guard.assert_no_growth()

--- a/tests/smoke/ui/test_alerts_multibyte_truncation.py
+++ b/tests/smoke/ui/test_alerts_multibyte_truncation.py
@@ -111,8 +111,12 @@ _ALL_LINES = _IP_LINE + _DNSBL_LINE + _DNS_REPLY_LINE
 
 
 @pytest.fixture
-def _seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[None]:
+def seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[tuple[str, ...]]:
     """Append the three straddling rows to ``unified.log``; restore its exact byte size after.
+
+    Yields the markers it actually seeded, so the test iterates over the
+    fixture's own output rather than module constants -- the assertions cannot
+    run against data this fixture did not write.
 
     Self-encapsulated (this module is ``ui_render``-only, so the shared
     ``_ui_pfb_isolation`` restore fixture does not run for it): the log
@@ -138,7 +142,7 @@ def _seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[None]:
     )
     assert append.returncode == 0, f"failed to append the fixture rows to {UNIFIED_LOG}: stderr={append.stderr!r}"
 
-    yield
+    yield (IP_MARKER, DNSBL_MARKER, REPLY_MARKER)
 
     restore = vm.ssh(f"truncate -s {original_size} {UNIFIED_LOG}", timeout=15)
     assert restore.returncode == 0, f"failed to restore {UNIFIED_LOG} size: stderr={restore.stderr!r}"
@@ -149,7 +153,7 @@ def _seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[None]:
 
 
 def test_unified_rows_keep_straddling_multibyte_char_whole(
-    smoke_vm: SmokeVM, webui: WebUI, _seeded_unified_rows: None
+    smoke_vm: SmokeVM, webui: WebUI, seeded_unified_rows: tuple[str, ...]
 ) -> None:
     """Every seeded row's straddling character survives whole; none renders U+FFFD."""
     guard = PhpErrorLogGuard(smoke_vm)
@@ -160,7 +164,8 @@ def test_unified_rows_keep_straddling_multibyte_char_whole(
     assert result.ok, f"Tier-A render oracle failed for the Alerts Unified view: {result.detail}"
 
     body = resp.text
-    for marker in (IP_MARKER, DNSBL_MARKER, REPLY_MARKER):
+    assert seeded_unified_rows, "the seeding fixture yielded no markers -- nothing would be asserted"
+    for marker in seeded_unified_rows:
         row = row_containing(body, marker)
         assert "�" not in row, (
             f"row for marker {marker!r} rendered U+FFFD -- a byte-based cut dangled the "

--- a/tests/smoke/ui/test_alerts_multibyte_truncation.py
+++ b/tests/smoke/ui/test_alerts_multibyte_truncation.py
@@ -27,18 +27,14 @@ whether the underlying feed/alias re-attribution lookup hits or misses
 on-disk feed-file fixture is needed for this row to exercise its truncation
 site; the row renders a delisted/"Not listed!" state harmlessly either way.
 
-DEVIATION from the issue's coverage-matrix wording (recorded in the #1815
-implementer handoff): the matrix asked for the IP row's straddling value to
-sit in the ``rhost`` (gethostbyaddr-resolved hostname) field -- site 11. That
-site was found to be DEAD CODE while writing ``AlertsMultibyteTruncationTest``
-(tests/php/): ``convert_ip_log()`` computes the truncated/wrapped value into
-``$fields[16]`` (pfblockerng_alerts.php ~:3088) but never reads that variable
-again -- the row's actually-rendered resolved-hostname cell comes from
-``$hostname['src']``/``$hostname['dst']``, a SEPARATE copy captured earlier,
-straight from the untruncated original. Asserting on ``rhost`` here would be a
-vacuous check this module cannot even execute to catch, so the IP row instead
-targets site 9 (logged Feed Name, ``$fields[15]``), which the same PHPUnit
-suite proved observable end-to-end.
+The IP row deliberately targets the logged Feed Name (``$fields[15]``) rather
+than the ``rhost`` (gethostbyaddr-resolved hostname) cell, which is the more
+obvious candidate: ``convert_ip_log()`` computes the truncated/wrapped rDNS
+value into ``$fields[16]`` but never reads that variable again -- the row's
+actually-rendered resolved-hostname cell comes from ``$hostname['src']`` /
+``$hostname['dst']``, a SEPARATE copy captured earlier, straight from the
+untruncated original (issue #2008). Asserting on ``rhost`` here would be a
+vacuous check, and this module cannot be executed locally to catch that.
 
 HONESTY NOTE (no local smoke VM in this environment, precedent: commit
 9fd4bfce, issue #1814): this module has NOT been executed against a live
@@ -88,7 +84,7 @@ IP_MARKER = "SMKIP09"
 IP_FEED = _mb_straddle(16, IP_MARKER, "trailingfeed")
 
 # Site 2 (convert_dnsbl_log, blocked domain $f2): wide-gate cut=59 (mode
-# 'Unified' != 'unified', see FACT C -- the narrow arm is unreachable).
+# 'Unified' != 'unified' is case-sensitive, so the narrow arm is unreachable).
 DNSBL_MARKER = "SMKDNSBL02"
 DNSBL_DOMAIN = _mb_straddle(59, DNSBL_MARKER, "trailing-domain-suffix.example")
 


### PR DESCRIPTION
## What this changes

The Alerts/Reports row builders in `pfblockerng_alerts.php` truncate long cell values for display. Eleven of those sites cut on **bytes** (`substr()`), so a multibyte character straddling the cut left a dangling lead byte; `pfb_hsc()`'s `ENT_SUBSTITUTE` (issue #1814) then rendered it as a spurious U+FFFD. Only `pfb_stat_hostname_cell()` had been converted, by issue #1069.

This converts all eleven to cut on **characters**, through a single new chokepoint:

```php
function pfb_truncate($value, $length)
```

`pfb_truncate()` pins `mb_substitute_character(0xFFFD)` around the cut and restores the previous value afterwards. That matters: `mb_substr()` decodes its input, so it substitutes invalid UTF-8 itself, using mbstring's default substitute character `?` (0x3F) — a character that legitimately occurs in data. Without the pin, this change would silently have replaced #1814's unambiguous U+FFFD marker with an ambiguous `?` in every truncated cell.

The eleven sites, all in `src/usr/local/www/pfblockerng/pfblockerng_alerts.php`:

| Builder | Cell |
| --- | --- |
| `convert_dnsbl_log()` | source-IP hostname, domain (`$f2`, incl. the `idn_to_utf8()` append), CNAME (`$f7`), DNSBL type / agent |
| `convert_dns_reply_log()` | source-IP hostname, TTL, replied domain, resolved value |
| `convert_ip_log()` | logged feed name, re-attributed feed name (`$feed_new`), rDNS hostname |

## Proof

Test-first, with one mid-flight correction worth stating plainly rather than glossing.

`tests/php/AlertsMultibyteTruncationTest.php` was authored and executed RED against untouched production code before any `src/` edit. It was then edited twice more, and the first of those edits was a mistake: it added an assertion that *blessed* the fabricated `?` the naive `mb_substr()` conversion produced for an invalid byte, instead of rejecting it. The following commit reversed that into the stronger oracle — the invalid byte must render U+FFFD and a `?` the input never carried must never appear — and that is what ships. So the reproduction test was not frozen byte-identical from the first red run to the final green one; the oracle was strengthened after the first cut was found to bless a fabricated character.

What is verified mechanically, by the delegation gate and re-executed independently by review, is the property that actually matters: the tests as committed fail against pre-fix source and pass against HEAD. Two `verify-red-proof.sh` runs pin it — the eleven-site conversion against the tests-only baseline, and the U+FFFD substitute-character fix against the commit that preceded it — each reporting `RED-OK` / `GREEN-OK` / `VERDICT: PASS`. The `try`/`finally` fix carries a third. See the audit comment for the pasted runs.

Coverage beyond the eleven sites:

- short-side branch coverage on one site per builder (a sub-gate value renders verbatim, no ellipsis) — proving this is not an always-truncate path;
- a 4-byte character (emoji) straddling the cut, not just a 2-byte one;
- an invalid UTF-8 byte before the cut, pinning that it still renders U+FFFD and never fabricates a `?` the input did not contain;
- an HTML metacharacter at the cut, pinning #1069's truncate-raw-then-encode ordering (a split `&quot;` must not happen);
- a punycode `xn--` domain that takes the `idn_to_utf8()` append, so the converted text is what straddles the cut;
- `mb_substitute_character()` is unchanged after a row renders — the helper must not leak request-global state.

`tests/php/AlertsRowOutputEncodingTest.php` carried an oracle that deliberately pinned the pre-fix behaviour, with a docblock saying the site was "explicitly OUT OF SCOPE for conversion to `mb_substr` (issue #1814 follow-up)". This IS that follow-up, so that oracle is retargeted to the new intent; the sibling test covering a genuinely invalid byte is untouched.

`tests/smoke/ui/test_alerts_multibyte_truncation.py` adds the Tier-A `ui_render` coverage (test mandate #4): it seeds `unified.log` with a DNSBL row, a DNS-reply row and an IP row whose values straddle their respective cuts, GETs `?view=unified`, and asserts each rendered row keeps the whole character and carries no U+FFFD. There is no local smoke VM in this environment, so that module is proven collect-clean and lint-clean here and executes in the live-VM smoke leg — same posture as the sibling #1814 change (commit `9fd4bfce`).

## Deliberately out of scope

The `strlen()` gates are left byte-based, matching the precedent #1069 set. That leaves a byte-gate/character-cut unit mismatch, filed as #2009 rather than folded in. Four further defects surfaced while working this and are filed separately too: #2007 (the Unified-view narrow truncation widths are unreachable — a `$mode` case mismatch), #2008 (`convert_ip_log()`'s rDNS cell is truncated into a variable that is never rendered), #2010 (`pfb_stat_hostname_cell()` still substitutes invalid UTF-8 with `?`), and #2027 (an unrelated test's cleanup assertion globs the shared system temp dir).

Fixes #1815

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
