### PR TITLE
tests: pin config path doubles to upstream parity (#1999, #2000, #2001)

### DIFF
--- a/tests/php/ConfigDelPathParityTest.php
+++ b/tests/php/ConfigDelPathParityTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Upstream parity matrix for the config_del_path() double (issue #2000).
+ *
+ * Pins the wrapper guards and array_del_path() walker semantics from pfSense
+ * config.lib.inc and util.inc across master, ed6c2eb8, and 9363ac5b.
+ */
+final class ConfigDelPathParityTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	public static function parityProvider(): array
+	{
+		$default = 'DEFAULT';
+
+		return [
+			'successful removal returns removed value' => [
+				['section' => ['leaf' => 'value', 'keep' => 'x']], 'section/leaf', $default,
+				'value', ['section' => ['keep' => 'x']],
+			],
+			'missing leaf returns default' => [
+				['section' => ['keep' => 'x']], 'section/leaf', $default,
+				$default, ['section' => ['keep' => 'x']],
+			],
+			'missing intermediate returns default' => [
+				['other' => ['leaf' => 'value']], 'section/leaf', $default,
+				$default, ['other' => ['leaf' => 'value']],
+			],
+			'scalar intermediate returns default' => [
+				['section' => 'occupied'], 'section/leaf', $default,
+				$default, ['section' => 'occupied'],
+			],
+			'exact trailing slash rejected without mutation' => [
+				['section' => ['leaf' => 'value']], 'section/leaf/', $default,
+				$default, ['section' => ['leaf' => 'value']],
+			],
+			'trailing slash with surrounding whitespace rejected without mutation' => [
+				['section' => ['leaf' => 'value']], " section/leaf/ \t", $default,
+				$default, ['section' => ['leaf' => 'value']],
+			],
+			'double slash rejected without mutation' => [
+				['section' => ['leaf' => 'value']], 'section//leaf', $default,
+				$default, ['section' => ['leaf' => 'value']],
+			],
+			'single leading slash is ignored and deletes' => [
+				['section' => ['leaf' => 'value']], '/section/leaf', $default,
+				'value', ['section' => []],
+			],
+			'non-array config returns default without mutation' => [
+				'not-an-array', 'section/leaf', $default,
+				$default, 'not-an-array',
+			],
+			'empty path deletes empty-string root key' => [
+				['' => 'root', 'keep' => 'x'], '', $default,
+				'root', ['keep' => 'x'],
+			],
+			'null leaf is removed and returned' => [
+				['section' => ['leaf' => null]], 'section/leaf', $default,
+				null, ['section' => []],
+			],
+		];
+	}
+
+	#[DataProvider('parityProvider')]
+	public function testConfigDelPathMatchesUpstreamParity(
+		mixed $initial,
+		string $path,
+		mixed $default,
+		mixed $expectedReturn,
+		mixed $expectedConfigAfter
+	): void {
+		$GLOBALS['config'] = $initial;
+
+		$actualReturn = config_del_path($path, $default);
+
+		$this->assertSame($expectedReturn, $actualReturn, "{$this->dataName()}: return value mismatch");
+		$this->assertSame($expectedConfigAfter, $GLOBALS['config'], "{$this->dataName()}: config after mismatch");
+	}
+
+	public function testMissingPathWithoutDefaultReturnsNull(): void
+	{
+		$GLOBALS['config'] = ['section' => ['keep' => 'x']];
+
+		$this->assertNull(config_del_path('section/missing'));
+		$this->assertSame(['section' => ['keep' => 'x']], $GLOBALS['config']);
+	}
+}

--- a/tests/php/ConfigGetPathParityTest.php
+++ b/tests/php/ConfigGetPathParityTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Upstream parity matrix for the config_get_path() double (issue #1999).
+ *
+ * Pins the wrapper guards and array_get_path() walker semantics from pfSense
+ * config.lib.inc and util.inc across master, ed6c2eb8, and 9363ac5b.
+ */
+final class ConfigGetPathParityTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	public static function parityProvider(): array
+	{
+		$default = 'DEFAULT';
+
+		return [
+			'plain hit' => [
+				['section' => ['leaf' => 'value']], 'section/leaf', $default,
+				'value', ['section' => ['leaf' => 'value']],
+			],
+			'missing leaf' => [
+				['section' => []], 'section/leaf', $default,
+				$default, ['section' => []],
+			],
+			'scalar intermediate' => [
+				['section' => 'occupied'], 'section/leaf', $default,
+				$default, ['section' => 'occupied'],
+			],
+			'exact trailing slash rejected' => [
+				['section' => ['leaf' => 'value']], 'section/leaf/', $default,
+				$default, ['section' => ['leaf' => 'value']],
+			],
+			'trailing slash with surrounding whitespace rejected' => [
+				['section' => ['leaf' => 'value']], " section/leaf/ \t", $default,
+				$default, ['section' => ['leaf' => 'value']],
+			],
+			'double slash rejected' => [
+				['section' => ['leaf' => 'value']], 'section//leaf', $default,
+				$default, ['section' => ['leaf' => 'value']],
+			],
+			'empty-string leaf uses non-null default' => [
+				['section' => ['leaf' => '']], 'section/leaf', $default,
+				$default, ['section' => ['leaf' => '']],
+			],
+			'empty-string leaf is returned with null default' => [
+				['section' => ['leaf' => '']], 'section/leaf', null,
+				'', ['section' => ['leaf' => '']],
+			],
+			'single leading slash is ignored' => [
+				['section' => ['leaf' => 'value']], '/section/leaf', $default,
+				'value', ['section' => ['leaf' => 'value']],
+			],
+			'non-array config returns default' => [
+				'not-an-array', 'section/leaf', $default,
+				$default, 'not-an-array',
+			],
+			'empty path returns whole config' => [
+				['section' => ['leaf' => 'value']], '', $default,
+				['section' => ['leaf' => 'value']], ['section' => ['leaf' => 'value']],
+			],
+		];
+	}
+
+	#[DataProvider('parityProvider')]
+	public function testConfigGetPathMatchesUpstreamParity(
+		mixed $initial,
+		string $path,
+		mixed $default,
+		mixed $expectedReturn,
+		mixed $expectedConfigAfter
+	): void {
+		$GLOBALS['config'] = $initial;
+
+		$actualReturn = config_get_path($path, $default);
+
+		$this->assertSame($expectedReturn, $actualReturn, "{$this->dataName()}: return value mismatch");
+		$this->assertSame($expectedConfigAfter, $GLOBALS['config'], "{$this->dataName()}: config after mismatch");
+	}
+}

--- a/tests/php/ConfigPathEnabledParityTest.php
+++ b/tests/php/ConfigPathEnabledParityTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Upstream parity matrix for the config_path_enabled() double (issue #2001).
+ *
+ * Pins the wrapper guards and array_path_enabled() semantics from pfSense
+ * config.lib.inc and util.inc across master, ed6c2eb8, and 9363ac5b.
+ */
+final class ConfigPathEnabledParityTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	public static function parityProvider(): array
+	{
+		return [
+			'enable key absent returns false' => [
+				['section' => ['other' => 'x']], 'section', 'enable', false,
+				false, ['section' => ['other' => 'x']],
+			],
+			'enable key null returns false' => [
+				['section' => ['enable' => null]], 'section', 'enable', false,
+				false, ['section' => ['enable' => null]],
+			],
+			'enable key empty string returns true' => [
+				['section' => ['enable' => '']], 'section', 'enable', false,
+				true, ['section' => ['enable' => '']],
+			],
+			'enable key nonempty value returns true' => [
+				['section' => ['enable' => 'on']], 'section', 'enable', false,
+				true, ['section' => ['enable' => 'on']],
+			],
+			'custom enable key returns true' => [
+				['section' => ['custom' => 'yes']], 'section', 'custom', false,
+				true, ['section' => ['custom' => 'yes']],
+			],
+			'scalar node returns custom default' => [
+				['section' => 'occupied'], 'section', 'enable', 'SCALAR_DEFAULT',
+				'SCALAR_DEFAULT', ['section' => 'occupied'],
+			],
+			'missing node returns custom default' => [
+				['section' => []], 'section/missing', 'enable', 'MISSING_DEFAULT',
+				'MISSING_DEFAULT', ['section' => []],
+			],
+			'exact trailing slash returns custom default' => [
+				['section' => ['enable' => 'on']], 'section/', 'enable', 'TRAILING_DEFAULT',
+				'TRAILING_DEFAULT', ['section' => ['enable' => 'on']],
+			],
+			'trailing slash with surrounding whitespace returns custom default' => [
+				['section' => ['enable' => 'on']], " section/ \t", 'enable', 'TRAILING_DEFAULT',
+				'TRAILING_DEFAULT', ['section' => ['enable' => 'on']],
+			],
+			'double slash returns custom default' => [
+				['section' => ['enable' => 'on']], 'section//enable', 'enable', 'DOUBLE_DEFAULT',
+				'DOUBLE_DEFAULT', ['section' => ['enable' => 'on']],
+			],
+			'non-array config returns custom default' => [
+				'not-an-array', 'section', 'enable', 'CONFIG_DEFAULT',
+				'CONFIG_DEFAULT', 'not-an-array',
+			],
+			'non-array config preserves array default with enable key' => [
+				'not-an-array', 'section', 'enable', ['enable' => 'on'],
+				['enable' => 'on'], 'not-an-array',
+			],
+			'null config preserves array default without enable key' => [
+				null, 'section', 'enable', ['other' => 'x'],
+				['other' => 'x'], null,
+			],
+			'custom true default is preserved' => [
+				['section' => []], 'section/missing', 'enable', true,
+				true, ['section' => []],
+			],
+			'empty path checks root enable key' => [
+				['enable' => 'on', 'section' => []], '', 'enable', false,
+				true, ['enable' => 'on', 'section' => []],
+			],
+		];
+	}
+
+	#[DataProvider('parityProvider')]
+	public function testConfigPathEnabledMatchesUpstreamParity(
+		mixed $initial,
+		string $path,
+		string $enableKey,
+		mixed $default,
+		mixed $expectedReturn,
+		mixed $expectedConfigAfter
+	): void {
+		$GLOBALS['config'] = $initial;
+
+		$actualReturn = config_path_enabled($path, $enableKey, $default);
+
+		$this->assertSame($expectedReturn, $actualReturn, "{$this->dataName()}: return value mismatch");
+		$this->assertSame($expectedConfigAfter, $GLOBALS['config'], "{$this->dataName()}: config after mismatch");
+	}
+}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -307,14 +307,26 @@ if (!function_exists('is_ipaddr_configured')) {
 // config -- or, just as load-bearing, that an abort path did NOT.
 
 if (!function_exists('config_get_path')) {
-	// pfSense config.lib.inc: walk a '/'-separated path, $default when absent.
+	// pfSense config.lib.inc config_get_path() + util.inc array_get_path().
 	function config_get_path(string $path, $default = null) {
-		$node = $GLOBALS['config'] ?? [];
-		foreach (explode('/', rtrim($path, '/')) as $key) {
+		if (str_ends_with(trim($path), '/') || str_contains($path, '//')) {
+			return $default;
+		}
+		$node = $GLOBALS['config'] ?? null;
+		if (!is_array($node)) {
+			return $default;
+		}
+		foreach (explode('/', $path) as $key) {
+			if (mb_strlen($key) === 0) {
+				continue;
+			}
 			if (!is_array($node) || !array_key_exists($key, $node)) {
 				return $default;
 			}
 			$node = $node[$key];
+		}
+		if ($default !== null && $node === '') {
+			return $default;
 		}
 		return $node;
 	}

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -439,21 +439,32 @@ if (!function_exists('config_set_path')) {
 }
 
 if (!function_exists('config_del_path')) {
-	// pfSense config.lib.inc: unset the node at a '/'-separated path.
-	// A missing path is a no-op (matches pfSense behaviour).
-	function config_del_path(string $path): void {
-		$keys = explode('/', rtrim($path, '/'));
-		$last = array_pop($keys);
+	// pfSense config.lib.inc config_del_path() + util.inc array_del_path().
+	function config_del_path(string $path, $default = null) {
+		if (str_ends_with(trim($path), '/') || str_contains($path, '//')) {
+			return $default;
+		}
 		$node = &$GLOBALS['config'];
-		foreach ($keys as $key) {
+		if (!is_array($node)) {
+			return $default;
+		}
+		$vpath = explode('/', $path);
+		$vkey = array_pop($vpath);
+		foreach ($vpath as $key) {
+			if (mb_strlen($key) === 0) {
+				continue;
+			}
 			if (!is_array($node) || !array_key_exists($key, $node)) {
-				return;
+				return $default;
 			}
 			$node = &$node[$key];
 		}
-		if (is_array($node)) {
-			unset($node[$last]);
+		if (!is_array($node) || !array_key_exists($vkey, $node)) {
+			return $default;
 		}
+		$ret = $node[$vkey];
+		unset($node[$vkey]);
+		return $ret;
 	}
 }
 

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -469,10 +469,16 @@ if (!function_exists('config_del_path')) {
 }
 
 if (!function_exists('config_path_enabled')) {
-	// pfSense config.lib.inc: node exists, is an array and carries the enable key.
-	function config_path_enabled(string $path, $enable_key = 'enable') {
-		$node = config_get_path($path);
-		return (is_array($node) && array_key_exists($enable_key, $node));
+	// pfSense config.lib.inc config_path_enabled() + util.inc array_path_enabled().
+	function config_path_enabled(string $path, $enable_key = 'enable', $default = false) {
+		if (str_ends_with(trim($path), '/') || str_contains($path, '//')) {
+			return $default;
+		}
+		if (!is_array($GLOBALS['config'] ?? null)) {
+			return $default;
+		}
+		$node = config_get_path($path, $default);
+		return is_array($node) ? isset($node[$enable_key]) : $default;
 	}
 }
 


### PR DESCRIPTION
## Summary

Ports the remaining three config-path doubles in `tests/php/pfsense_doubles.php` to upstream pfSense semantics, following #1918 / PR #2005:

- `config_get_path()` now rejects invalid wrapper paths, skips a single leading slash, and applies the empty-string/non-null-default coercion.
- `config_del_path()` now refuses invalid paths without mutation and returns the removed value or caller default.
- `config_path_enabled()` now uses `isset()` semantics, honors wrapper rejection, and preserves mixed caller defaults at the wrapper boundary.

The stack intentionally contains one commit per issue. Each commit adds its own upstream-parity matrix asserting both the return value and the complete resulting `$GLOBALS['config']` for every row.

## Verification

- Test-first frozen proofs independently re-executed for all three commits: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`.
- Focused parity suites: 38 tests, 76 assertions, all passing.
- Top-tier review rebuilt an independent oracle from fresh pfSense source at `master`, `ed6c2eb8`, and `9363ac5b`. Its 66-case differential run found one array-default/non-array-root gap; the review fix added two frozen rows and the exact upstream wrapper guard. Delta proof: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`.
- `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS`, including the full PHPUnit suite, PHPStan, PHPCS, and PHP lint.
- Two earlier verifier full-suite attempts hit the known outside-diff host-process tripwire tracked by #2006; after its isolation fix landed on `devel`, the canonical gate passed.

Fixes #1999
Fixes #2000
Fixes #2001

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
