### PR TITLE
tests: pin IDN malicious-off transport

### DIFF
--- a/tests/php/PythonTldWildcardIniEmitTest.php
+++ b/tests/php/PythonTldWildcardIniEmitTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/** The Python INI carries the configured DNSBL TLD-wildcard toggle. */
+/** The Python INI carries configured DNSBL toggles. */
 final class PythonTldWildcardIniEmitTest extends TestCase
 {
 	private string $tmp;
@@ -99,5 +99,19 @@ final class PythonTldWildcardIniEmitTest extends TestCase
 	{
 		$ini = $this->emit('on');
 		$this->assertMatchesRegularExpression('/^python_tld_wildcard\s*=\s*on$/m', $ini);
+	}
+
+	public function testStoredIdnMaliciousOffReachesPythonIni(): void
+	{
+		PfbConfig::writeSystem('dnsbl/pfb_idn', 'confusable');
+		PfbConfig::writeSystem('dnsbl/pfb_idn_block_malicious', '');
+
+		pfb_global();
+		pfb_unbound_python('enabled');
+		$ini = file_get_contents($GLOBALS['pfb']['unbound_py_conf']);
+
+		$this->assertNotFalse($ini, 'writer must create the Python INI');
+		$this->assertMatchesRegularExpression('/^idn_mode\s*=\s*confusable$/m', $ini);
+		$this->assertMatchesRegularExpression('/^python_idn_block_malicious\s*=\s*off$/m', $ini);
 	}
 }


### PR DESCRIPTION
## Summary

- Add focused config-to-Python-INI coverage for the IDN malicious-block Off path.
- Pin both `idn_mode = confusable` and `python_idn_block_malicious = off` after the public config gateway and `pfb_global()` transport.
- Complete the IDN-specific coverage after the shared empty-storage repair merged in #2125.

## Diagnosis

#2073 and #2085 are the same defect. Both use the same live case and fail before the homograph reaches the controlled upstream. A semantic bisect identified current-devel commit `bf02e361` as the first bad commit (original PR commit `24357382` in #1899). That commit made a present empty checkbox value resolve to the registered default; `pfb_idn_block_malicious` defaults On, so the generated INI incorrectly carried `python_idn_block_malicious = on`.

The Python analyzer is not the cause. Its False path still downgrades MALICIOUS from block to alert, and focused matcher coverage passes.

## Verification

- Frozen red/green proof: `FREEZE-OK`, `RED-OK` against pre-repair `dd75c81c`, `GREEN-OK` at HEAD; test hash `61631efd9fc7be5b138c3ae12e26c2edd12c0b27`.
- Focused PHPUnit: 3 tests, 7 assertions, passed.
- Focused Python matcher: 1 test passed.
- Live smoke `local-100033-1785748334-50c2c09e481a34ae` on `root@10.0.0.33`: 952 collected, 951 deselected, 1 selected; 1 passed.
- `scripts/agent/run-gates.sh --diff origin/devel`: passed vendor, PHP syntax, full PHPUnit, PHPStan, and PHPCS gates.
- Independent review: approved with no remaining findings.

Fixes #2073
Fixes #2085

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that stored IDN settings correctly generate the expected Python INI configuration.
  * Updated test documentation to reflect support for multiple Python INI DNSBL toggles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->