### PR TITLE
pfblockerng: fold DNSBL regex analysis onto the IGNORECASE runtime

### DIFF
--- a/benchmarks/spike_adr07_regex.py
+++ b/benchmarks/spike_adr07_regex.py
@@ -150,7 +150,7 @@ def categorise(line: str) -> str:
 # no other regex metacharacter. Anything with a char-class, quantifier on a label,
 # alternation in the body, or an unescaped/floating dot is IRREDUCIBLE.
 
-_DOMAIN_LITERAL = re.compile(r"^[a-z0-9_-]+(?:\\\.[a-z0-9_-]+)+$")  # underscore per #723
+_DOMAIN_LITERAL = re.compile(r"^[A-Za-z0-9_-]+(?:\\\.[A-Za-z0-9_-]+)+$")  # underscore #723; case-fold #2099
 
 _WILDCARD_PREFIXES = (r"^(.+\.)?", r"(^|\.)", r"^(?:.+\.)?")
 _EXACT_PREFIXES = (r"^",)
@@ -175,7 +175,7 @@ def reduce_pattern(pat: str) -> tuple[str, str] | None:
     for pre in _WILDCARD_PREFIXES:
         if body.startswith(pre):
             lit = body[len(pre) :]
-            dom = lit.replace("\\.", ".")
+            dom = lit.replace("\\.", ".").lower()
             if _DOMAIN_LITERAL.match(lit):
                 return "zone", dom
             return None
@@ -186,7 +186,7 @@ def reduce_pattern(pat: str) -> tuple[str, str] | None:
             # allow an optional (www\.)? prefix, fold to the exact base domain
             if lit.startswith(r"(www\.)?"):
                 lit = lit[len(r"(www\.)?") :]
-            dom = lit.replace("\\.", ".")
+            dom = lit.replace("\\.", ".").lower()
             if _DOMAIN_LITERAL.match(lit):
                 return "data", dom
             return None

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -195,7 +195,12 @@ def _regex_group_end(pattern: str, index: int) -> int:
 
 @lru_cache(maxsize=512)
 def _regex_atoms_overlap(first: str, second: str) -> bool:
-    """True when both atoms can match the same character, i.e. the pair is ambiguous."""
+    """True when both atoms can match the same character, i.e. the pair is ambiguous.
+
+    Compiled IGNORECASE (#2099): the DNSBL matcher compiles every admitted pattern
+    case-insensitively (#2079/#2097), so this probe must judge overlap under the
+    same semantics the runtime actually executes, not case-sensitive text overlap.
+    """
     if first == second:
         return True
     try:
@@ -203,8 +208,8 @@ def _regex_atoms_overlap(first: str, second: str) -> bool:
         # every stderr line into an admin-facing validation error.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            left = re.compile(first)
-            right = re.compile(second)
+            left = re.compile(first, re.IGNORECASE)
+            right = re.compile(second, re.IGNORECASE)
     except re.error:
         return False
     return any(left.fullmatch(probe) and right.fullmatch(probe) for probe in _REGEX_OVERLAP_ALPHABET)

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4396,7 +4396,12 @@ def tld_wildcard_classify(domain: str, tlds: dict[str, dict[str, str]], exclusio
 # reduce_pattern). A reducible ``/re/`` decides IDENTICALLY to a domain/wildcard
 # rule, so it folds to a domain Rule at zero per-query cost. ``D`` is a domain
 # literal: labels of [a-z0-9-] joined by ESCAPED dots (``\.``), no other metachar.
-_DNSBL_RX_DOMAIN_LITERAL = re.compile(r"^[a-z0-9_-]+(?:\\\.[a-z0-9_-]+)+$")  # underscore per #723
+# Case-insensitive (#2099): the runtime compiles every admitted regex with
+# IGNORECASE (#2079/#2097), so a mixed-case literal reduces exactly like its
+# lowercase twin -- the fold lowercases the extracted literal below so the
+# domain key stays canonical (matching how normalise() lowercases a plain
+# domain before validating it).
+_DNSBL_RX_DOMAIN_LITERAL = re.compile(r"^[A-Za-z0-9_-]+(?:\\\.[A-Za-z0-9_-]+)+$")  # underscore per #723
 # Prefixes that mean "domain + all subdomains" (-> wildcard zone after fold):
 _DNSBL_RX_WILDCARD_PREFIXES = (r"^(.+\.)?", r"(^|\.)", r"^(?:.+\.)?")
 # Prefix that means "exact domain only" (-> exact data after fold):
@@ -4421,7 +4426,7 @@ def _dnsbl_reduce_regex(inner: str) -> tuple[bool, str] | None:
         if body.startswith(pre):
             lit = body[len(pre) :]
             if _DNSBL_RX_DOMAIN_LITERAL.match(lit):
-                return True, lit.replace("\\.", ".")
+                return True, lit.replace("\\.", ".").lower()
             return None
     for pre in _DNSBL_RX_EXACT_PREFIXES:
         if body.startswith(pre):
@@ -4429,7 +4434,7 @@ def _dnsbl_reduce_regex(inner: str) -> tuple[bool, str] | None:
             if lit.startswith(_DNSBL_RX_WWW_OPT):
                 lit = lit[len(_DNSBL_RX_WWW_OPT) :]
             if _DNSBL_RX_DOMAIN_LITERAL.match(lit):
-                return False, lit.replace("\\.", ".")
+                return False, lit.replace("\\.", ".").lower()
             return None
     return None
 

--- a/tests/test_adr07_decision_spec.py
+++ b/tests/test_adr07_decision_spec.py
@@ -189,7 +189,7 @@ def _valid_domain(host: str) -> str | None:
 # Regex reduction grammar (mirrors benchmarks/spike_adr07_regex.reduce_pattern).
 # A reducible /re/ decides IDENTICALLY to a domain/wildcard rule (ADR.md SS2).
 # --------------------------------------------------------------------------- #
-_DOMAIN_LITERAL = re.compile(r"^[a-z0-9_-]+(?:\\\.[a-z0-9_-]+)+$")  # underscore per #723
+_DOMAIN_LITERAL = re.compile(r"^[A-Za-z0-9_-]+(?:\\\.[A-Za-z0-9_-]+)+$")  # underscore #723; case-fold #2099
 _WILDCARD_PREFIXES = (r"^(.+\.)?", r"(^|\.)", r"^(?:.+\.)?")
 _EXACT_PREFIXES = (r"^",)
 
@@ -206,7 +206,7 @@ def reduce_regex(inner: str) -> tuple[bool, str] | None:
         if body.startswith(pre):
             lit = body[len(pre) :]
             if _DOMAIN_LITERAL.match(lit):
-                return True, lit.replace("\\.", ".")
+                return True, lit.replace("\\.", ".").lower()
             return None
     for pre in _EXACT_PREFIXES:
         if body.startswith(pre):
@@ -214,7 +214,7 @@ def reduce_regex(inner: str) -> tuple[bool, str] | None:
             if lit.startswith(r"(www\.)?"):
                 lit = lit[len(r"(www\.)?") :]
             if _DOMAIN_LITERAL.match(lit):
-                return False, lit.replace("\\.", ".")
+                return False, lit.replace("\\.", ".").lower()
             return None
     return None
 

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -312,6 +312,28 @@ class TestRegexReduction:
                 assert domain == sdom, inner
                 assert wildcard == (cls == "zone"), inner
 
+    def test_regex_reduction_case_folds_literal_to_lowercase(self) -> None:
+        # Issue #2099: the domain-literal grammar was lowercase-only, so a
+        # mixed-case regex like /^Example\.com$/ never reduced to a domain rule
+        # -- even though it matches identically (IGNORECASE) to its lowercase
+        # twin at runtime -- and stayed a full per-query compiled regex (a
+        # missed optimisation, not a wrong match, per the issue). Reducing it
+        # must fold to the CANONICAL LOWERCASE key, mirroring how the plain-
+        # domain path (normalise()) already lowercases before validating.
+        spike = _spike()
+        cases = (
+            (r"^Example\.com$", (False, "example.com")),
+            (r"^(.+\.)?AdServer\.Example$", (True, "adserver.example")),
+            (r"(^|\.)Tracker\.NET$", (True, "tracker.net")),
+            (r"^(www\.)?Simple\.Example\.com$", (False, "simple.example.com")),
+        )
+        for inner, expected in cases:
+            prod = P._dnsbl_reduce_regex(inner)
+            assert prod == expected, inner
+            assert spec.reduce_regex(inner) == expected, inner
+            wildcard, domain = expected
+            assert spike.reduce_pattern("/" + inner + "/") == ("zone" if wildcard else "data", domain), inner
+
 
 # --------------------------------------------------------------------------- #
 # 3. DATA vs ZONE: an ABP wildcard block is a zone at its own key at any depth

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -313,13 +313,10 @@ class TestRegexReduction:
                 assert wildcard == (cls == "zone"), inner
 
     def test_regex_reduction_case_folds_literal_to_lowercase(self) -> None:
-        # Issue #2099: the domain-literal grammar was lowercase-only, so a
-        # mixed-case regex like /^Example\.com$/ never reduced to a domain rule
-        # -- even though it matches identically (IGNORECASE) to its lowercase
-        # twin at runtime -- and stayed a full per-query compiled regex (a
-        # missed optimisation, not a wrong match, per the issue). Reducing it
-        # must fold to the CANONICAL LOWERCASE key, mirroring how the plain-
-        # domain path (normalise()) already lowercases before validating.
+        # A mixed-case literal reduces exactly like its lowercase twin (the
+        # runtime matches IGNORECASE either way), so it must fold to the
+        # CANONICAL LOWERCASE key -- mirroring how the plain-domain path
+        # (normalise()) already lowercases before validating.
         spike = _spike()
         cases = (
             (r"^Example\.com$", (False, "example.com")),

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -289,6 +289,19 @@ class TestRegexReduction:
         # was no ``tally`` parameter at all, so this drop counted NOWHERE.
         assert tally == {("", ""): {"shape": 0, "wire_cap": 2}}
 
+    def test_unqueryable_folded_key_is_dropped_mixed_case(self) -> None:
+        # Same wire-cap drop as above, through the mixed-case fold path: the
+        # over-cap check runs on the ALREADY-LOWERCASED key, so a mixed-case
+        # over-cap literal is dropped exactly like its lowercase twin -- the
+        # fold's own .lower() doesn't change the label length the cap checks.
+        long_label = "A" * 64
+        tally: P.RejectTally = {}
+        res = _reconcile([f"/^(.+\\.)?{long_label}\\.com$/"], tally=tally)
+        assert res.block_domains == []
+        assert res.block_regex_irreducible == []
+        assert res.reduced == 0
+        assert tally == {("", ""): {"shape": 0, "wire_cap": 1}}
+
     def test_reduction_matches_oracle_and_spike(self) -> None:
         spike = _spike()
         for inner in (

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -162,6 +162,20 @@ class TestCatastrophicShapeHeuristic:
         ):
             assert _regex_is_catastrophic_shape(pat) is True, pat
 
+    def test_adjacent_quantifier_run_overlap_is_case_insensitive(self) -> None:
+        # Issue #2099: the DNSBL matcher compiles every admitted regex with
+        # re.IGNORECASE (#2079/#2097), but _regex_atoms_overlap -- which decides
+        # whether adjacent quantified atoms chain into one catastrophic run --
+        # compiled its probe WITHOUT it. [A-Z] and [a-z] share no character
+        # case-SENSITIVELY, so the gate judged this run non-overlapping and safe;
+        # under the runtime's actual case-insensitive semantics any letter matches
+        # both, so it is exactly as catastrophic as the same-case run above.
+        for pat in (
+            r"^[A-Z]+[a-z]+[A-Z]+@example\.com$",
+            r"^[a-z]+[A-Z]+[a-z]+@example\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
     def test_grouped_adjacent_quantifier_run_flagged(self) -> None:
         # The SAME shape wearing parentheses. Plain `(...)`/`(?:...)` groups do not change
         # what the engine backtracks over, so `([a-z]+)([a-z]+)([a-z]+)` is the ungrouped

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -163,13 +163,10 @@ class TestCatastrophicShapeHeuristic:
             assert _regex_is_catastrophic_shape(pat) is True, pat
 
     def test_adjacent_quantifier_run_overlap_is_case_insensitive(self) -> None:
-        # Issue #2099: the DNSBL matcher compiles every admitted regex with
-        # re.IGNORECASE (#2079/#2097), but _regex_atoms_overlap -- which decides
-        # whether adjacent quantified atoms chain into one catastrophic run --
-        # compiled its probe WITHOUT it. [A-Z] and [a-z] share no character
-        # case-SENSITIVELY, so the gate judged this run non-overlapping and safe;
-        # under the runtime's actual case-insensitive semantics any letter matches
-        # both, so it is exactly as catastrophic as the same-case run above.
+        # The DNSBL matcher compiles every admitted regex with re.IGNORECASE, so
+        # atom-overlap analysis must judge overlap under the same semantics: any
+        # letter matches BOTH [A-Z] and [a-z] once case-folded, so this run is
+        # exactly as catastrophic as the same-case run above.
         for pat in (
             r"^[A-Z]+[a-z]+[A-Z]+@example\.com$",
             r"^[a-z]+[A-Z]+[a-z]+@example\.com$",


### PR DESCRIPTION
Fixes #2099.

## What

Two DNSBL regex-analysis sites reasoned about patterns case-sensitively, while the DNSBL matcher itself has compiled every admitted pattern with `re.IGNORECASE` since #2079/#2097. This is the sweep those tickets' predicate ("is it a regex we use against domain names? then case-insensitive") never got to run over.

1. `_regex_atoms_overlap` (`pfb_dnsbl_regex_rules.py`) — decides whether adjacent quantified regex atoms overlap, feeding the catastrophic-backtracking shape gate. It compiled its overlap probe without `re.IGNORECASE`, so a pair ambiguous only under case-folding (e.g. `[A-Z]` vs `[a-z]`) passed the gate uncaught even though the runtime treats them as fully overlapping.
2. The domain-literal reduction grammar (`_DNSBL_RX_DOMAIN_LITERAL` / `_dnsbl_reduce_regex` in `pfb_unbound.py`, mirrored in the reference oracle `tests/test_adr07_decision_spec.py` and the benchmark spike `benchmarks/spike_adr07_regex.py`) only admitted lowercase literals. A mixed-case regex like `/^Example\.com$/` never reduced to a domain/wildcard rule — a missed optimisation (it still matched correctly at runtime), not a wrong answer. Widened the charset to admit either case and lowercase the extracted literal at fold time, so the domain key stays canonical (mirroring how `normalise()` already lowercases plain domains before validating).

Kept the reference oracle and benchmark spike in lockstep with production per the existing "mirrors" convention — all three copies of the domain-literal grammar changed together.

## Verified correct as-is (per issue's acceptance criteria)

The issue named two irreducible-by-design cases that stay correctly case-sensitive: the module-level `_REGEX_*` constants in `pfb_dnsbl_regex_rules.py` (they match pattern *text*, not domains) and the plain-domain label charset `_DNSBL_LABEL_CHARS` (it runs after `normalise()`'s own lowercasing, so widening it would be redundant). Neither touched.

## Tests

- `test_adjacent_quantifier_run_overlap_is_case_insensitive` (`tests/test_adr07_regex_safety.py`) — red-first: `^[A-Z]+[a-z]+[A-Z]+@example\.com$` was judged non-catastrophic pre-fix; now flagged, matching the same-case run right above it.
- `test_regex_reduction_case_folds_literal_to_lowercase` (`tests/test_adr07_reconcile.py`) — red-first: four mixed-case reducible patterns returned `None` (irreducible) pre-fix; now fold to their canonical lowercase domain/wildcard key, cross-checked against the reference oracle and the benchmark spike.

Both frozen at red time (`git hash-object`), re-executed unchanged at green, and independently re-verified via `scripts/agent/verify-red-proof.sh` (reverts prod to the pre-fix commit, requires RED, restores, requires GREEN).

## Verification

- `python -m pytest -q` — 4668 passed, 6 skipped
- `ruff check .` / `ruff format --check .` / `mypy tests/` — clean
- Independent small-tier verifier re-ran every gate + both red→green proofs from scratch, read the full diff against the issue's acceptance criteria, and reasoned through whether any case-sensitive regex metacharacter (`\s`/`\S`/`\w`/`\W`/`\d`/`\D`) could slip through the widened domain-literal charset — confirmed it cannot (the charset admits no backslash outside the fixed `\.` separator token). PASS, no blocking findings.

## Follow-on

The issue's `docs/misc/architecture-notes.md` invariant write-up is a dev-only doc change landing separately, straight to `devel`, once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Domain patterns now accept uppercase letters consistently.
  * Reduced domain names are normalized to lowercase for exact and wildcard matches.
  * Pattern overlap detection now follows case-insensitive matching behavior.
* **Tests**
  * Added regression coverage for mixed-case domain reduction.
  * Added safety coverage for detecting overlapping quantified patterns with mixed-case classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->