### PR TITLE
ci: pin ShellCheck instead of taking the runner image's

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,25 @@ jobs:
           persist-credentials: false
 
       - name: Install ShellCheck
-        run: sudo apt-get install -y shellcheck
+        # Pinned upstream release, verified by SHA-256. Installing it from apt was a silent
+        # no-op: ubuntu-24.04 preinstalls 0.9.0, so the lint verdict tracked whatever the
+        # runner image happened to carry and moved whenever GitHub rolled it (#2185).
+        # The pin matches the version CONTRIBUTING.md tells contributors to install, so a
+        # clean local run and CI agree — 0.9.0 rejects `A && B || C` (SC2015) where 0.11.0
+        # accepts it. Same shape as the shellspec and kcov pins already in this workflow.
+        env:
+          SHELLCHECK_VERSION: v0.11.0
+          SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+        run: |
+          curl -fsSLo shellcheck.tar.xz \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          echo "${SHELLCHECK_SHA256}  shellcheck.tar.xz" | sha256sum -c -
+          tar -xJf shellcheck.tar.xz "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
+          sudo install -m 0755 "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+          rm -rf shellcheck.tar.xz "shellcheck-${SHELLCHECK_VERSION}"
+          installed="$(shellcheck --version | awk '/^version:/ { print $2 }')"
+          [ "$installed" = "${SHELLCHECK_VERSION#v}" ] || {
+            echo "shellcheck on PATH is $installed, expected ${SHELLCHECK_VERSION#v}"; exit 1; }
 
       - name: Forbid bash shebangs
         # Repo is #!/bin/sh POSIX (no /bin/bash on FreeBSD/pfSense; macOS /bin/bash is
@@ -280,11 +298,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install jq and dash
-        # jq drives the ip_pre_AWS_*.sh region filters (required). dash is
-        # installed explicitly — the shellspec run below pins it as the test
-        # shell; never rely on the runner image happening to carry it.
-        run: sudo apt-get update && sudo apt-get install -y jq dash
+      - name: Require jq and dash
+        # jq drives the ip_pre_AWS_*.sh region filters; dash is the test shell the
+        # shellspec run below pins. ubuntu-24.04 ships both, and neither changes a gate
+        # verdict by version, so installing them over the image bought nothing. Assert
+        # them instead: a runner image that drops one must fail this job loudly rather
+        # than let the suite fall back to whatever /bin/sh is (#2185).
+        run: |
+          command -v jq >/dev/null 2>&1 || {
+            echo 'required tool missing from the runner image: jq'; exit 1; }
+          command -v dash >/dev/null 2>&1 || {
+            echo 'required tool missing from the runner image: dash'; exit 1; }
+          jq --version
+          dash -c 'echo "dash: $(command -v dash)"'
 
       - name: Install iprange
         # Real `iprange --except` set-subtraction (ADR-53 P3): the same

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,9 +255,11 @@ layer beneath the live-VM smoke. See
 
 [ShellCheck](https://www.shellcheck.net/) is available as a VS Code extension
 (see IDE setup above) and is also enforced in CI at `--severity=info`.
-Configuration is in `.shellcheckrc`. Install **v0.11.0** locally (`brew install
-shellcheck`) — CI pins that same release, and older ShellCheck reports findings
-0.11.0 does not, so a version gap reds CI after a clean local run. Functional shell tests (shellspec) live in
+Configuration is in `.shellcheckrc`. CI pins **v0.11.0**; install that same
+release locally (Homebrew and most distributions carry it, but check what your
+package manager actually gives you — `shellcheck --version`). Older ShellCheck
+reports findings 0.11.0 does not, so a version gap reds CI after a clean local
+run. Functional shell tests (shellspec) live in
 `tests/shell/` — see [Shell tests (shellspec)](#shell-tests-shellspec) above.
 
 ### Markdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,7 +255,9 @@ layer beneath the live-VM smoke. See
 
 [ShellCheck](https://www.shellcheck.net/) is available as a VS Code extension
 (see IDE setup above) and is also enforced in CI at `--severity=info`.
-Configuration is in `.shellcheckrc`. Functional shell tests (shellspec) live in
+Configuration is in `.shellcheckrc`. Install **v0.11.0** locally (`brew install
+shellcheck`) — CI pins that same release, and older ShellCheck reports findings
+0.11.0 does not, so a version gap reds CI after a clean local run. Functional shell tests (shellspec) live in
 `tests/shell/` — see [Shell tests (shellspec)](#shell-tests-shellspec) above.
 
 ### Markdown

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -1,13 +1,75 @@
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
+SHELLCHECK_PIN = "v0.11.0"
+
+
+def _workflow() -> str:
+    return (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
+
+
+def _job(workflow: str, name: str, next_name: str) -> str:
+    return workflow.split(f"\n  {name}:\n", 1)[1].split(f"\n  {next_name}:\n", 1)[0]
+
 
 def test_ruff_ci_install_is_pinned() -> None:
-    workflow = (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
-    ruff_job = workflow.split("\n  ruff:\n", 1)[1].split("\n  shellcheck:\n", 1)[0]
+    workflow = _workflow()
+    ruff_job = _job(workflow, "ruff", "shellcheck")
     install_step = ruff_job.split("      - name: Install Ruff\n", 1)[1].split("\n      - name:", 1)[0].strip()
     ruff_installs = [line.strip() for line in ruff_job.splitlines() if "pip install" in line and "ruff" in line]
 
     assert install_step == "run: pip install ruff==0.16.0"
     assert ruff_installs == ["run: pip install ruff==0.16.0"]
+
+
+def test_shellcheck_ci_install_is_pinned_to_a_verified_release_tarball() -> None:
+    """The lint verdict must come from a named ShellCheck, not from whatever the runner
+    image ships: ubuntu-24.04 preinstalls 0.9.0, so an apt install is a silent no-op."""
+    shellcheck_job = _job(_workflow(), "shellcheck", "shell-tests")
+    install_step = shellcheck_job.split("      - name: Install ShellCheck\n", 1)[1].split("\n      - name:", 1)[0]
+
+    assert f"SHELLCHECK_VERSION: {SHELLCHECK_PIN}" in install_step, (
+        f"the ShellCheck install must pin {SHELLCHECK_PIN}; step was:\n{install_step}"
+    )
+    assert re.search(r"SHELLCHECK_SHA256: [0-9a-f]{64}\b", install_step), (
+        f"the pinned download must carry a SHA-256 to verify against; step was:\n{install_step}"
+    )
+    assert "sha256sum -c" in install_step, (
+        f"the downloaded tarball must be checked against SHELLCHECK_SHA256; step was:\n{install_step}"
+    )
+    assert "apt-get install" not in install_step and "apt install" not in install_step, (
+        f"apt would re-pin the gate to the runner image's ShellCheck; step was:\n{install_step}"
+    )
+
+
+def test_ci_shellcheck_pin_matches_the_documented_local_version() -> None:
+    """CI and a clean local run must agree — 0.11.0 accepts constructs 0.9.0 rejects
+    (`A && B || C` / SC2015, issue #2185), so a drift here reds CI after a green local run."""
+    documented = re.findall(
+        r"ShellCheck.{0,200}?\bv(\d+\.\d+\.\d+)\b",
+        (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8"),
+        re.DOTALL,
+    )
+
+    assert documented, "CONTRIBUTING.md must document the ShellCheck version contributors install locally"
+    assert set(documented) == {SHELLCHECK_PIN.lstrip("v")}, (
+        f"CONTRIBUTING.md documents ShellCheck {documented}, CI pins {SHELLCHECK_PIN}"
+    )
+
+
+def test_shellspec_job_requires_jq_and_dash_instead_of_installing_them() -> None:
+    """ubuntu-24.04 ships both and neither changes a verdict by version, but the suite
+    pins dash as the test shell — its absence must fail the job, not fall back silently."""
+    shell_tests_job = _job(_workflow(), "shell-tests", "php-syntax")
+
+    assert not re.search(r"apt-get install[^\n]*\bdash\b", shell_tests_job), (
+        "dash must be required and asserted present, not installed over whatever the image ships"
+    )
+    assert not re.search(r"apt-get install[^\n]*\bjq\b", shell_tests_job), (
+        "jq must be required and asserted present, not installed over whatever the image ships"
+    )
+    assert "command -v jq" in shell_tests_job and "command -v dash" in shell_tests_job, (
+        "the job must assert jq and dash are present before the suites that need them run"
+    )

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -70,6 +70,13 @@ def test_shellspec_job_requires_jq_and_dash_instead_of_installing_them() -> None
     assert not re.search(r"apt-get install[^\n]*\bjq\b", shell_tests_job), (
         "jq must be required and asserted present, not installed over whatever the image ships"
     )
-    assert "command -v jq" in shell_tests_job and "command -v dash" in shell_tests_job, (
-        "the job must assert jq and dash are present before the suites that need them run"
-    )
+    # Scoped to the step that owns the guard, and matched on the guard's shape: a bare
+    # substring search is satisfied by any incidental `command -v <tool>` — the shellspec
+    # step resolves dash that way, and so does this step's own diagnostic line.
+    require_step = shell_tests_job.split("      - name: Require jq and dash\n", 1)[1].split("\n      - name:", 1)[0]
+
+    for tool in ("jq", "dash"):
+        assert re.search(rf"^\s*command -v {tool} [^\n]*\|\|", require_step, re.MULTILINE), (
+            f"{tool} must be asserted present, with a branch that fails the job when it is not;"
+            f" step was:\n{require_step}"
+        )


### PR DESCRIPTION
## Summary

`sudo apt-get install -y shellcheck` was a no-op: `ubuntu-24.04` preinstalls ShellCheck 0.9.0, so the lint gate's verdict tracked whatever the runner image happened to carry, and re-pinned itself whenever GitHub rolled the image. During #2177 a construct 0.11.0 accepts (`A && B || C`) failed CI under 0.9.0 with `SC2015`, after a clean local run.

- ShellCheck now installs from the pinned upstream release tarball (`v0.11.0`), verified against a SHA-256 and asserted on `PATH` afterwards — the same shape as the shellspec 0.28.1 and kcov v43 pins already in this workflow
- `CONTRIBUTING.md` names that version as the one to install locally, so a clean local run and CI agree
- `jq` and `dash` are asserted present instead of installed over the image: `ubuntu-24.04` ships both and neither changes a gate verdict by version, but the suite pins `dash` as its test shell, so an image that drops one fails the job loudly instead of falling back to whatever `/bin/sh` is

Deliberately left on apt, per the issue's scope: `qemu-system-x86`, `openssh-client`, `dnsutils`, the kcov build dependencies, the guarded `zstd` installs, and `iprange` (no upstream binary release) — infrastructure whose version does not change a gate verdict.

## Red → green proof

Reproduction tests were written first and executed against the untouched workflow. Frozen test blob `45c19eb83db6b0bfabfee407686aa69af38de332`, byte-identical across both runs.

RED (untouched workflow):

```text
FAILED tests/test_ci_tool_pins.py::test_shellcheck_ci_install_is_pinned_to_a_verified_release_tarball
FAILED tests/test_ci_tool_pins.py::test_ci_shellcheck_pin_matches_the_documented_local_version
FAILED tests/test_ci_tool_pins.py::test_shellspec_job_requires_jq_and_dash_instead_of_installing_them
3 failed, 1 passed
```

GREEN (same test bytes, workflow + CONTRIBUTING changed): `4 passed`.

The pre-existing `test_ruff_ci_install_is_pinned` passed in both runs — the new cases fail for the pin that was missing, not for the harness.

## Verification of the install step itself

The pinned artifact and both paths of the checksum gate were executed in-session, since a workflow step is not covered by a unit test:

```text
curl -fsSLo shellcheck.tar.xz .../v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz
sha256 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198   (2559196 bytes)
tar -tJf → shellcheck-v0.11.0/{LICENSE.txt,README.txt,shellcheck}

green path: "shellcheck.tar.xz: OK" → extracted, installed 0755
red path (one byte of the pin changed): "shellcheck.tar.xz: FAILED" → rc=1, no install
```

The `--version` assertion parses the real output shape (`shellcheck --version | awk '/^version:/ { print $2 }'` → `0.11.0`, checked against the locally installed 0.11.0), so a tarball that ever ships a different build fails the step rather than linting with it.

```text
python3 -c "yaml.safe_load(.github/workflows/test.yml)"   jobs=19
python3 scripts/check_version_literals.py                 clean
scripts/agent/run-gates.sh --diff origin/devel            GATES: PASS
```

Fixes #2185
