### PR TITLE
www: truncate Category and Feeds values before escaping

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -434,9 +434,10 @@ if (isset($savemsg)) {
 				<tr style="vertical-align: top"<?php if ($gtype != 'geoip'): ?> class="sortable"<?php endif; ?> id="pfb_r<?=$r_id;?>">
 					<td>
 					<?php
-						$row['aliasname'] = htmlspecialchars($row['aliasname']);
+						$aliasname_raw = $row['aliasname'];
+						$row['aliasname'] = htmlspecialchars($aliasname_raw);
 						if (strlen($row['aliasname']) >= 20) {
-							print ("<p title=\"{$row['aliasname']}\">" . substr($row['aliasname'], 0, 15) . '...</p>');
+							print ("<p title=\"{$row['aliasname']}\">" . htmlspecialchars(mb_substr($aliasname_raw, 0, 15, 'UTF-8')) . '...</p>');
 						} else {
 							print ($row['aliasname']);
 						}
@@ -445,9 +446,10 @@ if (isset($savemsg)) {
 
 					<td>
 					<?php
-						$row['description'] = htmlspecialchars($row['description']);
+						$description_raw = $row['description'];
+						$row['description'] = htmlspecialchars($description_raw);
 						if (strlen($row['description']) >= 20) {
-							print ("<p title=\"{$row['description']}\">" . substr($row['description'], 0, 15) . '...</p>');
+							print ("<p title=\"{$row['description']}\">" . htmlspecialchars(mb_substr($description_raw, 0, 15, 'UTF-8')) . '...</p>');
 						} else {
 							print ($row['description']);
 						}

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -867,10 +867,11 @@ print ($section);
 				<td>
 					<?php
 								$title = '';
-								$row['aliasname'] = htmlspecialchars($row['aliasname']);
+								$aliasname_raw = $row['aliasname'];
+								$row['aliasname'] = htmlspecialchars($aliasname_raw);
 								if (strlen($row['aliasname']) >= 15) {
 									$title 			= $row['aliasname'];
-									$row['aliasname']	= substr($row['aliasname'], 0, 15) . '...';
+									$row['aliasname']	= htmlspecialchars(mb_substr($aliasname_raw, 0, 15, 'UTF-8')) . '...';
 								}
 
 								if ($row['aliasname'] != $p_aliasname) {

--- a/tests/php/CategoryFeedsAliasTruncationRenderTest.php
+++ b/tests/php/CategoryFeedsAliasTruncationRenderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** Off-box render coverage for alias values not seedable by the Tier-A fixture (#2039). */
+final class CategoryFeedsAliasTruncationRenderTest extends TestCase
+{
+	private static function source(string $file): string
+	{
+		$src = file_get_contents(dirname(__DIR__, 2) . "/src/usr/local/www/pfblockerng/{$file}");
+		if ($src === false) {
+			throw new RuntimeException("failed to read {$file}");
+		}
+		return $src;
+	}
+
+	private static function slice(string $src, string $startMarker, string $endMarker): string
+	{
+		$start = strpos($src, $startMarker);
+		$end   = strpos($src, $endMarker, $start === false ? 0 : $start);
+		if ($start === false || $end === false || $end <= $start) {
+			throw new RuntimeException('could not locate alias render block');
+		}
+		return substr($src, $start, $end - $start);
+	}
+
+	private static function renderCategoryAlias(string $alias): string
+	{
+		$code = self::slice(
+			self::source('pfblockerng_category.php'),
+			"\t\t\t\t\t\t\$aliasname_raw = \$row['aliasname'];",
+			"\n\t\t\t\t\t?>"
+		);
+		$row = array('aliasname' => $alias);
+
+		ob_start();
+		eval($code);
+		return (string) ob_get_clean();
+	}
+
+	private static function renderFeedsAlias(string $alias): string
+	{
+		$code = self::slice(
+			self::source('pfblockerng_feeds.php'),
+			"\t\t\t\t\t\t\t\t\$title = '';",
+			"\n\t\t\t\t\t?>"
+		);
+		$row         = array('aliasname' => $alias, 'rowid' => 17);
+		$p_aliasname = '';
+		$feedtype    = 'ipv4';
+
+		ob_start();
+		eval($code);
+		return (string) ob_get_clean();
+	}
+
+	/** @return array<string, array{string, string}> */
+	public static function hostileAliasProvider(): array
+	{
+		return array(
+			'entity boundary' => array(str_repeat('a', 13) . '&' . str_repeat('b', 8), str_repeat('a', 13) . '&amp;b...'),
+			'multibyte boundary' => array(str_repeat('a', 14) . 'é' . str_repeat('b', 8), str_repeat('a', 14) . 'é...'),
+		);
+	}
+
+	#[DataProvider('hostileAliasProvider')]
+	public function testCategoryAliasTruncatesRawCharactersBeforeEscaping(string $alias, string $prefix): void
+	{
+		$html = self::renderCategoryAlias($alias);
+
+		$this->assertStringContainsString($prefix, $html, 'Category alias display split an entity or UTF-8 character');
+		$this->assertStringContainsString('title="' . htmlspecialchars($alias) . '"', $html, 'Category title lost the full alias');
+		$this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'Category alias render must remain valid UTF-8');
+	}
+
+	#[DataProvider('hostileAliasProvider')]
+	public function testFeedsAliasTruncatesRawCharactersBeforeEscaping(string $alias, string $prefix): void
+	{
+		$html = self::renderFeedsAlias($alias);
+
+		$this->assertStringContainsString($prefix, $html, 'Feeds alias display split an entity or UTF-8 character');
+		$this->assertStringContainsString('title="' . htmlspecialchars($alias) . '"', $html, 'Feeds title lost the full alias');
+		$this->assertTrue(mb_check_encoding($html, 'UTF-8'), 'Feeds alias render must remain valid UTF-8');
+	}
+}

--- a/tests/smoke/ui/test_xss_escaping.py
+++ b/tests/smoke/ui/test_xss_escaping.py
@@ -282,12 +282,8 @@ CFG_IPV4_FEEDS = "installedpackages/pfblockernglistsv4/config"
 FEEDS_PAGE_IPV4 = "/pfblockerng/pfblockerng_feeds.php?type=ipv4"
 FEEDS_PAGE_MARKERS = ("Pre-defined Alias/Group/Feeds", "IPv4 Alias name(s):")
 
-# Valid UTF-8 values whose escaped forms place the old byte cut in the middle
-# of an entity or multibyte character. The raw-character prefixes are the
-# intended 15-character display values on all three render sites.
-CATEGORY_ALIAS = "i2039aliasé&abcdefghij"
-CATEGORY_ALIAS_PREFIX = "i2039aliasé&amp;abc..."
-CATEGORY_ALIAS_ESCAPED = "i2039aliasé&amp;abcdefghij"
+# Reachable description value whose escaped form placed the old byte cut in
+# the middle of an entity. The edit form accepts and persists this value.
 CATEGORY_DESCRIPTION = "d2039des&aébcdefghijklmnop"
 CATEGORY_DESCRIPTION_PREFIX = "d2039des&amp;aébcde..."
 CATEGORY_DESCRIPTION_ESCAPED = "d2039des&amp;aébcdefghijklmnop"
@@ -336,13 +332,16 @@ def _seed_custom_feed_row(
     idiom (``_mk_alias``).
     """
     row = {"state": "Enabled", "url": url, "header": XSS_FEED_HEADER}
-    description_item = f", 'description' => {helpers._php_str(description)}" if description is not None else ""
-    entry = (
-        f"array('aliasname' => {helpers._php_str(aliasname)}, 'action' => 'Deny_Both'{description_item}, "
-        f"'row' => array({helpers._php_kv_array(row)}))"
+    description_write = (
+        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/description')}, {helpers._php_str(description)});\n"
+        if description is not None
+        else ""
     )
     snippet = (
-        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}')}, {entry});\n"
+        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/aliasname')}, {helpers._php_str(aliasname)});\n"
+        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/action')}, {helpers._php_str('Deny_Both')});\n"
+        f"{description_write}"
+        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/row/0')}, {helpers._php_kv_array(row)});\n"
         "write_config('pfBlockerNG smoke: seed XSS feed row');\n"
         "echo 'OK';"
     )
@@ -351,8 +350,8 @@ def _seed_custom_feed_row(
         raise RuntimeError(f"_seed_custom_feed_row failed: rc={result.returncode} {result.stdout!r} {result.stderr!r}")
 
 
-def test_category_and_feeds_truncation(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
-    """All three long cells truncate valid UTF-8 before HTML escaping."""
+def test_category_description_truncates_before_html_escaping(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """The reachable long description truncates raw UTF-8 before escaping."""
     vm = smoke_vm
     rowid = _free_rowid(vm, CFG_IPV4_FEEDS)
     try:
@@ -360,29 +359,19 @@ def test_category_and_feeds_truncation(webui: WebUI, smoke_vm: helpers.SmokeVM) 
             vm,
             CFG_IPV4_FEEDS,
             rowid,
-            CATEGORY_ALIAS,
+            "i2039description",
             XSS_FEED_URL,
             CATEGORY_DESCRIPTION,
         )
         base = f"{CFG_IPV4_FEEDS}/{rowid}"
-        got_alias = helpers.config_get(vm, f"{base}/aliasname")
-        assert got_alias == CATEGORY_ALIAS, f"config alias mismatch: expected {CATEGORY_ALIAS!r}, got {got_alias!r}"
         got_description = helpers.config_get(vm, f"{base}/description")
         assert got_description == CATEGORY_DESCRIPTION, (
             f"config description mismatch: expected {CATEGORY_DESCRIPTION!r}, got {got_description!r}"
         )
 
-        feeds_url = FEEDS_PAGE_IPV4
-        feeds = webui.get(feeds_url)
         category_url = "/pfblockerng/pfblockerng_category.php?type=ipv4"
         category = webui.get(category_url)
         failures: list[str] = []
-
-        try:
-            feeds_body = feeds.content.decode("utf-8", errors="strict")
-        except UnicodeDecodeError as exc:
-            failures.append(f"Feeds response is not valid UTF-8: {exc}")
-            feeds_body = feeds.content.decode("utf-8", errors="replace")
 
         try:
             category_body = category.content.decode("utf-8", errors="strict")
@@ -390,24 +379,15 @@ def test_category_and_feeds_truncation(webui: WebUI, smoke_vm: helpers.SmokeVM) 
             failures.append(f"Category response is not valid UTF-8: {exc}")
             category_body = category.content.decode("utf-8", errors="replace")
 
-        feeds_result = evaluate_render(feeds_url, feeds.status_code, feeds_body, FEEDS_PAGE_MARKERS)
         category_result = evaluate_render(category_url, category.status_code, category_body, ("Summary", "pfBlockerNG"))
-        if not feeds_result.ok:
-            failures.append(f"Feeds Tier-A render oracle failed: {feeds_result.detail}")
         if not category_result.ok:
             failures.append(f"Category Tier-A render oracle failed: {category_result.detail}")
-        if looks_like_login_page(feeds_body):
-            failures.append("Feeds GET returned the login form")
         if looks_like_login_page(category_body):
             failures.append("Category GET returned the login form")
 
         for label, expected, body in (
-            ("Category alias prefix", CATEGORY_ALIAS_PREFIX, category_body),
-            ("Category alias title", f'title="{CATEGORY_ALIAS_ESCAPED}"', category_body),
             ("Category description prefix", CATEGORY_DESCRIPTION_PREFIX, category_body),
             ("Category description title", f'title="{CATEGORY_DESCRIPTION_ESCAPED}"', category_body),
-            ("Feeds alias prefix", CATEGORY_ALIAS_PREFIX, feeds_body),
-            ("Feeds alias title", f'title="{CATEGORY_ALIAS_ESCAPED}"', feeds_body),
         ):
             if expected not in body:
                 failures.append(f"{label} missing or split: expected {expected!r}")

--- a/tests/smoke/ui/test_xss_escaping.py
+++ b/tests/smoke/ui/test_xss_escaping.py
@@ -282,6 +282,16 @@ CFG_IPV4_FEEDS = "installedpackages/pfblockernglistsv4/config"
 FEEDS_PAGE_IPV4 = "/pfblockerng/pfblockerng_feeds.php?type=ipv4"
 FEEDS_PAGE_MARKERS = ("Pre-defined Alias/Group/Feeds", "IPv4 Alias name(s):")
 
+# Valid UTF-8 values whose escaped forms place the old byte cut in the middle
+# of an entity or multibyte character. The raw-character prefixes are the
+# intended 15-character display values on all three render sites.
+CATEGORY_ALIAS = "i2039aliasé&abcdefghij"
+CATEGORY_ALIAS_PREFIX = "i2039aliasé&amp;abc..."
+CATEGORY_ALIAS_ESCAPED = "i2039aliasé&amp;abcdefghij"
+CATEGORY_DESCRIPTION = "d2039des&aébcdefghijklmnop"
+CATEGORY_DESCRIPTION_PREFIX = "d2039des&amp;aébcde..."
+CATEGORY_DESCRIPTION_ESCAPED = "d2039des&amp;aébcdefghijklmnop"
+
 # Hostile-input fixture: an "http" URL (hits the <a href> render branch) that
 # breaks out of the href attribute and opens a <script> tag.
 XSS_FEED_URL = 'http://a"><script>xss</script>.evil.example/list.txt'
@@ -311,7 +321,14 @@ def _free_rowid(vm: helpers.SmokeVM, cfg_root: str) -> int:
     return int(helpers._php_read_scalar(vm, pre, "$free", timeout=60.0))
 
 
-def _seed_custom_feed_row(vm: helpers.SmokeVM, cfg_root: str, rowid: int, aliasname: str, url: str) -> None:
+def _seed_custom_feed_row(
+    vm: helpers.SmokeVM,
+    cfg_root: str,
+    rowid: int,
+    aliasname: str,
+    url: str,
+    description: str | None = None,
+) -> None:
     """Write one custom-feed alias (unmatched by the predefined catalog) via the config API.
 
     Direct ``config_set_path`` + ``write_config`` (not the save form) -- a pure
@@ -319,16 +336,85 @@ def _seed_custom_feed_row(vm: helpers.SmokeVM, cfg_root: str, rowid: int, aliasn
     idiom (``_mk_alias``).
     """
     row = {"state": "Enabled", "url": url, "header": XSS_FEED_HEADER}
+    description_item = f", 'description' => {helpers._php_str(description)}" if description is not None else ""
+    entry = (
+        f"array('aliasname' => {helpers._php_str(aliasname)}, 'action' => 'Deny_Both'{description_item}, "
+        f"'row' => array({helpers._php_kv_array(row)}))"
+    )
     snippet = (
-        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/aliasname')}, {helpers._php_str(aliasname)});\n"
-        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/action')}, {helpers._php_str('Deny_Both')});\n"
-        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}/row/0')}, {helpers._php_kv_array(row)});\n"
+        f"config_set_path({helpers._php_str(f'{cfg_root}/{rowid}')}, {entry});\n"
         "write_config('pfBlockerNG smoke: seed XSS feed row');\n"
         "echo 'OK';"
     )
     result = helpers.php_eval(vm, snippet, timeout=60.0)
     if result.returncode != 0 or "OK" not in result.stdout:
         raise RuntimeError(f"_seed_custom_feed_row failed: rc={result.returncode} {result.stdout!r} {result.stderr!r}")
+
+
+def test_category_and_feeds_truncation(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """All three long cells truncate valid UTF-8 before HTML escaping."""
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_IPV4_FEEDS)
+    try:
+        _seed_custom_feed_row(
+            vm,
+            CFG_IPV4_FEEDS,
+            rowid,
+            CATEGORY_ALIAS,
+            XSS_FEED_URL,
+            CATEGORY_DESCRIPTION,
+        )
+        base = f"{CFG_IPV4_FEEDS}/{rowid}"
+        got_alias = helpers.config_get(vm, f"{base}/aliasname")
+        assert got_alias == CATEGORY_ALIAS, f"config alias mismatch: expected {CATEGORY_ALIAS!r}, got {got_alias!r}"
+        got_description = helpers.config_get(vm, f"{base}/description")
+        assert got_description == CATEGORY_DESCRIPTION, (
+            f"config description mismatch: expected {CATEGORY_DESCRIPTION!r}, got {got_description!r}"
+        )
+
+        feeds_url = FEEDS_PAGE_IPV4
+        feeds = webui.get(feeds_url)
+        category_url = "/pfblockerng/pfblockerng_category.php?type=ipv4"
+        category = webui.get(category_url)
+        failures: list[str] = []
+
+        try:
+            feeds_body = feeds.content.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            failures.append(f"Feeds response is not valid UTF-8: {exc}")
+            feeds_body = feeds.content.decode("utf-8", errors="replace")
+
+        try:
+            category_body = category.content.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            failures.append(f"Category response is not valid UTF-8: {exc}")
+            category_body = category.content.decode("utf-8", errors="replace")
+
+        feeds_result = evaluate_render(feeds_url, feeds.status_code, feeds_body, FEEDS_PAGE_MARKERS)
+        category_result = evaluate_render(category_url, category.status_code, category_body, ("Summary", "pfBlockerNG"))
+        if not feeds_result.ok:
+            failures.append(f"Feeds Tier-A render oracle failed: {feeds_result.detail}")
+        if not category_result.ok:
+            failures.append(f"Category Tier-A render oracle failed: {category_result.detail}")
+        if looks_like_login_page(feeds_body):
+            failures.append("Feeds GET returned the login form")
+        if looks_like_login_page(category_body):
+            failures.append("Category GET returned the login form")
+
+        for label, expected, body in (
+            ("Category alias prefix", CATEGORY_ALIAS_PREFIX, category_body),
+            ("Category alias title", f'title="{CATEGORY_ALIAS_ESCAPED}"', category_body),
+            ("Category description prefix", CATEGORY_DESCRIPTION_PREFIX, category_body),
+            ("Category description title", f'title="{CATEGORY_DESCRIPTION_ESCAPED}"', category_body),
+            ("Feeds alias prefix", CATEGORY_ALIAS_PREFIX, feeds_body),
+            ("Feeds alias title", f'title="{CATEGORY_ALIAS_ESCAPED}"', feeds_body),
+        ):
+            if expected not in body:
+                failures.append(f"{label} missing or split: expected {expected!r}")
+
+        assert not failures, "truncation render failures:\n" + "\n".join(f"- {failure}" for failure in failures)
+    finally:
+        _del_rowid(vm, CFG_IPV4_FEEDS, rowid)
 
 
 def _del_rowid(vm: helpers.SmokeVM, cfg_root: str, rowid: int) -> None:


### PR DESCRIPTION
## Summary

- truncate the raw Category alias, Category description, and Feeds alias values with `mb_substr()` before HTML escaping
- preserve the full escaped value in each title attribute
- cover the reachable description through Tier-A rendering and both alias render paths through focused off-box template tests

## Reachability finding

The edit form's `preg_match("/\\W/")` validation on `aliasname` is not a universal producer gate. The audit found paths that can bypass it or preserve values written elsewhere: installer migrations, wizard writes, settings snapshot restore/migration, the Category AJAX reorder/cleanup path, and XMLRPC synchronization. Alias rendering therefore remains a supported persisted-config concern even though the Tier-A fixture could not seed the hostile alias value reliably.

The live fixture does accept and persist the hostile `description` value, so Tier A proves the same ordering defect through that reachable field. The alias cases render the shipped Category and Feeds snippets off-box with entity-boundary and multibyte-boundary inputs.

## Verification

- `scripts/agent/verify-red-proof.sh ... --base-ref origin/devel`: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS` (`tests/php/CategoryFeedsAliasTruncationRenderTest.php` hash `f1d6a9d260ec9009aefb4b33e6fdf7671a6162ed`)
- `vendor/bin/phpunit tests/php/CategoryFeedsAliasTruncationRenderTest.php`: 4 tests, 12 assertions
- `scripts/agent/run-gates.sh --diff origin/devel`: all Python and PHP gates passed
- `scripts/local-smoke.sh --ref issue/2039-category-feeds-pages-alias --marker ui_render --filter category_description_truncates_before_html_escaping --no-two-vm`: 1 passed, 585 deselected

Fixes #2039

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alias and description truncation for international characters.
  * Prevented truncated text from splitting HTML entities or UTF-8 characters.
  * Preserved complete alias and description text in tooltips.
  * Maintained safe HTML escaping while displaying truncated content.

* **Tests**
  * Added coverage for multibyte characters, HTML entities, and escaped descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->