### PR TITLE
pfblockerng: keep the Python lint diagnostic when the stdin write fails

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -6302,6 +6302,12 @@ PYTHON;
 	$command = array($timeout_bin, '-s', 'TERM', '-k', '1', '5', $python, '-c', $probe);
 	$result = pfb_lint_probe_run($command, $content);
 	if ($result['failure'] !== '') {
+		// The probe compiles what it reads -- an over-pipe-buffer body can EPIPE the stdin
+		// write loop (failure = 'stdin write failed') while stderr already holds a real
+		// line-mapped SyntaxError; prefer that over the generic launch-failed warning.
+		if (!pfb_is_blank($result['stderr'])) {
+			return pfb_lint_parse_py_stderr($result['stderr']);
+		}
 		return [['line' => 1, 'message' => 'python syntax checker launch failed: ' . $result['failure'], 'severity' => 'warning']];
 	}
 	if ($result['exit'] === 0) {

--- a/tests/php/LintDiagnosticsTest.php
+++ b/tests/php/LintDiagnosticsTest.php
@@ -287,6 +287,26 @@ final class LintDiagnosticsTest extends TestCase
 		$this->assertSame([], pfb_lint_py_diagnostics("print('ok')\n", $pythonFixture, $timeoutFixture));
 	}
 
+	public function testPyDiagnosticsStdinWriteFailurePrefersParseableStderr(): void
+	{
+		// The probe compiles what it reads, so a body over the OS pipe buffer (~64KiB) can
+		// EPIPE the stdin write loop while stderr already holds the SyntaxError's line.
+		// The fake "timeout_bin" closes stdin immediately and writes that diagnostic
+		// before exiting; $pythonFixture is never actually exec'd (ignored argv).
+		$timeoutFixture = $this->fixture(
+			'exec 0<&-' . "\n" .
+			'printf "line 2: invalid syntax\n" 1>&2' . "\n" .
+			'exit 1'
+		);
+		$pythonFixture = $this->fixture('exit 0');
+		// ~256KiB: over the OS pipe buffer, under the endpoint's 1MiB cap.
+		$content = str_repeat('x', 300000) . "\n";
+		$this->assertSame(
+			[['line' => 2, 'message' => 'invalid syntax', 'severity' => 'error']],
+			pfb_lint_py_diagnostics($content, $pythonFixture, $timeoutFixture)
+		);
+	}
+
 	public function testPyDiagnosticsMissingPythonIsLineOneWarning(): void
 	{
 		$timeoutFixture = $this->fixture('exit 0');


### PR DESCRIPTION
## Problem

`pfb_lint_sh_diagnostics()` prefers a parseable stderr over its generic launch-failure warning (`pfblockerng_extra.inc:6262`):

```php
if ($result['failure'] !== '') {
    if (!pfb_is_blank($result['stderr'])) {
        return pfb_lint_parse_sh_stderr($result['stderr']);
    }
    return [['line' => 1, 'message' => 'sh syntax checker launch failed: ' . $result['failure'], ...]];
}
```

The reason, recorded in that comment: the checker exits at the first syntax error, so a body larger than the OS pipe buffer can EPIPE `pfb_lint_probe_run()`'s write loop while stderr already holds a real line-mapped diagnostic.

`pfb_lint_py_diagnostics()` had no equivalent check and returned the generic warning as soon as `failure` was non-empty. The same window exists there: the probe calls `compile(sys.stdin.read(), ...)` and prints `line N: message` to stderr, so a large hook script whose `SyntaxError` appears early enough loses that diagnostic and surfaces `python syntax checker launch failed: stdin write failed` instead.

For an administrator editing a hook script in the GUI, that is the difference between a line number and an opaque infrastructure warning.

## Change

Mirror the shell helper's branch — four lines. Everything else is unchanged: a blank stderr still produces the launch-failure warning, and the normal `exit === 1` parse path is untouched.

`pfb_lint_parse_py_stderr()` never returns an empty array for non-empty input (it falls back to a line-1 error carrying the raw text), so this cannot turn a failed probe into a false clean bill.

## Tests

`testPyDiagnosticsStdinWriteFailurePrefersParseableStderr` mirrors the existing
`testShDiagnosticsStdinWriteFailurePrefersParseableStderr`, which had no Python counterpart — that gap is why the asymmetry went unnoticed.

The EPIPE is forced deterministically rather than raced: the fake `timeout` closes stdin with `exec 0<&-` before writing its diagnostic, and the body is ~256 KiB, over the pipe buffer and under the endpoint's 1 MiB cap. This is the one fixture in the file that must *not* drain stdin, for the same reason as its shell twin.

Red against unmodified production code, with the test file frozen byte-identical across both runs (`git hash-object` = `53d076b64ac15781eab57454ddc1194f05359b4d`):

```
-  'line' => 2, 'message' => 'invalid syntax', 'severity' => 'error'
+  'line' => 1, 'message' => 'python syntax checker launch failed: stdin write failed', 'severity' => 'warning'
```

Green after: `OK (34 tests, 58 assertions)`.

Full suite failure set is identical to an untouched `origin/devel` checkout — 9 failures, same names, compared from JUnit XML rather than console output. `php -l`, PHPStan and PHPCS all pass.

Fixes #2181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuDuuZDtfqmqZkTpC1MkNs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python lint diagnostics so meaningful syntax errors are shown even when input processing fails.
  * Retained the relevant line information from diagnostic output instead of displaying only a generic launch-failure warning.

* **Tests**
  * Added regression coverage for preserving parseable diagnostics when the lint process terminates early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->