### PR TITLE
scheduler: pace apply reconciliation via ledger

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1493,10 +1493,13 @@ next success. Open is idempotent-by-key: opening an already-open key refreshes
 
 ### Tick-driven reconciliation — apply stage only
 
-`pfblockerng_tick()` gains one **unconditional** step (runs every tick regardless of due-ness,
-placed after conditional SafeSearch handling and before the log-maintenance tail — it never sets
-`$dispatched`, so it doesn't interact with the log-trim race guard) that, for every open
-`stage=apply` entry:
+`pfblockerng_tick()` gains an independent `apply_reconcile` due-ledger job with a fixed
+zero-jitter **900-second** interval, placed after conditional SafeSearch handling and before the
+log-maintenance tail. It takes `pfb_apply_reconcile.lock`, rechecks due-ness under the bounded
+exclusive lock, runs one reconciliation scan, and marks the anchored next slot only after that
+scan completes. It never sets `$dispatched`, so it does not interact with the log-trim race
+guard. A lock/open failure or thrown scan remains due for the next scheduled attempt. The scan handles every
+open `stage=apply` entry:
 
 - **IP:** re-applies the already-persisted mirror directly — `pfb_pfctl_table_op($item,
   'replace', '-f '.escapeshellarg("{$pfb['aliasdir']}/{$item}.txt"))` when the mirror exists
@@ -1508,17 +1511,17 @@ placed after conditional SafeSearch handling and before the log-maintenance tail
   re-runs `pfb_dnsbl_apply_ledger_update()` to re-settle the entry either way.
 
 **Deliberate narrowing (permanent, not a stopgap):** the DNSBL retry is a sentinel-re-flip only,
-**not** a full stop/restart. Re-invoking `pfb_reload_unbound()`'s restart fallback from every
-15-minute tick would restart a live DNS resolver indefinitely for a condition that stays
+**not** a full stop/restart. Re-invoking `pfb_reload_unbound()`'s restart fallback from each
+reconciliation attempt would restart a live DNS resolver indefinitely for a condition that stays
 genuinely stuck — heavier than this mechanism's own "no network I/O, no feed re-parse" premise.
 Consequence: a **genuinely** stuck DNSBL apply condition (Unbound fully down, a real conf/build
-failure) does **not** self-heal via the tick alone — it stays open/yellow until an operator's own
+failure) does **not** self-heal via the reconciliation job alone — it stays open/yellow until an operator's own
 Force Reload/Update pass (which does run the full restart path) or Unbound's own recovery
-resolves it. A stuck IP `pfctl` condition, by contrast, self-heals within one tick interval —
+resolves it. A stuck IP `pfctl` condition, by contrast, self-heals within one reconciliation interval —
 the two facilities are not symmetric on this specific point, by design.
 
 Retry is unbounded and uncounted — no attempt-count field, no backoff timer, per direct
-instruction (a genuinely un-fixable condition retries forever at tick cadence; cheap
+instruction (a genuinely un-fixable condition retries forever at the 900-second reconciliation cadence; cheap
 per-attempt, accepted as fine). Download/parse-stage entries are never touched by this step —
 those failures stay ledger-visible but retry only at their normal fetch/parse cadence.
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3854,7 +3854,7 @@ function pfb_tick_seed(): string
  *
  * Delegates to the due-ledger API for each job. The $now, $seed, and
  * $dbdir are injectable so PHPUnit can verify cadence without filesystem or
- * wall-clock dependencies. SafeSearch has its own zero-jitter 900-second entry.
+ * wall-clock dependencies. SafeSearch and apply reconciliation have their own zero-jitter 900-second entries.
  *
  * @param int    $now            Current epoch timestamp.
  * @param string $seed           Per-install seed for seeded_jitter.
@@ -3878,6 +3878,7 @@ function pfb_tick_due_jobs(
 		'dcc'        => pfb_due_ledger_is_due('dcc',        86400,          $now, $seed, $jitter_max, $dbdir),
 		'bl'         => pfb_due_ledger_is_due('bl',         $bl_interval,   $now, $seed, $jitter_max, $dbdir),
 		'ss_refresh' => $ss_refresh_due,
+		'apply_reconcile' => pfb_due_ledger_is_due('apply_reconcile', 900, $now, $seed, 0, $dbdir),
 	];
 }
 
@@ -3991,8 +3992,9 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir, float $t
  * pfblockerng_tick — ADR-43: apply-on-change due-ledger tick dispatcher.
  *
  * Reads the ledger and handles both cadence advancement and separate-process dispatch via
- * exec() for each due job (feeds, dcc, bl). SafeSearch runs when its own due-ledger entry
- * is due; the scheduled log maintenance (pfb_log_mgmt) runs only on an idle tick (see below).
+ * exec() for each due job (feeds, dcc, bl). SafeSearch and apply reconciliation run when
+ * their own due-ledger entries are due; scheduled log maintenance (pfb_log_mgmt) runs only
+ * on an idle tick (see below).
  *
  * Lives here (not in the www/ dispatcher script) rather than the reverse so the
  * PHPUnit bootstrap can load and call the real entrypoint off-appliance: the www
@@ -4027,13 +4029,17 @@ function pfb_due_ledger_is_pending(string $job_key, string $ledger_dir, float $t
  * $ps_lines is injectable for hermetic off-appliance tests; NULL preserves the
  * appliance's host process-table scan. $ss_refresh is an optional test seam; NULL calls
  * the production SafeSearch refresher. $ss_lock_opener and $ss_lock_timeout are test seams
- * for the bounded refresh lock; defaults use fopen() and a 5-second budget.
+ * for the bounded refresh lock; defaults use fopen() and a 5-second budget. The apply
+ * reconciliation callable, lock opener, and timeout are equivalent test seams.
  */
 function pfblockerng_tick(
 	?array $ps_lines = NULL,
 	?callable $ss_refresh = NULL,
 	?callable $ss_lock_opener = NULL,
-	float $ss_lock_timeout = 5.0
+	float $ss_lock_timeout = 5.0,
+	?callable $apply_reconcile = NULL,
+	?callable $apply_lock_opener = NULL,
+	float $apply_lock_timeout = 5.0
 ): void
 {
 	global $pfb;
@@ -4185,17 +4191,51 @@ function pfblockerng_tick(
 		}
 	}
 
-	// ADR-61: apply-stage reconciliation. Unconditional -- never gated on $due or
-	// pending state -- and touches ONLY stage='apply' entries (Semantics #5);
-	// download/parse/dedup stages keep their normal cadence, untouched here.
-	foreach (pfb_sync_status_list_open($dbdir) as $entry) {
-		if ($entry['stage'] !== 'apply') {
-			continue;
-		}
-		if ($entry['facility'] === 'ip') {
-			pfb_ip_apply_retry($entry['item']);
-		} elseif ($entry['facility'] === 'dnsbl') {
-			pfb_dnsbl_apply_retry();
+	// ADR-61: apply-stage reconciliation has its own zero-jitter 900-second
+	// ledger entry, independent of feed tick cadence. Only apply entries are touched.
+	if ($due['apply_reconcile']) {
+		$apply_lock_path = "{$dbdir}/pfb_apply_reconcile.lock";
+		$apply_default_opener = ($apply_lock_opener === NULL);
+		$apply_lock = $apply_default_opener ? @fopen($apply_lock_path, 'c') : $apply_lock_opener($apply_lock_path);
+		if ($apply_lock === FALSE || !is_resource($apply_lock)) {
+			pfb_logger("\nTick: apply reconciliation lock open failed [ {$apply_lock_path} ]", 2);
+		} else {
+			$apply_lock_timed_out = FALSE;
+			if (!pfb_flock_bounded($apply_lock, LOCK_EX, $apply_lock_timeout, $apply_lock_timed_out)) {
+				$reason = $apply_lock_timed_out ? 'timed out' : 'acquire failed';
+				pfb_logger("\nTick: apply reconciliation lock {$reason} [ {$apply_lock_path} ]", 2);
+				if ($apply_default_opener) {
+					@fclose($apply_lock);
+				}
+			} else {
+				try {
+					// Another tick may have completed while this one waited for the lock.
+					if (pfb_due_ledger_is_due('apply_reconcile', 900, $now, $seed, 0, $dbdir)) {
+						if ($apply_reconcile !== NULL) {
+							$apply_reconcile();
+						} else {
+							foreach (pfb_sync_status_list_open($dbdir) as $entry) {
+								if ($entry['stage'] !== 'apply') {
+									continue;
+								}
+								if ($entry['facility'] === 'ip') {
+									pfb_ip_apply_retry($entry['item']);
+								} elseif ($entry['facility'] === 'dnsbl') {
+									pfb_dnsbl_apply_retry();
+								}
+							}
+						}
+						pfb_due_ledger_mark_ran_anchored('apply_reconcile', 900, $now, $seed, 0, $dbdir);
+					}
+				} catch (Throwable $e) {
+					pfb_logger("\nTick: apply reconciliation failed: {$e->getMessage()}", 2);
+				} finally {
+					@flock($apply_lock, LOCK_UN);
+					if ($apply_default_opener) {
+						@fclose($apply_lock);
+					}
+				}
+			}
 		}
 	}
 
@@ -4228,7 +4268,7 @@ function pfblockerng_tick(
 // pfb_sync_status.json under a ledger dir, mirroring pfb_due_ledger_*'s pure,
 // clock-injectable, atomic-write idiom above. Writers/clearers live in
 // pfblockerng.inc; pfblockerng_tick() (above) retries open stage=apply entries
-// every tick. Tests: tests/php/PfbSyncStatusLedgerTest.php
+// when apply_reconcile is due. Tests: tests/php/PfbSyncStatusLedgerTest.php
 // ---------------------------------------------------------------------------
 
 /**

--- a/tests/php/TickApplyReconcileCadenceTest.php
+++ b/tests/php/TickApplyReconcileCadenceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Regression reproduction for issue #2100: apply retries must obey their own ledger. */
+final class TickApplyReconcileCadenceTest extends TestCase
+{
+	private string $dir;
+	private array $originalPfb;
+	private array $originalConfig;
+	private array $tmpfiles = [];
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_tick_apply_cadence_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0755, TRUE);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->originalConfig = $GLOBALS['config'] ?? [];
+		$GLOBALS['pfb'] = [
+			'dbdir' => $this->dir,
+			'aliasdir' => $this->dir,
+			'log' => "{$this->dir}/pfblockerng.log",
+			'errlog' => "{$this->dir}/error.log",
+			'runlog' => "{$this->dir}/run.log",
+			'extraslog' => "{$this->dir}/extras.log",
+		];
+		$GLOBALS['config'] = [];
+		$gen = 'installedpackages/pfblockerng/config/0';
+		config_set_path("{$gen}/pfb_interval", 'Disabled');
+		config_set_path("{$gen}/pfb_quiet_hours", '');
+		$now = time();
+		foreach (['cron', 'dcc', 'bl', 'ss_refresh'] as $job) {
+			pfb_due_ledger_write_entry($job, [
+				'last_run' => $now - 3600,
+				'next_due' => $now + 3600,
+				'jitter' => 0,
+			], $this->dir);
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb'] = $this->originalPfb;
+		$GLOBALS['config'] = $this->originalConfig;
+		foreach ($this->tmpfiles as $file) {
+			@unlink($file);
+		}
+		foreach (glob($this->dir . '/*') ?: [] as $file) {
+			@unlink($file);
+		}
+		@rmdir($this->dir);
+	}
+
+	public function testFutureApplyReconcileEntrySuppressesRetry(): void
+	{
+		$counter = tempnam(sys_get_temp_dir(), 'pfb_tick_apply_counter_');
+		$this->tmpfiles[] = $counter;
+		@unlink($counter);
+		$mock = tempnam(sys_get_temp_dir(), 'pfb_tick_apply_mock_');
+		$this->tmpfiles[] = $mock;
+		$counterArg = escapeshellarg($counter);
+		file_put_contents($mock, "#!/bin/sh\necho x >> {$counterArg}\nexit 1\n");
+		chmod($mock, 0755);
+		$GLOBALS['pfb']['pfctl'] = $mock;
+		file_put_contents("{$this->dir}/pfB_Test_v4.txt", "10.0.0.1\n");
+		pfb_sync_status_open('ip', 'pfB_Test_v4', 'apply', 'seeded failure', $this->dir);
+		$now = time();
+		pfb_due_ledger_write_entry('apply_reconcile', [
+			'last_run' => $now - 900,
+			'next_due' => $now + 3600,
+			'jitter' => 0,
+		], $this->dir);
+
+		pfblockerng_tick();
+
+		$this->assertFileDoesNotExist($counter, 'future apply_reconcile entry must suppress the retry');
+		$entry = pfb_due_ledger_read_entry('apply_reconcile', $this->dir);
+		$this->assertSame($now + 3600, $entry['next_due']);
+	}
+}

--- a/tests/php/TickApplyReconcileFailureTest.php
+++ b/tests/php/TickApplyReconcileFailureTest.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Issue #2100: apply_reconcile failures stay due and overlapping ticks run once. */
+final class TickApplyReconcileFailureTest extends TestCase
+{
+	private string $dir;
+	private array $originalPfb;
+	private array $originalConfig;
+	private bool $hadG = FALSE;
+	private array $originalG = [];
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_tick_apply_failure_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0755, TRUE);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->originalConfig = $GLOBALS['config'] ?? [];
+		$this->hadG = array_key_exists('g', $GLOBALS);
+		$this->originalG = $GLOBALS['g'] ?? [];
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dbdir' => $this->dir,
+			'log' => "{$this->dir}/pfblockerng.log",
+			'errlog' => "{$this->dir}/error.log",
+			'runlog' => "{$this->dir}/run.log",
+			'extraslog' => "{$this->dir}/extras.log",
+		]);
+		$GLOBALS['config'] = [];
+		$gen = 'installedpackages/pfblockerng/config/0';
+		config_set_path("{$gen}/pfb_interval", 'Disabled');
+		config_set_path("{$gen}/pfb_quiet_hours", '');
+		foreach (['pfb_min', 'pfb_hour', 'pfb_dailystart', 'skipfeed'] as $key) {
+			config_set_path("{$gen}/{$key}", '0');
+		}
+		$ip = 'installedpackages/pfblockerngipsettings/config/0';
+		foreach (['suppression', 'database_cc', 'asn_token', 'maxmind_account', 'maxmind_key'] as $key) {
+			config_set_path("{$ip}/{$key}", '');
+		}
+		config_set_path("{$ip}/maxmind_locale", 'en');
+		config_set_path("{$ip}/asn_reporting", 'disabled');
+		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
+		foreach (['pfb_dnsvip4', 'pfb_dnsvip6', 'top1m_enable', 'pfb_cache', 'pfb_py_reply', 'pfb_regex',
+			'pfb_regex_list', 'pfb_cname', 'tld_allow', 'pfb_py_nolog', 'pfb_noaaaa', 'pfb_noaaaa_list',
+			'pfb_gp', 'pfb_gp_bypass_list'] as $key) {
+			config_set_path("{$dnsbl}/{$key}", '');
+		}
+		config_set_path("{$dnsbl}/pfb_dnsport", '8081');
+		config_set_path("{$dnsbl}/pfb_dnsport_ssl", '8443');
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+		$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		$now = time();
+		foreach (['cron', 'dcc', 'bl', 'ss_refresh'] as $job) {
+			pfb_due_ledger_write_entry($job, [
+				'last_run' => $now - 3600,
+				'next_due' => $now + 3600,
+				'jitter' => 0,
+			], $this->dir);
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb'] = $this->originalPfb;
+		$GLOBALS['config'] = $this->originalConfig;
+		if ($this->hadG) {
+			$GLOBALS['g'] = $this->originalG;
+		} else {
+			unset($GLOBALS['g']);
+		}
+		foreach (glob($this->dir . '/*') ?: [] as $file) {
+			@unlink($file);
+		}
+		@rmdir($this->dir);
+	}
+
+	private function seedApply(int $nextDue): void
+	{
+		pfb_due_ledger_write_entry('apply_reconcile', [
+			'last_run' => $nextDue - 900,
+			'next_due' => $nextDue,
+			'jitter' => 0,
+		], $this->dir);
+	}
+
+	private function tick(?callable $worker = NULL, ?callable $opener = NULL, float $timeout = 5.0): void
+	{
+		pfblockerng_tick(NULL, NULL, NULL, 5.0, $worker, $opener, $timeout);
+	}
+
+	public function testDueAttemptMarksAnchoredFutureSlotAndRunsOnce(): void
+	{
+		$priorDue = time() - 100;
+		$this->seedApply($priorDue);
+		$calls = 0;
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+		});
+
+		$this->assertSame(1, $calls);
+		$entry = pfb_due_ledger_read_entry('apply_reconcile', $this->dir);
+		$this->assertSame($priorDue + 900, $entry['next_due'], 'apply_reconcile must use anchored 900-second cadence');
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+		});
+		$this->assertSame(1, $calls, 'future reservation must suppress the next tick');
+	}
+
+	public function testCompletedProductionScanWithNoOpenEntriesAdvancesLedger(): void
+	{
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'production scan precondition must have no open status rows');
+		$this->seedApply(time() - 2700);
+		$this->tick();
+		$entry = pfb_due_ledger_read_entry('apply_reconcile', $this->dir);
+		$this->assertNotNull($entry, 'completed production scan must reserve apply_reconcile');
+		$this->assertSame(0, $entry['jitter'], 'apply_reconcile must have zero jitter');
+		$this->assertSame(900, $entry['next_due'] - $entry['last_run'], 'apply_reconcile cadence must be exactly 900 seconds');
+		$this->assertGreaterThan(time(), $entry['next_due'], 'completed production scan must reserve a future slot');
+	}
+
+	public function testMultiIntervalOverdueRunsOnceAndCatchesUpFromNow(): void
+	{
+		$this->seedApply(time() - 2700);
+		$calls = 0;
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+		});
+		$entry = pfb_due_ledger_read_entry('apply_reconcile', $this->dir);
+		$this->assertSame(1, $calls, 'multiple missed intervals must not burst');
+		$this->assertGreaterThan(time(), $entry['next_due'], 'catch-up reservation must be future-dated');
+		$this->assertSame(900, $entry['next_due'] - $entry['last_run'], 'apply cadence remains exactly 900 seconds');
+	}
+
+	public function testLockOpenFalseAndNonResourceLeaveDueAndRetryable(): void
+	{
+		$priorDue = time() - 1;
+		$this->seedApply($priorDue);
+		$calls = 0;
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+		}, static fn(string $path): mixed => FALSE);
+		$this->assertSame(0, $calls);
+		$this->assertSame($priorDue, pfb_due_ledger_read_entry('apply_reconcile', $this->dir)['next_due']);
+
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+		}, static fn(string $path): mixed => 'not-a-resource');
+		$this->assertSame(0, $calls);
+		$this->assertSame($priorDue, pfb_due_ledger_read_entry('apply_reconcile', $this->dir)['next_due']);
+
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+		});
+		$this->assertSame(1, $calls, 'a cleared opener failure must retry on the next tick');
+	}
+
+	public function testAcquireFailureDoesNotCloseInjectedHandleOrAdvance(): void
+	{
+		$priorDue = time() - 1;
+		$this->seedApply($priorDue);
+		$handle = NULL;
+		$opener = static function () use (&$handle): mixed {
+			$handle = fopen('php://memory', 'r+');
+			return $handle;
+		};
+		$calls = 0;
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+		}, $opener, 0.0);
+		$this->assertSame(0, $calls);
+		$this->assertSame($priorDue, pfb_due_ledger_read_entry('apply_reconcile', $this->dir)['next_due']);
+		$this->assertIsResource($handle);
+		$this->assertSame(1, fwrite($handle, 'x'), 'caller-owned handle must remain open');
+		fclose($handle);
+	}
+
+	public function testLockContentionTimeoutLeavesDueAndRetriesAfterRelease(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl_fork() unavailable; timeout proof needs a lock holder process.');
+		}
+		$priorDue = time() - 1;
+		$this->seedApply($priorDue);
+		$lockPath = "{$this->dir}/pfb_apply_reconcile.lock";
+		$marker = "{$this->dir}/holder-ready";
+		$release = "{$this->dir}/holder-release";
+		$pid = pcntl_fork();
+		if ($pid === -1) {
+			$this->fail('pcntl_fork() failed while creating apply lock holder');
+		}
+		if ($pid === 0) {
+			$holder = fopen($lockPath, 'c');
+			if ($holder === FALSE || !flock($holder, LOCK_EX)) {
+				exit(2);
+			}
+			touch($marker);
+			$deadline = microtime(TRUE) + 3.0;
+			while (!is_file($release) && microtime(TRUE) < $deadline) {
+				usleep(1000);
+			}
+			flock($holder, LOCK_UN);
+			fclose($holder);
+			exit(is_file($release) ? 0 : 3);
+		}
+
+		$handle = NULL;
+		$opener = static function (string $path) use (&$handle): mixed {
+			$handle = fopen($path, 'c');
+			return $handle;
+		};
+		$calls = 0;
+		$status = NULL;
+		try {
+			$this->waitForPath($marker, 3.0);
+			$this->tick(static function () use (&$calls): void {
+				$calls++;
+			}, $opener, 0.01);
+			$this->assertSame(0, $calls, 'contention timeout must not run reconciliation');
+			$this->assertSame($priorDue, pfb_due_ledger_read_entry('apply_reconcile', $this->dir)['next_due']);
+			$this->assertStringContainsString('apply reconciliation lock timed out',
+				(string) @file_get_contents($GLOBALS['pfb']['errlog']));
+		} finally {
+			if (is_resource($handle)) {
+				fclose($handle);
+			}
+			touch($release);
+			pcntl_waitpid($pid, $status);
+		}
+		$this->assertTrue(pcntl_wifexited($status) && pcntl_wexitstatus($status) === 0,
+			'lock holder must exit cleanly before retry');
+
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+		});
+		$this->assertSame(1, $calls, 'released lock must allow one retry');
+		$this->assertGreaterThan(time(), pfb_due_ledger_read_entry('apply_reconcile', $this->dir)['next_due']);
+	}
+
+	public function testThrownWorkerStaysDueAndNextTickRetries(): void
+	{
+		$priorDue = time() - 1;
+		$this->seedApply($priorDue);
+		$calls = 0;
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+			throw new RuntimeException('reconcile failed');
+		});
+		$this->assertSame(1, $calls);
+		$this->assertSame($priorDue, pfb_due_ledger_read_entry('apply_reconcile', $this->dir)['next_due']);
+		$this->tick(static function () use (&$calls): void {
+			$calls++;
+		});
+		$this->assertSame(2, $calls);
+	}
+
+	public function testOverlappingTicksRunOneApplyReconciliation(): void
+	{
+		if (!function_exists('pcntl_fork')) {
+			$this->markTestSkipped('pcntl_fork() unavailable; overlap proof needs separate processes.');
+		}
+		$this->seedApply(time() - 1);
+		$ready = "{$this->dir}/ready";
+		$go = "{$this->dir}/go";
+		$openerStarted = "{$this->dir}/opener-started";
+		$openersRelease = "{$this->dir}/openers-release";
+		$calls = "{$this->dir}/calls";
+		$pids = [];
+		$workerFailures = [];
+		try {
+			for ($i = 0; $i < 2; $i++) {
+				$pid = pcntl_fork();
+				if ($pid === -1) {
+					$this->fail('pcntl_fork() failed');
+				}
+				if ($pid === 0) {
+					try {
+						file_put_contents($ready, "1\n", FILE_APPEND | LOCK_EX);
+						$this->waitForPath($go, 3.0);
+						$opener = static function (string $path) use ($openerStarted, $openersRelease): mixed {
+							file_put_contents($openerStarted, "1\n", FILE_APPEND | LOCK_EX);
+							$deadline = microtime(TRUE) + 3.0;
+							while (!is_file($openersRelease) && microtime(TRUE) < $deadline) {
+								usleep(1000);
+							}
+							if (!is_file($openersRelease)) {
+								throw new RuntimeException('timed out waiting for opener release');
+							}
+							return fopen($path, 'c');
+						};
+						$this->tick(static function () use ($calls): void {
+							file_put_contents($calls, "1\n", FILE_APPEND | LOCK_EX);
+						}, $opener);
+						exit(0);
+					} catch (Throwable $e) {
+						file_put_contents("{$this->dir}/worker-error", $e::class . ': ' . $e->getMessage());
+						exit(1);
+					}
+				}
+				$pids[] = $pid;
+			}
+			$this->assertTrue($this->waitForLineCount($ready, 2, 3.0),
+				'overlap workers did not reach ready barrier; lines=' . $this->lineCount($ready));
+			touch($go);
+			$this->assertTrue($this->waitForLineCount($openerStarted, 2, 3.0),
+				'both workers must pass the outer due check and reach opener; lines=' . $this->lineCount($openerStarted));
+			touch($openersRelease);
+		} finally {
+			touch($go);
+			touch($openersRelease);
+			foreach ($pids as $pid) {
+				pcntl_waitpid($pid, $status);
+				if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0) {
+					$workerFailures[] = "overlap worker {$pid} failed: " . (string) @file_get_contents("{$this->dir}/worker-error");
+				}
+			}
+		}
+		$this->assertSame([], $workerFailures, implode("\n", $workerFailures));
+		$lines = is_file($calls) ? array_values(array_filter(explode("\n", (string) file_get_contents($calls)), 'strlen')) : [];
+		$this->assertCount(1, $lines, 'in-lock due recheck must allow one overlapping reconciliation');
+	}
+
+	private function waitForPath(string $path, float $timeout): void
+	{
+		$deadline = microtime(TRUE) + $timeout;
+		while (!is_file($path) && microtime(TRUE) < $deadline) {
+			usleep(1000);
+		}
+		if (!is_file($path)) {
+			throw new RuntimeException("timed out waiting for {$path}");
+		}
+	}
+
+	private function waitForLineCount(string $path, int $expected, float $timeout): bool
+	{
+		$deadline = microtime(TRUE) + $timeout;
+		while (microtime(TRUE) < $deadline) {
+			if ($this->lineCount($path) >= $expected) {
+				return TRUE;
+			}
+			usleep(1000);
+		}
+		return $this->lineCount($path) >= $expected;
+	}
+
+	private function lineCount(string $path): int
+	{
+		$lines = is_file($path)
+			? array_values(array_filter(explode("\n", (string) file_get_contents($path)), 'strlen'))
+			: [];
+		return count($lines);
+	}
+}

--- a/tests/php/TickApplyReconciliationTest.php
+++ b/tests/php/TickApplyReconciliationTest.php
@@ -8,8 +8,8 @@ use PHPUnit\Framework\TestCase;
 /**
  * ADR-61 Phase 5 — tick-driven apply-stage reconciliation.
  *
- * pfblockerng_tick() gains one unconditional step (fires every tick, never
- * $due-gated) that retries every open stage='apply' ledger entry against
+ * pfblockerng_tick() gains one independent 900-second due-ledger step that retries
+ * every open stage='apply' ledger entry against
  * already-persisted content -- no re-download, re-parse, or re-dedup:
  *   - ip:    pfb_ip_apply_retry() -- a pfctl replace/kill against the aliasdir
  *            mirror, reusing pfb_pfctl_table_op()'s own ledger wiring.
@@ -17,18 +17,16 @@ use PHPUnit\Framework\TestCase;
  *            (no wait, no restart -- see RESULTS/05_Results.txt), then re-run
  *            the existing convergence decision.
  * Unbounded (ADR SS2.4): no attempt counter, no backoff -- a continued failure
- * simply stays open for the next tick. Semantics #5: download/parse/dedup
+ * simply stays open for the next reconciliation slot. Semantics #5: download/parse/dedup
  * stages are never touched by this step.
  *
- * Red→green: before this phase pfblockerng_tick() never read the ledger at
- * all -- every VERIFICATION case below fails against the pre-change worktree
- * because nothing retries (the seeded entry's underlying probe is never
- * invoked a second time).
+ * Red→green: before this phase pfblockerng_tick() had no scheduled apply
+ * reconciliation step.
  *
  * Functions under test:
  *   pfb_ip_apply_retry(string $item): void
  *   pfb_dnsbl_apply_retry(): void
- *   pfblockerng_tick() -- the new unconditional reconciliation step.
+ *   pfblockerng_tick() -- the new due-ledger reconciliation step.
  */
 #[CoversFunction('pfb_ip_apply_retry')]
 #[CoversFunction('pfb_dnsbl_apply_retry')]
@@ -71,7 +69,7 @@ final class TickApplyReconciliationTest extends TestCase
 		// issue #1666: pfb_interval='Disabled' (seeded above) only gates the tick's
 		// cron dispatch branch -- dcc/bl dispatch off the due-ledger regardless of
 		// pfb_interval, and an absent ledger entry reads as due NOW
-		// (pfb_due_ledger_is_due_from_entry()). Without seeding, every tick() call
+		// (pfb_due_ledger_is_due_from_entry()). Without seeding, every reconciliation call
 		// in this suite dispatched a REAL "pfblockerng.php dcc" background shell
 		// that a sibling suite's pfb_update_pass_running() `ps` scan could then see.
 		// Future-date every job so no dispatch branch fires here at all, and neuter
@@ -228,6 +226,15 @@ final class TickApplyReconciliationTest extends TestCase
 		return count(array_filter(explode("\n", (string) file_get_contents($counterFile)), 'strlen'));
 	}
 
+	private function assertApplyReservation(): void
+	{
+		$entry = pfb_due_ledger_read_entry('apply_reconcile', $this->dir);
+		$this->assertNotNull($entry, 'completed reconciliation must reserve apply_reconcile');
+		$this->assertSame(0, $entry['jitter'], 'apply_reconcile must have zero jitter');
+		$this->assertSame(900, $entry['next_due'] - $entry['last_run'], 'apply_reconcile cadence must be exactly 900 seconds');
+		$this->assertGreaterThan(time(), $entry['next_due'], 'completed reconciliation must reserve a future slot');
+	}
+
 	private function writeSentinel(int $gen): void
 	{
 		file_put_contents("{$this->dir}/pfb_py_reload", "{$gen}\n");
@@ -265,9 +272,8 @@ final class TickApplyReconciliationTest extends TestCase
 	 *         proving a real retry attempt happened, not just "no crash".
 	 *   And   the entry is STILL open (continued failure, no backoff, no counter).
 	 *
-	 * Red->green: on pre-Phase-5 code, pfblockerng_tick() never reads the ledger
-	 * at all, so the mock pfctl is never invoked a second time -- the spy count
-	 * stays at 1 (only the seed call), not 2+.
+	 * Red->green: on the pre-reconciliation tick, the apply job was not paced by
+	 * its own due-ledger reservation, so this scheduled retry did not exist.
 	 */
 	public function testTickRetriesOpenIpApplyEntryAndLeavesItOpenOnContinuedFailure(): void
 	{
@@ -297,6 +303,7 @@ final class TickApplyReconciliationTest extends TestCase
 		$this->assertCount(1, $open, 'a continued pfctl failure must leave the entry open (no backoff, no counter)');
 		$this->assertSame('pfB_Test_v4', $open[0]['item']);
 		$this->assertSame('apply', $open[0]['stage']);
+		$this->assertApplyReservation();
 	}
 
 	/**
@@ -306,7 +313,7 @@ final class TickApplyReconciliationTest extends TestCase
 	 *         mock pfctl is swapped in, simulating the table's real state
 	 *         resolving out-of-band).
 	 *   When  pfblockerng_tick() runs once.
-	 *   Then  the entry clears -- self-healed within one tick interval, no
+	 *   Then  the entry clears -- self-healed within one reconciliation interval, no
 	 *         source change / Force Reload required (ADR SS4 item 4).
 	 */
 	public function testTickClearsIpApplyEntryOnceUnderlyingConditionIsFixed(): void
@@ -328,7 +335,7 @@ final class TickApplyReconciliationTest extends TestCase
 		$this->tick();
 
 		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'ip'),
-			'a fixed underlying pfctl condition must clear the entry within one tick');
+			'a fixed underlying pfctl condition must clear the entry within one reconciliation interval');
 	}
 
 	/**
@@ -339,9 +346,8 @@ final class TickApplyReconciliationTest extends TestCase
 	 *   longer has one).
 	 *   When  pfblockerng_tick() runs once.
 	 *   Then  pfctl is invoked with the KILL op, not REPLACE -- there is no
-	 *         mirror content to replace with (pfb_ip_apply_retry()'s branch
-	 *         coverage: every prior test here seeds a mirror file and only
-	 *         exercises the replace branch).
+	 *         mirror content to replace with, and the continued KILL failure
+	 *         leaves the apply entry open for a later retry.
 	 */
 	public function testTickRetriesIpApplyEntryWithKillWhenMirrorFileIsAbsent(): void
 	{
@@ -351,7 +357,7 @@ final class TickApplyReconciliationTest extends TestCase
 		$mockBin = tempnam(sys_get_temp_dir(), 'pfb_pfctl_mock_');
 		$this->tmpfiles[] = $mockBin;
 		$argsLogEsc = escapeshellarg($argsLog);
-		file_put_contents($mockBin, "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> {$argsLogEsc}\nexit 0\n");
+		file_put_contents($mockBin, "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> {$argsLogEsc}\nprintf 'pfctl: EINVAL' >&2\nexit 1\n");
 		chmod($mockBin, 0755);
 
 		// Seed directly -- no mirror file is ever written for this alias.
@@ -368,16 +374,23 @@ final class TickApplyReconciliationTest extends TestCase
 			"expected the mirror-absent retry to invoke pfctl's KILL op, got: {$invocation}");
 		$this->assertStringNotContainsString('-T replace', $invocation,
 			"mirror-absent retry must not invoke REPLACE -- there is no mirror content, got: {$invocation}");
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'continued KILL failure must leave the apply entry open');
+		$this->assertSame('pfB_NoMirror_v4', $open[0]['item']);
+		$this->assertSame('apply', $open[0]['stage']);
+		$this->assertApplyReservation();
 	}
 
 	// -----------------------------------------------------------------------
-	// VERIFICATION (c) — Semantics #5: download/parse entries are untouched
+	// VERIFICATION (c) — Semantics #5: non-apply entries are untouched
 	// -----------------------------------------------------------------------
 
 	/**
 	 * Scenario:
 	 *   Given an open (ip,'pfB_Test_v4',apply) entry (retried/cleared this tick)
-	 *   ALONGSIDE an open (ip,'pfB_Other_v4',download) entry.
+	 *   ALONGSIDE open (ip,'pfB_Other_v4',download), (ip,'pfB_Other_v4',dedup),
+	 *         (ip,'pfB_Other_v4',script), and (dnsbl,'pfb_py_zone.txt',parse) entries.
 	 *   When  pfblockerng_tick() runs once.
 	 *   Then  the download entry's message/first_seen/last_seen are BYTE-IDENTICAL
 	 *         before and after -- proving the tick genuinely never touched it,
@@ -386,10 +399,12 @@ final class TickApplyReconciliationTest extends TestCase
 	public function testTickNeverTouchesDownloadOrParseStageEntries(): void
 	{
 		pfb_sync_status_open('ip', 'pfB_Other_v4', 'download', 'HTTP 404', $this->dir, static fn() => 1000);
+		pfb_sync_status_open('ip', 'pfB_Other_v4', 'dedup', 'dedup failed', $this->dir, static fn() => 1000);
+		pfb_sync_status_open('ip', 'pfB_Other_v4', 'script', 'pre-script failed', $this->dir, static fn() => 1000);
 		pfb_sync_status_open('dnsbl', 'pfb_py_zone.txt', 'parse', 'csv read failed', $this->dir, static fn() => 1000);
 
 		$before = pfb_sync_status_list_open($this->dir);
-		$this->assertCount(2, $before, 'seed: exactly the two non-apply entries must be open, nothing else');
+		$this->assertCount(4, $before, 'seed: exactly the four non-apply entries must be open, nothing else');
 
 		// An apply-stage entry too, so the tick genuinely has an apply row to act on.
 		file_put_contents("{$this->dir}/pfB_Test_v4.txt", "10.0.0.1\n");
@@ -417,7 +432,7 @@ final class TickApplyReconciliationTest extends TestCase
 		$beforeByKey = $byKey($before);
 		$afterByKey  = $byKey($after);
 
-		foreach (['ip|pfB_Other_v4|download', 'dnsbl|pfb_py_zone.txt|parse'] as $key) {
+		foreach (['ip|pfB_Other_v4|download', 'ip|pfB_Other_v4|dedup', 'ip|pfB_Other_v4|script', 'dnsbl|pfb_py_zone.txt|parse'] as $key) {
 			$this->assertArrayHasKey($key, $afterByKey, "expected {$key} to still be open after the tick");
 			$this->assertSame($beforeByKey[$key], $afterByKey[$key],
 				"expected {$key} to be BYTE-IDENTICAL before/after the tick (Semantics #5), got before="
@@ -467,6 +482,7 @@ final class TickApplyReconciliationTest extends TestCase
 			. 'broken -- the entry must stay open (no backoff, no counter)');
 		$this->assertSame('dnsbl', $open[0]['item']);
 		$this->assertSame('apply', $open[0]['stage']);
+		$this->assertApplyReservation();
 	}
 
 	/**
@@ -475,7 +491,7 @@ final class TickApplyReconciliationTest extends TestCase
 	 *   And   the underlying condition is FIXED before the tick runs (applied
 	 *         catches up to sentinel out-of-band -- e.g. the watcher finished).
 	 *   When  pfblockerng_tick() runs once.
-	 *   Then  the entry clears within one tick, no restart / Force Reload.
+	 *   Then  the entry clears within one due reconciliation attempt, no restart / Force Reload.
 	 */
 	public function testTickClearsDnsblApplyEntryOnceUnderlyingConditionIsFixed(): void
 	{
@@ -493,7 +509,7 @@ final class TickApplyReconciliationTest extends TestCase
 		$this->tick();
 
 		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
-			'a fixed underlying convergence condition must clear the entry within one tick');
+			'a fixed underlying convergence condition must clear within one due reconciliation attempt');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/TickCronTest.php
+++ b/tests/php/TickCronTest.php
@@ -117,7 +117,7 @@ final class TickCronTest extends TestCase
 	 *   Background: ledger absent (dir is empty).
 	 *     Given an empty ledger directory.
 	 *     When pfb_tick_due_jobs($now, $seed, $dir, $cron_interval, $bl_interval).
-	 *     Then cron, dcc, bl, ss_refresh are all TRUE (fail-safe: run now, jitter on mark_ran).
+	 *     Then cron, dcc, bl, ss_refresh, apply_reconcile are all TRUE (fail-safe: run now, jitter on mark_ran).
 	 */
 	public function testAllDueWhenLedgerAbsent(): void
 	{
@@ -135,6 +135,9 @@ final class TickCronTest extends TestCase
 		$this->assertTrue($due['ss_refresh'],
 			"ss_refresh: expected TRUE (absent ledger => due-now), got FALSE;\n"
 			. "  now=" . self::NOW . " dir={$this->dir}");
+		$this->assertTrue($due['apply_reconcile'],
+			"apply_reconcile: expected TRUE (absent ledger => due-now), got FALSE;\n"
+			. "  now=" . self::NOW . " dir={$this->dir}");
 	}
 
 	// -----------------------------------------------------------------------
@@ -146,14 +149,14 @@ final class TickCronTest extends TestCase
 	 *
 	 * Scenario:
 	 *   Background: all jobs have next_due = now + 1 hour.
-	 *     Given ledger entries with next_due > now for cron, dcc, bl, ss_refresh.
+	 *     Given ledger entries with next_due > now for cron, dcc, bl, ss_refresh, apply_reconcile.
 	 *     When pfb_tick_due_jobs($now, ...).
-	 *     Then cron, dcc, bl, ss_refresh are all FALSE (not yet due).
+	 *     Then cron, dcc, bl, ss_refresh, apply_reconcile are all FALSE (not yet due).
 	 */
 	public function testNoneDueWhenAllFuture(): void
 	{
 		$future = self::NOW + 3600;
-		foreach (['cron', 'dcc', 'bl', 'ss_refresh'] as $job) {
+		foreach (['cron', 'dcc', 'bl', 'ss_refresh', 'apply_reconcile'] as $job) {
 			pfb_due_ledger_write_entry($job, [
 				'last_run' => self::NOW - self::DAILY,
 				'next_due' => $future,
@@ -175,6 +178,9 @@ final class TickCronTest extends TestCase
 		$this->assertFalse($due['ss_refresh'],
 			"ss_refresh: expected FALSE (next_due in future), got TRUE;\n"
 			. "  now=" . self::NOW . " next_due={$future}");
+		$this->assertFalse($due['apply_reconcile'],
+			"apply_reconcile: expected FALSE (next_due in future), got TRUE;\n"
+			. "  now=" . self::NOW . " next_due={$future}");
 	}
 
 	// -----------------------------------------------------------------------
@@ -186,9 +192,9 @@ final class TickCronTest extends TestCase
 	 *
 	 * Scenario:
 	 *   Background: cron is overdue; dcc and bl are not yet due.
-	 *     Given cron.next_due = now - 1 (past); dcc/bl/ss_refresh.next_due = now + 1h (future).
+	 *     Given cron.next_due = now - 1 (past); dcc/bl/ss_refresh/apply_reconcile.next_due = now + 1h (future).
 	 *     When pfb_tick_due_jobs($now, ...).
-	 *     Then cron = TRUE, dcc = FALSE, bl = FALSE, ss_refresh = FALSE (catch-up for cron only).
+	 *     Then cron = TRUE, dcc = FALSE, bl = FALSE, ss_refresh = FALSE, apply_reconcile = FALSE (catch-up for cron only).
 	 */
 	public function testOnlyCronDueWhenOnlyCronPast(): void
 	{
@@ -201,7 +207,7 @@ final class TickCronTest extends TestCase
 
 		// dcc and bl are not yet due.
 		$future = self::NOW + 3600;
-		foreach (['dcc', 'bl', 'ss_refresh'] as $job) {
+		foreach (['dcc', 'bl', 'ss_refresh', 'apply_reconcile'] as $job) {
 			pfb_due_ledger_write_entry($job, [
 				'last_run' => self::NOW - self::DAILY,
 				'next_due' => $future,
@@ -222,6 +228,9 @@ final class TickCronTest extends TestCase
 			. "  now=" . self::NOW . " next_due={$future}");
 		$this->assertFalse($due['ss_refresh'],
 			"ss_refresh: expected FALSE (next_due in future), got TRUE;\n"
+			. "  now=" . self::NOW . " next_due={$future}");
+		$this->assertFalse($due['apply_reconcile'],
+			"apply_reconcile: expected FALSE (next_due in future), got TRUE;\n"
 			. "  now=" . self::NOW . " next_due={$future}");
 	}
 

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -399,6 +399,9 @@ final class TickEntrypointTest extends TestCase
 		// pfb_log_mgmt(): cap 'log' to 3 lines; every other type stays at the
 		// registry default (20000) -> no-op trim, keeping the test single-purpose.
 		config_set_path("{$gen}/log_max_log", '3');
+		// Apply reconciliation has an independent cadence; keep it idle unless a
+		// test explicitly seeds that job due.
+		$this->seedFutureLedgerEntry('apply_reconcile', time());
 	}
 
 	/**

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -12280,6 +12280,27 @@
                 "variadic": false,
                 "type": "float",
                 "default": "5.0"
+            },
+            {
+                "name": "apply_reconcile",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "apply_lock_opener",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "apply_lock_timeout",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "5.0"
             }
         ]
     },


### PR DESCRIPTION
## Summary

- Schedule apply-stage reconciliation through its own zero-jitter 900-second due-ledger entry.
- Serialize reconciliation with `pfb_apply_reconcile.lock` and recheck due state after acquiring the lock.
- Keep failed IP/DNSBL status rows open for the next scheduled retry; lock/open and thrown worker failures do not advance the ledger.
- Update the scheduling documentation without changing feed, script-stage, calendar-anchor, or crontab behavior.

## Log-maintenance audit answer

The existing self-gating remains adequate at per-minute tick frequency, so log maintenance does not need a due-ledger entry. It still runs only on idle ticks, never overlaps an update pass, and performs mutation only after its line-count or age retention thresholds are crossed. Keeping that lightweight threshold check on every idle tick also preserves the owner-settled next-available-tick behavior.

## Verification

- Frozen RED→GREEN cadence proof (`TickApplyReconcileCadenceTest.php`, hash `84968f500ea14598caba1dd08dc8c6ca68169d48`)
- Independent fixed-field review: PASS
- Focused apply and SafeSearch scheduler suites: 52 tests, 232 assertions
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS after the final rebase

Fixes #2100

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic apply reconciliation scheduling every 15 minutes.
  * Reconciliation attempts now retry after failures and catch up when overdue.
  * Added exclusive locking to prevent overlapping reconciliation runs.
  * Lock and reconciliation errors are logged without interrupting other scheduled tasks.

* **Bug Fixes**
  * Improved handling of failed, interrupted, or contested reconciliation attempts so they remain eligible for retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->