### PR TITLE
tests: replace smoke time assertions with event barriers

### DIFF
--- a/tests/smoke/test_hook_stream_visibility.py
+++ b/tests/smoke/test_hook_stream_visibility.py
@@ -16,6 +16,7 @@ log. RED against the block-behavior (LINE1 absent mid-hook); GREEN once the hook
 
 from __future__ import annotations
 
+import sys
 import time
 
 import pytest
@@ -70,34 +71,92 @@ def _streaming_hook(token: str) -> dict[str, str]:
     }
 
 
-def _wait_for_guest_file(vm: SmokeVM, path: str, *, deadline_s: float, poll_s: float = 1.0) -> bool:
-    """Poll until ``path`` exists on the guest or the deadline passes. Returns True iff it appeared.
+def _wait_for_guest_file(vm: SmokeVM, path: str, *, deadline_s: float, poll_s: float = 1.0) -> None:
+    """Poll until ``path`` exists on the guest or raise a salvage-only expiry.
 
     A bounded poll on a REMOTE file the hook creates — the only side we cannot signal — with a
-    hard deadline (never an open wait). This is the sanctioned last-resort poll, kept loud: the
-    caller asserts the return.
+    hard deadline (never an open wait). This is the sanctioned last-resort poll.
     """
     end = time.monotonic() + deadline_s
-    while time.monotonic() < end:
-        if vm.ssh("/bin/test", "-f", path).returncode == 0:
-            return True
-        time.sleep(poll_s)
-    return False
+    result = None
+    while True:
+        result = vm.ssh("/bin/test", "-f", path)
+        if result.returncode == 0:
+            return
+        remaining = end - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(
+                f"salvage cap expired / stuck or environment: guest file {path!r} expected test -f rc=0; "
+                f"actual rc={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
+            )
+        time.sleep(min(poll_s, remaining))
 
 
-def _wait_upgrade_gone(vm: SmokeVM, *, deadline_s: float, poll_s: float = 2.0) -> bool:
-    """Poll (bounded) until no pfSense-upgrade process remains. Returns True iff it drained.
+def _wait_upgrade_gone(vm: SmokeVM, *, deadline_s: float, poll_s: float = 2.0) -> None:
+    """Poll (bounded) until no pfSense-upgrade process remains or raise expiry.
 
     The test launches pfSense-upgrade DETACHED, so the wrapping pkg transaction (and its pkg
     lock) outlives the hook itself. Wait for it to exit before touching the package again; a
     bounded wait, never open-ended (pgrep rc 1 = none left).
     """
     end = time.monotonic() + deadline_s
-    while time.monotonic() < end:
-        if vm.ssh("/bin/sh", "-c", "pgrep -f pfSense-upgrade >/dev/null").returncode != 0:
-            return True
-        time.sleep(poll_s)
-    return False
+    result = None
+    while True:
+        result = vm.ssh("/bin/sh", "-c", "pgrep -f pfSense-upgrade >/dev/null")
+        if result.returncode == 1:
+            return
+        if result.returncode != 0:
+            raise RuntimeError(
+                "salvage cap expired / stuck or environment: _wait_upgrade_gone expected pgrep rc=0 "
+                f"(running) or rc=1 (gone); actual rc={result.returncode} "
+                f"stdout={result.stdout!r} stderr={result.stderr!r}"
+            )
+        remaining = end - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(
+                "salvage cap expired / stuck or environment: _wait_upgrade_gone expected pgrep rc!=0; "
+                f"actual rc={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
+            )
+        time.sleep(min(poll_s, remaining))
+
+
+def _cleanup_hook_run(vm: SmokeVM) -> None:
+    """Release the hook and clean up without hiding the test's primary failure."""
+    primary_error = sys.exception()
+    cleanup_errors: list[Exception] = []
+    upgrade_running = False
+    try:
+        vm.ssh("/usr/bin/touch", PROCEED)
+    except Exception as exc:
+        cleanup_errors.append(exc)
+        upgrade_running = True
+    else:
+        try:
+            _wait_upgrade_gone(vm, deadline_s=60.0)
+        except Exception as exc:
+            cleanup_errors.append(exc)
+            upgrade_running = True
+    try:
+        h.clear_update_hooks(vm)
+    except Exception as exc:
+        cleanup_errors.append(exc)
+    try:
+        vm.ssh("/bin/rm", "-f", GUI_LOG, WAITING, PROCEED)
+    except Exception as exc:
+        cleanup_errors.append(exc)
+    if not upgrade_running:
+        try:
+            pkg_delete(vm)
+        except Exception as exc:
+            cleanup_errors.append(exc)
+    if cleanup_errors:
+        if primary_error is not None:
+            for cleanup_error in cleanup_errors:
+                primary_error.add_note(f"hook cleanup: {cleanup_error}")
+        else:
+            for cleanup_error in cleanup_errors[1:]:
+                cleanup_errors[0].add_note(f"additional hook cleanup failure: {cleanup_error}")
+            raise cleanup_errors[0]
 
 
 @pytest.mark.timeout(1200)
@@ -144,10 +203,7 @@ def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
         )
 
         # The hook fires late in the resync; wait (bounded) for it to print LINE1 and block.
-        assert _wait_for_guest_file(vm, WAITING, deadline_s=300.0), (
-            "the streaming hook never reached its wait state within 300s — the reinstall resync "
-            "did not fire the post hook (was pfSense-upgrade -i -f run and the hook configured?)"
-        )
+        _wait_for_guest_file(vm, WAITING, deadline_s=300.0)
 
         # ---- THEN (streaming): LINE1 visible mid-hook, LINE2 not yet --------------- #
         # The hook is provably still blocked: it touched WAITING (removed only after LINE2),
@@ -157,19 +213,21 @@ def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
         # only appears AFTER it exits (block-behaviour) never shows LINE1 here — the hook cannot
         # exit until PROCEED, which is created only after this loop.
         mid = ""
-        end = time.monotonic() + 20.0
-        while time.monotonic() < end:
+
+        def line1_observed() -> bool:
+            nonlocal mid
             mid = vm.ssh("cat", GUI_LOG).stdout
-            if LINE1 in mid:
-                break
-            time.sleep(1.0)
+            return LINE1 in mid
+
+        try:
+            h.wait_until(line1_observed, timeout=20.0, interval=1.0)
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"salvage cap expired / stuck or environment: hook GUI log expected marker {LINE1!r}; "
+                f"observed tail={mid[-3000:]!r}"
+            ) from exc
         assert vm.ssh("/bin/test", "-f", WAITING).returncode == 0, (
             "the hook left its wait state before LINE1 was checked — timing invariant broken"
-        )
-        assert LINE1 in mid, (
-            f"the hook's first line {LINE1!r} did NOT reach the GUI log while the hook is still "
-            f"blocked — its output is buffered until the hook exits instead of streaming to the pkg "
-            f"Software page. GUI log so far:\n{mid[-3000:]}"
         )
         assert LINE2 not in mid, (
             f"{LINE2!r} appeared before the hook was released — the block-on-signal setup is "
@@ -178,34 +236,30 @@ def test_hook_output_streams_to_gui_while_running(repo_vm: SmokeVM) -> None:
 
         # ---- WHEN: release the hook, let the op finish ----------------------------- #
         vm.ssh("/usr/bin/touch", PROCEED)
-        assert _wait_for_guest_file(vm, GUI_LOG, deadline_s=60.0), "GUI log vanished after release"
 
         # Wait (bounded) for LINE2 to land — the op is done once the final line is mirrored.
-        end = time.monotonic() + 120.0
         final = ""
-        while time.monotonic() < end:
+
+        def line2_observed() -> bool:
+            nonlocal final
             final = vm.ssh("cat", GUI_LOG).stdout
-            if LINE2 in final:
-                break
-            time.sleep(1.0)
+            return LINE2 in final
+
+        try:
+            h.wait_until(line2_observed, timeout=120.0, interval=1.0)
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"salvage cap expired / stuck or environment: hook GUI log expected marker {LINE2!r}; "
+                f"observed tail={final[-3000:]!r}"
+            ) from exc
 
         # ---- THEN: both lines present at the end ----------------------------------- #
-        assert LINE1 in final and LINE2 in final, (
-            f"after releasing the hook, the GUI log is missing a line (LINE1={LINE1 in final}, "
-            f"LINE2={LINE2 in final}):\n{final[-3000:]}"
-        )
+        assert LINE1 in final, f"after releasing the hook, GUI log missing {LINE1!r}:\n{final[-3000:]}"
 
         # LINE2 means the HOOK finished, but the wrapping detached pfSense-upgrade keeps its pkg
         # lock through the rest of the resync. Drain it before cleanup so pkg_delete() below (in
         # finally) doesn't race the still-held lock. Assert (loud timeout): if it never exits the
         # test is not deterministic — surface that rather than proceed into a lock race.
-        assert _wait_upgrade_gone(vm, deadline_s=120.0), (
-            "pfSense-upgrade did not exit within 120s after the hook finished — cleanup would race "
-            "its still-held pkg lock"
-        )
+        _wait_upgrade_gone(vm, deadline_s=120.0)
     finally:
-        vm.ssh("/usr/bin/touch", PROCEED)  # never leave a blocked hook behind
-        _wait_upgrade_gone(vm, deadline_s=60.0)  # let a failed-path run release its pkg lock too
-        h.clear_update_hooks(vm)
-        vm.ssh("/bin/rm", "-f", GUI_LOG, WAITING, PROCEED)
-        pkg_delete(vm)
+        _cleanup_hook_run(vm)

--- a/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
+++ b/tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py
@@ -176,17 +176,27 @@ def reboot_observation(dnsbl_vm: SmokeVM) -> DnsblRebootObservation:
     print(f"[smoke] #1357 post-MFS manifest refs: {manifest_state}")
 
     # Poll for self-recovery (pfb_unbound.py staged AND both sinkholes) with NO manual update.
-    waited = 0
     recovered = False
     wild_recovered = False
-    while waited <= RECOVERY_DEADLINE:
+    staged_now = False
+    recovery_started = time.monotonic()
+
+    def recovery_observed() -> bool:
+        nonlocal recovered, staged_now, wild_recovered
         staged_now = vm.ssh("test", "-f", PFB_UNBOUND).returncode == 0
         recovered = recovered or (staged_now and _sinkholes(vm, domain))
         wild_recovered = wild_recovered or (staged_now and _sinkholes(vm, wild_sub_domain))
-        if recovered and wild_recovered:
-            break
-        time.sleep(10)
-        waited += 10
+        return recovered and wild_recovered
+
+    try:
+        h.wait_until(recovery_observed, timeout=RECOVERY_DEADLINE, interval=10.0)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "salvage cap expired / stuck or environment: RAM-disk reboot recovery expected "
+            f"recovered=True and wild_recovered=True; observed recovered={recovered} "
+            f"wild_recovered={wild_recovered} staged={staged_now}"
+        ) from exc
+    waited = int(time.monotonic() - recovery_started)
 
     return DnsblRebootObservation(
         domain=domain,

--- a/tests/smoke/test_smoke_killstates.py
+++ b/tests/smoke/test_smoke_killstates.py
@@ -75,10 +75,6 @@ PERMIT_ALIAS = "pfbkillpermit"  # the Permit custom-list aliasname (config row 1
 ALIAS_TABLE = f"pfB_{HEADER}_v4"  # the pf alias table the rule references
 FEED_FILE = "pfb_killstates_ip.txt"
 
-# Settle budget for the alias replace + kill-states to land after a reload.
-SETTLE_SECS = 2.0
-
-
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
@@ -217,7 +213,6 @@ def _assert_fresh_connection_blocked(vm: SmokeVM, cl: SmokeVM) -> None:
         f"— is the rule present and referencing {ALIAS_TABLE}?\n{_state_diag(vm)}"
     )
     _civm_connect(cl)
-    time.sleep(1.5)
     pkts_after = _rule_block_packets(vm)
     assert pkts_after >= 0, (
         f"could not read the reject rule's packet counter after the connection attempt.\n{_state_diag(vm)}"
@@ -238,8 +233,9 @@ def _block_victim(vm: SmokeVM, ips: tuple[str, ...] = (VICTIM,), *, timeout: flo
     """
     h.write_local_feed(vm, FEED_FILE, "".join(f"{ip}/32\n" for ip in ips))
     h.force_ip_refetch(vm, f"{HEADER}_v4")
+    # h.reload() is the causal barrier: CLI -> sync_package -> table delta ->
+    # pfb_remove_states -> pfctl -k completes before it returns.
     h.reload(vm, "update", timeout=timeout)
-    time.sleep(SETTLE_SECS)
 
 
 def _unblock_baseline(vm: SmokeVM, *, kill_on: bool, timeout: float = 600.0) -> None:

--- a/tests/smoke/test_smoke_upstream_block.py
+++ b/tests/smoke/test_smoke_upstream_block.py
@@ -145,12 +145,18 @@ def _wait_for_upstream_block_lines(vm: SmokeVM, name: str, *, timeout_s: float =
     """
     deadline = time.monotonic() + timeout_s
     lines: list[str] = []
-    while time.monotonic() < deadline:
+    while True:
         lines = _upstream_block_lines(_read_dnsbl_log(vm), name)
         if lines:
             return lines
-        time.sleep(poll_s)
-    return lines
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            tail = _read_dnsbl_log(vm)[-3000:]
+            raise RuntimeError(
+                f"salvage cap expired / stuck or environment: _wait_for_upstream_block_lines expected nonempty "
+                f"Upstream_Block lines matching {name!r}; observed lines={lines!r}; log tail={tail!r}"
+            )
+        time.sleep(min(poll_s, remaining))
 
 
 # ---------------------------------------------------------------------------
@@ -185,10 +191,6 @@ class TestUpstreamBlockNXRA:
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
         lines = _wait_for_upstream_block_lines(vm, name)
-        assert lines, (
-            f"No Upstream_Block log line for {name} after NXRA probe.\n"
-            f"Log excerpt (last 3000 chars):\n{_read_dnsbl_log(vm)[-3000:]}"
-        )
         assert any("NXRA" in line for line in lines), (
             f"Upstream_Block line found but b_eval is not NXRA.\nLines: {lines}"
         )
@@ -216,7 +218,6 @@ class TestUpstreamBlockEDE15:
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
         lines = _wait_for_upstream_block_lines(vm, name)
-        assert lines, f"No Upstream_Block log line for {name} (EDE15).\nLog excerpt:\n{_read_dnsbl_log(vm)[-3000:]}"
         assert any("EDE15 (Blocked)" in line for line in lines), f"b_eval is not 'EDE15 (Blocked)'.\nLines: {lines}"
         assert any("Quad9" in line for line in lines), (
             f"Provider 'Quad9' not found in Upstream_Block line.\nLines: {lines}"
@@ -249,7 +250,6 @@ class TestUpstreamBlockEDE17:
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
         lines = _wait_for_upstream_block_lines(vm, name)
-        assert lines, f"No Upstream_Block log line for {name} (EDE17).\nLog excerpt:\n{_read_dnsbl_log(vm)[-3000:]}"
         assert any("EDE17 (Filtered)" in line for line in lines), f"b_eval is not 'EDE17 (Filtered)'.\nLines: {lines}"
         assert any("Quad9" in line for line in lines), (
             f"Provider 'Quad9' not found in Upstream_Block line.\nLines: {lines}"
@@ -447,16 +447,21 @@ def _wait_for_counter_above(
     lock race) is polled through like any other non-matching value — the deadline
     already bounds it.
 
-    Returns the final observed ``(value, detail)`` (may equal ``baseline`` on timeout).
+    Raises a salvage-only error if the counter never exceeds ``baseline``.
     """
     deadline = time.monotonic() + timeout_s
     current: tuple[int, str] = (baseline, "")
-    while time.monotonic() < deadline:
+    while True:
         current = _read_upstream_counter(vm)
         if current[0] > baseline:
             return current
-        time.sleep(poll_s)
-    return current
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(
+                f"salvage cap expired / stuck or environment: _wait_for_counter_above expected counter > "
+                f"{baseline}; observed value={current[0]} detail={current[1]!r}"
+            )
+        time.sleep(min(poll_s, remaining))
 
 
 class TestUpstreamCounterIncrement:
@@ -508,28 +513,18 @@ class TestUpstreamCounterIncrement:
 
         # Confirm the block line was logged (proves the detection fired, not just a
         # natural NXDOMAIN — the counter increment is meaningless without this).
-        lines = _wait_for_upstream_block_lines(vm, name)
-        assert lines, (
-            f"No Upstream_Block log line for {name} — detection did not fire; "
-            f"counter increment cannot be attributed to an upstream block.\n"
-            f"Log excerpt:\n{_read_dnsbl_log(vm)[-2000:]}"
-        )
-
+        _wait_for_upstream_block_lines(vm, name)
         # Then: wait for the async flush and assert an EXACT +1 delta, not merely "some
         # increase". Only one NXRA probe happens in this test's window (asserted above via
         # the log-line check), and the serial pytest run + PFB_DB_FLUSH_INTERVAL=1.0s mean
         # every earlier test's increment (NXRA/EDE15/EDE17 above) is long since flushed into
-        # `baseline` by the time this test starts (the three control tests preceding this one
-        # each causal barrier, far past the 1s flush window). A bare
+        # `baseline` by the time this test starts (each of the three preceding control tests
+        # consumes a causal barrier, far past the 1s flush window). A bare
         # `final > baseline` would also pass if some OTHER probe's increment leaked into this
         # window — exact equality is the real proof this probe (and only this probe) counted.
-        # A read that is still ERRORED at the deadline is a read problem, not a stuck counter
-        # — keep the two failure modes distinct here too (mirrors the baseline assert).
-        final, final_detail = _wait_for_counter_above(vm, baseline)
-        assert final != -2, (
-            f"Upstream counter read ERRORED while waiting for the increase "
-            f"(NOT a stuck counter — do not blame the enqueue/flush): {final_detail!r}"
-        )
+        # A persistent read error (-2) at the deadline surfaces in the raised diagnostic's
+        # detail field, so the read-vs-stuck distinction remains visible in the failure text.
+        final, _ = _wait_for_counter_above(vm, baseline)
         delta = final - baseline
         assert delta == 1, (
             f"Upstream counter delta after NXRA block: expected=1 actual={delta} "

--- a/tests/smoke/test_smoke_upstream_block.py
+++ b/tests/smoke/test_smoke_upstream_block.py
@@ -87,6 +87,7 @@ def deployed_vm(smoke_vm: SmokeVM, client_vm: SmokeVM, stub_dns: _StubDnsServer)
     h.reload(smoke_vm, "update")
     h.wait_unbound_ready(smoke_vm)
     h.assert_link_health(client_vm, smoke_vm, control_name=h.unique_domain())
+    smoke_vm._pfb_upstream_barrier = seed  # type: ignore[attr-defined]
     try:
         yield smoke_vm, client_vm
     finally:
@@ -116,11 +117,22 @@ def _upstream_block_lines(log: str, name: str) -> list[str]:
     return out
 
 
-# Absence checks cannot poll for a line that must NOT appear -- they settle, then read
-# once. The settle must cover the SAME async-flush window the positive path budgets
-# (timeout_s=8.0 below): with a shorter settle, an over-trigger whose line lands in the
-# gap reads as a clean pass (#723).
-_ABSENCE_SETTLE_S = 8.0
+def _consume_dnsbl_barrier(vm: SmokeVM, cvm: SmokeVM) -> None:
+    """Consume the fixture DNSBL seed event before asserting an async absence."""
+    barrier: str = vm._pfb_upstream_barrier  # type: ignore[attr-defined]
+    baseline_lines = _read_dnsbl_log(vm).splitlines()
+    h.flush_unbound_name(vm, barrier)
+    before = h.count_log_marker(vm, _DNSBL_LOG, barrier)
+    answer = h.dns_probe_client(cvm, barrier, "A")
+    assert h.is_vip(answer), f"DNSBL barrier {barrier} expected VIP, got {answer}"
+    h.wait_until(
+        lambda: h.count_log_marker(vm, _DNSBL_LOG, barrier) > before,
+        timeout=30.0,
+        interval=1.0,
+    )
+    new_lines = _read_dnsbl_log(vm).splitlines()[len(baseline_lines) :]
+    unexpected = [line for line in new_lines if line.startswith("DNSBL-python") and "Upstream_Block" in line]
+    assert not unexpected, f"Upstream_Block appeared before the absence assertion barrier: {unexpected}"
 
 
 def _wait_for_upstream_block_lines(vm: SmokeVM, name: str, *, timeout_s: float = 8.0, poll_s: float = 0.5) -> list[str]:
@@ -128,8 +140,8 @@ def _wait_for_upstream_block_lines(vm: SmokeVM, name: str, *, timeout_s: float =
 
     The python module logs asynchronously (a queue flush), so a fresh probe's line is
     not instantaneous. Bounded polling is steadier than a fixed sleep on slow CI VMs and
-    returns as soon as the line lands on fast paths. (Absence checks can't poll — they
-    keep a fixed settle, see the control tests.)
+    returns as soon as the line lands on fast paths. Absence controls consume a separate
+    causal DNSBL barrier before reading their target log.
     """
     deadline = time.monotonic() + timeout_s
     lines: list[str] = []
@@ -272,7 +284,7 @@ class TestUpstreamBlockAuthoritativeControl:
         ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
-        time.sleep(_ABSENCE_SETTLE_S)
+        _consume_dnsbl_barrier(vm, cvm)
         log = _read_dnsbl_log(vm)
         lines = _upstream_block_lines(log, name)
         assert not lines, (
@@ -305,7 +317,7 @@ class TestUpstreamBlockForwarderNaturalControl:
         ans = h.dns_probe_client(cvm, name, "A")
         assert ans.rcode == "NXDOMAIN", f"Expected NXDOMAIN for {name}, got {ans.rcode}"
 
-        time.sleep(_ABSENCE_SETTLE_S)
+        _consume_dnsbl_barrier(vm, cvm)
         log = _read_dnsbl_log(vm)
         lines = _upstream_block_lines(log, name)
         assert not lines, (
@@ -334,7 +346,7 @@ class TestUpstreamBlockNormalControl:
         ans = h.dns_probe_client(cvm, name, "A")
         assert h.resolves_to(ans, h.STUB_DNS_A), f"Control name should resolve to sentinel {h.STUB_DNS_A}, got {ans}"
 
-        time.sleep(_ABSENCE_SETTLE_S)
+        _consume_dnsbl_barrier(vm, cvm)
         log = _read_dnsbl_log(vm)
         lines = _upstream_block_lines(log, name)
         assert not lines, (
@@ -508,7 +520,7 @@ class TestUpstreamCounterIncrement:
         # the log-line check), and the serial pytest run + PFB_DB_FLUSH_INTERVAL=1.0s mean
         # every earlier test's increment (NXRA/EDE15/EDE17 above) is long since flushed into
         # `baseline` by the time this test starts (the three control tests preceding this one
-        # each settle for _ABSENCE_SETTLE_S=8.0s, far past the 1s flush window). A bare
+        # each causal barrier, far past the 1s flush window). A bare
         # `final > baseline` would also pass if some OTHER probe's increment leaked into this
         # window — exact equality is the real proof this probe (and only this probe) counted.
         # A read that is still ERRORED at the deadline is a read problem, not a stuck counter

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -32,6 +32,7 @@ the ``stub_dns`` fixture. Without these all cases skip cleanly.
 
 from __future__ import annotations
 
+import csv
 import json
 import os
 import time
@@ -77,8 +78,6 @@ CFG_GENERAL = "installedpackages/pfblockerng/config/0"
 TEST_IP_BLOCK_RANGE = "192.168.89.9/32"
 TEST_IP_BLOCK_DST = "192.168.89.9"
 
-# Settle budget for the tail_pfb → daemon → syslogd → file path.
-FILTERLOG_SETTLE_SECS = 5.0
 EVENT_WAIT_SECS = 15.0
 # IP action tokens any IP security event may carry (block/permit/match).
 IP_ACT_TOKENS = ("act=block", "act=pass", "act=match")
@@ -98,9 +97,8 @@ def deployed_vm(
     """Deploy the branch .pkg once; wire DNSBL + IP; reload with syslog OFF.
 
     Given: the smoke VM is booted and the branch .pkg is available.
-    When:  we deploy, wire DNSBL (TWO unique blocked domains, VIP — the syslog-toggle
-           test uses one per OFF/ON probe so it never has to rely on the SAME domain
-           re-triggering the python hook on a repeat query) + one IP block feed
+    When:  we deploy, wire DNSBL (five unique blocked domains, VIP — seed, subject, OFF-state
+           drain, and ON-state barrier queries stay distinguishable) + one IP block feed
            (RFC 5737), and do a full reload with syslog export OFF (the default).
            The reload runs sync_package_pfblockerng, which materializes the syslog
            routing drop-in (ADR-38) and (re)starts the filterlog daemon tailing
@@ -116,7 +114,14 @@ def deployed_vm(
 
     _dnsbl_domain = h.unique_domain("pfbsyslogdnsbl")
     _dnsbl_domain_on = h.unique_domain("pfbsyslogdnsbl2")
-    _dnsbl_feed_path = h.write_local_feed(smoke_vm, "pfb_syslog_dnsbl.txt", f"{_dnsbl_domain}\n{_dnsbl_domain_on}\n")
+    _dnsbl_seed = h.unique_domain("pfbsyslogdnsblseed")
+    _dnsbl_drain = h.unique_domain("pfbsyslogdnsbldrain")
+    _dnsbl_barrier = h.unique_domain("pfbsyslogdnsblbarrier")
+    _dnsbl_feed_path = h.write_local_feed(
+        smoke_vm,
+        "pfb_syslog_dnsbl.txt",
+        f"{_dnsbl_domain}\n{_dnsbl_domain_on}\n{_dnsbl_seed}\n{_dnsbl_drain}\n{_dnsbl_barrier}\n",
+    )
     h.inject(
         smoke_vm,
         h.DnsblCase(
@@ -174,6 +179,9 @@ def deployed_vm(
 
     smoke_vm._pfb_dnsbl_domain = _dnsbl_domain  # type: ignore[attr-defined]
     smoke_vm._pfb_dnsbl_domain_on = _dnsbl_domain_on  # type: ignore[attr-defined]
+    smoke_vm._pfb_syslog_seed = _dnsbl_seed  # type: ignore[attr-defined]
+    smoke_vm._pfb_syslog_drain = _dnsbl_drain  # type: ignore[attr-defined]
+    smoke_vm._pfb_syslog_barrier = _dnsbl_barrier  # type: ignore[attr-defined]
     smoke_vm._pfb_civm_ip = _civm_ip  # type: ignore[attr-defined]
     yield smoke_vm
 
@@ -278,6 +286,24 @@ def _pfb_event_lines(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:
     return [ln for ln in content.splitlines() if "act=" in ln]
 
 
+def _pfb_event_history_lines(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:
+    """Return dedicated events across the current log and newsyslog rotations."""
+    script = (
+        "set -e\n"
+        f"for file in {PFB_SYSLOG_LOG} {PFB_SYSLOG_LOG}.[0-9]*; do\n"
+        '  [ -f "$file" ] || continue\n'
+        '  /usr/bin/bsdcat "$file"\n'
+        "done\n"
+    )
+    result = vm.ssh("/bin/sh", "-c", script, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"dedicated syslog history read failed: rc={result.returncode} "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+    return [line for line in result.stdout.splitlines() if "act=" in line]
+
+
 def _system_log_export_leaks(vm: SmokeVM, *, timeout: float = 30.0) -> list[str]:
     """Export records that LEAKED into system.log (must always be empty).
 
@@ -307,6 +333,43 @@ def _wait_for_event(
                 return ln
         time.sleep(interval)
     return ""
+
+
+def _unified_dnsbl_lines(vm: SmokeVM) -> list[str]:
+    """Return DNSBL rows already consumed by the filterlog daemon."""
+    return [line for line in h.read_log_file(vm, UNIFIED_LOG).splitlines() if line.startswith("DNSBL-python,")]
+
+
+def _wait_for_unified_dnsbl(vm: SmokeVM, domain: str, *, baseline_len: int, dnsbl_baseline: int) -> str:
+    """Wait for a later drain row proving earlier DNSBL input was consumed."""
+    found = [""]
+    observed_rows = _unified_dnsbl_lines(vm)
+    marker_count = h.count_log_marker(vm, DNSBL_LOG, domain)
+
+    def observed() -> bool:
+        nonlocal marker_count, observed_rows
+        found[0] = ""
+        observed_rows = _unified_dnsbl_lines(vm)
+        for line in observed_rows[baseline_len:]:
+            try:
+                fields = next(csv.reader([line]))
+            except csv.Error:
+                continue
+            if len(fields) == 11 and fields[2] == domain:
+                found[0] = line
+                break
+        marker_count = h.count_log_marker(vm, DNSBL_LOG, domain)
+        return bool(found[0]) and marker_count > dnsbl_baseline
+
+    try:
+        h.wait_until(observed, timeout=EVENT_WAIT_SECS, interval=1.0)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "salvage cap expired / stuck or environment: _wait_for_unified_dnsbl expected "
+            f"domain={domain!r} after baseline_len={baseline_len} and marker count > {dnsbl_baseline}; "
+            f"observed marker count={marker_count} unified rows={observed_rows!r}"
+        ) from exc
+    return found[0]
 
 
 def syslog_export_state_snapshot(vm: SmokeVM) -> str:
@@ -513,57 +576,45 @@ def test_syslog_routing_and_rotation_registered(deployed_vm: SmokeVM) -> None:
 
 
 def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
-    """OFF ⇒ no export record; ON ⇒ a pfblockerng record per DNSBL block, host-side, no restart.
-
-    Given: DNSBL blocking TWO distinct domains (VIP); syslog export OFF (per-test
-           reset, #1396). The OFF/ON proof is baseline-relative, so records left by
-           sibling tests (any order) don't matter.
-    When:  domain_off is probed WHILE export is STILL OFF (no restart) — the DNSBL block
-           itself still fires (proven via the CSV dnsbl.log marker), but must export
-           nothing. THEN log_syslog is enabled (write_config ONLY — no restart) and the
-           civm client (192.168.1.10) resolves a SECOND, never-before-queried domain
-           (domain_on — dodges any residual Unbound/module state from the OFF-phase probe,
-           so the python hook is guaranteed to run fresh) via pfSense.
-    Then:  the OFF-phase probe produces NO new record in pfblockerng_syslog.log. The
-           ON-phase probe DOES produce a NEW record with act=dnsbl + the queried name —
-           proving the toggle took effect LIVE, and that OFF truly exported nothing (not
-           just "no probe happened yet").
-    And:   the event did NOT leak into system.log; the CSV dnsbl.log was written for BOTH probes.
-    """
+    """OFF subject → OFF drain → ON barrier; subject must stay absent from syslog."""
     vm = deployed_vm
     domain_off: str = vm._pfb_dnsbl_domain  # type: ignore[attr-defined]
-    domain_on: str = vm._pfb_dnsbl_domain_on  # type: ignore[attr-defined]
+    drain_domain: str = vm._pfb_dnsbl_domain_on  # type: ignore[attr-defined]
+    barrier_domain: str = vm._pfb_syslog_barrier  # type: ignore[attr-defined]
     civm_ip: str = vm._pfb_civm_ip  # type: ignore[attr-defined]
 
     # Given: syslog export OFF (per-test reset) — baseline whatever is already there.
-    before = _pfb_event_lines(vm)
     sys_leak_before = len(_system_log_export_leaks(vm))
 
-    # Before: probe a blocked domain WHILE export is still OFF. The block itself must still
-    # fire (CSV assertion below) but must produce NO export line — the missing half of the
-    # toggle's before/after proof (CLAUDE.md: assert the before-state, not just the after).
+    # While OFF, emit a later distinguishable DNSBL event. Seeing that drain row in
+    # unified.log proves tail_pfb consumed the earlier subject before the gate flips ON.
+    unified_baseline = len(_unified_dnsbl_lines(vm))
     dnsbl_off_before = h.count_log_marker(vm, DNSBL_LOG, domain_off)
+    h.flush_unbound_name(vm, domain_off)
     ans_off = h.dns_probe_client(client_vm, domain_off, "A")
     assert h.is_vip(ans_off), f"DNSBL block shape unexpected before enabling syslog: expected VIP, got {ans_off}"
-    time.sleep(FILTERLOG_SETTLE_SECS)
+    drain_dnsbl_before = h.count_log_marker(vm, DNSBL_LOG, drain_domain)
+    h.flush_unbound_name(vm, drain_domain)
+    drain_answer = h.dns_probe_client(client_vm, drain_domain, "A")
+    assert h.is_vip(drain_answer), f"DNSBL OFF-state drain should be VIP, got {drain_answer}"
+    _wait_for_unified_dnsbl(
+        vm,
+        drain_domain,
+        baseline_len=unified_baseline,
+        dnsbl_baseline=drain_dnsbl_before,
+    )
 
     dnsbl_off_after = h.count_log_marker(vm, DNSBL_LOG, domain_off)
     assert dnsbl_off_after > dnsbl_off_before, (
         f"CSV dnsbl.log was NOT written for the OFF-phase probe (before {dnsbl_off_before}, after "
         f"{dnsbl_off_after}) — the block itself must fire regardless of the syslog toggle"
     )
-    after_off = _pfb_event_lines(vm)
-    assert len(after_off) == len(before), (
-        f"A pfblockerng export record appeared for {domain_off} while syslog export is OFF "
-        f"(before {len(before)} lines, after {len(after_off)}) — the OFF gate is not working.\n"
-        f"{syslog_export_state_snapshot(vm)}"
-    )
-
-    # When: enable LIVE (no restart) + probe a DIFFERENT, never-before-queried domain from
-    # the civm client (dodges any residual state from the OFF-phase probe above).
-    dnsbl_on_before = h.count_log_marker(vm, DNSBL_LOG, domain_on)
+    # When: enable LIVE (no restart) + probe the distinct configured barrier domain.
+    dnsbl_barrier_before = h.count_log_marker(vm, DNSBL_LOG, barrier_domain)
     _set_syslog_enabled(vm, on=True)
-    ans = h.dns_probe_client(client_vm, domain_on, "A")
+    barrier_baseline = len(_pfb_event_lines(vm))
+    h.flush_unbound_name(vm, barrier_domain)
+    ans = h.dns_probe_client(client_vm, barrier_domain, "A")
 
     # Then: DNSBL still blocks (additive).
     assert h.is_vip(ans), f"DNSBL block shape changed after enabling syslog: expected VIP, got {ans}"
@@ -571,11 +622,24 @@ def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM
     # Then: a NEW dedicated-file record (poll — tail/daemon latency). Match on
     # act=dnsbl + the queried name (qname=). NOTE: b_type is the MATCH type
     # ('DNSBL'/'TLD'/'Python'), NOT the sinkhole mode — there is no 'VIP' b_type.
-    line = _wait_for_event(vm, baseline_len=len(after_off), want=("act=dnsbl", f"qname={domain_on}", f"qip={civm_ip}"))
+    line = _wait_for_event(
+        vm, baseline_len=barrier_baseline, want=("act=dnsbl", f"qname={barrier_domain}", f"qip={civm_ip}")
+    )
     assert line, (
-        f"No new DNSBL export record after enabling export (LIVE, no restart) and probing {domain_on}.\n"
-        f"  expected a new line in {PFB_SYSLOG_LOG} with: act=dnsbl qname={domain_on} qip={civm_ip}\n"
+        f"No new DNSBL export record after enabling export (LIVE, no restart) and probing {barrier_domain}.\n"
+        f"  expected a new line in {PFB_SYSLOG_LOG} with: act=dnsbl qname={barrier_domain} qip={civm_ip}\n"
         f"  {syslog_export_state_snapshot(vm)}"
+    )
+
+    # This qname is unique to the module and queried only while export is OFF.
+    # Search rotations too so newsyslog cannot erase the negative evidence.
+    phase_lines = _pfb_event_history_lines(vm)
+    assert any(f"qname={barrier_domain}" in event and f"qip={civm_ip}" in event for event in phase_lines), (
+        f"dedicated syslog history missing already-observed barrier {barrier_domain}: {phase_lines!r}"
+    )
+    assert not any(f"qname={domain_off}" in event for event in phase_lines), (
+        f"OFF-phase subject {domain_off} appeared in syslog after its unified row was consumed: "
+        f"{phase_lines!r}\n{syslog_export_state_snapshot(vm)}"
     )
 
     # And: it did NOT leak into system.log.
@@ -585,10 +649,10 @@ def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM
     )
 
     # And: CSV dnsbl.log also written for the ON-phase probe (additive).
-    dnsbl_on_after = h.count_log_marker(vm, DNSBL_LOG, domain_on)
-    assert dnsbl_on_after > dnsbl_on_before, (
-        f"CSV dnsbl.log was NOT written after enabling syslog (before {dnsbl_on_before}, after "
-        f"{dnsbl_on_after}) — export must be additive"
+    dnsbl_barrier_after = h.count_log_marker(vm, DNSBL_LOG, barrier_domain)
+    assert dnsbl_barrier_after > dnsbl_barrier_before, (
+        f"CSV dnsbl.log was NOT written after enabling syslog (before {dnsbl_barrier_before}, after "
+        f"{dnsbl_barrier_after}) — export must be additive"
     )
 
 
@@ -925,58 +989,72 @@ def test_ip_attribution_cache_invalidated_after_feed_ownership_change(deployed_v
 
 
 def test_syslog_off_no_new_records(deployed_vm: SmokeVM, client_vm: SmokeVM) -> None:
-    """OFF ⇒ zero export; CSV logging unchanged — LIVE toggle, no restart.
-
-    Before/after proof: first seed export ON and prove ONE exported record in-test
-    (never inherited from a sibling, #1396), then disable LIVE and assert the count
-    does NOT increase. Exercised via the DNSBL leg (probes of the blocked domain
-    from civm).
-
-    Given: syslog export ON (seeded by THIS test) with a verified export record of
-           its own in the dedicated file.
-    When:  log_syslog set OFF (write_config ONLY — no restart); the blocked domain is
-           probed again from civm.
-    Then:  the export-record count does NOT increase — the daemon honored the LIVE off.
-    And:   the CSV dnsbl.log is STILL written (additive path, independent of the toggle).
-    """
+    """ON seed → OFF subject/drain → ON barrier; OFF subject must stay absent."""
     vm = deployed_vm
-    domain: str = vm._pfb_dnsbl_domain  # type: ignore[attr-defined]
+    domain: str = vm._pfb_syslog_seed  # type: ignore[attr-defined]
+    domain_off: str = vm._pfb_dnsbl_domain_on  # type: ignore[attr-defined]
+    drain_domain: str = vm._pfb_syslog_drain  # type: ignore[attr-defined]
+    barrier_domain: str = vm._pfb_syslog_barrier  # type: ignore[attr-defined]
     civm_ip: str = vm._pfb_civm_ip  # type: ignore[attr-defined]
 
     # Seed our own ON record (#1396): enable LIVE, probe, and prove ONE exported event —
     # the before-state for the OFF flip is created here, never inherited from a sibling.
     seed_baseline = len(_pfb_event_lines(vm))
     _set_syslog_enabled(vm, on=True)
+    h.flush_unbound_name(vm, domain)
     ans = h.dns_probe_client(client_vm, domain, "A")
     assert h.is_vip(ans), f"DNSBL block should fire while seeding the ON record, got {ans}"
     seed_line = _wait_for_event(vm, baseline_len=seed_baseline, want=("act=dnsbl", f"qname={domain}", f"qip={civm_ip}"))
     assert seed_line, (
         f"Seeding failed: no export record for {domain} with export ON.\n{syslog_export_state_snapshot(vm)}"
     )
-    # Let any trailing export from the seed probe land before baselining — a duplicate
-    # in-flight event would otherwise read as a spurious "OFF gate" failure below.
-    time.sleep(FILTERLOG_SETTLE_SECS)
+    unified_baseline = len(_unified_dnsbl_lines(vm))
+    dnsbl_csv_before = h.count_log_marker(vm, DNSBL_LOG, domain_off)
 
-    count_while_on = len(_pfb_event_lines(vm))
-
-    dnsbl_csv_before = h.count_log_marker(vm, DNSBL_LOG, domain)
-
-    # When: disable LIVE (no restart) + re-probe the blocked domain from civm.
+    # When: disable LIVE (no restart) + probe a distinct subject, then consume its unified row.
     _set_syslog_enabled(vm, on=False)
-    ans = h.dns_probe_client(client_vm, domain, "A")
+    h.flush_unbound_name(vm, domain_off)
+    ans = h.dns_probe_client(client_vm, domain_off, "A")
     assert h.is_vip(ans), f"DNSBL block should still work when syslog is OFF, got {ans}"
-    time.sleep(FILTERLOG_SETTLE_SECS)
-
-    # Then: no new export records (the LIVE off took effect).
-    count_while_off = len(_pfb_event_lines(vm))
-    assert count_while_off == count_while_on, (
-        f"New export records appeared after disabling export LIVE (before {count_while_on}, after "
-        f"{count_while_off}) — the live OFF gate is not working.\n{syslog_export_state_snapshot(vm)}"
+    drain_dnsbl_before = h.count_log_marker(vm, DNSBL_LOG, drain_domain)
+    h.flush_unbound_name(vm, drain_domain)
+    drain_answer = h.dns_probe_client(client_vm, drain_domain, "A")
+    assert h.is_vip(drain_answer), f"DNSBL OFF-state drain should be VIP, got {drain_answer}"
+    _wait_for_unified_dnsbl(
+        vm,
+        drain_domain,
+        baseline_len=unified_baseline,
+        dnsbl_baseline=drain_dnsbl_before,
     )
 
     # And: CSV still written in the OFF state (additive path independent of the toggle).
-    dnsbl_csv_after = h.count_log_marker(vm, DNSBL_LOG, domain)
+    dnsbl_csv_after = h.count_log_marker(vm, DNSBL_LOG, domain_off)
     assert dnsbl_csv_after > dnsbl_csv_before, (
         f"CSV dnsbl.log was NOT written while syslog export is OFF (before {dnsbl_csv_before}, "
         f"after {dnsbl_csv_after}) — the CSV path must be independent of the syslog toggle"
+    )
+
+    # Re-enable and consume a third configured barrier export before asserting the OFF subject absence.
+    _set_syslog_enabled(vm, on=True)
+    barrier_baseline = len(_pfb_event_lines(vm))
+    h.flush_unbound_name(vm, barrier_domain)
+    barrier_answer = h.dns_probe_client(client_vm, barrier_domain, "A")
+    assert h.is_vip(barrier_answer), f"DNSBL barrier should be VIP after re-enabling syslog, got {barrier_answer}"
+    barrier_line = _wait_for_event(
+        vm, baseline_len=barrier_baseline, want=("act=dnsbl", f"qname={barrier_domain}", f"qip={civm_ip}")
+    )
+    assert barrier_line, (
+        f"No dedicated syslog export for barrier {barrier_domain} after re-enabling export.\n"
+        f"{syslog_export_state_snapshot(vm)}"
+    )
+
+    # This qname is unique to the module and queried only while export is OFF.
+    # Search rotations too so newsyslog cannot erase the negative evidence.
+    phase_lines = _pfb_event_history_lines(vm)
+    assert any(f"qname={barrier_domain}" in event and f"qip={civm_ip}" in event for event in phase_lines), (
+        f"dedicated syslog history missing already-observed barrier {barrier_domain}: {phase_lines!r}"
+    )
+    assert not any(f"qname={domain_off}" in event for event in phase_lines), (
+        f"OFF-phase subject {domain_off} appeared in syslog after its unified row was consumed: "
+        f"{phase_lines!r}\n{syslog_export_state_snapshot(vm)}"
     )

--- a/tests/smoke/test_syslog_export.py
+++ b/tests/smoke/test_syslog_export.py
@@ -324,15 +324,22 @@ def _wait_for_event(
     timeout: float = EVENT_WAIT_SECS,
     interval: float = 1.0,
 ) -> str:
-    """Poll the dedicated file for a NEW event line; return it, or '' on timeout."""
+    """Poll the dedicated file for a NEW event line or raise a salvage-only expiry."""
     deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+    last_new: list[str] = []
+    while True:
         new = _pfb_event_lines(vm)[baseline_len:]
+        last_new = new
         for ln in new:
             if all(tok in ln for tok in want) and (not any_of or any(tok in ln for tok in any_of)):
                 return ln
-        time.sleep(interval)
-    return ""
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(
+                f"salvage cap expired / stuck or environment: _wait_for_event expected want={want!r} "
+                f"and any_of={any_of!r}; observed last new lines={last_new!r}"
+            )
+        time.sleep(min(interval, remaining))
 
 
 def _unified_dnsbl_lines(vm: SmokeVM) -> list[str]:
@@ -622,14 +629,7 @@ def test_syslog_on_dnsbl_event_exported(deployed_vm: SmokeVM, client_vm: SmokeVM
     # Then: a NEW dedicated-file record (poll — tail/daemon latency). Match on
     # act=dnsbl + the queried name (qname=). NOTE: b_type is the MATCH type
     # ('DNSBL'/'TLD'/'Python'), NOT the sinkhole mode — there is no 'VIP' b_type.
-    line = _wait_for_event(
-        vm, baseline_len=barrier_baseline, want=("act=dnsbl", f"qname={barrier_domain}", f"qip={civm_ip}")
-    )
-    assert line, (
-        f"No new DNSBL export record after enabling export (LIVE, no restart) and probing {barrier_domain}.\n"
-        f"  expected a new line in {PFB_SYSLOG_LOG} with: act=dnsbl qname={barrier_domain} qip={civm_ip}\n"
-        f"  {syslog_export_state_snapshot(vm)}"
-    )
+    _wait_for_event(vm, baseline_len=barrier_baseline, want=("act=dnsbl", f"qname={barrier_domain}", f"qip={civm_ip}"))
 
     # This qname is unique to the module and queried only while export is OFF.
     # Search rotations too so newsyslog cannot erase the negative evidence.
@@ -703,8 +703,9 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
 
     _trigger_ip_block(client_vm)
 
-    line = _wait_for_event(vm, baseline_len=len(before), want=(TEST_IP_BLOCK_DST,), any_of=IP_ACT_TOKENS)
-    if not line:
+    try:
+        _wait_for_event(vm, baseline_len=len(before), want=(TEST_IP_BLOCK_DST,), any_of=IP_ACT_TOKENS)
+    except RuntimeError as exc:
         ps = vm.ssh("/bin/ps", "-wax", timeout=30)
         daemon_running = "pfblockerng.inc filterlog" in ps.stdout
         pfctl = vm.ssh("/sbin/pfctl", "-t", "pfB_pfb_syslog_iptest_v4", "-T", "show", timeout=30)
@@ -738,8 +739,9 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
             )
         else:
             precondition = "none — daemon running and alias populated"
-        raise AssertionError(
-            f"No new IP-block export record referencing {TEST_IP_BLOCK_DST} after connection to it.\n"
+        raise RuntimeError(
+            f"salvage cap expired / stuck or environment: no new IP-block export record referencing "
+            f"{TEST_IP_BLOCK_DST} after connection to it.\n"
             f"  expected a new line in {PFB_SYSLOG_LOG} with {TEST_IP_BLOCK_DST!r} and one of {list(IP_ACT_TOKENS)!r}\n"
             f"  actual:   no matching line found\n"
             f"  new pfB events that did NOT reference the victim dst (last {min(len(near_misses), 5)}):\n"
@@ -749,7 +751,7 @@ def test_syslog_on_ip_block_event_exported(deployed_vm: SmokeVM, client_vm: Smok
             f"  ps: {ps.stdout[:400]!r}\n"
             f"  pfctl: {pfctl.stdout!r}\n"
             f"  {syslog_export_state_snapshot(vm)}"
-        )
+        ) from exc
 
     ip_block_after = h.read_log_file(vm, IP_BLOCK_LOG)
     assert len(ip_block_after) > len(ip_block_before), (
@@ -816,7 +818,6 @@ def test_ip_attribution_cache_invalidated_after_feed_ownership_change(deployed_v
             want=(TEST_IP_BLOCK_DST, "dport=18080"),
             any_of=IP_ACT_TOKENS,
         )
-        assert initial_syslog, f"initial FeedA event absent\n{syslog_export_state_snapshot(vm)}"
         assert f"feed={feed_a_header}" in initial_syslog, (
             f"initial event did not attribute {TEST_IP_BLOCK_DST} to FeedA {feed_a_header!r}: {initial_syslog!r}"
         )
@@ -1004,10 +1005,7 @@ def test_syslog_off_no_new_records(deployed_vm: SmokeVM, client_vm: SmokeVM) -> 
     h.flush_unbound_name(vm, domain)
     ans = h.dns_probe_client(client_vm, domain, "A")
     assert h.is_vip(ans), f"DNSBL block should fire while seeding the ON record, got {ans}"
-    seed_line = _wait_for_event(vm, baseline_len=seed_baseline, want=("act=dnsbl", f"qname={domain}", f"qip={civm_ip}"))
-    assert seed_line, (
-        f"Seeding failed: no export record for {domain} with export ON.\n{syslog_export_state_snapshot(vm)}"
-    )
+    _wait_for_event(vm, baseline_len=seed_baseline, want=("act=dnsbl", f"qname={domain}", f"qip={civm_ip}"))
     unified_baseline = len(_unified_dnsbl_lines(vm))
     dnsbl_csv_before = h.count_log_marker(vm, DNSBL_LOG, domain_off)
 
@@ -1040,13 +1038,7 @@ def test_syslog_off_no_new_records(deployed_vm: SmokeVM, client_vm: SmokeVM) -> 
     h.flush_unbound_name(vm, barrier_domain)
     barrier_answer = h.dns_probe_client(client_vm, barrier_domain, "A")
     assert h.is_vip(barrier_answer), f"DNSBL barrier should be VIP after re-enabling syslog, got {barrier_answer}"
-    barrier_line = _wait_for_event(
-        vm, baseline_len=barrier_baseline, want=("act=dnsbl", f"qname={barrier_domain}", f"qip={civm_ip}")
-    )
-    assert barrier_line, (
-        f"No dedicated syslog export for barrier {barrier_domain} after re-enabling export.\n"
-        f"{syslog_export_state_snapshot(vm)}"
-    )
+    _wait_for_event(vm, baseline_len=barrier_baseline, want=("act=dnsbl", f"qname={barrier_domain}", f"qip={civm_ip}"))
 
     # This qname is unique to the module and queried only while export is OFF.
     # Search rotations too so newsyslog cannot erase the negative evidence.

--- a/tests/smoke/ui/test_adr65_alerts_live.py
+++ b/tests/smoke/ui/test_adr65_alerts_live.py
@@ -18,7 +18,6 @@ via the ui-tests workflow or locally::
 
 from __future__ import annotations
 
-import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -80,16 +79,20 @@ def test_alerts_row_renders_logged_group_and_feed_live(deployed_vm: helpers.Smok
         answer = helpers.dns_probe(deployed_vm, domain)
         assert helpers.is_vip(answer), f"expected VIP block for {domain!r}, got {answer!r}"
 
-        deadline = time.monotonic() + 30.0
         hits = 0
-        line = ""
-        while time.monotonic() < deadline:
+
+        def log_hit_observed() -> bool:
+            nonlocal hits
             hits = _dnsbl_log_hits(deployed_vm, domain)
-            if hits >= 1:
-                line = _dnsbl_log_line(deployed_vm, domain)
-                break
-            time.sleep(1.0)
-        assert hits >= 1, f"expected a dnsbl.log line for {domain} after the block, found {hits}"
+            return hits >= 1
+
+        try:
+            helpers.wait_until(log_hit_observed, timeout=30.0, interval=1.0)
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"salvage cap expired / stuck or environment: ADR-65 dnsbl.log expected hits>=1; observed hits={hits}"
+            ) from exc
+        line = _dnsbl_log_line(deployed_vm, domain)
 
         fields = line.split(",")
         assert len(fields) > 8, f"unexpected dnsbl.log line shape for {domain}: {line!r}"

--- a/tests/test_smoke_absence_barrier_schema.py
+++ b/tests/test_smoke_absence_barrier_schema.py
@@ -1,0 +1,78 @@
+"""Green-only coverage for the unified DNSBL drain row schema."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Callable, cast
+
+import pytest
+
+from tests.smoke import test_syslog_export as syslog
+
+
+def test_syslog_event_history_reads_current_and_rotated_generations(monkeypatch: pytest.MonkeyPatch) -> None:
+    current = "pfblockerng: act=dnsbl qname=barrier.example.com qip=192.168.1.10"
+    rotated = "pfblockerng: act=dnsbl qname=subject.example.com qip=192.168.1.10"
+    monkeypatch.setattr(syslog.h, "read_log_file", lambda *_args, **_kwargs: current)
+
+    def ssh(*args: str, **_kwargs: object) -> SimpleNamespace:
+        assert args[:2] == ("/bin/sh", "-c")
+        script = args[2]
+        assert f"{syslog.PFB_SYSLOG_LOG} {syslog.PFB_SYSLOG_LOG}.[0-9]*" in script
+        assert "/usr/bin/bsdcat" in script
+        return SimpleNamespace(returncode=0, stdout=f"{current}\n{rotated}\n", stderr="")
+
+    vm = SimpleNamespace(ssh=ssh)
+    assert syslog._pfb_event_history_lines(cast(syslog.SmokeVM, vm)) == [current, rotated]
+
+
+def test_syslog_event_history_decompression_failure_is_loud() -> None:
+    vm = SimpleNamespace(
+        ssh=lambda *_args, **_kwargs: SimpleNamespace(returncode=1, stdout="partial", stderr="bad archive")
+    )
+    with pytest.raises(RuntimeError, match="history read failed.*bad archive"):
+        syslog._pfb_event_history_lines(cast(syslog.SmokeVM, vm))
+
+
+def test_syslog_unified_drain_expiry_reports_expected_and_observed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(syslog, "_unified_dnsbl_lines", lambda _vm: ["DNSBL-python,other,row"])
+    monkeypatch.setattr(syslog.h, "count_log_marker", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        syslog.h,
+        "wait_until",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("condition not met before timeout")),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"salvage cap expired / stuck or environment.*drain.example.com.*baseline_len=2.*marker count=0.*other",
+    ):
+        syslog._wait_for_unified_dnsbl(
+            cast(syslog.SmokeVM, object()), "drain.example.com", baseline_len=2, dnsbl_baseline=0
+        )
+
+
+@pytest.mark.parametrize(
+    ("drain", "encoded_drain"),
+    [
+        ("drain.example.com", "drain.example.com"),
+        ("drain,quoted.example.com", '"drain,quoted.example.com"'),
+        ('drain"quoted.example.com', '"drain""quoted.example.com"'),
+    ],
+)
+def test_syslog_unified_drain_matches_the_real_dnsbl_csv_schema(
+    monkeypatch: pytest.MonkeyPatch, drain: str, encoded_drain: str
+) -> None:
+    row = f"DNSBL-python,2026-08-01 12:00:00,{encoded_drain},192.168.1.10,A,VIP,group,{encoded_drain},feed,,A"
+    monkeypatch.setattr(syslog.h, "read_log_file", lambda *_args, **_kwargs: row)
+    monkeypatch.setattr(syslog.h, "count_log_marker", lambda *_args, **_kwargs: 1)
+
+    def observe_once(predicate: Callable[[], bool], **_kwargs: Any) -> bool:
+        assert predicate()
+        return True
+
+    monkeypatch.setattr(syslog.h, "wait_until", observe_once)
+
+    assert (
+        syslog._wait_for_unified_dnsbl(cast(syslog.SmokeVM, object()), drain, baseline_len=0, dnsbl_baseline=0) == row
+    )

--- a/tests/test_smoke_absence_barriers.py
+++ b/tests/test_smoke_absence_barriers.py
@@ -1,0 +1,225 @@
+"""Red canaries for the smoke absence controls' causal barriers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Callable
+
+import pytest
+
+from tests.smoke import helpers as h
+from tests.smoke import test_smoke_upstream_block as upstream
+from tests.smoke import test_syslog_export as syslog
+
+
+class _DelayedUpstreamStub:
+    def __init__(self) -> None:
+        self.rcode = "NOERROR"
+
+    def register_nxdomain(self, name: str, **_: Any) -> None:
+        self.rcode = "NXDOMAIN"
+
+
+def _upstream_case(monkeypatch: pytest.MonkeyPatch, method: Callable[..., None]) -> None:
+    vm = SimpleNamespace(_pfb_upstream_barrier="barrier.example.com")
+    cvm = object()
+    stub = _DelayedUpstreamStub()
+    lines: list[str] = []
+    counts: dict[str, int] = {}
+
+    def probe(_: object, name: str, *_args: Any, **_kwargs: Any) -> h.DnsAnswer:
+        if name == vm._pfb_upstream_barrier:
+            lines.extend(
+                (
+                    f"DNSBL-python, DNSBL, barrier={name}",
+                    f"DNSBL-python, Upstream_Block, qname={_subject}, barrier={name}",
+                )
+            )
+            return h.DnsAnswer(rcode="NOERROR", records=[h.DEFAULT_DNSBL_VIP4])
+        if stub.rcode == "NXDOMAIN":
+            return h.DnsAnswer(rcode="NXDOMAIN", records=[])
+        return h.DnsAnswer(rcode="NOERROR", records=[h.STUB_DNS_A])
+
+    def count_marker(_: object, _path: str, marker: str, **_kwargs: Any) -> int:
+        counts[marker] = sum(marker in line for line in lines)
+        return counts[marker]
+
+    _subject = "unset"
+    monkeypatch.setattr(upstream.h, "dns_probe_client", probe)
+    monkeypatch.setattr(upstream.h, "count_log_marker", count_marker)
+    monkeypatch.setattr(upstream.h, "flush_unbound_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(upstream, "_read_dnsbl_log", lambda *_args, **_kwargs: "\n".join(lines))
+    monkeypatch.setattr(upstream.time, "sleep", lambda *_args, **_kwargs: None)
+
+    def run(deployed_vm: tuple[object, object], stub_dns: _DelayedUpstreamStub) -> None:
+        nonlocal _subject
+        _subject = method.__name__
+        method(deployed_vm, stub_dns)
+
+    with pytest.raises(AssertionError, match="Upstream_Block appeared before the absence assertion barrier"):
+        run((vm, cvm), stub)
+
+
+@pytest.mark.parametrize(
+    ("method",),
+    [
+        (upstream.TestUpstreamBlockAuthoritativeControl().test_authoritative_nxdomain_not_logged,),
+        (upstream.TestUpstreamBlockForwarderNaturalControl().test_forwarder_natural_nxdomain_not_logged,),
+        (upstream.TestUpstreamBlockNormalControl().test_normal_resolution_not_logged,),
+    ],
+)
+def test_upstream_absence_controls_consume_a_later_barrier(
+    monkeypatch: pytest.MonkeyPatch, method: Callable[..., None]
+) -> None:
+    _upstream_case(monkeypatch, method)
+
+
+def _syslog_case(
+    monkeypatch: pytest.MonkeyPatch,
+    method: Callable[..., None],
+    *,
+    history_visible: bool = True,
+    match: str | None = None,
+) -> None:
+    vm = SimpleNamespace(
+        _pfb_dnsbl_domain="subject.example.com",
+        _pfb_dnsbl_domain_on="barrier-on.example.com",
+        _pfb_syslog_seed="seed.example.com",
+        _pfb_syslog_drain="drain-off.example.com",
+        _pfb_syslog_barrier="barrier-off.example.com",
+        _pfb_civm_ip="192.168.1.10",
+    )
+    events: list[str] = []
+    counts: dict[str, int] = {}
+
+    def probe(_: object, name: str, *_args: Any, **_kwargs: Any) -> h.DnsAnswer:
+        if name in (vm._pfb_dnsbl_domain_on, vm._pfb_syslog_barrier):
+            subject = (
+                vm._pfb_dnsbl_domain
+                if method.__name__ == "test_syslog_on_dnsbl_event_exported"
+                else vm._pfb_dnsbl_domain_on
+            )
+            events.append(f"act=dnsbl qname={subject} qip={vm._pfb_civm_ip}")
+            events.append(f"act=dnsbl qname={name} qip={vm._pfb_civm_ip}")
+        counts[name] = counts.get(name, 0) + 1
+        return h.DnsAnswer(rcode="NOERROR", records=[h.DEFAULT_DNSBL_VIP4])
+
+    def count_marker(_: object, _path: str, marker: str, **_kwargs: Any) -> int:
+        return counts.get(marker, 0)
+
+    monkeypatch.setattr(syslog.h, "dns_probe_client", probe)
+    monkeypatch.setattr(syslog.h, "flush_unbound_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(syslog.h, "count_log_marker", count_marker)
+    monkeypatch.setattr(syslog.h, "is_vip", lambda answer: True)
+    monkeypatch.setattr(syslog.h, "config_get", lambda *_args, **_kwargs: "")
+    monkeypatch.setattr(syslog, "_set_syslog_enabled", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        syslog,
+        "_pfb_event_lines",
+        lambda *_args, **_kwargs: [event for event in events if f"qname={vm._pfb_syslog_barrier}" in event],
+    )
+    monkeypatch.setattr(
+        syslog,
+        "_pfb_event_history_lines",
+        lambda *_args, **_kwargs: list(events) if history_visible else [],
+        raising=False,
+    )
+    monkeypatch.setattr(syslog, "_unified_dnsbl_lines", lambda *_args, **_kwargs: list(events), raising=False)
+    monkeypatch.setattr(syslog, "_system_log_export_leaks", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(syslog, "syslog_export_state_snapshot", lambda *_args, **_kwargs: "fake state")
+    monkeypatch.setattr(syslog, "_wait_for_event", lambda *_args, **_kwargs: "act=dnsbl qname=barrier")
+    monkeypatch.setattr(syslog, "_wait_for_unified_dnsbl", lambda *_args, **_kwargs: None, raising=False)
+    monkeypatch.setattr(syslog.time, "sleep", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(AssertionError, match=match):
+        method(vm, object())
+
+
+@pytest.mark.parametrize(
+    ("method",),
+    [
+        (syslog.test_syslog_on_dnsbl_event_exported,),
+        (syslog.test_syslog_off_no_new_records,),
+    ],
+)
+def test_syslog_absence_controls_consume_a_later_barrier(
+    monkeypatch: pytest.MonkeyPatch, method: Callable[..., None]
+) -> None:
+    _syslog_case(monkeypatch, method, match="appeared in syslog after its unified row was consumed")
+
+
+@pytest.mark.parametrize(
+    ("method",),
+    [
+        (syslog.test_syslog_on_dnsbl_event_exported,),
+        (syslog.test_syslog_off_no_new_records,),
+    ],
+)
+def test_syslog_absence_controls_reject_empty_history(
+    monkeypatch: pytest.MonkeyPatch, method: Callable[..., None]
+) -> None:
+    _syslog_case(monkeypatch, method, history_visible=False, match="history.*barrier")
+
+
+def _syslog_drain_order_case(monkeypatch: pytest.MonkeyPatch, method: Callable[..., None]) -> None:
+    vm = SimpleNamespace(
+        _pfb_dnsbl_domain="seed-or-subject.example.com",
+        _pfb_dnsbl_domain_on="subject-or-drain.example.com",
+        _pfb_syslog_seed="seed.example.com",
+        _pfb_syslog_drain="drain.example.com",
+        _pfb_syslog_barrier="barrier.example.com",
+        _pfb_civm_ip="192.168.1.10",
+    )
+    probes: list[str] = []
+    unified_waits: list[str] = []
+    events: list[str] = []
+    enabled = [False]
+
+    def probe(_: object, name: str, *_args: Any, **_kwargs: Any) -> h.DnsAnswer:
+        probes.append(name)
+        if enabled[0]:
+            events.append(f"act=dnsbl qname={name} qip={vm._pfb_civm_ip}")
+        return h.DnsAnswer(rcode="NOERROR", records=[h.DEFAULT_DNSBL_VIP4])
+
+    def wait_unified(_: object, domain: str, **_kwargs: Any) -> str:
+        unified_waits.append(domain)
+        return f"act=dnsbl qname={domain}"
+
+    monkeypatch.setattr(syslog.h, "dns_probe_client", probe)
+    monkeypatch.setattr(syslog.h, "flush_unbound_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(syslog.h, "count_log_marker", lambda *_args, **_kwargs: len(probes))
+    monkeypatch.setattr(syslog.h, "is_vip", lambda answer: True)
+    monkeypatch.setattr(syslog, "_set_syslog_enabled", lambda _vm, *, on, **_kwargs: enabled.__setitem__(0, on))
+    monkeypatch.setattr(syslog, "_pfb_event_lines", lambda *_args, **_kwargs: list(events))
+    monkeypatch.setattr(syslog, "_pfb_event_history_lines", lambda *_args, **_kwargs: list(events), raising=False)
+    monkeypatch.setattr(syslog, "_unified_dnsbl_lines", lambda *_args, **_kwargs: list(events), raising=False)
+    monkeypatch.setattr(syslog, "_system_log_export_leaks", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(syslog, "_wait_for_event", lambda *_args, **_kwargs: "act=dnsbl qname=barrier")
+    monkeypatch.setattr(syslog, "_wait_for_unified_dnsbl", wait_unified, raising=False)
+
+    method(vm, object())
+
+    if method.__name__ == "test_syslog_on_dnsbl_event_exported":
+        assert probes == [vm._pfb_dnsbl_domain, vm._pfb_dnsbl_domain_on, vm._pfb_syslog_barrier]
+        assert unified_waits == [vm._pfb_dnsbl_domain_on]
+    else:
+        assert probes == [
+            vm._pfb_syslog_seed,
+            vm._pfb_dnsbl_domain_on,
+            vm._pfb_syslog_drain,
+            vm._pfb_syslog_barrier,
+        ]
+        assert unified_waits == [vm._pfb_syslog_drain]
+
+
+@pytest.mark.parametrize(
+    ("method",),
+    [
+        (syslog.test_syslog_on_dnsbl_event_exported,),
+        (syslog.test_syslog_off_no_new_records,),
+    ],
+)
+def test_syslog_absence_controls_emit_a_distinct_off_state_drain_before_the_on_barrier(
+    monkeypatch: pytest.MonkeyPatch, method: Callable[..., None]
+) -> None:
+    _syslog_drain_order_case(monkeypatch, method)

--- a/tests/test_smoke_local_wait_expiry.py
+++ b/tests/test_smoke_local_wait_expiry.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from tests.smoke import test_hook_stream_visibility as hook
+from tests.smoke import test_smoke_upstream_block as upstream
+from tests.smoke import test_syslog_export as syslog
+
+
+def test_upstream_lines_expiry_reports_expected_and_observed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upstream, "_read_dnsbl_log", lambda _vm: "tail line")
+    with pytest.raises(RuntimeError, match=r"salvage cap expired / stuck or environment.*nonempty.*tail line"):
+        upstream._wait_for_upstream_block_lines(
+            cast(upstream.SmokeVM, object()), "example.invalid", timeout_s=0, poll_s=0
+        )
+
+
+def test_upstream_counter_expiry_reports_expected_and_observed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(upstream, "_read_upstream_counter", lambda _vm: (3, "counter stayed at baseline"))
+    with pytest.raises(RuntimeError, match=r"salvage cap expired / stuck or environment.*counter > 3.*3"):
+        upstream._wait_for_counter_above(cast(upstream.SmokeVM, object()), 3, timeout_s=0, poll_s=0)
+
+
+def test_syslog_event_expiry_reports_expected_and_observed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(syslog, "_pfb_event_lines", lambda _vm: ["new event line"])
+    with pytest.raises(
+        RuntimeError, match=r"salvage cap expired / stuck or environment.*want.*missing.*new event line"
+    ):
+        syslog._wait_for_event(
+            cast(syslog.SmokeVM, object()),
+            baseline_len=0,
+            want=("missing",),
+            any_of=("act=block",),
+            timeout=0,
+            interval=0,
+        )
+
+
+def test_guest_file_expiry_reports_command_result() -> None:
+    vm = SimpleNamespace(
+        ssh=lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="no file", stderr="not found")
+    )
+    with pytest.raises(
+        RuntimeError, match=r"salvage cap expired / stuck or environment.*guest file.*example.*rc=1.*no file.*not found"
+    ):
+        hook._wait_for_guest_file(cast(hook.SmokeVM, vm), "/tmp/example", deadline_s=0, poll_s=0)
+
+
+def test_upgrade_expiry_reports_expected_and_observed() -> None:
+    vm = SimpleNamespace(ssh=lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="pid 123", stderr=""))
+    with pytest.raises(RuntimeError, match=r"salvage cap expired / stuck or environment.*pgrep.*rc=0.*pid 123"):
+        hook._wait_upgrade_gone(cast(hook.SmokeVM, vm), deadline_s=0, poll_s=0)
+
+
+def test_upgrade_wait_rejects_transport_status_as_gone() -> None:
+    vm = SimpleNamespace(ssh=lambda *_args, **_kwargs: SimpleNamespace(returncode=255, stdout="", stderr="ssh failed"))
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"salvage cap expired / stuck or environment.*pgrep.*rc=255.*ssh failed",
+    ):
+        hook._wait_upgrade_gone(cast(hook.SmokeVM, vm), deadline_s=0, poll_s=0)
+
+
+def test_hook_cleanup_preserves_primary_failure_and_finishes(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def ssh(*args: str, **_kwargs: object) -> SimpleNamespace:
+        calls.append(args[0])
+        return SimpleNamespace(returncode=0)
+
+    vm = SimpleNamespace(ssh=ssh)
+
+    def expire(*_args: object, **_kwargs: object) -> None:
+        calls.append("wait")
+        raise RuntimeError("salvage cap expired / stuck or environment: upgrade still running")
+
+    monkeypatch.setattr(hook, "_wait_upgrade_gone", expire)
+    monkeypatch.setattr(hook.h, "clear_update_hooks", lambda _vm: calls.append("clear"))
+    monkeypatch.setattr(hook, "pkg_delete", lambda _vm: calls.append("delete"))
+    monkeypatch.setattr(hook, "repo_priority", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(hook, "write_repo_conf", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(hook, "pkg_update", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(hook, "pkg_installed_version", lambda *_args, **_kwargs: "already installed")
+
+    with pytest.raises(AssertionError, match="unexpectedly present") as caught:
+        hook.test_hook_output_streams_to_gui_while_running(cast(hook.SmokeVM, vm))
+
+    assert calls == ["delete", "/usr/bin/touch", "wait", "clear", "/bin/rm"]
+    assert any("salvage cap expired" in note for note in getattr(caught.value, "__notes__", ()))
+
+
+def test_hook_cleanup_expiry_is_loud_after_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def ssh(*args: str, **_kwargs: object) -> SimpleNamespace:
+        calls.append(args[0])
+        return SimpleNamespace(returncode=0)
+
+    vm = SimpleNamespace(ssh=ssh)
+
+    def expire(*_args: object, **_kwargs: object) -> None:
+        calls.append("wait")
+        raise RuntimeError("salvage cap expired / stuck or environment: upgrade still running")
+
+    monkeypatch.setattr(hook, "_wait_upgrade_gone", expire)
+    monkeypatch.setattr(hook.h, "clear_update_hooks", lambda _vm: calls.append("clear"))
+    monkeypatch.setattr(hook, "pkg_delete", lambda _vm: calls.append("delete"))
+
+    with pytest.raises(RuntimeError, match="salvage cap expired / stuck or environment"):
+        hook._cleanup_hook_run(cast(hook.SmokeVM, vm))
+
+    assert calls == ["/usr/bin/touch", "wait", "clear", "/bin/rm"]
+
+
+def test_hook_cleanup_preserves_primary_when_hook_reset_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def ssh(*args: str, **_kwargs: object) -> SimpleNamespace:
+        calls.append(args[0])
+        return SimpleNamespace(returncode=0)
+
+    vm = SimpleNamespace(ssh=ssh)
+    monkeypatch.setattr(hook, "_wait_upgrade_gone", lambda *_args, **_kwargs: calls.append("wait"))
+
+    def fail_clear(_vm: object) -> None:
+        calls.append("clear")
+        raise RuntimeError("hook reset failed")
+
+    monkeypatch.setattr(hook.h, "clear_update_hooks", fail_clear)
+    monkeypatch.setattr(hook, "pkg_delete", lambda _vm: calls.append("delete"))
+    monkeypatch.setattr(hook, "repo_priority", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(hook, "write_repo_conf", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(hook, "pkg_update", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(hook, "pkg_installed_version", lambda *_args, **_kwargs: "already installed")
+
+    with pytest.raises(AssertionError, match="unexpectedly present") as caught:
+        hook.test_hook_output_streams_to_gui_while_running(cast(hook.SmokeVM, vm))
+
+    assert calls == ["delete", "/usr/bin/touch", "wait", "clear", "/bin/rm", "delete"]
+    assert any("hook reset failed" in note for note in getattr(caught.value, "__notes__", ()))
+
+
+@pytest.mark.parametrize("failure_stage", ["touch", "wait"])
+def test_hook_cleanup_preserves_primary_on_transport_failure(
+    monkeypatch: pytest.MonkeyPatch, failure_stage: str
+) -> None:
+    calls: list[str] = []
+
+    def ssh(*args: str, **_kwargs: object) -> SimpleNamespace:
+        calls.append(args[0])
+        if failure_stage == "touch" and args[0] == "/usr/bin/touch":
+            raise OSError("touch transport failed")
+        return SimpleNamespace(returncode=0)
+
+    def wait(*_args: object, **_kwargs: object) -> None:
+        calls.append("wait")
+        if failure_stage == "wait":
+            raise TimeoutError("wait transport failed")
+
+    vm = SimpleNamespace(ssh=ssh)
+    monkeypatch.setattr(hook, "_wait_upgrade_gone", wait)
+    monkeypatch.setattr(hook.h, "clear_update_hooks", lambda _vm: calls.append("clear"))
+    monkeypatch.setattr(hook, "pkg_delete", lambda _vm: calls.append("delete"))
+
+    with pytest.raises(AssertionError, match="primary failure") as caught:
+        try:
+            raise AssertionError("primary failure")
+        finally:
+            hook._cleanup_hook_run(cast(hook.SmokeVM, vm))
+
+    expected = ["/usr/bin/touch", "clear", "/bin/rm"]
+    if failure_stage == "wait":
+        expected.insert(1, "wait")
+    assert calls == expected
+    assert any(f"{failure_stage} transport failed" in note for note in getattr(caught.value, "__notes__", ()))


### PR DESCRIPTION
## Summary

- replace settle-sleep absence assertions with causal log-pipeline barriers
- make module-local bounded poll expiry loud and typed instead of returning false or stale state
- keep the two tracker children stacked as one PR, one commit per issue

## Commit stack

1. `tests: barrier smoke absence assertions` — fixes #1987
2. `tests: distinguish smoke poll salvage expiry` — fixes #1998

## Barrier design

- Upstream-block absence controls emit and observe a later local-DNSBL record through the same QueueListener and `dnsbl.log` path before asserting the subject is absent.
- Syslog absence controls query the subject with export off, emit a distinct later drain event with export still off, observe that drain in the real RFC4180 DNSBL row in `unified.log`, then enable export and observe a third distinct event in the dedicated syslog file. The absence verdict scans the current log plus newsyslog rotations through FreeBSD `bsdcat` and re-proves that third barrier in the returned history before checking the OFF subject.
- Killstates uses the synchronous reload and client-connect boundaries already provided by the exercised operations.

## Evidence

- Frozen red→green proof: #1987 — 9 behavioral rows, hash `bc6e3ba7535ca848c4236f4174e2cd3d697d4c8d`, PASS
- Frozen red→green proof: #1998 — 10 selected behavioral rows, hash `50a54aba1a91fd6cc5de9b88b56c1fffd9a9349b`, PASS
- Focused barrier, parser, and expiry matrix: 26 passed
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS
- Exact-head CI at `aea0cd57d459ded9344f3f1c19152292ee41fed3`: PASS
- Exact-head live repo hook: 1 passed
- Content-identical exact-source live syslog module: 5 passed
- Earlier content-identical live coverage: affected main modules 15 passed; RAM-disk reboot 2 passed; UI e2e 2 passed
- Two independent exact-head reviews: PASS

## Review disposition

- All six inline review threads resolved.
- CodeRabbit findings fixed or evidence-triaged; no review requested from Copilot.

## Separate finding

- #2075 tracks the pre-existing production parser that skips RFC4180-quoted DNSBL rows during syslog export; no milestone assigned.

Fixes #1987
Fixes #1998

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
