### PR TITLE
pfblockerng: reject adjacent ungrouped regex quantifiers

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -99,13 +99,24 @@ def _regex_quantifier(pattern: str, index: int) -> tuple[int, bool, bool]:
     if marker != "{":
         return index, False, False
     end = index + 1
-    while end < len(pattern) and pattern[end] != "}":
+    while end < len(pattern) and "0" <= pattern[end] <= "9":
         end += 1
-    if end >= len(pattern):
+    if end == index + 1:
         return index, False, False
-    body = pattern[index + 1 : end]
-    unbounded = body.endswith(",") and body[:-1].isdigit()
-    end += 1
+    if end < len(pattern) and pattern[end] == "}":
+        end += 1
+        unbounded = False
+    elif end < len(pattern) and pattern[end] == ",":
+        end += 1
+        upper_start = end
+        while end < len(pattern) and "0" <= pattern[end] <= "9":
+            end += 1
+        if end >= len(pattern) or pattern[end] != "}":
+            return index, False, False
+        unbounded = end == upper_start
+        end += 1
+    else:
+        return index, False, False
     suffix = pattern[end] if end < len(pattern) else ""
     if suffix in "?+":
         end += 1

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -80,9 +80,86 @@ _REGEX_SHAPE_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+def _regex_quantifier(pattern: str, index: int) -> tuple[int, bool, bool]:
+    """Return (end, unbounded, backtracking) for a quantifier at ``index``."""
+    if index >= len(pattern):
+        return index, False, False
+    marker = pattern[index]
+    if marker in "+*":
+        end = index + 1
+        suffix = pattern[end] if end < len(pattern) else ""
+        if suffix in "?+":
+            end += 1
+        return end, True, suffix != "+"
+    if marker == "?":
+        end = index + 1
+        if end < len(pattern) and pattern[end] in "?+":
+            end += 1
+        return end, False, False
+    if marker != "{":
+        return index, False, False
+    end = index + 1
+    while end < len(pattern) and pattern[end] != "}":
+        end += 1
+    if end >= len(pattern):
+        return index, False, False
+    body = pattern[index + 1 : end]
+    unbounded = body.endswith(",") and body[:-1].isdigit()
+    end += 1
+    suffix = pattern[end] if end < len(pattern) else ""
+    if suffix in "?+":
+        end += 1
+    return end, unbounded, suffix != "+"
+
+
+def _regex_has_ungrouped_adjacent_quantifiers(pattern: str) -> bool:
+    """Reject adjacent unbounded quantifiers unless either is possessive."""
+    previous_unbounded = False
+    index = 0
+    while index < len(pattern):
+        character = pattern[index]
+        if character == "\\":
+            atom_end = index + 2
+        elif character == "[":
+            atom_end = index + 1
+            while atom_end < len(pattern):
+                if pattern[atom_end] == "\\":
+                    atom_end += 2
+                    continue
+                if pattern[atom_end] == "]":
+                    atom_end += 1
+                    break
+                atom_end += 1
+            else:
+                previous_unbounded = False
+                break
+        elif character == "." or character not in "()|?*+{}[]^$":
+            atom_end = index + 1
+        else:
+            previous_unbounded = False
+            index += 1
+            continue
+
+        if atom_end > len(pattern):
+            previous_unbounded = False
+            break
+        quantifier_end, unbounded, backtracking = _regex_quantifier(pattern, atom_end)
+        if quantifier_end == atom_end:
+            previous_unbounded = False
+            index = atom_end
+            continue
+        if previous_unbounded and unbounded and backtracking:
+            return True
+        previous_unbounded = unbounded and backtracking
+        index = quantifier_end
+    return False
+
+
 def _regex_has_catastrophic_shape(pattern: str) -> bool:
-    """True when ``pattern`` matches any of the four structural shapes above."""
-    return any(shape.search(pattern) is not None for shape in _REGEX_SHAPE_PATTERNS)
+    """True when ``pattern`` matches any known catastrophic structural shape."""
+    return _regex_has_ungrouped_adjacent_quantifiers(pattern) or any(
+        shape.search(pattern) is not None for shape in _REGEX_SHAPE_PATTERNS
+    )
 
 
 def _regex_complexity_budget(pattern: str) -> int:

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -123,6 +123,33 @@ def _regex_quantifier(pattern: str, index: int) -> tuple[int, bool, bool]:
     return end, unbounded, suffix != "+"
 
 
+def _regex_escape_atom_end(pattern: str, index: int) -> int:
+    """Return the end of the escape atom beginning at ``index``."""
+    marker_index = index + 1
+    if marker_index >= len(pattern):
+        return marker_index
+    marker = pattern[marker_index]
+    if marker in "xuU":
+        width = {"x": 2, "u": 4, "U": 8}[marker]
+        end = marker_index + 1 + width
+        if end <= len(pattern) and all(
+            character in "0123456789abcdefABCDEF" for character in pattern[marker_index + 1 : end]
+        ):
+            return end
+        return marker_index + 1
+    if marker in "Nn" and marker_index + 1 < len(pattern) and pattern[marker_index + 1] == "{":
+        end = marker_index + 2
+        while end < len(pattern) and pattern[end] != "}":
+            end += 1
+        return min(end + 1, len(pattern))
+    if marker in "0123456789":
+        end = marker_index + 1
+        while end < len(pattern) and end < marker_index + 3 and pattern[end] in "0123456789":
+            end += 1
+        return end
+    return marker_index + 1
+
+
 def _regex_has_ungrouped_adjacent_quantifiers(pattern: str) -> bool:
     """Reject adjacent unbounded quantifiers unless either is possessive."""
     previous_unbounded = False
@@ -130,9 +157,13 @@ def _regex_has_ungrouped_adjacent_quantifiers(pattern: str) -> bool:
     while index < len(pattern):
         character = pattern[index]
         if character == "\\":
-            atom_end = index + 2
+            atom_end = _regex_escape_atom_end(pattern, index)
         elif character == "[":
             atom_end = index + 1
+            if atom_end < len(pattern) and pattern[atom_end] == "^":
+                atom_end += 1
+            if atom_end < len(pattern) and pattern[atom_end] == "]":
+                atom_end += 1
             while atom_end < len(pattern):
                 if pattern[atom_end] == "\\":
                     atom_end += 2

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -158,9 +158,9 @@ class TestCatastrophicShapeHeuristic:
         # The budget comparison is strictly `>` _REGEX_BUDGET_MAX, so a pattern whose budget
         # equals MAX exactly is the last admissible value (off-by-one guard: a `>=` regression
         # would flag this). Build a pattern whose budget is EXACTLY MAX -- `_REGEX_BUDGET_MAX`
-        # unbounded `*` quantifiers, zero alternations, and no other catastrophic shape (no
-        # nested/adjacent quantified group, no stacked bounded repeat).
-        at_budget = "a*" * pfb_dnsbl_regex_rules._REGEX_BUDGET_MAX
+        # unbounded `*` quantifiers, zero alternations, and no other catastrophic shape (the
+        # literal separators prevent the adjacent-atom shape; no nested group or stacked repeat).
+        at_budget = "a*x" * pfb_dnsbl_regex_rules._REGEX_BUDGET_MAX
         # Compute the budget the SAME way the code does and pin it to MAX before asserting.
         budget = len(pfb_dnsbl_regex_rules._REGEX_UNBOUNDED_QUANTIFIER.findall(at_budget)) + len(
             pfb_dnsbl_regex_rules._REGEX_ALTERNATION.findall(at_budget)

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -189,6 +189,18 @@ class TestCatastrophicShapeHeuristic:
         # And a SHORT catastrophic shape IS flagged regardless of being well under length.
         assert _regex_is_catastrophic_shape(r"(a+)+") is True
 
+    def test_malformed_brace_scan_is_linear(self) -> None:
+        class CountingPattern(str):
+            reads = 0
+
+            def __getitem__(self, key: Any) -> str:
+                type(self).reads += 1
+                return super().__getitem__(key)
+
+        pattern = CountingPattern("a{" * 256)
+        assert _regex_is_catastrophic_shape(pattern) is False
+        assert pattern.reads <= len(pattern) * 16, pattern.reads
+
 
 # --------------------------------------------------------------------------- #
 # (1) STATIC CAP -- applied at LOAD (feed regex via _dnsbl_compile_regex_rules)

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -174,6 +174,17 @@ def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
         ("^.+@.+$", False),
         ("[a-z]{1,3}[a-z]{1,3}", False),
         ("[a-z]+[0-9]+", True),
+        (r"[]a]+[]b]+", True),
+        (r"[^]]+[^]]+", True),
+        (r"\N{LATIN SMALL LETTER A}+\w+", True),
+        (r"\N{LATIN SMALL LETTER A}+\N{LATIN SMALL LETTER B}+", True),
+        (r"\x61+\x61+", True),
+        (r"\u0061+\u0061+", True),
+        (r"\U00000061+\w+", True),
+        (r"\141+\141+", True),
+        (r"[]a]+", False),
+        (r"[^]]+", False),
+        (r"\N{LATIN SMALL LETTER A}+@.+$", False),
     ],
 )
 def test_ungrouped_adjacent_quantifier_shapes_are_consistent(pattern: str, expected_rejected: bool) -> None:
@@ -191,7 +202,7 @@ def test_ungrouped_adjacent_quantifier_shapes_are_consistent(pattern: str, expec
 
 @pytest.mark.parametrize(
     "pattern",
-    ["", "[", "\\", "[a+z+b]+", r"a\+b\*", r"[a\]]+[a\]]+"],
+    ["", "[", "\\", "[a+z+b]+", r"a\+b\*", r"[a\]]+[a\]]+", r"\N{"],
 )
 def test_ungrouped_adjacent_quantifier_scanner_handles_hostile_syntax(pattern: str) -> None:
     """Scanner inspects syntax only; malformed patterns reach compile-error handling."""

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 PKG_DIR = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng"
 SCRIPT = PKG_DIR / "pfb_dnsbl_regex_rules.py"
 
@@ -107,6 +109,17 @@ def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
     corpus = [
         "^ads\\.example\\.com$",
         "^(.+\\.)?ads?[0-9]*\\.example\\.(com|net|org)$",
+        "[a-z]+[a-z]+",
+        "a+a+",
+        r".+\w+",
+        r"\w+\d+",
+        "[a-z]*[a-z]+",
+        "[a-z]{1,}[a-z]{2,}",
+        "[a-z]+?[a-z]+",
+        "[a-z]++[a-z]++",
+        "^.+@.+$",
+        "[a-z]{1,3}[a-z]{1,3}",
+        "[a-z]+[0-9]+",
         "(a+)+",
         "(a*)*",
         "(\\w+\\.)+",
@@ -144,6 +157,60 @@ def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
     # Guard against a vacuously one-sided corpus.
     assert any(_regex_is_catastrophic_shape(pattern) for pattern in corpus)
     assert any(not _regex_is_catastrophic_shape(pattern) for pattern in corpus)
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected_rejected"),
+    [
+        ("[a-z]+[a-z]+", True),
+        ("a+a+", True),
+        (r".+\w+", True),
+        (r"\w+\d+", True),
+        ("[a-z]*[a-z]+", True),
+        ("[a-z]{1,}[a-z]{2,}", True),
+        ("[a-z]+?[a-z]+", True),
+        ("[a-z]++[a-z]++", False),
+        ("a+a+a+a+", True),
+        ("^.+@.+$", False),
+        ("[a-z]{1,3}[a-z]{1,3}", False),
+        ("[a-z]+[0-9]+", True),
+    ],
+)
+def test_ungrouped_adjacent_quantifier_shapes_are_consistent(pattern: str, expected_rejected: bool) -> None:
+    """The shared gate rejects adjacent backtracking quantifiers conservatively."""
+    from pfb_dnsbl_regex_rules import _regex_is_catastrophic_shape
+
+    assert _regex_is_catastrophic_shape(pattern) is expected_rejected
+    proc = run_probe((pattern + "\n").encode("utf-8"))
+    assert (proc.returncode == 1) is expected_rejected, proc.stderr.decode()
+    if expected_rejected:
+        assert b"catastrophic-backtracking shape" in proc.stderr
+    else:
+        assert proc.stderr == b""
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    ["", "[", "\\", "[a+z+b]+", r"a\+b\*", r"[a\]]+[a\]]+"],
+)
+def test_ungrouped_adjacent_quantifier_scanner_handles_hostile_syntax(pattern: str) -> None:
+    """Scanner inspects syntax only; malformed patterns reach compile-error handling."""
+    from pfb_dnsbl_regex_rules import _regex_is_catastrophic_shape
+
+    proc = run_probe((pattern + "\n").encode("utf-8"))
+    assert proc.returncode in (0, 1), proc.stderr.decode()
+    assert isinstance(_regex_is_catastrophic_shape(pattern), bool)
+    if pattern in ("", "[a+z+b]+", r"a\+b\*"):
+        assert _regex_is_catastrophic_shape(pattern) is False
+    if pattern == r"[a\]]+[a\]]+":
+        assert _regex_is_catastrophic_shape(pattern) is True
+
+
+def test_ungrouped_adjacent_quantifier_scanner_handles_oversized_line() -> None:
+    """A 100,000-character valid line stays bounded and does not crash the probe."""
+    proc = run_probe(("a" * 100_000 + "\n").encode("ascii"))
+    assert proc.returncode == 0, proc.stderr.decode()
+    assert proc.stderr == b""
 
 
 def test_main_treats_crlf_terminated_lines_like_lf() -> None:


### PR DESCRIPTION
## What changed

- Reject adjacent ungrouped atoms carrying backtracking unbounded quantifiers in the
  shared DNSBL regex admission module.
- Tokenize Python-valid literal, dot, bracket-class, escaped, fixed-width Unicode,
  named-Unicode, hex, octal/backreference, greedy, lazy, possessive, bounded, and
  open-ended-repeat syntax without executing candidate patterns.
- Keep malformed brace and named-escape scanning linear.
- Extend the shared probe/resolver parity matrix and reconcile the budget-threshold
  fixture with the new adjacent-atom rule.

## Security/root cause

The always-on gate's structural shapes were centered on parenthesized groups. Ungrouped
adjacent quantified atoms therefore fell through to the complexity budget, where four
quantifiers remained below the limit. A failing suffix could force the resolver's Python
regex engine to explore a large partition surface on live DNS traffic.

The fix lives only in `pfb_dnsbl_regex_rules.py`, the shared point of truth imported by
`pfb_unbound.py` and executed standalone by the PHP save-time validator.

## Conservative trade-off

The gate deliberately rejects every adjacent pair of backtracking unbounded atoms, even
when their character sets are disjoint, so a legitimate pattern such as
`[a-z]+[0-9]+` is now rejected. This matches the existing conservative treatment of
disjoint quantified alternation/group shapes. The curated 40-pattern ADR-07 corpus had
zero newly rejected benign rows; common separated forms such as `^.+@.+$`, bounded
pairs, and possessive pairs remain accepted. No bypass or opt-out was added.

## Verification

- Frozen consolidated RED: 18 expected failures against the pre-fix source; test hash
  `338936088f4e0758e16fb963a9cecf99d8726b05`.
- Unchanged GREEN: 31 selected tests passed; same hash.
- Frozen linearity RED: 66,048 character reads exceeded the 8,192 bound; GREEN uses
  1,023 reads; test hash `113e828fb21301d35427934cfb712665dc759f9c`.
- Focused files: 68 passed.
- Curated corpus: 19 reducible rows with 0 flags; 19 irreducible rows with only the 5
  deliberate ReDoS exemplars flagged.
- Independent hostile matrix: 30,976 atom/quantifier combinations; no mismatch.
- `scripts/agent/run-gates.sh --diff origin/devel`: pytest, Ruff check, Ruff format,
  and mypy all passed after the final rebase.

Pre-existing stale ADR-07 regex-cap comments are tracked separately in #2064 (no
milestone); this security diff does not broaden into PHP/docs wording cleanup.

Fixes #2035

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
