### PR TITLE
pfblockerng: fix stats hostname boundary

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1901,14 +1901,14 @@ function pfb_truncate($value, $length) {
 }
 
 // Compose the resolved-hostname stats cell for the IP src/dst-in stats. The raw
-// hostname is attacker-influenceable, so HTML-encode it; a >=45-char value is
+// hostname is attacker-influenceable, so HTML-encode it; a >45-char value is
 // truncated for display with the full value kept in the title attribute.
 // issue #1069: truncate the RAW value THEN encode -- encoding first then substr()
 // can split a named entity (&quot; -> &qu) or a multibyte char.
 function pfb_stat_hostname_cell($resolved) {
 	$resolved = (string) $resolved;
 	$full = pfb_hsc($resolved);
-	if (mb_strlen($resolved, 'UTF-8') >= 45) {
+	if (mb_strlen($resolved, 'UTF-8') > 45) {
 		$title = "title=\"{$full}\"";
 		$cell  = pfb_hsc(pfb_truncate($resolved, 45)) . "<small>...</small>";
 	} else {

--- a/tests/php/AlertsStatHostnameCellTest.php
+++ b/tests/php/AlertsStatHostnameCellTest.php
@@ -15,9 +15,9 @@ use PHPUnit\Framework\TestCase;
  *   Background:
  *     Given a resolved hostname folded into a <span title="..."><small> cell
  *
- * Branch coverage (both sides of the >=45 length gate, asserted):
- *   - short (<45): encoded in full, no title attr, no "..." ellipsis.
- *   - long (>=45): truncated cell + full value in the title attr.
+ * Branch coverage (both sides of the >45 length gate, asserted):
+ *   - short (<=45): encoded in full, no title attr, no "..." ellipsis.
+ *   - long (>45): truncated cell + full value in the title attr.
  *
  * Regression (issue #1069): the value must be truncated RAW then encoded.
  * Encoding first then substr() can split a named entity ("&quot;" -> "&qu") or a
@@ -100,6 +100,32 @@ final class AlertsStatHostnameCellTest extends TestCase
         $this->assertStringContainsString('title="', $cell, 'a long value keeps the full value in a title attr');
         $this->assertStringNotContainsString('&lt;', $cell, 'benign input must not produce stray entities');
         $this->assertStringNotContainsString('&amp;', $cell, 'benign input has no & to encode');
+    }
+
+    public function test_hostname_truncation_boundary_keeps_exact_limit_without_ellipsis(): void
+    {
+        $resolved = [
+            44 => str_repeat('a', 44),
+            45 => str_repeat('b', 45),
+            46 => str_repeat('c', 46),
+        ];
+        $actual = [];
+
+        foreach ($resolved as $length => $hostname) {
+            $this->assertSame($length, mb_strlen($hostname, 'UTF-8'));
+            $cell = pfb_stat_hostname_cell($hostname);
+            $actual[$length] = [
+                'visible' => strip_tags($cell),
+                'ellipsis' => str_contains($cell, '<small>...</small>'),
+                'title' => str_contains($cell, 'title="' . $hostname . '"'),
+            ];
+        }
+
+        $this->assertSame([
+            44 => ['visible' => $resolved[44], 'ellipsis' => FALSE, 'title' => FALSE],
+            45 => ['visible' => $resolved[45], 'ellipsis' => FALSE, 'title' => FALSE],
+            46 => ['visible' => str_repeat('c', 45) . '...', 'ellipsis' => TRUE, 'title' => TRUE],
+        ], $actual);
     }
 
     public function test_invalid_utf8_in_truncated_hostname_uses_replacement_character(): void

--- a/tests/smoke/ui/test_alerts_seed_restore.py
+++ b/tests/smoke/ui/test_alerts_seed_restore.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, cast
 import pytest
 
 from . import test_alerts_render_verify as alerts
+from . import test_alerts_stat_hostname_boundary as hostname_boundary
 
 
 def test_alert_fixture_ip_rows_match_current_csv_schema() -> None:
@@ -86,6 +87,27 @@ class _WrappedVM:
         if self.raise_after is not None and self.raise_after(remote):
             raise subprocess.TimeoutExpired(remote, timeout)
         return result
+
+
+def test_hostname_boundary_fixture_restores_log_after_seed_write_failure(tmp_path: Path, monkeypatch: Any) -> None:
+    log = tmp_path / "ip_block.log"
+    original = b"original log contents\n"
+    log.write_bytes(original)
+
+    class _SeedWriteFailure:
+        @staticmethod
+        def run(*args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args[0], 1, "", "injected seed failure")
+
+    monkeypatch.setattr(hostname_boundary, "IP_BLOCK_LOG", str(log))
+    monkeypatch.setattr(hostname_boundary, "subprocess", _SeedWriteFailure)
+    fixture = cast(Any, hostname_boundary.exact_ip_block_log).__wrapped__(_LocalVM())
+
+    with pytest.raises(AssertionError, match="failed to seed"):
+        next(fixture)
+
+    assert log.read_bytes() == original
+    assert not Path(f"{log}.bak-2117").exists()
 
 
 def _matrix_paths(tmp_path: Path) -> tuple[list[Path], Path, Path]:

--- a/tests/smoke/ui/test_alerts_stat_hostname_boundary.py
+++ b/tests/smoke/ui/test_alerts_stat_hostname_boundary.py
@@ -57,26 +57,27 @@ def exact_ip_block_log(smoke_vm: SmokeVM) -> Iterator[None]:
         moved = vm.ssh("mv", IP_BLOCK_LOG, backup, timeout=15)
         assert moved.returncode == 0, f"failed to back up {IP_BLOCK_LOG}: {moved.stderr!r}"
 
-    written = subprocess.run(
-        vm.ssh_argv("tee", IP_BLOCK_LOG),
-        input="".join(_ip_row(ip, hostname) for ip, hostname in CASES),
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
-    )
-    assert written.returncode == 0, f"failed to seed {IP_BLOCK_LOG}: {written.stderr!r}"
+    try:
+        written = subprocess.run(
+            vm.ssh_argv("tee", IP_BLOCK_LOG),
+            input="".join(_ip_row(ip, hostname) for ip, hostname in CASES),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert written.returncode == 0, f"failed to seed {IP_BLOCK_LOG}: {written.stderr!r}"
 
-    yield
-
-    removed = vm.ssh("rm", "-f", IP_BLOCK_LOG, timeout=15)
-    assert removed.returncode == 0, f"failed to remove seeded {IP_BLOCK_LOG}: {removed.stderr!r}"
-    if had_file:
-        restored = vm.ssh("mv", backup, IP_BLOCK_LOG, timeout=15)
-        assert restored.returncode == 0, f"failed to restore {IP_BLOCK_LOG}: {restored.stderr!r}"
-    assert vm.ssh("test", "!", "-e", backup, timeout=15).returncode == 0, (
-        f"{IP_BLOCK_LOG} restore did not take; backup {backup!r} remains"
-    )
+        yield
+    finally:
+        removed = vm.ssh("rm", "-f", IP_BLOCK_LOG, timeout=15)
+        assert removed.returncode == 0, f"failed to remove seeded {IP_BLOCK_LOG}: {removed.stderr!r}"
+        if had_file:
+            restored = vm.ssh("mv", backup, IP_BLOCK_LOG, timeout=15)
+            assert restored.returncode == 0, f"failed to restore {IP_BLOCK_LOG}: {restored.stderr!r}"
+        assert vm.ssh("test", "!", "-e", backup, timeout=15).returncode == 0, (
+            f"{IP_BLOCK_LOG} restore did not take; backup {backup!r} remains"
+        )
 
 
 def test_ip_block_stats_truncates_only_beyond_45_characters(

--- a/tests/smoke/ui/test_alerts_stat_hostname_boundary.py
+++ b/tests/smoke/ui/test_alerts_stat_hostname_boundary.py
@@ -1,0 +1,102 @@
+"""Tier-A coverage for the Alerts IP Block Stats hostname boundary (#2117).
+
+The stats pipeline reads resolved hostnames from ``ip_block.log`` field 18 and
+renders them through ``pfb_stat_hostname_cell()``. Exact 44/45/46-code-point
+rows pin the public page contract: only the 46-character hostname truncates.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+from .webui import row_containing
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+IP_BLOCK_LOG = "/var/log/pfblockerng/ip_block.log"
+IP_BLOCK_STATS = "/pfblockerng/pfblockerng_alerts.php?view=ip_block_stat"
+FIXED_TS = "2030-08-03 00:00:00"
+
+CASES = (
+    ("192.0.2.211", "a" * 44),
+    ("192.0.2.212", "b" * 45),
+    ("192.0.2.213", "c" * 46),
+)
+
+
+def _ip_row(ip: str, hostname: str) -> str:
+    """Return one current-schema inbound IP block row with ``hostname`` as rhost."""
+    return (
+        f"{FIXED_TS},100,em0,WAN,block,4,6,TCP,{ip},10.0.0.5,12345,443,"
+        f"in,US,pfB2117Alias,{ip},PFB2117Feed,{hostname},Unknown,Unknown,,,+\n"
+    )
+
+
+@pytest.fixture
+def exact_ip_block_log(smoke_vm: SmokeVM) -> Iterator[None]:
+    """Replace ``ip_block.log`` with the three rows, then restore exact prior state."""
+    vm = smoke_vm
+    backup = f"{IP_BLOCK_LOG}.bak-2117"
+    had_file = vm.ssh("test", "-f", IP_BLOCK_LOG, timeout=15).returncode == 0
+    no_stale_backup = vm.ssh("test", "!", "-e", backup, timeout=15)
+    assert no_stale_backup.returncode == 0, f"refusing to overwrite stale backup {backup!r}"
+
+    ensure = vm.ssh("mkdir", "-p", IP_BLOCK_LOG.rsplit("/", 1)[0], timeout=15)
+    assert ensure.returncode == 0, f"failed to create log directory: {ensure.stderr!r}"
+    if had_file:
+        moved = vm.ssh("mv", IP_BLOCK_LOG, backup, timeout=15)
+        assert moved.returncode == 0, f"failed to back up {IP_BLOCK_LOG}: {moved.stderr!r}"
+
+    written = subprocess.run(
+        vm.ssh_argv("tee", IP_BLOCK_LOG),
+        input="".join(_ip_row(ip, hostname) for ip, hostname in CASES),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert written.returncode == 0, f"failed to seed {IP_BLOCK_LOG}: {written.stderr!r}"
+
+    yield
+
+    removed = vm.ssh("rm", "-f", IP_BLOCK_LOG, timeout=15)
+    assert removed.returncode == 0, f"failed to remove seeded {IP_BLOCK_LOG}: {removed.stderr!r}"
+    if had_file:
+        restored = vm.ssh("mv", backup, IP_BLOCK_LOG, timeout=15)
+        assert restored.returncode == 0, f"failed to restore {IP_BLOCK_LOG}: {restored.stderr!r}"
+    assert vm.ssh("test", "!", "-e", backup, timeout=15).returncode == 0, (
+        f"{IP_BLOCK_LOG} restore did not take; backup {backup!r} remains"
+    )
+
+
+def test_ip_block_stats_truncates_only_beyond_45_characters(
+    smoke_vm: SmokeVM, webui: WebUI, exact_ip_block_log: None
+) -> None:
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    response = webui.get(IP_BLOCK_STATS)
+    result = evaluate_render(IP_BLOCK_STATS, response.status_code, response.text, ("IP Block Stats",))
+    assert result.ok, f"Tier-A render oracle failed for IP Block Stats: {result.detail}"
+
+    for ip, hostname in CASES[:2]:
+        row = row_containing(response.text, ip)
+        expected = f"<br /><span ><small>{hostname}</small></span>"
+        assert expected in row, f"{len(hostname)}-character hostname did not render in full:\n{row}"
+
+    ip, hostname = CASES[2]
+    row = row_containing(response.text, ip)
+    expected = f'<br /><span title="{hostname}"><small>{hostname[:45]}<small>...</small></small></span>'
+    assert expected in row, f"46-character hostname did not keep 45 characters plus ellipsis:\n{row}"
+
+    guard.assert_no_growth()


### PR DESCRIPTION
## Summary

- Follow the owner ruling: truncate resolved stats hostnames only when their UTF-8 character count exceeds 45; keep the 45-character cut.
- Pin 44/45/46 behavior in PHPUnit: 44 and 45 render fully without an ellipsis or title; 46 renders 45 characters plus the ellipsis and preserves the full hostname in `title`.
- Add reachable Tier-A `ui_render` coverage through the authenticated IP Block Stats page with exact controlled `ip_block.log` rows.
- Leave issue #2009's byte/character standardization untouched.

## Alerts sibling-site audit

No sibling truncation site on `pfblockerng_alerts.php` shares this mismatch. Every other `mb_strlen(...) >= limit` guard pairs with a `pfb_truncate(..., limit - 1)` cut (including the variable Unified/classic widths), so an ellipsis at the threshold always represents omitted text. `pfb_stat_hostname_cell()` was the only `>= 45` guard paired with a same-length cut of 45.

## Red to green

Frozen reproduction hash: `1a7023ffc4266163b0bf364df65f63ff729a4e0b`

```text
vendor/bin/phpunit --filter test_hostname_truncation_boundary_keeps_exact_limit_without_ellipsis tests/php/AlertsStatHostnameCellTest.php
RED: 1 failure; only n=45 differed (visible full value, ellipsis=true, title=true)
GREEN: OK (1 test, 4 assertions)

scripts/agent/verify-red-proof.sh ... --base-ref HEAD~1
FREEZE-OK
RED-OK
GREEN-OK
VERDICT: PASS
```

## Verification

- `vendor/bin/phpunit tests/php/AlertsStatHostnameCellTest.php` — `OK (7 tests, 36 assertions)`
- `python3 -m pytest --collect-only tests/smoke/ui/test_alerts_stat_hostname_boundary.py --override-ini='addopts='` — 1 Tier-A test collected
- `scripts/agent/run-gates.sh --diff origin/devel` — `GATES: PASS` (pytest, Ruff, mypy, PHP syntax, PHPUnit, PHPStan, PHPCS)
- Commit hooks — passed

Fixes #2117

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
