### PR TITLE
pfblockerng: mark failed feed pre-scripts in the ledger; re-run transforms when a list script is configured

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -357,10 +357,8 @@ function pfb_list_user_script_active($script_pre, $script_post): bool {
  * baseline exists to reparse -- the row then routes to the existing
  * local-reuse branch (Reload/Rebuild) and never reaches the network. No
  * baseline -> stay on the fast path; there is no Hold-specific branch
- * anywhere. Sibling one-purpose `_active` predicates already in this style
- * (name deliberately not followed by a literal paren here -- a source-scan
- * test elsewhere counts real call sites of this file's helpers by that exact
- * token): pfb_ip_reuse_skip_active, pfb_dnsbl_verbatim_reuse_active, and
+ * anywhere. Sibling one-purpose `_active` predicates in this style:
+ * pfb_ip_reuse_skip_active, pfb_dnsbl_verbatim_reuse_active,
  * pfb_supp_update_active. Both the DNSBL and IP loops call this ONCE per
  * row, keeping them in lock-step by construction.
  */

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -349,6 +349,25 @@ function pfb_list_user_script_active($script_pre, $script_post): bool {
 	    ($script_post && is_file("{$script_post}"));
 }
 
+/**
+ * pfb_list_script_reparse_active -- issue #1960 re-runs a configured script's
+ * transform every pass, but issue #1278's Hold contract ("download once,
+ * never again") is protected ONLY by the early verbatim-reuse fast path, so
+ * the script term may push a row off that path SOLELY when a local '.orig'
+ * baseline exists to reparse -- the row then routes to the existing
+ * local-reuse branch (Reload/Rebuild) and never reaches the network. No
+ * baseline -> stay on the fast path; there is no Hold-specific branch
+ * anywhere. Sibling one-purpose `_active` predicates already in this style
+ * (name deliberately not followed by a literal paren here -- a source-scan
+ * test elsewhere counts real call sites of this file's helpers by that exact
+ * token): pfb_ip_reuse_skip_active, pfb_dnsbl_verbatim_reuse_active, and
+ * pfb_supp_update_active. Both the DNSBL and IP loops call this ONCE per
+ * row, keeping them in lock-step by construction.
+ */
+function pfb_list_script_reparse_active(bool $verbatim_reuse_ok, bool $has_user_script, bool $orig_exists): bool {
+	return $verbatim_reuse_ok && $has_user_script && $orig_exists;
+}
+
 // Main pfBlockerNG function
 function sync_package_pfblockerng($cron='') {
 	global $g, $pfb, $pfbarr;
@@ -1712,18 +1731,24 @@ function sync_package_pfblockerng($cron='') {
 							$staging_current_generation = pfb_dnsbl_staging_is_current_generation(
 								pfb_dnsbl_staging_first_line("{$pfbfolder}/{$header}.txt"));
 
-							// issue #1960: a configured pre/post script must never take this
-							// verbatim fast path -- applied at the call site (not as a
-							// parameter) so pfb_dnsbl_verbatim_reuse_active() keeps its
-							// existing signature and its other caller's meaning (the
-							// #1083 stale-generation re-call below is a DIFFERENT question
+							// issue #1960/#1278: a configured pre/post script re-runs its transform
+							// every pass, but the Hold contract ("download once, never again") is
+							// protected ONLY by this fast path -- so the script term may push a row
+							// off it solely when a local '.orig' baseline exists to reparse (routes
+							// to the existing local-reuse branch below, never the network). No
+							// baseline -> stay on the fast path; no Hold-specific branch anywhere.
+							// (the #1083 stale-generation re-call below is a DIFFERENT question
 							// and stays deliberately ungated -- see the comment there).
-							if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(
+							$pfb_dnsbl_verbatim_reuse = pfb_dnsbl_verbatim_reuse_active(
 								$txt_exists,
 								file_exists("{$pfbfolder}/{$header}.update"),
 								file_exists("{$pfbfolder}/{$header}.fail"),
 								$reuse_unset,
-								$staging_current_generation)) {
+								$staging_current_generation);
+							$pfb_dnsbl_script_reparse = pfb_list_script_reparse_active($pfb_dnsbl_verbatim_reuse,
+								$pfb_dnsbl_user_script, file_exists("{$pfborig}/{$header}.orig"));
+
+							if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {
 
 
 								if ($row['state'] == 'Hold') {
@@ -1747,21 +1772,24 @@ function sync_package_pfblockerng($cron='') {
 								$alias_cnt		= $alias_cnt + $list_cnt;
 							}
 							else {
-								// #1083: verbatim reuse was rejected because of the FILE-STATE
-								// conditions (staging generation, txt/update/fail existence, reuse
-								// toggle) -- rebuild via the same reparse-from-.orig machinery a
-								// Reload uses, never a network refetch when .orig is available.
+								// #1083/#1960: this branch is entered when the fast-path check above
+								// is FALSE -- either the FILE-STATE conditions rejected verbatim reuse
+								// (staging generation, txt/update/fail existence, reuse toggle), OR
+								// they all held but $pfb_dnsbl_script_reparse pushed the row off the
+								// fast path (a configured script with a local '.orig' baseline to
+								// reparse). Rebuild via the same reparse-from-.orig machinery a Reload
+								// uses, never a network refetch when .orig is available.
 								// issue #1960: this re-call is deliberately NOT gated by
-								// $pfb_dnsbl_user_script -- it answers a DIFFERENT question than the
-								// fast path above ("among the file-state conditions, was stale
-								// staging generation the ONLY reason reuse was rejected?"). A
-								// stale-generation .txt with a configured script still re-runs its
-								// pre-script on this cheaper reparse (the normalize/reuse-skip call
-								// below is FALSE anyway here, since $downloaded_fresh is FALSE);
-								// gating this call would only force an unneeded network refetch for
-								// that case, silently changing #1083's Rebuild /
-								// pfb_dnsbl_hold_stale_rebuild_skip / pfb_dnsbl_stale_rebuild_converge_txt
-								// behaviour that nobody asked for.
+								// $pfb_dnsbl_user_script/$pfb_dnsbl_script_reparse -- it answers a
+								// DIFFERENT question than the fast path above ("among the file-state
+								// conditions, was stale staging generation the ONLY reason reuse was
+								// rejected?"). A stale-generation .txt with a configured script still
+								// re-runs its pre-script on this cheaper reparse (the
+								// normalize/reuse-skip call below is FALSE anyway here, since
+								// $downloaded_fresh is FALSE); gating this call would only force an
+								// unneeded network refetch for that case, silently changing #1083's
+								// Rebuild / pfb_dnsbl_hold_stale_rebuild_skip /
+								// pfb_dnsbl_stale_rebuild_converge_txt behaviour that nobody asked for.
 								$stale_generation_rebuild = !$staging_current_generation &&
 									pfb_dnsbl_verbatim_reuse_active(
 										$txt_exists,
@@ -1769,7 +1797,12 @@ function sync_package_pfblockerng($cron='') {
 										file_exists("{$pfbfolder}/{$header}.fail"),
 										$reuse_unset,
 										TRUE);
-								$pfbreuse_effective = $pfbreuse == 'on' || $stale_generation_rebuild;
+								// issue #1278: OR in the script-reparse route so a scripted row with
+								// a local '.orig' baseline reuses it (Reload, never a network
+								// refetch); a Hold row with no baseline never reaches this branch at
+								// all (see the fast path above).
+								$pfbreuse_effective = $pfbreuse == 'on' || $stale_generation_rebuild ||
+									$pfb_dnsbl_script_reparse;
 
 								if ($stale_generation_rebuild) {
 									$log = "\n[ {$header} ]{$logtab} Rebuild";
@@ -3299,14 +3332,20 @@ function sync_package_pfblockerng($cron='') {
 							touch("{$pfbfolder}/{$header}.update");
 						}
 
-						// issue #1960: a configured pre/post script must never take this
-						// verbatim fast path -- its transform has to re-run every pass, or an
-						// edited script would silently require a Force Reload to take effect.
-						if (!$pfb_user_script &&
-						    file_exists("{$pfbfolder}/{$header}.txt") &&
+						// issue #1960/#1278: a configured pre/post script re-runs its transform
+						// every pass, but the Hold contract ("download once, never again") is
+						// protected ONLY by this fast path -- so the script term may push a row
+						// off it solely when a local '.orig' baseline exists to reparse (routes
+						// to the existing local-reuse branch below, never the network). No
+						// baseline -> stay on the fast path; no Hold-specific branch anywhere.
+						$pfb_ip_verbatim_reuse = file_exists("{$pfbfolder}/{$header}.txt") &&
 						    !file_exists("{$pfbfolder}/{$header}.update") &&
 						    !file_exists("{$pfbfolder}/{$header}.fail") &&
-						    $pfbreuse == '') {
+						    $pfbreuse == '';
+						$pfb_script_reparse = pfb_list_script_reparse_active($pfb_ip_verbatim_reuse,
+						    $pfb_user_script, file_exists("{$pfborig}/{$header}.orig"));
+
+						if ($pfb_ip_verbatim_reuse && !$pfb_script_reparse) {
 
 							if ($row['state'] == 'Hold') {
 								$log = "\n[ {$header} ]{$logtab} static hold.";
@@ -3318,7 +3357,10 @@ function sync_package_pfblockerng($cron='') {
 						else {
 							// Short-circuit: skip the stat() below when reuse is off (ADR-28);
 							// FALSE here is truth-functionally identical since the callee ANDs $reuse_on anyway.
-							$pfbreuse_on = $pfbreuse == 'on';
+							// issue #1278: OR in the script-reparse route -- a scripted row with a
+							// local '.orig' baseline reuses it (never a network refetch); a Hold row
+							// with no baseline never reaches this branch (see the fast path above).
+							$pfbreuse_on = $pfbreuse == 'on' || $pfb_script_reparse;
 							$orig_exists_if_reused = $pfbreuse_on && file_exists("{$pfborig}/{$header}.orig");
 							if (pfb_ip_reuse_skip_active($pfbreuse_on, $orig_exists_if_reused, isset($list['dnsblip']))) {
 								$log = "\n[ {$header} ]{$logtab} Reload";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -314,6 +314,26 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 	return $result;
 }
 
+/**
+ * pfb_list_script_failure_record -- issue #1958: a per-feed pre-script that
+ * exits non-zero must not let the alias pass close as full success. Opens a
+ * distinct ADR-61 stage='script' ledger entry -- separate from stage='download',
+ * since the download itself genuinely succeeded and only the transform failed
+ * -- and (re)writes the '.update' retry marker. The marker matters because a
+ * row that entered the update branch via a '.fail' marker alone had that
+ * marker unlinked by the successful download; without this write the next
+ * ordinary pass takes the verbatim-reuse fast path and never retries the
+ * transform. The marker write is best-effort (@-suppressed): ledger
+ * visibility must never depend on it succeeding. ADR-61 symmetric ownership:
+ * the paired close is pfb_sync_status_close($facility, $item, 'script',
+ * $ledger_dir) at the alias-pass end.
+ */
+function pfb_list_script_failure_record(string $facility, string $item, string $message,
+    string $ledger_dir, string $update_marker): void {
+	@touch($update_marker);
+	pfb_sync_status_open($facility, $item, 'script', $message, $ledger_dir);
+}
+
 // Main pfBlockerNG function
 function sync_package_pfblockerng($cron='') {
 	global $g, $pfb, $pfbarr;
@@ -1573,6 +1593,9 @@ function sync_package_pfblockerng($cron='') {
 				// issue #1048: per-alias-pass failure flag -- a sibling feed's success must
 				// never close a DIFFERENT feed's still-open download-failure ledger entry.
 				$pfb_dl_failed		= FALSE;
+				// issue #1958: per-alias-pass script-failure flag -- a sibling feed's
+				// success must never close another feed's still-open script-failure entry.
+				$pfb_script_failed	= FALSE;
 
 				$alias = "DNSBL_{$list['aliasname']}";
 				if (empty(pfb_filter($alias, PFB_FILTER_WORD, 'DNSBL - Processes'))) {
@@ -1827,6 +1850,13 @@ function sync_package_pfblockerng($cron='') {
 									    $pfb_dnsbl_script_pre, $list['script_pre'], $header,
 									    escapeshellarg("{$file_dwn}.pre") . " dnsbl {$elog}");
 									if (!$pfb_pre['ok']) {
+										// issue #1958: pre-script failure genuinely served last-known-good --
+										// mark it in the ledger (distinct 'script' stage, never 'download') and
+										// retry the transform on the next ordinary pass via the '.update' marker.
+										pfb_list_script_failure_record('dnsbl', $alias,
+										    "[ {$alias} - {$header} ] Pre-script FAIL - serving last known-good",
+										    $pfb['dbdir'], "{$pfbfolder}/{$header}.update");
+										$pfb_script_failed = TRUE;
 										// #1083: a stale-generation '.txt' never re-enters the manifest.
 										if ($staging_current_generation && file_exists("{$pfbfolder}/{$header}.txt")) {
 											$lists_dnsbl_all[]	= "{$row['header']}.txt";
@@ -2220,6 +2250,12 @@ function sync_package_pfblockerng($cron='') {
 					// feed's success mask an earlier feed's still-live failure.
 					if (!$pfb_dl_failed) {
 						pfb_dnsbl_download_ledger_update(TRUE, $alias, '', $pfb['dbdir']);
+					}
+
+					// issue #1958: ADR-61 symmetric ownership -- close the 'script' stage
+					// entry once for the WHOLE alias-pass, iff no row's pre-script failed.
+					if (!$pfb_script_failed) {
+						pfb_sync_status_close('dnsbl', $alias, 'script', $pfb['dbdir']);
 					}
 
 					// ADR-12: record GENUINELY-changed DNSBL groups for
@@ -3121,6 +3157,9 @@ function sync_package_pfblockerng($cron='') {
 				// issue #1048: per-alias-pass failure flag -- a sibling feed's success must
 				// never close a DIFFERENT feed's still-open download-failure ledger entry.
 				$pfb_dl_failed = FALSE;
+				// issue #1958: per-alias-pass script-failure flag -- a sibling feed's
+				// success must never close another feed's still-open script-failure entry.
+				$pfb_script_failed = FALSE;
 
 				foreach	($list['row'] as $row) {
 					if (!empty($row['url']) && $row['state'] != 'Disabled') {
@@ -3434,6 +3473,13 @@ function sync_package_pfblockerng($cron='') {
 								    $pfb_script_pre, $list['script_pre'], $header,
 								    escapeshellarg("{$file_dwn}.pre") . " {$list['vtype']} {$elog}");
 								if (!$pfb_pre['ok']) {
+									// issue #1958: pre-script failure genuinely served last-known-good --
+									// mark it in the ledger (distinct 'script' stage, never 'download') and
+									// retry the transform on the next ordinary pass via the '.update' marker.
+									pfb_list_script_failure_record('ip', $alias,
+									    "[ {$alias} - {$header} ] Pre-script FAIL - serving last known-good",
+									    $pfb['dbdir'], "{$pfbfolder}/{$header}.update");
+									$pfb_script_failed = TRUE;
 									continue;
 								}
 								$pfb_parse_path = $pfb_pre['path'];
@@ -3616,6 +3662,12 @@ function sync_package_pfblockerng($cron='') {
 				// feed's success mask an earlier feed's still-live failure.
 				if (!$pfb_dl_failed) {
 					pfb_ip_download_ledger_update(TRUE, $alias, '', $pfb['dbdir']);
+				}
+
+				// issue #1958: ADR-61 symmetric ownership -- close the 'script' stage
+				// entry once for the WHOLE alias-pass, iff no row's pre-script failed.
+				if (!$pfb_script_failed) {
+					pfb_sync_status_close('ip', $alias, 'script', $pfb['dbdir']);
 				}
 			}
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -334,6 +334,21 @@ function pfb_list_script_failure_record(string $facility, string $item, string $
 	pfb_sync_status_open($facility, $item, 'script', $message, $ledger_dir);
 }
 
+/**
+ * pfb_list_user_script_active -- issue #1960: a feed with a configured
+ * pre/post script must never take an early verbatim-reuse fast path, because
+ * the transform has to re-run every pass; this is the same has_user_script
+ * term the IP and DNSBL loops' normalization-level reuse-skip gates (the
+ * norm_reuse_skip pair, one per loop) already carry at the normalization
+ * level. One helper for both loops keeps them in lock-step by construction.
+ * $script_pre/$script_post stay untyped: pfb_resolve_list_script() returns
+ * FALSE or a string, and both call sites hold that same union.
+ */
+function pfb_list_user_script_active($script_pre, $script_post): bool {
+	return ($script_pre && is_file("{$script_pre}")) ||
+	    ($script_post && is_file("{$script_post}"));
+}
+
 // Main pfBlockerNG function
 function sync_package_pfblockerng($cron='') {
 	global $g, $pfb, $pfbarr;
@@ -1623,6 +1638,10 @@ function sync_package_pfblockerng($cron='') {
 					if (!empty($list['script_post'])) {
 						$pfb_dnsbl_script_post = pfb_resolve_list_script($list['script_post']);
 					}
+					// issue #1960: computed once per ALIAS (mirrors where the scripts
+					// are resolved above) -- must dominate both the verbatim fast path
+					// below and the later normalize/reuse-skip call it also gates.
+					$pfb_dnsbl_user_script = pfb_list_user_script_active($pfb_dnsbl_script_pre, $pfb_dnsbl_script_post);
 
 					foreach ($list['row'] as $key => $row) {
 						if (!empty($row['url']) && $row['state'] != 'Disabled') {
@@ -1693,7 +1712,13 @@ function sync_package_pfblockerng($cron='') {
 							$staging_current_generation = pfb_dnsbl_staging_is_current_generation(
 								pfb_dnsbl_staging_first_line("{$pfbfolder}/{$header}.txt"));
 
-							if (pfb_dnsbl_verbatim_reuse_active(
+							// issue #1960: a configured pre/post script must never take this
+							// verbatim fast path -- applied at the call site (not as a
+							// parameter) so pfb_dnsbl_verbatim_reuse_active() keeps its
+							// existing signature and its other caller's meaning (the
+							// #1083 stale-generation re-call below is a DIFFERENT question
+							// and stays deliberately ungated -- see the comment there).
+							if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(
 								$txt_exists,
 								file_exists("{$pfbfolder}/{$header}.update"),
 								file_exists("{$pfbfolder}/{$header}.fail"),
@@ -1722,10 +1747,21 @@ function sync_package_pfblockerng($cron='') {
 								$alias_cnt		= $alias_cnt + $list_cnt;
 							}
 							else {
-								// #1083: verbatim reuse was rejected ONLY for stale staging
-								// generation (every other reuse condition still holds) -- rebuild
-								// via the same reparse-from-.orig machinery a Reload uses, never a
-								// network refetch when .orig is available.
+								// #1083: verbatim reuse was rejected because of the FILE-STATE
+								// conditions (staging generation, txt/update/fail existence, reuse
+								// toggle) -- rebuild via the same reparse-from-.orig machinery a
+								// Reload uses, never a network refetch when .orig is available.
+								// issue #1960: this re-call is deliberately NOT gated by
+								// $pfb_dnsbl_user_script -- it answers a DIFFERENT question than the
+								// fast path above ("among the file-state conditions, was stale
+								// staging generation the ONLY reason reuse was rejected?"). A
+								// stale-generation .txt with a configured script still re-runs its
+								// pre-script on this cheaper reparse (the normalize/reuse-skip call
+								// below is FALSE anyway here, since $downloaded_fresh is FALSE);
+								// gating this call would only force an unneeded network refetch for
+								// that case, silently changing #1083's Rebuild /
+								// pfb_dnsbl_hold_stale_rebuild_skip / pfb_dnsbl_stale_rebuild_converge_txt
+								// behaviour that nobody asked for.
 								$stale_generation_rebuild = !$staging_current_generation &&
 									pfb_dnsbl_verbatim_reuse_active(
 										$txt_exists,
@@ -1822,8 +1858,6 @@ function sync_package_pfblockerng($cron='') {
 								// content is byte-identical to the previous pass reuses the staged
 								// '.txt' the same way the verbatim-reuse branch does.
 								$pfb_norm = pfb_feed_normalize("{$file_dwn}.orig");
-								$pfb_dnsbl_user_script = ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) ||
-								    ($pfb_dnsbl_script_post && is_file("{$pfb_dnsbl_script_post}"));
 								if (pfb_dnsbl_norm_reuse_skip($downloaded_fresh, (bool) $custom, $orig_content_stale,
 								    $pfb_norm['changed'], file_exists("{$pfbfolder}/{$header}.txt"), $staging_current_generation,
 								    $pfb_dnsbl_user_script)) {
@@ -3233,6 +3267,10 @@ function sync_package_pfblockerng($cron='') {
 						if (isset($list['script_post']) && !empty($list['script_post'])) {
 							$pfb_script_post = pfb_resolve_list_script($list['script_post']);
 						}
+						// issue #1960: computed once per ROW (mirrors where the scripts are
+						// resolved above) -- must dominate both the verbatim fast path below
+						// and the later normalize/reuse-skip call it also gates.
+						$pfb_user_script = pfb_list_user_script_active($pfb_script_pre, $pfb_script_post);
 
 						// Determine 'list' details (return array $pfbarr)
 						if (isset($list['dnsblip'])) {
@@ -3261,7 +3299,11 @@ function sync_package_pfblockerng($cron='') {
 							touch("{$pfbfolder}/{$header}.update");
 						}
 
-						if (file_exists("{$pfbfolder}/{$header}.txt") &&
+						// issue #1960: a configured pre/post script must never take this
+						// verbatim fast path -- its transform has to re-run every pass, or an
+						// edited script would silently require a Force Reload to take effect.
+						if (!$pfb_user_script &&
+						    file_exists("{$pfbfolder}/{$header}.txt") &&
 						    !file_exists("{$pfbfolder}/{$header}.update") &&
 						    !file_exists("{$pfbfolder}/{$header}.fail") &&
 						    $pfbreuse == '') {
@@ -3444,11 +3486,6 @@ function sync_package_pfblockerng($cron='') {
 									$pftype = 'auto';
 								}
 							}
-
-							// IPv4/6 Advanced Tunable - a configured pre or post script means
-							// the feed must reparse every run (#1797 reuse-skip stays off).
-							$pfb_user_script = ($pfb_script_pre && is_file("{$pfb_script_pre}")) ||
-							    ($pfb_script_post && is_file("{$pfb_script_post}"));
 
 							// issue #1925: normalize once per file; the parse below reads .norm
 							// (raw .orig on normalize failure). A fresh download whose NORMALIZED

--- a/tests/php/ListScriptFailureLedgerWiringTest.php
+++ b/tests/php/ListScriptFailureLedgerWiringTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1958: a per-feed pre-script that exits non-zero must not let the
+ * alias pass close as full success. The IP and DNSBL loops inside
+ * sync_package_pfblockerng() drive real appliance exec and have no PHPUnit
+ * harness of their own (issue #993), so -- same technique as
+ * DnsblListScriptWiringTest / PfbSyncStatusIpWritersTest -- the wiring is
+ * pinned by source inspection with vacuity-guarded windows: each window's
+ * start/end anchors are asserted present BEFORE the content assertion inside
+ * them is trusted.
+ *
+ * Pins, per loop:
+ *   - the pre-script failure branch records the new ADR-61 'script' stage
+ *     ledger entry + '.update' retry marker via pfb_list_script_failure_record(),
+ *     sets $pfb_script_failed, and STILL falls through to the existing
+ *     continue; (DNSBL: the existing #1841-class manifest-row re-emission on a
+ *     stale-generation .txt must also survive, untouched).
+ *   - the alias-pass end closes the 'script' stage ledger entry, guarded by
+ *     !$pfb_script_failed, beside the existing download-ledger close.
+ *   - both loops declare their own per-alias-pass $pfb_script_failed reset --
+ *     a reset dropped from one loop is the #1048-class bug (a sibling feed's
+ *     success masking this feed's still-open failure).
+ */
+final class ListScriptFailureLedgerWiringTest extends TestCase
+{
+	private static string $applySource;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		if ($source === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		}
+		self::$applySource = $source;
+	}
+
+	// -----------------------------------------------------------------
+	// Row 7 -- IP pre-script failure branch.
+	// -----------------------------------------------------------------
+
+	public function testIpPreScriptFailureBranchRecordsLedgerAndMarkerBeforeContinue(): void
+	{
+		$dnsblCallPos = strpos(self::$applySource, 'pfb_list_pre_script_run(');
+		$this->assertNotFalse($dnsblCallPos, 'vacuity: the DNSBL pre-script call site must exist (first occurrence)');
+
+		$ipCallPos = strpos(self::$applySource, 'pfb_list_pre_script_run(', $dnsblCallPos + 1);
+		$this->assertNotFalse($ipCallPos, 'vacuity: the IP pre-script call site must exist (second occurrence)');
+
+		$ipFopenPos = strpos(self::$applySource, '@fopen($pfb_parse_path', $ipCallPos);
+		$this->assertNotFalse($ipFopenPos, 'vacuity: the IP parse-open that follows the IP pre-script call must exist');
+		$this->assertGreaterThan($ipCallPos, $ipFopenPos, 'the IP parse-open must sit after the IP pre-script call');
+
+		$window = substr(self::$applySource, $ipCallPos, $ipFopenPos - $ipCallPos);
+
+		$this->assertStringContainsString('" {$list[\'vtype\']} {$elog}"', $window,
+			'vacuity: this window must be the IP call (carries the vtype args-tail discriminator, not "dnsbl")');
+
+		$this->assertStringContainsString("pfb_list_script_failure_record('ip', \$alias,", $window,
+			'a pre-script failure must record the ADR-61 script-stage ledger entry, keyed on the IP facility');
+		$this->assertStringContainsString('$pfb_script_failed = TRUE;', $window,
+			'a pre-script failure must raise the per-alias-pass script-failure flag');
+		$this->assertStringContainsString('.update"', $window,
+			'a pre-script failure must (re)write the .update retry marker so the next ordinary pass retries the transform');
+		$this->assertStringContainsString('continue;', $window,
+			'the existing continue; (serving last-known-good, #1927) must survive untouched');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 8 -- DNSBL pre-script failure branch.
+	// -----------------------------------------------------------------
+
+	public function testDnsblPreScriptFailureBranchRecordsLedgerAndMarkerKeepingManifestRow(): void
+	{
+		$dnsblCallPos = strpos(self::$applySource, 'pfb_list_pre_script_run(');
+		$this->assertNotFalse($dnsblCallPos, 'vacuity: the DNSBL pre-script call site must exist (first occurrence)');
+
+		$dnsblFopenPos = strpos(self::$applySource, '@fopen($pfb_parse_path', $dnsblCallPos);
+		$this->assertNotFalse($dnsblFopenPos, 'vacuity: the DNSBL parse-open that follows the DNSBL pre-script call must exist');
+		$this->assertGreaterThan($dnsblCallPos, $dnsblFopenPos, 'the DNSBL parse-open must sit after the DNSBL pre-script call');
+
+		$window = substr(self::$applySource, $dnsblCallPos, $dnsblFopenPos - $dnsblCallPos);
+
+		$this->assertStringContainsString('" dnsbl {$elog}"', $window,
+			'vacuity: this window must be the DNSBL call (carries the stable "dnsbl" args-tail discriminator)');
+
+		$this->assertStringContainsString("pfb_list_script_failure_record('dnsbl', \$alias,", $window,
+			'a pre-script failure must record the ADR-61 script-stage ledger entry, keyed on the DNSBL facility');
+		$this->assertStringContainsString('$pfb_script_failed = TRUE;', $window,
+			'a pre-script failure must raise the per-alias-pass script-failure flag');
+		$this->assertStringContainsString('.update"', $window,
+			'a pre-script failure must (re)write the .update retry marker so the next ordinary pass retries the transform');
+		$this->assertStringContainsString('pfb_feed_manifest_row(', $window,
+			'the existing manifest-row re-emission on a stale-generation .txt must survive -- '
+			. 'dropping it would relocate the outage (#1841-class), not fix it');
+		$this->assertStringContainsString('continue;', $window,
+			'the existing continue; (serving last-known-good, #1927) must survive untouched');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 9 -- IP alias-pass close, guarded by !$pfb_script_failed.
+	// -----------------------------------------------------------------
+
+	public function testIpAliasPassClosesScriptStageGuardedByScriptFailedFlag(): void
+	{
+		$closePos = strpos(self::$applySource, "pfb_ip_download_ledger_update(TRUE,");
+		$this->assertNotFalse($closePos, 'vacuity: the IP download-ledger success-close call site must exist');
+
+		$endPos = strpos(self::$applySource, 'Remove database update file markers', $closePos);
+		$this->assertNotFalse($endPos, 'vacuity: the end-of-loop epilogue marker must exist after the IP close');
+
+		$window = substr(self::$applySource, $closePos, $endPos - $closePos);
+
+		$this->assertStringContainsString("pfb_sync_status_close('ip', \$alias, 'script'", $window,
+			'the alias-pass end must close the ADR-61 script-stage entry for this alias');
+		$this->assertStringContainsString('!$pfb_script_failed', $window,
+			'the script-stage close must be gated by the once-per-alias-pass flag, symmetric with the download-ledger close');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 10 -- DNSBL alias-pass close, guarded by !$pfb_script_failed.
+	// -----------------------------------------------------------------
+
+	public function testDnsblAliasPassClosesScriptStageGuardedByScriptFailedFlag(): void
+	{
+		$closePos = strpos(self::$applySource, "pfb_dnsbl_download_ledger_update(TRUE,");
+		$this->assertNotFalse($closePos, 'vacuity: the DNSBL download-ledger success-close call site must exist');
+
+		$endPos = strpos(self::$applySource, 'ADR-12: record GENUINELY-changed DNSBL groups', $closePos);
+		$this->assertNotFalse($endPos, 'vacuity: the ADR-12 change-tracking comment must exist after the DNSBL close');
+
+		$window = substr(self::$applySource, $closePos, $endPos - $closePos);
+
+		$this->assertStringContainsString("pfb_sync_status_close('dnsbl', \$alias, 'script'", $window,
+			'the alias-pass end must close the ADR-61 script-stage entry for this alias');
+		$this->assertStringContainsString('!$pfb_script_failed', $window,
+			'the script-stage close must be gated by the once-per-alias-pass flag, symmetric with the download-ledger close');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 11 -- both per-alias resets exist, one per loop.
+	// -----------------------------------------------------------------
+
+	public function testBothLoopsDeclareTheirOwnPerAliasScriptFailedReset(): void
+	{
+		$count = preg_match_all('/\$pfb_script_failed\s*=\s*FALSE;/', self::$applySource);
+		$this->assertNotFalse($count, 'the reset regex itself must be well-formed');
+		$this->assertSame(2, $count,
+			'exactly one $pfb_script_failed = FALSE; reset per loop (IP + DNSBL) must exist -- '
+			. 'a reset dropped from one loop is the #1048-class bug (a sibling feed\'s success '
+			. 'masking this feed\'s still-open failure)'
+		);
+	}
+}

--- a/tests/php/ListScriptReparseWiringTest.php
+++ b/tests/php/ListScriptReparseWiringTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1960/#1278 -- #1960 gated both loops' early verbatim-reuse fast
+ * paths on the bare has_user_script term (!$pfb_dnsbl_user_script /
+ * !$pfb_user_script). That makes a Hold-state row with a configured
+ * pre/post script leave the fast path UNCONDITIONALLY and fall through to a
+ * real network download every pass, breaking issue #1278's "download once,
+ * never again" Hold contract (the fast path is the ONLY thing protecting
+ * it -- see PfbListScriptReparseActiveTest's docblock).
+ *
+ * The fix routes a scripted row off the fast path ONLY when a local '.orig'
+ * baseline exists to reparse (pfb_list_script_reparse_active()), sending it
+ * to the existing local-reuse branch instead of the network. The IP and
+ * DNSBL loops inside sync_package_pfblockerng() drive real appliance exec
+ * and have no PHPUnit harness of their own (issue #993), so -- same
+ * technique as DnsblListScriptWiringTest / ListScriptTransformRerunWiringTest
+ * -- the wiring is pinned by source inspection with vacuity-guarded windows.
+ */
+final class ListScriptReparseWiringTest extends TestCase
+{
+	private static string $applySource;
+
+	// The IP loop's own list-collection comment sits strictly AFTER the whole
+	// DNSBL alias loop and BEFORE the IP loop's per-row body -- a token that
+	// only occurs between the two loops, used to prove a pair of call sites
+	// straddles them (one per loop) rather than both landing in one loop.
+	private const LOOP_BOUNDARY_COMMENT =
+		'// Collect lists and custom list configuration and format into one array ($lists).';
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		if ($source === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		}
+		self::$applySource = $source;
+	}
+
+	// -----------------------------------------------------------------
+	// Row 6 -- DNSBL fast path gated by !$pfb_dnsbl_script_reparse, not by
+	// the bare user-script term. Anchored on the gated statement HEAD (not a
+	// bare token) so a comment merely mentioning the token cannot satisfy it.
+	// -----------------------------------------------------------------
+
+	public function testDnsblFastPathGatedByScriptReparseNotBareUserScriptTerm(): void
+	{
+		$this->assertStringContainsString(
+			'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {',
+			self::$applySource,
+			'issue #1960/#1278: the DNSBL fast path must be gated by the script-reparse term (which '
+			. 'requires a local .orig baseline), not by the bare has_user_script term -- the bare term '
+			. 'forces a Hold row with no baseline through to a network download every pass'
+		);
+
+		$this->assertStringNotContainsString(
+			'if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(',
+			self::$applySource,
+			'the old bare-user-script gate must be gone -- its presence is the exact #1278 regression '
+			. 'this fix closes'
+		);
+
+		// The gate must sit on the fast path that logs "exists."/"static hold.", not on
+		// some other statement.
+		$gatePos = strpos(self::$applySource, 'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {');
+		$this->assertNotFalse($gatePos, 'vacuity: the gated DNSBL fast-path statement must exist');
+		$existsPos = strpos(self::$applySource, '{$logtab} exists.', $gatePos);
+		$this->assertNotFalse($existsPos,
+			'the gated statement must be the DNSBL verbatim-reuse fast path -- its branch logs "exists."');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 7 -- IP fast path likewise gated by !$pfb_script_reparse.
+	// -----------------------------------------------------------------
+
+	public function testIpFastPathGatedByScriptReparseNotBareUserScriptTerm(): void
+	{
+		$this->assertStringContainsString(
+			'if ($pfb_ip_verbatim_reuse && !$pfb_script_reparse) {',
+			self::$applySource,
+			'issue #1960/#1278: the IP fast path must be gated by the script-reparse term (which '
+			. 'requires a local .orig baseline), not by the bare has_user_script term -- the bare term '
+			. 'forces a Hold row with no baseline through to a network download every pass'
+		);
+
+		$this->assertStringNotContainsString(
+			'if (!$pfb_user_script &&',
+			self::$applySource,
+			'the old bare-user-script gate must be gone -- its presence is the exact #1278 regression '
+			. 'this fix closes'
+		);
+
+		$gatePos = strpos(self::$applySource, 'if ($pfb_ip_verbatim_reuse && !$pfb_script_reparse) {');
+		$this->assertNotFalse($gatePos, 'vacuity: the gated IP fast-path statement must exist');
+		$existsPos = strpos(self::$applySource, '{$logtab} exists.', $gatePos);
+		$this->assertNotFalse($existsPos,
+			'the gated statement must be the IP verbatim-reuse fast path -- its branch logs "exists."');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 8 -- DNSBL $pfbreuse_effective carries the script-reparse term, so
+	// a scripted row with a local baseline routes to local reuse, not the
+	// network.
+	// -----------------------------------------------------------------
+
+	public function testDnsblPfbreuseEffectiveCarriesScriptReparseTerm(): void
+	{
+		$stmtPos = strpos(self::$applySource, '$pfbreuse_effective = ');
+		$this->assertNotFalse($stmtPos, 'vacuity: the $pfbreuse_effective assignment must exist');
+
+		$stmtEnd = strpos(self::$applySource, ';', $stmtPos);
+		$this->assertNotFalse($stmtEnd, 'vacuity: the assignment statement must terminate');
+		$statement = substr(self::$applySource, $stmtPos, $stmtEnd - $stmtPos);
+
+		$this->assertStringContainsString('$pfb_dnsbl_script_reparse', $statement,
+			'issue #1278: $pfbreuse_effective must OR in the script-reparse route so a scripted row '
+			. 'with a local .orig baseline reuses it locally (Reload) instead of falling through to a '
+			. 'network download');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 9 -- IP reuse decision carries the script-reparse term at BOTH
+	// pfb_ip_reuse_skip_active( call sites (counted from source first), and
+	// nothing reassigns the carrying variable between them -- a mismatch
+	// there would log "Reload" then download anyway, or vice versa.
+	// -----------------------------------------------------------------
+
+	public function testIpReuseSkipActiveBothCallSitesCarryScriptReparseTerm(): void
+	{
+		$callCount = substr_count(self::$applySource, 'pfb_ip_reuse_skip_active(');
+		$this->assertSame(2, $callCount,
+			'vacuity: the IP loop must have exactly the two known pfb_ip_reuse_skip_active( call '
+			. 'sites (the log-line decision + the actual reuse-vs-download fork) -- a third call site '
+			. 'changes the shape this test pins, and this brief forbids weakening the !$is_dnsblip term '
+			. 'at any of them (#1002/#1020)');
+
+		$assignPos = strpos(self::$applySource, "\$pfbreuse_on = \$pfbreuse == 'on'");
+		$this->assertNotFalse($assignPos, 'vacuity: the $pfbreuse_on assignment must exist');
+
+		$assignEnd = strpos(self::$applySource, ';', $assignPos);
+		$this->assertNotFalse($assignEnd, 'vacuity: the assignment statement must terminate');
+		$assignStatement = substr(self::$applySource, $assignPos, $assignEnd - $assignPos);
+		$this->assertStringContainsString('$pfb_script_reparse', $assignStatement,
+			'issue #1278: $pfbreuse_on must OR in the script-reparse route so a scripted row with a '
+			. 'local .orig baseline reuses it locally instead of falling through to a network download');
+
+		$firstCallPos = strpos(self::$applySource, 'pfb_ip_reuse_skip_active(', $assignPos);
+		$this->assertNotFalse($firstCallPos, 'vacuity: the first call site (after the assignment) must exist');
+		$secondCallPos = strpos(self::$applySource, 'pfb_ip_reuse_skip_active(', $firstCallPos + 1);
+		$this->assertNotFalse($secondCallPos, 'vacuity: the second call site must exist');
+
+		$firstCallHead = substr(self::$applySource, $firstCallPos, strlen('pfb_ip_reuse_skip_active($pfbreuse_on,'));
+		$this->assertSame('pfb_ip_reuse_skip_active($pfbreuse_on,', $firstCallHead,
+			'the first pfb_ip_reuse_skip_active( call must feed $pfbreuse_on (the variable carrying '
+			. 'the OR\'d script-reparse term) as its reuse_on argument');
+
+		$secondCallHead = substr(self::$applySource, $secondCallPos, strlen('pfb_ip_reuse_skip_active($pfbreuse_on,'));
+		$this->assertSame('pfb_ip_reuse_skip_active($pfbreuse_on,', $secondCallHead,
+			'the second pfb_ip_reuse_skip_active( call must feed the SAME $pfbreuse_on -- a mismatch '
+			. 'here would log "Reload" then download anyway, or vice versa');
+
+		$between = substr(self::$applySource, $firstCallPos, $secondCallPos - $firstCallPos);
+		$this->assertStringNotContainsString('$pfbreuse_on = ', $between,
+			'no reassignment of $pfbreuse_on may sit between the two call sites -- that would silently '
+			. 'drop the script-reparse term for the second call, producing the exact log-vs-action '
+			. 'mismatch this row guards against');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 12 -- pfb_list_script_reparse_active( is called exactly twice,
+	// once per loop -- lock-step by construction.
+	// -----------------------------------------------------------------
+
+	public function testScriptReparseActiveCalledExactlyTwiceOncePerLoop(): void
+	{
+		// '($pfb_' (vs. the definition's '(bool $verbatim_reuse_ok') distinguishes an
+		// invocation -- both call sites pass a $pfb_*-prefixed verbatim-reuse variable
+		// as the first argument (mirrors testExactlyTwoLockStepCallSites' technique for
+		// pfb_list_user_script_active( in ListScriptTransformRerunWiringTest).
+		$count = substr_count(self::$applySource, 'pfb_list_script_reparse_active($pfb_');
+		$this->assertSame(2, $count,
+			'lock-step by construction -- both the DNSBL and IP loops must call the shared '
+			. 'pfb_list_script_reparse_active() helper exactly once each');
+
+		$firstPos = strpos(self::$applySource, 'pfb_list_script_reparse_active($pfb_');
+		$this->assertNotFalse($firstPos, 'vacuity: the first call site must exist');
+		$secondPos = strpos(self::$applySource, 'pfb_list_script_reparse_active($pfb_', $firstPos + 1);
+		$this->assertNotFalse($secondPos, 'vacuity: the second call site must exist');
+
+		$boundaryPos = strpos(self::$applySource, self::LOOP_BOUNDARY_COMMENT);
+		$this->assertNotFalse($boundaryPos, "vacuity: the IP loop's list-collection boundary comment must exist");
+
+		$this->assertLessThan($boundaryPos, $firstPos,
+			'the first pfb_list_script_reparse_active( call site must sit in the DNSBL loop, before '
+			. "the IP loop's boundary comment");
+		$this->assertGreaterThan($boundaryPos, $secondPos,
+			'the second pfb_list_script_reparse_active( call site must sit in the IP loop, after the '
+			. 'DNSBL loop');
+	}
+}

--- a/tests/php/ListScriptTransformRerunWiringTest.php
+++ b/tests/php/ListScriptTransformRerunWiringTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1960: the IP and DNSBL feed loops' early verbatim-reuse fast paths
+ * must carry the same has_user_script term the normalization-level reuse
+ * gates (pfb_ip_norm_reuse_skip() / pfb_dnsbl_norm_reuse_skip()) already
+ * carry -- a feed with a configured pre/post script must re-run its
+ * transform on an ordinary cron pass, never require a Force Reload. The IP
+ * and DNSBL loops inside sync_package_pfblockerng() drive real appliance
+ * exec and have no PHPUnit harness of their own (issue #993), so -- same
+ * technique as DnsblListScriptWiringTest / ListScriptFailureLedgerWiringTest
+ * -- the wiring is pinned by source inspection with vacuity-guarded windows.
+ *
+ * Deliberate asymmetry (see the production comment above the statement):
+ * the DNSBL loop's second pfb_dnsbl_verbatim_reuse_active(..., TRUE) re-call
+ * (#1083's $stale_generation_rebuild) answers a DIFFERENT question and stays
+ * deliberately UNGATED by the user-script term -- pinned here so a future
+ * "consistency cleanup" cannot silently change #1083 behaviour.
+ */
+final class ListScriptTransformRerunWiringTest extends TestCase
+{
+	private static string $applySource;
+
+	public static function setUpBeforeClass(): void
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		if ($source === FALSE) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		}
+		self::$applySource = $source;
+	}
+
+	// -----------------------------------------------------------------
+	// Row 8 -- IP fast-path condition carries !$pfb_user_script.
+	// -----------------------------------------------------------------
+
+	public function testIpFastPathCarriesUserScriptTerm(): void
+	{
+		$asnTouchPos = strpos(self::$applySource, "\$pfb['dbdir']}/asn.update");
+		$this->assertNotFalse($asnTouchPos, 'vacuity: the geoip/asn .update touch block must exist before the IP fast path');
+
+		$staticHoldPos = strpos(self::$applySource, 'static hold.', $asnTouchPos);
+		$this->assertNotFalse($staticHoldPos, 'vacuity: the IP fast-path "static hold." log must exist after the geoip/asn touches');
+
+		$window = substr(self::$applySource, $asnTouchPos, $staticHoldPos - $asnTouchPos);
+
+		$this->assertStringContainsString('!$pfb_user_script', $window,
+			'issue #1960: the IP fast path must be gated by the user-script term -- a configured '
+			. 'script must re-run its transform every pass instead of requiring Force Reload');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 9 -- $pfb_user_script assigned exactly ONCE in the IP loop and
+	// BEFORE the fast path (a leftover second assignment is the bug this
+	// row catches).
+	// -----------------------------------------------------------------
+
+	public function testIpUserScriptAssignedExactlyOnceBeforeFastPath(): void
+	{
+		$count = substr_count(self::$applySource, '$pfb_user_script = ');
+		$this->assertSame(1, $count,
+			'a leftover second assignment is the bug this row catches -- $pfb_user_script must be '
+			. 'computed exactly once per row');
+
+		$assignPos = strpos(self::$applySource, '$pfb_user_script = ');
+		$this->assertNotFalse($assignPos, 'vacuity: the assignment must exist');
+
+		$asnTouchPos = strpos(self::$applySource, "\$pfb['dbdir']}/asn.update");
+		$this->assertNotFalse($asnTouchPos, 'vacuity: the geoip/asn .update touch block must exist');
+
+		$fastPathPos = strpos(self::$applySource, 'static hold.', $asnTouchPos);
+		$this->assertNotFalse($fastPathPos, 'vacuity: the IP fast-path log must exist after the geoip/asn touches');
+
+		$this->assertLessThan($fastPathPos, $assignPos,
+			'$pfb_user_script must be computed before the fast path that consumes it');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 10 -- DNSBL fast-path call site carries !$pfb_dnsbl_user_script.
+	// -----------------------------------------------------------------
+
+	public function testDnsblFastPathCarriesUserScriptTerm(): void
+	{
+		$callPos = strpos(self::$applySource, 'pfb_dnsbl_verbatim_reuse_active(');
+		$this->assertNotFalse($callPos, 'vacuity: the DNSBL verbatim-reuse call site must exist');
+
+		$existsPos = strpos(self::$applySource, '{$logtab} exists.', $callPos);
+		$this->assertNotFalse($existsPos, 'vacuity: the DNSBL fast-path "exists." log must exist');
+
+		$window = substr(self::$applySource, $callPos, $existsPos - $callPos);
+
+		$this->assertStringContainsString('!$pfb_dnsbl_user_script', $window,
+			'issue #1960: the DNSBL fast path must be gated by the user-script term at the call '
+			. 'site -- pfb_dnsbl_verbatim_reuse_active() itself is untouched (owned elsewhere), '
+			. 'same contract as the IP loop');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 11 -- $pfb_dnsbl_user_script assigned exactly ONCE and before
+	// BOTH the fast path and the pfb_dnsbl_norm_reuse_skip() call.
+	// -----------------------------------------------------------------
+
+	public function testDnsblUserScriptAssignedExactlyOnceBeforeBothCallSites(): void
+	{
+		$count = substr_count(self::$applySource, '$pfb_dnsbl_user_script = ');
+		$this->assertSame(1, $count,
+			'a leftover second assignment is the bug this row catches -- $pfb_dnsbl_user_script '
+			. 'must be computed exactly once per alias');
+
+		$assignPos = strpos(self::$applySource, '$pfb_dnsbl_user_script = ');
+		$this->assertNotFalse($assignPos, 'vacuity: the assignment must exist');
+
+		$fastPathPos = strpos(self::$applySource, 'pfb_dnsbl_verbatim_reuse_active(');
+		$this->assertNotFalse($fastPathPos, 'vacuity: the DNSBL fast path must exist');
+		$this->assertLessThan($fastPathPos, $assignPos,
+			'$pfb_dnsbl_user_script must be computed before the fast path that consumes it');
+
+		$reuseSkipPos = strpos(self::$applySource, 'pfb_dnsbl_norm_reuse_skip(');
+		$this->assertNotFalse($reuseSkipPos, 'vacuity: the DNSBL normalize/reuse-skip call must exist');
+		$this->assertLessThan($reuseSkipPos, $assignPos,
+			'$pfb_dnsbl_user_script must be computed before the normalize/reuse-skip call too');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 12 -- the $stale_generation_rebuild re-call is NOT gated by the
+	// user-script term (#1083 deliberate asymmetry).
+	// -----------------------------------------------------------------
+
+	public function testStaleGenerationRebuildRecallIsNotGatedByUserScript(): void
+	{
+		$stmtPos = strpos(self::$applySource, '$stale_generation_rebuild = ');
+		$this->assertNotFalse($stmtPos, 'vacuity: the #1083 stale-generation rebuild re-call must exist');
+
+		$stmtEnd = strpos(self::$applySource, ';', $stmtPos);
+		$this->assertNotFalse($stmtEnd, 'vacuity: the statement must terminate');
+
+		$statement = substr(self::$applySource, $stmtPos, $stmtEnd - $stmtPos);
+
+		$this->assertStringNotContainsString('$pfb_dnsbl_user_script', $statement,
+			'issue #1960 deliberate asymmetry: the $stale_generation_rebuild re-call answers a '
+			. 'DIFFERENT question (#1083 -- was stale staging generation the ONLY file-state reason '
+			. 'reuse was rejected) and must stay ungated -- gating it would force a full network '
+			. 'refetch for a stale-generation .txt with a configured script instead of the cheaper '
+			. 'reparse-from-.orig path, where the pre-script still reruns anyway '
+			. "(pfb_dnsbl_norm_reuse_skip() is FALSE there since \$downloaded_fresh is FALSE), silently "
+			. 'changing #1083 Rebuild/pfb_dnsbl_hold_stale_rebuild_skip/'
+			. 'pfb_dnsbl_stale_rebuild_converge_txt behaviour that nobody asked for');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 13 -- lock-step: exactly TWO pfb_list_user_script_active( call
+	// sites in the file, one per loop.
+	// -----------------------------------------------------------------
+
+	public function testExactlyTwoLockStepCallSites(): void
+	{
+		// '($pfb_' (vs. the definition's '($script_pre') distinguishes an
+		// invocation -- both call sites pass a $pfb_*-prefixed variable pair.
+		$count = substr_count(self::$applySource, 'pfb_list_user_script_active($pfb_');
+		$this->assertSame(2, $count,
+			'a term added to one loop only is the exact defect issue #1960 forbids -- both the IP '
+			. 'and DNSBL loops must call the shared helper exactly once each');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 14 -- both loops still pass the user-script term to their
+	// norm-reuse-skip calls. DNSBL side is already covered by
+	// DnsblListScriptWiringTest::testReuseSkipCallSitePassesTheUserScriptFlag
+	// (run and cited, not duplicated here).
+	// -----------------------------------------------------------------
+
+	public function testIpNormReuseSkipCallSitePassesTheUserScriptFlag(): void
+	{
+		$reuseSkipPos = strpos(self::$applySource, 'pfb_ip_norm_reuse_skip(');
+		$this->assertNotFalse($reuseSkipPos, 'vacuity: the IP normalize/reuse-skip call site must exist');
+
+		$callEnd = strpos(self::$applySource, 'unchanged after normalization.', $reuseSkipPos);
+		$this->assertNotFalse($callEnd, 'vacuity: the reuse-skip branch body must exist');
+
+		$call = substr(self::$applySource, $reuseSkipPos, $callEnd - $reuseSkipPos);
+		$this->assertStringContainsString('$pfb_user_script', $call,
+			'a configured pre/post script must force a full reparse every pass -- same contract as '
+			. "the DNSBL loop's pfb_dnsbl_norm_reuse_skip() call "
+			. '(DnsblListScriptWiringTest::testReuseSkipCallSitePassesTheUserScriptFlag)');
+	}
+}

--- a/tests/php/ListScriptTransformRerunWiringTest.php
+++ b/tests/php/ListScriptTransformRerunWiringTest.php
@@ -87,18 +87,24 @@ final class ListScriptTransformRerunWiringTest extends TestCase
 
 	public function testDnsblFastPathCarriesUserScriptTerm(): void
 	{
-		$callPos = strpos(self::$applySource, 'pfb_dnsbl_verbatim_reuse_active(');
-		$this->assertNotFalse($callPos, 'vacuity: the DNSBL verbatim-reuse call site must exist');
-
-		$existsPos = strpos(self::$applySource, '{$logtab} exists.', $callPos);
-		$this->assertNotFalse($existsPos, 'vacuity: the DNSBL fast-path "exists." log must exist');
-
-		$window = substr(self::$applySource, $callPos, $existsPos - $callPos);
-
-		$this->assertStringContainsString('!$pfb_dnsbl_user_script', $window,
+		// Pinned as the whole gated statement head rather than a window opened on a
+		// bare 'pfb_dnsbl_verbatim_reuse_active(' token: that token also occurs inside
+		// the production comments describing this gate and the #1083 asymmetry, so a
+		// window anchored on it opens on prose instead of the call it claims to pin.
+		$this->assertStringContainsString(
+			'if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(',
+			self::$applySource,
 			'issue #1960: the DNSBL fast path must be gated by the user-script term at the call '
 			. 'site -- pfb_dnsbl_verbatim_reuse_active() itself is untouched (owned elsewhere), '
 			. 'same contract as the IP loop');
+
+		// The gate must sit on the fast path that logs "exists."/"static hold.", not on
+		// some other caller: the gated head is the LAST thing before that log.
+		$gatePos = strpos(self::$applySource, 'if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(');
+		$this->assertNotFalse($gatePos, 'vacuity: the gated DNSBL fast-path statement must exist');
+		$existsPos = strpos(self::$applySource, '{$logtab} exists.', $gatePos);
+		$this->assertNotFalse($existsPos,
+			'the gated statement must be the DNSBL verbatim-reuse fast path -- its branch logs "exists."');
 	}
 
 	// -----------------------------------------------------------------
@@ -116,8 +122,11 @@ final class ListScriptTransformRerunWiringTest extends TestCase
 		$assignPos = strpos(self::$applySource, '$pfb_dnsbl_user_script = ');
 		$this->assertNotFalse($assignPos, 'vacuity: the assignment must exist');
 
-		$fastPathPos = strpos(self::$applySource, 'pfb_dnsbl_verbatim_reuse_active(');
-		$this->assertNotFalse($fastPathPos, 'vacuity: the DNSBL fast path must exist');
+		// Anchored on the gated statement head, not a bare
+		// 'pfb_dnsbl_verbatim_reuse_active(' token -- that token also occurs in the
+		// production comments above the call, which would move this anchor onto prose.
+		$fastPathPos = strpos(self::$applySource, 'if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(');
+		$this->assertNotFalse($fastPathPos, 'vacuity: the gated DNSBL fast path must exist');
 		$this->assertLessThan($fastPathPos, $assignPos,
 			'$pfb_dnsbl_user_script must be computed before the fast path that consumes it');
 

--- a/tests/php/ListScriptTransformRerunWiringTest.php
+++ b/tests/php/ListScriptTransformRerunWiringTest.php
@@ -50,9 +50,16 @@ final class ListScriptTransformRerunWiringTest extends TestCase
 
 		$window = substr(self::$applySource, $asnTouchPos, $staticHoldPos - $asnTouchPos);
 
-		$this->assertStringContainsString('!$pfb_user_script', $window,
-			'issue #1960: the IP fast path must be gated by the user-script term -- a configured '
-			. 'script must re-run its transform every pass instead of requiring Force Reload');
+		// issue #1278: supersedes the bare !$pfb_user_script gate this row originally pinned --
+		// that shape forced a Hold row with a configured script through to a network download
+		// every pass (the #1278 regression). The script term now only pushes a row off the fast
+		// path when a local '.orig' baseline exists to reparse (see PfbListScriptReparseActiveTest
+		// / ListScriptReparseWiringTest for the full fix and its own coverage).
+		$this->assertStringContainsString('!$pfb_script_reparse', $window,
+			'issue #1960/#1278: the IP fast path must be gated by the script-reparse term (which '
+			. 'requires a local .orig baseline) -- a configured script re-runs its transform every '
+			. 'pass it has a baseline to reparse, but a Hold row with none stays on the fast path '
+			. 'instead of falling through to the network');
 	}
 
 	// -----------------------------------------------------------------
@@ -87,20 +94,22 @@ final class ListScriptTransformRerunWiringTest extends TestCase
 
 	public function testDnsblFastPathCarriesUserScriptTerm(): void
 	{
-		// Pinned as the whole gated statement head rather than a window opened on a
-		// bare 'pfb_dnsbl_verbatim_reuse_active(' token: that token also occurs inside
-		// the production comments describing this gate and the #1083 asymmetry, so a
-		// window anchored on it opens on prose instead of the call it claims to pin.
+		// issue #1278: supersedes the bare '!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active('
+		// shape this row originally pinned -- that gate forced a Hold row with a configured script
+		// through to a network download every pass (the #1278 regression). Pinned as the whole
+		// gated statement head rather than a window opened on a bare token: 'pfb_dnsbl_verbatim_reuse_active('
+		// also occurs inside the production comments describing this gate and the #1083 asymmetry,
+		// so a window anchored on it opens on prose instead of the call it claims to pin.
 		$this->assertStringContainsString(
-			'if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(',
+			'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {',
 			self::$applySource,
-			'issue #1960: the DNSBL fast path must be gated by the user-script term at the call '
-			. 'site -- pfb_dnsbl_verbatim_reuse_active() itself is untouched (owned elsewhere), '
-			. 'same contract as the IP loop');
+			'issue #1960/#1278: the DNSBL fast path must be gated by the script-reparse term (which '
+			. 'requires a local .orig baseline), not the bare has_user_script term -- same contract '
+			. 'as the IP loop');
 
 		// The gate must sit on the fast path that logs "exists."/"static hold.", not on
 		// some other caller: the gated head is the LAST thing before that log.
-		$gatePos = strpos(self::$applySource, 'if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(');
+		$gatePos = strpos(self::$applySource, 'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {');
 		$this->assertNotFalse($gatePos, 'vacuity: the gated DNSBL fast-path statement must exist');
 		$existsPos = strpos(self::$applySource, '{$logtab} exists.', $gatePos);
 		$this->assertNotFalse($existsPos,
@@ -125,7 +134,10 @@ final class ListScriptTransformRerunWiringTest extends TestCase
 		// Anchored on the gated statement head, not a bare
 		// 'pfb_dnsbl_verbatim_reuse_active(' token -- that token also occurs in the
 		// production comments above the call, which would move this anchor onto prose.
-		$fastPathPos = strpos(self::$applySource, 'if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(');
+		// issue #1278: the gate itself moved from the bare user-script term to the
+		// script-reparse term, but $pfb_dnsbl_user_script is still consumed just before it
+		// (now via pfb_list_script_reparse_active()), so the ordering this row pins is unchanged.
+		$fastPathPos = strpos(self::$applySource, 'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {');
 		$this->assertNotFalse($fastPathPos, 'vacuity: the gated DNSBL fast path must exist');
 		$this->assertLessThan($fastPathPos, $assignPos,
 			'$pfb_dnsbl_user_script must be computed before the fast path that consumes it');
@@ -160,6 +172,12 @@ final class ListScriptTransformRerunWiringTest extends TestCase
 			. "(pfb_dnsbl_norm_reuse_skip() is FALSE there since \$downloaded_fresh is FALSE), silently "
 			. 'changing #1083 Rebuild/pfb_dnsbl_hold_stale_rebuild_skip/'
 			. 'pfb_dnsbl_stale_rebuild_converge_txt behaviour that nobody asked for');
+
+		// issue #1278: the same asymmetry applies to the NEW script-reparse term -- this
+		// re-call must stay ungated by it too, same reasoning as $pfb_dnsbl_user_script above.
+		$this->assertStringNotContainsString('$pfb_dnsbl_script_reparse', $statement,
+			'issue #1960/#1278: the #1083 stale-generation rebuild re-call must stay ungated by the '
+			. 'new script-reparse term too -- same asymmetry reasoning as $pfb_dnsbl_user_script above');
 	}
 
 	// -----------------------------------------------------------------
@@ -175,6 +193,27 @@ final class ListScriptTransformRerunWiringTest extends TestCase
 		$this->assertSame(2, $count,
 			'a term added to one loop only is the exact defect issue #1960 forbids -- both the IP '
 			. 'and DNSBL loops must call the shared helper exactly once each');
+
+		// N4: a global count of 2 passes even if BOTH call sites sat inside the SAME loop --
+		// prove they straddle the two loops instead. The IP loop's own list-collection
+		// comment sits strictly AFTER the whole DNSBL alias loop and BEFORE the IP loop's
+		// per-row body, so it is a token that only occurs between the two loops.
+		$firstCallPos = strpos(self::$applySource, 'pfb_list_user_script_active($pfb_');
+		$this->assertNotFalse($firstCallPos, 'vacuity: the first call site must exist');
+		$secondCallPos = strpos(self::$applySource, 'pfb_list_user_script_active($pfb_', $firstCallPos + 1);
+		$this->assertNotFalse($secondCallPos, 'vacuity: the second call site must exist');
+
+		$boundaryPos = strpos(self::$applySource,
+			'// Collect lists and custom list configuration and format into one array ($lists).');
+		$this->assertNotFalse($boundaryPos, "vacuity: the IP loop's list-collection boundary comment must exist");
+
+		$this->assertLessThan($boundaryPos, $firstCallPos,
+			'the first pfb_list_user_script_active( call site must sit in the DNSBL loop, before the '
+			. "IP loop's boundary comment");
+		$this->assertGreaterThan($boundaryPos, $secondCallPos,
+			'the second pfb_list_user_script_active( call site must sit in the IP loop, after the '
+			. 'DNSBL loop -- a regression that moved both calls into ONE loop must fail here even '
+			. 'though the global count above stays 2');
 	}
 
 	// -----------------------------------------------------------------

--- a/tests/php/PfbListScriptFailureRecordTest.php
+++ b/tests/php/PfbListScriptFailureRecordTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1958: a per-feed pre-script that exits non-zero must not let the alias
+ * pass close as full success. pfb_list_script_failure_record() is the single
+ * write site for that: it opens a distinct ADR-61 stage='script' ledger entry
+ * (separate from stage='download' -- the download itself genuinely succeeded)
+ * and (re)writes the '.update' retry marker so the next ordinary pass still
+ * attempts the transform instead of taking the verbatim-reuse fast path.
+ *
+ * Decision (brief section 5): production code suppresses the marker touch()
+ * with '@' (matches the existing @rename/@copy best-effort idiom already used
+ * for filesystem side-writes in this file). PfbNoPhpWarningTrait does NOT fit
+ * here -- verified directly: a custom error handler registered for E_WARNING
+ * still fires even when the triggering statement is '@'-prefixed (PHP only
+ * drops E_WARNING from the bitmask error_reporting() reports to a *handler
+ * that checks it*; the trait's handler collects unconditionally). So this
+ * suite asserts the weaker, correct contract instead: no exception escapes,
+ * and the ledger entry is opened regardless of whether the marker write
+ * succeeded.
+ */
+#[CoversFunction('pfb_list_script_failure_record')]
+final class PfbListScriptFailureRecordTest extends TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_list_script_failure_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0777, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		@chmod($this->dir, 0777);
+		foreach (glob($this->dir . '/*') ?: [] as $file) {
+			@chmod($file, 0777);
+			@unlink($file);
+		}
+		@rmdir($this->dir);
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 1/2 -- opens a stage='script' entry, per facility.
+	// -----------------------------------------------------------------------
+
+	public function testRecordsScriptStageEntryForIpFacility(): void
+	{
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'Pre-script FAIL', $this->dir, $marker);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'a pre-script failure must open exactly one entry');
+		$this->assertSame('ip', $open[0]['facility']);
+		$this->assertSame('pfB_Example_v4', $open[0]['item']);
+		$this->assertSame('script', $open[0]['stage']);
+		$this->assertSame('Pre-script FAIL', $open[0]['message']);
+	}
+
+	public function testRecordsScriptStageEntryForDnsblFacility(): void
+	{
+		$marker = "{$this->dir}/DNSBL_Example.update";
+
+		pfb_list_script_failure_record('dnsbl', 'DNSBL_Example', 'Pre-script FAIL', $this->dir, $marker);
+
+		$open = pfb_sync_status_list_open($this->dir, 'dnsbl');
+		$this->assertCount(1, $open, 'a pre-script failure must open exactly one entry');
+		$this->assertSame('dnsbl', $open[0]['facility']);
+		$this->assertSame('DNSBL_Example', $open[0]['item']);
+		$this->assertSame('script', $open[0]['stage']);
+		$this->assertSame('Pre-script FAIL', $open[0]['message']);
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 3/4 -- retry marker created when absent, preserved when present.
+	// -----------------------------------------------------------------------
+
+	public function testRetryMarkerIsCreatedWhenAbsent(): void
+	{
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+		// Before-state: mandatory -- prove the marker did not already exist.
+		$this->assertFileDoesNotExist($marker, 'before: the retry marker must not exist yet');
+
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'msg', $this->dir, $marker);
+
+		$this->assertFileExists($marker, 'after: the retry marker must be created');
+	}
+
+	public function testRetryMarkerAlreadyPresentIsPreservedNotTruncated(): void
+	{
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+		file_put_contents($marker, 'pre-existing-marker-content');
+		$this->assertFileExists($marker, 'before: the marker is pre-created with known content');
+
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'msg', $this->dir, $marker);
+
+		$this->assertFileExists($marker, 'after: the marker must still exist');
+		$this->assertSame('pre-existing-marker-content', file_get_contents($marker),
+			'touch() must not truncate an already-present marker\'s content');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 5 -- the opened entry is closeable by the paired ADR-61 close.
+	// -----------------------------------------------------------------------
+
+	public function testOpenedEntryIsCloseableByThePairedClose(): void
+	{
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'msg', $this->dir, $marker);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'), 'before: entry genuinely open');
+
+		pfb_sync_status_close('ip', 'pfB_Example_v4', 'script', $this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'ip'),
+			'the paired pfb_sync_status_close(..., \'script\', ...) must close the entry this helper opened');
+	}
+
+	// -----------------------------------------------------------------------
+	// Row 6 -- 'script' stage does not collide with an open 'download' entry
+	// for the SAME item; closing 'script' leaves 'download' untouched.
+	// -----------------------------------------------------------------------
+
+	public function testScriptStageDoesNotCollideWithOpenDownloadEntry(): void
+	{
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+		pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'Download FAIL', $this->dir);
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'Pre-script FAIL', $this->dir, $marker);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(2, $open, 'both the download and script stage entries for the same item must coexist');
+		$stages = array_column($open, 'stage');
+		sort($stages);
+		$this->assertSame(['download', 'script'], $stages);
+
+		pfb_sync_status_close('ip', 'pfB_Example_v4', 'script', $this->dir);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'closing the script stage must leave the download entry untouched');
+		$this->assertSame('download', $open[0]['stage']);
+	}
+
+	// -----------------------------------------------------------------------
+	// Hostile row -- marker's parent directory does not exist: touch() fails,
+	// but the ledger entry must still open, and no exception may escape.
+	// -----------------------------------------------------------------------
+
+	public function testMarkerParentDirectoryMissingStillOpensLedgerEntryWithoutException(): void
+	{
+		$missingDir = "{$this->dir}/nonexistent/nested";
+		$marker     = "{$missingDir}/pfB_Example_v4.update";
+		$this->assertDirectoryDoesNotExist($missingDir, 'before: the marker\'s parent directory must not exist');
+
+		$caught = null;
+		try {
+			pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'Pre-script FAIL', $this->dir, $marker);
+		} catch (\Throwable $e) {
+			$caught = $e;
+		}
+
+		$this->assertNull($caught, 'a failed marker write must never throw/escape as an exception: ' . ($caught?->getMessage() ?? ''));
+		$this->assertFileDoesNotExist($marker, 'the marker cannot exist -- its parent directory is absent');
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'ledger visibility must not depend on the marker write succeeding');
+		$this->assertSame('script', $open[0]['stage']);
+	}
+
+	// -----------------------------------------------------------------------
+	// Hostile row -- a message with HTML-special and sigil-looking bytes must
+	// round-trip byte-identical through the ledger JSON (the widget applies
+	// its own htmlspecialchars(); the ledger itself must not mangle anything).
+	// -----------------------------------------------------------------------
+
+	public function testMessageWithSpecialCharactersRoundTripsByteIdentical(): void
+	{
+		$marker  = "{$this->dir}/pfB_Example_v4.update";
+		$message = 'Pre-script FAIL: <script>&"$HOME" `rm -rf /`';
+
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', $message, $this->dir, $marker);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open);
+		$this->assertSame($message, $open[0]['message'],
+			'the message must round-trip byte-identical through the ledger JSON -- no HTML-escaping at the ledger layer');
+	}
+}

--- a/tests/php/PfbListScriptFailureRecordTest.php
+++ b/tests/php/PfbListScriptFailureRecordTest.php
@@ -31,15 +31,19 @@ final class PfbListScriptFailureRecordTest extends TestCase
 
 	protected function setUp(): void
 	{
-		$this->dir = sys_get_temp_dir() . '/pfb_list_script_failure_' . getmypid() . '_' . uniqid();
-		mkdir($this->dir, 0777, TRUE);
+		// 0700 + random_bytes: a world-writable scratch dir under a shared /tmp,
+		// named from the time-based uniqid(), is guessable and pre-creatable by
+		// another local user. Mode asserted, never assumed.
+		$this->dir = sys_get_temp_dir() . '/pfb_list_script_failure_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE), "failed to create the scratch dir {$this->dir}");
 	}
 
 	protected function tearDown(): void
 	{
-		@chmod($this->dir, 0777);
+		// No chmod during cleanup: chmod() follows symlinks, so a planted entry
+		// would retarget it. No test here creates a read-only fixture, so the
+		// unlink alone is sufficient.
 		foreach (glob($this->dir . '/*') ?: [] as $file) {
-			@chmod($file, 0777);
 			@unlink($file);
 		}
 		@rmdir($this->dir);

--- a/tests/php/PfbListScriptReparseActiveTest.php
+++ b/tests/php/PfbListScriptReparseActiveTest.php
@@ -26,8 +26,8 @@ use PHPUnit\Framework\TestCase;
  * local-reuse branch instead of the network. No baseline -> the row stays on
  * the fast path; there is no Hold-specific branch anywhere.
  *
- * Full 2^3 truth table over (verbatim_reuse_ok, has_user_script, orig_exists);
- * only (TRUE, TRUE, TRUE) is TRUE.
+ * Full 2^3 truth table over (verbatim_reuse_ok, has_user_script, orig_exists):
+ * all eight rows are asserted below, and only (TRUE, TRUE, TRUE) is TRUE.
  */
 #[CoversFunction('pfb_list_script_reparse_active')]
 final class PfbListScriptReparseActiveTest extends TestCase
@@ -98,7 +98,50 @@ final class PfbListScriptReparseActiveTest extends TestCase
 	}
 
 	/**
-	 * Row 5 -- full truth table closed: all three conditions FALSE. FALSE.
+	 * Row 5 -- verbatim-reuse conditions hold, but neither a script nor a
+	 * baseline: the plain no-script feed on its unchanged fast path. FALSE.
+	 */
+	public function testVerbatimReuseOkNoScriptNoOrigIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_list_script_reparse_active(TRUE, FALSE, FALSE),
+			"verbatim_reuse_ok=TRUE, has_user_script=FALSE, orig_exists=FALSE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 6 -- reuse already rejected AND no baseline, script configured: the
+	 * normal download path owns this row. FALSE.
+	 */
+	public function testVerbatimReuseRejectedScriptConfiguredNoOrigIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_list_script_reparse_active(FALSE, TRUE, FALSE),
+			"verbatim_reuse_ok=FALSE, has_user_script=TRUE, orig_exists=FALSE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 7 -- reuse already rejected, no script, but a baseline exists: a
+	 * surviving '.orig' alone must never route a row to the reparse branch.
+	 * FALSE.
+	 */
+	public function testVerbatimReuseRejectedNoScriptOrigExistsIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_list_script_reparse_active(FALSE, FALSE, TRUE),
+			"verbatim_reuse_ok=FALSE, has_user_script=FALSE, orig_exists=TRUE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 8 -- full truth table closed: all three conditions FALSE. FALSE.
 	 */
 	public function testAllThreeFalseIsFalse(): void
 	{

--- a/tests/php/PfbListScriptReparseActiveTest.php
+++ b/tests/php/PfbListScriptReparseActiveTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1960/#1278 -- #1960 gated the IP/DNSBL loops' early verbatim-reuse
+ * fast paths on the bare has_user_script term: !$pfb_user_script && <fast
+ * path conditions>. That makes a Hold-state row with a configured pre/post
+ * script leave the fast path UNCONDITIONALLY, falling through to a real
+ * network download every pass -- breaking issue #1278's "download once,
+ * never again" Hold contract, which the fast path is the ONLY thing
+ * protecting (the DNSBL loop's Hold-specific network skip,
+ * pfb_dnsbl_hold_stale_rebuild_skip(), only fires on a stale-generation
+ * rebuild, not on a plain script-forced else-branch entry; the IP loop has
+ * no Hold-specific network skip at all).
+ *
+ * The fix: an ordinary pass never downloads ANY feed -- downloads are driven
+ * by the '.update'/'.fail' markers and the reuse toggle, and the fast path's
+ * own conditions already require those markers to be absent. So a
+ * script-configured row only ever needs the LOCAL '.orig' baseline. This
+ * predicate lets the script term push a row off the fast path ONLY when a
+ * '.orig' baseline exists to reparse -- routing it to the existing
+ * local-reuse branch instead of the network. No baseline -> the row stays on
+ * the fast path; there is no Hold-specific branch anywhere.
+ *
+ * Full 2^3 truth table over (verbatim_reuse_ok, has_user_script, orig_exists);
+ * only (TRUE, TRUE, TRUE) is TRUE.
+ */
+#[CoversFunction('pfb_list_script_reparse_active')]
+final class PfbListScriptReparseActiveTest extends TestCase
+{
+	/**
+	 * Row 1 -- verbatim-reuse conditions hold, script configured, '.orig'
+	 * baseline exists: the local-reparse route. TRUE.
+	 */
+	public function testVerbatimReuseOkScriptConfiguredOrigExistsIsTrue(): void
+	{
+		$this->assertTrue(
+			pfb_list_script_reparse_active(TRUE, TRUE, TRUE),
+			"verbatim_reuse_ok=TRUE, has_user_script=TRUE, orig_exists=TRUE -> TRUE\n" .
+			"expected: true\n" .
+			"got:      false"
+		);
+	}
+
+	/**
+	 * Row 2 -- THE HOLD FIX. Verbatim-reuse conditions hold, script
+	 * configured, but NO '.orig' baseline exists (the archetypal
+	 * held-because-dead-URL row that was never downloaded, or a Hold row
+	 * whose baseline was removed). Must be FALSE: with no baseline to
+	 * reparse locally, the row must stay on the fast path rather than fall
+	 * through to a network download that would open a permanent ledger
+	 * FAIL entry (#1278 breakage this whole fix exists to close).
+	 */
+	public function testVerbatimReuseOkScriptConfiguredNoOrigIsFalseTheHoldFix(): void
+	{
+		$this->assertFalse(
+			pfb_list_script_reparse_active(TRUE, TRUE, FALSE),
+			"verbatim_reuse_ok=TRUE, has_user_script=TRUE, orig_exists=FALSE -> FALSE " .
+			"(#1278 Hold fix: no baseline -> stay on the fast path, never the network)\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 3 -- verbatim-reuse conditions hold, NO script configured: the
+	 * ordinary no-script feed keeps its unchanged fast path regardless of
+	 * '.orig'. FALSE.
+	 */
+	public function testVerbatimReuseOkNoScriptIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_list_script_reparse_active(TRUE, FALSE, TRUE),
+			"verbatim_reuse_ok=TRUE, has_user_script=FALSE, orig_exists=TRUE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 4 -- verbatim-reuse conditions already rejected reuse (some
+	 * file-state condition failed -- e.g. '.update' or '.fail' present, or
+	 * the reuse toggle is on): the normal download/Reload/Rebuild path
+	 * already owns this row regardless of the script/orig terms. FALSE.
+	 */
+	public function testVerbatimReuseRejectedIsFalseRegardlessOfScriptAndOrig(): void
+	{
+		$this->assertFalse(
+			pfb_list_script_reparse_active(FALSE, TRUE, TRUE),
+			"verbatim_reuse_ok=FALSE, has_user_script=TRUE, orig_exists=TRUE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+
+	/**
+	 * Row 5 -- full truth table closed: all three conditions FALSE. FALSE.
+	 */
+	public function testAllThreeFalseIsFalse(): void
+	{
+		$this->assertFalse(
+			pfb_list_script_reparse_active(FALSE, FALSE, FALSE),
+			"verbatim_reuse_ok=FALSE, has_user_script=FALSE, orig_exists=FALSE -> FALSE\n" .
+			"expected: false\n" .
+			"got:      true"
+		);
+	}
+}

--- a/tests/php/PfbListUserScriptActiveTest.php
+++ b/tests/php/PfbListUserScriptActiveTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1960: pfb_list_user_script_active() is the has_user_script term
+ * shared by the IP and DNSBL feed loops' early verbatim-reuse fast paths and
+ * their normalization-level reuse gates (pfb_ip_norm_reuse_skip() /
+ * pfb_dnsbl_norm_reuse_skip()) -- one helper keeps every caller in lock-step
+ * by construction instead of re-deriving the ($script && is_file($script))
+ * pair at each call site. Parameters stay untyped: pfb_resolve_list_script()
+ * returns FALSE or a string, and every caller holds that same union.
+ */
+#[CoversFunction('pfb_list_user_script_active')]
+final class PfbListUserScriptActiveTest extends TestCase
+{
+	private string $tmp;
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_lusa_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		mkdir($this->tmp, 0755, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		exec('chmod -R u+rwx ' . escapeshellarg($this->tmp));
+		exec('rm -rf ' . escapeshellarg($this->tmp));
+	}
+
+	private function makeFile(string $name): string
+	{
+		$path = "{$this->tmp}/{$name}";
+		file_put_contents($path, "#!/bin/sh\nexit 0\n");
+		return $path;
+	}
+
+	// -----------------------------------------------------------------
+	// Row 1 -- pre-script configured and the file exists -> TRUE.
+	// -----------------------------------------------------------------
+
+	public function testPreScriptConfiguredAndExistsIsTrue(): void
+	{
+		$pre = $this->makeFile('pre.sh');
+		$this->assertTrue(pfb_list_user_script_active($pre, FALSE),
+			'a configured pre-script that exists on disk must report the feed as script-active');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 2 -- post-script configured and the file exists -> TRUE.
+	// -----------------------------------------------------------------
+
+	public function testPostScriptConfiguredAndExistsIsTrue(): void
+	{
+		$post = $this->makeFile('post.sh');
+		$this->assertTrue(pfb_list_user_script_active(FALSE, $post),
+			'a configured post-script that exists on disk must report the feed as script-active');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 3 -- BOTH configured -> TRUE.
+	// -----------------------------------------------------------------
+
+	public function testBothScriptsConfiguredAndExistIsTrue(): void
+	{
+		$pre  = $this->makeFile('pre.sh');
+		$post = $this->makeFile('post.sh');
+		$this->assertTrue(pfb_list_user_script_active($pre, $post),
+			'both a pre- and post-script configured and present must report script-active');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 4 -- NEITHER configured (both FALSE, the pfb_resolve_list_script()
+	// failure value) -> FALSE; pins the ordinary no-script feed keeps its
+	// fast path.
+	// -----------------------------------------------------------------
+
+	public function testNeitherScriptConfiguredIsFalse(): void
+	{
+		$this->assertFalse(pfb_list_user_script_active(FALSE, FALSE),
+			'the ordinary no-script feed (pfb_resolve_list_script() failure value on both) must keep its fast path');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 5 -- a path that is configured but does NOT exist on disk ->
+	// FALSE; a retired/deleted script must not permanently disable reuse.
+	// -----------------------------------------------------------------
+
+	public function testConfiguredPathThatDoesNotExistOnDiskIsFalse(): void
+	{
+		$missing = "{$this->tmp}/retired_pre.sh";
+		$this->assertFileDoesNotExist($missing, 'before: the path must not exist on disk');
+
+		$this->assertFalse(pfb_list_user_script_active($missing, FALSE),
+			'a retired/deleted script must not permanently disable reuse');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 6 -- a path that exists but is a DIRECTORY -> FALSE (is_file()
+	// semantics, not file_exists()).
+	// -----------------------------------------------------------------
+
+	public function testConfiguredPathThatIsADirectoryIsFalse(): void
+	{
+		$dir = "{$this->tmp}/a_directory";
+		mkdir($dir, 0755, TRUE);
+		$this->assertDirectoryExists($dir, 'before: the directory must exist');
+
+		$this->assertFalse(pfb_list_user_script_active($dir, FALSE),
+			'is_file() semantics, not file_exists() -- a directory must not count as a configured script');
+	}
+
+	// -----------------------------------------------------------------
+	// Row 7 -- empty-string path -> FALSE; pfb_resolve_list_script()
+	// returns FALSE, but a caller passing '' must not be truthy.
+	// -----------------------------------------------------------------
+
+	public function testEmptyStringPathIsFalse(): void
+	{
+		$this->assertFalse(pfb_list_user_script_active('', ''),
+			"a caller passing an empty string (rather than pfb_resolve_list_script()'s FALSE) must not be truthy");
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5142,6 +5142,33 @@
             }
         ]
     },
+    "pfb_list_script_reparse_active": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "verbatim_reuse_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "has_user_script",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "orig_exists",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
     "pfb_list_section_for_vtype": {
         "returnsRef": false,
         "returnType": "string",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5101,6 +5101,47 @@
             }
         ]
     },
+    "pfb_list_script_failure_record": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "update_marker",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_list_section_for_vtype": {
         "returnsRef": false,
         "returnType": "string",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5155,6 +5155,26 @@
             }
         ]
     },
+    "pfb_list_user_script_active": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "script_pre",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "script_post",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
     "pfb_live_punch_apply": {
         "returnsRef": false,
         "returnType": "array",


### PR DESCRIPTION
Resolves two related defects in the IPv4/IPv6 and DNSBL download loops, stacked as one commit per issue because both touch the same two loops in `pfblockerng_apply.inc` and must stay in lock-step.

Closes #1958
Closes #1960

## 1958 — a failed feed pre-script no longer closes the pass as full success

A per-feed pre-script that exits non-zero correctly keeps the last known-good staged list (#1927), but left `$pfb_dl_failed` untouched, so the ADR-61 sync-status ledger closed the alias pass as a full success. A persistently failing transform was visible only in the error log.

- New `pfb_list_script_failure_record()` opens a distinct **`stage='script'`** ledger entry — deliberately not `stage='download'`, because the download itself genuinely succeeded and only the transform failed. The widget renders open entries generically and counts any open entry per facility, so the distinct failure surfaces with no `www/` change.
- The same helper (re)writes the feed's **`.update` retry marker**. This closes the edge raised on PR #1956: a row that entered the update branch via a `.fail` marker alone had that marker unlinked by the successful download, so without rewriting it the next ordinary pass took the verbatim-reuse fast path and never retried the transform.
- Both loops gained a per-alias-pass `$pfb_script_failed` flag mirroring the existing #1048 `$pfb_dl_failed` flag, so a sibling feed's success cannot close another feed's still-open entry, plus a paired `pfb_sync_status_close(..., 'script', ...)` at the alias-pass end (ADR-61 symmetric ownership).
- Last known-good data keeps being served; the DNSBL branch's #1841-class manifest-row re-emission and the #1927 no-parse-of-leftovers behaviour are untouched.

## 1960 — a configured list script re-runs its transform on an ordinary pass

Both loops' early verbatim-reuse fast paths short-circuited before any script resolution, so editing a feed's pre/post script only took effect on a content change or a Force Reload — even though the normalization-level gates `pfb_ip_norm_reuse_skip()` / `pfb_dnsbl_norm_reuse_skip()` already carried a `has_user_script` term.

- New `pfb_list_user_script_active()` is the `($script && is_file($script))` pair that was already duplicated at both norm-reuse-skip call sites, now one helper both loops share — the term cannot drift onto only one loop.
- New `pfb_list_script_reparse_active()` decides whether the script term may push a row off the fast path. It may do so **only when a local `.orig` baseline exists to reparse**, and the row then routes to the existing local-reuse branch (`Reload`) rather than the network.
- No new cache-key surface. A feed with no script is byte-identically unaffected: the helper returns `FALSE`, so the added clause short-circuits to the previous condition, and the GeoIP/ASN `.update` touches still run before it.

### Why the routing, and not a plain `!has_user_script` gate

The first version of this PR gated the fast paths on the bare `has_user_script` term. Adversarial review found that this broke **#1278's `Hold` contract ("download once, never again") in both loops**: `Hold`'s only protection lives inside that fast path, so a held row with a script configured fell through to a real full-body download every pass. The DNSBL loop's `pfb_dnsbl_hold_stale_rebuild_skip()` does not cover it (it only fires when `$stale_generation_rebuild` is true, which is false in steady state) and the IP loop has no Hold-aware check in that branch at all.

The second-order damage is what made it more than a cost regression: on a held-because-dead URL — the archetypal `Hold` case — the download fails, `pfb_download_failure()` touches `.fail` and opens a permanent `stage='download'` ledger entry, and `.fail` is cleared only by a *successful* download. Removing the script again would not have restored the quiet state.

The fix rests on an invariant of the loops: **an ordinary pass never downloads any feed.** Downloads are driven by the `.update`/`.fail` markers and the reuse toggle, and the fast path's own conditions already require those markers to be absent. So a script-configured row only ever needs the local baseline. Requiring `.orig` to exist before the script term takes effect means a `Hold` row either reparses locally or stays on the fast path — it never reaches the network, and there is no Hold-specific branch anywhere in either loop. Every script-configured feed's pass is also cheaper than the first version's.

This also keeps #1960's own acceptance intact: `$downloaded_fresh` stays `FALSE` on the local-reparse route, so `pfb_{ip,dnsbl}_norm_reuse_skip()` is `FALSE` and the pre-script still runs, producing the new transform without a Force Reload.

### Deliberate asymmetry, pinned by tests

The DNSBL loop's second `pfb_dnsbl_verbatim_reuse_active(..., TRUE)` call — #1083's `$stale_generation_rebuild` — is **not** gated by either new term. It answers a different question: among the file-state conditions, was stale staging generation the only reason reuse was rejected? A stale-generation `.txt` with a configured script still re-runs its pre-script on that cheaper reparse anyway. Gating it would only force an unneeded refetch and silently change #1083's Rebuild behaviour. Tests assert the statement stays ungated by both terms.

## Considered and accepted

- **`.update` and the #1083 Rebuild classification.** With a leftover script-failure marker on a feed that is *also* in the rare pre-NDJSON stale-generation state, `$stale_generation_rebuild` is `FALSE` and the retry pass downloads instead of taking the cheap Rebuild. That is the existing, intended meaning of `.update` ("an update is pending, fetch it") rather than a new behaviour class. Bandwidth only.
- **Emerging Threats IQRisk.** A scripted ET IQRisk feed now runs the local gunzip + `et` rebuild on each pass it takes the reparse route, as a Force Reload already does. Local work only, no network.

## Out of scope, filed separately

- #2059 — feed **post-script** failures are ledger-silent in both loops. #1958's decided direction names the pre-script path only, and the semantics genuinely differ.
- #2060 — `pfb_sync_status_close_removed_alias()` closes only `stage='download'`, so the new `stage='script'` entry strands when an alias is deleted.
- #2102 — ADR-61's stage table and the `pfb_sync_status_open()`/`close()` docblocks under-enumerate now that `script` is a fifth stage. ADR-61 is Implemented, so it needs a dated amendment.

## Tests

Test-first red→green, each red run executed against its own true pre-fix baseline.

- `PfbListScriptFailureRecordTest` — ledger entry per facility, retry marker created when absent and not truncated when present, the paired close, coexistence with an open `download` entry for the same item, a missing marker parent directory, and a message with HTML-special bytes round-tripping byte-identically.
- `PfbListUserScriptActiveTest` — pre only, post only, both, neither, a configured-but-missing path, a directory (`is_file()` not `file_exists()`), and an empty string.
- `PfbListScriptReparseActiveTest` — the full truth table, including the row that is the Hold fix: reuse conditions hold and a script is configured, but no `.orig` baseline exists, so the row stays on the fast path.
- `ListScriptFailureLedgerWiringTest` / `ListScriptTransformRerunWiringTest` / `ListScriptReparseWiringTest` — the loop bodies sit inside `sync_package_pfblockerng()` and drive real appliance exec, so the call sites are pinned by vacuity-guarded source inspection, the same technique as `DnsblListScriptWiringTest`. Includes per-loop lock-step placement (not just a global count), assigned-exactly-once-before-use ordering, that both `pfb_ip_reuse_skip_active()` call sites are fed the same term with no reassignment between them, and the ungated `$stale_generation_rebuild` pin. The counting and negative assertions were mutation-tested against modified copies under `/tmp` to prove they fail on the regression they claim to pin.

Red→green provenance, stated precisely: `verify-red-proof.sh` returned `FREEZE-OK` / `RED-OK` / `GREEN-OK` / `VERDICT: PASS` for the #1958 commit. The #1960 commit's proof was re-executed against its own pre-fix commit rather than via the freeze hash, because a later commit deliberately tightened two of its test anchors that had been matching a comment instead of the call they pinned; both reviewers independently re-proved the red and judged the tightening legitimate hardening rather than a freeze violation.

Gates on the rebased branch: `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (`php -l` per touched file, full PHPUnit suite with zero failures, `composer phpstan` level 2 clean with no baseline change, `composer phpcs`). The `FunctionInventoryParityTest` golden was regenerated for the new package functions and re-verified without the regeneration env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
