### PR TITLE
docs: drop the future tense from the smoke channel default (#2209)

### DIFF
--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -56,9 +56,11 @@ scripts/local-smoke.sh --channel testing
 `--channel` decides which port the `.pkg` is built from, and the port NAMES the package
 (`pfSense-pkg-pfBlockerNG-<channel>`), so it decides which artifact the suite installs. The
 default is the channel the `devel` branch's `4.0.0.a*` line belongs to — the one
-`build-pkg-linux.yml` moves to in issue #2166 — because a run on any other channel
-verifies a differently-named package than CI ships (issue #2206). Nothing pins the two
-mechanically yet; pass `--channel` explicitly if you are verifying a specific artifact. An unknown channel is refused before a
+`build-pkg-linux.yml` builds (issue #2166) — because a run on any other channel
+verifies a differently-named package than CI ships (issue #2206). The two defaults are kept
+in step by hand: `tests/test_issue2166_workflow_channel_inputs.py` pins the workflows and
+`tests/smoke`, never this script's own default. Pass `--channel` explicitly if you are
+verifying a specific artifact. An unknown channel is refused before a
 box is leased, because `build-pkg-portable.py` would otherwise reject it on the box after the
 lease and the ports clone.
 

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -21,7 +21,7 @@
 #   --abi ABI   build ABI (default: FreeBSD:15:amd64)
 #   --channel C pkg channel to BUILD: stable|testing|edge|nightly (default: edge, the
 #               channel the devel branch's 4.0.0.a* line belongs to, and the one
-#               build-pkg-linux.yml moves to in issue #2166). The channel picks the port,
+#               build-pkg-linux.yml builds, issue #2166). The channel picks the port,
 #               and the port names the package, so a run on the wrong channel verifies a
 #               differently-named artifact than CI ships (issue #2206).
 #   --marker M  pytest -m marker (default: smoke); see also --filter
@@ -78,9 +78,10 @@ export PFB_BOXES
 _REF="${PFB_REF:-}"
 _ABI="FreeBSD:15:amd64"  # version-literal-ok: local-dev default; overridden by --abi
 # A local run must build the same-named package CI does, or a green local smoke proves
-# nothing about CI's artifact. NOT mechanically pinned to build-pkg-linux.yml: that workflow
-# still asks for the retired `devel` until issue #2166 lands, so this tracks the channel the
-# devel branch's 4.0.0.a* line belongs to. Revisit if the branch changes release line.
+# nothing about CI's artifact. NOT mechanically pinned to build-pkg-linux.yml: the guard test
+# (tests/test_issue2166_workflow_channel_inputs.py) scans the workflows and tests/smoke, never
+# this default, so the two are kept in step by hand. Both build the channel the devel branch's
+# 4.0.0.a* line belongs to. Revisit if the branch changes release line.
 _CHANNEL="edge"
 _MARKER="smoke"
 _FILTER=""


### PR DESCRIPTION
Fixes #2209.

Three comments describing `local-smoke.sh`'s channel default were written while the `edge` move was still pending, so they read as forward-looking. PR #2203 landed that move as `7b9d9a1a`, and one of them was outright false afterwards:

| File | Was | Now |
| --- | --- | --- |
| `scripts/local-smoke.sh:24` | "…and the one build-pkg-linux.yml **moves to** in issue #2166" | "…and the one build-pkg-linux.yml **builds**, issue #2166" |
| `scripts/local-smoke.sh:82` | "that workflow **still asks for the retired `devel`** until issue #2166 lands" | names the guard test and states the hand-kept coupling as a present fact |
| `docs/misc/local-smoke-debian.md:59` | "the one `build-pkg-linux.yml` **moves to** in issue #2166 … Nothing pins the two mechanically **yet**" | "the one `build-pkg-linux.yml` **builds**" + the same named-guard sentence |

## Why the warning stays

The claim these comments carry is still true and worth keeping — it just needed to stop reading as temporary. `tests/test_issue2166_workflow_channel_inputs.py` scans `.github/workflows/*.yml` and `tests/smoke/test_*.py` (lines 61, 96, 116) and never `scripts/local-smoke.sh`, so the local default and the CI default really are kept in step by hand. The rewrite says so and names the guard, rather than pointing at an issue whose resolution the reader has to go look up.

Making that coupling mechanical — extending the guard to `scripts/local-smoke.sh` and `scripts/smoke-on-box.sh` — is a real behaviour change with its own test and is deliberately not attempted here; #2209 records it as the larger optional follow-up.

## Scope and testing

Comment and prose only. No behaviour, no test expectations, no identifier or default value touched — `_CHANNEL="edge"` is unchanged, and `git diff` is limited to comment lines and one Markdown paragraph. No red→green proof applies, because nothing executable changed.

Gates run in-session via `scripts/agent/run-gates.sh --diff origin/devel`: `sh -n` PASS, `shellcheck` PASS, `markdownlint-cli2` PASS, `shellspec` SKIP (not installed in this sandbox — CI's `shellspec (POSIX sh)` leg is the authority). No spec asserts any of the rewritten strings; verified by grepping `tests/` for each phrase before editing.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.
