### PR TITLE
tests: synchronize lint fixtures with stdin

### DIFF
--- a/tests/php/Issue1787BlankEmptyCallSitesTest.php
+++ b/tests/php/Issue1787BlankEmptyCallSitesTest.php
@@ -156,8 +156,12 @@ final class Issue1787BlankEmptyCallSitesTest extends TestCase
 
 	public function testShUnicodeWhitespaceOnlyStderrIsNoDiagnosticWarning(): void
 	{
-		// Nonzero exit, stderr = NBSP + newline: no diagnostic to parse.
-		$timeoutFixture = $this->fixture('printf "\302\240\n" 1>&2' . "\n" . 'exit 1');
+		// Consume the complete probe before the nonzero exit; stderr = NBSP + newline.
+		$timeoutFixture = $this->fixture(
+			'cat >/dev/null' . "\n" .
+			'printf "\302\240\n" 1>&2' . "\n" .
+			'exit 1'
+		);
 		$shFixture = $this->fixture('exit 0'); // never exec'd — fake timeout ignores argv
 		$diagnostics = pfb_lint_sh_diagnostics("echo ok\n", $shFixture, $timeoutFixture);
 		$this->assertCount(1, $diagnostics);
@@ -189,7 +193,11 @@ final class Issue1787BlankEmptyCallSitesTest extends TestCase
 
 	public function testPyUnicodeWhitespaceOnlyStderrIsNoDiagnosticWarning(): void
 	{
-		$timeoutFixture = $this->fixture('printf "\302\240\n" 1>&2' . "\n" . 'exit 1');
+		$timeoutFixture = $this->fixture(
+			'cat >/dev/null' . "\n" .
+			'printf "\302\240\n" 1>&2' . "\n" .
+			'exit 1'
+		);
 		$pythonFixture = $this->fixture('exit 0'); // never exec'd — fake timeout ignores argv
 		$diagnostics = pfb_lint_py_diagnostics("print('ok')\n", $pythonFixture, $timeoutFixture);
 		$this->assertCount(1, $diagnostics);


### PR DESCRIPTION
## Summary

- drain each whitespace-only lint fixture's stdin before it emits stderr and exits
- preserve the separate fixture that deliberately closes stdin to exercise the write-failure path
- remove the parent-write/child-exit race without sleeps, retries, or deadline changes

## Verification

Red evidence on the untouched test blob `0320fc1051ca502e9cff21547dbcaf6e6d35ded0`:

```text
Actions run 30715375610, PHPUnit / PHP 8.5
Issue1787BlankEmptyCallSitesTest::testPyUnicodeWhitespaceOnlyStderrIsNoDiagnosticWarning
Failed asserting that 'python syntax checker launch failed: stdin write failed'
contains "exited 1 with no diagnostic".
```

Focused green on PHP 8.5.9:

```text
vendor/bin/phpunit --filter 'Issue1787BlankEmptyCallSitesTest::test(ShUnicodeWhitespaceOnlyStderrIsNoDiagnosticWarning|PyUnicodeWhitespaceOnlyStderrIsNoDiagnosticWarning|ShStdinWriteFailureWithWhitespaceOnlyStderrIsLaunchFailedWarning)' tests/php/Issue1787BlankEmptyCallSitesTest.php
OK (3 tests, 12 assertions)
```

Canonical gate:

```text
scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: python3 scripts/check_composer_vendor.py
GATE PASS: php -l tests/php/Issue1787BlankEmptyCallSitesTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

Fixes #2034

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
