### PR TITLE
pfblockerng: stage ET/IQRisk gunzip output before publishing

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -211,17 +211,26 @@ function pfb_apply_geoip_orig_pipeline(string $source, string $orig, string $mir
 }
 
 function pfb_apply_gunzip_orig_pipeline(string $source, string $orig, ?callable $consumer = NULL): bool {
-	$retval = 1;
-	$normalized = FALSE;
+	$published = FALSE;
 	if (file_exists($source)) {
+		// issue #2115: stage beside the active file — a redirect onto $orig truncates
+		// the last-good publication before gunzip's exit status can be read.
+		$staged = "{$orig}.tmp";
 		$output = array();
-		exec('/usr/bin/gunzip -c ' . escapeshellarg($source) . ' > ' . escapeshellarg($orig), $output, $retval);
-		$normalized = pfb_apply_trailing_newline_ok($orig);
+		exec('/usr/bin/gunzip -c ' . escapeshellarg($source) . ' > ' . escapeshellarg($staged), $output, $retval);
+		if ($retval === 0 && pfb_apply_trailing_newline_ok($staged)) {
+			$published = @rename($staged, $orig);
+		}
+		if (!$published) {
+			@unlink($staged);
+			return FALSE;
+		}
 	}
-	if ($consumer !== NULL) {
+	// A missing source is the supported reuse path: consume whatever is already published.
+	if ($consumer !== NULL && file_exists($orig)) {
 		$consumer($orig);
 	}
-	return $retval === 0 && $normalized;
+	return $published;
 }
 
 /**

--- a/tests/php/GunzipTrailingNewlineWiringTest.php
+++ b/tests/php/GunzipTrailingNewlineWiringTest.php
@@ -46,10 +46,29 @@ final class GunzipTrailingNewlineWiringTest extends TestCase
 		$this->assertSame("iprep-data\n", file_get_contents($orig));
 	}
 
-	public function testGunzipFailurePreservesLegacyEtConsumerAttempt(): void
+	/** A published feed stays in service when the next download decompresses badly. */
+	public function testCorruptGzipKeepsLastGoodOrigAndSkipsConsumer(): void
 	{
 		$raw = "{$this->dir}/bad.raw";
 		$orig = "{$this->dir}/bad.orig";
+		$events = [];
+		$this->assertNotFalse(file_put_contents($orig, "last-good\n"));
+		$this->assertNotFalse(file_put_contents($raw, 'not-gzip'));
+		$this->assertSame("last-good\n", file_get_contents($orig));
+
+		$this->assertFalse(pfb_apply_gunzip_orig_pipeline($raw, $orig,
+			static function () use (&$events): void { $events[] = 'consume'; }
+		));
+
+		$this->assertSame("last-good\n", file_get_contents($orig));
+		$this->assertSame([], $events);
+	}
+
+	/** A first-ever download that fails publishes nothing rather than an empty feed. */
+	public function testCorruptGzipWithoutPriorOrigPublishesNothing(): void
+	{
+		$raw = "{$this->dir}/fresh.raw";
+		$orig = "{$this->dir}/fresh.orig";
 		$events = [];
 		$this->assertNotFalse(file_put_contents($raw, 'not-gzip'));
 
@@ -57,18 +76,47 @@ final class GunzipTrailingNewlineWiringTest extends TestCase
 			static function () use (&$events): void { $events[] = 'consume'; }
 		));
 
-		$this->assertSame(['consume'], $events);
-		$this->assertFileExists($raw);
-		$this->assertFileExists($orig);
+		$this->assertFileDoesNotExist($orig);
+		$this->assertSame([], $events);
 	}
 
-	public function testMissingRawStillRunsLegacyEtConsumer(): void
+	/** Staging a failed decompression leaves the feed directory as it was found. */
+	public function testFailedGunzipLeavesNoTemporaryFileBehind(): void
+	{
+		$raw = "{$this->dir}/litter.raw";
+		$orig = "{$this->dir}/litter.orig";
+		$this->assertNotFalse(file_put_contents($raw, 'not-gzip'));
+
+		pfb_apply_gunzip_orig_pipeline($raw, $orig, NULL);
+
+		$this->assertSame([$raw], glob("{$this->dir}/*"));
+	}
+
+	/** The supported reuse case: no fresh download, prior publication feeds the consumer. */
+	public function testMissingRawReusesPriorOrigForConsumer(): void
+	{
+		$orig = "{$this->dir}/reuse.orig";
+		$events = [];
+		$this->assertNotFalse(file_put_contents($orig, "prior\n"));
+
+		$this->assertFalse(pfb_apply_gunzip_orig_pipeline("{$this->dir}/missing.raw", $orig,
+			static function (string $published) use (&$events): void {
+				$events[] = (string) file_get_contents($published);
+			}
+		));
+
+		$this->assertSame(["prior\n"], $events);
+	}
+
+	/** Nothing to reuse and nothing downloaded means nothing to consume. */
+	public function testMissingRawWithoutPriorOrigSkipsConsumer(): void
 	{
 		$events = [];
 		$this->assertFalse(pfb_apply_gunzip_orig_pipeline("{$this->dir}/missing.raw", "{$this->dir}/missing.orig",
 			static function () use (&$events): void { $events[] = 'consume'; }
 		));
-		$this->assertSame(['consume'], $events);
+
+		$this->assertSame([], $events);
 	}
 
 	/** The ET reuse path lives in the #993 sync monolith; behavior runs above. */


### PR DESCRIPTION
## Problem

`pfb_apply_gunzip_orig_pipeline()` decompressed the ET/IQRisk download straight onto the
active `.orig` file. Shell redirection truncates the target when the pipeline is set up,
which happens before gunzip's exit status is available, so a corrupt download destroyed the
last-good publication. The consumer callback then ran unconditionally and handed the
resulting empty file to the ET script.

Both faults are reachable on the supported path: a failed or corrupt upstream download is
sufficient, no hand-crafted input is required.

## Change

Decompress into a same-directory temporary file, normalize its trailing newline, and
`rename()` it over `.orig` only once both succeed. On failure the staged file is removed,
the prior `.orig` is left untouched, and the consumer is skipped.

The intentional missing-raw reuse path is preserved: when no `.raw` is present the prior
publication is still handed to the consumer. When there is nothing published to reuse, the
consumer no longer runs against a file that does not exist.

## Tests

`tests/php/GunzipTrailingNewlineWiringTest.php` gains four cases and reshapes the two that
pinned the previous behaviour. Red-before/green-after was executed with the test file frozen
byte-identical across both runs (`git hash-object` = `bf8bf44ba603d61644f9fc35c04c72600423b341`).

Red run against untouched production code — 4 failures, each the defect:

| Test | Red evidence |
| --- | --- |
| `testCorruptGzipKeepsLastGoodOrigAndSkipsConsumer` | `.orig` went from `last-good\n` to empty |
| `testCorruptGzipWithoutPriorOrigPublishesNothing` | empty `.orig` published |
| `testFailedGunzipLeavesNoTemporaryFileBehind` | `.orig` left behind by the failed run |
| `testMissingRawWithoutPriorOrigSkipsConsumer` | consumer invoked with nothing published |

`testMissingRawReusesPriorOrigForConsumer` passed at red and stays green, pinning the reuse
path against the fix.

Green run: `OK (7 tests, 30 assertions)`. Canonical gates pass (`php -l`, PHPStan, PHPCS).
The full PHPUnit suite reports the same 197 errors / 9 failures on this branch as on an
untouched `origin/devel` checkout in the same sandbox — a local environment artifact, with
CI green on `devel`.

Fixes #2115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuDuuZDtfqmqZkTpC1MkNs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves the last known-good configuration when decompression fails.
  * Prevents incomplete or invalid files from replacing valid data.
  * Cleans up temporary files after failed decompression.
  * Reuses existing valid data when the source file is unavailable.
  * Prevents downstream processing when no valid data is available.

* **Tests**
  * Added coverage for decompression failures, missing source files, data reuse, and temporary-file cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->