### PR TITLE
tests: wait for the blocked opener, not a retry budget

### DIFF
--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -469,9 +469,10 @@ final class PfbSyncStatusLedgerTest extends TestCase
 				}
 				fwrite($eventChild, "CONTENDED\n");
 				// Signal delivery cuts usleep() short, so hold the window against a
-				// deadline -- the opener stays runnable and answers every probe.
-				$startAt = microtime(TRUE) + ($openerStartDelayUs / 1000000);
-				while (microtime(TRUE) < $startAt) {
+				// monotonic deadline -- the opener stays runnable and answers every probe,
+				// and a wall-clock step cannot shorten or extend the window.
+				$startAt = hrtime(TRUE) + ($openerStartDelayUs * 1000);
+				while (hrtime(TRUE) < $startAt) {
 					usleep(1000);
 				}
 				pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
@@ -487,10 +488,10 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			// The wait ends on the observed BLOCKED state. A budget counted in signal
 			// round trips is not a wait: an opener that is merely slow to reach the lock
 			// answers NOT_BLOCKED as fast as the CPU allows and exhausts it in milliseconds
-			// (#2183). The cap below is wall-clock and generous -- its only job is reaping
+			// (#2183). The cap below is monotonic and generous -- its only job is reaping
 			// a stuck run, and the pause between probes leaves the opener CPU to advance.
-			$salvageDeadline = microtime(TRUE) + 30.0;
-			while (microtime(TRUE) < $salvageDeadline) {
+			$salvageDeadline = hrtime(TRUE) + (30 * 1000000000);
+			while (hrtime(TRUE) < $salvageDeadline) {
 				if (!@posix_kill($openerPid, SIGUSR1)) {
 					$this->fail('salvage cap expired / stuck or environment: awaiting BLOCKED signal before release; opener exited');
 				}

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -382,6 +382,16 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 	public function testOpenBlocksUntilARealConcurrentProcessReleasesTheLedgerLock(): void
 	{
+		$this->assertOpenerBlocksWhileTheLedgerLockIsHeld(0);
+	}
+
+	/**
+	 * @param int $openerStartDelayUs microseconds the opener waits, after proving the lock is
+	 *                                contended, before it calls into the ledger -- the window in
+	 *                                which the opener is running but has not reached the lock yet.
+	 */
+	private function assertOpenerBlocksWhileTheLedgerLockIsHeld(int $openerStartDelayUs): void
+	{
 		if (!function_exists('pcntl_fork') || !function_exists('pcntl_async_signals')
 			|| !function_exists('pcntl_signal') || !function_exists('posix_kill') || !defined('SIGUSR1')) {
 			$this->markTestSkipped('pcntl not available -- cannot spawn a real concurrent process for this test.');
@@ -458,6 +468,12 @@ final class PfbSyncStatusLedgerTest extends TestCase
 					exit(1);
 				}
 				fwrite($eventChild, "CONTENDED\n");
+				// Signal delivery cuts usleep() short, so hold the window against a
+				// deadline -- the opener stays runnable and answers every probe.
+				$startAt = microtime(TRUE) + ($openerStartDelayUs / 1000000);
+				while (microtime(TRUE) < $startAt) {
+					usleep(1000);
+				}
 				pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
 				fwrite($eventChild, "RETURNED\n");
 				fclose($eventChild);
@@ -468,7 +484,13 @@ final class PfbSyncStatusLedgerTest extends TestCase
 			$this->assertSame("CONTENDED\n", $this->readEvent($eventParent, 'concurrent opener contention'));
 			$blocked = FALSE;
 			$notBlockedSignals = [];
-			for ($attempt = 0; $attempt < 32; $attempt++) {
+			// The wait ends on the observed BLOCKED state. A budget counted in signal
+			// round trips is not a wait: an opener that is merely slow to reach the lock
+			// answers NOT_BLOCKED as fast as the CPU allows and exhausts it in milliseconds
+			// (#2183). The cap below is wall-clock and generous -- its only job is reaping
+			// a stuck run, and the pause between probes leaves the opener CPU to advance.
+			$salvageDeadline = microtime(TRUE) + 30.0;
+			while (microtime(TRUE) < $salvageDeadline) {
 				if (!@posix_kill($openerPid, SIGUSR1)) {
 					$this->fail('salvage cap expired / stuck or environment: awaiting BLOCKED signal before release; opener exited');
 				}
@@ -480,11 +502,16 @@ final class PfbSyncStatusLedgerTest extends TestCase
 				if (!str_starts_with($signalEvent, 'NOT_BLOCKED ')) {
 					$this->fail('unexpected opener signal event: expected BLOCKED or NOT_BLOCKED, got ' . $signalEvent);
 				}
-				$notBlockedSignals[] = $signalEvent;
+				$notBlockedSignals[$signalEvent] = ($notBlockedSignals[$signalEvent] ?? 0) + 1;
+				usleep(1000);
+			}
+			$observed = [];
+			foreach ($notBlockedSignals as $signalEvent => $count) {
+				$observed[] = $signalEvent . ' (x' . $count . ')';
 			}
 			$this->assertTrue($blocked,
-				'salvage cap expired / stuck or environment: awaiting BLOCKED opener state after signal retries; '
-				. 'observed=' . implode(';', $notBlockedSignals));
+				'salvage cap expired / stuck or environment: awaiting BLOCKED opener state until the salvage cap; '
+				. 'observed=' . implode(';', $observed));
 			fwrite($controlParent, "RELEASE\n");
 			$this->assertSame("RELEASING\n", $this->readEvent($eventParent, 'ledger lock holder release while still locked'));
 			$this->assertSame("RETURNED\n", $this->readEvent($eventParent, 'concurrent opener return after unlock'));
@@ -518,6 +545,18 @@ final class PfbSyncStatusLedgerTest extends TestCase
 				}
 			}
 		}
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #2183 — the blocked-state observation must survive an opener that is
+	// slow to reach the lock: it waits for the opener to BE blocked. A budget
+	// counted in signal round trips is not that wait — it is spent in milliseconds
+	// while the opener is still on its way, and reports the opener as NOT_BLOCKED.
+	// -----------------------------------------------------------------------
+
+	public function testOpenerIsObservedBlockedEvenWhenItIsSlowToReachTheLedgerLock(): void
+	{
+		$this->assertOpenerBlocksWhileTheLedgerLockIsHeld(250000);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The ledger lock-contention test observed the second opener's blocked state through at most 32 `SIGUSR1` round trips. An opener that is merely slow to reach the lock answers `NOT_BLOCKED` as fast as the CPU allows, so that budget was spent in milliseconds while the opener was still on its way, and the test reported a lock failure it had never waited for — the flake in #2183 (`observed=NOT_BLOCKED`, case duration 0.009 s).

- the wait now ends on the observed `BLOCKED` state, bounded only by a generous wall-clock salvage cap, with a short pause between probes so the opener keeps making progress
- the failure diagnostic reports each distinct observed state with its count instead of one line per probe (32 full backtraces before)
- the scenario moved into a helper parameterised by the delay between the opener proving contention and entering the ledger; a second test drives that helper with a 250 ms delay

No production code is touched. Per `.agents/policy/testing.md`, a test waits by consuming the event it needs — a retry budget counted in round trips is a duration doing assertion work.

## Red → green proof

The defect lives in the test harness itself, so the reproduction is the new slow-opener case and the "production" edit is the wait loop in the same file.

1. Behaviour-preserving prep: the scenario was extracted into `assertOpenerBlocksWhileTheLedgerLockIsHeld(int $openerStartDelayUs)` with the **old** 32-round-trip budget unchanged. Existing test stayed green — `OK (1 test, 7 assertions)`.
2. RED (frozen test blob `b549372af3ecbcd9612777991279ad24c8ba832c`):

```text
1) PfbSyncStatusLedgerTest::testOpenerIsObservedBlockedEvenWhenItIsSlowToReachTheLedgerLock
salvage cap expired / stuck or environment: awaiting BLOCKED opener state after signal retries;
observed=NOT_BLOCKED …|usleep|assertOpenerBlocksWhileTheLedgerLockIsHeld|…
Time: 00:00.007
```

The 7 ms runtime reproduces the signature reported in #2183 (0.009 s) exactly: the budget expired before the opener could reach the lock.

3. GREEN, same test bytes, wait loop replaced:

```text
OK (2 tests, 14 assertions)   Time: 00:00.332
```

The red file was reconstructed from the green tree by reverting only the wait-loop hunk; `git hash-object` returns `b549372af3ecbcd9612777991279ad24c8ba832c`, proving the reproduction test is byte-identical across red and green and that the only delta is the wait.

Note on the fault injection: the opener's delay holds against a deadline rather than a single `usleep()`, because signal delivery cuts `usleep()` short — a plain sleep let the opener reach the lock on the first probe and the test passed vacuously.

## Verification

```text
vendor/bin/phpunit tests/php/PfbSyncStatusLedgerTest.php   OK (27 tests, 104 assertions)
20 consecutive repeats of both contention tests            repeats=20 failures=0
scripts/agent/run-gates.sh --diff origin/devel             phpstan PASS, phpcs PASS
vendor/bin/phpunit (full suite, branch)                    1 failure
vendor/bin/phpunit (full suite, clean origin/devel)        the same 1 failure
```

The one full-suite failure is `DownloadStagePublishTest::testStagedPathSitsBesideTheTargetAndIsNotTheTarget`, identical on this branch and on clean `origin/devel`: a macOS-only `/var` vs `/private/var` symlink resolution mismatch, unrelated to this change. Tracked separately in #2192.

Fixes #2183



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when detecting lock contention by waiting until a defined deadline rather than relying on a fixed retry count.
  * Added coverage for cases where lock acquisition is delayed.
  * Enhanced diagnostics by aggregating repeated signals indicating that a lock is not yet blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->