### PR TITLE
tests: distinguish ADR-10 salvage cap expiry

### DIFF
--- a/tests/test_adr10_concurrency.py
+++ b/tests/test_adr10_concurrency.py
@@ -590,7 +590,10 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
             errors.append(repr(e))
         stats.append(local)
 
-    threads = [threading.Thread(target=query_loop, args=(index,), daemon=True) for index in range(n_threads)]
+    threads = [
+        threading.Thread(target=query_loop, args=(index,), name="adr10-query-{}".format(index), daemon=True)
+        for index in range(n_threads)
+    ]
     for t in threads:
         t.start()
 
@@ -635,8 +638,15 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
         stop.set()
         for t in threads:
             t.join(timeout=5)
+        live_query_threads = [t for t in threads if t.is_alive()]
         P.pfb_reload_stop.set()
         watcher.join(timeout=5)
+        if live_query_threads:
+            raise RuntimeError(
+                "salvage cap expired / stuck or environment: query threads/workers awaited; still alive: {}".format(
+                    ", ".join(t.name for t in live_query_threads)
+                )
+            )
 
     # --- assertions ------------------------------------------------------------- #
     assert not watcher.is_alive(), "watcher did not join cleanly"

--- a/tests/test_adr10_concurrency_salvage.py
+++ b/tests/test_adr10_concurrency_salvage.py
@@ -1,0 +1,50 @@
+"""Distinct failure contract for ADR-10 query-worker salvage."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+from tests import test_adr10_concurrency as concurrency
+
+
+def test_atomic_swap_reports_every_live_query_worker(tmp_path: Any, monkeypatch: Any) -> None:
+    created: list[Any] = []
+
+    class FakeThread:
+        def __init__(self, *, target: Any, args: tuple[Any, ...] = (), name: str | None = None, daemon: bool = False):
+            query_index = sum(thread.name != "pfb_reload_watcher_test" for thread in created)
+            self.name = name or "fake-query-{}".format(query_index)
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+            self.query_index = query_index
+            self.joined = False
+            created.append(self)
+
+        def start(self) -> None:
+            pass
+
+        def join(self, timeout: float) -> None:
+            self.joined = True
+
+        def is_alive(self) -> bool:
+            return self.name in {"adr10-query-1", "adr10-query-4"} or (
+                self.name.startswith("fake-query-") and self.query_index in {1, 4}
+            )
+
+    monkeypatch.setattr(concurrency.threading, "Thread", FakeThread)
+    monkeypatch.setattr(concurrency.threading.Condition, "wait_for", lambda _self, _predicate, timeout: True)
+
+    with pytest.raises(RuntimeError) as raised:
+        concurrency.test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path, monkeypatch)
+
+    message = str(raised.value)
+    assert re.match(r"^salvage cap expired / stuck or environment", message)
+    assert "adr10-query-1" in message
+    assert "adr10-query-4" in message
+    assert created[0].name == "pfb_reload_watcher_test"
+    assert created[0].joined is True
+    assert concurrency.P.pfb_reload_stop.is_set()

--- a/tests/test_adr10_watcher.py
+++ b/tests/test_adr10_watcher.py
@@ -215,6 +215,7 @@ class _Harness:
             (lambda: 8 * 1024 * 1024 * 1024) if ram_ok else (lambda: 1),
         )
         self.builds: list[int] = []
+        self._builder_error: RuntimeError | None = None
         self._gate = threading.Event()
         self._gate.set()  # un-gated by default; tests can clear() to make a build block
         self._lock = threading.Lock()
@@ -277,7 +278,13 @@ class _Harness:
         with self._builds_cond:
             self.builds.append(gen)
             self._builds_cond.notify_all()  # wake any wait_builds waiter.
-        self._gate.wait(10.0)  # safety-guard only; stop_join() always sets the gate.
+        if not self._gate.wait(10.0):
+            error = RuntimeError(
+                "salvage cap expired / stuck or environment: gated reload-builder release "
+                "after 10.0s (observed generation {})".format(gen)
+            )
+            self._builder_error = error
+            raise error
         if self.fail:
             return None
         return _snapshot(tag="gen{}.example.com".format(gen), counts=gen)
@@ -374,6 +381,14 @@ class _Harness:
         self._gate.set()  # release a blocked build so the thread can exit promptly
         if self.thread is not None:
             self.thread.join(timeout=timeout)
+            if self.thread.is_alive():
+                raise RuntimeError(
+                    "salvage cap expired / stuck or environment: watcher thread {!r} still alive after {:.1f}s".format(
+                        self.thread.name, timeout
+                    )
+                )
+        if self._builder_error is not None:
+            raise self._builder_error
 
 
 class TestHarnessWaiterDiagnostics:

--- a/tests/test_adr10_watcher_salvage.py
+++ b/tests/test_adr10_watcher_salvage.py
@@ -1,0 +1,43 @@
+"""Distinct failure contracts for ADR-10 watcher salvage caps."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+from tests import test_adr10_watcher as watcher
+
+
+def test_builder_gate_expiry_is_distinct(tmp_path: Any, monkeypatch: Any) -> None:
+    harness = watcher._Harness(tmp_path, monkeypatch)
+    monkeypatch.setattr(harness._gate, "wait", lambda _timeout: False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"salvage cap expired / stuck or environment.*gated reload-builder release.*observed generation 0",
+    ):
+        harness.builder()
+
+
+def test_watcher_stop_expiry_is_distinct(monkeypatch: Any) -> None:
+    class StuckWatcher:
+        name = "pfb_reload_watcher_test"
+
+        def join(self, timeout: float) -> None:
+            pass
+
+        def is_alive(self) -> bool:
+            return True
+
+    harness = object.__new__(watcher._Harness)
+    harness._gate = threading.Event()
+    harness.thread = StuckWatcher()
+    monkeypatch.setattr(watcher.P, "pfb_reload_stop", threading.Event(), raising=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"salvage cap expired / stuck or environment.*watcher thread 'pfb_reload_watcher_test' still alive",
+    ):
+        harness.stop_join(timeout=0)

--- a/tests/test_adr10_watcher_salvage_integration.py
+++ b/tests/test_adr10_watcher_salvage_integration.py
@@ -1,0 +1,26 @@
+"""Integrated ADR-10 watcher salvage-cap regression."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests import test_adr10_watcher as watcher
+
+
+def test_real_watcher_surfaces_builder_cap_after_cleanup(tmp_path: Any, monkeypatch: Any) -> None:
+    harness = watcher._Harness(tmp_path, monkeypatch)
+    monkeypatch.setattr(harness._gate, "wait", lambda _timeout: False)
+
+    harness.start()
+    harness.publish(1)
+    harness.wait_builds(1)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"salvage cap expired / stuck or environment.*gated reload-builder release.*observed generation 1",
+    ):
+        harness.stop_join()
+
+    assert not harness.thread.is_alive()

--- a/tests/test_bench_top1m_fixed_file.py
+++ b/tests/test_bench_top1m_fixed_file.py
@@ -200,7 +200,12 @@ def test_timed_parent_signal_kills_worker_process_group(tmp_path: Path) -> None:
         deadline = time.monotonic() + 10
         while time.monotonic() < deadline and not worker_pid_path.exists():
             time.sleep(0.05)
-        assert worker_pid_path.exists(), "timed worker did not start"
+        marker_exists = worker_pid_path.exists()
+        if not marker_exists:
+            raise RuntimeError(
+                f"salvage cap expired / stuck or environment: timed worker startup marker {worker_pid_path}; "
+                f"observed exists={marker_exists}"
+            )
         worker_pid = int(worker_pid_path.read_text())
 
         os.kill(driver.pid, signal.SIGTERM)

--- a/tests/test_bench_top1m_fixed_file_salvage.py
+++ b/tests/test_bench_top1m_fixed_file_salvage.py
@@ -1,0 +1,43 @@
+"""Distinct failure contract for TOP1M worker-start salvage expiry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests import test_bench_top1m_fixed_file as bench
+
+
+def test_worker_start_cap_reports_marker_state(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    waits: list[float] = []
+
+    class FakeDriver:
+        pid = 4242
+
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def wait(self, timeout: float) -> int:
+            waits.append(timeout)
+            return 0
+
+    monkeypatch.setattr(bench.subprocess, "Popen", FakeDriver)
+    monotonic_values = iter((0, 11))
+    monkeypatch.setattr(bench.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(bench.time, "sleep", lambda _seconds: None)
+
+    def no_process(*_args: object) -> None:
+        raise ProcessLookupError
+
+    monkeypatch.setattr(bench.os, "kill", no_process)
+
+    with pytest.raises(RuntimeError) as raised:
+        bench.test_timed_parent_signal_kills_worker_process_group(tmp_path)
+
+    message = str(raised.value)
+    assert message.startswith("salvage cap expired / stuck or environment:")
+    assert "timed worker startup marker" in message
+    assert str(tmp_path / "signal-worker.pid") in message
+    assert "observed exists=False" in message
+    assert waits == [2]


### PR DESCRIPTION
## Summary

- make the ADR-10 watcher builder-gate and stop/join salvage expiries fail loudly on the foreground pytest thread
- reject live ADR-10 query workers after join caps, naming every surviving worker before stats are graded
- distinguish TOP1M worker-start marker expiry from benchmark behaviour failure

All existing event, join, and marker waits remain intact. Each expiry raises `RuntimeError` with the shared `salvage cap expired / stuck or environment` vocabulary and the awaited state.

## Commit stack

1. `tests: make ADR-10 watcher caps fail loudly` — #2051
2. `tests: expose live ADR-10 query workers` — #2052
3. `tests: distinguish TOP1M worker-start stalls` — #2053

## Red to green evidence

- #2051: frozen direct and real-watcher regressions failed because pytest received no `RuntimeError`; both now surface the cap after watcher cleanup
- #2052: the frozen regression exposed the ordinary baseline assertion while two workers remained live; now it names both workers after watcher cleanup
- #2053: the frozen regression exposed `AssertionError: timed worker did not start`; now it reports the marker path and `exists=False`

Each frozen proof was independently replayed against its pre-fix commit and final commit with `scripts/agent/verify-red-proof.sh`.

## Gates

- `scripts/agent/run-gates.sh --diff origin/devel`
- `python3 -m pytest`
- `ruff check .`
- `ruff format --check .`
- `mypy tests/`

All pass on `3b71ba64e52d67d861a1088cc6810a1d6f7f1b8e` rebased onto `862aabaa73480f2bd76207746d4343f112cf8684`.

Fixes #2051
Fixes #2052
Fixes #2053

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
