### PR TITLE
tests: compare staged and target paths in resolved form

### DIFF
--- a/tests/php/DownloadStagePublishTest.php
+++ b/tests/php/DownloadStagePublishTest.php
@@ -91,8 +91,40 @@ final class DownloadStagePublishTest extends TestCase
 			return 0;
 		});
 
-		$this->assertSame($this->dir, dirname($seen));
+		// realpath() on both sides -- macOS resolves sys_get_temp_dir() through a
+		// /var -> /private/var symlink and tempnam() hands back the resolved path,
+		// so the raw strings differ on the prefix while naming the same directory
+		// (issue #2192).
+		$this->assertSame(realpath($this->dir), realpath(dirname($seen)));
 		$this->assertNotSame($target, $seen);
+	}
+
+	/**
+	 * The same-filesystem invariant is about the directory, never about how the
+	 * caller spelled it. Reaching the target through a symlink makes the resolved
+	 * and unresolved forms differ on EVERY platform, so this pins the comparison
+	 * that macOS was the only platform to fail (issue #2192).
+	 */
+	public function testStagedPathSitsBesideATargetReachedThroughASymlink(): void
+	{
+		$link = "{$this->dir}/via-symlink";
+		$this->assertTrue(symlink($this->dir, $link));
+
+		$target = "{$link}/feed.orig";
+		$seen   = '';
+		$this->assertTrue(pfb_stage_publish($target, static function (string $staged) use (&$seen): int {
+			$seen = $staged;
+			file_put_contents($staged, "x\n");
+			return 0;
+		}));
+
+		// The vacuity guard: without it the assertion below could pass on a fixture
+		// whose two spellings were already identical, pinning nothing. Compared
+		// against $link, never $this->dir -- $this->dir is already canonical on a
+		// Linux runner, which would let an unresolved comparison pass there.
+		$this->assertNotSame($link, dirname($seen),
+			'setup: the symlinked target must spell its directory differently from the staged path');
+		$this->assertSame(realpath($link), realpath(dirname($seen)));
 	}
 
 	/** A staged file published at tempnam's 0600 would hide the feed from its readers. */


### PR DESCRIPTION
## Problem

`DownloadStagePublishTest::testStagedPathSitsBesideTheTargetAndIsNotTheTarget` compared the fixture directory against `dirname()` of the staged path as raw strings:

```php
$this->assertSame($this->dir, dirname($seen));
```

`pfb_stage_publish()` stages through `tempnam(dirname($target), …)`, and `tempnam()` hands back a **fully resolved** path. On macOS `sys_get_temp_dir()` sits behind the `/var` → `/private/var` symlink, so the two spellings name the same directory but differ on the prefix and the assertion fails. CI runs on Linux, where the fixture path is already canonical, so the failure was invisible there — leaving a permanently red local PHPUnit baseline on any macOS checkout.

## Change

- Compare the resolved forms on both sides, matching the idiom already used in `LiveTableSnapshotAbandonedFcloseTest`.
- Add `testStagedPathSitsBesideATargetReachedThroughASymlink`, which reaches the target through a symlink the test creates itself. That fixture makes the resolved and unresolved spellings differ on **every** platform, so the comparison is pinned on a Linux runner too rather than only on macOS.

The expected side of the new assertion is the symlinked spelling (`$link`), never `$this->dir`: on Linux `$this->dir` is already canonical, so anchoring on it would let an unresolved comparison pass there. A `assertNotSame($link, dirname($seen))` vacuity guard asserts up front that the two spellings genuinely differ, so the test cannot pin nothing.

No production code changes — `src/` is untouched.

## Evidence

Executed on macOS 25.6.0, PHP 8.5.9, in a worktree cut from `origin/devel`:

**RED (before, clean base `2e934a30`):**

```text
$ vendor/bin/phpunit --filter DownloadStagePublishTest
1) DownloadStagePublishTest::testStagedPathSitsBesideTheTargetAndIsNotTheTarget
Failed asserting that two strings are identical.
-'/var/folders/…/T/pfb stage; 49911 '\''fixture'\'''
+'/private/var/folders/…/T/pfb stage; 49911 '\''fixture'\'''
tests/php/DownloadStagePublishTest.php:94
Tests: 10, Assertions: 34, Failures: 1.
```

**GREEN (after):**

```text
$ vendor/bin/phpunit --filter DownloadStagePublishTest
OK (11 tests, 40 assertions)
```

**Full suite baseline, now clean:**

```text
$ vendor/bin/phpunit
Tests: 4976, Assertions: 28604, Warnings: 32, Deprecations: 3, Notices: 1, Skipped: 3.
```

(0 failures; the warnings/deprecations are the pre-existing baseline noise.)

**Mutation probe — the new test is failable, and failable off macOS.** Dropping both `realpath()` calls from the new test's final assertion:

```text
1) DownloadStagePublishTest::testStagedPathSitsBesideATargetReachedThroughASymlink
-'/var/folders/…/T/pfb stage; 51911 '\''fixture'\''/via-symlink'
+'/private/var/folders/…/T/pfb stage; 51911 '\''fixture'\'''
```

The two sides differ by the `/via-symlink` segment, which is present regardless of platform — a Linux runner fails this mutant too. The mutation was applied to a scratch copy and reverted; the committed file is byte-identical to the green run.

Fixture cleanup was verified: no `pfb stage*` directories remain under the temporary directory after the suite.

Part of #2192
