### PR TITLE
Schedule SafeSearch refresh through the due ledger

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1365,8 +1365,8 @@ off switch; the Update page reports the suppression). The direct `pfblockerng.ph
 never gated. The tick carries **no**
 scheduling logic: it reads the due-ledger, dispatches each **due** job through the new API
 (`pfb_trigger scope=both force=false trigger=cron` for the feed pass), runs `ss_refresh` when its
-dedicated zero-jitter 900-second entry is due (cheap DNS re-resolution), then `mark_ran`s each
-dispatched job. `clearip`/`cleardnsbl` (ADR-30) and
+dedicated zero-jitter 900-second entry is due (cheap DNS re-resolution), then records each completed
+job's next due slot. `clearip`/`cleardnsbl` (ADR-30) and
 non-pfB cron jobs are left untouched; install/teardown stays idempotent via `pfblockerng_cron_exists`,
 and a pre-ADR-43 install's old fleet jobs are removed on the next `sync_package_pfblockerng()`.
 
@@ -1494,7 +1494,7 @@ next success. Open is idempotent-by-key: opening an already-open key refreshes
 ### Tick-driven reconciliation — apply stage only
 
 `pfblockerng_tick()` gains one **unconditional** step (runs every tick regardless of due-ness,
-placed after `pfblockerng_ss_refresh()` and before the log-maintenance tail — it never sets
+placed after conditional SafeSearch handling and before the log-maintenance tail — it never sets
 `$dispatched`, so it doesn't interact with the log-trim race guard) that, for every open
 `stage=apply` entry:
 

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1364,8 +1364,9 @@ case it logs `[ Disabled by … ]` and dispatches nothing (issue #1204 — the s
 off switch; the Update page reports the suppression). The direct `pfblockerng.php tick` verb is
 never gated. The tick carries **no**
 scheduling logic: it reads the due-ledger, dispatches each **due** job through the new API
-(`pfb_trigger scope=both force=false trigger=cron` for the feed pass), runs `ss_refresh` every tick
-(cheap DNS re-resolution), then `mark_ran`s each dispatched job. `clearip`/`cleardnsbl` (ADR-30) and
+(`pfb_trigger scope=both force=false trigger=cron` for the feed pass), runs `ss_refresh` when its
+dedicated zero-jitter 900-second entry is due (cheap DNS re-resolution), then `mark_ran`s each
+dispatched job. `clearip`/`cleardnsbl` (ADR-30) and
 non-pfB cron jobs are left untouched; install/teardown stays idempotent via `pfblockerng_cron_exists`,
 and a pre-ADR-43 install's old fleet jobs are removed on the next `sync_package_pfblockerng()`.
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3730,9 +3730,15 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir, float $t
  *
  * $ps_lines is injectable for hermetic off-appliance tests; NULL preserves the
  * appliance's host process-table scan. $ss_refresh is an optional test seam; NULL calls
- * the production SafeSearch refresher.
+ * the production SafeSearch refresher. $ss_lock_opener and $ss_lock_timeout are test seams
+ * for the bounded refresh lock; defaults use fopen() and a 5-second budget.
  */
-function pfblockerng_tick(?array $ps_lines = NULL, ?callable $ss_refresh = NULL): void
+function pfblockerng_tick(
+	?array $ps_lines = NULL,
+	?callable $ss_refresh = NULL,
+	?callable $ss_lock_opener = NULL,
+	float $ss_lock_timeout = 5.0
+): void
 {
 	global $pfb;
 
@@ -3851,15 +3857,19 @@ function pfblockerng_tick(?array $ps_lines = NULL, ?callable $ss_refresh = NULL)
 
 	// SafeSearch CNAME freshness: independent 900-second due-ledger cadence.
 	if ($due['ss_refresh']) {
-		$ss_lock = @fopen("{$dbdir}/pfb_ss_refresh.lock", 'c');
+		$ss_lock_path = "{$dbdir}/pfb_ss_refresh.lock";
+		$ss_default_opener = ($ss_lock_opener === NULL);
+		$ss_lock = $ss_default_opener ? @fopen($ss_lock_path, 'c') : $ss_lock_opener($ss_lock_path);
 		if ($ss_lock === FALSE) {
-			pfb_logger("\nTick: SafeSearch lock open failed [ {$dbdir}/pfb_ss_refresh.lock ]", 2);
+			pfb_logger("\nTick: SafeSearch lock open failed [ {$ss_lock_path} ]", 2);
 		} else {
 			$ss_lock_timed_out = FALSE;
-			if (!pfb_flock_bounded($ss_lock, LOCK_EX, 5.0, $ss_lock_timed_out)) {
+			if (!pfb_flock_bounded($ss_lock, LOCK_EX, $ss_lock_timeout, $ss_lock_timed_out)) {
 				$reason = $ss_lock_timed_out ? 'timed out' : 'acquire failed';
-				pfb_logger("\nTick: SafeSearch lock {$reason} [ {$dbdir}/pfb_ss_refresh.lock ]", 2);
-				@fclose($ss_lock);
+				pfb_logger("\nTick: SafeSearch lock {$reason} [ {$ss_lock_path} ]", 2);
+				if ($ss_default_opener) {
+					@fclose($ss_lock);
+				}
 			} else {
 				try {
 					// Another tick may have completed while this one waited for the lock.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3558,8 +3558,7 @@ function pfb_tick_seed(): string
  *
  * Delegates to the due-ledger API for each job. The $now, $seed, and
  * $dbdir are injectable so PHPUnit can verify cadence without filesystem or
- * wall-clock dependencies. ss_refresh is not returned — it runs every tick
- * unconditionally (called directly by pfblockerng_tick()).
+ * wall-clock dependencies. SafeSearch has its own zero-jitter 900-second entry.
  *
  * @param int    $now            Current epoch timestamp.
  * @param string $seed           Per-install seed for seeded_jitter.
@@ -3576,11 +3575,13 @@ function pfb_tick_due_jobs(
 	int    $bl_interval
 ): array {
 	$jitter_max = 23 * 3600;	// 82800 s mirrors the old rand(0,23)*3600 spread
+	$ss_refresh_due = pfb_due_ledger_is_due('ss_refresh', 900, $now, $seed, 0, $dbdir);
 
 	return [
-		'cron' => pfb_due_ledger_is_due('cron', $cron_interval, $now, $seed, 0,           $dbdir),
-		'dcc'  => pfb_due_ledger_is_due('dcc',  86400,          $now, $seed, $jitter_max,  $dbdir),
-		'bl'   => pfb_due_ledger_is_due('bl',   $bl_interval,   $now, $seed, $jitter_max,  $dbdir),
+		'cron'       => pfb_due_ledger_is_due('cron',       $cron_interval, $now, $seed, 0,          $dbdir),
+		'dcc'        => pfb_due_ledger_is_due('dcc',        86400,          $now, $seed, $jitter_max, $dbdir),
+		'bl'         => pfb_due_ledger_is_due('bl',         $bl_interval,   $now, $seed, $jitter_max, $dbdir),
+		'ss_refresh' => $ss_refresh_due,
 	];
 }
 
@@ -3694,8 +3695,8 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir, float $t
  * pfblockerng_tick — ADR-43: apply-on-change due-ledger tick dispatcher.
  *
  * Reads the ledger and handles both cadence advancement and separate-process dispatch via
- * exec() for each due job (feeds, dcc, bl). ss_refresh runs every tick; the scheduled
- * log maintenance (pfb_log_mgmt) runs only on an idle tick (see below).
+ * exec() for each due job (feeds, dcc, bl). SafeSearch runs when its own due-ledger entry
+ * is due; the scheduled log maintenance (pfb_log_mgmt) runs only on an idle tick (see below).
  *
  * Lives here (not in the www/ dispatcher script) rather than the reverse so the
  * PHPUnit bootstrap can load and call the real entrypoint off-appliance: the www
@@ -3728,9 +3729,10 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir, float $t
  * lines the concurrent writer appends during it.
  *
  * $ps_lines is injectable for hermetic off-appliance tests; NULL preserves the
- * appliance's host process-table scan.
+ * appliance's host process-table scan. $ss_refresh is an optional test seam; NULL calls
+ * the production SafeSearch refresher.
  */
-function pfblockerng_tick(?array $ps_lines = NULL): void
+function pfblockerng_tick(?array $ps_lines = NULL, ?callable $ss_refresh = NULL): void
 {
 	global $pfb;
 
@@ -3847,8 +3849,15 @@ function pfblockerng_tick(?array $ps_lines = NULL): void
 		}
 	}
 
-	// SafeSearch CNAME freshness: every tick (cheap DNS re-resolution).
-	pfblockerng_ss_refresh();
+	// SafeSearch CNAME freshness: independent 900-second due-ledger cadence.
+	if ($due['ss_refresh']) {
+		if ($ss_refresh !== NULL) {
+			$ss_refresh();
+		} else {
+			pfblockerng_ss_refresh();
+		}
+		pfb_due_ledger_mark_ran_anchored('ss_refresh', 900, $now, $seed, 0, $dbdir);
+	}
 
 	// ADR-61: apply-stage reconciliation. Unconditional -- never gated on $due or
 	// pending state -- and touches ONLY stage='apply' entries (Semantics #5);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3851,12 +3851,32 @@ function pfblockerng_tick(?array $ps_lines = NULL, ?callable $ss_refresh = NULL)
 
 	// SafeSearch CNAME freshness: independent 900-second due-ledger cadence.
 	if ($due['ss_refresh']) {
-		if ($ss_refresh !== NULL) {
-			$ss_refresh();
+		$ss_lock = @fopen("{$dbdir}/pfb_ss_refresh.lock", 'c');
+		if ($ss_lock === FALSE) {
+			pfb_logger("\nTick: SafeSearch lock open failed [ {$dbdir}/pfb_ss_refresh.lock ]", 2);
 		} else {
-			pfblockerng_ss_refresh();
+			$ss_lock_timed_out = FALSE;
+			if (!pfb_flock_bounded($ss_lock, LOCK_EX, 5.0, $ss_lock_timed_out)) {
+				$reason = $ss_lock_timed_out ? 'timed out' : 'acquire failed';
+				pfb_logger("\nTick: SafeSearch lock {$reason} [ {$dbdir}/pfb_ss_refresh.lock ]", 2);
+				@fclose($ss_lock);
+			} else {
+				try {
+					// Another tick may have completed while this one waited for the lock.
+					if (pfb_due_ledger_is_due('ss_refresh', 900, $now, $seed, 0, $dbdir)) {
+						if ($ss_refresh !== NULL) {
+							$ss_refresh();
+						} else {
+							pfblockerng_ss_refresh();
+						}
+						pfb_due_ledger_mark_ran_anchored('ss_refresh', 900, $now, $seed, 0, $dbdir);
+					}
+				} finally {
+					@flock($ss_lock, LOCK_UN);
+					@fclose($ss_lock);
+				}
+			}
 		}
-		pfb_due_ledger_mark_ran_anchored('ss_refresh', 900, $now, $seed, 0, $dbdir);
 	}
 
 	// ADR-61: apply-stage reconciliation. Unconditional -- never gated on $due or

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -92,8 +92,8 @@ if (isset($argv[1])) {
 		pfb_run_hooks($when, $ctx);
 		exit;
 	}
-	// issue #149: SafeSearch CNAME fallback freshness. Light cron path (every 15
-	// min): re-resolves the SafeSearch CNAME targets (duckduckgo/pixabay) and
+	// issue #149: SafeSearch CNAME fallback freshness. Legacy direct verb:
+	// re-resolves the SafeSearch CNAME targets (duckduckgo/pixabay) and
 	// refreshes their baked #2-fallback IPs in the SafeSearch CSV, triggering a
 	// python reload only on change. Does NOT run sync_package_pfblockerng.
 	elseif ($argv[1] == 'ss_refresh') {
@@ -101,7 +101,7 @@ if (isset($argv[1])) {
 		exit;
 	}
 	// ADR-43: due-ledger trigger-tick. Reads the ledger, dispatches each job
-	// that is due (feeds, dcc, bl), then calls ss_refresh unconditionally (cheap).
+	// that is due (feeds, dcc, bl), then runs due SafeSearch refresh work (cheap).
 	elseif ($argv[1] == 'tick') {
 		pfblockerng_tick();
 		exit;

--- a/tests/php/TickApplyReconciliationTest.php
+++ b/tests/php/TickApplyReconciliationTest.php
@@ -110,7 +110,7 @@ final class TickApplyReconciliationTest extends TestCase
 
 	/**
 	 * Minimum config keys pfb_global() reads (avoids undefined-array-key warnings --
-	 * pfblockerng_ss_refresh() calls pfb_global() internally every tick), plus
+	 * pfblockerng_ss_refresh() calls pfb_global() internally when its job is due), plus
 	 * pfb_interval='Disabled' so the tick's own cron dispatch branch never fires.
 	 *
 	 * NOTE (issue #1666): 'Disabled' alone does NOT gate the dcc/bl dispatch

--- a/tests/php/TickCronTest.php
+++ b/tests/php/TickCronTest.php
@@ -117,7 +117,7 @@ final class TickCronTest extends TestCase
 	 *   Background: ledger absent (dir is empty).
 	 *     Given an empty ledger directory.
 	 *     When pfb_tick_due_jobs($now, $seed, $dir, $cron_interval, $bl_interval).
-	 *     Then cron, dcc, bl are all TRUE (fail-safe: run now, jitter on mark_ran).
+	 *     Then cron, dcc, bl, ss_refresh are all TRUE (fail-safe: run now, jitter on mark_ran).
 	 */
 	public function testAllDueWhenLedgerAbsent(): void
 	{
@@ -132,6 +132,9 @@ final class TickCronTest extends TestCase
 		$this->assertTrue($due['bl'],
 			"bl: expected TRUE (absent ledger => due-now), got FALSE;\n"
 			. "  now=" . self::NOW . " dir={$this->dir}");
+		$this->assertTrue($due['ss_refresh'],
+			"ss_refresh: expected TRUE (absent ledger => due-now), got FALSE;\n"
+			. "  now=" . self::NOW . " dir={$this->dir}");
 	}
 
 	// -----------------------------------------------------------------------
@@ -143,14 +146,14 @@ final class TickCronTest extends TestCase
 	 *
 	 * Scenario:
 	 *   Background: all jobs have next_due = now + 1 hour.
-	 *     Given ledger entries with next_due > now for cron, dcc, bl.
+	 *     Given ledger entries with next_due > now for cron, dcc, bl, ss_refresh.
 	 *     When pfb_tick_due_jobs($now, ...).
-	 *     Then cron, dcc, bl are all FALSE (not yet due).
+	 *     Then cron, dcc, bl, ss_refresh are all FALSE (not yet due).
 	 */
 	public function testNoneDueWhenAllFuture(): void
 	{
 		$future = self::NOW + 3600;
-		foreach (['cron', 'dcc', 'bl'] as $job) {
+		foreach (['cron', 'dcc', 'bl', 'ss_refresh'] as $job) {
 			pfb_due_ledger_write_entry($job, [
 				'last_run' => self::NOW - self::DAILY,
 				'next_due' => $future,
@@ -169,6 +172,9 @@ final class TickCronTest extends TestCase
 		$this->assertFalse($due['bl'],
 			"bl: expected FALSE (next_due in future), got TRUE;\n"
 			. "  now=" . self::NOW . " next_due={$future}");
+		$this->assertFalse($due['ss_refresh'],
+			"ss_refresh: expected FALSE (next_due in future), got TRUE;\n"
+			. "  now=" . self::NOW . " next_due={$future}");
 	}
 
 	// -----------------------------------------------------------------------
@@ -180,9 +186,9 @@ final class TickCronTest extends TestCase
 	 *
 	 * Scenario:
 	 *   Background: cron is overdue; dcc and bl are not yet due.
-	 *     Given cron.next_due = now - 1 (past); dcc/bl.next_due = now + 1h (future).
+	 *     Given cron.next_due = now - 1 (past); dcc/bl/ss_refresh.next_due = now + 1h (future).
 	 *     When pfb_tick_due_jobs($now, ...).
-	 *     Then cron = TRUE, dcc = FALSE, bl = FALSE (catch-up for cron only).
+	 *     Then cron = TRUE, dcc = FALSE, bl = FALSE, ss_refresh = FALSE (catch-up for cron only).
 	 */
 	public function testOnlyCronDueWhenOnlyCronPast(): void
 	{
@@ -195,7 +201,7 @@ final class TickCronTest extends TestCase
 
 		// dcc and bl are not yet due.
 		$future = self::NOW + 3600;
-		foreach (['dcc', 'bl'] as $job) {
+		foreach (['dcc', 'bl', 'ss_refresh'] as $job) {
 			pfb_due_ledger_write_entry($job, [
 				'last_run' => self::NOW - self::DAILY,
 				'next_due' => $future,
@@ -213,6 +219,9 @@ final class TickCronTest extends TestCase
 			. "  now=" . self::NOW . " next_due={$future}");
 		$this->assertFalse($due['bl'],
 			"bl: expected FALSE (next_due in future), got TRUE;\n"
+			. "  now=" . self::NOW . " next_due={$future}");
+		$this->assertFalse($due['ss_refresh'],
+			"ss_refresh: expected FALSE (next_due in future), got TRUE;\n"
 			. "  now=" . self::NOW . " next_due={$future}");
 	}
 

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -414,6 +414,21 @@ final class TickEntrypointTest extends TestCase
 		], $GLOBALS['pfb']['dbdir']);
 	}
 
+	/** Seed an idle tick with only the SafeSearch ledger state under test due. */
+	private function prepareSafeSearchTick(): int
+	{
+		$this->seedTickPrereqs('Disabled');
+		pfb_global();
+		$this->ensureLogDir();
+
+		$now = time();
+		$this->seedFutureLedgerEntry('cron', $now);
+		$this->seedFutureLedgerEntry('dcc',  $now);
+		$this->seedFutureLedgerEntry('bl',   $now);
+
+		return $now;
+	}
+
 	// -----------------------------------------------------------------------
 	// Case A — the bug: pfb_interval='Disabled' must not silently stop log
 	// maintenance.
@@ -691,6 +706,99 @@ final class TickEntrypointTest extends TestCase
 			"cron next_due: expected old_next_due + interval ({$expected} = {$oldNextDue} + {$interval}), "
 			. "got {$cronEntry['next_due']} -- pfblockerng_tick() must anchor the feed-cron next_due to "
 			. 'its own previous schedule, not to wall-clock time() (issue #573 phase creep)');
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #2089 — SafeSearch refresh is its own zero-jitter 900-second job.
+	// -----------------------------------------------------------------------
+
+	/** An absent SafeSearch entry runs once and seeds a zero-jitter 900-second slot. */
+	public function testSafeSearchAbsentEntryRunsOnceAndSeedsCadence(): void
+	{
+		$now = $this->prepareSafeSearchTick();
+		$calls = 0;
+		$refresh = static function () use (&$calls): void {
+			$calls++;
+		};
+
+		pfblockerng_tick($this->suiteWorkerPsLines(), $refresh);
+
+		$this->assertSame(1, $calls, 'absent ss_refresh entry must invoke SafeSearch exactly once');
+		$entry = pfb_due_ledger_read_entry('ss_refresh', $GLOBALS['pfb']['dbdir']);
+		$this->assertNotNull($entry, 'due SafeSearch tick must create its ledger entry');
+		$this->assertSame(0, $entry['jitter'], 'ss_refresh cadence must have zero jitter');
+		$this->assertSame(900, $entry['next_due'] - $entry['last_run'],
+			'ss_refresh next_due must be exactly 900 seconds after last_run');
+		$this->assertGreaterThan($now, $entry['next_due'],
+			'ss_refresh next_due must be in the future after its first run');
+	}
+
+	/** A future SafeSearch entry does not call or rewrite the observer/ledger. */
+	public function testSafeSearchFutureEntryDoesNotRunOrChangeLedger(): void
+	{
+		$now = $this->prepareSafeSearchTick();
+		$this->seedFutureLedgerEntry('ss_refresh', $now);
+		$before = pfb_due_ledger_read_entry('ss_refresh', $GLOBALS['pfb']['dbdir']);
+		$calls = 0;
+		$refresh = static function () use (&$calls): void {
+			$calls++;
+		};
+
+		pfblockerng_tick($this->suiteWorkerPsLines(), $refresh);
+
+		$this->assertSame(0, $calls, 'future ss_refresh entry must not invoke SafeSearch');
+		$after = pfb_due_ledger_read_entry('ss_refresh', $GLOBALS['pfb']['dbdir']);
+		$this->assertSame($before, $after, 'future ss_refresh entry must remain unchanged');
+	}
+
+	/** A slightly overdue SafeSearch entry advances from its prior slot, not wall clock. */
+	public function testSafeSearchSlightlyOverdueEntryReanchorsFromPriorSlot(): void
+	{
+		$now = $this->prepareSafeSearchTick();
+		$oldNextDue = $now - 10;
+		pfb_due_ledger_write_entry('ss_refresh', [
+			'last_run' => $oldNextDue - 900,
+			'next_due' => $oldNextDue,
+			'jitter'   => 0,
+		], $GLOBALS['pfb']['dbdir']);
+		$calls = 0;
+		$refresh = static function () use (&$calls): void {
+			$calls++;
+		};
+
+		pfblockerng_tick($this->suiteWorkerPsLines(), $refresh);
+
+		$this->assertSame(1, $calls, 'overdue ss_refresh entry must invoke SafeSearch once');
+		$entry = pfb_due_ledger_read_entry('ss_refresh', $GLOBALS['pfb']['dbdir']);
+		$this->assertNotNull($entry, 'overdue ss_refresh entry must remain present');
+		$this->assertSame($oldNextDue + 900, $entry['next_due'],
+			'slightly overdue ss_refresh must advance from prior next_due exactly 900 seconds');
+	}
+
+	/** A multi-interval overdue SafeSearch entry runs once and catches up past now. */
+	public function testSafeSearchMultiIntervalOverdueEntryDoesNotBurst(): void
+	{
+		$now = $this->prepareSafeSearchTick();
+		$oldNextDue = $now - 1800;
+		pfb_due_ledger_write_entry('ss_refresh', [
+			'last_run' => $oldNextDue - 900,
+			'next_due' => $oldNextDue,
+			'jitter'   => 0,
+		], $GLOBALS['pfb']['dbdir']);
+		$calls = 0;
+		$refresh = static function () use (&$calls): void {
+			$calls++;
+		};
+
+		pfblockerng_tick($this->suiteWorkerPsLines(), $refresh);
+
+		$this->assertSame(1, $calls, 'multi-interval overdue ss_refresh must not replay missed slots');
+		$entry = pfb_due_ledger_read_entry('ss_refresh', $GLOBALS['pfb']['dbdir']);
+		$this->assertNotNull($entry, 'overdue ss_refresh entry must remain present');
+		$this->assertSame(900, $entry['next_due'] - $entry['last_run'],
+			'multi-interval catch-up must write one 900-second cadence slot');
+		$this->assertGreaterThan($now, $entry['next_due'],
+			'multi-interval catch-up must advance ss_refresh next_due past now');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/TickSafeSearchFailureTest.php
+++ b/tests/php/TickSafeSearchFailureTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** issue #2089: SafeSearch lock failures must fail closed and remain retryable. */
+final class TickSafeSearchFailureTest extends TestCase
+{
+	private string $dir;
+	private mixed $originalPfb;
+	private mixed $originalConfig;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_tick_ss_failure_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0755, TRUE);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->originalConfig = $GLOBALS['config'] ?? [];
+		$GLOBALS['pfb'] = [
+			'dbdir'     => $this->dir,
+			'log'       => "{$this->dir}/pfblockerng.log",
+			'errlog'    => "{$this->dir}/error.log",
+			'runlog'    => "{$this->dir}/run.log",
+			'extraslog' => "{$this->dir}/extras.log",
+		];
+		$GLOBALS['config'] = [];
+
+		$gen = 'installedpackages/pfblockerng/config/0';
+		config_set_path("{$gen}/pfb_interval", 'Disabled');
+		config_set_path("{$gen}/pfb_quiet_hours", '');
+		$now = time();
+		foreach (['cron', 'dcc', 'bl'] as $job) {
+			pfb_due_ledger_write_entry($job, [
+				'last_run' => $now - 3600,
+				'next_due' => $now + 3600,
+				'jitter'   => 0,
+			], $this->dir);
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb'] = $this->originalPfb;
+		$GLOBALS['config'] = $this->originalConfig;
+		foreach (glob($this->dir . '/*') ?: [] as $file) {
+			@unlink($file);
+		}
+		@rmdir($this->dir);
+	}
+
+	public function testLockOpenFailureLogsAndRetries(): void
+	{
+		$calls = 0;
+		$refresh = static function () use (&$calls): void {
+			$calls++;
+		};
+		$opener = static fn(string $path): mixed => FALSE;
+
+		pfblockerng_tick(['pfblockerng.php dcc'], $refresh, $opener, 5.0);
+
+		$this->assertSame(0, $calls, 'lock-open failure must not call SafeSearch');
+		$this->assertNull(pfb_due_ledger_read_entry('ss_refresh', $this->dir),
+			'lock-open failure must not advance ss_refresh ledger');
+		$this->assertStringContainsString('SafeSearch lock open failed', $this->errorLog());
+
+		pfblockerng_tick(['pfblockerng.php dcc'], $refresh);
+
+		$this->assertSame(1, $calls, 'SafeSearch must retry after lock-open failure');
+		$this->assertFutureReservation();
+	}
+
+	public function testLockTimeoutLogsAndRetriesAfterRelease(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl_fork() unavailable; timeout reproduction needs a real lock holder.');
+		}
+
+		$lockPath = "{$this->dir}/pfb_ss_refresh.lock";
+		$marker = "{$this->dir}/holder.ready";
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->fail('pcntl_fork() failed while creating the lock holder');
+		}
+		if ($pid === 0) {
+			$holder = fopen($lockPath, 'c');
+			if ($holder === FALSE || !flock($holder, LOCK_EX)) {
+				exit(2);
+			}
+			touch($marker);
+			usleep(500000);
+			flock($holder, LOCK_UN);
+			fclose($holder);
+			exit(0);
+		}
+		$this->waitForPath($marker, 2.0);
+
+		$calls = 0;
+		$refresh = static function () use (&$calls): void {
+			$calls++;
+		};
+		$opener = static fn(string $path): mixed => fopen($path, 'c');
+		pfblockerng_tick(['pfblockerng.php dcc'], $refresh, $opener, 0.01);
+
+		$this->assertSame(0, $calls, 'lock timeout must not call SafeSearch');
+		$this->assertNull(pfb_due_ledger_read_entry('ss_refresh', $this->dir),
+			'lock timeout must not advance ss_refresh ledger');
+		$this->assertStringContainsString('SafeSearch lock timed out', $this->errorLog());
+
+		pcntl_waitpid($pid, $status);
+		$this->assertTrue(pcntl_wifexited($status) && pcntl_wexitstatus($status) === 0,
+			'lock holder must exit cleanly before retry');
+		pfblockerng_tick(['pfblockerng.php dcc'], $refresh);
+
+		$this->assertSame(1, $calls, 'SafeSearch must retry after the lock is released');
+		$this->assertFutureReservation();
+	}
+
+	public function testNonTimeoutAcquireFailureLeavesMemoryHandleReusable(): void
+	{
+		$handle = NULL;
+		$calls = 0;
+		$refresh = static function () use (&$calls): void {
+			$calls++;
+		};
+		$opener = static function () use (&$handle): mixed {
+			$handle = fopen('php://memory', 'r+');
+			return $handle;
+		};
+
+		pfblockerng_tick(['pfblockerng.php dcc'], $refresh, $opener, 5.0);
+
+		$this->assertSame(0, $calls, 'non-timeout acquire failure must not call SafeSearch');
+		$this->assertNull(pfb_due_ledger_read_entry('ss_refresh', $this->dir),
+			'non-timeout acquire failure must not advance ss_refresh ledger');
+		$this->assertStringContainsString('SafeSearch lock acquire failed', $this->errorLog());
+		$this->assertIsResource($handle, 'lock opener handle must remain owned by the caller');
+		$this->assertSame(1, fwrite($handle, 'x'), 'failed acquire must not close the opener handle');
+		fclose($handle);
+
+		pfblockerng_tick(['pfblockerng.php dcc'], $refresh);
+
+		$this->assertSame(1, $calls, 'SafeSearch must retry after non-timeout acquire failure');
+		$this->assertFutureReservation();
+	}
+
+	public function testRefreshThrowLeavesDueAndNextTickRunsOnce(): void
+	{
+		$thrown = FALSE;
+		$refresh = static function () use (&$thrown): void {
+			if (!$thrown) {
+				$thrown = TRUE;
+				throw new RuntimeException('refresh failed');
+			}
+		};
+
+		try {
+			pfblockerng_tick(['pfblockerng.php dcc'], $refresh);
+		} catch (RuntimeException $e) {
+			$this->assertSame('refresh failed', $e->getMessage());
+		}
+
+		$this->assertTrue($thrown, 'first SafeSearch refresh must throw in this scenario');
+		$this->assertNull(pfb_due_ledger_read_entry('ss_refresh', $this->dir),
+			'a failed SafeSearch refresh must remain due for retry');
+		$successes = 0;
+		$retry = static function () use (&$successes): void {
+			$successes++;
+		};
+		pfblockerng_tick(['pfblockerng.php dcc'], $retry);
+
+		$this->assertSame(1, $successes, 'next tick must run exactly one retry after a thrown refresh');
+		$this->assertFutureReservation();
+	}
+
+	private function errorLog(): string
+	{
+		return (string) @file_get_contents($GLOBALS['pfb']['errlog']);
+	}
+
+	private function assertFutureReservation(): void
+	{
+		$entry = pfb_due_ledger_read_entry('ss_refresh', $this->dir);
+		$this->assertNotNull($entry, 'successful SafeSearch refresh must write its ledger entry');
+		$this->assertGreaterThan(time(), $entry['next_due'], 'successful SafeSearch refresh must schedule a future slot');
+	}
+
+	private function waitForPath(string $path, float $timeout): void
+	{
+		$deadline = microtime(TRUE) + $timeout;
+		while (!is_file($path) && microtime(TRUE) < $deadline) {
+			usleep(1000);
+		}
+		$this->assertFileExists($path, "timed out waiting for {$path}");
+	}
+}

--- a/tests/php/TickSafeSearchFailureTest.php
+++ b/tests/php/TickSafeSearchFailureTest.php
@@ -78,6 +78,7 @@ final class TickSafeSearchFailureTest extends TestCase
 
 		$lockPath = "{$this->dir}/pfb_ss_refresh.lock";
 		$marker = "{$this->dir}/holder.ready";
+		$holderReleasePath = "{$this->dir}/holder.release";
 		$pid = pcntl_fork();
 		if ($pid === -1) {
 			$this->fail('pcntl_fork() failed while creating the lock holder');
@@ -88,26 +89,38 @@ final class TickSafeSearchFailureTest extends TestCase
 				exit(2);
 			}
 			touch($marker);
-			usleep(500000);
+			$deadline = microtime(TRUE) + 3.0;
+			while (!is_file($holderReleasePath) && microtime(TRUE) < $deadline) {
+				usleep(1000);
+			}
 			flock($holder, LOCK_UN);
 			fclose($holder);
-			exit(0);
+			exit(is_file($holderReleasePath) ? 0 : 3);
 		}
-		$this->waitForPath($marker, 2.0);
 
 		$calls = 0;
 		$refresh = static function () use (&$calls): void {
 			$calls++;
 		};
 		$opener = static fn(string $path): mixed => fopen($path, 'c');
-		pfblockerng_tick(['pfblockerng.php dcc'], $refresh, $opener, 0.01);
+		$waitResult = NULL;
+		$status = NULL;
+		try {
+			$this->waitForPath($marker, 2.0);
+			pfblockerng_tick(['pfblockerng.php dcc'], $refresh, $opener, 0.01);
 
-		$this->assertSame(0, $calls, 'lock timeout must not call SafeSearch');
-		$this->assertNull(pfb_due_ledger_read_entry('ss_refresh', $this->dir),
-			'lock timeout must not advance ss_refresh ledger');
-		$this->assertStringContainsString('SafeSearch lock timed out', $this->errorLog());
+			$this->assertSame(0, $calls, 'lock timeout must not call SafeSearch');
+			$this->assertNull(pfb_due_ledger_read_entry('ss_refresh', $this->dir),
+				'lock timeout must not advance ss_refresh ledger');
+			$this->assertStringContainsString('SafeSearch lock timed out', $this->errorLog());
+		} finally {
+			// Always release and reap the holder, including when any post-fork
+			// assertion or tick call throws.
+			touch($holderReleasePath);
+			$waitResult = pcntl_waitpid($pid, $status);
+		}
 
-		pcntl_waitpid($pid, $status);
+		$this->assertSame($pid, $waitResult, 'lock holder must be reaped after timeout attempt');
 		$this->assertTrue(pcntl_wifexited($status) && pcntl_wexitstatus($status) === 0,
 			'lock holder must exit cleanly before retry');
 		pfblockerng_tick(['pfblockerng.php dcc'], $refresh);

--- a/tests/php/TickSafeSearchReservationTest.php
+++ b/tests/php/TickSafeSearchReservationTest.php
@@ -57,6 +57,7 @@ final class TickSafeSearchReservationTest extends TestCase
 		$startedPath = "{$this->dir}/started.log";
 		$callsPath   = "{$this->dir}/calls.log";
 		$goPath      = "{$this->dir}/go";
+		$openersReleasePath = "{$this->dir}/openers-release";
 		$releasePath = "{$this->dir}/release";
 		$pids = [];
 
@@ -69,7 +70,18 @@ final class TickSafeSearchReservationTest extends TestCase
 				try {
 					file_put_contents($readyPath, getmypid() . "\n", FILE_APPEND | LOCK_EX);
 					$this->waitForPath($goPath, 3.0);
-					file_put_contents($startedPath, getmypid() . "\n", FILE_APPEND | LOCK_EX);
+					$opener = static function (string $lockPath) use ($startedPath, $openersReleasePath): mixed {
+						file_put_contents($startedPath, getmypid() . "\n", FILE_APPEND | LOCK_EX);
+						$deadline = microtime(TRUE) + 3.0;
+						while (!is_file($openersReleasePath) && microtime(TRUE) < $deadline) {
+							usleep(1000);
+						}
+						if (!is_file($openersReleasePath)) {
+							throw new RuntimeException('timed out waiting for opener release');
+						}
+						$handle = fopen($lockPath, 'c');
+						return $handle;
+					};
 					$refresh = static function () use ($callsPath, $releasePath): void {
 						file_put_contents($callsPath, getmypid() . "\n", FILE_APPEND | LOCK_EX);
 						$deadline = microtime(TRUE) + 3.0;
@@ -77,7 +89,7 @@ final class TickSafeSearchReservationTest extends TestCase
 							usleep(1000);
 						}
 					};
-					pfblockerng_tick(['pfblockerng.php dcc'], $refresh);
+					pfblockerng_tick(['pfblockerng.php dcc'], $refresh, $opener);
 					exit(0);
 				} catch (Throwable $e) {
 					file_put_contents("{$this->dir}/worker-error.log", $e::class . ': ' . $e->getMessage());
@@ -94,6 +106,7 @@ final class TickSafeSearchReservationTest extends TestCase
 			touch($goPath);
 			$this->assertTrue($this->waitForLineCount($startedPath, 2, 3.0),
 				'overlap workers did not both reach started barrier; lines=' . $this->lineCount($startedPath));
+			touch($openersReleasePath);
 			// Both workers reached the overlap barrier. One callback is the expected
 			// winner; the second worker either waits on the lock or races the old code.
 			$this->assertTrue($this->waitForLineCount($callsPath, 1, 3.0),
@@ -102,6 +115,7 @@ final class TickSafeSearchReservationTest extends TestCase
 			// Release every worker even when a milestone assertion fails, then reap
 			// the children so a timed-out assertion cannot orphan processes.
 			touch($goPath);
+			touch($openersReleasePath);
 			touch($releasePath);
 			foreach ($pids as $pid) {
 				pcntl_waitpid($pid, $status);

--- a/tests/php/TickSafeSearchReservationTest.php
+++ b/tests/php/TickSafeSearchReservationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** issue #2089: overlapping ticks must serialize SafeSearch refresh work. */
+final class TickSafeSearchReservationTest extends TestCase
+{
+	private string $dir;
+	private mixed $originalPfb;
+	private mixed $originalConfig;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_tick_ss_reservation_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0755, TRUE);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->originalConfig = $GLOBALS['config'] ?? [];
+		$GLOBALS['pfb'] = ['dbdir' => $this->dir];
+		$GLOBALS['config'] = [];
+
+		$gen = 'installedpackages/pfblockerng/config/0';
+		config_set_path("{$gen}/pfb_interval", 'Disabled');
+		config_set_path("{$gen}/pfb_quiet_hours", '');
+		$now = time();
+		foreach (['cron', 'dcc', 'bl'] as $job) {
+			pfb_due_ledger_write_entry($job, [
+				'last_run' => $now - 3600,
+				'next_due' => $now + 3600,
+				'jitter'   => 0,
+			], $this->dir);
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb'] = $this->originalPfb;
+		$GLOBALS['config'] = $this->originalConfig;
+		foreach (glob($this->dir . '/*') ?: [] as $file) {
+			@unlink($file);
+		}
+		@rmdir($this->dir);
+	}
+
+	/**
+	 * Two real tick processes overlap their refresh callbacks. Before the lock/recheck,
+	 * both callbacks run; after it, only the winner runs and the loser observes not-due.
+	 */
+	public function testOverlappingTicksRunOneSafeSearchRefresh(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl_fork() unavailable; overlapping tick reproduction requires real processes.');
+		}
+
+		$readyPath   = "{$this->dir}/ready.log";
+		$callsPath   = "{$this->dir}/calls.log";
+		$goPath      = "{$this->dir}/go";
+		$releasePath = "{$this->dir}/release";
+		$pids = [];
+
+		for ($i = 0; $i < 2; $i++) {
+			$pid = pcntl_fork();
+			if ($pid === -1) {
+				$this->fail('pcntl_fork() failed while creating overlapping tick workers');
+			}
+			if ($pid === 0) {
+				try {
+					file_put_contents($readyPath, getmypid() . "\n", FILE_APPEND | LOCK_EX);
+					$this->waitForPath($goPath, 3.0);
+					$refresh = static function () use ($callsPath, $releasePath): void {
+						file_put_contents($callsPath, getmypid() . "\n", FILE_APPEND | LOCK_EX);
+						$deadline = microtime(TRUE) + 3.0;
+						while (!is_file($releasePath) && microtime(TRUE) < $deadline) {
+							usleep(1000);
+						}
+					};
+					pfblockerng_tick(['pfblockerng.php dcc'], $refresh);
+					exit(0);
+				} catch (Throwable $e) {
+					file_put_contents("{$this->dir}/worker-error.log", $e::class . ': ' . $e->getMessage());
+					exit(1);
+				}
+			}
+			$pids[] = $pid;
+		}
+
+		$this->waitForLineCount($readyPath, 2, 3.0);
+		touch($goPath);
+		// Old behavior reaches two callbacks quickly; new behavior holds the second
+		// process at the bounded lock while the first callback waits for release.
+		$this->waitForLineCount($callsPath, 2, 1.0);
+		touch($releasePath);
+
+		foreach ($pids as $pid) {
+			pcntl_waitpid($pid, $status);
+			$this->assertTrue(pcntl_wifexited($status) && pcntl_wexitstatus($status) === 0,
+				"tick worker {$pid} failed: " . (string) @file_get_contents("{$this->dir}/worker-error.log"));
+		}
+
+		$calls = is_file($callsPath)
+			? array_values(array_filter(explode("\n", (string) file_get_contents($callsPath)), 'strlen'))
+			: [];
+		$this->assertCount(1, $calls,
+			'overlapping ticks must invoke SafeSearch once after the in-lock due recheck; calls=' . var_export($calls, TRUE));
+	}
+
+	private function waitForPath(string $path, float $timeout): void
+	{
+		$deadline = microtime(TRUE) + $timeout;
+		while (!is_file($path) && microtime(TRUE) < $deadline) {
+			usleep(1000);
+		}
+		if (!is_file($path)) {
+			throw new RuntimeException("timed out waiting for {$path}");
+		}
+	}
+
+	private function waitForLineCount(string $path, int $expected, float $timeout): void
+	{
+		$deadline = microtime(TRUE) + $timeout;
+		while (microtime(TRUE) < $deadline) {
+			$lines = is_file($path)
+				? array_values(array_filter(explode("\n", (string) file_get_contents($path)), 'strlen'))
+				: [];
+			if (count($lines) >= $expected) {
+				return;
+			}
+			usleep(1000);
+		}
+	}
+}

--- a/tests/php/TickSafeSearchReservationTest.php
+++ b/tests/php/TickSafeSearchReservationTest.php
@@ -54,6 +54,7 @@ final class TickSafeSearchReservationTest extends TestCase
 		}
 
 		$readyPath   = "{$this->dir}/ready.log";
+		$startedPath = "{$this->dir}/started.log";
 		$callsPath   = "{$this->dir}/calls.log";
 		$goPath      = "{$this->dir}/go";
 		$releasePath = "{$this->dir}/release";
@@ -68,6 +69,7 @@ final class TickSafeSearchReservationTest extends TestCase
 				try {
 					file_put_contents($readyPath, getmypid() . "\n", FILE_APPEND | LOCK_EX);
 					$this->waitForPath($goPath, 3.0);
+					file_put_contents($startedPath, getmypid() . "\n", FILE_APPEND | LOCK_EX);
 					$refresh = static function () use ($callsPath, $releasePath): void {
 						file_put_contents($callsPath, getmypid() . "\n", FILE_APPEND | LOCK_EX);
 						$deadline = microtime(TRUE) + 3.0;
@@ -85,15 +87,29 @@ final class TickSafeSearchReservationTest extends TestCase
 			$pids[] = $pid;
 		}
 
-		$this->waitForLineCount($readyPath, 2, 3.0);
-		touch($goPath);
-		// Old behavior reaches two callbacks quickly; new behavior holds the second
-		// process at the bounded lock while the first callback waits for release.
-		$this->waitForLineCount($callsPath, 2, 1.0);
-		touch($releasePath);
+		$statuses = [];
+		try {
+			$this->assertTrue($this->waitForLineCount($readyPath, 2, 3.0),
+				'overlap workers did not both reach ready barrier; lines=' . $this->lineCount($readyPath));
+			touch($goPath);
+			$this->assertTrue($this->waitForLineCount($startedPath, 2, 3.0),
+				'overlap workers did not both reach started barrier; lines=' . $this->lineCount($startedPath));
+			// Both workers reached the overlap barrier. One callback is the expected
+			// winner; the second worker either waits on the lock or races the old code.
+			$this->assertTrue($this->waitForLineCount($callsPath, 1, 3.0),
+				'no SafeSearch callback reached overlap; lines=' . $this->lineCount($callsPath));
+		} finally {
+			// Release every worker even when a milestone assertion fails, then reap
+			// the children so a timed-out assertion cannot orphan processes.
+			touch($goPath);
+			touch($releasePath);
+			foreach ($pids as $pid) {
+				pcntl_waitpid($pid, $status);
+				$statuses[$pid] = $status;
+			}
+		}
 
-		foreach ($pids as $pid) {
-			pcntl_waitpid($pid, $status);
+		foreach ($statuses as $pid => $status) {
 			$this->assertTrue(pcntl_wifexited($status) && pcntl_wexitstatus($status) === 0,
 				"tick worker {$pid} failed: " . (string) @file_get_contents("{$this->dir}/worker-error.log"));
 		}
@@ -116,7 +132,7 @@ final class TickSafeSearchReservationTest extends TestCase
 		}
 	}
 
-	private function waitForLineCount(string $path, int $expected, float $timeout): void
+	private function waitForLineCount(string $path, int $expected, float $timeout): bool
 	{
 		$deadline = microtime(TRUE) + $timeout;
 		while (microtime(TRUE) < $deadline) {
@@ -124,9 +140,18 @@ final class TickSafeSearchReservationTest extends TestCase
 				? array_values(array_filter(explode("\n", (string) file_get_contents($path)), 'strlen'))
 				: [];
 			if (count($lines) >= $expected) {
-				return;
+				return TRUE;
 			}
 			usleep(1000);
 		}
+		return FALSE;
+	}
+
+	private function lineCount(string $path): int
+	{
+		$lines = is_file($path)
+			? array_values(array_filter(explode("\n", (string) file_get_contents($path)), 'strlen'))
+			: [];
+		return count($lines);
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10040,6 +10040,13 @@
                 "variadic": false,
                 "type": "?array",
                 "default": "NULL"
+            },
+            {
+                "name": "ss_refresh",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
             }
         ]
     },

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10047,6 +10047,20 @@
                 "variadic": false,
                 "type": "?callable",
                 "default": "NULL"
+            },
+            {
+                "name": "ss_lock_opener",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "ss_lock_timeout",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
             }
         ]
     },

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -455,8 +455,8 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
 
     On its own, "unchanged ledger" cannot distinguish "tick correctly skipped the non-due cron"
     from "tick never ran at all" — both look identical. The positive control:
-    ss_refresh rides every tick unconditionally (pfblockerng_tick calls it regardless of what
-    is due), so a SafeSearch CNAME row seeded with a STALE baked IP and a resolver (the
+    an absent ss_refresh ledger entry is due on this first tick (pfblockerng_tick calls it
+    when due), so a SafeSearch CNAME row seeded with a STALE baked IP and a resolver (the
     'pfbextdns' setting) pointed at the hermetic stub DNS makes THIS tick's ss_refresh
     deterministically detect a change and log its own marker — proving the tick executed.
 
@@ -486,7 +486,7 @@ def test_tick_skips_non_due_feed(deployed_vm: SmokeVM, stub_dns: _StubDnsServer)
     ss_before = h.count_log_marker(vm, h.PFB_LOG, ss_marker)
 
     try:
-        # When: tick fires — cron is not due, but ss_refresh always runs.
+        # When: tick fires — cron is not due, and the absent ss_refresh entry is due.
         _run_tick(vm)
 
         # Then: the synchronous ledger decision is unchanged (cron skipped).

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -3072,6 +3072,16 @@ def test_pfblockerng_download_extras_uses_typed_download_result() -> None:
     )
 
 
+def test_pfblockerng_tick_delegates_safesearch_to_due_ledger() -> None:
+    """Pin the CLI-only tick dispatch that Tier-A HTTP rendering cannot execute."""
+    source_path = helpers.SMOKE_DIR.parent.parent / "src/usr/local/www/pfblockerng/pfblockerng.php"
+    source = source_path.read_text(encoding="utf-8")
+
+    tick_branch = source.split("elseif ($argv[1] == 'tick') {", 1)[1].split("elseif ($argv[1] == 'cron-tick') {", 1)[0]
+    assert tick_branch.count("pfblockerng_tick();") == 1
+    assert "pfblockerng_ss_refresh" not in tick_branch
+
+
 def test_reputation_page_help_text_names_relocated_matchgen_paths(
     webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:  # noqa: ARG001


### PR DESCRIPTION
## Summary

- add SafeSearch as an independent 900-second due-ledger job with zero jitter
- replace unconditional per-tick refresh with ledger-gated dispatch
- preserve anchored advancement and existing fail-closed ledger semantics
- update scheduler documentation and the callable inventory

Part of #1944.

## Test-first proof

Frozen test hashes:

- `TickCronTest.php`: `dee4c63a4620b1246eb5f7e25628c7567b4aab00`
- `TickEntrypointTest.php`: `bb3f4a46085ced41ecbf7157c4ad5c1622367a87`

RED on unchanged `origin/devel`:

- SafeSearch filter: 4 tests, 5 assertions, 3 intended callback-count failures

GREEN on this head:

- SafeSearch filter: 4 tests, 14 assertions
- TickCron + TickEntrypoint: 30 tests, 102 assertions
- DueLedger hostile-state suite: 35 tests, 96 assertions
- Function inventory parity: 1 test, 6 assertions
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS

Independent step verification: PASS, no blocking findings.

Fixes #2089

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SafeSearch refreshes now run on a scheduled 15-minute cadence instead of every system tick.
  * Refresh scheduling tracks due and future runs for predictable behavior.
  * Overdue refreshes catch up with a single run, avoiding repeated bursts.

* **Bug Fixes**
  * Prevented premature or repeated refreshes when not due.
  * Refreshes now safely defer and retry when execution cannot be secured or fails.

* **Tests**
  * Added coverage for scheduling, catch-up, failure recovery, and overlapping refresh attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->