### PR TITLE
ci: pin the kcov build and the documented shellspec install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -292,6 +292,12 @@ jobs:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest
 
+    # The commit upstream's v43 tag pointed at when the pin was taken. Job-level so the
+    # cache keys below can carry it: a tag is a moving reference, so re-pinning kcov has
+    # to roll the cache over too, or a stale build would answer the new key (#2198).
+    env:
+      KCOV_COMMIT: a39874f938ce13f7a65f253120d1ec946b349ffe
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -378,11 +384,16 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.local/kcov
-          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
+          key: kcov-${{ env.KCOV_COMMIT }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
 
       - name: Build kcov from source (cache miss)
         # Only runs when the cache is cold. best-effort: a compile failure still
         # leaves CI green (coverage is informational).
+        # The clone resolves the v43 TAG, which upstream can move, so what it produced is
+        # checked against KCOV_COMMIT before anything is built from it (#2198). A mismatch
+        # fails this step: the build is swallowed by continue-on-error, so the cache save
+        # is skipped, kcov stays absent, and the coverage step reports it instead of
+        # measuring with a tool nobody pinned.
         id: build-kcov
         if: steps.cache-kcov.outputs.cache-hit != 'true'
         continue-on-error: true
@@ -390,6 +401,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -y \
             binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libdw-dev zlib1g-dev cmake g++
           git clone --depth 1 --branch v43 https://github.com/SimonKagstrom/kcov
+          cloned="$(git -C kcov rev-parse HEAD)"
+          [ "$cloned" = "$KCOV_COMMIT" ] || {
+            echo "kcov v43 resolves to $cloned, expected $KCOV_COMMIT (upstream re-tag?)"; exit 1; }
           cmake -S kcov -B kcov/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/.local/kcov"
           cmake --build kcov/build --parallel "$(nproc)"
           cmake --install kcov/build
@@ -402,7 +416,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.local/kcov
-          key: kcov-v43-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
+          key: kcov-${{ env.KCOV_COMMIT }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
 
       - name: Install kcov runtime deps and add to PATH
         # Runtime shared libs (libcurl, libelf, libdw) needed on both cache hit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,9 +162,18 @@ shellspec            # from the repo root; reads ./.shellspec
 shellspec --kcov     # with coverage (informational; needs kcov)
 ```
 
-Install with `brew install shellspec` (macOS) or the official installer
-(`curl -fsSL https://git.io/shellspec | sh`). The pre-commit hook and CI run it
-automatically when `shellspec` is present (coverage is informational, no floor).
+Install shellspec **0.28.1** — the version CI pins and verifies by checksum, so a
+clean local run and CI agree. Either take the release asset:
+
+```sh
+curl -fsSLo shellspec-dist.tar.gz \
+  https://github.com/shellspec/shellspec/releases/download/0.28.1/shellspec-dist.tar.gz
+tar -xzf shellspec-dist.tar.gz -C "$HOME"   # then put "$HOME/shellspec" on PATH
+```
+
+or use `brew install shellspec` (macOS) and check `shellspec --version`. The
+pre-commit hook and CI run it automatically when `shellspec` is present (coverage
+is informational, no floor).
 See [`tests/shell/README.md`](tests/shell/README.md) for the harness contracts
 (the `iprange` PATH shim, the AWS fixture, and the `PFB_SOURCED` source-for-test
 pattern).

--- a/tests/shell/README.md
+++ b/tests/shell/README.md
@@ -16,8 +16,8 @@ shellspec tests/shell/ip_pre_aws_spec.sh   # a single spec
 shellspec --kcov              # with coverage (writes ./coverage/, needs kcov)
 ```
 
-Install: `brew install shellspec` (macOS) or the official installer
-(`curl -fsSL https://git.io/shellspec | sh`); `kcov` is only needed for `--kcov`.
+Install per [`CONTRIBUTING.md`](../../CONTRIBUTING.md) ("Shell tests (shellspec)"),
+which pins the version CI verifies; `kcov` is only needed for `--kcov`.
 The pre-commit hook and CI run the suite automatically when `shellspec` is present.
 
 ## Layout

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -5,10 +5,15 @@ ROOT = Path(__file__).resolve().parents[1]
 
 SHELLCHECK_PIN = "v0.11.0"
 SHELLSPEC_PIN = "0.28.1"
+KCOV_PIN = "a39874f938ce13f7a65f253120d1ec946b349ffe"  # the commit tag v43 pointed at
 
 
 def _workflow() -> str:
     return (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
+
+
+def _contributing() -> str:
+    return (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
 
 
 def _job(workflow: str, name: str, next_name: str) -> str:
@@ -89,6 +94,49 @@ def test_shellspec_ci_install_is_pinned_to_a_verified_release_asset() -> None:
     assert not re.search(r"\|\s*tar\b", install_step), (
         f"fetch to a file and verify it before extracting, never pipe the download into tar; step was:\n{install_step}"
     )
+
+
+def test_contributing_documents_the_shellspec_version_ci_pins() -> None:
+    """A contributor whose local shellspec differs from the verified CI one gets a verdict
+    CI will not reproduce, so the documented install names the pinned version (#2198)."""
+    documented = re.findall(r"shellspec.{0,200}?\b(\d+\.\d+\.\d+)\b", _contributing(), re.DOTALL | re.IGNORECASE)
+
+    assert documented, "CONTRIBUTING.md must document the shellspec version contributors install locally"
+    assert set(documented) == {SHELLSPEC_PIN}, (
+        f"CONTRIBUTING.md documents shellspec {documented}, CI pins {SHELLSPEC_PIN}"
+    )
+
+
+def test_kcov_ci_build_is_pinned_to_an_immutable_commit() -> None:
+    """`--branch v43` resolves through a tag, which upstream can move: the coverage tool
+    that gets built — and cached under the key below — would change silently (#2198)."""
+    shell_tests_job = _job(_workflow(), "shell-tests", "php-syntax")
+    build_step = shell_tests_job.split("      - name: Build kcov from source (cache miss)\n", 1)[1].split(
+        "\n      - name:", 1
+    )[0]
+
+    assert f"KCOV_COMMIT: {KCOV_PIN}" in shell_tests_job, (
+        f"the kcov build must pin the commit v43 resolves to; job was:\n{shell_tests_job}"
+    )
+    # A clone by tag is fine as long as what it produced is checked against the pin before
+    # anything is built from it — the guard is the branch that fails, not the clone.
+    assert re.search(r"^\s*\[ \"\$cloned\" = \"\$KCOV_COMMIT\" \] \|\|", build_step, re.MULTILINE), (
+        f"the cloned tree must be asserted to be the pinned commit, with a branch that fails"
+        f" the step when it is not; step was:\n{build_step}"
+    )
+    # Anchored on the build invocation, not a bare `cmake` — the apt-get line installs a
+    # package by that name, and matching it would pass no matter where the check sits.
+    assert build_step.index("rev-parse HEAD") < build_step.index("cmake -S kcov"), (
+        f"verify the clone before building from it; step was:\n{build_step}"
+    )
+
+    keys = re.findall(r"^\s+key: (kcov-.+)$", shell_tests_job, re.MULTILINE)
+
+    assert len(keys) == 2, f"expected a restore key and a save key for the kcov cache; found {keys}"
+    for key in keys:
+        assert "env.KCOV_COMMIT" in key, (
+            f"a re-pinned kcov must roll the cache over, so the key carries the pin, not a tag name; key was: {key}"
+        )
 
 
 def test_shellspec_job_requires_jq_and_dash_instead_of_installing_them() -> None:

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -99,11 +99,31 @@ def test_shellspec_ci_install_is_pinned_to_a_verified_release_asset() -> None:
 def test_contributing_documents_the_shellspec_version_ci_pins() -> None:
     """A contributor whose local shellspec differs from the verified CI one gets a verdict
     CI will not reproduce, so the documented install names the pinned version (#2198)."""
-    documented = re.findall(r"shellspec.{0,200}?\b(\d+\.\d+\.\d+)\b", _contributing(), re.DOTALL | re.IGNORECASE)
+    # Anchored on the install instruction itself. Scanning a window after any mention of
+    # shellspec would take its version from whatever unrelated `X.Y.Z` a later doc edit
+    # happens to put nearby — the file names shellspec ~20 times.
+    documented = re.findall(r"Install shellspec\D{0,40}?\b(\d+\.\d+\.\d+)\b", _contributing())
 
     assert documented, "CONTRIBUTING.md must document the shellspec version contributors install locally"
     assert set(documented) == {SHELLSPEC_PIN}, (
         f"CONTRIBUTING.md documents shellspec {documented}, CI pins {SHELLSPEC_PIN}"
+    )
+
+
+def test_no_doc_offers_an_unpinned_shellspec_installer() -> None:
+    """CONTRIBUTING.md's pinned instructions are only worth anything if they are the ones a
+    contributor finds: tests/shell/README.md carried a second, unpinned install (`brew` +
+    the upstream `curl | sh`) that CONTRIBUTING.md itself links to (#2198)."""
+    skip = {"node_modules", ".venv", "vendor", "plugins", ".git"}
+    offenders = sorted(
+        str(path.relative_to(ROOT))
+        for path in ROOT.rglob("*.md")
+        if not skip & set(path.parts) and "git.io/shellspec" in path.read_text(encoding="utf-8")
+    )
+
+    assert offenders == [], (
+        f"these docs still hand out an unpinned shellspec installer instead of pointing at"
+        f" CONTRIBUTING.md's pinned instructions: {offenders}"
     )
 
 
@@ -115,6 +135,9 @@ def test_kcov_ci_build_is_pinned_to_an_immutable_commit() -> None:
         "\n      - name:", 1
     )[0]
 
+    # Equality with KCOV_PIN alone would still hold if both sides drifted back to `v43`,
+    # while every fresh clone would then fail the runtime comparison.
+    assert re.fullmatch(r"[0-9a-f]{40}", KCOV_PIN), f"KCOV_PIN must be a commit id, not a moving ref; was {KCOV_PIN}"
     assert f"KCOV_COMMIT: {KCOV_PIN}" in shell_tests_job, (
         f"the kcov build must pin the commit v43 resolves to; job was:\n{shell_tests_job}"
     )


### PR DESCRIPTION
## What

Closes the two pinning gaps #2194 left behind, both surfaced by the adversarial review of #2197.

**kcov was built from a mutable tag.** `git clone --depth 1 --branch v43` resolves through a tag reference, so a re-tag upstream would change the coverage tool that gets built and cached, with nothing to notice it. The commit that tag points at is now pinned as `KCOV_COMMIT`, the cloned tree is checked against it *before* anything is built from it, and the pin is carried in the cache key so a future re-pin rolls the cache over instead of restoring the old build. A mismatch fails the build step, which is `continue-on-error: true` — so the cache save is skipped, kcov stays absent, and the informational coverage step reports that instead of measuring with a tool nobody pinned.

**The documented local shellspec install was unpinned.** `CONTRIBUTING.md` pointed at `brew install shellspec` or the upstream installer, so a contributor's local verdict could come from a different shellspec than the checksum-verified `0.28.1` CI runs since #2197. It now documents `0.28.1` and the release asset, mirroring the ShellCheck instructions, and a test ties the two together the way `test_ci_shellcheck_pin_matches_the_documented_local_version` already does for ShellCheck.

## Evidence

The pin is what the tag actually resolves to today — probed, not read:

```
$ git clone --depth 1 --branch v43 https://github.com/SimonKagstrom/kcov /tmp/kcovprobe
warning: refs/tags/v43 88c07200750630f8eab9c0a5ac9abaedecc922f8 is not a commit!
$ git -C /tmp/kcovprobe rev-parse HEAD
a39874f938ce13f7a65f253120d1ec946b349ffe
```

(the tag is annotated; the pin is the commit it peels to, which is what the clone checks out and what the new guard compares against).

Test-first: both new cases were executed RED against the pre-change tree — `CONTRIBUTING.md must document the shellspec version contributors install locally` and `the kcov build must pin the commit v43 resolves to` — and GREEN after the change, with the whole file at `7 passed`.

Each assertion was then mutation-tested independently, since the first failing assert would otherwise mask the rest:

| Mutation | Assertion that fired |
| --- | --- |
| drop the `[ "$cloned" = "$KCOV_COMMIT" ]` guard | "the cloned tree must be asserted to be the pinned commit…" |
| move the guard after `cmake -S kcov` | "verify the clone before building from it" |
| revert the cache key to `kcov-v43-` | "a re-pinned kcov must roll the cache over…" |
| document `0.28.0` in CONTRIBUTING.md | "CONTRIBUTING.md documents shellspec ['0.28.0', …], CI pins 0.28.1" |

The ordering assertion is anchored on `cmake -S kcov` rather than a bare `cmake`, because the apt-get line installs a package by that name and a bare match would pass regardless of where the guard sits.

`${{ env.KCOV_COMMIT }}` in a step's `with:` follows existing repo usage (`${{ env.ARCHIVE }}`, `${{ env.PKG_PATH }}` in `release.yml`); the rendered keys were confirmed by parsing the workflow:

```
kcov-${{ env.KCOV_COMMIT }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}   (restore)
kcov-${{ env.KCOV_COMMIT }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}   (save)
```

Gates: pytest, ruff check, ruff format, mypy, markdownlint all PASS.

## Notes

The cache key change invalidates the existing `kcov-v43-*` entries by design — the first run on each runner image rebuilds kcov once and re-caches under the pinned key.

Part of #2198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by pinning KCOV builds and caches to a verified immutable commit.
  * Added validation to ensure the checked-out KCOV source matches the expected revision before compilation.

* **Tests**
  * Added automated checks for KCOV pinning, cache configuration, source validation, and consistency between documented and CI-pinned ShellSpec versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->