### PR TITLE
alerts: bound whitelist CNAME lookup

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -963,7 +963,7 @@ if (isset($_POST) && !empty($_POST)) {
 			$cname_lookup_timeout = 30;
 			$cname_lookup_kill_grace = 5;
 			$cname_lookup_file = "{$g['tmp_path']}/pfb_alerts_cname_" . getmypid() . '_' . bin2hex(random_bytes(8));
-			$cname_lookup_pipeline = "{$drill_esc} {$domain_esc} {$ext_dns} | /usr/bin/awk '/CNAME/ {sub(\"\.\$\", \"\", \$5); print \$5;}'";
+			$cname_lookup_pipeline = "{$drill_esc} {$domain_esc} {$ext_dns} | /usr/bin/awk '/CNAME/ {sub(\"[.]\$\", \"\", \$5); print \$5;}'";
 			$cname_lookup_cmd = "{$timeout_esc} -s TERM -k {$cname_lookup_kill_grace} {$cname_lookup_timeout} /bin/sh -c " .
 				escapeshellarg($cname_lookup_pipeline) . ' > ' . escapeshellarg($cname_lookup_file) . " 2>&1 < /dev/null";
 			$cname_lookup_output = array();

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -957,7 +957,24 @@ if (isset($_POST) && !empty($_POST)) {
 		if (!empty(pfb_filter($pfb['extdns'], PFB_FILTER_IP, 'alerts addwhitelistdom'))) {
 			$domain_esc	= escapeshellarg($domain);
 			$ext_dns 	= escapeshellarg("@{$pfb['extdns']}");
-			exec("/usr/bin/drill {$domain_esc} {$ext_dns} | /usr/bin/awk '/CNAME/ {sub(\"\.\$\", \"\", \$5); print \$5;}' 2>&1", $cname_list);
+			$drill_esc	= escapeshellarg($pfb['drill'] ?? '/usr/bin/drill');
+			$timeout_esc	= escapeshellarg($pfb['timeout'] ?? '/usr/bin/timeout');
+			// 30s DNS ceiling matches the established SafeSearch and whoisconvert lookups (#2014/#2015).
+			$cname_lookup_timeout = 30;
+			$cname_lookup_kill_grace = 5;
+			$cname_lookup_file = "{$g['tmp_path']}/pfb_alerts_cname_" . getmypid() . '_' . bin2hex(random_bytes(8));
+			$cname_lookup_pipeline = "{$drill_esc} {$domain_esc} {$ext_dns} | /usr/bin/awk '/CNAME/ {sub(\"\.\$\", \"\", \$5); print \$5;}'";
+			$cname_lookup_cmd = "{$timeout_esc} -s TERM -k {$cname_lookup_kill_grace} {$cname_lookup_timeout} /bin/sh -c " .
+				escapeshellarg($cname_lookup_pipeline) . ' > ' . escapeshellarg($cname_lookup_file) . " 2>&1 < /dev/null";
+			$cname_lookup_output = array();
+			$cname_lookup_status = 0;
+			exec($cname_lookup_cmd, $cname_lookup_output, $cname_lookup_status);
+			if ($cname_lookup_status === 124) {
+				pfb_logger("\npfblockerng_alerts: CNAME lookup TIMED OUT (killed); discarding partial output\n", 2);
+			} else {
+				$cname_list = file($cname_lookup_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: array();
+			}
+			@unlink($cname_lookup_file);
 		}
 
 		// Remove 'www.' prefix

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -971,6 +971,10 @@ if (isset($_POST) && !empty($_POST)) {
 			exec($cname_lookup_cmd, $cname_lookup_output, $cname_lookup_status);
 			if ($cname_lookup_status === 124) {
 				pfb_logger("\npfblockerng_alerts: CNAME lookup TIMED OUT (killed); discarding partial output\n", 2);
+			} elseif ($cname_lookup_status !== 0) {
+				pfb_logger("\npfblockerng_alerts: CNAME lookup FAILED (exit {$cname_lookup_status}); discarding output\n", 2);
+			} elseif (!is_file($cname_lookup_file)) {
+				pfb_logger("\npfblockerng_alerts: CNAME lookup FAILED (capture missing); discarding output\n", 2);
 			} else {
 				$cname_list = file($cname_lookup_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: array();
 			}

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -962,8 +962,11 @@ if (isset($_POST) && !empty($_POST)) {
 			// 30s DNS ceiling matches the established SafeSearch and whoisconvert lookups (#2014/#2015).
 			$cname_lookup_timeout = 30;
 			$cname_lookup_kill_grace = 5;
-			$cname_lookup_file = "{$g['tmp_path']}/pfb_alerts_cname_" . getmypid() . '_' . bin2hex(random_bytes(8));
-			$cname_lookup_pipeline = "{$drill_esc} {$domain_esc} {$ext_dns} | /usr/bin/awk '/CNAME/ {sub(\"[.]\$\", \"\", \$5); print \$5;}'";
+			$cname_lookup_prefix = "{$g['tmp_path']}/pfb_alerts_cname_" . getmypid() . '_' . bin2hex(random_bytes(8));
+			$cname_lookup_file = "{$cname_lookup_prefix}_result";
+			$cname_lookup_raw_file = "{$cname_lookup_prefix}_raw";
+			$cname_lookup_pipeline = "{$drill_esc} {$domain_esc} {$ext_dns} > " . escapeshellarg($cname_lookup_raw_file) .
+				" 2>&1 && /usr/bin/awk '/CNAME/ {sub(\"[.]\$\", \"\", \$5); print \$5;}' " . escapeshellarg($cname_lookup_raw_file);
 			$cname_lookup_cmd = "{$timeout_esc} -s TERM -k {$cname_lookup_kill_grace} {$cname_lookup_timeout} /bin/sh -c " .
 				escapeshellarg($cname_lookup_pipeline) . ' > ' . escapeshellarg($cname_lookup_file) . " 2>&1 < /dev/null";
 			$cname_lookup_output = array();
@@ -979,6 +982,7 @@ if (isset($_POST) && !empty($_POST)) {
 				$cname_list = file($cname_lookup_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: array();
 			}
 			@unlink($cname_lookup_file);
+			@unlink($cname_lookup_raw_file);
 		}
 
 		// Remove 'www.' prefix

--- a/tests/php/AlertsCnameLookupTimeoutTest.php
+++ b/tests/php/AlertsCnameLookupTimeoutTest.php
@@ -52,7 +52,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$this->assertStringContainsString(escapeshellarg($run['drill_path']), $pipeline, 'pipeline must carry the escaped injected drill fixture path');
 		$this->assertStringContainsString(escapeshellarg('example.com'), $pipeline, 'pipeline must carry the escaped domain argument');
 		$this->assertStringContainsString(escapeshellarg('@127.0.0.1'), $pipeline, 'pipeline must carry the escaped resolver argument');
-		$this->assertStringContainsString("/usr/bin/awk '/CNAME/ {sub(\"\\.\$\", \"\", \$5); print \$5;}'", $pipeline, 'pipeline must retain the CNAME awk transform');
+		$this->assertStringContainsString("/usr/bin/awk '/CNAME/ {sub(\"[.]\$\", \"\", \$5); print \$5;}'", $pipeline, 'pipeline must retain the CNAME awk transform');
 		$this->assertNotContains('--foreground', $argv, 'pipeline timeout must retain FreeBSD default reaper mode');
 		$this->assertNotContains('-f', $argv, 'pipeline timeout must retain FreeBSD default reaper mode');
 		$this->assertStringContainsString('CNAME lookup TIMED OUT', $run['log']);
@@ -89,7 +89,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$drill = $this->fixture('drill fixture.sh',
 			"printf '%s\\n' --START-- \"\$\$\" >> " . escapeshellarg($marker) . "\n"
 			. "printf '%b\\n' 'partial.example.com.\\t300\\tIN\\tCNAME\\talias.example.com.'\n"
-			. ($stall ? "while :; do sleep 1; done\n" : '')
+			. ($stall ? "while true; do sleep 1; done\n" : '')
 		);
 		$timeout = $this->fixture('timeout fixture.sh',
 			"printf '%s\\n' --CALL-- >> " . escapeshellarg($timeout_log) . "\n"

--- a/tests/php/AlertsCnameLookupTimeoutTest.php
+++ b/tests/php/AlertsCnameLookupTimeoutTest.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * Issue #2083: the Alerts addwhitelistdom CNAME lookup is a transient drill | awk
- * pipeline.  The extracted production block is run in a child so the red oracle
- * can safely prove that an unbounded drill leaves the request stuck.
- */
+/** Issue #2083: the Alerts CNAME lookup is bounded and never consumes incomplete data. */
 final class AlertsCnameLookupTimeoutTest extends TestCase
 {
 	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
@@ -42,6 +38,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$run = $this->runLookup(TRUE, TRUE);
 
 		$this->assertTrue($run['completed'], 'bounded lookup must return after the fixture stalls; child output: ' . $run['child_log']);
+		$this->assertTrue($run['partial_seen'], 'drill must emit partial output before the timeout fires');
 		$this->assertSame([], $run['cname_list'], 'partial CNAME output must be discarded on timeout');
 		$this->assertCount(1, $run['timeout_calls'], 'timeout shim must receive one bounded lookup');
 		$argv = $run['timeout_calls'][0];
@@ -59,6 +56,18 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$this->assertSame([], $run['capture_files'], 'timed-out capture files must be cleaned up');
 	}
 
+	public function testDrillFailureDiscardsPartialOutput(): void
+	{
+		$run = $this->runLookup(FALSE, FALSE, TRUE, FALSE, TRUE);
+
+		$this->assertTrue($run['completed'], 'failed drill must not abort the request; child output: ' . $run['child_log']);
+		$this->assertTrue($run['partial_seen'], 'drill must emit partial output before failing');
+		$this->assertSame([], $run['cname_list'], 'output from a failed drill must be discarded');
+		$this->assertCount(1, $run['timeout_calls']);
+		$this->assertStringContainsString('CNAME lookup FAILED (exit 7)', $run['log']);
+		$this->assertSame([], $run['capture_files']);
+	}
+
 	public function testCaptureFailureIsLoggedWithoutReadingMissingFile(): void
 	{
 		$run = $this->runLookup(FALSE, FALSE, FALSE);
@@ -68,6 +77,18 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$this->assertSame([], $run['timeout_calls'], 'failed outer redirection must not launch the lookup');
 		$this->assertStringContainsString('CNAME lookup FAILED', $run['log']);
 		$this->assertStringNotContainsString('file(', $run['child_log'], 'missing capture file must not emit a PHP warning');
+	}
+
+	public function testMissingCaptureAfterSuccessfulLookupIsLogged(): void
+	{
+		$run = $this->runLookup(FALSE, FALSE, TRUE, TRUE);
+
+		$this->assertTrue($run['completed'], 'missing capture must not abort the request; child output: ' . $run['child_log']);
+		$this->assertSame([], $run['cname_list'], 'missing capture must not produce CNAME data');
+		$this->assertCount(1, $run['timeout_calls'], 'the lookup must succeed before its capture disappears');
+		$this->assertStringContainsString('CNAME lookup FAILED (capture missing)', $run['log']);
+		$this->assertStringNotContainsString('file(', $run['child_log'], 'missing capture file must not emit a PHP warning');
+		$this->assertSame([], $run['capture_files']);
 	}
 
 	public function testLookupUsesDefaultReaperAndRegularFileCapture(): void
@@ -86,12 +107,11 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 	}
 
 	/**
-	 * @return array{completed:bool,cname_list:list<string>,timeout_calls:list<list<string>>,log:string,capture_files:list<string>,child_log:string,drill_path:string}
+	 * @return array{completed:bool,cname_list:list<string>,timeout_calls:list<list<string>>,log:string,capture_files:list<string>,child_log:string,drill_path:string,partial_seen:bool}
 	 */
-	private function runLookup(bool $stall, bool $expectTimeout, bool $captureAvailable = TRUE): array
+	private function runLookup(bool $stall, bool $expectTimeout, bool $captureAvailable = TRUE, bool $removeCapture = FALSE, bool $drillFails = FALSE): array
 	{
 		$marker = "{$this->tmp}/stall marker.log";
-		$drill_log = "{$this->tmp}/drill args.log";
 		$timeout_log = "{$this->tmp}/timeout args.log";
 		$timeout_flag = "{$this->tmp}/timeout fired";
 		$result = "{$this->tmp}/lookup result.json";
@@ -100,6 +120,8 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$drill = $this->fixture('drill fixture.sh',
 			"printf '%s\\n' --START-- \"\$\$\" >> " . escapeshellarg($marker) . "\n"
 			. "printf '%b\\n' 'partial.example.com.\\t300\\tIN\\tCNAME\\talias.example.com.'\n"
+			. "printf '%s\\n' --PARTIAL-WRITTEN-- >> " . escapeshellarg($marker) . "\n"
+			. ($drillFails ? "exit 7\n" : '')
 			. ($stall ? "while true; do sleep 1; done\n" : '')
 		);
 		$timeout = $this->fixture('timeout fixture.sh',
@@ -107,9 +129,13 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 			. "printf '%s\\n' \"\$@\" >> " . escapeshellarg($timeout_log) . "\n"
 			. "shift 5\n"
 			. "\"\$@\" & child=\$!\n"
-			. "(sleep 1; touch " . escapeshellarg($timeout_flag) . "; kill -TERM \$child 2>/dev/null) & watchdog=\$!\n"
+			. ($stall
+				? "tries=0\nwhile ! grep -q -- --PARTIAL-WRITTEN-- " . escapeshellarg($marker) . "; do\n"
+					. "tries=\$((tries + 1)); [ \"\$tries\" -ge 200 ] && { kill -TERM \$child 2>/dev/null; wait \$child 2>/dev/null; exit 125; }; sleep 0.01\n"
+					. "done\ntouch " . escapeshellarg($timeout_flag) . "; kill -TERM \$child 2>/dev/null\n"
+				: '')
 			. "wait \$child; rc=\$?\n"
-			. "kill \$watchdog 2>/dev/null; wait \$watchdog 2>/dev/null\n"
+			. ($removeCapture ? "rm -f " . escapeshellarg($this->tmp) . "/pfb_alerts_cname_*\n" : '')
 			. "[ -f " . escapeshellarg($timeout_flag) . " ] && exit 124\n"
 			. "exit \$rc\n"
 		);
@@ -121,6 +147,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		}
 		$worker_code = "<?php\n"
 			. 'require_once ' . var_export($bootstrap, TRUE) . ";\n"
+			. "if (function_exists('posix_setsid')) { posix_setsid(); }\n"
 			. 'eval(' . var_export($function, TRUE) . ");\n"
 			. '$GLOBALS[\'pfb\'][\'extdns\'] = \'127.0.0.1\';' . "\n"
 			. '$GLOBALS[\'pfb\'][\'drill\'] = ' . var_export($drill, TRUE) . ";\n"
@@ -143,39 +170,43 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		if (!is_resource($process)) {
 			throw new RuntimeException('could not start lookup worker');
 		}
+		$worker_status = proc_get_status($process);
+		$worker_pid = (int) ($worker_status['pid'] ?? 0);
 
-		$deadline = microtime(TRUE) + 8.0;
+		$completed = FALSE;
 		$marker_seen = FALSE;
-		while (microtime(TRUE) < $deadline) {
-			if (is_file($marker)) {
-				$marker_seen = TRUE;
+		$failure = NULL;
+		try {
+			$deadline = microtime(TRUE) + 8.0;
+			while (microtime(TRUE) < $deadline) {
+				if (is_file($marker)) {
+					$marker_seen = TRUE;
+				}
+				if (is_file($result)) {
+					break;
+				}
+				usleep(10_000);
 			}
-			if (is_file($result)) {
-				break;
-			}
-			usleep(10_000);
-		}
 
-		$status = proc_get_status($process);
-		$completed = is_file($result);
-		if (!$completed) {
-			if ($expectTimeout) {
-				$this->fail('STUCK/ENVIRONMENT: bounded lookup did not return; marker=' . ($marker_seen ? 'seen' : 'missing'));
+			$completed = is_file($result);
+			$failure = !$completed && $expectTimeout
+				? 'STUCK/ENVIRONMENT: bounded lookup did not return; marker=' . ($marker_seen ? 'seen' : 'missing')
+				: NULL;
+		} finally {
+			if (!$completed) {
+				$group_killed = $worker_pid > 0 && function_exists('posix_kill') && @posix_kill(-$worker_pid, 9);
+				if (!$group_killed) {
+					proc_terminate($process, 9);
+				}
 			}
-			// Red-path salvage: terminate the worker and the fixture it launched.
-			proc_terminate($process, 9);
-			$drill_pid = $this->fixturePid($marker);
-			if ($drill_pid !== NULL && function_exists('posix_kill')) {
-				posix_kill($drill_pid, 9);
-			}
-			proc_close($process);
-		}
-		else {
 			proc_close($process);
 		}
 		$drill_pid = $this->fixturePid($marker);
 		if ($drill_pid !== NULL && function_exists('posix_kill')) {
 			@posix_kill($drill_pid, 9);
+		}
+		if ($failure !== NULL) {
+			$this->fail($failure);
 		}
 
 		$payload = is_file($result) ? json_decode((string) file_get_contents($result), TRUE) : [];
@@ -188,6 +219,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 			'capture_files' => glob("{$this->tmp}/pfb_alerts_cname_*") ?: [],
 			'child_log' => is_file($child_log) ? (string) file_get_contents($child_log) : '',
 			'drill_path' => $drill,
+			'partial_seen' => is_file($marker) && str_contains((string) file_get_contents($marker), '--PARTIAL-WRITTEN--'),
 		];
 	}
 

--- a/tests/php/AlertsCnameLookupTimeoutTest.php
+++ b/tests/php/AlertsCnameLookupTimeoutTest.php
@@ -59,6 +59,17 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$this->assertSame([], $run['capture_files'], 'timed-out capture files must be cleaned up');
 	}
 
+	public function testCaptureFailureIsLoggedWithoutReadingMissingFile(): void
+	{
+		$run = $this->runLookup(FALSE, FALSE, FALSE);
+
+		$this->assertTrue($run['completed'], 'capture failure must not abort the request; child output: ' . $run['child_log']);
+		$this->assertSame([], $run['cname_list'], 'capture failure must not produce CNAME data');
+		$this->assertSame([], $run['timeout_calls'], 'failed outer redirection must not launch the lookup');
+		$this->assertStringContainsString('CNAME lookup FAILED', $run['log']);
+		$this->assertStringNotContainsString('file(', $run['child_log'], 'missing capture file must not emit a PHP warning');
+	}
+
 	public function testLookupUsesDefaultReaperAndRegularFileCapture(): void
 	{
 		$source = file_get_contents(self::ALERTS_PHP);
@@ -77,7 +88,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 	/**
 	 * @return array{completed:bool,cname_list:list<string>,timeout_calls:list<list<string>>,log:string,capture_files:list<string>,child_log:string,drill_path:string}
 	 */
-	private function runLookup(bool $stall, bool $expectTimeout): array
+	private function runLookup(bool $stall, bool $expectTimeout, bool $captureAvailable = TRUE): array
 	{
 		$marker = "{$this->tmp}/stall marker.log";
 		$drill_log = "{$this->tmp}/drill args.log";
@@ -114,7 +125,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 			. '$GLOBALS[\'pfb\'][\'extdns\'] = \'127.0.0.1\';' . "\n"
 			. '$GLOBALS[\'pfb\'][\'drill\'] = ' . var_export($drill, TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'][\'timeout\'] = ' . var_export($timeout, TRUE) . ";\n"
-			. '$GLOBALS[\'g\'][\'tmp_path\'] = ' . var_export($this->tmp, TRUE) . ";\n"
+			. '$GLOBALS[\'g\'][\'tmp_path\'] = ' . var_export($captureAvailable ? $this->tmp : "{$this->tmp}/missing", TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'][\'log\'] = ' . var_export("{$this->tmp}/pfblockerng.log", TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'][\'errlog\'] = ' . var_export("{$this->tmp}/pfblockerng.errlog", TRUE) . ";\n"
 			. '$list = pfb_alerts_test_cname_lookup(\'example.com\');' . "\n"

--- a/tests/php/AlertsCnameLookupTimeoutTest.php
+++ b/tests/php/AlertsCnameLookupTimeoutTest.php
@@ -14,7 +14,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 	protected function setUp(): void
 	{
 		$this->tmp = sys_get_temp_dir() . '/pfb alerts cname ' . bin2hex(random_bytes(6));
-		mkdir($this->tmp, 0777, true);
+		mkdir($this->tmp, 0777, TRUE);
 	}
 
 	protected function tearDown(): void

--- a/tests/php/AlertsCnameLookupTimeoutTest.php
+++ b/tests/php/AlertsCnameLookupTimeoutTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2083: the Alerts addwhitelistdom CNAME lookup is a transient drill | awk
+ * pipeline.  The extracted production block is run in a child so the red oracle
+ * can safely prove that an unbounded drill leaves the request stuck.
+ */
+final class AlertsCnameLookupTimeoutTest extends TestCase
+{
+	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+
+	private string $tmp;
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb alerts cname ' . bin2hex(random_bytes(6));
+		mkdir($this->tmp, 0777, true);
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->tmp);
+	}
+
+	public function testSuccessfulCnameOutputIsReadFromFile(): void
+	{
+		$run = $this->runLookup(FALSE, FALSE);
+
+		$this->assertTrue($run['completed'], 'lookup worker must complete; child output: ' . $run['child_log']);
+		$this->assertSame(['alias.example.com'], $run['cname_list'], 'completed CNAME output must be read from the regular file');
+		$this->assertCount(1, $run['timeout_calls'], 'a completed lookup must still use bounded timeout wrapper');
+		$this->assertStringNotContainsString('TIMED OUT', $run['log'], 'a completed lookup must not log timeout');
+		$this->assertSame([], $run['capture_files'], 'lookup capture files must be cleaned up after read');
+	}
+
+	public function testTimeoutDiscardsPartialOutputAndLogsExpiry(): void
+	{
+		$run = $this->runLookup(TRUE, TRUE);
+
+		$this->assertTrue($run['completed'], 'bounded lookup must return after the fixture stalls; child output: ' . $run['child_log']);
+		$this->assertSame([], $run['cname_list'], 'partial CNAME output must be discarded on timeout');
+		$this->assertCount(1, $run['timeout_calls'], 'timeout shim must receive one bounded lookup');
+		$argv = $run['timeout_calls'][0];
+		$this->assertSame(['-s', 'TERM', '-k', '5', '30'], array_slice($argv, 0, 5), 'lookup must use default-mode timeout with named 30-second budget and 5-second grace');
+		$this->assertSame(['/bin/sh', '-c'], array_slice($argv, 5, 2), 'timeout must invoke the complete pipeline through /bin/sh -c');
+		$this->assertCount(8, $argv, 'timeout argv must contain exactly one complete pipeline argument');
+		$pipeline = $argv[7];
+		$this->assertStringContainsString(escapeshellarg($run['drill_path']), $pipeline, 'pipeline must carry the escaped injected drill fixture path');
+		$this->assertStringContainsString(escapeshellarg('example.com'), $pipeline, 'pipeline must carry the escaped domain argument');
+		$this->assertStringContainsString(escapeshellarg('@127.0.0.1'), $pipeline, 'pipeline must carry the escaped resolver argument');
+		$this->assertStringContainsString("/usr/bin/awk '/CNAME/ {sub(\"\\.\$\", \"\", \$5); print \$5;}'", $pipeline, 'pipeline must retain the CNAME awk transform');
+		$this->assertNotContains('--foreground', $argv, 'pipeline timeout must retain FreeBSD default reaper mode');
+		$this->assertNotContains('-f', $argv, 'pipeline timeout must retain FreeBSD default reaper mode');
+		$this->assertStringContainsString('CNAME lookup TIMED OUT', $run['log']);
+		$this->assertSame([], $run['capture_files'], 'timed-out capture files must be cleaned up');
+	}
+
+	public function testLookupUsesDefaultReaperAndRegularFileCapture(): void
+	{
+		$source = file_get_contents(self::ALERTS_PHP);
+		$start = strpos((string) $source, '$cname_list = array();');
+		$end = strpos((string) $source, "// Remove 'www.' prefix", $start === FALSE ? 0 : $start);
+		$this->assertNotFalse($start, 'CNAME lookup source anchor must remain present');
+		$this->assertNotFalse($end, 'CNAME lookup source end anchor must remain present');
+		$block = substr($source, $start, $end - $start);
+		$this->assertStringContainsString('$cname_lookup_timeout = 30', $block);
+		$this->assertStringContainsString('$cname_lookup_kill_grace = 5', $block);
+		$this->assertStringContainsString('2>&1 < /dev/null', $block);
+		$this->assertStringContainsString('escapeshellarg($cname_lookup_file)', $block);
+		$this->assertStringNotContainsString('exec("/usr/bin/drill', $block);
+	}
+
+	/**
+	 * @return array{completed:bool,cname_list:list<string>,timeout_calls:list<list<string>>,log:string,capture_files:list<string>,child_log:string,drill_path:string}
+	 */
+	private function runLookup(bool $stall, bool $expectTimeout): array
+	{
+		$marker = "{$this->tmp}/stall marker.log";
+		$drill_log = "{$this->tmp}/drill args.log";
+		$timeout_log = "{$this->tmp}/timeout args.log";
+		$timeout_flag = "{$this->tmp}/timeout fired";
+		$result = "{$this->tmp}/lookup result.json";
+		$child_log = "{$this->tmp}/child output.log";
+
+		$drill = $this->fixture('drill fixture.sh',
+			"printf '%s\\n' --START-- \"\$\$\" >> " . escapeshellarg($marker) . "\n"
+			. "printf '%b\\n' 'partial.example.com.\\t300\\tIN\\tCNAME\\talias.example.com.'\n"
+			. ($stall ? "while :; do sleep 1; done\n" : '')
+		);
+		$timeout = $this->fixture('timeout fixture.sh',
+			"printf '%s\\n' --CALL-- >> " . escapeshellarg($timeout_log) . "\n"
+			. "printf '%s\\n' \"\$@\" >> " . escapeshellarg($timeout_log) . "\n"
+			. "shift 5\n"
+			. "\"\$@\" & child=\$!\n"
+			. "(sleep 1; touch " . escapeshellarg($timeout_flag) . "; kill -TERM \$child 2>/dev/null) & watchdog=\$!\n"
+			. "wait \$child; rc=\$?\n"
+			. "kill \$watchdog 2>/dev/null; wait \$watchdog 2>/dev/null\n"
+			. "[ -f " . escapeshellarg($timeout_flag) . " ] && exit 124\n"
+			. "exit \$rc\n"
+		);
+		$function = $this->lookupFunction($drill);
+		$worker = "{$this->tmp}/lookup worker.php";
+		$bootstrap = realpath(__DIR__ . '/bootstrap.php');
+		if ($bootstrap === FALSE) {
+			throw new RuntimeException('test bootstrap path unavailable');
+		}
+		$worker_code = "<?php\n"
+			. 'require_once ' . var_export($bootstrap, TRUE) . ";\n"
+			. 'eval(' . var_export($function, TRUE) . ");\n"
+			. '$GLOBALS[\'pfb\'][\'extdns\'] = \'127.0.0.1\';' . "\n"
+			. '$GLOBALS[\'pfb\'][\'drill\'] = ' . var_export($drill, TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'timeout\'] = ' . var_export($timeout, TRUE) . ";\n"
+			. '$GLOBALS[\'g\'][\'tmp_path\'] = ' . var_export($this->tmp, TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'log\'] = ' . var_export("{$this->tmp}/pfblockerng.log", TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'errlog\'] = ' . var_export("{$this->tmp}/pfblockerng.errlog", TRUE) . ";\n"
+			. '$list = pfb_alerts_test_cname_lookup(\'example.com\');' . "\n"
+			. 'file_put_contents(' . var_export($result, TRUE) . ', json_encode(['
+				. "'list' => \$list, 'log' => file_exists(\$GLOBALS['pfb']['log']) ? file_get_contents(\$GLOBALS['pfb']['log']) : '',"
+				. ' ]));' . "\n";
+		file_put_contents($worker, $worker_code);
+
+		$descriptors = [
+			0 => ['file', '/dev/null', 'r'],
+			1 => ['file', $child_log, 'ab'],
+			2 => ['file', $child_log, 'ab'],
+		];
+		$process = proc_open([PHP_BINARY, $worker], $descriptors, $pipes);
+		if (!is_resource($process)) {
+			throw new RuntimeException('could not start lookup worker');
+		}
+
+		$deadline = microtime(TRUE) + 8.0;
+		$marker_seen = FALSE;
+		while (microtime(TRUE) < $deadline) {
+			if (is_file($marker)) {
+				$marker_seen = TRUE;
+			}
+			if (is_file($result)) {
+				break;
+			}
+			usleep(10_000);
+		}
+
+		$status = proc_get_status($process);
+		$completed = is_file($result);
+		if (!$completed) {
+			if ($expectTimeout) {
+				$this->fail('STUCK/ENVIRONMENT: bounded lookup did not return; marker=' . ($marker_seen ? 'seen' : 'missing'));
+			}
+			// Red-path salvage: terminate the worker and the fixture it launched.
+			proc_terminate($process, 9);
+			$drill_pid = $this->fixturePid($marker);
+			if ($drill_pid !== NULL && function_exists('posix_kill')) {
+				posix_kill($drill_pid, 9);
+			}
+			proc_close($process);
+		}
+		else {
+			proc_close($process);
+		}
+		$drill_pid = $this->fixturePid($marker);
+		if ($drill_pid !== NULL && function_exists('posix_kill')) {
+			@posix_kill($drill_pid, 9);
+		}
+
+		$payload = is_file($result) ? json_decode((string) file_get_contents($result), TRUE) : [];
+		$timeout_calls = $this->timeoutCalls($timeout_log);
+		return [
+			'completed' => $completed,
+			'cname_list' => $payload['list'] ?? [],
+			'timeout_calls' => $timeout_calls,
+			'log' => $payload['log'] ?? '',
+			'capture_files' => glob("{$this->tmp}/pfb_alerts_cname_*") ?: [],
+			'child_log' => is_file($child_log) ? (string) file_get_contents($child_log) : '',
+			'drill_path' => $drill,
+		];
+	}
+
+	private function lookupFunction(string $drill): string
+	{
+		$source = file_get_contents(self::ALERTS_PHP);
+		if ($source === FALSE) {
+			throw new RuntimeException('test oracle: failed to read pfblockerng_alerts.php');
+		}
+		$start = strpos($source, "\t\t\$cname_list = array();");
+		$end = strpos($source, "\n\t\t// Remove 'www.' prefix", $start === FALSE ? 0 : $start);
+		if ($start === FALSE || $end === FALSE || $end <= $start) {
+			throw new RuntimeException('test oracle: CNAME lookup block bounds not found');
+		}
+		$block = substr($source, $start, $end - $start);
+		if (!str_contains($block, '$pfb[\'drill\']')) {
+			$block = str_replace('/usr/bin/drill', escapeshellarg($drill), $block);
+		}
+		return 'function pfb_alerts_test_cname_lookup(string $domain): array { global $pfb, $g; ' . $block . ' return $cname_list; }';
+	}
+
+	private function fixture(string $name, string $body): string
+	{
+		$path = "{$this->tmp}/{$name}";
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	private function fixturePid(string $marker): ?int
+	{
+		$lines = @file($marker, FILE_IGNORE_NEW_LINES);
+		foreach ($lines ?: [] as $line) {
+			if ($line !== '--START--' && ctype_digit($line)) {
+				return (int) $line;
+			}
+		}
+		return NULL;
+	}
+
+	/** @return list<list<string>> */
+	private function timeoutCalls(string $path): array
+	{
+		$lines = @file($path, FILE_IGNORE_NEW_LINES);
+		$calls = [];
+		$call = [];
+		foreach ($lines ?: [] as $line) {
+			if ($line === '--CALL--') {
+				if ($call !== []) {
+					$calls[] = $call;
+					$call = [];
+				}
+				continue;
+			}
+			$call[] = $line;
+		}
+		if ($call !== []) {
+			$calls[] = $call;
+		}
+		return $calls;
+	}
+}

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -10,7 +10,8 @@ token, and POST the exact ``{action: ..., domain/ip/table: ...}`` set the page's
 JS would send (mirroring ``test_log.py``'s manual-POST pattern).
 
 What this file establishes -- the same oracle discipline as ``test_functional.py``:
-the oracle is the box's EFFECTIVE state, NEVER the HTTP response body. For the
+the behavioral oracle is the box's EFFECTIVE state, never the HTTP response body;
+the response may prove only authenticated rendering and reachability. For the
 config-store actions (whitelist / TLD-exclusion / IP suppression) that is the
 ``config.xml`` node the handler writes (read via :func:`helpers.config_get`,
 base64-decoded -- these are pfBlockerNG textarea fields). For the marquee
@@ -88,7 +89,8 @@ def _post_action(webui: WebUI, data: dict[str, str], *, timeout: float = 300.0) 
     Re-harvests the token (per-render), merges it into ``data``, and POSTs to the
     alerts page exactly as the page's JS would -- no ``save`` button (these handlers
     gate on ``isset($_POST['<action>'])``, not on ``save``). The caller asserts
-    EFFECTIVE state (config.xml / DNS), never this response.
+    EFFECTIVE state (config.xml / DNS); the response may only establish authenticated
+    rendering and reachability.
     """
     payload: dict[str, Any] = {"__csrf_magic": _csrf(webui)}
     payload.update(data)

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -350,6 +350,7 @@ def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
             },
         )
         assert not looks_like_login_page(resp.text), "addwhitelistdom POST returned the login form (session lost)"
+        assert "Alert Settings" in resp.text, "addwhitelistdom redirect did not render the Alerts page"
         assert domain in _suppression_entries(vm, CFG_WHITELIST), (
             f"{domain} not written to the DNSBL whitelist config node after addwhitelistdom"
         )


### PR DESCRIPTION
## Summary

- bound the Alerts whitelist CNAME `drill | awk` pipeline with FreeBSD `timeout(1)`
- capture lookup output through a regular file and detach stdin from `/dev/null`
- discard partial output and log explicit level-2 diagnostics on timeout, command failure, or missing capture

## Wait semantics

The lookup is a transient helper pipeline, not a daemon launcher. Per `docs/misc/external-process-waits.md`, default FreeBSD timeout mode is therefore required: its process-reaper behavior owns and kills the full descendant tree on expiry. `--foreground` would supervise only the direct shell and could orphan a blocked `drill` or `awk` descendant.

PHP `exec()` waits for stdout EOF. The timeout command therefore redirects stdout and stderr to a regular file and reads stdin from `/dev/null`; PHP reads the file only after successful completion. A timed-out or failed lookup never reads its partial file, so failure cannot masquerade as a legitimate CNAME result.

The named 30-second lookup budget and 5-second TERM-to-KILL grace match the established per-query resolver caps from issues #2014 and #2015. This is one transient HTTP lookup, so no new GUI setting is introduced.

## Coverage

- frozen test-first proof: final committed test blob against original production is RED (6 tests, 14 assertions, 6 failures); exact head is GREEN (6 tests, 44 assertions)
- final frozen test blob: `0f7e525c7b28e53c1ccb7794a449e6db30125340`
- focused result: 6 tests, 44 assertions
- missing-capture regression executed RED before its production guard and GREEN afterward
- reachable UI coverage: `test_addwhitelistdom` now verifies the authenticated POST redirects back to the rendered Alerts page
- sibling sweep: `pfblockerng_alerts.php` contains exactly one executable `drill`/`dig`/`host` lookup; it is now bounded. The other drill text is a retired-machinery comment.

## Verification

```text
php -l src/usr/local/www/pfblockerng/pfblockerng_alerts.php
php -l tests/php/AlertsCnameLookupTimeoutTest.php
php vendor/bin/phpunit tests/php/AlertsCnameLookupTimeoutTest.php
shellspec --shell /bin/dash tests/shell/pfblockerng_truncate_survival_spec.sh
git hash-object tests/php/AlertsCnameLookupTimeoutTest.php
scripts/agent/run-gates.sh --diff origin/devel

OK (6 tests, 44 assertions)
12 shellspec examples, 0 failures
original production: RED (6 tests, 14 assertions, 6 failures)
exact head: GREEN (6 tests, 44 assertions)
GATES: PASS
```

Fixes #2083

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CNAME lookups with configurable command execution and bounded timeouts.
  * Prevented incomplete or failed lookup results from being processed.
  * Added cleanup and logging for timed-out, failed, or missing lookup output.
  * Preserved reliable Alerts-page behavior after whitelist actions.

* **Tests**
  * Added coverage for successful lookups, failures, timeouts, output cleanup, logging, and Alerts-page rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
