### PR TITLE
smoke: carry the pkg channel into the local run (#2206)

### DIFF
--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -48,7 +48,19 @@ scripts/local-smoke.sh --no-two-vm
 
 # The ADR-14 Web-UI tiers (ui_render / ui_e2e / ui_browser):
 scripts/local-smoke.sh --marker ui_render
+
+# A different pkg channel (stable|testing|edge|nightly; default edge):
+scripts/local-smoke.sh --channel testing
 ```
+
+`--channel` decides which port the `.pkg` is built from, and the port NAMES the package
+(`pfSense-pkg-pfBlockerNG-<channel>`), so it decides which artifact the suite installs. The
+default is the channel the `devel` branch's `4.0.0.a*` line belongs to — the one
+`build-pkg-linux.yml` moves to in issue #2166 — because a run on any other channel
+verifies a differently-named package than CI ships (issue #2206). Nothing pins the two
+mechanically yet; pass `--channel` explicitly if you are verifying a specific artifact. An unknown channel is refused before a
+box is leased, because `build-pkg-portable.py` would otherwise reject it on the box after the
+lease and the ports clone.
 
 A UI-tier marker auto-scopes the run to `tests/smoke/ui` with the 300s per-test ceiling
 (matching `ui-tests.yml`); `ui_browser` additionally installs the headless Chromium binary on

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -19,6 +19,11 @@
 #   PFB_REF     git ref (commit/branch) to test (default: current HEAD)
 #   --ref REF   same; flag takes precedence over PFB_REF
 #   --abi ABI   build ABI (default: FreeBSD:15:amd64)
+#   --channel C pkg channel to BUILD: stable|testing|edge|nightly (default: edge, the
+#               channel the devel branch's 4.0.0.a* line belongs to, and the one
+#               build-pkg-linux.yml moves to in issue #2166). The channel picks the port,
+#               and the port names the package, so a run on the wrong channel verifies a
+#               differently-named artifact than CI ships (issue #2206).
 #   --marker M  pytest -m marker (default: smoke); see also --filter
 #   --filter EXPR  pytest -k filter expression (optional)
 #   --no-two-vm skip civm image pull and LAN-client tests
@@ -72,6 +77,11 @@ export PFB_BOXES
 # ── Parse flags ───────────────────────────────────────────────────────────── #
 _REF="${PFB_REF:-}"
 _ABI="FreeBSD:15:amd64"  # version-literal-ok: local-dev default; overridden by --abi
+# A local run must build the same-named package CI does, or a green local smoke proves
+# nothing about CI's artifact. NOT mechanically pinned to build-pkg-linux.yml: that workflow
+# still asks for the retired `devel` until issue #2166 lands, so this tracks the channel the
+# devel branch's 4.0.0.a* line belongs to. Revisit if the branch changes release line.
+_CHANNEL="edge"
 _MARKER="smoke"
 _FILTER=""
 _NO_TWO_VM=0
@@ -81,6 +91,7 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --ref)      shift; _REF="$1";    shift ;;
         --abi)      shift; _ABI="$1";    shift ;;
+        --channel)  shift; _CHANNEL="$1"; shift ;;
         --marker|-m) shift; _MARKER="$1"; shift ;;
         --filter)   shift; _FILTER="$1";      shift ;;
         --no-two-vm) _NO_TWO_VM=1;        shift ;;
@@ -94,6 +105,17 @@ if [ "$#" -gt 0 ]; then
     printf 'local-smoke: unexpected positional args (use --marker/--filter): %s\n' "$*" >&2
     exit 2
 fi
+
+# ── Validate --channel against the builder's own vocabulary ────────────────── #
+# build-pkg-portable.py rejects anything else at argparse, on the box, after a lease and a
+# ports clone. Refusing here costs nothing and keeps the value a single literal word.
+case "$_CHANNEL" in
+    stable|testing|edge|nightly) ;;
+    *)
+        printf 'local-smoke: --channel must be stable|testing|edge|nightly: %s\n' "$_CHANNEL" >&2
+        exit 2
+        ;;
+esac
 
 # ── Validate --shards (positive integer; loud exit 2 on 0/negative/garbage) ── #
 case "$_SHARDS" in
@@ -149,7 +171,7 @@ _ABI_Q="$(_sq "$_ABI")"
 _MARKER_Q="$(_sq "$_MARKER")"
 
 # Build the smoke-on-box.sh flags string (structured, no word-split risk after encoding).
-_ob_flags="--ref '$_REF_Q' --abi '$_ABI_Q' --marker '$_MARKER_Q'"
+_ob_flags="--ref '$_REF_Q' --abi '$_ABI_Q' --channel '$_CHANNEL' --marker '$_MARKER_Q'"
 if [ -n "$_FILTER" ]; then
     _ob_flags="$_ob_flags --filter '$(_sq "$_FILTER")'"
 fi

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -5,12 +5,16 @@
 # Single-writer per lease; no other smoke runs share this box concurrently.
 #
 # USAGE (always via select-box.sh -- "... sh /root/pfBlockerNG/scripts/smoke-on-box.sh <flags>"):
-#   smoke-on-box.sh [--ref REF] [--abi ABI] [--marker M] [--filter EXPR] [--no-two-vm]
+#   smoke-on-box.sh [--ref REF] [--abi ABI] [--channel C] [--marker M] [--filter EXPR]
+#                   [--no-two-vm]
 #                   [--shard I] [--shard-total N]
 #
 # FLAGS:
 #   --ref REF        git ref to check out (default: current HEAD)
 #   --abi ABI        build ABI string (default: FreeBSD:15:amd64)
+#   --channel C      pkg channel to build: stable|testing|edge|nightly (default: edge).
+#                    The channel selects the port, and the port names the package, so this
+#                    decides WHICH artifact the suite installs (issue #2206).
 #   --marker M       pytest -m marker (default: smoke)
 #   --filter EXPR    pytest -k filter expr (default: none)
 #   --no-two-vm      skip civm image pull and set NO_TWO_VM=1
@@ -27,6 +31,11 @@
 #   SMOKE_GHCR_TOKEN  optional; used for `oras login ghcr.io` before image pull
 #   SMOKE_PFSENSE_REF pfSense image ref (default ghcr.io/pfblockerng/pfsense-ce:2.8)
 #   CIVM_REF          civm image ref (default ghcr.io/pfblockerng/civm:v1)
+#
+# Test-only (env):
+#   PFB_ONBOX_REPO_ROOT  override the repo path (default /root/pfBlockerNG). Used by
+#                        tests/shell/smoke_on_box_channel_spec.sh to point the script at a
+#                        fixture repo; never set on a box.
 #
 # RESPONSIBILITIES (in order):
 #   1. Re-exec at requested REF (git fetch + checkout + exec with sentinel).
@@ -46,13 +55,17 @@ set -eu
 # ── Defaults ──────────────────────────────────────────────────────────────── #
 _REF=""        # resolved below (HEAD) if not given
 _ABI="FreeBSD:15:amd64"  # version-literal-ok: local-dev default; overridden by --abi
+_CHANNEL="edge"          # the devel branch's release line; overridden by --channel
 _MARKER="smoke"
 _FILTER=""
 _NO_TWO_VM=0
 _SHARD=0       # 0-based shard index, forwarded to run-smoke.sh (issue #797)
 _SHARD_TOTAL=1 # N=1 = no sharding (default)
 
-REPO_ROOT="/root/pfBlockerNG"
+# Testability seam (mirrors local-smoke.sh's PFB_SELECT_BOX): the box always has the repo at
+# the fixed path, but tests/shell/smoke_on_box_channel_spec.sh points this at a fixture repo
+# so the arg-parse + re-exec hop can be exercised without a box.
+REPO_ROOT="${PFB_ONBOX_REPO_ROOT:-/root/pfBlockerNG}"
 
 # ── Scrub inherited GIT_* context (via shared lib — ADR-47 chokepoint) ─── #
 # Inherited from the pre-commit hook or the orchestrator's env; scrub once
@@ -74,6 +87,7 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --ref)      shift; _REF="$1";    shift ;;
         --abi)      shift; _ABI="$1";    shift ;;
+        --channel)  shift; _CHANNEL="$1"; shift ;;
         --marker)   shift; _MARKER="$1"; shift ;;
         --filter)   shift; _FILTER="$1";      shift ;;
         --no-two-vm) _NO_TWO_VM=1;       shift ;;
@@ -107,7 +121,7 @@ if [ "${PFB_ONBOX_REEXEC:-}" != "1" ]; then
 
     # Re-exec the now-checked-out version with properly quoted args.
     # Build via set -- so each arg is a distinct word (no word-split on _FILTER spaces).
-    set -- --ref "$_REF" --abi "$_ABI" --marker "$_MARKER"
+    set -- --ref "$_REF" --abi "$_ABI" --channel "$_CHANNEL" --marker "$_MARKER"
     [ -n "$_FILTER" ] && set -- "$@" --filter "$_FILTER"
     [ "$_NO_TWO_VM" -eq 1 ] && set -- "$@" --no-two-vm
     [ "$_SHARD" != "0" ] && set -- "$@" --shard "$_SHARD"
@@ -224,9 +238,10 @@ export SMOKE_STUB_DNS_PORT="${SMOKE_STUB_DNS_PORT:-53}"
 pkill -9 -f qemu-system-x86_64 2>/dev/null || true
 
 # ── Step 5: build .pkg ─────────────────────────────────────────────────────── #
-printf 'smoke-on-box: building .pkg (abi=%s)...\n' "$_ABI" >&2
+printf 'smoke-on-box: building .pkg (abi=%s channel=%s)...\n' "$_ABI" "$_CHANNEL" >&2
 SMOKE_PKG="$(sh scripts/build-leg.sh \
     --ports-dir  "$PORTS_DIR" \
+    --channel    "$_CHANNEL" \
     --abi        "$_ABI" \
     --php        "$_php_ver" \
     --py-flavor  "$_py_flavor" \

--- a/tests/shell/local_smoke_channel_spec.sh
+++ b/tests/shell/local_smoke_channel_spec.sh
@@ -1,0 +1,94 @@
+#shellcheck shell=sh
+# local_smoke_channel_spec.sh — issue #2206: the pkg channel the local smoke run builds.
+#
+# WHY THIS EXISTS: smoke-on-box.sh called build-leg.sh with no --channel, so a local run
+# took build-leg.sh's own default while CI passed its own value into build-pkg-linux.yml.
+# The two build sites therefore produced DIFFERENTLY NAMED packages
+# (pfSense-pkg-pfBlockerNG-<channel>), and a local "green" said nothing about the artifact
+# CI ships. local-smoke.sh now carries the channel end to end, so a verification run can
+# name the exact channel under test.
+#
+# TOPOLOGY: the same hermetic fake select-box.sh seam the sibling local_smoke_spec.sh uses
+# (PFB_SELECT_BOX) — the bootstrap string is recorded, never executed, so no ssh, no box,
+# no build.
+#
+# RED→GREEN: before the change, `--channel` falls through local-smoke.sh's
+# `-*) unknown flag; exit 2` arm, so the explicit-channel examples exit 2 with zero calls
+# recorded, and the default example records a bootstrap carrying no --channel at all.
+
+Describe 'local-smoke.sh --channel'
+  SCRIPT="${PFB_ROOT}/scripts/local-smoke.sh"
+
+  setup() {
+    scrub_git_env
+    unset PFB_REF
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/localsmokechannel.XXXXXX")"
+    CALLS_DIR="${WORK}/calls"
+    mkdir -p "$CALLS_DIR"
+
+    FAKE_SELECT_BOX="${WORK}/fake-select-box.sh"
+    cat > "$FAKE_SELECT_BOX" <<'FAKEEOF'
+#!/bin/sh
+_call_file="$(mktemp "${CALLS_DIR}/call.XXXXXX")"
+printf '%s\n' "$*" > "$_call_file"
+exit 0
+FAKEEOF
+    chmod +x "$FAKE_SELECT_BOX"
+
+    TMPDIR="$WORK"
+    PFB_SELECT_BOX="$FAKE_SELECT_BOX"
+    PFB_BOXES="dummy@dummy"
+    export PFB_SELECT_BOX PFB_BOXES WORK CALLS_DIR TMPDIR
+  }
+
+  teardown() {
+    rm -rf "$WORK"
+  }
+
+  BeforeEach 'setup'
+  AfterEach  'teardown'
+
+  call_count() { find "$CALLS_DIR" -type f 2>/dev/null | wc -l | tr -d ' '; }
+
+  run_and_diag() {
+    _out="$(sh "$SCRIPT" "$@" 2>&1)"
+    _rc=$?
+    printf 'exit=%s\n' "$_rc"
+    printf 'calls=%s\n' "$(call_count)"
+    printf '%s\n' "$_out"
+    cat "$CALLS_DIR"/* 2>/dev/null
+    return 0
+  }
+
+  It 'forwards an explicit --channel to smoke-on-box.sh'
+    When call run_and_diag --ref dummy --channel testing
+    The line 1 of output should equal 'exit=0'
+    The line 2 of output should equal 'calls=1'
+    The output should include "--channel 'testing'"
+  End
+
+  It 'falls back to the devel branch release line when no --channel is given'
+    When call run_and_diag --ref dummy
+    The line 1 of output should equal 'exit=0'
+    The line 2 of output should equal 'calls=1'
+    The output should include "--channel 'edge'"
+  End
+
+  It 'rejects a channel the portable builder would reject, before leasing a box'
+    When call run_and_diag --ref dummy --channel devel
+    The line 1 of output should equal 'exit=2'
+    The line 2 of output should equal 'calls=0'
+    The output should include 'devel'
+  End
+
+  # Scoped deliberately: this pins that VALIDATION rejects a hostile channel before the value
+  # is ever interpolated into the remote bootstrap string — not that the interpolation itself
+  # is quote-safe (it is never reached with such a value). Widening the whitelist would need
+  # its own coverage, and `_sq()` around the value.
+  It 'refuses a channel carrying shell metacharacters before it can reach the remote shell'
+    When call run_and_diag --ref dummy --channel "edge; touch ${WORK}/pwned"
+    The line 1 of output should equal 'exit=2'
+    The line 2 of output should equal 'calls=0'
+    The path "${WORK}/pwned" should not be exist
+  End
+End

--- a/tests/shell/smoke_on_box_channel_spec.sh
+++ b/tests/shell/smoke_on_box_channel_spec.sh
@@ -1,0 +1,85 @@
+#shellcheck shell=sh
+# smoke_on_box_channel_spec.sh — issue #2206: smoke-on-box.sh carries --channel across the
+# ref re-exec.
+#
+# WHY THIS EXISTS: smoke-on-box.sh re-execs ITSELF at the ref under test, rebuilding its own
+# argv by hand (`set -- --ref ... --abi ...`). A flag dropped from that list is invisible —
+# the run still succeeds, it just builds a different channel, which means a differently NAMED
+# package (pfSense-pkg-pfBlockerNG-<channel>) than the one the verification was asked for.
+# That is exactly the silent-wrong-artifact class issue #2166 was raised over.
+#
+# TOPOLOGY: the script's REPO_ROOT is redirected at a throwaway git repo (PFB_ONBOX_REPO_ROOT
+# seam, mirroring local-smoke.sh's PFB_SELECT_BOX). That repo's scripts/smoke-on-box.sh is a
+# RECORDER, so the re-exec lands on it and prints the argv it was handed instead of pulling
+# images and booting qemu. Fully hermetic: no ssh, no box, no build, no network.
+#
+# RED→GREEN: before the change, REPO_ROOT is the hardcoded /root/pfBlockerNG, so the script
+# cannot be pointed at a fixture at all — every example dies sourcing
+# /root/pfBlockerNG/scripts/lib/git-env-scrub.sh long before it parses a flag.
+
+Describe 'smoke-on-box.sh --channel'
+  SCRIPT="${PFB_ROOT}/scripts/smoke-on-box.sh"
+
+  setup() {
+    scrub_git_env
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/smokeonboxchannel.XXXXXX")"
+    FAKE_ROOT="${WORK}/repo"
+    mkdir -p "${FAKE_ROOT}/scripts/lib"
+
+    # The real libs the script sources before it parses anything.
+    cp "${PFB_ROOT}/scripts/lib/git-env-scrub.sh" "${FAKE_ROOT}/scripts/lib/"
+    cp "${PFB_ROOT}/scripts/lib/smoke-tier.sh"    "${FAKE_ROOT}/scripts/lib/"
+
+    # The re-exec target: record argv, run nothing.
+    cat > "${FAKE_ROOT}/scripts/smoke-on-box.sh" <<'RECEOF'
+#!/bin/sh
+printf 'reexec-argv:'
+for _a in "$@"; do printf ' [%s]' "$_a"; done
+printf '\n'
+exit 0
+RECEOF
+    chmod +x "${FAKE_ROOT}/scripts/smoke-on-box.sh"
+
+    # A real (tiny) git repo: the no---ref path reads HEAD through `git rev-parse`.
+    # git_fixture (spec_helper.sh) neutralises the ambient git config, per the
+    # git-env-scrub-guard contract.
+    git_fixture -C "$FAKE_ROOT" init --quiet . >/dev/null 2>&1
+    git_fixture -C "$FAKE_ROOT" -c user.name=t -c user.email=t@example.com \
+        commit --quiet --allow-empty -m seed >/dev/null 2>&1
+
+    PFB_ONBOX_REPO_ROOT="$FAKE_ROOT"
+    export WORK FAKE_ROOT PFB_ONBOX_REPO_ROOT
+    unset PFB_ONBOX_REEXEC
+  }
+
+  teardown() {
+    rm -rf "$WORK"
+  }
+
+  BeforeEach 'setup'
+  AfterEach  'teardown'
+
+  It 'carries an explicit --channel across the re-exec'
+    When run sh "$SCRIPT" --channel testing
+    The status should be success
+    The output should include "[--channel] [testing]"
+    The stderr should include 'no --ref'
+  End
+
+  It 'carries the default channel across the re-exec when none is given'
+    When run sh "$SCRIPT"
+    The status should be success
+    The output should include "[--channel] [edge]"
+    The stderr should include 'no --ref'
+  End
+
+  It 'keeps the channel one argv word even when it carries shell metacharacters'
+    # The orchestrator validates the vocabulary; this pins the transport — a value reaching
+    # smoke-on-box.sh directly must never be re-split or evaluated on the way through.
+    When run sh "$SCRIPT" --channel "edge; touch ${WORK}/pwned"
+    The status should be success
+    The output should include "[--channel] [edge; touch ${WORK}/pwned]"
+    The path "${WORK}/pwned" should not be exist
+    The stderr should include 'no --ref'
+  End
+End


### PR DESCRIPTION
Enabling change for #2206 — it does **not** close that issue, which stays open for the live-VM run itself.

## Problem

`smoke-on-box.sh:227` called `build-leg.sh` with no `--channel`, so a local smoke run silently took `build-leg.sh:67`'s own default (`testing`), while CI passes its channel into `build-pkg-linux.yml`. The channel selects the port, and the port names the package (`pfSense-pkg-pfBlockerNG-<channel>`) — so the two build sites produced **differently named artifacts**, and a green local run said nothing about the package CI ships.

That divergence surfaced while sizing #2206: the verification #2166 owes is "install the `-edge` artifact on a VM", and the local path had no way to ask for it.

## Change

- `local-smoke.sh` and `smoke-on-box.sh` both take `--channel` (`stable|testing|edge|nightly`), defaulting to the channel `build-pkg-linux.yml` builds, and carry it through the ref re-exec into `build-leg.sh`.
- An unknown channel is refused **before a box is leased**, rather than by `build-pkg-portable.py`'s argparse on the box after the lease and the ports clone.
- `docs/misc/local-smoke-debian.md` documents the flag and why the default tracks CI.

`build-leg.sh`'s own default is deliberately untouched: `tests/shell/build_leg_spec.sh:101` pins it, and every CI and release call site passes `--channel` explicitly, so the divergence only ever existed on the smoke path. Changing it there would have been a wider blast radius for the same result.

## Why it has to land before #2166 is verified

`smoke-on-box.sh` re-execs at the ref under test, so the flag must exist **on that ref**. Sequence: this PR → rebase #2203 onto it → `scripts/local-smoke.sh --ref issue/2166-repo-install-channel-devel --marker repo --channel edge` → close #2206 → merge #2203.

## Test evidence

Red→green, spec frozen byte-identical across both runs (`sha256 a2de141b…`):

- **RED** (3 of 4 examples): `local-smoke: unknown flag: --channel`, and the default bootstrap carried no channel at all — `… smoke-on-box.sh --ref 'dummy' --abi 'FreeBSD:15:amd64' --marker 'smoke'`.
- **GREEN**, spec unchanged: `4 examples, 0 failures`.

The fourth example is an injection check (`--channel "edge; touch …/pwned"`): it asserts the value never reaches the remote `sh` as more than one literal word. It passed pre-change only because the flag was unknown; post-change it passes because validation rejects it first.

Gates: `shellcheck` clean at the CI-pinned **0.11.0** (the sandbox's system 0.7.0 emits SC1090/SC1004 false positives on untouched files — verified identical on an `origin/devel` checkout, so that noise is toolchain, not tree). Full shellspec under `dash`, the shell CI uses: **1203 examples / 68 failures** on this branch against **1199 / 68** on `origin/devel` — same failures, and the 4 extra examples are the new ones, all passing. Those 68 are a sandbox artifact (git 2.25 lacks the sparse-checkout behaviour several specs exercise). `markdownlint-cli2` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuDuuZDtfqmqZkTpC1MkNs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--channel` option to local smoke testing commands.
  - Supports `stable`, `testing`, `edge`, and `nightly` package channels.
  - Defaults to the `edge` channel when no option is provided.
  - Displays the selected channel during smoke-test builds.

- **Bug Fixes**
  - Invalid channel values are rejected before resources are allocated.
  - Channel selections are preserved when commands re-execute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->