### PR TITLE
tests: skip TOP1M HTTP when listener binding is denied

### DIFF
--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -187,6 +187,7 @@ final class Top1mDccDetectorTest extends TestCase
 		if (!extension_loaded('curl')) {
 			$this->markTestSkipped('curl extension not available');
 		}
+		$this->requireLocalListenerCapability();
 		$body = "1,example.com\n";
 		$router = "{$this->dir}/router.php";
 		$this->assertNotFalse(file_put_contents($router, "<?php\nheader('ETag: \\\"followup-v1\\\"');\necho " . var_export($body, TRUE) . ";\n"));
@@ -437,6 +438,7 @@ final class Top1mDccDetectorTest extends TestCase
 	private function downloadTop1m(string $source, string $base, string $target): bool
 	{
 		$this->stopServer();
+		$this->requireLocalListenerCapability();
 		$GLOBALS['pfb']['dbdir'] = $this->dir . '/db';
 		$this->assertTrue(is_dir($GLOBALS['pfb']['dbdir']) || mkdir($GLOBALS['pfb']['dbdir']));
 		$router = $this->dir . '/router.php';
@@ -471,7 +473,7 @@ final class Top1mDccDetectorTest extends TestCase
 			}
 		}
 		if ($port === 0) {
-			$this->markTestSkipped('loopback HTTP fixture unavailable');
+			$this->fail('could not start local HTTP fixture');
 		}
 		return pfb_download(new PfbDownloadRequest(
 			listUrl: "http://127.0.0.1:{$port}/feed",
@@ -483,6 +485,19 @@ final class Top1mDccDetectorTest extends TestCase
 			timeout: 30,
 			type: 'top1m',
 		))->success;
+	}
+
+	private function requireLocalListenerCapability(): void
+	{
+		$errno = 0;
+		$error = '';
+		$listener = @stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+		if ($listener === FALSE) {
+			$reason = $error !== '' ? $error : "socket error {$errno}";
+			$this->markTestSkipped("environment cannot bind a loopback listener: {$reason}");
+			return;
+		}
+		fclose($listener);
 	}
 
 	private function stopServer(): void


### PR DESCRIPTION
Fixes #1594

## Summary

- probe whether the environment can bind an ephemeral loopback TCP listener before starting TOP1M HTTP fixtures;
- skip the listener-dependent cases with the socket error only when that capability probe fails;
- keep fixture startup failures fatal after a successful capability probe, preserving the intermittent failure signal tracked by #1951;
- leave the real HTTP response, status, body, and hash assertions unchanged when the fixture is available.

## Skip condition

The skip is keyed exclusively on `stream_socket_server('tcp://127.0.0.1:0')` failing. It is not keyed on `php -S` fixture startup or readiness failure. A host that can bind the probe but later fails to start the fixture still fails the test, so #1951 can rule this change out when diagnosing its full-suite ordering flake.

## Verification

- RED: `sandbox-exec -p '(version 1)(allow default)(deny network-bind)' vendor/bin/phpunit --filter 'Top1mDccDetectorTest::testChangeDetectUsesActualHttpProbeBodyAndMetadata' --testdox` — failed after 23.113s with `could not start local HTTP fixture` and `0 is not identical to 0`.
- GREEN, bind denied: `sandbox-exec -p '(version 1)(allow default)(deny network-bind)' vendor/bin/phpunit --filter Top1mDccDetectorTest --display-skipped` — 18 tests, 102 assertions, 8 explicit skips reporting `environment cannot bind a loopback listener: Operation not permitted`.
- GREEN, fixture available: `vendor/bin/phpunit --filter Top1mDccDetectorTest` — 18 tests, 195 assertions; the focused HTTP case retained all 7 assertions.
- `scripts/agent/run-gates.sh --diff origin/devel` — PASS on the final rebased head: Composer vendor check, PHP syntax, full PHPUnit, PHPStan, and PHPCS.

## AI assistance

Implemented with OpenAI Codex. Red/green evidence and the complete diff were reviewed before publication.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
