### PR TITLE
pfblockerng: add 3.3 settings-family bridge

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -21,4 +21,287 @@
  */
 
 // This file is used to 'include functions' not yet merged into pfSense
+
+const PFB_SETTINGS_FAMILY_RANK = ['3.3' => 0, '4.0' => 1, '4.1' => 2];
+
+final class PfbConfig
+{
+	public static function read(string $key): mixed
+	{
+		self::assertRegistered($key);
+		return config_get_path('installedpackages/pfblockerng/config/0/settings_family', NULL);
+	}
+
+	public static function writeSystem(string $key, mixed $value): void
+	{
+		self::assertRegistered($key);
+		if (!is_string($value) || !isset(PFB_SETTINGS_FAMILY_RANK[$value])) {
+			throw new InvalidArgumentException('PfbConfig: invalid settings family');
+		}
+		config_set_path('installedpackages/pfblockerng/config/0/settings_family', $value);
+	}
+
+	private static function assertRegistered(string $key): void
+	{
+		if ($key !== 'gen/settings_family') {
+			throw new InvalidArgumentException("PfbConfig: key '{$key}' is not registered");
+		}
+	}
+}
+
+function pfb_settings_family_current(): string
+{
+	$value = PfbConfig::read('gen/settings_family');
+	if ($value === NULL || $value === '') {
+		return '3.3';
+	}
+	if (!is_string($value) || !isset(PFB_SETTINGS_FAMILY_RANK[$value])) {
+		throw new RuntimeException('pfBlockerNG: invalid settings family marker');
+	}
+	return $value;
+}
+
+function pfb_settings_family_path_is_safe(string $path, bool $directory, int $expected_owner): bool
+{
+	clearstatcache(TRUE, $path);
+	$stat = @lstat($path);
+	if ($stat === FALSE || is_link($path) || ($stat['uid'] ?? -1) !== $expected_owner) {
+		return FALSE;
+	}
+	$type = $stat['mode'] & 0170000;
+	if ($directory) {
+		return $type === 0040000 && (($stat['mode'] & 0022) === 0);
+	}
+	return $type === 0100000 && (($stat['mode'] & 07777) === 0600);
+}
+
+function pfb_settings_family_root(): string
+{
+	global $pfb;
+	return (string) ($pfb['dbdir'] ?? '/var/db/pfblockerng');
+}
+
+function pfb_settings_family_expected_owner(string $root): int
+{
+	global $pfb;
+	if (isset($pfb['settings_family_expected_owner'])) {
+		return (int) $pfb['settings_family_expected_owner'];
+	}
+	return $root === '/var/db/pfblockerng' ? 0 : (function_exists('posix_geteuid') ? posix_geteuid() : 0);
+}
+
+function pfb_settings_family_payload_is_valid(mixed $value, array &$active_references): bool
+{
+	if (!is_array($value)) {
+		return is_scalar($value) || $value === NULL;
+	}
+	foreach ($value as $key => $nested) {
+		$reference = ReflectionReference::fromArrayElement($value, $key);
+		if ($reference !== NULL) {
+			$reference_id = $reference->getId();
+			if (isset($active_references[$reference_id])) {
+				return FALSE;
+			}
+			$active_references[$reference_id] = TRUE;
+			$valid = pfb_settings_family_payload_is_valid($nested, $active_references);
+			unset($active_references[$reference_id]);
+			if (!$valid) {
+				return FALSE;
+			}
+		} elseif (!pfb_settings_family_payload_is_valid($nested, $active_references)) {
+			return FALSE;
+		}
+	}
+	return TRUE;
+}
+
+function pfb_settings_family_save(string $family): bool
+{
+	if (!isset(PFB_SETTINGS_FAMILY_RANK[$family])) {
+		return FALSE;
+	}
+	$installed = config_get_path('installedpackages', []);
+	if (!is_array($installed)) {
+		return TRUE;
+	}
+	$owned = [];
+	foreach ($installed as $section => $value) {
+		if (str_starts_with((string) $section, 'pfblockerng')) {
+			$owned[(string) $section] = $value;
+		}
+	}
+	if ($owned === []) {
+		return TRUE;
+	}
+	$active_references = [];
+	if (!pfb_settings_family_payload_is_valid($owned, $active_references)) {
+		return FALSE;
+	}
+
+	$root = pfb_settings_family_root();
+	$expected_owner = pfb_settings_family_expected_owner($root);
+	if (file_exists($root) || is_link($root)) {
+		if (!pfb_settings_family_path_is_safe($root, TRUE, $expected_owner)) {
+			return FALSE;
+		}
+	} elseif (!@mkdir($root, 0755, TRUE) || !pfb_settings_family_path_is_safe($root, TRUE, $expected_owner)) {
+		return FALSE;
+	}
+	$slot = $root . '/settings-' . $family . '.xml';
+	if (file_exists($slot) || is_link($slot)) {
+		if (!pfb_settings_family_path_is_safe($slot, FALSE, $expected_owner)) {
+			return FALSE;
+		}
+	}
+	$encoded = base64_encode(serialize($owned));
+	if (function_exists('dump_xml_config')) {
+		$xml = @dump_xml_config(['family' => $family, 'payload' => $encoded], 'pfblockerng-settings');
+	} else {
+		$document = new SimpleXMLElement('<pfblockerng-settings/>');
+		$document->addChild('family', $family);
+		$document->addChild('payload', $encoded);
+		$xml = $document->asXML();
+	}
+	if (!is_string($xml) || $xml === '') {
+		return FALSE;
+	}
+	$tmp = @tempnam($root, '.settings-');
+	if (!is_string($tmp)) {
+		return FALSE;
+	}
+	$written = @file_put_contents($tmp, $xml, LOCK_EX);
+	$exact = $written === strlen($xml) && @file_get_contents($tmp) === $xml;
+	if (!$exact || !@chmod($tmp, 0600) || !pfb_settings_family_path_is_safe($tmp, FALSE, $expected_owner)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	if (!@rename($tmp, $slot)) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	clearstatcache(TRUE, $slot);
+	return pfb_settings_family_path_is_safe($slot, FALSE, $expected_owner)
+		&& @file_get_contents($slot) === $xml;
+}
+
+function pfb_settings_family_replace(string $family): bool
+{
+	if (!isset(PFB_SETTINGS_FAMILY_RANK[$family])) {
+		return FALSE;
+	}
+	$root = pfb_settings_family_root();
+	$expected_owner = pfb_settings_family_expected_owner($root);
+	$slot = $root . '/settings-' . $family . '.xml';
+	if (!file_exists($slot) && !is_link($slot)) {
+		return TRUE;
+	}
+	if (!pfb_settings_family_path_is_safe($root, TRUE, $expected_owner)
+		|| !pfb_settings_family_path_is_safe($slot, FALSE, $expected_owner)) {
+		return FALSE;
+	}
+	$parsed = NULL;
+	if (function_exists('parse_xml_config')) {
+		try {
+			$parsed = parse_xml_config($slot, 'pfblockerng-settings');
+		} catch (Throwable) {
+			return FALSE;
+		}
+	} else {
+		$document = @simplexml_load_file($slot, 'SimpleXMLElement', LIBXML_NONET | LIBXML_NOBLANKS);
+		if ($document !== FALSE && $document->getName() === 'pfblockerng-settings') {
+			$parsed = ['family' => (string) ($document->family ?? ''), 'payload' => (string) ($document->payload ?? '')];
+		}
+	}
+	if (!is_array($parsed)
+		|| !isset($parsed['family'], $parsed['payload'])
+		|| !is_string($parsed['family'])
+		|| $parsed['family'] !== $family
+		|| !is_string($parsed['payload'])) {
+		return FALSE;
+	}
+	$decoded = base64_decode($parsed['payload'], TRUE);
+	if ($decoded === FALSE) {
+		return FALSE;
+	}
+	try {
+		$owned = @unserialize($decoded, ['allowed_classes' => FALSE]);
+	} catch (Throwable) {
+		return FALSE;
+	}
+	if (!is_array($owned) || $owned === []) {
+		return FALSE;
+	}
+	foreach ($owned as $section => $_value) {
+		if (!is_string($section) || !str_starts_with($section, 'pfblockerng')) {
+			return FALSE;
+		}
+	}
+	$active_references = [];
+	if (!pfb_settings_family_payload_is_valid($owned, $active_references)) {
+		return FALSE;
+	}
+	$installed = config_get_path('installedpackages', []);
+	if (!is_array($installed)) {
+		$installed = [];
+	}
+	$rebuilt = [];
+	$owned_sections = array_keys($owned);
+	$owned_index = 0;
+	foreach ($installed as $section => $value) {
+		if (str_starts_with((string) $section, 'pfblockerng')) {
+			if (array_key_exists($owned_index, $owned_sections)) {
+				$owned_section = $owned_sections[$owned_index++];
+				$rebuilt[$owned_section] = $owned[$owned_section];
+				unset($owned[$owned_section]);
+			}
+			continue;
+		}
+		$rebuilt[$section] = $value;
+	}
+	foreach ($owned as $section => $value) {
+		$rebuilt[$section] = $value;
+	}
+	config_set_path('installedpackages', $rebuilt);
+	write_config('pfBlockerNG: restore settings family');
+	return TRUE;
+}
+
+function pfb_settings_family_record(string $family): bool
+{
+	if (!isset(PFB_SETTINGS_FAMILY_RANK[$family])) {
+		return FALSE;
+	}
+	try {
+		PfbConfig::writeSystem('gen/settings_family', $family);
+		return TRUE;
+	} catch (Throwable) {
+		return FALSE;
+	}
+}
+
+function pfb_install_settings_family_capture_restore(
+	?callable $current = NULL,
+	?callable $save = NULL,
+	?callable $replace = NULL
+): string {
+	$current ??= 'pfb_settings_family_current';
+	$save ??= 'pfb_settings_family_save';
+	$replace ??= 'pfb_settings_family_replace';
+	$source = $current();
+	if (!is_string($source) || !isset(PFB_SETTINGS_FAMILY_RANK[$source]) || !$save($source)) {
+		throw new RuntimeException('pfBlockerNG: unable to save source settings family');
+	}
+	if (!$replace('3.3')) {
+		throw new RuntimeException('pfBlockerNG: unable to restore 3.3 settings family');
+	}
+	return $source;
+}
+
+function pfb_install_settings_family_finalize(?callable $record = NULL): void
+{
+	$record ??= 'pfb_settings_family_record';
+	if (!$record('3.3')) {
+		throw new RuntimeException('pfBlockerNG: unable to record 3.3 settings family');
+	}
+}
 ?>

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -26,6 +26,8 @@ require_once('/usr/local/www/pfblockerng/pfblockerng.php');
 
 global $g, $pfb;
 pfb_global();
+$pfb_installed_family = pfb_install_settings_family_capture_restore();
+pfb_global();
 
 // Set 'Install flag' to skip sync process during installations.
 $g['pfblockerng_install'] = TRUE;
@@ -668,6 +670,7 @@ if ($ufound) {
 	update_status(" no changes required ... done.\n");
 }
 
+pfb_install_settings_family_finalize();
 unset($g['pfblockerng_install']);	// Remove 'Install flag'
 update_status("Upgrading... done\n\nCustom commands completed ... ");
 

--- a/tests/php/assert_settings_family_3_3.php
+++ b/tests/php/assert_settings_family_3_3.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Standalone settings-family bridge assertions for the release/3.3 source tree.
+ * This runner deliberately avoids PHPUnit so release-branch CI can execute it directly.
+ */
+
+$GLOBALS['config'] = [];
+$GLOBALS['pfb'] = [];
+$GLOBALS['write_config_calls'] = [];
+
+function config_get_path(string $path, mixed $default = null): mixed
+{
+	$value = $GLOBALS['config'];
+	foreach (explode('/', trim($path, '/')) as $part) {
+		if (!is_array($value) || !array_key_exists($part, $value)) {
+			return $default;
+		}
+		$value = $value[$part];
+	}
+	return $value;
+}
+
+function config_set_path(string $path, mixed $value): void
+{
+	$parts = explode('/', trim($path, '/'));
+	$cursor =& $GLOBALS['config'];
+	foreach ($parts as $part) {
+		if (!is_array($cursor)) {
+			$cursor = [];
+		}
+		if (!array_key_exists($part, $cursor) || !is_array($cursor[$part])) {
+			$cursor[$part] = [];
+		}
+		$cursor =& $cursor[$part];
+	}
+	$cursor = $value;
+}
+
+function write_config(string $message): void
+{
+	$GLOBALS['write_config_calls'][] = $message;
+}
+
+$extra = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+if (is_file($extra)) {
+	require_once $extra;
+}
+
+$failures = 0;
+$root = sys_get_temp_dir() . '/pfb_settings_family_3_3_' . bin2hex(random_bytes(5));
+mkdir($root, 0700, true);
+$GLOBALS['pfb']['dbdir'] = $root;
+
+function row(string $name, callable $check): void
+{
+	global $failures;
+	try {
+		$check();
+		echo "PASS {$name}\n";
+	} catch (Throwable $error) {
+		$failures++;
+		echo "FAIL {$name}: {$error->getMessage()}\n";
+	}
+}
+
+function check(bool $condition, string $message): void
+{
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function same(mixed $expected, mixed $actual, string $message): void
+{
+	if ($expected !== $actual) {
+		throw new RuntimeException($message);
+	}
+}
+
+function reset_fixture(array $installed): void
+{
+	$GLOBALS['config'] = [
+		'system' => ['hostname' => 'unchanged'],
+		'installedpackages' => $installed,
+	];
+	$GLOBALS['write_config_calls'] = [];
+	global $root;
+	foreach (glob($root . '/*') ?: [] as $path) {
+		is_dir($path) && !is_link($path) ? rmdir($path) : @unlink($path);
+	}
+	}
+
+function slot(string $family): string
+{
+	global $root;
+	return $root . '/settings-' . $family . '.xml';
+}
+
+function payload(string $family): array
+{
+	$xml = simplexml_load_file(slot($family), 'SimpleXMLElement', LIBXML_NONET | LIBXML_NOBLANKS);
+	check($xml !== false, 'slot XML parses');
+	$decoded = base64_decode((string) $xml->payload, true);
+	check($decoded !== false, 'slot payload decodes');
+	$owned = @unserialize($decoded, ['allowed_classes' => false]);
+	check(is_array($owned), 'slot payload is array');
+	return $owned;
+}
+
+row('missing marker bootstraps 3.3', static function (): void {
+	reset_fixture(['pfblockerng' => ['config' => ['0' => ['legacy' => 'yes']]]]);
+	same('3.3', pfb_settings_family_current(), 'missing marker must be 3.3');
+});
+
+row('NULL marker bootstraps 3.3', static function (): void {
+	reset_fixture(['pfblockerng' => ['config' => ['0' => ['settings_family' => null]]]]);
+	same('3.3', pfb_settings_family_current(), 'NULL marker must be 3.3');
+});
+
+row('empty marker bootstraps 3.3', static function (): void {
+	reset_fixture(['pfblockerng' => ['config' => ['0' => ['settings_family' => '']]]]);
+	same('3.3', pfb_settings_family_current(), 'empty marker must be 3.3');
+});
+
+row('explicit 3.3, 4.0, and 4.1 markers accepted', static function (): void {
+	foreach (['3.3', '4.0', '4.1'] as $family) {
+		reset_fixture(['pfblockerng' => ['config' => ['0' => ['settings_family' => $family]]]]);
+		same($family, pfb_settings_family_current(), 'explicit marker accepted');
+	}
+});
+
+row('invalid marker type/value rejected', static function (): void {
+	foreach ([['settings_family' => 3.3], ['settings_family' => '3.2'], ['settings_family' => '4.2']] as $marker) {
+		reset_fixture(['pfblockerng' => ['config' => ['0' => $marker]]]);
+		$thrown = false;
+		try {
+			pfb_settings_family_current();
+		} catch (Throwable) {
+			$thrown = true;
+		}
+		check($thrown, 'invalid marker must throw');
+	}
+});
+
+row('marker write uses minimal PfbConfig boundary', static function (): void {
+	reset_fixture([]);
+	check(PfbConfig::read('gen/settings_family') === null, 'missing gateway read');
+	PfbConfig::writeSystem('gen/settings_family', '3.3');
+	same('3.3', config_get_path('installedpackages/pfblockerng/config/0/settings_family'), 'marker write');
+	$thrown = false;
+	try {
+		PfbConfig::read('gen/unknown');
+	} catch (Throwable) {
+		$thrown = true;
+	}
+	check($thrown, 'unknown gateway key must throw');
+});
+
+row('source save captures exact owned sections only', static function (): void {
+	$owned = [
+		'pfblockerng' => ['config' => ['0' => ['credential' => 'secret-canary', 'empty' => [], 'nested' => ['order' => 'one']]]],
+		'pfblockerngglobal' => ['unknown' => ['empty' => '', 'order' => 'two']],
+	];
+	reset_fixture($owned + ['otherpackage' => ['config' => ['untouched' => 'yes']]]);
+	check(pfb_settings_family_save('4.1'), 'source save');
+	same($owned, payload('4.1'), 'owned payload exact');
+	check(!array_key_exists('otherpackage', payload('4.1')), 'foreign section excluded');
+});
+
+row('exact 3.3 target restore preserves foreign config', static function (): void {
+	$owned = ['pfblockerng' => ['config' => ['0' => ['credential' => 'secret-canary', 'empty' => []]]]];
+	reset_fixture($owned + ['otherpackage' => ['config' => ['untouched' => 'yes']]]);
+	check(pfb_settings_family_save('3.3'), 'target save');
+	$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'changed';
+	$GLOBALS['config']['installedpackages']['otherpackage']['config']['untouched'] = 'changed';
+	check(pfb_settings_family_replace('3.3'), 'target restore');
+	same($owned['pfblockerng'], $GLOBALS['config']['installedpackages']['pfblockerng'], 'owned restore');
+	same('changed', $GLOBALS['config']['installedpackages']['otherpackage']['config']['untouched'], 'foreign preserved');
+	same('unchanged', $GLOBALS['config']['system']['hostname'], 'system preserved');
+});
+
+row('missing target slot is no-op', static function (): void {
+	reset_fixture(['pfblockerng' => ['config' => ['0' => ['credential' => 'live']]]]);
+	$before = $GLOBALS['config'];
+	check(pfb_settings_family_replace('3.3'), 'missing target no-op');
+	same($before, $GLOBALS['config'], 'missing target mutation');
+});
+
+row('corrupt XML and bad base64 fail before mutation', static function (): void {
+	reset_fixture(['pfblockerng' => ['config' => ['0' => ['credential' => 'live']]]]);
+	check(pfb_settings_family_save('3.3'), 'fixture save');
+	file_put_contents(slot('3.3'), '<bad>');
+	$before = $GLOBALS['config'];
+	check(!pfb_settings_family_replace('3.3'), 'corrupt XML rejected');
+	same($before, $GLOBALS['config'], 'corrupt XML mutation');
+	file_put_contents(slot('3.3'), '<pfblockerng-settings><family>3.3</family><payload>not-base64!</payload></pfblockerng-settings>');
+	chmod(slot('3.3'), 0600);
+	check(!pfb_settings_family_replace('3.3'), 'bad base64 rejected');
+	same($before, $GLOBALS['config'], 'bad base64 mutation');
+});
+
+row('object, cycle, wrong-family, and foreign payloads fail closed', static function (): void {
+	reset_fixture(['pfblockerng' => ['config' => ['0' => ['credential' => 'live']]]]);
+	$write = static function (string $family, array $owned): void {
+		$xml = '<pfblockerng-settings><family>' . htmlspecialchars($family, ENT_XML1) . '</family><payload>'
+			. base64_encode(serialize($owned)) . '</payload></pfblockerng-settings>';
+		file_put_contents(slot('3.3'), $xml);
+		chmod(slot('3.3'), 0600);
+	};
+	$object = ['pfblockerng' => ['object' => new stdClass()]];
+	$write('3.3', $object);
+	check(!pfb_settings_family_replace('3.3'), 'object rejected');
+	$cycle = [];
+	$cycle['self'] =& $cycle;
+	$write('3.3', ['pfblockerng' => $cycle]);
+	check(!pfb_settings_family_replace('3.3'), 'cycle rejected');
+	$write('4.0', ['pfblockerng' => ['config' => []]]);
+	check(!pfb_settings_family_replace('3.3'), 'wrong family rejected');
+	$write('3.3', ['otherpackage' => ['config' => []]]);
+	check(!pfb_settings_family_replace('3.3'), 'foreign section rejected');
+});
+
+row('unsafe root, owner, mode, type, and symlink predicates reject', static function (): void {
+	reset_fixture(['pfblockerng' => ['config' => ['0' => ['live' => 'yes']]]]);
+	$GLOBALS['pfb']['settings_family_expected_owner'] = (function_exists('posix_geteuid') ? posix_geteuid() : 0) + 1;
+	check(!pfb_settings_family_save('3.3'), 'owner mismatch rejected');
+	unset($GLOBALS['pfb']['settings_family_expected_owner']);
+	chmod($GLOBALS['pfb']['dbdir'], 0777);
+	check(!pfb_settings_family_save('3.3'), 'group-world root rejected');
+	chmod($GLOBALS['pfb']['dbdir'], 0700);
+	check(pfb_settings_family_save('3.3'), 'safe root save');
+	chmod(slot('3.3'), 0644);
+	check(!pfb_settings_family_save('3.3'), 'unsafe slot mode rejected');
+	chmod(slot('3.3'), 0600);
+	unlink(slot('3.3'));
+	mkdir(slot('3.3'));
+	check(!pfb_settings_family_replace('3.3'), 'directory slot rejected');
+	rmdir(slot('3.3'));
+	file_put_contents($GLOBALS['pfb']['dbdir'] . '/target', 'x');
+	symlink($GLOBALS['pfb']['dbdir'] . '/target', slot('3.3'));
+	check(!pfb_settings_family_replace('3.3'), 'symlink slot rejected');
+	unlink(slot('3.3'));
+});
+
+row('no owned settings is no-op without inventing slot', static function (): void {
+	reset_fixture(['otherpackage' => ['config' => ['untouched' => 'yes']]]);
+	check(pfb_settings_family_save('3.3'), 'no owned save');
+	check(!file_exists(slot('3.3')), 'no owned slot');
+});
+
+row('unknown fields, nesting, empty values, order, and credential survive', static function (): void {
+	$owned = [
+		'pfblockerng' => ['config' => ['0' => ['first' => 'one', 'empty' => '', 'credential' => 'secret-canary', 'nested' => ['second' => [], 'third' => ['deep' => null]]]]],
+	];
+	reset_fixture($owned);
+	check(pfb_settings_family_save('3.3'), 'unknown save');
+	$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0'] = ['changed' => true];
+	check(pfb_settings_family_replace('3.3'), 'unknown restore');
+	same($owned, $GLOBALS['config']['installedpackages'], 'unknown exact restore');
+});
+
+row('atomic overwrite leaves no temp residue', static function (): void {
+	reset_fixture(['pfblockerng' => ['config' => ['0' => ['value' => 'one']]]]);
+	check(pfb_settings_family_save('3.3'), 'first atomic save');
+	$first = file_get_contents(slot('3.3'));
+	$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['value'] = 'two';
+	check(pfb_settings_family_save('3.3'), 'second atomic save');
+	check($first !== file_get_contents(slot('3.3')), 'overwrite changed bytes');
+	$temporary = array_filter(scandir($GLOBALS['pfb']['dbdir']) ?: [], static fn (string $entry): bool => str_starts_with($entry, '.settings-'));
+	same([], array_values($temporary), 'temporary residue');
+});
+
+row('install helper order is save source, restore 3.3, existing installer, record 3.3', static function (): void {
+	check(function_exists('pfb_install_settings_family_capture_restore'), 'capture helper exists');
+	check(function_exists('pfb_install_settings_family_finalize'), 'finalize helper exists');
+	$order = [];
+	$source = pfb_install_settings_family_capture_restore(
+		static function () use (&$order): string { $order[] = 'current'; return '4.1'; },
+		static function (string $family) use (&$order): bool { $order[] = 'save:' . $family; return true; },
+		static function (string $family) use (&$order): bool { $order[] = 'replace:' . $family; return true; }
+	);
+	pfb_install_settings_family_finalize(
+		static function (string $family) use (&$order): bool { $order[] = 'record:' . $family; return true; }
+	);
+	same('4.1', $source, 'source returned');
+	same(['current', 'save:4.1', 'replace:3.3', 'record:3.3'], $order, 'helper order');
+});
+
+row('installer call placement is structural', static function (): void {
+	$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc');
+	check($source !== '', 'installer source readable');
+	$capture = strpos($source, '$pfb_installed_family = pfb_install_settings_family_capture_restore();');
+	$refresh = strpos($source, 'pfb_global();', $capture === false ? 0 : $capture + 1);
+	$finalize = strpos($source, 'pfb_install_settings_family_finalize();');
+	$write = strrpos($source, "write_config('[pfBlockerNG] Save installation settings');");
+	check($capture !== false && $refresh !== false && $finalize !== false && $write !== false, 'installer hooks present');
+	check($capture < $refresh && $refresh < $finalize && $finalize < $write, 'installer hook order');
+});
+
+function remove_tree(string $path): void
+{
+	if (!is_dir($path)) {
+		return;
+	}
+	foreach (scandir($path) ?: [] as $entry) {
+		if ($entry === '.' || $entry === '..') {
+			continue;
+		}
+		$child = $path . '/' . $entry;
+		is_dir($child) && !is_link($child) ? remove_tree($child) : @unlink($child);
+	}
+	@rmdir($path);
+}
+
+remove_tree($root);
+echo $failures === 0 ? "ALL PASS\n" : "{$failures} FAILURES\n";
+exit($failures === 0 ? 0 : 1);

--- a/tests/php/assert_settings_family_adversarial_3_3.php
+++ b/tests/php/assert_settings_family_adversarial_3_3.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['config'] = [];
+$GLOBALS['pfb'] = [];
+$GLOBALS['write_config_calls'] = [];
+$GLOBALS['dump_xml_config_calls'] = 0;
+$GLOBALS['parse_xml_config_calls'] = 0;
+
+function config_get_path(string $path, mixed $default = null): mixed
+{
+	$value = $GLOBALS['config'];
+	foreach (explode('/', trim($path, '/')) as $part) {
+		if (!is_array($value) || !array_key_exists($part, $value)) {
+			return $default;
+		}
+		$value = $value[$part];
+	}
+	return $value;
+}
+
+function config_set_path(string $path, mixed $value): void
+{
+	$cursor =& $GLOBALS['config'];
+	foreach (explode('/', trim($path, '/')) as $part) {
+		if (!is_array($cursor)) {
+			$cursor = [];
+		}
+		if (!array_key_exists($part, $cursor) || !is_array($cursor[$part])) {
+			$cursor[$part] = [];
+		}
+		$cursor =& $cursor[$part];
+	}
+	$cursor = $value;
+}
+
+function write_config(string $message): void
+{
+	$GLOBALS['write_config_calls'][] = $message;
+}
+
+function dump_xml_config(array $data, string $root): string
+{
+	$GLOBALS['dump_xml_config_calls']++;
+	$document = new SimpleXMLElement('<' . $root . '/>');
+	foreach ($data as $key => $value) {
+		$document->addChild((string) $key, (string) $value);
+	}
+	return (string) $document->asXML();
+}
+
+function parse_xml_config(string $path, string $root): array|int
+{
+	$GLOBALS['parse_xml_config_calls']++;
+	$document = @simplexml_load_file($path, 'SimpleXMLElement', LIBXML_NONET | LIBXML_NOBLANKS);
+	if ($document === false || $document->getName() !== $root) {
+		return -1;
+	}
+	return ['family' => (string) ($document->family ?? ''), 'payload' => (string) ($document->payload ?? '')];
+}
+
+$sourceRoot = getenv('PFB_SOURCE_ROOT');
+$sourceRoot = is_string($sourceRoot) && $sourceRoot !== '' ? $sourceRoot : dirname(__DIR__, 2);
+$extra = $sourceRoot . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+require_once $extra;
+
+$root = sys_get_temp_dir() . '/pfb_settings_family_adversarial_' . bin2hex(random_bytes(5));
+mkdir($root, 0700, true);
+$GLOBALS['pfb']['dbdir'] = $root;
+
+function check(bool $condition, string $message): void
+{
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function same(mixed $expected, mixed $actual, string $message): void
+{
+	if ($expected !== $actual) {
+		throw new RuntimeException($message);
+	}
+}
+
+function reset_fixture(): void
+{
+	$GLOBALS['config'] = [
+		'system' => ['hostname' => 'unchanged'],
+		'installedpackages' => [
+			'pfblockerng' => ['config' => ['0' => ['credential' => 'live']]],
+			'otherpackage' => ['config' => ['untouched' => 'yes']],
+		],
+	];
+	$GLOBALS['write_config_calls'] = [];
+	$GLOBALS['dump_xml_config_calls'] = 0;
+	$GLOBALS['parse_xml_config_calls'] = 0;
+	global $root;
+	foreach (glob($root . '/*') ?: [] as $path) {
+		is_dir($path) && !is_link($path) ? rmdir($path) : @unlink($path);
+	}
+}
+
+function write_slot(string $family, array $owned): void
+{
+	global $root;
+	$document = new SimpleXMLElement('<pfblockerng-settings/>');
+	$document->addChild('family', $family);
+	$document->addChild('payload', base64_encode(serialize($owned)));
+	file_put_contents($root . '/settings-3.3.xml', $document->asXML());
+	chmod($root . '/settings-3.3.xml', 0600);
+}
+
+try {
+	$hostile = [];
+	$hostile['object'] = ['pfblockerng' => ['object' => new stdClass()]];
+	$cycle = [];
+	$cycle['self'] =& $cycle;
+	$hostile['cycle'] = ['pfblockerng' => $cycle];
+	$hostile['wrong family'] = ['family' => '4.0', 'owned' => ['pfblockerng' => ['config' => []]]];
+	$hostile['foreign section'] = ['family' => '3.3', 'owned' => ['otherpackage' => ['config' => []]]];
+	foreach ($hostile as $name => $fixture) {
+		reset_fixture();
+		$family = $fixture['family'] ?? '3.3';
+		$owned = $fixture['owned'] ?? $fixture;
+		write_slot($family, $owned);
+		$before = $GLOBALS['config'];
+		check(!pfb_settings_family_replace('3.3'), $name . ' must fail');
+		same($before, $GLOBALS['config'], $name . ' mutated live config');
+		same([], $GLOBALS['write_config_calls'], $name . ' wrote live config');
+	}
+
+	reset_fixture();
+	check(pfb_settings_family_save('3.3'), 'native save');
+	check($GLOBALS['dump_xml_config_calls'] > 0, 'native save must call dump_xml_config');
+	$GLOBALS['config']['installedpackages']['pfblockerng']['config']['0']['credential'] = 'changed';
+	check(pfb_settings_family_replace('3.3'), 'native restore');
+	check($GLOBALS['parse_xml_config_calls'] > 0, 'native restore must call parse_xml_config');
+	same('live', config_get_path('installedpackages/pfblockerng/config/0/credential'), 'native restore value');
+	same(['pfBlockerNG: restore settings family'], $GLOBALS['write_config_calls'], 'native restore write');
+
+	reset_fixture();
+	check(pfb_settings_family_save('3.3'), 'corrupt fixture save');
+	file_put_contents($root . '/settings-3.3.xml', '<broken>');
+	chmod($root . '/settings-3.3.xml', 0600);
+	$before = $GLOBALS['config'];
+	$GLOBALS['write_config_calls'] = [];
+	check(!pfb_settings_family_replace('3.3'), 'corrupt native slot must fail');
+	same($before, $GLOBALS['config'], 'corrupt native slot mutated config');
+	same([], $GLOBALS['write_config_calls'], 'corrupt native slot wrote config');
+
+	$install = $sourceRoot . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
+	$source = php_strip_whitespace($install);
+	check($source !== '', 'installer source readable');
+	$capture = strpos($source, '$pfb_installed_family = pfb_install_settings_family_capture_restore();');
+	$workBegin = strpos($source, '$g[\'pfblockerng_install\'] = TRUE;');
+	$workEnd = strrpos($source, 'update_status(" no changes required ... done.\\n");');
+	$finalize = strpos($source, 'pfb_install_settings_family_finalize();');
+	$finalWrite = strrpos($source, "write_config('[pfBlockerNG] Save installation settings');");
+	check($capture !== false && $workBegin !== false && $workEnd !== false && $finalize !== false && $finalWrite !== false, 'installer order markers present');
+	check($capture < $workBegin && $workBegin < $workEnd && $workEnd < $finalize && $finalize < $finalWrite, 'installer order must protect existing work');
+	same(1, substr_count($source, 'pfb_install_settings_family_finalize();'), 'finalize count');
+	echo "PASS hostile slots fail closed and installer order is protected\nALL PASS\n";
+	$exit = 0;
+} catch (Throwable $error) {
+	echo "FAIL adversarial settings-family assertions: {$error->getMessage()}\n";
+	$exit = 1;
+}
+
+function remove_tree(string $path): void
+{
+	if (!is_dir($path)) {
+		return;
+	}
+	foreach (scandir($path) ?: [] as $entry) {
+		if ($entry === '.' || $entry === '..') {
+			continue;
+		}
+		$child = $path . '/' . $entry;
+		is_dir($child) && !is_link($child) ? remove_tree($child) : @unlink($child);
+	}
+	@rmdir($path);
+}
+
+remove_tree($root);
+exit($exit);

--- a/tests/php/assert_settings_family_replace_persists_3_3.php
+++ b/tests/php/assert_settings_family_replace_persists_3_3.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['config'] = [];
+$GLOBALS['config_disk'] = [];
+$GLOBALS['pfb'] = [];
+$GLOBALS['write_config_calls'] = [];
+
+function config_get_path(string $path, mixed $default = null): mixed
+{
+	$value = $GLOBALS['config'];
+	foreach (explode('/', trim($path, '/')) as $part) {
+		if (!is_array($value) || !array_key_exists($part, $value)) {
+			return $default;
+		}
+		$value = $value[$part];
+	}
+	return $value;
+}
+
+function config_set_path(string $path, mixed $value): void
+{
+	$cursor =& $GLOBALS['config'];
+	foreach (explode('/', trim($path, '/')) as $part) {
+		if (!is_array($cursor)) {
+			$cursor = [];
+		}
+		if (!array_key_exists($part, $cursor) || !is_array($cursor[$part])) {
+			$cursor[$part] = [];
+		}
+		$cursor =& $cursor[$part];
+	}
+	$cursor = $value;
+}
+
+function config_read_file(bool $unused_defaults = false, bool $unused_merge = false): bool
+{
+	$GLOBALS['config'] = $GLOBALS['config_disk'];
+	return true;
+}
+
+function write_config(string $message): void
+{
+	$GLOBALS['write_config_calls'][] = $message;
+	$GLOBALS['config_disk'] = $GLOBALS['config'];
+}
+
+function pfb_global(): void
+{
+	config_read_file(false, true);
+	$GLOBALS['pfb']['config'] = config_get_path('installedpackages/pfblockerng/config/0', []);
+}
+
+$extra = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+require_once $extra;
+
+$root = sys_get_temp_dir() . '/pfb_settings_family_replace_' . bin2hex(random_bytes(5));
+mkdir($root, 0700, true);
+$GLOBALS['pfb']['dbdir'] = $root;
+
+function check(bool $condition, string $message): void
+{
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function same(mixed $expected, mixed $actual, string $message): void
+{
+	if ($expected !== $actual) {
+		throw new RuntimeException($message);
+	}
+}
+
+try {
+	$live = [
+		'pfblockerng' => ['config' => ['0' => ['credential' => 'live-4.1', 'pfb_keep' => 'on']]],
+		'otherpackage' => ['config' => ['untouched' => 'yes']],
+	];
+	$GLOBALS['config_disk'] = ['installedpackages' => $live];
+	pfb_global();
+	$legacy = ['pfblockerng' => ['config' => ['0' => ['credential' => 'legacy-3.3', 'pfb_keep' => 'off']]]];
+	$document = new SimpleXMLElement('<pfblockerng-settings/>');
+	$document->addChild('family', '3.3');
+	$document->addChild('payload', base64_encode(serialize($legacy)));
+	file_put_contents($root . '/settings-3.3.xml', $document->asXML());
+	chmod($root . '/settings-3.3.xml', 0600);
+
+	check(pfb_settings_family_replace('3.3'), 'replace succeeds');
+	same('legacy-3.3', config_get_path('installedpackages/pfblockerng/config/0/credential'), 'pre-reload restore');
+	same(['pfBlockerNG: restore settings family'], $GLOBALS['write_config_calls'], 'exact restore write message');
+	pfb_global();
+	same('legacy-3.3', config_get_path('installedpackages/pfblockerng/config/0/credential'), 'post-reload restore');
+	same('legacy-3.3', $GLOBALS['pfb']['config']['credential'], 'pfb_global source reload');
+
+	$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+	check(is_string($source) && str_contains($source, 'function pfb_global()'), 'real pfb_global source present');
+	$start = strpos($source, 'function pfb_global()');
+	check(strpos($source, 'config_read_file(false, true);', $start) !== false, 'real pfb_global reload retained');
+	echo "PASS replace persistence and pfb_global reload\nALL PASS\n";
+	$exit = 0;
+} catch (Throwable $error) {
+	echo "FAIL replace persistence: {$error->getMessage()}\n";
+	$exit = 1;
+}
+
+function remove_tree(string $path): void
+{
+	if (!is_dir($path)) {
+		return;
+	}
+	foreach (scandir($path) ?: [] as $entry) {
+		if ($entry === '.' || $entry === '..') {
+			continue;
+		}
+		$child = $path . '/' . $entry;
+		is_dir($child) && !is_link($child) ? remove_tree($child) : @unlink($child);
+	}
+	@rmdir($path);
+}
+
+remove_tree($root);
+exit($exit);

--- a/tests/test_settings_family_3_3.py
+++ b/tests/test_settings_family_3_3.py
@@ -1,0 +1,18 @@
+"""Release/3.3 settings-family bridge subprocess seam."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_php_assertion_runner() -> None:
+    runner = Path(__file__).with_name("php") / "assert_settings_family_3_3.php"
+    result = subprocess.run(
+        ["php", str(runner)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout

--- a/tests/test_settings_family_adversarial_3_3.py
+++ b/tests/test_settings_family_adversarial_3_3.py
@@ -1,0 +1,22 @@
+"""Adversarial settings-family slot and installer-order subprocess seam."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_php_adversarial_settings_family_assertions() -> None:
+    runner = (
+        Path(__file__).with_name("php") / "assert_settings_family_adversarial_3_3.php"
+    )
+    result = subprocess.run(
+        ["php", str(runner)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout

--- a/tests/test_settings_family_replace_persists_3_3.py
+++ b/tests/test_settings_family_replace_persists_3_3.py
@@ -1,0 +1,21 @@
+"""Persistence seam for settings-family replacement."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_php_replace_persists_before_pfb_global_reload() -> None:
+    runner = (
+        Path(__file__).with_name("php")
+        / "assert_settings_family_replace_persists_3_3.php"
+    )
+    result = subprocess.run(
+        ["php", str(runner)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout


### PR DESCRIPTION
## Summary

- make 3.3 the sole migration floor for missing or empty `settings_family`
- save the source settings family and restore the exact 3.3 slot in the shared install lifecycle
- validate slot ownership, mode, type, family, payload shape, and owned-section boundary before atomic publication or restore
- preserve unrelated pfSense configuration and exclude non-owned sections from snapshots

## Test evidence

- frozen bootstrap suite: base `97b2dd8` RED (`16 FAILURES`) → candidate GREEN (`ALL PASS`)
- frozen restore-persistence suite: predecessor `cf221a8` RED (missing exact restore write) → candidate GREEN (`ALL PASS`)
- supplemental frozen mutant proof: early finalize, wrong-family mutation, and native XML bypass each RED for the intended reason → candidate GREEN (`ALL PASS`)
- `python3 -m pytest -q` — `3 passed`
- targeted Ruff, PHP syntax, actionlint, and `git diff --check` — pass
- independent step verification — pass
- whole-PR top-tier adversarial review at `84468ca7` — pass

Canonical branch-wide gates retain only known `release/3.3` baseline failures in legacy `pfb_unbound.py` formatting and an absent newer-branch helper; changed-file gates pass.

Fixes #2158

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
