### PR TITLE
ci: add branch-independent Nightly workflow

### DIFF
--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -19,6 +19,7 @@ on:
       - "UI tests fan-out (all CI legs, live pfSense VM)"
       - "Version Tracker"
       - "Repo install (live pfSense VM)"
+      - "Nightly snapshot"
     types: [completed]
   # Red-path test handle (CLAUDE.md: a newly wired gate demonstrates its red
   # path once): simulate a failed nightly of the named workflow. The issue it

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,380 @@
+name: Nightly snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Explicit source ref to pin for this snapshot"
+        required: true
+        type: string
+      ports_repo:
+        description: "FreeBSD-ports repository carrying the Nightly recipe"
+        required: true
+        default: "pfBlockerNG/FreeBSD-ports"
+        type: string
+      ports_ref:
+        description: "Explicit FreeBSD-ports ref to pin for this snapshot"
+        required: true
+        default: "pfblockerng/use-github"
+        type: string
+  schedule:
+    - cron: "0 9 * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: nightly-snapshot
+  cancel-in-progress: false
+
+env:
+  NIGHTLY_SOURCE_REF: ${{ vars.NIGHTLY_SOURCE_REF }}
+  SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || vars.NIGHTLY_SOURCE_REF }}
+  PORTS_REPO: ${{ github.event_name == 'workflow_dispatch' && inputs.ports_repo || vars.NIGHTLY_PORTS_REPO || 'pfBlockerNG/FreeBSD-ports' }}
+  PORTS_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ports_ref || vars.NIGHTLY_PORTS_REF || 'pfblockerng/use-github' }}
+
+jobs:
+  prepare:
+    name: Pin inputs and allocate version
+    runs-on: ubuntu-latest
+    outputs:
+      outcome: ${{ steps.plan.outputs.outcome }}
+      allocation: ${{ steps.plan.outputs.allocation }}
+      build_matrix: ${{ steps.plan.outputs.build_matrix }}
+      source_sha: ${{ steps.plan.outputs.source_sha }}
+      ports_sha: ${{ steps.plan.outputs.ports_sha }}
+      matrix_digest: ${{ steps.plan.outputs.matrix_digest }}
+      source_date_epoch: ${{ steps.plan.outputs.source_date_epoch }}
+    steps:
+      - name: Checkout explicit source ref
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve pinned source, Ports, and live matrices
+        id: inputs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          if [ -z "${SOURCE_REF:-}" ]; then
+            echo "::error::missing NIGHTLY_SOURCE_REF configuration"
+            exit 1
+          fi
+          SOURCE_SHA="$(git rev-parse "${SOURCE_REF}^{commit}")"
+          SOURCE_DATE_EPOCH="$(git show -s --format=%ct "$SOURCE_SHA")"
+
+          case "$PORTS_REPO" in
+            http://*|https://*|file://*) PORTS_URL="$PORTS_REPO" ;;
+            *) PORTS_URL="https://github.com/${PORTS_REPO}.git" ;;
+          esac
+          PORTS_SHA="$(git ls-remote "$PORTS_URL" "$PORTS_REF" \
+            "refs/heads/${PORTS_REF}" "refs/tags/${PORTS_REF}" \
+            | awk 'NR == 1 { print $1 }')"
+          case "$PORTS_SHA" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
+              ;;
+            *)
+              echo "::error::FreeBSD-ports ref did not resolve: ${PORTS_REF}"
+              exit 1
+              ;;
+          esac
+
+          BUILD_MATRIX="$(sh scripts/read-version-matrix.sh --print-build)"
+          ROUTE_MATRIX="$(sh scripts/read-version-matrix.sh --print-route)"
+          BUILD_COUNT="$(printf '%s' "$BUILD_MATRIX" | jq 'length')"
+          ROUTE_COUNT="$(printf '%s' "$ROUTE_MATRIX" | jq 'length')"
+          if [ "$BUILD_COUNT" -eq 0 ] || [ "$ROUTE_COUNT" -eq 0 ]; then
+            echo "::error::missing live BUILD/ROUTE matrix rows"
+            exit 1
+          fi
+          MATRIX_DIGEST="$(
+            jq -S -c -n \
+              --argjson build "$BUILD_MATRIX" \
+              --argjson route "$ROUTE_MATRIX" \
+              '{build: $build, route: $route}' \
+              | sha256sum | cut -d' ' -f1
+          )"
+
+          STATE_SHA=""
+          if STATE_RESPONSE="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/contents/nightly-state.json?ref=nightly-state" \
+              2>/dev/null)"; then
+            STATE_SHA="$(printf '%s' "$STATE_RESPONSE" | jq -r '.sha')"
+            printf '%s' "$STATE_RESPONSE" \
+              | jq -r '.content' | tr -d '\n' | base64 --decode > state.json
+          else
+            printf '%s\n' '{"schema":1,"generation":0,"records":[]}' > state.json
+          fi
+          python3 scripts/nightly_provenance.py validate --state state.json
+
+          mkdir -p plan
+          # Durable generation checks reject stale completions before state mutation.
+          BUILD_DATE="$(date -u +%Y%m%d)"
+          python3 scripts/nightly_provenance.py allocate \
+            --state state.json \
+            --output plan/allocation.json \
+            --build-date "$BUILD_DATE" \
+            --source-sha "$SOURCE_SHA" \
+            --ports-sha "$PORTS_SHA" \
+            --matrix-digest "$MATRIX_DIGEST"
+          cp state.json plan/state.json
+          printf '%s\n' "$STATE_SHA" > plan/state-file-sha
+          printf '%s\n' "$BUILD_MATRIX" > plan/build-matrix.json
+          printf '%s\n' "$ROUTE_MATRIX" > plan/route-matrix.json
+          printf '%s\n' "$SOURCE_SHA" > plan/source-sha
+          printf '%s\n' "$PORTS_SHA" > plan/ports-sha
+          printf '%s\n' "$MATRIX_DIGEST" > plan/matrix-digest
+          printf '%s\n' "$SOURCE_DATE_EPOCH" > plan/source-date-epoch
+
+          {
+            echo "source_sha=$SOURCE_SHA"
+            echo "ports_sha=$PORTS_SHA"
+            echo "matrix_digest=$MATRIX_DIGEST"
+            echo "source_date_epoch=$SOURCE_DATE_EPOCH"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Select plan outcome
+        id: plan
+        run: |
+          set -eu
+          OUTCOME="$(jq -r '.allocation.outcome' plan/allocation.json)"
+          ALLOCATION="$(jq -c '.' plan/allocation.json)"
+          BUILD_MATRIX="$(cat plan/build-matrix.json)"
+          {
+            echo "outcome=$OUTCOME"
+            echo "allocation=$ALLOCATION"
+            echo "source_sha=${{ steps.inputs.outputs.source_sha }}"
+            echo "ports_sha=${{ steps.inputs.outputs.ports_sha }}"
+            echo "matrix_digest=${{ steps.inputs.outputs.matrix_digest }}"
+            echo "source_date_epoch=${{ steps.inputs.outputs.source_date_epoch }}"
+            echo "build_matrix<<NIGHTLY_BUILD_MATRIX"
+            printf '%s\n' "$BUILD_MATRIX"
+            echo "NIGHTLY_BUILD_MATRIX"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload pinned plan
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-plan
+          path: plan
+          if-no-files-found: error
+          retention-days: 14
+
+  build:
+    name: Build Nightly (${{ matrix.variant }} FreeBSD ${{ matrix.freebsd_major }})
+    needs: prepare
+    if: needs.prepare.outputs.outcome == 'build'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.build_matrix) }}
+    steps:
+      - name: Checkout pinned source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Ensure zstd encoder
+        run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
+
+      - name: Build and verify package
+        env:
+          ALLOCATION_JSON: ${{ needs.prepare.outputs.allocation }}
+          MATRIX_ROW: ${{ toJson(matrix) }}
+          SOURCE_DATE_EPOCH: ${{ needs.prepare.outputs.source_date_epoch }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+          MATRIX_DIGEST: ${{ needs.prepare.outputs.matrix_digest }}
+          RUN_ROOT: ${{ github.workspace }}/out
+          RUN_ID: nightly-${{ github.run_id }}-${{ matrix.freebsd_major }}
+          PORTS_REPO: ${{ env.PORTS_REPO }}
+          PORTS_REF: ${{ env.PORTS_REF }}
+        run: |
+          set -eu
+          mkdir -p result
+          printf '%s\n' "$MATRIX_ROW" > row.json
+          printf '%s' "$ALLOCATION_JSON" | jq '.allocation' > allocation.json
+          PKG_VERSION="$(jq -r '.allocation.pkg_version' allocation.json)"
+          FREEBSD_MAJOR="$(jq -r '.freebsd_major' row.json)"
+          VARIANT="$(jq -r '.variant' row.json)"
+          PY_FLAVOR="$(jq -r '.py_flavor' row.json)"
+          PHP_VERSION="$(jq -r '.php_version' row.json)"
+          PORTS_DIR="${RUN_ROOT}/${RUN_ID}/ports"
+          OUT_DIR="${RUN_ROOT}/${RUN_ID}/out"
+
+          python3 scripts/nightly_provenance.py record \
+            --allocation allocation.json \
+            --matrix-row row.json \
+            --source-date-epoch "$SOURCE_DATE_EPOCH" \
+            --output build-record.json
+          PKG="$(
+            sh scripts/build-leg.sh \
+              --ports-repo "$PORTS_REPO" \
+              --ports-ref "$PORTS_REF" \
+              --channel nightly \
+              --variant "$VARIANT" \
+              --build-record build-record.json \
+              --abi "FreeBSD:${FREEBSD_MAJOR}:amd64" \
+              --py-flavor "$PY_FLAVOR" \
+              --php "$PHP_VERSION" \
+              --local-src . \
+              --pkgversion "$PKG_VERSION" \
+              --ports-dir "$PORTS_DIR" \
+              --out-dir "$OUT_DIR"
+          )"
+          ACTUAL_PORTS_SHA="$(git -C "$PORTS_DIR" rev-parse HEAD)"
+          if [ "$ACTUAL_PORTS_SHA" != "$PORTS_SHA" ]; then
+            echo "::error::FreeBSD-ports checkout changed during build"
+            exit 1
+          fi
+          python3 - "$PKG" build-record.json <<'PY'
+          import json
+          import sys
+          from scripts.pfb_pkg import validate_project_pkg
+
+          validate_project_pkg(sys.argv[1], json.loads(open(sys.argv[2], encoding="utf-8").read()))
+          PY
+          PKG_NAME="$(basename "$PKG")"
+          PKG_SHA="$(sha256sum "$PKG" | cut -d' ' -f1)"
+          cp "$PKG" "result/$PKG_NAME"
+          jq -n \
+            --argjson matrix_row "$MATRIX_ROW" \
+            --slurpfile record build-record.json \
+            --arg abi "FreeBSD:${FREEBSD_MAJOR}:*" \
+            --arg name "$PKG_NAME" \
+            --arg sha256 "$PKG_SHA" \
+            '{matrix_row: $matrix_row, record: $record[0], artifact: {abi: $abi, name: $name, sha256: $sha256}}' \
+            > result/result.json
+
+      - name: Upload verified build
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-result-${{ matrix.freebsd_major }}
+          path: result
+          if-no-files-found: error
+          retention-days: 14
+
+  handoff:
+    name: Verify and hand off Nightly snapshot
+    needs: [prepare, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Exit cleanly for identical input
+        if: needs.prepare.outputs.outcome == 'unchanged'
+        run: echo "Nightly input unchanged; no package or state mutation required."
+
+      - name: Require every BUILD leg
+        if: needs.prepare.outputs.outcome == 'build'
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          set -eu
+          if [ "$BUILD_RESULT" != "success" ]; then
+            echo "::error::BUILD matrix failed or did not complete successfully: $BUILD_RESULT"
+            exit 1
+          fi
+
+      - name: Checkout pinned source for handoff validation
+        if: needs.prepare.outputs.outcome == 'build'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download pinned plan
+        if: needs.prepare.outputs.outcome == 'build'
+        uses: actions/download-artifact@v7
+        with:
+          name: nightly-plan
+          path: plan
+
+      - name: Download every BUILD result
+        if: needs.prepare.outputs.outcome == 'build'
+        uses: actions/download-artifact@v7
+        with:
+          pattern: nightly-result-*
+          path: results
+          merge-multiple: false
+
+      - name: Create verified publisher handoff
+        id: handoff
+        if: needs.prepare.outputs.outcome == 'build'
+        env:
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+          MATRIX_DIGEST: ${{ needs.prepare.outputs.matrix_digest }}
+        run: |
+          set -eu
+          python3 scripts/nightly_provenance.py handoff \
+            --state plan/state.json \
+            --allocation plan/allocation.json \
+            --build-matrix plan/build-matrix.json \
+            --route-matrix plan/route-matrix.json \
+            --results-dir results \
+            --source-sha "$SOURCE_SHA" \
+            --ports-sha "$PORTS_SHA" \
+            --matrix-digest "$MATRIX_DIGEST" \
+            --run-id "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+            --source-ref "$SOURCE_REF" \
+            --ports-repo "$PORTS_REPO" \
+            --ports-ref "$PORTS_REF" \
+            --output nightly-handoff.json
+          jq '[.builds[].artifact]' nightly-handoff.json > artifacts.json
+          python3 scripts/nightly_provenance.py complete \
+            --state plan/state.json \
+            --candidate plan/allocation.json \
+            --artifacts artifacts.json \
+            --run-id "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+            --output nightly-state.json
+
+      - name: Upload verified publisher handoff
+        if: steps.handoff.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-handoff-${{ github.run_id }}
+          path: nightly-handoff.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Persist immutable allocation and artifact identity
+        if: steps.handoff.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: |
+          set -eu
+          REPO="repos/${GITHUB_REPOSITORY}"
+          STATE_SHA="$(cat plan/state-file-sha)"
+          if ! gh api "${REPO}/git/ref/heads/nightly-state" >/dev/null 2>&1; then
+            gh api --method POST "${REPO}/git/refs" \
+              -f ref="refs/heads/nightly-state" \
+              -f sha="$SOURCE_SHA" >/dev/null
+          fi
+          CONTENT="$(base64 < nightly-state.json | tr -d '\n')"
+          if [ -n "$STATE_SHA" ]; then
+            gh api --method PUT "${REPO}/contents/nightly-state.json" \
+              -f message="Record Nightly ${GITHUB_RUN_ID}" \
+              -f content="$CONTENT" \
+              -f branch=nightly-state \
+              -f sha="$STATE_SHA" >/dev/null
+          else
+            gh api --method PUT "${REPO}/contents/nightly-state.json" \
+              -f message="Record Nightly ${GITHUB_RUN_ID}" \
+              -f content="$CONTENT" \
+              -f branch=nightly-state >/dev/null
+          fi
+          gh api "${REPO}/contents/nightly-state.json?ref=nightly-state" \
+            --jq '.content' | tr -d '\n' | base64 --decode | cmp -s nightly-state.json

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,14 +85,23 @@ jobs:
             *) PORTS_URL="https://github.com/${PORTS_REPO}.git" ;;
           esac
           PORTS_REFS="$(git ls-remote "$PORTS_URL" \
-            "refs/heads/${PORTS_REF}" "refs/tags/${PORTS_REF}" \
-            | awk '{ print $1 }' | sort -u)"
-          PORTS_REF_COUNT="$(printf '%s\n' "$PORTS_REFS" | grep -c . || true)"
+            "refs/heads/${PORTS_REF}" "refs/tags/${PORTS_REF}" "refs/tags/${PORTS_REF}^{}" \
+            | LC_ALL=C sort -u)"
+          PORTS_HEAD_SHA="$(printf '%s\n' "$PORTS_REFS" \
+            | awk -v ref="refs/heads/${PORTS_REF}" '$2 == ref { print $1 }')"
+          PORTS_TAG_OBJECT_SHA="$(printf '%s\n' "$PORTS_REFS" \
+            | awk -v ref="refs/tags/${PORTS_REF}" '$2 == ref { print $1 }')"
+          PORTS_TAG_SHA="$(printf '%s\n' "$PORTS_REFS" \
+            | awk -v ref="refs/tags/${PORTS_REF}^{}" '$2 == ref { print $1 }')"
+          [ -n "$PORTS_TAG_SHA" ] || PORTS_TAG_SHA="$PORTS_TAG_OBJECT_SHA"
+          PORTS_REF_COUNT=0
+          [ -n "$PORTS_HEAD_SHA" ] && PORTS_REF_COUNT=$((PORTS_REF_COUNT + 1))
+          [ -n "$PORTS_TAG_SHA" ] && PORTS_REF_COUNT=$((PORTS_REF_COUNT + 1))
           if [ "$PORTS_REF_COUNT" -ne 1 ]; then
             echo "::error::FreeBSD-ports ref is missing or ambiguous: ${PORTS_REF}"
             exit 1
           fi
-          PORTS_SHA="$PORTS_REFS"
+          PORTS_SHA="${PORTS_HEAD_SHA:-$PORTS_TAG_SHA}"
           if ! printf '%s\n' "$PORTS_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
             echo "::error::FreeBSD-ports ref did not resolve to a full SHA: ${PORTS_REF}"
             exit 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,17 +84,19 @@ jobs:
             http://*|https://*|file://*) PORTS_URL="$PORTS_REPO" ;;
             *) PORTS_URL="https://github.com/${PORTS_REPO}.git" ;;
           esac
-          PORTS_SHA="$(git ls-remote "$PORTS_URL" "$PORTS_REF" \
+          PORTS_REFS="$(git ls-remote "$PORTS_URL" \
             "refs/heads/${PORTS_REF}" "refs/tags/${PORTS_REF}" \
-            | awk 'NR == 1 { print $1 }')"
-          case "$PORTS_SHA" in
-            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
-              ;;
-            *)
-              echo "::error::FreeBSD-ports ref did not resolve: ${PORTS_REF}"
-              exit 1
-              ;;
-          esac
+            | awk '{ print $1 }' | sort -u)"
+          PORTS_REF_COUNT="$(printf '%s\n' "$PORTS_REFS" | grep -c . || true)"
+          if [ "$PORTS_REF_COUNT" -ne 1 ]; then
+            echo "::error::FreeBSD-ports ref is missing or ambiguous: ${PORTS_REF}"
+            exit 1
+          fi
+          PORTS_SHA="$PORTS_REFS"
+          if ! printf '%s\n' "$PORTS_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::FreeBSD-ports ref did not resolve to a full SHA: ${PORTS_REF}"
+            exit 1
+          fi
 
           matrix_nonempty() {
             [ "$(printf '%s' "$1" | jq 'length')" -gt 0 ]
@@ -135,10 +137,14 @@ jobs:
           if gh api \
               "repos/${GITHUB_REPOSITORY}/contents/nightly-state.json?ref=nightly-state" \
               >"$STATE_RESPONSE_FILE" 2>"$STATE_ERROR_FILE"; then
-            STATE_SHA="$(jq -r '.sha' "$STATE_RESPONSE_FILE")"
-            jq -r '.content' "$STATE_RESPONSE_FILE" \
+            STATE_SHA="$(jq -er '.sha' "$STATE_RESPONSE_FILE")"
+            if [ "$(jq -er '.encoding' "$STATE_RESPONSE_FILE")" != "base64" ]; then
+              echo "::error::nightly-state.json is not inline base64; it likely exceeds the Contents API size limit"
+              exit 1
+            fi
+            jq -er '.content' "$STATE_RESPONSE_FILE" \
               | tr -d '\n' | base64 --decode > state.json
-          elif grep -Eq 'HTTP[^0-9]*404' "$STATE_ERROR_FILE"; then
+          elif grep -Fq '(HTTP 404)' "$STATE_ERROR_FILE"; then
             printf '%s\n' '{"schema":1,"generation":0,"records":[]}' > state.json
           else
             cat "$STATE_ERROR_FILE" >&2
@@ -258,7 +264,7 @@ jobs:
           mkdir -p result
           printf '%s\n' "$MATRIX_ROW" > row.json
           printf '%s' "$ALLOCATION_JSON" | jq '.allocation' > allocation.json
-          PKG_VERSION="$(jq -r '.allocation.pkg_version' allocation.json)"
+          PKG_VERSION="$(jq -er '.pkg_version' allocation.json)"
           FREEBSD_MAJOR="$(jq -r '.freebsd_major' row.json)"
           VARIANT="$(jq -r '.variant' row.json)"
           PY_FLAVOR="$(jq -r '.py_flavor' row.json)"
@@ -436,5 +442,17 @@ jobs:
               -f content="$CONTENT" \
               -f branch=nightly-state >/dev/null
           fi
-          gh api "${REPO}/contents/nightly-state.json?ref=nightly-state" \
-            --jq '.content' | tr -d '\n' | base64 --decode | cmp -s nightly-state.json
+          VERIFIED=0
+          for _ in 1 2 3 4 5; do
+            if gh api "${REPO}/contents/nightly-state.json?ref=nightly-state" \
+                 --jq '.content' | tr -d '\n' | base64 --decode \
+                 | cmp -s nightly-state.json; then
+              VERIFIED=1
+              break
+            fi
+            sleep 3
+          done
+          if [ "$VERIFIED" -ne 1 ]; then
+            echo "::error::persisted nightly-state.json does not match the local state document"
+            exit 1
+          fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,15 +43,25 @@ jobs:
       build_matrix: ${{ steps.plan.outputs.build_matrix }}
       source_sha: ${{ steps.plan.outputs.source_sha }}
       ports_sha: ${{ steps.plan.outputs.ports_sha }}
+      matrix_sha: ${{ steps.plan.outputs.matrix_sha }}
       matrix_digest: ${{ steps.plan.outputs.matrix_digest }}
       source_date_epoch: ${{ steps.plan.outputs.source_date_epoch }}
     steps:
-      - name: Checkout explicit source ref
+      - name: Checkout trusted workflow tools
+        uses: actions/checkout@v6
+        with:
+          ref: devel
+          fetch-depth: 0
+          persist-credentials: false
+          path: trusted
+
+      - name: Checkout explicit source ref as package input
         uses: actions/checkout@v6
         with:
           ref: ${{ env.SOURCE_REF }}
           fetch-depth: 0
           persist-credentials: false
+          path: source
 
       - name: Resolve pinned source, Ports, and live matrices
         id: inputs
@@ -63,8 +73,10 @@ jobs:
             echo "::error::missing NIGHTLY_SOURCE_REF configuration"
             exit 1
           fi
-          SOURCE_SHA="$(git rev-parse "${SOURCE_REF}^{commit}")"
-          SOURCE_DATE_EPOCH="$(git show -s --format=%ct "$SOURCE_SHA")"
+          TRUSTED_DIR="${GITHUB_WORKSPACE}/trusted"
+          SOURCE_DIR="${GITHUB_WORKSPACE}/source"
+          SOURCE_SHA="$(git -C "$SOURCE_DIR" rev-parse HEAD)"
+          SOURCE_DATE_EPOCH="$(git -C "$SOURCE_DIR" show -s --format=%ct "$SOURCE_SHA")"
 
           case "$PORTS_REPO" in
             http://*|https://*|file://*) PORTS_URL="$PORTS_REPO" ;;
@@ -82,21 +94,31 @@ jobs:
               ;;
           esac
 
-          BUILD_MATRIX="$(sh scripts/read-version-matrix.sh --print-build)"
-          ROUTE_MATRIX="$(sh scripts/read-version-matrix.sh --print-route)"
-          BUILD_COUNT="$(printf '%s' "$BUILD_MATRIX" | jq 'length')"
-          ROUTE_COUNT="$(printf '%s' "$ROUTE_MATRIX" | jq 'length')"
-          if [ "$BUILD_COUNT" -eq 0 ] || [ "$ROUTE_COUNT" -eq 0 ]; then
+          matrix_nonempty() {
+            [ "$(printf '%s' "$1" | jq 'length')" -gt 0 ]
+          }
+          if matrix_nonempty '[]'; then
+            echo "::error::matrix gate red canary passed"
+            exit 1
+          fi
+          echo "matrix gate red canary: expected rejection"
+
+          git -C "$TRUSTED_DIR" fetch origin ci-metadata
+          MATRIX_SHA="$(git -C "$TRUSTED_DIR" rev-parse FETCH_HEAD)"
+          BUILD_MATRIX="$(sh "$TRUSTED_DIR/scripts/read-version-matrix.sh" \
+            --ref "$MATRIX_SHA" --print-build)"
+          ROUTE_MATRIX="$(sh "$TRUSTED_DIR/scripts/read-version-matrix.sh" \
+            --ref "$MATRIX_SHA" --print-route)"
+          if ! matrix_nonempty "$BUILD_MATRIX" || ! matrix_nonempty "$ROUTE_MATRIX"; then
             echo "::error::missing live BUILD/ROUTE matrix rows"
             exit 1
           fi
-          MATRIX_DIGEST="$(
-            jq -S -c -n \
-              --argjson build "$BUILD_MATRIX" \
-              --argjson route "$ROUTE_MATRIX" \
-              '{build: $build, route: $route}' \
-              | sha256sum | cut -d' ' -f1
-          )"
+          MATRIX_PAYLOAD="$(jq -S -c -n \
+            --arg matrix_sha "$MATRIX_SHA" \
+            --argjson build "$BUILD_MATRIX" \
+            --argjson route "$ROUTE_MATRIX" \
+            '{matrix_sha: $matrix_sha, build: $build, route: $route}')"
+          MATRIX_DIGEST="$(printf '%s' "$MATRIX_PAYLOAD" | sha256sum | cut -d' ' -f1)"
 
           STATE_SHA=""
           STATE_RESPONSE_FILE="$(mktemp)"
@@ -114,12 +136,12 @@ jobs:
             cat "$STATE_ERROR_FILE" >&2
             exit 1
           fi
-          python3 scripts/nightly_provenance.py validate --state state.json
+          python3 "$TRUSTED_DIR/scripts/nightly_provenance.py" validate --state state.json
 
           mkdir -p plan
           # Durable generation checks reject stale completions before state mutation.
           BUILD_DATE="$(date -u +%Y%m%d)"
-          python3 scripts/nightly_provenance.py allocate \
+          python3 "$TRUSTED_DIR/scripts/nightly_provenance.py" allocate \
             --state state.json \
             --output plan/allocation.json \
             --build-date "$BUILD_DATE" \
@@ -132,12 +154,14 @@ jobs:
           printf '%s\n' "$ROUTE_MATRIX" > plan/route-matrix.json
           printf '%s\n' "$SOURCE_SHA" > plan/source-sha
           printf '%s\n' "$PORTS_SHA" > plan/ports-sha
+          printf '%s\n' "$MATRIX_SHA" > plan/matrix-sha
           printf '%s\n' "$MATRIX_DIGEST" > plan/matrix-digest
           printf '%s\n' "$SOURCE_DATE_EPOCH" > plan/source-date-epoch
 
           {
             echo "source_sha=$SOURCE_SHA"
             echo "ports_sha=$PORTS_SHA"
+            echo "matrix_sha=$MATRIX_SHA"
             echo "matrix_digest=$MATRIX_DIGEST"
             echo "source_date_epoch=$SOURCE_DATE_EPOCH"
           } >> "$GITHUB_OUTPUT"
@@ -154,6 +178,7 @@ jobs:
             echo "allocation=$ALLOCATION"
             echo "source_sha=${{ steps.inputs.outputs.source_sha }}"
             echo "ports_sha=${{ steps.inputs.outputs.ports_sha }}"
+            echo "matrix_sha=${{ steps.inputs.outputs.matrix_sha }}"
             echo "matrix_digest=${{ steps.inputs.outputs.matrix_digest }}"
             echo "source_date_epoch=${{ steps.inputs.outputs.source_date_epoch }}"
             echo "build_matrix<<NIGHTLY_BUILD_MATRIX"
@@ -179,12 +204,21 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.prepare.outputs.build_matrix) }}
     steps:
-      - name: Checkout pinned source
+      - name: Checkout trusted workflow tools
+        uses: actions/checkout@v6
+        with:
+          ref: devel
+          fetch-depth: 0
+          persist-credentials: false
+          path: trusted
+
+      - name: Checkout pinned source as package input
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
           persist-credentials: false
+          path: source
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -206,6 +240,8 @@ jobs:
           RUN_ID: nightly-${{ github.run_id }}-${{ matrix.freebsd_major }}
           PORTS_REPO: ${{ env.PORTS_REPO }}
           PORTS_REF: ${{ env.PORTS_REF }}
+          TRUSTED_DIR: ${{ github.workspace }}/trusted
+          SOURCE_DIR: ${{ github.workspace }}/source
         run: |
           set -eu
           mkdir -p result
@@ -219,13 +255,13 @@ jobs:
           PORTS_DIR="${RUN_ROOT}/${RUN_ID}/ports"
           OUT_DIR="${RUN_ROOT}/${RUN_ID}/out"
 
-          python3 scripts/nightly_provenance.py record \
+          python3 "$TRUSTED_DIR/scripts/nightly_provenance.py" record \
             --allocation allocation.json \
             --matrix-row row.json \
             --source-date-epoch "$SOURCE_DATE_EPOCH" \
             --output build-record.json
           PKG="$(
-            sh scripts/build-leg.sh \
+            sh "$TRUSTED_DIR/scripts/build-leg.sh" \
               --ports-repo "$PORTS_REPO" \
               --ports-ref "$PORTS_REF" \
               --channel nightly \
@@ -234,7 +270,7 @@ jobs:
               --abi "FreeBSD:${FREEBSD_MAJOR}:amd64" \
               --py-flavor "$PY_FLAVOR" \
               --php "$PHP_VERSION" \
-              --local-src . \
+              --local-src "$SOURCE_DIR" \
               --pkgversion "$PKG_VERSION" \
               --ports-dir "$PORTS_DIR" \
               --out-dir "$OUT_DIR"
@@ -244,10 +280,10 @@ jobs:
             echo "::error::FreeBSD-ports checkout changed during build"
             exit 1
           fi
-          python3 - "$PKG" build-record.json <<'PY'
+          PYTHONPATH="$TRUSTED_DIR/scripts" python3 - "$PKG" build-record.json <<'PY'
           import json
           import sys
-          from scripts.pfb_pkg import validate_project_pkg
+          from pfb_pkg import validate_project_pkg
 
           validate_project_pkg(sys.argv[1], json.loads(open(sys.argv[2], encoding="utf-8").read()))
           PY
@@ -292,13 +328,14 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout pinned source for handoff validation
+      - name: Checkout trusted workflow tools for handoff validation
         if: needs.prepare.outputs.outcome == 'build'
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.prepare.outputs.source_sha }}
-          fetch-depth: 1
+          ref: devel
+          fetch-depth: 0
           persist-credentials: false
+          path: trusted
 
       - name: Download pinned plan
         if: needs.prepare.outputs.outcome == 'build'
@@ -321,10 +358,12 @@ jobs:
         env:
           SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+          MATRIX_SHA: ${{ needs.prepare.outputs.matrix_sha }}
           MATRIX_DIGEST: ${{ needs.prepare.outputs.matrix_digest }}
+          TRUSTED_DIR: ${{ github.workspace }}/trusted
         run: |
           set -eu
-          python3 scripts/nightly_provenance.py handoff \
+          python3 "$TRUSTED_DIR/scripts/nightly_provenance.py" handoff \
             --state plan/state.json \
             --allocation plan/allocation.json \
             --build-matrix plan/build-matrix.json \
@@ -332,6 +371,7 @@ jobs:
             --results-dir results \
             --source-sha "$SOURCE_SHA" \
             --ports-sha "$PORTS_SHA" \
+            --matrix-sha "$MATRIX_SHA" \
             --matrix-digest "$MATRIX_DIGEST" \
             --run-id "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
             --source-ref "$SOURCE_REF" \
@@ -339,7 +379,7 @@ jobs:
             --ports-ref "$PORTS_REF" \
             --output nightly-handoff.json
           jq '[.builds[].artifact]' nightly-handoff.json > artifacts.json
-          python3 scripts/nightly_provenance.py complete \
+          python3 "$TRUSTED_DIR/scripts/nightly_provenance.py" complete \
             --state plan/state.json \
             --candidate plan/allocation.json \
             --artifacts artifacts.json \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -344,6 +344,7 @@ jobs:
             --candidate plan/allocation.json \
             --artifacts artifacts.json \
             --run-id "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+            --expected-input-digest "$(jq -r '.allocation.input_digest' nightly-handoff.json)" \
             --output nightly-state.json
 
       - name: Upload verified publisher handoff

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,14 +99,20 @@ jobs:
           )"
 
           STATE_SHA=""
-          if STATE_RESPONSE="$(gh api \
+          STATE_RESPONSE_FILE="$(mktemp)"
+          STATE_ERROR_FILE="$(mktemp)"
+          trap 'rm -f "$STATE_RESPONSE_FILE" "$STATE_ERROR_FILE"' EXIT
+          if gh api \
               "repos/${GITHUB_REPOSITORY}/contents/nightly-state.json?ref=nightly-state" \
-              2>/dev/null)"; then
-            STATE_SHA="$(printf '%s' "$STATE_RESPONSE" | jq -r '.sha')"
-            printf '%s' "$STATE_RESPONSE" \
-              | jq -r '.content' | tr -d '\n' | base64 --decode > state.json
-          else
+              >"$STATE_RESPONSE_FILE" 2>"$STATE_ERROR_FILE"; then
+            STATE_SHA="$(jq -r '.sha' "$STATE_RESPONSE_FILE")"
+            jq -r '.content' "$STATE_RESPONSE_FILE" \
+              | tr -d '\n' | base64 --decode > state.json
+          elif grep -Eq 'HTTP[^0-9]*404' "$STATE_ERROR_FILE"; then
             printf '%s\n' '{"schema":1,"generation":0,"records":[]}' > state.json
+          else
+            cat "$STATE_ERROR_FILE" >&2
+            exit 1
           fi
           python3 scripts/nightly_provenance.py validate --state state.json
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,7 @@ jobs:
       build_matrix: ${{ steps.plan.outputs.build_matrix }}
       source_sha: ${{ steps.plan.outputs.source_sha }}
       ports_sha: ${{ steps.plan.outputs.ports_sha }}
+      tools_sha: ${{ steps.plan.outputs.tools_sha }}
       matrix_sha: ${{ steps.plan.outputs.matrix_sha }}
       matrix_digest: ${{ steps.plan.outputs.matrix_digest }}
       source_date_epoch: ${{ steps.plan.outputs.source_date_epoch }}
@@ -75,6 +76,7 @@ jobs:
           fi
           TRUSTED_DIR="${GITHUB_WORKSPACE}/trusted"
           SOURCE_DIR="${GITHUB_WORKSPACE}/source"
+          TOOLS_SHA="$(git -C "$TRUSTED_DIR" rev-parse HEAD)"
           SOURCE_SHA="$(git -C "$SOURCE_DIR" rev-parse HEAD)"
           SOURCE_DATE_EPOCH="$(git -C "$SOURCE_DIR" show -s --format=%ct "$SOURCE_SHA")"
 
@@ -97,7 +99,12 @@ jobs:
           matrix_nonempty() {
             [ "$(printf '%s' "$1" | jq 'length')" -gt 0 ]
           }
-          if matrix_nonempty '[]'; then
+          matrix_gate() {
+            if ! matrix_nonempty "$1" || ! matrix_nonempty "$2"; then
+              return 1
+            fi
+          }
+          if matrix_gate '[]' '[]'; then
             echo "::error::matrix gate red canary passed"
             exit 1
           fi
@@ -105,19 +112,20 @@ jobs:
 
           git -C "$TRUSTED_DIR" fetch origin ci-metadata
           MATRIX_SHA="$(git -C "$TRUSTED_DIR" rev-parse FETCH_HEAD)"
-          BUILD_MATRIX="$(sh "$TRUSTED_DIR/scripts/read-version-matrix.sh" \
+          BUILD_MATRIX="$(cd "$TRUSTED_DIR" && sh scripts/read-version-matrix.sh \
             --ref "$MATRIX_SHA" --print-build)"
-          ROUTE_MATRIX="$(sh "$TRUSTED_DIR/scripts/read-version-matrix.sh" \
+          ROUTE_MATRIX="$(cd "$TRUSTED_DIR" && sh scripts/read-version-matrix.sh \
             --ref "$MATRIX_SHA" --print-route)"
-          if ! matrix_nonempty "$BUILD_MATRIX" || ! matrix_nonempty "$ROUTE_MATRIX"; then
+          if ! matrix_gate "$BUILD_MATRIX" "$ROUTE_MATRIX"; then
             echo "::error::missing live BUILD/ROUTE matrix rows"
             exit 1
           fi
           MATRIX_PAYLOAD="$(jq -S -c -n \
+            --arg tools_sha "$TOOLS_SHA" \
             --arg matrix_sha "$MATRIX_SHA" \
             --argjson build "$BUILD_MATRIX" \
             --argjson route "$ROUTE_MATRIX" \
-            '{matrix_sha: $matrix_sha, build: $build, route: $route}')"
+            '{tools_sha: $tools_sha, matrix_sha: $matrix_sha, build: $build, route: $route}')"
           MATRIX_DIGEST="$(printf '%s' "$MATRIX_PAYLOAD" | sha256sum | cut -d' ' -f1)"
 
           STATE_SHA=""
@@ -154,6 +162,7 @@ jobs:
           printf '%s\n' "$ROUTE_MATRIX" > plan/route-matrix.json
           printf '%s\n' "$SOURCE_SHA" > plan/source-sha
           printf '%s\n' "$PORTS_SHA" > plan/ports-sha
+          printf '%s\n' "$TOOLS_SHA" > plan/tools-sha
           printf '%s\n' "$MATRIX_SHA" > plan/matrix-sha
           printf '%s\n' "$MATRIX_DIGEST" > plan/matrix-digest
           printf '%s\n' "$SOURCE_DATE_EPOCH" > plan/source-date-epoch
@@ -161,6 +170,7 @@ jobs:
           {
             echo "source_sha=$SOURCE_SHA"
             echo "ports_sha=$PORTS_SHA"
+            echo "tools_sha=$TOOLS_SHA"
             echo "matrix_sha=$MATRIX_SHA"
             echo "matrix_digest=$MATRIX_DIGEST"
             echo "source_date_epoch=$SOURCE_DATE_EPOCH"
@@ -178,6 +188,7 @@ jobs:
             echo "allocation=$ALLOCATION"
             echo "source_sha=${{ steps.inputs.outputs.source_sha }}"
             echo "ports_sha=${{ steps.inputs.outputs.ports_sha }}"
+            echo "tools_sha=${{ steps.inputs.outputs.tools_sha }}"
             echo "matrix_sha=${{ steps.inputs.outputs.matrix_sha }}"
             echo "matrix_digest=${{ steps.inputs.outputs.matrix_digest }}"
             echo "source_date_epoch=${{ steps.inputs.outputs.source_date_epoch }}"
@@ -207,7 +218,7 @@ jobs:
       - name: Checkout trusted workflow tools
         uses: actions/checkout@v6
         with:
-          ref: devel
+          ref: ${{ needs.prepare.outputs.tools_sha }}
           fetch-depth: 0
           persist-credentials: false
           path: trusted
@@ -332,7 +343,7 @@ jobs:
         if: needs.prepare.outputs.outcome == 'build'
         uses: actions/checkout@v6
         with:
-          ref: devel
+          ref: ${{ needs.prepare.outputs.tools_sha }}
           fetch-depth: 0
           persist-credentials: false
           path: trusted
@@ -358,6 +369,7 @@ jobs:
         env:
           SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+          TOOLS_SHA: ${{ needs.prepare.outputs.tools_sha }}
           MATRIX_SHA: ${{ needs.prepare.outputs.matrix_sha }}
           MATRIX_DIGEST: ${{ needs.prepare.outputs.matrix_digest }}
           TRUSTED_DIR: ${{ github.workspace }}/trusted
@@ -371,6 +383,7 @@ jobs:
             --results-dir results \
             --source-sha "$SOURCE_SHA" \
             --ports-sha "$PORTS_SHA" \
+            --tools-sha "$TOOLS_SHA" \
             --matrix-sha "$MATRIX_SHA" \
             --matrix-digest "$MATRIX_DIGEST" \
             --run-id "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \

--- a/docs/misc/release-channels.md
+++ b/docs/misc/release-channels.md
@@ -84,6 +84,8 @@ The caller selects the source line before generation. Stable, Testing, and Edge 
 configured `release/X.Y`; Nightly receives an explicit pinned source SHA. Source identity is
 immutable and exact.
 Every generated artifact records source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
+The matrix digest includes one pinned `ci-metadata` commit SHA used for both BUILD and ROUTE
+rows.
 Missing, malformed, conflicting, or changed observations fail closed before mutation.
 
 The branch-independent workflow in `.github/workflows/nightly.yml` uses the same pinned-input

--- a/docs/misc/release-channels.md
+++ b/docs/misc/release-channels.md
@@ -86,6 +86,13 @@ immutable and exact.
 Every generated artifact records source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
 Missing, malformed, conflicting, or changed observations fail closed before mutation.
 
+The branch-independent workflow in `.github/workflows/nightly.yml` uses the same pinned-input
+path for scheduled and manual runs. Scheduled runs require repository variable
+`NIGHTLY_SOURCE_REF`; manual runs require `source_ref`. The workflow serializes allocation,
+build, validation, and handoff, stores completed allocation/artifact identities in the
+`nightly-state` branch, and uploads `nightly-handoff.json` for the publisher. It does not
+publish a catalog, create a tag or Release, or mutate the FreeBSD-ports tree.
+
 ## Maintained lines and fixes
 
 Stable, Testing, and Edge destinations derive from each tagged package's grammar and exact

--- a/docs/misc/release-channels.md
+++ b/docs/misc/release-channels.md
@@ -84,8 +84,8 @@ The caller selects the source line before generation. Stable, Testing, and Edge 
 configured `release/X.Y`; Nightly receives an explicit pinned source SHA. Source identity is
 immutable and exact.
 Every generated artifact records source SHA, FreeBSD-ports SHA, and matrix/dependency digest.
-The matrix digest includes one pinned `ci-metadata` commit SHA used for both BUILD and ROUTE
-rows.
+The immutable input digest also binds one trusted-tools commit SHA and one pinned
+`ci-metadata` commit SHA used for both BUILD and ROUTE rows.
 Missing, malformed, conflicting, or changed observations fail closed before mutation.
 
 The branch-independent workflow in `.github/workflows/nightly.yml` uses the same pinned-input

--- a/scripts/nightly_provenance.py
+++ b/scripts/nightly_provenance.py
@@ -309,6 +309,7 @@ def build_handoff(
     results: Sequence[Mapping[str, object]],
     source_sha: str,
     ports_sha: str,
+    matrix_sha: str,
     matrix_digest: str,
     run_id: str,
     source_ref: str = "",
@@ -323,6 +324,8 @@ def build_handoff(
         raise ProvenanceError("handoff requires a build allocation")
     if (candidate.allocation.source_sha, candidate.allocation.ports_sha) != (source_sha, ports_sha):
         raise ProvenanceError("handoff source identity does not match allocation")
+    if not _SHA.fullmatch(matrix_sha):
+        raise ProvenanceError("handoff matrix_sha is malformed")
     if not _DIGEST.fullmatch(matrix_digest):
         raise ProvenanceError("handoff matrix_digest is malformed")
     expected_input_digest = combined_nightly_input_digest(source_sha, ports_sha, matrix_digest)
@@ -398,6 +401,7 @@ def build_handoff(
         "allocation": asdict(candidate.allocation),
         "source_sha": source_sha,
         "ports_sha": ports_sha,
+        "matrix_sha": matrix_sha,
         "matrix_digest": matrix_digest,
         "build_matrix": normalized_build_rows,
         "route_matrix": normalized_route_rows,
@@ -410,8 +414,17 @@ def _read_json(path: Path, *, default: object | None = None) -> object:
         if default is not None:
             return default
         raise ProvenanceError(f"missing JSON file: {path}")
+
+    def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        value: dict[str, object] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ProvenanceError(f"duplicate JSON key: {key}")
+            value[key] = item
+        return value
+
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        return json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate_keys)
     except (OSError, json.JSONDecodeError) as exc:
         raise ProvenanceError(f"invalid JSON file {path}: {exc}") from exc
 
@@ -508,6 +521,7 @@ def _command_handoff(args: argparse.Namespace) -> int:
         results=result_values,
         source_sha=args.source_sha,
         ports_sha=args.ports_sha,
+        matrix_sha=args.matrix_sha,
         matrix_digest=args.matrix_digest,
         run_id=args.run_id,
         source_ref=args.source_ref,
@@ -557,6 +571,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     handoff_parser.add_argument("--results-dir", required=True)
     handoff_parser.add_argument("--source-sha", required=True)
     handoff_parser.add_argument("--ports-sha", required=True)
+    handoff_parser.add_argument("--matrix-sha", required=True)
     handoff_parser.add_argument("--matrix-digest", required=True)
     handoff_parser.add_argument("--run-id", required=True)
     handoff_parser.add_argument("--source-ref", default="")

--- a/scripts/nightly_provenance.py
+++ b/scripts/nightly_provenance.py
@@ -309,6 +309,7 @@ def build_handoff(
     results: Sequence[Mapping[str, object]],
     source_sha: str,
     ports_sha: str,
+    tools_sha: str,
     matrix_sha: str,
     matrix_digest: str,
     run_id: str,
@@ -324,6 +325,8 @@ def build_handoff(
         raise ProvenanceError("handoff requires a build allocation")
     if (candidate.allocation.source_sha, candidate.allocation.ports_sha) != (source_sha, ports_sha):
         raise ProvenanceError("handoff source identity does not match allocation")
+    if not _SHA.fullmatch(tools_sha):
+        raise ProvenanceError("handoff tools_sha is malformed")
     if not _SHA.fullmatch(matrix_sha):
         raise ProvenanceError("handoff matrix_sha is malformed")
     if not _DIGEST.fullmatch(matrix_digest):
@@ -401,6 +404,7 @@ def build_handoff(
         "allocation": asdict(candidate.allocation),
         "source_sha": source_sha,
         "ports_sha": ports_sha,
+        "tools_sha": tools_sha,
         "matrix_sha": matrix_sha,
         "matrix_digest": matrix_digest,
         "build_matrix": normalized_build_rows,
@@ -521,6 +525,7 @@ def _command_handoff(args: argparse.Namespace) -> int:
         results=result_values,
         source_sha=args.source_sha,
         ports_sha=args.ports_sha,
+        tools_sha=args.tools_sha,
         matrix_sha=args.matrix_sha,
         matrix_digest=args.matrix_digest,
         run_id=args.run_id,
@@ -571,6 +576,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     handoff_parser.add_argument("--results-dir", required=True)
     handoff_parser.add_argument("--source-sha", required=True)
     handoff_parser.add_argument("--ports-sha", required=True)
+    handoff_parser.add_argument("--tools-sha", required=True)
     handoff_parser.add_argument("--matrix-sha", required=True)
     handoff_parser.add_argument("--matrix-digest", required=True)
     handoff_parser.add_argument("--run-id", required=True)

--- a/scripts/nightly_provenance.py
+++ b/scripts/nightly_provenance.py
@@ -199,6 +199,7 @@ def complete(
     artifacts: Sequence[Mapping[str, str]],
     *,
     run_id: str,
+    expected_input_digest: str | None = None,
 ) -> dict[str, object]:
     """Append one verified build, or replay an identical completion idempotently."""
     normalized = validate_state(dict(state))
@@ -208,6 +209,11 @@ def complete(
         validate_nightly_allocation(candidate.allocation)
     except (TypeError, ValueError) as exc:
         raise ProvenanceError(f"invalid candidate allocation: {exc}") from exc
+    if expected_input_digest is not None:
+        if not _DIGEST.fullmatch(expected_input_digest):
+            raise ProvenanceError("expected input digest is malformed")
+        if candidate.allocation.input_digest != expected_input_digest:
+            raise ProvenanceError("completion input digest does not match verified handoff")
     if not isinstance(run_id, str) or not run_id or len(run_id) > 128 or not run_id.isascii():
         raise ProvenanceError("run_id must be non-empty ASCII of at most 128 characters")
     allocation = candidate.allocation
@@ -319,6 +325,9 @@ def build_handoff(
         raise ProvenanceError("handoff source identity does not match allocation")
     if not _DIGEST.fullmatch(matrix_digest):
         raise ProvenanceError("handoff matrix_digest is malformed")
+    expected_input_digest = combined_nightly_input_digest(source_sha, ports_sha, matrix_digest)
+    if candidate.allocation.input_digest != expected_input_digest:
+        raise ProvenanceError("handoff input digest does not match pinned inputs")
     if not build_rows or not route_rows:
         raise ProvenanceError("BUILD and ROUTE matrices must not be empty")
 
@@ -443,7 +452,13 @@ def _command_complete(args: argparse.Namespace) -> int:
     )
     if type(candidate.generation) is not int:
         raise ProvenanceError("candidate generation must be an integer")
-    result = complete(state, candidate, artifacts if isinstance(artifacts, list) else [], run_id=args.run_id)
+    result = complete(
+        state,
+        candidate,
+        artifacts if isinstance(artifacts, list) else [],
+        run_id=args.run_id,
+        expected_input_digest=args.expected_input_digest,
+    )
     _write_json(Path(args.output), result)
     return 0
 
@@ -525,6 +540,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     complete_parser.add_argument("--candidate", required=True)
     complete_parser.add_argument("--artifacts", required=True)
     complete_parser.add_argument("--run-id", required=True)
+    complete_parser.add_argument("--expected-input-digest")
     complete_parser.add_argument("--output", required=True)
     complete_parser.set_defaults(handler=_command_complete)
     record_parser = subparsers.add_parser("record")

--- a/scripts/nightly_provenance.py
+++ b/scripts/nightly_provenance.py
@@ -438,6 +438,8 @@ def _write_json(path: Path, value: object) -> None:
 
 
 def _parse_date(value: str) -> date:
+    if not isinstance(value, str) or re.fullmatch(r"[0-9]{8}", value) is None:
+        raise ProvenanceError("build date must be YYYYMMDD")
     try:
         return date(int(value[:4]), int(value[4:6]), int(value[6:]))
     except (ValueError, IndexError) as exc:
@@ -469,10 +471,12 @@ def _command_complete(args: argparse.Namespace) -> int:
     )
     if type(candidate.generation) is not int:
         raise ProvenanceError("candidate generation must be an integer")
+    if not isinstance(artifacts, list):
+        raise ProvenanceError("artifacts JSON must be an array")
     result = complete(
         state,
         candidate,
-        artifacts if isinstance(artifacts, list) else [],
+        artifacts,
         run_id=args.run_id,
         expected_input_digest=args.expected_input_digest,
     )
@@ -502,6 +506,8 @@ def _command_handoff(args: argparse.Namespace) -> int:
     route_rows = _read_json(Path(args.route_matrix))
     if not isinstance(allocation_raw, dict) or not isinstance(allocation_raw.get("allocation"), dict):
         raise ProvenanceError("allocation JSON is malformed")
+    if not isinstance(state, dict):
+        raise ProvenanceError("state JSON must be an object")
     if not isinstance(build_rows, list) or not isinstance(route_rows, list):
         raise ProvenanceError("matrix JSON must be arrays")
     candidate = Candidate(
@@ -519,7 +525,7 @@ def _command_handoff(args: argparse.Namespace) -> int:
         result_values.append(result)
     handoff = build_handoff(
         candidate=candidate,
-        state=state if isinstance(state, dict) else {},
+        state=state,
         build_rows=build_rows,
         route_rows=route_rows,
         results=result_values,

--- a/scripts/nightly_provenance.py
+++ b/scripts/nightly_provenance.py
@@ -1,0 +1,563 @@
+"""Durable allocation and verified handoff state for branch-independent Nightly."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, replace
+from datetime import date
+from pathlib import Path
+from typing import Mapping, Sequence
+
+try:
+    from scripts.pfb_pkg import PkgError, build_input_digest, validate_build_matrix_row, validate_build_record
+    from scripts.release_version import (
+        NightlyAllocation,
+        allocate_nightly,
+        combined_nightly_input_digest,
+        validate_nightly_allocation,
+    )
+except ImportError:  # script directory is also a direct import root
+    from pfb_pkg import PkgError, build_input_digest, validate_build_matrix_row, validate_build_record
+    from release_version import (
+        NightlyAllocation,
+        allocate_nightly,
+        combined_nightly_input_digest,
+        validate_nightly_allocation,
+    )
+
+
+class ProvenanceError(ValueError):
+    """Durable Nightly state or completion is invalid."""
+
+
+_STATE_FIELDS = {"schema", "generation", "records"}
+_RECORD_FIELDS = {"allocation", "artifacts", "run_id"}
+_ALLOCATION_FIELDS = {
+    "outcome",
+    "portversion",
+    "portrevision",
+    "pkg_version",
+    "source_sha",
+    "ports_sha",
+    "input_digest",
+}
+_ARTIFACT_FIELDS = {"abi", "name", "sha256"}
+_SHA = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+_ABI = re.compile(r"^FreeBSD:[0-9]+:(?:[A-Za-z0-9._+-]+|\*)$")
+
+
+@dataclass(frozen=True)
+class Candidate:
+    allocation: NightlyAllocation
+    generation: int
+
+
+def empty_state() -> dict[str, object]:
+    """Return an empty, versioned provenance state."""
+    return {"schema": 1, "generation": 0, "records": []}
+
+
+def replace_allocation(allocation: NightlyAllocation, **changes: object) -> NightlyAllocation:
+    """Return a test- and tooling-friendly changed allocation."""
+    return replace(allocation, **changes)
+
+
+def _exact_fields(value: Mapping[str, object], expected: set[str], label: str) -> None:
+    keys = set(value)
+    if keys != expected:
+        raise ProvenanceError(
+            f"{label} exact fields required (missing={sorted(expected - keys)}, unknown={sorted(keys - expected)})"
+        )
+
+
+def _validate_sha(value: object, label: str) -> str:
+    if not isinstance(value, str) or not _SHA.fullmatch(value):
+        raise ProvenanceError(f"{label} must be lowercase 40- or 64-character hex")
+    return value
+
+
+def _validate_allocation(value: object) -> NightlyAllocation:
+    if not isinstance(value, dict):
+        raise ProvenanceError("record allocation must be an object")
+    _exact_fields(value, _ALLOCATION_FIELDS, "allocation")
+    try:
+        allocation = NightlyAllocation(**value)
+    except (TypeError, ValueError) as exc:
+        raise ProvenanceError(f"invalid allocation: {exc}") from exc
+    try:
+        validate_nightly_allocation(allocation)
+    except (TypeError, ValueError) as exc:
+        raise ProvenanceError(f"invalid allocation: {exc}") from exc
+    if allocation.outcome != "build":
+        raise ProvenanceError("durable records may contain only build allocations")
+    return allocation
+
+
+def _validate_artifacts(value: object) -> list[dict[str, str]]:
+    if not isinstance(value, list) or not value:
+        raise ProvenanceError("artifacts must be a non-empty list")
+    artifacts: list[dict[str, str]] = []
+    seen_abis: set[str] = set()
+    for item in value:
+        if not isinstance(item, dict):
+            raise ProvenanceError("artifact must be an object")
+        _exact_fields(item, _ARTIFACT_FIELDS, "artifact")
+        abi, name, digest = item["abi"], item["name"], item["sha256"]
+        if not isinstance(abi, str) or not _ABI.fullmatch(abi):
+            raise ProvenanceError("artifact.abi is malformed")
+        if abi in seen_abis:
+            raise ProvenanceError("artifact ABI entries must be unique")
+        seen_abis.add(abi)
+        if not isinstance(name, str) or not name or not name.isascii():
+            raise ProvenanceError("artifact.name must be non-empty ASCII")
+        if not isinstance(digest, str) or not _DIGEST.fullmatch(digest):
+            raise ProvenanceError("artifact.sha256 must be lowercase 64-character hex")
+        artifacts.append({"abi": abi, "name": name, "sha256": digest})
+    return sorted(artifacts, key=lambda item: item["abi"])
+
+
+def validate_state(state: object) -> dict[str, object]:
+    """Validate and normalize durable state without changing its values."""
+    if not isinstance(state, dict):
+        raise ProvenanceError("state must be an object")
+    _exact_fields(state, _STATE_FIELDS, "state")
+    if state["schema"] != 1:
+        raise ProvenanceError("state schema must be 1")
+    generation = state["generation"]
+    if type(generation) is not int or generation < 0:
+        raise ProvenanceError("state generation must be a non-negative integer")
+    records = state["records"]
+    if not isinstance(records, list) or generation != len(records):
+        raise ProvenanceError("state generation must equal record count")
+
+    normalized_records: list[dict[str, object]] = []
+    identities: set[tuple[str, str, str]] = set()
+    versions: set[str] = set()
+    for record in records:
+        if not isinstance(record, dict):
+            raise ProvenanceError("state record must be an object")
+        _exact_fields(record, _RECORD_FIELDS, "record")
+        allocation = _validate_allocation(record["allocation"])
+        artifacts = _validate_artifacts(record["artifacts"])
+        run_id = record["run_id"]
+        if not isinstance(run_id, str) or not run_id or len(run_id) > 128 or not run_id.isascii():
+            raise ProvenanceError("record.run_id must be non-empty ASCII of at most 128 characters")
+        identity = (allocation.source_sha, allocation.ports_sha, allocation.input_digest)
+        if identity in identities:
+            raise ProvenanceError("duplicate Nightly input identity")
+        if allocation.pkg_version in versions:
+            raise ProvenanceError("Nightly version collision")
+        identities.add(identity)
+        versions.add(allocation.pkg_version)
+        normalized_records.append({"allocation": asdict(allocation), "artifacts": artifacts, "run_id": run_id})
+    return {"schema": 1, "generation": generation, "records": normalized_records}
+
+
+def _allocations(state: Mapping[str, object]) -> tuple[NightlyAllocation, ...]:
+    records = state["records"]
+    assert isinstance(records, list)
+    return tuple(_validate_allocation(record["allocation"]) for record in records if isinstance(record, dict))
+
+
+def allocate_candidate(
+    state: Mapping[str, object],
+    *,
+    build_date: date,
+    source_sha: str,
+    ports_sha: str,
+    matrix_digest: str,
+) -> Candidate:
+    """Allocate from durable state, returning an unchanged candidate for a no-op."""
+    normalized = validate_state(dict(state))
+    if not isinstance(matrix_digest, str) or not _DIGEST.fullmatch(matrix_digest):
+        raise ProvenanceError("matrix_digest must be lowercase 64-character hex")
+    try:
+        input_digest = combined_nightly_input_digest(source_sha, ports_sha, matrix_digest)
+        allocation = allocate_nightly(
+            build_date,
+            _validate_sha(source_sha, "source_sha"),
+            _validate_sha(ports_sha, "ports_sha"),
+            input_digest,
+            _allocations(normalized),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ProvenanceError(str(exc)) from exc
+    return Candidate(allocation=allocation, generation=int(normalized["generation"]))
+
+
+def _artifact_signature(artifacts: Sequence[Mapping[str, str]]) -> tuple[tuple[str, str, str], ...]:
+    return tuple(sorted((item["abi"], item["name"], item["sha256"]) for item in artifacts))
+
+
+def complete(
+    state: Mapping[str, object],
+    candidate: Candidate,
+    artifacts: Sequence[Mapping[str, str]],
+    *,
+    run_id: str,
+) -> dict[str, object]:
+    """Append one verified build, or replay an identical completion idempotently."""
+    normalized = validate_state(dict(state))
+    if not isinstance(candidate, Candidate):
+        raise TypeError("candidate must be Candidate")
+    try:
+        validate_nightly_allocation(candidate.allocation)
+    except (TypeError, ValueError) as exc:
+        raise ProvenanceError(f"invalid candidate allocation: {exc}") from exc
+    if not isinstance(run_id, str) or not run_id or len(run_id) > 128 or not run_id.isascii():
+        raise ProvenanceError("run_id must be non-empty ASCII of at most 128 characters")
+    allocation = candidate.allocation
+    normalized_artifacts = _validate_artifacts(list(artifacts)) if artifacts else []
+
+    records = normalized["records"]
+    assert isinstance(records, list)
+    identity = (allocation.source_sha, allocation.ports_sha, allocation.input_digest)
+    for record in records:
+        assert isinstance(record, dict)
+        existing = _validate_allocation(record["allocation"])
+        existing_identity = (existing.source_sha, existing.ports_sha, existing.input_digest)
+        if existing_identity == identity:
+            existing_artifacts = _validate_artifacts(record["artifacts"])
+            if normalized_artifacts and _artifact_signature(existing_artifacts) != _artifact_signature(
+                normalized_artifacts
+            ):
+                raise ProvenanceError("artifact bytes collide for an existing Nightly input")
+            return normalized
+
+    if allocation.outcome != "build":
+        if normalized_artifacts:
+            raise ProvenanceError("unchanged candidate does not match durable artifacts")
+        return normalized
+    if candidate.generation != normalized["generation"]:
+        raise ProvenanceError("stale Nightly completion cannot replace newer state")
+    if any(
+        isinstance(record, dict)
+        and isinstance(record.get("allocation"), dict)
+        and record["allocation"].get("pkg_version") == allocation.pkg_version
+        for record in records
+    ):
+        raise ProvenanceError("Nightly version collision for different inputs")
+    if not normalized_artifacts:
+        raise ProvenanceError("build completion requires artifacts")
+    normalized["records"].append(
+        {
+            "allocation": asdict(allocation),
+            "artifacts": normalized_artifacts,
+            "run_id": run_id,
+        }
+    )
+    normalized["generation"] = int(normalized["generation"]) + 1
+    return validate_state(normalized)
+
+
+def make_build_record(
+    *,
+    allocation: NightlyAllocation,
+    matrix_row: Mapping[str, object],
+    source_date_epoch: int,
+) -> dict[str, object]:
+    """Create one digest-bound portable-builder record for a Nightly leg."""
+    if allocation.outcome != "build":
+        raise ProvenanceError("build records require a build allocation")
+    try:
+        row = validate_build_matrix_row(dict(matrix_row))
+    except (PkgError, TypeError, ValueError) as exc:
+        raise ProvenanceError(str(exc)) from exc
+    if type(source_date_epoch) is not int or source_date_epoch < 0:
+        raise ProvenanceError("source_date_epoch must be a non-negative integer")
+    version = allocation.pkg_version
+    major_minor = ".".join(str(row["pfsense_version"]).split(".")[:2])
+    record: dict[str, object] = {
+        "schema": 1,
+        "channel": "nightly",
+        "release_line": "nightly",
+        "classification": "nightly",
+        "source_tag": None,
+        "source_sha": allocation.source_sha,
+        "canonical_package_version": version,
+        "native_recipe_identity": "pfSense-pkg-pfBlockerNG-nightly",
+        "emitted_identity": "pfSense-pkg-pfBlockerNG",
+        "matrix_row": row,
+        "freebsd_ports_sha": allocation.ports_sha,
+        "route": f"nightly/{str(row['variant']).lower()}-{major_minor}",
+        "source_date_epoch": source_date_epoch,
+        "build_input_digest": "",
+    }
+    record["build_input_digest"] = build_input_digest(record)
+    try:
+        return validate_build_record(record)
+    except (PkgError, TypeError, ValueError) as exc:
+        raise ProvenanceError(str(exc)) from exc
+
+
+def build_handoff(
+    *,
+    candidate: Candidate,
+    state: Mapping[str, object],
+    build_rows: Sequence[Mapping[str, object]],
+    route_rows: Sequence[Mapping[str, object]],
+    results: Sequence[Mapping[str, object]],
+    source_sha: str,
+    ports_sha: str,
+    matrix_digest: str,
+    run_id: str,
+    source_ref: str = "",
+    ports_repo: str = "",
+    ports_ref: str = "",
+) -> dict[str, object]:
+    """Validate every matrix/build result and return publisher input."""
+    normalized_state = validate_state(dict(state))
+    if candidate.generation != normalized_state["generation"]:
+        raise ProvenanceError("handoff candidate generation is stale")
+    if candidate.allocation.outcome != "build":
+        raise ProvenanceError("handoff requires a build allocation")
+    if (candidate.allocation.source_sha, candidate.allocation.ports_sha) != (source_sha, ports_sha):
+        raise ProvenanceError("handoff source identity does not match allocation")
+    if not _DIGEST.fullmatch(matrix_digest):
+        raise ProvenanceError("handoff matrix_digest is malformed")
+    if not build_rows or not route_rows:
+        raise ProvenanceError("BUILD and ROUTE matrices must not be empty")
+
+    normalized_build_rows = [validate_build_matrix_row(dict(row)) for row in build_rows]
+    normalized_route_rows: list[dict[str, object]] = []
+    for raw_row in route_rows:
+        route_row = dict(raw_row)
+        role = route_row.get("role")
+        ci = route_row.pop("ci", None)
+        if ci is not None and type(ci) is not bool:
+            raise ProvenanceError("ROUTE matrix ci must be boolean")
+        if role == "route-only":
+            del route_row["role"]
+        normalized = validate_build_matrix_row(route_row)
+        if role is not None:
+            normalized["role"] = role
+        if ci is not None:
+            normalized["ci"] = ci
+        normalized_route_rows.append(normalized)
+    expected_rows = {str(row["freebsd_major"]): row for row in normalized_build_rows}
+    if len(expected_rows) != len(normalized_build_rows):
+        raise ProvenanceError("BUILD matrix contains duplicate FreeBSD majors")
+    if len(results) != len(expected_rows):
+        raise ProvenanceError("BUILD result count does not match BUILD matrix")
+
+    builds: list[dict[str, object]] = []
+    seen_majors: set[str] = set()
+    for result in results:
+        if not isinstance(result, dict):
+            raise ProvenanceError("BUILD result must be an object")
+        if set(result) != {"matrix_row", "record", "artifact"}:
+            raise ProvenanceError("BUILD result has unexpected fields")
+        row = validate_build_matrix_row(dict(result["matrix_row"]))
+        major = str(row["freebsd_major"])
+        if major in seen_majors or expected_rows.get(major) != row:
+            raise ProvenanceError("BUILD result row is missing, duplicated, or changed")
+        record = validate_build_record(result["record"], abi=f"FreeBSD:{major}:amd64")
+        if record["matrix_row"] != row:
+            raise ProvenanceError("build record matrix row does not match BUILD result")
+        if (
+            record["canonical_package_version"] != candidate.allocation.pkg_version
+            or record["source_sha"] != source_sha
+            or record["freebsd_ports_sha"] != ports_sha
+        ):
+            raise ProvenanceError("BUILD result provenance does not match Nightly allocation")
+        artifact = _validate_artifacts([result["artifact"]])[0]
+        if artifact["name"] != f"pfSense-pkg-pfBlockerNG-{candidate.allocation.pkg_version}.pkg":
+            raise ProvenanceError("BUILD artifact name does not match Nightly allocation")
+        seen_majors.add(major)
+        builds.append({"matrix_row": row, "record": record, "artifact": artifact})
+    if seen_majors != set(expected_rows):
+        raise ProvenanceError("BUILD results do not cover every BUILD matrix row")
+
+    route_keys: set[tuple[object, object]] = set()
+    for row in normalized_route_rows:
+        key = (row["variant"], row["pfsense_version"])
+        if key in route_keys:
+            raise ProvenanceError("ROUTE matrix contains duplicate version identity")
+        route_keys.add(key)
+
+    return {
+        "schema": 1,
+        "kind": "nightly-handoff",
+        "run_id": run_id,
+        "source_ref": source_ref,
+        "ports_repo": ports_repo,
+        "ports_ref": ports_ref,
+        "allocation": asdict(candidate.allocation),
+        "source_sha": source_sha,
+        "ports_sha": ports_sha,
+        "matrix_digest": matrix_digest,
+        "build_matrix": normalized_build_rows,
+        "route_matrix": normalized_route_rows,
+        "builds": sorted(builds, key=lambda item: str(item["matrix_row"]["freebsd_major"])),
+    }
+
+
+def _read_json(path: Path, *, default: object | None = None) -> object:
+    if not path.exists():
+        if default is not None:
+            return default
+        raise ProvenanceError(f"missing JSON file: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProvenanceError(f"invalid JSON file {path}: {exc}") from exc
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date(int(value[:4]), int(value[4:6]), int(value[6:]))
+    except (ValueError, IndexError) as exc:
+        raise ProvenanceError("build date must be YYYYMMDD") from exc
+
+
+def _command_allocate(args: argparse.Namespace) -> int:
+    state = _read_json(Path(args.state), default=empty_state())
+    candidate = allocate_candidate(
+        state,
+        build_date=_parse_date(args.build_date),
+        source_sha=args.source_sha,
+        ports_sha=args.ports_sha,
+        matrix_digest=args.matrix_digest,
+    )
+    _write_json(Path(args.output), {"allocation": asdict(candidate.allocation), "generation": candidate.generation})
+    return 0
+
+
+def _command_complete(args: argparse.Namespace) -> int:
+    state = _read_json(Path(args.state), default=empty_state())
+    candidate_raw = _read_json(Path(args.candidate))
+    artifacts = _read_json(Path(args.artifacts))
+    if not isinstance(candidate_raw, dict) or not isinstance(candidate_raw.get("allocation"), dict):
+        raise ProvenanceError("candidate JSON is malformed")
+    candidate = Candidate(
+        allocation=_validate_allocation(candidate_raw["allocation"]),
+        generation=candidate_raw.get("generation", -1),
+    )
+    if type(candidate.generation) is not int:
+        raise ProvenanceError("candidate generation must be an integer")
+    result = complete(state, candidate, artifacts if isinstance(artifacts, list) else [], run_id=args.run_id)
+    _write_json(Path(args.output), result)
+    return 0
+
+
+def _command_record(args: argparse.Namespace) -> int:
+    allocation_raw = _read_json(Path(args.allocation))
+    row_raw = _read_json(Path(args.matrix_row))
+    if not isinstance(allocation_raw, dict) or not isinstance(row_raw, dict):
+        raise ProvenanceError("allocation or matrix row JSON is malformed")
+    allocation = _validate_allocation(allocation_raw)
+    record = make_build_record(
+        allocation=allocation,
+        matrix_row=row_raw,
+        source_date_epoch=args.source_date_epoch,
+    )
+    _write_json(Path(args.output), record)
+    return 0
+
+
+def _command_handoff(args: argparse.Namespace) -> int:
+    state = _read_json(Path(args.state))
+    allocation_raw = _read_json(Path(args.allocation))
+    build_rows = _read_json(Path(args.build_matrix))
+    route_rows = _read_json(Path(args.route_matrix))
+    if not isinstance(allocation_raw, dict) or not isinstance(allocation_raw.get("allocation"), dict):
+        raise ProvenanceError("allocation JSON is malformed")
+    if not isinstance(build_rows, list) or not isinstance(route_rows, list):
+        raise ProvenanceError("matrix JSON must be arrays")
+    candidate = Candidate(
+        allocation=_validate_allocation(allocation_raw["allocation"]),
+        generation=allocation_raw.get("generation", -1),
+    )
+    if type(candidate.generation) is not int:
+        raise ProvenanceError("allocation generation must be an integer")
+    result_dir = Path(args.results_dir)
+    result_values: list[Mapping[str, object]] = []
+    for result_path in sorted(result_dir.glob("*/result.json")):
+        result = _read_json(result_path)
+        if not isinstance(result, dict):
+            raise ProvenanceError(f"malformed BUILD result: {result_path}")
+        result_values.append(result)
+    handoff = build_handoff(
+        candidate=candidate,
+        state=state if isinstance(state, dict) else {},
+        build_rows=build_rows,
+        route_rows=route_rows,
+        results=result_values,
+        source_sha=args.source_sha,
+        ports_sha=args.ports_sha,
+        matrix_digest=args.matrix_digest,
+        run_id=args.run_id,
+        source_ref=args.source_ref,
+        ports_repo=args.ports_repo,
+        ports_ref=args.ports_ref,
+    )
+    _write_json(Path(args.output), handoff)
+    return 0
+
+
+def _command_validate(args: argparse.Namespace) -> int:
+    value = _read_json(Path(args.state))
+    validate_state(value)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    allocate_parser = subparsers.add_parser("allocate")
+    allocate_parser.add_argument("--state", required=True)
+    allocate_parser.add_argument("--output", required=True)
+    allocate_parser.add_argument("--build-date", required=True)
+    allocate_parser.add_argument("--source-sha", required=True)
+    allocate_parser.add_argument("--ports-sha", required=True)
+    allocate_parser.add_argument("--matrix-digest", required=True)
+    allocate_parser.set_defaults(handler=_command_allocate)
+    complete_parser = subparsers.add_parser("complete")
+    complete_parser.add_argument("--state", required=True)
+    complete_parser.add_argument("--candidate", required=True)
+    complete_parser.add_argument("--artifacts", required=True)
+    complete_parser.add_argument("--run-id", required=True)
+    complete_parser.add_argument("--output", required=True)
+    complete_parser.set_defaults(handler=_command_complete)
+    record_parser = subparsers.add_parser("record")
+    record_parser.add_argument("--allocation", required=True)
+    record_parser.add_argument("--matrix-row", required=True)
+    record_parser.add_argument("--source-date-epoch", required=True, type=int)
+    record_parser.add_argument("--output", required=True)
+    record_parser.set_defaults(handler=_command_record)
+    handoff_parser = subparsers.add_parser("handoff")
+    handoff_parser.add_argument("--state", required=True)
+    handoff_parser.add_argument("--allocation", required=True)
+    handoff_parser.add_argument("--build-matrix", required=True)
+    handoff_parser.add_argument("--route-matrix", required=True)
+    handoff_parser.add_argument("--results-dir", required=True)
+    handoff_parser.add_argument("--source-sha", required=True)
+    handoff_parser.add_argument("--ports-sha", required=True)
+    handoff_parser.add_argument("--matrix-digest", required=True)
+    handoff_parser.add_argument("--run-id", required=True)
+    handoff_parser.add_argument("--source-ref", default="")
+    handoff_parser.add_argument("--ports-repo", default="")
+    handoff_parser.add_argument("--ports-ref", default="")
+    handoff_parser.add_argument("--output", required=True)
+    handoff_parser.set_defaults(handler=_command_handoff)
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("--state", required=True)
+    validate_parser.set_defaults(handler=_command_validate)
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except (OSError, PkgError, ProvenanceError, TypeError, ValueError) as exc:
+        print(f"nightly provenance: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_nightly_handoff.py
+++ b/tests/test_nightly_handoff.py
@@ -1,0 +1,101 @@
+"""Verified Nightly build-record and publisher-handoff contract."""
+
+from __future__ import annotations
+
+from datetime import date
+from hashlib import sha256
+
+import pytest
+
+from scripts import nightly_provenance as np
+
+
+def _row(
+    version: str = "2.8.0",
+    *,
+    role: str | None = None,
+    ci: bool | None = None,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "pfsense_version": version,
+        "channel": "CE",
+        "freebsd_version": "15.0-RELEASE",
+        "freebsd_major": "15",
+        "php_version": "8.3",
+        "py_flavor": "py311",
+        "variant": "CE",
+        "status": "GA",
+        "extra_pkgs": [],
+    }
+    if role is not None:
+        row["role"] = role
+    if ci is not None:
+        row["ci"] = ci
+    return row
+
+
+def _plan() -> tuple[np.Candidate, dict[str, object], dict[str, object]]:
+    state = np.empty_state()
+    candidate = np.allocate_candidate(
+        state,
+        build_date=date(2026, 8, 4),
+        source_sha="a" * 40,
+        ports_sha="b" * 40,
+        matrix_digest="c" * 64,
+    )
+    record = np.make_build_record(
+        allocation=candidate.allocation,
+        matrix_row=_row(),
+        source_date_epoch=1_800_000_000,
+    )
+    result = {
+        "matrix_row": _row(),
+        "record": record,
+        "artifact": {
+            "abi": "FreeBSD:15:*",
+            "name": f"pfSense-pkg-pfBlockerNG-{candidate.allocation.pkg_version}.pkg",
+            "sha256": sha256(b"pkg").hexdigest(),
+        },
+    }
+    return candidate, state, result
+
+
+def test_handoff_accepts_complete_build_and_route_rows() -> None:
+    candidate, state, result = _plan()
+
+    handoff = np.build_handoff(
+        candidate=candidate,
+        state=state,
+        build_rows=[_row()],
+        route_rows=[_row(ci=True), _row("2.7.0", role="route-only", ci=False)],
+        results=[result],
+        source_sha="a" * 40,
+        ports_sha="b" * 40,
+        matrix_digest="c" * 64,
+        run_id="123",
+    )
+
+    assert handoff["kind"] == "nightly-handoff"
+    builds = handoff["builds"]
+    route_matrix = handoff["route_matrix"]
+    assert isinstance(builds, list) and len(builds) == 1
+    assert isinstance(route_matrix, list)
+    assert isinstance(route_matrix[0], dict) and route_matrix[0]["ci"] is True
+    assert isinstance(route_matrix[1], dict) and route_matrix[1]["role"] == "route-only"
+
+
+def test_handoff_rejects_missing_build_result() -> None:
+    candidate, state, _ = _plan()
+
+    with pytest.raises(np.ProvenanceError, match="result count"):
+        np.build_handoff(
+            candidate=candidate,
+            state=state,
+            build_rows=[_row()],
+            route_rows=[_row()],
+            results=[],
+            source_sha="a" * 40,
+            ports_sha="b" * 40,
+            matrix_digest="c" * 64,
+            run_id="123",
+        )

--- a/tests/test_nightly_handoff.py
+++ b/tests/test_nightly_handoff.py
@@ -71,12 +71,14 @@ def test_handoff_accepts_complete_build_and_route_rows() -> None:
         results=[result],
         source_sha="a" * 40,
         ports_sha="b" * 40,
+        tools_sha="e" * 40,
         matrix_sha="d" * 40,
         matrix_digest="c" * 64,
         run_id="123",
     )
 
     assert handoff["kind"] == "nightly-handoff"
+    assert handoff["tools_sha"] == "e" * 40
     assert handoff["matrix_sha"] == "d" * 40
     builds = handoff["builds"]
     route_matrix = handoff["route_matrix"]
@@ -98,6 +100,7 @@ def test_handoff_rejects_missing_build_result() -> None:
             results=[],
             source_sha="a" * 40,
             ports_sha="b" * 40,
+            tools_sha="e" * 40,
             matrix_sha="d" * 40,
             matrix_digest="c" * 64,
             run_id="123",
@@ -120,6 +123,7 @@ def test_handoff_rejects_forged_input_digest() -> None:
             results=[result],
             source_sha="a" * 40,
             ports_sha="b" * 40,
+            tools_sha="e" * 40,
             matrix_sha="d" * 40,
             matrix_digest="c" * 64,
             run_id="123",

--- a/tests/test_nightly_handoff.py
+++ b/tests/test_nightly_handoff.py
@@ -99,3 +99,24 @@ def test_handoff_rejects_missing_build_result() -> None:
             matrix_digest="c" * 64,
             run_id="123",
         )
+
+
+def test_handoff_rejects_forged_input_digest() -> None:
+    candidate, state, result = _plan()
+    forged = np.Candidate(
+        allocation=np.replace_allocation(candidate.allocation, input_digest="f" * 64),
+        generation=candidate.generation,
+    )
+
+    with pytest.raises(np.ProvenanceError, match="input digest"):
+        np.build_handoff(
+            candidate=forged,
+            state=state,
+            build_rows=[_row()],
+            route_rows=[_row(ci=True)],
+            results=[result],
+            source_sha="a" * 40,
+            ports_sha="b" * 40,
+            matrix_digest="c" * 64,
+            run_id="123",
+        )

--- a/tests/test_nightly_handoff.py
+++ b/tests/test_nightly_handoff.py
@@ -71,11 +71,13 @@ def test_handoff_accepts_complete_build_and_route_rows() -> None:
         results=[result],
         source_sha="a" * 40,
         ports_sha="b" * 40,
+        matrix_sha="d" * 40,
         matrix_digest="c" * 64,
         run_id="123",
     )
 
     assert handoff["kind"] == "nightly-handoff"
+    assert handoff["matrix_sha"] == "d" * 40
     builds = handoff["builds"]
     route_matrix = handoff["route_matrix"]
     assert isinstance(builds, list) and len(builds) == 1
@@ -96,6 +98,7 @@ def test_handoff_rejects_missing_build_result() -> None:
             results=[],
             source_sha="a" * 40,
             ports_sha="b" * 40,
+            matrix_sha="d" * 40,
             matrix_digest="c" * 64,
             run_id="123",
         )
@@ -117,6 +120,7 @@ def test_handoff_rejects_forged_input_digest() -> None:
             results=[result],
             source_sha="a" * 40,
             ports_sha="b" * 40,
+            matrix_sha="d" * 40,
             matrix_digest="c" * 64,
             run_id="123",
         )

--- a/tests/test_nightly_handoff.py
+++ b/tests/test_nightly_handoff.py
@@ -86,6 +86,8 @@ def test_handoff_accepts_complete_build_and_route_rows() -> None:
     assert isinstance(route_matrix, list)
     assert isinstance(route_matrix[0], dict) and route_matrix[0]["ci"] is True
     assert isinstance(route_matrix[1], dict) and route_matrix[1]["role"] == "route-only"
+    assert route_matrix[1]["ci"] is False
+    assert "role" not in route_matrix[0]
 
 
 def test_handoff_rejects_missing_build_result() -> None:

--- a/tests/test_nightly_provenance.py
+++ b/tests/test_nightly_provenance.py
@@ -1,0 +1,143 @@
+"""Durable Nightly allocation and completion contract."""
+
+from __future__ import annotations
+
+from datetime import date
+from hashlib import sha256
+from typing import Any
+
+import pytest
+
+from scripts import nightly_provenance as np
+
+SOURCE_A = "a" * 40
+SOURCE_B = "b" * 40
+PORTS_A = "c" * 40
+PORTS_B = "d" * 40
+MATRIX_A = "e" * 64
+MATRIX_B = "f" * 64
+
+
+def _artifact(allocation: Any, abi: str = "FreeBSD:15:*", payload: bytes = b"pkg") -> dict[str, str]:
+    return {
+        "abi": abi,
+        "name": f"pfSense-pkg-pfBlockerNG-{allocation.pkg_version}.pkg",
+        "sha256": sha256(payload).hexdigest(),
+    }
+
+
+def _candidate(
+    state: dict[str, object],
+    *,
+    build_date: date = date(2026, 8, 4),
+    source_sha: str = SOURCE_A,
+    ports_sha: str = PORTS_A,
+    matrix_digest: str = MATRIX_A,
+) -> Any:
+    return np.allocate_candidate(
+        state,
+        build_date=build_date,
+        source_sha=source_sha,
+        ports_sha=ports_sha,
+        matrix_digest=matrix_digest,
+    )
+
+
+def test_empty_state_allocates_first_changed_input() -> None:
+    candidate = _candidate(np.empty_state())
+
+    assert candidate.allocation.pkg_version == "20260804"
+    assert candidate.allocation.outcome == "build"
+    assert candidate.generation == 0
+
+
+def test_unchanged_input_is_noop_even_after_skipped_calendar_days() -> None:
+    first = _candidate(np.empty_state())
+    state = np.complete(
+        np.empty_state(),
+        first,
+        [_artifact(first.allocation)],
+        run_id="100",
+    )
+
+    retry = _candidate(state, build_date=date(2026, 8, 7))
+
+    assert retry.allocation.outcome == "unchanged"
+    assert retry.allocation.pkg_version == "20260804"
+    assert retry.generation == 1
+
+
+def test_changed_inputs_allocate_same_day_revisions_and_next_day_reset() -> None:
+    first = _candidate(np.empty_state())
+    state_one = np.complete(np.empty_state(), first, [_artifact(first.allocation)], run_id="100")
+    second = _candidate(state_one, source_sha=SOURCE_B)
+    state_two = np.complete(state_one, second, [_artifact(second.allocation)], run_id="101")
+    third = _candidate(state_two, ports_sha=PORTS_B, matrix_digest=MATRIX_B)
+    state_three = np.complete(state_two, third, [_artifact(third.allocation)], run_id="102")
+    next_day = _candidate(
+        state_three,
+        build_date=date(2026, 8, 5),
+        source_sha=SOURCE_B,
+        ports_sha=PORTS_B,
+        matrix_digest=MATRIX_B,
+    )
+
+    assert second.allocation.pkg_version == "20260804_1"
+    assert third.allocation.pkg_version == "20260804_2"
+    assert next_day.allocation.pkg_version == "20260805"
+
+
+def test_retry_is_idempotent_and_does_not_append_duplicate_state() -> None:
+    first = _candidate(np.empty_state())
+    state = np.complete(np.empty_state(), first, [_artifact(first.allocation)], run_id="100")
+    retry = _candidate(state)
+    replay = np.complete(state, retry, [_artifact(retry.allocation)], run_id="100")
+
+    assert replay == state
+
+
+def test_stale_completion_cannot_replace_newer_state() -> None:
+    first = _candidate(np.empty_state())
+    state_one = np.complete(np.empty_state(), first, [_artifact(first.allocation)], run_id="100")
+    stale = _candidate(state_one, source_sha=SOURCE_B)
+    newer = _candidate(state_one, ports_sha=PORTS_B)
+    state_two = np.complete(state_one, newer, [_artifact(newer.allocation)], run_id="102")
+
+    with pytest.raises(np.ProvenanceError, match="stale"):
+        np.complete(state_two, stale, [_artifact(stale.allocation)], run_id="101")
+
+
+def test_same_version_with_different_input_or_bytes_fails_closed() -> None:
+    first = _candidate(np.empty_state())
+    state = np.complete(np.empty_state(), first, [_artifact(first.allocation)], run_id="100")
+
+    forged = np.Candidate(
+        allocation=np.replace_allocation(first.allocation, source_sha=SOURCE_B),
+        generation=state["generation"],  # type: ignore[arg-type]
+    )
+    with pytest.raises(np.ProvenanceError, match="collision"):
+        np.complete(state, forged, [_artifact(forged.allocation)], run_id="101")
+
+    different_bytes = _candidate(np.empty_state())
+    with pytest.raises(np.ProvenanceError, match="artifact"):
+        np.complete(state, different_bytes, [_artifact(different_bytes.allocation, payload=b"other")], run_id="100")
+
+
+def test_ports_only_identity_is_part_of_digest() -> None:
+    first = _candidate(np.empty_state())
+    changed = _candidate(np.empty_state(), ports_sha=PORTS_B)
+
+    assert first.allocation.input_digest != changed.allocation.input_digest
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"schema": 2, "generation": 0, "records": []},
+        {"schema": 1, "generation": -1, "records": []},
+        {"schema": 1, "generation": 0, "records": [{}]},
+    ],
+)
+def test_malformed_durable_state_fails_closed(state: dict[str, object]) -> None:
+    with pytest.raises((TypeError, ValueError, np.ProvenanceError)):
+        np.validate_state(state)

--- a/tests/test_nightly_provenance.py
+++ b/tests/test_nightly_provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 from hashlib import sha256
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -141,6 +142,14 @@ def test_ports_only_identity_is_part_of_digest() -> None:
     changed = _candidate(np.empty_state(), ports_sha=PORTS_B)
 
     assert first.allocation.input_digest != changed.allocation.input_digest
+
+
+def test_duplicate_json_keys_fail_closed(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    state_path.write_text('{"schema": 1, "schema": 1}', encoding="utf-8")
+
+    with pytest.raises(np.ProvenanceError, match="duplicate JSON key"):
+        np._read_json(state_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_nightly_provenance.py
+++ b/tests/test_nightly_provenance.py
@@ -123,6 +123,19 @@ def test_same_version_with_different_input_or_bytes_fails_closed() -> None:
         np.complete(state, different_bytes, [_artifact(different_bytes.allocation, payload=b"other")], run_id="100")
 
 
+def test_completion_rejects_digest_not_verified_by_handoff() -> None:
+    first = _candidate(np.empty_state())
+
+    with pytest.raises(np.ProvenanceError, match="completion input digest"):
+        np.complete(
+            np.empty_state(),
+            first,
+            [_artifact(first.allocation)],
+            run_id="100",
+            expected_input_digest="f" * 64,
+        )
+
+
 def test_ports_only_identity_is_part_of_digest() -> None:
     first = _candidate(np.empty_state())
     changed = _candidate(np.empty_state(), ports_sha=PORTS_B)

--- a/tests/test_nightly_provenance.py
+++ b/tests/test_nightly_provenance.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from dataclasses import asdict
 from datetime import date
 from hashlib import sha256
 from pathlib import Path
@@ -150,6 +152,47 @@ def test_duplicate_json_keys_fail_closed(tmp_path: Path) -> None:
 
     with pytest.raises(np.ProvenanceError, match="duplicate JSON key"):
         np._read_json(state_path)
+
+
+@pytest.mark.parametrize("value", [" 20260804", "+20260804", "2026080", "２０２６０８０４"])
+def test_build_date_requires_eight_ascii_digits(value: str) -> None:
+    with pytest.raises(np.ProvenanceError, match="build date"):
+        np._parse_date(value)
+
+
+def test_complete_rejects_malformed_artifacts_json(tmp_path: Path) -> None:
+    first = _candidate(np.empty_state())
+    state = np.complete(np.empty_state(), first, [_artifact(first.allocation)], run_id="100")
+    retry = _candidate(state)
+    state_path = tmp_path / "state.json"
+    candidate_path = tmp_path / "candidate.json"
+    artifacts_path = tmp_path / "artifacts.json"
+    output_path = tmp_path / "output.json"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    candidate_path.write_text(
+        json.dumps({"allocation": asdict(retry.allocation), "generation": retry.generation}),
+        encoding="utf-8",
+    )
+    artifacts_path.write_text("{}", encoding="utf-8")
+
+    assert (
+        np.main(
+            [
+                "complete",
+                "--state",
+                str(state_path),
+                "--candidate",
+                str(candidate_path),
+                "--artifacts",
+                str(artifacts_path),
+                "--run-id",
+                "100",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 1
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -1,0 +1,41 @@
+"""Static contract for the branch-independent Nightly workflow."""
+
+from pathlib import Path
+
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "nightly.yml"
+ALERT_WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "nightly-failure-alert.yml"
+
+
+def test_nightly_workflow_exists_and_is_branch_independent() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "name: Nightly snapshot" in text
+    assert "workflow_dispatch:" in text
+    assert "schedule:" in text
+    assert "NIGHTLY_SOURCE_REF: ${{ vars.NIGHTLY_SOURCE_REF }}" in text
+    assert "source_ref:" in text
+    assert "source_sha:" in text
+    assert "git rev-parse" in text
+    assert "cancel-in-progress: false" in text
+    assert "read-version-matrix.sh" in text
+    assert "--print-build" in text
+    assert "--print-route" in text
+    assert "build-record" in text
+    assert "pkgversion" in text
+    assert "actions/upload-artifact@" in text
+    assert "nightly-handoff-" in text
+    assert "nightly-state" in text
+    assert "contents: write" in text
+    assert "always()" in text
+    assert "missing" in text.lower()
+    assert "failed" in text.lower()
+    assert "stale" in text.lower()
+
+    forbidden = ("gh release", "git tag", "git push", "release notes", "PORTVERSION")
+    assert not any(token in text for token in forbidden), "Nightly workflow must not publish or mutate Ports"
+
+
+def test_nightly_failure_alert_watches_snapshot_workflow() -> None:
+    text = ALERT_WORKFLOW.read_text(encoding="utf-8")
+
+    assert '- "Nightly snapshot"' in text

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -27,6 +27,20 @@ def test_nightly_workflow_exists_and_is_branch_independent() -> None:
     assert "nightly-state" in text
     assert "contents: write" in text
     assert "always()" in text
+    assert "::error::missing live BUILD/ROUTE matrix rows" in text
+    assert "::error::BUILD matrix failed or did not complete successfully" in text
+    assert 'nightly_provenance.py" handoff' in text
+    assert "--state plan/state.json" in text
+    assert "--allocation plan/allocation.json" in text
+    assert "--expected-input-digest" in text
+    assert "PORTS_REF_COUNT" in text
+    assert "^[0-9a-f]{40}$" in text
+    assert ".encoding" in text
+    assert "(HTTP 404)" in text
+    assert "VERIFIED=0" in text
+    assert "for _ in 1 2 3 4 5" in text
+    assert "persisted nightly-state.json does not match" in text
+    assert "jq -er '.pkg_version' allocation.json" in text
 
     forbidden = ("gh release", "git tag", "git push", "release notes", "PORTVERSION")
     assert not any(token in text for token in forbidden), "Nightly workflow must not publish or mutate Ports"

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -39,19 +39,22 @@ def test_matrix_gate_red_canary_guards_live_matrix_enforcement() -> None:
     step = text[start:end]
 
     canary = (
-        "if matrix_nonempty '[]'; then\n"
+        "if matrix_gate '[]' '[]'; then\n"
         '            echo "::error::matrix gate red canary passed"\n'
         "            exit 1\n"
         "          fi"
     )
     assert "matrix_nonempty() {" in step
+    assert "matrix_gate() {" in step
     assert canary in step
     assert 'echo "matrix gate red canary: expected rejection"' in step
-    assert 'BUILD_MATRIX="$(sh "$TRUSTED_DIR/scripts/read-version-matrix.sh" \\' in step
-    assert 'ROUTE_MATRIX="$(sh "$TRUSTED_DIR/scripts/read-version-matrix.sh" \\' in step
-    assert 'if ! matrix_nonempty "$BUILD_MATRIX" || ! matrix_nonempty "$ROUTE_MATRIX"; then' in step
+    assert '(cd "$TRUSTED_DIR" && sh scripts/read-version-matrix.sh \\' in step
+    assert 'if ! matrix_gate "$BUILD_MATRIX" "$ROUTE_MATRIX"; then' in step
     assert 'echo "::error::missing live BUILD/ROUTE matrix rows"' in step
-    assert step.index(canary) < step.index('if ! matrix_nonempty "$BUILD_MATRIX"')
+    assert "TOOLS_SHA=" in step
+    assert "matrix_sha" in step
+    assert "tools_sha" in step
+    assert step.index(canary) < step.index('if ! matrix_gate "$BUILD_MATRIX" "$ROUTE_MATRIX"')
 
 
 def test_nightly_failure_alert_watches_snapshot_workflow() -> None:

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -15,7 +15,7 @@ def test_nightly_workflow_exists_and_is_branch_independent() -> None:
     assert "NIGHTLY_SOURCE_REF: ${{ vars.NIGHTLY_SOURCE_REF }}" in text
     assert "source_ref:" in text
     assert "source_sha:" in text
-    assert "git rev-parse" in text
+    assert "rev-parse HEAD" in text
     assert "cancel-in-progress: false" in text
     assert "read-version-matrix.sh" in text
     assert "--print-build" in text
@@ -27,12 +27,31 @@ def test_nightly_workflow_exists_and_is_branch_independent() -> None:
     assert "nightly-state" in text
     assert "contents: write" in text
     assert "always()" in text
-    assert "missing" in text.lower()
-    assert "failed" in text.lower()
-    assert "stale" in text.lower()
 
     forbidden = ("gh release", "git tag", "git push", "release notes", "PORTVERSION")
     assert not any(token in text for token in forbidden), "Nightly workflow must not publish or mutate Ports"
+
+
+def test_matrix_gate_red_canary_guards_live_matrix_enforcement() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    start = text.index("      - name: Resolve pinned source, Ports, and live matrices")
+    end = text.index("\n      - name: Select plan outcome", start)
+    step = text[start:end]
+
+    canary = (
+        "if matrix_nonempty '[]'; then\n"
+        '            echo "::error::matrix gate red canary passed"\n'
+        "            exit 1\n"
+        "          fi"
+    )
+    assert "matrix_nonempty() {" in step
+    assert canary in step
+    assert 'echo "matrix gate red canary: expected rejection"' in step
+    assert 'BUILD_MATRIX="$(sh "$TRUSTED_DIR/scripts/read-version-matrix.sh" \\' in step
+    assert 'ROUTE_MATRIX="$(sh "$TRUSTED_DIR/scripts/read-version-matrix.sh" \\' in step
+    assert 'if ! matrix_nonempty "$BUILD_MATRIX" || ! matrix_nonempty "$ROUTE_MATRIX"; then' in step
+    assert 'echo "::error::missing live BUILD/ROUTE matrix rows"' in step
+    assert step.index(canary) < step.index('if ! matrix_nonempty "$BUILD_MATRIX"')
 
 
 def test_nightly_failure_alert_watches_snapshot_workflow() -> None:

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -34,6 +34,10 @@ def test_nightly_workflow_exists_and_is_branch_independent() -> None:
     assert "--allocation plan/allocation.json" in text
     assert "--expected-input-digest" in text
     assert "PORTS_REF_COUNT" in text
+    assert "PORTS_HEAD_SHA" in text
+    assert "PORTS_TAG_SHA" in text
+    assert "refs/tags/${PORTS_REF}^{}" in text
+    assert "LC_ALL=C sort -u" in text
     assert "^[0-9a-f]{40}$" in text
     assert ".encoding" in text
     assert "(HTTP 404)" in text


### PR DESCRIPTION
## Summary
- add serialized scheduled/manual Nightly workflow with explicit pinned source and Ports inputs
- persist allocation and artifact identity in authenticated nightly-state handoff
- validate BUILD/ROUTE matrix completeness, package provenance, stale completion, and artifact collisions
- upload verified nightly-handoff.json for publisher follow-up

## Validation
- targeted Nightly pytest contract tests
- existing snapshot, release mutation, and package provenance tests
- shellspec build-leg contract
- actionlint
- canonical repository gates

Fixes #2144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated nightly snapshot processing with scheduled and on-demand runs.
  - Nightly builds now validate source, tools, ports, and platform combinations before publishing results.
  - Added durable tracking for repeatable runs, revisions, and safe retries.
  - Added verified handoffs with artifact and input integrity checks.
  - Added failure and recovery monitoring for nightly snapshot runs.

- **Bug Fixes**
  - Improved handling of unchanged inputs, invalid references, incomplete results, and stale updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->