### PR TITLE
tests: isolate suite-owned state

### DIFF
--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -84,7 +84,7 @@ composer_cloud_install_spec.sh:4
 git_no_docs_spec.sh:5
 githooks_pre_push_lease_spec.sh:33
 githooks_pre_push_tag_scheme_spec.sh:7
-githooks_prepare_commit_msg_guard_spec.sh:17
+githooks_prepare_commit_msg_guard_spec.sh:18
 pfblockerng_truncate_survival_spec.sh:4
 precommit_composer_vendor_spec.sh:2
 read_version_matrix_test_spec.sh:5

--- a/tests/php/SyslogEventHygieneTest.php
+++ b/tests/php/SyslogEventHygieneTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/SyslogEventTest.php';
+
+/**
+ * Issue #2046: SyslogEventTest must isolate and restore every global in its
+ * config/syslog test seam, including globals that were absent before a test.
+ */
+final class SyslogEventHygieneTest extends TestCase
+{
+	/** @var array<string, array{had: bool, value: mixed}> */
+	private array $outerState = [];
+
+	protected function setUp(): void
+	{
+		$this->outerState = $this->snapshotOwnedGlobals();
+	}
+
+	protected function tearDown(): void
+	{
+		$this->restoreOwnedGlobals($this->outerState);
+	}
+
+	public function testLifecycleRestoresAbsentOwnedGlobals(): void
+	{
+		$this->clearOwnedGlobals();
+
+		try {
+			$this->runLifecycle();
+
+			foreach ($this->ownedGlobalNames() as $name) {
+				$this->assertArrayNotHasKey(
+					$name,
+					$GLOBALS,
+					"absent outer state: {$name} must remain absent after SyslogEvent lifecycle"
+				);
+			}
+		} finally {
+			$this->restoreOwnedGlobals($this->outerState);
+		}
+	}
+
+	public function testLifecycleRestoresForeignOwnedGlobalSentinels(): void
+	{
+		$sentinels = [
+			'config'                => ['foreign_config_2046' => ['state' => 'untouched']],
+			'pfb_test_syslog_spy'   => 'foreign-spy-2046',
+			'pfb_test_syslog_calls' => ['foreign-call-2046'],
+			'pfb_test_syslog_reset' => 'foreign-reset-2046',
+		];
+		foreach ($sentinels as $name => $value) {
+			$GLOBALS[$name] = $value;
+		}
+
+		try {
+			$this->runLifecycle();
+
+			foreach ($sentinels as $name => $sentinel) {
+				$this->assertArrayHasKey(
+					$name,
+					$GLOBALS,
+					"foreign outer state: {$name} must be present after SyslogEvent lifecycle"
+				);
+				$this->assertSame(
+					$sentinel,
+					$GLOBALS[$name],
+					"foreign outer state: {$name} value must be restored exactly"
+				);
+			}
+		} finally {
+			$this->restoreOwnedGlobals($this->outerState);
+		}
+	}
+
+	/** Drive one real SyslogEventTest setUp()+test()+tearDown() cycle. */
+	private function runLifecycle(): void
+	{
+		$suite = new SyslogEventTest('testToggleOnEmitsExactlyOneCallWithCorrectBody');
+		$ref   = new ReflectionClass($suite);
+		$setUp = $ref->getMethod('setUp');
+		$test  = $ref->getMethod('testToggleOnEmitsExactlyOneCallWithCorrectBody');
+		$tear  = $ref->getMethod('tearDown');
+		$setUpComplete = false;
+
+		try {
+			$setUp->invoke($suite);
+			$setUpComplete = true;
+
+			$this->assertSame([], $GLOBALS['config'] ?? null, 'lifecycle: config root must be exactly []');
+			$this->assertSame(TRUE, $GLOBALS['pfb_test_syslog_spy'] ?? null, 'lifecycle: syslog spy must be TRUE');
+			$this->assertSame([], $GLOBALS['pfb_test_syslog_calls'] ?? null, 'lifecycle: syslog calls must be []');
+			$this->assertArrayNotHasKey('pfb_test_syslog_reset', $GLOBALS, 'lifecycle: reset flag must be absent');
+
+			$test->invoke($suite);
+		} finally {
+			if ($setUpComplete) {
+				$tear->invoke($suite);
+			}
+		}
+	}
+
+	/** @return list<string> */
+	private function ownedGlobalNames(): array
+	{
+		return ['config', 'pfb_test_syslog_spy', 'pfb_test_syslog_calls', 'pfb_test_syslog_reset'];
+	}
+
+	/** @return array<string, array{had: bool, value: mixed}> */
+	private function snapshotOwnedGlobals(): array
+	{
+		$snapshot = [];
+		foreach ($this->ownedGlobalNames() as $name) {
+			$snapshot[$name] = [
+				'had'   => array_key_exists($name, $GLOBALS),
+				'value' => $GLOBALS[$name] ?? null,
+			];
+		}
+		return $snapshot;
+	}
+
+	private function clearOwnedGlobals(): void
+	{
+		foreach ($this->ownedGlobalNames() as $name) {
+			unset($GLOBALS[$name]);
+		}
+	}
+
+	/** @param array<string, array{had: bool, value: mixed}> $snapshot */
+	private function restoreOwnedGlobals(array $snapshot): void
+	{
+		foreach ($snapshot as $name => $state) {
+			if ($state['had']) {
+				$GLOBALS[$name] = $state['value'];
+			} else {
+				unset($GLOBALS[$name]);
+			}
+		}
+	}
+}

--- a/tests/php/SyslogEventTest.php
+++ b/tests/php/SyslogEventTest.php
@@ -21,21 +21,49 @@ use PHPUnit\Framework\TestCase;
  */
 final class SyslogEventTest extends TestCase
 {
-	/** Install the spy; no cache-reset needed (function reads fresh each call). */
+	private bool $hadConfig = false;
+	private mixed $savedConfig = null;
+	private bool $hadSyslogSpy = false;
+	private mixed $savedSyslogSpy = null;
+	private bool $hadSyslogCalls = false;
+	private mixed $savedSyslogCalls = null;
+	private bool $hadSyslogReset = false;
+	private mixed $savedSyslogReset = null;
+
+	/** Install clean owned state; no cache-reset needed (function reads fresh each call). */
 	protected function setUp(): void
 	{
+		$this->hadConfig = array_key_exists('config', $GLOBALS);
+		$this->savedConfig = $GLOBALS['config'] ?? null;
+		$this->hadSyslogSpy = array_key_exists('pfb_test_syslog_spy', $GLOBALS);
+		$this->savedSyslogSpy = $GLOBALS['pfb_test_syslog_spy'] ?? null;
+		$this->hadSyslogCalls = array_key_exists('pfb_test_syslog_calls', $GLOBALS);
+		$this->savedSyslogCalls = $GLOBALS['pfb_test_syslog_calls'] ?? null;
+		$this->hadSyslogReset = array_key_exists('pfb_test_syslog_reset', $GLOBALS);
+		$this->savedSyslogReset = $GLOBALS['pfb_test_syslog_reset'] ?? null;
+
+		$GLOBALS['config'] = [];
 		$GLOBALS['pfb_test_syslog_spy']   = TRUE;
 		$GLOBALS['pfb_test_syslog_calls'] = [];
+		unset($GLOBALS['pfb_test_syslog_reset']);
 	}
 
 	protected function tearDown(): void
 	{
-		unset(
-			$GLOBALS['pfb_test_syslog_spy'],
-			$GLOBALS['pfb_test_syslog_calls']
-		);
-		// Wipe any log_syslog config seeded by individual tests.
-		config_del_path('installedpackages/pfblockerng/config/0/log_syslog');
+		foreach (
+			[
+				'config'                => [$this->hadConfig, $this->savedConfig],
+				'pfb_test_syslog_spy'   => [$this->hadSyslogSpy, $this->savedSyslogSpy],
+				'pfb_test_syslog_calls' => [$this->hadSyslogCalls, $this->savedSyslogCalls],
+				'pfb_test_syslog_reset' => [$this->hadSyslogReset, $this->savedSyslogReset],
+			] as $name => [$had, $value]
+		) {
+			if ($had) {
+				$GLOBALS[$name] = $value;
+			} else {
+				unset($GLOBALS[$name]);
+			}
+		}
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/shell/githooks_prepare_commit_msg_guard_maintenance_spec.sh
+++ b/tests/shell/githooks_prepare_commit_msg_guard_maintenance_spec.sh
@@ -1,0 +1,32 @@
+#shellcheck shell=sh
+
+Describe 'prepare-commit-msg fixture maintenance isolation (issue #2055)'
+  subject_spec="${PFB_ROOT}/tests/shell/githooks_prepare_commit_msg_guard_spec.sh"
+
+  setup() {
+    scrub_git_env
+    trace="$(mktemp "${SHELLSPEC_TMPBASE:-/tmp}/pcmguard-trace.XXXXXX")"
+  }
+
+  cleanup() {
+    rm "$trace"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  run_subject() {
+    cd "$PFB_ROOT" || return
+    env -u SHELLSPEC_MODE GIT_TRACE2_EVENT="$trace" shellspec --no-quick --fail-no-examples \
+      --shell "$(command -v dash)" "$subject_spec"
+  }
+
+  It 'proves successful fixture commits do not launch detached maintenance'
+    When run run_subject
+    The status should equal 0
+    The stdout should include '0 failures'
+    The stderr should equal ''
+    The contents of file "$trace" should include '"name":"commit"'
+    The contents of file "$trace" should not include '"--detach"'
+  End
+End

--- a/tests/shell/githooks_prepare_commit_msg_guard_spec.sh
+++ b/tests/shell/githooks_prepare_commit_msg_guard_spec.sh
@@ -22,6 +22,7 @@ Describe 'prepare-commit-msg agent worktree guard (issue #1262)'
     git_fixture -C "$primary" config user.email human@example.com
     git_fixture -C "$primary" config user.name Human
     git_fixture -C "$primary" config commit.gpgsign false
+    git_fixture -C "$primary" config maintenance.auto false
     ( cd "$primary" && echo seed > seed.txt && git_fixture add seed.txt \
         && git_fixture commit -q -m seed )
     git_fixture -C "$primary" worktree add -q "$wt" -b spec-branch


### PR DESCRIPTION
## Summary

- make `SyslogEventTest` establish and exactly restore its four owned globals
- prevent the prepare-commit-msg guard fixture from launching detached Git maintenance before cleanup
- add frozen regressions for both leaked-state failure modes

## Proof

- #2046: frozen lifecycle regression failed on the parent with 2 failures, then passed unchanged with 2 tests / 32 assertions; the original random predecessor pair at seed `1785615806` passed with 2 tests / 6 assertions
- #2055: frozen Trace2 regression failed on the parent because `git maintenance run --auto --quiet --detach` was observed, then passed unchanged after the fixture disabled repository-local auto-maintenance; both focused specs passed five consecutive runs under `/opt/homebrew/bin/dash`
- independent red-proof verification: PASS for both commits
- final rebased `scripts/agent/run-gates.sh --diff origin/devel`: PASS, including PHPUnit, PHPStan, PHPCS, ShellCheck, and full ShellSpec under `dash`

Fixes #2046
Fixes #2055

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test isolation by preserving and restoring existing system configuration during syslog-related tests.
  * Disabled automatic Git maintenance in the prepare-commit-msg guard test fixture to prevent unintended background activity.

* **Tests**
  * Added regression coverage confirming Git commits complete successfully without launching detached maintenance.
  * Added hygiene checks for restoring both absent and pre-existing global state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->