### PR TITLE
tests: use writeSystem in CLI smoke fixtures

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2166,9 +2166,10 @@ def set_feed_internal_allowlist(vm: SmokeVM, value: str, *, timeout: float = 60.
 def set_feed_sanity(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     """Set the ADR-49 opt-in plain-text feed sanity scan (``pfb_feed_sanity``, default OFF).
 
-    Config-only knob (no www/ checkbox) -- written through the ADR-29 gateway
-    (``PfbConfig::write``), the same call a future UI save path would make. Gates
-    ``pfb_text_sanity()`` inside ``pfb_download()`` on accepted ``text/plain`` /
+    Config-only knob (no www/ checkbox) -- written through the ADR-29 gateway's
+    system-context entry point (``PfbConfig::writeSystem``): this helper runs from
+    ``pfSsh.php``, a no-session CLI caller, not a page-authorized UI save (issue #2071).
+    Gates ``pfb_text_sanity()`` inside ``pfb_download()`` on accepted ``text/plain`` /
     ``text/html`` / ``text/csv`` feeds: ON rejects a feed whose sampled body looks
     like an HTML error page / NUL-laden / near-empty (``stage=plaintext``); OFF
     (the default) never calls the scanner. Call BEFORE the reload under test --
@@ -2177,7 +2178,7 @@ def set_feed_sanity(vm: SmokeVM, on: bool, *, timeout: float = 60.0) -> None:
     value = "PfbToggle::On" if on else "PfbToggle::Off"
     snippet = (
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        f"PfbConfig::write('gen/pfb_feed_sanity', {value});\n"
+        f"PfbConfig::writeSystem('gen/pfb_feed_sanity', {value});\n"
         "write_config('pfBlockerNG smoke: set pfb_feed_sanity');\n"
         "echo 'OK';"
     )

--- a/tests/smoke/test_smoke_adr40.py
+++ b/tests/smoke/test_smoke_adr40.py
@@ -334,10 +334,12 @@ def test_adr40_content_gate_fires_on_change(adr40_vm: SmokeVM) -> None:
 
 
 def _set_delta_mode(vm: h.SmokeVM, mode: str, *, timeout: float = 60.0) -> None:
-    """Persist ``pfb_alias_delta_mode`` through ``PfbConfig::write``.
+    """Persist ``pfb_alias_delta_mode`` through ``PfbConfig::writeSystem``.
 
-    Mirrors the UI save path (pfblockerng_ip.php POST → PfbConfig::write).
-    The key is REGISTERED UNDER THE GENERAL SECTION (config/0), so the gateway
+    Runs from ``pfSsh.php``, a no-session CLI caller -- not the page-authorized
+    UI save path (pfblockerng_ip.php POST → PfbConfig::write), which enforces
+    a page privilege this fixture cannot present (issue #2071). The key is
+    REGISTERED UNDER THE GENERAL SECTION (config/0), so the gateway
     is the section-proof way to land it where ``PfbConfig::read`` looks: a
     hand-rolled ``config_set_path`` into CFG_IP_SETTINGS wrote a value
     production never read, so the apply path silently kept the box's own mode
@@ -352,7 +354,7 @@ def _set_delta_mode(vm: h.SmokeVM, mode: str, *, timeout: float = 60.0) -> None:
     """
     snippet = (
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        f"PfbConfig::write('gen/pfb_alias_delta_mode', {h._php_str(mode)});\n"
+        f"PfbConfig::writeSystem('gen/pfb_alias_delta_mode', {h._php_str(mode)});\n"
         "write_config('pfBlockerNG smoke: set pfb_alias_delta_mode');\n"
         "echo 'OK';"
     )

--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -122,11 +122,15 @@ def _write_ledger_entry(vm: SmokeVM, job_key: str, last_run: int, next_due: int,
 
 
 def _set_quiet_hours(vm: SmokeVM, window: str) -> None:
-    """Set pfb_quiet_hours in config.xml via pfSsh.php."""
-    # Use the config gateway rather than direct xml munging.
+    """Set pfb_quiet_hours in config.xml via pfSsh.php.
+
+    pfSsh.php is a no-session CLI caller, so this uses the config gateway's
+    system-context entry point (``PfbConfig::writeSystem``) rather than the
+    page-authorized ``write()`` a UI save would use (issue #2071).
+    """
     snippet = (
         f"require_once('{_PFB_EXTRA}');"
-        f"PfbConfig::write('gen/pfb_quiet_hours', {json.dumps(window)});"
+        f"PfbConfig::writeSystem('gen/pfb_quiet_hours', {json.dumps(window)});"
         "write_config('ADR-43 smoke: set quiet-hours');"
         "echo 'OK';"
     )

--- a/tests/smoke/test_smoke_apply_on_change.py
+++ b/tests/smoke/test_smoke_apply_on_change.py
@@ -126,7 +126,7 @@ def _set_quiet_hours(vm: SmokeVM, window: str) -> None:
 
     pfSsh.php is a no-session CLI caller, so this uses the config gateway's
     system-context entry point (``PfbConfig::writeSystem``) rather than the
-    page-authorized ``write()`` a UI save would use (issue #2071).
+    page-authorized ``PfbConfig::write()`` a UI save would use (issue #2071).
     """
     snippet = (
         f"require_once('{_PFB_EXTRA}');"

--- a/tests/smoke/test_top1m_fixed_file.py
+++ b/tests/smoke/test_top1m_fixed_file.py
@@ -344,13 +344,16 @@ def _runtime_state(vm: SmokeVM, *, root: str = "") -> dict:
 
 
 def _configure_top1m(vm: SmokeVM) -> None:
+    """Configure TOP1M via pfSsh.php -- a no-session CLI caller, hence writeSystem()
+    (the gateway's system-context entry point) rather than the page-authorized
+    writeSection() the DNSBL UI save uses (issue #2071)."""
     result = h.php_eval(
         vm,
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        "PfbConfig::write('dnsbl/top1m_enable', 'on');\n"
-        "PfbConfig::write('dnsbl/top1m_source', PfbTop1mSource::Tranco);\n"
-        "PfbConfig::write('dnsbl/top1m_count', '1');\n"
-        "PfbConfig::write('dnsbl/top1m_inclusion', 'com');\n"
+        "PfbConfig::writeSystem('dnsbl/top1m_enable', 'on');\n"
+        "PfbConfig::writeSystem('dnsbl/top1m_source', PfbTop1mSource::Tranco);\n"
+        "PfbConfig::writeSystem('dnsbl/top1m_count', '1');\n"
+        "PfbConfig::writeSystem('dnsbl/top1m_inclusion', 'com');\n"
         "write_config('pfBlockerNG #1542 smoke: enable deterministic TOP1M fixture');\n"
         "echo 'OK';",
     )
@@ -556,7 +559,7 @@ def test_top1m_fixed_file_publish_reload_cache_and_teardown(top1m_fixed_file_vm:
     teardown = _json_eval(
         vm,
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
-        "PfbConfig::write('gen/pfb_keep', PfbToggle::On);\n"
+        "PfbConfig::writeSystem('gen/pfb_keep', PfbToggle::On);\n"
         "write_config('pfBlockerNG #1542 smoke: keep-on callable teardown');\n"
         "pfb_global();\n"
         "$ok = pfb_unbound_py_teardown_raw_set();\n"

--- a/tests/smoke/test_top1m_fixed_file.py
+++ b/tests/smoke/test_top1m_fixed_file.py
@@ -344,9 +344,9 @@ def _runtime_state(vm: SmokeVM, *, root: str = "") -> dict:
 
 
 def _configure_top1m(vm: SmokeVM) -> None:
-    """Configure TOP1M via pfSsh.php -- a no-session CLI caller, hence writeSystem()
+    """Configure TOP1M via pfSsh.php -- a no-session CLI caller, hence PfbConfig::writeSystem()
     (the gateway's system-context entry point) rather than the page-authorized
-    writeSection() the DNSBL UI save uses (issue #2071)."""
+    PfbConfig::writeSection() the DNSBL UI save uses (issue #2071)."""
     result = h.php_eval(
         vm,
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"


### PR DESCRIPTION
## Summary

- use `PfbConfig::writeSystem()` from positive `pfSsh.php` smoke fixtures
- preserve the deliberate fail-closed `PfbConfig::write()` coverage
- correct helper documentation to distinguish CLI/system writes from page-authorized saves

## Root cause

Since #1895, `PfbConfig::write()` enforces the registered field’s page privilege. These fixtures execute through `pfSsh.php` without a web session, so their setup writes fatal before the behavioral assertions run. `writeSystem()` is the existing gateway entry point for those trusted system-context callers.

## Coverage

Tree-wide enumeration leaves bare `PfbConfig::write()` only in `tests/smoke/ui/test_general_scoped_operator.py`, where it is negative coverage proving the CLI include chain fails closed. Positive fixture rows changed:

- feed sanity
- ADR-40 alias delta mode
- apply-on-change quiet hours
- Top1M configuration and teardown

## Red → green evidence

```text
ADR-40 on devel:
1 failed, 952 deselected
PfbConfig: write of key 'gen/pfb_alias_delta_mode' requires page privilege

ADR-40 on branch:
1 passed, 952 deselected

Feed sanity on branch:
2 passed, 951 deselected

Apply-on-change on branch:
4 passed, 949 deselected

Top1M on branch:
1 passed, 952 deselected
```

## Verification

```text
scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: python3 -m pytest
GATE PASS: ruff check .
GATE PASS: ruff format --check .
GATE PASS: mypy tests/
GATES: PASS
```

Independent full-profile review found one documentation nit, applied before the final push; no remaining findings.

Fixes #2071

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
