### PR TITLE
ci: pin the remaining unverified tool installs (kcov build, local shellspec)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,18 +378,28 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.local/kcov
-          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
+          key: kcov-a39874f938ce13f7a65f253120d1ec946b349ffe-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
 
       - name: Build kcov from source (cache miss)
         # Only runs when the cache is cold. best-effort: a compile failure still
-        # leaves CI green (coverage is informational).
+        # leaves CI green (coverage is informational). Pinned to a commit, not the
+        # `v43` tag: a tag is a moving reference and a re-tag upstream would swap
+        # what gets built and cached under this key with nothing noticing. `--branch`
+        # only accepts a ref (tag/branch), so a commit pin needs the
+        # init/fetch-by-sha/checkout shape below instead of `clone --branch`
+        # (GitHub serves any reachable commit SHA over the smart HTTP protocol).
         id: build-kcov
         if: steps.cache-kcov.outputs.cache-hit != 'true'
         continue-on-error: true
+        env:
+          KCOV_COMMIT: a39874f938ce13f7a65f253120d1ec946b349ffe
         run: |
           sudo apt-get update && sudo apt-get install -y \
             binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libdw-dev zlib1g-dev cmake g++
-          git clone --depth 1 --branch v43 https://github.com/SimonKagstrom/kcov
+          mkdir kcov && git -C kcov init -q
+          git -C kcov remote add origin https://github.com/SimonKagstrom/kcov
+          git -C kcov fetch --depth 1 origin "$KCOV_COMMIT"
+          git -C kcov checkout -q FETCH_HEAD
           cmake -S kcov -B kcov/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/.local/kcov"
           cmake --build kcov/build --parallel "$(nproc)"
           cmake --install kcov/build
@@ -402,7 +412,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.local/kcov
-          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
+          key: kcov-a39874f938ce13f7a65f253120d1ec946b349ffe-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
 
       - name: Install kcov runtime deps and add to PATH
         # Runtime shared libs (libcurl, libelf, libdw) needed on both cache hit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,9 +162,14 @@ shellspec            # from the repo root; reads ./.shellspec
 shellspec --kcov     # with coverage (informational; needs kcov)
 ```
 
-Install with `brew install shellspec` (macOS) or the official installer
-(`curl -fsSL https://git.io/shellspec | sh`). The pre-commit hook and CI run it
-automatically when `shellspec` is present (coverage is informational, no floor).
+CI pins **0.28.1**; install that same release locally (Homebrew and most
+distributions carry it, but check what your package manager actually gives
+you — `shellspec --version`) with `brew install shellspec` (macOS) or the
+official installer pinned to that version
+(`curl -fsSL https://git.io/shellspec | sh -s 0.28.1`) — an unpinned
+`| sh` installs whatever is latest, the same drift CI closed on the CI side
+(#2194). The pre-commit hook and CI run it automatically when `shellspec` is
+present (coverage is informational, no floor).
 See [`tests/shell/README.md`](tests/shell/README.md) for the harness contracts
 (the `iprange` PATH shim, the AWS fixture, and the `PFB_SOURCED` source-for-test
 pattern).

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -143,9 +143,16 @@ def test_kcov_ci_build_is_pinned_to_a_commit_not_a_moving_tag() -> None:
     assert not re.search(r"--branch\s+v43\b", build_step), (
         f"kcov must not be built from the moving v43 tag; step was:\n{build_step}"
     )
-    assert re.search(rf"\b{KCOV_COMMIT_PIN}\b", build_step), (
-        f"the kcov build must check out the pinned commit {KCOV_COMMIT_PIN}; step was:\n{build_step}"
+    # Not just "the pin appears somewhere" -- the env var must feed the actual
+    # fetch+checkout, or a later edit could build a default branch while leaving
+    # the pin text dangling elsewhere in the step (unfailable regression).
+    assert f"KCOV_COMMIT: {KCOV_COMMIT_PIN}" in build_step, (
+        f"the pinned commit must be wired through KCOV_COMMIT; step was:\n{build_step}"
     )
+    assert re.search(
+        r'git -C kcov fetch --depth 1 origin "\$KCOV_COMMIT"\s+git -C kcov checkout -q FETCH_HEAD\b',
+        build_step,
+    ), f"the kcov build must fetch and check out $KCOV_COMMIT; step was:\n{build_step}"
 
     cache_steps = [
         step
@@ -153,4 +160,7 @@ def test_kcov_ci_build_is_pinned_to_a_commit_not_a_moving_tag() -> None:
         for step in [shell_tests_job.split(f"      - name: {name}\n", 1)[1].split("\n      - name:", 1)[0]]
     ]
     for step in cache_steps:
-        assert KCOV_COMMIT_PIN in step, f"the kcov cache key must fold in the pinned commit; step was:\n{step}"
+        key_line = re.search(r"(?m)^\s+key:\s*(.+)$", step)
+        assert key_line and KCOV_COMMIT_PIN in key_line.group(1), (
+            f"the kcov cache key must fold in the pinned commit; step was:\n{step}"
+        )

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -143,11 +143,13 @@ def test_kcov_ci_build_is_pinned_to_a_commit_not_a_moving_tag() -> None:
     assert not re.search(r"--branch\s+v43\b", build_step), (
         f"kcov must not be built from the moving v43 tag; step was:\n{build_step}"
     )
-    # Not just "the pin appears somewhere" -- the env var must feed the actual
-    # fetch+checkout, or a later edit could build a default branch while leaving
-    # the pin text dangling elsewhere in the step (unfailable regression).
-    assert f"KCOV_COMMIT: {KCOV_COMMIT_PIN}" in build_step, (
-        f"the pinned commit must be wired through KCOV_COMMIT; step was:\n{build_step}"
+    # Not just "the pin appears somewhere" -- extract the actual env value (never a
+    # bare substring search over the whole step, which a stray same-step comment
+    # containing the pin text would satisfy while the real value moved) and require
+    # it feeds the fetch+checkout via $KCOV_COMMIT.
+    env_value = re.search(r"(?m)^\s+KCOV_COMMIT:\s*(.+)$", build_step)
+    assert env_value and env_value.group(1).split("#", 1)[0].strip() == KCOV_COMMIT_PIN, (
+        f"KCOV_COMMIT must be set to the pinned commit; step was:\n{build_step}"
     )
     assert re.search(
         r'git -C kcov fetch --depth 1 origin "\$KCOV_COMMIT"\s+git -C kcov checkout -q FETCH_HEAD\b',
@@ -161,6 +163,6 @@ def test_kcov_ci_build_is_pinned_to_a_commit_not_a_moving_tag() -> None:
     ]
     for step in cache_steps:
         key_line = re.search(r"(?m)^\s+key:\s*(.+)$", step)
-        assert key_line and KCOV_COMMIT_PIN in key_line.group(1), (
+        assert key_line and KCOV_COMMIT_PIN in key_line.group(1).split("#", 1)[0], (
             f"the kcov cache key must fold in the pinned commit; step was:\n{step}"
         )

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -5,6 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 SHELLCHECK_PIN = "v0.11.0"
 SHELLSPEC_PIN = "0.28.1"
+KCOV_COMMIT_PIN = "a39874f938ce13f7a65f253120d1ec946b349ffe"
 
 
 def _workflow() -> str:
@@ -112,3 +113,44 @@ def test_shellspec_job_requires_jq_and_dash_instead_of_installing_them() -> None
             f"{tool} must be asserted present, with a branch that fails the job when it is not;"
             f" step was:\n{require_step}"
         )
+
+
+def test_ci_shellspec_pin_matches_the_documented_local_version() -> None:
+    """A local install must be the same shellspec CI verifies against, in the same
+    shape as the ShellCheck version tie above."""
+    documented = re.findall(
+        r"[Ss]hellspec.{0,300}?\bpins\s+\*\*(\d+\.\d+\.\d+)\*\*",
+        (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8"),
+        re.DOTALL,
+    )
+
+    assert documented, "CONTRIBUTING.md must document the shellspec version CI pins"
+    assert set(documented) == {SHELLSPEC_PIN}, (
+        f"CONTRIBUTING.md documents shellspec {documented}, CI pins {SHELLSPEC_PIN}"
+    )
+
+
+def test_kcov_ci_build_is_pinned_to_a_commit_not_a_moving_tag() -> None:
+    """`--branch v43` tracks a moving tag: a re-tag upstream swaps what gets built and
+    cached under the `kcov-*` key with nothing noticing. The build must check out a
+    fixed commit SHA instead, and that SHA must be folded into both cache steps' keys
+    so a re-pin busts the cache rather than silently keeping the old binary."""
+    shell_tests_job = _job(_workflow(), "shell-tests", "php-syntax")
+    build_step = shell_tests_job.split("      - name: Build kcov from source (cache miss)\n", 1)[1].split(
+        "\n      - name:", 1
+    )[0]
+
+    assert not re.search(r"--branch\s+v43\b", build_step), (
+        f"kcov must not be built from the moving v43 tag; step was:\n{build_step}"
+    )
+    assert re.search(rf"\b{KCOV_COMMIT_PIN}\b", build_step), (
+        f"the kcov build must check out the pinned commit {KCOV_COMMIT_PIN}; step was:\n{build_step}"
+    )
+
+    cache_steps = [
+        step
+        for name in ("Restore cached kcov binary", "Save kcov binary to cache")
+        for step in [shell_tests_job.split(f"      - name: {name}\n", 1)[1].split("\n      - name:", 1)[0]]
+    ]
+    for step in cache_steps:
+        assert KCOV_COMMIT_PIN in step, f"the kcov cache key must fold in the pinned commit; step was:\n{step}"


### PR DESCRIPTION
## Summary

- Pin the kcov build to a resolved commit (`a39874f938ce13f7a65f253120d1ec946b349ffe`, currently `v43`) via a fetch-by-SHA clone instead of `clone --branch v43`, and fold the commit into both cache steps' keys — a re-tag upstream no longer silently swaps the coverage tool cached under `kcov-*`.
- Document the shellspec version CI pins (`0.28.1`) in CONTRIBUTING.md and pin the official installer to it, mirroring the existing ShellCheck local-install doc.
- Tie CI's pin to the documented version with a new test in `tests/test_ci_tool_pins.py`, same shape as `test_ci_shellcheck_pin_matches_the_documented_local_version`.

Part of #2198

## Test plan

- [x] `tests/test_ci_tool_pins.py::test_ci_shellspec_pin_matches_the_documented_local_version` and `test_kcov_ci_build_is_pinned_to_a_commit_not_a_moving_tag` reproduced RED against the pre-change files, GREEN unchanged after
- [x] `python3 -m pytest` (full suite): 4677 passed, 4 skipped
- [x] `actionlint .github/workflows/test.yml` — only a pre-existing unrelated SC2016 finding
- [x] `ruff check` / `ruff format --check` on the changed test file
- [x] `markdownlint-cli2 CONTRIBUTING.md` — 0 issues
- [x] verified `git init && git remote add ... && git fetch --depth 1 origin <sha> && git checkout FETCH_HEAD` resolves the pinned kcov commit against the real GitHub remote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Pinned the CI coverage tool to a specific, reproducible version.
  - Updated CI cache handling to use the pinned version consistently.

- **Tests**
  - Added checks to verify that CI tool versions match documented local versions.
  - Added validation to prevent use of moving version tags for coverage builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->