### PR TITLE
ci: verify the shellspec tarball against a pinned SHA-256

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -321,10 +321,26 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y iprange
 
       - name: Install shellspec
-        # Pinned release tarball; the executable runs from its extracted tree.
+        # Pinned upstream release ASSET, verified by SHA-256 before anything is extracted;
+        # the executable then runs from that tree. This replaced a source-archive tarball
+        # piped straight into tar: GitHub generates that archive on demand from the tag,
+        # so its bytes are not a stable artifact — a re-tag upstream would swap what runs
+        # the POSIX gate and the workflow would not notice (#2194). An uploaded release
+        # asset is immutable. Extracted outside the checkout so the repo tree stays clean.
+        # Same shape as the ShellCheck pin above.
+        env:
+          SHELLSPEC_VERSION: 0.28.1
+          SHELLSPEC_SHA256: 350d3de04ba61505c54eda31a3c2ee912700f1758b1a80a284bc08fd8b6c5992
         run: |
-          curl -fsSL https://github.com/shellspec/shellspec/archive/refs/tags/0.28.1.tar.gz | tar -xz
-          echo "$PWD/shellspec-0.28.1" >> "$GITHUB_PATH"
+          curl -fsSLo shellspec-dist.tar.gz \
+            "https://github.com/shellspec/shellspec/releases/download/${SHELLSPEC_VERSION}/shellspec-dist.tar.gz"
+          echo "${SHELLSPEC_SHA256}  shellspec-dist.tar.gz" | sha256sum -c -
+          tar -xzf shellspec-dist.tar.gz -C "$HOME"
+          rm -f shellspec-dist.tar.gz
+          echo "$HOME/shellspec" >> "$GITHUB_PATH"
+          installed="$("$HOME/shellspec/shellspec" --version)"
+          [ "$installed" = "$SHELLSPEC_VERSION" ] || {
+            echo "shellspec is $installed, expected $SHELLSPEC_VERSION"; exit 1; }
 
       - name: Run shellspec
         # Functional gate for the shell scripts, pinned to dash — the

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -4,6 +4,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 SHELLCHECK_PIN = "v0.11.0"
+SHELLSPEC_PIN = "0.28.1"
 
 
 def _workflow() -> str:
@@ -56,6 +57,37 @@ def test_ci_shellcheck_pin_matches_the_documented_local_version() -> None:
     assert documented, "CONTRIBUTING.md must document the ShellCheck version contributors install locally"
     assert set(documented) == {SHELLCHECK_PIN.lstrip("v")}, (
         f"CONTRIBUTING.md documents ShellCheck {documented}, CI pins {SHELLCHECK_PIN}"
+    )
+
+
+def test_shellspec_ci_install_is_pinned_to_a_verified_release_asset() -> None:
+    """The POSIX gate must run the shellspec whose bytes we pinned. A
+    `/archive/refs/tags/` tarball is generated on demand from the tag, so it is not a
+    stable artifact: a re-tag upstream changes what runs the suite and nothing notices
+    (#2194). Same shape as the ShellCheck pin — release asset, fetched to a file, then
+    `sha256sum -c` before anything is extracted."""
+    install_step = (
+        _job(_workflow(), "shell-tests", "php-syntax")
+        .split("      - name: Install shellspec\n", 1)[1]
+        .split("\n      - name:", 1)[0]
+    )
+
+    assert f"SHELLSPEC_VERSION: {SHELLSPEC_PIN}" in install_step, (
+        f"the shellspec install must pin {SHELLSPEC_PIN}; step was:\n{install_step}"
+    )
+    assert re.search(r"SHELLSPEC_SHA256: [0-9a-f]{64}\b", install_step), (
+        f"the pinned download must carry a SHA-256 to verify against; step was:\n{install_step}"
+    )
+    assert "sha256sum -c" in install_step, (
+        f"the downloaded tarball must be checked against SHELLSPEC_SHA256; step was:\n{install_step}"
+    )
+    assert "/releases/download/" in install_step and "/archive/refs/tags/" not in install_step, (
+        f"pin the uploaded release asset, not the on-demand tag archive; step was:\n{install_step}"
+    )
+    # A pipe into tar unpacks the bytes before (or instead of) checking them — the
+    # verification has to gate the extraction, so the download must land in a file.
+    assert not re.search(r"\|\s*tar\b", install_step), (
+        f"fetch to a file and verify it before extracting, never pipe the download into tar; step was:\n{install_step}"
     )
 
 


### PR DESCRIPTION
## What

The `shell-tests` job installed shellspec by piping GitHub's on-demand source archive for tag `0.28.1` straight into `tar`. The version was pinned but the bytes were not: that archive is generated per request rather than stored, so a re-tag upstream — or anything else able to answer that request — silently changes what runs the POSIX shell gate, and the workflow would not notice.

This switches the install to the uploaded `0.28.1` release asset (`shellspec-dist.tar.gz`, an immutable artifact), fetches it to a file, and verifies it with `sha256sum -c` before extracting — the same shape as the ShellCheck step next to it (#2185). The tree is unpacked outside the checkout so the workspace stays clean, and the resulting executable's `--version` is asserted against the pin.

## Evidence

Release asset and checksum probed in-session:

```
$ gh api repos/shellspec/shellspec/releases/tags/0.28.1 --jq '[.assets[].name]'
["shellspec-dist.tar.gz"]
$ shasum -a 256 shellspec-dist.tar.gz
350d3de04ba61505c54eda31a3c2ee912700f1758b1a80a284bc08fd8b6c5992  shellspec-dist.tar.gz
```

The dist tree drives this repo's suite unchanged (`shellspec tests/shell/shard_modules_spec.sh` → `49 examples, 0 failures`), and the step body was simulated end to end under `bash --noprofile --norc -eo pipefail`:

- correct checksum → `shellspec-dist.tar.gz: OK`, `shellspec --version` = `0.28.1`, workspace left clean;
- tampered checksum → `FAILED`, step exits 1, **nothing extracted** and nothing appended to `$GITHUB_PATH`.

Test-first: the new case in `tests/test_ci_tool_pins.py` was executed RED against the old step (`the shellspec install must pin 0.28.1`) before the workflow edit, and GREEN after it unchanged. It pins the version, requires a 64-hex `SHELLSPEC_SHA256`, requires `sha256sum -c`, requires a release-asset URL, and rejects a pipe into `tar` — so the verification cannot be dropped, emptied, or bypassed without a red test.

## Notes

- Out of scope, noted for a follow-up: `CONTRIBUTING.md` still tells contributors to install shellspec via `brew` or the unversioned upstream installer, so a local run is not pinned to `0.28.1` the way the ShellCheck instructions now are.
- The prebuilt-runner-image idea raised on #2185 would move this pin into the image build rather than remove the need for one.

Part of #2194
