### PR TITLE
pfblockerng: bound SafeSearch DNS and derive chroot teardown (#2014, #2026)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7508,14 +7508,31 @@ function pfb_ss_resolve_target($target) {
 	// DNS traffic (a box with a loopback resolver made the real exec succeed and the
 	// off-appliance test fail). Production default unchanged.
 	$drill_esc = escapeshellarg($pfb['drill'] ?? '/usr/bin/drill');
+	// Bound the transient drill | awk pipeline as a whole. FreeBSD timeout's default
+	// reaper mode kills every descendant on expiry; --foreground would orphan awk/drill.
+	$timeout_esc = escapeshellarg($pfb['timeout'] ?? '/usr/bin/timeout');
 
 	$out4 = array();
-	exec("{$drill_esc} A {$target_esc} {$extdns_esc} | /usr/bin/awk '/[ \\t]IN[ \\t]+A[ \\t]/ {print \$5; exit}'", $out4);
-	$v4 = filter_var(trim($out4[0] ?? ''), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ?: '';
+	$ret4 = 0;
+	$pipeline4 = "{$drill_esc} A {$target_esc} {$extdns_esc} | /usr/bin/awk '/[ \\t]IN[ \\t]+A[ \\t]/ {print \$5; exit}'";
+	exec("{$timeout_esc} -s TERM -k 5 30 /bin/sh -c " . escapeshellarg($pipeline4), $out4, $ret4);
+	if ($ret4 === 124) {
+		pfb_logger("\npfb_ss_resolve_target: A lookup TIMED OUT (killed); treating as unresolved\n", 2);
+		$v4 = '';
+	} else {
+		$v4 = filter_var(trim($out4[0] ?? ''), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ?: '';
+	}
 
 	$out6 = array();
-	exec("{$drill_esc} AAAA {$target_esc} {$extdns_esc} | /usr/bin/awk '/[ \\t]IN[ \\t]+AAAA[ \\t]/ {print \$5; exit}'", $out6);
-	$v6 = filter_var(trim($out6[0] ?? ''), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ?: '';
+	$ret6 = 0;
+	$pipeline6 = "{$drill_esc} AAAA {$target_esc} {$extdns_esc} | /usr/bin/awk '/[ \\t]IN[ \\t]+AAAA[ \\t]/ {print \$5; exit}'";
+	exec("{$timeout_esc} -s TERM -k 5 30 /bin/sh -c " . escapeshellarg($pipeline6), $out6, $ret6);
+	if ($ret6 === 124) {
+		pfb_logger("\npfb_ss_resolve_target: AAAA lookup TIMED OUT (killed); treating as unresolved\n", 2);
+		$v6 = '';
+	} else {
+		$v6 = filter_var(trim($out6[0] ?? ''), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ?: '';
+	}
 
 	return array($v4, $v6);
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7785,11 +7785,7 @@ function pfb_unbound_dnsbl($mode) {
 			// source of truth); it also mkdirs the chroot + nullfs mount-point dirs.
 			exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache stage >/dev/null 2>&1');
 		} else {
-			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
-			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_dnsbl_regex_rules.py");
-			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
-			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
-			unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_tld.txt");
+			exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache teardown >/dev/null 2>&1');
 		}
 
 		// Save changes to unbound.conf
@@ -17787,11 +17783,7 @@ function pfblockerng_php_pre_deinstall_command() {
 		}
 	}
 
-	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound.py");
-	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_dnsbl_regex_rules.py");
-	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_unbound_include.inc");
-	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_hsts.txt");
-	unlink_if_exists("{$g['unbound_chroot_path']}/pfb_py_tld.txt");
+	exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache teardown >/dev/null 2>&1');
 
 	// Remove widget (code from Snort deinstall)
 	$pfb['widgets'] = config_get_path('widgets/sequence', '');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -320,14 +320,15 @@ aliastables() {
 # wiped on reboot, so DNSBL comes up dead; this keeps it alive across reboot with PURE FILE
 # OPS (no reload/restart), kept SEPARATE from the IP aliastables flow above (different
 # lifecycles). stage = copy the SHIPPED set (PFB_PY_SHIPPED) from /usr/local into the chroot
-# (re-run on every save/restore, never restored stale); save = stage then archive the
+# (re-run on every save/restore, never restored stale); teardown = remove the SHIPPED set
+# plus its mapped TLD copy; save = stage then archive the
 # GENERATED set plus exact TOP1M detector sidecars; restore = boot earlyshellcmd, untar
 # the cached files THEN stage. Naming contract: a new generated file MUST keep the
-# pfb_unbound*/pfb_py_* prefix; a new shipped file goes in PFB_PY_SHIPPED and in the two
-# chroot teardown lists in pfblockerng.inc (the port's plist is GENERATED from the stagedir,
-# so packaging needs nothing) -- a NAME-MAPPED shipped file (source basename != chroot
-# basename) is the sole exception: it needs its own explicit stage/save handling instead;
-# see pfb_py_tld.txt. Order matters: a module goes BEFORE the file that imports it, so a
+# pfb_unbound*/pfb_py_* prefix; a new shipped file goes in PFB_PY_SHIPPED (the port's plist
+# is GENERATED from the stagedir, so packaging needs nothing) -- a NAME-MAPPED shipped file
+# (source basename != chroot basename) is the sole exception: it needs its own explicit
+# stage/save/teardown handling instead; see pfb_py_tld.txt. Order matters: a module goes
+# BEFORE the file that imports it, so a
 # load racing the staging loop never sees the importer without its dependency.
 dnsbl_cache() {
 	# Overridable for unit tests; default to the live locations.
@@ -362,10 +363,19 @@ dnsbl_cache() {
 			chown -f unbound:unbound "${pfbchroot}/pfb_py_tld.txt"
 		fi
 	}
+	dnsbl_cache_teardown() {
+		for _f in ${PFB_PY_SHIPPED}; do
+			rm -f "${pfbchroot}/${_f}"
+		done
+		rm -f "${pfbchroot}/pfb_py_tld.txt"
+	}
 
 	case "${1}" in
 		stage)
 			dnsbl_cache_stage
+			;;
+		teardown)
+			dnsbl_cache_teardown
 			;;
 		save)
 			dnsbl_cache_stage

--- a/tests/php/SafeSearchCnameTest.php
+++ b/tests/php/SafeSearchCnameTest.php
@@ -55,7 +55,7 @@ final class SafeSearchCnameTest extends TestCase
 		// Per-test log + extdns sandbox for the resolve_target boundary assertions.
 		$this->tmp = sys_get_temp_dir() . '/pfb_ss_' . uniqid('', true);
 		mkdir($this->tmp, 0777, true);
-		foreach (['log', 'errlog', 'extdns'] as $key) {
+		foreach (['log', 'errlog', 'extdns', 'drill', 'timeout'] as $key) {
 			$this->hadPfbKeys[$key]   = array_key_exists($key, $GLOBALS['pfb'] ?? []);
 			$this->savedPfbKeys[$key] = $GLOBALS['pfb'][$key] ?? null;
 		}
@@ -81,6 +81,66 @@ final class SafeSearchCnameTest extends TestCase
 	{
 		$path = $GLOBALS['pfb']['log'];
 		return file_exists($path) ? (string) file_get_contents($path) : '';
+	}
+
+	private function makeFixture(string $name, string $body): string
+	{
+		$path = "{$this->tmp}/{$name}";
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	/** @return array{timeoutLog:string, drillLog:string} */
+	private function installLookupFixtures(bool $expire): array
+	{
+		$timeoutLog = "{$this->tmp}/timeout args.log";
+		$drillLog = "{$this->tmp}/drill args.log";
+		$timeoutLogEsc = escapeshellarg($timeoutLog);
+		$drillLogEsc = escapeshellarg($drillLog);
+
+		if ($expire) {
+			$timeoutBody = "printf '%s\\n' --CALL-- >> {$timeoutLogEsc}\nprintf '%s\\n' \"$@\" >> {$timeoutLogEsc}\nprintf '%b\\n' 'partial.example.com.\\t300\\tIN\\tA\\t192.0.2.99' 'partial.example.com.\\t300\\tIN\\tAAAA\\t2001:db8::99'\nexit 124";
+		} else {
+			$timeoutBody = "printf '%s\\n' --CALL-- >> {$timeoutLogEsc}\nprintf '%s\\n' \"$@\" >> {$timeoutLogEsc}\nshift 5\nexec \"$@\"";
+		}
+		$timeout = $this->makeFixture('timeout fixture.sh', $timeoutBody);
+		$drill = $this->makeFixture('drill fixture.sh',
+			"printf '%s\\n' \"$@\" >> {$drillLogEsc}\n"
+			. "case \"$1\" in\n"
+			. "A) printf '%b\\n' 'safe.duckduckgo.com.\\t300\\tIN\\tA\\t192.0.2.10' ;;\n"
+			. "AAAA) printf '%b\\n' 'safe.duckduckgo.com.\\t300\\tIN\\tAAAA\\t2001:db8::10' ;;\n"
+			. "esac");
+
+		$GLOBALS['pfb']['timeout'] = $timeout;
+		$GLOBALS['pfb']['drill'] = $drill;
+		$GLOBALS['pfb']['extdns'] = '127.0.0.1; echo no';
+		return ['timeoutLog' => $timeoutLog, 'drillLog' => $drillLog];
+	}
+
+	/** @return list<list<string>> */
+	private function timeoutCalls(string $path): array
+	{
+		if (!is_file($path)) {
+			return [];
+		}
+		$lines = file($path, FILE_IGNORE_NEW_LINES);
+		$calls = [];
+		$call = [];
+		foreach ($lines ?: [] as $line) {
+			if ($line === '--CALL--') {
+				if ($call !== []) {
+					$calls[] = $call;
+					$call = [];
+				}
+				continue;
+			}
+			$call[] = $line;
+		}
+		if ($call !== []) {
+			$calls[] = $call;
+		}
+		return $calls;
 	}
 	// --- pfb_ss_csv_rows -------------------------------------------------------
 
@@ -260,6 +320,7 @@ final class SafeSearchCnameTest extends TestCase
 		$stub = tempnam(sys_get_temp_dir(), 'pfb_drill_stub_');
 		file_put_contents($stub, "#!/bin/sh\nexit 0\n");
 		chmod($stub, 0755);
+		$this->installLookupFixtures(false);
 		$GLOBALS['pfb']['drill'] = $stub;
 		try {
 			$result = pfb_ss_resolve_target('safe.duckduckgo.com');
@@ -272,6 +333,57 @@ final class SafeSearchCnameTest extends TestCase
 		$this->assertStringNotContainsString('failed validation', $this->logContents());
 	}
 
+	public function test_resolve_target_a_result_runs_through_default_reaper_timeout(): void
+	{
+		$logs = $this->installLookupFixtures(false);
+
+		$result = pfb_ss_resolve_target('safe.duckduckgo.com');
+
+		$this->assertSame(['192.0.2.10', '2001:db8::10'], $result);
+		$calls = $this->timeoutCalls($logs['timeoutLog']);
+		$this->assertCount(2, $calls);
+		$this->assertSame(['-s', 'TERM', '-k', '5', '30', '/bin/sh', '-c'], array_slice($calls[0], 0, 7));
+		$this->assertNotContains('--foreground', $calls[0]);
+		$this->assertSame(
+			['A', 'safe.duckduckgo.com', '@127.0.0.1; echo no', 'AAAA', 'safe.duckduckgo.com', '@127.0.0.1; echo no'],
+			file($logs['drillLog'], FILE_IGNORE_NEW_LINES)
+		);
+	}
+
+	public function test_resolve_target_aaaa_result_runs_through_default_reaper_timeout(): void
+	{
+		$this->installLookupFixtures(false);
+		// The fixture serves both families; isolate the AAAA leg by using a drill fixture
+		// whose A output is intentionally not an IPv4 answer.
+		$GLOBALS['pfb']['drill'] = $this->makeFixture('aaaa drill fixture.sh',
+			"case \"$1\" in\n"
+			. "A) exit 0 ;;\n"
+			. "AAAA) printf '%b\\n' 'safe.duckduckgo.com.\\t300\\tIN\\tAAAA\\t2001:db8::10' ;;\n"
+			. "esac");
+
+		$result = pfb_ss_resolve_target('safe.duckduckgo.com');
+
+		$this->assertSame(['', '2001:db8::10'], $result);
+	}
+
+	public function test_resolve_target_timeout_discards_partial_a_and_aaaa_results_and_logs_both_expiries(): void
+	{
+		$logs = $this->installLookupFixtures(true);
+
+		$result = pfb_ss_resolve_target('safe.duckduckgo.com');
+
+		$this->assertSame(['', ''], $result);
+		$log = $this->logContents();
+		$this->assertStringContainsString('A lookup TIMED OUT', $log);
+		$this->assertStringContainsString('AAAA lookup TIMED OUT', $log);
+		$calls = $this->timeoutCalls($logs['timeoutLog']);
+		$this->assertCount(2, $calls);
+		foreach ($calls as $call) {
+			$this->assertSame(['-s', 'TERM', '-k', '5', '30', '/bin/sh', '-c'], array_slice($call, 0, 7));
+			$this->assertNotContains('--foreground', $call);
+		}
+	}
+
 	public function test_resolve_target_uses_injected_resolver_binary(): void
 	{
 		// Seam proof (#723): a stub resolver that EMITS a drill-shaped answer must have
@@ -281,6 +393,7 @@ final class SafeSearchCnameTest extends TestCase
 		$stub = tempnam(sys_get_temp_dir(), 'pfb_drill_stub_');
 		file_put_contents($stub, "#!/bin/sh\n[ \"\$1\" = \"A\" ] && printf 'stub.example.com.\\t300\\tIN\\tA\\t192.0.2.99\\n'\nexit 0\n");
 		chmod($stub, 0755);
+		$this->installLookupFixtures(false);
 		$GLOBALS['pfb']['drill'] = $stub;
 		try {
 			$result = pfb_ss_resolve_target('safe.duckduckgo.com');

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -4,6 +4,7 @@
 # Pins the three subcommands against a sandbox chroot:
 #   stage   -- copies the SHIPPED files into the chroot and creates the nullfs/devfs
 #              mount-point dirs (the fresh-MFS fix that made pfb_python_mount fail).
+#   teardown -- removes the SHIPPED files and mapped TLD copy from the chroot.
 #   save    -- archives ONLY the GENERATED set (pfb_py_* + pfb_unbound.ini), never the
 #              shipped files (those come from /usr/local on restore -> no stale code).
 #   restore -- untars the generated set THEN stages the shipped files; round-trips the
@@ -82,7 +83,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     dc restore
   }
 
-  It 'stage copies the shipped files and creates the nullfs/devfs mount-point dirs'
+  It 'stage copies all shipped files and the mapped TLD file, then creates mount-point dirs'
     setup_sandbox
     # Before: the chroot does not exist at all (fresh MFS).
     When call dc stage
@@ -91,11 +92,45 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     The path "${pfbchroot}/pfb_dnsbl_regex_rules.py" should be exist
     The path "${pfbchroot}/pfb_unbound_include.inc" should be exist
     The path "${pfbchroot}/pfb_py_hsts.txt" should be exist
+    The path "${pfbchroot}/pfb_py_tld.txt" should be exist
     # The mount-point dirs exist (the fresh-MFS fix).
     The path "${pfbchroot}/lib" should be directory
     The path "${pfbchroot}/dev" should be directory
     The path "${pfbchroot}/var/log/pfblockerng" should be directory
     The path "${pfbchroot}/usr/local/share/GeoIP" should be directory
+    cleanup_sandbox
+  End
+
+  It 'teardown removes all shipped files and the mapped TLD file from a chroot path with spaces'
+    setup_sandbox
+    pfbchroot="${sandbox}/chroot path"
+    dc stage
+    When call dc teardown
+    The status should be success
+    The path "${pfbchroot}/pfb_dnsbl_regex_rules.py" should not be exist
+    The path "${pfbchroot}/pfb_unbound.py" should not be exist
+    The path "${pfbchroot}/pfb_unbound_include.inc" should not be exist
+    The path "${pfbchroot}/pfb_py_hsts.txt" should not be exist
+    The path "${pfbchroot}/pfb_py_tld.txt" should not be exist
+    cleanup_sandbox
+  End
+
+  teardown_twice() {
+    dnsbl_cache teardown 2>/dev/null
+    first=$?
+    dnsbl_cache teardown 2>/dev/null
+    second=$?
+    printf '%s:%s\n' "${first}" "${second}"
+  }
+
+  It 'teardown is idempotent when all files are already absent'
+    setup_sandbox
+    pfbchroot="${sandbox}/chroot path"
+    dc stage
+    dc teardown
+    When call teardown_twice
+    The output should equal '0:0'
+    The path "${pfbchroot}/pfb_py_tld.txt" should not be exist
     cleanup_sandbox
   End
 

--- a/tests/test_dnsbl_chroot_teardown_contract.py
+++ b/tests/test_dnsbl_chroot_teardown_contract.py
@@ -1,0 +1,92 @@
+"""DNSBL chroot teardown keeps each consumer and the shell source of truth wired."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PKG_DIR = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng"
+INC = PKG_DIR / "pfblockerng.inc"
+SHELL = PKG_DIR / "pfblockerng.sh"
+TEARDOWN_EXEC = "exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache teardown >/dev/null 2>&1');"
+STAGE_EXEC = "exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache stage >/dev/null 2>&1');"
+STATIC_CHROOT_FILES = (
+    "pfb_dnsbl_regex_rules.py",
+    "pfb_unbound.py",
+    "pfb_unbound_include.inc",
+    "pfb_py_hsts.txt",
+    "pfb_py_tld.txt",
+)
+
+
+def _php_function_body(source: str, name: str) -> str:
+    """Extract one top-level function from the PHP source."""
+    matches = list(
+        re.finditer(
+            rf"^function {re.escape(name)}\([^\n]*\)\s*\{{",
+            source,
+            re.MULTILINE,
+        )
+    )
+    assert len(matches) == 1, f"expected one {name}() declaration"
+    start = matches[0].end()
+    following = re.search(r"^function\s+", source[start:], re.MULTILINE)
+    end = start + following.start() if following else len(source)
+    return source[start:end]
+
+
+def _shell_teardown_body(source: str) -> str:
+    match = re.search(
+        r"dnsbl_cache_teardown\(\) \{\n(?P<body>.*?)\n\t\}\n\n\tcase \"\$\{1\}\" in",
+        source,
+        re.DOTALL,
+    )
+    assert match is not None, "dnsbl_cache_teardown() dispatch boundary not found"
+    return match.group("body")
+
+
+def _shipped_files(source: str) -> list[str]:
+    assignments = re.findall(r"^\s*PFB_PY_SHIPPED='([^']*)'", source, re.MULTILINE)
+    assert len(assignments) == 1, "PFB_PY_SHIPPED must have one declaration"
+    files = assignments[0].split()
+    assert files, "PFB_PY_SHIPPED must not be empty"
+    return files
+
+
+def test_each_php_consumer_has_one_scoped_teardown_call() -> None:
+    source = INC.read_text()
+    for name in ("pfb_unbound_dnsbl", "pfblockerng_php_pre_deinstall_command"):
+        body = _php_function_body(source, name)
+        assert body.count(TEARDOWN_EXEC) == 1
+        for call in re.finditer(r"unlink_if_exists\s*\((?P<argument>.*?)\)", body, re.DOTALL):
+            argument = call.group("argument")
+            assert "unbound_chroot_path" not in argument, argument
+            assert not any(file_name in argument for file_name in STATIC_CHROOT_FILES), argument
+
+        if name == "pfb_unbound_dnsbl":
+            branches = [
+                match
+                for match in re.finditer(
+                    r"^[ \t]*if \(\$mode == 'enabled'\) \{\n"
+                    r"(?P<enabled>.*?)[ \t]*\} else \{\n"
+                    r"(?P<disabled>.*?)\n[ \t]*\}",
+                    body,
+                    re.MULTILINE | re.DOTALL,
+                )
+                if STAGE_EXEC in match.group("enabled")
+            ]
+            assert len(branches) == 1, "enabled stage branch not uniquely scoped"
+            enabled, disabled = branches[0].group("enabled", "disabled")
+            assert TEARDOWN_EXEC not in enabled
+            assert disabled.count(TEARDOWN_EXEC) == 1
+
+
+def test_shell_teardown_derives_shipped_files_and_maps_tld_copy() -> None:
+    source = SHELL.read_text()
+    body = _shell_teardown_body(source)
+    shipped = _shipped_files(source)
+
+    assert body.count("for _f in ${PFB_PY_SHIPPED}; do") == 1
+    assert body.count('rm -f "${pfbchroot}/${_f}"') == 1
+    assert 'rm -f "${pfbchroot}/pfb_py_tld.txt"' in body
+    assert all(file_name not in body for file_name in shipped)

--- a/tests/test_dnsbl_chroot_teardown_parity.py
+++ b/tests/test_dnsbl_chroot_teardown_parity.py
@@ -1,17 +1,8 @@
-"""Every shipped DNSBL Python file staged into Unbound's chroot must also be torn
-down when DNSBL Python mode is disabled and when the package is uninstalled.
+"""DNSBL chroot teardown stays wired to the shell's single source of truth.
 
-`dnsbl_cache stage` in pfblockerng.sh owns the shipped-file set as ONE list
-(``PFB_PY_SHIPPED``) and pfblockerng.inc's *enable* branch defers to it by shelling
-out. The *teardown* side does not: `pfb_unbound_dnsbl()`'s disable branch and
-`pfblockerng_php_pre_deinstall_command()` each carry their own hardcoded
-`unlink_if_exists()` list, so a newly shipped file is staged into `/var/unbound` by
-the single source and then left orphaned there by both teardown paths.
-
-Issue #1765 hit exactly that: `pfb_dnsbl_regex_rules.py` was added to
-``PFB_PY_SHIPPED`` and neither teardown list. This pins the invariant until the
-teardown lists are derived from the single source too (tracked separately) --
-adding a file to ``PFB_PY_SHIPPED`` without updating both lists fails here.
+`dnsbl_cache stage` owns ``PFB_PY_SHIPPED`` and both PHP consumers must invoke
+`dnsbl_cache teardown`; the shell operation derives the static set and its
+name-mapped TLD copy. No PHP teardown block may duplicate those basenames.
 """
 
 from __future__ import annotations
@@ -40,41 +31,21 @@ def _shipped_files() -> list[str]:
     return files
 
 
-def _teardown_blocks() -> dict[str, set[str]]:
-    """Every run of consecutive ``unlink_if_exists("{$g['unbound_chroot_path']}/...")``
-    calls in pfblockerng.inc, keyed by the line number the run starts at, mapped to the
-    set of chroot basenames it removes."""
-    source = INC.read_text().splitlines()
-    call = re.compile(r"""unlink_if_exists\("\{\$g\['unbound_chroot_path'\]\}/([^"]+)"\)""")
-    blocks: dict[str, set[str]] = {}
-    current: set[str] = set()
-    start = 0
-    for number, line in enumerate(source, start=1):
-        found = call.search(line)
-        if found:
-            if not current:
-                start = number
-            current.add(found.group(1))
-        elif current:
-            blocks[f"pfblockerng.inc:{start}"] = current
-            current = set()
-    if current:
-        blocks[f"pfblockerng.inc:{start}"] = current
-    return blocks
+def test_both_chroot_teardown_consumers_call_the_derived_shell_operation() -> None:
+    source = INC.read_text()
+    teardown_call = "exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache teardown >/dev/null 2>&1');"
+    assert source.count(teardown_call) == 2
+    assert not re.search(
+        r"""unlink_if_exists\("\{\$g\['unbound_chroot_path'\]\}/pfb_[^"]+"\)""",
+        source,
+    )
 
 
-def test_both_chroot_teardown_lists_cover_every_shipped_python_file() -> None:
-    blocks = _teardown_blocks()
-    # The disable branch of pfb_unbound_dnsbl() and pfblockerng_php_pre_deinstall_command().
-    assert len(blocks) == 2, f"expected exactly 2 chroot teardown blocks, found: {sorted(blocks)}"
-
-    expected = set(_shipped_files()) | set(NAME_MAPPED_CHROOT_FILES)
-    for location, removed in blocks.items():
-        missing = expected - removed
-        assert not missing, (
-            f"{location}: staged into the chroot but never torn down: {sorted(missing)}. "
-            "Add an unlink_if_exists() line for each, or derive the list from PFB_PY_SHIPPED."
-        )
+def test_teardown_derivation_includes_the_name_mapped_tld_copy() -> None:
+    source = SHELL.read_text()
+    assert "for _f in ${PFB_PY_SHIPPED}; do" in source
+    assert '"${pfbchroot}/pfb_py_tld.txt"' in source
+    assert NAME_MAPPED_CHROOT_FILES == ("pfb_py_tld.txt",)
 
 
 def test_an_imported_module_is_staged_before_the_file_that_imports_it() -> None:


### PR DESCRIPTION
## Summary

- bound both SafeSearch `drill(1)` lookups with `/usr/bin/timeout -s TERM -k 5 30` in default reaper mode, logging expiry and discarding partial answers
- derive DNSBL chroot teardown from `PFB_PY_SHIPPED` plus the mapped `pfb_py_tld.txt`, with both disable and pre-deinstall callers delegating to it

## Commits

- `pfblockerng: bound SafeSearch drill lookups` — issue #2014
- `pfblockerng: derive DNSBL chroot teardown` — issue #2026

## Evidence

- #2014 frozen PHPUnit proof: RED 16 tests / 30 assertions / 2 expected failures; GREEN 16 tests / 40 assertions; hash `4713855940e5a57dc372c02ebe48a0390aa9cde0`
- #2026 frozen pytest proof: RED 1 failed / 3 passed; GREEN 4 passed; hash `fe03dbad2d2e7eaf4d4f7d00cbe266b6717afa68`
- #2026 frozen ShellSpec proof under dash: RED 18 examples / 2 failures; GREEN 18 examples / 0 failures; hash `faaddb1f43bb92c894fff517abda28747717c396`
- #2026 review guard proof: five realistic source mutants RED; real head GREEN 6 tests; hash `0a710f9c1890158fe3d719ee41593cd4e182df1c`
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS — pytest, Ruff, mypy, PHPUnit, PHPStan, PHPCS, sh syntax, ShellCheck, and full ShellSpec under dash
- independent per-commit verifier gates: PASS

Adversarial review's production audit passed. Its test-honesty finding was applied with scoped consumer/helper guards and independently re-reviewed; the pre-existing Alerts-page sibling was deferred to #2083.

The SafeSearch resolver uses default reaper mode because `drill | awk` is a transient process tree. Wrapping the complete pipeline through `/bin/sh -c` lets timeout kill all descendants and preserve exit 124; `--foreground` could leave a descendant behind.

Fixes #2014
Fixes #2026

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
