### PR TITLE
pfblockerng: reconcile Alerts truncation semantics

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1910,7 +1910,7 @@ function pfb_stat_hostname_cell($resolved) {
 	$full = pfb_hsc($resolved);
 	if (mb_strlen($resolved, 'UTF-8') >= 45) {
 		$title = "title=\"{$full}\"";
-		$cell  = pfb_hsc(mb_substr($resolved, 0, 45, 'UTF-8')) . "<small>...</small>";
+		$cell  = pfb_hsc(pfb_truncate($resolved, 45)) . "<small>...</small>";
 	} else {
 		$title = '';
 		$cell  = $full;

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1908,7 +1908,7 @@ function pfb_truncate($value, $length) {
 function pfb_stat_hostname_cell($resolved) {
 	$resolved = (string) $resolved;
 	$full = pfb_hsc($resolved);
-	if (strlen($resolved) >= 45) {
+	if (mb_strlen($resolved, 'UTF-8') >= 45) {
 		$title = "title=\"{$full}\"";
 		$cell  = pfb_hsc(mb_substr($resolved, 0, 45, 'UTF-8')) . "<small>...</small>";
 	} else {
@@ -2245,7 +2245,7 @@ function convert_dnsbl_log($mode, $fields) {
 	$hostname = array_key_exists($fields[3], $local_hosts) ? $local_hosts[$fields[3]] : '';
 	if (!empty($hostname)) {
 		$h_title		= '';
-		if (strlen($hostname) >= 25) {
+		if (mb_strlen($hostname, 'UTF-8') >= 25) {
 			$h_title	= pfb_hsc($hostname);
 			$hostname	= pfb_hsc(pfb_truncate($hostname, 24)) . "<small>...</small>";
 		} else {
@@ -2263,7 +2263,7 @@ function convert_dnsbl_log($mode, $fields) {
 	if (strpos($f2, 'xn--') !== FALSE) {
 		$f2 = "{$f2} [" . idn_to_utf8($f2) . "]";
 	}
-	if (strlen($f2) >= ($mode != 'Unified' ? 60 : 40)) {
+	if (mb_strlen($f2, 'UTF-8') >= ($mode != 'Unified' ? 60 : 40)) {
 		$f2 = pfb_hsc(pfb_truncate($f2, ($mode != 'Unified' ? 59 : 39))) . "<small>...</small>";
 	} else {
 		$f2 = pfb_hsc($f2);
@@ -2274,7 +2274,7 @@ function convert_dnsbl_log($mode, $fields) {
 		if (strpos($f7, 'xn--') !== FALSE) {
 			$f7		= "{$f7} [" . idn_to_utf8($f7) . "]";
 		}
-		if (strlen($f7) >= ($mode != 'Unified' ? 52 : 32)) {
+		if (mb_strlen($f7, 'UTF-8') >= ($mode != 'Unified' ? 52 : 32)) {
 			$f7		= pfb_hsc(pfb_truncate($f7, ($mode != 'Unified' ? 51 : 31))) . "<small>...</small>";
 		} else {
 			$f7		= pfb_hsc($f7);
@@ -2322,7 +2322,7 @@ function convert_dnsbl_log($mode, $fields) {
 	}
 
 	if (!empty($fields[4])) {
-		if (strlen($fields[4]) >= 25) {
+		if (mb_strlen($fields[4], 'UTF-8') >= 25) {
 			$f4 = pfb_hsc(pfb_truncate($fields[4], 24)) . "<small>...</small>";
 			$fields[4] = "<span title=\"" . pfb_hsc($fields[4]) . "\">{$f4}</span>";
 		} else {
@@ -2516,7 +2516,7 @@ function convert_dns_reply_log($mode, $fields) {
 
 	$hostname = $local_hosts[$fields[7]] ?: '';
 	$title_hostname = '';
-	if (!empty($hostname) && strlen($hostname) >= 25) {
+	if (!empty($hostname) && mb_strlen($hostname, 'UTF-8') >= 25) {
 		$title_hostname = pfb_hsc($hostname);
 		$hostname	= pfb_hsc(pfb_truncate($hostname, 24)) . "<small>...</small>";
 	} else {
@@ -2598,7 +2598,7 @@ function convert_dns_reply_log($mode, $fields) {
 
 	// Truncate long TTLs
 	$pfb_title5 = '';
-	if (strlen($fields[5]) >= 6) {
+	if (mb_strlen($fields[5], 'UTF-8') >= 6) {
 		$pfb_title5	= pfb_hsc($fields[5]);
 		$fields[5]	= pfb_hsc(pfb_truncate($fields[5], 5)) . "<small>...</small>";
 	} else {
@@ -2607,7 +2607,7 @@ function convert_dns_reply_log($mode, $fields) {
 
 	// Truncate long Domain names
 	$pfb_title6 = '';
-	if (strlen($fields[6]) >= ($mode != 'Unified' ? 45 : 30)) {
+	if (mb_strlen($fields[6], 'UTF-8') >= ($mode != 'Unified' ? 45 : 30)) {
 		$pfb_title6	= pfb_hsc($fields[6]);
 		$fields[6]	= pfb_hsc(pfb_truncate($fields[6], ($mode != 'Unified' ? 44 : 29))) . "<small>...</small>";
 	} else {
@@ -2616,7 +2616,7 @@ function convert_dns_reply_log($mode, $fields) {
 
 	// Truncate long Resolved names
 	$pfb_title8 = '';
-	if (strlen($fields[8]) >= 17) {
+	if (mb_strlen($fields[8], 'UTF-8') >= 17) {
 		$pfb_title8	= pfb_hsc($fields[8]);
 		$fields[8]	= pfb_hsc(pfb_truncate($fields[8], 16)) . "<small>...</small>";
 	} else {
@@ -3079,7 +3079,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 		$fields[98] = pfb_hsc($fields[8]);
 	}
 
-	if (strlen($fields[15]) >= 17) {
+	if (mb_strlen($fields[15], 'UTF-8') >= 17) {
 		if (!empty($pfb_matchtitle)) {
 			$pfb_matchtitle .= '&#013;';
 		}
@@ -3088,7 +3088,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	} else {
 		$fields[15]	= pfb_hsc($fields[15]);
 	}
-	if (strlen($feed_new) >= 17) {
+	if (mb_strlen($feed_new, 'UTF-8') >= 17) {
 		if (!empty($pfb_matchtitle)) {
 			$pfb_matchtitle .= '&#013;';
 		}

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -3101,13 +3101,6 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 	$fields[14]		= pfb_hsc($fields[14]);
 	$feed_match_cell	= pfb_ip_feed_match_cell($fields[15], $feed_new, $fields[14], pfb_hsc($eval_new));
 
-	if (empty($fields[16])) {
-		$fields[16] = 'Unknown';
-	}
-	elseif (strlen($fields[16]) >= 22) {
-		$fields[16] = "<span title=\"" . pfb_hsc($fields[16]) . "\">" . pfb_hsc(pfb_truncate($fields[16], 21)) . "<small>...</small></span>";
-	}
-
 	// Interface / Protocol / GeoIP code / Timestamp printed verbatim
 	$fields[2]	= pfb_hsc($fields[2]);
 	$fields[6]	= pfb_hsc($fields[6]);

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2263,8 +2263,8 @@ function convert_dnsbl_log($mode, $fields) {
 	if (strpos($f2, 'xn--') !== FALSE) {
 		$f2 = "{$f2} [" . idn_to_utf8($f2) . "]";
 	}
-	if (strlen($f2) >= ($mode != 'unified' ? 60 : 40)) {
-		$f2 = pfb_hsc(pfb_truncate($f2, ($mode != 'unified' ? 59 : 39))) . "<small>...</small>";
+	if (strlen($f2) >= ($mode != 'Unified' ? 60 : 40)) {
+		$f2 = pfb_hsc(pfb_truncate($f2, ($mode != 'Unified' ? 59 : 39))) . "<small>...</small>";
 	} else {
 		$f2 = pfb_hsc($f2);
 	}
@@ -2274,8 +2274,8 @@ function convert_dnsbl_log($mode, $fields) {
 		if (strpos($f7, 'xn--') !== FALSE) {
 			$f7		= "{$f7} [" . idn_to_utf8($f7) . "]";
 		}
-		if (strlen($f7) >= ($mode != 'unified' ? 52 : 32)) {
-			$f7		= pfb_hsc(pfb_truncate($f7, ($mode != 'unified' ? 51 : 31))) . "<small>...</small>";
+		if (strlen($f7) >= ($mode != 'Unified' ? 52 : 32)) {
+			$f7		= pfb_hsc(pfb_truncate($f7, ($mode != 'Unified' ? 51 : 31))) . "<small>...</small>";
 		} else {
 			$f7		= pfb_hsc($f7);
 		}
@@ -2607,9 +2607,9 @@ function convert_dns_reply_log($mode, $fields) {
 
 	// Truncate long Domain names
 	$pfb_title6 = '';
-	if (strlen($fields[6]) >= ($mode != 'unified' ? 45 : 30)) {
+	if (strlen($fields[6]) >= ($mode != 'Unified' ? 45 : 30)) {
 		$pfb_title6	= pfb_hsc($fields[6]);
-		$fields[6]	= pfb_hsc(pfb_truncate($fields[6], ($mode != 'unified' ? 44 : 29))) . "<small>...</small>";
+		$fields[6]	= pfb_hsc(pfb_truncate($fields[6], ($mode != 'Unified' ? 44 : 29))) . "<small>...</small>";
 	} else {
 		$fields[6]	= pfb_hsc($fields[6]);
 	}

--- a/tests/php/AlertsDnsReplyWhitelistTypeTest.php
+++ b/tests/php/AlertsDnsReplyWhitelistTypeTest.php
@@ -202,4 +202,30 @@ final class AlertsDnsReplyWhitelistTypeTest extends TestCase
 			'the pre-fix classification renders the "Add Domain to DNSBL" icon, not the wildcard-whitelist delete icon'
 		);
 	}
+
+	public function testConvertDnsReplyLogReportsKeepsWideDomainTruncationWidth(): void
+	{
+		$domain = 'WIDE-REPLY07-' . str_repeat('c', 40) . '-tail';
+		$this->assertGreaterThan(45, strlen($domain));
+		$fields = $this->replyFields($domain, '10.0.0.9');
+
+		$output = '';
+		$diagnostics = $this->runCapturing(function () use ($fields, &$output): void {
+			ob_start();
+			convert_dns_reply_log('Reports', $fields);
+			$output = ob_get_clean();
+		});
+
+		$this->assertSame([], $diagnostics, 'wide Reports rendering must not add PHP diagnostics');
+		$this->assertStringContainsString(
+			'<td title="' . $domain . '">' . substr($domain, 0, 44) . '<small>...</small></td>',
+			$output,
+			'Reports DNS-reply domains must retain the existing 44-character display width'
+		);
+		$this->assertStringNotContainsString(
+			'<td title="' . $domain . '">' . substr($domain, 0, 29) . '<small>...</small></td>',
+			$output,
+			'Reports DNS-reply domains must not use the Unified 29-character display width'
+		);
+	}
 }

--- a/tests/php/AlertsMultibyteTruncationTest.php
+++ b/tests/php/AlertsMultibyteTruncationTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * issue #1815: the 11 byte-substr() display-truncation sites in
+ * issue #1815: the 10 byte-substr() display-truncation sites in
  * pfblockerng_alerts.php's row builders (convert_dnsbl_log / convert_dns_reply_log /
  * convert_ip_log) cut on BYTES, not characters. A multibyte character straddling the
  * cut leaves a dangling lead byte; pfb_hsc()'s ENT_SUBSTITUTE (issue #1814) then
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
  * whole. This file pins every site converted to mb_substr(..., 'UTF-8') (the #1069
  * exemplar's own form, pfb_stat_hostname_cell()).
  *
- * Coverage matrix (rows 1-11 = the 11 sites; 12-16 = branch/hostile-input axes):
+ * Coverage matrix (rows 1-10 = the 10 sites; 12-16 = branch/hostile-input axes):
  *   1  convert_dnsbl_log     $hostname (SRC-IP resolved name)          cut=24
  *   2  convert_dnsbl_log     $f2 (blocked domain)                      cut=59 (wide arm)
  *   3  convert_dnsbl_log     $f7 (CNAME evaluated domain)              cut=51 (wide arm)
@@ -25,7 +25,6 @@ use PHPUnit\Framework\TestCase;
  *   8  convert_dns_reply_log $fields[8] (resolved value)               cut=16
  *   9  convert_ip_log        $fields[15] (logged Feed Name)             cut=16
  *   10 convert_ip_log        $feed_new (re-attributed feed)             cut=16
- *   11 convert_ip_log        $fields[16] (gethostbyaddr hostname)       cut=21
  *   12 short-side branch coverage, one per builder (no truncation, no U+FFFD)
  *   13 4-byte character (emoji) straddling the cut
  *   14 invalid UTF-8 byte before the cut -- see that test's docblock
@@ -307,7 +306,7 @@ final class AlertsMultibyteTruncationTest extends TestCase
 	}
 
 	// =========================================================================
-	// Rows 1-11: the 11 truncation sites
+	// Rows 1-10: the 10 truncation sites
 	// =========================================================================
 
 	public function test_row01_dnsbl_srcip_hostname_truncation_keeps_multibyte_char_whole(): void
@@ -481,64 +480,6 @@ final class AlertsMultibyteTruncationTest extends TestCase
 		$this->assertStringContainsString('<small>...</small>', $html);
 		$this->assertStringNotContainsString("\u{FFFD}", $html);
 		$this->assertStringContainsString('é', $html);
-	}
-
-	/**
-	 * Row 11's site -- convert_ip_log()'s rDNS-hostname cell, which wraps a
-	 * truncated `$fields[16]` in a `<span title="...">` -- is DEAD CODE in the
-	 * current production source, discovered empirically while writing this test
-	 * (the content assertion the other 10 rows use never passed, in EITHER
-	 * direction). Verified via `grep -n '\$fields\[16\]'`: inside convert_ip_log()
-	 * the only hits are the 'Unknown' default and this truncating assignment; the
-	 * value that variable holds is never read again in the function or in either of
-	 * its <tr> print templates. What the row actually PRINTS for the resolved
-	 * hostname is `$hostname['src']`/`$hostname['dst']` -- a SEPARATE copy captured
-	 * earlier by pfb_ip_render_query() (via pfb_ip_render_attribution(), called
-	 * BEFORE this site runs) straight from the ORIGINAL, untruncated
-	 * $fields[16]/[17] -- so mutating $fields[16] here has zero effect on the
-	 * rendered output, before or after this fix. Tracked as issue #2008.
-	 *
-	 * Consequence: the rendered-HTML oracle every other row uses (no U+FFFD,
-	 * multibyte char present) cannot discriminate this site at all -- both the
-	 * byte-substr() original and the mb_substr() fix produce IDENTICAL rendered
-	 * output (the computed span never reaches it). This test instead proves the
-	 * one thing that IS observable: the conversion executes cleanly (no PHP
-	 * warning/notice) against both a short and a straddling-multibyte value. The
-	 * src edit at this site is still applied, per the issue's literal "convert all
-	 * 11 sites" scope and because it is a safe, behaviour-preserving textual
-	 * change regardless of reachability.
-	 */
-	public function test_row11_ip_resolved_hostname_truncation_executes_without_warning_dead_code(): void
-	{
-		file_put_contents("{$this->denydir}/Row11Feed.txt", "192.0.2.110\n192.0.2.111\n");
-		$rdnsLong  = $this->mbStraddle(21, 'R11', 'é', 'trailing-rdns.example');
-		$rdnsShort = 'short-rdns.example';
-		$this->assertLessThan(22, strlen($rdnsShort), 'fixture sanity: must be under the 22-char gate');
-
-		foreach ([$rdnsLong, $rdnsShort] as $rdns) {
-			$fields = $this->ipRawFields([
-				8 => '192.0.2.110', 15 => '192.0.2.110',
-				14 => 'pfB_Row11_v4', 16 => 'Row11Feed', 17 => $rdns,
-			]);
-
-			$warnings = [];
-			set_error_handler(function (int $errno, string $errstr) use (&$warnings): bool {
-				$warnings[] = $errstr;
-				return TRUE;
-			});
-			try {
-				$html = $this->renderIpRow($fields, 'Block');
-			} finally {
-				restore_error_handler();
-			}
-
-			$this->assertSame(
-				[],
-				$warnings,
-				"convert_ip_log() must render {$rdns} at the fields[16] site without a PHP warning/notice, got:\n" . implode("\n", $warnings)
-			);
-			$this->assertNotSame('', $html, 'the row must still render (this site being dead code must not break the rest of the row)');
-		}
 	}
 
 	// =========================================================================

--- a/tests/php/AlertsMultibyteTruncationTest.php
+++ b/tests/php/AlertsMultibyteTruncationTest.php
@@ -14,7 +14,8 @@ use PHPUnit\Framework\TestCase;
  * whole. This file pins every site converted to mb_substr(..., 'UTF-8') (the #1069
  * exemplar's own form, pfb_stat_hostname_cell()).
  *
- * Coverage matrix (rows 1-10 = the 10 sites; 12-16 = branch/hostile-input axes):
+ * Coverage matrix (rows 1-10 = the 10 sites; 12-16 = branch/hostile-input axes;
+ * 17-19 = Unified-view narrow-width arms):
  *   1  convert_dnsbl_log     $hostname (SRC-IP resolved name)          cut=24
  *   2  convert_dnsbl_log     $f2 (blocked domain)                      cut=59 (wide arm)
  *   3  convert_dnsbl_log     $f7 (CNAME evaluated domain)              cut=51 (wide arm)
@@ -30,11 +31,9 @@ use PHPUnit\Framework\TestCase;
  *   14 invalid UTF-8 byte before the cut -- see that test's docblock
  *   15 HTML metacharacter at the character-cut boundary -- entity stays complete
  *   16 punycode/xn-- domain whose idn_to_utf8()-produced text straddles the cut
- *
- * DEFERRED (not tested here): the mode=='unified' (lowercase) narrow-arm ternaries
- * on sites 2/3/7 are unreachable in production (callers only ever pass the literals
- * 'Unified'/'non_unified' -- never lowercase 'unified' -- so `$mode != 'unified'` is
- * always TRUE). Tracked separately by the issue #1815 planner; out of scope here.
+ *   17 Unified DNSBL domain narrow cut=39 (wide side remains row 2)
+ *   18 Unified DNSBL CNAME narrow cut=31 (wide side remains row 3)
+ *   19 Unified DNS reply domain narrow cut=29 (wide side remains row 7)
  *
  * Every test drives the value through the row builder's OWN production surface
  * (convert_dnsbl_log() / convert_dns_reply_log() / convert_ip_log()), capturing
@@ -118,6 +117,10 @@ final class AlertsMultibyteTruncationTest extends TestCase
 			'aliasdir'         => $this->aliasdir,
 			'asn_reporting'    => 'disabled',
 			'supp'             => '',	// PfbToggle::Off -- suppression-list lookup skipped
+			'unidnsbl'         => '#f0f0f0',
+			'unidnsbl2'        => '#202020',
+			'unireply'         => '#f0f0f0',
+			'unireply2'        => '#202020',
 		];
 		$GLOBALS['local_hosts']              = [];
 		$GLOBALS['dnsbl_int']                = [];
@@ -222,10 +225,10 @@ final class AlertsMultibyteTruncationTest extends TestCase
 		];
 	}
 
-	private function renderDnsblRow(array $fields): string
+	private function renderDnsblRow(array $fields, string $mode = 'Reports'): string
 	{
 		ob_start();
-		convert_dnsbl_log('Reports', $fields);
+		convert_dnsbl_log($mode, $fields);
 		return (string) ob_get_clean();
 	}
 
@@ -250,10 +253,10 @@ final class AlertsMultibyteTruncationTest extends TestCase
 		];
 	}
 
-	private function renderReplyRow(array $fields): string
+	private function renderReplyRow(array $fields, string $mode = 'Reports'): string
 	{
 		ob_start();
-		convert_dns_reply_log('Reports', $fields);
+		convert_dns_reply_log($mode, $fields);
 		return (string) ob_get_clean();
 	}
 
@@ -640,6 +643,63 @@ final class AlertsMultibyteTruncationTest extends TestCase
 		$this->assertStringContainsString('<small>...</small>', $html);
 		$this->assertStringNotContainsString("\u{FFFD}", $html, 'the idn_to_utf8()-produced text must not dangle at the cut');
 		$this->assertStringContainsString('тест', $html, 'the whole IDN-converted Cyrillic word must survive the cut');
+	}
+
+	// =========================================================================
+	// Rows 17-19: Unified-view narrow-width arms. Values stay below the Reports
+	// gates so a still-wide implementation renders them verbatim.
+	// =========================================================================
+
+	public function test_row17_unified_dnsbl_domain_uses_narrow_truncation_width(): void
+	{
+		$domain = 'R17' . str_repeat('a', 36) . 'TAIL';
+		$expected = 'R17' . str_repeat('a', 36);
+		$this->assertGreaterThanOrEqual(40, strlen($domain));
+		$this->assertLessThan(60, strlen($domain));
+		$fields = $this->dnsblFields($domain, '10.1.0.20', 'Grp17', 'Feed17');
+
+		$html = $this->renderDnsblRow($fields, 'Unified');
+
+		$this->assertStringContainsString("<td>{$expected}<small>...</small></td>", $html);
+		$this->assertStringNotContainsString("<td>{$domain}</td>", $html);
+	}
+
+	public function test_row18_unified_dnsbl_cname_uses_narrow_truncation_width(): void
+	{
+		$cname = 'R18' . str_repeat('b', 28) . 'TAIL';
+		$expected = 'R18' . str_repeat('b', 28);
+		$this->assertGreaterThanOrEqual(32, strlen($cname));
+		$this->assertLessThan(52, strlen($cname));
+		$fields = $this->dnsblFields(
+			'blocked-domain-18.example',
+			'10.1.0.21',
+			'Grp18',
+			'Feed18',
+			'',
+			'DNSBL_CNAME',
+			$cname
+		);
+
+		$html = $this->renderDnsblRow($fields, 'Unified');
+
+		$this->assertStringContainsString("CNAME: {$expected}<small>...</small>", $html);
+		$this->assertStringNotContainsString("CNAME: {$cname}", $html);
+	}
+
+	public function test_row19_unified_dnsreply_domain_uses_narrow_truncation_width(): void
+	{
+		$domain = 'R19' . str_repeat('c', 26) . 'TAIL';
+		$expected = 'R19' . str_repeat('c', 26);
+		$this->assertGreaterThanOrEqual(30, strlen($domain));
+		$this->assertLessThan(45, strlen($domain));
+		$srcIp = '10.1.0.22';
+		$GLOBALS['local_hosts'] = [$srcIp => ''];
+		$fields = $this->replyFields($domain, $srcIp);
+
+		$html = $this->renderReplyRow($fields, 'Unified');
+
+		$this->assertStringContainsString("<td title=\"{$domain}\">{$expected}<small>...</small></td>", $html);
+		$this->assertStringNotContainsString("<td title=\"{$domain}\">{$domain}</td>", $html);
 	}
 
 	// =========================================================================

--- a/tests/php/AlertsMultibyteTruncationTest.php
+++ b/tests/php/AlertsMultibyteTruncationTest.php
@@ -196,6 +196,21 @@ final class AlertsMultibyteTruncationTest extends TestCase
 		return $marker . str_repeat('a', $cut - 3 - strlen($marker)) . $mbChar . $mbChar . $metachar . $tail;
 	}
 
+	/**
+	 * Build a value that reaches a byte gate but stays below that gate in UTF-8
+	 * code points, so the gate itself (not the cut) is the regression oracle.
+	 */
+	private function characterGateValue(int $gate, string $marker): string
+	{
+		$value = $marker;
+		while (strlen($value) < $gate) {
+			$value .= '界';
+		}
+		$this->assertGreaterThanOrEqual($gate, strlen($value));
+		$this->assertLessThan($gate, mb_strlen($value, 'UTF-8'));
+		return $value;
+	}
+
 	// -----------------------------------------------------------------------
 	// convert_dnsbl_log() harness
 	// -----------------------------------------------------------------------
@@ -700,6 +715,141 @@ final class AlertsMultibyteTruncationTest extends TestCase
 
 		$this->assertStringContainsString("<td title=\"{$domain}\">{$expected}<small>...</small></td>", $html);
 		$this->assertStringNotContainsString("<td title=\"{$domain}\">{$domain}</td>", $html);
+	}
+
+	// =========================================================================
+	// Character-count gates: byte length reaches each gate while code-point
+	// length stays below it, so no display ellipsis is justified.
+	// =========================================================================
+
+	public function test_character_gate_dnsbl_srcip_hostname_renders_complete_value(): void
+	{
+		$srcIp = '10.1.0.31';
+		$value = $this->characterGateValue(25, 'CG01');
+		$GLOBALS['local_hosts'] = [$srcIp => $value];
+		$html = $this->renderDnsblRow($this->dnsblFields('cg-domain-01.example', $srcIp, 'CG', 'Feed'));
+		$escaped = pfb_hsc($value);
+
+		$this->assertStringContainsString("<span title=\"\">{$escaped}</span>", $html);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
+	}
+
+	public function test_character_gate_dnsbl_domain_renders_complete_value(): void
+	{
+		$value = $this->characterGateValue(40, 'CG02');
+		$html = $this->renderDnsblRow(
+			$this->dnsblFields($value, '10.1.0.32', 'CG', 'Feed'),
+			'Unified'
+		);
+		$escaped = pfb_hsc($value);
+
+		$this->assertStringContainsString("<td>{$escaped}</td>", $html);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
+	}
+
+	public function test_character_gate_dnsbl_cname_renders_complete_value(): void
+	{
+		$value = $this->characterGateValue(32, 'CG03');
+		$fields = $this->dnsblFields('cg-domain-03.example', '10.1.0.33', 'CG', 'Feed', '', 'DNSBL_CNAME', $value);
+		$html = $this->renderDnsblRow($fields, 'Unified');
+		$escaped = pfb_hsc($value);
+
+		$this->assertStringContainsString("CNAME: {$escaped}</td>", $html);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
+	}
+
+	public function test_character_gate_dnsbl_agent_renders_complete_value(): void
+	{
+		$value = $this->characterGateValue(25, 'CG04');
+		$html = $this->renderDnsblRow($this->dnsblFields('cg-domain-04.example', '10.1.0.34', 'CG', 'Feed', $value));
+		$escaped = pfb_hsc($value);
+
+		$this->assertStringContainsString("<br /><small>DNSBL-python | {$escaped} | A</small>", $html);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
+	}
+
+	public function test_character_gate_dnsreply_srcip_hostname_renders_complete_value(): void
+	{
+		$srcIp = '10.1.0.35';
+		$value = $this->characterGateValue(25, 'CG05');
+		$GLOBALS['local_hosts'] = [$srcIp => $value];
+		$html = $this->renderReplyRow($this->replyFields('cg-domain-05.example', $srcIp));
+		$escaped = pfb_hsc($value);
+
+		$this->assertStringContainsString("<td title=\"\">{$srcIp}<br /><small>{$escaped}</small></td>", $html);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
+	}
+
+	public function test_character_gate_dnsreply_ttl_renders_complete_value(): void
+	{
+		$srcIp = '10.1.0.36';
+		$GLOBALS['local_hosts'] = [$srcIp => ''];
+		$fields = $this->replyFields('cg-domain-06.example', $srcIp);
+		$fields[5] = $this->characterGateValue(6, 'CG');
+		$html = $this->renderReplyRow($fields);
+		$escaped = pfb_hsc($fields[5]);
+
+		$this->assertStringContainsString("<td title=\"\">{$escaped}</td>", $html);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
+	}
+
+	public function test_character_gate_dnsreply_domain_renders_complete_value(): void
+	{
+		$srcIp = '10.1.0.37';
+		$GLOBALS['local_hosts'] = [$srcIp => ''];
+		$value = $this->characterGateValue(30, 'CG07');
+		$html = $this->renderReplyRow($this->replyFields($value, $srcIp), 'Unified');
+		$escaped = pfb_hsc($value);
+
+		$this->assertStringContainsString("<td title=\"\">{$escaped}</td>", $html);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
+	}
+
+	public function test_character_gate_dnsreply_resolved_value_renders_complete_value(): void
+	{
+		$srcIp = '10.1.0.38';
+		$GLOBALS['local_hosts'] = [$srcIp => ''];
+		$fields = $this->replyFields('cg-domain-08.example', $srcIp);
+		$fields[8] = $this->characterGateValue(17, 'CG08');
+		$html = $this->renderReplyRow($fields);
+		$escaped = pfb_hsc($fields[8]);
+
+		$this->assertStringContainsString("<td title=\"\">{$escaped}</td>", $html);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
+	}
+
+	public function test_character_gate_ip_logged_feed_renders_complete_value(): void
+	{
+		$value = $this->characterGateValue(17, 'CG09');
+		file_put_contents("{$this->denydir}/{$value}.txt", "192.0.2.190\n");
+		$fields = $this->ipRawFields([
+			8 => '192.0.2.190', 15 => '192.0.2.190',
+			14 => 'pfB_CG09_v4', 16 => $value,
+		]);
+		$html = $this->renderIpRow($fields, 'Block');
+		$escaped = pfb_hsc($value);
+
+		$this->assertStringContainsString($escaped . '<br /><small>', $html);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
+	}
+
+	public function test_character_gate_ip_re_attributed_feed_renders_complete_value(): void
+	{
+		$value = $this->characterGateValue(17, 'CG10');
+		file_put_contents("{$this->denydir}/{$value}.txt", "192.0.2.191\n");
+		$oldFeed = 'CG10Old';
+		$fields = $this->ipRawFields([
+			8 => '192.0.2.191', 15 => '192.0.2.191',
+			14 => 'pfB_CG10_v4', 16 => $oldFeed,
+		]);
+		$html = $this->renderIpRow($fields, 'Block');
+		$escaped = pfb_hsc($value);
+
+		$this->assertStringContainsString(
+			"<s>{$oldFeed}</s><br /><small><s>192.0.2.191</s></small><br />{$escaped}<br /><small>",
+			$html
+		);
+		$this->assertStringNotContainsString($escaped . '<small>...</small>', $html);
 	}
 
 	// =========================================================================

--- a/tests/php/AlertsRowOutputEncodingTest.php
+++ b/tests/php/AlertsRowOutputEncodingTest.php
@@ -177,6 +177,40 @@ final class AlertsRowOutputEncodingTest extends TestCase
         $this->assertStringNotContainsString('&amp;', $html, 'benign input has no & to encode');
     }
 
+    public function test_reports_dnsbl_domain_and_cname_keep_wide_truncation_widths(): void
+    {
+        $domain = 'WIDE-DNSBL02-' . str_repeat('a', 55) . '-tail';
+        $cname  = 'WIDE-DNSBL03-' . str_repeat('b', 47) . '-tail';
+        $this->assertGreaterThan(60, strlen($domain));
+        $this->assertGreaterThan(52, strlen($cname));
+        $fields    = $this->dnsblFields($domain, '10.0.0.8', 'WideGroup', 'WideFeed');
+        $fields[5] = 'DNSBL_CNAME';
+        $fields[7] = $cname;
+
+        $html = $this->renderDnsblRow($fields);
+
+        $this->assertStringContainsString(
+            'Domain: ' . substr($domain, 0, 59) . '<small>...</small>',
+            $html,
+            'Reports DNSBL domains must retain the existing 59-character display width'
+        );
+        $this->assertStringContainsString(
+            'CNAME: ' . substr($cname, 0, 51) . '<small>...</small>',
+            $html,
+            'Reports DNSBL CNAMEs must retain the existing 51-character display width'
+        );
+        $this->assertStringNotContainsString(
+            'Domain: ' . substr($domain, 0, 39) . '<small>...</small>',
+            $html,
+            'Reports DNSBL domains must not use the Unified 39-character display width'
+        );
+        $this->assertStringNotContainsString(
+            'CNAME: ' . substr($cname, 0, 31) . '<small>...</small>',
+            $html,
+            'Reports DNSBL CNAMEs must not use the Unified 31-character display width'
+        );
+    }
+
     public function test_invalid_utf8_byte_in_domain_renders_substituted_not_blanked(): void
     {
         // issue #1814: a single invalid-UTF-8 byte (0xFF is never valid in any UTF-8

--- a/tests/php/AlertsStatHostnameCellTest.php
+++ b/tests/php/AlertsStatHostnameCellTest.php
@@ -102,6 +102,25 @@ final class AlertsStatHostnameCellTest extends TestCase
         $this->assertStringNotContainsString('&amp;', $cell, 'benign input has no & to encode');
     }
 
+    public function test_invalid_utf8_in_truncated_hostname_uses_replacement_character(): void
+    {
+        $resolved = str_repeat('a', 40) . "\xFF" . str_repeat('b', 10);
+        $this->assertGreaterThanOrEqual(45, mb_strlen($resolved, 'UTF-8'));
+
+        $cell = pfb_stat_hostname_cell($resolved);
+
+        $this->assertStringContainsString(
+            str_repeat('a', 40) . "\u{FFFD}" . str_repeat('b', 4) . '<small>...</small>',
+            $cell,
+            'the displayed cut must represent an invalid byte with U+FFFD'
+        );
+        $this->assertStringNotContainsString(
+            str_repeat('a', 40) . '?' . str_repeat('b', 4) . '<small>...</small>',
+            $cell,
+            "the displayed cut must not fabricate '?' for an invalid byte"
+        );
+    }
+
     public function test_character_gate_hostname_renders_complete_value_without_ellipsis(): void
     {
         $resolved = 'CG11' . str_repeat('界', 14);

--- a/tests/php/AlertsStatHostnameCellTest.php
+++ b/tests/php/AlertsStatHostnameCellTest.php
@@ -101,4 +101,21 @@ final class AlertsStatHostnameCellTest extends TestCase
         $this->assertStringNotContainsString('&lt;', $cell, 'benign input must not produce stray entities');
         $this->assertStringNotContainsString('&amp;', $cell, 'benign input has no & to encode');
     }
+
+    public function test_character_gate_hostname_renders_complete_value_without_ellipsis(): void
+    {
+        $resolved = 'CG11' . str_repeat('界', 14);
+        while (strlen($resolved) < 45) {
+            $resolved .= '界';
+        }
+        $this->assertGreaterThanOrEqual(45, strlen($resolved));
+        $this->assertLessThan(45, mb_strlen($resolved, 'UTF-8'));
+
+        $cell = pfb_stat_hostname_cell($resolved);
+        $escaped = pfb_hsc($resolved);
+
+        $this->assertStringContainsString("<small>{$escaped}</small>", $cell);
+        $this->assertStringNotContainsString($escaped . '<small>...</small>', $cell);
+        $this->assertStringNotContainsString('title="', $cell);
+    }
 }

--- a/tests/smoke/ui/test_alerts_multibyte_truncation.py
+++ b/tests/smoke/ui/test_alerts_multibyte_truncation.py
@@ -29,12 +29,12 @@ site; the row renders a delisted/"Not listed!" state harmlessly either way.
 
 The IP row deliberately targets the logged Feed Name (``$fields[15]``) rather
 than the ``rhost`` (gethostbyaddr-resolved hostname) cell, which is the more
-obvious candidate: ``convert_ip_log()`` computes the truncated/wrapped rDNS
-value into ``$fields[16]`` but never reads that variable again -- the row's
-actually-rendered resolved-hostname cell comes from ``$hostname['src']`` /
-``$hostname['dst']``, a SEPARATE copy captured earlier, straight from the
-untruncated original (issue #2008). Asserting on ``rhost`` here would be a
-vacuous check, and this module cannot be executed locally to catch that.
+obvious candidate: the former discarded ``$fields[16]`` default/truncation
+block was removed by issue #2008, and the row's actually-rendered
+resolved-hostname cell comes from ``$hostname['src']`` / ``$hostname['dst']``,
+a SEPARATE copy captured earlier, straight from the untruncated original.
+Asserting on ``rhost`` here would be a vacuous check, and this module cannot be
+executed locally to catch that.
 
 HONESTY NOTE (no local smoke VM in this environment, precedent: commit
 9fd4bfce, issue #1814): this module has NOT been executed against a live

--- a/tests/smoke/ui/test_alerts_multibyte_truncation.py
+++ b/tests/smoke/ui/test_alerts_multibyte_truncation.py
@@ -1,23 +1,25 @@
-"""Tier-A ``ui_render`` coverage for issue #1815: the Alerts page's row-cell
-display-truncation sites cut on CHARACTERS (``mb_substr(..., 'UTF-8')``), not
-BYTES, so a multibyte character straddling the cut renders whole instead of
-leaving a dangling lead byte for ``pfb_hsc()``'s ``ENT_SUBSTITUTE`` to replace
-with a spurious U+FFFD.
+"""Tier-A ``ui_render`` coverage for issues #1815, #2007, and #2009: Alerts
+row-cell truncation uses the Unified widths and matching UTF-8 character units.
+Four values straddle their character cuts and remain valid; a fifth value is
+long in bytes but short in characters and renders complete without an ellipsis.
 
 Scenario (self-encapsulated: log truncated back to its exact pre-test byte
 size in teardown, loud assertion that the restore took):
-  Given three ``unified.log`` rows -- one ``Block,``-prefixed IP row, one
+  Given four ``unified.log`` rows -- one ``Block,``-prefixed IP row, one
         ``DNSBL_CNAME`` row carrying blocked-domain and CNAME values, one
-        verbatim DNS-reply row -- each value shaped
+        verbatim DNS-reply row with a truncating value, and one DNS-reply row
+        whose multibyte domain reaches the old byte gate but stays below the
+        character gate -- with each truncating value shaped
         ``<marker><'a' padding><'é'><tail>`` so its multibyte character's lead
         byte lands exactly on that value's truncation cut
         (see ``pfblockerng_alerts.php``'s ``convert_ip_log`` /
         ``convert_dnsbl_log`` / ``convert_dns_reply_log``)
   When  GET ``pfblockerng_alerts.php?view=unified``
   Then  the Tier-A render oracle passes
-  And   all four markers locate their rows
-  And   each value is truncated (the ``<small>...</small>`` ellipsis renders)
-  And   each value's multibyte character survives WHOLE (no U+FFFD, 'é' present)
+  And   all five markers locate their rows
+  And   the four long values render exact truncated prefixes and ellipses
+  And   the code-point-short value renders complete without an ellipsis
+  And   each truncated value's multibyte character survives whole
 
 ``?view=unified`` needs no config precondition (no ``pfb_dnsbl`` toggle, no
 sinkhole VIP): the Unified loop reads only ``unified.log``, and its
@@ -113,13 +115,16 @@ _DNSBL_LINE = "DNSBL-python,{},{},127.0.0.1,Python,DNSBL_CNAME,RVMbGroup,{},RVMb
     FIXED_TS, DNSBL_DOMAIN, CNAME_DOMAIN
 )
 _DNS_REPLY_LINE = f"DNS-reply,{FIXED_TS},A,A,A,300,{REPLY_DOMAIN},127.0.0.1,203.0.113.9,US\n"
+CJK_REPLY_MARKER = "SMKREPLYCG"
+CJK_REPLY_DOMAIN = CJK_REPLY_MARKER + "界" * 7
+_DNS_REPLY_CHARACTER_GATE_LINE = f"DNS-reply,{FIXED_TS},A,A,A,300,{CJK_REPLY_DOMAIN},127.0.0.1,203.0.113.10,US\n"
 
-_ALL_LINES = _IP_LINE + _DNSBL_LINE + _DNS_REPLY_LINE
+_ALL_LINES = _IP_LINE + _DNSBL_LINE + _DNS_REPLY_LINE + _DNS_REPLY_CHARACTER_GATE_LINE
 
 
 @pytest.fixture
-def seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[tuple[tuple[str, str, int], ...]]:
-    """Append the three rows carrying four straddling values; restore log size after.
+def seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[tuple[tuple[str, str, int | None], ...]]:
+    """Append four rows carrying five values; restore log size after.
 
     Yields the markers it actually seeded, so the test iterates over the
     fixture's own output rather than module constants -- the assertions cannot
@@ -154,6 +159,7 @@ def seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[tuple[tuple[str, str, int
         (DNSBL_MARKER, DNSBL_DOMAIN, 39),
         (CNAME_MARKER, CNAME_DOMAIN, 31),
         (REPLY_MARKER, REPLY_DOMAIN, 29),
+        (CJK_REPLY_MARKER, CJK_REPLY_DOMAIN, None),
     )
 
     restore = vm.ssh(f"truncate -s {original_size} {UNIFIED_LOG}", timeout=15)
@@ -165,7 +171,7 @@ def seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[tuple[tuple[str, str, int
 
 
 def test_unified_rows_keep_straddling_multibyte_char_whole(
-    smoke_vm: SmokeVM, webui: WebUI, seeded_unified_rows: tuple[tuple[str, str, int], ...]
+    smoke_vm: SmokeVM, webui: WebUI, seeded_unified_rows: tuple[tuple[str, str, int | None], ...]
 ) -> None:
     """Every seeded value's straddling character survives whole; none renders U+FFFD."""
     guard = PhpErrorLogGuard(smoke_vm)
@@ -177,7 +183,10 @@ def test_unified_rows_keep_straddling_multibyte_char_whole(
 
     body = resp.text
     assert seeded_unified_rows, "the seeding fixture yielded no markers -- nothing would be asserted"
-    for marker, value, cut in seeded_unified_rows:
+    truncation_rows = tuple(case for case in seeded_unified_rows if case[2] is not None)
+    assert len(truncation_rows) == 4, f"fixture must yield four truncation cases, got {truncation_rows!r}"
+    for marker, value, cut in truncation_rows:
+        assert cut is not None
         row = row_containing(body, marker)
         expected = value[:cut] + "<small>...</small>"
         assert expected in row, (
@@ -197,5 +206,26 @@ def test_unified_rows_keep_straddling_multibyte_char_whole(
         assert "<small>...</small>" in row, (
             f"row for marker {marker!r} did not truncate at all -- fixture broken, not a #1815 signal:\n{row}"
         )
+
+    guard.assert_no_growth()
+
+
+def test_unified_character_gate_domain_renders_complete_without_lying_ellipsis(
+    smoke_vm: SmokeVM, webui: WebUI, seeded_unified_rows: tuple[tuple[str, str, int | None], ...]
+) -> None:
+    """A byte-long/CJK-short DNS reply domain must render complete in Unified view."""
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(UNIFIED_VIEW)
+    result = evaluate_render(UNIFIED_VIEW, resp.status_code, resp.text, ("Alert Settings",))
+    assert result.ok, f"Tier-A render oracle failed for the Alerts Unified view: {result.detail}"
+
+    character_gate_rows = tuple(case for case in seeded_unified_rows if case[2] is None)
+    assert len(character_gate_rows) == 1, f"fixture must yield one character-gate case, got {character_gate_rows!r}"
+    marker, value, _ = character_gate_rows[0]
+    row = row_containing(resp.text, marker)
+    assert f'<td title="">{value}</td>' in row, f"complete value missing from marker row {marker!r}:\n{row}"
+    assert value + "<small>...</small>" not in row, f"marker-local value received a lying ellipsis:\n{row}"
 
     guard.assert_no_growth()

--- a/tests/smoke/ui/test_alerts_multibyte_truncation.py
+++ b/tests/smoke/ui/test_alerts_multibyte_truncation.py
@@ -7,15 +7,17 @@ with a spurious U+FFFD.
 Scenario (self-encapsulated: log truncated back to its exact pre-test byte
 size in teardown, loud assertion that the restore took):
   Given three ``unified.log`` rows -- one ``Block,``-prefixed IP row, one
-        verbatim DNSBL row, one verbatim DNS-reply row -- each carrying a
-        value shaped ``<marker><'a' padding><'é'><tail>`` so its multibyte
-        character's lead byte lands exactly on that row's truncation cut
+        ``DNSBL_CNAME`` row carrying blocked-domain and CNAME values, one
+        verbatim DNS-reply row -- each value shaped
+        ``<marker><'a' padding><'é'><tail>`` so its multibyte character's lead
+        byte lands exactly on that value's truncation cut
         (see ``pfblockerng_alerts.php``'s ``convert_ip_log`` /
         ``convert_dnsbl_log`` / ``convert_dns_reply_log``)
   When  GET ``pfblockerng_alerts.php?view=unified``
   Then  the Tier-A render oracle passes
-  And   each row is truncated (the ``<small>...</small>`` ellipsis renders)
-  And   each row's multibyte character survives WHOLE (no U+FFFD, 'é' present)
+  And   all four markers locate their rows
+  And   each value is truncated (the ``<small>...</small>`` ellipsis renders)
+  And   each value's multibyte character survives WHOLE (no U+FFFD, 'é' present)
 
 ``?view=unified`` needs no config precondition (no ``pfb_dnsbl`` toggle, no
 sinkhole VIP): the Unified loop reads only ``unified.log``, and its
@@ -83,14 +85,17 @@ def _mb_straddle(cut: int, marker: str, tail: str, mb_char: str = "é") -> str:
 IP_MARKER = "SMKIP09"
 IP_FEED = _mb_straddle(16, IP_MARKER, "trailingfeed")
 
-# Site 2 (convert_dnsbl_log, blocked domain $f2): wide-gate cut=59 (mode
-# 'Unified' != 'unified' is case-sensitive, so the narrow arm is unreachable).
+# Site 2 (convert_dnsbl_log, blocked domain $f2): Unified cut=39; below wide gate 60.
 DNSBL_MARKER = "SMKDNSBL02"
-DNSBL_DOMAIN = _mb_straddle(59, DNSBL_MARKER, "trailing-domain-suffix.example")
+DNSBL_DOMAIN = _mb_straddle(39, DNSBL_MARKER, "tail")
 
-# Site 7 (convert_dns_reply_log, replied domain $fields[6]): wide-gate cut=44.
+# Site 3 (convert_dnsbl_log, CNAME evaluated domain $f7): Unified cut=31; below wide gate 52.
+CNAME_MARKER = "SMKDNSBL03"
+CNAME_DOMAIN = _mb_straddle(31, CNAME_MARKER, "tail")
+
+# Site 7 (convert_dns_reply_log, replied domain $fields[6]): Unified cut=29; below wide gate 45.
 REPLY_MARKER = "SMKREPLY07"
-REPLY_DOMAIN = _mb_straddle(44, REPLY_MARKER, "trailing-domain-suffix.example")
+REPLY_DOMAIN = _mb_straddle(29, REPLY_MARKER, "tail")
 
 # unified.log row shapes (test_alerts_render_verify.py's _ip_line/_dnsbl_line/
 # _dns_reply_line document the exact CSV layouts these mirror):
@@ -104,15 +109,17 @@ _IP_LINE = (
     f"192.0.2.201,10.0.0.5,12345,443,in,US,RVMbAlias,192.0.2.201,{IP_FEED},"
     "Unknown,Unknown,Unknown,,,+\n"
 )
-_DNSBL_LINE = f"DNSBL-python,{FIXED_TS},{DNSBL_DOMAIN},127.0.0.1,Python,DNSBL,RVMbGroup,{DNSBL_DOMAIN},RVMbFeed,+,A\n"
+_DNSBL_LINE = "DNSBL-python,{},{},127.0.0.1,Python,DNSBL_CNAME,RVMbGroup,{},RVMbFeed,+,A\n".format(
+    FIXED_TS, DNSBL_DOMAIN, CNAME_DOMAIN
+)
 _DNS_REPLY_LINE = f"DNS-reply,{FIXED_TS},A,A,A,300,{REPLY_DOMAIN},127.0.0.1,203.0.113.9,US\n"
 
 _ALL_LINES = _IP_LINE + _DNSBL_LINE + _DNS_REPLY_LINE
 
 
 @pytest.fixture
-def seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[tuple[str, ...]]:
-    """Append the three straddling rows to ``unified.log``; restore its exact byte size after.
+def seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[tuple[tuple[str, str, int], ...]]:
+    """Append the three rows carrying four straddling values; restore log size after.
 
     Yields the markers it actually seeded, so the test iterates over the
     fixture's own output rather than module constants -- the assertions cannot
@@ -142,7 +149,12 @@ def seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[tuple[str, ...]]:
     )
     assert append.returncode == 0, f"failed to append the fixture rows to {UNIFIED_LOG}: stderr={append.stderr!r}"
 
-    yield (IP_MARKER, DNSBL_MARKER, REPLY_MARKER)
+    yield (
+        (IP_MARKER, IP_FEED, 16),
+        (DNSBL_MARKER, DNSBL_DOMAIN, 39),
+        (CNAME_MARKER, CNAME_DOMAIN, 31),
+        (REPLY_MARKER, REPLY_DOMAIN, 29),
+    )
 
     restore = vm.ssh(f"truncate -s {original_size} {UNIFIED_LOG}", timeout=15)
     assert restore.returncode == 0, f"failed to restore {UNIFIED_LOG} size: stderr={restore.stderr!r}"
@@ -153,9 +165,9 @@ def seeded_unified_rows(smoke_vm: SmokeVM) -> Iterator[tuple[str, ...]]:
 
 
 def test_unified_rows_keep_straddling_multibyte_char_whole(
-    smoke_vm: SmokeVM, webui: WebUI, seeded_unified_rows: tuple[str, ...]
+    smoke_vm: SmokeVM, webui: WebUI, seeded_unified_rows: tuple[tuple[str, str, int], ...]
 ) -> None:
-    """Every seeded row's straddling character survives whole; none renders U+FFFD."""
+    """Every seeded value's straddling character survives whole; none renders U+FFFD."""
     guard = PhpErrorLogGuard(smoke_vm)
     guard.snapshot()
 
@@ -165,8 +177,18 @@ def test_unified_rows_keep_straddling_multibyte_char_whole(
 
     body = resp.text
     assert seeded_unified_rows, "the seeding fixture yielded no markers -- nothing would be asserted"
-    for marker in seeded_unified_rows:
+    for marker, value, cut in seeded_unified_rows:
         row = row_containing(body, marker)
+        expected = value[:cut] + "<small>...</small>"
+        assert expected in row, (
+            f"row for marker {marker!r} did not show exact cut {cut} with ellipsis; "
+            f"expected fragment {expected!r}:\n{row}"
+        )
+        unexpected = expected + value[cut:]
+        assert unexpected not in row, (
+            f"row for marker {marker!r} rendered the seeded tail after its ellipsis "
+            f"(unexpected fragment {unexpected!r}):\n{row}"
+        )
         assert "�" not in row, (
             f"row for marker {marker!r} rendered U+FFFD -- a byte-based cut dangled the "
             f"straddling multibyte character's lead byte instead of keeping it whole:\n{row}"


### PR DESCRIPTION
## Summary

- Delete `convert_ip_log()`'s discarded rDNS default/truncation block and its warning-only test.
- Activate the intended Unified-view widths by matching the callers' canonical `Unified` mode spelling.
- Count all 11 surviving truncation gates in UTF-8 code points, matching their character-based cuts.
- Route `pfb_stat_hostname_cell()` through `pfb_truncate()` so invalid bytes render as U+FFFD, never a fabricated `?`.

The #2007 decision is to make the narrow arms reachable. The `Unified` caller spelling and the existing Unified print branch establish that mode as canonical; deleting the narrow arms would preserve the extra-column layout defect.

Fixes #2007
Fixes #2008
Fixes #2009
Fixes #2010

## Evidence

- `scripts/agent/run-gates.sh --diff origin/devel` — `GATES: PASS` (pytest, Ruff, mypy, PHP lint, PHPUnit, PHPStan, PHPCS).
- `git diff --name-only origin/devel...HEAD | python3 scripts/check_coverage_pairing.py` — coverage pairing OK.
- `python3 -m pytest --collect-only -q tests/smoke/ui/test_alerts_multibyte_truncation.py` — 2 Tier-A `ui_render` tests collected.
- #2008: behavior-preserving green-before/green-after deletion; independent full gate PASS.
- #2007: frozen rendered tests `RED-OK` / `GREEN-OK`; forced-narrow mutant makes both wide-width oracles fail.
- #2009: frozen tests fail 11/11 against byte gates and pass 11/11 against character gates.
- #2010: frozen test renders `?` against the parent and U+FFFD against the new helper call.

No live smoke VM was available because `SMOKE_ADMIN_PASSWORD` is unset. The Tier-A module is collection-, Ruff-, format-, and mypy-clean; the PR UI gate runs it on the supported appliance matrix.

## Commit stack

1. #2008 — delete dead IP rDNS truncation
2. #2007 — activate Unified alerts widths
3. #2009 — count alert truncation gates in characters
4. #2010 — unify stats truncation substitution

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert and report text truncation for multibyte and invalid UTF-8 content.
  * Prevented incomplete characters, incorrect ellipses, and misleading truncation in DNSBL, DNS reply, and hostname displays.
  * Preserved the appropriate display widths across Reports and Unified views.

* **Tests**
  * Expanded automated coverage for Unicode, invalid encoding, IDN, HTML entity, and view-specific truncation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->