### PR TITLE
tests: drain stdin in the lint probe's fake timeout fixtures

### DIFF
--- a/tests/php/LintDiagnosticsTest.php
+++ b/tests/php/LintDiagnosticsTest.php
@@ -68,6 +68,16 @@ final class LintDiagnosticsTest extends TestCase
 		return $path;
 	}
 
+	/**
+	 * A fake `timeout` that consumes stdin before exiting. A fixture that exits without
+	 * reading races the probe's write loop: when the child wins, the write EPIPEs and the
+	 * probe reports a launch failure instead of the exit code under test.
+	 */
+	private function drainingFixture(string $body): string
+	{
+		return $this->fixture("cat >/dev/null\n{$body}");
+	}
+
 	// --- pfb_lint_parse_sh_stderr ---------------------------------------
 
 	public function testShParserExtractsLineMappedSyntaxError(): void
@@ -193,7 +203,7 @@ final class LintDiagnosticsTest extends TestCase
 
 	public function testShDiagnosticsSilentZeroExitIsEmpty(): void
 	{
-		$timeoutFixture = $this->fixture('exit 0');
+		$timeoutFixture = $this->drainingFixture('exit 0');
 		$shFixture = $this->fixture('exit 0');
 		$this->assertSame([], pfb_lint_sh_diagnostics("echo ok\n", $shFixture, $timeoutFixture));
 	}
@@ -218,7 +228,7 @@ final class LintDiagnosticsTest extends TestCase
 
 	public function testShDiagnosticsNonzeroExitWithEmptyStderrIsLineOneWarning(): void
 	{
-		$timeoutFixture = $this->fixture('exit 5'); // e.g. timeout SIGTERM: nonzero, nothing on stderr
+		$timeoutFixture = $this->drainingFixture('exit 5'); // e.g. timeout SIGTERM: nonzero, nothing on stderr
 		$shFixture = $this->fixture('exit 0');
 		$diagnostics = pfb_lint_sh_diagnostics("sleep 100\n", $shFixture, $timeoutFixture);
 		$this->assertCount(1, $diagnostics);
@@ -262,7 +272,7 @@ final class LintDiagnosticsTest extends TestCase
 
 	public function testPyDiagnosticsParsesPinnedFixtureStderr(): void
 	{
-		$timeoutFixture = $this->fixture('printf "line 2: invalid syntax\n" 1>&2' . "\n" . 'exit 1');
+		$timeoutFixture = $this->drainingFixture('printf "line 2: invalid syntax\n" 1>&2' . "\n" . 'exit 1');
 		$pythonFixture = $this->fixture('exit 0'); // never actually exec'd -- the fake timeout ignores argv
 		$this->assertSame(
 			[['line' => 2, 'message' => 'invalid syntax', 'severity' => 'error']],
@@ -272,7 +282,7 @@ final class LintDiagnosticsTest extends TestCase
 
 	public function testPyDiagnosticsSilentZeroExitIsEmpty(): void
 	{
-		$timeoutFixture = $this->fixture('exit 0');
+		$timeoutFixture = $this->drainingFixture('exit 0');
 		$pythonFixture = $this->fixture('exit 0');
 		$this->assertSame([], pfb_lint_py_diagnostics("print('ok')\n", $pythonFixture, $timeoutFixture));
 	}
@@ -297,7 +307,7 @@ final class LintDiagnosticsTest extends TestCase
 
 	public function testPyDiagnosticsNonzeroExitWithEmptyStderrIsLineOneWarning(): void
 	{
-		$timeoutFixture = $this->fixture('exit 5');
+		$timeoutFixture = $this->drainingFixture('exit 5');
 		$pythonFixture = $this->fixture('exit 0');
 		$diagnostics = pfb_lint_py_diagnostics("print('ok')\n", $pythonFixture, $timeoutFixture);
 		$this->assertCount(1, $diagnostics);

--- a/tests/php/LintDiagnosticsTest.php
+++ b/tests/php/LintDiagnosticsTest.php
@@ -190,9 +190,7 @@ final class LintDiagnosticsTest extends TestCase
 		// \n sits in the FORMAT string (before the %s value) so printf(1) expands it to a
 		// real newline -- a \n glued onto the end of the %s-substituted VALUE itself is
 		// never escape-processed and would ship as a literal backslash-n.
-		// Needs no drain (issue #2173): the write race is unobservable here because a
-		// non-blank stderr takes the same parse path whether or not the write EPIPEs.
-		$timeoutFixture = $this->fixture(<<<'SH'
+		$timeoutFixture = $this->drainingFixture(<<<'SH'
 			printf '%s\n' '/dev/stdin: 2: Syntax error: end of file unexpected (expecting "fi")' 1>&2
 			exit 2
 			SH);

--- a/tests/php/LintDiagnosticsTest.php
+++ b/tests/php/LintDiagnosticsTest.php
@@ -190,6 +190,8 @@ final class LintDiagnosticsTest extends TestCase
 		// \n sits in the FORMAT string (before the %s value) so printf(1) expands it to a
 		// real newline -- a \n glued onto the end of the %s-substituted VALUE itself is
 		// never escape-processed and would ship as a literal backslash-n.
+		// Needs no drain (issue #2173): the write race is unobservable here because a
+		// non-blank stderr takes the same parse path whether or not the write EPIPEs.
 		$timeoutFixture = $this->fixture(<<<'SH'
 			printf '%s\n' '/dev/stdin: 2: Syntax error: end of file unexpected (expecting "fi")' 1>&2
 			exit 2


### PR DESCRIPTION
## Problem

`pfb_lint_probe_run()` spawns the syntax-check command and then writes the script body into the child's stdin:

```php
$written = @fwrite($pipes[0], substr($content, $offset, 8192));
if ($written === FALSE || $written === 0) {
    $write_ok = FALSE;   // -> failure = 'stdin write failed'
```

Several tests build a fake `timeout` binary whose entire body is `exit 0` or `exit 5`. Those children never read stdin and exit immediately, so the parent's write is racing them:

- parent wins — the body lands in the pipe buffer, `failure` stays empty, and the helper reports the exit code the test asserts on;
- child wins — the read end is already closed, `fwrite()` returns `FALSE` on EPIPE, and the helper returns `... launch failed: stdin write failed` instead.

`.agents/policy/testing.md` rules this out directly: a test may not depend on which of two processes is scheduled first.

## Change

Route those fixtures through a `drainingFixture()` helper that prefixes `cat >/dev/null`, so the child consumes stdin before exiting and the parent's write always completes. The exit code becomes the only variable under test.

`testShDiagnosticsStdinWriteFailurePrefersParseableStderr` keeps its immediate `exec 0<&-` fixture — that test exercises the EPIPE path on purpose, and it is what keeps the failure branch covered.

No production code is touched. `pfb_lint_probe_run()`'s behaviour is correct; the defect was in the fixtures.

## Evidence

Failures observed per run of the whole class, this sandbox, PHP 8.3.32:

| Tree | Runs | Failures |
| --- | --- | --- |
| before | 25 | 3 × `testShDiagnosticsSilentZeroExitIsEmpty`, 2 × `testPyDiagnosticsNonzeroExitWithEmptyStderrIsLineOneWarning` |
| before (single method, isolated) | 30 | 2 × `testShDiagnosticsNonzeroExitWithEmptyStderrIsLineOneWarning` |
| after | 105 | 0 |

A first pass fixed four fixtures and still left 3 failures in 60 runs, in `testPyDiagnosticsParsesPinnedFixtureStderr`. That one had looked safe on the reasoning that a non-blank stderr wins over the launch-failure branch — true of `pfb_lint_sh_diagnostics()`, which prefers parseable stderr, but **not** of `pfb_lint_py_diagnostics()`, which returns the launch-failure warning as soon as `failure` is non-empty. Its fixture now drains too.

That asymmetry between the two helpers is a real production difference rather than a test artifact, and is filed separately.

The full suite matches an untouched `origin/devel` checkout at 197 errors / 9 failures, and the count no longer moves between runs — the instability this fixes is what produced two different baselines (9 and 11) while landing #2171.

Fixes #2173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuDuuZDtfqmqZkTpC1MkNs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic handling for commands that continue producing input during timeout scenarios.
  * Updated timeout-related checks to correctly validate zero-exit, parseable-error, and nonzero-exit outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->