### PR TITLE
tests: synchronise two wall-clock-dependent assertions on their events (#2029, #2024)

### DIFF
--- a/tests/php/PfbSettingsFamilyTest.php
+++ b/tests/php/PfbSettingsFamilyTest.php
@@ -6,6 +6,21 @@ use PHPUnit\Framework\TestCase;
 
 final class PfbSettingsFamilyTest extends TestCase
 {
+	/**
+	 * How far ahead of the clock a "created in the future" fixture is written (#2029).
+	 *
+	 * pfb_settings_downgrade_context_target() reads its own time(), so such a fixture is
+	 * only in the future while the wall clock stays behind its created_at. Every rejection
+	 * row is therefore written against the clock read immediately before ITS OWN write --
+	 * never one array-literal snapshot shared by all rows, which made each row's verdict
+	 * depend on how long the preceding rows took to validate (a one-second margin lost that
+	 * race on CI). The margin is a salvage bound, not an assertion: the guard beside it
+	 * reports STUCK/ENVIRONMENT if the clock ever overtakes it. Its mirror-image sibling,
+	 * the "older than the window" row, drifts the safe way -- it only gets older -- and so
+	 * needs no such guard.
+	 */
+	private const FUTURE_MARGIN_S = 300;
+
 	private string $root;
 
 	protected function setUp(): void
@@ -98,18 +113,33 @@ final class PfbSettingsFamilyTest extends TestCase
 
 	public function testInvalidContextsRejectAndRegularFilesAreConsumed(): void
 	{
+		// 'created_at' is an OFFSET, resolved against the clock read immediately before
+		// that row's OWN write (#2029) -- see FUTURE_MARGIN_S.
 		$contexts = [
-			['version' => 2, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time()],
-			['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time() - 301],
-			['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time() + 1],
-			['version' => 1, 'source_family' => '3.2', 'target_family' => '3.2', 'created_at' => time()],
-			['version' => 1, 'source_family' => '4.0', 'target_family' => '4.0', 'created_at' => time()],
-			['version' => '1', 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => time()],
-			['version' => 1, 'source_family' => ['4.0'], 'target_family' => '3.2', 'created_at' => time()],
+			'with an unsupported version'          => ['version' => 2, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => 0],
+			'older than the 300-second window'     => ['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => -301],
+			'created in the future'                => ['version' => 1, 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => self::FUTURE_MARGIN_S],
+			'whose source family is not the live family' => ['version' => 1, 'source_family' => '3.2', 'target_family' => '3.2', 'created_at' => 0],
+			'whose target family does not rank below its source' => ['version' => 1, 'source_family' => '4.0', 'target_family' => '4.0', 'created_at' => 0],
+			'whose version is a string, not an int' => ['version' => '1', 'source_family' => '4.0', 'target_family' => '3.2', 'created_at' => 0],
+			'whose source family is an array, not a string' => ['version' => 1, 'source_family' => ['4.0'], 'target_family' => '3.2', 'created_at' => 0],
 		];
-		foreach ($contexts as $context) {
+		foreach ($contexts as $why => $context) {
+			$offset                = (int) $context['created_at'];
+			$context['created_at'] = time() + $offset;
 			$this->writeContext($context);
-			$this->assertNull(pfb_settings_downgrade_context_target('4.0'));
+			$target = pfb_settings_downgrade_context_target('4.0');
+			if ($offset > 0) {
+				// Salvage guard, never the verdict: re-read the clock AFTER the call, so a
+				// pass proves the fixture was still in the future when the validator read
+				// time(). Only its expiry is time-shaped, and it says so.
+				$this->assertGreaterThan(time(), $context['created_at'],
+					'STUCK/ENVIRONMENT: the wall clock consumed the whole ' . self::FUTURE_MARGIN_S
+					. 's future margin during one validation call -- the run is stuck or the '
+					. 'environment is broken, not a behavioural failure');
+			}
+			$this->assertNull($target, "a context {$why} must be rejected, got "
+				. var_export($target, TRUE));
 			pfb_settings_downgrade_context_consume();
 			$this->assertFileDoesNotExist($this->contextPath());
 		}

--- a/tests/php/TickFeedPassDeferralTest.php
+++ b/tests/php/TickFeedPassDeferralTest.php
@@ -34,8 +34,19 @@ use PHPUnit\Framework\TestCase;
  */
 final class TickFeedPassDeferralTest extends TestCase
 {
+	/**
+	 * Reaper for a stuck run, never a deadline the dispatch contract is judged against
+	 * (#2024, tracker #1517). Its expiry says STUCK/ENVIRONMENT and nothing about tick.
+	 */
+	private const SALVAGE_CAP_S = 30.0;
+
 	/** Per-test private sandbox for $pfb['dbdir'] -- see TickEntrypointTest::setUp(). */
 	private string $dbdir = '';
+
+	/** The argv recorder installPhpArgvRecorder() wrote, and its spawn log. */
+	private string $recorderPath = '';
+
+	private string $spawnLog = '';
 
 	private bool $hadDbdir = FALSE;
 	private mixed $originalDbdir = NULL;
@@ -190,51 +201,65 @@ final class TickFeedPassDeferralTest extends TestCase
 		], $GLOBALS['pfb']['dbdir']);
 	}
 
+	/**
+	 * Install the argv recorder and return the $pfb['php'] value that drives it.
+	 *
+	 * The value is a `<spawn counter>; <recorder>` pair, not a bare path: $pfb['php'] is
+	 * interpolated into exec("{$pfb['php']} <script> <args> ... &"), so the counter runs
+	 * in the FOREGROUND of that exec() -- the shape installLedgerRequeueCommand() already
+	 * relies on -- and only the recorder is backgrounded. exec() returns once the
+	 * foreground segment has run, so the moment pfblockerng_tick() returns the spawn log
+	 * holds exactly one byte per dispatch: the dispatch COUNT is an observed fact rather
+	 * than something awaitRecordedInvocations() has to infer from how long nothing else
+	 * showed up (#2024).
+	 */
 	private function installPhpArgvRecorder(): string
 	{
-		$phpPath = "{$this->dbdir}/php-recorder";
-		$script   = <<<'SH'
+		$this->recorderPath = "{$this->dbdir}/php-recorder";
+		$this->spawnLog     = "{$this->dbdir}/php-spawns";
+		// Created empty up front so an empty spawn log reads as "tick dispatched nothing"
+		// rather than as "the counter never got the chance to run".
+		file_put_contents($this->spawnLog, '');
+		// The argv file is published by rename, so a *.done.* path is never a partial read.
+		$script = <<<'SH'
 #!/bin/sh
-active="${0}.active.$$"
-done="${0}.done.$$"
-tmp="${done}.tmp"
-true > "$active"
-trap 'rm -f "$active" "$tmp"' EXIT HUP INT TERM
+tmp="${0}.tmp.$$"
 printf '%s\0' "$@" > "$tmp"
-mv "$tmp" "$done"
+mv "$tmp" "${0}.done.$$"
 SH;
-		file_put_contents($phpPath, $script . "\n");
-		chmod($phpPath, 0755);
-		return $phpPath;
+		file_put_contents($this->recorderPath, $script . "\n");
+		chmod($this->recorderPath, 0755);
+		return 'printf x >> ' . escapeshellarg($this->spawnLog)
+			. '; ' . escapeshellarg($this->recorderPath);
 	}
 
-	/** @return list<list<string>> */
-	private function awaitRecordedInvocations(string $phpPath): array
+	/**
+	 * Block until every dispatch this tick spawned has published its argv.
+	 *
+	 * The wait ends on the event -- one *.done.* marker per counted spawn -- so a tick
+	 * that dispatched nothing returns [] immediately and a tick that dispatched twice is
+	 * reported as two invocations, both without consulting the clock. The cap below only
+	 * reaps a run whose recorder never finished; its expiry is an environment verdict.
+	 *
+	 * @return list<list<string>>
+	 */
+	private function awaitRecordedInvocations(): array
 	{
-		$deadline    = hrtime(TRUE) + 2_000_000_000;
-		$stableSince = NULL;
-		$donePaths   = [];
-		while (hrtime(TRUE) < $deadline) {
-			$now         = hrtime(TRUE);
-			$currentDone = glob("{$phpPath}.done.*") ?: [];
-			$activePaths = glob("{$phpPath}.active.*") ?: [];
-			sort($currentDone);
-			if ($currentDone !== [] && $activePaths === []) {
-				if ($currentDone !== $donePaths) {
-					$donePaths   = $currentDone;
-					$stableSince = $now;
-				} elseif ($stableSince !== NULL && $now - $stableSince >= 200_000_000) {
-					break;
-				}
-			} else {
-				$stableSince = NULL;
+		$spawned   = strlen((string) @file_get_contents($this->spawnLog));
+		$deadline  = microtime(TRUE) + self::SALVAGE_CAP_S;
+		$donePaths = [];
+		while (TRUE) {
+			$donePaths = glob("{$this->recorderPath}.done.*") ?: [];
+			if (count($donePaths) >= $spawned || microtime(TRUE) >= $deadline) {
+				break;
 			}
 			usleep(1000);
 		}
-		$this->assertNotEmpty($donePaths,
-			'tick dispatch must complete at the configured PHP executable within 2 seconds');
-		$this->assertSame([], glob("{$phpPath}.active.*") ?: [],
-			'all configured PHP invocations must finish before argv is asserted');
+		sort($donePaths);
+		$this->assertCount($spawned, $donePaths, sprintf(
+			'STUCK/ENVIRONMENT: %d of the %d recorder(s) tick spawned published argv within the '
+			. '%ss salvage cap -- the run is stuck or the environment is broken, not a '
+			. 'behavioural failure', count($donePaths), $spawned, self::SALVAGE_CAP_S));
 
 		$recorded = [];
 		foreach ($donePaths as $donePath) {
@@ -501,8 +526,7 @@ SH;
 	{
 		$this->seedTickPrereqs('Disabled');
 		pfb_global();
-		$fakePhp = $this->installPhpArgvRecorder();
-		$GLOBALS['pfb']['php'] = $fakePhp;
+		$GLOBALS['pfb']['php'] = $this->installPhpArgvRecorder();
 		if (!is_dir($GLOBALS['pfb']['logdir'])) {
 			@mkdir($GLOBALS['pfb']['logdir'], 0755, TRUE);
 		}
@@ -528,7 +552,7 @@ SH;
 
 		$this->assertSame([
 			['/usr/local/www/pfblockerng/pfblockerng.php', 'pfb_trigger', 'scope=both', 'force=false', 'trigger=manual'],
-		], $this->awaitRecordedInvocations($fakePhp),
+		], $this->awaitRecordedInvocations(),
 			'disabled pending apply must dispatch exactly once with the manual trigger argv');
 		$after = pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']);
 		$this->assertSame([
@@ -604,8 +628,7 @@ SH;
 	{
 		$this->seedTickPrereqs('24');
 		pfb_global();
-		$fakePhp = $this->installPhpArgvRecorder();
-		$GLOBALS['pfb']['php'] = $fakePhp;
+		$GLOBALS['pfb']['php'] = $this->installPhpArgvRecorder();
 		$now = time();
 		$this->seedDueLedgerEntry('cron', $now);
 		$this->seedFutureLedgerEntry('dcc', $now);
@@ -615,15 +638,14 @@ SH;
 
 		$this->assertSame([
 			['/usr/local/www/pfblockerng/pfblockerng.php', 'cron'],
-		], $this->awaitRecordedInvocations($fakePhp));
+		], $this->awaitRecordedInvocations());
 	}
 
 	public function testDccUsesConfiguredPhpExactlyOnce(): void
 	{
 		$this->seedTickPrereqs('24');
 		pfb_global();
-		$fakePhp = $this->installPhpArgvRecorder();
-		$GLOBALS['pfb']['php'] = $fakePhp;
+		$GLOBALS['pfb']['php'] = $this->installPhpArgvRecorder();
 		$now = time();
 		$this->seedFutureLedgerEntry('cron', $now);
 		$this->seedDueLedgerEntry('dcc', $now);
@@ -633,15 +655,14 @@ SH;
 
 		$this->assertSame([
 			['/usr/local/www/pfblockerng/pfblockerng.php', 'dcc'],
-		], $this->awaitRecordedInvocations($fakePhp));
+		], $this->awaitRecordedInvocations());
 	}
 
 	public function testBlUsesConfiguredPhpExactlyOnce(): void
 	{
 		$this->seedTickPrereqs('24');
 		pfb_global();
-		$fakePhp = $this->installPhpArgvRecorder();
-		$GLOBALS['pfb']['php'] = $fakePhp;
+		$GLOBALS['pfb']['php'] = $this->installPhpArgvRecorder();
 		$GLOBALS['pfb']['enable'] = PfbToggle::On;
 		$GLOBALS['pfb']['blconfig'] = [
 			'blacklist_enable'   => 'Enable',
@@ -660,7 +681,7 @@ SH;
 
 		$this->assertSame([
 			['/usr/local/www/pfblockerng/pfblockerng.php', 'bl', 'test-list'],
-		], $this->awaitRecordedInvocations($fakePhp));
+		], $this->awaitRecordedInvocations());
 	}
 
 	public function testDisabledManualChildRequeueSurvivesDispatch(): void
@@ -677,15 +698,17 @@ SH;
 		pfb_due_ledger_write_entry('cron', $expected, $GLOBALS['pfb']['dbdir']);
 		$this->seedFutureLedgerEntry('dcc', $now);
 		$this->seedFutureLedgerEntry('bl', $now);
-		$fakePhp = $this->installPhpArgvRecorder();
-		$requeue = $this->installLedgerRequeueCommand();
-		$GLOBALS['pfb']['php'] = escapeshellarg($requeue) . '; ' . escapeshellarg($fakePhp);
+		$recorderCmd = $this->installPhpArgvRecorder();
+		$requeue     = $this->installLedgerRequeueCommand();
+		// Another foreground segment ahead of the recorder's own -- both run inside the
+		// dispatching exec(), only the recorder is backgrounded.
+		$GLOBALS['pfb']['php'] = escapeshellarg($requeue) . '; ' . $recorderCmd;
 
 		pfblockerng_tick();
 
 		$this->assertSame([
 			['/usr/local/www/pfblockerng/pfblockerng.php', 'pfb_trigger', 'scope=both', 'force=false', 'trigger=manual'],
-		], $this->awaitRecordedInvocations($fakePhp));
+		], $this->awaitRecordedInvocations());
 		$this->assertSame($expected,
 			pfb_due_ledger_read_entry('cron', $GLOBALS['pfb']['dbdir']),
 			'a child lock-loss requeue must survive the parent dispatch path');


### PR DESCRIPTION
Two `#1517`-class defects, one per commit: a behavioural verdict that depends on the wall clock. Different files, no production change.

## `6213a6da` — `PfbSettingsFamilyTest` (Fixes #2029)

`testInvalidContextsRejectAndRegularFilesAreConsumed()` built all seven rejection contexts in one array literal, so every `time()` in it was evaluated at a single instant and then validated one row at a time. The "created in the future" row carried a one-second margin, which the six preceding rows could consume: once the clock ticked past `created_at`, `pfb_settings_downgrade_context_target()` accepted the context and the test failed with the target family it was meant to reject. This is the failure that hit `PHPUnit unit tests / PHP 8.5` on an unrelated branch.

Classification (#1517): **(b)** — a deadline doing assertion work.

`created_at` is now an offset resolved against the clock read immediately before that row's own write; the future row gets a 300-second margin; and a post-call clock re-read guards it, so a clock that ever overtakes the margin reports `STUCK/ENVIRONMENT` instead of a behavioural verdict. Each row also carries a label, so a failure names the context that was wrongly accepted rather than printing a bare "Failed asserting that '3.2' is null".

The mirror-image `-301` row drifts the safe way (it only gets older); the constant's docblock records why the two differ, so the fix does not get undone.

### Red → green (executed)

Forcing exactly the CI mechanism — a clock tick between the array literal and the row's validation — with a temporary `sleep(2)` after the literal:

```
# before
1) PfbSettingsFamilyTest::testInvalidContextsRejectAndRegularFilesAreConsumed
Failed asserting that '3.2' is null.
Tests: 1, Assertions: 5, Failures: 1.

# after, same injected sleep(2)
OK (1 test, 25 assertions)
```

Salvage-guard vacuity check (margin temporarily cut to 1 s, `sleep(2)` moved between the write and the call) — the guard fires *before* the behavioural assertion and says so:

```
STUCK/ENVIRONMENT: the wall clock consumed the whole 300s future margin during one validation
call -- the run is stuck or the environment is broken, not a behavioural failure
Failed asserting that 1785614279 is greater than 1785614280.
```

## `b427357e` — `TickFeedPassDeferralTest` (Fixes #2024)

`awaitRecordedInvocations()` bounded its wait on a 2-second deadline and then asserted on the result, so a loaded host reported `tick dispatch must complete at the configured PHP executable within 2 seconds` — an environment condition indistinguishable from a violation of the dispatch contract. The 200 ms quiescence window it used to conclude "no further invocation is coming" was the same shape in miniature.

Classification (#1517): **(b)** for the 2 s cap, **(a)** for the quiescence window (a fixed duration used as coordination).

The dispatch count is now an observed fact rather than something inferred from elapsed time. `$pfb['php']` is interpolated into `exec("{$pfb['php']} <script> <args> ... &")`, so a `<counter>; <recorder>` value runs the counter in the **foreground** of that `exec()` and backgrounds only the recorder — the shape `installLedgerRequeueCommand()` already relies on. `exec()` returns only after the foreground segment has run, so the moment `pfblockerng_tick()` returns the spawn log holds exactly one byte per dispatch. The helper waits for precisely that many argv markers and stops on the last one.

Consequences: the quiescence window and the `.active.*` marker it needed are gone; the argv file is published by rename under a name outside the `.done.*` glob (the old `*.done.*.tmp` was matched by that glob); a tick that dispatched nothing returns `[]` immediately, and a tick that dispatched twice is reported as two invocations — both without consulting the clock. "Exactly once" is now proven against the counted spawns instead of against 200 ms of silence. The remaining 30-second cap only reaps a stuck run and reports `STUCK/ENVIRONMENT`, matching the wording `DnsblQueryClientTest` established.

The `assertSame` assertions on the recorded argv are unchanged.

### Red → green (executed)

Forcing the environment condition with a temporary `sleep 3` inside the recorder:

```
# before
1) TickFeedPassDeferralTest::testBlUsesConfiguredPhpExactlyOnce
tick dispatch must complete at the configured PHP executable within 2 seconds
Failed asserting that an array is not empty.

# after, same injected sleep 3
[probe] spawned=1
OK (1 test, 3 assertions)
```

Salvage-cap vacuity check (cap temporarily cut to 1 s, recorder still sleeping 3 s):

```
STUCK/ENVIRONMENT: only 0 of the 1 recorder(s) tick spawned published argv within the 1s
salvage cap -- the run is stuck or the environment is broken, not a behavioural failure
```

The `[probe] spawned=1` line is the spawn counter observed working; both temporary injections were removed before committing.

## Scope note for #1994

#1994 (another #1517 child) names `TickFeedPassDeferralTest.php` alongside `DnsblManifestAtomicGenerationTest.php` and `PfbSyncStatusLedgerTest.php`. This PR completes the `TickFeedPassDeferralTest.php` half of it — the `:214`/`:217`/`:218`/`:232`/`:235` sites in that ticket's enumeration are all gone. #1994 is left with its other two files and stays blocked behind #1780, which owns `PfbSyncStatusLedgerTest.php`. Recorded as a comment on #1994 as well.

Note that #1994's suggested replacement for this file (synchronize on the `pfb_due_ledger_mark_ran*()` write) was not taken: that write happens inside `pfblockerng_tick()` and has therefore already occurred by the time the helper is called, so it cannot tell the helper how many recorders are still to publish. Counting the foreground spawn segments does, and needs no production change.

## Gates

```
GATE PASS: python3 scripts/check_composer_vendor.py
GATE PASS: php -l tests/php/PfbSettingsFamilyTest.php
GATE PASS: php -l tests/php/TickFeedPassDeferralTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

Fixes #2029
Fixes #2024
Refs #1517, #1994

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
