### PR TITLE
ci: hand the coverage-pairing gate real paths, not git's escapes (#2137)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -775,7 +775,11 @@ jobs:
         run: |
           set -eu
           git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
-          git diff --name-only "origin/$BASE...HEAD" > changed.txt
+          # core.quotePath=false: git's default wraps any non-ASCII path in quotes
+          # and octal-escapes it, and check_coverage_pairing.py classifies by
+          # startswith("src/") — so a quoted path matches no rule and an unpaired
+          # src/ change passes silently (issue #2137).
+          git -c core.quotePath=false diff --name-only "origin/$BASE...HEAD" > changed.txt
           echo "Changed files vs origin/$BASE:"; cat changed.txt
 
       - name: Enforce src<->tests and www<->ui coverage pairing

--- a/tests/test_issue2137_coverage_pairing_quotepath.py
+++ b/tests/test_issue2137_coverage_pairing_quotepath.py
@@ -1,0 +1,150 @@
+"""The coverage-pairing gate must see real paths, not git's quoted escapes.
+
+``.github/workflows/test.yml``'s ``coverage-pairing`` job computes the PR's
+changed-file list with ``git diff --name-only`` and pipes it into
+``scripts/check_coverage_pairing.py``, which classifies a path by
+``str.startswith("src/")``. Under git's default ``core.quotePath=true`` a path
+carrying any non-ASCII byte comes back wrapped in double quotes and
+octal-escaped (``"src/.../caf\\303\\251.inc"``), so it starts with ``"`` and
+matches no classifier at all: not src, not www, not docs, not a test. A
+production file under ``src/`` then clears the gate with no paired test and no
+``no-test-needed`` justification, and the job reports a clean pass rather than a
+skip — the miss is silent (issue #2137).
+
+These tests run the workflow's OWN command line, extracted from the YAML rather
+than retyped, against a scratch repository holding one non-ASCII ``src/`` path.
+The classifier is deliberately left strict: it is fed the real bytes, never
+taught to unwrap a quoted form.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+CHECKER = ROOT / "scripts" / "check_coverage_pairing.py"
+
+# The non-ASCII path from the issue's transcript. 'é' is two UTF-8 bytes, which is
+# what git escapes as \303\251 when core.quotePath is left at its default.
+NON_ASCII_SRC = "src/usr/local/pkg/pfblockerng/café.inc"
+ASCII_SRC = "src/usr/local/pkg/pfblockerng/plain.inc"
+
+
+def _compute_command() -> str:
+    """Return the workflow's changed-file command, read from the YAML itself.
+
+    Retyping the command here would let the workflow drift away from the test
+    while both stayed green, so the line is extracted instead.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    matches = [line.strip() for line in text.splitlines() if "diff --name-only" in line and "changed.txt" in line]
+    assert matches, "no changed-file computation found in test.yml"
+    assert len(matches) == 1, f"expected exactly one changed-file computation, got {matches}"
+    return matches[0]
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _scratch_repo(tmp_path: Path, changed: str) -> Path:
+    """A repo whose HEAD adds ``changed`` on top of ``origin/devel``."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # `git init -b` needs git >= 2.28; this must work on older git too.
+    _git("init", cwd=repo)
+    _git("config", "user.email", "test@example.invalid", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    _git("config", "commit.gpgsign", "false", cwd=repo)
+
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git("add", "README.md", cwd=repo)
+    _git("commit", "-m", "base", cwd=repo)
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    # The workflow diffs against origin/$BASE; create that ref directly rather
+    # than standing up a second repository to clone from.
+    _git("update-ref", "refs/remotes/origin/devel", base_sha, cwd=repo)
+
+    target = repo / changed
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("x\n", encoding="utf-8")
+    _git("add", "--", changed, cwd=repo)
+    _git("commit", "-m", "add a src file with no test", cwd=repo)
+    return repo
+
+
+def _run_gate(repo: Path) -> subprocess.CompletedProcess[str]:
+    """Run the workflow's compute step, then the gate, exactly as CI chains them."""
+    subprocess.run(
+        ["sh", "-euc", _compute_command()],
+        cwd=repo,
+        check=True,
+        env={"PATH": "/usr/bin:/bin", "BASE": "devel", "HOME": str(repo)},
+        capture_output=True,
+        text=True,
+    )
+    changed_txt = (repo / "changed.txt").read_bytes()
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        input=changed_txt.decode("utf-8", "surrogateescape"),
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("changed", "label"),
+    [(ASCII_SRC, "ascii control"), (NON_ASCII_SRC, "non-ascii path")],
+)
+def test_an_unpaired_src_change_fails_the_gate(tmp_path: Path, changed: str, label: str) -> None:
+    """A src/ change with no test fails the gate whatever bytes its path carries.
+
+    The ASCII row is the control: it already failed before the fix, so a green
+    non-ASCII row cannot be explained by the probe shape.
+    """
+    result = _run_gate(_scratch_repo(tmp_path, changed))
+    assert result.returncode == 1, (
+        f"{label}: unpaired {changed} passed the coverage-pairing gate "
+        f"(rc={result.returncode}); stdout={result.stdout!r}"
+    )
+    assert "coverage pairing violated" in result.stdout.lower()
+
+
+def test_the_changed_file_list_holds_the_real_path(tmp_path: Path) -> None:
+    """The computed list carries the path itself, never git's quoted escape.
+
+    Pins the cause rather than the symptom: the classifier is strict by design,
+    so the wiring is what has to hand it real bytes.
+    """
+    repo = _scratch_repo(tmp_path, NON_ASCII_SRC)
+    _run_gate(repo)
+    listed = (repo / "changed.txt").read_text(encoding="utf-8").strip()
+    assert listed == NON_ASCII_SRC, f"changed.txt holds {listed!r}, not the real path"
+    assert not listed.startswith('"'), "path is quoted: core.quotePath is not disabled"
+    assert "\\303" not in listed, "path is octal-escaped: core.quotePath is not disabled"
+
+
+def test_the_workflow_disables_quotepath_on_its_own_command() -> None:
+    """The fix lives on the command, so a rewrite that drops the flag fails here."""
+    command = _compute_command()
+    assert re.search(r"\bgit\s+-c\s+core\.quotePath=false\b", command), (
+        f"changed-file computation must disable core.quotePath: {command!r}"
+    )


### PR DESCRIPTION
Fixes #2137.

## The defect

`.github/workflows/test.yml`'s `coverage-pairing` job computed its changed-file list with a bare `git diff --name-only`. Git's default `core.quotePath=true` emits any path containing a non-ASCII byte wrapped in double quotes and octal-escaped, and `scripts/check_coverage_pairing.py` classifies a path with `str.startswith("src/")`. The quoted form starts with `"`, so it matched no classifier at all — not src, not www, not docs, not a test. A production file under `src/` then cleared the gate with no paired test and no `no-test-needed` justification, and the job reported a clean pass rather than a skip, so the miss was silent.

## The change

The one flag the issue and its three re-checks asked for, at the compute step:

```sh
git -c core.quotePath=false diff --name-only "origin/$BASE...HEAD" > changed.txt
```

`scripts/check_coverage_pairing.py` is deliberately untouched. Teaching it to unwrap a quoted path would make the workaround permanent and leave the wiring free to drift again; the gate should be handed real bytes instead.

**Sweep** (the issue's second acceptance item): this was the only changed-file *list* in the workflow. Every other `git diff` under `.github/workflows/` runs `--quiet`/`--stat` or a plain diff against a fixed literal path and feeds no classifier. The sibling checkers — `check_comment_narration.py`, `check_retired_tokens.py`, `check_version_literals.py`, `check_context_budget.py` — already force `core.quotePath` off themselves, as noted on the issue on 2026-08-05.

## Test evidence

`tests/test_issue2137_coverage_pairing_quotepath.py` (new, stdlib + pytest) extracts the command from the YAML rather than restating it, so a rewrite that drops the flag fails the test instead of drifting past it, and runs that command against a scratch repository holding the issue's own non-ASCII path.

Test-first, executed, frozen `sha256 f05b0054…` across the pair:

- **RED**, before the workflow was touched: `3 failed, 1 passed`.
  - `non-ascii path: unpaired src/usr/local/pkg/pfblockerng/café.inc passed the coverage-pairing gate (rc=0)`
  - `changed.txt holds '"src/usr/local/pkg/pfblockerng/caf\303\251.inc"', not the real path`
  - `changed-file computation must disable core.quotePath: 'git diff --name-only "origin/$BASE...HEAD" > changed.txt'`
- **GREEN**, same hash, after the one-line change: `4 passed`.

The ASCII control (`plain.inc`) is the non-vacuity check: it failed the gate in the RED run too, so the non-ASCII row going green cannot be explained by the probe's shape. `ruff format` later reflowed one comprehension (`sha256 a3d21f84…`) and the suite was re-run: `4 passed`.

Gates: `ruff check`, `ruff format --check` (522 files), `mypy tests/` (315 files) all clean, and the pre-commit hook chain passed.

Full suite in this sandbox: 507 failures on the branch against **508** on an untouched `origin/devel` checkout run in the same sandbox. Failure *sets* were diffed from `--junitxml`, never scraped from console output: one test differs, `TestGatherBootSet::test_boots_newest_stable_per_channel`, and it is not a regression — that class is order- and concurrency-sensitive here, the two suites were sharing `/tmp` while running at the same time, and re-running the class alone afterwards gives `5 passed` on the branch and on `origin/devel` alike. The large baseline failure population is a sandbox artifact: git is 2.25, which lacks `git init -b`, and the same set fails on an untouched checkout.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage checks for projects containing non-ASCII source file names.
  * Changed-file detection now preserves original file paths, ensuring accurate coverage pairing.

* **Tests**
  * Added regression coverage for non-ASCII paths, unpaired source changes, and correct workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->