### PR TITLE
tests: isolate host-state cleanup checks

### DIFF
--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -999,24 +999,32 @@ final class IpPrefetchTest extends TestCase
 	 */
 	public function test_prefetch_leaves_no_temp_pattern_files_behind(): void
 	{
-		$fields = $this->buildBlockFields('192.0.2.77');
-		$rq     = pfb_ip_render_query($fields);
+		$tempDir = sys_get_temp_dir() . '/pfb_ip_prefetch_cleanup_' . bin2hex(random_bytes(6));
+		$this->assertTrue(mkdir($tempDir, 0755), "failed to create owned temp dir {$tempDir}");
 
-		$rows = [[
-			'host'              => $rq['host'],
-			'folder'            => $rq['folder'],
-			'validate_file_cmd' => $rq['validate_file_cmd'],
-			'validate_cmd'      => $rq['validate_cmd'],
-			'eval_ip_raw'       => $fields[14],
-		]];
+		$repo = dirname(__DIR__, 2);
+		$code = 'require ' . var_export("{$repo}/tests/php/bootstrap.php", TRUE) . ';'
+			. '$lines = pfb_ip_prefetch_grep_lines(\'/bin/echo\', \'\', [\'^probe$\']);'
+			. 'echo json_encode(['
+			. '\'ran\' => is_array($lines),'
+			. '\'leftover\' => glob(sys_get_temp_dir() . \'/pfb_ip_prefetch_*\') ?: []'
+			. ']);';
+		try {
+			$cmd = 'TMPDIR=' . escapeshellarg($tempDir) . ' ' . escapeshellarg(PHP_BINARY)
+				. ' -d ' . escapeshellarg("sys_temp_dir={$tempDir}") . ' -r ' . escapeshellarg($code);
+			$output = shell_exec($cmd);
+		} finally {
+			rmdir_recursive($tempDir);
+		}
 
-		pfb_ip_prefetch($rows);
-
-		$leftover = glob(sys_get_temp_dir() . '/pfb_ip_prefetch_*') ?: [];
+		$decoded = json_decode((string) $output, TRUE);
+		$this->assertIsArray($decoded, 'expected valid child JSON, got ' . var_export($output, TRUE));
+		$this->assertTrue($decoded['ran'] ?? FALSE, 'expected the helper to create and process its pattern file');
 		$this->assertSame(
 			[],
-			$leftover,
-			'expected no pfb_ip_prefetch_* temp files to remain, found ' . var_export($leftover, true)
+			$decoded['leftover'] ?? NULL,
+			'expected no pfb_ip_prefetch_* temp files to remain in the test-owned temp dir, found '
+				. var_export($decoded['leftover'] ?? NULL, TRUE)
 		);
 	}
 

--- a/tests/php/Issue1840SuppUpdateNullPostinstallTest.php
+++ b/tests/php/Issue1840SuppUpdateNullPostinstallTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+define('PFB_ISSUE1840_PFB_BASELINE', $GLOBALS['pfb']);
+
 /**
  * issue #1840 -- POST-INSTALL sync fatal: pfb_ip_suppress_body_active() receives a
  * NULL $supp_update.
@@ -62,7 +64,7 @@ final class Issue1840SuppUpdateNullPostinstallTest extends TestCase
 		mkdir($this->dbdir, 0755, TRUE);
 		mkdir("{$this->dbdir}/deny", 0755, TRUE);
 
-		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+		$GLOBALS['pfb'] = array_merge(PFB_ISSUE1840_PFB_BASELINE, [
 			'dbdir'    => $this->dbdir,
 			'log'      => "{$this->dbdir}/pfblockerng.log",
 			'errlog'   => "{$this->dbdir}/error.log",


### PR DESCRIPTION
## Summary

- reset `Issue1840SuppUpdateNullPostinstallTest` from an immutable suite-discovery baseline before each case, so sibling tests cannot leak `$GLOBALS['pfb']` state into it
- run the IP-prefetch cleanup contract inside a child whose PHP environment and `sys_temp_dir` both point at a directory created and owned by the test
- keep one commit per issue; PR #2018 is present in `devel`

## Host-dependency proof

- **#2002 RED:** a preceding reproduction test poisoned `$GLOBALS['pfb']['base_rule']`; both Issue1840 cases failed with `Cannot access offset of type string on string`. **GREEN:** the identical three-test order passed after the per-test baseline reset. Five hostile randomized runs also passed without child-process isolation.
- **#2027 RED:** one foreign `pfb_ip_prefetch_stray_probe_*` file in shared system temp failed the old cleanup assertion. **GREEN:** the foreign file remained while the focused test passed: 1 test, 4 assertions. A hostile parent `sys_temp_dir` override also passed because the child pins both `TMPDIR` and PHP `sys_temp_dir` to its owned directory.
- the cleanup test asserts the helper returned an array before checking zero leftovers, so temp-file creation failure cannot produce a vacuous green

## Gates

- `scripts/agent/run-gates.sh --diff origin/devel` — PASS on head `9730dd6c31f02d68bfd03f95493912f2450161e2`
- PHP syntax, full PHPUnit, PHPStan, and PHPCS all passed after rebasing onto latest `devel`
- full random-order probing exposed an unrelated pre-existing `SyslogEventTest` leak on both base and PR head; tracked separately as #2046

Fixes #2002
Fixes #2027

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
