### PR TITLE
pfblockerng: make extra-only ledger paths safe

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8738,55 +8738,6 @@ function pfb_unbound_py_top1m_atomic_copy(string $source, string $path, array $s
 	return TRUE;
 }
 
-// issue #1780: bounded flock() acquire -- a wall-clock deadline AND an independent
-// poll cap both bound the wait (a stalled/backward clock still terminates). ORs in
-// LOCK_NB itself; never fclose()s -- the caller owns the handle.
-//
-// issue #1780: $timed_out distinguishes a genuine flock() error (would-block
-// byref never reaches 1 -- not a contention signal at all) from a genuine
-// deadline/poll-cap expiry, so a caller can log the correct one instead of a
-// single ambiguous FALSE. Set TRUE ONLY when the wait genuinely expired; left
-// FALSE on every other return (a real flock() error, or success).
-function pfb_flock_bounded($fp, int $operation, float $timeout_s, ?bool &$timed_out = NULL): bool {
-	$timed_out = FALSE;
-	// Clamp before the poll-cap cast below: a budget whose /0.02 quotient overflows int
-	// makes that cast warn and yield 0, collapsing the cap to 2 attempts (unbounding it).
-	$wait_s = min(max($timeout_s, 0.0), 3600.0);
-	$deadline = microtime(TRUE) + $wait_s;
-	// Independent poll cap bounds the wait if the wall clock stalls or moves backward.
-	$max_polls = (int) ceil($wait_s / 0.02) + 2;
-	$polls = 0;
-	$first_attempt = TRUE;
-	do {
-		$allow_expired_attempt = $first_attempt && $wait_s <= 0.0;
-		$first_attempt = FALSE;
-		if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
-			break;
-		}
-		$would_block = 0;
-		if (@flock($fp, $operation | LOCK_NB, $would_block)) {
-			if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
-				@flock($fp, LOCK_UN);
-				break;
-			}
-			return TRUE;
-		}
-		if ($would_block !== 1) {
-			// A real flock() error -- never a timeout/contention signal.
-			return FALSE;
-		}
-		$polls++;
-		$remaining_s = $deadline - microtime(TRUE);
-		if ($polls >= $max_polls || $remaining_s <= 0.0) {
-			break;
-		}
-		usleep((int) min(20000, ceil($remaining_s * 1000000)));
-	} while (TRUE);
-
-	$timed_out = TRUE;
-	return FALSE;
-}
-
 // issue #1780: the bounded default every NULL caller of the publication lock
 // resolves to. Holders are local manifest/GC/teardown file writes; the worst-case
 // hold is unmeasured, so 60s is a deliberately loose finite cap -- it exists to

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3457,6 +3457,55 @@ function pfb_syslog_emit(string $body): void
 	closelog();
 }
 
+// issue #1780: bounded flock() acquire -- a wall-clock deadline AND an independent
+// poll cap both bound the wait (a stalled/backward clock still terminates). ORs in
+// LOCK_NB itself; never fclose()s -- the caller owns the handle.
+//
+// issue #1780: $timed_out distinguishes a genuine flock() error (would-block
+// byref never reaches 1 -- not a contention signal at all) from a genuine
+// deadline/poll-cap expiry, so a caller can log the correct one instead of a
+// single ambiguous FALSE. Set TRUE ONLY when the wait genuinely expired; left
+// FALSE on every other return (a real flock() error, or success).
+function pfb_flock_bounded($fp, int $operation, float $timeout_s, ?bool &$timed_out = NULL): bool {
+	$timed_out = FALSE;
+	// Clamp before the poll-cap cast below: a budget whose /0.02 quotient overflows int
+	// makes that cast warn and yield 0, collapsing the cap to 2 attempts (unbounding it).
+	$wait_s = min(max($timeout_s, 0.0), 3600.0);
+	$deadline = microtime(TRUE) + $wait_s;
+	// Independent poll cap bounds the wait if the wall clock stalls or moves backward.
+	$max_polls = (int) ceil($wait_s / 0.02) + 2;
+	$polls = 0;
+	$first_attempt = TRUE;
+	do {
+		$allow_expired_attempt = $first_attempt && $wait_s <= 0.0;
+		$first_attempt = FALSE;
+		if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
+			break;
+		}
+		$would_block = 0;
+		if (@flock($fp, $operation | LOCK_NB, $would_block)) {
+			if (!$allow_expired_attempt && microtime(TRUE) >= $deadline) {
+				@flock($fp, LOCK_UN);
+				break;
+			}
+			return TRUE;
+		}
+		if ($would_block !== 1) {
+			// A real flock() error -- never a timeout/contention signal.
+			return FALSE;
+		}
+		$polls++;
+		$remaining_s = $deadline - microtime(TRUE);
+		if ($polls >= $max_polls || $remaining_s <= 0.0) {
+			break;
+		}
+		usleep((int) min(20000, ceil($remaining_s * 1000000)));
+	} while (TRUE);
+
+	$timed_out = TRUE;
+	return FALSE;
+}
+
 // ---------------------------------------------------------------------------
 // ADR-43 — Due-ledger library: persisted per-job next-due ledger (pfb_due_ledger.json under
 // $pfb['dbdir']) recording {last_run, next_due, jitter} so a tick decides what's due without
@@ -3554,7 +3603,12 @@ function pfb_due_ledger_read_entry(string $job_key, string $ledger_dir, float $t
 	}
 	if (!pfb_flock_bounded($fp, LOCK_SH, $timeout_s)) {
 		fclose($fp);
-		pfb_logger("\nADR-43: due-ledger read lock timed out [ {$path} ]", 2);
+		$message = "\nADR-43: due-ledger read lock timed out [ {$path} ]";
+		if (function_exists('pfb_logger')) {
+			pfb_logger($message, 2);
+		} else {
+			logger(LOG_ERR, $message);
+		}
 		$unavailable = TRUE;
 		return NULL;
 	}
@@ -4274,7 +4328,12 @@ function pfb_sync_status_read_all(string $ledger_dir, float $timeout_s = 5.0, ?b
 	}
 	if (!pfb_flock_bounded($fp, LOCK_SH, $timeout_s)) {
 		fclose($fp);
-		pfb_logger("\nADR-61: sync-status ledger read lock timed out [ {$path} ]", 2);
+		$message = "\nADR-61: sync-status ledger read lock timed out [ {$path} ]";
+		if (function_exists('pfb_logger')) {
+			pfb_logger($message, 2);
+		} else {
+			logger(LOG_ERR, $message);
+		}
 		$unavailable = TRUE;
 		return [];
 	}
@@ -4341,7 +4400,12 @@ function pfb_sync_status_locked(string $ledger_dir, callable $fn, float $timeout
 		fclose($fp);
 		// issue #1780: the acquire timed out -- log it loudly (observable, was
 		// silent) before degrading to the same fail-open contract as above.
-		pfb_logger("\nADR-61: sync-status ledger lock timed out [ {$lock_path} ] -- proceeding unlocked", 2);
+		$message = "\nADR-61: sync-status ledger lock timed out [ {$lock_path} ] -- proceeding unlocked";
+		if (function_exists('pfb_logger')) {
+			pfb_logger($message, 2);
+		} else {
+			logger(LOG_ERR, $message);
+		}
 		$fn();
 		return;
 	}

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -760,11 +760,15 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 	public function testExtraOnlyLockTimeoutDoesNotRequireMain(): void
 	{
-		$dataPath = $this->dir . '/pfb_sync_status.json';
-		file_put_contents($dataPath, '{}');
-		$holder = fopen($dataPath, 'c');
-		$this->assertNotFalse($holder, 'test fixture must open the sync-status data file');
-		$this->assertTrue(flock($holder, LOCK_EX), 'test fixture must hold the sync-status data lock');
+		$holders = [];
+		foreach (['pfb_due_ledger.json' => '{}', 'pfb_sync_status.json' => '{}', 'pfb_sync_status.json.lock' => ''] as $name => $contents) {
+			$path = $this->dir . '/' . $name;
+			file_put_contents($path, $contents);
+			$holder = fopen($path, 'c');
+			$this->assertNotFalse($holder, "test fixture must open {$name}");
+			$this->assertTrue(flock($holder, LOCK_EX), "test fixture must lock {$name}");
+			$holders[] = $holder;
+		}
 
 		$extraPath = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
 		$childCode = <<<'PHP'
@@ -772,28 +776,58 @@ require $argv[1];
 if (function_exists('pfb_logger') || !function_exists('logger')) {
 	exit(3);
 }
-$unavailable = FALSE;
-$data = pfb_sync_status_read_all($argv[2], 0.05, $unavailable);
-echo json_encode(['data' => $data, 'unavailable' => $unavailable], JSON_THROW_ON_ERROR), "\n";
+$dueUnavailable = FALSE;
+$due = pfb_due_ledger_read_entry('dcc', $argv[2], 0.05, $dueUnavailable);
+$syncUnavailable = FALSE;
+$sync = pfb_sync_status_read_all($argv[2], 0.05, $syncUnavailable);
+$callbackRan = FALSE;
+pfb_sync_status_locked($argv[2], static function () use (&$callbackRan): void {
+	$callbackRan = TRUE;
+}, 0.05);
+echo json_encode([
+	'due' => $due,
+	'due_unavailable' => $dueUnavailable,
+	'sync' => $sync,
+	'sync_unavailable' => $syncUnavailable,
+	'callback_ran' => $callbackRan,
+], JSON_THROW_ON_ERROR), "\n";
 PHP;
-		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$descriptors = [0 => ['file', '/dev/null', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
 		$process = proc_open([PHP_BINARY, '-r', $childCode, $extraPath, $this->dir], $descriptors, $pipes);
 		$this->assertIsResource($process, 'test fixture must launch an extra-only child process');
-		stream_set_timeout($pipes[1], 5);
-		stream_set_timeout($pipes[2], 5);
+		$deadline = hrtime(TRUE) + 5_000_000_000;
+		do {
+			$status = proc_get_status($process);
+			if (!$status['running']) {
+				break;
+			}
+			usleep(10000);
+		} while (hrtime(TRUE) < $deadline);
+		$timedOut = $status['running'];
+		if ($timedOut) {
+			proc_terminate($process, 9);
+		}
 		$output = stream_get_contents($pipes[1]);
 		$errors = stream_get_contents($pipes[2]);
 		fclose($pipes[1]);
 		fclose($pipes[2]);
-		$exitCode = proc_close($process);
-		flock($holder, LOCK_UN);
-		fclose($holder);
+		$closeExitCode = proc_close($process);
+		foreach ($holders as $holder) {
+			flock($holder, LOCK_UN);
+			fclose($holder);
+		}
 
+		$this->assertFalse($timedOut, 'extra-only child exceeded the 5-second hard deadline');
+		$exitCode = $status['exitcode'] !== -1 ? $status['exitcode'] : $closeExitCode;
 		$this->assertSame(0, $exitCode, "extra-only child failed: {$errors}");
 		$result = json_decode($output, TRUE);
 		$this->assertIsArray($result, "extra-only child output was invalid JSON: {$output}");
-		$this->assertSame([], $result['data'] ?? NULL, 'a timed-out extra-only read must return an empty ledger');
-		$this->assertTrue($result['unavailable'] ?? FALSE, 'a timed-out extra-only read must report unavailable');
+		$this->assertArrayHasKey('due', $result, 'extra-only child must report the due-read result');
+		$this->assertNull($result['due'], 'a timed-out extra-only due read must return no entry');
+		$this->assertTrue($result['due_unavailable'] ?? FALSE, 'a timed-out extra-only due read must report unavailable');
+		$this->assertSame([], $result['sync'] ?? NULL, 'a timed-out extra-only sync read must return an empty ledger');
+		$this->assertTrue($result['sync_unavailable'] ?? FALSE, 'a timed-out extra-only sync read must report unavailable');
+		$this->assertTrue($result['callback_ran'] ?? FALSE, 'a timed-out extra-only sync lock must run its callback');
 	}
 
 	/**

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -758,6 +758,44 @@ final class PfbSyncStatusLedgerTest extends TestCase
 	// two read-modify-write callers (open/close) failing closed on it.
 	// -----------------------------------------------------------------------
 
+	public function testExtraOnlyLockTimeoutDoesNotRequireMain(): void
+	{
+		$dataPath = $this->dir . '/pfb_sync_status.json';
+		file_put_contents($dataPath, '{}');
+		$holder = fopen($dataPath, 'c');
+		$this->assertNotFalse($holder, 'test fixture must open the sync-status data file');
+		$this->assertTrue(flock($holder, LOCK_EX), 'test fixture must hold the sync-status data lock');
+
+		$extraPath = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+		$childCode = <<<'PHP'
+require $argv[1];
+if (function_exists('pfb_logger') || !function_exists('logger')) {
+	exit(3);
+}
+$unavailable = FALSE;
+$data = pfb_sync_status_read_all($argv[2], 0.05, $unavailable);
+echo json_encode(['data' => $data, 'unavailable' => $unavailable], JSON_THROW_ON_ERROR), "\n";
+PHP;
+		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([PHP_BINARY, '-r', $childCode, $extraPath, $this->dir], $descriptors, $pipes);
+		$this->assertIsResource($process, 'test fixture must launch an extra-only child process');
+		stream_set_timeout($pipes[1], 5);
+		stream_set_timeout($pipes[2], 5);
+		$output = stream_get_contents($pipes[1]);
+		$errors = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$exitCode = proc_close($process);
+		flock($holder, LOCK_UN);
+		fclose($holder);
+
+		$this->assertSame(0, $exitCode, "extra-only child failed: {$errors}");
+		$result = json_decode($output, TRUE);
+		$this->assertIsArray($result, "extra-only child output was invalid JSON: {$output}");
+		$this->assertSame([], $result['data'] ?? NULL, 'a timed-out extra-only read must return an empty ledger');
+		$this->assertTrue($result['unavailable'] ?? FALSE, 'a timed-out extra-only read must report unavailable');
+	}
+
 	/**
 	 * read_all()'s $unavailable discriminates: TRUE only on a genuine
 	 * lock-acquire expiry against the DATA file (pfb_sync_status.json) itself --

--- a/tests/test_bounded_flock.py
+++ b/tests/test_bounded_flock.py
@@ -6,7 +6,7 @@ five flock() acquires that violated that premise -- plain blocking LOCK_EX/LOCK_
 calls with no LOCK_NB and no deadline, so a wedged holder (a crashed writer that
 never released, a stuck NFS mount, ...) hung the caller forever. All five were
 rewritten to go through the shared bounded helper (pfb_flock_bounded() in
-pfblockerng.inc), which ORs in LOCK_NB itself and polls against a wall-clock
+pfblockerng_extra.inc), which ORs in LOCK_NB itself and polls against a wall-clock
 deadline.
 
 This module scans the SHIPPED source tree (scan roots: every ``*.inc``/``*.php``


### PR DESCRIPTION
## Summary

- relocate the existing bounded `flock()` helper into `pfblockerng_extra.inc`, which owns every direct caller
- keep the main-loaded `pfb_logger()` path while falling back to `extra.inc`'s native logger on three direct-include timeout branches
- add a frozen, hard-deadline extra-only subprocess regression test and correct the bounded-flock source-location test note

## Root cause and scope

`pfblockerng.inc` loaded `pfblockerng_extra.inc` before defining `pfb_flock_bounded()`. Supported direct consumers can load `extra.inc` without the main file, so the widget-ledger render reached `pfb_sync_status_locked()` with no helper definition and fatally exited. The same exposure covered five lock call sites. Three timeout branches also called the main-only `pfb_logger()`.

The repair moves the existing helper byte-for-byte into `extra.inc`, before its first use, and removes the original definition. It does not make `extra.inc` include the main file: that would invert the deliberate main-to-extra load relationship, create cycle/order risk, and drag the main file's pfSense bootstrap into lightweight direct consumers. Updating every consumer would have the same dependency cost; duplicating the helper would add declaration and drift risk; a new shared loader would add unnecessary packaging surface.

The timeout branches retain `pfb_logger()` whenever the main file is loaded and otherwise use the existing `logger(LOG_ERR, ...)` fallback. Moving all of `pfb_logger()` was rejected because its dependency tree remains main-owned; using only the native logger would change normal package log routing.

## Direct-include and sibling audit

Production WWW pages and the widget controller load `pfblockerng.inc` first. The production firewall-alias pre-write hook loads `extra.inc` directly, but its alias-rename path is self-contained. Direct-extra smoke helpers exercise the due and sync ledgers and therefore exposed this defect.

Source enumeration found 26 functions called by `extra.inc` whose definitions were only in the main file before this change. `pfb_flock_bounded()` was reachable on normal direct-ledger paths and is relocated. `pfb_logger()` was reachable on three direct-ledger timeout paths and is guarded. The other 24 are confined to main-loaded page or CLI entry points: `pfb_file_mtime`, `pfb_port_alias_types`, `pfb_exclude_alias_types`, `pfb_alias_type`, `pfb_feed_pass_busy`, `pfb_filter`, `pfblockerng_ss_refresh`, `pfb_ip_apply_retry`, `pfb_dnsbl_apply_retry`, `pfb_update_pass_running`, `pfb_log_mgmt`, `pfb_strip`, `pfb_is_empty`, `pfb_pfctl_op_failed`, `pfb_pfctl_error_message`, `pfb_feed_pass_acquire`, `pfb_feed_pass_release`, `pfb_text_area_encode`, `pfb_create_suppression_file`, `pfb_unlock`, `pfb_unbound_py_atomic_write_root`, `pfb_is_blank`, `pfb_sanitize_text_area`, and `pfb_python_interpreter`.

## Test evidence

- Live RED on untouched devel: `local-100037-1785748418-8c25cc2f687055bf` — 7 selected; 5 failed, 2 passed, 1 teardown error; undefined `pfb_flock_bounded()` fatal
- Frozen local RED: child exit 255 at the undefined helper; final test hash `f80379b162135cb532a947728cf1d01f3d1ef071`
- Frozen local GREEN: same test and hash; 1 test, 16 assertions passed
- Mechanical red proof: `FREEZE-OK`, `RED-OK`, `GREEN-OK`, `VERDICT: PASS`
- Focused suites: 32 PHPUnit tests / 122 assertions; 4 due-ledger timeout tests / 14 assertions; 4 bounded-flock pytest cases
- Canonical `scripts/agent/run-gates.sh --diff origin/devel`: PASS (pytest, Ruff check/format, mypy, vendor check, PHP lint, PHPUnit, PHPStan, PHPCS)
- Focused live GREEN: `local-100036-1785751491-f0b3970ad4d4b97c` — 7 passed, 586 deselected
- Full live `ui_render`: `local-100032-1785751626-8e3e8f6b6f796f0f` — 198 passed, 395 deselected
- Independent implementation gate: PASS; extra-only, main-to-extra, extra-to-main, and all three real lock-timeout branches probed without fatal or duplicate declaration
- Review fixes: replaced ineffective pipe timeouts with a 5-second monotonic process deadline and SIGKILL/reap path; the child now holds and asserts all three direct-extra timeout branches

Fixes #2124

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary lock contention during synchronization and ledger operations.
  * Operations now respect bounded wait times and continue safely when locks remain unavailable.
  * Added fallback error logging to improve visibility when standard logging is unavailable.

* **Tests**
  * Added coverage for synchronization behavior when components are loaded independently.
  * Verified timeout responses, empty results, and callback execution under lock contention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->