### PR TITLE
pfblockerng: preserve DNSBL regex escape case

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -360,7 +360,7 @@ def main(argv: list[str]) -> int:
         line = raw_line.rstrip("\r\n")
         if not line.strip() or line.lstrip().startswith("#"):
             continue
-        pattern = pfb_split_regex_line(line)[0].strip().lower()
+        pattern = pfb_split_regex_line(line)[0].strip()
         if not pattern:
             continue
         if any(ord(character) < 0x20 or ord(character) == 0x7F for character in pattern):
@@ -393,7 +393,7 @@ def main(argv: list[str]) -> int:
             # same patterns at load without surfacing warnings either.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                re.compile(pattern)
+                re.compile(pattern, re.IGNORECASE)
         except Exception as error:
             _report(line_number, pattern, f"Python regex compile error: {error}")
             failed = True

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -529,7 +529,7 @@ def _build_swap_snapshot() -> Snapshot | None:
                     continue
                 try:
                     regex_db[name] = {
-                        "re": re.compile(pattern),
+                        "re": re.compile(pattern, re.IGNORECASE),
                         "important": False,
                         "band": PRIO_USER_BLOCK,
                     }
@@ -1137,7 +1137,7 @@ def _load_user_regex_entries(config: ConfigParser) -> list[tuple[str, str]]:
                 continue
             row_number += 1
             pattern, description = pfb_split_regex_line(line)
-            pattern = pattern.rstrip().encode("utf-8").lower().decode("utf-8")
+            pattern = pattern.rstrip()
             if not pattern:
                 continue
             if description is not None:
@@ -1635,7 +1635,7 @@ def init_standard(id: int, env: module_env) -> bool:
                     # ADR-07: a USER regex is SOVEREIGN -- band 5 (user block),
                     # so it beats feed allows and remains user-owned.
                     regexDB[name] = {
-                        "re": re.compile(pattern),
+                        "re": re.compile(pattern, re.IGNORECASE),
                         "important": False,
                         "band": PRIO_USER_BLOCK,
                     }

--- a/tests/php/DnsblRegexEntryErrorTest.php
+++ b/tests/php/DnsblRegexEntryErrorTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
  *
  * The DNSBL custom-list validator makes one bounded Python re pass over the
  * original form text. Python reports only rejected entries on stderr, retaining
- * source line numbers and the lowercased, inline-comment-stripped pattern.
+ * source line numbers and the raw, inline-comment-stripped pattern.
  */
 #[CoversFunction('pfb_dnsbl_regex_validation_errors')]
 final class DnsblRegexEntryErrorTest extends TestCase
@@ -149,16 +149,13 @@ final class DnsblRegexEntryErrorTest extends TestCase
 
 		$this->assertCount(1, $errors);
 		$this->assertStringContainsString('line 5:', $errors[0]);
-		$this->assertStringContainsString("'(?r)'", $errors[0]);
+		$this->assertStringContainsString("'(?R)'", $errors[0]);
 		$this->assertStringContainsString('Python', $errors[0]);
 	}
 
-	public function testUppercaseNamedGroupIsRejectedAfterResolverLowercases(): void
+	public function testUppercaseNamedGroupIsAcceptedWithoutResolverLowercasing(): void
 	{
-		$error = self::oneError("(?P<X>A)\n");
-		$this->assertStringContainsString('line 1:', $error);
-		$this->assertStringContainsString("'(?p<x>a)'", $error);
-		$this->assertStringContainsString('unknown extension', $error);
+		$this->assertSame([], self::errors("(?P<X>A)\n"));
 	}
 
 	/** @return array<string, array{string}> */
@@ -191,7 +188,7 @@ final class DnsblRegexEntryErrorTest extends TestCase
 	{
 		$error = self::oneError($pattern . "\n");
 		$this->assertStringContainsString('line 1:', $error);
-		$this->assertStringContainsString("'" . strtolower($pattern) . "'", $error);
+		$this->assertStringContainsString("'{$pattern}'", $error);
 		$this->assertStringContainsString('Python', $error);
 	}
 
@@ -346,7 +343,7 @@ final class DnsblRegexEntryErrorTest extends TestCase
 		$this->assertSame(
 			[],
 			self::errors($line . "\n", TRUE),
-			'the resolver measures the stripped/trimmed/lowercased pattern, not the raw line'
+			'the resolver measures the stripped/trimmed pattern, not the raw line'
 		);
 	}
 

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -306,8 +306,8 @@ class TestCatastrophicShapeHeuristic:
         # The two spellings are different regexes and each pins one half of the scanner.
         # Lowercase `\n{2,}` is a newline carrying an open-ended REPEAT; reading it as the
         # named-Unicode escape swallows the quantifier and blinds the gate to the run. This
-        # is the spelling the gate meets in production, because both consumers lowercase a
-        # pattern before admission (that fold is itself a defect -- issue #2079).
+        # is the spelling the gate meets in production; admission preserves raw pattern
+        # syntax (issue #2079), while query normalization stays separate.
         assert _regex_is_catastrophic_shape(r"\n{2,}\n{2,}\n{2,}") is True
         # Capital-N `\N{BULLET}` IS the named escape and is ONE atom, so its quantified run
         # is a run of three too -- green here only if the braces are consumed as part of the

--- a/tests/test_issue1718_regex_ascii_lower_compat.py
+++ b/tests/test_issue1718_regex_ascii_lower_compat.py
@@ -1,8 +1,9 @@
-"""Issue #1718: preserve PHP ASCII-only regex lowercasing."""
+"""Issue #2079: preserve raw user regex syntax with case-insensitive matching."""
 
 from __future__ import annotations
 
 import base64
+import re
 from pathlib import Path
 from typing import Any
 
@@ -10,15 +11,44 @@ import pfb_unbound as P
 from tests.test_issue1718_regex_transport import _ini, _initial_load
 
 
-def test_user_regex_lowercase_matches_php_ascii_semantics(tmp_path: Path, monkeypatch: Any) -> None:
-    encoded = base64.b64encode("ÄBC#Name\n".encode("utf-8")).decode("ascii")
+def test_user_regex_preserves_raw_patterns_and_matches_case_insensitively(tmp_path: Path, monkeypatch: Any) -> None:
+    text = (
+        r"\D+\.EXAMPLE\.COM#Non digit"
+        "\n"
+        r"\W+\.EXAMPLE\.COM#Non word"
+        "\n"
+        r"\S+\.EXAMPLE\.COM#Non space"
+        "\n"
+        r"a\Bbc\.EXAMPLE\.COM#Boundary"
+        "\n"
+        r"\d+\.EXAMPLE\.COM#Digit"
+        "\n"
+    )
+    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    expected = {
+        "non_digit": (r"\D+\.EXAMPLE\.COM", "abc.example.com", "123.example.com"),
+        "non_word": (r"\W+\.EXAMPLE\.COM", "---.example.com", "abc.example.com"),
+        "non_space": (r"\S+\.EXAMPLE\.COM", "abc.example.com", " .example.com"),
+        "boundary": (r"a\Bbc\.EXAMPLE\.COM", "abc.example.com", "a-bc.example.com"),
+        "digit": (r"\d+\.EXAMPLE\.COM", "123.example.com", "abc.example.com"),
+    }
 
     try:
         _initial_load(tmp_path, monkeypatch, _ini(encoded))
-        assert P.regexDB["name"]["re"].pattern == "Äbc"
+        for name, (pattern, matching_query, non_matching_query) in expected.items():
+            compiled = P.regexDB[name]["re"]
+            assert compiled.pattern == pattern
+            assert compiled.flags & re.IGNORECASE
+            assert compiled.search(matching_query), (name, matching_query)
+            assert not compiled.search(non_matching_query), (name, non_matching_query)
 
         swapped = P._build_swap_snapshot()
         assert swapped is not None
-        assert swapped.regex_db["name"]["re"].pattern == "Äbc"
+        for name, (pattern, matching_query, non_matching_query) in expected.items():
+            compiled = swapped.regex_db[name]["re"]
+            assert compiled.pattern == pattern
+            assert compiled.flags & re.IGNORECASE
+            assert compiled.search(matching_query), (name, matching_query)
+            assert not compiled.search(non_matching_query), (name, non_matching_query)
     finally:
         P.deinit(0)

--- a/tests/test_issue1718_regex_transport.py
+++ b/tests/test_issue1718_regex_transport.py
@@ -1,8 +1,9 @@
-"""Issue #1718: opaque base64 regex transport reaches both Python load sites."""
+"""Issue #2079: opaque base64 regex transport reaches both Python load sites."""
 
 from __future__ import annotations
 
 import base64
+import re
 from pathlib import Path
 from typing import Any
 
@@ -44,8 +45,10 @@ def test_initial_load_decodes_base64_rows_and_preserves_names(tmp_path: Path, mo
     try:
         _initial_load(tmp_path, monkeypatch, _ini(encoded))
         assert set(P.regexDB) == {"foo_desc", "foo_desc_2", "inline_description", "regex_4"}
-        assert P.regexDB["foo_desc"]["re"].pattern == 'a%=:;"\\d'
-        assert P.regexDB["foo_desc_2"]["re"].pattern == 'b%=:;"\\d'
+        assert P.regexDB["foo_desc"]["re"].pattern == 'A%=:;"\\D'
+        assert P.regexDB["foo_desc"]["re"].flags & re.IGNORECASE
+        assert P.regexDB["foo_desc_2"]["re"].pattern == 'B%=:;"\\D'
+        assert P.regexDB["foo_desc_2"]["re"].flags & re.IGNORECASE
         assert P.regexDB["inline_description"]["re"].pattern == "unnamed"
         assert P.regexDB["regex_4"]["re"].pattern == "blank"
     finally:
@@ -68,6 +71,7 @@ def test_swap_load_matches_initial(tmp_path: Path, monkeypatch: Any) -> None:
         swapped = P._build_swap_snapshot()
         assert swapped is not None
         assert {name: entry["re"].pattern for name, entry in swapped.regex_db.items()} == initial
+        assert all(entry["re"].flags & re.IGNORECASE for entry in swapped.regex_db.values())
     finally:
         P.deinit(0)
 


### PR DESCRIPTION
## Summary

- Preserve administrator-supplied DNSBL regex patterns instead of case-folding their source text.
- Compile the initial resolver load, zero-downtime swap load, and save-time validation probe with `re.IGNORECASE`.
- Keep feed-sourced block and allow regex compilation unchanged.

## Existing entries and release note

No configuration migration or administrator edit is required. Existing supported entries are ASCII-only at the GUI boundary:

- lowercase escapes (`\d`, `\w`, `\s`, `\b`) and ASCII literals retain their existing case-insensitive matching;
- uppercase complement escapes (`\D`, `\W`, `\S`, `\B`), anchors, and named-group syntax now keep their authored meaning instead of being rewritten;
- corrected compilation takes effect the next time the regex list is loaded or reloaded after the update.

This is an administrator-visible correctness fix and should be called out in the release notes. The repository keeps release notes on the GitHub Release rather than in an in-tree changelog, so no release-note file changes here.

## Feed-sourced regex audit

Feed regex follows a separate path: raw ABP lines become `RegexRule.pattern`, then `_dnsbl_compile_regex_rules()` compiles the raw pattern independently for block and allow databases. It never calls `_load_user_regex_entries()` and never took the user-list fold. That compiler remains raw and case-sensitive.

The audit also found that `MAIN.regex_list` produces user block entries in `regexDB` only. `allowRegexDB` is feed-only; user allows use `whiteDB`. The affected user path therefore did not include an allow-regex entry.

## Verification

- Frozen resolver RED→GREEN proof: `tests/test_issue1718_regex_ascii_lower_compat.py`, hash `c6ca18f3a37f67d12f1f93e9fccbe8dc877d9abd`.
- Frozen save-probe RED→GREEN proof through the PHP wrapper: `tests/php/DnsblRegexEntryErrorTest.php`, hash `ef9e91aed3ec3d10867af21dad33bc23edc41591`.
- Focused regex matrix: 136 tests passed.
- `scripts/agent/run-gates.sh --diff origin/devel`: all Python and PHP gates passed.
- Independent step verification replayed both frozen proofs, read the full six-file diff, and reran the canonical gates: PASS, no skips.

Fixes #2079

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
