### PR TITLE
tests: isolate shellspec scratch Git config

### DIFF
--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -10,16 +10,13 @@
 #      (scripts/lib/git-env-scrub.sh) is a violation: the class must be
 #      suppressed at the lib chokepoint, not scattered.
 #
-#   2. Any spec that shells out to `git` must call scrub_git_env.
-#      A spec file (*_spec.sh) that contains the token `git ` (bare git command)
-#      but does NOT call `scrub_git_env` is a violation: inherited GIT_DIR from
-#      the pre-commit hook would corrupt its fixture repo operations.
+#   2. Fixture/setup Git calls use git_fixture(). Raw Git command positions in
+#      specs are violations unless a same-line marker carries a non-empty reason.
+#      The lexical scan ignores comments and inert quoted text, while retaining
+#      active command substitutions and handling env/assignment prefixes.
 #
-# Note: `git -C` and `git fetch` etc. all start with `git ` (space after git).
-# `git` in a comment is not excluded — the check is a heuristic; if the file
-# only mentions git in a comment but scrub_git_env is not called, that is fine
-# in practice (the check may false-positive but the cost is adding the call,
-# which is cheap and defensive).
+# Intentional Git calls exercising a hook under test may use a same-line marker;
+# an empty marker or a marker on a prior line does not exempt the command.
 #
 # Usage: sh scripts/git-env-scrub-guard.sh [ROOT]
 #   ROOT defaults to the repo root (parent of scripts/).
@@ -55,20 +52,140 @@ grep -Ern --include='*.sh' \
     | grep -v "${GUARD_SELF}" \
     | grep -v "${SCRUB_SPEC}" >> "$TMPF" || true
 
-# ── Clause 2: any spec with `git ` must call scrub_git_env ──────────────── #
+# ── Clause 2: raw fixture Git calls use git_fixture. ────────────────────── #
+# Strip comments and quoted text before checking command positions. The guard is
+# intentionally lexical rather than a shell evaluator: it catches direct Git at
+# indentation, after `&&`/`;`/`!`, and in `$(git ...)` without executing fixtures.
+scan_raw_git() {
+    awk '
+    function unquoted(line,    i,c,state,out,depth) {
+        state=""
+        out=""
+        depth=0
+        for (i = 1; i <= length(line); i++) {
+            c = substr(line, i, 1)
+            if (state == "single") {
+                if (c == "\047") state = ""
+                out = out " "
+                continue
+            }
+            if (state == "double") {
+                if (c == "\\") {
+                    i++
+                    out = out "  "
+                } else if (c == "$" && substr(line, i + 1, 1) == "(") {
+                    out = out "$("
+                    i++
+                    depth=1
+                    state="cmd"
+                } else if (c == "\"") {
+                    state = ""
+                    out = out " "
+                } else {
+                    out = out " "
+                }
+                continue
+            }
+            if (state == "cmd_single") {
+                if (c == "\047") state = "cmd"
+                out = out " "
+                continue
+            }
+            if (state == "cmd_double") {
+                if (c == "\\") {
+                    i++
+                    out = out "  "
+                } else if (c == "\"") {
+                    state = "cmd"
+                    out = out " "
+                } else if (c == "$" && substr(line, i + 1, 1) == "(") {
+                    out = out "$("
+                    i++
+                    depth++
+                    state="cmd"
+                } else {
+                    out = out " "
+                }
+                continue
+            }
+            if (state == "cmd") {
+                if (c == "\047") {
+                    state="cmd_single"
+                    out = out " "
+                } else if (c == "\"") {
+                    state="cmd_double"
+                    out = out " "
+                } else if (c == "$" && substr(line, i + 1, 1) == "(") {
+                    out = out "$("
+                    i++
+                    depth++
+                } else if (c == ")") {
+                    depth--
+                    out = out " "
+                    if (depth == 0) state="double"
+                } else {
+                    out = out c
+                }
+                continue
+            }
+            if (c == "#") {
+                tail = substr(line, i)
+                if (match(tail, /^#[[:space:]]*git-env-scrub-guard:/)) {
+                    out = out "# git-env-scrub-guard:" substr(tail, RLENGTH + 1)
+                }
+                break
+            }
+            if (c == "\047" || c == "\"") {
+                state = c == "\047" ? "single" : "double"
+                out = out " "
+            } else if (c == "\\") {
+                i++
+                out = out "  "
+            } else {
+                out = out c
+            }
+        }
+        return out
+    }
+    function raw_git(line) {
+        prefix="([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*"
+        env_prefix="env([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+"
+        boundary="(^[[:space:]]*|[;&|!][[:space:]]*)"
+        sub_boundary="\\$\\([[:space:]]*"
+        return line ~ (boundary prefix "git([[:space:]]|$)") \
+            || line ~ (boundary env_prefix "git([[:space:]]|$)") \
+            || line ~ (sub_boundary prefix "git([[:space:]]|$)") \
+            || line ~ (sub_boundary env_prefix "git([[:space:]]|$)")
+    }
+    {
+        original = $0
+        cleaned = unquoted(original)
+        if (!raw_git(cleaned)) next
+        marker = "# git-env-scrub-guard:"
+        marker_at = index(cleaned, marker)
+        if (marker_at) {
+            reason = substr(cleaned, marker_at + length(marker))
+            sub(/[[:space:]]+$/, "", reason)
+            if (reason !~ /^[[:space:]]*$/) next
+        }
+        printf "%s:%d: raw git setup without fixture helper\n", FILENAME, FNR
+    }' "$1"
+}
+
 find "${ROOT}/tests/shell" -name '*_spec.sh' | LC_ALL=C sort \
 | while IFS= read -r _spec; do
-    if grep -q 'git ' "$_spec" 2>/dev/null; then
-        if ! grep -q 'scrub_git_env' "$_spec" 2>/dev/null; then
-            printf '%s: calls git without scrub_git_env (GIT_DIR may corrupt fixture repos)\n' \
-                "$_spec" >> "$TMPF"
-        fi
-    fi
+    scan_raw_git "$_spec" >> "$TMPF"
 done
 
 if [ -s "$TMPF" ]; then
     cat "$TMPF" >&2
-    printf 'git-env-scrub-guard: violations found — add scrub_git_env or move unset to the lib\n' >&2
+    printf 'git-env-scrub-guard: violations found\n' >&2
+    if grep -q 'raw git setup without fixture helper' "$TMPF"; then
+        printf 'git-env-scrub-guard: add git_fixture for fixture/setup Git calls\n' >&2
+    fi
+    if grep -Eq 'unset (GIT_DIR|GIT_INDEX_FILE|GIT_WORK_TREE|GIT_PREFIX|GIT_OBJECT_DIRECTORY|GIT_COMMON_DIR)' "$TMPF"; then
+        printf 'git-env-scrub-guard: move GIT_* unsets to the lib\n' >&2
+    fi
     exit 1
 fi
 

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -10,10 +10,10 @@
 #      (scripts/lib/git-env-scrub.sh) is a violation: the class must be
 #      suppressed at the lib chokepoint, not scattered.
 #
-#   2. Fixture/setup Git calls use git_fixture(). Raw Git command positions in
-#      specs are violations unless a same-line marker carries a non-empty reason.
-#      The lexical scan ignores comments and inert quoted text, while retaining
-#      active command substitutions and handling env/assignment prefixes.
+#   2. The swept scratch-repo specs retain every git_fixture() pin. An explicit
+#      per-file count catches removal without pretending this guard is a shell
+#      parser. A lexical scan also catches common raw Git command forms unless a
+#      same-line marker carries a non-empty reason.
 #
 # Intentional Git calls exercising a hook under test may use a same-line marker;
 # an empty marker or a marker on a prior line does not exempt the command.
@@ -53,9 +53,51 @@ grep -Ern --include='*.sh' \
     | grep -v "${SCRUB_SPEC}" >> "$TMPF" || true
 
 # ── Clause 2: raw fixture Git calls use git_fixture. ────────────────────── #
-# Strip comments and quoted text before checking command positions. The guard is
-# intentionally lexical rather than a shell evaluator: it catches direct Git at
-# indentation, after `&&`/`;`/`!`, and in `$(git ...)` without executing fixtures.
+# The manifest pins the completed sweep. The lexical lint below keeps common raw
+# command mistakes visible without claiming to parse arbitrary shell programs.
+check_fixture_manifest() {
+    marker="${ROOT}/tests/shell/agent_run_gates_spec.sh"
+    [ -f "$marker" ] || return 0
+
+    while IFS=: read -r spec expected; do
+        path="${ROOT}/tests/shell/${spec}"
+        if [ ! -f "$path" ]; then
+            printf '%s: swept fixture spec is missing\n' "$path" >> "$TMPF"
+            continue
+        fi
+        actual=$(awk '{
+            line=$0
+            while (match(line, /(^|[^[:alnum:]_])git_fixture([^[:alnum:]_]|$)/)) {
+                count++
+                line=substr(line, RSTART + RLENGTH)
+            }
+        } END { print count + 0 }' "$path")
+        if [ "$actual" -ne "$expected" ]; then
+            printf '%s: git_fixture pin count changed (expected %s, found %s)\n' \
+                "$path" "$expected" "$actual" >> "$TMPF"
+        fi
+    done <<'EOF'
+agent_run_gates_spec.sh:4
+agent_verify_red_proof_spec.sh:12
+agent_work_branch_spec.sh:5
+composer_cloud_install_spec.sh:4
+git_no_docs_spec.sh:5
+githooks_pre_push_lease_spec.sh:33
+githooks_pre_push_tag_scheme_spec.sh:7
+githooks_prepare_commit_msg_guard_spec.sh:17
+pfblockerng_truncate_survival_spec.sh:4
+precommit_composer_vendor_spec.sh:2
+read_version_matrix_test_spec.sh:5
+release_ci_gate_spec.sh:33
+session_branch_sync_spec.sh:46
+sparse_clone_ports_spec.sh:17
+EOF
+}
+
+check_fixture_manifest
+
+# This lexical lint covers common direct-command mistakes. The manifest above,
+# rather than this deliberately small scanner, is the completed-sweep invariant.
 scan_raw_git() {
     awk '
     function unquoted(line,    i,c,state,out,depth) {

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -123,11 +123,11 @@ Describe 'run-gates.sh gates_for()'
 End
 
 Describe 'run-gates.sh Composer vendor guard'
-  gitc() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+  gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
   make_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rungatesphp.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     gitc config commit.gpgsign false
     mkdir -p "$repo/src" "$repo/vendor/bin" "$repo/scripts"
     printf 'base\n' > "$repo/README"
@@ -222,11 +222,11 @@ Describe 'run-gates.sh Composer vendor guard'
 End
 
 Describe 'run-gates.sh main (fixture repo, stubbed tools)'
-  gitc() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+  gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
   make_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rungates.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     # Under scripts/ so the files are in shellcheck's scope (src, scripts, .claude/hooks).
     mkdir -p "$repo/scripts"
     printf '#!/bin/sh\n# gone-marker: content distinct from kept.sh so git reports a\n# genuine deletion (identical content collapses to an R100 rename)\ntrue\n' > "$repo/scripts/gone.sh"

--- a/tests/shell/agent_verify_red_proof_spec.sh
+++ b/tests/shell/agent_verify_red_proof_spec.sh
@@ -6,10 +6,10 @@
 Describe 'verify-red-proof.sh'
   script="scripts/agent/verify-red-proof.sh"
 
-  gitc() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+  gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
 
   assert_repo_clean() {
-    status_output=$(git -C "$repo" status --porcelain "$@")
+    status_output=$(git_fixture -C "$repo" status --porcelain "$@")
     status_code=$?
     if [ "$status_code" -ne 0 ]; then
       return "$status_code"
@@ -27,7 +27,7 @@ Describe 'verify-red-proof.sh'
     # aim every fixture git op at the REAL repo -- scrub before any git runs.
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     printf '%s\n' "$1" > "$repo/src.txt"
     printf 'grep -q GOOD src.txt\n' > "$repo/test_pin.sh"
     gitc add -A
@@ -43,7 +43,7 @@ Describe 'verify-red-proof.sh'
     # src.txt unchanged) -- mirrors PR #1247's da2d7820 (fix) + 501deb92 (follow-up).
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof3.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     printf '%s\n' "$1" > "$repo/src.txt"
     printf 'grep -q GOOD src.txt\n' > "$repo/test_pin.sh"
     gitc add -A
@@ -62,7 +62,7 @@ Describe 'verify-red-proof.sh'
     # HEAD~1 tracks old.txt; HEAD deletes it. $1 is the test command.
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-del.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     echo OLD > "$repo/old.txt"
     printf '%s\n' "$1" > "$repo/test_pin.sh"
     gitc add -A
@@ -75,7 +75,7 @@ Describe 'verify-red-proof.sh'
   make_deleted_directory_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-del-dir.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     mkdir "$repo/gone"
     echo OLD > "$repo/gone/a.txt"
     printf 'test ! -e gone\n' > "$repo/test_pin.sh"
@@ -89,7 +89,7 @@ Describe 'verify-red-proof.sh'
   make_deleted_directory_with_red_descendants_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-del-dir-desc.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     mkdir "$repo/gone"
     echo OLD > "$repo/gone/a.txt"
     printf 'gone/ignored.txt\n' > "$repo/.gitignore"
@@ -104,7 +104,7 @@ Describe 'verify-red-proof.sh'
   make_ignored_deleted_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-ignored.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     mkdir "$repo/gone"
     echo OLD > "$repo/gone/a.txt"
     printf 'gone/ignored.txt\nunrelated/\n' > "$repo/.gitignore"
@@ -119,7 +119,7 @@ Describe 'verify-red-proof.sh'
   make_deleted_overlap_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-overlap.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     mkdir "$repo/gone"
     echo OLD > "$repo/gone/a.txt"
     printf 'test ! -e gone/a.txt\n' > "$repo/test_pin.sh"
@@ -133,7 +133,7 @@ Describe 'verify-red-proof.sh'
   make_deleted_directory_with_nested_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-nested.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     mkdir "$repo/gone"
     echo OLD > "$repo/gone/a.txt"
     printf 'if test -e gone/a.txt; then\n  mkdir -p gone/nested\n  git -C gone/nested init -q\n  %s\nelse\n  test ! -e gone\nfi\n' "$1" > "$repo/test_pin.sh"
@@ -147,7 +147,7 @@ Describe 'verify-red-proof.sh'
   make_mixed_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-mixed.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     echo BAD > "$repo/src.txt"
     echo OLD > "$repo/old.txt"
     printf 'grep -q GOOD src.txt && test ! -e old.txt\n' > "$repo/test_pin.sh"
@@ -161,7 +161,7 @@ Describe 'verify-red-proof.sh'
   make_added_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/redproof-add.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     printf 'test -e added.txt\n' > "$repo/test_pin.sh"
     gitc add -A
     gitc commit -qm v1

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -68,10 +68,10 @@ Describe 'work-branch.sh --worktree anchors at the primary checkout'
     fixture=$(mktemp -d "${TMPDIR:-/tmp}/wb_spec.XXXXXX") || return 1
     fixture=$(cd "$fixture" && pwd -P) || return 1
     primary="$fixture/primary"
-    git init -q "$primary" &&
-      git -C "$primary" -c user.email=t@t -c user.name=t -c commit.gpgsign=false \
+    git_fixture init -q "$primary" &&
+      git_fixture -C "$primary" -c user.email=t@t -c user.name=t -c commit.gpgsign=false \
         commit -q --allow-empty -m init &&
-      git -C "$primary" worktree add -q --detach "$fixture/session" >/dev/null 2>&1
+      git_fixture -C "$primary" worktree add -q --detach "$fixture/session" >/dev/null 2>&1
   }
   cleanup() { rm -rf "$fixture"; }
   BeforeEach 'setup'
@@ -115,9 +115,10 @@ Describe 'work-branch.sh --worktree anchors at the primary checkout'
   End
 
   It 'refuses a --separate-git-dir layout instead of anchoring outside the checkout'
-    When run sh -c 'git init -q --separate-git-dir "$1/gitmeta" "$1/sep" &&
-      git -C "$1/sep" -c user.email=t@t -c user.name=t -c commit.gpgsign=false commit -q --allow-empty -m init &&
-      cd "$1/sep" && exec sh "$2" issue 11 tld --worktree --base HEAD' _ "$fixture" "$script_abs"
+    git_fixture init -q --separate-git-dir "$fixture/gitmeta" "$fixture/sep" &&
+      git_fixture -C "$fixture/sep" -c user.email=t@t -c user.name=t -c commit.gpgsign=false \
+        commit -q --allow-empty -m init
+    When run sh -c 'cd "$1/sep" && exec sh "$2" issue 11 tld --worktree --base HEAD' _ "$fixture" "$script_abs"
     The status should equal 2
     The stderr should include 'separate-git-dir'
   End

--- a/tests/shell/composer_cloud_install_spec.sh
+++ b/tests/shell/composer_cloud_install_spec.sh
@@ -104,10 +104,10 @@ EOF
     # Turn the WORK fixture dir into a git repo with both files committed, so
     # the guard's HEAD comparison has a baseline to diff against.
     commit_baseline() {
-      git -C "$WORK" init -q
-      git -C "$WORK" -c user.name=spec -c user.email=spec@example.invalid \
+      git_fixture -C "$WORK" init -q
+      git_fixture -C "$WORK" -c user.name=spec -c user.email=spec@example.invalid \
         add composer.json composer.lock
-      git -C "$WORK" -c user.name=spec -c user.email=spec@example.invalid \
+      git_fixture -C "$WORK" -c user.name=spec -c user.email=spec@example.invalid \
         commit -qm baseline
     }
 
@@ -130,7 +130,7 @@ EOF
     It 'refuses STAGED composer.lock edits'
       commit_baseline
       echo '{"packages": []}' > "${WORK}/composer.lock"
-      git -C "$WORK" add composer.lock
+      git_fixture -C "$WORK" add composer.lock
       When call refuse_if_composer_files_dirty "$WORK"
       The status should be failure
       The stderr should include 'uncommitted changes'

--- a/tests/shell/git_env_scrub_guard_marker_spec.sh
+++ b/tests/shell/git_env_scrub_guard_marker_spec.sh
@@ -1,0 +1,24 @@
+#shellcheck shell=sh
+
+Describe 'git-env-scrub-guard marker comments'
+  GUARD="${PFB_ROOT}/scripts/git-env-scrub-guard.sh"
+
+  setup_root() {
+    root="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/guardmarker.XXXXXX")"
+    mkdir -p "${root}/scripts/lib" "${root}/tests/shell"
+    printf '#!/bin/sh\npfb_scrub_git_env() { :; }\n' > "${root}/scripts/lib/git-env-scrub.sh"
+  }
+  cleanup_root() { rm -rf "$root"; }
+
+  BeforeEach 'setup_root'
+  AfterEach 'cleanup_root'
+
+  It 'does not accept marker text inside an inert quoted string'
+    printf '%s\n' 'scrub_git_env' \
+      "printf '%s' '# git-env-scrub-guard: fake'; git status" \
+      > "${root}/tests/shell/quoted_marker_spec.sh"
+    When run sh "$GUARD" "$root"
+    The status should be failure
+    The error should include 'quoted_marker_spec.sh'
+  End
+End

--- a/tests/shell/git_env_scrub_guard_supplemental_spec.sh
+++ b/tests/shell/git_env_scrub_guard_supplemental_spec.sh
@@ -1,0 +1,147 @@
+#shellcheck shell=sh
+# Focused lexical guard coverage: each command form gets its own fixture so a
+# dropped scanner branch cannot hide behind another positive case.
+
+Describe 'git-env-scrub-guard raw Git command scanner'
+  GUARD="${PFB_ROOT}/scripts/git-env-scrub-guard.sh"
+
+  setup_root() {
+    root="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/guardsupp.XXXXXX")"
+    mkdir -p "${root}/scripts/lib" "${root}/tests/shell"
+    printf '#!/bin/sh\npfb_scrub_git_env() { :; }\n' > "${root}/scripts/lib/git-env-scrub.sh"
+  }
+  cleanup_root() { rm -rf "$root"; }
+  write_case() {
+    case_name="$1"
+    case_body="$2"
+    printf '%s\n%s\n' 'scrub_git_env' "$case_body" > "${root}/tests/shell/${case_name}_spec.sh"
+  }
+  raw_case() {
+    write_case "$1" "$2"
+    sh "$GUARD" "$root"
+  }
+  marker_case() {
+    write_case "$1" "$2"
+    sh "$GUARD" "$root"
+  }
+
+  BeforeEach 'setup_root'
+  AfterEach 'cleanup_root'
+
+  It 'detects a raw Git command at the start of a line'
+    When call raw_case start 'git status'
+    The status should be failure
+    The error should include 'start_spec.sh'
+  End
+
+  It 'detects a raw Git command after indentation'
+    When call raw_case indent '  git status'
+    The status should be failure
+    The error should include 'indent_spec.sh'
+  End
+
+  It 'detects a raw Git command after &&'
+    When call raw_case and 'true && git status'
+    The status should be failure
+    The error should include 'and_spec.sh'
+  End
+
+  It 'detects a raw Git command after ;'
+    When call raw_case semicolon 'true; git status'
+    The status should be failure
+    The error should include 'semicolon_spec.sh'
+  End
+
+  It 'detects a raw Git command after !'
+    When call raw_case bang '! git status'
+    The status should be failure
+    The error should include 'bang_spec.sh'
+  End
+
+  It 'detects an unquoted command substitution'
+    When call raw_case substitution 'value=$(git status)'
+    The status should be failure
+    The error should include 'substitution_spec.sh'
+  End
+
+  It 'detects an active command substitution inside double quotes'
+    When call raw_case quoted_substitution 'value="$(git status)"'
+    The status should be failure
+    The error should include 'quoted_substitution_spec.sh'
+  End
+
+  It 'detects an env-prefixed raw Git command'
+    When call raw_case env_prefix 'env -u FOO git status'
+    The status should be failure
+    The error should include 'env_prefix_spec.sh'
+  End
+
+  It 'detects an assignment-prefixed raw Git command'
+    When call raw_case assignment_prefix 'FOO=bar git status'
+    The status should be failure
+    The error should include 'assignment_prefix_spec.sh'
+  End
+
+  It 'detects a literal tab between Git and its subcommand'
+    tab_case="$(printf 'git\tstatus')"
+    When call raw_case literal_tab "$tab_case"
+    The status should be failure
+    The error should include 'literal_tab_spec.sh'
+  End
+
+  It 'detects repeated spaces between Git and its subcommand'
+    When call raw_case repeated_spaces 'git  status'
+    The status should be failure
+    The error should include 'repeated_spaces_spec.sh'
+  End
+
+  It 'does not classify gitc as the Git command'
+    When call raw_case gitc 'gitc status'
+    The status should be success
+    The output should include 'git-env-scrub-guard: clean'
+  End
+
+  It 'does not classify comments'
+    When call raw_case comments '# git status'
+    The status should be success
+    The output should include 'git-env-scrub-guard: clean'
+  End
+
+  It 'does not classify prose or titles'
+    When call raw_case prose "printf '%s' 'a title mentions git status'"
+    The status should be success
+    The output should include 'git-env-scrub-guard: clean'
+  End
+
+  It 'does not classify quoted inert fixture text'
+    When call raw_case inert "printf '%s' '{\"command\":\"git status\"}'"
+    The status should be success
+    The output should include 'git-env-scrub-guard: clean'
+  End
+
+  It 'accepts a same-line marker with a non-empty reason'
+    When call marker_case good_marker 'git status # git-env-scrub-guard: hook under test'
+    The status should be success
+    The output should include 'git-env-scrub-guard: clean'
+  End
+
+  It 'rejects an empty same-line marker'
+    When call marker_case empty_marker 'git status # git-env-scrub-guard:'
+    The status should be failure
+    The error should include 'empty_marker_spec.sh'
+  End
+
+  It 'rejects a marker placed on the prior line'
+    prior_marker="$(printf '%s\n%s' '# git-env-scrub-guard: prior reason' 'git status')"
+    When call marker_case prior_marker "$prior_marker"
+    The status should be failure
+    The error should include 'prior_marker_spec.sh'
+  End
+
+  It 'detects a raw Git command after a 10k-character prefix'
+    oversized="$(awk 'BEGIN { for (i = 0; i < 10000; i++) printf "x" }')"
+    When call raw_case oversized "$oversized; git status"
+    The status should be failure
+    The error should include 'oversized_spec.sh'
+  End
+End

--- a/tests/shell/git_env_scrub_spec.sh
+++ b/tests/shell/git_env_scrub_spec.sh
@@ -123,6 +123,93 @@ Describe 'scripts/git-env-scrub-guard.sh'
             The error should include 'violations found'
         End
 
+        It 'fails when a spec calls raw git setup without the fixture helper'
+            setup_violating_spec() {
+                WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/guardspec.XXXXXX")"
+                mkdir -p "${WORK}/scripts/lib" "${WORK}/tests/shell"
+                printf '#!/bin/sh\npfb_scrub_git_env() { unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_OBJECT_DIRECTORY GIT_COMMON_DIR; }\n' \
+                    > "${WORK}/scripts/lib/git-env-scrub.sh"
+                printf '#!/bin/sh\nDescribe foo\n  It bar\n    scrub_git_env\n    git init /tmp/x 2>/dev/null || true\n  End\nEnd\n' \
+                    > "${WORK}/tests/shell/bad_spec.sh"
+                sh "$GUARD" "$WORK"
+            }
+            When run setup_violating_spec
+            The status should be failure
+            The error should include 'raw git setup without fixture helper'
+        End
+
+        It 'scans direct git command positions without matching prose or quoted fixtures'
+            setup_hostile_specs() {
+                WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/guardspec.XXXXXX")"
+                mkdir -p "${WORK}/scripts/lib" "${WORK}/tests/shell"
+                printf '#!/bin/sh\npfb_scrub_git_env() { :; }\n' \
+                    > "${WORK}/scripts/lib/git-env-scrub.sh"
+                printf '%s\n' \
+                    'scrub_git_env' \
+                    '# comment: git status' \
+                    "It 'title mentions git status'" \
+                    "printf '%s' 'git status'" \
+                    'gitc status' \
+                    '    git init' \
+                    'true && git status' \
+                    'true; git status' \
+                    '! git status' \
+                    'value=$(git status)' \
+                    'git  status' \
+                    "git$(printf '\t')status" \
+                    'printf "%s" '\''$(git status)'\''' \
+                    > "${WORK}/tests/shell/hostile_spec.sh"
+                sh "$GUARD" "$WORK"
+            }
+            When run setup_hostile_specs
+            The status should be failure
+            The error should include 'hostile_spec.sh'
+            The error should include 'raw git setup without fixture helper'
+        End
+
+        It 'requires a same-line non-empty reason for a raw git escape'
+            setup_marker_specs() {
+                WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/guardspec.XXXXXX")"
+                mkdir -p "${WORK}/scripts/lib" "${WORK}/tests/shell"
+                printf '#!/bin/sh\npfb_scrub_git_env() { :; }\n' \
+                    > "${WORK}/scripts/lib/git-env-scrub.sh"
+                printf '%s\n' \
+                    'scrub_git_env' \
+                    'git status # git-env-scrub-guard: allow hook under test' \
+                    > "${WORK}/tests/shell/good_marker_spec.sh"
+                printf '%s\n' \
+                    'git status # git-env-scrub-guard:' \
+                    > "${WORK}/tests/shell/empty_marker_spec.sh"
+                printf '%s\n%s\n%s\n' \
+                    'scrub_git_env' \
+                    '# git-env-scrub-guard: allow prior line is not valid' \
+                    'git status' \
+                    > "${WORK}/tests/shell/prior_marker_spec.sh"
+                sh "$GUARD" "$WORK"
+            }
+            When run setup_marker_specs
+            The status should be failure
+            The error should include 'empty_marker_spec.sh'
+            The error should include 'prior_marker_spec.sh'
+            The error should not include 'good_marker_spec.sh'
+        End
+
+        It 'does not truncate oversized lines before scanning command separators'
+            setup_oversized_spec() {
+                WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/guardspec.XXXXXX")"
+                mkdir -p "${WORK}/scripts/lib" "${WORK}/tests/shell"
+                printf '#!/bin/sh\npfb_scrub_git_env() { :; }\n' \
+                    > "${WORK}/scripts/lib/git-env-scrub.sh"
+                printf '%s\n%s; git status\n' 'scrub_git_env' \
+                    "$(awk 'BEGIN { for (i = 0; i < 10000; i++) printf "x" }')" \
+                    > "${WORK}/tests/shell/oversized_spec.sh"
+                sh "$GUARD" "$WORK"
+            }
+            When run setup_oversized_spec
+            The status should be failure
+            The error should include 'oversized_spec.sh'
+        End
+
     End
 
 End

--- a/tests/shell/git_fixture_manifest_spec.sh
+++ b/tests/shell/git_fixture_manifest_spec.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# shellcheck shell=sh
+
+Describe 'git fixture sweep manifest'
+  GUARD="${PFB_ROOT}/scripts/git-env-scrub-guard.sh"
+  SWEPT_SPECS='agent_run_gates_spec.sh
+agent_verify_red_proof_spec.sh
+agent_work_branch_spec.sh
+composer_cloud_install_spec.sh
+git_no_docs_spec.sh
+githooks_pre_push_lease_spec.sh
+githooks_pre_push_tag_scheme_spec.sh
+githooks_prepare_commit_msg_guard_spec.sh
+pfblockerng_truncate_survival_spec.sh
+precommit_composer_vendor_spec.sh
+read_version_matrix_test_spec.sh
+release_ci_gate_spec.sh
+session_branch_sync_spec.sh
+sparse_clone_ports_spec.sh'
+
+  setup_root() {
+    root="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/guardmanifest.XXXXXX")"
+    mkdir -p "${root}/scripts/lib" "${root}/tests/shell"
+    cp "${PFB_ROOT}/scripts/lib/git-env-scrub.sh" "${root}/scripts/lib/"
+    for spec in $SWEPT_SPECS; do
+      cp "${PFB_ROOT}/tests/shell/${spec}" "${root}/tests/shell/"
+    done
+  }
+  cleanup_root() { rm -rf "$root"; }
+
+  assert_each_fixture_pin_is_required() {
+    sh "$GUARD" "$root" >/dev/null 2>&1 || return 1
+    for spec in $SWEPT_SPECS; do
+      path="${root}/tests/shell/${spec}"
+      awk '
+        !changed && /git_fixture/ {
+          sub(/git_fixture/, "git")
+          changed=1
+        }
+        { print }
+      ' "$path" > "${path}.tmp" || return 1
+      mv "${path}.tmp" "$path"
+      if sh "$GUARD" "$root" >/dev/null 2>&1; then
+        printf 'guard missed removed fixture pin: %s\n' "$spec" >&2
+        return 1
+      fi
+      cp "${PFB_ROOT}/tests/shell/${spec}" "$path"
+    done
+  }
+
+  BeforeEach 'setup_root'
+  AfterEach 'cleanup_root'
+
+  It 'fails after the first fixture helper is removed from every swept spec'
+    When call assert_each_fixture_pin_is_required
+    The status should be success
+  End
+End

--- a/tests/shell/git_no_docs_spec.sh
+++ b/tests/shell/git_no_docs_spec.sh
@@ -21,15 +21,15 @@ Describe 'git-no-docs.sh'
   setup() {
     scrub_git_env
     repo=$(mktemp -d)
-    git -C "$repo" init -q
-    git -C "$repo" config user.name t
-    git -C "$repo" config user.email t@t
+    git_fixture -C "$repo" init -q
+    git_fixture -C "$repo" config user.name t
+    git_fixture -C "$repo" config user.email t@t
     printf '%s\n' 'docsdir/** linguist-documentation' > "$repo/.gitattributes"
     mkdir -p "$repo/docsdir"
     printf 'doc line\n' > "$repo/docsdir/notes.md"
     printf 'code line\n' > "$repo/code.sh"
-    git -C "$repo" add -A
-    git -C "$repo" commit -qm 'mixed commit'
+    git_fixture -C "$repo" add -A
+    git_fixture -C "$repo" commit -qm 'mixed commit'
   }
   cleanup() {
     rm -rf "$repo"

--- a/tests/shell/githooks_pre_push_lease_spec.sh
+++ b/tests/shell/githooks_pre_push_lease_spec.sh
@@ -21,24 +21,24 @@ Describe 'pre-push agent lease-by-effect guard (issue #1307)'
   setup() {
     scrub_git_env
     base="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/prepushlease.XXXXXX")"
-    git init -q --bare "${base}/remote.git"
-    git clone -q "${base}/remote.git" "${base}/A" 2>/dev/null
-    git -C "${base}/A" config user.email a@example.com
-    git -C "${base}/A" config user.name A
-    git -C "${base}/A" config commit.gpgsign false
-    ( cd "${base}/A" && git checkout -q -b devel && echo one > f \
-        && git add f && git commit -q -m c1 && git push -q origin devel )
-    git clone -q "${base}/remote.git" "${base}/B" 2>/dev/null
-    git -C "${base}/B" config user.email b@example.com
-    git -C "${base}/B" config user.name B
-    git -C "${base}/B" config commit.gpgsign false
-    ( cd "${base}/B" && git checkout -q devel && echo two >> f \
-        && git add f && git commit -q -m c2-other && git push -q origin devel )
+    git_fixture init -q --bare "${base}/remote.git"
+    git_fixture clone -q "${base}/remote.git" "${base}/A" 2>/dev/null
+    git_fixture -C "${base}/A" config user.email a@example.com
+    git_fixture -C "${base}/A" config user.name A
+    git_fixture -C "${base}/A" config commit.gpgsign false
+    ( cd "${base}/A" && git_fixture checkout -q -b devel && echo one > f \
+        && git_fixture add f && git_fixture commit -q -m c1 && git_fixture push -q origin devel )
+    git_fixture clone -q "${base}/remote.git" "${base}/B" 2>/dev/null
+    git_fixture -C "${base}/B" config user.email b@example.com
+    git_fixture -C "${base}/B" config user.name B
+    git_fixture -C "${base}/B" config commit.gpgsign false
+    ( cd "${base}/B" && git_fixture checkout -q devel && echo two >> f \
+        && git_fixture add f && git_fixture commit -q -m c2-other && git_fixture push -q origin devel )
     # A now diverges; its tracking ref still holds c1 while the remote is at c2.
-    ( cd "${base}/A" && git commit -q --amend -m c1-amended )
-    a_local="$(git -C "${base}/A" rev-parse devel)"
-    a_tracking="$(git -C "${base}/A" rev-parse refs/remotes/origin/devel)"
-    remote_tip="$(git -C "${base}/remote.git" rev-parse refs/heads/devel)"
+    ( cd "${base}/A" && git_fixture commit -q --amend -m c1-amended )
+    a_local="$(git_fixture -C "${base}/A" rev-parse devel)"
+    a_tracking="$(git_fixture -C "${base}/A" rev-parse refs/remotes/origin/devel)"
+    remote_tip="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/devel)"
   }
 
   cleanup() {
@@ -49,7 +49,7 @@ Describe 'pre-push agent lease-by-effect guard (issue #1307)'
   AfterEach 'cleanup'
 
   remote_tip_now() {
-    git -C "${base}/remote.git" rev-parse refs/heads/devel
+    git_fixture -C "${base}/remote.git" rev-parse refs/heads/devel
   }
 
   # Feed one stdin line to the hook from inside clone A, agent env explicit
@@ -77,9 +77,9 @@ Describe 'pre-push agent lease-by-effect guard (issue #1307)'
   End
 
   It 'allows the same rewrite once the tracking ref matches the advertised remote'
-    git -C "${base}/A" fetch -q origin
+    git_fixture -C "${base}/A" fetch -q origin
     fresh_tracking() {
-      tracking="$(git -C "${base}/A" rev-parse refs/remotes/origin/devel)"
+      tracking="$(git_fixture -C "${base}/A" rev-parse refs/remotes/origin/devel)"
       [ "$tracking" = "$remote_tip" ] || { echo "tracking=$tracking != remote=$remote_tip" >&2; return 1; }
       agent_hook "refs/heads/devel $a_local refs/heads/devel $remote_tip"
     }
@@ -96,11 +96,11 @@ Describe 'pre-push agent lease-by-effect guard (issue #1307)'
 
   It 'allows an agent fast-forward push with a stale tracking ref'
     ff_push() {
-      cd "${base}/A" && git fetch -q origin \
-        && git update-ref refs/remotes/origin/devel "$a_tracking" \
-        && git checkout -q -B devel "$remote_tip" && echo three >> f \
-        && git add f && git commit -q -m c3 \
-        && agent_hook "refs/heads/devel $(git rev-parse devel) refs/heads/devel $remote_tip"
+      cd "${base}/A" && git_fixture fetch -q origin \
+        && git_fixture update-ref refs/remotes/origin/devel "$a_tracking" \
+        && git_fixture checkout -q -B devel "$remote_tip" && echo three >> f \
+        && git_fixture add f && git_fixture commit -q -m c3 \
+        && agent_hook "refs/heads/devel $(git_fixture rev-parse devel) refs/heads/devel $remote_tip"
     }
     When run ff_push
     The status should equal 0
@@ -148,9 +148,9 @@ Describe 'pre-push agent lease-by-effect guard (issue #1307)'
   It 'blocks a real agent force-push and leaves the remote tip untouched'
     real_force() {
       cd "${base}/A" \
-        && git config core.hooksPath "${PFB_ROOT}/.githooks" \
+        && git_fixture config core.hooksPath "${PFB_ROOT}/.githooks" \
         && [ "$(remote_tip_now)" = "$remote_tip" ] \
-        && env -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID CLAUDECODE=1 git push --force origin devel
+        && env -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID CLAUDECODE=1 git push --force origin devel # git-env-scrub-guard: allow hook-under-test push
     }
     When run real_force
     The status should not equal 0
@@ -161,9 +161,9 @@ Describe 'pre-push agent lease-by-effect guard (issue #1307)'
   It 'blocks the same real force-push for a Codex agent marker'
     real_force_codex() {
       cd "${base}/A" \
-        && git config core.hooksPath "${PFB_ROOT}/.githooks" \
+        && git_fixture config core.hooksPath "${PFB_ROOT}/.githooks" \
         && [ "$(remote_tip_now)" = "$remote_tip" ] \
-        && env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL CODEX_THREAD_ID=codex-test git push --force origin devel
+        && env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL CODEX_THREAD_ID=codex-test git push --force origin devel # git-env-scrub-guard: allow hook-under-test push
     }
     When run real_force_codex
     The status should not equal 0
@@ -174,9 +174,9 @@ Describe 'pre-push agent lease-by-effect guard (issue #1307)'
   It 'lands the same real force-push for a human (control)'
     real_force_human() {
       cd "${base}/A" \
-        && git config core.hooksPath "${PFB_ROOT}/.githooks" \
+        && git_fixture config core.hooksPath "${PFB_ROOT}/.githooks" \
         && [ "$(remote_tip_now)" = "$remote_tip" ] \
-        && env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID git push --force origin devel
+        && env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID git push --force origin devel # git-env-scrub-guard: allow hook-under-test push
     }
     When run real_force_human
     The status should equal 0

--- a/tests/shell/githooks_pre_push_tag_scheme_spec.sh
+++ b/tests/shell/githooks_pre_push_tag_scheme_spec.sh
@@ -10,12 +10,12 @@ Describe 'pre-push tag-scheme loop still consumes the update list (issue #1307)'
   setup() {
     scrub_git_env
     base="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/prepushtag.XXXXXX")"
-    git init -q -b devel "${base}/repo"
-    git -C "${base}/repo" config user.email t@example.com
-    git -C "${base}/repo" config user.name T
-    git -C "${base}/repo" config commit.gpgsign false
-    ( cd "${base}/repo" && echo one > f && git add f && git commit -q -m c1 )
-    sha="$(git -C "${base}/repo" rev-parse HEAD)"
+    git_fixture init -q -b devel "${base}/repo"
+    git_fixture -C "${base}/repo" config user.email t@example.com
+    git_fixture -C "${base}/repo" config user.name T
+    git_fixture -C "${base}/repo" config commit.gpgsign false
+    ( cd "${base}/repo" && echo one > f && git_fixture add f && git_fixture commit -q -m c1 )
+    sha="$(git_fixture -C "${base}/repo" rev-parse HEAD)"
   }
 
   cleanup() {

--- a/tests/shell/githooks_prepare_commit_msg_guard_spec.sh
+++ b/tests/shell/githooks_prepare_commit_msg_guard_spec.sh
@@ -18,13 +18,13 @@ Describe 'prepare-commit-msg agent worktree guard (issue #1262)'
     base="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pcmguard.XXXXXX")"
     primary="${base}/primary"
     wt="${base}/wt"
-    git init -q -b devel "$primary"
-    git -C "$primary" config user.email human@example.com
-    git -C "$primary" config user.name Human
-    git -C "$primary" config commit.gpgsign false
-    ( cd "$primary" && echo seed > seed.txt && git add seed.txt \
-        && git commit -q -m seed )
-    git -C "$primary" worktree add -q "$wt" -b spec-branch
+    git_fixture init -q -b devel "$primary"
+    git_fixture -C "$primary" config user.email human@example.com
+    git_fixture -C "$primary" config user.name Human
+    git_fixture -C "$primary" config commit.gpgsign false
+    ( cd "$primary" && echo seed > seed.txt && git_fixture add seed.txt \
+        && git_fixture commit -q -m seed )
+    git_fixture -C "$primary" worktree add -q "$wt" -b spec-branch
     printf '%s\n' 'msg' > "${primary}/.git/PCM_MSG"
     printf '%s\n' 'msg' > "${primary}/.git/worktrees/wt/PCM_MSG"
   }
@@ -37,7 +37,7 @@ Describe 'prepare-commit-msg agent worktree guard (issue #1262)'
   AfterEach 'cleanup'
 
   commit_count() {
-    git -C "$primary" rev-list --count HEAD
+    git_fixture -C "$primary" rev-list --count HEAD
   }
 
   # Direct hook invocations: cwd selects primary vs linked worktree; env is
@@ -81,16 +81,16 @@ Describe 'prepare-commit-msg agent worktree guard (issue #1262)'
   End
 
   It 'does not apply a legacy Claude coauthor identity to a Codex commit'
-    git -C "$primary" config coauthor.name Claude
-    git -C "$primary" config coauthor.email noreply@anthropic.com
+    git_fixture -C "$primary" config coauthor.name Claude
+    git_fixture -C "$primary" config coauthor.email noreply@anthropic.com
     When run codex_hook_in "$wt" ../primary/.git/worktrees/wt/PCM_MSG
     The status should equal 0
     The contents of file "${primary}/.git/worktrees/wt/PCM_MSG" should not include 'noreply@anthropic.com'
   End
 
   It 'keeps the legacy coauthor identity for a Claude commit'
-    git -C "$primary" config coauthor.name Claude
-    git -C "$primary" config coauthor.email noreply@anthropic.com
+    git_fixture -C "$primary" config coauthor.name Claude
+    git_fixture -C "$primary" config coauthor.email noreply@anthropic.com
     When run agent_hook_in "$wt" ../primary/.git/worktrees/wt/PCM_MSG
     The status should equal 0
     The contents of file "${primary}/.git/worktrees/wt/PCM_MSG" should include 'Co-Authored-By: Claude <noreply@anthropic.com>'
@@ -103,7 +103,7 @@ Describe 'prepare-commit-msg agent worktree guard (issue #1262)'
   End
 
   It 'passes an agent commit when the valve marks the checkout agent-dedicated'
-    git -C "$primary" config pfblockerng.allowprimarycommit true
+    git_fixture -C "$primary" config pfblockerng.allowprimarycommit true
     When run agent_hook_in "$primary" .git/PCM_MSG
     The status should equal 0
     The stderr should equal ''
@@ -125,9 +125,9 @@ Describe 'prepare-commit-msg agent worktree guard (issue #1262)'
   It 'aborts a verify-skipping agent commit in the primary checkout'
     real_commit() {
       cd "$primary" \
-        && git config core.hooksPath "${PFB_ROOT}/.githooks" \
-        && echo change >> seed.txt && git add seed.txt \
-        && env -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID CLAUDECODE=1 git commit -n -m blocked
+        && git_fixture config core.hooksPath "${PFB_ROOT}/.githooks" \
+        && echo change >> seed.txt && git_fixture add seed.txt \
+        && env -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID CLAUDECODE=1 git commit -n -m blocked # git-env-scrub-guard: allow hook-under-test commit
     }
     When run real_commit
     The status should not equal 0
@@ -138,9 +138,9 @@ Describe 'prepare-commit-msg agent worktree guard (issue #1262)'
   It 'lands the same verify-skipping commit for a human (control)'
     real_commit_human() {
       cd "$primary" \
-        && git config core.hooksPath "${PFB_ROOT}/.githooks" \
-        && echo change >> seed.txt && git add seed.txt \
-        && env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID git commit -n -m allowed
+        && git_fixture config core.hooksPath "${PFB_ROOT}/.githooks" \
+        && echo change >> seed.txt && git_fixture add seed.txt \
+        && env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID git commit -n -m allowed # git-env-scrub-guard: allow hook-under-test commit
     }
     When run real_commit_human
     The status should equal 0

--- a/tests/shell/pfblockerng_truncate_survival_spec.sh
+++ b/tests/shell/pfblockerng_truncate_survival_spec.sh
@@ -21,7 +21,7 @@
 # retirement). Scoped to the whole of src/ (not just pfblockerng/) so the guard also
 # covers any future shell source elsewhere under src/.
 _trunc_legacy_hits() {
-	git -C "${1:-${PFB_ROOT}}" grep -nE '(^|[;&|({[:space:]]):[[:space:]]*>' -- \
+	git_fixture -C "${1:-${PFB_ROOT}}" grep -nE '(^|[;&|({[:space:]]):[[:space:]]*>' -- \
 		src scripts tests
 }
 
@@ -34,7 +34,7 @@ _trunc_legacy_hits() {
 # planted-violation fixture: a clean-tree assertion alone passes just as well
 # with a broken pattern as with a working one.
 _colon_loop_hits() {
-	git -C "${1:-${PFB_ROOT}}" grep -nE '(while|until)[[:space:]]+:' -- \
+	git_fixture -C "${1:-${PFB_ROOT}}" grep -nE '(while|until)[[:space:]]+:' -- \
 		src scripts tests
 }
 
@@ -400,8 +400,8 @@ Describe 'structural retirement guard: no ":" special-builtin idioms remain (iss
     # itself become a hit for the guards it exercises.
     printf '#!/bin/sh\n%s > "$1"\n' ':' > "${fixture}/src/truncate.sh"
     printf '#!/bin/sh\nwhile %s; do sleep 1; done\n' ':' > "${fixture}/scripts/loop.sh"
-    git -C "${fixture}" init -q
-    git -C "${fixture}" add -A
+    git_fixture -C "${fixture}" init -q
+    git_fixture -C "${fixture}" add -A
   }
   drop_violations() { rm -rf "$fixture"; }
 

--- a/tests/shell/precommit_composer_vendor_spec.sh
+++ b/tests/shell/precommit_composer_vendor_spec.sh
@@ -2,11 +2,11 @@
 # .githooks/pre-commit Composer vendor guard: a failed guard blocks Composer tools.
 
 Describe '.githooks/pre-commit Composer vendor guard'
-  gitc() { git -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+  gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
   make_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitphp.XXXXXX")"
-    git -C "$repo" init -q
+    git_fixture -C "$repo" init -q
     gitc config commit.gpgsign false
     mkdir -p "$repo/.githooks" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"

--- a/tests/shell/read_version_matrix_test_spec.sh
+++ b/tests/shell/read_version_matrix_test_spec.sh
@@ -27,12 +27,12 @@ Describe 'read-version-matrix.sh derived test matrices'
       # `commit -qm fixture` would otherwise land on the live branch (resetting
       # user.* + polluting history). Mirrors tests/test_read_version_matrix.py.
       scrub_git_env
-      git init -q
-      git config user.email ci@example.invalid
-      git config user.name CI
+      git_fixture init -q
+      git_fixture config user.email ci@example.invalid
+      git_fixture config user.name CI
       printf '%s\n' "$_mm_json" > supported-versions.json
-      git add supported-versions.json
-      git -c commit.gpgsign=false commit -qm fixture
+      git_fixture add supported-versions.json
+      git_fixture -c commit.gpgsign=false commit -qm fixture
     )
     printf '%s' "$_mm_repo"
   }

--- a/tests/shell/release_ci_gate_spec.sh
+++ b/tests/shell/release_ci_gate_spec.sh
@@ -54,12 +54,12 @@ EOF
 
     # A 2-commit repo: ancestor then tip (first-parent walk = tip, ancestor).
     repo="${work}/repo"
-    git init -q -b main "$repo"
+    git_fixture init -q -b main "$repo"
     ( cd "$repo" \
-      && git -c user.name=t -c user.email=t@t commit -q --allow-empty -m ancestor \
-      && git -c user.name=t -c user.email=t@t commit -q --allow-empty -m tip )
-    ancestor="$(git -C "$repo" rev-parse HEAD~1)"
-    tip="$(git -C "$repo" rev-parse HEAD)"
+      && git_fixture -c user.name=t -c user.email=t@t commit -q --allow-empty -m ancestor \
+      && git_fixture -c user.name=t -c user.email=t@t commit -q --allow-empty -m tip )
+    ancestor="$(git_fixture -C "$repo" rev-parse HEAD~1)"
+    tip="$(git_fixture -C "$repo" rev-parse HEAD)"
   }
   cleanup() { rm -rf "$work"; }
   Before 'setup'
@@ -75,13 +75,13 @@ EOF
     message="$1"
     mode="$2"
     shift 2
-    blob="$(printf '%s\n' "$message" | git -C "$repo" hash-object -w --stdin)"
+    blob="$(printf '%s\n' "$message" | git_fixture -C "$repo" hash-object -w --stdin)"
     for path do
       printf '%s %s\t%s\0' "$mode" "$blob" "$path" |
-        git -C "$repo" update-index -z --index-info
+        git_fixture -C "$repo" update-index -z --index-info
     done
-    git -C "$repo" -c user.name=t -c user.email=t@t commit -q -m "$message"
-    tip="$(git -C "$repo" rev-parse HEAD)"
+    git_fixture -C "$repo" -c user.name=t -c user.email=t@t commit -q -m "$message"
+    tip="$(git_fixture -C "$repo" rev-parse HEAD)"
   }
   commit_paths() {
     message="$1"
@@ -89,8 +89,8 @@ EOF
     commit_index_paths "$message" 100644 "$@"
   }
   commit_empty() {
-    git -C "$repo" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "$1"
-    tip="$(git -C "$repo" rev-parse HEAD)"
+    git_fixture -C "$repo" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "$1"
+    tip="$(git_fixture -C "$repo" rev-parse HEAD)"
   }
   run_gate() {
     ( cd "$repo" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
@@ -276,13 +276,13 @@ EOF
 
   It 'accepts a green check on the 20th queried commit'
     deep20="${work}/deep20"
-    git init -q -b main "$deep20"
+    git_fixture init -q -b main "$deep20"
     i=1
     while [ "$i" -le 20 ]; do
-      git -C "$deep20" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "c$i"
+      git_fixture -C "$deep20" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "c$i"
       i=$((i + 1))
     done
-    green20="$(git -C "$deep20" rev-parse HEAD~19)"
+    green20="$(git_fixture -C "$deep20" rev-parse HEAD~19)"
     payload "$green20" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
     run_gate_deep20() {
       ( cd "$deep20" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
@@ -295,13 +295,13 @@ EOF
 
   It 'rejects a green check on the 21st commit outside the query window'
     deep21="${work}/deep21"
-    git init -q -b main "$deep21"
+    git_fixture init -q -b main "$deep21"
     i=1
     while [ "$i" -le 21 ]; do
-      git -C "$deep21" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "c$i"
+      git_fixture -C "$deep21" -c user.name=t -c user.email=t@t commit -q --allow-empty -m "c$i"
       i=$((i + 1))
     done
-    green21="$(git -C "$deep21" rev-parse HEAD~20)"
+    green21="$(git_fixture -C "$deep21" rev-parse HEAD~20)"
     payload "$green21" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
     run_gate_deep21() {
       ( cd "$deep21" && PATH="${work}/bin:${PATH}" REPO="own/repo" GH_TOKEN=x \
@@ -315,28 +315,28 @@ EOF
 
   It 'walks merge commits through the first parent before accepting green'
     merge_repo="${work}/merge"
-    git init -q -b main "$merge_repo"
-    git -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q --allow-empty -m root
+    git_fixture init -q -b main "$merge_repo"
+    git_fixture -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q --allow-empty -m root
 
-    code_blob="$(printf 'unchecked code\n' | git -C "$merge_repo" hash-object -w --stdin)"
+    code_blob="$(printf 'unchecked code\n' | git_fixture -C "$merge_repo" hash-object -w --stdin)"
     printf '100644 %s\tscripts/unchecked.sh\0' "$code_blob" |
-      git -C "$merge_repo" update-index -z --index-info
-    git -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q -m code
-    code_sha="$(git -C "$merge_repo" rev-parse HEAD)"
+      git_fixture -C "$merge_repo" update-index -z --index-info
+    git_fixture -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q -m code
+    code_sha="$(git_fixture -C "$merge_repo" rev-parse HEAD)"
 
-    git -C "$merge_repo" checkout -q -b side
-    side_blob="$(printf 'side docs\n' | git -C "$merge_repo" hash-object -w --stdin)"
+    git_fixture -C "$merge_repo" checkout -q -b side
+    side_blob="$(printf 'side docs\n' | git_fixture -C "$merge_repo" hash-object -w --stdin)"
     printf '100644 %s\tdocs/side.txt\0' "$side_blob" |
-      git -C "$merge_repo" update-index -z --index-info
-    git -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q -m side-docs
-    side_sha="$(git -C "$merge_repo" rev-parse HEAD)"
+      git_fixture -C "$merge_repo" update-index -z --index-info
+    git_fixture -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q -m side-docs
+    side_sha="$(git_fixture -C "$merge_repo" rev-parse HEAD)"
 
-    git -C "$merge_repo" checkout -q main
-    main_blob="$(printf 'main docs\n' | git -C "$merge_repo" hash-object -w --stdin)"
+    git_fixture -C "$merge_repo" checkout -q main
+    main_blob="$(printf 'main docs\n' | git_fixture -C "$merge_repo" hash-object -w --stdin)"
     printf '100644 %s\tdocs/main.txt\0' "$main_blob" |
-      git -C "$merge_repo" update-index -z --index-info
-    git -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q -m main-docs
-    git -C "$merge_repo" -c user.name=t -c user.email=t@t merge -q --no-ff side -m merge
+      git_fixture -C "$merge_repo" update-index -z --index-info
+    git_fixture -C "$merge_repo" -c user.name=t -c user.email=t@t commit -q -m main-docs
+    git_fixture -C "$merge_repo" -c user.name=t -c user.email=t@t merge -q --no-ff side -m merge
 
     payload "$side_sha" '{"check_runs":[{"name":"All tests passed","started_at":"2026-01-01T00:00:00Z","completed_at":"2026-01-01T00:10:00Z","conclusion":"success"}]}'
     run_gate_merge() {

--- a/tests/shell/session_branch_sync_spec.sh
+++ b/tests/shell/session_branch_sync_spec.sh
@@ -12,44 +12,44 @@ Describe 'session-branch-sync shallow-history recovery'
     remote="$base/remote.git"
     seed="$base/seed"
     session="$base/session"
-    git init -q --bare "$remote"
-    git clone -q "$remote" "$seed" 2>/dev/null
-    git -C "$seed" config user.email seed@example.com
-    git -C "$seed" config user.name Seed
-    git -C "$seed" config commit.gpgsign false
-    git -C "$seed" checkout -q -b devel
+    git_fixture init -q --bare "$remote"
+    git_fixture clone -q "$remote" "$seed" 2>/dev/null
+    git_fixture -C "$seed" config user.email seed@example.com
+    git_fixture -C "$seed" config user.name Seed
+    git_fixture -C "$seed" config commit.gpgsign false
+    git_fixture -C "$seed" checkout -q -b devel
     i=1
     while [ "$i" -le 3 ]; do
       printf 'base-%s\n' "$i" >> "$seed/base.txt"
-      git -C "$seed" add base.txt
-      git -C "$seed" commit -q -m "base-$i"
+      git_fixture -C "$seed" add base.txt
+      git_fixture -C "$seed" commit -q -m "base-$i"
       i=$((i + 1))
     done
-    git -C "$seed" push -q origin devel
+    git_fixture -C "$seed" push -q origin devel
 
-    git clone -q --depth=2 --branch devel "file://$remote" "$session"
-    git -C "$session" config user.email agent@example.com
-    git -C "$session" config user.name Agent
-    git -C "$session" config commit.gpgsign false
-    git -C "$session" checkout -q -b topic
+    git_fixture clone -q --depth=2 --branch devel "file://$remote" "$session"
+    git_fixture -C "$session" config user.email agent@example.com
+    git_fixture -C "$session" config user.name Agent
+    git_fixture -C "$session" config commit.gpgsign false
+    git_fixture -C "$session" checkout -q -b topic
     printf '%s\n' topic > "$session/topic.txt"
-    git -C "$session" add topic.txt
-    git -C "$session" commit -q -m topic
+    git_fixture -C "$session" add topic.txt
+    git_fixture -C "$session" commit -q -m topic
 
     i=4
     while [ "$i" -le 7 ]; do
       printf 'base-%s\n' "$i" >> "$seed/base.txt"
-      git -C "$seed" add base.txt
-      git -C "$seed" commit -q -m "base-$i"
+      git_fixture -C "$seed" add base.txt
+      git_fixture -C "$seed" commit -q -m "base-$i"
       i=$((i + 1))
     done
-    git -C "$seed" push -q origin devel
-    git -C "$session" fetch -q --depth=2 origin devel
+    git_fixture -C "$seed" push -q origin devel
+    git_fixture -C "$session" fetch -q --depth=2 origin devel
 
     # origin/devel's new shallow boundary is newer than topic's base. The
     # commits exist on one real history, but this clone cannot yet see that.
-    [ "$(git -C "$session" rev-parse --is-shallow-repository)" = true ]
-    ! git -C "$session" merge-base HEAD origin/devel >/dev/null 2>&1
+    [ "$(git_fixture -C "$session" rev-parse --is-shallow-repository)" = true ]
+    ! git_fixture -C "$session" merge-base HEAD origin/devel >/dev/null 2>&1
   }
 
   cleanup() {
@@ -63,10 +63,10 @@ Describe 'session-branch-sync shallow-history recovery'
     sync_and_verify() {
       cd "$session" || return 1
       sh "$hook" \
-        && [ "$(git rev-parse --is-shallow-repository)" = false ] \
-        && git merge-base --is-ancestor origin/devel HEAD \
-        && [ "$(git rev-list --count origin/devel..HEAD)" -eq 1 ] \
-        && [ "$(git log -1 --format=%s)" = topic ]
+        && [ "$(git_fixture rev-parse --is-shallow-repository)" = false ] \
+        && git_fixture merge-base --is-ancestor origin/devel HEAD \
+        && [ "$(git_fixture rev-list --count origin/devel..HEAD)" -eq 1 ] \
+        && [ "$(git_fixture log -1 --format=%s)" = topic ]
     }
     When run sync_and_verify
     The status should equal 0
@@ -83,27 +83,27 @@ Describe 'session-branch-sync unrelated-history refusal'
     remote="$base/remote.git"
     seed="$base/seed"
     session="$base/session"
-    git init -q --bare "$remote"
-    git clone -q "$remote" "$seed" 2>/dev/null
-    git -C "$seed" config user.email seed@example.com
-    git -C "$seed" config user.name Seed
-    git -C "$seed" config commit.gpgsign false
-    git -C "$seed" checkout -q -b devel
+    git_fixture init -q --bare "$remote"
+    git_fixture clone -q "$remote" "$seed" 2>/dev/null
+    git_fixture -C "$seed" config user.email seed@example.com
+    git_fixture -C "$seed" config user.name Seed
+    git_fixture -C "$seed" config commit.gpgsign false
+    git_fixture -C "$seed" checkout -q -b devel
     printf '%s\n' base > "$seed/base.txt"
-    git -C "$seed" add base.txt
-    git -C "$seed" commit -q -m base
-    git -C "$seed" push -q origin devel
+    git_fixture -C "$seed" add base.txt
+    git_fixture -C "$seed" commit -q -m base
+    git_fixture -C "$seed" push -q origin devel
 
-    git init -q -b topic "$session"
-    git -C "$session" config user.email agent@example.com
-    git -C "$session" config user.name Agent
-    git -C "$session" config commit.gpgsign false
+    git_fixture init -q -b topic "$session"
+    git_fixture -C "$session" config user.email agent@example.com
+    git_fixture -C "$session" config user.name Agent
+    git_fixture -C "$session" config commit.gpgsign false
     printf '%s\n' topic > "$session/topic.txt"
-    git -C "$session" add topic.txt
-    git -C "$session" commit -q -m topic
-    git -C "$session" remote add origin "$remote"
-    git -C "$session" fetch -q origin devel
-    tip="$(git -C "$session" rev-parse HEAD)"
+    git_fixture -C "$session" add topic.txt
+    git_fixture -C "$session" commit -q -m topic
+    git_fixture -C "$session" remote add origin "$remote"
+    git_fixture -C "$session" fetch -q origin devel
+    tip="$(git_fixture -C "$session" rev-parse HEAD)"
   }
 
   cleanup() {
@@ -117,8 +117,8 @@ Describe 'session-branch-sync unrelated-history refusal'
     sync_and_verify() {
       cd "$session" || return 1
       sh "$hook" \
-        && [ "$(git rev-parse HEAD)" = "$tip" ] \
-        && [ "$(git rev-parse --is-shallow-repository)" = false ]
+        && [ "$(git_fixture rev-parse HEAD)" = "$tip" ] \
+        && [ "$(git_fixture rev-parse --is-shallow-repository)" = false ]
     }
     When run sync_and_verify
     The status should equal 0

--- a/tests/shell/sparse_clone_ports_spec.sh
+++ b/tests/shell/sparse_clone_ports_spec.sh
@@ -42,20 +42,20 @@ Describe 'sparse-clone-ports.sh'
     mkdir -p "${REMOTE}/${PORT_SUB}"
     (
       cd "$REMOTE" || exit 1
-      git init -q
-      git config user.email ci@example.invalid
-      git config user.name CI
-      git config uploadpack.allowFilter true
-      git checkout -q -b devel
+      git_fixture init -q
+      git_fixture config user.email ci@example.invalid
+      git_fixture config user.name CI
+      git_fixture config uploadpack.allowFilter true
+      git_fixture checkout -q -b devel
       printf 'PORTNAME=pfBlockerNG-devel\n# classic: pfblockerng_extra.inc from FILESDIR (stub)\n' > "${PORT_SUB}/Makefile"
-      git add -A && git -c commit.gpgsign=false commit -qm devel
-      git checkout -q -b pfblockerng/use-github
+      git_fixture add -A && git_fixture -c commit.gpgsign=false commit -qm devel
+      git_fixture checkout -q -b pfblockerng/use-github
       printf 'PORTNAME=pfBlockerNG-devel\nUSE_GITHUB=yes\n' > "${PORT_SUB}/Makefile"
-      git add -A && git -c commit.gpgsign=false commit -qm use-github
-      git tag use-github-tag
-      git checkout -q devel
+      git_fixture add -A && git_fixture -c commit.gpgsign=false commit -qm use-github
+      git_fixture tag use-github-tag
+      git_fixture checkout -q devel
     ) >/dev/null 2>&1
-    USE_GITHUB_SHA="$(cd "$REMOTE" && git rev-parse pfblockerng/use-github)"
+    USE_GITHUB_SHA="$(cd "$REMOTE" && git_fixture rev-parse pfblockerng/use-github)"
     BIN="${WORK}/bin"
     mkdir -p "$BIN"
     cat > "${BIN}/python3" <<'PYEOF'
@@ -99,7 +99,7 @@ PYEOF
   fresh_sha_result() {
     run_clone_sha >/dev/null 2>&1 || { echo "script-failed=$?"; return 1; }
     if is_build_input_variant; then echo 'variant=usegithub'; else echo 'variant=stub'; fi
-    echo "head=$(git -C "$DEST" rev-parse HEAD)"
+    echo "head=$(git_fixture -C "$DEST" rev-parse HEAD)"
   }
   It 'fresh-clone-by-sha: DEST absent, REF a full 40-hex commit SHA -> clones + checks out that commit'
     When call fresh_sha_result
@@ -144,7 +144,7 @@ PYEOF
   # prepare step runs, THEN the tree ends on REF (use-github). before/after both asserted so
   # green proves the switch caused it — and the old `git clone`-into-existing-DEST path is red.
   reuse_before_after() {
-    git clone -q "$URL" "$DEST" >/dev/null 2>&1            # full clone, checks out devel
+    git_fixture clone -q "$URL" "$DEST" >/dev/null 2>&1            # full clone, checks out devel
     if is_build_input_variant; then echo 'before=usegithub'; else echo 'before=stub'; fi
     run_clone >/dev/null 2>&1 || { echo "script-failed=$?"; return 1; }
     if is_build_input_variant; then echo 'after=usegithub'; else echo 'after=stub'; fi
@@ -159,9 +159,9 @@ PYEOF
   # Regression guard: the reuse branch already fetches a full-SHA REF (fetch + FETCH_HEAD,
   # not `-b`) — this must keep working unchanged by the fresh-clone REF-shape guard above.
   reuse_sha_result() {
-    git clone -q "$URL" "$DEST" >/dev/null 2>&1            # full clone, checks out devel
+    git_fixture clone -q "$URL" "$DEST" >/dev/null 2>&1            # full clone, checks out devel
     run_clone_sha >/dev/null 2>&1 || { echo "script-failed=$?"; return 1; }
-    echo "head=$(git -C "$DEST" rev-parse HEAD)"
+    echo "head=$(git_fixture -C "$DEST" rev-parse HEAD)"
   }
   It 'reuse-by-sha: an existing work-tree fetches + checks out a full-SHA REF'
     When call reuse_sha_result

--- a/tests/shell/spec_helper.sh
+++ b/tests/shell/spec_helper.sh
@@ -17,6 +17,11 @@ PFB_SHIMS="${PFB_ROOT}/tests/shell/bin"
 . "${PFB_ROOT}/scripts/lib/git-env-scrub.sh"
 scrub_git_env() { pfb_scrub_git_env; }
 
+# Run fixture/setup Git calls without developer global or system config.
+git_fixture() {
+	GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git "$@"
+}
+
 # Put the iprange shim ahead of the real PATH -- pfb_real_iprange() (see
 # pfblockerng_suppress_spec.sh) strips PFB_SHIMS back off to find a genuine
 # system iprange when one is present.


### PR DESCRIPTION
## Summary

- add a per-call `git_fixture` helper that neutralizes global and system Git configuration without changing the environment seen by scripts under test
- sweep all 14 shellspec scratch-repository fixtures and assertions to use the helper
- extend the existing guard with independently pinned command-position, prefix, quoting, marker, and oversized-line coverage

## Reproduction and verification

On the then-current `origin/devel`, a temporary `HOME/.gitconfig` with `commit.gpgsign=true`, `gpg.format=ssh`, and a missing signing key produced 100 shellspec failures. A focused failure ended with:

```text
fatal: failed to write commit object
```

Final executed evidence:

- hostile signing config across all 14 swept specs: 204 examples, 0 failures
- canonical `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS`
- original frozen proof (`6f15c901…`): 10 examples / 4 failures RED, 10 / 0 GREEN
- scanner supplemental proof (`f7f0b241…`): 19 / 3 RED, 19 / 0 GREEN
- quoted-marker proof (`80f14414…`): 1 / 1 RED, 1 / 0 GREEN
- independent final verification: PASS; all 19 changed files reviewed; no skipped checks

The three similarly named pytest commits (`65d849d0`, `14cc20bb`, and `22a596ae`) intentionally covered only the pytest harness. This PR completes the separate shellspec mechanism.

Fixes #1984

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shell safeguards to reliably detect unapproved raw Git fixture commands.
  - Reduced false positives by ignoring comments and quoted text while preserving valid command detection.
  - Same-line exemption markers now require a meaningful reason.
  - Added clearer remediation messages identifying the affected Git operation.
  - Improved handling of complex command syntax, prefixes, and long lines.

- **Tests**
  - Standardized repository fixtures to run with isolated Git configuration.
  - Expanded coverage for command detection, exemptions, quoting, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->