### PR TITLE
pfblockerng: reject adjacent unbounded regex quantifier runs

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -77,6 +77,10 @@ _REGEX_OVERLAP_ALPHABET = string.printable + "é"
 
 _REGEX_REPEAT = re.compile(r"\{(?P<min>\d+)(?P<comma>,?)(?P<max>\d*)\}")
 
+# How deep the scan follows lookarounds nested inside lookarounds. Real patterns never nest
+# more than one or two; the bound only stops a hostile line from exhausting the stack.
+_REGEX_NESTED_SCAN_MAX = 8
+
 # Complexity-budget backstop: cap the combined count of unbounded quantifiers (`+`/`*`,
 # unescaped) and alternations (`|`, unescaped) in one pattern. The structural regexes
 # above catch KNOWN bad shapes; this catches novel compositions of many quantifiers /
@@ -228,7 +232,14 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     closed = pattern[group_end - 1 : group_end] == ")"
     if pattern.startswith(("(?#", "(?=", "(?!", "(?<=", "(?<!"), index):
         # Skipping an UNCLOSED construct would blind the scan to everything after it.
-        return "", "bridge" if closed else "break", group_end if closed else index + 2
+        if not closed:
+            return "", "break", index + 2
+        if pattern.startswith("(?#", index):
+            return "", "bridge", group_end  # a comment is inert text, not a pattern
+        # A lookaround matches no characters, so it cannot join or separate the run around
+        # it -- but the engine still backtracks over its body, which is scanned on its own.
+        body_start = index + 4 if pattern[index + 2] == "<" else index + 3
+        return pattern[body_start : group_end - 1], "nested", group_end
     if pattern.startswith("(?P<", index):
         name_end = pattern.find(">", index)
         if name_end == -1:
@@ -253,15 +264,21 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     return "", "bridge" if quantifier_end == group_end or role == "bridge" else "break", body_start
 
 
-def _regex_has_adjacent_unbounded_atoms(pattern: str) -> bool:
+def _regex_has_adjacent_unbounded_atoms(pattern: str, depth: int = 0) -> bool:
     """True when ``pattern`` carries a run of more than ``_REGEX_ADJACENT_ATOM_MAX``
     back-to-back atoms that each take a backtracking unbounded quantifier and whose
     character sets overlap along the run -- every atom in such a run can cede characters to
-    its neighbour. Pure string analysis: nothing here runs the candidate against an input."""
+    its neighbour. A lookaround's body is scanned as a pattern of its own, bounded by
+    ``_REGEX_NESTED_SCAN_MAX`` so nested lookarounds cannot exhaust the stack. Pure string
+    analysis: nothing here runs the candidate against an input."""
     run: list[str] = []
     index = 0
     while index < len(pattern):
         atom, role, index = _regex_next_unit(pattern, index)
+        if role == "nested":
+            if depth < _REGEX_NESTED_SCAN_MAX and _regex_has_adjacent_unbounded_atoms(atom, depth + 1):
+                return True
+            continue
         if role == "bridge":
             continue
         if role != "run":

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -211,7 +211,12 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     ``(...)``/``(?:...)``/``(?P<n>...)`` is scanned through as if the parentheses were not
     there; one wrapping a single atom IS that atom when the quantifier sits outside it."""
     if pattern[index] == ")":
-        return "", "bridge", index + 1
+        quantifier_end, role = _regex_quantifier(pattern, index + 1)
+        return (
+            "",
+            "break" if role == "break" and quantifier_end > index + 1 else "bridge",
+            max(quantifier_end, index + 1),
+        )
     if pattern[index] != "(":
         if pattern[index] in "|^$*+?{}":
             return "", "break", index + 1
@@ -220,8 +225,10 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
         return pattern[index:atom_end], role, max(quantifier_end, atom_end)
 
     group_end = _regex_group_end(pattern, index)
+    closed = pattern[group_end - 1 : group_end] == ")"
     if pattern.startswith(("(?#", "(?=", "(?!", "(?<=", "(?<!"), index):
-        return "", "bridge", group_end
+        # Skipping an UNCLOSED construct would blind the scan to everything after it.
+        return "", "bridge" if closed else "break", group_end if closed else index + 2
     if pattern.startswith("(?P<", index):
         name_end = pattern.find(">", index)
         if name_end == -1:
@@ -234,15 +241,16 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     else:
         body_start = index + 1
     quantifier_end, role = _regex_quantifier(pattern, group_end)
-    if quantifier_end == group_end:
-        return "", "bridge", body_start  # unquantified: scan the body in place
     body = pattern[body_start : group_end - 1]
     # A quantified group repeats its body, so the body IS the run's atom -- one atom
     # (`(?:[a-z])+` is `[a-z]+`) or a plain sequence (`(ab)+(ab)+(ab)+` repeats too). A body
     # carrying its own group or alternation belongs to the shapes above instead.
     if role == "run" and body and not any(character in body for character in "()|"):
         return body, "run", quantifier_end
-    return "", "break" if role == "run" else role, quantifier_end
+    # Every other group is entered rather than skipped: parentheses hide a run from the
+    # reader, never from the engine. Only what the group does to its NEIGHBOURS varies --
+    # one that may match nothing cannot separate them; one that must match does.
+    return "", "bridge" if quantifier_end == group_end or role == "bridge" else "break", body_start
 
 
 def _regex_has_adjacent_unbounded_atoms(pattern: str) -> bool:

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -24,8 +24,10 @@ Probe usage: <pfb_python_interpreter()> pfb_dnsbl_regex_rules.py [1]
 from __future__ import annotations
 
 import re
+import string
 import sys
 import warnings
+from functools import lru_cache
 
 # Length ceiling (heuristic): a pattern over this many characters is dropped
 # at load ONLY when the opt-in "Limit long/complex regex" setting is enabled.
@@ -59,6 +61,22 @@ _REGEX_ADJACENT_GROUP_QUANTIFIER = re.compile(r"\([^()]*[+*][^()]*\)\([^()]*\)\s
 # group/atom (optionally already quantified) then two consecutive brace quantifiers.
 _REGEX_STACKED_BOUNDED_REPEAT = re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?:,\d*)?\}")
 
+# Adjacent unbounded quantifiers over OVERLAPPING atoms, grouped or not: [a-z]+[a-z]+[a-z]+,
+# ([a-z]+)([a-z]+)([a-z]+), \w+\w+\w+, a{2,}a{2,}a{2,}. Each atom can cede characters to its
+# neighbour, so a failing tail walks a partition of the matched span -- the mechanism the
+# group-keyed shapes above already cover, minus the parentheses they all key on. Measured
+# against a 253-character name (the longest the matcher can be handed): a run of 3 costs
+# 7 ms and a run of 4 costs 462 ms, versus 0.08 ms for a run of 2 -- so runs LONGER than
+# this bound are rejected and a pair stays admitted (a pair is what real host patterns use).
+_REGEX_ADJACENT_ATOM_MAX = 2
+
+# Character sets are compared by probing both atoms with one character at a time: this
+# alphabet only has to be big enough to separate the classes a domain pattern is written
+# over (letters, digits, punctuation, whitespace, non-ASCII word characters).
+_REGEX_OVERLAP_ALPHABET = string.printable + "é"
+
+_REGEX_OPEN_ENDED_REPEAT = re.compile(r"\{\d+,\}")
+
 # Complexity-budget backstop: cap the combined count of unbounded quantifiers (`+`/`*`,
 # unescaped) and alternations (`|`, unescaped) in one pattern. The structural regexes
 # above catch KNOWN bad shapes; this catches novel compositions of many quantifiers /
@@ -71,7 +89,8 @@ _REGEX_BUDGET_MAX = 12
 _REGEX_UNBOUNDED_QUANTIFIER = re.compile(r"(?<!\\)[+*]")
 _REGEX_ALTERNATION = re.compile(r"(?<!\\)\|")
 
-# The four structural shapes, tried in the order above.
+# The four regex-matched structural shapes, tried in the order above (the adjacent-atom
+# run below needs a scan rather than a pattern, so it is a predicate of its own).
 _REGEX_SHAPE_PATTERNS: tuple[re.Pattern[str], ...] = (
     _REGEX_NESTED_QUANTIFIER,
     _REGEX_ALTERNATION_OVERLAP,
@@ -80,9 +99,120 @@ _REGEX_SHAPE_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+def _regex_atom_end(pattern: str, index: int) -> int:
+    """End offset of the single-character atom starting at ``index`` -- a character class,
+    an escape, ``.``, or a literal. An unterminated class swallows the rest of the string."""
+    character = pattern[index]
+    if character == "\\":
+        marker = pattern[index + 1 : index + 2]
+        width = {"x": 2, "u": 4, "U": 8}.get(marker, 0)
+        if width:
+            end = index + 2 + width
+            if end <= len(pattern) and all(digit in string.hexdigits for digit in pattern[index + 2 : end]):
+                return end
+        # `\N{NAME}` is one atom; lowercase `\n{2,}` is a newline carrying a REPEAT.
+        elif marker == "N" and pattern[index + 2 : index + 3] == "{":
+            closing = pattern.find("}", index + 3)
+            if closing != -1:
+                return closing + 1
+        return min(index + 2, len(pattern))
+    if character != "[":
+        return index + 1
+    end = index + 1
+    if pattern[end : end + 1] == "^":
+        end += 1
+    if pattern[end : end + 1] == "]":
+        end += 1
+    while end < len(pattern):
+        if pattern[end] == "\\":
+            end += 2
+            continue
+        if pattern[end] == "]":
+            return end + 1
+        end += 1
+    return len(pattern)
+
+
+def _regex_backtracking_quantifier_end(pattern: str, index: int) -> int:
+    """End offset of a BACKTRACKING unbounded quantifier at ``index`` (``+``/``*``/``{m,}``,
+    optionally lazy), else ``index``. A possessive quantifier never gives characters back."""
+    end = index
+    if pattern[index : index + 1] in ("+", "*"):
+        end = index + 1
+    elif pattern[index : index + 1] == "{":
+        repeat = _REGEX_OPEN_ENDED_REPEAT.match(pattern, index)
+        if repeat is not None:
+            end = repeat.end()
+    if end == index:
+        return index
+    modifier = pattern[end : end + 1]
+    if modifier == "+":
+        return index
+    return end + 1 if modifier == "?" else end
+
+
+@lru_cache(maxsize=512)
+def _regex_atoms_overlap(first: str, second: str) -> bool:
+    """True when both atoms can match the same character, i.e. the pair is ambiguous."""
+    if first == second:
+        return True
+    try:
+        left = re.compile(first)
+        right = re.compile(second)
+    except re.error:
+        return False
+    return any(left.fullmatch(probe) and right.fullmatch(probe) for probe in _REGEX_OVERLAP_ALPHABET)
+
+
+def _regex_has_adjacent_unbounded_atoms(pattern: str) -> bool:
+    """True when ``pattern`` carries a run of more than ``_REGEX_ADJACENT_ATOM_MAX``
+    back-to-back atoms that each take a backtracking unbounded quantifier and whose
+    character sets overlap along the run. Plain ``(...)``/``(?:...)`` parentheses are
+    transparent -- they do not change what the engine backtracks over -- while a quantified
+    group, an alternation, or any other ``(?...)`` construct ends the run (the shapes above
+    own those). Pure string analysis: nothing here runs the candidate against an input."""
+    run: list[str] = []
+    index = 0
+    while index < len(pattern):
+        character = pattern[index]
+        if character == "(":
+            if pattern.startswith("(?:", index):
+                index += 3
+            elif pattern.startswith("(?", index):
+                run = []
+                index += 2
+            else:
+                index += 1
+            continue
+        if character == ")":
+            index += 1
+            if pattern[index : index + 1] in ("*", "+", "?", "{"):
+                run = []
+            continue
+        if character in "|^$*+?{}":
+            run = []
+            index += 1
+            continue
+        atom_end = _regex_atom_end(pattern, index)
+        atom = pattern[index:atom_end]
+        quantifier_end = _regex_backtracking_quantifier_end(pattern, atom_end)
+        if quantifier_end == atom_end:
+            run = []
+            index = atom_end
+            continue
+        run = [*run, atom] if not run or _regex_atoms_overlap(run[-1], atom) else [atom]
+        if len(run) > _REGEX_ADJACENT_ATOM_MAX:
+            return True
+        index = quantifier_end
+    return False
+
+
 def _regex_has_catastrophic_shape(pattern: str) -> bool:
-    """True when ``pattern`` matches any of the four structural shapes above."""
-    return any(shape.search(pattern) is not None for shape in _REGEX_SHAPE_PATTERNS)
+    """True when ``pattern`` matches any of the four structural shapes above or carries a
+    run of adjacent unbounded quantifiers over overlapping atoms."""
+    return _regex_has_adjacent_unbounded_atoms(pattern) or any(
+        shape.search(pattern) is not None for shape in _REGEX_SHAPE_PATTERNS
+    )
 
 
 def _regex_complexity_budget(pattern: str) -> int:

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -75,7 +75,7 @@ _REGEX_ADJACENT_ATOM_MAX = 2
 # over (letters, digits, punctuation, whitespace, non-ASCII word characters).
 _REGEX_OVERLAP_ALPHABET = string.printable + "é"
 
-_REGEX_OPEN_ENDED_REPEAT = re.compile(r"\{\d+,\}")
+_REGEX_REPEAT = re.compile(r"\{(?P<min>\d+)(?P<comma>,?)(?P<max>\d*)\}")
 
 # Complexity-budget backstop: cap the combined count of unbounded quantifiers (`+`/`*`,
 # unescaped) and alternations (`|`, unescaped) in one pattern. The structural regexes
@@ -133,22 +133,58 @@ def _regex_atom_end(pattern: str, index: int) -> int:
     return len(pattern)
 
 
-def _regex_backtracking_quantifier_end(pattern: str, index: int) -> int:
-    """End offset of a BACKTRACKING unbounded quantifier at ``index`` (``+``/``*``/``{m,}``,
-    optionally lazy), else ``index``. A possessive quantifier never gives characters back."""
+def _regex_quantifier(pattern: str, index: int) -> tuple[int, str]:
+    """Classify the quantifier at ``index`` as ``(end offset, role in a run)``:
+
+    "run"    -- backtracking and unbounded (`+`, `*`, `{m,}`, lazy forms): extends a run.
+    "bridge" -- can match nothing (`?`, `{0,n}`): cannot separate its neighbours, so it
+                neither extends nor ends a run.
+    "break"  -- absent, fixed (`{m}`, `{m,n}`), or possessive: ends the run. A possessive
+                quantifier never gives characters back, so it cannot partition a span.
+    """
     end = index
+    unbounded = True
     if pattern[index : index + 1] in ("+", "*"):
         end = index + 1
+        optional = pattern[index] == "*"
     elif pattern[index : index + 1] == "{":
-        repeat = _REGEX_OPEN_ENDED_REPEAT.match(pattern, index)
-        if repeat is not None:
-            end = repeat.end()
-    if end == index:
-        return index
+        repeat = _REGEX_REPEAT.match(pattern, index)
+        if repeat is None:
+            return index, "break"
+        end = repeat.end()
+        unbounded = repeat.group("max") == "" and repeat.group("comma") == ","
+        optional = repeat.group("min") == "0"
+    elif pattern[index : index + 1] == "?":
+        end = index + 1
+        unbounded = False
+        optional = True
+    else:
+        return index, "break"
     modifier = pattern[end : end + 1]
-    if modifier == "+":
-        return index
-    return end + 1 if modifier == "?" else end
+    if modifier == "+":  # possessive
+        return end + 1, "bridge" if optional else "break"
+    if modifier == "?":  # lazy
+        end += 1
+    return end, "run" if unbounded else ("bridge" if optional else "break")
+
+
+def _regex_group_end(pattern: str, index: int) -> int:
+    """End offset past the ``)`` closing the group that opens at ``index`` (the end of the
+    string when it is never closed). Parentheses inside a class or an escape do not count."""
+    depth = 0
+    while index < len(pattern):
+        character = pattern[index]
+        if character in ("\\", "["):
+            index = _regex_atom_end(pattern, index)
+            continue
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    return len(pattern)
 
 
 @lru_cache(maxsize=512)
@@ -157,61 +193,83 @@ def _regex_atoms_overlap(first: str, second: str) -> bool:
     if first == second:
         return True
     try:
-        left = re.compile(first)
-        right = re.compile(second)
+        # Warnings are suppressed for the same reason main() suppresses them: PHP turns
+        # every stderr line into an admin-facing validation error.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            left = re.compile(first)
+            right = re.compile(second)
     except re.error:
         return False
     return any(left.fullmatch(probe) and right.fullmatch(probe) for probe in _REGEX_OVERLAP_ALPHABET)
 
 
+def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
+    """Read one unit at ``index``, returning ``(atom, role, next index)`` with the roles of
+    ``_regex_quantifier``. A group contributes by what it does to the engine, not by its
+    punctuation: a comment or a lookaround consumes nothing and bridges; a plain
+    ``(...)``/``(?:...)``/``(?P<n>...)`` is scanned through as if the parentheses were not
+    there; one wrapping a single atom IS that atom when the quantifier sits outside it."""
+    if pattern[index] == ")":
+        return "", "bridge", index + 1
+    if pattern[index] != "(":
+        if pattern[index] in "|^$*+?{}":
+            return "", "break", index + 1
+        atom_end = _regex_atom_end(pattern, index)
+        quantifier_end, role = _regex_quantifier(pattern, atom_end)
+        return pattern[index:atom_end], role, max(quantifier_end, atom_end)
+
+    group_end = _regex_group_end(pattern, index)
+    if pattern.startswith(("(?#", "(?=", "(?!", "(?<=", "(?<!"), index):
+        return "", "bridge", group_end
+    if pattern.startswith("(?P<", index):
+        name_end = pattern.find(">", index)
+        if name_end == -1:
+            return "", "break", group_end
+        body_start = name_end + 1
+    elif pattern.startswith("(?:", index):
+        body_start = index + 3
+    elif pattern.startswith("(?", index):
+        return "", "break", group_end  # atomic, flags, conditionals: not a plain group
+    else:
+        body_start = index + 1
+    quantifier_end, role = _regex_quantifier(pattern, group_end)
+    if quantifier_end == group_end:
+        return "", "bridge", body_start  # unquantified: scan the body in place
+    body = pattern[body_start : group_end - 1]
+    # A quantified group repeats its body, so the body IS the run's atom -- one atom
+    # (`(?:[a-z])+` is `[a-z]+`) or a plain sequence (`(ab)+(ab)+(ab)+` repeats too). A body
+    # carrying its own group or alternation belongs to the shapes above instead.
+    if role == "run" and body and not any(character in body for character in "()|"):
+        return body, "run", quantifier_end
+    return "", "break" if role == "run" else role, quantifier_end
+
+
 def _regex_has_adjacent_unbounded_atoms(pattern: str) -> bool:
     """True when ``pattern`` carries a run of more than ``_REGEX_ADJACENT_ATOM_MAX``
     back-to-back atoms that each take a backtracking unbounded quantifier and whose
-    character sets overlap along the run. Plain ``(...)``/``(?:...)`` parentheses are
-    transparent -- they do not change what the engine backtracks over -- while a quantified
-    group, an alternation, or any other ``(?...)`` construct ends the run (the shapes above
-    own those). Pure string analysis: nothing here runs the candidate against an input."""
+    character sets overlap along the run -- every atom in such a run can cede characters to
+    its neighbour. Pure string analysis: nothing here runs the candidate against an input."""
     run: list[str] = []
     index = 0
     while index < len(pattern):
-        character = pattern[index]
-        if character == "(":
-            if pattern.startswith("(?:", index):
-                index += 3
-            elif pattern.startswith("(?", index):
-                run = []
-                index += 2
-            else:
-                index += 1
+        atom, role, index = _regex_next_unit(pattern, index)
+        if role == "bridge":
             continue
-        if character == ")":
-            index += 1
-            if pattern[index : index + 1] in ("*", "+", "?", "{"):
-                run = []
-            continue
-        if character in "|^$*+?{}":
+        if role != "run":
             run = []
-            index += 1
-            continue
-        atom_end = _regex_atom_end(pattern, index)
-        atom = pattern[index:atom_end]
-        quantifier_end = _regex_backtracking_quantifier_end(pattern, atom_end)
-        if quantifier_end == atom_end:
-            run = []
-            index = atom_end
             continue
         run = [*run, atom] if not run or _regex_atoms_overlap(run[-1], atom) else [atom]
         if len(run) > _REGEX_ADJACENT_ATOM_MAX:
             return True
-        index = quantifier_end
     return False
 
 
 def _regex_has_catastrophic_shape(pattern: str) -> bool:
     """True when ``pattern`` matches any of the four structural shapes above or carries a
     run of adjacent unbounded quantifiers over overlapping atoms."""
-    return _regex_has_adjacent_unbounded_atoms(pattern) or any(
-        shape.search(pattern) is not None for shape in _REGEX_SHAPE_PATTERNS
+    return any(shape.search(pattern) is not None for shape in _REGEX_SHAPE_PATTERNS) or (
+        _regex_has_adjacent_unbounded_atoms(pattern)
     )
 
 

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -143,6 +143,83 @@ class TestCatastrophicShapeHeuristic:
         for pat in (r"(a+)(a+)+", r"(a+)(b+)*", r"(\w+)(\d+)+$", r"^(x+)(y+)*\.example$"):
             assert _regex_is_catastrophic_shape(pat) is True, pat
 
+    def test_ungrouped_adjacent_quantifier_run_flagged(self) -> None:
+        # issue #2035: a run of back-to-back atoms that each carry an unbounded quantifier
+        # and whose character sets OVERLAP partitions the matched span the same way the
+        # grouped shapes do -- every atom can cede characters to its neighbour. The four
+        # group-keyed shapes above all miss it (no parentheses anywhere) and four
+        # quantifiers sit well under the complexity budget. Measured at the maximum DNS
+        # name length (253 characters, the longest input the matcher can ever be handed):
+        # three adjacent `[a-z]+` cost 7 ms per query and four cost 462 ms.
+        for pat in (
+            r"^[a-z]+[a-z]+[a-z]+[a-z]+@example\.com$",  # the issue's console reproduction
+            r"^[a-z]+[a-z]+[a-z]+\.example\.com$",
+            r"\w+\w+\w+",
+            r".*.*.*",
+            r"[a-z]+[a-z0-9]+[0-9a-z]+",  # overlap does not require identical atoms
+            r"^a{2,}a{2,}a{2,}$",  # `{m,}` is unbounded too
+            r"^[a-z]+?[a-z]+?[a-z]+?$",  # lazy quantifiers backtrack just as hard
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_grouped_adjacent_quantifier_run_flagged(self) -> None:
+        # The SAME shape wearing parentheses. Plain `(...)`/`(?:...)` groups do not change
+        # what the engine backtracks over, so `([a-z]+)([a-z]+)([a-z]+)` is the ungrouped
+        # run above -- and it is the more expensive form, measured at 1277 ms per query for
+        # four groups against a 253-character name (vs 462 ms ungrouped). No group-keyed
+        # shape above catches it: none of these carries a quantifier ON a group.
+        for pat in (
+            r"^([a-z]+)([a-z]+)([a-z]+)([a-z]+)@example\.com$",
+            r"^([a-z]+)([a-z]+)([a-z]+)\.example\.com$",
+            r"^(?:\w+)(?:\w+)(?:\w+)\.example$",
+            r"^[a-z]+(\w+)[a-z]+\.example$",  # grouped and ungrouped atoms in one run
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_adjacent_quantifiers_over_disjoint_atoms_not_flagged(self) -> None:
+        # Adjacency alone is NOT the danger: when neighbouring atoms cannot match the same
+        # character there is exactly ONE way to split the input, so the engine never
+        # backtracks (measured 0.00 ms at 253 characters for the four-atom row below).
+        # Rejecting these would silently drop legitimate feed entries.
+        for pat in (
+            r"^cdn[a-z]+[0-9]*\.example\.com$",
+            r"^[a-z]+[0-9]+[a-z]+[0-9]+@example\.com$",
+            r"^\w+\.\w+$",
+            r"^.+@.+$",  # a literal separator ends the run
+        ):
+            assert _regex_is_catastrophic_shape(pat) is False, pat
+
+    def test_two_adjacent_overlapping_quantifiers_not_flagged(self) -> None:
+        # The rule flags runs LONGER than _REGEX_ADJACENT_ATOM_MAX (2), because a pair
+        # splits the input linearly: measured 0.08 ms at the 253-character maximum, three
+        # orders of magnitude under the 100 ms eviction ceiling and under the 10 ms warn
+        # ceiling. A pair is the shape realistic host patterns actually use, so flagging it
+        # would cost false positives to buy no measurable safety.
+        for pat in (
+            r"^[a-z]+[a-z0-9-]*\.doubleclick\.net$",
+            r"^\w+\w+$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is False, pat
+
+    def test_non_backtracking_adjacent_quantifiers_not_flagged(self) -> None:
+        # A possessive quantifier (`a++`) never gives characters back, and a FIXED repeat
+        # (`a{3}`) has nothing to give -- neither can partition the span, so neither starts
+        # or continues a run.
+        for pat in (r"^[a-z]++[a-z]++[a-z]++$", r"^[a-z]{3}[a-z]{3}[a-z]{3}$"):
+            assert _regex_is_catastrophic_shape(pat) is False, pat
+
+    def test_newline_repeat_is_not_read_as_a_named_unicode_escape(self) -> None:
+        # `\N{...}` (capital N) is a named-Unicode escape whose braces are part of the
+        # atom; `\n{2,}` (lowercase) is a newline carrying an open-ended REPEAT. Reading
+        # the lowercase form as the escape swallows the quantifier and blinds the gate to
+        # the run -- and lowercase is what the gate actually sees, since both consumers
+        # lowercase every pattern before admission.
+        assert _regex_is_catastrophic_shape(r"\n{2,}\n{2,}\n{2,}") is True
+        # The capital-N form is ONE atom, so its quantified run is a run of three too --
+        # green here only if `\N{BULLET}` is consumed whole and `+` is read as its
+        # quantifier (mis-parsing the braces as a repeat breaks the run and returns False).
+        assert _regex_is_catastrophic_shape("\\N{BULLET}+\\N{BULLET}+\\N{BULLET}+") is True
+
     def test_stacked_bounded_repeat_flagged(self) -> None:
         # Two consecutive {m}/{m,n} repeats multiply -> a tiny source string explodes.
         for pat in (r"a{500}{500}", r"(x){500}{500}", r"[a-z]{50}{50}", r"\w{20}{20}$"):
@@ -159,8 +236,10 @@ class TestCatastrophicShapeHeuristic:
         # equals MAX exactly is the last admissible value (off-by-one guard: a `>=` regression
         # would flag this). Build a pattern whose budget is EXACTLY MAX -- `_REGEX_BUDGET_MAX`
         # unbounded `*` quantifiers, zero alternations, and no other catastrophic shape (no
-        # nested/adjacent quantified group, no stacked bounded repeat).
-        at_budget = "a*" * pfb_dnsbl_regex_rules._REGEX_BUDGET_MAX
+        # nested/adjacent quantified group, no stacked bounded repeat, and -- issue #2035 --
+        # no run of adjacent quantified atoms either, so the unquantified `b` separators
+        # keep every quantifier in a run of one).
+        at_budget = "a*b" * pfb_dnsbl_regex_rules._REGEX_BUDGET_MAX
         # Compute the budget the SAME way the code does and pin it to MAX before asserting.
         budget = len(pfb_dnsbl_regex_rules._REGEX_UNBOUNDED_QUANTIFIER.findall(at_budget)) + len(
             pfb_dnsbl_regex_rules._REGEX_ALTERNATION.findall(at_budget)

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -176,6 +176,51 @@ class TestCatastrophicShapeHeuristic:
         ):
             assert _regex_is_catastrophic_shape(pat) is True, pat
 
+    def test_zero_width_construct_does_not_split_a_run(self) -> None:
+        # A comment or a lookaround consumes NOTHING, so dropping one into the middle of a
+        # run leaves the engine backtracking over exactly the same span -- each row below
+        # is the issue's own reproduction plus one inert construct, and each still costs
+        # ~460 ms per query. Treating these as a run boundary would make the whole rule a
+        # one-token bypass.
+        for pat in (
+            r"^[a-z]+[a-z]+(?#c)[a-z]+[a-z]+@example\.com$",
+            r"^[a-z]+[a-z]+(?=a)[a-z]+[a-z]+@example\.com$",
+            r"^[a-z]+[a-z]+(?!b)[a-z]+[a-z]+@example\.com$",
+            r"^[a-z]+[a-z]+(?<=a)[a-z]+[a-z]+@example\.com$",
+            r"^[a-z]+[a-z]+(?<!b)[a-z]+[a-z]+@example\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_quantified_single_atom_group_counts_as_its_atom(self) -> None:
+        # `(?:[a-z])+` IS `[a-z]+` -- the group wraps one atom and the quantifier sits
+        # outside it. Measured at 475 ms per query for the four-group row, so a run spelled
+        # this way is the same defect, not a different one.
+        for pat in (
+            r"^(?:[a-z])+(?:[a-z])+(?:[a-z])+(?:[a-z])+@example\.com$",
+            r"^([a-z])+([a-z])+([a-z])+@example\.com$",
+            r"^(?P<a>\w)+(?P<b>\w)+(?P<c>\w)+@example\.com$",
+            # A group body wider than one atom repeats the same way: measured 238 ms per
+            # query for the four-group row against a matching 253-character name.
+            r"^(ab)+(ab)+(ab)+@example\.com$",
+            r"^(?:ab)+(?:ab)+(?:ab)+(?:ab)+@example\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_quantified_group_run_over_distinct_bodies_not_flagged(self) -> None:
+        # Two quantified groups only partition the span when they can consume the same
+        # input; `(ab)+(cd)+` has exactly one way to split, so it stays admitted.
+        assert _regex_is_catastrophic_shape(r"^(ab)+(cd)+(ef)+@example\.com$") is False
+
+    def test_optional_atom_does_not_split_a_run(self) -> None:
+        # An atom that may match nothing cannot separate its neighbours: when it matches
+        # empty the runs on either side are one run, and the engine explores that partition
+        # too (measured 7.8 ms per query, over the warn ceiling and under the evict one).
+        assert _regex_is_catastrophic_shape(r"^[a-z]+[a-z]+x?[a-z]+@example\.com$") is True
+        assert _regex_is_catastrophic_shape(r"^[a-z]+[a-z]+(?P<g>x?)[a-z]+[a-z]+@example\.com$") is True
+        # …but an optional atom only BRIDGES a run, it never starts or extends one: the
+        # canonical `ads?` shape keeps its two quantifiers in runs of one.
+        assert _regex_is_catastrophic_shape(r"^ads?[0-9]*\.example\.(com|net)$") is False
+
     def test_adjacent_quantifiers_over_disjoint_atoms_not_flagged(self) -> None:
         # Adjacency alone is NOT the danger: when neighbouring atoms cannot match the same
         # character there is exactly ONE way to split the input, so the engine never
@@ -205,19 +250,21 @@ class TestCatastrophicShapeHeuristic:
         # A possessive quantifier (`a++`) never gives characters back, and a FIXED repeat
         # (`a{3}`) has nothing to give -- neither can partition the span, so neither starts
         # or continues a run.
-        for pat in (r"^[a-z]++[a-z]++[a-z]++$", r"^[a-z]{3}[a-z]{3}[a-z]{3}$"):
+        # The middle row is the discriminating one: its first two atoms already form a run,
+        # so it stays admitted ONLY because the possessive third atom is refused entry.
+        for pat in (r"^[a-z]++[a-z]++[a-z]++$", r"^[a-z]+[a-z]+[a-z]++$", r"^[a-z]{3}[a-z]{3}[a-z]{3}$"):
             assert _regex_is_catastrophic_shape(pat) is False, pat
 
     def test_newline_repeat_is_not_read_as_a_named_unicode_escape(self) -> None:
-        # `\N{...}` (capital N) is a named-Unicode escape whose braces are part of the
-        # atom; `\n{2,}` (lowercase) is a newline carrying an open-ended REPEAT. Reading
-        # the lowercase form as the escape swallows the quantifier and blinds the gate to
-        # the run -- and lowercase is what the gate actually sees, since both consumers
-        # lowercase every pattern before admission.
+        # The two spellings are different regexes and each pins one half of the scanner.
+        # Lowercase `\n{2,}` is a newline carrying an open-ended REPEAT; reading it as the
+        # named-Unicode escape swallows the quantifier and blinds the gate to the run. This
+        # is the spelling the gate meets in production, because both consumers lowercase a
+        # pattern before admission (that fold is itself a defect -- issue #2079).
         assert _regex_is_catastrophic_shape(r"\n{2,}\n{2,}\n{2,}") is True
-        # The capital-N form is ONE atom, so its quantified run is a run of three too --
-        # green here only if `\N{BULLET}` is consumed whole and `+` is read as its
-        # quantifier (mis-parsing the braces as a repeat breaks the run and returns False).
+        # Capital-N `\N{BULLET}` IS the named escape and is ONE atom, so its quantified run
+        # is a run of three too -- green here only if the braces are consumed as part of the
+        # atom and `+` is read as its quantifier, the exact opposite parse from the row above.
         assert _regex_is_catastrophic_shape("\\N{BULLET}+\\N{BULLET}+\\N{BULLET}+") is True
 
     def test_stacked_bounded_repeat_flagged(self) -> None:

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -234,6 +234,24 @@ class TestCatastrophicShapeHeuristic:
         # so its atoms never join the outer run.
         assert _regex_is_catastrophic_shape(r"^(?=.*ad)[a-z]+[a-z]+\.example$") is False
         assert _regex_is_catastrophic_shape(r"^(?=[a-z]+)[a-z]+[a-z]+\.example$") is False
+        # A COMMENT is inert text rather than a pattern, so what looks like a run inside one
+        # is not a run at all and must not be read as one.
+        assert _regex_is_catastrophic_shape(r"^(?#[a-z]+[a-z]+[a-z]+)x$") is False
+
+    def test_nested_lookaround_scan_stops_at_its_depth_bound(self) -> None:
+        # The recursion into lookaround bodies is bounded so a hostile line cannot exhaust
+        # the stack. Pin the ceiling from BOTH sides: a run at the deepest scanned nesting is
+        # still found, and one nested a level deeper is deliberately not looked for -- which
+        # is the documented cost of the bound, not an accident.
+        run = "[a-z]+[a-z]+[a-z]+"
+        at_bound = "(?=" * pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX + run
+        past_bound = "(?=" * (pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX + 1) + run
+        assert _regex_is_catastrophic_shape(at_bound + ")" * pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX) is True
+        assert (
+            _regex_is_catastrophic_shape(past_bound + ")" * (pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX + 1)) is False
+        )
+        # Nesting far past the bound is answered rather than crashing the load path.
+        assert _regex_is_catastrophic_shape("(?=" * 5000 + "a" + ")" * 5000) is False
 
     def test_quantified_group_run_over_distinct_bodies_not_flagged(self) -> None:
         # Two quantified groups only partition the span when they can consume the same

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -220,6 +220,21 @@ class TestCatastrophicShapeHeuristic:
         # An optional group of literals is still just a literal prefix.
         assert _regex_is_catastrophic_shape(r"^(www\.)?ads?\.example\.com$") is False
 
+    def test_lookaround_body_is_scanned_for_a_run_of_its_own(self) -> None:
+        # A lookaround consumes nothing, so it bridges the run around it -- but the engine
+        # still backtracks over what is INSIDE it (measured 18.5 ms at 110 characters), so
+        # its body is scanned on its own terms rather than skipped with the construct.
+        for pat in (
+            r"^(?=([a-z]+[a-z]+[a-z]+[a-z]+x))\@example\.com$",
+            r"^(?!(\w+\w+\w+y))[a-z]+\.example$",
+            r"^(?<=([a-z]+[a-z]+[a-z]+))x$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+        # A lookahead body is NOT adjacent to what follows it -- it matches no characters --
+        # so its atoms never join the outer run.
+        assert _regex_is_catastrophic_shape(r"^(?=.*ad)[a-z]+[a-z]+\.example$") is False
+        assert _regex_is_catastrophic_shape(r"^(?=[a-z]+)[a-z]+[a-z]+\.example$") is False
+
     def test_quantified_group_run_over_distinct_bodies_not_flagged(self) -> None:
         # Two quantified groups only partition the span when they can consume the same
         # input; `(ab)+(cd)+` has exactly one way to split, so it stays admitted.

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -206,6 +206,20 @@ class TestCatastrophicShapeHeuristic:
         ):
             assert _regex_is_catastrophic_shape(pat) is True, pat
 
+    def test_group_body_is_scanned_for_a_run_of_its_own(self) -> None:
+        # Wrapping a run in a group hides it from nothing: the engine still backtracks over
+        # the body (measured 24.8 ms at 81 characters for the first row, doubling every ten
+        # further characters). Whatever a group does to its NEIGHBOURS, its body is scanned.
+        for pat in (
+            r"^([a-z]+[a-z]+[a-z]+[a-z]+)?@example\.com$",
+            r"^([a-z]+(x)?[a-z]+[a-z]+[a-z]+)+@example\.com$",
+            r"^(?:[a-z]+[a-z]+[a-z]+){0,3}@example\.com$",
+            r"^[a-z]+([a-z]+)?[a-z]+[a-z]+@example\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+        # An optional group of literals is still just a literal prefix.
+        assert _regex_is_catastrophic_shape(r"^(www\.)?ads?\.example\.com$") is False
+
     def test_quantified_group_run_over_distinct_bodies_not_flagged(self) -> None:
         # Two quantified groups only partition the span when they can consume the same
         # input; `(ab)+(cd)+` has exactly one way to split, so it stays admitted.

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -82,7 +82,10 @@ def test_main_reports_only_its_own_diagnostics_for_a_pattern_that_warns() -> Non
     """
     # Line 1 warns but compiles (accepted); line 2 is a genuine rejection, so the
     # process exits 1 and PHP reads stderr -- the case where a leak would surface.
-    proc = run_probe(b"[[a]]\n(a+)+\n", "0")
+    # Line 1 also carries two DIFFERENT quantified atoms, which is what drives the shape
+    # gate's atom-overlap probe to compile a fragment of its own: the leak has two possible
+    # sources now, and neither may reach the admin.
+    proc = run_probe(b"[[a]+[c]+x\n(a+)+\n", "0")
     assert proc.returncode == 1
     assert proc.stderr.decode("utf-8").splitlines() == ["line 2: '(a+)+': catastrophic-backtracking shape"], proc.stderr
 

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -146,6 +146,55 @@ def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
     assert any(not _regex_is_catastrophic_shape(pattern) for pattern in corpus)
 
 
+def test_probe_and_resolver_both_reject_an_adjacent_quantifier_run() -> None:
+    """issue #2035: the shape gate's structural rules all keyed on a parenthesised group,
+    so a run of ungrouped adjacent quantified atoms reached BOTH consumers unflagged --
+    the save-time probe returned 0 and the resolver's load-time gate returned False.
+
+    The rule lives in the one shared module, so this drives both surfaces the way they are
+    really used: ``main()`` through a subprocess (what pfb_dnsbl_regex_validation_errors()
+    runs) and the composed predicate (what pfb_unbound.py imports).
+    """
+    from pfb_dnsbl_regex_rules import _regex_is_catastrophic_shape
+
+    pattern = r"^[a-z]+[a-z]+[a-z]+[a-z]+@example\.com$"
+    assert _regex_is_catastrophic_shape(pattern) is True
+
+    proc = run_probe((pattern + "\n").encode("utf-8"), "1")
+    assert proc.returncode == 1, f"probe admitted {pattern!r}"
+    assert proc.stderr.decode("utf-8").splitlines() == [f"line 1: {pattern!r}: catastrophic-backtracking shape"], (
+        proc.stderr
+    )
+
+
+def test_shape_gate_stays_total_on_malformed_pattern_fragments() -> None:
+    """The gate reads the pattern STRING before anything compiles it, so it is handed
+    fragments ``re`` itself would reject -- an unterminated class, a dangling backslash, a
+    half-written repeat. Each must return a verdict rather than raise, or a single bad feed
+    line becomes an unhandled exception on the resolver's load path."""
+    from pfb_dnsbl_regex_rules import _regex_is_catastrophic_shape
+
+    for fragment in (
+        "",
+        "[a-z",
+        "[^",
+        "[]",
+        "\\",
+        "\\x",
+        "\\u00",
+        "\\N{",
+        "a{",
+        "a{2,",
+        "**",
+        "((((",
+        ")+",
+        "(?",
+        "[a-z]+" * 500,
+        "a" * 5000 + "+",
+    ):
+        assert isinstance(_regex_is_catastrophic_shape(fragment), bool), fragment
+
+
 def test_main_treats_crlf_terminated_lines_like_lf() -> None:
     """A regex-list body with CRLF line endings splits into the same lines (and
     reports the same line numbers) as an LF-only body."""

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -196,6 +196,11 @@ def test_shape_gate_stays_total_on_malformed_pattern_fragments() -> None:
         "a" * 5000 + "+",
     ):
         assert isinstance(_regex_is_catastrophic_shape(fragment), bool), fragment
+    # A construct that is never closed must not swallow the rest of the scan: such a pattern
+    # cannot compile, so it never reaches the resolver, but the gate still reads what is
+    # there rather than going blind from the first `(?#` onwards.
+    assert _regex_is_catastrophic_shape(r"(?#x\w+\w+\w+") is True
+    assert _regex_is_catastrophic_shape(r"(?=a\w+\w+\w+") is True
 
 
 def test_main_treats_crlf_terminated_lines_like_lf() -> None:


### PR DESCRIPTION
## What changed

`_regex_is_catastrophic_shape()` gains a fifth structural shape in the shared admission
module: a run of more than `_REGEX_ADJACENT_ATOM_MAX` (2) back-to-back atoms that each carry
a *backtracking* unbounded quantifier and whose character sets **overlap along the run** is
rejected.

## The blind spot, and its class

All four existing shapes key on a parenthesised group (`\([^()]*…\)`), so a run of adjacent
unbounded quantifiers with no group involved fell through to the complexity budget — where
four quantifiers sit well under the threshold of 12. The class is not the one literal in the
issue; measured with `re.search` against a 253-character name (the longest input the matcher
can ever be handed), a failing tail:

| pattern | cost per query | before |
| --- | --- | --- |
| `^[a-z]+[a-z]+[a-z]+@example\.com$` | 7 ms | admitted |
| `^[a-z]+[a-z]+[a-z]+[a-z]+@example\.com$` (the issue's reproduction) | 462 ms | admitted |
| `^([a-z]+)([a-z]+)([a-z]+)([a-z]+)@example\.com$` | 1277 ms | admitted |
| `^[a-z]+[a-z]+(?#c)[a-z]+[a-z]+@example\.com$` | 464 ms | admitted |
| `^(?:[a-z])+(?:[a-z])+(?:[a-z])+(?:[a-z])+@example\.com$` | 475 ms | admitted |
| `^[a-z]+[a-z]+(?P<g>x?)[a-z]+[a-z]+@example\.com$` | 475 ms | admitted |
| `^(ab)+(ab)+(ab)+(ab)+@example\.com$` | 238 ms | admitted |
| `^[a-z]+[a-z0-9-]*\.doubleclick\.net$` (run of 2) | 0.08 ms | admitted, still admitted |
| `^[a-z]+[0-9]+[a-z]+[0-9]+@example\.com$` (disjoint) | 0.00 ms | admitted, still admitted |

Every "admitted" row above except the last two is now rejected. Three properties drove the
rule's shape, and the first two are why the first attempt at this fix was wrong:

- **Punctuation is not the boundary of the defect — backtracking behaviour is.** Each unit is
  classified by what it does to the engine: a comment or a lookaround consumes nothing and
  therefore *bridges* a run; an atom that may match nothing (`x?`, `{0,3}`) bridges it too,
  because when it matches empty its neighbours are one run; a plain `(...)`/`(?:...)`/
  `(?P<n>...)` is scanned through as if the parentheses were absent; and a quantified group IS
  its body repeated, so `(?:[a-z])+` is `[a-z]+` and `(ab)+(ab)+(ab)+` is a run of three. A
  possessive (`++`) or fixed (`{3}`) repeat still ends a run — neither can partition a span.
  Ending a run on punctuation instead left the rule evadable by inserting the five-character
  comment `(?#c)` into the issue's own pattern, at an unchanged 464 ms per query.
- **Adjacency alone is not the defect — overlap is.** Neighbouring atoms that cannot match the
  same character admit exactly one split of the input, so the engine never backtracks (0.00 ms
  above). Rejecting those would silently drop legitimate feed entries such as
  `^cdn[a-z]+[0-9]*\.example\.com$` or `^(ab)+(cd)+(ef)+@example\.com$`.
- **The bound sits at 2 rather than 3 on measured evidence.** A run of 3 costs 7 ms per query,
  which is **under the 100 ms eviction ceiling**, so ADR-07's runtime warn/evict layer — the
  bounded residual that backstops this gate — would log it and then keep it forever. A run of
  2 costs 0.08 ms, three orders of magnitude under that ceiling, and is the shape real host
  patterns actually use.

A body carrying its own group or alternation still belongs to the four shapes above, which
already flag `(a+)+`, `(a|a)+` and `(a+)(b+)*`.

## Is anything legitimate now rejected?

Measured rather than asserted:

- 41 regex rows from the ADR-07/DNSBL feed corpora plus ~1,230 regex-shaped literals across
  the test suites: **23 verdict changes, 22 of them the deliberate ReDoS exemplars added by
  this PR**; zero feed-corpus rows changed verdict.
- 25 hand-written realistic DNSBL/ABP idioms (`^(.+\.)?ads?[0-9]*\.example\.(com|net|org)$`,
  `^.+@.+$`, `^(?i)ADS\.example\.com$`, `^(?=.*ad)[a-z.]+$`, `^[0-9a-f]{8}\.example\.net$`, …):
  none newly rejected.
- Differential fuzz, 439,304 patterns built from regex building blocks (now including the
  group, lookaround, comment, possessive and lazy spellings): **zero** patterns the old gate
  rejected and the new gate admits — the change is strictly additive — **zero** exceptions, and
  no non-termination.

The trade-offs, stated plainly rather than buried:

1. A run of two overlapping atoms (`[a-z]+[a-z0-9]*`) stays admitted at a measured 0.08 ms.
   That is a deliberate floor, not an oversight.
2. The bridging rule costs one false-positive shape: a run separated only by optional atoms
   over sets that overlap cheaply in practice — the one non-exemplar literal in the sweep was
   `^\s*key:\s*(.+?),?\s*$` (a config-parser regex from a test helper, not a feed row), which
   measures 0.007 ms and would now be refused if someone entered it as a DNSBL pattern. The
   same rule is what catches the 475 ms nullable-group row, so it stays; DNS names carry no
   whitespace, which is what makes that shape implausible as a real blocklist entry.
3. A group is now ENTERED rather than skipped, so a run wrapped in an optional group
   (`^([a-z]+[a-z]+[a-z]+[a-z]+)?@example\.com$`, 24.8 ms at 81 characters and doubling every
   ten further characters) is rejected along with the ungrouped spelling.
4. A lookaround still bridges the run around it — it consumes nothing — but its BODY is now
   scanned as a pattern of its own, so a run hidden inside `(?=…)` (18.5 ms at 110 characters)
   is rejected too. The recursion is depth-bounded; a `(?#…)` comment stays skipped, since its
   contents are inert text rather than a pattern.
5. Patterns whose negated class escapes are mangled by the pre-existing lowercasing of every
   stored pattern (`\W`→`\w`, `\S`→`\s`) can now be rejected for the *mangled* form's shape.
   The root cause is filed separately as #2079; this gate correctly judges the string the
   engine would actually compile.

No bypass, opt-out, or setting was added; the gate is still unconditional and still pure string
analysis — the atom-overlap probe compiles single-atom fragments only and matches them against a
fixed 101-character alphabet, never the candidate pattern against an input.

## Both consumers

The rule lands in `pfb_dnsbl_regex_rules.py`, imported by `pfb_unbound.py` and executed
standalone by `pfblockerng_extra.inc`'s save-time probe (#1765), so one edit reaches both.
Verified on both surfaces: the issue's console reproduction now exits 1 with
`catastrophic-backtracking shape`, `_regex_is_catastrophic_shape` returns `True`, the existing
`test_probe_and_resolver_agree_on_every_admission_verdict` parity test stays green, and
`vendor/bin/phpunit --filter DnsblRegexEntryError` (the PHP suite that drives the probe end to
end) passes 59/59.

## Verification

- **Red → green, test-first.** Reproduction tests authored and executed RED against the
  untouched module: 11 failed, 40 passed, failing on the adjacency verdict. Frozen
  byte-identical (`git hash-object`: `5cda0f4f694d9c2a6b29bc9819a7d81f3154374a` for
  `tests/test_adr07_regex_safety.py`, `3001a72ab9e759da4dbb08dbde5821ea96e18813` for
  `tests/test_pfb_dnsbl_regex_rules.py`) and re-run GREEN with zero edits: 51 passed.
- `scripts/agent/run-gates.sh --diff origin/devel`: pytest, `ruff check`, `ruff format
  --check`, `mypy tests/` — all PASS.
- `benchmarks/spike_adr07_regex.py` (the repo's manual-only ReDoS kill-gate) run locally:
  `VERDICT: GO (with mitigations)`, exit 0.
- Gate self-cost on hostile input: a 6,000-character adversarial pattern costs 1.1 ms of gate
  time (the atom-overlap probe is memoised with `lru_cache`; it was 14 ms without).

One existing fixture changed: `test_complexity_budget_at_threshold_not_flagged` built its
exactly-at-budget pattern as `"a*" * 12`, which is itself a 12-atom adjacent run. It now uses
`"a*b" * 12`, keeping the fixture's stated purpose (the strict `>` off-by-one guard on the
budget) intact — the test still computes the budget and pins it to `_REGEX_BUDGET_MAX` before
asserting.

## Relationship to #2067

#2067 targets this same issue from a parallel session. It is not superseded on style but on
measured behaviour: it admits `^([a-z]+)([a-z]+)([a-z]+)([a-z]+)@example\.com$` (1277 ms/query,
among the most expensive rows in the table above) while rejecting `[a-z]+[0-9]+` and
`^cdn[a-z]+[0-9]*\.example\.com$` (0.00 ms/query, legitimate feed shapes). Its two open Copilot
findings — `\n{...}` being read as a named-Unicode escape, and the probe-consistency cases that
do not survive the probe's lowercasing — are covered here by
`test_newline_repeat_is_not_read_as_a_named_unicode_escape` and by driving the probe through its
real subprocess entry point.

## Deliberately NOT fixed here

A mandatory unquantified atom whose character set overlaps its neighbours
(`^[a-z]+[a-z]+a[a-z]+[a-z]+@x\.com$`, 25.7 ms per query at 121 characters, and the
`(?(1)a|b)` conditional spelling of the same shape) is still treated as a run boundary. That
is the neighbouring family — a mandatory atom sitting IN the gap rather than nothing sitting
there — and it is pre-existing: `origin/devel` and both earlier commits on this branch admit it
too. Filed as #2082 with its measurements rather than widened into this PR, because the
discriminator is not run length (`^[a-z]+x[a-z]+y[a-z]+@x\.com$` has the same run length and
costs 0.00 ms) and getting it wrong costs false positives.

Fixes #2035

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
