### PR TITLE
pfblockerng: parse DNSBL syslog rows as CSV

### DIFF
--- a/.ADRs/ADR_38_System_Log_Integration/ADR.md
+++ b/.ADRs/ADR_38_System_Log_Integration/ADR.md
@@ -621,3 +621,23 @@ Proposed phase is eventually implemented. **No edit needed**; ADR-32 is not stal
 Syslog behaviour is unchanged. The requirement to emit tokens consumable by older packages and the
 inherited `RollbackContractTest` requirement are superseded. Current canonical storage and
 supported forward-upgrade legacy reads remain required; package downgrade is unsupported.
+
+## Amendment 4 (2026-08-02, issue #2075) — Preserve RFC4180 DNSBL rows in Unified
+
+**Scope.** Corrects Amendment 1's A1.3/A1.6 claim that every feature row is reconstructed through a
+`pfb_unified_format_*` formatter and that this fully decouples `unified.log` from its producers. The
+daemon remains the sole `unified.log` writer, and the host-side DNSBL syslog decision remains
+unchanged.
+
+The Python DNSBL writers now own RFC4180 serialization for their fixed 11-field rows: minimal
+quoting, doubled embedded quotes, and CR/LF normalized to spaces before encoding so each event stays
+one physical line. The daemon parses each `DNSBL-python` row with the matching CSV grammar to derive
+the syslog fields, but appends the original encoded row to `unified.log` byte-for-byte. Rebuilding a
+parsed row with the legacy comma-join formatter would discard required quoting from a comma-bearing
+query name and corrupt the Unified read path.
+
+IP rows and DNS-reply rows continue through `pfb_unified_format_ip()` and
+`pfb_unified_format_dnsreply()`. `pfb_unified_format_dnsbl()` remains a pure fixed-column
+compatibility/schema oracle for existing callers and unit tests, not the production DNSBL
+serialization boundary. The invariant is now **semantic schema parity plus encoded-byte fidelity**,
+not producer-independent DNSBL serialization.

--- a/.ADRs/ADR_65_DNSBL_Manifest_Single_Source/ADR.md
+++ b/.ADRs/ADR_65_DNSBL_Manifest_Single_Source/ADR.md
@@ -539,3 +539,14 @@ or TLD decisions.
 The 1,000,000-line base-versus-branch benchmark stayed within the 10% gate: PHP
 publication was +6.97% wall / +0.19% peak RSS, while Python manifest build was -0.23%
 wall / -1.74% peak RSS.
+
+---
+
+## 12. Post-implementation addendum (2026-08-02 — issue #2075)
+
+The Python writer remains the authoritative serializer for each fixed 11-field DNSBL
+event. It emits RFC4180 CSV with minimal quoting, doubles embedded quotes, and normalizes
+CR/LF to spaces so every event occupies one physical line. The filterlog daemon parses
+that row with the matching CSV grammar for syslog export, then preserves the original
+encoded bytes in `unified.log`; it no longer reconstructs production DNSBL rows through
+`pfb_unified_format_dnsbl()`. Attribution and field order remain unchanged.

--- a/docs/misc/alerts-reports-pipeline.md
+++ b/docs/misc/alerts-reports-pipeline.md
@@ -39,7 +39,7 @@ behind.
 | `dnsbl.log` | `pfb_unbound.py` (`_log_dnsbl` path) | full verdict: block type, group, evaluated domain/zone, feed, query type |
 | `dns_reply.log` | `pfb_unbound.py` | reply type/record, TTL, resolved address, GeoIP iso code |
 | `ip_block/permit/match.log` | filterlog daemon (`pfb_daemon_filterlog`, `pfblockerng.inc`) | pf tracker → pfB rule/alias, matching feed + IP/CIDR entry (`find_reported_header()`), GeoIP (`mmdblookup`), rDNS, ASN (3 CSV columns, issue #1369 — see below) |
-| `unified.log` | filterlog daemon (sole writer, ADR-38 Amendment 1) | reformatted copies of the three streams above |
+| `unified.log` | filterlog daemon (sole writer, ADR-38 Amendments 1/4) | reformatted IP/DNS-reply rows; byte-identical RFC4180 DNSBL rows |
 
 The daemon reconstructs the bare pf event into a fully attributed record **once**, at
 event time, and caches its lookups in the `ipcache` SQLite table so repeated offenders

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15741,18 +15741,11 @@ function pfb_daemon_filterlog() {
 					if (strncmp($line, 'DNSBL-python,', 13) === 0) {
 						$dnsline = rtrim($line, "\r\n");
 						if ($dnsline !== '') {
-							$df = explode(',', $dnsline);
-							// Reformat through the schema-owning formatter when well-formed;
-							// fall back to the raw line otherwise so a malformed row is never
-							// dropped or corrupted.
+							$df = str_getcsv($dnsline, ',', '"', '');
+							@file_put_contents("{$pfb['unilog']}", "{$dnsline}\n", FILE_APPEND | LOCK_EX);
+							// Emit syslog only for a well-formed logical row; raw unified.log
+							// preservation above covers malformed rows without corruption.
 							if (count($df) === 11) {
-								$uni = pfb_unified_format_dnsbl(array(
-									'l_type' => $df[0], 'datetime' => $df[1], 'q_name' => $df[2],
-									'q_ip' => $df[3], 'p_type' => $df[4], 'b_type' => $df[5],
-									'group' => $df[6], 'b_eval' => $df[7], 'feed' => $df[8],
-									'dup' => $df[9], 'q_type' => $df[10],
-								));
-								@file_put_contents("{$pfb['unilog']}", "{$uni}\n", FILE_APPEND | LOCK_EX);
 								// Every DNSBL block line syslogs uniformly (incl. the PHP-path
 								// block the old python-only emitter missed). pfb_syslog_event
 								// no-ops when the toggle is off. Refresh the daemon's config
@@ -15765,8 +15758,6 @@ function pfb_daemon_filterlog() {
 										'b_eval' => $df[7],
 									)));
 								}
-							} else {
-								@file_put_contents("{$pfb['unilog']}", "{$dnsline}\n", FILE_APPEND | LOCK_EX);
 							}
 						}
 						continue;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2869,8 +2869,9 @@ function pfb_syslog_format_ip(array $fields): string
 // ADR-38 Amendment 1 — DNSBL syslog + unified.log formatters. pfb_syslog_format_dnsbl()
 // (PHP port of the retired Python syslog_format_dnsbl()) formats a DNSBL block event as
 // key=value; fixed order act qname qip qtype [group] [feed] btype eval (group/feed omitted
-// when ''); escaping matches pfb_syslog_format_ip. pfb_unified_format_ip/_dnsbl/_dnsreply
-// render comma-joined unified.log/dnsbl.log rows in FIXED column order — no escaping.
+// when ''); escaping matches pfb_syslog_format_ip. pfb_unified_format_ip/_dnsreply
+// render comma-joined unified.log rows; Amendment 4 keeps the DNSBL formatter as a
+// pure schema oracle while production preserves the Python writer's RFC4180 bytes.
 // All four are PURE — no globals, no I/O, no config reads.
 // ---------------------------------------------------------------------------
 
@@ -2938,10 +2939,11 @@ function pfb_unified_format_ip(array $fields): string
 }
 
 /**
- * pfb_unified_format_dnsbl — render a dnsbl.log CSV line as a comma-joined string.
+ * pfb_unified_format_dnsbl — render plain DNSBL fields as a comma-joined string.
  *
- * Owns the 11-column schema for DNSBL rows in unified.log (mirrors dnsbl.log
- * exactly).  Raw passthrough — no escaping; the caller appends "\n".
+ * Retained as the pure 11-column schema/compatibility oracle. ADR-38 Amendment 4:
+ * the production daemon preserves the Python writer's RFC4180 row bytes instead,
+ * because this formatter deliberately applies no escaping.
  *
  * Column order: l_type, datetime, q_name, q_ip, p_type, b_type, group,
  *               b_eval, feed, dup, q_type.

--- a/tests/php/FilterlogFieldGuardTest.php
+++ b/tests/php/FilterlogFieldGuardTest.php
@@ -7,11 +7,10 @@ use PHPUnit\Framework\TestCase;
 /**
  * pfb_daemon_filterlog()'s CSV field-count guard (issue #1768).
  *
- * pfb_daemon_filterlog() reads php://stdin in an unbounded daemon loop and
- * is not directly callable from a unit test (see LogTimestampBaselineTest's
- * docblock -- the same constraint applies here; no test in this suite calls
- * it directly, confirmed by grep). A short/malformed filterlog line (fewer
- * space-separated fields than the BSD/syslog $f_pos offset expects) left
+ * SyslogEventTest exercises the daemon's DNSBL stdin branch in a bounded child
+ * process. This filter.log field-split path stays a pure extracted test because
+ * reaching it also requires pfSense firewall state. A short/malformed filterlog
+ * line (fewer space-separated fields than the BSD/syslog $f_pos offset expects) left
  * $f[$f_pos] undefined, and `explode(',', $f[$f_pos])` on that undefined
  * offset passed NULL to explode() -- a PHP 8.1+ deprecation, and part of the
  * #1768 "Passing null" gate failure.

--- a/tests/php/LogTimestampBaselineTest.php
+++ b/tests/php/LogTimestampBaselineTest.php
@@ -12,13 +12,11 @@ use PHPUnit\Framework\TestCase;
  * (below) to pin the FIXED, always-on ISO-8601 behaviour instead: all 10 log
  * types now share the same 'Y-m-d H:i:s' shape.
  *
- * pfb_daemon_filterlog() reads php://stdin in an unbounded daemon loop and is
- * not directly callable from a unit test; its 'BSD'/'syslog' timestamp branch
- * (§1.3's ip_blocklog/ip_permitlog/ip_matchlog row) was extracted into the
- * pure, directly-callable pfb_filterlog_timestamp() and is exercised for real
- * below. Only the REST of pfb_daemon_filterlog() -- the stdin daemon loop
- * itself -- remains untestable directly. pfb_log_event() (§1.8's dnsbl.log
- * twin writer) IS directly callable and is exercised for real below too.
+ * SyslogEventTest exercises the daemon's DNSBL stdin branch in a bounded child
+ * process. This file keeps the 'BSD'/'syslog' timestamp branch (§1.3's
+ * ip_blocklog/ip_permitlog/ip_matchlog row) on its smaller pure seam,
+ * pfb_filterlog_timestamp(). pfb_log_event() (§1.8's dnsbl.log twin writer) is
+ * directly callable and exercised below too.
  */
 #[CoversFunction('pfb_logger')]
 #[CoversFunction('pfb_parse_fail_log')]

--- a/tests/php/SyslogEventTest.php
+++ b/tests/php/SyslogEventTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class SyslogEventTest extends TestCase
 {
+	private const DAEMON_DEADLINE_S = 3.0;
+
 	private bool $hadConfig = false;
 	private mixed $savedConfig = null;
 	private bool $hadSyslogSpy = false;
@@ -29,6 +31,8 @@ final class SyslogEventTest extends TestCase
 	private mixed $savedSyslogCalls = null;
 	private bool $hadSyslogReset = false;
 	private mixed $savedSyslogReset = null;
+	/** @var string[] */
+	private array $daemonTempFiles = [];
 
 	/** Install clean owned state; no cache-reset needed (function reads fresh each call). */
 	protected function setUp(): void
@@ -64,6 +68,77 @@ final class SyslogEventTest extends TestCase
 				unset($GLOBALS[$name]);
 			}
 		}
+		foreach ($this->daemonTempFiles as $path) {
+			if (is_file($path)) {
+				unlink($path);
+			}
+		}
+		$this->daemonTempFiles = [];
+	}
+
+	/** @return array{0: array<int, array<string, mixed>>, 1: string} */
+	private function runFilterlogDaemon(string $row): array
+	{
+		$unilog = tempnam(sys_get_temp_dir(), 'pfb_dnsbl_unilog_');
+		$calls = tempnam(sys_get_temp_dir(), 'pfb_dnsbl_calls_');
+		$done = tempnam(sys_get_temp_dir(), 'pfb_dnsbl_done_');
+		$stderr = tempnam(sys_get_temp_dir(), 'pfb_dnsbl_stderr_');
+		foreach ([$unilog, $calls, $done, $stderr] as $path) {
+			$this->assertIsString($path, 'test setup: temp file creation failed');
+			$this->daemonTempFiles[] = $path;
+		}
+		unlink($done);
+		$bootstrap = __DIR__ . '/bootstrap.php';
+		$childCode = <<<'PHP'
+			$args = $argv;
+			require $args[4];
+			$GLOBALS['pfb']['unilog'] = $args[1];
+			$GLOBALS['pfb']['asn_reporting'] = 'disabled';
+			$GLOBALS['pfb']['geoipshare'] = '';
+			$GLOBALS['config'] = [];
+			config_set_path('installedpackages/pfblockerng/config/0/log_syslog', 'on');
+			$GLOBALS['pfb_test_syslog_spy'] = TRUE;
+			$GLOBALS['pfb_test_syslog_calls'] = [];
+			pfb_daemon_filterlog();
+			file_put_contents($args[2], json_encode($GLOBALS['pfb_test_syslog_calls'], JSON_THROW_ON_ERROR));
+			file_put_contents($args[3], 'done');
+			PHP;
+		$descriptors = [
+			0 => ['pipe', 'r'],
+			1 => ['file', '/dev/null', 'w'],
+			2 => ['file', $stderr, 'w'],
+		];
+		$proc = proc_open([PHP_BINARY, '-r', $childCode, $unilog, $calls, $done, $bootstrap], $descriptors, $pipes);
+		$this->assertIsResource($proc, 'test setup: failed to spawn filterlog daemon child');
+		fwrite($pipes[0], $row . "\n");
+		fclose($pipes[0]);
+
+		$deadline = microtime(TRUE) + self::DAEMON_DEADLINE_S;
+		while (!is_file($done) && microtime(TRUE) < $deadline) {
+			$status = proc_get_status($proc);
+			if (!$status['running']) {
+				break;
+			}
+			usleep(10000);
+		}
+		$status = proc_get_status($proc);
+		if (!is_file($done)) {
+			if ($status['running']) {
+				proc_terminate($proc, 9);
+				proc_close($proc);
+				$this->fail('STUCK/ENVIRONMENT: filterlog daemon child did not complete before the hard deadline');
+			}
+			$exitCode = proc_close($proc);
+			$this->fail(
+				'filterlog daemon child exited before completion (exit ' . $exitCode . '): '
+				. (string) file_get_contents($stderr)
+			);
+		}
+		$exitCode = proc_close($proc);
+		$this->assertSame(0, $exitCode, 'filterlog daemon child must exit cleanly');
+		$decoded = json_decode((string) file_get_contents($calls), TRUE, 512, JSON_THROW_ON_ERROR);
+		$this->assertIsArray($decoded, 'child syslog spy output must be an array');
+		return [$decoded, (string) file_get_contents($unilog)];
 	}
 
 	// -----------------------------------------------------------------------
@@ -231,5 +306,46 @@ final class SyslogEventTest extends TestCase
 		$this->assertSame($body, $calls_after[0]['body'], 'after flip: body matches');
 		$this->assertSame(LOG_LOCAL6, $calls_after[0]['facility'], 'after flip: facility is LOG_LOCAL6');
 		$this->assertSame(LOG_INFO, $calls_after[0]['severity'], 'after flip: severity is LOG_INFO');
+	}
+
+	/**
+	 * The daemon reads Python's RFC4180 DNSBL rows at its public stdin boundary.
+	 * Each row must be written to unified.log byte-for-byte, while only a logical
+	 * 11-field row emits the dedicated DNSBL syslog event.
+	 */
+	public function testFilterlogDaemonPreservesDnsblRowsAndParsesQuotedFields(): void
+	{
+		$plain = 'DNSBL-python,2026-08-02 12:34:56,plain.example.com,192.0.2.7,Python,DNSBL_Python,real_group,example.com,real_feed,+,A';
+		$quoted = 'DNSBL-python,2026-08-02 12:34:56,"a,""quoted"".example.com",192.0.2.7,Python,DNSBL_Python,real_group,example.com,real_feed,+,A';
+		$malformed = 'DNSBL-python,2026-08-02 12:34:56,too-short,192.0.2.7,Python,DNSBL_Python';
+
+		$cases = [
+			[
+				'label' => 'plain 11-field row',
+				'row' => $plain,
+				'body' => 'act=dnsbl qname=plain.example.com qip=192.0.2.7 qtype=A group=real_group feed=real_feed btype=DNSBL_Python eval=example.com',
+			],
+			[
+				'label' => 'quoted comma and quote q_name',
+				'row' => $quoted,
+				'body' => 'act=dnsbl qname="a,\\"quoted\\".example.com" qip=192.0.2.7 qtype=A group=real_group feed=real_feed btype=DNSBL_Python eval=example.com',
+			],
+			[
+				'label' => 'malformed row',
+				'row' => $malformed,
+				'body' => NULL,
+			],
+		];
+
+		foreach ($cases as $case) {
+			[$calls, $unified] = $this->runFilterlogDaemon($case['row']);
+			$this->assertSame($case['row'] . "\n", $unified, $case['label'] . ': unified.log must preserve raw row bytes');
+			if ($case['body'] === NULL) {
+				$this->assertSame([], $calls, $case['label'] . ': malformed row must emit no syslog event');
+				continue;
+			}
+			$this->assertCount(1, $calls, $case['label'] . ': exactly one syslog event expected');
+			$this->assertSame($case['body'], $calls[0]['body'], $case['label'] . ': syslog body fields must remain exact');
+		}
 	}
 }

--- a/tests/php/UnifiedFormatTest.php
+++ b/tests/php/UnifiedFormatTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 /**
  * ADR-38 Amendment 1 — DNSBL syslog + unified.log formatter tests.
  * ADR-38 Amendment 3 (issue #1369) — ASN CSV-column helper tests.
+ * ADR-38 Amendment 4 (issue #2075) — the DNSBL formatter remains a pure
+ * fixed-column compatibility/schema oracle, not the production RFC4180 writer.
  *
  * Pins the behaviour of:
  *   pfb_syslog_format_dnsbl(array $fields): string
@@ -286,7 +288,7 @@ final class UnifiedFormatTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	/**
-	 * 11 named fields joined in the dnsbl.log column order.
+	 * 11 plain named fields joined in the legacy dnsbl.log column order.
 	 *
 	 * Scenario:
 	 *   Given the 11 fields from a representative real dnsbl.log line.

--- a/tests/test_dnsbl_log_csv_quoting.py
+++ b/tests/test_dnsbl_log_csv_quoting.py
@@ -176,10 +176,9 @@ class TestDnsReplyWriterCommaInQName:
 class TestPlainNameRowStaysBareCsv:
     """Comma-free rows must stay byte-identical to the historical format.
 
-    The filterlog daemon (pfb_daemon_filterlog) fast-paths dnsbl.log lines with
-    a plain explode(',') == 11 check before re-emitting them verbatim into
-    unified.log; gratuitous quoting of clean fields would knock every ordinary
-    row off that path. QUOTE_MINIMAL semantics are the pinned contract.
+    QUOTE_MINIMAL preserves the historical bare row for ordinary names while
+    still producing valid input for the daemon's str_getcsv() and the Alerts
+    page's fgetcsv() readers. That byte compatibility is the pinned contract.
     """
 
     def test_plain_fields_are_not_quoted(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

`pfb_daemon_filterlog()` split `DNSBL-python` rows with `explode(',')`, so an RFC4180-quoted query name containing a comma produced extra fragments and skipped the dedicated syslog event. The raw row still reached `unified.log`, hiding the export gap.

This change parses the row with PHP's CSV parser using the writer's RFC4180 grammar, preserves the original encoded row byte-for-byte in `unified.log`, and emits syslog only for the expected 11 logical fields.

Fixes #2075

## Writer contract

The current Python `_csv_row()` uses `csv.writer` with the Excel/RFC4180 dialect: minimal quoting and doubled embedded quotes. Before encoding, it replaces CRLF, CR, and LF with spaces; therefore it can emit quoted commas and doubled quotes but never a physical multiline log row. This was established from the current implementation and by running `tests/test_dnsbl_log_csv_quoting.py` (9 passed).

## Test-first proof

- Frozen reproduction: `tests/php/SyslogEventTest.php`, hash `2b00070996739da88758136d9a5498d01552682d`.
- RED on untouched `15f796784b0858f69c08253886d3b70158c49781`: quoted comma/quote query expected one syslog event, got zero.
- GREEN unchanged: focused daemon test passed with 29 assertions; full file passed 6 tests / 47 assertions.
- Independent `verify-red-proof.sh`: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`.

## Verification

- `python3 -m pytest tests/test_dnsbl_log_csv_quoting.py -q` — 9 passed.
- `scripts/agent/run-gates.sh --diff origin/devel` — `GATES: PASS` from implementer and independent verifier.
- Independent review gate covered plain, quoted comma/quote, malformed short-row fallback, and writer newline normalization.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNSBL log handling for CSV data, including quoted fields.
  * Preserved malformed DNSBL entries in their original form instead of rewriting them.
  * Valid DNSBL entries are now formatted correctly, while malformed entries are excluded from syslog output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->