### PR TITLE
tests: pin the gunzip exit status half of the publish gate

### DIFF
--- a/tests/php/GunzipTrailingNewlineWiringTest.php
+++ b/tests/php/GunzipTrailingNewlineWiringTest.php
@@ -92,6 +92,25 @@ final class GunzipTrailingNewlineWiringTest extends TestCase
 		$this->assertSame([$raw], glob("{$this->dir}/*"));
 	}
 
+	/** A corrupt stream whose salvageable output still looks well-formed must not publish. */
+	public function testNonZeroGunzipExitBlocksPublicationOfPlausibleOutput(): void
+	{
+		$raw = "{$this->dir}/crc.raw";
+		$orig = "{$this->dir}/crc.orig";
+		$events = [];
+		$gz = (string) gzencode("replacement-line\n");
+		$gz[strlen($gz) - 5] = chr(ord($gz[strlen($gz) - 5]) ^ 0xFF);
+		$this->assertNotFalse(file_put_contents($raw, $gz));
+		$this->assertNotFalse(file_put_contents($orig, "last-good\n"));
+
+		$this->assertFalse(pfb_apply_gunzip_orig_pipeline($raw, $orig,
+			static function () use (&$events): void { $events[] = 'consume'; }
+		));
+
+		$this->assertSame("last-good\n", file_get_contents($orig));
+		$this->assertSame([], $events);
+	}
+
 	/** The supported reuse case: no fresh download, prior publication feeds the consumer. */
 	public function testMissingRawReusesPriorOrigForConsumer(): void
 	{


### PR DESCRIPTION
## Problem

Follow-up to #2115 / PR #2168, which landed while its second review pass was still running. That review found a coverage gap in the tests that shipped with it, and this PR closes it. No production code changes.

Every failure case in `GunzipTrailingNewlineWiringTest` fed gunzip input that produced **empty** output, so `pfb_apply_trailing_newline_ok()` rejected the staged file on its own and nothing exercised the exit-status half of the publish condition independently.

Executed mutation proof: removing `$retval === 0` from

```php
if ($retval === 0 && pfb_apply_trailing_newline_ok($staged)) {
```

left the whole suite green at `OK (7 tests, 30 assertions)`. That mutant reintroduces exactly the class of bug #2115 was filed over — a download that decompresses partially, exits nonzero, and gets published anyway over the last-good data.

## Change

One test case. Corrupting the CRC trailer of an otherwise valid gzip member produces a nonzero exit whose salvageable output is non-empty and newline-terminated, so the trailing-newline check passes and only the exit status can block publication.

Deterministic across zlib versions: the last eight bytes of a gzip member are always CRC32 followed by ISIZE, so flipping a bit at `strlen($gz) - 5` always lands in the CRC field regardless of payload length. No binary fixture needed.

## Evidence

| Run | Result |
| --- | --- |
| New test against shipped code | `OK (8 tests, 36 assertions)` |
| New test against the mutant (retval condition removed) | fails — `Failed asserting that true is false` |

The mutant that survived the previous suite now dies, and the assertion is proven non-vacuous rather than merely green.

Related: #2115, #2168, and #2169 (sibling gzip sites in `pfb_download()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuDuuZDtfqmqZkTpC1MkNs
