### PR TITLE
build: close frozen-v3 verification gaps

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -313,8 +313,10 @@ python3 scripts/build-frozen-v3.py --out /tmp/frozen-v3-stage
 
 Writes `<out>/fbsd<major>/<pkgname>-<version>.pkg` per row plus a JSON identity report
 (`<out>/frozen-v3-report.json`: source commit, artifact SHA-256, payload inventory with
-per-file SHA-256, dependency/ABI facts). `--verify-only DIR` re-validates an already-staged
-directory with no build seam invoked at all. See `--help` for the full flag set.
+per-file SHA-256, dependency/ABI facts). `--verify-only DIR` requires that report (or the
+path passed with `--report`), re-validates an already-staged directory against its exact
+recorded identities, and never rewrites the report; no build seam is invoked. See `--help`
+for the full flag set.
 
 **This tool never publishes anything** — no GitHub Release upload, no catalog write, no
 network write of any kind. Publication is a separate, maintainer-gated step.

--- a/scripts/build-frozen-v3.py
+++ b/scripts/build-frozen-v3.py
@@ -517,13 +517,54 @@ def build_and_stage_one(
         shutil.rmtree(scratch, ignore_errors=True)
 
 
-def _assert_no_stray_pkgs(out_dir: Path, staged: set[Path]) -> None:
-    found = set(out_dir.glob("fbsd*/*.pkg"))
-    extra = sorted(p.name for p in found - staged)
+def _assert_no_stray_pkgs(
+    out_dir: Path,
+    staged: set[Path],
+    *,
+    plan: list[tuple[FrozenTarget, dict]],
+    target_filter: str | None,
+    major_filter: str | None,
+) -> None:
+    owned_majors = {row["freebsd_major"] for _, row in plan}
+    extra: list[str] = []
+    for path in sorted(out_dir.rglob("*.pkg")):
+        relative = path.relative_to(out_dir)
+        layout = relative.parts
+        if len(layout) != 2:
+            extra.append(relative.as_posix())
+            continue
+        major_match = re.fullmatch(r"fbsd([1-9][0-9]*)", layout[0])
+        if major_match is None:
+            extra.append(relative.as_posix())
+            continue
+        major = major_match.group(1)
+        if major_filter is not None and major != major_filter:
+            continue
+        if major_filter is None and major not in owned_majors:
+            extra.append(relative.as_posix())
+            continue
+        if path in staged:
+            continue
+        if target_filter is not None and any(
+            target.channel != target_filter
+            and re.fullmatch(
+                rf"{re.escape(target.portname)}-{re.escape(target.portversion)}(?:_[0-9]+)?(?:,[0-9]+)?\.pkg",
+                path.name,
+            )
+            for target in FROZEN_TARGETS
+        ):
+            continue
+        extra.append(relative.as_posix())
     if extra:
         raise ArtifactValidationError(
             f"{out_dir}: unexpected staged file(s) beyond the planned artifacts: {', '.join(extra)}"
         )
+
+
+def _assert_no_staging_symlinks(out_dir: Path) -> None:
+    links = sorted(path.relative_to(out_dir).as_posix() for path in out_dir.rglob("*") if path.is_symlink())
+    if links:
+        raise ArtifactValidationError(f"{out_dir}: staging symlink(s) are not allowed: {', '.join(links)}")
 
 
 def build_all(
@@ -534,7 +575,10 @@ def build_all(
     out_dir: Path,
     ports_dir: str | None,
     do_determinism: bool,
+    target_filter: str | None,
+    major_filter: str | None,
 ) -> dict:
+    _assert_no_staging_symlinks(out_dir)
     export_cache: dict[str, Path] = {}
     artifacts: list[dict] = []
     staged: set[Path] = set()
@@ -596,11 +640,25 @@ def build_all(
                     **identity,
                 }
             )
-    _assert_no_stray_pkgs(out_dir, staged)
+    _assert_no_stray_pkgs(
+        out_dir,
+        staged,
+        plan=plan,
+        target_filter=target_filter,
+        major_filter=major_filter,
+    )
     return {"ports_ref": FROZEN_PORTS_REF, "artifacts": artifacts}
 
 
-def verify_staged(dir_: Path, plan: list[tuple[FrozenTarget, dict]], *, repo: Path) -> dict:
+def verify_staged(
+    dir_: Path,
+    plan: list[tuple[FrozenTarget, dict]],
+    *,
+    repo: Path,
+    target_filter: str | None,
+    major_filter: str | None,
+) -> dict:
+    _assert_no_staging_symlinks(dir_)
     export_cache: dict[str, Path] = {}
     artifacts: list[dict] = []
     staged: set[Path] = set()
@@ -640,7 +698,13 @@ def verify_staged(dir_: Path, plan: list[tuple[FrozenTarget, dict]], *, repo: Pa
                     **identity,
                 }
             )
-    _assert_no_stray_pkgs(dir_, staged)
+    _assert_no_stray_pkgs(
+        dir_,
+        staged,
+        plan=plan,
+        target_filter=target_filter,
+        major_filter=major_filter,
+    )
     return {"ports_ref": FROZEN_PORTS_REF, "artifacts": artifacts}
 
 
@@ -735,7 +799,13 @@ def main(argv: list[str] | None = None) -> int:
             raise MatrixError("nothing to do: --target/--major filters excluded every BUILD-matrix row")
 
         if args.verify_only is not None:
-            report = verify_staged(args.verify_only.resolve(), plan, repo=repo)
+            report = verify_staged(
+                args.verify_only.resolve(),
+                plan,
+                repo=repo,
+                target_filter=args.target,
+                major_filter=major_filter,
+            )
         else:
             out_dir.mkdir(parents=True, exist_ok=True)
             report = build_all(
@@ -745,6 +815,8 @@ def main(argv: list[str] | None = None) -> int:
                 out_dir=out_dir,
                 ports_dir=args.ports_dir,
                 do_determinism=not args.no_deterministic_check,
+                target_filter=args.target,
+                major_filter=major_filter,
             )
 
         report_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/build-frozen-v3.py
+++ b/scripts/build-frozen-v3.py
@@ -582,6 +582,142 @@ def _assert_no_staging_symlinks(out_dir: Path) -> None:
         raise ArtifactValidationError(f"{out_dir}: staging symlink(s) are not allowed: {', '.join(links)}")
 
 
+_REPORT_ARTIFACT_FIELDS = (
+    "channel",
+    "tag",
+    "source_commit",
+    "ports_ref",
+    "matrix_row",
+    "staged_path",
+    "name",
+    "version",
+    "origin",
+    "abi",
+    "arch",
+    "artifact_sha256",
+    "payload_file_count",
+    "payload_files",
+    "install_script_sha256",
+    "deinstall_script_sha256",
+)
+_REPORT_HASH_FIELDS = ("artifact_sha256", "install_script_sha256", "deinstall_script_sha256")
+
+
+def _validate_report_staged_path(value: object, *, index: int) -> str:
+    if not isinstance(value, str) or "\x00" in value or value.startswith("/"):
+        raise ArtifactValidationError(f"identity report artifact {index}: staged_path is unsafe: {value!r}")
+    parts = value.split("/")
+    if len(parts) != 2 or re.fullmatch(r"fbsd[1-9][0-9]*", parts[0]) is None:
+        raise ArtifactValidationError(f"identity report artifact {index}: staged_path is unsafe: {value!r}")
+    filename = parts[1]
+    if not filename.endswith(".pkg"):
+        raise ArtifactValidationError(f"identity report artifact {index}: staged_path is unsafe: {value!r}")
+    _safe_segment(filename, f"identity report artifact {index} staged_path")
+    return value
+
+
+def _read_identity_report(
+    report_path: Path,
+    plan: list[tuple[FrozenTarget, dict]],
+    *,
+    allow_missing: bool = False,
+    reject_unselected: bool = False,
+) -> dict:
+    try:
+        raw = report_path.read_bytes()
+    except OSError as e:
+        raise ArtifactValidationError(f"identity report {report_path}: unreadable ({e})") from None
+    try:
+        obj = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as e:
+        raise ArtifactValidationError(f"identity report {report_path}: malformed JSON ({e})") from None
+    if not isinstance(obj, dict):
+        raise ArtifactValidationError(f"identity report {report_path}: top level must be an object")
+    if obj.get("ports_ref") != FROZEN_PORTS_REF:
+        raise ArtifactValidationError(
+            f"identity report mismatch for ports_ref: expected {FROZEN_PORTS_REF!r}, actual {obj.get('ports_ref')!r}"
+        )
+    report_artifacts = obj.get("artifacts")
+    if not isinstance(report_artifacts, list):
+        raise ArtifactValidationError(f"identity report {report_path}: artifacts must be a list")
+
+    selected = {(target.channel, row["freebsd_major"]) for target, row in plan}
+    indexed: dict[tuple[str, str], dict] = {}
+    for index, artifact in enumerate(report_artifacts):
+        if not isinstance(artifact, dict):
+            raise ArtifactValidationError(f"identity report artifact {index}: must be an object")
+        missing = [field for field in _REPORT_ARTIFACT_FIELDS if field not in artifact]
+        if missing:
+            raise ArtifactValidationError(f"identity report artifact {index}: missing field(s): {', '.join(missing)}")
+        for field in ("channel", "tag", "source_commit", "ports_ref", "name", "version", "origin", "abi", "arch"):
+            if not isinstance(artifact[field], str):
+                raise ArtifactValidationError(
+                    f"identity report artifact {index}: {field} must be a string, got {artifact[field]!r}"
+                )
+        try:
+            row = validate_matrix([artifact["matrix_row"]])[0]
+        except MatrixError as e:
+            raise ArtifactValidationError(f"identity report artifact {index}: malformed matrix_row ({e})") from None
+        _validate_report_staged_path(artifact["staged_path"], index=index)
+        for field in _REPORT_HASH_FIELDS:
+            if not isinstance(artifact[field], str) or re.fullmatch(r"[0-9a-f]{64}", artifact[field]) is None:
+                raise ArtifactValidationError(
+                    f"identity report artifact {index}: {field} has malformed SHA-256 {artifact[field]!r}"
+                )
+        count = artifact["payload_file_count"]
+        if type(count) is not int or count < 0:
+            raise ArtifactValidationError(
+                f"identity report artifact {index}: payload_file_count must be a non-negative integer"
+            )
+        payload_files = artifact["payload_files"]
+        if not isinstance(payload_files, dict):
+            raise ArtifactValidationError(f"identity report artifact {index}: payload_files must be an object")
+        for path, digest in payload_files.items():
+            if (
+                not isinstance(path, str)
+                or not isinstance(digest, str)
+                or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+            ):
+                raise ArtifactValidationError(
+                    f"identity report artifact {index}: payload_files contains malformed entry {path!r}: {digest!r}"
+                )
+        key = (artifact["channel"], row["freebsd_major"])
+        if key in selected:
+            if key in indexed:
+                raise ArtifactValidationError(f"identity report: duplicate selected identity {key!r}")
+            indexed[key] = artifact
+        elif reject_unselected:
+            raise ArtifactValidationError(f"identity report: unexpected identity {key!r}")
+
+    missing = sorted(selected - indexed.keys())
+    if missing and not allow_missing:
+        raise ArtifactValidationError(f"identity report: missing selected identity {missing[0]!r}")
+    return {"ports_ref": obj["ports_ref"], "artifacts": indexed, "document": obj}
+
+
+def _merge_identity_report(existing: dict, updated: dict, plan: list[tuple[FrozenTarget, dict]]) -> dict:
+    artifacts = dict(existing["artifacts"])
+    for artifact in updated["artifacts"]:
+        key = (artifact["channel"], artifact["matrix_row"]["freebsd_major"])
+        artifacts[key] = artifact
+    document = dict(existing["document"])
+    document["ports_ref"] = FROZEN_PORTS_REF
+    document["artifacts"] = []
+    for target, row in plan:
+        key = (target.channel, row["freebsd_major"])
+        if key in artifacts:
+            document["artifacts"].append(artifacts[key])
+    return document
+
+
+def _compare_report_identity(actual: dict, expected: dict) -> None:
+    for field in _REPORT_ARTIFACT_FIELDS:
+        if actual[field] != expected[field]:
+            raise ArtifactValidationError(
+                f"identity report mismatch for {field}: expected {expected[field]!r}, actual {actual[field]!r}"
+            )
+
+
 def build_all(
     plan: list[tuple[FrozenTarget, dict]],
     *,
@@ -672,6 +808,7 @@ def verify_staged(
     repo: Path,
     target_filter: str | None,
     major_filter: str | None,
+    oracle: dict,
 ) -> dict:
     _assert_no_staging_symlinks(dir_)
     export_cache: dict[str, Path] = {}
@@ -702,17 +839,17 @@ def verify_staged(
             pkg_path = candidates[0]
             identity = validate_artifact(pkg_path, export_dir, target, row)
             staged.add(pkg_path)
-            artifacts.append(
-                {
-                    "channel": target.channel,
-                    "tag": target.tag,
-                    "source_commit": target.commit,
-                    "ports_ref": FROZEN_PORTS_REF,
-                    "matrix_row": row,
-                    "staged_path": str(pkg_path.relative_to(dir_)),
-                    **identity,
-                }
-            )
+            actual = {
+                "channel": target.channel,
+                "tag": target.tag,
+                "source_commit": target.commit,
+                "ports_ref": FROZEN_PORTS_REF,
+                "matrix_row": row,
+                "staged_path": str(pkg_path.relative_to(dir_)),
+                **identity,
+            }
+            _compare_report_identity(actual, oracle["artifacts"][(target.channel, row["freebsd_major"])])
+            artifacts.append(actual)
     _assert_no_stray_pkgs(
         dir_,
         staged,
@@ -751,7 +888,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--report",
         type=Path,
         default=None,
-        help="JSON identity report path (default: <out>/frozen-v3-report.json).",
+        help="build mode writes the identity report here (default: <out>/frozen-v3-report.json).",
     )
     p.add_argument(
         "--ports-dir",
@@ -781,7 +918,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         metavar="DIR",
-        help="validate an already-staged DIR against the BUILD matrix without building anything.",
+        help=(
+            "verify-only requires the identity report as an oracle.\n"
+            "verify-only does not rewrite the identity report; validate DIR against the BUILD matrix "
+            "without building anything."
+        ),
     )
     p.add_argument(
         "--target",
@@ -814,15 +955,26 @@ def main(argv: list[str] | None = None) -> int:
             raise MatrixError("nothing to do: --target/--major filters excluded every BUILD-matrix row")
 
         if args.verify_only is not None:
+            oracle = _read_identity_report(report_path, plan)
             report = verify_staged(
                 args.verify_only.resolve(),
                 plan,
                 repo=repo,
                 target_filter=args.target,
                 major_filter=major_filter,
+                oracle=oracle,
             )
         else:
             out_dir.mkdir(parents=True, exist_ok=True)
+            full_plan = plan_artifacts(rows, target_filter=None, major_filter=None)
+            existing = None
+            if (args.target is not None or major_filter is not None) and report_path.exists():
+                existing = _read_identity_report(
+                    report_path,
+                    full_plan,
+                    allow_missing=True,
+                    reject_unselected=True,
+                )
             report = build_all(
                 plan,
                 repo=repo,
@@ -833,10 +985,11 @@ def main(argv: list[str] | None = None) -> int:
                 target_filter=args.target,
                 major_filter=major_filter,
             )
-
-        report_path.parent.mkdir(parents=True, exist_ok=True)
-        report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
-        print(f"build-frozen-v3.py: wrote {report_path} ({len(report['artifacts'])} artifact(s))", file=sys.stderr)
+            if existing is not None:
+                report = _merge_identity_report(existing, report, full_plan)
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+            print(f"build-frozen-v3.py: wrote {report_path} ({len(report['artifacts'])} artifact(s))", file=sys.stderr)
         return 0
     except (MatrixError, TagResolutionError, BuildLegError, ArtifactValidationError, DeterminismError) as e:
         print(f"build-frozen-v3.py: {e}", file=sys.stderr)

--- a/scripts/build-frozen-v3.py
+++ b/scripts/build-frozen-v3.py
@@ -370,6 +370,21 @@ def validate_artifact(pkg_path: Path, export_dir: Path, target: FrozenTarget, ro
     export_root = export_dir.resolve()
     payload_inventory: dict[str, str] = {}
     for member_name, data in sorted(payload.items()):
+        manifest_entry = files_manifest[member_name]
+        if not isinstance(manifest_entry, dict):
+            raise ArtifactValidationError(f"{pkg_path.name}: manifest file entry {member_name!r} must be an object")
+        manifest_sum = manifest_entry.get("sum")
+        if not isinstance(manifest_sum, str) or re.fullmatch(r"1\$[0-9a-f]{64}", manifest_sum) is None:
+            raise ArtifactValidationError(
+                f"{pkg_path.name}: manifest file entry {member_name!r} has malformed sum {manifest_sum!r}"
+            )
+        payload_sha256 = hashlib.sha256(data).hexdigest()
+        expected_sum = f"1${payload_sha256}"
+        if manifest_sum != expected_sum:
+            raise ArtifactValidationError(
+                f"{pkg_path.name}: manifest checksum mismatch for payload file {member_name!r}: "
+                f"expected {expected_sum!r}, actual {manifest_sum!r}"
+            )
         rel = member_name.lstrip("/")
         export_path = (export_dir / rel).resolve()
         if export_path != export_root and export_root not in export_path.parents:
@@ -390,7 +405,7 @@ def validate_artifact(pkg_path: Path, export_dir: Path, target: FrozenTarget, ro
                 )
         elif data != export_bytes:
             raise ArtifactValidationError(f"{pkg_path.name}: payload file {member_name!r} diverges from the tag export")
-        payload_inventory[member_name] = hashlib.sha256(data).hexdigest()
+        payload_inventory[member_name] = payload_sha256
 
     artifact_sha256 = hashlib.sha256(pkg_path.read_bytes()).hexdigest()
 

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -1082,6 +1082,337 @@ def test_verify_only_validates_staged_dir_without_invoking_build_seam(
     assert len(report["artifacts"]) == 1
 
 
+def _stage_valid_artifact(tmp_path: Path, stage: Path, target: Any, row: dict) -> Path:
+    """Stage one identity-valid fixture and return its export directory."""
+    fixture_root = tmp_path / f"fixture-{target.channel}-{row['freebsd_major']}"
+    _, export_dir = _happy_fixture(
+        fixture_root,
+        target,
+        row,
+        out_dir=stage / f"fbsd{row['freebsd_major']}",
+    )
+    return export_dir
+
+
+def _stub_verify_exports(monkeypatch: pytest.MonkeyPatch, exports: dict[str, Path]) -> None:
+    _stub_git(monkeypatch, exports)
+
+
+def test_issue_2019_filtered_target_accepts_other_frozen_target_but_rejects_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Target-filtered verification accepts the sibling target in the selected major."""
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE, DEVEL))
+    stage = tmp_path / "stage"
+    exports = {
+        STABLE.commit: _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15),
+        DEVEL.commit: _stage_valid_artifact(tmp_path, stage, DEVEL, ROW_15),
+    }
+    _stub_verify_exports(monkeypatch, exports)
+
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+    rc = bfv.main(
+        [
+            "--out",
+            str(stage),
+            "--verify-only",
+            str(stage),
+            "--target",
+            "stable",
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0, "a legitimate sibling target in the selected major must be ignored"
+
+    _write_pkg(stage / "fbsd15" / "random-extra-1.0.pkg", name="random-extra", version="1.0")
+    rc = bfv.main(
+        [
+            "--out",
+            str(stage),
+            "--verify-only",
+            str(stage),
+            "--target",
+            "stable",
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 1, "an unknown selected-major package must be rejected"
+
+
+def test_issue_2019_major_filter_ignores_unselected_valid_major_pkg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Major-filtered verification ignores valid-layout packages in unselected majors."""
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    stage = tmp_path / "stage"
+    export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
+    _stub_verify_exports(monkeypatch, {STABLE.commit: export})
+    (stage / "fbsd16").mkdir(parents=True)
+    _write_pkg(stage / "fbsd16" / "random-extra-1.0.pkg", name="random-extra", version="1.0")
+
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15, ROW_16]))
+    rc = bfv.main(
+        [
+            "--out",
+            str(stage),
+            "--verify-only",
+            str(stage),
+            "--major",
+            "15",
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "root-extra.pkg",
+        "not-fbsd/random-extra.pkg",
+        "fbsd15/nested/random-extra.pkg",
+    ],
+)
+def test_issue_2019_invalid_pkg_layout_rejected_recursively(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, relative_path: str
+) -> None:
+    """Stray scan rejects root, non-fbsd, and deeper package paths under every filter."""
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    stage = tmp_path / "stage"
+    export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
+    _stub_verify_exports(monkeypatch, {STABLE.commit: export})
+    stray = stage / relative_path
+    stray.parent.mkdir(parents=True, exist_ok=True)
+    _write_pkg(stray, name="random-extra", version="1.0")
+
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+    rc = bfv.main(
+        [
+            "--out",
+            str(stage),
+            "--verify-only",
+            str(stage),
+            "--target",
+            "stable",
+            "--major",
+            "15",
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 1
+
+
+def test_issue_2019_stray_diagnostics_report_relative_paths_for_duplicate_basenames(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No-filter stray diagnostics include both selected relative paths for one basename."""
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    stage = tmp_path / "stage"
+    export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
+    _stage_valid_artifact(tmp_path, stage, STABLE, ROW_16)
+    _stub_verify_exports(monkeypatch, {STABLE.commit: export})
+    for major in ("15", "16"):
+        _write_pkg(stage / f"fbsd{major}" / "same-extra.pkg", name="same-extra", version="1.0")
+
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15, ROW_16]))
+    rc = bfv.main(
+        [
+            "--out",
+            str(stage),
+            "--verify-only",
+            str(stage),
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 1
+    stderr = capsys.readouterr().err
+    assert "fbsd15/same-extra.pkg" in stderr
+    assert "fbsd16/same-extra.pkg" in stderr
+
+
+def test_issue_2019_stable_filename_boundary_does_not_claim_devel_pkg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stable's shorter port name cannot claim the legitimate devel sibling filename."""
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE, DEVEL))
+    stage = tmp_path / "stage"
+    stable_export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
+    _stage_valid_artifact(tmp_path, stage, DEVEL, ROW_15)
+    _stub_verify_exports(monkeypatch, {STABLE.commit: stable_export, DEVEL.commit: stable_export})
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+
+    rc = bfv.main(
+        [
+            "--out",
+            str(stage),
+            "--verify-only",
+            str(stage),
+            "--target",
+            "stable",
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+        ]
+    )
+    assert rc == 0, "stable candidate boundary must not claim the devel sibling"
+
+
+@pytest.mark.parametrize("target_filter", [None, "stable"])
+def test_issue_2019_selected_scope_rejects_stale_frozen_target_revision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target_filter: str | None
+) -> None:
+    """A build rejects extra revisions of a selected frozen target."""
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    export = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    _stub_git(monkeypatch, {STABLE.commit: export})
+    monkeypatch.setattr(bfv, "_invoke_build_leg", _fake_build_leg({"stable": STABLE}))
+    stage = tmp_path / "stage"
+    (stage / "fbsd15").mkdir(parents=True)
+    _write_pkg(
+        stage / "fbsd15" / f"{STABLE.portname}-{STABLE.portversion}_1.pkg",
+        name=STABLE.portname,
+        version=f"{STABLE.portversion}_1",
+        files=_demo_payload(STABLE.portname),
+    )
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+
+    assert (
+        bfv.main(
+            [
+                "--out",
+                str(stage),
+                "--matrix-cmd",
+                f"cat {matrix_file}",
+                "--repo",
+                str(tmp_path),
+                "--no-deterministic-check",
+            ]
+            + (["--target", target_filter] if target_filter is not None else [])
+        )
+        == 1
+    )
+
+
+def test_issue_2019_build_rejects_symlinked_leg_before_staging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Build mode cannot stage through a symlinked FreeBSD leg directory."""
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    export = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    _stub_git(monkeypatch, {STABLE.commit: export})
+    monkeypatch.setattr(bfv, "_invoke_build_leg", _fake_build_leg({"stable": STABLE}))
+    stage = tmp_path / "stage"
+    outside = tmp_path / "outside"
+    stage.mkdir()
+    outside.mkdir()
+    (stage / "fbsd15").symlink_to(outside, target_is_directory=True)
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+
+    assert (
+        bfv.main(
+            [
+                "--out",
+                str(stage),
+                "--matrix-cmd",
+                f"cat {matrix_file}",
+                "--repo",
+                str(tmp_path),
+                "--no-deterministic-check",
+            ]
+        )
+        == 1
+    )
+    assert not (outside / f"{STABLE.portname}-{STABLE.portversion}.pkg").exists()
+
+
+def test_issue_2019_verify_rejects_packages_hidden_by_symlinked_leg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify mode cannot overlook packages behind a symlinked leg directory."""
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    stage = tmp_path / "stage"
+    outside = tmp_path / "outside"
+    stage.mkdir()
+    outside.mkdir()
+    (stage / "fbsd15").symlink_to(outside, target_is_directory=True)
+    export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
+    _write_pkg(outside / "random-extra-1.0.pkg", name="random-extra", version="1.0")
+    _stub_verify_exports(monkeypatch, {STABLE.commit: export})
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+
+    assert (
+        bfv.main(
+            [
+                "--out",
+                str(stage),
+                "--verify-only",
+                str(stage),
+                "--matrix-cmd",
+                f"cat {matrix_file}",
+                "--repo",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+
+
+def test_issue_2019_target_and_major_filters_scope_strays_to_intersection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Combined filters accept sibling/other-major staging but reject selected-scope extras."""
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE, DEVEL))
+    stage = tmp_path / "stage"
+    stable_export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
+    _stage_valid_artifact(tmp_path, stage, DEVEL, ROW_15)
+    _stub_verify_exports(monkeypatch, {STABLE.commit: stable_export, DEVEL.commit: stable_export})
+    (stage / "fbsd16").mkdir(parents=True)
+    _write_pkg(stage / "fbsd16" / "random-extra-1.0.pkg", name="random-extra", version="1.0")
+
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15, ROW_16]))
+    args = [
+        "--out",
+        str(stage),
+        "--verify-only",
+        str(stage),
+        "--target",
+        "stable",
+        "--major",
+        "15",
+        "--matrix-cmd",
+        f"cat {matrix_file}",
+        "--repo",
+        str(tmp_path),
+    ]
+    assert bfv.main(args) == 0
+
+    _write_pkg(stage / "fbsd15" / "random-extra-1.0.pkg", name="random-extra", version="1.0")
+    assert bfv.main(args) == 1
+
+
 def test_staging_layout_no_extra_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
     monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -1140,32 +1140,53 @@ def test_matrix_row_with_non_string_scalar_rejected_cleanly(field: str) -> None:
         bfv.validate_matrix([row])
 
 
-def test_verify_only_validates_staged_dir_without_invoking_build_seam(
+def test_issue_2021_verify_only_uses_build_report_without_invoking_build_seam(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
     monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE,))
+    export_dir = _write_export(tmp_path / "src", _demo_payload(STABLE.portname))
     _stub_git(monkeypatch, {STABLE.commit: export_dir})
+    monkeypatch.setattr(bfv, "_invoke_build_leg", _fake_build_leg({"stable": STABLE}))
+
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps([ROW_15]))
+    stage_dir = tmp_path / "stage"
+    report_path = stage_dir / "frozen-v3-report.json"
+    report_writes: list[Path] = []
+    real_write_text = Path.write_text
+
+    def track_report_write(path: Path, *args: Any, **kwargs: Any) -> int:
+        if path == report_path:
+            report_writes.append(path)
+        return real_write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", track_report_write)
+    assert (
+        bfv.main(
+            [
+                "--out",
+                str(stage_dir),
+                "--matrix-cmd",
+                f"cat {matrix_file}",
+                "--repo",
+                str(tmp_path),
+                "--no-deterministic-check",
+            ]
+        )
+        == 0
+    )
+    assert report_writes == [report_path]
+    report_bytes = report_path.read_bytes()
 
     def boom(argv: list[str], *, cwd: Path) -> str:
         raise AssertionError("build seam must not be invoked in --verify-only mode")
 
     monkeypatch.setattr(bfv, "_invoke_build_leg", boom)
 
-    stage_dir = tmp_path / "stage"
-    (stage_dir / "fbsd15").mkdir(parents=True)
-    pkg_path = stage_dir / "fbsd15" / f"{STABLE.portname}-{STABLE.portversion}.pkg"
-    _write_pkg(
-        pkg_path,
-        name=STABLE.portname,
-        version=STABLE.portversion,
-        deps=_deps_for(ROW_15),
-        scripts=DEMO_SCRIPTS,
-        files=_packaged_payload(STABLE.portname, STABLE.portversion),
-    )
+    def fail_write(self: Path, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("verify-only must not rewrite the identity report")
 
-    matrix_file = tmp_path / "matrix.json"
-    matrix_file.write_text(json.dumps([ROW_15]))
+    monkeypatch.setattr(Path, "write_text", fail_write)
 
     rc = bfv.main(
         [
@@ -1180,8 +1201,7 @@ def test_verify_only_validates_staged_dir_without_invoking_build_seam(
         ]
     )
     assert rc == 0
-    report = json.loads((stage_dir / "frozen-v3-report.json").read_text())
-    assert len(report["artifacts"]) == 1
+    assert report_path.read_bytes() == report_bytes
 
 
 def _stage_valid_artifact(tmp_path: Path, stage: Path, target: Any, row: dict) -> Path:
@@ -1200,6 +1220,500 @@ def _stub_verify_exports(monkeypatch: pytest.MonkeyPatch, exports: dict[str, Pat
     _stub_git(monkeypatch, exports)
 
 
+def _issue_2021_build_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    targets: tuple[Any, ...] = (STABLE,),
+    rows: tuple[dict, ...] = (ROW_15,),
+) -> tuple[Path, Path, Path]:
+    """Build a real fixture so verify-only consumes the exact emitted report bytes."""
+    exports = {
+        target.commit: _write_export(tmp_path / f"src-{target.channel}", _demo_payload(target.portname))
+        for target in targets
+    }
+    monkeypatch.setattr(bfv, "FROZEN_TARGETS", targets)
+    _stub_git(monkeypatch, exports)
+    monkeypatch.setattr(bfv, "_invoke_build_leg", _fake_build_leg({t.channel: t for t in targets}))
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text(json.dumps(list(rows)))
+    stage = tmp_path / "stage"
+    assert (
+        bfv.main(
+            [
+                "--out",
+                str(stage),
+                "--matrix-cmd",
+                f"cat {matrix_file}",
+                "--repo",
+                str(tmp_path),
+                "--no-deterministic-check",
+            ]
+        )
+        == 0
+    )
+    return stage, matrix_file, stage / "frozen-v3-report.json"
+
+
+def _run_issue_2021_verify(
+    stage: Path,
+    matrix_file: Path,
+    tmp_path: Path,
+    *,
+    report: Path | None = None,
+    target: str | None = None,
+    major: int | None = None,
+) -> int:
+    args = [
+        "--out",
+        str(stage),
+        "--verify-only",
+        str(stage),
+        "--matrix-cmd",
+        f"cat {matrix_file}",
+        "--repo",
+        str(tmp_path),
+    ]
+    if report is not None:
+        args += ["--report", str(report)]
+    if target is not None:
+        args += ["--target", target]
+    if major is not None:
+        args += ["--major", str(major)]
+    return bfv.main(args)
+
+
+def _load_report(report_path: Path) -> dict:
+    return json.loads(report_path.read_text())
+
+
+def _write_report(report_path: Path, report: dict) -> bytes:
+    raw = json.dumps(report, indent=2, sort_keys=True).encode() + b"\n"
+    report_path.write_bytes(raw)
+    return raw
+
+
+def _strip_pkg_payload(pkg_path: Path, member_to_remove: str) -> None:
+    manifest, payload = bfv._read_pkg(pkg_path)
+    assert member_to_remove in payload
+    payload.pop(member_to_remove)
+    _write_pkg(
+        pkg_path,
+        name=manifest["name"],
+        version=manifest["version"],
+        origin=manifest["origin"],
+        abi=manifest["abi"],
+        arch=manifest["arch"],
+        deps=manifest["deps"],
+        scripts=manifest["scripts"],
+        files=payload,
+    )
+
+
+def _seed_verify_report(stage: Path, entries: list[tuple[Any, dict, Path]]) -> None:
+    artifacts = []
+    for target, row, export_dir in entries:
+        pkg_path = stage / f"fbsd{row['freebsd_major']}" / f"{target.portname}-{target.portversion}.pkg"
+        identity = bfv.validate_artifact(pkg_path, export_dir, target, row)
+        artifacts.append(
+            {
+                "channel": target.channel,
+                "tag": target.tag,
+                "source_commit": target.commit,
+                "ports_ref": bfv.FROZEN_PORTS_REF,
+                "matrix_row": row,
+                "staged_path": str(pkg_path.relative_to(stage)),
+                **identity,
+            }
+        )
+    _write_report(stage / "frozen-v3-report.json", {"ports_ref": bfv.FROZEN_PORTS_REF, "artifacts": artifacts})
+
+
+def test_issue_2021_full_report_binds_selected_identity_and_ignores_extra_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(
+        tmp_path, monkeypatch, targets=(STABLE, DEVEL), rows=(ROW_15, ROW_16)
+    )
+    report = _load_report(report_path)
+    report["metadata"] = {"producer": "fixture", "ignored": [1, 2, 3]}
+    report["artifacts"][0]["extra_metadata"] = {"ignored": True}
+    explicit_report = tmp_path / "oracle.json"
+    original = _write_report(explicit_report, report)
+    report_path.unlink()
+
+    monkeypatch.setattr(bfv, "_invoke_build_leg", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path, report=explicit_report) == 0
+    assert explicit_report.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    ("target", "major"),
+    [("stable", None), (None, 15)],
+)
+def test_issue_2021_filtered_verify_compares_selected_rows_and_preserves_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: str | None, major: int | None
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(
+        tmp_path, monkeypatch, targets=(STABLE, DEVEL), rows=(ROW_15, ROW_16)
+    )
+    original = report_path.read_bytes()
+    monkeypatch.setattr(bfv, "_invoke_build_leg", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path, target=target, major=major) == 0
+    assert report_path.read_bytes() == original
+
+
+@pytest.mark.parametrize("filter_args", [["--target", "stable"], ["--major", "15"]])
+def test_issue_2021_filtered_rebuild_preserves_full_stage_oracle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, filter_args: list[str]
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(
+        tmp_path, monkeypatch, targets=(STABLE, DEVEL), rows=(ROW_15, ROW_16)
+    )
+    report = _load_report(report_path)
+    report["metadata"] = {"preserve": True}
+    _write_report(report_path, report)
+    args = [
+        "--out",
+        str(stage),
+        "--matrix-cmd",
+        f"cat {matrix_file}",
+        "--repo",
+        str(tmp_path),
+        "--no-deterministic-check",
+        *filter_args,
+    ]
+
+    assert bfv.main(args) == 0
+    rebuilt = _load_report(report_path)
+    assert rebuilt["metadata"] == {"preserve": True}
+    assert len(rebuilt["artifacts"]) == 4
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 0
+
+
+def test_issue_2021_filtered_rebuild_merges_partial_known_oracle_without_fabrication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(
+        tmp_path, monkeypatch, targets=(STABLE, DEVEL), rows=(ROW_15, ROW_16)
+    )
+    report = _load_report(report_path)
+    report["artifacts"] = [
+        artifact
+        for artifact in report["artifacts"]
+        if (artifact["channel"], artifact["matrix_row"]["freebsd_major"]) == ("devel", "15")
+    ]
+    _write_report(report_path, report)
+
+    assert (
+        bfv.main(
+            [
+                "--out",
+                str(stage),
+                "--matrix-cmd",
+                f"cat {matrix_file}",
+                "--repo",
+                str(tmp_path),
+                "--no-deterministic-check",
+                "--target",
+                "stable",
+            ]
+        )
+        == 0
+    )
+    rebuilt = _load_report(report_path)
+    keys = {(a["channel"], a["matrix_row"]["freebsd_major"]) for a in rebuilt["artifacts"]}
+    assert keys == {("stable", "15"), ("stable", "16"), ("devel", "15")}
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path, target="stable") == 0
+
+
+def test_issue_2021_filtered_rebuild_rejects_unknown_oracle_identity_before_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(
+        tmp_path, monkeypatch, targets=(STABLE, DEVEL), rows=(ROW_15, ROW_16)
+    )
+    report = _load_report(report_path)
+    report["artifacts"][0]["channel"] = "unknown"
+    original = _write_report(report_path, report)
+    monkeypatch.setattr(bfv, "_invoke_build_leg", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+
+    rc = bfv.main(
+        [
+            "--out",
+            str(stage),
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+            "--no-deterministic-check",
+            "--target",
+            "stable",
+        ]
+    )
+    assert rc == 1
+    assert "unexpected identity" in capsys.readouterr().err
+    assert report_path.read_bytes() == original
+
+
+def test_issue_2021_filtered_rebuild_restores_full_plan_order_and_preserves_unselected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(
+        tmp_path, monkeypatch, targets=(STABLE, DEVEL), rows=(ROW_15, ROW_16)
+    )
+    report = _load_report(report_path)
+    devel_15 = next(
+        artifact
+        for artifact in report["artifacts"]
+        if (artifact["channel"], artifact["matrix_row"]["freebsd_major"]) == ("devel", "15")
+    )
+    devel_15["preserved"] = True
+    report["artifacts"].reverse()
+    _write_report(report_path, report)
+
+    assert (
+        bfv.main(
+            [
+                "--out",
+                str(stage),
+                "--matrix-cmd",
+                f"cat {matrix_file}",
+                "--repo",
+                str(tmp_path),
+                "--no-deterministic-check",
+                "--target",
+                "stable",
+            ]
+        )
+        == 0
+    )
+    rebuilt = _load_report(report_path)
+    keys = [(a["channel"], a["matrix_row"]["freebsd_major"]) for a in rebuilt["artifacts"]]
+    assert keys == [("stable", "15"), ("stable", "16"), ("devel", "15"), ("devel", "16")]
+    assert next(a for a in rebuilt["artifacts"] if a["channel"] == "devel" and a["matrix_row"] == ROW_15)["preserved"]
+
+
+def test_issue_2021_stripped_real_payload_is_rejected_and_oracle_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
+    pkg_path = next(stage.glob("fbsd15/*.pkg"))
+    _strip_pkg_payload(pkg_path, "/usr/local/www/pfblockerng/index.php")
+    original = report_path.read_bytes()
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
+    assert report_path.read_bytes() == original
+
+
+def test_issue_2021_artifact_checksum_mismatch_rejected_independently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
+    pkg_path = next(stage.glob("fbsd15/*.pkg"))
+    _strip_pkg_payload(pkg_path, "/usr/local/www/pfblockerng/index.php")
+    _, payload = bfv._read_pkg(pkg_path)
+    report = _load_report(report_path)
+    report["artifacts"][0]["payload_file_count"] = len(payload)
+    report["artifacts"][0]["payload_files"] = {
+        path: hashlib.sha256(data).hexdigest() for path, data in sorted(payload.items())
+    }
+    report["artifacts"][0]["artifact_sha256"] = "0" * 64
+    original = _write_report(report_path, report)
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
+    assert report_path.read_bytes() == original
+
+
+def test_issue_2021_payload_inventory_mismatch_rejected_when_oracle_checksum_matches_stripped_pkg(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
+    pkg_path = next(stage.glob("fbsd15/*.pkg"))
+    _strip_pkg_payload(pkg_path, "/usr/local/www/pfblockerng/index.php")
+    report = _load_report(report_path)
+    report["artifacts"][0]["artifact_sha256"] = hashlib.sha256(pkg_path.read_bytes()).hexdigest()
+    original = _write_report(report_path, report)
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
+    assert report_path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    ("field", "mutate"),
+    [
+        ("channel", lambda a: "devel"),
+        ("tag", lambda a: "v999"),
+        ("source_commit", lambda a: "0" * 40),
+        ("ports_ref", lambda a: "1" * 40),
+        ("record_ports_ref", lambda a: "1" * 40),
+        ("matrix_row", lambda a: dict(ROW_16)),
+        ("staged_path", lambda a: "fbsd15/$([ -f PWNED ]).pkg"),
+        ("name", lambda a: "other"),
+        ("version", lambda a: "9.9.9"),
+        ("origin", lambda a: "evil/origin"),
+        ("abi", lambda a: "FreeBSD:99:*"),
+        ("arch", lambda a: "freebsd:99:*"),
+        ("artifact_sha256", lambda a: "0" * 64),
+        ("payload_file_count", lambda a: a["payload_file_count"] + 1),
+        ("payload_files", lambda a: {**a["payload_files"], next(iter(a["payload_files"])): "f" * 64}),
+        ("install_script_sha256", lambda a: "0" * 64),
+        ("deinstall_script_sha256", lambda a: "0" * 64),
+    ],
+)
+def test_issue_2021_every_emitted_identity_field_mismatch_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    mutate: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
+    report = _load_report(report_path)
+    artifact = report["artifacts"][0]
+    if field == "ports_ref":
+        report["ports_ref"] = mutate(artifact)
+    elif field == "record_ports_ref":
+        artifact["ports_ref"] = mutate(artifact)
+    else:
+        artifact[field] = mutate(artifact)
+    original = _write_report(report_path, report)
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
+    stderr = capsys.readouterr().err
+    expected_field = "ports_ref" if field == "record_ports_ref" else field
+    assert expected_field in stderr or "missing selected identity" in stderr
+    assert report_path.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, "unreadable"),
+        (b"", "malformed JSON"),
+        (b"{not-json", "malformed JSON"),
+        (b"\xff\xfe", "malformed JSON"),
+        (b"[]", "top level must be an object"),
+        (json.dumps({"ports_ref": bfv.FROZEN_PORTS_REF, "artifacts": {}}).encode(), "artifacts must be a list"),
+        (
+            json.dumps({"ports_ref": bfv.FROZEN_PORTS_REF, "artifacts": ["not-an-object"]}).encode(),
+            "artifact 0: must be an object",
+        ),
+        (
+            json.dumps({"ports_ref": bfv.FROZEN_PORTS_REF, "artifacts": [{"channel": "stable"}]}).encode(),
+            "artifact 0: missing field(s)",
+        ),
+    ],
+)
+def test_issue_2021_missing_or_hostile_oracle_rejected_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw: bytes | None,
+    expected: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
+    if raw is None:
+        report_path.unlink()
+        before = None
+    else:
+        report_path.write_bytes(raw)
+        before = raw
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
+    stderr = capsys.readouterr().err
+    assert expected in stderr
+    assert "Traceback" not in stderr
+    if before is not None:
+        assert report_path.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        (
+            "matrix_row",
+            {"freebsd_major": "../15", "php_version": "8.3", "py_flavor": "py311"},
+            "malformed matrix_row",
+        ),
+        ("staged_path", None, "staged_path is unsafe"),
+        ("staged_path", "fbsd15/demo\x00.pkg", "staged_path is unsafe"),
+        ("staged_path", "/absolute.pkg", "staged_path is unsafe"),
+        ("staged_path", "fbsd15/nested/demo.pkg", "staged_path is unsafe"),
+        ("staged_path", "other/demo.pkg", "staged_path is unsafe"),
+        ("staged_path", "fbsd15/demo.txt", "staged_path is unsafe"),
+        ("staged_path", "fbsd15/$unsafe.pkg", "unsafe path segment"),
+        ("channel", 1, "channel must be a string"),
+        ("tag", 1, "tag must be a string"),
+        ("source_commit", 1, "source_commit must be a string"),
+        ("ports_ref", 1, "ports_ref must be a string"),
+        ("name", 1, "name must be a string"),
+        ("version", 1, "version must be a string"),
+        ("origin", 1, "origin must be a string"),
+        ("abi", 1, "abi must be a string"),
+        ("arch", 1, "arch must be a string"),
+        ("payload_file_count", True, "payload_file_count must be a non-negative integer"),
+        ("payload_file_count", -1, "payload_file_count must be a non-negative integer"),
+        ("payload_files", [], "payload_files must be an object"),
+        ("payload_files", {"/payload": None}, "payload_files contains malformed entry"),
+        ("payload_files", {"/payload": "not-a-sha256"}, "payload_files contains malformed entry"),
+        ("artifact_sha256", "0" * 63, "artifact_sha256 has malformed SHA-256"),
+        ("install_script_sha256", "g" * 64, "install_script_sha256 has malformed SHA-256"),
+        ("deinstall_script_sha256", "1$" + "0" * 64, "deinstall_script_sha256 has malformed SHA-256"),
+    ],
+)
+def test_issue_2021_hostile_oracle_branch_rejected_with_specific_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: object,
+    expected: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
+    report = _load_report(report_path)
+    report["artifacts"][0][field] = value
+    original = _write_report(report_path, report)
+
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
+    stderr = capsys.readouterr().err
+    assert expected in stderr
+    assert "Traceback" not in stderr
+    assert report_path.read_bytes() == original
+
+
+@pytest.mark.parametrize("field", ["artifact_sha256", "install_script_sha256", "deinstall_script_sha256"])
+@pytest.mark.parametrize("value", [None, 123, [], {}])
+def test_issue_2021_non_string_report_hash_rejected_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    field: str,
+    value: object,
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
+    report = _load_report(report_path)
+    report["artifacts"][0][field] = value
+    original = _write_report(report_path, report)
+
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
+    stderr = capsys.readouterr().err
+    assert field in stderr
+    assert "Traceback" not in stderr
+    assert report_path.read_bytes() == original
+
+
+def test_issue_2021_help_describes_report_oracle_contract() -> None:
+    help_text = bfv.build_arg_parser().format_help().lower()
+    assert "build mode writes the identity report" in help_text
+    assert "verify-only requires the identity report as an oracle" in help_text
+    assert "verify-only does not rewrite the identity report" in help_text
+
+
+def test_issue_2021_duplicate_selected_identity_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
+    report = _load_report(report_path)
+    report["artifacts"].append(dict(report["artifacts"][0]))
+    original = _write_report(report_path, report)
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
+    assert report_path.read_bytes() == original
+
+
 def test_issue_2019_filtered_target_accepts_other_frozen_target_but_rejects_unknown(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1211,6 +1725,7 @@ def test_issue_2019_filtered_target_accepts_other_frozen_target_but_rejects_unkn
         DEVEL.commit: _stage_valid_artifact(tmp_path, stage, DEVEL, ROW_15),
     }
     _stub_verify_exports(monkeypatch, exports)
+    _seed_verify_report(stage, [(STABLE, ROW_15, exports[STABLE.commit]), (DEVEL, ROW_15, exports[DEVEL.commit])])
 
     matrix_file = tmp_path / "matrix.json"
     matrix_file.write_text(json.dumps([ROW_15]))
@@ -1256,6 +1771,7 @@ def test_issue_2019_major_filter_ignores_unselected_valid_major_pkg(
     stage = tmp_path / "stage"
     export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
     _stub_verify_exports(monkeypatch, {STABLE.commit: export})
+    _seed_verify_report(stage, [(STABLE, ROW_15, export)])
     (stage / "fbsd16").mkdir(parents=True)
     _write_pkg(stage / "fbsd16" / "random-extra-1.0.pkg", name="random-extra", version="1.0")
 
@@ -1328,6 +1844,7 @@ def test_issue_2019_stray_diagnostics_report_relative_paths_for_duplicate_basena
     export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
     _stage_valid_artifact(tmp_path, stage, STABLE, ROW_16)
     _stub_verify_exports(monkeypatch, {STABLE.commit: export})
+    _seed_verify_report(stage, [(STABLE, ROW_15, export), (STABLE, ROW_16, export)])
     for major in ("15", "16"):
         _write_pkg(stage / f"fbsd{major}" / "same-extra.pkg", name="same-extra", version="1.0")
 
@@ -1358,8 +1875,9 @@ def test_issue_2019_stable_filename_boundary_does_not_claim_devel_pkg(
     monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE, DEVEL))
     stage = tmp_path / "stage"
     stable_export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
-    _stage_valid_artifact(tmp_path, stage, DEVEL, ROW_15)
-    _stub_verify_exports(monkeypatch, {STABLE.commit: stable_export, DEVEL.commit: stable_export})
+    devel_export = _stage_valid_artifact(tmp_path, stage, DEVEL, ROW_15)
+    _stub_verify_exports(monkeypatch, {STABLE.commit: stable_export, DEVEL.commit: devel_export})
+    _seed_verify_report(stage, [(STABLE, ROW_15, stable_export), (DEVEL, ROW_15, devel_export)])
     matrix_file = tmp_path / "matrix.json"
     matrix_file.write_text(json.dumps([ROW_15]))
 
@@ -1461,24 +1979,11 @@ def test_issue_2019_verify_rejects_packages_hidden_by_symlinked_leg(
     export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
     _write_pkg(outside / "random-extra-1.0.pkg", name="random-extra", version="1.0")
     _stub_verify_exports(monkeypatch, {STABLE.commit: export})
+    _seed_verify_report(stage, [(STABLE, ROW_15, export)])
     matrix_file = tmp_path / "matrix.json"
     matrix_file.write_text(json.dumps([ROW_15]))
 
-    assert (
-        bfv.main(
-            [
-                "--out",
-                str(stage),
-                "--verify-only",
-                str(stage),
-                "--matrix-cmd",
-                f"cat {matrix_file}",
-                "--repo",
-                str(tmp_path),
-            ]
-        )
-        == 1
-    )
+    assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
 
 
 def test_issue_2019_target_and_major_filters_scope_strays_to_intersection(
@@ -1488,8 +1993,9 @@ def test_issue_2019_target_and_major_filters_scope_strays_to_intersection(
     monkeypatch.setattr(bfv, "FROZEN_TARGETS", (STABLE, DEVEL))
     stage = tmp_path / "stage"
     stable_export = _stage_valid_artifact(tmp_path, stage, STABLE, ROW_15)
-    _stage_valid_artifact(tmp_path, stage, DEVEL, ROW_15)
-    _stub_verify_exports(monkeypatch, {STABLE.commit: stable_export, DEVEL.commit: stable_export})
+    devel_export = _stage_valid_artifact(tmp_path, stage, DEVEL, ROW_15)
+    _stub_verify_exports(monkeypatch, {STABLE.commit: stable_export, DEVEL.commit: devel_export})
+    _seed_verify_report(stage, [(STABLE, ROW_15, stable_export), (DEVEL, ROW_15, devel_export)])
     (stage / "fbsd16").mkdir(parents=True)
     _write_pkg(stage / "fbsd16" / "random-extra-1.0.pkg", name="random-extra", version="1.0")
 

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -67,6 +67,7 @@ def _write_pkg(
     compact_overrides: dict | None = None,
     link_members: tuple[tuple[str, str, int], ...] = (),
     duplicate_manifest: bool = False,
+    manifest_file_overrides: dict[str, object] | None = None,
 ) -> None:
     """Write a libpkg-shaped .pkg (zstd tar, +COMPACT_MANIFEST + +MANIFEST + payload)."""
     manifest: dict = {
@@ -105,6 +106,8 @@ def _write_pkg(
         }
         for p, b in (files or {}).items()
     }
+    if manifest_file_overrides:
+        full["files"].update(manifest_file_overrides)
     if scripts is not None:
         full["scripts"] = scripts
     full_raw = json.dumps(full, separators=(",", ":")).encode() + b"\n"
@@ -760,6 +763,105 @@ def test_info_xml_unsubstituted_pkgversion_token_rejected(tmp_path: Path) -> Non
     )
     with pytest.raises(bfv.ArtifactValidationError, match="info.xml"):
         bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+# Issue #2020: every +MANIFEST files[].sum must match packaged member bytes.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(("target", "row"), [(STABLE, ROW_15), (DEVEL, ROW_15)])
+def test_issue_2020_manifest_checksum_accepts_stable_and_devel(tmp_path: Path, target: Any, row: dict) -> None:
+    pkg_path, export_dir = _happy_fixture(tmp_path, target, row)
+    record = bfv.validate_artifact(pkg_path, export_dir, target, row)
+    assert record["payload_file_count"] == 3
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "/usr/local/pkg/pfblockerng/pfblockerng.inc",
+        "/usr/local/share/demo-pkg/info.xml",
+        "/usr/local/www/pfblockerng/index.php",
+    ],
+)
+def test_issue_2020_manifest_checksum_mismatch_rejected_for_each_member(tmp_path: Path, member_name: str) -> None:
+    files = _packaged_payload(STABLE.portname, STABLE.portversion)
+    expected = f"1${hashlib.sha256(files[member_name]).hexdigest()}"
+    wrong = "1$" + "0" * 64
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=files,
+        manifest_file_overrides={member_name: {"sum": wrong}},
+    )
+
+    with pytest.raises(bfv.ArtifactValidationError) as exc_info:
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+    message = str(exc_info.value)
+    assert member_name in message
+    assert expected in message
+    assert wrong in message
+
+
+def test_issue_2020_info_xml_export_checksum_rejected(tmp_path: Path) -> None:
+    files = _packaged_payload(STABLE.portname, STABLE.portversion)
+    info_path = f"/usr/local/share/{STABLE.portname}/info.xml"
+    export_sum = f"1${hashlib.sha256(_demo_payload(STABLE.portname)[info_path]).hexdigest()}"
+    packaged_sum = f"1${hashlib.sha256(files[info_path]).hexdigest()}"
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=files,
+        manifest_file_overrides={info_path: {"sum": export_sum}},
+    )
+
+    with pytest.raises(bfv.ArtifactValidationError) as exc_info:
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+    message = str(exc_info.value)
+    assert info_path in message
+    assert packaged_sum in message
+    assert export_sum in message
+
+
+@pytest.mark.parametrize(
+    ("label", "entry"),
+    [
+        ("wrong_digest", {"sum": "1$" + "0" * 64}),
+        ("missing_sum", {}),
+        ("wrong_prefix", {"sum": "2$" + "0" * 64}),
+        ("string_entry", "not-an-object"),
+        ("list_entry", []),
+        ("null_entry", None),
+    ],
+)
+def test_issue_2020_malformed_manifest_file_entry_rejected(tmp_path: Path, label: str, entry: object) -> None:
+    del label
+    member_name = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+    export_dir = _write_export(tmp_path, _demo_payload(STABLE.portname))
+    pkg_path = tmp_path / f"{STABLE.portname}-{STABLE.portversion}.pkg"
+    _write_pkg(
+        pkg_path,
+        name=STABLE.portname,
+        version=STABLE.portversion,
+        deps=_deps_for(ROW_15),
+        scripts=DEMO_SCRIPTS,
+        files=_packaged_payload(STABLE.portname, STABLE.portversion),
+        manifest_file_overrides={member_name: entry},
+    )
+
+    with pytest.raises(bfv.ArtifactValidationError) as exc_info:
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+    assert member_name in str(exc_info.value)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Close the three frozen-v3 build-driver defects found by PR #2012's adversarial review in one stacked review:

- make stray-package validation recursive and filter-aware, while reporting staging-root-relative paths;
- recompute every `+MANIFEST files[].sum` from the packaged member bytes and reject malformed or mismatched libpkg checksums;
- require `--verify-only` to compare each selected package with the prior build's preserved identity report, including artifact checksum and complete payload inventory.

The stack contains exactly one commit per issue:

1. `build: fix filtered frozen-v3 stray checks` — Fixes #2019
2. `build: verify frozen-v3 manifest file checksums` — Fixes #2020
3. `build: bind frozen-v3 verification to its identity report` — Fixes #2021

## Integrity evidence

- #2019: frozen tests failed 8/8 against pre-fix source, then passed 8/8 unchanged; independent gate replayed the source revert and probed filtered target/major ownership plus duplicate relative diagnostics.
- #2020: genuine zstd/USTAR packages with export-valid bytes and tampered manifest sums failed 10/12 before the fix, then passed 12/12; independent probes verified ordinary members and substituted `info.xml` against the packaged bytes.
- #2021: a build-produced package/report was repacked with one real payload member removed and a matching reduced manifest/checksum set. The directional validator accepted that self-consistent stripped package, while report-bound verification rejected it. Final frozen tests failed 47/47 against pre-#2021 source, then passed 47/47 unchanged. Independent probes separately exercised artifact SHA, payload inventory/count, all emitted identity fields, filtered verification, report preservation, hostile JSON types, and the CLI help contract.

## Gates

- `scripts/agent/run-gates.sh --diff origin/devel` — PASS after the final live rebase:
  - full `python3 -m pytest`
  - `ruff check .`
  - `ruff format --check .`
  - `mypy tests/`
  - `npx markdownlint-cli2`
- Focused frozen-driver module: 146 passed.
- Independent per-commit verifier gates: PASS after findings were corrected.

No Release upload, catalog generation, public catalog write, or other publication action is included or performed. That immutable/public boundary remains maintainer-gated on #1676.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
