### PR TITLE
tests: prove lock ordering with events (#1994)

### DIFF
--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -77,6 +77,34 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			static fn(string $path): bool => preg_match('/pfb_py_raw\.[0-9a-f]{32}$/D', $path) === 1));
 	}
 
+	private function readEvent(mixed $stream, string $awaited, bool $child = FALSE): string
+	{
+		$line = @fgets($stream);
+		if ($line !== FALSE) {
+			if (str_starts_with($line, 'SALVAGE_EXPIRED ')) {
+				$this->fail(trim(substr($line, strlen('SALVAGE_EXPIRED '))));
+			}
+			return $line;
+		}
+		$message = "salvage cap expired / stuck or environment: awaiting {$awaited}";
+		if ($child) {
+			@fwrite($stream, "SALVAGE_EXPIRED {$message}\n");
+			exit(2);
+		}
+		$meta = stream_get_meta_data($stream);
+		$reason = ($meta['timed_out'] ?? FALSE) ? 'timeout' : (feof($stream) ? 'EOF' : 'read failure');
+		$this->fail("{$message} ({$reason})");
+	}
+
+	private function expectChildEvent(mixed $stream, string $expected, string $awaited): void
+	{
+		$event = trim($this->readEvent($stream, $awaited, TRUE));
+		if ($event !== $expected) {
+			@fwrite($stream, "EVENT_ERROR awaiting {$awaited}; expected {$expected}; got {$event}\n");
+			exit(2);
+		}
+	}
+
 	private function assertContendedOperationTimesOut(callable $operation): void
 	{
 		$manifestBefore = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
@@ -92,15 +120,21 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			if ($holderPid === 0) {
 				fclose($holderParent);
 				$lock = pfb_unbound_py_publication_lock();
+				if (!is_resource($lock)) {
+					fwrite($holderChild, "HOLDER_ERROR\n");
+					fclose($holderChild);
+					exit(1);
+				}
 				fwrite($holderChild, "LOCKED\n");
-				fgets($holderChild);
+				$this->expectChildEvent($holderChild, 'RELEASE', 'publication holder release');
 				pfb_unbound_py_publication_unlock($lock);
+				fwrite($holderChild, "UNLOCKED\n");
 				fclose($holderChild);
 				exit(0);
 			}
 			$this->assertGreaterThan(0, $holderPid);
 			fclose($holderChild);
-			$this->assertSame("LOCKED\n", fgets($holderParent));
+			$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'publication holder acquisition'));
 
 			[$operationParent, $operationChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 			stream_set_timeout($operationParent, 5);
@@ -108,29 +142,33 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			$operationPid = pcntl_fork();
 			if ($operationPid === 0) {
 				fclose($operationParent);
-				$started = microtime(TRUE);
 				$ok = $operation();
-				fwrite($operationChild, json_encode([
-					'ok' => $ok,
-					'elapsed' => microtime(TRUE) - $started,
-				]) . "\n");
+				fwrite($operationChild, "RESULT\n");
+				fwrite($operationChild, json_encode(['ok' => $ok]) . "\n");
 				fclose($operationChild);
 				exit(0);
 			}
 			$this->assertGreaterThan(0, $operationPid);
 			fclose($operationChild);
 
-			$read = [$operationParent];
-			$write = NULL;
-			$except = NULL;
-			$this->assertSame(1, stream_select($read, $write, $except, 1),
-				'contended interactive operation exceeded its bounded lock wait');
-			$result = json_decode((string) fgets($operationParent), TRUE);
+			$this->assertSame("RESULT\n", $this->readEvent($operationParent, 'contended operation verdict'));
+			$result = json_decode($this->readEvent($operationParent, 'contended operation result'), TRUE);
 			$this->assertIsArray($result);
-			$this->assertFalse($result['ok'], 'contended interactive operation must skip mutation');
-			$this->assertLessThan(1.0, $result['elapsed'], 'contended lock wait exceeded its deadline margin');
+			$this->assertArrayHasKey('ok', $result);
+			$this->assertFalse($result['ok'], 'contended interactive operation must publish a false skip verdict');
 			$this->assertSame($manifestBefore, file_get_contents($GLOBALS['pfb']['unbound_py_sources']),
 				'lock timeout must not mutate the published manifest');
+			fwrite($holderParent, "RELEASE\n");
+			$this->assertSame("UNLOCKED\n", $this->readEvent($holderParent, 'publication holder unlock'));
+			fclose($holderParent);
+			pcntl_waitpid($holderPid, $holderStatus);
+			$holderPid = NULL;
+			pcntl_waitpid($operationPid, $operationStatus);
+			$operationPid = NULL;
+			$this->assertTrue(pcntl_wifexited($holderStatus) && pcntl_wexitstatus($holderStatus) === 0,
+				'publication holder must exit cleanly after the release event');
+			$this->assertTrue(pcntl_wifexited($operationStatus) && pcntl_wexitstatus($operationStatus) === 0,
+				'contended operation must exit cleanly after publishing its verdict');
 		} finally {
 			if (is_resource($holderParent)) {
 				@fwrite($holderParent, "RELEASE\n");
@@ -303,15 +341,20 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			if ($holderPid === 0) {
 				fclose($holderParent);
 				$lock = pfb_unbound_py_publication_lock();
+				if (!is_resource($lock)) {
+					fwrite($holderChild, "HOLDER_ERROR\n");
+					fclose($holderChild);
+					exit(1);
+				}
 				fwrite($holderChild, "LOCKED\n");
-				fgets($holderChild);
+				$this->expectChildEvent($holderChild, 'RELEASE', 'scalar patch holder release');
 				pfb_unbound_py_publication_unlock($lock);
 				fclose($holderChild);
 				exit(0);
 			}
 			$this->assertGreaterThan(0, $holderPid);
 			fclose($holderChild);
-			$this->assertSame("LOCKED\n", fgets($holderParent));
+			$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'scalar patch holder acquisition'));
 
 			[$patchParent, $patchChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 			stream_set_timeout($patchParent, 5);
@@ -320,21 +363,36 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			if ($patchPid === 0) {
 				fclose($patchParent);
 				fwrite($patchChild, "ATTEMPT\n");
-				$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example']);
+				$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example'], [
+					'lock' => function () use ($patchChild) {
+						$lockPath = dirname($GLOBALS['pfb']['unbound_py_sources']) . '/pfb_py_sources.lock';
+						$probe = @fopen($lockPath, 'c');
+						$wouldBlock = 0;
+						$contended = $probe !== FALSE
+							&& !@flock($probe, LOCK_EX | LOCK_NB, $wouldBlock)
+							&& $wouldBlock === 1;
+						if (!$contended) {
+							fwrite($patchChild, "PROBE_FAILED\n");
+							if (is_resource($probe)) {
+								fclose($probe);
+							}
+							return FALSE;
+						}
+						fwrite($patchChild, "CONTENDED\n");
+						fclose($probe);
+						return pfb_unbound_py_publication_lock(0.25);
+					},
+				]);
 				fwrite($patchChild, $ok ? "DONE\n" : "FAILED\n");
 				fclose($patchChild);
 				exit($ok ? 0 : 1);
 			}
 			$this->assertGreaterThan(0, $patchPid);
 			fclose($patchChild);
-			$this->assertSame("ATTEMPT\n", fgets($patchParent));
-			$read = [$patchParent];
-			$write = NULL;
-			$except = NULL;
-			$this->assertSame(0, stream_select($read, $write, $except, 0, 200000),
-				'patch completed before the publication lock was released');
+			$this->assertSame("ATTEMPT\n", $this->readEvent($patchParent, 'scalar patch attempt'));
+			$this->assertSame("CONTENDED\n", $this->readEvent($patchParent, 'scalar patch lock contention'));
 			fwrite($holderParent, "RELEASE\n");
-			$this->assertSame("DONE\n", fgets($patchParent));
+			$this->assertSame("DONE\n", $this->readEvent($patchParent, 'scalar patch completion'));
 			pcntl_waitpid($holderPid, $holderStatus);
 			$holderPid = NULL;
 			pcntl_waitpid($patchPid, $patchStatus);
@@ -519,35 +577,33 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		}
 
 		$lockPath   = dirname($GLOBALS['pfb']['unbound_py_sources']) . '/pfb_py_sources.lock';
-		$markerPath = "{$this->tmp}/publock_timeout.marker";
+		[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		stream_set_timeout($holderParent, 5);
+		stream_set_timeout($holderChild, 5);
 		$pid = pcntl_fork();
 		if ($pid === -1) {
 			$this->markTestSkipped('pcntl_fork() failed.');
 		}
 		if ($pid === 0) {
+			fclose($holderParent);
 			$fp = fopen($lockPath, 'c');
 			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
 				exit(1);	// never signal readiness without a REAL hold -- the parent
 					// would then run with no contention and a negative assertion
 					// ("no dispatch", "entry survived") would pass for the wrong reason
 			}
-			touch($markerPath);
-			usleep(400000);
+			fwrite($holderChild, "LOCKED\n");
+			$this->expectChildEvent($holderChild, 'RELEASE', 'publication timeout holder release');
 			flock($fp, LOCK_UN);
 			fclose($fp);
+			fwrite($holderChild, "UNLOCKED\n");
+			fclose($holderChild);
 			exit(0);
 		}
-		$deadline = microtime(TRUE) + 2.0;
-		while (!file_exists($markerPath)) {
-			if (microtime(TRUE) >= $deadline) {
-				pcntl_waitpid($pid, $waitStatus);
-				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
-			}
-			usleep(1000);
-		}
+		fclose($holderChild);
+		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'publication timeout holder acquisition'));
 
 		$result = pfb_unbound_py_publication_lock(0.15);
-		pcntl_waitpid($pid, $waitStatus);
 
 		$this->assertFalse($result, 'a contended publication lock acquire past its own budget must return FALSE');
 
@@ -557,5 +613,11 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$this->assertStringNotContainsString('DNSBL publication lock unavailable', $log,
 			'a genuine expiry must NOT log "unavailable" -- that string is reserved for a real flock() '
 			. 'error or an fopen() failure, never a mere timeout');
+		fwrite($holderParent, "RELEASE\n");
+		$this->assertSame("UNLOCKED\n", $this->readEvent($holderParent, 'publication timeout holder release'));
+		fclose($holderParent);
+		pcntl_waitpid($pid, $waitStatus);
+		$this->assertTrue(pcntl_wifexited($waitStatus) && pcntl_wexitstatus($waitStatus) === 0,
+			'publication timeout holder must exit cleanly after the release event');
 	}
 }

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -115,6 +115,41 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		}
 	}
 
+	private function cleanupPublicationHolder(?int &$pid, mixed &$parent, ?Throwable &$cleanupError): void
+	{
+		if (is_resource($parent)) {
+			@fwrite($parent, "RELEASE\n");
+			try {
+				$event = trim($this->readEvent($parent, 'publication timeout holder cleanup'));
+				if ($event !== 'UNLOCKED') {
+					throw new RuntimeException(
+						"publication timeout holder cleanup expected UNLOCKED, got {$event}"
+					);
+				}
+			} catch (Throwable $error) {
+				$cleanupError ??= $error;
+			}
+			@fclose($parent);
+			$parent = NULL;
+		}
+		if (is_int($pid) && $pid > 0) {
+			$waited = pcntl_waitpid($pid, $status, WNOHANG);
+			if ($waited === 0 && function_exists('posix_kill')) {
+				@posix_kill($pid, SIGKILL);
+				$waited = pcntl_waitpid($pid, $status);
+			} elseif ($waited === 0) {
+				$waited = pcntl_waitpid($pid, $status);
+			}
+			if ($waited < 0 && $cleanupError === NULL) {
+				$cleanupError = new RuntimeException('publication timeout holder waitpid failed');
+			} elseif ($waited > 0 && (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0)
+				&& $cleanupError === NULL) {
+				$cleanupError = new RuntimeException('publication timeout holder exited unsuccessfully');
+			}
+			$pid = NULL;
+		}
+	}
+
 	private function assertContendedOperationTimesOut(callable $operation): void
 	{
 		$manifestBefore = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
@@ -587,47 +622,69 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		}
 
 		$lockPath   = dirname($GLOBALS['pfb']['unbound_py_sources']) . '/pfb_py_sources.lock';
-		[$holderParent, $holderChild] = $this->signalPair();
-		stream_set_timeout($holderParent, 5);
-		stream_set_timeout($holderChild, 5);
-		$pid = pcntl_fork();
-		if ($pid === -1) {
-			$this->markTestSkipped('pcntl_fork() failed.');
-		}
-		if ($pid === 0) {
-			fclose($holderParent);
-			$fp = fopen($lockPath, 'c');
-			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
-				exit(1);	// never signal readiness without a REAL hold -- the parent
-					// would then run with no contention and a negative assertion
-					// ("no dispatch", "entry survived") would pass for the wrong reason
+		$holderParent = NULL;
+		$holderChild = NULL;
+		$pid = NULL;
+		$primaryError = NULL;
+		$cleanupError = NULL;
+		try {
+			[$holderParent, $holderChild] = $this->signalPair();
+			stream_set_timeout($holderParent, 5);
+			stream_set_timeout($holderChild, 5);
+			$pid = pcntl_fork();
+			if ($pid === -1) {
+				$this->markTestSkipped('pcntl_fork() failed.');
 			}
-			fwrite($holderChild, "LOCKED\n");
-			$this->expectChildEvent($holderChild, 'RELEASE', 'publication timeout holder release');
-			flock($fp, LOCK_UN);
-			fclose($fp);
-			fwrite($holderChild, "UNLOCKED\n");
+			if ($pid === 0) {
+				fclose($holderParent);
+				$fp = @fopen($lockPath, 'c');
+				if ($fp === FALSE || !@flock($fp, LOCK_EX)) {
+					@fwrite($holderChild, "HOLDER_ERROR\n");
+					@fclose($holderChild);
+					exit(1);
+				}
+				fwrite($holderChild, "LOCKED\n");
+				$this->expectChildEvent($holderChild, 'RELEASE', 'publication timeout holder release');
+				@flock($fp, LOCK_UN);
+				fclose($fp);
+				fwrite($holderChild, "UNLOCKED\n");
+				fclose($holderChild);
+				exit(0);
+			}
 			fclose($holderChild);
-			exit(0);
+			$holderChild = NULL;
+			$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'publication timeout holder acquisition'));
+
+			$result = pfb_unbound_py_publication_lock(0.15);
+
+			$this->assertFalse($result, 'a contended publication lock acquire past its own budget must return FALSE');
+
+			$log = (string) file_get_contents($GLOBALS['pfb']['errlog']);
+			$this->assertStringContainsString('DNSBL publication lock timed out', $log,
+				'a genuine lock-acquire expiry must log "timed out", got errlog=' . var_export($log, TRUE));
+			$this->assertStringNotContainsString('DNSBL publication lock unavailable', $log,
+				'a genuine expiry must NOT log "unavailable" -- that string is reserved for a real flock() '
+				. 'error or an fopen() failure, never a mere timeout');
+			fwrite($holderParent, "RELEASE\n");
+			$this->assertSame("UNLOCKED\n", $this->readEvent($holderParent, 'publication timeout holder release'));
+			fclose($holderParent);
+			$holderParent = NULL;
+			pcntl_waitpid($pid, $waitStatus);
+			$this->assertTrue(pcntl_wifexited($waitStatus) && pcntl_wexitstatus($waitStatus) === 0,
+				'publication timeout holder must exit cleanly after the release event');
+			$pid = NULL;
+		} catch (Throwable $error) {
+			$primaryError = $error;
 		}
-		fclose($holderChild);
-		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'publication timeout holder acquisition'));
-
-		$result = pfb_unbound_py_publication_lock(0.15);
-
-		$this->assertFalse($result, 'a contended publication lock acquire past its own budget must return FALSE');
-
-		$log = (string) file_get_contents($GLOBALS['pfb']['errlog']);
-		$this->assertStringContainsString('DNSBL publication lock timed out', $log,
-			'a genuine lock-acquire expiry must log "timed out", got errlog=' . var_export($log, TRUE));
-		$this->assertStringNotContainsString('DNSBL publication lock unavailable', $log,
-			'a genuine expiry must NOT log "unavailable" -- that string is reserved for a real flock() '
-			. 'error or an fopen() failure, never a mere timeout');
-		fwrite($holderParent, "RELEASE\n");
-		$this->assertSame("UNLOCKED\n", $this->readEvent($holderParent, 'publication timeout holder release'));
-		fclose($holderParent);
-		pcntl_waitpid($pid, $waitStatus);
-		$this->assertTrue(pcntl_wifexited($waitStatus) && pcntl_wexitstatus($waitStatus) === 0,
-			'publication timeout holder must exit cleanly after the release event');
+		$this->cleanupPublicationHolder($pid, $holderParent, $cleanupError);
+		if (is_resource($holderChild)) {
+			@fclose($holderChild);
+		}
+		if ($primaryError !== NULL) {
+			throw $primaryError;
+		}
+		if ($cleanupError !== NULL) {
+			throw $cleanupError;
+		}
 	}
 }

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -134,11 +134,13 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		}
 		if (is_int($pid) && $pid > 0) {
 			$waited = pcntl_waitpid($pid, $status, WNOHANG);
-			if ($waited === 0 && function_exists('posix_kill')) {
-				@posix_kill($pid, SIGKILL);
-				$waited = pcntl_waitpid($pid, $status);
-			} elseif ($waited === 0) {
-				$waited = pcntl_waitpid($pid, $status);
+			if ($waited === 0) {
+				if (function_exists('posix_kill')) {
+					@posix_kill($pid, SIGKILL);
+					$waited = pcntl_waitpid($pid, $status);
+				} elseif ($cleanupError === NULL) {
+					$cleanupError = new RuntimeException('publication timeout holder cannot be reaped: posix_kill unavailable');
+				}
 			}
 			if ($waited < 0 && $cleanupError === NULL) {
 				$cleanupError = new RuntimeException('publication timeout holder waitpid failed');
@@ -152,6 +154,10 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 
 	private function assertContendedOperationTimesOut(callable $operation): void
 	{
+		if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+			$this->markTestSkipped('pcntl_fork() and posix_kill() required for fork cleanup.');
+		}
+
 		$manifestBefore = (string) file_get_contents($GLOBALS['pfb']['unbound_py_sources']);
 		$holderPid = NULL;
 		$operationPid = NULL;
@@ -186,17 +192,30 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			stream_set_timeout($operationChild, 5);
 			$operationPid = pcntl_fork();
 			if ($operationPid === 0) {
+				fclose($holderParent);
 				fclose($operationParent);
-				$ok = $operation();
-				fwrite($operationChild, "RESULT\n");
-				fwrite($operationChild, json_encode(['ok' => $ok]) . "\n");
+				try {
+					$ok = $operation();
+					fwrite($operationChild, "RESULT\n");
+					fwrite($operationChild, json_encode(['ok' => $ok]) . "\n");
+				} catch (Throwable $error) {
+					$message = preg_replace('/\s+/', ' ', trim($error->getMessage()));
+					$message = is_string($message) && $message !== '' ? substr($message, 0, 512) : get_class($error);
+					@fwrite($operationChild, "OPERATION_ERROR {$message}\n");
+					@fclose($operationChild);
+					exit(1);
+				}
 				fclose($operationChild);
 				exit(0);
 			}
 			$this->assertGreaterThan(0, $operationPid);
 			fclose($operationChild);
 
-			$this->assertSame("RESULT\n", $this->readEvent($operationParent, 'contended operation verdict'));
+			$operationVerdict = $this->readEvent($operationParent, 'contended operation verdict');
+			if (str_starts_with($operationVerdict, 'OPERATION_ERROR ')) {
+				throw new RuntimeException(trim($operationVerdict));
+			}
+			$this->assertSame("RESULT\n", $operationVerdict);
 			$result = json_decode($this->readEvent($operationParent, 'contended operation result'), TRUE);
 			$this->assertIsArray($result);
 			$this->assertArrayHasKey('ok', $result);
@@ -371,6 +390,10 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 
 	public function testDefaultScalarPatchRetriesUntilPublicationLockIsReleased(): void
 	{
+		if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+			$this->markTestSkipped('pcntl_fork() and posix_kill() required for fork cleanup.');
+		}
+
 		$manifest = $this->publish();
 		$this->assertIsArray($manifest);
 		$rawRefs = array_column($manifest['feeds'], 'raw');
@@ -406,6 +429,7 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			stream_set_timeout($patchChild, 5);
 			$patchPid = pcntl_fork();
 			if ($patchPid === 0) {
+				fclose($holderParent);
 				fclose($patchParent);
 				fwrite($patchChild, "ATTEMPT\n");
 				$ok = pfb_unbound_python_sources_patch('user_unlock', ['allow.example'], [
@@ -468,6 +492,10 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 
 	public function testScalarPatchTimesOutWithoutMutatingManifest(): void
 	{
+		if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+			$this->markTestSkipped('pcntl_fork() and posix_kill() required for fork cleanup.');
+		}
+
 		$manifest = $this->publish();
 		$this->assertIsArray($manifest);
 
@@ -479,6 +507,17 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$this->assertSame([], $patched['config']['user_unlock']);
 		$log = (string) file_get_contents($GLOBALS['pfb']['log']);
 		$this->assertStringContainsString('retry the action or run a DNSBL update', $log);
+	}
+
+	public function testContendedOperationExceptionIsReportedAndReaped(): void
+	{
+		$this->publish();
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('OPERATION_ERROR operation exploded with a second line');
+
+		$this->assertContendedOperationTimesOut(static function (): bool {
+			throw new RuntimeException("operation exploded\nwith a second line");
+		});
 	}
 
 	public function testGarbageCollectionTimesOutWithoutRemovingRawGenerations(): void
@@ -617,8 +656,8 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 
 	public function testPublicationLockTimeoutLogsTimedOutNotUnavailable(): void
 	{
-		if (!function_exists('pcntl_fork')) {
-			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+			$this->markTestSkipped('pcntl_fork() and posix_kill() required for fork cleanup.');
 		}
 
 		$lockPath   = dirname($GLOBALS['pfb']['unbound_py_sources']) . '/pfb_py_sources.lock';

--- a/tests/php/DnsblManifestAtomicGenerationTest.php
+++ b/tests/php/DnsblManifestAtomicGenerationTest.php
@@ -86,14 +86,24 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			}
 			return $line;
 		}
-		$message = "salvage cap expired / stuck or environment: awaiting {$awaited}";
-		if ($child) {
-			@fwrite($stream, "SALVAGE_EXPIRED {$message}\n");
-			exit(2);
-		}
 		$meta = stream_get_meta_data($stream);
 		$reason = ($meta['timed_out'] ?? FALSE) ? 'timeout' : (feof($stream) ? 'EOF' : 'read failure');
+		$message = "salvage cap expired / stuck or environment: awaiting {$awaited}";
+		if ($child) {
+			@fwrite($stream, "SALVAGE_EXPIRED {$message} ({$reason})\n");
+			exit(2);
+		}
 		$this->fail("{$message} ({$reason})");
+	}
+
+	/** @return array{0:mixed,1:mixed} */
+	private function signalPair(): array
+	{
+		$pair = @stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		if ($pair === FALSE) {
+			$this->markTestSkipped('stream_socket_pair() failed -- cannot signal across the fork.');
+		}
+		return $pair;
 	}
 
 	private function expectChildEvent(mixed $stream, string $expected, string $awaited): void
@@ -113,7 +123,7 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$holderParent = NULL;
 		$operationParent = NULL;
 		try {
-			[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+			[$holderParent, $holderChild] = $this->signalPair();
 			stream_set_timeout($holderParent, 5);
 			stream_set_timeout($holderChild, 5);
 			$holderPid = pcntl_fork();
@@ -136,7 +146,7 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			fclose($holderChild);
 			$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'publication holder acquisition'));
 
-			[$operationParent, $operationChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+			[$operationParent, $operationChild] = $this->signalPair();
 			stream_set_timeout($operationParent, 5);
 			stream_set_timeout($operationChild, 5);
 			$operationPid = pcntl_fork();
@@ -334,7 +344,7 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		$holderParent = NULL;
 		$patchParent = NULL;
 		try {
-			[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+			[$holderParent, $holderChild] = $this->signalPair();
 			stream_set_timeout($holderParent, 5);
 			stream_set_timeout($holderChild, 5);
 			$holderPid = pcntl_fork();
@@ -356,7 +366,7 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 			fclose($holderChild);
 			$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'scalar patch holder acquisition'));
 
-			[$patchParent, $patchChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+			[$patchParent, $patchChild] = $this->signalPair();
 			stream_set_timeout($patchParent, 5);
 			stream_set_timeout($patchChild, 5);
 			$patchPid = pcntl_fork();
@@ -577,7 +587,7 @@ final class DnsblManifestAtomicGenerationTest extends TestCase
 		}
 
 		$lockPath   = dirname($GLOBALS['pfb']['unbound_py_sources']) . '/pfb_py_sources.lock';
-		[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		[$holderParent, $holderChild] = $this->signalPair();
 		stream_set_timeout($holderParent, 5);
 		stream_set_timeout($holderChild, 5);
 		$pid = pcntl_fork();

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -86,7 +86,7 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		return static fn (): int => $ts;
 	}
 
-	private function readEvent(mixed $stream, string $awaited, bool $child = FALSE): string
+	private function readEvent(mixed $stream, string $awaited, bool $child = FALSE, mixed $report = NULL): string
 	{
 		$line = @fgets($stream);
 		if ($line !== FALSE) {
@@ -95,23 +95,35 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			}
 			return $line;
 		}
-		$message = "salvage cap expired / stuck or environment: awaiting {$awaited}";
-		if ($child) {
-			@fwrite($stream, "SALVAGE_EXPIRED {$message}\n");
-			exit(2);
-		}
 		$meta = stream_get_meta_data($stream);
 		$reason = ($meta['timed_out'] ?? FALSE) ? 'timeout' : (feof($stream) ? 'EOF' : 'read failure');
+		$message = "salvage cap expired / stuck or environment: awaiting {$awaited}";
+		if ($child) {
+			$destination = is_resource($report) ? $report : $stream;
+			@fwrite($destination, "SALVAGE_EXPIRED {$message} ({$reason})\n");
+			exit(2);
+		}
 		$this->fail("{$message} ({$reason})");
 	}
 
-	private function expectChildEvent(mixed $stream, string $expected, string $awaited): void
+	private function expectChildEvent(mixed $stream, string $expected, string $awaited, mixed $report = NULL): void
 	{
-		$event = trim($this->readEvent($stream, $awaited, TRUE));
+		$event = trim($this->readEvent($stream, $awaited, TRUE, $report));
 		if ($event !== $expected) {
-			@fwrite($stream, "EVENT_ERROR awaiting {$awaited}; expected {$expected}; got {$event}\n");
+			$destination = is_resource($report) ? $report : $stream;
+			@fwrite($destination, "EVENT_ERROR awaiting {$awaited}; expected {$expected}; got {$event}\n");
 			exit(2);
 		}
+	}
+
+	/** @return array{0:mixed,1:mixed} */
+	private function signalPair(): array
+	{
+		$pair = @stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		if ($pair === FALSE) {
+			$this->markTestSkipped('stream_socket_pair() failed -- cannot signal across the fork.');
+		}
+		return $pair;
 	}
 
 	/** @return array{0:int,1:mixed} */
@@ -120,7 +132,7 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		if (!function_exists('pcntl_fork')) {
 			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
 		}
-		[$parent, $child] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		[$parent, $child] = $this->signalPair();
 		stream_set_timeout($parent, 5);
 		stream_set_timeout($child, 5);
 		$pid = pcntl_fork();
@@ -355,79 +367,142 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 	public function testOpenBlocksUntilARealConcurrentProcessReleasesTheLedgerLock(): void
 	{
-		if (!function_exists('pcntl_fork')) {
+		if (!function_exists('pcntl_fork') || !function_exists('pcntl_async_signals')
+			|| !function_exists('pcntl_signal') || !function_exists('posix_kill') || !defined('SIGUSR1')) {
 			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
 		}
 
 		$lockPath   = $this->dir . '/pfb_sync_status.json.lock';
-		[$controlParent, $controlChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
-		stream_set_timeout($controlParent, 5);
-		stream_set_timeout($controlChild, 5);
-		[$eventParent, $eventChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
-		stream_set_timeout($eventParent, 5);
-		stream_set_timeout($eventChild, 5);
-		$holderPid = pcntl_fork();
-		if ($holderPid === -1) {
-			$this->markTestSkipped('pcntl_fork() failed.');
-		}
-		if ($holderPid === 0) {
-			fclose($controlParent);
-			fclose($eventParent);
-			$fp = @fopen($lockPath, 'c');
-			if ($fp === FALSE || !@flock($fp, LOCK_EX)) {
-				@fwrite($eventChild, "HOLDER_ERROR\n");
-				exit(1);
+		$controlParent = NULL;
+		$controlChild = NULL;
+		$eventParent = NULL;
+		$eventChild = NULL;
+		$holderPid = NULL;
+		$openerPid = NULL;
+		try {
+			[$controlParent, $controlChild] = $this->signalPair();
+			stream_set_timeout($controlParent, 5);
+			stream_set_timeout($controlChild, 5);
+			[$eventParent, $eventChild] = $this->signalPair();
+			stream_set_timeout($eventParent, 5);
+			stream_set_timeout($eventChild, 5);
+			$holderPid = pcntl_fork();
+			if ($holderPid === -1) {
+				$this->markTestSkipped('pcntl_fork() failed.');
 			}
-			fwrite($eventChild, "LOCKED\n");
-			$this->expectChildEvent($controlChild, 'RELEASE', 'ledger lock holder release');
-			fwrite($eventChild, "RELEASING\n");
-			@flock($fp, LOCK_UN);
-			fclose($fp);
+			if ($holderPid === 0) {
+				fclose($controlParent);
+				fclose($eventParent);
+				$fp = @fopen($lockPath, 'c');
+				if ($fp === FALSE || !@flock($fp, LOCK_EX)) {
+					@fwrite($eventChild, "HOLDER_ERROR\n");
+					exit(1);
+				}
+				fwrite($eventChild, "LOCKED\n");
+				$this->expectChildEvent($controlChild, 'RELEASE', 'ledger lock holder release', $eventChild);
+				fwrite($eventChild, "RELEASING\n");
+				@flock($fp, LOCK_UN);
+				fclose($fp);
+				fclose($controlChild);
+				fclose($eventChild);
+				exit(0);
+			}
 			fclose($controlChild);
-			fclose($eventChild);
-			exit(0);
-		}
-		fclose($controlChild);
-		$this->assertSame("LOCKED\n", $this->readEvent($eventParent, 'ledger lock holder acquisition'));
+			$controlChild = NULL;
+			$this->assertSame("LOCKED\n", $this->readEvent($eventParent, 'ledger lock holder acquisition'));
 
-		$openerPid = pcntl_fork();
-		if ($openerPid === -1) {
-			$this->markTestSkipped('pcntl_fork() failed.');
-		}
-		if ($openerPid === 0) {
-			fclose($controlParent);
-			fclose($eventParent);
-			$probe = @fopen($lockPath, 'c');
-			$wouldBlock = 0;
-			$contended = $probe !== FALSE
-				&& !@flock($probe, LOCK_EX | LOCK_NB, $wouldBlock)
-				&& $wouldBlock === 1;
-			if (is_resource($probe)) {
-				fclose($probe);
+			$openerPid = pcntl_fork();
+			if ($openerPid === -1) {
+				$this->markTestSkipped('pcntl_fork() failed.');
 			}
-			if (!$contended) {
-				fwrite($eventChild, "PROBE_FAILED\n");
-				exit(1);
+			if ($openerPid === 0) {
+				fclose($controlParent);
+				fclose($eventParent);
+				pcntl_async_signals(TRUE);
+				pcntl_signal(SIGUSR1, static function () use ($eventChild): void {
+					$functions = array_values(array_filter(array_map(
+						static fn(array $frame): string => (string) ($frame['function'] ?? ''),
+						debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)
+					), static fn(string $name): bool => $name !== ''));
+					$required = ['pfb_flock_bounded', 'pfb_sync_status_locked', 'pfb_sync_status_open'];
+					$blocked = count(array_intersect($required, $functions)) === count($required)
+						&& !in_array('pfb_sync_status_read_all', $functions, TRUE);
+					$event = $blocked ? 'BLOCKED' : 'NOT_BLOCKED ' . implode('|', array_slice($functions, 0, 24));
+					@fwrite($eventChild, $event . "\n");
+				});
+				$probe = @fopen($lockPath, 'c');
+				$wouldBlock = 0;
+				$contended = $probe !== FALSE
+					&& !@flock($probe, LOCK_EX | LOCK_NB, $wouldBlock)
+					&& $wouldBlock === 1;
+				if (is_resource($probe)) {
+					fclose($probe);
+				}
+				if (!$contended) {
+					fwrite($eventChild, "PROBE_FAILED\n");
+					exit(1);
+				}
+				fwrite($eventChild, "CONTENDED\n");
+				pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+				fwrite($eventChild, "RETURNED\n");
+				fclose($eventChild);
+				exit(0);
 			}
-			fwrite($eventChild, "CONTENDED\n");
-			pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
-			fwrite($eventChild, "RETURNED\n");
 			fclose($eventChild);
-			exit(0);
+			$eventChild = NULL;
+			$this->assertSame("CONTENDED\n", $this->readEvent($eventParent, 'concurrent opener contention'));
+			$blocked = FALSE;
+			$notBlockedSignals = [];
+			for ($attempt = 0; $attempt < 32; $attempt++) {
+				if (!@posix_kill($openerPid, SIGUSR1)) {
+					$this->fail('salvage cap expired / stuck or environment: awaiting BLOCKED signal before release; opener exited');
+				}
+				$signalEvent = trim($this->readEvent($eventParent, 'opener blocked-state signal'));
+				if ($signalEvent === 'BLOCKED') {
+					$blocked = TRUE;
+					break;
+				}
+				if (!str_starts_with($signalEvent, 'NOT_BLOCKED ')) {
+					$this->fail('unexpected opener signal event: expected BLOCKED or NOT_BLOCKED, got ' . $signalEvent);
+				}
+				$notBlockedSignals[] = $signalEvent;
+			}
+			$this->assertTrue($blocked,
+				'salvage cap expired / stuck or environment: awaiting BLOCKED opener state after signal retries; '
+				. 'observed=' . implode(';', $notBlockedSignals));
+			fwrite($controlParent, "RELEASE\n");
+			$this->assertSame("RELEASING\n", $this->readEvent($eventParent, 'ledger lock holder release while still locked'));
+			$this->assertSame("RETURNED\n", $this->readEvent($eventParent, 'concurrent opener return after unlock'));
+			fclose($controlParent);
+			$controlParent = NULL;
+			fclose($eventParent);
+			$eventParent = NULL;
+			pcntl_waitpid($holderPid, $holderStatus);
+			$holderPid = NULL;
+			pcntl_waitpid($openerPid, $openerStatus);
+			$openerPid = NULL;
+			$this->assertTrue(pcntl_wifexited($holderStatus) && pcntl_wexitstatus($holderStatus) === 0,
+				'ledger lock holder must exit cleanly after the release event');
+			$this->assertTrue(pcntl_wifexited($openerStatus) && pcntl_wexitstatus($openerStatus) === 0,
+				'concurrent opener must return cleanly after the release event');
+		} finally {
+			if (is_resource($controlParent)) {
+				@fwrite($controlParent, "RELEASE\n");
+			}
+			foreach ([$controlParent, $controlChild, $eventParent, $eventChild] as $stream) {
+				if (is_resource($stream)) {
+					@fclose($stream);
+				}
+			}
+			foreach ([$holderPid, $openerPid] as $pid) {
+				if (is_int($pid) && $pid > 0) {
+					if (pcntl_waitpid($pid, $childStatus, WNOHANG) === 0 && function_exists('posix_kill')) {
+						@posix_kill($pid, SIGKILL);
+					}
+					pcntl_waitpid($pid, $childStatus);
+				}
+			}
 		}
-		fclose($eventChild);
-		$this->assertSame("CONTENDED\n", $this->readEvent($eventParent, 'concurrent opener contention'));
-		fwrite($controlParent, "RELEASE\n");
-		$this->assertSame("RELEASING\n", $this->readEvent($eventParent, 'ledger lock holder release while still locked'));
-		$this->assertSame("RETURNED\n", $this->readEvent($eventParent, 'concurrent opener return after unlock'));
-		fclose($controlParent);
-		fclose($eventParent);
-		pcntl_waitpid($holderPid, $holderStatus);
-		pcntl_waitpid($openerPid, $openerStatus);
-		$this->assertTrue(pcntl_wifexited($holderStatus) && pcntl_wexitstatus($holderStatus) === 0,
-			'ledger lock holder must exit cleanly after the release event');
-		$this->assertTrue(pcntl_wifexited($openerStatus) && pcntl_wexitstatus($openerStatus) === 0,
-			'concurrent opener must return cleanly after the release event');
 	}
 
 	// -----------------------------------------------------------------------
@@ -450,7 +525,7 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		]);
 
 		$lockPath   = $this->dir . '/pfb_sync_status.json.lock';
-		[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		[$holderParent, $holderChild] = $this->signalPair();
 		stream_set_timeout($holderParent, 5);
 		stream_set_timeout($holderChild, 5);
 		$pid        = pcntl_fork();

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -158,32 +158,47 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		return [$pid, $parent];
 	}
 
-	private function releaseDataFileHolder(?int &$pid, mixed $parent): void
+	private function releaseDataFileHolder(?int &$pid, mixed &$parent): void
 	{
-		if (!is_resource($parent)) {
-			return;
-		}
-		@fwrite($parent, "RELEASE\n");
-		try {
-			$this->assertSame("UNLOCKED\n", $this->readEvent($parent, 'data-file holder unlock'));
-		} catch (Throwable $error) {
-			if (is_int($pid) && $pid > 0 && function_exists('posix_kill')) {
-				@posix_kill($pid, SIGKILL);
+		$cleanupError = NULL;
+		$released = FALSE;
+		if (is_resource($parent)) {
+			@fwrite($parent, "RELEASE\n");
+			try {
+				$event = trim($this->readEvent($parent, 'data-file holder unlock'));
+				if ($event !== 'UNLOCKED') {
+					throw new RuntimeException("data-file holder cleanup expected UNLOCKED, got {$event}");
+				}
+				$released = TRUE;
+			} catch (Throwable $error) {
+				$cleanupError = $error;
 			}
-			fclose($parent);
-			if (is_int($pid) && $pid > 0) {
-				pcntl_waitpid($pid, $status);
+			@fclose($parent);
+			$parent = NULL;
+		}
+		if (is_int($pid) && $pid > 0) {
+			if ($released) {
+				$waited = pcntl_waitpid($pid, $status);
+			} else {
+				$waited = pcntl_waitpid($pid, $status, WNOHANG);
+				if ($waited === 0 && function_exists('posix_kill')) {
+					@posix_kill($pid, SIGKILL);
+					$waited = pcntl_waitpid($pid, $status);
+				} elseif ($waited === 0) {
+					$waited = pcntl_waitpid($pid, $status);
+				}
+			}
+			if ($waited < 0 && $cleanupError === NULL) {
+				$cleanupError = new RuntimeException('data-file holder waitpid failed');
+			} elseif ($waited > 0 && (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0)
+				&& $cleanupError === NULL) {
+				$cleanupError = new RuntimeException('data-file holder exited unsuccessfully');
 			}
 			$pid = NULL;
-			throw $error;
 		}
-		fclose($parent);
-		if (is_int($pid) && $pid > 0) {
-			pcntl_waitpid($pid, $status);
-			$this->assertTrue(pcntl_wifexited($status) && pcntl_wexitstatus($status) === 0,
-				'data-file holder must exit cleanly after the release event');
+		if ($cleanupError !== NULL) {
+			throw $cleanupError;
 		}
-		$pid = NULL;
 	}
 
 	// -----------------------------------------------------------------------
@@ -525,35 +540,41 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		]);
 
 		$lockPath   = $this->dir . '/pfb_sync_status.json.lock';
-		[$holderParent, $holderChild] = $this->signalPair();
-		stream_set_timeout($holderParent, 5);
-		stream_set_timeout($holderChild, 5);
-		$pid        = pcntl_fork();
-		if ($pid === -1) {
-			$GLOBALS['pfb'] = $originalPfb;
-			$this->markTestSkipped('pcntl_fork() failed.');
-		}
-
-		if ($pid === 0) {
-			fclose($holderParent);
-			$fp = fopen($lockPath, 'c');
-			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
-				@fwrite($holderChild, "HOLDER_ERROR\n");
-				exit(1);
-			}
-			fwrite($holderChild, "LOCKED\n");
-			$this->expectChildEvent($holderChild, 'RELEASE', 'sync-status expiry holder release');
-			flock($fp, LOCK_UN);
-			fclose($fp);
-			fwrite($holderChild, "UNLOCKED\n");
-			fclose($holderChild);
-			exit(0);
-		}
-
-		fclose($holderChild);
-		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'sync-status expiry holder acquisition'));
-
+		$holderParent = NULL;
+		$holderChild = NULL;
+		$pid = NULL;
+		$primaryError = NULL;
+		$cleanupError = NULL;
 		try {
+			[$holderParent, $holderChild] = $this->signalPair();
+			stream_set_timeout($holderParent, 5);
+			stream_set_timeout($holderChild, 5);
+			$pid = pcntl_fork();
+			if ($pid === -1) {
+				$this->markTestSkipped('pcntl_fork() failed.');
+			}
+
+			if ($pid === 0) {
+				fclose($holderParent);
+				$fp = @fopen($lockPath, 'c');
+				if ($fp === FALSE || !@flock($fp, LOCK_EX)) {
+					@fwrite($holderChild, "HOLDER_ERROR\n");
+					@fclose($holderChild);
+					exit(1);
+				}
+				fwrite($holderChild, "LOCKED\n");
+				$this->expectChildEvent($holderChild, 'RELEASE', 'sync-status expiry holder release');
+				@flock($fp, LOCK_UN);
+				fclose($fp);
+				fwrite($holderChild, "UNLOCKED\n");
+				fclose($holderChild);
+				exit(0);
+			}
+
+			fclose($holderChild);
+			$holderChild = NULL;
+			$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'sync-status expiry holder acquisition'));
+
 			$fnRan = FALSE;
 			pfb_sync_status_locked($this->dir, function () use (&$fnRan) {
 				$fnRan = TRUE;
@@ -565,14 +586,53 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			$log = (string) file_get_contents($GLOBALS['pfb']['log']);
 			$this->assertStringContainsString('sync-status ledger lock timed out', $log,
 				'a timed-out acquire must be logged loudly -- an operator-observable signal, never silent');
-		} finally {
-			fwrite($holderParent, "RELEASE\n");
-			$this->assertSame("UNLOCKED\n", $this->readEvent($holderParent, 'sync-status expiry holder unlock'));
-			fclose($holderParent);
-			pcntl_waitpid($pid, $waitStatus);
-			$this->assertTrue(pcntl_wifexited($waitStatus) && pcntl_wexitstatus($waitStatus) === 0,
-				'sync-status expiry holder must exit cleanly after the release event');
-			$GLOBALS['pfb'] = $originalPfb;
+		} catch (Throwable $error) {
+			$primaryError = $error;
+		}
+		$released = FALSE;
+		if (is_resource($holderParent)) {
+			@fwrite($holderParent, "RELEASE\n");
+			try {
+				$event = trim($this->readEvent($holderParent, 'sync-status expiry holder cleanup'));
+				if ($event !== 'UNLOCKED') {
+					throw new RuntimeException("sync-status expiry holder cleanup expected UNLOCKED, got {$event}");
+				}
+				$released = TRUE;
+			} catch (Throwable $error) {
+				$cleanupError = $error;
+			}
+			@fclose($holderParent);
+			$holderParent = NULL;
+		}
+		if (is_int($pid) && $pid > 0) {
+			if ($released) {
+				$waited = pcntl_waitpid($pid, $waitStatus);
+			} else {
+				$waited = pcntl_waitpid($pid, $waitStatus, WNOHANG);
+				if ($waited === 0 && function_exists('posix_kill')) {
+					@posix_kill($pid, SIGKILL);
+					$waited = pcntl_waitpid($pid, $waitStatus);
+				} elseif ($waited === 0) {
+					$waited = pcntl_waitpid($pid, $waitStatus);
+				}
+			}
+			if ($waited < 0 && $cleanupError === NULL) {
+				$cleanupError = new RuntimeException('sync-status expiry holder waitpid failed');
+			} elseif ($waited > 0 && (!pcntl_wifexited($waitStatus) || pcntl_wexitstatus($waitStatus) !== 0)
+				&& $cleanupError === NULL) {
+				$cleanupError = new RuntimeException('sync-status expiry holder exited unsuccessfully');
+			}
+			$pid = NULL;
+		}
+		if (is_resource($holderChild)) {
+			@fclose($holderChild);
+		}
+		$GLOBALS['pfb'] = $originalPfb;
+		if ($primaryError !== NULL) {
+			throw $primaryError;
+		}
+		if ($cleanupError !== NULL) {
+			throw $cleanupError;
 		}
 	}
 
@@ -711,14 +771,27 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 		$dataPath   = $this->dir . '/pfb_sync_status.json';
 		[$pid, $holderParent] = $this->forkRealDataFileHolder($dataPath);
-		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'read_all data-file holder acquisition'));
+		$primaryError = NULL;
+		$cleanupError = NULL;
 		try {
+			$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'read_all data-file holder acquisition'));
 			$unavailable = FALSE;
 			$data = pfb_sync_status_read_all($this->dir, 0.15, $unavailable);
 			$this->assertSame([], $data, 'an expired read must still return [] (same as empty), never a stale/partial ledger');
 			$this->assertTrue($unavailable, 'a genuine lock-acquire expiry must set $unavailable = TRUE');
-		} finally {
+		} catch (Throwable $error) {
+			$primaryError = $error;
+		}
+		try {
 			$this->releaseDataFileHolder($pid, $holderParent);
+		} catch (Throwable $error) {
+			$cleanupError = $error;
+		}
+		if ($primaryError !== NULL) {
+			throw $primaryError;
+		}
+		if ($cleanupError !== NULL) {
+			throw $cleanupError;
 		}
 
 		// FALSE: absent ledger file.
@@ -761,11 +834,24 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 		$dataPath   = $this->dir . '/pfb_sync_status.json';
 		[$pid, $holderParent] = $this->forkRealDataFileHolder($dataPath);
-		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'open abort data-file holder acquisition'));
+		$primaryError = NULL;
+		$cleanupError = NULL;
 		try {
+			$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'open abort data-file holder acquisition'));
 			pfb_sync_status_open('dnsbl', 'SomeGroup', 'apply', 'should never persist', $this->dir, self::clockAt(2000), 0.15);
-		} finally {
+		} catch (Throwable $error) {
+			$primaryError = $error;
+		}
+		try {
 			$this->releaseDataFileHolder($pid, $holderParent);
+		} catch (Throwable $error) {
+			$cleanupError = $error;
+		}
+		if ($primaryError !== NULL) {
+			throw $primaryError;
+		}
+		if ($cleanupError !== NULL) {
+			throw $cleanupError;
 		}
 
 		$open = pfb_sync_status_list_open($this->dir);
@@ -789,11 +875,24 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 		$dataPath   = $this->dir . '/pfb_sync_status.json';
 		[$pid, $holderParent] = $this->forkRealDataFileHolder($dataPath);
-		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'close abort data-file holder acquisition'));
+		$primaryError = NULL;
+		$cleanupError = NULL;
 		try {
+			$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'close abort data-file holder acquisition'));
 			pfb_sync_status_close('ip', 'pfB_StillOpen_v4', 'download', $this->dir, 0.15);
-		} finally {
+		} catch (Throwable $error) {
+			$primaryError = $error;
+		}
+		try {
 			$this->releaseDataFileHolder($pid, $holderParent);
+		} catch (Throwable $error) {
+			$cleanupError = $error;
+		}
+		if ($primaryError !== NULL) {
+			throw $primaryError;
+		}
+		if ($cleanupError !== NULL) {
+			throw $cleanupError;
 		}
 
 		$open = pfb_sync_status_list_open($this->dir);

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -86,6 +86,94 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		return static fn (): int => $ts;
 	}
 
+	private function readEvent(mixed $stream, string $awaited, bool $child = FALSE): string
+	{
+		$line = @fgets($stream);
+		if ($line !== FALSE) {
+			if (str_starts_with($line, 'SALVAGE_EXPIRED ')) {
+				$this->fail(trim(substr($line, strlen('SALVAGE_EXPIRED '))));
+			}
+			return $line;
+		}
+		$message = "salvage cap expired / stuck or environment: awaiting {$awaited}";
+		if ($child) {
+			@fwrite($stream, "SALVAGE_EXPIRED {$message}\n");
+			exit(2);
+		}
+		$meta = stream_get_meta_data($stream);
+		$reason = ($meta['timed_out'] ?? FALSE) ? 'timeout' : (feof($stream) ? 'EOF' : 'read failure');
+		$this->fail("{$message} ({$reason})");
+	}
+
+	private function expectChildEvent(mixed $stream, string $expected, string $awaited): void
+	{
+		$event = trim($this->readEvent($stream, $awaited, TRUE));
+		if ($event !== $expected) {
+			@fwrite($stream, "EVENT_ERROR awaiting {$awaited}; expected {$expected}; got {$event}\n");
+			exit(2);
+		}
+	}
+
+	/** @return array{0:int,1:mixed} */
+	private function forkRealDataFileHolder(string $lockPath): array
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		}
+		[$parent, $child] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		stream_set_timeout($parent, 5);
+		stream_set_timeout($child, 5);
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->markTestSkipped('pcntl_fork() failed.');
+		}
+		if ($pid === 0) {
+			fclose($parent);
+			$fp = @fopen($lockPath, 'c');
+			if ($fp === FALSE || !@flock($fp, LOCK_EX)) {
+				@fwrite($child, "HOLDER_ERROR\n");
+				exit(1);
+			}
+			fwrite($child, "LOCKED\n");
+			$this->expectChildEvent($child, 'RELEASE', 'data-file holder release');
+			@flock($fp, LOCK_UN);
+			fclose($fp);
+			fwrite($child, "UNLOCKED\n");
+			fclose($child);
+			exit(0);
+		}
+		fclose($child);
+		return [$pid, $parent];
+	}
+
+	private function releaseDataFileHolder(?int &$pid, mixed $parent): void
+	{
+		if (!is_resource($parent)) {
+			return;
+		}
+		@fwrite($parent, "RELEASE\n");
+		try {
+			$this->assertSame("UNLOCKED\n", $this->readEvent($parent, 'data-file holder unlock'));
+		} catch (Throwable $error) {
+			if (is_int($pid) && $pid > 0 && function_exists('posix_kill')) {
+				@posix_kill($pid, SIGKILL);
+			}
+			fclose($parent);
+			if (is_int($pid) && $pid > 0) {
+				pcntl_waitpid($pid, $status);
+			}
+			$pid = NULL;
+			throw $error;
+		}
+		fclose($parent);
+		if (is_int($pid) && $pid > 0) {
+			pcntl_waitpid($pid, $status);
+			$this->assertTrue(pcntl_wifexited($status) && pcntl_wexitstatus($status) === 0,
+				'data-file holder must exit cleanly after the release event');
+		}
+		$pid = NULL;
+	}
+
 	// -----------------------------------------------------------------------
 	// open() — new key, refresh-in-place, injectable clock.
 	// -----------------------------------------------------------------------
@@ -272,54 +360,74 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		}
 
 		$lockPath   = $this->dir . '/pfb_sync_status.json.lock';
-		$markerPath = $this->dir . '/child_locked.marker';
-		$pid        = pcntl_fork();
-		if ($pid === -1) {
+		[$controlParent, $controlChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		stream_set_timeout($controlParent, 5);
+		stream_set_timeout($controlChild, 5);
+		[$eventParent, $eventChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		stream_set_timeout($eventParent, 5);
+		stream_set_timeout($eventChild, 5);
+		$holderPid = pcntl_fork();
+		if ($holderPid === -1) {
 			$this->markTestSkipped('pcntl_fork() failed.');
 		}
-
-		if ($pid === 0) {
-			// Child: acquire the SAME lock file pfb_sync_status_locked() uses, signal
-			// readiness (issue #1055 -- a marker file, not a guessed sleep), hold the
-			// lock briefly (simulating a still-running backgrounded pass mid
-			// read-modify-write), then release. A fresh fopen() (not an inherited fd)
-			// makes this a genuine second, independent lock holder.
-			$fp = fopen($lockPath, 'c');
-			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
-				exit(1);	// never signal readiness without a REAL hold -- the parent
-					// would then run with no contention and a negative assertion
-					// ("no dispatch", "entry survived") would pass for the wrong reason
+		if ($holderPid === 0) {
+			fclose($controlParent);
+			fclose($eventParent);
+			$fp = @fopen($lockPath, 'c');
+			if ($fp === FALSE || !@flock($fp, LOCK_EX)) {
+				@fwrite($eventChild, "HOLDER_ERROR\n");
+				exit(1);
 			}
-			touch($markerPath);
-			usleep(500000);
-			flock($fp, LOCK_UN);
+			fwrite($eventChild, "LOCKED\n");
+			$this->expectChildEvent($controlChild, 'RELEASE', 'ledger lock holder release');
+			fwrite($eventChild, "RELEASING\n");
+			@flock($fp, LOCK_UN);
 			fclose($fp);
+			fclose($controlChild);
+			fclose($eventChild);
 			exit(0);
 		}
+		fclose($controlChild);
+		$this->assertSame("LOCKED\n", $this->readEvent($eventParent, 'ledger lock holder acquisition'));
 
-		// issue #1055: poll for the child's readiness marker instead of guessing a
-		// fixed delay -- a bounded poll is the accepted last resort across this
-		// fork boundary (no in-process signal reaches across processes).
-		$deadline = microtime(TRUE) + 2.0;
-		while (!file_exists($markerPath)) {
-			if (microtime(TRUE) >= $deadline) {
-				pcntl_waitpid($pid, $waitStatus);
-				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
-			}
-			usleep(1000);
+		$openerPid = pcntl_fork();
+		if ($openerPid === -1) {
+			$this->markTestSkipped('pcntl_fork() failed.');
 		}
-
-		$start = microtime(TRUE);
-		pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
-		$elapsed = microtime(TRUE) - $start;
-
-		pcntl_waitpid($pid, $waitStatus);
-
-		$this->assertGreaterThanOrEqual(
-			0.3,
-			$elapsed,
-			'pfb_sync_status_open() must block on the lock file until the real concurrent holder releases it -- a near-instant return means the read-modify-write span is not actually protected'
-		);
+		if ($openerPid === 0) {
+			fclose($controlParent);
+			fclose($eventParent);
+			$probe = @fopen($lockPath, 'c');
+			$wouldBlock = 0;
+			$contended = $probe !== FALSE
+				&& !@flock($probe, LOCK_EX | LOCK_NB, $wouldBlock)
+				&& $wouldBlock === 1;
+			if (is_resource($probe)) {
+				fclose($probe);
+			}
+			if (!$contended) {
+				fwrite($eventChild, "PROBE_FAILED\n");
+				exit(1);
+			}
+			fwrite($eventChild, "CONTENDED\n");
+			pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+			fwrite($eventChild, "RETURNED\n");
+			fclose($eventChild);
+			exit(0);
+		}
+		fclose($eventChild);
+		$this->assertSame("CONTENDED\n", $this->readEvent($eventParent, 'concurrent opener contention'));
+		fwrite($controlParent, "RELEASE\n");
+		$this->assertSame("RELEASING\n", $this->readEvent($eventParent, 'ledger lock holder release while still locked'));
+		$this->assertSame("RETURNED\n", $this->readEvent($eventParent, 'concurrent opener return after unlock'));
+		fclose($controlParent);
+		fclose($eventParent);
+		pcntl_waitpid($holderPid, $holderStatus);
+		pcntl_waitpid($openerPid, $openerStatus);
+		$this->assertTrue(pcntl_wifexited($holderStatus) && pcntl_wexitstatus($holderStatus) === 0,
+			'ledger lock holder must exit cleanly after the release event');
+		$this->assertTrue(pcntl_wifexited($openerStatus) && pcntl_wexitstatus($openerStatus) === 0,
+			'concurrent opener must return cleanly after the release event');
 	}
 
 	// -----------------------------------------------------------------------
@@ -342,7 +450,9 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		]);
 
 		$lockPath   = $this->dir . '/pfb_sync_status.json.lock';
-		$markerPath = $this->dir . '/child_locked_expiry.marker';
+		[$holderParent, $holderChild] = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+		stream_set_timeout($holderParent, 5);
+		stream_set_timeout($holderChild, 5);
 		$pid        = pcntl_fork();
 		if ($pid === -1) {
 			$GLOBALS['pfb'] = $originalPfb;
@@ -350,30 +460,23 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		}
 
 		if ($pid === 0) {
-			// Child: fresh fopen() (not an inherited fd) -- a genuine second,
-			// independent lock holder. Holds well past the parent's small budget.
+			fclose($holderParent);
 			$fp = fopen($lockPath, 'c');
 			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
-				exit(1);	// never signal readiness without a REAL hold -- the parent
-					// would then run with no contention and a negative assertion
-					// ("no dispatch", "entry survived") would pass for the wrong reason
+				@fwrite($holderChild, "HOLDER_ERROR\n");
+				exit(1);
 			}
-			touch($markerPath);
-			usleep(500000);
+			fwrite($holderChild, "LOCKED\n");
+			$this->expectChildEvent($holderChild, 'RELEASE', 'sync-status expiry holder release');
 			flock($fp, LOCK_UN);
 			fclose($fp);
+			fwrite($holderChild, "UNLOCKED\n");
+			fclose($holderChild);
 			exit(0);
 		}
 
-		$deadline = microtime(TRUE) + 2.0;
-		while (!file_exists($markerPath)) {
-			if (microtime(TRUE) >= $deadline) {
-				pcntl_waitpid($pid, $waitStatus);
-				$GLOBALS['pfb'] = $originalPfb;
-				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
-			}
-			usleep(1000);
-		}
+		fclose($holderChild);
+		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'sync-status expiry holder acquisition'));
 
 		try {
 			$fnRan = FALSE;
@@ -388,7 +491,12 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			$this->assertStringContainsString('sync-status ledger lock timed out', $log,
 				'a timed-out acquire must be logged loudly -- an operator-observable signal, never silent');
 		} finally {
+			fwrite($holderParent, "RELEASE\n");
+			$this->assertSame("UNLOCKED\n", $this->readEvent($holderParent, 'sync-status expiry holder unlock'));
+			fclose($holderParent);
 			pcntl_waitpid($pid, $waitStatus);
+			$this->assertTrue(pcntl_wifexited($waitStatus) && pcntl_wexitstatus($waitStatus) === 0,
+				'sync-status expiry holder must exit cleanly after the release event');
 			$GLOBALS['pfb'] = $originalPfb;
 		}
 	}
@@ -516,50 +624,6 @@ final class PfbSyncStatusLedgerTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Fork a child that opens $lockPath fresh (never an inherited fd -- a genuine
-	 * second, independent lock holder), takes LOCK_EX, signals readiness via a
-	 * marker file, holds for $holdMicros, then releases.
-	 *
-	 * @return int the child pid (caller must pcntl_waitpid it).
-	 */
-	private function forkRealDataFileHolder(string $lockPath, string $markerPath, int $holdMicros): int
-	{
-		if (!function_exists('pcntl_fork')) {
-			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
-		}
-		$pid = pcntl_fork();
-		if ($pid === -1) {
-			$this->markTestSkipped('pcntl_fork() failed.');
-		}
-		if ($pid === 0) {
-			$fp = fopen($lockPath, 'c');
-			if ($fp === FALSE || !flock($fp, LOCK_EX)) {
-				exit(1);	// never signal readiness without a REAL hold -- the parent
-					// would then run with no contention and a negative assertion
-					// ("no dispatch", "entry survived") would pass for the wrong reason
-			}
-			touch($markerPath);
-			usleep($holdMicros);
-			flock($fp, LOCK_UN);
-			fclose($fp);
-			exit(0);
-		}
-		return $pid;
-	}
-
-	private function waitForDataFileMarker(string $markerPath, int $pid): void
-	{
-		$deadline = microtime(TRUE) + 2.0;
-		while (!file_exists($markerPath)) {
-			if (microtime(TRUE) >= $deadline) {
-				pcntl_waitpid($pid, $waitStatus);
-				$this->fail('child process never signalled lock acquisition (marker file never appeared) -- deadlock or fork failure?');
-			}
-			usleep(1000);
-		}
-	}
-
-	/**
 	 * read_all()'s $unavailable discriminates: TRUE only on a genuine
 	 * lock-acquire expiry against the DATA file (pfb_sync_status.json) itself --
 	 * a SEPARATE lock from pfb_sync_status_locked()'s .json.lock EX acquire.
@@ -571,17 +635,16 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
 
 		$dataPath   = $this->dir . '/pfb_sync_status.json';
-		$markerPath = $this->dir . '/read_all_timeout.marker';
-		// Holder keeps the lock for 400ms -- well past the 150ms budget under test.
-		$pid = $this->forkRealDataFileHolder($dataPath, $markerPath, 400000);
-		$this->waitForDataFileMarker($markerPath, $pid);
-
-		$unavailable = FALSE;
-		$data = pfb_sync_status_read_all($this->dir, 0.15, $unavailable);
-		pcntl_waitpid($pid, $waitStatus);
-
-		$this->assertSame([], $data, 'an expired read must still return [] (same as empty), never a stale/partial ledger');
-		$this->assertTrue($unavailable, 'a genuine lock-acquire expiry must set $unavailable = TRUE');
+		[$pid, $holderParent] = $this->forkRealDataFileHolder($dataPath);
+		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'read_all data-file holder acquisition'));
+		try {
+			$unavailable = FALSE;
+			$data = pfb_sync_status_read_all($this->dir, 0.15, $unavailable);
+			$this->assertSame([], $data, 'an expired read must still return [] (same as empty), never a stale/partial ledger');
+			$this->assertTrue($unavailable, 'a genuine lock-acquire expiry must set $unavailable = TRUE');
+		} finally {
+			$this->releaseDataFileHolder($pid, $holderParent);
+		}
 
 		// FALSE: absent ledger file.
 		$absentDir = $this->dir . '/absent_subdir';
@@ -622,12 +685,13 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		$this->assertCount(1, pfb_sync_status_list_open($this->dir), 'precondition: one entry exists before the contended open()');
 
 		$dataPath   = $this->dir . '/pfb_sync_status.json';
-		$markerPath = $this->dir . '/open_abort_timeout.marker';
-		$pid = $this->forkRealDataFileHolder($dataPath, $markerPath, 400000);
-		$this->waitForDataFileMarker($markerPath, $pid);
-
-		pfb_sync_status_open('dnsbl', 'SomeGroup', 'apply', 'should never persist', $this->dir, self::clockAt(2000), 0.15);
-		pcntl_waitpid($pid, $waitStatus);
+		[$pid, $holderParent] = $this->forkRealDataFileHolder($dataPath);
+		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'open abort data-file holder acquisition'));
+		try {
+			pfb_sync_status_open('dnsbl', 'SomeGroup', 'apply', 'should never persist', $this->dir, self::clockAt(2000), 0.15);
+		} finally {
+			$this->releaseDataFileHolder($pid, $holderParent);
+		}
 
 		$open = pfb_sync_status_list_open($this->dir);
 		$this->assertCount(1, $open,
@@ -649,12 +713,13 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		$this->assertCount(1, pfb_sync_status_list_open($this->dir), 'precondition: the entry must be open before the contended close()');
 
 		$dataPath   = $this->dir . '/pfb_sync_status.json';
-		$markerPath = $this->dir . '/close_abort_timeout.marker';
-		$pid = $this->forkRealDataFileHolder($dataPath, $markerPath, 400000);
-		$this->waitForDataFileMarker($markerPath, $pid);
-
-		pfb_sync_status_close('ip', 'pfB_StillOpen_v4', 'download', $this->dir, 0.15);
-		pcntl_waitpid($pid, $waitStatus);
+		[$pid, $holderParent] = $this->forkRealDataFileHolder($dataPath);
+		$this->assertSame("LOCKED\n", $this->readEvent($holderParent, 'close abort data-file holder acquisition'));
+		try {
+			pfb_sync_status_close('ip', 'pfB_StillOpen_v4', 'download', $this->dir, 0.15);
+		} finally {
+			$this->releaseDataFileHolder($pid, $holderParent);
+		}
 
 		$open = pfb_sync_status_list_open($this->dir);
 		$this->assertCount(1, $open,

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -129,8 +129,8 @@ final class PfbSyncStatusLedgerTest extends TestCase
 	/** @return array{0:int,1:mixed} */
 	private function forkRealDataFileHolder(string $lockPath): array
 	{
-		if (!function_exists('pcntl_fork')) {
-			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+			$this->markTestSkipped('pcntl_fork() and posix_kill() required for fork cleanup.');
 		}
 		[$parent, $child] = $this->signalPair();
 		stream_set_timeout($parent, 5);
@@ -184,8 +184,8 @@ final class PfbSyncStatusLedgerTest extends TestCase
 				if ($waited === 0 && function_exists('posix_kill')) {
 					@posix_kill($pid, SIGKILL);
 					$waited = pcntl_waitpid($pid, $status);
-				} elseif ($waited === 0) {
-					$waited = pcntl_waitpid($pid, $status);
+				} elseif ($waited === 0 && $cleanupError === NULL) {
+					$cleanupError = new RuntimeException('data-file holder cannot be reaped: posix_kill unavailable');
 				}
 			}
 			if ($waited < 0 && $cleanupError === NULL) {
@@ -529,8 +529,8 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 	public function testSyncStatusLockedExpiryIsObservableAndStillRunsFn(): void
 	{
-		if (!function_exists('pcntl_fork')) {
-			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
+		if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+			$this->markTestSkipped('pcntl_fork() and posix_kill() required for fork cleanup.');
 		}
 
 		$originalPfb = $GLOBALS['pfb'] ?? [];
@@ -612,8 +612,8 @@ final class PfbSyncStatusLedgerTest extends TestCase
 				if ($waited === 0 && function_exists('posix_kill')) {
 					@posix_kill($pid, SIGKILL);
 					$waited = pcntl_waitpid($pid, $waitStatus);
-				} elseif ($waited === 0) {
-					$waited = pcntl_waitpid($pid, $waitStatus);
+				} elseif ($waited === 0 && $cleanupError === NULL) {
+					$cleanupError = new RuntimeException('sync-status expiry holder cannot be reaped: posix_kill unavailable');
 				}
 			}
 			if ($waited < 0 && $cleanupError === NULL) {


### PR DESCRIPTION
## Summary

Replace scheduler-sensitive timing verdicts in the two remaining #1994 PHPUnit modules with explicit cross-process event ordering.

- `DnsblManifestAtomicGenerationTest` now consumes lock-holder, contention, result, release, and completion events instead of measuring elapsed time or asserting that no pipe data arrived within 200 ms.
- `PfbSyncStatusLedgerTest` now proves the concurrent-open order on one shared event stream: `LOCKED` -> `CONTENDED` -> `RELEASING` -> `RETURNED`.
- Fixed-duration lock holds introduced by #2025 are now release-controlled. Their bounded-expiry assertions run while the holder still owns the lock, then the holder is released and reaped.
- Event waits retain only a five-second salvage cap. Timeout or EOF fails with `salvage cap expired / stuck or environment` and names the awaited event; wrong tokens and failed lock setup are distinct failures.

No production code changed.

## Composition with #2025

PR #2025 added bounded-lock expiry semantics and new contention tests in both files. This conversion preserves those assertions: the expiry result and log are still observed before releasing the real holder. It also preserves #2025's requirement that a child never signals readiness unless `fopen()` and `flock()` genuinely succeeded.

## Scope note

`tests/php/TickFeedPassDeferralTest.php` was originally included in #1994, but #2024 and PR #2040 already converted it on current `devel`. Tip confirms its completion count is event-derived and its remaining 30-second bound is only a loud `STUCK/ENVIRONMENT` salvage cap, so this PR does not touch it.

## Evidence

Behavior-preserving baseline before conversion:

```text
OK (40 tests, 194 assertions)
```

Focused suite after conversion:

```text
OK (40 tests, 219 assertions)
```

Canonical gates on the final rebased commit:

```text
GATE PASS: php -l tests/php/DnsblManifestAtomicGenerationTest.php
GATE PASS: php -l tests/php/PfbSyncStatusLedgerTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

Independent gate also ran the concurrent-open test 20 times and the seven lock/event tests five times. Its hostile early-return probe failed the broken sequence as intended:

```text
mutation caught: expected RELEASING, got RETURNED
```

The two-file conformance sweep has no `microtime`, `stream_select`, `usleep`, fixed holder sleep, marker poll, or elapsed-time verdict remaining.

Fixes #1994
Refs #1517, #2024, #2025, #2040

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of concurrency and locking test coverage.
  * Added deterministic checks for lock acquisition, release, timeouts, and cleanup.
  * Added validation for lock-related logging and fail-open behavior.
  * Expanded coverage for expired, missing, corrupt, and successful data reads.
  * Verified read-modify-write operations stop safely when locks cannot be acquired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->