### PR TITLE
pfblockerng: make feed regex case-insensitive

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4932,7 +4932,7 @@ def _dnsbl_compile_regex_rules(
             )
             continue
         try:
-            compiled = re.compile(rule.pattern)
+            compiled = re.compile(rule.pattern, re.IGNORECASE)
         except re.error as e:
             sys.stderr.write(
                 "[pfBlockerNG]: ABP regex compile error feed [ {} ] pattern [ {} ]: {}".format(

--- a/tests/test_adr07_decision_spec.py
+++ b/tests/test_adr07_decision_spec.py
@@ -456,7 +456,7 @@ def _domain_matches(rule: Rule, query: str) -> bool:
 
 
 def _regex_matches(rule: Rule, query: str) -> bool:
-    return re.search(rule.key, query.strip(".").lower()) is not None
+    return re.search(rule.key, query.strip(".").lower(), flags=re.IGNORECASE) is not None
 
 
 def _matches(rule: Rule, query: str) -> bool:
@@ -616,8 +616,8 @@ def test_regex_reducible_allow_folds_to_whitelist() -> None:
 
 
 # --- 4. REGEX IRREDUCIBLE: matches as written ------------------------------ #
-def test_regex_irreducible_block_matches_as_written() -> None:
-    rs = rules_from([r"/ad[0-9]\.example\.com$/"])
+def test_regex_irreducible_block_matches_case_insensitively() -> None:
+    rs = rules_from([r"/AD[0-9]\.EXAMPLE\.COM$/"])
     assert any(r.target is Target.REGEX for r in rs)
     assert decide(rs, "ad7.example.com").outcome == "block"
     assert decide(rs, "ads.example.com").outcome == "pass"  # 's' is not [0-9]

--- a/tests/test_adr07_emit_wire.py
+++ b/tests/test_adr07_emit_wire.py
@@ -280,6 +280,21 @@ class TestUserUnlock:
 # 3. ON -- the live 6-band matcher == the Phase-2 oracle decide()
 # --------------------------------------------------------------------------- #
 class TestLiveMatcherEqualsOracle:
+    def test_feed_block_and_allow_regex_are_case_insensitive_without_rewriting(self) -> None:
+        feeds = {
+            "f": [
+                r"/AD[0-9]\.EXAMPLE\.COM$/",
+                "||safe7.example.com^",
+                r"@@/SAFE[0-9]\.EXAMPLE\.COM$/",
+            ]
+        }
+        res = _build(feeds)
+
+        assert {entry["re"].pattern for entry in res.regex_db.values()} == {r"AD[0-9]\.EXAMPLE\.COM$"}
+        assert {entry["re"].pattern for entry in res.allow_regex_db.values()} == {r"SAFE[0-9]\.EXAMPLE\.COM$"}
+        assert _live_label(res, "ad7.example.com") == "block"
+        assert _live_label(res, "safe7.example.com") == "resolve"
+
     def test_feed_allow_unblocks_globally(self) -> None:
         feeds = {"f": ["||example.com^", "@@||safe.example.com^"]}
         res = _build(feeds)

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -124,11 +124,11 @@ def _resolve(result: P.ReconcileResult, query: str) -> str:
     import re
 
     for rr in result.block_regex_irreducible:
-        if re.search(rr.pattern, q):
+        if re.search(rr.pattern, q, flags=re.IGNORECASE):
             matched = True
             bp = max(bp, rr.band)
     for rr in result.allow_regex_irreducible:
-        if re.search(rr.pattern, q):
+        if re.search(rr.pattern, q, flags=re.IGNORECASE):
             matched = True
             ap = max(ap, rr.band)
 
@@ -444,7 +444,7 @@ class TestPrecedenceVsOracle:
             (["||x.example.com^$important", "@@||x.example.com^"], "x.example.com"),
             (["@@||y.example.com^$important", "||y.example.com^"], "y.example.com"),
             (["/^(.+\\.)?doubleclick\\.net$/"], "ad.doubleclick.net"),
-            (["/ad[0-9]\\.example\\.com$/"], "ad7.example.com"),
+            (["/AD[0-9]\\.EXAMPLE\\.COM$/"], "ad7.example.com"),
             (["||example.com^", "@@/^(.+\\.)?cdn\\.example\\.com$/"], "cdn.example.com"),
             (["||a.example.com^", "||a.example.com^$badfilter"], "a.example.com"),
         ],


### PR DESCRIPTION
## Summary

- Compile feed-sourced block and allow regex with `re.IGNORECASE`.
- Preserve every feed pattern exactly as authored; no case-folding or other text rewrite is added.
- Keep the ADR-07 decision and reconcile parity oracles aligned with the runtime compiler.

## Existing feed entries

An existing feed pattern containing uppercase literals that silently never matched lowercased DNS query names may now start matching. This is the intended, user-visible correctness fix. Patterns using `\D`, `\W`, `\S`, or `\B` retain their authored meaning because the pattern text is never folded.

## Probe and parity surfaces

The save-time probe did not move: it receives only the administrator's `MAIN.regex_list` contents and does not observe downloaded feed rows. Its shared issue #1765 module still supplies the same admission predicates to both consumers. The two test parity evaluators that do observe feed regex now use case-insensitive matching with unchanged pattern text.

## Verification

- Frozen RED before production edit: the feed block/allow test preserved uppercase source patterns, but the lowercased block query returned `pass`; test hash `3f5f2fc9a78239c23fefb6413fde644fca1f7299`.
- Frozen replay: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS` against pre-fix base `a91924172fc1a528719d3ec65f11c74b7ed0feff`.
- Focused DNSBL regex matrix: `324 passed`.
- Issue #2079 user-entry load and zero-downtime swap coverage: `5 passed` within the focused run; authored case and `re.IGNORECASE` remain unchanged.
- `scripts/agent/run-gates.sh --diff origin/devel`: pytest, Ruff check, Ruff format, and mypy all passed.

Fixes #2097

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
