### PR TITLE
tests: synchronize ADR-10 and top1m waits

### DIFF
--- a/tests/_adr10_reload_trigger.py
+++ b/tests/_adr10_reload_trigger.py
@@ -35,8 +35,8 @@ This serialises the writer against the builder so the builder always reads a CON
 (manifest, ini) pair -- the snapshot swap under test is atomic, but the build *input*
 (two separate files read in sequence) would otherwise race a mid-build overwrite and
 yield a self-consistent-but-cross-gen snapshot. The atomic _snapshot rebind is still
-exercised ``flips`` times, each a genuine generation advance every query thread must
-observe without a torn (mixed) view.
+exercised ``flips`` times; a query observes every intermediate generation, and every
+query thread observes the baseline and final generation without a torn (mixed) view.
 """
 
 from __future__ import annotations
@@ -87,6 +87,8 @@ def _wait_generation_marker(path: str, target: int, timeout: float) -> None:
             return
         time.sleep(0.01)
     actual = _read_gen(path)
+    if (actual or 0) >= target:
+        return
     raise RuntimeError(
         "wait_generation_marker stuck/environment: expected target generation {} at {!r}; actual={!r}".format(
             target, path, actual

--- a/tests/_adr10_reload_trigger.py
+++ b/tests/_adr10_reload_trigger.py
@@ -9,20 +9,19 @@ genuinely exercises the atomic-publish-vs-concurrent-read path. Pure stdlib -- i
 deliberately does NOT import ``pfb_unbound``, so it spawns clean under any start
 method (spawn/fork) and never drags the matcher into the trigger process.
 
-It alternates between TWO source pairs (gen1 <-> gen2), flipping ``K`` times with a
-small gap, so the query threads see repeated generational swaps over several seconds
--- an extended torn hunt, not a single edge. The user-regex lane lives in the ini, so
+It alternates between TWO source pairs (gen1 <-> gen2), flipping ``K`` times so the
+query threads see repeated generational swaps -- an extended torn hunt, not a single
+edge. The user-regex lane lives in the ini, so
 gen1 and gen2 carry DIFFERENT ini text; publishing the ini alongside the manifest is
 mandatory (a manifest-only flip would freeze the user-regex stratum across the swap).
 
 argv (positional):
-    <wait_before>           seconds to sleep before the FIRST flip (gen1 baseline)
     <flips>                 number of flips to perform (>=1); flip i publishes pair (i%2)
-    <gap>                   seconds to sleep AFTER each flip is applied, before the next
     <live_manifest_path>    where the live manifest is read by the watcher
     <live_ini_path>         where the live user-regex ini is read by the watcher
     <sentinel_path>         the reload-generation sentinel
     <applied_path>          the applied-generation marker the watcher publishes on swap
+    <observed_path>         the query-process marker for a completed generation scan
     <manifest_a> <ini_a>    gen1 source pair (published on even flips: 0, 2, ...)
     <manifest_b> <ini_b>    gen2 source pair (published on odd flips: 1, 3, ...)
 
@@ -31,12 +30,13 @@ FIRST flip (i=0) publishes pair B (gen2) -- i.e. we publish pair ``(i + 1) % 2``
 sequence the watcher applies is gen2, gen1, gen2, ... and every flip is a real advance.
 
 Each flip WAITS for the watcher to APPLY the resulting generation (the applied marker
-reaches ``2 + i``) before the next flip. This serialises the writer against the
-builder so the builder always reads a CONSISTENT (manifest, ini) pair -- the snapshot
-swap under test is atomic, but the build *input* (two separate files read in sequence)
-would otherwise race a mid-build overwrite and yield a self-consistent-but-cross-gen
-snapshot. The atomic _snapshot rebind is still exercised ``flips`` times, each a genuine
-generation advance the query threads must observe without a torn (mixed) view.
+reaches ``2 + i``), then for a query to OBSERVE that generation before the next flip.
+This serialises the writer against the builder so the builder always reads a CONSISTENT
+(manifest, ini) pair -- the snapshot swap under test is atomic, but the build *input*
+(two separate files read in sequence) would otherwise race a mid-build overwrite and
+yield a self-consistent-but-cross-gen snapshot. The atomic _snapshot rebind is still
+exercised ``flips`` times, each a genuine generation advance every query thread must
+observe without a torn (mixed) view.
 """
 
 from __future__ import annotations
@@ -78,30 +78,33 @@ def _bump_sentinel(sentinel: str) -> int:
     return nxt
 
 
-def _wait_applied(applied_path: str, target: int, timeout: float) -> None:
-    """Block until the watcher's applied marker reaches ``target`` (or ``timeout``)."""
+def _wait_generation_marker(path: str, target: int, timeout: float) -> None:
+    """Wait for a marker, failing loudly when the run is stuck or the environment is broken."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        if (_read_gen(applied_path) or 0) >= target:
+        actual = _read_gen(path)
+        if (actual or 0) >= target:
             return
         time.sleep(0.01)
+    actual = _read_gen(path)
+    raise RuntimeError(
+        "wait_generation_marker stuck/environment: expected target generation {} at {!r}; actual={!r}".format(
+            target, path, actual
+        )
+    )
 
 
 def main(argv: list[str]) -> int:
-    wait_before = float(argv[1])
-    flips = int(argv[2])
-    gap = float(argv[3])
-    live_manifest = argv[4]
-    live_ini = argv[5]
-    sentinel = argv[6]
-    applied = argv[7]
-    manifest_a, ini_a = argv[8], argv[9]
-    manifest_b, ini_b = argv[10], argv[11]
+    flips = int(argv[1])
+    live_manifest = argv[2]
+    live_ini = argv[3]
+    sentinel = argv[4]
+    applied = argv[5]
+    observed = argv[6]
+    manifest_a, ini_a = argv[7], argv[8]
+    manifest_b, ini_b = argv[9], argv[10]
 
     pairs = [(manifest_a, ini_a), (manifest_b, ini_b)]
-
-    # Let the query process accumulate a gen1 baseline against the OLD lists first.
-    time.sleep(wait_before)
 
     for i in range(flips):
         # Flip 0 publishes pair B (gen2), flip 1 pair A (gen1), ... -- the live state
@@ -116,9 +119,8 @@ def main(argv: list[str]) -> int:
         gen = _bump_sentinel(sentinel)
         # Wait for the watcher to APPLY this generation before flipping again, so the
         # next overwrite cannot race an in-flight build's (manifest, ini) reads.
-        _wait_applied(applied, gen, timeout=20.0)
-        if i + 1 < flips:
-            time.sleep(gap)
+        _wait_generation_marker(applied, gen, timeout=20.0)
+        _wait_generation_marker(observed, gen, timeout=20.0)
 
     return 0
 

--- a/tests/test_adr10_concurrency.py
+++ b/tests/test_adr10_concurrency.py
@@ -10,7 +10,7 @@ hammer the matcher. It proves the zero-downtime swap is:
   * REAL per lane -- gen1 and gen2 differ across EVERY block/allow mechanism, and the
     final state is verified down to a per-mechanism CONTROL domain, so a degenerate
     empty/all-blocked build cannot masquerade as a valid generation;
-  * non-stalling -- queries keep flowing throughout (high total count, no crash).
+  * synchronized -- every query thread observes the baseline and final generations.
 
 The trigger is a real second process (no shared GIL with the query process, like the
 PHP trigger on a box), so it genuinely races atomic-publish against concurrent-read.
@@ -44,14 +44,16 @@ repo's branch + before/after coverage rules.
 from __future__ import annotations
 
 import base64
+import importlib.util
 import json
 import os
 import subprocess
 import sys
 import threading
-import time
 from dataclasses import dataclass, field
 from typing import Any
+
+import pytest
 
 import pfb_unbound as P
 
@@ -311,6 +313,15 @@ def _write(path: str, data: str) -> None:
         fh.write(data)
 
 
+def _write_observed(path: str, generation: int) -> None:
+    tmp = "{}.tmp".format(path)
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write("{}\n".format(generation))
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, path)
+
+
 def _manifest_json(tld_master: str, plain_raw: str, user_raw: str, abp_raw: str, spec: GenSpec) -> str:
     return json.dumps(
         {
@@ -469,6 +480,7 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
     live_ini = os.path.join(tmp_dir, "live_pfb_unbound.ini")
     sentinel = os.path.join(tmp_dir, "pfb_py_reload")
     applied = os.path.join(tmp_dir, "pfb_py_reload.applied")
+    observed = os.path.join(tmp_dir, "pfb_py_reload.observed")
     _write(live_manifest, _read_file(g1_manifest))
     _write(live_ini, _read_file(g1_ini))
     _write(sentinel, "1\n")
@@ -507,8 +519,32 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
     stats: list[dict[str, int]] = []
     _torn_samples: list[dict[str, bool]] = []
     n_threads = 6
+    observed_condition = threading.Condition()
+    observed_generations = [0] * n_threads
+    observed_marker_generation = 0
 
-    def query_loop() -> None:
+    def record_observed(index: int, generation: int) -> None:
+        nonlocal observed_marker_generation
+        with observed_condition:
+            if generation <= observed_generations[index]:
+                return
+            observed_generations[index] = generation
+            if generation > observed_marker_generation:
+                observed_marker_generation = generation
+                _write_observed(observed, generation)
+            observed_condition.notify_all()
+
+    def wait_observed(target: int) -> None:
+        with observed_condition:
+            if not observed_condition.wait_for(
+                lambda: all(generation >= target for generation in observed_generations), timeout=60.0
+            ):
+                raise RuntimeError(
+                    "observed generation stuck/environment: expected target {} for every query thread; "
+                    "actual={!r}".format(target, observed_generations)
+                )
+
+    def query_loop(index: int) -> None:
         local = {"n": 0, "gen1": 0, "gen2": 0, "torn": 0}
         try:
             while not stop.is_set():
@@ -527,52 +563,55 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
                         _torn_samples.append(
                             {n: got[n] for n in _PROBE_NAMES if got[n] not in (expected_gen1[n], expected_gen2[n])}
                         )
+                applied_generation = P._reload_read_generation(applied)
+                if applied_generation and got == (expected_gen1 if applied_generation % 2 else expected_gen2):
+                    record_observed(index, applied_generation)
         except Exception as e:  # noqa: BLE001 -- record, never let a query crash silently
             errors.append(repr(e))
         stats.append(local)
 
-    threads = [threading.Thread(target=query_loop, daemon=True) for _ in range(n_threads)]
+    threads = [threading.Thread(target=query_loop, args=(index,), daemon=True) for index in range(n_threads)]
     for t in threads:
         t.start()
 
-    # BEFORE: let the loops read a gen1 baseline before the first flip.
-    time.sleep(0.15)
-    assert _scan(P._snapshot) == expected_gen1, "expected gen1 live before the trigger"
-
-    # Fire the trigger: it sleeps wait_before, then ALTERNATES gen2/gen1/gen2/... K times,
-    # waiting for the watcher to APPLY each generation before the next flip (so the build
-    # input never races a mid-build overwrite -- the atomic _snapshot swap is still
-    # exercised once per flip).
-    wait_before = 0.3
+    # BEFORE: every loop must scan and record the gen1 baseline before the trigger starts.
     flips = 5
-    gap = 0.05
-    proc = subprocess.Popen(
-        [
-            sys.executable,
-            _TRIGGER,
-            str(wait_before),
-            str(flips),
-            str(gap),
-            live_manifest,
-            live_ini,
-            sentinel,
-            applied,
-            g1_manifest,
-            g1_ini,
-            g2_manifest,
-            g2_ini,
-        ]
-    )
     last_gen_expected = expected_gen2 if flips % 2 == 1 else expected_gen1
     last_applied = 1 + flips
+    proc = None
     try:
+        wait_observed(1)
+        with observed_condition:
+            baseline_observed = observed_generations.copy()
+        assert baseline_observed == [1] * n_threads, "not every query thread observed gen1: {}".format(
+            baseline_observed
+        )
+        assert _scan(P._snapshot) == expected_gen1, "expected gen1 live before the trigger"
+
+        # Fire the trigger: it ALTERNATES gen2/gen1/gen2/... K times, waiting for the
+        # watcher to APPLY and a query to OBSERVE each generation before the next flip.
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                _TRIGGER,
+                str(flips),
+                live_manifest,
+                live_ini,
+                sentinel,
+                applied,
+                observed,
+                g1_manifest,
+                g1_ini,
+                g2_manifest,
+                g2_ini,
+            ]
+        )
         assert proc.wait(timeout=60) == 0, "trigger process failed to publish + flip"
-        # Wait (bounded) for the watcher to APPLY the LAST generation under query load.
-        deadline = time.monotonic() + 15.0
-        while time.monotonic() < deadline and P._reload_read_generation(applied) != last_applied:
-            time.sleep(0.02)
-        time.sleep(0.2)  # let the loops observe the final generation a bit
+        wait_observed(last_applied)
     finally:
+        if proc is not None and proc.poll() is None:
+            proc.kill()
+            proc.wait()
         stop.set()
         for t in threads:
             t.join(timeout=5)
@@ -583,7 +622,6 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
     assert not watcher.is_alive(), "watcher did not join cleanly"
     assert errors == [], "query thread(s) raised: {}".format(errors)
 
-    total_n = sum(s["n"] for s in stats)
     total_gen1 = sum(s["gen1"] for s in stats)
     total_gen2 = sum(s["gen2"] for s in stats)
     total_torn = sum(s["torn"] for s in stats)
@@ -595,14 +633,12 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
     # Both patterns were observed under load -- a genuine generational swap, both ways.
     assert total_gen1 > 0, "no gen1 pattern observed (baseline + odd flips)"
     assert total_gen2 > 0, "no gen2 pattern observed under load"
-    # Queries kept flowing (no stall) -- every thread did real, repeated work. The
-    # floor is deliberately conservative (>= ~10 scans/thread): a genuine stall leaves
-    # total_n on the order of n_threads (each loop ran once or twice before blocking),
-    # which this still catches, while the previous 50/thread floor was timing-fragile
-    # and flaked under the slower coverage-instrumented run on a busy CI runner. The
-    # per-thread liveness guarantee is pinned exactly by the next assertion.
-    assert total_n > n_threads * 10, "suspiciously few scans ({}) -- a stall?".format(total_n)
-    assert all(s["n"] > 0 for s in stats), "a query thread never ran"
+
+    with observed_condition:
+        final_observed = observed_generations.copy()
+    assert all(generation >= last_applied for generation in final_observed), (
+        "not every query thread observed final generation {}: {}".format(last_applied, final_observed)
+    )
 
     # FINAL state: the watcher applied the LAST published generation, and the live
     # snapshot grades EXACTLY as that generation's oracle -- per-mechanism CONTROLs
@@ -628,3 +664,13 @@ def _build_snapshot_from(manifest: str, ini: str) -> Any:
     finally:
         P.pfb["pfb_py_sources"] = saved_m
         P.pfb["pfb_unbound.ini"] = saved_i
+
+
+def test_reload_trigger_marker_waiter_reports_stuck_environment(tmp_path: Any) -> None:
+    spec = importlib.util.spec_from_file_location("adr10_reload_trigger", _TRIGGER)
+    assert spec is not None and spec.loader is not None, "trigger module could not be loaded"
+    trigger = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(trigger)
+
+    with pytest.raises(RuntimeError, match=r"stuck/environment.*target generation 7.*actual=None"):
+        trigger._wait_generation_marker(str(tmp_path / "missing"), 7, timeout=0.0)

--- a/tests/test_adr10_concurrency.py
+++ b/tests/test_adr10_concurrency.py
@@ -463,6 +463,19 @@ def _assert_state(snap: Any, expected: dict[str, bool], label: str) -> None:
     )
 
 
+def _matching_applied_generation(
+    before: int | None,
+    after: int | None,
+    got: dict[str, bool],
+    expected_gen1: dict[str, bool],
+    expected_gen2: dict[str, bool],
+) -> int | None:
+    if before is None or before != after:
+        return None
+    expected = expected_gen1 if after % 2 else expected_gen2
+    return after if got == expected else None
+
+
 # --------------------------------------------------------------------------- #
 # THE test
 # --------------------------------------------------------------------------- #
@@ -548,6 +561,7 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
         local = {"n": 0, "gen1": 0, "gen2": 0, "torn": 0}
         try:
             while not stop.is_set():
+                applied_before = P._reload_read_generation(applied)
                 snap = P._snapshot  # capture ONCE per scan, exactly as operate() does
                 got = _scan(snap)
                 local["n"] += 1
@@ -563,8 +577,14 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
                         _torn_samples.append(
                             {n: got[n] for n in _PROBE_NAMES if got[n] not in (expected_gen1[n], expected_gen2[n])}
                         )
-                applied_generation = P._reload_read_generation(applied)
-                if applied_generation and got == (expected_gen1 if applied_generation % 2 else expected_gen2):
+                applied_generation = _matching_applied_generation(
+                    applied_before,
+                    P._reload_read_generation(applied),
+                    got,
+                    expected_gen1,
+                    expected_gen2,
+                )
+                if applied_generation is not None:
                     record_observed(index, applied_generation)
         except Exception as e:  # noqa: BLE001 -- record, never let a query crash silently
             errors.append(repr(e))
@@ -666,11 +686,35 @@ def _build_snapshot_from(manifest: str, ini: str) -> Any:
         P.pfb["pfb_unbound.ini"] = saved_i
 
 
-def test_reload_trigger_marker_waiter_reports_stuck_environment(tmp_path: Any) -> None:
+def _load_reload_trigger() -> Any:
     spec = importlib.util.spec_from_file_location("adr10_reload_trigger", _TRIGGER)
     assert spec is not None and spec.loader is not None, "trigger module could not be loaded"
     trigger = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(trigger)
+    return trigger
+
+
+def test_same_parity_stale_scan_is_not_credited_to_later_generation() -> None:
+    expected_gen1 = {"probe.example": False}
+    expected_gen2 = {"probe.example": True}
+
+    assert _matching_applied_generation(2, 6, expected_gen2, expected_gen1, expected_gen2) is None
+    assert _matching_applied_generation(6, 6, expected_gen2, expected_gen1, expected_gen2) == 6
+
+
+def test_reload_trigger_marker_waiter_reports_stuck_environment(tmp_path: Any) -> None:
+    trigger = _load_reload_trigger()
 
     with pytest.raises(RuntimeError, match=r"stuck/environment.*target generation 7.*actual=None"):
         trigger._wait_generation_marker(str(tmp_path / "missing"), 7, timeout=0.0)
+
+
+def test_reload_trigger_marker_waiter_accepts_successful_final_recheck(monkeypatch: Any) -> None:
+    trigger = _load_reload_trigger()
+    times = iter((0.0, 0.0, 1.0))
+    reads = iter((None, 7))
+    monkeypatch.setattr(trigger.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(trigger.time, "sleep", lambda _: None)
+    monkeypatch.setattr(trigger, "_read_gen", lambda _: next(reads))
+
+    trigger._wait_generation_marker("marker", 7, timeout=1.0)

--- a/tests/test_adr10_watcher.py
+++ b/tests/test_adr10_watcher.py
@@ -220,8 +220,35 @@ class _Harness:
         self._lock = threading.Lock()
         # issue #456: the builder SIGNALS each recorded build on this Condition so
         # wait_builds blocks deterministically on the daemon thread instead of polling
-        # a deadline and hoping -- the latter races (and returns silently) under load.
+        # and hoping -- the latter races (and returns silently) under load.
         self._builds_cond = threading.Condition(self._lock)
+        orig_run_swap = P._reload_run_swap
+        orig_write_applied = P._reload_write_applied
+
+        def _applied_identity() -> tuple[int, int] | None:
+            try:
+                stat = os.stat(self.applied)
+            except OSError:
+                return None
+            return stat.st_dev, stat.st_ino
+
+        def _signaling_run_swap(builder: Any) -> bool:
+            swapped = orig_run_swap(builder)
+            if swapped:
+                with self._builds_cond:
+                    self._builds_cond.notify_all()
+            return swapped
+
+        def _signaling_write_applied(gen: int) -> None:
+            before = _applied_identity()
+            orig_write_applied(gen)
+            after = _applied_identity()
+            if after is not None and after != before and self.read_applied() == gen:
+                with self._builds_cond:
+                    self._builds_cond.notify_all()
+
+        monkeypatch.setattr(P, "_reload_run_swap", _signaling_run_swap)
+        monkeypatch.setattr(P, "_reload_write_applied", _signaling_write_applied)
         self.fail = False
         self.os = os
         P.pfb_reload_stop = threading.Event()
@@ -306,22 +333,12 @@ class _Harness:
                 )
 
     def wait_snapshot_contains(self, tag: str, timeout: float = 10.0) -> None:
-        # wait_builds/wait_sentinel_reads return before the swap is installed, so this
-        # stays a poll on the module-level P._snapshot we cannot signal from here --
-        # but with a loud timeout (issue #456). Check-then-deadline-then-final-recheck
-        # ordering (#729/#551) matches wait_snapshot_changed below: the tag may land
-        # during the final sleep, so always re-check once more right before giving up.
-        deadline = time.monotonic() + timeout
-        while True:
-            if tag in P._snapshot.data_db:
-                return
-            if time.monotonic() >= deadline:
-                break
-            time.sleep(0.005)
-        raise AssertionError(
-            "wait_snapshot_contains timed out after {:.1f}s: {!r} was never present in "
-            "P._snapshot.data_db (keys={!r})".format(timeout, tag, sorted(P._snapshot.data_db.keys()))
-        )
+        with self._builds_cond:
+            if not self._builds_cond.wait_for(lambda: tag in P._snapshot.data_db, timeout=timeout):
+                raise RuntimeError(
+                    "wait_snapshot_contains stuck/environment after {:.1f}s: expected {!r} in "
+                    "P._snapshot.data_db; actual keys={!r}".format(timeout, tag, sorted(P._snapshot.data_db.keys()))
+                )
 
     def wait_builds(self, n: int, timeout: float = 10.0) -> None:
         # Block on the builder's signal until >= n builds are recorded. The timeout is a
@@ -336,24 +353,21 @@ class _Harness:
                 )
 
     def wait_snapshot_changed(self, old: Any, timeout: float = 10.0) -> None:
-        # wait_builds returns when a build is RECORDED (before the builder returns), so
-        # P._snapshot may not be swapped yet. The swap is done by production code on a
-        # module-level variable we cannot signal from here, so this stays a poll -- but
-        # with a loud timeout assertion (safety-guard, never a silent return; issue #456).
-        # Check-then-deadline order (#729/#551): the swap may land during the final sleep,
-        # after the last check but before the deadline expires -- always re-check once more
-        # right before giving up, or that in-flight swap reads as a false "never swapped".
-        deadline = time.monotonic() + timeout
-        while True:
-            if P._snapshot is not old:
-                return
-            if time.monotonic() >= deadline:
-                break
-            time.sleep(0.005)
-        raise AssertionError(
-            "wait_snapshot_changed timed out after {:.1f}s: P._snapshot was never swapped "
-            "from the old snapshot (expected a new snapshot to be installed)".format(timeout)
-        )
+        with self._builds_cond:
+            if not self._builds_cond.wait_for(lambda: P._snapshot is not old, timeout=timeout):
+                raise RuntimeError(
+                    "wait_snapshot_changed stuck/environment after {:.1f}s: expected P._snapshot "
+                    "to differ from {!r}; actual is old snapshot={!r}".format(timeout, old, P._snapshot)
+                )
+
+    def wait_applied(self, target: int, timeout: float = 10.0) -> None:
+        with self._builds_cond:
+            if not self._builds_cond.wait_for(lambda: self.read_applied() == target, timeout=timeout):
+                raise RuntimeError(
+                    "wait_applied stuck/environment after {:.1f}s: expected applied generation {}; actual={!r}".format(
+                        timeout, target, self.read_applied()
+                    )
+                )
 
     def stop_join(self, timeout: float = 30.0) -> None:
         P.pfb_reload_stop.set()
@@ -369,7 +383,8 @@ class TestHarnessWaiterDiagnostics:
     came from wait_builds returning silently when the daemon thread was starved, so the
     real symptom -- "the build never happened in time" -- was masked into a misleading
     downstream ``builds == [2, 3]`` equality mismatch. These pin the contract directly:
-    when the awaited condition is never met, the waiter raises a descriptive AssertionError.
+    snapshot/applied waiters raise descriptive RuntimeErrors; existing build/read waiters
+    retain their AssertionError contracts.
     (Against the pre-fix silent-return waiters these tests FAIL -- no exception is raised.)
 
     issue #957 adds a second contract: start() must not return before the watcher's
@@ -389,15 +404,12 @@ class TestHarnessWaiterDiagnostics:
         h = _Harness(tmp_path, monkeypatch)
         old = _snapshot(tag="old.example.com", counts=0)
         P._snapshot = old
-        with pytest.raises(AssertionError, match=r"wait_snapshot_changed timed out"):
+        with pytest.raises(RuntimeError, match=r"wait_snapshot_changed stuck/environment"):
             h.wait_snapshot_changed(old, timeout=0.1)
 
-    def test_wait_snapshot_changed_returns_when_swap_lands_at_deadline(self, tmp_path: Any, monkeypatch: Any) -> None:
-        # #729/#551: a swap that lands during the FINAL sleep (after the last check, before
-        # the deadline expires) must still be observed, not read as a false "never swapped".
-        # timeout=0.0 makes the deadline already-expired at call time, so the loop's ONLY
-        # chance to see the swap is the check-before-give-up -- this is what the old
-        # check-then-sleep-then-recheck-deadline ordering skipped.
+    def test_wait_snapshot_changed_returns_when_already_changed(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # A swap already visible before waiting must return immediately, even with no wait
+        # budget, rather than report a false stuck/environment timeout.
         h = _Harness(tmp_path, monkeypatch)
         old = _snapshot(tag="old.example.com", counts=0)
         new = _snapshot(tag="new.example.com", counts=1)
@@ -414,13 +426,37 @@ class TestHarnessWaiterDiagnostics:
         # No watcher thread -> the tag is never added. wait_snapshot_contains must raise.
         h = _Harness(tmp_path, monkeypatch)
         P._snapshot = _snapshot(tag="old.example.com", counts=0)
-        with pytest.raises(AssertionError, match=r"wait_snapshot_contains timed out"):
+        with pytest.raises(RuntimeError, match=r"wait_snapshot_contains stuck/environment"):
             h.wait_snapshot_contains("gen1.example.com", timeout=0.1)
 
+    def test_wait_applied_raises_on_timeout(self, tmp_path: Any, monkeypatch: Any) -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        with pytest.raises(RuntimeError, match=r"wait_applied stuck/environment"):
+            h.wait_applied(1, timeout=0.1)
+
+    def test_applied_write_failure_does_not_signal_stale_marker(self, tmp_path: Any, monkeypatch: Any) -> None:
+        h = _Harness(tmp_path, monkeypatch)
+        with open(h.applied, "w", encoding="utf-8") as fh:
+            fh.write("42\n")
+        notifications = 0
+
+        def _record_notification() -> None:
+            nonlocal notifications
+            notifications += 1
+
+        monkeypatch.setattr(h._builds_cond, "notify_all", _record_notification)
+
+        def _fail_replace(source: str, destination: str) -> None:
+            raise OSError("forced marker replace failure")
+
+        monkeypatch.setattr(P.os, "replace", _fail_replace)
+        P._reload_write_applied(42)
+
+        assert notifications == 0
+        assert h.read_applied() == 42
+
     def test_wait_snapshot_contains_returns_when_tag_already_present(self, tmp_path: Any, monkeypatch: Any) -> None:
-        # #729/#551: timeout=0.0 makes the deadline already-expired at call time, so the
-        # loop's ONLY chance to see the tag is the check-before-give-up -- this must
-        # still return, not raise, when the tag is already present.
+        # An already-present tag must return immediately, even with no wait budget.
         h = _Harness(tmp_path, monkeypatch)
         P._snapshot = _snapshot(tag="gen1.example.com", counts=1)
         h.wait_snapshot_contains("gen1.example.com", timeout=0.0)  # must return, not raise.
@@ -499,9 +535,7 @@ class TestWatcherLoop:
             h.publish(2)
             h.wait_builds(1, timeout=3.0)
             h.wait_snapshot_contains("gen2.example.com", timeout=3.0)
-            deadline = time.monotonic() + 3.0
-            while time.monotonic() < deadline and h.read_applied() != 2:
-                time.sleep(0.01)
+            h.wait_applied(2, timeout=3.0)
             assert h.read_applied() == 2
             assert h.thread.is_alive()
         finally:
@@ -724,9 +758,7 @@ class TestAppliedMarker:
         assert h.read_applied() is None  # BEFORE: no marker yet.
         h.start()
         try:
-            deadline = time.monotonic() + 10.0
-            while time.monotonic() < deadline and h.read_applied() != 5:
-                time.sleep(0.01)
+            h.wait_applied(5)
             assert h.read_applied() == 5  # AFTER: baseline published.
             assert h.builds == []  # baseline adoption did NOT rebuild.
         finally:
@@ -740,9 +772,7 @@ class TestAppliedMarker:
             assert h.read_applied() is None  # BEFORE: nothing applied (no sentinel yet).
             h.publish(1)
             h.wait_builds(1)
-            deadline = time.monotonic() + 10.0
-            while time.monotonic() < deadline and h.read_applied() != 1:
-                time.sleep(0.01)
+            h.wait_applied(1)
             assert h.read_applied() == 1  # AFTER: marker advanced to the swapped gen.
         finally:
             h.stop_join()

--- a/tests/test_bench_top1m_fixed_file.py
+++ b/tests/test_bench_top1m_fixed_file.py
@@ -31,13 +31,15 @@ def _pid_exists(pid: int) -> bool:
     return True
 
 
-def _wait_pid_gone(pid: int, timeout: float = 5.0) -> bool:
+def _wait_pid_gone(pid: int, timeout: float = 5.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if not _pid_exists(pid):
-            return True
+            return
         time.sleep(0.05)
-    return not _pid_exists(pid)
+    if not _pid_exists(pid):
+        return
+    raise RuntimeError(f"stuck/environment: pid={pid}; expected absence, actual presence")
 
 
 def test_benchmark_default_is_exactly_one_million() -> None:
@@ -48,6 +50,11 @@ def test_generated_input_is_bounded_at_one_million() -> None:
     assert _BENCH._line_count("1000000") == 1_000_000
     with pytest.raises(_BENCH.argparse.ArgumentTypeError, match="must not exceed"):
         _BENCH._line_count("1000001")
+
+
+def test_wait_pid_gone_reports_stuck_environment_for_live_pid() -> None:
+    with pytest.raises(RuntimeError, match=r"stuck/environment.*pid=.*expected absence.*actual presence"):
+        _wait_pid_gone(os.getpid(), timeout=0)
 
 
 def test_streamed_fixture_is_deterministic_unique_and_bounded(tmp_path: Path) -> None:
@@ -156,7 +163,7 @@ def test_timed_timeout_kills_descendant_process_group(tmp_path: Path) -> None:
 
     child_pid = int(child_pid_path.read_text())
     try:
-        assert _wait_pid_gone(child_pid), f"timed-out child survived: pid={child_pid}"
+        _wait_pid_gone(child_pid)
     finally:
         if _pid_exists(child_pid):
             with contextlib.suppress(ProcessLookupError):
@@ -198,7 +205,7 @@ def test_timed_parent_signal_kills_worker_process_group(tmp_path: Path) -> None:
 
         os.kill(driver.pid, signal.SIGTERM)
         assert driver.wait(timeout=10) == 77
-        assert _wait_pid_gone(worker_pid), f"worker survived benchmark driver signal: pid={worker_pid}"
+        _wait_pid_gone(worker_pid)
     finally:
         with contextlib.suppress(ProcessLookupError):
             os.kill(driver.pid, signal.SIGKILL)


### PR DESCRIPTION
## Summary

- signal ADR-10 snapshot and applied-marker completion through the existing harness condition
- synchronize the separate reload trigger on per-generation query observations and replace scheduler-count liveness with per-thread progress barriers
- keep real cross-process marker/PID polls as salvage waits, but raise typed `stuck/environment` failures on expiry

## Evidence

- `python3 -m pytest tests/test_adr10_watcher.py tests/test_adr10_concurrency.py tests/test_bench_top1m_fixed_file.py` — 50 passed in 5.69s
- `scripts/agent/run-gates.sh --diff origin/devel` — pytest, Ruff check, Ruff format, and mypy passed
- independent step gates passed for watcher signaling, concurrency handshakes, and top1m PID salvage behavior
- pre-push rebase preserved all three patches byte-for-byte (`git range-diff` exact)

This is behavior-preserving test synchronization under #1517; no production source changed, so the policy's behavior-preserving red-proof exception applies.

## Follow-ups found

- #2051 — residual watcher harness salvage caps expire silently
- #2052 — query-thread join cap can hide live workers
- #2053 — top1m worker-start cap misclassifies stalls

Fixes #1992.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reload and watcher synchronization for more reliable generation updates.
  * Added clear timeout errors when environments, markers, or processes become stuck.
  * Improved diagnostics for snapshot, applied-generation, and process-wait failures.

* **Tests**
  * Added coverage for unavailable reload markers and stuck-process handling.
  * Replaced timing-based checks with deterministic synchronization to reduce flaky test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->