### PR TITLE
tests: distinguish timing salvage failures (#1996)

### DIFF
--- a/tests/php/DnsblLogEventQueryAttributionSalvageDiagnosticTest.php
+++ b/tests/php/DnsblLogEventQueryAttributionSalvageDiagnosticTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Source pin: the query responder's salvage expiry must be loud and parent-observed. */
+final class DnsblLogEventQueryAttributionSalvageDiagnosticTest extends TestCase
+{
+	public function testResponderExpiryIsTypedTrackedAndNotDetached(): void
+	{
+		$source = file_get_contents(__DIR__ . '/DnsblLogEventQueryAttributionTest.php');
+		$this->assertNotFalse($source, 'DnsblLogEventQueryAttributionTest.php must be readable');
+
+		$this->assertStringContainsString(
+			"throw new RuntimeException('salvage cap expired / stuck or environment: waiting for the query-channel request marker');",
+			$source,
+			'query-channel request-marker salvage expiry must be distinguishable from a behavioural failure'
+		);
+		$this->assertStringNotContainsString(
+			'> /dev/null 2>&1 &',
+			$source,
+			'the responder must be tracked by the parent, not detached through a background shell'
+		);
+		$this->assertStringContainsString('$this->forkChild(', $source, 'the responder must be a tracked child');
+		$this->assertStringContainsString('pcntl_waitpid', $source, 'the parent must observe and reap the responder');
+	}
+}

--- a/tests/php/DnsblLogEventQueryAttributionSalvageDiagnosticTest.php
+++ b/tests/php/DnsblLogEventQueryAttributionSalvageDiagnosticTest.php
@@ -23,6 +23,7 @@ final class DnsblLogEventQueryAttributionSalvageDiagnosticTest extends TestCase
 		$this->assertStringContainsString('if ($written !== strlen($reply))', $spawnResponder);
 		$this->assertStringContainsString("throw new RuntimeException('query responder reply write failed');", $spawnResponder);
 		$this->assertStringContainsString('$this->forkChild(', $spawnResponder, 'the responder must be a tracked child');
+		$this->assertStringNotContainsString('> /dev/null 2>&1 &', $spawnResponder, 'the responder must not use the old detached shell');
 		foreach (['exec(', 'proc_open(', 'shell_exec(', 'system(', 'passthru('] as $sink) {
 			$this->assertStringNotContainsString($sink, $spawnResponder, "responder must not invoke process sink {$sink}");
 		}
@@ -47,11 +48,19 @@ final class DnsblLogEventQueryAttributionSalvageDiagnosticTest extends TestCase
 			$callerEnd = strpos($source, "\n\tpublic function ", $callerStart + 1);
 			$callerEnd = $callerEnd === false ? strlen($source) : $callerEnd;
 			$callerSource = substr($source, $callerStart, $callerEnd - $callerStart);
-			$reap = strpos($callerSource, '$this->reapResponders();');
-			$assert = strpos($callerSource, '$this->assert');
-			$this->assertNotFalse($reap, "{$caller}() must reap its responder");
-			$this->assertNotFalse($assert, "{$caller}() must retain product assertions");
-			$this->assertLessThan($assert, $reap, "{$caller}() must reap before product assertions");
+			$reapMatch = [];
+			$assertMatch = [];
+			$this->assertSame(
+				1,
+				preg_match('/^[ \t]*\$this->reapResponders\(\);[ \t]*$/m', $callerSource, $reapMatch, PREG_OFFSET_CAPTURE),
+				"{$caller}() must reap its responder on an executable line"
+			);
+			$this->assertSame(
+				1,
+				preg_match('/^[ \t]*\$this->assert[A-Za-z]+\(/m', $callerSource, $assertMatch, PREG_OFFSET_CAPTURE),
+				"{$caller}() must retain product assertions on executable lines"
+			);
+			$this->assertLessThan($assertMatch[0][1], $reapMatch[0][1], "{$caller}() must reap before product assertions");
 		}
 	}
 }

--- a/tests/php/DnsblLogEventQueryAttributionSalvageDiagnosticTest.php
+++ b/tests/php/DnsblLogEventQueryAttributionSalvageDiagnosticTest.php
@@ -12,17 +12,46 @@ final class DnsblLogEventQueryAttributionSalvageDiagnosticTest extends TestCase
 		$source = file_get_contents(__DIR__ . '/DnsblLogEventQueryAttributionTest.php');
 		$this->assertNotFalse($source, 'DnsblLogEventQueryAttributionTest.php must be readable');
 
+		$signature = "\tprivate function spawnResponder(string \$replyTemplateJson): void";
+		$start = strpos($source, $signature);
+		$this->assertNotFalse($start, 'spawnResponder() must exist');
+		$end = strpos($source, "\n\tprivate function ", $start + strlen($signature));
+		$this->assertNotFalse($end, 'spawnResponder() must have a following private method boundary');
+		$spawnResponder = substr($source, $start, $end - $start);
+
+		$this->assertStringContainsString('$written = file_put_contents(', $spawnResponder);
+		$this->assertStringContainsString('if ($written !== strlen($reply))', $spawnResponder);
+		$this->assertStringContainsString("throw new RuntimeException('query responder reply write failed');", $spawnResponder);
+		$this->assertStringContainsString('$this->forkChild(', $spawnResponder, 'the responder must be a tracked child');
+		foreach (['exec(', 'proc_open(', 'shell_exec(', 'system(', 'passthru('] as $sink) {
+			$this->assertStringNotContainsString($sink, $spawnResponder, "responder must not invoke process sink {$sink}");
+		}
+
 		$this->assertStringContainsString(
-			"throw new RuntimeException('salvage cap expired / stuck or environment: waiting for the query-channel request marker');",
-			$source,
+			'salvage cap expired / stuck or environment',
+			$spawnResponder,
 			'query-channel request-marker salvage expiry must be distinguishable from a behavioural failure'
 		);
-		$this->assertStringNotContainsString(
-			'> /dev/null 2>&1 &',
-			$source,
-			'the responder must be tracked by the parent, not detached through a background shell'
-		);
-		$this->assertStringContainsString('$this->forkChild(', $source, 'the responder must be a tracked child');
-		$this->assertStringContainsString('pcntl_waitpid', $source, 'the parent must observe and reap the responder');
+		$this->assertStringContainsString('query-channel request marker', $spawnResponder);
+		$this->assertStringContainsString("\tprivate const SALVAGE_CAP_S = 30.0;", $source);
+		$this->assertStringContainsString('self::SALVAGE_CAP_S', $spawnResponder, 'the responder poll must use the salvage cap');
+
+		foreach ([
+			'testBlockedVerdictAttributesLiveGroupAndBumpsLiveCounter',
+			'testCleanVerdictAttributesUnknownNoCounterMove',
+			'testBlockedEmptyAttributionFallsBackToUnknownPerField',
+			'testHostileGroupIsHtmlEncodedNeverRaw',
+		] as $caller) {
+			$callerStart = strpos($source, "\tpublic function {$caller}(): void");
+			$this->assertNotFalse($callerStart, "{$caller}() must exist");
+			$callerEnd = strpos($source, "\n\tpublic function ", $callerStart + 1);
+			$callerEnd = $callerEnd === false ? strlen($source) : $callerEnd;
+			$callerSource = substr($source, $callerStart, $callerEnd - $callerStart);
+			$reap = strpos($callerSource, '$this->reapResponders();');
+			$assert = strpos($callerSource, '$this->assert');
+			$this->assertNotFalse($reap, "{$caller}() must reap its responder");
+			$this->assertNotFalse($assert, "{$caller}() must retain product assertions");
+			$this->assertLessThan($assert, $reap, "{$caller}() must reap before product assertions");
+		}
 	}
 }

--- a/tests/php/DnsblLogEventQueryAttributionSalvageDiagnosticTest.php
+++ b/tests/php/DnsblLogEventQueryAttributionSalvageDiagnosticTest.php
@@ -19,23 +19,45 @@ final class DnsblLogEventQueryAttributionSalvageDiagnosticTest extends TestCase
 		$this->assertNotFalse($end, 'spawnResponder() must have a following private method boundary');
 		$spawnResponder = substr($source, $start, $end - $start);
 
-		$this->assertStringContainsString('$written = file_put_contents(', $spawnResponder);
-		$this->assertStringContainsString('if ($written !== strlen($reply))', $spawnResponder);
-		$this->assertStringContainsString("throw new RuntimeException('query responder reply write failed');", $spawnResponder);
-		$this->assertStringContainsString('$this->forkChild(', $spawnResponder, 'the responder must be a tracked child');
+		$this->assertSame(
+			1,
+			preg_match('/^[ \t]*\$this->forkChild\(function \(\) use \(\$replyTemplateJson\): void \{$/m', $spawnResponder),
+			'the responder must fork on an executable line'
+		);
+		$this->assertSame(
+			1,
+			preg_match('/^[ \t]*\$deadline = microtime\(true\) \+ self::SALVAGE_CAP_S;[ \t]*$/m', $spawnResponder),
+			'the responder deadline must use the salvage cap on an executable line'
+		);
+		$this->assertSame(
+			1,
+			preg_match('/^[ \t]*\$written = file_put_contents\([^;]+, \$reply\);[ \t]*$/m', $spawnResponder),
+			'the reply write count must be captured on an executable line'
+		);
+		$this->assertSame(
+			1,
+			preg_match('/^[ \t]*if \(\$written !== strlen\(\$reply\)\) \{$/m', $spawnResponder),
+			'the reply write count must be checked on an executable line'
+		);
+		$this->assertSame(
+			1,
+			preg_match('/^[ \t]*throw new RuntimeException\(\'query responder reply write failed\'\);[ \t]*$/m', $spawnResponder),
+			'the reply-write failure must throw on an executable line'
+		);
 		$this->assertStringNotContainsString('> /dev/null 2>&1 &', $spawnResponder, 'the responder must not use the old detached shell');
 		foreach (['exec(', 'proc_open(', 'shell_exec(', 'system(', 'passthru('] as $sink) {
 			$this->assertStringNotContainsString($sink, $spawnResponder, "responder must not invoke process sink {$sink}");
 		}
 
-		$this->assertStringContainsString(
-			'salvage cap expired / stuck or environment',
-			$spawnResponder,
-			'query-channel request-marker salvage expiry must be distinguishable from a behavioural failure'
+		$this->assertSame(
+			1,
+			preg_match(
+				'/^[ \t]*throw new RuntimeException\((?:"|\')[^"\']*salvage cap expired \/ stuck or environment[^"\']*query-channel request marker[^"\']*(?:"|\')\);[ \t]*$/m',
+				$spawnResponder
+			),
+			'query-channel request-marker salvage expiry must be typed on an executable line'
 		);
-		$this->assertStringContainsString('query-channel request marker', $spawnResponder);
-		$this->assertStringContainsString("\tprivate const SALVAGE_CAP_S = 30.0;", $source);
-		$this->assertStringContainsString('self::SALVAGE_CAP_S', $spawnResponder, 'the responder poll must use the salvage cap');
+		$this->assertSame(1, preg_match('/^[ \t]*private const SALVAGE_CAP_S = 30\.0;[ \t]*$/m', $source));
 
 		foreach ([
 			'testBlockedVerdictAttributesLiveGroupAndBumpsLiveCounter',

--- a/tests/php/DnsblLogEventQueryAttributionTest.php
+++ b/tests/php/DnsblLogEventQueryAttributionTest.php
@@ -28,8 +28,12 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_log_event')]
 final class DnsblLogEventQueryAttributionTest extends TestCase
 {
+	/** Salvage only: expiry means the run is stuck or the box is broken. */
+	private const SALVAGE_CAP_S = 30.0;
 	private string $tmp;
 	private array $savedPfb = [];
+	/** @var array<int, true> */
+	private array $children = [];
 
 	protected function setUp(): void
 	{
@@ -72,12 +76,32 @@ final class DnsblLogEventQueryAttributionTest extends TestCase
 			'supp'     => 'off',
 		];
 		touch($GLOBALS['pfb']['unbound_py_zone']);
+
+		foreach (['pcntl_fork', 'pcntl_waitpid', 'pcntl_wifexited', 'pcntl_wexitstatus', 'posix_kill'] as $function) {
+			if (!function_exists($function)) {
+				$this->markTestSkipped("{$function}() is unavailable -- cannot run cross-process query-channel tests.");
+			}
+		}
 	}
 
 	protected function tearDown(): void
 	{
-		$GLOBALS['pfb'] = $this->savedPfb;
-		$this->rrmdir($this->tmp);
+		$failure = null;
+		try {
+			foreach (array_keys($this->children) as $pid) {
+				try {
+					$this->reapChild($pid);
+				} catch (Throwable $e) {
+					$failure ??= $e;
+				}
+			}
+		} finally {
+			$GLOBALS['pfb'] = $this->savedPfb;
+			$this->rrmdir($this->tmp);
+		}
+		if ($failure !== null) {
+			throw $failure;
+		}
 	}
 
 	private function rrmdir(string $dir): void
@@ -128,43 +152,92 @@ final class DnsblLogEventQueryAttributionTest extends TestCase
 		return $row ? (int) $row['counter'] : 0;
 	}
 
+	/** Fork a tracked child; the closure must communicate through temp files. */
+	private function forkChild(callable $task): int
+	{
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->markTestSkipped('pcntl_fork() failed.');
+		}
+		if ($pid === 0) {
+			try {
+				$task();
+				exit(0);
+			} catch (Throwable $e) {
+				@file_put_contents("{$this->tmp}/child-error-" . getmypid(), $e->getMessage());
+				exit(1);
+			}
+		}
+		$this->children[$pid] = true;
+		return $pid;
+	}
+
+	/** Reap a tracked responder under the salvage cap; terminate it rather than orphaning it. */
+	private function reapChild(int $pid, float $timeout_s = self::SALVAGE_CAP_S): void
+	{
+		$deadline = microtime(true) + $timeout_s;
+		do {
+			$waited = pcntl_waitpid($pid, $status, WNOHANG);
+			if ($waited === $pid) {
+				unset($this->children[$pid]);
+				$failure = $this->childFailureMessage($pid);
+				if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0) {
+					throw new RuntimeException($failure);
+				}
+				return;
+			}
+			usleep(20000);
+		} while (microtime(true) < $deadline);
+
+		@posix_kill($pid, 9);
+		pcntl_waitpid($pid, $status);
+		unset($this->children[$pid]);
+		throw new RuntimeException("salvage cap expired / stuck or environment: responder process {$pid} did not exit");
+	}
+
+	private function childFailureMessage(int $pid): string
+	{
+		$error = @file_get_contents("{$this->tmp}/child-error-{$pid}");
+		return $error !== false && $error !== '' ? "child {$pid} failed: {$error}" : "child {$pid} failed";
+	}
+
+	private function reapResponders(): void
+	{
+		foreach (array_keys($this->children) as $pid) {
+			$this->reapChild($pid);
+		}
+	}
+
 	/**
-	 * Spawn a background PHP process playing the query channel's Python side --
+	 * Spawn a tracked process playing the query channel's Python side --
 	 * mirrors DnsblQueryClientTest::spawnResponder(). Answers with $replyTemplateJson
 	 * (its "__ID__" placeholder substituted for the request's real id).
 	 */
 	private function spawnResponder(string $replyTemplateJson): void
 	{
-		$code = <<<'PHP'
-			$dir = $argv[1];
-			$tpl = $argv[2];
-			$reqPath = $dir . '/pfb_py_query';
-			$deadline = microtime(true) + 3.0;
-			$req = null;
+		$this->forkChild(function () use ($replyTemplateJson): void {
+			$reqPath = "{$this->tmp}/query/pfb_py_query";
+			$deadline = microtime(true) + self::SALVAGE_CAP_S;
+			$request = null;
 			while (microtime(true) < $deadline) {
 				if (file_exists($reqPath)) {
 					$raw = @file_get_contents($reqPath);
 					if ($raw !== false && trim($raw) !== '') {
-						$dec = json_decode($raw, true);
-						if (is_array($dec) && isset($dec['id'])) {
-							$req = $dec;
+						$decoded = json_decode($raw, true);
+						if (is_array($decoded) && isset($decoded['id'])) {
+							$request = $decoded;
 							break;
 						}
 					}
 				}
 				usleep(50000);
 			}
-			if ($req === null) {
-				exit(1);
+			if ($request === null) {
+				throw new RuntimeException('salvage cap expired / stuck or environment: waiting for the query-channel request marker');
 			}
-			$reply = str_replace('__ID__', (string) $req['id'], $tpl);
-			file_put_contents($dir . '/pfb_py_query.reply', $reply);
-			PHP;
-
-		$cmd = escapeshellarg(PHP_BINARY) . ' -r ' . escapeshellarg($code)
-			. ' ' . escapeshellarg("{$this->tmp}/query") . ' ' . escapeshellarg($replyTemplateJson)
-			. ' > /dev/null 2>&1 &';
-		exec($cmd);
+			$reply = str_replace('__ID__', (string) $request['id'], $replyTemplateJson);
+			file_put_contents("{$this->tmp}/query/pfb_py_query.reply", $reply);
+		});
 	}
 
 	/**
@@ -223,6 +296,7 @@ final class DnsblLogEventQueryAttributionTest extends TestCase
 		$unexpected = $this->callCapturingUnexpectedWarnings(function () use ($domain) {
 			pfb_log_event('DNSBL-HTTPS', $domain, '203.0.113.10', 'Mozilla/5.0');
 		});
+		$this->reapResponders();
 		$this->assertSame([], $unexpected, 'expected no unrelated PHP warning; got: ' . var_export($unexpected, true));
 
 		$fields = $this->logFields();
@@ -251,6 +325,7 @@ final class DnsblLogEventQueryAttributionTest extends TestCase
 		]));
 
 		pfb_log_event('DNSBL-HTTPS', $domain, '203.0.113.11', 'Mozilla/5.0');
+		$this->reapResponders();
 
 		$fields = $this->logFields();
 		$this->assertSame('Unknown', $fields[5], "expected mode(5)='Unknown', got: {$fields[5]}");
@@ -298,6 +373,7 @@ final class DnsblLogEventQueryAttributionTest extends TestCase
 		]));
 
 		pfb_log_event('DNSBL-HTTPS', $domain, '203.0.113.13', 'Mozilla/5.0');
+		$this->reapResponders();
 
 		$fields = $this->logFields();
 		$this->assertSame('Unknown', $fields[5], "expected mode(5)='Unknown' (never empty), got: '{$fields[5]}'");
@@ -329,6 +405,7 @@ final class DnsblLogEventQueryAttributionTest extends TestCase
 		]));
 
 		pfb_log_event('DNSBL-HTTPS', $domain, '203.0.113.14', 'Mozilla/5.0');
+		$this->reapResponders();
 
 		$fields = $this->logFields();
 		// (before) the raw responder value carries live HTML metacharacters.

--- a/tests/php/DnsblLogEventQueryAttributionTest.php
+++ b/tests/php/DnsblLogEventQueryAttributionTest.php
@@ -236,7 +236,10 @@ final class DnsblLogEventQueryAttributionTest extends TestCase
 				throw new RuntimeException('salvage cap expired / stuck or environment: waiting for the query-channel request marker');
 			}
 			$reply = str_replace('__ID__', (string) $request['id'], $replyTemplateJson);
-			file_put_contents("{$this->tmp}/query/pfb_py_query.reply", $reply);
+			$written = file_put_contents("{$this->tmp}/query/pfb_py_query.reply", $reply);
+			if ($written !== strlen($reply)) {
+				throw new RuntimeException('query responder reply write failed');
+			}
 		});
 	}
 

--- a/tests/php/DnsblRegexEntryErrorTest.php
+++ b/tests/php/DnsblRegexEntryErrorTest.php
@@ -425,13 +425,10 @@ final class DnsblRegexEntryErrorTest extends TestCase
 		$this->assertStringNotContainsString('length cap', $error);
 	}
 
-	public function testHundredThousandCharacterLineIsRejectedWithoutHanging(): void
+	public function testHundredThousandCharacterLineIsRejectedByLengthCap(): void
 	{
 		$pattern = self::anchoredPattern(100000);
-		$start = microtime(TRUE);
 		$error = self::oneError($pattern . "\n", TRUE);
-		$elapsed = microtime(TRUE) - $start;
-		$this->assertLessThan(5.0, $elapsed, 'must resolve well within the 5s timeout wrapper');
 		$this->assertStringContainsString('200-character length cap', $error);
 	}
 


### PR DESCRIPTION
## Summary

- Track and reap the DNSBL log-event query responder instead of detaching it through a background shell.
- Keep the real request-marker poll under a 30-second salvage cap and report expiry as a typed `salvage cap expired / stuck or environment` failure naming the awaited marker.
- Replace the 100,000-character regex test's elapsed-time verdict with the production length-cap diagnostic.

## Evidence

Final frozen red→green proof:

```text
RED:    diagnostic fails against origin/devel
HASH:   4e3b42afe8265f991e3c2de4847a4de21f3245cb
GREEN:  OK (65 tests, 190 assertions)
VERIFY: FREEZE-OK · RED-OK · GREEN-OK · VERDICT: PASS
```

Canonical gates:

```text
GATE PASS: python3 scripts/check_composer_vendor.py
GATE PASS: php -l (3 changed PHP files)
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

Independent implementation gate and all three review-fix gates: PASS. Final valid-PHP mutation probes cover tracked forking, cap use, typed expiry, executable responder reaping, detached-shell rejection, and checked reply writes.

Fixes #1996
Refs #1517

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved process-based test reliability by tracking, timing out, and cleaning up child responders.
  * Added diagnostics covering salvage-expiry handling, child-process tracking, observation, and reaping.
  * Clarified oversized regular-expression coverage to verify rejection by the configured length cap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
