### PR TITLE
tests: distinguish remaining PFBL-03 salvage expiry

### DIFF
--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -761,21 +761,22 @@ class _ControlHarness:
             f"to reach sequence {seq}; observed {self.read_applied()!r}"
         )
 
-    def stop_join(self) -> bool:
+    def stop_join(self) -> None:
         """Signal the watcher to stop and wait until it dies.
 
         Loops in 0.5-second slices for up to 10 seconds so that CPU contention
-        does not cause a single long join to return prematurely.  Returns True
-        when the thread has fully exited, False when it outlived the budget."""
+        does not cause a single long join to return prematurely."""
         P.pfb_control_stop.set()
         if self.thread is None:
-            return True
+            return
         deadline = time.monotonic() + 10.0
-        while time.monotonic() < deadline:
+        while self.thread.is_alive() and time.monotonic() < deadline:
             self.thread.join(timeout=0.5)
-            if not self.thread.is_alive():
-                return True
-        return False
+        if self.thread.is_alive():
+            raise RuntimeError(
+                "salvage cap expired / stuck or environment: control watcher thread "
+                f"{self.thread.name!r} to stop; still alive"
+            )
 
 
 # Sentinel used in the snapshot below to distinguish "key absent" from "key = None"
@@ -825,15 +826,10 @@ def control_harness(tmp_path: Any, monkeypatch: Any) -> Any:
         teardown_errors: list[str] = []
         try:
             # Stop the watcher and confirm it is dead.
-            died = h.stop_join()
-            if not died:
+            h.stop_join()
+            if h.thread is not None and h.thread.is_alive():
                 teardown_errors.append(
-                    f"control_harness teardown: watcher thread '{h.thread!r}' did not exit "
-                    "within 10 s — the watcher is still alive after stop_join."
-                )
-            elif h.thread is not None and h.thread.is_alive():
-                teardown_errors.append(
-                    f"control_harness teardown: thread {h.thread!r} is still alive after stop_join reported death."
+                    f"control_harness teardown: thread {h.thread!r} is still alive after stop_join returned."
                 )
 
             # Confirm no pfb_control_watcher_test thread survives in the process.

--- a/tests/test_pfbl03_control_channel.py
+++ b/tests/test_pfbl03_control_channel.py
@@ -711,9 +711,14 @@ class _ControlHarness:
         except (OSError, ValueError):
             return None
 
-    def wait_read(self, seq: int, count: int = 1, timeout: float = 3.0) -> bool:
+    def wait_read(self, seq: int, count: int = 1, timeout: float = 3.0) -> None:
         with self.read_condition:
-            return self.read_condition.wait_for(lambda: self.read_seqs.count(seq) >= count, timeout=timeout)
+            if self.read_condition.wait_for(lambda: self.read_seqs.count(seq) >= count, timeout=timeout):
+                return
+            raise RuntimeError(
+                "salvage cap expired / stuck or environment: control record read marker "
+                f"to observe sequence {seq} {count} time(s); observed {self.read_seqs!r}"
+            )
 
     def pause_read(self, seq: int) -> tuple[threading.Event, threading.Event]:
         started = threading.Event()
@@ -1016,7 +1021,7 @@ class TestControlWatcherLoop:
         # must NOT apply it (3 <= 5), so blocking stays as we set it.
         P.pfb["python_blacklist"] = True
         h.publish({"seq": 3, "cmd": "disable"})
-        assert h.wait_read(3), f"control records read: {h.read_seqs!r}"
+        h.wait_read(3)
 
         # A fresh unknown command proves the watcher consumed/progressed past the stale
         # record without changing the state.
@@ -1041,7 +1046,7 @@ class TestControlWatcherLoop:
         # wait_applied(9) itself is the started gate here (seq 9 = baseline): the
         # watcher adopts it and publishes it without applying the command.
         h.wait_applied(9)  # baseline adopted + published.
-        assert h.wait_read(9, count=2), f"control records read: {h.read_seqs!r}"
+        h.wait_read(9, count=2)
 
         # A fresh unknown command proves the watcher progressed past the baseline
         # without changing the state.
@@ -1084,7 +1089,7 @@ class TestPermissionBoundaryModel:
         release: threading.Event | None = None
         try:
             h.wait_applied(1)
-            assert h.wait_read(1, count=2), f"control records read: {h.read_seqs!r}"
+            h.wait_read(1, count=2)
             read_started, release = h.pause_read(2)
             h.publish({"seq": 2, "cmd": "wipe-everything"})
             assert read_started.wait(3.0), f"control records read: {h.read_seqs!r}"

--- a/tests/test_pfbl03_control_channel_salvage.py
+++ b/tests/test_pfbl03_control_channel_salvage.py
@@ -43,3 +43,39 @@ def test_record_read_expiry_is_distinct() -> None:
         match=r"salvage cap expired / stuck or environment.*record read.*sequence 7.*observed \[\]",
     ):
         harness.wait_read(7, timeout=0)
+
+
+def test_watcher_stop_expiry_is_distinct(monkeypatch: Any) -> None:
+    class StuckWatcher:
+        name = "pfb_control_watcher_test"
+
+        def join(self, timeout: float) -> None:
+            pass
+
+        def is_alive(self) -> bool:
+            return True
+
+    harness = object.__new__(channel._ControlHarness)
+    harness.thread = StuckWatcher()
+    ticks = iter((0.0, 11.0))
+    monkeypatch.setattr(channel.time, "monotonic", lambda: next(ticks, 11.0))
+    monkeypatch.setattr(channel.P, "pfb_control_stop", threading.Event(), raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="salvage cap expired / stuck or environment.*watcher thread 'pfb_control_watcher_test' to stop",
+    ):
+        harness.stop_join()
+
+
+def test_stopped_watcher_succeeds_after_elapsed_deadline(monkeypatch: Any) -> None:
+    watcher = threading.Thread(name="pfb_control_watcher_test", target=lambda: None)
+    watcher.start()
+    watcher.join()
+    harness = object.__new__(channel._ControlHarness)
+    harness.thread = watcher
+    ticks = iter((0.0, 11.0))
+    monkeypatch.setattr(channel.time, "monotonic", lambda: next(ticks, 11.0))
+    monkeypatch.setattr(channel.P, "pfb_control_stop", threading.Event(), raising=False)
+
+    harness.stop_join()

--- a/tests/test_pfbl03_control_channel_salvage.py
+++ b/tests/test_pfbl03_control_channel_salvage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import Any
 
 import pytest
@@ -30,3 +31,15 @@ def test_applied_marker_expiry_is_distinct(monkeypatch: Any) -> None:
 
     with pytest.raises(RuntimeError, match="salvage cap expired / stuck or environment.*applied marker.*sequence 7"):
         harness.wait_applied(7, timeout=0)
+
+
+def test_record_read_expiry_is_distinct() -> None:
+    harness = object.__new__(channel._ControlHarness)
+    harness.read_condition = threading.Condition()
+    harness.read_seqs = []
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"salvage cap expired / stuck or environment.*record read.*sequence 7.*observed \[\]",
+    ):
+        harness.wait_read(7, timeout=0)


### PR DESCRIPTION
## Summary

- make `wait_read()` raise a distinct `salvage cap expired / stuck or environment` diagnostic naming the awaited sequence and observed reads
- make `stop_join()` raise the same diagnostic class naming the stuck watcher
- remove boolean verdict handling from callers so successful waits are return-value-free and cap expiry cannot masquerade as product behavior
- extend the existing PFBL-03 salvage-cap reproduction module without introducing another convention

## Verification

- `python3 -m pytest tests/test_pfbl03_control_channel.py tests/test_pfbl03_control_channel_salvage.py` — 50 passed
- `scripts/agent/run-gates.sh --diff origin/devel` — full pytest, Ruff check/format, and mypy passed
- `scripts/agent/verify-red-proof.sh ... --base-ref HEAD~1` for #2054 — `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`
- `scripts/agent/verify-red-proof.sh ... --base-ref 6b71f1f0` for the review-found stopped-watcher edge — `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`
- combined `scripts/agent/verify-red-proof.sh ... --base-ref origin/devel` — `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`

Red-time test hashes: #2047 `255e8186cb6ff1114eb25b037b5eee65003924f5`; #2054 final `97b924e075cacea8f9410f496662f9fe47f7e3f4`.

Fixes #2047.
Fixes #2054.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
