### PR TITLE
pfblockerng: fold (www.)? DNSBL regex prefix case-insensitively

### DIFF
--- a/benchmarks/spike_adr07_regex.py
+++ b/benchmarks/spike_adr07_regex.py
@@ -184,7 +184,7 @@ def reduce_pattern(pat: str) -> tuple[str, str] | None:
         if body.startswith(pre):
             lit = body[len(pre) :]
             # allow an optional (www\.)? prefix, fold to the exact base domain
-            if lit.startswith(r"(www\.)?"):
+            if lit[: len(r"(www\.)?")].lower() == r"(www\.)?":
                 lit = lit[len(r"(www\.)?") :]
             dom = lit.replace("\\.", ".").lower()
             if _DOMAIN_LITERAL.match(lit):

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -42,7 +42,7 @@ matcher strata, emit/wire, regex safety, PHP boundary); the regex/ReDoS kill-gat
 `benchmarks/spike_adr07_regex.py` — it exits non-zero on NO-GO (`--report-only` forces exit 0),
 runnable via the manual-only CI `benchmarks` job. See `.ADRs/ADR_07_ABP_DNSBL_Support/`.
 
-### DNSBL regex case-insensitivity invariant (#2079, #2097, #2098, #2099)
+### DNSBL regex case-insensitivity invariant (#2079, #2097, #2098, #2099, #2199)
 
 Domain names are case-insensitive, so **everything that evaluates a domain-matching regex
 must be too** — by lowercasing for plain comparison, by `re.IGNORECASE` for a compiled
@@ -52,6 +52,10 @@ atom-overlap probe); the domain-literal reduction grammar (prod `pfb_unbound.py`
 reference oracle `tests/test_adr07_decision_spec.py`, and the benchmark spike
 `benchmarks/spike_adr07_regex.py` — kept in lockstep) admits either case and lowercases the
 folded key at fold time, so a mixed-case literal reduces identically to its lowercase twin.
+The exact-form fold's optional `(www\.)?` prefix strip is the one fixed-text token in the
+grammar that contains a letter (the other prefixes -- `^`, `(.+\.)?`, `(^|\.)` -- are pure
+metacharacters, so case never applied to them); that token is matched case-insensitively too
+(#2199) -- a source pattern spelling it `(WWW\.)?` folds exactly like the lowercase form.
 Two constructs stay deliberately case-sensitive because they analyse **pattern text**, not
 domains: the module-level `_REGEX_*` shape-detection constants in `pfb_dnsbl_regex_rules.py`
 (match regex syntax punctuation), and the plain-domain label charset `_DNSBL_LABEL_CHARS`

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4431,7 +4431,7 @@ def _dnsbl_reduce_regex(inner: str) -> tuple[bool, str] | None:
     for pre in _DNSBL_RX_EXACT_PREFIXES:
         if body.startswith(pre):
             lit = body[len(pre) :]
-            if lit.startswith(_DNSBL_RX_WWW_OPT):
+            if lit[: len(_DNSBL_RX_WWW_OPT)].lower() == _DNSBL_RX_WWW_OPT:
                 lit = lit[len(_DNSBL_RX_WWW_OPT) :]
             if _DNSBL_RX_DOMAIN_LITERAL.match(lit):
                 return False, lit.replace("\\.", ".").lower()

--- a/tests/test_adr07_decision_spec.py
+++ b/tests/test_adr07_decision_spec.py
@@ -211,7 +211,7 @@ def reduce_regex(inner: str) -> tuple[bool, str] | None:
     for pre in _EXACT_PREFIXES:
         if body.startswith(pre):
             lit = body[len(pre) :]
-            if lit.startswith(r"(www\.)?"):
+            if lit[: len(r"(www\.)?")].lower() == r"(www\.)?":
                 lit = lit[len(r"(www\.)?") :]
             if _DOMAIN_LITERAL.match(lit):
                 return False, lit.replace("\\.", ".").lower()

--- a/tests/test_adr07_reconcile.py
+++ b/tests/test_adr07_reconcile.py
@@ -336,6 +336,9 @@ class TestRegexReduction:
             (r"^(.+\.)?AdServer\.Example$", (True, "adserver.example")),
             (r"(^|\.)Tracker\.NET$", (True, "tracker.net")),
             (r"^(www\.)?Simple\.Example\.com$", (False, "simple.example.com")),
+            # #2199: the www-opt PREFIX TOKEN ITSELF is mixed-case, not just the
+            # domain label after it -- must still fold (runtime is IGNORECASE).
+            (r"^(WWW\.)?Example\.com$", (False, "example.com")),
         )
         for inner, expected in cases:
             prod = P._dnsbl_reduce_regex(inner)


### PR DESCRIPTION
## Summary

- The exact-form domain-literal fold's optional `(www\.)?` prefix strip was a plain `str.startswith()` on the fixed token, so a regex spelled with a mixed-case `WWW.` prefix (e.g. `^(WWW\.)?example\.com$`) never folded to a domain rule, even though the runtime's `IGNORECASE` compile matches it identically to the lowercase form.
- Fixed in lockstep across the three mirrored copies: production reducer (`pfb_unbound.py`), the reference oracle (`tests/test_adr07_decision_spec.py`), and the benchmark spike (`benchmarks/spike_adr07_regex.py`), matching the token case-insensitively before stripping it.
- Same class of defect as #2099 (missed optimisation, not a wrong match — the pattern still blocks/allows correctly as a compiled regex, it just never got the zero-per-query-cost fold).
- Extended the DNSBL regex case-insensitivity invariant note in `docs/misc/architecture-notes.md`.

Part of #2199

## Test plan

- [x] RED: added `^(WWW\.)?Example\.com$` case to `test_regex_reduction_case_folds_literal_to_lowercase` in `tests/test_adr07_reconcile.py`, confirmed it failed against the pre-fix code (`_dnsbl_reduce_regex` returned `None` instead of folding).
- [x] GREEN: same test passes unchanged after the fix.
- [x] Full test suite (`pytest tests/`, excluding php/smoke): 4678 passed, 4 skipped.
- [x] `scripts/agent/run-gates.sh --diff origin/devel`: pytest, ruff check, ruff format, mypy, markdownlint all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain pattern handling to recognize optional `www.` prefixes regardless of capitalization.
  * Mixed-case domain patterns are now correctly normalized to lowercase exact-domain rules.

* **Tests**
  * Added coverage for uppercase and mixed-case `WWW.` prefixes across pattern reduction and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->