### PR TITLE
tests: fix torn-sample and alias-rule diagnostics

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4857,7 +4857,10 @@ def pfctl_rule_has_alias(vm: SmokeVM, alias: str, *, timeout: float = 30.0) -> b
 
 def _rule_line_has_alias(line: str, alias: str) -> bool:
     """Return whether one ruleset line references table ``alias``."""
-    return f"<{alias}>" in line or (alias.startswith("pfB_") and alias in line)
+    escaped = re.escape(alias)
+    if re.search(rf"<{escaped}>", line):
+        return True
+    return alias.startswith("pfB_") and re.search(rf"(?<![A-Za-z0-9_]){escaped}(?![A-Za-z0-9_])", line) is not None
 
 
 def wait_until(predicate: Callable[[], bool], *, timeout: float = 12.0, interval: float = 2.0) -> bool:

--- a/tests/test_adr10_concurrency.py
+++ b/tests/test_adr10_concurrency.py
@@ -476,6 +476,15 @@ def _matching_applied_generation(
     return after if got == expected else None
 
 
+def _torn_sample(
+    got: dict[str, bool], expected_gen1: dict[str, bool], expected_gen2: dict[str, bool]
+) -> dict[str, dict[str, bool]]:
+    return {
+        "not_gen1": {n: got[n] for n in got if got[n] != expected_gen1[n]},
+        "not_gen2": {n: got[n] for n in got if got[n] != expected_gen2[n]},
+    }
+
+
 # --------------------------------------------------------------------------- #
 # THE test
 # --------------------------------------------------------------------------- #
@@ -530,7 +539,7 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
     stop = threading.Event()
     errors: list[str] = []
     stats: list[dict[str, int]] = []
-    _torn_samples: list[dict[str, bool]] = []
+    _torn_samples: list[dict[str, dict[str, bool]]] = []
     n_threads = 6
     observed_condition = threading.Condition()
     observed_generations = [0] * n_threads
@@ -572,11 +581,9 @@ def test_atomic_swap_no_torn_across_every_matcher_mechanism(tmp_path: Any, monke
                 else:
                     local["torn"] += 1  # a mixed view -- the atomic swap must prevent this
                     if len(_torn_samples) < 4:
-                        # Capture which domains diverge from BOTH oracles, to make a
+                        # Capture which domains diverge from each oracle, to make a
                         # failure self-explanatory (which lane tore).
-                        _torn_samples.append(
-                            {n: got[n] for n in _PROBE_NAMES if got[n] not in (expected_gen1[n], expected_gen2[n])}
-                        )
+                        _torn_samples.append(_torn_sample(got, expected_gen1, expected_gen2))
                 applied_generation = _matching_applied_generation(
                     applied_before,
                     P._reload_read_generation(applied),

--- a/tests/test_adr10_concurrency_diagnostics.py
+++ b/tests/test_adr10_concurrency_diagnostics.py
@@ -1,0 +1,39 @@
+"""Regression coverage for ADR-10 torn-scan diagnostics."""
+
+from __future__ import annotations
+
+from tests import test_adr10_concurrency as concurrency
+
+
+def test_torn_sample_reports_divergence_from_each_complete_generation() -> None:
+    expected_gen1 = {
+        "block.gen1.example": True,
+        "allow.gen1.example": False,
+        "block.gen2.example": True,
+        "allow.gen2.example": False,
+        "control.example": True,
+    }
+    expected_gen2 = {
+        "block.gen1.example": False,
+        "allow.gen1.example": True,
+        "block.gen2.example": False,
+        "allow.gen2.example": True,
+        "control.example": True,
+    }
+    got = {
+        "block.gen1.example": True,
+        "allow.gen1.example": False,
+        "block.gen2.example": False,
+        "allow.gen2.example": True,
+        "control.example": True,
+    }
+
+    assert got["block.gen1.example"] is True
+    assert got["allow.gen1.example"] is False
+    assert got["block.gen2.example"] is False
+    assert got["allow.gen2.example"] is True
+    assert got["control.example"] is True
+    assert concurrency._torn_sample(got, expected_gen1, expected_gen2) == {
+        "not_gen1": {"block.gen2.example": False, "allow.gen2.example": True},
+        "not_gen2": {"block.gen1.example": True, "allow.gen1.example": False},
+    }

--- a/tests/test_smoke_alias_rule_dump.py
+++ b/tests/test_smoke_alias_rule_dump.py
@@ -389,6 +389,37 @@ def test_public_dump_uses_exact_alias_match(monkeypatch: pytest.MonkeyPatch) -> 
     assert generic not in dump
 
 
+@pytest.mark.parametrize(
+    ("live_rules", "alias", "expected"),
+    [
+        ("block drop in quick from <pfB_Foo_v4> to any", "pfB_Foo_v4", True),
+        ("block drop in quick from <pfB_Foo_v4_other_v4> to any", "pfB_Foo_v4", False),
+        ("block drop in quick from <pfB_Other_v4> to any", "pfB_Foo_v4", False),
+        ("block drop in quick from pfB_Foo_v4, to any", "pfB_Foo_v4", True),
+        ("block drop in quick from pfB_Foo_v4_other_v4 to any", "pfB_Foo_v4", False),
+        ("block drop in quick from harness to any", "harness", False),
+        ("block drop in quick from <harness> to any", "harness", True),
+        # Bare-token matching must quote an unvalidated alias before compiling it as regex.
+        ("block drop in quick from pfB_FooXv4 to any", "pfB_Foo.v4", False),
+    ],
+    ids=[
+        "exact-angle-token",
+        "longer-angle-token",
+        "foreign-angle-token",
+        "bare-token-punctuation-boundary",
+        "longer-bare-token",
+        "generic-bare-word",
+        "generic-angle-token",
+        "metacharacter-is-literal",
+    ],
+)
+def test_pfctl_rule_has_alias_matches_complete_tokens(live_rules: str, alias: str, expected: bool) -> None:
+    """Match only the complete requested table token in an authoritative pfctl snapshot."""
+    actual = helpers.pfctl_rule_has_alias(_FakeVM(live_rules=live_rules), alias)  # type: ignore[arg-type]
+
+    assert actual == expected, f"alias={alias!r} live_rules={live_rules!r}: expected {expected}, got {actual}"
+
+
 def test_no_retired_pf_poll_names_remain() -> None:
     """Every Python smoke file must use sync boundaries plus one-shot reads."""
     retired = ["_".join(("wait", "pfctl", "table")), "_".join(("rule", "references"))]


### PR DESCRIPTION
## Summary

- report ADR-10 mixed-generation samples as observed probe values that differ from each complete generation oracle
- match smoke rules on complete alias tokens, including identifier-bounded bare `pfB_` forms, without longer-prefix false positives

## Red to green

- #2066: frozen `tests/test_adr10_concurrency_diagnostics.py` (`5f8180144061df876e711dd70ed2e562952d671b`) failed with an empty sample against `e05b21c7`, then passed unchanged at issue commit `3ef019f2`; normal ADR-10 concurrency: 4 passed
- #2068: frozen `tests/test_smoke_alias_rule_dump.py` (`1cfb77fa9fb81f8d9e2535d305d55611e9e62a35`) failed 2 prefix rows against `3ef019f2`, then passed all 8 unchanged at issue commit `c5c26205`; full alias diagnostic suite: 39 passed

## Verification

- both independent per-step red-proof replays: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`
- exact-head `scripts/agent/run-gates.sh --diff origin/devel`: pytest, Ruff check, Ruff format, and mypy passed
- #2068 issue reproduction after fix: `actual=False expected=False`

Fixes #2066
Fixes #2068

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
