### PR TITLE
tests: replace source wiring scans with behavior

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -38,6 +38,121 @@ if (!is_array($pfb)) {
 	$pfb = array();
 }
 
+/**
+ * Capture the installed settings family, then restore the package snapshot for the current
+ * version. Install callers run migrations separately so the legacy VIP migration retains its
+ * historical position between restore and migration.
+ */
+function pfb_install_settings_family_capture_restore(
+	?callable $current = NULL,
+	?callable $save = NULL,
+	?callable $version = NULL,
+	?callable $from_version = NULL,
+	?callable $replace = NULL
+): string {
+	$current ??= 'pfb_settings_family_current';
+	$save ??= 'pfb_settings_family_save';
+	$version ??= 'pfb_pkg_ver';
+	$from_version ??= 'pfb_settings_family_from_version';
+	$replace ??= 'pfb_settings_family_replace';
+	$source_family = $current();
+	if ($source_family === NULL || !$save($source_family)) {
+		throw new RuntimeException('pfBlockerNG: unable to save source settings family');
+	}
+	$installed_family = $from_version((string) $version());
+	if ($installed_family === NULL || !$replace($installed_family)) {
+		throw new RuntimeException('pfBlockerNG: unable to restore settings family');
+	}
+	return $installed_family;
+}
+
+function pfb_install_settings_family_finalize(
+	string $installed_family,
+	?callable $migrations = NULL,
+	?callable $record = NULL
+): void {
+	$migrations ??= 'pfb_run_migrations';
+	$record ??= 'pfb_settings_family_record';
+	$migrations();
+	if (!$record($installed_family)) {
+		throw new RuntimeException('pfBlockerNG: unable to record settings family');
+	}
+}
+
+function pfb_install_registry_writeback(
+	array $sections,
+	?callable $pass = NULL,
+	?callable $write_section = NULL,
+	?callable $flush = NULL
+): void {
+	$pass ??= 'pfb_registry_pass';
+	$write_section ??= 'PfbConfig::writeSectionSystem';
+	$flush ??= 'write_config';
+	foreach ($pass($sections) as $path => $blob) {
+		$write_section($path, $blob);
+	}
+	$flush('[pfBlockerNG] Save installation settings');
+}
+
+function pfb_install_probe_cleanup(?callable $purge = NULL): void {
+	$purge ??= 'pfb_purge_probe_bodies';
+	$purge();
+}
+
+function pfb_lint_response(array $server, array $post, callable $allowed, callable $diagnostics): array {
+	$reply = static function (int $status, array $payload): array {
+		return [
+			'status'  => $status,
+			'headers' => ['Content-Type: application/json; charset=utf-8'],
+			'body'    => (string) json_encode($payload, JSON_INVALID_UTF8_SUBSTITUTE),
+		];
+	};
+	if (($server['REQUEST_METHOD'] ?? '') !== 'POST') {
+		return $reply(405, ['error' => 'POST only']);
+	}
+	$lang = $post['lang'] ?? NULL;
+	if (!is_string($lang) || !in_array($lang, ['regex', 'sh', 'py'], TRUE)) {
+		return $reply(400, ['error' => 'lang must be one of regex, sh, py']);
+	}
+	$privilege = $lang === 'regex' ? 'pfblockerng/pfblockerng_dnsbl.php' : 'diag_command.php';
+	if (!$allowed($privilege)) {
+		return $reply(403, ['error' => 'insufficient privilege']);
+	}
+	$content = $post['content'] ?? '';
+	if (!is_string($content)) {
+		return $reply(400, ['error' => 'content must be a string']);
+	}
+	if (strlen($content) > 1048576) {
+		return $reply(413, ['error' => 'content too large']);
+	}
+	$cap = ($post['cap'] ?? '') === '1';
+	return $reply(200, ['diagnostics' => $diagnostics($lang, $content, $cap)]);
+}
+
+function pfb_update_tail_response(array $query, callable $tail): array {
+	$has_offset = isset($query['offset']) && ctype_digit((string) $query['offset']);
+	$payload = $tail('update', $has_offset ? (int) $query['offset'] : -1, $has_offset);
+	return [
+		'headers' => ['Content-Type: application/json', 'Cache-Control: no-cache, no-store, must-revalidate'],
+		'body'    => (string) json_encode($payload, JSON_INVALID_UTF8_SUBSTITUTE),
+	];
+}
+
+function pfb_widget_table_call(array $table, string $mode = '', ?callable $render = NULL): mixed {
+	$render ??= 'pfBlockerNG_get_table';
+	return $render($table, $mode);
+}
+
+function pfb_widget_post_guard(array $post, array $server, string $field): bool {
+	$present = $field === 'pfb_submit' ? isset($post[$field]) : !empty($post[$field]);
+	return $present && pfb_widget_post_allowed($server);
+}
+
+function pfb_geoip_doc_link(): string {
+	return '<a target="_blank" rel="noopener noreferrer" href="https://dev.maxmind.com/geoip/whats-new-in-geoip2/">'
+		. '<span class="text-danger"><strong>What\'s new in GeoIP2</strong></span></a>';
+}
+
 // Folders
 $pfb['dbdir']		= "{$g['vardb_path']}/pfblockerng";
 $pfb['aliasdir']	= "{$g['vardb_path']}/aliastables";
@@ -3831,6 +3946,55 @@ function pfb_dnsbl_feed_count(string $dir): int {
 	return $total;
 }
 
+function pfb_update_unbound_feed_count(string $dir, ?callable $counter = NULL): int {
+	$counter ??= 'pfb_dnsbl_feed_count';
+	return $counter($dir);
+}
+
+function pfb_geoip_networks_header(string $iso_file, string $country, string $geoip_id, string $iso): string {
+	$networks = pfb_count_lines($iso_file) ?? 'ERROR';
+	$geoip_id = $geoip_id === '' || str_starts_with($geoip_id, ' [') ? $geoip_id : " [{$geoip_id}]";
+	return "# Country: {$country}{$geoip_id}\n# ISO Code: {$iso}\n# Total Networks: {$networks}\n";
+}
+
+function pfb_geoip_append_iso_data(
+	string $cat,
+	string $iso_file,
+	string $pfb_file,
+	string $build_tmp,
+	string $iso,
+	string $type,
+	?callable $logger = NULL
+): bool {
+	$logger ??= 'pfb_logger';
+	$output = array();
+	$status = 0;
+	exec(
+		$cat . ' ' . escapeshellarg($iso_file) . ' >> ' . escapeshellarg($pfb_file),
+		$output,
+		$status
+	);
+	if ($status !== 0) {
+		$logger("\n Failed to append ISO data [ {$iso} IPv{$type} ] (cat status {$status})\n", 4);
+		@unlink($pfb_file);
+		rmdir_recursive($build_tmp);
+		return FALSE;
+	}
+	return TRUE;
+}
+
+function pfb_download_extraction_succeeded(int $retval): bool {
+	return $retval === 0;
+}
+
+function pfb_download_initial_retval(): int {
+	return 1;
+}
+
+function pfb_download_retval_success(?int $retval): bool {
+	return $retval === 0;
+}
+
 // issue #1109/#1258: ONE unified high-water guard for both pfb_log_mgmt()
 // branches -- fires past a margin-widened high-water mark; $margin_raw is
 // parsed HERE (self-defending). $logmax unclamped -- float math, not intdiv().
@@ -6666,6 +6830,16 @@ function pfb_ip_suppress_body_active(bool $supp_on, bool $vtype_matches, bool $s
 	return $supp_on && $vtype_matches && $supp_update && $adv && ($feed_changed || $recompute_ran);
 }
 
+function pfb_ip_recompute_ran_for_vtype(string $vtype, bool $ran_v4, bool $ran_v6): bool {
+	return $vtype === '_v4' ? $ran_v4 : ($vtype === '_v6' ? $ran_v6 : FALSE);
+}
+
+function pfb_ip_suppress_body_for_vtype(bool $supp_on, string $vtype, bool $supp_update, bool $adv,
+    bool $feed_changed, bool $ran_v4, bool $ran_v6): bool {
+	return pfb_ip_suppress_body_active($supp_on, $vtype === '_v4' || $vtype === '_v6', $supp_update,
+	    $adv, $feed_changed, pfb_ip_recompute_ran_for_vtype($vtype, $ran_v4, $ran_v6));
+}
+
 // ---------------------------------------------------------------------------
 // ADR-40 — forward-delta alias-table apply
 // ---------------------------------------------------------------------------
@@ -7811,7 +7985,7 @@ function pfb_unbound_python_whitelist($mode='') {
 	pfb_global();
 
 	$dnsbl_whitelist = '';
-	$dnsbl_white = pfb_text_area_decode($pfb['dnsblconfig']['whitelist'], TRUE, FALSE, TRUE);
+	$dnsbl_white = pfb_text_area_decode($pfb['dnsblconfig']['whitelist'] ?? '', TRUE, FALSE, TRUE);
 	if (!empty($dnsbl_white)) {
 		foreach ($dnsbl_white as $key => $line) {
 			if (!empty($line)) {
@@ -7849,7 +8023,7 @@ function pfb_unbound_python_whitelist($mode='') {
 function pfb_dnsbl_whitelist_lines() {
 	global $pfb;
 
-	$lines = pfb_text_area_decode($pfb['dnsblconfig']['whitelist'], TRUE, FALSE, TRUE);
+	$lines = pfb_text_area_decode($pfb['dnsblconfig']['whitelist'] ?? '', TRUE, FALSE, TRUE);
 	$out = array();
 	if (!empty($lines)) {
 		foreach ($lines as $line) {
@@ -8780,6 +8954,11 @@ function pfb_unbound_py_teardown_raw_set(): bool {
 	}
 }
 
+function pfb_top1m_teardown_call(?callable $teardown = NULL): bool {
+	$teardown ??= 'pfb_unbound_py_teardown_raw_set';
+	return (bool) $teardown();
+}
+
 
 // ADR-10: flip the zero-downtime RELOAD SENTINEL (the all-or-nothing commit that
 // wakes the Python reload-watcher). The sentinel host path is /var/unbound/pfb_py_reload
@@ -9530,6 +9709,122 @@ function pfb_unbound_python_sources_unlock() {
 }
 
 
+// Build the Python INI from the current, gateway-loaded DNSBL settings.
+function pfb_unbound_python_ini($mode, ?string $now = NULL): string {
+	global $pfb;
+
+	$python_enable = ($mode == 'enabled') ? 'on' : 'off';
+	$python_reply = ($pfb['dnsbl_py_reply'] === PfbToggle::On) ? 'on' : 'off';
+	$python_blocking = 'on';
+	$python_hsts = ($pfb['dnsbl_hsts'] === PfbToggle::On) ? 'on' : 'off';
+	$dnsbl_tld_wildcard = $pfb['dnsbl_tld_wildcard'];
+	$python_tld_wildcard = !empty($dnsbl_tld_wildcard) ? 'on' : 'off';
+
+	$idn_mode = $pfb['dnsbl_idn']->toStored();
+	$python_idn = ($pfb['dnsbl_idn'] === PfbIdnMode::All) ? 'on' : 'off';
+	$python_idn_block_malicious = (pfb_cfg_toggle_read($pfb['dnsbl_idn_block_malicious']) === PfbToggle::On) ? 'on' : 'off';
+	$python_idn_escalate_suspicious = (pfb_cfg_toggle_read($pfb['dnsbl_idn_escalate_suspicious']) === PfbToggle::On) ? 'on' : 'off';
+	$python_cname = ($pfb['dnsbl_cname'] === PfbToggle::On) ? 'on' : 'off';
+
+	$dnsbl_control = $pfb['dnsbl_control'];
+	$dnsbl_control_legacy = $pfb['dnsbl_control_legacy'];
+	$python_control = ($dnsbl_control === PfbToggle::On) ? 'on' : 'off';
+	$python_control_legacy = ($dnsbl_control === PfbToggle::On && $dnsbl_control_legacy === PfbToggle::On) ? 'on' : 'off';
+	$python_noaaaa = ($pfb['dnsbl_noaaaa'] === PfbToggle::On) ? 'on' : 'off';
+
+	$tld_allow = 'off';
+	$tld_allow_list = '';
+	if ($pfb['dnsbl_tld_allow'] === PfbToggle::On) {
+		foreach (['tld_allow_gtld', 'tld_allow_cctld', 'tld_allow_itld', 'tld_allow_bgtld'] as $field) {
+			if (!empty($pfb['dnsblconfig'][$field])) {
+				$tld_allow = 'on';
+				$tld_allow_list .= ',' . $pfb['dnsblconfig'][$field];
+			}
+		}
+		$tld_allow_list = ltrim($tld_allow_list, ',');
+	}
+
+	$python_nolog = ($pfb['dnsbl_py_nolog'] === PfbToggle::On) ? 'on' : 'off';
+	$regex_cap = ($pfb['dnsbl_regex_cap'] === PfbToggle::On) ? 'on' : 'off';
+	$decisiondb_max = $pfb['dnsbl_decisiondb_max'] ?? '10000';
+	$forwarding = (config_get_path('unbound/forwarding') == 'on') ? 'on' : 'off';
+	$now ??= date('Y-m-d H:i:s', time());
+
+	$pfb_py_conf = <<<EOF
+; pfBlockerNG DNSBL Unbound python configuration file
+; pfb_unbound.ini [ File created: {$now} ]
+[MAIN]
+dnsbl_ipv4	= {$pfb['dnsbl_vip4']}
+dnsbl_ipv6	= {$pfb['dnsbl_vip6']}
+python_enable	= {$python_enable}
+python_reply	= {$python_reply}
+python_blocking	= {$python_blocking}
+python_hsts	= {$python_hsts}
+python_tld_wildcard	= {$python_tld_wildcard}
+python_idn	= {$python_idn}
+idn_mode	= {$idn_mode}
+python_idn_block_malicious	= {$python_idn_block_malicious}
+python_idn_escalate_suspicious	= {$python_idn_escalate_suspicious}
+python_tld_seg	= 1
+decisiondb_max	= {$decisiondb_max}
+tld_allow	= {$tld_allow}
+tld_allow_list	= {$tld_allow_list}
+python_nolog	= {$python_nolog}
+python_cname	= {$python_cname}
+python_control	= {$python_control}
+python_control_legacy	= {$python_control_legacy}
+regex_cap	= {$regex_cap}
+forwarding	= {$forwarding}
+
+EOF;
+	if ($pfb['dnsbl_regex'] === PfbToggle::On && isset($pfb['dnsbl_regex_list']) && !empty($pfb['dnsbl_regex_list'])) {
+		$pfb_py_conf .= "regex_list = {$pfb['dnsbl_regex_list']}\n";
+	}
+
+	if ($pfb['dnsbl_noaaaa'] === PfbToggle::On && isset($pfb['dnsbl_noaaaa_list']) && !empty($pfb['dnsbl_noaaaa_list'])) {
+		$noaaaa = '';
+		$noaaaa_list = pfb_text_area_decode($pfb['dnsbl_noaaaa_list'], TRUE, TRUE, TRUE);
+		if (!empty($noaaaa_list)) {
+			foreach ($noaaaa_list as $key => $list) {
+				if (str_starts_with($list[0], '.')) {
+					$list[0] = pfb_strip_wildcard_marker($list[0], 'pfb_unbound_python noAAAA');
+					if (pfb_is_blank($list[0])) {
+						continue;
+					}
+					$noaaaa .= "{$key} = {$list[0]},1\n";
+				} else {
+					$noaaaa .= "{$key} = {$list[0]},0\n";
+				}
+			}
+			if (!pfb_is_blank($noaaaa)) {
+				$pfb_py_conf .= <<<EOF
+
+[noAAAA]
+{$noaaaa}
+EOF;
+			}
+		}
+	}
+
+	if ($pfb['dnsbl_gp'] === PfbToggle::On && isset($pfb['dnsbl_gp_bypass_list']) && !empty($pfb['dnsbl_gp_bypass_list'])) {
+		$gp_bypass = '';
+		$gp_bypass_list = pfb_text_area_decode($pfb['dnsbl_gp_bypass_list'], TRUE, TRUE, FALSE);
+		if (!empty($gp_bypass_list)) {
+			foreach ($gp_bypass_list as $key => $list) {
+				$gp_bypass .= "{$key} = {$list[0]}\n";
+			}
+			$pfb_py_conf .= <<<EOF
+
+[GP_Bypass_List]
+{$gp_bypass}
+EOF;
+		}
+	}
+
+	return $pfb_py_conf;
+}
+
+
 // ADR-06 (#51): map a per-alert DNSBL Lock/Unlock action (dnsbl_remove POST value) to its
 // temporary-unlock STORE operation + status message. The four icon actions collapse onto two
 // pfb_unlock modes: unlock/relock ADD the domain ('unlock'), lock/reunlock REMOVE it ('lock').
@@ -9575,10 +9870,7 @@ function pfb_unbound_python($mode) {
 	}
 
 	// Add python settings to DNS Resolver configuration
-	$python_enable = 'off';
 	if ($mode == 'enabled') {
-		$python_enable = 'on';
-
 		if (!config_path_enabled('unbound', 'python') ||
 		    config_get_path('unbound/python_script') != 'pfb_unbound') {
 
@@ -9609,177 +9901,8 @@ function pfb_unbound_python($mode) {
 			pfb_unbound_python_sources_whitelist();
 		}
 
-		$python_reply = 'off';
-		if ($pfb['dnsbl_py_reply'] === PfbToggle::On) {
-			$python_reply = 'on';
-		}
-
-		$python_blocking = 'on';
-
-		$python_hsts = 'off';
-		if ($pfb['dnsbl_hsts'] === PfbToggle::On) {
-			$python_hsts = 'on';
-		}
-
-		// issue #1255: DNSBL Wildcard Blocking (TLD) -- HSTS parity (shipped file +
-		// ini enable flag). $pfb['dnsbl_tld_wildcard'] is used as a bare truthy check
-		// elsewhere (the deferred stats branch), not an == 'on' comparison.
-		$python_tld_wildcard = 'off';
-		if ($pfb['dnsbl_tld_wildcard']) {
-			$python_tld_wildcard = 'on';
-		}
-
-		// ADR-08: emit the IDN mode + the legacy python_idn flag + the Confusable sub-toggles.
-		// python_idn = on ONLY for All-IDN, so the legacy flag (and its blacklist side-effect)
-		// stays byte-identical to today; Confusable rides the explicit idn_mode key instead.
-		// py_unbound.ini IDN mode: the SAME canonical token as config.xml (toStored):
-		// 'on' (= All) | 'confusable' | 'off'. The Python IdnMode enum reads it directly.
-		$idn_mode = $pfb['dnsbl_idn']->toStored();
-		$python_idn = ($pfb['dnsbl_idn'] === PfbIdnMode::All) ? 'on' : 'off';
-
-		$python_idn_block_malicious = (pfb_cfg_toggle_read($pfb['dnsbl_idn_block_malicious']) === PfbToggle::On) ? 'on' : 'off';
-		$python_idn_escalate_suspicious = (pfb_cfg_toggle_read($pfb['dnsbl_idn_escalate_suspicious']) === PfbToggle::On) ? 'on' : 'off';
-
-		$python_cname = 'off';
-		if ($pfb['dnsbl_cname'] === PfbToggle::On) {
-			$python_cname = 'on';
-		}
-
-		$python_control = 'off';
-		if ($pfb['dnsbl_control'] === PfbToggle::On) {
-			$python_control = 'on';
-		}
-
-		// PFBL-03: deprecated legacy DNS-TXT control transport. OFF unless the operator
-		// explicitly opted back in (and the parent DNSBL Control toggle is enabled).
-		// DNSBL control is CLI-driven; this path is slated for removal next release.
-		$python_control_legacy = 'off';
-		if ($pfb['dnsbl_control'] === PfbToggle::On && $pfb['dnsbl_control_legacy'] === PfbToggle::On) {
-			$python_control_legacy = 'on';
-		}
-
-		$python_noaaaa = 'off';
-		if ($pfb['dnsbl_noaaaa'] === PfbToggle::On) {
-			$python_noaaaa = 'on';
-		}
-
-		$tld_allow = 'off';
-		$tld_allow_list = '';
-		if ($pfb['dnsbl_tld_allow'] === PfbToggle::On) {
-			if (!empty($pfb['dnsblconfig']['tld_allow_gtld'])) {
-				$tld_allow = 'on';
-				$tld_allow_list = $pfb['dnsblconfig']['tld_allow_gtld'];
-			}
-			if (!empty($pfb['dnsblconfig']['tld_allow_cctld'])) {
-				$tld_allow = 'on';
-				$tld_allow_list .= ',' . $pfb['dnsblconfig']['tld_allow_cctld'];
-			}
-			if (!empty($pfb['dnsblconfig']['tld_allow_itld'])) {
-				$tld_allow = 'on';
-				$tld_allow_list .= ',' . $pfb['dnsblconfig']['tld_allow_itld'];
-			}
-			if (!empty($pfb['dnsblconfig']['tld_allow_bgtld'])) {
-				$tld_allow = 'on';
-				$tld_allow_list .= ',' . $pfb['dnsblconfig']['tld_allow_bgtld'];
-			}
-			$tld_allow_list = ltrim($tld_allow_list, ',');
-		}
-
-		$python_nolog = 'off';
-		if ($pfb['dnsbl_py_nolog'] === PfbToggle::On) {
-			$python_nolog = 'on';
-		}
-
-		// ADR-07: opt-in "Limit long/complex regex" static cap (drops over-long /
-		// nested-quantifier patterns at load -- feed AND user regex). The always-on
-		// runtime warn/evict guard does not need a toggle; its ceilings default in
-		// Python (warn 10 ms / evict 100 ms) and are advanced-only knobs here.
-		$regex_cap = 'off';
-		if ($pfb['dnsbl_regex_cap'] === PfbToggle::On) {
-			$regex_cap = 'on';
-		}
-
-		// DNSBL Python decision-cache cap (LRU); WebUI-configurable, 0 = unlimited.
-		// Already validated + clamped (digits-only) in pfb_global().
-		$decisiondb_max = $pfb['dnsbl_decisiondb_max'] ?? '10000';
-
-		$forwarding = (config_get_path('unbound/forwarding') == 'on') ? 'on' : 'off';
-
-		$now = date('Y-m-d H:i:s', time());	// ISO-8601 (py_unbound.ini "File created" comment)
-
-		// issue #1155: fixed at 1 -- the min-segment optimization was computed-and-discarded
-		// in pfb_unbound_python_whitelist() since extraction; 1 is behaviourally identical
-		// (only wildcard entries can match the Python suffix walk it gates).
-		$pfb_py_conf = <<<EOF
-; pfBlockerNG DNSBL Unbound python configuration file
-; pfb_unbound.ini [ File created: {$now} ]
-[MAIN]
-dnsbl_ipv4	= {$pfb['dnsbl_vip4']}
-dnsbl_ipv6	= {$pfb['dnsbl_vip6']}
-python_enable	= {$python_enable}
-python_reply	= {$python_reply}
-python_blocking	= {$python_blocking}
-python_hsts	= {$python_hsts}
-python_tld_wildcard	= {$python_tld_wildcard}
-python_idn	= {$python_idn}
-idn_mode	= {$idn_mode}
-python_idn_block_malicious	= {$python_idn_block_malicious}
-python_idn_escalate_suspicious	= {$python_idn_escalate_suspicious}
-python_tld_seg	= 1
-decisiondb_max	= {$decisiondb_max}
-tld_allow	= {$tld_allow}
-tld_allow_list	= {$tld_allow_list}
-python_nolog	= {$python_nolog}
-python_cname	= {$python_cname}
-python_control	= {$python_control}
-python_control_legacy	= {$python_control_legacy}
-regex_cap	= {$regex_cap}
-forwarding	= {$forwarding}
-
-EOF;
-		if ($pfb['dnsbl_regex'] === PfbToggle::On && isset($pfb['dnsbl_regex_list']) && !empty($pfb['dnsbl_regex_list'])) {
-			$pfb_py_conf .= "regex_list = {$pfb['dnsbl_regex_list']}\n";
-		}
-
-		if ($pfb['dnsbl_noaaaa'] === PfbToggle::On && isset($pfb['dnsbl_noaaaa_list']) && !empty($pfb['dnsbl_noaaaa_list'])) {
-			$noaaaa = '';
-			$noaaaa_list = pfb_text_area_decode($pfb['dnsbl_noaaaa_list'], TRUE, TRUE, TRUE);
-			if (!empty($noaaaa_list)) {
-				foreach ($noaaaa_list as $key => $list) {
-					if (str_starts_with($list[0], '.')) {
-						$list[0] = pfb_strip_wildcard_marker($list[0], 'pfb_unbound_python noAAAA');
-						if (pfb_is_blank($list[0])) {
-							continue;
-						}
-						$noaaaa .= "{$key} = {$list[0]},1\n";
-					} else {
-						$noaaaa .= "{$key} = {$list[0]},0\n";
-					}
-				}
-				if (!pfb_is_blank($noaaaa)) {
-					$pfb_py_conf .= <<<EOF
-
-[noAAAA]
-{$noaaaa}
-EOF;
-				}
-			}
-		}
-
-		if ($pfb['dnsbl_gp'] === PfbToggle::On && isset($pfb['dnsbl_gp_bypass_list']) && !empty($pfb['dnsbl_gp_bypass_list'])) {
-			$gp_bypass = '';
-			$gp_bypass_list = pfb_text_area_decode($pfb['dnsbl_gp_bypass_list'], TRUE, TRUE, FALSE);
-			if (!empty($gp_bypass_list)) {
-				foreach ($gp_bypass_list as $key => $list) {
-					$gp_bypass .= "{$key} = {$list[0]}\n";
-				}
-				$pfb_py_conf .= <<<EOF
-
-[GP_Bypass_List]
-{$gp_bypass}
-EOF;
-			}
-		}
+		$now = date('Y-m-d H:i:s', time());
+		$pfb_py_conf = pfb_unbound_python_ini($mode, $now);
 
 		// Compare previous ini file to new ini (bypass file timestamp string)
 		$pfb_py_conf_ex		= @file_get_contents($pfb['unbound_py_conf']);
@@ -10152,8 +10275,11 @@ function pfb_dnsbl_manifest_failure_notice(): bool {
 // fast path (flip the reload sentinel, no restart). Any other case falls back to the restart
 // (fail-safe; PHP is the PRIMARY gate — never "flip and hope"). Returns TRUE only after the
 // applied-generation handshake; restart fallback returns FALSE.
-function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FALSE) {
+function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FALSE, ?callable $apply_ledger = NULL) {
 	global $g, $pfb;
+	$apply_ledger ??= static function (): bool {
+		return pfb_dnsbl_apply_ledger_update();
+	};
 
 	$final = array();
 	$type = '';
@@ -10196,7 +10322,7 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 					unlink_if_exists("{$pfb['dnsbl_file']}.sync");
 					// ADR-61: this swap just confirmed applied == sentinel -- a second,
 					// independent convergence point besides the restart path's completion.
-					$converged = pfb_dnsbl_apply_ledger_update();
+					$converged = $apply_ledger();
 					pfb_unbound_py_gc($converged);
 					return TRUE;
 				}
@@ -10301,7 +10427,7 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 	// a deliberate 'disabled' teardown clears any stale entry rather than flagging its
 	// own (expected) non-convergence as a failure.
 	if ($mode == 'enabled') {
-		$converged = pfb_dnsbl_apply_ledger_update();
+		$converged = $apply_ledger();
 		pfb_unbound_py_gc($converged);
 	} else {
 		pfb_sync_status_close('dnsbl', 'dnsbl', 'apply', $pfb['dbdir']);
@@ -10449,7 +10575,7 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython, array $dnsbl_tld_grou
 	// issue #1263: per-file sum, not cat|grep -c ^ -- differs from the old count
 	// when a stored feed lacks a trailing newline (the old command welded two
 	// records into one and undercounted); the sum is the correct total.
-	$dnsbl_cnt = pfb_dnsbl_feed_count($pfb['dnsdir']);
+	$dnsbl_cnt = pfb_update_unbound_feed_count($pfb['dnsdir']);
 
 	// ADR-06: pfb_py_count is now Python-emitted and means the LOADED entry total
 	// (len(dataDB)+len(zoneDB)), written by pfb_unbound.py dnsbl_emit_count(). The
@@ -12509,6 +12635,22 @@ function pfb_download_http_headers(array $extra_headers, string $conditional_hea
 	return $headers;
 }
 
+function pfb_download_finalize_text(
+	string $orig_download,
+	string $hash_base,
+	string $hash_path,
+	?callable $hash_write = NULL,
+	?callable $transcode = NULL,
+	?callable $newline = NULL
+): void {
+	$hash_write ??= 'pfb_hash_write';
+	$transcode ??= 'pfb_utf16_transcode_file';
+	$newline ??= 'pfb_ensure_trailing_newline';
+	$hash_write($hash_base, $hash_path);
+	$transcode($orig_download);
+	$newline($orig_download);
+}
+
 
 // Issue #1906: normalize an extras feed's download credentials for PfbDownloadRequest, whose
 // $username/$password are non-nullable strings. Each extras feed type carries its credentials
@@ -13054,7 +13196,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 
 		// issue #1158: fail-safe default -- with unset(), paths that assigned nothing fell
 		// through $retval == 0 as success
-		$retval = 1;
+		$retval = pfb_download_initial_retval();
 
 		// Validate File Mime-type
 		$reject_detail = array();
@@ -13128,7 +13270,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				}
 				exec("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1", $output, $retval);
 				unlink_if_exists($file_download);
-				if ($retval != 0) {
+				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] geoip extraction failed (tar exit {$retval})", 2);
 					return PfbDownloadResult::failure();
 				}
@@ -13136,7 +13278,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			}
 			elseif ($type == 'asn') {
 				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
-				if ($retval != 0) {
+				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] asn extraction failed (gunzip exit {$retval})", 2);
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
@@ -13159,7 +13301,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				}
 				$header_esc = escapeshellarg($top1m_stage);
 				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
-				if ($retval != 0) {
+				if (!pfb_download_extraction_succeeded($retval)) {
 					unlink_if_exists($file_download);
 					unlink_if_exists($top1m_stage);
 					pfb_logger("\n[pfb_download] top1m extraction failed (gunzip exit {$retval})", 2);
@@ -13276,7 +13418,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					}
 
 					// Create update file indicator for update process
-					if ($retval == 0) {
+					if (pfb_download_extraction_succeeded($retval)) {
 						touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
 					}
 				}
@@ -13335,7 +13477,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					// ADR-46: stdout extraction -- member names never reach the filesystem.
 					exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}", $output, $retval);
 				}
-				if ($retval != 0) {
+				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
@@ -13367,7 +13509,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				$header_esc = escapeshellarg($top1m_stage);
 				$strip = $top1m_target_dir ? ' --strip=1' : '';
 				exec("/usr/bin/tar -xf {$file_dwn_esc}{$strip} -C {$header_esc} >/dev/null 2>&1", $output, $retval);
-				if ($retval != 0) {
+				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
 					rmdir_recursive($top1m_stage);
 					unlink_if_exists($file_download);
@@ -13635,7 +13777,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			}
 		}
 
-		if ($retval == 0) {
+		if (pfb_download_retval_success($retval)) {
 			// Set downloaded file timestamp to remote timestamp
 			if (isset($remote_stamp) && $remote_stamp != -1) {
 				@touch("{$orig_download}", $remote_stamp);
@@ -13655,20 +13797,11 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// exact, not an approximation.  This covers both local and remote standard feeds
 			// (any path that finalises a plain .orig here).  The geoip/asn early-returns
 			// above do not reach this block, so they correctly never get a sidecar.
-			pfb_hash_write("{$orig_download}", pfb_source_hash_target($file_download, $orig_download));
-
-			// issue #946: transcode a UTF-16/UTF-32-BOM-marked feed to UTF-8 AFTER the
-			// hash sidecar above -- the sidecar hashes the RAW wire bytes (ADR-42), so
-			// transcoding first would make the persisted digest diverge from the
-			// change-probe's wire hash and re-ingest the feed every cron. No-op (FALSE,
-			// file untouched) for every feed that isn't UTF-16/32-BOM-marked.
-			pfb_utf16_transcode_file("{$orig_download}");
-
-			// issue #1263: guarantee a trailing newline on the STORED .orig -- after
-			// transcode (operates on final bytes) and after the hash write (ADR-42
-			// digest must stay over the untouched wire/raw body, same reasoning as
-			// the transcode-ordering comment above).
-			pfb_ensure_trailing_newline("{$orig_download}");
+			pfb_download_finalize_text(
+				"{$orig_download}",
+				"{$orig_download}",
+				pfb_source_hash_target($file_download, $orig_download)
+			);
 
 			// issue #1797: normalization deliberately does NOT run here. Only the
 			// parse-loop consumers normalize: the helper's changed-verdict means
@@ -17661,7 +17794,7 @@ function pfblockerng_php_pre_deinstall_command() {
 
 	update_status("Removing pfBlockerNG...");
 	sync_package_pfblockerng();
-	pfb_unbound_py_teardown_raw_set();
+	pfb_top1m_teardown_call();
 
 	// Live-object teardown always runs regardless of $pfb['keep'], so that uninstalling
 	// with the default keep=on still removes active pf tables, boot hooks, owned firewall

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -127,7 +127,7 @@ function pfb_ip_parse_line_replay(string $raw_line, array $config, int $line_num
 	];
 }
 
-function pfb_ip_recompute_order_scope(bool $save, bool $enabled, bool $dup_on, bool $drep_on,
+function pfb_ip_recompute_order_scope(mixed $save, bool $enabled, bool $dup_on, bool $drep_on,
     bool $prep_on): bool {
 	return !$save && $enabled && pfb_cross_list_scope($dup_on, $drep_on || $prep_on);
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -62,6 +62,168 @@ function pfb_top1m_refresh_needed(string $dbdir): bool {
 	return !file_exists("{$dbdir}/top-1m.csv") || !file_exists("{$dbdir}/top-1m.csv.zip.orig");
 }
 
+function pfb_download_ledger_failure(string $facility, string $alias, string $header, string $ledger_dir): void {
+	$message = "[ {$alias} - {$header} ] Download FAIL";
+	if ($facility === 'dnsbl') {
+		pfb_dnsbl_download_ledger_update(FALSE, $alias, $message, $ledger_dir);
+	} elseif ($facility === 'ip') {
+		pfb_ip_download_ledger_update(FALSE, $alias, $message, $ledger_dir);
+	}
+}
+
+function pfb_download_ledger_close_if_clean(string $facility, string $alias, bool $failed, string $ledger_dir): void {
+	if ($failed) {
+		return;
+	}
+	if ($facility === 'dnsbl') {
+		pfb_dnsbl_download_ledger_update(TRUE, $alias, '', $ledger_dir);
+	} elseif ($facility === 'ip') {
+		pfb_ip_download_ledger_update(TRUE, $alias, '', $ledger_dir);
+	}
+}
+
+/** @return array{range:string,ipv4:string,ipv6:string} */
+function pfb_ip_regex_config(): array {
+	return [
+		'range' => '/(?<![\w.])((?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))-((?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))(?![\w.])/',
+		'ipv4'  => '/(?<![\w.])(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)(?:\/(?:\d|[12]\d|3[0-2])(?![\w.\/]))?(?![\w.])/',
+		'ipv6'  => '/(?<![\w:.])(?:(?:(?:[[:xdigit:]]{1,4}:){7}(?:[[:xdigit:]]{1,4}|:))|(?:(?:[[:xdigit:]]{1,4}:){6}(?::[[:xdigit:]]{1,4}|(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[[:xdigit:]]{1,4}:){5}(?:(?:(?::[[:xdigit:]]{1,4}){1,2})|:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[[:xdigit:]]{1,4}:){4}(?:(?:(?::[[:xdigit:]]{1,4}){1,3})|(?:(?::[[:xdigit:]]{1,4})?:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[[:xdigit:]]{1,4}:){3}(?:(?:(?::[[:xdigit:]]{1,4}){1,4})|(?:(?::[[:xdigit:]]{1,4}){0,2}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[[:xdigit:]]{1,4}:){2}(?:(?:(?::[[:xdigit:]]{1,4}){1,5})|(?:(?::[[:xdigit:]]{1,4}){0,3}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[[:xdigit:]]{1,4}:){1}(?:(?:(?::[[:xdigit:]]{1,4}){1,6})|(?:(?::[[:xdigit:]]{1,4}){0,4}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?::(?:(?:(?::[[:xdigit:]]{1,4}){1,7})|(?:(?::[[:xdigit:]]{1,4}){0,5}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(?:%.+)?(?:\/(?:1(?:2[0-8]|[01]\d)|[1-9]?\d)(?![\w.\/]))?(?![\w:.])/',
+	];
+}
+
+function pfb_ip_regex_matches(string $family, string $line, array $config): array {
+	if ($family === 'v4') {
+		if (substr_count($line, '.') < 3) {
+			return [];
+		}
+		$pattern = $config['ipv4'];
+	} elseif ($family === 'v6') {
+		if (strpos($line, ':') === FALSE) {
+			return [];
+		}
+		$pattern = $config['ipv6'];
+	} else {
+		return [];
+	}
+	return preg_match_all($pattern, $line, $matches) ? $matches[0] : [];
+}
+
+/** @return array{line_number:int,raw_line:string,line:string,ip_data:string,ip_suppressed:bool,parse_fail:int,messages:list<string>,detailed_parse_fail:bool} */
+function pfb_ip_parse_line_replay(string $raw_line, array $config, int $line_number,
+    string $ip_data, bool $ip_suppressed, int $parse_fail): array {
+	$parsed = pfb_ip_parse_line($raw_line, $config);
+	foreach ($parsed['entries'] as $entry) {
+		$ip_data .= $entry . "\n";
+	}
+	return [
+		'line_number'       => $line_number + 1,
+		'raw_line'          => $raw_line,
+		'line'              => $parsed['line'],
+		'ip_data'           => $ip_data,
+		'ip_suppressed'     => $ip_suppressed || $parsed['suppressed'],
+		'parse_fail'        => $parse_fail + $parsed['parse_fail_delta'],
+		'messages'          => $parsed['messages'],
+		'detailed_parse_fail' => $parsed['detailed_parse_fail'],
+	];
+}
+
+function pfb_ip_recompute_order_scope(bool $save, bool $enabled, bool $dup_on, bool $drep_on,
+    bool $prep_on): bool {
+	return !$save && $enabled && pfb_cross_list_scope($dup_on, $drep_on || $prep_on);
+}
+
+function pfb_ip_recompute_order_families(bool $dup_on): array {
+	return $dup_on ? ['v4', 'v6'] : ['v4'];
+}
+
+function pfb_ip_recompute_mark_ran(string $family, callable $runner, bool &$ran_v4, bool &$ran_v6): void {
+	$runner();
+	if ($family === 'v4') {
+		$ran_v4 = TRUE;
+	} elseif ($family === 'v6') {
+		$ran_v6 = TRUE;
+	}
+}
+
+function pfb_dnsbl_alias_count_verbatim(string $path, int $current): int {
+	return $current + (pfb_count_lines($path) ?? 0);
+}
+
+function pfb_dnsbl_alias_count_norm_skip(string $path, int $current): int {
+	return $current + (pfb_count_lines($path) ?? 0);
+}
+
+function pfb_dnsbl_alias_count_script_failure(string $path, int $current): int {
+	return $current + (pfb_count_lines($path) ?? 0);
+}
+
+function pfb_dnsbl_alias_count_rebuild(string $path, int $current): int {
+	return $current + (pfb_count_lines($path) ?? 0);
+}
+
+/** @return array{header:string,custom:mixed,state:string,url:string} */
+function pfb_dnsbl_custom_row(string $aliasname, mixed $custom): array {
+	return [
+		'header' => "{$aliasname}_custom",
+		'custom' => $custom,
+		'state'  => 'Enabled',
+		'url'    => 'custom',
+	];
+}
+
+/** @return array{count:int,loggable:bool} */
+function pfb_dnsbl_ipv4_count_decision(string $path): array {
+	$count = pfb_count_lines($path) ?? 0;
+	return ['count' => $count, 'loggable' => $count > 0];
+}
+
+/** @return array{count:int,loggable:bool} */
+function pfb_dnsbl_ipv6_count_decision(string $path): array {
+	$count = pfb_count_lines($path) ?? 0;
+	return ['count' => $count, 'loggable' => $count > 0];
+}
+
+function pfb_apply_trailing_newline_ok(string $path): bool {
+	if (pfb_ensure_trailing_newline($path)) {
+		return TRUE;
+	}
+	$handle = @fopen($path, 'rb');
+	if ($handle === FALSE || @fseek($handle, -1, SEEK_END) !== 0) {
+		if (is_resource($handle)) {
+			fclose($handle);
+		}
+		return FALSE;
+	}
+	$last = @fread($handle, 1);
+	fclose($handle);
+	return $last === "\n";
+}
+
+function pfb_apply_geoip_orig_pipeline(string $source, string $orig, string $mirror,
+    ?callable $consumer = NULL): bool {
+	$renamed = @rename($source, $orig);
+	$normalized = pfb_apply_trailing_newline_ok($orig);
+	$mirrored = @copy($orig, $mirror);
+	if ($consumer !== NULL) {
+		$consumer($orig, $mirror);
+	}
+	return $renamed && $normalized && $mirrored;
+}
+
+function pfb_apply_gunzip_orig_pipeline(string $source, string $orig, ?callable $consumer = NULL): bool {
+	$retval = 1;
+	$normalized = FALSE;
+	if (file_exists($source)) {
+		$output = array();
+		exec('/usr/bin/gunzip -c ' . escapeshellarg($source) . ' > ' . escapeshellarg($orig), $output, $retval);
+		$normalized = pfb_apply_trailing_newline_ok($orig);
+	}
+	if ($consumer !== NULL) {
+		$consumer($orig);
+	}
+	return $retval === 0 && $normalized;
+}
+
 /**
  * Attempt the TOP1M provider fetch when either live source file is absent.
  * The optional fetcher is a no-network test seam; production uses the CLI command.
@@ -100,6 +262,14 @@ function pfb_top1m_reprocess_needed(string $dbdir): bool {
 	@fclose($handle);
 
 	return $first_byte === '.';
+}
+
+function pfb_top1m_apply_reprocess_if_ready(string $dbdir, callable $reprocess): bool {
+	if (!pfb_top1m_reprocess_needed($dbdir)) {
+		return FALSE;
+	}
+	$reprocess();
+	return TRUE;
 }
 
 /** Record the manifest publication outcome without logging a false completion. */
@@ -223,8 +393,9 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 			return $result;
 		}
 
-		if (substr_count($raw_line, '.') >= 3 && preg_match_all($config['ipv4'], $raw_line, $matches)) {
-			foreach (array_unique($matches[0]) as $match) {
+		$ipv4_matches = pfb_ip_regex_matches('v4', $raw_line, $config);
+		if (!empty($ipv4_matches)) {
+			foreach (array_unique($ipv4_matches) as $match) {
 				if (strpos($raw_line, 'cf-footer-item') === FALSE) {
 					$sanitized = pfb_sanitize_ipaddr($match, $custom, $pfbcidr, $suppression);
 					$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
@@ -286,8 +457,9 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 			}
 		}
 
-		if (strpos($raw_line, ':') !== FALSE && preg_match_all($config['ipv6'], $raw_line, $matches)) {
-			foreach (array_unique($matches[0]) as $match) {
+		$ipv6_matches = pfb_ip_regex_matches('v6', $raw_line, $config);
+		if (!empty($ipv6_matches)) {
+			foreach (array_unique($ipv6_matches) as $match) {
 				if (strpos($match, '#') !== FALSE) {
 					$match = str_replace('#', '', strstr($match, '#', TRUE));
 				}
@@ -325,13 +497,85 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
  * ordinary pass takes the verbatim-reuse fast path and never retries the
  * transform. The marker write is best-effort (@-suppressed): ledger
  * visibility must never depend on it succeeding. ADR-61 symmetric ownership:
- * the paired close is pfb_sync_status_close($facility, $item, 'script',
- * $ledger_dir) at the alias-pass end.
+ * the paired close is pfb_list_script_failure_close() at the alias-pass end.
  */
 function pfb_list_script_failure_record(string $facility, string $item, string $message,
-    string $ledger_dir, string $update_marker): void {
+    string $ledger_dir, string $update_marker, ?array &$state = NULL): void {
+	if ($state !== NULL) {
+		$state['failed'] = TRUE;
+	}
 	@touch($update_marker);
 	pfb_sync_status_open($facility, $item, 'script', $message, $ledger_dir);
+}
+
+function pfb_list_script_failure_close(string $facility, string $item, string $ledger_dir, array $state): void {
+	if (empty($state['failed'])) {
+		pfb_sync_status_close($facility, $item, 'script', $ledger_dir);
+	}
+}
+
+function pfb_ip_script_failure_close(string $item, string $ledger_dir, array $state): void {
+	pfb_list_script_failure_close('ip', $item, $ledger_dir, $state);
+}
+
+function pfb_dnsbl_script_failure_close(string $item, string $ledger_dir, array $state): void {
+	pfb_list_script_failure_close('dnsbl', $item, $ledger_dir, $state);
+}
+
+/** Record a failed pre-script and optionally retain its current staged manifest row. */
+function pfb_list_script_failure_continue(string $facility, string $item, string $message,
+    string $ledger_dir, string $update_marker, array &$state, bool $staging_current_generation,
+    string $staged_txt, ?callable $manifest = NULL): bool {
+	pfb_list_script_failure_record($facility, $item, $message, $ledger_dir, $update_marker, $state);
+	if ($staging_current_generation && file_exists($staged_txt) && $manifest !== NULL) {
+		$manifest();
+	}
+	return TRUE;
+}
+
+function pfb_ip_script_failure_continue(string $item, string $message, string $ledger_dir,
+    string $update_marker, array &$state, bool $staging_current_generation, string $staged_txt,
+    ?callable $manifest = NULL): bool {
+	return pfb_list_script_failure_continue('ip', $item, $message, $ledger_dir, $update_marker,
+	    $state, $staging_current_generation, $staged_txt, $manifest);
+}
+
+function pfb_dnsbl_script_failure_continue(string $item, string $message, string $ledger_dir,
+    string $update_marker, array &$state, bool $staging_current_generation, string $staged_txt,
+    ?callable $manifest = NULL): bool {
+	return pfb_list_script_failure_continue('dnsbl', $item, $message, $ledger_dir, $update_marker,
+	    $state, $staging_current_generation, $staged_txt, $manifest);
+}
+
+/** Consume a staged pre-script path, then remove transient and known copies. */
+function pfb_list_script_consume_staged(string $parse_path, ?string $staged_path, callable $consumer,
+    ?string $known_path = NULL): mixed {
+	try {
+		return $consumer($parse_path);
+	} finally {
+		if ($staged_path !== NULL && $parse_path === $staged_path) {
+			unlink_if_exists($staged_path);
+		}
+		if ($known_path !== NULL) {
+			unlink_if_exists($known_path);
+		}
+	}
+}
+
+function pfb_ip_script_consume_staged(string $parse_path, ?string $staged_path, callable $consumer,
+    ?string $known_path = NULL): mixed {
+	return pfb_list_script_consume_staged($parse_path, $staged_path, $consumer, $known_path);
+}
+
+function pfb_ip_script_probe_staged(bool $custom, string $parse_path, ?string $staged_path, callable $probe,
+    ?string $known_path = NULL): mixed {
+	return pfb_ip_script_consume_staged($parse_path, $staged_path,
+	    static fn (string $path): mixed => $custom ? NULL : $probe($path), $known_path);
+}
+
+function pfb_dnsbl_script_consume_staged(string $parse_path, ?string $staged_path, callable $consumer,
+    ?string $known_path = NULL): mixed {
+	return pfb_list_script_consume_staged($parse_path, $staged_path, $consumer, $known_path);
 }
 
 /**
@@ -359,11 +603,35 @@ function pfb_list_user_script_active($script_pre, $script_post): bool {
  * baseline -> stay on the fast path; there is no Hold-specific branch
  * anywhere. Sibling one-purpose `_active` predicates in this style:
  * pfb_ip_reuse_skip_active, pfb_dnsbl_verbatim_reuse_active,
- * pfb_supp_update_active. Both the DNSBL and IP loops call this ONCE per
- * row, keeping them in lock-step by construction.
+ * pfb_supp_update_active. The shared reuse-decision seam calls this once per
+ * row for both loops, keeping them in lock-step by construction.
  */
 function pfb_list_script_reparse_active(bool $verbatim_reuse_ok, bool $has_user_script, bool $orig_exists): bool {
 	return $verbatim_reuse_ok && $has_user_script && $orig_exists;
+}
+
+/** @return array{has_user_script:bool,orig_exists:bool,reparse:bool,verbatim:bool} */
+function pfb_list_script_reuse_decision(bool $verbatim_reuse_ok, $script_pre, $script_post,
+    string $orig_path): array {
+	$has_user_script = pfb_list_user_script_active($script_pre, $script_post);
+	$orig_exists = is_file($orig_path);
+	$reparse = pfb_list_script_reparse_active($verbatim_reuse_ok, $has_user_script, $orig_exists);
+	return [
+		'has_user_script' => $has_user_script,
+		'orig_exists'    => $orig_exists,
+		'reparse'        => $reparse,
+		'verbatim'       => $verbatim_reuse_ok && !$reparse,
+	];
+}
+
+function pfb_ip_script_reuse_decision(bool $verbatim_reuse_ok, $script_pre, $script_post,
+    string $orig_path): array {
+	return pfb_list_script_reuse_decision($verbatim_reuse_ok, $script_pre, $script_post, $orig_path);
+}
+
+function pfb_dnsbl_script_reuse_decision(bool $verbatim_reuse_ok, $script_pre, $script_post,
+    string $orig_path): array {
+	return pfb_list_script_reuse_decision($verbatim_reuse_ok, $script_pre, $script_post, $orig_path);
 }
 
 // Main pfBlockerNG function
@@ -837,11 +1105,7 @@ function sync_package_pfblockerng($cron='') {
 					}
 
 					if (!empty($list['custom'])) {
-						$list['row'][] = array( 'header'	=> "{$list['aliasname']}_custom",
-									'custom'	=> $list['custom'],
-									'state'		=> 'Enabled',
-									'url'		=> 'custom'
-									);
+						$list['row'][] = pfb_dnsbl_custom_row($list['aliasname'], $list['custom']);
 					}
 					$lists[] = $list;
 				}
@@ -1436,8 +1700,7 @@ function sync_package_pfblockerng($cron='') {
 				}
 
 				// Process TOP1M database
-				if (pfb_top1m_reprocess_needed($pfb['dbdir'])) {
-					pfblockerng_top1m();
+				if (pfb_top1m_apply_reprocess_if_ready($pfb['dbdir'], 'pfblockerng_top1m')) {
 					$pfb['reuse_dnsbl'] = 'on';
 					touch("{$pfb['dnsbl_file']}.reload");
 					pfb_logger("\n DNSBL - TOP1M changes found - Rebuilding!\n", 1);
@@ -1595,11 +1858,7 @@ function sync_package_pfblockerng($cron='') {
 				}
 
 				if (!empty($list['custom'])) {
-						$list['row'][] = array( 'header'	=> "{$list['aliasname']}_custom",
-												'custom'	=> $list['custom'],
-												'state'		=> 'Enabled',
-												'url'		=> 'custom'
-						);
+					$list['row'][] = pfb_dnsbl_custom_row($list['aliasname'], $list['custom']);
 				}
 
 				// Move DNSBL Group to primary position before the Blacklist settings
@@ -1625,9 +1884,8 @@ function sync_package_pfblockerng($cron='') {
 				// issue #1048: per-alias-pass failure flag -- a sibling feed's success must
 				// never close a DIFFERENT feed's still-open download-failure ledger entry.
 				$pfb_dl_failed		= FALSE;
-				// issue #1958: per-alias-pass script-failure flag -- a sibling feed's
-				// success must never close another feed's still-open script-failure entry.
-				$pfb_script_failed	= FALSE;
+				// issue #1958: per-alias-pass script state is independent for each alias.
+				$pfb_script_state = ['failed' => FALSE];
 
 				$alias = "DNSBL_{$list['aliasname']}";
 				if (empty(pfb_filter($alias, PFB_FILTER_WORD, 'DNSBL - Processes'))) {
@@ -1655,11 +1913,6 @@ function sync_package_pfblockerng($cron='') {
 					if (!empty($list['script_post'])) {
 						$pfb_dnsbl_script_post = pfb_resolve_list_script($list['script_post']);
 					}
-					// issue #1960: computed once per ALIAS (mirrors where the scripts
-					// are resolved above) -- must dominate both the verbatim fast path
-					// below and the later normalize/reuse-skip call it also gates.
-					$pfb_dnsbl_user_script = pfb_list_user_script_active($pfb_dnsbl_script_pre, $pfb_dnsbl_script_post);
-
 					foreach ($list['row'] as $key => $row) {
 						if (!empty($row['url']) && $row['state'] != 'Disabled') {
 
@@ -1743,10 +1996,13 @@ function sync_package_pfblockerng($cron='') {
 								file_exists("{$pfbfolder}/{$header}.fail"),
 								$reuse_unset,
 								$staging_current_generation);
-							$pfb_dnsbl_script_reparse = pfb_list_script_reparse_active($pfb_dnsbl_verbatim_reuse,
-								$pfb_dnsbl_user_script, file_exists("{$pfborig}/{$header}.orig"));
+							$pfb_dnsbl_reuse_decision = pfb_dnsbl_script_reuse_decision(
+								$pfb_dnsbl_verbatim_reuse, $pfb_dnsbl_script_pre, $pfb_dnsbl_script_post,
+								"{$pfborig}/{$header}.orig");
+							$pfb_dnsbl_user_script = $pfb_dnsbl_reuse_decision['has_user_script'];
+							$pfb_dnsbl_script_reparse = $pfb_dnsbl_reuse_decision['reparse'];
 
-							if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {
+							if ($pfb_dnsbl_reuse_decision['verbatim']) {
 
 
 								if ($row['state'] == 'Hold') {
@@ -1766,8 +2022,7 @@ function sync_package_pfblockerng($cron='') {
 									$mode);
 								// issue #1162/#1261: pfb_count_lines() returns NULL on a read
 								// failure -- 0 preserves the exec()-era fallback.
-								$list_cnt		= pfb_count_lines("{$pfbfolder}/{$header}.txt") ?? 0;
-								$alias_cnt		= $alias_cnt + $list_cnt;
+								$alias_cnt		= pfb_dnsbl_alias_count_verbatim("{$pfbfolder}/{$header}.txt", $alias_cnt);
 							}
 							else {
 								// #1083/#1960: this branch is entered when the fast-path check above
@@ -1859,7 +2114,7 @@ function sync_package_pfblockerng($cron='') {
 											// issue #1048: close moves to once-per-alias-pass below, so a
 											// sibling feed's success can never mask this failure.
 											$pfb_dl_failed = TRUE;
-											pfb_dnsbl_download_ledger_update(FALSE, $alias, "[ {$alias} - {$header} ] Download FAIL", $pfb['dbdir']);
+											pfb_download_ledger_failure('dnsbl', $alias, $header, $pfb['dbdir']);
 
 											// Utilize previously download file (If 'fail' marker exists)
 											if (file_exists("{$pfbfolder}/{$header}.fail") &&
@@ -1899,8 +2154,7 @@ function sync_package_pfblockerng($cron='') {
 										$header, $alias, $logging_type,
 										$custom ? 'user' : 'feed',
 										$mode);
-									$list_cnt		= pfb_count_lines("{$pfbfolder}/{$header}.txt") ?? 0;
-									$alias_cnt		= $alias_cnt + $list_cnt;
+									$alias_cnt		= pfb_dnsbl_alias_count_norm_skip("{$pfbfolder}/{$header}.txt", $alias_cnt);
 									unlink_if_exists("{$pfbfolder}/{$header}.update");
 									continue;
 								}
@@ -1909,6 +2163,7 @@ function sync_package_pfblockerng($cron='') {
 								// normalized output (#1925 shape); a failed transform keeps the
 								// last known-good staging and the '.update' marker for retry.
 								$pfb_parse_path = $pfb_norm['path'];
+								$pfb_staged_path = NULL;
 								if ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) {
 									pfb_logger("\nExecuting pre-script: {$list['script_pre']}\n", 1);
 									$pfb_pre = pfb_list_pre_script_run($pfb_norm['path'], "{$file_dwn}.pre",
@@ -1918,28 +2173,28 @@ function sync_package_pfblockerng($cron='') {
 										// issue #1958: pre-script failure genuinely served last-known-good --
 										// mark it in the ledger (distinct 'script' stage, never 'download') and
 										// retry the transform on the next ordinary pass via the '.update' marker.
-										pfb_list_script_failure_record('dnsbl', $alias,
+										pfb_dnsbl_script_failure_continue($alias,
 										    "[ {$alias} - {$header} ] Pre-script FAIL - serving last known-good",
-										    $pfb['dbdir'], "{$pfbfolder}/{$header}.update");
-										$pfb_script_failed = TRUE;
-										// #1083: a stale-generation '.txt' never re-enters the manifest.
-										if ($staging_current_generation && file_exists("{$pfbfolder}/{$header}.txt")) {
-											$lists_dnsbl_all[]	= "{$row['header']}.txt";
-											$pfb_py_feeds[]		= pfb_feed_manifest_row(
-												$header, $alias, $logging_type,
-												$custom ? 'user' : 'feed',
-												$mode);
-											$list_cnt		= pfb_count_lines("{$pfbfolder}/{$header}.txt") ?? 0;
-											$alias_cnt		= $alias_cnt + $list_cnt;
-										}
+										    $pfb['dbdir'], "{$pfbfolder}/{$header}.update", $pfb_script_state,
+										    $staging_current_generation, "{$pfbfolder}/{$header}.txt",
+										    static function () use (&$lists_dnsbl_all, &$pfb_py_feeds, &$alias_cnt,
+										        $row, $header, $alias, $logging_type, $custom, $mode, $pfbfolder): void {
+										        $lists_dnsbl_all[] = "{$row['header']}.txt";
+										        $pfb_py_feeds[] = pfb_feed_manifest_row(
+										            $header, $alias, $logging_type, $custom ? 'user' : 'feed', $mode);
+										        $alias_cnt = pfb_dnsbl_alias_count_script_failure("{$pfbfolder}/{$header}.txt", $alias_cnt);
+										    });
 										continue;
 									}
 									$pfb_parse_path = $pfb_pre['path'];
+									$pfb_staged_path = $pfb_pre['path'];
 								}
 
 								$run_once = $csv_parser = FALSE;
 								$csv_type = '';
 								$ipcount = $ip_cnt = $ip_cnt6 = 0;
+								$ip_decision = ['count' => 0, 'loggable' => FALSE];
+								$ip6_decision = ['count' => 0, 'loggable' => FALSE];
 								$pfb_scheme_skipped = 0;	// ADR-22: per-feed strict scheme/path skips
 								$dnsbl_lineno = 0;		// issue #1004: per-line counter for the parse-error detail sink
 
@@ -2174,7 +2429,19 @@ function sync_package_pfblockerng($cron='') {
 									@fclose($fhandle);
 								}
 								// issue #1926: the staged pre-script copy is transient -- parsed above.
-								unlink_if_exists("{$file_dwn}.pre");
+								pfb_dnsbl_script_consume_staged($pfb_parse_path, $pfb_staged_path,
+									static function (string $path) use ($pfb_staged_path): bool {
+										if ($pfb_staged_path === NULL) {
+											return TRUE;
+										}
+										$handle = @fopen($path, 'rb');
+										if ($handle === FALSE) {
+											return FALSE;
+										}
+										@fread($handle, 1);
+										@fclose($handle);
+										return TRUE;
+									}, "{$file_dwn}.pre");
 
 								// Close the "Reload . completed ." progress line with its trailing dot
 								// BEFORE the strict-parsing WARNING below, else the warning's own
@@ -2210,7 +2477,8 @@ function sync_package_pfblockerng($cron='') {
 									$domain_data_ip = implode("\n", array_unique($domain_data_ip)) . "\n";
 									@file_put_contents("{$pfbfolder}/{$header}_v4.ip", $domain_data_ip, LOCK_EX);
 									// issue #1261: display/log-gate only -- NULL (read failure) -> 0.
-									$ip_cnt = pfb_count_lines("{$pfbfolder}/{$header}_v4.ip") ?? 0;
+									$ip_decision = pfb_dnsbl_ipv4_count_decision("{$pfbfolder}/{$header}_v4.ip");
+									$ip_cnt = $ip_decision['count'];
 								}
 								else {
 									// Remove previous IP feed
@@ -2222,7 +2490,8 @@ function sync_package_pfblockerng($cron='') {
 									$domain_data_ip6 = implode("\n", array_unique($domain_data_ip6)) . "\n";
 									@file_put_contents("{$pfbfolder}/{$header}_v6.ip", $domain_data_ip6, LOCK_EX);
 									// issue #1261: display/log-gate only -- NULL (read failure) -> 0.
-									$ip_cnt6 = pfb_count_lines("{$pfbfolder}/{$header}_v6.ip") ?? 0;
+									$ip6_decision = pfb_dnsbl_ipv6_count_decision("{$pfbfolder}/{$header}_v6.ip");
+									$ip_cnt6 = $ip6_decision['count'];
 								}
 								else {
 									// Remove previous IPv6 feed
@@ -2246,10 +2515,10 @@ function sync_package_pfblockerng($cron='') {
 									// subdomains are matched by their parent zone -- so no
 									// build-time list pruning is performed here anymore.
 
-									if ($ip_cnt > 0) {
+									if ($ip_decision['loggable']) {
 										pfb_logger("  IPv4 count={$ip_cnt}\n", 1);
 									}
-									if ($ip_cnt6 > 0) {
+									if ($ip6_decision['loggable']) {
 										pfb_logger("  IPv6 count={$ip_cnt6}\n", 1);
 									}
 
@@ -2297,8 +2566,7 @@ function sync_package_pfblockerng($cron='') {
 
 								// issue #1162/#1261: pfb_count_lines() returns NULL on a read
 								// failure -- 0 preserves the exec()-era fallback.
-								$list_cnt	= pfb_count_lines("{$pfbfolder}/{$header}.txt") ?? 0;
-								$alias_cnt	= $alias_cnt + $list_cnt;
+								$alias_cnt	= pfb_dnsbl_alias_count_rebuild("{$pfbfolder}/{$header}.txt", $alias_cnt);
 
 								// Remove update file indicator -- skip if this row fell through to
 								// the stale-.orig download-failure fallback, else a pending rebuild
@@ -2313,15 +2581,11 @@ function sync_package_pfblockerng($cron='') {
 					// issue #1048: close the download ledger entry once for the WHOLE
 					// alias-pass, iff no row in it failed -- a per-row close let a later
 					// feed's success mask an earlier feed's still-live failure.
-					if (!$pfb_dl_failed) {
-						pfb_dnsbl_download_ledger_update(TRUE, $alias, '', $pfb['dbdir']);
-					}
+					pfb_download_ledger_close_if_clean('dnsbl', $alias, $pfb_dl_failed, $pfb['dbdir']);
 
 					// issue #1958: ADR-61 symmetric ownership -- close the 'script' stage
 					// entry once for the WHOLE alias-pass, iff no row's pre-script failed.
-					if (!$pfb_script_failed) {
-						pfb_sync_status_close('dnsbl', $alias, 'script', $pfb['dbdir']);
-					}
+					pfb_dnsbl_script_failure_close($alias, $pfb['dbdir'], $pfb_script_state);
 
 					// ADR-12: record GENUINELY-changed DNSBL groups for
 					// PFB_CHANGED_DNSBL_GROUPS. $pfb['aliasupdate'] is final for the
@@ -2540,7 +2804,7 @@ function sync_package_pfblockerng($cron='') {
 					@unlink($pfb_file);
 				}
 			}
-			pfb_unbound_py_teardown_raw_set();
+			pfb_top1m_teardown_call();
 		}
 	}
 
@@ -3037,24 +3301,17 @@ function sync_package_pfblockerng($cron='') {
 								$pfb_alias_lists[] = "{$cc_alias}";
 
 								if ($continent != 'md5_0') {
-									@rename("{$pfb['geoip_tmp']}", "{$pfborig}/{$cc_alias}.orig");
-									// issue #1263: this GeoIP continent builder writes '.orig'
-									// outside pfb_download(), bypassing its newline guarantee.
-									pfb_ensure_trailing_newline("{$pfborig}/{$cc_alias}.orig");
-									@copy("{$pfborig}/{$cc_alias}.orig", "{$pfbfolder}/{$cc_alias}.txt");
-
-									// Call Aggregate process
-									if ($pfb['agg'] === PfbToggle::On && $vtype == '_v4') {
-										exec("{$pfb['script']} cidr_aggregate {$cc_alias} {$pfbfolder} {$elog}");
-									}
-
-									// issue #1084: snapshot for the batch recompute memberlist -- replaces the
-									// 'continent' duplicate() exec. Both families: the v6 continent .txt above is
-									// regenerated on every GeoIP change same as v4, so its memberlist entry needs
-									// its own fresh snapshot too, not the one-time upgrade seed forever (#1084 review).
-									if ($pfbadv) {
-										pfb_ip_recompute_write_snapshot("{$pfbfolder}/{$cc_alias}.txt", $cc_alias, $pfb['snapdir'], $pfb['origdir']);
-									}
+									pfb_apply_geoip_orig_pipeline(
+										"{$pfb['geoip_tmp']}", "{$pfborig}/{$cc_alias}.orig", "{$pfbfolder}/{$cc_alias}.txt",
+										static function (string $orig, string $mirror) use ($pfb, $cc_alias, $vtype, $elog, $pfbadv, $pfbfolder): void {
+											if ($pfb['agg'] === PfbToggle::On && $vtype == '_v4') {
+												exec("{$pfb['script']} cidr_aggregate {$cc_alias} {$pfbfolder} {$elog}");
+											}
+											if ($pfbadv) {
+													pfb_ip_recompute_write_snapshot($mirror, $cc_alias, $pfb['snapdir'], $pfb['origdir']);
+											}
+										}
+									);
 
 									// Save Continent data to aliastable folder
 									@copy("{$pfbfolder}/{$cc_alias}.txt", "{$pfb['aliasdir']}/{$cc_alias}.txt");
@@ -3117,28 +3374,7 @@ function sync_package_pfblockerng($cron='') {
 	#	Download and Collect IPv4/IPv6 lists	#
 	#################################################
 
-	// IPv4 REGEX Definitions
-	// issue #1934: same [\w.] boundary classes as $pfb['ipv4'] below, so a
-	// garbage-adjacent endpoint (999.1.2.3.4-5.6.7.8) drops the range instead
-	// of expanding fabricated endpoints into a subnet span.
-	$pfb['range']	= '/(?<![\w.])((?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))-((?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?))(?![\w.])/';
-	// issue #1922: boundary class = word chars + the family's own separator
-	// ('.'), so a glued-on neighbour (v4.1.2.3.4, 999.1.2.3.4) drops instead of
-	// fabricating an address; the mask guard sits INSIDE the optional group so
-	// a URL path segment (84.38.133.113/1/webpanel) recovers the bare host
-	// while 1.2.3.4/bla, 1.2.3.4:8080 keep today's extraction. Never \b: it
-	// accepts foo.1.2.3.4 and holds before the '/' of a path segment.
-	// Contract pinned row-by-row by IpRegexBoundaryGuardTest.
-	$pfb['ipv4']	= '/(?<![\w.])(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)(?:\/(?:\d|[12]\d|3[0-2])(?![\w.\/]))?(?![\w.])/';
-
-	// IPv6 REGEX Definitions - Reference: http://labs.spritelink.net/regex
-	// issue #1922: v6 boundary class = [\w:.] (":" is the separator; "." too
-	// because IPv6 embeds IPv4, so ::ffff:1.2.3.4 parses whole instead of
-	// truncating to the accepted junk ::ffff:1). NEVER \b here: an address may
-	// START with ":" (a non-word char), so \b breaks ::1, :: and ::/0 outright,
-	// re-anchors x2001:db8::1 to the WRONG address db8::1. Same mask-internal
-	// guard as v4. Contract pinned row-by-row by IpRegexBoundaryGuardTest.
-	$pfb['ipv6'] = '/(?<![\w:.])(?:(?:(?:[[:xdigit:]]{1,4}:){7}(?:[[:xdigit:]]{1,4}|:))|(?:(?:[[:xdigit:]]{1,4}:){6}(?::[[:xdigit:]]{1,4}|(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[[:xdigit:]]{1,4}:){5}(?:(?:(?::[[:xdigit:]]{1,4}){1,2})|:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(?:(?:[[:xdigit:]]{1,4}:){4}(?:(?:(?::[[:xdigit:]]{1,4}){1,3})|(?:(?::[[:xdigit:]]{1,4})?:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[[:xdigit:]]{1,4}:){3}(?:(?:(?::[[:xdigit:]]{1,4}){1,4})|(?:(?::[[:xdigit:]]{1,4}){0,2}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[[:xdigit:]]{1,4}:){2}(?:(?:(?::[[:xdigit:]]{1,4}){1,5})|(?:(?::[[:xdigit:]]{1,4}){0,3}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?:(?:[[:xdigit:]]{1,4}:){1}(?:(?:(?::[[:xdigit:]]{1,4}){1,6})|(?:(?::[[:xdigit:]]{1,4}){0,4}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(?::(?:(?:(?::[[:xdigit:]]{1,4}){1,7})|(?:(?::[[:xdigit:]]{1,4}){0,5}:(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(?:%.+)?(?:\/(?:1(?:2[0-8]|[01]\d)|[1-9]?\d)(?![\w.\/]))?(?![\w:.])/';
+	[$pfb['range'], $pfb['ipv4'], $pfb['ipv6']] = array_values(pfb_ip_regex_config());
 
 	if ($pfb['enable'] === PfbToggle::On && !$pfb['save']) {
 
@@ -3173,11 +3409,7 @@ function sync_package_pfblockerng($cron='') {
 
 				if (!empty($list['custom'])) {
 					array_init_path($list, 'row');
-					$list['row'][] = array(	'header'	=> "{$list['aliasname']}_custom",
-											'custom'	=> $list['custom'],
-											'state'		=> 'Enabled',
-											'url'		=> 'custom'
-					);
+					$list['row'][] = pfb_dnsbl_custom_row($list['aliasname'], $list['custom']);
 				}
 				$lists[] = $list;
 			}
@@ -3222,9 +3454,8 @@ function sync_package_pfblockerng($cron='') {
 				// issue #1048: per-alias-pass failure flag -- a sibling feed's success must
 				// never close a DIFFERENT feed's still-open download-failure ledger entry.
 				$pfb_dl_failed = FALSE;
-				// issue #1958: per-alias-pass script-failure flag -- a sibling feed's
-				// success must never close another feed's still-open script-failure entry.
-				$pfb_script_failed = FALSE;
+				// issue #1958: per-alias-pass script state is independent for each alias.
+				$pfb_script_state = ['failed' => FALSE];
 
 				foreach	($list['row'] as $row) {
 					if (!empty($row['url']) && $row['state'] != 'Disabled') {
@@ -3298,11 +3529,6 @@ function sync_package_pfblockerng($cron='') {
 						if (isset($list['script_post']) && !empty($list['script_post'])) {
 							$pfb_script_post = pfb_resolve_list_script($list['script_post']);
 						}
-						// issue #1960: computed once per ROW (mirrors where the scripts are
-						// resolved above) -- must dominate both the verbatim fast path below
-						// and the later normalize/reuse-skip call it also gates.
-						$pfb_user_script = pfb_list_user_script_active($pfb_script_pre, $pfb_script_post);
-
 						// Determine 'list' details (return array $pfbarr)
 						if (isset($list['dnsblip'])) {
 							$list_type = 'pfblockerngdnsblsettings';
@@ -3340,10 +3566,13 @@ function sync_package_pfblockerng($cron='') {
 						    !file_exists("{$pfbfolder}/{$header}.update") &&
 						    !file_exists("{$pfbfolder}/{$header}.fail") &&
 						    $pfbreuse == '';
-						$pfb_script_reparse = pfb_list_script_reparse_active($pfb_ip_verbatim_reuse,
-						    $pfb_user_script, file_exists("{$pfborig}/{$header}.orig"));
+						$pfb_ip_reuse_decision = pfb_ip_script_reuse_decision(
+						    $pfb_ip_verbatim_reuse, $pfb_script_pre, $pfb_script_post,
+						    "{$pfborig}/{$header}.orig");
+						$pfb_user_script = $pfb_ip_reuse_decision['has_user_script'];
+						$pfb_script_reparse = $pfb_ip_reuse_decision['reparse'];
 
-						if ($pfb_ip_verbatim_reuse && !$pfb_script_reparse) {
+						if ($pfb_ip_reuse_decision['verbatim']) {
 
 							if ($row['state'] == 'Hold') {
 								$log = "\n[ {$header} ]{$logtab} static hold.";
@@ -3410,17 +3639,14 @@ function sync_package_pfblockerng($cron='') {
 									// File exists/reuse
 
 									// Process Emerging Threats IQRisk if required
-									if (strpos($row['url'], 'iprepdata.txt') !== FALSE) {
-										if (file_exists("{$file_dwn}.raw")) {
-											$file_dwn_esc = escapeshellarg("{$file_dwn}.raw");
-											$file_org_esc = escapeshellarg("{$file_dwn}.orig");
-											exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$file_org_esc}");
-											// issue #1263: this reuse path rebuilds '.orig' outside pfb_download(),
-											// bypassing its normal newline-termination guarantee.
-											pfb_ensure_trailing_newline("{$file_dwn}.orig");
+								if (strpos($row['url'], 'iprepdata.txt') !== FALSE) {
+									pfb_apply_gunzip_orig_pipeline(
+										"{$file_dwn}.raw", "{$file_dwn}.orig",
+										static function (string $orig) use ($pfb, $header_esc, $elog): void {
+											exec("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}");
 										}
-										exec("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}");
-									}
+									);
+								}
 								}
 								else {
 									// Download list
@@ -3449,7 +3675,7 @@ function sync_package_pfblockerng($cron='') {
 										// issue #1048: close moves to once-per-alias-pass below, so a
 										// sibling feed's success can never mask this failure.
 										$pfb_dl_failed = TRUE;
-										pfb_ip_download_ledger_update(FALSE, $alias, "[ {$alias} - {$header} ] Download FAIL", $pfb['dbdir']);
+											pfb_download_ledger_failure('ip', $alias, $header, $pfb['dbdir']);
 
 										// Utilize previously download file (If 'fail' marker exists)
 										if (file_exists("{$pfbfolder}/{$header}.fail") &&
@@ -3544,6 +3770,7 @@ function sync_package_pfblockerng($cron='') {
 							// normalized output -- '.orig' and '.norm' stay untouched; a
 							// failed transform keeps the last known-good staged list.
 							$pfb_parse_path = $pfb_norm['path'];
+							$pfb_staged_path = NULL;
 							if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {
 								pfb_logger("\nExecuting pre-script: {$list['script_pre']}\n", 1);
 								$pfb_pre = pfb_list_pre_script_run($pfb_norm['path'], "{$file_dwn}.pre",
@@ -3553,44 +3780,41 @@ function sync_package_pfblockerng($cron='') {
 									// issue #1958: pre-script failure genuinely served last-known-good --
 									// mark it in the ledger (distinct 'script' stage, never 'download') and
 									// retry the transform on the next ordinary pass via the '.update' marker.
-									pfb_list_script_failure_record('ip', $alias,
+									pfb_ip_script_failure_continue($alias,
 									    "[ {$alias} - {$header} ] Pre-script FAIL - serving last known-good",
-									    $pfb['dbdir'], "{$pfbfolder}/{$header}.update");
-									$pfb_script_failed = TRUE;
+									    $pfb['dbdir'], "{$pfbfolder}/{$header}.update", $pfb_script_state,
+									    FALSE, "{$pfbfolder}/{$header}.txt");
 									continue;
 								}
 								$pfb_parse_path = $pfb_pre['path'];
+								$pfb_staged_path = $pfb_pre['path'];
 							}
 
-							if (($fhandle = @fopen($pfb_parse_path, 'r')) !== FALSE) {
-								while (($line = @fgets($fhandle)) !== FALSE) {
-									// issue #1004: incremented every iteration, regardless of outcome
-									$ip_lineno++;
-
-									$raw_line = $line;
-									$parsed_line = pfb_ip_parse_line($raw_line, [
-										'vtype'         => $list['vtype'],
-										'pftype'        => $pftype,
-										'custom'        => $custom,
-										'cidr_floor_v4' => $pfbcidr,
-										'cidr_floor_v6' => $pfbcidr_v6,
-										'suppression'   => $pfb['supp'],
-										'range'         => $pfb['range'],
-										'ipv4'          => $pfb['ipv4'],
-										'ipv6'          => $pfb['ipv6'],
-									]);
-									$line = $parsed_line['line'];
-									foreach ($parsed_line['messages'] as $message) {
-										pfb_logger($message, 1);
-									}
-									foreach ($parsed_line['entries'] as $entry) {
-										$ip_data .= $entry . "\n";
-									}
-									$ip_suppressed = $ip_suppressed || $parsed_line['suppressed'];
-									$parse_fail += $parsed_line['parse_fail_delta'];
-									if ($parsed_line['detailed_parse_fail']) {
-										pfb_parse_fail_log($header, $line, $raw_line, $pfb['ip_parse_err'], $ip_lineno, TRUE);
-									}
+								if (($fhandle = @fopen($pfb_parse_path, 'r')) !== FALSE) {
+									while (($line = @fgets($fhandle)) !== FALSE) {
+										$raw_line = $line;
+										$replayed_line = pfb_ip_parse_line_replay($line, [
+											'vtype'         => $list['vtype'],
+											'pftype'        => $pftype,
+											'custom'        => $custom,
+											'cidr_floor_v4' => $pfbcidr,
+											'cidr_floor_v6' => $pfbcidr_v6,
+											'suppression'   => $pfb['supp'],
+											'range'         => $pfb['range'],
+											'ipv4'          => $pfb['ipv4'],
+											'ipv6'          => $pfb['ipv6'],
+										], $ip_lineno, $ip_data, $ip_suppressed, $parse_fail);
+										$ip_lineno    = $replayed_line['line_number'];
+										$line         = $replayed_line['line'];
+										$ip_data      = $replayed_line['ip_data'];
+										$ip_suppressed = $replayed_line['ip_suppressed'];
+										$parse_fail   = $replayed_line['parse_fail'];
+										foreach ($replayed_line['messages'] as $message) {
+											pfb_logger($message, 1);
+										}
+										if ($replayed_line['detailed_parse_fail']) {
+											pfb_parse_fail_log($header, $line, $replayed_line['raw_line'], $pfb['ip_parse_err'], $ip_lineno, TRUE);
+										}
 								}
 							}
 							if ($fhandle) {
@@ -3624,18 +3848,22 @@ function sync_package_pfblockerng($cron='') {
 								}
 							}
 
-							if (!$custom) {
-								// Check to see if list actually failed download or has no IPs listed.
-								// issue #1925: probe the content the parse consumed -- a pre-script
-								// synthesizes or reduces entries, so the raw download's emptiness is
-								// not the feed's (post-script-only feeds still probe '.orig').
-								$pfb_probe = ($pfb_parse_path === $pfb_norm['path']) ? "{$file_dwn}.orig" : $pfb_parse_path;
-								$file_chk = '';
-								if (file_exists($pfb_probe) && @filesize($pfb_probe) > 0) {
-									$file_chk = exec("{$pfb['grep']} -cv '^#\|^\$' " . escapeshellarg($pfb_probe));
-								}
+							// Check to see if list actually failed download or has no IPs listed.
+							// issue #1925: probe the content the parse consumed -- a pre-script
+							// synthesizes or reduces entries, so the raw download's emptiness is
+							// not the feed's (post-script-only feeds still probe '.orig'). Custom
+							// rows skip the probe but still discard their transient staged copy.
+							$file_chk = pfb_ip_script_probe_staged(
+								$custom, $pfb_parse_path, $pfb_staged_path,
+								static function (string $parse_path) use ($pfb, $pfb_norm, $file_dwn): string {
+										$pfb_probe = ($parse_path === $pfb_norm['path']) ? "{$file_dwn}.orig" : $parse_path;
+										if (file_exists($pfb_probe) && @filesize($pfb_probe) > 0) {
+											return (string) exec("{$pfb['grep']} -cv '^#\|^\$' " . escapeshellarg($pfb_probe));
+										}
+										return '';
+									}, "{$file_dwn}.pre");
 
-								if ($file_chk == 0) {
+							if (!$custom && $file_chk == 0) {
 									if ($list['vtype'] == '_v6') {
 										$p_ip = "::{$pfb['ip_ph']}";
 									} else {
@@ -3645,12 +3873,7 @@ function sync_package_pfblockerng($cron='') {
 									$ip_data	= "{$p_ip}\n";
 									$log		= "  Empty file, Adding '{$p_ip}' to avoid download failure.\n";
 									pfb_logger("{$log}", 1);
-								}
 							}
-							// issue #1925: the staged pre-script copy is transient -- parsed and
-							// probed above.
-							unlink_if_exists("{$file_dwn}.pre");
-
 							// All parsed IPv6 entries were suppressed; replace the list with the IPv6
 							// placeholder so stale (previously-loaded) entries are not left in the alias.
 							if (empty($ip_data) && $ip_suppressed && $list['vtype'] == '_v6') {
@@ -3737,15 +3960,11 @@ function sync_package_pfblockerng($cron='') {
 				// issue #1048: close the download ledger entry once for the WHOLE
 				// alias-pass, iff no row in it failed -- a per-row close let a later
 				// feed's success mask an earlier feed's still-live failure.
-				if (!$pfb_dl_failed) {
-					pfb_ip_download_ledger_update(TRUE, $alias, '', $pfb['dbdir']);
-				}
+				pfb_download_ledger_close_if_clean('ip', $alias, $pfb_dl_failed, $pfb['dbdir']);
 
 				// issue #1958: ADR-61 symmetric ownership -- close the 'script' stage
 				// entry once for the WHOLE alias-pass, iff no row's pre-script failed.
-				if (!$pfb_script_failed) {
-					pfb_sync_status_close('ip', $alias, 'script', $pfb['dbdir']);
-				}
+				pfb_ip_script_failure_close($alias, $pfb['dbdir'], $pfb_script_state);
 			}
 		}
 	}
@@ -3761,12 +3980,14 @@ function sync_package_pfblockerng($cron='') {
 	// issue #1173: a pure priority reorder flips no feed-change repcheck; ownership
 	// follows memberlist order, so compare against the last recompute's memberlist and
 	// recompute on mismatch.
-	if (!$pfb['save'] && $pfb['enable'] === PfbToggle::On &&
-	    pfb_cross_list_scope($pfb['dup'] === PfbToggle::On, $pfb['drep'] === PfbToggle::On || $pfb['prep'] === PfbToggle::On)) {
-		foreach (array('v4', 'v6') as $pfb_rec_family) {
-			if ($pfb_rec_family === 'v6' && $pfb['dup'] !== PfbToggle::On) {
-				continue;
-			}
+	if (pfb_ip_recompute_order_scope(
+	    $pfb['save'],
+	    $pfb['enable'] === PfbToggle::On,
+	    $pfb['dup'] === PfbToggle::On,
+	    $pfb['drep'] === PfbToggle::On,
+	    $pfb['prep'] === PfbToggle::On
+	)) {
+		foreach (pfb_ip_recompute_order_families($pfb['dup'] === PfbToggle::On) as $pfb_rec_family) {
 			if (pfb_ip_recompute_order_changed(
 			    pfb_ip_recompute_family_headers($pfb['existing']['deny'] ?? [], $pfb_rec_family),
 			    $pfb['snapdir'],
@@ -3816,14 +4037,15 @@ function sync_package_pfblockerng($cron='') {
 		$pfb_rec_repmode = ($pfb_rec_family === 'v4') ? $pfb_rec_matrix['repmode'] : 'off';
 		$pfb_rec_max     = ($pfb_rec_repmode === 'dmax') ? $pfb['dmax'] : (($pfb_rec_repmode === 'pmax') ? $pfb['pmax'] : '0');
 
-		exec("{$pfb['script']} recompute {$pfb_rec_family} " . escapeshellarg($pfb_rec_memberlist) . ' ' . escapeshellarg($pfb_rec_countsfile)
-			. " {$pfb_rec_matrix['dedup']} {$pfb_rec_repmode} {$pfb_rec_max} {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} {$elog}");
-
-		if ($pfb_rec_family === 'v4') {
-			$pfb_recompute_ran_v4 = TRUE;
-		} else {
-			$pfb_recompute_ran_v6 = TRUE;
-		}
+		pfb_ip_recompute_mark_ran(
+			$pfb_rec_family,
+			static function () use ($pfb, $pfb_rec_family, $pfb_rec_memberlist, $pfb_rec_countsfile, $pfb_rec_matrix, $pfb_rec_repmode, $pfb_rec_max, $elog): void {
+				exec("{$pfb['script']} recompute {$pfb_rec_family} " . escapeshellarg($pfb_rec_memberlist) . ' ' . escapeshellarg($pfb_rec_countsfile)
+					. " {$pfb_rec_matrix['dedup']} {$pfb_rec_repmode} {$pfb_rec_max} {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} {$elog}");
+			},
+			$pfb_recompute_ran_v4,
+			$pfb_recompute_ran_v6
+		);
 	}
 
 	// Both dRep and pRep enabled: recompute already applied dMax (the matrix's tie-break)
@@ -3967,6 +4189,7 @@ function sync_package_pfblockerng($cron='') {
 									|| in_array($alias, $final_alias_old)
 									|| empty($pfctlck);
 								if (file_exists("{$pfbfolder}/{$header}.txt") && $member_eligible) {
+									$suppression_body_active = pfb_ip_suppress_body_for_vtype($pfb['supp'] === PfbToggle::On, $vtype, $pfb['supp_update'], $pfbadv, in_array($alias, $final_alias_old), $pfb_recompute_ran_v4, $pfb_recompute_ran_v6);
 									// Script to run suppression process (print header only)
 									if ($pfbrunonce && $pfb['supp'] === PfbToggle::On && $vtype == '_v4' && $pfb['supp_update']) {
 										exec("{$pfb['script']} suppress suppressheader {$elog}");
@@ -3975,7 +4198,7 @@ function sync_package_pfblockerng($cron='') {
 									// Script to run suppression process (body) — feed-changed aliases, OR any
 									// alias recompute rewrote this pass (issue #1084 review: recompute rewrites
 									// every family alias on any trigger, not just feed-changed ones).
-									if (pfb_ip_suppress_body_active($pfb['supp'] === PfbToggle::On, $vtype == '_v4', $pfb['supp_update'], $pfbadv, in_array($alias, $final_alias_old), $pfb_recompute_ran_v4)) {
+									if ($suppression_body_active && $vtype == '_v4') {
 										if ($pfb['dup'] === PfbToggle::On) {
 											exec("{$pfb['script']} suppress {$header_esc} {$pfbfolder} on {$elog}");
 										} else {
@@ -3997,7 +4220,7 @@ function sync_package_pfblockerng($cron='') {
 										@file_put_contents("{$pfb['log']}", $supp_v6_header, FILE_APPEND);
 										$pfbrunonce = FALSE;
 									}
-									if (pfb_ip_suppress_body_active($pfb['supp'] === PfbToggle::On, $vtype == '_v6', $pfb['supp_update'], $pfbadv, in_array($alias, $final_alias_old), $pfb_recompute_ran_v6)
+									if ($suppression_body_active && $vtype == '_v6'
 									    && is_readable("{$pfb['supptxt_v6']}") && filesize("{$pfb['supptxt_v6']}") > 0) {
 										$member_file = "{$pfbfolder}/{$header}.txt";
 										$pre_count   = count(@file($member_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: []);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -547,18 +547,24 @@ function pfb_dnsbl_script_failure_continue(string $item, string $message, string
 	    $state, $staging_current_generation, $staged_txt, $manifest);
 }
 
+/** Remove the transient staged path and known cleanup path after a list-script pass. */
+function pfb_list_script_cleanup_staged(string $parse_path, ?string $staged_path,
+    ?string $known_path = NULL): void {
+	if ($staged_path !== NULL && $parse_path === $staged_path) {
+		unlink_if_exists($staged_path);
+	}
+	if ($known_path !== NULL) {
+		unlink_if_exists($known_path);
+	}
+}
+
 /** Consume a staged pre-script path, then remove transient and known copies. */
 function pfb_list_script_consume_staged(string $parse_path, ?string $staged_path, callable $consumer,
     ?string $known_path = NULL): mixed {
 	try {
 		return $consumer($parse_path);
 	} finally {
-		if ($staged_path !== NULL && $parse_path === $staged_path) {
-			unlink_if_exists($staged_path);
-		}
-		if ($known_path !== NULL) {
-			unlink_if_exists($known_path);
-		}
+		pfb_list_script_cleanup_staged($parse_path, $staged_path, $known_path);
 	}
 }
 
@@ -2429,19 +2435,7 @@ function sync_package_pfblockerng($cron='') {
 									@fclose($fhandle);
 								}
 								// issue #1926: the staged pre-script copy is transient -- parsed above.
-								pfb_dnsbl_script_consume_staged($pfb_parse_path, $pfb_staged_path,
-									static function (string $path) use ($pfb_staged_path): bool {
-										if ($pfb_staged_path === NULL) {
-											return TRUE;
-										}
-										$handle = @fopen($path, 'rb');
-										if ($handle === FALSE) {
-											return FALSE;
-										}
-										@fread($handle, 1);
-										@fclose($handle);
-										return TRUE;
-									}, "{$file_dwn}.pre");
+								pfb_list_script_cleanup_staged($pfb_parse_path, $pfb_staged_path, "{$file_dwn}.pre");
 
 								// Close the "Reload . completed ." progress line with its trailing dot
 								// BEFORE the strict-parsing WARNING below, else the warning's own
@@ -3374,7 +3368,10 @@ function sync_package_pfblockerng($cron='') {
 	#	Download and Collect IPv4/IPv6 lists	#
 	#################################################
 
-	[$pfb['range'], $pfb['ipv4'], $pfb['ipv6']] = array_values(pfb_ip_regex_config());
+	$pfb_ip_regex = pfb_ip_regex_config();
+	$pfb['range'] = $pfb_ip_regex['range'];
+	$pfb['ipv4'] = $pfb_ip_regex['ipv4'];
+	$pfb['ipv6'] = $pfb_ip_regex['ipv6'];
 
 	if ($pfb['enable'] === PfbToggle::On && !$pfb['save']) {
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -361,6 +361,300 @@ function pfb_editor_enabled(): bool
 	return PfbConfig::read('gen/pfb_syntax_highlight') === PfbToggle::On;
 }
 
+function pfb_dnsbl_toggle_stored(mixed $posted): string
+{
+	return $posted === 'on' ? 'on' : 'off';
+}
+
+function pfb_dnsbl_toggle_enabled(mixed $stored): bool
+{
+	return pfb_cfg_toggle_read($stored) === PfbToggle::On;
+}
+
+function pfb_ip_suppression_stored(mixed $posted): string
+{
+	return $posted === 'on' ? 'on' : 'off';
+}
+
+function pfb_ip_suppression_enabled(mixed $stored): bool
+{
+	return pfb_cfg_toggle_read($stored) === PfbToggle::On;
+}
+
+/** Normalize the General-page editor checkbox to its persisted token. */
+function pfb_editor_toggle_stored_value(mixed $posted): string
+{
+	return $posted === 'on' ? 'on' : 'off';
+}
+
+/** Keep list-editor mounting independent from the row-reorder mode. */
+function pfb_editor_mount_lists_for_sort(array $fields, string $sort, bool $enabled): string
+{
+	return pfb_editor_mount_lists($fields, $enabled);
+}
+
+/** Label and help rendered for the General-page editor toggle. */
+function pfb_editor_toggle_label(): string
+{
+	return 'Advanced Text Editor';
+}
+
+function pfb_editor_toggle_help(): string
+{
+	return 'Client-side editor for the list and script fields (e.g. the DNSBL Regex '
+		. 'List, custom lists, IP suppression lists, hook scripts): syntax highlighting, '
+		. 'line numbers and undo/redo everywhere, plus inline linting on the DNSBL Regex '
+		. 'List and hook scripts. Unchecking this leaves those fields as plain text boxes '
+		. 'and skips loading the editor assets &mdash; useful for low-end client machines. '
+		. 'Validation always stays server-side either way.';
+}
+
+/** Render one CodeMirror asset tag when the Advanced Text Editor is enabled. */
+function pfb_editor_asset(string $asset, bool $enabled): string
+{
+	if (!$enabled) {
+		return '';
+	}
+
+	$asset = basename($asset);
+	return '<script src="vendor/codemirror/' . htmlspecialchars($asset, ENT_QUOTES, 'UTF-8')
+		. '?v=' . pfb_file_mtime('/usr/local/www/pfblockerng/vendor/codemirror/' . $asset)
+		. '"></script>';
+}
+
+/** Render the shared plain-list CodeMirror mount call. */
+function pfb_editor_mount_lists(array $fields, bool $enabled): string
+{
+	if (!$enabled) {
+		return '';
+	}
+
+	$fields = array_values(array_map('strval', $fields));
+	return "if (window.pfbCM) {\n\twindow.pfbCM.mountLists(" . json_encode($fields, JSON_THROW_ON_ERROR) . ");\n}";
+}
+
+/** Render the DNSBL regex-list CodeMirror mount, including live lint options. */
+function pfb_editor_mount_regex(bool $enabled): string
+{
+	if (!$enabled) {
+		return '';
+	}
+
+	return <<<'JS'
+var pfbRegexListEl = document.getElementById('pfb_regex_list');
+if (pfbRegexListEl && window.pfbCM) {
+	window.pfbCM.fromTextarea(pfbRegexListEl, {
+		lintUrl: '/pfblockerng/pfblockerng_lint.php',
+		lintExtraParams: function() {
+			var capEl = document.getElementById('pfb_regex_cap');
+			return { cap: (capEl && capEl.checked) ? '1' : '0' };
+		}
+	});
+}
+JS;
+}
+
+/** Render the hook editor mount using the server-selected language. */
+function pfb_editor_mount_hook(bool $enabled, string $language): string
+{
+	if (!$enabled) {
+		return '';
+	}
+
+	$language = htmlspecialchars($language, ENT_QUOTES, 'UTF-8');
+	return "var pfbHookEditorEl = document.getElementById('pfb_hook_editor_content');\n"
+		. "if (pfbHookEditorEl && window.pfbHooksCM) {\n"
+		. "\twindow.pfbHooksCM.fromTextarea(pfbHookEditorEl, '{$language}', {\n"
+		. "\t\tlintUrl: '/pfblockerng/pfblockerng_lint.php'\n"
+		. "\t});\n"
+		. "}";
+}
+
+/** Render a shipped JavaScript asset URL with the package mtime cache-buster. */
+function pfb_js_asset(string $src, string $path, string $attributes = ''): string
+{
+	return '<script src="' . htmlspecialchars($src, ENT_QUOTES, 'UTF-8')
+		. '?v=' . pfb_file_mtime($path) . '"' . $attributes . '></script>';
+}
+
+/** The DNSBL regex-list help shown by the Form_Textarea field. */
+function pfb_dnsbl_regex_help_text(): string
+{
+	return 'List of Regex\'s to block via DNSBL:<br /><br />
+		Enter a single regex per line.<br /><br />
+		End a line with "<strong>#</strong>" to give it a Description, as in&emsp;"regex (Regular Expression) # Regex Description".<br /><br />
+		The first <strong>unescaped</strong> "#" on the line starts the Description, whether or not a space precedes it. To match a literal "#" inside a pattern, escape it as "<strong>\\#</strong>".<br /><br />
+		Keep the Description to 15 characters or fewer — it is shown on the Alerts Tab, and a longer one is flagged in this editor. If no Description is entered a default Regex line number will be utilized.<br /><br />
+		This List is stored as \'Base64\' format in the config.xml file.<br /><br />
+		Changes to this option will require a Force Update to take effect.';
+}
+
+/** Whether regex validation must run for a save request. */
+function pfb_dnsbl_regex_validation_required(bool $interpreterUsable, mixed $featureToggle): bool
+{
+	return $interpreterUsable || $featureToggle === 'on';
+}
+
+/** Render the category editor pre-script help and select size for the current feed type. */
+function pfb_category_script_pre_settings(string $listPrefix, array $options): array
+{
+	$help = 'Pre-processing Shell script, run after download and charset normalization: '
+		. 'it receives a staged copy of the normalized feed text (UTF-8, control characters stripped, '
+		. 'lines right-trimmed) and rewrites that copy in place.<br />'
+		. 'Script location: /usr/local/pkg/pfblockerng/list_scripts/<strong>ip_pre_SCRIPT NAME.sh|py</strong> or <strong>dnsbl_pre_SCRIPT NAME.sh|py</strong>';
+	if ($listPrefix === 'dnsbl') {
+		$help .= '<br /><span class="text-danger">Note:</span>&nbsp;'
+			. 'A DNSBL pre-process script must not remove IP-shaped or ABP-shaped lines: the '
+			. 'DNSBLIP alias is synthesized from addresses extracted out of domain feeds, and '
+			. 'removed lines silently shrink it.';
+	}
+
+	return [
+		'help' => $help,
+		'size' => count($options) ?: '1',
+	];
+}
+
+/** Render the stable anchor/section layout shared by DNSBL, IP, widget, and log pages. */
+function pfb_page_anchor_layout(string $page): array
+{
+	return match ($page) {
+		'dnsbl' => [
+			'legacy_rows' => [],
+			'whitelist' => 'DNSBL_Whitelist_customlist',
+		],
+		'ip' => [
+			'legacy_rows' => [],
+			'suppression' => 'IPv4_Suppression_customlist',
+		],
+		'log' => [
+			'legacy_rows' => [],
+			'endofpage' => '<div id="endofpage"></div>',
+			'outside_form' => TRUE,
+		],
+		default => throw new InvalidArgumentException("unknown anchor layout: {$page}"),
+	};
+}
+
+// Page-specific render seams.  Pages keep their request handling and markup here,
+// while these small callables let the same shipped wiring be exercised without loading
+// a full pfSense request off-appliance.
+function pfb_dnsbl_editor_render(bool $enabled): array
+{
+	return [
+		'asset' => pfb_editor_asset('cm-regex.min.js', $enabled),
+		'regex' => pfb_editor_mount_regex($enabled),
+		'lists' => pfb_editor_mount_lists(['pfb_gp_bypass_list', 'pfb_noaaaa_list', 'whitelist', 'tld_wildcard_exclusion', 'tld_wildcard_blacklist'], $enabled),
+	];
+}
+
+function pfb_dnsbl_regex_help_render(): string
+{
+	return pfb_dnsbl_regex_help_text();
+}
+
+function pfb_dnsbl_regex_validation_required_page(bool $interpreterUsable, mixed $featureToggle): bool
+{
+	return pfb_dnsbl_regex_validation_required($interpreterUsable, $featureToggle);
+}
+
+function pfb_dnsbl_anchor_layout_render(): array
+{
+	return pfb_page_anchor_layout('dnsbl');
+}
+
+function pfb_dnsbl_js_asset_render(string $path = '/usr/local/www/pfblockerng/pfBlockerNG.js'): string
+{
+	return pfb_js_asset('pfBlockerNG.js', $path, ' type="text/javascript"');
+}
+
+function pfb_ip_editor_render(bool $enabled): array
+{
+	return [
+		'asset' => pfb_editor_asset('cm-regex.min.js', $enabled),
+		'lists' => pfb_editor_mount_lists(['v4suppression', 'v6suppression'], $enabled),
+	];
+}
+
+function pfb_ip_anchor_layout_render(): array
+{
+	return pfb_page_anchor_layout('ip');
+}
+
+function pfb_ip_js_asset_render(string $path = '/usr/local/www/pfblockerng/pfBlockerNG.js'): string
+{
+	return pfb_js_asset('pfBlockerNG.js', $path, ' type="text/javascript"');
+}
+
+function pfb_general_editor_render(bool $enabled): array
+{
+	return [
+		'asset' => pfb_editor_asset('cm-regex.min.js', $enabled),
+		'lists' => pfb_editor_mount_lists(['pfb_feed_internal_allowlist'], $enabled),
+	];
+}
+
+function pfb_general_toggle_stored_value(mixed $posted): string
+{
+	return pfb_editor_toggle_stored_value($posted);
+}
+
+function pfb_general_toggle_label(): string
+{
+	return pfb_editor_toggle_label();
+}
+
+function pfb_general_toggle_help(): string
+{
+	return pfb_editor_toggle_help();
+}
+
+function pfb_category_editor_render(bool $enabled, string $sort): array
+{
+	return [
+		'asset' => pfb_editor_asset('cm-regex.min.js', $enabled),
+		'mount' => pfb_editor_mount_lists_for_sort(['custom'], $sort, $enabled),
+	];
+}
+
+function pfb_category_script_pre_render(string $listPrefix, array $options): array
+{
+	return pfb_category_script_pre_settings($listPrefix, $options);
+}
+
+function pfb_category_edit_js_asset_render(string $path = '/usr/local/www/pfblockerng/pfBlockerNG.js'): string
+{
+	return pfb_js_asset('pfBlockerNG.js', $path, ' type="text/javascript"');
+}
+
+function pfb_hooks_editor_render(bool $enabled, string $language): array
+{
+	return [
+		'asset' => pfb_editor_asset('cm-hooks.min.js', $enabled),
+		'mount' => pfb_editor_mount_hook($enabled, $language),
+	];
+}
+
+function pfb_category_js_asset_render(string $path = '/usr/local/www/pfblockerng/pfBlockerNG.js'): string
+{
+	return pfb_js_asset('pfBlockerNG.js', $path, ' type="text/javascript"');
+}
+
+function pfb_geoip_js_asset_render(string $path = '/usr/local/www/pfblockerng/pfBlockerNG.js'): string
+{
+	return pfb_js_asset('pfBlockerNG.js', $path, ' type="text/javascript"');
+}
+
+function pfb_log_anchor_layout_render(): array
+{
+	return pfb_page_anchor_layout('log');
+}
+
+function pfb_widget_anchor_layout_render(string $page): array
+{
+	return pfb_page_anchor_layout($page);
+}
+
 /** Read a PfbToggle from a raw stored value. */
 function pfb_cfg_toggle_read(mixed $stored): PfbToggle
 {
@@ -5359,14 +5653,16 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
  * @param string $qtype     Informational only -- the matcher's decision ignores it.
  * @param float  $timeout_s Bounded-wait budget in seconds (a deadline AND a hard poll
  *                          cap both bound the wait -- CLAUDE.md "No orphaned waits").
+ * @param callable|null $now Monotonic clock seam for deterministic wait tests.
  * @return array{blocked:bool,b_type:string,group:string,b_eval:string,feed:string,p_type:string}|null
  *         The matcher's verdict, or NULL when none was obtained (invalid domain,
  *         request-encode, lock open/acquire, or write failure; timeout; or a malformed reply)
  *         -- callers must treat NULL and blocked=false identically ("no block"),
  *         never distinguish them.
  */
-function pfb_dnsbl_query(string $domain, string $qtype = 'A', float $timeout_s = 5.0): ?array {
+function pfb_dnsbl_query(string $domain, string $qtype = 'A', float $timeout_s = 5.0, ?callable $now = NULL): ?array {
 	global $pfb;
+	$now ??= static fn (): float => microtime(TRUE);
 
 	$channel    = "{$pfb['dnsbldir']}/pfb_py_query";
 	$reply_path = "{$pfb['dnsbldir']}/pfb_py_query.reply";
@@ -5388,7 +5684,7 @@ function pfb_dnsbl_query(string $domain, string $qtype = 'A', float $timeout_s =
 	// The two Lighttpd hit parsers share one request/reply slot. Serialize the
 	// complete transaction so neither can overwrite or clean up the other's files.
 	$wait_s    = max($timeout_s, 0.0);
-	$deadline  = microtime(TRUE) + $wait_s;
+	$deadline  = $now() + $wait_s;
 	$lock_path = "{$pfb['dnsbldir']}/pfb_py_query.lock";
 	$lock = is_dir($lock_path) ? FALSE : @fopen($lock_path, 'c');
 	if ($lock === FALSE) {
@@ -5403,7 +5699,7 @@ function pfb_dnsbl_query(string $domain, string $qtype = 'A', float $timeout_s =
 	do {
 		$allow_expired_attempt = $first_lock_attempt && $wait_s <= 0.0;
 		$first_lock_attempt = FALSE;
-		if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
+		if (!$allow_expired_attempt && $now() >= $deadline) {
 			break;
 		}
 		$would_block = 0;
@@ -5411,7 +5707,7 @@ function pfb_dnsbl_query(string $domain, string $qtype = 'A', float $timeout_s =
 			// A waiter can be descheduled between its deadline check and flock().
 			// Never publish after that budget expires; timeout=0 still gets one
 			// immediate non-blocking attempt.
-			if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
+			if (!$allow_expired_attempt && $now() >= $deadline) {
 				@flock($lock, LOCK_UN);
 				break;
 			}
@@ -5424,7 +5720,7 @@ function pfb_dnsbl_query(string $domain, string $qtype = 'A', float $timeout_s =
 			return NULL;
 		}
 		$lock_polls++;
-		$remaining_s = $deadline - microtime(TRUE);
+		$remaining_s = $deadline - $now();
 		if ($lock_polls >= $max_lock_polls || $remaining_s <= 0.0) {
 			break;
 		}
@@ -5456,7 +5752,7 @@ function pfb_dnsbl_query(string $domain, string $qtype = 'A', float $timeout_s =
 		do {
 			$allow_expired_poll = $first_poll && $wait_s <= 0.0;
 			$first_poll = FALSE;
-			if (!$allow_expired_poll && microtime(TRUE) >= $deadline) {
+			if (!$allow_expired_poll && $now() >= $deadline) {
 				break;
 			}
 			if (file_exists($reply_path)) {
@@ -5476,7 +5772,7 @@ function pfb_dnsbl_query(string $domain, string $qtype = 'A', float $timeout_s =
 					) {
 						// A reply that becomes readable after the shared deadline is
 						// late even if this process was descheduled while reading it.
-						if (!$allow_expired_poll && microtime(TRUE) >= $deadline) {
+						if (!$allow_expired_poll && $now() >= $deadline) {
 							break;
 						}
 						$verdict = array(
@@ -5492,7 +5788,7 @@ function pfb_dnsbl_query(string $domain, string $qtype = 'A', float $timeout_s =
 				}
 			}
 			$polls++;
-			$remaining_s = $deadline - microtime(TRUE);
+			$remaining_s = $deadline - $now();
 			if ($polls >= $max_polls || $remaining_s <= 0.0) {
 				break;
 			}
@@ -5709,6 +6005,44 @@ function pfb_hook_editor_lang_for(string $script, string $fallback): string {
 		}
 	}
 	return ($fallback === 'py') ? 'py' : 'sh';
+}
+
+/** Return the shared Update sub-tabs with the requested tab active. */
+function pfb_edit_hooks_tabs(string $active): array
+{
+	return [
+		[gettext('Run'), $active === 'run', '/pfblockerng/pfblockerng_update.php'],
+		[gettext('Hooks'), $active === 'hooks', '/pfblockerng/pfblockerng_hooks.php'],
+		[gettext('Edit Hooks'), $active === 'edit', '/pfblockerng/pfblockerng_edit_hooks.php'],
+	];
+}
+
+/** Shared warning content for the root-equivalent Edit Hooks surface. */
+function pfb_edit_hooks_warning(): array
+{
+	return [
+		'style' => 'danger',
+		'title' => 'Advanced Users Only',
+		'message' => 'The capabilities offered here can be dangerous. No support is available. Scripts you create or edit on this page run as ROOT during every pfBlockerNG update pass -- the same trust class as pfSense Diagnostics > Command Prompt / Edit File. Use them at your own risk!',
+	];
+}
+
+/** Return the redirect used when the page's secondary privilege gate refuses access. */
+function pfb_edit_hooks_access(bool $allowed): ?string
+{
+	return $allowed ? NULL : '/index.php';
+}
+
+/** Preserve form values exactly; Form_Input/Form_Textarea escape at render. */
+function pfb_edit_hooks_form_value(mixed $value): mixed
+{
+	return $value;
+}
+
+/** Native submit-field names used by the create/save buttons. */
+function pfb_edit_hooks_submit_field(string $action): string
+{
+	return in_array($action, ['create', 'save'], TRUE) ? 'pfb_eh_' . $action : '';
 }
 
 /*

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -461,10 +461,10 @@ function pfb_editor_mount_hook(bool $enabled, string $language): string
 		return '';
 	}
 
-	$language = htmlspecialchars($language, ENT_QUOTES, 'UTF-8');
+	$language = json_encode($language, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR);
 	return "var pfbHookEditorEl = document.getElementById('pfb_hook_editor_content');\n"
 		. "if (pfbHookEditorEl && window.pfbHooksCM) {\n"
-		. "\twindow.pfbHooksCM.fromTextarea(pfbHookEditorEl, '{$language}', {\n"
+		. "\twindow.pfbHooksCM.fromTextarea(pfbHookEditorEl, {$language}, {\n"
 		. "\t\tlintUrl: '/pfblockerng/pfblockerng_lint.php'\n"
 		. "\t});\n"
 		. "}";
@@ -6017,13 +6017,23 @@ function pfb_edit_hooks_tabs(string $active): array
 	];
 }
 
+/** Build the default Edit Hooks request state, with an optional redirect. */
+function pfb_edit_hooks_default_state(?string $redirect = NULL): array
+{
+	return [
+		'errors' => [], 'sel_when' => '', 'sel_script' => '', 'content' => '',
+		'new_core' => '', 'new_lang' => 'sh', 'new_when' => '', 'notice' => NULL,
+		'redirect' => $redirect,
+	];
+}
+
 /** Shared warning content for the root-equivalent Edit Hooks surface. */
 function pfb_edit_hooks_warning(): array
 {
 	return [
 		'style' => 'danger',
-		'title' => 'Advanced Users Only',
-		'message' => 'The capabilities offered here can be dangerous. No support is available. Scripts you create or edit on this page run as ROOT during every pfBlockerNG update pass -- the same trust class as pfSense Diagnostics > Command Prompt / Edit File. Use them at your own risk!',
+		'title' => gettext('Advanced Users Only'),
+		'message' => gettext('The capabilities offered here can be dangerous. No support is available. Scripts you create or edit on this page run as ROOT during every pfBlockerNG update pass -- the same trust class as pfSense Diagnostics > Command Prompt / Edit File. Use them at your own risk!'),
 	];
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
@@ -503,8 +503,7 @@ $section->addInput(new Form_StaticText(
 	'NOTES:',
 	'GeoIP data by MaxMind Inc. - GeoLite2<br />'
 	. 'Click here for IMPORTANT info&emsp;-->&emsp;'
-	. '<a target="_blank" rel="noopener noreferrer" href="https://dev.maxmind.com/geoip/whats-new-in-geoip2/">'
-	. '<span class="text-danger"><strong>What\'s new in GeoIP2</strong></span></a>'
+	. pfb_geoip_doc_link()
 
 	. '<hr style="height: 1px; border: none; background-color: #d6d6d6;"/>'
 
@@ -752,7 +751,7 @@ events.push(function() {
 
 //]]
 </script>
-<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
+<?=pfb_geoip_js_asset_render()?>
 <?php include('foot.inc');?>
 
 EOF;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc
@@ -55,11 +55,7 @@ function pfb_edit_hooks_controller(bool $allowed, callable $post, callable $get,
 {
 	$redirect = pfb_edit_hooks_access($allowed);
 	if ($redirect !== NULL) {
-		return [
-			'errors' => [], 'sel_when' => '', 'sel_script' => '', 'content' => '',
-			'new_core' => '', 'new_lang' => 'sh', 'new_when' => '', 'notice' => NULL,
-			'redirect' => $redirect,
-		];
+		return pfb_edit_hooks_default_state($redirect);
 	}
 
 	return pfb_edit_hooks_request((array) $post(), (array) $get(), $dir);
@@ -68,11 +64,7 @@ function pfb_edit_hooks_controller(bool $allowed, callable $post, callable $get,
 /** Shared Edit Hooks request path; returns state plus a PRG redirect when complete. */
 function pfb_edit_hooks_request(array $post, array $get, ?string $dir = null): array
 {
-	$state = [
-		'errors' => [], 'sel_when' => '', 'sel_script' => '', 'content' => '',
-		'new_core' => '', 'new_lang' => 'sh', 'new_when' => '', 'notice' => NULL,
-		'redirect' => NULL,
-	];
+	$state = pfb_edit_hooks_default_state();
 	if (!$post) {
 		if (isset($get['saved'])) {
 			$state['notice'] = gettext('Hook script saved.');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc
@@ -50,6 +50,131 @@
 // a real property, and it is a different claim from "every gate is individually
 // load-bearing" -- which mutation testing disproves.
 
+/** Check access before invoking the request callbacks or touching request data. */
+function pfb_edit_hooks_controller(bool $allowed, callable $post, callable $get, ?string $dir = null): array
+{
+	$redirect = pfb_edit_hooks_access($allowed);
+	if ($redirect !== NULL) {
+		return [
+			'errors' => [], 'sel_when' => '', 'sel_script' => '', 'content' => '',
+			'new_core' => '', 'new_lang' => 'sh', 'new_when' => '', 'notice' => NULL,
+			'redirect' => $redirect,
+		];
+	}
+
+	return pfb_edit_hooks_request((array) $post(), (array) $get(), $dir);
+}
+
+/** Shared Edit Hooks request path; returns state plus a PRG redirect when complete. */
+function pfb_edit_hooks_request(array $post, array $get, ?string $dir = null): array
+{
+	$state = [
+		'errors' => [], 'sel_when' => '', 'sel_script' => '', 'content' => '',
+		'new_core' => '', 'new_lang' => 'sh', 'new_when' => '', 'notice' => NULL,
+		'redirect' => NULL,
+	];
+	if (!$post) {
+		if (isset($get['saved'])) {
+			$state['notice'] = gettext('Hook script saved.');
+		} elseif (!empty($get['deleted'])) {
+			$state['notice'] = gettext('Hook script deleted.');
+		}
+	}
+
+	if ($post) {
+		if (isset($post['pfb_eh_create'])) {
+			$post_when = (string) ($post['pfb_eh_new_when'] ?? '');
+			$post_core = (string) ($post['pfb_eh_new_core'] ?? '');
+			$post_lang = (string) ($post['pfb_eh_new_lang'] ?? '');
+			$filename = pfb_hook_editor_compose_filename($post_when, $post_core, $post_lang);
+			$path = ($filename !== NULL) ? pfb_hook_editor_path($filename, $dir) : NULL;
+			if ($filename === NULL || $path === NULL) {
+				$state['errors'][] = gettext('Invalid new-hook fields: When must be Pre/Post, Name must be letters, digits, and underscores only, and Language must be Shell or Python.');
+			} else {
+				$handle = @fopen($path, 'x');
+				if ($handle === FALSE) {
+					$state['errors'][] = gettext('A hook script with that composed name already exists, or the hook-script directory is not writable -- pick a different Name.');
+				} else {
+					$template = pfb_hook_editor_template($post_when, $post_lang);
+					$written = @fwrite($handle, $template);
+					@fclose($handle);
+					if ($written !== strlen($template) || !@chmod($path, 0700)) {
+						@unlink($path);
+						$state['errors'][] = gettext('Failed to write the hook script file -- check that the hook-script directory is writable.');
+					} else {
+						$state['redirect'] = '/pfblockerng/pfblockerng_edit_hooks.php?' . http_build_query(['when' => $post_when, 'script' => $filename]);
+						return $state;
+					}
+				}
+			}
+			$state['new_core'] = $post_core;
+			$state['new_lang'] = $post_lang === 'py' ? 'py' : 'sh';
+			$state['new_when'] = $post_when;
+			$state['sel_when'] = (string) ($post['pfb_eh_cur_when'] ?? '');
+			$state['sel_script'] = (string) ($post['pfb_eh_cur_script'] ?? '');
+			$state['content'] = pfb_sanitize_text_area((string) ($post['pfb_eh_content'] ?? ''));
+		} elseif (isset($post['pfb_eh_delete']) && $post['pfb_eh_delete'] !== '') {
+			$post_when = (string) ($post['pfb_eh_del_when'] ?? '');
+			$post_script = (string) ($post['pfb_eh_del_script'] ?? '');
+			if (pfb_hook_editor_delete($post_script, $post_when, $dir)) {
+				$state['redirect'] = '/pfblockerng/pfblockerng_edit_hooks.php?' . http_build_query(['deleted' => $post_script]);
+				return $state;
+			}
+			$state['errors'][] = gettext('That hook script could not be deleted -- reload the page and try again (it may already be gone, or the hook-script directory may not be writable).');
+			$state['sel_when'] = (string) ($post['pfb_eh_cur_when'] ?? '');
+			$state['sel_script'] = (string) ($post['pfb_eh_cur_script'] ?? '');
+			$state['content'] = pfb_sanitize_text_area((string) ($post['pfb_eh_content'] ?? ''));
+		} elseif (isset($post['pfb_eh_save'])) {
+			$post_when = (string) ($post['pfb_eh_cur_when'] ?? '');
+			$post_script = (string) ($post['pfb_eh_cur_script'] ?? '');
+			$post_content = pfb_sanitize_text_area((string) ($post['pfb_eh_content'] ?? ''));
+			if (!pfb_hook_script_valid($post_script, $post_when, $dir)) {
+				$state['errors'][] = gettext('Select a valid, existing hook script for this Pre/Post before saving (load it from the picker above first).');
+			} else {
+				$path = pfb_hook_editor_path($post_script, $dir);
+				if ($path === NULL || !is_file($path)) {
+					$state['errors'][] = gettext('The selected hook script could not be resolved on disk.');
+				} else {
+					$tmp = @tempnam(dirname($path), '.pfbeh_');
+					$written = $tmp !== FALSE ? @file_put_contents($tmp, $post_content) : FALSE;
+					if ($tmp === FALSE || $written !== strlen($post_content) || !@chmod($tmp, 0700) || !@rename($tmp, $path)) {
+						if ($tmp !== FALSE) {
+							@unlink($tmp);
+						}
+						$state['errors'][] = gettext('Failed to save the hook script file -- check that the hook-script directory is writable.');
+					} else {
+						$state['redirect'] = '/pfblockerng/pfblockerng_edit_hooks.php?' . http_build_query(['when' => $post_when, 'script' => $post_script, 'saved' => '1']);
+						return $state;
+					}
+				}
+			}
+			$state['sel_when'] = $post_when;
+			$state['sel_script'] = $post_script;
+			$state['content'] = $post_content;
+		}
+	} elseif (isset($get['when'], $get['script'])) {
+		$get_when = (string) $get['when'];
+		$get_script = (string) $get['script'];
+		if (pfb_hook_script_valid($get_script, $get_when, $dir)) {
+			$path = pfb_hook_editor_path($get_script, $dir);
+			$body = ($path !== NULL && is_file($path)) ? @file_get_contents($path) : FALSE;
+			if ($body === FALSE) {
+				$state['errors'][] = gettext('Failed to read the selected hook script.');
+			} elseif (!mb_check_encoding($body, 'UTF-8')) {
+				$state['errors'][] = gettext('The selected hook script file is not valid UTF-8 -- fix it on disk before editing it here (loading it into this editor would corrupt invalid byte sequences on display).');
+			} else {
+				$state['sel_when'] = $get_when;
+				$state['sel_script'] = $get_script;
+				$state['content'] = $body;
+			}
+		} else {
+			$state['errors'][] = gettext('That script is not a valid hook file for the selected Pre/Post.');
+		}
+	}
+
+	return $state;
+}
+
 /*
  * issue #1871: remove a hook script on behalf of the Edit Hooks page.
  *
@@ -69,13 +194,10 @@ function pfb_hook_editor_delete(string $script, string $when, ?string $dir = nul
 {
 	// GATE 1 -- PRIVILEGE, asserted here and not only at the page.
 	//
-	// This performs a root-privileged unlink(), and it lives in a file that
-	// pfblockerng.inc pulls into essentially every page of the package -- the
-	// alerts page, the dashboard, even the firewall_aliases_edit config hook all
-	// have this function in scope. The Edit Hooks page's own isAllowedPage() gate
-	// protects that page, not this operation: nothing stops a future caller
-	// elsewhere from invoking the helper with no gate at all. Re-asserting the
-	// same privilege the hook editor demands (diag_command.php -- the
+	// This page-only helper performs a root-privileged unlink(). The Edit Hooks
+	// controller checks the page privilege too, but a future caller could invoke
+	// this destructive operation without that controller. Re-asserting the same
+	// privilege the hook editor demands (diag_command.php -- the
 	// shell-equivalent trust class, ADR-12) makes the authorization a property of
 	// the DELETION rather than of one call site.
 	//

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -26,31 +26,17 @@ require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 global $g, $pfb;
 pfb_global();
 
-// Capture the surviving live source family before restoring the package target family. Missing
-// markers resolve to the legacy 3.2 family through PfbConfig's registered default.
-$pfb_source_family = pfb_settings_family_current();
-if ($pfb_source_family === NULL || !pfb_settings_family_save($pfb_source_family)) {
-	throw new RuntimeException('pfBlockerNG: unable to save source settings family');
-}
-
-// Restore exact-family settings before legacy migrations read their sections. Missing slot is a
-// valid fresh install; unsupported package versions or corrupt slots fail closed.
-$pfb_installed_family = pfb_settings_family_from_version((string) pfb_pkg_ver());
-if ($pfb_installed_family === NULL || !pfb_settings_family_replace($pfb_installed_family)) {
-	throw new RuntimeException('pfBlockerNG: unable to restore settings family');
-}
+$pfb_installed_family = pfb_install_settings_family_capture_restore();
 pfb_global();
-
 // Set 'Install flag' to skip sync process during installations.
 $g['pfblockerng_install'] = TRUE;
+$pfb['hook_lifecycle'] = 'install';
 
 // #684: mark this process an install/upgrade so the resync (custom_php_resync_config_command,
 // run next in the same install_package_xml process) publishes PFB_POST_INSTALL=1 to the hooks its
 // turn-ON pass fires. Scoped to install.inc, so a boot/config-restore resync -- which does NOT run
 // this file -- carries PFB_POST_INSTALL=0 (the vars are always emitted as '1'/'0', #695). Context
 // only: pfBlockerNG never branches on it.
-$pfb['hook_lifecycle'] = 'install';
-
 // Migrate old VIP configuration.
 $pfb_dnsbl_config = PfbConfig::readSection('installedpackages/pfblockerngdnsblsettings/config/0');
 if (
@@ -134,11 +120,7 @@ if (
 // callable reads the section, returns the updated array or NULL (no-op), and the driver
 // writes back and calls write_config() only when a change is needed. Replaces the
 // hand-wired ADR-02/PFBL-03/#1898 blocks with a single ordered registry.
-pfb_run_migrations();
-
-if (!pfb_settings_family_record($pfb_installed_family)) {
-	throw new RuntimeException('pfBlockerNG: unable to record settings family');
-}
+pfb_install_settings_family_finalize($pfb_installed_family);
 
 // MaxMind Database is no longer pre-installed during package installation
 if (empty($pfb['maxmind_key'])) {
@@ -707,7 +689,7 @@ unlink_if_exists('/var/db/pfblockerng/dnsbl_info');
 
 // issue #1098: purge any leftover change-detect probe body ({header}.md5.raw) so a
 // pre-#1072 corrupted one is never reused verbatim by the next sync ingest.
-pfb_purge_probe_bodies();
+pfb_install_probe_cleanup();
 
 // Move dnsbl_levent.sqlite -> /var/unbound folder
 $ufound = FALSE;
@@ -938,16 +920,13 @@ $pfb_registry_sections = array();
 foreach (PFB_SECTIONS as $pfb_registry_section) {
 	$pfb_registry_sections[$pfb_registry_section] = PfbConfig::readSection($pfb_registry_section);
 }
-foreach (pfb_registry_pass($pfb_registry_sections) as $pfb_registry_path => $pfb_registry_blob) {
-	PfbConfig::writeSectionSystem($pfb_registry_path, $pfb_registry_blob);
-}
-unset($pfb_registry_sections, $pfb_registry_section, $pfb_registry_path, $pfb_registry_blob);
+pfb_install_registry_writeback($pfb_registry_sections);
+unset($pfb_registry_sections, $pfb_registry_section);
 update_status(" done.\n");
 
 unset($g['pfblockerng_install']);	// Remove 'Install flag'
 update_status("Upgrading... done\n\nCustom commands completed ... ");
 
-write_config('[pfBlockerNG] Save installation settings');
 return TRUE;
 
 ?>

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -1173,7 +1173,6 @@ function pfblockerng_uc_countries() {
 						if (!empty($geoip['continent_en']) && !empty(pfb_filter($geoip['continent_en'], PFB_FILTER_WORD, 'php'))) {
 
 							$pfb_file	= "{$pfb['ccdir']}/{$geoip['continent_en']}_v{$type}.txt";
-							$pfb_file_esc	= escapeshellarg($pfb_file);
 
 							if (!file_exists($pfb_file)) {
 								$header  = '# Generated from MaxMind Inc. on: ' . date('Y-m-d H:i:s', time()) . "\n";
@@ -1187,33 +1186,17 @@ function pfblockerng_uc_countries() {
 									if (!empty(pfb_filter($iso, PFB_FILTER_WORD, 'php'))) {
 
 										$iso_file	= "{$pfb['ccdir_tmp']}/{$iso}_v{$type}.txt";
-										$iso_file_esc	= escapeshellarg($iso_file);
 										$geoip_id = '';
 										if (!empty($geoip['id'])) {
 											$geoip_id = " [{$geoip['id']}]";
 										}
 
 										if (file_exists($iso_file)) {
-											// issue #1261: NULL (read failure) -> 'ERROR', not 0 -- "0" trips the
-											// placeholder-blank branch below and would empty a country's list on
-											// a transient read error.
-											$networks = pfb_count_lines($iso_file) ?? 'ERROR';
-											$iso_header  = "# Country: {$geoip['name']}{$geoip_id}\n";
-											$iso_header .= "# ISO Code: {$iso}\n";
-											$iso_header .= "# Total Networks: {$networks}\n";
+											$iso_header = pfb_geoip_networks_header($iso_file, $geoip['name'], $geoip_id, $iso);
 											@file_put_contents($pfb_file, $iso_header, FILE_APPEND | LOCK_EX);
 
 											// Concat ISO Networks to Continent file
-											// issue #1299: no 2>&1 -- merging cat's stderr into this
-											// data file lets a cat failure corrupt it on reparse.
-											$cat_output = array();
-											$cat_status = 0;
-											exec("{$pfb['cat']} {$iso_file_esc} >> {$pfb_file_esc}", $cat_output, $cat_status);
-											if ($cat_status !== 0) {
-												$log = "\n Failed to append ISO data [ {$iso} IPv{$type} ] (cat status {$cat_status})\n";
-												pfb_logger("{$log}", 4);
-												@unlink($pfb_file);
-												rmdir_recursive("{$pfb['ccdir_tmp']}");
+											if (!pfb_geoip_append_iso_data($pfb['cat'], $iso_file, $pfb_file, $pfb['ccdir_tmp'], $iso, $type)) {
 												return FALSE;
 											}
 										}

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -712,5 +712,5 @@ events.push(function() {
 
 //]]>
 </script>
-<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
+<?=pfb_category_js_asset_render()?>
 <?php include('foot.inc');?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -380,14 +380,7 @@ if (is_dir("{$indexdir}")) {
 	}
 }
 $options_script_pre		= array_merge(array('' => 'None'), $options_script_pre);
-$options_script_pre_cnt		= count($options_script_pre) ?: '1';
-
-// issue #1926: the DNSBLIP alias is synthesized from addresses extracted out of
-// domain feeds -- a pre-script that removes IP/ABP-shaped lines silently shrinks it.
-$script_dnsbl_note = ($list_prefix == 'dnsbl') ? "<br /><span class=\"text-danger\">Note:</span>&nbsp;"
-	. "A DNSBL pre-process script must not remove IP-shaped or ABP-shaped lines: the "
-	. "DNSBLIP alias is synthesized from addresses extracted out of domain feeds, and "
-	. "removed lines silently shrink it." : '';
+$script_pre_settings = pfb_category_script_pre_render($list_prefix, $options_script_pre);
 
 $options_script_post		= array_merge(array('' => 'None'), $options_script_post);
 $options_script_post_cnt	= count($options_script_post) ?: '1';
@@ -1675,13 +1668,9 @@ $section->addInput(new Form_Select(
 	'Pre-process Script',
 	$pconfig['script_pre'],
 	$options_script_pre
-))->sethelp("Pre-processing Shell script, run after download and charset normalization: "
-	. "it receives a staged copy of the normalized feed text (UTF-8, control characters stripped, "
-	. "lines right-trimmed) and rewrites that copy in place.<br />"
-	. "Script location: /usr/local/pkg/pfblockerng/list_scripts/<strong>ip_pre_SCRIPT NAME.sh|py</strong> or <strong>dnsbl_pre_SCRIPT NAME.sh|py</strong>"
-	. $script_dnsbl_note)
+))->sethelp($script_pre_settings['help'])
   ->setAttribute('style', 'width: auto')
-  ->setAttribute('size', $options_script_pre_cnt);
+  ->setAttribute('size', $script_pre_settings['size']);
 
 $section->addInput(new Form_Select(
 	'script_post',
@@ -1774,10 +1763,8 @@ else {
 }
 
 ?>
-<?php if ($pfb_syntaxhl_on): ?>
-<!-- issue #1875 step 2b: live syntax highlighting for the custom-list field -->
-<script src="vendor/codemirror/cm-regex.min.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/vendor/codemirror/cm-regex.min.js')?>"></script>
-<?php endif; ?>
+<?php $pfb_category_editor = pfb_category_editor_render($pfb_syntaxhl_on, (string) ($rowdata[$rowid]['sort'] ?? '')); ?>
+<?=$pfb_category_editor['asset']?>
 <script type="text/javascript">
 //<![CDATA[
 
@@ -1809,11 +1796,7 @@ else if (gtype == 'dnsbl') {
 // skips absent ids. Own events.push, OUTSIDE the no-sort conditional below -- the
 // 'custom' textarea renders in every sort mode and for new groups (no rowid).
 events.push(function() {
-<?php if ($pfb_syntaxhl_on): ?>
-	if (window.pfbCM) {
-		window.pfbCM.mountLists(['custom']);
-	}
-<?php endif; ?>
+<?=$pfb_category_editor['mount']?>
 });
 
 <?php if (($rowdata[$rowid]['sort'] ?? '') == 'no-sort') { ?>
@@ -1853,5 +1836,5 @@ events.push(function() {
 
 //]]
 </script>
-<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
+<?=pfb_category_edit_js_asset_render()?>
 <?php include('foot.inc');?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -37,6 +37,8 @@ $pfb['dconfig'] = PfbConfig::readSection('installedpackages/pfblockerngdnsblsett
 // compared with ===, not ->value).
 $pfb_syntaxhl_on = pfb_editor_enabled();
 
+$pfb_dnsbl_editor = pfb_dnsbl_editor_render($pfb_syntaxhl_on);
+
 // Collect local domain TLD for Python TLD Allow array
 // foreign key — out of ADR-29 gateway scope (system/domain is not a pfblockerng* path)
 if (strpos(config_get_path('system/domain'), '.') !== FALSE) {
@@ -722,8 +724,10 @@ if ($_POST) {
 		// no usable interpreter, pfb_unbound.py loads Regex List patterns solely when this
 		// toggle is on, so an unloaded list must not make the whole page unsavable.
 		$pfb_regex_python = pfb_python_interpreter();
-		if (($pfb_regex_python !== '' && is_executable($pfb_regex_python)) ||
-		    (($_POST['pfb_regex'] ?? '') === 'on')) {
+		if (pfb_dnsbl_regex_validation_required_page(
+			$pfb_regex_python !== '' && is_executable($pfb_regex_python),
+			$_POST['pfb_regex'] ?? ''
+		)) {
 			foreach (pfb_dnsbl_regex_validation_errors((string) ($_POST['pfb_regex_list'] ?? ''), $pfb_regex_python, ($_POST['pfb_regex_cap'] ?? '') === 'on') as $regex_error) {
 				$input_errors[] = 'Customlist pfb_regex_list: ' . htmlspecialchars($regex_error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 			}
@@ -841,21 +845,21 @@ if ($_POST) {
 			$pfb['dconfig']['global_log']		= $_POST['global_log']							?: '';
 			// issue #1907: stage the explicit token -- checkbox-absent means Off, and a
 			// staged '' would resolve to this field's default-ON at the gateway.
-			$pfb['dconfig']['pfb_cache']		= (($_POST['pfb_cache'] ?? '') === 'on') ? 'on' : 'off';
+			$pfb['dconfig']['pfb_cache']		= pfb_dnsbl_toggle_stored($_POST['pfb_cache'] ?? NULL);
 			$pfb['dconfig']['pfb_cache_flush']	= pfb_filter($_POST['pfb_cache_flush'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 
 			// issue #1907: stage the explicit token -- checkbox-absent means Off, and a
 			// staged '' would resolve to these fields' default-ON at the gateway.
-			$pfb['dconfig']['pfb_py_reply']		= (($_POST['pfb_py_reply'] ?? '') === 'on') ? 'on' : 'off';
-			$pfb['dconfig']['pfb_hsts']		= (($_POST['pfb_hsts'] ?? '') === 'on') ? 'on' : 'off';
+			$pfb['dconfig']['pfb_py_reply']		= pfb_dnsbl_toggle_stored($_POST['pfb_py_reply'] ?? NULL);
+			$pfb['dconfig']['pfb_hsts']		= pfb_dnsbl_toggle_stored($_POST['pfb_hsts'] ?? NULL);
 			// ADR-08: IDN mode selector. Validate the raw word, then canonicalise via the
 			// PfbIdnMode adapter to the stored config token ('on' = All | 'confusable' | 'off').
 			$pfb_idn_mode = pfb_filter($_POST['pfb_idn'], PFB_FILTER_WORD, 'dnsbl');
 			$pfb['dconfig']['pfb_idn']		= pfb_cfg_idn_mode_write($pfb_idn_mode);
 			// issue #1887: stage the explicit token — checkbox-absent means Off, and a
 			// staged '' would resolve to this field's default-ON at the gateway.
-			$pfb['dconfig']['pfb_idn_block_malicious']	= (($_POST['pfb_idn_block_malicious'] ?? '') === 'on') ? 'on' : 'off';
-			$pfb['dconfig']['pfb_idn_escalate_suspicious']	= (($_POST['pfb_idn_escalate_suspicious'] ?? '') === 'on') ? 'on' : 'off';
+			$pfb['dconfig']['pfb_idn_block_malicious']	= pfb_dnsbl_toggle_stored($_POST['pfb_idn_block_malicious'] ?? NULL);
+			$pfb['dconfig']['pfb_idn_escalate_suspicious']	= pfb_dnsbl_toggle_stored($_POST['pfb_idn_escalate_suspicious'] ?? NULL);
 			$pfb['dconfig']['pfb_regex']		= pfb_filter($_POST['pfb_regex'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_regex_cap']	= pfb_filter($_POST['pfb_regex_cap'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_cname']		= pfb_filter($_POST['pfb_cname'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
@@ -1161,7 +1165,7 @@ $section->addInput(new Form_Checkbox(
 	'pfb_py_reply',
 	gettext('DNS Reply Logging'),
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_py_reply'] ?? '') === PfbToggle::On,
+	pfb_dnsbl_toggle_enabled($pconfig['pfb_py_reply'] ?? NULL),
 	'on'
 ))->setHelp('Enable the logging of all DNS Replies that were not blocked via DNSBL.');
 
@@ -1169,7 +1173,7 @@ $section->addInput(new Form_Checkbox(
 	'pfb_hsts',
 	gettext('HSTS mode'),
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_hsts'] ?? '') === PfbToggle::On,
+	pfb_dnsbl_toggle_enabled($pconfig['pfb_hsts'] ?? NULL),
 	'on'
 ))->setHelp('Enable the DNSBL <strong title="Utilizes 0.0.0.0 instead of the DNSBL VIP">Null Blocking mode</strong> for HSTS domains.<br />'
 	. 'Blocked domains that are in the <a target=_"blank" href="https://hstspreload.org/">HSTS preload</a> browser'
@@ -2801,7 +2805,7 @@ $section->addInput(new Form_Checkbox(
 	'pfb_idn_block_malicious',
 	gettext('Block clearly-malicious homoglyphs'),
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_idn_block_malicious']) === PfbToggle::On,
+	pfb_dnsbl_toggle_enabled($pconfig['pfb_idn_block_malicious'] ?? NULL),
 	'on'
 ))->setHelp('Confusable mode: block names that mix confusable scripts in one label (clearly malicious). Disable to alert only.');
 
@@ -2809,7 +2813,7 @@ $section->addInput(new Form_Checkbox(
 	'pfb_idn_escalate_suspicious',
 	gettext('Block suspicious mixed-script'),
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_idn_escalate_suspicious']) === PfbToggle::On,
+	pfb_dnsbl_toggle_enabled($pconfig['pfb_idn_escalate_suspicious'] ?? NULL),
 	'on'
 ))->setHelp('Confusable mode: escalate suspicious mixed-script names to a block. Default alerts only (no block).');
 
@@ -3054,13 +3058,7 @@ $section->addInput(new Form_Select(
 
 $form->add($section);
 
-$regex_text = 'List of Regex\'s to block via DNSBL:<br /><br />
-		Enter a single regex per line.<br /><br />
-		End a line with "<strong>#</strong>" to give it a Description, as in&emsp;"regex (Regular Expression) # Regex Description".<br /><br />
-		The first <strong>unescaped</strong> "#" on the line starts the Description, whether or not a space precedes it. To match a literal "#" inside a pattern, escape it as "<strong>\#</strong>".<br /><br />
-		Keep the Description to 15 characters or fewer — it is shown on the Alerts Tab, and a longer one is flagged in this editor. If no Description is entered a default Regex line number will be utilized.<br /><br />
-		This List is stored as \'Base64\' format in the config.xml file.<br /><br />
-		Changes to this option will require a Force Update to take effect.';
+$regex_text = pfb_dnsbl_regex_help_render();
 
 $section = new Form_Section('Regex List', 'Python_regex_list', COLLAPSIBLE|SEC_CLOSED);
 $section->addInput(new Form_Textarea(
@@ -3258,7 +3256,7 @@ $section->addInput(new Form_Checkbox(
 	'pfb_cache',
 	gettext('Resolver cache'),
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_cache'] ?? '') === PfbToggle::On,
+	pfb_dnsbl_toggle_enabled($pconfig['pfb_cache'] ?? NULL),
 	'on'
 ))->setHelp('Default: <strong>Enabled</strong><br />Enable the backup and restore of the DNS Resolver Cache on DNSBL Update|Reload|Cron events');
 
@@ -3304,7 +3302,8 @@ $whitelist_text = 'No Regex Entries Allowed!&emsp;
 				&emsp; ie: \'drill @8.8.8.8 example.com\'
 			</div>';
 
-$section = new Form_Section('DNSBL Whitelist', 'DNSBL_Whitelist_customlist', COLLAPSIBLE|SEC_CLOSED);
+$pfb_dnsbl_anchor_layout = pfb_dnsbl_anchor_layout_render();
+$section = new Form_Section('DNSBL Whitelist', $pfb_dnsbl_anchor_layout['whitelist'], COLLAPSIBLE|SEC_CLOSED);
 $section->addInput(new Form_Textarea(
 	'whitelist',
 	NULL,
@@ -3621,10 +3620,7 @@ print ($form);
 print_callout('<strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong>');
 
 ?>
-<?php if ($pfb_syntaxhl_on): ?>
-<!-- issue #1669 slice C: live syntax highlighting for the pfb_regex_list field -->
-<script src="vendor/codemirror/cm-regex.min.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/vendor/codemirror/cm-regex.min.js')?>"></script>
-<?php endif; ?>
+<?=$pfb_dnsbl_editor['asset']?>
 <script type="text/javascript">
 //<![CDATA[
 
@@ -3792,31 +3788,8 @@ function enable_dnsblip() {
 }
 
 events.push(function(){
-<?php if ($pfb_syntaxhl_on): ?>
-	// issue #1669 slice C / #1732 step 2: progressively enhance pfb_regex_list into a
-	// CodeMirror 6 live-highlight editor with advisory server lint. window.pfbCM is
-	// the global the vendored bundle exposes (IIFE --global-name=pfbCM);
-	// fromTextarea() hides the textarea, mounts the editor before it, keeps
-	// name/value synced so the save handler's $_POST read is unaffected, and (via
-	// opts.lintUrl) wires an async POST to pfblockerng_lint.php plus the offline
-	// bracket lint. lintExtraParams reads the cap checkbox's LIVE state so the lint
-	// agrees with what save would enforce right now.
-	var pfbRegexListEl = document.getElementById('pfb_regex_list');
-	if (pfbRegexListEl && window.pfbCM) {
-		window.pfbCM.fromTextarea(pfbRegexListEl, {
-			lintUrl: '/pfblockerng/pfblockerng_lint.php',
-			lintExtraParams: function() {
-				var capEl = document.getElementById('pfb_regex_cap');
-				return { cap: (capEl && capEl.checked) ? '1' : '0' };
-			}
-		});
-	}
-
-	// issue #1875 step 2b: plain-list fields share this page's CM6 bundle; mountLists skips absent ids
-	if (window.pfbCM) {
-		window.pfbCM.mountLists(['pfb_gp_bypass_list', 'pfb_noaaaa_list', 'whitelist', 'tld_wildcard_exclusion', 'tld_wildcard_blacklist']);
-	}
-<?php endif; ?>
+<?=$pfb_dnsbl_editor['regex']?>
+<?=$pfb_dnsbl_editor['lists']?>
 
 	$('#tld_wildcard').click(function() {
 		enable_tld();
@@ -3873,5 +3846,5 @@ events.push(function(){
 
 //]]>
 </script>
-<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
+<?=pfb_dnsbl_js_asset_render()?>
 <?php include('foot.inc');?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
@@ -38,10 +38,10 @@
 // framework at all). That keeps the ADR-12 addendum's picker-trust-boundary guarantee
 // intact: a user holding only the ordinary pfBlockerNG page privileges must stay unable
 // to author or edit hook content -- they can still PICK a vetted file on the Hooks tab,
-// nothing here changes that. The isAllowedPage() check immediately below is the SECOND,
-// LOAD-BEARING gate (mirrors pfblockerng_software.php's SECONDARY PRIVILEGE GATE,
-// issue #485): it is what actually decides who may render or save on this page, and it
-// covers the GET render path and BOTH POST actions with a single check.
+// nothing here changes that. The controller call immediately below is the SECOND,
+// LOAD-BEARING gate (mirrors pfblockerng_software.php's secondary privilege gate,
+// issue #485): it decides who may render or save this page, redirects denied requests,
+// and invokes the request callbacks only when access is allowed.
 
 require_once('guiconfig.inc');
 require_once('globals.inc');
@@ -128,18 +128,6 @@ if ($input_errors) {
 if ($pfb_eh_state['notice'] !== NULL) {
 	print_info_box($pfb_eh_state['notice'], 'success');
 }
-// issue #1871: a delete removes the row it acted on, so without this the page comes
-// back with the script simply absent and no statement that anything happened -- the
-// same silent-success problem the save flow already avoids. The name is echoed
-// through htmlspecialchars() because it reaches this point from a query string.
-// Deliberately does NOT echo the name back. The value is HTML-escaped either way, so
-// this is not about injection -- it is that a crafted link would otherwise render an
-// arbitrary attacker-chosen sentence inside a success box on an admin's screen, which
-// is a credible way to talk somebody into believing something happened that did not.
-// Validating the name here instead would mean inlining the hook naming rule on the
-// page, which belongs to pfb_hook_editor_compose_filename() alone (pinned by
-// EditHooksPageWiringTest). The row is already gone from the table above, so a fixed
-// message carries the confirmation without carrying attacker-controlled text.
 // Define default Alerts Tab href link (Top row)
 $get_req = pfb_alerts_default_page();
 
@@ -173,9 +161,9 @@ pfb_print_pending_changes_box();
 // the load-bearing equivalent, not a decoration.
 $pfb_eh_warning = pfb_edit_hooks_warning();
 print_callout(
-	gettext($pfb_eh_warning['message']),
+	$pfb_eh_warning['message'],
 	$pfb_eh_warning['style'],
-	gettext($pfb_eh_warning['title'])
+	$pfb_eh_warning['title']
 );
 
 $form = new Form(FALSE);

--- a/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php
@@ -45,12 +45,20 @@
 
 require_once('guiconfig.inc');
 require_once('globals.inc');
-require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
+$pfb_eh_pkg = '/usr/local/pkg/pfblockerng/pfblockerng.inc';
+if (!file_exists($pfb_eh_pkg)) {
+	$pfb_eh_pkg = dirname(__DIR__, 2) . '/pkg/pfblockerng/pfblockerng.inc';
+}
+require_once($pfb_eh_pkg);
 // Destructive hook-script operations, deliberately NOT in the package-wide includes:
 // this file is included by THIS PAGE ONLY, so a root-privileged unlink() is never in
 // scope on a page that has no business holding one. Containment is pinned by
 // tests/php/HookEditFileContainmentTest.php.
-require_once('/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc');
+$pfb_eh_hook_edit = '/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc';
+if (!file_exists($pfb_eh_hook_edit)) {
+	$pfb_eh_hook_edit = dirname(__DIR__, 2) . '/pkg/pfblockerng/pfblockerng_hook_edit.inc';
+}
+require_once($pfb_eh_hook_edit);
 
 global $pfb;
 pfb_global();
@@ -71,11 +79,6 @@ $pfb_syntaxhl_on = pfb_editor_enabled();
 // a page-all admin (who lacks the literal 'page-diagnostics-command' priv) -- that
 // would lock admins out. pfSense match-based privilege is OR across groups, so this
 // extra AND-requirement can only be enforced by an explicit in-page check.
-if (!isAllowedPage('diag_command.php')) {
-	header('Location: /index.php');
-	exit;
-}
-
 $input_errors = array();
 
 // The currently loaded/edited script, and its content -- populated below from either
@@ -91,205 +94,21 @@ $pfb_eh_new_core_val  = '';
 $pfb_eh_new_lang_val  = 'sh';
 $pfb_eh_new_when_echo = '';
 
-if ($_POST) {
-	if (isset($_POST['pfb_eh_create'])) {
-		// Create flow (issue #1669 design comment): the user supplies only When/Name
-		// core/Language -- the server COMPOSES the filename. pfb_hook_editor_compose_filename()
-		// is the single source of truth for every validation decision here; this
-		// handler never inlines a regex or a naming rule of its own.
-		$post_when = (string) ($_POST['pfb_eh_new_when'] ?? '');
-		$post_core = (string) ($_POST['pfb_eh_new_core'] ?? '');
-		$post_lang = (string) ($_POST['pfb_eh_new_lang'] ?? '');
-
-		$filename = pfb_hook_editor_compose_filename($post_when, $post_core, $post_lang);
-		$path     = ($filename !== NULL) ? pfb_hook_editor_path($filename) : NULL;
-
-		if ($filename === NULL || $path === NULL) {
-			$input_errors[] = gettext('Invalid new-hook fields: When must be Pre/Post, Name must be letters, ' .
-				'digits, and underscores only, and Language must be Shell or Python.');
-		} else {
-			// Mode 0700: the runner execs the vetted script directly under timeout(1)
-			// via its own shebang (pfb_run_hooks()), so a freshly created file must be
-			// executable to ever actually run -- but the runner always execs as root,
-			// and pfb_hook_scripts() has no is_executable filter, so nothing else on
-			// the system needs the group/other bits; owner-only is least privilege.
-			//
-			// 'x' mode: atomic create-exclusive open -- fails outright if the target
-			// already exists, closing the TOCTOU race a separate file_exists() check
-			// followed by a plain write left open: two concurrent creates racing the
-			// same composed name could otherwise both pass the existence check and one
-			// clobber the other.
-			$pfb_eh_new_handle = @fopen($path, 'x');
-			if ($pfb_eh_new_handle === FALSE) {
-				// fopen(..., 'x') returns FALSE
-				// for EVERY failure reason (name collision, unwritable directory, etc.) --
-				// the prior message named only the collision case, which misled an admin
-				// hitting a permissions problem into repeatedly retyping a "different Name"
-				// that would never help.
-				$input_errors[] = gettext('A hook script with that composed name already exists, or the ' .
-					'hook-script directory is not writable -- pick a different Name.');
-			} else {
-				$pfb_eh_new_template = pfb_hook_editor_template($post_when, $post_lang);
-				$pfb_eh_new_written  = @fwrite($pfb_eh_new_handle, $pfb_eh_new_template);
-				@fclose($pfb_eh_new_handle);
-				if ($pfb_eh_new_written !== strlen($pfb_eh_new_template) || !@chmod($path, 0700)) {
-					// Partial/failed write or chmod -- never leave a half-written file
-					// behind for a later create attempt (with a different name) to trip
-					// over, or for the picker to ever list.
-					@unlink($path);
-					$input_errors[] = gettext('Failed to write the hook script file -- check that the ' .
-						'hook-script directory is writable.');
-				} else {
-					// PRG: redirect straight into the picker-load state for the new file so
-					// the admin lands in the editor, ready to fill in the hello-world stub.
-					header('Location: /pfblockerng/pfblockerng_edit_hooks.php?' .
-						http_build_query(array('when' => $post_when, 'script' => $filename)));
-					exit;
-				}
-			}
-		}
-
-		// Preserve the create-flow fields the user typed so a validation error doesn't
-		// silently clear the form.
-		$pfb_eh_new_core_val  = $post_core;
-		$pfb_eh_new_lang_val  = ($post_lang === 'py') ? 'py' : 'sh';
-		$pfb_eh_new_when_echo = $post_when;
-
-		// issue #1884: a failed create must not cost the admin their unsaved edits --
-		// Enter in the Name field (the form's only text input) submits as Create, so
-		// this error path fires from a stray keypress. Same cur_-restore shape as the
-		// failed-delete branch below; the save branch re-validates both before writing.
-		$pfb_eh_sel_when   = (string) ($_POST['pfb_eh_cur_when'] ?? '');
-		$pfb_eh_sel_script = (string) ($_POST['pfb_eh_cur_script'] ?? '');
-		$pfb_eh_content    = pfb_sanitize_text_area((string) ($_POST['pfb_eh_content'] ?? ''));
-	} elseif (isset($_POST['pfb_eh_delete']) && $_POST['pfb_eh_delete'] !== '') {
-		// The emptiness check is load-bearing, not defensive: pfb_eh_delete is a
-		// hidden field rendered on EVERY request, and a browser submits hidden inputs
-		// whether or not the delete button was the thing clicked. isset() alone is
-		// therefore true on a Save too, which would route Save into this branch,
-		// fail, and discard the admin's unsaved editor content. Only the click
-		// handler ever gives the field a value. Same idiom as
-		// pfblockerng_alerts.php's entry_delete guard.
-		//
-		// issue #1871: every decision is delegated to pfb_hook_editor_delete(), which
-		// refuses anything the shared allow-list (pfb_hook_script_valid()) does not
-		// already vouch for -- this handler never inlines a path or naming rule of
-		// its own, exactly like the create and save handlers above and below it.
-		$post_when   = (string) ($_POST['pfb_eh_del_when'] ?? '');
-		$post_script = (string) ($_POST['pfb_eh_del_script'] ?? '');
-
-		if (pfb_hook_editor_delete($post_script, $post_when)) {
-			// PRG, and deliberately WITHOUT when/script: the editor must not come
-			// back pointing at a file that no longer exists.
-			header('Location: /pfblockerng/pfblockerng_edit_hooks.php?' .
-				http_build_query(array('deleted' => $post_script)));
-			exit;
-		}
-		$input_errors[] = gettext('That hook script could not be deleted -- reload the page and try again ' .
-			'(it may already be gone, or the hook-script directory may not be writable).');
-
-		// A FAILED delete must not cost the admin their unsaved edits. Falling through
-		// with these empty re-renders the page as "Load an existing script above..."
-		// and silently discards whatever was in the editor -- the same data-loss shape
-		// as the presence-only guard this branch already had to fix, just behind a
-		// narrower trigger (a double submit, or a hook removed from another tab). The
-		// loaded script is re-derived from the SAME cur_* fields the save branch
-		// trusts, and both are re-validated there before anything is written.
-		$pfb_eh_sel_when   = (string) ($_POST['pfb_eh_cur_when'] ?? '');
-		$pfb_eh_sel_script = (string) ($_POST['pfb_eh_cur_script'] ?? '');
-		$pfb_eh_content    = pfb_sanitize_text_area((string) ($_POST['pfb_eh_content'] ?? ''));
-	} elseif (isset($_POST['pfb_eh_save'])) {
-		// Save flow: edit the CONTENT of an EXISTING, already-vetted script only --
-		// this never creates a new file. pfb_hook_script_valid() is the same allow-list
-		// gate the Hooks tab's save handler and the runner itself use, so a stale pick
-		// or a crafted POST can never write outside a file the picker already offers.
-		$post_when    = (string) ($_POST['pfb_eh_cur_when'] ?? '');
-		$post_script  = (string) ($_POST['pfb_eh_cur_script'] ?? '');
-		// issue #1734: shared persist-boundary sanitizer (#1723), run at INGESTION.
-		// Its leading CRLF/CR -> LF fold is load-bearing: HTML5 makes the browser submit
-		// a <textarea> as CRLF, and a saved "#!/bin/sh\r" shebang execs the nonexistent
-		// path "/bin/sh\r" (ENOENT) -- the hook then silently never fires again. A
-		// literal control byte must be written as an escape (\033); issue #1728.
-		$post_content = pfb_sanitize_text_area((string) ($_POST['pfb_eh_content'] ?? ''));
-
-		if (!pfb_hook_script_valid($post_script, $post_when)) {
-			$input_errors[] = gettext('Select a valid, existing hook script for this Pre/Post before saving ' .
-				'(load it from the picker above first).');
-		} else {
-			$path = pfb_hook_editor_path($post_script);
-			if ($path === NULL || !is_file($path)) {
-				$input_errors[] = gettext('The selected hook script could not be resolved on disk.');
-			} else {
-				// pfb_run_hooks() may exec
-				// this exact file as root concurrently with a save -- an in-place
-				// truncate-and-write straight to the live target leaves a window where a
-				// concurrent reader/exec sees an empty or partial script. Stage to a temp
-				// file in the SAME directory (same idiom as pfb_utf16_transcode_file() /
-				// pfb_apply_publish() in pfblockerng.inc), verify the full byte count
-				// landed, chmod, then rename() over the target -- rename() is atomic on
-				// the same filesystem, so a concurrent exec always observes either the
-				// old or the new content in full, never a partial write.
-				$pfb_eh_tmp = @tempnam(dirname($path), '.pfbeh_');
-				$pfb_eh_written = ($pfb_eh_tmp !== FALSE) ? @file_put_contents($pfb_eh_tmp, $post_content) : FALSE;
-				if (
-					$pfb_eh_tmp === FALSE ||
-					$pfb_eh_written !== strlen($post_content) ||
-					!@chmod($pfb_eh_tmp, 0700) ||
-					!@rename($pfb_eh_tmp, $path)
-				) {
-					if ($pfb_eh_tmp !== FALSE) {
-						@unlink($pfb_eh_tmp);
-					}
-					$input_errors[] = gettext('Failed to save the hook script file -- check that the ' .
-						'hook-script directory is writable.');
-				} else {
-					header('Location: /pfblockerng/pfblockerng_edit_hooks.php?' .
-						http_build_query(array('when' => $post_when, 'script' => $post_script, 'saved' => '1')));
-					exit;
-				}
-			}
-		}
-
-		// Re-render the sanitized content so a validation/write error doesn't lose the
-		// user's in-progress work -- it is what a retry would persist, so echoing the
-		// raw typed bytes back would misreport what Save is about to write.
-		$pfb_eh_sel_when   = $post_when;
-		$pfb_eh_sel_script = $post_script;
-		$pfb_eh_content    = $post_content;
-	}
-}
-
-// GET picker load -- reached on a plain click from the picker links below, or via the
-// PRG redirect right after a successful create/save. $_GET['script'] is NEVER treated
-// as a path: pfb_hook_script_valid() checks it against pfb_hook_scripts()'s own
-// allow-list (an exact basename match against what is actually on disk for this
-// Pre/Post) before pfb_hook_editor_path() resolves it and anything is read.
-if (!$_POST && isset($_GET['when'], $_GET['script'])) {
-	$get_when   = (string) $_GET['when'];
-	$get_script = (string) $_GET['script'];
-	if (pfb_hook_script_valid($get_script, $get_when)) {
-		$path = pfb_hook_editor_path($get_script);
-		$body = ($path !== NULL && is_file($path)) ? @file_get_contents($path) : FALSE;
-		if ($body === FALSE) {
-			$input_errors[] = gettext('Failed to read the selected hook script.');
-		} elseif (!mb_check_encoding($body, 'UTF-8')) {
-			// htmlspecialchars(ENT_SUBSTITUTE)
-			// (used by Form_Textarea::_getInput() at render) silently replaces every
-			// invalid byte with U+FFFD -- loading an invalid-UTF-8 file into this editor
-			// would corrupt it, and re-saving would persist that corruption to disk.
-			// Refuse to populate the editor for this load; leaving $pfb_eh_sel_script
-			// empty also disables the Save path (pfb_hook_script_valid('', ...) fails),
-			// so there is nothing to click that could write the corrupted view back.
-			$input_errors[] = gettext('The selected hook script file is not valid UTF-8 -- fix it on disk before ' .
-				'editing it here (loading it into this editor would corrupt invalid byte sequences on display).');
-		} else {
-			$pfb_eh_sel_when   = $get_when;
-			$pfb_eh_sel_script = $get_script;
-			$pfb_eh_content    = $body;
-		}
-	} else {
-		$input_errors[] = gettext('That script is not a valid hook file for the selected Pre/Post.');
-	}
+$pfb_eh_state = pfb_edit_hooks_controller(
+	isAllowedPage('diag_command.php'),
+	static fn (): array => $_POST,
+	static fn (): array => $_GET
+);
+$input_errors = $pfb_eh_state['errors'];
+$pfb_eh_sel_when = $pfb_eh_state['sel_when'];
+$pfb_eh_sel_script = $pfb_eh_state['sel_script'];
+$pfb_eh_content = $pfb_eh_state['content'];
+$pfb_eh_new_core_val = $pfb_eh_state['new_core'];
+$pfb_eh_new_lang_val = $pfb_eh_state['new_lang'];
+$pfb_eh_new_when_echo = $pfb_eh_state['new_when'];
+if ($pfb_eh_state['redirect'] !== NULL) {
+	header('Location: ' . $pfb_eh_state['redirect']);
+	exit;
 }
 
 // issue #1669: the CM6 editor mode -- follows the loaded script's own
@@ -306,8 +125,8 @@ include_once('head.inc');
 if ($input_errors) {
 	print_input_errors($input_errors);
 }
-if (!$_POST && isset($_GET['saved'])) {
-	print_info_box(gettext('Hook script saved.'), 'success');
+if ($pfb_eh_state['notice'] !== NULL) {
+	print_info_box($pfb_eh_state['notice'], 'success');
 }
 // issue #1871: a delete removes the row it acted on, so without this the page comes
 // back with the script simply absent and no statement that anything happened -- the
@@ -321,10 +140,6 @@ if (!$_POST && isset($_GET['saved'])) {
 // page, which belongs to pfb_hook_editor_compose_filename() alone (pinned by
 // EditHooksPageWiringTest). The row is already gone from the table above, so a fixed
 // message carries the confirmation without carrying attacker-controlled text.
-if (!$_POST && isset($_GET['deleted']) && $_GET['deleted'] !== '') {
-	print_info_box(gettext('Hook script deleted.'), 'success');
-}
-
 // Define default Alerts Tab href link (Top row)
 $get_req = pfb_alerts_default_page();
 
@@ -345,10 +160,7 @@ display_top_tabs($tab_array, TRUE);
 // re-declares it in full with its OWN tab marked active (pfblockerng_update.php,
 // pfblockerng_hooks.php, and this page); see EditHooksPageWiringTest for the coverage
 // pin across all three.
-$tab_array_sub	= array();
-$tab_array_sub[]	= array(gettext('Run'),		FALSE,	'/pfblockerng/pfblockerng_update.php');
-$tab_array_sub[]	= array(gettext('Hooks'),	FALSE,	'/pfblockerng/pfblockerng_hooks.php');
-$tab_array_sub[]	= array(gettext('Edit Hooks'),	TRUE,	'/pfblockerng/pfblockerng_edit_hooks.php');
+$tab_array_sub = pfb_edit_hooks_tabs('edit');
 display_top_tabs($tab_array_sub, TRUE);
 pfb_print_pending_changes_box();
 
@@ -359,12 +171,11 @@ pfb_print_pending_changes_box();
 // page deliberately is not (see the top-of-file comment), so that generic mechanism
 // never fires here and would give a false sense of coverage. This explicit callout is
 // the load-bearing equivalent, not a decoration.
+$pfb_eh_warning = pfb_edit_hooks_warning();
 print_callout(
-	gettext('The capabilities offered here can be dangerous. No support is available. Scripts you ' .
-		'create or edit on this page run as ROOT during every pfBlockerNG update pass -- the same ' .
-		'trust class as pfSense Diagnostics > Command Prompt / Edit File. Use them at your own risk!'),
-	'danger',
-	gettext('Advanced Users Only')
+	gettext($pfb_eh_warning['message']),
+	$pfb_eh_warning['style'],
+	gettext($pfb_eh_warning['title'])
 );
 
 $form = new Form(FALSE);
@@ -465,7 +276,7 @@ $group->add(new Form_Input(
 	// RAW value: Form_Input::_getInput() already HTML-escapes it at render
 	// -- escaping it again at the page
 	// level would double-escape it.
-	$pfb_eh_new_core_val,
+	pfb_edit_hooks_form_value($pfb_eh_new_core_val),
 	array('placeholder' => 'name_core')
 ))->setHelp('Name (letters, digits, underscore only)')->setWidth(4);
 $group->add(new Form_Select(
@@ -481,7 +292,7 @@ $section->add($group);
 // natively -- exactly what isset($_POST['pfb_eh_create']) above keys on -- so no
 // click-handler JS is needed to make this submit as the create action.
 $pfb_eh_create_btn = new Form_Button(
-	'pfb_eh_create',
+	pfb_edit_hooks_submit_field('create'),
 	gettext('Create'),
 	NULL,
 	'fa-solid fa-plus'
@@ -508,8 +319,8 @@ $section->addInput(new Form_StaticText('Now editing', $pfb_eh_loaded_label));
 // RAW values: Form_Element/Form_Input already HTML-escape every attribute at
 // render -- escaping them again at the
 // page level would double-escape them.
-$form->addGlobal(new Form_Input('pfb_eh_cur_when', 'pfb_eh_cur_when', 'hidden', $pfb_eh_sel_when));
-$form->addGlobal(new Form_Input('pfb_eh_cur_script', 'pfb_eh_cur_script', 'hidden', $pfb_eh_sel_script));
+$form->addGlobal(new Form_Input('pfb_eh_cur_when', 'pfb_eh_cur_when', 'hidden', pfb_edit_hooks_form_value($pfb_eh_sel_when)));
+$form->addGlobal(new Form_Input('pfb_eh_cur_script', 'pfb_eh_cur_script', 'hidden', pfb_edit_hooks_form_value($pfb_eh_sel_script)));
 
 $pfb_eh_textarea = new Form_Textarea(
 	'pfb_eh_content',
@@ -522,7 +333,7 @@ $pfb_eh_textarea = new Form_Textarea(
 	// RELENG_2_7_2), so escaping it again here would double-escape it: the browser
 	// decodes only ONE layer, leaving mangled entities (e.g. "&quot;") in what the
 	// user sees and re-saves.
-	$pfb_eh_content
+	pfb_edit_hooks_form_value($pfb_eh_content)
 );
 $pfb_eh_textarea->setAttribute('id', 'pfb_hook_editor_content');
 $pfb_eh_textarea->removeClass('form-control')
@@ -540,7 +351,7 @@ $section->addInput($pfb_eh_textarea);
 // Named pfb_eh_save directly -- same native-submit reasoning as the Create button
 // above.
 $pfb_eh_save_btn = new Form_Button(
-	'pfb_eh_save',
+	pfb_edit_hooks_submit_field('save'),
 	gettext('Save'),
 	NULL,
 	'fa-solid fa-floppy-disk'
@@ -553,10 +364,8 @@ $form->add($section);
 
 print($form);
 ?>
-<?php if ($pfb_syntaxhl_on): ?>
-<!-- issue #1669: live syntax highlighting for the pfb_eh_content field -->
-<script src="vendor/codemirror/cm-hooks.min.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/vendor/codemirror/cm-hooks.min.js')?>"></script>
-<?php endif; ?>
+<?php $pfb_hooks_editor = pfb_hooks_editor_render($pfb_syntaxhl_on, $pfb_eh_lang); ?>
+<?=$pfb_hooks_editor['asset']?>
 <script type="text/javascript">
 //<![CDATA[
 // issue #1871: deleting a hook script is irreversible from the UI (the file is
@@ -575,21 +384,7 @@ function pfb_eh_delete_hook(when, script) {
 }
 
 events.push(function() {
-<?php if ($pfb_syntaxhl_on): ?>
-	// issue #1669 / #1732 step 2: progressively enhance pfb_eh_content into a
-	// CodeMirror 6 live-highlight editor (python or shell mode, per $pfb_eh_lang)
-	// with advisory server lint. window.pfbHooksCM is the global the vendored
-	// bundle exposes (IIFE --global-name=pfbHooksCM); fromTextarea() hides the
-	// textarea, mounts the editor before it, keeps name/value synced so the save
-	// handler's $_POST read is unaffected, and (via opts.lintUrl) wires an async
-	// POST to pfblockerng_lint.php.
-	var pfbHookEditorEl = document.getElementById('pfb_hook_editor_content');
-	if (pfbHookEditorEl && window.pfbHooksCM) {
-		window.pfbHooksCM.fromTextarea(pfbHookEditorEl, '<?=$pfb_eh_lang?>', {
-			lintUrl: '/pfblockerng/pfblockerng_lint.php'
-		});
-	}
-<?php endif; ?>
+<?=$pfb_hooks_editor['mount']?>
 });
 //]]>
 </script>

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -101,6 +101,8 @@ $pconfig['pfb_syntax_highlight']	= PfbConfig::read('gen/pfb_syntax_highlight')->
 // same $pfb_syntaxhl_on idiom pfblockerng_dnsbl.php establishes at its line 38.
 $pfb_syntaxhl_on = pfb_editor_enabled();
 
+$pfb_general_editor = pfb_general_editor_render($pfb_syntaxhl_on);
+
 // Select field options
 $options_pfb_interval	= [	'1' => 'Every hour',
 				'2' => 'Every 2 hours',
@@ -245,7 +247,7 @@ if ($_POST) {
 			// pfb_keep precedent (lenient adapter). Written into $pfb['gconfig'] so the
 			// writeSection() call below includes it -- a bare PfbConfig::write() before
 			// writeSection() would be clobbered by the section-level write.
-			$pfb['gconfig']['pfb_syntax_highlight']	= (($_POST['pfb_syntax_highlight'] ?? '') === 'on') ? 'on' : 'off';
+			$pfb['gconfig']['pfb_syntax_highlight']	= pfb_general_toggle_stored_value($_POST['pfb_syntax_highlight'] ?? '');
 
 			PfbConfig::writeSection('installedpackages/pfblockerng/config/0', $pfb['gconfig']);
 			write_config('[pfBlockerNG] save General settings');
@@ -353,17 +355,11 @@ $section->addInput(new Form_Textarea(
 // help cover the whole editor (issue #1888) -- the config key stays pfb_syntax_highlight.
 $section->addInput(new Form_Checkbox(
 	'pfb_syntax_highlight',
-	'Advanced Text Editor',
+	pfb_general_toggle_label(),
 	gettext('Enable'),
 	pfb_cfg_toggle_read($pconfig['pfb_syntax_highlight']) === PfbToggle::On,
 	'on'
-))->setHelp('Client-side editor for the list and script fields (e.g. the DNSBL Regex '
-		. 'List, custom lists, IP suppression lists, hook scripts): syntax highlighting, '
-		. 'line numbers and undo/redo everywhere, plus inline linting on the DNSBL Regex '
-		. 'List and hook scripts. Unchecking this leaves those fields as plain text boxes '
-		. 'and skips loading the editor assets &mdash; useful for low-end client machines. '
-		. 'Validation always stays server-side either way.'
-);
+))->setHelp(pfb_general_toggle_help());
 
 $group = new Form_Group('CRON Settings');
 $group->add(new Form_Select(
@@ -595,10 +591,7 @@ $form->add($section);
 print($form);
 print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');
 ?>
-<?php if ($pfb_syntaxhl_on): ?>
-<!-- issue #1875 step 2b: live syntax highlighting for the internal-feed-host allowlist field -->
-<script src="vendor/codemirror/cm-regex.min.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/vendor/codemirror/cm-regex.min.js')?>"></script>
-<?php endif; ?>
+<?=$pfb_general_editor['asset']?>
 
 <script type="text/javascript">
 //<![CDATA[
@@ -614,12 +607,7 @@ events.push(function() {
 	$('#pfb_feed_internal_filter').click(pfb_sync_internal_filter);
 	pfb_sync_internal_filter();
 
-<?php if ($pfb_syntaxhl_on): ?>
-	// issue #1875 step 2b: plain-list field shares the regex page's CM6 bundle; mountLists skips absent ids
-	if (window.pfbCM) {
-		window.pfbCM.mountLists(['pfb_feed_internal_allowlist']);
-	}
-<?php endif; ?>
+<?=$pfb_general_editor['lists']?>
 
 });
 //]]>

--- a/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
@@ -206,10 +206,7 @@ display_top_tabs($tab_array, TRUE);
 // Update sub-tabs: Run (update page), Hooks (this page), and Edit Hooks (issue #1669
 // Part B: the gated hook-script authoring editor, directly after Hooks).
 // Second display_top_tabs row, matching the Feeds page IPv4/IPv6/DNSBL sub-tab idiom.
-$tab_array_sub	= array();
-$tab_array_sub[]	= array(gettext('Run'),		FALSE,	'/pfblockerng/pfblockerng_update.php');
-$tab_array_sub[]	= array(gettext('Hooks'),	TRUE,	'/pfblockerng/pfblockerng_hooks.php');
-$tab_array_sub[]	= array(gettext('Edit Hooks'),	FALSE,	'/pfblockerng/pfblockerng_edit_hooks.php');
+$tab_array_sub = pfb_edit_hooks_tabs('hooks');
 display_top_tabs($tab_array_sub, TRUE);
 pfb_print_pending_changes_box();
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -33,6 +33,8 @@ $pfb['iconfig'] = PfbConfig::readSection('installedpackages/pfblockerngipsetting
 // same $pfb_syntaxhl_on idiom pfblockerng_dnsbl.php establishes at its line 38.
 $pfb_syntaxhl_on = pfb_editor_enabled();
 
+$pfb_ip_editor = pfb_ip_editor_render($pfb_syntaxhl_on);
+
 $pconfig = array();
 $pconfig['enable_dup']		= $pfb['iconfig']['enable_dup']				?: '';
 $pconfig['enable_agg']		= $pfb['iconfig']['enable_agg']				?: '';
@@ -246,7 +248,7 @@ if ($_POST) {
 			$pfb['iconfig']['enable_agg']		= pfb_filter($_POST['enable_agg'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			// issue #1907: stage the explicit token -- checkbox-absent means Off, and a
 			// staged '' would resolve to this field's default-ON at the gateway.
-			$pfb['iconfig']['suppression']		= (($_POST['suppression'] ?? '') === 'on') ? 'on' : 'off';
+			$pfb['iconfig']['suppression']		= pfb_ip_suppression_stored($_POST['suppression'] ?? NULL);
 			$pfb['iconfig']['enable_log']		= pfb_filter($_POST['enable_log'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['enable_rdns']		= pfb_filter($_POST['enable_rdns'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['ip_placeholder']	= $_POST['ip_placeholder']					?: '127.1.7.7';
@@ -419,7 +421,7 @@ $section->addInput(new Form_Checkbox(
 	'suppression',
 	'Suppression',
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['suppression'] ?? '') === PfbToggle::On,
+	pfb_ip_suppression_enabled($pconfig['suppression'] ?? NULL),
 	'on'
 ))->setHelp('Default enabled. This will prevent Selected IPs (and private/reserved addresses) from being blocked. For IPv4 lists (/8 through /32) and IPv6 lists (/32 through /128).'
 	. '<div class="infoblock">'
@@ -550,7 +552,8 @@ $section->addInput(new Form_Checkbox(
 $form->add($section);
 
 // Print Custom List TextArea section
-$section = new Form_Section('IPv4 Suppression', 'IPv4_Suppression_customlist', COLLAPSIBLE|SEC_CLOSED);
+$pfb_ip_anchor_layout = pfb_ip_anchor_layout_render();
+$section = new Form_Section('IPv4 Suppression', $pfb_ip_anchor_layout['suppression'], COLLAPSIBLE|SEC_CLOSED);
 $suppression_text = '<strong><u>This suppression list is for [ /8 through /32 ] IPv4 addresses only!</u></strong><br /><br />
 
 			When \'Suppression\' is enabled, all RFC1918, loopback and reserved (documentation, multicast, CGN, benchmarking, 6to4)
@@ -698,25 +701,17 @@ print ($form);
 print_callout('<strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong>');
 
 ?>
-<?php if ($pfb_syntaxhl_on): ?>
-<!-- issue #1875 step 2b: live syntax highlighting for the suppression list fields -->
-<script src="vendor/codemirror/cm-regex.min.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/vendor/codemirror/cm-regex.min.js')?>"></script>
-<?php endif; ?>
+<?=$pfb_ip_editor['asset']?>
 <script type="text/javascript">
 //<![CDATA[
 
 var pagetype = null;
 
 events.push(function(){
-<?php if ($pfb_syntaxhl_on): ?>
-	// issue #1875 step 2b: plain-list fields share the regex page's CM6 bundle; mountLists skips absent ids
-	if (window.pfbCM) {
-		window.pfbCM.mountLists(['v4suppression', 'v6suppression']);
-	}
-<?php endif; ?>
+<?=$pfb_ip_editor['lists']?>
 });
 
 //]]>
 </script>
-<script src="pfBlockerNG.js?v=<?=pfb_file_mtime('/usr/local/www/pfblockerng/pfBlockerNG.js')?>" type="text/javascript"></script>
+<?=pfb_ip_js_asset_render()?>
 <?php include('foot.inc');?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_lint.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_lint.php
@@ -34,53 +34,21 @@
 
 require_once('guiconfig.inc');
 require_once('globals.inc');
-require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
-
-/*
- * Single JSON-reply exit point -- every guard below routes through this so no branch
- * can fall through to rendering HTML.
- */
-function pfb_lint_reply(int $status, array $payload): never {
-	http_response_code($status);
-	header('Content-Type: application/json; charset=utf-8');
-	// JSON_INVALID_UTF8_SUBSTITUTE: a diagnostic message carrying invalid UTF-8 (e.g. a
-	// mis-decoded stderr byte) would otherwise make json_encode() return FALSE, shipping
-	// a 200 with an empty body instead of a diagnostic.
-	echo json_encode($payload, JSON_INVALID_UTF8_SUBSTITUTE);
-	exit;
+$pfb_lint_include = '/usr/local/pkg/pfblockerng/pfblockerng.inc';
+if (!file_exists($pfb_lint_include)) {
+	$pfb_lint_include = dirname(__DIR__, 2) . '/pkg/pfblockerng/pfblockerng.inc';
 }
+require_once($pfb_lint_include);
 
-if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
-	pfb_lint_reply(405, ['error' => 'POST only']);
+$pfb_lint_response = pfb_lint_response(
+	$_SERVER,
+	$_POST,
+	static fn (string $page): bool => isAllowedPage($page),
+	static fn (string $lang, string $content, bool $cap): array => pfb_lint_diagnostics($lang, $content, $cap)
+);
+http_response_code($pfb_lint_response['status']);
+foreach ($pfb_lint_response['headers'] as $header) {
+	header($header);
 }
-
-$lang = $_POST['lang'] ?? null;
-if (!is_string($lang) || !in_array($lang, ['regex', 'sh', 'py'], TRUE)) {
-	// A crafted lang[]= array fails is_string() before in_array() ever runs.
-	pfb_lint_reply(400, ['error' => 'lang must be one of regex, sh, py']);
-}
-
-if ($lang === 'regex') {
-	if (!isAllowedPage('pfblockerng/pfblockerng_dnsbl.php')) {
-		pfb_lint_reply(403, ['error' => 'insufficient privilege']);
-	}
-} else {
-	// sh/py exec a real interpreter's parser -- the same Command-Prompt-equivalent
-	// trust class pfblockerng_edit_hooks.php gates on (issue #1669), not the ordinary
-	// DNSBL page priv.
-	if (!isAllowedPage('diag_command.php')) {
-		pfb_lint_reply(403, ['error' => 'insufficient privilege']);
-	}
-}
-
-$content = $_POST['content'] ?? '';
-if (!is_string($content)) {
-	pfb_lint_reply(400, ['error' => 'content must be a string']);
-}
-if (strlen($content) > 1048576) {
-	pfb_lint_reply(413, ['error' => 'content too large']);
-}
-
-$cap = (($_POST['cap'] ?? '') === '1');
-
-pfb_lint_reply(200, ['diagnostics' => pfb_lint_diagnostics($lang, $content, $cap)]);
+echo $pfb_lint_response['body'];
+exit;

--- a/src/usr/local/www/pfblockerng/pfblockerng_log.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_log.php
@@ -513,7 +513,7 @@ print($form);
 ?>
 <!-- issue #1881: the auto-scroll target lives OUTSIDE the form -- as a Form_StaticText
      row it was an empty .form-group whose theme border drew a stray separator. -->
-<div id="endofpage"></div>
+<?=pfb_log_anchor_layout_render()['endofpage']?>
 
 <script type="text/javascript">	
 //<![CDATA[

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -49,13 +49,11 @@ if (($_GET['ajax'] ?? '') === 'tail') {
 	// e.g. an HAProxy graceful-restart drain in an update hook -- one such blocked poll leaves the
 	// client's in-flight guard stuck and freezes the live tail until a manual reload.
 	session_write_close();
-	header('Content-Type: application/json');
-	header('Cache-Control: no-cache, no-store, must-revalidate');
-	$pfb_has_off = isset($_GET['offset']) && ctype_digit((string) $_GET['offset']);
-	// JSON_INVALID_UTF8_SUBSTITUTE: without it, an invalid-UTF-8 byte in the tailed log
-	// line makes json_encode() return FALSE -- print(FALSE) is an empty response body,
-	// which fails the client's JSON.parse() and stalls the live tail (issue #1814).
-	print(json_encode(pfb_log_tail_payload('update', $pfb_has_off ? (int) $_GET['offset'] : -1, $pfb_has_off), JSON_INVALID_UTF8_SUBSTITUTE));
+	$pfb_tail_response = pfb_update_tail_response($_GET, 'pfb_log_tail_payload');
+	foreach ($pfb_tail_response['headers'] as $pfb_tail_header) {
+		header($pfb_tail_header);
+	}
+	print($pfb_tail_response['body']);
 	exit;
 }
 
@@ -218,10 +216,7 @@ display_top_tabs($tab_array, TRUE);
 // Update sub-tabs: Run (this page), Hooks (pre/post update scripts), and Edit Hooks
 // (issue #1669 Part B: the gated hook-script authoring editor, directly after Hooks).
 // Second display_top_tabs row, matching the Feeds page IPv4/IPv6/DNSBL sub-tab idiom.
-$tab_array_sub	= array();
-$tab_array_sub[]	= array(gettext('Run'),		TRUE,	'/pfblockerng/pfblockerng_update.php');
-$tab_array_sub[]	= array(gettext('Hooks'),	FALSE,	'/pfblockerng/pfblockerng_hooks.php');
-$tab_array_sub[]	= array(gettext('Edit Hooks'),	FALSE,	'/pfblockerng/pfblockerng_edit_hooks.php');
+$tab_array_sub = pfb_edit_hooks_tabs('run');
 display_top_tabs($tab_array_sub, TRUE);
 pfb_print_pending_changes_box(TRUE);
 

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -32,8 +32,16 @@
  */
 
 $nocsrf = TRUE;
-@require_once('/usr/local/www/widgets/include/widget-pfblockerng.inc');
-@require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
+$pfb_widget_include = '/usr/local/www/widgets/include/widget-pfblockerng.inc';
+if (!file_exists($pfb_widget_include)) {
+	$pfb_widget_include = dirname(__DIR__) . '/include/widget-pfblockerng.inc';
+}
+@require_once($pfb_widget_include);
+$pfb_widget_pkg_include = '/usr/local/pkg/pfblockerng/pfblockerng.inc';
+if (!file_exists($pfb_widget_pkg_include)) {
+	$pfb_widget_pkg_include = dirname(__DIR__, 3) . '/pkg/pfblockerng/pfblockerng.inc';
+}
+@require_once($pfb_widget_pkg_include);
 @require_once('guiconfig.inc');
 
 pfb_global();
@@ -63,7 +71,7 @@ if ($_GET) {
 	// Called by Ajax to update widget contents
 	elseif ($_GET['getNewWidget']) {
 		$pfb_table = pfBlockerNG_get_header('js');
-		pfBlockerNG_get_table($pfb_table, 'js');
+		pfb_widget_table_call($pfb_table, 'js');
 		return;
 	}
 }
@@ -73,7 +81,7 @@ if ($_POST) {
 	// Save widget customizations
 	// issue #1050: $nocsrf=TRUE means csrf-magic never runs here -- gate the mutation itself.
 	// issue #1064: per-field reads use ?? '' -- a crafted POST (or an unchecked checkbox) omits keys.
-	if (isset($_POST['pfb_submit']) && pfb_widget_post_allowed($_SERVER)) {
+	if (pfb_widget_post_guard($_POST, $_SERVER, 'pfb_submit')) {
 		$pfb['wglobal']['widget-popup']			= pfb_filter($_POST['pfb_popup'] ?? '', PFB_FILTER_ON_OFF, 'widget');
 		$pfb['wglobal']['widget-sortmix']		= pfb_filter($_POST['pfb_sortmix'] ?? '', PFB_FILTER_ON_OFF, 'widget');
 		$pfb['wglobal']['widget-show_agg']		= pfb_filter($_POST['pfb_show_agg'] ?? '', PFB_FILTER_ON_OFF, 'widget');
@@ -179,7 +187,7 @@ if ($_POST) {
 
 	// Clear widget Failed downloads
 	// issue #1050: $nocsrf=TRUE means csrf-magic never runs here -- gate the mutation itself.
-	elseif (!empty($_POST['pfblockerngack']) && pfb_widget_post_allowed($_SERVER)) {
+	elseif (pfb_widget_post_guard($_POST, $_SERVER, 'pfblockerngack')) {
 		exec("{$pfb['sed']} -i '' 's/FAIL/Fail/g' /var/log/pfblockerng/error.log");
 		// issue #999: ADR-61 moved the reporting list to the sync-status ledger --
 		// close the entries it actually reads, not just the retired error.log.
@@ -189,7 +197,7 @@ if ($_POST) {
 	}
 
 	// Clear widget IP/DNSBL Packet Counts
-	elseif (!empty($_POST['pfblockerngclearall']) && pfb_widget_post_allowed($_SERVER)) {
+	elseif (pfb_widget_post_guard($_POST, $_SERVER, 'pfblockerngclearall')) {
 		pfBlockerNG_clearip();
 		pfBlockerNG_clearsqlite('clearip');
 		pfBlockerNG_clearsqlite('cleardnsbl');
@@ -198,7 +206,7 @@ if ($_POST) {
 	}
 
 	// Clear widget IP Packet Counts
-	elseif (!empty($_POST['pfblockerngclearip']) && pfb_widget_post_allowed($_SERVER)) {
+	elseif (pfb_widget_post_guard($_POST, $_SERVER, 'pfblockerngclearip')) {
 		pfBlockerNG_clearip();
 		pfBlockerNG_clearsqlite('clearip');
 		header("Location: /");
@@ -206,7 +214,7 @@ if ($_POST) {
 	}
 
 	// Clear widget DNSBL Packet Counts
-	elseif (!empty($_POST['pfblockerngcleardnsbl']) && pfb_widget_post_allowed($_SERVER)) {
+	elseif (pfb_widget_post_guard($_POST, $_SERVER, 'pfblockerngcleardnsbl')) {
 		pfBlockerNG_clearsqlite('cleardnsbl');
 		header("Location: /");
 		exit(0);
@@ -935,10 +943,7 @@ function pfBlockerNG_get_header($mode='') {
 
 				if ($data == 'Suppression' || $data == 'Whitelist') {
 					$d_type = ($data == 'Suppression') ? 'ip' : 'dnsbl';
-					// issue #1881: link the target section's own id -- the dedicated
-					// "#Suppression"/"#Whitelist" anchor rows were empty form rows
-					// drawing stray separators and are gone.
-					$d_anchor = ($data == 'Suppression') ? 'IPv4_Suppression_customlist' : 'DNSBL_Whitelist_customlist';
+					$d_anchor = pfb_widget_anchor_layout_render($d_type)[$data === 'Suppression' ? 'suppression' : 'whitelist'];
 					print("{$tab5}<td {$tdl} title=\"{$titles[$key][$data]}\"><i class=\"{$faicon[$key][$col]}\"></i>&nbsp;&nbsp;"
 						. "<a target=\"_blank\" href=\"/pfblockerng/pfblockerng_{$d_type}.php#{$d_anchor}\" title=\"Link to {$data}\">"
 						. "<small><span class=\"pfb_{$data}\">{$value}</span></small></a></td>\n");
@@ -1096,7 +1101,7 @@ function pfBlockerNG_get_table($pfb_table, $mode='') {
 			</thead>
 			<tbody id="pfBNG-table">
 				<!-- Print table contents, subsequent refresh by javascript function -->
-				<?=pfBlockerNG_get_table($pfb_table);?>
+				<?=pfb_widget_table_call($pfb_table);?>
 			</tbody>
 		</table>
 	</div>

--- a/tests/php/AlertsFilterFieldsInitTest.php
+++ b/tests/php/AlertsFilterFieldsInitTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\TestCase;
 final class AlertsFilterFieldsInitTest extends TestCase
 {
 	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+	private static string $initRegion;
 
 	public static function setUpBeforeClass(): void
 	{
@@ -40,17 +41,24 @@ final class AlertsFilterFieldsInitTest extends TestCase
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_alerts.php');
 		}
 		if (!preg_match(
-			'/\/\/ Initialize filterfieldsarray\n(.*?\$filterfieldsarray\[\d\]\[\$field_2\] = \'\';\n\})\n/s',
+			'/((?:\$filterfieldsarray\s*=\s*array\(\);\n).*?\$filterfieldsarray\[\d\]\[\$field_2\] = \'\';\n\})\n/s',
 			$src,
 			$m
 		)) {
 			throw new RuntimeException('test bootstrap: filterfieldsarray init block not found');
 		}
+		self::$initRegion = $m[1];
 		eval(
 			'function pfb_alerts_oracle_filterfieldsarray_init(): array {'
 			. $m[1]
 			. ' return $filterfieldsarray; }'
 		);
+	}
+
+	public function testExtractionStartsAtExecutableCodeNotProductionComment(): void
+	{
+		$this->assertStringStartsWith('$filterfieldsarray', self::$initRegion);
+		$this->assertStringNotContainsString('Initialize filterfieldsarray', self::$initRegion);
 	}
 
 	public function testSlotTwoIsSeededWithItsOwn81Through89KeySet(): void

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -49,28 +49,27 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		$src = file_get_contents(
+		$src = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
 		);
-		if ($src === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_alerts.php');
+		if ($src === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng_alerts.php');
 		}
 
 		// Region 1: the delete_ip case body (own trailing break;) -- wrapped in a
 		// throwaway switch so `break;` has a valid target.
 		if (!function_exists('pfb_alerts_oracle_delete_ip')) {
-			if (!preg_match(
-				'/case \'delete_ip\':\n(.*?)\n\t\t\tcase \'delete_ipwhitelist\':/s',
-				$src,
-				$m
-			)) {
+			$start = strpos($src, "case 'delete_ip':");
+			$end = strpos($src, "case 'delete_ipwhitelist':", $start === FALSE ? 0 : $start);
+			if ($start === FALSE || $end === FALSE || $end <= $start) {
 				throw new RuntimeException('test bootstrap: delete_ip region not found');
 			}
+			$region = substr($src, $start + strlen("case 'delete_ip':"), $end - $start - strlen("case 'delete_ip':"));
 			eval(
 				'function pfb_alerts_oracle_delete_ip(string $entry, string $table, array &$clists): array {'
 				. ' global $pfb; $pfb_found = TRUE; $savemsg = \'\'; $type = \'\';'
 				. ' switch (1) { case 1:'
-				. $m[1]
+				. $region
 				. ' }'
 				. ' return [\'pfb_found\' => $pfb_found, \'savemsg\' => $savemsg]; }'
 			);
@@ -78,18 +77,17 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 
 		// Region 2: the delete_ipwhitelist case body (own trailing break;).
 		if (!function_exists('pfb_alerts_oracle_delete_ipwhitelist')) {
-			if (!preg_match(
-				'/case \'delete_ipwhitelist\':\n(.*?)\n\t\t\tdefault:/s',
-				$src,
-				$m
-			)) {
+			$start = strpos($src, "case 'delete_ipwhitelist':");
+			$end = strpos($src, 'default:', $start === FALSE ? 0 : $start);
+			if ($start === FALSE || $end === FALSE || $end <= $start) {
 				throw new RuntimeException('test bootstrap: delete_ipwhitelist region not found');
 			}
+			$region = substr($src, $start + strlen("case 'delete_ipwhitelist':"), $end - $start - strlen("case 'delete_ipwhitelist':"));
 			eval(
 				'function pfb_alerts_oracle_delete_ipwhitelist(string $entry, string $table, array &$clists): array {'
 				. ' global $pfb; $pfb_found = TRUE; $savemsg = \'\'; $type = \'\';'
 				. ' switch (1) { case 1:'
-				. $m[1]
+				. $region
 				. ' }'
 				. ' if ($pfb_found) { write_config("pfBlockerNG: Deleted [ {$entry} ] from {$type} customlist", FALSE); }'
 				. ' return [\'pfb_found\' => $pfb_found, \'savemsg\' => $savemsg]; }'
@@ -785,8 +783,10 @@ SH
 
 	public function testAlertsPageDispatchKeepsFiltersNavigationAndStrictIpActions(): void
 	{
-		$src = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php');
-		$this->assertNotFalse($src);
+		// Top-level POST dispatch has no off-appliance callable seam; this retained
+		// pin uses comment-free PHP tokens so nearby production prose is irrelevant.
+		$src = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php');
+		$this->assertNotSame('', $src, 'comment-free Alerts source must be readable');
 
 		$this->assertStringContainsString("pfb_filter(\$_POST['ip'], PFB_FILTER_IP, 'alerts addsuppress')", $src);
 		$this->assertStringContainsString("pfb_filter(\$_POST['table'], PFB_FILTER_WORD, 'alerts addsuppress')", $src);
@@ -797,8 +797,8 @@ SH
 		$this->assertStringContainsString("pfb_filter(\$_POST['table'], PFB_FILTER_WORD, 'alerts ip_remove')", $src);
 		$this->assertStringContainsString('header("Location: /pfblockerng/pfblockerng_category_edit.php?type=ipv{$vtype}&act=addgroup', $src);
 
-		$remove_start = strpos($src, "\telseif (isset(\$_POST['ip_remove'])");
-		$remove_end = strpos($src, "\n\t// Whitelist IP events", $remove_start);
+		$remove_start = strpos($src, "} elseif (isset(\$_POST['ip_remove'])");
+		$remove_end = strpos($src, "} elseif (isset(\$_POST['ip_white'])", $remove_start === FALSE ? 0 : $remove_start);
 		$this->assertNotFalse($remove_start);
 		$this->assertNotFalse($remove_end);
 		$remove = substr($src, $remove_start, $remove_end - $remove_start);

--- a/tests/php/AlertsStatPipelineLocaleSafetyTest.php
+++ b/tests/php/AlertsStatPipelineLocaleSafetyTest.php
@@ -34,6 +34,8 @@ use PHPUnit\Framework\TestCase;
  *     pin (same convention as UpdateAjaxTailJsonEncodingTest's call-site flag
  *     pin) covering EVERY exec( in the block -- the coverage axis the brief
  *     asks for, cheaper than eval-extracting and driving all ~20 pipelines.
+ *     This top-level block has no off-appliance callable seam, so the retained
+ *     pin scans php_strip_whitespace() output and cannot depend on comments.
  */
 #[CoversNothing]
 final class AlertsStatPipelineLocaleSafetyTest extends TestCase
@@ -41,8 +43,7 @@ final class AlertsStatPipelineLocaleSafetyTest extends TestCase
 	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
 
 	/** Bounds the whole per-$stat_type stats/chart section (both anchors are unique in the file). */
-	private const BLOCK_START_ANCHOR = "\$cut_cmd = \"{\$pfb['cut']} -d ',' -f{\$column}\";";
-	private const BLOCK_END_ANCHOR = '// Collect DNSBL widget statistics';
+	private const BLOCK_END_ANCHOR = 'function pfb_hsc(';
 
 	private string|false $prevLcAll = FALSE;
 	private string $tmpLog = '';
@@ -52,21 +53,19 @@ final class AlertsStatPipelineLocaleSafetyTest extends TestCase
 		if (function_exists('pfb_alerts_oracle_default_stat_pipeline')) {
 			return;
 		}
-		$src = self::readSource();
-
 		// Anchored on the literal `default:` case of the $stat_type switch -- the
 		// simplest pipeline in the block (fewest interpolated command vars), verbatim.
-		$block = self::boundedBlock($src);
-		$defPos = strpos($block, "default:\n");
+		$block = self::boundedCodeBlock();
+		$defPos = strpos($block, 'default:');
 		if ($defPos === FALSE) {
 			throw new RuntimeException('test bootstrap: default: case not found in the stats/chart switch');
 		}
-		$lineStart = $defPos + strlen("default:\n");
-		$lineEnd = strpos($block, "\n", $lineStart);
-		if ($lineEnd === FALSE) {
+		$lineStart = strpos($block, 'exec("', $defPos);
+		$lineEnd = strpos($block, ');', $lineStart === FALSE ? 0 : $lineStart);
+		if ($lineStart === FALSE || $lineEnd === FALSE) {
 			throw new RuntimeException('test bootstrap: could not find the end of the default: case exec() line');
 		}
-		$execLine = trim(substr($block, $lineStart, $lineEnd - $lineStart));
+		$execLine = substr($block, $lineStart, $lineEnd + 2 - $lineStart);
 		if (strpos($execLine, 'exec(') !== 0) {
 			throw new RuntimeException("test bootstrap: default: case body was not the expected single exec() line, got: {$execLine}");
 		}
@@ -101,26 +100,18 @@ final class AlertsStatPipelineLocaleSafetyTest extends TestCase
 		}
 	}
 
-	private static function readSource(): string
+	private static function boundedCodeBlock(): string
 	{
-		$src = file_get_contents(self::ALERTS_PHP);
-		if ($src === FALSE) {
-			throw new RuntimeException('test oracle: failed to read ' . self::ALERTS_PHP);
+		$code = php_strip_whitespace(self::ALERTS_PHP);
+		if ($code === '') {
+			throw new RuntimeException('test oracle: failed to read comment-free Alerts source');
 		}
-		return $src;
-	}
-
-	private static function boundedBlock(string $src): string
-	{
-		$start = strpos($src, self::BLOCK_START_ANCHOR);
-		if ($start === FALSE) {
-			throw new RuntimeException('test oracle: stats/chart block start anchor not found');
+		$start = strpos($code, '$cut_cmd =');
+		$end = strpos($code, self::BLOCK_END_ANCHOR, $start === FALSE ? 0 : $start);
+		if ($start === FALSE || $end === FALSE || $end <= $start) {
+			throw new RuntimeException('test oracle: comment-free stats/chart block bounds not found');
 		}
-		$end = strpos($src, self::BLOCK_END_ANCHOR, $start);
-		if ($end === FALSE || $end <= $start) {
-			throw new RuntimeException('test oracle: stats/chart block end anchor not found');
-		}
-		return substr($src, $start, $end - $start);
+		return substr($code, $start, $end - $start);
 	}
 
 	public function testDefaultStatPipelineSurvivesAnInvalidUtf8ByteUnderAUtf8Locale(): void
@@ -161,7 +152,7 @@ final class AlertsStatPipelineLocaleSafetyTest extends TestCase
 
 	public function testEveryStatChartExecCarriesTheByteSafeLocalePrefix(): void
 	{
-		$block = self::boundedBlock(self::readSource());
+		$block = self::boundedCodeBlock();
 
 		// Every site in this block calls exec("...") -- a double-quoted string
 		// literal as the first argument -- never exec($var) or a single-quoted one.

--- a/tests/php/AlertsUnboundCachePolicyTest.php
+++ b/tests/php/AlertsUnboundCachePolicyTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 /**
  * Issue #1615 -- Alerts generation changes flush only allow-to-block deltas:
  * exact names target one cache entry; wildcard removals flush the full cache.
+ * The page dispatch is top-level and has no off-appliance callable seam; retained
+ * wiring pins therefore read php_strip_whitespace() output, never production prose.
  */
 final class AlertsUnboundCachePolicyTest extends TestCase
 {
@@ -14,9 +16,11 @@ final class AlertsUnboundCachePolicyTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		self::$source = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
-		);
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+		self::$source = php_strip_whitespace($path);
+		if (self::$source === '') {
+			throw new RuntimeException('test bootstrap: failed to read Alerts source');
+		}
 	}
 
 	private function region(string $startMarker, string $endMarker): string
@@ -42,17 +46,17 @@ final class AlertsUnboundCachePolicyTest extends TestCase
 	public function testKnownAllowToBlockChangesFlushTheirFiniteNameSetAfterReload(): void
 	{
 		$this->assertOrdered(
-			$this->region('// Add Domain to DNSBL Customlist', '// Add Domain/CNAME(s) to the DNSBL Whitelist'),
+			$this->region("elseif (isset(\$_POST['dnsbl_add'])", "} elseif (isset(\$_POST['addwhitelistdom'])"),
 			"pfb_reload_unbound('enabled', FALSE, TRUE, TRUE);",
 			'pfb_unbound_py_ccache_flush(array($domain));'
 		);
 		$this->assertOrdered(
-			$this->region("if (\$_POST['entry_delete'] == 'delete_domainwildcard')", '// Unlock/Lock DNSBL events'),
+			$this->region("if (\$_POST['entry_delete'] == 'delete_domainwildcard')", "} elseif (isset(\$_POST['dnsbl_remove'])"),
 			"pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);",
 			'pfb_unbound_py_ccache_flush(array($entry));'
 		);
 		$this->assertOrdered(
-			$this->region('// Unlock/Lock DNSBL events', '// sprintf with the (domain-filtered'),
+			$this->region("elseif (isset(\$_POST['dnsbl_remove'])", "} elseif (isset(\$_POST['ip_remove'])"),
 			"pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);",
 			'pfb_unbound_py_ccache_flush(array($domain));'
 		);
@@ -60,7 +64,7 @@ final class AlertsUnboundCachePolicyTest extends TestCase
 
 	public function testWildcardWhitelistRemovalFlushesFullCacheAfterSuccessfulSwap(): void
 	{
-		$delete = $this->region('// Delete entry from customlists', '// Unlock/Lock DNSBL events');
+		$delete = $this->region("elseif (isset(\$_POST['entry_delete'])", "} elseif (isset(\$_POST['dnsbl_remove'])");
 
 		$this->assertOrdered(
 			$delete,
@@ -75,10 +79,10 @@ final class AlertsUnboundCachePolicyTest extends TestCase
 	public function testBlockToAllowAlertsChangesDoNotFlushUnboundCache(): void
 	{
 		$whitelist = $this->region(
-			'// Add Domain/CNAME(s) to the DNSBL Whitelist',
-			'// Save Domain/CNAME(s) to the TLD Exclusion customlist'
+			"elseif (isset(\$_POST['addwhitelistdom'])",
+			"} elseif (isset(\$_POST['entry_delete'])"
 		);
-		$unlock = $this->region('// Unlock/Lock DNSBL events', '// sprintf with the (domain-filtered');
+		$unlock = $this->region("elseif (isset(\$_POST['dnsbl_remove'])", "} elseif (isset(\$_POST['ip_remove'])");
 
 		$this->assertStringNotContainsString('flush {$domain_esc}', $whitelist);
 		$this->assertStringNotContainsString('if ($action == \'unlock\')', $unlock);

--- a/tests/php/AliasCntGrepCountGuardTest.php
+++ b/tests/php/AliasCntGrepCountGuardTest.php
@@ -2,96 +2,87 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * $alias_cnt accumulation from a per-file line count (issue #1162; issue
- * #1261: the exec("grep -c ^ <file>") fork is replaced by pfb_count_lines()).
- *
- * sync_package_pfblockerng() has sites that feed a file's line count into
- * `+` arithmetic: `$alias_cnt = $alias_cnt + $list_cnt;`. Before #1261,
- * $list_cnt came from exec()'s raw output (a non-numeric string on a failed
- * grep, needing an inline (int) cast). Now pfb_count_lines() returns ?int
- * directly, and NULL (read failure) is coerced to 0 at the assignment
- * (`?? 0`) -- so $list_cnt is always a plain int by the time it reaches the
- * accumulation, and the accumulation itself needs no cast. Both sites are
- * inside sync_package_pfblockerng(), not unit-reachable directly -- pinned
- * here via source-inspection (house precedent:
- * tests/php/DownloadRetvalFailsafeTest.php) plus a mirrored-expression data
- * provider (house precedent: tests/php/IpRegexPrefilterGuardTest.php).
+ * Alias totals use the apply-pass count seam: unreadable input contributes zero,
+ * while empty and unterminated files retain their real line counts.
  */
 final class AliasCntGrepCountGuardTest extends TestCase
 {
-	private static string $src;
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	private string $dir;
 
 	public static function setUpBeforeClass(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
-		$src = file_get_contents($path);
-		if ($src === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	}
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_alias_count_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->dir}/*") ?: [] as $path) {
+			is_dir($path) ? @rmdir($path) : @unlink($path);
 		}
-		self::$src = $src;
+		@rmdir($this->dir);
 	}
 
-	// -----------------------------------------------------------------------
-	// Source-inspection pin -- both $alias_cnt accumulation sites exist, both
-	// feed from pfb_count_lines() with a `?? 0` NULL fallback, and no exec()
-	// grep fork survives at either site.
-	// -----------------------------------------------------------------------
-
-	private const ACCUMULATION_RE = '/\$alias_cnt\s*=\s*\$alias_cnt\s*\+\s*\$list_cnt\s*;/';
-	private const COUNT_ASSIGN_RE = '/\$list_cnt\s*=\s*pfb_count_lines\([^;]*\)\s*\?\?\s*0\s*;/';
-
-	public function testVacuityExactlyFourAccumulationSitesExist(): void
-	{
-		$count = preg_match_all(self::ACCUMULATION_RE, self::$src);
-		$this->assertSame(4, $count,
-			'expected exactly 4 $alias_cnt = $alias_cnt + $list_cnt; accumulation sites '
-			. '(list-reuse branch, the issue #1797 norm-unchanged skip branch, the '
-			. 'downloaded/rebuilt branch, and the issue #1926 DNSBL pre-script-failure '
-			. "manifest-kept branch); found {$count}");
-	}
-
-	public function testAllSitesAssignListCntFromPfbCountLinesWithNullFallback(): void
-	{
-		$count = preg_match_all(self::COUNT_ASSIGN_RE, self::$src);
-		$this->assertSame(4, $count,
-			'expected exactly 4 `$list_cnt = pfb_count_lines(...) ?? 0;` assignments feeding '
-			. "the accumulation sites (issue #1261, extended by issue #1926); found {$count}");
-	}
-
-	public function testNoExecGrepForkSurvivesForListCnt(): void
-	{
-		$this->assertDoesNotMatchRegularExpression(
-			'/\$list_cnt\s*=\s*exec\(/',
-			self::$src,
-			'a $list_cnt = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
-		);
-	}
-
-	// -----------------------------------------------------------------------
-	// Mirrored-expression hostile-input rows (issue #1162's failure mode +
-	// the happy path). Mirrors the production expressions exactly.
-	// -----------------------------------------------------------------------
-
-	public static function accumulationRows(): array
+	/** @return array<string, array{string}> */
+	public static function aliasSeams(): array
 	{
 		return [
-			'NULL count (pfb_count_lines() read failure)' => [NULL, 0],
-			'happy path count'                             => [42, 42],
-			'zero count (empty file)'                      => [0, 0],
+			'verbatim reuse'    => ['pfb_dnsbl_alias_count_verbatim'],
+			'normalize skip'    => ['pfb_dnsbl_alias_count_norm_skip'],
+			'pre-script failure' => ['pfb_dnsbl_alias_count_script_failure'],
+			'rebuilt feed'      => ['pfb_dnsbl_alias_count_rebuild'],
 		];
 	}
 
-	/** Mirror of the post-#1261 `$list_cnt = pfb_count_lines(...) ?? 0; $alias_cnt = $alias_cnt + $list_cnt;`. */
-	#[DataProvider('accumulationRows')]
-	public function testAccumulationNeverThrowsAndCoercesNullToZero(?int $pfbCountLinesResult, int $expect): void
+	#[\PHPUnit\Framework\Attributes\DataProvider('aliasSeams')]
+	public function testEveryAliasRouteUsesSafeFileLineCount(string $seam): void
 	{
-		$alias_cnt = 0;
-		$list_cnt  = $pfbCountLinesResult ?? 0;
-		$alias_cnt = $alias_cnt + $list_cnt;
-		$this->assertSame($expect, $alias_cnt);
+		$path = "{$this->dir}/feed.txt";
+		$this->assertNotFalse(file_put_contents($path, "one\ntwo\n"));
+
+		$this->assertSame(12, $seam($path, 10));
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('aliasSeams')]
+	public function testEveryAliasRouteCountsAnUnterminatedLastLine(string $seam): void
+	{
+		$path = "{$this->dir}/unterminated.txt";
+		$this->assertNotFalse(file_put_contents($path, "one\ntwo"));
+		$this->assertSame(12, $seam($path, 10));
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('aliasSeams')]
+	public function testEveryAliasRouteTurnsReadFailureIntoZero(string $seam): void
+	{
+		$path = "{$this->dir}/unreadable";
+		$this->assertTrue(mkdir($path, 0700));
+
+		$this->assertSame(10, $seam($path, 10));
+	}
+
+	/**
+	 * sync_package_pfblockerng() has no safe off-appliance driver (#993); it performs live
+	 * downloads, firewall changes, and service work. These four thin executable-code pins are
+	 * therefore retained only for outer dispatch. Comments/docblocks are stripped first; each
+	 * route's count behavior is executed above.
+	 */
+	public function testSyncPassDispatchesEveryDistinctAliasCountRoute(): void
+	{
+		$source = php_strip_whitespace(self::APPLY);
+		$start = strpos($source, 'function sync_package_pfblockerng(');
+		$this->assertNotFalse($start);
+		$sync = substr($source, $start);
+		foreach (self::aliasSeams() as [$seam]) {
+			$this->assertSame(1, substr_count($sync, "{$seam}("), "sync pass must dispatch {$seam} exactly once");
+		}
 	}
 }

--- a/tests/php/AliasCntGrepCountGuardTest.php
+++ b/tests/php/AliasCntGrepCountGuardTest.php
@@ -15,7 +15,7 @@ final class AliasCntGrepCountGuardTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+		require_once self::APPLY;
 	}
 
 	protected function setUp(): void
@@ -80,7 +80,9 @@ final class AliasCntGrepCountGuardTest extends TestCase
 		$source = php_strip_whitespace(self::APPLY);
 		$start = strpos($source, 'function sync_package_pfblockerng(');
 		$this->assertNotFalse($start);
-		$sync = substr($source, $start);
+		$end = strrpos($source, 'pfb_feed_pass_release();');
+		$this->assertNotFalse($end);
+		$sync = substr($source, $start, $end + strlen('pfb_feed_pass_release();') - $start);
 		foreach (self::aliasSeams() as [$seam]) {
 			$this->assertSame(1, substr_count($sync, "{$seam}("), "sync pass must dispatch {$seam} exactly once");
 		}

--- a/tests/php/AnchorRowRelocationWiringTest.php
+++ b/tests/php/AnchorRowRelocationWiringTest.php
@@ -4,108 +4,36 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1881 -- three page anchors used to be their own empty Form_StaticText rows, each
- * drawing a stray horizontal separator (every .form-group carries a theme border-bottom).
- * The issue's original "all three are dead, delete them" premise was falsified on the
- * issue: the dashboard widget builds "#Suppression"/"#Whitelist" links dynamically
- * (pfblockerng.widget.php, href=".../pfblockerng_{$d_type}.php#{$data}"), and
- * "#endofpage" is pfblockerng_log.php's own scrollIntoView() target. So the fix is
- * RELOCATION, not deletion:
- *
- *  - the widget links retarget the existing Form_Section ids
- *    (#IPv4_Suppression_customlist / #DNSBL_Whitelist_customlist -- section ids render as
- *    DOM ids, e.g. the dnsbl page's own $('#Python_Group_Policy') JS relies on that), and
- *    the two empty anchor rows are deleted;
- *  - the log page's #endofpage div moves out of the form (raw HTML after print($form)),
- *    so the scroll target survives with no .form-group around it.
- *
- * Source pins are the Tier-A coverage for pages carrying top-level render execution
- * (DnsblRegexHighlightWiringTest precedent); the visual empty-row absence and the live
- * scroll behaviour are Tier-B browser coverage.
- */
 final class AnchorRowRelocationWiringTest extends TestCase
 {
-	private static function src(string $rel): string
+	public function testDnsblLayoutUsesWhitelistSectionAndNoLegacyRows(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/' . $rel;
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException("failed to read {$rel}");
-		}
-		return $src;
+		$layout = pfb_dnsbl_anchor_layout_render();
+
+		$this->assertSame([], $layout['legacy_rows']);
+		$this->assertSame('DNSBL_Whitelist_customlist', $layout['whitelist']);
 	}
 
-	public function testDnsblPageNoLongerRendersTheEmptyWhitelistAnchorRow(): void
+	public function testIpLayoutUsesSuppressionSectionAndNoLegacyRows(): void
 	{
-		$this->assertStringNotContainsString(
-			'<div id="Whitelist"></div>',
-			self::src('pfblockerng/pfblockerng_dnsbl.php'),
-			'expected the empty #Whitelist Form_StaticText anchor row to be gone from the DNSBL page'
-		);
+		$layout = pfb_ip_anchor_layout_render();
+
+		$this->assertSame([], $layout['legacy_rows']);
+		$this->assertSame('IPv4_Suppression_customlist', $layout['suppression']);
 	}
 
-	public function testIpPageNoLongerRendersTheEmptySuppressionAnchorRow(): void
+	public function testLogLayoutRendersEndAnchorOutsideTheForm(): void
 	{
-		$this->assertStringNotContainsString(
-			'<div id="Suppression"></div>',
-			self::src('pfblockerng/pfblockerng_ip.php'),
-			'expected the empty #Suppression Form_StaticText anchor row to be gone from the IP page'
-		);
+		$layout = pfb_log_anchor_layout_render();
+
+		$this->assertSame([], $layout['legacy_rows']);
+		$this->assertSame('<div id="endofpage"></div>', $layout['endofpage']);
+		$this->assertTrue($layout['outside_form']);
 	}
 
-	public function testWidgetLinksTargetTheSectionIdsInsteadOfTheDeletedAnchors(): void
+	public function testUnknownPageCannotSilentlyProduceAnAnchor(): void
 	{
-		$widget = self::src('widgets/widgets/pfblockerng.widget.php');
-		$this->assertStringContainsString(
-			'IPv4_Suppression_customlist',
-			$widget,
-			'expected the widget Suppression link to target the IPv4 Suppression section id'
-		);
-		$this->assertStringContainsString(
-			'DNSBL_Whitelist_customlist',
-			$widget,
-			'expected the widget Whitelist link to target the DNSBL Whitelist section id'
-		);
-		$this->assertStringNotContainsString(
-			'.php#{$data}',
-			$widget,
-			'expected the raw #{$data} fragment (which produced the now-deleted #Suppression/#Whitelist anchors) to be gone'
-		);
-	}
-
-	public function testLogPageEndofpageAnchorSurvivesOutsideTheForm(): void
-	{
-		$log = self::src('pfblockerng/pfblockerng_log.php');
-
-		// The scroll target must still exist -- the page's own JS scrolls to it...
-		$this->assertStringContainsString(
-			'<div id="endofpage"></div>',
-			$log,
-			'expected the #endofpage scroll target to still exist on the Logs page'
-		);
-		$this->assertStringContainsString(
-			'getElementById("endofpage")',
-			$log,
-			'expected the auto-scroll JS consumer of #endofpage to remain'
-		);
-
-		// ...but no longer as a Form_StaticText row inside the form: the div must render
-		// AFTER print($form), where no .form-group (and thus no bordered row) wraps it.
-		$divPos   = strpos($log, '<div id="endofpage"></div>');
-		$printPos = strpos($log, 'print($form);');
-		$this->assertNotFalse($printPos, 'expected print($form); in pfblockerng_log.php');
-		$this->assertGreaterThan(
-			$printPos,
-			$divPos,
-			'expected the #endofpage div to render after print($form) -- inside the form it is an '
-			. 'empty Form_StaticText row drawing a stray separator'
-		);
-		// Vacuity guard for the relocation: the old in-form Form_StaticText carrier is gone.
-		$this->assertSame(
-			1,
-			substr_count($log, '<div id="endofpage"></div>'),
-			'expected exactly one #endofpage div (the relocated one) -- a leftover in-form copy would keep the stray row'
-		);
+		$this->expectException(InvalidArgumentException::class);
+		pfb_page_anchor_layout('unknown');
 	}
 }

--- a/tests/php/BlacklistLangFallbackTest.php
+++ b/tests/php/BlacklistLangFallbackTest.php
@@ -34,6 +34,7 @@ final class BlacklistLangFallbackTest extends TestCase
 {
 	private const BLACKLIST_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_blacklist.php';
 	private const UT1_FILE = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/ut1_global_usage';
+	private static string $parseRegion;
 
 	/** Matches pfblockerng_blacklist.php's own $options_blacklist_lang (:143-144). */
 	private const LANGS = ['EN', 'DE', 'FR', 'IT', 'NL', 'PT', 'ES', 'RU'];
@@ -47,12 +48,13 @@ final class BlacklistLangFallbackTest extends TestCase
 
 		if (!function_exists('pfb_blacklist_oracle_parse_data')) {
 			if (!preg_match(
-				'/(\/\/ Build array of Blacklist categories and descriptions by language\n.*?\n\tksort\(\$data, SORT_NATURAL\);\n)/s',
+				'/((?:\$data\s*=\s*array\(\);\n).*?\n\tksort\(\$data, SORT_NATURAL\);\n)/s',
 				$src,
 				$m
 			)) {
 				throw new RuntimeException('test bootstrap: blacklist category/description parse block not found');
 			}
+			self::$parseRegion = $m[1];
 			eval(
 				'function pfb_blacklist_oracle_parse_data(array $contents): array {'
 				. ' $type = \'x\'; $blacklist_types = [\'x\' => [\'CONTENTS\' => $contents]];'
@@ -87,6 +89,12 @@ final class BlacklistLangFallbackTest extends TestCase
 				. ' return [$category_lang, $name_lang]; }'
 			);
 		}
+	}
+
+	public function testParseExtractionStartsAtExecutableCodeNotProductionComment(): void
+	{
+		$this->assertStringStartsWith('$data', self::$parseRegion);
+		$this->assertStringNotContainsString('Build array of Blacklist categories', self::$parseRegion);
 	}
 
 	/**

--- a/tests/php/CategoryEditAutoSortTest.php
+++ b/tests/php/CategoryEditAutoSortTest.php
@@ -16,28 +16,31 @@ use PHPUnit\Framework\TestCase;
  *
  * Like CategoryEditRowMoveTest, the page carries top-level execution and
  * cannot be require()d off-appliance: the sort block is eval-extracted
- * verbatim from the REAL source, anchored on its own leading comment, as a
+ * from the REAL source using its executable if/assignment boundaries, as a
  * pure array transform.
  */
 final class CategoryEditAutoSortTest extends TestCase
 {
 	public static function setUpBeforeClass(): void
 	{
-		$src = file_get_contents(
+		$src = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
 		);
-		if ($src === false) {
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
 		}
 
 		if (!function_exists('pfb_category_oracle_auto_sort')) {
 			if (!preg_match(
-				'/\/\/ Sort row by Header\/Label field followed by Enabled\/Disabled State settings\n'
-				. '(if \(empty\(\$input_errors\).*?\$rowdata\[\$rowid\]\[\'row\'\] = \$final;\n)/s',
+				'/(if \(empty\(\$input_errors\).*?\$rowdata\[\$rowid\]\[\'row\'\] = \$final;)'
+				. '\s*\}\s*\$numrows/s',
 				$src,
 				$m
 			)) {
 				throw new RuntimeException('test bootstrap: auto-sort block not found');
+			}
+			if (strpos($m[1], '$rowdata[$rowid][\'row\'] = $final;') === FALSE) {
+				throw new RuntimeException('test bootstrap: auto-sort executable boundary lost its assignment');
 			}
 			eval(
 				'function pfb_category_oracle_auto_sort(array $rowdata, $rowid): array {'

--- a/tests/php/CategoryEditCustomEditorSortModePlacementTest.php
+++ b/tests/php/CategoryEditCustomEditorSortModePlacementTest.php
@@ -4,45 +4,21 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1875 step 2b fix -- the CM6 mount for the 'custom' field must render in EVERY
- * page mode, not only when the row-reorder block does.
- *
- * The first wiring pass placed the gated mountLists init inside the pre-existing
- * ADR-63 events.push, which is itself wrapped in the
- * `($rowdata[$rowid]['sort'] ?? '') == 'no-sort'` PHP conditional: auto-sort groups AND
- * brand-new groups (no rowid, so 'sort' resolves to '') rendered no editor at all,
- * while the 'custom' Form_Textarea itself renders unconditionally.
- * CategoryEditCustomEditorWiringTest cannot see this: its gate regex matches the
- * events.push/gate/mountLists chain wherever it sits, including inside an unrelated
- * outer conditional. This test pins the placement: the mountLists init must appear
- * BEFORE the no-sort conditional opens, i.e. outside it (same source-pin rationale as
- * the sibling wiring tests -- the page carries top-level render execution and cannot be
- * require()d off-appliance).
- */
 final class CategoryEditCustomEditorSortModePlacementTest extends TestCase
 {
-	public function testMountListsInitSitsOutsideTheNoSortRowReorderConditional(): void
+	public function testCustomEditorMountRunsForNoSortAndAutoSortRows(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_category_edit.php');
-		}
+		$noSort = pfb_category_editor_render(TRUE, 'no-sort')['mount'];
+		$auto   = pfb_category_editor_render(TRUE, 'auto-sort')['mount'];
 
-		// The full open-tag form is unique to the script-section conditional; the bare
-		// `['sort'] ?? '') == 'no-sort'` literal also matches the earlier gutter-render
-		// if() (~line 1140), which is not the block that swallowed the mount.
-		$mountPos = strpos($src, 'pfbCM.mountLists(');
-		$sortPos  = strpos($src, "<?php if ((\$rowdata[\$rowid]['sort'] ?? '') == 'no-sort') { ?>");
+		$this->assertStringContainsString('pfbCM.mountLists', $noSort);
+		$this->assertStringContainsString('custom', $noSort);
+		$this->assertSame($noSort, $auto);
+	}
 
-		$this->assertNotFalse($mountPos, 'expected a pfbCM.mountLists( call in the file');
-		$this->assertNotFalse($sortPos, 'expected the ADR-63 no-sort row-reorder conditional in the file');
-		$this->assertLessThan(
-			$sortPos,
-			$mountPos,
-			'expected the pfbCM.mountLists( init to appear BEFORE (outside) the no-sort row-reorder '
-			. 'conditional -- inside it, auto-sort groups and new groups render no editor at all'
-		);
+	public function testDisabledCustomEditorStaysEmptyRegardlessOfSortMode(): void
+	{
+		$this->assertSame('', pfb_category_editor_render(FALSE, 'no-sort')['mount']);
+		$this->assertSame('', pfb_category_editor_render(FALSE, 'auto-sort')['mount']);
 	}
 }

--- a/tests/php/CategoryEditCustomEditorWiringTest.php
+++ b/tests/php/CategoryEditCustomEditorWiringTest.php
@@ -4,113 +4,19 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1875 step 2a (RED, test-first): mounting the CM6 editor on the Category-Edit
- * page's custom-list field (custom), gated by the same `$pfb_syntaxhl_on` boolean idiom
- * pfblockerng_dnsbl.php already establishes
- * (`pfb_editor_enabled()`, the issue #1887 named accessor).
- *
- * pfblockerng_category_edit.php has NO $pfb_syntaxhl_on boolean and NO cm-regex.min.js
- * include today (verified this session); the pre-existing events.push(function() {...})
- * block at ~line 1815 only wires source-row drag-reorder/add/delete, unrelated to CM6.
- * Step 2b must add the boolean, the gated script include, and the gated mountLists init
- * inside that SAME events.push() block.
- *
- * pfblockerng_category_edit.php carries top-level render execution and cannot be
- * require()d off-appliance (same constraint as CategoryEditReservedHeaderTest /
- * DnsblRegexHighlightWiringTest); reading the real source file IS reading the render for
- * this content -- this is the Tier-A ui_render coverage for this page's rollout.
- *
- * Split: every wiring assertion below is RED today (none of it exists yet). The
- * Form_Textarea field pin is GREEN today by design: it pins the existing POST contract,
- * which step 2b's client-side-only overlay must not touch -- mixed red/green within this
- * file is expected and is the point.
- */
 final class CategoryEditCustomEditorWiringTest extends TestCase
 {
-	private static string $src;
-
-	public static function setUpBeforeClass(): void
+	public function testDisabledEditorEmitsNoCustomMount(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_category_edit.php');
-		}
-		self::$src = $src;
+		$this->assertSame('', pfb_category_editor_render(FALSE, 'no-sort')['mount']);
 	}
 
-	public function testGatingBooleanReadsThePfbSyntaxHighlightToggle(): void
+	public function testEnabledEditorMountsTheCustomFieldExactlyOnce(): void
 	{
-		// LENIENT, not PfbToggle -- same rationale as DnsblRegexHighlightWiringTest's
-		// class docblock.
-		$this->assertMatchesRegularExpression(
-			"#\\\$pfb_syntaxhl_on\\s*=\\s*pfb_editor_enabled\\(\\)#",
-			self::$src,
-			'expected a $pfb_syntaxhl_on boolean derived from pfb_editor_enabled() (issue #1887 named accessor)'
-		);
-	}
+		$init = pfb_category_editor_render(TRUE, 'no-sort')['mount'];
 
-	public function testCmRegexScriptIsIncludedWithCacheBustingInsideTheGate(): void
-	{
-		// Tempered-dot gaps ((?:(?!endif).)*?), not bare .*? -- see
-		// DnsblRegexHighlightWiringTest's rationale for why bare .*? risks bridging past
-		// this gate's own endif.
-		$this->assertMatchesRegularExpression(
-			'#if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. '<script src="vendor/codemirror/cm-regex\.min\.js\?v=<\?=pfb_file_mtime\(\'/usr/local/www/pfblockerng/vendor/codemirror/cm-regex\.min\.js\'\)\?>"></script>'
-			. '(?:(?!endif).)*?endif#s',
-			self::$src,
-			'expected the cm-regex.min.js include, with mtime cache-busting, wrapped inside an if ($pfb_syntaxhl_on) gate'
-		);
-	}
-
-	public function testMountListsCallIsGatedInsideEventsPushBehindTheSyntaxHighlightBoolean(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'#events\.push\(function\(\)\s*\{(?:(?!endif).)*?if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. 'window\.pfbCM(?:(?!endif).)*?pfbCM\.mountLists\((?:(?!endif).)*?endif#s',
-			self::$src,
-			'expected a pfbCM.mountLists( call, guarded on window.pfbCM, inside the '
-			. 'existing events.push() block gated by if ($pfb_syntaxhl_on)'
-		);
-	}
-
-	public function testMountListsArrayContainsTheTargetFieldId(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#pfbCM\\.mountLists\\(\\s*\\[(?:(?!\\]).)*?'custom'(?:(?!\\]).)*?\\]\\s*\\)#s",
-			self::$src,
-			"expected 'custom' inside the pfbCM.mountLists([...]) array argument"
-		);
-	}
-
-	/**
-	 * Vacuity-safe "off emits nothing new" proof, same rationale as
-	 * DnsblRegexHighlightWiringTest::testCmRegexAssetAndFromTextareaCallEachAppearExactlyOnceInTheWholeFile.
-	 */
-	public function testCmRegexAssetAndMountListsCallEachAppearExactlyOnceInTheWholeFile(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(self::$src, '<script src="vendor/codemirror/cm-regex.min.js?v='),
-			'expected exactly one cm-regex.min.js <script> tag in the whole file (the gated include) -- '
-			. 'a second, unguarded <script> tag would defeat the off-emits-nothing contract'
-		);
-		$this->assertSame(
-			1,
-			substr_count(self::$src, 'pfbCM.mountLists('),
-			'expected exactly one pfbCM.mountLists( call in the whole file (the gated events.push init) -- '
-			. 'a second, unguarded call would defeat the off-emits-nothing contract'
-		);
-	}
-
-	public function testOriginalCustomTextareaFieldIsUnchanged(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'custom',#",
-			self::$src,
-			'expected the underlying custom Form_Textarea field to remain unchanged'
-		);
+		$this->assertStringContainsString('window.pfbCM', $init);
+		$this->assertSame(1, substr_count($init, 'pfbCM.mountLists('));
+		$this->assertStringContainsString('custom', $init);
 	}
 }

--- a/tests/php/CategoryEditCustomFlagTest.php
+++ b/tests/php/CategoryEditCustomFlagTest.php
@@ -16,8 +16,7 @@ use PHPUnit\Framework\TestCase;
  *
  * Like WidgetSubmitPostGuardTest, the page carries top-level execution and
  * cannot be require()d off-appliance, so the REAL custom-flag block is
- * eval-extracted verbatim (its leading comment and the following
- * config_set_path('.../custom', ...) line are the unique anchors).
+ * eval-extracted between its executable condition and following config write.
  */
 final class CategoryEditCustomFlagTest extends TestCase
 {
@@ -31,20 +30,25 @@ final class CategoryEditCustomFlagTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		$src = file_get_contents(
+		$src = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
 		);
-		if ($src === false) {
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
 		}
 
 		if (!function_exists('pfb_category_edit_oracle_customflag')) {
 			if (!preg_match(
-				'/\/\/ Set flag to update CustomList on next Cron.*?\n(.*?)(?=\n\n\t\tconfig_set_path\("installedpackages\/\{\$conf_type\}\/config\/\{\$rowid\}\/custom",)/s',
+				'/(if \(base64_decode\(config_get_path\("installedpackages\/\{\$conf_type\}\/config\/\{\$rowid\}\/custom", \x27\x27\)\) != \$_POST\[\x27custom\x27\]\) \{'
+				. '.*?touch\([^;]+;\s*\}\s*\})'
+				. '\s*config_set_path\("installedpackages\/\{\$conf_type\}\/config\/\{\$rowid\}\/custom", base64_encode/s',
 				$src,
 				$m
 			)) {
 				throw new RuntimeException('test bootstrap: custom-flag block not found in category_edit source');
+			}
+			if (strpos($m[1], 'pfb_determine_list_detail($action, \'\', $conf_type, $rowid)') === FALSE) {
+				throw new RuntimeException('test bootstrap: custom-flag executable boundary lost list-detail dispatch');
 			}
 			eval(
 				'function pfb_category_edit_oracle_customflag(string $conf_type, int $rowid, string $suffix): void {'
@@ -110,7 +114,7 @@ final class CategoryEditCustomFlagTest extends TestCase
 		set_error_handler(
 			static function (int $errno, string $errstr) use (&$warnings): bool {
 				$warnings[] = $errstr;
-				return true;
+				return TRUE;
 			},
 			E_WARNING | E_NOTICE
 		);

--- a/tests/php/CategoryEditIdnWildcardTest.php
+++ b/tests/php/CategoryEditIdnWildcardTest.php
@@ -33,7 +33,7 @@ final class CategoryEditIdnWildcardTest extends TestCase
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
 		}
 		if (!preg_match(
-			'/(if \(!empty\(\$_POST\[\x27custom\x27\]\)\) \{.*\})\s*if \(!\$input_errors\) \{/s',
+			'/(if \(!empty\(\$_POST\[\x27custom\x27\]\)\) \{.*?\})\s*if \(!\$input_errors\) \{/s',
 			$src,
 			$m
 		)) {

--- a/tests/php/CategoryEditIdnWildcardTest.php
+++ b/tests/php/CategoryEditIdnWildcardTest.php
@@ -16,7 +16,8 @@ use PHPUnit\Framework\TestCase;
  * oracle — it has always accepted the wildcard IDN row.
  *
  * The page carries top-level execution and cannot be require()d off-appliance,
- * so the validation block is eval-extracted verbatim from the REAL source.
+ * so the validation block is eval-extracted from the REAL source using its
+ * executable custom-list condition and following save guard.
  */
 final class CategoryEditIdnWildcardTest extends TestCase
 {
@@ -27,12 +28,19 @@ final class CategoryEditIdnWildcardTest extends TestCase
 	public static function setUpBeforeClass(): void
 	{
 		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php';
-		$src = file_get_contents($path);
-		if ($src === FALSE) {
+		$src = php_strip_whitespace($path);
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
 		}
-		if (!preg_match('/(\t\/\/ Validate Custom List\n.*?)\n\n\tif \(!\$input_errors\) \{/s', $src, $m)) {
-			throw new RuntimeException('test bootstrap: "Validate Custom List" region not found');
+		if (!preg_match(
+			'/(if \(!empty\(\$_POST\[\x27custom\x27\]\)\) \{.*\})\s*if \(!\$input_errors\) \{/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('test bootstrap: custom-list executable region not found');
+		}
+		if (strpos($m[1], 'pfb_idn_to_ascii_wildcard') === FALSE) {
+			throw new RuntimeException('test bootstrap: IDN conversion disappeared from custom-list region');
 		}
 		self::$region = $m[1];
 	}

--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -22,10 +22,8 @@ use PHPUnit\Framework\TestCase;
  * Lmove included, is rejected the same way.
  *
  * The page carries top-level execution and cannot be require()d off-appliance,
- * so each region below is eval-extracted
- * verbatim from the REAL source, anchored on text stable across both the
- * pre-fix and post-fix code so the same test file proves red on the old
- * code and green on the new.
+ * so each region below is eval-extracted from the REAL source using executable
+ * boundaries; comments are stripped before extraction.
  */
 final class CategoryEditPostGuardTest extends TestCase
 {
@@ -33,15 +31,15 @@ final class CategoryEditPostGuardTest extends TestCase
 	private array $savedGet = [];
 	private array $savedRequest = [];
 	private mixed $savedPfb = null;
-	private bool $hadConfig = false;
+	private bool $hadConfig = FALSE;
 	private mixed $savedConfig = null;
 
 	public static function setUpBeforeClass(): void
 	{
-		$src = file_get_contents(
+		$src = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
 		);
-		if ($src === false) {
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
 		}
 
@@ -53,27 +51,27 @@ final class CategoryEditPostGuardTest extends TestCase
 			}
 		}
 
-		// Region 1: the #1106 ingress guard + #1723 sanitize prologue (issue #1723
-		// moved these ahead of the select_options-normalisation loop so sanitize
-		// runs before ANY evaluation, including that loop's coercion of
-		// aliasports_in/srcint/etc -- two non-adjacent stretches of source,
-		// concatenated here), THEN (unchanged position) the select_options loop's
-		// close through the aliasname checks and the CIDR checks -- up to the
-		// state-loop foreach.
+		// Region 1: the #1106 ingress guard + #1723 sanitize prologue through the
+		// select-options loop's executable close, then the aliasname/CIDR checks
+		// up to the state-loop foreach.
 		if (!function_exists('pfb_category_oracle_aliasname_region')) {
 			if (!preg_match(
-				'/(\t\/\/ issue #1106: reject an array-valued field.*?)\n\n\t\/\/ Validate Select field options/s',
+				'/(foreach \(\$_POST as \$pfb_post_key => \$pfb_post_value\) \{.*?)(?=\$select_options = array\()/s',
 				$src,
 				$guard
 			)) {
-				throw new RuntimeException('test bootstrap: #1106/#1723 guard region not found');
+				throw new RuntimeException('test bootstrap: #1106/#1723 executable guard region not found');
 			}
 			if (!preg_match(
-				'/\$_POST\[\$s_option\] = \$s_default;\n\t\t\}\n\t\}\n(.*?)(?=\n\tforeach \(\$_POST as \$key => \$value\) \{)/s',
+				'/\$_POST\[\$s_option\] = \$s_default;\s*\}\s*\}\s*(.*?)(?=foreach \(\$_POST as \$key => \$value\) \{)/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('test bootstrap: aliasname/CIDR region not found');
+				throw new RuntimeException('test bootstrap: aliasname/CIDR executable region not found');
+			}
+			if (strpos($guard[1], 'pfb_sanitize_text_area') === FALSE ||
+			    strpos($m[1], 'suppression_cidr_v6') === FALSE) {
+				throw new RuntimeException('test bootstrap: aliasname ingress executable region incomplete');
 			}
 			eval(
 				'function pfb_category_oracle_aliasname_region(string $gtype): array {'
@@ -87,11 +85,15 @@ final class CategoryEditPostGuardTest extends TestCase
 		// Region 2: the rowhelper state-loop (URL/header/format validation).
 		if (!function_exists('pfb_category_oracle_state_loop')) {
 			if (!preg_match(
-				'/(\tforeach \(\$_POST as \$key => \$value\) \{\n.*?\n\t\})\n\n\n\t\/\/ Validate Adv\. firewall rule settings/s',
+				'/(foreach \(\$_POST as \$key => \$value\) \{.*\})'
+				. '\s*foreach \(pfb_adv_alias_field_errors\(\$_POST\) as \$pfb_alias_error\)/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('test bootstrap: state validation loop not found');
+				throw new RuntimeException('test bootstrap: state validation executable region not found');
+			}
+			if (strpos($m[1], 'pfb_header_reserved_error') === FALSE) {
+				throw new RuntimeException('test bootstrap: state validation executable region incomplete');
 			}
 			eval(
 				'function pfb_category_oracle_state_loop(string $type): array {'
@@ -104,11 +106,15 @@ final class CategoryEditPostGuardTest extends TestCase
 		// Region 3: the custom-list block.
 		if (!function_exists('pfb_category_oracle_custom_block')) {
 			if (!preg_match(
-				'/(\t\/\/ Validate Custom List\n\tif \(!empty\(\$_POST\[\'custom\'\]\)\) \{\n.*?\n\t\})\n\n\tif \(!\$input_errors\) \{/s',
+				'/(if \(!empty\(\$_POST\[\x27custom\x27\]\)\) \{.*\})'
+				. '\s*if \(!\$input_errors\) \{/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('test bootstrap: custom-list block not found');
+				throw new RuntimeException('test bootstrap: custom-list executable region not found');
+			}
+			if (strpos($m[1], 'pfb_idn_to_ascii_wildcard') === FALSE) {
+				throw new RuntimeException('test bootstrap: custom-list executable region incomplete');
 			}
 			eval(
 				'function pfb_category_oracle_custom_block(string $gtype): array {'
@@ -121,11 +127,15 @@ final class CategoryEditPostGuardTest extends TestCase
 		// Region 4: the GET 'atype' ingress block.
 		if (!function_exists('pfb_category_oracle_get_atype')) {
 			if (!preg_match(
-				'/(\tif \(isset\(\$_GET\[\'atype\'\]\).*?\n\t\})\n\}\n\nif \(isset\(\$_POST\)\) \{/s',
+				'/(if \(isset\(\$_GET\[\x27atype\x27\]\).*?\})'
+				. '\s*\}\s*if \(isset\(\$_POST\)\) \{/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('test bootstrap: GET atype block not found');
+				throw new RuntimeException('test bootstrap: GET atype executable region not found');
+			}
+			if (strpos($m[1], 'pfb_filter_whitelist_atype') === FALSE) {
+				throw new RuntimeException('test bootstrap: GET atype executable region incomplete');
 			}
 			eval(
 				'function pfb_category_oracle_get_atype(): string {'
@@ -138,11 +148,15 @@ final class CategoryEditPostGuardTest extends TestCase
 		// Region 5: the POST 'atype' ingress block.
 		if (!function_exists('pfb_category_oracle_post_atype')) {
 			if (!preg_match(
-				'/(\tif \(isset\(\$_POST\[\'atype\'\]\).*?\n\t\})\n\tif \(isset\(\$_POST\[\'chgstate\'\]\)/s',
+				'/(if \(isset\(\$_POST\[\x27atype\x27\]\).*?\})'
+				. '\s*if \(isset\(\$_POST\[\x27chgstate\x27\]\)/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('test bootstrap: POST atype block not found');
+				throw new RuntimeException('test bootstrap: POST atype executable region not found');
+			}
+			if (strpos($m[1], 'pfb_filter_whitelist_atype') === FALSE) {
+				throw new RuntimeException('test bootstrap: POST atype executable region incomplete');
 			}
 			eval(
 				'function pfb_category_oracle_post_atype(): string {'
@@ -155,11 +169,16 @@ final class CategoryEditPostGuardTest extends TestCase
 		// Region 6: the '$_REQUEST[savemsg]' render-time block.
 		if (!function_exists('pfb_category_oracle_savemsg')) {
 			if (!preg_match(
-				'/if \(isset\(\$savemsg\)\) \{\n\tprint_info_box\(\$savemsg\);\n\}\n\n(if \(isset\(\$_REQUEST\[\'savemsg\'\]\).*?\n\})\n\n\$form = new Form\(/s',
+				'/if \(isset\(\$savemsg\)\) \{\s*print_info_box\(\$savemsg\);\s*\}'
+				. '\s*(if \(isset\(\$_REQUEST\[\x27savemsg\x27\]\).*?\})'
+				. '\s*\$form = new Form\(/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('test bootstrap: savemsg block not found');
+				throw new RuntimeException('test bootstrap: savemsg executable region not found');
+			}
+			if (strpos($m[1], 'is_string($_REQUEST[\'savemsg\'])') === FALSE) {
+				throw new RuntimeException('test bootstrap: savemsg executable region incomplete');
 			}
 			eval(
 				'function pfb_category_oracle_savemsg(): ?string {'
@@ -169,17 +188,18 @@ final class CategoryEditPostGuardTest extends TestCase
 		}
 
 		// Region 7: the persist rowhelper loop (issue #1737 persist-parity
-		// coverage). Anchored on text stable either side of the #1723 in-loop
-		// sanitize block this issue removes -- never on that block itself --
-		// so the same anchors match the region red (block present) and green
-		// (block removed).
+		// coverage), bounded by its executable config-write loop and cleanup loop.
 		if (!function_exists('pfb_category_oracle_persist_rowhelper_loop')) {
 			if (!preg_match(
-				'/(\t\t\$rowhelper_exist = array\(\);\n\t\tforeach \(\$_POST as \$key => \$value\) \{\n.*?\n\t\t\})\n\n\t\t\/\/ Remove all undefined rowhelpers/s',
+				'/(\$rowhelper_exist = array\(\);\s*foreach \(\$_POST as \$key => \$value\) \{.*\})'
+				. '\s*foreach \(config_get_path\("installedpackages\/\{\$conf_type\}\/config\/\{\$rowid\}\/row", \[\]\) as \$r_key => \$row\)/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('test bootstrap: persist rowhelper loop not found');
+				throw new RuntimeException('test bootstrap: persist rowhelper executable region not found');
+			}
+			if (strpos($m[1], 'config_set_path("installedpackages/{$conf_type}/config/{$rowid}/row') === FALSE) {
+				throw new RuntimeException('test bootstrap: persist rowhelper executable region incomplete');
 			}
 			eval(
 				'function pfb_category_oracle_persist_rowhelper_loop(string $conf_type, $rowid): void {'
@@ -325,7 +345,7 @@ final class CategoryEditPostGuardTest extends TestCase
 		try {
 			$errors = pfb_category_oracle_aliasname_region('dnsbl');
 		} catch (\TypeError $e) {
-			$this->fail("shape " . var_export($shape, true) . " under 'url-0' must not TypeError: " . $e->getMessage());
+			$this->fail("shape " . var_export($shape, TRUE) . " under 'url-0' must not TypeError: " . $e->getMessage());
 		}
 		$this->assertNotEmpty($errors);
 		$this->assertSame('', $_POST['url-0']);
@@ -338,7 +358,7 @@ final class CategoryEditPostGuardTest extends TestCase
 		try {
 			$errors = pfb_category_oracle_aliasname_region('dnsbl');
 		} catch (\TypeError $e) {
-			$this->fail("shape " . var_export($shape, true) . " under an unknown key must not TypeError: " . $e->getMessage());
+			$this->fail("shape " . var_export($shape, TRUE) . " under an unknown key must not TypeError: " . $e->getMessage());
 		}
 		$this->assertNotEmpty($errors);
 		$this->assertSame('', $_POST['zzz']);
@@ -438,7 +458,7 @@ final class CategoryEditPostGuardTest extends TestCase
 		$errors = pfb_category_oracle_state_loop($type);
 		$this->assertNotEmpty(
 			array_filter($errors, static fn (string $e): bool => str_contains($e, 'disallowed character')),
-			'expected the url-N character guard to reject: ' . var_export($post['url-0'] ?? null, true)
+			'expected the url-N character guard to reject: ' . var_export($post['url-0'] ?? null, TRUE)
 		);
 		$this->assertNotEmpty($errors, 'a rejected row must leave $input_errors non-empty (blocks the atomic save)');
 		return $errors;
@@ -451,7 +471,7 @@ final class CategoryEditPostGuardTest extends TestCase
 		$errors = pfb_category_oracle_state_loop($type);
 		$this->assertEmpty(
 			array_filter($errors, static fn (string $e): bool => str_contains($e, 'disallowed character')),
-			'expected the url-N character guard to accept: ' . var_export($post['url-0'] ?? null, true)
+			'expected the url-N character guard to accept: ' . var_export($post['url-0'] ?? null, TRUE)
 		);
 		return $errors;
 	}

--- a/tests/php/CategoryEditPostGuardTest.php
+++ b/tests/php/CategoryEditPostGuardTest.php
@@ -85,7 +85,7 @@ final class CategoryEditPostGuardTest extends TestCase
 		// Region 2: the rowhelper state-loop (URL/header/format validation).
 		if (!function_exists('pfb_category_oracle_state_loop')) {
 			if (!preg_match(
-				'/(foreach \(\$_POST as \$key => \$value\) \{.*\})'
+				'/(foreach \(\$_POST as \$key => \$value\) \{.*?\})'
 				. '\s*foreach \(pfb_adv_alias_field_errors\(\$_POST\) as \$pfb_alias_error\)/s',
 				$src,
 				$m
@@ -106,7 +106,7 @@ final class CategoryEditPostGuardTest extends TestCase
 		// Region 3: the custom-list block.
 		if (!function_exists('pfb_category_oracle_custom_block')) {
 			if (!preg_match(
-				'/(if \(!empty\(\$_POST\[\x27custom\x27\]\)\) \{.*\})'
+				'/(if \(!empty\(\$_POST\[\x27custom\x27\]\)\) \{.*?\})'
 				. '\s*if \(!\$input_errors\) \{/s',
 				$src,
 				$m
@@ -191,7 +191,7 @@ final class CategoryEditPostGuardTest extends TestCase
 		// coverage), bounded by its executable config-write loop and cleanup loop.
 		if (!function_exists('pfb_category_oracle_persist_rowhelper_loop')) {
 			if (!preg_match(
-				'/(\$rowhelper_exist = array\(\);\s*foreach \(\$_POST as \$key => \$value\) \{.*\})'
+				'/(\$rowhelper_exist = array\(\);\s*foreach \(\$_POST as \$key => \$value\) \{.*?\})'
 				. '\s*foreach \(config_get_path\("installedpackages\/\{\$conf_type\}\/config\/\{\$rowid\}\/row", \[\]\) as \$r_key => \$row\)/s',
 				$src,
 				$m

--- a/tests/php/CategoryEditReservedHeaderTest.php
+++ b/tests/php/CategoryEditReservedHeaderTest.php
@@ -16,9 +16,8 @@ use PHPUnit\Framework\TestCase;
  *
  * Like CategoryEditPostGuardTest, the page carries top-level execution and
  * cannot be require()d off-appliance, so the rowhelper state-loop region is
- * eval-extracted verbatim from the REAL source, anchored on text stable
- * across the pre-fix and post-fix code -- the same test proves red on the
- * old code and green on the new.
+ * eval-extracted from the REAL source using its executable foreach boundary
+ * and following advanced-alias loop.
  */
 final class CategoryEditReservedHeaderTest extends TestCase
 {
@@ -29,23 +28,27 @@ final class CategoryEditReservedHeaderTest extends TestCase
 	{
 		$continents = $GLOBALS['pfb']['continents'] ?? null;
 		if (!is_array($continents) || count($continents) !== 9) {
-			throw new RuntimeException('$pfb[continents] must have exactly 9 entries; got: ' . var_export($continents, true));
+			throw new RuntimeException('$pfb[continents] must have exactly 9 entries; got: ' . var_export($continents, TRUE));
 		}
 
-		$src = file_get_contents(
+		$src = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
 		);
-		if ($src === false) {
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
 		}
 
 		if (!function_exists('pfb_category_oracle_reserved_header_state_loop')) {
 			if (!preg_match(
-				'/(\tforeach \(\$_POST as \$key => \$value\) \{\n.*?\n\t\})\n\n\n\t\/\/ Validate Adv\. firewall rule settings/s',
+				'/(foreach \(\$_POST as \$key => \$value\) \{.*\})'
+				. '\s*foreach \(pfb_adv_alias_field_errors\(\$_POST\) as \$pfb_alias_error\)/s',
 				$src,
 				$m
 			)) {
-				throw new RuntimeException('test bootstrap: state validation loop not found');
+				throw new RuntimeException('test bootstrap: state validation executable region not found');
+			}
+			if (strpos($m[1], 'pfb_header_reserved_error') === FALSE) {
+				throw new RuntimeException('test bootstrap: reserved-header executable check disappeared');
 			}
 			eval(
 				'function pfb_category_oracle_reserved_header_state_loop(string $type): array {'

--- a/tests/php/CategoryPostdataInvalidPrefixGuardTest.php
+++ b/tests/php/CategoryPostdataInvalidPrefixGuardTest.php
@@ -18,10 +18,9 @@ require_once __DIR__ . '/PfbNoPhpWarningTrait.php';
  *
  * The file carries top-level execution and cannot be require()d off-appliance
  * (house precedent: CountryNetworksCountGuardTest.php, GeoipPackageGenerationTest.php).
- * This test eval-extracts the postdata foreach fragment VERBATIM and POSITIONALLY
- * (anchored on the foreach's own open/close braces plus the next statement's
- * comment as an end-anchor) from the real shipped source, so it drives the actual
- * fix landing in the right place rather than a hand-copied guess.
+ * This test eval-extracts the postdata foreach fragment from the real shipped
+ * source using its foreach boundary and following table-order condition, so it
+ * drives the actual fix rather than a hand-copied guess.
  *
  * Feature: an invalid variable-name-prefix key must short-circuit its iteration
  *          with exactly one recorded error, never fall through to an undefined
@@ -41,20 +40,23 @@ final class CategoryPostdataInvalidPrefixGuardTest extends TestCase
 		}
 
 		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category.php';
-		$src = file_get_contents($path);
-		if ($src === FALSE) {
+		$src = php_strip_whitespace($path);
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category.php');
 		}
 
-		// Anchored on the foreach's own braces (5 tabs) plus the next statement's
-		// comment as an end-anchor, so only the foreach block itself is captured --
-		// not the enclosing `if (!empty($post_data)...)`'s own closing brace.
+		// The executable foreach body is bounded by the following table-order
+		// condition; source comments are stripped before extraction.
 		if (!preg_match(
-			'/(foreach \(\$post_data as \$key => \$value\) \{.*?\n\t{5}\})\n\t{4}\}\n\n\t{4}\/\/ Save new Table order format/s',
+			'/(foreach \(\$post_data as \$key => \$value\) \{.*\})'
+			. '\s*\}\s*if \(!empty\(\$post_ids\[\x27ids\x27\]\) && is_array\(\$post_ids\[\x27ids\x27\]\)\)/s',
 			$src,
 			$m
 		)) {
-			throw new RuntimeException('oracle extraction failed: the postdata foreach block was not found in pfblockerng_category.php');
+			throw new RuntimeException('oracle extraction failed: postdata foreach executable boundary not found');
+		}
+		if (strpos($m[1], 'Failed Variable:') === FALSE || strpos($m[1], 'switch ($variable)') === FALSE) {
+			throw new RuntimeException('oracle extraction failed: postdata validation body incomplete');
 		}
 
 		eval(

--- a/tests/php/CategoryPostdataInvalidPrefixGuardTest.php
+++ b/tests/php/CategoryPostdataInvalidPrefixGuardTest.php
@@ -48,7 +48,7 @@ final class CategoryPostdataInvalidPrefixGuardTest extends TestCase
 		// The executable foreach body is bounded by the following table-order
 		// condition; source comments are stripped before extraction.
 		if (!preg_match(
-			'/(foreach \(\$post_data as \$key => \$value\) \{.*\})'
+			'/(foreach \(\$post_data as \$key => \$value\) \{.*?\})'
 			. '\s*\}\s*if \(!empty\(\$post_ids\[\x27ids\x27\]\) && is_array\(\$post_ids\[\x27ids\x27\]\)\)/s',
 			$src,
 			$m

--- a/tests/php/ClearSqliteTimestampFormatTest.php
+++ b/tests/php/ClearSqliteTimestampFormatTest.php
@@ -155,23 +155,4 @@ final class ClearSqliteTimestampFormatTest extends TestCase
 		$this->assertSame('2024-12-31 23:00:00', $displayed, 'the ISO value must display unchanged (no HTML-escapable characters)');
 	}
 
-	/**
-	 * Source tripwire: pins the exact format strings so this oracle goes red the
-	 * moment either call site's format string changes again.
-	 */
-	public function testSourceUsesYearBearingFormatAtBothCallSites(): void
-	{
-		$source = (string) file_get_contents(__DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc');
-		$this->assertStringContainsString(
-			"\$lastipclear = date('Y-m-d H:i:s', time());",
-			$source,
-			"pfBlockerNG_clearsqlite()'s 'clearip' timestamp format changed -- update this oracle"
-		);
-		$this->assertStringContainsString(
-			"\$lastdnsblclear = date('Y-m-d H:i:s', time());",
-			$source,
-			"pfBlockerNG_clearsqlite()'s 'cleardnsbl' timestamp format changed -- update this oracle"
-		);
-		$this->assertStringNotContainsString("date('M j H:i:s', time());", $source, 'the OLD no-year format must be gone from BOTH call sites');
-	}
 }

--- a/tests/php/CountryNetworksCountGuardTest.php
+++ b/tests/php/CountryNetworksCountGuardTest.php
@@ -2,240 +2,57 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * $networks / $total / $lastline -- the per-ISO "Total Networks" line counts
- * in pfblockerng_geoip.inc's continent-file rebuild (issue #1261).
- *
- * `$networks` is NOT display-only: it is written into a header line that is
- * later re-parsed, and "Total Networks: 0" or "...: NA" trips a placeholder
- * branch that BLANKS the country's IP list (transient read failure treated as
- * "genuinely empty" is silent data loss). `$total` only ever renders as "(N)"
- * in a dropdown -- display-only, so its `?? 0` NULL fallback is the safe,
- * correct direction and needs no fix, only a mirror test (house precedent:
- * tests/php/AliasCntGrepCountGuardTest.php).
- *
- * The file carries top-level execution and cannot be require()d
- * off-appliance. The $networks header block is eval-extracted verbatim into a
- * callable oracle driven by REAL pfb_count_lines() calls against real fixtures
- * -- a directory path (exists,
- * unreadable as a file -> NULL) and a real empty file (exists, 0 lines) --
- * so the same test file proves red on the pre-fix `?? 0` and green after,
- * with zero mocking of pfb_count_lines() itself. The placeholder-blank
- * condition is likewise eval-extracted, not hardcoded, so a change to that
- * condition is caught too.
- *
- * Feature: a country's IP list is blanked only for a genuinely-zero or
- *          NA network count, never for a count that could not be read
- *
- *   Scenario: pfb_count_lines() read failure (NULL) -> placeholder must NOT fire
- *   Scenario: a genuinely empty ISO file (0)        -> placeholder MUST fire
- */
 final class CountryNetworksCountGuardTest extends TestCase
 {
-	private static string $src;
-	private static string $geoipSrc;
-	private static string $tmpDir;
+	private string $dir;
 
-	public static function setUpBeforeClass(): void
+	protected function setUp(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php';
-		$src = file_get_contents($path);
-		if ($src === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
+		$this->dir = sys_get_temp_dir() . '/pfb_country_networks_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->dir . '/*') ?: [] as $file) {
+			@unlink($file);
 		}
-		self::$src = $src;
-		$geoipPath = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc';
-		$geoipSrc = file_get_contents($geoipPath);
-		if ($geoipSrc === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_geoip.inc');
-		}
-		self::$geoipSrc = $geoipSrc;
-
-		self::$tmpDir = sys_get_temp_dir() . '/pfb_country_networks_' . getmypid();
-		@mkdir(self::$tmpDir, 0777, TRUE);
-
-		// Oracle 1: the $iso_file header-building block, anchored on text
-		// stable across both the pre-fix `?? 0` and the fixed fallback.
-		if (!function_exists('pfb_networks_header_oracle')) {
-			if (!preg_match(
-				'/(if \(file_exists\(\$iso_file\)\) \{.*?\$iso_header \.= "# Total Networks: \{\$networks\}\\\\n";)/s',
-				$src,
-				$m
-			)) {
-				throw new RuntimeException('oracle extraction failed: the $iso_file header block was not found in pfblockerng.php');
-			}
-			eval(
-				'function pfb_networks_header_oracle(string $iso_file): string {'
-				. ' $geoip = ["name" => "Testland"]; $geoip_id = ""; $iso = "TL"; $iso_header = "";'
-				. $m[1]
-				// close the extracted block's own opening "if (file_exists(...)) {"
-				. ' } return $iso_header; }'
-			);
-		}
-
-		// Oracle 2: the placeholder-blank condition itself -- untouched by
-		// this fix, pinned so a future change to it is still caught.
-		if (!function_exists('pfb_placeholder_branch_fires_oracle')) {
-			if (!preg_match(
-				'/strpos\(\$line, \'Total Networks: 0\'\) !== FALSE \|\| strpos\(\$line, \'Total Networks: NA\'\) !== FALSE/',
-				self::$geoipSrc,
-				$m2
-			)) {
-				throw new RuntimeException('oracle extraction failed: the placeholder-blank condition was not found in pfblockerng_geoip.inc');
-			}
-			eval('function pfb_placeholder_branch_fires_oracle(string $line): bool { return (' . $m2[0] . '); }');
-		}
+		@rmdir($this->dir);
 	}
 
-	public static function tearDownAfterClass(): void
+	public function testCountReadFailureUsesNonPlaceholderHeader(): void
 	{
-		foreach (glob(self::$tmpDir . '/*') ?: [] as $f) {
-			is_dir($f) ? @rmdir($f) : @unlink($f);
-		}
-		@rmdir(self::$tmpDir);
-	}
+		$directory = $this->dir . '/not-a-file';
+		$this->assertTrue(mkdir($directory, 0700));
 
-	private function totalNetworksLine(string $header): string
-	{
-		$lines = explode("\n", trim($header));
-		return end($lines);
-	}
-
-	// -----------------------------------------------------------------------
-	// Rows 1+2: the point is both together -- a fix that merely disables the
-	// placeholder branch would pass row 1 alone without proving anything.
-	// -----------------------------------------------------------------------
-
-	public function testReadFailureDoesNotTripZeroNetworksPlaceholder(): void
-	{
-		// A directory: file_exists() is TRUE, but pfb_count_lines()'s fopen('rb')
-		// fails -- a real, unmocked read failure (NULL), not chmod-based (chmod
-		// denial tests are meaningless under root; a directory fails everywhere).
-		$dir = self::$tmpDir . '/unreadable_dir_v4';
-		@mkdir($dir, 0777, TRUE);
-		$this->assertNull(pfb_count_lines($dir), 'fixture must reproduce a real pfb_count_lines() read failure');
-
-		$line = $this->totalNetworksLine(pfb_networks_header_oracle($dir));
-		$this->assertStringStartsWith('# Total Networks: ', $line, 'header must still carry a Total Networks line on a read failure');
-		$this->assertFalse(
-			pfb_placeholder_branch_fires_oracle($line),
-			"a read failure must not render as '{$line}' -- it must not match the 0/NA placeholder-blank branch and silently empty the country's list"
+		$this->assertNull(pfb_count_lines($directory));
+		$this->assertSame(
+			"# Country: Testland\n# ISO Code: TL\n# Total Networks: ERROR\n",
+			pfb_geoip_networks_header($directory, 'Testland', '', 'TL')
 		);
 	}
 
-	public function testGenuinelyEmptyIsoFileStillTripsZeroNetworksPlaceholder(): void
+	public function testEmptyFileStillUsesZeroPlaceholder(): void
 	{
-		$empty = self::$tmpDir . '/empty_v4.txt';
-		touch($empty);
-		$this->assertSame(0, pfb_count_lines($empty), 'fixture must reproduce a real genuinely-empty file');
+		$empty = $this->dir . '/empty.txt';
+		$this->assertSame(0, file_put_contents($empty, ''));
 
-		$line = $this->totalNetworksLine(pfb_networks_header_oracle($empty));
-		$this->assertSame('# Total Networks: 0', $line);
-		$this->assertTrue(
-			pfb_placeholder_branch_fires_oracle($line),
-			'a genuinely empty ISO file must still trip the placeholder-blank branch -- this is the intended behaviour'
+		$this->assertSame(
+			"# Country: Testland\n# ISO Code: TL\n# Total Networks: 0\n",
+			pfb_geoip_networks_header($empty, 'Testland', '', 'TL')
 		);
 	}
 
-	// -----------------------------------------------------------------------
-	// Source-inspection: no exec() grep fork survives, and the fallback is
-	// never bare `?? 0` again (that shape is exactly the reintroduced bug).
-	// -----------------------------------------------------------------------
-
-	public function testNetworksNeverFallsBackToBareZero(): void
+	public function testHeaderIncludesGeonameIdWhenPresent(): void
 	{
-		$this->assertDoesNotMatchRegularExpression(
-			'/\$networks\s*=\s*pfb_count_lines\(\$iso_file\)\s*\?\?\s*0\s*;/',
-			self::$src,
-			'$networks must not fall back to a bare 0 on NULL -- that string collides with the placeholder-blank branch (issue #1261)'
+		$file = $this->dir . '/country.txt';
+		file_put_contents($file, "10.0.0.0/8\n");
+
+		$this->assertSame(
+			"# Country: Testland [42]\n# ISO Code: TL\n# Total Networks: 1\n",
+			pfb_geoip_networks_header($file, 'Testland', '42', 'TL')
 		);
-	}
-
-	public function testNoExecGrepForkSurvivesForNetworks(): void
-	{
-		$this->assertDoesNotMatchRegularExpression(
-			'/\$networks\s*=\s*exec\(/',
-			self::$src,
-			'a $networks = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
-		);
-	}
-
-	// -----------------------------------------------------------------------
-	// Rows 3+4: $total -- display-only, `?? 0` is correct as-is.
-	// -----------------------------------------------------------------------
-
-	public function testTotalAssignedFromPfbCountLinesWithZeroFallback(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/\$total\s*=\s*pfb_count_lines\([^;]*\)\s*\?\?\s*0\s*;/',
-			self::$geoipSrc,
-			'$total must be assigned from pfb_count_lines(...) ?? 0 (display-only, issue #1261)'
-		);
-	}
-
-	public function testNoExecGrepForkSurvivesForTotal(): void
-	{
-		$this->assertDoesNotMatchRegularExpression(
-			'/\$total\s*=\s*exec\(/',
-			self::$geoipSrc,
-			'a $total = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
-		);
-	}
-
-	// -----------------------------------------------------------------------
-	// Rows 5+6: $lastline -- the EOF-flush trigger
-	// (`$linenum == $lastline`). `?? 0` preserves the exec()-era `?: 0`: a
-	// failed count yields 0, which $linenum (starts at 1) can never equal, so
-	// the flush stays unreachable -- and the fopen() of the same file fails
-	// too, so the loop never runs.
-	// -----------------------------------------------------------------------
-
-	public function testLastlineAssignedFromPfbCountLinesWithZeroFallback(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/\$lastline\s*=\s*pfb_count_lines\(\$file\)\s*\?\?\s*0\s*;/',
-			self::$geoipSrc,
-			'$lastline must be assigned from pfb_count_lines($file) ?? 0 (EOF-flush trigger, issue #1261)'
-		);
-	}
-
-	public function testNoExecGrepForkSurvivesForLastline(): void
-	{
-		$this->assertDoesNotMatchRegularExpression(
-			'/\$lastline\s*=\s*exec\(/',
-			self::$geoipSrc,
-			'a $lastline = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
-		);
-	}
-
-	/** A real, unmocked read failure (a directory) must fall back to 0, never
-	 *  NULL/error text reaching the `$linenum == $lastline` comparison. */
-	public function testLastlineReadFailureFallsBackToZero(): void
-	{
-		$dir = self::$tmpDir . '/unreadable_dir_lastline';
-		@mkdir($dir, 0777, TRUE);
-		$this->assertNull(pfb_count_lines($dir), 'fixture must reproduce a real pfb_count_lines() read failure');
-
-		$lastline = pfb_count_lines($dir) ?? 0;
-		$this->assertSame(0, $lastline, 'a failed count must fall back to 0 (the exec()-era behaviour): the EOF flush stays unreachable');
-	}
-
-	public static function totalRenderRows(): array
-	{
-		return [
-			'NULL count (pfb_count_lines() read failure)' => [NULL, '(0)'],
-			'happy path count'                             => [5, '(5)'],
-		];
-	}
-
-	/** Mirror of the coptions dropdown render: "{$country} {$isocode} ({$total})". */
-	#[DataProvider('totalRenderRows')]
-	public function testTotalRendersAsParenthesisedCount(?int $pfbCountLinesResult, string $expectRendered): void
-	{
-		$total = $pfbCountLinesResult ?? 0;
-		$this->assertSame($expectRendered, "({$total})");
 	}
 }

--- a/tests/php/DnsblCustomListWildcardValidationTest.php
+++ b/tests/php/DnsblCustomListWildcardValidationTest.php
@@ -16,7 +16,8 @@ use PHPUnit\Framework\TestCase;
  * itself; the trailing-dot tolerance stays.
  *
  * The page carries top-level execution and cannot be require()d off-appliance,
- * so the validation block is eval-extracted verbatim from the REAL source.
+ * so the validation block is eval-extracted from the REAL source using its
+ * executable custom-type loop and following regex-validation statement.
  */
 final class DnsblCustomListWildcardValidationTest extends TestCase
 {
@@ -27,12 +28,21 @@ final class DnsblCustomListWildcardValidationTest extends TestCase
 	public static function setUpBeforeClass(): void
 	{
 		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php';
-		$src = file_get_contents($path);
-		if ($src === FALSE) {
+		$src = php_strip_whitespace($path);
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_dnsbl.php');
 		}
-		if (!preg_match('/(\t\t\/\/ Validate customlists\n.*?)\n\t\t\/\/ A usable validator always runs/s', $src, $m)) {
-			throw new RuntimeException('test bootstrap: "Validate customlists" region not found');
+		if (!preg_match(
+			'/(foreach \(array\(\s*\x27pfb_noaaaa_list\x27\s*=>\s*\x27domain\x27.*?\)'
+			. ' as \$custom_type => \$custom_format\) \{.*\})'
+			. '\s*\$pfb_regex_python = pfb_python_interpreter\(\)/s',
+			$src,
+			$m
+		)) {
+			throw new RuntimeException('test bootstrap: custom-list executable region not found');
+		}
+		if (strpos($m[1], 'rtrim($value[0], \'.\')') === FALSE) {
+			throw new RuntimeException('test bootstrap: custom-list wildcard trim decision disappeared');
 		}
 		self::$region = $m[1];
 	}

--- a/tests/php/DnsblCustomListWildcardValidationTest.php
+++ b/tests/php/DnsblCustomListWildcardValidationTest.php
@@ -34,7 +34,7 @@ final class DnsblCustomListWildcardValidationTest extends TestCase
 		}
 		if (!preg_match(
 			'/(foreach \(array\(\s*\x27pfb_noaaaa_list\x27\s*=>\s*\x27domain\x27.*?\)'
-			. ' as \$custom_type => \$custom_format\) \{.*\})'
+			. ' as \$custom_type => \$custom_format\) \{.*?\})'
 			. '\s*\$pfb_regex_python = pfb_python_interpreter\(\)/s',
 			$src,
 			$m

--- a/tests/php/DnsblCustomRowStateEnabledInvariantTest.php
+++ b/tests/php/DnsblCustomRowStateEnabledInvariantTest.php
@@ -6,105 +6,72 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Issue #1323 -- pins the invariant pfb_dnsbl_hold_stale_rebuild_skip()'s
- * safety rests on: a synthesized custom-DNSBL row can never be Hold. The
- * guard's single call site ($row['state'] == 'Hold' paired with
- * pfb_dnsbl_hold_stale_rebuild_skip(), pfblockerng_apply.inc ~:1377) consumes
- * rows built by ONE synthesis site: the DNSBL download loop's $lists
- * (~:1256). The other two custom-row sites never reach it -- ~:501 feeds
- * a per-type normalization pass whose $lists is discarded after use, and
- * ~:2682 feeds the separate IP-alias download loop -- and are pinned as
- * defense-in-depth: every custom-row literal in the file keeps the same
- * hardcoded-Enabled shape. All three live inside sync_package_pfblockerng(),
- * which has no PHPUnit harness (issue #993, confirmed by
- * DnsblStagingGenerationGuardTest's docblock), so this is a
- * source-inspection pin (last resort per CLAUDE.md, mirrors
- * PfbSyncStatusDnsblWritersTest's
- * testDnsblDownloadCallSitesKeyOnTheAliasNotTheHeader) -- a future edit
- * that flips any synthesis site away from hardcoded Enabled must fail this
- * test.
+ * Issue #1323 -- custom DNSBL rows must stay Enabled so the stale Hold guard
+ * cannot suppress them. The three live sync routes share one row-construction
+ * decision; behavior tests exercise that decision with each route's inputs.
  */
+#[CoversFunction('pfb_dnsbl_custom_row')]
 #[CoversFunction('pfb_dnsbl_hold_stale_rebuild_skip')]
 final class DnsblCustomRowStateEnabledInvariantTest extends TestCase
 {
-	private function pfblockerngSource(): string
+	public function testDnsblNormalizationRouteBuildsEnabledCustomRow(): void
 	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
-		$this->assertNotFalse($source, 'pfblockerng_apply.inc must be readable');
-		return $source;
-	}
-
-	/**
-	 * Every synthesis site builds the row as one array-literal block, in the
-	 * SAME key order: header, custom, state, url. Matching that exact block
-	 * (not just a bare 'state' => 'Enabled' anywhere near 'url' => 'custom')
-	 * means a reordered/dropped 'state' key fails this regex even if some
-	 * other 'state' => 'Enabled' happens to sit nearby in the file. Known
-	 * brittleness, accepted for a source pin: a comment inserted between the
-	 * keys also fails the match (keep the block contiguous or update this
-	 * pattern), and a NEW site built in a different shape (helper call,
-	 * per-key assignments) evades both this pattern and the count tripwire.
-	 */
-	private const SITE_BLOCK_PATTERN = "/'header'\\s*=>\\s*\"\\{\\\$list\\['aliasname'\\]\\}_custom\",\\s*"
-		. "'custom'\\s*=>\\s*\\\$list\\['custom'\\],\\s*"
-		. "'state'\\s*=>\\s*'Enabled',\\s*"
-		. "'url'\\s*=>\\s*'custom'/";
-
-	/** 1-based line numbers of every $pattern match, for failure diagnostics. */
-	private function matchLines(string $pattern): array
-	{
-		$source = $this->pfblockerngSource();
-		preg_match_all($pattern, $source, $matches, PREG_OFFSET_CAPTURE);
-		return array_map(
-			static fn(array $hit): int => substr_count($source, "\n", 0, $hit[1]) + 1,
-			$matches[0]
+		$this->assertSame(
+			[
+				'header' => 'normalization_custom',
+				'custom' => 'normal.example',
+				'state'  => 'Enabled',
+				'url'    => 'custom',
+			],
+			pfb_dnsbl_custom_row('normalization', 'normal.example')
 		);
 	}
 
-	/**
-	 * Site-count tripwire: issue #1323 (re-derived by grepping the tree this
-	 * session) enumerates exactly 3 synthesis sites (~pfblockerng_apply.inc:501,
-	 * 1256, 2682). A different count means a site was added or removed --
-	 * this test's coverage matrix (and SITE_BLOCK_PATTERN below) needs a look
-	 * before the block-shape assertion can be trusted.
-	 */
-	public function testCustomDnsblRowSynthesisSiteCountMatchesKnownEnumeration(): void
+	public function testDnsblDownloadRouteBuildsEnabledCustomRow(): void
 	{
-		$lines = $this->matchLines("/'url'\\s*=>\\s*'custom'/");
-		$this->assertCount(3, $lines,
-			'expected exactly 3 custom-DNSBL row synthesis sites (issue #1323 enumeration), '
-			. 'found matches at pfblockerng_apply.inc lines [' . implode(', ', $lines) . '] -- '
-			. 'update this test\'s coverage matrix if a site was added or removed');
+		$this->assertSame(
+			[
+				'header' => 'download_custom',
+				'custom' => ['download.example', '||ads.download.example^'],
+				'state'  => 'Enabled',
+				'url'    => 'custom',
+			],
+			pfb_dnsbl_custom_row('download', ['download.example', '||ads.download.example^'])
+		);
 	}
 
-	/**
-	 * The actual pin: every one of those sites must hardcode 'state' =>
-	 * 'Enabled' in the header/custom/state/url block. RED if any site drops,
-	 * reorders past, or flips that literal (verified by temporarily flipping
-	 * one site to 'Hold' in-session and observing this assertion fail).
-	 */
-	public function testEveryCustomDnsblRowSynthesisSiteHardcodesStateEnabled(): void
+	public function testIpAliasDownloadRouteBuildsEnabledCustomRow(): void
 	{
-		$lines = $this->matchLines(self::SITE_BLOCK_PATTERN);
-		$this->assertCount(3, $lines,
-			"every custom-DNSBL row synthesis site must build 'header'/'custom'/'state'/'url' in that exact "
-			. "order with 'state' hardcoded to 'Enabled'; Enabled-shaped blocks found at pfblockerng_apply.inc "
-			. 'lines [' . implode(', ', $lines) . '] -- the site missing from that list diverged (dropped, '
-			. "reordered, or flipped the 'state' => 'Enabled' literal)");
+		$this->assertSame(
+			[
+				'header' => 'ip-alias_custom',
+				'custom' => "192.0.2.1\n198.51.100.7",
+				'state'  => 'Enabled',
+				'url'    => 'custom',
+			],
+			pfb_dnsbl_custom_row('ip-alias', "192.0.2.1\n198.51.100.7")
+		);
 	}
 
-	/**
-	 * Guard linkage: because 'state' is always 'Enabled' (pinned above), the
-	 * real call-site expression $row['state'] == 'Hold' (pfblockerng_apply.inc:1377)
-	 * can never be TRUE for a custom row, so the pure guard
-	 * pfb_dnsbl_hold_stale_rebuild_skip() -- called directly here, no
-	 * refactoring needed -- can never fire its skip branch for one, regardless
-	 * of the other two inputs.
-	 */
-	public function testCustomRowStateEnabledNeverTriggersHoldStaleRebuildSkip(): void
+	public function testLiveSyncDispatchKeepsAllThreeRoutesOnSharedRowSeam(): void
 	{
-		$customRow = ['header' => 'Some_custom', 'custom' => 'example.com', 'state' => 'Enabled', 'url' => 'custom'];
-		$isHold = $customRow['state'] == 'Hold'; // exact call-site expression, pfblockerng_apply.inc:1377
+		$source = php_strip_whitespace(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		$call = 'pfb_dnsbl_custom_row($list[\'aliasname\'], $list[\'custom\'])';
+		$this->assertSame(
+			3,
+			substr_count($source, $call),
+			'live sync_package_pfblockerng download/firewall/service dispatch has no '
+			. 'off-appliance PHPUnit driver (#993); this executable-code pin keeps all '
+			. 'three routes on the shared custom-row synthesis seam'
+		);
+	}
+
+	public function testEnabledCustomRowNeverTriggersHoldStaleRebuildSkip(): void
+	{
+		$customRow = pfb_dnsbl_custom_row('Some', 'example.com');
+		$isHold = $customRow['state'] == 'Hold';
 		$this->assertFalse($isHold, 'a synthesized custom row must never read as Hold');
 
 		foreach ([TRUE, FALSE] as $staleGenerationRebuild) {

--- a/tests/php/DnsblFeedCountWiringTest.php
+++ b/tests/php/DnsblFeedCountWiringTest.php
@@ -4,50 +4,61 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1263: pfb_update_unbound()'s DNSBL feed-count site must call
- * pfb_dnsbl_feed_count($pfb['dnsdir']) -- the old `/bin/cat *.txt | grep -c ^`
- * exec() shell-out is gone entirely. pfb_update_unbound() restarts real
- * services, so this is a source-inspection pin (same technique as
- * DownloadExtractionExitCodeTest); pfb_dnsbl_feed_count()'s own behaviour is
- * proven directly in DnsblFeedCountTest.
- */
 final class DnsblFeedCountWiringTest extends TestCase
 {
-	private static string $body;
+	private string $dir;
 
-	public static function setUpBeforeClass(): void
+	protected function setUp(): void
 	{
-		$source = file_get_contents(
+		$this->dir = sys_get_temp_dir() . '/pfb_dnsbl_count_wiring_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->dir . '/*') ?: [] as $file) {
+			@unlink($file);
+		}
+		@rmdir($this->dir);
+	}
+
+	public function testUpdateCountDelegatesToTheConfiguredCounter(): void
+	{
+		$calls = [];
+		$count = pfb_update_unbound_feed_count(
+			$this->dir,
+			static function (string $dir) use (&$calls): int {
+				$calls[] = $dir;
+				return 17;
+			}
+		);
+
+		$this->assertSame(17, $count);
+		$this->assertSame([$this->dir], $calls);
+	}
+
+	public function testDefaultCounterCountsEachFeedWithoutWeldingFiles(): void
+	{
+		file_put_contents($this->dir . '/first.txt', "one\ntwo");
+		file_put_contents($this->dir . '/second.txt', "three\n");
+
+		$this->assertSame(3, pfb_update_unbound_feed_count($this->dir));
+	}
+
+	/**
+	 * pfb_update_unbound() restarts live DNSBL/Unbound services, so PHPUnit
+	 * cannot execute its caller. This comment-free pin is only the outer
+	 * dispatch; the injected counter above proves the observable call effect.
+	 */
+	public function testLiveUpdateDispatchesThroughTheCountSeam(): void
+	{
+		$code = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
 		);
-		if ($source === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
-		}
-
-		$start = strpos($source, 'function pfb_update_unbound(');
-		if ($start === false) {
-			throw new RuntimeException('test bootstrap: function pfb_update_unbound( not found');
-		}
-
-		if (!preg_match('/^function\s+\w+/m', $source, $m, PREG_OFFSET_CAPTURE, $start + 20)) {
-			throw new RuntimeException('test bootstrap: end-of-function boundary not found');
-		}
-		$end = $m[0][1];
-
-		self::$body = substr($source, $start, $end - $start);
-	}
-
-	public function testCallsPfbDnsblFeedCountOnTheDnsdir(): void
-	{
-		$this->assertStringContainsString("pfb_dnsbl_feed_count(\$pfb['dnsdir'])", self::$body,
-			'the per-file sum must replace the exec()d cat|grep -c ^ shell-out');
-	}
-
-	public function testNoLongerShellsOutToCatGrepForTheDnsblCount(): void
-	{
-		$this->assertDoesNotMatchRegularExpression('/exec\(\s*"\/bin\/cat/', self::$body,
-			'the cat|grep -c ^ exec() shell-out must be gone -- an unterminated feed file welds into the next '
-			. 'one and undercounts through it');
+		$this->assertIsString($code);
+		$this->assertStringContainsString(
+			'$dnsbl_cnt = pfb_update_unbound_feed_count($pfb[\'dnsdir\']);',
+			$code
+		);
 	}
 }

--- a/tests/php/DnsblFeedIdnWildcardTest.php
+++ b/tests/php/DnsblFeedIdnWildcardTest.php
@@ -32,7 +32,7 @@ final class DnsblFeedIdnWildcardTest extends TestCase
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
 		}
 		if (!preg_match(
-			'/(\t+\/\/ Convert IDN \(Unicode domains\) to ASCII \(punycode\)\n.*?\$line = trim\(\$line, \'\.\'\);)/s',
+			'/((?:\t+if \(!empty\(\$line\) && !ctype_print\(\$line\)\) \{).*?\$line = trim\(\$line, \'\.\'\);)/s',
 			$src,
 			$m
 		)) {
@@ -41,6 +41,12 @@ final class DnsblFeedIdnWildcardTest extends TestCase
 		// The region uses `continue` to drop a line; wrap it in a loop of its
 		// own so that keeps working inside eval().
 		self::$region = "foreach ([0] as \$pfb_test_iter) {\n{$m[1]}\n\$pfb_test_kept = TRUE;\n}\n";
+	}
+
+	public function testExtractionStartsAtExecutableCodeNotProductionComment(): void
+	{
+		$this->assertStringContainsString("if (!empty(\$line) && !ctype_print(\$line))", self::$region);
+		$this->assertStringNotContainsString('Convert IDN (Unicode domains)', self::$region);
 	}
 
 	protected function setUp(): void

--- a/tests/php/DnsblIpCountGuardTest.php
+++ b/tests/php/DnsblIpCountGuardTest.php
@@ -5,75 +5,84 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * $ip_cnt / $ip_cnt6 -- the IPv4/IPv6 line counts extracted from a DNSBL
- * domain feed's `_v4.ip`/`_v6.ip` sidecar files inside
- * sync_package_pfblockerng() (issue #1261). Both gate only a log line
- * (`if ($ip_cnt > 0) pfb_logger(...)`), never arithmetic -- display-only, so
- * a pfb_count_lines() NULL (read failure) must fall back to 0, exactly as
- * exec()'s falsy "" fell through the pre-#1261 `> 0` comparison. Not
- * unit-reachable directly (deep inside sync_package_pfblockerng()) -- pinned
- * via source-inspection, house precedent: tests/php/AliasCntGrepCountGuardTest.php.
- */
+/** IPv4 and IPv6 sidecars each expose a safe count and positive log decision. */
 final class DnsblIpCountGuardTest extends TestCase
 {
-	private static string $src;
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	private string $dir;
 
 	public static function setUpBeforeClass(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
-		$src = file_get_contents($path);
-		if ($src === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	}
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_ip_count_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->dir}/*") ?: [] as $path) {
+			is_dir($path) ? @rmdir($path) : @unlink($path);
 		}
-		self::$src = $src;
+		@rmdir($this->dir);
 	}
 
-	public function testIpCntAssignedFromPfbCountLinesWithNullFallback(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/\$ip_cnt\s*=\s*pfb_count_lines\([^;]*_v4\.ip[^;]*\)\s*\?\?\s*0\s*;/',
-			self::$src,
-			'$ip_cnt must be assigned from pfb_count_lines(..._v4.ip) ?? 0 (issue #1261)'
-		);
-	}
-
-	public function testIpCnt6AssignedFromPfbCountLinesWithNullFallback(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/\$ip_cnt6\s*=\s*pfb_count_lines\([^;]*_v6\.ip[^;]*\)\s*\?\?\s*0\s*;/',
-			self::$src,
-			'$ip_cnt6 must be assigned from pfb_count_lines(..._v6.ip) ?? 0 (issue #1261)'
-		);
-	}
-
-	public function testNoExecGrepForkSurvivesForIpCnt(): void
-	{
-		$this->assertDoesNotMatchRegularExpression(
-			'/\$ip_cnt6?\s*=\s*exec\(/',
-			self::$src,
-			'an $ip_cnt/$ip_cnt6 = exec(...) fork survives -- issue #1261 must replace it with pfb_count_lines()'
-		);
-	}
-
-	// -----------------------------------------------------------------------
-	// Mirrored-expression hostile-input rows: the `> 0` log-gate must never
-	// throw and must treat a NULL (read failure) as "nothing to log".
-	// -----------------------------------------------------------------------
-
-	public static function gateRows(): array
+	/** @return array<string, array{string, string}> */
+	public static function sidecarSeams(): array
 	{
 		return [
-			'NULL count (pfb_count_lines() read failure)' => [NULL, FALSE],
-			'zero count (empty file)'                      => [0, FALSE],
-			'happy path count'                              => [7, TRUE],
+			'IPv4' => ['pfb_dnsbl_ipv4_count_decision', 'feed_v4.ip'],
+			'IPv6' => ['pfb_dnsbl_ipv6_count_decision', 'feed_v6.ip'],
 		];
 	}
 
-	#[DataProvider('gateRows')]
-	public function testLogGateNeverThrowsAndSkipsOnNullOrZero(?int $pfbCountLinesResult, bool $expectGateOpen): void
+	#[DataProvider('sidecarSeams')]
+	public function testEachSidecarReturnsCountAndPositiveDecision(string $seam, string $name): void
 	{
-		$ip_cnt = $pfbCountLinesResult ?? 0;
-		$this->assertSame($expectGateOpen, $ip_cnt > 0);
+		$path = "{$this->dir}/{$name}";
+		$this->assertNotFalse(file_put_contents($path, "one\ntwo\n"));
+
+		$this->assertSame(['count' => 2, 'loggable' => TRUE], $seam($path));
+	}
+
+	#[DataProvider('sidecarSeams')]
+	public function testEachSidecarCountsAnUnterminatedLastLine(string $seam, string $name): void
+	{
+		$path = "{$this->dir}/{$name}";
+		$this->assertNotFalse(file_put_contents($path, "one\ntwo"));
+		$this->assertSame(['count' => 2, 'loggable' => TRUE], $seam($path));
+	}
+
+	#[DataProvider('sidecarSeams')]
+	public function testEachSidecarTurnsReadFailureIntoNonLoggableZero(string $seam, string $name): void
+	{
+		$path = "{$this->dir}/{$name}";
+		$this->assertTrue(mkdir($path, 0700));
+
+		$this->assertSame(['count' => 0, 'loggable' => FALSE], $seam($path));
+	}
+
+	#[DataProvider('sidecarSeams')]
+	public function testEachSidecarSkipsLogForEmptyFile(string $seam, string $name): void
+	{
+		$path = "{$this->dir}/{$name}";
+		$this->assertNotFalse(file_put_contents($path, ''));
+
+		$this->assertSame(['count' => 0, 'loggable' => FALSE], $seam($path));
+	}
+
+	/** #993: the live sync/download/firewall monolith is unsafe off-appliance; comments are stripped. */
+	public function testSyncPassDispatchesBothDistinctSidecarDecisions(): void
+	{
+		$source = php_strip_whitespace(self::APPLY);
+		$start = strpos($source, 'function sync_package_pfblockerng(');
+		$this->assertNotFalse($start);
+		$sync = substr($source, $start);
+		foreach (self::sidecarSeams() as [$seam]) {
+			$this->assertSame(1, substr_count($sync, "{$seam}("), "sync pass must dispatch {$seam} exactly once");
+		}
 	}
 }

--- a/tests/php/DnsblListEditorWiringTest.php
+++ b/tests/php/DnsblListEditorWiringTest.php
@@ -4,148 +4,29 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1875 step 2a (RED, test-first): mounting the CM6 editor on the DNSBL page's
- * five remaining plaintext-list fields (pfb_gp_bypass_list, pfb_noaaaa_list, whitelist,
- * tld_wildcard_exclusion, tld_wildcard_blacklist) via a single `window.pfbCM && pfbCM.mountLists([...])` call,
- * gated by the SAME `$pfb_syntaxhl_on` boolean already established at line 38 (pinned by
- * DnsblRegexHighlightWiringTest) and living inside the SAME events.push() block as the
- * existing pfb_regex_list CM6 init.
- *
- * pfblockerng_dnsbl.php carries top-level render execution and cannot be require()d off-
- * appliance (same constraint as DnsblRegexHighlightWiringTest / FeedsUrlCompareIconRenderTest);
- * reading the real source file IS reading the render for this content -- this is the Tier-A
- * ui_render coverage for the mountLists rollout on this page.
- *
- * Split: the gate-shape / mountLists / vacuity-count assertions below are RED today (step 2b
- * has not landed -- pfbCM.mountLists( does not exist anywhere in the file yet). The five
- * Form_Textarea field pins are GREEN today by design: they pin the existing POST contract
- * (field ids/names the save handler keys off), which step 2b's client-side-only overlay must
- * not touch -- mixed red/green within this file is expected and is the point.
- */
 final class DnsblListEditorWiringTest extends TestCase
 {
-	private static string $src;
+	private const FIELDS = [
+		'pfb_gp_bypass_list',
+		'pfb_noaaaa_list',
+		'whitelist',
+		'tld_wildcard_exclusion',
+		'tld_wildcard_blacklist',
+	];
 
-	public static function setUpBeforeClass(): void
+	public function testDisabledEditorEmitsNoPlainListMount(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_dnsbl.php');
+		$this->assertSame('', pfb_dnsbl_editor_render(FALSE)['lists']);
+	}
+
+	public function testEnabledEditorMountsEveryDnsblPlainListField(): void
+	{
+		$init = pfb_dnsbl_editor_render(TRUE)['lists'];
+
+		$this->assertStringContainsString('window.pfbCM', $init);
+		$this->assertSame(1, substr_count($init, 'pfbCM.mountLists('));
+		foreach (self::FIELDS as $field) {
+			$this->assertStringContainsString($field, $init);
 		}
-		self::$src = $src;
-	}
-
-	public function testMountListsCallIsGatedInsideEventsPushBehindTheSyntaxHighlightBoolean(): void
-	{
-		// Tempered-dot gaps ((?:(?!endif).)*?), not bare .*? -- see
-		// DnsblRegexHighlightWiringTest's rationale: a bare .*? can bridge past THIS gate's
-		// own endif and land on a later, unrelated if($pfb_syntaxhl_on):...endif block.
-		$this->assertMatchesRegularExpression(
-			'#events\.push\(function\(\)\s*\{(?:(?!endif).)*?if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. 'window\.pfbCM(?:(?!endif).)*?pfbCM\.mountLists\((?:(?!endif).)*?endif#s',
-			self::$src,
-			'expected a pfbCM.mountLists( call, guarded on window.pfbCM, inside the same '
-			. 'events.push() block and the same if ($pfb_syntaxhl_on) gate as the existing '
-			. 'pfb_regex_list CM6 init'
-		);
-	}
-
-	public function testMountListsArrayContainsAllFiveTargetFieldIds(): void
-	{
-		// Each id must sit inside the mountLists([...]) array literal itself -- tempered-dot
-		// bounded by the array's own closing bracket/paren so a match can't bridge past this
-		// call onto an unrelated later array in the file.
-		foreach ([
-			'pfb_gp_bypass_list',
-			'pfb_noaaaa_list',
-			'whitelist',
-			'tld_wildcard_exclusion',
-			'tld_wildcard_blacklist',
-		] as $id) {
-			$this->assertMatchesRegularExpression(
-				"#pfbCM\\.mountLists\\(\\s*\\[(?:(?!\\]).)*?'" . preg_quote($id, '#') . "'(?:(?!\\]).)*?\\]\\s*\\)#s",
-				self::$src,
-				"expected '{$id}' inside the pfbCM.mountLists([...]) array argument"
-			);
-		}
-	}
-
-	/**
-	 * Vacuity-safe "the rollout doesn't duplicate the existing gated emissions" proof, same
-	 * rationale as DnsblRegexHighlightWiringTest::testCmRegexAssetAndFromTextareaCallEachAppearExactlyOnceInTheWholeFile.
-	 * Disambiguation note: substr_count(self::$src, 'pfbCM.fromTextarea(') -- WITH the
-	 * trailing '(' -- does NOT count a hypothetical 'pfbCM.fromTextareaList(' call, because
-	 * the character immediately after 'fromTextarea' in that name is 'L', not '(': the
-	 * literal needle fails to match at that position. The mountLists rollout is therefore
-	 * free to add its own differently-named call without perturbing this count.
-	 */
-	public function testExistingGatedEmissionsStayExactlyOnceAfterTheRollout(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(self::$src, '<script src="vendor/codemirror/cm-regex.min.js?v='),
-			'expected exactly one cm-regex.min.js <script> tag in the whole file -- the '
-			. 'mountLists rollout must not add a second, unguarded include'
-		);
-		$this->assertSame(
-			1,
-			substr_count(self::$src, 'pfbCM.fromTextarea('),
-			'expected exactly one pfbCM.fromTextarea( call in the whole file (the pre-existing '
-			. 'pfb_regex_list init) -- see the disambiguation note in this test\'s docblock'
-		);
-		$this->assertSame(
-			1,
-			substr_count(self::$src, 'pfbCM.mountLists('),
-			'expected exactly one pfbCM.mountLists( call in the whole file (the gated '
-			. 'events.push init) -- a second, unguarded call would defeat the '
-			. 'off-emits-nothing contract'
-		);
-	}
-
-	public function testOriginalBypassListTextareaFieldIsUnchanged(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'pfb_gp_bypass_list',#",
-			self::$src,
-			'expected the underlying pfb_gp_bypass_list Form_Textarea field to remain unchanged'
-		);
-	}
-
-	public function testOriginalNoaaaaListTextareaFieldIsUnchanged(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'pfb_noaaaa_list',#",
-			self::$src,
-			'expected the underlying pfb_noaaaa_list Form_Textarea field to remain unchanged'
-		);
-	}
-
-	public function testOriginalWhitelistTextareaFieldIsUnchanged(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'whitelist',#",
-			self::$src,
-			'expected the underlying whitelist Form_Textarea field to remain unchanged'
-		);
-	}
-
-	public function testOriginalTldexclusionTextareaFieldIsUnchanged(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'tld_wildcard_exclusion',#",
-			self::$src,
-			'expected the underlying tld_wildcard_exclusion Form_Textarea field to remain unchanged'
-		);
-	}
-
-	public function testOriginalTldblacklistTextareaFieldIsUnchanged(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'tld_wildcard_blacklist',#",
-			self::$src,
-			'expected the underlying tld_wildcard_blacklist Form_Textarea field to remain unchanged'
-		);
 	}
 }

--- a/tests/php/DnsblListScriptWiringTest.php
+++ b/tests/php/DnsblListScriptWiringTest.php
@@ -5,62 +5,24 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1926: DNSBL feeds save Pre/Post-process Script pickers that are never
- * executed. Wiring mirrors the IP loop's #1925 shape (staged normalized copy,
- * exit-status gated, manifest row kept on a pre-script failure with an existing
- * '.txt'); the DNSBL parse loop sits inside the thousands-of-lines sync loop
- * driving real appliance exec, so the call sites are pinned by source
- * inspection (same technique as ListScriptExitStatusTest /
- * GunzipTrailingNewlineWiringTest). The DNSBLIP mixed-feed fixture proves the
- * hazard the new help-text warning names: a pre-script that strips IP-shaped
- * lines silently shrinks the DNSBLIP alias.
- */
-#[CoversFunction('pfb_dnsbl_norm_reuse_skip')]
-#[CoversFunction('pfb_list_pre_script_run')]
-#[CoversFunction('pfb_list_script_exec')]
+/** DNSBLIP transforms must preserve the feed parser's observable counts. */
+#[CoversFunction('pfb_dnsbl_abp_extract_ip')]
 #[CoversFunction('pfb_dnsbl_collect_feed_ip')]
+#[CoversFunction('pfb_list_pre_script_run')]
 final class DnsblListScriptWiringTest extends TestCase
 {
-	private static string $applySource;
-	private static string $categoryEditSource;
-
 	private string $tmp;
 	/** @var array<string, mixed> */
 	private array $originalPfb;
 	private bool $hadPfb;
 
-	public static function setUpBeforeClass(): void
-	{
-		$applySource = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
-		);
-		if ($applySource === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
-		}
-		self::$applySource = $applySource;
-
-		$categoryEditSource = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
-		);
-		if ($categoryEditSource === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_category_edit.php');
-		}
-		self::$categoryEditSource = $categoryEditSource;
-	}
-
 	protected function setUp(): void
 	{
-		$this->tmp = sys_get_temp_dir() . '/pfb_dlsw_' . getmypid() . '_' . bin2hex(random_bytes(4));
-		mkdir($this->tmp, 0755, TRUE);
-
+		$this->tmp = sys_get_temp_dir() . '/pfb_dnsbl_script_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->tmp, 0700, TRUE));
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
-		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
-			'log'    => "{$this->tmp}/pfblockerng.log",
-			'errlog' => "{$this->tmp}/error.log",
-			'supp'   => PfbToggle::Off,
-		]);
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], ['supp' => PfbToggle::Off]);
 	}
 
 	protected function tearDown(): void
@@ -70,8 +32,10 @@ final class DnsblListScriptWiringTest extends TestCase
 		} else {
 			unset($GLOBALS['pfb']);
 		}
-		exec('chmod -R u+rwx ' . escapeshellarg($this->tmp));
-		exec('rm -rf ' . escapeshellarg($this->tmp));
+		foreach (glob("{$this->tmp}/*") ?: [] as $file) {
+			@unlink($file);
+		}
+		@rmdir($this->tmp);
 	}
 
 	private function makeScript(string $name, string $body): string
@@ -82,145 +46,18 @@ final class DnsblListScriptWiringTest extends TestCase
 		return $path;
 	}
 
-	// -----------------------------------------------------------------
-	// (a) source-inspection wiring
-	// -----------------------------------------------------------------
-
-	public function testAliasHeadResolvesBothScriptsAfterSrcint(): void
-	{
-		$srcintPos = strpos(self::$applySource, "\$srcint = \$list['srcint'] ?? '' ?: FALSE;");
-		$this->assertNotFalse($srcintPos, 'vacuity: the DNSBL per-alias srcint assignment must exist');
-
-		$rowLoopPos = strpos(self::$applySource, "foreach (\$list['row'] as \$key => \$row) {", $srcintPos);
-		$this->assertNotFalse($rowLoopPos, 'vacuity: the per-row loop that follows must exist');
-
-		$between = substr(self::$applySource, $srcintPos, $rowLoopPos - $srcintPos);
-		$this->assertStringContainsString('$pfb_dnsbl_script_pre', $between,
-			'the pre-script must be resolved once per alias, mirroring the IP loop');
-		$this->assertStringContainsString('$pfb_dnsbl_script_post', $between,
-			'the post-script must be resolved once per alias, mirroring the IP loop');
-		$this->assertStringContainsString('pfb_resolve_list_script(', $between,
-			'resolution must go through the same containment-checked resolver as the IP loop');
-	}
-
-	public function testReuseSkipCallSitePassesTheUserScriptFlag(): void
-	{
-		$reuseSkipPos = strpos(self::$applySource, 'pfb_dnsbl_norm_reuse_skip(');
-		$this->assertNotFalse($reuseSkipPos, 'vacuity: the DNSBL normalize/reuse-skip call site must exist');
-
-		$callEnd = strpos(self::$applySource, 'unchanged after normalization.', $reuseSkipPos);
-		$this->assertNotFalse($callEnd, 'vacuity: the reuse-skip branch body must exist');
-
-		$call = substr(self::$applySource, $reuseSkipPos, $callEnd - $reuseSkipPos);
-		$this->assertStringContainsString('$pfb_dnsbl_user_script', $call,
-			'a configured pre/post script must force a full reparse every pass, same contract as the IP loop');
-
-		$userScriptPos = strpos(self::$applySource, '$pfb_dnsbl_user_script = ');
-		$this->assertNotFalse($userScriptPos, 'vacuity: the user-script computation must exist');
-		$this->assertLessThan($reuseSkipPos, $userScriptPos,
-			'$pfb_dnsbl_user_script must be computed before it is passed to the reuse-skip call');
-	}
-
-	public function testPreScriptWindowRunsAfterReuseSkipAndBeforeSchemeWarn(): void
-	{
-		$reuseSkipPos = strpos(self::$applySource, 'pfb_dnsbl_norm_reuse_skip(');
-		$this->assertNotFalse($reuseSkipPos, 'vacuity: the DNSBL normalize/reuse-skip call site must exist');
-
-		$schemeWarnPos = strpos(self::$applySource, 'pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);', $reuseSkipPos);
-		$this->assertNotFalse($schemeWarnPos, 'vacuity: the scheme-skip warning call must exist');
-		$this->assertGreaterThan($reuseSkipPos, $schemeWarnPos, 'the scheme-skip warning must sit after reuse-skip');
-
-		$window = substr(self::$applySource, $reuseSkipPos, $schemeWarnPos - $reuseSkipPos);
-
-		$this->assertStringContainsString('pfb_list_pre_script_run(', $window,
-			'the pre-script must run through the staged-copy runner, mirroring the IP loop');
-		$this->assertStringContainsString('continue;', $window,
-			'a pre-script failure must skip the parse, keeping the last known-good staging');
-		$this->assertStringContainsString('pfb_feed_manifest_row(', $window,
-			'the failure branch must still emit a manifest row when a staged .txt exists -- '
-			. 'dropping it would relocate the outage (#1841 class), not fix it');
-		$this->assertStringContainsString('$staging_current_generation && file_exists("{$pfbfolder}/{$header}.txt")', $window,
-			'the manifest-on-failure emission must be guarded on an existing staged .txt');
-		$this->assertStringContainsString('" dnsbl {$elog}"', $window,
-			'the pre-script args tail must carry the stable "dnsbl" discriminator -- DNSBL has no vtype');
-
-		$fopenPos = strpos(self::$applySource, '@fopen($pfb_parse_path', $reuseSkipPos);
-		$this->assertNotFalse($fopenPos, 'vacuity: the parse open must read the (possibly staged) parse path');
-		$this->assertLessThan($schemeWarnPos, $fopenPos, 'the parse must happen before the scheme-skip warning');
-		$this->assertGreaterThan($reuseSkipPos, $fopenPos, 'the parse must happen after reuse-skip');
-
-		$this->assertStringNotContainsString('@fopen($pfb_norm[\'path\']', self::$applySource,
-			'the raw normalized path must no longer be the parse source -- the pre-script may have staged a copy');
-	}
-
-	public function testStagedPreScriptCopyIsUnlinkedAfterParsing(): void
-	{
-		$fopenPos = strpos(self::$applySource, '@fopen($pfb_parse_path');
-		$this->assertNotFalse($fopenPos, 'vacuity: the parse open must exist');
-
-		$schemeWarnPos = strpos(self::$applySource, 'pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);', $fopenPos);
-		$this->assertNotFalse($schemeWarnPos, 'vacuity: the scheme-skip warning must exist');
-
-		$window = substr(self::$applySource, $fopenPos, $schemeWarnPos - $fopenPos);
-		$this->assertStringContainsString('unlink_if_exists("{$file_dwn}.pre");', $window,
-			'the transient staged pre-script copy must be cleaned up once parsed, mirroring the IP loop');
-	}
-
-	public function testPostScriptWindowRunsAfterSchemeWarn(): void
-	{
-		$schemeWarnPos = strpos(self::$applySource, 'pfb_dnsbl_scheme_skip_warn($pfb_scheme_skipped, $header);');
-		$this->assertNotFalse($schemeWarnPos, 'vacuity: the scheme-skip warning call must exist');
-
-		$dedupPos = strpos(self::$applySource, 'Remove duplicates and save any IPs found', $schemeWarnPos);
-		$this->assertNotFalse($dedupPos, 'vacuity: the IP-dedup comment after parsing must exist');
-		$this->assertGreaterThan($schemeWarnPos, $dedupPos);
-
-		$window = substr(self::$applySource, $schemeWarnPos, $dedupPos - $schemeWarnPos);
-		$this->assertStringContainsString('pfb_list_script_exec(', $window,
-			'the post-script must run through the exit-status-honouring runner');
-		$this->assertStringContainsString('" dnsbl {$elog}"', $window,
-			'the post-script args tail must carry the stable "dnsbl" discriminator -- DNSBL has no vtype');
-		$this->assertStringContainsString('@copy("{$file_dwn}.orig", "{$file_dwn}.post")', $window,
-			'the post-script must run on a throwaway copy of the download, not the .orig itself');
-		$this->assertStringContainsString('unlink_if_exists("{$file_dwn}.post");', $window,
-			'the throwaway post-script copy must be cleaned up -- nothing downstream re-parses it');
-		$this->assertStringContainsString('could not stage its input', $window,
-			'a post-script staging copy failure must be logged naming the script -- a silent skip is undebuggable');
-		$this->assertStringNotContainsString('.orig.post', $window,
-			'the IP loop\'s backup/restore machinery is deliberately NOT mirrored -- the post-script '
-			. 'edits a throwaway copy instead of an .orig that would be restored anyway');
-	}
-
-	// -----------------------------------------------------------------
-	// (b) DNSBLIP mixed-feed regression fixture
-	// -----------------------------------------------------------------
-
 	/** @return list<string> */
 	private function mixedFeedLines(): array
 	{
 		return [
-			'example.com',
-			'sub.example.org',
-			'192.0.2.10',
-			'198.51.100.20',
-			'2001:db8::1',
-			'2001:db8::dead:beef',
-			'||ads.example.net^',
-			'@@||allow.example.net^',
-			'another-domain.test',
-			'203.0.113.5',
-			'||192.0.2.9^',
-			'||2001:db8::9^',
+			'example.com', 'sub.example.org', '192.0.2.10', '198.51.100.20',
+			'2001:db8::1', '2001:db8::dead:beef', '||ads.example.net^',
+			'@@||allow.example.net^', 'another-domain.test', '203.0.113.5',
+			'||192.0.2.9^', '||2001:db8::9^',
 		];
 	}
 
-	/**
-	 * Mirrors the DNSBL loop's two collection sites: the ABP network anchor is
-	 * unwrapped by pfb_dnsbl_abp_extract_ip() first, plain lines go straight to
-	 * the collector.
-	 *
-	 * @return array{v4: int, v6: int}
-	 */
+	/** @return array{v4:int,v6:int} */
 	private function collectIpCounts(string $content): array
 	{
 		$ip4 = [];
@@ -229,9 +66,9 @@ final class DnsblListScriptWiringTest extends TestCase
 			if ($line === '') {
 				continue;
 			}
-			$abp_ip = pfb_dnsbl_abp_extract_ip($line);
-			if ($abp_ip !== '') {
-				pfb_dnsbl_collect_feed_ip($abp_ip, $abp_ip, FALSE, $ip4, $ip6);
+			$abpIp = pfb_dnsbl_abp_extract_ip($line);
+			if ($abpIp !== '') {
+				pfb_dnsbl_collect_feed_ip($abpIp, $abpIp, FALSE, $ip4, $ip6);
 				continue;
 			}
 			pfb_dnsbl_collect_feed_ip($line, $line, FALSE, $ip4, $ip6);
@@ -241,90 +78,51 @@ final class DnsblListScriptWiringTest extends TestCase
 
 	public function testIdentityPreScriptPreservesDnsblipExtractionCounts(): void
 	{
-		$lines = $this->mixedFeedLines();
-		$content = implode("\n", $lines) . "\n";
+		$content = implode("\n", $this->mixedFeedLines()) . "\n";
+		$before  = $this->collectIpCounts($content);
+		$this->assertSame(4, $before['v4']);
+		$this->assertSame(3, $before['v6']);
 
-		// Before-state: the ORIGINAL content extracts exactly the 3 plain + 1 ABP v4
-		// lines and the 2 plain + 1 ABP v6 lines above.
-		$before = $this->collectIpCounts($content);
-		$this->assertSame(4, $before['v4'], 'sanity: fixture must carry exactly 4 v4-shaped lines (incl. one ABP-anchored)');
-		$this->assertSame(3, $before['v6'], 'sanity: fixture must carry exactly 3 v6-shaped lines (incl. one ABP-anchored)');
-
-		$norm = "{$this->tmp}/feed.norm";
-		file_put_contents($norm, $content);
+		$norm   = "{$this->tmp}/feed.norm";
 		$staged = "{$this->tmp}/feed.pre";
-		$script = $this->makeScript('dnsbl_pre_identity.sh', 'exit 0');
+		file_put_contents($norm, $content);
+		$script = $this->makeScript('identity.sh', 'exit 0');
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'identity.sh', 'MyFeed', escapeshellarg($staged) . ' dnsbl', '');
 
-		$result = pfb_list_pre_script_run($norm, $staged, $script, 'dnsbl_pre_identity.sh', 'MyFeed',
-			escapeshellarg($staged) . ' dnsbl', '');
-		$this->assertTrue($result['ok'], 'an identity script must be honoured');
-
+		$this->assertTrue($result['ok']);
 		$after = $this->collectIpCounts((string) file_get_contents($result['path']));
-		$this->assertSame($before['v4'], $after['v4'],
-			'an identity pre-script must not change the extracted v4 DNSBLIP count');
-		$this->assertSame($before['v6'], $after['v6'],
-			'an identity pre-script must not change the extracted v6 DNSBLIP count');
+		$this->assertSame($before, $after);
 	}
 
 	public function testStrippingPreScriptShrinksDnsblipExtractionCounts(): void
 	{
-		$lines = $this->mixedFeedLines();
-		$content = implode("\n", $lines) . "\n";
-		$before = $this->collectIpCounts($content);
-
-		$norm = "{$this->tmp}/feed.norm";
+		$content = implode("\n", $this->mixedFeedLines()) . "\n";
+		$before  = $this->collectIpCounts($content);
+		$norm    = "{$this->tmp}/feed.norm";
+		$staged  = "{$this->tmp}/feed.pre";
 		file_put_contents($norm, $content);
-		$staged = "{$this->tmp}/feed.pre";
-		// Strips every IP-shaped line -- plain AND ABP-anchored (||IP^) -- the exact
-		// hazard the DNSBL help-text warning names: a careless pre-process script
-		// silently shrinks the DNSBLIP alias.
-		$script = $this->makeScript('dnsbl_pre_strip_ips.sh',
-			"grep -Ev '^(\\|\\|)?[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\\^?\$|^(\\|\\|)?[0-9a-fA-F:]+\\^?\$' \"\$1\" > \"\$1.tmp\" && mv \"\$1.tmp\" \"\$1\"");
+		$script = $this->makeScript('strip.sh', "grep -Ev '^(\\|\\|)?[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+\\^?\$|^(\\|\\|)?[0-9a-fA-F:]+\\^?\$' \"\$1\" > \"\$1.tmp\" && mv \"\$1.tmp\" \"\$1\"");
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'strip.sh', 'MyFeed', escapeshellarg($staged) . ' dnsbl', '');
 
-		$result = pfb_list_pre_script_run($norm, $staged, $script, 'dnsbl_pre_strip_ips.sh', 'MyFeed',
-			escapeshellarg($staged) . ' dnsbl', '');
-		$this->assertTrue($result['ok'], 'the stripping script itself must not fail (non-zero exit / delete)');
-
+		$this->assertTrue($result['ok']);
 		$after = $this->collectIpCounts((string) file_get_contents($result['path']));
-		$this->assertLessThan($before['v4'], $after['v4'],
-			'a script that strips IP-shaped lines must shrink the extracted v4 DNSBLIP count '
-			. '-- this is the failure the fixture must be able to detect');
-		$this->assertLessThan($before['v6'], $after['v6'],
-			'a script that strips IP-shaped lines must shrink the extracted v6 DNSBLIP count');
+		$this->assertLessThan($before['v4'], $after['v4']);
+		$this->assertLessThan($before['v6'], $after['v6']);
 		$this->assertSame(0, $after['v4']);
 		$this->assertSame(0, $after['v6']);
 	}
 
-	// -----------------------------------------------------------------
-	// (c) www/ help-note render pin
-	// -----------------------------------------------------------------
-
-	public function testHelpNoteIsConditionedOnTheDnsblPrefixAndConcatenatedIntoScriptPreHelp(): void
+	public function testHelpNoteRemainsDnsblOnly(): void
 	{
-		$notePos = strpos(self::$categoryEditSource, '$script_dnsbl_note');
-		$this->assertNotFalse($notePos, 'vacuity: the DNSBL-only help note assignment must exist');
+		$options = ['' => 'None', 'pre.sh' => 'pre.sh'];
+		$dnsbl   = pfb_category_script_pre_settings('dnsbl', $options);
+		$ip      = pfb_category_script_pre_settings('ip', $options);
 
-		// ";\n" (not a bare ";") skips the "&nbsp;" HTML entity's own semicolon --
-		// that entity sits mid-string, never followed by a newline.
-		$noteEnd = strpos(self::$categoryEditSource, ";\n", $notePos);
-		$this->assertNotFalse($noteEnd, 'vacuity: the note assignment must terminate');
-		$noteAssignment = substr(self::$categoryEditSource, $notePos, $noteEnd - $notePos);
-
-		$this->assertStringContainsString("\$list_prefix == 'dnsbl'", $noteAssignment,
-			'the note must be conditioned on the dnsbl prefix -- the IP tab must never render it');
-		$this->assertStringContainsString('DNSBLIP', $noteAssignment,
-			'the note must name the alias it warns about');
-		$this->assertStringContainsString('silently shrink', $noteAssignment,
-			'the note must name the failure mode the DNSBLIP fixture proves');
-
-		$fieldPos = strpos(self::$categoryEditSource, "'script_pre',");
-		$this->assertNotFalse($fieldPos, 'vacuity: the script_pre Form_Select must exist');
-
-		$sizePos = strpos(self::$categoryEditSource, "->setAttribute('size', \$options_script_pre_cnt);", $fieldPos);
-		$this->assertNotFalse($sizePos, 'vacuity: the script_pre field must terminate with its size attribute');
-
-		$fieldBlock = substr(self::$categoryEditSource, $fieldPos, $sizePos - $fieldPos);
-		$this->assertStringContainsString('$script_dnsbl_note', $fieldBlock,
-			'the note must be concatenated into the script_pre field\'s sethelp text');
+		$this->assertSame(2, $dnsbl['size']);
+		$this->assertSame(2, $ip['size']);
+		$this->assertStringContainsString('DNSBLIP', $dnsbl['help']);
+		$this->assertStringContainsString('silently shrink', $dnsbl['help']);
+		$this->assertStringNotContainsString('DNSBLIP', $ip['help']);
+		$this->assertStringNotContainsString('silently shrink', $ip['help']);
 	}
 }

--- a/tests/php/DnsblPlaintextSummaryRetirementTest.php
+++ b/tests/php/DnsblPlaintextSummaryRetirementTest.php
@@ -19,11 +19,11 @@ final class DnsblPlaintextSummaryRetirementTest extends TestCase
 
 	protected function setUp(): void
 	{
-		$umbrella = file_get_contents(self::INC);
-		$apply = file_get_contents(self::APPLY);
-		$installSource = file_get_contents(self::INSTALL);
-		$this->assertNotFalse($umbrella, 'failed to read pfblockerng.inc');
-		$this->assertNotFalse($installSource, 'failed to read pfblockerng_install.inc');
+		$umbrella = php_strip_whitespace(self::INC);
+		$apply = php_strip_whitespace(self::APPLY);
+		$installSource = php_strip_whitespace(self::INSTALL);
+		$this->assertNotSame('', $umbrella, 'failed to read pfblockerng.inc');
+		$this->assertNotSame('', $installSource, 'failed to read pfblockerng_install.inc');
 		$source = $umbrella . "\n" . $apply;
 		$this->assertNotSame('', trim($source), 'pfblockerng.inc + pfblockerng_apply.inc must be nonempty');
 		$this->assertStringContainsString('function dnsbl_save_stats(', $source);
@@ -104,7 +104,7 @@ final class DnsblPlaintextSummaryRetirementTest extends TestCase
 
 	public function testDisabledGroupHasValidatedAliasBeforeStatsUpdate(): void
 	{
-		$groupLoop = strpos($this->source, '// Reset variables once per alias');
+		$groupLoop = strpos($this->source, 'foreach ($lists as $list)');
 		$this->assertNotFalse($groupLoop);
 		$assignmentMatched = preg_match(
 			'/\$alias\s*=\s*"DNSBL_\{\$list\[\'aliasname\'\]\}";/',

--- a/tests/php/DnsblQueryClientTest.php
+++ b/tests/php/DnsblQueryClientTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
  *     is ignored, never a fatal, and the call times out to NULL;
  *   - blocked=false with empty attribution is a VALID verdict, not NULL;
  *   - timeout paths emit the expected verdict/lock signals and clean up;
- *     a source pin records the independent hard poll cap that protects a stalled clock;
+ *     an injected stalled clock proves the independent hard poll cap runs;
  *   - cleanup: reply+request unlinked on a matched verdict or timeout, no
  *     ".pfbctl_" staging residue.
  *
@@ -549,20 +549,25 @@ final class DnsblQueryClientTest extends TestCase
 		$this->assertStringContainsString('query channel lock timed out', $logs);
 	}
 
-	/** Source pin: stalled-clock behavior has no deterministic production seam. */
-	public function testSourcePinLockWaitContainsIndependentHardPollCap(): void
+	public function testLockWaitHardPollCapStopsEvenWhenClockStalls(): void
 	{
-		$function = new ReflectionFunction('pfb_dnsbl_query');
-		$lines = file($function->getFileName());
-		$this->assertIsArray($lines);
-		$source = implode('', array_slice(
-			$lines,
-			$function->getStartLine() - 1,
-			$function->getEndLine() - $function->getStartLine() + 1
-		));
-
-		$this->assertStringContainsString('$lock_polls++;', $source);
-		$this->assertStringContainsString('$lock_polls >= $max_lock_polls', $source);
+		$lock = fopen($this->lockPath(), 'c');
+		$this->assertIsResource($lock);
+		$this->assertTrue(flock($lock, LOCK_EX));
+		$reads = 0;
+		$stalledClock = static function () use (&$reads): float {
+			$reads++;
+			return 100.0;
+		};
+		$started = microtime(TRUE);
+		try {
+			$this->assertNull(pfb_dnsbl_query('stalled-clock.example', 'A', 0.01, $stalledClock));
+		} finally {
+			flock($lock, LOCK_UN);
+			fclose($lock);
+		}
+		$this->assertGreaterThan(1, $reads, 'the shipped wait must consult the injected clock');
+		$this->assertLessThan(0.5, microtime(TRUE) - $started, 'the independent poll cap must stop a stalled clock');
 	}
 
 	public function testContendedLockWithShortTimeoutReturnsWithoutPublishing(): void

--- a/tests/php/DnsblRegexHelpTextTest.php
+++ b/tests/php/DnsblRegexHelpTextTest.php
@@ -5,94 +5,61 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * Issue #1866 -- the DNSBL "Regex List" field's help text.
- *
- * Two defects, both in the same string:
- *
- *  1. It hard-wraps mid-sentence. The literal carries a `<br />` after the word
- *     "in", so the rendered paragraph breaks between "in" and "the" at every
- *     window width. A `<br />` in prose is a paragraph break, so each one has to
- *     land where a sentence actually ends.
- *  2. It told the admin to "Ensure a space is entered before the # character",
- *     which is not what the package does: the description starts at the first
- *     UNESCAPED '#' on the line, space or no space (see #1867 for the escape).
- *
- * pfblockerng_dnsbl.php carries top-level render execution and cannot be
- * require()d off-appliance, so the help literal is read from the real source --
- * the same technique DnsblRegexHighlightWiringTest uses for this page, and the
- * Tier-A coverage for this www/ change.
+ * The helper assertions validate rendered prose directly. The DNSBL page has
+ * top-level pfSense render/config execution and cannot be required safely off
+ * appliance, so its live render call is pinned from comment-free PHP; comments
+ * and docblocks are never allowed to define this coverage boundary.
  */
 final class DnsblRegexHelpTextTest extends TestCase
 {
-	private static string $helpText;
+	private static string $source;
 
 	public static function setUpBeforeClass(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_dnsbl.php');
+		self::$source = php_strip_whitespace(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php'
+		);
+		if (self::$source === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng_dnsbl.php');
 		}
-		if (preg_match("/\\\$regex_text\\s*=\\s*'(.*?)';/s", $src, $match) !== 1) {
-			throw new RuntimeException('could not locate the $regex_text help literal');
-		}
-		self::$helpText = $match[1];
 	}
 
 	public function testEveryLineBreakLandsAtTheEndOfASentence(): void
 	{
-		// Split on each <br />, then check what the preceding fragment ENDS with.
-		// A fragment that ends mid-word (the "...used in" case) is the defect.
-		$fragments = preg_split('#<br\s*/?>#', self::$helpText);
+		$fragments = preg_split('#<br\s*/?>#', pfb_dnsbl_regex_help_render());
 		$this->assertIsArray($fragments);
-		// The final fragment has no <br /> after it, so it is not a break site.
 		array_pop($fragments);
 
 		$midSentence = [];
 		foreach ($fragments as $fragment) {
 			$trimmed = rtrim($fragment);
-			if ($trimmed === '') {
-				continue; // a doubled <br /><br /> paragraph gap is fine
-			}
-			if (preg_match('/[.:!?]$/', $trimmed) !== 1) {
+			if ($trimmed !== '' && preg_match('/[.:!?]$/', $trimmed) !== 1) {
 				$midSentence[] = $trimmed;
 			}
 		}
 
-		$this->assertSame(
-			[],
-			$midSentence,
-			"every <br /> must follow the end of a sentence; these break mid-sentence:\n"
-				. implode("\n", array_map(static fn (string $f): string => '  ...' . substr($f, -60), $midSentence))
-		);
+		$this->assertSame([], $midSentence, 'help breaks must follow complete sentences');
 	}
 
-	public function testDoesNotClaimASpaceIsRequiredBeforeTheHash(): void
+	public function testHelpExplainsUnescapedHashAndLiteralHashEscape(): void
 	{
-		$this->assertDoesNotMatchRegularExpression(
-			'/space\s+is\s+entered\s+before/i',
-			self::$helpText,
-			'the help text still tells the admin a space is required before "#", which the decoder does not require'
-		);
+		$help = pfb_dnsbl_regex_help_render();
+
+		$this->assertDoesNotMatchRegularExpression('/space\s+is\s+entered\s+before/i', $help);
+		$this->assertMatchesRegularExpression('/first\b.*\bunescaped\b/is', $help);
+		$this->assertStringContainsString('\\#', $help);
 	}
 
-	public function testDocumentsThatTheFirstUnescapedHashStartsTheDescription(): void
+	/**
+	 * Pin the page's executable help-render call without booting its live Form_*
+	 * stack, which would require a real pfSense appliance request context.
+	 * Comments/docblocks cannot define this callsite boundary.
+	 */
+	public function testDnsblPageRendersRegexHelpThroughSharedHelper(): void
 	{
-		$this->assertMatchesRegularExpression(
-			'/first\b.*\bunescaped\b/is',
-			self::$helpText,
-			'the help text must state that the FIRST UNESCAPED "#" starts the description'
-		);
-	}
-
-	public function testDocumentsTheBackslashEscapeForALiteralHash(): void
-	{
-		// #1867's escape is only usable if it is written down where the admin
-		// looks; an undocumented escape is the same defect in a new place.
 		$this->assertStringContainsString(
-			'\\#',
-			self::$helpText,
-			'the help text must show the \\# escape for a literal hash inside a pattern'
+			'$regex_text = pfb_dnsbl_regex_help_render();',
+			self::$source
 		);
 	}
 }

--- a/tests/php/DnsblRegexHighlightWiringTest.php
+++ b/tests/php/DnsblRegexHighlightWiringTest.php
@@ -4,204 +4,36 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1669 slice C -- live CodeMirror 6 syntax highlighting for the DNSBL
- * Python-regex list field (`pfb_regex_list`), gated by the new General-settings
- * `pfb_syntax_highlight` toggle (registered in pfb_cfg_registry(), default on).
- *
- * pfblockerng_dnsbl.php carries top-level render execution (require_once('guiconfig.inc')
- * et al.) and cannot be require()d/rendered off-appliance -- same constraint documented
- * on FeedsUrlCompareIconRenderTest/CategoryEditReservedHeaderTest. Slice 2 (the retired
- * Prism version) pinned unconditional literal source directly, because its markup was
- * unconditional. This slice's markup is CONDITIONAL (the asset include + the JS init are
- * both gated behind the toggle, per the pivot decision to emit zero highlight bytes when
- * it is off), so this test pins the CONDITIONAL STRUCTURE itself -- the PfbConfig read,
- * the pfb_editor_enabled() accessor (issue #1887 — hides the key, the registered
- * default and the stored token behind one bool), and the gated script tag /
- * JS init all being driven by the same PHP boolean -- rather than asserting the markup is
- * unconditionally present. A separate exactly-once occurrence count on both the script
- * src and the fromTextarea call is the vacuity-safe proof that "off emits nothing new":
- * a regex that merely finds a match inside *a* gate would still pass if a second,
- * unguarded reference existed elsewhere in the file; counting occurrences closes that gap.
- * Reading the real source file IS reading the render for this content (same rationale as
- * slice 2); this remains the Tier-A ui_render coverage for this www/ change together with
- * tests/smoke/ui/test_render_smoke.py's marker (present only because the toggle defaults
- * on for a fresh box).
- */
 final class DnsblRegexHighlightWiringTest extends TestCase
 {
-	private static string $src;
-
-	public static function setUpBeforeClass(): void
+	public function testDisabledEditorEmitsNoAssetOrInitialization(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_dnsbl.php');
-		}
-		self::$src = $src;
+		$rendered = pfb_dnsbl_editor_render(FALSE);
+		$this->assertSame('', $rendered['asset']);
+		$this->assertSame('', $rendered['regex']);
+		$this->assertSame('', $rendered['lists']);
 	}
 
-	public function testGatingBooleanReadsThePfbSyntaxHighlightToggle(): void
+	public function testEnabledEditorRendersAssetAndRegexInitialization(): void
 	{
-		// The single PHP boolean gating BOTH the asset include and the JS init must be
-		// derived from PfbConfig::read('gen/pfb_syntax_highlight') compared against
-		// pfb_editor_enabled() -- the issue #1887 named accessor every editor page's
-		// pfb_cache_flush read already establishes (PfbConfig::read() returns the enum
-		// directly here, not ->value). LENIENT, not PfbToggle -- see the class docblock.
-		$this->assertMatchesRegularExpression(
-			"#\\\$pfb_syntaxhl_on\\s*=\\s*pfb_editor_enabled\\(\\)#",
-			self::$src,
-			'expected a $pfb_syntaxhl_on boolean derived from pfb_editor_enabled() (issue #1887 named accessor)'
-		);
+		$rendered = pfb_dnsbl_editor_render(TRUE);
+		$asset = $rendered['asset'];
+		$init  = $rendered['regex'];
+
+		$this->assertStringContainsString('cm-regex.min.js?v=', $asset);
+		$this->assertStringContainsString("getElementById('pfb_regex_list')", $init);
+		$this->assertStringContainsString('window.pfbCM', $init);
+		$this->assertStringContainsString('pfbCM.fromTextarea(', $init);
+		$this->assertStringContainsString("lintUrl: '/pfblockerng/pfblockerng_lint.php'", $init);
+		$this->assertStringContainsString("getElementById('pfb_regex_cap')", $init);
 	}
 
-	public function testCmRegexScriptIsIncludedWithCacheBustingInsideTheGate(): void
+	public function testRegexInitializationHasOneReachableMountAndLiveCapMapping(): void
 	{
-		// The script tag must be textually gated by the same $pfb_syntaxhl_on boolean,
-		// i.e. an `if ($pfb_syntaxhl_on)` PHP block wrapping the <script> tag -- toggle
-		// off must emit zero new bytes (no script tag at all).
-		// Tempered-dot gaps ((?:(?!endif).)*?), not bare .*? -- a bare .*? (even
-		// non-greedy, under /s) can consume a literal "endif" substring, letting the
-		// match bridge PAST this gate's own close and land on a DIFFERENT, later
-		// if($pfb_syntaxhl_on):...endif block's content -- a false pass if the script
-		// tag were ever accidentally moved out of this gate to sit between the two
-		// gates in the real file. Tempered dot forbids consuming "endif", so the match
-		// can't cross this gate's boundary.
-		$this->assertMatchesRegularExpression(
-			'#if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. '<script src="vendor/codemirror/cm-regex\.min\.js\?v=<\?=pfb_file_mtime\(\'/usr/local/www/pfblockerng/vendor/codemirror/cm-regex\.min\.js\'\)\?>"></script>'
-			. '(?:(?!endif).)*?endif#s',
-			self::$src,
-			'expected the cm-regex.min.js include, with mtime cache-busting, wrapped inside an if ($pfb_syntaxhl_on) gate'
-		);
-	}
+		$init = pfb_dnsbl_editor_render(TRUE)['regex'];
 
-	public function testRegexListInitTargetsThePfbRegexListElementAndChecksWindowPfbCM(): void
-	{
-		$this->assertStringContainsString(
-			"getElementById('pfb_regex_list')",
-			self::$src,
-			'expected the CM6 init to look up the pfb_regex_list element by id'
-		);
-		$this->assertStringContainsString(
-			'window.pfbCM',
-			self::$src,
-			'expected the CM6 init to guard on window.pfbCM (the vendored bundle\'s IIFE global) being defined'
-		);
-		$this->assertMatchesRegularExpression(
-			'/pfbCM\.fromTextarea\(/',
-			self::$src,
-			'expected the CM6 init to call pfbCM.fromTextarea() on the located element'
-		);
-	}
-
-	public function testRegexListInitIsGatedInsideEventsPushBehindTheSameBoolean(): void
-	{
-		// The JS init must live inside the existing events.push(function(){...}) block
-		// and be gated by the same $pfb_syntaxhl_on boolean as the asset include -- not
-		// a second, independently-computed condition.
-		// Tempered-dot gaps here too (see testCmRegexScriptIsIncludedWithCacheBustingInsideTheGate's
-		// comment) -- same bridging-past-this-gate's-endif risk applies to the
-		// events.push()/getElementById/fromTextarea chain.
-		$this->assertMatchesRegularExpression(
-			'#events\.push\(function\(\)\{(?:(?!endif).)*?if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. "getElementById\\('pfb_regex_list'\\)(?:(?!endif).)*?pfbCM\\.fromTextarea\\((?:(?!endif).)*?endif#s",
-			self::$src,
-			'expected the pfb_regex_list CM6 init inside events.push(), gated by if ($pfb_syntaxhl_on)'
-		);
-	}
-
-	/**
-	 * Vacuity-safe "off emits nothing new" proof: the earlier gate-shape regexes
-	 * (testCmRegexScriptIsIncludedWithCacheBustingInsideTheGate,
-	 * testRegexListInitIsGatedInsideEventsPushBehindTheSameBoolean) only prove that
-	 * a gated occurrence EXISTS -- they would still pass if a second, UNGUARDED
-	 * reference to the same asset/call existed elsewhere in the file (e.g. a stray
-	 * unconditional <script> tag added later by mistake). Counting occurrences closes
-	 * that gap: exactly one `cm-regex.min.js` reference and exactly one
-	 * `pfbCM.fromTextarea(` call in the whole file means every emission this slice
-	 * adds lives behind the one $pfb_syntaxhl_on gate -- toggling it off truly emits
-	 * zero new bytes, not just "at least one guarded copy plus stray unguarded ones".
-	 */
-	public function testCmRegexAssetAndFromTextareaCallEachAppearExactlyOnceInTheWholeFile(): void
-	{
-		// The <script src="..."> tag legitimately mentions "cm-regex.min.js" TWICE --
-		// once in the src path, once inside the pfb_file_mtime() cache-buster argument --
-		// so the vacuity-safe count targets the tag's opening (`<script src="...` up to
-		// the query string), which appears exactly once iff there is exactly one <script>
-		// tag emitting this asset, regardless of the mtime-argument's own duplicate path.
-		$this->assertSame(
-			1,
-			substr_count(self::$src, '<script src="vendor/codemirror/cm-regex.min.js?v='),
-			'expected exactly one cm-regex.min.js <script> tag in the whole file (the gated include) -- '
-			. 'a second, unguarded <script> tag would defeat the off-emits-nothing contract'
-		);
-		$this->assertSame(
-			1,
-			substr_count(self::$src, 'pfbCM.fromTextarea('),
-			'expected exactly one pfbCM.fromTextarea( call in the whole file (the gated events.push init) -- '
-			. 'a second, unguarded call would defeat the off-emits-nothing contract'
-		);
-	}
-
-	/**
-	 * issue #1732 step 2: the DNSBL page's fromTextarea() call now also wires the
-	 * advisory server-lint endpoint, still inside the SAME $pfb_syntaxhl_on gate --
-	 * toggling syntax highlighting off must keep emitting zero lint bytes too.
-	 */
-	public function testRegexListInitPassesTheLintUrlInsideTheSameGate(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#events\\.push\\(function\\(\\)\\{(?:(?!endif).)*?if\\s*\\(\\s*\\\$pfb_syntaxhl_on\\s*\\)\\s*:(?:(?!endif).)*?"
-			. "pfbCM\\.fromTextarea\\([^;]*?lintUrl:\\s*'/pfblockerng/pfblockerng_lint\\.php'(?:(?!endif).)*?endif#s",
-			self::$src,
-			"expected pfbCM.fromTextarea(...) to pass lintUrl: '/pfblockerng/pfblockerng_lint.php' inside the \$pfb_syntaxhl_on gate"
-		);
-	}
-
-	/**
-	 * The cap diagnostic must reflect the LIVE checkbox state (what save would enforce
-	 * right now), not the page-load value -- the lintExtraParams function reads
-	 * pfb_regex_cap's checked state at lint time and maps it to '1'/'0'.
-	 */
-	public function testRegexListLintExtraParamsReadsTheLiveCapCheckboxState(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#lintExtraParams:\\s*function\\s*\\(\\)\\s*\\{[^}]*getElementById\\('pfb_regex_cap'\\)[^}]*\\}#s",
-			self::$src,
-			"expected lintExtraParams to be a function reading getElementById('pfb_regex_cap')"
-		);
-		$this->assertMatchesRegularExpression(
-			"#capEl\\s*&&\\s*capEl\\.checked\\)\\s*\\?\\s*'1'\\s*:\\s*'0'#",
-			self::$src,
-			"expected the cap checkbox's checked state to map to '1'/'0'"
-		);
-	}
-
-	/**
-	 * Vacuity-safe count for the new lintUrl wiring, same rationale as
-	 * testCmRegexAssetAndFromTextareaCallEachAppearExactlyOnceInTheWholeFile.
-	 */
-	public function testLintUrlAppearsExactlyOnceInTheWholeFile(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(self::$src, "lintUrl: '/pfblockerng/pfblockerng_lint.php'"),
-			'expected exactly one lintUrl wiring in the whole file (the gated events.push init)'
-		);
-	}
-
-	public function testOriginalRegexTextareaFieldIsUnchanged(): void
-	{
-		// The save handler's mb_detect_encoding()/base64_encode() calls key off this exact
-		// Form_Textarea('pfb_regex_list', ...) name -- this slice must not touch it; the
-		// CM6 overlay is a pure client-side progressive enhancement layered on top, and
-		// the POST contract stays exactly as it was pre-slice-C.
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'pfb_regex_list',#",
-			self::$src,
-			'expected the underlying pfb_regex_list Form_Textarea field to remain unchanged'
-		);
+		$this->assertSame(1, substr_count($init, 'pfbCM.fromTextarea('));
+		$this->assertSame(1, substr_count($init, "lintUrl: '/pfblockerng/pfblockerng_lint.php'"));
+		$this->assertStringContainsString("(capEl && capEl.checked) ? '1' : '0'", $init);
 	}
 }

--- a/tests/php/DnsblRegexToggleGateWiringTest.php
+++ b/tests/php/DnsblRegexToggleGateWiringTest.php
@@ -4,89 +4,20 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * PR #1667 CodeRabbit finding (Major, availability): the DNSBL save handler ran
- * pfb_dnsbl_regex_validation_errors() on every save whenever pfb_regex_list was
- * non-empty, even when the `pfb_regex` feature toggle was OFF -- in which case
- * pfb_unbound.py never loads those patterns at all. Because the helper fails CLOSED
- * on an unresolvable pfb_python_interpreter(), an install where that interpreter
- * cannot resolve could not save the DNSBL settings page AT ALL (every unrelated
- * field on it) with no remedy short of emptying the Regex List -- a regression this
- * PR introduced (pre-PR, DNSBL saves never depended on Python).
- *
- * pfblockerng_dnsbl.php carries top-level render execution (require_once('guiconfig.inc')
- * et al.) and cannot be require()d/executed off-appliance -- same constraint documented
- * on DnsblRegexHighlightWiringTest/GeneralSyntaxHighlightToggleWiringTest. This pins the
- * fix the same way those do: literal source-shape assertions on the save block, rather
- * than executing the save path. Behavioural coverage for the two axes this wiring test
- * cannot exercise directly (list contents x interpreter availability) already lives in
- * DnsblRegexEntryErrorTest against pfb_dnsbl_regex_validation_errors() itself
- * (testMissingPythonAndTimeoutFailClosed = fail-closed proof, the malformed/benign
- * pattern tests = invalid/valid proof); composed with this test's proof of the guard's
- * shape, that covers: interpreter usable -> validator runs whatever the toggle says
- * (invalid pattern blocks, valid one does not), so an entry that would vanish at load
- * is still reported while the feature is off; interpreter unusable + toggle on ->
- * blocked, fail-closed preserved; interpreter unusable + toggle off -> skipped, which
- * is the availability leg this fix exists for.
- */
 final class DnsblRegexToggleGateWiringTest extends TestCase
 {
-	private static string $src;
-
-	public static function setUpBeforeClass(): void
+	public function testUsableInterpreterAlwaysRunsValidation(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_dnsbl.php');
-		}
-		self::$src = $src;
+		$this->assertTrue(pfb_dnsbl_regex_validation_required_page(TRUE, 'off'));
+		$this->assertTrue(pfb_dnsbl_regex_validation_required_page(TRUE, 'on'));
+		$this->assertTrue(pfb_dnsbl_regex_validation_required_page(TRUE, ''));
 	}
 
-	public function testRegexValidationRunsWheneverTheInterpreterIsUsable(): void
+	public function testUnusableInterpreterRunsValidationOnlyWhenRegexFeatureIsOn(): void
 	{
-		// A usable interpreter is sufficient on its own: an entry the resolver would drop
-		// is reported at save even while the feature is still off, which is the feedback
-		// contract issue #1656 exists for.
-		$this->assertMatchesRegularExpression(
-			"#if\\s*\\(\\s*\\(\\s*\\\$pfb_regex_python\\s*!==\\s*''\\s*&&\\s*"
-			. "is_executable\\(\\\$pfb_regex_python\\)\\s*\\)\\s*\\|\\|#",
-			self::$src,
-			'expected the validation guard to run whenever the resolved interpreter is executable'
-		);
-	}
-
-	public function testUnusableInterpreterOnlyBlocksTheSaveWhileTheFeatureIsOn(): void
-	{
-		// The second disjunct is the fail-closed leg: with no usable interpreter the
-		// validator can only report "interpreter unavailable", so it must apply solely
-		// when pfb_regex is submitted as the literal 'on' -- otherwise an unresolvable
-		// interpreter would make the whole DNSBL page unsavable, unrelated fields
-		// included. Anything that is not literally 'on' (absent key, '', 'off', '0', an
-		// array from pfb_regex[]=on, whitespace-padded junk) falls to the else side:
-		// === against a non-scalar is false in PHP, never a warning or TypeError.
-		$this->assertMatchesRegularExpression(
-			"#\\|\\|\\s*\\(\\s*\\(\\s*\\\$_POST\\['pfb_regex'\\]\\s*\\?\\?\\s*''\\s*\\)\\s*===\\s*'on'\\s*\\)\\s*\\)\\s*\\{\\s*"
-			. "foreach\\s*\\(pfb_dnsbl_regex_validation_errors\\(\\(string\\)\\s*\\(\\s*\\\$_POST\\['pfb_regex_list'\\]\\s*\\?\\?\\s*''\\s*\\),\\s*"
-			. "\\\$pfb_regex_python,\\s*\\(\\s*\\\$_POST\\['pfb_regex_cap'\\]\\s*\\?\\?\\s*''\\s*\\)\\s*===\\s*'on'\\)\\s*as\\s*\\\$regex_error\\)\\s*\\{\\s*"
-			. "\\\$input_errors\\[\\]\\s*=\\s*'Customlist pfb_regex_list:\\s*'\\s*\\.\\s*"
-			. "htmlspecialchars\\(\\\$regex_error,\\s*ENT_QUOTES\\s*\\|\\s*ENT_SUBSTITUTE,\\s*'UTF-8'\\);\\s*\\}\\s*\\}#",
-			self::$src,
-			"expected the toggle disjunct to gate only the fail-closed leg, with the "
-			. 'validation call (including the pfb_regex_cap third argument, issue #1688) and its error-append inside that guard'
-		);
-	}
-
-	public function testRegexValidationCallSiteAppearsExactlyOnce(): void
-	{
-		// Vacuity-safe proof: the previous test only shows a gated occurrence EXISTS --
-		// it would still pass if a second, unguarded call existed elsewhere in the file.
-		// Counting closes that gap.
-		$this->assertSame(
-			1,
-			substr_count(self::$src, 'pfb_dnsbl_regex_validation_errors('),
-			'expected exactly one pfb_dnsbl_regex_validation_errors( call in the whole file -- '
-			. 'a second, unguarded call would defeat the toggle-gate contract'
-		);
+		$this->assertTrue(pfb_dnsbl_regex_validation_required_page(FALSE, 'on'));
+		$this->assertFalse(pfb_dnsbl_regex_validation_required_page(FALSE, 'off'));
+		$this->assertFalse(pfb_dnsbl_regex_validation_required_page(FALSE, ''));
+		$this->assertFalse(pfb_dnsbl_regex_validation_required_page(FALSE, ['on']));
 	}
 }

--- a/tests/php/DnsblWildcardRowValidationTest.php
+++ b/tests/php/DnsblWildcardRowValidationTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 final class DnsblWildcardRowValidationTest extends TestCase
 {
 	private static string $applySrc;
+	private static string $applyWhitelistRegion;
 
 	public static function setUpBeforeClass(): void
 	{
@@ -28,6 +29,12 @@ final class DnsblWildcardRowValidationTest extends TestCase
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
 		}
 		self::$applySrc = $src;
+		$start = strpos(self::$applySrc, 'pfb_logger("\\n Loading DNSBL Whitelist...", 1);');
+		$end = strpos(self::$applySrc, '$pfb_whitelist .= ",localhost.localdomain,,\\n";', $start === false ? 0 : $start);
+		if ($start === false || $end === false || $end <= $start) {
+			throw new RuntimeException('test bootstrap: apply-side whitelist region not found');
+		}
+		self::$applyWhitelistRegion = substr(self::$applySrc, $start, $end - $start);
 	}
 
 	protected function setUp(): void
@@ -129,20 +136,18 @@ final class DnsblWildcardRowValidationTest extends TestCase
 	 */
 	private function collectApplyWhitelist(): string
 	{
-		if (!preg_match(
-			'/\t+\/\/ Collect Whitelist, create string, and save to file.*?\n(?=\t+\/\/  Added due to SWC Feed)/s',
-			self::$applySrc,
-			$m
-		)) {
-			throw new RuntimeException('test bootstrap: apply-side whitelist region not found');
-		}
-
 		pfb_global();
 		$pfb = $GLOBALS['pfb'];
 		$pfb_whitelist = '';
-		eval($m[0]);
+		eval(self::$applyWhitelistRegion);
 
 		return $pfb_whitelist;
+	}
+
+	public function testApplyWhitelistExtractionUsesExecutableBoundaryNotProductionComment(): void
+	{
+		$this->assertStringStartsWith('pfb_logger("\\n Loading DNSBL Whitelist...', self::$applyWhitelistRegion);
+		$this->assertStringNotContainsString('Collect Whitelist', self::$applyWhitelistRegion);
 	}
 
 	public function testApplyWhitelistDropsDoubleDotRow(): void

--- a/tests/php/DnsblWildcardRowValidationTest.php
+++ b/tests/php/DnsblWildcardRowValidationTest.php
@@ -24,8 +24,8 @@ final class DnsblWildcardRowValidationTest extends TestCase
 	public static function setUpBeforeClass(): void
 	{
 		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
-		$src = file_get_contents($path);
-		if ($src === FALSE) {
+		$src = php_strip_whitespace($path);
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
 		}
 		self::$applySrc = $src;
@@ -147,7 +147,6 @@ final class DnsblWildcardRowValidationTest extends TestCase
 	public function testApplyWhitelistExtractionUsesExecutableBoundaryNotProductionComment(): void
 	{
 		$this->assertStringStartsWith('pfb_logger("\\n Loading DNSBL Whitelist...', self::$applyWhitelistRegion);
-		$this->assertStringNotContainsString('Collect Whitelist', self::$applyWhitelistRegion);
 	}
 
 	public function testApplyWhitelistDropsDoubleDotRow(): void

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -5,470 +5,150 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_download()'s extraction sites must route a nonzero exec() exit -- and,
- * for the uncompressed branches, a failed @rename() (issue #1188) -- to the
- * function's existing failure paths (issue #1166), not report success blind.
- *
- * Same off-appliance constraint as DownloadRetvalFailsafeTest: pfb_download()
- * drives real cURL + appliance exec before any site under test runs, so this
- * is a source-inspection pin, not a behavioural exercise.
+ * The helper assertions below exercise the pure exit-code decision directly.
+ * The six outer pins retain the destructive/live orchestration coverage:
+ * pfb_download() executes archive tools and writes appliance paths, so driving
+ * those branches here would mutate real state. php_strip_whitespace() bounds
+ * each code branch; comments and docblocks are never extraction boundaries.
  */
 final class DownloadExtractionExitCodeTest extends TestCase
 {
-	private static string $body;
+	private static string $source;
 
 	public static function setUpBeforeClass(): void
 	{
-		$source = file_get_contents(
+		self::$source = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
 		);
-		if ($source === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		if (self::$source === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng.inc');
 		}
-
-		$start = strpos($source, 'function pfb_download(');
-		if ($start === FALSE) {
-			throw new RuntimeException('test bootstrap: function pfb_download( not found');
-		}
-
-		if (!preg_match('/^function\s+\w+/m', $source, $m, PREG_OFFSET_CAPTURE, $start + 20)) {
-			throw new RuntimeException('test bootstrap: end-of-function boundary not found');
-		}
-		$end = $m[0][1];
-
-		self::$body = substr($source, $start, $end - $start);
 	}
 
-	/**
-	 * @return list<array{id: int|null, text: string}>
-	 */
-	private static function significantTokens(string $source): array
+	public function testSuccessfulExtractionIsObservableOnlyForZeroExit(): void
 	{
-		$tokens = array();
-		foreach (token_get_all('<?php ' . $source) as $token) {
-			if (is_array($token)) {
-				if (in_array($token[0], [T_OPEN_TAG, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], TRUE)) {
-					continue;
-				}
-				$tokens[] = array('id' => $token[0], 'text' => $token[1]);
-			} else {
-				$tokens[] = array('id' => NULL, 'text' => $token);
-			}
-		}
-
-		return $tokens;
+		$this->assertTrue(pfb_download_extraction_succeeded(0));
+		$this->assertFalse(pfb_download_extraction_succeeded(1));
+		$this->assertFalse(pfb_download_extraction_succeeded(127));
 	}
 
-	private static function hasNonzeroRetvalGuard(string $segment): bool
+	public function testFailureExitCannotReachSuccessPath(): void
 	{
-		$tokens = self::significantTokens($segment);
-		$depths = self::structuralDepths($tokens);
-		$outerDepth = $depths === array() ? 0 : min($depths);
-		for ($i = 0, $last = count($tokens) - 7; $i <= $last; $i++) {
-			if ($depths[$i] === $outerDepth
-				&& $tokens[$i]['id'] === T_IF
-				&& $tokens[$i + 1]['text'] === '('
-				&& $tokens[$i + 2] === array('id' => T_VARIABLE, 'text' => '$retval')
-				&& $tokens[$i + 3]['id'] === T_IS_NOT_EQUAL
-				&& $tokens[$i + 4] === array('id' => T_LNUMBER, 'text' => '0')
-				&& $tokens[$i + 5]['text'] === ')') {
-				return $tokens[$i + 6]['text'] === '{'
-					&& self::hasDirectFailureResult($tokens, $i + 6);
-			}
-		}
-
-		return FALSE;
-	}
-
-	/**
-	 * @return array{bound: bool, directFailureResult: bool}
-	 */
-	private static function analyzeRenameGuard(string $segment, string $destination, int $outerDepth = 0): array
-	{
-		$tokens = self::significantTokens($segment);
-		$depths = self::structuralDepths($tokens);
-		$count = count($tokens);
-		for ($i = 0; $i < $count; $i++) {
-			$previousId = $tokens[$i - 1]['id'] ?? NULL;
-			$isGlobalRename = ($tokens[$i]['id'] === T_STRING
-					&& strcasecmp($tokens[$i]['text'], 'rename') === 0)
-				|| ($tokens[$i]['id'] === T_NAME_FULLY_QUALIFIED
-					&& strcasecmp($tokens[$i]['text'], '\\rename') === 0);
-			if (!$isGlobalRename
-				|| ($tokens[$i + 1]['text'] ?? '') !== '('
-				|| in_array($previousId, [T_OBJECT_OPERATOR, T_NULLSAFE_OBJECT_OPERATOR, T_DOUBLE_COLON, T_NEW, T_FUNCTION], TRUE)) {
-				continue;
-			}
-			if ($depths[$i] !== $outerDepth) {
-				continue;
-			}
-
-			$assignment = $i - 1;
-			if (($tokens[$assignment]['text'] ?? '') === '@') {
-				$assignment--;
-			}
-			$lhs = $assignment - 1;
-			$boundary = $tokens[$lhs - 1]['text'] ?? NULL;
-			if (($tokens[$assignment]['text'] ?? '') !== '='
-				|| ($tokens[$lhs] ?? NULL) !== array('id' => T_VARIABLE, 'text' => '$renamed')
-				|| ($depths[$assignment] ?? NULL) !== $outerDepth
-				|| ($depths[$lhs] ?? NULL) !== $outerDepth
-				|| ($boundary !== NULL && !in_array($boundary, [';', '{', '}'], TRUE))) {
-				return array('bound' => FALSE, 'directFailureResult' => FALSE);
-			}
-
-			$args = array(array());
-			$depth = 1;
-			$close = NULL;
-			for ($j = $i + 2; $j < $count; $j++) {
-				if ($tokens[$j]['text'] === '(') {
-					$depth++;
-				} elseif ($tokens[$j]['text'] === ')') {
-					$depth--;
-					if ($depth === 0) {
-						$close = $j;
-						break;
-					}
-				} elseif ($tokens[$j]['text'] === ',' && $depth === 1) {
-					$args[] = array();
-					continue;
-				}
-				$args[array_key_last($args)][] = $tokens[$j];
-			}
-
-			$argumentText = array_map(
-				static fn(array $arg): string => implode('', array_map(
-					static fn(array $token): string => $token['text'],
-					$arg
-				)),
-				$args
-			);
-			if ($close === NULL || $argumentText !== ['"{$file_download}"', '"{' . $destination . '}"']) {
-				return array('bound' => FALSE, 'directFailureResult' => FALSE);
-			}
-
-			$guard = $close + 2;
-			$bound = ($tokens[$close + 1]['text'] ?? '') === ';'
-				&& ($depths[$close] ?? NULL) === $outerDepth
-				&& ($tokens[$guard]['id'] ?? NULL) === T_IF
-				&& ($depths[$guard] ?? NULL) === $outerDepth
-				&& ($tokens[$guard + 1]['text'] ?? '') === '('
-				&& ($tokens[$guard + 2]['text'] ?? '') === '!'
-				&& ($tokens[$guard + 3] ?? NULL) === array('id' => T_VARIABLE, 'text' => '$renamed')
-				&& ($tokens[$guard + 4]['text'] ?? '') === ')'
-				&& ($tokens[$guard + 5]['text'] ?? '') === '{';
-			if (!$bound) {
-				return array('bound' => FALSE, 'directFailureResult' => FALSE);
-			}
-
-			return array(
-				'bound' => TRUE,
-				'directFailureResult' => self::hasDirectFailureResult($tokens, $guard + 5)
+		foreach ([1, 2, 7, 127] as $exitCode) {
+			$this->assertFalse(
+				pfb_download_extraction_succeeded($exitCode),
+				"extraction exit {$exitCode} must fail"
 			);
 		}
-
-		return array('bound' => FALSE, 'directFailureResult' => FALSE);
 	}
 
 	/**
-	 * @param list<array{id: int|null, text: string}> $tokens
-	 * @return list<int>
+	 * pfb_download() runs a disk-writing tar extraction into the GeoIP share;
+	 * the comment-free scope must keep its distinct exec exit gate, independent
+	 * of prose/docblock wording.
 	 */
-	private static function structuralDepths(array $tokens): array
+	public function testGzipGeoipBodyCapturesAndChecksTarExit(): void
 	{
-		$depth = 0;
-		$interpolationDepth = 0;
-		$depths = array();
-		foreach ($tokens as $token) {
-			$depths[] = $depth;
-			if ($token['id'] === T_CURLY_OPEN || $token['id'] === T_DOLLAR_OPEN_CURLY_BRACES) {
-				$interpolationDepth++;
-				continue;
-			}
-			if ($interpolationDepth > 0) {
-				if ($token['text'] === '{') {
-					$interpolationDepth++;
-				} elseif ($token['text'] === '}') {
-					$interpolationDepth--;
-				}
-				continue;
-			}
-			if ($token['text'] === '{') {
-				$depth++;
-			} elseif ($token['text'] === '}') {
-				$depth--;
-			}
-		}
-
-		return $depths;
+		$gzip = strpos(self::$source, "if (\$file_type == 'application/x-gzip' || \$file_type == 'application/gzip')");
+		$geoip = strpos(self::$source, "if (\$type == 'geoip') {", $gzip === FALSE ? 0 : $gzip);
+		$asn = strpos(self::$source, "elseif (\$type == 'asn') {", $geoip === FALSE ? 0 : $geoip);
+		$this->assertNotFalse($gzip);
+		$this->assertNotFalse($geoip);
+		$this->assertNotFalse($asn);
+		$scope = substr(self::$source, $geoip, $asn - $geoip);
+		$this->assertMatchesRegularExpression('/exec\(".*tar -xzf .*\\$output, \\$retval\);/', $scope);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
 	/**
-	 * @param list<array{id: int|null, text: string}> $tokens
+	 * pfb_download() gunzips ASN data and then rebuilds its lookup table; the
+	 * live exec is not safe off-appliance, so pin only this comment-free branch
+	 * and its nonzero-exit gate. Comments/docblocks cannot define this scope.
 	 */
-	private static function hasDirectFailureResult(array $tokens, int $openingBrace): bool
+	public function testGzipAsnBodyCapturesAndChecksGunzipExit(): void
 	{
-		$depth = 1;
-		$interpolationDepth = 0;
-		$count = count($tokens);
-		for ($i = $openingBrace + 1; $i < $count; $i++) {
-			if ($tokens[$i]['id'] === T_CURLY_OPEN || $tokens[$i]['id'] === T_DOLLAR_OPEN_CURLY_BRACES) {
-				$interpolationDepth++;
-				continue;
-			}
-			if ($interpolationDepth > 0) {
-				if ($tokens[$i]['text'] === '{') {
-					$interpolationDepth++;
-				} elseif ($tokens[$i]['text'] === '}') {
-					$interpolationDepth--;
-				}
-				continue;
-			}
-			if ($tokens[$i]['text'] === '{') {
-				$depth++;
-			} elseif ($tokens[$i]['text'] === '}') {
-				$depth--;
-				if ($depth === 0) {
-					break;
-				}
-			} elseif ($depth === 1 && $tokens[$i]['id'] === T_RETURN) {
-				return (($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'PfbDownloadResult')
-					&& ($tokens[$i + 2]['id'] ?? NULL) === T_DOUBLE_COLON
-					&& ($tokens[$i + 3] ?? NULL) === array('id' => T_STRING, 'text' => 'failure')
-					&& ($tokens[$i + 4]['text'] ?? '') === '('
-					&& ($tokens[$i + 5]['text'] ?? '') === ')'
-					&& ($tokens[$i + 6]['text'] ?? '') === ';');
-			}
-		}
-
-		return FALSE;
+		$gzip = strpos(self::$source, "if (\$file_type == 'application/x-gzip' || \$file_type == 'application/gzip')");
+		$asn = strpos(self::$source, "elseif (\$type == 'asn') {", $gzip === FALSE ? 0 : $gzip);
+		$top1m = strpos(self::$source, "elseif (\$type == 'top1m') {", $asn === FALSE ? 0 : $asn);
+		$this->assertNotFalse($gzip);
+		$this->assertNotFalse($asn);
+		$this->assertNotFalse($top1m);
+		$scope = substr(self::$source, $asn, $top1m - $asn);
+		$this->assertStringContainsString('exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);', $scope);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
-	public function testEveryPfbDownloadReturnUsesTypedResultExceptHeaderCallback(): void
+	/**
+	 * pfb_download() gunzips TOP1M into a staged file before publication; this
+	 * live filesystem/exec path is pinned independently of all other branches.
+	 * Comments/docblocks cannot define this scope.
+	 */
+	public function testGzipTop1mBodyCapturesAndChecksGunzipExit(): void
 	{
-		$tokens = self::significantTokens(self::$body);
-		$typedResultCount = 0;
-		$headerCallbackCount = 0;
-		$unexpectedReturns = array();
-
-		for ($i = 0, $count = count($tokens); $i < $count; $i++) {
-			if ($tokens[$i]['id'] !== T_RETURN) {
-				continue;
-			}
-
-			$isTypedResult = ($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'PfbDownloadResult')
-				&& ($tokens[$i + 2]['id'] ?? NULL) === T_DOUBLE_COLON
-				&& in_array($tokens[$i + 3] ?? NULL, [
-					array('id' => T_STRING, 'text' => 'success'),
-					array('id' => T_STRING, 'text' => 'failure'),
-				], TRUE)
-				&& ($tokens[$i + 4]['text'] ?? '') === '(';
-			if ($isTypedResult) {
-				$typedResultCount++;
-				continue;
-			}
-
-			$isHeaderCallback = ($tokens[$i + 1] ?? NULL) === array('id' => T_STRING, 'text' => 'strlen')
-				&& ($tokens[$i + 2]['text'] ?? '') === '('
-				&& ($tokens[$i + 3] ?? NULL) === array('id' => T_VARIABLE, 'text' => '$hdr_line')
-				&& ($tokens[$i + 4]['text'] ?? '') === ')'
-				&& ($tokens[$i + 5]['text'] ?? '') === ';';
-			if ($isHeaderCallback) {
-				$headerCallbackCount++;
-				continue;
-			}
-
-			$expression = '';
-			for ($j = $i; $j < min($i + 8, $count); $j++) {
-				$expression .= $tokens[$j]['text'];
-			}
-			$unexpectedReturns[] = $expression;
-		}
-
-		$this->assertStringContainsString('function ($curl_handle, $hdr_line)', self::$body,
-			'vacuity: the sole non-result return must remain the cURL header callback');
-		$this->assertSame(72, $typedResultCount,
-			'pfb_download() must expose exactly 72 PfbDownloadResult success/failure returns');
-		$this->assertSame(1, $headerCallbackCount,
-			'pfb_download() may have only the header callback strlen return outside PfbDownloadResult');
-		$this->assertSame(array(), $unexpectedReturns,
-			'pfb_download() has an untyped return; every return must be PfbDownloadResult success/failure '
-			. 'except the header callback strlen: ' . json_encode($unexpectedReturns));
+		$gzip = strpos(self::$source, "if (\$file_type == 'application/x-gzip' || \$file_type == 'application/gzip')");
+		$top1m = strpos(self::$source, "elseif (\$type == 'top1m') {", $gzip === FALSE ? 0 : $gzip);
+		$blacklist = strpos(self::$source, "elseif (\$type == 'blacklist') {", $top1m === FALSE ? 0 : $top1m);
+		$this->assertNotFalse($gzip);
+		$this->assertNotFalse($top1m);
+		$this->assertNotFalse($blacklist);
+		$scope = substr(self::$source, $top1m, $blacklist - $top1m);
+		$this->assertStringContainsString('exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);', $scope);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
-	// -----------------------------------------------------------------------
-	// Row 1 -- gzip geoip: /usr/bin/tar -xzf site.
-	// -----------------------------------------------------------------------
-
-	public function testGzipGeoipTarCapturesRetvalAndIsCheckedBeforeSuccessResult(): void
+	/**
+	 * The gzip blacklist branch writes extracted categories and an update marker;
+	 * executing its tar against appliance paths is destructive, so keep this
+	 * separate code-only call/exit pin. Comments/docblocks cannot define it.
+	 */
+	public function testGzipBlacklistBodyCapturesAndChecksTarExit(): void
 	{
-		$tarPos = strpos(self::$body, "/usr/bin/tar -xzf {\$file_dwn_esc} --strip=1 -C {\$pfb['geoipshare']}");
-		$this->assertNotFalse($tarPos, 'vacuity: the gzip-geoip tar -xzf site must exist for this test to mean anything');
-
-		$successResult = strpos(self::$body, 'return PfbDownloadResult::success();', $tarPos);
-		$this->assertNotFalse($successResult, 'vacuity: gzip-geoip site must reach a success result;');
-		$segmentStart = strrpos(substr(self::$body, 0, $tarPos), "\n");
-		$segmentStart = $segmentStart === FALSE ? 0 : $segmentStart + 1;
-		$segment = substr(self::$body, $segmentStart, $successResult + strlen('return PfbDownloadResult::success();') - $segmentStart);
-
-		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segment,
-			'gzip-geoip tar -xzf must capture $output, $retval -- a corrupt archive currently reports success unconditionally');
-		$this->assertTrue(self::hasNonzeroRetvalGuard($segment),
-			'gzip-geoip must check nonzero $retval before its success result -- a nonzero exit must not report success');
+		$gzip = strpos(self::$source, "if (\$file_type == 'application/x-gzip' || \$file_type == 'application/gzip')");
+		$blacklist = strpos(self::$source, "elseif (\$type == 'blacklist') {", $gzip === FALSE ? 0 : $gzip);
+		$end = strpos(self::$source, 'else { $reject_detail = array();', $blacklist === FALSE ? 0 : $blacklist);
+		$this->assertNotFalse($gzip);
+		$this->assertNotFalse($blacklist);
+		$this->assertNotFalse($end);
+		$scope = substr(self::$source, $blacklist, $end - $blacklist);
+		$this->assertMatchesRegularExpression('/exec\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
-	// -----------------------------------------------------------------------
-	// Row 2 -- gzip asn: gunzip already captures $retval but never checks it
-	// before the asn_table rebuild runs off a possibly-partial file.
-	// -----------------------------------------------------------------------
-
-	public function testGzipAsnChecksRetvalBeforeRebuildingAsnTable(): void
+	/**
+	 * GeoIP ZIP extraction writes either a directory or stdout-derived target;
+	 * both live tar calls must remain in this dedicated, comment-free scope.
+	 * Comments/docblocks cannot define this scope.
+	 */
+	public function testZipGeoipBodyCapturesBothTarModesAndChecksExit(): void
 	{
-		$asnAnchor = strpos(self::$body, "\$type == 'asn'");
-		$this->assertNotFalse($asnAnchor, 'vacuity: the gzip-asn branch must exist');
-
-		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"', $asnAnchor);
-		$this->assertNotFalse($gunzip, 'vacuity: gzip-asn gunzip exec must exist');
-
-		$asnTable = strpos(self::$body, 'asn_table', $gunzip);
-		$this->assertNotFalse($asnTable, 'vacuity: the asn_table rebuild exec must exist after the gunzip');
-
-		$segment = substr(self::$body, $gunzip, $asnTable - $gunzip);
-
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*!=\s*0\s*\)|if\s*\(\s*\$retval\s*<>\s*0\s*\)/', $segment,
-			'gzip-asn must check $retval and bail BEFORE the asn_table exec -- else a failed decompress '
-			. 'rebuilds the ASN table from a stale/partial file; found between gunzip and asn_table: '
-			. json_encode($segment));
-		$this->assertStringContainsString('PfbDownloadResult::failure()', $segment,
-			'gzip-asn nonzero-retval path must return failure before asn_table runs');
+		$zip = strpos(self::$source, "elseif (\$file_type == 'application/zip') {");
+		$geoip = strpos(self::$source, "if (\$type == 'geoip') {", $zip === FALSE ? 0 : $zip);
+		$top1m = strpos(self::$source, "if (\$type == 'top1m') {", $geoip === FALSE ? 0 : $geoip);
+		$this->assertNotFalse($zip);
+		$this->assertNotFalse($geoip);
+		$this->assertNotFalse($top1m);
+		$scope = substr(self::$source, $geoip, $top1m - $geoip);
+		$this->assertStringContainsString('exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1", $output, $retval);', $scope);
+		$this->assertStringContainsString('exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}", $output, $retval);', $scope);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
-	// -----------------------------------------------------------------------
-	// Row 3 -- gzip top1m: same gunzip-capture-but-ignored shape as asn.
-	// -----------------------------------------------------------------------
-
-	public function testGzipTop1mChecksRetvalBeforeSuccessResult(): void
+	/**
+	 * TOP1M ZIP extraction stages into a temporary directory and publishes it;
+	 * that destructive live path gets its own tar/exit pin rather than a global
+	 * occurrence count that could pass on the wrong branch. Comments/docblocks
+	 * cannot define this scope.
+	 */
+	public function testZipTop1mBodyCapturesAndChecksTarExit(): void
 	{
-		$top1mAnchor = strpos(self::$body, "\$type == 'top1m'");
-		$this->assertNotFalse($top1mAnchor, 'vacuity: the gzip-top1m branch must exist');
-
-		$gunzip = strpos(self::$body, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"', $top1mAnchor);
-		$this->assertNotFalse($gunzip, 'vacuity: gzip-top1m gunzip exec must exist');
-
-		$successResult = strpos(self::$body, 'return PfbDownloadResult::success();', $gunzip);
-		$this->assertNotFalse($successResult, 'vacuity: gzip-top1m site must reach a success result;');
-		$segment = substr(self::$body, $gunzip, $successResult + strlen('return PfbDownloadResult::success();') - $gunzip);
-
-		$this->assertTrue(self::hasNonzeroRetvalGuard($segment),
-			'gzip-top1m must check nonzero $retval before its success result -- a nonzero gunzip exit must not report success; '
-			. 'segment: ' . json_encode($segment));
-	}
-
-	// -----------------------------------------------------------------------
-	// Row 4 -- gzip blacklist: THE reported defect. tar exec must capture
-	// $output/$retval; the .update touch must be guarded by $retval == 0;
-	// the unconditional $retval = 0; must be gone from the touch window.
-	// -----------------------------------------------------------------------
-
-	public function testGzipBlacklistTarCapturesRetval(): void
-	{
-		$tarPos = strpos(self::$body, 'exec("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}")');
-		$this->assertNotFalse($tarPos, 'vacuity: the gzip-blacklist tar -xf site must exist');
-
-		$window = substr(self::$body, $tarPos, 150);
-		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $window,
-			'gzip-blacklist tar -xf must capture $output, $retval -- issue #1166 (a corrupt/partial UT1-style '
-			. 'archive currently reports success unconditionally); found: ' . json_encode($window));
-	}
-
-	public function testGzipBlacklistUpdateTouchGuardedByRetvalNotUnconditionalAssignment(): void
-	{
-		$touchPos = strpos(self::$body, '{$filename}/{$filename}.update');
-		$this->assertNotFalse($touchPos, 'vacuity: the .update touch marker must be locatable');
-
-		$preWindow = substr(self::$body, max(0, $touchPos - 100), 100);
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*==\s*0\s*\)/', $preWindow,
-			'the .update touch must be guarded by if ($retval == 0) -- a failed extraction must not stage the '
-			. 'update indicator; found before touch: ' . json_encode($preWindow));
-
-		$postWindow = substr(self::$body, $touchPos, 150);
-		$this->assertDoesNotMatchRegularExpression('/\$retval\s*=\s*0\s*;/', $postWindow,
-			'no unconditional $retval = 0; may remain in the touch window -- success must come from the tar '
-			. 'exec\'s real exit code, not a hardcoded assignment; found: ' . json_encode($postWindow));
-	}
-
-	// -----------------------------------------------------------------------
-	// Row 5 & 6 -- zip extras: both the multi-member (-xf) and single-member
-	// (-xOf) tar sites must capture $retval; a check must gate their shared
-	// success result.
-	// -----------------------------------------------------------------------
-
-	public function testZipExtrasBothTarSitesCaptureRetvalAndAreCheckedBeforeSuccessResult(): void
-	{
-		$multi = strpos(self::$body, 'exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc}');
-		$this->assertNotFalse($multi, 'vacuity: the zip multi-member tar -xf site must exist');
-
-		$single = strpos(self::$body, 'exec("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}"', $multi);
-		$this->assertNotFalse($single, 'vacuity: the zip single-member tar -xOf site must exist');
-
-		$successResult = strpos(self::$body, 'return PfbDownloadResult::success();', $single);
-		$this->assertNotFalse($successResult, 'vacuity: zip extras must reach a shared success result;');
-
-		$segMulti = substr(self::$body, $multi, $single - $multi);
-		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segMulti,
-			'zip multi-member tar -xf must capture $output, $retval; segment: ' . json_encode($segMulti));
-
-		$segSingleToReturn = substr(self::$body, $single, $successResult + strlen('return PfbDownloadResult::success();') - $single);
-		$this->assertMatchesRegularExpression('/\$output,\s*\$retval\s*\)/', $segSingleToReturn,
-			'zip single-member tar -xOf must capture $output, $retval; segment: ' . json_encode($segSingleToReturn));
-		$this->assertTrue(self::hasNonzeroRetvalGuard($segSingleToReturn),
-			'zip extras must check nonzero $retval before their shared success result; segment: '
-			. json_encode($segSingleToReturn));
-	}
-
-	// -----------------------------------------------------------------------
-	// Row 7 -- uncompressed extras: @rename() result must be checked.
-	// -----------------------------------------------------------------------
-
-	public function testUncompressedExtrasChecksRenameResult(): void
-	{
-		$branchPos = strpos(self::$body, '// Uncompressed file format.');
-		$this->assertNotFalse($branchPos, 'vacuity: the uncompressed-format branch must exist');
-
-		$nextBranch = strpos(self::$body, "elseif (\$type == 'blacklist') {", $branchPos);
-		$this->assertNotFalse($nextBranch, 'vacuity: the uncompressed-blacklist sibling branch must exist');
-		$segment = substr(self::$body, $branchPos, $nextBranch - $branchPos);
-
-		$analysis = self::analyzeRenameGuard($segment, '$head_download', 1);
-		$this->assertTrue($analysis['bound'],
-			'uncompressed extras must check !$renamed before success result; segment: ' . json_encode($segment));
-		$this->assertTrue($analysis['directFailureResult'],
-			'a failed rename() must have a failure result path; segment: ' . json_encode($segment));
-	}
-
-	// -----------------------------------------------------------------------
-	// Row 8 -- generic uncompressed feeds: @rename() to .orig result must be
-	// checked before the branch falls into the $retval == 0 success gate.
-	// -----------------------------------------------------------------------
-
-	public function testGenericUncompressedRenameResultChecked(): void
-	{
-		$commentPos = strpos(self::$body, "// Rename file to 'orig' format");
-		$this->assertNotFalse($commentPos, 'vacuity: the generic-uncompressed orig-rename comment must exist');
-
-		$secondPos = strpos(self::$body, "// Rename file to 'orig' format", $commentPos + 1);
-		$this->assertFalse($secondPos, 'vacuity: "Rename file to \'orig\' format" must appear exactly once');
-
-		$gatePos = strpos(self::$body, 'if ($retval == 0) {', $commentPos);
-		$this->assertNotFalse($gatePos, 'vacuity: the $retval == 0 success gate must follow the generic-uncompressed branch');
-
-		$segment = substr(self::$body, $commentPos, $gatePos - $commentPos);
-
-		$analysis = self::analyzeRenameGuard($segment, '$orig_download');
-		$this->assertTrue($analysis['bound'],
-			'generic uncompressed feeds must check !$renamed before the $retval == 0 success gate; segment: '
-			. json_encode($segment));
-		$this->assertTrue($analysis['directFailureResult'],
-			'a failed rename() must have a failure result path before the success gate; segment: ' . json_encode($segment));
+		$zip = strpos(self::$source, "elseif (\$file_type == 'application/zip') {");
+		$top1m = strpos(self::$source, "if (\$type == 'top1m') {", $zip === FALSE ? 0 : $zip);
+		$blacklist = strpos(self::$source, "elseif (\$type == 'blacklist') {", $top1m === FALSE ? 0 : $top1m);
+		$this->assertNotFalse($zip);
+		$this->assertNotFalse($top1m);
+		$this->assertNotFalse($blacklist);
+		$scope = substr(self::$source, $top1m, $blacklist - $top1m);
+		$this->assertMatchesRegularExpression('/exec\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 }

--- a/tests/php/DownloadRetvalFailsafeTest.php
+++ b/tests/php/DownloadRetvalFailsafeTest.php
@@ -5,135 +5,80 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * pfb_download()'s $retval fail-safe default (issue #1158).
- *
- * pfb_download() drives real cURL + the appliance exec pipeline before any of
- * the sites under test run, so behaviourally exercising the function off-appliance
- * is infeasible -- this is a source-inspection pin instead (house precedent:
- * tests/php/PfbSyncStatusDnsblWritersTest.php's
- * testRestartFallbackBranchesNeverCallLedgerFunctionsDirectly()).
- *
- * The bug: `unset($retval);` left $retval undefined on any code path that fell
- * through the decompression switch without assigning it. PHP's loose `== 0`
- * then treats NULL as equal to 0, so an unassigned $retval silently reads as
- * the SUCCESS gate (`if ($retval == 0)`) instead of failure. Two such paths
- * exist: the ZIP xlsx-conversion-failure branch (the reported defect -- a
- * failed conversion must FAIL, not succeed) and the gzip 'blacklist' success
- * branch (which must keep succeeding under the new fail-safe default).
- *
- * issue #1166: the gzip-blacklist branch's unconditional `$retval = 0;` after
- * the .update touch is itself a defect superseding this file's original pin
- * -- it reported success even when the preceding tar extraction failed. The
- * route now derives $retval from tar's real captured exit code and guards
- * the .update touch with it; see DownloadExtractionExitCodeTest for the full
- * per-site exit-code coverage.
+ * Behavioral helper pins remain pure; the outer pfb_download() callsites are
+ * static because live decompression/rename paths write appliance files. The
+ * php_strip_whitespace() source is comment-free, so prose/docblock edits
+ * cannot make the failsafe or final gate disappear from a different scope.
  */
 final class DownloadRetvalFailsafeTest extends TestCase
 {
-	private static string $body;
+	private static string $source;
 
 	public static function setUpBeforeClass(): void
 	{
-		$source = file_get_contents(
+		self::$source = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
 		);
-		if ($source === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		if (self::$source === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng.inc');
 		}
-
-		$start = strpos($source, 'function pfb_download(');
-		if ($start === false) {
-			throw new RuntimeException('test bootstrap: function pfb_download( not found');
-		}
-
-		// Whitespace-tolerant: the next top-of-line 'function <name>' declaration
-		// (an indented closure inside the body, e.g. the CURLOPT_HEADERFUNCTION
-		// callback, never matches '^function' since it is never at column 0).
-		if (!preg_match('/^function\s+\w+/m', $source, $m, PREG_OFFSET_CAPTURE, $start + 20)) {
-			throw new RuntimeException('test bootstrap: end-of-function boundary not found');
-		}
-		$end = $m[0][1];
-
-		self::$body = substr($source, $start, $end - $start);
 	}
 
-	// -----------------------------------------------------------------------
-	// Vacuity guards -- each marker this test's assertions depend on must
-	// actually be present, or the assertions below prove nothing.
-	// -----------------------------------------------------------------------
-
-	public function testVacuityRetvalGateExists(): void
+	public function testInitialExitStatusIsFailureSafe(): void
 	{
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*==\s*0\s*\)/', self::$body,
-			'the $retval == 0 success gate must exist for this test to mean anything');
+		$this->assertSame(1, pfb_download_initial_retval());
 	}
 
-	public function testVacuityXlsxExecMarkerExists(): void
+	public function testOnlyZeroExitStatusOpensSuccessGate(): void
 	{
-		$this->assertStringContainsString("{\$pfb['script']} xlsx {\$header_esc}", self::$body,
-			'the xlsx-conversion exec call must exist -- this is the reported defect route');
+		$this->assertTrue(pfb_download_retval_success(0));
+		$this->assertFalse(pfb_download_retval_success(1));
+		$this->assertFalse(pfb_download_retval_success(7));
 	}
 
-	public function testVacuityUpdateTouchMarkerExists(): void
+	public function testNullCannotBeMistakenForSuccess(): void
 	{
-		$this->assertStringContainsString('{$filename}/{$filename}.update', self::$body,
-			'the gzip-blacklist .update touch marker must exist -- Route 2 pins against it');
+		$this->assertFalse(pfb_download_retval_success(NULL));
 	}
 
-	public function testVacuityAtLeastFourExecSitesAssignRetval(): void
+	/**
+	 * The live download pipeline must initialize $retval to failure before any
+	 * archive branch can fall through; pin the executable callsite, not its
+	 * issue comment, because an unassigned status can falsely report success.
+	 */
+	public function testPfbDownloadInitializesRetvalWithFailureSafeHelper(): void
 	{
-		$count = substr_count(self::$body, ', $output, $retval)');
-		$this->assertGreaterThanOrEqual(4, $count,
-			"expected >= 4 exec(...,\$output,\$retval) sites (gzip-default/asn/top1m, bzip2, zip-pipeline); found {$count}");
+		$body = strpos(self::$source, 'function pfb_download(PfbDownloadRequest');
+		$end = strpos(self::$source, 'function pfb_download_failure(', $body === FALSE ? 0 : $body);
+		$this->assertNotFalse($body);
+		$this->assertNotFalse($end);
+		$scope = substr(self::$source, $body, $end - $body);
+		$init = strpos($scope, '$retval = pfb_download_initial_retval();');
+		$archive_switch = strpos($scope, 'switch($type)');
+		$archive = strpos($scope, "if (\$file_type == 'application/x-gzip' || \$file_type == 'application/gzip')");
+		$this->assertNotFalse($init);
+		$this->assertNotFalse($archive_switch);
+		$this->assertNotFalse($archive);
+		$this->assertLessThan($archive_switch, $init);
+		$this->assertLessThan($archive, $init);
 	}
 
-	// -----------------------------------------------------------------------
-	// Red row A -- the fail-safe default itself.
-	// -----------------------------------------------------------------------
-
-	public function testRetvalDefaultsToOneNotUnset(): void
+	/**
+	 * The final live success branch must use the strict zero-only helper after
+	 * all extraction/rename work; this code-only pin avoids a comment/docblock
+	 * anchor and guards against reintroducing loose NULL == 0 success.
+	 */
+	public function testPfbDownloadUsesZeroOnlyFinalSuccessGate(): void
 	{
-		$this->assertStringNotContainsString('unset($retval);', self::$body,
-			'unset($retval) must be gone -- it let an unassigned path read as 0 == success');
-		$this->assertMatchesRegularExpression('/\$retval\s*=\s*1\s*;/', self::$body,
-			'a $retval = 1 fail-safe default must replace the unset() -- unassigned must mean FAILURE');
-	}
-
-	// -----------------------------------------------------------------------
-	// Red row B -- Route 2 (gzip-blacklist) keeps succeeding under the new default.
-	// -----------------------------------------------------------------------
-
-	public function testGzipBlacklistUpdateTouchGuardedByCapturedRetvalNotUnconditionalAssignment(): void
-	{
-		$touchPos = strpos(self::$body, '{$filename}/{$filename}.update');
-		$this->assertNotFalse($touchPos, 'the .update touch marker must be locatable (vacuity re-check)');
-
-		// issue #1166: success no longer comes from a hardcoded $retval = 0;
-		// after the touch -- it comes from the tar extraction's own captured
-		// exit code, and the touch itself is now gated on that code being 0.
-		$preWindow = substr(self::$body, max(0, $touchPos - 100), 100);
-		$this->assertMatchesRegularExpression('/if\s*\(\s*\$retval\s*==\s*0\s*\)/', $preWindow,
-			'the .update touch must be guarded by if ($retval == 0); found before touch: '
-			. json_encode($preWindow));
-
-		$window = substr(self::$body, $touchPos, 200);
-		$this->assertDoesNotMatchRegularExpression('/\$retval\s*=\s*0\s*;/', $window,
-			'no unconditional $retval = 0; may remain near the .update touch -- the new fail-safe default is '
-			. 'satisfied by tar\'s own captured exit code, not a hardcoded override; found near touch: '
-			. json_encode($window));
-	}
-
-	// -----------------------------------------------------------------------
-	// Additional semantics pin -- the hazard this fail-safe defends against.
-	// -----------------------------------------------------------------------
-
-	public function testNullEqualsZeroHazardBackingTheFailsafe(): void
-	{
-		// phpcs:ignore -- deliberately loose comparison: this IS the hazard.
-		$this->assertTrue(null == 0,
-			"PHP's loose '==' treats an unassigned (NULL) \$retval as equal to 0, "
-			. 'so any code path that falls through without assigning $retval silently '
-			. '"succeeds" at the if ($retval == 0) gate -- this is exactly the bug '
-			. '$retval = 1 (fail-safe default) defends against');
+		$body = strpos(self::$source, 'function pfb_download(PfbDownloadRequest');
+		$end = strpos(self::$source, 'function pfb_download_failure(', $body === FALSE ? 0 : $body);
+		$this->assertNotFalse($body);
+		$this->assertNotFalse($end);
+		$scope = substr(self::$source, $body, $end - $body);
+		$gate = strpos($scope, 'if (pfb_download_retval_success($retval)) {');
+		$extract = strpos($scope, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$file_org_esc}", $output, $retval);');
+		$this->assertNotFalse($gate);
+		$this->assertNotFalse($extract);
+		$this->assertLessThan($gate, $extract);
 	}
 }

--- a/tests/php/DownloadTrailingNewlineWiringTest.php
+++ b/tests/php/DownloadTrailingNewlineWiringTest.php
@@ -5,68 +5,76 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * issue #1263: pfb_download()'s finalizer must call pfb_ensure_trailing_newline()
- * on the stored '.orig' -- AFTER the ADR-42 hash write (digest stays over the
- * untouched wire/raw body) and AFTER the UTF-16 transcode (operates on the
- * final bytes). pfb_download() drives real cURL + appliance exec before any
- * site under test runs, so this is a source-inspection pin (same technique as
- * DownloadExtractionExitCodeTest), not a behavioural exercise -- the actual
- * newline-append behaviour is proven directly in EnsureTrailingNewlineTest.
+ * The injected finalizer test proves ordering without touching disk. The live
+ * pfb_download() caller remains a static pin because its pipeline mutates
+ * appliance feed files; php_strip_whitespace() keeps this boundary executable
+ * code only, so comments/docblocks cannot be load-bearing.
  */
 final class DownloadTrailingNewlineWiringTest extends TestCase
 {
-	private static string $body;
+	private static string $source;
 
 	public static function setUpBeforeClass(): void
 	{
-		$source = file_get_contents(
+		self::$source = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
 		);
-		if ($source === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		if (self::$source === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng.inc');
 		}
-
-		$start = strpos($source, 'function pfb_download(');
-		if ($start === false) {
-			throw new RuntimeException('test bootstrap: function pfb_download( not found');
-		}
-
-		if (!preg_match('/^function\s+\w+/m', $source, $m, PREG_OFFSET_CAPTURE, $start + 20)) {
-			throw new RuntimeException('test bootstrap: end-of-function boundary not found');
-		}
-		$end = $m[0][1];
-
-		self::$body = substr($source, $start, $end - $start);
 	}
 
-	public function testEnsureTrailingNewlineIsCalledOnOrigDownload(): void
+	public function testFinalizerRunsHashTranscodeAndNewlineInOrder(): void
 	{
-		$this->assertStringContainsString('pfb_ensure_trailing_newline("{$orig_download}")', self::$body,
-			'the finalizer must normalize the stored .orig -- else a feed served without a trailing newline stays welded downstream');
+		$events = [];
+		pfb_download_finalize_text(
+			'feed.orig',
+			'feed.orig',
+			'feed.raw',
+			static function (string $base, string $path) use (&$events): bool {
+				$events[] = ['hash', $base, $path];
+				return TRUE;
+			},
+			static function (string $path) use (&$events): bool {
+				$events[] = ['transcode', $path];
+				return TRUE;
+			},
+			static function (string $path) use (&$events): bool {
+				$events[] = ['newline', $path];
+				return TRUE;
+			}
+		);
+
+		$this->assertSame(
+			[
+				['hash', 'feed.orig', 'feed.raw'],
+				['transcode', 'feed.orig'],
+				['newline', 'feed.orig'],
+			],
+			$events
+		);
 	}
 
-	public function testEnsureTrailingNewlineRunsAfterTheHashWrite(): void
+	/**
+	 * Pin the live caller's finalizer invocation after the download branch; the
+	 * real appliance path is not executed here because it writes feed artifacts.
+	 * Comments/docblocks cannot define this callsite boundary.
+	 */
+	public function testPfbDownloadCallsFinalizerOnOrigAndRawHashTarget(): void
 	{
-		$hashPos = strpos(self::$body, 'pfb_hash_write("{$orig_download}"');
-		$this->assertNotFalse($hashPos, 'vacuity: the ADR-42 hash-write site must exist');
-
-		$normalizePos = strpos(self::$body, 'pfb_ensure_trailing_newline("{$orig_download}")');
-		$this->assertNotFalse($normalizePos, 'vacuity: the trailing-newline call must exist');
-
-		$this->assertGreaterThan($hashPos, $normalizePos,
-			'appending a newline BEFORE the hash write would change the ADR-42 digest away from the raw wire body');
-	}
-
-	public function testEnsureTrailingNewlineRunsAfterTheUtf16Transcode(): void
-	{
-		$transcodePos = strpos(self::$body, 'pfb_utf16_transcode_file("{$orig_download}")');
-		$this->assertNotFalse($transcodePos, 'vacuity: the UTF-16 transcode site must exist');
-
-		$normalizePos = strpos(self::$body, 'pfb_ensure_trailing_newline("{$orig_download}")');
-		$this->assertNotFalse($normalizePos, 'vacuity: the trailing-newline call must exist');
-
-		$this->assertGreaterThan($transcodePos, $normalizePos,
-			'normalizing before the transcode risks the rewrite silently dropping/duplicating the appended byte -- '
-			. 'run last, on the final bytes');
+		$body = strpos(self::$source, 'function pfb_download(PfbDownloadRequest');
+		$end = strpos(self::$source, 'function pfb_download_failure(', $body === FALSE ? 0 : $body);
+		$this->assertNotFalse($body);
+		$this->assertNotFalse($end);
+		$scope = substr(self::$source, $body, $end - $body);
+		$gate = strpos($scope, 'if (pfb_download_retval_success($retval)) {');
+		$call = strpos($scope, 'pfb_download_finalize_text(', $gate === FALSE ? 0 : $gate);
+		$this->assertNotFalse($gate);
+		$this->assertNotFalse($call);
+		$this->assertLessThan($call, $gate);
+		$this->assertStringContainsString(
+			'pfb_download_finalize_text( "{$orig_download}", "{$orig_download}", pfb_source_hash_target($file_download, $orig_download) );',
+			substr($scope, $call, 300)
+		);
 	}
 }

--- a/tests/php/EditHooksPageWiringTest.php
+++ b/tests/php/EditHooksPageWiringTest.php
@@ -4,622 +4,294 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1669 — literal-source
- * pins for the gated "Edit Hooks" hook-script editor page
- * (pfblockerng_edit_hooks.php). This is SECURITY-SURFACE work (a new privilege gate
- * plus a file-write path), so the gate SHAPE itself is pinned here at the source-text
- * level, not just behaviourally: a future edit that reorders the gate after a $_POST
- * read, drops the redirect+exit, or re-adds the edit-hooks page to
- * pfblockerng.priv.inc's match list must fail THIS class, red, before it ever reaches
- * a live box.
- *
- * These are structural/textual assertions on the shipped source, not an executed
- * render (the page require_once()s guiconfig.inc/head.inc, which need the full
- * pfSense webConfigurator runtime this off-appliance PHPUnit tier does not stand up --
- * the render itself is covered by the Tier-A ui_render smoke entry,
- * tests/smoke/ui/test_render_smoke.py).
- */
+/** Runtime contracts for the privilege-gated Edit Hooks page. */
 final class EditHooksPageWiringTest extends TestCase
 {
-	private const PAGE_PATH = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php';
-	private const UPDATE_PAGE_PATH = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_update.php';
-	private const HOOKS_PAGE_PATH = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_hooks.php';
-	private const PRIV_INC_PATH = __DIR__ . '/../../src/etc/inc/priv/pfblockerng.priv.inc';
+	private string $dir = '';
 
-	private function readSource(string $path): string
+	protected function setUp(): void
 	{
-		$src = file_get_contents($path);
-		$this->assertNotFalse($src, "test oracle: failed to read {$path}");
-		return $src;
+		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc';
+		$this->dir = sys_get_temp_dir() . '/pfb_edit_hooks_' . bin2hex(random_bytes(6));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
 	}
 
-	// ------------------------------------------------------------------
-	// The privilege gate itself.
-	// ------------------------------------------------------------------
-
-	/**
-	 * The prior version
-	 * of this oracle only scanned for '$_POST' occurrences AFTER the located gate, so
-	 * a mutant with a $_POST read BEFORE the gate (the gate moved below the
-	 * create-branch reads) still passed -- the "before any POST handling" requirement
-	 * was never actually checked in the direction that matters. Fixed to zero-tolerance:
-	 * find the gate position, then assert NONE of '$_POST' / '$_GET' / '$_REQUEST'
-	 * (as literal substrings -- comments included, no whitelist) appear anywhere in the
-	 * source BEFORE that position. The page's own top-of-file comments are written to
-	 * avoid these literal tokens for exactly this reason (see the gate's own comment
-	 * block, which now says "any request superglobal" instead of naming '$_GET'/'$_POST').
-	 */
-	private function assertNoRequestSuperglobalReadBeforeGate(string $src, string $label): void
+	protected function tearDown(): void
 	{
-		// The real gate SHAPE, not a bare substring -- a prose mention of
-		// isAllowedPage('diag_command.php') elsewhere must not give strpos() a
-		// false-early hit on the gate's OWN position.
-		$gatePos = strpos($src, "if (!isAllowedPage('diag_command.php')) {");
-		$this->assertNotFalse($gatePos, "{$label}: the diag_command.php isAllowedPage() gate is missing");
-
-		$before = substr($src, 0, $gatePos);
-		foreach (['$_POST', '$_GET', '$_REQUEST'] as $superglobal) {
-			$this->assertStringNotContainsString(
-				$superglobal,
-				$before,
-				"{$label}: {$superglobal} must not appear anywhere before the gate (zero-tolerance, comments " .
-					'included) -- the gate must be provably the first thing on the page that could ever observe ' .
-					'a request, so it can never be silently reordered after a read'
-			);
+		foreach (glob($this->dir . '/*') ?: [] as $path) {
+			@unlink($path);
 		}
+		@rmdir($this->dir);
+	}
+
+	private function makeHook(string $name, string $body = "#!/bin/sh\nexit 0\n"): string
+	{
+		$path = $this->dir . '/' . $name;
+		$this->assertNotFalse(file_put_contents($path, $body));
+		$this->assertTrue(chmod($path, 0700));
+		return $path;
 	}
 
 	public function testNoRequestSuperglobalReadBeforeGate(): void
 	{
-		$this->assertNoRequestSuperglobalReadBeforeGate($this->readSource(self::PAGE_PATH), 'pfblockerng_edit_hooks.php');
+		$probed = FALSE;
+		$probe = static function () use (&$probed): array {
+			$probed = TRUE;
+			return [];
+		};
+		$state = pfb_edit_hooks_controller(FALSE, $probe, $probe, $this->dir);
+		$this->assertSame('/index.php', $state['redirect']);
+		$this->assertFalse($probed, 'denied requests must not invoke POST/GET callbacks');
 	}
 
 	public function testGateRedirectsToIndexAndExits(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
+		$path = $this->makeHook('hook_post_guarded.sh', "before\n");
+		$state = pfb_edit_hooks_controller(
+			FALSE,
+			static fn (): array => ['pfb_eh_save' => '1', 'pfb_eh_cur_when' => 'post', 'pfb_eh_cur_script' => basename($path), 'pfb_eh_content' => 'after'],
+			static fn (): array => [],
+			$this->dir
+		);
+		$this->assertSame('/index.php', $state['redirect']);
+		$this->assertSame("before\n", file_get_contents($path), 'privilege refusal must leave a valid save untouched');
+	}
 
-		$gatePos = strpos($src, "if (!isAllowedPage('diag_command.php')) {");
-		$this->assertNotFalse($gatePos, 'gate is not the expected if (!isAllowedPage(...)) { ... } shape');
+	public function testShippedPageDelegatesDeniedRequestToController(): void
+	{
+		$root = var_export(dirname(__DIR__, 2), TRUE);
+		$page = var_export(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php', TRUE);
+		$script = <<<PHP
+require {$root} . '/tests/php/bootstrap.php';
+\$shim = sys_get_temp_dir() . '/pfb_edit_hooks_shim_' . getmypid();
+mkdir(\$shim, 0777, TRUE);
+file_put_contents(\$shim . '/guiconfig.inc', "<?php");
+set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+error_reporting(E_ERROR | E_PARSE);
+\$GLOBALS['pfb_test_allowed_pages'] = ['diag_command.php' => FALSE];
+register_shutdown_function(static function (): void { echo 'shutdown'; });
+require {$page};
+echo 'after-page';
+PHP;
+		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
+		$this->assertIsResource($process);
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
 
-		$blockEnd = strpos($src, '}', $gatePos);
-		$this->assertNotFalse($blockEnd, 'test oracle: gate block has no closing brace');
-		$block = substr($src, $gatePos, $blockEnd - $gatePos);
+		$this->assertSame(0, $status, (string) $stderr);
+		$this->assertSame('shutdown', $stdout, 'denied page must exit through the controller redirect');
+	}
 
-		$this->assertStringContainsString("header('Location: /index.php');", $block, 'gate must redirect to /index.php');
-		$this->assertStringContainsString('exit;', $block, 'gate must exit after the redirect');
+	public function testControllerReturnsSuccessNoticesFromGet(): void
+	{
+		$saved = pfb_edit_hooks_controller(TRUE, static fn (): array => [], static fn (): array => ['saved' => '1'], $this->dir);
+		$deleted = pfb_edit_hooks_controller(TRUE, static fn (): array => [], static fn (): array => ['deleted' => 'hook_post_old.sh'], $this->dir);
+		$this->assertSame('Hook script saved.', $saved['notice']);
+		$this->assertSame('Hook script deleted.', $deleted['notice']);
 	}
 
 	public function testWarningBannerCallPresent(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
-
-		$this->assertStringContainsString('print_callout(', $src, 'the advanced-users warning banner call is missing');
-		$this->assertStringContainsString("'danger'", $src, "the warning banner must use the 'danger' style");
-		$this->assertStringContainsString('Advanced Users Only', $src, 'the warning banner heading text is missing');
-		$this->assertStringContainsString(
-			'Command Prompt',
-			$src,
-			'the warning banner must name the Command-Prompt-equivalent trust class it mirrors'
-		);
+		$warning = pfb_edit_hooks_warning();
+		$this->assertSame('danger', $warning['style']);
+		$this->assertSame('Advanced Users Only', $warning['title']);
+		$this->assertStringContainsString('Command Prompt', $warning['message']);
 	}
 
 	public function testPrivIncDoesNotMatchThisPage(): void
 	{
-		$src = $this->readSource(self::PRIV_INC_PATH);
-
-		// Scope the assertion to the ACTUAL match-array entries (not the file's prose
-		// comments, which are allowed -- and expected -- to name the page while
-		// explaining the deliberate omission). A real match entry looks like:
-		//   $priv_list['page-firewall-pfblockerng']['match'][] = "pfblockerng/....php...";
-		$matchCount = preg_match_all(
-			"/\\\$priv_list\\['page-firewall-pfblockerng'\\]\\['match'\\]\\[\\] = \"([^\"]+)\";/",
-			$src,
-			$m
-		);
-		$this->assertGreaterThan(0, $matchCount, 'test oracle: no match[] entries found at all -- priv file shape changed?');
-
-		$target = 'pfblockerng/pfblockerng_edit_hooks.php';
-		foreach ($m[1] as $matchValue) {
-			// A bare
-			// assertStringNotContainsString($matchValue) misses a FUTURE glob entry (e.g.
-			// "pfblockerng/pfblockerng_*") that would cover this page at RUNTIME under
-			// pfSense's own match semantics while never literally containing its filename
-			// as a substring. Reimplements pfSense's OWN cmp_page_matches() wildcard
-			// algorithm (src/etc/inc/auth_func.inc, verified against pfSense master):
-			// '.' -> '\.', '*' -> '.*', '?' -> '\?', anchored @^/{$match}$@ against
-			// '/{$page}' -- so this asserts the same MATCH SEMANTICS pfSense applies, not
-			// a substring proxy for them.
-			$regex = str_replace(['.', '*', '?'], ['\.', '.*', '\?'], $matchValue);
-			$this->assertSame(
-				0,
-				preg_match("@^/{$regex}\$@", "/{$target}"),
-				"pfblockerng.priv.inc match entry \"{$matchValue}\" matches {$target} under pfSense's own " .
-					'cmp_page_matches() wildcard semantics -- the isAllowedPage() secondary gate must be the only ' .
-					'thing that can ever govern access to it'
-			);
+		$priv_list = [];
+		require dirname(__DIR__, 2) . '/src/etc/inc/priv/pfblockerng.priv.inc';
+		$matches = $priv_list['page-firewall-pfblockerng']['match'] ?? [];
+		$this->assertNotEmpty($matches);
+		$this->assertNotContains('pfblockerng/pfblockerng_edit_hooks.php', $matches);
+		foreach ($matches as $match) {
+			$regex = str_replace(['.', '*', '?'], ['\\.', '.*', '\\?'], $match);
+			$this->assertSame(0, preg_match("@^{$regex}$@", 'pfblockerng/pfblockerng_edit_hooks.php'));
 		}
 	}
 
-	// ------------------------------------------------------------------
-	// Picker / save / render use ONLY the three pure helpers -- never an inline
-	// regex or a raw path decision of their own.
-	// ------------------------------------------------------------------
-
 	public function testPickerUsesPfbHookScripts(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
-		$this->assertStringContainsString('pfb_hook_scripts(', $src, 'the picker must list files via pfb_hook_scripts()');
+		$path = $this->makeHook('hook_pre_picker.sh');
+		$state = pfb_edit_hooks_controller(
+			TRUE,
+			static fn (): array => [],
+			fn (): array => ['when' => 'pre', 'script' => basename($path)],
+			$this->dir
+		);
+		$this->assertSame([], $state['errors']);
+		$this->assertSame(basename($path), $state['sel_script']);
+		$this->assertSame("#!/bin/sh\nexit 0\n", $state['content']);
 	}
 
 	public function testSavePathUsesTheThreeHelpersNotInlineValidation(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
-
-		foreach (
-			[
-				'pfb_hook_editor_compose_filename(',
-				'pfb_hook_editor_path(',
-				'pfb_hook_editor_template(',
-				'pfb_hook_script_valid(',
-			] as $needle
-		) {
-			$this->assertStringContainsString($needle, $src, "the page must call {$needle} — no inline reimplementation");
-		}
-
-		// The page must never inline the name-core allow-list regex itself -- that
-		// decision belongs SOLELY to pfb_hook_editor_compose_filename().
-		$this->assertStringNotContainsString(
-			'A-Za-z0-9_',
-			$src,
-			'the page must not inline the hook-name-core regex -- it belongs only to pfb_hook_editor_compose_filename()'
+		$path = $this->makeHook('hook_post_existing.sh');
+		$state = pfb_edit_hooks_request(
+			['pfb_eh_save' => '1', 'pfb_eh_cur_when' => 'post', 'pfb_eh_cur_script' => basename($path), 'pfb_eh_content' => 'updated'],
+			[],
+			$this->dir
 		);
-	}
+		$this->assertSame([], $state['errors']);
+		$this->assertSame('updated', file_get_contents($path));
 
-	// ------------------------------------------------------------------
-	// pfSense's own
-	// Form_Textarea::_getInput() / Form_Input::_getInput() ALREADY call
-	// htmlspecialchars() on the value at render (verified against pfSense master and
-	// RELENG_2_7_2) -- wrapping the value in htmlspecialchars() again at the PAGE
-	// level double-escapes it. The browser then decodes only ONE layer of entities,
-	// so the user sees the still-escaped remainder (e.g. "&quot;" instead of a
-	// literal double quote), and Save writes that mangled text straight back -- the
-	// very first load->save of the shipped hook template (which contains literal
-	// double quotes) corrupts it. Fixed by passing the RAW php variable into every
-	// Form_Textarea/Form_Input constructor call here and letting the framework
-	// escape exactly once, at render.
-	// ------------------------------------------------------------------
-
-	/**
-	 * Locates the constructor call whose head matches $pattern and returns the
-	 * position of its OWN opening '(' -- not the first ");" after it, which a
-	 * multi-line comment inside the argument list (e.g. "(no transformation);")
-	 * can trip: a balanced-paren scan (extractBalancedParens()) is what actually
-	 * finds the matching close, regardless of what stray "(" / ")" pairs a comment
-	 * carries.
-	 */
-	private function locateCallOpenParen(string $src, string $pattern, string $label): int
-	{
-		$this->assertMatchesRegularExpression($pattern, $src, "{$label}: call site not found");
-		preg_match($pattern, $src, $m, PREG_OFFSET_CAPTURE);
-		$callPos = $m[0][1];
-		$openParenPos = strpos($src, '(', $callPos);
-		$this->assertNotFalse($openParenPos, "{$label}: call site has no opening (");
-		return $openParenPos;
-	}
-
-	private function extractBalancedParens(string $src, int $openParenPos): string
-	{
-		$depth = 0;
-		$len = strlen($src);
-		for ($i = $openParenPos; $i < $len; $i++) {
-			if ($src[$i] === '(') {
-				$depth++;
-			} elseif ($src[$i] === ')') {
-				$depth--;
-				if ($depth === 0) {
-					return substr($src, $openParenPos, $i - $openParenPos + 1);
-				}
-			}
-		}
-		$this->fail('test oracle: unbalanced parentheses while scanning a call site');
-	}
-
-	private function assertConstructorPassesRawVariable(string $src, string $pattern, string $variable, string $label): void
-	{
-		$openParenPos = $this->locateCallOpenParen($src, $pattern, $label);
-		$block = $this->extractBalancedParens($src, $openParenPos);
-
-		$this->assertStringNotContainsString(
-			'htmlspecialchars(',
-			$block,
-			"{$label}: must pass the RAW {$variable} -- pfSense's Form_Input/Form_Textarea framework classes already " .
-				'htmlspecialchars() the value at render, so a page-level call here double-escapes it'
+		$state = pfb_edit_hooks_request(
+			['pfb_eh_save' => '1', 'pfb_eh_cur_when' => 'post', 'pfb_eh_cur_script' => '../outside.sh', 'pfb_eh_content' => 'blocked'],
+			[],
+			$this->dir
 		);
-		$this->assertStringContainsString($variable, $block, "{$label}: expected the raw {$variable} in the call site");
+		$this->assertNotSame([], $state['errors']);
+		$this->assertSame('updated', file_get_contents($path));
 	}
 
 	public function testTextareaContentPassedRawNotDoubleEscaped(): void
 	{
-		$this->assertConstructorPassesRawVariable(
-			$this->readSource(self::PAGE_PATH),
-			"/new Form_Textarea\\(/",
-			'$pfb_eh_content',
-			'pfb_eh_content Form_Textarea'
-		);
+		$value = 'echo "<quoted> & raw"';
+		$this->assertSame($value, pfb_edit_hooks_form_value($value));
 	}
 
 	public function testNewCoreInputValuePassedRaw(): void
 	{
-		$this->assertConstructorPassesRawVariable(
-			$this->readSource(self::PAGE_PATH),
-			"/new Form_Input\\(\\s*'pfb_eh_new_core',/",
-			'$pfb_eh_new_core_val',
-			'pfb_eh_new_core Form_Input'
-		);
+		$value = 'name_&_<quoted>';
+		$this->assertSame($value, pfb_edit_hooks_form_value($value));
 	}
 
 	public function testHiddenCurrentWhenAndScriptFieldsPassedRaw(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
-
-		$this->assertConstructorPassesRawVariable(
-			$src,
-			"/new Form_Input\\('pfb_eh_cur_when',/",
-			'$pfb_eh_sel_when',
-			'pfb_eh_cur_when hidden Form_Input'
-		);
-		$this->assertConstructorPassesRawVariable(
-			$src,
-			"/new Form_Input\\('pfb_eh_cur_script',/",
-			'$pfb_eh_sel_script',
-			'pfb_eh_cur_script hidden Form_Input'
-		);
+		$this->assertSame('pre', pfb_edit_hooks_form_value('pre'));
+		$this->assertSame('hook_pre_name.sh', pfb_edit_hooks_form_value('hook_pre_name.sh'));
 	}
 
-	/**
-	 * The MANDATORY red/green proof for finding F1: simulates the real rendering
-	 * chain end to end using PHP's own htmlspecialchars()/html_entity_decode() --
-	 * page value -> ONE framework htmlspecialchars() at render -> ONE browser decode
-	 * -- and asserts it reproduces a real hook-script template byte-for-byte.
-	 * Whether the page currently double-escapes is read from the ACTUAL source text
-	 * (not hardcoded), so this goes red again if the page-level htmlspecialchars()
-	 * wrapper around $pfb_eh_content is ever reintroduced.
-	 */
 	public function testTextareaRoundTripFidelityThroughFrameworkEscapeAndBrowserDecode(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
-
-		$openParenPos = $this->locateCallOpenParen($src, "/new Form_Textarea\\(/", 'pfb_eh_content Form_Textarea');
-		$block = $this->extractBalancedParens($src, $openParenPos);
-		$pageDoublesEscape = str_contains($block, 'htmlspecialchars(');
-
 		$original = pfb_hook_editor_template('pre', 'sh');
-		$this->assertStringContainsString(
-			'"',
-			$original,
-			'test oracle: the template fixture must contain a literal double quote for this round-trip to be meaningful'
-		);
-
-		// The real chain: page hands a value to Form_Textarea -> Form_Textarea::_getInput()
-		// calls htmlspecialchars() on it EXACTLY ONCE at render (pfSense master +
-		// RELENG_2_7_2) -> the browser parses that markup and decodes entities exactly
-		// once when the textarea's value is read back out (displayed, or re-POSTed by
-		// a same-page Save).
-		$pageValue      = $pageDoublesEscape ? htmlspecialchars($original) : $original;
-		$rendered       = htmlspecialchars($pageValue);
-		$browserDecoded = html_entity_decode($rendered);
-
-		$this->assertSame(
-			$original,
-			$browserDecoded,
-			'page value -> one framework htmlspecialchars() -> one browser decode must reproduce the original ' .
-				'template byte-for-byte; a page-level htmlspecialchars() wrapper around $pfb_eh_content double-escapes ' .
-				'it, so the first load->save of the shipped template corrupts it'
-		);
+		$this->assertSame($original, html_entity_decode(htmlspecialchars(pfb_edit_hooks_form_value($original))));
 	}
-
-	// ------------------------------------------------------------------
-	// The Create/Save buttons post the
-	// action fields the server keys on DIRECTLY as their own submit name -- a
-	// clicked <button type="submit" name="pfb_eh_create"|"pfb_eh_save"> is included
-	// in the browser's OWN POST natively (no separate click-handler JS needed to
-	// inject a same-named hidden field first).
-	// ------------------------------------------------------------------
 
 	public function testSubmitButtonsUseNativeNamesWithNoJsInjection(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
-
-		$this->assertMatchesRegularExpression(
-			"/new Form_Button\\(\\s*'pfb_eh_create',/",
-			$src,
-			'the Create button must be named pfb_eh_create directly so the browser posts it natively'
-		);
-		$this->assertMatchesRegularExpression(
-			"/new Form_Button\\(\\s*'pfb_eh_save',/",
-			$src,
-			'the Save button must be named pfb_eh_save directly so the browser posts it natively'
-		);
-
-		// Quoted literals, not bare substrings: the PHP local variables
-		// $pfb_eh_create_btn/$pfb_eh_save_btn are kept as-is (only the Form_Button
-		// NAME/submit-field string argument changed), so a bare substring check would
-		// false-positive on those unrelated variable names.
-		foreach (["'pfb_eh_create_btn'", "'pfb_eh_save_btn'", 'pfbEhSubmitAs'] as $stale) {
-			$this->assertStringNotContainsString(
-				$stale,
-				$src,
-				"the old JS-injection wiring ({$stale}) must be fully removed now the buttons post natively"
-			);
-		}
+		$this->assertSame('pfb_eh_create', pfb_edit_hooks_submit_field('create'));
+		$this->assertSame('pfb_eh_save', pfb_edit_hooks_submit_field('save'));
+		$this->assertSame('', pfb_edit_hooks_submit_field('delete'));
 	}
-
-	// ------------------------------------------------------------------
-	// The create flow must open the target
-	// with fopen 'x' (atomic create-exclusive, closing the file_exists/write TOCTOU),
-	// check the write byte count, and unlink the partial file on a failed write/chmod.
-	// Structural oracle: the page cannot run off-appliance,
-	// so pin the source text of the create block instead.
-	// ------------------------------------------------------------------
 
 	public function testCreateFlowUsesAtomicOpenWithPartialWriteCleanup(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
-
-		$this->assertMatchesRegularExpression(
-			"/@?fopen\\(\\\$path,\\s*'x'\\)/",
-			$src,
-			"the create flow must open the hook file with fopen(..., 'x') -- atomic create-exclusive -- " .
-				'not a separate file_exists() check followed by a plain write (TOCTOU)'
+		$state = pfb_edit_hooks_request(
+			['pfb_eh_create' => '1', 'pfb_eh_new_when' => 'pre', 'pfb_eh_new_core' => 'created', 'pfb_eh_new_lang' => 'sh'],
+			[],
+			$this->dir
 		);
-		// NOTE: no blanket "no file_put_contents" assertion -- the SAVE path (line ~161)
-		// legitimately overwrites an existing vetted file in place; only the CREATE flow
-		// needs create-exclusive semantics, pinned by the fopen 'x' assertion above.
-		$this->assertMatchesRegularExpression(
-			'/\\$pfb_eh_new_written\\s*!==\\s*strlen\\(\\$pfb_eh_new_template\\)/',
-			$src,
-			'the create flow must compare the fwrite() return against the full template length (partial-write detection)'
-		);
-		$this->assertMatchesRegularExpression(
-			'/@?unlink\\(\\$path\\)/',
-			$src,
-			'a failed write/chmod must unlink the partial file so it never lingers for the picker or a retry'
-		);
-		$this->assertMatchesRegularExpression(
-			"/@?chmod\\(\\\$path,\\s*0700\\)/",
-			$src,
-			'the create flow must chmod the new hook file to 0700, not a laxer mode -- the runner always execs ' .
-				'it as root and pfb_hook_scripts() has no is_executable filter, so no group/other bits are ever ' .
-				'needed (owner-only is least privilege)'
-		);
+		$path = $this->dir . '/hook_pre_created.sh';
+		$this->assertSame([], $state['errors']);
+		$this->assertSame('/pfblockerng/pfblockerng_edit_hooks.php?when=pre&script=hook_pre_created.sh', $state['redirect']);
+		$this->assertFileExists($path);
+		$this->assertSame(0700, fileperms($path) & 0777);
+		$this->assertStringContainsString('#!/bin/sh', (string) file_get_contents($path));
 	}
 
-	// ------------------------------------------------------------------
-	// "Edit Hooks" sub-tab: directly after "Hooks", on every page that declares the
-	// Update sub-tab row (coverage matrix: pfblockerng_update.php, pfblockerng_hooks.php,
-	// and this page itself, each re-declaring the full row with its own tab active).
-	// ------------------------------------------------------------------
-
-	private function assertEditHooksTabDirectlyAfterHooksTab(string $src, string $label): void
-	{
-		$hooksPos = strpos($src, "array(gettext('Hooks'),");
-		$this->assertNotFalse($hooksPos, "{$label}: the 'Hooks' sub-tab entry is missing");
-
-		$editHooksPos = strpos($src, "array(gettext('Edit Hooks'),");
-		$this->assertNotFalse($editHooksPos, "{$label}: the 'Edit Hooks' sub-tab entry is missing");
-
-		$this->assertGreaterThan($hooksPos, $editHooksPos, "{$label}: 'Edit Hooks' must be declared directly after 'Hooks'");
-		$this->assertStringContainsString(
-			"/pfblockerng/pfblockerng_edit_hooks.php'",
-			$src,
-			"{$label}: the 'Edit Hooks' sub-tab must link pfblockerng_edit_hooks.php"
-		);
-
-		// Nothing else may sit between the two entries in the sub-tab array (directly
-		// after, not just somewhere after).
-		$between = substr($src, $hooksPos, $editHooksPos - $hooksPos);
-		$this->assertSame(
-			1,
-			substr_count($between, '$tab_array_sub[]'),
-			"{$label}: another sub-tab entry sits between 'Hooks' and 'Edit Hooks'"
-		);
-	}
-
-	/**
-	 * issue #1884: Enter in the Name field submits as Create (only text input +
-	 * first submit button), so the create-failure path fires from a stray
-	 * keypress. It must restore the loaded script and the unsaved buffer from
-	 * the posted cur_ and content fields — the same shape the failed-delete
-	 * branch uses — instead of blanking the editor.
-	 */
 	public function testCreateFailureRestoresTheLoadedScriptAndBuffer(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
-
-		$createPos = strpos($src, "isset(\$_POST['pfb_eh_create'])");
-		$this->assertNotFalse($createPos, 'vacuity: the create branch must exist');
-		$deletePos = strpos($src, "isset(\$_POST['pfb_eh_delete'])", $createPos);
-		$this->assertNotFalse($deletePos, 'vacuity: the delete branch must follow the create branch');
-
-		$branch = substr($src, $createPos, $deletePos - $createPos);
-		$this->assertStringContainsString("\$pfb_eh_sel_when   = (string) (\$_POST['pfb_eh_cur_when'] ?? '');", $branch,
-			'a failed create must restore the loaded Pre/Post from the posted cur_when');
-		$this->assertStringContainsString("\$pfb_eh_sel_script = (string) (\$_POST['pfb_eh_cur_script'] ?? '');", $branch,
-			'a failed create must restore the loaded script from the posted cur_script');
-		$this->assertStringContainsString("\$pfb_eh_content    = pfb_sanitize_text_area((string) (\$_POST['pfb_eh_content'] ?? ''));", $branch,
-			'a failed create must restore the unsaved buffer (sanitized at ingestion, #1723) instead of blanking it');
-		$this->assertStringNotContainsString("\$pfb_eh_content      = '';", $branch,
-			'the blanking assignment is the data-loss defect — it must be gone');
-
-		// The typed create-When echo must survive the restore: the create-When
-		// select prefers the explicit echo over the restored loaded-script when.
-		$this->assertStringContainsString('$pfb_eh_new_when_echo = $post_when;', $branch,
-			'the typed create-When choice must still echo after a validation error');
-		$this->assertStringContainsString("\$pfb_eh_new_when_val = (\$pfb_eh_new_when_echo === 'pre' || \$pfb_eh_new_when_echo === 'post')", $src,
-			'the create-When select must prefer the typed echo over the restored loaded-script when');
+		$state = pfb_edit_hooks_request(
+			[
+				'pfb_eh_create' => '1', 'pfb_eh_new_when' => 'post', 'pfb_eh_new_core' => 'bad-name', 'pfb_eh_new_lang' => 'py',
+				'pfb_eh_cur_when' => 'pre', 'pfb_eh_cur_script' => 'hook_pre_loaded.sh', 'pfb_eh_content' => "line\r\n",
+			],
+			[],
+			$this->dir
+		);
+		$this->assertNotSame([], $state['errors']);
+		$this->assertSame('pre', $state['sel_when']);
+		$this->assertSame('hook_pre_loaded.sh', $state['sel_script']);
+		$this->assertSame("line\n", $state['content']);
+		$this->assertSame('bad-name', $state['new_core']);
+		$this->assertSame('py', $state['new_lang']);
+		$this->assertSame('post', $state['new_when']);
 	}
 
 	public function testEditHooksTabOnUpdatePage(): void
 	{
-		$this->assertEditHooksTabDirectlyAfterHooksTab($this->readSource(self::UPDATE_PAGE_PATH), 'pfblockerng_update.php');
+		$tabs = pfb_edit_hooks_tabs('run');
+		$this->assertSame(['Run', TRUE, '/pfblockerng/pfblockerng_update.php'], $tabs[0]);
+		$this->assertSame(['Hooks', FALSE, '/pfblockerng/pfblockerng_hooks.php'], $tabs[1]);
+		$this->assertSame(['Edit Hooks', FALSE, '/pfblockerng/pfblockerng_edit_hooks.php'], $tabs[2]);
 	}
 
 	public function testEditHooksTabOnHooksPage(): void
 	{
-		$this->assertEditHooksTabDirectlyAfterHooksTab($this->readSource(self::HOOKS_PAGE_PATH), 'pfblockerng_hooks.php');
+		$tabs = pfb_edit_hooks_tabs('hooks');
+		$this->assertSame(['Run', FALSE, '/pfblockerng/pfblockerng_update.php'], $tabs[0]);
+		$this->assertSame(['Hooks', TRUE, '/pfblockerng/pfblockerng_hooks.php'], $tabs[1]);
+		$this->assertSame(['Edit Hooks', FALSE, '/pfblockerng/pfblockerng_edit_hooks.php'], $tabs[2]);
 	}
 
 	public function testEditHooksTabOnItself(): void
 	{
-		$this->assertEditHooksTabDirectlyAfterHooksTab($this->readSource(self::PAGE_PATH), 'pfblockerng_edit_hooks.php (self)');
+		$tabs = pfb_edit_hooks_tabs('edit');
+		$this->assertSame(['Run', FALSE, '/pfblockerng/pfblockerng_update.php'], $tabs[0]);
+		$this->assertSame(['Hooks', FALSE, '/pfblockerng/pfblockerng_hooks.php'], $tabs[1]);
+		$this->assertSame(['Edit Hooks', TRUE, '/pfblockerng/pfblockerng_edit_hooks.php'], $tabs[2]);
 	}
 
 	public function testEditHooksTabIsActiveOnlyOnItself(): void
 	{
-		// TRUE on itself...
-		$src = $this->readSource(self::PAGE_PATH);
-		$this->assertStringContainsString("array(gettext('Edit Hooks'),\tTRUE,", $src, 'self: Edit Hooks tab must be active');
-
-		// ...FALSE on the two sibling pages.
-		foreach ([self::UPDATE_PAGE_PATH => 'update', self::HOOKS_PAGE_PATH => 'hooks'] as $path => $label) {
-			$src = $this->readSource($path);
-			$this->assertStringContainsString(
-				"array(gettext('Edit Hooks'),\tFALSE,",
-				$src,
-				"{$label}: Edit Hooks tab must be inactive"
-			);
-		}
+		$active = array_map(static fn (array $tab): bool => $tab[1], pfb_edit_hooks_tabs('edit'));
+		$this->assertSame([FALSE, FALSE, TRUE], $active);
 	}
 
-	// ------------------------------------------------------------------
-	// The save flow
-	// must sanitize $_POST content through the shared persist-boundary helper
-	// before it is ever written, and
-	// stage the write to a temp file in the same directory and rename() it into
-	// place atomically -- never truncate+write the live target in place, since
-	// pfb_run_hooks() may exec it as root concurrently with a save. The GET
-	// picker-load path must reject invalid-UTF-8 file content before populating the
-	// editor. Structural oracles: the page
-	// cannot run off-appliance, so these pin the source-text shape of the blocks.
-	// ------------------------------------------------------------------
-
-	private function extractSaveFlowBlock(string $src): string
-	{
-		$blockStart = strpos($src, "isset(\$_POST['pfb_eh_save'])");
-		$this->assertNotFalse($blockStart, 'test oracle: save-flow block start marker not found');
-		$blockEnd = strpos($src, '// GET picker load', $blockStart);
-		$this->assertNotFalse($blockEnd, 'test oracle: save-flow block end marker not found');
-		return substr($src, $blockStart, $blockEnd - $blockStart);
-	}
-
-	/**
-	 * issue #1734: the save path joins the #1723 persist-boundary standard -- the shared
-	 * pfb_sanitize_text_area() replaces the hand-rolled pfb_hook_editor_normalize_content().
-	 * The shared helper still performs the identical CRLF/CR -> LF collapse first, so the
-	 * shebang-corruption regression the old helper existed for stays fixed, and it
-	 * additionally scrubs legacy encodings, control characters, the BOM, and per-line
-	 * trailing whitespace before the content ever reaches disk.
-	 */
 	public function testSavePathSanitizesContentBeforeWrite(): void
 	{
-		$block = $this->extractSaveFlowBlock($this->readSource(self::PAGE_PATH));
-
-		// Pin the CALL-shape assignment, not the
-		// bare function-name token -- the save block's own comment names the helper, so
-		// a substring assertion passes even with the call stripped (coverage theater;
-		// the mutant survived 19/19). A comment can never satisfy this assignment regex.
-		$callShape = '/\\$post_content\\s*=\\s*pfb_sanitize_text_area\\(/';
-		$this->assertSame(
-			1,
-			preg_match($callShape, $block, $m, PREG_OFFSET_CAPTURE),
-			'the save flow must ASSIGN $post_content through the shared pfb_sanitize_text_area() -- writing the ' .
-				"raw \$_POST value persists the browser's CRLF textarea normalization straight into the hook " .
-				"script file, breaking its shebang exec (e.g. \"#!/bin/sh\\r\" -> ENOENT), and leaves control " .
-				'characters and trailing per-line whitespace in the saved script'
+		$path = $this->makeHook('hook_post_sanitize.sh');
+		$content = "#!/bin/sh\r\necho ok  \r\n" . "bad\x01\r\n";
+		$state = pfb_edit_hooks_request(
+			['pfb_eh_save' => '1', 'pfb_eh_cur_when' => 'post', 'pfb_eh_cur_script' => basename($path), 'pfb_eh_content' => $content],
+			[],
+			$this->dir
 		);
-
-		$sanitizePos = $m[0][1];
-		$writePos = strpos($block, 'file_put_contents(');
-		$this->assertNotFalse($writePos, 'test oracle: no file_put_contents( call found in the save-flow block');
-		$this->assertLessThan(
-			$writePos,
-			$sanitizePos,
-			'content must be sanitized BEFORE it is written to the temp file, not after'
-		);
+		$this->assertSame([], $state['errors']);
+		$this->assertSame(pfb_sanitize_text_area($content), file_get_contents($path));
 	}
 
-	/**
-	 * issue #1734: the hand-rolled helper is removed, not merely bypassed -- a surviving
-	 * call would mean the content is sanitized twice, or (worse) that a later edit
-	 * silently reverted the save path to the narrower normalization.
-	 */
 	public function testSavePathNoLongerUsesTheHandRolledNormalizer(): void
 	{
-		$this->assertStringNotContainsString(
-			'pfb_hook_editor_normalize_content',
-			$this->readSource(self::PAGE_PATH),
-			'pfb_hook_editor_normalize_content() was retired by #1734 -- the page must not reference it at all, ' .
-				'in code or in a comment that would outlive it'
+		$path = $this->makeHook('hook_post_shared.sh');
+		$content = "a\r\nb  \r\n";
+		$state = pfb_edit_hooks_request(
+			['pfb_eh_save' => '1', 'pfb_eh_cur_when' => 'post', 'pfb_eh_cur_script' => basename($path), 'pfb_eh_content' => $content],
+			[],
+			$this->dir
 		);
+		$this->assertSame([], $state['errors']);
+		$this->assertSame(pfb_sanitize_text_area($content), file_get_contents($path));
 	}
 
 	public function testSaveFlowWritesAtomicallyViaTempFileAndRename(): void
 	{
-		$block = $this->extractSaveFlowBlock($this->readSource(self::PAGE_PATH));
-
-		$this->assertStringContainsString(
-			'tempnam(dirname($path)',
-			$block,
-			'the save flow must stage the new content to a temp file in the SAME directory as the target ' .
-				'(tempnam(dirname($path), ...)) -- a cross-filesystem temp file would break the atomic rename() below'
+		$path = $this->makeHook('hook_post_atomic.sh', "old\n");
+		$before = fileinode($path);
+		$state = pfb_edit_hooks_request(
+			['pfb_eh_save' => '1', 'pfb_eh_cur_when' => 'post', 'pfb_eh_cur_script' => basename($path), 'pfb_eh_content' => "new\n"],
+			[],
+			$this->dir
 		);
-		$this->assertMatchesRegularExpression(
-			'/@?rename\\(/',
-			$block,
-			'the save flow must atomically rename() the temp file over the target -- an in-place truncate+write ' .
-				'lets a concurrent pfb_run_hooks() exec see an empty/partial script'
-		);
-		$this->assertDoesNotMatchRegularExpression(
-			"/file_put_contents\\(\\\$path,/",
-			$block,
-			'the save flow must never file_put_contents() the live target path directly (in-place truncate) -- ' .
-				'it must write the temp file and rename() it into place instead'
-		);
-		$this->assertMatchesRegularExpression(
-			'/@?chmod\\(\\$pfb_eh_tmp,\\s*0700\\)/',
-			$block,
-			'the save flow must chmod the temp file to 0700, not a laxer mode, before rename() -- same ' .
-				'least-privilege rationale as the create flow (root-only exec, no is_executable filter)'
-		);
+		$this->assertSame([], $state['errors']);
+		$this->assertNotSame($before, fileinode($path));
+		$this->assertSame("new\n", file_get_contents($path));
+		$this->assertSame(0700, fileperms($path) & 0777);
+		$this->assertSame([], glob($this->dir . '/.pfbeh_*') ?: []);
 	}
 
 	public function testLoadPathRejectsInvalidUtf8ContentBeforePopulatingEditor(): void
 	{
-		$src = $this->readSource(self::PAGE_PATH);
-
-		$this->assertStringContainsString(
-			'mb_check_encoding(',
-			$src,
-			'the GET picker-load path must validate the loaded file is valid UTF-8 before populating the editor ' .
-				'-- htmlspecialchars(ENT_SUBSTITUTE) silently mangles invalid bytes to U+FFFD on display, and a ' .
-				'subsequent save would persist that corruption back to disk'
-		);
-
-		$blockStart = strpos($src, "if (!\$_POST && isset(\$_GET['when'], \$_GET['script']))");
-		$this->assertNotFalse($blockStart, 'test oracle: GET picker-load block start marker not found');
-		$blockEnd = strpos($src, '$pfb_eh_lang = pfb_hook_editor_lang_for(', $blockStart);
-		$this->assertNotFalse($blockEnd, 'test oracle: GET picker-load block end marker not found');
-		$block = substr($src, $blockStart, $blockEnd - $blockStart);
-
-		$checkPos = strpos($block, 'mb_check_encoding(');
-		$assignPos = strpos($block, '$pfb_eh_content    = $body;');
-		$this->assertNotFalse($checkPos, 'test oracle: mb_check_encoding( not found inside the picker-load block');
-		$this->assertNotFalse($assignPos, 'test oracle: $pfb_eh_content assignment not found inside the picker-load block');
-		$this->assertLessThan(
-			$assignPos,
-			$checkPos,
-			'the UTF-8 validity check must gate the $pfb_eh_content assignment, not follow it'
-		);
+		$path = $this->makeHook('hook_pre_invalid.sh', "#!/bin/sh\n\xFF\n");
+		$state = pfb_edit_hooks_request([], ['when' => 'pre', 'script' => basename($path)], $this->dir);
+		$this->assertNotSame([], $state['errors']);
+		$this->assertSame('', $state['sel_script']);
+		$this->assertSame('', $state['content']);
 	}
 }

--- a/tests/php/EditHooksSyntaxHighlightWiringTest.php
+++ b/tests/php/EditHooksSyntaxHighlightWiringTest.php
@@ -22,7 +22,7 @@ final class EditHooksSyntaxHighlightWiringTest extends TestCase
 		$this->assertStringContainsString('cm-hooks.min.js?v=', $asset);
 		$this->assertStringContainsString("getElementById('pfb_hook_editor_content')", $init);
 		$this->assertStringContainsString('window.pfbHooksCM', $init);
-		$this->assertStringContainsString("fromTextarea(pfbHookEditorEl, 'py'", $init);
+		$this->assertStringContainsString('fromTextarea(pfbHookEditorEl, "py"', $init);
 		$this->assertStringContainsString("lintUrl: '/pfblockerng/pfblockerng_lint.php'", $init);
 	}
 
@@ -31,9 +31,10 @@ final class EditHooksSyntaxHighlightWiringTest extends TestCase
 		$python = pfb_hooks_editor_render(TRUE, 'py')['mount'];
 		$shell  = pfb_hooks_editor_render(TRUE, 'sh')['mount'];
 
-		$this->assertStringContainsString("'py'", $python);
-		$this->assertStringNotContainsString("'sh'", $python);
-		$this->assertStringContainsString("'sh'", $shell);
+		$this->assertStringContainsString('"py"', $python);
+		$this->assertStringNotContainsString('"sh"', $python);
+		$this->assertStringContainsString('"sh"', $shell);
+		$this->assertStringNotContainsString('"py"', $shell);
 	}
 
 	public function testHookEditorAssetAndLintEachRenderOnce(): void

--- a/tests/php/EditHooksSyntaxHighlightWiringTest.php
+++ b/tests/php/EditHooksSyntaxHighlightWiringTest.php
@@ -4,168 +4,45 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1669 Part B slice B2 -- live CodeMirror 6 syntax highlighting (python + shell
- * modes only, no PHP -- ADR-12 addendum) for the Edit Hooks page's
- * #pfb_hook_editor_content textarea, gated by the same General-settings
- * `pfb_syntax_highlight` toggle DnsblRegexHighlightWiringTest pins for the DNSBL
- * regex-list field (registered in pfb_cfg_registry(), default on).
- *
- * pfblockerng_edit_hooks.php carries top-level render execution (require_once('guiconfig.inc')
- * et al.) and cannot be require()d/rendered off-appliance -- same constraint documented on
- * DnsblRegexHighlightWiringTest/FeedsUrlCompareIconRenderTest/CategoryEditReservedHeaderTest.
- * This test pins the CONDITIONAL STRUCTURE itself (the pfb_editor_enabled() accessor
- * comparison, and the gated script tag / JS init all being driven by the same PHP boolean),
- * plus vacuity-safe exactly-once occurrence counts, rather than asserting the markup is
- * unconditionally present. Reading the real source file IS reading the render for this
- * content (same rationale as DnsblRegexHighlightWiringTest); this remains the Tier-A
- * ui_render coverage for this www/ change together with tests/smoke/ui/test_render_smoke.py's
- * "edit_hooks" marker (present only because the toggle defaults on for a fresh box).
- */
 final class EditHooksSyntaxHighlightWiringTest extends TestCase
 {
-	private static string $src;
-
-	public static function setUpBeforeClass(): void
+	public function testDisabledHookEditorEmitsNoAssetOrInitialization(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_edit_hooks.php');
-		}
-		self::$src = $src;
+		$rendered = pfb_hooks_editor_render(FALSE, 'py');
+		$this->assertSame('', $rendered['asset']);
+		$this->assertSame('', $rendered['mount']);
 	}
 
-	public function testGatingBooleanReadsThePfbSyntaxHighlightToggle(): void
+	public function testEnabledHookEditorTargetsContentAndLiveLanguage(): void
 	{
-		// Same enum-comparison idiom as pfblockerng_dnsbl.php's $pfb_syntaxhl_on -- LENIENT
-		// (issue #1887 accessor) -- see DnsblRegexHighlightWiringTest's docblock for
-		// why a default-on field needs the lenient adapter.
-		$this->assertMatchesRegularExpression(
-			"#\\\$pfb_syntaxhl_on\\s*=\\s*pfb_editor_enabled\\(\\)#",
-			self::$src,
-			'expected a $pfb_syntaxhl_on boolean derived from pfb_editor_enabled() (issue #1887 named accessor)'
-		);
+		$rendered = pfb_hooks_editor_render(TRUE, 'py');
+		$asset = $rendered['asset'];
+		$init  = $rendered['mount'];
+
+		$this->assertStringContainsString('cm-hooks.min.js?v=', $asset);
+		$this->assertStringContainsString("getElementById('pfb_hook_editor_content')", $init);
+		$this->assertStringContainsString('window.pfbHooksCM', $init);
+		$this->assertStringContainsString("fromTextarea(pfbHookEditorEl, 'py'", $init);
+		$this->assertStringContainsString("lintUrl: '/pfblockerng/pfblockerng_lint.php'", $init);
 	}
 
-	public function testCmHooksScriptIsIncludedWithCacheBustingInsideTheGate(): void
+	public function testHookEditorUsesCurrentServerLanguage(): void
 	{
-		// Tempered-dot gaps ((?:(?!endif).)*?), not bare .*? -- see
-		// DnsblRegexHighlightWiringTest's identical comment for why a bare .*? risks
-		// bridging past this gate's own close into a later, unrelated if/endif block.
-		$this->assertMatchesRegularExpression(
-			'#if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. '<script src="vendor/codemirror/cm-hooks\.min\.js\?v=<\?=pfb_file_mtime\(\'/usr/local/www/pfblockerng/vendor/codemirror/cm-hooks\.min\.js\'\)\?>"></script>'
-			. '(?:(?!endif).)*?endif#s',
-			self::$src,
-			'expected the cm-hooks.min.js include, with mtime cache-busting, wrapped inside an if ($pfb_syntaxhl_on) gate'
-		);
+		$python = pfb_hooks_editor_render(TRUE, 'py')['mount'];
+		$shell  = pfb_hooks_editor_render(TRUE, 'sh')['mount'];
+
+		$this->assertStringContainsString("'py'", $python);
+		$this->assertStringNotContainsString("'sh'", $python);
+		$this->assertStringContainsString("'sh'", $shell);
 	}
 
-	public function testEditorInitTargetsThePfbHookEditorContentElementAndChecksWindowPfbHooksCM(): void
+	public function testHookEditorAssetAndLintEachRenderOnce(): void
 	{
-		$this->assertStringContainsString(
-			"getElementById('pfb_hook_editor_content')",
-			self::$src,
-			'expected the CM6 init to look up the pfb_hook_editor_content element by id'
-		);
-		$this->assertStringContainsString(
-			'window.pfbHooksCM',
-			self::$src,
-			'expected the CM6 init to guard on window.pfbHooksCM (the vendored cm-hooks bundle\'s IIFE global) being defined'
-		);
-		$this->assertMatchesRegularExpression(
-			'/pfbHooksCM\.fromTextarea\(/',
-			self::$src,
-			'expected the CM6 init to call pfbHooksCM.fromTextarea() on the located element'
-		);
-	}
+		$asset = pfb_hooks_editor_render(TRUE, 'sh')['asset'];
+		$init  = pfb_hooks_editor_render(TRUE, 'sh')['mount'];
 
-	public function testEditorInitPassesTheServerComputedLanguage(): void
-	{
-		// Mode selection follows the hook file's extension -- decided server-side by
-		// pfb_hook_editor_lang_for(), rendered as fromTextarea()'s second argument (a
-		// quoted 'py'|'sh' literal echoed from PHP), never re-derived in JS.
-		$this->assertStringContainsString('pfb_hook_editor_lang_for(', self::$src, 'expected the page to call pfb_hook_editor_lang_for()');
-		// [,)] after the language literal, not a bare `\)`: issue #1732 step 2 added a
-		// third (opts) argument, so the call no longer necessarily closes right after
-		// the language literal -- the second-argument contract itself is unchanged.
-		$this->assertMatchesRegularExpression(
-			"/pfbHooksCM\\.fromTextarea\\([^)]*,\\s*'<\\?=\\\$pfb_eh_lang\\?>'\\s*[,)]/",
-			self::$src,
-			'expected fromTextarea() to be called with a second argument echoing $pfb_eh_lang'
-		);
-	}
-
-	public function testEditorInitIsGatedInsideEventsPushBehindTheSameBoolean(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'#events\.push\(function\(\)\s*\{(?:(?!endif).)*?if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. "getElementById\\('pfb_hook_editor_content'\\)(?:(?!endif).)*?pfbHooksCM\\.fromTextarea\\((?:(?!endif).)*?endif#s",
-			self::$src,
-			'expected the pfb_hook_editor_content CM6 init inside events.push(), gated by if ($pfb_syntaxhl_on)'
-		);
-	}
-
-	/**
-	 * Vacuity-safe "off emits nothing new" proof -- same rationale as
-	 * DnsblRegexHighlightWiringTest::testCmRegexAssetAndFromTextareaCallEachAppearExactlyOnceInTheWholeFile():
-	 * the earlier gate-shape regexes only prove a gated occurrence EXISTS, not that no
-	 * second, unguarded copy exists elsewhere. Counting occurrences closes that gap.
-	 */
-	public function testCmHooksAssetAndFromTextareaCallEachAppearExactlyOnceInTheWholeFile(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(self::$src, '<script src="vendor/codemirror/cm-hooks.min.js?v='),
-			'expected exactly one cm-hooks.min.js <script> tag in the whole file (the gated include) -- '
-			. 'a second, unguarded <script> tag would defeat the off-emits-nothing contract'
-		);
-		$this->assertSame(
-			1,
-			substr_count(self::$src, 'pfbHooksCM.fromTextarea('),
-			'expected exactly one pfbHooksCM.fromTextarea( call in the whole file (the gated events.push init) -- '
-			. 'a second, unguarded call would defeat the off-emits-nothing contract'
-		);
-	}
-
-	/**
-	 * issue #1732 step 2: the Edit Hooks page's fromTextarea() call now also wires the
-	 * advisory server-lint endpoint, still inside the SAME $pfb_syntaxhl_on gate --
-	 * toggling syntax highlighting off must keep emitting zero lint bytes too.
-	 */
-	public function testEditorInitPassesTheLintUrlInsideTheSameGate(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#events\\.push\\(function\\(\\)\\s*\\{(?:(?!endif).)*?if\\s*\\(\\s*\\\$pfb_syntaxhl_on\\s*\\)\\s*:(?:(?!endif).)*?"
-			. "pfbHooksCM\\.fromTextarea\\([^;]*?lintUrl:\\s*'/pfblockerng/pfblockerng_lint\\.php'(?:(?!endif).)*?endif#s",
-			self::$src,
-			"expected pfbHooksCM.fromTextarea(...) to pass lintUrl: '/pfblockerng/pfblockerng_lint.php' inside the \$pfb_syntaxhl_on gate"
-		);
-	}
-
-	/**
-	 * Vacuity-safe count for the new lintUrl wiring, same rationale as
-	 * testCmHooksAssetAndFromTextareaCallEachAppearExactlyOnceInTheWholeFile.
-	 */
-	public function testLintUrlAppearsExactlyOnceInTheWholeFile(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(self::$src, "lintUrl: '/pfblockerng/pfblockerng_lint.php'"),
-			'expected exactly one lintUrl wiring in the whole file (the gated events.push init)'
-		);
-	}
-
-	public function testOriginalHookEditorTextareaFieldIsUnchanged(): void
-	{
-		// The save handler's $_POST['pfb_eh_content'] read keys off this exact
-		// Form_Textarea('pfb_eh_content', ...) name -- this slice must not touch it; the
-		// CM6 overlay is a pure client-side progressive enhancement layered on top.
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'pfb_eh_content',#",
-			self::$src,
-			'expected the underlying pfb_eh_content Form_Textarea field to remain unchanged'
-		);
+		$this->assertSame(1, substr_count($asset, '<script'));
+		$this->assertSame(1, substr_count($init, 'pfbHooksCM.fromTextarea('));
+		$this->assertSame(1, substr_count($init, "lintUrl: '/pfblockerng/pfblockerng_lint.php'"));
 	}
 }

--- a/tests/php/EscapedPathFilesystemCallTest.php
+++ b/tests/php/EscapedPathFilesystemCallTest.php
@@ -71,6 +71,8 @@ final class EscapedPathFilesystemCallTest extends TestCase
 	 */
 	public function test_no_filesystem_call_receives_escaped_path(): void
 	{
+		// This is a whole-tree static safety rule, not one runnable call path.
+		// PRODUCTION COMMENTS AND DOCBLOCKS MUST NEVER BE LOAD-BEARING FOR A TEST.
 		$root = dirname(__DIR__, 2);
 		$violations = [];
 
@@ -81,7 +83,7 @@ final class EscapedPathFilesystemCallTest extends TestCase
 			if (!in_array($file->getExtension(), ['php', 'inc'], TRUE)) {
 				continue;
 			}
-			$source = file_get_contents($file->getPathname());
+			$source = php_strip_whitespace($file->getPathname());
 			$this->assertNotFalse($source, "Failed to read {$file->getPathname()}");
 			$count = preg_match_all(self::FS_CALL_PATTERN, $source, $m, PREG_OFFSET_CAPTURE);
 			// FALSE = regex-engine error, which must fail loud — not read as "no match".

--- a/tests/php/FeedsAltSelectedKeyTest.php
+++ b/tests/php/FeedsAltSelectedKeyTest.php
@@ -17,13 +17,14 @@ use PHPUnit\Framework\TestCase;
  *
  * Like WidgetSubmitPostGuardTest, the page carries top-level execution and
  * cannot be require()d off-appliance, so the REAL alt_selected block is
- * eval-extracted verbatim (its leading comment and the following
- * ``if ($config_mod)`` line are the unique anchors).
+ * eval-extracted verbatim (the executable ``if (isset($_POST['alt_selected']))``
+ * start and following ``if ($config_mod)`` line are the unique anchors).
  */
 final class FeedsAltSelectedKeyTest extends TestCase
 {
 	private array $savedPost = [];
 	private mixed $savedConfig = null;
+	private static string $altRegion;
 
 	public static function setUpBeforeClass(): void
 	{
@@ -36,12 +37,13 @@ final class FeedsAltSelectedKeyTest extends TestCase
 
 		if (!function_exists('pfb_feeds_oracle_alt_selected')) {
 			if (!preg_match(
-				'/\/\/ Save all .selected. Alternate URL feeds\.\n(.*?)(?=\n\n\t\tif \(\$config_mod\))/s',
+				'/(if \(isset\(\$_POST\[\'alt_selected\'\]\)\) \{.*?)(?=\n\n\t\tif \(\$config_mod\))/s',
 				$src,
 				$m
 			)) {
 				throw new RuntimeException('test bootstrap: alt_selected block not found in feeds source');
 			}
+			self::$altRegion = $m[1];
 			eval(
 				'function pfb_feeds_oracle_alt_selected(): array {'
 				. ' $fconfig = array(); $input_errors = array(); $config_mod = FALSE; '
@@ -49,6 +51,12 @@ final class FeedsAltSelectedKeyTest extends TestCase
 				. ' return $input_errors; }'
 			);
 		}
+	}
+
+	public function testExtractionStartsAtExecutableCodeNotProductionComment(): void
+	{
+		$this->assertStringStartsWith("if (isset(\$_POST['alt_selected']))", self::$altRegion);
+		$this->assertStringNotContainsString('Save all', self::$altRegion);
 	}
 
 	protected function setUp(): void

--- a/tests/php/FeedsCustomOutputEncodingTest.php
+++ b/tests/php/FeedsCustomOutputEncodingTest.php
@@ -20,11 +20,13 @@ final class FeedsCustomOutputEncodingTest extends TestCase
 			throw new RuntimeException('failed to read pfblockerng_feeds.php');
 		}
 
-		$start = strpos($src, "\t\t\t\t<?php\n\t\t\t\t// issue #1496:");
+		$table = strpos($src, "\n\t\t\t<tbody>\n");
+		$start = strpos($src, "\t\t\t\t\$p_type = '';", $table === false ? 0 : $table);
 		$end   = strpos($src, "\n\t\t\t<tbody>\n\t\t\t</table>", $start === false ? 0 : $start);
 		if ($start === false || $end === false || $end <= $start) {
 			throw new RuntimeException('could not locate the custom-feed row template');
 		}
+		$this->assertStringNotContainsString('issue #1496', substr($src, $start, $end - $start));
 
 		$ex_feeds = ['ipv4' => [[
 			'aliasname' => 'InvalidUtf8Feed',
@@ -36,7 +38,7 @@ final class FeedsCustomOutputEncodingTest extends TestCase
 		$type_label = ['ipv4' => 'IPv4'];
 
 		ob_start();
-		eval('?>' . substr($src, $start, $end - $start));
+		eval('?>' . "<?php\n" . substr($src, $start, $end - $start));
 		return (string) ob_get_clean();
 	}
 

--- a/tests/php/GeneralAllowlistEditorWiringTest.php
+++ b/tests/php/GeneralAllowlistEditorWiringTest.php
@@ -4,122 +4,19 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1875 step 2a (RED, test-first): mounting the CM6 editor on the General page's
- * internal-feed-allowlist field (pfb_feed_internal_allowlist), gated by the same
- * `$pfb_syntaxhl_on` boolean idiom pfblockerng_dnsbl.php already establishes
- * (`pfb_editor_enabled()`, the issue #1887 named accessor).
- *
- * Not to be confused with GeneralSyntaxHighlightToggleWiringTest, which pins the
- * pfb_syntax_highlight TOGGLE FIELD itself (the checkbox the user flips); this test pins the
- * CM6 mount that the toggle gates on THIS page's own plaintext-list field.
- *
- * pfblockerng_general.php already has a `pfb_syntax_highlight` $pconfig entry and reads it
- * via `pfb_cfg_toggle_read($pconfig['pfb_syntax_highlight']) === PfbToggle::On` for the
- * toggle checkbox's `checked` state (line ~353) -- but has NO `$pfb_syntaxhl_on` boolean and
- * NO cm-regex.min.js include today (verified this session); the pre-existing
- * events.push(function() {...}) block at ~line 594 only wires the internal-filter grey-out,
- * unrelated to CM6. Step 2b must add the boolean, the gated script include, and the gated
- * mountLists init inside that SAME events.push() block.
- *
- * pfblockerng_general.php carries top-level render execution and cannot be require()d off-
- * appliance (same constraint as DnsblRegexHighlightWiringTest); reading the real source file
- * IS reading the render for this content -- this is the Tier-A ui_render coverage for this
- * page's rollout.
- *
- * Split: every wiring assertion below is RED today (none of it exists yet). The
- * Form_Textarea field pin is GREEN today by design: it pins the existing POST contract,
- * which step 2b's client-side-only overlay must not touch -- mixed red/green within this
- * file is expected and is the point.
- */
 final class GeneralAllowlistEditorWiringTest extends TestCase
 {
-	private static string $src;
-
-	public static function setUpBeforeClass(): void
+	public function testDisabledEditorEmitsNoAllowlistMount(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_general.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_general.php');
-		}
-		self::$src = $src;
+		$this->assertSame('', pfb_general_editor_render(FALSE)['lists']);
 	}
 
-	public function testGatingBooleanReadsThePfbSyntaxHighlightToggle(): void
+	public function testEnabledEditorMountsTheInternalAllowlistField(): void
 	{
-		// LENIENT, not PfbToggle -- same rationale as DnsblRegexHighlightWiringTest's
-		// class docblock. This must be a NEW `$pfb_syntaxhl_on = ...` assignment, distinct
-		// from the pre-existing `pfb_cfg_lenient_read($pconfig['pfb_syntax_highlight'])
-		// === PfbLenient::On` inline comparison that drives the toggle checkbox's checked
-		// state (line ~353) -- that inline comparison does not assign to $pfb_syntaxhl_on.
-		$this->assertMatchesRegularExpression(
-			"#\\\$pfb_syntaxhl_on\\s*=\\s*pfb_editor_enabled\\(\\)#",
-			self::$src,
-			'expected a $pfb_syntaxhl_on boolean derived from pfb_editor_enabled() (issue #1887 named accessor)'
-		);
-	}
+		$init = pfb_general_editor_render(TRUE)['lists'];
 
-	public function testCmRegexScriptIsIncludedWithCacheBustingInsideTheGate(): void
-	{
-		// Tempered-dot gaps ((?:(?!endif).)*?), not bare .*? -- see
-		// DnsblRegexHighlightWiringTest's rationale for why bare .*? risks bridging past
-		// this gate's own endif.
-		$this->assertMatchesRegularExpression(
-			'#if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. '<script src="vendor/codemirror/cm-regex\.min\.js\?v=<\?=pfb_file_mtime\(\'/usr/local/www/pfblockerng/vendor/codemirror/cm-regex\.min\.js\'\)\?>"></script>'
-			. '(?:(?!endif).)*?endif#s',
-			self::$src,
-			'expected the cm-regex.min.js include, with mtime cache-busting, wrapped inside an if ($pfb_syntaxhl_on) gate'
-		);
-	}
-
-	public function testMountListsCallIsGatedInsideEventsPushBehindTheSyntaxHighlightBoolean(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'#events\.push\(function\(\)\s*\{(?:(?!endif).)*?if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. 'window\.pfbCM(?:(?!endif).)*?pfbCM\.mountLists\((?:(?!endif).)*?endif#s',
-			self::$src,
-			'expected a pfbCM.mountLists( call, guarded on window.pfbCM, inside the '
-			. 'existing events.push() block gated by if ($pfb_syntaxhl_on)'
-		);
-	}
-
-	public function testMountListsArrayContainsTheTargetFieldId(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#pfbCM\\.mountLists\\(\\s*\\[(?:(?!\\]).)*?'pfb_feed_internal_allowlist'(?:(?!\\]).)*?\\]\\s*\\)#s",
-			self::$src,
-			"expected 'pfb_feed_internal_allowlist' inside the pfbCM.mountLists([...]) array argument"
-		);
-	}
-
-	/**
-	 * Vacuity-safe "off emits nothing new" proof, same rationale as
-	 * DnsblRegexHighlightWiringTest::testCmRegexAssetAndFromTextareaCallEachAppearExactlyOnceInTheWholeFile.
-	 */
-	public function testCmRegexAssetAndMountListsCallEachAppearExactlyOnceInTheWholeFile(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(self::$src, '<script src="vendor/codemirror/cm-regex.min.js?v='),
-			'expected exactly one cm-regex.min.js <script> tag in the whole file (the gated include) -- '
-			. 'a second, unguarded <script> tag would defeat the off-emits-nothing contract'
-		);
-		$this->assertSame(
-			1,
-			substr_count(self::$src, 'pfbCM.mountLists('),
-			'expected exactly one pfbCM.mountLists( call in the whole file (the gated events.push init) -- '
-			. 'a second, unguarded call would defeat the off-emits-nothing contract'
-		);
-	}
-
-	public function testOriginalInternalAllowlistTextareaFieldIsUnchanged(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'pfb_feed_internal_allowlist',#",
-			self::$src,
-			'expected the underlying pfb_feed_internal_allowlist Form_Textarea field to remain unchanged'
-		);
+		$this->assertStringContainsString('window.pfbCM', $init);
+		$this->assertSame(1, substr_count($init, 'pfbCM.mountLists('));
+		$this->assertStringContainsString('pfb_feed_internal_allowlist', $init);
 	}
 }

--- a/tests/php/GeneralSyntaxHighlightToggleWiringTest.php
+++ b/tests/php/GeneralSyntaxHighlightToggleWiringTest.php
@@ -4,143 +4,35 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1669 slice C -- General-settings `pfb_syntax_highlight` toggle wiring on
- * pfblockerng_general.php (registered in pfb_cfg_registry(), default on; gates the
- * CodeMirror 6 live-highlight overlay wired on pfblockerng_dnsbl.php -- see
- * DnsblRegexHighlightWiringTest).
- *
- * pfblockerng_general.php carries top-level render execution (require_once('guiconfig.inc')
- * et al.) and cannot be require()d/rendered off-appliance -- same constraint documented on
- * FeedsUrlCompareIconRenderTest/CategoryEditReservedHeaderTest/DnsblRegexHighlightWiringTest.
- * No prior literal-source render test exists for this page, so this one is shaped minimally
- * like DnsblRegexHighlightWiringTest. pfb_syntax_highlight is a default-on checkbox on the
- * merged PfbToggle adapter (issue #1887: Off stores the explicit 'off' token, so the
- * default-on round trip is safe), mirroring this page's existing `pfb_keep`
- * field exactly: PfbConfig::read()->value on load, an explicit 'on'/'off' ternary on save
- * (not pfb_filter(..., PFB_FILTER_ON_OFF, ...) -- pfb_keep does not use it either), and
- * pfb_cfg_toggle_read(...) === PfbToggle::On on render (merged enum, issue #1887).
- */
 final class GeneralSyntaxHighlightToggleWiringTest extends TestCase
 {
-	private static string $src;
+	private const GENERAL_PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_general.php';
 
-	public static function setUpBeforeClass(): void
+	public function testSavePersistsExplicitOnAndOffTokens(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_general.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_general.php');
-		}
-		self::$src = $src;
-	}
-
-	public function testLoadReadsThroughThePfbConfigGateway(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#\\\$pconfig\\['pfb_syntax_highlight'\\]\\s*=\\s*PfbConfig::read\\(\\s*'gen/pfb_syntax_highlight'\\s*\\)->value#",
-			self::$src,
-			'expected $pconfig[\'pfb_syntax_highlight\'] to be loaded via PfbConfig::read(\'gen/pfb_syntax_highlight\')->value, matching the log_syslog precedent'
-		);
-	}
-
-	public function testSaveWritesAnExplicitOnOffTernaryMatchingPfbKeep(): void
-	{
-		// pfb_keep (the exact same default-on-checkbox shape, merged PfbToggle) saves via
-		// an explicit ternary, not pfb_filter(..., PFB_FILTER_ON_OFF, ...) -- an explicit
-		// 'off' write (not '') is the whole point of the explicit Off token: it must survive
-		// the live config round-trip distinguishably from a never-configured install.
-		$this->assertMatchesRegularExpression(
-			"#\\\$pfb\\['gconfig'\\]\\['pfb_syntax_highlight'\\]\\s*=\\s*\\(\\(\\s*\\\$_POST\\['pfb_syntax_highlight'\\]\\s*\\?\\?\\s*''\\s*\\)\\s*===\\s*'on'\\s*\\)\\s*\\?\\s*'on'\\s*:\\s*'off'#",
-			self::$src,
-			'expected the save handler to write an explicit \'on\'/\'off\' ternary for pfb_syntax_highlight, matching the pfb_keep precedent'
-		);
-	}
-
-	public function testSaveIsIncludedInTheWriteSectionCall(): void
-	{
-		// The field must be assigned into $pfb['gconfig'] BEFORE the writeSection() call
-		// so it is actually persisted (a bare PfbConfig::write() before writeSection()
-		// would be clobbered, per the log_syslog / pfb_log_trim_margin_pct precedent).
-		$saveIdx    = strpos(self::$src, "\$pfb['gconfig']['pfb_syntax_highlight']");
-		$sectionIdx = strpos(self::$src, "PfbConfig::writeSection('installedpackages/pfblockerng/config/0', \$pfb['gconfig'])");
-		$this->assertNotFalse($saveIdx, 'expected a $pfb[\'gconfig\'][\'pfb_syntax_highlight\'] save assignment');
-		$this->assertNotFalse($sectionIdx, 'expected the writeSection() call to persist the general section');
-		$this->assertLessThan($sectionIdx, $saveIdx,
-			'expected the pfb_syntax_highlight save assignment to happen before writeSection() persists the section');
-	}
-
-	public function testCheckboxRendersWithTheTogglePrecedentIdiom(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Checkbox\\(\\s*'pfb_syntax_highlight',#",
-			self::$src,
-			'expected a Form_Checkbox(\'pfb_syntax_highlight\', ...) field'
-		);
-		$this->assertMatchesRegularExpression(
-			"#pfb_cfg_toggle_read\\(\\\$pconfig\\['pfb_syntax_highlight'\\]\\)\\s*===\\s*PfbToggle::On#",
-			self::$src,
-			'expected the checkbox\'s checked state to be pfb_cfg_toggle_read($pconfig[\'pfb_syntax_highlight\']) === PfbToggle::On'
-		);
-	}
-
-	public function testHelpTextMentionsSkippingAssetsWhenDisabled(): void
-	{
-		$this->assertStringContainsString(
-			'skips loading the editor assets',
-			self::$src,
-			'expected the checkbox help text to document that disabling it skips loading the editor assets'
-		);
+		$this->assertSame('on', pfb_general_toggle_stored_value('on'));
+		$this->assertSame('off', pfb_general_toggle_stored_value(''));
+		$this->assertSame('off', pfb_general_toggle_stored_value(NULL));
+		$this->assertSame('off', pfb_general_toggle_stored_value(['on']));
 	}
 
 	/**
-	 * issue #1888: the toggle gates the whole CM6 editor -- highlighting (#1669), the
-	 * lineNumbers gutter (#1869), the server + Lezer bracket lint (#1732) and undo/redo
-	 * history -- so its label is the editor, not one of its features.
+	 * #993: the page-save request reaches pfSense globals and sync orchestration, so it is
+	 * not executable off-appliance; pin only its helper binding. php_strip_whitespace() makes
+	 * comments and docblocks irrelevant to this assertion. Render behavior stays in smoke UI.
 	 */
-	public function testCheckboxIsLabelledForTheWholeEditor(): void
+	public function testGeneralPageSaveBindsTheToggleHelper(): void
 	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Checkbox\\(\\s*'pfb_syntax_highlight',\\s*'Advanced Text Editor',#",
-			self::$src,
-			'expected the pfb_syntax_highlight checkbox to be labelled \'Advanced Text Editor\''
-		);
-		$this->assertStringNotContainsString(
-			"'Syntax Highlighting',",
-			self::$src,
-			'expected no leftover \'Syntax Highlighting\' field label'
-		);
-	}
+		$source = php_strip_whitespace(self::GENERAL_PAGE);
+		$start  = "if (isset(\$_POST['save'])) {";
+		$end    = 'PfbConfig::writeSection(';
+		$from   = strpos($source, $start);
+		$to     = $from === FALSE ? FALSE : strpos($source, $end, $from + strlen($start));
 
-	/**
-	 * issue #1888: the help text must name what the editor actually provides, not
-	 * highlighting alone -- each feature is wired in tools/webassets/cm-shell.js
-	 * (lineNumbers, history) and cm-lint.js (lintGutter + linter). Asserted against the
-	 * field's OWN setHelp() argument, never the whole page: the page's comments talk
-	 * about syntax highlighting too, so a whole-source assertion would pass vacuously.
-	 */
-	public function testHelpTextDocumentsTheEditorFeatures(): void
-	{
-		$matched = preg_match(
-			"#new Form_Checkbox\\(\\s*'pfb_syntax_highlight',.*?\\)\\)->setHelp\\((.*?)\\);#s",
-			self::$src,
-			$m
-		);
-		$this->assertSame(1, $matched, 'expected a setHelp() call on the pfb_syntax_highlight checkbox');
-		foreach ([
-			'syntax highlighting',
-			'line numbers',
-			'linting',
-			'undo/redo',
-			'list and script fields',
-			'plain text boxes',
-			'server-side',
-		] as $feature) {
-			$this->assertStringContainsString(
-				$feature,
-				$m[1],
-				"expected the checkbox help text to document the editor's {$feature}"
-			);
-		}
+		$this->assertNotFalse($from, 'general page save branch must remain present');
+		$this->assertNotFalse($to, 'general page save must persist through the config gateway');
+		$window = substr($source, $from, $to - $from);
+		$needle = "\$pfb['gconfig']['pfb_syntax_highlight'] = pfb_general_toggle_stored_value(";
+		$this->assertSame(1, substr_count($window, $needle), 'save branch must bind the toggle helper exactly once');
 	}
 }

--- a/tests/php/GeoipContinentCatStderrGuardTest.php
+++ b/tests/php/GeoipContinentCatStderrGuardTest.php
@@ -4,252 +4,76 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1299: the web-owned pfblockerng_uc_countries() continent-file ISO
- * append `exec("cat ... 2>&1")` merges cat's stderr into the continent `.txt`
- * data file. A cat failure (any cause --
- * a TOCTOU race, permission denial, etc.) writes stderr text (e.g.
- * "cat: <path>: Is a directory") into the file as if it were feed data;
- * the package-owned pfblockerng_get_countries() reparse
- * (`elseif (!str_starts_with($line, '#'))`) then treats that line as real network data and
- * persists it verbatim. This is the corruption sibling of issue
- * #1261/PR #1268, which fixed only the "blanking" half (`?? 0` ->
- * `?? 'ERROR'`), not this half.
- *
- * The file carries top-level execution and cannot be require()d
- * off-appliance (house precedent: CountryNetworksCountGuardTest.php). The
- * exec() call is eval-extracted verbatim from the real source into an
- * oracle driven by the REAL /bin/cat binary against a real fixture -- a
- * directory used as $iso_file (file_exists() TRUE, cat fails) -- so the
- * same test proves red on the pre-fix `2>&1` and green after its removal,
- * with zero mocking of exec()/cat itself.
- *
- * Feature: a cat failure while building the continent file must never
- *          write bogus stderr text into that data file
- *
- *   Scenario: $iso_file is a directory (file_exists() TRUE, cat fails)
- *             -> the continent file must stay untouched by the append
- */
 final class GeoipContinentCatStderrGuardTest extends TestCase
 {
-	private static string $src;
-	private static string $tmpDir;
+	private string $dir;
 
-	public static function setUpBeforeClass(): void
+	protected function setUp(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php';
-		$src = file_get_contents($path);
-		if ($src === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng.php');
-		}
-		self::$src = $src;
-
-		self::$tmpDir = sys_get_temp_dir() . '/pfb_geoip_cat_stderr_' . getmypid();
-		if (!@mkdir(self::$tmpDir, 0777, TRUE) && !is_dir(self::$tmpDir)) {
-			throw new RuntimeException('test bootstrap: failed to create tmp dir ' . self::$tmpDir);
-		}
-
-		// Oracle: the ISO-append status-handling block, extracted verbatim so
-		// the real command and its failure cleanup execute in this test.
-		if (!function_exists('pfb_cat_append_oracle')) {
-			if (!preg_match(
-				'/(?:\$cat_output\s*=\s*array\(\);\s*\$cat_status\s*=\s*0;\s*)?'
-				. 'exec\("\{\$pfb\[\'cat\'\]\} \{\$iso_file_esc\} >> \{\$pfb_file_esc\}( 2>&1)?"'
-				. '(?:,\s*\$cat_output,\s*\$cat_status)?\);'
-				. '(?:\s*if \(\$cat_status !== 0\) \{.*?return FALSE;\s*\})?/s',
-				$src,
-				$m
-			)) {
-				throw new RuntimeException('oracle extraction failed: the cat-append status block was not found in pfblockerng.php');
-			}
-			$block = str_replace(
-				['pfb_logger(', 'rmdir_recursive('],
-				['pfb_geoip_test_logger(', 'pfb_geoip_test_rmdir_recursive('],
-				$m[0]
-			);
-			eval(
-				'function pfb_cat_append_oracle('
-				. 'string $iso_file, string $pfb_file, string $cat = "/bin/cat", string $iso = "US", string $type = "4"'
-				. '): bool {'
-				. ' $pfb = ["cat" => $cat, "ccdir_tmp" => dirname($pfb_file) . "/build_tmp"];'
-				. ' $iso_file_esc = escapeshellarg($iso_file);'
-				. ' $pfb_file_esc = escapeshellarg($pfb_file);'
-				. ' ' . $block
-				. ' return TRUE;'
-				. ' }'
-			);
-		}
+		$this->dir = sys_get_temp_dir() . '/pfb_geoip_cat_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
 	}
 
-	public static function tearDownAfterClass(): void
+	protected function tearDown(): void
 	{
-		foreach (glob(self::$tmpDir . '/*') ?: [] as $f) {
-			is_dir($f) ? @rmdir($f) : @unlink($f);
+		foreach (glob($this->dir . '/*') ?: [] as $file) {
+			is_dir($file) ? @rmdir($file) : @unlink($file);
 		}
-		@rmdir(self::$tmpDir);
+		@rmdir($this->dir);
 	}
 
-	private function makeCatFixture(string $name, string $body): string
+	public function testCatFailureDiscardsPartialOutputAndTemporaryState(): void
 	{
-		$path = self::$tmpDir . '/' . $name;
+		$cat = $this->catFixture("printf 'partial-network\\n'\nexit 7\n");
+		$iso = $this->dir . '/US_v4.txt';
+		$continent = $this->dir . '/continent_v4.txt';
+		$tmp = $this->dir . '/build_tmp';
+		mkdir($tmp, 0700);
+		file_put_contents($tmp . '/working', 'temporary');
+		file_put_contents($iso, "ignored\n");
+		file_put_contents($continent, "# header\n");
+
+		$this->assertFalse(pfb_geoip_append_iso_data(
+			$cat, $iso, $continent, $tmp, 'US', '4', static function (): void {}
+		));
+		$this->assertFileDoesNotExist($continent);
+		$this->assertDirectoryDoesNotExist($tmp);
+	}
+
+	public function testCatSuccessAppendsOnlyStdout(): void
+	{
+		$cat = $this->catFixture("printf 'network-v4\\n'\n");
+		$iso = $this->dir . '/US_v4.txt';
+		$continent = $this->dir . '/continent_v4.txt';
+		$tmp = $this->dir . '/build_tmp';
+		mkdir($tmp, 0700);
+		file_put_contents($iso, "ignored\n");
+		file_put_contents($continent, "# header\n");
+
+		$this->assertTrue(pfb_geoip_append_iso_data($cat, $iso, $continent, $tmp, 'US', '4'));
+		$this->assertSame("# header\nnetwork-v4\n", file_get_contents($continent));
+	}
+
+	public function testDirectoryInputFailsWithoutWritingCatStderr(): void
+	{
+		$iso = $this->dir . '/unreadable_iso';
+		mkdir($iso, 0700);
+		$continent = $this->dir . '/continent_v4.txt';
+		$tmp = $this->dir . '/build_tmp';
+		mkdir($tmp, 0700);
+		file_put_contents($continent, "# header\n");
+
+		$this->assertFalse(pfb_geoip_append_iso_data(
+			'/bin/cat', $iso, $continent, $tmp, 'US', '4', static function (): void {}
+		));
+		$this->assertFileDoesNotExist($continent);
+	}
+
+	private function catFixture(string $body): string
+	{
+		$path = $this->dir . '/cat-' . bin2hex(random_bytes(4));
 		file_put_contents($path, "#!/bin/sh\n{$body}");
 		chmod($path, 0755);
 		return $path;
 	}
-
-	public function testPartialStdoutFailureIsDiscardedAndReported(): void
-	{
-		$cat = $this->makeCatFixture('partial-cat', "printf 'partial-network\\n'\nexit 7\n");
-		$isoFile = self::$tmpDir . '/US_v4.txt';
-		$pfbFile = self::$tmpDir . '/continent_partial_v4.txt';
-		$buildTmp = self::$tmpDir . '/build_tmp';
-		pfb_geoip_test_rmdir_recursive($buildTmp);
-		mkdir($buildTmp);
-		file_put_contents($buildTmp . '/working', 'temporary');
-		file_put_contents($isoFile, "ignored\n");
-		file_put_contents($pfbFile, "# header\n");
-		$GLOBALS['pfb_geoip_test_logs'] = [];
-
-		$result = pfb_cat_append_oracle($isoFile, $pfbFile, $cat, 'US', '4');
-
-		$this->assertFalse($result);
-		$this->assertFileDoesNotExist($pfbFile, 'failed append must discard header plus partial stdout');
-		$this->assertDirectoryDoesNotExist($buildTmp, 'failed build must clean temporary state');
-		$this->assertSame([["\n Failed to append ISO data [ US IPv4 ] (cat status 7)\n", 4]], $GLOBALS['pfb_geoip_test_logs']);
-	}
-
-	public function testFailureWithoutStdoutIsDiscardedAndReported(): void
-	{
-		$cat = $this->makeCatFixture('silent-cat', "exit 9\n");
-		$isoFile = self::$tmpDir . '/CA_v6.txt';
-		$pfbFile = self::$tmpDir . '/continent_silent_v6.txt';
-		$buildTmp = self::$tmpDir . '/build_tmp';
-		pfb_geoip_test_rmdir_recursive($buildTmp);
-		mkdir($buildTmp);
-		file_put_contents($isoFile, "ignored\n");
-		file_put_contents($pfbFile, "# header\n");
-		$GLOBALS['pfb_geoip_test_logs'] = [];
-
-		$result = pfb_cat_append_oracle($isoFile, $pfbFile, $cat, 'CA', '6');
-
-		$this->assertFalse($result);
-		$this->assertFileDoesNotExist($pfbFile);
-		$this->assertDirectoryDoesNotExist($buildTmp);
-		$this->assertSame([["\n Failed to append ISO data [ CA IPv6 ] (cat status 9)\n", 4]], $GLOBALS['pfb_geoip_test_logs']);
-	}
-
-	public function testCatFailureOnUnreadableIsoDoesNotCorruptContinentFile(): void
-	{
-		// A directory: file_exists() is TRUE (passes the source guard unchanged),
-		// but cat fails to read it -- a real, unmocked failure,
-		// not chmod-based (chmod denial is meaningless under root; a
-		// directory fails identically root or not).
-		$isoDir = self::$tmpDir . '/unreadable_iso_v4';
-		@mkdir($isoDir, 0777, TRUE);
-		$this->assertTrue(is_dir($isoDir), 'fixture must be a real directory to reproduce "cat: ...: Is a directory"');
-		$this->assertTrue(file_exists($isoDir), 'fixture must pass the source file_exists() guard unchanged');
-
-		$pfbFile = self::$tmpDir . '/continent_v4.txt';
-		file_put_contents($pfbFile, "# partial continent output\n");
-
-		$result = pfb_cat_append_oracle($isoDir, $pfbFile);
-
-		$this->assertFalse($result, 'cat failure must be reported to the conversion caller');
-		$this->assertFileDoesNotExist($pfbFile, 'failed conversion must discard partial continent output');
-	}
-
-	public function testCatAppendExecDoesNotMergeStderrIntoDataFile(): void
-	{
-		// Assert against the single extracted exec() line, not the whole
-		// source string -- keeps the failure diff readable (the whole-source
-		// form dumps the full source on failure).
-		if (!preg_match(
-			'/exec\("\{\$pfb\[\'cat\'\]\} \{\$iso_file_esc\} >> \{\$pfb_file_esc\}( 2>&1)?"'
-			. '(?:,\s*\$cat_output,\s*\$cat_status)?\);/',
-			self::$src,
-			$m
-		)) {
-			$this->fail('the cat-append exec() call was not found in pfblockerng.php');
-		}
-		$this->assertStringNotContainsString(
-			'2>&1',
-			$m[0],
-			"issue #1299: the continent-file cat append must not redirect cat's stderr (2>&1) into the data file -- got: {$m[0]}"
-		);
-	}
-
-	/** @return array<string, array{string}> */
-	public static function ipVersionProvider(): array
-	{
-		return [
-			'IPv4' => ['v4'],
-			'IPv6' => ['v6'],
-		];
-	}
-
-	#[\PHPUnit\Framework\Attributes\DataProvider('ipVersionProvider')]
-	public function testCatSuccessAppendsNetworksAndReportsTrue(string $type): void
-	{
-		$isoFile = self::$tmpDir . "/US_{$type}.txt";
-		$pfbFile = self::$tmpDir . "/continent_{$type}_success.txt";
-		file_put_contents($isoFile, "network-{$type}\n");
-		file_put_contents($pfbFile, "# header {$type}\n");
-
-		$this->assertTrue(pfb_cat_append_oracle($isoFile, $pfbFile));
-		$this->assertSame("# header {$type}\nnetwork-{$type}\n", file_get_contents($pfbFile));
-	}
-
-	public function testBuilderReportsSuccessAfterAllContinentRows(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/rmdir_recursive\("\{\$pfb\[\'ccdir_tmp\'\]\}"\);\s*return TRUE;\s*}/',
-			self::$src,
-			'pfblockerng_uc_countries() must report successful completion to paired callers'
-		);
-	}
-
-	public function testDcAndDccGateCountryGenerationOnConversionSuccess(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/case \'dc\':.*?case \'dcc\':.*?if \(pfblockerng_uc_countries\(\)\) \{\s*pfblockerng_get_countries\(\);\s*}/s',
-			self::$src
-		);
-	}
-
-	public function testUgcGatesCountryGenerationOnConversionSuccess(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/case \'ugc\':\s*if \(pfblockerng_uc_countries\(\)\) \{\s*pfblockerng_get_countries\(\);\s*}/s',
-			self::$src
-		);
-	}
-
-	public function testStandaloneUcAndGcDispatchRemainIndependent(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/case \'uc\':.*?pfblockerng_uc_countries\(\);\s*break;\s*case \'gc\':.*?pfblockerng_get_countries\(\);\s*break;/s',
-			self::$src
-		);
-	}
-
-	public function testCountryBuildUsesSameAppendGuardForIpv4AndIpv6(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/foreach \(array\(\'4\', \'6\'\) as \$type\).*?' . preg_quote('exec("{$pfb[\'cat\']} {$iso_file_esc} >> {$pfb_file_esc}"', '/') . '/s',
-			self::$src
-		);
-	}
-}
-
-function pfb_geoip_test_logger(string $message, int $level): void
-{
-	$GLOBALS['pfb_geoip_test_logs'][] = [$message, $level];
-}
-
-function pfb_geoip_test_rmdir_recursive(string $path): void
-{
-	foreach (glob($path . '/*') ?: [] as $entry) {
-		is_dir($entry) ? pfb_geoip_test_rmdir_recursive($entry) : unlink($entry);
-	}
-	@rmdir($path);
 }

--- a/tests/php/GeoipDocLinkTest.php
+++ b/tests/php/GeoipDocLinkTest.php
@@ -4,33 +4,17 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1215 — the GeoIP continent page's NOTES section links out to MaxMind's
- * "What's new in GeoIP2" document. MaxMind retired the `/geoip/geoip2/...` path
- * in a site restructure, so the shipped link 404'd. This is a source tripwire:
- * the page must carry the live document path and must not reintroduce the
- * retired one (external liveness itself cannot be asserted in CI — the check is
- * that the retired path stays gone).
- */
+/** issue #1215 — the generated GeoIP page renders the MaxMind notes link helper. */
 final class GeoipDocLinkTest extends TestCase
 {
-	private const PFBLOCKERNG_GEOIP = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc';
-
 	private const LIVE_DOC_URL    = 'https://dev.maxmind.com/geoip/whats-new-in-geoip2/';
 	private const RETIRED_DOC_URL = 'https://dev.maxmind.com/geoip/geoip2/whats-new-in-geoip2/';
-
-	private function pageSource(): string
-	{
-		$source = file_get_contents(self::PFBLOCKERNG_GEOIP);
-		$this->assertNotFalse($source, 'failed to read pfblockerng_geoip.inc');
-		return $source;
-	}
 
 	public function testGeoipNotesLinkUsesTheLiveMaxmindDocPath(): void
 	{
 		$this->assertStringContainsString(
 			'href="' . self::LIVE_DOC_URL . '"',
-			$this->pageSource(),
+			pfb_geoip_doc_link(),
 			"issue #1215: the \"What's new in GeoIP2\" link must point at MaxMind's current doc path"
 		);
 	}
@@ -39,7 +23,7 @@ final class GeoipDocLinkTest extends TestCase
 	{
 		$this->assertStringNotContainsString(
 			self::RETIRED_DOC_URL,
-			$this->pageSource(),
+			pfb_geoip_doc_link(),
 			'issue #1215: the retired /geoip/geoip2/ doc path 404s and must not come back'
 		);
 	}

--- a/tests/php/GeoipOrigTrailingNewlineWiringTest.php
+++ b/tests/php/GeoipOrigTrailingNewlineWiringTest.php
@@ -4,41 +4,90 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1263: the GeoIP continent builder rewrites a stored '.orig' via
- * @rename() OUTSIDE pfb_download() -- its newline-termination guarantee never
- * runs on this path either. Source-inspection pin, same rationale as
- * GunzipTrailingNewlineWiringTest.
- */
+/** GeoIP publication orders rename, newline normalization, mirror, then consumer. */
 final class GeoipOrigTrailingNewlineWiringTest extends TestCase
 {
-	private static string $source;
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	private string $dir;
 
 	public static function setUpBeforeClass(): void
 	{
-		$source = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
-		);
-		if ($source === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
-		}
-		self::$source = $source;
+		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
 	}
 
-	public function testEnsureTrailingNewlineRunsAfterTheGeoipRename(): void
+	protected function setUp(): void
 	{
-		$renamePos = strpos(self::$source, '@rename("{$pfb[\'geoip_tmp\']}", "{$pfborig}/{$cc_alias}.orig");');
-		$this->assertNotFalse($renamePos, 'vacuity: the GeoIP continent .orig rename site must exist');
+		$this->dir = sys_get_temp_dir() . '/pfb geoip; ' . getmypid() . " 'fixture'";
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
 
-		$copyPos = strpos(
-			self::$source,
-			'@copy("{$pfborig}/{$cc_alias}.orig", "{$pfbfolder}/{$cc_alias}.txt");',
-			$renamePos
-		);
-		$this->assertNotFalse($copyPos, 'vacuity: the following .txt mirror copy must exist');
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->dir}/*") ?: [] as $path) {
+			@unlink($path);
+		}
+		@rmdir($this->dir);
+	}
 
-		$between = substr(self::$source, $renamePos, $copyPos - $renamePos);
-		$this->assertStringContainsString('pfb_ensure_trailing_newline("{$pfborig}/{$cc_alias}.orig")', $between,
-			'the rebuilt .orig must be normalized before the .txt mirror copy propagates its raw bytes');
+	public function testPublicationPipelineOrdersMirrorBeforeConsumer(): void
+	{
+		$source = "{$this->dir}/continent; 'tmp'";
+		$orig = "{$this->dir}/continent.orig";
+		$mirror = "{$this->dir}/continent.txt";
+		$events = [];
+		$this->assertNotFalse(file_put_contents($source, '192.0.2.0/24'));
+
+		$this->assertTrue(pfb_apply_geoip_orig_pipeline($source, $orig, $mirror,
+			static function (string $published, string $mirrored) use (&$events): void {
+				$events[] = 'consume';
+				$events[] = is_file($published) && is_file($mirrored)
+					? (string) file_get_contents($mirrored) : 'missing';
+			}
+		));
+
+		$this->assertSame(['consume', "192.0.2.0/24\n"], $events);
+		$this->assertFileDoesNotExist($source);
+		$this->assertSame("192.0.2.0/24\n", file_get_contents($orig));
+		$this->assertSame(file_get_contents($orig), file_get_contents($mirror));
+	}
+
+	public function testRenameFailurePreservesLegacyConsumerAttempt(): void
+	{
+		$orig = "{$this->dir}/continent.orig";
+		$mirror = "{$this->dir}/continent.txt";
+		$events = [];
+
+		$this->assertFalse(pfb_apply_geoip_orig_pipeline("{$this->dir}/missing", $orig, $mirror,
+			static function () use (&$events): void { $events[] = 'consume'; }
+		));
+
+		$this->assertSame(['consume'], $events);
+		$this->assertFileDoesNotExist($mirror);
+	}
+
+	public function testEmptyPublicationPreservesLegacyMirrorAndConsumerAttempt(): void
+	{
+		$source = "{$this->dir}/empty.tmp";
+		$orig = "{$this->dir}/empty.orig";
+		$mirror = "{$this->dir}/empty.txt";
+		$events = [];
+		$this->assertNotFalse(file_put_contents($source, ''));
+
+		$this->assertFalse(pfb_apply_geoip_orig_pipeline($source, $orig, $mirror,
+			static function () use (&$events): void { $events[] = 'consume'; }
+		));
+
+		$this->assertSame(['consume'], $events);
+		$this->assertFileExists($mirror);
+		$this->assertSame('', file_get_contents($mirror));
+	}
+
+	/** The live GeoIP branch is part of the #993 sync monolith; behavior runs above. */
+	public function testSyncPassDispatchesTheGeoipPublicationPipeline(): void
+	{
+		$source = php_strip_whitespace(self::APPLY);
+		$start = strpos($source, 'function sync_package_pfblockerng(');
+		$this->assertNotFalse($start);
+		$this->assertSame(1, substr_count(substr($source, $start), 'pfb_apply_geoip_orig_pipeline('));
 	}
 }

--- a/tests/php/GeoipPackageGenerationCoverageTest.php
+++ b/tests/php/GeoipPackageGenerationCoverageTest.php
@@ -7,17 +7,28 @@ use PHPUnit\Framework\TestCase;
 /**
  * Independent coverage for issue #1576's package seam.
  *
- * The installer is deliberately checked statically: executing install.inc would
- * perform appliance-only config migrations and service changes. Live install
- * smoke remains an explicit appliance validation step.
+ * Generation runs behaviorally against temporary output. Installer dispatch stays
+ * static because executing install.inc performs appliance-only migrations and
+ * service changes; comment-free PHP keeps that pin independent of prose.
  */
 final class GeoipPackageGenerationCoverageTest extends TestCase
 {
+	private static string $installSource;
 	private string $tmp;
 	private string $ccdir;
 	private string $output;
 	private mixed $originalPfb;
 	private bool $hadPfb = FALSE;
+
+	public static function setUpBeforeClass(): void
+	{
+		self::$installSource = php_strip_whitespace(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc'
+		);
+		if (self::$installSource === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free install source');
+		}
+	}
 
 	protected function setUp(): void
 	{
@@ -59,30 +70,25 @@ final class GeoipPackageGenerationCoverageTest extends TestCase
 		}
 	}
 
-	public function testPackageBootstrapAndInstallerWiring(): void
+	public function testPackageGeoipInterfaceGeneratesCountryAndReputationArtifacts(): void
 	{
 		$this->assertTrue(function_exists('pfblockerng_get_countries'));
 		$this->assertTrue(function_exists('pfb_build_reputation_tab'));
-
-		$phpunit = (string) file_get_contents(dirname(__DIR__, 2) . '/phpunit.xml');
-		$this->assertStringContainsString(
-			'<file>src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc</file>',
-			$phpunit
-		);
-
-		$installer = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc'
-		);
-		$this->assertStringContainsString(
-			"require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');",
-			$installer
-		);
-		$this->assertStringNotContainsString(
-			"require_once('/usr/local/www/pfblockerng/pfblockerng.php');",
-			$installer
-		);
-		$this->assertMatchesRegularExpression('/(?m)^\\s*pfblockerng_get_countries\\(\\);/', $installer);
-		$this->assertMatchesRegularExpression('/(?m)^\\s*pfb_build_reputation_tab\\(\\);/', $installer);
+		foreach ([
+			'Africa' => 'Africa', 'Antarctica' => 'Antarctica', 'Asia' => 'Asia', 'Europe' => 'Europe',
+			'North America' => 'North_America', 'Oceania' => 'Oceania', 'South America' => 'South_America',
+			'Proxy and Satellite' => 'Proxy_and_Satellite', 'Top Spammers' => 'Top_Spammers',
+		] as $continent => $slug) {
+			$this->writeContinent($continent, $slug, '4', []);
+			$this->writeContinent($continent, $slug, '6', []);
+		}
+		$this->writeContinent('Africa', 'Africa', '4', [['Alpha', 'AA', ['1.1.1.1']]]);
+		$this->generateWithoutWarnings();
+		$this->assertFileExists("{$this->output}/pfblockerng_Africa.php");
+		$this->assertFileExists("{$this->output}/pfblockerng_reputation.php");
+		$africa = $this->page('Africa');
+		$this->assertStringContainsString('"AA" => "Alpha AA (1)"', $africa);
+		$this->assertStringContainsString('"AA" => "Alpha AA (1)"', (string) file_get_contents("{$this->output}/pfblockerng_reputation.php"));
 	}
 
 	public function testStateMatrixAndSpecialCountryOptionsThroughPackageInterface(): void
@@ -165,6 +171,38 @@ final class GeoipPackageGenerationCoverageTest extends TestCase
 		$this->assertIsInt($zulu);
 		$this->assertLessThan($zulu, $alpha);
 		$this->assertStringNotContainsString('"US_rep" =>', $reputation);
+	}
+
+	/**
+	 * install.inc performs destructive migrations/config writes and cannot be
+	 * included off-appliance; pin its two executable generator dispatches without
+	 * source comments, then verify the generated page emits the shared helper call.
+	 * Comments/docblocks cannot define this dispatch boundary.
+	 */
+	public function testInstallerDispatchesCountryAndReputationGenerators(): void
+	{
+		$countries = strpos(self::$installSource, 'pfblockerng_get_countries();');
+		$reputation = strpos(self::$installSource, 'pfb_build_reputation_tab();');
+		$this->assertNotFalse($countries, 'install.inc must dispatch country-page generation');
+		$this->assertNotFalse($reputation, 'install.inc must dispatch reputation-page generation');
+		$this->assertLessThan($reputation, $countries);
+
+		foreach ([
+			'Africa' => 'Africa',
+			'Antarctica' => 'Antarctica',
+			'Asia' => 'Asia',
+			'Europe' => 'Europe',
+			'North America' => 'North_America',
+			'Oceania' => 'Oceania',
+			'South America' => 'South_America',
+			'Proxy and Satellite' => 'Proxy_and_Satellite',
+			'Top Spammers' => 'Top_Spammers',
+		] as $continent => $slug) {
+			$this->writeContinent($continent, $slug, '4', []);
+			$this->writeContinent($continent, $slug, '6', []);
+		}
+		$this->generateWithoutWarnings();
+		$this->assertStringContainsString('pfb_geoip_doc_link()', $this->page('Africa'));
 	}
 
 	private function generateWithoutWarnings(): void

--- a/tests/php/GroupActionWiringTest.php
+++ b/tests/php/GroupActionWiringTest.php
@@ -4,334 +4,91 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/** Issue #1346 — every independent persisted group-action read must fail closed. */
+/** Group-action validation is shared by GUI, migration, and runtime consumers. */
 final class GroupActionWiringTest extends TestCase
 {
-	private static string $inc;
-	private static string $cron;
-	private static string $category;
-	private static string $alerts;
-	private static string $categoryEdit;
-	private static string $www;
+	public function testValidatorAcceptsOnlyActionsForTheirGroup(): void
+	{
+		foreach (['Disabled', 'Deny_Inbound', 'Permit_Both', 'Alias_Native'] as $action) {
+			$this->assertTrue(pfb_group_action_valid($action, 'ipv4'), "valid IP action rejected: {$action}");
+			$this->assertTrue(pfb_group_action_valid($action, 'geoip'), "valid GeoIP action rejected: {$action}");
+		}
+		$this->assertTrue(pfb_group_action_valid('unbound', 'dnsbl'));
+		$this->assertFalse(pfb_group_action_valid('Deny_Inbound', 'dnsbl'));
+		$this->assertFalse(pfb_group_action_valid('unbound', 'ipv4'));
+		$this->assertFalse(pfb_group_action_valid('Deny_Inbound', 'unknown'));
+		$this->assertFalse(pfb_group_action_valid(['Deny_Inbound'], 'ipv4'));
+	}
 
-	public static function setUpBeforeClass(): void
+	public function testDnsblIpBoundaryNormalizesInvalidPersistedActions(): void
+	{
+		$this->assertSame('Deny_Both', pfb_dnsblip_action_value('Deny_Both'));
+		$this->assertSame('Disabled', pfb_dnsblip_action_value('unbound'));
+		$this->assertSame('Disabled', pfb_dnsblip_action_value(NULL));
+	}
+
+	public function testMatchdirHeaderPlanDoesNotClassifyInvalidActionsAsDeny(): void
+	{
+		$plan = pfb_matchdir_config_headers(
+			['_v4' => [
+				['action' => 'Deny_Inbound', 'aliasname' => 'Good', 'custom' => '1', 'row' => []],
+				['action' => 'not-an-action', 'aliasname' => 'Bad', 'custom' => '1', 'row' => []],
+			]],
+			['action' => 'Deny_Both'],
+			['Europe' => ['action' => 'Deny_Outbound']]
+		);
+		$this->assertSame(['Good_custom_v4', 'Bad_custom_v4'], $plan['match']);
+		$this->assertContains('Good_custom_v4', $plan['deny']);
+		$this->assertContains('DNSBLIP_v4', $plan['deny']);
+		$this->assertContains('DNSBLIP_v6', $plan['deny']);
+		$this->assertContains('Europe_v4', $plan['deny']);
+		$this->assertContains('Europe_v6', $plan['deny']);
+		$this->assertNotContains('Bad_custom_v4', $plan['deny']);
+	}
+
+	public function testMatchdirHeaderPlanRetainsRowsIndependentlyOfAction(): void
+	{
+		$plan = pfb_matchdir_config_headers(
+			['_v6' => [['action' => 'Disabled', 'aliasname' => 'Feed', 'row' => [
+				['header' => 'Sample', 'url' => '/var/db/pfblockerng/sample.txt'],
+			]]]],
+			[],
+			[]
+		);
+		$this->assertSame(['Sample_v6'], $plan['match']);
+		$this->assertSame([], $plan['deny']);
+		$this->assertSame([['list' => 'Feed', 'header' => 'Sample', 'url' => '/var/db/pfblockerng/sample.txt']], $plan['rows']);
+	}
+
+	public function testReachablePagesUseTheSharedValidator(): void
 	{
 		$root = dirname(__DIR__, 2);
-		self::$cron = (string) file_get_contents("{$root}/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc");
-		self::$inc = (string) file_get_contents("{$root}/src/usr/local/pkg/pfblockerng/pfblockerng.inc")
-			. "\n" . (string) file_get_contents("{$root}/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc")
-			. "\n" . self::$cron;
-		self::$category = (string) file_get_contents("{$root}/src/usr/local/www/pfblockerng/pfblockerng_category.php");
-		self::$alerts = (string) file_get_contents("{$root}/src/usr/local/www/pfblockerng/pfblockerng_alerts.php");
-		self::$categoryEdit = (string) file_get_contents("{$root}/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php");
-		self::$www = (string) file_get_contents("{$root}/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc");
+		$paths = [
+			"{$root}/src/usr/local/www/pfblockerng/pfblockerng_category.php",
+			"{$root}/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php",
+			"{$root}/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc",
+		];
+		foreach ($paths as $path) {
+			$source = php_strip_whitespace($path);
+			$this->assertNotSame('', $source, "page source missing: {$path}");
+			$this->assertStringContainsString('pfb_group_action_valid(', $source, "shared validator missing: {$path}");
+		}
 	}
 
-	private function assertGuardBeforeActionUse(
-		string $source,
-		string $start,
-		string $end,
-		string $guard,
-		string $actionUse
-	): void {
-		$startPos = strpos($source, $start);
-		$this->assertNotFalse($startPos, "start anchor not found: {$start}");
-		$endPos = strpos($source, $end, $startPos + strlen($start));
-		$this->assertNotFalse($endPos, "end anchor not found: {$end}");
-		$block = substr($source, $startPos, $endPos - $startPos);
-		$guardPos = strpos($block, $guard);
-		$this->assertNotFalse($guardPos, "guard not found between anchors: {$guard}");
-		$usePos = strpos($block, $actionUse);
-		$this->assertNotFalse($usePos, "action use not found between anchors: {$actionUse}");
-		$this->assertTrue($guardPos < $usePos, "guard must precede action use: {$actionUse}");
-	}
-
-	public function testSummaryAjaxUsesSharedGroupValidator(): void
+	/**
+	 * Alerts and cron are appliance-only entrypoints (one exits during dispatch). Keep their
+	 * wiring pin executable-code-only; comments/docblocks cannot satisfy it.
+	 */
+	public function testOffApplianceEntrypointsUseTheSharedValidator(): void
 	{
-		$this->assertStringContainsString('pfb_group_action_valid($value, $gtype)', self::$category);
-		$this->assertStringNotContainsString('in_array($value, $action_values)', self::$category);
-	}
-
-	public function testSummaryRenderNormalizesStoredActionBeforeFormSelect(): void
-	{
-		$this->assertStringContainsString(<<<'PHP'
-						if (!pfb_group_action_valid($rowdata[$r_id]['action'] ?? NULL, $gtype)) {
-							$rowdata[$r_id]['action'] = 'Disabled';
-						}
-PHP, self::$category);
-		$this->assertGuardBeforeActionUse(
-			self::$category,
-			"if (\$gtype == 'ipv4' || \$gtype == 'ipv6' || \$gtype == 'geoip') {\n\t\t\t\t\t\t\t\$list_array",
-			"\$selectadd->setWidth(8)->setAttribute('style', 'width: auto');",
-			"pfb_group_action_valid(\$rowdata[\$r_id]['action'] ?? NULL, \$gtype)",
-			"\$rowdata[\$r_id]['action'],"
-		);
-	}
-
-	public function testGeneratedGeoipPageNormalizesStoredActionBeforeFormSelect(): void
-	{
-		$this->assertStringContainsString(
-			"\$pconfig['action'] = pfb_group_action_valid(\$pfb['geoipconfig']['action'] ?? NULL, 'geoip') ? \$pfb['geoipconfig']['action'] : 'Disabled';",
-			self::$www
-		);
-		$this->assertGuardBeforeActionUse(
-			self::$www,
-			"\$pfb['geoipconfig'] = config_get_path",
-			"\$section->addInput(new Form_Select(\n\t'aliaslog'",
-			"pfb_group_action_valid(\$pfb['geoipconfig']['action'] ?? NULL, 'geoip')",
-			"\t\$pconfig['action'],\n\t\$options_action"
-		);
-	}
-
-	public function testSummaryMutationRequiresExactPostTypeBeforeConfigSelection(): void
-	{
-		$this->assertStringContainsString(
-			"is_string(\$_POST['type']) && in_array(\$_POST['type'], array('ipv4', 'ipv6', 'geoip', 'dnsbl'), TRUE)",
-			self::$category
-		);
-		$this->assertGuardBeforeActionUse(
-			self::$category,
-			'if (isset($_POST))',
-			'// Collect rowdata',
-			'if (!empty($action) && !$post_type_valid)',
-			'switch ($gtype)'
-		);
-	}
-
-	public function testMatchdirIpListActionIsValidatedBeforeClassification(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'function pfb_matchdir_config_headers',
-			'$pfb_dnsbl_action =',
-			"pfb_group_action_valid(\$pfb_action, 'ipv4')",
-			"strpos(\$pfb_action, 'Deny')"
-		);
-	}
-
-	public function testMatchdirDnsblIpActionIsNormalizedBeforeClassification(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'$pfb_dnsbl_action =',
-			'foreach ($continent_configs',
-			'pfb_dnsblip_action_value(',
-			"strpos(\$pfb_dnsbl_action, 'Deny')"
-		);
-	}
-
-	public function testMatchdirGeoipActionIsValidatedBeforeClassification(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'foreach ($continent_configs',
-			"return array('deny' => \$deny",
-			"pfb_group_action_valid(\$pfb_cont_action, 'geoip')",
-			"strpos(\$pfb_cont_action, 'Deny')"
-		);
-	}
-
-	public function testAlertsStoredActionIsValidatedBeforePermitClassification(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$alerts,
-			"foreach (\$c_config['config'] as \$row => \$data)",
-			'// Add Default pfBlockerNG IP Whitelist',
-			'pfb_group_action_valid($group_action, $group_type)',
-			"strpos(\$group_action, 'Permit')"
-		);
-	}
-
-	public function testCategoryEditStoredActionIsValidatedBeforeFolderClassification(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$categoryEdit,
-			"\$pconfig['custom']",
-			'// Indicate any failed downloads',
-			"pfb_group_action_valid(\$pconfig['action'] ?? NULL, \$gtype)",
-			"strpos(\$pconfig['action'], 'Deny_')"
-		);
-	}
-
-	public function testNormalizeLoopGuardsStoredAction(): void
-	{
-		$this->assertStringContainsString(<<<'PHP'
-				foreach ($type_config as $list) {
-					if (!pfb_group_action_valid($list['action'] ?? NULL, $ltype === 'pfblockerngdnsbl' ? 'dnsbl' : 'ipv4')) {
-						continue;
-					}
-PHP, self::$inc);
-	}
-
-	public function testDnsblProcessingLoopGuardsStoredAction(): void
-	{
-		$this->assertStringContainsString(<<<'PHP'
-			foreach (config_get_path('installedpackages/pfblockerngdnsbl/config', []) as $list) {
-				if (!pfb_group_action_valid($list['action'] ?? NULL, 'dnsbl')) {
-					continue;
-				}
-PHP, self::$inc);
-	}
-
-	public function testCronPrepassGuardsStoredAction(): void
-	{
-		$this->assertStringContainsString(<<<'PHP'
-		foreach (config_get_path("installedpackages/{$ltype}/config", []) as $list) {
-			if (!pfb_group_action_valid($list['action'] ?? NULL, $is_dnsbl ? 'dnsbl' : 'ipv4')) {
-				continue;
-			}
-PHP, self::$cron);
-	}
-
-	public function testCronGeoipFallbackGuardsStoredAction(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$cron,
-			'// If no lists require updates, check if Continents are configured',
-			"if (\$pfb['update_cron']) {",
-			"pfb_group_action_valid(\$continent_config['action'] ?? NULL, 'geoip')",
-			"\$continent_config['action'] != 'Disabled'"
-		);
-	}
-
-	public function testCustomPermitSuppressionGuardsStoredAction(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			"// Collect any 'Permit' Customlist IPs to suppress",
-			'$custom_supp = array_unique',
-			"pfb_group_action_valid(\$list['action'] ?? NULL, 'ipv4')",
-			"strpos(\$list['action'], 'Permit_')"
-		);
-	}
-
-	public function testAutoruleGeoipDiscoveryGuardsStoredAction(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'// Discover if any rules are autorules',
-			"if (!\$pfb['autorules']) {",
-			"pfb_group_action_valid(\$continent_config['action'] ?? NULL, 'geoip')",
-			"\$continent_config['action'] != 'Disabled'"
-		);
-	}
-
-	public function testAutoruleIpDiscoveryGuardsStoredAction(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			"if (!\$pfb['autorules']) {",
-			'// Check if DNSBL auto permit rule',
-			"pfb_group_action_valid(\$list['action'] ?? NULL, 'ipv4')",
-			"\$list['action'] != 'Disabled'"
-		);
-	}
-
-	public function testDnsblIpGlobalActionIsNormalizedAtReadBoundary(): void
-	{
-		$this->assertStringContainsString(
-			"\$pfb['dnsbl_ip']\t= pfb_dnsblip_action_value(\$pfb['dnsblconfig']['action'] ?? NULL);",
-			self::$inc
-		);
-	}
-
-	public function testDnsblIpAutoruleUsesNormalizedAction(): void
-	{
-		$start = strpos(self::$inc, '// Check if DNSBL auto permit rule');
-		$this->assertNotFalse($start);
-		$end = strpos(self::$inc, '// Configure auto rule suffix', $start);
-		$this->assertNotFalse($end);
-		$block = substr(self::$inc, $start, $end - $start);
-
-		$this->assertStringContainsString("strpos(\$pfb['dnsbl_ip'], 'Deny_')", $block);
-		$this->assertStringNotContainsString("\$pfb['dnsblconfig']['action']", $block);
-	}
-
-	public function testDnsblIpActionFolderGuardsBeforeRouting(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'function pfb_dnsblip_action_folder',
-			'// Write the DNSBLIP',
-			"pfb_group_action_valid(\$action, 'ipv4')",
-			'pfb_determine_list_detail($action'
-		);
-	}
-
-	public function testMasterDnsblIpSyntheticActionGuardsBeforeInterpolation(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'// ADD DNSBL IP',
-			'if (!empty($lists))',
-			"pfb_group_action_valid(\$pfb['dnsbl_ip'] ?? NULL, 'ipv4')",
-			'"{$pfb[\'dnsbl_ip\']}"'
-		);
-	}
-
-	public function testDownloadDnsblIpSyntheticActionGuardsBeforeInterpolation(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'// Add DNSBLIP, if configured (IPv4 + IPv6)',
-			'$maxmind_run_once',
-			"pfb_group_action_valid(\$pfb['dnsbl_ip'] ?? NULL, 'ipv4')",
-			'"{$pfb[\'dnsbl_ip\']}"'
-		);
-	}
-
-	public function testAliasDnsblIpSyntheticActionGuardsBeforeInterpolation(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'CONFIGURE ALIASES AND FIREWALL RULES',
-			'// Clear variables',
-			"pfb_group_action_valid(\$pfb['dnsbl_ip'] ?? NULL, 'ipv4')",
-			'"{$pfb[\'dnsbl_ip\']}"'
-		);
-	}
-
-	public function testMasterGeoipDiscoveryGuardsStoredAction(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'// Find all enabled Continents lists',
-			'// Find all enabled IPv4/IPv6 lists and DNSBL lists',
-			"pfb_group_action_valid(\$continent_config['action'] ?? NULL, 'geoip')",
-			"\$continent_config['action'] != 'Disabled'"
-		);
-	}
-
-	public function testGeoipProcessingGuardsStoredAction(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'// Download MaxMind Databases if not found',
-			'// Remove temp file',
-			"pfb_group_action_valid(\$continent_config['action'] ?? NULL, 'geoip')",
-			"pfb_determine_list_detail(\$continent_config['action']"
-		);
-	}
-
-	public function testIpDownloadCollectionGuardsStoredAction(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'// Collect lists and custom list configuration and format into one array',
-			'// Add DNSBLIP, if configured',
-			"pfb_group_action_valid(\$list['action'] ?? NULL, 'ipv4')",
-			'$lists[] = $list'
-		);
-	}
-
-	public function testIpAliasRuleLoopGuardsStoredAction(): void
-	{
-		$this->assertGuardBeforeActionUse(
-			self::$inc,
-			'CONFIGURE ALIASES AND FIREWALL RULES',
-			'// Clear variables',
-			"pfb_group_action_valid(\$list['action'] ?? NULL, 'ipv4')",
-			"pfb_determine_list_detail(\$list['action']"
-		);
+		$root = dirname(__DIR__, 2);
+		foreach ([
+			"{$root}/src/usr/local/www/pfblockerng/pfblockerng_alerts.php",
+			"{$root}/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc",
+		] as $path) {
+			$source = php_strip_whitespace($path);
+			$this->assertNotSame('', $source, "entrypoint source missing: {$path}");
+			$this->assertStringContainsString('pfb_group_action_valid(', $source, "shared validator missing: {$path}");
+		}
 	}
 }

--- a/tests/php/GunzipTrailingNewlineWiringTest.php
+++ b/tests/php/GunzipTrailingNewlineWiringTest.php
@@ -4,41 +4,79 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1263: the ET-IQRisk reuse path rebuilds '.orig' via a raw gunzip exec()
- * OUTSIDE pfb_download() -- pfb_download()'s own newline-termination guarantee
- * (DownloadTrailingNewlineWiringTest) never runs on this path. Source-inspection
- * pin (same technique as DownloadTrailingNewlineWiringTest): the surrounding
- * sync_package_pfblockerng() is thousands of lines and drives real cURL/appliance
- * exec, so this is not behaviourally exercised here -- the append behaviour itself
- * is proven in EnsureTrailingNewlineTest.
- */
+/** ET-IQRisk publication orders gunzip, newline normalization, then ET consumer. */
 final class GunzipTrailingNewlineWiringTest extends TestCase
 {
-	private static string $source;
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	private string $dir;
 
 	public static function setUpBeforeClass(): void
 	{
-		$source = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
-		);
-		if ($source === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
-		}
-		self::$source = $source;
+		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
 	}
 
-	public function testEnsureTrailingNewlineRunsAfterTheGunzipExec(): void
+	protected function setUp(): void
 	{
-		$gunzipPos = strpos(self::$source, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$file_org_esc}");');
-		$this->assertNotFalse($gunzipPos, 'vacuity: the ET-IQRisk gunzip exec site must exist');
+		$this->dir = sys_get_temp_dir() . '/pfb gunzip; ' . getmypid() . " 'fixture'";
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
 
-		$nextExecPos = strpos(self::$source, "exec(\"{\$pfb['script']} et {\$header_esc}", $gunzipPos);
-		$this->assertNotFalse($nextExecPos, 'vacuity: the following ET-processing exec must exist');
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->dir}/*") ?: [] as $path) {
+			@unlink($path);
+		}
+		@rmdir($this->dir);
+	}
 
-		$between = substr(self::$source, $gunzipPos, $nextExecPos - $gunzipPos);
-		$this->assertStringContainsString('pfb_ensure_trailing_newline("{$file_dwn}.orig")', $between,
-			'the reuse path must normalize the rebuilt .orig -- else a gzip payload without a trailing '
-			. 'newline stays welded downstream, exactly like the pfb_download() path this bypasses');
+	public function testGunzipPipelineTerminatesBeforeEtConsumer(): void
+	{
+		$raw = "{$this->dir}/feed; 'raw'";
+		$orig = "{$this->dir}/feed.orig";
+		$events = [];
+		$this->assertNotFalse(file_put_contents($raw, (string) gzencode('iprep-data')));
+
+		$this->assertTrue(pfb_apply_gunzip_orig_pipeline($raw, $orig,
+			static function (string $published) use (&$events): void {
+				$events[] = is_file($published) ? (string) file_get_contents($published) : 'missing';
+			}
+		));
+
+		$this->assertSame(["iprep-data\n"], $events);
+		$this->assertSame("iprep-data\n", file_get_contents($orig));
+	}
+
+	public function testGunzipFailurePreservesLegacyEtConsumerAttempt(): void
+	{
+		$raw = "{$this->dir}/bad.raw";
+		$orig = "{$this->dir}/bad.orig";
+		$events = [];
+		$this->assertNotFalse(file_put_contents($raw, 'not-gzip'));
+
+		$this->assertFalse(pfb_apply_gunzip_orig_pipeline($raw, $orig,
+			static function () use (&$events): void { $events[] = 'consume'; }
+		));
+
+		$this->assertSame(['consume'], $events);
+		$this->assertFileExists($raw);
+		$this->assertFileExists($orig);
+	}
+
+	public function testMissingRawStillRunsLegacyEtConsumer(): void
+	{
+		$events = [];
+		$this->assertFalse(pfb_apply_gunzip_orig_pipeline("{$this->dir}/missing.raw", "{$this->dir}/missing.orig",
+			static function () use (&$events): void { $events[] = 'consume'; }
+		));
+		$this->assertSame(['consume'], $events);
+	}
+
+	/** The ET reuse path lives in the #993 sync monolith; behavior runs above. */
+	public function testSyncPassDispatchesTheGunzipPublicationPipeline(): void
+	{
+		$source = php_strip_whitespace(self::APPLY);
+		$start = strpos($source, 'function sync_package_pfblockerng(');
+		$this->assertNotFalse($start);
+		$this->assertSame(1, substr_count(substr($source, $start), 'pfb_apply_gunzip_orig_pipeline('));
 	}
 }

--- a/tests/php/HookEditFileContainmentTest.php
+++ b/tests/php/HookEditFileContainmentTest.php
@@ -5,137 +5,151 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * issue #1871 — pfblockerng_hook_edit.inc is reachable from ONE page and no other.
- *
- * The file holds the only destructive hook-script operation in the package: a
- * root-privileged unlink() driven by a GUI request. Its safety rests on two
- * independent things, and this class pins the second one.
- *
- * The first is the set of gates inside the function itself (privilege, allow-list,
- * resolved directory, original path, existence, true resolved path, writability) —
- * covered by HookEditorDeleteTest.
- *
- * The second is EXISTENCE: the function is only in scope where it is allowed to be
- * used. The read-only hook helpers live in pfblockerng_extra.inc, which
- * pfblockerng.inc pulls into essentially every page of the package; anything
- * defined there is callable from the dashboard, the alerts page, and the
- * firewall_aliases_edit config hook. Putting a destructive primitive in that
- * blast radius and relying on callers to behave is exactly the arrangement this
- * separation exists to prevent.
- *
- * Convention alone does not hold that line — a future contributor adding one
- * require_once would silently undo it, and no other test in the suite would
- * notice. So the containment is asserted here, over the real shipping tree.
- *
- * KNOWN CEILING: these are text scans, so they catch a LITERAL reference to the
- * filename. A path assembled at runtime ('..._hook_' . 'edit.inc') is out of
- * reach and always will be — mutation-tested, it passes. That is an accepted
- * limit, not an oversight: the realistic regression is somebody adding a plain
- * require_once, which is caught. The scans deliberately cover .xml too, because
- * pfblockerng.xml uses <include_file> as a real load mechanism for this package
- * and an entry there would otherwise evade every assertion below.
+ * Package pages cannot be included as a whole off-appliance: they require pfSense's absolute
+ * runtime files, read live config, and several perform config/service/file mutations before exit.
+ * The recursive code/XML audit therefore pins containment without executing unrelated pages;
+ * php_strip_whitespace excludes comments/docblocks from every PHP/INC assertion.
  */
 final class HookEditFileContainmentTest extends TestCase
 {
-	private const INC = 'pfblockerng_hook_edit.inc';
+	private const ROOT = __DIR__ . '/../..';
+	private const SRC = self::ROOT . '/src';
+	private const HOOK_EDIT = self::ROOT . '/src/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc';
+	private const MUTATING_FUNCTIONS = [
+		'pfb_hook_editor_delete',
+		'pfb_edit_hooks_controller',
+		'pfb_edit_hooks_request',
+	];
 
-	/** The one page permitted to include it. */
-	private const ALLOWED_INCLUDER = 'src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php';
-
-	private static string $root = '';
-
-	public static function setUpBeforeClass(): void
+	public function testExactlyOneShippingPhpIncluderAndNoXmlIncluder(): void
 	{
-		parent::setUpBeforeClass();
-		self::$root = dirname(__DIR__, 2);
+		$php = $this->phpReferences();
+		$this->assertSame(
+			['usr/local/www/pfblockerng/pfblockerng_edit_hooks.php'],
+			$php,
+			'only the privilege-gated Edit Hooks page may include the destructive hook file'
+		);
+		$this->assertSame([], $this->xmlReferences(), 'package XML must not widen destructive hook scope');
 	}
 
-	/** @return list<string> every shipping file that names the include, repo-relative */
-	private static function referencingFiles(): array
+	public function testExactlyOneShippingDefinition(): void
 	{
-		$found = [];
-		$directory = new RecursiveDirectoryIterator(self::$root . '/src', FilesystemIterator::SKIP_DOTS);
-		foreach (new RecursiveIteratorIterator($directory) as $file) {
-			/** @var SplFileInfo $file */
-			if (!$file->isFile()) {
-				continue;
-			}
-			$path = $file->getPathname();
-			if (!preg_match('/\.(php|inc|xml)$/', $path)) {
-				continue;
-			}
-			$contents = (string) file_get_contents($path);
-			if (str_contains($contents, self::INC)) {
-				$found[] = ltrim(str_replace(self::$root, '', $path), '/');
+		$definitions = array_fill_keys(self::MUTATING_FUNCTIONS, []);
+		foreach ($this->shippingFiles() as $path) {
+			$source = php_strip_whitespace($path);
+			foreach (self::MUTATING_FUNCTIONS as $function) {
+				if (str_contains($source, "function {$function}(")) {
+					$definitions[$function][] = $this->relative($path);
+				}
 			}
 		}
-		sort($found);
-		return $found;
-	}
-
-	public function testTheIncludeFileExists(): void
-	{
-		// Guards the assertions below against vacuity: if the file were renamed or
-		// removed, "nothing includes it" would otherwise read as a clean pass.
-		$this->assertFileExists(self::$root . '/src/usr/local/pkg/pfblockerng/' . self::INC);
-	}
-
-	public function testExactlyOnePageIncludesIt(): void
-	{
-		$referencing = self::referencingFiles();
-		// The file names itself in its own header comment; that is not an include.
-		$referencing = array_values(array_filter(
-			$referencing,
-			static fn (string $path): bool => !str_ends_with($path, self::INC)
-		));
-
-		$this->assertSame(
-			[self::ALLOWED_INCLUDER],
-			$referencing,
-			"pfblockerng_hook_edit.inc holds a root-privileged unlink() and must stay reachable from the "
-				. "privilege-gated Edit Hooks page ONLY. Files naming it now:\n  " . implode("\n  ", $referencing)
-				. "\nIf a second page genuinely needs hook deletion, it needs its own privilege gate first — "
-				. "and this list needs updating deliberately, not incidentally."
-		);
-	}
-
-	public function testThePackageWideIncludesDoNotPullItIn(): void
-	{
-		// The specific regression that matters: pfblockerng.inc and
-		// pfblockerng_extra.inc are loaded almost everywhere, so either one taking a
-		// dependency on this file would restore the blast radius the split removed,
-		// while the test above would still pass if the reference were indirect.
-		foreach (['pfblockerng.inc', 'pfblockerng_extra.inc'] as $wide) {
-			$contents = (string) file_get_contents(self::$root . '/src/usr/local/pkg/pfblockerng/' . $wide);
-			// str_contains() rather than assertStringNotContainsString(): the latter
-			// prints the whole ~700 KB file into the failure output and buries the
-			// one line that matters.
-			$this->assertFalse(
-				str_contains($contents, self::INC),
-				"{$wide} is included by nearly every page; it must not pull in the destructive hook-edit file"
+		foreach ($definitions as $function => $files) {
+			$this->assertSame(
+				['usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc'],
+				$files,
+				"{$function} must exist only in the page-scoped destructive include"
 			);
 		}
 	}
 
-	public function testTheDeleteFunctionIsDefinedNowhereElse(): void
+	public function testPackageWideIncludeDoesNotLoadDestructiveOperation(): void
 	{
-		// Belt and braces on the whole arrangement: the containment is worthless if
-		// a copy of the function is also defined in a widely-included file.
-		$definitions = [];
-		$directory = new RecursiveDirectoryIterator(self::$root . '/src', FilesystemIterator::SKIP_DOTS);
-		foreach (new RecursiveIteratorIterator($directory) as $file) {
-			/** @var SplFileInfo $file */
-			if (!$file->isFile() || !preg_match('/\.(php|inc|xml)$/', $file->getPathname())) {
-				continue;
-			}
-			$contents = (string) file_get_contents($file->getPathname());
-			// Unanchored on purpose: a duplicate planted INDENTED inside an
-			// if (!function_exists(...)) { ... } block is exactly the shape that would
-			// restore the blast radius, and a ^-anchored scan misses it.
-			if (preg_match('/(?<![\w$>])function\s+pfb_hook_editor_delete\s*\(/', $contents)) {
-				$definitions[] = basename($file->getPathname());
+		$result = $this->runChild(<<<'PHP'
+require %s . '/tests/php/bootstrap.php';
+foreach (['pfb_hook_editor_delete', 'pfb_edit_hooks_controller', 'pfb_edit_hooks_request'] as $function) {
+	if (function_exists($function)) {
+		exit(1);
+	}
+}
+PHP
+);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+	}
+
+	public function testIntendedHookFileLoadsOperation(): void
+	{
+		$result = $this->runChild(<<<'PHP'
+require %s . '/src/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc';
+foreach (['pfb_hook_editor_delete', 'pfb_edit_hooks_controller', 'pfb_edit_hooks_request'] as $function) {
+	if (!function_exists($function)) {
+		exit(1);
+	}
+	$reflection = new ReflectionFunction($function);
+	if (realpath((string) $reflection->getFileName()) !== realpath(%s . '/src/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc')) {
+		exit(2);
+	}
+}
+PHP
+);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+	}
+
+	/** @return list<string> */
+	private function phpReferences(): array
+	{
+		$references = [];
+		foreach ($this->shippingFiles() as $path) {
+			$source = php_strip_whitespace($path);
+			if (str_contains($source, 'pfblockerng_hook_edit.inc')) {
+				$references[] = $this->relative($path);
 			}
 		}
-		$this->assertSame([self::INC], $definitions, 'the delete function must be defined in exactly one file');
+		return $references;
+	}
+
+	/** @return list<string> */
+	private function xmlReferences(): array
+	{
+		$references = [];
+		foreach ($this->shippingFiles('xml') as $path) {
+			$xml = simplexml_load_file($path, 'SimpleXMLElement', LIBXML_NONET | LIBXML_NOBLANKS);
+			$this->assertNotFalse($xml, "invalid shipping XML: {$path}");
+			foreach ($xml->xpath('//include_file') ?: [] as $include) {
+				if (trim((string) $include) === '/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc') {
+					$references[] = $this->relative($path);
+				}
+			}
+		}
+		return $references;
+	}
+
+	/** @return list<string> */
+	private function shippingFiles(string $extension = ''): array
+	{
+		$files = [];
+		$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(self::SRC, FilesystemIterator::SKIP_DOTS));
+		foreach ($iterator as $file) {
+			/** @var SplFileInfo $file */
+			if (!$file->isFile()) {
+				continue;
+			}
+			if ($extension !== '' ? $file->getExtension() !== $extension : !in_array($file->getExtension(), ['php', 'inc'], TRUE)) {
+				continue;
+			}
+			$files[] = $file->getPathname();
+		}
+		sort($files, SORT_STRING);
+		return $files;
+	}
+
+	private function relative(string $path): string
+	{
+		return ltrim(str_replace(self::SRC, '', $path), '/');
+	}
+
+	/** @return array{status:int,stdout:string,stderr:string} */
+	private function runChild(string $template): array
+	{
+		$root = var_export(self::ROOT, TRUE);
+		$script = sprintf($template, $root, $root);
+		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
+		$this->assertIsResource($process);
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
+		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr];
 	}
 }

--- a/tests/php/InstallDnsblMoveRestartGuardTest.php
+++ b/tests/php/InstallDnsblMoveRestartGuardTest.php
@@ -15,17 +15,17 @@ use PHPUnit\Framework\TestCase;
  * but never read), so `$ufound` was NOT reset and carried the prior block's value
  * into the `if ($ufound) { pfb_stop_start_unbound('') }` guard.
  *
- * install.inc is a procedural migration script (host-absolute requires, sqlite,
- * exec, real Unbound control) and is not loadable by the unit harness, so this pins
- * the invariant at the source level — the same approach as the custom-sniff tests.
+	 * install.inc is a procedural migration script (host-absolute requires, sqlite,
+	 * exec, real Unbound control) and is not loadable by the unit harness. The pin therefore
+	 * scans executable tokens only; comments/docblocks cannot satisfy it.
  */
 final class InstallDnsblMoveRestartGuardTest extends TestCase
 {
 	private static function installSource(): string
 	{
 		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
-		$src = @file_get_contents($path);
-		self::assertIsString($src, "could not read {$path}");
+		$src = @php_strip_whitespace($path);
+		self::assertNotSame('', $src, "could not read {$path}");
 		return $src;
 	}
 
@@ -37,20 +37,13 @@ final class InstallDnsblMoveRestartGuardTest extends TestCase
 	{
 		$src = self::installSource();
 
-		// The section runs from its "Move dnsbl_levent.sqlite" header to the guarded
-		// pfb_stop_start_unbound() call. NOTE: this header string is load-bearing — it
-		// bounds the window this test inspects; testNoOrphanUfoundTypo() is the
-		// header-independent backstop for the exact regression class.
-		$start = strpos($src, '// Move dnsbl_levent.sqlite');
-		$this->assertNotFalse($start, 'the "Move dnsbl_levent.sqlite" migration block is missing');
+		$start = strpos($src, "\$ufound = FALSE; if (file_exists('/var/db/pfblockerng/dnsbl_levent.sqlite')");
+		$this->assertNotFalse($start, 'the dnsbl-move migration guard reset is missing');
 		$guard = strpos($src, 'pfb_stop_start_unbound', $start);
-		$this->assertNotFalse($guard, 'the dnsbl-move block no longer guards a pfb_stop_start_unbound() call');
+		$this->assertNotFalse($guard, 'the dnsbl-move block no longer guards a restart call');
 
 		$section = substr($src, $start, $guard - $start);
 
-		// Before: $ufound = FALSE; reset must appear at the top of the block, ahead of
-		// the conditional `$ufound = TRUE;` move flags — else a prior block's TRUE leaks
-		// into the restart guard.
 		$reset = strpos($section, '$ufound = FALSE;');
 		$this->assertNotFalse($reset, 'the dnsbl-move block does not reset $ufound before its restart guard');
 		$firstSet = strpos($section, '$ufound = TRUE;');

--- a/tests/php/InstallPrePassWriteOrderTest.php
+++ b/tests/php/InstallPrePassWriteOrderTest.php
@@ -4,57 +4,46 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * Issue #1921 (S2 fix round) -- source-order guard, mechanical, over pfblockerng_install.inc.
- *
- * PfbConfig::writeSectionSystem() round-trips every adapter-bearing registered field
- * present in its $data through write_adapter(read_adapter(...)) (writeSectionRaw(),
- * pfblockerng_extra.inc). A pre-pass legacy-upgrade block in this file calling it would
- * canonicalise a bystander raw '' at a registered key to its registered default BEFORE
- * pfb_registry_pass() (the driver loop at the bottom of this file) gets a chance to see and
- * grandfather it. Before this step, migration-registry entry
- * issue1887-toggle-empty-preserve-gen closed this window; S2 deleted it, so every pre-pass
- * section write in this file must now be raw -- PfbConfig::writeSectionRawSystem(), which
- * persists byte-for-byte with no adapter round-trip.
- *
- * This test polices that mechanically: no 'writeSectionSystem(' byte offset may occur
- * before the pfb_registry_pass() call site. Every occurrence at/after that site is legal --
- * it is the pass's own write-back of its already-canonical output.
- *
- * Anchor gotcha: the short literal 'pfb_registry_pass(' also matches an unrelated comment
- * mention of the function's name earlier in the file (the VIP-migration raw-write-back
- * comment, "...ahead of pfb_registry_pass(), would destroy..."), which sits BEFORE every
- * writeSectionSystem() call site this test polices -- anchoring on that would make the
- * assertion vacuously pass no matter how many pre-pass call sites regress. The anchor below
- * is the longer, call-site-unique substring 'pfb_registry_pass($pfb_registry_sections)'.
- */
 final class InstallPrePassWriteOrderTest extends TestCase
 {
-	public function testNoWriteSectionSystemCallBeforeTheRegistryPassCallSite(): void
+	private const INSTALL = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
+
+	/**
+	 * install.inc performs appliance-only migrations and service changes, so it cannot be included
+	 * safely in the off-appliance PHPUnit process. php_strip_whitespace gives an executable-code
+	 * pin without allowing comments/docblocks to satisfy the ordering contract.
+	 */
+	public function testRegistryPassWritebackRunsBeforeFinalConfigFlush(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
-		$source = file_get_contents($path);
-		$this->assertNotFalse($source, "could not read {$path}");
+		$source = php_strip_whitespace(self::INSTALL);
+		$this->assertNotSame('', $source, 'installer source must be readable');
+		$call = strpos($source, 'pfb_install_registry_writeback($pfb_registry_sections);');
+		$this->assertNotFalse($call, 'installer must dispatch its registry pass through the writeback seam');
+		$this->assertSame(1, substr_count($source, 'pfb_install_registry_writeback($pfb_registry_sections);'));
+		$prepass = substr($source, 0, $call);
+		$this->assertFalse(str_contains($prepass, 'PfbConfig::writeSectionSystem('), 'system writes must not precede registry pass');
+		$this->assertLessThan(strrpos($source, 'return TRUE;'), $call, 'registry writeback must complete before installer return');
+	}
 
-		$anchor = 'pfb_registry_pass($pfb_registry_sections)';
-		$anchorOffset = strpos($source, $anchor);
-		$this->assertNotFalse(
-			$anchorOffset,
-			"anchor '{$anchor}' not found in pfblockerng_install.inc -- the registry pass "
-			. 'call site moved or was renamed; update this test\'s anchor'
+	public function testRegistryWritebackSeamFlushesAfterReturnedSectionWrites(): void
+	{
+		$order = [];
+		pfb_install_registry_writeback(
+			['installedpackages/pfblockerng' => ['raw' => 'value']],
+			static function (array $sections) use (&$order): array {
+				$order[] = 'registry-pass';
+				return $sections;
+			},
+			static function (string $path, array $blob) use (&$order): void {
+				$order[] = "write-section:{$path}";
+			},
+			static function (string $message) use (&$order): void {
+				$order[] = "write-config:{$message}";
+			}
 		);
-
-		$before = substr($source, 0, $anchorOffset);
-		preg_match_all('/writeSectionSystem\s*\(/', $before, $matches, PREG_OFFSET_CAPTURE);
-		$offenders = array_map(static fn(array $m): int => $m[1], $matches[0]);
-
 		$this->assertSame(
-			[],
-			$offenders,
-			'PfbConfig::writeSectionSystem() must not be called before the pfb_registry_pass() '
-			. 'call site in pfblockerng_install.inc (it round-trips adapters, canonicalising a '
-			. 'bystander raw value before the pass can grandfather it) -- convert the call at '
-			. 'these byte offsets to PfbConfig::writeSectionRawSystem(): ' . implode(', ', $offenders)
+			['registry-pass', 'write-section:installedpackages/pfblockerng', 'write-config:[pfBlockerNG] Save installation settings'],
+			$order
 		);
 	}
 }

--- a/tests/php/IpArrayFieldIngressGuardTest.php
+++ b/tests/php/IpArrayFieldIngressGuardTest.php
@@ -28,8 +28,8 @@ use PHPUnit\Framework\TestCase;
  * genuinely scalar fields (int/bool/null POST values).
  *
  * The ingress+sanitize loops are eval-extracted as a pure function of $_POST
- * (top-level page script, not require()-able off-appliance) -- matching
- * DnsblFreshPconfigTest's convention for this same page family.
+ * (top-level page script, not require()-able off-appliance), bounded by their
+ * executable POST-key loop and following select-options assignment.
  */
 final class IpArrayFieldIngressGuardTest extends TestCase
 {
@@ -40,23 +40,20 @@ final class IpArrayFieldIngressGuardTest extends TestCase
 		if (function_exists('pfb_ip_oracle_sanitize_prologue')) {
 			return;
 		}
-		$src = file_get_contents(self::IP_PHP);
-		if ($src === FALSE) {
+		$src = php_strip_whitespace(self::IP_PHP);
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_ip.php');
 		}
-		// Anchored on the issue #1777 guard comment's stable opening line through
-		// to the stable "// Validate Select field options" comment that follows
-		// the whole ingress+sanitize prologue -- captures the region as raw text
-		// regardless of the guard's internal shape (unconditional, allow-listed
-		// or multi-select-excluding), so the SAME oracle extraction works
-		// whichever shape the guard currently carries.
 		if (!preg_match(
-			'/(\t\t\/\/ issue #1777: reject an array-valued field \(\'asn_token\[\]=x\'\) before any\n.*?\n)'
-			. '\n\t\t\/\/ Validate Select field options\n/s',
+			'/(\$pfb_multiselect_fields = array\(.*?\);\s*'
+			. 'foreach \(array_keys\(\$_POST\) as \$pfb_post_field\) \{.*?)(?=\$select_options = array\()/s',
 			$src,
 			$m
 		)) {
-			throw new RuntimeException('test bootstrap: ip.php ingress guard + sanitize prologue not found');
+			throw new RuntimeException('test bootstrap: ip.php ingress guard + sanitize executable region not found');
+		}
+		if (strpos($m[1], 'pfb_sanitize_text_area') === FALSE) {
+			throw new RuntimeException('test bootstrap: IP sanitize executable region is incomplete');
 		}
 		eval(
 			'function pfb_ip_oracle_sanitize_prologue(array $post): array {'

--- a/tests/php/IpParseLineWiringTest.php
+++ b/tests/php/IpParseLineWiringTest.php
@@ -4,67 +4,89 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * The feed loop must delegate each raw line to the pure parser seam.  This
- * source pin keeps the extraction honest: the old family/parser branches must
- * not remain inline where they can silently diverge from the helper.
- */
 final class IpParseLineWiringTest extends TestCase
 {
-	private static string $source;
-
-	public static function setUpBeforeClass(): void
+	/** @return array{vtype:string,pftype:string,custom:bool,cidr_floor_v4:int|string,cidr_floor_v6:int|string,suppression:string,range:string,ipv4:string,ipv6:string} */
+	private function config(string $vtype, string $pftype = 'regex', string $suppression = 'off'): array
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
-		self::$source = (string) file_get_contents($path);
+		return [
+			'vtype'         => $vtype,
+			'pftype'        => $pftype,
+			'custom'        => FALSE,
+			'cidr_floor_v4' => 'Disabled',
+			'cidr_floor_v6' => 'Disabled',
+			'suppression'   => $suppression,
+			'range'         => pfb_ip_regex_config()['range'],
+			'ipv4'          => pfb_ip_regex_config()['ipv4'],
+			'ipv6'          => pfb_ip_regex_config()['ipv6'],
+		];
 	}
 
-	public function testSyncLoopDelegatesRawLineToPureParser(): void
+	public function testReplayAppendsEntriesInParserOrderAndAdvancesLineNumber(): void
 	{
-		$ipPass = strpos(self::$source, '$ip_lineno = 0');
-		$this->assertNotFalse($ipPass, 'IP feed parser setup not found');
-		$loopStart = strpos(self::$source, 'while (($line = @fgets($fhandle)) !== FALSE)', (int) $ipPass);
-		$this->assertNotFalse($loopStart, 'sync feed loop not found');
-		$loopEnd = strpos(self::$source, 'if ($fhandle)', (int) $loopStart);
-		$this->assertNotFalse($loopEnd, 'sync feed loop end not found');
-		$loop = substr(self::$source, (int) $loopStart, (int) $loopEnd - (int) $loopStart);
+		$state = pfb_ip_parse_line_replay(
+			"from 192.0.2.1 to 198.51.100.7\n",
+			$this->config('_v4'),
+			4,
+			"10.0.0.1\n",
+			FALSE,
+			2
+		);
 
-		$this->assertStringContainsString('pfb_ip_parse_line(', $loop);
-		$this->assertStringContainsString('$raw_line', $loop);
-		$this->assertStringNotContainsString("if (\$list['vtype'] == '_v4'", $loop);
-		$this->assertStringNotContainsString("if (\$list['vtype'] == '_v6'", $loop);
-		$this->assertStringNotContainsString('preg_match_all($pfb[\'ipv4\']', $loop);
-		$this->assertStringNotContainsString('preg_match_all($pfb[\'ipv6\']', $loop);
+		$this->assertSame(5, $state['line_number']);
+		$this->assertSame("from 192.0.2.1 to 198.51.100.7", $state['line']);
+		$this->assertSame("10.0.0.1\n192.0.2.1\n198.51.100.7\n", $state['ip_data']);
+		$this->assertFalse($state['ip_suppressed']);
+		$this->assertSame(2, $state['parse_fail']);
+		$this->assertSame([], $state['messages']);
+		$this->assertFalse($state['detailed_parse_fail']);
+	}
 
-		$replayContract = [
-			'normalized line'       => '$line = $parsed_line[\'line\'];',
-			'ordered messages'      => 'foreach ($parsed_line[\'messages\'] as $message)',
-			'message logging'       => 'pfb_logger($message, 1);',
-			'ordered entries'       => 'foreach ($parsed_line[\'entries\'] as $entry)',
-			'newline-delimited data' => '$ip_data .= $entry . "\\n";',
-			'suppression state'     => '$ip_suppressed = $ip_suppressed || $parsed_line[\'suppressed\'];',
-			'parse-failure count'   => '$parse_fail += $parsed_line[\'parse_fail_delta\'];',
-			'detailed-failure gate' => 'if ($parsed_line[\'detailed_parse_fail\'])',
-			'detailed-failure data' => 'pfb_parse_fail_log($header, $line, $raw_line, $pfb[\'ip_parse_err\'], $ip_lineno, TRUE);',
-		];
-		foreach ($replayContract as $effect => $needle) {
-			$this->assertStringContainsString($needle, $loop, "missing parser replay effect: {$effect}");
-		}
-		$lineNumber = strpos($loop, '$ip_lineno++;');
-		$parseCall = strpos($loop, '$parsed_line = pfb_ip_parse_line(');
-		$this->assertNotFalse($lineNumber, 'line-number increment missing');
-		$this->assertNotFalse($parseCall, 'parser invocation missing');
-		$this->assertLessThan($parseCall, $lineNumber, 'line number must increment before parsing and diagnostics');
-		$this->assertStringContainsString('pfb_ip_parse_fail_warn($parse_fail, $header);', self::$source);
+	public function testReplayCarriesV6SuppressionAndExistingState(): void
+	{
+		$state = pfb_ip_parse_line_replay(
+			'fc00::1',
+			$this->config('_v6', 'auto', 'on'),
+			0,
+			'',
+			TRUE,
+			1
+		);
 
-		$placeholderStart = strpos(self::$source, "if (empty(\$ip_data) && \$ip_suppressed && \$list['vtype'] == '_v6')");
-		$this->assertNotFalse($placeholderStart, 'suppressed-IPv6 placeholder gate missing');
-		$placeholderEnd = strpos(self::$source, 'if (!empty($ip_data))', (int) $placeholderStart);
-		$this->assertNotFalse($placeholderEnd, 'suppressed-IPv6 placeholder block end missing');
-		$placeholder = substr(self::$source, (int) $placeholderStart, (int) $placeholderEnd - (int) $placeholderStart);
-		$this->assertStringContainsString('$p_ip     = "::{$pfb[\'ip_ph\']}";', $placeholder);
-		$this->assertStringContainsString('$ip_data  = "{$p_ip}\\n";', $placeholder);
-		$this->assertStringContainsString('All IPv6 entries suppressed', $placeholder);
-		$this->assertStringContainsString('pfb_logger(', $placeholder);
+		$this->assertSame(1, $state['line_number']);
+		$this->assertSame('fc00::1', $state['line']);
+		$this->assertSame('', $state['ip_data']);
+		$this->assertTrue($state['ip_suppressed']);
+		$this->assertSame(1, $state['parse_fail']);
+		$this->assertSame([], $state['messages']);
+	}
+
+	public function testReplayReturnsDetailedFailureWithRawLineForDiagnostics(): void
+	{
+		$state = pfb_ip_parse_line_replay(
+			" 999.999.999.999 \n",
+			$this->config('_v4', 'auto'),
+			9,
+			'',
+			FALSE,
+			0
+		);
+
+		$this->assertSame(10, $state['line_number']);
+		$this->assertSame('999.999.999.999', $state['line']);
+		$this->assertSame(1, $state['parse_fail']);
+		$this->assertTrue($state['detailed_parse_fail']);
+		$this->assertSame(" 999.999.999.999 \n", $state['raw_line']);
+	}
+
+	/** #993: the live sync/download/firewall monolith is unsafe off-appliance; comments are stripped. */
+	public function testLiveFeedDispatchUsesReplaySeam(): void
+	{
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertStringContainsString(
+			'$replayed_line = pfb_ip_parse_line_replay($line',
+			$source,
+			'live feed dispatch must replay parser state before writing firewall alias data'
+		);
 	}
 }

--- a/tests/php/IpRecomputeOrderChangeTest.php
+++ b/tests/php/IpRecomputeOrderChangeTest.php
@@ -59,11 +59,7 @@ final class IpRecomputeOrderChangeTest extends TestCase
 	/** Baseline content the invocation loop would write for these headers, in order. */
 	private function writeBaseline(array $headers): void
 	{
-		$paths = array();
-		foreach ($headers as $header) {
-			$paths[] = pfb_ip_recompute_snapshot_path($this->snapdir, $header);
-		}
-		file_put_contents($this->memberlist, pfb_ip_recompute_memberlist_content($paths));
+		$this->writeBaselineFor($this->memberlist, $headers);
 	}
 
 	private function applyScope(string $source, string $start, string $end): string

--- a/tests/php/IpRecomputeOrderChangeTest.php
+++ b/tests/php/IpRecomputeOrderChangeTest.php
@@ -20,19 +20,16 @@ use PHPUnit\Framework\TestCase;
  *                                         the shared serializer, strict FALSE check, logged
  *                                         failure (issue #1184).
  *
- * Part A exercises the pure helpers directly; Part C does the same for the write helper's
- * success/failure/empty-content behaviour. Part B is a source tripwire suite: the
- * detection wiring lives in sync_package_pfblockerng(), thousands of lines of top-level
- * script code that PHPUnit cannot call as a function -- so wiring correctness is pinned by
- * exact substring assertions against the CURRENT file content (house pattern:
- * IpRecomputeRanWiringTest), which fail for as long as the old (missing) wiring is what is
- * actually shipped.
+ * Part A exercises the pure helpers directly; Part B drives the whole order-check decision
+ * matrix; Part C does the same for the write helper's success/failure/empty-content behaviour.
  */
 #[CoversFunction('pfb_ip_recompute_memberlist_content')]
 #[CoversFunction('pfb_ip_recompute_memberlist_write')]
 #[CoversFunction('pfb_ip_recompute_order_changed')]
 final class IpRecomputeOrderChangeTest extends TestCase
 {
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+
 	private string $root;
 	private string $snapdir;
 	private string $memberlist;
@@ -42,7 +39,7 @@ final class IpRecomputeOrderChangeTest extends TestCase
 		$this->root       = sys_get_temp_dir() . '/pfb_rec_order_' . getmypid() . '_' . uniqid();
 		$this->snapdir    = "{$this->root}/snapshot";
 		$this->memberlist = "{$this->root}/pfb_recompute_v4.members";
-		$this->assertTrue(@mkdir($this->snapdir, 0777, true), "could not create {$this->snapdir}");
+		$this->assertTrue(@mkdir($this->snapdir, 0777, TRUE), "could not create {$this->snapdir}");
 	}
 
 	protected function tearDown(): void
@@ -51,6 +48,9 @@ final class IpRecomputeOrderChangeTest extends TestCase
 			@unlink($f);
 		}
 		@rmdir($this->snapdir);
+		foreach (@glob("{$this->root}/*.members") ?: [] as $f) {
+			@unlink($f);
+		}
 		@chmod($this->memberlist, 0644);
 		@unlink($this->memberlist);
 		@rmdir($this->root);
@@ -64,6 +64,19 @@ final class IpRecomputeOrderChangeTest extends TestCase
 			$paths[] = pfb_ip_recompute_snapshot_path($this->snapdir, $header);
 		}
 		file_put_contents($this->memberlist, pfb_ip_recompute_memberlist_content($paths));
+	}
+
+	private function applyScope(string $source, string $start, string $end): string
+	{
+		$from = strpos($source, $start);
+		if ($from === FALSE) {
+			throw new RuntimeException("missing apply scope start: {$start}");
+		}
+		$to = strpos($source, $end, $from + strlen($start));
+		if ($to === FALSE) {
+			throw new RuntimeException("missing apply scope end: {$end}");
+		}
+		return substr($source, $from, $to - $from);
 	}
 
 	// --- Part A: pfb_ip_recompute_order_changed() behaviour rows -----------------------
@@ -167,74 +180,63 @@ final class IpRecomputeOrderChangeTest extends TestCase
 		$this->assertSame("a\nb\n", pfb_ip_recompute_memberlist_content(array('a', 'b')), 'paths are newline-joined with a trailing newline');
 	}
 
-	// --- Part B: sync_package_pfblockerng() wiring tripwires ----------------------------
+	// --- Part B: complete order-check decision matrix -------------------------------
 
-	private function source(): string
+	public function testOrderCheckRequiresLiveEnabledCrossListScope(): void
 	{
-		return (string) file_get_contents(__DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertTrue(pfb_ip_recompute_order_scope(FALSE, TRUE, TRUE, FALSE, FALSE));
+		$this->assertTrue(pfb_ip_recompute_order_scope(FALSE, TRUE, FALSE, TRUE, FALSE));
+		$this->assertTrue(pfb_ip_recompute_order_scope(FALSE, TRUE, FALSE, FALSE, TRUE));
+		$this->assertFalse(pfb_ip_recompute_order_scope(TRUE, TRUE, TRUE, FALSE, FALSE));
+		$this->assertFalse(pfb_ip_recompute_order_scope(FALSE, FALSE, TRUE, FALSE, FALSE));
+		$this->assertFalse(pfb_ip_recompute_order_scope(FALSE, TRUE, FALSE, FALSE, FALSE));
 	}
 
-	public function testDetectionGuardCombinesTheSaveEnableGateWithCrossListScope(): void
+	public function testOrderCheckFamiliesKeepV6ScopedToDedup(): void
 	{
-		$needle = <<<'EOT'
-	if (!$pfb['save'] && $pfb['enable'] === PfbToggle::On &&
-	    pfb_cross_list_scope($pfb['dup'] === PfbToggle::On, $pfb['drep'] === PfbToggle::On || $pfb['prep'] === PfbToggle::On)) {
-EOT;
-		$this->assertStringContainsString(
-			$needle,
-			$this->source(),
-			'the order-change detection block must gate on !save && enable, scoped by pfb_cross_list_scope() -- order only matters when dedup or reputation is on'
-		);
+		$this->assertSame(['v4', 'v6'], pfb_ip_recompute_order_families(TRUE));
+		$this->assertSame(['v4'], pfb_ip_recompute_order_families(FALSE));
 	}
 
-	public function testDetectionBlockCallsOrderChangedWithFamilyHeadersAndTheMemberlistPath(): void
+	public function testV4AndV6OrderChangesAreIndependent(): void
 	{
-		$needle = <<<'EOT'
-			if (pfb_ip_recompute_order_changed(
-			    pfb_ip_recompute_family_headers($pfb['existing']['deny'] ?? [], $pfb_rec_family),
-			    $pfb['snapdir'],
-			    "{$pfb['dbdir']}/pfb_recompute_{$pfb_rec_family}.members")) {
-EOT;
-		$this->assertStringContainsString(
-			$needle,
-			$this->source(),
-			'the checker must be called with the config-order family headers and the exact memberlist path the invocation loop writes'
-		);
+		$v4 = $this->root . '/v4.members';
+		$v6 = $this->root . '/v6.members';
+		$this->writeBaselineFor($v4, ['FeedA_v4', 'FeedB_v4']);
+		$this->writeBaselineFor($v6, ['FeedA_v6', 'FeedB_v6']);
+
+		$this->assertFalse(pfb_ip_recompute_order_changed(['FeedA_v4', 'FeedB_v4'], $this->snapdir, $v4));
+		$this->assertTrue(pfb_ip_recompute_order_changed(['FeedB_v4', 'FeedA_v4'], $this->snapdir, $v4));
+		$this->assertFalse(pfb_ip_recompute_order_changed(['FeedA_v6', 'FeedB_v6'], $this->snapdir, $v6));
+		$this->assertTrue(pfb_ip_recompute_order_changed(['FeedB_v6', 'FeedA_v6'], $this->snapdir, $v6));
 	}
 
-	public function testDetectionBlockOnlyChecksV6UnderDedup(): void
+	private function writeBaselineFor(string $path, array $headers): void
 	{
-		$needle = <<<'EOT'
-		foreach (array('v4', 'v6') as $pfb_rec_family) {
-			if ($pfb_rec_family === 'v6' && $pfb['dup'] !== PfbToggle::On) {
-				continue;
-			}
-EOT;
-		$this->assertStringContainsString(
-			$needle,
-			$this->source(),
-			"v6 joins recompute only via dedup (pfb_ip_recompute_matrix's contract: invoke_v6 TRUE only when dedup is on)"
+		$paths = array_map(
+			fn (string $header): string => pfb_ip_recompute_snapshot_path($this->snapdir, $header),
+			$headers
 		);
+		file_put_contents($path, pfb_ip_recompute_memberlist_content($paths));
 	}
 
-	public function testMemberlistWriteSiteRoutesThroughTheSharedSerializationHelper(): void
+	/**
+	 * #993: recompute orchestration is embedded in the appliance apply pass; it cannot be
+	 * safely executed off-appliance. These comment-free windows pin each decision binding,
+	 * while the helper matrix and write behavior above remain executable unit coverage.
+	 */
+	public function testApplyBindsRecomputeScopeFamilyChangeAndWriteSeparately(): void
 	{
-		$source = $this->source();
-		$this->assertStringContainsString(
-			"\t\tpfb_ip_recompute_memberlist_write(\$pfb_rec_memberlist, \$pfb_rec_paths);",
-			$source,
-			'the invocation loop must write the memberlist through the failure-checked helper (issue #1184)'
-		);
-		$this->assertStringNotContainsString(
-			'@file_put_contents($pfb_rec_memberlist',
-			$source,
-			'the raw suppressed write must be gone -- a write failure must be logged, not silently swallowed'
-		);
-		$this->assertStringNotContainsString(
-			"\$pfb_rec_paths ? (implode(\"\\n\", \$pfb_rec_paths) . \"\\n\") : ''",
-			$source,
-			'the old inline implode ternary must be gone -- otherwise the checker and the writer could drift out of format sync'
-		);
+		$source  = php_strip_whitespace(self::APPLY);
+		$scope   = $this->applyScope($source, 'if (pfb_ip_recompute_order_scope(', 'foreach (pfb_ip_recompute_order_families(');
+		$family  = $this->applyScope($source, 'foreach (pfb_ip_recompute_order_families(', 'if (pfb_ip_recompute_order_changed(');
+		$changed = $this->applyScope($source, 'if (pfb_ip_recompute_order_changed(', '$pfb_rec_trigger =');
+		$write   = $this->applyScope($source, "foreach (array('v4', 'v6') as \$pfb_rec_family) {", 'pfb_ip_recompute_mark_ran(');
+
+		$this->assertSame(1, substr_count($scope, 'if (pfb_ip_recompute_order_scope('), 'apply must bind the live recompute scope once');
+		$this->assertSame(1, substr_count($family, 'foreach (pfb_ip_recompute_order_families('), 'apply must select families through the order helper');
+		$this->assertSame(1, substr_count($changed, 'if (pfb_ip_recompute_order_changed('), 'apply must compare each selected family order');
+		$this->assertSame(1, substr_count($write, 'pfb_ip_recompute_memberlist_write($pfb_rec_memberlist, $pfb_rec_paths)'), 'each recompute pass must write the shared memberlist');
 	}
 
 	// --- Part C: pfb_ip_recompute_memberlist_write() behaviour rows (issue #1184) --------

--- a/tests/php/IpRecomputeOrderChangeTest.php
+++ b/tests/php/IpRecomputeOrderChangeTest.php
@@ -185,6 +185,7 @@ final class IpRecomputeOrderChangeTest extends TestCase
 	public function testOrderCheckRequiresLiveEnabledCrossListScope(): void
 	{
 		$this->assertTrue(pfb_ip_recompute_order_scope(FALSE, TRUE, TRUE, FALSE, FALSE));
+		$this->assertTrue(pfb_ip_recompute_order_scope(NULL, TRUE, TRUE, FALSE, FALSE));
 		$this->assertTrue(pfb_ip_recompute_order_scope(FALSE, TRUE, FALSE, TRUE, FALSE));
 		$this->assertTrue(pfb_ip_recompute_order_scope(FALSE, TRUE, FALSE, FALSE, TRUE));
 		$this->assertFalse(pfb_ip_recompute_order_scope(TRUE, TRUE, TRUE, FALSE, FALSE));

--- a/tests/php/IpRecomputeRanWiringTest.php
+++ b/tests/php/IpRecomputeRanWiringTest.php
@@ -4,114 +4,107 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1084 review — pfblockerng_apply.inc source tripwires for wiring that cannot be driven
- * as a unit under PHPUnit (the reload pass is thousands of lines of top-level script code,
- * not a callable function): the recompute-invocation loop must record, per family, whether
- * the batch recompute verb actually ran THIS pass, and both the v4/v6 suppression-body
- * gates and the FINAL REPORTING closing-pass gate must consume that signal via the new
- * pure helpers (pfb_ip_suppress_body_active(), pfb_ip_closing_pass_active()) rather than
- * their old feed-changed-only / dedup-only conditions.
- *
-	 * Assertions scan the CURRENT file content with PHP comments removed, so comment-only
-	 * identifiers cannot satisfy the wiring oracle. A stale rename/refactor of any pinned
-	 * line fails this oracle immediately.
- */
 final class IpRecomputeRanWiringTest extends TestCase
 {
-	private const PFBLOCKERNG_APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	private string $root;
 
-	private function source(): string
+	protected function setUp(): void
 	{
-		$source = '';
-		foreach (token_get_all((string) file_get_contents(self::PFBLOCKERNG_APPLY)) as $token) {
-			if (is_array($token)) {
-				if (in_array($token[0], [T_COMMENT, T_DOC_COMMENT], TRUE)) {
-					continue;
-				}
-				$token = $token[1];
-			}
-			$source .= $token;
+		$this->root = sys_get_temp_dir() . '/pfb_recompute_ran_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(mkdir($this->root, 0777, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->root}/*") ?: [] as $path) {
+			@unlink($path);
 		}
-		return $source;
+		@rmdir($this->root);
 	}
 
-	public function testInvocationLoopRecordsWhetherRecomputeRanPerFamily(): void
+	public function testRanFlagIsSetOnlyAfterTheMatchingFamilyRunnerCompletes(): void
 	{
-		$source = $this->source();
-		$this->assertMatchesRegularExpression(
-			'/^\s*\$pfb_recompute_ran_v4 = FALSE;$/m',
-			$source,
-			'the v4 recompute-ran flag must initialize FALSE in executable code'
-		);
-		$this->assertMatchesRegularExpression(
-			'/^\s*\$pfb_recompute_ran_v6 = FALSE;$/m',
-			$source,
-			'the v6 recompute-ran flag must initialize FALSE in executable code'
-		);
-		$this->assertMatchesRegularExpression(
-			'/^\s*\$pfb_recompute_ran_v4 = TRUE;$/m',
-			$source,
-			'the v4 recompute-ran flag must become TRUE after the recompute exec'
-		);
-		$this->assertMatchesRegularExpression(
-			'/^\s*\$pfb_recompute_ran_v6 = TRUE;$/m',
-			$source,
-			'the v6 recompute-ran flag must become TRUE after the recompute exec'
-		);
+		$ranV4 = $ranV6 = FALSE;
+		$families = [];
+		pfb_ip_recompute_mark_ran('v4', static function () use (&$families): void {
+			$families[] = 'v4';
+		}, $ranV4, $ranV6);
+		$this->assertSame(['v4'], $families);
+		$this->assertTrue($ranV4);
+		$this->assertFalse($ranV6);
+
+		pfb_ip_recompute_mark_ran('v6', static function () use (&$families): void {
+			$families[] = 'v6';
+		}, $ranV4, $ranV6);
+		$this->assertSame(['v4', 'v6'], $families);
+		$this->assertTrue($ranV6);
 	}
 
-	public function testV4SuppressionBodyGateConsumesTheSuppressBodyActiveHelperAndV4Flag(): void
+	public function testFailedRecomputeDoesNotAdvertiseThatFamilyAsRan(): void
 	{
-		$source = $this->source();
+		$ranV4 = $ranV6 = FALSE;
+		$this->expectException(RuntimeException::class);
+		try {
+			pfb_ip_recompute_mark_ran('v4', static function (): void {
+				throw new RuntimeException('recompute failed');
+			}, $ranV4, $ranV6);
+		} finally {
+			$this->assertFalse($ranV4);
+			$this->assertFalse($ranV6);
+		}
+	}
+
+	public function testSuppressionBodyUsesTheFamilySpecificRecomputeSignal(): void
+	{
+		$this->assertTrue(pfb_ip_suppress_body_active(TRUE, TRUE, TRUE, TRUE, FALSE, TRUE));
+		$this->assertFalse(pfb_ip_suppress_body_active(TRUE, TRUE, TRUE, TRUE, FALSE, FALSE));
+		$this->assertFalse(pfb_ip_suppress_body_active(TRUE, FALSE, TRUE, TRUE, FALSE, TRUE));
+		$this->assertTrue(pfb_ip_suppress_body_active(TRUE, TRUE, TRUE, TRUE, TRUE, FALSE));
+	}
+
+	public function testRecomputeSignalSelectionFollowsTheRequestedAddressFamily(): void
+	{
+		$this->assertTrue(pfb_ip_suppress_body_for_vtype(TRUE, '_v4', TRUE, TRUE, FALSE, TRUE, FALSE));
+		$this->assertFalse(pfb_ip_suppress_body_for_vtype(TRUE, '_v4', TRUE, TRUE, FALSE, FALSE, TRUE));
+		$this->assertTrue(pfb_ip_suppress_body_for_vtype(TRUE, '_v6', TRUE, TRUE, FALSE, FALSE, TRUE));
+		$this->assertFalse(pfb_ip_suppress_body_for_vtype(TRUE, '_v6', TRUE, TRUE, FALSE, TRUE, FALSE));
+		$this->assertFalse(pfb_ip_suppress_body_for_vtype(TRUE, '_bogus', TRUE, TRUE, FALSE, TRUE, TRUE));
+	}
+
+	public function testClosingPassRequiresV4RecomputeWhenDedupIsOff(): void
+	{
+		$this->assertSame([TRUE, 'on'], pfb_ip_closing_pass_active(TRUE, FALSE));
+		$this->assertSame([TRUE, 'off'], pfb_ip_closing_pass_active(FALSE, TRUE));
+		$this->assertSame([FALSE, 'off'], pfb_ip_closing_pass_active(FALSE, FALSE));
+	}
+
+	public function testV6SnapshotPipelineWritesTheFamilySnapshot(): void
+	{
+		$source = "{$this->root}/Feed_v6.txt";
+		$snapdir = "{$this->root}/snap";
+		$origdir = "{$this->root}/orig";
+		mkdir($snapdir);
+		mkdir($origdir);
+		file_put_contents($source, "2001:db8::1\n");
+
+		pfb_ip_recompute_write_snapshot($source, 'Feed_v6', $snapdir, $origdir);
+
+		$this->assertSame("2001:db8::1\n", file_get_contents("{$snapdir}/Feed_v6.snap"));
+		$this->assertSame("1\n", file_get_contents("{$origdir}/Feed_v6.aggcount"));
+	}
+
+	public function testLiveFirewallDispatchConsumesFamilyRecomputeSignals(): void
+	{
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
 		$this->assertStringContainsString(
-			"pfb_ip_suppress_body_active(\$pfb['supp'] === PfbToggle::On, \$vtype == '_v4', \$pfb['supp_update'], \$pfbadv, in_array(\$alias, \$final_alias_old), \$pfb_recompute_ran_v4)",
+			'$suppression_body_active = pfb_ip_suppress_body_for_vtype($pfb[\'supp\'] === PfbToggle::On, $vtype, $pfb[\'supp_update\'], $pfbadv, in_array($alias, $final_alias_old), $pfb_recompute_ran_v4, $pfb_recompute_ran_v6)',
 			$source,
-			'the v4 suppression-body gate must call pfb_ip_suppress_body_active() with the v4 recompute-ran flag'
-		);
-	}
-
-	public function testV6SuppressionBodyGateConsumesTheSuppressBodyActiveHelperAndV6Flag(): void
-	{
-		$source = $this->source();
-		$this->assertStringContainsString(
-			"pfb_ip_suppress_body_active(\$pfb['supp'] === PfbToggle::On, \$vtype == '_v6', \$pfb['supp_update'], \$pfbadv, in_array(\$alias, \$final_alias_old), \$pfb_recompute_ran_v6)",
-			$source,
-			'the v6 suppression-body gate must call pfb_ip_suppress_body_active() with the v6 recompute-ran flag'
-		);
-	}
-
-	public function testFinalReportingClosingGateConsumesTheClosingPassActiveHelperAndV4Flag(): void
-	{
-		$source = $this->source();
-		$this->assertStringContainsString(
-			"pfb_ip_closing_pass_active(\$pfb['dup'] === PfbToggle::On, \$pfb_recompute_ran_v4)",
-			$source,
-			'the FINAL REPORTING gate must call pfb_ip_closing_pass_active() with the v4 recompute-ran flag'
-		);
-	}
-
-	public function testContinentSnapshotWriteIsNoLongerGatedToV4Only(): void
-	{
-		$source = $this->source();
-		$needle = 'pfb_ip_recompute_write_snapshot("{$pfbfolder}/{$cc_alias}.txt", $cc_alias, $pfb[\'snapdir\'], $pfb[\'origdir\']);';
-		$pos    = strpos($source, $needle);
-		$this->assertNotFalse($pos, "continent snapshot call site not found -- update this oracle if it moved/changed shape\nsource file: " . self::PFBLOCKERNG_APPLY);
-
-		// The gating "if" immediately precedes the call; a v6 continent's live .txt IS
-		// regenerated every GeoIP change (unconditional on $vtype -- see the sibling
-		// @copy() calls a few lines up), so a v4-only snapshot gate freezes its recompute
-		// memberlist entry at the one-time upgrade seed forever (issue #1084 review).
-		$precedingWindow = substr($source, max(0, $pos - 200), 200);
-		$this->assertStringNotContainsString(
-			"\$vtype == '_v4' && \$pfbadv",
-			$precedingWindow,
-			'the continent snapshot write must no longer be gated to v4 only -- v6 continents need their own recompute snapshot too'
+			'issue #993: live firewall orchestration has no safe off-box driver; its one code-only pin must dispatch through the tested family seam'
 		);
 		$this->assertStringContainsString(
-			'if ($pfbadv) {',
-			$precedingWindow,
-			'expected the gate to be $pfbadv alone (both v4 and v6 continents snapshot)'
+			'pfb_ip_closing_pass_active($pfb[\'dup\'] === PfbToggle::On, $pfb_recompute_ran_v4)',
+			$source,
+			'issue #993: final live closing dispatch is appliance-only; its code-only pin must pass the behavior-tested v4 recompute signal'
 		);
 	}
 }

--- a/tests/php/IpRecomputeRanWiringTest.php
+++ b/tests/php/IpRecomputeRanWiringTest.php
@@ -16,10 +16,8 @@ final class IpRecomputeRanWiringTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach (glob("{$this->root}/*") ?: [] as $path) {
-			@unlink($path);
-		}
-		@rmdir($this->root);
+		rmdir_recursive($this->root);
+		$this->assertDirectoryDoesNotExist($this->root);
 	}
 
 	public function testRanFlagIsSetOnlyAfterTheMatchingFamilyRunnerCompletes(): void

--- a/tests/php/IpRegexBoundaryGuardTest.php
+++ b/tests/php/IpRegexBoundaryGuardTest.php
@@ -8,8 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Boundary + mask guards on the production IP extraction regexes (issue #1922),
- * pinned against the real $pfb['ipv4'] / $pfb['ipv6'] / $pfb['range'] literals
- * extracted from pfblockerng_apply.inc.
+ * exercised through the production regex configuration seam.
  *
  * The defect class is silent address fabrication: a valid-looking address that
  * appears nowhere in the input is extracted and blocked (v4.1.2.3.4 -> 4.1.2.3),
@@ -34,18 +33,10 @@ final class IpRegexBoundaryGuardTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
-		$src = (string) file_get_contents($path);
-
-		self::assertSame(1, preg_match("/\\\$pfb\\['ipv4'\\]\\s*=\\s*'(.*)';/", $src, $m4),
-			'could not locate $pfb[\'ipv4\'] literal');
-		self::assertSame(1, preg_match("/\\\$pfb\\['ipv6'\\]\\s*=\\s*'(.*)';/", $src, $m6),
-			'could not locate $pfb[\'ipv6\'] literal');
-		self::assertSame(1, preg_match("/\\\$pfb\\['range'\\]\\s*=\\s*'(.*)';/", $src, $mr),
-			'could not locate $pfb[\'range\'] literal');
-		self::$reV4    = $m4[1];
-		self::$reV6    = $m6[1];
-		self::$reRange = $mr[1];
+		$config = pfb_ip_regex_config();
+		self::$reV4    = $config['ipv4'];
+		self::$reV6    = $config['ipv6'];
+		self::$reRange = $config['range'];
 	}
 
 	/** @return array{vtype:string,pftype:string,custom:bool,cidr_floor_v4:int|string,cidr_floor_v6:int|string,suppression:string,range:string,ipv4:string,ipv6:string} */

--- a/tests/php/IpRegexPrefilterGuardTest.php
+++ b/tests/php/IpRegexPrefilterGuardTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * IP regex prefilter guards in pfb_ip_parse_line() (pfblockerng_apply.inc),
- * pinned here against the real regex literals extracted from the production file.
+ * exercised through the production regex-match seam.
  *
  * The two preg_match_all fallback parsers run on $raw_line (the original feed line,
  * which may carry IPs embedded in mid-line noise) and are gated by a cheap
@@ -36,40 +36,24 @@ final class IpRegexPrefilterGuardTest extends TestCase
 {
 	private static string $reV4;
 	private static string $reV6;
-	private static string $src;
 
 	public static function setUpBeforeClass(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
-		self::$src = (string) file_get_contents($path);
-
-		// Extract the real regex literals (single-line, single-quoted) so the
-		// invariant tracks the shipped regex — a regex change that let a guarded
-		// line slip through would break the equivalence assertions below.
-		self::assertSame(1, preg_match("/\\\$pfb\\['ipv4'\\]\\s*=\\s*'(.*)';/", self::$src, $m4),
-			'could not locate $pfb[\'ipv4\'] literal');
-		self::assertSame(1, preg_match("/\\\$pfb\\['ipv6'\\]\\s*=\\s*'(.*)';/", self::$src, $m6),
-			'could not locate $pfb[\'ipv6\'] literal');
-		self::$reV4 = $m4[1];
-		self::$reV6 = $m6[1];
+		$config = pfb_ip_regex_config();
+		self::$reV4 = $config['ipv4'];
+		self::$reV6 = $config['ipv6'];
 	}
 
 	/** Mimic the production IPv4 guarded path: dot-count guard then regex. */
 	private function guardedV4(string $line): array
 	{
-		if (substr_count($line, '.') >= 3 && preg_match_all(self::$reV4, $line, $m)) {
-			return $m[0];
-		}
-		return [];
+		return pfb_ip_regex_matches('v4', $line, ['ipv4' => self::$reV4, 'ipv6' => self::$reV6]);
 	}
 
 	/** Mimic the production IPv6 guarded path: colon-presence guard then regex. */
 	private function guardedV6(string $line): array
 	{
-		if (strpos($line, ':') !== FALSE && preg_match_all(self::$reV6, $line, $m)) {
-			return $m[0];
-		}
-		return [];
+		return pfb_ip_regex_matches('v6', $line, ['ipv4' => self::$reV4, 'ipv6' => self::$reV6]);
 	}
 
 	/** The unguarded reference: raw regex, exactly the pre-guard behaviour. */
@@ -185,19 +169,11 @@ final class IpRegexPrefilterGuardTest extends TestCase
 		$this->assertSame([], $this->guardedV6($line));
 	}
 
-	/**
-	 * Source-pin: the shipped guards are the necessary-condition (presence) form,
-	 * NOT a start-anchored one. If someone rewrites either guard to test the line
-	 * START, the embedded-match data-provider cases above already fail; this pins
-	 * the exact predicate so the guard cannot be silently dropped or re-shaped.
-	 */
-	public function testProductionGuardsArePresenceChecks(): void
+	public function testGuardRejectsUnknownFamilyWithoutRunningARegex(): void
 	{
-		$this->assertStringContainsString(
-			"substr_count(\$raw_line, '.') >= 3 && preg_match_all(\$config['ipv4'], \$raw_line, \$matches)",
-			self::$src, 'IPv4 dot-count prefilter guard missing or altered');
-		$this->assertStringContainsString(
-			"strpos(\$raw_line, ':') !== FALSE && preg_match_all(\$config['ipv6'], \$raw_line, \$matches)",
-			self::$src, 'IPv6 colon prefilter guard missing or altered');
+		$this->assertSame([], pfb_ip_regex_matches('other', '192.0.2.1', [
+			'ipv4' => '(?!)',
+			'ipv6' => '(?!)',
+		]));
 	}
 }

--- a/tests/php/IpRegexPrefilterGuardTest.php
+++ b/tests/php/IpRegexPrefilterGuardTest.php
@@ -171,9 +171,39 @@ final class IpRegexPrefilterGuardTest extends TestCase
 
 	public function testGuardRejectsUnknownFamilyWithoutRunningARegex(): void
 	{
-		$this->assertSame([], pfb_ip_regex_matches('other', '192.0.2.1', [
-			'ipv4' => '(?!)',
-			'ipv6' => '(?!)',
-		]));
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$result = pfb_ip_regex_matches('other', '192.0.2.1', [
+				'ipv4' => '/[/',
+				'ipv6' => '/[/',
+			]);
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame([], $result);
+		$this->assertSame([], $diagnostics, 'an unknown family must never reach preg_match_all');
+	}
+
+	public function testV4ControlWouldWarnIfItsRegexRan(): void
+	{
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		});
+		try {
+			$result = pfb_ip_regex_matches('v4', '192.0.2.1', [
+				'ipv4' => '/[/',
+				'ipv6' => '/[/',
+			]);
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame([], $result);
+		$this->assertNotEmpty($diagnostics, 'the v4 control must prove its malformed regex was evaluated');
 	}
 }

--- a/tests/php/IpSettingsAdvAliasValidationTest.php
+++ b/tests/php/IpSettingsAdvAliasValidationTest.php
@@ -12,8 +12,8 @@ use PHPUnit\Framework\TestCase;
  * (pfblockerng_<Continent>.php) via file_put_contents. On a POST save those pages
  * process the four Advanced alias fields (aliasports_in / aliasaddr_in /
  * aliasports_out / aliasaddr_out) in TWO steps that this suite exercises together,
- * both extracted verbatim from the shipped template source so the real page code
- * runs — not a copy:
+ * both extracted from executable boundaries in the shipped template source so
+ * the real page code runs — not a copy:
  *
  *   1. Select-option normalization: each field whose submitted value is not a key
  *      in its dropdown options is reset to '' (its default). The options are built
@@ -50,30 +50,34 @@ final class IpSettingsAdvAliasValidationTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		$src = file_get_contents(
+		$src = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc'
 		);
-		self::assertNotFalse($src, 'could not read pfblockerng_geoip.inc');
+		self::assertNotSame('', $src, 'could not read pfblockerng_geoip.inc');
 
 		// Slice 1: build $options_aliasports_* / $options_aliasaddr_* from config.
 		$ok = preg_match(
-			'/\/\/ Collect all pfSense .Port. Aliases.*?(?=\$ports_list\s*=)/s',
+			'/(\$pfb_ac_lists\s*=\s*pfb_alias_autocomplete_lists\(config_get_path\(\x27aliases\/alias\x27, \[\]\)\);'
+			. '.*?)(?=\$ports_list\s*=)/s',
 			$src,
 			$m
 		);
 		self::assertSame(1, $ok, 'could not locate the alias-options block in pfblockerng_geoip.inc');
-		self::$optionsBlock = $m[0];
+		self::assertStringContainsString('$options_aliasaddr_out', $m[1]);
+		self::$optionsBlock = $m[1];
 
 		// Slice 2: the select-option normalization foreach(es) + the Advanced In/Out
 		// validation — the full save-time processing of the four alias fields.
 		$ok = preg_match(
-			'/\/\/ Validate Select field options.*?' .
-			'(?=\/\/ Validate Adv\. firewall rule \x27Protocol\x27 setting)/s',
+			'/(\$select_options\s*=\s*array\(\s*\x27action\x27\s*=>\s*\x27Disabled\x27'
+			. '.*?foreach \(pfb_adv_alias_field_errors\(\$_POST\) as \$pfb_alias_error\) \{.*?\})'
+			. '.*?(?=if \(!empty\(\$_POST\[\x27autoports_in\x27\]\))/s',
 			$src,
 			$m
 		);
 		self::assertSame(1, $ok, 'could not locate the alias normalization/validation block in pfblockerng_geoip.inc');
-		self::$processBlock = $m[0];
+		self::assertStringContainsString('pfb_adv_alias_field_errors', $m[1]);
+		self::$processBlock = $m[1];
 	}
 
 	protected function setUp(): void

--- a/tests/php/IpSuppressionEditorWiringTest.php
+++ b/tests/php/IpSuppressionEditorWiringTest.php
@@ -4,124 +4,20 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1875 step 2a (RED, test-first): mounting the CM6 editor on the IP page's two
- * suppression-list fields (v4suppression, v6suppression), gated by the same
- * `$pfb_syntaxhl_on` boolean idiom pfblockerng_dnsbl.php already establishes
- * (`pfb_editor_enabled()`, the issue #1887 named accessor).
- *
- * pfblockerng_ip.php has NO $pfb_syntaxhl_on boolean, NO cm-regex.min.js include, and NO
- * events.push() block at all today (verified this session) -- step 2b must introduce all
- * three from scratch on this page, unlike pfblockerng_dnsbl.php which already carries the
- * boolean and the gated script include for its pre-existing pfb_regex_list init.
- *
- * pfblockerng_ip.php carries top-level render execution and cannot be require()d off-
- * appliance (same constraint as DnsblRegexHighlightWiringTest); reading the real source file
- * IS reading the render for this content -- this is the Tier-A ui_render coverage for this
- * page's rollout.
- *
- * Split: every wiring assertion below is RED today (none of this exists yet). The two
- * Form_Textarea field pins are GREEN today by design: they pin the existing POST contract,
- * which step 2b's client-side-only overlay must not touch -- mixed red/green within this
- * file is expected and is the point.
- */
 final class IpSuppressionEditorWiringTest extends TestCase
 {
-	private static string $src;
-
-	public static function setUpBeforeClass(): void
+	public function testDisabledEditorEmitsNoSuppressionMount(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_ip.php';
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('failed to read pfblockerng_ip.php');
-		}
-		self::$src = $src;
+		$this->assertSame('', pfb_ip_editor_render(FALSE)['lists']);
 	}
 
-	public function testGatingBooleanReadsThePfbSyntaxHighlightToggle(): void
+	public function testEnabledEditorMountsBothSuppressionFieldsExactlyOnce(): void
 	{
-		// LENIENT, not PfbToggle -- same rationale as DnsblRegexHighlightWiringTest's
-		// class docblock (a default-on field's '' off value cannot survive the live
-		// config round-trip under PfbToggle).
-		$this->assertMatchesRegularExpression(
-			"#\\\$pfb_syntaxhl_on\\s*=\\s*pfb_editor_enabled\\(\\)#",
-			self::$src,
-			'expected a $pfb_syntaxhl_on boolean derived from pfb_editor_enabled() (issue #1887 named accessor)'
-		);
-	}
+		$init = pfb_ip_editor_render(TRUE)['lists'];
 
-	public function testCmRegexScriptIsIncludedWithCacheBustingInsideTheGate(): void
-	{
-		// Tempered-dot gaps ((?:(?!endif).)*?), not bare .*? -- see
-		// DnsblRegexHighlightWiringTest's rationale for why bare .*? risks bridging past
-		// this gate's own endif.
-		$this->assertMatchesRegularExpression(
-			'#if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. '<script src="vendor/codemirror/cm-regex\.min\.js\?v=<\?=pfb_file_mtime\(\'/usr/local/www/pfblockerng/vendor/codemirror/cm-regex\.min\.js\'\)\?>"></script>'
-			. '(?:(?!endif).)*?endif#s',
-			self::$src,
-			'expected the cm-regex.min.js include, with mtime cache-busting, wrapped inside an if ($pfb_syntaxhl_on) gate'
-		);
-	}
-
-	public function testMountListsCallIsGatedInsideEventsPushBehindTheSyntaxHighlightBoolean(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'#events\.push\(function\(\)\s*\{(?:(?!endif).)*?if\s*\(\s*\$pfb_syntaxhl_on\s*\)\s*:(?:(?!endif).)*?'
-			. 'window\.pfbCM(?:(?!endif).)*?pfbCM\.mountLists\((?:(?!endif).)*?endif#s',
-			self::$src,
-			'expected a pfbCM.mountLists( call, guarded on window.pfbCM, inside an '
-			. 'events.push() block gated by if ($pfb_syntaxhl_on)'
-		);
-	}
-
-	public function testMountListsArrayContainsBothTargetFieldIds(): void
-	{
-		foreach (['v4suppression', 'v6suppression'] as $id) {
-			$this->assertMatchesRegularExpression(
-				"#pfbCM\\.mountLists\\(\\s*\\[(?:(?!\\]).)*?'" . preg_quote($id, '#') . "'(?:(?!\\]).)*?\\]\\s*\\)#s",
-				self::$src,
-				"expected '{$id}' inside the pfbCM.mountLists([...]) array argument"
-			);
-		}
-	}
-
-	/**
-	 * Vacuity-safe "off emits nothing new" proof, same rationale as
-	 * DnsblRegexHighlightWiringTest::testCmRegexAssetAndFromTextareaCallEachAppearExactlyOnceInTheWholeFile.
-	 */
-	public function testCmRegexAssetAndMountListsCallEachAppearExactlyOnceInTheWholeFile(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(self::$src, '<script src="vendor/codemirror/cm-regex.min.js?v='),
-			'expected exactly one cm-regex.min.js <script> tag in the whole file (the gated include) -- '
-			. 'a second, unguarded <script> tag would defeat the off-emits-nothing contract'
-		);
-		$this->assertSame(
-			1,
-			substr_count(self::$src, 'pfbCM.mountLists('),
-			'expected exactly one pfbCM.mountLists( call in the whole file (the gated events.push init) -- '
-			. 'a second, unguarded call would defeat the off-emits-nothing contract'
-		);
-	}
-
-	public function testOriginalV4suppressionTextareaFieldIsUnchanged(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'v4suppression',#",
-			self::$src,
-			'expected the underlying v4suppression Form_Textarea field to remain unchanged'
-		);
-	}
-
-	public function testOriginalV6suppressionTextareaFieldIsUnchanged(): void
-	{
-		$this->assertMatchesRegularExpression(
-			"#new Form_Textarea\\(\\s*'v6suppression',#",
-			self::$src,
-			'expected the underlying v6suppression Form_Textarea field to remain unchanged'
-		);
+		$this->assertStringContainsString('window.pfbCM', $init);
+		$this->assertSame(1, substr_count($init, 'pfbCM.mountLists('));
+		$this->assertStringContainsString('v4suppression', $init);
+		$this->assertStringContainsString('v6suppression', $init);
 	}
 }

--- a/tests/php/LintEndpointWiringTest.php
+++ b/tests/php/LintEndpointWiringTest.php
@@ -4,186 +4,83 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1732 source-scan pins for the lint-endpoint page
- * (pfblockerng_lint.php) and its priv.inc wiring. Same rationale as
- * EditHooksPageWiringTest: the page require_once()s guiconfig.inc, which needs
- * the full pfSense webConfigurator runtime this off-appliance PHPUnit tier does
- * not stand up, so the gate SHAPE is pinned at the source-text level instead of
- * an executed render.
- */
 final class LintEndpointWiringTest extends TestCase
 {
-	private const PAGE_PATH = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_lint.php';
-	private const PRIV_INC_PATH = __DIR__ . '/../../src/etc/inc/priv/pfblockerng.priv.inc';
+	private const ROOT = __DIR__ . '/../..';
+	private const PAGE = self::ROOT . '/src/usr/local/www/pfblockerng/pfblockerng_lint.php';
 
-	private static string $pageSrc;
-	private static string $privSrc;
-
-	public static function setUpBeforeClass(): void
+	public function testRealPageRejectsWrongMethodBeforeDispatch(): void
 	{
-		parent::setUpBeforeClass();
-		$pageSrc = file_get_contents(self::PAGE_PATH);
-		$privSrc = file_get_contents(self::PRIV_INC_PATH);
-		self::assertNotFalse($pageSrc, 'test oracle: failed to read ' . self::PAGE_PATH);
-		self::assertNotFalse($privSrc, 'test oracle: failed to read ' . self::PRIV_INC_PATH);
-		self::$pageSrc = $pageSrc;
-		self::$privSrc = $privSrc;
+		$result = $this->request(['lang' => 'regex', 'content' => 'x'], ['REQUEST_METHOD' => 'GET']);
+		$this->assertSame('POST only', $result['body']['error']);
 	}
 
-	private function firstDispatchCallPos(): int
+	public function testRealPageDispatchesAllowedRegexAndRejectsDeniedPython(): void
 	{
-		$pos = strpos(self::$pageSrc, 'pfb_lint_diagnostics(');
-		$this->assertNotFalse($pos, 'the endpoint must call pfb_lint_diagnostics(...)');
-		return $pos;
-	}
-
-	public function testRegexGatePresentAndBeforeDispatch(): void
-	{
-		$gatePos = strpos(self::$pageSrc, "isAllowedPage('pfblockerng/pfblockerng_dnsbl.php')");
-		$this->assertNotFalse(
-			$gatePos,
-			"the regex-lang gate must call isAllowedPage('pfblockerng/pfblockerng_dnsbl.php')"
+		$regex = $this->request(
+			['lang' => 'regex', 'content' => 'example.com'],
+			['REQUEST_METHOD' => 'POST'],
+			['pfblockerng/pfblockerng_dnsbl.php' => TRUE]
 		);
-		$this->assertLessThan($this->firstDispatchCallPos(), $gatePos, 'the regex gate must run before the lint dispatch');
-	}
+		$this->assertArrayHasKey('diagnostics', $regex['body']);
 
-	public function testShPyGatePresentAndBeforeDispatch(): void
-	{
-		$gatePos = strpos(self::$pageSrc, "isAllowedPage('diag_command.php')");
-		$this->assertNotFalse($gatePos, "the sh/py-lang gate must call isAllowedPage('diag_command.php')");
-		$this->assertLessThan($this->firstDispatchCallPos(), $gatePos, 'the sh/py gate must run before the lint dispatch');
-	}
-
-	public function testRegexGateStringAppearsExactlyOnce(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(self::$pageSrc, "'pfblockerng/pfblockerng_dnsbl.php'"),
-			'no second, ungated dispatch path for lang=regex'
+		$python = $this->request(
+			['lang' => 'py', 'content' => 'x'],
+			['REQUEST_METHOD' => 'POST'],
+			['diag_command.php' => FALSE]
 		);
+		$this->assertSame('insufficient privilege', $python['body']['error']);
 	}
 
-	public function testDiagCommandGateStringAppearsExactlyOnce(): void
+	public function testRealPageRejectsArrayAndOversizeContent(): void
 	{
-		$this->assertSame(
-			1,
-			substr_count(self::$pageSrc, "'diag_command.php'"),
-			'no second, ungated dispatch path for lang=sh/py'
+		$array = $this->request(
+			['lang' => 'regex', 'content' => ['x']],
+			['REQUEST_METHOD' => 'POST'],
+			['pfblockerng/pfblockerng_dnsbl.php' => TRUE]
 		);
-	}
+		$this->assertSame('content must be a string', $array['body']['error']);
 
-	public function testExactlyOneDispatchCallSite(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(self::$pageSrc, 'pfb_lint_diagnostics('),
-			'exactly one dispatch call site -- no second ungated path'
+		$large = $this->request(
+			['lang' => 'regex', 'content' => str_repeat('x', 1048577)],
+			['REQUEST_METHOD' => 'POST'],
+			['pfblockerng/pfblockerng_dnsbl.php' => TRUE]
 		);
+		$this->assertSame('content too large', $large['body']['error']);
 	}
 
-	public function testLangAllowListRestrictedToRegexShPy(): void
+	/** @param array<string,mixed> $post @param array<string,string> $server @param array<string,bool> $allowed @return array{body:array<string,mixed>} */
+	private function request(array $post, array $server, array $allowed = []): array
 	{
-		$this->assertMatchesRegularExpression(
-			"/in_array\\(\\\$lang,\\s*\\['regex',\\s*'sh',\\s*'py'\\]/",
-			self::$pageSrc,
-			'the lang allow-list must be restricted to regex|sh|py'
-		);
-	}
-
-	public function testLangIsStringGuardPresent(): void
-	{
-		$this->assertStringContainsString(
-			'is_string($lang)',
-			self::$pageSrc,
-			'a crafted lang[]= array must be rejected by an is_string() guard'
-		);
-	}
-
-	public function testContentIsStringGuardPresent(): void
-	{
-		$this->assertStringContainsString(
-			'is_string($content)',
-			self::$pageSrc,
-			'a crafted content[]= array must be rejected by an is_string() guard'
-		);
-	}
-
-	public function testJsonContentTypeHeaderPresent(): void
-	{
-		$this->assertStringContainsString('Content-Type: application/json', self::$pageSrc);
-	}
-
-	public function testJsonContentTypeHeaderCarriesUtf8Charset(): void
-	{
-		$this->assertStringContainsString(
-			"Content-Type: application/json; charset=utf-8",
-			self::$pageSrc,
-			'the JSON reply header must declare charset=utf-8'
-		);
-	}
-
-	public function testJsonEncodeCarriesInvalidUtf8Substitute(): void
-	{
-		$this->assertMatchesRegularExpression(
-			'/json_encode\([^)]*JSON_INVALID_UTF8_SUBSTITUTE/',
-			self::$pageSrc,
-			'json_encode(...) must pass JSON_INVALID_UTF8_SUBSTITUTE -- else a diagnostic ' .
-				'message carrying invalid UTF-8 makes json_encode() return false (200 with an empty body)'
-		);
-	}
-
-	public function testPostOnlyCheckPresent(): void
-	{
-		$this->assertStringContainsString('REQUEST_METHOD', self::$pageSrc);
-		$this->assertStringContainsString("!== 'POST'", self::$pageSrc);
-	}
-
-	public function testSizeCapLiteralPresent(): void
-	{
-		$this->assertStringContainsString('1048576', self::$pageSrc);
-	}
-
-	public function testNeverCallsExecFamilyDirectly(): void
-	{
-		foreach (['proc_open(', 'exec(', 'shell_exec(', 'system(', 'passthru('] as $sink) {
-			$this->assertStringNotContainsString(
-				$sink,
-				self::$pageSrc,
-				"the endpoint must never call {$sink} directly -- launching lives in pfblockerng_extra.inc"
-			);
-		}
-	}
-
-	public function testNeverWritesSubmittedContentToDisk(): void
-	{
-		foreach (['file_put_contents(', 'fwrite('] as $sink) {
-			$this->assertStringNotContainsString(
-				$sink,
-				self::$pageSrc,
-				"the endpoint must never {$sink} the submitted content -- never written to disk"
-			);
-		}
-	}
-
-	public function testPrivIncHasExactlyOneLintMatchEntry(): void
-	{
-		$this->assertSame(
-			1,
-			substr_count(
-				self::$privSrc,
-				'$priv_list[\'page-firewall-pfblockerng\'][\'match\'][] = "pfblockerng/pfblockerng_lint.php";'
-			),
-			'the lint endpoint must have exactly one priv.inc match entry'
-		);
-	}
-
-	public function testPrivIncStillExcludesEditHooksPage(): void
-	{
-		$this->assertStringNotContainsString(
-			'"pfblockerng/pfblockerng_edit_hooks.php"',
-			self::$privSrc,
-			'pfblockerng_edit_hooks.php must stay out of the match list (existing invariant)'
-		);
+		$payload = json_encode(compact('post', 'server', 'allowed'), JSON_THROW_ON_ERROR);
+		$root = var_export(self::ROOT, TRUE);
+		$page = var_export(self::PAGE, TRUE);
+		$script = <<<PHP
+\$request = json_decode(stream_get_contents(STDIN), TRUE, 512, JSON_THROW_ON_ERROR);
+\$GLOBALS['pfb_test_allowed_pages'] = \$request['allowed'];
+\$_SERVER = \$request['server'];
+\$_POST = \$request['post'];
+\$shim = sys_get_temp_dir() . '/pfb_lint_shim_' . getmypid();
+mkdir(\$shim, 0777, TRUE);
+file_put_contents(\$shim . '/guiconfig.inc', "<?php");
+set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+require {$root} . '/tests/php/bootstrap.php';
+require {$page};
+PHP;
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
+		$this->assertIsResource($process);
+		fwrite($pipes[0], $payload);
+		fclose($pipes[0]);
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
+		$this->assertSame('', trim((string) $stderr), (string) $stderr);
+		$body = json_decode((string) $stdout, TRUE);
+		$this->assertIsArray($body, (string) $stdout);
+		$this->assertSame(0, $status);
+		return ['body' => $body];
 	}
 }

--- a/tests/php/ListScriptExitStatusTest.php
+++ b/tests/php/ListScriptExitStatusTest.php
@@ -2,29 +2,11 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1927: the per-feed list pre/post transform scripts' exit status must be
- * honoured — a failed transform is not feed data.
- *
- * pfb_list_script_exec() runs a vetted list script under timeout(1) and returns
- * its exit code; non-zero (124 = timed out) is logged to the pfBlockerNG log AND
- * the error log, naming the stage, the script, and the feed. $tmo_prefix is
- * injectable for off-appliance tests (the appliance default wraps /usr/bin/timeout).
- *
- * The apply-loop call sites gate on that code — a failed pre-script's leftovers
- * are never parsed (the download is restored and the last known-good staged list
- * kept), and a failed post-script's leftovers never feed the empty-feed check.
- * Those sites sit inside the thousands-of-lines sync loop driving real appliance
- * exec, so they are pinned by source inspection (same technique as
- * GunzipTrailingNewlineWiringTest); the behaviour itself is proven on the helper.
- */
-#[CoversFunction('pfb_list_script_exec')]
 final class ListScriptExitStatusTest extends TestCase
 {
-	private static string $applySource;
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
 
 	private string $tmp;
 	/** @var array<string, mixed> */
@@ -33,20 +15,13 @@ final class ListScriptExitStatusTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		$source = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
-		);
-		if ($source === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
-		}
-		self::$applySource = $source;
+		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
 	}
 
 	protected function setUp(): void
 	{
-		$this->tmp = sys_get_temp_dir() . '/pfb_lse_' . getmypid() . '_' . bin2hex(random_bytes(4));
-		mkdir($this->tmp, 0755, TRUE);
-
+		$this->tmp = sys_get_temp_dir() . '/pfb_script_exit_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->tmp, 0700, TRUE));
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
 		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
@@ -62,10 +37,10 @@ final class ListScriptExitStatusTest extends TestCase
 		} else {
 			unset($GLOBALS['pfb']);
 		}
-		foreach (glob("{$this->tmp}/*") ?: [] as $f) {
-			unlink($f);
+		foreach (glob("{$this->tmp}/*") ?: [] as $file) {
+			@unlink($file);
 		}
-		rmdir($this->tmp);
+		@rmdir($this->tmp);
 	}
 
 	private function makeScript(string $name, string $body): string
@@ -76,143 +51,201 @@ final class ListScriptExitStatusTest extends TestCase
 		return $path;
 	}
 
-	private function mainLog(): string
+	private function log(string $name): string
 	{
-		return (string) @file_get_contents("{$this->tmp}/pfblockerng.log");
+		return (string) @file_get_contents("{$this->tmp}/{$name}");
 	}
 
-	private function errorLog(): string
+	private function applyScope(string $source, string $start, string $end): string
 	{
-		return (string) @file_get_contents("{$this->tmp}/error.log");
+		$from = strrpos($source, $start);
+		if ($from === FALSE) {
+			throw new RuntimeException("missing apply scope start: {$start}");
+		}
+		$to = strpos($source, $end, $from + strlen($start));
+		if ($to === FALSE) {
+			throw new RuntimeException("missing apply scope end: {$end}");
+		}
+		return substr($source, $from, $to + strlen($end) - $from);
 	}
 
-	public function testZeroExitReturnsZeroAndLogsNoFailure(): void
+	public function testZeroExitIsReturnedWithoutFailureLog(): void
 	{
-		$script = $this->makeScript('ip_pre_ok.sh', 'exit 0');
+		$script = $this->makeScript('ok.sh', 'exit 0');
 
-		$ret = pfb_list_script_exec($script, 'ip_pre_ok.sh', 'pre', 'MyFeed_v4', '', '');
-
-		$this->assertSame(0, $ret, 'a successful script must report exit 0 to the caller');
-		$this->assertStringNotContainsString('exited non-zero', $this->mainLog(),
-			'a zero exit must not log a failure');
-		$this->assertStringNotContainsString('TIMED OUT', $this->mainLog(),
-			'a zero exit must not log a timeout');
+		$this->assertSame(0, pfb_list_script_exec($script, 'ok.sh', 'pre', 'Feed', '', ''));
+		$this->assertStringNotContainsString('exited non-zero', $this->log('pfblockerng.log'));
 	}
 
-	public function testNonZeroExitIsReturnedAndLoggedNamingStageScriptAndFeed(): void
+	public function testNonZeroExitIsReturnedAndNamesStageScriptAndFeed(): void
 	{
-		$script = $this->makeScript('ip_pre_AWS_fail.sh', 'exit 7');
+		$script = $this->makeScript('fail.sh', 'exit 7');
 
-		$ret = pfb_list_script_exec($script, 'ip_pre_AWS_fail.sh', 'pre', 'MyFeed_v4', '', '');
-
-		$this->assertSame(7, $ret, 'the script exit code must be surfaced, not discarded');
-		$log = $this->mainLog();
-		$this->assertStringContainsString("pre-script 'ip_pre_AWS_fail.sh'", $log,
-			'the failure log line must name the stage and the script');
-		$this->assertStringContainsString('MyFeed_v4', $log,
-			'the failure log line must name the feed');
-		$this->assertStringContainsString('[ 7 ]', $log,
-			'the failure log line must carry the exit code');
-		$this->assertStringContainsString('exited non-zero', $this->errorLog(),
-			'the failure must also surface in the error log');
+		$this->assertSame(7, pfb_list_script_exec($script, 'fail.sh', 'pre', 'Feed', '', ''));
+		$log = $this->log('pfblockerng.log');
+		$this->assertStringContainsString("pre-script 'fail.sh'", $log);
+		$this->assertStringContainsString('Feed', $log);
+		$this->assertStringContainsString('[ 7 ]', $log);
+		$this->assertStringContainsString('exited non-zero', $this->log('error.log'));
 	}
 
-	public function testExit124IsLoggedAsTimedOut(): void
+	public function testExit124IsReportedAsTimeout(): void
 	{
-		// timeout(1) reports an overrun as exit 124 — indistinguishable from the
-		// script exiting 124 itself, which is exactly what the helper keys on.
-		$script = $this->makeScript('ip_post_slow.sh', 'exit 124');
+		$script = $this->makeScript('slow.sh', 'exit 124');
 
-		$ret = pfb_list_script_exec($script, 'ip_post_slow.sh', 'post', 'SlowFeed_v6', '', '');
-
-		$this->assertSame(124, $ret);
-		$log = $this->mainLog();
-		$this->assertStringContainsString('TIMED OUT', $log,
-			'exit 124 must be reported as a timeout, not a generic non-zero');
-		$this->assertStringContainsString("post-script 'ip_post_slow.sh'", $log);
-		$this->assertStringContainsString('SlowFeed_v6', $log);
-		$this->assertStringContainsString('TIMED OUT', $this->errorLog(),
-			'the timeout must also surface in the error log');
+		$this->assertSame(124, pfb_list_script_exec($script, 'slow.sh', 'post', 'Feed', '', ''));
+		$this->assertStringContainsString('TIMED OUT', $this->log('pfblockerng.log'));
+		$this->assertStringContainsString('TIMED OUT', $this->log('error.log'));
 	}
 
-	public function testPreScriptCallSiteGatesOnExitStatus(): void
+	public function testSuccessfulPreScriptUsesStagedCopyAndLeavesNormalizedInput(): void
 	{
-		// issue #1925: the pre-script now runs AFTER normalize + reuse-skip, on a
-		// staged copy of the normalized output — never before it.
-		$reuseSkipPos = strpos(self::$applySource, 'pfb_ip_norm_reuse_skip(');
-		$this->assertNotFalse($reuseSkipPos, 'vacuity: the IP-loop normalize/reuse-skip step must exist');
+		$norm   = "{$this->tmp}/feed.norm";
+		$staged = "{$this->tmp}/feed.pre";
+		$script = $this->makeScript('rewrite.sh', 'printf changed > "$1"');
+		file_put_contents($norm, 'original');
 
-		$prePos = strpos(self::$applySource, 'Executing pre-script:', $reuseSkipPos);
-		$this->assertNotFalse($prePos, 'vacuity: the pre-script call site must exist');
-		$this->assertGreaterThan($reuseSkipPos, $prePos,
-			'the pre-script must run after normalize + reuse-skip, never before it');
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'rewrite.sh', 'Feed', escapeshellarg($staged), '');
 
-		$parsePos = strpos(self::$applySource, 'pfb_ip_parse_line(', $prePos);
-		$this->assertNotFalse($parsePos, 'vacuity: the parse step after the pre-script must exist');
-
-		$between = substr(self::$applySource, $prePos, $parsePos - $prePos);
-		$this->assertStringContainsString('pfb_list_pre_script_run(', $between,
-			'the pre-script must run through the staged-copy runner');
-		$this->assertStringContainsString('continue;', $between,
-			'on failure the row must skip the parse, keeping the last known-good staged list');
-		$this->assertStringContainsString('{$list[\'vtype\']}', $between,
-			'v4/v6 vtype must pass through to the pre-script args');
-
-		$this->assertStringNotContainsString('.orig.pre', self::$applySource,
-			'.orig.pre must be fully retired — the pre-script never touches the raw download');
+		$this->assertTrue($result['ok']);
+		$this->assertSame($staged, $result['path']);
+		$this->assertSame('original', file_get_contents($norm));
+		$this->assertSame('changed', file_get_contents($staged));
 	}
 
-	public function testEmptyFeedProbeReadsTheContentTheParseConsumed(): void
+	public function testFailedPreScriptDiscardsStagedOutputAndKeepsNormalizedInput(): void
 	{
-		$probePos = strpos(self::$applySource, 'Check to see if list actually failed download');
-		$this->assertNotFalse($probePos, 'vacuity: the empty-feed probe must exist');
+		$norm   = "{$this->tmp}/feed.norm";
+		$staged = "{$this->tmp}/feed.pre";
+		$script = $this->makeScript('fail-rewrite.sh', 'printf bad > "$1"; exit 7');
+		file_put_contents($norm, 'original');
 
-		$suppressedPos = strpos(self::$applySource, 'All parsed IPv6 entries were suppressed', $probePos);
-		$this->assertNotFalse($suppressedPos, 'vacuity: the v6-suppression block after the probe must exist');
+		$result = pfb_list_pre_script_run($norm, $staged, $script, 'fail-rewrite.sh', 'Feed', escapeshellarg($staged), '');
 
-		$between = substr(self::$applySource, $probePos, $suppressedPos - $probePos);
-		$this->assertStringContainsString("\$pfb_parse_path === \$pfb_norm['path']", $between,
-			'the probe must select the content the parse consumed — a pre-script synthesizes or '
-			. 'reduces entries, so the raw download\'s emptiness is not the feed\'s');
-
-		// The staged copy must outlive the probe READ: the grep on $pfb_probe comes
-		// first, the unlink after it — a cleanup hoisted above the read would probe
-		// a deleted file.
-		$readPos = strpos(self::$applySource, 'escapeshellarg($pfb_probe)', $probePos);
-		$this->assertNotFalse($readPos, 'vacuity: the probe must read $pfb_probe');
-		$this->assertLessThan($suppressedPos, $readPos,
-			'the probe read must sit inside the empty-feed block');
-
-		$unlinkPos = strpos(self::$applySource, 'unlink_if_exists("{$file_dwn}.pre")', $probePos);
-		$this->assertNotFalse($unlinkPos,
-			'the staged pre-script copy must be unlinked AFTER the empty-feed probe consumed it');
-		$this->assertGreaterThan($readPos, $unlinkPos,
-			'the staged-copy unlink must come after the probe read, never before it');
-		$this->assertLessThan($suppressedPos, $unlinkPos,
-			'the staged-copy unlink must sit between the probe and the v6-suppression block');
+		$this->assertFalse($result['ok']);
+		$this->assertSame($norm, $result['path']);
+		$this->assertFileDoesNotExist($staged);
+		$this->assertSame('original', file_get_contents($norm));
 	}
 
-	public function testPostScriptCallSiteGatesOnExitStatus(): void
+	public function testPreScriptWithMissingInputFailsWithoutProducingData(): void
 	{
-		// issue #1926: the DNSBL loop now logs the same "Executing post-script:" line
-		// earlier in the file -- anchor past the IP-loop's own reuse-skip call site
-		// (same technique as testPreScriptCallSiteGatesOnExitStatus) so this finds the
-		// IP-loop's occurrence, not the DNSBL one.
-		$reuseSkipPos = strpos(self::$applySource, 'pfb_ip_norm_reuse_skip(');
-		$this->assertNotFalse($reuseSkipPos, 'vacuity: the IP-loop normalize/reuse-skip step must exist');
+		$staged = "{$this->tmp}/feed.pre";
+		$script = $this->makeScript('unused.sh', 'exit 0');
 
-		$postPos = strpos(self::$applySource, 'Executing post-script:', $reuseSkipPos);
-		$this->assertNotFalse($postPos, 'vacuity: the post-script call site must exist');
+		$result = pfb_list_pre_script_run("{$this->tmp}/missing.norm", $staged, $script, 'unused.sh', 'Feed', escapeshellarg($staged), '');
 
-		$chkPos = strpos(self::$applySource, 'if (!$custom) {', $postPos);
-		$this->assertNotFalse($chkPos, 'vacuity: the empty-feed check after the post-script must exist');
+		$this->assertFalse($result['ok']);
+		$this->assertFileDoesNotExist($staged);
+	}
 
-		$between = substr(self::$applySource, $postPos, $chkPos - $postPos);
-		$this->assertStringContainsString('pfb_list_script_exec(', $between,
-			'the post-script must run through the exit-status-honouring runner');
-		$this->assertStringContainsString('!== 0', $between,
-			'the post-script exit status must be examined, not discarded');
-		$this->assertStringContainsString('@rename("{$file_dwn}.orig.post", "{$file_dwn}.orig")', $between,
-			'on failure the saved download must be restored before the empty-feed check reads it');
+	public function testDnsblSuccessfulPreScriptConsumesBeforeCleanup(): void
+	{
+		$staged = "{$this->tmp}/feed.pre";
+		file_put_contents($staged, 'dnsbl-data');
+		$events = [];
+
+		$result = pfb_dnsbl_script_consume_staged($staged, $staged, function (string $path) use (&$events): string {
+			$events[] = 'consume:' . file_get_contents($path);
+			return 'parsed';
+		});
+
+		$this->assertSame('parsed', $result);
+		$this->assertSame(['consume:dnsbl-data'], $events);
+		$this->assertFileDoesNotExist($staged);
+	}
+
+	public function testIpSuccessfulPreScriptConsumesBeforeCleanup(): void
+	{
+		$staged = "{$this->tmp}/feed.pre";
+		file_put_contents($staged, 'ip-data');
+		$events = [];
+
+		$result = pfb_ip_script_consume_staged($staged, $staged, function (string $path) use (&$events): string {
+			$events[] = 'consume:' . file_get_contents($path);
+			return 'probed';
+		});
+
+		$this->assertSame('probed', $result);
+		$this->assertSame(['consume:ip-data'], $events);
+		$this->assertFileDoesNotExist($staged);
+	}
+
+	public function testCustomIpFeedSkipsProbeButStillRemovesTheStagedCopy(): void
+	{
+		$staged = "{$this->tmp}/custom.pre";
+		file_put_contents($staged, 'custom-data');
+		$probes = 0;
+
+		$result = pfb_ip_script_probe_staged(TRUE, $staged, $staged, static function () use (&$probes): string {
+			$probes++;
+			return 'unexpected';
+		});
+
+		$this->assertNull($result);
+		$this->assertSame(0, $probes);
+		$this->assertFileDoesNotExist($staged);
+	}
+
+	public function testDnsblKnownPrePathIsRemovedWithoutAnActiveStagedCopy(): void
+	{
+		$norm  = "{$this->tmp}/feed.norm";
+		$known = "{$this->tmp}/feed.pre";
+		file_put_contents($known, 'stale-dnsbl-data');
+
+		$result = pfb_dnsbl_script_consume_staged(
+			$norm,
+			NULL,
+			static fn(string $path): string => $path,
+			$known
+		);
+
+		$this->assertSame($norm, $result);
+		$this->assertFileDoesNotExist($known,
+			'a processed DNSBL row must remove a stale known .pre path even without a pre-script stage');
+	}
+
+	public function testIpKnownPrePathIsRemovedWithoutAnActiveStagedCopy(): void
+	{
+		$norm  = "{$this->tmp}/feed.norm";
+		$known = "{$this->tmp}/feed.pre";
+		file_put_contents($known, 'stale-ip-data');
+
+		$result = pfb_ip_script_probe_staged(
+			FALSE,
+			$norm,
+			NULL,
+			static fn(string $path): string => $path,
+			$known
+		);
+
+		$this->assertSame($norm, $result);
+		$this->assertFileDoesNotExist($known,
+			'a processed IP row must remove a stale known .pre path even without a pre-script stage');
+	}
+
+	/**
+	 * #993: sync_package_pfblockerng() is a top-level appliance orchestration path that
+	 * downloads feeds and mutates firewall/service state, so it has no safe off-appliance
+	 * driver. php_strip_whitespace() makes these six route pins independent of comments.
+	 */
+	public function testEachFeedFamilyDispatchesEveryScriptStageOnce(): void
+	{
+		$source      = php_strip_whitespace(self::APPLY);
+		$dnsbl_pre   = $this->applyScope($source, 'if ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) {', 'pfb_dnsbl_script_failure_continue($alias,');
+		$dnsbl_stage = $this->applyScope($source, 'pfb_dnsbl_script_consume_staged(', 'if (!empty($domain_data)) {');
+		$dnsbl_post  = $this->applyScope($source, 'if ($pfb_dnsbl_script_post && is_file("{$pfb_dnsbl_script_post}")) {', 'if (isset($csvline)) {');
+		$ip_pre      = $this->applyScope($source, 'if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {', 'pfb_ip_script_failure_continue($alias,');
+		$ip_stage    = $this->applyScope($source, '$file_chk = pfb_ip_script_probe_staged(', 'if (!$custom && $file_chk == 0) {');
+		$ip_post     = $this->applyScope($source, 'if ($pfb_script_post && is_file("{$pfb_script_post}")) {', '$file_chk = pfb_ip_script_probe_staged(');
+
+		$this->assertSame(1, substr_count($dnsbl_pre, 'pfb_list_pre_script_run($pfb_norm[\'path\']'), 'DNSBL pre-script dispatch must stay in its loop');
+		$this->assertSame(1, substr_count($dnsbl_stage, 'pfb_dnsbl_script_consume_staged('), 'DNSBL staged input must be consumed once');
+		$this->assertStringContainsString('"{$file_dwn}.pre"', $dnsbl_stage, 'DNSBL staged seam must receive its known cleanup path');
+		$this->assertSame(1, substr_count($dnsbl_post, 'pfb_list_script_exec($pfb_dnsbl_script_post, $list[\'script_post\'], \'post\''), 'DNSBL post-script dispatch must stay in its loop');
+		$this->assertSame(1, substr_count($ip_pre, 'pfb_list_pre_script_run($pfb_norm[\'path\']'), 'IP pre-script dispatch must stay in its loop');
+		$this->assertSame(1, substr_count($ip_stage, 'pfb_ip_script_probe_staged('), 'IP staged input must be probed once');
+		$this->assertStringContainsString('"{$file_dwn}.pre"', $ip_stage, 'IP staged seam must receive its known cleanup path');
+		$this->assertSame(1, substr_count($ip_post, 'pfb_list_script_exec($pfb_script_post, $list[\'script_post\'], \'post\''), 'IP post-script dispatch must stay in its loop');
 	}
 }

--- a/tests/php/ListScriptExitStatusTest.php
+++ b/tests/php/ListScriptExitStatusTest.php
@@ -15,7 +15,7 @@ final class ListScriptExitStatusTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+		require_once self::APPLY;
 	}
 
 	protected function setUp(): void
@@ -233,19 +233,31 @@ final class ListScriptExitStatusTest extends TestCase
 	{
 		$source      = php_strip_whitespace(self::APPLY);
 		$dnsbl_pre   = $this->applyScope($source, 'if ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) {', 'pfb_dnsbl_script_failure_continue($alias,');
-		$dnsbl_stage = $this->applyScope($source, 'pfb_dnsbl_script_consume_staged(', 'if (!empty($domain_data)) {');
+		$dnsbl_loop  = 'if (($dhandle = @fopen("{$pfbfolder}/{$header}.bk", \'w\')) !== FALSE) {';
+		$dnsbl_end   = 'if (!empty($domain_data)) {';
+		$dnsbl_stage = $this->applyScope($source, $dnsbl_loop, $dnsbl_end);
 		$dnsbl_post  = $this->applyScope($source, 'if ($pfb_dnsbl_script_post && is_file("{$pfb_dnsbl_script_post}")) {', 'if (isset($csvline)) {');
 		$ip_pre      = $this->applyScope($source, 'if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {', 'pfb_ip_script_failure_continue($alias,');
 		$ip_stage    = $this->applyScope($source, '$file_chk = pfb_ip_script_probe_staged(', 'if (!$custom && $file_chk == 0) {');
 		$ip_post     = $this->applyScope($source, 'if ($pfb_script_post && is_file("{$pfb_script_post}")) {', '$file_chk = pfb_ip_script_probe_staged(');
 
 		$this->assertSame(1, substr_count($dnsbl_pre, 'pfb_list_pre_script_run($pfb_norm[\'path\']'), 'DNSBL pre-script dispatch must stay in its loop');
-		$this->assertSame(1, substr_count($dnsbl_stage, 'pfb_dnsbl_script_consume_staged('), 'DNSBL staged input must be consumed once');
+		$dnsbl_cleanup = 'pfb_list_script_cleanup_staged($pfb_parse_path, $pfb_staged_path, "{$file_dwn}.pre");';
+		$this->assertSame(1, substr_count($dnsbl_stage, $dnsbl_cleanup), 'DNSBL staged input cleanup must stay in its loop');
 		$this->assertStringContainsString('"{$file_dwn}.pre"', $dnsbl_stage, 'DNSBL staged seam must receive its known cleanup path');
 		$this->assertSame(1, substr_count($dnsbl_post, 'pfb_list_script_exec($pfb_dnsbl_script_post, $list[\'script_post\'], \'post\''), 'DNSBL post-script dispatch must stay in its loop');
 		$this->assertSame(1, substr_count($ip_pre, 'pfb_list_pre_script_run($pfb_norm[\'path\']'), 'IP pre-script dispatch must stay in its loop');
 		$this->assertSame(1, substr_count($ip_stage, 'pfb_ip_script_probe_staged('), 'IP staged input must be probed once');
 		$this->assertStringContainsString('"{$file_dwn}.pre"', $ip_stage, 'IP staged seam must receive its known cleanup path');
 		$this->assertSame(1, substr_count($ip_post, 'pfb_list_script_exec($pfb_script_post, $list[\'script_post\'], \'post\''), 'IP post-script dispatch must stay in its loop');
+
+		$removed = 0;
+		$mutant = str_replace($dnsbl_cleanup, '', $source, $removed);
+		$this->assertSame(1, $removed, 'mutation fixture must remove the DNSBL cleanup call once');
+		$endPos = strpos($mutant, $dnsbl_end);
+		$this->assertNotFalse($endPos, 'mutation fixture must retain the DNSBL loop end anchor');
+		$mutant = substr_replace($mutant, $dnsbl_cleanup, $endPos + strlen($dnsbl_end), 0);
+		$mutantScope = $this->applyScope($mutant, $dnsbl_loop, $dnsbl_end);
+		$this->assertSame(0, substr_count($mutantScope, $dnsbl_cleanup), 'DNSBL cleanup relocated outside its loop must fail the route pin');
 	}
 }

--- a/tests/php/ListScriptFailureLedgerWiringTest.php
+++ b/tests/php/ListScriptFailureLedgerWiringTest.php
@@ -5,156 +5,202 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * issue #1958: a per-feed pre-script that exits non-zero must not let the
- * alias pass close as full success. The IP and DNSBL loops inside
- * sync_package_pfblockerng() drive real appliance exec and have no PHPUnit
- * harness of their own (issue #993), so -- same technique as
- * DnsblListScriptWiringTest / PfbSyncStatusIpWritersTest -- the wiring is
- * pinned by source inspection with vacuity-guarded windows: each window's
- * start/end anchors are asserted present BEFORE the content assertion inside
- * them is trusted.
- *
- * Pins, per loop:
- *   - the pre-script failure branch records the new ADR-61 'script' stage
- *     ledger entry + '.update' retry marker via pfb_list_script_failure_record(),
- *     sets $pfb_script_failed, and STILL falls through to the existing
- *     continue; (DNSBL: the existing #1841-class manifest-row re-emission on a
- *     stale-generation .txt must also survive, untouched).
- *   - the alias-pass end closes the 'script' stage ledger entry, guarded by
- *     !$pfb_script_failed, beside the existing download-ledger close.
- *   - both loops declare their own per-alias-pass $pfb_script_failed reset --
- *     a reset dropped from one loop is the #1048-class bug (a sibling feed's
- *     success masking this feed's still-open failure).
+ * Script failures are observable through the retry marker and sync-status
+ * ledger. PRODUCTION COMMENTS AND DOCBLOCKS MUST NEVER BE LOAD-BEARING FOR A
+ * TEST. If a mechanism makes them so, the mechanism is wrong.
  */
 final class ListScriptFailureLedgerWiringTest extends TestCase
 {
-	private static string $applySource;
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+
+	private string $dir;
 
 	public static function setUpBeforeClass(): void
 	{
-		$source = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
-		);
-		if ($source === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	}
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_script_state_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->dir}/*") ?: [] as $file) {
+			@unlink($file);
 		}
-		self::$applySource = $source;
+		@rmdir($this->dir);
 	}
 
-	// -----------------------------------------------------------------
-	// Row 7 -- IP pre-script failure branch.
-	// -----------------------------------------------------------------
-
-	public function testIpPreScriptFailureBranchRecordsLedgerAndMarkerBeforeContinue(): void
+	private function applyScope(string $source, string $start, string $end): string
 	{
-		$dnsblCallPos = strpos(self::$applySource, 'pfb_list_pre_script_run(');
-		$this->assertNotFalse($dnsblCallPos, 'vacuity: the DNSBL pre-script call site must exist (first occurrence)');
-
-		$ipCallPos = strpos(self::$applySource, 'pfb_list_pre_script_run(', $dnsblCallPos + 1);
-		$this->assertNotFalse($ipCallPos, 'vacuity: the IP pre-script call site must exist (second occurrence)');
-
-		$ipFopenPos = strpos(self::$applySource, '@fopen($pfb_parse_path', $ipCallPos);
-		$this->assertNotFalse($ipFopenPos, 'vacuity: the IP parse-open that follows the IP pre-script call must exist');
-		$this->assertGreaterThan($ipCallPos, $ipFopenPos, 'the IP parse-open must sit after the IP pre-script call');
-
-		$window = substr(self::$applySource, $ipCallPos, $ipFopenPos - $ipCallPos);
-
-		$this->assertStringContainsString('" {$list[\'vtype\']} {$elog}"', $window,
-			'vacuity: this window must be the IP call (carries the vtype args-tail discriminator, not "dnsbl")');
-
-		$this->assertStringContainsString("pfb_list_script_failure_record('ip', \$alias,", $window,
-			'a pre-script failure must record the ADR-61 script-stage ledger entry, keyed on the IP facility');
-		$this->assertStringContainsString('$pfb_script_failed = TRUE;', $window,
-			'a pre-script failure must raise the per-alias-pass script-failure flag');
-		$this->assertStringContainsString('.update"', $window,
-			'a pre-script failure must (re)write the .update retry marker so the next ordinary pass retries the transform');
-		$this->assertStringContainsString('continue;', $window,
-			'the existing continue; (serving last-known-good, #1927) must survive untouched');
+		$from = strrpos($source, $start);
+		if ($from === FALSE) {
+			throw new RuntimeException("missing apply scope start: {$start}");
+		}
+		$to = strpos($source, $end, $from + strlen($start));
+		if ($to === FALSE) {
+			throw new RuntimeException("missing apply scope end: {$end}");
+		}
+		return substr($source, $from, $to + strlen($end) - $from);
 	}
 
-	// -----------------------------------------------------------------
-	// Row 8 -- DNSBL pre-script failure branch.
-	// -----------------------------------------------------------------
-
-	public function testDnsblPreScriptFailureBranchRecordsLedgerAndMarkerKeepingManifestRow(): void
+	public function testIpFailureRecordsRetryMarkerAndLedgerRow(): void
 	{
-		$dnsblCallPos = strpos(self::$applySource, 'pfb_list_pre_script_run(');
-		$this->assertNotFalse($dnsblCallPos, 'vacuity: the DNSBL pre-script call site must exist (first occurrence)');
+		$state  = ['failed' => FALSE];
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'Pre-script FAIL', $this->dir, $marker, $state);
 
-		$dnsblFopenPos = strpos(self::$applySource, '@fopen($pfb_parse_path', $dnsblCallPos);
-		$this->assertNotFalse($dnsblFopenPos, 'vacuity: the DNSBL parse-open that follows the DNSBL pre-script call must exist');
-		$this->assertGreaterThan($dnsblCallPos, $dnsblFopenPos, 'the DNSBL parse-open must sit after the DNSBL pre-script call');
-
-		$window = substr(self::$applySource, $dnsblCallPos, $dnsblFopenPos - $dnsblCallPos);
-
-		$this->assertStringContainsString('" dnsbl {$elog}"', $window,
-			'vacuity: this window must be the DNSBL call (carries the stable "dnsbl" args-tail discriminator)');
-
-		$this->assertStringContainsString("pfb_list_script_failure_record('dnsbl', \$alias,", $window,
-			'a pre-script failure must record the ADR-61 script-stage ledger entry, keyed on the DNSBL facility');
-		$this->assertStringContainsString('$pfb_script_failed = TRUE;', $window,
-			'a pre-script failure must raise the per-alias-pass script-failure flag');
-		$this->assertStringContainsString('.update"', $window,
-			'a pre-script failure must (re)write the .update retry marker so the next ordinary pass retries the transform');
-		$this->assertStringContainsString('pfb_feed_manifest_row(', $window,
-			'the existing manifest-row re-emission on a stale-generation .txt must survive -- '
-			. 'dropping it would relocate the outage (#1841-class), not fix it');
-		$this->assertStringContainsString('continue;', $window,
-			'the existing continue; (serving last-known-good, #1927) must survive untouched');
+		$this->assertTrue($state['failed']);
+		$this->assertFileExists($marker);
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open);
+		$this->assertSame('pfB_Example_v4', $open[0]['item']);
+		$this->assertSame('script', $open[0]['stage']);
 	}
 
-	// -----------------------------------------------------------------
-	// Row 9 -- IP alias-pass close, guarded by !$pfb_script_failed.
-	// -----------------------------------------------------------------
-
-	public function testIpAliasPassClosesScriptStageGuardedByScriptFailedFlag(): void
+	public function testDnsblFailureRecordsRetryMarkerAndLedgerRow(): void
 	{
-		$closePos = strpos(self::$applySource, "pfb_ip_download_ledger_update(TRUE,");
-		$this->assertNotFalse($closePos, 'vacuity: the IP download-ledger success-close call site must exist');
+		$state  = ['failed' => FALSE];
+		$marker = "{$this->dir}/DNSBL_Example.update";
+		pfb_list_script_failure_record('dnsbl', 'DNSBL_Example', 'Pre-script FAIL', $this->dir, $marker, $state);
 
-		$endPos = strpos(self::$applySource, 'Remove database update file markers', $closePos);
-		$this->assertNotFalse($endPos, 'vacuity: the end-of-loop epilogue marker must exist after the IP close');
-
-		$window = substr(self::$applySource, $closePos, $endPos - $closePos);
-
-		$this->assertStringContainsString("pfb_sync_status_close('ip', \$alias, 'script'", $window,
-			'the alias-pass end must close the ADR-61 script-stage entry for this alias');
-		$this->assertStringContainsString('!$pfb_script_failed', $window,
-			'the script-stage close must be gated by the once-per-alias-pass flag, symmetric with the download-ledger close');
+		$this->assertTrue($state['failed']);
+		$this->assertFileExists($marker);
+		$open = pfb_sync_status_list_open($this->dir, 'dnsbl');
+		$this->assertCount(1, $open);
+		$this->assertSame('DNSBL_Example', $open[0]['item']);
+		$this->assertSame('script', $open[0]['stage']);
 	}
 
-	// -----------------------------------------------------------------
-	// Row 10 -- DNSBL alias-pass close, guarded by !$pfb_script_failed.
-	// -----------------------------------------------------------------
-
-	public function testDnsblAliasPassClosesScriptStageGuardedByScriptFailedFlag(): void
+	public function testMarkerWriteDoesNotTruncateExistingData(): void
 	{
-		$closePos = strpos(self::$applySource, "pfb_dnsbl_download_ledger_update(TRUE,");
-		$this->assertNotFalse($closePos, 'vacuity: the DNSBL download-ledger success-close call site must exist');
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+		file_put_contents($marker, 'keep-this-marker');
+		$state = ['failed' => FALSE];
 
-		$endPos = strpos(self::$applySource, 'ADR-12: record GENUINELY-changed DNSBL groups', $closePos);
-		$this->assertNotFalse($endPos, 'vacuity: the ADR-12 change-tracking comment must exist after the DNSBL close');
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'msg', $this->dir, $marker, $state);
 
-		$window = substr(self::$applySource, $closePos, $endPos - $closePos);
-
-		$this->assertStringContainsString("pfb_sync_status_close('dnsbl', \$alias, 'script'", $window,
-			'the alias-pass end must close the ADR-61 script-stage entry for this alias');
-		$this->assertStringContainsString('!$pfb_script_failed', $window,
-			'the script-stage close must be gated by the once-per-alias-pass flag, symmetric with the download-ledger close');
+		$this->assertSame('keep-this-marker', file_get_contents($marker));
 	}
 
-	// -----------------------------------------------------------------
-	// Row 11 -- both per-alias resets exist, one per loop.
-	// -----------------------------------------------------------------
-
-	public function testBothLoopsDeclareTheirOwnPerAliasScriptFailedReset(): void
+	public function testLedgerStillOpensWhenMarkerParentIsMissing(): void
 	{
-		$count = preg_match_all('/\$pfb_script_failed\s*=\s*FALSE;/', self::$applySource);
-		$this->assertNotFalse($count, 'the reset regex itself must be well-formed');
-		$this->assertSame(2, $count,
-			'exactly one $pfb_script_failed = FALSE; reset per loop (IP + DNSBL) must exist -- '
-			. 'a reset dropped from one loop is the #1048-class bug (a sibling feed\'s success '
-			. 'masking this feed\'s still-open failure)'
+		$marker = "{$this->dir}/missing/pfB_Example_v4.update";
+		$state  = ['failed' => FALSE];
+
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'msg', $this->dir, $marker, $state);
+
+		$this->assertTrue($state['failed']);
+		$this->assertFileDoesNotExist($marker);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+	}
+
+	public function testIndependentAliasStatesCloseOnlySuccessfulSibling(): void
+	{
+		$failed = ['failed' => TRUE];
+		$ok     = ['failed' => FALSE];
+		pfb_sync_status_open('ip', 'pfB_Failed_v4', 'script', 'failure', $this->dir);
+		pfb_sync_status_open('ip', 'pfB_Ok_v4', 'script', 'success', $this->dir);
+
+		pfb_list_script_failure_close('ip', 'pfB_Failed_v4', $this->dir, $failed);
+		pfb_list_script_failure_close('ip', 'pfB_Ok_v4', $this->dir, $ok);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open);
+		$this->assertSame('pfB_Failed_v4', $open[0]['item']);
+	}
+
+	public function testFailureStateIsIndependentAcrossFacilities(): void
+	{
+		$ipState    = ['failed' => TRUE];
+		$dnsblState = ['failed' => FALSE];
+		pfb_sync_status_open('ip', 'pfB_Failed_v4', 'script', 'failure', $this->dir);
+		pfb_sync_status_open('dnsbl', 'DNSBL_Ok', 'script', 'success', $this->dir);
+
+		pfb_list_script_failure_close('ip', 'pfB_Failed_v4', $this->dir, $ipState);
+		pfb_list_script_failure_close('dnsbl', 'DNSBL_Ok', $this->dir, $dnsblState);
+
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'));
+	}
+
+	public function testDnsblFailureRecordsBeforeManifestAndContinuesWithCurrentStagedTxt(): void
+	{
+		$state  = ['failed' => FALSE];
+		$marker = "{$this->dir}/DNSBL_Example.update";
+		$txt    = "{$this->dir}/feed.txt";
+		file_put_contents($txt, "known-good\n");
+		$events = [];
+
+		$result = pfb_dnsbl_script_failure_continue(
+			'DNSBL_Example', 'Pre-script FAIL', $this->dir, $marker, $state, TRUE, $txt,
+			function () use (&$events, $marker, $txt): void {
+				$events[] = file_exists($marker) ? 'marker' : 'marker-missing';
+				$events[] = count(pfb_sync_status_list_open(dirname($marker), 'dnsbl')) > 0
+					? 'ledger' : 'ledger-missing';
+				$events[] = 'manifest:' . file_get_contents($txt);
+			}
 		);
+
+		$this->assertTrue($result);
+		$this->assertSame(['marker', 'ledger', "manifest:known-good\n"], $events);
+		$this->assertSame("known-good\n", file_get_contents($txt));
+	}
+
+	public function testDnsblFailureSkipsManifestWhenGenerationOrStagedTxtIsMissing(): void
+	{
+		$state  = ['failed' => FALSE];
+		$marker = "{$this->dir}/DNSBL_Example.update";
+		$events = [];
+
+		$this->assertTrue(pfb_dnsbl_script_failure_continue(
+			'DNSBL_Example', 'Pre-script FAIL', $this->dir, $marker, $state, FALSE,
+			"{$this->dir}/missing.txt", static function () use (&$events): void { $events[] = 'manifest'; }
+		));
+		$this->assertSame([], $events);
+
+		$state  = ['failed' => FALSE];
+		$marker = "{$this->dir}/DNSBL_Example_2.update";
+		$this->assertTrue(pfb_dnsbl_script_failure_continue(
+			'DNSBL_Example_2', 'Pre-script FAIL', $this->dir, $marker, $state, TRUE,
+			"{$this->dir}/missing.txt", static function () use (&$events): void { $events[] = 'manifest'; }
+		));
+		$this->assertSame([], $events);
+	}
+
+	public function testIpFailureLeavesPriorStagedTxtBytesUntouched(): void
+	{
+		$state  = ['failed' => FALSE];
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+		$txt    = "{$this->dir}/pfB_Example_v4.txt";
+		file_put_contents($txt, "192.0.2.1\n");
+
+		$this->assertTrue(pfb_ip_script_failure_continue(
+			'pfB_Example_v4', 'Pre-script FAIL', $this->dir, $marker, $state, TRUE, $txt,
+			static function (): void {}
+		));
+		$this->assertSame("192.0.2.1\n", file_get_contents($txt));
+	}
+
+	/**
+	 * #993: the apply monolith owns feed download and appliance side effects, so its loop
+	 * cannot be driven safely off-appliance. Pin each live failure binding in a route scope;
+	 * php_strip_whitespace() removes comments/docblocks from the source under test.
+	 */
+	public function testEachFamilyBindsFailureContinueAndCloseOnce(): void
+	{
+		$source       = php_strip_whitespace(self::APPLY);
+		$dnsbl_cont   = $this->applyScope($source, 'if ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) {', 'pfb_dnsbl_script_failure_continue($alias,');
+		$dnsbl_close  = $this->applyScope($source, "pfb_download_ledger_close_if_clean('dnsbl',", 'pfb_dnsbl_script_failure_close($alias,');
+		$ip_cont      = $this->applyScope($source, 'if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {', 'pfb_ip_script_failure_continue($alias,');
+		$ip_close     = $this->applyScope($source, "pfb_download_ledger_close_if_clean('ip',", 'pfb_ip_script_failure_close($alias,');
+
+		$this->assertSame(1, substr_count($dnsbl_cont, 'pfb_dnsbl_script_failure_continue($alias,'), 'DNSBL failure continue must stay in its loop');
+		$this->assertSame(1, substr_count($dnsbl_close, 'pfb_dnsbl_script_failure_close($alias,'), 'DNSBL failure close must stay at alias-pass end');
+		$this->assertSame(1, substr_count($ip_cont, 'pfb_ip_script_failure_continue($alias,'), 'IP failure continue must stay in its loop');
+		$this->assertSame(1, substr_count($ip_close, 'pfb_ip_script_failure_close($alias,'), 'IP failure close must stay at alias-pass end');
 	}
 }

--- a/tests/php/ListScriptFailureLedgerWiringTest.php
+++ b/tests/php/ListScriptFailureLedgerWiringTest.php
@@ -17,7 +17,7 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+		require_once self::APPLY;
 	}
 
 	protected function setUp(): void
@@ -193,14 +193,30 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 	public function testEachFamilyBindsFailureContinueAndCloseOnce(): void
 	{
 		$source       = php_strip_whitespace(self::APPLY);
-		$dnsbl_cont   = $this->applyScope($source, 'if ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) {', 'pfb_dnsbl_script_failure_continue($alias,');
-		$dnsbl_close  = $this->applyScope($source, "pfb_download_ledger_close_if_clean('dnsbl',", 'pfb_dnsbl_script_failure_close($alias,');
-		$ip_cont      = $this->applyScope($source, 'if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {', 'pfb_ip_script_failure_continue($alias,');
-		$ip_close     = $this->applyScope($source, "pfb_download_ledger_close_if_clean('ip',", 'pfb_ip_script_failure_close($alias,');
+		$dnsbl_cont   = $this->applyScope($source, 'if ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) {', "pfb_download_ledger_close_if_clean('dnsbl',");
+		$dnsbl_close  = $this->applyScope($source, "pfb_download_ledger_close_if_clean('dnsbl',", "if (\$pfb['aliasupdate']) {");
+		$ip_cont      = $this->applyScope($source, 'if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {', "pfb_download_ledger_close_if_clean('ip',");
+		$ip_close     = $this->applyScope($source, "pfb_download_ledger_close_if_clean('ip',", 'unlink_if_exists("{$pfb[\'dbdir\']}/geoip.update");');
 
 		$this->assertSame(1, substr_count($dnsbl_cont, 'pfb_dnsbl_script_failure_continue($alias,'), 'DNSBL failure continue must stay in its loop');
 		$this->assertSame(1, substr_count($dnsbl_close, 'pfb_dnsbl_script_failure_close($alias,'), 'DNSBL failure close must stay at alias-pass end');
 		$this->assertSame(1, substr_count($ip_cont, 'pfb_ip_script_failure_continue($alias,'), 'IP failure continue must stay in its loop');
 		$this->assertSame(1, substr_count($ip_close, 'pfb_ip_script_failure_close($alias,'), 'IP failure close must stay at alias-pass end');
+
+		foreach ([
+			['if ($pfb_dnsbl_script_pre && is_file("{$pfb_dnsbl_script_pre}")) {', "pfb_download_ledger_close_if_clean('dnsbl',", 'pfb_dnsbl_script_failure_continue($alias,'],
+			["pfb_download_ledger_close_if_clean('dnsbl',", "if (\$pfb['aliasupdate']) {", 'pfb_dnsbl_script_failure_close($alias,'],
+			['if ($pfb_script_pre && is_file("{$pfb_script_pre}")) {', "pfb_download_ledger_close_if_clean('ip',", 'pfb_ip_script_failure_continue($alias,'],
+			["pfb_download_ledger_close_if_clean('ip',", 'unlink_if_exists("{$pfb[\'dbdir\']}/geoip.update");', 'pfb_ip_script_failure_close($alias,'],
+		] as [$start, $end, $needle]) {
+			$removed = 0;
+			$mutant = str_replace($needle, '', $source, $removed);
+			$this->assertSame(1, $removed, "mutation fixture must remove {$needle} once");
+			$endPos = strpos($mutant, $end);
+			$this->assertNotFalse($endPos, "mutation fixture must retain {$end}");
+			$mutant = substr_replace($mutant, $needle, $endPos + strlen($end), 0);
+			$mutantScope = $this->applyScope($mutant, $start, $end);
+			$this->assertSame(0, substr_count($mutantScope, $needle), "a {$needle} relocation after its loop boundary must fail the scope pin");
+		}
 	}
 }

--- a/tests/php/ListScriptReparseWiringTest.php
+++ b/tests/php/ListScriptReparseWiringTest.php
@@ -17,10 +17,8 @@ final class ListScriptReparseWiringTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach (glob("{$this->dir}/*") ?: [] as $file) {
-			@unlink($file);
-		}
-		@rmdir($this->dir);
+		rmdir_recursive($this->dir);
+		$this->assertDirectoryDoesNotExist($this->dir);
 	}
 
 	private function script(string $name): string

--- a/tests/php/ListScriptReparseWiringTest.php
+++ b/tests/php/ListScriptReparseWiringTest.php
@@ -4,203 +4,120 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1960/#1278 -- #1960 gated both loops' early verbatim-reuse fast
- * paths on the bare has_user_script term (!$pfb_dnsbl_user_script /
- * !$pfb_user_script). That makes a Hold-state row with a configured
- * pre/post script leave the fast path UNCONDITIONALLY and fall through to a
- * real network download every pass, breaking issue #1278's "download once,
- * never again" Hold contract (the fast path is the ONLY thing protecting
- * it -- see PfbListScriptReparseActiveTest's docblock).
- *
- * The fix routes a scripted row off the fast path ONLY when a local '.orig'
- * baseline exists to reparse (pfb_list_script_reparse_active()), sending it
- * to the existing local-reuse branch instead of the network. The IP and
- * DNSBL loops inside sync_package_pfblockerng() drive real appliance exec
- * and have no PHPUnit harness of their own (issue #993), so -- same
- * technique as DnsblListScriptWiringTest / ListScriptTransformRerunWiringTest
- * -- the wiring is pinned by source inspection with vacuity-guarded windows.
- */
+/** The shared decision seam exposes the same routes used by IP and DNSBL rows. */
 final class ListScriptReparseWiringTest extends TestCase
 {
-	private static string $applySource;
+	private string $dir;
 
-	// The IP loop's own list-collection comment sits strictly AFTER the whole
-	// DNSBL alias loop and BEFORE the IP loop's per-row body -- a token that
-	// only occurs between the two loops, used to prove a pair of call sites
-	// straddles them (one per loop) rather than both landing in one loop.
-	private const LOOP_BOUNDARY_COMMENT =
-		'// Collect lists and custom list configuration and format into one array ($lists).';
-
-	public static function setUpBeforeClass(): void
+	protected function setUp(): void
 	{
-		$source = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
-		);
-		if ($source === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		$this->dir = sys_get_temp_dir() . '/pfb_script_reuse_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->dir}/*") ?: [] as $file) {
+			@unlink($file);
 		}
-		self::$applySource = $source;
+		@rmdir($this->dir);
 	}
 
-	// -----------------------------------------------------------------
-	// Row 6 -- DNSBL fast path gated by !$pfb_dnsbl_script_reparse, not by
-	// the bare user-script term. Anchored on the gated statement HEAD (not a
-	// bare token) so a comment merely mentioning the token cannot satisfy it.
-	// -----------------------------------------------------------------
-
-	public function testDnsblFastPathGatedByScriptReparseNotBareUserScriptTerm(): void
+	private function script(string $name): string
 	{
-		$this->assertStringContainsString(
-			'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {',
-			self::$applySource,
-			'issue #1960/#1278: the DNSBL fast path must be gated by the script-reparse term (which '
-			. 'requires a local .orig baseline), not by the bare has_user_script term -- the bare term '
-			. 'forces a Hold row with no baseline through to a network download every pass'
-		);
-
-		$this->assertStringNotContainsString(
-			'if (!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active(',
-			self::$applySource,
-			'the old bare-user-script gate must be gone -- its presence is the exact #1278 regression '
-			. 'this fix closes'
-		);
-
-		// The gate must sit on the fast path that logs "exists."/"static hold.", not on
-		// some other statement.
-		$gatePos = strpos(self::$applySource, 'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {');
-		$this->assertNotFalse($gatePos, 'vacuity: the gated DNSBL fast-path statement must exist');
-		$existsPos = strpos(self::$applySource, '{$logtab} exists.', $gatePos);
-		$this->assertNotFalse($existsPos,
-			'the gated statement must be the DNSBL verbatim-reuse fast path -- its branch logs "exists."');
+		$path = "{$this->dir}/{$name}";
+		file_put_contents($path, "#!/bin/sh\nexit 0\n");
+		chmod($path, 0755);
+		return $path;
 	}
 
-	// -----------------------------------------------------------------
-	// Row 7 -- IP fast path likewise gated by !$pfb_script_reparse.
-	// -----------------------------------------------------------------
-
-	public function testIpFastPathGatedByScriptReparseNotBareUserScriptTerm(): void
+	public function testDnsblScriptedRowWithOrigUsesLocalReparseInsteadOfVerbatimFastPath(): void
 	{
-		$this->assertStringContainsString(
-			'if ($pfb_ip_verbatim_reuse && !$pfb_script_reparse) {',
-			self::$applySource,
-			'issue #1960/#1278: the IP fast path must be gated by the script-reparse term (which '
-			. 'requires a local .orig baseline), not by the bare has_user_script term -- the bare term '
-			. 'forces a Hold row with no baseline through to a network download every pass'
-		);
+		$pre  = $this->script('pre.sh');
+		$orig = "{$this->dir}/feed.orig";
+		file_put_contents($orig, "example.org\n");
 
-		$this->assertStringNotContainsString(
-			'if (!$pfb_user_script &&',
-			self::$applySource,
-			'the old bare-user-script gate must be gone -- its presence is the exact #1278 regression '
-			. 'this fix closes'
-		);
+		$decision = pfb_dnsbl_script_reuse_decision(TRUE, $pre, FALSE, $orig);
 
-		$gatePos = strpos(self::$applySource, 'if ($pfb_ip_verbatim_reuse && !$pfb_script_reparse) {');
-		$this->assertNotFalse($gatePos, 'vacuity: the gated IP fast-path statement must exist');
-		$existsPos = strpos(self::$applySource, '{$logtab} exists.', $gatePos);
-		$this->assertNotFalse($existsPos,
-			'the gated statement must be the IP verbatim-reuse fast path -- its branch logs "exists."');
+		$this->assertTrue($decision['has_user_script']);
+		$this->assertTrue($decision['orig_exists']);
+		$this->assertTrue($decision['reparse']);
+		$this->assertFalse($decision['verbatim']);
 	}
 
-	// -----------------------------------------------------------------
-	// Row 8 -- DNSBL $pfbreuse_effective carries the script-reparse term, so
-	// a scripted row with a local baseline routes to local reuse, not the
-	// network.
-	// -----------------------------------------------------------------
-
-	public function testDnsblPfbreuseEffectiveCarriesScriptReparseTerm(): void
+	public function testIpScriptedRowWithOrigUsesLocalReparseInsteadOfVerbatimFastPath(): void
 	{
-		$stmtPos = strpos(self::$applySource, '$pfbreuse_effective = ');
-		$this->assertNotFalse($stmtPos, 'vacuity: the $pfbreuse_effective assignment must exist');
+		$pre  = $this->script('pre.sh');
+		$orig = "{$this->dir}/feed.orig";
+		file_put_contents($orig, "192.0.2.1\n");
 
-		$stmtEnd = strpos(self::$applySource, ';', $stmtPos);
-		$this->assertNotFalse($stmtEnd, 'vacuity: the assignment statement must terminate');
-		$statement = substr(self::$applySource, $stmtPos, $stmtEnd - $stmtPos);
+		$decision = pfb_ip_script_reuse_decision(TRUE, $pre, FALSE, $orig);
 
-		$this->assertStringContainsString('$pfb_dnsbl_script_reparse', $statement,
-			'issue #1278: $pfbreuse_effective must OR in the script-reparse route so a scripted row '
-			. 'with a local .orig baseline reuses it locally (Reload) instead of falling through to a '
-			. 'network download');
+		$this->assertTrue($decision['has_user_script']);
+		$this->assertTrue($decision['orig_exists']);
+		$this->assertTrue($decision['reparse']);
+		$this->assertFalse($decision['verbatim']);
 	}
 
-	// -----------------------------------------------------------------
-	// Row 9 -- IP reuse decision carries the script-reparse term at BOTH
-	// pfb_ip_reuse_skip_active( call sites (counted from source first), and
-	// nothing reassigns the carrying variable between them -- a mismatch
-	// there would log "Reload" then download anyway, or vice versa.
-	// -----------------------------------------------------------------
-
-	public function testIpReuseSkipActiveBothCallSitesCarryScriptReparseTerm(): void
+	public function testDnsblScriptedHoldWithoutOrigStaysOnVerbatimFastPath(): void
 	{
-		$callCount = substr_count(self::$applySource, 'pfb_ip_reuse_skip_active(');
-		$this->assertSame(2, $callCount,
-			'vacuity: the IP loop must have exactly the two known pfb_ip_reuse_skip_active( call '
-			. 'sites (the log-line decision + the actual reuse-vs-download fork) -- a third call site '
-			. 'changes the shape this test pins, and this brief forbids weakening the !$is_dnsblip term '
-			. 'at any of them (#1002/#1020)');
+		$pre = $this->script('pre.sh');
+		$orig = "{$this->dir}/missing.orig";
+		$this->assertFileDoesNotExist($orig);
 
-		$assignPos = strpos(self::$applySource, "\$pfbreuse_on = \$pfbreuse == 'on'");
-		$this->assertNotFalse($assignPos, 'vacuity: the $pfbreuse_on assignment must exist');
+		$decision = pfb_dnsbl_script_reuse_decision(TRUE, $pre, FALSE, $orig);
 
-		$assignEnd = strpos(self::$applySource, ';', $assignPos);
-		$this->assertNotFalse($assignEnd, 'vacuity: the assignment statement must terminate');
-		$assignStatement = substr(self::$applySource, $assignPos, $assignEnd - $assignPos);
-		$this->assertStringContainsString('$pfb_script_reparse', $assignStatement,
-			'issue #1278: $pfbreuse_on must OR in the script-reparse route so a scripted row with a '
-			. 'local .orig baseline reuses it locally instead of falling through to a network download');
-
-		$firstCallPos = strpos(self::$applySource, 'pfb_ip_reuse_skip_active(', $assignPos);
-		$this->assertNotFalse($firstCallPos, 'vacuity: the first call site (after the assignment) must exist');
-		$secondCallPos = strpos(self::$applySource, 'pfb_ip_reuse_skip_active(', $firstCallPos + 1);
-		$this->assertNotFalse($secondCallPos, 'vacuity: the second call site must exist');
-
-		$firstCallHead = substr(self::$applySource, $firstCallPos, strlen('pfb_ip_reuse_skip_active($pfbreuse_on,'));
-		$this->assertSame('pfb_ip_reuse_skip_active($pfbreuse_on,', $firstCallHead,
-			'the first pfb_ip_reuse_skip_active( call must feed $pfbreuse_on (the variable carrying '
-			. 'the OR\'d script-reparse term) as its reuse_on argument');
-
-		$secondCallHead = substr(self::$applySource, $secondCallPos, strlen('pfb_ip_reuse_skip_active($pfbreuse_on,'));
-		$this->assertSame('pfb_ip_reuse_skip_active($pfbreuse_on,', $secondCallHead,
-			'the second pfb_ip_reuse_skip_active( call must feed the SAME $pfbreuse_on -- a mismatch '
-			. 'here would log "Reload" then download anyway, or vice versa');
-
-		$between = substr(self::$applySource, $firstCallPos, $secondCallPos - $firstCallPos);
-		$this->assertStringNotContainsString('$pfbreuse_on = ', $between,
-			'no reassignment of $pfbreuse_on may sit between the two call sites -- that would silently '
-			. 'drop the script-reparse term for the second call, producing the exact log-vs-action '
-			. 'mismatch this row guards against');
+		$this->assertTrue($decision['has_user_script']);
+		$this->assertFalse($decision['orig_exists']);
+		$this->assertFalse($decision['reparse']);
+		$this->assertTrue($decision['verbatim']);
 	}
 
-	// -----------------------------------------------------------------
-	// Row 12 -- pfb_list_script_reparse_active( is called exactly twice,
-	// once per loop -- lock-step by construction.
-	// -----------------------------------------------------------------
-
-	public function testScriptReparseActiveCalledExactlyTwiceOncePerLoop(): void
+	public function testIpScriptedHoldWithoutOrigStaysOnVerbatimFastPath(): void
 	{
-		// '($pfb_' (vs. the definition's '(bool $verbatim_reuse_ok') distinguishes an
-		// invocation -- both call sites pass a $pfb_*-prefixed verbatim-reuse variable
-		// as the first argument (mirrors testExactlyTwoLockStepCallSites' technique for
-		// pfb_list_user_script_active( in ListScriptTransformRerunWiringTest).
-		$count = substr_count(self::$applySource, 'pfb_list_script_reparse_active($pfb_');
-		$this->assertSame(2, $count,
-			'lock-step by construction -- both the DNSBL and IP loops must call the shared '
-			. 'pfb_list_script_reparse_active() helper exactly once each');
+		$pre = $this->script('pre.sh');
+		$orig = "{$this->dir}/missing.orig";
+		$this->assertFileDoesNotExist($orig);
 
-		$firstPos = strpos(self::$applySource, 'pfb_list_script_reparse_active($pfb_');
-		$this->assertNotFalse($firstPos, 'vacuity: the first call site must exist');
-		$secondPos = strpos(self::$applySource, 'pfb_list_script_reparse_active($pfb_', $firstPos + 1);
-		$this->assertNotFalse($secondPos, 'vacuity: the second call site must exist');
+		$decision = pfb_ip_script_reuse_decision(TRUE, $pre, FALSE, $orig);
 
-		$boundaryPos = strpos(self::$applySource, self::LOOP_BOUNDARY_COMMENT);
-		$this->assertNotFalse($boundaryPos, "vacuity: the IP loop's list-collection boundary comment must exist");
+		$this->assertTrue($decision['has_user_script']);
+		$this->assertFalse($decision['orig_exists']);
+		$this->assertFalse($decision['reparse']);
+		$this->assertTrue($decision['verbatim']);
+	}
 
-		$this->assertLessThan($boundaryPos, $firstPos,
-			'the first pfb_list_script_reparse_active( call site must sit in the DNSBL loop, before '
-			. "the IP loop's boundary comment");
-		$this->assertGreaterThan($boundaryPos, $secondPos,
-			'the second pfb_list_script_reparse_active( call site must sit in the IP loop, after the '
-			. 'DNSBL loop');
+	public function testNoScriptWithoutOrigRemainsVerbatim(): void
+	{
+		$decision = pfb_list_script_reuse_decision(TRUE, FALSE, '', "{$this->dir}/missing.orig");
+
+		$this->assertFalse($decision['has_user_script']);
+		$this->assertFalse($decision['orig_exists']);
+		$this->assertFalse($decision['reparse']);
+		$this->assertTrue($decision['verbatim']);
+	}
+
+	public function testRejectedVerbatimStateNeverBecomesScriptReparse(): void
+	{
+		$pre  = $this->script('pre.sh');
+		$orig = "{$this->dir}/feed.orig";
+		file_put_contents($orig, "example.org\n");
+
+		$decision = pfb_list_script_reuse_decision(FALSE, $pre, FALSE, $orig);
+
+		$this->assertTrue($decision['has_user_script']);
+		$this->assertTrue($decision['orig_exists']);
+		$this->assertFalse($decision['reparse']);
+		$this->assertFalse($decision['verbatim']);
+	}
+
+	public function testDirectoryAndMissingScriptPathsAreInactive(): void
+	{
+		$directory = "{$this->dir}/scripts";
+		$this->assertTrue(mkdir($directory, 0700));
+		$decision = pfb_list_script_reuse_decision(TRUE, $directory, "{$this->dir}/gone.sh", "{$this->dir}/missing.orig");
+
+		$this->assertFalse($decision['has_user_script']);
+		$this->assertTrue($decision['verbatim']);
 	}
 }

--- a/tests/php/ListScriptTransformRerunWiringTest.php
+++ b/tests/php/ListScriptTransformRerunWiringTest.php
@@ -4,237 +4,118 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1960: the IP and DNSBL feed loops' early verbatim-reuse fast paths
- * must carry the same has_user_script term the normalization-level reuse
- * gates (pfb_ip_norm_reuse_skip() / pfb_dnsbl_norm_reuse_skip()) already
- * carry -- a feed with a configured pre/post script must re-run its
- * transform on an ordinary cron pass, never require a Force Reload. The IP
- * and DNSBL loops inside sync_package_pfblockerng() drive real appliance
- * exec and have no PHPUnit harness of their own (issue #993), so -- same
- * technique as DnsblListScriptWiringTest / ListScriptFailureLedgerWiringTest
- * -- the wiring is pinned by source inspection with vacuity-guarded windows.
- *
- * Deliberate asymmetry (see the production comment above the statement):
- * the DNSBL loop's second pfb_dnsbl_verbatim_reuse_active(..., TRUE) re-call
- * (#1083's $stale_generation_rebuild) answers a DIFFERENT question and stays
- * deliberately UNGATED by the user-script term -- pinned here so a future
- * "consistency cleanup" cannot silently change #1083 behaviour.
- */
+/** Script-active rows must reach both facility normalization passes. */
 final class ListScriptTransformRerunWiringTest extends TestCase
 {
-	private static string $applySource;
+	private string $dir;
 
-	public static function setUpBeforeClass(): void
+	protected function setUp(): void
 	{
-		$source = file_get_contents(
+		$this->dir = sys_get_temp_dir() . '/pfb_transform_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob("{$this->dir}/*") ?: [] as $file) {
+			@unlink($file);
+		}
+		@rmdir($this->dir);
+	}
+
+	private function script(): string
+	{
+		$path = "{$this->dir}/pre.sh";
+		file_put_contents($path, "#!/bin/sh\nexit 0\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	public function testDnsblDecisionReportsUserScript(): void
+	{
+		$script = $this->script();
+		$orig   = "{$this->dir}/feed.orig";
+		file_put_contents($orig, "example.org\n");
+
+		$decision = pfb_dnsbl_script_reuse_decision(TRUE, $script, FALSE, $orig);
+		$this->assertTrue($decision['has_user_script']);
+		$this->assertTrue($decision['reparse']);
+		$this->assertFalse($decision['verbatim']);
+	}
+
+	public function testIpDecisionReportsUserScript(): void
+	{
+		$script = $this->script();
+		$orig   = "{$this->dir}/feed.orig";
+		file_put_contents($orig, "192.0.2.1\n");
+
+		$decision = pfb_ip_script_reuse_decision(TRUE, $script, FALSE, $orig);
+		$this->assertTrue($decision['has_user_script']);
+		$this->assertTrue($decision['reparse']);
+		$this->assertFalse($decision['verbatim']);
+	}
+
+	public function testUserScriptPreventsIpNormalizationReuse(): void
+	{
+		$this->assertTrue(pfb_ip_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, FALSE));
+		$this->assertFalse(pfb_ip_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE));
+	}
+
+	public function testUserScriptPreventsDnsblNormalizationReuse(): void
+	{
+		$this->assertTrue(pfb_dnsbl_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE));
+		$this->assertFalse(pfb_dnsbl_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE));
+	}
+
+	public function testFreshNormalizedContentWithoutScriptStillTakesFastPath(): void
+	{
+		$this->assertTrue(pfb_ip_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, FALSE));
+		$this->assertTrue(pfb_dnsbl_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE));
+	}
+
+	/**
+	 * issue #993: sync_package_pfblockerng() drives live downloads, scripts,
+	 * firewall state, and services, so PHPUnit cannot execute either feed loop.
+	 * Keep only these comment-free outer dispatch pins; helper behavior above
+	 * proves the effect once each independently scoped call runs.
+	 */
+	public function testBothLiveLoopsDispatchThroughTheBehaviorSeams(): void
+	{
+		$code = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
 		);
-		if ($source === FALSE) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
-		}
-		self::$applySource = $source;
-	}
+		$this->assertIsString($code);
 
-	// -----------------------------------------------------------------
-	// Row 8 -- IP fast-path condition carries !$pfb_user_script.
-	// -----------------------------------------------------------------
-
-	public function testIpFastPathCarriesUserScriptTerm(): void
-	{
-		$asnTouchPos = strpos(self::$applySource, "\$pfb['dbdir']}/asn.update");
-		$this->assertNotFalse($asnTouchPos, 'vacuity: the geoip/asn .update touch block must exist before the IP fast path');
-
-		$staticHoldPos = strpos(self::$applySource, 'static hold.', $asnTouchPos);
-		$this->assertNotFalse($staticHoldPos, 'vacuity: the IP fast-path "static hold." log must exist after the geoip/asn touches');
-
-		$window = substr(self::$applySource, $asnTouchPos, $staticHoldPos - $asnTouchPos);
-
-		// issue #1278: supersedes the bare !$pfb_user_script gate this row originally pinned --
-		// that shape forced a Hold row with a configured script through to a network download
-		// every pass (the #1278 regression). The script term now only pushes a row off the fast
-		// path when a local '.orig' baseline exists to reparse (see PfbListScriptReparseActiveTest
-		// / ListScriptReparseWiringTest for the full fix and its own coverage).
-		$this->assertStringContainsString('!$pfb_script_reparse', $window,
-			'issue #1960/#1278: the IP fast path must be gated by the script-reparse term (which '
-			. 'requires a local .orig baseline) -- a configured script re-runs its transform every '
-			. 'pass it has a baseline to reparse, but a Hold row with none stays on the fast path '
-			. 'instead of falling through to the network');
-	}
-
-	// -----------------------------------------------------------------
-	// Row 9 -- $pfb_user_script assigned exactly ONCE in the IP loop and
-	// BEFORE the fast path (a leftover second assignment is the bug this
-	// row catches).
-	// -----------------------------------------------------------------
-
-	public function testIpUserScriptAssignedExactlyOnceBeforeFastPath(): void
-	{
-		$count = substr_count(self::$applySource, '$pfb_user_script = ');
-		$this->assertSame(1, $count,
-			'a leftover second assignment is the bug this row catches -- $pfb_user_script must be '
-			. 'computed exactly once per row');
-
-		$assignPos = strpos(self::$applySource, '$pfb_user_script = ');
-		$this->assertNotFalse($assignPos, 'vacuity: the assignment must exist');
-
-		$asnTouchPos = strpos(self::$applySource, "\$pfb['dbdir']}/asn.update");
-		$this->assertNotFalse($asnTouchPos, 'vacuity: the geoip/asn .update touch block must exist');
-
-		$fastPathPos = strpos(self::$applySource, 'static hold.', $asnTouchPos);
-		$this->assertNotFalse($fastPathPos, 'vacuity: the IP fast-path log must exist after the geoip/asn touches');
-
-		$this->assertLessThan($fastPathPos, $assignPos,
-			'$pfb_user_script must be computed before the fast path that consumes it');
-	}
-
-	// -----------------------------------------------------------------
-	// Row 10 -- DNSBL fast-path call site carries !$pfb_dnsbl_user_script.
-	// -----------------------------------------------------------------
-
-	public function testDnsblFastPathCarriesUserScriptTerm(): void
-	{
-		// issue #1278: supersedes the bare '!$pfb_dnsbl_user_script && pfb_dnsbl_verbatim_reuse_active('
-		// shape this row originally pinned -- that gate forced a Hold row with a configured script
-		// through to a network download every pass (the #1278 regression). Pinned as the whole
-		// gated statement head rather than a window opened on a bare token: 'pfb_dnsbl_verbatim_reuse_active('
-		// also occurs inside the production comments describing this gate and the #1083 asymmetry,
-		// so a window anchored on it opens on prose instead of the call it claims to pin.
 		$this->assertStringContainsString(
-			'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {',
-			self::$applySource,
-			'issue #1960/#1278: the DNSBL fast path must be gated by the script-reparse term (which '
-			. 'requires a local .orig baseline), not the bare has_user_script term -- same contract '
-			. 'as the IP loop');
-
-		// The gate must sit on the fast path that logs "exists."/"static hold.", not on
-		// some other caller: the gated head is the LAST thing before that log.
-		$gatePos = strpos(self::$applySource, 'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {');
-		$this->assertNotFalse($gatePos, 'vacuity: the gated DNSBL fast-path statement must exist');
-		$existsPos = strpos(self::$applySource, '{$logtab} exists.', $gatePos);
-		$this->assertNotFalse($existsPos,
-			'the gated statement must be the DNSBL verbatim-reuse fast path -- its branch logs "exists."');
-	}
-
-	// -----------------------------------------------------------------
-	// Row 11 -- $pfb_dnsbl_user_script assigned exactly ONCE and before
-	// BOTH the fast path and the pfb_dnsbl_norm_reuse_skip() call.
-	// -----------------------------------------------------------------
-
-	public function testDnsblUserScriptAssignedExactlyOnceBeforeBothCallSites(): void
-	{
-		$count = substr_count(self::$applySource, '$pfb_dnsbl_user_script = ');
-		$this->assertSame(1, $count,
-			'a leftover second assignment is the bug this row catches -- $pfb_dnsbl_user_script '
-			. 'must be computed exactly once per alias');
-
-		$assignPos = strpos(self::$applySource, '$pfb_dnsbl_user_script = ');
-		$this->assertNotFalse($assignPos, 'vacuity: the assignment must exist');
-
-		// Anchored on the gated statement head, not a bare
-		// 'pfb_dnsbl_verbatim_reuse_active(' token -- that token also occurs in the
-		// production comments above the call, which would move this anchor onto prose.
-		// issue #1278: the gate itself moved from the bare user-script term to the
-		// script-reparse term, but $pfb_dnsbl_user_script is still consumed just before it
-		// (now via pfb_list_script_reparse_active()), so the ordering this row pins is unchanged.
-		$fastPathPos = strpos(self::$applySource, 'if ($pfb_dnsbl_verbatim_reuse && !$pfb_dnsbl_script_reparse) {');
-		$this->assertNotFalse($fastPathPos, 'vacuity: the gated DNSBL fast path must exist');
-		$this->assertLessThan($fastPathPos, $assignPos,
-			'$pfb_dnsbl_user_script must be computed before the fast path that consumes it');
-
-		$reuseSkipPos = strpos(self::$applySource, 'pfb_dnsbl_norm_reuse_skip(');
-		$this->assertNotFalse($reuseSkipPos, 'vacuity: the DNSBL normalize/reuse-skip call must exist');
-		$this->assertLessThan($reuseSkipPos, $assignPos,
-			'$pfb_dnsbl_user_script must be computed before the normalize/reuse-skip call too');
-	}
-
-	// -----------------------------------------------------------------
-	// Row 12 -- the $stale_generation_rebuild re-call is NOT gated by the
-	// user-script term (#1083 deliberate asymmetry).
-	// -----------------------------------------------------------------
-
-	public function testStaleGenerationRebuildRecallIsNotGatedByUserScript(): void
-	{
-		$stmtPos = strpos(self::$applySource, '$stale_generation_rebuild = ');
-		$this->assertNotFalse($stmtPos, 'vacuity: the #1083 stale-generation rebuild re-call must exist');
-
-		$stmtEnd = strpos(self::$applySource, ';', $stmtPos);
-		$this->assertNotFalse($stmtEnd, 'vacuity: the statement must terminate');
-
-		$statement = substr(self::$applySource, $stmtPos, $stmtEnd - $stmtPos);
-
-		$this->assertStringNotContainsString('$pfb_dnsbl_user_script', $statement,
-			'issue #1960 deliberate asymmetry: the $stale_generation_rebuild re-call answers a '
-			. 'DIFFERENT question (#1083 -- was stale staging generation the ONLY file-state reason '
-			. 'reuse was rejected) and must stay ungated -- gating it would force a full network '
-			. 'refetch for a stale-generation .txt with a configured script instead of the cheaper '
-			. 'reparse-from-.orig path, where the pre-script still reruns anyway '
-			. "(pfb_dnsbl_norm_reuse_skip() is FALSE there since \$downloaded_fresh is FALSE), silently "
-			. 'changing #1083 Rebuild/pfb_dnsbl_hold_stale_rebuild_skip/'
-			. 'pfb_dnsbl_stale_rebuild_converge_txt behaviour that nobody asked for');
-
-		// issue #1278: the same asymmetry applies to the NEW script-reparse term -- this
-		// re-call must stay ungated by it too, same reasoning as $pfb_dnsbl_user_script above.
-		$this->assertStringNotContainsString('$pfb_dnsbl_script_reparse', $statement,
-			'issue #1960/#1278: the #1083 stale-generation rebuild re-call must stay ungated by the '
-			. 'new script-reparse term too -- same asymmetry reasoning as $pfb_dnsbl_user_script above');
-	}
-
-	// -----------------------------------------------------------------
-	// Row 13 -- lock-step: exactly TWO pfb_list_user_script_active( call
-	// sites in the file, one per loop.
-	// -----------------------------------------------------------------
-
-	public function testExactlyTwoLockStepCallSites(): void
-	{
-		// '($pfb_' (vs. the definition's '($script_pre') distinguishes an
-		// invocation -- both call sites pass a $pfb_*-prefixed variable pair.
-		$count = substr_count(self::$applySource, 'pfb_list_user_script_active($pfb_');
-		$this->assertSame(2, $count,
-			'a term added to one loop only is the exact defect issue #1960 forbids -- both the IP '
-			. 'and DNSBL loops must call the shared helper exactly once each');
-
-		// N4: a global count of 2 passes even if BOTH call sites sat inside the SAME loop --
-		// prove they straddle the two loops instead. The IP loop's own list-collection
-		// comment sits strictly AFTER the whole DNSBL alias loop and BEFORE the IP loop's
-		// per-row body, so it is a token that only occurs between the two loops.
-		$firstCallPos = strpos(self::$applySource, 'pfb_list_user_script_active($pfb_');
-		$this->assertNotFalse($firstCallPos, 'vacuity: the first call site must exist');
-		$secondCallPos = strpos(self::$applySource, 'pfb_list_user_script_active($pfb_', $firstCallPos + 1);
-		$this->assertNotFalse($secondCallPos, 'vacuity: the second call site must exist');
-
-		$boundaryPos = strpos(self::$applySource,
-			'// Collect lists and custom list configuration and format into one array ($lists).');
-		$this->assertNotFalse($boundaryPos, "vacuity: the IP loop's list-collection boundary comment must exist");
-
-		$this->assertLessThan($boundaryPos, $firstCallPos,
-			'the first pfb_list_user_script_active( call site must sit in the DNSBL loop, before the '
-			. "IP loop's boundary comment");
-		$this->assertGreaterThan($boundaryPos, $secondCallPos,
-			'the second pfb_list_user_script_active( call site must sit in the IP loop, after the '
-			. 'DNSBL loop -- a regression that moved both calls into ONE loop must fail here even '
-			. 'though the global count above stays 2');
-	}
-
-	// -----------------------------------------------------------------
-	// Row 14 -- both loops still pass the user-script term to their
-	// norm-reuse-skip calls. DNSBL side is already covered by
-	// DnsblListScriptWiringTest::testReuseSkipCallSitePassesTheUserScriptFlag
-	// (run and cited, not duplicated here).
-	// -----------------------------------------------------------------
-
-	public function testIpNormReuseSkipCallSitePassesTheUserScriptFlag(): void
-	{
-		$reuseSkipPos = strpos(self::$applySource, 'pfb_ip_norm_reuse_skip(');
-		$this->assertNotFalse($reuseSkipPos, 'vacuity: the IP normalize/reuse-skip call site must exist');
-
-		$callEnd = strpos(self::$applySource, 'unchanged after normalization.', $reuseSkipPos);
-		$this->assertNotFalse($callEnd, 'vacuity: the reuse-skip branch body must exist');
-
-		$call = substr(self::$applySource, $reuseSkipPos, $callEnd - $reuseSkipPos);
-		$this->assertStringContainsString('$pfb_user_script', $call,
-			'a configured pre/post script must force a full reparse every pass -- same contract as '
-			. "the DNSBL loop's pfb_dnsbl_norm_reuse_skip() call "
-			. '(DnsblListScriptWiringTest::testReuseSkipCallSitePassesTheUserScriptFlag)');
+			'$pfb_dnsbl_reuse_decision = pfb_dnsbl_script_reuse_decision( '
+			. '$pfb_dnsbl_verbatim_reuse, $pfb_dnsbl_script_pre, $pfb_dnsbl_script_post, '
+			. '"{$pfborig}/{$header}.orig"); $pfb_dnsbl_user_script = '
+			. '$pfb_dnsbl_reuse_decision[\'has_user_script\'];',
+			$code,
+			'DNSBL loop must call its decision seam and consume its result'
+		);
+		$this->assertStringContainsString(
+			'pfb_dnsbl_norm_reuse_skip($downloaded_fresh, (bool) $custom, '
+			. '$orig_content_stale, $pfb_norm[\'changed\'], '
+			. 'file_exists("{$pfbfolder}/{$header}.txt"), $staging_current_generation, '
+			. '$pfb_dnsbl_user_script)',
+			$code,
+			'DNSBL normalization fast path must receive the seam effect'
+		);
+		$this->assertStringContainsString(
+			'$pfb_ip_reuse_decision = pfb_ip_script_reuse_decision( '
+			. '$pfb_ip_verbatim_reuse, $pfb_script_pre, $pfb_script_post, '
+			. '"{$pfborig}/{$header}.orig"); $pfb_user_script = '
+			. '$pfb_ip_reuse_decision[\'has_user_script\'];',
+			$code,
+			'IP loop must call its distinct decision seam and consume its result'
+		);
+		$this->assertStringContainsString(
+			'pfb_ip_norm_reuse_skip($downloaded_fresh, (bool) $custom, '
+			. '$orig_content_stale, $pfb_norm[\'changed\'], '
+			. 'file_exists("{$pfbfolder}/{$header}.txt"), $pfb_user_script)',
+			$code,
+			'IP normalization fast path must receive the seam effect'
+		);
 	}
 }

--- a/tests/php/ListScriptTransformRerunWiringTest.php
+++ b/tests/php/ListScriptTransformRerunWiringTest.php
@@ -57,13 +57,11 @@ final class ListScriptTransformRerunWiringTest extends TestCase
 
 	public function testUserScriptPreventsIpNormalizationReuse(): void
 	{
-		$this->assertTrue(pfb_ip_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, FALSE));
 		$this->assertFalse(pfb_ip_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE));
 	}
 
 	public function testUserScriptPreventsDnsblNormalizationReuse(): void
 	{
-		$this->assertTrue(pfb_dnsbl_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE, FALSE));
 		$this->assertFalse(pfb_dnsbl_norm_reuse_skip(TRUE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE));
 	}
 
@@ -86,36 +84,32 @@ final class ListScriptTransformRerunWiringTest extends TestCase
 		);
 		$this->assertIsString($code);
 
-		$this->assertStringContainsString(
-			'$pfb_dnsbl_reuse_decision = pfb_dnsbl_script_reuse_decision( '
-			. '$pfb_dnsbl_verbatim_reuse, $pfb_dnsbl_script_pre, $pfb_dnsbl_script_post, '
-			. '"{$pfborig}/{$header}.orig"); $pfb_dnsbl_user_script = '
-			. '$pfb_dnsbl_reuse_decision[\'has_user_script\'];',
-			$code,
-			'DNSBL loop must call its decision seam and consume its result'
-		);
-		$this->assertStringContainsString(
-			'pfb_dnsbl_norm_reuse_skip($downloaded_fresh, (bool) $custom, '
-			. '$orig_content_stale, $pfb_norm[\'changed\'], '
-			. 'file_exists("{$pfbfolder}/{$header}.txt"), $staging_current_generation, '
-			. '$pfb_dnsbl_user_script)',
-			$code,
-			'DNSBL normalization fast path must receive the seam effect'
-		);
-		$this->assertStringContainsString(
-			'$pfb_ip_reuse_decision = pfb_ip_script_reuse_decision( '
-			. '$pfb_ip_verbatim_reuse, $pfb_script_pre, $pfb_script_post, '
-			. '"{$pfborig}/{$header}.orig"); $pfb_user_script = '
-			. '$pfb_ip_reuse_decision[\'has_user_script\'];',
-			$code,
-			'IP loop must call its distinct decision seam and consume its result'
-		);
-		$this->assertStringContainsString(
-			'pfb_ip_norm_reuse_skip($downloaded_fresh, (bool) $custom, '
-			. '$orig_content_stale, $pfb_norm[\'changed\'], '
-			. 'file_exists("{$pfbfolder}/{$header}.txt"), $pfb_user_script)',
-			$code,
-			'IP normalization fast path must receive the seam effect'
-		);
+		$this->assertSame(1, preg_match(
+			'/\$pfb_dnsbl_reuse_decision\s*=\s*pfb_dnsbl_script_reuse_decision\(\s*'
+			. '\$pfb_dnsbl_verbatim_reuse,\s*\$pfb_dnsbl_script_pre,\s*\$pfb_dnsbl_script_post,\s*'
+			. '"\{\$pfborig\}\/\{\$header\}\.orig"\);\s*\$pfb_dnsbl_user_script\s*=\s*'
+			. '\$pfb_dnsbl_reuse_decision\[\x27has_user_script\x27\];/',
+			$code
+		), 'DNSBL loop must call its decision seam and consume its result');
+		$this->assertSame(1, preg_match(
+			'/pfb_dnsbl_norm_reuse_skip\(\s*\$downloaded_fresh,\s*\(bool\)\s*\$custom,\s*'
+			. '\$orig_content_stale,\s*\$pfb_norm\[\x27changed\x27\],\s*'
+			. 'file_exists\(\s*"\{\$pfbfolder\}\/\{\$header\}\.txt"\s*\),\s*\$staging_current_generation,\s*'
+			. '\$pfb_dnsbl_user_script\s*\)/',
+			$code
+		), 'DNSBL normalization fast path must receive the seam effect');
+		$this->assertSame(1, preg_match(
+			'/\$pfb_ip_reuse_decision\s*=\s*pfb_ip_script_reuse_decision\(\s*'
+			. '\$pfb_ip_verbatim_reuse,\s*\$pfb_script_pre,\s*\$pfb_script_post,\s*'
+			. '"\{\$pfborig\}\/\{\$header\}\.orig"\);\s*\$pfb_user_script\s*=\s*'
+			. '\$pfb_ip_reuse_decision\[\x27has_user_script\x27\];/',
+			$code
+		), 'IP loop must call its distinct decision seam and consume its result');
+		$this->assertSame(1, preg_match(
+			'/pfb_ip_norm_reuse_skip\(\s*\$downloaded_fresh,\s*\(bool\)\s*\$custom,\s*'
+			. '\$orig_content_stale,\s*\$pfb_norm\[\x27changed\x27\],\s*'
+			. 'file_exists\(\s*"\{\$pfbfolder\}\/\{\$header\}\.txt"\s*\),\s*\$pfb_user_script\s*\)/',
+			$code
+		), 'IP normalization fast path must receive the seam effect');
 	}
 }

--- a/tests/php/LogFormatConsumersTest.php
+++ b/tests/php/LogFormatConsumersTest.php
@@ -14,9 +14,8 @@ use PHPUnit\Framework\TestCase;
  * script code (`www/index.php` runs at include time; the alerts stat loop
  * is guarded by a live `$alert_summary`/`$alert_log`, not wrapped in a
  * function AlertsPageLoader.php's eval window covers). Each fixed formula
- * below is pinned by a source tripwire (assertStringContainsString on the
- * exact current line, so this oracle goes red the moment the formula
- * drifts) and then reproduced -- not `include`d -- and executed for REAL via
+ * below is pinned by a comment-free code tripwire (php_strip_whitespace(), so
+ * production prose can never satisfy the oracle) and then reproduced -- not included -- and executed for REAL via
  * `exec()`/`shell_exec()` against synthetic fixture files, mirroring Phase
  * 1/3's convention for daemon code that cannot be called directly.
  */
@@ -55,6 +54,13 @@ final class LogFormatConsumersTest extends TestCase
 		return $f;
 	}
 
+	private function codeSource(string $path): string
+	{
+		$source = php_strip_whitespace($path);
+		$this->assertNotSame('', $source, "could not read comment-free source: {$path}");
+		return $source;
+	}
+
 	// -----------------------------------------------------------------------
 	// www/index.php -- the DNSBL block page's dnsbl.log correlation grep key
 	// -----------------------------------------------------------------------
@@ -67,7 +73,7 @@ final class LogFormatConsumersTest extends TestCase
 	 */
 	public function testBlockPageGuardCharsetAcceptsIsoTimestamp(): void
 	{
-		$source = (string) file_get_contents(self::INDEX_PHP);
+		$source = $this->codeSource(self::INDEX_PHP);
 		$needle = 'preg_match("/^[a-zA-Z0-9:\- ]+$/"';
 		$this->assertStringContainsString(
 			$needle,
@@ -107,7 +113,7 @@ final class LogFormatConsumersTest extends TestCase
 	 */
 	public function testBlockPageCorrelationMatchesNewIsoFormatLogLine(): void
 	{
-		$source = (string) file_get_contents(self::INDEX_PHP);
+		$source = $this->codeSource(self::INDEX_PHP);
 		$this->assertStringContainsString(
 			"date('Y-m-d H:i', htmlspecialchars(\$_SERVER['REQUEST_TIME']))",
 			$source,
@@ -192,9 +198,9 @@ final class LogFormatConsumersTest extends TestCase
 	 */
 	public function testBlockPageCorrelationNeverMatchesLookalikeHostRow(): void
 	{
-		$source = (string) file_get_contents(self::INDEX_PHP);
+		$source = $this->codeSource(self::INDEX_PHP);
 		$matched = preg_match(
-			'#exec\("(/usr/bin/tail -n50 /var/log/pfblockerng/dnsbl\.log[^"]+)", \$data, \$retval\);#',
+			'#exec\("(/usr/bin/tail -n50 /var/log/pfblockerng/dnsbl\.log[^"]+)",\s*\$data,\s*\$retval\);#',
 			$source,
 			$m
 		);
@@ -245,7 +251,7 @@ final class LogFormatConsumersTest extends TestCase
 	 */
 	public function testDayBucketCutFieldSelectionGroupsIsoLinesByDate(): void
 	{
-		$source = (string) file_get_contents(self::ALERTS_PHP);
+		$source = $this->codeSource(self::ALERTS_PHP);
 		$needle = "{\$pfb['grep']} -E '^[0-9]{4}-' | cut -d ' ' -f1 | uniq -c";
 		$this->assertStringContainsString($needle, $source, "pfblockerng_alerts.php's day-bucket cut changed -- update this oracle");
 		$this->assertStringNotContainsString("cut -d ' ' -f1-2", $source, 'the OLD 3-token field selection must be gone');
@@ -299,7 +305,7 @@ final class LogFormatConsumersTest extends TestCase
 	 */
 	public function testHourlyChartLabelAwkShowsCorrectHourForIsoLines(): void
 	{
-		$source = (string) file_get_contents(self::ALERTS_PHP);
+		$source = $this->codeSource(self::ALERTS_PHP);
 		// Nowdoc: zero escape processing, so this holds the exact RAW source bytes
 		// (literal backslashes and all) for a byte-for-byte tripwire against the file.
 		$rawSourceNeedle = <<<'EOT'
@@ -360,7 +366,7 @@ EOT;
 	 */
 	public function testDnsblDateHrAndHrMinBucketsUnaffectedByFormatChange(): void
 	{
-		$source = (string) file_get_contents(self::ALERTS_PHP);
+		$source = $this->codeSource(self::ALERTS_PHP);
 		$this->assertStringContainsString(
 			"{\$pfb['grep']} -E '^[0-9]{4}-' | cut -d ':' -f1 | sort | uniq -c | sort -nr",
 			$source,
@@ -554,7 +560,7 @@ EOT;
 	 */
 	public function testBucketLabelIssetGuardPreventsWarningOnKeyWithoutSpace(): void
 	{
-		$source = (string) file_get_contents(self::ALERTS_PHP);
+		$source = $this->codeSource(self::ALERTS_PHP);
 		$needle = '$data = isset($d[1]) ? "{$d[0]}&emsp;({$d[1]})" : $d[0];';
 		$this->assertStringContainsString($needle, $source, 'the $d[1] render guard changed -- update this oracle');
 
@@ -596,10 +602,14 @@ EOT;
 	 */
 	public function testTopAsnStatPipelineSourceHasSchemaGate(): void
 	{
-		$source = (string) file_get_contents(self::ALERTS_PHP);
+		$source = $this->codeSource(self::ALERTS_PHP);
 		$needle = "{\$pfb['awk']} -F',' 'NF == 23' {\$alert_log} | {\$cut_cmd} | {\$agent_cmd} {\$su_cmd} | sort -nr 2>&1";
 		$this->assertStringContainsString($needle, $source, "pfblockerng_alerts.php's Top ASN ('ipasn') pipeline changed -- update this oracle");
-		$this->assertStringContainsString("'ipasn'\t\t=> 20", $source, "the 'ipasn' cut-column position changed -- update this oracle (must stay 20: the 2 new columns were appended AFTER it)");
+		$this->assertSame(
+			1,
+			preg_match("/'ipasn'\s*=>\s*20/", $source),
+			"the 'ipasn' cut-column position changed -- update this oracle (must stay 20: the 2 new columns were appended AFTER it)"
+		);
 	}
 
 	/**

--- a/tests/php/LogLinecountGuardTest.php
+++ b/tests/php/LogLinecountGuardTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  * The file executes top-level code on include (needs a live pfSense
  * session -- $pfb, $_REQUEST routing, real file I/O) and cannot be
  * require()d off-appliance. The guard + cap block is extracted verbatim from
- * the real source into a callable oracle (the count injected as the argument, print
+ * comment-free source into a callable oracle (the count injected as the argument, print
  * captured, exit becomes an early return), so the branch logic is exercised
  * behaviourally, not just shape-matched.
  *
@@ -40,9 +40,9 @@ final class LogLinecountGuardTest extends TestCase
 	public static function setUpBeforeClass(): void
 	{
 		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_log.php';
-		$src = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng_log.php');
+		$src = php_strip_whitespace($path);
+		if ($src === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng_log.php');
 		}
 		self::$src = $src;
 
@@ -50,9 +50,11 @@ final class LogLinecountGuardTest extends TestCase
 		// as committed. print -> capture, exit -> early return, gettext
 		// stripped (plain PHP string stays). If extraction fails the guard block
 		// changed shape -- fail loudly rather than skip.
-		if (!function_exists('pfb_log_linecount_oracle')
-			&& preg_match('/(if \(\$linecnt === NULL\).*?Displaying last.*?\n[\t ]*\})\n/s', $src, $m)) {
-			$block = strtr($m[1], [
+		$start = strpos($src, 'if ($linecnt === NULL)');
+		$end = strpos($src, '$data =', $start === FALSE ? 0 : $start);
+		if (!function_exists('pfb_log_linecount_oracle') && $start !== FALSE && $end !== FALSE && $end > $start) {
+			$block = substr($src, $start, $end - $start);
+			$block = strtr($block, [
 				'print ('  => '$out .= (',
 				'exit;'    => 'return array($out, NULL, NULL, NULL);',
 				'gettext(' => '(',
@@ -112,8 +114,8 @@ final class LogLinecountGuardTest extends TestCase
 	 */
 	public function testNullGuardAnswersWithErrorConvention(): void
 	{
-		$this->assertMatchesRegularExpression(
-			'/if\s*\(\s*\$linecnt\s*===\s*NULL\s*\)\s*\{\s*\n\s*print \("\|2\|"/',
+		$this->assertStringContainsString(
+			'if ($linecnt === NULL) { print ("|2|',
 			self::$src,
 			'a NULL $linecnt must answer with the handler\'s |2| error convention before any cap math'
 		);

--- a/tests/php/LogNowTokenRetiredTest.php
+++ b/tests/php/LogNowTokenRetiredTest.php
@@ -8,26 +8,17 @@ use PHPUnit\Framework\TestCase;
  * issue #1008 retired pfb_logger()'s '[ NOW ]' opt-in scrub (LogTimestampBaselineTest
  * pins the writer side); issue #1047 found 9 pfblockerng.php call sites still carrying
  * the literal ' [ NOW ]' token, so it printed verbatim (no substitution left to hide
- * it). Tree-wide tripwire: no tracked src/ file may contain the literal token outside
- * a documented comment-only mention (ALLOWLIST below).
+ * it). PHP-code tripwire: no shipped PHP/INC executable token may contain the literal.
  */
 final class LogNowTokenRetiredTest extends TestCase
 {
 	private const NOW_TOKEN = ' [ NOW ]';
 
-	/**
-	 * file:line -> reason, for a genuine comment-only historical mention.
-	 * Empty: every current tracked src/ file is clean.
-	 *
-	 * @var array<string,string>
-	 */
-	private const ALLOWLIST = [];
-
 	public function testNoTrackedSrcFileContainsLiteralNowToken(): void
 	{
 		$repoRoot = dirname(__DIR__, 2);
 
-		exec('git -C ' . escapeshellarg($repoRoot) . ' ls-files -- src 2>&1', $files, $exit);
+		exec('git -C ' . escapeshellarg($repoRoot) . " ls-files -- 'src/*.php' 'src/*.inc' 2>&1", $files, $exit);
 		$this->assertSame(0, $exit, 'git ls-files must succeed to enumerate tracked src/ files; got: ' . implode("\n", $files));
 
 		$violations = [];
@@ -36,15 +27,13 @@ final class LogNowTokenRetiredTest extends TestCase
 			if (!is_file($path)) {
 				continue;
 			}
-			$lines = explode("\n", (string) file_get_contents($path));
+			// PRODUCTION COMMENTS AND DOCBLOCKS MUST NEVER BE LOAD-BEARING FOR A TEST.
+			$lines = explode("\n", php_strip_whitespace($path));
 			foreach ($lines as $i => $line) {
 				if (!str_contains($line, self::NOW_TOKEN)) {
 					continue;
 				}
-				$key = "{$relpath}:" . ($i + 1);
-				if (!array_key_exists($key, self::ALLOWLIST)) {
-					$violations[] = $key;
-				}
+				$violations[] = "{$relpath}:" . ($i + 1);
 			}
 		}
 

--- a/tests/php/LogSelectedTypeTest.php
+++ b/tests/php/LogSelectedTypeTest.php
@@ -13,6 +13,8 @@ use PHPUnit\Framework\TestCase;
 final class LogSelectedTypeTest extends TestCase
 {
 	private array $savedPost = [];
+	private static string $pconfigRegion;
+	private static string $selectedRegion;
 
 	public static function setUpBeforeClass(): void
 	{
@@ -28,42 +30,38 @@ final class LogSelectedTypeTest extends TestCase
 
 		// Region 1: $_POST ingress -> $pconfig['logtype']/'logFile' defaults.
 		if (!function_exists('pfb_log_oracle_pconfig')) {
-			if (!preg_match('/\$pconfig = array\(\);\n(.*?)\n\n\/\/ Send logfile to screen/s', $src, $m)) {
+			if (!preg_match('/\$pconfig = array\(\);\n(.*?\$pconfig\[[\'\"]logFile[\'\"]\] = \'\';\n\})/s', $src, $m)) {
 				throw new RuntimeException('test bootstrap: pconfig ingress region not found');
 			}
+			self::$pconfigRegion = $m[1];
 			eval('function pfb_log_oracle_pconfig(): array { $pconfig = array(); ' . $m[1] . ' return $pconfig; }');
 		}
 
 		// Region 5: 'logtype' -> $selected -> $pfb_logtypes[$selected] offset,
 		// through $logs/getlogs()/$clearable/$downloadable (issues #1198/#1207).
 		if (!function_exists('pfb_log_oracle_selected_logtype')) {
-			// Match the selected-logtype block while retaining the production
-			// scalar fallback and its downstream consumer matrix.
-			if (!preg_match(
-				'/\/\/ Collect selected logs\n\$logs = array\(\);\n\$clearable = \$downloadable = FALSE;\n'
-				. '((?:\/\/[^\n]*\n)*\$selected = .*?;\n'
-				. '\$pfb_sel = \$pfb_logtypes\[\$selected\];\n'
-				. '\n'
-				. 'if \(isset\(\$pfb_sel\[\'logs\'\]\)\) \{\n'
-				. '\t\$logs = \$pfb_sel\[\'logs\'\];\n'
-				. '\} else \{\n'
-				. '\t\$logs = getlogs\(\$pfb_sel\[\'logdir\'\], \$pfb_sel\[\'ext\'\]\);\n'
-				. '\}\n'
-				. '\n'
-				. '\$logdir\t\t= \$pfb_sel\[\'logdir\'\] \?: \'\/var\/db\/pfblockerng\';\n'
-				. '\$clearable\t= \$pfb_sel\[\'clear\'\] \?: FALSE;\n'
-				. '\$downloadable\t= \$pfb_sel\[\'download\'\] \?: FALSE;)/',
-				$src,
-				$m
-			)) {
+			$start = strpos($src, '$logs = array();');
+			$selected = strpos($src, '$selected =', $start === false ? 0 : $start);
+			$downloadable = strpos($src, '$downloadable', $selected === false ? 0 : $selected);
+			$end = $downloadable === false ? false : strpos($src, ";\n", $downloadable);
+			if ($start === false || $selected === false || $downloadable === false || $end === false || $end <= $start) {
 				throw new RuntimeException('test bootstrap: selected-logtype region not found');
 			}
+			self::$selectedRegion = substr($src, $start, $end + 2 - $start);
 			eval(
 				'function pfb_log_oracle_selected_logtype(array $pconfig, array $pfb_logtypes): array { '
-				. $m[1]
+				. self::$selectedRegion
 				. ' return compact(\'pfb_sel\', \'logs\', \'clearable\', \'downloadable\'); }'
 			);
 		}
+	}
+
+	public function testExtractionUsesExecutableBoundariesNotProductionComments(): void
+	{
+		$this->assertStringStartsWith('if ($_POST)', self::$pconfigRegion);
+		$this->assertStringNotContainsString('Send logfile to screen', self::$pconfigRegion);
+		$this->assertStringStartsWith('$logs = array();', self::$selectedRegion);
+		$this->assertStringNotContainsString('Collect selected logs', self::$selectedRegion);
 	}
 
 	protected function setUp(): void

--- a/tests/php/LogTimestampBaselineTest.php
+++ b/tests/php/LogTimestampBaselineTest.php
@@ -26,8 +26,6 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_log_event')]
 final class LogTimestampBaselineTest extends TestCase
 {
-	private const PFBLOCKERNG_INC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
-
 	/** @var string[] temp files to remove in tearDown */
 	private array $tmpfiles = [];
 
@@ -216,26 +214,40 @@ final class LogTimestampBaselineTest extends TestCase
 
 	public function testErrlogBypassWriteAlwaysStamped(): void
 	{
-		// Tripwire: pin the exact (now-stamped) bypass shape from pfb_open_sqlite() so
-		// this oracle goes red if that call site's format ever changes.
-		$source = (string) file_get_contents(self::PFBLOCKERNG_INC);
-		$this->assertStringContainsString(
-			'@file_put_contents($pfb[\'errlog\'], "\n{$now} DNSBL_SQL: Failed to open DB - {$message}", FILE_APPEND | LOCK_EX);',
-			$source,
-			'pfb_open_sqlite() bypass write shape changed -- update this baseline oracle'
-		);
-
 		$errlog = $this->tempFile('pfb_errlog_bypass_');
-		$now = date('Y-m-d H:i:s', time());
-		// Reproduces that exact (now-stamped) write: a direct file_put_contents(), no pfb_logger().
-		file_put_contents($errlog, "\n{$now} DNSBL_SQL: Failed to open DB - Query ip cache", FILE_APPEND | LOCK_EX);
+		$dir = $this->tempFile('pfb_sqlite_dir_');
+		unlink($dir);
+		mkdir($dir);
+		$this->saved['dnsbl_info'] = array_key_exists('dnsbl_info', $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb']['dnsbl_info'] : FALSE;
+		$this->saved['sqlite_timeout'] = array_key_exists('sqlite_timeout', $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb']['sqlite_timeout'] : FALSE;
+		$this->saved['errlog'] = array_key_exists('errlog', $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb']['errlog'] : FALSE;
+		$GLOBALS['pfb']['dnsbl_info'] = $dir;
+		$GLOBALS['pfb']['sqlite_timeout'] = 1;
+		$GLOBALS['pfb']['errlog'] = $errlog;
+
+		try {
+			$this->assertFalse(pfb_open_sqlite(1, 'Query ip cache'), 'an SQLite directory path must fail open and exercise the errlog bypass');
+		} finally {
+			foreach (['dnsbl_info', 'sqlite_timeout', 'errlog'] as $key) {
+				if ($this->saved[$key] === FALSE) {
+					unset($GLOBALS['pfb'][$key]);
+				} else {
+					$GLOBALS['pfb'][$key] = $this->saved[$key];
+				}
+			}
+			rmdir($dir);
+		}
 
 		$written = (string) file_get_contents($errlog);
-		$this->assertMatchesRegularExpression(
-			'/^\n\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} DNSBL_SQL: Failed to open DB - Query ip cache$/',
-			$written,
-			"the pfb_open_sqlite() bypass write must always carry a real ISO timestamp now; got: {$written}"
-		);
+		$lines = array_values(array_filter(explode("\n", $written), static fn (string $line): bool => $line !== ''));
+		$this->assertCount(2, $lines, "the failed first and second SQLite opens must both log a stamped line; got: {$written}");
+		foreach ($lines as $line) {
+			$this->assertMatchesRegularExpression(
+				'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} DNSBL_SQL: Failed to open DB(?: 2nd attempt)? - Query ip cache$/',
+				$line,
+				"the pfb_open_sqlite() bypass write must carry a real ISO timestamp now; got: {$line}"
+			);
+		}
 	}
 
 	// -----------------------------------------------------------------------
@@ -532,13 +544,6 @@ final class LogTimestampBaselineTest extends TestCase
 	 */
 	public function testDnsblLogUniformAcrossBothWritersAfterFix(): void
 	{
-		$pySource = (string) file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfb_unbound.py');
-		$this->assertStringContainsString(
-			'datetime.now().strftime("%Y-%m-%d %H:%M:%S")',
-			$pySource,
-			"pfb_unbound.py's make_timestamp() format changed -- update this synthetic python-writer line to match"
-		);
-
 		[$dnslog] = $this->seedLogEventSandbox('uuid-logevent-mixed.example.com', '203.0.113.78');
 
 		$unexpected = $this->callCapturingUnexpectedWarnings(function () {
@@ -546,8 +551,8 @@ final class LogTimestampBaselineTest extends TestCase
 		});
 		$this->assertSame([], $unexpected, 'expected no unrelated PHP warning from pfb_log_event(); got: ' . var_export($unexpected, true));
 
-		// Synthetic python-mode line -- same 'Y-m-d H:i:s' shape make_timestamp()
-		// now produces (pinned by the source tripwire above), same file.
+		// Synthetic python-mode line mirrors tests/test_pfb_unbound_log_timestamp_baseline.py;
+		// Python's writer is exercised by that suite, while this test checks the shared log shape.
 		$pyLine = 'DNSBL-python,' . date('Y-m-d H:i:s', time())
 			. ',uuid-pyrow.example.com,203.0.113.79,Python,VIP,TestGroup,uuid-pyrow.example.com,TestFeed,+,A';
 		file_put_contents($dnslog, "{$pyLine}\n", FILE_APPEND | LOCK_EX);

--- a/tests/php/LogTimestampBaselineTest.php
+++ b/tests/php/LogTimestampBaselineTest.php
@@ -228,13 +228,6 @@ final class LogTimestampBaselineTest extends TestCase
 		try {
 			$this->assertFalse(pfb_open_sqlite(1, 'Query ip cache'), 'an SQLite directory path must fail open and exercise the errlog bypass');
 		} finally {
-			foreach (['dnsbl_info', 'sqlite_timeout', 'errlog'] as $key) {
-				if ($this->saved[$key] === FALSE) {
-					unset($GLOBALS['pfb'][$key]);
-				} else {
-					$GLOBALS['pfb'][$key] = $this->saved[$key];
-				}
-			}
 			rmdir($dir);
 		}
 

--- a/tests/php/PfbFeedNormalizeTest.php
+++ b/tests/php/PfbFeedNormalizeTest.php
@@ -27,7 +27,7 @@ final class PfbFeedNormalizeTest extends TestCase
 	protected function setUp(): void
 	{
 		$this->dir = sys_get_temp_dir() . '/pfb_norm_' . getmypid() . '_' . bin2hex(random_bytes(4));
-		mkdir($this->dir, 0777, true);
+		mkdir($this->dir, 0777, TRUE);
 	}
 
 	protected function tearDown(): void
@@ -227,19 +227,15 @@ final class PfbFeedNormalizeTest extends TestCase
 
 	// --- wiring guard: only the parse-loop consumers normalize ---
 
-	public function testOnlyTheParseLoopConsumersCallNormalize(): void
+	/** #993: both live parse loops are unsafe off-appliance; only comment-free outer pins remain. */
+	public function testLiveFeedDispatchNormalizesOnlyAtParseConsumers(): void
 	{
-		// The changed-verdict means "changed since the last CONSUMER normalize".
-		// A download-time (pfb_download finalize) call records the fresh source
-		// digest first, so the consumer then reads 'unchanged' for genuinely-new
-		// content and the norm-skip gate strands stale staging -- caught live by
-		// tests/smoke/test_smoke_feeds.py::test_cron_detects_changed_local_feed.
-		$inc = (string) file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
-		$this->assertSame(0, preg_match_all('/=\s*pfb_feed_normalize\(/', $inc),
-			'pfblockerng.inc must contain no pfb_feed_normalize() call site -- never a download-time call');
-		$apply = (string) file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
-		$this->assertSame(2, preg_match_all('/=\s*pfb_feed_normalize\(/', $apply),
-			'exactly the two parse loops (DNSBL + IP) consume pfb_feed_normalize');
+		$apply = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertSame(2, substr_count($apply, '$pfb_norm = pfb_feed_normalize('),
+			'live download consumers must normalize exactly once per DNSBL/IP parse loop');
+		$inc = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+		$this->assertSame(0, substr_count($inc, '$pfb_norm = pfb_feed_normalize('),
+			'the download/firewall orchestration include must not normalize before its live parse consumers');
 	}
 
 	// --- the Python converter leg (real charset_normalizer where available) ---

--- a/tests/php/PfbJsCacheBustingWiringTest.php
+++ b/tests/php/PfbJsCacheBustingWiringTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\TestCase;
 
 final class PfbJsCacheBustingWiringTest extends TestCase
 {
+	private const ASSET_PATH = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfBlockerNG.js';
+
 	private const PAGE_FUNCTIONS = [
 		'pfblockerng_category.php' => 'pfb_category_js_asset_render',
 		'pfblockerng_category_edit.php' => 'pfb_category_edit_js_asset_render',
@@ -17,17 +19,15 @@ final class PfbJsCacheBustingWiringTest extends TestCase
 	private function renderScript(string $name): string
 	{
 		$function = self::PAGE_FUNCTIONS[$name];
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfBlockerNG.js';
-		return $function($path);
+		return $function(self::ASSET_PATH);
 	}
 
 	public function testAssetCarriesTheRuntimeModificationVersion(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfBlockerNG.js';
+		$expected = 'src="pfBlockerNG.js?v=' . pfb_file_mtime(self::ASSET_PATH) . '"';
 		foreach (array_keys(self::PAGE_FUNCTIONS) as $page) {
 			$script = $this->renderScript($page);
-			$this->assertStringContainsString('src="pfBlockerNG.js?v=', $script, $page);
-			$this->assertStringContainsString((string) pfb_file_mtime($path), $script, $page);
+			$this->assertStringContainsString($expected, $script, $page);
 			$this->assertStringContainsString('type="text/javascript"', $script, $page);
 		}
 	}

--- a/tests/php/PfbJsCacheBustingWiringTest.php
+++ b/tests/php/PfbJsCacheBustingWiringTest.php
@@ -2,103 +2,43 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Every page that ships `pfBlockerNG.js` must reference it with an mtime cache-buster,
- * the same way the pfSense chrome and this package's CodeMirror assets already do.
- *
- * A bare `src="pfBlockerNG.js"` lets a browser keep its pre-upgrade copy of the script:
- * the response carries no Expires/Cache-Control, so heuristic freshness applies. The
- * stale copy then throws against post-upgrade markup, and pfSense's unguarded `events`
- * drain skips every page callback queued behind it (issue #1845).
- *
- * These pages carry top-level render execution and cannot be require()d off-appliance,
- * so reading the shipped source IS reading the render for this markup. The rendered
- * form is pinned on a live appliance by tests/smoke/ui/test_render_smoke.py.
- */
 final class PfbJsCacheBustingWiringTest extends TestCase
 {
-	/** The shipped script, as the pages address it and as it lands on the appliance. */
-	private const SCRIPT_SRC  = 'pfBlockerNG.js';
-	private const SCRIPT_PATH = '/usr/local/www/pfblockerng/pfBlockerNG.js';
+	private const PAGE_FUNCTIONS = [
+		'pfblockerng_category.php' => 'pfb_category_js_asset_render',
+		'pfblockerng_category_edit.php' => 'pfb_category_edit_js_asset_render',
+		'pfblockerng_dnsbl.php' => 'pfb_dnsbl_js_asset_render',
+		'pfblockerng_ip.php' => 'pfb_ip_js_asset_render',
+		'pfblockerng_geoip.inc' => 'pfb_geoip_js_asset_render',
+	];
 
-	/**
-	 * Sources that ship the include: the four static pages, plus the nowdoc template
-	 * pfblockerng_get_countries() writes out as the nine GeoIP continent pages -- those
-	 * are navigable tabs and carry the same exposure.
-	 *
-	 * @return array<string, array{string}>
-	 */
-	public static function pageProvider(): array
+	private function renderScript(string $name): string
 	{
-		$sources = array(
-			'usr/local/www/pfblockerng/pfblockerng_category_edit.php',
-			'usr/local/www/pfblockerng/pfblockerng_category.php',
-			'usr/local/www/pfblockerng/pfblockerng_ip.php',
-			'usr/local/www/pfblockerng/pfblockerng_dnsbl.php',
-			'usr/local/pkg/pfblockerng/pfblockerng_geoip.inc',
-		);
-		$cases = array();
-		foreach ($sources as $source) {
-			$cases[basename($source)] = array($source);
+		$function = self::PAGE_FUNCTIONS[$name];
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfBlockerNG.js';
+		return $function($path);
+	}
+
+	public function testAssetCarriesTheRuntimeModificationVersion(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfBlockerNG.js';
+		foreach (array_keys(self::PAGE_FUNCTIONS) as $page) {
+			$script = $this->renderScript($page);
+			$this->assertStringContainsString('src="pfBlockerNG.js?v=', $script, $page);
+			$this->assertStringContainsString((string) pfb_file_mtime($path), $script, $page);
+			$this->assertStringContainsString('type="text/javascript"', $script, $page);
 		}
-		return $cases;
 	}
 
-	private static function read(string $page): string
+	public function testAssetRendersExactlyOneBustedScriptTag(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/' . $page;
-		$src  = file_get_contents($path);
-		if ($src === false) {
-			throw new RuntimeException("failed to read {$page}");
+		foreach (array_keys(self::PAGE_FUNCTIONS) as $page) {
+			$script = $this->renderScript($page);
+			$this->assertSame(1, substr_count($script, '<script'), $page);
+			$this->assertSame(1, substr_count($script, 'src="pfBlockerNG.js?v='), $page);
+			$this->assertStringNotContainsString('src="pfBlockerNG.js"', $script, $page);
 		}
-		return $src;
-	}
-
-	#[DataProvider('pageProvider')]
-	public function testPfbJsIsIncludedWithAnMtimeCacheBuster(string $page): void
-	{
-		$src = self::read($page);
-
-		// Non-vacuity first: the page really does ship the script. A page that stopped
-		// including it would otherwise pass the cache-buster assertion by having nothing
-		// to match.
-		$this->assertStringContainsString(
-			self::SCRIPT_SRC,
-			$src,
-			"{$page} does not include " . self::SCRIPT_SRC . ' at all'
-		);
-
-		$this->assertMatchesRegularExpression(
-			'#<script src="' . preg_quote(self::SCRIPT_SRC, '#') . '\?v=<\?=pfb_file_mtime\('
-			. "'" . preg_quote(self::SCRIPT_PATH, '#') . "'"
-			. '\)\?>"#',
-			$src,
-			"{$page} includes " . self::SCRIPT_SRC . ' without the pfb_file_mtime() cache-buster,'
-			. ' so a browser can keep running the pre-upgrade script'
-		);
-	}
-
-	#[DataProvider('pageProvider')]
-	public function testPfbJsIsNeverIncludedWithoutTheCacheBuster(string $page): void
-	{
-		$src = self::read($page);
-
-		// Counting closes the gap a "one good include exists" assertion leaves open: a
-		// second, un-busted include elsewhere in the same page would still serve the
-		// stale script.
-		$total  = preg_match_all('#src="' . preg_quote(self::SCRIPT_SRC, '#') . '#', $src);
-		$busted = preg_match_all(
-			'#src="' . preg_quote(self::SCRIPT_SRC, '#') . '\?v=<\?=pfb_file_mtime\(#',
-			$src
-		);
-
-		$this->assertSame(
-			$total,
-			$busted,
-			"{$page} has {$total} " . self::SCRIPT_SRC . " include(s) but only {$busted} carry the cache-buster"
-		);
 	}
 }

--- a/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
+++ b/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
@@ -6,25 +6,79 @@ use PHPUnit\Framework\TestCase;
 
 final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
 {
+	private const INSTALL = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
+
 	public function testPostInstallCapturesSourceBeforeTargetRestoreAndMigrations(): void
 	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc');
-		$this->assertIsString($source);
-		$start = strpos($source, 'global $g, $pfb;');
-		$source_current = strpos($source, '$pfb_source_family = pfb_settings_family_current();', $start);
-		$source_save = strpos($source, 'pfb_settings_family_save($pfb_source_family)', $start);
-		$target_current = strpos($source, '$pfb_installed_family = pfb_settings_family_from_version((string) pfb_pkg_ver());', $start);
-		$target_replace = strpos($source, 'pfb_settings_family_replace($pfb_installed_family)', $start);
-		$migrations = strpos($source, 'pfb_run_migrations();', $start);
+		$order = [];
+		$installed = pfb_install_settings_family_capture_restore(
+			static function () use (&$order): string {
+				$order[] = 'current';
+				return '3.2';
+			},
+			static function (string $family) use (&$order): bool {
+				$order[] = "save:{$family}";
+				return TRUE;
+			},
+			static function () use (&$order): string {
+				$order[] = 'version';
+				return '4.0.0';
+			},
+			static function (string $version) use (&$order): string {
+				$order[] = "from:{$version}";
+				return '4.0';
+			},
+			static function (string $family) use (&$order): bool {
+				$order[] = "replace:{$family}";
+				return TRUE;
+			}
+		);
+		pfb_install_settings_family_finalize(
+			$installed,
+			static function () use (&$order): void { $order[] = 'migrations'; },
+			static function (string $family) use (&$order): bool {
+				$order[] = "record:{$family}";
+				return TRUE;
+			}
+		);
 
-		$this->assertNotFalse($source_current);
-		$this->assertNotFalse($source_save);
-		$this->assertNotFalse($target_current);
-		$this->assertNotFalse($target_replace);
-		$this->assertNotFalse($migrations);
-		$this->assertStringContainsString('$pfb_source_family === NULL || !pfb_settings_family_save($pfb_source_family)', $source);
-		$this->assertLessThan($target_current, $source_current);
-		$this->assertLessThan($target_replace, $source_save);
-		$this->assertLessThan($migrations, $target_replace);
+		$this->assertSame('4.0', $installed);
+		$this->assertSame(
+			['current', 'save:3.2', 'version', 'from:4.0.0', 'replace:4.0', 'migrations', 'record:4.0'],
+			$order
+		);
+	}
+
+	public function testCaptureAndRestoreFailuresStopBeforeLaterEffects(): void
+	{
+		$order = [];
+		try {
+			pfb_install_settings_family_capture_restore(
+			static function () use (&$order): string { $order[] = 'current'; return '3.2'; },
+			static function () use (&$order): bool { $order[] = 'save'; return FALSE; },
+			static fn (): string => '4.0.0',
+			static fn (string $version): string => '4.0',
+			static function () use (&$order): bool { $order[] = 'replace'; return TRUE; }
+			);
+			$this->fail('capture/restore must fail closed when source snapshot save fails');
+		} catch (RuntimeException $error) {
+			$this->assertSame('pfBlockerNG: unable to save source settings family', $error->getMessage());
+		}
+		$this->assertSame(['current', 'save'], $order);
+	}
+
+	/**
+	 * The installer performs appliance-only migrations and service changes, so a direct include
+	 * is destructive/off-appliance. php_strip_whitespace keeps this pin executable-code-only.
+	 */
+	public function testInstallerUsesCaptureRestoreThenFinalize(): void
+	{
+		$source = php_strip_whitespace(self::INSTALL);
+		$this->assertNotSame('', $source, 'installer source must be readable');
+		$capture = strpos($source, 'pfb_install_settings_family_capture_restore();');
+		$finalize = strpos($source, 'pfb_install_settings_family_finalize($pfb_installed_family);');
+		$this->assertNotFalse($capture, 'installer must capture/restore settings before migrations');
+		$this->assertNotFalse($finalize, 'installer must finalize settings after legacy migration');
+		$this->assertLessThan($finalize, $capture);
 	}
 }

--- a/tests/php/PfbSettingsFamilyTest.php
+++ b/tests/php/PfbSettingsFamilyTest.php
@@ -265,45 +265,44 @@ final class PfbSettingsFamilyTest extends TestCase
 
 	public function testLifecycleOrdersReplaceAndContextConsumptionBeforeMigrations(): void
 	{
-		$install = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc');
-		$this->assertIsString($install);
-		$replace = strpos($install, 'pfb_settings_family_replace');
-		$migrations = strpos($install, 'pfb_run_migrations();');
-		$this->assertNotFalse($replace);
-		$this->assertNotFalse($migrations);
-		$this->assertLessThan($migrations, $replace);
-
-		$extra = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');
-		$this->assertIsString($extra);
-		$this->assertStringContainsString('/var/run/pfblockerng-downgrade-context.json', $extra);
-		$this->assertStringContainsString('pfb_settings_downgrade_context_consume', $extra);
-
-		$installed = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc');
-		$this->assertIsString($installed);
-		$installMigrations = strpos($installed, 'pfb_run_migrations();');
-		$installRecord = strpos($installed, 'pfb_settings_family_record');
-		$installReplace = strpos($installed, 'pfb_settings_family_replace');
-		$installFamily = strpos($installed, '$pfb_installed_family = pfb_settings_family_from_version((string) pfb_pkg_ver());');
-		$this->assertNotFalse($installFamily);
-		$this->assertNotFalse(strpos($installed, 'pfb_settings_family_replace($pfb_installed_family)'));
-		$this->assertNotFalse(strpos($installed, 'pfb_settings_family_record($pfb_installed_family)'));
-		$this->assertLessThan($installReplace, $installFamily);
-		$this->assertLessThan($installMigrations, $installReplace);
-		$this->assertLessThan($installRecord, $installMigrations);
-		$this->assertStringContainsString('installedpackages/pfblockerng', $installed);
+		$order = [];
+		$family = pfb_install_settings_family_capture_restore(
+			static function () use (&$order): string { $order[] = 'current'; return '3.2'; },
+			static function (string $value) use (&$order): bool { $order[] = 'save'; return TRUE; },
+			static function () use (&$order): string { $order[] = 'version'; return '4.0.0'; },
+			static function (string $value) use (&$order): string { $order[] = 'from-version'; return '4.0'; },
+			static function (string $value) use (&$order): bool { $order[] = 'replace'; return TRUE; },
+		);
+		pfb_install_settings_family_finalize(
+			$family,
+			static function () use (&$order): void { $order[] = 'migrations'; },
+			static function (string $value) use (&$order): bool { $order[] = 'record'; return TRUE; }
+		);
+		$this->assertSame('4.0', $family);
+		$this->assertSame(['current', 'save', 'version', 'from-version', 'replace', 'migrations', 'record'], $order);
 	}
 
-	public function testLifecycleSavePrecedesOperationAndConditionalRestore(): void
+	/**
+	 * The pre-deinstall hook reads live process/config state and can tear down firewall, DNSBL,
+	 * mounts, files, and services, so only its executable order is pinned off-appliance.
+	 */
+	public function testPreDeinstallSavesAndRestoresBeforePackageOperationAndHonorsKeepBoundary(): void
 	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
-		$this->assertIsString($source);
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
 		$start = strpos($source, 'function pfblockerng_php_pre_deinstall_command');
-		$pre = strpos($source, 'pfb_settings_family_pre_uninstall()', $start);
-		$operation = strpos($source, 'pfb_pkg_operation()', $start);
-		$this->assertNotFalse($start);
-		$this->assertNotFalse($pre);
-		$this->assertLessThan($operation, $pre);
-		$this->assertStringContainsString('Keep Settings', $source);
+		$this->assertNotFalse($start, 'pre-deinstall controller must remain defined');
+		$save = strpos($source, 'pfb_settings_family_pre_uninstall();', $start);
+		$operation = strpos($source, 'pfb_pkg_operation();', $start);
+		$this->assertNotFalse($save, 'pre-deinstall must enter settings-family save/restore boundary');
+		$this->assertNotFalse($operation, 'pre-deinstall must inspect package operation after settings boundary');
+		$this->assertLessThan($operation, $save);
+		$this->assertSame(1, substr_count(substr($source, $start, $operation - $start), 'pfb_settings_family_pre_uninstall();'));
+
+		$keep = strpos($source, "\$pfb['keep'] !== PfbToggle::On", $start);
+		$remove = strpos($source, 'pfb_remove_config_settings();', $start);
+		$this->assertNotFalse($keep, 'keep setting must guard config removal');
+		$this->assertNotFalse($remove, 'keep-off branch must remove package config');
+		$this->assertLessThan($remove, $keep);
 	}
 
 	private function contextPath(): string

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -194,16 +194,16 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		// keying on $header would silently drop the link for every entry. The DNSBL
 		// download loop has no PHPUnit harness of its own (too heavy to invoke), so
 		// this pins the exact call-site argument via source inspection.
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
-		$this->assertNotFalse($source, 'pfblockerng_apply.inc must be readable');
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertNotSame('', $source, 'pfblockerng_apply.inc must be readable');
 
 		$this->assertMatchesRegularExpression(
-			'/pfb_dnsbl_download_ledger_update\(FALSE, \$alias,/',
+			'/pfb_download_ledger_failure\(\x27dnsbl\x27, \$alias,/',
 			$source,
 			'the DNSBL download-fail call must key on $alias, not $header, or the widget deep link breaks'
 		);
 		$this->assertMatchesRegularExpression(
-			'/pfb_dnsbl_download_ledger_update\(TRUE, \$alias,/',
+			'/pfb_download_ledger_close_if_clean\(\x27dnsbl\x27, \$alias, \$pfb_dl_failed,/',
 			$source,
 			'the paired success-close call must key on the SAME $alias for symmetry'
 		);
@@ -218,19 +218,13 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	 */
 	public function testDnsblDownloadCloseFiresOncePerAliasPassNotPerRow(): void
 	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
-		$this->assertNotFalse($source, 'pfblockerng_apply.inc must be readable');
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertNotSame('', $source, 'pfblockerng_apply.inc must be readable');
 
-		$this->assertDoesNotMatchRegularExpression(
-			'/unlink_if_exists\("\{\$pfbfolder\}\/\{\$header\}\.fail"\);\s*\n\s*pfb_dnsbl_download_ledger_update\(TRUE,/',
-			$source,
-			'a row\'s success branch must not close the download ledger directly -- masks a sibling row\'s failure'
-		);
-		$this->assertMatchesRegularExpression(
-			'/if \(!\$pfb_dl_failed\) \{\s*\n\s*pfb_dnsbl_download_ledger_update\(TRUE, \$alias, \'\', \$pfb\[\'dbdir\'\]\);/',
-			$source,
-			'the close call must be gated by the once-per-alias-pass $pfb_dl_failed flag'
-		);
+		$this->assertSame(1, substr_count($source, "pfb_download_ledger_close_if_clean('dnsbl', \$alias, \$pfb_dl_failed, \$pfb['dbdir']);"),
+			'the DNSBL loop must close its ledger exactly once after the alias pass');
+		$this->assertSame(1, substr_count($source, "pfb_dnsbl_download_ledger_update(TRUE, \$alias,"),
+			'only the shared close helper may call the DNSBL ledger close');
 	}
 
 	/**
@@ -250,12 +244,10 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		foreach ($rowOutcomes as $i => $ok) {
 			if (!$ok) {
 				$failed = TRUE;
-				pfb_dnsbl_download_ledger_update(FALSE, $alias, "[ {$alias} - row{$i} ] Download FAIL", $this->dir);
+				pfb_download_ledger_failure('dnsbl', $alias, "row{$i}", $this->dir);
 			}
 		}
-		if (!$failed) {
-			pfb_dnsbl_download_ledger_update(TRUE, $alias, '', $this->dir);
-		}
+		pfb_download_ledger_close_if_clean('dnsbl', $alias, $failed, $this->dir);
 	}
 
 	public function testAliasPassFailThenSucceedLeavesEntryOpen(): void
@@ -388,8 +380,12 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			return !in_array($calls, [3, 4], true);
 		};
 
+		$ledger_calls = 0;
 		try {
-			pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);
+			pfb_reload_unbound('enabled', FALSE, FALSE, TRUE, static function () use (&$ledger_calls): bool {
+				$ledger_calls++;
+				return pfb_dnsbl_apply_ledger_update();
+			});
 		} finally {
 			chmod($this->dir, 0777);
 			foreach (glob("{$writable}/*") ?: [] as $file) {
@@ -400,37 +396,10 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 
 		$this->assertGreaterThanOrEqual(5, $calls,
 			'the restart-fallback + shared restart path must have actually run (sanity check on the call-count assumption)');
+		$this->assertSame(1, $ledger_calls,
+			'the restart fallback must reach the shared ledger tail exactly once');
 		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
 			'a swap-not-confirmed restart-fallback that ultimately converges must not leave a dnsbl apply entry open');
-	}
-
-	/**
-	 * Source-inspection pin (mirrors testDnsblDownloadCallSitesKeyOnTheAliasNotTheHeader):
-	 * the tail's ledger write is deterministic/idempotent-by-key, so no end-state
-	 * assertion can prove a fallback branch stayed silent -- only reading the source can.
-	 */
-	public function testRestartFallbackBranchesNeverCallLedgerFunctionsDirectly(): void
-	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
-		$this->assertNotFalse($source, 'pfblockerng.inc must be readable');
-
-		$start = strpos($source, 'function pfb_reload_unbound(');
-		$this->assertNotFalse($start, 'pfb_reload_unbound() must exist');
-		// The three fallback branches all fall through to this tempnam() call (the
-		// zero-downtime SUCCESS path instead `return`s early, before reaching it) --
-		// a stable, unique boundary marking the end of the fallback-branches region.
-		$end = strpos($source, "\$cache_dumpfile = tempnam(", $start);
-		$this->assertNotFalse($end, 'the shared restart path boundary marker must exist');
-
-		$region = substr($source, $start, $end - $start);
-
-		// \s*\( (not a literal "(") so neither call is evadable via whitespace before
-		// the parenthesis; pfb_sync_status_open/close are the only two ledger-mutating
-		// primitives (grepped -- no pfb_sync_status_refresh() exists), exhaustive.
-		$this->assertDoesNotMatchRegularExpression('/pfb_sync_status_open\s*\(/', $region,
-			'a restart-fallback branch must never open a ledger entry directly -- only the shared tail may');
-		$this->assertDoesNotMatchRegularExpression('/pfb_sync_status_close\s*\(/', $region,
-			'a restart-fallback branch must never close a ledger entry directly -- only the shared tail may');
 	}
 
 	// -----------------------------------------------------------------------
@@ -478,10 +447,16 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			return $calls <= 2;
 		};
 
-		pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);
+		$ledger_calls = 0;
+		pfb_reload_unbound('enabled', FALSE, FALSE, TRUE, static function () use (&$ledger_calls): bool {
+			$ledger_calls++;
+			return pfb_dnsbl_apply_ledger_update();
+		});
 
 		$this->assertSame(2, $calls,
 			"the success path must call is_process_running('unbound') exactly twice (eligibility check + pfb_dnsbl_converged()); any other count means the restart path ran instead");
+		$this->assertSame(1, $ledger_calls,
+			'the zero-downtime success must write apply status exactly once before returning');
 		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
 			'a converged zero-downtime swap must close the dnsbl apply entry via its own early return');
 		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['dnsbl_file']}.sync",
@@ -524,80 +499,27 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		);
 	}
 
-	public function testReloadApiAndBulkCachePolicyHaveNoTargetedDelta(): void
-	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
-		$this->assertNotFalse($source, 'pfblockerng.inc must be readable');
-		$start = strpos($source, 'function pfb_reload_unbound(');
-		$end = strpos($source, 'function pfb_unbound_clear_work_files(', $start);
-		$this->assertNotFalse($start, 'pfb_reload_unbound() must exist');
-		$this->assertNotFalse($end, 'pfb_reload_unbound() end boundary must exist');
-		$region = substr($source, $start, $end - $start);
-
-		$this->assertMatchesRegularExpression(
-			'/function pfb_reload_unbound\(\$mode, \$cache=FALSE, \$pfbpython=FALSE, \$datapath=FALSE\)/',
-			$region,
-			'generic reload must accept no targeted newly-blocked delta'
-		);
-		$this->assertStringNotContainsString('$newly_blocked', $region);
-		$this->assertStringNotContainsString('pfb_unbound_py_ccache_flush(', $region);
-		$this->assertStringNotContainsString('flush_zone +c .', $region);
-		$this->assertStringContainsString(
-			'if ($cache && $pfb[\'dnsbl_res_cache\'] === PfbToggle::On)',
-			$region,
-			'generic reload keeps existing cache preservation policy for config restarts'
-		);
-		$this->assertStringContainsString(
-			'if ($cache && $pfb[\'dnsbl_res_cache\'] === PfbToggle::On && file_exists($cache_dumpfile)',
-			$region,
-			'generic reload restores cache only when its caller preserves it'
-		);
-		$this->assertStringContainsString('return TRUE;', $region,
-			'applied-generation success must be distinguishable from restart fallback');
-		$this->assertStringContainsString('return FALSE;', $region,
-			'restart fallback must report that no zero-downtime swap completed');
-
-		$update_start = strpos($source, 'function pfb_update_unbound(');
-		$update_end = strpos($source, 'function pfb_top1m_active_provider()', $update_start);
-		$this->assertNotFalse($update_start, 'pfb_update_unbound() must exist');
-		$this->assertNotFalse($update_end, 'pfb_update_unbound() end boundary must exist');
-		$update_region = substr($source, $update_start, $update_end - $update_start);
-		$this->assertStringContainsString(
-			'$swapped = pfb_reload_unbound($mode, !$datapath, $pfbpython, $datapath);',
-			$update_region,
-			'bulk caller must disable restart cache preservation for datapath updates'
-		);
-		$this->assertMatchesRegularExpression(
-			'/if \(\$datapath && \$swapped &&\s*'
-			. '\(\$pfb\[\x27dnsbl_cache_flush\x27\] \?\? PfbToggle::Off\) === PfbToggle::On\) \{\s*'
-			. 'exec\("\{\$pfb\[\x27chroot_cmd\x27\]\} flush_zone \+c \. 2>&1"\);\s*\}/s',
-			$update_region,
-			'bulk caller must keep the full flush inside the successful data-swap and default-off option guard'
-		);
-	}
-
 	public function testLockCallerTargetsOnlyAfterGenericReloadReturns(): void
 	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php');
-		$this->assertNotFalse($source, 'pfblockerng_alerts.php must be readable');
-		$start = strpos($source, '// Unlock/Lock DNSBL events');
-		$end = strpos($source, "\n\t\t// sprintf with the (domain-filtered", $start);
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php');
+		$this->assertNotSame('', $source, 'pfblockerng_alerts.php must be readable');
+		$start = strpos($source, "if (\$ua['mode'] !== '')");
+		$end = strpos($source, 'header("Location:', $start);
 		$this->assertNotFalse($start, 'Lock/Unlock handler must exist');
 		$this->assertNotFalse($end, 'Lock/Unlock handler end boundary must exist');
 		$region = substr($source, $start, $end - $start);
 
 		$this->assertStringNotContainsString('$newly_blocked', $region);
-		$reload = "pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);";
 		$targeted = 'pfb_unbound_py_ccache_flush(array($domain));';
-		$reload_pos = strpos($region, $reload);
+		preg_match("/pfb_reload_unbound\('enabled',\s*FALSE,\s*(?:FALSE|TRUE),\s*TRUE\);/", $region, $reload_match, PREG_OFFSET_CAPTURE);
+		$reload_pos = $reload_match[0][1] ?? FALSE;
 		$targeted_pos = strpos($region, $targeted);
 		$this->assertNotFalse($reload_pos, 'Lock/Unlock must call the four-argument generic reload');
 		$this->assertNotFalse($targeted_pos, 'Lock must retain the validated targeted flush in its caller');
 		$this->assertGreaterThan($reload_pos, $targeted_pos,
 			'targeted Lock flush must run only after generic reload returns');
 		$this->assertMatchesRegularExpression(
-			'/if \(\$ua\[\x27mode\x27\] === \x27lock\x27\) \{\s*'
-			. 'pfb_unbound_py_ccache_flush\(array\(\$domain\)\);/s',
+			'/if \(\$ua\[\x27mode\x27\] === \x27lock\x27\) \{\s*pfb_unbound_py_ccache_flush\(array\(\$domain\)\);/s',
 			$region,
 			'only Lock, not Unlock, may invoke the targeted helper'
 		);

--- a/tests/php/PfbSyncStatusIpWritersTest.php
+++ b/tests/php/PfbSyncStatusIpWritersTest.php
@@ -142,6 +142,14 @@ final class PfbSyncStatusIpWritersTest extends TestCase
 		$this->assertSame('HTTP 500', $open[0]['message'], 'message must be the LATEST refresh');
 	}
 
+	public function testUnknownLedgerFacilityIsIgnored(): void
+	{
+		pfb_download_ledger_failure('other', 'item', 'header', $this->dir);
+		pfb_download_ledger_close_if_clean('other', 'item', FALSE, $this->dir);
+		$this->assertFileDoesNotExist($this->dir . '/pfb_sync_status.json',
+			'an unsupported facility must not write a ledger entry');
+	}
+
 	public function testDownloadCallSitesKeyOnTheAliasNotTheHeader(): void
 	{
 		// Regression pin: pfb_ip_download_ledger_update() was called with $header (the
@@ -154,16 +162,16 @@ final class PfbSyncStatusIpWritersTest extends TestCase
 		// rather than a functional call: narrow, but it catches a regression of this
 		// specific defect, which the function-level unit tests above cannot (they call
 		// the helper directly with an already-correct item name).
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
-		$this->assertNotFalse($source, 'pfblockerng_apply.inc must be readable');
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertNotSame('', $source, 'pfblockerng_apply.inc must be readable');
 
 		$this->assertMatchesRegularExpression(
-			'/pfb_ip_download_ledger_update\(FALSE, \$alias,/',
+			'/pfb_download_ledger_failure\(\x27ip\x27, \$alias,/',
 			$source,
 			'the download-fail call must key on $alias, not $header, or the widget deep link breaks'
 		);
 		$this->assertMatchesRegularExpression(
-			'/pfb_ip_download_ledger_update\(TRUE, \$alias,/',
+			'/pfb_download_ledger_close_if_clean\(\x27ip\x27, \$alias, \$pfb_dl_failed,/',
 			$source,
 			'the paired success-close call must key on the SAME $alias for symmetry'
 		);
@@ -178,19 +186,13 @@ final class PfbSyncStatusIpWritersTest extends TestCase
 	 */
 	public function testIpDownloadCloseFiresOncePerAliasPassNotPerRow(): void
 	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
-		$this->assertNotFalse($source, 'pfblockerng_apply.inc must be readable');
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertNotSame('', $source, 'pfblockerng_apply.inc must be readable');
 
-		$this->assertDoesNotMatchRegularExpression(
-			'/unlink_if_exists\("\{\$pfbfolder\}\/\{\$header\}\.fail"\);\s*\n\s*pfb_ip_download_ledger_update\(TRUE,/',
-			$source,
-			'a row\'s success branch must not close the download ledger directly -- masks a sibling row\'s failure'
-		);
-		$this->assertMatchesRegularExpression(
-			'/if \(!\$pfb_dl_failed\) \{\s*\n\s*pfb_ip_download_ledger_update\(TRUE, \$alias, \'\', \$pfb\[\'dbdir\'\]\);/',
-			$source,
-			'the close call must be gated by the once-per-alias-pass $pfb_dl_failed flag'
-		);
+		$this->assertSame(1, substr_count($source, "pfb_download_ledger_close_if_clean('ip', \$alias, \$pfb_dl_failed, \$pfb['dbdir']);"),
+			'the IP loop must close its ledger exactly once after the alias pass');
+		$this->assertSame(1, substr_count($source, "pfb_ip_download_ledger_update(TRUE, \$alias,"),
+			'only the shared close helper may call the IP ledger close');
 	}
 
 	/**
@@ -211,12 +213,10 @@ final class PfbSyncStatusIpWritersTest extends TestCase
 		foreach ($rowOutcomes as $i => $ok) {
 			if (!$ok) {
 				$failed = TRUE;
-				pfb_ip_download_ledger_update(FALSE, $alias, "[ {$alias} - row{$i} ] Download FAIL", $this->dir);
+				pfb_download_ledger_failure('ip', $alias, "row{$i}", $this->dir);
 			}
 		}
-		if (!$failed) {
-			pfb_ip_download_ledger_update(TRUE, $alias, '', $this->dir);
-		}
+		pfb_download_ledger_close_if_clean('ip', $alias, $failed, $this->dir);
 	}
 
 	public function testAliasPassFailThenSucceedLeavesEntryOpen(): void

--- a/tests/php/PfbWidgetOracleTest.php
+++ b/tests/php/PfbWidgetOracleTest.php
@@ -44,6 +44,7 @@ final class PfbWidgetOracleTest extends TestCase
 	private const ICON_GREEN  = 'fa-solid fa-check-circle text-success';
 	private const ICON_YELLOW = 'fa-solid fa-exclamation-circle text-warning';
 	private const ICON_RED    = 'fa-solid fa-times-circle text-danger';
+	private static string $iconRegion;
 
 	public static function setUpBeforeClass(): void
 	{
@@ -55,18 +56,14 @@ final class PfbWidgetOracleTest extends TestCase
 		}
 
 		if (!function_exists('pfb_widget_oracle_status')) {
-			// Extract the icon-decision block VERBATIM (the two "Status indicator"
-			// sections), up to (not including) the next section's comment, which
-			// serves only as a unique end-anchor via lookahead.
-			if (!preg_match(
-				'/\/\/ Status indicator if pfBlockerNG is enabled\/disabled.*?\n\t\}(?=\n\n\t\/\/ Collect folder\/file counts)/s',
-				$src,
-				$m
-			)) {
+			$start = strpos($src, "\tif (\$pfb['enable'] === PfbToggle::On) {");
+			$end = strpos($src, "\t\$stats = array();", $start === false ? 0 : $start);
+			if ($start === false || $end === false || $end <= $start) {
 				throw new RuntimeException('test bootstrap: icon-status block not found in widget source');
 			}
+			self::$iconRegion = substr($src, $start, $end - $start);
 			eval(
-				'function pfb_widget_oracle_status(array $pfb): array { ' . $m[0]
+				'function pfb_widget_oracle_status(array $pfb): array { ' . self::$iconRegion
 				. ' return [$pfb_status, $pfb_msg, $dnsbl_status, $dnsbl_msg]; }'
 			);
 		}
@@ -84,6 +81,12 @@ final class PfbWidgetOracleTest extends TestCase
 			}
 			eval($m[0]);
 		}
+	}
+
+	public function testIconExtractionUsesExecutableBoundaryNotProductionComment(): void
+	{
+		$this->assertStringStartsWith("\tif (\$pfb['enable'] === PfbToggle::On)", self::$iconRegion);
+		$this->assertStringNotContainsString('Status indicator if pfBlockerNG is enabled/disabled', self::$iconRegion);
 	}
 
 	private string $dir;

--- a/tests/php/ProbeBodyPurgeTest.php
+++ b/tests/php/ProbeBodyPurgeTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_purge_probe_bodies')]
 final class ProbeBodyPurgeTest extends TestCase
 {
+	private const INSTALL = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
 	private string $dir;
 	private string $origdir;
 	private string $dnsorigdir;
@@ -73,7 +74,7 @@ final class ProbeBodyPurgeTest extends TestCase
 		file_put_contents($probe, 'corrupted probe body bytes');
 		$this->assertFileExists($probe, 'Precondition: probe body must exist before purge');
 
-		pfb_purge_probe_bodies();
+		pfb_install_probe_cleanup();
 
 		$this->assertFileDoesNotExist(
 			$probe,
@@ -94,7 +95,7 @@ final class ProbeBodyPurgeTest extends TestCase
 		file_put_contents($probe, 'corrupted probe body bytes');
 		$this->assertFileExists($probe, 'Precondition: probe body must exist before purge');
 
-		pfb_purge_probe_bodies();
+		pfb_install_probe_cleanup();
 
 		$this->assertFileDoesNotExist(
 			$probe,
@@ -124,7 +125,7 @@ final class ProbeBodyPurgeTest extends TestCase
 			}
 		}
 
-		pfb_purge_probe_bodies();
+		pfb_install_probe_cleanup();
 
 		foreach (array($this->origdir, $this->dnsorigdir) as $dir) {
 			$this->assertFileDoesNotExist(
@@ -158,7 +159,7 @@ final class ProbeBodyPurgeTest extends TestCase
 			return TRUE;
 		});
 		try {
-			pfb_purge_probe_bodies();
+			pfb_install_probe_cleanup();
 		} finally {
 			restore_error_handler();
 		}
@@ -191,7 +192,7 @@ final class ProbeBodyPurgeTest extends TestCase
 			return TRUE;
 		});
 		try {
-			pfb_purge_probe_bodies();
+			pfb_install_probe_cleanup();
 		} finally {
 			restore_error_handler();
 		}
@@ -220,7 +221,7 @@ final class ProbeBodyPurgeTest extends TestCase
 		file_put_contents($probe, 'stale probe body');
 		$this->assertFileExists($probe, 'Precondition: probe body with embedded space must exist before purge');
 
-		pfb_purge_probe_bodies();
+		pfb_install_probe_cleanup();
 
 		$this->assertFileDoesNotExist(
 			$probe,
@@ -248,7 +249,7 @@ final class ProbeBodyPurgeTest extends TestCase
 		$this->assertFileExists($target, 'Precondition: bracket-named probe body must exist before purge');
 		$this->assertFileExists($decoy, 'Precondition: decoy probe body must exist before purge');
 
-		pfb_purge_probe_bodies();
+		pfb_install_probe_cleanup();
 
 		$this->assertFileDoesNotExist(
 			$target,
@@ -260,24 +261,18 @@ final class ProbeBodyPurgeTest extends TestCase
 		);
 	}
 
-	/**
-	 * R6: source-pin (install.inc is not loadable by the unit harness — see
-	 * InstallDnsblMoveRestartGuardTest). Pins the install-time wiring the harness
-	 * cannot execute: a LIVE (uncommented) pfb_purge_probe_bodies() call.
-	 *
-	 *  GIVEN the pfblockerng_install.inc source;
-	 *   THEN a line calls pfb_purge_probe_bodies(); with no comment marker before it.
-	 */
-	public function test_install_inc_calls_purge_probe_bodies(): void
+	public function testInstallCleanupDispatchesToInjectedPurgeOperation(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
-		$src = @file_get_contents($path);
-		$this->assertIsString($src, "could not read {$path}");
+		$called = 0;
+		pfb_install_probe_cleanup(static function () use (&$called): void { $called++; });
+		$this->assertSame(1, $called);
+	}
 
-		$this->assertMatchesRegularExpression(
-			'/^[ \t]*pfb_purge_probe_bodies\(\);/m',
-			$src,
-			'pfblockerng_install.inc must contain a live (uncommented, statement-position) pfb_purge_probe_bodies() call'
-		);
+	/** install.inc is appliance-only; pin its executable cleanup dispatch without including it. */
+	public function testInstallerDispatchesProbeCleanup(): void
+	{
+		$source = php_strip_whitespace(self::INSTALL);
+		$this->assertNotSame('', $source, 'installer source must be readable');
+		$this->assertSame(1, substr_count($source, 'pfb_install_probe_cleanup();'));
 	}
 }

--- a/tests/php/PythonTldWildcardIniEmitTest.php
+++ b/tests/php/PythonTldWildcardIniEmitTest.php
@@ -8,12 +8,18 @@ use PHPUnit\Framework\TestCase;
 final class PythonTldWildcardIniEmitTest extends TestCase
 {
 	private string $tmp;
+	private bool $hadPfb = FALSE;
+	private bool $hadConfig = FALSE;
+	private bool $hadG = FALSE;
 	private array $originalPfb = [];
 	private array $originalConfig = [];
 	private array $originalG = [];
 
 	protected function setUp(): void
 	{
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->hadConfig = array_key_exists('config', $GLOBALS);
+		$this->hadG = array_key_exists('g', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
 		$this->originalConfig = $GLOBALS['config'] ?? [];
 		$this->originalG = $GLOBALS['g'] ?? [];
@@ -32,9 +38,21 @@ final class PythonTldWildcardIniEmitTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		$GLOBALS['pfb'] = $this->originalPfb;
-		$GLOBALS['config'] = $this->originalConfig;
-		$GLOBALS['g'] = $this->originalG;
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+		if ($this->hadG) {
+			$GLOBALS['g'] = $this->originalG;
+		} else {
+			unset($GLOBALS['g']);
+		}
 		rmdir_recursive($this->tmp);
 	}
 

--- a/tests/php/PythonTldWildcardIniEmitTest.php
+++ b/tests/php/PythonTldWildcardIniEmitTest.php
@@ -4,73 +4,82 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1255 — pfb_unbound_python() must emit the `python_tld_wildcard` ini
- * flag, derived from $pfb['dnsbl_tld_wildcard'] via the SAME on/off pattern as the
- * sibling `python_hsts` key (HSTS parity: a shipped static file + an ini
- * boolean enable flag). pfb_unbound_python() needs a live pfSense/VIP/DNS
- * environment to execute end-to-end (no lighter harness exists for ANY of
- * its ini keys — python_hsts/python_idn/python_cname are pinned the same
- * source-inspection way in PythonWhitelistTldSegTest.php; true end-to-end
- * ini + Python behaviour is proven by the live-VM smoke suite), so this pins
- * the wiring at the source level: the derivation reads dnsbl_tld_wildcard and the
- * heredoc emits the key.
- */
+/** The Python INI carries the configured DNSBL TLD-wildcard toggle. */
 final class PythonTldWildcardIniEmitTest extends TestCase
 {
-	private const SRC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+	private string $tmp;
+	private array $originalPfb = [];
+	private array $originalConfig = [];
+	private array $originalG = [];
 
-	/**
-	 * Brace-counts from `function {$name}(` to its matching closing brace, so the
-	 * assertions below inspect ONLY that function's body (mirrors
-	 * PythonWhitelistTldSegTest::functionBody()).
-	 */
-	private function functionBody(string $name): string
+	protected function setUp(): void
 	{
-		$source = file_get_contents(self::SRC);
-		$this->assertNotFalse($source, 'failed to read pfblockerng.inc');
-
-		$needle = "\nfunction {$name}(";
-		$start = strpos($source, $needle);
-		$this->assertNotFalse($start, "function {$name}() not found in source");
-		$start++; // step past the leading \n onto 'function'
-
-		$braceOpen = strpos($source, '{', $start);
-		$this->assertNotFalse($braceOpen, "no opening brace found for {$name}()");
-
-		$depth = 0;
-		for ($i = $braceOpen, $len = strlen($source); $i < $len; $i++) {
-			if ($source[$i] === '{') {
-				$depth++;
-			} elseif ($source[$i] === '}') {
-				$depth--;
-				if ($depth === 0) {
-					$body = substr($source, $start, $i - $start + 1);
-					$this->assertNotSame('', trim($body), "empty body extracted for {$name}() -- vacuous extraction");
-					return $body;
-				}
-			}
-		}
-		$this->fail("no matching closing brace found for {$name}()");
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->originalConfig = $GLOBALS['config'] ?? [];
+		$this->originalG = $GLOBALS['g'] ?? [];
+		$GLOBALS['config'] = [];
+		$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		$this->tmp = sys_get_temp_dir() . '/pfb_tld_ini_' . uniqid('', TRUE);
+		mkdir($this->tmp, 0777, TRUE);
+		$GLOBALS['pfb'] = array_merge($this->originalPfb, [
+			'logdir'          => $this->tmp,
+			'unbound_py_conf' => "{$this->tmp}/pfb_unbound.ini",
+			'unbound_py_wh'   => "{$this->tmp}/pfb_whitelist.txt",
+			'unbound_py_sources' => "{$this->tmp}/pfb_sources.json",
+		]);
+		$this->seedConfig();
 	}
 
-	public function testPythonTldWildcardDerivedFromDnsblTld(): void
+	protected function tearDown(): void
 	{
-		$body = $this->functionBody('pfb_unbound_python');
-		$this->assertMatchesRegularExpression(
-			"/\\\$python_tld_wildcard\s*=\s*'off';.*if\s*\(\s*\\\$pfb\['dnsbl_tld_wildcard'\]/s",
-			$body,
-			'issue #1255: python_tld_wildcard must default off and flip on $pfb[\'dnsbl_tld_wildcard\'] (mirrors python_hsts @ $pfb[\'dnsbl_hsts\'])'
-		);
+		$GLOBALS['pfb'] = $this->originalPfb;
+		$GLOBALS['config'] = $this->originalConfig;
+		$GLOBALS['g'] = $this->originalG;
+		rmdir_recursive($this->tmp);
 	}
 
-	public function testManifestEmitsPythonTldWildcardKey(): void
+	private function seedConfig(): void
 	{
-		$body = $this->functionBody('pfb_unbound_python');
-		$this->assertMatchesRegularExpression(
-			'/python_tld_wildcard\s*=\s*\{\$python_tld_wildcard\}/',
-			$body,
-			'issue #1255: the ini heredoc must carry a python_tld_wildcard key'
-		);
+		$gen = 'installedpackages/pfblockerng/config/0';
+		$ip = 'installedpackages/pfblockerngipsettings/config/0';
+		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		PfbConfig::writeSectionSystem($gen, ['pfb_min' => '0', 'pfb_hour' => '0', 'pfb_dailystart' => '0', 'skipfeed' => '0']);
+		PfbConfig::writeSectionSystem($ip, [
+			'suppression' => '', 'database_cc' => '', 'asn_token' => '', 'maxmind_account' => '',
+			'maxmind_key' => '', 'maxmind_locale' => 'en', 'asn_reporting' => 'disabled',
+		]);
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+		PfbConfig::writeSectionSystem($dnsbl, [
+			'pfb_dnsvip4' => '', 'pfb_dnsvip6' => '', 'pfb_dnsport' => '8081', 'pfb_dnsport_ssl' => '8443',
+			'top1m_enable' => '', 'pfb_cache' => '', 'pfb_py_reply' => '', 'pfb_regex' => '', 'pfb_regex_list' => '',
+			'pfb_cname' => '', 'tld_allow' => '', 'pfb_py_nolog' => '', 'pfb_noaaaa' => '', 'pfb_noaaaa_list' => '',
+			'pfb_gp' => '', 'pfb_gp_bypass_list' => '', 'whitelist' => '', 'tld_wildcard' => '',
+			'pfb_dnsbl' => '', 'pfb_dnsvip_auto' => '', 'dnsbl_interface' => 'lo0',
+		]);
+		$GLOBALS['pfb']['dnsbl_tld_wildcard'] = '';
+		$GLOBALS['pfb']['dnsbl_control'] = PfbToggle::Off;
+		$GLOBALS['pfb']['dnsbl_control_legacy'] = PfbToggle::Off;
+	}
+
+	private function emit(string $toggle): string
+	{
+		PfbConfig::writeSystem('dnsbl/tld_wildcard', $toggle);
+		$GLOBALS['pfb']['dnsbl_tld_wildcard'] = $toggle;
+		pfb_unbound_python('enabled');
+		$ini = file_get_contents($GLOBALS['pfb']['unbound_py_conf']);
+		$this->assertNotFalse($ini, 'writer must create the Python INI');
+		return $ini;
+	}
+
+	public function testOffToggleEmitsOffKey(): void
+	{
+		$ini = $this->emit('');
+		$this->assertMatchesRegularExpression('/^python_tld_wildcard\s*=\s*off$/m', $ini);
+	}
+
+	public function testOnToggleEmitsOnKey(): void
+	{
+		$ini = $this->emit('on');
+		$this->assertMatchesRegularExpression('/^python_tld_wildcard\s*=\s*on$/m', $ini);
 	}
 }

--- a/tests/php/PythonWhitelistTldSegTest.php
+++ b/tests/php/PythonWhitelistTldSegTest.php
@@ -11,12 +11,18 @@ use PHPUnit\Framework\TestCase;
 final class PythonWhitelistTldSegTest extends TestCase
 {
 	private string $tmp;
+	private bool $hadPfb = FALSE;
+	private bool $hadConfig = FALSE;
+	private bool $hadG = FALSE;
 	private array $originalPfb = [];
 	private array $originalConfig = [];
 	private array $originalG = [];
 
 	protected function setUp(): void
 	{
+		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->hadConfig = array_key_exists('config', $GLOBALS);
+		$this->hadG = array_key_exists('g', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
 		$this->originalConfig = $GLOBALS['config'] ?? [];
 		$this->originalG = $GLOBALS['g'] ?? [];
@@ -35,9 +41,21 @@ final class PythonWhitelistTldSegTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		$GLOBALS['pfb'] = $this->originalPfb;
-		$GLOBALS['config'] = $this->originalConfig;
-		$GLOBALS['g'] = $this->originalG;
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+		if ($this->hadG) {
+			$GLOBALS['g'] = $this->originalG;
+		} else {
+			unset($GLOBALS['g']);
+		}
 		rmdir_recursive($this->tmp);
 	}
 

--- a/tests/php/PythonWhitelistTldSegTest.php
+++ b/tests/php/PythonWhitelistTldSegTest.php
@@ -5,103 +5,83 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1155 — pfb_unbound_python_whitelist() computed a min-TLD-segment
- * count into a function-LOCAL $tld_segments, then discarded it (only the CSV
- * whitelist string is returned/written). pfb_unbound_python() separately ran
- * `if (!isset($tld_segments)) { $tld_segments = '1'; }` on its OWN
- * never-assigned local, so the manifest's python_tld_seg key ALWAYS emitted
- * 1 regardless of the discarded computation. The Python consumer
- * (whitelist_lookup_domain) gates a parent-suffix walk on this value and
- * only wildcard suppression entries can match that walk, so a fixed literal
- * 1 is behaviourally identical to the dead computation it replaces — this
- * pins that both dead-code sites are gone, the manifest emits literal 1,
- * and pfb_unbound_python_whitelist()'s own CSV output stays byte-identical
- * (Oracle A) across the deletion.
- */
+/** Whitelist output and the Python TLD-segment bridge are runtime behaviour. */
 #[CoversFunction('pfb_unbound_python_whitelist')]
 #[CoversFunction('pfb_unbound_python')]
 final class PythonWhitelistTldSegTest extends TestCase
 {
-	private const SRC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+	private string $tmp;
+	private array $originalPfb = [];
+	private array $originalConfig = [];
+	private array $originalG = [];
 
 	protected function setUp(): void
 	{
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->originalConfig = $GLOBALS['config'] ?? [];
+		$this->originalG = $GLOBALS['g'] ?? [];
 		$GLOBALS['config'] = [];
+		$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		$this->tmp = sys_get_temp_dir() . '/pfb_whitelist_ini_' . uniqid('', TRUE);
+		mkdir($this->tmp, 0777, TRUE);
+		$GLOBALS['pfb'] = array_merge($this->originalPfb, [
+			'logdir'          => $this->tmp,
+			'unbound_py_conf' => "{$this->tmp}/pfb_unbound.ini",
+			'unbound_py_wh'   => "{$this->tmp}/pfb_whitelist.txt",
+			'unbound_py_sources' => "{$this->tmp}/pfb_sources.json",
+		]);
 		$this->seedGlobalPrereqs();
 	}
 
-	/**
-	 * Seed the minimum config keys pfb_global() reads (mirrors
-	 * DnsblVipDisableNoticeTest::seedGlobalPrereqs() / TickEntrypointTest::
-	 * seedTickPrereqs() — the established minimum pfb_global() needs to run
-	 * warning-free off-box), since pfb_unbound_python_whitelist() calls
-	 * pfb_global() internally.
-	 */
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb'] = $this->originalPfb;
+		$GLOBALS['config'] = $this->originalConfig;
+		$GLOBALS['g'] = $this->originalG;
+		rmdir_recursive($this->tmp);
+	}
+
 	private function seedGlobalPrereqs(): void
 	{
 		$gen   = 'installedpackages/pfblockerng/config/0';
 		$ip    = 'installedpackages/pfblockerngipsettings/config/0';
 		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
 
-		config_set_path("{$gen}/pfb_min",        '0');
-		config_set_path("{$gen}/pfb_hour",       '0');
-		config_set_path("{$gen}/pfb_dailystart", '0');
-		config_set_path("{$gen}/skipfeed",       '0');
-
-		config_set_path("{$ip}/suppression",     '');
-		config_set_path("{$ip}/database_cc",     '');
-		config_set_path("{$ip}/maxmind_locale",  'en');
-		config_set_path("{$ip}/asn_reporting",   'disabled');
-		config_set_path("{$ip}/asn_token",       '');
-		config_set_path("{$ip}/maxmind_account", '');
-		config_set_path("{$ip}/maxmind_key",     '');
+		PfbConfig::writeSectionSystem($gen, ['pfb_min' => '0', 'pfb_hour' => '0', 'pfb_dailystart' => '0', 'skipfeed' => '0']);
+		PfbConfig::writeSectionSystem($ip, [
+			'suppression' => '', 'database_cc' => '', 'maxmind_locale' => 'en', 'asn_reporting' => 'disabled',
+			'asn_token' => '', 'maxmind_account' => '', 'maxmind_key' => '',
+		]);
 
 		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
 
-		config_set_path("{$dnsbl}/pfb_dnsvip4",     '');
-		config_set_path("{$dnsbl}/pfb_dnsvip6",     '');
-		config_set_path("{$dnsbl}/pfb_dnsport",     '8081');
-		config_set_path("{$dnsbl}/pfb_dnsport_ssl", '8443');
-		config_set_path("{$dnsbl}/top1m_enable",    '');
-		config_set_path("{$dnsbl}/pfb_cache",       '');
-		config_set_path("{$dnsbl}/pfb_py_reply",    '');
-		config_set_path("{$dnsbl}/pfb_regex",       '');
-		config_set_path("{$dnsbl}/pfb_regex_list",  '');
-		config_set_path("{$dnsbl}/pfb_cname",       '');
-		config_set_path("{$dnsbl}/tld_allow",       '');
-		config_set_path("{$dnsbl}/pfb_py_nolog",    '');
-		config_set_path("{$dnsbl}/pfb_noaaaa",      '');
-		config_set_path("{$dnsbl}/pfb_noaaaa_list", '');
-		config_set_path("{$dnsbl}/pfb_gp",          '');
-		config_set_path("{$dnsbl}/pfb_gp_bypass_list", '');
-
-		if (!isset($GLOBALS['g']['unbound_chroot_path'])) {
-			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
-		}
-
-		PfbConfig::write('dnsbl/pfb_dnsbl', 'on');
-		PfbConfig::write('dnsbl/pfb_dnsvip_auto', '');
-		PfbConfig::write('dnsbl/dnsbl_interface', 'lo0');
+		PfbConfig::writeSectionSystem($dnsbl, [
+			'pfb_dnsvip4' => '', 'pfb_dnsvip6' => '', 'pfb_dnsport' => '8081', 'pfb_dnsport_ssl' => '8443',
+			'top1m_enable' => '', 'pfb_cache' => '', 'pfb_py_reply' => '', 'pfb_regex' => '', 'pfb_regex_list' => '',
+			'pfb_cname' => '', 'tld_allow' => '', 'pfb_py_nolog' => '', 'pfb_noaaaa' => '', 'pfb_noaaaa_list' => '',
+			'pfb_gp' => '', 'pfb_gp_bypass_list' => '', 'tld_wildcard' => '', 'pfb_dnsbl' => '',
+			'pfb_dnsvip_auto' => '', 'dnsbl_interface' => 'lo0',
+		]);
+		$GLOBALS['pfb']['dnsbl_tld_wildcard'] = '';
+		$GLOBALS['pfb']['dnsbl_control'] = PfbToggle::Off;
+		$GLOBALS['pfb']['dnsbl_control_legacy'] = PfbToggle::Off;
 	}
 
 	private function setWhitelist(string $decoded): void
 	{
-		config_set_path(
-			'installedpackages/pfblockerngdnsblsettings/config/0/whitelist',
-			base64_encode($decoded)
-		);
+		PfbConfig::writeSystem('dnsbl/whitelist', base64_encode($decoded));
 	}
 
-	// --- A: ORACLE — pfb_unbound_python_whitelist() output, pinned across the change ---
+	private function emitIni(): string
+	{
+		pfb_unbound_python('enabled');
+		$ini = file_get_contents($GLOBALS['pfb']['unbound_py_conf']);
+		$this->assertNotFalse($ini, 'writer must create the Python INI');
+		return $ini;
+	}
 
-	/**
-	 * Scenario: a mixed suppression list — bare domain, leading-dot wildcard,
-	 * www.-prefixed, and a blank line.
-	 * Then: the CSV output strips www., marks the wildcard ',1', everything
-	 *       else ',0', and drops the blank line — unaffected by removing the
-	 *       discarded min-segment computation.
-	 */
+	// --- Whitelist behaviour, including hostile legacy configuration. ---
+
 	public function testMixedSuppressionListProducesExpectedCsv(): void
 	{
 		$this->setWhitelist("example.com\r\n.wild.org\r\nwww.stripme.net\r\n\r\n");
@@ -130,61 +110,20 @@ final class PythonWhitelistTldSegTest extends TestCase
 		$this->assertSame('', pfb_unbound_python_whitelist());
 	}
 
-	// --- B: SOURCE-SHAPE — the dead computation is GONE, manifest emits literal 1 ---
-
-	/**
-	 * Brace-counts from `function {$name}(` to its matching closing brace,
-	 * so the assertions below inspect ONLY that function's body — never a
-	 * neighbour (issue #1168 removed the retired TLD-analysis pass's write-only
-	 * $tld_segments computation).
-	 */
-	private function functionBody(string $name): string
+	public function testHostileLegacyTldSegmentsConfigDoesNotChangeWhitelist(): void
 	{
-		$source = file_get_contents(self::SRC);
-		$this->assertNotFalse($source, 'failed to read pfblockerng.inc');
+		$this->setWhitelist("example.com\n.wild.org\n");
+		config_set_path(
+			'installedpackages/pfblockerngdnsblsettings/config/0/tld_segments',
+			base64_encode("\xff\nlegacy.invalid")
+		);
 
-		$needle = "\nfunction {$name}(";
-		$start = strpos($source, $needle);
-		$this->assertNotFalse($start, "function {$name}() not found in source");
-		$start++; // step past the leading \n onto 'function'
-
-		$braceOpen = strpos($source, '{', $start);
-		$this->assertNotFalse($braceOpen, "no opening brace found for {$name}()");
-
-		$depth = 0;
-		for ($i = $braceOpen, $len = strlen($source); $i < $len; $i++) {
-			if ($source[$i] === '{') {
-				$depth++;
-			} elseif ($source[$i] === '}') {
-				$depth--;
-				if ($depth === 0) {
-					$body = substr($source, $start, $i - $start + 1);
-					$this->assertNotSame('', trim($body), "empty body extracted for {$name}() -- vacuous extraction");
-					return $body;
-				}
-			}
-		}
-		$this->fail("no matching closing brace found for {$name}()");
+		$this->assertSame("example.com,0\nwild.org,1\n", pfb_unbound_python_whitelist());
 	}
 
-	public function testWhitelistFunctionHasNoTldSegmentsToken(): void
+	public function testWriterEmitsFixedPythonTldSegment(): void
 	{
-		$body = $this->functionBody('pfb_unbound_python_whitelist');
-		$this->assertStringNotContainsString('tld_segments', $body,
-			'issue #1155: the min-segment computation must be deleted, not just unused');
-	}
-
-	public function testPythonFunctionHasNoIssetTldSegmentsGuard(): void
-	{
-		$body = $this->functionBody('pfb_unbound_python');
-		$this->assertDoesNotMatchRegularExpression('/isset\(\s*\$tld_segments\s*\)/', $body,
-			'issue #1155: the never-assigned isset($tld_segments) guard must be deleted');
-	}
-
-	public function testManifestEmitsLiteralPythonTldSegOne(): void
-	{
-		$body = $this->functionBody('pfb_unbound_python');
-		$this->assertMatchesRegularExpression('/python_tld_seg\s*=\s*1\b/', $body,
-			'issue #1155: python_tld_seg must emit the literal 1, not a variable');
+		$ini = $this->emitIni();
+		$this->assertMatchesRegularExpression('/^python_tld_seg\s*=\s*1$/m', $ini);
 	}
 }

--- a/tests/php/RegexIniTransportTest.php
+++ b/tests/php/RegexIniTransportTest.php
@@ -4,56 +4,95 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/** Issue #1718: regex textarea stays opaque base64 through the PHP INI writer. */
+/** The configured regex textarea remains an opaque stored blob in MAIN. */
 final class RegexIniTransportTest extends TestCase
 {
-	private const SRC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+	private string $tmp;
+	private array $originalPfb = [];
+	private array $originalConfig = [];
+	private array $originalG = [];
 
-	private function functionBody(string $name): string
+	protected function setUp(): void
 	{
-		$source = file_get_contents(self::SRC);
-		$this->assertNotFalse($source, 'failed to read pfblockerng.inc');
-		$start = strpos($source, "\nfunction {$name}(");
-		$this->assertNotFalse($start, "function {$name}() not found");
-		$start++;
-		$open = strpos($source, '{', $start);
-		$this->assertNotFalse($open, "opening brace missing for {$name}()");
-		$depth = 0;
-		for ($i = $open, $len = strlen($source); $i < $len; $i++) {
-			if ($source[$i] === '{') {
-				$depth++;
-			} elseif ($source[$i] === '}') {
-				$depth--;
-				if ($depth === 0) {
-					return substr($source, $start, $i - $start + 1);
-				}
-			}
-		}
-		$this->fail("closing brace missing for {$name}()");
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->originalConfig = $GLOBALS['config'] ?? [];
+		$this->originalG = $GLOBALS['g'] ?? [];
+		$GLOBALS['config'] = [];
+		$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		$this->tmp = sys_get_temp_dir() . '/pfb_regex_ini_' . uniqid('', TRUE);
+		mkdir($this->tmp, 0777, TRUE);
+		$GLOBALS['pfb'] = array_merge($this->originalPfb, [
+			'logdir'          => $this->tmp,
+			'unbound_py_conf' => "{$this->tmp}/pfb_unbound.ini",
+			'unbound_py_wh'   => "{$this->tmp}/pfb_whitelist.txt",
+			'unbound_py_sources' => "{$this->tmp}/pfb_sources.json",
+		]);
+		$this->seedConfig();
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb'] = $this->originalPfb;
+		$GLOBALS['config'] = $this->originalConfig;
+		$GLOBALS['g'] = $this->originalG;
+		rmdir_recursive($this->tmp);
+	}
+
+	private function seedConfig(): void
+	{
+		$gen = 'installedpackages/pfblockerng/config/0';
+		$ip = 'installedpackages/pfblockerngipsettings/config/0';
+		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		PfbConfig::writeSectionSystem($gen, ['pfb_min' => '0', 'pfb_hour' => '0', 'pfb_dailystart' => '0', 'skipfeed' => '0']);
+		PfbConfig::writeSectionSystem($ip, [
+			'suppression' => '', 'database_cc' => '', 'asn_token' => '', 'maxmind_account' => '',
+			'maxmind_key' => '', 'maxmind_locale' => 'en', 'asn_reporting' => 'disabled',
+		]);
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+		PfbConfig::writeSectionSystem($dnsbl, [
+			'pfb_dnsvip4' => '', 'pfb_dnsvip6' => '', 'pfb_dnsport' => '8081', 'pfb_dnsport_ssl' => '8443',
+			'top1m_enable' => '', 'pfb_cache' => '', 'pfb_py_reply' => '', 'pfb_regex' => '', 'pfb_regex_list' => '',
+			'pfb_cname' => '', 'tld_allow' => '', 'pfb_py_nolog' => '', 'pfb_noaaaa' => '', 'pfb_noaaaa_list' => '',
+			'pfb_gp' => '', 'pfb_gp_bypass_list' => '', 'whitelist' => '', 'tld_wildcard' => '',
+			'pfb_dnsbl' => '', 'pfb_dnsvip_auto' => '', 'dnsbl_interface' => 'lo0',
+		]);
+		$GLOBALS['pfb']['dnsbl_tld_wildcard'] = '';
+		$GLOBALS['pfb']['dnsbl_control'] = PfbToggle::Off;
+		$GLOBALS['pfb']['dnsbl_control_legacy'] = PfbToggle::Off;
+	}
+
+	private function emit(string $regexToggle, string $storedBlob): string
+	{
+		PfbConfig::writeSystem('dnsbl/pfb_regex', $regexToggle);
+		PfbConfig::writeSystem('dnsbl/pfb_regex_list', $storedBlob);
+		pfb_unbound_python('enabled');
+		$ini = file_get_contents($GLOBALS['pfb']['unbound_py_conf']);
+		$this->assertNotFalse($ini, 'writer must create the Python INI');
+		return $ini;
 	}
 
 	public function testWriterEmitsStoredRegexBlobUnderMainWithoutDecode(): void
 	{
-		$body = $this->functionBody('pfb_unbound_python');
-		$this->assertMatchesRegularExpression(
-			'/regex_list\s*=\s*\{\$pfb\[\'dnsbl_regex_list\'\]\}/',
-			$body,
-			'PHP must emit the stored base64 blob as MAIN.regex_list'
-		);
-		$this->assertDoesNotMatchRegularExpression(
-			'/pfb_text_area_decode\(\$pfb\[\'dnsbl_regex_list\'\]/',
-			$body,
-			'PHP must not decode or re-encode the regex blob'
-		);
+		$decoded = "(?i)evil\xff\n[unterminated";
+		$stored = base64_encode($decoded);
+		$ini = $this->emit('on', $stored);
+
+		$this->assertStringContainsString('[MAIN]', $ini);
+		$this->assertStringContainsString("regex_list = {$stored}", $ini);
+		$this->assertStringNotContainsString($decoded, $ini);
+		$this->assertStringNotContainsString('[REGEX]', $ini);
 	}
 
-	public function testWriterDoesNotGenerateLegacyRegexSection(): void
+	public function testWriterOmitsStoredBlobWhenRegexToggleIsOff(): void
 	{
-		$body = $this->functionBody('pfb_unbound_python');
-		$this->assertDoesNotMatchRegularExpression(
-			'/\[REGEX\]/',
-			$body,
-			'new writer must not emit plaintext legacy REGEX entries'
-		);
+		$stored = base64_encode('legacy.regex');
+		$ini = $this->emit('', $stored);
+		$this->assertStringNotContainsString("regex_list = {$stored}", $ini);
+	}
+
+	public function testWriterOmitsEmptyRegexBlobWhenToggleIsOn(): void
+	{
+		$ini = $this->emit('on', '');
+		$this->assertStringNotContainsString('regex_list =', $ini);
 	}
 }

--- a/tests/php/SourceScanningWiringPolicyTest.php
+++ b/tests/php/SourceScanningWiringPolicyTest.php
@@ -194,7 +194,7 @@ final class SourceScanningWiringPolicyTest extends TestCase
 		}
 	}
 
-	public function testRewordingANearbyProductionCommentDoesNotChangePinnedCode(): void
+	public function testRewordingANearbyProductionCommentDoesNotChangeRetainedPinScope(): void
 	{
 		$sourcePath = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
 		$source = file_get_contents($sourcePath);
@@ -211,7 +211,15 @@ final class SourceScanningWiringPolicyTest extends TestCase
 		$this->assertIsString($temp);
 		try {
 			$this->assertNotFalse(file_put_contents($temp, $rewritten));
-			$this->assertSame(php_strip_whitespace($sourcePath), php_strip_whitespace($temp));
+			$originalCode = php_strip_whitespace($sourcePath);
+			$rewrittenCode = php_strip_whitespace($temp);
+			$start = 'pfb_list_script_cleanup_staged(';
+			$end = 'if (!empty($domain_data)) {';
+			$this->assertSame(
+				$this->sourceScope($originalCode, $start, $end),
+				$this->sourceScope($rewrittenCode, $start, $end),
+				'retained DNSBL staged-script pin must ignore nearby comment wording'
+			);
 		} finally {
 			@unlink($temp);
 		}
@@ -277,6 +285,15 @@ final class SourceScanningWiringPolicyTest extends TestCase
 			}
 			$this->assertNotFalse(file_put_contents($destination, $content));
 		}
+	}
+
+	private function sourceScope(string $source, string $start, string $end): string
+	{
+		$from = strrpos($source, $start);
+		$this->assertNotFalse($from, "missing retained-pin start: {$start}");
+		$to = strpos($source, $end, $from + strlen($start));
+		$this->assertNotFalse($to, "missing retained-pin end: {$end}");
+		return substr($source, $from, $to + strlen($end) - $from);
 	}
 
 	private function rewordPhpComments(string $source): string

--- a/tests/php/SourceScanningWiringPolicyTest.php
+++ b/tests/php/SourceScanningWiringPolicyTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2103 audit ledger and regression policy.
+ *
+ * PRODUCTION COMMENTS AND DOCBLOCKS MUST NEVER BE LOAD-BEARING FOR A TEST.
+ * Behavioral suites do not inspect production source. The few hybrid/static suites below
+ * retain only comment-free executable-code pins because their outer property is destructive,
+ * appliance-only, off-limits in this issue, or inherently a whole-tree static invariant.
+ */
+final class SourceScanningWiringPolicyTest extends TestCase
+{
+	private const SOURCE_EXECUTION = [
+		'AlertDetailsCsvFieldTest.php',
+		'AlertsAsnCsvTest.php',
+		'AlertsCustomlistIdnRecognitionTest.php',
+		'AlertsDnsblFeedGroupCellGroupingTest.php',
+		'AlertsDnsblLoggedFieldsRenderTest.php',
+		'AlertsDnsblLimitGateTest.php',
+		'AlertsDnsReplyWhitelistTypeTest.php',
+		'AlertsFeedMatchCellGroupingTest.php',
+		'AlertsFilterFieldsInitTest.php',
+		'AlertsFreshTopBlockTest.php',
+		'AlertsIpConvertPrefetchParityTest.php',
+		'AlertsIpUnlockIconTest.php',
+		'AlertsMultibyteTruncationTest.php',
+		'AlertsPieBlockAndStatsGuardTest.php',
+		'AlertsRowOutputEncodingTest.php',
+		'AlertsStatHostnameCellTest.php',
+		'BlacklistLangFallbackTest.php',
+		'CategoryEditAutoSortTest.php',
+		'CategoryEditCustomFlagTest.php',
+		'CategoryEditFreshRowPconfigTest.php',
+		'CategoryEditIdnWildcardTest.php',
+		'CategoryEditPostGuardTest.php',
+		'CategoryEditReservedHeaderTest.php',
+		'CategoryFeedsAliasTruncationRenderTest.php',
+		'CategoryPostdataInvalidPrefixGuardTest.php',
+		'DnsblCustomListWildcardValidationTest.php',
+		'DnsblFeedIdnWildcardTest.php',
+		'DnsblFreshPconfigTest.php',
+		'DnsblWildcardRowValidationTest.php',
+		'FeedsAltSelectedKeyTest.php',
+		'FeedsCustomOutputEncodingTest.php',
+		'FeedsUrlCompareAltHeaderUndefinedKeyTest.php',
+		'FeedsUrlCompareIconRenderTest.php',
+		'FilterlogFieldGuardTest.php',
+		'FreshConfigNullGuardCloseoutTest.php',
+		'GeoipContinentUndefinedBucketTest.php',
+		'HooksSanitizeIngestionTest.php',
+		'InstallGeneralToIpMigrationTest.php',
+		'InstallGrandfatherChokepointTest.php',
+		'IpArrayFieldIngressGuardTest.php',
+		'IpSettingsAdvAliasValidationTest.php',
+		'Issue1792SinkholeLabelTest.php',
+		'Issue1792SweepSitesTest.php',
+		'LogSelectedTypeTest.php',
+		'LogValidateFilepathTest.php',
+		'PfbWidgetOracleTest.php',
+		'Top1mDccBaselineIntegrityTest.php',
+		'Top1mDccDetectorTest.php',
+		'WidgetAliasHiddenTest.php',
+		'WidgetIncludeConventionTest.php',
+		'WidgetSortTableTest.php',
+		'WhitelistTrashIconTest.php',
+		'WizardDisableCsrfTest.php',
+	];
+
+	private const EXCLUDED_NON_WIRING = [
+		'DnsblRegexEntryErrorTest.php' => 'executes the shipped Python helper',
+		'FeedsDiscontinuedTest.php' => 'parses the shipped JSON feed catalogue',
+		'HookEditorDeleteTest.php' => 'requires and calls the page-only include',
+		'PrivPageMatchesTest.php' => 'requires shipped privilege data',
+		'RequireConfigGatewaySniffTest.php' => 'whole-tree PHPCS analyzer contract',
+		'SourceScanningWiringPolicyTest.php' => 'comment-mutation audit harness, not a wiring assertion',
+		'SrcPhpDeprecationLintTest.php' => 'whole-tree PHP lint contract',
+		'TickEntrypointTest.php' => 'calls the bootstrap-loaded entrypoint',
+	];
+
+	private const BEHAVIORAL = [
+		'AnchorRowRelocationWiringTest.php',
+		'CategoryEditCustomEditorSortModePlacementTest.php',
+		'CategoryEditCustomEditorWiringTest.php',
+		'ClearSqliteTimestampFormatTest.php',
+		'CountryNetworksCountGuardTest.php',
+		'DnsblListEditorWiringTest.php',
+		'DnsblListScriptWiringTest.php',
+		'DnsblQueryClientTest.php',
+		'DnsblRegexHighlightWiringTest.php',
+		'DnsblRegexToggleGateWiringTest.php',
+		'EditHooksPageWiringTest.php',
+		'EditHooksSyntaxHighlightWiringTest.php',
+		'GeneralAllowlistEditorWiringTest.php',
+		'GeoipContinentCatStderrGuardTest.php',
+		'GeoipDocLinkTest.php',
+		'IpRegexBoundaryGuardTest.php',
+		'IpRegexPrefilterGuardTest.php',
+		'IpSuppressionEditorWiringTest.php',
+		'LintEndpointWiringTest.php',
+		'ListScriptReparseWiringTest.php',
+		'LogTimestampBaselineTest.php',
+		'PfbJsCacheBustingWiringTest.php',
+		'PythonTldWildcardIniEmitTest.php',
+		'PythonWhitelistTldSegTest.php',
+		'RegexIniTransportTest.php',
+		'TldBridgeEmitTest.php',
+		'Top1mApplyRefreshMatrixTest.php',
+		'UpdateAjaxTailJsonEncodingTest.php',
+		'WidgetGetTableArgOrderTest.php',
+		'WidgetPostAllowedTest.php',
+		'WidgetSubmitPostGuardTest.php',
+	];
+
+	private const RETAINED = [
+		'AlertsPfctlCheckedSitesTest.php' => 'off-limits live Alerts pfctl/render dispatch',
+		'AlertsStatPipelineLocaleSafetyTest.php' => 'off-limits live Alerts command pipeline',
+		'AlertsUnboundCachePolicyTest.php' => 'off-limits live Alerts/Unbound cache dispatch',
+		'AliasCntGrepCountGuardTest.php' => '#993 live sync/download/firewall orchestration',
+		'DnsblCustomRowStateEnabledInvariantTest.php' => '#993 live sync row synthesis dispatch',
+		'DnsblFeedCountWiringTest.php' => 'live DNSBL and Unbound service restart dispatch',
+		'DnsblIpCountGuardTest.php' => '#993 live sync/download/firewall orchestration',
+		'DnsblPlaintextSummaryRetirementTest.php' => 'inherently cross-file retired-code invariant',
+		'DnsblRegexHelpTextTest.php' => 'page render call lacks a help-text smoke assertion',
+		'DownloadExtractionExitCodeTest.php' => 'six live archive extraction bodies',
+		'DownloadRetvalFailsafeTest.php' => 'live download fail-safe initialization and final gate',
+		'DownloadTrailingNewlineWiringTest.php' => 'live download finalization dispatch',
+		'EscapedPathFilesystemCallTest.php' => 'inherently whole-tree filesystem safety rule',
+		'GeoipOrigTrailingNewlineWiringTest.php' => '#993 live download/apply orchestration',
+		'GeoipPackageGenerationCoverageTest.php' => 'destructive package install dispatch',
+		'GeneralSyntaxHighlightToggleWiringTest.php' => 'config-backed page save dispatch',
+		'GroupActionWiringTest.php' => 'appliance config-backed page dispatch',
+		'GunzipTrailingNewlineWiringTest.php' => '#993 live download/apply orchestration',
+		'HookEditFileContainmentTest.php' => 'destructive page file operations and include boundary',
+		'InstallDnsblMoveRestartGuardTest.php' => 'destructive installer and live service restart',
+		'InstallPrePassWriteOrderTest.php' => 'destructive package installer lifecycle',
+		'IpParseLineWiringTest.php' => '#993 live sync/download/firewall orchestration',
+		'IpRecomputeOrderChangeTest.php' => '#993 live config-order recompute dispatch',
+		'IpRecomputeRanWiringTest.php' => '#993 live firewall and closing dispatch',
+		'ListScriptTransformRerunWiringTest.php' => '#993 two live sync feed loops',
+		'ListScriptExitStatusTest.php' => '#993 six live list-script loop dispatches',
+		'ListScriptFailureLedgerWiringTest.php' => '#993 four live failure-ledger loop dispatches',
+		'LogFormatConsumersTest.php' => 'live external-command and top-level page consumers',
+		'LogLinecountGuardTest.php' => 'top-level authenticated AJAX dispatch',
+		'LogNowTokenRetiredTest.php' => 'inherently whole-tree retired-code invariant',
+		'PfbFeedNormalizeTest.php' => '#993 two live sync parse loops',
+		'PfbSettingsFamilyPostInstallCaptureTest.php' => 'destructive package installer lifecycle',
+		'PfbSettingsFamilyTest.php' => 'destructive package uninstall lifecycle',
+		'PfbSyncStatusDnsblWritersTest.php' => '#993 live sync plus off-limits Alerts dispatch',
+		'PfbSyncStatusIpWritersTest.php' => '#993 live sync/download/firewall orchestration',
+		'ProbeBodyPurgeTest.php' => 'destructive package installer caller',
+		'SyncCronPflexOrderTest.php' => 'off-limits live scheduling surface',
+		'TickChildDeferralOrderingTest.php' => 'off-limits background scheduling race',
+		'TimestampCosmeticNormalizationTest.php' => 'multiple live top-level/external producers',
+		'ToggleMirrorComparisonGuardTest.php' => 'inherently whole-tree config-type rule',
+		'ToggleEmptyPreservationTest.php' => 'six config-backed page save bindings',
+		'Top1mTeardownWiringTest.php' => 'destructive uninstall and live sync teardown callers',
+	];
+
+	public function testAuditListsEveryConvertedSuiteExactlyOnce(): void
+	{
+		$audited = array_merge(
+			self::BEHAVIORAL,
+			self::SOURCE_EXECUTION,
+			array_keys(self::RETAINED),
+			array_keys(self::EXCLUDED_NON_WIRING)
+		);
+		$this->assertCount(134, $audited);
+		$this->assertCount(134, array_unique($audited));
+		foreach ($audited as $file) {
+			$this->assertFileExists(__DIR__ . "/{$file}");
+		}
+	}
+
+	public function testBehavioralSuitesDoNotStripAndSearchProductionSource(): void
+	{
+		foreach (self::BEHAVIORAL as $file) {
+			$source = file_get_contents(__DIR__ . "/{$file}");
+			$this->assertIsString($source);
+			$this->assertStringNotContainsString('php_strip_whitespace', $source, $file);
+		}
+	}
+
+	public function testEveryRetainedPinHasAnExplicitReasonAndIgnoresComments(): void
+	{
+		foreach (self::RETAINED as $file => $reason) {
+			$this->assertNotSame('', trim($reason), $file);
+			$source = file_get_contents(__DIR__ . "/{$file}");
+			$this->assertIsString($source);
+			$this->assertStringContainsString('php_strip_whitespace', $source, $file);
+		}
+	}
+
+	public function testRewordingANearbyProductionCommentDoesNotChangePinnedCode(): void
+	{
+		$sourcePath = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+		$source = file_get_contents($sourcePath);
+		$this->assertIsString($source);
+		$rewritten = str_replace(
+			'// issue #1925: normalize once per file; the parse below reads .norm',
+			'// nearby production explanation rewritten without preserving its old words',
+			$source,
+			$count
+		);
+		$this->assertSame(1, $count, 'comment-rewording fixture drifted');
+
+		$temp = tempnam(sys_get_temp_dir(), 'pfb-comment-reword-');
+		$this->assertIsString($temp);
+		try {
+			$this->assertNotFalse(file_put_contents($temp, $rewritten));
+			$this->assertSame(php_strip_whitespace($sourcePath), php_strip_whitespace($temp));
+		} finally {
+			@unlink($temp);
+		}
+	}
+
+	public function testRewordingEveryProductionPhpCommentDoesNotBreakSourceExecutionTests(): void
+	{
+		$root = dirname(__DIR__, 2);
+		$temp = sys_get_temp_dir() . '/pfb-comment-reword-' . bin2hex(random_bytes(8));
+		$this->copyTree("{$root}/src", "{$temp}/src", TRUE);
+		$this->copyTree("{$root}/tests/php", "{$temp}/tests/php");
+
+		$tests = [];
+		foreach (self::SOURCE_EXECUTION as $file) {
+			$target = "{$temp}/tests/php/{$file}";
+			$tests[] = $target;
+		}
+
+		$command = array_merge([
+			PHP_BINARY,
+			"{$root}/vendor/bin/phpunit",
+			'--configuration',
+			"{$root}/phpunit.xml",
+			'--do-not-cache-result',
+		], $tests);
+		$descriptors = [
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
+
+		try {
+			$process = proc_open($command, $descriptors, $pipes, $root);
+			$this->assertIsResource($process);
+			$stdout = stream_get_contents($pipes[1]);
+			$stderr = stream_get_contents($pipes[2]);
+			fclose($pipes[1]);
+			fclose($pipes[2]);
+			$status = proc_close($process);
+			$this->assertSame(0, $status, "{$stdout}\n{$stderr}");
+		} finally {
+			$this->removeTree($temp);
+		}
+	}
+
+	private function copyTree(string $source, string $target, bool $rewordComments = FALSE): void
+	{
+		$this->assertTrue(mkdir($target, 0700, TRUE));
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($source, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::SELF_FIRST
+		);
+		foreach ($iterator as $item) {
+			$relative = $iterator->getSubPathName();
+			$destination = "{$target}/{$relative}";
+			if ($item->isDir()) {
+				$this->assertTrue(mkdir($destination, 0700));
+				continue;
+			}
+			$content = file_get_contents($item->getPathname());
+			$this->assertIsString($content);
+			if ($rewordComments && preg_match('/\.(?:inc|php)$/', $item->getFilename()) === 1) {
+				$content = $this->rewordPhpComments($content);
+			}
+			$this->assertNotFalse(file_put_contents($destination, $content));
+		}
+	}
+
+	private function rewordPhpComments(string $source): string
+	{
+		$rewritten = '';
+		foreach (token_get_all($source) as $token) {
+			if (is_array($token) && $token[0] === T_ENCAPSED_AND_WHITESPACE) {
+				$rewritten .= (string) preg_replace(
+					'/(^|\n)([ \t]*)\/\/[^\n]*/',
+					'$1$2// generated production comment reworded by issue 2103 regression',
+					$token[1]
+				);
+				continue;
+			}
+			if (!is_array($token) || !in_array($token[0], [T_COMMENT, T_DOC_COMMENT], TRUE)) {
+				$rewritten .= is_array($token) ? $token[1] : $token;
+				continue;
+			}
+			$trimmed = ltrim($token[1]);
+			if (str_starts_with($trimmed, '//')) {
+				$replacement = '// production comment reworded by issue 2103 regression';
+			} elseif (str_starts_with($trimmed, '#')) {
+				$replacement = '# production comment reworded by issue 2103 regression';
+			} else {
+				$replacement = '/* production comment reworded by issue 2103 regression */';
+			}
+			$rewritten .= $replacement . str_repeat("\n", substr_count($token[1], "\n"));
+		}
+		return $rewritten;
+	}
+
+	private function removeTree(string $root): void
+	{
+		if (!is_dir($root)) {
+			return;
+		}
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($iterator as $item) {
+			$item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+		}
+		rmdir($root);
+	}
+}

--- a/tests/php/SyncCronPflexOrderTest.php
+++ b/tests/php/SyncCronPflexOrderTest.php
@@ -14,12 +14,9 @@ use PHPUnit\Framework\TestCase;
  * $pflex use), so this pins warning hygiene and the per-row invariant,
  * not a TLS behaviour change.
  *
- * The cron module is loaded through the package umbrella; this suite reads
- * its source text and pins the ORDER of the two statements: the first
- * `$pflex = FALSE` derivation line must precede the first `pfb_update_check(`
- * call site (the .fail retry) textually.
- * Whole-line comments are stripped before scanning so a comment mentioning
- * either token cannot satisfy or break the ordering assertion.
+ * The cron module is an appliance-only scheduler surface. This suite scans executable
+ * tokens with php_strip_whitespace and pins the ORDER of the two statements: the first
+ * `$pflex = FALSE` derivation line must precede the first `pfb_update_check(` call site.
  */
 final class SyncCronPflexOrderTest extends TestCase
 {
@@ -27,10 +24,10 @@ final class SyncCronPflexOrderTest extends TestCase
 
 	public static function setUpBeforeClass(): void
 	{
-		$src = file_get_contents(
+		$src = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc'
 		);
-		if ($src === false) {
+		if ($src === '') {
 			throw new RuntimeException('test bootstrap: failed to read pfblockerng_cron.inc');
 		}
 
@@ -42,9 +39,7 @@ final class SyncCronPflexOrderTest extends TestCase
 			throw new RuntimeException('test bootstrap: pfblockerng_sync_cron() body not found');
 		}
 
-		// Scan code only: a whole-line comment naming either token must not
-		// shift the first-occurrence offsets (bit this PR once mid-review).
-		self::$functionBody = preg_replace('#^\s*//.*$#m', '', $m[0]);
+		self::$functionBody = $m[0];
 	}
 
 	public function testDerivationAndCallSiteBothPresentExactlyOnceAndTwoOrMoreTimes(): void

--- a/tests/php/TickChildDeferralOrderingTest.php
+++ b/tests/php/TickChildDeferralOrderingTest.php
@@ -44,7 +44,10 @@ final class TickChildDeferralOrderingTest extends TestCase
 
 	public function testChildLockLossAfterLaunchKeepsPendingRetry(): void
 	{
-		$src = file_get_contents(
+		// Scheduling is off-limits for #2103 and the background child cannot be made
+		// deterministic off-appliance. Keep the ordering pin against comment-free PHP.
+		// PRODUCTION COMMENTS AND DOCBLOCKS MUST NEVER BE LOAD-BEARING FOR A TEST.
+		$src = php_strip_whitespace(
 			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc'
 		);
 		$this->assertNotFalse($src, 'test oracle: failed to read pfblockerng_extra.inc');

--- a/tests/php/TimestampCosmeticNormalizationTest.php
+++ b/tests/php/TimestampCosmeticNormalizationTest.php
@@ -9,9 +9,8 @@ use PHPUnit\Framework\TestCase;
  * outside the two genuine wrong-year bugs (DnsblAliasUpdateTimestampFormatTest /
  * ClearSqliteTimestampFormatTest cover those). Each site here already carried a
  * year (or, for the debug filename, has zero external consumer); the changes are
- * pure format polish, verified with a source tripwire (so this oracle goes red the
- * moment the format string drifts again) plus a reproduction of the exact new
- * behaviour.
+ * pure format polish. Top-level producers have no off-appliance callable seam, so
+ * retained pins use php_strip_whitespace() and never production comments.
  */
 final class TimestampCosmeticNormalizationTest extends TestCase
 {
@@ -34,13 +33,20 @@ final class TimestampCosmeticNormalizationTest extends TestCase
 		date_default_timezone_set($this->savedTz);
 	}
 
+	private function codeSource(string $path): string
+	{
+		$source = php_strip_whitespace($path);
+		$this->assertNotSame('', $source, "could not read comment-free source: {$path}");
+		return $source;
+	}
+
 	// -----------------------------------------------------------------------
 	// pfblockerng_apply.inc:1791 -- the /tmp debug-snapshot filename ('M_j' -> 'Y-m-d')
 	// -----------------------------------------------------------------------
 
 	public function testDebugFilenameSourceUsesFixedWidthFormat(): void
 	{
-		$source = (string) file_get_contents(self::PFBLOCKERNG_APPLY);
+		$source = $this->codeSource(self::PFBLOCKERNG_APPLY);
 		$this->assertStringContainsString(
 			"\$ts = date('Y-m-d', time());",
 			$source,
@@ -77,7 +83,7 @@ final class TimestampCosmeticNormalizationTest extends TestCase
 
 	public function testMaxmindGmdateSourceUsesIsoFormat(): void
 	{
-		$source = (string) file_get_contents(self::PFBLOCKERNG_PHP);
+		$source = $this->codeSource(self::PFBLOCKERNG_PHP);
 		$this->assertStringContainsString(
 			"@gmdate('Y-m-d H:i:s', pfb_file_mtime(\$maxmind_cont));",
 			$source,
@@ -156,7 +162,7 @@ final class TimestampCosmeticNormalizationTest extends TestCase
 	 */
 	public function testExpiresHttpHeaderIsByteForByteUnchanged(): void
 	{
-		$source = (string) file_get_contents(self::INDEX_PHP);
+		$source = $this->codeSource(self::INDEX_PHP);
 		$this->assertStringContainsString(
 			'header("Expires: Sat, 26 Jul 2014 05:00:00 GMT");',
 			$source,

--- a/tests/php/TldBridgeEmitTest.php
+++ b/tests/php/TldBridgeEmitTest.php
@@ -5,47 +5,35 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
-/**
- * ADR-66 Phase 1 -- the PHP-side halves of the two TLD cross-language
- * bridges (the Python-side reader halves live in
- * tests/test_adr66_tld_bridges.py, sharing the same key-name seam so a
- * half-renamed bridge fails loudly in Phases 2/3).
- *
- * C1 -- ini bridge writer: pfb_unbound_python() derives tld_allow/
- * tld_allow_list from $pfb['dnsbl_tld_allow'] + the four tld_allow_{gtld,cctld,
- * itld,bgtld} config fields and emits them into the MAIN-ini heredoc
- * (mirrors PythonTldWildcardIniEmitTest.php's structural pin -- no lighter
- * harness exists for pfb_unbound_python(), a live pfSense/VIP/DNS
- * environment; true end-to-end ini + Python behaviour is proven by the
- * live-VM smoke suite).
- *
- * C3 -- manifest bridge writer: a LIVE call of pfb_unbound_python_sources()
- * (mirrors UnboundPythonSourcesTest.php's $pfb setup) proving
- * config.tld_wildcard_blacklist/tld_wildcard_exclusion carry the configured
- * values when $pfb['dnsbl_tld_wildcard'] is truthy, and are emptied when falsy.
- */
+/** PHP-side TLD bridge tests exercise the writer and manifest at runtime. */
 #[CoversFunction('pfb_unbound_python')]
 #[CoversFunction('pfb_unbound_python_sources')]
 final class TldBridgeEmitTest extends TestCase
 {
-	private const SRC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
-
 	private string $tmp;
-	private bool $hadPfb = false;
+	private bool $hadPfb = FALSE;
 	private array $originalPfb = [];
+	private array $originalConfig = [];
+	private array $originalG = [];
 
 	protected function setUp(): void
 	{
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->originalConfig = $GLOBALS['config'] ?? [];
+		$this->originalG = $GLOBALS['g'] ?? [];
+		$GLOBALS['config'] = [];
+		$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		$this->tmp = sys_get_temp_dir() . '/pfb_tldbridge_' . uniqid('', TRUE);
+		mkdir("{$this->tmp}/dnsbl", 0777, TRUE);
+		mkdir("{$this->tmp}/db", 0777, TRUE);
 
-		$this->tmp = sys_get_temp_dir() . '/pfb_tldbridge_' . uniqid('', true);
-		mkdir("{$this->tmp}/dnsbl", 0777, true);
-		mkdir("{$this->tmp}/db", 0777, true);
-
-		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+		$GLOBALS['pfb'] = array_merge($this->originalPfb, [
 			'log'                => "{$this->tmp}/pfblockerng.log",
 			'errlog'             => "{$this->tmp}/error.log",
+			'logdir'             => $this->tmp,
+			'unbound_py_conf'    => "{$this->tmp}/pfb_unbound.ini",
+			'unbound_py_wh'      => "{$this->tmp}/pfb_whitelist.txt",
 			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
 			'dnsdir'             => "{$this->tmp}/dnsbl",
 			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
@@ -54,12 +42,15 @@ final class TldBridgeEmitTest extends TestCase
 			'dnsbl_tld_data'     => "{$this->tmp}/does_not_exist",
 			'dnsbl_unlock'       => "{$this->tmp}/dnsbl_unlock",
 			'dnsbl_tld_wildcard' => '',
+			'dnsbl_control'      => PfbToggle::Off,
+			'dnsbl_control_legacy' => PfbToggle::Off,
 			'dnsblconfig'        => [
 				'tld_wildcard_blacklist' => '',
 				'tld_wildcard_exclusion' => '',
 				'whitelist'              => '',
 			],
 		]);
+		$this->seedConfig();
 	}
 
 	protected function tearDown(): void
@@ -69,99 +60,91 @@ final class TldBridgeEmitTest extends TestCase
 		} else {
 			unset($GLOBALS['pfb']);
 		}
-
+		$GLOBALS['config'] = $this->originalConfig;
+		$GLOBALS['g'] = $this->originalG;
 		rmdir_recursive($this->tmp);
 	}
 
-	/**
-	 * Brace-counts from `function {$name}(` to its matching closing brace
-	 * (mirrors PythonTldWildcardIniEmitTest::functionBody()).
-	 */
-	private function functionBody(string $name): string
+	private function seedConfig(): void
 	{
-		$source = file_get_contents(self::SRC);
-		$this->assertNotFalse($source, 'failed to read pfblockerng.inc');
+		$gen = 'installedpackages/pfblockerng/config/0';
+		$ip = 'installedpackages/pfblockerngipsettings/config/0';
+		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		PfbConfig::writeSectionSystem($gen, ['pfb_min' => '0', 'pfb_hour' => '0', 'pfb_dailystart' => '0', 'skipfeed' => '0']);
+		PfbConfig::writeSectionSystem($ip, [
+			'suppression' => '', 'database_cc' => '', 'asn_token' => '', 'maxmind_account' => '',
+			'maxmind_key' => '', 'maxmind_locale' => 'en', 'asn_reporting' => 'disabled',
+		]);
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+		PfbConfig::writeSectionSystem($dnsbl, [
+			'pfb_dnsvip4' => '', 'pfb_dnsvip6' => '', 'pfb_dnsport' => '8081', 'pfb_dnsport_ssl' => '8443',
+			'top1m_enable' => '', 'pfb_cache' => '', 'pfb_py_reply' => '', 'pfb_regex' => '', 'pfb_regex_list' => '',
+			'pfb_cname' => '', 'tld_allow' => '', 'pfb_py_nolog' => '', 'pfb_noaaaa' => '', 'pfb_noaaaa_list' => '',
+			'pfb_gp' => '', 'pfb_gp_bypass_list' => '', 'whitelist' => '', 'tld_wildcard' => '',
+			'tld_wildcard_blacklist' => '', 'tld_wildcard_exclusion' => '',
+			'pfb_dnsbl' => '', 'pfb_dnsvip_auto' => '', 'dnsbl_interface' => 'lo0',
+		]);
+	}
 
-		$needle = "\nfunction {$name}(";
-		$start = strpos($source, $needle);
-		$this->assertNotFalse($start, "function {$name}() not found in source");
-		$start++;
-
-		$braceOpen = strpos($source, '{', $start);
-		$this->assertNotFalse($braceOpen, "no opening brace found for {$name}()");
-
-		$depth = 0;
-		for ($i = $braceOpen, $len = strlen($source); $i < $len; $i++) {
-			if ($source[$i] === '{') {
-				$depth++;
-			} elseif ($source[$i] === '}') {
-				$depth--;
-				if ($depth === 0) {
-					$body = substr($source, $start, $i - $start + 1);
-					$this->assertNotSame('', trim($body), "empty body extracted for {$name}() -- vacuous extraction");
-					return $body;
-				}
-			}
+	private function emitIni(string $toggle, array $fields): string
+	{
+		PfbConfig::writeSystem('dnsbl/tld_allow', $toggle);
+		foreach ($fields as $key => $value) {
+			PfbConfig::writeSystem("dnsbl/{$key}", $value);
 		}
-		$this->fail("no matching closing brace found for {$name}()");
+		pfb_unbound_python('enabled');
+		$ini = file_get_contents($GLOBALS['pfb']['unbound_py_conf']);
+		$this->assertNotFalse($ini, 'writer must create the Python INI');
+		return $ini;
 	}
 
-	// ------------------------------------------------------------------ //
-	// C1 -- ini bridge writer (structural).
-	// ------------------------------------------------------------------ //
-	public function testIniWriterDerivesTldAllowFromDnsblTldAllowToggle(): void
+	public function testIniBridgeReadsAllTldAllowFieldsWhenOn(): void
 	{
-		$body = $this->functionBody('pfb_unbound_python');
-		$this->assertMatchesRegularExpression(
-			"/\\\$tld_allow\s*=\s*'off';\s*\\\$tld_allow_list\s*=\s*'';\s*if\s*\(\s*\\\$pfb\['dnsbl_tld_allow'\]\s*===\s*PfbToggle::On\s*\)/s",
-			$body,
-			'the tld_allow/tld_allow_list pair must default off/empty and derive from $pfb[\'dnsbl_tld_allow\']'
-		);
+		$ini = $this->emitIni('on', [
+			'tld_allow_gtld' => 'com,net',
+			'tld_allow_cctld' => 'uk',
+			'tld_allow_itld' => '公司',
+			'tld_allow_bgtld' => 'example',
+		]);
+		$this->assertMatchesRegularExpression('/^tld_allow\s*=\s*on$/m', $ini);
+		$this->assertMatchesRegularExpression('/^tld_allow_list\s*=\s*com,net,uk,公司,example$/m', $ini);
 	}
 
-	public function testIniWriterReadsAllFourTldAllowConfigFields(): void
+	public function testIniBridgeOffToggleSuppressesConfiguredTldList(): void
 	{
-		$body = $this->functionBody('pfb_unbound_python');
-		foreach (['tld_allow_gtld', 'tld_allow_cctld', 'tld_allow_itld', 'tld_allow_bgtld'] as $field) {
-			$this->assertStringContainsString(
-				"dnsblconfig']['{$field}']",
-				$body,
-				"pfb_unbound_python() must read dnsblconfig['{$field}'] into tld_allow_list"
-			);
-		}
+		$ini = $this->emitIni('', [
+			'tld_allow_gtld' => 'com',
+			'tld_allow_cctld' => 'uk',
+			'tld_allow_itld' => '公司',
+			'tld_allow_bgtld' => 'example',
+		]);
+		$this->assertMatchesRegularExpression('/^tld_allow\s*=\s*off$/m', $ini);
+		$this->assertMatchesRegularExpression('/^tld_allow_list\s*=\s*$/m', $ini);
 	}
 
-	public function testIniHeredocEmitsTldAllowKeys(): void
+	public function testIniBridgeOnWithEmptyFieldsEmitsOffAndEmptyList(): void
 	{
-		$body = $this->functionBody('pfb_unbound_python');
-		$this->assertMatchesRegularExpression(
-			'/tld_allow\s*=\s*\{\$tld_allow\}/',
-			$body,
-			'the ini heredoc must carry a tld_allow key'
-		);
-		$this->assertMatchesRegularExpression(
-			'/tld_allow_list\s*=\s*\{\$tld_allow_list\}/',
-			$body,
-			'the ini heredoc must carry a tld_allow_list key'
-		);
+		$ini = $this->emitIni('on', [
+			'tld_allow_gtld' => '',
+			'tld_allow_cctld' => '',
+			'tld_allow_itld' => '',
+			'tld_allow_bgtld' => '',
+		]);
+		$this->assertMatchesRegularExpression('/^tld_allow\s*=\s*off$/m', $ini);
+		$this->assertMatchesRegularExpression('/^tld_allow_list\s*=\s*$/m', $ini);
 	}
 
-	// ------------------------------------------------------------------ //
-	// C3 -- manifest bridge writer (live call).
-	// ------------------------------------------------------------------ //
 	public function testManifestTldKeysEmptyWhenDnsblTldOff(): void
 	{
 		$GLOBALS['pfb']['dnsbl_tld_wildcard'] = '';
-		$GLOBALS['pfb']['dnsblconfig']['tld_wildcard_blacklist'] = base64_encode('evil-tld');
+		$GLOBALS['pfb']['dnsblconfig']['tld_wildcard_blacklist'] = base64_encode("evil-tld\n\xff");
 		$GLOBALS['pfb']['dnsblconfig']['tld_wildcard_exclusion'] = base64_encode('good.example');
 
-		$m = pfb_unbound_python_sources([]);
-
-		// issue #1328: the oracle must never ride the manifest under its post-rename
-		// (ADR-66) blob name either.
-		$this->assertArrayNotHasKey('tld_wildcard_master', $m['config'], 'tld_wildcard_master must never appear in the manifest');
-		$this->assertSame([], $m['config']['tld_wildcard_blacklist'], 'OFF must empty tld_wildcard_blacklist even though it was configured');
-		$this->assertSame([], $m['config']['tld_wildcard_exclusion'], 'OFF must empty tld_wildcard_exclusion even though it was configured');
+		$manifest = pfb_unbound_python_sources([]);
+		$this->assertIsArray($manifest);
+		$this->assertArrayNotHasKey('tld_wildcard_master', $manifest['config']);
+		$this->assertSame([], $manifest['config']['tld_wildcard_blacklist']);
+		$this->assertSame([], $manifest['config']['tld_wildcard_exclusion']);
 	}
 
 	public function testManifestTldKeysPopulatedWhenDnsblTldOn(): void
@@ -170,10 +153,10 @@ final class TldBridgeEmitTest extends TestCase
 		$GLOBALS['pfb']['dnsblconfig']['tld_wildcard_blacklist'] = base64_encode('evil-tld');
 		$GLOBALS['pfb']['dnsblconfig']['tld_wildcard_exclusion'] = base64_encode('good.example');
 
-		$m = pfb_unbound_python_sources([]);
-
-		$this->assertArrayNotHasKey('tld_wildcard_master', $m['config'], 'tld_wildcard_master must never appear in the manifest, even ON');
-		$this->assertSame(['evil-tld'], $m['config']['tld_wildcard_blacklist'], 'ON must populate tld_wildcard_blacklist from config');
-		$this->assertSame(['good.example'], $m['config']['tld_wildcard_exclusion'], 'ON must populate tld_wildcard_exclusion from config');
+		$manifest = pfb_unbound_python_sources([]);
+		$this->assertIsArray($manifest);
+		$this->assertArrayNotHasKey('tld_wildcard_master', $manifest['config']);
+		$this->assertSame(['evil-tld'], $manifest['config']['tld_wildcard_blacklist']);
+		$this->assertSame(['good.example'], $manifest['config']['tld_wildcard_exclusion']);
 	}
 }

--- a/tests/php/TldBridgeEmitTest.php
+++ b/tests/php/TldBridgeEmitTest.php
@@ -12,6 +12,8 @@ final class TldBridgeEmitTest extends TestCase
 {
 	private string $tmp;
 	private bool $hadPfb = FALSE;
+	private bool $hadConfig = FALSE;
+	private bool $hadG = FALSE;
 	private array $originalPfb = [];
 	private array $originalConfig = [];
 	private array $originalG = [];
@@ -19,6 +21,8 @@ final class TldBridgeEmitTest extends TestCase
 	protected function setUp(): void
 	{
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
+		$this->hadConfig = array_key_exists('config', $GLOBALS);
+		$this->hadG = array_key_exists('g', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
 		$this->originalConfig = $GLOBALS['config'] ?? [];
 		$this->originalG = $GLOBALS['g'] ?? [];
@@ -60,8 +64,16 @@ final class TldBridgeEmitTest extends TestCase
 		} else {
 			unset($GLOBALS['pfb']);
 		}
-		$GLOBALS['config'] = $this->originalConfig;
-		$GLOBALS['g'] = $this->originalG;
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+		if ($this->hadG) {
+			$GLOBALS['g'] = $this->originalG;
+		} else {
+			unset($GLOBALS['g']);
+		}
 		rmdir_recursive($this->tmp);
 	}
 

--- a/tests/php/ToggleEmptyPreservationTest.php
+++ b/tests/php/ToggleEmptyPreservationTest.php
@@ -86,6 +86,15 @@ final class ToggleEmptyPreservationTest extends TestCase
 			$this->assertNotFalse($to, "config gateway write missing for {$needle}");
 			$window = substr($source, $from, $to - $from);
 			$this->assertSame(1, substr_count($window, $needle), "save binding must be unique: {$needle}");
+
+			$otherPage = $page === self::DNSBL_PAGE ? self::IP_PAGE : self::DNSBL_PAGE;
+			$otherSource = php_strip_whitespace($otherPage);
+			$otherFrom = strpos($otherSource, $start);
+			$otherTo = $otherFrom === FALSE ? FALSE : strpos($otherSource, $end, $otherFrom + strlen($start));
+			$this->assertNotFalse($otherFrom, "other-page save branch missing for {$needle}");
+			$this->assertNotFalse($otherTo, "other-page config gateway write missing for {$needle}");
+			$otherWindow = substr($otherSource, $otherFrom, $otherTo - $otherFrom);
+			$this->assertStringNotContainsString($needle, $otherWindow, "save binding must stay off the other page: {$needle}");
 		}
 	}
 }

--- a/tests/php/ToggleEmptyPreservationTest.php
+++ b/tests/php/ToggleEmptyPreservationTest.php
@@ -4,222 +4,88 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * issue #1887 follow-through — a pre-merge stored '' meant an EXPLICIT Off, and that
- * intent must survive the merge on the fields where the registered default is 'on'.
- *
- * Under the merged contract a stored '' is the not-configured state and resolves to the
- * registered default. For a default-'' toggle that changes nothing. For a default-'on'
- * toggle it FLIPS a legacy unchecked save: a 3.2.x operator who deliberately unchecked
- * Keep holds '' (upstream wrote '' for unchecked), and reading that as On silently
- * re-enables their opt-out. The same shape reached pfb_idn_block_malicious through its
- * save path.
- *
- * issue #1921 (S2): the one-time '' -> 'off' upgrade conversion this file used to pin
- * directly (pfb_run_migrations()'s #1887 entries) folded into pfb_registry_pass()'s
- * grandfather map (gen/pfb_keep and dnsbl/pfb_idn_block_malicious both carry
- * ['' => 'off']) -- RegistryPassTest rows 4 and 8 cover the full absent/''/'on'/'off'
- * matrix for both keys now. What remains here is the save-path half, unrelated to any
- * migration: the DNSBL page staged its two IDN checkboxes as `pfb_filter(...) ?: ''`, so
- * an UNCHECKED save wrote '' — which the gateway now reads as the default. For the
- * default-'on' pfb_idn_block_malicious that meant the checkbox could never be turned off
- * again. The save path stages the explicit token instead (the general.php idiom), and
- * both IDN toggles carry the toggle adapter.
- *
- * issue #1907 (#1921 S3): the same save-path shape, extended to dnsbl/pfb_cache,
- * dnsbl/pfb_py_reply, dnsbl/pfb_hsts, and ip/suppression -- all four adopted the toggle
- * adapter and flipped their registry default to 'on', so their pages' saves needed the
- * same explicit-token staging fix.
- */
+/** issue #1887/#1907: page checkbox decisions persist explicit Off tokens. */
 final class ToggleEmptyPreservationTest extends TestCase
 {
-	private const IDN = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_block_malicious';
+	private const DNSBL_PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php';
+	private const IP_PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_ip.php';
 
 	protected function setUp(): void
 	{
 		$GLOBALS['config'] = [];
 	}
 
-	// -----------------------------------------------------------------------
-	// The save-path half: an unchecked IDN save must disable, not re-enable
-	// -----------------------------------------------------------------------
-
 	/**
-	 * The defect the sweep found: with the field read through the gateway, a staged ''
-	 * resolves to the default 'on', so the old `pfb_filter(...) ?: ''` unchecked save
-	 * could never turn malicious-homoglyph blocking off. The save must stage the
-	 * explicit token; this drives the staged value through the same writeSection the
-	 * page uses and asserts the read-back.
+	 * The DNSBL page owns these save/render decisions. An absent checkbox must stay Off
+	 * even when the registry default is On; a checked box must round-trip as On.
 	 */
-	public function testUncheckedIdnBlockMaliciousSaveDisables(): void
+	public function testDnsblPageToggleSaveAndRenderDecisions(): void
 	{
 		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
-
-		// The page's staging idiom for an unchecked box (POST key absent).
-		$staged = ((NULL ?? '') === 'on') ? 'on' : 'off';
-		PfbConfig::writeSection($section, ['pfb_idn_block_malicious' => $staged]);
-
-		$this->assertSame('off', config_get_path(self::IDN),
-			'an unchecked save must persist the explicit off token');
-		$this->assertSame(PfbToggle::Off, PfbConfig::read('dnsbl/pfb_idn_block_malicious'),
-			'an unchecked save must read back as disabled — not resolve to the default-on');
-	}
-
-	/**
-	 * The page source stages both IDN checkboxes with the explicit-token ternary, not
-	 * the `?: ''` coalesce whose '' now means "not configured".
-	 */
-	public function testDnsblPageStagesTheIdnTogglesExplicitly(): void
-	{
-		$src = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php'
-		);
-
-		foreach (['pfb_idn_block_malicious', 'pfb_idn_escalate_suspicious'] as $field) {
-			$this->assertStringContainsString(
-				"((\$_POST['{$field}'] ?? '') === 'on') ? 'on' : 'off'",
-				$src,
-				"{$field} must be staged as an explicit 'on'/'off' (checkbox-absent means Off)"
-			);
-			$this->assertStringNotContainsString(
-				"pfb_filter(\$_POST['{$field}'], PFB_FILTER_ON_OFF, 'dnsbl')\t?: ''",
-				$src,
-				"{$field} must not be staged with the ?: '' coalesce"
-			);
-		}
-	}
-
-	// -----------------------------------------------------------------------
-	// issue #1907 — the same shape for dnsbl/pfb_cache, dnsbl/pfb_py_reply,
-	// dnsbl/pfb_hsts, and ip/suppression: all four flipped to a default-'on'
-	// registry entry, so an unchecked save staging '' would resolve back to On at
-	// the gateway unless the page stages the explicit 'off' token.
-	// -----------------------------------------------------------------------
-
-	/**
-	 * @return array<string,array{0:string,1:string,2:string}> label => [gateway key, section path, bare key]
-	 */
-	private static function issue1907Fields(): array
-	{
-		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
-		$ip    = 'installedpackages/pfblockerngipsettings/config/0';
-		return [
-			'pfb_cache'    => ['dnsbl/pfb_cache',    $dnsbl, 'pfb_cache'],
-			'pfb_py_reply' => ['dnsbl/pfb_py_reply', $dnsbl, 'pfb_py_reply'],
-			'pfb_hsts'     => ['dnsbl/pfb_hsts',     $dnsbl, 'pfb_hsts'],
-			'suppression'  => ['ip/suppression',     $ip,    'suppression'],
+		$fields = [
+			'pfb_cache' => 'dnsbl/pfb_cache',
+			'pfb_py_reply' => 'dnsbl/pfb_py_reply',
+			'pfb_hsts' => 'dnsbl/pfb_hsts',
+			'pfb_idn_block_malicious' => 'dnsbl/pfb_idn_block_malicious',
+			'pfb_idn_escalate_suspicious' => 'dnsbl/pfb_idn_escalate_suspicious',
 		];
-	}
 
-	/**
-	 * An unchecked save (POST key absent, staged via the page's explicit ternary)
-	 * must persist and read back as disabled -- not resolve to the new default-on.
-	 */
-	public function testUncheckedIssue1907FieldsSaveDisables(): void
-	{
-		foreach (self::issue1907Fields() as $label => [$gateway_key, $section, $bare]) {
+		foreach ($fields as $bare => $key) {
 			$GLOBALS['config'] = [];
+			$unchecked = pfb_dnsbl_toggle_stored(NULL);
+			PfbConfig::writeSection($section, [$bare => $unchecked]);
+			$this->assertSame('off', config_get_path("{$section}/{$bare}"), "{$bare}: absent POST must persist Off");
+			$this->assertFalse(pfb_dnsbl_toggle_enabled(PfbConfig::read($key)), "{$bare}: unchecked render must be disabled");
 
-			$post_value = NULL; // checkbox absent from $_POST
-			$staged     = (($post_value ?? '') === 'on') ? 'on' : 'off';
-			PfbConfig::writeSection($section, [$bare => $staged]);
-
-			$this->assertSame('off', config_get_path("{$section}/{$bare}"),
-				"{$label}: an unchecked save must persist the explicit off token");
-			$this->assertSame(PfbToggle::Off, PfbConfig::read($gateway_key),
-				"{$label}: an unchecked save must read back as disabled -- not resolve to the default-on");
+			$checked = pfb_dnsbl_toggle_stored('on');
+			PfbConfig::writeSection($section, [$bare => $checked]);
+			$this->assertSame('on', config_get_path("{$section}/{$bare}"), "{$bare}: checked POST must persist On");
+			$this->assertTrue(pfb_dnsbl_toggle_enabled(PfbConfig::read($key)), "{$bare}: checked render must be enabled");
 		}
 	}
 
-	/**
-	 * The before-state for the flip: a checked save stages 'on' and reads back as
-	 * enabled -- the polarity pair for the unchecked case above.
-	 */
-	public function testCheckedIssue1907FieldsSaveEnables(): void
+	/** The IP page has its own suppression save/render decision and same polarity. */
+	public function testIpPageSuppressionSaveAndRenderDecision(): void
 	{
-		foreach (self::issue1907Fields() as $label => [$gateway_key, $section, $bare]) {
-			$GLOBALS['config'] = [];
+		$section = 'installedpackages/pfblockerngipsettings/config/0';
+		$key = 'ip/suppression';
 
-			$post_value = 'on'; // checkbox checked
-			$staged     = (($post_value ?? '') === 'on') ? 'on' : 'off';
-			PfbConfig::writeSection($section, [$bare => $staged]);
+		$unchecked = pfb_ip_suppression_stored(NULL);
+		PfbConfig::writeSection($section, ['suppression' => $unchecked]);
+		$this->assertSame('off', config_get_path("{$section}/suppression"), 'IP unchecked POST must persist Off');
+		$this->assertFalse(pfb_ip_suppression_enabled(PfbConfig::read($key)), 'IP unchecked render must be disabled');
 
-			$this->assertSame('on', config_get_path("{$section}/{$bare}"),
-				"{$label}: a checked save must persist the explicit on token");
-			$this->assertSame(PfbToggle::On, PfbConfig::read($gateway_key),
-				"{$label}: a checked save must read back as enabled");
-		}
+		$checked = pfb_ip_suppression_stored('on');
+		PfbConfig::writeSection($section, ['suppression' => $checked]);
+		$this->assertSame('on', config_get_path("{$section}/suppression"), 'IP checked POST must persist On');
+		$this->assertTrue(pfb_ip_suppression_enabled(PfbConfig::read($key)), 'IP checked render must be enabled');
 	}
 
 	/**
-	 * The page source stages all four checkboxes with the explicit-token ternary, not
-	 * the `pfb_filter(...) ?: ''` coalesce whose '' now means "not configured" and
-	 * would silently re-enable an unchecked save now these fields default on.
+	 * #993: these page-save branches require pfSense request/config globals and cannot run
+	 * off-appliance; each shipped binding is pinned in its own comment-free source window.
+	 * php_strip_whitespace() strips comments/docblocks, so they cannot satisfy the pins.
 	 */
-	public function testPagesStageTheIssue1907TogglesExplicitly(): void
+	public function testShippedSaveBindingsKeepEachToggleOnItsPage(): void
 	{
-		$dnsbl_src = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php'
-		);
-		foreach (['pfb_cache', 'pfb_py_reply', 'pfb_hsts'] as $field) {
-			$this->assertStringContainsString(
-				"((\$_POST['{$field}'] ?? '') === 'on') ? 'on' : 'off'",
-				$dnsbl_src,
-				"{$field} must be staged as an explicit 'on'/'off' (checkbox-absent means Off)"
-			);
-			$this->assertStringNotContainsString(
-				"pfb_filter(\$_POST['{$field}'], PFB_FILTER_ON_OFF, 'dnsbl')",
-				$dnsbl_src,
-				"{$field} must not be staged with the pfb_filter(...) ?: '' coalesce"
-			);
+		foreach ([
+			"\$pfb['dconfig']['pfb_cache'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_py_reply'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_hsts'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_idn_block_malicious'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_idn_escalate_suspicious'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
+			"\$pfb['iconfig']['suppression'] = pfb_ip_suppression_stored(" => self::IP_PAGE,
+		] as $needle => $page) {
+			$source = php_strip_whitespace($page);
+			$start  = "if (isset(\$_POST['save'])) {";
+			$end    = 'PfbConfig::writeSection(';
+			$from   = strpos($source, $start);
+			$to     = $from === FALSE ? FALSE : strpos($source, $end, $from + strlen($start));
+
+			$this->assertNotFalse($from, "save branch missing for {$needle}");
+			$this->assertNotFalse($to, "config gateway write missing for {$needle}");
+			$window = substr($source, $from, $to - $from);
+			$this->assertSame(1, substr_count($window, $needle), "save binding must be unique: {$needle}");
 		}
-
-		$ip_src = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_ip.php'
-		);
-		$this->assertStringContainsString(
-			"((\$_POST['suppression'] ?? '') === 'on') ? 'on' : 'off'",
-			$ip_src,
-			"suppression must be staged as an explicit 'on'/'off' (checkbox-absent means Off)"
-		);
-		$this->assertStringNotContainsString(
-			"pfb_filter(\$_POST['suppression'], PFB_FILTER_ON_OFF, 'ip')",
-			$ip_src,
-			"suppression must not be staged with the pfb_filter(...) ?: '' coalesce"
-		);
-	}
-
-	/**
-	 * The render expression must survive the validation-error re-render, where
-	 * `$pconfig = $_POST` replaces the gateway enum with the raw POST string ('on',
-	 * or absent when unchecked): pfb_cfg_toggle_read() accepts both (enum
-	 * passthrough + string parse), and `?? ''` covers the unchecked-POST absent key.
-	 */
-	public function testPagesRenderTheIssue1907TogglesThroughTheToggleRead(): void
-	{
-		$dnsbl_src = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php'
-		);
-		foreach (['pfb_cache', 'pfb_py_reply', 'pfb_hsts'] as $field) {
-			$this->assertStringContainsString(
-				"pfb_cfg_toggle_read(\$pconfig['{$field}'] ?? '') === PfbToggle::On",
-				$dnsbl_src,
-				"{$field} must render through pfb_cfg_toggle_read with the absent-POST fallback"
-			);
-		}
-
-		$ip_src = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_ip.php'
-		);
-		$this->assertStringContainsString(
-			"pfb_cfg_toggle_read(\$pconfig['suppression'] ?? '') === PfbToggle::On",
-			$ip_src,
-			'suppression must render through pfb_cfg_toggle_read with the absent-POST fallback'
-		);
-		$this->assertStringNotContainsString(
-			"\$pconfig['suppression'] === PfbToggle::On",
-			$ip_src,
-			'a bare enum comparison breaks on the $pconfig = $_POST error re-render path'
-		);
 	}
 }

--- a/tests/php/ToggleMirrorComparisonGuardTest.php
+++ b/tests/php/ToggleMirrorComparisonGuardTest.php
@@ -63,7 +63,8 @@ final class ToggleMirrorComparisonGuardTest extends TestCase
 			if (!$file->isFile() || !preg_match('/\.(php|inc)$/', $file->getPathname())) {
 				continue;
 			}
-			foreach (explode("\n", (string) file_get_contents($file->getPathname())) as $n => $line) {
+			// Whole-tree static type rule: comments are not executable input.
+			foreach (explode("\n", php_strip_whitespace($file->getPathname())) as $n => $line) {
 				// Adapter feeds are fine: the raw section value is compared/coalesced
 				// BEFORE pfb_cfg_toggle_read() types it.
 				if (str_contains($line, 'pfb_cfg_toggle_read(')) {
@@ -113,7 +114,7 @@ final class ToggleMirrorComparisonGuardTest extends TestCase
 			if (!$file->isFile() || !preg_match('/\.(php|inc)$/', $file->getPathname())) {
 				continue;
 			}
-			foreach (explode("\n", (string) file_get_contents($file->getPathname())) as $n => $line) {
+			foreach (explode("\n", php_strip_whitespace($file->getPathname())) as $n => $line) {
 				foreach ($sinks as $kind => $rx) {
 					if (preg_match($rx, $line)) {
 						$offences[] = substr($file->getPathname(), strlen($root) + 1) . ':' . ($n + 1)

--- a/tests/php/Top1mApplyRefreshMatrixTest.php
+++ b/tests/php/Top1mApplyRefreshMatrixTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_top1m_refresh_needed')]
 #[CoversFunction('pfb_top1m_fetch_if_needed')]
 #[CoversFunction('pfb_top1m_reprocess_needed')]
+#[CoversFunction('pfb_top1m_apply_reprocess_if_ready')]
 #[CoversFunction('pfb_dnsbl_publish_result')]
 #[CoversFunction('pfb_dnsbl_reload_needed')]
 final class Top1mApplyRefreshMatrixTest extends TestCase
@@ -102,16 +103,21 @@ final class Top1mApplyRefreshMatrixTest extends TestCase
 		$this->assertSame('pending-combined-change', file_get_contents($marker));
 	}
 
-	public function testApplyWiresTheIdentityGateBeforeTop1mConversion(): void
+	public function testApplyReprocessesOnlyWhenIdentityGateIsReady(): void
 	{
-		$source = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
-		);
-		$gate = strpos($source, "if (pfb_top1m_reprocess_needed(\$pfb['dbdir']))");
-		$this->assertNotFalse($gate, 'apply path must gate TOP1M conversion on current identity');
-		$converter = strpos($source, 'pfblockerng_top1m();', $gate);
-		$this->assertNotFalse($converter);
-		$this->assertLessThan($converter, $gate);
+		$attempts = 0;
+		$this->assertFalse(pfb_top1m_apply_reprocess_if_ready($this->dbdir, static function () use (&$attempts): void {
+			$attempts++;
+		}), 'missing active identity must not convert');
+		$this->assertSame(0, $attempts);
+
+		file_put_contents("{$this->dbdir}/top-1m.csv", "live\n");
+		file_put_contents("{$this->dbdir}/top-1m.csv.zip.orig", "raw\n");
+		file_put_contents("{$this->dbdir}/top-1m.update", 'pending');
+		$this->assertTrue(pfb_top1m_apply_reprocess_if_ready($this->dbdir, static function () use (&$attempts): void {
+			$attempts++;
+		}), 'current identity plus update marker must convert');
+		$this->assertSame(1, $attempts);
 	}
 
 	public function testPublishResultLogsOnlyTheTruthfulOutcome(): void

--- a/tests/php/Top1mTeardownWiringTest.php
+++ b/tests/php/Top1mTeardownWiringTest.php
@@ -6,28 +6,30 @@ use PHPUnit\Framework\TestCase;
 
 final class Top1mTeardownWiringTest extends TestCase
 {
-	private function functionBody(string $name): string
+	public function testTeardownCallRunsInjectedEffect(): void
 	{
-		$function = new ReflectionFunction($name);
-		$lines = file((string) $function->getFileName());
-		$this->assertIsArray($lines);
-		return implode('', array_slice(
-			$lines,
-			$function->getStartLine() - 1,
-			$function->getEndLine() - $function->getStartLine() + 1
-		));
+		$calls = 0;
+		$this->assertTrue(pfb_top1m_teardown_call(static function () use (&$calls): bool {
+			$calls++;
+			return TRUE;
+		}));
+		$this->assertSame(1, $calls, 'the teardown seam must invoke its effect exactly once');
 	}
 
+	/**
+	 * The sync and pre-deinstall entrypoints are appliance-only procedural flows. Keep this
+	 * wiring pin code-only so comments/docblocks cannot satisfy it; the seam above proves the
+	 * observable teardown effect.
+	 */
 	public function testDisableAndUninstallWireTheSharedTeardown(): void
 	{
-		$this->assertStringContainsString(
-			'pfb_unbound_py_teardown_raw_set();',
-			$this->functionBody('sync_package_pfblockerng'),
-			'DNSBL disable must remove the fixed TOP1M runtime set'
-		);
+		$apply = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$inc = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+		$this->assertStringContainsString('pfb_top1m_teardown_call();', $apply,
+			'DNSBL disable must invoke the shared TOP1M teardown seam');
 		$this->assertMatchesRegularExpression(
-			'/sync_package_pfblockerng\(\);\s+pfb_unbound_py_teardown_raw_set\(\);/',
-			$this->functionBody('pfblockerng_php_pre_deinstall_command'),
+			'/sync_package_pfblockerng\(\);\s*pfb_top1m_teardown_call\(\);/',
+			$inc,
 			'package removal must tear down retained TOP1M runtime state after the disable pass'
 		);
 	}

--- a/tests/php/UpdateAjaxTailJsonEncodingTest.php
+++ b/tests/php/UpdateAjaxTailJsonEncodingTest.php
@@ -2,101 +2,40 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Pin the JSON-encoding contract of the Update page's AJAX live-log-tail endpoint
- * (pfblockerng_update.php, ?ajax=tail branch):
- * print(json_encode(pfb_log_tail_payload(...))). An invalid-UTF-8 byte in the
- * tailed log line must not make json_encode() return FALSE -- print(FALSE) is an
- * empty response body, which fails the client's JSON.parse() and stalls the live
- * tail (issue #1814).
- *
- * Reachability: the ?ajax=tail branch is top-level code (before any function
- * definition) that calls exit() right after the print(), and needs
- * guiconfig.inc's session/webConfigurator runtime -- the same reachability gap
- * already documented for pfblockerng_lint.php's endpoint (see
- * LintEndpointWiringTest::testJsonEncodeCarriesInvalidUtf8Substitute, which pins
- * that endpoint's identical JSON_INVALID_UTF8_SUBSTITUTE contract the same way)
- * and for pfblockerng_dnsbl.php/pfblockerng_edit_hooks.php's page renders. This
- * class follows that established convention:
- *   - testJsonEncodeCallSiteCarriesInvalidUtf8SubstituteFlag pins the exact
- *     call-site source text (fails whenever the production line drops the flag).
- *   - testInvalidUtf8SubstituteFlagFixesEncodingOfTailedInvalidByte pins the
- *     flag's behavior against the real pfb_log_tail_payload() output shape on
- *     an actual hostile payload; it does not read the production file, so the
- *     call-site pin above is what ties it to the endpoint.
- */
-#[CoversFunction('pfb_log_tail_payload')]
 final class UpdateAjaxTailJsonEncodingTest extends TestCase
 {
-	private const UPDATE_PAGE_PATH = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_update.php';
-	private const UPDATE_PID = '/var/run/pfb_runnow.pid';
-
-	protected function setUp(): void
+	public function testTailReaderReceivesValidatedOffsetAndResponseIsJson(): void
 	{
-		global $pfb;
-		@mkdir($pfb['logdir'], 0777, TRUE);
-		@file_put_contents($pfb['runlog'], '');
-		@file_put_contents($pfb['log'], '');
-		$GLOBALS['pfb_test_valid_pids'] = [];
-	}
-
-	protected function tearDown(): void
-	{
-		$GLOBALS['pfb_test_valid_pids'] = [];
-	}
-
-	public function testJsonEncodeCallSiteCarriesInvalidUtf8SubstituteFlag(): void
-	{
-		$src = file_get_contents(self::UPDATE_PAGE_PATH);
-		$this->assertNotFalse($src, 'test oracle: failed to read ' . self::UPDATE_PAGE_PATH);
-
-		$anchor = 'print(json_encode(pfb_log_tail_payload(';
-		$pos = strpos($src, $anchor);
-		$this->assertNotFalse($pos, 'the ajax=tail endpoint must call print(json_encode(pfb_log_tail_payload(...)))');
-
-		// pfb_log_tail_payload(...)'s own arguments contain nested parens (e.g. "(int)
-		// $_GET['offset']"), so a naive "up to the next )" scan would stop inside them.
-		// The statement is single-line in production; bound the scan to that line instead.
-		$eol = strpos($src, "\n", $pos);
-		$this->assertNotFalse($eol, 'test oracle: could not find the end of the call-site line');
-		$line = substr($src, $pos, $eol - $pos);
-
-		$this->assertStringContainsString(
-			'JSON_INVALID_UTF8_SUBSTITUTE',
-			$line,
-			'the ajax=tail json_encode(...) call must pass JSON_INVALID_UTF8_SUBSTITUTE -- else an invalid ' .
-				'byte in the tailed log line makes json_encode() return FALSE (print(FALSE) => empty body => ' .
-				'the client JSON.parse() fails and the live tail stalls)'
+		$received = NULL;
+		$result = pfb_update_tail_response(
+			['ajax' => 'tail', 'offset' => '17'],
+			static function (string $which, int $offset, bool $hasOffset) use (&$received): array {
+				$received = [$which, $offset, $hasOffset];
+				return ['data' => "line\n"];
+			}
 		);
+		$this->assertSame(['update', 17, TRUE], $received);
+		$this->assertSame(['Content-Type: application/json', 'Cache-Control: no-cache, no-store, must-revalidate'], $result['headers']);
+		$this->assertSame(['data' => "line\n"], json_decode($result['body'], TRUE));
 	}
 
-	public function testInvalidUtf8SubstituteFlagFixesEncodingOfTailedInvalidByte(): void
+	public function testInvalidUtf8TailByteIsSubstitutedInValidJson(): void
 	{
-		global $pfb;
-		// Finished-run branch (deterministic single read, no polling state to juggle): a
-		// tailed line ending in a lone invalid lead byte (the byte-substr/log-rotation shape).
-		file_put_contents($pfb['runlog'], "line one\nbad line \xFF end");
-		$GLOBALS['pfb_test_valid_pids'][self::UPDATE_PID] = FALSE; // process gone -> flush trailing partial
-
-		$payload = pfb_log_tail_payload('update', -1, FALSE);
-		$this->assertStringContainsString("\xFF", $payload['data'], 'test oracle: the invalid byte must reach the payload');
-
-		// Pre-fix: exactly what the ajax=tail call site did before JSON_INVALID_UTF8_SUBSTITUTE
-		// was added -- an invalid byte anywhere in the payload makes json_encode() return FALSE.
-		$this->assertFalse(json_encode($payload), 'documents the pre-fix defect: an invalid UTF-8 byte makes json_encode() return FALSE');
-
-		// Post-fix: the flag the call site now carries.
-		$json = json_encode($payload, JSON_INVALID_UTF8_SUBSTITUTE);
-		$this->assertNotFalse($json, 'with the flag, an invalid byte must not make json_encode() return FALSE');
-		$this->assertTrue(mb_check_encoding($json, 'UTF-8'), 'the JSON body must be valid UTF-8');
-		// json_encode() escapes non-ASCII as the literal backslash-u-f-f-f-d text (no
-		// JSON_UNESCAPED_UNICODE), so decode back to check for the actual U+FFFD codepoint
-		// rather than string-searching the escaped JSON text.
-		$decoded = json_decode($json, TRUE);
-		$this->assertIsArray($decoded, 'the JSON must decode back to an array');
-		$this->assertStringContainsString("\u{FFFD}", $decoded['data'], 'the invalid byte must be substituted with U+FFFD, not dropped');
+		$args = NULL;
+		$result = pfb_update_tail_response(
+			['ajax' => 'tail'],
+			static function (string $which, int $offset, bool $hasOffset) use (&$args): array {
+				$args = [$which, $offset, $hasOffset];
+				return ['data' => "bad \xFF"];
+			}
+		);
+		$this->assertSame(['update', -1, FALSE], $args);
+		$this->assertTrue(mb_check_encoding($result['body'], 'UTF-8'));
+		$decoded = json_decode($result['body'], TRUE);
+		$this->assertIsArray($decoded);
+		$this->assertStringContainsString("\u{FFFD}", $decoded['data']);
 	}
+
 }

--- a/tests/php/WidgetGetTableArgOrderTest.php
+++ b/tests/php/WidgetGetTableArgOrderTest.php
@@ -4,192 +4,54 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * Pins the pfBlockerNG_get_table($pfb_table, $mode='') argument-order
- * contract in two complementary halves, established by issue #1693's
- * reorder of $mode/$pfb_table (matching the #1657 shape for the same PHP 8
- * optional-before-required-parameter defect class):
- *
- *   - testJsModeCallPathEmitsPipeDelimitedFieldsInOrder /
- *     testDefaultModeCallPathEmitsTableMarkupWithFieldsInTheRightCells
- *     (runtime, DECLARATION pin): eval-extract the REAL function body --
- *     same idiom PfbWidgetOracleTest already uses for
- *     pfBlockerNG_get_failed()/pfBlockerNG_clearfailed() -- and invoke it
- *     directly the same two ways the widget does (js mode with both
- *     positional args, default mode relying on $mode's default). A
- *     reverted declaration (optional $mode moved back before required
- *     $pfb_table) then throws before producing output -- TypeError from
- *     reset() on the js-mode call, ArgumentCountError on the default-mode
- *     call, both proven by mutation -- and a silent field-order corruption
- *     inside the function body is caught by asserting the exact rendered
- *     output, not merely that the call did not throw. This half pins ONLY
- *     the declaration's own argument contract: it hand-writes its own call
- *     expressions and cannot see a mistake in the widget's actual call-site
- *     source.
- *
- *   - testEveryCallSitePassesPfbTableFirstArgument (source pin, CALL-SITE
- *     pin): closes exactly the gap the runtime half leaves open --
- *     a declaration/call-site positional drift where the declaration stays
- *     correct but a call site in pfblockerng.widget.php is edited to pass
- *     its arguments in the wrong order. `php -l` cannot see that either
- *     (SrcPhpDeprecationLintTest), for the identical reason: a caller is
- *     never part of what -l parses. This test extracts every literal
- *     `pfBlockerNG_get_table(` call expression from the widget source and
- *     asserts each one's first argument is literally `$pfb_table`, with an
- *     `assertCount(2, ...)` vacuity guard so a second, unpinned call site
- *     cannot appear silently -- same shape as
- *     DnsblRegexToggleGateWiringTest's `substr_count(...) === 1` guard.
- *
- * Together the two halves close the finding SrcPhpDeprecationLintTest
- * structurally cannot: a declaration reorder is caught by the runtime half,
- * a call-site-only argument swap is caught by the source-pin half.
- */
 final class WidgetGetTableArgOrderTest extends TestCase
 {
-	private static string $src;
+	private const ROOT = __DIR__ . '/../..';
+	private const WIDGET = self::ROOT . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
 
-	/** Saved $GLOBALS['pfb'], restored in tearDown (repo convention, PfbWidgetOracleTest). */
-	private bool $hadPfb = false;
-	private mixed $savedPfb = null;
-
-	public static function setUpBeforeClass(): void
+	public function testAjaxWidgetBranchExecutesTheShippedTableCall(): void
 	{
-		$src = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php'
-		);
-		if ($src === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng.widget.php');
-		}
-		self::$src = $src;
-
-		if (function_exists('pfBlockerNG_get_table')) {
-			return;
-		}
-
-		if (!preg_match('/function\s+pfBlockerNG_get_table\s*\([^)]*\).*?\n\}/s', $src, $m)) {
-			throw new RuntimeException('test bootstrap: pfBlockerNG_get_table() not found in widget source');
-		}
-		eval($m[0]);
+		$result = $this->runWidget(['getNewWidget' => '1'], []);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertStringEndsWith('after-include', trim($result['stdout']));
 	}
 
-	protected function setUp(): void
+	public function testDefaultWidgetRenderExecutesTheShippedTableCall(): void
 	{
-		$this->hadPfb   = array_key_exists('pfb', $GLOBALS);
-		$this->savedPfb = $GLOBALS['pfb'] ?? null;
+		$result = $this->runWidget([], []);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertStringContainsString('<tbody id="pfBNG-table">', $result['stdout']);
 	}
 
-	protected function tearDown(): void
+	/** @return array{status:int,stdout:string,stderr:string} */
+	private function runWidget(array $get, array $post): array
 	{
-		if ($this->hadPfb) {
-			$GLOBALS['pfb'] = $this->savedPfb;
-		} else {
-			unset($GLOBALS['pfb']);
-		}
-	}
-
-	/**
-	 * A single alias row is enough to pin field order -- no fixture factory needed.
-	 *
-	 * @return array<string,array<string,mixed>>
-	 */
-	private function fixture(): array
-	{
-		return [
-			'pfB_Example_v4' => [
-				'count'   => 7,
-				'packets' => 0,
-				'update'  => '2024-06-01',
-				'img'     => '<i class="fa-solid fa-check"></i>',
-				'rule'    => 0,
-				'id'      => 1,
-			],
-		];
-	}
-
-	/**
-	 * The Ajax refresh path, invoked the same way pfblockerng.widget.php:66 does:
-	 * pfBlockerNG_get_table($pfb_table, 'js'). Declaration pin only -- see class
-	 * docblock; this hand-writes its own call and cannot see a call-site-only
-	 * argument swap in the widget source (testEveryCallSitePassesPfbTableFirstArgument
-	 * covers that).
-	 */
-	public function testJsModeCallPathEmitsPipeDelimitedFieldsInOrder(): void
-	{
-		$GLOBALS['pfb'] = ['pfctlerr' => '', 'err' => '', 'popup' => ''];
-
-		ob_start();
-		pfBlockerNG_get_table($this->fixture(), 'js');
-		$out = ob_get_clean();
-
-		$this->assertSame(
-			"pfB_Example_v4||7||0||2024-06-01||<i class=\"fa-solid fa-check\"></i><span title=\"Alias Firewall Rule count\"></span>\n",
-			$out,
-			'js-mode call path must emit the fixture row fields pipe-delimited in count/packets/update/img order'
-		);
-	}
-
-	/**
-	 * The default HTML-render path, invoked the same way pfblockerng.widget.php:1080
-	 * does: pfBlockerNG_get_table($pfb_table), relying on $mode's default ''.
-	 * Declaration pin only -- see class docblock. Asserts the exact rendered
-	 * fragment (byte-for-byte, like the js-mode sibling's assertSame) so a swap
-	 * between two columns inside the function body -- which a presence-only
-	 * assertStringContainsString per column cannot catch -- fails here.
-	 */
-	public function testDefaultModeCallPathEmitsTableMarkupWithFieldsInTheRightCells(): void
-	{
-		$GLOBALS['pfb'] = ['pfctlerr' => '', 'err' => '', 'popup' => ''];
-
-		ob_start();
-		pfBlockerNG_get_table($this->fixture());
-		$out = ob_get_clean();
-
-		$expected = "<tr>\n"
-			. "\t\t\t\t\t\t<td><small>pfB_Example_v4</small></td>\n"
-			. "\t\t\t\t\t\t<td><small>7</small></td>\n"
-			. "\t\t\t\t\t\t<td><small>0</small></td>\n"
-			. "\t\t\t\t\t\t<td><small>2024-06-01</small></td>\n"
-			. "\t\t\t\t\t\t<td><i class=\"fa-solid fa-check\"></i><span title=\"Alias Firewall Rule count\"></span></td>\n"
-			. "\t\t\t\t</tr>\n"
-			. "\t\t\t\t";
-
-		$this->assertSame(
-			$expected,
-			$out,
-			'default-mode call path must emit alias/count/packets/update/img in exactly those column positions'
-		);
-	}
-
-	/**
-	 * Call-site pin -- see class docblock. Extracts every literal
-	 * `pfBlockerNG_get_table(` call expression from the widget source (the
-	 * negative lookbehind excludes the `function pfBlockerNG_get_table(...)`
-	 * declaration line itself) and asserts each call's first positional
-	 * argument is literally `$pfb_table`. Robust to whitespace/reformatting
-	 * and to the second argument's presence/value -- it pins only the
-	 * property that actually matters: which parameter slot gets $pfb_table.
-	 */
-	public function testEveryCallSitePassesPfbTableFirstArgument(): void
-	{
-		preg_match_all('/(?<!function )pfBlockerNG_get_table\(([^)]*)\)/', self::$src, $m);
-		$calls = $m[1];
-
-		// Vacuity-safe: proves the extraction found the real call sites (not zero,
-		// not a broken regex) AND that no third, unpinned call site has appeared.
-		$this->assertCount(
-			2,
-			$calls,
-			'expected exactly 2 pfBlockerNG_get_table( call sites in the widget source -- '
-				. 'a new, unpinned call site must not appear silently. Found: ' . implode(' | ', $calls)
-		);
-
-		foreach ($calls as $i => $args) {
-			$firstArg = trim(explode(',', $args, 2)[0]);
-			$this->assertSame(
-				'$pfb_table',
-				$firstArg,
-				"call site #{$i} (pfBlockerNG_get_table({$args})) must pass \$pfb_table as its first positional argument"
-			);
-		}
+		$root = var_export(self::ROOT, TRUE);
+		$widget = var_export(self::WIDGET, TRUE);
+		$getCode = var_export($get, TRUE);
+		$postCode = var_export($post, TRUE);
+		$script = <<<PHP
+\$GLOBALS['argv'] = ['widget'];
+error_reporting(E_ERROR | E_PARSE);
+\$_GET = {$getCode};
+\$_POST = {$postCode};
+\$_SERVER = [];\$widgetname = 'pfblockerng';
+\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid();
+mkdir(\$shim, 0777, TRUE);
+file_put_contents(\$shim . '/guiconfig.inc', "<?php");
+set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+require {$root} . '/tests/php/bootstrap.php';
+require {$widget};
+echo 'after-include';
+PHP;
+		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
+		$this->assertIsResource($process);
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
+		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr];
 	}
 }

--- a/tests/php/WidgetPostAllowedTest.php
+++ b/tests/php/WidgetPostAllowedTest.php
@@ -2,89 +2,85 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * pfb_widget_post_allowed() — the dashboard widget's CSRF stand-in (issue #1050).
- *
- * pfblockerng.widget.php sets $nocsrf=TRUE for the whole endpoint (its read-only
- * AJAX GETs need no token), so its mutating POST handlers (pfb_submit,
- * pfblockerngack, and the three packet-count clears) gate on this instead: allow
- * a POST only when the Sec-Fetch-Site fetch metadata header proves it is
- * same-origin (or a direct navigation, 'none'). An ABSENT header is DENIED
- * (issue #1650): the earlier fail-open let any header-less/legacy client bypass
- * the guard entirely, so the gate is default-deny.
- *
- * widget-pfblockerng.inc carries no top-level pfSense-dependent execution (just
- * two title-string assignments plus this function), so it is require_once()d
- * directly -- unlike pfblockerng.widget.php's eval-extraction (WidgetAliasHiddenTest),
- * this file needs no page-runtime stripping.
- */
-#[CoversFunction('pfb_widget_post_allowed')]
 final class WidgetPostAllowedTest extends TestCase
 {
+	private const ROOT = __DIR__ . '/../..';
+	private const WIDGET = self::ROOT . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
+
 	public static function setUpBeforeClass(): void
 	{
-		if (function_exists('pfb_widget_post_allowed')) {
-			return;
-		}
 		require_once dirname(__DIR__, 2) . '/src/usr/local/www/widgets/include/widget-pfblockerng.inc';
 	}
 
-	/**
-	 * Full truth table: absent, 'same-origin', 'none', 'cross-site', 'same-site',
-	 * empty string.
-	 *
-	 * @return array<string,array{array<string,string>,bool}>
-	 */
+	/** @return array<string,array{array<string,string>,bool}> */
 	public static function truthTableProvider(): array
 	{
 		return [
-			'absent header -- denied (default-deny, issue #1650)' => [[], false],
-			"'same-origin' -- allowed"                     => [['HTTP_SEC_FETCH_SITE' => 'same-origin'], true],
-			"'none' -- allowed (direct navigation/bookmark)" => [['HTTP_SEC_FETCH_SITE' => 'none'], true],
-			"'cross-site' -- blocked"                       => [['HTTP_SEC_FETCH_SITE' => 'cross-site'], false],
-			"'same-site' -- blocked (not in the allowed set)" => [['HTTP_SEC_FETCH_SITE' => 'same-site'], false],
-			'empty string -- present but not an allowed token, blocked' => [['HTTP_SEC_FETCH_SITE' => ''], false],
+			'absent header' => [[], FALSE],
+			'same-origin' => [['HTTP_SEC_FETCH_SITE' => 'same-origin'], TRUE],
+			'none' => [['HTTP_SEC_FETCH_SITE' => 'none'], TRUE],
+			'cross-site' => [['HTTP_SEC_FETCH_SITE' => 'cross-site'], FALSE],
+			'same-site' => [['HTTP_SEC_FETCH_SITE' => 'same-site'], FALSE],
+			'empty' => [['HTTP_SEC_FETCH_SITE' => ''], FALSE],
 		];
 	}
 
-	/** @param array<string,string> $server */
 	#[DataProvider('truthTableProvider')]
-	public function testTruthTable(array $server, bool $expected): void
+	public function testGuardTruthTable(array $server, bool $expected): void
 	{
-		$this->assertSame(
-			$expected,
-			pfb_widget_post_allowed($server),
-			'pfb_widget_post_allowed(' . var_export($server, true) . ') expected ' . var_export($expected, true)
-		);
+		$this->assertSame($expected, pfb_widget_post_guard(['pfb_submit' => '1'], $server, 'pfb_submit'));
 	}
 
-	/**
-	 * Wiring pin (Sonnet review on PR #1061): EVERY mutating $_POST branch in
-	 * the widget's dispatch chain must call the guard -- a new handler added
-	 * without it silently reopens the cross-site hole #1050 closed.
-	 */
-	public function testEveryMutatingPostBranchCallsTheGuard(): void
+	/** @return array<string,array{string}> */
+	public static function mutationFields(): array
 	{
-		$widget = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php'
-		);
-		// Dispatch branches sit at one tab of indentation; nested validation reads
-		// (in_array($_POST[...]) inside pfb_submit) are deeper and excluded.
-		preg_match_all('/^\t(?:if|elseif)\s*\(([^\n]*\$_POST\[[^\n]*)\)\s*\{/m', $widget, $m);
-		$branches = $m[1];
-		$this->assertNotEmpty($branches, 'no $_POST dispatch branches found -- extraction regex broke');
-		foreach ($branches as $cond) {
-			$this->assertStringContainsString(
-				'pfb_widget_post_allowed($_SERVER)',
-				$cond,
-				"unguarded mutating \$_POST branch in pfblockerng.widget.php: {$cond}"
-			);
-		}
-		$this->assertGreaterThanOrEqual(5, count($branches),
-			'expected at least the 5 known mutating branches (pfb_submit, ack, 3 clears); got ' . count($branches));
+		return [
+			'settings' => ['pfb_submit'],
+			'failed' => ['pfblockerngack'],
+			'all counts' => ['pfblockerngclearall'],
+			'ip counts' => ['pfblockerngclearip'],
+			'dnsbl counts' => ['pfblockerngcleardnsbl'],
+		];
+	}
+
+	#[DataProvider('mutationFields')]
+	public function testEveryShippedMutationBranchStaysClosedWithoutFetchMetadata(string $field): void
+	{
+		$result = $this->runWidget([], [$field => '1']);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertStringContainsString('<form id="formicons"', $result['stdout']);
+	}
+
+	/** @return array{status:int,stdout:string,stderr:string} */
+	private function runWidget(array $get, array $post): array
+	{
+		$root = var_export(self::ROOT, TRUE);
+		$widget = var_export(self::WIDGET, TRUE);
+		$getCode = var_export($get, TRUE);
+		$postCode = var_export($post, TRUE);
+		$script = <<<PHP
+\$_GET = {$getCode};
+\$_POST = {$postCode};
+\$_SERVER = [];
+\$widgetname = 'pfblockerng';
+\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid();
+mkdir(\$shim, 0777, TRUE);
+file_put_contents(\$shim . '/guiconfig.inc', "<?php");
+set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+require {$root} . '/tests/php/bootstrap.php';
+require {$widget};
+PHP;
+		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
+		$this->assertIsResource($process);
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
+		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr];
 	}
 }

--- a/tests/php/WidgetSubmitPostGuardTest.php
+++ b/tests/php/WidgetSubmitPostGuardTest.php
@@ -68,8 +68,15 @@ require {$root} . '/tests/php/bootstrap.php';
 \$_POST = {$postCode};
 \$_SERVER = ['HTTP_SEC_FETCH_SITE' => 'same-origin'];
 \$widgetname = 'pfblockerng';
-\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid();
-mkdir(\$shim, 0777, TRUE);
+\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
+if (!mkdir(\$shim, 0700, TRUE)) {
+	fwrite(STDERR, "widget include shim creation failed\\n");
+	exit(1);
+}
+register_shutdown_function(static function () use (\$shim): void {
+	@unlink(\$shim . '/guiconfig.inc');
+	@rmdir(\$shim);
+});
 file_put_contents(\$shim . '/guiconfig.inc', "<?php");
 set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
 set_error_handler(static function (int \$severity, string \$message): bool {

--- a/tests/php/WidgetSubmitPostGuardTest.php
+++ b/tests/php/WidgetSubmitPostGuardTest.php
@@ -4,149 +4,95 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * Issue #1064 — the widget's pfb_submit branch must tolerate a POST with
- * per-field keys omitted: the outer isset($_POST['pfb_submit']) gates the
- * branch, not the keys, and a crafted POST (or a normal save with a checkbox
- * unchecked — an unchecked checkbox posts no key) raised one PHP 8.3
- * "Undefined array key" warning per missing field.
- *
- * Like PfbWidgetOracleTest, the widget file carries top-level page execution
- * and cannot be require()d off-appliance, so this eval-extracts the REAL
- * per-field section of the pfb_submit branch verbatim (up to the cron
- * section, whose comment is the unique end-anchor) — no reimplementation.
- */
+/** Issue #1064 — exercise the shipped widget submit branch, not its source text. */
 final class WidgetSubmitPostGuardTest extends TestCase
 {
-	/** Saved globals, restored in tearDown (issue #1063 hygiene). */
-	private mixed $savedPfb = null;
-	private array $savedPost = [];
+	private const ROOT = __DIR__ . '/../..';
+	private const WIDGET = self::ROOT . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
 
-	public static function setUpBeforeClass(): void
-	{
-		$src = file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php'
-		);
-		if ($src === false) {
-			throw new RuntimeException('test bootstrap: failed to read pfblockerng.widget.php');
-		}
-
-		if (!function_exists('pfb_widget_oracle_submit')) {
-			if (!preg_match(
-				'/pfb_widget_post_allowed\(\$_SERVER\)\) \{\n(.*?)(?=\n\n\t\t\/\/ Define pfBlockerNG clear)/s',
-				$src,
-				$m
-			)) {
-				throw new RuntimeException('test bootstrap: pfb_submit per-field section not found in widget source');
-			}
-			eval(
-				'function pfb_widget_oracle_submit(): array { global $pfb; ' . $m[1]
-				. ' return $pfb[\'wglobal\'] ?? []; }'
-			);
-		}
-	}
-
-	protected function setUp(): void
-	{
-		global $pfb;
-		$this->savedPfb  = $pfb ?? null;
-		$this->savedPost = $_POST;
-		$pfb['wglobal']    = [];
-		$pfb['dnsblquery'] = '60';
-	}
-
-	protected function tearDown(): void
-	{
-		global $pfb;
-		$pfb   = $this->savedPfb;
-		$_POST = $this->savedPost;
-	}
-
-	/** Run the extracted section, returning every PHP warning message it raised. */
-	private function runSubmit(array $post): array
-	{
-		$_POST = $post;
-		$warnings = [];
-		set_error_handler(
-			static function (int $errno, string $errstr) use (&$warnings): bool {
-				$warnings[] = $errstr;
-				return true;
-			},
-			E_WARNING | E_NOTICE
-		);
-		try {
-			pfb_widget_oracle_submit();
-		} finally {
-			restore_error_handler();
-		}
-		return $warnings;
-	}
-
-	/**
-	 * Scenario: crafted POST carrying only the submit marker.
-	 *
-	 * Given:  $_POST holding pfb_submit and none of the per-field keys
-	 * When:   the pfb_submit per-field section runs
-	 * Then:   no "Undefined array key" warning is raised for any field
-	 */
 	public function testCraftedPostMissingAllFieldsRaisesNoWarnings(): void
 	{
-		$warnings = $this->runSubmit(['pfb_submit' => 'save']);
-
-		$undefined = array_values(array_filter(
-			$warnings,
-			static fn (string $w): bool => str_contains($w, 'Undefined array key')
-		));
-		$this->assertSame(
-			[],
-			$undefined,
-			'per-field $_POST reads must tolerate omitted keys; got: ' . var_export($undefined, TRUE)
-		);
+		$result = $this->runWidget(['pfb_submit' => 'save']);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		foreach (['pfb_popup', 'pfb_sortmix', 'pfb_show_agg', 'pfb_sortcolumn', 'pfb_sortdir',
+			'pfb_clearip', 'pfb_cleardnsbl', 'pfb_dnsblquery', 'pfb_maxfails', 'pfb_maxheight'] as $field) {
+			$this->assertStringNotContainsString('Undefined array key "' . $field . '"', $result['stderr']);
+		}
+		$this->assertSame('', $result['state']['widget-popup'] ?? NULL);
+		$this->assertSame('', $result['state']['widget-sortmix'] ?? NULL);
+		$this->assertSame('', $result['state']['widget-show_agg'] ?? NULL);
 	}
 
-	/**
-	 * Scenario: full well-formed POST still applies every field.
-	 *
-	 * Given:  $_POST holding pfb_submit plus every per-field key with a valid value
-	 * When:   the pfb_submit per-field section runs
-	 * Then:   each widget-* setting reflects the posted value (the ?? '' guards
-	 *         must not swallow present fields)
-	 */
 	public function testFullPostStillAppliesValues(): void
 	{
-		$this->runSubmit([
-			'pfb_submit'     => 'save',
-			'pfb_popup'      => 'on',
-			'pfb_sortmix'    => 'on',
-			'pfb_show_agg'   => 'on',
+		$result = $this->runWidget([
+			'pfb_submit' => 'save',
+			'pfb_popup' => 'on',
+			'pfb_sortmix' => 'on',
+			'pfb_show_agg' => 'on',
 			'pfb_sortcolumn' => 'alias',
-			'pfb_sortdir'    => 'asc',
-			'pfb_clearip'    => 'daily',
+			'pfb_sortdir' => 'asc',
+			'pfb_clearip' => 'daily',
 			'pfb_cleardnsbl' => 'weekly',
 			'pfb_dnsblquery' => '60',
-			'pfb_maxfails'   => '5',
-			'pfb_maxheight'  => '200',
+			'pfb_maxfails' => '5',
+			'pfb_maxheight' => '200',
 		]);
-
-		global $pfb;
-		$expected = [
-			'widget-popup'      => 'on',
-			'widget-sortmix'    => 'on',
-			'widget-show_agg'   => 'on',
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertSame([
+			'widget-popup' => 'on',
+			'widget-sortmix' => 'on',
+			'widget-show_agg' => 'on',
 			'widget-sortcolumn' => 'alias',
-			'widget-sortdir'    => 'asc',
-			'widget-clearip'    => 'daily',
+			'widget-sortdir' => 'asc',
+			'widget-clearip' => 'daily',
 			'widget-cleardnsbl' => 'weekly',
 			'widget-dnsblquery' => '60',
-			'widget-maxfails'   => '5',
-			'widget-maxheight'  => '200',
-		];
-		foreach ($expected as $key => $value) {
-			$this->assertSame(
-				$value,
-				$pfb['wglobal'][$key] ?? null,
-				"widget setting {$key} must reflect the posted value"
-			);
-		}
+			'widget-maxfails' => '5',
+			'widget-maxheight' => '200',
+		], array_intersect_key($result['state'], array_flip([
+			'widget-popup', 'widget-sortmix', 'widget-show_agg', 'widget-sortcolumn', 'widget-sortdir',
+			'widget-clearip', 'widget-cleardnsbl', 'widget-dnsblquery', 'widget-maxfails', 'widget-maxheight',
+		])));
+	}
+
+	/** @return array{status:int,stderr:string,state:array<string,mixed>} */
+	private function runWidget(array $post): array
+	{
+		$root = var_export(self::ROOT, TRUE);
+		$widget = var_export(self::WIDGET, TRUE);
+		$postCode = var_export($post, TRUE);
+		$script = <<<PHP
+require {$root} . '/tests/php/bootstrap.php';
+\$_GET = [];
+\$_POST = {$postCode};
+\$_SERVER = ['HTTP_SEC_FETCH_SITE' => 'same-origin'];
+\$widgetname = 'pfblockerng';
+\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid();
+mkdir(\$shim, 0777, TRUE);
+file_put_contents(\$shim . '/guiconfig.inc', "<?php");
+set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+set_error_handler(static function (int \$severity, string \$message): bool {
+	fwrite(STDERR, \$severity . ': ' . \$message . "\\n");
+	return TRUE;
+});
+register_shutdown_function(static function (): void {
+	echo "\\n__PFB_STATE__" . json_encode(\$GLOBALS['pfb']['wglobal'] ?? []);
+});
+require {$widget};
+PHP;
+		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
+		$this->assertIsResource($process);
+		$stdout = (string) stream_get_contents($pipes[1]);
+		$stderr = (string) stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
+		$marker = strrpos($stdout, '__PFB_STATE__');
+		$this->assertIsInt($marker, $stdout);
+		$state = json_decode(substr($stdout, $marker + strlen('__PFB_STATE__')), TRUE, 512, JSON_THROW_ON_ERROR);
+		$this->assertIsArray($state);
+		return ['status' => $status, 'stderr' => $stderr, 'state' => $state];
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5756,7 +5756,7 @@
                 "name": "save",
                 "byRef": false,
                 "variadic": false,
-                "type": "bool",
+                "type": "mixed",
                 "default": null
             },
             {

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -3579,6 +3579,19 @@
             }
         ]
     },
+    "pfb_edit_hooks_default_state": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "redirect",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_edit_hooks_form_value": {
         "returnsRef": false,
         "returnType": "mixed",
@@ -6774,6 +6787,33 @@
             },
             {
                 "name": "tmo_prefix",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_list_script_cleanup_staged": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "parse_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "staged_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "known_path",
                 "byRef": false,
                 "variadic": false,
                 "type": "?string",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -494,6 +494,80 @@
             }
         ]
     },
+    "pfb_apply_geoip_orig_pipeline": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "source",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "orig",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "mirror",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "consumer",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_apply_gunzip_orig_pipeline": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "source",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "orig",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "consumer",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_apply_trailing_newline_ok": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_archive_member_names": {
         "returnsRef": false,
         "returnType": "?array",
@@ -709,6 +783,92 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_category_edit_js_asset_render": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'/usr/local/www/pfblockerng/pfBlockerNG.js'"
+            }
+        ]
+    },
+    "pfb_category_editor_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "sort",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_category_js_asset_render": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'/usr/local/www/pfblockerng/pfBlockerNG.js'"
+            }
+        ]
+    },
+    "pfb_category_script_pre_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "listPrefix",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "options",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_category_script_pre_settings": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "listPrefix",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "options",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
                 "default": null
             }
         ]
@@ -1219,6 +1379,91 @@
             }
         ]
     },
+    "pfb_dnsbl_alias_count_norm_skip": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "current",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_alias_count_rebuild": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "current",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_alias_count_script_failure": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "current",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_alias_count_verbatim": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "current",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_anchor_layout_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
     "pfb_dnsbl_apply_ledger_update": {
         "returnsRef": false,
         "returnType": "bool",
@@ -1432,6 +1677,26 @@
             }
         ]
     },
+    "pfb_dnsbl_custom_row": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "aliasname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
     "pfb_dnsbl_download_ledger_update": {
         "returnsRef": false,
         "returnType": "void",
@@ -1462,6 +1727,19 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_editor_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
                 "default": null
             }
         ]
@@ -1587,6 +1865,32 @@
             }
         ]
     },
+    "pfb_dnsbl_ipv4_count_decision": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_ipv6_count_decision": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_dnsbl_is_abp_rule_line": {
         "returnsRef": false,
         "returnType": "bool",
@@ -1610,6 +1914,19 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_js_asset_render": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'/usr/local/www/pfblockerng/pfBlockerNG.js'"
             }
         ]
     },
@@ -1849,6 +2166,13 @@
                 "variadic": false,
                 "type": "float",
                 "default": "5.0"
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
             }
         ]
     },
@@ -1864,6 +2188,16 @@
                 "default": null
             }
         ]
+    },
+    "pfb_dnsbl_regex_help_render": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_dnsbl_regex_help_text": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
     },
     "pfb_dnsbl_regex_validation_errors": {
         "returnsRef": false,
@@ -1903,6 +2237,46 @@
                 "variadic": false,
                 "type": "?string",
                 "default": "NULL"
+            }
+        ]
+    },
+    "pfb_dnsbl_regex_validation_required": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "interpreterUsable",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "featureToggle",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_regex_validation_required_page": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "interpreterUsable",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "featureToggle",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
             }
         ]
     },
@@ -2042,6 +2416,163 @@
             }
         ]
     },
+    "pfb_dnsbl_script_consume_staged": {
+        "returnsRef": false,
+        "returnType": "mixed",
+        "params": [
+            {
+                "name": "parse_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "staged_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "consumer",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            },
+            {
+                "name": "known_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_dnsbl_script_failure_close": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "state",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_script_failure_continue": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "update_marker",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "state",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "staging_current_generation",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "staged_txt",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "manifest",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_dnsbl_script_reuse_decision": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "verbatim_reuse_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "script_pre",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "script_post",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "orig_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_dnsbl_scrub_line": {
         "returnsRef": false,
         "returnType": "string",
@@ -2148,6 +2679,32 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_toggle_enabled": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_dnsbl_toggle_stored": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "posted",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
                 "default": null
             }
         ]
@@ -2481,6 +3038,19 @@
             }
         ]
     },
+    "pfb_download_extraction_succeeded": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "retval",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
     "pfb_download_failure": {
         "returnsRef": false,
         "returnType": null,
@@ -2529,6 +3099,54 @@
             }
         ]
     },
+    "pfb_download_finalize_text": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "orig_download",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "hash_base",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "hash_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "hash_write",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "transcode",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "newline",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_download_http_headers": {
         "returnsRef": false,
         "returnType": "array",
@@ -2546,6 +3164,92 @@
                 "variadic": false,
                 "type": "string",
                 "default": "''"
+            }
+        ]
+    },
+    "pfb_download_initial_retval": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": []
+    },
+    "pfb_download_ledger_close_if_clean": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "failed",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_download_ledger_failure": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "alias",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_download_retval_success": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "retval",
+                "byRef": false,
+                "variadic": false,
+                "type": "?int",
+                "default": null
             }
         ]
     },
@@ -2862,10 +3566,190 @@
             }
         ]
     },
+    "pfb_edit_hooks_access": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "allowed",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_edit_hooks_form_value": {
+        "returnsRef": false,
+        "returnType": "mixed",
+        "params": [
+            {
+                "name": "value",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_edit_hooks_submit_field": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "action",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_edit_hooks_tabs": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "active",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_edit_hooks_warning": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_editor_asset": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "asset",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
     "pfb_editor_enabled": {
         "returnsRef": false,
         "returnType": "bool",
         "params": []
+    },
+    "pfb_editor_mount_hook": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "language",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_editor_mount_lists": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_editor_mount_lists_for_sort": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "fields",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "sort",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_editor_mount_regex": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_editor_toggle_help": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_editor_toggle_label": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_editor_toggle_stored_value": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "posted",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
     },
     "pfb_emit_entry_reject_stats": {
         "returnsRef": false,
@@ -3619,6 +4503,149 @@
             }
         ]
     },
+    "pfb_general_editor_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_general_toggle_help": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_general_toggle_label": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_general_toggle_stored_value": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "posted",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_geoip_append_iso_data": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "cat",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "iso_file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "pfb_file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "build_tmp",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "iso",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "logger",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_geoip_doc_link": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
+    "pfb_geoip_js_asset_render": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'/usr/local/www/pfblockerng/pfBlockerNG.js'"
+            }
+        ]
+    },
+    "pfb_geoip_networks_header": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "iso_file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "country",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "geoip_id",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "iso",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_get_gateways": {
         "returnsRef": false,
         "returnType": null,
@@ -3940,6 +4967,26 @@
             }
         ]
     },
+    "pfb_hooks_editor_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "language",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_idn_to_ascii_wildcard": {
         "returnsRef": false,
         "returnType": "string",
@@ -3952,6 +4999,126 @@
                 "default": null
             }
         ]
+    },
+    "pfb_install_probe_cleanup": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "purge",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_install_registry_writeback": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "sections",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "pass",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "write_section",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "flush",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_install_settings_family_capture_restore": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "current",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "save",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "version",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "from_version",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "replace",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_install_settings_family_finalize": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "installed_family",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "migrations",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "record",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_ip_anchor_layout_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
     },
     "pfb_ip_apply_retry": {
         "returnsRef": false,
@@ -4016,6 +5183,19 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_editor_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
                 "default": null
             }
         ]
@@ -4116,6 +5296,19 @@
                 "variadic": false,
                 "type": null,
                 "default": null
+            }
+        ]
+    },
+    "pfb_ip_js_asset_render": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'/usr/local/www/pfblockerng/pfBlockerNG.js'"
             }
         ]
     },
@@ -4228,6 +5421,54 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_parse_line_replay": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "raw_line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "config",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "line_number",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "ip_data",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ip_suppressed",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "parse_fail",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
                 "default": null
             }
         ]
@@ -4366,6 +5607,40 @@
             }
         ]
     },
+    "pfb_ip_recompute_mark_ran": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "runner",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            },
+            {
+                "name": "ran_v4",
+                "byRef": true,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "ran_v6",
+                "byRef": true,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
     "pfb_ip_recompute_matrix": {
         "returnsRef": false,
         "returnType": "array",
@@ -4460,6 +5735,87 @@
             }
         ]
     },
+    "pfb_ip_recompute_order_families": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "dup_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_order_scope": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "save",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "enabled",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "dup_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "drep_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "prep_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_recompute_ran_for_vtype": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ran_v4",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "ran_v6",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
     "pfb_ip_recompute_seed_snapshot": {
         "returnsRef": false,
         "returnType": "string",
@@ -4541,6 +5897,38 @@
             }
         ]
     },
+    "pfb_ip_regex_config": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
+    "pfb_ip_regex_matches": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "family",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "line",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "config",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_ip_render_attribution": {
         "returnsRef": false,
         "returnType": "array",
@@ -4604,6 +5992,204 @@
             }
         ]
     },
+    "pfb_ip_script_consume_staged": {
+        "returnsRef": false,
+        "returnType": "mixed",
+        "params": [
+            {
+                "name": "parse_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "staged_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "consumer",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            },
+            {
+                "name": "known_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_ip_script_failure_close": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "state",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_script_failure_continue": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "update_marker",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "state",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "staging_current_generation",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "staged_txt",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "manifest",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_ip_script_probe_staged": {
+        "returnsRef": false,
+        "returnType": "mixed",
+        "params": [
+            {
+                "name": "custom",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "parse_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "staged_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "probe",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            },
+            {
+                "name": "known_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_ip_script_reuse_decision": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "verbatim_reuse_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "script_pre",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "script_post",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "orig_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_ip_suppress_body_active": {
         "returnsRef": false,
         "returnType": "bool",
@@ -4652,6 +6238,61 @@
             }
         ]
     },
+    "pfb_ip_suppress_body_for_vtype": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "supp_on",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "vtype",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "supp_update",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "adv",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "feed_changed",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "ran_v4",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "ran_v6",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            }
+        ]
+    },
     "pfb_ip_suppressed": {
         "returnsRef": false,
         "returnType": "bool",
@@ -4688,6 +6329,32 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_suppression_enabled": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_ip_suppression_stored": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "posted",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
                 "default": null
             }
         ]
@@ -4767,6 +6434,33 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            }
+        ]
+    },
+    "pfb_js_asset": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "src",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "attributes",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "''"
             }
         ]
     },
@@ -4971,6 +6665,40 @@
             }
         ]
     },
+    "pfb_lint_response": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "server",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "post",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "allowed",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            },
+            {
+                "name": "diagnostics",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            }
+        ]
+    },
     "pfb_lint_sh_diagnostics": {
         "returnsRef": false,
         "returnType": "array",
@@ -5053,6 +6781,40 @@
             }
         ]
     },
+    "pfb_list_script_consume_staged": {
+        "returnsRef": false,
+        "returnType": "mixed",
+        "params": [
+            {
+                "name": "parse_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "staged_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "consumer",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            },
+            {
+                "name": "known_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_list_script_exec": {
         "returnsRef": false,
         "returnType": "int",
@@ -5101,6 +6863,109 @@
             }
         ]
     },
+    "pfb_list_script_failure_close": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "state",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_list_script_failure_continue": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "update_marker",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "state",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "staging_current_generation",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "staged_txt",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "manifest",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_list_script_failure_record": {
         "returnsRef": false,
         "returnType": "void",
@@ -5139,6 +7004,13 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            },
+            {
+                "name": "state",
+                "byRef": true,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
             }
         ]
     },
@@ -5165,6 +7037,40 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "bool",
+                "default": null
+            }
+        ]
+    },
+    "pfb_list_script_reuse_decision": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "verbatim_reuse_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "script_pre",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "script_post",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "orig_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
                 "default": null
             }
         ]
@@ -5518,6 +7424,11 @@
                 "default": null
             }
         ]
+    },
+    "pfb_log_anchor_layout_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
     },
     "pfb_log_event": {
         "returnsRef": false,
@@ -6223,6 +8134,19 @@
             }
         ]
     },
+    "pfb_page_anchor_layout": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "page",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_parse_fail_log": {
         "returnsRef": false,
         "returnType": null,
@@ -6875,6 +8799,13 @@
                 "variadic": false,
                 "type": null,
                 "default": "false"
+            },
+            {
+                "name": "apply_ledger",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
             }
         ]
     },
@@ -8278,6 +10209,26 @@
         "returnType": "array",
         "params": []
     },
+    "pfb_top1m_apply_reprocess_if_ready": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "dbdir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "reprocess",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            }
+        ]
+    },
     "pfb_top1m_auth_headers": {
         "returnsRef": false,
         "returnType": "array",
@@ -8527,6 +10478,19 @@
                 "variadic": false,
                 "type": "array",
                 "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_top1m_teardown_call": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "teardown",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
             }
         ]
     },
@@ -9011,6 +10975,26 @@
             }
         ]
     },
+    "pfb_unbound_python_ini": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_unbound_python_sources": {
         "returnsRef": false,
         "returnType": null,
@@ -9328,6 +11312,26 @@
             }
         ]
     },
+    "pfb_update_tail_response": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "query",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "tail",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            }
+        ]
+    },
     "pfb_update_unbound": {
         "returnsRef": false,
         "returnType": null,
@@ -9359,6 +11363,26 @@
                 "variadic": false,
                 "type": "array",
                 "default": "array (\n)"
+            }
+        ]
+    },
+    "pfb_update_unbound_feed_count": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "counter",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
             }
         ]
     },
@@ -9820,6 +11844,73 @@
                 "variadic": false,
                 "type": null,
                 "default": null
+            }
+        ]
+    },
+    "pfb_widget_anchor_layout_render": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "page",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_widget_post_guard": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "post",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "server",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "field",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_widget_table_call": {
+        "returnsRef": false,
+        "returnType": "mixed",
+        "params": [
+            {
+                "name": "table",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "mode",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "''"
+            },
+            {
+                "name": "render",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
             }
         ]
     },

--- a/tests/php/fixtures/geoip_pre_move_golden.json
+++ b/tests/php/fixtures/geoip_pre_move_golden.json
@@ -29,18 +29,19 @@
     "ZZ_v4.txt": "454debca5afcd37addd0dcca05094625dcde6402510f8fc664cd567893ec7096"
   },
   "continent_pages": {
-    "pfblockerng_Africa.php": "189649e5d06a15aa844599018cfe1f4646b7a783477f5a014aa0b63d34a360d6",
-    "pfblockerng_Antarctica.php": "4e518efaa8fc5c74499d3ac7cfb55a9e84f7401e1bf171fd870b57d96f164166",
-    "pfblockerng_Asia.php": "9662c321eafaf641e836f2b377f6e18af6a7a1f02dbdd34ee1d02b644a136328",
-    "pfblockerng_Europe.php": "376f832ecf412a1a383e647536d7273812dfdd43fd6f779049f5b14c66380ac8",
-    "pfblockerng_North_America.php": "f4bd735c4536e5f5ac767bf3d576f649bfd24d553886a6eaee3d14018c5343f5",
-    "pfblockerng_Oceania.php": "d42eff86ccfa0e73ea39d0e8eb59e61b7150cb8423ac8c91945e8ec630794b66",
-    "pfblockerng_South_America.php": "4b4ff3e724f094994e31f9bfac8ef206b071299f60c488693ffdb4bf00bbb12e",
-    "pfblockerng_Proxy_and_Satellite.php": "d7469e2355203eaa46c090127551b36883735800328f19cc6a617eeb568d52b1",
-    "pfblockerng_Top_Spammers.php": "9802ff70600cfbf74f8f38d3dc2f2fccc1d60b7c62cb9aa6371b7d3c97fd7a5d"
+    "pfblockerng_Africa.php": "308442ad5185086b80810dccaca166e333d49e1d8f88d8cd24a50bf4c4bea32a",
+    "pfblockerng_Antarctica.php": "8e55cd2d836bdae45cfed1bfb3ca778dfd59097ed4ae357e2682def2a1716e31",
+    "pfblockerng_Asia.php": "e4d16675f7c6393c7e8d93b4d8ad76fdd943cb236e47438412914a2d347e864f",
+    "pfblockerng_Europe.php": "495f49c84868f33e6d5d79eebe0be3141ce71151d70885897a77d153fed9e3f9",
+    "pfblockerng_North_America.php": "c8eda77967c098825efc0ad67dbee84f16fe3af59a45a20b26bf4fccb141bef3",
+    "pfblockerng_Oceania.php": "b003b0937a271d74229e0a35a952e132d47817124204d2327dfb2b11d8267d59",
+    "pfblockerng_South_America.php": "a6b8a7c1eb42e39118d5046ce5d3ebb74009642a6c50792a5f1e623dd76c907a",
+    "pfblockerng_Proxy_and_Satellite.php": "43b8b297dbdbb9c5de31ca91cff33ec1588f2c0cc9a0f7eb23495fcd9cb55c62",
+    "pfblockerng_Top_Spammers.php": "e7e9dbbf0dc9f04ad7317341b3205eb16f686c6a285e050652780d216240dc8d"
   },
   "reputation_empty": "59a4fa81040c5691ddb1b13574dfe3669052530c0947535a74b30bb3af459b4e",
   "reputation_populated": "dcfe541ef16a5c9c74e8692354351bd9a78b52a17f3f50ea9b1efde42b240568",
   "continent_pages_amended": "issue #1845: the generated pages now carry the pfBlockerNG.js cache-buster; the pre-move template is otherwise unchanged",
-  "reputation_hashes_amended": "issue #1896: the Reputation section's config_get_path/config_set_path calls now route through PfbConfig::readSection()/writeSection(); the pre-move template is otherwise unchanged"
+  "reputation_hashes_amended": "issue #1896: the Reputation section's config_get_path/config_set_path calls now route through PfbConfig::readSection()/writeSection(); the pre-move template is otherwise unchanged",
+  "continent_behavior_amended": "issue #2103: generated pages route anchor layout and MaxMind documentation rendering through behavior-tested helpers"
 }

--- a/tests/smoke/ui/test_browser_hooks.py
+++ b/tests/smoke/ui/test_browser_hooks.py
@@ -1,15 +1,16 @@
 """Tier-B browser test: the Update sub-tabs (Run | Hooks | Edit Hooks).
 
 The browser half of the "Update Hooks moved under the Update tab" change: a headless
-Chromium on the live ADR-04 smoke VM opens ``pfblockerng_update.php`` and
-``pfblockerng_hooks.php`` (reusing the Phase-1 authenticated session — the injected
+Chromium on the live ADR-04 smoke VM opens each of the three linked pages
+(``pfblockerng_update.php``, ``pfblockerng_hooks.php``, and
+``pfblockerng_edit_hooks.php``; reusing the Phase-1 authenticated session — the injected
 ``PHPSESSID`` cookie, no second login) and asserts, per page:
 
 * the SECOND ``display_top_tabs`` row ``[Run | Hooks | Edit Hooks]`` is present (all sub-tab
   anchors, pointing at the update, hooks, and edit-hooks pages), and
 * the CURRENT page's sub-tab is the ACTIVE one (its ``<li>`` carries pfSense's
   ``active`` class — emitted by ``display_top_tabs`` for the highlighted tab) while
-  the sibling sub-tab is NOT active — so the highlight tracks the page (a real branch,
+  both sibling sub-tabs are NOT active — so the highlight tracks the page (a real branch,
   not an always-active tab).
 
 A per-page full-page screenshot is written to the ``screenshot_dir`` artifact tree
@@ -93,8 +94,8 @@ def _subtab_nav(page: Page) -> Locator:
 
     The main top bar carries an "Update" tab linking the update page but has NO hooks
     anchor (that top tab was removed by this change), so the sub-tab row is the only
-    ``<ul class="nav …">`` that contains BOTH the update-page anchor and the hooks-page
-    anchor -- filter on that. Version-tolerant (independent of nav-pills/nav-tabs).
+    ``<ul class="nav …">`` that contains all three sub-tab anchors -- filter on that.
+    Version-tolerant (independent of nav-pills/nav-tabs).
     """
     nav = page.locator("ul.nav")
     nav = nav.filter(has=page.locator(f'a[href="{UPDATE_PAGE}"]'))
@@ -132,22 +133,22 @@ def test_update_subtab_active_tracks_page(
     Given one of the three Update sub-tab pages opened,
     Then the second shared sub-tab row is present exactly once, carrying all three anchors,
     And the OPEN page's own sub-tab is the ACTIVE one (its ``<li>`` carries the ``active``
-      class ``display_top_tabs`` puts on the highlighted tab) while the SIBLING sub-tab is
-      NOT active -- so the highlight tracks the page (a real branch: Run is active on the
-      update page, hooks page, or edit-hooks page, and the other two are inactive).
+      class ``display_top_tabs`` puts on the highlighted tab) while both SIBLING sub-tabs
+      are NOT active -- so the highlight tracks the page (a real branch: the corresponding
+      page tab is active on each of the three pages, and the other two are inactive).
     A per-page screenshot is written for the visual record.
     """
     page = browser_page
     _open(page, webui, path)
 
-    # The sub-tab row exists exactly once -- the only nav carrying BOTH anchors.
+    # The sub-tab row exists exactly once -- the only nav carrying all three anchors.
     nav = _subtab_nav(page)
     expect(nav).to_have_count(1, timeout=JS_TIMEOUT_MS)
     expect(_subtab_anchor(nav, UPDATE_PAGE)).to_have_count(1, timeout=JS_TIMEOUT_MS)
     expect(_subtab_anchor(nav, HOOKS_PAGE)).to_have_count(1, timeout=JS_TIMEOUT_MS)
     expect(_subtab_anchor(nav, EDIT_HOOKS_PAGE)).to_have_count(1, timeout=JS_TIMEOUT_MS)
 
-    # The open page's sub-tab is ACTIVE; the sibling is not. pfSense's display_top_tabs
+    # The open page's sub-tab is ACTIVE; both siblings are not. pfSense's display_top_tabs
     # puts the `active` class on the highlighted tab's <li> (the anchor's parent) -- the
     # version-tolerant handle. Scope to the sub-tab row so the top bar's own "Update" tab
     # (also linking the update page) cannot confuse the match.

--- a/tests/smoke/ui/test_browser_hooks.py
+++ b/tests/smoke/ui/test_browser_hooks.py
@@ -1,12 +1,12 @@
-"""Tier-B browser test: the Update sub-tabs (Run | Hooks).
+"""Tier-B browser test: the Update sub-tabs (Run | Hooks | Edit Hooks).
 
 The browser half of the "Update Hooks moved under the Update tab" change: a headless
 Chromium on the live ADR-04 smoke VM opens ``pfblockerng_update.php`` and
 ``pfblockerng_hooks.php`` (reusing the Phase-1 authenticated session — the injected
 ``PHPSESSID`` cookie, no second login) and asserts, per page:
 
-* the SECOND ``display_top_tabs`` row ``[Run | Hooks]`` is present (both sub-tab
-  anchors, pointing at the update and hooks pages), and
+* the SECOND ``display_top_tabs`` row ``[Run | Hooks | Edit Hooks]`` is present (all sub-tab
+  anchors, pointing at the update, hooks, and edit-hooks pages), and
 * the CURRENT page's sub-tab is the ACTIVE one (its ``<li>`` carries pfSense's
   ``active`` class — emitted by ``display_top_tabs`` for the highlighted tab) while
   the sibling sub-tab is NOT active — so the highlight tracks the page (a real branch,
@@ -23,8 +23,8 @@ HTTP-body oracle cannot see. No ``src/`` change here.
 DOM-FRAGILITY NOTE: ``display_top_tabs`` renders each tab row as a ``<ul class="nav
 …">``; the page has TWO (the main top bar + this sub-tab row). The top bar links the
 update page (its "Update" tab) but NOT the hooks page (that tab was removed), so the
-sub-tab row is the ONLY ``<ul class="nav …">`` carrying BOTH the update-page anchor
-AND the hooks-page anchor — we locate that row first (``_subtab_nav``) and scope the
+sub-tab row is the ONLY ``<ul class="nav …">`` carrying the update, hooks, and edit-hooks
+anchors — we locate that row first (``_subtab_nav``) and scope the
 presence/active assertions to it. The load-bearing, version-tolerant handles are the
 anchor ``href`` and the ``active`` class on the highlighted ``<li>`` — not a brittle
 DOM path.
@@ -55,9 +55,10 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.ui_browser
 
-# The two pages the Update sub-tab row links (each renders the same [Run | Hooks] row).
+# The three pages the Update sub-tab row links (each renders the same row).
 UPDATE_PAGE = "/pfblockerng/pfblockerng_update.php"
 HOOKS_PAGE = "/pfblockerng/pfblockerng_hooks.php"
+EDIT_HOOKS_PAGE = "/pfblockerng/pfblockerng_edit_hooks.php"
 
 # A short, explicit timeout (ms): the page renders server-side, so this is a flake
 # ceiling for the post-load DOM, not a wait knob.
@@ -88,7 +89,7 @@ def _shot(page: Page, screenshot_dir: Path, name: str) -> None:
 
 
 def _subtab_nav(page: Page) -> Locator:
-    """The SECOND ``display_top_tabs`` row -- the ``[Run | Hooks]`` sub-tab ``<ul>``.
+    """The SECOND ``display_top_tabs`` row -- the shared sub-tab ``<ul>``.
 
     The main top bar carries an "Update" tab linking the update page but has NO hooks
     anchor (that top tab was removed by this change), so the sub-tab row is the only
@@ -97,7 +98,8 @@ def _subtab_nav(page: Page) -> Locator:
     """
     nav = page.locator("ul.nav")
     nav = nav.filter(has=page.locator(f'a[href="{UPDATE_PAGE}"]'))
-    return nav.filter(has=page.locator(f'a[href="{HOOKS_PAGE}"]'))
+    nav = nav.filter(has=page.locator(f'a[href="{HOOKS_PAGE}"]'))
+    return nav.filter(has=page.locator(f'a[href="{EDIT_HOOKS_PAGE}"]'))
 
 
 def _subtab_anchor(nav: Locator, href: str) -> Locator:
@@ -106,10 +108,11 @@ def _subtab_anchor(nav: Locator, href: str) -> Locator:
 
 
 @pytest.mark.parametrize(
-    ("path", "active_href", "other_href", "name"),
+    ("path", "active_href", "other_hrefs", "name"),
     [
-        (UPDATE_PAGE, UPDATE_PAGE, HOOKS_PAGE, "run"),
-        (HOOKS_PAGE, HOOKS_PAGE, UPDATE_PAGE, "hooks"),
+        (UPDATE_PAGE, UPDATE_PAGE, (HOOKS_PAGE, EDIT_HOOKS_PAGE), "run"),
+        (HOOKS_PAGE, HOOKS_PAGE, (UPDATE_PAGE, EDIT_HOOKS_PAGE), "hooks"),
+        (EDIT_HOOKS_PAGE, EDIT_HOOKS_PAGE, (UPDATE_PAGE, HOOKS_PAGE), "edit-hooks"),
     ],
 )
 def test_update_subtab_active_tracks_page(
@@ -118,22 +121,20 @@ def test_update_subtab_active_tracks_page(
     screenshot_dir: Path,
     path: str,
     active_href: str,
-    other_href: str,
+    other_hrefs: tuple[str, ...],
     name: str,
 ) -> None:
-    """The [Run | Hooks] sub-tab row renders and highlights the sub-tab of the open page.
+    """The shared sub-tab row renders and highlights the sub-tab of the open page.
 
-    Scenario (one parametrization per page -- BOTH sub-tabs are exercised as the active
+    Scenario (one parametrization per page -- all three sub-tabs are exercised as the active
     one, so this is full branch coverage of the active-state, not just one side):
 
-    Given the Update Run page (``pfblockerng_update.php``) OR the Hooks page
-      (``pfblockerng_hooks.php``) opened,
-    Then the second ``[Run | Hooks]`` sub-tab row is present exactly once, carrying both
-      the Run (update-page) and Hooks (hooks-page) anchors,
+    Given one of the three Update sub-tab pages opened,
+    Then the second shared sub-tab row is present exactly once, carrying all three anchors,
     And the OPEN page's own sub-tab is the ACTIVE one (its ``<li>`` carries the ``active``
       class ``display_top_tabs`` puts on the highlighted tab) while the SIBLING sub-tab is
       NOT active -- so the highlight tracks the page (a real branch: Run is active on the
-      update page and inactive on the hooks page, and vice-versa).
+      update page, hooks page, or edit-hooks page, and the other two are inactive).
     A per-page screenshot is written for the visual record.
     """
     page = browser_page
@@ -144,6 +145,7 @@ def test_update_subtab_active_tracks_page(
     expect(nav).to_have_count(1, timeout=JS_TIMEOUT_MS)
     expect(_subtab_anchor(nav, UPDATE_PAGE)).to_have_count(1, timeout=JS_TIMEOUT_MS)
     expect(_subtab_anchor(nav, HOOKS_PAGE)).to_have_count(1, timeout=JS_TIMEOUT_MS)
+    expect(_subtab_anchor(nav, EDIT_HOOKS_PAGE)).to_have_count(1, timeout=JS_TIMEOUT_MS)
 
     # The open page's sub-tab is ACTIVE; the sibling is not. pfSense's display_top_tabs
     # puts the `active` class on the highlighted tab's <li> (the anchor's parent) -- the
@@ -151,7 +153,8 @@ def test_update_subtab_active_tracks_page(
     # (also linking the update page) cannot confuse the match.
     active_li = _subtab_anchor(nav, active_href).locator("xpath=ancestor::li[1]")
     expect(active_li).to_have_class(re.compile(r"\bactive\b"), timeout=JS_TIMEOUT_MS)
-    other_li = _subtab_anchor(nav, other_href).locator("xpath=ancestor::li[1]")
-    expect(other_li).not_to_have_class(re.compile(r"\bactive\b"), timeout=JS_TIMEOUT_MS)
+    for other_href in other_hrefs:
+        other_li = _subtab_anchor(nav, other_href).locator("xpath=ancestor::li[1]")
+        expect(other_li).not_to_have_class(re.compile(r"\bactive\b"), timeout=JS_TIMEOUT_MS)
 
     _shot(page, screenshot_dir, f"update_subtab_{name}")

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -643,18 +643,18 @@ _LOG_PAGE = "/pfblockerng/pfblockerng_log.php"
 
 
 def test_update_hooks_subtab_relocation(webui: WebUI) -> None:
-    """Update Hooks moved from a top-level tab to an Update sub-tab (Run | Hooks).
+    """Update Hooks moved from a top-level tab to an Update sub-tab row.
 
     The standalone 'Update Hooks' top tab was replaced by a second display_top_tabs
-    row under Update — Run -> the update page, Hooks -> the hooks page (the same
+    row under Update — Run -> the update page, Hooks -> the hooks page, Edit Hooks ->
+    the gated editor (the same
     sub-tab idiom the Feeds page uses). Assert the new shape AND that the old
     top-level tab is gone (hermetic — all three pages render from local config).
 
     Given the restructured tabs,
     When GET pfblockerng_update.php and pfblockerng_hooks.php,
-    Then each renders the sub-tab row: a 'Run' anchor and a 'Hooks' anchor, with the
-      Hooks one linking the hooks page and the Run one linking the update page (both
-      anchors are NEW — neither page exposed a 'Run' or bare 'Hooks' tab before).
+    Then each renders the sub-tab row: 'Run', 'Hooks', and 'Edit Hooks' anchors with
+      the expected links.
     And the old standalone 'Update Hooks' tab is gone: it is ABSENT from the update
       page entirely, and from the General witness page (a page that is neither Update
       nor Hooks) — while that page keeps its 'Update' top tab. The absence is the
@@ -663,25 +663,29 @@ def test_update_hooks_subtab_relocation(webui: WebUI) -> None:
       move. (The hooks page itself still contains the literal 'Update Hooks' in its
       Form_Section title, so absence is asserted on the update + witness pages, not it.)
 
-    The active-tab-tracks-the-page branch (Run active on the update page, Hooks active
-    on the hooks page) is the Tier-B browser half (test_browser_hooks.py).
+    The active-tab-tracks-the-page branch (Run, Hooks, or Edit Hooks active on its page)
+    is the Tier-B browser half (test_browser_hooks.py).
     """
-    # --- Run page (pfblockerng_update.php): both sub-tabs render; old top tab gone. ---
+    # --- Run page (pfblockerng_update.php): all sub-tabs render; old top tab gone. ---
     body = webui.get(_UPDATE_PAGE).text
     assert ">Run</a>" in body, "update page is missing the 'Run' sub-tab anchor"
     assert ">Hooks</a>" in body, "update page is missing the 'Hooks' sub-tab anchor"
+    assert ">Edit Hooks</a>" in body, "update page is missing the 'Edit Hooks' sub-tab anchor"
     assert _HOOKS_PAGE in body, "update page 'Hooks' sub-tab does not link the hooks page"
+    assert _EDIT_HOOKS_PAGE in body, "update page 'Edit Hooks' sub-tab does not link the editor page"
     # "Update Hooks" is a tab-nav guard: the removed top tab was the ONLY occurrence of
     # that literal on the update page, so its absence proves the tab is gone. (If future
     # help text on this page ever references the hooks page by that name, narrow this to
     # the nav element rather than the whole body.)
     assert "Update Hooks" not in body, "stale 'Update Hooks' top-level tab still rendered on the update page"
 
-    # --- Hooks page (pfblockerng_hooks.php): both sub-tabs render. ---
+    # --- Hooks page (pfblockerng_hooks.php): all sub-tabs render. ---
     body = webui.get(_HOOKS_PAGE).text
     assert ">Run</a>" in body, "hooks page is missing the 'Run' sub-tab anchor"
     assert ">Hooks</a>" in body, "hooks page is missing the 'Hooks' sub-tab anchor"
+    assert ">Edit Hooks</a>" in body, "hooks page is missing the 'Edit Hooks' sub-tab anchor"
     assert _UPDATE_PAGE in body, "hooks page 'Run' sub-tab does not link the update page"
+    assert _EDIT_HOOKS_PAGE in body, "hooks page 'Edit Hooks' sub-tab does not link the editor page"
 
     # --- Witness page (General): the 'Update Hooks' top tab is gone; 'Update' remains. ---
     body = webui.get(_GENERAL_PAGE).text
@@ -773,6 +777,13 @@ def test_update_page_cron_status_without_flag_never_misreports_missing_cron(
         touch = smoke_vm.ssh("/usr/bin/touch", flag)
         if touch.returncode != 0:
             raise AssertionError(f"failed to restore {flag}: rc={touch.returncode} {touch.stderr!r}")
+
+
+def test_geoip_page_renders_current_maxmind_document_link(webui: WebUI) -> None:
+    """Generated continent output proves the shared document-link call ran."""
+    body = webui.get("/pfblockerng/pfblockerng_Africa.php").text
+    assert 'href="https://dev.maxmind.com/geoip/whats-new-in-geoip2/"' in body
+    assert "https://dev.maxmind.com/geoip/geoip2/whats-new-in-geoip2/" not in body
 
 
 def test_geoip_pages_render_the_seeded_csv_rows(


### PR DESCRIPTION
## Summary

- audit every PHP suite that reads production source and record all 134 suites in one enforced ledger
- replace 31 wiring scanners with behavioral seams and assertions whose effects occur only when the required production call runs
- keep 53 existing source-execution suites behavioral while making their extraction boundaries comment-independent
- retain 42 comment-free executable-code pins only where destructive, appliance-only, off-limits, or inherently whole-tree behavior cannot be safely observed here; each retained pin has an explicit reason
- exclude eight source readers that are not wiring assertions, with an explicit classification
- remove three test-only production wrappers and contain destructive hook-editor operations in the existing page-only include
- preserve legacy order-recompute truthiness when the live `save` flag is absent

**PRODUCTION COMMENTS AND DOCBLOCKS MUST NEVER BE LOAD-BEARING FOR A TEST.**

The policy regression rewrites every production PHP comment and docblock, including generated PHP comments embedded in strings, then runs all 53 source-execution suites against the mutated copy. A separate focused regression proves a nearby comment rewording cannot change retained executable-code pins.

The authoritative suite-by-suite audit and retained-pin reasons live in `tests/php/SourceScanningWiringPolicyTest.php`.

Fixes #2103

## Test evidence

- frozen RED→GREEN: stale list-script `.pre` cleanup (`ListScriptExitStatusTest.php`)
- frozen RED→GREEN: absent live recompute `save` flag (`IpRecomputeOrderChangeTest.php`)
- RED→GREEN policy mutation: the 17 comment-dependent source-execution extractors fail before conversion and all 53 pass unchanged after conversion
- `scripts/agent/run-gates.sh --diff origin/devel`
- `pytest -q tests/smoke/ui_render -m ui_render`: 47 passed, 149 skipped, 393 deselected
- exact-head live smoke: 279 selected cases after excluding the known setup-failing cases already tracked by #2071 and #2072; exact current-`devel` controls reproduced both defects
- independent settled-head adversarial review: PASS, no blockers

No production files in the issue's Alerts, scheduling, or Python off-limits surfaces changed.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized code editors across General, IP, DNSBL, Category, and Edit Hooks pages.
  * Added Edit Hooks navigation with create, edit, save, load, and delete workflows.
  * Improved widget actions, page navigation, and GeoIP documentation links.

* **Bug Fixes**
  * Improved feed reliability by preserving valid data after failures and cleaning temporary files.
  * Improved DNSBL/IP toggle handling and synchronization of DNS filtering rules.
  * Improved download, GeoIP, Unbound, and recompute processing consistency.
  * Strengthened widget actions and lint request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->