### PR TITLE
pfblockerng: preserve empty toggle storage

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -84,6 +84,12 @@ Authorization is a property of the **write**, not the call site (the
 - **Canonical current storage.** Read adapters accept legacy tokens needed by supported forward
   upgrades; writes emit the current canonical token. They do not constrain new storage to what an
   older package understands.
+- **Adapter presence owns empty-string semantics (issue #2120).** A genuinely absent/`NULL`
+  value resolves to the registry default before every read adapter. A stored `''` reaches an
+  adapter-bearing entry's read adapter, while a plain scalar still treats `''` as not configured
+  and resolves it to the registry default. `PfbConfig::read()` never exposes absence. Writing
+  `NULL` to an adapter-bearing entry deletes that key (and a section write omits it), so absence
+  stays truthful instead of materialising a default; plain-scalar behaviour is unchanged.
 - Enums/booleans are the **internal runtime representation**; conversion at the boundary:
   stored string → enum on read; enum → canonical stored string on write.
 - **The enum owns its stored-value semantics** via the `PfbStoredEnum` interface +
@@ -106,21 +112,28 @@ Authorization is a property of the **write**, not the call site (the
 
 - **PHP adapters / enums** (`PfbToggle`, `PfbIdnMode` + the thin `pfb_cfg_*_read/write`
   delegations) in `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc`:
-  - Every ADAPTER-CARRYING checkbox field → `PfbToggle` (`'on'`/`'off'`; issue #1887 merged the former
-    `PfbLenient` into it). Off is an EXPLICIT stored token; a stored `''` is the
-    not-configured state and resolves to the field's registered default at the gateway,
-    exactly as an absent key does. Tokens are recognised case-insensitively on read;
-    writes always emit canonical lowercase. The runtime `$pfb[]` toggle mirrors carry
+  - Every ADAPTER-CARRYING checkbox field → `PfbToggle` (issue #1887 merged the former
+    `PfbLenient` into it). Read is deliberately narrow and case-insensitive: `on` in any
+    case is `On`; every other present token (`''`, legacy `'off'`, junk) is `Off`.
+    Only genuine absence consults the field's registered default. Writes emit `'on'` for
+    `On` and canonical `''` for `Off`; `'off'` is accepted forever but never written
+    (issue #2120, deliberately reversing #1887's explicit-`'off'` writer). The enum's
+    `Off = 'off'` backing value remains its internal/render identity. The runtime `$pfb[]`
+    toggle mirrors carry
     the enum itself (never `->value`), so consumers compare `=== PfbToggle::On`.
     Registered checkbox fields still on `NULL`/`NULL` adapters (e.g. `pfb_regex`,
     `pfb_noaaaa`, `pfb_gp`, `pfb_py_nolog`, `tld_wildcard`, `top1m_enable`)
     keep the raw `{'on', ''}` storage until they adopt the pair — a field joining the
     adapter set moves all its consumers in the same commit (see below).
-  - **`pfb_cache`/`pfb_py_reply`/`pfb_hsts`/ip-section `suppression` → `PfbToggle`**
-    (issue #1907): default **On** — the de-facto default every settings page has claimed
-    since 3.2. Each carries the registry grandfather map `['' => 'off']` (a 3.2 deliberate
-    uncheck stored `''` and must not resolve to the new `'on'` default), and
-    `pfb_py_reply`/`pfb_hsts` additionally get the `issue1907-python-gated-toggles`
+  - **Nine adapter-bearing toggles default On:** `pfb_keep`, `pfb_software_check`,
+    `pfb_feed_internal_filter`, `pfb_syntax_highlight`, `pfb_cache`, `pfb_py_reply`,
+    `pfb_hsts`, `pfb_idn_block_malicious`, and ip-section `suppression`. For all nine,
+    absence reads On while a stored `''` reads Off. The six former `'' => 'off'`
+    grandfather arms (`pfb_keep`, `pfb_cache`, `pfb_py_reply`, `pfb_hsts`,
+    `pfb_idn_block_malicious`, `suppression`) were retired by #2120 because the runtime
+    adapter now preserves that legacy uncheck and canonical writes use `''`; the separate
+    `pfb_keep` absent → `'on'` grandfather remains. `pfb_py_reply`/`pfb_hsts`
+    additionally get the `issue1907-python-gated-toggles`
     migration: a stored `'on'` beside a pre-upgrade `dnsbl_mode` that is present and not
     `'dnsbl_python'` was inert (both consumers were python-gated in 3.2) and is disabled
     before the ADR-02 python force would otherwise activate it.
@@ -144,14 +157,16 @@ Authorization is a property of the **write**, not the call site (the
     `pfb_alias_delta_batch` (plain string, `NULL`/`NULL` adapters) is the batch-size companion
     field; its stored value is a decimal integer string, clamped to `[64, 4096]` at read time by
     `pfb_alias_delta_batch_clamp()`.
-  - **`pfb_idn` → `PfbIdnMode`** (registry adapters `pfb_cfg_idn_mode_read/write`): tokens
-    `'on'` (= All) / `'confusable'` / `'off'`. `All` **reuses the original `'on'`** block-all
+  - **`pfb_idn` → `PfbIdnMode`** (registry adapters `pfb_cfg_idn_mode_read/write`): live
+    cases are `'on'` (= All), `'confusable'`, and Off. `All` **reuses the original `'on'`** block-all
     token, so current code reading a pre-4.0.0 configuration preserves block-all with no
     migration. `PfbConfig::read('dnsbl/pfb_idn')` returns the enum;
-    `PfbConfig::write()` and the `py_unbound.ini` build both emit `toStored()`; consumers compare
-    `=== PfbIdnMode::All` / `::Confusable`. The 4.0.0-alpha-only `'all'` token is **not** carried
-    (alpha compatibility is intentionally not maintained) — it reads as Off. One canonical
-    vocabulary spans `config.xml`, the ini, and the Python `IdnMode` enum.
+    `PfbConfig::write()` and the `py_unbound.ini` build both emit `toStored()`: Off → `''`,
+    All → `'on'`, Confusable → `'confusable'`. Reads accept both `''` and legacy `'off'`
+    as Off. The 4.0.0-alpha-only `'all'` token is **not** carried (alpha compatibility is
+    intentionally not maintained) — like other unrecognised junk, it keeps the enum's
+    existing `default()` fallback to Off. Consumers compare `=== PfbIdnMode::All` /
+    `::Confusable`; form rendering uses the enum's backing `->value`, not its storage token.
   - **`top1m_source` → `PfbTop1mSource`** (issue #877 review, registry adapters
     `pfb_cfg_top1m_source_read/write`): tokens `'tranco'` (default) / `'cisco'` /
     `'openpagerank'` (#928, replacing ADR-59 P4's `'domcop'`) /
@@ -171,9 +186,10 @@ Authorization is a property of the **write**, not the call site (the
     round-trip, just identity pass-through like any other plain field. Validated on POST
     by `PFB_FILTER_TOKEN` (`pfblockerng.inc`) — a base64url/JWT charset
     (`[A-Za-z0-9._~+/=-]`), NOT `PFB_FILTER_WORD` (which would reject a real token).
-- **Python** (`pfb_unbound.py`): the **`IdnMode` enum** shares that vocabulary — `All = 'on'`,
-  `Confusable = 'confusable'`, `Off = 'off'` — and reads the ini `idn_mode` token directly (the
-  legacy `python_idn` fallback is retained for a config predating the key). The toggle enum has
+- **Python** (`pfb_unbound.py`): the **`IdnMode` enum** keeps the internal cases
+  `All = 'on'`, `Confusable = 'confusable'`, `Off = 'off'`. A present empty or legacy
+  `'off'` ini value reads Off; absent `idn_mode` and unrecognised junk retain the legacy
+  `python_idn` fallback. The toggle enum has
   **no Python consumer** (`config.getboolean()` reads all bool toggles), so it is a
   PHP-only adapter.
 
@@ -209,10 +225,10 @@ The gateway preserves existing behaviour while configurations move forward:
 
 - **Legacy-read invariant** (old store → new code): `PfbConfig::read($key)` on any supported
   legacy stored token returns a well-formed runtime value — no crash, correct type, sane default
-  for absent. `''` and absent are the SAME not-configured state (issue #1887): every gateway
-  entry point (`read()`, `write()`, `writeSection()`) resolves both to the registered default
-  through one shared helper, so a stored `''` can never mean different things to the read and
-  the normalising write paths.
+  for absent. Issue #2120 deliberately reverses #1887's `''`-equals-absence identity for
+  adapter-bearing entries only: genuine absence resolves to the registered default; stored
+  `''` reaches the adapter. Plain scalars retain the #1887 identity. The shared normalization
+  still makes `read()`, `write()`, and `writeSection()` agree on the same distinction.
 - **Grandfather invariant (issue #1921)**: when an absent current default — or a raw legacy
   stored value — would change established behaviour, the registry entry carries a
   `grandfather` map: raw stored value → new value, with the dedicated `PFB_GF_ABSENT` marker
@@ -227,12 +243,10 @@ The gateway preserves existing behaviour while configurations move forward:
 
   | Field | Grandfather map | Why |
   | --- | --- | --- |
-  | `gen/pfb_keep` | `[ABSENT => 'on', '' => 'off']` | #281 upgrade keeps settings; #1887 preserves a 3.2 deliberate uncheck |
+  | `gen/pfb_keep` | `[ABSENT => 'on']` | #281 upgrade keeps settings; #2120's runtime adapter owns the legacy `''` uncheck |
   | `gen/pfb_feed_internal_filter` | `[ABSENT => 'off']` | #1770 — existing feeds are never silently dropped |
   | `gen/pfb_alias_delta_mode` | `[ABSENT => 'replace']` | ADR-40 — an upgrade keeps the pre-ADR-40 full replace |
   | `dnsbl/pfb_dnsbl_lenient` | `[ABSENT => 'on']` | ADR-22 — an upgrade keeps permissive parsing |
-  | `dnsbl/pfb_idn_block_malicious` | `['' => 'off']` | #1887 — the old `?: ''` unchecked save |
-  | `dnsbl/pfb_cache` · `dnsbl/pfb_py_reply` · `dnsbl/pfb_hsts` · `ip/suppression` | `['' => 'off']` | #1907 — default flipped to the page-claimed `'on'`; a 3.2 uncheck stored `''` |
 
   **Every entry carries its decision.** Exactly one of a `grandfather` map or a
   `no_grandfather` reason string per registry entry, with two exceptions carrying neither:
@@ -267,6 +281,10 @@ left untouched) and carries **both** a read and a write adapter, the value is ro
 `read_adapter()` then `write_adapter()` before the section is persisted. A key with no adapter
 pair (plain string) or not present in `$data` passes through byte-identical; `writeSection()`
 never calls `write_config()`.
+
+For an adapter-bearing key, an explicit `NULL` removes that key from the section before the
+section is persisted; an omitted key remains omitted. This matches single-key `write(NULL)`
+deletion. Plain registered scalars retain their existing byte-preserving section behavior.
 
 Before this fix, `writeSection()` called `config_set_path($section, $data)` directly, bypassing
 every adapter — a legacy read-only token (`top1m_source` `'domcop'`/`'alexa'`, `pfb_idn` alpha-only
@@ -342,9 +360,9 @@ legacy token, e.g. `top1m_source` `'alexa'` → `'tranco'`).
 **Migrations persist raw.** `pfb_run_migrations()` and every legacy-reshape write earlier in
 `pfblockerng_install.inc` persist via `PfbConfig::writeSectionRawSystem()` (direct
 `config_set_path()`, no adapter round-trip) — an adapter-riding write-back before the pass
-would resolve a bystander raw `''` to its registered default (`gen/pfb_keep` `''` → `'on'`)
-and destroy the very evidence the grandfather maps key on. Canonicalisation is the pass's
-job. Pinned by `tests/php/InstallPrePassWriteOrderTest.php` (no `writeSectionSystem` before
+would canonicalise a bystander legacy token (for example `top1m_source = 'alexa'`) before
+the registry pass can inspect it. Canonicalisation is the pass's job. Pinned by
+`tests/php/InstallPrePassWriteOrderTest.php` (no `writeSectionSystem` before
 the pass call in the installer) and the raw-bystander regression in
 `MigrationRegistryTest`.
 
@@ -378,8 +396,8 @@ ordering), `tests/php/LegacyKeyRenameMigrationTest.php` (row rename).
 
 | Adapter type | Stored vocabulary |
 | ------------ | ----------------- |
-| `toggle`            | `{'on', 'off'}` (issue #1887; case-insensitive read, lowercase write; a stored `''` ≡ absent → registered default) |
-| `idn`               | write `{'on' (=All), 'confusable', 'off'}`; legacy reads `'all'`→Off, `''`→Off (4.0.0-alpha `'all'` not carried) |
+| `toggle`            | write `{'on', ''}`; case-insensitive `on` read; `''`, legacy `'off'`, and junk → Off; only absence → registered default |
+| `idn`               | write `{'on' (=All), 'confusable', '' (=Off)}`; legacy `'off'` → Off; unrecognised `'all'`/junk keep the Off fallback |
 | `alias_delta_mode`  | `{'auto', 'delta', 'replace'}` — unknown/absent token reads as `'auto'` (ADR-40, since 4.0.0) |
 | `top1m_source`      | write `{'tranco' (default), 'cisco', 'openpagerank', 'majestic', 'cloudflare'}` (majestic ADR-59 P4, cloudflare ADR-59 P5, openpagerank replaced P4's domcop in #928); legacy read `'alexa'`→Tranco (dead service, #872) and `'domcop'`→OpenPageRank (list moved hosting, #928), neither re-emitted |
 | `plain`             | identity — any stored value passes through unchanged |

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -244,7 +244,6 @@ The gateway preserves existing behaviour while configurations move forward:
   | Field | Grandfather map | Why |
   | --- | --- | --- |
   | `gen/pfb_keep` | `[ABSENT => 'on']` | #281 upgrade keeps settings; #2120's runtime adapter owns the legacy `''` uncheck |
-  | `gen/pfb_feed_internal_filter` | `[ABSENT => 'off']` | #1770 — existing feeds are never silently dropped |
   | `gen/pfb_alias_delta_mode` | `[ABSENT => 'replace']` | ADR-40 — an upgrade keeps the pre-ADR-40 full replace |
   | `dnsbl/pfb_dnsbl_lenient` | `[ABSENT => 'on']` | ADR-22 — an upgrade keeps permissive parsing |
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1496,13 +1496,15 @@ def init_standard(id: int, env: module_env) -> bool:
                 pfb["python_tld_wildcard"] = config.getboolean("MAIN", "python_tld_wildcard")
             if config.has_option("MAIN", "python_idn"):
                 pfb["python_idn"] = config.getboolean("MAIN", "python_idn")
-            # ADR-08: the IDN mode. The PHP ini writer emits an explicit
-            # idn_mode = off|all|confusable key; honour it when present, else fall
+            # ADR-08: the IDN mode. The PHP ini writer emits idn_mode = ''|on|confusable;
+            # honour it when present, else fall
             # back to the legacy derivation ('on'->All-IDN, off->Off) for a config
             # written before the key existed.
             if config.has_option("MAIN", "idn_mode"):
                 _raw_idn = config.get("MAIN", "idn_mode").strip().lower()
-                if _raw_idn in (IDN_MODE_OFF, IDN_MODE_ALL, IDN_MODE_CONFUSABLE):
+                if _raw_idn == "":
+                    pfb["idn_mode"] = IdnMode.Off
+                elif _raw_idn in (IDN_MODE_OFF, IDN_MODE_ALL, IDN_MODE_CONFUSABLE):
                     pfb["idn_mode"] = IdnMode(_raw_idn)
                 else:
                     pfb["idn_mode"] = idn_mode_from_legacy(pfb["python_idn"])

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10518,7 +10518,7 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython, array $dnsbl_tld_grou
 	}
 
 	// When pfBlockerNG is disabled and 'keep blocklists' is disabled.
-	// Toggles are 'on'/'off' (PfbToggle, issue #1887); != 'on' covers 'off' and a legacy ''.
+	// Runtime values are PfbToggle enums; anything other than On is disabled.
 	if ($pfb['enable'] !== PfbToggle::On && $pfb['keep'] !== PfbToggle::On && !$pfb['install']) {
 		unlink_if_exists("{$pfb['dnsbl_file']}{$ext}");
 	}
@@ -12138,9 +12138,8 @@ function pfb_legacy_key_rename_migrate($sections) {
  * NEWCFG: the key takes its registered default -- passed once through the grandfather
  * map's own non-ABSENT entries (the ABSENT entry itself is never consulted; it
  * specifically signals an EXISTING install, which a NEWCFG section by definition is
- * not). A handful of registered defaults happen to collide with their own map's
- * non-ABSENT input (e.g. a default of '' where 'grandfather' also carries '' => 'off'
- * -- issue #1907's still-open divergence): materialising the raw default there would
+	 * not). A registered default can collide with its own map's non-ABSENT input;
+	 * materialising the raw default there would
  * mint a value only to have the very next OLDCFG pass (the section is no longer empty
  * once seeded) immediately re-map it, breaking idempotency across a fresh install's
  * first upgrade. Running the default through the SAME lookup once, up front, is a
@@ -12269,11 +12268,10 @@ function pfb_registry_pass(array $sections, ?array $registry = NULL): array {
 
 
 // Whether the feed-host internal-address filter is enabled. Reads the General-settings
-// 'pfb_feed_internal_filter' on/off flag, defaulting to ON when the key is absent (a
-// fresh install ships the filter active; the registry pass's grandfather pins it OFF on an
-// already-configured box so existing feeds are never silently dropped, issue #1921). issue
-// #1887: reads the enum through the gateway — junk now falls back to Off like every other
-// toggle (it was "anything but 'off' is ON"), and case variants are recognised.
+// 'pfb_feed_internal_filter' on/off flag. Absence uses the registered On default; present
+// empty and legacy 'off' are Off. issue #1887: reads the enum through the gateway — junk
+// now falls back to Off like every other toggle (it was "anything but 'off' is ON"), and
+// case variants are recognised.
 function pfb_feed_filter_enabled(): bool {
 
 	return PfbConfig::read('gen/pfb_feed_internal_filter') === PfbToggle::On;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4555,9 +4555,9 @@ function pfb_update_available(?string $installed, ?string $latest): bool {
 
 /*
  * Whether the "Check for new versions" setting (pfb_software_check) is enabled. Default
- * ENABLED: an our-repo install checks for and notifies of new versions out of the box. Only
- * an explicit 'off' (the user un-ticking the box, persisted by the Software page) disables it;
- * an unset value (never saved) or 'on' reads as enabled.
+ * ENABLED: an our-repo install checks for and notifies of new versions out of the box. An
+ * absent value receives that default; case-insensitive 'on' enables it, and every other
+ * present token disables it. The Software page persists unchecked as canonical empty Off.
  */
 function pfb_software_check_enabled(): bool {
 	// issue #1887: the ON default lives in the registry now; the accessor just asks.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -3890,7 +3890,7 @@ function sync_package_pfblockerng($cron='') {
 										// issue #1896: boundary conversion -- the shell script reads this
 										// positional token raw ('on'/'off'), never the enum itself.
 										$pfb_drep_token = $pfb['drep']->toStored();
-										exec("{$pfb['script']} {$args} {$header_esc} {$pfb['max']} {$pfb_drep_token} {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} {$elog}");
+										exec("{$pfb['script']} {$args} {$header_esc} {$pfb['max']} " . escapeshellarg($pfb_drep_token) . " {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} {$elog}");
 									}
 
 									// issue #1084: snapshot the pristine post-preprocessing feed for the

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1392,7 +1392,7 @@ function sync_package_pfblockerng($cron='') {
 	#########################################################
 
 	// When pfBlockerNG is Disabled and 'Keep Blocklists' is Disabled.
-	// Toggles are 'on'/'off' (PfbToggle, issue #1887); != 'on' covers 'off' and a legacy ''.
+	// Runtime toggles are enums; any state other than On disables this path.
 	if ($pfb['enable'] !== PfbToggle::On && $pfb['keep'] !== PfbToggle::On && !$pfb['install']) {
 		$log = "\n  Removing DB Files/Folders \n";
 		pfb_logger("{$log}", 1);
@@ -3888,7 +3888,7 @@ function sync_package_pfblockerng($cron='') {
 									$args = pfb_ip_preprocess_args($pfb['dup'] === PfbToggle::On, $pfb['agg'] === PfbToggle::On, $pfb['rep'] === PfbToggle::On);
 									if (!empty($args)) {
 										// issue #1896: boundary conversion -- the shell script reads this
-										// positional token raw ('on'/'off'), never the enum itself.
+										// positional token raw ('on'/''), never the enum itself.
 										$pfb_drep_token = $pfb['drep']->toStored();
 										exec("{$pfb['script']} {$args} {$header_esc} {$pfb['max']} " . escapeshellarg($pfb_drep_token) . " {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} {$elog}");
 									}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1881,10 +1881,10 @@ final class PfbConfig
 	 * write_adapter(read_adapter(...)). A migration transforms RAW config.xml
 	 * storage: persisting its result through that round-trip would canonicalise a
 	 * still-raw legacy value on a BYSTANDER key (e.g. a stored top1m_source
-	 * 'alexa' the migration never touched) before the registry pass
-	 * (pfb_registry_pass(), issue #1921) gets a chance to see and grandfather it --
-	 * canonicalisation is that pass's job, not a migration's. This method persists
-	 * $data byte-for-byte via config_set_path(), with no adapter involvement at all.
+	 * 'alexa' the migration never touched). pfb_registry_pass() (issue #1921) must
+	 * receive exact stored inputs for its rename/grandfather decisions; unrelated
+	 * legacy tokens remain read-compatible until an ordinary write canonicalises them.
+	 * This method persists $data byte-for-byte via config_set_path().
 	 *
 	 * System-context, same no-session contract as writeSystem()/writeSectionSystem()
 	 * (issue #1895) -- for migrations/install/upgrade callers only, never www/.
@@ -2488,16 +2488,16 @@ function pfb_settings_family_pre_uninstall(): void
 // pfb_run_migrations() to execute all entries in registry order; helper bodies are
 // UNCHANGED, this registry only wraps them.
 //
-// issue #1921: the four grandfather/preservation migrations that used to live here
-// (#1887's two '' preservations, ADR-22's lenient seed, issue #281's pfb_keep seed) are
-// folded into pfb_registry_pass() (pfblockerng.inc), the one registry-driven pass the
-// installer runs AFTER this driver. What remains here is genuinely cross-key or
+// issue #1921 moved the old grandfather/preservation migrations into
+// pfb_registry_pass() (pfblockerng.inc), the one registry-driven pass the installer
+// runs AFTER this driver; issue #2120 later retired its raw-empty maps while retaining
+// the absence maps. What remains here is genuinely cross-key or
 // per-row work pfb_registry_pass() cannot express: the dynamic per-feed row rename,
 // and two bespoke migrations keyed on ANOTHER field's value (ADR-02, PFBL-03) rather
 // than a simple absent/''-map. write-back MUST stay RAW (writeSectionRawSystem(), not
 // writeSectionSystem()) -- see pfb_run_migrations()'s inline comment: canonicalising a
-// still-raw bystander value here, ahead of the registry pass, would destroy exactly
-// the value that pass needs to grandfather.
+// still-raw bystander would mutate a key outside the migration's declared work and hide
+// the exact stored input from the later registry pass.
 // Tests: tests/php/MigrationRegistryTest.php
 // ---------------------------------------------------------------------------
 
@@ -2586,9 +2586,8 @@ function pfb_run_migrations(): void
 			if ($result !== NULL) {
 				foreach ($result as $section => $data) {
 					// issue #1895: upgrade migrations run with no web session in scope.
-					// issue #1921: RAW write-back -- a migration transforms raw storage;
-					// canonicalising a bystander key here, ahead of pfb_registry_pass(),
-					// would destroy the raw value that pass needs to grandfather.
+					// issue #1921: RAW write-back keeps bystander values byte-identical so
+					// pfb_registry_pass() receives exact stored inputs for rename/grandfather decisions.
 					PfbConfig::writeSectionRawSystem($section, $data);
 				}
 				write_config($migration['message']);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -648,7 +648,7 @@ function pfb_cfg_idn_mode_read(mixed $stored): PfbIdnMode
 
 /**
  * Write a PfbIdnMode (enum or legacy string) back to its canonical stored token
- * ('on' | 'confusable' | ''). All persists as the legacy 'on' token (reproduces
+ * ('on' | 'confusable' | ''). All persists as its recognised 'on' token (preserving
  * the prior block-all-IDN behaviour); the 4.0.0-alpha 'all' token falls back to Off.
  */
 function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
@@ -933,14 +933,13 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'ADR-19 Software page capability; #1887 relocated the pre-existing ON default into the registry, absent unchanged',
 		],
 
-		// Internal-address feed-host filter toggle: 'on'|'off'. Default 'on' (new install).
-		// issue #1887: toggle adapter adopted; the #1770 grandfather still pins 'off'
-		// once on an already-configured box (applied by the registry pass, issue #1921).
+		// Internal-address feed-host filter toggle: 'on'|''. Default 'on'.
+		// A present empty token is explicit Off; absent uses the registered default.
 		'gen/pfb_feed_internal_filter' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
-			'grandfather'   => [PFB_GF_ABSENT => 'off'],
+			'no_grandfather' => 'legacy absent state now matches the registered default',
 		],
 
 		// Allowlist for internal-feed hosts (base64-encoded). Default ''.
@@ -1017,11 +1016,8 @@ function pfb_cfg_registry(): array
 		// (CodeMirror 6), gating asset emission on pfblockerng_dnsbl.php. NEW feature --
 		// no prior behaviour to preserve, so both fresh installs and upgraders take the
 		// same 'on' absent-default; no grandfather seed is needed (config-gateway.md's
-		// two-case forward-compat rule). Uses the LENIENT adapter, not PfbToggle -- a
-		// TOGGLE field's '' off-value cannot survive the live config round-trip when the
-		// default is 'on' (absent collapses back to the default, silently re-enabling a
-		// deliberate off; the #484 pfb_keep bug class, enforced by
-		// CfgGatewayTest::testNoToggleFieldDefaultsToOn). Mirrors pfb_keep exactly.
+		// two-case forward-compat rule). PfbToggle presence handling preserves a
+		// present empty Off while absent resolves to the default. Mirrors pfb_keep.
 		'gen/pfb_syntax_highlight' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
@@ -2045,14 +2041,13 @@ final class PfbConfig
 	 *
 	 * Both sides are canonicalised through the exact same pipeline write() and
 	 * writeSectionRaw() already use, so this can never disagree with what actually gets
-	 * stored: notConfigured() resolves NULL/'' to the registered default first; an
-	 * adapter-bearing field then round-trips write_adapter(read_adapter($value)) (the
-	 * same normalisation writeSectionRaw()'s loop applies to the incoming side); a plain
+	 * stored: adapter NULL carries a deletion sentinel, present empty remains Off, and
+	 * other adapter values round-trip write_adapter(read_adapter($value)) (the same
+	 * normalisation writeSectionRaw()'s loop applies to the incoming side); a plain
 	 * field is cast (string) (matching writeRaw()'s cast). The stored side reads via
 	 * config_get_path() directly (bypassing the registry default, then applying it here)
-	 * -- an absent key canonicalises identically to an explicit registered-default value,
-	 * so a field that has never been saved and a field just re-saved at its default both
-	 * correctly read as "unchanged" against an incoming default.
+	 * -- adapter absence remains distinct from an explicit registered-default value,
+	 * while plain-field absence still canonicalises to its registered default.
 	 *
 	 * write() has no equivalent carve-out -- an explicit single-key write() call is
 	 * always an authorization event, changed or not, because there is no read-modify-
@@ -2083,8 +2078,9 @@ final class PfbConfig
 	 * Mirrors the two normalisation pipelines already in this class byte-for-byte so the
 	 * comparison can never diverge from what an actual write would store:
 	 *   - adapter-bearing field (both read_adapter and write_adapter set, always paired
-	 *     -- see pfb_cfg_registry()): write_adapter(read_adapter(notConfigured($value))),
-	 *     the same round trip writeSectionRaw()'s normalisation loop applies.
+	 *     -- see pfb_cfg_registry()): NULL is a deletion sentinel; other values use
+	 *     write_adapter(read_adapter(notConfigured($value))), the same round trip
+	 *     writeSectionRaw()'s normalisation loop applies.
 	 *   - plain scalar field: (string) notConfigured($value), matching writeRaw()'s cast.
 	 *   - plain NON-scalar (a crafted-POST array riding the section blob):
 	 *     writeSectionRaw() persists it verbatim, so it must compare by SHAPE -- a
@@ -2100,7 +2096,10 @@ final class PfbConfig
 	private static function canonicalize(array $entry, mixed $value): string
 	{
 		if ($entry['read_adapter'] !== NULL && $value === NULL) {
-			return $entry['write_adapter']($entry['read_adapter']($entry['default']));
+			// Keep deletion distinct from an explicit stored default. This makes a
+			// section write from default -> NULL an authorization event, while
+			// absent -> NULL remains a no-op (both sides carry this sentinel).
+			return "\0PfbConfig::delete";
 		}
 		$value         = self::notConfigured($entry, $value);
 		$read_adapter  = $entry['read_adapter'];

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -23,15 +23,14 @@
 // This file is used to 'include functions' not yet merged into pfSense
 
 // ---------------------------------------------------------------------------
-// ADR-28 — config field enums (PfbStoredEnum contract): read = EnumClass::fromStored($raw)
-// (registry default applied first; '' / legacy / junk resolved by the enum), write =
-// $enum->toStored(). Goal: preserve forward-upgrade behaviour while keeping current
-// canonical storage; an unknown token falls through to the safe default.
+// ADR-28 — config field enums (PfbStoredEnum contract): adapter fields use the
+// registered default only for an absent key; present empty, legacy, and junk tokens are
+// parsed by the enum. Writes use $enum->toStored(), with Off represented by '' on disk.
 // Tests: tests/php/CfgAdaptersTest.php.
 // ---------------------------------------------------------------------------
 
-// PfbStoredEnum — the contract every config-backed enum implements. Keeps the
-// reader/writer dumb: read = EnumClass::fromStored($raw), write = $enum->toStored().
+// PfbStoredEnum — the contract every config-backed enum implements. Reads own raw-token
+// fallback; field-aware gateway writes own empty Off storage and absence deletion.
 interface PfbStoredEnum
 {
 	// Parse-fallback for unknown/non-scalar input. NOT the per-field absent default
@@ -77,19 +76,13 @@ trait PfbStoredEnumAdapter
 
 	public function toStored(): string
 	{
-		return $this->value;
+		return $this->value === 'off' ? '' : $this->value;
 	}
 }
 
-// PfbToggle — the single on/off enum for every checkbox field (issue #1887; absorbed the
-// retired PfbLenient, which existed only to be the variant whose Off survived storage).
-//   Stored vocabulary: 'on' | 'off'. Off is an EXPLICIT token: a checkbox submits nothing
-//   when unchecked, so an Off stored as '' was indistinguishable from "never configured"
-//   and a default-on field silently re-enabled itself on read-back (the #484 bug class).
-//   '' is NOT in the vocabulary — PfbConfig treats a stored '' as "not configured" and
-//   resolves it to the field's registered default, so an install written before this merge
-//   reads as that default rather than as a hard Off. That resolution lives in the gateway
-//   because it needs the per-field default, which an enum cannot see.
+// PfbToggle — the single on/off enum for every checkbox field. The enum keeps 'off' as
+// its runtime/backing value while PfbStoredEnumAdapter::toStored() emits '' on disk;
+// absent adapter keys alone use the field's registered default.
 enum PfbToggle: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
@@ -126,8 +119,8 @@ enum PfbToggle: string implements PfbStoredEnum
 
 // PfbIdnMode — ADR-08 IDN-feature mode selector, adopted into the PfbConfig gateway.
 // Used by pfb_idn / $pfb['dnsbl_idn']. Canonical tokens (config.xml, py_unbound.ini, and
-// the Python IdnMode enum share one vocabulary): 'on' (=All), 'confusable', 'off'; '' /
-// unknown -> Off. Reusing 'on' for All keeps existing installs migration-free and
+// the Python IdnMode enum share one vocabulary): 'on' (=All), 'confusable', with '' as
+// stored Off; legacy 'off' and unknown values also parse as Off. Reusing 'on' for All keeps existing installs migration-free and
 // preserves the established block-all-IDN behaviour.
 enum PfbIdnMode: string implements PfbStoredEnum
 {
@@ -361,30 +354,14 @@ function pfb_editor_enabled(): bool
 	return PfbConfig::read('gen/pfb_syntax_highlight') === PfbToggle::On;
 }
 
-function pfb_dnsbl_toggle_stored(mixed $posted): string
-{
-	return $posted === 'on' ? 'on' : 'off';
-}
-
 function pfb_dnsbl_toggle_enabled(mixed $stored): bool
 {
 	return pfb_cfg_toggle_read($stored) === PfbToggle::On;
 }
 
-function pfb_ip_suppression_stored(mixed $posted): string
-{
-	return $posted === 'on' ? 'on' : 'off';
-}
-
 function pfb_ip_suppression_enabled(mixed $stored): bool
 {
 	return pfb_cfg_toggle_read($stored) === PfbToggle::On;
-}
-
-/** Normalize the General-page editor checkbox to its persisted token. */
-function pfb_editor_toggle_stored_value(mixed $posted): string
-{
-	return $posted === 'on' ? 'on' : 'off';
 }
 
 /** Keep list-editor mounting independent from the row-reorder mode. */
@@ -594,11 +571,6 @@ function pfb_general_editor_render(bool $enabled): array
 	];
 }
 
-function pfb_general_toggle_stored_value(mixed $posted): string
-{
-	return pfb_editor_toggle_stored_value($posted);
-}
-
 function pfb_general_toggle_label(): string
 {
 	return pfb_editor_toggle_label();
@@ -664,7 +636,8 @@ function pfb_cfg_toggle_read(mixed $stored): PfbToggle
 /** Write a PfbToggle (enum or legacy string) back to its stored string. */
 function pfb_cfg_toggle_write(PfbToggle|string $toggle): string
 {
-	return ($toggle instanceof PfbToggle ? $toggle : PfbToggle::fromStored($toggle))->toStored();
+	$toggle = $toggle instanceof PfbToggle ? $toggle : PfbToggle::fromStored($toggle);
+	return $toggle->toStored();
 }
 
 /** Read a PfbIdnMode from a raw stored value (legacy 'on' -> All). */
@@ -680,7 +653,8 @@ function pfb_cfg_idn_mode_read(mixed $stored): PfbIdnMode
  */
 function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 {
-	return ($mode instanceof PfbIdnMode ? $mode : PfbIdnMode::fromStored($mode))->toStored();
+	$mode = $mode instanceof PfbIdnMode ? $mode : PfbIdnMode::fromStored($mode);
+	return $mode->toStored();
 }
 
 /** Read a PfbTop1mSource from a raw stored value (legacy 'alexa' -> Tranco, 'domcop' -> OpenPageRank). */
@@ -790,18 +764,15 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 
-		// Keep blocklists when pfBlockerNG is disabled: 'on' | 'off' | ''.
+		// Keep blocklists when pfBlockerNG is disabled: 'on' | ''.
 		// Default ON — the #281 canonical default; GUI and pfb_global() agree.
-		// Uses the lenient adapter so an unchecked-save (off) is stored as the
-		// explicit 'off' token, distinguishable from a never-configured install
-		// (key absent) which the registry default returns as 'on'. The empty-string
-		// '' is a LEGACY READ token for installs written before this fix; it maps
-		// to Off on read, same as 'off'. Write always emits canonical 'off'.
+		// A present empty unchecked-save is Off; only a never-configured (absent)
+		// key uses the registered default On.
 		'gen/pfb_keep' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
-			'grandfather'   => [PFB_GF_ABSENT => 'on', '' => 'off'],
+			'grandfather'   => [PFB_GF_ABSENT => 'on'],
 		],
 
 		// Update interval: numeric hour string | 'Disabled'. Default '1'.
@@ -1187,7 +1158,7 @@ function pfb_cfg_registry(): array
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
-			'grandfather'   => ['' => 'off'],
+			'no_grandfather' => 'v3.2 deliberate empty checkbox state is preserved by the owner-ruled storage contract',
 		],
 
 		// Full resolver-cache flush after a successful DNSBL data swap. Default off.
@@ -1206,8 +1177,8 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 
-		// ADR-22: scheme-parsing leniency: 'on' | 'off' | ''. Default 'off'.
-		// Toggle adapter: Off stores the explicit 'off' token.
+		// ADR-22: scheme-parsing leniency: 'on' | ''. Default 'off'.
+		// Toggle adapter: Off stores the empty token.
 		'dnsbl/pfb_dnsbl_lenient' => [
 			'default'       => 'off',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
@@ -1216,32 +1187,32 @@ function pfb_cfg_registry(): array
 		],
 
 		// Python DNS reply logging. Default on (the de-facto page default since 3.2 --
-		// #1907 owner decision). '' grandfather preserves a 3.2 deliberate uncheck.
+		// #1907 owner decision). A present empty token is deliberate Off.
 		// Bespoke pre-ADR-02 migration (pfb_python_gated_toggles_migrate) additionally
 		// disables a stored 'on' that was inert under pre-upgrade Unbound mode.
 		'dnsbl/pfb_py_reply' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
-			'grandfather'   => ['' => 'off'],
+			'no_grandfather' => 'v3.2 deliberate empty checkbox state is preserved by the owner-ruled storage contract',
 		],
 
 		// HSTS null-blocking mode: 'on' | ''. Default on (the de-facto page default
-		// since 3.2 -- #1907 owner decision). '' grandfather preserves a 3.2 deliberate
-		// uncheck. Bespoke pre-ADR-02 migration (pfb_python_gated_toggles_migrate)
+		// since 3.2 -- #1907 owner decision). A present empty token is deliberate Off.
+		// Bespoke pre-ADR-02 migration (pfb_python_gated_toggles_migrate)
 		// additionally disables a stored 'on' that was inert under pre-upgrade Unbound
 		// mode.
 		'dnsbl/pfb_hsts' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
-			'grandfather'   => ['' => 'off'],
+			'no_grandfather' => 'v3.2 deliberate empty checkbox state is preserved by the owner-ruled storage contract',
 		],
 
 		// ADR-08: IDN mode — adopted into the gateway as a PfbIdnMode enum (ADR-28
 		// reframe: preserve behaviour on upgrade, not byte-identical storage). Read
 		// normalises legacy 'on' -> All; write persists the canonical token
-		// ('on'=All | 'confusable' | 'off'), reusing the pre-4.0.0 'on' token so All
+		// ('on'=All | 'confusable' | ''=Off), reusing the pre-4.0.0 'on' token so All
 		// round-trips with zero migration. Legacy '' and the 4.0.0-alpha 'all' token
 		// read as Off; unknown tokens also fall through to Off.
 		// See ADR-28 §2.2 + CfgAdaptersTest.
@@ -1252,14 +1223,13 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 
-		// Confusable: block malicious homoglyphs (default on). Default 'on'.
-		// issue #1887: toggle adapter — without it, read() resolving a stored '' to the
-		// default 'on' made the page's old ?: '' unchecked save impossible to turn off.
+		// Confusable: block malicious homoglyphs (default on). A present empty token is
+		// deliberate Off; only an absent key receives the registered default On.
 		'dnsbl/pfb_idn_block_malicious' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
-			'grandfather'   => ['' => 'off'],
+			'no_grandfather' => 'v3.2 deliberate empty checkbox state is preserved by the owner-ruled storage contract',
 		],
 
 		// Confusable: escalate suspicious mixed-script to block (opt-in). Default ''.
@@ -1647,7 +1617,7 @@ function pfb_cfg_registry(): array
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
-			'grandfather'   => ['' => 'off'],
+			'no_grandfather' => 'v3.2 deliberate empty checkbox state is preserved by the owner-ruled storage contract',
 		],
 
 		// -------------------------------------------------------------------
@@ -1759,9 +1729,9 @@ final class PfbConfig
 		$entry   = self::entry($key);
 		$path    = self::sectionPath($key);
 		$raw     = config_get_path($path, NULL);
-		$stored  = (string) self::notConfigured($entry, $raw);
+		$stored  = self::notConfigured($entry, $raw);
 		$adapter = $entry['read_adapter'];
-		return ($adapter !== NULL) ? $adapter($stored) : $stored;
+		return ($adapter !== NULL) ? $adapter($stored) : (string) $stored;
 	}
 
 	/**
@@ -1849,11 +1819,11 @@ final class PfbConfig
 	 * For each key in $data that is registered to this EXACT section (a
 	 * registered key name living under a DIFFERENT section path is foreign
 	 * data and is left untouched) and carries BOTH a read and a write
-	 * adapter, the value is round-tripped read_adapter() then
+	 * adapter, a present value is round-tripped read_adapter() then
 	 * write_adapter() — coalescing a legacy/read-only token (e.g. top1m_source
-	 * 'domcop'/'alexa', pfb_idn 'all'), a NULL, a non-scalar (a crafted POST
-	 * array), or junk input to the field's canonical stored form, exactly as
-	 * a single-key PfbConfig::write() would. Unregistered keys and
+	 * 'domcop'/'alexa', pfb_idn 'all'), a non-scalar (a crafted POST array),
+	 * or junk input to the field's canonical stored form. NULL omits the
+	 * adapter key, exactly as a single-key PfbConfig::write() would. Unregistered keys and
 	 * adapter-less (plain-string) registered keys pass through byte-identical.
 	 * Consequence: canonical storage is enforced on section writes too — a
 	 * legacy token riding a readSection()->writeSection()
@@ -1862,10 +1832,10 @@ final class PfbConfig
 	 * write_config() — callers persist.
 	 *
 	 * Read adapter runs FIRST (mixed -> runtime value; the non-scalar guard
-	 * handles arrays/NULL/junk and is idempotent on an already-adapted enum
+	 * handles arrays/junk and is idempotent on an already-adapted enum
 	 * instance), write adapter SECOND (runtime value -> canonical stored
-	 * string) — calling the write adapter directly on a raw array or NULL
-	 * would TypeError (write adapters are typed EnumClass|string).
+	 * string). NULL is omitted before adapter dispatch, so it cannot reach a
+	 * typed write adapter.
 	 *
 	 * Privilege gate is DELTA-AWARE (issue #1895 addendum): a registered field
 	 * present in $data is only an authorization event when its canonical
@@ -1979,6 +1949,10 @@ final class PfbConfig
 		$entry   = self::entry($key);
 		$path    = self::sectionPath($key);
 		$adapter = $entry['write_adapter'];
+		if ($adapter !== NULL && $value === NULL) {
+			config_del_path($path);
+			return;
+		}
 		$value   = self::notConfigured($entry, $value);
 		$stored  = ($adapter !== NULL) ? $adapter($value) : (string) $value;
 		config_set_path($path, $stored);
@@ -2006,7 +1980,11 @@ final class PfbConfig
 			if (!array_key_exists($bare, $data)) {
 				continue;
 			}
-			$data[$bare] = $write_adapter($read_adapter(self::notConfigured($entry, $data[$bare])));
+			if ($data[$bare] === NULL) {
+				unset($data[$bare]);
+				continue;
+			}
+			$data[$bare] = $write_adapter($read_adapter($data[$bare]));
 		}
 		config_set_path($section, $data);
 	}
@@ -2121,6 +2099,9 @@ final class PfbConfig
 	 */
 	private static function canonicalize(array $entry, mixed $value): string
 	{
+		if ($entry['read_adapter'] !== NULL && $value === NULL) {
+			return $entry['write_adapter']($entry['read_adapter']($entry['default']));
+		}
 		$value         = self::notConfigured($entry, $value);
 		$read_adapter  = $entry['read_adapter'];
 		$write_adapter = $entry['write_adapter'];
@@ -2134,34 +2115,23 @@ final class PfbConfig
 	}
 
 	/**
-	 * Substitute the registered default for a "not configured" value (issue #1887).
+	 * Substitute a registered default at the configuration boundary.
 	 *
-	 * NULL (key absent) and '' (key present but empty) are the SAME state: pfSense
-	 * stores an unchecked checkbox as an empty element, so '' carries no more operator
-	 * intent than a missing key does. Both resolve to the field's registered default,
-	 * and no registered field needs them distinguished — one with a non-empty default
-	 * either already coerces '' to that default at save time (the numeric fields' `?:`)
-	 * or cannot legitimately hold '' (the mode selectors); the fields where '' IS
-	 * meaningful (pfb_feed_internal_allowlist, pfb_quiet_hours, global_log,
-	 * dnsbl_allow_int) all have '' as their registered default, making this identity.
-	 *
-	 * Called from read(), write() AND writeSection(), not from read() alone. The two
-	 * write paths apply the adapters directly to raw stored values, bypassing the
-	 * registry default — so resolving '' only in read() would leave a stored '' reading
-	 * as the default while any section save normalised it to 'off': the same value
-	 * meaning two different things at two layers, where saving an unrelated field on
-	 * the page would flip it. Pinned by
-	 * ToggleMergeTest::testReadAndWriteSectionAgreeOnStoredEmptyString().
-	 *
-	 * An enum cannot do this itself — fromStored() has no access to the per-field
-	 * default, which is precisely why the resolution belongs to the gateway.
+	 * Adapter-backed fields distinguish absence (NULL) from a present empty token:
+	 * NULL uses the registered default, while '' remains raw and the adapter parses it
+	 * as Off. Plain scalar fields retain their existing NULL/'' defaulting behaviour.
+	 * This shared rule is used by read(), write(), and canonicalize(); section writes
+	 * apply adapter round-tripping directly so present empty values stay byte-identical.
 	 *
 	 * @param  array{default:string,read_adapter:callable|null,write_adapter:callable|null} $entry
-	 * @param  mixed $value  Raw stored value, or the runtime value on the write paths.
-	 * @return mixed         $entry['default'] when $value is NULL or '', else $value verbatim.
+	 * @param  mixed $value  Raw stored value, or the runtime value on a write path.
+	 * @return mixed         Registered default only for the field's not-configured state.
 	 */
 	private static function notConfigured(array $entry, mixed $value): mixed
 	{
+		if ($entry['read_adapter'] !== NULL) {
+			return $value === NULL ? $entry['default'] : $value;
+		}
 		return ($value === NULL || $value === '') ? $entry['default'] : $value;
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1147,8 +1147,8 @@ function pfb_cfg_registry(): array
 		],
 
 		// Resolver cache backup/restore option. Default on (the de-facto page default
-		// since 3.2 -- #1907 owner decision). '' grandfather preserves a 3.2 deliberate
-		// uncheck.
+		// since 3.2 -- #1907 owner decision). A present '' remains an explicit uncheck;
+		// no grandfather arm is needed.
 		'dnsbl/pfb_cache' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
@@ -1606,8 +1606,8 @@ function pfb_cfg_registry(): array
 
 		// issue #1931: IP page "Enable Suppression" toggle -- path-addressed, no longer
 		// collides with dnsbl/whitelist. Default on (the de-facto page default since
-		// 3.2 -- #1907 owner decision). '' grandfather preserves a 3.2 deliberate
-		// uncheck.
+		// 3.2 -- #1907 owner decision). A present '' remains an explicit uncheck;
+		// no grandfather arm is needed.
 		'ip/suppression' => [
 			'default'       => 'on',
 			'read_adapter'  => 'pfb_cfg_toggle_read',

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -93,13 +93,13 @@ enum PfbToggle: string implements PfbStoredEnum
 	/**
 	 * Recognise either token in ANY case before giving up (issue #1887).
 	 *
-	 * The write path is unchanged and still emits lowercase, so this only affects input
-	 * the package did not write itself: a hand-edited config.xml, a restored backup, an
+	 * Writes emit canonical 'on'/empty storage, so this only affects legacy or foreign
+	 * input: a hand-edited config.xml, a restored backup, an
 	 * HA sync, another tool touching installedpackages/*. Without it, 'On' or 'OFF' fell
 	 * past tryFrom() into the Off fallback and silently disabled a feature for an
 	 * operator who spelled it the obvious way, with nothing logged.
 	 *
-	 * Deliberately narrow: only a case variant of the two canonical tokens is accepted.
+	 * Deliberately narrow: only a case variant of the recognised 'on'/'off' read tokens is accepted.
 	 * 'yes', 'true' and '1' remain junk and still fall back to Off, so a typo cannot
 	 * enable something. Pinned in both directions by ToggleCaseInsensitiveTest.
 	 */
@@ -108,9 +108,8 @@ enum PfbToggle: string implements PfbStoredEnum
 		return self::tryFrom(strtolower($raw)) ?? self::default();
 	}
 
-	// Parse-fallback ONLY (unknown/non-scalar -> "not On"). NOT the absent default: a
-	// direct fromStored('') caller lands here, while a gateway read never does (PfbConfig
-	// has already substituted the registry default for '').
+	// Parse-fallback ONLY (empty/unknown/non-scalar -> "not On"). NOT the absent default:
+	// the gateway substitutes the registry default only for NULL and passes present empty here.
 	public static function default(): static
 	{
 		return self::Off;
@@ -1980,7 +1979,7 @@ final class PfbConfig
 				unset($data[$bare]);
 				continue;
 			}
-			$data[$bare] = $write_adapter($read_adapter($data[$bare]));
+			$data[$bare] = $write_adapter($read_adapter(self::notConfigured($entry, $data[$bare])));
 		}
 		config_set_path($section, $data);
 	}
@@ -2119,8 +2118,7 @@ final class PfbConfig
 	 * Adapter-backed fields distinguish absence (NULL) from a present empty token:
 	 * NULL uses the registered default, while '' remains raw and the adapter parses it
 	 * as Off. Plain scalar fields retain their existing NULL/'' defaulting behaviour.
-	 * This shared rule is used by read(), write(), and canonicalize(); section writes
-	 * apply adapter round-tripping directly so present empty values stay byte-identical.
+	 * This shared rule is used by read(), write(), writeSection(), and canonicalize().
 	 *
 	 * @param  array{default:string,read_adapter:callable|null,write_adapter:callable|null} $entry
 	 * @param  mixed $value  Raw stored value, or the runtime value on a write path.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -648,8 +648,8 @@ function pfb_cfg_idn_mode_read(mixed $stored): PfbIdnMode
 
 /**
  * Write a PfbIdnMode (enum or legacy string) back to its canonical stored token
- * ('on' | 'confusable' | 'off'). All persists as the legacy 'on' token (reproduces
- * the prior block-all-IDN behaviour); the 4.0.0-alpha 'all' token is dropped to 'off'.
+ * ('on' | 'confusable' | ''). All persists as the legacy 'on' token (reproduces
+ * the prior block-all-IDN behaviour); the 4.0.0-alpha 'all' token falls back to Off.
  */
 function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -108,9 +108,8 @@ if (
 	// Reset saved wizard configuration.
 	config_del_path('pfblockerng_wizard'); // foreign key — out of ADR-29 gateway scope (root-level, not installedpackages/pfblockerng*)
 
-	// issue #1921: RAW write-back -- this migration transforms raw storage; canonicalising
-	// a bystander adapter-bearing key here, ahead of pfb_registry_pass(), would destroy
-	// the raw value that pass needs to grandfather.
+	// issue #1921: RAW write-back keeps bystander values byte-identical so
+	// pfb_registry_pass() receives exact stored inputs for rename/grandfather decisions.
 	PfbConfig::writeSectionRawSystem('installedpackages/pfblockerngdnsblsettings/config/0', $pfb_dnsbl_config);
 	write_config('Migrated old pfBlockerNG VIP configuration');
 	pfb_global();
@@ -401,9 +400,8 @@ foreach ($upgrade_type as $type) {
 		}
 	}
 	if ($type_ufound) {
-		// issue #1921: pre-pass legacy reshape -- raw write-back; canonicalisation is
-		// pfb_registry_pass()'s job (a section write riding the adapters here would resolve
-		// a bystander raw '' to its registered default before the pass grandfathers it).
+		// issue #1921: pre-pass legacy reshape -- raw write-back keeps bystander values
+		// byte-identical for pfb_registry_pass()'s rename/grandfather decisions.
 		PfbConfig::writeSectionRawSystem("installedpackages/{$type}/config", $pfb_type_items);
 		$ufound = TRUE;
 	}
@@ -488,9 +486,8 @@ if (!empty($pfb_interfaces)) {
 		if (isset($pfb_interfaces['ipsec_action'])) {
 			unset($pfb_interfaces['ipsec_action']);
 		}
-		// issue #1921: pre-pass legacy reshape -- raw write-back; canonicalisation is
-		// pfb_registry_pass()'s job (a section write riding the adapters here would resolve
-		// a bystander raw '' to its registered default before the pass grandfathers it).
+		// issue #1921: pre-pass legacy reshape -- raw write-back keeps bystander values
+		// byte-identical for pfb_registry_pass()'s rename/grandfather decisions.
 		PfbConfig::writeSectionRawSystem('installedpackages/pfblockerng/config/0', $pfb_interfaces);
 	}
 }
@@ -544,9 +541,8 @@ if ($ufound) {
 	foreach ($et_type as $type => $cats) {
 		$pfb_iqrisk[$type] = implode(',', $cats);
 	}
-	// issue #1921: pre-pass legacy reshape -- raw write-back; canonicalisation is
-	// pfb_registry_pass()'s job (a section write riding the adapters here would resolve
-	// a bystander raw '' to its registered default before the pass grandfathers it).
+	// issue #1921: pre-pass legacy reshape -- raw write-back keeps bystander values
+	// byte-identical for pfb_registry_pass()'s rename/grandfather decisions.
 	PfbConfig::writeSectionRawSystem('installedpackages/pfblockerngreputation/config/0', $pfb_iqrisk);
 } else {
 	update_status(" no changes required ... done.\n");
@@ -579,9 +575,8 @@ if (!empty(pfb_gconfig_operator_view($pfb_gen_section)) && empty($pfb_ip_section
 			unset($pfb['gconfig'][$setting]);
 		}
 	}
-	// issue #1921: pre-pass legacy reshape -- raw write-back; canonicalisation is
-	// pfb_registry_pass()'s job (a section write riding the adapters here would resolve
-	// a bystander raw '' to its registered default before the pass grandfathers it).
+	// issue #1921: pre-pass legacy reshape -- raw write-back keeps bystander values
+	// byte-identical for pfb_registry_pass()'s rename/grandfather decisions.
 	PfbConfig::writeSectionRawSystem('installedpackages/pfblockerngipsettings/config/0', $pfb['iconfig']);
 	PfbConfig::writeSectionRawSystem('installedpackages/pfblockerng/config/0', $pfb['gconfig']);
 	update_status(" saving new changes ... done.\n");
@@ -771,9 +766,8 @@ if (!empty(PfbConfig::readSection('installedpackages/pfblockerngdnsbleasylist'))
 
 		$dnsblcfg   = PfbConfig::readSection('installedpackages/pfblockerngdnsbl/config');
 		$dnsblcfg[] = $add;
-		// issue #1921: pre-pass legacy reshape -- raw write-back; canonicalisation is
-		// pfb_registry_pass()'s job (a section write riding the adapters here would resolve
-		// a bystander raw '' to its registered default before the pass grandfathers it).
+		// issue #1921: pre-pass legacy reshape -- raw write-back keeps bystander values
+		// byte-identical for pfb_registry_pass()'s rename/grandfather decisions.
 		PfbConfig::writeSectionRawSystem('installedpackages/pfblockerngdnsbl/config', $dnsblcfg);
 	}
 
@@ -801,9 +795,8 @@ if (!empty($doh_config)) {
 			$doh_config['safesearch_doh_list'] = 'use-application-dns.net';
 		}
 		unset($doh_config['safesearch_firefoxdoh']);
-		// issue #1921: pre-pass legacy reshape -- raw write-back; canonicalisation is
-		// pfb_registry_pass()'s job (a section write riding the adapters here would resolve
-		// a bystander raw '' to its registered default before the pass grandfathers it).
+		// issue #1921: pre-pass legacy reshape -- raw write-back keeps bystander values
+		// byte-identical for pfb_registry_pass()'s rename/grandfather decisions.
 		PfbConfig::writeSectionRawSystem('installedpackages/pfblockerngsafesearch', $doh_config);
 	}
 }
@@ -848,9 +841,8 @@ if (!empty($pfb_maxmind_gen) && !isset($pfb_maxmind_ip['maxmind_key'])) {
 		}
 	}
 	if ($ufound) {
-		// issue #1921: pre-pass legacy reshape -- raw write-back; canonicalisation is
-		// pfb_registry_pass()'s job (a section write riding the adapters here would resolve
-		// a bystander raw '' to its registered default before the pass grandfathers it).
+		// issue #1921: pre-pass legacy reshape -- raw write-back keeps bystander values
+		// byte-identical for pfb_registry_pass()'s rename/grandfather decisions.
 		PfbConfig::writeSectionRawSystem('installedpackages/pfblockerngipsettings/config/0', $pfb_maxmind_ip);
 		PfbConfig::writeSectionRawSystem('installedpackages/pfblockerng/config/0', $maxmind_config);
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -646,7 +646,7 @@ if ($_POST) {
 
 		// ADR-08: IDN Blocking mode must be one of the <select> options. PFB_FILTER_WORD
 		// only checks shape, so without this an out-of-vocabulary value (e.g. a tampered
-		// POST) would canonicalise to 'off' and silently disable IDN blocking.
+		// POST) would canonicalise to Off and silently disable IDN blocking.
 		if (!in_array(pfb_filter($_POST['pfb_idn'] ?? '', PFB_FILTER_WORD, 'dnsbl'),
 			array('off', 'confusable', 'on'), TRUE)) {
 			$input_errors[] = 'DNSBL IDN Blocking mode is invalid!';

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -72,9 +72,9 @@ $pconfig['pfb_cache_flush']	= PfbConfig::read('dnsbl/pfb_cache_flush');
 $pconfig['pfb_py_reply']	= PfbConfig::read('dnsbl/pfb_py_reply');
 $pconfig['pfb_hsts']		= PfbConfig::read('dnsbl/pfb_hsts');
 // ADR-08: IDN mode selector (Off | All-IDN | Confusable). PfbConfig::read() returns a
-// PfbIdnMode enum (legacy 'on' -> All; alpha-only 'all' and '' -> Off); toStored() gives the
-// canonical config token ('on' | 'confusable' | 'off') that the <select> options below carry.
-$pconfig['pfb_idn']		= PfbConfig::read('dnsbl/pfb_idn')->toStored();
+// PfbIdnMode enum (legacy 'on' -> All; alpha-only 'all', legacy 'off', and '' -> Off);
+// enum value gives the runtime option key that the <select> options below carry.
+$pconfig['pfb_idn']		= PfbConfig::read('dnsbl/pfb_idn')->value;
 // Confusable-mode sub-toggles: block clearly-malicious homoglyphs is default-on;
 // escalate suspicious mixed-script (else alert only) is opt-in (default off).
 // Default 'on' owned by the registry (ADR-29); PfbConfig::read applies it when absent.
@@ -843,23 +843,20 @@ if ($_POST) {
 			$pfb['dconfig']['pfb_dnsbl_rule']	= pfb_filter($_POST['pfb_dnsbl_rule'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['dnsbl_allow_int']	= implode(',', (array)$_POST['dnsbl_allow_int'])			?: '';
 			$pfb['dconfig']['global_log']		= $_POST['global_log']							?: '';
-			// issue #1907: stage the explicit token -- checkbox-absent means Off, and a
-			// staged '' would resolve to this field's default-ON at the gateway.
-			$pfb['dconfig']['pfb_cache']		= pfb_dnsbl_toggle_stored($_POST['pfb_cache'] ?? NULL);
+			// issue #1907: checkbox-absent is the owner-ruled empty Off token.
+			$pfb['dconfig']['pfb_cache']		= pfb_filter($_POST['pfb_cache'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';
 			$pfb['dconfig']['pfb_cache_flush']	= pfb_filter($_POST['pfb_cache_flush'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 
-			// issue #1907: stage the explicit token -- checkbox-absent means Off, and a
-			// staged '' would resolve to these fields' default-ON at the gateway.
-			$pfb['dconfig']['pfb_py_reply']		= pfb_dnsbl_toggle_stored($_POST['pfb_py_reply'] ?? NULL);
-			$pfb['dconfig']['pfb_hsts']		= pfb_dnsbl_toggle_stored($_POST['pfb_hsts'] ?? NULL);
+			// issue #1907: checkbox-absent is the owner-ruled empty Off token.
+			$pfb['dconfig']['pfb_py_reply']		= pfb_filter($_POST['pfb_py_reply'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';
+			$pfb['dconfig']['pfb_hsts']		= pfb_filter($_POST['pfb_hsts'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';
 			// ADR-08: IDN mode selector. Validate the raw word, then canonicalise via the
-			// PfbIdnMode adapter to the stored config token ('on' = All | 'confusable' | 'off').
+			// PfbIdnMode adapter to ('on' = All | 'confusable' | '' = Off).
 			$pfb_idn_mode = pfb_filter($_POST['pfb_idn'], PFB_FILTER_WORD, 'dnsbl');
 			$pfb['dconfig']['pfb_idn']		= pfb_cfg_idn_mode_write($pfb_idn_mode);
-			// issue #1887: stage the explicit token — checkbox-absent means Off, and a
-			// staged '' would resolve to this field's default-ON at the gateway.
-			$pfb['dconfig']['pfb_idn_block_malicious']	= pfb_dnsbl_toggle_stored($_POST['pfb_idn_block_malicious'] ?? NULL);
-			$pfb['dconfig']['pfb_idn_escalate_suspicious']	= pfb_dnsbl_toggle_stored($_POST['pfb_idn_escalate_suspicious'] ?? NULL);
+			// issue #1887: checkbox-absent is the owner-ruled empty Off token.
+			$pfb['dconfig']['pfb_idn_block_malicious']	= pfb_filter($_POST['pfb_idn_block_malicious'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';
+			$pfb['dconfig']['pfb_idn_escalate_suspicious']	= pfb_filter($_POST['pfb_idn_escalate_suspicious'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';
 			$pfb['dconfig']['pfb_regex']		= pfb_filter($_POST['pfb_regex'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_regex_cap']	= pfb_filter($_POST['pfb_regex_cap'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_cname']		= pfb_filter($_POST['pfb_cname'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -191,16 +191,9 @@ if ($_POST) {
 		if (!$input_errors) {
 
 			$pfb['gconfig']['enable_cb']			= pfb_filter($_POST['enable_cb'], PFB_FILTER_ON_OFF, 'general', '');
-			// Store as explicit 'on'/'off' (not '' for unchecked) so an unchecked save
-			// (off) is distinguishable from a never-configured install (key absent =>
-			// default on). Mirrors the pfb_feed_internal_filter precedent.
-			$pfb['gconfig']['pfb_keep']			= (($_POST['pfb_keep'] ?? '') === 'on') ? 'on' : 'off';
+			$pfb['gconfig']['pfb_keep']			= pfb_filter($_POST['pfb_keep'] ?? '', PFB_FILTER_ON_OFF, 'general') ?: '';
 
-			// Store the master feed-host filter toggle as an explicit 'on'/'off' (a
-			// checkbox submits 'on' when checked, nothing when unchecked) so the
-			// runtime reader can tell an unchecked save (off) from a never-configured
-			// install (key absent => default on).
-			$pfb['gconfig']['pfb_feed_internal_filter']	= (($_POST['pfb_feed_internal_filter'] ?? '') === 'on') ? 'on' : 'off';
+			$pfb['gconfig']['pfb_feed_internal_filter']	= pfb_filter($_POST['pfb_feed_internal_filter'] ?? '', PFB_FILTER_ON_OFF, 'general') ?: '';
 
 			// The allowlist textarea is greyed (disabled) when the filter is off, so the
 			// browser does not submit it. Preserve the previously stored value in that
@@ -241,13 +234,7 @@ if ($_POST) {
 			// service restart is needed when the toggle changes.
 			$pfb['gconfig']['log_syslog']	= pfb_filter($_POST['log_syslog'], PFB_FILTER_ON_OFF, 'general', '');
 
-			// issue #1669 slice C: persist the syntax-highlight toggle as an explicit
-			// 'on'/'off' (not '' for unchecked) so an unchecked save is distinguishable
-			// from a never-configured install (key absent => default on) -- mirrors the
-			// pfb_keep precedent (lenient adapter). Written into $pfb['gconfig'] so the
-			// writeSection() call below includes it -- a bare PfbConfig::write() before
-			// writeSection() would be clobbered by the section-level write.
-			$pfb['gconfig']['pfb_syntax_highlight']	= pfb_general_toggle_stored_value($_POST['pfb_syntax_highlight'] ?? '');
+			$pfb['gconfig']['pfb_syntax_highlight']	= pfb_filter($_POST['pfb_syntax_highlight'] ?? '', PFB_FILTER_ON_OFF, 'general') ?: '';
 
 			PfbConfig::writeSection('installedpackages/pfblockerng/config/0', $pfb['gconfig']);
 			write_config('[pfBlockerNG] save General settings');

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -246,9 +246,8 @@ if ($_POST) {
 
 			$pfb['iconfig']['enable_dup']		= pfb_filter($_POST['enable_dup'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['enable_agg']		= pfb_filter($_POST['enable_agg'], PFB_FILTER_ON_OFF, 'ip')	?: '';
-			// issue #1907: stage the explicit token -- checkbox-absent means Off, and a
-			// staged '' would resolve to this field's default-ON at the gateway.
-			$pfb['iconfig']['suppression']		= pfb_ip_suppression_stored($_POST['suppression'] ?? NULL);
+			// issue #1907: checkbox-absent is the owner-ruled empty Off token.
+			$pfb['iconfig']['suppression']		= pfb_filter($_POST['suppression'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
 			$pfb['iconfig']['enable_log']		= pfb_filter($_POST['enable_log'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['enable_rdns']		= pfb_filter($_POST['enable_rdns'], PFB_FILTER_ON_OFF, 'ip')	?: '';
 			$pfb['iconfig']['ip_placeholder']	= $_POST['ip_placeholder']					?: '127.1.7.7';

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -76,10 +76,9 @@ if ($_POST && !empty($_POST['pfb_sw_action'])) {
 }
 
 // "Save" the settings (standard pfSense CSRF POST). A checkbox is absent from the POST when
-// unticked, so persist an explicit 'on'/'off' — an unset value defaults to enabled, an
-// explicit 'off' is the user opting out.
+// unticked, so persist the owner-ruled empty Off token; an absent config key defaults On.
 if ($_POST && isset($_POST['save'])) {
-	PfbConfig::write('gen/pfb_software_check', isset($_POST['pfb_software_check']) ? 'on' : 'off');
+	PfbConfig::write('gen/pfb_software_check', pfb_filter($_POST['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '');
 	write_config('[pfBlockerNG] save Software settings');
 	header('Location: /pfblockerng/pfblockerng_software.php');
 	exit;

--- a/tests/php/ApplyDrepShellBoundaryTest.php
+++ b/tests/php/ApplyDrepShellBoundaryTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** The empty-capable _rep drep token must remain argv[4] at the shell boundary. */
+final class ApplyDrepShellBoundaryTest extends TestCase
+{
+	public function testDrepTokenIsShellQuotedAtTheOnlyEmptyCapableCrossing(): void
+	{
+		$source = file_get_contents(
+			__DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		$this->assertIsString($source);
+		$this->assertStringContainsString(
+			'escapeshellarg($pfb_drep_token)',
+			$source,
+			'empty drep tokens need shell quoting so argv[4] stays present'
+		);
+	}
+}

--- a/tests/php/ApplyDrepShellBoundaryTest.php
+++ b/tests/php/ApplyDrepShellBoundaryTest.php
@@ -9,14 +9,12 @@ final class ApplyDrepShellBoundaryTest extends TestCase
 {
 	public function testDrepTokenIsShellQuotedAtTheOnlyEmptyCapableCrossing(): void
 	{
-		$source = file_get_contents(
-			__DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
-		);
-		$this->assertIsString($source);
-		$this->assertStringContainsString(
-			'escapeshellarg($pfb_drep_token)',
-			$source,
-			'empty drep tokens need shell quoting so argv[4] stays present'
+		$executable = php_strip_whitespace(__DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$binding = <<<'PHP'
+$pfb_drep_token = $pfb['drep']->toStored(); exec("{$pfb['script']} {$args} {$header_esc} {$pfb['max']} " . escapeshellarg($pfb_drep_token) . " {$pfb['ccexclude']} {$pfb['ccwhite']} {$pfb['ccblack']} {$elog}");
+PHP;
+		$this->assertSame(1, substr_count($executable, $binding),
+			'the drep token must stay quoted in argv[4] before ccexclude/ccwhite/ccblack'
 		);
 	}
 }

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -7,24 +7,24 @@ use PHPUnit\Framework\TestCase;
 /**
  * ADR-28 Phase 1 — round-trip identity tests for the field-aware config adapters.
  *
- * Rule (ADR-28 §2.2 reframe): for every adapted field, every existing stored value
- * (incl. empty / unset / any legacy variant) must satisfy write(read(v)) == v for
- * canonical values, or must map to a behaviour-equivalent canonical token for legacy
- * migration values (behaviour preserved on forward upgrade).  Fields that
- * cannot satisfy this are excluded (documented in 01_Results.txt).
+ * Rule (ADR-28 §2.2 reframe): adapters preserve recognised stored cases. Toggle Off
+ * writes the canonical empty token; legacy 'off' remains read-compatible only.
+ * Multi-valued enums preserve each recognised token, while unknown tokens retain
+ * their adapter default fallback. Gateway absence/default handling lives in the
+ * gateway contract suites.
  *
  * Scenario A — PfbToggle (pfb_dnsvip_auto): 'on' / '' checkbox.
- *   Background: stored as 'on' (checked) or '' (unchecked / missing key).
+ *   Background: stored as 'on' (checked) or '' (unchecked). Direct adapter NULL
+ *   also falls back Off; PfbConfig applies registered defaults to gateway absence.
  *     Given a raw stored value v.
  *     When pfb_cfg_toggle_read(v) -> enum, pfb_cfg_toggle_write(enum) -> stored.
  *     Then write(read(v)) == v for canonical values; junk -> default ''.
  *
- * Scenario B — retired by issue #1887: PfbLenient merged into PfbToggle (whose Off is
- *   now the explicit 'off' token; '' is a legacy read token normalising to Off at the
- *   adapter and to the registered default at the PfbConfig gateway).
+ * Scenario B — retired by issue #1887: PfbLenient merged into PfbToggle. The shared
+ *   toggle adapter accepts legacy 'off' on read and writes the empty Off token.
  *
- * Scenario C — PfbIdnMode (pfb_idn / dnsbl_idn): backing values 'on'/'confusable'/'off'.
- *   Background: config.xml stores 'on' (= All, block-all-IDN), 'confusable', 'off'. 'on'
+ * Scenario C — PfbIdnMode (pfb_idn / dnsbl_idn): backing values 'on'/'confusable'/''.
+ *   Background: config.xml stores 'on' (= All, block-all-IDN), 'confusable', or ''. 'on'
  *     reuses the pre-4.0.0 block-all token, preserving established block-all-IDN
  *     behaviour. The 4.0.0-alpha-only 'all' token is dropped (unrecognised ->
  *     Off), and '' (absent/disabled) is Off.
@@ -32,9 +32,9 @@ use PHPUnit\Framework\TestCase;
  *     When pfb_cfg_idn_mode_read(v) -> enum, pfb_cfg_idn_mode_write(enum) -> stored.
  *     Then write(read('on')) == 'on'  (canonical identity).
  *     And write(read('confusable')) == 'confusable'  (identity).
- *     And write(read('off')) == 'off'  (identity).
- *     And write(read('all')) == 'off'  (dropped alpha token -> Off).
- *     And write(read('')) == 'off'    (normalised default).
+ *     And write(read('off')) == ''       (legacy Off -> canonical empty).
+ *     And write(read('all')) == ''       (dropped alpha token -> Off fallback).
+ *     And write(read('')) == ''          (canonical Off identity).
  *
  * Scenario E — PfbTop1mSource (top1m_source, issue #877): backing values 'tranco' /
  *   'cisco' / 'openpagerank' (#928, replacing ADR-59 P4's 'domcop') / 'majestic'
@@ -133,7 +133,7 @@ final class CfgAdaptersTest extends TestCase
 
 	public function testToggleRoundTripOff(): void
 	{
-		// Given: canonical 'off' (issue #1887 explicit token).  write(read(v)) == v.
+		// Given: legacy 'off' (read-compatible). Off writes the canonical empty token.
 		$v = 'off';
 		$result = pfb_cfg_toggle_write(pfb_cfg_toggle_read($v));
 		$this->assertSame('', $result);
@@ -159,7 +159,7 @@ final class CfgAdaptersTest extends TestCase
 		// PfbConfig::write() advertises an "enum or string" contract; a raw
 		// legacy string must normalise through the read adapter (it was a
 		// TypeError before — pfblockerng_update.php Force Reload passes 'on').
-		// Canonical strings normalize to checkbox storage; legacy ''/junk are Off.
+		// Strings normalize to checkbox storage; legacy 'off', empty, and junk are Off.
 		$this->assertSame('on', pfb_cfg_toggle_write('on'));
 		$this->assertSame('', pfb_cfg_toggle_write(''));
 		$this->assertSame('', pfb_cfg_toggle_write('off'));
@@ -167,9 +167,8 @@ final class CfgAdaptersTest extends TestCase
 	}
 
 	// Scenario B (PfbLenient) retired by issue #1887 — the enum merged into PfbToggle,
-	// whose Scenario A now covers the identical vocabulary ('on'/'off', '' legacy-off,
-	// junk/non-scalar fallback). pfb_cfg_lenient_read()/write() are gone; the retired-
-	// token grep guards their return.
+	// whose Scenario A now covers the shared toggle vocabulary and fallback.
+	// pfb_cfg_lenient_read()/write() are gone; the retired-token grep guards their return.
 
 	// -----------------------------------------------------------------------
 	// Scenario C — PfbIdnMode
@@ -243,7 +242,7 @@ final class CfgAdaptersTest extends TestCase
 	public function testIdnModeDroppedAlphaAllNormalisesToOff(): void
 	{
 		// 'all' (4.0.0-alpha only; compatibility intentionally dropped) is unrecognised
-		// -> Off, so a write-back emits 'off' — NOT the legacy 'all'.
+		// -> Off, so a write-back emits the canonical empty token — NOT 'all'.
 		$v = 'all';
 		// Before: raw.
 		$this->assertSame('all', $v);
@@ -251,7 +250,7 @@ final class CfgAdaptersTest extends TestCase
 		// When round-tripped.
 		$result = pfb_cfg_idn_mode_write(pfb_cfg_idn_mode_read($v));
 
-		// Then: 'off' (unrecognised -> Off).
+		// Then: '' (unrecognised -> Off).
 		$this->assertSame('', $result);
 		$this->assertNotSame('all', $result);
 	}
@@ -313,7 +312,7 @@ final class CfgAdaptersTest extends TestCase
 		// "enum or string" contract: raw string normalises through read adapter.
 		// 'on'  -> All (canonical) — round-trips losslessly.
 		// 'confusable' and 'off' are canonical and round-trip.
-		// '', junk, and the dropped 4.0.0-alpha 'all' normalise to Off -> 'off'.
+		// '', junk, and the dropped 4.0.0-alpha 'all' normalise to Off -> ''.
 		$this->assertSame('on',          pfb_cfg_idn_mode_write('on'));
 		$this->assertSame('confusable',  pfb_cfg_idn_mode_write('confusable'));
 		$this->assertSame('',             pfb_cfg_idn_mode_write('off'));
@@ -341,7 +340,7 @@ final class CfgAdaptersTest extends TestCase
 	//   Replaced by: pfb_cfg_toggle_read($raw ?? '')->value
 	//
 	// dnsbl_lenient (line ~1364): old = (($raw ?? '') === 'on') ? 'on' : 'off'
-	//   Replaced by: pfb_cfg_lenient_read($raw ?? '')->value
+	//   Replaced by the shared PfbToggle adapter.
 	//
 	// dnsbl_idn (lines ~1372-1373): EXCLUDED — old ternary passes '' through
 	//   as '' (not 'off'), which differs from pfb_cfg_idn_mode_read('')->value
@@ -371,7 +370,7 @@ final class CfgAdaptersTest extends TestCase
 		$oldResult = ($raw === 'on') ? 'all' : $raw;
 		$this->assertSame('', $oldResult, 'old ternary must pass empty string through as empty string');
 
-		// Adapter: '' normalises to Off = 'off'.
+		// Adapter: '' parses as Off (the enum backing value is 'off').
 		$adapterResult = pfb_cfg_idn_mode_read($raw)->value;
 		$this->assertSame('off', $adapterResult, 'adapter must return off for empty string');
 

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -136,10 +136,9 @@ final class CfgAdaptersTest extends TestCase
 		// Given: canonical 'off' (issue #1887 explicit token).  write(read(v)) == v.
 		$v = 'off';
 		$result = pfb_cfg_toggle_write(pfb_cfg_toggle_read($v));
-		$this->assertSame($v, $result);
-		// Legacy '' no longer round-trips: it is the not-configured token and
-		// normalises to the canonical 'off' at the adapter.
-		$this->assertSame('off', pfb_cfg_toggle_write(pfb_cfg_toggle_read('')));
+		$this->assertSame('', $result);
+		// Legacy '' reads as Off; the current checkbox storage writes empty.
+		$this->assertSame('', pfb_cfg_toggle_write(pfb_cfg_toggle_read('')));
 	}
 
 	public function testToggleDefaultIsOff(): void
@@ -152,7 +151,7 @@ final class CfgAdaptersTest extends TestCase
 	{
 		// write produces the exact stored strings — not 'true'/'false' or 1/0.
 		$this->assertSame('on', pfb_cfg_toggle_write(PfbToggle::On));
-		$this->assertSame('off', pfb_cfg_toggle_write(PfbToggle::Off));
+		$this->assertSame('', pfb_cfg_toggle_write(PfbToggle::Off));
 	}
 
 	public function testToggleWriteAcceptsLegacyString(): void
@@ -160,12 +159,11 @@ final class CfgAdaptersTest extends TestCase
 		// PfbConfig::write() advertises an "enum or string" contract; a raw
 		// legacy string must normalise through the read adapter (it was a
 		// TypeError before — pfblockerng_update.php Force Reload passes 'on').
-		// Canonical strings round-trip; legacy ''/junk normalise to the explicit 'off'
-		// (issue #1887; a gateway write additionally resolves '' to the field default).
+		// Canonical strings normalize to checkbox storage; legacy ''/junk are Off.
 		$this->assertSame('on', pfb_cfg_toggle_write('on'));
-		$this->assertSame('off', pfb_cfg_toggle_write(''));
-		$this->assertSame('off', pfb_cfg_toggle_write('off'));
-		$this->assertSame('off', pfb_cfg_toggle_write('yes'));
+		$this->assertSame('', pfb_cfg_toggle_write(''));
+		$this->assertSame('', pfb_cfg_toggle_write('off'));
+		$this->assertSame('', pfb_cfg_toggle_write('yes'));
 	}
 
 	// Scenario B (PfbLenient) retired by issue #1887 — the enum merged into PfbToggle,
@@ -254,7 +252,7 @@ final class CfgAdaptersTest extends TestCase
 		$result = pfb_cfg_idn_mode_write(pfb_cfg_idn_mode_read($v));
 
 		// Then: 'off' (unrecognised -> Off).
-		$this->assertSame('off', $result);
+		$this->assertSame('', $result);
 		$this->assertNotSame('all', $result);
 	}
 
@@ -267,7 +265,7 @@ final class CfgAdaptersTest extends TestCase
 	public function testIdnModeRoundTripOff(): void
 	{
 		$v = 'off';
-		$this->assertSame($v, pfb_cfg_idn_mode_write(pfb_cfg_idn_mode_read($v)));
+		$this->assertSame('', pfb_cfg_idn_mode_write(pfb_cfg_idn_mode_read($v)));
 	}
 
 	public function testIdnModeCanonicalOnRoundTripsLosslessly(): void
@@ -290,9 +288,9 @@ final class CfgAdaptersTest extends TestCase
 
 	public function testIdnModeEmptyNormalisesToOff(): void
 	{
-		// '' normalises to 'off' on write.
+		// '' remains the empty Off token on write.
 		$result = pfb_cfg_idn_mode_write(pfb_cfg_idn_mode_read(''));
-		$this->assertSame('off', $result);
+		$this->assertSame('', $result);
 	}
 
 	public function testIdnModeDefaultIsOff(): void
@@ -307,7 +305,7 @@ final class CfgAdaptersTest extends TestCase
 		// token, reused for current canonical round-trip correctness).
 		$this->assertSame('on', pfb_cfg_idn_mode_write(PfbIdnMode::All));
 		$this->assertSame('confusable', pfb_cfg_idn_mode_write(PfbIdnMode::Confusable));
-		$this->assertSame('off', pfb_cfg_idn_mode_write(PfbIdnMode::Off));
+		$this->assertSame('', pfb_cfg_idn_mode_write(PfbIdnMode::Off));
 	}
 
 	public function testIdnModeWriteAcceptsLegacyString(): void
@@ -318,10 +316,10 @@ final class CfgAdaptersTest extends TestCase
 		// '', junk, and the dropped 4.0.0-alpha 'all' normalise to Off -> 'off'.
 		$this->assertSame('on',          pfb_cfg_idn_mode_write('on'));
 		$this->assertSame('confusable',  pfb_cfg_idn_mode_write('confusable'));
-		$this->assertSame('off',         pfb_cfg_idn_mode_write('off'));
-		$this->assertSame('off',         pfb_cfg_idn_mode_write(''));
-		$this->assertSame('off',         pfb_cfg_idn_mode_write('yes'));
-		$this->assertSame('off',         pfb_cfg_idn_mode_write('all'));   // dropped alpha token
+		$this->assertSame('',             pfb_cfg_idn_mode_write('off'));
+		$this->assertSame('',             pfb_cfg_idn_mode_write(''));
+		$this->assertSame('',             pfb_cfg_idn_mode_write('yes'));
+		$this->assertSame('',             pfb_cfg_idn_mode_write('all'));   // dropped alpha token
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/CfgAdaptersTest.php
+++ b/tests/php/CfgAdaptersTest.php
@@ -88,7 +88,7 @@ final class CfgAdaptersTest extends TestCase
 	public function testToggleReadJunkReturnsDefault(): void
 	{
 		// Given an unrecognised stored value — maps to Off (the default). 'off' is NOT
-		// junk since issue #1887 — it is the canonical Off token (round-trip tests below).
+		// junk since issue #1887 — it is a recognised legacy read token.
 		$this->assertSame(PfbToggle::Off, pfb_cfg_toggle_read('yes'));
 		$this->assertSame(PfbToggle::Off, pfb_cfg_toggle_read('1'));
 	}
@@ -311,7 +311,7 @@ final class CfgAdaptersTest extends TestCase
 	{
 		// "enum or string" contract: raw string normalises through read adapter.
 		// 'on'  -> All (canonical) — round-trips losslessly.
-		// 'confusable' and 'off' are canonical and round-trip.
+		// 'confusable' is canonical; legacy 'off' normalises to canonical empty Off.
 		// '', junk, and the dropped 4.0.0-alpha 'all' normalise to Off -> ''.
 		$this->assertSame('on',          pfb_cfg_idn_mode_write('on'));
 		$this->assertSame('confusable',  pfb_cfg_idn_mode_write('confusable'));
@@ -326,8 +326,8 @@ final class CfgAdaptersTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	// testOffValuesAreDifferentAcrossFields retired by issue #1887: the premise inverted.
-	// There is ONE off vocabulary now — PfbToggle::Off and PfbIdnMode::Off both store
-	// 'off' by design, so distinct Off tokens are no longer a property to defend.
+	// Both enums keep the internal 'off' backing value and write canonical empty Off,
+	// so distinct stored Off tokens are no longer a property to defend.
 
 	// -----------------------------------------------------------------------
 	// Scenario D — Seam behaviour: pfb_global() adapter expressions produce
@@ -388,9 +388,9 @@ final class CfgAdaptersTest extends TestCase
 		// Old seam: $pfb_idn_raw = $stored ?? ''; $pfb['dnsbl_idn'] = ($pfb_idn_raw === 'on') ? 'all' : $pfb_idn_raw;
 		$cases = [
 			['on',          'all'],         // legacy migration: 'on' -> 'all'
-			['all',         'all'],         // canonical
-			['confusable',  'confusable'],  // canonical
-			['off',         'off'],         // canonical
+			['all',         'all'],         // old seam pass-through
+			['confusable',  'confusable'],  // old seam pass-through
+			['off',         'off'],         // legacy old seam pass-through
 			['',            ''],            // absent/blank: passes through as '' (NOT 'off')
 			['junk',        'junk'],        // junk: passes through unchanged
 		];

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -13,8 +13,9 @@ require_once __DIR__ . '/LogTypesFixture.php';
  * Three test groups per the phase requirements:
  *
  * A — ROUND-TRIP IDENTITY
- *   For every registered field that carries a read+write adapter pair:
- *   write(read(v)) == v for every canonical stored vocabulary value.
+ *   For every registered field that carries a read+write adapter pair, recognised
+ *   values preserve their case; toggle Off writes the canonical empty token and
+ *   legacy 'off' remains read-compatible only.
  *   Mirrors the ADR-28 §2.2 contract.
  *
  * B — DEFAULT ON ABSENT KEY
@@ -55,7 +56,7 @@ final class CfgGatewayTest extends TestCase
 
 	// -----------------------------------------------------------------------
 	// A — Round-trip identity for adapter-bearing fields
-	//     (toggle and lenient adapters; idn-mode exclusion documented below)
+	//     (toggle adapters; multi-valued enum handling documented below)
 	// -----------------------------------------------------------------------
 
 	/**
@@ -69,7 +70,7 @@ final class CfgGatewayTest extends TestCase
 	 */
 	public function testToggleFieldsRoundTripOn(): void
 	{
-		// Representative toggle-adapted fields (pfb_keep is now lenient — see below).
+		// Representative toggle-adapted fields (pfb_keep is default-on).
 		$toggle_fields = [
 			'gen/enable_cb'        => 'installedpackages/pfblockerng/config/0/enable_cb',
 			'dnsbl/pfb_dnsbl'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
@@ -106,10 +107,8 @@ final class CfgGatewayTest extends TestCase
 	{
 		// pfb_keep is default-on — see testPfbKeepRoundTrip*() below. issue #1907:
 		// dnsbl/pfb_hsts, dnsbl/pfb_cache, dnsbl/pfb_py_reply, ip/suppression joined
-		// that same default-on class -- a stored '' no longer resolves to Off for any
-		// of the four, so they are excluded here too (see testParityPfbHstsAbsentYieldsOff
-		// and its pfb_cache/pfb_py_reply siblings in PfbGlobalParityTest, and
-		// testIpSuppressionAbsentKeyReturnsOnDefault above).
+		// that same default-on class. Their present empty token is explicit Off and is
+		// covered by ConfigEmptyStorageContractTest.
 		$toggle_fields = [
 			'gen/enable_cb'        => 'installedpackages/pfblockerng/config/0/enable_cb',
 			'dnsbl/pfb_dnsbl'        => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl',
@@ -138,13 +137,13 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	/**
-	 * PfbLenient field (pfb_dnsbl_lenient): 'on'/'off' round-trip; '' -> 'off' (documented).
+	 * Toggle field (pfb_dnsbl_lenient): 'on'/'off' read; Off writes ''.
 	 *
 	 * Scenario:
-	 *   Background: pfb_dnsbl_lenient stored as 'on', 'off', or '' (pre-ADR-22).
+	 *   Background: pfb_dnsbl_lenient stored as 'on', legacy 'off', or ''.
 	 *     Given v.  When read/write.
 	 *     Then 'on' and 'off' round-trip losslessly.
-	 *     And '' normalises to 'off' on write (documented default normalisation).
+	 *     And Off writes the canonical empty token.
 	 */
 	public function testLenientFieldRoundTripOn(): void
 	{
@@ -168,7 +167,7 @@ final class CfgGatewayTest extends TestCase
 	{
 		$path = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_lenient';
 
-		// Given: canonical 'off'.
+		// Given: legacy 'off' (read-compatible; never written).
 		$this->seedConfig($path, 'off');
 
 		// Before: raw 'off'.
@@ -192,7 +191,7 @@ final class CfgGatewayTest extends TestCase
 		// Before: raw ''.
 		$this->assertSame('', config_get_path($path));
 
-		// When/After: normalised to 'off' (documented, matches pfb_global() behaviour).
+		// When/After: Off remains the canonical empty token.
 		$enum = PfbConfig::read('dnsbl/pfb_dnsbl_lenient');
 		$this->assertSame(PfbToggle::Off, $enum);
 
@@ -202,13 +201,13 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	/**
-	 * pfb_keep (lenient adapter): 'on'/'off'/'' round-trips and legacy '' normalises.
+	 * pfb_keep (toggle adapter): 'on'/'off'/'' reads; Off writes the empty token.
 	 *
 	 * Scenario:
 	 *   Background: pfb_keep stored as 'on', 'off', or '' (pre-#484-fix legacy empty).
 	 *     Given v.  When read/write.
-	 *     Then 'on' round-trips to 'on'; 'off' round-trips to 'off'.
-	 *     And '' (legacy) normalises to the current canonical 'off' on write.
+	 *     Then 'on' round-trips to 'on'; legacy 'off' reads Off and writes ''.
+	 *     And '' is preserved as the canonical empty token on write.
 	 */
 	public function testPfbKeepLenientRoundTripOn(): void
 	{
@@ -232,13 +231,13 @@ final class CfgGatewayTest extends TestCase
 	{
 		$path = 'installedpackages/pfblockerng/config/0/pfb_keep';
 
-		// Given: canonical 'off' (the new stored value for unchecked-save after #484 fix).
+		// Given: legacy 'off' (accepted on read; no longer written).
 		$this->seedConfig($path, 'off');
 
 		// Before: raw 'off'.
 		$this->assertSame('off', config_get_path($path), 'before: pfb_keep seed is off');
 
-		// When/After: read -> PfbToggle::Off; write -> 'off'.
+		// When/After: read -> PfbToggle::Off; write -> ''.
 		$enum = PfbConfig::read('gen/pfb_keep');
 		$this->assertSame(PfbToggle::Off, $enum, "read: pfb_keep 'off' -> PfbToggle::Off");
 
@@ -250,9 +249,8 @@ final class CfgGatewayTest extends TestCase
 	{
 		$path = 'installedpackages/pfblockerng/config/0/pfb_keep';
 
-		// Given: '' — issue #1887: for a registered field a stored '' is the SAME state
-		// as an absent key (pfSense writes an unchecked checkbox as an empty element),
-		// so it resolves to the registered default 'on', not to a hard Off.
+		// Given: '' — an adapter-bearing field's present empty token is explicit Off;
+		// only an absent key resolves to its registered default.
 		$this->seedConfig($path, '');
 
 		$this->assertSame('', config_get_path($path), 'before: pfb_keep seed is empty string');
@@ -266,16 +264,14 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	/**
-	 * issue #1669 slice C: pfb_syntax_highlight (lenient adapter, default on):
+	 * issue #1669 slice C: pfb_syntax_highlight (toggle adapter, default on):
 	 * 'on'/'off' round-trip losslessly. Mirrors testPfbKeepLenientRoundTripOn/Off --
-	 * this field is the same default-on-checkbox shape as pfb_keep, using the LENIENT
-	 * adapter (not PfbToggle) for the same #484-class reason (see the registry comment
-	 * and CfgGatewayTest::testNoToggleFieldDefaultsToOn).
+	 * this field is the same default-on-checkbox shape as pfb_keep, using PfbToggle.
 	 *
 	 * Scenario:
 	 *   Background: pfb_syntax_highlight stored as 'on' or 'off'.
 	 *     Given v.  When read/write.
-	 *     Then 'on' round-trips to 'on'; 'off' round-trips to 'off'.
+	 *     Then 'on' round-trips to 'on'; legacy 'off' reads Off and writes ''.
 	 */
 	public function testPfbSyntaxHighlightLenientRoundTripOn(): void
 	{
@@ -299,13 +295,13 @@ final class CfgGatewayTest extends TestCase
 	{
 		$path = 'installedpackages/pfblockerng/config/0/pfb_syntax_highlight';
 
-		// Given: canonical 'off' (the explicit unchecked-save token).
+		// Given: legacy 'off' (accepted on read; no longer written).
 		$this->seedConfig($path, 'off');
 
 		// Before: raw 'off'.
 		$this->assertSame('off', config_get_path($path), 'before: pfb_syntax_highlight seed is off');
 
-		// When/After: read -> PfbToggle::Off; write -> 'off'.
+		// When/After: read -> PfbToggle::Off; write -> ''.
 		$enum = PfbConfig::read('gen/pfb_syntax_highlight');
 		$this->assertSame(PfbToggle::Off, $enum, "read: pfb_syntax_highlight 'off' -> PfbToggle::Off");
 
@@ -398,7 +394,7 @@ final class CfgGatewayTest extends TestCase
 		// When: read with no seed.
 		$result = PfbConfig::read('gen/pfb_keep');
 
-		// Then: returns On (the registered default 'on', applied through lenient adapter).
+		// Then: returns On (the registered default 'on').
 		$this->assertSame(PfbToggle::On, $result, 'pfb_keep absent -> PfbToggle::On (default on)');
 	}
 
@@ -595,7 +591,7 @@ final class CfgGatewayTest extends TestCase
 	/**
 	 * issue #1907: dnsbl/pfb_cache, dnsbl/pfb_py_reply, dnsbl/pfb_hsts, ip/suppression --
 	 * same default-on shape as pfb_idn_block_malicious/pfb_keep above. Absent AND a
-	 * stored '' resolves to Off (presence is the adapter discriminator); a
+	 * stored '' resolves to Off (presence is the adapter discriminator); an
 	 * stored 'off'/'on' round-trip losslessly.
 	 */
 	public function testIssue1907FieldsResolveAbsentAndEmptyStringToOnDefault(): void
@@ -1669,7 +1665,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertInstanceOf(PfbIdnMode::class, $result, 'pfb_idn must return a PfbIdnMode enum');
 		$this->assertSame(PfbIdnMode::Off, $result, "pfb_idn 'all' (dropped alpha token) -> PfbIdnMode::Off");
 
-		// Write emits the canonical 'off' — 'all' is not re-emitted.
+		// Write emits the canonical empty Off token — 'all' is not re-emitted.
 		PfbConfig::write('dnsbl/pfb_idn', $result);
 		$stored = config_get_path($path);
 		$this->assertSame('', $stored, "write(read('all')) == '' for pfb_idn");
@@ -1730,22 +1726,12 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	/**
-	 * No registered field may be a TOGGLE adapter (off-value '') while defaulting
-	 * to 'on'. Such a field cannot represent "off" on a live pfSense config: an
-	 * empty stored value does not persist distinguishably from absent, and an
-	 * absent value re-applies the registry default 'on' — silently flipping a
-	 * deliberate "off" back to "on". (This is the pfb_keep bug: #484 fan-out.)
-	 *
-	 * A default-'on' field MUST therefore use the LENIENT adapter (off persists as
-	 * the explicit 'off' token) or a PLAIN field that writes an explicit 'on'/'off'
-	 * (as pfb_feed_internal_filter does). This guard makes the rule mechanical so
-	 * the class of bug cannot recur — the off-box config doubles round-trip ''
-	 * faithfully and would otherwise never catch it.
+	 * Default-on adapter fields are valid: adapter presence distinguishes absent
+	 * (registered default) from present empty (Off), and PfbToggle writes empty.
+	 * The old no-default-on invariant was retired by issue #2120.
 	 */
-	// testNoToggleFieldDefaultsToOn retired by issue #1887: PfbToggle::Off now stores the
-	// explicit 'off' token and the gateway resolves ''/absent to the registered default, so
-	// a default-'on' toggle field is legal — a deliberate Off survives the round trip
-	// (ToggleMergeTest::testExplicitOffOnDefaultOnFieldSurvives pins the #484 bug class).
+	// testNoToggleFieldDefaultsToOn retired by issue #1887/#2120; the adapter-presence
+	// distinction is pinned by ConfigEmptyStorageContractTest.
 
 	/**
 	 * The static cache in pfb_cfg_registry() is stable: multiple calls return the same array.
@@ -2402,7 +2388,6 @@ final class CfgGatewayTest extends TestCase
 	{
 		$samples_by_read_adapter = [
 			'pfb_cfg_toggle_read'           => ['on', '', 'junk'],
-			'pfb_cfg_lenient_read'          => ['on', 'off', '', 'junk'],
 			'pfb_cfg_idn_mode_read'         => ['on', 'confusable', 'off', 'all', 'junk'],
 			'pfb_cfg_top1m_source_read'     => ['tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare', 'alexa', 'domcop', 'junk'],
 			'pfb_cfg_alias_delta_mode_read' => ['auto', 'delta', 'replace', '', 'junk'],
@@ -2518,7 +2503,7 @@ final class CfgGatewayTest extends TestCase
 
 	/**
 	 * pfb_idn: the dropped 4.0.0-alpha-only 'all' token riding a section blob
-	 * write normalises to 'off' (never re-emitted); the canonical 'on' token
+	 * write normalises to empty (never re-emits legacy 'off'); the canonical 'on' token
 	 * (= PfbIdnMode::All) stays 'on' unchanged.
 	 *
 	 * Scenario:
@@ -2532,7 +2517,7 @@ final class CfgGatewayTest extends TestCase
 		$section = 'installedpackages/pfblockerngdnsblsettings/config/0';
 		$path    = $section . '/pfb_idn';
 
-		// Alpha-only 'all' -> normalised to 'off'.
+		// Alpha-only 'all' -> normalised to empty Off.
 		PfbConfig::writeSection($section, ['pfb_idn' => 'all']);
 		$this->assertSame('', config_get_path($path),
 			"dropped alpha-only 'all' riding a section write normalises to ''"
@@ -2547,13 +2532,13 @@ final class CfgGatewayTest extends TestCase
 
 	/**
 	 * pfb_keep: the legacy empty-string token (pre-#484 absent-key install)
-	 * riding a section blob write normalises to the explicit 'off' token, same
-	 * as the single-key PfbConfig::write() lenient-adapter contract.
+	 * riding a section blob write preserves the explicit empty Off token, same
+	 * as the single-key PfbConfig::write() toggle contract.
 	 *
 	 * Scenario:
 	 *   Given a General settings blob with pfb_keep = '' (legacy empty).
 	 *   When PfbConfig::writeSection() persists it.
-	 *   Then the stored pfb_keep is 'off', never the legacy '' token.
+	 *   Then the stored pfb_keep remains '', and legacy 'off' is never written.
 	 */
 	public function testWriteSectionPfbKeepEmptyResolvesToRegisteredDefault(): void
 	{
@@ -2774,7 +2759,7 @@ final class CfgGatewayTest extends TestCase
 	 * issue #1896: a realistic Reputation save blob (mirrors
 	 * pfblockerng_geoip.inc's Reputation save handler) mixing the three newly
 	 * registered toggles with unadapted plain fields. The unchecked toggle
-	 * ('') normalises to the canonical 'off' token; every unadapted field
+	 * ('') remains the canonical empty Off token; every unadapted field
 	 * (p24_dmax_var, et_header, ccexclude) is byte-identical.
 	 *
 	 * Scenario:
@@ -2790,8 +2775,8 @@ final class CfgGatewayTest extends TestCase
 
 		$data = [
 			'enable_rep'    => 'on',     // adapted (toggle), canonical.
-			'enable_pdup'   => '',       // adapted (toggle), unchecked -> normalises to 'off'.
-			'enable_dedup'  => '',       // adapted (toggle), unchecked -> normalises to 'off'.
+			'enable_pdup'   => '',       // adapted (toggle), unchecked -> remains empty.
+			'enable_dedup'  => '',       // adapted (toggle), unchecked -> remains empty.
 			'p24_dmax_var'  => '5',      // unadapted, plain.
 			'et_header'     => '',       // unadapted, plain.
 			'ccexclude'     => 'US,CA',  // unadapted, plain.

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -142,8 +142,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Background: pfb_dnsbl_lenient stored as 'on', legacy 'off', or ''.
 	 *     Given v.  When read/write.
-	 *     Then 'on' and 'off' round-trip losslessly.
-	 *     And Off writes the canonical empty token.
+	 *     Then 'on' remains 'on'; legacy 'off' and empty both write canonical empty Off.
 	 */
 	public function testLenientFieldRoundTripOn(): void
 	{
@@ -265,7 +264,7 @@ final class CfgGatewayTest extends TestCase
 
 	/**
 	 * issue #1669 slice C: pfb_syntax_highlight (toggle adapter, default on):
-	 * 'on'/'off' round-trip losslessly. Mirrors testPfbKeepLenientRoundTripOn/Off --
+	 * 'on' remains 'on' and legacy 'off' normalises to empty. Mirrors testPfbKeepLenientRoundTripOn/Off --
 	 * this field is the same default-on-checkbox shape as pfb_keep, using PfbToggle.
 	 *
 	 * Scenario:
@@ -590,11 +589,10 @@ final class CfgGatewayTest extends TestCase
 
 	/**
 	 * issue #1907: dnsbl/pfb_cache, dnsbl/pfb_py_reply, dnsbl/pfb_hsts, ip/suppression --
-	 * same default-on shape as pfb_idn_block_malicious/pfb_keep above. Absent AND a
-	 * stored '' resolves to Off (presence is the adapter discriminator); an
-	 * stored 'off'/'on' round-trip losslessly.
+	 * same default-on shape as pfb_idn_block_malicious/pfb_keep above. Absent resolves
+	 * to On; present empty and legacy 'off' resolve to Off; present 'on' resolves to On.
 	 */
-	public function testIssue1907FieldsResolveAbsentAndEmptyStringToOnDefault(): void
+	public function testIssue1907FieldsDistinguishAbsentFromEmpty(): void
 	{
 		$fields = [
 			'dnsbl/pfb_cache'    => 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache',
@@ -2509,7 +2507,7 @@ final class CfgGatewayTest extends TestCase
 	 * Scenario:
 	 *   Given a DNSBL settings blob with pfb_idn = the alpha-only 'all' token.
 	 *   When PfbConfig::writeSection() persists it.
-	 *   Then the stored pfb_idn is 'off', never the dropped 'all' token.
+	 *   Then the stored pfb_idn is empty Off, never the dropped 'all' token.
 	 *   And a canonical 'on' token riding the same path stays 'on'.
 	 */
 	public function testWriteSectionPfbIdnAlphaOnlyAllNormalisesToOff(): void
@@ -2605,7 +2603,7 @@ final class CfgGatewayTest extends TestCase
 	 *   When PfbConfig::writeSection() persists it.
 	 *   Then the stored pfb_keep key is absent, no crash.
 	 */
-	public function testWriteSectionNullValueNormalisesViaDefaultCollapse(): void
+	public function testWriteSectionNullValueDeletesAdapterKey(): void
 	{
 		$section = 'installedpackages/pfblockerng/config/0';
 		$path    = $section . '/pfb_keep';

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -131,9 +131,9 @@ final class CfgGatewayTest extends TestCase
 			$enum = PfbConfig::read($key);
 			$this->assertSame(PfbToggle::Off, $enum, "read: {$key} '' -> PfbToggle::Off");
 
-			// After: write back emits the canonical explicit 'off' (issue #1887).
+			// After: write back emits the empty checkbox token.
 			PfbConfig::write($key, $enum);
-			$this->assertSame('off', config_get_path($path), "write(read(''))=='off' for {$key}");
+			$this->assertSame('', config_get_path($path), "write(read(''))=='' for {$key}");
 		}
 	}
 
@@ -179,7 +179,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame(PfbToggle::Off, $enum);
 
 		PfbConfig::write('dnsbl/pfb_dnsbl_lenient', $enum);
-		$this->assertSame('off', config_get_path($path));
+		$this->assertSame('', config_get_path($path));
 	}
 
 	public function testLenientFieldEmptyNormalisesToOff(): void
@@ -197,8 +197,8 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame(PfbToggle::Off, $enum);
 
 		PfbConfig::write('dnsbl/pfb_dnsbl_lenient', $enum);
-		// Normalised: stored as 'off', NOT ''.
-		$this->assertSame('off', config_get_path($path));
+		// Checkbox Off stores as ''.
+		$this->assertSame('', config_get_path($path));
 	}
 
 	/**
@@ -243,7 +243,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame(PfbToggle::Off, $enum, "read: pfb_keep 'off' -> PfbToggle::Off");
 
 		PfbConfig::write('gen/pfb_keep', $enum);
-		$this->assertSame('off', config_get_path($path), "write(read('off'))==off for pfb_keep");
+		$this->assertSame('', config_get_path($path), "write(read('off'))=='' for pfb_keep");
 	}
 
 	public function testPfbKeepEmptyResolvesToRegisteredDefault(): void
@@ -258,11 +258,11 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('', config_get_path($path), 'before: pfb_keep seed is empty string');
 
 		$enum = PfbConfig::read('gen/pfb_keep');
-		$this->assertSame(PfbToggle::On, $enum, "read: pfb_keep '' -> registered default On");
+		$this->assertSame(PfbToggle::Off, $enum, "read: pfb_keep '' -> PfbToggle::Off");
 
 		// After: write emits the canonical token of the default.
 		PfbConfig::write('gen/pfb_keep', $enum);
-		$this->assertSame('on', config_get_path($path), "write(read(''))=='on' for pfb_keep");
+		$this->assertSame('', config_get_path($path), "write(read(''))=='' for pfb_keep");
 	}
 
 	/**
@@ -310,7 +310,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame(PfbToggle::Off, $enum, "read: pfb_syntax_highlight 'off' -> PfbToggle::Off");
 
 		PfbConfig::write('gen/pfb_syntax_highlight', $enum);
-		$this->assertSame('off', config_get_path($path), "write(read('off'))==off for pfb_syntax_highlight");
+		$this->assertSame('', config_get_path($path), "write(read('off'))=='' for pfb_syntax_highlight");
 	}
 
 	// -----------------------------------------------------------------------
@@ -595,7 +595,7 @@ final class CfgGatewayTest extends TestCase
 	/**
 	 * issue #1907: dnsbl/pfb_cache, dnsbl/pfb_py_reply, dnsbl/pfb_hsts, ip/suppression --
 	 * same default-on shape as pfb_idn_block_malicious/pfb_keep above. Absent AND a
-	 * stored '' both resolve to On (the '' ≡ absent gateway identity -- ADR-28); a
+	 * stored '' resolves to Off (presence is the adapter discriminator); a
 	 * stored 'off'/'on' round-trip losslessly.
 	 */
 	public function testIssue1907FieldsResolveAbsentAndEmptyStringToOnDefault(): void
@@ -612,7 +612,7 @@ final class CfgGatewayTest extends TestCase
 			$this->assertSame(PfbToggle::On, PfbConfig::read($key), "{$key}: absent -> On (default)");
 
 			$this->seedConfig($path, '');
-			$this->assertSame(PfbToggle::On, PfbConfig::read($key), "{$key}: stored '' -> On (== absent)");
+			$this->assertSame(PfbToggle::Off, PfbConfig::read($key), "{$key}: stored '' -> Off");
 
 			$this->seedConfig($path, 'off');
 			$this->assertSame(PfbToggle::Off, PfbConfig::read($key), "{$key}: stored 'off' -> Off");
@@ -1061,9 +1061,9 @@ final class CfgGatewayTest extends TestCase
 		$enum = PfbConfig::read('gen/log_syslog');
 		$this->assertSame(PfbToggle::Off, $enum, "read: log_syslog '' -> PfbToggle::Off");
 
-		// After: write back emits the canonical explicit 'off' (issue #1887).
+		// After: write back emits the empty checkbox token.
 		PfbConfig::write('gen/log_syslog', $enum);
-		$this->assertSame('off', config_get_path($path), "write(read(''))=='off' for log_syslog");
+		$this->assertSame('', config_get_path($path), "write(read(''))=='' for log_syslog");
 	}
 
 	/**
@@ -1488,8 +1488,8 @@ final class CfgGatewayTest extends TestCase
 		// When: write Off enum.
 		PfbConfig::write('dnsbl/pfb_dnsbl_lenient', PfbToggle::Off);
 
-		// After: stored as 'off' (not '' — PfbToggle::Off = 'off').
-		$this->assertSame('off', config_get_path($path));
+		// After: stored as the empty checkbox token; PfbToggle::Off backing remains 'off'.
+		$this->assertSame('', config_get_path($path));
 	}
 
 	/**
@@ -1672,7 +1672,7 @@ final class CfgGatewayTest extends TestCase
 		// Write emits the canonical 'off' — 'all' is not re-emitted.
 		PfbConfig::write('dnsbl/pfb_idn', $result);
 		$stored = config_get_path($path);
-		$this->assertSame('off', $stored, "write(read('all')) == 'off' for pfb_idn");
+		$this->assertSame('', $stored, "write(read('all')) == '' for pfb_idn");
 		$this->assertNotSame('all', $stored, "'all' must not be re-emitted");
 	}
 
@@ -1969,9 +1969,9 @@ final class CfgGatewayTest extends TestCase
 
 		PfbConfig::write('dnsbl/dnsbl_redir', $enum);
 
-		// After: stored as the canonical explicit 'off' (issue #1887).
-		$this->assertSame('off', config_get_path($path),
-			"write(read('')) == 'off' for dnsbl_redir"
+		// After: stored as the empty checkbox token.
+		$this->assertSame('', config_get_path($path),
+			"write(read('')) == '' for dnsbl_redir"
 		);
 	}
 
@@ -2223,9 +2223,9 @@ final class CfgGatewayTest extends TestCase
 
 		PfbConfig::write('dnsbl/dnsbl_dot_block', $enum);
 
-		// After: stored as the canonical explicit 'off' (issue #1887).
-		$this->assertSame('off', config_get_path($path),
-			"write(read('')) == 'off' for dnsbl_dot_block"
+		// After: stored as the empty checkbox token.
+		$this->assertSame('', config_get_path($path),
+			"write(read('')) == '' for dnsbl_dot_block"
 		);
 	}
 
@@ -2534,8 +2534,8 @@ final class CfgGatewayTest extends TestCase
 
 		// Alpha-only 'all' -> normalised to 'off'.
 		PfbConfig::writeSection($section, ['pfb_idn' => 'all']);
-		$this->assertSame('off', config_get_path($path),
-			"dropped alpha-only 'all' riding a section write normalises to 'off'"
+		$this->assertSame('', config_get_path($path),
+			"dropped alpha-only 'all' riding a section write normalises to ''"
 		);
 
 		// Canonical 'on' -> stays 'on'.
@@ -2562,9 +2562,8 @@ final class CfgGatewayTest extends TestCase
 
 		PfbConfig::writeSection($section, ['pfb_keep' => '']);
 
-		$this->assertSame('on', config_get_path($path),
-			"'' is the not-configured state (issue #1887): a section write resolves it to the "
-				. "registered default 'on', matching what read() reports"
+		$this->assertSame('', config_get_path($path),
+			"'' is the checkbox Off token and remains empty on a section write"
 		);
 	}
 
@@ -2584,8 +2583,8 @@ final class CfgGatewayTest extends TestCase
 
 		PfbConfig::writeSection($section, ['pfb_dnsbl' => 'yes']);
 
-		$this->assertSame('off', config_get_path($path),
-			"junk toggle value 'yes' riding a section write parse-falls-back to the canonical 'off'"
+		$this->assertSame('', config_get_path($path),
+			"junk toggle value 'yes' riding a section write parse-falls-back to empty"
 		);
 	}
 
@@ -2614,13 +2613,12 @@ final class CfgGatewayTest extends TestCase
 
 	/**
 	 * Hostile input: a NULL value on an adapted key riding a section blob write
-	 * is not a TypeError -- the read adapter's NULL->'' collapse feeds the write
-	 * adapter a well-formed enum, landing on the field's Off/legacy-empty token.
+	 * is not a TypeError -- NULL deletes the adapted key.
 	 *
 	 * Scenario:
 	 *   Given a General settings blob with pfb_keep = NULL.
 	 *   When PfbConfig::writeSection() persists it.
-	 *   Then the stored pfb_keep is 'off' (lenient NULL-collapse path), no crash.
+	 *   Then the stored pfb_keep key is absent, no crash.
 	 */
 	public function testWriteSectionNullValueNormalisesViaDefaultCollapse(): void
 	{
@@ -2629,9 +2627,7 @@ final class CfgGatewayTest extends TestCase
 
 		PfbConfig::writeSection($section, ['pfb_keep' => NULL]);
 
-		$this->assertSame('on', config_get_path($path),
-			'NULL is the not-configured state (issue #1887): a section write resolves it to the registered default'
-		);
+		$this->assertNull(config_get_path($path), 'NULL section writes delete adapted keys');
 	}
 
 	/**
@@ -2767,7 +2763,7 @@ final class CfgGatewayTest extends TestCase
 
 		$this->assertSame('on', $result['pfb_dnsbl'], 'pfb_dnsbl canonical stays on');
 		$this->assertSame('openpagerank', $result['top1m_source'], "legacy 'domcop' normalises to 'openpagerank'");
-		$this->assertSame('off', $result['pfb_idn'], "alpha-only 'all' normalises to 'off'");
+		$this->assertSame('', $result['pfb_idn'], "alpha-only 'all' normalises to empty");
 		$this->assertSame('on', $result['pfb_hsts'], 'pfb_hsts canonical stays on');
 		$this->assertSame('lo0', $result['dnsbl_interface'], 'unadapted dnsbl_interface is byte-identical');
 		$this->assertSame('', $result['pfb_dnsvip4'], 'unadapted pfb_dnsvip4 is byte-identical');
@@ -2806,8 +2802,8 @@ final class CfgGatewayTest extends TestCase
 		$result = PfbConfig::readSection($section);
 
 		$this->assertSame('on', $result['enable_rep'], 'enable_rep canonical stays on');
-		$this->assertSame('off', $result['enable_pdup'], "unchecked enable_pdup ('') normalises to 'off'");
-		$this->assertSame('off', $result['enable_dedup'], "unchecked enable_dedup ('') normalises to 'off'");
+		$this->assertSame('', $result['enable_pdup'], "unchecked enable_pdup ('') remains empty");
+		$this->assertSame('', $result['enable_dedup'], "unchecked enable_dedup ('') remains empty");
 		$this->assertSame('5', $result['p24_dmax_var'], 'unadapted p24_dmax_var is byte-identical');
 		$this->assertSame('', $result['et_header'], 'unadapted et_header is byte-identical');
 		$this->assertSame('US,CA', $result['ccexclude'], 'unadapted ccexclude is byte-identical');

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -244,7 +244,7 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('', config_get_path($path), "write(read('off'))=='' for pfb_keep");
 	}
 
-	public function testPfbKeepEmptyResolvesToRegisteredDefault(): void
+	public function testPfbKeepEmptyPreservesExplicitOff(): void
 	{
 		$path = 'installedpackages/pfblockerng/config/0/pfb_keep';
 
@@ -2538,7 +2538,7 @@ final class CfgGatewayTest extends TestCase
 	 *   When PfbConfig::writeSection() persists it.
 	 *   Then the stored pfb_keep remains '', and legacy 'off' is never written.
 	 */
-	public function testWriteSectionPfbKeepEmptyResolvesToRegisteredDefault(): void
+	public function testWriteSectionPfbKeepEmptyPreservesExplicitOff(): void
 	{
 		$section = 'installedpackages/pfblockerng/config/0';
 		$path    = $section . '/pfb_keep';

--- a/tests/php/CfgWriteAuthorizationTest.php
+++ b/tests/php/CfgWriteAuthorizationTest.php
@@ -92,7 +92,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 
 		PfbConfig::write('gen/pfb_keep', PfbToggle::Off);
 
-		$this->assertSame('off', config_get_path($path),
+		$this->assertSame('', config_get_path($path),
 			'allowed write must persist the canonical stored token'
 		);
 	}
@@ -143,7 +143,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 
 		PfbConfig::write('gen/pfb_software_check', PfbToggle::Off);
 
-		$this->assertSame('off', config_get_path($path),
+		$this->assertSame('', config_get_path($path),
 			'write must succeed and persist the canonical stored token'
 		);
 	}
@@ -339,7 +339,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 
 		PfbConfig::writeSection(self::GEN, $data);
 
-		$this->assertSame('off', config_get_path(self::GEN . '/pfb_keep'),
+		$this->assertSame('', config_get_path(self::GEN . '/pfb_keep'),
 			'the unrelated, actually-changed field must persist canonically'
 		);
 		$this->assertSame('on', config_get_path(self::GEN . '/pfb_software_check'),
@@ -407,7 +407,7 @@ final class CfgWriteAuthorizationTest extends TestCase
 			'pfb_software_check' => 'on',
 		]);
 
-		$this->assertSame('off', config_get_path(self::GEN . '/pfb_keep'),
+		$this->assertSame('', config_get_path(self::GEN . '/pfb_keep'),
 			'the unrelated, actually-changed field must persist canonically'
 		);
 		$this->assertSame('on', config_get_path(self::GEN . '/pfb_software_check'),

--- a/tests/php/CfgWriteAuthorizationTest.php
+++ b/tests/php/CfgWriteAuthorizationTest.php
@@ -385,15 +385,13 @@ final class CfgWriteAuthorizationTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// L - equivalence subtlety: stored ABSENT canonicalises identical to the incoming
-	//     registered default.
+	// L - deletion subtlety: stored ABSENT canonicalises identical to incoming NULL.
 	// -----------------------------------------------------------------------
 
 	public function testWriteSectionAbsentStoredFieldEqualsIncomingDefaultIsPassThrough(): void
 	{
 		// pfb_software_check is entirely ABSENT from the stored section -- never saved
-		// on this box before. notConfigured() must resolve the missing key to the
-		// registered default ('on'), the same as it would for an explicit 'on'.
+		// on this box before. An incoming NULL is the same deletion/no-op state.
 		config_set_path(self::GEN, ['pfb_keep' => 'on']);
 
 		$GLOBALS['pfb_test_allowed_pages'] = [
@@ -403,16 +401,61 @@ final class CfgWriteAuthorizationTest extends TestCase
 
 		PfbConfig::writeSection(self::GEN, [
 			'pfb_keep'           => 'off',
-			// The registered default -- canonically identical to "absent".
-			'pfb_software_check' => 'on',
+			// NULL means delete; absent -> NULL is a no-op and needs no privilege.
+			'pfb_software_check' => NULL,
 		]);
 
 		$this->assertSame('', config_get_path(self::GEN . '/pfb_keep'),
 			'the unrelated, actually-changed field must persist canonically'
 		);
-		$this->assertSame('on', config_get_path(self::GEN . '/pfb_software_check'),
-			'absent-stored must canonicalise identically to the registered default and be '
-			. 'treated as an unchanged pass-through, not an authorization event'
+		$this->assertNull(config_get_path(self::GEN . '/pfb_software_check'),
+			'absent-stored must canonicalise identically to incoming NULL and remain absent'
+		);
+	}
+
+	public function testWriteSectionDefaultValueToNullRequiresPrivilegeAndLeavesSectionUnchanged(): void
+	{
+		$baseline = [
+			'pfb_keep'           => 'on',
+			'pfb_software_check' => 'on',
+		];
+		config_set_path(self::GEN, $baseline);
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+			'pkg_mgr_installed.php'                => false,
+		];
+
+		try {
+			PfbConfig::writeSection(self::GEN, [
+				'pfb_keep'           => 'on',
+				'pfb_software_check' => NULL,
+			]);
+			$this->fail('expected RuntimeException, none thrown');
+		} catch (RuntimeException $e) {
+			$this->assertStringContainsString('pfb_software_check', $e->getMessage());
+		}
+
+		$this->assertSame($baseline, config_get_path(self::GEN),
+			'blocked deletion must leave the whole section unchanged'
+		);
+	}
+
+	public function testWriteSectionAbsentValueToNullIsNoOpWithoutPrivilege(): void
+	{
+		$baseline = ['pfb_keep' => 'on'];
+		config_set_path(self::GEN, $baseline);
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pfblockerng/pfblockerng_general.php' => true,
+			'pkg_mgr_installed.php'                => false,
+		];
+
+		PfbConfig::writeSection(self::GEN, [
+			'pfb_keep'           => 'on',
+			'pfb_software_check' => NULL,
+		]);
+
+		$this->assertSame($baseline, config_get_path(self::GEN),
+			'absent deletion must remain a no-op without privilege'
 		);
 	}
 

--- a/tests/php/CfgWriteAuthorizationTest.php
+++ b/tests/php/CfgWriteAuthorizationTest.php
@@ -30,10 +30,8 @@ use PHPUnit\Framework\TestCase;
  *       pfb_software_check's pass-through value).
  *   K - same seeding as J, but the privilege-gated field's value actually CHANGES --
  *       enforcement is retained: exception, section unmodified.
- *   L - equivalence subtlety: the privilege-gated field is ABSENT from stored config
- *       entirely; the incoming blob carries the registered default -- canonicalises
- *       identical to "unchanged", so it is a pass-through too (notConfigured()'s
- *       identity riding the delta comparison).
+	 *   L - deletion subtlety: stored ABSENT and incoming NULL are the same no-op state;
+	 *       deleting an explicit value remains an authorization event.
  */
 final class CfgWriteAuthorizationTest extends TestCase
 {
@@ -146,6 +144,19 @@ final class CfgWriteAuthorizationTest extends TestCase
 		$this->assertSame('', config_get_path($path),
 			'write must succeed and persist the canonical stored token'
 		);
+	}
+
+	public function testWriteAllowedNullDeletesStoredAdapterKey(): void
+	{
+		$path = self::GEN . '/pfb_software_check';
+		config_set_path($path, 'on');
+		$GLOBALS['pfb_test_allowed_pages'] = [
+			'pkg_mgr_installed.php' => true,
+		];
+
+		PfbConfig::write('gen/pfb_software_check', NULL);
+
+		$this->assertNull(config_get_path($path), 'public write(NULL) must delete the adapted key');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/ConfigEmptyStorageContractTest.php
+++ b/tests/php/ConfigEmptyStorageContractTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Owner-ruled storage contract for adapter-bearing registry fields (issue #2120). */
+final class ConfigEmptyStorageContractTest extends TestCase
+{
+	private const SECTIONS = [
+		'gen'   => 'installedpackages/pfblockerng/config/0',
+		'dnsbl' => 'installedpackages/pfblockerngdnsblsettings/config/0',
+		'ip'    => 'installedpackages/pfblockerngipsettings/config/0',
+	];
+
+	/** @var array<string,array{path:string,default:PfbToggle}> */
+	private const DEFAULT_ON_TOGGLES = [
+		'gen/pfb_keep'                    => ['section' => 'gen', 'bare' => 'pfb_keep'],
+		'gen/pfb_software_check'          => ['section' => 'gen', 'bare' => 'pfb_software_check'],
+		'gen/pfb_feed_internal_filter'   => ['section' => 'gen', 'bare' => 'pfb_feed_internal_filter'],
+		'gen/pfb_syntax_highlight'       => ['section' => 'gen', 'bare' => 'pfb_syntax_highlight'],
+		'dnsbl/pfb_cache'                 => ['section' => 'dnsbl', 'bare' => 'pfb_cache'],
+		'dnsbl/pfb_py_reply'              => ['section' => 'dnsbl', 'bare' => 'pfb_py_reply'],
+		'dnsbl/pfb_hsts'                  => ['section' => 'dnsbl', 'bare' => 'pfb_hsts'],
+		'dnsbl/pfb_idn_block_malicious'  => ['section' => 'dnsbl', 'bare' => 'pfb_idn_block_malicious'],
+		'ip/suppression'                  => ['section' => 'ip', 'bare' => 'suppression'],
+	];
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	private function path(string $key): string
+	{
+		[$section, $bare] = explode('/', $key, 2);
+		return self::SECTIONS[$section] . '/' . $bare;
+	}
+
+	public function testDefaultOnTogglePresenceAndVocabulary(): void
+	{
+		foreach (self::DEFAULT_ON_TOGGLES as $key => $spec) {
+			$path = $this->path($key);
+			$this->assertSame(PfbToggle::On, PfbConfig::read($key), "{$key}: absent -> registered On");
+
+			config_set_path($path, '');
+			$this->assertSame(PfbToggle::Off, PfbConfig::read($key), "{$key}: present empty -> Off");
+			config_set_path($path, 'off');
+			$this->assertSame(PfbToggle::Off, PfbConfig::read($key), "{$key}: legacy off -> Off");
+			foreach (['junk', 'yes', '1'] as $raw) {
+				config_set_path($path, $raw);
+				$this->assertSame(PfbToggle::Off, PfbConfig::read($key), "{$key}: {$raw} -> Off");
+			}
+			foreach (['on', 'On', 'ON'] as $raw) {
+				config_set_path($path, $raw);
+				$this->assertSame(PfbToggle::On, PfbConfig::read($key), "{$key}: {$raw} -> On");
+			}
+
+			PfbConfig::writeSystem($key, PfbToggle::On);
+			$this->assertSame('on', config_get_path($path), "{$key}: write On -> on");
+			PfbConfig::writeSystem($key, PfbToggle::Off);
+			$this->assertSame('', config_get_path($path), "{$key}: write Off -> empty");
+			PfbConfig::writeSystem($key, NULL);
+			$this->assertNull(config_get_path($path), "{$key}: write NULL deletes");
+
+			PfbConfig::writeSectionSystem(self::SECTIONS[$spec['section']], [$spec['bare'] => 'on']);
+			$this->assertSame('on', config_get_path($path), "{$key}: section write On -> on");
+			PfbConfig::writeSectionSystem(self::SECTIONS[$spec['section']], [$spec['bare'] => '']);
+			$this->assertSame('', config_get_path($path), "{$key}: section write empty stays empty");
+			PfbConfig::writeSectionSystem(self::SECTIONS[$spec['section']], [$spec['bare'] => NULL]);
+			$this->assertNull(config_get_path($path), "{$key}: section write NULL deletes");
+		}
+	}
+
+	public function testIdnModeEmptyAndJunkUseOffFallbackAndWritesEmpty(): void
+	{
+		$key  = 'dnsbl/pfb_idn';
+		$path = $this->path($key);
+		$this->assertSame(PfbIdnMode::Off, PfbConfig::read($key), 'IDN absent -> registered Off');
+		foreach (['', 'off', 'all', 'yes', 'junk'] as $raw) {
+			config_set_path($path, $raw);
+			$this->assertSame(PfbIdnMode::Off, PfbConfig::read($key), "IDN {$raw} -> Off");
+		}
+		config_set_path($path, 'on');
+		$this->assertSame(PfbIdnMode::All, PfbConfig::read($key));
+		config_set_path($path, 'confusable');
+		$this->assertSame(PfbIdnMode::Confusable, PfbConfig::read($key));
+
+		PfbConfig::writeSystem($key, PfbIdnMode::Off);
+		$this->assertSame('', config_get_path($path));
+		PfbConfig::writeSystem($key, PfbIdnMode::All);
+		$this->assertSame('on', config_get_path($path));
+		PfbConfig::writeSystem($key, PfbIdnMode::Confusable);
+		$this->assertSame('confusable', config_get_path($path));
+		PfbConfig::writeSystem($key, NULL);
+		$this->assertNull(config_get_path($path));
+
+		PfbConfig::writeSectionSystem(self::SECTIONS['dnsbl'], ['pfb_idn' => PfbIdnMode::Off]);
+		$this->assertSame('', config_get_path($path));
+		PfbConfig::writeSectionSystem(self::SECTIONS['dnsbl'], ['pfb_idn' => NULL]);
+		$this->assertNull(config_get_path($path));
+	}
+
+	public function testSiblingEnumsKeepExistingEmptyJunkFallbacks(): void
+	{
+		$alias = $this->path('gen/pfb_alias_delta_mode');
+		$top1m = $this->path('dnsbl/top1m_source');
+		foreach (['', 'junk'] as $raw) {
+			config_set_path($alias, $raw);
+			$this->assertSame(PfbAliasDeltaMode::Auto, PfbConfig::read('gen/pfb_alias_delta_mode'));
+			config_set_path($top1m, $raw);
+			$this->assertSame(PfbTop1mSource::Tranco, PfbConfig::read('dnsbl/top1m_source'));
+		}
+		config_set_path($top1m, 'domcop');
+		$this->assertSame(PfbTop1mSource::OpenPageRank, PfbConfig::read('dnsbl/top1m_source'));
+		config_set_path($top1m, 'alexa');
+		$this->assertSame(PfbTop1mSource::Tranco, PfbConfig::read('dnsbl/top1m_source'));
+		foreach (['auto', 'delta', 'replace'] as $raw) {
+			config_set_path($alias, $raw);
+			$this->assertSame($raw, PfbConfig::read('gen/pfb_alias_delta_mode')->value);
+		}
+	}
+
+	public function testPlainScalarEmptyReadAndWriteContractsStayUnchanged(): void
+	{
+		$key  = 'dnsbl/dnsbl_interface';
+		$path = $this->path($key);
+		$this->assertSame('lo0', PfbConfig::read($key), 'plain scalar absent -> lo0');
+		config_set_path($path, '');
+		$this->assertSame('lo0', PfbConfig::read($key), 'plain scalar empty -> lo0');
+		PfbConfig::writeSystem($key, '');
+		$this->assertSame('lo0', config_get_path($path), 'single plain write keeps current defaulting');
+		PfbConfig::writeSectionSystem(self::SECTIONS['dnsbl'], ['dnsbl_interface' => '']);
+		$this->assertSame('', config_get_path($path), 'raw section plain write stays byte-identical');
+		$this->assertSame('lo0', PfbConfig::read($key), 'plain scalar raw empty still reads lo0');
+	}
+}

--- a/tests/php/ConfigEmptyStorageContractTest.php
+++ b/tests/php/ConfigEmptyStorageContractTest.php
@@ -13,7 +13,7 @@ final class ConfigEmptyStorageContractTest extends TestCase
 		'ip'    => 'installedpackages/pfblockerngipsettings/config/0',
 	];
 
-	/** @var array<string,array{path:string,default:PfbToggle}> */
+	/** @var array<string,array{section:string,bare:string}> */
 	private const DEFAULT_ON_TOGGLES = [
 		'gen/pfb_keep'                    => ['section' => 'gen', 'bare' => 'pfb_keep'],
 		'gen/pfb_software_check'          => ['section' => 'gen', 'bare' => 'pfb_software_check'],

--- a/tests/php/FeedFilterEnabledTest.php
+++ b/tests/php/FeedFilterEnabledTest.php
@@ -57,12 +57,11 @@ final class FeedFilterEnabledTest extends TestCase
 		$this->assertTrue(pfb_feed_filter_enabled());
 	}
 
-	public function testEmptyStringReadsAsTheRegisteredDefaultOn(): void
+	public function testEmptyStringReadsAsExplicitOff(): void
 	{
-		// issue #1887: '' is the not-configured state and resolves to the registered
-		// default 'on' at the gateway — same effective result as the old fail-safe.
+		// issue #2120: the owner-ruled toggle contract preserves present '' as Off.
 		$this->setToggle('');
-		$this->assertTrue(pfb_feed_filter_enabled());
+		$this->assertFalse(pfb_feed_filter_enabled());
 	}
 
 	public function testJunkTokenFallsBackToOff(): void

--- a/tests/php/FeedFilterEnabledTest.php
+++ b/tests/php/FeedFilterEnabledTest.php
@@ -11,9 +11,8 @@ use PHPUnit\Framework\TestCase;
  * feed-host guard at all.
  *
  * Default-ON contract: a fresh, never-configured install (key absent) reads as ON, so
- * the filter ships active. An explicit stored 'off' (written by an unchecked save, or
- * pinned by the install-time grandfather migration on an existing box) reads as OFF.
- * Any other stored value reads as ON (the value the UI writes when checked is 'on').
+ * the filter ships active. Case-insensitive 'on' reads as On; every other present token
+ * reads as Off. Unchecked saves write canonical empty; legacy 'off' remains read-compatible.
  */
 #[CoversFunction('pfb_feed_filter_enabled')]
 final class FeedFilterEnabledTest extends TestCase
@@ -43,7 +42,7 @@ final class FeedFilterEnabledTest extends TestCase
 	{
 		// Before: absent -> enabled.
 		$this->assertTrue(pfb_feed_filter_enabled());
-		// After: a stored 'off' (unchecked save / grandfather pin) -> disabled.
+		// After: a legacy stored 'off' (hand-edited or HA-synchronised) -> disabled.
 		$this->setToggle('off');
 		$this->assertFalse(pfb_feed_filter_enabled());
 	}

--- a/tests/php/GeneralSyntaxHighlightToggleWiringTest.php
+++ b/tests/php/GeneralSyntaxHighlightToggleWiringTest.php
@@ -32,7 +32,7 @@ final class GeneralSyntaxHighlightToggleWiringTest extends TestCase
 		$this->assertNotFalse($from, 'general page save branch must remain present');
 		$this->assertNotFalse($to, 'general page save must persist through the config gateway');
 		$window = substr($source, $from, $to - $from);
-		$needle = "\$pfb['gconfig']['pfb_syntax_highlight'] = pfb_filter(";
+		$needle = "\$pfb['gconfig']['pfb_syntax_highlight'] = pfb_filter(\$_POST['pfb_syntax_highlight'] ?? '', PFB_FILTER_ON_OFF, 'general') ?: '';";
 		$this->assertSame(1, substr_count($window, $needle), 'save branch must bind the toggle helper exactly once');
 	}
 }

--- a/tests/php/GeneralSyntaxHighlightToggleWiringTest.php
+++ b/tests/php/GeneralSyntaxHighlightToggleWiringTest.php
@@ -10,10 +10,10 @@ final class GeneralSyntaxHighlightToggleWiringTest extends TestCase
 
 	public function testSavePersistsExplicitOnAndOffTokens(): void
 	{
-		$this->assertSame('on', pfb_general_toggle_stored_value('on'));
-		$this->assertSame('off', pfb_general_toggle_stored_value(''));
-		$this->assertSame('off', pfb_general_toggle_stored_value(NULL));
-		$this->assertSame('off', pfb_general_toggle_stored_value(['on']));
+		$this->assertSame('on', pfb_filter('on', PFB_FILTER_ON_OFF, 'general'));
+		$this->assertSame('', pfb_filter('', PFB_FILTER_ON_OFF, 'general'));
+		$this->assertSame('', pfb_filter(NULL, PFB_FILTER_ON_OFF, 'general'));
+		$this->assertSame('', pfb_filter(['on'], PFB_FILTER_ON_OFF, 'general'));
 	}
 
 	/**
@@ -32,7 +32,7 @@ final class GeneralSyntaxHighlightToggleWiringTest extends TestCase
 		$this->assertNotFalse($from, 'general page save branch must remain present');
 		$this->assertNotFalse($to, 'general page save must persist through the config gateway');
 		$window = substr($source, $from, $to - $from);
-		$needle = "\$pfb['gconfig']['pfb_syntax_highlight'] = pfb_general_toggle_stored_value(";
+		$needle = "\$pfb['gconfig']['pfb_syntax_highlight'] = pfb_filter(";
 		$this->assertSame(1, substr_count($window, $needle), 'save branch must bind the toggle helper exactly once');
 	}
 }

--- a/tests/php/MigrationRegistryTest.php
+++ b/tests/php/MigrationRegistryTest.php
@@ -30,8 +30,8 @@ use PHPUnit\Framework\TestCase;
  *     config is a no-op (no write_config() calls).
  *   - RAW WRITE-BACK (issue #1921): every write this driver performs must persist
  *     RAW (adapter-free, PfbConfig::writeSectionRawSystem()) -- a migration transforms
- *     raw storage, and canonicalising a still-raw bystander value here, ahead of
- *     pfb_registry_pass(), would destroy exactly what that pass needs to grandfather.
+ *     raw storage, and canonicalising a bystander would mutate a key outside the
+ *     migration's declared work and hide the exact input from pfb_registry_pass().
  *   - pfb_migration_registry() returns exactly the declared entries in the correct order,
  *     each declaring exactly one of the single-'section' / multi-'sections' target forms.
  */
@@ -392,11 +392,10 @@ final class MigrationRegistryTest extends TestCase
 		// ADR-02 fired (the driver actually ran and rewrote this section).
 		$this->assertSame('dnsbl_python', $dnsbl['dnsbl_mode']);
 		$this->assertSame('on', $dnsbl['pfb_py_block']);
-		// The bystander legacy token must survive RAW -- canonicalisation is the
-		// registry pass's job (issue #1921), not the migration driver's.
+		// The bystander legacy token must survive RAW: this migration does not own it.
+		// An ordinary adapter-backed write may canonicalise it later (issue #1921).
 		$this->assertSame('alexa', $dnsbl['top1m_source'],
-			'pfb_run_migrations() write-back must persist RAW -- canonicalising a still-raw '
-			. 'bystander legacy value ahead of the registry pass destroys what the pass needs to grandfather'
+			'pfb_run_migrations() write-back must persist unrelated bystander values byte-identical'
 		);
 	}
 

--- a/tests/php/PfbGlobalParityTest.php
+++ b/tests/php/PfbGlobalParityTest.php
@@ -548,7 +548,7 @@ final class PfbGlobalParityTest extends TestCase
 	 *
 	 * #484 FIX (merged into PfbToggle by #1887): the GUI stores
 	 * 'off' for unchecked-save — distinguishable from absent (default 'on'). Current code
-	 * reads the legacy '' token (written by the old GUI) as PfbToggle::Off.
+	 * reads a present empty token as PfbToggle::Off.
 	 */
 	public function testRepair281PfbKeepDefaultIsFormallyOn(): void
 	{
@@ -565,12 +565,10 @@ final class PfbGlobalParityTest extends TestCase
 		$this->assertSame(PfbToggle::On, $result);
 		$this->assertSame('on', $result->value);
 
-		// issue #1887 (owner decision): a stored '' is the SAME not-configured state as an
-		// absent key — pfSense writes an unchecked checkbox as an empty element — so it
-		// resolves to the registered default 'on'. A deliberate opt-out is the explicit
-		// 'off' token, which round-trips (testPfbKeepRoundTrip* in CfgGatewayTest).
+		// issue #2120: a present empty token is the owner-ruled Off state; only an
+		// absent key resolves to the registered default On.
 		config_set_path('installedpackages/pfblockerng/config/0/pfb_keep', '');
 		$result_empty = PfbConfig::read('gen/pfb_keep');
-		$this->assertSame(PfbToggle::On, $result_empty, "stored '' pfb_keep resolves to the registered default On");
+		$this->assertSame(PfbToggle::Off, $result_empty, "stored '' pfb_keep resolves to Off");
 	}
 }

--- a/tests/php/PfbGlobalParityTest.php
+++ b/tests/php/PfbGlobalParityTest.php
@@ -8,9 +8,10 @@ use PHPUnit\Framework\TestCase;
  * ADR-29 Phase 4 — Default-parity tests for pfb_global() seam routing.
  *
  * For every key that pfb_global() reads from a registered section, this file
- * asserts that PfbConfig::read($key) on an absent/empty section returns the
- * SAME effective value the OLD pfb_global() code produced (registered default
- * == prior per-site default).
+ * asserts that PfbConfig::read($key) on an absent section returns the SAME
+ * effective value the OLD pfb_global() code produced (registered default ==
+ * prior per-site default). Present empty adapter tokens are explicit Off and
+ * are covered by the storage contract suite.
  *
  * The intentional divergences are the #281/#1907 default-repair class: pfb_keep (OLD
  * code used `?? 'on'`, PHP null-coalesce) and, per the #1907 owner decision,
@@ -45,7 +46,7 @@ final class PfbGlobalParityTest extends TestCase
 	 * enable_cb: OLD pfb_global() = $pfb['config']['enable_cb'] = null when absent.
 	 * Via gateway: PfbConfig::read('gen/enable_cb')->value = '' (PfbToggle::Off).
 	 * PARITY: null and '' are both falsy; downstream checks == 'on' — equivalent.
-	 * Gateway form emits '' (the registered default), which is the canonical off value.
+	 * Gateway storage emits the canonical empty Off token.
 	 */
 	public function testParityEnableCbAbsentYieldsOff(): void
 	{
@@ -70,8 +71,8 @@ final class PfbGlobalParityTest extends TestCase
 	 * installs (gen/pfb_keep's grandfather map); new installs and the runtime both
 	 * default to 'on'.
 	 *
-	 * #484 FIX (merged into PfbToggle by #1887): the GUI stores
-	 * 'off' for unchecked-save — distinguishable from absent (default 'on').
+	 * The GUI stores the canonical empty token for unchecked-save — distinguishable
+	 * from absent (default 'on'). Legacy 'off' remains read-compatible only.
 	 */
 	public function testParityPfbKeepAbsentYieldsOn(): void
 	{
@@ -216,7 +217,7 @@ final class PfbGlobalParityTest extends TestCase
 			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto')
 		);
 
-		// The adapter's legacy '' normalises to the canonical 'off' (issue #1887).
+		// The adapter's empty Off token remains empty on write.
 		$old_result = pfb_cfg_toggle_read('')->value;
 		$this->assertSame('off', $old_result);
 
@@ -286,7 +287,7 @@ final class PfbGlobalParityTest extends TestCase
 	/**
 	 * pfb_dnsbl_lenient: OLD = pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_dnsbl_lenient'] ?? '')->value.
 	 * When absent: pfb_cfg_toggle_read('')->value = 'off'.
-	 * Via gateway: PfbConfig::read('dnsbl/pfb_dnsbl_lenient')->value = 'off' (default 'off', lenient adapter).
+	 * Via gateway: PfbConfig::read('dnsbl/pfb_dnsbl_lenient')->value = 'off' (default Off).
 	 * PARITY: identical.
 	 */
 	public function testParityPfbDnsblLenientAbsentYieldsOff(): void
@@ -314,9 +315,8 @@ final class PfbGlobalParityTest extends TestCase
 	 * (pfblockerng_dnsbl.php's own isset(...) ? ... : 'on' render fallback), so
 	 * PfbConfig::read('dnsbl/pfb_hsts') now resolves absent to PfbToggle::On.
 	 * DIVERGENCE (intentional, same class as #281's pfb_keep repair below): the
-	 * registry pass's ['' => 'off'] grandfather preserves a 3.2 deliberate uncheck for
-	 * existing installs (RegistryPassTest row 9); a genuinely fresh install and the
-	 * runtime both now default to On.
+	 * Existing stored empty values remain explicit Off; absent values and fresh
+	 * installs use the registered On default.
 	 */
 	public function testParityPfbHstsAbsentYieldsOn(): void
 	{
@@ -547,8 +547,8 @@ final class PfbGlobalParityTest extends TestCase
 	 * into config.xml for existing installs; the runtime default is identical.
 	 *
 	 * #484 FIX (merged into PfbToggle by #1887): the GUI stores
-	 * 'off' for unchecked-save — distinguishable from absent (default 'on'). Current code
-	 * reads a present empty token as PfbToggle::Off.
+	 * The empty token is used for unchecked-save — distinguishable from absent
+	 * (default 'on'). Current code reads a present empty token as PfbToggle::Off.
 	 */
 	public function testRepair281PfbKeepDefaultIsFormallyOn(): void
 	{

--- a/tests/php/RegistryPassTest.php
+++ b/tests/php/RegistryPassTest.php
@@ -152,7 +152,7 @@ final class RegistryPassTest extends TestCase
 	// 2 -- Grandfathers (OLDCFG, per key x state)
 	// -----------------------------------------------------------------------
 
-	/** Row 4: gen/pfb_keep -- absent -> 'on'; '' -> 'off'; 'on' -> 'on'; 'off' -> 'off'. */
+	/** Row 4: gen/pfb_keep -- absent -> 'on'; empty remains empty; canonical tokens unchanged. */
 	public function testGrandfatherPfbKeep(): void
 	{
 		$populated = ['pfb_interval' => '4']; // OLDCFG discriminator
@@ -161,7 +161,7 @@ final class RegistryPassTest extends TestCase
 		$this->assertSame('on', $absent[self::GEN_SECTION]['pfb_keep'] ?? NULL);
 
 		$empty = pfb_registry_pass([self::GEN_SECTION => $populated + ['pfb_keep' => '']]);
-		$this->assertSame('off', $empty[self::GEN_SECTION]['pfb_keep'] ?? NULL);
+		$this->assertSame('', $empty[self::GEN_SECTION]['pfb_keep'] ?? NULL);
 
 		$on = pfb_registry_pass([self::GEN_SECTION => $populated + ['pfb_keep' => 'on']]);
 		$this->assertSame('on', $on[self::GEN_SECTION]['pfb_keep'] ?? NULL,
@@ -174,7 +174,7 @@ final class RegistryPassTest extends TestCase
 		$this->assertSecondPassIsEmpty([self::GEN_SECTION => $populated + ['pfb_keep' => '']]);
 	}
 
-	/** Row 5: gen/pfb_feed_internal_filter -- absent -> 'off'; 'on' -> 'on'; 'off' -> 'off'. */
+	/** Row 5: gen/pfb_feed_internal_filter -- absent -> 'off'; stored empty is untouched. */
 	public function testGrandfatherFeedInternalFilter(): void
 	{
 		$populated = ['pfb_interval' => '4'];
@@ -225,13 +225,13 @@ final class RegistryPassTest extends TestCase
 		$this->assertSecondPassIsEmpty([self::DNSBL_SECTION => $populated]);
 	}
 
-	/** Row 8: dnsbl/pfb_idn_block_malicious -- '' -> 'off'; absent -> 'on' (seeded default); 'on' -> 'on'. */
+	/** Row 8: dnsbl/pfb_idn_block_malicious -- empty remains empty; absent -> 'on'; 'on' -> 'on'. */
 	public function testGrandfatherIdnBlockMalicious(): void
 	{
 		$populated = ['pfb_dnsbl' => 'on'];
 
 		$empty = pfb_registry_pass([self::DNSBL_SECTION => $populated + ['pfb_idn_block_malicious' => '']]);
-		$this->assertSame('off', $empty[self::DNSBL_SECTION]['pfb_idn_block_malicious'] ?? NULL);
+		$this->assertSame('', $empty[self::DNSBL_SECTION]['pfb_idn_block_malicious'] ?? NULL);
 
 		$absent = pfb_registry_pass([self::DNSBL_SECTION => $populated]);
 		$this->assertSame('on', $absent[self::DNSBL_SECTION]['pfb_idn_block_malicious'] ?? NULL,
@@ -268,7 +268,7 @@ final class RegistryPassTest extends TestCase
 
 		foreach ($cases as [$section, $key, $populated]) {
 			$empty = pfb_registry_pass([$section => $populated + [$key => '']]);
-			$this->assertSame('off', $empty[$section][$key] ?? NULL, "{$key}: '' must map to 'off'");
+			$this->assertSame('', $empty[$section][$key] ?? NULL, "{$key}: '' must remain empty");
 
 			$oldcfg_absent = pfb_registry_pass([$section => $populated]);
 			$this->assertSame('on', $oldcfg_absent[$section][$key] ?? '__missing__',

--- a/tests/php/RegistryPassTest.php
+++ b/tests/php/RegistryPassTest.php
@@ -252,17 +252,10 @@ final class RegistryPassTest extends TestCase
 	/**
 	 * Row 9: dnsbl/pfb_cache, dnsbl/pfb_py_reply, dnsbl/pfb_hsts, ip/suppression --
 	 * issue #1907 owner decision: default flipped to 'on' (the de-facto page default
-	 * since 3.2). '' -> 'off' (the grandfather map's one entry, unchanged -- a 3.2
-	 * deliberate uncheck still survives upgrade); 'on' -> 'on'; absent (OLDCFG and
-	 * NEWCFG alike) -> 'on'.
-	 *
-	 * OLDCFG-absent seeds 'on' because this map carries no PFB_GF_ABSENT entry (only
-	 * '' => 'off'), so the OLDCFG absent-seed branch falls straight to the stabilised
-	 * default -- see pfb_registry_pass()'s docblock. Stabilisation is a no-op here: 'on'
-	 * is not itself one of the map's non-ABSENT inputs (only '' is), unlike before this
-	 * default flip when the default ('') collided with the map's own '' => 'off' entry.
+	 * since 3.2). Present empty remains canonical Off; 'on' remains On; absent (OLDCFG
+	 * and NEWCFG alike) seeds the registered On default. No grandfather arm remains.
 	 */
-	public function testGrandfatherEmptyStringToOffGroup(): void
+	public function testDefaultOnGroupPreservesEmptyAndSeedsAbsent(): void
 	{
 		$cases = [
 			[self::DNSBL_SECTION, 'pfb_cache',    ['pfb_dnsbl' => 'on']],
@@ -277,8 +270,7 @@ final class RegistryPassTest extends TestCase
 
 			$oldcfg_absent = pfb_registry_pass([$section => $populated]);
 			$this->assertSame('on', $oldcfg_absent[$section][$key] ?? '__missing__',
-				"{$key}: OLDCFG absent must seed the registry default 'on' -- this map carries no "
-				. 'PFB_GF_ABSENT entry');
+				"{$key}: OLDCFG absent must seed the registry default 'on'");
 
 			$newcfg_absent = pfb_registry_pass([$section => []]);
 			$this->assertSame('on', $newcfg_absent[$section][$key] ?? '__missing__',

--- a/tests/php/RegistryPassTest.php
+++ b/tests/php/RegistryPassTest.php
@@ -98,9 +98,8 @@ final class RegistryPassTest extends TestCase
 	}
 
 	/**
-	 * Row 2: a marker-only gen section (settings_family only) is NEWCFG -- the two
-	 * grandfathered fields must take their registered ('on'-side) default, not the
-	 * absent-grandfather value.
+	 * Row 2: a marker-only gen section (settings_family only) is NEWCFG -- registered
+	 * defaults must win over any OLDCFG-only grandfather decisions.
 	 */
 	public function testMarkerOnlyGenSectionIsNewcfgAndTakesRegistryDefaults(): void
 	{
@@ -109,7 +108,7 @@ final class RegistryPassTest extends TestCase
 		$result = pfb_registry_pass($sections);
 
 		$this->assertSame('on', $result[self::GEN_SECTION]['pfb_feed_internal_filter'] ?? NULL,
-			'NEWCFG must take the registry default, not the OLDCFG absent-grandfather (off)');
+			'NEWCFG must take the registry default for the feed filter');
 		$this->assertSame('auto', $result[self::GEN_SECTION]['pfb_alias_delta_mode'] ?? NULL,
 			'NEWCFG must take the registry default, not the OLDCFG absent-grandfather (replace)');
 	}
@@ -124,8 +123,8 @@ final class RegistryPassTest extends TestCase
 
 		$result = pfb_registry_pass($sections);
 
-		$this->assertSame('off', $result[self::GEN_SECTION]['pfb_feed_internal_filter'] ?? NULL,
-			'gen is OLDCFG (populated) -- the feed-filter grandfather must fire');
+		$this->assertSame('on', $result[self::GEN_SECTION]['pfb_feed_internal_filter'] ?? NULL,
+			'gen is OLDCFG (populated) -- feed-filter absent uses registered default');
 		$this->assertSame('tranco', $result[self::DNSBL_SECTION]['top1m_source'] ?? NULL,
 			'dnsbl is NEWCFG (empty) -- fields seed at their registry default');
 
@@ -174,13 +173,18 @@ final class RegistryPassTest extends TestCase
 		$this->assertSecondPassIsEmpty([self::GEN_SECTION => $populated + ['pfb_keep' => '']]);
 	}
 
-	/** Row 5: gen/pfb_feed_internal_filter -- absent -> 'off'; stored empty is untouched. */
+	/** Row 5: gen/pfb_feed_internal_filter -- absent -> registered default 'on'; empty stays empty. */
 	public function testGrandfatherFeedInternalFilter(): void
 	{
 		$populated = ['pfb_interval' => '4'];
 
 		$absent = pfb_registry_pass([self::GEN_SECTION => $populated]);
-		$this->assertSame('off', $absent[self::GEN_SECTION]['pfb_feed_internal_filter'] ?? NULL);
+		$this->assertSame('on', $absent[self::GEN_SECTION]['pfb_feed_internal_filter'] ?? NULL);
+
+		$empty = pfb_registry_pass([self::GEN_SECTION => $populated + ['pfb_feed_internal_filter' => '']]);
+		$this->assertSame('', $empty[self::GEN_SECTION]['pfb_feed_internal_filter'] ?? NULL,
+			'present empty must stay the canonical Off token'
+		);
 
 		$on = pfb_registry_pass([self::GEN_SECTION => $populated + ['pfb_feed_internal_filter' => 'on']]);
 		$this->assertSame('on', $on[self::GEN_SECTION]['pfb_feed_internal_filter'] ?? NULL);
@@ -188,6 +192,7 @@ final class RegistryPassTest extends TestCase
 		$off = pfb_registry_pass([self::GEN_SECTION => $populated + ['pfb_feed_internal_filter' => 'off']]);
 		$this->assertSame('off', $off[self::GEN_SECTION]['pfb_feed_internal_filter'] ?? NULL);
 
+		$this->assertSecondPassIsEmpty([self::GEN_SECTION => $populated + ['pfb_feed_internal_filter' => '']]);
 		$this->assertSecondPassIsEmpty([self::GEN_SECTION => $populated]);
 	}
 

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -134,9 +134,9 @@ final class SoftwareUpdateDecisionTest extends TestCase
 
 	/*
 	 * ---- pfb_software_check_enabled() — the single "Check for new versions" boolean ----
-	 * Default ENABLED via the registry (issue #1887): absent and '' are the not-configured
-	 * state and resolve to the registered default 'on'. An explicit 'off' — in any letter
-	 * case — disables; junk tokens fall back to Off like every other toggle (the pre-#1887
+	 * Default ENABLED via the registry (issue #1887): absent resolves to the registered
+	 * default 'on'; present '' is explicit Off. Legacy 'off' — in any letter case —
+	 * also disables; junk tokens fall back to Off like every other toggle (the pre-#1887
 	 * reader treated any non-'off' string as enabled). Both sides asserted so green proves
 	 * 'off' is a real disabling branch, not an always-enabled path.
 	 */
@@ -144,8 +144,8 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	{
 		return [
 			// issue #1887: the accessor reads the gateway itself (zero-arg); the ON
-			// default lives in the registry. '' and absent are the same not-configured
-			// state; junk now falls back to Off like every other toggle (it read as
+			// default lives in the registry. Present '' is explicit Off; absent uses
+			// that default. Junk falls back to Off like every other toggle (it read as
 			// enabled under the old hand-written `!== 'off'` reader).
 			'unset (never saved) -> enabled' => [null, true],
 			'on -> enabled'                  => ['on', true],

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -151,7 +151,7 @@ final class SoftwareUpdateDecisionTest extends TestCase
 			'on -> enabled'                  => ['on', true],
 			'off -> disabled'                => ['off', false],
 			'OFF (case variant) -> disabled' => ['OFF', false],
-			'empty string -> enabled'        => ['', true],
+			'empty string -> disabled'       => ['', false],
 			'legacy/other -> disabled'       => ['default', false],
 		];
 	}

--- a/tests/php/ToggleAdapterAdoptionTest.php
+++ b/tests/php/ToggleAdapterAdoptionTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  * junk falls back to Off — the same convention as every other toggle — and the case
  * variants an operator would plausibly hand-edit ('OFF', 'On') are now recognised
  * instead of being junk. Junk can only exist via a hand-edited config.xml: both save
- * paths emit canonical tokens, and the #1770 install seed writes 'off'/nothing.
+	 * paths emit canonical 'on'/empty tokens, and the registry seeds registered defaults.
  *
  * No global setters exist for either field (the #1895 interim confinement decision):
  * the Software page's privilege gate (issue #485) stays meaningful because the write
@@ -118,7 +118,7 @@ final class ToggleAdapterAdoptionTest extends TestCase
 	}
 
 	/**
-	 * The unchecked-save round trip: the Software page's inline write ('off') survives
+	 * The unchecked-save round trip: the Software page's inline empty write survives
 	 * the gateway and reads back as a disabled check.
 	 */
 	public function testSoftwareCheckUncheckedSaveRoundTrips(): void

--- a/tests/php/ToggleAdapterAdoptionTest.php
+++ b/tests/php/ToggleAdapterAdoptionTest.php
@@ -124,7 +124,7 @@ final class ToggleAdapterAdoptionTest extends TestCase
 	public function testSoftwareCheckUncheckedSaveRoundTrips(): void
 	{
 		PfbConfig::write('gen/pfb_software_check', PfbToggle::Off);
-		$this->assertSame('off', config_get_path(self::SW), 'Off must persist as the explicit off token');
+		$this->assertSame('', config_get_path(self::SW), 'Off must persist as the canonical empty token');
 		$this->assertFalse(pfb_software_check_enabled(), 'the persisted off must read back as disabled');
 	}
 }

--- a/tests/php/ToggleCaseInsensitiveTest.php
+++ b/tests/php/ToggleCaseInsensitiveTest.php
@@ -7,8 +7,8 @@ use PHPUnit\Framework\TestCase;
 /**
  * issue #1887 — PfbToggle accepts its two tokens in any case.
  *
- * The canonical stored form stays lowercase 'on'/'off' — the write path is unchanged and
- * still emits exactly those. This is about the READ path being forgiving of input the
+	 * Canonical writes are 'on'/empty; legacy 'off' remains readable in any case. This is
+	 * about the READ path being forgiving of input the
  * package did not write itself: a hand-edited config.xml, a restored backup, an HA sync,
  * or another tool touching installedpackages/*. Before this, 'On' or 'OFF' fell through
  * tryFrom() to the parse fallback and silently read as Off — a disabled feature for an

--- a/tests/php/ToggleEmptyPreservationTest.php
+++ b/tests/php/ToggleEmptyPreservationTest.php
@@ -32,12 +32,12 @@ final class ToggleEmptyPreservationTest extends TestCase
 
 		foreach ($fields as $bare => $key) {
 			$GLOBALS['config'] = [];
-			$unchecked = pfb_dnsbl_toggle_stored(NULL);
+			$unchecked = pfb_filter(NULL, PFB_FILTER_ON_OFF, 'dnsbl');
 			PfbConfig::writeSection($section, [$bare => $unchecked]);
-			$this->assertSame('off', config_get_path("{$section}/{$bare}"), "{$bare}: absent POST must persist Off");
+			$this->assertSame('', config_get_path("{$section}/{$bare}"), "{$bare}: absent POST must persist empty");
 			$this->assertFalse(pfb_dnsbl_toggle_enabled(PfbConfig::read($key)), "{$bare}: unchecked render must be disabled");
 
-			$checked = pfb_dnsbl_toggle_stored('on');
+			$checked = pfb_filter('on', PFB_FILTER_ON_OFF, 'dnsbl');
 			PfbConfig::writeSection($section, [$bare => $checked]);
 			$this->assertSame('on', config_get_path("{$section}/{$bare}"), "{$bare}: checked POST must persist On");
 			$this->assertTrue(pfb_dnsbl_toggle_enabled(PfbConfig::read($key)), "{$bare}: checked render must be enabled");
@@ -50,12 +50,12 @@ final class ToggleEmptyPreservationTest extends TestCase
 		$section = 'installedpackages/pfblockerngipsettings/config/0';
 		$key = 'ip/suppression';
 
-		$unchecked = pfb_ip_suppression_stored(NULL);
+		$unchecked = pfb_filter(NULL, PFB_FILTER_ON_OFF, 'ip');
 		PfbConfig::writeSection($section, ['suppression' => $unchecked]);
-		$this->assertSame('off', config_get_path("{$section}/suppression"), 'IP unchecked POST must persist Off');
+		$this->assertSame('', config_get_path("{$section}/suppression"), 'IP unchecked POST must persist empty');
 		$this->assertFalse(pfb_ip_suppression_enabled(PfbConfig::read($key)), 'IP unchecked render must be disabled');
 
-		$checked = pfb_ip_suppression_stored('on');
+		$checked = pfb_filter('on', PFB_FILTER_ON_OFF, 'ip');
 		PfbConfig::writeSection($section, ['suppression' => $checked]);
 		$this->assertSame('on', config_get_path("{$section}/suppression"), 'IP checked POST must persist On');
 		$this->assertTrue(pfb_ip_suppression_enabled(PfbConfig::read($key)), 'IP checked render must be enabled');
@@ -69,12 +69,12 @@ final class ToggleEmptyPreservationTest extends TestCase
 	public function testShippedSaveBindingsKeepEachToggleOnItsPage(): void
 	{
 		foreach ([
-			"\$pfb['dconfig']['pfb_cache'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
-			"\$pfb['dconfig']['pfb_py_reply'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
-			"\$pfb['dconfig']['pfb_hsts'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
-			"\$pfb['dconfig']['pfb_idn_block_malicious'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
-			"\$pfb['dconfig']['pfb_idn_escalate_suspicious'] = pfb_dnsbl_toggle_stored(" => self::DNSBL_PAGE,
-			"\$pfb['iconfig']['suppression'] = pfb_ip_suppression_stored(" => self::IP_PAGE,
+			"\$pfb['dconfig']['pfb_cache'] = pfb_filter(" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_py_reply'] = pfb_filter(" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_hsts'] = pfb_filter(" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_idn_block_malicious'] = pfb_filter(" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_idn_escalate_suspicious'] = pfb_filter(" => self::DNSBL_PAGE,
+			"\$pfb['iconfig']['suppression'] = pfb_filter(" => self::IP_PAGE,
 		] as $needle => $page) {
 			$source = php_strip_whitespace($page);
 			$start  = "if (isset(\$_POST['save'])) {";

--- a/tests/php/ToggleEmptyPreservationTest.php
+++ b/tests/php/ToggleEmptyPreservationTest.php
@@ -69,12 +69,12 @@ final class ToggleEmptyPreservationTest extends TestCase
 	public function testShippedSaveBindingsKeepEachToggleOnItsPage(): void
 	{
 		foreach ([
-			"\$pfb['dconfig']['pfb_cache'] = pfb_filter(" => self::DNSBL_PAGE,
-			"\$pfb['dconfig']['pfb_py_reply'] = pfb_filter(" => self::DNSBL_PAGE,
-			"\$pfb['dconfig']['pfb_hsts'] = pfb_filter(" => self::DNSBL_PAGE,
-			"\$pfb['dconfig']['pfb_idn_block_malicious'] = pfb_filter(" => self::DNSBL_PAGE,
-			"\$pfb['dconfig']['pfb_idn_escalate_suspicious'] = pfb_filter(" => self::DNSBL_PAGE,
-			"\$pfb['iconfig']['suppression'] = pfb_filter(" => self::IP_PAGE,
+			"\$pfb['dconfig']['pfb_cache'] = pfb_filter(\$_POST['pfb_cache'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_py_reply'] = pfb_filter(\$_POST['pfb_py_reply'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_hsts'] = pfb_filter(\$_POST['pfb_hsts'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_idn_block_malicious'] = pfb_filter(\$_POST['pfb_idn_block_malicious'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';" => self::DNSBL_PAGE,
+			"\$pfb['dconfig']['pfb_idn_escalate_suspicious'] = pfb_filter(\$_POST['pfb_idn_escalate_suspicious'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';" => self::DNSBL_PAGE,
+			"\$pfb['iconfig']['suppression'] = pfb_filter(\$_POST['suppression'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';" => self::IP_PAGE,
 		] as $needle => $page) {
 			$source = php_strip_whitespace($page);
 			$start  = "if (isset(\$_POST['save'])) {";

--- a/tests/php/ToggleMergeTest.php
+++ b/tests/php/ToggleMergeTest.php
@@ -111,7 +111,7 @@ final class ToggleMergeTest extends TestCase
 	/**
 	 * A stored '' is explicit Off; absent uses the field's registered default.
 	 */
-	public function testStoredEmptyStringResolvesToTheRegisteredDefault(): void
+	public function testStoredEmptyStringResolvesToOff(): void
 	{
 		config_set_path(self::KEEP, '');
 		$this->assertSame('', config_get_path(self::KEEP), "before: pfb_keep seed is ''");
@@ -132,7 +132,7 @@ final class ToggleMergeTest extends TestCase
 	/**
 	 * A stored '' and an absent key remain distinguishable through the gateway.
 	 */
-	public function testStoredEmptyStringIsIndistinguishableFromAbsent(): void
+	public function testStoredEmptyStringRemainsDistinctFromAbsent(): void
 	{
 		$absent = PfbConfig::read('gen/pfb_keep');
 
@@ -175,12 +175,12 @@ final class ToggleMergeTest extends TestCase
 	}
 
 	/**
-	 * write() also resolves '' to the registered default rather than to Off.
+	 * write() preserves a present empty string as explicit Off.
 	 *
-	 * Covers the third gateway entry point: a caller passing a legacy '' string
-	 * (rather than an enum) must not pin a default-on field to Off.
+	 * Covers the third gateway entry point: a caller passing the canonical empty
+	 * checkbox token (rather than an enum) must pin the field to Off.
 	 */
-	public function testWriteResolvesLegacyEmptyStringToTheDefault(): void
+	public function testWritePreservesExplicitEmptyOff(): void
 	{
 		PfbConfig::write('gen/pfb_keep', '');
 

--- a/tests/php/ToggleMergeTest.php
+++ b/tests/php/ToggleMergeTest.php
@@ -5,24 +5,19 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * issue #1887 — merging PfbToggle and PfbLenient into one explicit on/off enum.
+ * issue #1887/#2120 — merging PfbToggle and PfbLenient while preserving canonical
+ * empty Off storage and legacy 'off' read compatibility.
  *
  * Two independent changes are proved here, because each fixes a different defect:
  *
  * A — EXPLICIT OFF SURVIVES THE ROUND TRIP
- *   PfbToggle::Off serialises to 'off', not ''. A checkbox submits nothing when
- *   unchecked, so an Off stored as '' is indistinguishable from "never configured"
- *   for a default-on field: the registry default reasserts itself and silently
- *   re-enables the setting. That is the #484 bug class, and it is the whole reason
- *   the separate PfbLenient enum existed.
+ *   PfbToggle::Off serialises to ''. A present empty token is an explicit Off,
+ *   while an absent key resolves to the registered default on default-on fields.
  *
- * B — '' AND ABSENT ARE THE SAME STATE
- *   For a registered field, a stored '' means "not configured" exactly as an absent
- *   key does, so both resolve to the field's registered default. This has to hold at
- *   EVERY gateway entry point, not just read(): write() and writeSection() apply the
- *   adapters directly to raw stored values, so resolving '' in read() alone would
- *   leave a stored '' reading as the default while any section save normalised it to
- *   'off' — the same value meaning two different things at two layers.
+ * B — EMPTY AND ABSENT ARE DISTINCT STATES
+ *   For adapter-backed fields, a present '' reads as Off while an absent key reads
+ *   as the field's registered default. All gateway entry points preserve that
+ *   distinction and writeSection() keeps present empty byte-identical.
  *
  * The enum cannot resolve B on its own: fromStored() has no access to the field's
  * registered default, so "'' means this field's default" is only expressible at the
@@ -110,16 +105,11 @@ final class ToggleMergeTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// B — '' is the same state as absent
+	// B — '' is explicit Off; absence resolves to the registered default
 	// -----------------------------------------------------------------------
 
 	/**
-	 * A stored '' resolves to the field's registered default, exactly as absent does.
-	 *
-	 * Both directions are asserted so the test cannot pass by treating '' as a fixed
-	 * Off: on a default-ON field '' must read On, and on a default-OFF field it must
-	 * still read Off. A single-field version of this test would be satisfied by the
-	 * current always-Off behaviour.
+	 * A stored '' is explicit Off; absent uses the field's registered default.
 	 */
 	public function testStoredEmptyStringResolvesToTheRegisteredDefault(): void
 	{
@@ -140,10 +130,7 @@ final class ToggleMergeTest extends TestCase
 	}
 
 	/**
-	 * A stored '' and an absent key are indistinguishable through the gateway.
-	 *
-	 * Stated as an equivalence rather than against a literal so it keeps holding if a
-	 * field's registered default is ever changed.
+	 * A stored '' and an absent key remain distinguishable through the gateway.
 	 */
 	public function testStoredEmptyStringIsIndistinguishableFromAbsent(): void
 	{
@@ -152,7 +139,7 @@ final class ToggleMergeTest extends TestCase
 		config_set_path(self::KEEP, '');
 		$empty = PfbConfig::read('gen/pfb_keep');
 
-		$this->assertNotSame($absent, $empty, "pfb_keep: stored '' must remain distinct from an absent key");
+		$this->assertNotSame($absent, $empty, "pfb_keep: stored '' must remain Off while absent defaults On");
 	}
 
 	/**
@@ -161,7 +148,7 @@ final class ToggleMergeTest extends TestCase
 	 * writeSection() applies read_adapter() then write_adapter() to the raw stored
 	 * value, bypassing read() and therefore the registry default. Without the ''
 	 * resolution being shared by both entry points, a section save rewrites a stored
-	 * '' to 'off' while read() reports the default — so merely saving an unrelated
+	 * '' to a different token while read() reports Off — so merely saving an unrelated
 	 * field on the page flips this one. Asserting the two agree is what forces the
 	 * resolution into shared code rather than into read() alone.
 	 */

--- a/tests/php/ToggleMergeTest.php
+++ b/tests/php/ToggleMergeTest.php
@@ -51,7 +51,7 @@ final class ToggleMergeTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Writing Off stores the explicit 'off' token for every toggle field.
+	 * Writing Off stores the empty checkbox token for every toggle field.
 	 *
 	 * Asserted across a default-on and a default-off field together: the point is
 	 * that the stored vocabulary is now uniform, so a field's default no longer
@@ -62,9 +62,9 @@ final class ToggleMergeTest extends TestCase
 		foreach (['gen/pfb_keep' => self::KEEP, 'gen/enable_cb' => self::ENABLE] as $key => $path) {
 			PfbConfig::write($key, PfbToggle::Off);
 			$this->assertSame(
-				'off',
+				'',
 				config_get_path($path),
-				"{$key}: writing PfbToggle::Off must store the explicit 'off' token, not ''"
+				"{$key}: writing PfbToggle::Off must store the empty checkbox token"
 			);
 		}
 	}
@@ -86,7 +86,7 @@ final class ToggleMergeTest extends TestCase
 			$this->assertSame(PfbToggle::Off, $enum, "{$key}: stored 'off' must read as PfbToggle::Off");
 
 			PfbConfig::write($key, $enum);
-			$this->assertSame('off', config_get_path($path), "{$key}: write(read('off')) must be 'off'");
+			$this->assertSame('', config_get_path($path), "{$key}: write(read('off')) must be empty checkbox storage");
 		}
 	}
 
@@ -126,9 +126,9 @@ final class ToggleMergeTest extends TestCase
 		config_set_path(self::KEEP, '');
 		$this->assertSame('', config_get_path(self::KEEP), "before: pfb_keep seed is ''");
 		$this->assertSame(
-			PfbToggle::On,
+			PfbToggle::Off,
 			PfbConfig::read('gen/pfb_keep'),
-			"pfb_keep: stored '' must resolve to the registered default 'on', as an absent key does"
+			"pfb_keep: stored '' must resolve to Off, while an absent key resolves to On"
 		);
 
 		config_set_path(self::ENABLE, '');
@@ -152,7 +152,7 @@ final class ToggleMergeTest extends TestCase
 		config_set_path(self::KEEP, '');
 		$empty = PfbConfig::read('gen/pfb_keep');
 
-		$this->assertSame($absent, $empty, "pfb_keep: stored '' must read identically to an absent key");
+		$this->assertNotSame($absent, $empty, "pfb_keep: stored '' must remain distinct from an absent key");
 	}
 
 	/**
@@ -180,10 +180,10 @@ final class ToggleMergeTest extends TestCase
 			'pfb_keep: a section save must not change what the field reads as'
 		);
 		$this->assertSame(
-			'on',
+			'',
 			config_get_path(self::KEEP),
 			"pfb_keep: writeSection() must normalise a stored '' to the canonical form of the "
-				. "registered default, not to 'off'"
+				. "empty checkbox storage"
 		);
 	}
 
@@ -198,9 +198,9 @@ final class ToggleMergeTest extends TestCase
 		PfbConfig::write('gen/pfb_keep', '');
 
 		$this->assertSame(
-			'on',
+			'',
 			config_get_path(self::KEEP),
-			"pfb_keep: write('') must resolve to the registered default, not store 'off'"
+			"pfb_keep: write('') must store empty checkbox storage"
 		);
 	}
 
@@ -251,7 +251,7 @@ final class ToggleMergeTest extends TestCase
 			$this->assertSame(PfbToggle::On, PfbConfig::read($key), "{$key}: 'on' must read as PfbToggle::On");
 
 			PfbConfig::write($key, PfbToggle::Off);
-			$this->assertSame('off', config_get_path($spec['path']), "{$key}: Off must store as 'off'");
+			$this->assertSame('', config_get_path($spec['path']), "{$key}: Off must store as empty checkbox storage");
 		}
 	}
 }

--- a/tests/php/ToggleMirrorTypeTest.php
+++ b/tests/php/ToggleMirrorTypeTest.php
@@ -11,14 +11,13 @@ use PHPUnit\Framework\TestCase;
  * pfb_global() used to publish these mirrors as `PfbConfig::read($key)->value`, i.e. it
  * read the enum and immediately threw the type away. Consumers then re-derived the
  * meaning with hand-written string comparisons, and the vocabulary drifted three ways:
- * 'on', the newly explicit 'off', and a bare '' assigned by the force-disable paths.
+ * 'on', legacy 'off', and a bare '' assigned by the force-disable paths.
  *
- * That is what produced the fail-dangerous class this issue had to repair: `== ''` stops
- * matching a disabled package the moment Off is stored as 'off', and `!empty()` inverts
- * outright because '' is falsy while 'off' is truthy. Neither mistake is visible at the
- * call site, and both fail silently.
+ * That is what produced the fail-dangerous class this issue had to repair: `== ''` does not
+ * match legacy 'off', and `!empty()` inverts outright because '' is falsy while 'off' is
+ * truthy. Neither mistake is visible at the call site, and both fail silently.
  *
- * Publishing the enum itself is the fix: one vocabulary, no '' anywhere, and a comparison
+ * Publishing the enum itself is the fix: one runtime vocabulary, no raw tokens, and a comparison
  * that has to name PfbToggle::On or PfbToggle::Off to mean anything. www/ already
  * re-parsed these mirrors through pfb_cfg_toggle_read() to get an enum back — with the
  * mirror typed, that re-parsing is deleted rather than rewritten.

--- a/tests/php/WwwGroupAGatewayTest.php
+++ b/tests/php/WwwGroupAGatewayTest.php
@@ -239,7 +239,7 @@ final class WwwGroupAGatewayTest extends TestCase
 	 * Issue #930: writeSection() applies the toggle adapter to every registered
 	 * field of the target section, preserving the canonical empty Off token.
 	 */
-	public function testGeneralSectionPfbKeepEmptyResolvesToDefault(): void
+	public function testGeneralSectionPfbKeepEmptyPreservesExplicitOff(): void
 	{
 		$section = 'installedpackages/pfblockerng/config/0';
 

--- a/tests/php/WwwGroupAGatewayTest.php
+++ b/tests/php/WwwGroupAGatewayTest.php
@@ -53,11 +53,10 @@ final class WwwGroupAGatewayTest extends TestCase
 
 	/**
 	 * pfb_keep: page used `isset($pfb['gconfig']['pfb_keep']) ? ... : 'on'` — default 'on'.
-	 * Registry default = 'on' (PfbToggle::On after #484 fix). Page default REMOVED; gateway owns it.
+	 * Registry default = 'on' (PfbToggle::On). Page default REMOVED; gateway owns it.
 	 *
 	 * Parity: absent key → PfbConfig::read('gen/pfb_keep')->value === 'on' (was: 'on').
-	 * (#484 gave pfb_keep an explicit-off adapter; #1887 merged it back into PfbToggle,
-	 * whose Off now stores 'off' — the value is unchanged throughout.)
+	 * Present empty is explicit Off; legacy 'off' remains read-compatible and is never written.
 	 */
 	public function testGeneralPfbKeepAbsentDefaultMatchesPriorPageDefault(): void
 	{
@@ -70,7 +69,7 @@ final class WwwGroupAGatewayTest extends TestCase
 		$result = PfbConfig::read('gen/pfb_keep');
 
 		// Then: PfbToggle::On, value 'on' — matches prior page default 'on'.
-		// (#484 fix: pfb_keep now uses the lenient adapter; the value is unchanged.)
+		// PfbToggle owns the default-on adapter contract.
 		$this->assertSame(PfbToggle::On, $result, 'pfb_keep absent -> PfbToggle::On');
 		$this->assertSame('on', $result->value, 'pfb_keep absent -> value "on" (parity with prior isset default)');
 	}
@@ -237,10 +236,8 @@ final class WwwGroupAGatewayTest extends TestCase
 	 * Asserts the before-state ('on') and the after-state ('off') are distinct —
 	 * proving the write changed the value rather than being an always-equal no-op.
 	 *
-	 * Issue #930: writeSection() now applies the lenient adapter to every
-	 * registered field of the target section (same as a single-key
-	 * PfbConfig::write()) -- the legacy '' token is coalesced to the explicit
-	 * 'off' token instead of persisting raw.
+	 * Issue #930: writeSection() applies the toggle adapter to every registered
+	 * field of the target section, preserving the canonical empty Off token.
 	 */
 	public function testGeneralSectionPfbKeepEmptyResolvesToDefault(): void
 	{
@@ -340,9 +337,7 @@ final class WwwGroupAGatewayTest extends TestCase
 	 *   Then PfbConfig::readSection() returns an identical array.
 	 *
 	 * Issue #930: pfb_idn is adapter-bearing (PfbIdnMode); its fixture value uses
-	 * the canonical 'off' token (not the legacy '' — writeSection() now normalises
-	 * every registered field of the target section, and the real save handler's
-	 * 3-way select never emits '' either) so this stays a true byte-identical
+	 * the canonical empty Off token so this stays a true byte-identical
 	 * round-trip assertion.
 	 */
 	public function testDnsblSectionWriteReadRoundTrip(): void

--- a/tests/php/WwwGroupAGatewayTest.php
+++ b/tests/php/WwwGroupAGatewayTest.php
@@ -233,7 +233,7 @@ final class WwwGroupAGatewayTest extends TestCase
 	}
 
 	/**
-	 * General section: pfb_keep = '' (disabled) is normalised, not round-tripped raw.
+	 * General section: pfb_keep = '' (disabled) is preserved byte-for-byte.
 	 * Asserts the before-state ('on') and the after-state ('off') are distinct —
 	 * proving the write changed the value rather than being an always-equal no-op.
 	 *
@@ -250,12 +250,11 @@ final class WwwGroupAGatewayTest extends TestCase
 		PfbConfig::writeSection($section, ['pfb_keep' => 'on']);
 		$this->assertSame('on', PfbConfig::readSection($section)['pfb_keep'], 'pfb_keep starts as "on"');
 
-		// When: write '' — the not-configured token (issue #1887: '' ≡ absent).
+		// When: write '' — the owner-ruled Off token.
 		PfbConfig::writeSection($section, ['pfb_keep' => '']);
 
-		// Then: reads back as the registered default 'on'. A deliberate opt-out is the
-		// explicit 'off' token, which round-trips untouched (CfgGatewayTest).
-		$this->assertSame('on', PfbConfig::readSection($section)['pfb_keep'], "pfb_keep '' resolves to the registered default 'on'");
+		// Then: reads back as the owner-ruled empty Off token.
+		$this->assertSame('', PfbConfig::readSection($section)['pfb_keep'], "pfb_keep '' remains empty");
 	}
 
 	// -----------------------------------------------------------------------
@@ -309,11 +308,9 @@ final class WwwGroupAGatewayTest extends TestCase
 	}
 
 	/**
-	 * IP section: suppression toggled from 'on' -> 'off' round-trips correctly. issue
-	 * #1907 adopted the toggle adapter (default on) -- mirrors
-	 * testDnsblPfbIdnBlockMaliciousOffRoundTrips: a staged '' is now the not-configured
-	 * state and resolves to the registered default 'on', which is exactly why the
-	 * page's save handler stages the explicit 'off' token instead.
+	 * IP section: suppression toggled from 'on' -> '' round-trips correctly. issue
+	 * #1907 adopted the toggle adapter (default on); present empty is the owner-ruled Off
+	 * state while an absent key resolves to the registered default.
 	 */
 	public function testIpSectionSuppressionOffRoundTrips(): void
 	{
@@ -323,16 +320,11 @@ final class WwwGroupAGatewayTest extends TestCase
 		PfbConfig::writeSection($section, ['suppression' => 'on']);
 		$this->assertSame('on', PfbConfig::readSection($section)['suppression'], 'suppression starts as "on"');
 
-		// When: write the explicit 'off' (the page's unchecked-save token since #1907).
-		PfbConfig::writeSection($section, ['suppression' => 'off']);
-
-		// Then: reads back as 'off' -- the disabled state survives.
-		$this->assertSame('off', PfbConfig::readSection($section)['suppression'], "suppression 'off' round-trips");
-
-		// And a staged '' is the not-configured state: it resolves to the registered
-		// default 'on' -- which is exactly why the page must stage the explicit token.
+		// When: write the owner-ruled empty Off token.
 		PfbConfig::writeSection($section, ['suppression' => '']);
-		$this->assertSame('on', PfbConfig::readSection($section)['suppression'], "a staged '' resolves to the default-on");
+
+		// Then: reads back as empty -- the disabled state survives.
+		$this->assertSame('', PfbConfig::readSection($section)['suppression'], "suppression empty round-trips");
 	}
 
 	// -----------------------------------------------------------------------
@@ -408,13 +400,13 @@ final class WwwGroupAGatewayTest extends TestCase
 		// When: write (models the page save handler).
 		PfbConfig::writeSection($section, $data);
 
-		// Then: read back is byte-identical EXCEPT the toggle-adapter fields stored as ''
-		// — issue #1887 canonicalises the not-configured token to each field's registered
-		// default ('off' here; both have default ''). Everything else passes untouched.
+		// Then: read back is byte-identical. Toggle Off values are stored as empty.
 		$expected = $data;
-		$expected['pfb_dnsvip_auto'] = 'off';
-		$expected['pfb_regex_cap']   = 'off';
-		$expected['pfb_idn_escalate_suspicious'] = 'off';
+		$expected['pfb_dnsvip_auto'] = '';
+		$expected['pfb_regex_cap']   = '';
+		$expected['pfb_idn_escalate_suspicious'] = '';
+		$expected['pfb_idn'] = '';
+		$expected['pfb_dnsbl_lenient'] = '';
 		$result = PfbConfig::readSection($section);
 		$this->assertSame($expected, $result, 'DNSBL section round-trips with only the #1887 toggle canonicalisation');
 	}
@@ -431,21 +423,16 @@ final class WwwGroupAGatewayTest extends TestCase
 		PfbConfig::writeSection($section, ['pfb_idn_block_malicious' => 'on']);
 		$this->assertSame('on', PfbConfig::readSection($section)['pfb_idn_block_malicious'], 'pfb_idn_block_malicious starts as "on"');
 
-		// When: write the explicit 'off' (the page's unchecked-save token since #1887).
-		PfbConfig::writeSection($section, ['pfb_idn_block_malicious' => 'off']);
-
-		// Then: reads back as 'off' — the disabled state survives.
-		$this->assertSame('off', PfbConfig::readSection($section)['pfb_idn_block_malicious'], "pfb_idn_block_malicious 'off' round-trips");
-
-		// And a staged '' is the not-configured state: it resolves to the registered
-		// default 'on' — which is exactly why the page must stage the explicit token.
+		// When: write the owner-ruled empty Off token.
 		PfbConfig::writeSection($section, ['pfb_idn_block_malicious' => '']);
-		$this->assertSame('on', PfbConfig::readSection($section)['pfb_idn_block_malicious'], "a staged '' resolves to the default-on");
+
+		// Then: reads back as empty — the disabled state survives.
+		$this->assertSame('', PfbConfig::readSection($section)['pfb_idn_block_malicious'], "pfb_idn_block_malicious empty round-trips");
 	}
 
 	/**
-	 * pfb_feed_internal_filter toggled from 'on' → 'off' round-trips correctly.
-	 * Asserts the before-state ('on') and the after-state ('off') are distinct.
+	 * pfb_feed_internal_filter toggled from 'on' → empty round-trips correctly.
+	 * Asserts the before-state ('on') and the after-state (empty) are distinct.
 	 */
 	public function testGeneralPfbFeedInternalFilterOffRoundTrips(): void
 	{
@@ -455,10 +442,10 @@ final class WwwGroupAGatewayTest extends TestCase
 		PfbConfig::writeSection($section, ['pfb_feed_internal_filter' => 'on']);
 		$this->assertSame('on', PfbConfig::readSection($section)['pfb_feed_internal_filter'], 'pfb_feed_internal_filter starts as "on"');
 
-		// When: write 'off' (user unchecked the box and saved).
-		PfbConfig::writeSection($section, ['pfb_feed_internal_filter' => 'off']);
+		// When: write empty (user unchecked the box and saved).
+		PfbConfig::writeSection($section, ['pfb_feed_internal_filter' => '']);
 
-		// Then: reads back as 'off'.
-		$this->assertSame('off', PfbConfig::readSection($section)['pfb_feed_internal_filter'], 'pfb_feed_internal_filter "off" round-trips identically');
+		// Then: reads back as empty.
+		$this->assertSame('', PfbConfig::readSection($section)['pfb_feed_internal_filter'], 'pfb_feed_internal_filter empty round-trips identically');
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -2696,19 +2696,6 @@
             }
         ]
     },
-    "pfb_dnsbl_toggle_stored": {
-        "returnsRef": false,
-        "returnType": "string",
-        "params": [
-            {
-                "name": "posted",
-                "byRef": false,
-                "variadic": false,
-                "type": "mixed",
-                "default": null
-            }
-        ]
-    },
     "pfb_dnsbl_unbracket_ip6": {
         "returnsRef": false,
         "returnType": "string",
@@ -3751,19 +3738,6 @@
         "returnType": "string",
         "params": []
     },
-    "pfb_editor_toggle_stored_value": {
-        "returnsRef": false,
-        "returnType": "string",
-        "params": [
-            {
-                "name": "posted",
-                "byRef": false,
-                "variadic": false,
-                "type": "mixed",
-                "default": null
-            }
-        ]
-    },
     "pfb_emit_entry_reject_stats": {
         "returnsRef": false,
         "returnType": "void",
@@ -4538,19 +4512,6 @@
         "returnsRef": false,
         "returnType": "string",
         "params": []
-    },
-    "pfb_general_toggle_stored_value": {
-        "returnsRef": false,
-        "returnType": "string",
-        "params": [
-            {
-                "name": "posted",
-                "byRef": false,
-                "variadic": false,
-                "type": "mixed",
-                "default": null
-            }
-        ]
     },
     "pfb_geoip_append_iso_data": {
         "returnsRef": false,
@@ -6352,19 +6313,6 @@
         "params": [
             {
                 "name": "stored",
-                "byRef": false,
-                "variadic": false,
-                "type": "mixed",
-                "default": null
-            }
-        ]
-    },
-    "pfb_ip_suppression_stored": {
-        "returnsRef": false,
-        "returnType": "string",
-        "params": [
-            {
-                "name": "posted",
                 "byRef": false,
                 "variadic": false,
                 "type": "mixed",

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1075,6 +1075,48 @@ def config_get(vm: SmokeVM, path: str, *, timeout: float = 60.0) -> str:
     return out[start + len(_CFG_VAL_OPEN) : end]
 
 
+def config_get_state(vm: SmokeVM, path: str, *, timeout: float = 60.0) -> tuple[bool, str]:
+    """Read exact stored presence and raw scalar token for a config path."""
+    marker = "<<<CFGABSENT>>>"
+    snippet = (
+        f"$v = config_get_path({_php_str(path)}, NULL); "
+        f"echo {_php_str(_CFG_VAL_OPEN)} . "
+        f"($v === NULL ? {_php_str(marker)} : 'PRESENT|' . (string) $v) . "
+        f"{_php_str(_CFG_VAL_CLOSE)};"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(f"config_get_state({path!r}) failed: {result.stderr!r}")
+    out = result.stdout
+    start = out.find(_CFG_VAL_OPEN)
+    end = out.find(_CFG_VAL_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"config_get_state({path!r}): no delimited value in pfSsh.php output: {out!r}")
+    value = out[start + len(_CFG_VAL_OPEN) : end]
+    if value == marker:
+        return False, ""
+    if not value.startswith("PRESENT|"):
+        raise RuntimeError(f"config_get_state({path!r}): malformed value {value!r}")
+    return True, value[len("PRESENT|") :]
+
+
+def config_restore_state(vm: SmokeVM, path: str, state: tuple[bool, str], *, timeout: float = 60.0) -> None:
+    """Restore exact presence/raw state captured by :func:`config_get_state`."""
+    if state[0]:
+        config_set(vm, path, state[1], timeout=timeout)
+        return
+    snippet = (
+        f"config_del_path({_php_str(path)});\n"
+        "write_config('pfBlockerNG smoke: restore absent config value');\n"
+        "echo 'OK';"
+    )
+    result = php_eval(vm, snippet, timeout=timeout)
+    if result.returncode != 0 or "OK" not in result.stdout:
+        raise RuntimeError(
+            f"config_restore_state({path!r}) failed: rc={result.returncode} {result.stderr!r} {result.stdout!r}"
+        )
+
+
 def config_set(vm: SmokeVM, path: str, value: str, *, timeout: float = 60.0) -> None:
     """Write one scalar config value back VERBATIM (the restore half of config_get).
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1078,10 +1078,8 @@ def config_get(vm: SmokeVM, path: str, *, timeout: float = 60.0) -> str:
 def config_set(vm: SmokeVM, path: str, value: str, *, timeout: float = 60.0) -> None:
     """Write one scalar config value back VERBATIM (the restore half of config_get).
 
-    Restores must preserve the stored token exactly: a captured canonical ``'off'``
-    round-trips as ``'off'``, never degraded to the raw ``''`` the boolean toggle
-    helpers write (issue #1947 — ``'' != 'off'`` fails a strict restore assert even
-    though both mean Off under the #1887 toggle vocabulary).
+    Restores preserve the captured stored token exactly. This raw helper deliberately
+    bypasses adapter canonicalisation, including for legacy ``'off'`` toggle values.
     """
     snippet = (
         f"config_set_path({_php_str(path)}, {_php_str(value)});\n"
@@ -1692,12 +1690,10 @@ def set_package_enabled(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None
 
 def set_pfb_keep(vm: SmokeVM, keep: bool, *, timeout: float = 60.0) -> None:
     """Set ``pfb_keep`` at ``CFG_GLOBAL``: ``True`` → ``'on'`` (retain settings + data on
-    uninstall); ``False`` → ``'off'`` (full removal — live objects + settings + data all gone).
+    uninstall); ``False`` → ``''`` (full removal — live objects + settings + data all gone).
 
-    ``pfb_keep`` uses the merged toggle adapter (``PfbToggle``, issue #1887) whose stored
-    vocabulary is ``{'on', 'off'}``; the off case writes the explicit ``'off'`` token.
-    A stored ``''`` is the not-configured state and resolves to the registered default
-    (``'on'`` for pfb_keep) at the PfbConfig gateway; write always emits ``'off'``.
+    ``pfb_keep`` uses the merged toggle adapter (``PfbToggle``): a present empty token is
+    canonical Off while an absent key resolves to the registered default On.
 
     ``pfb_keep`` defaults to ``'on'`` (issue #281), so a test that asserts sections are
     swept after uninstall MUST call ``set_pfb_keep(vm, False)`` explicitly to select the
@@ -1705,7 +1701,7 @@ def set_pfb_keep(vm: SmokeVM, keep: bool, *, timeout: float = 60.0) -> None:
     #484 fix) uses ``set_pfb_keep(vm, True)`` (or relies on the default, but explicit
     is clearer).
     """
-    val = "on" if keep else "off"
+    val = "on" if keep else ""
     snippet = (
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         f"$g['pfb_keep'] = {_php_str(val)};\n"

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -843,7 +843,7 @@ def test_user_filter_rule_survives_disable_and_uninstall(deployed_vm: SmokeVM, p
         h.set_package_enabled(vm, True)
         h.set_dnsbl_enabled(vm, True)
         # GIVEN — select the full-removal uninstall path (pfb_keep defaults to 'on'; a test that
-        # asserts sections-gone must set pfb_keep=off explicitly — see issue #484).
+        # asserts sections-gone must set pfb_keep to Off explicitly — see issue #484).
         h.set_pfb_keep(vm, False)
         # GIVEN — seed the user filter rule; assert block is disabled.
         _set_dot_block(vm, enabled=False, ifaces=[], exception="")
@@ -1094,7 +1094,7 @@ def test_uninstall_sweep_removes_all_dot_block_rules(deployed_vm: SmokeVM, prima
     h.set_package_enabled(vm, True)
     h.set_dnsbl_enabled(vm, True)
     # GIVEN — select the full-removal uninstall path (pfb_keep defaults to 'on'; a test
-    # that asserts sections-gone must set pfb_keep=off explicitly — see issue #484).
+    # that asserts sections-gone must set pfb_keep to Off explicitly — see issue #484).
     h.set_pfb_keep(vm, False)
     # GIVEN — enable DoT block on the primary interface and seed a user filter rule.
     # The seed is wrapped so the finally can remove it: it carries no pfB marker, so

--- a/tests/smoke/test_smoke_managed_objects.py
+++ b/tests/smoke/test_smoke_managed_objects.py
@@ -508,7 +508,7 @@ def test_managed_objects_uninstall_sweeps_orphan_preserves_user_objects(deployed
     vm = deployed_vm
 
     # GIVEN — select the full-removal uninstall path (pfb_keep defaults to 'on'; a test that
-    # asserts sections-gone must set pfb_keep=off explicitly — see issue #484).
+    # asserts sections-gone must set pfb_keep to Off explicitly — see issue #484).
     h.set_pfb_keep(vm, False)
     # GIVEN — seed the three objects; first confirm DNSBL is disabled / clean.
     h.set_dnsbl_enabled(vm, False)

--- a/tests/smoke/ui/test_alerts_idn_exclusion_render.py
+++ b/tests/smoke/ui/test_alerts_idn_exclusion_render.py
@@ -130,7 +130,7 @@ def _seeded_idn_exclusion(smoke_vm: SmokeVM) -> Iterator[None]:
     )
 
     # Restore VERBATIM, not through the boolean helper: the box may hold the
-    # canonical 'off' token, which set_dnsbl_enabled would degrade to the raw ''
+    # legacy 'off' token, which set_dnsbl_enabled would canonicalise to raw ''
     # and fail the strict round-trip assert below (issue #1947).
     helpers.config_set(vm, CFG_DNSBL_ENABLE, prior_dnsbl)
     assert helpers.config_get(vm, CFG_DNSBL_ENABLE) == prior_dnsbl, (

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -392,11 +392,8 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
     NOTE on the stored vocabulary (issue #964): the page form sends 'on' (checked) or
     '' (unchecked) — ``pfb_filter(..., PFB_FILTER_ON_OFF)`` rejects 'off' — but the
     save persists the section via ``PfbConfig::writeSection`` (pfblockerng_dnsbl.php:903),
-    which since a2c5c26a round-trips every adapter-carrying key through its read+write
-    adapters, and ``PfbToggle``'s canonical off token is 'off', never '' — so an
-    unchecked save STORES 'off'. Page-reachable stored tokens: 'on' (checked) and
-    'off' (unchecked); the render side maps both correctly
-    (``pfb_cfg_toggle_read('off') !== PfbToggle::On`` → unchecked).
+    which round-trips every adapter-carrying key through its read+write adapters;
+    unchecked saves store the empty token. Legacy ``'off'`` remains readable.
 
     Scenario: ADR-29 gateway save→reload round-trip for pfb_dnsbl_lenient on the DNSBL page.
       Background: pfBlockerNG deployed; DNSBL VIP seeded; webConfigurator authenticated.
@@ -412,13 +409,12 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
     page = browser_page
 
     # GIVEN: the form sends a plain on/'' checkbox, but the save's writeSection adapter
-    # ride coalesces the unchecked '' to PfbToggle's canonical 'off' (issue #964/#1887).
     # Map the stored value to its checkbox token ('on' = checked, anything else =
-    # unchecked) and each POSTed token to the value the save will STORE.
+    # unchecked) and each POSTed token to the value the save will store.
     original_raw = helpers.config_get(smoke_vm, _CFG_LENIENT)
     original_box = "on" if original_raw == "on" else ""
     flipped = "" if original_box == "on" else "on"
-    stored_token = {"on": "on", "": "off"}  # POSTed checkbox token -> canonical stored token
+    stored_token = {"on": "on", "": ""}  # POSTed checkbox token -> canonical stored token
 
     try:
         # ---- FLIP: POST the checkbox to the opposite state ---- #
@@ -429,8 +425,7 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
         stored_flip = helpers.config_get(smoke_vm, _CFG_LENIENT)
         assert stored_flip == stored_token[flipped], (
             f"pfb_dnsbl_lenient gateway FAIL after flip: stored {stored_flip!r}, "
-            f"expected {stored_token[flipped]!r} (the writeSection adapter ride stores "
-            f"canonical 'on'/'off', issue #964)"
+            f"expected {stored_token[flipped]!r} (the writeSection adapter stores canonical on/empty)"
         )
 
         # DOM oracle: reload the DNSBL page and assert the checkbox state matches.
@@ -451,7 +446,7 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
         stored_restore = helpers.config_get(smoke_vm, _CFG_LENIENT)
         assert stored_restore == stored_token[original_box], (
             f"pfb_dnsbl_lenient gateway FAIL after restore: stored {stored_restore!r}, "
-            f"expected {stored_token[original_box]!r} (canonical 'on'/'off', issue #964)"
+            f"expected {stored_token[original_box]!r} (canonical on/empty)"
         )
 
         # DOM oracle: reload and assert the checkbox matches the restored value.

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -401,7 +401,7 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
     Given the current checkbox state of pfb_dnsbl_lenient (read via config_get oracle —
       'on' = checked, anything else = unchecked),
     When the DNSBL page is POST-saved with the checkbox flipped,
-    Then config.xml holds the CANONICAL token ('on' or 'off'); AND the DNSBL page,
+    Then config.xml holds the CANONICAL token ('on' or ''); AND the DNSBL page,
       navigated fresh in the browser, renders the checkbox in the matching state; AND a
       second POST restores the original state with the same two assertions (both
       directions).
@@ -411,8 +411,8 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
     # GIVEN: the form sends a plain on/'' checkbox, but the save's writeSection adapter
     # Map the stored value to its checkbox token ('on' = checked, anything else =
     # unchecked) and each POSTed token to the value the save will store.
-    original_raw = helpers.config_get(smoke_vm, _CFG_LENIENT)
-    original_box = "on" if original_raw == "on" else ""
+    original_state = helpers.config_get_state(smoke_vm, _CFG_LENIENT)
+    original_box = "on" if original_state[0] and original_state[1] == "on" else ""
     flipped = "" if original_box == "on" else "on"
     stored_token = {"on": "on", "": ""}  # POSTed checkbox token -> canonical stored token
 
@@ -458,12 +458,14 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
         else:
             expect(box_restore).not_to_be_checked(timeout=JS_TIMEOUT_MS)
         _shot(page, screenshot_dir, "gateway_dnsbl_lenient_after_restore")
+        helpers.config_restore_state(smoke_vm, _CFG_LENIENT, original_state)
+        assert helpers.config_get_state(smoke_vm, _CFG_LENIENT) == original_state
 
     finally:
         # Belt-and-suspenders: restore to the original checkbox value on any mid-flip
         # abort (compare against the canonical stored token an unchecked save leaves).
-        if helpers.config_get(smoke_vm, _CFG_LENIENT) != stored_token[original_box]:
-            webui.post(DNSBL_PAGE, {"pfb_dnsbl_lenient": original_box}, timeout=_DNSBL_POST_TIMEOUT)
+        if helpers.config_get_state(smoke_vm, _CFG_LENIENT) != original_state:
+            helpers.config_restore_state(smoke_vm, _CFG_LENIENT, original_state)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -105,7 +105,7 @@ def test_gateway_pfb_keep_save_roundtrip(
     # GIVEN: read the starting value so we know which direction to flip first.
     # An absent pfb_keep reads as the registered default 'on' (issue #1887), so resolve
     # absent -> 'on': the restore must return the box to its EFFECTIVE original state,
-    # never pin an explicit 'off' onto a merely-unconfigured default-on field.
+    # never pin an explicit Off onto a merely-unconfigured default-on field.
     original_raw = helpers.config_get(smoke_vm, _CFG_KEEP)
     original = "on" if original_raw in (None, "on") else ""
     flipped = "" if original == "on" else "on"

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -102,12 +102,11 @@ def test_gateway_pfb_keep_save_roundtrip(
     """
     page = browser_page
 
-    # GIVEN: read the starting value so we know which direction to flip first.
-    # An absent pfb_keep reads as the registered default 'on' (issue #1887), so resolve
-    # absent -> 'on': the restore must return the box to its EFFECTIVE original state,
-    # never pin an explicit Off onto a merely-unconfigured default-on field.
-    original_raw = helpers.config_get(smoke_vm, _CFG_KEEP)
-    original = "on" if original_raw in (None, "on") else ""
+    # GIVEN: capture exact presence/raw state, then resolve the effective state.
+    # An absent pfb_keep reads as the registered default 'on'; explicit empty is Off.
+    original_state = helpers.config_get_state(smoke_vm, _CFG_KEEP)
+    original_raw = original_state[1]
+    original = "on" if not original_state[0] or original_raw == "on" else ""
     flipped = "" if original == "on" else "on"
 
     try:
@@ -156,16 +155,14 @@ def test_gateway_pfb_keep_save_roundtrip(
         else:
             expect(box_restore).not_to_be_checked(timeout=JS_TIMEOUT_MS)
         _shot(page, screenshot_dir, "gateway_general_pfb_keep_after_restore")
+        helpers.config_restore_state(smoke_vm, _CFG_KEEP, original_state)
+        assert helpers.config_get_state(smoke_vm, _CFG_KEEP) == original_state
 
     finally:
         # Belt-and-suspenders: ensure box is always left at its original value even
         # if an assertion above aborted mid-flip, so the session VM is left clean.
-        if helpers.config_get(smoke_vm, _CFG_KEEP) != original:
-            webui.post(
-                GENERAL_PAGE,
-                {"pfb_keep": original} if original == "on" else {"pfb_keep": original},
-                timeout=_GENERAL_POST_TIMEOUT,
-            )
+        if helpers.config_get_state(smoke_vm, _CFG_KEEP) != original_state:
+            helpers.config_restore_state(smoke_vm, _CFG_KEEP, original_state)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_browser_general.py
+++ b/tests/smoke/ui/test_browser_general.py
@@ -82,19 +82,16 @@ def test_gateway_pfb_keep_save_roundtrip(
     """pfb_keep (PfbToggle gateway field) persists via the General page and reflects in the DOM.
 
     Proves that the ADR-29 gateway routing on ``pfblockerng_general.php`` stores
-    the exact legacy token for ``pfb_keep`` ('on'/'off'), and that the General page
+    the canonical checkbox token for ``pfb_keep`` ('on'/''), and that the General page
     re-renders the checkbox in the correct state when the page is reloaded.
 
-    NOTE on the off-token (issue #484): the General save persists an EXPLICIT 'off'
-    for an unchecked pfb_keep (``(($_POST['pfb_keep'] ?? '') === 'on') ? 'on' : 'off'``),
-    not '' -- so a default-on flag can record a deliberate off across a pkg upgrade.
-    The two page-reachable tokens are therefore 'on' (checked) and 'off' (unchecked).
+    Unchecked saves persist the empty checkbox token; legacy ``'off'`` remains readable.
 
     Scenario: ADR-29 gateway save→reload round-trip for pfb_keep on the General page.
       Background: pfBlockerNG deployed; webConfigurator authenticated; wizard dismissed.
 
     Given the current stored value of pfb_keep (read via config_get oracle) is one
-      of the two legal tokens ('on' or 'off'),
+      of the two canonical tokens ('on' or ''),
 
     When the General page is POST-saved with pfb_keep set to the OTHER value,
 
@@ -109,11 +106,9 @@ def test_gateway_pfb_keep_save_roundtrip(
     # An absent pfb_keep reads as the registered default 'on' (issue #1887), so resolve
     # absent -> 'on': the restore must return the box to its EFFECTIVE original state,
     # never pin an explicit 'off' onto a merely-unconfigured default-on field.
-    original = helpers.config_get(smoke_vm, _CFG_KEEP) or "on"
-    assert original in ("on", "off"), f"pfb_keep starting value {original!r} not in expected vocabulary {{'on', 'off'}}"
-    # The two branches: flip to the opposite, then restore. The off-token is the explicit
-    # 'off' the save emits for an unchecked box (issue #484), not ''.
-    flipped = "off" if original == "on" else "on"
+    original_raw = helpers.config_get(smoke_vm, _CFG_KEEP)
+    original = "on" if original_raw in (None, "on") else ""
+    flipped = "" if original == "on" else "on"
 
     try:
         # ---- FLIP: POST pfb_keep to the opposite value ---- #
@@ -123,7 +118,7 @@ def test_gateway_pfb_keep_save_roundtrip(
         resp = webui.post(GENERAL_PAGE, overrides_flip, timeout=_GENERAL_POST_TIMEOUT)
         assert "Sign In" not in resp.text, "pfb_keep flip POST lost the session (got login page)"
 
-        # Config oracle: stored token must equal the flipped value.
+        # Config oracle: stored token must equal the canonical flipped value.
         stored_flip = helpers.config_get(smoke_vm, _CFG_KEEP)
         assert stored_flip == flipped, (
             f"pfb_keep gateway FAIL after flip: stored {stored_flip!r}, expected {flipped!r} "
@@ -146,7 +141,7 @@ def test_gateway_pfb_keep_save_roundtrip(
         resp = webui.post(GENERAL_PAGE, overrides_restore, timeout=_GENERAL_POST_TIMEOUT)
         assert "Sign In" not in resp.text, "pfb_keep restore POST lost the session (got login page)"
 
-        # Config oracle: stored token must equal the original.
+        # Config oracle: stored token must equal the canonical original.
         stored_restore = helpers.config_get(smoke_vm, _CFG_KEEP)
         assert stored_restore == original, (
             f"pfb_keep gateway FAIL after restore: stored {stored_restore!r}, expected {original!r}"

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -507,15 +507,13 @@ def test_dnsbl_idn_mode_select_round_trips_all_modes(
     """
     page = "/pfblockerng/pfblockerng_dnsbl.php"
     cfg = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn"
-    original = helpers.config_get(smoke_vm, cfg)
+    original_state = helpers.config_get_state(smoke_vm, cfg)
     try:
         for posted, expected in (("confusable", "confusable"), ("on", "on"), ("off", "")):
             got = _post_and_get(webui, smoke_vm, page, {"pfb_idn": posted}, cfg)
             assert got == expected, f"pfb_idn select: POSTing {posted!r} stored {got!r} (expected {expected!r})"
     finally:
-        # Restore the original; fall back to 'off' since the save validator rejects an
-        # empty/absent value (only off/confusable/on are accepted), leaving the box clean.
-        _post_and_get(webui, smoke_vm, page, {"pfb_idn": original or "off"}, cfg)
+        helpers.config_restore_state(smoke_vm, cfg, original_state)
 
 
 def test_dnsbl_top1m_token_masked_field_persists_and_is_never_echoed(

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -127,7 +127,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         config_path="installedpackages/pfblockerng/config/0/enable_cb",
         # issue #1887: enable_cb carries the toggle adapter, so the save's
         # writeSection ride canonicalises an unchecked '' to the explicit 'off'.
-        off="off",
     ),
     ToggleFlow(
         name="general_keep_settings",
@@ -136,7 +135,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         config_path="installedpackages/pfblockerng/config/0/pfb_keep",
         # issue #484: the General save stores an explicit 'off' for an unchecked
         # pfb_keep (not '') so a default-on flag can persist a deliberate off.
-        off="off",
         # Registry default 'on': an absent key means the feature is ON.
         absent="on",
     ),
@@ -163,7 +161,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="suppression",
         config_path="installedpackages/pfblockerngipsettings/config/0/suppression",
         # issue #1907: toggle-adapter field -- unchecked save stores the explicit 'off'.
-        off="off",
         # Registry default 'on': an absent key means the feature is ON.
         absent="on",
     ),
@@ -208,7 +205,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="pfb_dnsbl",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl",
         # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
-        off="off",
     ),
     ToggleFlow(
         name="dnsbl_tld_wildcard",
@@ -222,7 +218,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="pfb_hsts",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts",
         # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
-        off="off",
         # Registry default 'on' since issue #1907: an absent key means the feature is ON.
         absent="on",
     ),
@@ -250,7 +245,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="pfb_cache",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache",
         # issue #1907: toggle-adapter field -- unchecked save stores the explicit 'off'.
-        off="off",
         # Registry default 'on': an absent key means the feature is ON.
         absent="on",
     ),
@@ -260,7 +254,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="pfb_cache_flush",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush",
         # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
-        off="off",
     ),
     ToggleFlow(
         name="dnsbl_py_nolog",
@@ -277,7 +270,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="pfb_idn_block_malicious",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_block_malicious",
         # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
-        off="off",
         # Registry default 'on': an absent key means the feature is ON.
         absent="on",
     ),
@@ -287,7 +279,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="pfb_idn_escalate_suspicious",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_escalate_suspicious",
         # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
-        off="off",
     ),
     # issue #381: opt out of automatic DNSBL NAT-rule creation (default '' = NAT on).
     # The form POST exercises the new save handler; config.xml is the oracle.
@@ -297,7 +288,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="pfb_dnsbl_nonat",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat",
         # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
-        off="off",
     ),
     # ---- Reputation settings (installedpackages/pfblockerngreputation/config/0) -
     # issue #1896: enable_dedup ("dMAX") joined the toggle-adapter registry
@@ -312,7 +302,6 @@ FLOWS: tuple[ToggleFlow, ...] = (
         field="enable_dedup",
         config_path="installedpackages/pfblockerngreputation/config/0/enable_dedup",
         # issue #1896: toggle-adapter field — unchecked save stores the explicit 'off'.
-        off="off",
     ),
 )
 

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -39,7 +39,8 @@ import pytest
 
 from .. import helpers
 from .render_oracle import PhpErrorLogGuard
-from .webui import looks_like_login_page
+from .test_render_smoke import software_panel_forced
+from .webui import looks_like_login_page, scrape_form_fields
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -359,11 +360,14 @@ def test_toggle_flow_changes_effective_config(
     final restore leaves the box clean for Tier A / the sibling flows on the
     session VM. The oracle is config.xml read over SSH, never the POST response.
     """
-    # Resolve absence to registered behavior, plus accepted unchecked read
-    # representations to canonical empty Off, so restoration tests the writer.
-    stored_original = helpers.config_get(smoke_vm, flow.config_path)
+    # Capture exact presence/raw state. Effective state resolves absent to the
+    # registered default, while an explicit empty token remains Off.
+    original_state = helpers.config_get_state(smoke_vm, flow.config_path)
+    stored_original = original_state[1]
     original = (
-        flow.off if stored_original.casefold() in {"off", "disabled"} else stored_original or flow.absent or flow.off
+        flow.absent
+        if not original_state[0]
+        else (flow.off if stored_original.casefold() in {"", "off", "disabled"} else stored_original)
     )
     # The toggle's "other" value -- we drive AWAY from original, then BACK.
     flipped = flow.off if original == flow.on else flow.on
@@ -377,15 +381,53 @@ def test_toggle_flow_changes_effective_config(
         # 2) Flip via the form; assert config.xml moved to the flipped value.
         _set_and_confirm(webui, smoke_vm, flow, flipped)
         # 3) Flip back via the form; assert config.xml returned to the original
-        #    (the reverse transition -- proves the change is the POST's doing).
+        #    effective state (the reverse transition -- proves the change is the POST's doing).
         _set_and_confirm(webui, smoke_vm, flow, original)
+        # A POST cannot recreate an originally absent key; restore exact raw
+        # presence after the transition and assert the snapshot is byte-identical.
+        helpers.config_restore_state(smoke_vm, flow.config_path, original_state)
+        assert helpers.config_get_state(smoke_vm, flow.config_path) == original_state
     finally:
         # Belt-and-suspenders: if an assertion above aborted mid-flip, force the
         # box back to its original value so a failure here can't poison Tier A or
         # the next flow on the session-scoped VM.
-        if helpers.config_get(smoke_vm, flow.config_path) != original:
-            overrides = {flow.field: flow.on} if original == flow.on else {flow.field: flow.post_off}
-            webui.post(flow.page, overrides, timeout=flow.post_timeout)
+        if helpers.config_get_state(smoke_vm, flow.config_path) != original_state:
+            helpers.config_restore_state(smoke_vm, flow.config_path, original_state)
+
+
+def test_software_page_toggle_post_roundtrip(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Software-page checkbox stores checked ``on`` and unchecked ``''`` tokens."""
+    flow = ToggleFlow(
+        name="software_update_check",
+        page="/pfblockerng/pfblockerng_software.php",
+        field="pfb_software_check",
+        config_path="installedpackages/pfblockerng/config/0/pfb_software_check",
+        absent="on",
+    )
+    original_state = helpers.config_get_state(smoke_vm, flow.config_path)
+    original = flow.absent if not original_state[0] else (flow.off if original_state[1] != flow.on else flow.on)
+    flipped = flow.off if original == flow.on else flow.on
+    try:
+        with software_panel_forced(smoke_vm, "on"):
+            page = webui.get(flow.page)
+            assert "pfb-software-panel" in page.text, "Software panel override must expose reachable POST form"
+            assert scrape_form_fields(page.text).get(flow.field) == ("on" if original == flow.on else None)
+            _set_and_confirm(webui, smoke_vm, flow, flipped)
+            page = webui.get(flow.page)
+            assert "pfb-software-panel" in page.text
+            assert scrape_form_fields(page.text).get(flow.field) == ("on" if flipped == flow.on else None)
+            _set_and_confirm(webui, smoke_vm, flow, original)
+            page = webui.get(flow.page)
+            assert "pfb-software-panel" in page.text
+            assert scrape_form_fields(page.text).get(flow.field) == ("on" if original == flow.on else None)
+        helpers.config_restore_state(smoke_vm, flow.config_path, original_state)
+        assert helpers.config_get_state(smoke_vm, flow.config_path) == original_state
+    finally:
+        if helpers.config_get_state(smoke_vm, flow.config_path) != original_state:
+            helpers.config_restore_state(smoke_vm, flow.config_path, original_state)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -414,15 +414,15 @@ def test_software_page_toggle_post_roundtrip(
         with software_panel_forced(smoke_vm, "on"):
             page = webui.get(flow.page)
             assert "pfb-software-panel" in page.text, "Software panel override must expose reachable POST form"
-            assert scrape_form_fields(page.text).get(flow.field) == ("on" if original == flow.on else None)
+            assert (flow.field in scrape_form_fields(page.text)) is (original == flow.on)
             _set_and_confirm(webui, smoke_vm, flow, flipped)
             page = webui.get(flow.page)
             assert "pfb-software-panel" in page.text
-            assert scrape_form_fields(page.text).get(flow.field) == ("on" if flipped == flow.on else None)
+            assert (flow.field in scrape_form_fields(page.text)) is (flipped == flow.on)
             _set_and_confirm(webui, smoke_vm, flow, original)
             page = webui.get(flow.page)
             assert "pfb-software-panel" in page.text
-            assert scrape_form_fields(page.text).get(flow.field) == ("on" if original == flow.on else None)
+            assert (flow.field in scrape_form_fields(page.text)) is (original == flow.on)
         helpers.config_restore_state(smoke_vm, flow.config_path, original_state)
         assert helpers.config_get_state(smoke_vm, flow.config_path) == original_state
     finally:

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -125,16 +125,14 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page=GENERAL_PAGE,
         field="enable_cb",
         config_path="installedpackages/pfblockerng/config/0/enable_cb",
-        # issue #1887: enable_cb carries the toggle adapter, so the save's
-        # writeSection ride canonicalises an unchecked '' to the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
     ),
     ToggleFlow(
         name="general_keep_settings",
         page=GENERAL_PAGE,
         field="pfb_keep",
         config_path="installedpackages/pfblockerng/config/0/pfb_keep",
-        # issue #484: the General save stores an explicit 'off' for an unchecked
-        # pfb_keep (not '') so a default-on flag can persist a deliberate off.
+        # A present empty token preserves a deliberate Off.
         # Registry default 'on': an absent key means the feature is ON.
         absent="on",
     ),
@@ -160,7 +158,7 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page=IP_PAGE,
         field="suppression",
         config_path="installedpackages/pfblockerngipsettings/config/0/suppression",
-        # issue #1907: toggle-adapter field -- unchecked save stores the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
         # Registry default 'on': an absent key means the feature is ON.
         absent="on",
     ),
@@ -204,7 +202,7 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page="/pfblockerng/pfblockerng_dnsbl.php",
         field="pfb_dnsbl",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl",
-        # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
     ),
     ToggleFlow(
         name="dnsbl_tld_wildcard",
@@ -217,7 +215,7 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page="/pfblockerng/pfblockerng_dnsbl.php",
         field="pfb_hsts",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_hsts",
-        # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
         # Registry default 'on' since issue #1907: an absent key means the feature is ON.
         absent="on",
     ),
@@ -244,7 +242,7 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page="/pfblockerng/pfblockerng_dnsbl.php",
         field="pfb_cache",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache",
-        # issue #1907: toggle-adapter field -- unchecked save stores the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
         # Registry default 'on': an absent key means the feature is ON.
         absent="on",
     ),
@@ -253,7 +251,7 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page="/pfblockerng/pfblockerng_dnsbl.php",
         field="pfb_cache_flush",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache_flush",
-        # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
     ),
     ToggleFlow(
         name="dnsbl_py_nolog",
@@ -269,7 +267,7 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page="/pfblockerng/pfblockerng_dnsbl.php",
         field="pfb_idn_block_malicious",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_block_malicious",
-        # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
         # Registry default 'on': an absent key means the feature is ON.
         absent="on",
     ),
@@ -278,7 +276,7 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page="/pfblockerng/pfblockerng_dnsbl.php",
         field="pfb_idn_escalate_suspicious",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_escalate_suspicious",
-        # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
     ),
     # issue #381: opt out of automatic DNSBL NAT-rule creation (default '' = NAT on).
     # The form POST exercises the new save handler; config.xml is the oracle.
@@ -287,7 +285,7 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page="/pfblockerng/pfblockerng_dnsbl.php",
         field="pfb_dnsbl_nonat",
         config_path="installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat",
-        # issue #1887: toggle-adapter field — unchecked save stores the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
     ),
     # ---- Reputation settings (installedpackages/pfblockerngreputation/config/0) -
     # issue #1896: enable_dedup ("dMAX") joined the toggle-adapter registry
@@ -301,7 +299,7 @@ FLOWS: tuple[ToggleFlow, ...] = (
         page="/pfblockerng/pfblockerng_reputation.php",
         field="enable_dedup",
         config_path="installedpackages/pfblockerngreputation/config/0/enable_dedup",
-        # issue #1896: toggle-adapter field — unchecked save stores the explicit 'off'.
+        # Adapter-backed unchecked saves use the canonical empty Off token.
     ),
 )
 
@@ -456,10 +454,10 @@ def test_dnsbl_idn_mode_select_round_trips_all_modes(
 ) -> None:
     """The 'IDN Blocking' select (``pfb_idn``) round-trips all three modes via config.xml.
 
-    Off (``'off'``) / Confusable (``'confusable'``) / Always (``'on'``) are the options
+    Off (``'off'``) / Confusable (``'confusable'``) / Always (``'on'``) are the form options
     (ADR-08 reuses the legacy ``'on'`` token to back the "Always"/block-all-IDN mode, so it
-    round-trips with no migration); the save stores the posted token verbatim for each
-    (off->off, confusable->confusable, on->on). The 4.0.0-alpha ``'all'`` token no longer
+    round-trips with no migration); storage canonicalises Off to ``''`` while preserving
+    Confusable and Always. The 4.0.0-alpha ``'all'`` token no longer
     exists. Drives EACH mode and asserts the effective config node (branch coverage: every
     selectable value, not just one), restoring the original at the end. The DNSBL save only
     write_config()s (config.xml is the oracle) and needs the sinkhole VIP -- supplied by
@@ -469,9 +467,9 @@ def test_dnsbl_idn_mode_select_round_trips_all_modes(
     cfg = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn"
     original = helpers.config_get(smoke_vm, cfg)
     try:
-        for mode in ("confusable", "on", "off"):
-            got = _post_and_get(webui, smoke_vm, page, {"pfb_idn": mode}, cfg)
-            assert got == mode, f"pfb_idn select: POSTing {mode!r} stored {got!r} (expected {mode!r})"
+        for posted, expected in (("confusable", "confusable"), ("on", "on"), ("off", "")):
+            got = _post_and_get(webui, smoke_vm, page, {"pfb_idn": posted}, cfg)
+            assert got == expected, f"pfb_idn select: POSTing {posted!r} stored {got!r} (expected {expected!r})"
     finally:
         # Restore the original; fall back to 'off' since the save validator rejects an
         # empty/absent value (only off/confusable/on are accepted), leaving the box clean.

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -359,12 +359,12 @@ def test_toggle_flow_changes_effective_config(
     final restore leaves the box clean for Tier A / the sibling flows on the
     session VM. The oracle is config.xml read over SSH, never the POST response.
     """
-    # An absent key reads as '' over the raw config path; resolve it to the token the
-    # absent state is behaviourally equivalent to (flow.absent — the registry default for
-    # adapter'd fields, issue #1887; flow.off otherwise), so the restore drives the box
-    # back to its EFFECTIVE original state instead of pinning an explicit Off onto a
-    # default-on field that was merely unconfigured.
-    original = helpers.config_get(smoke_vm, flow.config_path) or flow.absent or flow.off
+    # Resolve absence to registered behavior, plus accepted unchecked read
+    # representations to canonical empty Off, so restoration tests the writer.
+    stored_original = helpers.config_get(smoke_vm, flow.config_path)
+    original = (
+        flow.off if stored_original.casefold() in {"off", "disabled"} else stored_original or flow.absent or flow.off
+    )
     # The toggle's "other" value -- we drive AWAY from original, then BACK.
     flipped = flow.off if original == flow.on else flow.on
 

--- a/tests/smoke/ui/test_general_scoped_operator.py
+++ b/tests/smoke/ui/test_general_scoped_operator.py
@@ -163,7 +163,7 @@ require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');
 $defined = function_exists('isAllowedPage') ? 'YES' : 'NO';
 echo "PFB1904:ISALLOWEDPAGE_DEFINED:{$defined}\\n";
 
-$before = (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_keep', '');
+$before = config_get_path('installedpackages/pfblockerng/config/0/pfb_keep', NULL);
 
 $caught = 'NO_EXCEPTION';
 try {
@@ -175,7 +175,7 @@ try {
 }
 echo "PFB1904:WRITE_CAUGHT:{$caught}\\n";
 
-$afterWrite = (string) config_get_path('installedpackages/pfblockerng/config/0/pfb_keep', '');
+$afterWrite = config_get_path('installedpackages/pfblockerng/config/0/pfb_keep', NULL);
 echo 'PFB1904:AFTER_WRITE_UNCHANGED:' . (($afterWrite === $before) ? 'YES' : 'NO') . "\\n";
 
 PfbConfig::writeSystem('gen/pfb_keep', 'off');
@@ -331,7 +331,7 @@ def test_scoped_operator_general_save_pass_through_and_software_refused(
     username = f"pfbop{uuid.uuid4().hex[:10]}"
     password = uuid.uuid4().hex
 
-    orig_software_check = helpers.config_get(vm, SOFTWARE_CHECK_CFG)
+    orig_software_state = helpers.config_get_state(vm, SOFTWARE_CHECK_CFG)
     orig_interval = helpers.config_get(vm, INTERVAL_CFG)
     orig_nextuid = helpers.config_get(vm, "system/nextuid")
 
@@ -414,7 +414,7 @@ def test_scoped_operator_general_save_pass_through_and_software_refused(
     finally:
         # Field restores run BEFORE the user delete: a raised delete must never skip
         # putting the box's config back the way it was.
-        _set_config_value(vm, SOFTWARE_CHECK_CFG, orig_software_check)
+        helpers.config_restore_state(vm, SOFTWARE_CHECK_CFG, orig_software_state)
         _set_config_value(vm, INTERVAL_CFG, orig_interval)
         if user_created:
             _delete_scoped_user(vm, username, orig_nextuid)
@@ -455,7 +455,7 @@ def test_cli_gateway_write_fails_closed_writesystem_succeeds(
         and the sentinel is never reached / the snippet aborts.
     """
     vm = smoke_vm
-    orig = helpers.config_get(vm, PFB_KEEP_CFG)
+    orig_state = helpers.config_get_state(vm, PFB_KEEP_CFG)
     try:
         result = helpers.php_eval(vm, _CLI_GATEWAY_PHP, timeout=90.0)
         assert result.returncode == 0, (
@@ -482,12 +482,9 @@ def test_cli_gateway_write_fails_closed_writesystem_succeeds(
         stored = _extract_sentinel(out, "PFB1904:WRITESYSTEM_STORED:")
         assert stored == "", f"PfbConfig::writeSystem() did not persist canonical empty storage: {stored!r}"
 
-        # Confirms the in-snippet writeSystem() restore call itself did not throw
-        # (its exact resulting stored token is not asserted -- notConfigured()
-        # canonicalises an originally-absent value to the registered default,
-        # which is a correct, if not byte-identical, restoration).
+        # Confirms writeSystem() restored the exact pre-test value, including absence.
         _extract_sentinel(out, "PFB1904:RESTORED:")
     finally:
         # Safety net: guarantee pfb_keep is back to its pre-test raw value even if
         # the snippet above raised before reaching its own writeSystem() restore.
-        _set_config_value(vm, PFB_KEEP_CFG, orig)
+        helpers.config_restore_state(vm, PFB_KEEP_CFG, orig_state)

--- a/tests/smoke/ui/test_general_scoped_operator.py
+++ b/tests/smoke/ui/test_general_scoped_operator.py
@@ -461,7 +461,7 @@ def test_cli_gateway_write_fails_closed_writesystem_succeeds(
         BEFORE the privilege check (reordering ``writeRaw()`` ahead of
         ``assertWriteAllowed()``) flips this to ``'NO'`` even though the
         exception still fires.
-      * ``WRITESYSTEM_STORED == 'off'`` -- a regression that made
+      * ``WRITESYSTEM_STORED == ''`` -- a regression that made
         ``writeSystem()`` ALSO gate on ``isAllowedPage()`` (collapsing the
         escape hatch into ``write()``) makes this call throw instead of storing,
         and the sentinel is never reached / the snippet aborts.
@@ -492,7 +492,7 @@ def test_cli_gateway_write_fails_closed_writesystem_succeeds(
         assert unchanged == "YES", "PfbConfig::write() mutated pfb_keep despite throwing RuntimeException"
 
         stored = _extract_sentinel(out, "PFB1904:WRITESYSTEM_STORED:")
-        assert stored == "off", f"PfbConfig::writeSystem() did not persist the canonical 'off' token: {stored!r}"
+        assert stored == "", f"PfbConfig::writeSystem() did not persist canonical empty storage: {stored!r}"
 
         # Confirms the in-snippet writeSystem() restore call itself did not throw
         # (its exact resulting stored token is not asserted -- notConfigured()

--- a/tests/smoke/ui/test_general_scoped_operator.py
+++ b/tests/smoke/ui/test_general_scoped_operator.py
@@ -277,7 +277,7 @@ def test_scoped_operator_general_save_pass_through_and_software_refused(
     ``pfb_software_check`` sits at a seeded non-default value.
 
       Given a webConfigurator user holding ONLY ``page-firewall-pfblockerng`` (no
-        Package Manager privilege), and ``pfb_software_check`` stored as ``'off'``
+        Package Manager privilege), and ``pfb_software_check`` stored as legacy ``'off'``
         (the pass-through cell; non-default so a "reset to default" bug would also
         be visible),
 
@@ -287,7 +287,7 @@ def test_scoped_operator_general_save_pass_through_and_software_refused(
 
       Then the save succeeds (200, still authenticated, no new gated PHP
         diagnostic), the changed field persists, and ``pfb_software_check`` is
-        STILL ``'off'`` -- the delta-aware pass-through carve-out treated the
+        canonical ``''`` -- the delta-aware pass-through carve-out treated the
         unchanged field as a non-event rather than asserting a privilege this
         operator does not hold.
 
@@ -316,14 +316,9 @@ def test_scoped_operator_general_save_pass_through_and_software_refused(
       * ``pfb_interval`` persisted -- a regression that made the save silently
         no-op (e.g. an over-broad early return) leaves the stored value at its
         PRE-save baseline -> the equality assertion fails.
-      * ``pfb_software_check`` still ``'off'`` -- a regression that dropped the
-        delta-aware carve-out entirely (reverting to writeSection() unconditionally
-        re-persisting every registered field through its adapter) would still
-        store ``'off'`` byte-identically in THIS case (no accidental value change),
-        so this assertion alone does not catch that regression -- it is the
-        status/session assertions above that do; this assertion instead catches a
-        regression that makes the pass-through cell get OVERWRITTEN with some
-        other value (e.g. a stray default-coercion bug).
+      * ``pfb_software_check`` canonicalised to ``''`` -- the legacy read-only
+        ``'off'`` seed must become canonical empty storage without requiring that
+        field's separate privilege because both tokens represent the same Off value.
       * PhpErrorLogGuard -- a regression that let an uncaught exception reach the
         page (rather than a clean redirect) logs a PHP Fatal/Uncaught line ->
         ``assert_no_growth()`` fails.
@@ -388,9 +383,9 @@ def test_scoped_operator_general_save_pass_through_and_software_refused(
         assert helpers.config_get(vm, INTERVAL_CFG) == new_interval, (
             "the scoped operator's save of the UNRELATED pfb_interval field did not persist"
         )
-        assert helpers.config_get(vm, SOFTWARE_CHECK_CFG) == "off", (
-            "pfb_software_check changed as a side effect of an unrelated General save -- the "
-            "writeSection() delta-aware pass-through carve-out (issue #1895 addendum) regressed"
+        assert helpers.config_get(vm, SOFTWARE_CHECK_CFG) == "", (
+            "pfb_software_check did not canonicalise legacy 'off' during an unrelated General save -- "
+            "the writeSection() adapter round-trip or delta-aware privilege carve-out regressed"
         )
 
         # Companion: force the page's FIRST (provenance) gate open so its SECOND
@@ -446,7 +441,7 @@ def test_cli_gateway_write_fails_closed_writesystem_succeeds(
       Then it throws ``RuntimeException`` (fail-closed) and the stored value is
         UNCHANGED; and ``PfbConfig::writeSystem('gen/pfb_keep', 'off')`` -- the
         explicit system-caller escape hatch -- succeeds and persists the
-        canonical ``'off'`` token.
+        canonical empty token.
 
     Failability:
       * ``ISALLOWEDPAGE_DEFINED`` -- documents which CAUTION arm this box hits;

--- a/tests/smoke/ui/test_general_scoped_operator.py
+++ b/tests/smoke/ui/test_general_scoped_operator.py
@@ -316,9 +316,6 @@ def test_scoped_operator_general_save_pass_through_and_software_refused(
       * ``pfb_interval`` persisted -- a regression that made the save silently
         no-op (e.g. an over-broad early return) leaves the stored value at its
         PRE-save baseline -> the equality assertion fails.
-      * ``pfb_software_check`` canonicalised to ``''`` -- the legacy read-only
-        ``'off'`` seed must become canonical empty storage without requiring that
-        field's separate privilege because both tokens represent the same Off value.
       * PhpErrorLogGuard -- a regression that let an uncaught exception reach the
         page (rather than a clean redirect) logs a PHP Fatal/Uncaught line ->
         ``assert_no_growth()`` fails.
@@ -452,10 +449,6 @@ def test_cli_gateway_write_fails_closed_writesystem_succeeds(
         ``assertWriteAllowed()`` pass when ``isAllowedPage`` is undefined (e.g.
         inverting the ``!function_exists(...) || !isAllowedPage(...)`` guard)
         flips this to ``'NO_EXCEPTION'``.
-      * ``AFTER_WRITE_UNCHANGED == 'YES'`` -- a regression that mutated config
-        BEFORE the privilege check (reordering ``writeRaw()`` ahead of
-        ``assertWriteAllowed()``) flips this to ``'NO'`` even though the
-        exception still fires.
       * ``WRITESYSTEM_STORED == ''`` -- a regression that made
         ``writeSystem()`` ALSO gate on ``isAllowedPage()`` (collapsing the
         escape hatch into ``write()``) makes this call throw instead of storing,

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1790,9 +1790,7 @@ def test_dnsbl_cache_flush_option_renders(webui: WebUI, php_error_log_guard: Php
 # issue #1907: dnsbl/pfb_cache, dnsbl/pfb_py_reply, dnsbl/pfb_hsts (DNSBL page) and
 # ip/suppression (IP page) flipped their registry default to 'on' -- the checkbox must
 # render CHECKED with no stored config, and still render UNCHECKED for a present Off token
-# (RegistryPassTest/CfgGatewayTest/PfbGlobalParityTest cover the gateway-level contract
-# off-box; this is the reachable Tier-A UI proof of the same
-# contract per testing.md #4).
+# for both canonical empty and legacy ``off`` storage.
 _ISSUE1907_DNSBL_TOGGLES = (
     ("pfb_cache", "installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache"),
     ("pfb_py_reply", "installedpackages/pfblockerngdnsblsettings/config/0/pfb_py_reply"),
@@ -1854,25 +1852,25 @@ def test_dnsbl_python_gated_toggles_render_checked_when_absent(
 def test_dnsbl_python_gated_toggles_render_unchecked_when_stored_off(
     smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:
-    """The polarity pair: a stored 'off' still renders unchecked -- the default-on flip
-    did not also wire the checkboxes to always render checked."""
+    """Legacy ``off`` and canonical empty Off tokens both render unchecked."""
     vm = smoke_vm
     priors = {
         path: helpers.config_get(vm, path) if _config_path_exists(vm, path) else None
         for _name, path in _ISSUE1907_DNSBL_TOGGLES
     }
-    for _name, path in _ISSUE1907_DNSBL_TOGGLES:
-        _set_scalar_or_absent(vm, path, "off")
     try:
-        page = "/pfblockerng/pfblockerng_dnsbl.php"
-        resp = webui.get(page)
-        result = evaluate_render(page, resp.status_code, resp.text, ("DNSBL Configuration",))
-        assert result.ok, f"DNSBL render oracle failed: {result.detail}"
-        fields = scrape_form_fields(resp.text)
-        for name, _path in _ISSUE1907_DNSBL_TOGGLES:
-            assert name not in fields, (
-                f"{name} must render UNCHECKED when stored 'off', got checked with value {fields.get(name)!r}"
-            )
+        for stored in ("off", ""):
+            for _name, path in _ISSUE1907_DNSBL_TOGGLES:
+                _set_scalar_or_absent(vm, path, stored)
+            page = "/pfblockerng/pfblockerng_dnsbl.php"
+            resp = webui.get(page)
+            result = evaluate_render(page, resp.status_code, resp.text, ("DNSBL Configuration",))
+            assert result.ok, f"DNSBL render oracle failed for {stored!r}: {result.detail}"
+            fields = scrape_form_fields(resp.text)
+            for name, _path in _ISSUE1907_DNSBL_TOGGLES:
+                assert name not in fields, (
+                    f"{name} must render UNCHECKED when stored {stored!r}, got checked with value {fields.get(name)!r}"
+                )
     finally:
         for _name, path in _ISSUE1907_DNSBL_TOGGLES:
             _set_scalar_or_absent(vm, path, priors[path])

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1789,9 +1789,9 @@ def test_dnsbl_cache_flush_option_renders(webui: WebUI, php_error_log_guard: Php
 
 # issue #1907: dnsbl/pfb_cache, dnsbl/pfb_py_reply, dnsbl/pfb_hsts (DNSBL page) and
 # ip/suppression (IP page) flipped their registry default to 'on' -- the checkbox must
-# render CHECKED with no stored config, and still render UNCHECKED once a save stores
-# the explicit 'off' token (RegistryPassTest/CfgGatewayTest/PfbGlobalParityTest cover the
-# gateway-level contract off-box; this is the reachable Tier-A UI proof of the same
+# render CHECKED with no stored config, and still render UNCHECKED for a present Off token
+# (RegistryPassTest/CfgGatewayTest/PfbGlobalParityTest cover the gateway-level contract
+# off-box; this is the reachable Tier-A UI proof of the same
 # contract per testing.md #4).
 _ISSUE1907_DNSBL_TOGGLES = (
     ("pfb_cache", "installedpackages/pfblockerngdnsblsettings/config/0/pfb_cache"),

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1899,22 +1899,24 @@ def test_ip_suppression_renders_checked_when_absent(
         _set_scalar_or_absent(vm, path, prior)
 
 
-def test_ip_suppression_renders_unchecked_when_stored_off(
+def test_ip_suppression_renders_unchecked_for_empty_and_legacy_off(
     smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:
-    """The polarity pair: a stored 'off' still renders unchecked."""
+    """Canonical empty and legacy ``off`` suppression tokens render unchecked."""
     vm = smoke_vm
     path = _ISSUE1907_IP_SUPPRESSION_PATH
     prior = helpers.config_get(vm, path) if _config_path_exists(vm, path) else None
-    _set_scalar_or_absent(vm, path, "off")
     try:
-        resp = webui.get(_IP_PAGE)
-        result = evaluate_render(_IP_PAGE, resp.status_code, resp.text, ("IP Configuration",))
-        assert result.ok, f"IP render oracle failed: {result.detail}"
-        fields = scrape_form_fields(resp.text)
-        assert "suppression" not in fields, (
-            f"suppression must render UNCHECKED when stored 'off', got checked with value {fields.get('suppression')!r}"
-        )
+        for stored in ("", "off"):
+            _set_scalar_or_absent(vm, path, stored)
+            resp = webui.get(_IP_PAGE)
+            result = evaluate_render(_IP_PAGE, resp.status_code, resp.text, ("IP Configuration",))
+            assert result.ok, f"IP render oracle failed for {stored!r}: {result.detail}"
+            fields = scrape_form_fields(resp.text)
+            assert "suppression" not in fields, (
+                f"suppression must render UNCHECKED when stored {stored!r}, "
+                f"got checked with value {fields.get('suppression')!r}"
+            )
     finally:
         _set_scalar_or_absent(vm, path, prior)
 

--- a/tests/test_adr28_cfg_adapters.py
+++ b/tests/test_adr28_cfg_adapters.py
@@ -38,6 +38,8 @@ Scenario D — IdnMode enum invariants.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 # conftest.py adds src/usr/local/pkg/pfblockerng to sys.path and injects
@@ -83,12 +85,24 @@ def _boundary(ini_value: str | None, python_idn: bool) -> IdnMode:
     """
     if ini_value is not None:
         raw = ini_value.strip().lower()
+        if raw == "":
+            return IdnMode.Off
         if raw in (IDN_MODE_OFF, IDN_MODE_ALL, IDN_MODE_CONFUSABLE):
             return IdnMode(raw)
         # Unrecognised string -> legacy fallback.
         return idn_mode_from_legacy(python_idn)
     # Key absent -> legacy fallback.
     return idn_mode_from_legacy(python_idn)
+
+
+def test_present_empty_idn_mode_is_explicit_off() -> None:
+    # Present idn_mode='' is the PHP gateway's empty Off token; it must not
+    # fall back to python_idn as an absent key does.
+    assert _boundary("", True) is IdnMode.Off
+    assert _boundary("", False) is IdnMode.Off
+
+    source = Path(__file__).parents[1].joinpath("src/usr/local/pkg/pfblockerng/pfb_unbound.py")
+    assert 'if _raw_idn == "":' in source.read_text()
 
 
 # ===========================================================================
@@ -163,7 +177,7 @@ class TestIdnModeDecisionEnum:
 # Scenario C — boundary truth-table (12 combinations)
 # ===========================================================================
 #
-# 6 ini values × 2 python_idn values = 12 combinations.
+# 7 ini values × 2 python_idn values = 14 combinations.
 # For each, assert:
 #   1. The BEFORE-state (what the pre-adoption code produced — a string).
 #   2. The AFTER-state (what the adopted boundary produces — an IdnMode).
@@ -173,7 +187,7 @@ class TestIdnModeDecisionEnum:
 #   canonical ini -> store that string;  unrecognised/absent -> IDN_MODE_ALL if python_idn else IDN_MODE_OFF.
 #
 # Post-adoption logic (enums):
-#   canonical ini -> IdnMode(raw);  unrecognised/absent -> idn_mode_from_legacy(python_idn).
+#   canonical ini -> IdnMode(raw);  present empty -> Off; unrecognised/absent -> legacy fallback.
 #   IdnMode.value == the canonical string -> byte-identical.
 #
 # The 12 combos below are (ini_value, python_idn) -> expected_mode.
@@ -195,8 +209,8 @@ _TRUTH_TABLE: list[tuple[str | None, bool, IdnMode, str]] = [
     ("all", False, IdnMode.Off, IDN_MODE_OFF),
     ("bogus", True, IdnMode.All, IDN_MODE_ALL),
     ("bogus", False, IdnMode.Off, IDN_MODE_OFF),
-    # Empty string -> treated as unrecognised (not in canonical set) -> legacy fallback.
-    ("", True, IdnMode.All, IDN_MODE_ALL),
+    # Present empty string -> explicit Off, independent of python_idn.
+    ("", True, IdnMode.Off, IDN_MODE_OFF),
     ("", False, IdnMode.Off, IDN_MODE_OFF),
     # Absent key (None) -> legacy fallback.
     (None, True, IdnMode.All, IDN_MODE_ALL),

--- a/tests/test_adr28_cfg_adapters.py
+++ b/tests/test_adr28_cfg_adapters.py
@@ -4,11 +4,13 @@ Pins the ACTUAL adoption contract after the dead pfb_cfg_* helpers were removed
 and the IdnMode enum is now the live in-memory representation for idn_mode.
 
 Policy (ADR-28 §2.2):
-  - The ini wire value stays the canonical string ('off'/'all'/'confusable').
+  - The ini wire value stays the recognised string ('off'/'on'/'confusable');
+    present empty is an explicit Off token at this boundary.
   - The in-memory value is IdnMode (converted at the read boundary).
   - Unrecognised / absent ini key falls back to idn_mode_from_legacy(python_idn)
     (NOT pfb_cfg_idn_mode_read semantics — the legacy fallback preserves python_idn).
-  - Round-trip: IdnMode backing value == the canonical stored string.
+  - IdnMode backing values remain the existing internal tokens; the PHP adapter owns
+    canonical empty Off storage.
 
 Scenario A — idn_mode_from_legacy: bool -> IdnMode migration.
   Background: the legacy python_idn on/off toggle maps to All or Off.
@@ -22,25 +24,27 @@ Scenario B — idn_mode_decision: the All-IDN gate (pure unit).
     When idn_mode_decision(q, mode) is called.
     Then True IFF mode is All AND the name has an xn-- label.
 
-Scenario C — boundary truth-table: 12 combinations of ini value x python_idn.
+Scenario C — boundary truth-table: 14 combinations of ini value x python_idn.
   Background: the ini_read boundary in pfb_global converts raw string -> IdnMode,
     with a legacy fallback when the key is absent or unrecognised.
-    Given idn_mode ini value in {'off','all','confusable','bogus','',ABSENT}
+    Given idn_mode ini value in {'off','on','confusable','all','bogus','',ABSENT}
     And python_idn in {True, False}.
     When the boundary logic (as in pfb_global) is applied.
-    Then the resulting IdnMode is byte-identical to the pre-adoption behaviour.
-    And the before-state (prior to adoption) is asserted explicitly per combination.
+    Then the resulting IdnMode and backing token match the production read boundary.
 
 Scenario D — IdnMode enum invariants.
-  Round-trip: IdnMode.value == the canonical ini string for each member.
+  IdnMode.value retains the enum's internal token for each member.
   default() == Off.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import Any
 
 import pytest
+import unboundmodule
+
+import pfb_unbound
 
 # conftest.py adds src/usr/local/pkg/pfblockerng to sys.path and injects
 # Unbound globals onto builtins — mirror the pattern from test_adr06_build_module.py.
@@ -71,38 +75,30 @@ _NON_IDN_QUERIES = (
 
 
 # ---------------------------------------------------------------------------
-# Helper: replicate the ini read-boundary logic from pfb_global() exactly
-# (lines 1095-1102 of pfb_unbound.py) so the truth-table test is a genuine
-# re-implementation, not just calling the function under test.
+# Helper: drive the actual init_standard() MAIN-section reader so the truth-table
+# test exercises the production boundary rather than a copied implementation.
 # ---------------------------------------------------------------------------
 
 
-def _boundary(ini_value: str | None, python_idn: bool) -> IdnMode:
-    """Replicate the pfb_global ini read-boundary for idn_mode.
-
-    ini_value=None means the key is absent from the ini.
-    Returned value must be byte-identical to what pfb_global sets in pfb["idn_mode"].
-    """
+def _production_boundary(tmp_path: Any, monkeypatch: Any, ini_value: str | None, python_idn: bool) -> IdnMode:
+    lines = ["[MAIN]", "python_enable = false", f"python_idn = {'true' if python_idn else 'false'}"]
     if ini_value is not None:
-        raw = ini_value.strip().lower()
-        if raw == "":
-            return IdnMode.Off
-        if raw in (IDN_MODE_OFF, IDN_MODE_ALL, IDN_MODE_CONFUSABLE):
-            return IdnMode(raw)
-        # Unrecognised string -> legacy fallback.
-        return idn_mode_from_legacy(python_idn)
-    # Key absent -> legacy fallback.
-    return idn_mode_from_legacy(python_idn)
+        lines.append(f"idn_mode = {ini_value}")
+    (tmp_path / "pfb_unbound.ini").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    pfb_unbound.pfb["mod_maxminddb_e"] = "stub"
+    try:
+        assert pfb_unbound.init_standard(0, unboundmodule.module_env()) is True
+        return pfb_unbound.pfb["idn_mode"]
+    finally:
+        pfb_unbound.deinit(0)
 
 
-def test_present_empty_idn_mode_is_explicit_off() -> None:
+def test_present_empty_idn_mode_is_explicit_off(tmp_path: Any, monkeypatch: Any) -> None:
     # Present idn_mode='' is the PHP gateway's empty Off token; it must not
     # fall back to python_idn as an absent key does.
-    assert _boundary("", True) is IdnMode.Off
-    assert _boundary("", False) is IdnMode.Off
-
-    source = Path(__file__).parents[1].joinpath("src/usr/local/pkg/pfblockerng/pfb_unbound.py")
-    assert 'if _raw_idn == "":' in source.read_text()
+    assert _production_boundary(tmp_path, monkeypatch, "", True) is IdnMode.Off
+    assert _production_boundary(tmp_path, monkeypatch, "", False) is IdnMode.Off
 
 
 # ===========================================================================
@@ -174,27 +170,21 @@ class TestIdnModeDecisionEnum:
 
 
 # ===========================================================================
-# Scenario C — boundary truth-table (12 combinations)
+# Scenario C — boundary truth-table (14 combinations)
 # ===========================================================================
 #
 # 7 ini values × 2 python_idn values = 14 combinations.
 # For each, assert:
-#   1. The BEFORE-state (what the pre-adoption code produced — a string).
-#   2. The AFTER-state (what the adopted boundary produces — an IdnMode).
-#   3. That the IdnMode backing value matches the pre-adoption string (byte-identical).
+#   1. The IdnMode selected by the production boundary.
+#   2. The enum backing value used by existing runtime consumers.
 #
-# Pre-adoption logic (strings):
-#   canonical ini -> store that string;  unrecognised/absent -> IDN_MODE_ALL if python_idn else IDN_MODE_OFF.
-#
-# Post-adoption logic (enums):
+# Current boundary logic:
 #   canonical ini -> IdnMode(raw);  present empty -> Off; unrecognised/absent -> legacy fallback.
-#   IdnMode.value == the canonical string -> byte-identical.
-#
-# The 12 combos below are (ini_value, python_idn) -> expected_mode.
+#   IdnMode.value remains the existing enum's internal token.
 
 
 _TRUTH_TABLE: list[tuple[str | None, bool, IdnMode, str]] = [
-    # (ini_value, python_idn, expected_IdnMode, pre_adoption_string)
+    # (ini_value, python_idn, expected_IdnMode, expected_backing_value)
     # Canonical ini values — python_idn is IGNORED when ini is recognised.
     # 'on' (reused legacy token) is the canonical block-all value (IdnMode.All).
     ("off", True, IdnMode.Off, IDN_MODE_OFF),
@@ -218,35 +208,36 @@ _TRUTH_TABLE: list[tuple[str | None, bool, IdnMode, str]] = [
 ]
 
 
-@pytest.mark.parametrize("ini_value,python_idn,expected_mode,pre_adoption_str", _TRUTH_TABLE)
+@pytest.mark.parametrize("ini_value,python_idn,expected_mode,expected_value", _TRUTH_TABLE)
 def test_boundary_truth_table(
-    ini_value: str | None, python_idn: bool, expected_mode: IdnMode, pre_adoption_str: str
+    tmp_path: Any,
+    monkeypatch: Any,
+    ini_value: str | None,
+    python_idn: bool,
+    expected_mode: IdnMode,
+    expected_value: str,
 ) -> None:
-    """Boundary truth-table: each of the 12 (ini_value x python_idn) combos is byte-identical
-    to the pre-adoption behaviour.
+    """Boundary truth-table: all 14 ``ini_value``/``python_idn`` combinations.
 
     Given a raw ini_value and python_idn toggle.
-    When the read-boundary logic is applied.
-    Then the resulting IdnMode matches expected_mode AND its .value equals the pre-adoption string.
+    When the production read boundary runs.
+    Then the IdnMode and its existing backing value match the contract.
     """
-    # Before-state: the pre-adoption code produced a specific string for this combination.
-    # Assert it is as documented so a drift in the spec fails explicitly.
-    assert pre_adoption_str in (IDN_MODE_OFF, IDN_MODE_ALL, IDN_MODE_CONFUSABLE), (
-        f"pre_adoption_str {pre_adoption_str!r} must be one of the canonical strings"
+    assert expected_value in (IDN_MODE_OFF, IDN_MODE_ALL, IDN_MODE_CONFUSABLE), (
+        f"expected_value {expected_value!r} must be an enum backing token"
     )
 
-    # When: apply the boundary.
-    result = _boundary(ini_value, python_idn)
+    # When: execute the production init boundary.
+    result = _production_boundary(tmp_path, monkeypatch, ini_value, python_idn)
 
     # Then: the IdnMode matches the expected value.
     assert result is expected_mode, (
         f"ini={ini_value!r}, python_idn={python_idn}: expected {expected_mode}, got {result}"
     )
 
-    # And: the backing value is byte-identical to the pre-adoption string.
-    assert result.value == pre_adoption_str, (
-        f"ini={ini_value!r}, python_idn={python_idn}: "
-        f"IdnMode.value {result.value!r} != pre-adoption string {pre_adoption_str!r}"
+    # And: the backing value remains the enum's existing internal token.
+    assert result.value == expected_value, (
+        f"ini={ini_value!r}, python_idn={python_idn}: IdnMode.value {result.value!r} != expected {expected_value!r}"
     )
 
 
@@ -258,7 +249,7 @@ def test_boundary_truth_table(
 class TestIdnModeEnumInvariants:
     """IdnMode enum structural guarantees (backing value, default)."""
 
-    def test_backing_values_equal_canonical_ini_strings(self) -> None:
+    def test_backing_values_remain_internal_tokens(self) -> None:
         assert IdnMode.Off.value == IDN_MODE_OFF
         assert IdnMode.All.value == IDN_MODE_ALL
         assert IdnMode.Confusable.value == IDN_MODE_CONFUSABLE


### PR DESCRIPTION
## Summary

- Restore the owner-ruled toggle storage contract: only absence receives the registered default; present `on` is On; every other present token is Off; Off writes as an empty string.
- Apply the shared empty/absence rule to stored enums without collapsing their vocabularies. `PfbIdnMode` preserves `on`/`confusable`, maps empty and legacy `off` to Off, writes Off as empty, and retains the existing junk fallback.
- Keep plain scalars unchanged: their empty value still resolves to the registered default.
- Remove the four page-level toggle-storage helpers and the six empty-to-`off` grandfather arms while retaining `pfb_keep`'s absent-to-`on` arm.
- Update the normative forward-upgrade contract and re-pin gateway, registry, parity, and UI coverage.

## Write and boundary decisions

`PfbConfig::write($adapterKey, NULL)` deletes an existing stored key. `writeSection()` likewise omits an adapter-bearing key whose supplied value is `NULL`; absence therefore remains truthful and the registered default governs the next read. Dedicated tests cover both paths.

The shell-boundary audit found one empty-capable toggle crossing: reputation `drep` is positional argument 4 to `pfblockerng.sh`. It is now passed through `escapeshellarg()`, preserving the empty argument and every later position. The derived preprocessing/suppression selectors remain non-empty command tokens, and the existing aggregate boundary was already quoted.

Direct stored-value audit:

- `pfb_software_panel_override()`'s strict `=== 'off'` comparison is an unrelated hidden file sentinel, not configuration storage; unchanged.
- The widget's loose `widget-sortmix == 'off'` comparison is an unrelated widget preference with its own direct storage; unchanged.
- The three literal adapter-toggle writers found under `www/` (`pfb_keep`, `pfb_feed_internal_filter`, and `pfb_software_check`) now retain validated `PFB_FILTER_ON_OFF` output (`on`/empty). The IP/DNSBL/editor helper callers use the same existing filter directly; the four translation helpers are removed.

## Upgrade verdict

The 3.2/fixed-4.0 mixed-version HA round trip remains **UNPROVEN**. The required probe is two peers on exact 3.2 and fixed 4.0 packages, synchronization in both directions, followed by disabling `pfb_keep` and executing cleanup on the 3.2 peer. Source and token compatibility are not substituted for that live proof.

## Verification

- Frozen RED→GREEN proof: byte-identical matrix for all nine default-On toggles, `PfbIdnMode`, a representative plain scalar, merge/fixpoint behavior, UI wiring, and the `drep` shell position; `scripts/agent/verify-red-proof.sh` PASS.
- Exact-head `scripts/agent/run-gates.sh --diff origin/devel`: PASS, including full Python, PHPUnit, PHPStan, PHPCS, and Markdown gates.
- Raw-empty #2072 reproduction: `scripts/local-smoke.sh --marker smoke --filter recompute --no-two-vm` — 12 passed, 939 deselected (`local-100034-1785739388-9172f8e2de476720`). The devel helper already writes raw empty, so no local reversal was needed; PR #2118 was not changed.
- Tier-B functional toggle/IDN/scoped-writer matrix: 24 passed after re-pinning accepted unchecked start tokens; final focused legacy/default round trip 2 passed (`local-100033-1785741181-11361adcc15bc278`).
- Browser save/visibility coverage: 3 passed (`local-100032-1785740578-9469e434c7f76acc`).
- Final production-head focused appliance matrix: IDN mode round trip, scoped General save, CLI authorization/nullable restore, and IP suppression render for canonical empty plus legacy `off` — 4 passed, 589 deselected (`local-100032-1785746273-bce30210162011a0`). The commits after that run change comments, documentation, and test names only.
- Full Tier-A render sweep: all issue-specific rows passed, but the suite ended 188 passed, 10 failed, 1 error because the baseline widget-ledger path calls an unloaded `pfb_flock_bounded()`. Exact `devel` reproduced the same fatal; tracked separately as #2124 with no milestone.
- Independent review: initial implementation verification accepted; the full top-tier review and small-tier delta rounds rejected concrete authorization, absence-oracle, UI, assertion, and terminology gaps, all fixed. Exact final head `7030860483d147dcf6adc5527bc9d1e0ecfb712c` received small-tier ACCEPT after 283 focused tests and 2,381 assertions.

Fixes #2120

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty toggle values now consistently represent explicitly disabled settings instead of reverting to defaults.
  * IDN mode correctly treats an explicitly empty value as Off.
  * Legacy configuration values continue to resolve safely to canonical settings.
  * Configuration cleanup, persistence, and command handling now behave consistently across options.
  * Explicitly removed settings are handled correctly without affecting absent configuration.

* **Tests**
  * Expanded coverage for empty-value storage, legacy compatibility, configuration round trips, UI behavior, and shell argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
