### PR TITLE
pfblockerng: route Python through package wrapper

### DIFF
--- a/.agents/context/lang-python.md
+++ b/.agents/context/lang-python.md
@@ -6,9 +6,11 @@ Scope: writing or changing Python. Load when: any touched `*.py` file.
   new functions; no bare `except:` (`except Exception` minimum).
 - `pfb_unbound.py` runs in Unbound's Python loader — **stdlib only, no external deps**.
 - **No direct Python interpreter invocation ON the appliance.** There is no
-  `python`/`python3` symlink. Only `pfb_python_interpreter()` may construct the exact
-  versioned path from the installed package dependency; appliance consumers use that
-  resolver. Otherwise drive the box via PHP (`php`/`pfSsh.php`/`h.php_eval`) or POSIX sh.
+  `python`/`python3` symlink. Appliance consumers invoke
+  `/usr/local/pkg/pfblockerng/pfb_python.sh`, the only resolver allowed to construct the exact
+  versioned path from the installed package dependency. `pfb_python_interpreter()` delegates
+  to it for compatibility and test probes. Otherwise drive the box via PHP
+  (`php`/`pfSsh.php`/`h.php_eval`) or POSIX sh.
   Enforced by `scripts/check_appliance_python.py` (pre-commit + CI). Bare `python3` in
   dev/CI tooling under `scripts/` is fine — it names the developer's interpreter.
 - **Content hashing:** the Python side uses `hashlib.md5` for its own self-comparisons only,

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -231,8 +231,8 @@ if [ "$staged_php" = 1 ] || [ "$staged_xml" = 1 ]; then
 	fi
 fi
 
-# --- Forbid direct Python interpreter paths ON the pfSense appliance. Only the
-#     annotated dependency-derived construction in pfb_python_interpreter() is allowed. ---
+# --- Forbid direct Python interpreter paths ON the pfSense appliance. Consumers
+#     invoke pfb_python.sh, the sole dependency-derived resolver. ---
 if [ "$staged_py" = 1 ] || [ "$staged_php" = 1 ] || [ "$staged_sh" = 1 ]; then
 	if [ -n "$py_bin" ]; then
 		step 'no-direct-appliance-python'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,8 +249,8 @@ jobs:
         run: python3 scripts/check_noopener.py
 
       - name: Forbid direct Python paths on the pfSense appliance
-        # Only pfb_python_interpreter() may construct the dependency-derived versioned
-        # path. All appliance consumers use that resolver. Scans tracked src/ + tests.
+        # pfb_python.sh alone constructs the dependency-derived versioned path; all
+        # appliance consumers invoke that wrapper. Scans tracked src/ + tests.
         run: python3 scripts/check_appliance_python.py
 
       - name: Forbid hardcoded pfSense/FreeBSD version literals

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,10 @@ worktrees, landing, tests, issues, commits) carries over; *this package's mechan
 - Every change ships WITH its tests; no coverage theater (every test carries an assertion
   that fails on regression); a `www/` change carries the reachable UI coverage required by
   `.agents/policy/testing.md`.
-- No direct Python interpreter invocation ON the appliance. Only
-  `pfb_python_interpreter()` may derive the exact versioned path from the installed package
-  dependency; consumers use that resolver. Otherwise use PHP or POSIX sh. Shell is POSIX sh
+- No direct Python interpreter invocation ON the appliance. Consumers invoke
+  `/usr/local/pkg/pfblockerng/pfb_python.sh`; that wrapper alone derives the exact versioned
+  path from the installed package dependency. `pfb_python_interpreter()` delegates to the
+  wrapper for compatibility and test probes. Otherwise use PHP or POSIX sh. Shell is POSIX sh
   under strict ash/dash semantics.
 - Every registered config field goes through `PfbConfig` — never direct `config_*_path`.
 - No orphaned waits: harness-tracked work gets no timer; every untracked wait has a hard

--- a/scripts/check_appliance_python.py
+++ b/scripts/check_appliance_python.py
@@ -52,7 +52,7 @@ from pathlib import Path
 # scanned, so the literal here is harmless.
 _FORBIDDEN = "/usr/local/bin/python"
 _BARE_PYTHON = re.compile(r"(?<![A-Za-z0-9_./-])python3(?:\.[0-9]+)?(?=$|[\s\"'`;|&()<>\[\],])")
-_GUEST_SSH = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.ssh\s*\(")
+_GUEST_SSH = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\.ssh\s*\(")
 _SOURCE_EXTENSIONS = {"", ".html", ".inc", ".js", ".php", ".py", ".sh", ".xml"}
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -65,7 +65,7 @@ def _is_appliance_line(path: Path, line: str) -> bool:
     if path.suffix.lower() not in _SOURCE_EXTENSIONS:
         return False
     stripped = line.lstrip()
-    if not stripped or stripped.startswith(("#", "//", "/*", "*")) or "client_vm" in line:
+    if not stripped or stripped.startswith(("#", "//", "/*", "*")):
         return False
     try:
         relative = path.resolve().relative_to(_REPO_ROOT)
@@ -73,8 +73,9 @@ def _is_appliance_line(path: Path, line: str) -> bool:
         return True
     if relative.parts and relative.parts[0] == "src":
         return True
-    is_smoke_guest = relative.parts[:2] == ("tests", "smoke") and _GUEST_SSH.search(line) is not None
-    return is_smoke_guest and "client_vm.ssh" not in line
+    return relative.parts[:2] == ("tests", "smoke") and any(
+        match.group(1) != "client_vm" for match in _GUEST_SSH.finditer(line)
+    )
 
 
 def _tracked_files(roots: tuple[str, ...]) -> list[Path]:

--- a/scripts/check_appliance_python.py
+++ b/scripts/check_appliance_python.py
@@ -3,7 +3,7 @@
 
 PROBLEM
 -------
-pfSense ships ``python3.11`` but NO ``python3`` symlink, so a command that
+pfSense ships a versioned Python dependency but NO ``python3`` symlink, so a command that
 shells out to the interpreter on the box —
 
     vm.ssh(f"/usr/local/bin/python3 -c {snippet}")     # smoke test -> pfSense VM
@@ -15,13 +15,12 @@ no-ops and the surrounding logic proceeds on stale/empty state. This bit the
 ``apply_on_change`` and ``tick`` smoke modules — their ledger writes silently did
 nothing, leaving the tests passing or failing by accident of unrelated state.
 
-The package dependency does provide a versioned interpreter. Package code may
-construct that exact path only through the dependency resolver; all other
-appliance paths remain forbidden. Tests and ad-hoc appliance commands should use
-**PHP** (``/usr/local/bin/php`` / ``pfSsh.php``) or **POSIX sh** unless they are
-exercising the dependency-derived launcher.
+The package dependency does provide a versioned interpreter. Package code must
+invoke it through ``/usr/local/pkg/pfblockerng/pfb_python.sh``, which is the sole
+dependency resolver. Tests and ad-hoc appliance commands should use **PHP**
+(``/usr/local/bin/php`` / ``pfSsh.php``), **POSIX sh**, or that wrapper.
 
-This check is the mechanical backstop for that rule (CLAUDE.md, "Python"). It is
+This check is the mechanical backstop for that rule (AGENTS.md, "Python"). It is
 PREVENTATIVE — there are no offenders in shipped code today; it guards against
 re-introducing the footgun.
 
@@ -32,18 +31,16 @@ SCOPE (deliberately low false-positive)
   ``scripts/`` is dev/CI-host tooling (it runs on the developer's box, which DOES
   have ``python3``) and is intentionally NOT scanned.
 * Flags the literal appliance interpreter path ``/usr/local/bin/python`` (covers
-  ``python``, ``python3``, ``python3.11``, ...). The sole spawn-path exception is
-  the annotated dependency-derived construction in ``pfb_python_interpreter()``.
-  Bare ``python3`` is NOT flagged:
-  it legitimately names the dev-host / client-VM interpreter, and the appliance
-  footgun has always used the full path. The CLAUDE.md rule covers the rest as
-  human discipline.
+  ``python``, ``python3``, ``python3.11``, ...) everywhere in the scan roots.
+* Also flags bare ``python3`` and hardcoded ``python3.NN`` commands in shipped
+  source. Test-runner and client-VM commands remain outside that appliance rule.
 
 Exit status: 0 = clean, 1 = one or more violations (printed with file:line).
 """
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -53,24 +50,26 @@ from pathlib import Path
 # for this per-line scan (ADR-28). This file lives under scripts/, which is not
 # scanned, so the literal here is harmless.
 _FORBIDDEN = "/usr/local/bin/python"
-_DERIVED_CONSTRUCTION = "$interpreter = '/usr/local/bin/python' . $version; // appliance-python-ok: dependency-derived"
-_RESOLVER_PATH = "src/usr/local/pkg/pfblockerng/pfblockerng.inc"
+_BARE_PYTHON = re.compile(r"(?<![A-Za-z0-9_./-])python3(?:\.[0-9]+)?(?=$|[\s\"'`;|&()<>\[\],])")
+_SOURCE_EXTENSIONS = {"", ".html", ".inc", ".js", ".php", ".py", ".sh", ".xml"}
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Tracked-tree roots that run ON the appliance.
 _SCAN_ROOTS = ("src", "tests")
 
 
-def _is_resolver_path(path: Path) -> bool:
-    """True iff *path* IS the sole exempted resolver file, compared as a
-    normalized repo-relative path — not merely a string/suffix match, so a
-    same-named file nested elsewhere (e.g. ``nested/`` + this path) does not
-    inherit the exemption."""
+def _is_source_line(path: Path, line: str) -> bool:
+    """Return whether a line belongs to executable shipped source."""
+    if path.suffix.lower() not in _SOURCE_EXTENSIONS:
+        return False
+    stripped = line.lstrip()
+    if not stripped or stripped.startswith(("#", "//", "/*", "*")) or "client_vm" in line:
+        return False
     try:
         relative = path.resolve().relative_to(_REPO_ROOT)
     except (OSError, ValueError):
-        return False
-    return relative.as_posix() == _RESOLVER_PATH
+        return True
+    return bool(relative.parts) and relative.parts[0] == "src"
 
 
 def _tracked_files(roots: tuple[str, ...]) -> list[Path]:
@@ -94,8 +93,7 @@ def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
         except (OSError, UnicodeError):
             continue
         for lineno, line in enumerate(text.splitlines(), start=1):
-            allowed = _is_resolver_path(path) and line.strip() == _DERIVED_CONSTRUCTION
-            if _FORBIDDEN in line and not allowed:
+            if _FORBIDDEN in line or (_is_source_line(path, line) and _BARE_PYTHON.search(line)):
                 violations.append((path, lineno, line.strip()))
     return violations
 
@@ -110,7 +108,7 @@ def main(argv: list[str]) -> int:
         print(f"  {path}:{lineno}: {line}", file=sys.stderr)
     print(
         "\nThe appliance has no `python` or `python3` symlink. Use PHP/POSIX sh, "
-        "or the exact versioned interpreter returned by pfb_python_interpreter(). "
+        "or /usr/local/pkg/pfblockerng/pfb_python.sh. "
         'See AGENTS.md ("Python").',
         file=sys.stderr,
     )

--- a/scripts/check_appliance_python.py
+++ b/scripts/check_appliance_python.py
@@ -33,7 +33,8 @@ SCOPE (deliberately low false-positive)
 * Flags the literal appliance interpreter path ``/usr/local/bin/python`` (covers
   ``python``, ``python3``, ``python3.11``, ...) everywhere in the scan roots.
 * Also flags bare ``python3`` and hardcoded ``python3.NN`` commands in shipped
-  source. Test-runner and client-VM commands remain outside that appliance rule.
+  source and direct pfSense-guest SSH calls in the smoke suite. Test-runner and
+  client-VM commands remain outside that appliance rule.
 
 Exit status: 0 = clean, 1 = one or more violations (printed with file:line).
 """
@@ -51,6 +52,7 @@ from pathlib import Path
 # scanned, so the literal here is harmless.
 _FORBIDDEN = "/usr/local/bin/python"
 _BARE_PYTHON = re.compile(r"(?<![A-Za-z0-9_./-])python3(?:\.[0-9]+)?(?=$|[\s\"'`;|&()<>\[\],])")
+_GUEST_SSH = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.ssh\s*\(")
 _SOURCE_EXTENSIONS = {"", ".html", ".inc", ".js", ".php", ".py", ".sh", ".xml"}
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -58,8 +60,8 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SCAN_ROOTS = ("src", "tests")
 
 
-def _is_source_line(path: Path, line: str) -> bool:
-    """Return whether a line belongs to executable shipped source."""
+def _is_appliance_line(path: Path, line: str) -> bool:
+    """Return whether a line executes in shipped source or on a pfSense guest."""
     if path.suffix.lower() not in _SOURCE_EXTENSIONS:
         return False
     stripped = line.lstrip()
@@ -69,7 +71,10 @@ def _is_source_line(path: Path, line: str) -> bool:
         relative = path.resolve().relative_to(_REPO_ROOT)
     except (OSError, ValueError):
         return True
-    return bool(relative.parts) and relative.parts[0] == "src"
+    if relative.parts and relative.parts[0] == "src":
+        return True
+    is_smoke_guest = relative.parts[:2] == ("tests", "smoke") and _GUEST_SSH.search(line) is not None
+    return is_smoke_guest and "client_vm.ssh" not in line
 
 
 def _tracked_files(roots: tuple[str, ...]) -> list[Path]:
@@ -93,7 +98,7 @@ def find_violations(paths: list[Path]) -> list[tuple[Path, int, str]]:
         except (OSError, UnicodeError):
             continue
         for lineno, line in enumerate(text.splitlines(), start=1):
-            if _FORBIDDEN in line or (_is_source_line(path, line) and _BARE_PYTHON.search(line)):
+            if _FORBIDDEN in line or (_is_appliance_line(path, line) and _BARE_PYTHON.search(line)):
                 violations.append((path, lineno, line.strip()))
     return violations
 

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -14,7 +14,9 @@ Two consumers share this ONE module instead of duplicating the literals:
 Stdlib only, no ``unboundmodule`` reference at module scope or in any
 function here -- import-safe standalone in a plain interpreter.
 
-Probe usage: pfb_python.sh pfb_dnsbl_regex_rules.py [1]
+Probe usage:
+  /usr/local/pkg/pfblockerng/pfb_python.sh \
+    /usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py [1]
   argv[1] == "1" enables the opt-in length cap (absent argv -> cap off).
   Reads regex-list lines from stdin; each rejected line is reported on
   stderr as ``line <n>: <pattern!r>: <message>``. Exits 1 if any line

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -14,7 +14,7 @@ Two consumers share this ONE module instead of duplicating the literals:
 Stdlib only, no ``unboundmodule`` reference at module scope or in any
 function here -- import-safe standalone in a plain interpreter.
 
-Probe usage: <pfb_python_interpreter()> pfb_dnsbl_regex_rules.py [1]
+Probe usage: pfb_python.sh pfb_dnsbl_regex_rules.py [1]
   argv[1] == "1" enables the opt-in length cap (absent argv -> cap off).
   Reads regex-list lines from stdin; each rejected line is reported on
   stderr as ``line <n>: <pattern!r>: <message>``. Exits 1 if any line

--- a/src/usr/local/pkg/pfblockerng/pfb_feed_normalize.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_feed_normalize.py
@@ -1,6 +1,6 @@
 """Detect a downloaded feed file's encoding and convert it to UTF-8 (issue #1797).
 
-Usage: <pfb_python_interpreter()> pfb_feed_normalize.py <src> <dst>
+Usage: pfb_python.sh pfb_feed_normalize.py <src> <dst>
 
 Runs only for files that already FAILED the iconv UTF-8 validity gate in
 pfb_feed_normalize_generate(); the caller never hands it valid UTF-8.

--- a/src/usr/local/pkg/pfblockerng/pfb_feed_normalize.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_feed_normalize.py
@@ -1,6 +1,8 @@
 """Detect a downloaded feed file's encoding and convert it to UTF-8 (issue #1797).
 
-Usage: pfb_python.sh pfb_feed_normalize.py <src> <dst>
+Usage:
+  /usr/local/pkg/pfblockerng/pfb_python.sh \
+    /usr/local/pkg/pfblockerng/pfb_feed_normalize.py <src> <dst>
 
 Runs only for files that already FAILED the iconv UTF-8 validity gate in
 pfb_feed_normalize_generate(); the caller never hands it valid UTF-8.

--- a/src/usr/local/pkg/pfblockerng/pfb_python.sh
+++ b/src/usr/local/pkg/pfblockerng/pfb_python.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# Resolve and execute pfBlockerNG's package-provided Python interpreter.
+#
+# Normal mode queries /usr/local/sbin/pkg for the installed
+# pfSense-pkg-pfBlockerNG, then reads its direct dependencies. The only
+# accepted direct dependency names are pyNN/pythonNN (NN is at least two
+# digits); module dependencies and ambiguous versions fail closed.
+#
+# --print-interpreter prints the resolved path for the PHP compatibility seam.
+# With PFB_PYTHON_DEPENDENCIES set (newline-separated direct dependencies),
+# this mode intentionally skips the executable check for off-box tests. Live
+# --print-interpreter and every execution require an executable interpreter.
+# PFB_PYTHON_DIR overrides /usr/local/bin; PFB_PKG_BIN overrides
+# /usr/local/sbin/pkg. These environment variables are test seams, not
+# appliance fallbacks.
+
+diag() {
+	printf '%s\n' "pfb_python.sh: $*" >&2
+}
+
+fail() {
+	diag "$1"
+	exit 1
+}
+
+trim() {
+	_pfb_trim_value=$1
+	_pfb_trim_value=${_pfb_trim_value#"${_pfb_trim_value%%[![:space:]]*}"}
+	_pfb_trim_value=${_pfb_trim_value%"${_pfb_trim_value##*[![:space:]]}"}
+	printf '%s' "${_pfb_trim_value}"
+}
+
+print_mode=0
+if [ "$#" -gt 0 ] && [ "$1" = '--print-interpreter' ]; then
+	print_mode=1
+	shift
+fi
+
+if [ "$print_mode" -eq 1 ] && [ "$#" -gt 0 ]; then
+	fail 'usage: --print-interpreter takes no arguments'
+fi
+
+python_dir=${PFB_PYTHON_DIR:-/usr/local/bin}
+dependencies_set=0
+if [ "${PFB_PYTHON_DEPENDENCIES+x}" = x ]; then
+	dependencies_set=1
+	dependencies=${PFB_PYTHON_DEPENDENCIES}
+else
+	pkg_bin=${PFB_PKG_BIN:-/usr/local/sbin/pkg}
+	pkg_names=$(
+		"${pkg_bin}" query -g '%n' 'pfSense-pkg-pfBlockerNG*' 2>/dev/null
+	)
+	pkg_status=$?
+	if [ "${pkg_status}" -ne 0 ]; then
+		fail "package-name query failed (expected pfSense-pkg-pfBlockerNG stable/devel/nightly via ${pkg_bin})"
+	fi
+
+	pkg_name=''
+	while IFS= read -r candidate || [ -n "${candidate}" ]; do
+		candidate_lc=$(printf '%s' "${candidate}" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+		case "${candidate_lc}" in
+			pfsense-pkg-pfblockerng|pfsense-pkg-pfblockerng-devel|pfsense-pkg-pfblockerng-nightly)
+				pkg_name=${candidate}
+				break
+				;;
+		esac
+	done <<EOF
+${pkg_names}
+EOF
+	if [ -z "${pkg_name}" ]; then
+		fail "no valid pfBlockerNG package (expected stable/devel/nightly, got ${pkg_names:-none})"
+	fi
+
+	dependencies=$(
+		"${pkg_bin}" query '%dn' "${pkg_name}" 2>/dev/null
+	)
+	dep_status=$?
+	if [ "${dep_status}" -ne 0 ]; then
+		fail "dependency query failed for ${pkg_name} (expected direct pyNN/pythonNN dependencies)"
+	fi
+fi
+
+version=''
+version_count=0
+while IFS= read -r raw_dependency || [ -n "${raw_dependency}" ]; do
+	dependency=$(trim "${raw_dependency}")
+	case "${dependency}" in
+		py[0-9][0-9]*|python[0-9][0-9]*)
+			case "${dependency}" in
+				python*) digits=${dependency#python} ;;
+				py*) digits=${dependency#py} ;;
+			esac
+			case "${digits}" in
+				''|*[!0-9]*) continue ;;
+			esac
+			major=${digits%"${digits#?}"}
+			minor=${digits#?}
+			candidate_version=${major}.${minor}
+			if [ -z "${version}" ]; then
+				version=${candidate_version}
+				version_count=1
+			elif [ "${version}" != "${candidate_version}" ]; then
+				version_count=2
+			fi
+			;;
+	esac
+done <<EOF
+${dependencies}
+EOF
+
+if [ "${version_count}" -ne 1 ]; then
+	fail "expected exactly one pyNN/pythonNN dependency, got ${dependencies:-none}"
+fi
+
+interpreter=${python_dir%/}/python${version}
+if [ "${print_mode}" -eq 1 ] && [ "${dependencies_set}" -eq 1 ]; then
+	printf '%s\n' "${interpreter}"
+	exit 0
+fi
+
+if [ ! -x "${interpreter}" ]; then
+	fail "interpreter is not executable (expected ${interpreter})"
+fi
+
+if [ "${print_mode}" -eq 1 ]; then
+	printf '%s\n' "${interpreter}"
+	exit 0
+fi
+
+if exec "${interpreter}" "$@"; then
+	:
+else
+	status=$?
+	diag "failed to execute interpreter ${interpreter}"
+	exit "${status}"
+fi

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1358,13 +1358,13 @@ function pfb_feed_normalize_generate(string $src, string $dst, ?string $interpre
 
 
 // issue #1797: detect + convert a non-UTF-8 feed file to UTF-8 via
-// pfb_feed_normalize.py (charset_normalizer, a RUN_DEPENDS). The interpreter
-// comes ONLY from pfb_python_interpreter() on the appliance ($interpreter is
-// a test seam). U+FFFD replacements reported by the script are logged: a high
+// pfb_feed_normalize.py (charset_normalizer, a RUN_DEPENDS). The wrapper
+// resolves the interpreter on the appliance ($interpreter is a test seam).
+// U+FFFD replacements reported by the script are logged: a high
 // count means the detection was probably wrong, and silence here would be
 // silent data corruption.
 function pfb_feed_convert_encoding(string $src, string $dst, ?string $interpreter = NULL): bool {
-	$py = $interpreter ?? pfb_python_interpreter();
+	$py = $interpreter ?? PFB_PYTHON_WRAPPER;
 	if ($py === '') {
 		return FALSE;
 	}
@@ -4597,6 +4597,10 @@ function pfb_should_notify(?string $installed, ?string $latest, ?string $last_no
  */
 define('PFB_PKG_BIN', '/usr/local/sbin/pkg');
 
+if (!defined('PFB_PYTHON_WRAPPER')) {
+	define('PFB_PYTHON_WRAPPER', __DIR__ . '/pfb_python.sh');
+}
+
 /*
  * The installed pfBlockerNG package NAME (e.g. 'pfSense-pkg-pfBlockerNG-devel'), read
  * from `pkg query '%n'` filtered to our prefix; '' when not installed via pkg or the
@@ -4622,11 +4626,9 @@ function pfb_pkg_installed_name(): string {
 }
 
 /*
- * Resolve the package-provided Python interpreter. Direct dependencies use either
- * py311 or python311 naming; module dependencies such as py311-sqlite3 are ignored.
- * A supplied dependency list is a pure off-box/test path. The live path reads the
- * installed package's direct dependencies once and fails closed when the resulting
- * versioned interpreter is not executable.
+ * Resolve the package-provided Python interpreter through the single POSIX wrapper.
+ * A supplied dependency list is a pure off-box/test path marshalled into the
+ * wrapper. The live path invokes the wrapper once and caches success or failure.
  */
 function pfb_python_interpreter(?array $dependencies = null): string {
 	$live_lookup = $dependencies === null;
@@ -4635,38 +4637,26 @@ function pfb_python_interpreter(?array $dependencies = null): string {
 		if ($live_result !== null) {
 			return $live_result;
 		}
-		$pkgname = pfb_pkg_installed_name();
-		if ($pkgname === '') {
-			return $live_result = '';
-		}
-		$dependencies = array();
-		$ret = -1;
-		exec(escapeshellarg(PFB_PKG_BIN) . " query '%dn' " . escapeshellarg($pkgname) . ' 2>/dev/null', $dependencies, $ret);
-		if ($ret !== 0) {
-			return $live_result = '';
-		}
 	}
 
-	$versions = array();
-	foreach ($dependencies as $dependency) {
-		if (!is_string($dependency)
-			|| preg_match('/^(?:py|python)([0-9]+)$/', trim($dependency), $match) !== 1
-			|| strlen($match[1]) < 2) {
-			continue;
+	$env = '';
+	if (!$live_lookup) {
+		$marshalled = array();
+		foreach ($dependencies as $dependency) {
+			if (is_string($dependency)) {
+				$marshalled[] = $dependency;
+			}
 		}
-		$version = $match[1][0] . '.' . substr($match[1], 1);
-		$versions[$version] = TRUE;
+		$env = 'PFB_PYTHON_DEPENDENCIES=' . escapeshellarg(implode("\n", $marshalled)) . ' ';
 	}
-	if (count($versions) !== 1) {
+	$output = array();
+	$ret = -1;
+	exec($env . escapeshellarg(PFB_PYTHON_WRAPPER) . ' --print-interpreter 2>/dev/null', $output, $ret);
+	if ($ret !== 0 || !isset($output[0])) {
 		return $live_lookup ? ($live_result = '') : '';
 	}
-
-	$version = (string) array_key_first($versions);
-	$interpreter = '/usr/local/bin/python' . $version; // appliance-python-ok: dependency-derived
-	if ($live_lookup && !is_executable($interpreter)) {
-		return $live_result = '';
-	}
-	return $interpreter;
+	$interpreter = trim((string) $output[0]);
+	return $live_lookup ? ($live_result = $interpreter) : $interpreter;
 }
 
 /*
@@ -5159,8 +5149,7 @@ function pfb_hook_script_valid($script, $when, $dir = null) {
 
 /*
  * Build the command for an allow-listed hook. Python hooks are dispatched through
- * the package's versioned interpreter because appliances do not promise a python3
- * symlink; shell hooks retain their direct execution/shebang behavior.
+ * the package wrapper; shell hooks retain their direct execution/shebang behavior.
  */
 function pfb_hook_script_command(string $script, string $path, string $python): string {
 	if (str_ends_with($script, '.py')) {
@@ -5480,11 +5469,11 @@ function pfb_run_hooks($when, $ctx = array()) {
 		}
 		$path = PFB_HOOK_SCRIPT_DIR . '/' . basename($script);
 		if (str_ends_with($script, '.py') && $python === null) {
-			$python = pfb_python_interpreter();
+			$python = pfb_python_interpreter() !== '' ? PFB_PYTHON_WRAPPER : '';
 		}
 		$hookcmd = pfb_hook_script_command($script, $path, (string) $python);
 		if ($hookcmd === '') {
-			pfb_logger("[ pfB Hook ] {$when} {$label} script '{$script}' has no usable Python interpreter; skipping\n", 2);
+			pfb_logger("[ pfB Hook ] {$when} {$label} script '{$script}' has no usable launcher; skipping\n", 2);
 			continue;
 		}
 
@@ -5496,7 +5485,7 @@ function pfb_run_hooks($when, $ctx = array()) {
 		// Run the vetted script as root under timeout(1): SIGTERM at $timeout,
 		// SIGKILL after the grace period. The PFB_* context rides the env prefix
 		// (the script reads it from the environment). Shell scripts run via their own
-		// shebang + execute bit; Python scripts use the dependency-derived interpreter.
+		// shebang + execute bit; Python scripts use the package wrapper.
 		//
 		// Two independent reasons a hook that (re)starts a daemon -- e.g. the documented
 		// HAProxy graceful-reload recipe -- would otherwise hang the WHOLE pass for the

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -338,8 +338,8 @@ dnsbl_cache() {
 	dnsblarchive="${dnsblarchive:-/usr/local/etc/pfb_dnsbl_cache.tar}"
 	pathtar="${pathtar:-/usr/bin/tar}"
 
-	# The shipped (static) DNSBL python files -- the ONE definition of the set.
-	PFB_PY_SHIPPED='pfb_dnsbl_regex_rules.py pfb_unbound.py pfb_unbound_include.inc pfb_py_hsts.txt'
+	# The shipped (static) DNSBL Python files + their launcher -- the ONE definition of the set.
+	PFB_PY_SHIPPED='pfb_dnsbl_regex_rules.py pfb_unbound.py pfb_unbound_include.inc pfb_py_hsts.txt pfb_python.sh'
 
 	dnsbl_cache_stage() {
 		mkdir -p "${pfbchroot}"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -6037,14 +6037,10 @@ function pfb_hook_editor_template(string $when, string $lang): string {
 		"  PFB_CHANGED_DNSBL_GROUPS -- space-separated DNSBL_* groups updated this pass\n";
 
 	if ($lang === 'py') {
-		// env-based, versioned shebang: pfSense ships python3.11 with NO unversioned
-		// 'python3' symlink, so a bare '#!/usr/bin/env python3' is an rc=127 footgun
-		// here -- the version must be spelled out. (This is a template string for a
-		// hook SCRIPT the OS execs directly via its own shebang -- not this package
-		// invoking an appliance interpreter itself; see scripts/check_appliance_python.py.)
-		$header = "#!/usr/bin/env python3.11\n" .
-			"# NOTE: verify the interpreter version above matches this box's installed python3\n" .
-			"# (pfSense CE ships python3.11 with no unversioned 'python3' symlink).\n";
+		// The hook runner invokes the package wrapper explicitly; this shebang keeps
+		// direct execution on the same resolver path.
+		$header = "#!/usr/local/pkg/pfblockerng/pfb_python.sh\n" .
+			"# The package wrapper resolves this box's installed Python dependency.\n";
 		$comment = "#\n# " . str_replace("\n", "\n# ", rtrim($contract)) . "\n#\n";
 		$body = "import os\n" .
 			"\n" .
@@ -6342,12 +6338,12 @@ function pfb_lint_diagnostics(
 		// sees them, so a long description warns without blocking a save.
 		'regex' => array_merge(
 			pfb_lint_parse_regex_errors(
-				pfb_dnsbl_regex_validation_errors($content, $python ?? pfb_python_interpreter(), $cap, $timeout_bin)
+				pfb_dnsbl_regex_validation_errors($content, $python ?? PFB_PYTHON_WRAPPER, $cap, $timeout_bin)
 			),
 			pfb_dnsbl_regex_description_warnings($content)
 		),
 		'sh' => pfb_lint_sh_diagnostics($content, $sh ?? '/bin/sh', $timeout_bin),
-		'py' => pfb_lint_py_diagnostics($content, $python ?? pfb_python_interpreter(), $timeout_bin),
+		'py' => pfb_lint_py_diagnostics($content, $python ?? PFB_PYTHON_WRAPPER, $timeout_bin),
 		default => [],
 	};
 }

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -724,11 +724,12 @@ if ($_POST) {
 		// no usable interpreter, pfb_unbound.py loads Regex List patterns solely when this
 		// toggle is on, so an unloaded list must not make the whole page unsavable.
 		$pfb_regex_python = pfb_python_interpreter();
+		$pfb_regex_ready = $pfb_regex_python !== '';
 		if (pfb_dnsbl_regex_validation_required_page(
-			$pfb_regex_python !== '' && is_executable($pfb_regex_python),
+			$pfb_regex_ready,
 			$_POST['pfb_regex'] ?? ''
 		)) {
-			foreach (pfb_dnsbl_regex_validation_errors((string) ($_POST['pfb_regex_list'] ?? ''), $pfb_regex_python, ($_POST['pfb_regex_cap'] ?? '') === 'on') as $regex_error) {
+			foreach (pfb_dnsbl_regex_validation_errors((string) ($_POST['pfb_regex_list'] ?? ''), PFB_PYTHON_WRAPPER, ($_POST['pfb_regex_cap'] ?? '') === 'on') as $regex_error) {
 				$input_errors[] = 'Customlist pfb_regex_list: ' . htmlspecialchars($regex_error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 			}
 		}

--- a/tests/php/HookEditorHelpersTest.php
+++ b/tests/php/HookEditorHelpersTest.php
@@ -261,7 +261,7 @@ final class HookEditorHelpersTest extends TestCase
 	public function testPythonTemplateHasPythonShebangAndHelloWorldUsesVar(): void
 	{
 		$tpl = pfb_hook_editor_template('post', 'py');
-		$this->assertStringStartsWith('#!', $tpl);
+		$this->assertStringStartsWith("#!/usr/local/pkg/pfblockerng/pfb_python.sh\n", $tpl);
 		$this->assertStringContainsString('import os', $tpl);
 		$this->assertStringContainsString("os.environ.get('PFB_WHEN')", $tpl);
 	}

--- a/tests/php/PythonRuntimeResolutionTest.php
+++ b/tests/php/PythonRuntimeResolutionTest.php
@@ -136,6 +136,8 @@ final class PythonRuntimeResolutionTest extends TestCase
 			$old_python_dir === FALSE ? putenv('PFB_PYTHON_DIR') : putenv('PFB_PYTHON_DIR=' . $old_python_dir);
 			@unlink($script);
 			@unlink($marker);
+			@unlink($python_dir . '/python3.11');
+			@rmdir($python_dir);
 			@rmdir($dir);
 		}
 	}

--- a/tests/php/PythonRuntimeResolutionTest.php
+++ b/tests/php/PythonRuntimeResolutionTest.php
@@ -9,8 +9,8 @@ use PHPUnit\Framework\TestCase;
 /**
  * Pins the appliance Python runtime boundary used by DNSBL validation and
  * update hooks. The package dependency is authoritative: py311/python311
- * selects the matching versioned interpreter, while module dependencies and
- * malformed or ambiguous versions must never be treated as the interpreter.
+ * selects the matching versioned interpreter through the shared wrapper, while
+ * module dependencies and malformed or ambiguous versions must never be treated as it.
  */
 #[CoversFunction('pfb_python_interpreter')]
 #[CoversFunction('pfb_hook_script_command')]
@@ -41,6 +41,9 @@ final class PythonRuntimeResolutionTest extends TestCase
 		return [
 			'py311' => [['py311']],
 			'python311' => [['python311']],
+			'whitespace is trimmed' => [['  py311  ']],
+			'duplicate aliases collapse' => [['py311', 'python311', 'py311-sqlite3']],
+			'non-string array member is ignored' => [[123, 'py311']],
 			'module dependency is not interpreter' => [['py311-sqlite3']],
 		];
 	}
@@ -60,6 +63,8 @@ final class PythonRuntimeResolutionTest extends TestCase
 			'ambiguous versions' => [['py311', 'python312']],
 			'malformed nonnumeric version' => [['python3x']],
 			'python dotted name is not package dependency' => [['python3.11']],
+			'one digit version is rejected' => [['py3']],
+			'whitespace-only dependency is ignored' => [['   ']],
 		];
 	}
 
@@ -69,14 +74,13 @@ final class PythonRuntimeResolutionTest extends TestCase
 		$this->assertSame('', pfb_python_interpreter($dependencies), json_encode($dependencies));
 	}
 
-	public function testPythonHookUsesVersionedInterpreterAndEscapedScriptPath(): void
+	public function testPythonHookUsesWrapperAndEscapedScriptPath(): void
 	{
-		$python = '/usr/local/bin/' . 'python3.11';
 		$path = '/usr/local/pkg/pfblockerng/hooks/hook_post_delta.py';
 
 		$this->assertSame(
-			escapeshellarg($python) . ' ' . escapeshellarg($path),
-			pfb_hook_script_command('hook_post_delta.py', $path, $python)
+			escapeshellarg(PFB_PYTHON_WRAPPER) . ' ' . escapeshellarg($path),
+			pfb_hook_script_command('hook_post_delta.py', $path, PFB_PYTHON_WRAPPER)
 		);
 	}
 
@@ -84,10 +88,7 @@ final class PythonRuntimeResolutionTest extends TestCase
 	{
 		$path = '/usr/local/pkg/pfblockerng/hooks/hook_post_delta.sh';
 
-		$this->assertSame(
-			escapeshellarg($path),
-			pfb_hook_script_command('hook_post_delta.sh', $path, '/usr/local/bin/' . 'python3.11')
-		);
+		$this->assertSame(escapeshellarg($path), pfb_hook_script_command('hook_post_delta.sh', $path, PFB_PYTHON_WRAPPER));
 	}
 
 	public function testPythonHookFailsClosedWhenInterpreterUnavailable(): void
@@ -116,14 +117,23 @@ final class PythonRuntimeResolutionTest extends TestCase
 			"Path({$python_marker}).write_text('ran\\n')\n"
 		);
 		chmod($script, 0600);
+		$python_dir = $dir . '/bin';
+		mkdir($python_dir, 0700);
+		$this->assertTrue(symlink(self::$python, $python_dir . '/python3.11'));
+		$old_dependencies = getenv('PFB_PYTHON_DEPENDENCIES');
+		$old_python_dir = getenv('PFB_PYTHON_DIR');
+		putenv('PFB_PYTHON_DEPENDENCIES=py311');
+		putenv('PFB_PYTHON_DIR=' . $python_dir);
 		try {
-			$command = pfb_hook_script_command('hook_post_invalid.py', $script, self::$python);
+			$command = pfb_hook_script_command('hook_post_invalid.py', $script, PFB_PYTHON_WRAPPER);
 			$output = [];
 			$status = -1;
 			exec($command . ' 2>&1', $output, $status);
 			$this->assertSame(0, $status, implode("\n", $output));
 			$this->assertSame("ran\n", file_get_contents($marker));
 		} finally {
+			$old_dependencies === FALSE ? putenv('PFB_PYTHON_DEPENDENCIES') : putenv('PFB_PYTHON_DEPENDENCIES=' . $old_dependencies);
+			$old_python_dir === FALSE ? putenv('PFB_PYTHON_DIR') : putenv('PFB_PYTHON_DIR=' . $old_python_dir);
 			@unlink($script);
 			@unlink($marker);
 			@rmdir($dir);

--- a/tests/php/PythonRuntimeResolutionTest.php
+++ b/tests/php/PythonRuntimeResolutionTest.php
@@ -35,7 +35,7 @@ final class PythonRuntimeResolutionTest extends TestCase
 		return trim($output[0]);
 	}
 
-	/** @return array<string, array{array<int, string>}> */
+	/** @return array<string, array{array<int, string|int>}> */
 	public static function supportedDependencyProvider(): array
 	{
 		return [

--- a/tests/shell/pfb_python_spec.sh
+++ b/tests/shell/pfb_python_spec.sh
@@ -1,0 +1,132 @@
+#shellcheck shell=sh
+# pfb_python.sh resolver/exec contract. The dependency and pkg seams keep every
+# row off-appliance while preserving strict POSIX argument and failure behavior.
+
+Describe 'pfb_python.sh'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbpy.XXXXXX")"
+    bindir="${work}/bin"
+    mkdir -p "${bindir}"
+    marker="${work}/args"
+    wrapper="${PFB_PKGDIR}/pfb_python.sh"
+    cat > "${bindir}/python3.11" <<EOF
+#!/bin/sh
+printf '<%s>\n' "\$1" "\$2" "\$3" > "${marker}"
+EOF
+    chmod +x "${bindir}/python3.11"
+  }
+
+  cleanup() {
+    rm -rf "${work}"
+  }
+
+  run_print() {
+    PFB_PYTHON_DEPENDENCIES="${deps}" PFB_PYTHON_DIR="${bindir}" "${wrapper}" --print-interpreter
+  }
+
+  run_args() {
+    PFB_PYTHON_DEPENDENCIES="${deps}" PFB_PYTHON_DIR="${bindir}" "${wrapper}" "$@"
+  }
+
+  run_invalids() {
+    for deps in '' '   ' 'python3x' 'python3.11' 'py3' "$(printf 'py311\npython312')"; do
+      if PFB_PYTHON_DEPENDENCIES="${deps}" PFB_PYTHON_DIR="${bindir}" "${wrapper}" --print-interpreter 2>&1; then
+        return 1
+      fi
+    done
+  }
+
+  It 'resolves py/python aliases with whitespace and module rows collapsed'
+    setup
+    deps="$(printf '  py311  \npython311\npy311-sqlite3\n')"
+    When call run_print
+    The output should equal "${bindir}/python3.11"
+    The status should be success
+    cleanup
+  End
+
+  It 'rejects empty, malformed, one-digit, and ambiguous dependency lists'
+    setup
+    When call run_invalids
+    The status should be success
+    The output should include 'expected exactly one pyNN/pythonNN dependency'
+    cleanup
+  End
+
+  It 'executes with spaces, shell metacharacters, and glob arguments byte-preserved'
+    setup
+    deps='py311'
+    When call run_args 'a b' '$(touch should-not-run)' '*.txt'
+    The status should be success
+    The contents of file "${marker}" should equal "$(printf '<a b>\n<$(touch should-not-run)>\n<*.txt>\n')"
+    The path 'should-not-run' should not be exist
+    cleanup
+  End
+
+  It 'accepts the first valid stable/devel/nightly package after unknown names'
+    setup
+    pkg="${work}/pkg"
+    cat > "${pkg}" <<EOF
+#!/bin/sh
+if [ "\$2" = '-g' ]; then
+  printf '%s\n' 'unknown-package' 'PFSENSE-PKG-PFBLOCKERNG-devel'
+else
+  [ "\$3" = 'PFSENSE-PKG-PFBLOCKERNG-devel' ] || exit 1
+  printf '%s\n' 'python311'
+fi
+EOF
+    chmod +x "${pkg}"
+    When run env PFB_PKG_BIN="${pkg}" PFB_PYTHON_DIR="${bindir}" "${wrapper}" --print-interpreter
+    The output should equal "${bindir}/python3.11"
+    The status should be success
+    cleanup
+  End
+
+  It 'fails clearly for package query, dependency query, and missing package failures'
+    setup
+    pkg="${work}/pkg"
+    cat > "${pkg}" <<'EOF'
+#!/bin/sh
+case "$PFB_PKG_TEST_MODE:$2" in
+  names-fail:-g) exit 7 ;;
+  deps-fail:-g) printf '%s\n' 'pfSense-pkg-pfBlockerNG'; exit 0 ;;
+  deps-fail:*) exit 8 ;;
+  none:-g) printf '%s\n' 'unknown-package'; exit 0 ;;
+esac
+EOF
+    chmod +x "${pkg}"
+    run_pkg_failures() {
+      for mode in names-fail deps-fail none; do
+        if PFB_PKG_TEST_MODE="${mode}" PFB_PKG_BIN="${pkg}" "${wrapper}" --print-interpreter 2>&1; then
+          return 1
+        fi
+      done
+    }
+    When call run_pkg_failures
+    The status should be success
+    The output should include 'package-name query failed'
+    The output should include 'dependency query failed'
+    The output should include 'no valid pfBlockerNG package'
+    cleanup
+  End
+
+  It 'requires a live derived interpreter to be executable'
+    setup
+    pkg="${work}/pkg"
+    cat > "${pkg}" <<'EOF'
+#!/bin/sh
+if [ "$2" = '-g' ]; then
+  printf '%s\n' 'pfSense-pkg-pfBlockerNG-nightly'
+else
+  printf '%s\n' 'py311'
+fi
+EOF
+    chmod +x "${pkg}"
+    empty_dir="${work}/empty"
+    mkdir -p "${empty_dir}"
+    When run env PFB_PKG_BIN="${pkg}" PFB_PYTHON_DIR="${empty_dir}" "${wrapper}" --print-interpreter
+    The status should be failure
+    The stderr should include 'interpreter is not executable'
+    cleanup
+  End
+End

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -48,6 +48,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     echo 'INC-CODE-v1' > "${pfbpkgdir}/pfb_unbound_include.inc"
     echo 'HSTS-v1' > "${pfbpkgdir}/pfb_py_hsts.txt"
     echo 'WRAPPER-CODE-v1' > "${pfbpkgdir}/pfb_python.sh"
+    chmod +x "${pfbpkgdir}/pfb_python.sh"
     # issue #1255: the TLD-Wildcard public-suffix oracle -- name-mapped (source
     # basename 'dnsbl_tld', chroot copy 'pfb_py_tld.txt'), NOT in PFB_PY_SHIPPED
     # (whose same-basename cp -f loop cannot rename).
@@ -93,7 +94,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     The path "${pfbchroot}/pfb_dnsbl_regex_rules.py" should be exist
     The path "${pfbchroot}/pfb_unbound_include.inc" should be exist
     The path "${pfbchroot}/pfb_py_hsts.txt" should be exist
-    The path "${pfbchroot}/pfb_python.sh" should be exist
+    The path "${pfbchroot}/pfb_python.sh" should be executable
     The path "${pfbchroot}/pfb_py_tld.txt" should be exist
     # The mount-point dirs exist (the fresh-MFS fix).
     The path "${pfbchroot}/lib" should be directory

--- a/tests/shell/pfblockerng_dnsbl_cache_spec.sh
+++ b/tests/shell/pfblockerng_dnsbl_cache_spec.sh
@@ -47,6 +47,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     echo 'RULES-CODE-v1' > "${pfbpkgdir}/pfb_dnsbl_regex_rules.py"
     echo 'INC-CODE-v1' > "${pfbpkgdir}/pfb_unbound_include.inc"
     echo 'HSTS-v1' > "${pfbpkgdir}/pfb_py_hsts.txt"
+    echo 'WRAPPER-CODE-v1' > "${pfbpkgdir}/pfb_python.sh"
     # issue #1255: the TLD-Wildcard public-suffix oracle -- name-mapped (source
     # basename 'dnsbl_tld', chroot copy 'pfb_py_tld.txt'), NOT in PFB_PY_SHIPPED
     # (whose same-basename cp -f loop cannot rename).
@@ -92,6 +93,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     The path "${pfbchroot}/pfb_dnsbl_regex_rules.py" should be exist
     The path "${pfbchroot}/pfb_unbound_include.inc" should be exist
     The path "${pfbchroot}/pfb_py_hsts.txt" should be exist
+    The path "${pfbchroot}/pfb_python.sh" should be exist
     The path "${pfbchroot}/pfb_py_tld.txt" should be exist
     # The mount-point dirs exist (the fresh-MFS fix).
     The path "${pfbchroot}/lib" should be directory
@@ -111,6 +113,7 @@ Describe 'pfblockerng.sh dnsbl_cache (#468)'
     The path "${pfbchroot}/pfb_unbound.py" should not be exist
     The path "${pfbchroot}/pfb_unbound_include.inc" should not be exist
     The path "${pfbchroot}/pfb_py_hsts.txt" should not be exist
+    The path "${pfbchroot}/pfb_python.sh" should not be exist
     The path "${pfbchroot}/pfb_py_tld.txt" should not be exist
     cleanup_sandbox
   End

--- a/tests/smoke/test_smoke_lint_probe.py
+++ b/tests/smoke/test_smoke_lint_probe.py
@@ -118,11 +118,10 @@ _PY_PATH_CLOSE = "<<<PFBPYEND>>>"
 
 
 def _guest_python(vm: SmokeVM) -> str:
-    """The package Python on the guest, via the canonical dependency resolver.
+    """The package Python wrapper on the guest, cross-checked with PHP.
 
-    ``pfb_python_interpreter()`` is the SAME resolver the lint endpoint uses —
-    the appliance ships no unversioned ``python3``, and the no-appliance-python
-    rule forbids constructing the path any other way.  Runs through
+    ``pfb_python_interpreter()`` is the PHP readiness resolver; the wrapper is
+    the SAME launcher the lint endpoint uses. Runs through
     ``helpers.php_eval`` (pfSsh.php, the fully-bootstrapped pfSense shell): a
     bare ``php -r`` require of ``pfblockerng.inc`` dies in pfSense's own error
     handler with exit 0, so the path is delimited the same way
@@ -130,7 +129,7 @@ def _guest_python(vm: SmokeVM) -> str:
     """
     snippet = (
         'require_once("/usr/local/pkg/pfblockerng/pfblockerng.inc"); '
-        f'echo "{_PY_PATH_OPEN}" . pfb_python_interpreter() . "{_PY_PATH_CLOSE}";'
+        f'echo "{_PY_PATH_OPEN}" . pfb_python_interpreter() . "\\n" . PFB_PYTHON_WRAPPER . "{_PY_PATH_CLOSE}";'
     )
     result = h.php_eval(vm, snippet, timeout=120)
     out = result.stdout
@@ -139,9 +138,23 @@ def _guest_python(vm: SmokeVM) -> str:
     assert result.returncode == 0 and start != -1 and end != -1, (
         f"pfb_python_interpreter() resolution failed: rc={result.returncode} stdout={out!r} stderr={result.stderr!r}"
     )
-    path = out[start + len(_PY_PATH_OPEN) : end].strip()
-    assert path, f"pfb_python_interpreter() returned an empty path: stdout={out!r}"
-    return path
+    resolved, wrapper = out[start + len(_PY_PATH_OPEN) : end].strip().splitlines()
+    assert resolved, f"pfb_python_interpreter() returned an empty path: stdout={out!r}"
+    assert wrapper, f"PFB_PYTHON_WRAPPER was empty: stdout={out!r}"
+    wrapper_result = vm.ssh(
+        f"printf %s {_PY_PATH_OPEN!r}; {shlex.quote(wrapper)} --print-interpreter; printf %s {_PY_PATH_CLOSE!r}",
+        timeout=120,
+    )
+    wrapped_out = wrapper_result.stdout
+    wrapped_start = wrapped_out.find(_PY_PATH_OPEN)
+    wrapped_end = wrapped_out.find(_PY_PATH_CLOSE)
+    assert wrapper_result.returncode == 0 and wrapped_start != -1 and wrapped_end != -1, (
+        f"pfb_python.sh --print-interpreter failed: rc={wrapper_result.returncode} "
+        f"stdout={wrapped_out!r} stderr={wrapper_result.stderr!r}"
+    )
+    wrapped = wrapped_out[wrapped_start + len(_PY_PATH_OPEN) : wrapped_end].strip()
+    assert wrapped == resolved, f"PHP resolver {resolved!r} differs from wrapper {wrapped!r}"
+    return wrapper
 
 
 def test_py_compile_probe_valid_script_is_silent_and_zero(deployed_vm: SmokeVM) -> None:

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -3083,6 +3083,25 @@ def test_pfblockerng_download_extras_uses_typed_download_result() -> None:
     )
 
 
+def test_dnsbl_regex_save_uses_package_python_wrapper() -> None:
+    """Pin the POST-only validator path that a Tier-A GET cannot execute.
+
+    PHP may probe ``pfb_python_interpreter()`` for readiness, but the validator
+    itself must invoke the package wrapper so interpreter selection stays in one
+    implementation.
+    """
+    source_path = helpers.SMOKE_DIR.parent.parent / "src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php"
+    source = source_path.read_text(encoding="utf-8")
+    block = source.split("// A usable validator always runs", 1)[1].split("// Validate DNSBL VIP address", 1)[0]
+
+    assert "$pfb_regex_python = pfb_python_interpreter();" in block
+    assert re.search(
+        r"pfb_dnsbl_regex_validation_errors\(\(string\).*?,\s*PFB_PYTHON_WRAPPER,",
+        block,
+        flags=re.DOTALL,
+    ), "DNSBL regex save validation must execute through PFB_PYTHON_WRAPPER"
+
+
 def test_pfblockerng_tick_delegates_safesearch_to_due_ledger() -> None:
     """Pin the CLI-only tick dispatch that Tier-A HTTP rendering cannot execute."""
     source_path = helpers.SMOKE_DIR.parent.parent / "src/usr/local/www/pfblockerng/pfblockerng.php"

--- a/tests/test_appliance_python_check.py
+++ b/tests/test_appliance_python_check.py
@@ -1,6 +1,6 @@
 """Tests for scripts/check_appliance_python.py.
 
-Per CLAUDE.md's test-coverage rule, every flagged case is paired with the correct
+Per AGENTS.md's test-coverage rule, every flagged case is paired with the correct
 form that must stay clean, so a green proves the check DISCRIMINATES (the appliance
 interpreter path is rejected) rather than always firing or never firing.
 
@@ -49,35 +49,27 @@ def test_flags_any_literal_interpreter_path(tmp_path: Path) -> None:
         assert _find(tmp_path, line), f"/usr/local/bin/{suffix} should be flagged"
 
 
-def test_dependency_derived_interpreter_construction_is_allowed(
+def test_dependency_derived_interpreter_construction_is_rejected(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The exemption is repo-root-anchored, not a suffix match, so anchor _REPO_ROOT at
-    # tmp_path to exercise it without touching the real repo tree.
     monkeypatch.setattr(cap, "_REPO_ROOT", tmp_path.resolve())
     prefix = "/usr/local/bin/" + "python"
     line = f"    $interpreter = '{prefix}' . $version; // appliance-python-ok: dependency-derived\n"
     relative_path = "src/usr/local/pkg/pfblockerng/pfblockerng.inc"
-    assert _find(tmp_path, line, relative_path) == [], "resolver's dependency-derived construction must be allowed"
+    assert _find(tmp_path, line, relative_path), "only the shell wrapper may construct the interpreter path"
 
 
-def test_resolver_path_with_dot_segments_still_exempt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Normalization must not break the legitimate case: an absolute path to the real
-    # resolver file, spelled with "./" and "../" segments, still resolves to it.
+def test_resolver_path_with_dot_segments_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cap, "_REPO_ROOT", tmp_path.resolve())
     prefix = "/usr/local/bin/" + "python"
     line = f"    $interpreter = '{prefix}' . $version; // appliance-python-ok: dependency-derived\n"
     real = tmp_path / "src/usr/local/pkg/pfblockerng/pfblockerng.inc"
     real.parent.mkdir(parents=True, exist_ok=True)
     real.write_text(line, encoding="utf-8")
-    # "other" must exist for the OS to traverse the literal path: without it the read
-    # raises FileNotFoundError, find_violations skips the file, and the assertion below
-    # would pass without the exemption ever being consulted.
+    # "other" must exist so the OS can traverse the literal path.
     (tmp_path / "src/usr/local/pkg/other").mkdir(parents=True, exist_ok=True)
     non_normalized = tmp_path / "src/usr/local/pkg/other/../pfblockerng/./pfblockerng.inc"
-    assert cap.find_violations([non_normalized]) == [], (
-        "a non-normalized (./,../) path to the resolver must stay exempt"
-    )
+    assert cap.find_violations([non_normalized]), "the PHP resolver has no construction exemption"
 
 
 def test_annotation_does_not_allow_literal_interpreter(tmp_path: Path) -> None:
@@ -138,6 +130,27 @@ def test_bare_python3_is_not_flagged(tmp_path: Path) -> None:
     # or scripts/ bench tooling on the dev box) — out of scope, must NOT be flagged.
     bare = '    client_vm.ssh("python3 /tmp/tcp_rst_probe.py 2.0")\n'
     assert _find(tmp_path, bare) == [], "bare python3 (dev/client) must not be flagged"
+
+
+def test_bare_python3_source_command_is_flagged(tmp_path: Path) -> None:
+    source = '    subprocess.run(["python3", "-c", snippet], check=True)\n'
+    violations = _find(tmp_path, source)
+    assert len(violations) == 1, f"bare appliance python3 source command must be flagged; got {violations}"
+
+
+def test_hardcoded_versioned_python_source_command_is_flagged(tmp_path: Path) -> None:
+    source = '    subprocess.run(["python3.11", script], check=True)\n'
+    violations = _find(tmp_path, source)
+    assert len(violations) == 1, f"hardcoded versioned python source command must be flagged; got {violations}"
+
+
+def test_comment_only_python_mentions_are_not_flagged(tmp_path: Path) -> None:
+    assert _find(tmp_path, "# documentation mentions python3 and python3.11\n") == []
+
+
+def test_wrapper_invocation_is_not_flagged(tmp_path: Path) -> None:
+    wrapper = '    subprocess.run(["/usr/local/pkg/pfblockerng/pfb_python.sh", script], check=True)\n'
+    assert _find(tmp_path, wrapper) == []
 
 
 def test_unbound_embedded_loader_not_flagged(tmp_path: Path) -> None:

--- a/tests/test_appliance_python_check.py
+++ b/tests/test_appliance_python_check.py
@@ -138,6 +138,7 @@ def test_bare_python3_client_vm_is_not_flagged(tmp_path: Path, monkeypatch: pyte
     [
         '    vm.ssh("python3 -c x")\n',
         '    smoke_vm.ssh("python3.11 -c x")\n',
+        '    vm.ssh("python3 -c x")  # unlike client_vm\n',
     ],
 )
 def test_bare_python_guest_ssh_in_smoke_is_flagged(

--- a/tests/test_appliance_python_check.py
+++ b/tests/test_appliance_python_check.py
@@ -125,11 +125,33 @@ def test_clean_php_is_not_flagged(tmp_path: Path) -> None:
     assert _find(tmp_path, clean) == [], "PHP via php_eval must stay clean"
 
 
-def test_bare_python3_is_not_flagged(tmp_path: Path) -> None:
+def test_bare_python3_client_vm_is_not_flagged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Bare `python3` names the dev-host / client-VM interpreter (e.g. the civm tcp probe,
     # or scripts/ bench tooling on the dev box) — out of scope, must NOT be flagged.
+    monkeypatch.setattr(cap, "_REPO_ROOT", tmp_path.resolve())
     bare = '    client_vm.ssh("python3 /tmp/tcp_rst_probe.py 2.0")\n'
-    assert _find(tmp_path, bare) == [], "bare python3 (dev/client) must not be flagged"
+    assert _find(tmp_path, bare, "tests/smoke/probe.py") == [], "client-VM python3 must not be flagged"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        '    vm.ssh("python3 -c x")\n',
+        '    smoke_vm.ssh("python3.11 -c x")\n',
+    ],
+)
+def test_bare_python_guest_ssh_in_smoke_is_flagged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    monkeypatch.setattr(cap, "_REPO_ROOT", tmp_path.resolve())
+    violations = _find(tmp_path, command, "tests/smoke/probe.py")
+    assert len(violations) == 1, f"pfSense guest Python command must be flagged; got {violations}"
+
+
+def test_bare_python_dev_host_command_in_smoke_is_not_flagged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cap, "_REPO_ROOT", tmp_path.resolve())
+    command = '    subprocess.run(["python3", "tool.py"], check=True)\n'
+    assert _find(tmp_path, command, "tests/smoke/probe.py") == []
 
 
 def test_bare_python3_source_command_is_flagged(tmp_path: Path) -> None:

--- a/tests/test_dnsbl_chroot_teardown_contract.py
+++ b/tests/test_dnsbl_chroot_teardown_contract.py
@@ -15,6 +15,7 @@ STATIC_CHROOT_FILES = (
     "pfb_unbound.py",
     "pfb_unbound_include.inc",
     "pfb_py_hsts.txt",
+    "pfb_python.sh",
     "pfb_py_tld.txt",
 )
 

--- a/tests/test_feed_normalize_script.py
+++ b/tests/test_feed_normalize_script.py
@@ -1,7 +1,7 @@
 """pfb_feed_normalize.py (issue #1797): detection + conversion contract.
 
 Runs the shipped script under the DEV interpreter (sys.executable — dev/CI
-tooling; the appliance reaches it only through pfb_python_interpreter()).
+tooling; the appliance reaches it only through the ``pfb_python.sh`` package wrapper).
 Skips when charset_normalizer is not installed in the dev environment.
 """
 


### PR DESCRIPTION
## Summary

- ship `/usr/local/pkg/pfblockerng/pfb_python.sh` as the sole package-dependency-to-interpreter resolver and argument-preserving launcher
- make `pfb_python_interpreter()` delegate to the wrapper while preserving its injected dependency seam and cached live result
- route every current package caller, generated Python hook shebang, and invocation header through the wrapper
- update the appliance-Python checker, chroot staging, tests, and canonical policy text

## Resolver direction

The shell wrapper owns package discovery, direct-dependency parsing, interpreter selection, executable validation, and `exec`. PHP delegates to `pfb_python.sh --print-interpreter`; it keeps only the compatibility API, injected-list marshalling, and the existing live-result cache. This keeps one resolver usable from every language without duplicating the version-selection rules.

Converted callers:

- `pfblockerng.inc`: feed normalization and Python hook execution
- `pfblockerng_extra.inc`: DNSBL-regex lint and Python lint
- `pfblockerng_dnsbl.php`: DNSBL-regex save validation (the PHP resolver remains only as the readiness probe)
- generated Python hook shebangs
- `pfb_feed_normalize.py` and `pfb_dnsbl_regex_rules.py` invocation documentation

The devel and nightly ports already install every shipped `*.sh` and generate their plist from the staged tree. The exact-head live package build installed and executed the wrapper. The stable port remains pinned to v3.2.15, which does not carry this new file.

## Policy authorization

Owner directive authorizing the `AGENTS.md` never-list change:

> Nowadays, we should be able to turn pfb_python_interpreter() into a shell script we call to call python from anywhere. This is a general improvement to implement right now (ask GPT to do it, and have it also update all sites that call python using pfb_python_interpreter() now to replace with the shell script python wrapper).

Landed wording:

> No direct Python interpreter invocation ON the appliance. Consumers invoke `/usr/local/pkg/pfblockerng/pfb_python.sh`; that wrapper alone derives the exact versioned path from the installed package dependency. `pfb_python_interpreter()` delegates to the wrapper for compatibility and test probes. Otherwise use PHP or POSIX sh. Shell is POSIX sh under strict ash/dash semantics.

## Verification

- four frozen RED -> GREEN proofs: resolver/checker, generated-hook template, DNSBL UI call-site contract, and hostile guest-command guard
- `scripts/agent/run-gates.sh --diff origin/devel`
- explicit `dash` ShellSpec: 24 focused examples; full gate 1,179 examples
- live `test_smoke_lint_probe.py` on production head `2156cffc`: 8 passed, including PHP/wrapper interpreter parity
- independent implementation gate: accepted
- top-tier independent review of `a1319bfd`: approved, no findings
- exact-head GitHub CI on `a1319bfd`: all required checks passed
- live Tier-A `ui_render` on production head `2156cffc`: 198 passed; the follow-up commit only adds its frozen call-site contract test

Fixes #2135

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
