### PR TITLE
ci: build the pkg channel the ports tree still carries (#2166)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -275,7 +275,7 @@ jobs:
     needs: [resolve-version, publish-image]
     uses: ./.github/workflows/build-pkg-linux.yml
     with:
-      channel: devel
+      channel: edge
       # Pass the CE-version-derived target EXPLICITLY (issue #22) — never rely on
       # the builder's defaults, which match the min CE only.
       abi: FreeBSD:${{ needs.resolve-version.outputs.freebsd_major }}:amd64

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -33,9 +33,9 @@ on:
   workflow_dispatch:
     inputs:
       channel:
-        description: "pfBlockerNG channel/port (devel|stable)"
+        description: "pfBlockerNG channel/port — one of stable, testing, edge, nightly (the builder rejects anything else)"
         required: false
-        default: "devel"
+        default: "edge"
       abi:
         description: "Target ABI — FreeBSD:<freebsd_major>:<arch> for the target pfSense base, per the ci-metadata version matrix"
         required: false
@@ -73,7 +73,7 @@ on:
       channel:
         required: false
         type: string
-        default: "devel"
+        default: "edge"
       abi:
         required: false
         type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -493,7 +493,8 @@ jobs:
 
       - name: Detect pkg channel from tag
         id: channel
-        # The channel drives which port we build (devel vs stable). Classified by
+        # The channel drives which port we build (stable, testing, or edge — the ports
+        # tree carries one recipe per channel). Classified by
         # scripts/release-version.sh: vX.Y.Z.aN|.bN|.rN -> prerelease, vX.Y.Z -> stable.
         #
         # It also decides, from the SAME classification, whether the live smoke/UI

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -243,7 +243,7 @@ jobs:
     if: ${{ inputs.pkg_artifact == '' }}
     uses: ./.github/workflows/build-pkg-linux.yml
     with:
-      channel: devel
+      channel: edge
       # Build a .pkg whose ABI + dep names match THIS leg's image. A bare dispatch
       # keeps the workflow's min-CE defaults; the fan-out passes per-leg values from
       # the ci-metadata version matrix so each leg gets an ABI/flavor-matched .pkg

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -275,7 +275,7 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.leg_matrix) }}
     uses: ./.github/workflows/build-pkg-linux.yml
     with:
-      channel: devel
+      channel: edge
       # ABI/dep target matching this leg's image (CE=FreeBSD:15, Plus=FreeBSD:16
       # in the current matrix) — pkg add refuses a cross-major-ABI .pkg.
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -205,7 +205,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.build_matrix) }}
     uses: ./.github/workflows/build-pkg-linux.yml
     with:
-      channel: devel
+      channel: edge
       # Build the leg's .pkg for its own pfSense base, with the ABI/php/python
       # values coming from the leg's version-matrix entry.
       abi: FreeBSD:${{ matrix.freebsd_major }}:amd64

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -173,10 +173,10 @@ jobs:
             # regardless of what's given, so every arch of this FreeBSD major
             # is served by the one build this triggers.
             ABI="FreeBSD:${MAJOR}:amd64"
-            # Channel maps to pkg channel: CE on devel branch -> devel, main -> stable
-            # For standalone tracker runs we use 'devel' as the pkg channel by default.
+            # Channel maps to pkg channel: the devel branch's prerelease line -> edge,
+            # main -> stable. For standalone tracker runs we use 'edge' by default.
             # A real release tag push always uses release.yml; this is a build smoke-check.
-            PKG_CHANNEL="devel"
+            PKG_CHANNEL="edge"
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "  [DRY-RUN] WOULD dispatch build-pkg-linux.yml:"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,8 +298,9 @@ On a FreeBSD machine with the ports tree available:
 cd /usr/ports/net/pfSense-pkg-pfBlockerNG
 make package
 
-# Devel
-cd /usr/ports/net/pfSense-pkg-pfBlockerNG-devel
+# Pre-release channel (edge is the line the devel branch builds;
+# testing and nightly have their own recipes)
+cd /usr/ports/net/pfSense-pkg-pfBlockerNG-edge
 make package
 ```
 
@@ -682,8 +683,10 @@ To update the ports tree manually instead:
 ```sh
 # In our fork clone (pfBlockerNG/FreeBSD-ports, branch pfblockerng/use-github),
 # edit the matching port Makefile:
-# net/pfSense-pkg-pfBlockerNG/Makefile        (stable)
-# net/pfSense-pkg-pfBlockerNG-devel/Makefile  (devel)
+# net/pfSense-pkg-pfBlockerNG/Makefile          (stable)
+# net/pfSense-pkg-pfBlockerNG-testing/Makefile  (testing)
+# net/pfSense-pkg-pfBlockerNG-edge/Makefile     (edge)
+# net/pfSense-pkg-pfBlockerNG-nightly/Makefile  (nightly)
 
 # Update GH_TAGNAME to the new tag, then bump PORTREVISION if the
 # PORTVERSION is unchanged, or update PORTVERSION to match the new tag.

--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ retained versions per pfSense edition, with their commit and date.
 ### Building from the FreeBSD ports tree
 
 On a FreeBSD machine with the ports tree available, the package can be built
-directly — `make package` in `net/pfSense-pkg-pfBlockerNG` (stable) or
-`net/pfSense-pkg-pfBlockerNG-devel` (devel); the resulting `.pkg` lands in
-`work/pkg/`.
+directly — `make package` in `net/pfSense-pkg-pfBlockerNG` (stable) or the
+channel recipe you want, e.g. `net/pfSense-pkg-pfBlockerNG-edge` (the line the
+`devel` branch builds); the resulting `.pkg` lands in `work/pkg/`.
 
 ## Documentation
 

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -167,11 +167,12 @@ The portable Linux builder reproduces `make package` for this `NO_BUILD` port. F
 
 ```sh
 python3 scripts/build-pkg-portable.py \
-  --ports /path/to/FreeBSD-ports --channel devel --local-src . \
+  --ports /path/to/FreeBSD-ports --channel edge --local-src . \
   --abi FreeBSD:15:amd64 --py-flavor py311 --php 8.3 --out out/
 ```
 
-`--ports` is a FreeBSD-ports checkout containing `net/pfSense-pkg-pfBlockerNG-devel`.
+`--ports` is a FreeBSD-ports checkout containing `net/pfSense-pkg-pfBlockerNG-edge`
+(the channel the devel branch builds; `--channel` accepts stable, testing, edge, nightly).
 `pkg add` checks a dep is PRESENT, not its version, so this `.pkg` installs on the
 baked-deps image.
 

--- a/docs/misc/pfSense_versions.md
+++ b/docs/misc/pfSense_versions.md
@@ -8,7 +8,8 @@ How these were obtained (and how to re-verify — see CLAUDE.md "Investigating t
 live system"): on a live box, `pkg info` (installed set), `pkg info -d <pkg>`
 (a package's declared deps), `php -v` / `python --version`. The authoritative
 dependency list is the port Makefile `RUN_DEPENDS`
-(`net/pfSense-pkg-pfBlockerNG-devel`); the tables below are a hand-maintained
+(`net/pfSense-pkg-pfBlockerNG-edge`, the channel the devel branch builds — the
+`-devel` recipe was retired from the ports tree, issue #2166); the tables below are a hand-maintained
 mirror — confirm against the port (or a built `.pkg`) when baking an image.
 
 ## 2.8.x (CE)
@@ -71,7 +72,7 @@ them from the local pkg db **offline** (see `.ADRs/ADR_04_VM_Smoke_Tests/IMAGE_R
 
 These are the port's explicit `RUN_DEPENDS` (10 packages, issue #1806 — fixes a
 pre-existing drift against the port Makefile: this table had stopped at 9),
-verified against `net/pfSense-pkg-pfBlockerNG-devel/Makefile`. To bake them
+verified against `net/pfSense-pkg-pfBlockerNG-edge/Makefile`. To bake them
 onto an image, run
 [`scripts/misc/install_deps_CE_2.8.sh`](../../scripts/misc/install_deps_CE_2.8.sh)
 on the box (as root):

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4550,11 +4550,18 @@ function pfb_wizard_dnsvip_settings(bool $auto, $vip4, $vip6): array {
 /*
  * Channel a build is on, from its installed package NAME:
  *   pfSense-pkg-pfBlockerNG         -> 'stable'
- *   pfSense-pkg-pfBlockerNG-devel   -> 'devel'
+ *   pfSense-pkg-pfBlockerNG-testing -> 'testing'
+ *   pfSense-pkg-pfBlockerNG-edge    -> 'edge'
+ *   pfSense-pkg-pfBlockerNG-devel   -> 'devel'   (retired port; installed boxes remain)
  *   pfSense-pkg-pfBlockerNG-NIGHTLY -> 'nightly' (ADR-18)
  * Anything unrecognised/empty -> NULL. The installed name is authoritative for "what
  * channel am I on" (ADR-19 §2 channel detection). Suffix match is case-insensitive so
  * the NIGHTLY/devel spellings are tolerant.
+ *
+ * issue #2166: the ports tree replaced the -devel recipe with -testing/-edge/-nightly, so
+ * a build from the current CI channel reports one of those names. -devel stays mapped:
+ * boxes installed before the rename still carry it, and dropping it here would read them
+ * as an unknown channel — i.e. not our build.
  */
 function pfb_channel_from_pkgname(?string $name): ?string {
 	if (!is_string($name) || $name === '') {
@@ -4568,6 +4575,10 @@ function pfb_channel_from_pkgname(?string $name): ?string {
 	switch ($suffix) {
 		case '':
 			return 'stable';
+		case '-testing':
+			return 'testing';
+		case '-edge':
+			return 'edge';
 		case '-devel':
 			return 'devel';
 		case '-nightly':
@@ -4579,13 +4590,16 @@ function pfb_channel_from_pkgname(?string $name): ?string {
 
 /*
  * The pkg repo "read latest" maps to, for a given channel (2026-06-14 + 2026-06-15
- * amendments): stable AND devel share ONE repo 'pfblockerng' (the channel selects the
- * package, not a per-channel repo); 'nightly' is the sole separately-channelled build,
- * repo 'pfblockerng-nightly'. An unrecognised channel -> NULL (no repo to read from).
+ * amendments): stable AND the pre-release channels share ONE repo 'pfblockerng' (the
+ * channel selects the package, not a per-channel repo); 'nightly' is the sole
+ * separately-channelled build, repo 'pfblockerng-nightly'. An unrecognised channel ->
+ * NULL (no repo to read from). Per-channel catalogues are #2148's cutover, not this.
  */
 function pfb_pkg_repo_name_for_channel(?string $channel): ?string {
 	switch ($channel) {
 		case 'stable':
+		case 'testing':
+		case 'edge':
 		case 'devel':
 			return 'pfblockerng';
 		case 'nightly':

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -34,6 +34,10 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		return [
 			'stable: bare release name'   => ['pfSense-pkg-pfBlockerNG', 'stable'],
 			'devel: -devel suffix'        => ['pfSense-pkg-pfBlockerNG-devel', 'devel'],
+			'testing: -testing suffix'    => ['pfSense-pkg-pfBlockerNG-testing', 'testing'],
+			'edge: -edge suffix'          => ['pfSense-pkg-pfBlockerNG-edge', 'edge'],
+			'edge: case-insensitive'      => ['PFSENSE-PKG-PFBLOCKERNG-EDGE', 'edge'],
+			'testing: case-insensitive'   => ['PFSENSE-PKG-PFBLOCKERNG-TESTING', 'testing'],
 			'nightly: -NIGHTLY suffix'    => ['pfSense-pkg-pfBlockerNG-NIGHTLY', 'nightly'],
 			'nightly: case-insensitive'   => ['pfSense-pkg-pfBlockerNG-nightly', 'nightly'],
 			'devel: case-insensitive'     => ['PFSENSE-PKG-PFBLOCKERNG-DEVEL', 'devel'],
@@ -61,6 +65,8 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		return [
 			'stable -> shared pfblockerng'  => ['stable', 'pfblockerng'],
 			'devel -> shared pfblockerng'   => ['devel', 'pfblockerng'],
+			'testing -> shared pfblockerng' => ['testing', 'pfblockerng'],
+			'edge -> shared pfblockerng'    => ['edge', 'pfblockerng'],
 			'nightly -> pfblockerng-nightly' => ['nightly', 'pfblockerng-nightly'],
 			'unknown channel -> null'        => ['beta', null],
 			'null channel -> null'           => [null, null],

--- a/tests/smoke/pkg_identity.py
+++ b/tests/smoke/pkg_identity.py
@@ -1,0 +1,57 @@
+"""The package NAME the branch under test installs as.
+
+The built .pkg carries the name of the port the builder was pointed at
+(``build-pkg-portable.py --channel`` -> ``net/pfSense-pkg-pfBlockerNG-<channel>``), so a
+live-install case that spells the suffix by hand silently outlives every channel rename and
+then fails on the VM at ``pkg install`` — issue #2166, where the workflows still asked for
+the retired ``devel`` channel weeks after the ports tree had replaced it with
+``testing``/``edge``/``nightly``.
+
+Stdlib only, no relative imports: the default unit tier ``--ignore``s tests/smoke, so
+tests/test_issue2166_workflow_channel_inputs.py loads this module BY PATH to pin it against
+the workflows. Importing the smoke package instead would drag in conftest's dnspython and
+requests, which that tier does not install.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# The channel build-pkg-linux.yml builds, for the case where no artifact is in hand (a dev
+# box collecting without SMOKE_PKG). test_issue2166_workflow_channel_inputs.py pins this to
+# the workflow's own default, so the two can never drift apart unnoticed.
+DEFAULT_CHANNEL = "edge"
+
+# `<name>-<version>.pkg`: a FreeBSD pkg version never contains '-' and always starts with a
+# digit, so the last '-' before a digit run ends the name.
+_PKG_FILE = re.compile(r"^(?P<name>pfSense-pkg-pfBlockerNG(?:-[a-z]+)?)-\d[^-]*\.pkg$")
+
+
+def branch_channel(pkg_path: str | None) -> str:
+    """Return the channel the build installed from ``pkg_path`` reports on the box.
+
+    `pfb_channel_from_pkgname()` derives the channel from the installed package NAME, so a
+    live case asserting on the channel must read it from the same artifact the name comes
+    from — a hard-coded ``"devel"`` outlives a rename exactly as silently as a hard-coded
+    package name did (issue #2166).
+    """
+    suffix = branch_pkg_name(pkg_path)[len("pfSense-pkg-pfBlockerNG") :]
+    return suffix.lstrip("-") or "stable"
+
+
+def branch_pkg_name(pkg_path: str | None) -> str:
+    """Return the pfBlockerNG package name ``pkg_path`` installs as.
+
+    ``pkg_path`` is the built artifact (the harness hands it over as ``SMOKE_PKG``); pass
+    ``None`` when there is no artifact to read and the caller only needs the name CI builds.
+
+    An artifact whose name cannot be read raises: guessing there would hand the caller a name
+    the .pkg does not have, which is the silent drift this module exists to stop.
+    """
+    if not pkg_path:  # unset or empty SMOKE_PKG — conftest treats both as "no artifact"
+        return f"pfSense-pkg-pfBlockerNG-{DEFAULT_CHANNEL}"
+    match = _PKG_FILE.match(Path(pkg_path).name)
+    if not match:
+        raise ValueError(f"not a pfBlockerNG package filename: {pkg_path!r}")
+    return match.group("name")

--- a/tests/smoke/test_dns_redirect.py
+++ b/tests/smoke/test_dns_redirect.py
@@ -51,11 +51,12 @@ import pytest
 
 from . import helpers as h
 from .conftest import SmokeVM, _StubDnsServer
+from .pkg_identity import branch_pkg_name
 
 pytestmark = pytest.mark.smoke
 
-# Package name on the devel channel (matches test_smoke_managed_objects.py).
-_PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"
+# Branch package name, read off the built .pkg (matches test_smoke_managed_objects.py).
+_PKG_NAME = branch_pkg_name(os.environ.get("SMOKE_PKG"))
 
 # Marker prefix for DNS-redirect owned rules (mirrors PFB_DNS_REDIR_DESCR_V4_PFX).
 _REDIR_DESCR_PFX = "pfB_DNS_Redirect_"

--- a/tests/smoke/test_dot_doq_block.py
+++ b/tests/smoke/test_dot_doq_block.py
@@ -55,11 +55,12 @@ import pytest
 
 from . import helpers as h
 from .conftest import SmokeVM, _StubDnsServer
+from .pkg_identity import branch_pkg_name
 
 pytestmark = pytest.mark.smoke
 
-# Package name on the devel channel (matches test_dns_redirect.py).
-_PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"
+# Branch package name, read off the built .pkg (matches test_dns_redirect.py).
+_PKG_NAME = branch_pkg_name(os.environ.get("SMOKE_PKG"))
 
 # Marker prefix for DoT/DoQ-block owned rules (mirrors PFB_DOT_BLOCK_DESCR_PFX). Doubles as
 # the ``_is_block_853_line`` ownership anchor in ``pfctl -sr`` output (#813, #849): plain

--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -43,6 +43,7 @@ import pytest
 
 from . import helpers as h
 from .conftest import SmokeVM
+from .pkg_identity import branch_pkg_name
 from .test_repo_install import (
     _box_real_varver,
     _ensure_egress_open,
@@ -59,9 +60,12 @@ from .test_repo_install import (
 pytestmark = pytest.mark.repo
 
 NIGHTLY_NAME = "pfSense-pkg-pfBlockerNG-nightly"
-DEVEL_NAME = "pfSense-pkg-pfBlockerNG-devel"
+# The DEVEL_* names below are historical: they mean "the branch package, whichever channel it
+# was built on" (the ports tree retired the -devel channel; the devel branch now builds edge).
+# Nightly is the one package with a fixed name of its own, so it stays a literal.
+DEVEL_NAME = branch_pkg_name(os.environ.get("SMOKE_PKG"))
 NIGHTLY_REPO = "pfblockerng-nightly"  # the %R origin a nightly install reports
-DEVEL_REPO = "pfblockerng"  # %R origin of the controlled -devel install (the shared release repo)
+DEVEL_REPO = "pfblockerng"  # %R origin of the controlled branch-package install (the shared release repo)
 
 SPIKE = "/tmp/pfb_nightly_spike"
 NIGHTLY_DIR = f"{SPIKE}/nightly"  # the file:// nightly catalog

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -94,10 +94,11 @@ from ._matrix import (
     own_variant,
 )
 from .conftest import SmokeVM
+from .pkg_identity import branch_pkg_name
 
 pytestmark = pytest.mark.repo
 
-PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"
+PKG_NAME = branch_pkg_name(os.environ.get("SMOKE_PKG"))
 
 # Our repo conf on the guest + the served catalog root. The conf name follows the
 # CLAUDE.md "match the surrounding pattern" rule: pfSense's own conf is
@@ -820,7 +821,7 @@ def test_install_from_our_repo_lands_all_files(repo_vm: SmokeVM) -> None:
     with NO ``-r`` — picks ours.
 
     Given the package ABSENT (``pkg query %v`` fails),
-    When ``pkg install -y pfSense-pkg-pfBlockerNG-devel`` runs (NO ``-r``, NO ``-f``),
+    When ``pkg install -y <the branch package>`` runs (NO ``-r``, NO ``-f``),
     Then it installs from OUR repo (``pkg query %R`` == ``pfblockerng``), with
       no "Missing dependency" (RUN_DEPENDS resolved), AND every file the package
       registers (``pkg info -l``) is present on-box (> 50) — the install really wrote

--- a/tests/smoke/test_smoke_managed_objects.py
+++ b/tests/smoke/test_smoke_managed_objects.py
@@ -33,11 +33,12 @@ import pytest
 
 from . import helpers as h
 from .conftest import SmokeVM, _StubDnsServer
+from .pkg_identity import branch_pkg_name
 
 pytestmark = pytest.mark.smoke
 
-# Package name on the devel channel (matches test_repo_install.py's PKG_NAME).
-_PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"
+# Branch package name, read off the built .pkg (matches test_repo_install.py's PKG_NAME).
+_PKG_NAME = branch_pkg_name(os.environ.get("SMOKE_PKG"))
 
 # Descr markers that identify pfBlockerNG-owned objects (mirrors pfb_is_managed_obj in pfblockerng.inc).
 _AUTO_VIP_DESCR_V4 = "pfB_AUTO_VIP_v4"

--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -62,6 +62,7 @@ import pytest
 # (module-level "unused") fixture import; the matching F811 ("redefinition" by each case param)
 # is suppressed for this file in pyproject. Both are the standard pytest re-export idiom.
 from .conftest import SmokeVM
+from .pkg_identity import branch_channel
 from .test_repo_install import (  # noqa: F401
     DECOY_REPO_DIR,
     DECOY_REPO_NAME,
@@ -86,6 +87,11 @@ from .test_repo_install import (  # noqa: F401
 )
 
 pytestmark = pytest.mark.repo
+
+# The channel the branch build reports through pfb_channel_from_pkgname() — read off the
+# artifact, never spelled here: the ports tree renames channels (issue #2166) and a literal
+# would keep passing this file's own reading while failing on the VM.
+BRANCH_CHANNEL = branch_channel(os.environ.get("SMOKE_PKG"))
 
 # The per-channel repo a "Read latest" maps to (ADR §2 + 2026-06-15 amendment): stable/devel
 # share ``pfblockerng``; nightly is the only separate repo. Phase 1 exercises the shared repo
@@ -420,8 +426,8 @@ def test_file_notice_is_idempotent_per_version(repo_vm: SmokeVM) -> None:
     """
     version_a = "9.9.9_1"
     version_b = "9.9.9_2"
-    msg_a = f"pfBlockerNG {version_a} available (devel)"
-    msg_b = f"pfBlockerNG {version_b} available (devel)"
+    msg_a = f"pfBlockerNG {version_a} available ({BRANCH_CHANNEL})"
+    msg_b = f"pfBlockerNG {version_b} available ({BRANCH_CHANNEL})"
     try:
         # GIVEN: a clean before-state — no last-notified, no matching notice for A.
         close_all_notices(repo_vm)
@@ -849,7 +855,7 @@ def test_software_positive_journey_on_our_repo_install(repo_vm: SmokeVM, tmp_pat
         cache = read_software_cache(repo_vm)
         assert cache.get("installed") == low, f"cache installed {cache.get('installed')!r} != {low!r}"
         assert cache.get("latest") == low, f"cache latest {cache.get('latest')!r} != {low!r} (should equal installed)"
-        assert cache.get("channel") == "devel", f"cache channel {cache.get('channel')!r} != 'devel'"
+        assert cache.get("channel") == BRANCH_CHANNEL, f"cache channel {cache.get('channel')!r} != {BRANCH_CHANNEL!r}"
         assert count_matching_notices(repo_vm, high) == 0, "a notice fired while installed == latest (no update)"
 
         # WHEN: publish the HIGHER build into the SAME repo; the check sees a newer latest.
@@ -924,7 +930,7 @@ def test_software_check_setting_gates_background_check(repo_vm: SmokeVM, tmp_pat
     base_version = read_compact_version(src)
     low = f"{base_version}_1"
     high = f"{base_version}_9"
-    msg = "available (devel)"
+    msg = f"available ({BRANCH_CHANNEL})"
 
     try:
         # GIVEN: our-repo install + a newer build published into the same repo.

--- a/tests/test_issue2166_workflow_channel_inputs.py
+++ b/tests/test_issue2166_workflow_channel_inputs.py
@@ -1,0 +1,174 @@
+"""Issue #2166 — the channel a workflow builds, and the package identity that follows it.
+
+`scripts/build-pkg-portable.py` owns the channel vocabulary (`_CHANNEL_PORT_SUB`, which
+also drives the port origin `net/pfSense-pkg-pfBlockerNG-<channel>` and therefore the built
+package's NAME). When that vocabulary was renamed (`devel` -> `testing`/`edge`/`nightly`),
+the workflows that pass `channel:` into build-pkg-linux.yml kept the retired name, and every
+repo-install leg died at argparse (`invalid choice: 'devel'`) before a single .pkg was built.
+
+Two consumers hard-code that vocabulary and must not drift from the builder again:
+
+* the workflows, pinned here against the builder's own channel set; and
+* the live-install smoke modules, which install the built .pkg BY NAME — so they read the
+  name off the artifact (`tests/smoke/pkg_identity.py`) instead of spelling a channel suffix.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github/workflows"
+
+_spec = importlib.util.spec_from_file_location("build_pkg_portable", ROOT / "scripts/build-pkg-portable.py")
+assert _spec and _spec.loader
+_builder = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _builder  # the module's dataclasses resolve their own module by name
+_spec.loader.exec_module(_builder)
+
+VALID_CHANNELS = frozenset(_builder._CHANNEL_PORT_SUB)
+
+
+def _pkg_identity() -> ModuleType:
+    """Load tests/smoke/pkg_identity.py by path — importing the smoke PACKAGE would drag in
+    tests/smoke/conftest.py and its dnspython/requests deps, which the default tier
+    (`--ignore=tests/smoke`) deliberately does not install."""
+    spec = importlib.util.spec_from_file_location("pfb_pkg_identity", ROOT / "tests/smoke/pkg_identity.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# `channel: testing` (a call site) and the `default: "testing"` of a `channel:` input.
+# A `${{ ... }}` value is resolved at run time and carries no literal to check.
+_CALL_SITE = re.compile(r'^\s*channel:\s*["\']?([A-Za-z0-9_.-]+)["\']?\s*(?:#.*)?$')
+_CHANNEL_KEY = re.compile(r"^(\s*)channel:\s*(?:#.*)?$")
+_DEFAULT = re.compile(r'^\s*default:\s*["\']?([A-Za-z0-9_.-]+)["\']?\s*(?:#.*)?$')
+# A `run:` step that assembles the channel in shell and dispatches it (version-tracker.yml's
+# `PKG_CHANNEL="edge"` -> `gh workflow run build-pkg-linux.yml --field channel=...`). The YAML
+# scanners above never see these, and a stale one costs a red workflow run a day.
+_SHELL_ASSIGN = re.compile(r'^\s*[A-Z_]*CHANNEL=["\']?([a-z][A-Za-z0-9_.-]*)["\']?\s*(?:#.*)?$')
+
+
+def _channel_literals() -> list[tuple[str, int, str]]:
+    """Every hard-coded channel value in the workflows, as (file, line number, value)."""
+    found: list[tuple[str, int, str]] = []
+    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+        lines = workflow.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            call_site = _CALL_SITE.match(line) or _SHELL_ASSIGN.match(line)
+            if call_site:
+                found.append((workflow.name, index + 1, call_site.group(1)))
+                continue
+            key = _CHANNEL_KEY.match(line)
+            if not key:
+                continue
+            indent = len(key.group(1))
+            for follower in lines[index + 1 :]:
+                if follower.strip() and len(follower) - len(follower.lstrip()) <= indent:
+                    break  # left the `channel:` input block
+                default = _DEFAULT.match(follower)
+                if default:
+                    found.append((workflow.name, index + 1, default.group(1)))
+                    break
+    return found
+
+
+def test_workflows_hard_code_at_least_one_channel() -> None:
+    """Guard the scanner itself: a regex that matches nothing would pass every assertion."""
+    assert _channel_literals(), "no literal channel value found in .github/workflows — scanner is broken"
+
+
+def test_smoke_modules_never_hard_code_a_channel_suffixed_package_name() -> None:
+    """The live-install constants must follow the artifact, not a channel spelled by hand.
+
+    A `PKG_NAME = "pfSense-pkg-pfBlockerNG-devel"` survives every rename silently and then
+    fails on the VM at `pkg install`, one leg at a time, long after the build went green.
+    """
+    assignment = re.compile(r'^\s*_?[A-Z_]*NAME\s*=\s*["\']pfSense-pkg-pfBlockerNG-([a-z]+)["\']')
+    hard_coded = [
+        f"{path.name}:{number} pins {match.group(1)!r}"
+        for path in sorted((ROOT / "tests/smoke").glob("test_*.py"))
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1)
+        if (match := assignment.match(line)) and match.group(1) != "nightly"
+    ]
+    assert not hard_coded, (
+        "smoke modules must take the branch package name from the built .pkg "
+        "(pkg_identity.branch_pkg_name), not a hard-coded channel suffix:\n  " + "\n  ".join(hard_coded)
+    )
+
+
+def test_smoke_modules_never_hard_code_the_channel_the_build_reports() -> None:
+    """A live case that asserts on the channel must derive it, for the same reason.
+
+    `assert cache.get("channel") == "devel"` outlives the rename exactly as silently as a
+    hard-coded package name, and fails on the VM instead of here (issue #2166 review round 3).
+    """
+    # Both comparison senses, dict/bracket access, and the notice text the box emits.
+    channel_literal = re.compile(r"""(?:channel["']?\]?\)?\s*[!=]=\s*|available \()["']?(devel|testing|edge)\b""")
+    hard_coded = [
+        f"{path.name}:{number}: {line.strip()[:70]}"
+        for path in sorted((ROOT / "tests/smoke").glob("test_*.py"))
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1)
+        if channel_literal.search(line)
+    ]
+    assert not hard_coded, (
+        "smoke cases must take the channel from the built .pkg (pkg_identity.branch_channel), "
+        "not a hard-coded channel name:\n  " + "\n  ".join(hard_coded)
+    )
+
+
+def test_branch_channel_reads_the_channel_off_the_built_artifact() -> None:
+    """The channel a build reports is the suffix of the package it installs as."""
+    branch_channel = _pkg_identity().branch_channel
+    assert branch_channel("/out/pfSense-pkg-pfBlockerNG-edge-4.0.0.a24.pkg") == "edge"
+    assert branch_channel("/out/pfSense-pkg-pfBlockerNG-testing-3.2.15.pkg") == "testing"
+    assert branch_channel("/out/pfSense-pkg-pfBlockerNG-3.2.15.pkg") == "stable"
+    assert branch_channel(None) == _pkg_identity().DEFAULT_CHANNEL
+
+
+def test_branch_pkg_name_reads_the_name_off_the_built_artifact() -> None:
+    """`<name>-<version>.pkg` — the version always starts with a digit, the name never does."""
+    branch_pkg_name = _pkg_identity().branch_pkg_name
+    assert branch_pkg_name("/out/pfSense-pkg-pfBlockerNG-edge-4.0.0.a24.pkg") == "pfSense-pkg-pfBlockerNG-edge"
+    assert branch_pkg_name("/out/pfSense-pkg-pfBlockerNG-3.2.15.pkg") == "pfSense-pkg-pfBlockerNG"
+    assert branch_pkg_name("/out/pfSense-pkg-pfBlockerNG-nightly-20260804.pkg") == "pfSense-pkg-pfBlockerNG-nightly"
+
+
+def test_branch_pkg_name_rejects_an_artifact_it_cannot_read() -> None:
+    """A SMOKE_PKG that is not a pfBlockerNG .pkg must fail loudly.
+
+    Falling back to the default channel there would hand the caller a name the artifact does
+    not have — the same silent drift this module exists to stop, one level removed.
+    """
+    branch_pkg_name = _pkg_identity().branch_pkg_name
+    for hostile in ("/out/some-other-port-1.2.3.pkg", "/out/pfSense-pkg-pfBlockerNG-edge-4.0.0.a24.txz", "/out/x"):
+        try:
+            name = branch_pkg_name(hostile)
+        except ValueError:
+            continue
+        raise AssertionError(f"branch_pkg_name({hostile!r}) silently returned {name!r} instead of raising")
+
+
+def test_branch_pkg_name_falls_back_to_the_channel_ci_actually_builds() -> None:
+    """No SMOKE_PKG (collection on a dev box) still has to name the package CI produces."""
+    defaults = {value for name, _, value in _channel_literals() if name == "build-pkg-linux.yml"}
+    assert len(defaults) == 1, f"build-pkg-linux.yml's dispatch and call defaults disagree: {sorted(defaults)}"
+    assert _pkg_identity().branch_pkg_name(None) == f"pfSense-pkg-pfBlockerNG-{defaults.pop()}"
+
+
+def test_every_workflow_channel_literal_is_a_builder_channel() -> None:
+    stale = [
+        f"{name}:{line} passes channel {value!r}"
+        for name, line, value in _channel_literals()
+        if value not in VALID_CHANNELS
+    ]
+    assert not stale, (
+        "workflows pass a channel build-pkg-portable.py rejects "
+        f"(valid: {sorted(VALID_CHANNELS)}):\n  " + "\n  ".join(stale)
+    )


### PR DESCRIPTION
> [!NOTE]
> **Merge hold released.** Both conditions are met.
>
> 1. #2206 is closed, and the repo owner confirms the `scripts/local-smoke.sh --marker repo` live-VM run was executed. That run's log is not attached to #2206's own thread, and the `PFB_BOXES` pool was unreachable from this session (all eight boxes time out), so it could not be re-executed here — recorded for the audit trail.
> 2. CI is green on the rebased head. The GitHub Actions outage `qcvjkzcs7j74` has cleared.

Fixes the nightly **Repo install (live pfSense VM)** red on `devel` (#2166).

## Root cause

All three matrix legs died in `build-pkg / build pfBlockerNG .pkg (portable, Linux)`, before any live install:

```
build-pkg-portable.py: error: argument --channel: invalid choice: 'devel'
(choose from 'stable', 'testing', 'edge', 'nightly')
```

Evidence: run [31093847936](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/31093847936), job 92591044403 line 284, with `CHANNEL: devel` in the step env at line 262.

Two same-day commits retired the `devel` channel and its consumers were never updated:

- FreeBSD-ports `67cd249d` (2026-08-04) replaced `net/pfSense-pkg-pfBlockerNG-devel` with the four channel recipes. `GET contents/net/pfSense-pkg-pfBlockerNG-devel/Makefile?ref=pfblockerng/use-github` now returns 404; `-testing`, `-edge` and `-nightly` all resolve.
- `970e6fb9` renamed `_CHANNEL_PORT_SUB` and the `--channel` choices in `scripts/build-pkg-portable.py`.

Meanwhile `smoke.yml`, `smoke-single.yml`, `ui-tests.yml` and `build-image.yml` still passed `channel: devel`, as did both `build-pkg-linux.yml` defaults and `version-tracker.yml`'s `PKG_CHANNEL="devel"` — the last one dispatching the same rejected channel from a daily cron.

## Why `edge` and not `testing`

The successor is chosen by version line, not by the enum's position:

| Port | PORTNAME | PORTVERSION |
| --- | --- | --- |
| `net/pfSense-pkg-pfBlockerNG-edge` | `pfSense-pkg-pfBlockerNG-edge` | `4.0.0.a24` |
| `net/pfSense-pkg-pfBlockerNG-testing` | `pfSense-pkg-pfBlockerNG-testing` | `3.2.15` |

`4.0.0.a24` is exactly what `net/pfSense-pkg-pfBlockerNG-devel` last carried (ports `d1ae4352`, "update to 4.0.0.alpha.24"), and `.agents/context/release.md` selects Edge for a prerelease tag with `Z == 0` — which is the `devel` branch's `4.0.0.alpha.N` line.

## Changes

- The four `workflow_call` callers, both `build-pkg-linux.yml` channel defaults, and `version-tracker.yml`'s dispatch now request `edge`; the dispatch input's description names the real vocabulary.
- `tests/smoke/pkg_identity.py` (new, stdlib-only): `branch_pkg_name()` reads the package name off the built `.pkg`. The port name *is* the package name, so a channel change renames the artifact — and the live-install modules were installing `pfSense-pkg-pfBlockerNG-devel`, a name the build no longer produces. `test_repo_install.py`, `test_dns_redirect.py`, `test_dot_doq_block.py`, `test_smoke_managed_objects.py` and `test_nightly_install.py` now derive it instead of hard-coding a suffix.
- `src/usr/local/pkg/pfblockerng/pfblockerng.inc`: `pfb_channel_from_pkgname()` learns `-testing` and `-edge` (keeping `-devel` for boxes installed before the ports rename), and `pfb_pkg_repo_name_for_channel()` maps them to the shared `pfblockerng` repo. Without this an `-edge` install resolves to no channel, `pfb_pkg_installed_name()` filters it out and returns `''`, and the provenance gate reads a genuine our-repo build as not-our-build — which would have kept the nightly job red on `test_software_update.py` (marker `repo`) even after the build succeeded. `tests/php/SoftwareUpdateDecisionTest.php` covers it; `tests/smoke/pkg_identity.py`'s new `branch_channel()` lets that smoke module derive the channel instead of spelling it.
- `tests/test_issue2166_workflow_channel_inputs.py` (new, 8 tests) pins all three consumers against the builder's own `_CHANNEL_PORT_SUB`: a workflow literal the builder would reject — as a YAML value, an input default, or a shell `*CHANNEL=` assignment — or a smoke constant that hard-codes a channel suffix, now fails in the fast tier rather than on a VM.
- `docs/misc/local-smoke-debian.md`, the runbook `.agents/context/smoke.md` sends every dev to first, no longer documents the broken `--channel devel` invocation.

## Test evidence

Three red→green rounds, each test file frozen byte-identical across its round's pair (round one `sha256 1c0eddb3…`, round two `sha256 5e98e649…`; the shipped file differs from the round-one hash because two docstrings were reworded between rounds, with the suite re-run after):

- Round one RED, before any production edit: 6 stale workflow literals (`build-image.yml:278`, `build-pkg-linux.yml:35` and `:73`, `smoke-single.yml:246`, `smoke.yml:278`, `ui-tests.yml:208`), plus 3 failures for the package-identity half. GREEN, unchanged test: `5 passed`.
- Round two RED, after review widened the scanner to shell assignments: `version-tracker.yml:179 passes channel 'devel'` and `branch_pkg_name('/out/some-other-port-1.2.3.pkg') silently returned 'pfSense-pkg-pfBlockerNG-edge' instead of raising`. GREEN, unchanged test: `6 passed`.
- Round three, after review found the channel-table gap. PHP RED: 5 provider failures, `Failed asserting that null is identical to 'pfblockerng'`; GREEN `OK (51 tests, 55 assertions)`. Python RED: the new scanner naming all four literal channel sites plus `AttributeError: no attribute 'branch_channel'`; GREEN `8 passed`.

Gates: `ruff check`, `ruff format --check` (513 files), `mypy tests/` (309 files) and `scripts/parity-guard.sh` all clean; `tests/smoke` collects (813 tests). Full unit suite 4239 passed against a 4232-passed `origin/devel` baseline in the same sandbox (443 vs 444 environment failures, which wobble by one because `TestGatherBootSet` is order-dependent here — it passes 23/23 in isolation). Those failures are a sandbox artifact: git is 2.25, which lacks `git init -b`, and the same set fails on an untouched `origin/devel` checkout.

## Not covered here

Per-channel catalogues, `add-repo.sh`'s bootstrap and the migration of installed package identities remain #2148's cutover. This PR only teaches the existing channel table the two names the ports tree now produces, which is what the nightly job needs.

`scripts/build-frozen-v3.py:76` also pins `channel="devel"` for its historical v3.2.16 frozen target and would hit the same argparse rejection. It rebuilds an artifact whose port no longer exists in the ports tree, so it needs its own decision rather than a rename here.

## Reviewer note — outstanding proof

`.agents/context/smoke.md` requires a red→green proof for `tests/smoke/**` to be *executed on a leased `PFB_BOXES` box, never dispatched to CI*. That pool is unreachable from the environment this branch was prepared in (`ssh root@10.0.0.31` → `No route to host`, same for `.32`), so the live-VM half of the proof is missing. The package-identity change is covered at unit level only. Please run `scripts/local-smoke.sh --marker repo` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuDuuZDtfqmqZkTpC1MkNs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `stable`, `testing`, `edge`, and `nightly` package channels.
  * Added channel detection and repository mapping for testing and edge packages.
  * Retained compatibility with existing devel package installations.

* **Bug Fixes**
  * Updated builds, releases, version tracking, and smoke tests to use the edge channel by default.

* **Tests**
  * Added coverage for channel mapping, package naming, artifact validation, and workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
