### PR TITLE
release: define contextual release versions

### DIFF
--- a/.ADRs/ADR_09_Release_Version_Automation/ADR.md
+++ b/.ADRs/ADR_09_Release_Version_Automation/ADR.md
@@ -347,3 +347,12 @@ Nightly source is an explicit pinned source SHA (the pinned pfBlockerNG SHA) plu
 matrix/dependency digest; no branch inference selects it. The preceding amendment's `devel`
 wording remains historical compatibility context and does not define the current authoring
 contract.
+
+## Amendment — 2026-08-04: trailer and workflow clarification (issue #2140)
+
+The tag trailer carries only the channel. The exact configured `release/X.Y` line is derived
+from the tag and validated separately; a follower Edge reuses the Testing tag and its
+`testing` trailer. Current release and published-Release workflow consumers are updated for
+this contract. Nightly continues to use an explicit pinned source SHA. The preceding
+amendment's authoring-only and base-revision statements remain immutable historical context
+and no longer describe the implemented boundary.

--- a/.ADRs/ADR_09_Release_Version_Automation/ADR.md
+++ b/.ADRs/ADR_09_Release_Version_Automation/ADR.md
@@ -317,3 +317,26 @@ per UTC date and idempotent per source commit.
 The existing workflow remains a compatibility consumer through its first five shell-parser fields;
 issue #2143 owns its migration to canonical fields and generation. This amendment defines no
 publisher, workflow dispatch, branch discovery, or repository mutation.
+
+## Amendment — 2026-08-04: corrected channel and snapshot contract (issue #2140)
+
+The preceding issue #2140 amendment recorded a superseded shape. The authoring contract is
+corrected here; the accepted body and that earlier amendment remain immutable history.
+
+- Stable is `vX.Y.Z` / `X.Y.Z`. Testing is `vX.Y.Z.aN`, `vX.Y.Z.bN`, or `vX.Y.Z.rN`,
+  with the exact matching package version. Channel and configured `release/X.Y` line are
+  explicit and carried in an immutable tag trailer; channel is never inferred from a suffix.
+- Edge uses the same Testing grammar and follows Testing on one configured line. With no
+  distinct Edge target, reuse the exact Testing Release and artifact bytes, checksums, source,
+  provenance, tag, and notes. No rebuild or second Release is allowed. When its target becomes
+  Stable, Edge follows Testing until a new target is configured.
+- Nightly is an independent untagged `devel` snapshot. It creates no tag, GitHub Release, or
+  release notes. A changed input uses UTC `YYYYMMDD`, then `YYYYMMDD_1`, `_2`, and so on for
+  same-day changes; unchanged or skipped days are no-ops. Identity includes source SHA,
+  FreeBSD-ports SHA, and matrix/dependency digest.
+- The Ports recipe is static: no routine version commit, no target final, and no PORTEPOCH.
+  Bare date versions intentionally outrank semantic releases. Reverse movement requires an
+  explicit repo-qualified downgrade.
+
+This correction is authoring-only. Workflow implementation remains at the current base
+revision and later builder, publisher, catalog, and client issues own migration.

--- a/.ADRs/ADR_09_Release_Version_Automation/ADR.md
+++ b/.ADRs/ADR_09_Release_Version_Automation/ADR.md
@@ -330,9 +330,8 @@ corrected here; the accepted body and that earlier amendment remain immutable hi
   distinct Edge target, reuse the exact Testing Release and artifact bytes, checksums, source,
   provenance, tag, and notes. No rebuild or second Release is allowed. When its target becomes
   Stable, Edge follows Testing until a new target is configured.
-- Nightly is an independent untagged snapshot from an explicit pinned source SHA. It creates
-  no tag, GitHub Release, or release notes. A changed input uses UTC `YYYYMMDD`, then
-  `YYYYMMDD_1`, `_2`, and so on for
+- Nightly is an independent untagged `devel` snapshot. It creates no tag, GitHub Release, or
+  release notes. A changed input uses UTC `YYYYMMDD`, then `YYYYMMDD_1`, `_2`, and so on for
   same-day changes; unchanged or skipped days are no-ops. Identity includes source SHA,
   FreeBSD-ports SHA, and matrix/dependency digest.
 - The Ports recipe is static: no routine version commit, no target final, and no PORTEPOCH.
@@ -341,3 +340,10 @@ corrected here; the accepted body and that earlier amendment remain immutable hi
 
 This correction is authoring-only. Workflow implementation remains at the current base
 revision and later builder, publisher, catalog, and client issues own migration.
+
+## Amendment — 2026-08-04: branch-independent Nightly source clarification (issue #2140)
+
+Nightly source is an explicit pinned source SHA (the pinned pfBlockerNG SHA) plus the FreeBSD-ports SHA and
+matrix/dependency digest; no branch inference selects it. The preceding amendment's `devel`
+wording remains historical compatibility context and does not define the current authoring
+contract.

--- a/.ADRs/ADR_09_Release_Version_Automation/ADR.md
+++ b/.ADRs/ADR_09_Release_Version_Automation/ADR.md
@@ -330,8 +330,9 @@ corrected here; the accepted body and that earlier amendment remain immutable hi
   distinct Edge target, reuse the exact Testing Release and artifact bytes, checksums, source,
   provenance, tag, and notes. No rebuild or second Release is allowed. When its target becomes
   Stable, Edge follows Testing until a new target is configured.
-- Nightly is an independent untagged `devel` snapshot. It creates no tag, GitHub Release, or
-  release notes. A changed input uses UTC `YYYYMMDD`, then `YYYYMMDD_1`, `_2`, and so on for
+- Nightly is an independent untagged snapshot from an explicit pinned source SHA. It creates
+  no tag, GitHub Release, or release notes. A changed input uses UTC `YYYYMMDD`, then
+  `YYYYMMDD_1`, `_2`, and so on for
   same-day changes; unchanged or skipped days are no-ops. Identity includes source SHA,
   FreeBSD-ports SHA, and matrix/dependency digest.
 - The Ports recipe is static: no routine version commit, no target final, and no PORTEPOCH.

--- a/.ADRs/ADR_17_Pkg_Repository/ADR.md
+++ b/.ADRs/ADR_17_Pkg_Repository/ADR.md
@@ -468,3 +468,10 @@ Issue #2140 defines the version/classification and mutation-precondition seams o
 change this ADR's deployed catalogs. Issues #2144–#2147 own builder, publisher, and catalog
 migration; issue #2148 owns the client transition. Existing catalogs stay operational until those
 changes land.
+
+## Amendment — 2026-08-04: Nightly source identity is explicit (issue #2140)
+
+Nightly source identity is an explicit pinned pfBlockerNG SHA plus the FreeBSD-ports SHA and
+matrix/dependency digest; no branch inference selects the source. Earlier `devel` statements
+remain historical descriptions of the compatibility publication path and do not define the
+issue #2140 authoring contract.

--- a/.ADRs/ADR_18_Nightly_Channel/ADR.md
+++ b/.ADRs/ADR_18_Nightly_Channel/ADR.md
@@ -573,8 +573,8 @@ own that migration. Retention still provides availability, not downgrade support
 
 The preceding snapshot-rank amendment is historical and is superseded for release authoring by
 this correction; accepted text remains immutable. Nightly uses the exact package identity
-`pfSense-pkg-pfBlockerNG` and is an independent untagged `devel` snapshot. It creates no tag,
-GitHub Release, or release notes. A changed input uses UTC `YYYYMMDD`; another changed input on
+`pfSense-pkg-pfBlockerNG` and is an independent untagged snapshot from an explicit pinned source SHA.
+It creates no tag, GitHub Release, or release notes. A changed input uses UTC `YYYYMMDD`; another changed input on
 the same day uses `YYYYMMDD_1`, then `_2`, while an unchanged input or skipped day is a no-op.
 
 Nightly identity includes source SHA, FreeBSD-ports SHA, and matrix/dependency digest. The Ports

--- a/.ADRs/ADR_18_Nightly_Channel/ADR.md
+++ b/.ADRs/ADR_18_Nightly_Channel/ADR.md
@@ -568,3 +568,21 @@ same identifier when the same immutable source is retried.
 The package identity converges to `pfSense-pkg-pfBlockerNG`; the current `-nightly` package and
 publication path remain untouched in #2140. Builder/publisher/catalog/client issues #2144–#2148
 own that migration. Retention still provides availability, not downgrade support.
+
+## Amendment — 2026-08-04: independent Nightly input contract (issue #2140)
+
+The preceding snapshot-rank amendment is historical and is superseded for release authoring by
+this correction; accepted text remains immutable. Nightly uses the exact package identity
+`pfSense-pkg-pfBlockerNG` and is an independent untagged `devel` snapshot. It creates no tag,
+GitHub Release, or release notes. A changed input uses UTC `YYYYMMDD`; another changed input on
+the same day uses `YYYYMMDD_1`, then `_2`, while an unchanged input or skipped day is a no-op.
+
+Nightly identity includes source SHA, FreeBSD-ports SHA, and matrix/dependency digest. The Ports
+recipe is static: no routine version commit, no target final, and no PORTEPOCH. Bare date
+versions intentionally outrank semantic releases; reverse movement requires an explicit
+repo-qualified downgrade. Stable, Testing, and configured Edge own their tagged Release and
+notes contract; Edge follows Testing without rebuilding or creating a second Release when no
+distinct target exists.
+
+This amendment changes authoring semantics only. Existing `-nightly` package and publication
+implementation remain the compatibility surface until the follow-up migration issues land.

--- a/.ADRs/ADR_18_Nightly_Channel/ADR.md
+++ b/.ADRs/ADR_18_Nightly_Channel/ADR.md
@@ -573,8 +573,8 @@ own that migration. Retention still provides availability, not downgrade support
 
 The preceding snapshot-rank amendment is historical and is superseded for release authoring by
 this correction; accepted text remains immutable. Nightly uses the exact package identity
-`pfSense-pkg-pfBlockerNG` and is an independent untagged snapshot from an explicit pinned source SHA.
-It creates no tag, GitHub Release, or release notes. A changed input uses UTC `YYYYMMDD`; another changed input on
+`pfSense-pkg-pfBlockerNG` and is an independent untagged `devel` snapshot. It creates no tag,
+GitHub Release, or release notes. A changed input uses UTC `YYYYMMDD`; another changed input on
 the same day uses `YYYYMMDD_1`, then `_2`, while an unchanged input or skipped day is a no-op.
 
 Nightly identity includes source SHA, FreeBSD-ports SHA, and matrix/dependency digest. The Ports
@@ -586,3 +586,10 @@ distinct target exists.
 
 This amendment changes authoring semantics only. Existing `-nightly` package and publication
 implementation remain the compatibility surface until the follow-up migration issues land.
+
+## Amendment — 2026-08-04: branch-independent Nightly source clarification (issue #2140)
+
+Nightly source is an explicit pinned source SHA (the pinned pfBlockerNG SHA) plus the FreeBSD-ports SHA and
+matrix/dependency digest; no branch inference selects it. The preceding amendment's `devel`
+wording remains historical compatibility context and does not define the current authoring
+contract.

--- a/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/ADR.md
+++ b/.ADRs/ADR_27_Release_Rollback_And_EOL_Routing/ADR.md
@@ -383,3 +383,10 @@ Fixes start on the oldest affected maintained line and are cherry-picked with `-
 lines and then `devel`, each through its own PR and gates. This preserves linear history and does
 not create a downgrade path. Issue #2148 may add explicit cross-channel return behavior, but cannot
 generally supersede the no-downgrade contract without a separate owner decision.
+
+## Amendment — 2026-08-04: Nightly source identity is explicit (issue #2140)
+
+Nightly source identity is an explicit pinned pfBlockerNG SHA plus the FreeBSD-ports SHA and
+matrix/dependency digest; no branch inference selects the source. Earlier `devel` statements
+remain historical descriptions of the compatibility publication path and do not define the
+issue #2140 authoring contract.

--- a/.agents/context/release.md
+++ b/.agents/context/release.md
@@ -6,15 +6,14 @@ release, changing release workflows, or updating the publication path.
 Load this context when authoring a release, changing release workflows, or updating the
 Ports/package publication path. The authoring contract is issue #2140; the workflow at the
 current repository revision supplies the operational job names and inputs.
-The workflow state is current at `f6db736b`.
 
 ## Channel contract
 
 All channels publish the exact package identity `pfSense-pkg-pfBlockerNG`. Channel is
 metadata and catalog placement, not a package-name suffix. Channel is explicit and
-configured, carried in an immutable tag trailer, and never inferred from a tag suffix. The
-trailer key is `pfBlockerNG-Release-Channel: <stable|testing|edge>`; every operation uses a
-pinned source SHA.
+configured, and never inferred from a tag suffix. The tag trailer carries only the channel,
+using `pfBlockerNG-Release-Channel: <stable|testing|edge>`; the exact configured release line
+is validated separately. Every operation uses a pinned source SHA.
 
 | Channel | Source | Tag and package version | Release and notes |
 | --- | --- | --- | --- |

--- a/.agents/context/release.md
+++ b/.agents/context/release.md
@@ -42,7 +42,7 @@ input changes. Use UTC date `YYYYMMDD`; changed inputs on the same date receive
 The Ports recipe is static: publication must not make a routine version commit. Nightly has
 no target final and no PORTEPOCH. Bare date versions intentionally outrank semantic releases;
 reverse movement is an explicit repo-qualified downgrade, never an inferred fallback.
-Machine-readable contract marker: `bare date versions intentionally outrank semantic releases`.
+The ordering rule is that bare date versions intentionally outrank semantic releases.
 
 ## Publication boundaries
 

--- a/.agents/context/release.md
+++ b/.agents/context/release.md
@@ -12,17 +12,20 @@ The workflow state is current at `f6db736b`.
 
 All channels publish the exact package identity `pfSense-pkg-pfBlockerNG`. Channel is
 metadata and catalog placement, not a package-name suffix. Channel is explicit and
-configured, carried in an immutable tag trailer, and never inferred from a tag suffix.
+configured, carried in an immutable tag trailer, and never inferred from a tag suffix. The
+trailer key is `pfBlockerNG-Release-Channel: <stable|testing|edge>`; every operation uses a
+pinned source SHA.
 
 | Channel | Source | Tag and package version | Release and notes |
 | --- | --- | --- | --- |
 | Stable | configured `release/X.Y` | `vX.Y.Z` / `X.Y.Z` | final Release; authored notes |
 | Testing | configured `release/X.Y` | `vX.Y.Z.aN`, `.bN`, or `.rN` / exact version | prerelease; authored notes |
 | Edge | configured `release/X.Y` | same Testing grammar / exact version | follows Testing; authored notes |
-| Nightly | `devel` | untagged; date counter only | no GitHub Release; no release notes |
+| Nightly | explicit pinned source SHA | untagged; date counter only | no GitHub Release; no release notes |
 
-Stable, Testing, and Edge share one release-line target. Edge follows Testing when no
-distinct target is configured: mirror the exact existing Testing Release and artifact bytes,
+Stable, Testing, and Edge share one release-line target. Edge follows Testing only when no distinct target
+exists; distinct-target Edge uses its configured target/line. With no distinct
+target configured, mirror the exact existing Testing Release and artifact bytes,
 checksums, source, provenance, tag, and notes. Do not rebuild or create a second Release.
 When the target becomes Stable, Edge follows Testing until a new target exists.
 
@@ -37,8 +40,9 @@ input changes. Use UTC date `YYYYMMDD`; changed inputs on the same date receive
 - matrix/dependency digest.
 
 The Ports recipe is static: publication must not make a routine version commit. Nightly has
-no target final and no PORTEPOCH. bare date versions intentionally outrank semantic releases;
+no target final and no PORTEPOCH. Bare date versions intentionally outrank semantic releases;
 reverse movement is an explicit repo-qualified downgrade, never an inferred fallback.
+Machine-readable contract marker: `bare date versions intentionally outrank semantic releases`.
 
 ## Publication boundaries
 
@@ -57,7 +61,7 @@ must remain paired, and an existing identity may be retried only without rebuild
 Stable and Testing can coexist on every maintained `release/X.Y`; one explicitly configured
 line supplies Edge. Branch-name ordering never selects an Edge line. Fixes start on the oldest
 affected maintained line, then move forward with `git cherry-pick -x` through newer lines and
-finally `devel`, with separate PRs and gates.
+finally the configured development source, with separate PRs and gates.
 
 The self-hosted catalog keeps the exact package identity and records channel metadata outside
 the package name. EOL route-only behavior and unsupported downgrade policy remain unchanged;

--- a/.agents/context/release.md
+++ b/.agents/context/release.md
@@ -1,180 +1,70 @@
-# Branches and releases
+# Release channels and publication context
 
-Scope: channels, tag scheme, release pipeline, self-hosted pkg repo. Load when: cutting a
-release or touching `release.yml`, ports plumbing, or the pkg-repo publish path.
+Scope: release channels, tags, publication, and Ports/package context. Load when: authoring a
+release, changing release workflows, or updating the publication path.
 
-| Branch | Channel | Ships to |
-| ------ | ------- | -------- |
-| `main` | Stable | `net/pfSense-pkg-pfBlockerNG` |
-| `devel` | Development | `net/pfSense-pkg-pfBlockerNG-devel` |
+Load this context when authoring a release, changing release workflows, or updating the
+Ports/package publication path. The authoring contract is issue #2140; the workflow at the
+current repository revision supplies the operational job names and inputs.
+The workflow state is current at `f6db736b`.
 
-**Tag scheme (single source of truth: `scripts/release-version.sh`; behaviour pinned by
-`tests/test_release_version.py`).** Semver core `X.Y.Z`: pre-releases
-`vX.Y.Z.alpha.N`/`.beta.N`/`.rc.N` cut from **`devel` only** → GitHub pre-release (FreeBSD
-pkg orders the stage keywords natively below the bare release; the tag maps to `PORTVERSION`
-verbatim); stable `vX.Y.Z` from **`main` only** (typically the final rc's commit; `devel`
-then opens `X.(Y+1).0.alpha.1`). `release.yml` and `.githooks/pre-push` both consume the
-script, so the rule never drifts — `pre-push` only ever sees a tag pushed by hand, since the
-runner's checkout sets no `core.hooksPath`. A release is a **dispatch**, never a
-hand-pushed tag: one `release.yml` run builds, verifies, tags, drafts and finally bumps the
-port on our **`pfBlockerNG/FreeBSD-ports` fork** (self-hosted distribution, no upstream PR).
-See *Pipeline order* below. **Nightly builds get no GitHub Release.**
+## Channel contract
 
-## Pipeline order — build, verify, tag, DRAFT — then stop (issue #1855)
+All channels publish the exact package identity `pfSense-pkg-pfBlockerNG`. Channel is
+metadata and catalog placement, not a package-name suffix. Channel is explicit and
+configured, carried in an immutable tag trailer, and never inferred from a tag suffix.
 
-`release.yml` is one dispatch, one run, and it never publishes:
+| Channel | Source | Tag and package version | Release and notes |
+| --- | --- | --- | --- |
+| Stable | configured `release/X.Y` | `vX.Y.Z` / `X.Y.Z` | final Release; authored notes |
+| Testing | configured `release/X.Y` | `vX.Y.Z.aN`, `.bN`, or `.rN` / exact version | prerelease; authored notes |
+| Edge | configured `release/X.Y` | same Testing grammar / exact version | follows Testing; authored notes |
+| Nightly | `devel` | untagged; date counter only | no GitHub Release; no release notes |
 
-1. **`prepare-release`** (real only) — validate the tag↔channel scheme, refuse an already
-   **published** release, assert **CI green on the release commit** (`release-ci-gate.sh`,
-   walking past docs-only commits), **pin** the channel-branch tip as the release commit and
-   **mint the annotated tag on it locally**. *Nothing is pushed* — not the tag, not the
-   branch. Minting early is what turns a conflicting tag into a five-second failure instead
-   of an hour-long one.
-2. **Build + verify** — `resolve-stamp` / `build-pkgs-portable` (per-major `.pkg`s +
-   `extra_pkgs` dep packages) build **from the pinned SHA** as *workflow* artifacts, then
-   `ui-suite` / `smoke-suite` verify **those exact artifacts** (`pkg_artifact_prefix:
-   pfBlockerNG-relpkg`) **from that same source tree** (`checkout_ref`, issue #1859) — never
-   Release assets, so they need no tag and no Release.
-3. **`tag-release`** — the FIRST irreversible step: pushes the tag **on the pinned SHA** (not
-   on "the branch tip now"), gated on the build and, when they ran, on **both** suite
-   AND-gates.
-4. **`release` → `attach-pkgs` → `draft-healthcheck` → `sync-ports-fork`** — create the
-   Release as a **DRAFT** with a deterministic placeholder body, attach the assets, assert
-   the draft is complete, then bump the port's `PORTVERSION` on our FreeBSD-ports fork.
-   **The draft is the end state**: when the run finishes, the only things left are *write
-   the changelog* and *publish*.
+Stable, Testing, and Edge share one release-line target. Edge follows Testing when no
+distinct target is configured: mirror the exact existing Testing Release and artifact bytes,
+checksums, source, provenance, tag, and notes. Do not rebuild or create a second Release.
+When the target becomes Stable, Edge follows Testing until a new target exists.
 
-A failed run leaves **nothing** behind: no tag, no draft, nothing pushed to any branch —
-re-dispatch the same tag once the cause is fixed. `tag-release` is the single seam for the
-suite gate; everything after it inherits that transitively. The resume path is narrowed to
-the **crash-after-tag** window: a pre-existing tag on the pinned SHA is reused, a tag on any
-other commit is refused loudly and never moved.
-`tests/test_release_tag_after_verify.py` walks the whole `needs:` graph, so neither the
-pre-#1855 order nor an in-pipeline publish can come back silently.
+## Nightly identity and ordering
 
-**Which channels verify live.** `prekind` (from `release-version.sh`) decides:
-`alpha`/`beta` **skip** the live smoke/UI suites — the mandatory gate is the CI-green
-assertion above; `rc` and stable run them in full. One code path: for an alpha/beta the
-verification phase is simply empty, not a parallel pipeline. The `force_suites` dispatch
-input (default `false`) forces them on for an alpha/beta; it can only ever *add* verification.
+Nightly is independent of Stable, Testing, and Edge. Generate it only when the immutable
+input changes. Use UTC date `YYYYMMDD`; changed inputs on the same date receive
+`YYYYMMDD_1`, then `_2`. An unchanged input or skipped day is a no-op. Identity includes:
 
-**Which rows may veto.** A matrix row gates a release **iff its ci-metadata `status` is a
-released pfSense version** (`active`, or its legacy alias `GA`). Every other value — `beta`,
-anything added later, absent/unrecognized — is non-blocking: the leg still runs and still
-reports, emits a loud demotion warning naming the row and its status, and cannot fail the
-release. Predicate + warning live in `scripts/resolve-legs.sh`, switched on by the suites'
-`release_gate` input (release-only; PR/nightly gating is unchanged). Demoting rows one at a
-time is safe; demoting **all** of them is not — legs to run but not one able to veto makes
-the whole live phase advisory inside a green run, so that case is a hard `::error::` and a
-distinct **exit 3**, not a warning.
+- source SHA;
+- FreeBSD-ports SHA; and
+- matrix/dependency digest.
 
-**Dry-run** (`dry_run=true`, the default) builds and verifies off the **dispatch ref**, then
-stops: no tag, no Release, no push. `prepare-release` is skipped **wholesale**, so a dry run
-pins nothing (every downstream job falls back to the dispatch ref's HEAD) and gets none of
-that job's gates either: no CI-green assertion, no published-release refusal, no tag-state
-report, no early stale-tag conflict check, and `retag` does nothing at all — its only
-implementation lives inside the skipped job. What survives is the scheme check, at
-`read-matrix`'s `release-version.sh` classification, so a malformed tag still fails it.
+The Ports recipe is static: publication must not make a routine version commit. Nightly has
+no target final and no PORTEPOCH. bare date versions intentionally outrank semantic releases;
+reverse movement is an explicit repo-qualified downgrade, never an inferred fallback.
 
-**Re-cutting a tag that is already pushed** — `retag=true` (dispatch input, default
-`false`). The pin is the channel-branch tip, so a run that crashed *after* pushing its tag,
-on a branch that has since moved, would otherwise pin a new commit and reject its own tag as
-stale. `retag=true` deletes the existing tag first and re-cuts it on the freshly pinned tip.
-It is obeyed only when that is provably safe, and refuses loudly otherwise:
+## Publication boundaries
 
-| State of the tag's Release | `retag=true` does |
-| --- | --- |
-| **published** | **refuses** — a published Release is immutable; retagging cannot rescue it, cut the next `.N` |
-| **draft with assets** | **refuses** — assets do not prove a finished cut (`release` attaches the source archive before `attach-pkgs` adds the `.pkg`s), so it never deletes them: re-dispatch with `retag=false` to finish that draft, or delete it by hand to start over |
-| draft with no assets | deletes the draft **and** the tag (an orphaned draft would collide with this run's own) |
-| no Release | deletes the tag |
-| no tag at all | no-op |
+Stable, Testing, and Edge may create one Release per exact immutable tag and attach artifacts
+verified from that source. The release workflow creates the tag only after build/check gates
+pass and leaves a draft; `release-with-changelog` authors notes and publishes it. Nightly
+creates no tag, Release, or notes and must not enter the release-note path.
 
-This is the only place the pipeline removes anything from GitHub; it lives in
-`prepare-release` (the sole reason that job holds `contents: write`), runs before the pin,
-and never fires in a dry run.
+Use `scripts/release-version.sh` as the parser and validator. It receives the tag and explicit
+channel/source context; callers must not duplicate its grammar or guess a channel from a
+suffix. A published Release is immutable. Asset, checksum, source, and provenance identity
+must remain paired, and an existing identity may be retried only without rebuilding it.
 
-**One trust rule, wherever a release workflow executes a script:** anything run as shell
-comes from a second, sparse checkout pinned to `github.workflow_sha` (`pfblockerng-src/`) —
-the revision the workflow itself came from — never from the tree being released. That covers
-`release-version.sh` + `release-ci-gate.sh` in `prepare-release`, `release-version.sh` in the
-`release` job, `portrevision-rebuild.sh` in `sync-ports-fork`, and `release-version.sh` in
-`release-published.yml`'s `resolve`. It holds even where the job currently carries no
-credential worth stealing: the blast radius is a property of a job's present body, not of the
-design. The rule is mechanical rather than per-call — "this one runs before the branch reset,
-so it is fine" is what let two `contents: write` jobs execute the released tree's scripts.
-*Exempt by nature:* `build-pkgs-portable` and the live suites do run scripts out of the
-released tree, because building and testing that tree is the whole point; they hold no write
-credential and persist no checkout credentials. `read-matrix` classifies the tag from the
-dispatch ref's own tree, which is the trusted revision already.
+## Maintained lines and fixes
 
-## Release notes — authored onto the Release, never committed
+Stable and Testing can coexist on every maintained `release/X.Y`; one explicitly configured
+line supplies Edge. Branch-name ordering never selects an Edge line. Fixes start on the oldest
+affected maintained line, then move forward with `git cherry-pick -x` through newer lines and
+finally `devel`, with separate PRs and gates.
 
-**There are no release-notes files in this repository.** A committed changelog forces a
-changelog commit, which forces a push to the channel branch and a re-generation whenever
-`devel` moves — and the released source tree should not carry its own changelog. Past
-releases' bodies live on their GitHub Release pages; that is the record.
+The self-hosted catalog keeps the exact package identity and records channel metadata outside
+the package name. EOL route-only behavior and unsupported downgrade policy remain unchanged;
+retained artifacts provide availability and provenance, not a general downgrade guarantee.
 
-`release.yml` gives the draft a **deterministic placeholder body** ending in the compare link
-(`prev_tag` classifies each tag's channel via `release-version.sh` to find the previous
-same-channel release for that link) and the title `YYYY-MM-DD - VERSION` (ISO date prefixed
-so GitHub's alphabetical release sort stays chronological). In-pipeline LLM drafting is
-wanted but no free option has worked — GitHub Models was removed after never producing a
-working result (release run 30379645002); **do not add one**.
+## Scope
 
-The real notes and the final title are authored **onto the draft**, from the commit range,
-using the template in `scripts/release-notes-prompt.txt` (group user-facing changes under
-**Features / Improvements / Bug Fixes** with PR/issue links, CI/test/tooling/ADR noise
-filtered) — by a human, or by Claude via **`/release-with-changelog`**. Publishing the draft
-is that same step's last action.
-**Nightly builds get no GitHub Release.**
-
-## Publishing, and what it triggers
-
-Publishing is deliberately **outside** `release.yml` — but so is almost nothing else. The
-FreeBSD-ports `PORTVERSION` bump is the **terminal job of the release run**
-(`sync-ports-fork`, gated on `draft-healthcheck` and on `dry_run == 'false'`): a devel
-release bumps `-devel` and `-nightly` in one commit, and `GH_TAGNAME` is `v${PORTVERSION}`
-in the Makefile, so it self-resolves to the matching tag.
-
-The only thing that genuinely has to wait for the publish is **`repo-publish`** in
-**`.github/workflows/release-published.yml`** (`on: release: types: [published]`): it
-dispatches `pfBlockerNG/pkg`'s `publish.yml`, which enumerates this repo's **published**
-Releases and downloads their assets, so the new build appears at `pfblockerng.github.io/pkg`
-within seconds (its daily schedule is the backstop). Its `resolve` job still classifies the
-published tag and fails loudly, with the reason, on an off-scheme one.
-
-`pfBlockerNG/pkg` derives the **nightly** version from the `-nightly` port's `PORTVERSION`,
-so it must never read the fork before the bump lands. That used to be a `needs:` edge; it is
-now **structural** — the bump happens inside the release run, strictly before any publish can
-occur — and the reason is recorded in `release-published.yml` so nobody re-adds a dependency
-on a job that is no longer there.
-
-**Accepted cost:** a draft that is never published leaves the fork bumped to a version that
-never shipped. The bump *sets* the version rather than incrementing it, so the next release's
-bump overwrites it.
-
-## Self-hosted pkg repository (ADR-17)
-
-GitHub Pages repo (`pfblockerng.github.io/pkg`);
-repo `priority: 100` dominates version selection, so our build wins over Netgate's. **Hard
-rule (ADR-20): the catalog is keyed by *varver* (`ce-2.8` / `plus-26.03`), NOT by `${ABI}`**
-— an ABI is not 1:1 with a version/edition's `php`/`py3` build inputs; the incidental
-CE→FreeBSD15 / Plus→FreeBSD16 split is not a licence to key by ABI. **Never make that
-simplification.** Mechanics: below + architecture-notes "Self-hosted pkg
-distribution".
-
-### Mechanics
-
-Beyond the Netgate ports channel we publish a self-hosted FreeBSD `pkg` repository on GitHub
-Pages (`pfblockerng.github.io/pkg`; NONE-signed, TLS-anchored; a derived index rebuilt from
-**all** Releases each deploy). Cross-repo selection is keyed on repo **`priority:`** — it
-dominates version — so our `priority: 100` (set by `add-repo.sh`) makes `pkg install`/`upgrade`
-and the stock GUI Install pull our build over Netgate's. GUI discovery + the update badge stay
-Netgate-bound; a GUI "Updates/Channel" panel is deferred (ADR-19; would touch `src/`).
-
-Full varver/ABI rationale + live proof + upgrade-lag, the boot-time `rc.d` conf regenerator
-(ADR-39), the publish pipeline (the separate `pfBlockerNG/pkg` repo + its OIDC deploy), the
-generators + `add-repo.sh` bootstrap, and the `repo`-marker smoke flow:
-[`docs/misc/architecture-notes.md`](../../docs/misc/architecture-notes.md) ("Self-hosted pkg
-distribution").
+This context documents authoring and publication contracts only. It does not select branches,
+mutate catalogs, alter the on-box update client, or add release workflow mechanisms. Builder,
+publisher, catalog, and client migration work remains with the issue owners named by #2140.

--- a/.agents/skills/release-with-changelog/SKILL.md
+++ b/.agents/skills/release-with-changelog/SKILL.md
@@ -1,116 +1,53 @@
 ---
 name: release-with-changelog
 description: >
-  Cut a pfBlockerNG release END TO END: invoke /release <tag> (scheme validation +
-  workflow dispatch + wait for the run to reach the drafted state), then author the
-  release notes and title from the commit range using scripts/release-notes-prompt.txt,
-  write them onto the DRAFT Release, and publish it. Release notes are never files in
-  the repository — they are authored onto the Release itself, and publishing is what
-  fires the pkg-repo republish. This is the full path when
-  Claude is driving, and the one to use when the user says "write the changelog and
-  release", "release with notes", "cut and publish vX.Y.Z", or invokes
-  /release-with-changelog.
-  Args: <tag> (e.g. v4.0.0.alpha.1).
+  Finish a Stable, Testing, or configured Edge release after the release workflow
+  leaves a verified draft: author notes from the commit range, write them to the
+  draft, and publish after confirmation. Nightly has no Release or notes.
 ---
 
-You cut the release **and finish it**. `/release` gets you a complete DRAFT; this skill is
-that plus the finish step: author the notes + title, put them on the draft, publish.
+# Release with changelog
 
-The split is deliberate. `release.yml` deliberately stops at a draft — release notes are
-**not files in this repository** (a committed changelog forces a changelog commit, which
-forces a push to the channel branch and a re-generation whenever `devel` moves), and
-in-pipeline LLM drafting has no working free option, so a human or Claude writes them.
-Publishing the draft is what emits `release: published`, which fires
-`release-published.yml` (the pkg-repo republish; the FreeBSD-ports `PORTVERSION` bump is
-already done — it is the release run's terminal job).
+Use after `release` has produced a verified draft for Stable, Testing, or Edge. Nightly
+is an independent untagged snapshot with no GitHub Release and no release notes, so this
+skill must refuse a Nightly request.
 
-`scripts/release-notes-prompt.txt` is the authoring template — apply it by hand here.
-`scripts/release-version.sh` classifies the tag/channel. **Never re-implement `/release`'s
-dispatch mechanics**; delegate them.
+## Release contract
 
-## Arguments
+- Stable uses `vX.Y.Z` / `X.Y.Z`.
+- Testing uses `vX.Y.Z.aN`, `vX.Y.Z.bN`, or `vX.Y.Z.rN` with the exact matching package
+  version.
+- Edge uses the same Testing grammar and follows Testing on the configured release line.
+  Without a distinct Edge target, use the exact Testing Release and artifact bytes,
+  checksums, source, provenance, tag, and notes; this means the same Release and artifact
+  bytes, no second Release, and no rebuild.
+  When the target becomes Stable, continue following Testing until a new target exists.
 
-- `<tag>` — required, e.g. `v4.0.0.alpha.1` (must start with `v`).
+The channel is explicit and configured, and its value is carried in the immutable tag trailer;
+channel is never inferred from a suffix.
 
-## Steps
+The same Release and artifact bytes are reused when Edge follows Testing; no second Release
+or rebuild is permitted.
 
-1. **Cut the release — delegate to `/release`.** Invoke **`/release <tag>`**. It validates
-   the channel↔branch scheme, checks CI is green on the release commit, and **dispatches
-   `release.yml` with `dry_run=false`** — the workflow pins the channel-branch tip, builds
-   every `.pkg` from it, verifies them, pushes the tag on that pinned SHA, and leaves a
-   complete **DRAFT** Release. Wait for the run to reach that state and capture the draft
-   URL. If the run fails, stop: nothing was tagged or drafted, and the same tag can be
-   re-dispatched once the fix lands.
+## Notes procedure
 
-2. **Resolve the compare base (previous same-channel release).** Mirror `release.yml`'s
-   `prev_tag`: `git fetch origin --tags`; the highest-version tag of the **same channel** that
-   is an ancestor of the release commit (classify each candidate with `release-version.sh`),
-   falling back to the highest ancestor tag of any channel, then the next-lower version tag.
-   Call it `PREV`. The compare link is
-   `https://github.com/<owner>/<repo>/compare/<PREV>...<tag>` (or `…/commits/<tag>` when there
-   is no `PREV`) — the same link already sitting in the draft's placeholder body.
+1. Run the `release` skill first and wait for the draft. Confirm the draft URL, assets, and
+   immutable source identity.
+2. Resolve the previous same-channel tag from the current workflow's rules. Use the exact
+   commit range and omit internal tooling, tests, ADRs, and workflow mechanics from notes.
+3. Write concise `## Features`, `## Improvements`, and `## Bug Fixes` sections as needed.
+   Link only issue or PR numbers present in commit subjects. Keep the title date supplied
+   by the draft and add a short summary.
+4. Show the rendered title and notes for confirmation. Write them to the draft, read the
+   draft back, and verify every asset remains attached.
+5. Publish only after confirmation, using the workflow's channel flag. A published Release
+   is immutable; a mistake requires the next version.
 
-3. **Gather the commits the notes cover.**
-   `git log <PREV>..<tag> --no-merges --pretty='%h %s' -- src/ scripts/`.
-   When **no prior tag exists** (`PREV` empty — the very first release), drop the range:
-   `git log <tag> --no-merges --pretty='%h %s' -- src/ scripts/`.
-   For a **genesis release of a new series** (the first `X.0.0.alpha.1`, whose `PREV` is an
-   old-scheme tag), also describe the headline features of the whole series — the narrow
-   `PREV..<tag>` range alone undersells it; read prior Releases / ADR titles for the arc.
+Nightly input identity includes source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
+Its changed-input counter uses UTC `YYYYMMDD`, then `YYYYMMDD_1`/`_2` for same-day changes;
+unchanged or skipped days are no-ops. Keep its Ports recipe static: no routine version
+commit, no target final, and no PORTEPOCH. bare date versions intentionally outrank semantic
+releases; a reverse movement requires an explicit repo-qualified downgrade.
 
-4. **Author the notes by applying `scripts/release-notes-prompt.txt`.** Follow its shape:
-   keep only user-relevant changes (drop CI / tests / tooling / lint /
-   internal refactors / dev-docs); group under `## Features`, `## Improvements`, `## Bug Fixes`
-   (omit an empty group); link each item's PR/issue as `([#N](…/issues/N))` when the subject
-   references `#N` (the `/issues/` path resolves for PRs too); **never name internal ADRs** —
-   describe the user-facing change. Professional, engineer-like tone; precision over flash.
-   End the body with the exact compare link from step 2.
-
-5. **Compose the title.** `<YYYY-MM-DD> - <version> — <three-word summary>`, keeping the ISO
-   date the draft already carries (it keeps GitHub's alphabetical release sort chronological)
-   and appending the summary. There is no `SUMMARY` marker anywhere any more: the workflow
-   derives no title suffix, so this step owns the final title.
-
-6. **Confirm the rendered notes with the user.** Show the title + body. This is the public
-   release body — get a nod before writing it (cheap to revise now; the Release is immutable
-   once published).
-
-7. **Write them onto the draft.** It stays a draft while you do:
-
-   ```sh
-   gh release edit <tag> --title "<title>" --notes-file <path-to-body>
-   ```
-
-   Re-read it (`gh release view <tag>`) and confirm the body rendered as intended and every
-   asset is still attached.
-
-8. **Publish.** This is the irreversible, public step, and it locks the Release immutable:
-
-   ```sh
-   gh release edit <tag> --draft=false --prerelease   # stable: --latest instead
-   ```
-
-   Publishing fires `release-published.yml`, which dispatches the `pfBlockerNG/pkg`
-   republish so the build appears at `pfblockerng.github.io/pkg`. (The FreeBSD-ports
-   `PORTVERSION` bump already happened, as the terminal job of the release run.) Point at
-   that run and report the published Release URL.
-
-## Guardrails
-
-- **Never publish a draft you have not read.** The body and the asset list are frozen by
-  immutability the moment you publish.
-- **Never leave a release drafted silently.** If you stop before step 8 (the user asked to
-  review, something failed), say so explicitly and name the draft URL — a drafted release
-  ships nothing to users: no pkg-repo refresh. (The ports fork is already bumped to that
-  version, so an abandoned draft leaves the fork ahead of what actually shipped until the
-  next cut overwrites it.)
-- **Prerelease flag matches the channel** — `--prerelease` for `alpha`/`beta`/`rc`,
-  `--latest` for a stable `vX.Y.Z`. `release-version.sh` classifies it; the draft was already
-  created with the right flag, so only re-assert it, never flip it.
-- **Inherit every `/release` guardrail** — channel↔branch enforcement, immutable published
-  releases (cut the next `.N` instead of re-releasing), never a direct `main`/`devel` push.
-  This skill only adds the notes-authoring + publish behind it.
-- **Don't fabricate PR/issue numbers.** Link a `#N` only when a commit subject references it;
-  otherwise describe the change without a link.
-- **Keep ADRs out of the public notes** — neutral, user-facing wording only.
-- **Never commit release notes to the repository.** They live on the Release.
+Never commit notes to the repository. If publication stops, report the draft URL and the
+remaining action.

--- a/.agents/skills/release-with-changelog/SKILL.md
+++ b/.agents/skills/release-with-changelog/SKILL.md
@@ -25,15 +25,21 @@ skill must refuse a Nightly request.
   When the target becomes Stable, continue following Testing until a new target exists.
 
 The channel is explicit and configured, and `pfBlockerNG-Release-Channel: <stable|testing|edge>`
-is carried in the immutable tag trailer; channel is never inferred from a suffix. Every
-operation uses a pinned source SHA.
+is carried in each distinct release's immutable tag trailer; channel is never inferred from
+a suffix. A follower Edge reuses the Testing tag and its `testing` trailer. Every operation
+uses a pinned source SHA.
 
 The same Release and artifact bytes are reused when Edge follows Testing; no second Release
 or rebuild is permitted.
 
 ## Notes procedure
 
-1. Run the `release` skill first and wait for the draft. Confirm the draft URL, assets, and
+Follower Edge must not dispatch `release.yml` or enter this notes procedure. Reuse the
+existing Testing Release and notes. Catalog routing is owned by #2144; until that path
+exists, stop and report the missing route instead of creating another draft.
+
+1. For Stable, Testing, or distinct-target Edge, run the `release` skill first and wait for
+   the draft. Confirm the draft URL, assets, and
    immutable source identity.
 2. Resolve the previous same-channel tag from the current workflow's rules. Use the exact
    commit range and omit internal tooling, tests, ADRs, and workflow mechanics from notes.

--- a/.agents/skills/release-with-changelog/SKILL.md
+++ b/.agents/skills/release-with-changelog/SKILL.md
@@ -17,14 +17,16 @@ skill must refuse a Nightly request.
 - Stable uses `vX.Y.Z` / `X.Y.Z`.
 - Testing uses `vX.Y.Z.aN`, `vX.Y.Z.bN`, or `vX.Y.Z.rN` with the exact matching package
   version.
-- Edge uses the same Testing grammar and follows Testing on the configured release line.
-  Without a distinct Edge target, use the exact Testing Release and artifact bytes,
+- Edge uses the same Testing grammar. Edge follows Testing only when no distinct target
+  exists; distinct-target Edge uses its configured target/line. Without a distinct Edge
+  target, use the exact Testing Release and artifact bytes,
   checksums, source, provenance, tag, and notes; this means the same Release and artifact
   bytes, no second Release, and no rebuild.
   When the target becomes Stable, continue following Testing until a new target exists.
 
-The channel is explicit and configured, and its value is carried in the immutable tag trailer;
-channel is never inferred from a suffix.
+The channel is explicit and configured, and `pfBlockerNG-Release-Channel: <stable|testing|edge>`
+is carried in the immutable tag trailer; channel is never inferred from a suffix. Every
+operation uses a pinned source SHA.
 
 The same Release and artifact bytes are reused when Edge follows Testing; no second Release
 or rebuild is permitted.
@@ -46,7 +48,7 @@ or rebuild is permitted.
 Nightly input identity includes source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
 Its changed-input counter uses UTC `YYYYMMDD`, then `YYYYMMDD_1`/`_2` for same-day changes;
 unchanged or skipped days are no-ops. Keep its Ports recipe static: no routine version
-commit, no target final, and no PORTEPOCH. bare date versions intentionally outrank semantic
+commit, no target final, and no PORTEPOCH. Bare date versions intentionally outrank semantic
 releases; a reverse movement requires an explicit repo-qualified downgrade.
 
 Never commit notes to the repository. If publication stops, report the draft URL and the

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -10,8 +10,9 @@ description: >
 
 Use for a request to prepare a Stable, Testing, or Edge release. Require an explicit
 channel and configured `release/X.Y` source line. The channel is explicit and configured;
-store `pfBlockerNG-Release-Channel: <stable|testing|edge>` in the immutable tag trailer and
-never infer it from a suffix. Use a pinned source SHA for every channel.
+store `pfBlockerNG-Release-Channel: <stable|testing|edge>` in each distinct release's
+immutable tag trailer and never infer it from a suffix. A follower Edge reuses the Testing
+tag and its `testing` trailer. Use a pinned source SHA for every channel.
 
 ## Contract
 
@@ -36,16 +37,20 @@ never infer it from a suffix. Use a pinned source SHA for every channel.
 
 ## Procedure
 
-1. Validate the tag with `scripts/release-version.sh` and the explicit channel/source
+1. Decide whether Edge has a distinct target. Follower Edge must not dispatch `release.yml`:
+   reuse the existing Testing identity without a new draft, tag, or build. Catalog routing is
+   owned by #2144; until that path exists, stop and report the missing route.
+2. Validate the tag with `scripts/release-version.sh` and the explicit channel/source
    line. Do not reimplement its grammar.
-2. Confirm the selected line is current, the immutable source and tag trailer agree, and
+3. Confirm the selected line is current, the immutable source and tag trailer agree, and
    no published Release already owns the tag.
-3. Confirm the required checks are green for that source. A docs-only tip may inherit the
+4. Confirm the required checks are green for that source. A docs-only tip may inherit the
    nearest checked ancestor; do not silently ignore a failed check.
-4. Dispatch the current release workflow from its supported workflow ref. The workflow
+5. For Stable, Testing, or distinct-target Edge, dispatch the current release workflow from
+   its supported workflow ref. The workflow
    builds and verifies exact artifacts before creating a tag and draft Release; do not
    create or push a tag by hand.
-5. Stop at the complete draft. Report its URL and state that notes and publication remain
+6. Stop at the complete draft. Report its URL and state that notes and publication remain
    for `release-with-changelog`.
 
 `release.yml` at the current repository revision is authoritative for inputs and job

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,186 +1,51 @@
 ---
 name: release
 description: >
-  Cut a pfBlockerNG release by validating the tag scheme, then DISPATCHING
-  .github/workflows/release.yml — the workflow builds and VERIFIES first, then
-  pushes the tag and leaves a complete DRAFT Release (source archive + .pkg
-  assets, placeholder body). It stops there: this skill never writes notes and
-  never publishes. Report the draft URL; /release-with-changelog is the path that
-  writes the notes onto that draft and publishes it. You do NOT push a tag by
-  hand. Enforces the scheme before
-  dispatch: prereleases (vX.Y.Z.alpha.N | .beta.N | .rc.N) cut from `devel` only,
-  stable (vX.Y.Z) from `main` only — the same rule release-version.sh, the
-  workflow's prepare-release job, and the pre-push hook enforce, so a bad tag is
-  refused locally instead of failing in CI. Args: <tag> (e.g. v4.0.0.alpha.1)
-  [--dry-run]. Use when the user says "cut a release", "release vX.Y.Z…", "tag a
-  release", "publish the alpha", or invokes /release.
+  Prepare a Stable, Testing, or configured Edge release by validating its explicit
+  channel and release line, then dispatching the current release workflow. Nightly
+  is an independent untagged snapshot and is not handled by this skill.
 ---
 
-You cut a pfBlockerNG release **up to the draft**. **`release.yml` is
-`workflow_dispatch`-only and does everything up to that point** — its `prepare-release`
-job validates the scheme, asserts CI is green, **pins the channel-branch tip** and mints
-the tag locally; the workflow then builds every `.pkg` from that pinned SHA, runs the
-verification suites against those exact artifacts and that exact source, and only **when
-green** pushes the tag (on the pinned SHA), creates the Release **as a DRAFT**, attaches
-the assets and health-checks it. So you do **not** `git tag`/`git push` a tag by hand; you
-**dispatch the workflow** with `dry_run=false`. Everything below is the friendly pre-check
-that the tag + commit are correct **before** that dispatch.
+# Release
 
-**The workflow never publishes.** It hands you a complete draft with a placeholder body.
-Writing the real notes + title onto that draft and publishing it is a separate, explicit
-step — **`/release-with-changelog`** does exactly that (it invokes this skill first). If
-the user asked for `/release`, stop at the draft and say so; do not publish.
+Use for a request to prepare a Stable, Testing, or Edge release. Require an explicit
+channel and configured `release/X.Y` source line. The channel is explicit and configured;
+store that choice in the immutable tag trailer and never infer it from a suffix.
 
-**A failed run leaves nothing behind** — no tag, no draft, nothing pushed to any branch.
-The version number is not burned, so re-dispatching the SAME tag after fixing the cause is
-the normal recovery.
+## Contract
 
-**Which channels verify live.** `alpha` and `beta` tags **skip** the live smoke/UI suites —
-their mandatory gate is CI green on the release commit. `rc` and stable run the suites in
-full and tag only on green. Add `-f force_suites=true` to run them for an alpha/beta too.
-Independently, only a matrix row whose ci-metadata `status` is a released pfSense version
-(`active`/`GA`) can veto; a `beta`-status row (e.g. a pfSense Plus beta) still runs and
-reports, loudly demoted, but cannot fail the release.
+- Stable uses `vX.Y.Z` / `X.Y.Z`.
+- Testing uses `vX.Y.Z.aN`, `vX.Y.Z.bN`, or `vX.Y.Z.rN`; the package version is the
+  exact `X.Y.Z.aN`, `X.Y.Z.bN`, or `X.Y.Z.rN` value.
+- Edge uses the same Testing grammar and package version. It follows Testing on the
+  configured release line. With no distinct Edge target, mirror the exact existing
+  Testing Release and artifact bytes, checksums, source, provenance, tag, and notes:
+  the result has the same Release and artifact bytes, no second Release, and no rebuild.
+  When that target becomes Stable, Edge keeps
+  following Testing until a new target is configured.
+- Nightly is untagged, has no GitHub Release, and has no release notes. It is generated
+  independently from the `devel` branch when its input changes. A changed input uses UTC date
+  `YYYYMMDD`; another changed input on the same date uses `YYYYMMDD_1`, then `_2`. An
+  unchanged input or skipped day is a no-op.
+- Nightly identity includes source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
+  Keep the Ports recipe static: no routine version commit, no target final, and no
+  PORTEPOCH. bare date versions intentionally outrank semantic releases; a reverse
+  movement requires an explicit repo-qualified downgrade.
 
-`scripts/release-version.sh` is the single source of truth for the scheme; **call it,
-never re-implement the regex.** This skill is the pre-check and the workflow's
-`prepare-release` job is the backstop that covers the workflow's own push.
-`.githooks/pre-push` does **not** see that push: the runner's checkout never sets
-`core.hooksPath`, so the hook only backstops tags pushed by hand from a dev machine.
+## Procedure
 
-## Arguments
+1. Validate the tag with `scripts/release-version.sh` and the explicit channel/source
+   line. Do not reimplement its grammar.
+2. Confirm the selected line is current, the immutable source and tag trailer agree, and
+   no published Release already owns the tag.
+3. Confirm the required checks are green for that source. A docs-only tip may inherit the
+   nearest checked ancestor; do not silently ignore a failed check.
+4. Dispatch the current release workflow from its supported workflow ref. The workflow
+   builds and verifies exact artifacts before creating a tag and draft Release; do not
+   create or push a tag by hand.
+5. Stop at the complete draft. Report its URL and state that notes and publication remain
+   for `release-with-changelog`.
 
-- `<tag>` — required, e.g. `v4.0.0.alpha.1` (must start with `v`).
-- `--dry-run` — dispatch the workflow's no-publish harness
-  (`gh workflow run release.yml -f tag=<tag> -f dry_run=true`) to validate the scheme,
-  build the `.pkg` artifacts, and render the release body — publishing nothing, tag never
-  created. The real release is the same dispatch with `dry_run=false`.
-
-## The scheme (enforced, not advisory)
-
-| Tag | Channel | Cut from | Result |
-| --- | --- | --- | --- |
-| `vX.Y.Z.alpha.N` / `.beta.N` / `.rc.N` | devel | **`devel` only** | GitHub **pre-release** |
-| `vX.Y.Z` | stable | **`main` only** | full release |
-
-Refuse — do not push — when the tag's channel does not match the branch it would sit
-on: an `alpha`/`beta`/`rc` tag whose commit is on `main`, or a bare `vX.Y.Z` whose
-commit is only on `devel`. This is the "no alpha/beta/rc off main, no production off
-devel" guard, applied before the tag exists.
-
-## Steps
-
-1. **Classify the tag.** Run `sh scripts/release-version.sh <tag>` (no branch arg).
-   A non-zero exit ⇒ malformed tag — stop and show its error. Capture `channel`,
-   `prerelease`, `portversion`.
-
-2. **Pick the channel branch.** `devel` for a prerelease, `main` for stable. This is
-   the branch the tag must be cut from.
-
-3. **Fetch + locate the commit.** `git fetch origin --tags`. The release commit is the
-   **tip of the channel branch** (`origin/devel` or `origin/main`) unless the user named
-   a specific commit; that commit must be reachable from the channel branch.
-   - Re-assert the scheme against the resolved branch: `sh scripts/release-version.sh
-     <tag> <branch>` must exit 0. (This is exactly what the pre-push hook and the
-     workflow's metadata step run.)
-   - For a **stable** tag, the commit must be on `origin/main`. For a **prerelease**,
-     the commit must be on `origin/devel` but **not** already on `origin/main` (a
-     prerelease of code that is already stable makes no sense) — mirror the pre-push
-     hook's `merge-base --is-ancestor` checks.
-
-4. **Pre-flight gates** (stop on any failure, report which):
-   - **No PUBLISHED release for the tag.** A published GitHub Release is immutable+final
-     → refuse (bump the version). A tag that exists with **no release yet** (or only a
-     DRAFT) is a run that crashed *after* tagging — that is FINE **as long as the channel
-     branch has not moved since**: `tag-release` reuses a tag that already points at the
-     SHA this run verified, and refuses (loudly, without moving it) a tag pointing at any
-     other commit. If the branch has moved, delete the unpublished tag or bump the
-     version. Only a **published** release is an outright blocker (`gh release view <tag>`
-     ⇒ if it exists and is not a draft, stop).
-   - The local channel branch is up to date with its remote (the notes commit, if any, is
-     already pushed — the workflow tags the **remote** branch tip, so an un-pushed local
-     commit would be missed).
-   - **CI is green on the release commit** — the `All tests passed` check-run on the
-     channel-branch tip must be `success`. NOTE: the workflow's `verify-checks` walks back
-     first-parent ancestors past docs-only commits (a docs-only tip skips CI via
-     `paths-ignore` and carries no check-run), so check the nearest ancestor
-     **with** a check-run. Read via `gh api repos/<owner>/<repo>/commits/<sha>/check-runs`.
-     If pending, wait; if failed, stop.
-   - Git hooks are active (`git config core.hooksPath` = `.githooks`); if not, run
-     `sh scripts/setup-hooks.sh`. This arms the pre-push backstop for tags pushed **by
-     hand from this machine** — it never covers the tag the workflow pushes, which runs
-     on a runner checkout with no `core.hooksPath`.
-
-5. **Notes.** Nothing to prepare: release notes are **not files in this repository**. The
-   workflow gives the draft a deterministic placeholder body ending in the compare link, and
-   the title `YYYY-MM-DD - VERSION`. The real notes and the final title are written onto the
-   draft afterwards by **`/release-with-changelog`** (or by a human), which then publishes
-   it. Don't author notes here.
-
-6. **Confirm, then dispatch.** Dispatching with `dry_run=false` **becomes** irreversible
-   once verification is green — it pushes the tag and drafts the Release. It still publishes
-   nothing, and a run that fails before the tag leaves no trace at all.
-   Confirm the tag + channel-branch tip with the user, then dispatch — **do not push a tag
-   by hand**:
-
-   ```sh
-   gh workflow run release.yml --ref <default-branch> -f tag=<tag> -f dry_run=false
-   ```
-
-   Add `-f force_suites=true` to run the live smoke/UI suites for an `alpha`/`beta` tag
-   (they always run for `rc`/stable).
-
-   Add `-f retag=true` to **re-cut a tag that is already pushed** — the recovery for a run
-   that crashed after pushing its tag while the channel branch moved on, or simply when you
-   want a clean cut on the current tip. It deletes the existing tag (and an **assetless**
-   draft Release for it) before pinning. It **refuses** when the tag has a **published**
-   Release — that is immutable, and the only way forward is the next `.N` — and when its
-   draft **already has assets**: assets do not prove a finished cut (the source archive is
-   attached before the `.pkg`s), so it never deletes them. Finish that draft by
-   re-dispatching the same tag with `retag=false`, or delete it by hand to start over.
-   Leave it `false` for a normal cut.
-
-   The workflow pins the channel-branch tip and tags **that** commit after verification;
-   `prepare-release` is what re-validates the scheme for that push (the runner installs no
-   git hooks, so `pre-push` never sees it). On `--dry-run`, the
-   same dispatch with `dry_run=false` → `dry_run=true` (publishes nothing). Dispatch is
-   only allowed from the default branch (`devel`), but the workflow operates on the
-   resolved channel branch regardless. After dispatching, find the run
-   (`gh run list --workflow=release.yml`) to report/watch it.
-
-7. **Report the DRAFT.** After dispatch, point at the running `Release` workflow (Actions
-   tab) and state what it will produce:
-   - a **DRAFT** GitHub Release (`pre-release` for alpha/beta/rc), title
-     `YYYY-MM-DD - <version>`, body a placeholder ending in the compare link;
-   - one **`.pkg` per FreeBSD major** (plus each major's `extra_pkgs` dependency packages)
-     attached to that draft, alongside the `src/` source archive;
-   - the **port bump** on `pfBlockerNG/FreeBSD-ports@pfblockerng/use-github`, as the run's
-     terminal job — so when the run ends the only things left are the changelog and the
-     publish;
-   - **nothing published**: the pkg-repo republish fires when the release is actually
-     published, from `release-published.yml`.
-
-   Offer to watch the run. When it finishes, report the **draft Release URL** (the
-   `draft-healthcheck` job prints it in the run summary; `gh release view <tag> --json url`
-   also works) and say plainly that the release is **drafted pending notes** — someone must
-   write the notes + title onto it and publish it, which `/release-with-changelog` does.
-
-## Guardrails
-
-- **Never** dispatch a release whose channel/branch pairing
-  `release-version.sh <tag> <branch>` rejects. The scheme is non-negotiable; the
-  workflow's `prepare-release` will reject it anyway — after a runner has spun up — so
-  catch it here.
-- **Don't push a tag by hand** — dispatching the workflow is the whole job; it creates and
-  pushes the tag, and only after the build and the verification suites are green. A
-  hand-pushed tag now *blocks* the run unless it happens to point at the exact commit the
-  run pinned (the check fires in `prepare-release`, before the build).
-- **Never publish from this skill.** It stops at the draft. Publishing is
-  `/release-with-changelog`'s last step, after the notes are written.
-- **Never** re-release a tag with a **published** Release — cut the next `.N`
-  (e.g. `.alpha.2`) instead. A tag with no/draft release is resumable, not a re-release.
-- **A run that failed verification burned nothing** — no tag, no draft, the version number
-  is still available. Fix the cause, land it, re-dispatch the same tag.
-- **Never** push directly to `main`/`devel` from this skill — code reaches the channel
-  branch through the normal PR/landing flow first; this skill only dispatches the workflow.
-- The dry-run dispatch publishes nothing — use it freely to validate before the real cut.
+`release.yml` at the current repository revision is authoritative for inputs and job
+names. If it contradicts this contract, stop and report the contradiction instead of
+inventing a compatibility path.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -10,26 +10,28 @@ description: >
 
 Use for a request to prepare a Stable, Testing, or Edge release. Require an explicit
 channel and configured `release/X.Y` source line. The channel is explicit and configured;
-store that choice in the immutable tag trailer and never infer it from a suffix.
+store `pfBlockerNG-Release-Channel: <stable|testing|edge>` in the immutable tag trailer and
+never infer it from a suffix. Use a pinned source SHA for every channel.
 
 ## Contract
 
 - Stable uses `vX.Y.Z` / `X.Y.Z`.
 - Testing uses `vX.Y.Z.aN`, `vX.Y.Z.bN`, or `vX.Y.Z.rN`; the package version is the
   exact `X.Y.Z.aN`, `X.Y.Z.bN`, or `X.Y.Z.rN` value.
-- Edge uses the same Testing grammar and package version. It follows Testing on the
-  configured release line. With no distinct Edge target, mirror the exact existing
+- Edge uses the same Testing grammar and package version. Edge follows Testing only when no distinct target
+  exists; distinct-target Edge uses its configured target/line. With no
+  distinct Edge target, mirror the exact existing
   Testing Release and artifact bytes, checksums, source, provenance, tag, and notes:
   the result has the same Release and artifact bytes, no second Release, and no rebuild.
   When that target becomes Stable, Edge keeps
   following Testing until a new target is configured.
 - Nightly is untagged, has no GitHub Release, and has no release notes. It is generated
-  independently from the `devel` branch when its input changes. A changed input uses UTC date
+  independently from its pinned source when its input changes. A changed input uses UTC date
   `YYYYMMDD`; another changed input on the same date uses `YYYYMMDD_1`, then `_2`. An
   unchanged input or skipped day is a no-op.
 - Nightly identity includes source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
   Keep the Ports recipe static: no routine version commit, no target final, and no
-  PORTEPOCH. bare date versions intentionally outrank semantic releases; a reverse
+  PORTEPOCH. Bare date versions intentionally outrank semantic releases; a reverse
   movement requires an explicit repo-qualified downgrade.
 
 ## Procedure

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -53,7 +53,7 @@ while IFS=' ' read -r _local_ref local_sha remote_ref _remote_sha; do
 
     raw_tag_message=$(git for-each-ref --format='%(contents)' "$tag_ref")
     trailers=$(printf '%s\n' "$raw_tag_message" | git interpret-trailers --parse)
-    channel_count=$(printf '%s\n' "$raw_tag_message" | grep -Eic '^pfBlockerNG-Release-Channel: ' || true)
+    channel_count=$(printf '%s\n' "$raw_tag_message" | grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:' || true)
     if [ "$channel_count" -ne 1 ]; then
         echo "error: tag '$tag' must carry exactly one release-channel trailer" >&2
         exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -53,7 +53,7 @@ while IFS=' ' read -r _local_ref local_sha remote_ref _remote_sha; do
 
     raw_tag_message=$(git for-each-ref --format='%(contents)' "$tag_ref")
     trailers=$(printf '%s\n' "$raw_tag_message" | git interpret-trailers --parse)
-    channel_count=$(printf '%s\n' "$raw_tag_message" | grep -Ec '^pfBlockerNG-Release-Channel: ' || true)
+    channel_count=$(printf '%s\n' "$raw_tag_message" | grep -Eic '^pfBlockerNG-Release-Channel: ' || true)
     if [ "$channel_count" -ne 1 ]; then
         echo "error: tag '$tag' must carry exactly one release-channel trailer" >&2
         exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -23,7 +23,7 @@ CLASSIFY="${ROOT}/scripts/release-version.sh"
 # Both loops below consume the per-ref update list, so capture stdin once.
 updates=$(cat)
 
-while IFS=' ' read -r _local_ref local_sha remote_ref _remote_sha; do
+while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
     # Only inspect tag pushes
     case "$remote_ref" in refs/tags/*) ;; *) continue ;; esac
 
@@ -41,7 +41,16 @@ while IFS=' ' read -r _local_ref local_sha remote_ref _remote_sha; do
     fi
 
     tag_ref="refs/tags/${tag}"
-    type=$(git cat-file -t "$tag_ref" 2>/dev/null || true)
+    if [ "$local_ref" != "$tag_ref" ]; then
+        echo "error: versioned tag '$tag' must be pushed from source ref '$tag_ref'" >&2
+        exit 1
+    fi
+    ref_sha=$(git rev-parse --verify "$tag_ref" 2>/dev/null || true)
+    if [ "$ref_sha" != "$local_sha" ]; then
+        echo "error: tag '$tag' update does not match its local tag object" >&2
+        exit 1
+    fi
+    type=$(git cat-file -t "$local_sha" 2>/dev/null || true)
     if [ "$type" != "tag" ]; then
         if [ -z "$type" ]; then
             echo "error: '$tag' does not point to a commit reachable from an exact release/X.Y line" >&2
@@ -53,7 +62,7 @@ while IFS=' ' read -r _local_ref local_sha remote_ref _remote_sha; do
 
     raw_tag_message=$(git for-each-ref --format='%(contents)' "$tag_ref")
     trailers=$(printf '%s\n' "$raw_tag_message" | git interpret-trailers --parse)
-    channel_count=$(printf '%s\n' "$raw_tag_message" | grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:' || true)
+    channel_count=$(printf '%s\n' "$trailers" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
     if [ "$channel_count" -ne 1 ]; then
         echo "error: tag '$tag' must carry exactly one release-channel trailer" >&2
         exit 1
@@ -78,7 +87,7 @@ while IFS=' ' read -r _local_ref local_sha remote_ref _remote_sha; do
     fi
 
     release_line=$(sh "$CLASSIFY" "$tag" "$channel" | sed -n 's/^release_line=//p')
-    commit=$(git rev-parse --verify "${tag_ref}^{commit}" 2>/dev/null) || {
+    commit=$(git rev-parse --verify "${local_sha}^{commit}" 2>/dev/null) || {
         echo "error: tag '$tag' does not resolve to a commit" >&2
         exit 1
     }

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -60,8 +60,7 @@ while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
         exit 1
     fi
 
-    raw_tag_message=$(git for-each-ref --format='%(contents)' "$tag_ref")
-    trailers=$(printf '%s\n' "$raw_tag_message" | git interpret-trailers --parse)
+    trailers=$(git for-each-ref --format='%(contents)' "$tag_ref" | git interpret-trailers --parse)
     channel_count=$(printf '%s\n' "$trailers" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
     if [ "$channel_count" -ne 1 ]; then
         echo "error: tag '$tag' must carry exactly one release-channel trailer" >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,9 +4,9 @@
 # Single source of truth for the tag scheme: scripts/release-version.sh.
 #
 # Rules:
-#   - vX.Y.Z                       -> commit must be reachable from origin/main   (stable)
-#   - vX.Y.Z.alpha.N|.beta.N|.rc.N -> commit on origin/devel but NOT origin/main  (prerelease)
-#   - neither branch, or a malformed version tag -> rejected
+#   - every versioned tag is annotated and carries exactly one explicit channel trailer
+#   - its commit must be reachable from the exact release/X.Y line derived by the parser
+#   - malformed metadata, an unknown channel, or an unreachable release line -> rejected
 #   - agent (CLAUDECODE=1 or CODEX_THREAD_ID set) branch push rewriting remote
 #     history -> allowed only when the advertised remote oid equals the local
 #     remote-tracking ref, i.e. the history being overwritten was fetched
@@ -18,6 +18,7 @@
 z40="0000000000000000000000000000000000000000"
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || ROOT="."
 CLASSIFY="${ROOT}/scripts/release-version.sh"
+[ -f "$CLASSIFY" ] || [ -z "${PFB_ROOT:-}" ] || CLASSIFY="${PFB_ROOT}/scripts/release-version.sh"
 
 # Both loops below consume the per-ref update list, so capture stdin once.
 updates=$(cat)
@@ -34,34 +35,56 @@ while IFS=' ' read -r _local_ref local_sha remote_ref _remote_sha; do
     # Only enforce versioned tags (vX.Y.Z and vX.Y.Z.<suffix>)
     case "$tag" in v[0-9]*.[0-9]*.[0-9]*) ;; *) continue ;; esac
 
-    # Dereference annotated tags to the underlying commit
-    commit=$(git rev-parse --verify "${local_sha}^{commit}" 2>/dev/null) \
-        || commit="$local_sha"
-
-    on_main=0
-    on_devel=0
-    git merge-base --is-ancestor "$commit" "origin/main"  2>/dev/null && on_main=1
-    git merge-base --is-ancestor "$commit" "origin/devel" 2>/dev/null && on_devel=1
-
-    if [ "$on_main" = 0 ] && [ "$on_devel" = 0 ]; then
-        echo "error: '$tag' does not point to a commit reachable from 'origin/main' or 'origin/devel'" >&2
-        echo "       Push the commit to the appropriate branch and wait for CI to pass before tagging." >&2
-        exit 1
-    fi
-
-    # A commit merged into main must be a STABLE tag; a commit only on devel must
-    # be a PRERELEASE tag. Delegate the shape + branch<->channel check to the
-    # single source of truth so the hook and the workflow never drift.
-    if [ "$on_main" = 1 ]; then branch="main"; else branch="devel"; fi
-
     if [ ! -f "$CLASSIFY" ]; then
         echo "error: ${CLASSIFY} not found — cannot validate the tag scheme" >&2
         exit 1
     fi
 
-    if ! err=$(sh "$CLASSIFY" "$tag" "$branch" 2>&1 >/dev/null); then
-        echo "error: tag '$tag' is not valid for branch '$branch':" >&2
+    tag_ref="refs/tags/${tag}"
+    type=$(git cat-file -t "$tag_ref" 2>/dev/null || true)
+    if [ "$type" != "tag" ]; then
+        if [ -z "$type" ]; then
+            echo "error: '$tag' does not point to a commit reachable from an exact release/X.Y line" >&2
+            exit 1
+        fi
+        echo "error: tag '$tag' must be an annotated tag" >&2
+        exit 1
+    fi
+
+    raw_tag_message=$(git for-each-ref --format='%(contents)' "$tag_ref")
+    trailers=$(printf '%s\n' "$raw_tag_message" | git interpret-trailers --parse)
+    channel_count=$(printf '%s\n' "$raw_tag_message" | grep -Ec '^pfBlockerNG-Release-Channel: ' || true)
+    if [ "$channel_count" -ne 1 ]; then
+        echo "error: tag '$tag' must carry exactly one release-channel trailer" >&2
+        exit 1
+    fi
+    channel_line=$(printf '%s\n' "$trailers" | grep -F 'pfBlockerNG-Release-Channel:' || true)
+    case "$channel_line" in
+        'pfBlockerNG-Release-Channel: stable') channel=stable ;;
+        'pfBlockerNG-Release-Channel: testing') channel=testing ;;
+        'pfBlockerNG-Release-Channel: edge') channel=edge ;;
+        *) channel= ;;
+    esac
+    if [ -z "$channel" ]; then
+        echo "error: tag '$tag' has an unknown release-channel trailer" >&2
+        exit 1
+    fi
+
+    # Classify from the explicit trailer, never from a suffix or branch name.
+    if ! err=$(sh "$CLASSIFY" "$tag" "$channel" 2>&1 >/dev/null); then
+        echo "error: tag '$tag' is not valid for channel '$channel':" >&2
         printf '%s\n' "$err" | sed 's/^/       /' >&2
+        exit 1
+    fi
+
+    release_line=$(sh "$CLASSIFY" "$tag" "$channel" | sed -n 's/^release_line=//p')
+    commit=$(git rev-parse --verify "${tag_ref}^{commit}" 2>/dev/null) || {
+        echo "error: tag '$tag' does not resolve to a commit" >&2
+        exit 1
+    }
+    if ! git merge-base --is-ancestor "$commit" "origin/$release_line" 2>/dev/null; then
+        echo "error: '$tag' does not point to a commit reachable from 'origin/$release_line'" >&2
+        echo "       Push the commit to the exact release line and wait for CI to pass before tagging." >&2
         exit 1
     fi
 done <<PFB_TAG_UPDATES

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -61,8 +61,7 @@ jobs:
           git fetch --tags --force origin
           TYPE=$(git cat-file -t "refs/tags/${TAG}" 2>/dev/null || true)
           [ "$TYPE" = tag ] || { echo "::error::published tag ${TAG} is not an annotated tag"; exit 1; }
-          RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
-          TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
+          TRAILERS=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" | git interpret-trailers --parse)
           CHANNEL_COUNT=$(printf '%s\n' "$TRAILERS" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
           [ "$CHANNEL_COUNT" -eq 1 ] || { echo "::error::published tag ${TAG} must carry exactly one release-channel trailer"; exit 1; }
           CHANNEL_LINE=$(printf '%s\n' "$TRAILERS" | grep -F 'pfBlockerNG-Release-Channel:' || true)

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -13,13 +13,8 @@ name: Release published (downstream)
 # (the terminal sync-ports-fork job), so that when a run finishes the only
 # things left are "write the changelog" and "publish".
 #
-# ORDERING, for the record: pfBlockerNG/pkg derives the NIGHTLY version from the
-# `-nightly` port's PORTVERSION in the FreeBSD-ports fork, so it must never read that
-# fork before the bump lands — racing it shipped a stale-versioned nightly (e.g.
-# an older prerelease on the newer commit). That used to be a `needs: [sync-ports-fork]`
-# edge here. It is now STRUCTURAL — the bump happens inside the release run, strictly
-# before any publish can occur — so do NOT re-add a dependency on a job that is no
-# longer in this workflow.
+# Nightly is independent and untagged. This published-Release workflow must not allocate,
+# build, or mutate it; tagged release publication never changes the static Nightly port.
 #
 # Fires for prereleases too (`published` covers a pre-release being published).
 on:
@@ -67,7 +62,7 @@ jobs:
           [ "$TYPE" = tag ] || { echo "::error::published tag ${TAG} is not an annotated tag"; exit 1; }
           RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
           TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
-          CHANNEL_COUNT=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Ec '^pfBlockerNG-Release-Channel: ' || true)
+          CHANNEL_COUNT=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel: ' || true)
           [ "$CHANNEL_COUNT" -eq 1 ] || { echo "::error::published tag ${TAG} must carry exactly one release-channel trailer"; exit 1; }
           CHANNEL_LINE=$(printf '%s\n' "$TRAILERS" | grep -F 'pfBlockerNG-Release-Channel:' || true)
           case "$CHANNEL_LINE" in

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -54,6 +54,7 @@ jobs:
         id: classify
         env:
           TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           set -eu
           [ -n "$TAG" ] || { echo "::error::the published release carries no tag"; exit 1; }
@@ -62,7 +63,7 @@ jobs:
           [ "$TYPE" = tag ] || { echo "::error::published tag ${TAG} is not an annotated tag"; exit 1; }
           RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
           TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
-          CHANNEL_COUNT=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel: ' || true)
+          CHANNEL_COUNT=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:' || true)
           [ "$CHANNEL_COUNT" -eq 1 ] || { echo "::error::published tag ${TAG} must carry exactly one release-channel trailer"; exit 1; }
           CHANNEL_LINE=$(printf '%s\n' "$TRAILERS" | grep -F 'pfBlockerNG-Release-Channel:' || true)
           case "$CHANNEL_LINE" in
@@ -81,6 +82,10 @@ jobs:
             exit 1
           fi
           eval "$OUT"   # sets version / channel / prerelease / prekind / portversion
+          case "${RELEASE_PRERELEASE}:${prerelease}" in
+            false:false|true:true) ;;
+            *) echo "::error::published Release prerelease flag does not match ${TAG}"; exit 1 ;;
+          esac
           if ! git fetch origin "$release_line" --tags; then
             echo "::error::cannot fetch the derived source line origin/${release_line} for ${TAG}"; exit 1
           fi
@@ -101,7 +106,7 @@ jobs:
   # The pkg catalog is hosted + deployed by the SEPARATE pfBlockerNG/pkg repo: its own
   # publish.yml enumerates this repo's PUBLISHED Releases (the durable store), consumes
   # their .pkg assets for the release/<varver>/ subtree (arch-less; issue #1806 — devel
-  # = latest prerelease, stable = latest stable; nightly still built from devel HEAD),
+  # = latest prerelease, stable = latest stable),
   # and deploys to its OWN GitHub Pages via same-repo OIDC — no cross-repo deploy key.
   # We just trigger it so the new Release appears at pfblockerng.github.io/pkg within
   # seconds (its daily schedule is the backstop).

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -86,6 +86,14 @@ jobs:
             exit 1
           fi
           eval "$OUT"   # sets version / channel / prerelease / prekind / portversion
+          if ! git fetch origin "$release_line" --tags; then
+            echo "::error::cannot fetch the derived source line origin/${release_line} for ${TAG}"; exit 1
+          fi
+          COMMIT=$(git rev-parse --verify "refs/tags/${TAG}^{commit}" 2>/dev/null) || {
+            echo "::error::published tag ${TAG} does not resolve to a commit"; exit 1; }
+          if ! git merge-base --is-ancestor "$COMMIT" "origin/${release_line}"; then
+            echo "::error::published tag ${TAG} commit is not reachable from origin/${release_line}"; exit 1
+          fi
           {
             echo "tag=${TAG}"
             echo "channel=${release_channel}"

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -63,7 +63,7 @@ jobs:
           [ "$TYPE" = tag ] || { echo "::error::published tag ${TAG} is not an annotated tag"; exit 1; }
           RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
           TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
-          CHANNEL_COUNT=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:' || true)
+          CHANNEL_COUNT=$(printf '%s\n' "$TRAILERS" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
           [ "$CHANNEL_COUNT" -eq 1 ] || { echo "::error::published tag ${TAG} must carry exactly one release-channel trailer"; exit 1; }
           CHANNEL_LINE=$(printf '%s\n' "$TRAILERS" | grep -F 'pfBlockerNG-Release-Channel:' || true)
           case "$CHANNEL_LINE" in

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -2,7 +2,7 @@ name: Release published (downstream)
 
 # The one thing that must wait for a GitHub Release to actually be PUBLISHED.
 #
-# release.yml deliberately stops at a complete DRAFT (issue #1855): the release notes
+# The dispatch workflow deliberately stops at a complete DRAFT (issue #1855): the release notes
 # and the final title are authored onto that draft by a human or by Claude, who then
 # publishes it. pfBlockerNG/pkg's publish.yml enumerates this repo's PUBLISHED Releases
 # and downloads their assets, so it genuinely cannot run before that moment — hence this
@@ -10,13 +10,13 @@ name: Release published (downstream)
 # publishing a release would silently stop refreshing the catalog.
 #
 # The FreeBSD-ports PORTVERSION bump is NOT here: it runs at the END of the release run
-# (release.yml's terminal sync-ports-fork job), so that when a run finishes the only
+# (the terminal sync-ports-fork job), so that when a run finishes the only
 # things left are "write the changelog" and "publish".
 #
 # ORDERING, for the record: pfBlockerNG/pkg derives the NIGHTLY version from the
 # `-nightly` port's PORTVERSION in the FreeBSD-ports fork, so it must never read that
 # fork before the bump lands — racing it shipped a stale-versioned nightly (e.g.
-# 4.0.0.alpha.3.* on the alpha.4 commit). That used to be a `needs: [sync-ports-fork]`
+# an older prerelease on the newer commit). That used to be a `needs: [sync-ports-fork]`
 # edge here. It is now STRUCTURAL — the bump happens inside the release run, strictly
 # before any publish can occur — so do NOT re-add a dependency on a job that is no
 # longer in this workflow.
@@ -31,13 +31,13 @@ permissions:
 
 jobs:
   # ── 0. Classify the published tag ────────────────────────────────────────
-  # Everything downstream needs is derived from the tag alone, via the single source
-  # of truth (scripts/release-version.sh). A published release whose tag is not in the
-  # scheme is a hard error, not a silent skip — the ports bump would be meaningless.
+  # Everything downstream needs is derived from the tag plus its explicit channel
+  # trailer, via the single source of truth (scripts/release-version.sh). A published
+  # release whose tag or metadata is invalid is a hard error, not a silent skip.
   resolve:
     name: Resolve the published tag
     runs-on: ubuntu-latest
-    # No job-level `outputs:`. This job published tag/branch/portversion for the ports
+    # No job-level `outputs:`. This job previously published tag/source/portversion for the ports
     # bump; that bump moved into the release run and took every consumer with it, and an
     # output nobody reads reads as a live contract. What survives is the GATE: an
     # off-scheme published tag fails here, and `repo-publish` hangs off it via `needs:`.
@@ -50,7 +50,7 @@ jobs:
           # came from instead. The blast radius is small today (no App token, a
           # read-scoped GITHUB_TOKEN, nothing pushed), but that is a property of this
           # job's current body, not of the design: the next credential added here would
-          # silently inherit the hole. Same rule as release.yml's ports helper. Do not
+          # silently inherit the hole. Same rule as the dispatch workflow's ports helper. Do not
           # "simplify" this to the event ref or the release tag.
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
@@ -62,22 +62,37 @@ jobs:
         run: |
           set -eu
           [ -n "$TAG" ] || { echo "::error::the published release carries no tag"; exit 1; }
+          git fetch --tags --force origin
+          TYPE=$(git cat-file -t "refs/tags/${TAG}" 2>/dev/null || true)
+          [ "$TYPE" = tag ] || { echo "::error::published tag ${TAG} is not an annotated tag"; exit 1; }
+          RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
+          TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
+          CHANNEL_COUNT=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Ec '^pfBlockerNG-Release-Channel: ' || true)
+          [ "$CHANNEL_COUNT" -eq 1 ] || { echo "::error::published tag ${TAG} must carry exactly one release-channel trailer"; exit 1; }
+          CHANNEL_LINE=$(printf '%s\n' "$TRAILERS" | grep -F 'pfBlockerNG-Release-Channel:' || true)
+          case "$CHANNEL_LINE" in
+            'pfBlockerNG-Release-Channel: stable') CHANNEL=stable ;;
+            'pfBlockerNG-Release-Channel: testing') CHANNEL=testing ;;
+            'pfBlockerNG-Release-Channel: edge') CHANNEL=edge ;;
+            *) CHANNEL= ;;
+          esac
+          [ -n "$CHANNEL" ] || { echo "::error::published tag ${TAG} carries an unknown release-channel trailer"; exit 1; }
           # release-version.sh writes its diagnostics to STDERR, so capturing stdout
           # alone annotated an empty line and buried the real reason in the raw log.
           # On success the script writes nothing to stderr, so `eval` still sees only
           # the KEY=VALUE lines. Newlines are folded out: an annotation is one line.
-          if ! OUT=$(sh scripts/release-version.sh "$TAG" 2>&1); then
+          if ! OUT=$(sh scripts/release-version.sh "$TAG" "$CHANNEL" 2>&1); then
             echo "::error::cannot classify the published tag ${TAG} — $(printf '%s' "$OUT" | tr '\n' ' ')"
             exit 1
           fi
           eval "$OUT"   # sets version / channel / prerelease / prekind / portversion
-          if [ "$channel" = "devel" ]; then BRANCH="devel"; else BRANCH="main"; fi
           {
             echo "tag=${TAG}"
-            echo "branch=${BRANCH}"
+            echo "channel=${release_channel}"
+            echo "source=${release_line}"
             echo "portversion=${portversion}"
           } >> "$GITHUB_OUTPUT"
-          echo "Published ${TAG}: channel=${channel} branch=${BRANCH} portversion=${portversion}"
+          echo "Published ${TAG}: channel=${release_channel} source=${release_line} portversion=${portversion}"
 
   # ── 1. Poke the self-hosted pkg repository to republish (ADR-17) ──────────
   # The pkg catalog is hosted + deployed by the SEPARATE pfBlockerNG/pkg repo: its own

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,7 @@ name: Release
 #
 # Tag scheme (single source of truth: scripts/release-version.sh):
 #   * vX.Y.Z       -> STABLE release
-#   * vX.Y.Z.aN|.bN|.rN -> TESTING release
-#   * vX.Y.Z.edge.YYYYMMDD.N -> EDGE release (scheduler-owned)
+#   * vX.Y.Z.aN|.bN|.rN -> TESTING or distinct-target EDGE release
 # GH_TAGNAME is `v${PORTVERSION}` in the port Makefile, so it self-resolves to the
 # matching tag and nothing here sets it.
 # Self-hosted distribution (ADR-17): no upstream pfsense/FreeBSD-ports PR.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Release
 # input; it builds, verifies, tags and DRAFTS a release — and stops there.
 #
 # BUILD + VERIFY BEFORE ANYTHING IS TAGGED (issue #1855).  Runs 30419586338
-# (v4.0.0.alpha.23) and 30424647767 (v4.0.0.alpha.24) each pushed the tag, created
+# (two consecutive prerelease runs) each pushed the tag, created
 # the draft Release and attached the .pkg assets BEFORE the verification suites ran
 # — both then failed verification and left a tag pointing at unverified code plus a
 # draft that had to be deleted unpublished.  The order is now:
@@ -50,8 +50,9 @@ name: Release
 # tag + draft.
 #
 # Tag scheme (single source of truth: scripts/release-version.sh):
-#   * vX.Y.Z                       -> STABLE release (from 'main')   -> full release
-#   * vX.Y.Z.alpha.N|.beta.N|.rc.N -> ALPHA/BETA/RC  (from 'devel') -> pre-release
+#   * vX.Y.Z       -> STABLE release
+#   * vX.Y.Z.aN|.bN|.rN -> TESTING release
+#   * vX.Y.Z.edge.YYYYMMDD.N -> EDGE release (scheduler-owned)
 # GH_TAGNAME is `v${PORTVERSION}` in the port Makefile, so it self-resolves to the
 # matching tag and nothing here sets it.
 # Self-hosted distribution (ADR-17): no upstream pfsense/FreeBSD-ports PR.
@@ -59,8 +60,17 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag, e.g. v4.0.0.alpha.1 (REQUIRED)."
+        description: "Release tag, e.g. v4.0.0.a1 (REQUIRED)."
         required: true
+      channel:
+        description: "Release channel (must be explicit; never inferred from tag or branch)."
+        required: true
+        type: choice
+        options: [stable, testing, edge]
+      source:
+        description: "Exact source release line release/X.Y, e.g. release/4.0 (REQUIRED)."
+        required: true
+        type: string
       dry_run:
         description: "true (default) = validate + build, publish NOTHING. false = cut the real release."
         required: false
@@ -112,7 +122,7 @@ jobs:
       contents: write  # ONLY for the retag deletion below
       checks: read     # gh api /commits/<sha>/check-runs to assert CI green
 
-    # Only what a downstream job actually reads. branch/channel/portversion are resolved
+    # Only what a downstream job actually reads. source/channel/portversion are resolved
     # in the `resolve` step and used inside this job; they are NOT re-exported, because
     # nothing consumes them — read-matrix classifies the tag itself, and the `release` job
     # re-derives its own. An output nobody reads states a contract that does not exist.
@@ -165,40 +175,42 @@ jobs:
           path: pfblockerng-src
           persist-credentials: false
 
-      - name: Resolve tag + channel branch
+      - name: Resolve tag + explicit channel + source line
         id: resolve
         # Classify the tag via the single source of truth (scripts/release-version.sh)
         # and map the channel to its canonical branch.  Re-assert the branch<->channel
         # pairing with a second release-version.sh call (must exit 0) before proceeding.
         env:
-          TAG: ${{ github.event.inputs.tag }}
+          TAG:     ${{ github.event.inputs.tag }}
+          CHANNEL: ${{ github.event.inputs.channel }}
+          SOURCE:  ${{ github.event.inputs.source }}
         run: |
           [ -n "$TAG" ] || { echo "::error::tag input is required"; exit 1; }
-          OUT=$(sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/release-version.sh" "$TAG") || { echo "$OUT"; exit 1; }
+          [ -n "$CHANNEL" ] || { echo "::error::channel input is required"; exit 1; }
+          [ -n "$SOURCE" ] || { echo "::error::source input is required"; exit 1; }
+          OUT=$(sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/release-version.sh" "$TAG" "$CHANNEL" "$SOURCE") || { echo "$OUT"; exit 1; }
           eval "$OUT"   # sets version / channel / prerelease / prekind / portversion
-          if [ "$channel" = "devel" ]; then BRANCH="devel"; else BRANCH="main"; fi
-          # Re-assert branch<->channel pairing
-          sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/release-version.sh" "$TAG" "$BRANCH" > /dev/null || {
-            echo "::error::tag ${TAG} is not valid for branch ${BRANCH} (channel ${channel})"
+          if [ "$release_line" != "$SOURCE" ]; then
+            echo "::error::tag ${TAG} does not belong to source ${SOURCE}"
             exit 1
-          }
+          fi
           {
             echo "tag=${TAG}"
-            echo "branch=${BRANCH}"
-            echo "channel=${channel}"
+            echo "source=${SOURCE}"
+            echo "channel=${release_channel}"
             echo "portversion=${portversion}"
           } >> "$GITHUB_OUTPUT"
-          echo "Tag ${TAG}: channel=${channel} branch=${BRANCH} portversion=${portversion}"
+          echo "Tag ${TAG}: channel=${release_channel} source=${SOURCE} portversion=${portversion}"
 
-      - name: Check out the channel branch
-        # Operate on the live branch tip, not the dispatch ref.  fetch --tags so
+      - name: Check out the exact source line
+        # Operate on the selected release line, not the dispatch ref.  fetch --tags so
         # ancestry checks and the tag-exists guard below work correctly.
         env:
-          BRANCH: ${{ steps.resolve.outputs.branch }}
+          SOURCE: ${{ steps.resolve.outputs.source }}
         run: |
-          git fetch origin "$BRANCH" --tags
-          git checkout "$BRANCH"
-          git reset --hard "origin/$BRANCH"
+          git fetch origin "$SOURCE" --tags
+          git checkout "$SOURCE"
+          git reset --hard "origin/$SOURCE"
 
       - name: Delete the existing tag before pinning (retag, opt-in)
         # THE ONE PLACE THIS PIPELINE DELETES ANYTHING FROM GITHUB. Opt-in per dispatch,
@@ -330,21 +342,40 @@ jobs:
         # so a commit landing on the channel branch mid-verification can never end up
         # inside the release.
         env:
-          TAG: ${{ steps.resolve.outputs.tag }}
+          TAG:     ${{ steps.resolve.outputs.tag }}
+          CHANNEL: ${{ steps.resolve.outputs.channel }}
         run: |
           set -eu
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           SHA=$(git rev-parse HEAD)
           if git rev-parse -q --verify "refs/tags/${TAG}" > /dev/null 2>&1; then
-            EXISTING=$(git rev-list -n 1 "refs/tags/${TAG}")
+            TYPE=$(git cat-file -t "refs/tags/${TAG}" 2>/dev/null || true)
+            if [ "$TYPE" != "tag" ]; then
+              echo "::error::tag ${TAG} already exists but is not an annotated tag"
+              exit 1
+            fi
+            EXISTING=$(git rev-parse "refs/tags/${TAG}^{commit}")
             if [ "$EXISTING" != "$SHA" ]; then
               echo "::error::tag ${TAG} already exists at ${EXISTING}, but this release pins ${SHA} — delete the stale (unpublished) tag or bump the version"
               exit 1
             fi
+            RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
+            TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
+            MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
+            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Ec '^pfBlockerNG-Release-Channel: ' || true)
+            if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
+              echo "::error::tag ${TAG} has invalid release-channel trailer metadata"
+              exit 1
+            fi
             echo "Tag ${TAG} already exists at ${SHA} — resuming a run that crashed after pushing it."
           else
-            git tag -a "$TAG" -m "$TAG" "$SHA"
+            # Compatibility oracle: git tag -a "$TAG" -m "$TAG" "$SHA"
+            MESSAGE=$(mktemp)
+            printf '%s\n\n' "$TAG" | git interpret-trailers \
+              --trailer "pfBlockerNG-Release-Channel: ${CHANNEL}" > "$MESSAGE"
+            git tag -a "$TAG" -F "$MESSAGE" "$SHA"
+            rm -f "$MESSAGE"
             echo "Minted ${TAG} locally at ${SHA} — not pushed."
           fi
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
@@ -463,7 +494,7 @@ jobs:
       - name: Detect pkg channel from tag
         id: channel
         # The channel drives which port we build (devel vs stable). Classified by
-        # scripts/release-version.sh: vX.Y.Z.alpha.N|.beta.N|.rc.N -> devel, vX.Y.Z -> stable.
+        # scripts/release-version.sh: vX.Y.Z.aN|.bN|.rN -> prerelease, vX.Y.Z -> stable.
         #
         # It also decides, from the SAME classification, whether the live smoke/UI
         # suites run for this release (issue #1855 Part 3):
@@ -476,11 +507,15 @@ jobs:
         # `force_suites` is the manual escape hatch: it can only ever ADD
         # verification (rc/stable already run the suites unconditionally).
         env:
-          INPUT_TAG:    ${{ github.event.inputs.tag }}
-          FORCE_SUITES: ${{ github.event.inputs.force_suites }}
+          INPUT_TAG:     ${{ github.event.inputs.tag }}
+          INPUT_CHANNEL: ${{ github.event.inputs.channel }}
+          INPUT_SOURCE:  ${{ github.event.inputs.source }}
+          FORCE_SUITES:  ${{ github.event.inputs.force_suites }}
         run: |
           TAG="$INPUT_TAG"
-          OUT=$(sh scripts/release-version.sh "$TAG") || { echo "$OUT"; exit 1; }
+          CHANNEL="$INPUT_CHANNEL"
+          SOURCE="$INPUT_SOURCE"
+          OUT=$(sh scripts/release-version.sh "$TAG" "$CHANNEL" "$SOURCE") || { echo "$OUT"; exit 1; }
           eval "$OUT"
           case "$prekind" in
             alpha|beta) RUN_SUITES="false" ;;
@@ -491,12 +526,17 @@ jobs:
           case "${FORCE_SUITES:-}" in
             [Tt][Rr][Uu][Ee]) RUN_SUITES="true" ;;
           esac
+          case "$release_channel" in
+            stable) PKG_CHANNEL=stable ;;
+            testing|edge) PKG_CHANNEL=devel ;;
+            *) echo "::error::unknown release channel: ${release_channel}"; exit 1 ;;
+          esac
           {
-            echo "pkg_channel=${channel}"
+            echo "pkg_channel=${PKG_CHANNEL}"
             echo "portversion=${portversion}"
             echo "run_suites=${RUN_SUITES}"
           } >> "$GITHUB_OUTPUT"
-          echo "Tag: ${TAG}  →  pkg channel: ${channel}  portversion: ${portversion}"
+          echo "Tag: ${TAG}  →  release channel: ${release_channel}  source: ${SOURCE}  portversion: ${portversion}"
           echo "Live smoke/UI suites for this release: ${RUN_SUITES} (prekind='${prekind:-stable}', force_suites='${FORCE_SUITES:-false}')"
 
       - name: Read matrix from ci-metadata
@@ -588,20 +628,39 @@ jobs:
         env:
           TAG: ${{ needs.prepare-release.outputs.tag }}
           SHA: ${{ needs.prepare-release.outputs.sha }}
+          CHANNEL: ${{ github.event.inputs.channel }}
         run: |
           set -eu
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch --tags --force origin
           if git rev-parse -q --verify "refs/tags/${TAG}" > /dev/null 2>&1; then
-            EXISTING=$(git rev-list -n 1 "refs/tags/${TAG}")
+            TYPE=$(git cat-file -t "refs/tags/${TAG}" 2>/dev/null || true)
+            if [ "$TYPE" != "tag" ]; then
+              echo "::error::tag ${TAG} already exists but is not an annotated tag"
+              exit 1
+            fi
+            EXISTING=$(git rev-parse "refs/tags/${TAG}^{commit}")
             if [ "$EXISTING" != "$SHA" ]; then
               echo "::error::tag ${TAG} already exists at ${EXISTING}, but this run built and verified ${SHA} — delete the stale (unpublished) tag or bump the version"
               exit 1
             fi
+            RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
+            TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
+            MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
+            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Ec '^pfBlockerNG-Release-Channel: ' || true)
+            if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
+              echo "::error::tag ${TAG} has invalid release-channel trailer metadata"
+              exit 1
+            fi
             echo "Tag ${TAG} already at ${SHA} — reusing it (resuming a run that crashed after tagging)."
           else
-            git tag -a "$TAG" -m "$TAG" "$SHA"
+            # Compatibility oracle: git tag -a "$TAG" -m "$TAG" "$SHA"
+            MESSAGE=$(mktemp)
+            printf '%s\n\n' "$TAG" | git interpret-trailers \
+              --trailer "pfBlockerNG-Release-Channel: ${CHANNEL}" > "$MESSAGE"
+            git tag -a "$TAG" -F "$MESSAGE" "$SHA"
+            rm -f "$MESSAGE"
             git push origin "refs/tags/${TAG}"
             echo "Created and pushed tag ${TAG} at ${SHA}"
           fi
@@ -629,7 +688,8 @@ jobs:
     # re-exporting them claimed a contract nothing downstream ever used.
     outputs:
       tag:         ${{ steps.meta.outputs.tag }}
-      branch:      ${{ steps.meta.outputs.branch }}
+      source:      ${{ steps.meta.outputs.source }}
+      channel:     ${{ steps.meta.outputs.channel }}
       portversion: ${{ steps.meta.outputs.portversion }}
       dry_run:     ${{ steps.meta.outputs.dry_run }}
 
@@ -668,8 +728,10 @@ jobs:
         # writes (a 'FALSE'-style variant reaches this job through the case-insensitive
         # job-level `if:`).
         env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-          INPUT_DRY: ${{ github.event.inputs.dry_run }}
+          INPUT_TAG:     ${{ github.event.inputs.tag }}
+          INPUT_CHANNEL: ${{ github.event.inputs.channel }}
+          INPUT_SOURCE:  ${{ github.event.inputs.source }}
+          INPUT_DRY:     ${{ github.event.inputs.dry_run }}
         run: |
           # An API dispatch can hand this an arbitrary string despite the boolean input
           # type, so reject anything but true/false before any $GITHUB_OUTPUT is written.
@@ -680,24 +742,26 @@ jobs:
             *) echo "::error::dry_run input must be exactly 'true' or 'false' (got: '${INPUT_DRY}')"; exit 1 ;;
           esac
           TAG="$INPUT_TAG"
+          CHANNEL="$INPUT_CHANNEL"
+          SOURCE="$INPUT_SOURCE"
           [ -n "$TAG" ] || { echo "::error::tag input is required"; exit 1; }
+          [ -n "$CHANNEL" ] || { echo "::error::channel input is required"; exit 1; }
+          [ -n "$SOURCE" ] || { echo "::error::source input is required"; exit 1; }
 
-          OUT=$(sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/release-version.sh" "$TAG") || { echo "$OUT"; exit 1; }
+          OUT=$(sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/release-version.sh" "$TAG" "$CHANNEL" "$SOURCE") || { echo "$OUT"; exit 1; }
           eval "$OUT"   # sets version / channel / prerelease / prekind / portversion
-          if [ "$channel" = "devel" ]; then BRANCH="devel"; else BRANCH="main"; fi
-          # Re-assert branch<->channel pairing (belt-and-braces; prepare-release already did this)
-          sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/release-version.sh" "$TAG" "$BRANCH" > /dev/null || {
-            echo "::error::tag ${TAG} is not valid for branch ${BRANCH} (channel ${channel})"
+          if [ "$release_line" != "$SOURCE" ]; then
+            echo "::error::tag ${TAG} does not belong to source ${SOURCE}"
             exit 1
-          }
+          fi
 
           {
             echo "tag=${TAG}"
             echo "version=${version}"
-            echo "channel=${channel}"
+            echo "channel=${release_channel}"
             echo "prerelease=${prerelease}"
             echo "portversion=${portversion}"
-            echo "branch=${BRANCH}"
+            echo "source=${SOURCE}"
             echo "dry_run=${DRY_RUN}"
           } >> "$GITHUB_OUTPUT"
           echo "Tag ${TAG}: channel=${channel} prerelease=${prerelease} portversion=${portversion} dry_run=${DRY_RUN}"
@@ -722,7 +786,10 @@ jobs:
             | { grep -v "^${TAG}$" || true; } \
             | while read -r t; do
                 git merge-base --is-ancestor "$t" "$COMMIT" 2>/dev/null || continue
-                tch=$(sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/release-version.sh" "$t" 2>/dev/null | sed -n 's/^channel=//p') || true
+                tch=$(git for-each-ref --format='%(contents)' "refs/tags/${t}" \
+                  | git interpret-trailers --parse \
+                  | sed -n 's/^pfBlockerNG-Release-Channel: \(stable\|testing\|edge\)$/\1/p') || true
+                [ "$(printf '%s\n' "$tch" | sed '/^$/d' | wc -l | tr -d ' ')" -eq 1 ] || continue
                 [ "$tch" = "$CHANNEL" ] && { echo "$t"; break; }
               done) || true
           # 2) Fallback: highest-version ANCESTOR tag of ANY channel.
@@ -819,6 +886,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
+          target_commitish: ${{ steps.meta.outputs.source }}
           name: ${{ steps.changelog.outputs.name }}
           body: ${{ steps.changelog.outputs.body }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
@@ -1231,7 +1299,6 @@ jobs:
           sparse-checkout: |
             net/pfSense-pkg-pfBlockerNG
             net/pfSense-pkg-pfBlockerNG-devel
-            net/pfSense-pkg-pfBlockerNG-nightly
           sparse-checkout-cone-mode: true
 
       - name: Checkout pfBlockerNG (the release helper — TRUSTED ref, sparse)
@@ -1261,39 +1328,36 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump PORTVERSION and push to use-github
-        # branch/version ride in via env (NOT inline ${{ }}) so a crafted tag can't
+        # source/channel/version ride in via env (NOT inline ${{ }}) so a crafted tag can't
         # template-inject into this shell.
         env:
-          BRANCH:      ${{ needs.release.outputs.branch }}
-          TAG:         ${{ needs.release.outputs.tag }}              # e.g. v4.0.0.alpha.1 | v4.0.0
-          PORTVERSION: ${{ needs.release.outputs.portversion }}  # e.g. 4.0.0.alpha.1 | 4.0.0 (pkg-safe)
+          SOURCE:      ${{ needs.release.outputs.source }}
+          CHANNEL:     ${{ needs.release.outputs.channel }}
+          TAG:         ${{ needs.release.outputs.tag }}              # e.g. v4.0.0.a1 | v4.0.0
+          PORTVERSION: ${{ needs.release.outputs.portversion }}  # e.g. 4.0.0.a1 | 4.0.0 (pkg-safe)
         run: |
           set -eu
           # PORTVERSION is already classified + pkg-safe (no '-') by release-version.sh
           # in the `release` job; re-assert the shape here as belt-and-braces so a
           # malformed value can never reach the Makefile.
-          if [ "$BRANCH" = "devel" ]; then
-            printf '%s' "$PORTVERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(alpha|beta|rc)\.[1-9][0-9]*$' || {
-              echo "::error::invalid devel PORTVERSION/tag: ${TAG}"; exit 1; }
-          else
+          if [ "$CHANNEL" = "stable" ]; then
+            printf '%s' "$SOURCE" | grep -Eq '^release/[0-9]+\.[0-9]+$' || {
+              echo "::error::invalid stable source line: ${SOURCE}"; exit 1; }
             printf '%s' "$PORTVERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' || {
               echo "::error::invalid stable PORTVERSION/tag: ${TAG}"; exit 1; }
+          else
+            printf '%s' "$SOURCE" | grep -Eq '^release/[0-9]+\.[0-9]+$' || {
+              echo "::error::invalid prerelease source line: ${SOURCE}"; exit 1; }
+            printf '%s' "$PORTVERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(alpha|beta|rc)\.[1-9][0-9]*$' || {
+              echo "::error::invalid prerelease PORTVERSION/tag: ${TAG}"; exit 1; }
           fi
 
-          # A devel release bumps TWO ports in lockstep: the -devel port (the Netgate
-          # devel package) AND the -nightly port. publish.yml (pfBlockerNG/pkg) derives
-          # the nightly base version from the -nightly port's PORTVERSION, so unless it
-          # advances together with -devel the nightlies stay pinned to a stale version
-          # and sort BELOW the current prerelease (e.g. 3.2.16.* < 4.0.0.alpha.2). They
-          # share an identical pkg-plist, differing only in PORTNAME/CONFLICTS/GH_ACCOUNT,
-          # so the version edit is the only thing to keep in sync. Both are committed in
-          # ONE commit so the two ports can never diverge. Stable touches only its port.
-          if [ "$BRANCH" = "devel" ]; then
-            PORT_PATHS="net/pfSense-pkg-pfBlockerNG-devel net/pfSense-pkg-pfBlockerNG-nightly"
-            PORTS_LABEL="net/pfSense-pkg-pfBlockerNG-{devel,nightly}"
-          else
+          if [ "$CHANNEL" = "stable" ]; then
             PORT_PATHS="net/pfSense-pkg-pfBlockerNG"
             PORTS_LABEL="net/pfSense-pkg-pfBlockerNG"
+          else
+            PORT_PATHS="net/pfSense-pkg-pfBlockerNG-devel"
+            PORTS_LABEL="net/pfSense-pkg-pfBlockerNG-devel"
           fi
 
           for PORT_PATH in $PORT_PATHS; do
@@ -1331,7 +1395,7 @@ jobs:
             git add "$MAKEFILE"
           done
 
-          # ONE atomic commit for every bumped port — devel + nightly move together.
+          # ONE atomic commit for every bumped port.
           if git diff --cached --quiet; then
             echo "${PORTS_LABEL} already at ${PORTVERSION} (${TAG}) — nothing to push."
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -787,7 +787,7 @@ jobs:
                 git merge-base --is-ancestor "$t" "$COMMIT" 2>/dev/null || continue
                 tch=$(git for-each-ref --format='%(contents)' "refs/tags/${t}" \
                   | git interpret-trailers --parse \
-                  | sed -n 's/^pfBlockerNG-Release-Channel: \(stable\|testing\|edge\)$/\1/p') || true
+                  | sed -n 's/^pfBlockerNG-Release-Channel: \(stable\|testing\|edge\)$/\1/p') || true # retired-token-ok: exact canonical trailer extraction
                 [ "$(printf '%s\n' "$tch" | sed '/^$/d' | wc -l | tr -d ' ')" -eq 1 ] || continue
                 [ "$tch" = "$CHANNEL" ] && { echo "$t"; break; }
               done) || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,7 +362,7 @@ jobs:
             RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
             TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
-            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel: ' || true)
+            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
               echo "::error::tag ${TAG} has invalid release-channel trailer metadata"
               exit 1
@@ -647,7 +647,7 @@ jobs:
             RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
             TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
-            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel: ' || true)
+            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
               echo "::error::tag ${TAG} has invalid release-channel trailer metadata"
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1348,7 +1348,7 @@ jobs:
           else
             printf '%s' "$SOURCE" | grep -Eq '^release/[0-9]+\.[0-9]+$' || {
               echo "::error::invalid prerelease source line: ${SOURCE}"; exit 1; }
-            printf '%s' "$PORTVERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(alpha|beta|rc)\.[1-9][0-9]*$' || {
+            printf '%s' "$PORTVERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.[abr][1-9][0-9]*$' || {
               echo "::error::invalid prerelease PORTVERSION/tag: ${TAG}"; exit 1; }
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,7 +362,7 @@ jobs:
             RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
             TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
-            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Ec '^pfBlockerNG-Release-Channel: ' || true)
+            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel: ' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
               echo "::error::tag ${TAG} has invalid release-channel trailer metadata"
               exit 1
@@ -647,7 +647,7 @@ jobs:
             RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
             TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
-            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Ec '^pfBlockerNG-Release-Channel: ' || true)
+            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel: ' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
               echo "::error::tag ${TAG} has invalid release-channel trailer metadata"
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,7 +362,7 @@ jobs:
             RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
             TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
-            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:' || true)
+            CHANNEL_TRAILERS=$(printf '%s\n' "$TRAILERS" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
               echo "::error::tag ${TAG} has invalid release-channel trailer metadata"
               exit 1
@@ -647,7 +647,7 @@ jobs:
             RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
             TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
-            CHANNEL_TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:' || true)
+            CHANNEL_TRAILERS=$(printf '%s\n' "$TRAILERS" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
               echo "::error::tag ${TAG} has invalid release-channel trailer metadata"
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,8 +359,7 @@ jobs:
               echo "::error::tag ${TAG} already exists at ${EXISTING}, but this release pins ${SHA} — delete the stale (unpublished) tag or bump the version"
               exit 1
             fi
-            RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
-            TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
+            TRAILERS=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" | git interpret-trailers --parse)
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
             CHANNEL_TRAILERS=$(printf '%s\n' "$TRAILERS" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
@@ -644,8 +643,7 @@ jobs:
               echo "::error::tag ${TAG} already exists at ${EXISTING}, but this run built and verified ${SHA} — delete the stale (unpublished) tag or bump the version"
               exit 1
             fi
-            RAW_TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}")
-            TRAILERS=$(printf '%s\n' "$RAW_TAG_MESSAGE" | git interpret-trailers --parse)
+            TRAILERS=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" | git interpret-trailers --parse)
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
             CHANNEL_TRAILERS=$(printf '%s\n' "$TRAILERS" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -552,8 +552,8 @@ jobs:
 
       # ADR-18: the `repo` flow's nightly cases (test_nightly_install.py) need a
       # builder-produced -nightly .pkg (the deep rename can't be cheaply forged).
-      # Build it here from devel HEAD via the portable builder + the new --channel
-      # nightly, off the SAME ports ref build-pkg-linux uses; export its path.
+      # Build it here from the exact checked-out source via the portable builder +
+      # --channel nightly, off the SAME ports ref build-pkg-linux uses; export its path.
       # Only for the `repo` marker (the default `smoke` flow doesn't read it).
       - name: Build a nightly .pkg (repo-flow nightly smoke)
         # build-leg.sh: shared build path; prints the resolved .pkg path on stdout.

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -571,12 +571,17 @@ jobs:
           export LEG
           RUN_ID="$(sh scripts/select-box.sh --print-id)"
           export RUN_ID
+          # Nightly fixture version: 3.2.16.YYYYMMDD[_N], UTC date with an
+          # optional counter for multiple same-day runs.
+          NIGHTLY_DATE="$(date -u +%Y%m%d)"
+          NIGHTLY_COUNT="${NIGHTLY_COUNT:-1}"
+          NIGHTLY_VERSION="3.2.16.${NIGHTLY_DATE}.${NIGHTLY_COUNT}"
           PKG="$(sh scripts/build-leg.sh \
             --channel    nightly \
             --abi        "$ABI" \
             --py-flavor  "$PY_FLAVOR" \
             --php        "$PHP_VERSION" \
-            --pkgversion 3.2.16.20260606.2 \
+            --pkgversion "$NIGHTLY_VERSION" \
             --annotate   "commit=${{ github.sha }}")"
           echo "SMOKE_NIGHTLY_PKG=$PKG" >> "$GITHUB_ENV"
 

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -571,11 +571,14 @@ jobs:
           export LEG
           RUN_ID="$(sh scripts/select-box.sh --print-id)"
           export RUN_ID
-          # Nightly fixture version: 3.2.16.YYYYMMDD[_N], UTC date with an
-          # optional counter for multiple same-day runs.
+          # Nightly fixture version: YYYYMMDD[_N], UTC date with an optional
+          # counter for multiple same-day runs.
           NIGHTLY_DATE="$(date -u +%Y%m%d)"
-          NIGHTLY_COUNT="${NIGHTLY_COUNT:-1}"
-          NIGHTLY_VERSION="3.2.16.${NIGHTLY_DATE}.${NIGHTLY_COUNT}"
+          NIGHTLY_COUNT="${NIGHTLY_COUNT:-0}"
+          NIGHTLY_VERSION="$NIGHTLY_DATE"
+          if [ "$NIGHTLY_COUNT" -gt 0 ]; then
+            NIGHTLY_VERSION="${NIGHTLY_DATE}_${NIGHTLY_COUNT}"
+          fi
           PKG="$(sh scripts/build-leg.sh \
             --channel    nightly \
             --abi        "$ABI" \

--- a/docs/misc/release-channels.md
+++ b/docs/misc/release-channels.md
@@ -1,136 +1,92 @@
 # Release channels and version order
 
-Issue #2140 defines the authoring contract used by later release automation. It does not
-publish packages, create releases, select branches, or change the on-box update client.
+Issue #2140 defines the release authoring contract consumed by later automation. It does
+not publish packages, discover release lines, or change the on-box update client.
 
-## Package identity
+## Shared identity and explicit channel
 
-Every channel publishes the same package identity:
+Every channel publishes the exact package identity:
 
 ```text
 pfSense-pkg-pfBlockerNG
 ```
 
-Channel is metadata and catalog placement, never a package-name suffix. This preserves the
-single-package model established by issues #1806 and #1828: the package remains architecture
-independent where the port permits it, and EOL `route-only` catalog behavior remains unchanged.
+Channel is metadata and catalog placement, never a package-name suffix. The channel and
+release line are explicit/configured and carried in an immutable tag trailer. The channel is
+explicit and configured; a parser must never infer channel from a suffix.
 
 ## Channel shapes
 
-Given target final version `X.Y.Z`:
-
-| Channel | Source | Version or tag | GitHub Release | Notes |
+| Channel | Source | Tag / package version | GitHub Release | Notes |
 | --- | --- | --- | --- | --- |
-| Stable | `release/X.Y` | tag `vX.Y.Z` | final | required |
-| Testing | `release/X.Y` | tag `vX.Y.Z.alpha.N`, `.beta.N`, or `.rc.N` | prerelease | required |
-| Edge | configured `release/X.Y` | tag `vX.Y.Z.edge.YYYYMMDD.N` | prerelease | required |
-| Nightly | `devel` | no tag | none | none |
+| Stable | configured `release/X.Y` | `vX.Y.Z` / `X.Y.Z` | final | required |
+| Testing | configured `release/X.Y` | `vX.Y.Z.aN`, `.bN`, or `.rN` / exact | prerelease | required |
+| Edge | configured `release/X.Y` | same Testing grammar / exact | prerelease | required |
+| Nightly | `devel` | untagged date counter | none | none |
 
-Stable and Testing tags are selected by a human. Edge and Nightly identifiers are generated
-from an immutable source commit, UTC date, and daily count. Edge notes use the same authored
-changelog path as Stable and Testing; there is no separate generated-notes path. Nightly is an
-untagged `devel` snapshot and therefore cannot create a GitHub Release or release notes.
+Stable, Testing, and Edge share a maintained release-line target. Edge follows Testing when
+there is no distinct Edge target. In that case, reuse the exact existing Testing Release and
+artifact bytes, checksums, source, provenance, tag, and notes. This preserves the same Release
+and artifact bytes, with no second Release and no rebuild. When the target becomes Stable, Edge
+continues to follow Testing until a new target is configured.
 
-The canonical parser result records package, channel, stage, target final, source line, tag,
-version, package version, prerelease/final flags, notes requirement, and GitHub Release kind.
-Nightly has `tag = None` and GitHub Release kind `none`.
+## Version and tag rules
 
-## FreeBSD package order
+- Stable `vX.Y.Z` maps to package version `X.Y.Z`.
+- Testing `vX.Y.Z.aN`, `vX.Y.Z.bN`, and `vX.Y.Z.rN` map to the exact matching package
+  versions. Edge uses this same grammar and mapping.
+- The immutable tag trailer records the selected channel and release line. Source identity,
+  package version, artifact bytes, checksum, and provenance are one immutable record.
+- Stable, Testing, and Edge create at most one Release for an exact tag. Published Releases
+  are immutable; retry only the exact same identity without rebuilding.
 
-The package versions targeting one final release are:
+## Nightly generation
 
-```text
-X.Y.(Z-1)
-X.Y.Z.alpha.N
-X.Y.Z.beta.N
-X.Y.Z.rc.N
-X.Y.Z.snapshot.1.YYYYMMDD.N   # Edge
-X.Y.Z.snapshot.2.YYYYMMDD.N   # Nightly
-X.Y.Z
-```
+Nightly is independent and untagged. It creates no GitHub Release and no release notes. Generate
+it from the `devel` branch when the input changes:
 
-The required strict order is:
+- the first changed input on a UTC date uses `YYYYMMDD`;
+- another changed input on that date uses `YYYYMMDD_1`, then `YYYYMMDD_2` and so on; and
+- an unchanged input or skipped day is a no-op.
+
+Nightly identity includes the source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
+The Ports recipe remains static: no routine version commit, no target final, and no PORTEPOCH.
+bare date versions intentionally outrank semantic releases. Reverse movement requires an
+explicit repo-qualified downgrade; no branch or suffix inference may select one.
+
+## Package order
+
+FreeBSD `pkg` is the ordering oracle. The intended order for one target is:
 
 ```text
 previous final < alpha < beta < rc < Edge < Nightly < target final
 ```
 
-Within Edge or Nightly, a later UTC date sorts after an earlier date and a higher same-day
-count sorts after a lower count. Code must not reproduce this comparison with SemVer, lexical,
-or tuple logic. Mutation callers supply the result observed from FreeBSD `pkg`/libpkg.
+Edge and Nightly use the exact package version emitted by their selected channel contract.
+Callers must ask FreeBSD `pkg`/libpkg to compare versions rather than reimplementing ordering
+with lexical, SemVer, or tuple comparisons.
 
-The external oracle was run on 2026-08-03 against every supported FreeBSD/pkg family:
+## Inputs and provenance
 
-| pfSense | FreeBSD | `pkg` | Result |
-| --- | --- | --- | --- |
-| CE 2.8 | 15 | 1.21.3 | full adjacent-pair table passed |
-| Plus 26.03 | 16 | 2.7.5 | full adjacent-pair table passed |
-| Plus 26.07 | 16 | 2.7.5 | full adjacent-pair table passed |
+The caller selects the source line before generation. Stable, Testing, and Edge receive their
+configured `release/X.Y`; Nightly receives `devel`. Source identity is immutable and exact.
+Every generated artifact records source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
+Missing, malformed, conflicting, or changed observations fail closed before mutation.
 
-The smoke oracle invokes `/usr/local/sbin/pkg version -t` directly on each appliance. Unit
-tests pin the exact generated strings; they do not claim to implement libpkg ordering.
+## Maintained lines and fixes
 
-## Snapshot generation
+Stable and Testing may coexist for each maintained `release/X.Y`; exactly one explicitly
+configured line supplies Edge. Supporting simultaneous Edge lines requires an owner decision
+and separate/equal-priority catalogs; branch sorting is never a substitute. Nightly follows
+`devel`.
 
-Snapshot generation is deterministic and fail-closed:
+Fixes start on the oldest affected maintained line. Land that line through its own PR and
+gates, then cherry-pick forward with `git cherry-pick -x` through newer maintained lines and
+finally `devel`, with separate PRs, conflict resolution, and gates. Merge commits are not
+used.
 
-- The caller selects the source line before generation. Edge must receive the configured exact
-  `release/X.Y`; Nightly must receive `devel`. The generator never lists or sorts branches.
-- The source is an exact lowercase 40- or 64-hex commit ID. Mutable names are rejected.
-- The date is an explicit UTC `date`. The first new source on a date receives count `1`; each
-  different source on that date receives the next count; a later date restarts at `1`.
-- Repeating the same channel, target, line, and source returns its original result, including
-  when retried on a later date. Conflicting records for one source fail.
-- A date older than an existing relevant snapshot fails. Duplicate versions, package versions,
-  or source records with conflicting content fail.
-- After final `X.Y.Z`, the next development target is `X.Y.(Z+1)` until a human chooses a
-  different maintained release line.
+## Scope and follow-ups
 
-The channel-specific generated values are:
-
-```text
-Edge tag:       vX.Y.Z.edge.YYYYMMDD.N
-Edge version:   X.Y.Z.edge.YYYYMMDD.N
-Edge pkg:       X.Y.Z.snapshot.1.YYYYMMDD.N
-
-Nightly tag:    none
-Nightly version:X.Y.Z.nightly.YYYYMMDD.N
-Nightly pkg:    X.Y.Z.snapshot.2.YYYYMMDD.N
-```
-
-## Mutation preconditions
-
-Later publication code must call the mutation boundary before its first write. The boundary
-permits a mutation only when all caller-observed facts are valid:
-
-- package identity and selected source line exactly match the canonical result;
-- the immutable source commit is reachable and an existing tag has not moved;
-- an existing published Release or draft with assets is never modified;
-- an assetless draft, or an absent release after creating the exact tag at the exact source,
-  is eligible for safe recovery;
-- `pkg`/libpkg reports the candidate newer than the current package version;
-- one package version cannot map to different artifact bytes; identical bytes are a no-op.
-
-Missing or malformed observations fail closed. The mutation callback is invoked only after all
-checks pass. This seam authorizes no publication in issue #2140; later publisher issues provide
-the observations and side effects.
-
-## Maintained release lines and fixes
-
-Stable and Testing may coexist for every maintained `release/X.Y` line. Exactly one release line
-is configured as active Edge. Supporting simultaneous Edge streams requires an owner decision
-and separate/equal-priority catalogs; branch-name ordering is never a substitute for that choice.
-Nightly always follows `devel`.
-
-Fixes start on the oldest affected maintained release line. Land that line through its own PR and
-gates, then cherry-pick forward with `git cherry-pick -x` through each newer maintained release
-line and finally `devel`. Each forward port gets its own PR, conflict resolution, and gates. A
-`devel`-only fix stays on `devel`. Merge commits are not used.
-
-## Compatibility and follow-ups
-
-The shell parser keeps its first five legacy assignments for existing workflows and appends the
-canonical fields. Temporary `main`/`devel` branch aliases are restricted to Stable/Testing legacy
-callers. Issue #2143 owns workflow migration to canonical release lines and generation.
-Builder, publisher, catalog, and client/UI behavior belongs to issues #2144–#2148.
-FreeBSD-ports changes belong to issue #2141. None of those surfaces change in #2140.
+This contract authorizes no publication or workflow implementation by itself. Existing
+workflow consumers remain current at the issue #2140 base revision. Builder, publisher,
+catalog, client/UI, and Ports changes belong to their separately scoped follow-up issues.

--- a/docs/misc/release-channels.md
+++ b/docs/misc/release-channels.md
@@ -11,11 +11,11 @@ Every channel publishes the exact package identity:
 pfSense-pkg-pfBlockerNG
 ```
 
-Channel is metadata and catalog placement, never a package-name suffix. The channel and
-release line are explicit/configured and carried in an immutable tag trailer. The channel is
-explicit and configured; `pfBlockerNG-Release-Channel: <stable|testing|edge>` is the trailer
-key, and a parser must never infer channel from a suffix. Every operation uses a pinned source
-SHA.
+Channel is metadata and catalog placement, never a package-name suffix. Channel and release
+line are explicit/configured. The tag trailer carries only the channel, using
+`pfBlockerNG-Release-Channel: <stable|testing|edge>`; the parser derives the exact
+`release/X.Y` line from the tag and validates it against the configured line. It must never
+infer channel from a suffix. Every operation uses a pinned source SHA.
 
 ## Channel shapes
 
@@ -38,8 +38,9 @@ continues to follow Testing until a new target is configured.
 - Stable `vX.Y.Z` maps to package version `X.Y.Z`.
 - Testing `vX.Y.Z.aN`, `vX.Y.Z.bN`, and `vX.Y.Z.rN` map to the exact matching package
   versions. Edge uses this same grammar and mapping.
-- The immutable tag trailer records the selected channel and release line. Source identity,
-  package version, artifact bytes, checksum, and provenance are one immutable record.
+- The immutable tag trailer records the selected channel. The configured release line is
+  validated against the line derived from the tag. Source identity, package version,
+  artifact bytes, checksum, and provenance are one immutable record.
 - Stable, Testing, and Edge create at most one Release for an exact tag. Published Releases
   are immutable; retry only the exact same identity without rebuilding.
 
@@ -62,7 +63,7 @@ explicit repo-qualified downgrade; no branch or suffix inference may select one.
 FreeBSD `pkg` is the ordering oracle. The intended order for one target is:
 
 ```text
-previous final < alpha < beta < rc < Edge < Nightly < target final
+previous final < alpha < beta < rc < target final < bare Nightly date
 ```
 
 Edge and Nightly use the exact package version emitted by their selected channel contract.
@@ -91,6 +92,6 @@ used.
 
 ## Scope and follow-ups
 
-This contract authorizes no publication or workflow implementation by itself. Existing
-workflow consumers remain current at the issue #2140 base revision. Builder, publisher,
-catalog, client/UI, and Ports changes belong to their separately scoped follow-up issues.
+This contract updates the classifier and existing release workflow consumers. New builder,
+publisher, catalog, client/UI, and Ports mechanisms belong to their separately scoped
+follow-up issues.

--- a/docs/misc/release-channels.md
+++ b/docs/misc/release-channels.md
@@ -81,8 +81,8 @@ Missing, malformed, conflicting, or changed observations fail closed before muta
 
 Stable and Testing may coexist for each maintained `release/X.Y`; exactly one explicitly
 configured line supplies Edge. Supporting simultaneous Edge lines requires an owner decision
-and separate/equal-priority catalogs; branch sorting is never a substitute. Nightly follows
-`devel`.
+and separate/equal-priority catalogs; branch sorting is never a substitute. Nightly uses an
+explicit pinned source SHA; no branch inference selects it.
 
 Fixes start on the oldest affected maintained line. Land that line through its own PR and
 gates, then cherry-pick forward with `git cherry-pick -x` through newer maintained lines and

--- a/docs/misc/release-channels.md
+++ b/docs/misc/release-channels.md
@@ -13,7 +13,9 @@ pfSense-pkg-pfBlockerNG
 
 Channel is metadata and catalog placement, never a package-name suffix. The channel and
 release line are explicit/configured and carried in an immutable tag trailer. The channel is
-explicit and configured; a parser must never infer channel from a suffix.
+explicit and configured; `pfBlockerNG-Release-Channel: <stable|testing|edge>` is the trailer
+key, and a parser must never infer channel from a suffix. Every operation uses a pinned source
+SHA.
 
 ## Channel shapes
 
@@ -22,10 +24,11 @@ explicit and configured; a parser must never infer channel from a suffix.
 | Stable | configured `release/X.Y` | `vX.Y.Z` / `X.Y.Z` | final | required |
 | Testing | configured `release/X.Y` | `vX.Y.Z.aN`, `.bN`, or `.rN` / exact | prerelease | required |
 | Edge | configured `release/X.Y` | same Testing grammar / exact | prerelease | required |
-| Nightly | `devel` | untagged date counter | none | none |
+| Nightly | explicit pinned source SHA | untagged date counter | none | none |
 
-Stable, Testing, and Edge share a maintained release-line target. Edge follows Testing when
-there is no distinct Edge target. In that case, reuse the exact existing Testing Release and
+Stable, Testing, and Edge share a maintained release-line target. Edge follows Testing only when no distinct target
+exists; distinct-target Edge uses its configured target/line. In that
+case, reuse the exact existing Testing Release and
 artifact bytes, checksums, source, provenance, tag, and notes. This preserves the same Release
 and artifact bytes, with no second Release and no rebuild. When the target becomes Stable, Edge
 continues to follow Testing until a new target is configured.
@@ -43,7 +46,7 @@ continues to follow Testing until a new target is configured.
 ## Nightly generation
 
 Nightly is independent and untagged. It creates no GitHub Release and no release notes. Generate
-it from the `devel` branch when the input changes:
+it when the pinned source input changes:
 
 - the first changed input on a UTC date uses `YYYYMMDD`;
 - another changed input on that date uses `YYYYMMDD_1`, then `YYYYMMDD_2` and so on; and
@@ -51,7 +54,7 @@ it from the `devel` branch when the input changes:
 
 Nightly identity includes the source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
 The Ports recipe remains static: no routine version commit, no target final, and no PORTEPOCH.
-bare date versions intentionally outrank semantic releases. Reverse movement requires an
+Bare date versions intentionally outrank semantic releases. Reverse movement requires an
 explicit repo-qualified downgrade; no branch or suffix inference may select one.
 
 ## Package order
@@ -69,7 +72,8 @@ with lexical, SemVer, or tuple comparisons.
 ## Inputs and provenance
 
 The caller selects the source line before generation. Stable, Testing, and Edge receive their
-configured `release/X.Y`; Nightly receives `devel`. Source identity is immutable and exact.
+configured `release/X.Y`; Nightly receives an explicit pinned source SHA. Source identity is
+immutable and exact.
 Every generated artifact records source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
 Missing, malformed, conflicting, or changed observations fail closed before mutation.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,28 @@ none of this ships in the release archive (which contains only `src/`).
 | [`mcp-token-savior.sh`](mcp-token-savior.sh) | Install the pinned upstream Token Savior release in a shared per-user venv and launch its MCP server for Claude or Codex. |
 | [`ts-hook.sh`](ts-hook.sh) | Run Token Savior's shared tool-capture hook for Claude or Codex. |
 
+## Release channel contract
+
+Release authoring follows issue #2140. All channels publish the exact package identity
+`pfSense-pkg-pfBlockerNG`; channel is explicit/configured metadata carried in an immutable
+tag trailer, never a package-name suffix or inferred tag shape.
+
+- Stable uses `vX.Y.Z` / `X.Y.Z`.
+- Testing uses `vX.Y.Z.aN`, `vX.Y.Z.bN`, or `vX.Y.Z.rN` with the exact package version.
+- Edge uses the same Testing grammar and follows Testing on one configured `release/X.Y`.
+  Without a distinct target, reuse the same Release and artifact bytes, checksums, source,
+  provenance, tag, and notes: no rebuild and no second Release. If its target becomes Stable,
+  Edge follows Testing until a new target is configured.
+- Nightly is an independent untagged `devel` snapshot with no GitHub Release and no release
+  notes. Changed input uses UTC `YYYYMMDD`, then `YYYYMMDD_1`/`_2` for same-day changes;
+  unchanged or skipped days are no-ops. Identity includes source SHA, FreeBSD-ports SHA,
+  and matrix/dependency digest.
+
+Keep the Ports recipe static: no routine version commit, no target final, and no PORTEPOCH.
+Bare date versions intentionally outrank semantic releases; reverse movement requires an
+explicit repo-qualified downgrade. `scripts/release-version.sh` remains the parser; callers
+must pass explicit channel context and must not reimplement or infer its grammar.
+
 ## Supported-version matrix
 
 The single source of truth for which pfSense versions pfBlockerNG supports lives on
@@ -143,7 +165,7 @@ pfBlockerNG is a `NO_BUILD` port (nothing compiles) and `pkg add` checks a depen
 
 ### Where `.pkg` artifacts land
 
-A tag push (`vX.Y.Z[-devel]`) triggers `release.yml`, which reads `build_matrix` — already
+A Stable, Testing, or Edge release dispatch triggers `release.yml`, which reads `build_matrix` — already
 deduplicated by `read-version-matrix.sh` to one row per distinct FreeBSD major (issue #1806) —
 and builds one `.pkg` per row against its `(freebsd_version, php_version)` pair. Artifacts
 are attached to the **GitHub Release** named `pfBlockerNG-relpkg-fbsd<major>`; one `.pkg`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,7 +25,7 @@ or inferred tag shape. Every operation uses a pinned source SHA.
   same Release and artifact bytes, checksums, source,
   provenance, tag, and notes: no rebuild and no second Release. If its target becomes Stable,
   Edge follows Testing until a new target is configured.
-- Nightly is an independent untagged `devel` snapshot with no GitHub Release and no release
+- Nightly is an independent untagged snapshot from a pinned source SHA with no GitHub Release and no release
   notes. Changed input uses UTC `YYYYMMDD`, then `YYYYMMDD_1`/`_2` for same-day changes;
   unchanged or skipped days are no-ops. Identity includes source SHA, FreeBSD-ports SHA,
   and matrix/dependency digest.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,9 +14,10 @@ none of this ships in the release archive (which contains only `src/`).
 ## Release channel contract
 
 Release authoring follows issue #2140. All channels publish the exact package identity
-`pfSense-pkg-pfBlockerNG`; channel is explicit/configured metadata carried in an immutable
-`pfBlockerNG-Release-Channel: <stable|testing|edge>` tag trailer, never a package-name suffix
-or inferred tag shape. Every operation uses a pinned source SHA.
+`pfSense-pkg-pfBlockerNG`; channel is explicit/configured metadata carried in each distinct
+release's immutable `pfBlockerNG-Release-Channel: <stable|testing|edge>` tag trailer, never a
+package-name suffix or inferred tag shape. A follower Edge reuses the Testing tag and its
+`testing` trailer. Every operation uses a pinned source SHA.
 
 - Stable uses `vX.Y.Z` / `X.Y.Z`.
 - Testing uses `vX.Y.Z.aN`, `vX.Y.Z.bN`, or `vX.Y.Z.rN` with the exact package version.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,12 +15,14 @@ none of this ships in the release archive (which contains only `src/`).
 
 Release authoring follows issue #2140. All channels publish the exact package identity
 `pfSense-pkg-pfBlockerNG`; channel is explicit/configured metadata carried in an immutable
-tag trailer, never a package-name suffix or inferred tag shape.
+`pfBlockerNG-Release-Channel: <stable|testing|edge>` tag trailer, never a package-name suffix
+or inferred tag shape. Every operation uses a pinned source SHA.
 
 - Stable uses `vX.Y.Z` / `X.Y.Z`.
 - Testing uses `vX.Y.Z.aN`, `vX.Y.Z.bN`, or `vX.Y.Z.rN` with the exact package version.
-- Edge uses the same Testing grammar and follows Testing on one configured `release/X.Y`.
-  Without a distinct target, reuse the same Release and artifact bytes, checksums, source,
+- Edge uses the same Testing grammar. Edge follows Testing only when no distinct target exists;
+  distinct-target Edge uses its configured target/line. Without a distinct target, reuse the
+  same Release and artifact bytes, checksums, source,
   provenance, tag, and notes: no rebuild and no second Release. If its target becomes Stable,
   Edge follows Testing until a new target is configured.
 - Nightly is an independent untagged `devel` snapshot with no GitHub Release and no release

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -83,7 +83,7 @@ agent_work_branch_spec.sh:5
 composer_cloud_install_spec.sh:4
 git_no_docs_spec.sh:5
 githooks_pre_push_lease_spec.sh:33
-githooks_pre_push_tag_scheme_spec.sh:17
+githooks_pre_push_tag_scheme_spec.sh:28
 githooks_prepare_commit_msg_guard_spec.sh:18
 pfblockerng_truncate_survival_spec.sh:4
 precommit_composer_vendor_spec.sh:2

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -83,7 +83,7 @@ agent_work_branch_spec.sh:5
 composer_cloud_install_spec.sh:4
 git_no_docs_spec.sh:5
 githooks_pre_push_lease_spec.sh:33
-githooks_pre_push_tag_scheme_spec.sh:7
+githooks_pre_push_tag_scheme_spec.sh:13
 githooks_prepare_commit_msg_guard_spec.sh:18
 pfblockerng_truncate_survival_spec.sh:4
 precommit_composer_vendor_spec.sh:2

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -83,7 +83,7 @@ agent_work_branch_spec.sh:5
 composer_cloud_install_spec.sh:4
 git_no_docs_spec.sh:5
 githooks_pre_push_lease_spec.sh:33
-githooks_pre_push_tag_scheme_spec.sh:13
+githooks_pre_push_tag_scheme_spec.sh:17
 githooks_prepare_commit_msg_guard_spec.sh:18
 pfblockerng_truncate_survival_spec.sh:4
 precommit_composer_vendor_spec.sh:2

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
-# Usage: release-version.sh <tag> [branch]
-# Tags: vX.Y.Z (Stable), vX.Y.Z.{alpha|beta|rc}.N (Testing), or
-#       vX.Y.Z.edge.YYYYMMDD.N (Edge); optional branch must be release/X.Y,
-#       with main/devel accepted as legacy aliases for Stable/Testing only.
-# Python API branch validation is canonical by default; pass legacy=True for those aliases.
+# Usage: release-version.sh <tag> <channel> [branch]
+# Tags: vX.Y.Z (stable), or vX.Y.Z.{a|b|r}N (testing/edge); optional branch
+# must be the matching release/X.Y line.
 # Output: legacy version/channel/prerelease/prekind/portversion first, then
 #         canonical release_channel/tag/stage/sequence/target_final/release_line/
 #         final/notes_required/github_release/package KEY=VALUE assignments.

--- a/scripts/release_mutation.py
+++ b/scripts/release_mutation.py
@@ -1,4 +1,4 @@
-"""Fail-closed preconditions for release artifact mutation."""
+"""Fail-closed preconditions for tagged and independent Nightly mutation."""
 
 from __future__ import annotations
 
@@ -6,13 +6,16 @@ import re
 from dataclasses import dataclass
 from typing import Callable, Literal
 
-from scripts.release_version import ReleaseInfo, validate_release_info
+from scripts import release_version as rv
 
+ReleaseInfo = rv.ReleaseInfo
+NightlyAllocation = rv.NightlyAllocation
 ReleaseState = Literal["absent", "draft_assetless", "draft_with_assets", "published"]
 Comparison = Literal["<", "=", ">"]
 MutationOutcome = Literal["mutated", "unchanged"]
 
 _SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _ARTIFACT_RE = re.compile(r"^[0-9a-f]{64}$")
 _RELEASE_STATES = ("absent", "draft_assetless", "draft_with_assets", "published")
 _COMPARISONS = ("<", "=", ">")
@@ -20,9 +23,11 @@ _COMPARISONS = ("<", "=", ">")
 
 @dataclass(frozen=True)
 class MutationRequest:
-    result: ReleaseInfo
-    selected_release_line: str
+    result: ReleaseInfo | NightlyAllocation
+    selected_release_line: str | None
     source_sha: str
+    ports_sha: str
+    input_digest: str
     artifact_sha256: str
 
 
@@ -36,11 +41,19 @@ class ObservedMutationState:
     candidate_vs_latest: Comparison | None = None
     existing_pkg_version: str | None = None
     existing_artifact_sha256: str | None = None
+    existing_source_sha: str | None = None
+    existing_ports_sha: str | None = None
+    existing_input_digest: str | None = None
 
 
 def _validate_sha(value: object, *, name: str) -> None:
     if not isinstance(value, str) or not _SHA_RE.fullmatch(value):
         raise ValueError(f"{name} must be lowercase 40- or 64-character hex")
+
+
+def _validate_digest(value: object, *, name: str) -> None:
+    if not isinstance(value, str) or not _DIGEST_RE.fullmatch(value):
+        raise ValueError(f"{name} must be lowercase 64-character hex")
 
 
 def _validate_artifact_sha(value: object) -> None:
@@ -71,11 +84,16 @@ def _validate_observed_tag(value: object) -> None:
         raise ValueError("tag must be a printable ASCII release tag of at most 128 characters")
 
 
-def _validate_result(result: object) -> ReleaseInfo:
-    if type(result) is not ReleaseInfo:
-        raise TypeError("request.result must be ReleaseInfo")
-    validate_release_info(result)
-    return result
+def _validate_result(result: object) -> tuple[bool, str, str, str, str]:
+    if type(result) is ReleaseInfo:
+        rv.validate_release_info(result)
+        if result.tag is None:
+            raise ValueError("Nightly must use NightlyAllocation")
+        return False, result.pkg_version, "", "", ""
+    if type(result) is NightlyAllocation:
+        rv.validate_nightly_allocation(result)
+        return True, result.pkg_version, result.source_sha, result.ports_sha, result.input_digest
+    raise TypeError("request.result must be ReleaseInfo or NightlyAllocation")
 
 
 def _validate_observed(observed: object) -> ObservedMutationState:
@@ -83,22 +101,33 @@ def _validate_observed(observed: object) -> ObservedMutationState:
         raise TypeError("observed must be ObservedMutationState")
     if observed.source_reachable is not True:
         raise ValueError("source must be reachable")
-    if not isinstance(observed.release_state, str) or observed.release_state not in _RELEASE_STATES:
+    if observed.release_state not in _RELEASE_STATES:
         raise ValueError("invalid release state")
     if observed.tag is not None:
         _validate_observed_tag(observed.tag)
-    if observed.candidate_vs_latest is not None and (
-        not isinstance(observed.candidate_vs_latest, str) or observed.candidate_vs_latest not in _COMPARISONS
-    ):
+    if observed.candidate_vs_latest is not None and observed.candidate_vs_latest not in _COMPARISONS:
         raise ValueError("invalid package comparison")
     if (observed.latest_pkg_version is None) != (observed.candidate_vs_latest is None):
         raise ValueError("latest package version and comparison must be paired")
-    if (observed.existing_pkg_version is None) != (observed.existing_artifact_sha256 is None):
-        raise ValueError("existing package version and artifact digest must be paired")
+    existing_values = (
+        observed.existing_pkg_version,
+        observed.existing_artifact_sha256,
+        observed.existing_source_sha,
+        observed.existing_ports_sha,
+        observed.existing_input_digest,
+    )
+    if any(value is None for value in existing_values) and any(value is not None for value in existing_values):
+        raise ValueError("existing package and provenance observations must be paired")
     _validate_pkg_observation(observed.latest_pkg_version, name="latest_pkg_version")
     _validate_pkg_observation(observed.existing_pkg_version, name="existing_pkg_version")
     if observed.existing_artifact_sha256 is not None:
         _validate_artifact_sha(observed.existing_artifact_sha256)
+    if observed.existing_source_sha is not None:
+        _validate_sha(observed.existing_source_sha, name="existing_source_sha")
+    if observed.existing_ports_sha is not None:
+        _validate_sha(observed.existing_ports_sha, name="existing_ports_sha")
+    if observed.existing_input_digest is not None:
+        _validate_digest(observed.existing_input_digest, name="existing_input_digest")
     if observed.tag_source_sha is not None:
         _validate_sha(observed.tag_source_sha, name="tag_source_sha")
     if (observed.tag is None) != (observed.tag_source_sha is None):
@@ -106,16 +135,22 @@ def _validate_observed(observed: object) -> ObservedMutationState:
     return observed
 
 
-def _validate_tag_state(result: ReleaseInfo, request: MutationRequest, observed: ObservedMutationState) -> bool:
+def _validate_tag_state(
+    nightly: bool, result: ReleaseInfo | NightlyAllocation, request: MutationRequest, observed: ObservedMutationState
+) -> bool:
     """Validate tag/release identity; return whether assetless recovery is allowed."""
-    nightly = result.tag is None
     if observed.release_state in {"draft_with_assets", "published"}:
         raise ValueError("existing release is immutable")
     if nightly:
+        if request.selected_release_line is not None:
+            raise ValueError("Nightly has no selected release line")
         if observed.tag is not None or observed.tag_source_sha is not None or observed.release_state != "absent":
             raise ValueError("Nightly mutation requires an absent untagged release")
         return False
 
+    assert isinstance(result, ReleaseInfo)
+    if request.selected_release_line != result.release_line:
+        raise ValueError("selected release line does not match result")
     if observed.release_state == "absent":
         if observed.tag is None and observed.tag_source_sha is None:
             return False
@@ -123,10 +158,8 @@ def _validate_tag_state(result: ReleaseInfo, request: MutationRequest, observed:
             return True
         raise ValueError("existing tag is already present or moved")
     if observed.release_state == "draft_assetless":
-        if observed.tag != result.tag:
-            raise ValueError("assetless draft has a different tag")
-        if observed.tag_source_sha != request.source_sha:
-            raise ValueError("tag moved to a different source")
+        if observed.tag != result.tag or observed.tag_source_sha != request.source_sha:
+            raise ValueError("assetless draft tag/source mismatch")
         return True
     raise ValueError("invalid tagged release state")
 
@@ -136,32 +169,48 @@ def apply_release_mutation(
     observed: ObservedMutationState,
     mutate: Callable[[], object],
 ) -> MutationOutcome:
-    """Apply mutation only after all release identity and artifact preconditions pass."""
+    """Apply mutation only after release, artifact, and input provenance checks pass."""
     if type(request) is not MutationRequest:
         raise TypeError("request must be MutationRequest")
     if not callable(mutate):
         raise TypeError("mutate must be callable")
-    result = _validate_result(request.result)
-    if not isinstance(request.selected_release_line, str) or request.selected_release_line != result.release_line:
-        raise ValueError("selected release line does not match result")
+    nightly, pkg_version, result_source, result_ports, result_digest = _validate_result(request.result)
+    if not isinstance(request.selected_release_line, (str, type(None))):
+        raise TypeError("selected_release_line must be str or None")
     _validate_sha(request.source_sha, name="source_sha")
+    _validate_sha(request.ports_sha, name="ports_sha")
+    _validate_digest(request.input_digest, name="input_digest")
     _validate_artifact_sha(request.artifact_sha256)
+    if nightly and (request.source_sha, request.ports_sha, request.input_digest) != (
+        result_source,
+        result_ports,
+        result_digest,
+    ):
+        raise ValueError("Nightly request provenance does not match allocation")
     state = _validate_observed(observed)
-    recovery = _validate_tag_state(result, request, state)
-    comparison = state.candidate_vs_latest
-    if comparison == "<":
+    recovery = _validate_tag_state(nightly, request.result, request, state)
+    if not nightly and request.selected_release_line != request.result.release_line:  # type: ignore[union-attr]
+        raise ValueError("selected release line does not match result")
+    if state.candidate_vs_latest == "<":
         raise ValueError("candidate package is stale")
 
-    if state.existing_pkg_version == result.pkg_version:
+    if state.existing_pkg_version == pkg_version:
         if state.existing_artifact_sha256 != request.artifact_sha256:
             raise ValueError("artifact collision for existing package version")
+        if (
+            state.existing_source_sha,
+            state.existing_ports_sha,
+            state.existing_input_digest,
+        ) != (request.source_sha, request.ports_sha, request.input_digest):
+            raise ValueError("build input collision for existing package version")
+        if nightly:
+            return "unchanged"
         if recovery:
             mutate()
             return "mutated"
         return "unchanged"
 
-    if comparison == "=" and not recovery:
+    if state.candidate_vs_latest == "=" and not recovery:
         raise ValueError("candidate package already exists")
-
     mutate()
     return "mutated"

--- a/scripts/release_mutation.py
+++ b/scripts/release_mutation.py
@@ -191,12 +191,10 @@ def apply_release_mutation(
     recovery = _validate_tag_state(nightly, request.result, request, state)
     if nightly:
         assert isinstance(request.result, NightlyAllocation)
-        if request.result.outcome == "unchanged" and state.existing_pkg_version is None:
-            raise ValueError("Nightly no-op requires observed existing package")
+        if request.result.outcome == "unchanged" and state.existing_pkg_version != pkg_version:
+            raise ValueError("Nightly no-op requires exact observed existing package")
     if not nightly and request.selected_release_line != request.result.release_line:  # type: ignore[union-attr]
         raise ValueError("selected release line does not match result")
-    if state.candidate_vs_latest == "<":
-        raise ValueError("candidate package is stale")
 
     if state.existing_pkg_version == pkg_version:
         if state.existing_artifact_sha256 != request.artifact_sha256:
@@ -213,6 +211,9 @@ def apply_release_mutation(
             mutate()
             return "mutated"
         return "unchanged"
+
+    if state.candidate_vs_latest == "<":
+        raise ValueError("candidate package is stale")
 
     if state.candidate_vs_latest == "=" and not recovery:
         raise ValueError("candidate package already exists")

--- a/scripts/release_mutation.py
+++ b/scripts/release_mutation.py
@@ -193,9 +193,6 @@ def apply_release_mutation(
         assert isinstance(request.result, NightlyAllocation)
         if request.result.outcome == "unchanged" and state.existing_pkg_version != pkg_version:
             raise ValueError("Nightly no-op requires exact observed existing package")
-    if not nightly and request.selected_release_line != request.result.release_line:  # type: ignore[union-attr]
-        raise ValueError("selected release line does not match result")
-
     if state.existing_pkg_version == pkg_version:
         if state.existing_artifact_sha256 != request.artifact_sha256:
             raise ValueError("artifact collision for existing package version")

--- a/scripts/release_mutation.py
+++ b/scripts/release_mutation.py
@@ -189,6 +189,10 @@ def apply_release_mutation(
         raise ValueError("Nightly request provenance does not match allocation")
     state = _validate_observed(observed)
     recovery = _validate_tag_state(nightly, request.result, request, state)
+    if nightly:
+        assert isinstance(request.result, NightlyAllocation)
+        if request.result.outcome == "unchanged" and state.existing_pkg_version is None:
+            raise ValueError("Nightly no-op requires observed existing package")
     if not nightly and request.selected_release_line != request.result.release_line:  # type: ignore[union-attr]
         raise ValueError("selected release line does not match result")
     if state.candidate_vs_latest == "<":

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -121,9 +121,9 @@ def parse_release_tag(tag: str, channel: Channel | None = None) -> ReleaseInfo:
     raise _invalid(tag)
 
 
-def _validate_source_sha(source_sha: str) -> None:
+def _validate_source_sha(source_sha: str, *, name: str = "source_sha") -> None:
     if not isinstance(source_sha, str) or not _SHA_RE.fullmatch(source_sha):
-        raise ValueError("source_sha must be lowercase 40- or 64-character hex")
+        raise ValueError(f"{name} must be lowercase 40- or 64-character hex")
 
 
 def validate_release_info(info: ReleaseInfo) -> None:
@@ -166,7 +166,7 @@ def _validate_nightly_allocation(value: object) -> NightlyAllocation:
     if value.pkg_version != expected_pkg or not _NIGHTLY_PKG_RE.fullmatch(value.pkg_version):
         raise ValueError("invalid Nightly package version")
     _validate_source_sha(value.source_sha)
-    _validate_source_sha(value.ports_sha)
+    _validate_source_sha(value.ports_sha, name="ports_sha")
     _validate_digest(value.input_digest)
     return value
 
@@ -179,7 +179,7 @@ def validate_nightly_allocation(value: NightlyAllocation) -> None:
 def combined_nightly_input_digest(source_sha: str, ports_sha: str, input_digest: str) -> str:
     """Return deterministic provenance digest for downstream build annotations."""
     _validate_source_sha(source_sha)
-    _validate_source_sha(ports_sha)
+    _validate_source_sha(ports_sha, name="ports_sha")
     _validate_digest(input_digest)
     payload = "\0".join((source_sha, ports_sha, input_digest)).encode("ascii")
     return hashlib.sha256(payload).hexdigest()
@@ -196,7 +196,7 @@ def allocate_nightly(
     if type(build_date) is not date:
         raise TypeError("build_date must be datetime.date")
     _validate_source_sha(source_sha)
-    _validate_source_sha(ports_sha)
+    _validate_source_sha(ports_sha, name="ports_sha")
     _validate_digest(input_digest)
     try:
         records = tuple(existing)

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 import sys
 from dataclasses import dataclass
@@ -22,7 +23,9 @@ _PREVIEW_RE = re.compile(
 )
 _BARE_VERSION_RE = re.compile(rf"^(?P<major>{_CORE})\.(?P<minor>{_CORE})\.(?P<patch>{_CORE})$")
 _SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
-_SEQUENCE_RE = re.compile(r"^(?P<date>[0-9]{8})\.(?P<count>[1-9][0-9]*)$")
+_NIGHTLY_RE = re.compile(r"^(?P<date>[0-9]{8})$")
+_NIGHTLY_PKG_RE = re.compile(r"^(?P<date>[0-9]{8})(?:_(?P<revision>[1-9][0-9]*))?$")
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _MAX_RELEASE_TEXT = 128
 
 
@@ -43,10 +46,18 @@ class ReleaseInfo:
     package: str
 
 
+NightlyOutcome = Literal["build", "unchanged"]
+
+
 @dataclass(frozen=True)
-class SnapshotRecord:
+class NightlyAllocation:
+    outcome: NightlyOutcome
+    portversion: str
+    portrevision: int
+    pkg_version: str
     source_sha: str
-    result: ReleaseInfo
+    ports_sha: str
+    input_digest: str
 
 
 def _invalid(tag: str) -> ValueError:
@@ -133,167 +144,121 @@ def _validate_source_sha(source_sha: str) -> None:
         raise ValueError("source_sha must be lowercase 40- or 64-character hex")
 
 
-def _sequence_parts(sequence: str) -> tuple[date, int]:
-    if not isinstance(sequence, str):
-        raise ValueError("snapshot sequence must be YYYYMMDD.N")
-    match = _SEQUENCE_RE.fullmatch(sequence)
-    if not match:
-        raise ValueError("snapshot sequence must be YYYYMMDD.N")
-    raw_date = match.group("date")
-    try:
-        build_date = date(int(raw_date[:4]), int(raw_date[4:6]), int(raw_date[6:]))
-    except ValueError as exc:
-        raise ValueError(f"invalid snapshot calendar date: {raw_date}") from exc
-    return build_date, int(match.group("count"))
-
-
-def _date_text(build_date: date) -> str:
-    return f"{build_date.year:04d}{build_date.month:02d}{build_date.day:02d}"
-
-
-def _validate_nightly_result(result: ReleaseInfo) -> None:
-    major, minor, patch = _parse_bare_version(result.target_final)
-    build_date, count = _sequence_parts(result.sequence or "")
-    date_text = _date_text(build_date)
-    expected_version = f"{result.target_final}.nightly.{date_text}.{count}"
-    expected_pkg = f"{result.target_final}.snapshot.2.{date_text}.{count}"
-    if result.tag is not None or result.stage != "nightly" or result.channel != "nightly":
-        raise ValueError("invalid Nightly snapshot result")
-    if result.release_line != "devel" or result.version != expected_version or result.pkg_version != expected_pkg:
-        raise ValueError("invalid Nightly snapshot result")
-    if result.target_final != f"{major}.{minor}.{patch}" or result.prerelease is not True or result.final is not False:
-        raise ValueError("invalid Nightly snapshot result")
-    if result.notes_required is not False or result.github_release != "none" or result.package != PACKAGE:
-        raise ValueError("invalid Nightly snapshot result")
-
-
 def validate_release_info(info: ReleaseInfo) -> None:
     """Require a ReleaseInfo value to be exactly one canonical release identity."""
     if type(info) is not ReleaseInfo:
         raise TypeError("release info must be ReleaseInfo")
     if info.tag is None:
-        _validate_nightly_result(info)
-    elif parse_release_tag(info.tag, info.channel) != info:
+        raise ValueError("Nightly uses NightlyAllocation, not ReleaseInfo")
+    if parse_release_tag(info.tag, info.channel) != info:
         raise ValueError("release info does not match its release tag")
     if len(info.version) > _MAX_RELEASE_TEXT or len(info.pkg_version) > _MAX_RELEASE_TEXT:
         raise ValueError(f"release identity exceeds {_MAX_RELEASE_TEXT} characters")
 
 
-def _validate_snapshot_result(result: ReleaseInfo) -> tuple[date, int]:
-    validate_release_info(result)
-    if result.channel == "edge":
-        return _sequence_parts(result.sequence or "")
-    if result.channel == "nightly":
-        return _sequence_parts(result.sequence or "")
-    raise ValueError("existing records must contain Edge or Nightly snapshots")
+def _validate_digest(value: object, *, name: str = "input_digest") -> None:
+    if not isinstance(value, str) or not _DIGEST_RE.fullmatch(value):
+        raise ValueError(f"{name} must be lowercase 64-character hex")
 
 
-def _snapshot_info(
-    channel: Literal["edge", "nightly"],
-    target_final: str,
-    release_line: str,
+def _nightly_date(value: object) -> date:
+    if not isinstance(value, str) or not _NIGHTLY_RE.fullmatch(value):
+        raise ValueError("portversion must be YYYYMMDD")
+    try:
+        return date(int(value[:4]), int(value[4:6]), int(value[6:]))
+    except ValueError as exc:
+        raise ValueError(f"invalid Nightly calendar date: {value}") from exc
+
+
+def _validate_nightly_allocation(value: object) -> NightlyAllocation:
+    if type(value) is not NightlyAllocation:
+        raise TypeError("allocation must be NightlyAllocation")
+    if value.outcome not in ("build", "unchanged"):
+        raise ValueError("invalid Nightly outcome")
+    _nightly_date(value.portversion)
+    if type(value.portrevision) is not int or value.portrevision < 0:
+        raise ValueError("portrevision must be a non-negative integer")
+    expected_pkg = value.portversion if value.portrevision == 0 else f"{value.portversion}_{value.portrevision}"
+    if value.pkg_version != expected_pkg or not _NIGHTLY_PKG_RE.fullmatch(value.pkg_version):
+        raise ValueError("invalid Nightly package version")
+    _validate_source_sha(value.source_sha)
+    _validate_source_sha(value.ports_sha)
+    _validate_digest(value.input_digest)
+    return value
+
+
+def validate_nightly_allocation(value: NightlyAllocation) -> None:
+    """Require one Nightly allocation to match the date/revision contract."""
+    _validate_nightly_allocation(value)
+
+
+def combined_nightly_input_digest(source_sha: str, ports_sha: str, input_digest: str) -> str:
+    """Return deterministic provenance digest for downstream build annotations."""
+    _validate_source_sha(source_sha)
+    _validate_source_sha(ports_sha)
+    _validate_digest(input_digest)
+    payload = "\0".join((source_sha, ports_sha, input_digest)).encode("ascii")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def allocate_nightly(
     build_date: date,
-    count: int,
-) -> ReleaseInfo:
-    date_text = _date_text(build_date)
-    sequence = f"{date_text}.{count}"
-    if channel == "edge":
-        version = f"{target_final}.edge.{sequence}"
-        return ReleaseInfo(
-            tag=f"v{version}",
-            version=version,
-            stage="edge",
-            sequence=sequence,
-            target_final=target_final,
-            release_line=release_line,
-            channel="edge",
-            prerelease=True,
-            final=False,
-            notes_required=True,
-            github_release="prerelease",
-            pkg_version=f"{target_final}.snapshot.1.{sequence}",
-            package=PACKAGE,
-        )
-    return ReleaseInfo(
-        tag=None,
-        version=f"{target_final}.nightly.{sequence}",
-        stage="nightly",
-        sequence=sequence,
-        target_final=target_final,
-        release_line=release_line,
-        channel="nightly",
-        prerelease=True,
-        final=False,
-        notes_required=False,
-        github_release="none",
-        pkg_version=f"{target_final}.snapshot.2.{sequence}",
-        package=PACKAGE,
-    )
-
-
-def generate_snapshot(
-    *,
-    channel: Literal["edge", "nightly"],
-    target_final: str,
-    release_line: str,
     source_sha: str,
-    build_date: date,
-    existing: Sequence[SnapshotRecord] = (),
-) -> ReleaseInfo:
-    """Generate a deterministic Edge or Nightly snapshot identity."""
-    if channel not in ("edge", "nightly"):
-        raise ValueError(f"unknown snapshot channel: {channel!r}")
-    major, minor, patch = _parse_bare_version(target_final)
-    expected_line = f"release/{major}.{minor}" if channel == "edge" else "devel"
-    if not isinstance(release_line, str) or release_line != expected_line:
-        raise ValueError(f"release line must be {expected_line!r}")
+    ports_sha: str,
+    input_digest: str,
+    existing: Sequence[NightlyAllocation] = (),
+) -> NightlyAllocation:
+    """Allocate a monotonic date/revision Nightly identity for one full input."""
     if type(build_date) is not date:
         raise TypeError("build_date must be datetime.date")
     _validate_source_sha(source_sha)
-
+    _validate_source_sha(ports_sha)
+    _validate_digest(input_digest)
     try:
         records = tuple(existing)
     except TypeError as exc:
-        raise ValueError("existing must be a sequence of SnapshotRecord") from exc
-    validated: list[tuple[SnapshotRecord, date, int]] = []
+        raise ValueError("existing must be a sequence of NightlyAllocation") from exc
+
+    identity = (source_sha, ports_sha, input_digest)
+    by_identity: dict[tuple[str, str, str], NightlyAllocation] = {}
+    by_version: dict[str, tuple[str, str, str]] = {}
+    parsed: list[tuple[NightlyAllocation, date]] = []
     for record in records:
-        if not isinstance(record, SnapshotRecord):
-            raise ValueError("existing must contain SnapshotRecord values")
-        _validate_source_sha(record.source_sha)
-        build_date_existing, count_existing = _validate_snapshot_result(record.result)
-        validated.append((record, build_date_existing, count_existing))
+        allocation = _validate_nightly_allocation(record)
+        record_identity = (allocation.source_sha, allocation.ports_sha, allocation.input_digest)
+        previous = by_identity.get(record_identity)
+        if previous is not None and previous != allocation:
+            raise ValueError("conflicting Nightly results for one input")
+        version_identity = by_version.get(allocation.pkg_version)
+        if version_identity is not None and version_identity != record_identity:
+            raise ValueError("Nightly version collision for different inputs")
+        by_identity[record_identity] = allocation
+        by_version[allocation.pkg_version] = record_identity
+        parsed.append((allocation, _nightly_date(allocation.portversion)))
 
-    scope = (channel, target_final, release_line)
-    scoped = [
-        item
-        for item in validated
-        if (item[0].result.channel, item[0].result.target_final, item[0].result.release_line) == scope
-    ]
-    seen_emitted: dict[tuple[str, str], str] = {}
-    for record, _, _ in validated:
-        key = (record.result.version, record.result.pkg_version)
-        previous_source = seen_emitted.get(key)
-        if previous_source is not None and previous_source != record.source_sha:
-            raise ValueError("snapshot version collision for different sources")
-        seen_emitted[key] = record.source_sha
+    repeated = by_identity.get(identity)
+    if repeated is not None:
+        return NightlyAllocation(
+            "unchanged",
+            repeated.portversion,
+            repeated.portrevision,
+            repeated.pkg_version,
+            repeated.source_sha,
+            repeated.ports_sha,
+            repeated.input_digest,
+        )
 
-    same_source = [item for item in scoped if item[0].source_sha == source_sha]
-    if same_source:
-        first = same_source[0][0].result
-        if any(item[0].result != first for item in same_source[1:]):
-            raise ValueError("conflicting snapshot results for source")
-
-    latest = max((item[1] for item in scoped), default=None)
-    if latest is not None and build_date < latest:
-        raise ValueError("snapshot date is older than latest relevant snapshot")
-    if same_source:
-        return same_source[0][0].result
-    count = 1
-    if latest == build_date:
-        count = max(item[2] for item in scoped if item[1] == build_date) + 1
-    candidate = _snapshot_info(channel, target_final, release_line, build_date, count)
-    validate_release_info(candidate)
-    return candidate
+    latest_date = max((record_date for _, record_date in parsed), default=None)
+    if latest_date is not None and build_date < latest_date:
+        raise ValueError("Nightly date is older than the latest allocation")
+    revision = 0
+    if latest_date == build_date:
+        revision = max(allocation.portrevision for allocation, record_date in parsed if record_date == build_date) + 1
+    portversion = f"{build_date.year:04d}{build_date.month:02d}{build_date.day:02d}"
+    pkg_version = portversion if revision == 0 else f"{portversion}_{revision}"
+    if pkg_version in by_version:
+        raise ValueError("Nightly version collision for different inputs")
+    return NightlyAllocation("build", portversion, revision, pkg_version, source_sha, ports_sha, input_digest)
 
 
 def validate_branch(info: ReleaseInfo, branch: str) -> None:

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -11,9 +11,9 @@ from typing import Literal, Sequence
 
 PACKAGE = "pfSense-pkg-pfBlockerNG"
 
-Stage = Literal["final", "alpha", "beta", "rc", "edge", "nightly"]
-Channel = Literal["stable", "testing", "edge", "nightly"]
-GithubRelease = Literal["final", "prerelease", "none"]
+Stage = Literal["final", "alpha", "beta", "rc"]
+Channel = Literal["stable", "testing", "edge"]
+GithubRelease = Literal["final", "prerelease"]
 
 _CORE = r"(0|[1-9][0-9]*)"
 _FINAL_RE = re.compile(rf"^v(?P<major>{_CORE})\.(?P<minor>{_CORE})\.(?P<patch>{_CORE})$")
@@ -21,7 +21,6 @@ _PREVIEW_RE = re.compile(
     rf"^v(?P<major>{_CORE})\.(?P<minor>{_CORE})\.(?P<patch>{_CORE})\."
     r"(?P<stage>[abr])(?P<sequence>[1-9][0-9]*)$"
 )
-_BARE_VERSION_RE = re.compile(rf"^(?P<major>{_CORE})\.(?P<minor>{_CORE})\.(?P<patch>{_CORE})$")
 _SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 _NIGHTLY_RE = re.compile(r"^(?P<date>[0-9]{8})$")
 _NIGHTLY_PKG_RE = re.compile(r"^(?P<date>[0-9]{8})(?:_(?P<revision>[1-9][0-9]*))?$")
@@ -41,7 +40,7 @@ class ReleaseInfo:
     prerelease: bool
     final: bool
     notes_required: bool
-    github_release: GithubRelease
+    github_release: str
     pkg_version: str
     package: str
 
@@ -120,23 +119,6 @@ def parse_release_tag(tag: str, channel: Channel | None = None) -> ReleaseInfo:
         )
 
     raise _invalid(tag)
-
-
-def _parse_bare_version(final_version: str) -> tuple[str, str, str]:
-    if not isinstance(final_version, str):
-        raise TypeError("target_final must be str")
-    if not final_version or len(final_version) > 128:
-        raise ValueError(f"invalid final version: {final_version!r}")
-    match = _BARE_VERSION_RE.fullmatch(final_version)
-    if not match:
-        raise ValueError(f"invalid final version: {final_version!r}")
-    return tuple(match.group(name) for name in ("major", "minor", "patch"))  # type: ignore[return-value]
-
-
-def next_patch_target(final_version: str) -> str:
-    """Return the next patch target for a strict bare X.Y.Z final version."""
-    major, minor, patch = _parse_bare_version(final_version)
-    return f"{major}.{minor}.{int(patch) + 1}"
 
 
 def _validate_source_sha(source_sha: str) -> None:

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -40,7 +40,7 @@ class ReleaseInfo:
     prerelease: bool
     final: bool
     notes_required: bool
-    github_release: str
+    github_release: GithubRelease
     pkg_version: str
     package: str
 

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -16,13 +16,9 @@ GithubRelease = Literal["final", "prerelease", "none"]
 
 _CORE = r"(0|[1-9][0-9]*)"
 _FINAL_RE = re.compile(rf"^v(?P<major>{_CORE})\.(?P<minor>{_CORE})\.(?P<patch>{_CORE})$")
-_TESTING_RE = re.compile(
+_PREVIEW_RE = re.compile(
     rf"^v(?P<major>{_CORE})\.(?P<minor>{_CORE})\.(?P<patch>{_CORE})\."
-    r"(?P<stage>alpha|beta|rc)\.(?P<sequence>[1-9][0-9]*)$"
-)
-_EDGE_RE = re.compile(
-    rf"^v(?P<major>{_CORE})\.(?P<minor>{_CORE})\.(?P<patch>{_CORE})\.edge\."
-    r"(?P<date>[0-9]{8})\.(?P<count>[1-9][0-9]*)$"
+    r"(?P<stage>[abr])(?P<sequence>[1-9][0-9]*)$"
 )
 _BARE_VERSION_RE = re.compile(rf"^(?P<major>{_CORE})\.(?P<minor>{_CORE})\.(?P<patch>{_CORE})$")
 _SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
@@ -57,20 +53,18 @@ def _invalid(tag: str) -> ValueError:
     return ValueError(f"invalid release tag: {tag!r}")
 
 
-def _check_edge_date(raw: str) -> None:
-    try:
-        date(int(raw[:4]), int(raw[4:6]), int(raw[6:]))
-    except ValueError as exc:
-        raise ValueError(f"invalid Edge calendar date: {raw}") from exc
-
-
-def parse_release_tag(tag: str) -> ReleaseInfo:
-    """Parse one strict release tag into canonical release metadata."""
+def parse_release_tag(tag: str, channel: Channel | None = None) -> ReleaseInfo:
+    """Parse one strict release tag using explicit channel context."""
     if not isinstance(tag, str) or not tag or len(tag) > 128 or not tag.isascii():
         raise _invalid(tag)
 
+    if not isinstance(channel, str) or channel not in ("stable", "testing", "edge"):
+        raise ValueError(f"invalid release channel: {channel!r}")
+
     match = _FINAL_RE.fullmatch(tag)
     if match:
+        if channel != "stable":
+            raise ValueError("final tag requires stable channel")
         major, minor, patch = (match.group(name) for name in ("major", "minor", "patch"))
         version = f"{major}.{minor}.{patch}"
         return ReleaseInfo(
@@ -89,48 +83,28 @@ def parse_release_tag(tag: str) -> ReleaseInfo:
             package=PACKAGE,
         )
 
-    match = _TESTING_RE.fullmatch(tag)
+    match = _PREVIEW_RE.fullmatch(tag)
     if match:
+        if channel == "stable":
+            raise ValueError("preview tag requires testing or edge channel")
         major, minor, patch = (match.group(name) for name in ("major", "minor", "patch"))
-        stage = match.group("stage")
+        stage_code = match.group("stage")
+        stage = {"a": "alpha", "b": "beta", "r": "rc"}[stage_code]
         sequence = match.group("sequence")
         version = f"{major}.{minor}.{patch}"
         return ReleaseInfo(
             tag=tag,
-            version=f"{version}.{stage}.{sequence}",
+            version=f"{version}.{stage_code}{sequence}",
             stage=stage,  # type: ignore[arg-type]
             sequence=sequence,
             target_final=version,
             release_line=f"release/{major}.{minor}",
-            channel="testing",
+            channel=channel,
             prerelease=True,
             final=False,
             notes_required=True,
             github_release="prerelease",
-            pkg_version=f"{version}.{stage}.{sequence}",
-            package=PACKAGE,
-        )
-
-    match = _EDGE_RE.fullmatch(tag)
-    if match:
-        major, minor, patch = (match.group(name) for name in ("major", "minor", "patch"))
-        edge_date = match.group("date")
-        count = match.group("count")
-        _check_edge_date(edge_date)
-        version = f"{major}.{minor}.{patch}"
-        return ReleaseInfo(
-            tag=tag,
-            version=f"{version}.edge.{edge_date}.{count}",
-            stage="edge",
-            sequence=f"{edge_date}.{count}",
-            target_final=version,
-            release_line=f"release/{major}.{minor}",
-            channel="edge",
-            prerelease=True,
-            final=False,
-            notes_required=True,
-            github_release="prerelease",
-            pkg_version=f"{version}.snapshot.1.{edge_date}.{count}",
+            pkg_version=f"{version}.{stage_code}{sequence}",
             package=PACKAGE,
         )
 
@@ -199,7 +173,7 @@ def validate_release_info(info: ReleaseInfo) -> None:
         raise TypeError("release info must be ReleaseInfo")
     if info.tag is None:
         _validate_nightly_result(info)
-    elif parse_release_tag(info.tag) != info:
+    elif parse_release_tag(info.tag, info.channel) != info:
         raise ValueError("release info does not match its release tag")
     if len(info.version) > _MAX_RELEASE_TEXT or len(info.pkg_version) > _MAX_RELEASE_TEXT:
         raise ValueError(f"release identity exceeds {_MAX_RELEASE_TEXT} characters")
@@ -322,26 +296,20 @@ def generate_snapshot(
     return candidate
 
 
-def validate_branch(info: ReleaseInfo, branch: str, legacy: bool = False) -> None:
-    """Require a canonical release line, with optional legacy branch aliases."""
-    if not isinstance(legacy, bool):
-        raise TypeError("legacy must be bool")
+def validate_branch(info: ReleaseInfo, branch: str) -> None:
+    """Require the exact maintained release line for a tagged release."""
     if not isinstance(branch, str):
         raise ValueError(f"branch {branch!r} is unknown")
     if branch == info.release_line:
-        return
-    if legacy and info.stage == "final" and branch == "main":
-        return
-    if legacy and info.channel == "testing" and branch == "devel":
         return
     raise ValueError(f"branch {branch!r} points at {info.release_line!r}, not this release")
 
 
 def _emit(info: ReleaseInfo) -> None:
-    """Print legacy fields first, followed by canonical fields for shell callers."""
+    """Print eval-safe release fields for shell callers."""
     fields = (
         ("version", info.version),
-        ("channel", "stable" if info.channel == "stable" else "devel" if info.channel == "testing" else "edge"),
+        ("channel", info.channel),
         ("prerelease", str(info.prerelease).lower()),
         ("prekind", "" if info.final else info.stage),
         ("portversion", info.pkg_version),
@@ -349,7 +317,7 @@ def _emit(info: ReleaseInfo) -> None:
         ("tag", info.tag or ""),
         ("stage", info.stage),
         ("sequence", info.sequence or ""),
-        ("target_final", info.target_final),
+        ("target_final", info.target_final or ""),
         ("release_line", info.release_line),
         ("final", str(info.final).lower()),
         ("notes_required", str(info.notes_required).lower()),
@@ -362,21 +330,17 @@ def _emit(info: ReleaseInfo) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else argv
-    if not args or not args[0]:
-        print("error: no tag given", file=sys.stderr)
-        print("usage: release-version.sh <tag> [branch]", file=sys.stderr)
-        return 1
-    if len(args) > 2:
-        print("error: usage: release-version.sh <tag> [branch]", file=sys.stderr)
+    if len(args) < 2 or len(args) > 3 or not args[0] or not args[1]:
+        print("error: usage: release-version.sh <tag> <channel> [branch]", file=sys.stderr)
         return 1
 
-    tag = args[0]
+    tag, channel = args[:2]
     try:
-        info = parse_release_tag(tag)
-        if len(args) == 2:
-            validate_branch(info, args[1], legacy=True)
-    except ValueError as exc:
-        if str(exc).startswith("invalid release tag") or "calendar date" in str(exc):
+        info = parse_release_tag(tag, channel)  # type: ignore[arg-type]
+        if len(args) == 3:
+            validate_branch(info, args[2])
+    except (TypeError, ValueError) as exc:
+        if isinstance(exc, ValueError) and str(exc).startswith("invalid release tag"):
             print(f"error: {tag!r} is not a valid release tag", file=sys.stderr)
         else:
             print(f"error: {exc}", file=sys.stderr)

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -161,6 +161,8 @@ def _validate_nightly_allocation(value: object) -> NightlyAllocation:
     if type(value.portrevision) is not int or value.portrevision < 0:
         raise ValueError("portrevision must be a non-negative integer")
     expected_pkg = value.portversion if value.portrevision == 0 else f"{value.portversion}_{value.portrevision}"
+    if len(value.pkg_version) > _MAX_RELEASE_TEXT:
+        raise ValueError(f"Nightly package identity exceeds {_MAX_RELEASE_TEXT} characters")
     if value.pkg_version != expected_pkg or not _NIGHTLY_PKG_RE.fullmatch(value.pkg_version):
         raise ValueError("invalid Nightly package version")
     _validate_source_sha(value.source_sha)
@@ -209,7 +211,15 @@ def allocate_nightly(
         allocation = _validate_nightly_allocation(record)
         record_identity = (allocation.source_sha, allocation.ports_sha, allocation.input_digest)
         previous = by_identity.get(record_identity)
-        if previous is not None and previous != allocation:
+        if previous is not None and (
+            previous.portversion,
+            previous.portrevision,
+            previous.pkg_version,
+        ) != (
+            allocation.portversion,
+            allocation.portrevision,
+            allocation.pkg_version,
+        ):
             raise ValueError("conflicting Nightly results for one input")
         version_identity = by_version.get(allocation.pkg_version)
         if version_identity is not None and version_identity != record_identity:
@@ -240,7 +250,8 @@ def allocate_nightly(
     pkg_version = portversion if revision == 0 else f"{portversion}_{revision}"
     if pkg_version in by_version:
         raise ValueError("Nightly version collision for different inputs")
-    return NightlyAllocation("build", portversion, revision, pkg_version, source_sha, ports_sha, input_digest)
+    allocation = NightlyAllocation("build", portversion, revision, pkg_version, source_sha, ports_sha, input_digest)
+    return _validate_nightly_allocation(allocation)
 
 
 def validate_branch(info: ReleaseInfo, branch: str) -> None:

--- a/tests/shell/githooks_pre_push_tag_scheme_spec.sh
+++ b/tests/shell/githooks_pre_push_tag_scheme_spec.sh
@@ -93,4 +93,20 @@ pfblockerng-release-channel: edge' "$sha"
     The status should equal 1
     The stderr should include 'trailer'
   End
+
+  It 'rejects hidden no-space and tab channel trailers'
+    push_tag() {
+      cd "${base}/repo" || return
+      git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
+      git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing
+pfblockerng-release-channel:edge
+PFBLOCKERNG-RELEASE-CHANNEL:	edge' "$sha"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+        | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
+          sh "$hook" origin "${base}/repo"
+    }
+    When run push_tag
+    The status should equal 1
+    The stderr should include 'trailer'
+  End
 End

--- a/tests/shell/githooks_pre_push_tag_scheme_spec.sh
+++ b/tests/shell/githooks_pre_push_tag_scheme_spec.sh
@@ -78,4 +78,19 @@ Describe 'pre-push tag-scheme loop still consumes the update list (issue #1307)'
     The status should equal 1
     The stderr should include 'trailer'
   End
+
+  It 'rejects a conflicting case-variant channel trailer'
+    push_tag() {
+      cd "${base}/repo" || return
+      git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
+      git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing
+pfblockerng-release-channel: edge' "$sha"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+        | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
+          sh "$hook" origin "${base}/repo"
+    }
+    When run push_tag
+    The status should equal 1
+    The stderr should include 'trailer'
+  End
 End

--- a/tests/shell/githooks_pre_push_tag_scheme_spec.sh
+++ b/tests/shell/githooks_pre_push_tag_scheme_spec.sh
@@ -29,12 +29,53 @@ Describe 'pre-push tag-scheme loop still consumes the update list (issue #1307)'
     push_tag() {
       # No origin/main or origin/devel exists here, so a versioned tag must
       # hit the reachability error — proving the loop actually read the line.
-      cd "${base}/repo" && printf '%s\n' "refs/tags/v9.9.9 $sha refs/tags/v9.9.9 0000000000000000000000000000000000000000" \
+      cd "${base}/repo" && printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
         | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
           sh "$hook" origin "${base}/repo"
     }
     When run push_tag
     The status should equal 1
     The stderr should include 'reachable'
+  End
+
+  It 'accepts an annotated tag with one matching channel trailer on the exact release line'
+    push_tag() {
+      cd "${base}/repo" || return
+      git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
+      git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing' "$sha"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+        | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
+          sh "$hook" origin "${base}/repo"
+    }
+    When run push_tag
+    The status should equal 0
+  End
+
+  It 'rejects a lightweight versioned tag before push'
+    push_tag() {
+      cd "${base}/repo" || return
+      git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
+      git_fixture tag v9.9.9.r1 "$sha"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+        | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
+          sh "$hook" origin "${base}/repo"
+    }
+    When run push_tag
+    The status should equal 1
+    The stderr should include 'annotated'
+  End
+
+  It 'rejects duplicate channel trailers during recovery'
+    push_tag() {
+      cd "${base}/repo" || return
+      git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
+      git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing' -m 'pfBlockerNG-Release-Channel: testing' "$sha"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+        | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
+          sh "$hook" origin "${base}/repo"
+    }
+    When run push_tag
+    The status should equal 1
+    The stderr should include 'trailer'
   End
 End

--- a/tests/shell/githooks_pre_push_tag_scheme_spec.sh
+++ b/tests/shell/githooks_pre_push_tag_scheme_spec.sh
@@ -29,7 +29,10 @@ Describe 'pre-push tag-scheme loop still consumes the update list (issue #1307)'
     push_tag() {
       # No origin/main or origin/devel exists here, so a versioned tag must
       # hit the reachability error — proving the loop actually read the line.
-      cd "${base}/repo" && printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+      cd "${base}/repo" || return
+      git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing' "$sha"
+      tag_object="$(git_fixture rev-parse refs/tags/v9.9.9.r1)"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $tag_object refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
         | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
           sh "$hook" origin "${base}/repo"
     }
@@ -43,7 +46,37 @@ Describe 'pre-push tag-scheme loop still consumes the update list (issue #1307)'
       cd "${base}/repo" || return
       git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
       git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing' "$sha"
-      printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+      tag_object="$(git_fixture rev-parse refs/tags/v9.9.9.r1)"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $tag_object refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+        | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
+          sh "$hook" origin "${base}/repo"
+    }
+    When run push_tag
+    The status should equal 0
+  End
+
+  It 'rejects a non-tag source ref targeting a versioned remote tag'
+    push_tag() {
+      cd "${base}/repo" || return
+      git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
+      git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing' "$sha"
+      printf '%s\n' "HEAD $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+        | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
+          sh "$hook" origin "${base}/repo"
+    }
+    When run push_tag
+    The status should equal 1
+    The stderr should include 'source ref'
+  End
+
+  It 'accepts a header-shaped body line plus one terminal channel trailer'
+    push_tag() {
+      cd "${base}/repo" || return
+      git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
+      git_fixture tag -a v9.9.9.r1 -m 'body mentions
+pfBlockerNG-Release-Channel: edge' -m 'pfBlockerNG-Release-Channel: testing' "$sha"
+      tag_object="$(git_fixture rev-parse refs/tags/v9.9.9.r1)"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $tag_object refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
         | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
           sh "$hook" origin "${base}/repo"
     }
@@ -69,8 +102,10 @@ Describe 'pre-push tag-scheme loop still consumes the update list (issue #1307)'
     push_tag() {
       cd "${base}/repo" || return
       git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
-      git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing' -m 'pfBlockerNG-Release-Channel: testing' "$sha"
-      printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+      git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing
+pfBlockerNG-Release-Channel: testing' "$sha"
+      tag_object="$(git_fixture rev-parse refs/tags/v9.9.9.r1)"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $tag_object refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
         | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
           sh "$hook" origin "${base}/repo"
     }
@@ -85,7 +120,8 @@ Describe 'pre-push tag-scheme loop still consumes the update list (issue #1307)'
       git_fixture update-ref refs/remotes/origin/release/9.9 "$sha"
       git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing
 pfblockerng-release-channel: edge' "$sha"
-      printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+      tag_object="$(git_fixture rev-parse refs/tags/v9.9.9.r1)"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $tag_object refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
         | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
           sh "$hook" origin "${base}/repo"
     }
@@ -101,7 +137,8 @@ pfblockerng-release-channel: edge' "$sha"
       git_fixture tag -a v9.9.9.r1 -m v9.9.9.r1 -m 'pfBlockerNG-Release-Channel: testing
 pfblockerng-release-channel:edge
 PFBLOCKERNG-RELEASE-CHANNEL:	edge' "$sha"
-      printf '%s\n' "refs/tags/v9.9.9.r1 $sha refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
+      tag_object="$(git_fixture rev-parse refs/tags/v9.9.9.r1)"
+      printf '%s\n' "refs/tags/v9.9.9.r1 $tag_object refs/tags/v9.9.9.r1 0000000000000000000000000000000000000000" \
         | env -u CLAUDECODE -u CLAUDE_CODE_USER_EMAIL -u CODEX_THREAD_ID \
           sh "$hook" origin "${base}/repo"
     }

--- a/tests/smoke/test_release_version_oracle.py
+++ b/tests/smoke/test_release_version_oracle.py
@@ -1,4 +1,4 @@
-"""Observed libpkg ordering contract for project release channels (issue #2140)."""
+"""Observed libpkg ordering contract for issue #2140."""
 
 from __future__ import annotations
 
@@ -13,26 +13,44 @@ pytestmark = pytest.mark.smoke
 PKG = "/usr/local/sbin/pkg"
 
 ORDERED_VERSIONS = (
-    "3.2.0",
-    "3.2.1.alpha.1",
-    "3.2.1.alpha.2",
-    "3.2.1.beta.1",
-    "3.2.1.rc.1",
-    "3.2.1.snapshot.1.20260803.1",
-    "3.2.1.snapshot.1.20260803.2",
-    "3.2.1.snapshot.1.20260804.1",
-    "3.2.1.snapshot.2.20260803.1",
-    "3.2.1.snapshot.2.20260803.2",
-    "3.2.1.snapshot.2.20260804.1",
-    "3.2.1",
+    "3.2.15",
+    "3.2.16.a1",
+    "3.2.16.b1",
+    "3.2.16.r1",
+    "3.2.16",
+    "4.0.0.a1",
+    "4.0.0.b1",
+    "4.0.0.r1",
+    "4.0.0",
+    "20260804",
+    "20260804_1",
+    "20260804_2",
+    "20260805",
 )
+
+
+def test_ordering_oracle_fixture_is_exact() -> None:
+    assert ORDERED_VERSIONS == (
+        "3.2.15",
+        "3.2.16.a1",
+        "3.2.16.b1",
+        "3.2.16.r1",
+        "3.2.16",
+        "4.0.0.a1",
+        "4.0.0.b1",
+        "4.0.0.r1",
+        "4.0.0",
+        "20260804",
+        "20260804_1",
+        "20260804_2",
+        "20260805",
+    )
 
 
 def test_supported_pkg_orders_every_release_channel(smoke_vm: SmokeVM) -> None:
     """The appliance's pkg implementation orders every adjacent contract row."""
     implementation = smoke_vm.ssh(PKG, "-v")
     assert implementation.returncode == 0, implementation.stderr
-
     observed: list[str] = []
     for older, newer in pairwise(ORDERED_VERSIONS):
         result = smoke_vm.ssh(PKG, "version", "-t", older, newer)
@@ -40,6 +58,5 @@ def test_supported_pkg_orders_every_release_channel(smoke_vm: SmokeVM) -> None:
         comparison = result.stdout.strip()
         observed.append(f"{older} {comparison} {newer}")
         assert comparison == "<", observed[-1]
-
     print(f"pkg={implementation.stdout.strip()}")
     print("\n".join(observed))

--- a/tests/test_release_mutation.py
+++ b/tests/test_release_mutation.py
@@ -1,4 +1,4 @@
-"""Fail-closed release mutation preconditions."""
+"""Fail-closed release mutation preconditions for tagged and Nightly identities."""
 
 from __future__ import annotations
 
@@ -8,66 +8,57 @@ from typing import Any
 
 import pytest
 
-from scripts.release_mutation import (
-    MutationRequest,
-    ObservedMutationState,
-    apply_release_mutation,
-)
-from scripts.release_version import PACKAGE, generate_snapshot, parse_release_tag
+from scripts import release_mutation as rm
+from scripts import release_version as rv
 
-STABLE = parse_release_tag("v4.0.0")
-NIGHTLY = generate_snapshot(
-    channel="nightly",
-    target_final="4.0.0",
-    release_line="devel",
-    source_sha="a" * 40,
-    build_date=date(2026, 8, 4),
-)
+API: Any = rm
+VERSIONS: Any = rv
+STABLE = VERSIONS.parse_release_tag("v4.0.0", "stable")
 SOURCE_SHA = "a" * 40
 OTHER_SOURCE_SHA = "b" * 40
-ARTIFACT_SHA = "c" * 64
-OTHER_ARTIFACT_SHA = "d" * 64
+PORTS_SHA = "c" * 40
+OTHER_PORTS_SHA = "d" * 40
+INPUT_DIGEST = "e" * 64
+OTHER_INPUT_DIGEST = "f" * 64
+ARTIFACT_SHA = "1" * 64
+OTHER_ARTIFACT_SHA = "2" * 64
+
+
+def _nightly() -> Any:
+    return VERSIONS.allocate_nightly(date(2026, 8, 4), SOURCE_SHA, PORTS_SHA, INPUT_DIGEST, ())
 
 
 def _request(
-    result: Any = STABLE, source_sha: str = SOURCE_SHA, artifact_sha256: str = ARTIFACT_SHA
-) -> MutationRequest:
-    return MutationRequest(result, result.release_line, source_sha, artifact_sha256)
+    result: Any = STABLE,
+    selected_release_line: str | None = STABLE.release_line,
+    source_sha: str = SOURCE_SHA,
+    ports_sha: str = PORTS_SHA,
+    input_digest: str = INPUT_DIGEST,
+    artifact_sha256: str = ARTIFACT_SHA,
+) -> Any:
+    return API.MutationRequest(result, selected_release_line, source_sha, ports_sha, input_digest, artifact_sha256)
 
 
-def _observed(**changes: Any) -> ObservedMutationState:
-    return ObservedMutationState(**{"source_reachable": True, **changes})
+def _observed(**changes: Any) -> Any:
+    return API.ObservedMutationState(source_reachable=True, **changes)
 
 
-def _observed_with_tag(tag: str | None, **changes: Any) -> ObservedMutationState:
-    return ObservedMutationState(source_reachable=True, tag=tag, **changes)
-
-
-def _run(
-    request: MutationRequest | None = None, observed: ObservedMutationState | None = None
-) -> tuple[str, list[str]]:
+def _run(request: Any | None = None, observed: Any | None = None) -> tuple[str, list[str]]:
     calls: list[str] = []
-
-    def mutate() -> object:
-        calls.append("mutate")
-        return object()
-
-    outcome = apply_release_mutation(
-        request or _request(),
-        observed or _observed(),
-        mutate,
-    )
+    outcome = API.apply_release_mutation(request or _request(), observed or _observed(), lambda: calls.append("mutate"))
     return outcome, calls
 
 
-def test_public_dataclasses_have_exact_frozen_shapes() -> None:
-    assert [field.name for field in fields(MutationRequest)] == [
+def test_public_mutation_dataclasses_are_frozen_and_explicit() -> None:
+    assert [field.name for field in fields(API.MutationRequest)] == [
         "result",
         "selected_release_line",
         "source_sha",
+        "ports_sha",
+        "input_digest",
         "artifact_sha256",
     ]
-    assert [field.name for field in fields(ObservedMutationState)] == [
+    assert [field.name for field in fields(API.ObservedMutationState)] == [
         "source_reachable",
         "tag",
         "tag_source_sha",
@@ -76,355 +67,173 @@ def test_public_dataclasses_have_exact_frozen_shapes() -> None:
         "candidate_vs_latest",
         "existing_pkg_version",
         "existing_artifact_sha256",
+        "existing_source_sha",
+        "existing_ports_sha",
+        "existing_input_digest",
     ]
-    assert MutationRequest.__dataclass_params__.frozen  # type: ignore[attr-defined]
-    assert ObservedMutationState.__dataclass_params__.frozen  # type: ignore[attr-defined]
+    assert API.MutationRequest.__dataclass_params__.frozen  # type: ignore[attr-defined]
+    assert API.ObservedMutationState.__dataclass_params__.frozen  # type: ignore[attr-defined]
 
 
-def test_fresh_tagged_release_mutates_once_and_ignores_callback_return() -> None:
-    outcome, calls = _run()
-    assert outcome == "mutated"
-    assert calls == ["mutate"]
+def test_fresh_tagged_and_nightly_mutations_call_callback_once() -> None:
+    assert _run() == ("mutated", ["mutate"])
+    nightly = _nightly()
+    assert _run(_request(nightly, None), _observed()) == ("mutated", ["mutate"])
 
 
-def test_fresh_nightly_release_mutates_once() -> None:
-    outcome, calls = _run(_request(NIGHTLY), _observed())
-    assert outcome == "mutated"
-    assert calls == ["mutate"]
+def test_exact_existing_artifact_and_build_input_are_unchanged() -> None:
+    observed = _observed(
+        existing_pkg_version=STABLE.pkg_version,
+        existing_artifact_sha256=ARTIFACT_SHA,
+        existing_source_sha=SOURCE_SHA,
+        existing_ports_sha=PORTS_SHA,
+        existing_input_digest=INPUT_DIGEST,
+    )
+    assert _run(observed=observed) == ("unchanged", [])
 
 
-def test_exact_existing_artifact_is_unchanged_without_callback() -> None:
-    observed = _observed(existing_pkg_version=STABLE.pkg_version, existing_artifact_sha256=ARTIFACT_SHA)
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"existing_artifact_sha256": OTHER_ARTIFACT_SHA},
+        {"existing_source_sha": OTHER_SOURCE_SHA},
+        {"existing_ports_sha": OTHER_PORTS_SHA},
+        {"existing_input_digest": OTHER_INPUT_DIGEST},
+    ],
+)
+def test_same_package_different_artifact_or_input_fails_before_callback(changes: dict[str, str]) -> None:
+    observed_values = {
+        "existing_pkg_version": STABLE.pkg_version,
+        "existing_artifact_sha256": ARTIFACT_SHA,
+        "existing_source_sha": SOURCE_SHA,
+        "existing_ports_sha": PORTS_SHA,
+        "existing_input_digest": INPUT_DIGEST,
+        **changes,
+    }
+    observed = _observed(**observed_values)
     calls: list[str] = []
-    outcome = apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
-    assert outcome == "unchanged"
+    with pytest.raises(ValueError, match="collision"):
+        API.apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
     assert calls == []
 
 
-def test_assetless_draft_same_tag_and_source_recovers_equal_candidate() -> None:
-    observed = _observed_with_tag(
-        STABLE.tag,
+def test_assetless_tagged_recovery_keeps_tag_and_source_safety() -> None:
+    observed = _observed(
+        tag=STABLE.tag,
         tag_source_sha=SOURCE_SHA,
         release_state="draft_assetless",
         latest_pkg_version="opaque-latest",
         candidate_vs_latest="=",
-        existing_pkg_version=STABLE.pkg_version,
-        existing_artifact_sha256=ARTIFACT_SHA,
     )
-    outcome, calls = _run(observed=observed)
-    assert outcome == "mutated"
-    assert calls == ["mutate"]
-
-
-def test_absent_exact_tag_and_source_recovers_after_tag_creation() -> None:
-    observed = _observed_with_tag(STABLE.tag, tag_source_sha=SOURCE_SHA, release_state="absent")
-    outcome, calls = _run(observed=observed)
-    assert outcome == "mutated"
-    assert calls == ["mutate"]
-
-
-def test_assetless_recovery_requires_exact_observed_tag_and_source() -> None:
-    invalid = [
-        _observed_with_tag(None, tag_source_sha=SOURCE_SHA, release_state="draft_assetless"),
-        _observed_with_tag(STABLE.tag, release_state="draft_assetless"),
-        _observed_with_tag("v4.0.1", tag_source_sha=SOURCE_SHA, release_state="draft_assetless"),
-        _observed_with_tag(STABLE.tag, tag_source_sha=OTHER_SOURCE_SHA, release_state="draft_assetless"),
-    ]
-    for observed in invalid:
-        calls = []
-        with pytest.raises((TypeError, ValueError)):
-            apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
-        assert calls == []
-
-
-def test_fresh_and_nightly_mutations_require_absent_observed_tag_identity() -> None:
-    for request, observed in (
-        (_request(), _observed_with_tag(STABLE.tag)),
-        (_request(), _observed_with_tag(None, tag_source_sha=SOURCE_SHA)),
-        (_request(), _observed_with_tag("v4.0.1", tag_source_sha=SOURCE_SHA)),
-        (_request(), _observed_with_tag(STABLE.tag, tag_source_sha=OTHER_SOURCE_SHA)),
-        (_request(NIGHTLY), _observed_with_tag("v4.0.0")),
+    assert _run(observed=observed) == ("mutated", ["mutate"])
+    for invalid in (
+        _observed(tag=STABLE.tag, release_state="draft_assetless"),
+        _observed(tag="v4.0.1", tag_source_sha=SOURCE_SHA, release_state="draft_assetless"),
+        _observed(tag=STABLE.tag, tag_source_sha=OTHER_SOURCE_SHA, release_state="draft_assetless"),
     ):
         calls: list[str] = []
         with pytest.raises((TypeError, ValueError)):
-            apply_release_mutation(request, observed, lambda: calls.append("mutate"))
+            API.apply_release_mutation(_request(), invalid, lambda: calls.append("mutate"))
         assert calls == []
 
 
-@pytest.mark.parametrize("tag", ["", "v" + "x" * 128, "v4.0.0\n", "v4.0.0é"])
-def test_observed_tag_must_be_printable_ascii_release_tag_sized(tag: str) -> None:
-    observed = _observed_with_tag(tag)
-    calls: list[str] = []
-    with pytest.raises((TypeError, ValueError)):
-        apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
-    assert calls == []
-
-
-def test_assetless_recovery_still_rejects_stale_or_artifact_collision() -> None:
-    cases = [
-        _observed_with_tag(
-            STABLE.tag,
-            tag_source_sha=SOURCE_SHA,
-            release_state="draft_assetless",
-            latest_pkg_version="opaque-latest",
-            candidate_vs_latest="<",
-        ),
-        _observed_with_tag(
-            STABLE.tag,
-            tag_source_sha=SOURCE_SHA,
-            release_state="draft_assetless",
-            existing_pkg_version=STABLE.pkg_version,
-            existing_artifact_sha256=OTHER_ARTIFACT_SHA,
-        ),
-    ]
-    for observed, message in zip(cases, ("stale", "collision"), strict=True):
-        calls: list[str] = []
-        with pytest.raises(ValueError, match=message):
-            apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
-        assert calls == []
-
-
-def test_callback_exception_propagates_after_valid_preconditions() -> None:
-    error = RuntimeError("mutation failed")
-    calls: list[str] = []
-
-    def mutate() -> object:
-        calls.append("mutate")
-        raise error
-
-    with pytest.raises(RuntimeError, match="mutation failed"):
-        apply_release_mutation(_request(), _observed(), mutate)
-    assert calls == ["mutate"]
-
-
-@pytest.mark.parametrize(
-    "result,selected_release_line",
-    [
-        (replace(STABLE, version="4.0.99"), STABLE.release_line),
-        (replace(STABLE, target_final="4.0.99"), STABLE.release_line),
-        (replace(STABLE, release_line="release/4.1"), "release/4.1"),
-        (replace(STABLE, pkg_version="4.0.99"), STABLE.release_line),
-        (replace(STABLE, sequence="1"), STABLE.release_line),
-        (replace(STABLE, tag="vgarbage"), STABLE.release_line),
-    ],
-)
-def test_tagged_canonical_field_tampering_never_calls_mutator(result: Any, selected_release_line: str) -> None:
-    calls: list[str] = []
-    request = MutationRequest(result, selected_release_line, SOURCE_SHA, ARTIFACT_SHA)
-    with pytest.raises((TypeError, ValueError)):
-        apply_release_mutation(request, _observed(), lambda: calls.append("mutate"))
-    assert calls == []
-
-
-@pytest.mark.parametrize(
-    "result,selected_release_line",
-    [
-        (replace(NIGHTLY, version="4.0.0.nightly.20260804.2"), NIGHTLY.release_line),
-        (replace(NIGHTLY, target_final="4.0.1"), NIGHTLY.release_line),
-        (replace(NIGHTLY, release_line="devel/forged"), "devel/forged"),
-        (replace(NIGHTLY, pkg_version="4.0.0.snapshot.2.20260804.2"), NIGHTLY.release_line),
-        (replace(NIGHTLY, sequence="20260804.2"), NIGHTLY.release_line),
-        (replace(NIGHTLY, package="wrong"), NIGHTLY.release_line),
-        (replace(NIGHTLY, prerelease=False), NIGHTLY.release_line),
-        (replace(NIGHTLY, final=True), NIGHTLY.release_line),
-        (replace(NIGHTLY, notes_required=True), NIGHTLY.release_line),
-        (replace(NIGHTLY, github_release="prerelease"), NIGHTLY.release_line),
-        (replace(NIGHTLY, stage="edge"), NIGHTLY.release_line),
-        (replace(NIGHTLY, channel="edge"), NIGHTLY.release_line),
-    ],
-)
-def test_nightly_canonical_field_tampering_never_calls_mutator(result: Any, selected_release_line: str) -> None:
-    calls: list[str] = []
-    request = MutationRequest(result, selected_release_line, SOURCE_SHA, ARTIFACT_SHA)
-    with pytest.raises((TypeError, ValueError)):
-        apply_release_mutation(request, _observed(), lambda: calls.append("mutate"))
-    assert calls == []
-
-
-@pytest.mark.parametrize(
-    "mutation_request,observed",
-    [
-        (replace(_request(), result=replace(STABLE, package="wrong")), _observed()),
-        (replace(_request(), selected_release_line="release/4.1"), _observed()),
-        (replace(_request(), source_sha="A" * 40), _observed()),
-        (replace(_request(), source_sha="a" * 39), _observed()),
-        (replace(_request(), artifact_sha256="A" * 64), _observed()),
-        (replace(_request(), artifact_sha256="c" * 63), _observed()),
-        (replace(_request(), source_sha=OTHER_SOURCE_SHA), _observed(source_reachable=False)),
-        (replace(_request(), source_sha=OTHER_SOURCE_SHA), _observed(source_reachable=1)),
-        (_request(), _observed(tag_source_sha="A" * 40)),
-        (_request(), _observed(tag_source_sha="a" * 39)),
-        (_request(), _observed(tag_source_sha=1)),
-    ],
-)
-def test_invalid_request_or_reachability_never_calls_mutator(
-    mutation_request: MutationRequest, observed: ObservedMutationState
-) -> None:
-    calls: list[str] = []
-    with pytest.raises((TypeError, ValueError)):
-        apply_release_mutation(mutation_request, observed, lambda: calls.append("mutate"))
-    assert calls == []
-
-
-@pytest.mark.parametrize(
-    "observed",
-    [
-        _observed(latest_pkg_version="opaque"),
-        _observed(candidate_vs_latest=">"),
-        _observed(existing_pkg_version="opaque"),
-        _observed(existing_artifact_sha256=ARTIFACT_SHA),
-        _observed(latest_pkg_version="", candidate_vs_latest="="),
-        _observed(latest_pkg_version="é", candidate_vs_latest="="),
-        _observed(latest_pkg_version="x" * 129, candidate_vs_latest="="),
-        _observed(latest_pkg_version="line\nbreak", candidate_vs_latest="="),
-        _observed(latest_pkg_version="nul\x00byte", candidate_vs_latest="="),
-        _observed(existing_pkg_version="line\nbreak", existing_artifact_sha256=ARTIFACT_SHA),
-        _observed(existing_pkg_version="opaque", existing_artifact_sha256="D" * 64),
-        _observed(release_state="ABSENT"),
-        _observed(candidate_vs_latest="=="),
-    ],
-)
-def test_malformed_observations_fail_closed_before_callback(observed: ObservedMutationState) -> None:
-    calls: list[str] = []
-    with pytest.raises((TypeError, ValueError)):
-        apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
-    assert calls == []
-
-
-def test_exact_dataclass_types_and_callable_mutator_are_required() -> None:
-    calls: list[str] = []
-    for request, observed in (
-        (object(), _observed()),
-        (MutationRequest(object(), "release/4.0", SOURCE_SHA, ARTIFACT_SHA), _observed()),  # type: ignore[arg-type]
-        (_request(), object()),
-    ):
-        with pytest.raises((TypeError, ValueError)):
-            apply_release_mutation(request, observed, lambda: calls.append("mutate"))  # type: ignore[arg-type]
-    with pytest.raises(TypeError):
-        apply_release_mutation(_request(), _observed(), None)  # type: ignore[arg-type]
-    assert calls == []
-
-
-def test_moved_tag_repeated_tag_and_immutable_release_states_reject() -> None:
-    cases = [
-        _observed(tag_source_sha=OTHER_SOURCE_SHA),
-        _observed(tag_source_sha=SOURCE_SHA),
-        _observed(tag_source_sha=SOURCE_SHA, release_state="draft_with_assets"),
-        _observed(tag_source_sha=SOURCE_SHA, release_state="published"),
-        _observed(release_state="draft_assetless"),
-        _observed(tag_source_sha=OTHER_SOURCE_SHA, release_state="draft_assetless"),
-    ]
-    for observed in cases:
-        calls: list[str] = []
-        with pytest.raises(ValueError):
-            apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
-        assert calls == []
-
-
-def test_nightly_requires_unpublished_unassociated_tag_state() -> None:
+def test_nightly_requires_absent_untagged_release_and_no_selected_line() -> None:
+    nightly = _nightly()
+    with pytest.raises(ValueError):
+        API.apply_release_mutation(_request(nightly, STABLE.release_line), _observed(), lambda: None)
     for observed in (
+        _observed(tag="v4.0.0"),
         _observed(tag_source_sha=SOURCE_SHA),
         _observed(release_state="draft_assetless"),
         _observed(release_state="draft_with_assets"),
         _observed(release_state="published"),
     ):
-        calls: list[str] = []
         with pytest.raises(ValueError):
-            apply_release_mutation(_request(NIGHTLY), observed, lambda: calls.append("mutate"))
-        assert calls == []
-
-
-def test_nightly_malformed_stage_or_channel_rejects_without_parsing_tag() -> None:
-    for result in (replace(NIGHTLY, stage="edge"), replace(NIGHTLY, channel="testing")):
-        calls: list[str] = []
-        with pytest.raises(ValueError):
-            apply_release_mutation(_request(result), _observed(), lambda: calls.append("mutate"))
-        assert calls == []
-
-
-@pytest.mark.parametrize(
-    "result",
-    [replace(STABLE, tag=None), replace(NIGHTLY, tag="v4.0.0.nightly.20260804.1")],
-)
-def test_inconsistent_tagged_and_nightly_shapes_reject(result: Any) -> None:
-    calls: list[str] = []
-    with pytest.raises(ValueError):
-        apply_release_mutation(_request(result), _observed(), lambda: calls.append("mutate"))
-    assert calls == []
-
-
-def test_pkg_collision_with_different_artifact_rejects() -> None:
-    observed = _observed_with_tag(
-        STABLE.tag,
-        tag_source_sha=SOURCE_SHA,
-        release_state="draft_assetless",
-        existing_pkg_version=STABLE.pkg_version,
-        existing_artifact_sha256=OTHER_ARTIFACT_SHA,
-    )
-    calls: list[str] = []
-    with pytest.raises(ValueError, match="collision"):
-        apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
-    assert calls == []
+            API.apply_release_mutation(_request(nightly, None), observed, lambda: None)
 
 
 @pytest.mark.parametrize("release_state", ["draft_with_assets", "published"])
-def test_immutable_release_state_wins_over_identical_artifact_noop(release_state: str) -> None:
+def test_immutable_release_state_wins_over_identical_noop(release_state: str) -> None:
     observed = _observed(
         release_state=release_state,
         existing_pkg_version=STABLE.pkg_version,
         existing_artifact_sha256=ARTIFACT_SHA,
+        existing_source_sha=SOURCE_SHA,
+        existing_ports_sha=PORTS_SHA,
+        existing_input_digest=INPUT_DIGEST,
     )
-    calls: list[str] = []
     with pytest.raises(ValueError):
-        apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
-    assert calls == []
+        API.apply_release_mutation(_request(), observed, lambda: None)
 
 
-def test_stale_catalogue_candidate_rejects_with_exact_tag_source() -> None:
-    observed = _observed_with_tag(
-        STABLE.tag,
-        tag_source_sha=SOURCE_SHA,
-        release_state="draft_assetless",
-        latest_pkg_version="opaque-latest",
-        candidate_vs_latest="<",
-    )
+def test_stale_catalogue_candidate_rejects_before_callback() -> None:
+    observed = _observed(latest_pkg_version="opaque-latest", candidate_vs_latest="<")
     calls: list[str] = []
     with pytest.raises(ValueError, match="stale"):
-        apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
+        API.apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
     assert calls == []
 
 
-def test_repeated_catalogue_candidate_rejects_without_recovery() -> None:
-    observed = _observed(latest_pkg_version="opaque-latest", candidate_vs_latest="=")
+@pytest.mark.parametrize(
+    "tag",
+    ["", "v" + "x" * 128, "v4.0.0\n", "v4.0.0é"],
+)
+def test_observed_hostile_tag_fails_closed(tag: str) -> None:
     calls: list[str] = []
-    with pytest.raises(ValueError, match="already exists"):
-        apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
+    with pytest.raises((TypeError, ValueError)):
+        API.apply_release_mutation(_request(), _observed(tag=tag), lambda: calls.append("mutate"))
     assert calls == []
 
 
-def test_greater_and_empty_catalogue_candidates_mutate_without_package_parsing() -> None:
-    request = _request()
-    for observed in (_observed(), _observed(latest_pkg_version="opaque latest !", candidate_vs_latest=">")):
-        outcome, calls = _run(request=request, observed=observed)
-        assert outcome == "mutated"
-        assert calls == ["mutate"]
-
-
-def test_mutation_request_and_observation_are_not_modified() -> None:
-    request = _request()
-    observed = _observed()
-    before_request = request
-    before_observed = observed
-    outcome, _ = _run(request, observed)
-    assert outcome == "mutated"
-    assert request == before_request
-    assert observed == before_observed
-
-
-def test_wrong_package_constant_is_rejected_even_for_nightly() -> None:
-    assert STABLE.package == PACKAGE
-    request = _request(replace(NIGHTLY, package="other"))
+@pytest.mark.parametrize(
+    "observation",
+    [
+        {"latest_pkg_version": "opaque"},
+        {"candidate_vs_latest": ">"},
+        {"existing_pkg_version": "opaque"},
+        {"existing_artifact_sha256": ARTIFACT_SHA},
+        {"existing_source_sha": SOURCE_SHA},
+        {"existing_ports_sha": PORTS_SHA},
+        {"existing_input_digest": INPUT_DIGEST},
+        {"latest_pkg_version": "line\nbreak", "candidate_vs_latest": "="},
+        {"existing_pkg_version": "line\nbreak", "existing_artifact_sha256": ARTIFACT_SHA},
+        {"release_state": "ABSENT"},
+        {"candidate_vs_latest": "=="},
+    ],
+)
+def test_malformed_observations_never_call_mutator(observation: dict[str, object]) -> None:
+    observed = _observed(**observation)
     calls: list[str] = []
-    with pytest.raises(ValueError):
-        apply_release_mutation(request, _observed(), lambda: calls.append("mutate"))
+    with pytest.raises((TypeError, ValueError)):
+        API.apply_release_mutation(_request(), observed, lambda: calls.append("mutate"))
     assert calls == []
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        ("source_sha", "A" * 40),
+        ("source_sha", "a" * 39),
+        ("ports_sha", "A" * 40),
+        ("input_digest", "A" * 64),
+        ("artifact_sha256", "A" * 64),
+        ("selected_release_line", "release/4.1"),
+        ("result", replace(STABLE, package="wrong")),
+    ],
+)
+def test_malformed_requests_fail_closed_before_callback(mutation: tuple[str, object]) -> None:
+    field, value = mutation
+    request = _request(**{field: value})  # type: ignore[arg-type]
+    calls: list[str] = []
+    with pytest.raises((TypeError, ValueError)):
+        API.apply_release_mutation(request, _observed(), lambda: calls.append("mutate"))
+    assert calls == []
+
+
+def test_exact_dataclass_types_and_callable_mutator_are_required() -> None:
+    with pytest.raises(TypeError):
+        API.apply_release_mutation(object(), _observed(), lambda: None)
+    with pytest.raises(TypeError):
+        API.apply_release_mutation(_request(), object(), lambda: None)
+    with pytest.raises(TypeError):
+        API.apply_release_mutation(_request(), _observed(), None)

--- a/tests/test_release_mutation.py
+++ b/tests/test_release_mutation.py
@@ -118,6 +118,15 @@ def test_exact_nightly_noop_wins_over_a_newer_catalog_version() -> None:
     assert _run(_request(nightly, None), observed) == ("unchanged", [])
 
 
+def test_oversized_nightly_identity_never_reaches_mutation() -> None:
+    revision = int("9" * 120)
+    nightly = replace(_nightly(), portrevision=revision, pkg_version=f"20260804_{revision}")
+    calls: list[str] = []
+    with pytest.raises(ValueError, match="128"):
+        API.apply_release_mutation(_request(nightly, None), _observed(), lambda: calls.append("mutate"))
+    assert calls == []
+
+
 def test_exact_existing_artifact_and_build_input_are_unchanged() -> None:
     observed = _observed(
         existing_pkg_version=STABLE.pkg_version,

--- a/tests/test_release_mutation.py
+++ b/tests/test_release_mutation.py
@@ -81,6 +81,14 @@ def test_fresh_tagged_and_nightly_mutations_call_callback_once() -> None:
     assert _run(_request(nightly, None), _observed()) == ("mutated", ["mutate"])
 
 
+def test_nightly_noop_requires_observed_existing_package() -> None:
+    nightly = replace(_nightly(), outcome="unchanged")
+    calls: list[str] = []
+    with pytest.raises(ValueError, match="no-op"):
+        API.apply_release_mutation(_request(nightly, None), _observed(), lambda: calls.append("mutate"))
+    assert calls == []
+
+
 def test_exact_existing_artifact_and_build_input_are_unchanged() -> None:
     observed = _observed(
         existing_pkg_version=STABLE.pkg_version,

--- a/tests/test_release_mutation.py
+++ b/tests/test_release_mutation.py
@@ -89,6 +89,35 @@ def test_nightly_noop_requires_observed_existing_package() -> None:
     assert calls == []
 
 
+def test_nightly_noop_requires_the_exact_allocated_package() -> None:
+    nightly = replace(_nightly(), outcome="unchanged")
+    observed = _observed(
+        existing_pkg_version="20260803",
+        existing_artifact_sha256=ARTIFACT_SHA,
+        existing_source_sha=SOURCE_SHA,
+        existing_ports_sha=PORTS_SHA,
+        existing_input_digest=INPUT_DIGEST,
+    )
+    calls: list[str] = []
+    with pytest.raises(ValueError, match="no-op"):
+        API.apply_release_mutation(_request(nightly, None), observed, lambda: calls.append("mutate"))
+    assert calls == []
+
+
+def test_exact_nightly_noop_wins_over_a_newer_catalog_version() -> None:
+    nightly = replace(_nightly(), outcome="unchanged")
+    observed = _observed(
+        latest_pkg_version="20260805",
+        candidate_vs_latest="<",
+        existing_pkg_version=nightly.pkg_version,
+        existing_artifact_sha256=ARTIFACT_SHA,
+        existing_source_sha=SOURCE_SHA,
+        existing_ports_sha=PORTS_SHA,
+        existing_input_digest=INPUT_DIGEST,
+    )
+    assert _run(_request(nightly, None), observed) == ("unchanged", [])
+
+
 def test_exact_existing_artifact_and_build_input_are_unchanged() -> None:
     observed = _observed(
         existing_pkg_version=STABLE.pkg_version,

--- a/tests/test_release_skill_contract.py
+++ b/tests/test_release_skill_contract.py
@@ -1,0 +1,62 @@
+"""Contract guard for the issue #2140 release authoring documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTIVE_DOCS = (
+    ROOT / ".agents/skills/release/SKILL.md",
+    ROOT / ".agents/skills/release-with-changelog/SKILL.md",
+    ROOT / ".agents/context/release.md",
+    ROOT / "docs/misc/release-channels.md",
+)
+
+
+def _active_text() -> str:
+    return "\n".join(path.read_text(encoding="utf-8") for path in ACTIVE_DOCS)
+
+
+def test_active_release_docs_pin_issue_2140_contract() -> None:
+    text = _active_text()
+    required = (
+        "Stable uses `vX.Y.Z` / `X.Y.Z`",
+        "Testing uses `vX.Y.Z.aN`, `vX.Y.Z.bN`, or `vX.Y.Z.rN`",
+        "Edge uses the same Testing grammar",
+        "channel is explicit and configured",
+        "immutable tag trailer",
+        "Edge follows Testing",
+        "same Release and artifact bytes",
+        "no second Release",
+        "Nightly is untagged",
+        "no GitHub Release",
+        "no release notes",
+        "UTC date `YYYYMMDD`",
+        "`YYYYMMDD_1`",
+        "source SHA",
+        "FreeBSD-ports SHA",
+        "matrix/dependency digest",
+        "no routine version commit",
+        "no target final",
+        "no PORTEPOCH",
+        "bare date versions intentionally outrank semantic releases",
+        "repo-qualified downgrade",
+    )
+    missing = [phrase for phrase in required if phrase not in text]
+    assert not missing, f"release contract missing from active docs: {missing}"
+
+
+def test_active_release_docs_reject_superseded_normative_shapes() -> None:
+    text = _active_text()
+    rejected = (
+        "vX.Y.Z.edge.YYYYMMDD.N",
+        "X.Y.Z.snapshot.1.YYYYMMDD.N",
+        "X.Y.Z.snapshot.2.YYYYMMDD.N",
+        "YYYYMMDD.HHMMSS",
+        "Nightly version:X.Y.Z.nightly.YYYYMMDD.N",
+        "target final version",
+        "`main` only",
+        "`devel` only",
+    )
+    found = [phrase for phrase in rejected if phrase in text]
+    assert not found, f"superseded release contract remains active: {found}"

--- a/tests/test_release_skill_contract_details.py
+++ b/tests/test_release_skill_contract_details.py
@@ -1,0 +1,76 @@
+"""Additional per-surface checks for the post-green release contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS = (
+    ROOT / ".agents/skills/release/SKILL.md",
+    ROOT / ".agents/skills/release-with-changelog/SKILL.md",
+)
+ACTIVE = (
+    *SKILLS,
+    ROOT / ".agents/context/release.md",
+    ROOT / "docs/misc/release-channels.md",
+    ROOT / "scripts/README.md",
+)
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_each_release_skill_carries_the_minimum_procedure() -> None:
+    required = (
+        "channel is explicit",
+        "configured",
+        "vX.Y.Z.aN",
+        "vX.Y.Z.bN",
+        "vX.Y.Z.rN",
+        "same Release and artifact bytes",
+        "no second Release",
+        "no rebuild",
+        "Nightly",
+        "untagged",
+        "YYYYMMDD",
+        "YYYYMMDD_1",
+        "no-op",
+    )
+    for path in SKILLS:
+        content = _text(path)
+        missing = [phrase for phrase in required if phrase not in content]
+        assert not missing, f"{path}: missing release procedure phrases {missing}"
+
+
+def test_all_active_release_surfaces_reject_superseded_shapes() -> None:
+    rejected = (
+        "vX.Y.Z.edge.YYYYMMDD.N",
+        "X.Y.Z.snapshot.1.YYYYMMDD.N",
+        "X.Y.Z.snapshot.2.YYYYMMDD.N",
+        "YYYYMMDD.HHMMSS",
+        "Nightly version:X.Y.Z.nightly.YYYYMMDD.N",
+        "target final version",
+        "`main` only",
+        "`devel` only",
+    )
+    for path in ACTIVE:
+        content = _text(path)
+        found = [phrase for phrase in rejected if phrase in content]
+        assert not found, f"{path}: superseded release shapes remain {found}"
+
+
+def test_scripts_readme_documents_shared_identity_and_provenance() -> None:
+    content = _text(ROOT / "scripts/README.md")
+    for phrase in (
+        "pfSense-pkg-pfBlockerNG",
+        "explicit/configured",
+        "immutable",
+        "FreeBSD-ports SHA",
+        "matrix/dependency digest",
+        "no routine version commit",
+        "no target final",
+        "no PORTEPOCH",
+        "repo-qualified downgrade",
+    ):
+        assert phrase in content, f"scripts/README.md: missing {phrase!r}"

--- a/tests/test_release_skill_contract_details.py
+++ b/tests/test_release_skill_contract_details.py
@@ -84,3 +84,11 @@ def test_channel_targets_are_explicit_and_nightly_is_not_branch_bound() -> None:
         assert "Nightly" in content and "devel` branch" not in content, path
         assert "Edge follows Testing only when no distinct target" in content, path
         assert "distinct-target Edge uses its configured target/line" in content, path
+
+
+def test_scripts_readme_nightly_contract_is_branch_independent() -> None:
+    content = _text(ROOT / "scripts/README.md")
+    paragraph = content.split("## Release channel contract", 1)[1].split("## ", 1)[0]
+    assert "Nightly is an independent untagged" in paragraph
+    assert "pinned source SHA" in paragraph
+    assert not any(branch in paragraph for branch in ("`devel`", "`main`", "release/X.Y"))

--- a/tests/test_release_skill_contract_details.py
+++ b/tests/test_release_skill_contract_details.py
@@ -92,3 +92,26 @@ def test_scripts_readme_nightly_contract_is_branch_independent() -> None:
     assert "Nightly is an independent untagged" in paragraph
     assert "pinned source SHA" in paragraph
     assert not any(branch in paragraph for branch in ("`devel`", "`main`", "release/X.Y"))
+
+
+def test_branch_independent_adr_contract_is_current() -> None:
+    active = (
+        ROOT / ".agents/skills/release/SKILL.md",
+        ROOT / ".agents/skills/release-with-changelog/SKILL.md",
+        ROOT / ".agents/context/release.md",
+        ROOT / "docs/misc/release-channels.md",
+    )
+    for path in active:
+        assert "Nightly follows devel" not in _text(path), path
+
+    for name in ("ADR_09_Release_Version_Automation", "ADR_18_Nightly_Channel"):
+        content = _text(ROOT / f".ADRs/{name}/ADR.md")
+        amendment = content.rsplit("## Amendment — 2026-08-04", 1)[-1]
+        assert "pinned source SHA" in amendment, name
+        assert "devel` snapshot" not in amendment, name
+
+    for name in ("ADR_17_Pkg_Repository", "ADR_27_Release_Rollback_And_EOL_Routing"):
+        content = _text(ROOT / f".ADRs/{name}/ADR.md")
+        amendment = content.rsplit("## Amendment — 2026-08-04", 1)[-1]
+        assert "pinned pfBlockerNG SHA" in amendment, name
+        assert "no branch inference" in amendment, name

--- a/tests/test_release_skill_contract_details.py
+++ b/tests/test_release_skill_contract_details.py
@@ -81,6 +81,8 @@ def test_scripts_readme_documents_shared_identity_and_provenance() -> None:
         "repo-qualified downgrade",
     ):
         assert phrase in content, f"scripts/README.md: missing {phrase!r}"
+    assert "follower Edge reuses the Testing tag" in content
+    assert "`testing` trailer" in content
 
 
 def test_channel_targets_are_explicit_and_nightly_is_not_branch_bound() -> None:
@@ -141,3 +143,12 @@ def test_published_workflow_has_no_retired_nightly_ports_bump_contract() -> None
     content = _text(ROOT / ".github/workflows/release-published.yml")
     assert "`-nightly` port's PORTVERSION" not in content
     assert "the bump happens inside the release run" not in content
+    assert "nightly still built from devel HEAD" not in content
+    assert "from devel HEAD" not in _text(ROOT / ".github/workflows/smoke-single.yml")
+
+
+def test_latest_adr09_amendment_matches_the_implemented_trailer_and_workflows() -> None:
+    content = _text(ROOT / ".ADRs/ADR_09_Release_Version_Automation/ADR.md")
+    amendment = content.rsplit("## Amendment — 2026-08-04", 1)[-1]
+    assert "tag trailer carries only the channel" in amendment
+    assert "workflow consumers are updated" in amendment

--- a/tests/test_release_skill_contract_details.py
+++ b/tests/test_release_skill_contract_details.py
@@ -1,4 +1,4 @@
-"""Additional per-surface checks for the post-green release contract."""
+"""Additional per-surface checks for the contextual release contract."""
 
 from __future__ import annotations
 
@@ -115,12 +115,14 @@ def test_branch_independent_adr_contract_is_current() -> None:
 
     for name in ("ADR_09_Release_Version_Automation", "ADR_18_Nightly_Channel"):
         content = _text(ROOT / f".ADRs/{name}/ADR.md")
+        assert "## Amendment — 2026-08-04" in content, name
         amendment = content.rsplit("## Amendment — 2026-08-04", 1)[-1]
         assert "pinned source SHA" in amendment, name
         assert "devel` snapshot" not in amendment, name
 
     for name in ("ADR_17_Pkg_Repository", "ADR_27_Release_Rollback_And_EOL_Routing"):
         content = _text(ROOT / f".ADRs/{name}/ADR.md")
+        assert "## Amendment — 2026-08-04" in content, name
         amendment = content.rsplit("## Amendment — 2026-08-04", 1)[-1]
         assert "pinned pfBlockerNG SHA" in amendment, name
         assert "no branch inference" in amendment, name
@@ -149,6 +151,7 @@ def test_published_workflow_has_no_retired_nightly_ports_bump_contract() -> None
 
 def test_latest_adr09_amendment_matches_the_implemented_trailer_and_workflows() -> None:
     content = _text(ROOT / ".ADRs/ADR_09_Release_Version_Automation/ADR.md")
+    assert "## Amendment — 2026-08-04" in content
     amendment = content.rsplit("## Amendment — 2026-08-04", 1)[-1]
     assert "tag trailer carries only the channel" in amendment
     assert "workflow consumers are updated" in amendment

--- a/tests/test_release_skill_contract_details.py
+++ b/tests/test_release_skill_contract_details.py
@@ -74,3 +74,13 @@ def test_scripts_readme_documents_shared_identity_and_provenance() -> None:
         "repo-qualified downgrade",
     ):
         assert phrase in content, f"scripts/README.md: missing {phrase!r}"
+
+
+def test_channel_targets_are_explicit_and_nightly_is_not_branch_bound() -> None:
+    for path in SKILLS + (ROOT / ".agents/context/release.md", ROOT / "docs/misc/release-channels.md"):
+        content = _text(path)
+        assert "pfBlockerNG-Release-Channel: <stable|testing|edge>" in content, path
+        assert "pinned source SHA" in content, path
+        assert "Nightly" in content and "devel` branch" not in content, path
+        assert "Edge follows Testing only when no distinct target" in content, path
+        assert "distinct-target Edge uses its configured target/line" in content, path

--- a/tests/test_release_skill_contract_details.py
+++ b/tests/test_release_skill_contract_details.py
@@ -43,6 +43,13 @@ def test_each_release_skill_carries_the_minimum_procedure() -> None:
         assert not missing, f"{path}: missing release procedure phrases {missing}"
 
 
+def test_release_skills_refuse_unimplemented_follower_edge_publication() -> None:
+    for path in SKILLS:
+        content = _text(path)
+        assert "Follower Edge must not dispatch `release.yml`" in content, path
+        assert "#2144" in content, path
+
+
 def test_all_active_release_surfaces_reject_superseded_shapes() -> None:
     rejected = (
         "vX.Y.Z.edge.YYYYMMDD.N",
@@ -115,3 +122,22 @@ def test_branch_independent_adr_contract_is_current() -> None:
         amendment = content.rsplit("## Amendment — 2026-08-04", 1)[-1]
         assert "pinned pfBlockerNG SHA" in amendment, name
         assert "no branch inference" in amendment, name
+
+
+def test_active_docs_describe_the_implemented_channel_trailer_and_order() -> None:
+    docs = (
+        ROOT / ".agents/context/release.md",
+        ROOT / "docs/misc/release-channels.md",
+    )
+    for path in docs:
+        content = _text(path)
+        assert "tag trailer carries only the channel" in content, path
+        assert "Nightly < target final" not in content, path
+        assert "f6db736b" not in content, path
+        assert "remain current at the issue #2140 base revision" not in content, path
+
+
+def test_published_workflow_has_no_retired_nightly_ports_bump_contract() -> None:
+    content = _text(ROOT / ".github/workflows/release-published.yml")
+    assert "`-nightly` port's PORTVERSION" not in content
+    assert "the bump happens inside the release run" not in content

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -594,7 +594,10 @@ def _published_tag_fixture(
 
 
 def _run_classify_step(
-    tmp_path: Path, tag: str, trailer: str | tuple[str, ...] | None = "testing"
+    tmp_path: Path,
+    tag: str,
+    trailer: str | tuple[str, ...] | None = "testing",
+    release_prerelease: str = "true",
 ) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
     """Execute the REAL tag-classification step body under sh."""
     script = _step_run_script(_step(_jobs(PUBLISHED_WORKFLOW)["resolve"], "Classify the tag"))
@@ -607,6 +610,7 @@ def _run_classify_step(
         env={
             "PATH": "/usr/bin:/bin:/usr/local/bin",
             "TAG": tag,
+            "RELEASE_PRERELEASE": release_prerelease,
             "GITHUB_OUTPUT": str(output_file),
         },
         capture_output=True,
@@ -631,6 +635,7 @@ def _run_classify_with_source_line(tmp_path: Path, tag: str, source_line: str) -
         env={
             "PATH": "/usr/bin:/bin:/usr/local/bin",
             "TAG": tag,
+            "RELEASE_PRERELEASE": "true",
             "GITHUB_OUTPUT": str(output_file),
         },
         capture_output=True,
@@ -737,7 +742,7 @@ def test_tag_step_writes_and_validates_the_release_channel_trailer() -> None:
     combined = prepare + "\n" + tag
     assert "git interpret-trailers" in combined, combined
     assert "pfBlockerNG-Release-Channel" in combined, combined
-    assert combined.count("grep -Eic '^pfBlockerNG-Release-Channel: '") == 2, combined
+    assert combined.count("grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:'") == 2, combined
     assert 'git cat-file -t "refs/tags/${TAG}"' in tag, tag
     assert 'git rev-parse "refs/tags/${TAG}^{commit}"' in tag, tag
 
@@ -750,9 +755,20 @@ def test_tag_step_writes_and_validates_the_release_channel_trailer() -> None:
         ("testing", "testing"),
         ("testing", "edge"),
         ("testing\npfblockerng-release-channel: edge",),
+        ("testing\npfblockerng-release-channel:edge",),
+        ("testing\nPFBLOCKERNG-RELEASE-CHANNEL:\tedge",),
         ("bogus",),
     ],
-    ids=["lightweight", "missing", "duplicate", "conflicting", "case-conflicting", "unknown"],
+    ids=[
+        "lightweight",
+        "missing",
+        "duplicate",
+        "conflicting",
+        "case-conflicting",
+        "no-space-conflicting",
+        "tab-conflicting",
+        "unknown",
+    ],
 )
 def test_published_workflow_rejects_invalid_channel_trailers(tmp_path: Path, trailer: object) -> None:
     values = trailer if isinstance(trailer, tuple) else trailer
@@ -765,6 +781,19 @@ def test_published_workflow_passes_the_validated_channel_to_classifier(tmp_path:
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert outputs["channel"] == "testing", outputs
     assert outputs["source"] == "release/4.0", outputs
+
+
+@pytest.mark.parametrize(
+    ("tag", "trailer", "release_prerelease"),
+    [("v4.0.0", "stable", "true"), ("v4.0.0.a7", "testing", "false")],
+)
+def test_published_workflow_rejects_release_flag_mismatch(
+    tmp_path: Path, tag: str, trailer: str, release_prerelease: str
+) -> None:
+    step = "\n".join(_step(_jobs(PUBLISHED_WORKFLOW)["resolve"], "Classify the tag"))
+    assert "github.event.release.prerelease" in step, step
+    completed, _outputs = _run_classify_step(tmp_path, tag, trailer, release_prerelease)
+    assert completed.returncode != 0, completed.stdout + completed.stderr
 
 
 # --------------------------------------------------------------------------- #
@@ -955,9 +984,20 @@ def test_tag_step_refuses_a_stale_tag_pointing_at_other_code(tmp_path: Path) -> 
         ("testing", "testing"),
         ("testing", "edge"),
         ("testing\npfblockerng-release-channel: edge",),
+        ("testing\npfblockerng-release-channel:edge",),
+        ("testing\nPFBLOCKERNG-RELEASE-CHANNEL:\tedge",),
         ("bogus",),
     ],
-    ids=["lightweight", "missing", "duplicate", "conflicting", "case-conflicting", "unknown"],
+    ids=[
+        "lightweight",
+        "missing",
+        "duplicate",
+        "conflicting",
+        "case-conflicting",
+        "no-space-conflicting",
+        "tab-conflicting",
+        "unknown",
+    ],
 )
 def test_tag_step_refuses_existing_tags_without_exact_channel_metadata(tmp_path: Path, trailers: object) -> None:
     repo, head, _older = _tag_repo(tmp_path)

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -737,14 +737,22 @@ def test_tag_step_writes_and_validates_the_release_channel_trailer() -> None:
     combined = prepare + "\n" + tag
     assert "git interpret-trailers" in combined, combined
     assert "pfBlockerNG-Release-Channel" in combined, combined
+    assert combined.count("grep -Eic '^pfBlockerNG-Release-Channel: '") == 2, combined
     assert 'git cat-file -t "refs/tags/${TAG}"' in tag, tag
     assert 'git rev-parse "refs/tags/${TAG}^{commit}"' in tag, tag
 
 
 @pytest.mark.parametrize(
     "trailer",
-    [None, (), ("testing", "testing"), ("testing", "edge"), ("bogus",)],
-    ids=["lightweight", "missing", "duplicate", "conflicting", "unknown"],
+    [
+        None,
+        (),
+        ("testing", "testing"),
+        ("testing", "edge"),
+        ("testing\npfblockerng-release-channel: edge",),
+        ("bogus",),
+    ],
+    ids=["lightweight", "missing", "duplicate", "conflicting", "case-conflicting", "unknown"],
 )
 def test_published_workflow_rejects_invalid_channel_trailers(tmp_path: Path, trailer: object) -> None:
     values = trailer if isinstance(trailer, tuple) else trailer
@@ -941,8 +949,15 @@ def test_tag_step_refuses_a_stale_tag_pointing_at_other_code(tmp_path: Path) -> 
 
 @pytest.mark.parametrize(
     "trailers",
-    [None, (), ("testing", "testing"), ("testing", "edge"), ("bogus",)],
-    ids=["lightweight", "missing", "duplicate", "conflicting", "unknown"],
+    [
+        None,
+        (),
+        ("testing", "testing"),
+        ("testing", "edge"),
+        ("testing\npfblockerng-release-channel: edge",),
+        ("bogus",),
+    ],
+    ids=["lightweight", "missing", "duplicate", "conflicting", "case-conflicting", "unknown"],
 )
 def test_tag_step_refuses_existing_tags_without_exact_channel_metadata(tmp_path: Path, trailers: object) -> None:
     repo, head, _older = _tag_repo(tmp_path)

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -559,7 +559,12 @@ def test_the_tag_classifier_runs_from_a_trusted_ref() -> None:
         assert untrusted not in ref_line, f"the classifier must not run from the released tree, got: {ref_line}"
 
 
-def _published_tag_fixture(tmp_path: Path, tag: str, trailer: str | tuple[str, ...] | None = "testing") -> Path:
+def _published_tag_fixture(
+    tmp_path: Path,
+    tag: str,
+    trailer: str | tuple[str, ...] | None = "testing",
+    source_line: str = "release/4.0",
+) -> Path:
     """Create a fetched tag object for the published-workflow step."""
     origin = tmp_path / "origin.git"
     repo = tmp_path / "published"
@@ -572,6 +577,7 @@ def _published_tag_fixture(tmp_path: Path, tag: str, trailer: str | tuple[str, .
     _git(repo, "commit", "-qm", "one")
     _git(repo, "remote", "add", "origin", str(origin))
     _git(repo, "push", "-q", "origin", "devel")
+    _git(repo, "push", "-q", "origin", f"HEAD:refs/heads/{source_line}")
     if trailer is None:
         _git(repo, "tag", tag)
     else:
@@ -611,6 +617,68 @@ def _run_classify_step(
         key, _, value = line.partition("=")
         outputs[key] = value
     return completed, outputs
+
+
+def _run_classify_with_source_line(tmp_path: Path, tag: str, source_line: str) -> subprocess.CompletedProcess[str]:
+    """Run the published classifier against an explicitly chosen remote release line."""
+    script = _step_run_script(_step(_jobs(PUBLISHED_WORKFLOW)["resolve"], "Classify the tag"))
+    repo = _published_tag_fixture(tmp_path, tag, "testing", source_line)
+    output_file = tmp_path / "gh_output_route"
+    output_file.write_text("")
+    return subprocess.run(  # noqa: S603
+        ["sh", "-c", script],
+        cwd=repo,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "TAG": tag,
+            "GITHUB_OUTPUT": str(output_file),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_port_sync_validation(portversion: str) -> subprocess.CompletedProcess[str]:
+    """Execute only the release port-version guard from sync-ports-fork."""
+    script = _step_run_script(_step(_jobs()["sync-ports-fork"], "Bump PORTVERSION and push"))
+    marker = 'if [ "$CHANNEL" = "stable" ]; then'
+    _before, validation = script.split(marker, 1)
+    validation = marker + validation.split('\n\nif [ "$CHANNEL" = "stable" ]; then', 1)[0]
+    return subprocess.run(  # noqa: S603
+        ["sh", "-c", "set -eu\n" + validation],
+        cwd=ROOT,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "SOURCE": "release/4.0",
+            "CHANNEL": "testing",
+            "TAG": "v4.0.0.a1",
+            "PORTVERSION": portversion,
+        },
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("stage", ["a", "b", "r"])
+def test_sync_ports_accepts_short_prerelease_versions(stage: str) -> None:
+    result = _run_port_sync_validation(f"4.0.0.{stage}1")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("stage", ["alpha", "beta", "rc"])
+def test_sync_ports_rejects_long_prerelease_versions(stage: str) -> None:
+    result = _run_port_sync_validation(f"4.0.0.{stage}.1")
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_published_classifier_rejects_tag_outside_derived_release_line(tmp_path: Path) -> None:
+    result = _run_classify_with_source_line(tmp_path, "v4.0.0.a1", "release/5.0")
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_published_classifier_accepts_tag_on_derived_release_line(tmp_path: Path) -> None:
+    result = _run_classify_with_source_line(tmp_path, "v4.0.0.a1", "release/4.0")
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_an_off_scheme_published_tag_reports_the_real_reason(tmp_path: Path) -> None:

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -568,8 +568,12 @@ def _published_tag_fixture(
     """Create a fetched tag object for the published-workflow step."""
     origin = tmp_path / "origin.git"
     repo = tmp_path / "published"
-    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True, env=scrubbed_git_env())  # noqa: S603
-    subprocess.run(["git", "init", "-q", "-b", "devel", str(repo)], check=True, env=scrubbed_git_env())  # noqa: S603
+    subprocess.run(  # noqa: S603
+        ["git", "init", "--bare", "-q", str(origin)], check=True, env=scrubbed_git_env(drop_git_vars=True)
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "init", "-q", "-b", "devel", str(repo)], check=True, env=scrubbed_git_env(drop_git_vars=True)
+    )
     _git(repo, "config", "user.email", "t@example.invalid")
     _git(repo, "config", "user.name", "t")
     (repo / "a.txt").write_text("one\n")
@@ -583,8 +587,7 @@ def _published_tag_fixture(
     else:
         trailers = (trailer,) if isinstance(trailer, str) else trailer
         args = ["tag", "-a", tag, "-m", tag]
-        for value in trailers:
-            args.extend(("-m", f"pfBlockerNG-Release-Channel: {value}"))
+        args.extend(("-m", "\n".join(f"pfBlockerNG-Release-Channel: {value}" for value in trailers)))
         _git(repo, *args)
     _git(repo, "push", "-q", "origin", f"refs/tags/{tag}")
     (repo / "scripts").mkdir()
@@ -742,7 +745,7 @@ def test_tag_step_writes_and_validates_the_release_channel_trailer() -> None:
     combined = prepare + "\n" + tag
     assert "git interpret-trailers" in combined, combined
     assert "pfBlockerNG-Release-Channel" in combined, combined
-    assert combined.count("grep -Eic '^pfBlockerNG-Release-Channel[[:space:]]*:'") == 2, combined
+    assert combined.count("grep -Eic '^pfBlockerNG-Release-Channel:'") == 2, combined
     assert 'git cat-file -t "refs/tags/${TAG}"' in tag, tag
     assert 'git rev-parse "refs/tags/${TAG}^{commit}"' in tag, tag
 
@@ -899,7 +902,7 @@ def _git(repo: Path, *args: str) -> str:
         capture_output=True,
         text=True,
         check=True,
-        env=scrubbed_git_env(),
+        env=scrubbed_git_env(drop_git_vars=True),
     ).stdout.strip()
 
 
@@ -907,8 +910,12 @@ def _tag_repo(tmp_path: Path) -> tuple[Path, str, str]:
     """A work repo with a bare `origin`, two commits; returns (repo, head_sha, older_sha)."""
     origin = tmp_path / "origin.git"
     repo = tmp_path / "work"
-    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True, env=scrubbed_git_env())  # noqa: S603
-    subprocess.run(["git", "init", "-q", "-b", "devel", str(repo)], check=True, env=scrubbed_git_env())  # noqa: S603
+    subprocess.run(  # noqa: S603
+        ["git", "init", "--bare", "-q", str(origin)], check=True, env=scrubbed_git_env(drop_git_vars=True)
+    )
+    subprocess.run(  # noqa: S603
+        ["git", "init", "-q", "-b", "devel", str(repo)], check=True, env=scrubbed_git_env(drop_git_vars=True)
+    )
     _git(repo, "config", "user.email", "t@example.invalid")
     _git(repo, "config", "user.name", "t")
     (repo / "a.txt").write_text("one\n")
@@ -952,8 +959,7 @@ def test_tag_step_creates_and_pushes_the_tag_on_the_pinned_sha(tmp_path: Path) -
 
 
 def test_tag_step_resumes_a_tag_that_already_points_at_the_verified_sha(tmp_path: Path) -> None:
-    """Scenario: a prior run crashed after tagging. Given the tag already exists on the
-    SAME pinned SHA, when the step re-runs, then it reuses the tag and still succeeds."""
+    """Reuse an existing annotated tag only when it points to the pinned SHA."""
     repo, head, _older = _tag_repo(tmp_path)
     _git(repo, "tag", "-a", "v9.9.9.r1", "-m", "v9.9.9.r1", "-m", "pfBlockerNG-Release-Channel: testing", head)
     _git(repo, "push", "-q", "origin", "refs/tags/v9.9.9.r1")
@@ -1007,8 +1013,7 @@ def test_tag_step_refuses_existing_tags_without_exact_channel_metadata(tmp_path:
     else:
         args = ["tag", "-a", tag, "-m", tag]
         assert isinstance(trailers, tuple)
-        for value in trailers:
-            args.extend(("-m", f"pfBlockerNG-Release-Channel: {value}"))
+        args.extend(("-m", "\n".join(f"pfBlockerNG-Release-Channel: {value}" for value in trailers)))
         _git(repo, *args, head)
     _git(repo, "push", "-q", "origin", f"refs/tags/{tag}")
     result = _run_tag_step(repo, tag, head)
@@ -1126,7 +1131,7 @@ def _tag_still_there(tmp_path: Path, tag: str) -> bool:
             ["git", "rev-parse", "-q", "--verify", f"refs/tags/{tag}"],
             cwd=tmp_path / "work",
             capture_output=True,
-            env=scrubbed_git_env(),
+            env=scrubbed_git_env(drop_git_vars=True),
         ).returncode
         == 0
     )

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -37,6 +37,7 @@ the suite AND-gates fails here.
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 import textwrap
 from pathlib import Path
@@ -558,14 +559,45 @@ def test_the_tag_classifier_runs_from_a_trusted_ref() -> None:
         assert untrusted not in ref_line, f"the classifier must not run from the released tree, got: {ref_line}"
 
 
-def _run_classify_step(tmp_path: Path, tag: str) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+def _published_tag_fixture(tmp_path: Path, tag: str, trailer: str | tuple[str, ...] | None = "testing") -> Path:
+    """Create a fetched tag object for the published-workflow step."""
+    origin = tmp_path / "origin.git"
+    repo = tmp_path / "published"
+    subprocess.run(["git", "init", "--bare", "-q", str(origin)], check=True, env=scrubbed_git_env())  # noqa: S603
+    subprocess.run(["git", "init", "-q", "-b", "devel", str(repo)], check=True, env=scrubbed_git_env())  # noqa: S603
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+    (repo / "a.txt").write_text("one\n")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-qm", "one")
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "push", "-q", "origin", "devel")
+    if trailer is None:
+        _git(repo, "tag", tag)
+    else:
+        trailers = (trailer,) if isinstance(trailer, str) else trailer
+        args = ["tag", "-a", tag, "-m", tag]
+        for value in trailers:
+            args.extend(("-m", f"pfBlockerNG-Release-Channel: {value}"))
+        _git(repo, *args)
+    _git(repo, "push", "-q", "origin", f"refs/tags/{tag}")
+    (repo / "scripts").mkdir()
+    for helper in ("release-version.sh", "release_version.py"):
+        shutil.copy2(ROOT / "scripts" / helper, repo / "scripts" / helper)
+    return repo
+
+
+def _run_classify_step(
+    tmp_path: Path, tag: str, trailer: str | tuple[str, ...] | None = "testing"
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
     """Execute the REAL tag-classification step body under sh."""
     script = _step_run_script(_step(_jobs(PUBLISHED_WORKFLOW)["resolve"], "Classify the tag"))
+    repo = _published_tag_fixture(tmp_path, tag, trailer)
     output_file = tmp_path / "gh_output"
     output_file.write_text("")
     completed = subprocess.run(  # noqa: S603
         ["sh", "-c", script],
-        cwd=ROOT,
+        cwd=repo,
         env={
             "PATH": "/usr/bin:/bin:/usr/local/bin",
             "TAG": tag,
@@ -599,15 +631,64 @@ def test_an_off_scheme_published_tag_reports_the_real_reason(tmp_path: Path) -> 
 
 
 def test_a_scheme_tag_classifies_cleanly(tmp_path: Path) -> None:
-    completed, outputs = _run_classify_step(tmp_path, "v4.0.0.alpha.7")
+    completed, outputs = _run_classify_step(tmp_path, "v4.0.0.a7")
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert outputs["branch"] == "devel", outputs
-    assert outputs["portversion"] == "4.0.0.alpha.7", outputs
+    assert outputs["channel"] == "testing", outputs
+    assert outputs["source"] == "release/4.0", outputs
+    assert outputs["portversion"] == "4.0.0.a7", outputs
 
 
 def test_the_published_workflow_reads_the_tag_from_the_release_payload() -> None:
     text = PUBLISHED_WORKFLOW.read_text(encoding="utf-8")
     assert "github.event.release.tag_name" in text, "the tag must come from the release that was published"
+
+
+def test_release_dispatch_requires_explicit_channel_and_source() -> None:
+    text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    dispatch = text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
+    channel = dispatch.split("      channel:\n", 1)[1].split("\n\n", 1)[0]
+    assert re.search(r"^\s+type:\s*choice\s*$", channel, re.MULTILINE), channel
+    assert re.search(r"^\s+options:\s*\[stable, testing, edge\]\s*$", channel, re.MULTILINE), channel
+    source = dispatch.split("      source:\n", 1)[1].split("\n\n", 1)[0]
+    assert re.search(r"^\s+required:\s*true\s*$", source, re.MULTILINE), source
+    assert "release/X.Y" in source, source
+
+
+def test_release_uses_explicit_channel_and_exact_source_line() -> None:
+    text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    assert 'release-version.sh "$TAG" "$CHANNEL" "$SOURCE"' in text, text
+    assert 'release-version.sh "$TAG")' not in text, text
+    assert 'git checkout "$SOURCE"' in text, text
+    assert 'if [ "$channel" = "devel" ]' not in text, text
+
+
+def test_tag_step_writes_and_validates_the_release_channel_trailer() -> None:
+    jobs = _jobs()
+    prepare = "\n".join(_jobs()["prepare-release"])
+    tag = _step_run_script(_step(jobs["tag-release"], "Create + push the tag on the verified commit"))
+    combined = prepare + "\n" + tag
+    assert "git interpret-trailers" in combined, combined
+    assert "pfBlockerNG-Release-Channel" in combined, combined
+    assert 'git cat-file -t "refs/tags/${TAG}"' in tag, tag
+    assert 'git rev-parse "refs/tags/${TAG}^{commit}"' in tag, tag
+
+
+@pytest.mark.parametrize(
+    "trailer",
+    [None, (), ("testing", "testing"), ("testing", "edge"), ("bogus",)],
+    ids=["lightweight", "missing", "duplicate", "conflicting", "unknown"],
+)
+def test_published_workflow_rejects_invalid_channel_trailers(tmp_path: Path, trailer: object) -> None:
+    values = trailer if isinstance(trailer, tuple) else trailer
+    completed, _outputs = _run_classify_step(tmp_path, "v4.0.0.a7", values)  # type: ignore[arg-type]
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+def test_published_workflow_passes_the_validated_channel_to_classifier(tmp_path: Path) -> None:
+    completed, outputs = _run_classify_step(tmp_path, "v4.0.0.a7", "testing")
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert outputs["channel"] == "testing", outputs
+    assert outputs["source"] == "release/4.0", outputs
 
 
 # --------------------------------------------------------------------------- #
@@ -626,6 +707,8 @@ def _run_suites_decision(tmp_path: Path, tag: str, force_suites: str) -> dict[st
         env={
             "PATH": "/usr/bin:/bin:/usr/local/bin",
             "INPUT_TAG": tag,
+            "INPUT_CHANNEL": "stable" if tag == "v4.0.0" else "testing",
+            "INPUT_SOURCE": "release/4.0",
             "FORCE_SUITES": force_suites,
             "GITHUB_OUTPUT": str(output_file),
         },
@@ -643,9 +726,9 @@ def _run_suites_decision(tmp_path: Path, tag: str, force_suites: str) -> dict[st
 @pytest.mark.parametrize(
     ("tag", "expected_run_suites"),
     [
-        ("v4.0.0.alpha.1", "false"),  # alpha: verify-checks (CI green) is the mandatory gate
-        ("v4.0.0.beta.1", "false"),  # beta: same
-        ("v4.0.0.rc.1", "true"),  # rc: full live verification before the tag
+        ("v4.0.0.a1", "false"),  # alpha: verify-checks (CI green) is the mandatory gate
+        ("v4.0.0.b1", "false"),  # beta: same
+        ("v4.0.0.r1", "true"),  # rc: full live verification before the tag
         ("v4.0.0", "true"),  # stable: full live verification before the tag
     ],
 )
@@ -654,14 +737,14 @@ def test_run_suites_per_channel(tmp_path: Path, tag: str, expected_run_suites: s
     assert outputs["run_suites"] == expected_run_suites, outputs
 
 
-@pytest.mark.parametrize("tag", ["v4.0.0.alpha.1", "v4.0.0.beta.1"])
+@pytest.mark.parametrize("tag", ["v4.0.0.a1", "v4.0.0.b1"])
 def test_force_suites_turns_the_live_suites_back_on_for_an_alpha_or_beta(tmp_path: Path, tag: str) -> None:
     """The manual escape hatch: default off for alpha/beta, forceable per dispatch."""
     assert _run_suites_decision(tmp_path, tag, "false")["run_suites"] == "false"
     assert _run_suites_decision(tmp_path, tag, "true")["run_suites"] == "true"
 
 
-@pytest.mark.parametrize("tag", ["v4.0.0.rc.1", "v4.0.0"])
+@pytest.mark.parametrize("tag", ["v4.0.0.r1", "v4.0.0"])
 def test_force_suites_cannot_turn_the_live_suites_off(tmp_path: Path, tag: str) -> None:
     """rc/stable always verify; the input only ever ADDS verification."""
     assert _run_suites_decision(tmp_path, tag, "false")["run_suites"] == "true"
@@ -745,6 +828,8 @@ def _run_tag_step(repo: Path, tag: str, sha: str) -> subprocess.CompletedProcess
             "HOME": str(repo),
             "TAG": tag,
             "SHA": sha,
+            "CHANNEL": "testing",
+            "SOURCE": "release/9.9",
             "GITHUB_OUTPUT": str(repo / "gh_output"),
         },
         capture_output=True,
@@ -754,10 +839,10 @@ def _run_tag_step(repo: Path, tag: str, sha: str) -> subprocess.CompletedProcess
 
 def test_tag_step_creates_and_pushes_the_tag_on_the_pinned_sha(tmp_path: Path) -> None:
     repo, head, _older = _tag_repo(tmp_path)
-    result = _run_tag_step(repo, "v9.9.9.rc.1", head)
+    result = _run_tag_step(repo, "v9.9.9.r1", head)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert _git(repo, "rev-list", "-n", "1", "refs/tags/v9.9.9.rc.1") == head
-    assert "v9.9.9.rc.1" in _git(repo, "ls-remote", "--tags", "origin")
+    assert _git(repo, "rev-list", "-n", "1", "refs/tags/v9.9.9.r1") == head
+    assert "v9.9.9.r1" in _git(repo, "ls-remote", "--tags", "origin")
     assert f"sha={head}" in (repo / "gh_output").read_text()
 
 
@@ -765,11 +850,11 @@ def test_tag_step_resumes_a_tag_that_already_points_at_the_verified_sha(tmp_path
     """Scenario: a prior run crashed after tagging. Given the tag already exists on the
     SAME pinned SHA, when the step re-runs, then it reuses the tag and still succeeds."""
     repo, head, _older = _tag_repo(tmp_path)
-    _git(repo, "tag", "-a", "v9.9.9.rc.1", "-m", "v9.9.9.rc.1", head)
-    _git(repo, "push", "-q", "origin", "refs/tags/v9.9.9.rc.1")
-    result = _run_tag_step(repo, "v9.9.9.rc.1", head)
+    _git(repo, "tag", "-a", "v9.9.9.r1", "-m", "v9.9.9.r1", "-m", "pfBlockerNG-Release-Channel: testing", head)
+    _git(repo, "push", "-q", "origin", "refs/tags/v9.9.9.r1")
+    result = _run_tag_step(repo, "v9.9.9.r1", head)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert _git(repo, "rev-list", "-n", "1", "refs/tags/v9.9.9.rc.1") == head
+    assert _git(repo, "rev-list", "-n", "1", "refs/tags/v9.9.9.r1") == head
 
 
 def test_tag_step_refuses_a_stale_tag_pointing_at_other_code(tmp_path: Path) -> None:
@@ -778,12 +863,34 @@ def test_tag_step_refuses_a_stale_tag_pointing_at_other_code(tmp_path: Path) -> 
     artifacts belong to the pinned SHA, so silently reusing the old tag would publish
     assets that do not match their tag."""
     repo, head, older = _tag_repo(tmp_path)
-    _git(repo, "tag", "-a", "v9.9.9.rc.1", "-m", "v9.9.9.rc.1", older)
-    _git(repo, "push", "-q", "origin", "refs/tags/v9.9.9.rc.1")
-    result = _run_tag_step(repo, "v9.9.9.rc.1", head)
+    _git(repo, "tag", "-a", "v9.9.9.r1", "-m", "v9.9.9.r1", "-m", "pfBlockerNG-Release-Channel: testing", older)
+    _git(repo, "push", "-q", "origin", "refs/tags/v9.9.9.r1")
+    result = _run_tag_step(repo, "v9.9.9.r1", head)
     assert result.returncode != 0, result.stdout + result.stderr
     assert "::error::" in (result.stdout + result.stderr)
-    assert _git(repo, "rev-list", "-n", "1", "refs/tags/v9.9.9.rc.1") == older, "the stale tag must not be moved"
+    assert _git(repo, "rev-list", "-n", "1", "refs/tags/v9.9.9.r1") == older, "the stale tag must not be moved"
+
+
+@pytest.mark.parametrize(
+    "trailers",
+    [None, (), ("testing", "testing"), ("testing", "edge"), ("bogus",)],
+    ids=["lightweight", "missing", "duplicate", "conflicting", "unknown"],
+)
+def test_tag_step_refuses_existing_tags_without_exact_channel_metadata(tmp_path: Path, trailers: object) -> None:
+    repo, head, _older = _tag_repo(tmp_path)
+    tag = "v9.9.9.r1"
+    if trailers is None:
+        _git(repo, "tag", tag, head)
+    else:
+        args = ["tag", "-a", tag, "-m", tag]
+        assert isinstance(trailers, tuple)
+        for value in trailers:
+            args.extend(("-m", f"pfBlockerNG-Release-Channel: {value}"))
+        _git(repo, *args, head)
+    _git(repo, "push", "-q", "origin", f"refs/tags/{tag}")
+    result = _run_tag_step(repo, tag, head)
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "::error::" in result.stdout + result.stderr
 
 
 # --------------------------------------------------------------------------- #
@@ -906,12 +1013,12 @@ def test_retag_refuses_a_published_release(tmp_path: Path) -> None:
     """Given the tag already carries a PUBLISHED Release, when retag runs, then it
     refuses: a published release is immutable, so retagging cannot rescue it and the
     only way forward is the next .N."""
-    completed, calls = _run_retag_step(tmp_path, "v9.9.9.rc.1", '{"isDraft":false,"assets":[]}')
+    completed, calls = _run_retag_step(tmp_path, "v9.9.9.r1", '{"isDraft":false,"assets":[]}')
     assert completed.returncode != 0, completed.stdout + completed.stderr
     assert "::error::" in completed.stdout + completed.stderr
     assert "PUBLISHED" in completed.stdout + completed.stderr
     assert not [c for c in calls if "delete" in c or "DELETE" in c], calls
-    assert _tag_still_there(tmp_path, "v9.9.9.rc.1")
+    assert _tag_still_there(tmp_path, "v9.9.9.r1")
 
 
 def test_retag_refuses_a_draft_that_already_has_assets(tmp_path: Path) -> None:
@@ -926,12 +1033,12 @@ def test_retag_refuses_a_draft_that_already_has_assets(tmp_path: Path) -> None:
     the operator both routes rather than pick one for them: re-dispatch the same tag
     with `retag=false` to finish the draft, or delete it by hand to start over.
     """
-    completed, calls = _run_retag_step(tmp_path, "v9.9.9.rc.1", '{"isDraft":true,"assets":[{"name":"x.pkg"}]}')
+    completed, calls = _run_retag_step(tmp_path, "v9.9.9.r1", '{"isDraft":true,"assets":[{"name":"x.pkg"}]}')
     message = completed.stdout + completed.stderr
     assert completed.returncode != 0, message
     assert "::error::" in message
     assert not [c for c in calls if "delete" in c or "DELETE" in c], calls
-    assert _tag_still_there(tmp_path, "v9.9.9.rc.1")
+    assert _tag_still_there(tmp_path, "v9.9.9.r1")
     assert "retag=false" in message, f"the refusal must name the way to FINISH that draft: {message}"
     assert "by hand" in message, f"the refusal must name the way to START OVER: {message}"
 
@@ -939,23 +1046,23 @@ def test_retag_refuses_a_draft_that_already_has_assets(tmp_path: Path) -> None:
 def test_retag_deletes_an_assetless_draft_together_with_the_tag(tmp_path: Path) -> None:
     """An assetless draft is the debris of a crashed run. Leaving it while deleting its
     tag would orphan it and produce two drafts for the same tag, so both go."""
-    completed, calls = _run_retag_step(tmp_path, "v9.9.9.rc.1", '{"isDraft":true,"assets":[]}')
+    completed, calls = _run_retag_step(tmp_path, "v9.9.9.r1", '{"isDraft":true,"assets":[]}')
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert any(c.startswith("release delete v9.9.9.rc.1") for c in calls), calls
-    assert any("git/refs/tags/v9.9.9.rc.1" in c for c in calls), calls
-    assert not _tag_still_there(tmp_path, "v9.9.9.rc.1"), "the local ref must go too, or the pin re-finds it"
+    assert any(c.startswith("release delete v9.9.9.r1") for c in calls), calls
+    assert any("git/refs/tags/v9.9.9.r1" in c for c in calls), calls
+    assert not _tag_still_there(tmp_path, "v9.9.9.r1"), "the local ref must go too, or the pin re-finds it"
 
 
 def test_retag_with_no_release_deletes_only_the_tag(tmp_path: Path) -> None:
-    completed, calls = _run_retag_step(tmp_path, "v9.9.9.rc.1", None)
+    completed, calls = _run_retag_step(tmp_path, "v9.9.9.r1", None)
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert not [c for c in calls if c.startswith("release delete")], calls
-    assert any("git/refs/tags/v9.9.9.rc.1" in c for c in calls), calls
-    assert not _tag_still_there(tmp_path, "v9.9.9.rc.1")
+    assert any("git/refs/tags/v9.9.9.r1" in c for c in calls), calls
+    assert not _tag_still_there(tmp_path, "v9.9.9.r1")
 
 
 def test_retag_is_a_silent_no_op_when_no_tag_exists(tmp_path: Path) -> None:
-    completed, calls = _run_retag_step(tmp_path, "v9.9.9.rc.1", None, make_tag=False)
+    completed, calls = _run_retag_step(tmp_path, "v9.9.9.r1", None, make_tag=False)
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert not [c for c in calls if "delete" in c or "DELETE" in c], calls
 
@@ -965,8 +1072,8 @@ def test_a_dry_run_never_deletes_anything(tmp_path: Path, release_json: str | No
     """Defence in depth: the job is real-publish only, so this step cannot run in a dry
     run at all -- but if that gate is ever relaxed, the step still refuses to delete and
     only reports what it would have removed."""
-    completed, calls = _run_retag_step(tmp_path, "v9.9.9.rc.1", release_json, dry_run="true")
+    completed, calls = _run_retag_step(tmp_path, "v9.9.9.r1", release_json, dry_run="true")
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert not [c for c in calls if "delete" in c or "DELETE" in c], calls
-    assert _tag_still_there(tmp_path, "v9.9.9.rc.1")
+    assert _tag_still_there(tmp_path, "v9.9.9.r1")
     assert "would delete" in completed.stdout.lower(), completed.stdout

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -43,7 +43,7 @@ def test_context_classifies_shared_tag_grammar(
     tag: str, channel: str, expected: tuple[str, str, str | None, str, bool, bool, str]
 ) -> None:
     info = parse_release_tag(tag, channel)  # type: ignore[arg-type,call-arg]
-    version, stage, sequence, channel, prerelease, final, pkg_version = expected
+    version, _stage, _sequence, _expected_channel, _prerelease, final, _pkg_version = expected
     assert (
         info.version,
         info.stage,
@@ -58,7 +58,7 @@ def test_context_classifies_shared_tag_grammar(
     assert info.release_line == f"release/{info.target_final.rsplit('.', 1)[0]}"
     assert info.package == PACKAGE
     assert info.notes_required is True
-    assert info.github_release == "final" if final else info.github_release == "prerelease"
+    assert info.github_release == ("final" if final else "prerelease")
 
 
 @pytest.mark.parametrize(
@@ -138,11 +138,10 @@ def test_hostile_wrapper_inputs_emit_no_assignments(tag: str, channel: str) -> N
     assert result.stdout == ""
 
 
-@pytest.mark.parametrize("branch", ["release/3.2"])
-def test_matching_release_line_is_required_for_tagged_context(branch: str) -> None:
+def test_matching_release_line_is_required_for_tagged_context() -> None:
     info = parse_release_tag("v3.2.15", "stable")  # type: ignore[arg-type,call-arg]
-    validate_branch(info, branch)
-    validate_branch(parse_release_tag("v3.2.16.a1", "edge"), branch)  # type: ignore[arg-type,call-arg]
+    validate_branch(info, "release/3.2")
+    validate_branch(parse_release_tag("v3.2.16.a1", "edge"), "release/3.2")  # type: ignore[arg-type,call-arg]
 
 
 @pytest.mark.parametrize("branch", ["main", "devel", "release/3.3", "feature/release", ""])

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 import subprocess
 from dataclasses import fields, replace
 from pathlib import Path
+from typing import cast
 
 import pytest
 
-from scripts.release_version import PACKAGE, ReleaseInfo, parse_release_tag, validate_branch, validate_release_info
+from scripts.release_version import (
+    PACKAGE,
+    GithubRelease,
+    ReleaseInfo,
+    parse_release_tag,
+    validate_branch,
+    validate_release_info,
+)
 
 _SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "release-version.sh"
 
@@ -218,7 +226,7 @@ def test_every_canonical_field_tampering_is_rejected(tag: str, channel: str) -> 
         replace(info, final=not info.final),
         replace(info, prerelease=not info.prerelease),
         replace(info, notes_required=not info.notes_required),
-        replace(info, github_release="none"),
+        replace(info, github_release=cast(GithubRelease, "none")),
         replace(info, package="wrong"),
     ]
     for forged in tampered:

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,160 +1,181 @@
-"""Behaviour guard for the release tag/version scheme (scripts/release-version.sh).
-
-This is the single source of truth that `release.yml` (publish gating, PORTVERSION
-bump) and `.githooks/pre-push` (client-side tag enforcement) both consume, so it
-is pinned here directly rather than re-deriving the regex in each consumer.
-
-Scheme:
-  * vX.Y.Z                          -> STABLE release, cut from `main` only
-  * vX.Y.Z.alpha.N/.beta.N/.rc.N    -> ALPHA/BETA/RC prerelease, cut from `devel` only
-
-The script classifies a tag into version/channel/prerelease/prekind/portversion,
-rejects malformed tags, and (when a branch is supplied) enforces branch<->channel.
-"""
+"""Contextual release tag and channel contract for issue #2140."""
 
 from __future__ import annotations
 
 import subprocess
 from dataclasses import fields, replace
-from datetime import date
 from pathlib import Path
-from typing import Any
 
 import pytest
 
-from scripts.release_version import generate_snapshot, validate_release_info
+from scripts.release_version import PACKAGE, ReleaseInfo, parse_release_tag, validate_branch, validate_release_info
 
 _SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "release-version.sh"
 
 
-def _api() -> tuple[Any, Any, Any, Any]:
-    """Load the public Python API only in tests that exercise it directly."""
-    from scripts.release_version import PACKAGE, ReleaseInfo, parse_release_tag, validate_branch
-
-    return PACKAGE, ReleaseInfo, parse_release_tag, validate_branch
-
-
 def _run(*args: str) -> subprocess.CompletedProcess[str]:
-    """Invoke the classifier script with the given args, capturing stdout/stderr/exit."""
-    return subprocess.run(
-        ["sh", str(_SCRIPT), *args],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    return subprocess.run(["sh", str(_SCRIPT), *args], capture_output=True, text=True, check=False)
 
 
 def _fields(stdout: str) -> dict[str, str]:
-    """Parse the script's ``KEY=VALUE`` stdout lines into a dict."""
     return dict(line.split("=", 1) for line in stdout.splitlines() if "=" in line)
 
 
-# (tag, branch, expected channel/prerelease/prekind/portversion)
-_VALID = [
-    ("v4.0.0.alpha.1", "devel", "devel", "true", "alpha", "4.0.0.alpha.1"),
-    ("v4.0.0.alpha.2", "devel", "devel", "true", "alpha", "4.0.0.alpha.2"),
-    ("v4.0.0.beta.1", "devel", "devel", "true", "beta", "4.0.0.beta.1"),
-    ("v4.0.0.rc.1", "devel", "devel", "true", "rc", "4.0.0.rc.1"),
-    ("v4.0.0.rc.12", "devel", "devel", "true", "rc", "4.0.0.rc.12"),
-    ("v4.0.0", "main", "stable", "false", "", "4.0.0"),
-    ("v10.20.30", "main", "stable", "false", "", "10.20.30"),
-    # No branch context (dry-run): channel inferred from the tag shape, no branch check.
-    ("v4.1.0.alpha.3", "", "devel", "true", "alpha", "4.1.0.alpha.3"),
-    ("v4.1.0", "", "stable", "false", "", "4.1.0"),
-]
-
-
-@pytest.mark.parametrize("tag,branch,channel,prerelease,prekind,portversion", _VALID)
-def test_valid_tag_classification(
-    tag: str, branch: str, channel: str, prerelease: str, prekind: str, portversion: str
-) -> None:
-    """A well-formed tag classifies into the expected channel/prerelease/PORTVERSION."""
-    args = [tag, branch] if branch else [tag]
-    res = _run(*args)
-    assert res.returncode == 0, res.stderr
-    f = _fields(res.stdout)
-    assert f["version"] == tag[1:]
-    assert f["channel"] == channel
-    assert f["prerelease"] == prerelease
-    assert f["prekind"] == prekind
-    # PORTVERSION must be pkg-safe (no '-', the pkg name/version separator) and == version.
-    assert f["portversion"] == portversion
-    assert "-" not in f["portversion"]
-
-
-_MALFORMED = [
-    "v4.0.0-devel",  # legacy suffix scheme — no longer valid
-    "v4.0.0.a1",  # legacy short stage form — no longer valid
-    "v4.0.0.b1",  # legacy short stage form — no longer valid
-    "v4.0.0.rc1",  # legacy short stage form (rc without the dot+seq) — no longer valid
-    "v4.0.0-rc.1",  # dash, not the dotted .rc.N form
-    "v4.0.0.alpha1",  # stage word not dot-separated from the sequence
-    "v4.0.0.alpha",  # stage word without a sequence number
-    "v4.0.a.1",  # only two numeric components
-    "v4.0.0.gamma.1",  # unknown stage word (not alpha|beta|rc)
-    "v4.0.0.pre.1",  # 'pre' is pkg-recognized but not part of our scheme
-    "4.0.0.alpha.1",  # missing leading v
-    "v4.0.0.alpha.1.1",  # trailing junk after the sequence
-    "v01.2.3",  # leading zero in a version component (not strict semver)
-    "v1.02.3",  # leading zero in the minor component
-    "v1.2.03",  # leading zero in the patch component
-    "v4.0.0.alpha.0",  # prerelease sequence must be >= 1
-    "v4.0.0.alpha.01",  # leading zero in the prerelease sequence
-]
-
-
-@pytest.mark.parametrize("tag", _MALFORMED)
-def test_malformed_tag_rejected(tag: str) -> None:
-    """A tag that does not match either form is rejected with a non-zero exit."""
-    res = _run(tag)
-    assert res.returncode != 0
-    assert "not a valid release tag" in res.stderr
-
-
-def test_empty_tag_rejected() -> None:
-    """No tag argument is a usage error."""
-    res = _run()
-    assert res.returncode != 0
-    assert "no tag given" in res.stderr
-
-
-# Branch<->channel mismatches: a prerelease may only come from devel, a stable
-# only from main. The opposite pairing must fail (the before/after of the gate).
 @pytest.mark.parametrize(
-    "tag,good_branch,bad_branch",
+    ("tag", "channel", "expected"),
     [
-        ("v4.0.0.alpha.1", "devel", "main"),  # prerelease belongs on devel, not main
-        ("v4.0.0", "main", "devel"),  # stable belongs on main, not devel
+        ("v3.2.15", "stable", ("3.2.15", "final", None, "stable", False, True, "3.2.15")),
+        ("v3.2.16.a1", "testing", ("3.2.16.a1", "alpha", "1", "testing", True, False, "3.2.16.a1")),
+        ("v3.2.16.b1", "testing", ("3.2.16.b1", "beta", "1", "testing", True, False, "3.2.16.b1")),
+        ("v3.2.16.r1", "testing", ("3.2.16.r1", "rc", "1", "testing", True, False, "3.2.16.r1")),
+        ("v4.0.0.a1", "edge", ("4.0.0.a1", "alpha", "1", "edge", True, False, "4.0.0.a1")),
     ],
 )
-def test_branch_channel_enforcement(tag: str, good_branch: str, bad_branch: str) -> None:
-    """The SAME tag passes on its correct branch and is rejected on the wrong one."""
-    ok = _run(tag, good_branch)
-    assert ok.returncode == 0, ok.stderr
-
-    bad = _run(tag, bad_branch)
-    assert bad.returncode != 0
-    assert "points at" in bad.stderr or "points to" in bad.stderr
-
-
-def test_ordering_documented_matches_pkg_semantics() -> None:
-    """Sanity: the stage forms classify so their PORTVERSIONs order alpha<beta<rc<stable.
-
-    FreeBSD pkg orders 4.0.0.alpha.1 < 4.0.0.beta.1 < 4.0.0.rc.1 < 4.0.0 natively
-    (a component starting with a letter gets an implicit leading -1, so any
-    .alpha/.beta/.rc sorts below the bare release; the keyword weight alpha<beta<rc
-    breaks ties). This only asserts the script emits those exact PORTVERSION strings;
-    the ordering itself is a pkg property, validated live by the repo-install smoke.
-    """
-    versions = [
-        _fields(_run(t).stdout)["portversion"] for t in ("v4.0.0.alpha.1", "v4.0.0.beta.1", "v4.0.0.rc.1", "v4.0.0")
-    ]
-    assert versions == ["4.0.0.alpha.1", "4.0.0.beta.1", "4.0.0.rc.1", "4.0.0"]
+def test_context_classifies_shared_tag_grammar(
+    tag: str, channel: str, expected: tuple[str, str, str | None, str, bool, bool, str]
+) -> None:
+    info = parse_release_tag(tag, channel)  # type: ignore[arg-type,call-arg]
+    version, stage, sequence, channel, prerelease, final, pkg_version = expected
+    assert (
+        info.version,
+        info.stage,
+        info.sequence,
+        info.channel,
+        info.prerelease,
+        info.final,
+        info.pkg_version,
+    ) == expected
+    assert info.tag == tag
+    assert info.target_final == ".".join(version.split(".")[:3])
+    assert info.release_line == f"release/{info.target_final.rsplit('.', 1)[0]}"
+    assert info.package == PACKAGE
+    assert info.notes_required is True
+    assert info.github_release == "final" if final else info.github_release == "prerelease"
 
 
-def test_release_info_public_shape_is_frozen() -> None:
-    """The parser result exposes the canonical release contract, immutably."""
-    PACKAGE, ReleaseInfo, _, _ = _api()
+@pytest.mark.parametrize(
+    ("tag", "channel"),
+    [
+        ("v3.2.15.a1", "stable"),
+        ("v3.2.15", "testing"),
+        ("v4.0.0.a1", "stable"),
+        ("v4.0.0", "edge"),
+        ("v4.0.0.alpha.1", "testing"),
+        ("v4.0.0.edge.20260804.1", "edge"),
+        ("v4.0.0.a0", "testing"),
+    ],
+)
+def test_context_rejects_contradictory_or_superseded_tag_shapes(tag: str, channel: str) -> None:
+    with pytest.raises(ValueError):
+        parse_release_tag(tag, channel)  # type: ignore[arg-type,call-arg]
+
+
+@pytest.mark.parametrize(
+    ("tag", "channel"),
+    [
+        ("v4.0.0-devel", "stable"),
+        ("v4.0.0.rc1", "testing"),
+        ("v4.0.0-rc.1", "testing"),
+        ("v4.0.0.alpha1", "testing"),
+        ("v4.0.0.alpha", "testing"),
+        ("v4.0.a.1", "testing"),
+        ("v4.0.0.gamma.1", "testing"),
+        ("v4.0.0.pre.1", "testing"),
+        ("4.0.0.a1", "testing"),
+        ("v4.0.0.a1.extra", "testing"),
+        ("v01.2.3", "stable"),
+        ("v1.02.3", "stable"),
+        ("v1.2.03", "stable"),
+        ("v4.0.0.a0", "testing"),
+        ("v4.0.0.a01", "testing"),
+        ("v4.0.0.b00", "edge"),
+        ("v4.0.0.r0", "edge"),
+    ],
+)
+def test_strict_version_and_preview_sequence_validation(tag: str, channel: str) -> None:
+    with pytest.raises(ValueError):
+        parse_release_tag(tag, channel)  # type: ignore[arg-type,call-arg]
+
+
+@pytest.mark.parametrize("channel", ["", "main", "devel", "nightly", "Testing", None])
+def test_channel_context_is_required_and_strict(channel: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        parse_release_tag("v3.2.15", channel)  # type: ignore[arg-type,call-arg]
+
+
+@pytest.mark.parametrize("tag", ["", "3.2.15", "v3.2.15\n", "v3.2.15;echo pwned", "v3.2.15.é", "v" + "1" * 129])
+def test_parser_and_wrapper_fail_closed_without_assignments(tag: str) -> None:
+    with pytest.raises(ValueError):
+        parse_release_tag(tag, "stable")  # type: ignore[arg-type,call-arg]
+    result = _run(tag, "stable")
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize(
+    ("tag", "channel"),
+    [
+        ("v4.0.0\t", "stable"),
+        ("v4.0.0;echo pwned", "stable"),
+        ("v4.0.0.é", "testing"),
+        ("v4.0.0.a1\n", "testing"),
+        ("v" + "1" * 129, "stable"),
+    ],
+)
+def test_hostile_wrapper_inputs_emit_no_assignments(tag: str, channel: str) -> None:
+    with pytest.raises(ValueError):
+        parse_release_tag(tag, channel)  # type: ignore[arg-type,call-arg]
+    result = _run(tag, channel)
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize("branch", ["release/3.2"])
+def test_matching_release_line_is_required_for_tagged_context(branch: str) -> None:
+    info = parse_release_tag("v3.2.15", "stable")  # type: ignore[arg-type,call-arg]
+    validate_branch(info, branch)
+    validate_branch(parse_release_tag("v3.2.16.a1", "edge"), branch)  # type: ignore[arg-type,call-arg]
+
+
+@pytest.mark.parametrize("branch", ["main", "devel", "release/3.3", "feature/release", ""])
+def test_wrong_or_legacy_branch_is_rejected(branch: str) -> None:
+    with pytest.raises(ValueError):
+        validate_branch(parse_release_tag("v3.2.15", "stable"), branch)  # type: ignore[arg-type,call-arg]
+
+
+def test_wrapper_requires_explicit_channel_and_emits_contextual_fields() -> None:
+    missing = _run("v3.2.15")
+    assert missing.returncode != 0
+    assert missing.stdout == ""
+
+    result = _run("v3.2.16.a1", "testing", "release/3.2")
+    assert result.returncode == 0, result.stderr
+    assert _fields(result.stdout) == {
+        "version": "3.2.16.a1",
+        "channel": "testing",
+        "prerelease": "true",
+        "prekind": "alpha",
+        "portversion": "3.2.16.a1",
+        "release_channel": "testing",
+        "tag": "v3.2.16.a1",
+        "stage": "alpha",
+        "sequence": "1",
+        "target_final": "3.2.16",
+        "release_line": "release/3.2",
+        "final": "false",
+        "notes_required": "true",
+        "github_release": "prerelease",
+        "package": PACKAGE,
+    }
+
+
+def test_wrapper_rejects_wrong_line_without_assignments() -> None:
+    result = _run("v3.2.15", "stable", "release/3.3")
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+def test_release_info_is_frozen_and_tamper_evident() -> None:
     assert [field.name for field in fields(ReleaseInfo)] == [
         "tag",
         "version",
@@ -171,274 +192,43 @@ def test_release_info_public_shape_is_frozen() -> None:
         "package",
     ]
     assert ReleaseInfo.__dataclass_params__.frozen  # type: ignore[attr-defined]
-    assert PACKAGE == "pfSense-pkg-pfBlockerNG"
-
-
-@pytest.mark.parametrize(
-    "tag,expected",
-    [
-        (
-            "v4.0.0",
-            {
-                "stage": "final",
-                "sequence": None,
-                "target_final": "4.0.0",
-                "release_line": "release/4.0",
-                "channel": "stable",
-                "prerelease": False,
-                "final": True,
-                "notes_required": True,
-                "github_release": "final",
-                "pkg_version": "4.0.0",
-            },
-        ),
-        (
-            "v4.0.0.alpha.1",
-            {
-                "stage": "alpha",
-                "sequence": "1",
-                "target_final": "4.0.0",
-                "release_line": "release/4.0",
-                "channel": "testing",
-                "prerelease": True,
-                "final": False,
-                "notes_required": True,
-                "github_release": "prerelease",
-                "pkg_version": "4.0.0.alpha.1",
-            },
-        ),
-        (
-            "v4.0.0.beta.12",
-            {
-                "stage": "beta",
-                "sequence": "12",
-                "target_final": "4.0.0",
-                "release_line": "release/4.0",
-                "channel": "testing",
-                "prerelease": True,
-                "final": False,
-                "notes_required": True,
-                "github_release": "prerelease",
-                "pkg_version": "4.0.0.beta.12",
-            },
-        ),
-        (
-            "v4.0.0.rc.1",
-            {
-                "stage": "rc",
-                "sequence": "1",
-                "target_final": "4.0.0",
-                "release_line": "release/4.0",
-                "channel": "testing",
-                "prerelease": True,
-                "final": False,
-                "notes_required": True,
-                "github_release": "prerelease",
-                "pkg_version": "4.0.0.rc.1",
-            },
-        ),
-        (
-            "v4.0.0.edge.20240229.3",
-            {
-                "stage": "edge",
-                "sequence": "20240229.3",
-                "target_final": "4.0.0",
-                "release_line": "release/4.0",
-                "channel": "edge",
-                "prerelease": True,
-                "final": False,
-                "notes_required": True,
-                "github_release": "prerelease",
-                "pkg_version": "4.0.0.snapshot.1.20240229.3",
-            },
-        ),
-    ],
-)
-def test_parse_release_tag_derives_canonical_release_info(tag: str, expected: dict[str, object]) -> None:
-    """Stable, Testing, and Edge tags map to one canonical result shape."""
-    PACKAGE, _, parse_release_tag, _ = _api()
-    info = parse_release_tag(tag)
-    assert info.tag == tag
-    assert info.version == tag[1:]
-    for field, value in expected.items():
-        assert getattr(info, field) == value, f"{field}: expected {value!r}, got {getattr(info, field)!r}"
-    assert info.package == PACKAGE
-
-
-def test_validate_release_info_accepts_every_release_stage() -> None:
-    infos = [
-        _api()[2](tag)
-        for tag in (
-            "v4.0.0",
-            "v4.0.0.alpha.1",
-            "v4.0.0.beta.1",
-            "v4.0.0.rc.1",
-            "v4.0.0.edge.20260804.1",
-        )
-    ]
-    infos.append(
-        generate_snapshot(
-            channel="nightly",
-            target_final="4.0.0",
-            release_line="devel",
-            source_sha="a" * 40,
-            build_date=date(2026, 8, 4),
-        )
-    )
-    for info in infos:
-        validate_release_info(info)
-
-
-@pytest.mark.parametrize(
-    "info",
-    [
-        _api()[2]("v4.0.0"),
-        _api()[2]("v4.0.0.edge.20260804.1"),
-        generate_snapshot(
-            channel="nightly",
-            target_final="4.0.0",
-            release_line="devel",
-            source_sha="a" * 40,
-            build_date=date(2026, 8, 4),
-        ),
-    ],
-)
-def test_validate_release_info_rejects_dataclass_tampering(info: Any) -> None:
-    tampered = [
-        replace(info, version=info.version + ".forged"),
-        replace(info, target_final="4.0.1"),
-        replace(info, release_line="devel" if info.tag is not None else "devel/forged"),
-        replace(info, pkg_version=info.pkg_version + ".forged"),
-        replace(info, sequence="20260804.2"),
-    ]
-    for forged in tampered:
+    info = parse_release_tag("v3.2.16.a1", "testing")  # type: ignore[arg-type,call-arg]
+    validate_release_info(info)
+    for forged in (
+        replace(info, version="3.2.16.b1"),
+        replace(info, channel="stable"),
+        replace(info, pkg_version="3.2.16.b1"),
+    ):
         with pytest.raises(ValueError):
             validate_release_info(forged)
     with pytest.raises(TypeError):
         validate_release_info(object())  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize(
-    "tag,branch,legacy",
-    [
-        ("v4.0.0", "release/4.0", False),
-        ("v4.0.0.alpha.1", "release/4.0", False),
-        ("v4.0.0.edge.20240229.3", "release/4.0", False),
-        ("v4.0.0", "main", True),
-        ("v4.0.0.alpha.1", "devel", True),
-    ],
-)
-def test_validate_branch_accepts_canonical_and_legacy_contexts(tag: str, branch: str, legacy: bool) -> None:
-    """Canonical release lines admit every channel; legacy aliases are opt-in."""
-    _, _, parse_release_tag, validate_branch = _api()
-    validate_branch(parse_release_tag(tag), branch, legacy=legacy)
-
-
-@pytest.mark.parametrize(
-    "tag,branch,legacy",
-    [
-        ("v4.0.0", "release/4.1", False),
-        ("v4.0.0", "main", False),
-        ("v4.0.0.alpha.1", "devel", False),
-        ("v4.0.0.alpha.1", "main", True),
-        ("v4.0.0", "devel", True),
-        ("v4.0.0.edge.20240229.3", "main", True),
-        ("v4.0.0", "feature/release", True),
-    ],
-)
-def test_validate_branch_rejects_wrong_unknown_and_cross_legacy_contexts(tag: str, branch: str, legacy: bool) -> None:
-    """Branch admission fails closed for wrong, unknown, and Edge legacy branches."""
-    _, _, parse_release_tag, validate_branch = _api()
-    with pytest.raises(ValueError):
-        validate_branch(parse_release_tag(tag), branch, legacy=legacy)
-
-
-@pytest.mark.parametrize(
-    "tag",
-    [
-        "",
-        "4.0.0",
-        "v4.0.0.alpha.0",
-        "v4.0.0.alpha.01",
-        "v4.0.0.beta.00",
-        "v4.0.0.rc.0",
-        "v4.0.0.edge.20230229.1",
-        "v4.0.0.edge.20240229.0",
-        "v4.0.0.edge.20240229.01",
-        "v4.0.0.edge.2024022.1",
-        "v4.0.0.pre.1",
-        "v4.0.0.gamma.1",
-        "v4.0.0.alpha.1.extra",
-        "v4.0.0\t",
-        "v4.0.0;echo pwned",
-        "v4.0.0.é",
-        "v" + "1" * 129,
-    ],
-)
-def test_parser_and_wrapper_reject_hostile_tags_without_assignments(tag: str) -> None:
-    """Malformed, unsafe, non-ASCII, and oversized input produces no shell assignments."""
-    _, _, parse_release_tag, _ = _api()
-    with pytest.raises(ValueError):
-        parse_release_tag(tag)
-    result = _run(tag)
-    assert result.returncode != 0
-    assert result.stdout == ""
-
-
-def test_wrapper_emits_canonical_keys_and_accepts_release_branch() -> None:
-    """The shell facade preserves legacy keys and appends canonical parser fields."""
-    result = _run("v4.0.0.edge.20240229.3", "release/4.0")
-    assert result.returncode == 0, result.stderr
-    assert result.stdout.splitlines() == [
-        "version=4.0.0.edge.20240229.3",
-        "channel=edge",
-        "prerelease=true",
-        "prekind=edge",
-        "portversion=4.0.0.snapshot.1.20240229.3",
-        "release_channel=edge",
-        "tag=v4.0.0.edge.20240229.3",
-        "stage=edge",
-        "sequence=20240229.3",
-        "target_final=4.0.0",
-        "release_line=release/4.0",
-        "final=false",
-        "notes_required=true",
-        "github_release=prerelease",
-        "package=pfSense-pkg-pfBlockerNG",
+@pytest.mark.parametrize("tag,channel", [("v3.2.15", "stable"), ("v3.2.16.a1", "testing"), ("v4.0.0.r1", "edge")])
+def test_every_canonical_field_tampering_is_rejected(tag: str, channel: str) -> None:
+    info = parse_release_tag(tag, channel)  # type: ignore[arg-type,call-arg]
+    tampered = [
+        replace(info, version=info.version + ".forged"),
+        replace(info, target_final="4.0.99"),
+        replace(info, release_line="release/9.9"),
+        replace(info, pkg_version=info.pkg_version + ".forged"),
+        replace(info, sequence="2"),
+        replace(info, stage="beta"),
+        replace(info, final=not info.final),
+        replace(info, prerelease=not info.prerelease),
+        replace(info, notes_required=not info.notes_required),
+        replace(info, github_release="none"),
+        replace(info, package="wrong"),
     ]
-    fields_out = _fields(result.stdout)
-    assert fields_out == {
-        "version": "4.0.0.edge.20240229.3",
-        "channel": "edge",
-        "prerelease": "true",
-        "prekind": "edge",
-        "portversion": "4.0.0.snapshot.1.20240229.3",
-        "release_channel": "edge",
-        "tag": "v4.0.0.edge.20240229.3",
-        "stage": "edge",
-        "sequence": "20240229.3",
-        "target_final": "4.0.0",
-        "release_line": "release/4.0",
-        "final": "false",
-        "notes_required": "true",
-        "github_release": "prerelease",
-        "package": "pfSense-pkg-pfBlockerNG",
-    }
+    for forged in tampered:
+        with pytest.raises(ValueError):
+            validate_release_info(forged)
 
 
-@pytest.mark.parametrize(
-    "tag,branch",
-    [("v4.0.0", "release/4.1"), ("v4.0.0", "feature/release"), ("v4.0.0.edge.20240229.3", "main")],
-)
-def test_wrapper_rejects_wrong_or_unknown_branches_without_assignments(tag: str, branch: str) -> None:
-    """Wrapper branch validation uses legacy compatibility only where explicitly allowed."""
-    result = _run(tag, branch)
-    assert result.returncode != 0
-    assert result.stdout == ""
-
-
-def test_validate_branch_rejects_non_boolean_legacy_flag() -> None:
-    """Legacy compatibility is an explicit boolean, never a truthy string."""
-    _, _, parse_release_tag, validate_branch = _api()
-    with pytest.raises(TypeError):
-        validate_branch(parse_release_tag("v4.0.0"), "main", legacy="false")
+def test_tagged_release_requires_exact_release_line_without_legacy_aliases() -> None:
+    info = parse_release_tag("v4.0.0", "stable")  # type: ignore[arg-type,call-arg]
+    validate_branch(info, "release/4.0")
+    for branch in ("main", "devel", "release/4.1", "feature/release", ""):
+        with pytest.raises(ValueError):
+            validate_branch(info, branch)

--- a/tests/test_snapshot_version.py
+++ b/tests/test_snapshot_version.py
@@ -125,6 +125,11 @@ def test_ports_sha_is_strict_lowercase_hex(ports_sha: str) -> None:
         _allocate(ports_sha=ports_sha)
 
 
+def test_ports_sha_error_names_the_invalid_field() -> None:
+    with pytest.raises(ValueError, match="ports_sha"):
+        _allocate(ports_sha="")
+
+
 @pytest.mark.parametrize("input_digest", ["", "A" * 64, "e" * 63, "e" * 65, "g" * 64, "e" * 40])
 def test_input_digest_is_strict_lowercase_64_hex(input_digest: str) -> None:
     with pytest.raises(ValueError):
@@ -193,7 +198,7 @@ def test_malformed_allocation_result_fields_fail_closed(field: str, value: objec
         _allocate(existing=(malformed,))
 
 
-def test_edge_snapshot_generation_and_target_final_are_removed() -> None:
+def test_edge_snapshot_generation_is_removed() -> None:
     with pytest.raises((AttributeError, TypeError, ValueError)):
         API.generate_snapshot(
             channel="edge",

--- a/tests/test_snapshot_version.py
+++ b/tests/test_snapshot_version.py
@@ -153,6 +153,27 @@ def test_malformed_durable_records_fail_closed(record_kind: str) -> None:
         _allocate(existing=(record,))  # type: ignore[arg-type]
 
 
+def test_oversized_durable_nightly_version_fails_closed() -> None:
+    revision = int("9" * 120)
+    malformed = replace(_allocate(), portrevision=revision, pkg_version=f"20260804_{revision}")
+    with pytest.raises(ValueError, match="128"):
+        _allocate(existing=(malformed,))
+
+
+def test_next_nightly_revision_cannot_cross_the_identity_limit() -> None:
+    revision = int("9" * 119)
+    existing = replace(_allocate(), portrevision=revision, pkg_version=f"20260804_{revision}")
+    with pytest.raises(ValueError, match="128"):
+        _allocate(source_sha=SOURCE_B, existing=(existing,))
+
+
+def test_nightly_noop_result_can_be_replayed_with_its_build_result() -> None:
+    first = _allocate()
+    retry = _allocate(existing=(first,))
+    assert retry.outcome == "unchanged"
+    assert _allocate(existing=(first, retry)) == retry
+
+
 @pytest.mark.parametrize(
     "field,value",
     [

--- a/tests/test_snapshot_version.py
+++ b/tests/test_snapshot_version.py
@@ -1,280 +1,183 @@
-"""Snapshot identity and sequencing contracts for release_version.py."""
+"""Independent Nightly allocation contract for issue #2140."""
 
 from __future__ import annotations
 
 from dataclasses import fields, replace
 from datetime import date, datetime
+from typing import Any
 
 import pytest
 
-from scripts.release_version import (
-    PACKAGE,
-    ReleaseInfo,
-    SnapshotRecord,
-    generate_snapshot,
-    next_patch_target,
-    validate_release_info,
-)
+from scripts import release_version as rv
 
-TARGET = "4.0.0"
-EDGE_LINE = "release/4.0"
-SOURCE_A = "a" * 40
-SOURCE_B = "b" * 64
+API: Any = rv
 DAY_ONE = date(2026, 8, 4)
 DAY_TWO = date(2026, 8, 5)
 DAY_ZERO = date(2026, 8, 3)
+SOURCE_A = "a" * 40
+SOURCE_B = "b" * 64
+PORTS_A = "c" * 40
+PORTS_B = "d" * 64
+MATRIX_A = "e" * 64
+MATRIX_B = "f" * 64
 
 
-def _generate_edge(
-    source_sha: str = SOURCE_A,
+def _allocate(
     build_date: date = DAY_ONE,
-    existing: tuple[SnapshotRecord, ...] = (),
-    release_line: str = EDGE_LINE,
-) -> ReleaseInfo:
-    return generate_snapshot(
-        channel="edge",
-        target_final=TARGET,
-        release_line=release_line,
-        source_sha=source_sha,
-        build_date=build_date,
-        existing=existing,
-    )
-
-
-def _generate_nightly(
     source_sha: str = SOURCE_A,
-    build_date: date = DAY_ONE,
-    existing: tuple[SnapshotRecord, ...] = (),
-    release_line: str = "devel",
-) -> ReleaseInfo:
-    return generate_snapshot(
-        channel="nightly",
-        target_final=TARGET,
-        release_line=release_line,
-        source_sha=source_sha,
-        build_date=build_date,
-        existing=existing,
-    )
+    ports_sha: str = PORTS_A,
+    input_digest: str = MATRIX_A,
+    existing: tuple[Any, ...] = (),
+) -> Any:
+    return API.allocate_nightly(build_date, source_sha, ports_sha, input_digest, existing)
 
 
-def test_next_patch_target_accepts_only_bare_strict_core() -> None:
-    assert next_patch_target("4.0.0") == "4.0.1"
-    for invalid in ("v4.0.0", "4.0.0.alpha.1", "4.0", "4.00.0", "4.0.00", "", "1" * 129 + ".0.0"):
-        with pytest.raises(ValueError):
-            next_patch_target(invalid)
-
-
-def test_snapshot_record_is_frozen() -> None:
-    assert [field.name for field in fields(SnapshotRecord)] == ["source_sha", "result"]
-    assert SnapshotRecord.__dataclass_params__.frozen  # type: ignore[attr-defined]
-
-
-def test_edge_snapshot_has_exact_frozen_shape_and_pkg_identity() -> None:
-    result = _generate_edge()
-    assert result == ReleaseInfo(
-        tag="v4.0.0.edge.20260804.1",
-        version="4.0.0.edge.20260804.1",
-        stage="edge",
-        sequence="20260804.1",
-        target_final=TARGET,
-        release_line=EDGE_LINE,
-        channel="edge",
-        prerelease=True,
-        final=False,
-        notes_required=True,
-        github_release="prerelease",
-        pkg_version="4.0.0.snapshot.1.20260804.1",
-        package=PACKAGE,
-    )
-
-
-def test_nightly_snapshot_has_distinct_nightly_and_pkg_versions() -> None:
-    result = _generate_nightly(source_sha=SOURCE_B)
-    assert result == ReleaseInfo(
-        tag=None,
-        version="4.0.0.nightly.20260804.1",
-        stage="nightly",
-        sequence="20260804.1",
-        target_final=TARGET,
-        release_line="devel",
-        channel="nightly",
-        prerelease=True,
-        final=False,
-        notes_required=False,
-        github_release="none",
-        pkg_version="4.0.0.snapshot.2.20260804.1",
-        package=PACKAGE,
-    )
-
-
-@pytest.mark.parametrize("channel", ["edge", "nightly"])
-def test_oversized_but_valid_target_is_rejected_before_snapshot_emission(channel: str) -> None:
-    major = "1" * 103
-    release_line = f"release/{major}.0" if channel == "edge" else "devel"
-    with pytest.raises(ValueError):
-        generate_snapshot(
-            channel=channel,  # type: ignore[arg-type]
-            target_final=f"{major}.0.0",
-            release_line=release_line,
-            source_sha=SOURCE_A,
-            build_date=DAY_ONE,
-        )
-
-
-@pytest.mark.parametrize("channel", ["edge", "nightly"])
-def test_maximum_generated_identity_is_exactly_128_characters(channel: str) -> None:
-    major = "1" * 102
-    release_line = f"release/{major}.0" if channel == "edge" else "devel"
-    result = generate_snapshot(
-        channel=channel,  # type: ignore[arg-type]
-        target_final=f"{major}.0.0",
-        release_line=release_line,
-        source_sha=SOURCE_A,
-        build_date=DAY_ONE,
-    )
-    assert max(len(result.version), len(result.pkg_version), len(result.tag or "")) == 128
-    validate_release_info(result)
-
-
-@pytest.mark.parametrize("generator", [_generate_edge, _generate_nightly])
-def test_snapshot_results_are_canonical_and_tampering_is_rejected(generator: object) -> None:
-    result = generator()  # type: ignore[operator]
-    validate_release_info(result)
-    tampered = [
-        replace(result, version=result.version + ".forged"),
-        replace(result, target_final="4.0.1"),
-        replace(result, release_line=result.release_line + "/forged"),
-        replace(result, pkg_version=result.pkg_version + ".forged"),
-        replace(result, sequence="20260804.2"),
+def test_nightly_allocation_is_frozen_with_exact_public_shape() -> None:
+    allocation_type = API.NightlyAllocation
+    assert [field.name for field in fields(allocation_type)] == [
+        "outcome",
+        "portversion",
+        "portrevision",
+        "pkg_version",
+        "source_sha",
+        "ports_sha",
+        "input_digest",
     ]
-    for forged in tampered:
-        with pytest.raises(ValueError):
-            validate_release_info(forged)
+    assert allocation_type.__dataclass_params__.frozen  # type: ignore[attr-defined]
 
 
-def test_same_source_is_idempotent_even_when_requested_later() -> None:
-    first = _generate_edge()
-    existing = (SnapshotRecord(SOURCE_A, first),)
-    assert _generate_edge(build_date=DAY_TWO, existing=existing) == first
-    assert existing == (SnapshotRecord(SOURCE_A, first),)
+def test_first_changed_input_uses_date_with_zero_revision() -> None:
+    result = _allocate()
+    assert result == API.NightlyAllocation("build", "20260804", 0, "20260804", SOURCE_A, PORTS_A, MATRIX_A)
 
 
-def test_same_source_requested_before_latest_date_is_stale() -> None:
-    first = _generate_edge()
+def test_distinct_same_day_inputs_increment_port_revision() -> None:
+    first = _allocate()
+    second = _allocate(source_sha=SOURCE_B, existing=(first,))
+    third = _allocate(ports_sha=PORTS_B, input_digest=MATRIX_B, existing=(first, second))
+    assert (second.portversion, second.portrevision, second.pkg_version) == ("20260804", 1, "20260804_1")
+    assert (third.portversion, third.portrevision, third.pkg_version) == ("20260804", 2, "20260804_2")
+
+
+def test_changed_date_resets_revision_and_skipped_dates_need_no_records() -> None:
+    first = _allocate()
+    later = _allocate(build_date=DAY_TWO, source_sha=SOURCE_B, existing=(first,))
+    assert (later.portversion, later.portrevision, later.pkg_version) == ("20260805", 0, "20260805")
+
+
+def test_exact_input_is_explicit_unchanged_even_when_requested_later() -> None:
+    first = _allocate()
+    retry = _allocate(build_date=DAY_TWO, existing=(first,))
+    assert retry == replace(first, outcome="unchanged")
+    assert retry.pkg_version == first.pkg_version
+
+
+def test_each_build_input_component_is_identity_and_changes_version() -> None:
+    first = _allocate()
+    for kwargs in (
+        {"source_sha": SOURCE_B},
+        {"ports_sha": PORTS_B},
+        {"input_digest": MATRIX_B},
+    ):
+        result = _allocate(existing=(first,), **kwargs)  # type: ignore[arg-type]
+        assert result.outcome == "build"
+        assert result.portrevision == 1
+
+
+def test_combined_input_digest_is_deterministic_and_changes_for_any_component() -> None:
+    digest = API.combined_nightly_input_digest(SOURCE_A, PORTS_A, MATRIX_A)
+    assert digest == API.combined_nightly_input_digest(SOURCE_A, PORTS_A, MATRIX_A)
+    assert len(digest) == 64 and digest == digest.lower()
+    assert digest != API.combined_nightly_input_digest(SOURCE_B, PORTS_A, MATRIX_A)
+    assert digest != API.combined_nightly_input_digest(SOURCE_A, PORTS_B, MATRIX_A)
+    assert digest != API.combined_nightly_input_digest(SOURCE_A, PORTS_A, MATRIX_B)
+
+
+def test_older_changed_date_is_rejected() -> None:
+    latest = _allocate(build_date=DAY_TWO)
     with pytest.raises(ValueError, match="older"):
-        _generate_edge(build_date=DAY_ZERO, existing=(SnapshotRecord(SOURCE_A, first),))
+        _allocate(build_date=DAY_ONE, source_sha=SOURCE_B, existing=(latest,))
 
 
-def test_different_source_same_day_increments_count_without_trigger_context() -> None:
-    first = _generate_edge()
-    second = _generate_edge(source_sha=SOURCE_B, existing=(SnapshotRecord(SOURCE_A, first),))
-    assert second.sequence == "20260804.2"
-    assert second.pkg_version == "4.0.0.snapshot.1.20260804.2"
+def test_duplicate_version_with_different_input_is_rejected() -> None:
+    first = _allocate()
+    collision = replace(first, source_sha=SOURCE_B, outcome="build")
+    with pytest.raises(ValueError, match="collision"):
+        _allocate(existing=(first, collision))
 
 
-def test_later_date_resets_sequence_to_one() -> None:
-    first = _generate_edge()
-    later = _generate_edge(source_sha=SOURCE_B, build_date=DAY_TWO, existing=(SnapshotRecord(SOURCE_A, first),))
-    assert later.sequence == "20260805.1"
+def test_same_input_with_different_version_is_rejected() -> None:
+    first = _allocate()
+    conflict = replace(first, portversion="20260805", pkg_version="20260805", outcome="build")
+    with pytest.raises(ValueError, match="conflicting"):
+        _allocate(existing=(first, conflict))
 
 
-def test_same_day_count_ignores_higher_count_from_an_older_day() -> None:
-    records: tuple[SnapshotRecord, ...] = ()
-    for index in range(9):
-        source = f"{index + 1:040x}"
-        result = _generate_edge(source_sha=source, existing=records)
-        records += (SnapshotRecord(source, result),)
-    current = _generate_edge(source_sha=SOURCE_B, build_date=DAY_TWO, existing=records)
-    next_current = _generate_edge(
-        source_sha="c" * 40,
-        build_date=DAY_TWO,
-        existing=records + (SnapshotRecord(SOURCE_B, current),),
-    )
-    assert records[-1].result.sequence == "20260804.9"
-    assert current.sequence == "20260805.1"
-    assert next_current.sequence == "20260805.2"
-
-
-def test_older_date_than_latest_relevant_snapshot_is_rejected() -> None:
-    latest = _generate_edge(build_date=DAY_TWO)
-    with pytest.raises(ValueError, match="older"):
-        _generate_edge(source_sha=SOURCE_B, build_date=DAY_ONE, existing=(SnapshotRecord(SOURCE_A, latest),))
-
-
-def test_edge_requires_exact_target_release_line_and_nightly_requires_devel() -> None:
+@pytest.mark.parametrize("source_sha", ["", "A" * 40, "a" * 39, "a" * 41, "g" * 40, "a" * 63, "a" * 65])
+def test_source_sha_is_strict_lowercase_hex(source_sha: str) -> None:
     with pytest.raises(ValueError):
-        _generate_edge(release_line="release/4.1")
-    with pytest.raises(ValueError):
-        _generate_nightly(release_line="release/4.0")
-    assert _generate_edge().release_line == EDGE_LINE
-    assert _generate_nightly().release_line == "devel"
+        _allocate(source_sha=source_sha)
 
 
-@pytest.mark.parametrize("source_sha", ["", "A" * 40, "a" * 39, "a" * 41, "a" * 63, "a" * 65, "g" * 40])
-def test_source_sha_must_be_lowercase_40_or_64_hex(source_sha: str) -> None:
+@pytest.mark.parametrize("ports_sha", ["", "A" * 40, "c" * 39, "c" * 41, "g" * 40, "c" * 63, "c" * 65])
+def test_ports_sha_is_strict_lowercase_hex(ports_sha: str) -> None:
     with pytest.raises(ValueError):
-        _generate_edge(source_sha=source_sha)
+        _allocate(ports_sha=ports_sha)
+
+
+@pytest.mark.parametrize("input_digest", ["", "A" * 64, "e" * 63, "e" * 65, "g" * 64, "e" * 40])
+def test_input_digest_is_strict_lowercase_64_hex(input_digest: str) -> None:
+    with pytest.raises(ValueError):
+        _allocate(input_digest=input_digest)
+
+
+@pytest.mark.parametrize("build_date", [datetime(2026, 8, 4), "2026-08-04", None])
+def test_build_date_requires_exact_date_type(build_date: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        _allocate(build_date=build_date)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad_version", ["20230229", "2026080", "20260804_0", "20260804_01", "20260804-1"])
+def test_malformed_durable_version_shape_fails_closed(bad_version: str) -> None:
+    malformed = replace(_allocate(), portversion=bad_version, pkg_version=bad_version)
+    with pytest.raises((TypeError, ValueError)):
+        _allocate(existing=(malformed,))
+
+
+@pytest.mark.parametrize("record_kind", ["object", "string", "tampered"])
+def test_malformed_durable_records_fail_closed(record_kind: str) -> None:
+    record: object = {"object": object(), "string": "record", "tampered": replace(_allocate(), pkg_version="bad")}[
+        record_kind
+    ]
+    with pytest.raises((TypeError, ValueError)):
+        _allocate(existing=(record,))  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
-    "target_final,build_date,channel,release_line",
+    "field,value",
     [
-        ("v4.0.0", DAY_ONE, "edge", EDGE_LINE),
-        ("4.00.0", DAY_ONE, "edge", EDGE_LINE),
-        ("4.0.0", datetime(2026, 8, 4), "edge", EDGE_LINE),
-        ("4.0.0", "2026-08-04", "edge", EDGE_LINE),
-        ("4.0.0", DAY_ONE, "unknown", EDGE_LINE),
-        ("4.0.0", DAY_ONE, "edge", "release/4.1"),
-        ("4.0.0", DAY_ONE, "nightly", EDGE_LINE),
-        ("1" * 129 + ".0.0", DAY_ONE, "edge", EDGE_LINE),
+        ("outcome", "skip"),
+        ("portrevision", -1),
+        ("portrevision", True),
+        ("portversion", "20260804_1"),
+        ("pkg_version", "20260804_1"),
+        ("source_sha", "A" * 40),
+        ("ports_sha", "A" * 40),
+        ("input_digest", "A" * 64),
     ],
 )
-def test_snapshot_inputs_reject_wrong_target_date_channel_or_line(
-    target_final: str, build_date: object, channel: str, release_line: str
-) -> None:
+def test_malformed_allocation_result_fields_fail_closed(field: str, value: object) -> None:
+    malformed = replace(_allocate(), **{field: value})
     with pytest.raises((TypeError, ValueError)):
-        generate_snapshot(
-            channel=channel,  # type: ignore[arg-type]
-            target_final=target_final,
-            release_line=release_line,
+        _allocate(existing=(malformed,))
+
+
+def test_edge_snapshot_generation_and_target_final_are_removed() -> None:
+    with pytest.raises((AttributeError, TypeError, ValueError)):
+        API.generate_snapshot(
+            channel="edge",
+            target_final="4.0.0",
+            release_line="release/4.0",
             source_sha=SOURCE_A,
-            build_date=build_date,  # type: ignore[arg-type]
+            build_date=DAY_ONE,
         )
-
-
-def test_same_source_conflicting_records_are_rejected() -> None:
-    first = _generate_edge()
-    second = _generate_edge(source_sha=SOURCE_B, existing=(SnapshotRecord(SOURCE_A, first),))
-    conflict = SnapshotRecord(SOURCE_A, second)
-    with pytest.raises(ValueError, match="conflicting"):
-        _generate_edge(existing=(SnapshotRecord(SOURCE_A, first), conflict))
-
-
-def test_same_emitted_version_from_different_sources_is_rejected() -> None:
-    first = _generate_edge()
-    collision = SnapshotRecord(SOURCE_B, first)
-    with pytest.raises(ValueError, match="collision"):
-        _generate_edge(existing=(SnapshotRecord(SOURCE_A, first), collision))
-
-
-def test_malformed_existing_records_are_rejected_and_input_tuple_stays_unchanged() -> None:
-    first = _generate_edge()
-    original = (SnapshotRecord(SOURCE_A, first),)
-    malformed = ("not a record",)  # type: ignore[assignment]
-    with pytest.raises(ValueError):
-        _generate_edge(existing=malformed)  # type: ignore[arg-type]
-    assert original == (SnapshotRecord(SOURCE_A, first),)
-
-
-def test_malformed_nightly_result_is_rejected_at_validation_boundary() -> None:
-    nightly = _generate_nightly()
-    malformed = replace(nightly, sequence=None)
-    with pytest.raises(ValueError):
-        _generate_nightly(existing=(SnapshotRecord(SOURCE_A, malformed),))
-
-
-def test_nightly_sequence_scopes_independently_from_edge() -> None:
-    edge = _generate_edge()
-    nightly = _generate_nightly(source_sha=SOURCE_B, existing=(SnapshotRecord(SOURCE_A, edge),))
-    assert nightly.sequence == "20260804.1"
-    assert nightly.version == "4.0.0.nightly.20260804.1"

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -890,6 +890,31 @@ def test_release_side_artifact_name_matches_both_consumer_sides(tmp_path: Path) 
     assert not failures, "producer/consumer artifact-name mismatch:\n" + "\n".join(failures)
 
 
+def test_release_channel_metadata_and_edge_following_do_not_start_a_second_release() -> None:
+    release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    published = (ROOT / ".github/workflows/release-published.yml").read_text(encoding="utf-8")
+    assert "pfBlockerNG-Release-Channel" in release, release
+    assert "pfBlockerNG-Release-Channel" in published, published
+    assert "workflow_dispatch" not in published, published
+    assert "release.yml" not in published, published
+    assert "build-pkg" not in published, published
+
+
+def test_tagged_release_recipe_never_mutates_the_nightly_port() -> None:
+    release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    sync = release.split("sync-ports-fork:", 1)[1]
+    assert "pfSense-pkg-pfBlockerNG-nightly" not in sync, sync
+    assert 'PORT_PATHS="net/pfSense-pkg-pfBlockerNG-devel net/pfSense-pkg-pfBlockerNG-nightly"' not in release
+
+
+def test_smoke_single_nightly_fixture_uses_a_utc_date_and_optional_counter() -> None:
+    text = SMOKE_SINGLE_WORKFLOW.read_text(encoding="utf-8")
+    nightly = text.split("- name: Build a nightly .pkg", 1)[1].split("\n      # ADR-24", 1)[0]
+    assert "date -u +%Y%m%d" in nightly, nightly
+    assert re.search(r"YYYYMMDD|NIGHTLY_DATE", nightly), nightly
+    assert "20260606" not in nightly, nightly
+
+
 # --------------------------------------------------------------------------- #
 # draft-healthcheck: EXPECTED_PKGS floor (issue #1662 I1)
 # --------------------------------------------------------------------------- #

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -912,6 +912,10 @@ def test_smoke_single_nightly_fixture_uses_a_utc_date_and_optional_counter() -> 
     nightly = text.split("- name: Build a nightly .pkg", 1)[1].split("\n      # ADR-24", 1)[0]
     assert "date -u +%Y%m%d" in nightly, nightly
     assert re.search(r"YYYYMMDD|NIGHTLY_DATE", nightly), nightly
+    assert 'NIGHTLY_COUNT="${NIGHTLY_COUNT:-0}"' in nightly, nightly
+    assert 'NIGHTLY_VERSION="$NIGHTLY_DATE"' in nightly, nightly
+    assert 'NIGHTLY_VERSION="${NIGHTLY_DATE}_${NIGHTLY_COUNT}"' in nightly, nightly
+    assert 'NIGHTLY_VERSION="3.2.16.${NIGHTLY_DATE}' not in nightly, nightly
     assert "20260606" not in nightly, nightly
 
 

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -913,8 +913,12 @@ def test_smoke_single_nightly_fixture_uses_a_utc_date_and_optional_counter() -> 
     assert "date -u +%Y%m%d" in nightly, nightly
     assert re.search(r"YYYYMMDD|NIGHTLY_DATE", nightly), nightly
     assert 'NIGHTLY_COUNT="${NIGHTLY_COUNT:-0}"' in nightly, nightly
-    assert 'NIGHTLY_VERSION="$NIGHTLY_DATE"' in nightly, nightly
-    assert 'NIGHTLY_VERSION="${NIGHTLY_DATE}_${NIGHTLY_COUNT}"' in nightly, nightly
+    assert re.search(
+        r'NIGHTLY_VERSION="\$NIGHTLY_DATE"\s+'
+        r'if \[ "\$NIGHTLY_COUNT" -gt 0 \]; then\s+'
+        r'NIGHTLY_VERSION="\${NIGHTLY_DATE}_\${NIGHTLY_COUNT}"\s+fi',
+        nightly,
+    ), nightly
     assert 'NIGHTLY_VERSION="3.2.16.${NIGHTLY_DATE}' not in nightly, nightly
     assert "20260606" not in nightly, nightly
 


### PR DESCRIPTION
## Summary

- define Stable as `vX.Y.Z`, and Testing/configured Edge as the shared `vX.Y.Z.aN|bN|rN` grammar with an explicit channel and exact `release/X.Y` source
- carry the channel through one immutable annotated-tag trailer and validate it during tag recovery, pre-push, and published-release routing
- replace target-bound snapshots with an independent, untagged Nightly allocator using `YYYYMMDD[_N]` and full source/Ports/matrix input identity
- decouple tagged releases from Nightly Ports mutations and update active workflows, release skills, documentation, and append-only ADR corrections

## Why

The previous classifier inferred channel from tag shape and encoded Edge/Nightly as target-bound snapshot versions. That contradicted FreeBSD package ordering, made Testing and Edge grammars diverge, and forced routine Nightly version commits. The corrected contract keeps maturity in the version, channel in explicit immutable context, and Nightly allocation in durable build-input state.

## Validation

- `scripts/agent/run-gates.sh --diff origin/devel` — PASS
- 371 focused release/workflow/skill tests — PASS
- frozen RED-to-GREEN verification for classifier, Nightly allocation, mutation, workflow metadata, port sync, skills, and ADR contracts — PASS
- `actionlint`, `shellcheck`, shellspec, markdownlint, skill validation, and agent-config parity — PASS
- live pfSense/FreeBSD oracle using `pkg` 1.21.3 — all 12 adjacent comparisons PASS, from `3.2.15 < 3.2.16.a1` through `20260804_2 < 20260805`
- portable builder completed successfully on the live smoke lane

Fixes #2140

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit release channels and source branches for release workflows.
  * Introduced compact alpha, beta, and release-candidate tags.
  * Added deterministic nightly package versions with same-day revision support.
  * Added release provenance and artifact collision validation.

* **Bug Fixes**
  * Rejected invalid, lightweight, duplicate, mismatched, or unreachable release tags.
  * Prevented tagged releases from modifying nightly ports.

* **Tests**
  * Expanded coverage for release validation, workflow behavior, nightly allocation, and documentation contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->