### PR TITLE
tests/smoke: store explicit toggle off states

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1595,7 +1595,7 @@ def _php_read_scalar(vm: SmokeVM, pre: str, expr: str, *, timeout: float = 60.0)
 
 def set_dnsvip_auto(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     """Toggle the ADR-13 'Create VIPs automatically' setting (``pfb_dnsvip_auto``)."""
-    val = "on" if on else ""
+    val = "on" if on else "off"
     snippet = (
         f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
         f"$d['pfb_dnsvip_auto'] = {_php_str(val)};\n"
@@ -1611,7 +1611,7 @@ def set_dnsvip_auto(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
 def set_dnsbl_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     """Toggle the DNSBL component (``pfb_dnsbl``) so the next reload runs
     pfb_create_dnsbl in 'enabled' / 'disabled' mode (mode keys on dnsbl=='on')."""
-    val = "on" if on else ""
+    val = "on" if on else "off"
     snippet = (
         f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
         f"$d['pfb_dnsbl'] = {_php_str(val)};\n"
@@ -1628,7 +1628,7 @@ def set_dnsbl_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
 
 def set_dnsbl_cache_flush(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     """Toggle the opt-in full resolver-cache flush after DNSBL data swaps."""
-    val = "on" if on else ""
+    val = "on" if on else "off"
     snippet = (
         f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
         f"$d['pfb_cache_flush'] = {_php_str(val)};\n"
@@ -1671,11 +1671,11 @@ def set_package_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None
 
     ``enable_cb='on'`` → master ON (``$pfb['enable']=='on'``; ``$mode=='enabled'``
     when DNSBL is also on and the DNS resolver is up).
-    ``enable_cb=''`` → master OFF (``$mode`` never reaches ``'enabled'``).
+    ``enable_cb='off'`` → master OFF (``$mode`` never reaches ``'enabled'``).
 
     Written via the same section-read/write pattern as :func:`set_dnsbl_enabled`.
     """
-    val = "on" if on else ""
+    val = "on" if on else "off"
     snippet = (
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         f"$g['enable_cb'] = {_php_str(val)};\n"
@@ -1760,8 +1760,8 @@ def set_ip_reputation(
     merged through untouched.
     """
     settings = {
-        "enable_dedup": "on" if drep else "",
-        "enable_pdup": "on" if prep else "",
+        "enable_dedup": "on" if drep else "off",
+        "enable_pdup": "on" if prep else "off",
         "p24_dmax_var": str(dmax),
         "p24_pmax_var": str(pmax),
         "ccwhite": ccwhite,
@@ -1799,7 +1799,7 @@ def set_ip_suppression(
     """
     snippet = (
         f"$ip = config_get_path({_php_str(CFG_IP_SETTINGS)}, array());\n"
-        f"$ip['suppression'] = {_php_str('on' if enabled else '')};\n"
+        f"$ip['suppression'] = {_php_str('on' if enabled else 'off')};\n"
         f"$ip['v4suppression'] = {_php_str(_b64_textarea(v4 or []))};\n"
         f"$ip['v6suppression'] = {_php_str(_b64_textarea(v6 or []))};\n"
         f"config_set_path({_php_str(CFG_IP_SETTINGS)}, $ip);\n"
@@ -1876,7 +1876,7 @@ def set_dnsbl_nonat(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     managed ``pfB DNSBL`` NAT on the next reload.  When False (the default),
     the NAT is created whenever ``dnsbl_interface`` is not ``lo0``.
     """
-    val = "on" if on else ""
+    val = "on" if on else "off"
     snippet = (
         f"$d = config_get_path({_php_str(CFG_DNSBL_SETTINGS)}, array());\n"
         f"$d['pfb_dnsbl_nonat'] = {_php_str(val)};\n"
@@ -2996,9 +2996,9 @@ def inject_dnsbl_lists(
     if primary_spec.idn_mode is not None:
         settings["pfb_idn"] = primary_spec.idn_mode
     if primary_spec.idn_block_malicious is not None:
-        settings["pfb_idn_block_malicious"] = "on" if primary_spec.idn_block_malicious else ""
+        settings["pfb_idn_block_malicious"] = "on" if primary_spec.idn_block_malicious else "off"
     if primary_spec.idn_escalate_suspicious is not None:
-        settings["pfb_idn_escalate_suspicious"] = "on" if primary_spec.idn_escalate_suspicious else ""
+        settings["pfb_idn_escalate_suspicious"] = "on" if primary_spec.idn_escalate_suspicious else "off"
 
     # Build each list-group PHP literal.
     lists_php = ", ".join(_dnsbl_list_php(spec, action) for spec, action in specs_and_actions)
@@ -3079,9 +3079,9 @@ def _dnsbl_inject_snippet(spec: DnsblCase) -> str:
         # Only emitted when the case sets it, so the default matrix is unchanged.
         settings["pfb_idn"] = spec.idn_mode
     if spec.idn_block_malicious is not None:
-        settings["pfb_idn_block_malicious"] = "on" if spec.idn_block_malicious else ""
+        settings["pfb_idn_block_malicious"] = "on" if spec.idn_block_malicious else "off"
     if spec.idn_escalate_suspicious is not None:
-        settings["pfb_idn_escalate_suspicious"] = "on" if spec.idn_escalate_suspicious else ""
+        settings["pfb_idn_escalate_suspicious"] = "on" if spec.idn_escalate_suspicious else "off"
     if spec.control is not None:
         # "DNSBL Control" (CFG_DNSBL_SETTINGS/pfb_control -> ini python_control). Folded into
         # the replace so the control state rides the same write as every other toggle — see

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1105,7 +1105,7 @@ def _php_kv_array(data: dict[str, str]) -> str:
 
 
 def pin_cron_due(vm: SmokeVM) -> int:
-    """Set pfb_reuse='' and pfb_dailystart=date('G') on the guest so an EveryDay feed is due.
+    """Set pfb_reuse='off' and pfb_dailystart=date('G') on the guest so an EveryDay feed is due.
 
     Returns the guest's wall-clock hour (0-23) pinned into ``pfb_dailystart``, echoed back
     atomically with the write. Callers that later run ``cron`` should fast-guard against an
@@ -1116,7 +1116,7 @@ def pin_cron_due(vm: SmokeVM) -> int:
     sentinel_open, sentinel_close = "<<<HOUR>>>", "<<<END>>>"
     snippet = (
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
-        "$g['pfb_reuse'] = '';\n"
+        "$g['pfb_reuse'] = 'off';\n"
         "$hour = date('G');\n"
         "$g['pfb_dailystart'] = $hour;\n"
         f"config_set_path({_php_str(CFG_GLOBAL)}, $g);\n"

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -19,6 +19,7 @@ primitives.
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -26,6 +27,78 @@ from . import helpers as h
 from .conftest import STUB_DNS_A, SmokeVM, _StubDnsServer, expected_control_answer
 
 pytestmark = pytest.mark.smoke
+
+
+def _capture_php_eval(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    snippets: list[str] = []
+
+    def capture(_vm: object, snippet: str, *, timeout: float = 60.0) -> SimpleNamespace:
+        del timeout
+        snippets.append(snippet)
+        return SimpleNamespace(returncode=0, stdout="OK", stderr="")
+
+    monkeypatch.setattr(h, "php_eval", capture)
+    return snippets
+
+
+def test_explicit_off_toggle_helpers_write_canonical_adapter_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adapter-backed boolean Off writes use ``'off'` instead of the absent ``''`` state."""
+    snippets = _capture_php_eval(monkeypatch)
+    vm = SmokeVM("")
+
+    h.set_dnsvip_auto(vm, False)
+    h.set_dnsbl_enabled(vm, False)
+    h.set_dnsbl_cache_flush(vm, False)
+    h.set_package_enabled(vm, False)
+    h.set_ip_reputation(vm)
+    h.set_ip_suppression(vm)
+    h.set_dnsbl_nonat(vm, False)
+
+    expected = (
+        "$d['pfb_dnsvip_auto'] = 'off';",
+        "$d['pfb_dnsbl'] = 'off';",
+        "$d['pfb_cache_flush'] = 'off';",
+        "$g['enable_cb'] = 'off';",
+        "$rep['enable_dedup'] = 'off';",
+        "$rep['enable_pdup'] = 'off';",
+        "$ip['suppression'] = 'off';",
+        "$d['pfb_dnsbl_nonat'] = 'off';",
+    )
+    for assignment in expected:
+        assert any(assignment in snippet for snippet in snippets), f"missing explicit Off assignment: {assignment}"
+
+
+def test_explicit_off_inject_dnsbl_lists_writes_idn_adapter_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Multi-list injection keeps both adapter-backed IDN Off toggles canonical."""
+    snippets = _capture_php_eval(monkeypatch)
+    monkeypatch.setattr(h, "set_control_records", lambda *args, **kwargs: None)
+    spec = h.DnsblCase(
+        aliasname="idn-off",
+        feed_url="/var/db/pfblockerng/idn-off.txt",
+        idn_block_malicious=False,
+        idn_escalate_suspicious=False,
+    )
+
+    h.inject_dnsbl_lists(SmokeVM(""), [(spec, "Deny")])
+
+    assert len(snippets) == 1
+    assert "'pfb_idn_block_malicious' => 'off'" in snippets[0]
+    assert "'pfb_idn_escalate_suspicious' => 'off'" in snippets[0]
+
+
+def test_explicit_off_dnsbl_inject_snippet_writes_idn_adapter_tokens() -> None:
+    """Single-list injection uses the same canonical IDN Off representation."""
+    spec = h.DnsblCase(
+        aliasname="idn-off",
+        feed_url="/var/db/pfblockerng/idn-off.txt",
+        idn_block_malicious=False,
+        idn_escalate_suspicious=False,
+    )
+
+    snippet = h._dnsbl_inject_snippet(spec)
+
+    assert "'pfb_idn_block_malicious' => 'off'" in snippet
+    assert "'pfb_idn_escalate_suspicious' => 'off'" in snippet
 
 
 @pytest.fixture(scope="module")

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -35,7 +35,7 @@ def _capture_php_eval(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     def capture(_vm: object, snippet: str, *, timeout: float = 60.0) -> SimpleNamespace:
         del timeout
         snippets.append(snippet)
-        return SimpleNamespace(returncode=0, stdout="OK", stderr="")
+        return SimpleNamespace(returncode=0, stdout="OK<<<HOUR>>>12<<<END>>>", stderr="")
 
     monkeypatch.setattr(h, "php_eval", capture)
     return snippets
@@ -53,6 +53,7 @@ def test_explicit_off_toggle_helpers_write_canonical_adapter_token(monkeypatch: 
     h.set_ip_reputation(vm)
     h.set_ip_suppression(vm)
     h.set_dnsbl_nonat(vm, False)
+    h.pin_cron_due(vm)
 
     expected = (
         "$d['pfb_dnsvip_auto'] = 'off';",
@@ -63,6 +64,7 @@ def test_explicit_off_toggle_helpers_write_canonical_adapter_token(monkeypatch: 
         "$rep['enable_pdup'] = 'off';",
         "$ip['suppression'] = 'off';",
         "$d['pfb_dnsbl_nonat'] = 'off';",
+        "$g['pfb_reuse'] = 'off';",
     )
     for assignment in expected:
         assert any(assignment in snippet for snippet in snippets), f"missing explicit Off assignment: {assignment}"

--- a/tests/smoke/test_smoke_helpers.py
+++ b/tests/smoke/test_smoke_helpers.py
@@ -42,7 +42,7 @@ def _capture_php_eval(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 
 
 def test_explicit_off_toggle_helpers_write_canonical_adapter_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Adapter-backed boolean Off writes use ``'off'` instead of the absent ``''`` state."""
+    """Adapter-backed boolean Off writes use ``'off'`` instead of the absent ``''`` state."""
     snippets = _capture_php_eval(monkeypatch)
     vm = SmokeVM("")
 


### PR DESCRIPTION
## Summary

- store the disabled suppression state as canonical `off` in the shared smoke helper, so PfbConfig does not resolve it as absent and restore the default-on state
- sweep every boolean-empty write in `tests/smoke/helpers.py` and make every PfbToggle-adapted helper use explicit `off`
- add focused helper coverage while leaving production gateway behavior and test fixtures unchanged

## Sibling sweep

Changed adapter-backed helpers/fields:

- `pin_cron_due`: `pfb_reuse`
- `set_dnsvip_auto`: `pfb_dnsvip_auto`
- `set_dnsbl_enabled`: `pfb_dnsbl`
- `set_dnsbl_cache_flush`: `pfb_cache_flush`
- `set_package_enabled`: `enable_cb`
- `set_ip_reputation`: `enable_dedup`, `enable_pdup`
- `set_ip_suppression`: `suppression`
- `set_dnsbl_nonat`: `pfb_dnsbl_nonat`
- single- and multi-list DNSBL injection: `pfb_idn_block_malicious`, `pfb_idn_escalate_suspicious`

Confirmed correct and unchanged: raw/unadapted `enable_dup`, `tld_wildcard`, `pfb_control`, and `pfb_control_legacy` still use `''`; already-canonical adapter-backed helpers (`pfb_keep`, `pfb_dnsbl_lenient`, HSTS injection, and `pfb_feed_sanity` through PfbConfig) needed no change. The sweep found no separate defect.

## Verification

- issue-carried live RED: isolated dedup selected one test and failed with empty deny/snapshot directories; the public-IP suppression control selected one and passed
- frozen focused proof: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`
- focused helper tests: `3 passed, 23 deselected`
- full helper module: `19 passed, 7 skipped`
- `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS`
- independent step gate: PASS
- exact-head PR CI at `64904408`: PASS (required checks; live UI fan-out skipped by workflow scope)
- exact-head live smoke: BLOCKED after five capped lease attempts; direct SSH probes returned `No route to host` for all eight configured boxes, so zero tests were selected or executed and no live GREEN is claimed

No production files, fixtures, scheduling surfaces, apply path, or Alerts page changed.

Fixes #2072

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
