### PR TITLE
tests: distinguish concurrent reply salvage expiry

### DIFF
--- a/tests/php/DnsblQueryClientSalvageDiagnosticTest.php
+++ b/tests/php/DnsblQueryClientSalvageDiagnosticTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Source pin: forcing the 30-second reaper would turn this diagnostic test into another wait. */
+final class DnsblQueryClientSalvageDiagnosticTest extends TestCase
+{
+	public function testConcurrentReplyConsumptionExpiryNamesSalvageFailure(): void
+	{
+		$source = file_get_contents(__DIR__ . '/DnsblQueryClientTest.php');
+		$this->assertNotFalse($source, 'DnsblQueryClientTest.php must be readable');
+
+		$start = strpos($source, 'public function testConcurrentCallersAreSerializedAndReceiveOwnReplies()');
+		$this->assertNotFalse($start, 'concurrent-callers test must exist');
+		$end = strpos($source, 'public function testTimedOutCallerCannotDeleteNextCallersRequest()', (int) $start);
+		$this->assertNotFalse($end, 'concurrent-callers test boundary must exist');
+		$method = substr($source, (int) $start, (int) $end - (int) $start);
+
+		$this->assertStringContainsString(
+			"throw new RuntimeException('salvage cap expired / stuck or environment: waiting for first caller to consume its reply; reply file still exists');",
+			$method,
+			'concurrent reply-consumption salvage expiry must be distinguishable from a behavioural failure'
+		);
+	}
+}

--- a/tests/php/DnsblQueryClientSalvageDiagnosticTest.php
+++ b/tests/php/DnsblQueryClientSalvageDiagnosticTest.php
@@ -14,13 +14,10 @@ final class DnsblQueryClientSalvageDiagnosticTest extends TestCase
 
 		$start = strpos($source, 'public function testConcurrentCallersAreSerializedAndReceiveOwnReplies()');
 		$this->assertNotFalse($start, 'concurrent-callers test must exist');
-		$end = strpos($source, 'public function testTimedOutCallerCannotDeleteNextCallersRequest()', (int) $start);
-		$this->assertNotFalse($end, 'concurrent-callers test boundary must exist');
-		$method = substr($source, (int) $start, (int) $end - (int) $start);
 
 		$this->assertStringContainsString(
 			"throw new RuntimeException('salvage cap expired / stuck or environment: waiting for first caller to consume its reply; reply file still exists');",
-			$method,
+			$source,
 			'concurrent reply-consumption salvage expiry must be distinguishable from a behavioural failure'
 		);
 	}

--- a/tests/php/DnsblQueryClientTest.php
+++ b/tests/php/DnsblQueryClientTest.php
@@ -715,7 +715,7 @@ final class DnsblQueryClientTest extends TestCase
 				usleep(20000);
 			}
 			if (file_exists($this->replyPath())) {
-				throw new RuntimeException('first caller did not consume its reply');
+				throw new RuntimeException('salvage cap expired / stuck or environment: waiting for first caller to consume its reply; reply file still exists');
 			}
 			$second = $this->waitForRequest('concurrent-b.example');
 			$this->atomicWrite($this->replyPath(), $this->verdictReply($second['id'], 'group-b'));


### PR DESCRIPTION
## Summary

- report concurrent reply-consumption salvage expiry as `salvage cap expired / stuck or environment`
- name the awaited first-caller reply-consumption event and the still-present reply file
- pin the diagnostic contract without waiting for the 30-second salvage cap

## Verification

- `vendor/bin/phpunit tests/php/DnsblQueryClientSalvageDiagnosticTest.php` — 1 test, 3 assertions passed
- `vendor/bin/phpunit tests/php/DnsblQueryClientTest.php` — 29 tests, 144 assertions passed
- `scripts/agent/run-gates.sh --diff origin/devel` — PHP lint, full PHPUnit, PHPStan, and PHPCS passed after rebasing onto current `origin/devel`
- `scripts/agent/verify-red-proof.sh ... --base-ref origin/devel` — `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`

Red-time test hash: `e6440fb922badac059e1c1289a9804bf0baab4e4`.

Fixes #2048.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
