### PR TITLE
pfblockerng: stage blacklist category extraction before publishing

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4012,6 +4012,52 @@ function pfb_stage_publish(string $target, callable $extract): bool {
 	return TRUE;
 }
 
+/**
+ * Publish a directory extraction atomically. $extract writes into an empty staging
+ * directory beside $target and returns its exit code; $target is replaced only once
+ * that code reports success, so a failed extraction leaves the directory already in
+ * service intact (issue #2172).
+ *
+ * @param callable(string):int $extract
+ */
+function pfb_stage_publish_dir(string $target, callable $extract): bool {
+	$staged = @tempnam(dirname($target), '.pfbstagedir_');
+	if ($staged === FALSE) {
+		return FALSE;
+	}
+	// tempnam() hands back a FILE; the extractor needs a directory at that path.
+	// 0755, not tempnam's 0600: a published category has unprivileged readers.
+	if (!@unlink($staged) || !@mkdir($staged, 0755) || !@chmod($staged, 0755)) {
+		is_dir($staged) ? rmdir_recursive($staged) : unlink_if_exists($staged);
+		return FALSE;
+	}
+	if (!pfb_download_extraction_succeeded((int) $extract($staged))) {
+		rmdir_recursive($staged);
+		return FALSE;
+	}
+	// rename() cannot replace a non-empty directory, so the previous publication moves
+	// aside first and is restored if the swap does not complete.
+	$backup = NULL;
+	if (is_dir($target)) {
+		$backup = @tempnam(dirname($target), '.pfbstagebak_');
+		if ($backup === FALSE || !@unlink($backup) || !@rename($target, $backup)) {
+			rmdir_recursive($staged);
+			return FALSE;
+		}
+	}
+	if (!@rename($staged, $target)) {
+		if ($backup !== NULL) {
+			@rename($backup, $target);
+		}
+		rmdir_recursive($staged);
+		return FALSE;
+	}
+	if ($backup !== NULL) {
+		rmdir_recursive($backup);
+	}
+	return TRUE;
+}
+
 function pfb_download_retval_success(?int $retval): bool {
 	return $retval === 0;
 }
@@ -13349,9 +13395,6 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				$filename = basename("{$file_esc}", '.tar.gz');
 
 				if (!empty(pfb_filter($filename, PFB_FILTER_WORD, 'pfb_download category'))) {
-					rmdir_recursive("{$pfb['dbdir']}/{$filename}/");
-					safe_mkdir("{$pfb['dbdir']}/{$filename}/");
-
 					// ADR-46: disk-writing extraction of a THIRD-PARTY archive (member
 					// names feed on-disk filenames) -- reject hostile member names first
 					// (a NULL member list = unlistable archive rejects too, fail-closed).
@@ -13364,26 +13407,34 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 
 					// Extract Blacklist categories from sub-folders into a single folder structure
 					$cmd = "--include='*domains' -s',.*/\\(.*\\)/\\(.*\\)/domains,{$filename}_\\1_\\2,' -s',.*/\\(.*\\)/domains,{$filename}_\\1,'";
-					$filename_esc = escapeshellarg("{$pfb['dbdir']}/{$filename}/");
-					exec("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C {$filename_esc} >/dev/null 2>&1", $output, $retval);
+					// issue #2172: the extraction runs in a staging directory and is swapped
+					// into place only once tar reports success, so a failed extraction leaves
+					// the category contents already in service untouched.
+					$retval = pfb_download_initial_retval();
+					if (!pfb_stage_publish_dir("{$pfb['dbdir']}/{$filename}",
+					    static function (string $staged) use ($file_dwn, $filename, $cmd, &$output, &$retval): int {
+						exec("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1", $output, $retval);
+						if (!pfb_download_extraction_succeeded($retval)) {
+							return $retval;
+						}
 
-					// Rename any Category files with dashes
-					$verifydir = "{$pfb['dbdir']}/{$filename}";
-					if (is_dir("{$verifydir}")) {
-						$list = glob("{$verifydir}/{$filename}*");
+						// Rename any Category files with dashes
+						$list = glob("{$staged}/{$filename}*");
 						if (is_array($list) && !empty($list)) {
 							foreach ($list as $verify) {
-								if (strpos($verify, '-') !== FALSE) {
-									rename($verify, str_replace('-', '_', $verify));
+								if (strpos(basename($verify), '-') !== FALSE) {
+									rename($verify, dirname($verify) . '/' . str_replace('-', '_', basename($verify)));
 								}
 							}
 						}
+						return $retval;
+					})) {
+						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})", 2);
+						return PfbDownloadResult::failure();
 					}
 
 					// Create update file indicator for update process
-					if (pfb_download_extraction_succeeded($retval)) {
-						touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
-					}
+					touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
 				}
 				else {
 					pfb_logger("\n Invalid filename [{$filename}]", 1);

--- a/tests/php/DownloadStagePublishDirTest.php
+++ b/tests/php/DownloadStagePublishDirTest.php
@@ -33,10 +33,20 @@ final class DownloadStagePublishDirTest extends TestCase
 
 	private function removeTree(string $path): void
 	{
-		foreach (glob("{$path}/*") ?: [] as $child) {
+		foreach ($this->entries($path) as $name) {
+			$child = "{$path}/{$name}";
 			is_dir($child) && !is_link($child) ? $this->removeTree($child) : @unlink($child);
 		}
 		@rmdir($path);
+	}
+
+	/**
+	 * Staging and backup directories are dot-named, and glob() never returns dot
+	 * entries -- a litter assertion spelled with glob() cannot fail on leftovers.
+	 */
+	private function entries(string $path): array
+	{
+		return array_values(array_diff(scandir($path) ?: array(), array('.', '..')));
 	}
 
 	public function testSuccessfulExtractionPublishesTheStagedDirectory(): void
@@ -84,7 +94,7 @@ final class DownloadStagePublishDirTest extends TestCase
 			return 1;
 		});
 
-		$this->assertSame([], glob("{$this->dir}/*"));
+		$this->assertSame([], $this->entries($this->dir));
 	}
 
 	public function testSuccessfulPublicationLeavesNoStagingDirectoryBehind(): void
@@ -100,8 +110,33 @@ final class DownloadStagePublishDirTest extends TestCase
 
 		// Only the published category survives: no staging or backup directory is
 		// left in the database directory, and the replaced contents are gone.
-		$this->assertSame([$target], glob("{$this->dir}/*"));
+		$this->assertSame(['category'], $this->entries($this->dir));
 		$this->assertFileDoesNotExist("{$target}/cat_ads");
+	}
+
+	/**
+	 * The previous category moves aside so the staged one can take its name; if that
+	 * second step does not complete, the category that was in service comes back.
+	 * Driven by an extraction that reports success while leaving no staging directory
+	 * to publish, which is the one way the swap fails without the backup step failing
+	 * first.
+	 */
+	public function testAFailedSwapRestoresThePreviousCategoryContents(): void
+	{
+		$target = "{$this->dir}/category";
+		$this->assertTrue(mkdir($target, 0755));
+		$this->assertNotFalse(file_put_contents("{$target}/cat_ads", "last-good\n"));
+
+		$this->assertFalse(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_ads", "fresh\n");
+			@unlink("{$staged}/cat_ads");
+			@rmdir($staged);
+			return 0;
+		}));
+
+		$this->assertSame("last-good\n", file_get_contents("{$target}/cat_ads"));
+		$this->assertSame(['category'], $this->entries($this->dir),
+			'the moved-aside category must not be left behind under its backup name');
 	}
 
 	/** Staging beside the target is what makes the publication a same-filesystem rename. */
@@ -134,7 +169,7 @@ final class DownloadStagePublishDirTest extends TestCase
 
 		$this->assertDirectoryDoesNotExist($seen, 'the staging directory must be renamed into place');
 		$this->assertDirectoryExists($target);
-		$this->assertSame([], glob("{$target}/*"));
+		$this->assertSame([], $this->entries($target));
 	}
 
 	/** A category published at tempnam's 0600 would hide the feed from its readers. */

--- a/tests/php/DownloadStagePublishDirTest.php
+++ b/tests/php/DownloadStagePublishDirTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_download() publishes an extracted blacklist category through a staging
+ * directory, so a failed extraction cannot destroy the category contents already
+ * in service (issue #2172).
+ *
+ * pfb_download() itself is not off-appliance unit-testable (ADR §5), so the
+ * behaviour is covered at the pfb_stage_publish_dir() boundary and the call site
+ * is pinned by source inspection.
+ */
+#[CoversFunction('pfb_stage_publish_dir')]
+final class DownloadStagePublishDirTest extends TestCase
+{
+	private const INC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb stagedir; ' . getmypid() . " 'fixture'";
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		$this->removeTree($this->dir);
+	}
+
+	private function removeTree(string $path): void
+	{
+		foreach (glob("{$path}/*") ?: [] as $child) {
+			is_dir($child) && !is_link($child) ? $this->removeTree($child) : @unlink($child);
+		}
+		@rmdir($path);
+	}
+
+	public function testSuccessfulExtractionPublishesTheStagedDirectory(): void
+	{
+		$target = "{$this->dir}/category";
+		$this->assertTrue(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_ads", "fresh\n");
+			return 0;
+		}));
+
+		$this->assertSame("fresh\n", file_get_contents("{$target}/cat_ads"));
+	}
+
+	/** The defect: the category was wiped before anyone knew the archive extracts. */
+	public function testFailedExtractionKeepsThePreviousCategoryContents(): void
+	{
+		$target = "{$this->dir}/category";
+		$this->assertTrue(mkdir($target, 0755));
+		$this->assertNotFalse(file_put_contents("{$target}/cat_ads", "last-good\n"));
+
+		$this->assertFalse(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_ads", 'trunc');
+			return 1;
+		}));
+
+		$this->assertSame("last-good\n", file_get_contents("{$target}/cat_ads"));
+	}
+
+	public function testFailedExtractionWithNoPriorCategoryPublishesNothing(): void
+	{
+		$target = "{$this->dir}/category";
+		$this->assertFalse(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_ads", 'partial');
+			return 1;
+		}));
+
+		$this->assertDirectoryDoesNotExist($target);
+	}
+
+	public function testFailedExtractionLeavesNoStagingDirectoryBehind(): void
+	{
+		$target = "{$this->dir}/category";
+		pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_ads", 'partial');
+			return 1;
+		});
+
+		$this->assertSame([], glob("{$this->dir}/*"));
+	}
+
+	public function testSuccessfulPublicationLeavesNoStagingDirectoryBehind(): void
+	{
+		$target = "{$this->dir}/category";
+		$this->assertTrue(mkdir($target, 0755));
+		$this->assertNotFalse(file_put_contents("{$target}/cat_ads", "last-good\n"));
+
+		$this->assertTrue(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_news", "fresh\n");
+			return 0;
+		}));
+
+		// Only the published category survives: no staging or backup directory is
+		// left in the database directory, and the replaced contents are gone.
+		$this->assertSame([$target], glob("{$this->dir}/*"));
+		$this->assertFileDoesNotExist("{$target}/cat_ads");
+	}
+
+	/** Staging beside the target is what makes the publication a same-filesystem rename. */
+	public function testStagedDirectorySitsBesideTheTargetAndIsNotTheTarget(): void
+	{
+		$target = "{$this->dir}/category";
+		$seen = '';
+		pfb_stage_publish_dir($target, static function (string $staged) use (&$seen): int {
+			$seen = $staged;
+			return 0;
+		});
+
+		// realpath() on both sides -- macOS resolves sys_get_temp_dir() through a
+		// /var -> /private/var symlink and tempnam() hands back the resolved path,
+		// so the raw strings differ on the prefix while naming the same directory
+		// (issue #2192).
+		$this->assertSame(realpath($this->dir), realpath(dirname($seen)));
+		$this->assertNotSame($target, $seen);
+	}
+
+	/** The extractor is handed a directory that already exists, as tar -C requires. */
+	public function testExtractorReceivesAnExistingEmptyDirectory(): void
+	{
+		$target = "{$this->dir}/category";
+		$seen = '';
+		pfb_stage_publish_dir($target, static function (string $staged) use (&$seen): int {
+			$seen = $staged;
+			return 0;
+		});
+
+		$this->assertDirectoryDoesNotExist($seen, 'the staging directory must be renamed into place');
+		$this->assertDirectoryExists($target);
+		$this->assertSame([], glob("{$target}/*"));
+	}
+
+	/** A category published at tempnam's 0600 would hide the feed from its readers. */
+	public function testPublishedDirectoryIsWorldReadable(): void
+	{
+		$target = "{$this->dir}/category";
+		$this->assertTrue(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_ads", "data\n");
+			return 0;
+		}));
+
+		$this->assertSame('0755', substr(sprintf('%o', fileperms($target)), -4));
+	}
+
+	/**
+	 * The category directory is never emptied before the extraction reports success,
+	 * so the last-good contents survive an ENOSPC or a killed tar.
+	 */
+	public function testBlacklistBranchNoLongerWipesTheCategoryBeforeExtracting(): void
+	{
+		$source = file_get_contents(self::INC);
+		$this->assertNotFalse($source);
+
+		// Counted, never matched against the haystack: this file is ~700 KB and a
+		// containment matcher would dump all of it into the failure output.
+		$this->assertSame(0, preg_match_all('/rmdir_recursive\("\{\$pfb\[\'dbdir\'\]\}\/\{\$filename\}/', $source),
+			'the blacklist branch still wipes the live category directory before extracting');
+		$this->assertSame(0, preg_match_all('/-C \{\$filename_esc\}/', $source),
+			'the blacklist branch still extracts straight into the live category directory');
+	}
+
+	/**
+	 * Preserving the last-good category means a failed extraction no longer leaves an
+	 * empty directory behind, so the branch must fail the download itself rather than
+	 * falling through onto the stale category as a successful update.
+	 */
+	public function testEveryStagedDirectoryPublicationSitsInAFailureGuard(): void
+	{
+		$source = file_get_contents(self::INC);
+		$this->assertNotFalse($source);
+
+		// One occurrence is the definition; every other must be a guarded call.
+		$occurrences = substr_count($source, 'pfb_stage_publish_dir(');
+		$this->assertGreaterThan(1, $occurrences,
+			'expected the blacklist branch to publish through pfb_stage_publish_dir()');
+		$this->assertSame($occurrences - 1, substr_count($source, 'if (!pfb_stage_publish_dir('),
+			'every pfb_stage_publish_dir() call must sit directly in a failure guard');
+	}
+}

--- a/tests/php/DownloadStagePublishDirTest.php
+++ b/tests/php/DownloadStagePublishDirTest.php
@@ -43,10 +43,15 @@ final class DownloadStagePublishDirTest extends TestCase
 	/**
 	 * Staging and backup directories are dot-named, and glob() never returns dot
 	 * entries -- a litter assertion spelled with glob() cannot fail on leftovers.
+	 * An unreadable directory reports a sentinel rather than an empty listing, so it
+	 * fails its assertion loudly instead of reading as "nothing was left behind".
 	 */
 	private function entries(string $path): array
 	{
-		return array_values(array_diff(scandir($path) ?: array(), array('.', '..')));
+		$entries = @scandir($path);
+		return $entries === FALSE
+			? array('<unreadable>')
+			: array_values(array_diff($entries, array('.', '..')));
 	}
 
 	public function testSuccessfulExtractionPublishesTheStagedDirectory(): void
@@ -134,9 +139,9 @@ final class DownloadStagePublishDirTest extends TestCase
 			return 0;
 		}));
 
+		// No litter assertion here: the restore is a single rename, so the backup
+		// cannot survive an assertion that the contents came back.
 		$this->assertSame("last-good\n", file_get_contents("{$target}/cat_ads"));
-		$this->assertSame(['category'], $this->entries($this->dir),
-			'the moved-aside category must not be left behind under its backup name');
 	}
 
 	/** Staging beside the target is what makes the publication a same-filesystem rename. */

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -9602,6 +9602,26 @@
             }
         ]
     },
+    "pfb_stage_publish_dir": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "target",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "extract",
+                "byRef": false,
+                "variadic": false,
+                "type": "callable",
+                "default": null
+            }
+        ]
+    },
     "pfb_stdout_is_terminal": {
         "returnsRef": false,
         "returnType": "bool",


### PR DESCRIPTION
## Problem

The blacklist branch of `pfb_download()` destroyed the last-good category before it knew the new archive extracts:

```php
rmdir_recursive("{$pfb['dbdir']}/{$filename}/");
safe_mkdir("{$pfb['dbdir']}/{$filename}/");
exec("/usr/bin/tar -xf ... -C {$filename_esc} >/dev/null 2>&1", $output, $retval);
```

`pfb_validate_archive()` gates this branch, so a structurally broken archive never reaches the extraction step. What can still reach it is a genuine failure — ENOSPC, a killed process, an I/O error, a member-level failure — and by then the previous category contents are already gone with no way back. Same class as #2169, different mechanism (a directory wipe rather than a shell redirect), which is why it was out of that PR's scope.

One correction to the issue text: the caller *was* told about a nonzero `tar` exit. `$retval` survived to the shared `pfb_download_retval_success($retval)` check below the decompress chain, which reported "Decompression Failed" and returned `PfbDownloadResult::failure()`. The loss of the last-good contents is the defect; the missing failure result is not, and the branch keeps reporting failure here (see below for why it now does so explicitly).

## Change

`pfb_stage_publish_dir()` is the directory sibling of #2169's `pfb_stage_publish()`: it hands the extractor an empty staging directory beside the target and swaps it into place only once the exit code reports success. Because `rename()` cannot replace a non-empty directory, the previous publication moves aside to a second temporary name first and is restored if the swap does not complete. On any failure the staging directory is removed and the category already in service is untouched.

The branch now fails the download explicitly rather than relying on the `$retval` fall-through. That is load-bearing, not cosmetic: `pfb_stage_publish_dir()` can also fail at the publish step (`mkdir`, `rename`) with `tar`'s exit code still zero, and the fall-through would read that zero and report a successful update.

Two smaller consequences of staging:

- The dash-rename of extracted category files runs inside the staging directory, before publication, so a published category is never observed mid-rename.
- That rename now rewrites only the basename. It previously ran `str_replace('-', '_', ...)` over the whole path — harmless while the parent was a fixed name, but it would rewrite the generated staging path.

## Tests

`pfb_download()` is not off-appliance unit-testable (ADR §5), so behaviour is covered at the `pfb_stage_publish_dir()` boundary and the call site is pinned by source inspection, following `DownloadStagePublishTest`'s precedent.

One red→green cycle, test file frozen byte-identical across both runs at `f3ad56033cceac72f47c9b3a49eafc1a05385470`:

```
RED : Tests: 10, Assertions: 18, Errors: 8, Failures: 2
      1) testBlacklistBranchNoLongerWipesTheCategoryBeforeExtracting
         the blacklist branch still wipes the live category directory before extracting
      2) testEveryStagedDirectoryPublicationSitsInAFailureGuard
         expected the blacklist branch to publish through pfb_stage_publish_dir()
      (8 errors: Call to undefined function pfb_stage_publish_dir())
GREEN: OK (10 tests, 37 assertions)
```

The behaviour tests cover both sides of the guard — a failed extraction keeps the previous category contents, a successful one replaces them — plus the no-prior-category case, staging-litter cleanup on both outcomes, same-directory staging, and the 0755 publication mode (`tempnam()` creates at 0600 and a published category has unprivileged readers).

The wiring assertions count by target rather than by command spelling, and are counted rather than matched against the haystack because `pfblockerng.inc` is ~700 KB and a containment matcher dumps the whole file into the failure output.

The function inventory golden was regenerated through its sanctioned path (`PFB_UPDATE_FUNCTION_INVENTORY=1`), adding only `pfb_stage_publish_dir`.

Gates on the rebased tip:

```
GATE PASS: python3 scripts/check_composer_vendor.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc
GATE PASS: php -l tests/php/DownloadStagePublishDirTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

Full PHPUnit suite: `Tests: 4986, Assertions: 28643` with no failures, the same warning/deprecation/notice profile as an untouched `origin/devel` checkout in this sandbox (`Tests: 4958, Assertions: 28545`).

Part of #2172

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blacklist updates to extract files safely before publishing them.
  * Preserves existing category data if extraction or publication fails.
  * Prevents incomplete updates and removes temporary staging files after processing.
  * Update markers are now created only after a successful update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->