### PR TITLE
tests: replace legacy pf polls with filter sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -477,7 +477,7 @@ Cases live in `tests/smoke/test_smoke_matrix.py` and compose the Phase-4 helpers
    reload verb; pass `scope="update"` for DNSBL-IP), then assert with
    `h.dns_probe` / `h.is_nxdomain` / `h.is_null_ip` / `h.is_vip` /
    `h.resolves_to`, and `h.pfctl_table_members` / `h.member_present` /
-   `h.rule_references` for the IP side. `__exit__` resets to baseline.
+   `h.pfctl_rule_has_alias` for the IP side. `__exit__` resets to baseline.
 
 ### HTTP feed-load smoke (ADR-16)
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -607,7 +607,7 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     generated (a product bug, NOT reload lag); in CONFIG but not RULES.DEBUG ⇒ the pfSense
     rule generator dropped it; in RULES.DEBUG but not LIVE PF ⇒ filter_configure has not
     applied it yet (genuine lag) or pfctl rejected the ruleset; present at all three ⇒ the
-    poll read stale state.
+    single-shot read saw stale state.
 
     A FAILED PROBE is never a missing rule: if one of the three VERDICT probes — the config
     read, the rules.debug grep, or ``pfctl -sr`` — errors out OR its transport stalls

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -591,8 +591,8 @@ def _tolerate_timeout(call: Callable[[], subprocess.CompletedProcess[str]]) -> s
 def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     """Return a layered snapshot naming WHERE a pfB alias's auto-rule was lost.
 
-    :func:`rule_references` already polls, so its failure does NOT mean "we read too
-    early" — no rule naming ``alias`` reached live pf within the whole poll window.
+    The single-shot rule read is authoritative after its caller's sync boundary; a
+    missing rule naming ``alias`` is therefore a real assertion failure.
     Two very different causes produce that, and only the layer that still has the rule
     tells them apart, so dump all three:
 
@@ -617,8 +617,8 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     fourth probe, ``pfctl -sTables``, only annotates whether the table exists — a failure
     there reports that line as ``UNKNOWN`` and leaves the verdict to the three layers.
 
-    The ruleset layers use :func:`rule_line_references`, the same match rule
-    :func:`rule_references` applies, so the dump cannot contradict the assertion it explains.
+    The ruleset layers use :func:`_rule_line_has_alias`, the same match rule
+    :func:`pfctl_rule_has_alias` applies, so the dump cannot contradict the assertion it explains.
     """
     # fullmatch, not match: `$` also matches just before a TRAILING newline, so `match()` would
     # admit "pfB_x\n" into the PHP string literal below.
@@ -653,8 +653,8 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     sr = _tolerate_timeout(lambda: vm.ssh(PFCTL, "-sr", timeout=timeout))
     dbg_ok = dbg.returncode in (0, 1)
     sr_ok = sr.returncode == 0
-    dbg_lines = [ln for ln in dbg.stdout.splitlines() if rule_line_references(ln, alias)]
-    live = [ln for ln in sr.stdout.splitlines() if rule_line_references(ln, alias)]
+    dbg_lines = [ln for ln in dbg.stdout.splitlines() if _rule_line_has_alias(ln, alias)]
+    live = [ln for ln in sr.stdout.splitlines() if _rule_line_has_alias(ln, alias)]
 
     tables_res = _tolerate_timeout(lambda: vm.ssh(PFCTL, "-sTables", timeout=timeout))
     tables_ok = tables_res.returncode == 0
@@ -677,7 +677,7 @@ def alias_rule_dump(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> str:
     elif not live:
         stage = "LIVE PF — emitted but not loaded: filter_configure has not applied it yet (lag), or pfctl refused it"
     else:
-        stage = "NONE — the rule is present at all three layers; the poll read stale state"
+        stage = "NONE — the rule is present at all three layers; the single-shot read saw stale state"
 
     return (
         f"[STAGE LOST] {stage}\n"
@@ -4847,64 +4847,16 @@ def pfctl_tables(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
-@timed_step(lambda vm, name, **_k: f"wait_pfctl_table:{name}")
-def wait_pfctl_table(vm: SmokeVM, name: str, *, timeout: float = 30.0, interval: float = 2.0) -> list[str]:
-    """Poll ``pfctl -t <name> -T show`` until the table EXISTS and is NON-EMPTY.
-
-    Returns the members once populated, or ``[]`` on timeout — the caller asserts
-    on the result, so a genuine failure surfaces as a clear assertion (with the
-    per-run diagnostics snapshot already uploaded), never an open-ended hang.
-
-    A BOUNDED poll is the right primitive here precisely because DNSBL-IP table
-    population is legitimately ASYNC: ``filter_configure`` lands ``pfB_DNSBLIP_v4``/
-    ``pfB_DNSBLIP_v6`` slightly AFTER ``pfblockerng.php update`` returns (the tables
-    are absent on a synchronous read right after the reload, but present in teardown
-    diagnostics — issue #35). This is NOT the ADR-04 "first response is authoritative"
-    DNS case (that holds after :func:`wait_unbound_ready`, where the first answer is
-    the truth); it mirrors the :func:`rule_references` reload-lag poll instead.
-    """
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if name in pfctl_tables(vm):
-            members = pfctl_table_members(vm, name)
-            if members:
-                return members
-        time.sleep(interval)
-    return []
+def pfctl_rule_has_alias(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> bool:
+    """Return whether one authoritative ``pfctl -sr`` snapshot references ``alias``."""
+    result = vm.ssh(PFCTL, "-sr", timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(f"pfctl -sr failed: rc={result.returncode} stderr={result.stderr!r}")
+    return any(_rule_line_has_alias(line, alias) for line in result.stdout.splitlines())
 
 
-def rule_references(vm: SmokeVM, alias: str, *, timeout: float = 30.0, attempts: int = 10, delay: float = 2.0) -> bool:
-    """True iff a loaded pf rule references ``alias`` (``pfctl -sr`` | grep).
-
-    pfBlockerNG's ``filter_configure`` lands the auto-rule slightly AFTER the
-    update CLI returns, so poll rather than read once (the rule was observed
-    present in on-failure diagnostics dumped moments after a single-shot read
-    returned False — a pure timing race).
-
-    CONTRACT: ``alias`` SHOULD be a pfBlockerNG-owned table name (``pfB_<header>_v{4,6}``,
-    ``pfB_DNSBLIP_v4``, ``pfB_*_Aggregated_v4`` …) — every in-tree caller passes one. The
-    exact ``<alias>`` pf table-reference is always matched; the looser bare-substring
-    fallback (a rule that names the table without the ``<>`` syntax) is gated behind the
-    ``pfB_`` prefix so a generic token can NEVER coincidentally match a FOREIGN rule — e.g.
-    a baked ``CI HARNESS RULE`` or the floating ``REJECT ALL OUT MGT1``. A non-``pfB_``
-    alias is still honoured, via the exact table-reference match alone.
-    """
-    for attempt in range(attempts):
-        result = vm.ssh(PFCTL, "-sr", timeout=timeout)
-        if result.returncode != 0:
-            raise RuntimeError(f"pfctl -sr failed: rc={result.returncode} stderr={result.stderr!r}")
-        if any(rule_line_references(line, alias) for line in result.stdout.splitlines()):
-            return True
-        if attempt < attempts - 1:
-            time.sleep(delay)
-    return False
-
-
-def rule_line_references(line: str, alias: str) -> bool:
-    """True iff one ruleset line references table ``alias`` — the match rule of
-    :func:`rule_references`, shared so :func:`alias_rule_dump` (which exists to EXPLAIN a
-    rule_references failure) cannot disagree with it about what "references" means.
-    """
+def _rule_line_has_alias(line: str, alias: str) -> bool:
+    """Return whether one ruleset line references table ``alias``."""
     return f"<{alias}>" in line or (alias.startswith("pfB_") and alias in line)
 
 

--- a/tests/smoke/test_smoke_714_asn_geoip.py
+++ b/tests/smoke/test_smoke_714_asn_geoip.py
@@ -472,13 +472,14 @@ def test_714_b3_v6_regex_parser_success_not_double_counted(deployed_vm: SmokeVM)
 
         h.inject(deployed_vm, spec)
         h.reload(deployed_vm, "update")
+        h.apply_filter_sync(deployed_vm)
 
         # THEN: both addresses reached the pf table (proves they were actually parsed
         # and collected, not silently dropped by some other mechanism). By-VALUE
         # comparison (h.ip_in): pf/pfBlockerNG may render a compressed literal
         # differently (e.g. an equivalent expanded form), which a substring check
         # would miss.
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         for ip in good_lines:
             assert h.ip_in(ip, members), f"expected valid IPv6 {ip} in pf table {spec.alias}: {members}"
 

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -177,9 +177,9 @@ def test_adr40_content_gate_idempotence(adr40_vm: SmokeVM) -> None:
     )
 
     # Before-state: pf table is populated with the settled IP.
-    # Use wait_pfctl_table — filter_configure is async after pfblockerng.php returns;
-    # a bare pfctl_table_members read can race and miss the table.
-    members_before = h.wait_pfctl_table(adr40_vm, ip_spec.alias)
+    # Wait for the blocking filter apply before the authoritative table read.
+    h.apply_filter_sync(adr40_vm)
+    members_before = h.pfctl_table_members(adr40_vm, ip_spec.alias)
     assert any(fed_ip in m for m in members_before), (
         f"before-state: pf table {ip_spec.alias} does not contain {fed_ip}: {members_before}"
     )
@@ -194,6 +194,7 @@ def test_adr40_content_gate_idempotence(adr40_vm: SmokeVM) -> None:
     h.force_ip_refetch(adr40_vm, f"{ip_spec.header}_{ip_spec.family}")
     h.clear_hook_markers(adr40_vm, token)
     h.reload(adr40_vm, "update")
+    h.apply_filter_sync(adr40_vm)
     env_second = h.read_hook_env(adr40_vm, marker)
     assert env_second is not None, "post hook did not fire on the idempotence update"
 
@@ -264,8 +265,8 @@ def test_adr40_content_gate_fires_on_change(adr40_vm: SmokeVM) -> None:
     assert env_settle is not None, "post hook did not fire on the settling update"
 
     # Before-state: only old_ip in the table; new_ip absent.
-    # Use wait_pfctl_table — filter_configure is async after pfblockerng.php returns.
-    members_before = h.wait_pfctl_table(adr40_vm, ip_spec.alias)
+    h.apply_filter_sync(adr40_vm)
+    members_before = h.pfctl_table_members(adr40_vm, ip_spec.alias)
     assert any(old_ip in m for m in members_before), (
         f"before-state: pf table {ip_spec.alias} missing {old_ip}: {members_before}"
     )
@@ -285,6 +286,7 @@ def test_adr40_content_gate_fires_on_change(adr40_vm: SmokeVM) -> None:
     # inspects ONLY this reload's output, not the session-accumulated log (order-independent).
     log_len_before = len(adr40_vm.ssh("cat", h.PFB_LOG).stdout)
     h.reload(adr40_vm, "update")
+    h.apply_filter_sync(adr40_vm)
     env_changed = h.read_hook_env(adr40_vm, marker)
     assert env_changed is not None, "post hook did not fire after feed content change"
 
@@ -418,12 +420,13 @@ def test_adr40_delta_apply_small_churn(adr40_vm: h.SmokeVM) -> None:
         # Settle with OLD IP.
         h.clear_hook_markers(adr40_vm, token)
         h.reload(adr40_vm, "update")
+        h.apply_filter_sync(adr40_vm)
         env_settle = h.read_hook_env(adr40_vm, marker)
         assert env_settle is not None, "post hook did not fire on settling update"
 
         # Before-state: old_ip in table, new_ip absent.
-        # Use wait_pfctl_table — filter_configure is async after pfblockerng.php returns.
-        members_before = h.wait_pfctl_table(adr40_vm, ip_spec.alias)
+        # The blocking filter apply above makes this one-shot read authoritative.
+        members_before = h.pfctl_table_members(adr40_vm, ip_spec.alias)
         assert any(old_ip in m for m in members_before), (
             f"before-state: pf table {ip_spec.alias} missing {old_ip}: {members_before}"
         )
@@ -445,6 +448,7 @@ def test_adr40_delta_apply_small_churn(adr40_vm: h.SmokeVM) -> None:
 
         h.clear_hook_markers(adr40_vm, token)
         h.reload(adr40_vm, "update")
+        h.apply_filter_sync(adr40_vm)
         env_changed = h.read_hook_env(adr40_vm, marker)
         assert env_changed is not None, "post hook did not fire after feed content change (delta mode)"
 
@@ -545,12 +549,13 @@ def test_adr40_delta_replace_mode(adr40_vm: h.SmokeVM) -> None:
         # Settle.
         h.clear_hook_markers(adr40_vm, token)
         h.reload(adr40_vm, "update")
+        h.apply_filter_sync(adr40_vm)
         env_settle = h.read_hook_env(adr40_vm, marker)
         assert env_settle is not None, "post hook did not fire on settling update"
 
         # Before-state: old_ip in table, new_ip absent.
-        # Use wait_pfctl_table — filter_configure is async after pfblockerng.php returns.
-        members_before = h.wait_pfctl_table(adr40_vm, ip_spec.alias)
+        # The blocking filter apply above makes this one-shot read authoritative.
+        members_before = h.pfctl_table_members(adr40_vm, ip_spec.alias)
         assert any(old_ip in m for m in members_before), (
             f"before-state: pf table {ip_spec.alias} missing {old_ip}: {members_before}"
         )
@@ -572,6 +577,7 @@ def test_adr40_delta_replace_mode(adr40_vm: h.SmokeVM) -> None:
 
         h.clear_hook_markers(adr40_vm, token)
         h.reload(adr40_vm, "update")
+        h.apply_filter_sync(adr40_vm)
         env_changed = h.read_hook_env(adr40_vm, marker)
         assert env_changed is not None, "post hook did not fire after feed change (replace mode)"
 

--- a/tests/smoke/test_smoke_adr62.py
+++ b/tests/smoke/test_smoke_adr62.py
@@ -288,7 +288,8 @@ def test_adr62_bracketed_ipv6_dnsblip_vs_adblock_marker(deployed_vm: SmokeVM, cl
         ans = h.dns_probe_client_until(client_vm, domain, h.is_vip)
         assert not h.resolves_to(ans, STUB_DNS_A), f"{domain} still resolving after the feed loaded: {ans}"
 
-        v6_members = h.wait_pfctl_table(deployed_vm, "pfB_DNSBLIP_v6")
+        h.apply_filter_sync(deployed_vm)
+        v6_members = h.pfctl_table_members(deployed_vm, "pfB_DNSBLIP_v6")
         assert h.member_present(v6_members, ipv6_lit), (
             f"bracketed IPv6 literal {ipv6_lit} not collected into pfB_DNSBLIP_v6: {v6_members}"
         )
@@ -298,7 +299,7 @@ def test_adr62_bracketed_ipv6_dnsblip_vs_adblock_marker(deployed_vm: SmokeVM, cl
 
         # Delta D6 (ADR §2, PR #1107 review): a plain feed's ||<IPv4>^ anchor
         # collects into the DNSBLIP v4 alias (origin/devel silently dropped it).
-        v4_members = h.wait_pfctl_table(deployed_vm, "pfB_DNSBLIP_v4")
+        v4_members = h.pfctl_table_members(deployed_vm, "pfB_DNSBLIP_v4")
         assert h.member_present(v4_members, ipv4_anchor), (
             f"plain-feed ABP IP anchor ||{ipv4_anchor}^ not collected into pfB_DNSBLIP_v4 (delta D6): {v4_members}"
         )

--- a/tests/smoke/test_smoke_aggregate.py
+++ b/tests/smoke/test_smoke_aggregate.py
@@ -26,7 +26,7 @@ WHAT THIS FILE AUTOMATES (ADR §7 manual-smoke checklist):
   ``pfB_Deny_Aggregated_v4`` table is ABSENT and its ``.lst`` does not exist (the OFF
   branch / byte-identical baseline).
 * **Deny aggregate on + Native = no rule** -- select ``["Deny"]`` ⇒ the table is built
-  with the fed IP and ``rule_references`` is FALSE (Native ⇒ no firewall rule); the
+  with the fed IP and ``pfctl_rule_has_alias`` is FALSE (Native ⇒ no firewall rule); the
   member table ``pfB_<x>_v4`` stays present (additive).
 * **Cross-type, no leakage** -- a Permit member with ``["Permit"]`` selected ⇒ its IP is
   in ``pfB_Permit_Aggregated_v4`` and ABSENT from ``pfB_Deny_Aggregated_v4`` (which is
@@ -154,12 +154,14 @@ def test_aggregate_none_selected_is_noop(deployed_vm: SmokeVM) -> None:
     spec = h.IpCase(aliasname="aggnoop", feed_url=feed, header="aggnoop", action="Deny_Both")
     h.inject(deployed_vm, spec)
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
 
     # The member table DID build (the denydir has content) — so the aggregate's absence
-    # is a real OFF-branch result, not just "nothing ran". Poll: the member pf table lands
-    # via filter_configure slightly AFTER the update CLI returns (issue #35), so a synchronous
-    # pfctl_tables read races it; wait_pfctl_table polls until it is present + non-empty.
-    assert h.wait_pfctl_table(deployed_vm, spec.alias), f"member table {spec.alias} missing — injection did not build"
+    # is a real OFF-branch result, not just "nothing ran". The blocking filter apply above
+    # makes the following one-shot table read authoritative.
+    assert h.pfctl_table_members(deployed_vm, spec.alias), (
+        f"member table {spec.alias} missing — injection did not build"
+    )
     assert agg not in h.pfctl_tables(deployed_vm), f"aggregate {agg} built with NOTHING selected (OFF branch broken)"
     assert deployed_vm.ssh("test", "-f", consumer).returncode != 0, (
         f"aggregate consumer {consumer} exists with NOTHING selected (OFF branch broken)"
@@ -179,7 +181,7 @@ def test_aggregate_deny_builds_table_native_no_rule(deployed_vm: SmokeVM) -> Non
         ``pfB_aggdeny_v4`` therefore builds,
       When ``pfb_agg_types`` selects ``["Deny"]`` and a full ``update`` runs,
       Then ``pfB_Deny_Aggregated_v4`` is loaded and CONTAINS the fed IP (the union of the
-        denydir), and ``rule_references(pfB_Deny_Aggregated_v4)`` is FALSE — Native means
+        denydir), and ``pfctl_rule_has_alias(pfB_Deny_Aggregated_v4)`` is FALSE — Native means
         NO firewall rule, the load-bearing ADR-11 contract. The member table stays present
         (the aggregate is ADDITIVE — it does not consume/replace the per-feed table).
     """
@@ -191,14 +193,19 @@ def test_aggregate_deny_builds_table_native_no_rule(deployed_vm: SmokeVM) -> Non
     h.inject(deployed_vm, spec)
     h.set_aggregate_types(deployed_vm, ["Deny"])
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
 
-    members = h.wait_pfctl_table(deployed_vm, agg)
+    members = h.pfctl_table_members(deployed_vm, agg)
     assert h.member_present(members, fed_ip), f"fed Deny IP {fed_ip} not in aggregate {agg}: {members}"
     # Native ⇒ no firewall rule references the aggregate alias.
-    assert not h.rule_references(deployed_vm, agg), f"aggregate {agg} is referenced by a pf rule — Native must add NONE"
+    assert not h.pfctl_rule_has_alias(deployed_vm, agg), (
+        f"aggregate {agg} is referenced by a pf rule — Native must add NONE"
+    )
     # Additive: the per-feed member table is untouched/present alongside the aggregate
-    # (poll — the member table can land via filter_configure after the CLI returns, issue #35).
-    assert h.wait_pfctl_table(deployed_vm, spec.alias), f"member table {spec.alias} vanished — aggregate not additive"
+    # One sync covers both member-table reads below.
+    assert h.pfctl_table_members(deployed_vm, spec.alias), (
+        f"member table {spec.alias} vanished — aggregate not additive"
+    )
     assert h.member_present(h.pfctl_table_members(deployed_vm, spec.alias), fed_ip), (
         f"member table {spec.alias} lost {fed_ip} — aggregate perturbed the source table"
     )
@@ -230,8 +237,9 @@ def test_aggregate_permit_does_not_leak_into_deny(deployed_vm: SmokeVM) -> None:
     h.inject(deployed_vm, spec)
     h.set_aggregate_types(deployed_vm, ["Permit"])
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
 
-    permit_members = h.wait_pfctl_table(deployed_vm, permit_agg)
+    permit_members = h.pfctl_table_members(deployed_vm, permit_agg)
     assert h.member_present(permit_members, fed_ip), f"Permit IP {fed_ip} not in {permit_agg}: {permit_members}"
     # Deny aggregate is NOT selected ⇒ never built ⇒ absent/empty and free of the Permit IP.
     assert _table_absent_or_empty(deployed_vm, deny_agg), (
@@ -282,7 +290,8 @@ def test_aggregate_additive_across_combination(deployed_vm: SmokeVM) -> None:
     # BEFORE: only Deny selected ⇒ Deny aggregate present, Permit aggregate absent.
     h.set_aggregate_types(deployed_vm, ["Deny"])
     h.reload(deployed_vm, "update")
-    deny_members_before = h.wait_pfctl_table(deployed_vm, deny_agg)
+    h.apply_filter_sync(deployed_vm)
+    deny_members_before = h.pfctl_table_members(deployed_vm, deny_agg)
     assert h.member_present(deny_members_before, deny_ip), f"Deny IP {deny_ip} not in {deny_agg}: {deny_members_before}"
     assert _table_absent_or_empty(deployed_vm, permit_agg), (
         f"{permit_agg} present though only Deny selected: {h.pfctl_tables(deployed_vm)}"
@@ -291,10 +300,11 @@ def test_aggregate_additive_across_combination(deployed_vm: SmokeVM) -> None:
     # AFTER: grow to {Deny,Permit} ⇒ both aggregates present with their own contents.
     h.set_aggregate_types(deployed_vm, ["Deny", "Permit"])
     h.reload(deployed_vm, "update")
-    assert h.member_present(h.wait_pfctl_table(deployed_vm, deny_agg), deny_ip), (
+    h.apply_filter_sync(deployed_vm)
+    assert h.member_present(h.pfctl_table_members(deployed_vm, deny_agg), deny_ip), (
         f"Deny IP {deny_ip} dropped from {deny_agg} after adding Permit"
     )
-    assert h.member_present(h.wait_pfctl_table(deployed_vm, permit_agg), permit_ip), (
+    assert h.member_present(h.pfctl_table_members(deployed_vm, permit_agg), permit_ip), (
         f"Permit IP {permit_ip} not in {permit_agg} after selecting it"
     )
     # The per-feed member tables are unchanged (additive): both still present + hold their IP.
@@ -327,6 +337,7 @@ def test_aggregate_empty_union_writes_never_empty_consumer(deployed_vm: SmokeVM)
 
     h.set_aggregate_types(deployed_vm, ["Match"])
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
 
     assert deployed_vm.ssh("test", "-f", consumer).returncode == 0, f"never-empty consumer {consumer} missing"
     body = deployed_vm.ssh("cat", consumer).stdout
@@ -362,12 +373,14 @@ def test_aggregate_teardown_on_deselect(deployed_vm: SmokeVM) -> None:
     # BEFORE: Deny selected ⇒ table + consumer exist.
     h.set_aggregate_types(deployed_vm, ["Deny"])
     h.reload(deployed_vm, "update")
-    assert h.member_present(h.wait_pfctl_table(deployed_vm, agg), fed_ip), f"{agg} not built before teardown"
+    h.apply_filter_sync(deployed_vm)
+    assert h.member_present(h.pfctl_table_members(deployed_vm, agg), fed_ip), f"{agg} not built before teardown"
     assert deployed_vm.ssh("test", "-f", consumer).returncode == 0, f"consumer {consumer} missing before teardown"
 
     # AFTER: deselect everything ⇒ table gone + consumer removed.
     h.set_aggregate_types(deployed_vm, [])
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
     assert agg not in h.pfctl_tables(deployed_vm), f"{agg} still loaded after deselect — teardown left an orphan table"
     assert deployed_vm.ssh("test", "-f", consumer).returncode != 0, (
         f"consumer {consumer} still present after deselect — teardown left an orphan file"
@@ -429,9 +442,10 @@ def test_aggregate_post_hook_sees_fresh_table_and_changed_alias(deployed_vm: Smo
         h.clear_hook_markers(deployed_vm, token)
         deployed_vm.ssh("/bin/rm", "-f", table_marker)
         h.reload(deployed_vm, "update")
+        h.apply_filter_sync(deployed_vm)
 
         # BEFORE: the settled aggregate does NOT yet contain the new IP.
-        settled = h.wait_pfctl_table(deployed_vm, agg)
+        settled = h.pfctl_table_members(deployed_vm, agg)
         assert h.member_present(settled, settle_ip), f"settle IP {settle_ip} not in {agg} after settle: {settled}"
         assert not h.member_present(settled, new_ip), (
             f"new IP {new_ip} already in {agg} before the feed change — cannot prove freshness"
@@ -444,6 +458,7 @@ def test_aggregate_post_hook_sees_fresh_table_and_changed_alias(deployed_vm: Smo
         h.clear_hook_markers(deployed_vm, token)
         deployed_vm.ssh("/bin/rm", "-f", table_marker)
         h.reload(deployed_vm, "update")
+        h.apply_filter_sync(deployed_vm)
 
         # (a) The table the hook recorded contains the NEW IP — proof the hook saw the FRESH,
         #     loaded aggregate (built before the post hook), never the stale pre-update content.
@@ -480,8 +495,8 @@ def test_aggregate_deny_includes_dnsblip(deployed_vm: SmokeVM) -> None:
         ``dnsbl_ip_action="Deny_Both"`` (collect DNSBL-IP into the Deny dir),
       When ``pfb_agg_types=["Deny"]`` and a full ``update`` runs,
       Then ``198.51.100.17`` (via ``pfB_DNSBLIP_v4``) is present in
-        ``pfB_Deny_Aggregated_v4``. The DNSBLIP table population is legitimately async
-        (issue #35), so we ``wait_pfctl_table`` on the aggregate (bounded poll).
+        ``pfB_Deny_Aggregated_v4``. A blocking filter apply precedes the authoritative
+        ``pfctl_table_members`` reads on both tables.
     """
     dnsblip = "198.51.100.17"
     agg = h.aggregate_table("Deny", "v4")
@@ -501,13 +516,14 @@ def test_aggregate_deny_includes_dnsblip(deployed_vm: SmokeVM) -> None:
     h.set_aggregate_types(deployed_vm, ["Deny"])
     h.reload(deployed_vm, "update")
 
+    h.apply_filter_sync(deployed_vm)
     # Sanity: the DNSBLIP member table itself collected the literal (the fold's source).
-    dnsblip_members = h.wait_pfctl_table(deployed_vm, "pfB_DNSBLIP_v4")
+    dnsblip_members = h.pfctl_table_members(deployed_vm, "pfB_DNSBLIP_v4")
     assert h.member_present(dnsblip_members, dnsblip), (
         f"DNSBLIP {dnsblip} not collected into pfB_DNSBLIP_v4: {dnsblip_members}"
     )
     # The Deny aggregate folds the denydir (incl. DNSBLIP) in. Use CIDR COVERAGE, not exact
     # membership: the aggregate is iprange-collapsed, so the DNSBLIP IP can be folded into a
     # supernet (e.g. .16 + .17 -> .16/31) — present in the set, but not as its bare literal.
-    agg_members = h.wait_pfctl_table(deployed_vm, agg)
+    agg_members = h.pfctl_table_members(deployed_vm, agg)
     assert h.member_covers(agg_members, dnsblip), f"DNSBLIP {dnsblip} did not fold into {agg}: {agg_members}"

--- a/tests/smoke/test_smoke_boot_reload.py
+++ b/tests/smoke/test_smoke_boot_reload.py
@@ -144,9 +144,10 @@ def reboot_observation(request: pytest.FixtureRequest, deployed_vm: SmokeVM) -> 
     spec.feed_url = h.write_local_feed(vm, f"issue334_{'ram' if ramdisk else 'std'}.txt", f"{fed_ip}\n")
     h.inject(vm, spec)
     h.reload(vm, "update")
+    h.apply_filter_sync(vm)
 
-    before_members = h.wait_pfctl_table(vm, spec.alias)
-    before_rule = h.rule_references(vm, spec.alias)
+    before_members = h.pfctl_table_members(vm, spec.alias)
+    before_rule = h.pfctl_rule_has_alias(vm, spec.alias)
     archive_present = ramdisk and h.archive_exists(vm, h.ALIASARCHIVE)
 
     # ramdisk leg: drop a /var sentinel so the post-reboot check can PROVE /var came up
@@ -163,8 +164,8 @@ def reboot_observation(request: pytest.FixtureRequest, deployed_vm: SmokeVM) -> 
     h.reboot_vm(vm)
 
     # Then (captured): the alias table + its rule reference, post-reboot.
-    after_members = h.wait_pfctl_table(vm, spec.alias)
-    after_rule = h.rule_references(vm, spec.alias)
+    after_members = h.pfctl_table_members(vm, spec.alias)
+    after_rule = h.pfctl_rule_has_alias(vm, spec.alias)
 
     var_wiped: bool | None = None
     var_mount = ""

--- a/tests/smoke/test_smoke_download_loop.py
+++ b/tests/smoke/test_smoke_download_loop.py
@@ -226,6 +226,7 @@ def test_709_invert_v4_list_members_reach_pf_table(download_loop_vm: SmokeVM) ->
 
     # When: a full update runs.
     h.reload(vm, "update")
+    h.apply_filter_sync(vm)
 
     native_member = f"{h.PFB_DBDIR}/native/{header}_v4.txt"
     deny_member = f"{h.PFB_DBDIR}/deny/{header}_v4.txt"
@@ -233,7 +234,7 @@ def test_709_invert_v4_list_members_reach_pf_table(download_loop_vm: SmokeVM) ->
     in_native = _file_present(vm, native_member)
     in_deny = _file_present(vm, deny_member)
     mirror_body = _read_file(vm, mirror)
-    members = h.wait_pfctl_table(vm, spec.alias)
+    members = h.pfctl_table_members(vm, spec.alias)
 
     def _report() -> str:
         return (

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -145,14 +145,12 @@ def test_ip_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -
     assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the feed was ever loaded"
 
     with h.CaseContext(deployed_vm, spec):
-        # Use wait_pfctl_table instead of the single-shot pfctl_table_members:
-        # filter_configure is async so the pf table may not be populated immediately
-        # after CaseContext.__enter__ completes the reload.
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        # CaseContext.__enter__ applies the blocking filter sync before this read.
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         assert h.member_present(members, member_host), f"{member_host} not in {spec.alias}: {members}"
         assert _covered_by(members, member_in_cidr), f"{member_in_cidr} not covered by {spec.alias}: {members}"
         assert not _covered_by(members, non_member), f"{non_member} unexpectedly in {spec.alias}: {members}"
-        assert h.rule_references(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
 
 
 def test_dnsbl_http_feed_loads(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
@@ -247,6 +245,7 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
         refused_before = h.count_log_marker(deployed_vm, main_log, refused_marker)
         h.reload(deployed_vm, "update")
         h.reload(deployed_vm, "updateip")
+        h.apply_filter_sync(deployed_vm)
         assert spec.alias not in h.pfctl_tables(deployed_vm), (
             "filter ON + empty allowlist must BLOCK the internal mock feed (pf table not built)"
         )
@@ -264,9 +263,8 @@ def test_feed_internal_filter_blocks_then_allowlist_exempts(deployed_vm: SmokeVM
         h.set_feed_internal_allowlist(deployed_vm, "192.168.89.0/24")
         h.reload(deployed_vm, "update")
         h.reload(deployed_vm, "updateip")
-        # Use wait_pfctl_table: filter_configure is async; the table may not be
-        # populated immediately after the reloads complete.
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        h.apply_filter_sync(deployed_vm)
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         assert members, "allowlisting the SLIRP CIDR must EXEMPT the feed (pf table built)"
         assert h.member_present(members, "203.0.113.5"), f"listed host missing after exemption: {members}"
     finally:
@@ -301,13 +299,13 @@ def test_ip_http_range_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedSer
     assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the feed was ever loaded"
 
     with h.CaseContext(deployed_vm, spec):
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         assert _covered_by(members, inside), f"{inside} not covered by the range in {spec.alias}: {members}"
         assert not _covered_by(members, just_past), (
             f"{just_past} (one past the range) unexpectedly in {spec.alias}: {members}"
         )
         assert not _covered_by(members, outside), f"{outside} unexpectedly in {spec.alias}: {members}"
-        assert h.rule_references(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
 
 
 def test_ipv6_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
@@ -332,7 +330,7 @@ def test_ipv6_http_feed_loads(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer)
         assert _covered_by(members, member_host), f"{member_host} not in {spec.alias}: {members}"
         assert _covered_by(members, member_in_prefix), f"{member_in_prefix} not covered by {spec.alias}: {members}"
         assert not _covered_by(members, non_member), f"{non_member} unexpectedly in {spec.alias}: {members}"
-        assert h.rule_references(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
 
 
 # --------------------------------------------------------------------------- #
@@ -390,7 +388,7 @@ def test_ip_generic_parse_failure_logs_line_and_number(deployed_vm: SmokeVM, moc
     summary_before = h.count_log_marker(deployed_vm, h.PFB_LOG, summary_marker)
 
     with h.CaseContext(deployed_vm, spec):
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         assert h.member_present(members, valid_host), f"{valid_host} not in {spec.alias}: {members}"
 
         header_after = h.count_log_marker(deployed_vm, h.IP_PARSE_ERR_LOG, header_marker)
@@ -2111,7 +2109,7 @@ def test_cron_spurious_200_same_bytes_no_reingest(
         # is aliasname_family, not the bare header.
         feed_marker = f"{spec.aliasname}_{spec.family}"
         with h.CaseContext(deployed_vm, spec):
-            members_before = h.wait_pfctl_table(deployed_vm, spec.alias)
+            members_before = h.pfctl_table_members(deployed_vm, spec.alias)
             assert h.member_present(members_before, member_ip), (
                 f"BEFORE: {member_ip} must be in {spec.alias}: {members_before}"
             )
@@ -2126,6 +2124,7 @@ def test_cron_spurious_200_same_bytes_no_reingest(
 
             # WHEN — cron; server returns 200 (no ETag → no If-None-Match → plain 200).
             h.reload(deployed_vm, "cron")
+            h.apply_filter_sync(deployed_vm)
 
             # THEN — "[ feed_marker ] ( content unchanged )" appeared (spurious 200 detected
             # by hash, for THIS feed).
@@ -2356,12 +2355,12 @@ def test_zip_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> 
 
     with h.CaseContext(deployed_vm, spec):
         # When — Force Update downloads + file-detects application/zip + bsdtar decompresses.
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         # Then — the member IP loaded (fails if zip bytes were misrouted to the wrong decompressor).
         assert h.member_present(members, _ADR44_MEMBER), (
             f"expected {_ADR44_MEMBER!r} in {spec.alias} after zip decompression, got: {members}"
         )
-        assert h.rule_references(deployed_vm, spec.alias), (
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), (
             f"no loaded pf rule references {spec.alias} after zip feed import"
         )
 
@@ -2391,7 +2390,7 @@ def test_gzip_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) ->
 
     with h.CaseContext(deployed_vm, spec):
         # When — Force Update downloads + file-detects application/gzip + gunzip decompresses.
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         # Then — the member IP loaded (fails if gzip was mis-normalised to application/zip).
         assert h.member_present(members, _ADR44_MEMBER), (
             f"expected {_ADR44_MEMBER!r} in {spec.alias} after gzip decompression, "
@@ -2399,7 +2398,7 @@ def test_gzip_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) ->
             f"(regression: pfb_mime_normalise() may have rewritten application/gzip → application/zip, "
             f"routing gzip bytes to bsdtar and loading zero entries)"
         )
-        assert h.rule_references(deployed_vm, spec.alias), (
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), (
             f"no loaded pf rule references {spec.alias} after gzip feed import"
         )
 
@@ -2429,7 +2428,7 @@ def test_bzip2_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -
 
     with h.CaseContext(deployed_vm, spec):
         # When — Force Update downloads + file-detects application/x-bzip2 + bzip2 decompresses.
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         # Then — the member IP loaded (fails if bzip2 was mis-normalised to application/zip).
         assert h.member_present(members, _ADR44_MEMBER), (
             f"expected {_ADR44_MEMBER!r} in {spec.alias} after bzip2 decompression, "
@@ -2437,7 +2436,7 @@ def test_bzip2_feed_imports(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -
             f"(regression: pfb_mime_normalise() may have rewritten application/x-bzip2 → application/zip, "
             f"routing bzip2 bytes to bsdtar and loading zero entries)"
         )
-        assert h.rule_references(deployed_vm, spec.alias), (
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), (
             f"no loaded pf rule references {spec.alias} after bzip2 feed import"
         )
 
@@ -2628,7 +2627,7 @@ def test_octet_stream_zip_recovered(deployed_vm: SmokeVM, mock_feeds: _MockFeedS
 
     with h.CaseContext(deployed_vm, spec):
         # When — Force Update fetches the junk-prefixed ZIP.
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         # Then — member is present regardless of which branch handled it.
         # (When recovery_exercised: proves octet-stream was recovered to application/zip and imported.
         #  When not: proves the normal zip branch handled it — still a valid import assertion.)
@@ -2636,7 +2635,7 @@ def test_octet_stream_zip_recovered(deployed_vm: SmokeVM, mock_feeds: _MockFeedS
             f"expected {_ADR45_MEMBER!r} in {spec.alias} after junk-prefixed ZIP, got: {members} "
             f"(box file(1) reported {box_mime!r}; recovery_exercised={recovery_exercised})"
         )
-        assert h.rule_references(deployed_vm, spec.alias), (
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), (
             f"no loaded pf rule references {spec.alias} after octet-stream ZIP recovery"
         )
 
@@ -3147,7 +3146,7 @@ def test_validate_log_healthy_feed_no_spurious_reject(deployed_vm: SmokeVM, mock
 
     with h.CaseContext(deployed_vm, spec):
         # When -- Force Update loads the healthy feed successfully.
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         assert h.member_present(members, member_host), (
             f"expected {member_host!r} in {spec.alias} after the healthy feed load, got: {members}"
         )
@@ -3455,7 +3454,7 @@ def test_feed_sanity_flag_on_still_imports_healthy_feed(deployed_vm: SmokeVM, mo
 
         with h.CaseContext(deployed_vm, spec):
             # When -- Force Update loads the healthy feed with the scan ON.
-            members = h.wait_pfctl_table(deployed_vm, spec.alias)
+            members = h.pfctl_table_members(deployed_vm, spec.alias)
             assert h.member_present(members, member_host), (
                 f"expected {member_host!r} in {spec.alias} after the healthy feed load with "
                 f"pfb_feed_sanity ON, got: {members}"

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -160,13 +160,11 @@ def test_ip_probe_membership_and_rule(deployed_vm: SmokeVM, mock_feeds: object) 
     feed_url = h.write_local_feed(deployed_vm, "smoke_ip_selftest.txt", f"{fed_ip}\n")
     spec = h.IpCase(aliasname="smokeipself", feed_url=feed_url, header="smokeipself")
     with h.CaseContext(deployed_vm, spec):
-        # Use wait_pfctl_table rather than the single-shot pfctl_table_members:
-        # filter_configure is async, so the pf table may not yet be populated
-        # immediately after CaseContext.__enter__ completes the reload.
-        members = h.wait_pfctl_table(deployed_vm, spec.alias)
+        # CaseContext.__enter__ applies the blocking filter sync before this read.
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
         assert h.member_present(members, fed_ip), f"{fed_ip} not in {spec.alias}: {members}"
         assert not h.member_present(members, non_fed), f"{non_fed} unexpectedly in {spec.alias}"
-        assert h.rule_references(deployed_vm, spec.alias), f"no rule references {spec.alias}"
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), f"no rule references {spec.alias}"
 
 
 # The dump's own body runs two full three-layer probes on top of the case reload, so the
@@ -175,7 +173,7 @@ def test_ip_probe_membership_and_rule(deployed_vm: SmokeVM, mock_feeds: object) 
 def test_alias_rule_dump_localises_a_present_and_an_absent_rule(deployed_vm: SmokeVM, mock_feeds: object) -> None:
     """``alias_rule_dump``'s [STAGE LOST] verdict must be right against the REAL box.
 
-    A future rule_references failure will be BELIEVED on this verdict — "the rule was never
+    A future pfctl_rule_has_alias failure will be BELIEVED on this verdict — "the rule was never
     generated" accuses the product, "not loaded yet" accuses the test — so the verdict is
     pinned on the live surface, where the pfSsh.php config read, the rules.debug grep and the
     pfctl reads must genuinely work (fakes cannot prove any of those three).
@@ -191,8 +189,8 @@ def test_alias_rule_dump_localises_a_present_and_an_absent_rule(deployed_vm: Smo
     feed_url = h.write_local_feed(deployed_vm, "smoke_dump_selftest.txt", "198.51.100.9\n")
     spec = h.IpCase(aliasname="smokedump", feed_url=feed_url, header="smokedump")
     with h.CaseContext(deployed_vm, spec):
-        assert h.wait_pfctl_table(deployed_vm, spec.alias), f"{spec.alias} never populated"
-        assert h.rule_references(deployed_vm, spec.alias), f"no rule references {spec.alias}"
+        assert h.pfctl_table_members(deployed_vm, spec.alias), f"{spec.alias} never populated"
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), f"no rule references {spec.alias}"
 
         present = h.alias_rule_dump(deployed_vm, spec.alias)
         assert "[STAGE LOST] NONE" in present, f"a rule loaded at every layer was misreported:\n{present}"

--- a/tests/smoke/test_smoke_hooks.py
+++ b/tests/smoke/test_smoke_hooks.py
@@ -808,13 +808,14 @@ def test_hooks_changed_aliases_ip_and_dnsbl(deployed_vm: SmokeVM, mock_feeds: _M
     # Settle: a first full update processes both feeds (their aliases ARE updated here).
     h.clear_hook_markers(deployed_vm, token)
     h.reload(deployed_vm, "update")
-    # Wait until the IP alias kernel table is actually LOADED before the no-op pass. ADR-40's gate
+    h.apply_filter_sync(deployed_vm)
+    # Ensure the IP alias kernel table is actually LOADED before the no-op pass. ADR-40's gate
     # lists an alias on a reuse-cached pass iff its kernel table is empty (empty($pfctlck) → the #468
     # empty-table self-heal). If the settle update's `pfctl -T replace` load races the next pass's
     # $pfctlck read (slow/contended box), the no-op pass sees an empty table, self-heals, and reports
     # the alias — a non-deterministic false failure of the "empty changed-list" assertion below.
-    # Polling the table non-empty here removes that race (it stays loaded between the two passes).
-    assert h.wait_pfctl_table(deployed_vm, ip_spec.alias), (
+    # The blocking filter apply above makes this one-shot table read authoritative.
+    assert h.pfctl_table_members(deployed_vm, ip_spec.alias), (
         f"IP kernel table {ip_spec.alias} did not populate after the settle update"
     )
 
@@ -914,10 +915,11 @@ def test_hooks_webhook_fires_on_ip_change(
     # this pass WOULD fire the hook — clear the sink afterwards so the no-op assertion
     # below is clean).
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
     # Settle the IP kernel table before the no-op pass — see the race note in
     # test_hooks_changed_aliases_ip_and_dnsbl: an unloaded table makes the no-op pass self-heal
     # (#468) and populate PFB_CHANGED_IP_ALIASES, firing the guard and producing a flaky callback.
-    assert h.wait_pfctl_table(deployed_vm, ip_spec.alias), (
+    assert h.pfctl_table_members(deployed_vm, ip_spec.alias), (
         f"IP kernel table {ip_spec.alias} did not populate after the settle update"
     )
 
@@ -1012,10 +1014,11 @@ def test_hooks_webhook_dnsbl_guard_branch(
     # Settle: a first full update processes both feeds (both WOULD fire here); clear the
     # sink afterwards so the DNSBL-only assertion below is clean.
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
     # Settle the IP kernel table before the DNSBL-only pass — see the race note in
     # test_hooks_changed_aliases_ip_and_dnsbl: an unloaded IP table makes the no-op pass self-heal
     # (#468) and populate PFB_CHANGED_IP_ALIASES, firing the IP guard on a DNSBL-only change.
-    assert h.wait_pfctl_table(deployed_vm, ip_spec.alias), (
+    assert h.pfctl_table_members(deployed_vm, ip_spec.alias), (
         f"IP kernel table {ip_spec.alias} did not populate after the settle update"
     )
     webhook_sink.clear()

--- a/tests/smoke/test_smoke_ip_recompute.py
+++ b/tests/smoke/test_smoke_ip_recompute.py
@@ -214,6 +214,7 @@ def test_recompute_dedup_ownership_across_overlapping_feeds(deployed_vm: SmokeVM
     # priority, pfb_ip_recompute_family_headers()).
     h.inject_ip_lists(deployed_vm, [spec_a, spec_b])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
     a_lines = _lines(deployed_vm, f"{DENYDIR}/r1a_v4.txt")
     b_lines = _lines(deployed_vm, f"{DENYDIR}/r1b_v4.txt")
@@ -227,8 +228,8 @@ def test_recompute_dedup_ownership_across_overlapping_feeds(deployed_vm: SmokeVM
     assert "r1b_v4 203.0.113.44" not in master, f"masterfile kept B's pruned containment row: {master}"
     assert "r1b_v4 198.51.100.211" not in master, f"masterfile kept B's pruned exact-repeat row: {master}"
 
-    a_members = h.wait_pfctl_table(deployed_vm, spec_a.alias)
-    b_members = h.wait_pfctl_table(deployed_vm, spec_b.alias)
+    a_members = h.pfctl_table_members(deployed_vm, spec_a.alias)
+    b_members = h.pfctl_table_members(deployed_vm, spec_b.alias)
     assert h.member_present(a_members, "198.51.100.211"), (
         f"pf table {spec_a.alias} missing exact-repeat winner: {a_members}"
     )
@@ -271,19 +272,21 @@ def test_recompute_v6_snapshot_round_trips_across_static_pass(deployed_vm: Smoke
     h.inject_ip_lists(deployed_vm, [spec])
 
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
     snap_lines = _lines(deployed_vm, f"{SNAPDIR}/r2v6_v6.snap")
     deny_lines_pass1 = _lines(deployed_vm, f"{DENYDIR}/r2v6_v6.txt")
     deny_raw_pass1 = _raw(deployed_vm, f"{DENYDIR}/r2v6_v6.txt")
     expected = sorted(["2001:db8:5678::/64", "2001:db8:5678:1::42"])
     assert sorted(snap_lines) == expected, f"snapshot content wrong after first ingest: {snap_lines}"
     assert sorted(deny_lines_pass1) == expected, f"deny file content wrong after first ingest: {deny_lines_pass1}"
-    members_pass1 = h.wait_pfctl_table(deployed_vm, spec.alias)
+    members_pass1 = h.pfctl_table_members(deployed_vm, spec.alias)
     assert h.member_present(members_pass1, "2001:db8:5678:1::42"), f"pf table missing bare host: {members_pass1}"
     assert h.member_covers(members_pass1, "2001:db8:5678::1"), f"pf table missing /64 coverage: {members_pass1}"
 
     # Held static: no edit, no force_ip_refetch -- updateip's force=true alone
     # reprocesses this alias again from its cached raw body.
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
     deny_raw_pass2 = _raw(deployed_vm, f"{DENYDIR}/r2v6_v6.txt")
     assert deny_raw_pass2 == deny_raw_pass1, (
         f"deny file not byte-identical across a static pass: pass1={deny_raw_pass1!r} pass2={deny_raw_pass2!r}"
@@ -291,7 +294,7 @@ def test_recompute_v6_snapshot_round_trips_across_static_pass(deployed_vm: Smoke
     master = _lines(deployed_vm, MASTERFILE)
     assert "r2v6_v6 2001:db8:5678::/64" in master, f"masterfile missing v6 /64 row after round-trip: {master}"
     assert "r2v6_v6 2001:db8:5678:1::42" in master, f"masterfile missing v6 host row after round-trip: {master}"
-    members_pass2 = h.wait_pfctl_table(deployed_vm, spec.alias)
+    members_pass2 = h.pfctl_table_members(deployed_vm, spec.alias)
     assert h.member_present(members_pass2, "2001:db8:5678:1::42"), (
         f"pf table lost bare host after round-trip: {members_pass2}"
     )
@@ -331,6 +334,7 @@ def test_recompute_rewrites_unchanged_sibling_across_passes(deployed_vm: SmokeVM
     spec_b = h.IpCase(aliasname="r4b", feed_url=feed_b, header="r4b", action="Deny_Both")
     h.inject_ip_lists(deployed_vm, [spec_a, spec_b])
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
 
     # BEFORE: both settle correctly.
     a_before = _lines(deployed_vm, f"{DENYDIR}/r4a_v4.txt")
@@ -342,6 +346,7 @@ def test_recompute_rewrites_unchanged_sibling_across_passes(deployed_vm: SmokeVM
     h.write_local_feed(deployed_vm, "r4_feed_a.txt", "198.51.100.31\n198.51.100.32\n")
     h.force_ip_refetch(deployed_vm, "r4a_v4")
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
 
     a_after = _lines(deployed_vm, f"{DENYDIR}/r4a_v4.txt")
     b_after = _lines(deployed_vm, f"{DENYDIR}/r4b_v4.txt")
@@ -352,7 +357,7 @@ def test_recompute_rewrites_unchanged_sibling_across_passes(deployed_vm: SmokeVM
     assert "r4a_v4 198.51.100.32" in master, f"masterfile missing A's new row: {master}"
     assert "r4b_v4 198.51.100.41" in master, f"masterfile missing B's unchanged row after the family rewrite: {master}"
 
-    b_members = h.wait_pfctl_table(deployed_vm, spec_b.alias)
+    b_members = h.pfctl_table_members(deployed_vm, spec_b.alias)
     assert h.member_present(b_members, "198.51.100.41"), f"pf table {spec_b.alias} lost its member: {b_members}"
 
 
@@ -433,6 +438,7 @@ def test_recompute_closing_refills_placeholder_dup_off_pmax(deployed_vm: SmokeVM
     # collapsed /24; "collapse" (listed 2nd) is the one that ends up empty.
     h.inject_ip_lists(deployed_vm, [spec_anchor, spec_collapse])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
     anchor_lines = _lines(deployed_vm, f"{DENYDIR}/r9hi_v4.txt")
     collapse_lines = _lines(deployed_vm, f"{DENYDIR}/r9lo_v4.txt")
@@ -442,7 +448,7 @@ def test_recompute_closing_refills_placeholder_dup_off_pmax(deployed_vm: SmokeVM
     # No pf-table assertion for the collapsed alias: its mirror is unlinked while the
     # deny file is still empty, before the closing pass refills the placeholder (see
     # test_recompute_closing_refills_placeholder_dup_on).
-    anchor_members = h.wait_pfctl_table(deployed_vm, spec_anchor.alias)
+    anchor_members = h.pfctl_table_members(deployed_vm, spec_anchor.alias)
     assert h.member_covers(anchor_members, "192.0.2.21"), (
         f"pf table lost the anchor's own offending host: {anchor_members}"
     )
@@ -495,6 +501,7 @@ def test_recompute_suppression_realigns_across_sibling_change(deployed_vm: Smoke
     spec_b = h.IpCase(aliasname="r6b", feed_url=feed_b, header="r6b", action="Deny_Both")
     h.inject_ip_lists(deployed_vm, [spec_a, spec_b])
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
 
     # BEFORE: the suppressed IP is genuinely absent (not merely "never checked").
     a_before = _lines(deployed_vm, f"{DENYDIR}/r6a_v4.txt")
@@ -505,6 +512,7 @@ def test_recompute_suppression_realigns_across_sibling_change(deployed_vm: Smoke
     h.write_local_feed(deployed_vm, "r6_feed_b.txt", "172.104.92.31\n")
     h.force_ip_refetch(deployed_vm, "r6b_v4")
     h.reload(deployed_vm, "update")
+    h.apply_filter_sync(deployed_vm)
 
     a_after = _lines(deployed_vm, f"{DENYDIR}/r6a_v4.txt")
     assert suppressed_ip not in a_after, (
@@ -515,7 +523,7 @@ def test_recompute_suppression_realigns_across_sibling_change(deployed_vm: Smoke
         f"unrelated survivor {survivor_ip} dropped by the sibling-triggered rewrite: {a_after}"
     )
 
-    a_members = h.wait_pfctl_table(deployed_vm, spec_a.alias)
+    a_members = h.pfctl_table_members(deployed_vm, spec_a.alias)
     assert not h.member_present(a_members, suppressed_ip), (
         f"pf table {spec_a.alias} still carries the suppressed IP: {a_members}"
     )

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -142,7 +142,7 @@ def test_ip_alias_table_and_rule(deployed_vm: SmokeVM, mock_feeds: _MockFeedServ
         members = h.pfctl_table_members(deployed_vm, spec.alias)
         assert h.member_present(members, fed_ip), f"{fed_ip} not in {spec.alias}: {members}"
         assert not h.member_present(members, non_fed), f"{non_fed} unexpectedly in {spec.alias}: {members}"
-        assert h.rule_references(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
+        assert h.pfctl_rule_has_alias(deployed_vm, spec.alias), f"no loaded pf rule references {spec.alias}"
 
 
 # --------------------------------------------------------------------------- #
@@ -1029,8 +1029,7 @@ def test_dnsbl_fail_closed_broken_manifest(
 # --------------------------------------------------------------------------- #
 
 
-# The 30s default body cap cannot cover reload + two 30s table polls + two ~20s
-# rule_references polls + the on-failure dump: it kills the diagnostic before it prints
+# The 30s default body cap cannot cover reload + two table reads + the on-failure dump.
 # (issue #1239). The budget is a deadlock guard here, not a pacer.
 @pytest.mark.timeout(180)
 def test_dnsblip_dual_stack_partition(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
@@ -1050,12 +1049,8 @@ def test_dnsblip_dual_stack_partition(deployed_vm: SmokeVM, mock_feeds: _MockFee
     this pins is specifically the dual-stack PARTITION (families never collide on one
     table).
 
-    ``pfB_DNSBLIP_v4`` / ``pfB_DNSBLIP_v6`` are populated ASYNC — ``filter_configure``
-    lands them slightly after ``pfblockerng.php update`` returns (absent on a sync read
-    right after the reload, present in teardown diagnostics — issue #35). So the table
-    read goes through the bounded :func:`~helpers.wait_pfctl_table` poll, mirroring the
-    ``rule_references`` reload-lag pattern; a real miss surfaces as an assertion on the
-    empty list (with diagnostics uploaded), never a hang.
+    ``pfB_DNSBLIP_v4`` / ``pfB_DNSBLIP_v6`` are read after one blocking filter apply,
+    making each single-shot table result authoritative.
     """
     # Given: a feed carrying exactly one literal per family.
     v4 = "203.0.113.7"  # RFC 5737 documentation range
@@ -1072,12 +1067,13 @@ def test_dnsblip_dual_stack_partition(deployed_vm: SmokeVM, mock_feeds: _MockFee
         dnsbl_ip_action="Deny_Both",
     )
     with h.CaseContext(deployed_vm, spec, scope="update"):
-        # When: read each per-family table through the bounded async-population poll.
-        # Then: both tables exist and are non-empty (empty list -> clear assertion).
-        v4_members = h.wait_pfctl_table(deployed_vm, "pfB_DNSBLIP_v4")
-        v6_members = h.wait_pfctl_table(deployed_vm, "pfB_DNSBLIP_v6")
-        assert v4_members, "pfB_DNSBLIP_v4 never appeared/populated within the poll window"
-        assert v6_members, "pfB_DNSBLIP_v6 never appeared/populated within the poll window"
+        h.apply_filter_sync(deployed_vm)
+        # When: read each per-family table once after the sync boundary.
+        # Then: both tables exist and are non-empty.
+        v4_members = h.pfctl_table_members(deployed_vm, "pfB_DNSBLIP_v4")
+        v6_members = h.pfctl_table_members(deployed_vm, "pfB_DNSBLIP_v6")
+        assert v4_members, "pfB_DNSBLIP_v4 missing after filter sync"
+        assert v6_members, "pfB_DNSBLIP_v6 missing after filter sync"
 
         # Then: each table holds ONLY its own family (the partition — no collision / merge).
         assert h.member_present(v4_members, v4), f"{v4} not in pfB_DNSBLIP_v4: {v4_members}"
@@ -1086,13 +1082,12 @@ def test_dnsblip_dual_stack_partition(deployed_vm: SmokeVM, mock_feeds: _MockFee
         assert any(":" in m for m in v6_members), f"no IPv6 in pfB_DNSBLIP_v6: {v6_members}"
         assert not any(_is_v4_literal(m) for m in v6_members), f"IPv4 leaked into pfB_DNSBLIP_v6: {v6_members}"
 
-        # Then: inet/inet6 rules reference the matching per-family table. rule_references
-        # already polls, so a False here is NOT an early read — dump the three layers so the
-        # failure says WHICH one lost the rule (issue #1239) instead of being re-guessed.
-        assert h.rule_references(deployed_vm, "pfB_DNSBLIP_v4"), (
+        # Then: inet/inet6 rules reference the matching per-family table. On failure, dump
+        # the three layers so the report says WHICH one lost the rule (issue #1239).
+        assert h.pfctl_rule_has_alias(deployed_vm, "pfB_DNSBLIP_v4"), (
             "no rule references pfB_DNSBLIP_v4\n" + h.alias_rule_dump(deployed_vm, "pfB_DNSBLIP_v4")
         )
-        assert h.rule_references(deployed_vm, "pfB_DNSBLIP_v6"), (
+        assert h.pfctl_rule_has_alias(deployed_vm, "pfB_DNSBLIP_v6"), (
             "no rule references pfB_DNSBLIP_v6\n" + h.alias_rule_dump(deployed_vm, "pfB_DNSBLIP_v6")
         )
 

--- a/tests/smoke/test_smoke_suppression.py
+++ b/tests/smoke/test_smoke_suppression.py
@@ -246,9 +246,10 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
     # needed (unlike the ADR-40 tests, which use the force=false 'update'
     # verb and must call force_ip_refetch explicitly).
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
     # BEFORE: both addresses match the freshly-loaded, UNSUPPRESSED table.
-    members = h.wait_pfctl_table(deployed_vm, spec.alias)
+    members = h.pfctl_table_members(deployed_vm, spec.alias)
     assert members, f"pf table {spec.alias} never populated after the settling update"
     matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, target)
     assert matched, f"expected {target} to MATCH {spec.alias} before suppression; pfctl said: {raw!r}"
@@ -258,6 +259,7 @@ def test_suppression_v4_carves_containing_range_spares_sibling(deployed_vm: Smok
     # WHEN: configure suppression for the target host only, then re-run.
     _set_suppression(deployed_vm, v4=[host_entry])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
     # THEN: the target is carved out; the sibling -- an unrelated feed entry -- is untouched.
     matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, target)
@@ -319,8 +321,9 @@ def test_suppression_v6_carves_containing_range_spares_sibling(deployed_vm: Smok
 
     h.inject_ip_lists(deployed_vm, [companion_spec, v6spec])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
-    members = h.wait_pfctl_table(deployed_vm, v6spec.alias)
+    members = h.pfctl_table_members(deployed_vm, v6spec.alias)
     assert members, f"pf table {v6spec.alias} never populated after the settling update"
     matched, raw = h.pfctl_table_test_raw(deployed_vm, v6spec.alias, target)
     assert matched, f"expected {target} to MATCH {v6spec.alias} before suppression; pfctl said: {raw!r}"
@@ -333,6 +336,7 @@ def test_suppression_v6_carves_containing_range_spares_sibling(deployed_vm: Smok
     # mixed-family case in the same pass.
     _set_suppression(deployed_vm, v6=[host_entry])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
     matched, raw = h.pfctl_table_test_raw(deployed_vm, v6spec.alias, target)
     assert not matched, f"expected {target} to NO LONGER match {v6spec.alias} after suppression; pfctl said: {raw!r}"
@@ -381,8 +385,9 @@ def test_suppression_v4_bare_host_removed(deployed_vm: SmokeVM) -> None:
 
     h.inject(deployed_vm, spec)
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
-    members = h.wait_pfctl_table(deployed_vm, spec.alias)
+    members = h.pfctl_table_members(deployed_vm, spec.alias)
     assert members, f"pf table {spec.alias} never populated after the settling update"
     for ip in (inside_16, removed_host, kept_host):
         matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, ip)
@@ -390,6 +395,7 @@ def test_suppression_v4_bare_host_removed(deployed_vm: SmokeVM) -> None:
 
     _set_suppression(deployed_vm, v4=[host_entry])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
     matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, removed_host)
     assert not matched, f"expected {removed_host} to be REMOVED from {spec.alias}; pfctl said: {raw!r}"
@@ -433,8 +439,9 @@ def test_suppression_v4_subnet_mask_carves_at_granularity(deployed_vm: SmokeVM) 
 
     h.inject(deployed_vm, spec)
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
-    members = h.wait_pfctl_table(deployed_vm, spec.alias)
+    members = h.pfctl_table_members(deployed_vm, spec.alias)
     assert members, f"pf table {spec.alias} never populated after the settling update"
     for ip in (hole_ip, sibling_ip):
         matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, ip)
@@ -442,6 +449,7 @@ def test_suppression_v4_subnet_mask_carves_at_granularity(deployed_vm: SmokeVM) 
 
     _set_suppression(deployed_vm, v4=[hole_subnet])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
     matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, hole_ip)
     assert not matched, (
@@ -501,10 +509,11 @@ def test_suppression_drops_reserved_classes_keeps_public(deployed_vm: SmokeVM) -
 
     h.inject_ip_lists(deployed_vm, [v4spec, v6spec])
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
-    members_v6 = h.wait_pfctl_table(deployed_vm, v6spec.alias)
+    members_v6 = h.pfctl_table_members(deployed_vm, v6spec.alias)
     assert members_v6, f"pf table {v6spec.alias} never populated after the update"
-    members_v4 = h.wait_pfctl_table(deployed_vm, v4spec.alias)
+    members_v4 = h.pfctl_table_members(deployed_vm, v4spec.alias)
     assert members_v4, f"pf table {v4spec.alias} never populated after the update"
 
     matched, raw = h.pfctl_table_test_raw(deployed_vm, v6spec.alias, public_v6)
@@ -554,9 +563,10 @@ def test_suppression_cidr_v6_floor_clamps_wide_cidr_to_bare_host(deployed_vm: Sm
 
     h.inject(deployed_vm, spec)
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
     # BEFORE: the floor is absent (Disabled) -- the /48 loads unclamped.
-    members = h.wait_pfctl_table(deployed_vm, spec.alias)
+    members = h.pfctl_table_members(deployed_vm, spec.alias)
     assert members, f"pf table {spec.alias} never populated after the settling update"
     matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, inside_cidr)
     assert matched, f"expected {inside_cidr} (inside the un-floored /48) to MATCH {spec.alias}; pfctl said: {raw!r}"
@@ -566,6 +576,7 @@ def test_suppression_cidr_v6_floor_clamps_wide_cidr_to_bare_host(deployed_vm: Sm
     # WHEN: set the floor above the feed's /48, then re-run.
     _set_suppression_cidr_v6(deployed_vm, "56")
     h.reload(deployed_vm, "updateip", wait_unbound=False)
+    h.apply_filter_sync(deployed_vm)
 
     # THEN: the /48 collapsed to its bare base address -- the wide span no longer matches...
     matched, raw = h.pfctl_table_test_raw(deployed_vm, spec.alias, inside_cidr)

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -520,14 +520,14 @@ def test_alerts_invalid_actions_leave_state_unchanged_and_addsuppress_writes_exa
         custom_path = f"{CFG_IPV4_LISTS}/0/custom"
         helpers.inject(vm, spec)
         helpers.reload(vm, "updateip")
-        table_before = sorted(helpers.wait_pfctl_table(vm, hostile_table))
+        helpers.apply_filter_sync(vm)
+        table_before = sorted(helpers.pfctl_table_members(vm, hostile_table))
         assert table_before, f"{hostile_table} did not populate before hostile action"
         # Build the live table under Deny_Both first, then change only the
         # persisted row classification. Permit_Inbound with the harness's
         # default protocol does not declare a live table, while Alerts derives
-        # whitelist metadata from the current config row. The bounded table
-        # wait must finish before this write because filter_configure can land
-        # asynchronously after updateip returns. Avoiding a second reload then
+        # whitelist metadata from the current config row. The blocking filter
+        # apply above settles the table before this write. Avoiding a second reload then
         # leaves one real table plus matching Permit metadata: exactly the two
         # preconditions raw ip_white forwarding needs to mutate state.
         classify_result = helpers.php_eval(
@@ -616,10 +616,11 @@ def test_addsuppress_v4_carves_containing_range_and_spares_sibling(
 
     helpers.inject(vm, spec)
     helpers.reload(vm, "updateip")
+    helpers.apply_filter_sync(vm)
     try:
-        # BEFORE: the table is populated (filter_configure lands async after the
-        # CLI returns, hence the poll) and both addresses match it live.
-        members = helpers.wait_pfctl_table(vm, table)
+        # BEFORE: the table is populated after the blocking filter apply and both
+        # addresses match it live.
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
         assert matched, f"{target} expected to match pf table {table} before suppression; pfctl said: {raw!r}"
@@ -687,8 +688,9 @@ def test_addsuppress_v6_carves_containing_range_and_spares_sibling(
 
     helpers.inject(vm, spec)
     helpers.reload(vm, "updateip")
+    helpers.apply_filter_sync(vm)
     try:
-        members = helpers.wait_pfctl_table(vm, table)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
         assert matched, f"{target} expected to match pf table {table} before suppression; pfctl said: {raw!r}"
@@ -753,6 +755,7 @@ def test_addsuppress_v4_already_covered_by_broader_entry_skips_duplicate(
 
     helpers.inject(vm, spec)
     helpers.reload(vm, "updateip")
+    helpers.apply_filter_sync(vm)
     try:
         # GIVEN: a broader manual suppression entry already covers the target
         # -- seeded directly via config (mirroring a prior manual "+"/edit),
@@ -768,7 +771,7 @@ def test_addsuppress_v4_already_covered_by_broader_entry_skips_duplicate(
         # BEFORE: the target still matches the live table (the broader
         # suppression entry is config-only until this point -- no reload ran
         # since it was seeded).
-        members = helpers.wait_pfctl_table(vm, table)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
         assert matched, (
@@ -848,6 +851,7 @@ def test_delete_ip_v4_unsuppresses_broader_entry_and_restores_block(
 
     helpers.inject(vm, spec)
     helpers.reload(vm, "updateip")
+    helpers.apply_filter_sync(vm)
     try:
         # GIVEN: seed the broader manual suppression entry directly (mirrors a
         # prior manual customlist edit, not one produced by addsuppress here).
@@ -861,7 +865,7 @@ def test_delete_ip_v4_unsuppresses_broader_entry_and_restores_block(
 
         # BEFORE: the table exists (the sibling populated it) and does NOT cover
         # the suppressed hole; the /28 entry is present in v4suppression.
-        members = helpers.wait_pfctl_table(vm, table)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         assert supp_entry in _suppression_entries(vm, CFG_V4SUPPRESSION), (
             f"{supp_entry} not present in v4suppression before the un-suppress POST"
@@ -928,6 +932,7 @@ def test_delete_ip_v6_unsuppresses_entry_and_restores_block(
 
     helpers.inject(vm, spec)
     helpers.reload(vm, "updateip")
+    helpers.apply_filter_sync(vm)
     try:
         supp_b64 = base64.b64encode(f"{supp_entry} # smoke-unsuppress\r\n".encode()).decode()
         helpers.php_eval(
@@ -939,7 +944,7 @@ def test_delete_ip_v6_unsuppresses_entry_and_restores_block(
 
         # BEFORE: the table exists (the sibling populated it) and does NOT cover
         # the suppressed hole; the /64 entry is present in v6suppression.
-        members = helpers.wait_pfctl_table(vm, table)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         assert supp_entry in _suppression_entries(vm, CFG_V6SUPPRESSION), (
             f"{supp_entry} not present in v6suppression before the un-suppress POST"
@@ -1123,9 +1128,10 @@ def test_ip_unlock_v4_carves_containing_range_relock_restores_and_spares_sibling
 
     helpers.inject(vm, spec)
     helpers.reload(vm, "updateip")
+    helpers.apply_filter_sync(vm)
     try:
         # BEFORE: the table is populated and both addresses match it live.
-        members = helpers.wait_pfctl_table(vm, table)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
         assert matched, f"{target} expected to match pf table {table} before unlock; pfctl said: {raw!r}"
@@ -1201,8 +1207,9 @@ def test_ip_unlock_v6_carves_containing_range_relock_restores_and_spares_sibling
 
     helpers.inject(vm, spec)
     helpers.reload(vm, "updateip")
+    helpers.apply_filter_sync(vm)
     try:
-        members = helpers.wait_pfctl_table(vm, table)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
         assert matched, f"{target} expected to match pf table {table} before unlock; pfctl said: {raw!r}"
@@ -1273,8 +1280,9 @@ def test_ip_unlock_rejects_invalid_ip_no_mutation(
 
     helpers.inject(vm, spec)
     helpers.reload(vm, "updateip")
+    helpers.apply_filter_sync(vm)
     try:
-        members = helpers.wait_pfctl_table(vm, table)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
 
         store_before = _ip_unlock_hosts(vm)
@@ -1375,8 +1383,9 @@ def test_ip_unlock_double_punch_v4_second_punch_keeps_first_carved(
         # must still hit `finally: helpers.reset(vm)`.
         helpers.inject(vm, spec)
         helpers.reload(vm, "updateip")
+        helpers.apply_filter_sync(vm)
         # BEFORE: the table is populated and every address matches it live.
-        members = helpers.wait_pfctl_table(vm, table)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         for host in (first, second, third_inside, sibling):
             matched, raw = helpers.pfctl_table_test_raw(vm, table, host)
@@ -1472,7 +1481,8 @@ def test_ip_unlock_double_punch_v6_second_punch_keeps_first_carved(
         # must still hit `finally: helpers.reset(vm)`.
         helpers.inject(vm, spec)
         helpers.reload(vm, "updateip")
-        members = helpers.wait_pfctl_table(vm, table)
+        helpers.apply_filter_sync(vm)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         for host in (first, second, third_inside, sibling):
             matched, raw = helpers.pfctl_table_test_raw(vm, table, host)
@@ -1564,9 +1574,10 @@ def test_ip_unlock_not_currently_blocked_records_nothing(
         # must still hit `finally: helpers.reset(vm)`.
         helpers.inject(vm, spec)
         helpers.reload(vm, "updateip")
+        helpers.apply_filter_sync(vm)
         # BEFORE: the table is populated; the member matches, the target does not
         # (the before-state gate -- "not currently blocked" must be genuinely true).
-        members = helpers.wait_pfctl_table(vm, table)
+        members = helpers.pfctl_table_members(vm, table)
         assert members, f"pf table {table} never populated after the settling update"
         matched, raw = helpers.pfctl_table_test_raw(vm, table, member)
         assert matched, f"{member} expected to match pf table {table} before the test; pfctl said: {raw!r}"

--- a/tests/test_smoke_alias_rule_dump.py
+++ b/tests/test_smoke_alias_rule_dump.py
@@ -1,22 +1,10 @@
-"""``alias_rule_dump`` must name WHICH layer lost a pfB alias's auto-rule.
-
-Issue #1239 filed a ``rule_references`` smoke flake with a fabricated cause ("the check
-does not poll" — it has polled since PR #133). The real cause is still unknown, and the two
-candidates demand opposite responses: the rule was never written to config.xml (a PRODUCT
-bug — a populated block table with nothing enforcing it) versus the rule was written and
-emitted but pf had not loaded it yet (a genuine reload lag, i.e. a test-only flake).
-
-Only the layer that still holds the rule tells them apart, so the on-failure dump reports a
-``[STAGE LOST]`` verdict across CONFIG -> RULES.DEBUG -> LIVE PF. This module pins that
-verdict for every layer combination off-VM (``tests.smoke.helpers`` is import-safe —
-precedent: ``test_smoke_unbound_ready.py``), so the next live occurrence localises itself
-instead of being re-guessed.
-"""
+"""Pin the layered alias-rule diagnostic and forbid retired pfctl polls."""
 
 from __future__ import annotations
 
 import subprocess
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import pytest
 
@@ -111,7 +99,7 @@ def _fake_php_eval(rows: str, *, returncode: int = 0, raw: str | None = None, ra
         # Scenario: emitted into rules.debug but not yet loaded into pf -> the genuine
         # reload-lag verdict (or a pfctl load rejection), i.e. a test-only flake.
         (CFG_ROW, DEBUG_ROW, "", "LIVE PF"),
-        # Scenario: present at all three layers -> rule_references' poll read stale state;
+        # Scenario: present at all three layers -> the read saw stale state;
         # the rule IS there, so the assertion, not the product, is what to look at.
         (CFG_ROW, DEBUG_ROW, LIVE_ROW, "NONE"),
     ],
@@ -382,18 +370,36 @@ def _php_snippet_for(alias: str) -> str:
     return captured[0]
 
 
-def test_ruleset_layers_use_the_same_match_rule_as_the_assertion_they_explain() -> None:
-    """The dump explains a rule_references failure, so it must not disagree with it.
+def test_public_dump_uses_exact_alias_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The public dump includes only rules that reference the requested table."""
+    monkeypatch.setattr(helpers, "php_eval", _fake_php_eval(CFG_ROW))
+    foreign = "block drop in quick from <pfB_Other_v4> to any"
+    generic = "block drop in quick on em0 # mentions harness"
+    vm = _FakeVM(
+        rules_debug=f"{DEBUG_ROW}\n{foreign}\n{generic}\n",
+        live_rules=f"{LIVE_ROW}\n{foreign}\n{generic}\n",
+        tables=f"{ALIAS}\npfB_Other_v4\n",
+    )
 
-    If the dump applied a looser (or stricter) match than rule_references, it could report
-    the rule as PRESENT at live pf on the very run where rule_references declared it absent —
-    a self-contradicting diagnostic. Both route through rule_line_references.
-    """
-    assert helpers.rule_line_references(f"block drop in quick from <{ALIAS}> to any", ALIAS)
-    assert not helpers.rule_line_references("block drop in quick from <pfB_Other_v4> to any", ALIAS)
-    # A non-pfB_ alias gets the exact table-reference match ONLY — a bare token must not
-    # match a foreign rule (the baked CI harness rules mention plenty of generic words).
-    assert not helpers.rule_line_references("block drop in quick on em0 # mentions harness", "harness")
+    dump = helpers.alias_rule_dump(vm, ALIAS)  # type: ignore[arg-type]
+
+    assert f"[RULES.DEBUG {ALIAS}: 1] {DEBUG_ROW}" in dump
+    assert f"[LIVE PF -sr {ALIAS}: 1] {LIVE_ROW}" in dump
+    assert foreign not in dump
+    assert generic not in dump
+
+
+def test_no_retired_pf_poll_names_remain() -> None:
+    """Every Python smoke file must use sync boundaries plus one-shot reads."""
+    retired = ["_".join(("wait", "pfctl", "table")), "_".join(("rule", "references"))]
+    root = Path(__file__).parent
+    hits = [
+        (str(path), token)
+        for path in sorted(root.rglob("*.py"))
+        for token in retired
+        if token in path.read_text(encoding="utf-8")
+    ]
+    assert not hits, "retired pf poll names found:\n" + "\n".join(f"{path}: {token}" for path, token in hits)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- replace every active pre-#557 pf table/rule poll with `apply_filter_sync()` (or the already-completed reboot/CaseContext boundary) plus an authoritative one-shot read
- delete the two bounded poll helpers and keep the rule check as one `pfctl -sr` snapshot
- add a frozen hermetic scanner so either retired helper name fails the suite anywhere under `tests/`

Fixes #1986.

## Exhaustive sweep

The issue body's original file list was illustrative. Source enumeration found 80 direct calls: 65 table polls and 15 rule polls. This PR sweeps the complete active set of 16 files:

| file | direct calls or active reference swept |
| --- | ---: |
| `CONTRIBUTING.md` | active helper guidance |
| `tests/smoke/helpers.py` | both helper definitions plus diagnostic prose/matcher |
| `tests/smoke/test_smoke_714_asn_geoip.py` | 1 |
| `tests/smoke/test_smoke_adr40.py` | 4 |
| `tests/smoke/test_smoke_adr62.py` | 2 |
| `tests/smoke/test_smoke_aggregate.py` | 12 |
| `tests/smoke/test_smoke_boot_reload.py` | 4 |
| `tests/smoke/test_smoke_download_loop.py` | 1 |
| `tests/smoke/test_smoke_feeds.py` | 18 |
| `tests/smoke/test_smoke_helpers.py` | 4 |
| `tests/smoke/test_smoke_hooks.py` | 3 |
| `tests/smoke/test_smoke_ip_recompute.py` | 7 |
| `tests/smoke/test_smoke_matrix.py` | 5 |
| `tests/smoke/test_smoke_suppression.py` | 7 |
| `tests/smoke/ui/test_alerts.py` | 12 |
| `tests/test_smoke_alias_rule_dump.py` | frozen scanner and public diagnostic coverage |

The post-reboot reads deliberately do not invoke a repairing filter apply: completed reboot/readiness is their synchronous boundary, preserving the reboot-survival oracle. All other state groups reuse or add one blocking apply before one-shot table/rule reads. Historical mentions under immutable accepted ADR artifacts remain unchanged; the active tree is clean.

```text
$ git grep -n -E 'wait_pfctl_table|rule_references' -- tests/
# no output; exit 1

$ rg -n '\b(wait_pfctl_table|rule_references)\b' -g '!.ADRs/**'
# no output; exit 1
```

## Evidence

- test-first RED: `31 collected, 30 passed, 1 failed`; the only failure was the new exhaustive survivor scanner
- frozen test hash: `ea9e665c89df22f21f066c24b873d575eee4e767` at RED, GREEN, and final head
- GREEN: `31 passed`
- independent red replay: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`
- canonical gates on rebased head: pytest, Ruff check, Ruff format-check, mypy, and markdownlint passed
- exact-head GitHub Tests workflow: all required checks passed
- independent step verifier: PASS across all 80 rows; no caller assertion removed
- independent top-tier review of exact base/head: PASS; all 16 file blobs and the patch remained identical after the final rebase
- live reboot coverage: standard and RAM-disk reboot cases passed (`2 passed`)
- live UI coverage on exact head: full repeat passed (`59 passed`); the changed IPv6 case also passed isolated. A first full run had one transient IPv6 carve miss (`58 passed, 1 failed`); the exact-head repeat, exact-head isolated run, `devel` full control (`59 passed`), and `devel` isolated control all passed.
- affected non-UI live sweep: `144 passed, 3 skipped, 1 xfailed, 10 failed`; every failure was independently reproduced on `devel` before the changed assertion path: four config-write fixture failures are #2071, five batch-recompute snapshot failures are #2072, and the IDN alert-only regression is #2073

## Scope

- #1989 and all production completion-signal work remain separate and untouched
- pre-existing alias-prefix matcher collision is #2068
- no production file, off-limits file, or concurrently owned test file changed
- no Copilot review was requested; unsolicited comments were triaged, replied to, and resolved without gating the PR

## Audit

Implementation and independent verification were generated with OpenAI Codex. Commits are signed by Andre Brait.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
