### PR TITLE
ci: carry a git-quoted path through every changed-file gate (#2212)

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -43,7 +43,7 @@
           },
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/check_retired_tokens.py\" 7f671b73835f8e8c39cdb244489cdcbc471ecdc8a4cc361a5d8de4680284b97a && exec python3 \"$root/scripts/check_retired_tokens.py\" --claude-hook",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/check_retired_tokens.py\" eed470d0bf0d1f4b228a69ce44e285e7153082d26cf0b71f38e1701aa72ae6f9 && exec python3 \"$root/scripts/check_retired_tokens.py\" --claude-hook",
             "timeout": 30,
             "statusMessage": "Checking retired tokens"
           }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -49,15 +49,17 @@ skip() { skipped="${skipped} $1"; }
 # --- Stage classification: run a language's gates ONLY when this commit stages a
 #     file of that type. (diff-filter ACMR = added/copied/modified/renamed; a pure
 #     deletion stages nothing to lint.) Nothing staged -> nothing to do. ---
-#     -z + tr: git C-quotes a path holding a literal " \ or tab, and the quoted
-#     form ends `.inc"` rather than `.inc`, so the suffix tests below match
-#     nothing and the file's gates are skipped (issue #2212). A path containing
-#     a NEWLINE still splits here — representing one needs a NUL-aware consumer,
-#     which POSIX sh has no clean read for; CI's own Ruff/PHPCS/PHPStan jobs run
-#     unconditionally and remain the backstop for that residual case.
-staged_all=$(git -c core.quotePath=false diff --cached --name-only -z --diff-filter=ACMRD | tr '\0' '\n')
+#     -z: git C-quotes a path holding a literal " \ or tab, and the quoted form
+#     ends `.inc"` rather than `.inc`, so the suffix tests below match nothing
+#     and the file's gates are skipped (issue #2212). The newline is folded to
+#     \001 BEFORE the NULs become newlines: otherwise a newline inside a pathname
+#     becomes a record separator, one changed path arrives as two, and the tail
+#     can name a real unchanged file whose gates then run and pass while the
+#     changed file is never seen. \001 matches no suffix test, so such a path
+#     falls through to CI's unconditional Ruff/PHPCS/PHPStan jobs instead.
+staged_all=$(git diff --cached --name-only -z --diff-filter=ACMRD | tr '\n' '\001' | tr '\0' '\n')
 [ -n "$staged_all" ] || exit 0
-staged=$(git -c core.quotePath=false diff --cached --name-only -z --diff-filter=ACMR | tr '\0' '\n')
+staged=$(git diff --cached --name-only -z --diff-filter=ACMR | tr '\n' '\001' | tr '\0' '\n')
 staged_has() { printf '%s\n' "$staged" | grep -qE "$1"; }
 staged_py=0;  staged_has '\.py$'        && staged_py=1
 staged_md=0;  staged_has '\.md$'        && staged_md=1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -49,9 +49,15 @@ skip() { skipped="${skipped} $1"; }
 # --- Stage classification: run a language's gates ONLY when this commit stages a
 #     file of that type. (diff-filter ACMR = added/copied/modified/renamed; a pure
 #     deletion stages nothing to lint.) Nothing staged -> nothing to do. ---
-staged_all=$(git diff --cached --name-only --diff-filter=ACMRD)
+#     -z + tr: git C-quotes a path holding a literal " \ or tab, and the quoted
+#     form ends `.inc"` rather than `.inc`, so the suffix tests below match
+#     nothing and the file's gates are skipped (issue #2212). A path containing
+#     a NEWLINE still splits here — representing one needs a NUL-aware consumer,
+#     which POSIX sh has no clean read for; CI's own Ruff/PHPCS/PHPStan jobs run
+#     unconditionally and remain the backstop for that residual case.
+staged_all=$(git -c core.quotePath=false diff --cached --name-only -z --diff-filter=ACMRD | tr '\0' '\n')
 [ -n "$staged_all" ] || exit 0
-staged=$(git diff --cached --name-only --diff-filter=ACMR)
+staged=$(git -c core.quotePath=false diff --cached --name-only -z --diff-filter=ACMR | tr '\0' '\n')
 staged_has() { printf '%s\n' "$staged" | grep -qE "$1"; }
 staged_py=0;  staged_has '\.py$'        && staged_py=1
 staged_md=0;  staged_has '\.md$'        && staged_md=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -775,12 +775,14 @@ jobs:
         run: |
           set -eu
           git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
-          # core.quotePath=false: git's default wraps any non-ASCII path in quotes
-          # and octal-escapes it, and check_coverage_pairing.py classifies by
+          # -z emits raw NUL-separated paths. quotePath=false alone covers only
+          # non-ASCII bytes (issue #2137); git C-quotes a literal " \ tab or
+          # newline unconditionally, and check_coverage_pairing.py classifies by
           # startswith("src/") — so a quoted path matches no rule and an unpaired
-          # src/ change passes silently (issue #2137).
-          git -c core.quotePath=false diff --name-only "origin/$BASE...HEAD" > changed.txt
-          echo "Changed files vs origin/$BASE:"; cat changed.txt
+          # src/ change passes silently (issue #2212).
+          git -c core.quotePath=false diff --name-only -z "origin/$BASE...HEAD" > changed.txt
+          # tr for the log only: changed.txt keeps its NUL separators for the gate.
+          echo "Changed files vs origin/$BASE:"; tr '\0' '\n' < changed.txt
 
       - name: Enforce src<->tests and www<->ui coverage pairing
         # ubuntu-latest ships python3. --warn-only downgrades a violation to a

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -19,6 +19,11 @@
 # mandate #4).
 
 worktree='' base='origin/devel' plan=0 allow_missing=0
+
+# git_list() writes one temp file per RUN (the name is $$-derived, so it is the
+# same path for all four calls). Sweep it on the way out, including on a signal
+# between its creation and its own rm -- otherwise a killed run leaves litter.
+trap 'rm -f "${TMPDIR:-/tmp}/run-gates.$$.list"' EXIT INT TERM
 overall=0
 
 usage() {
@@ -46,11 +51,12 @@ usage() {
 # same question twice and let the first answer decide (issue #2212).
 git_list() {
 	# ONE git call, captured to a file so its own exit status is read directly.
-	# A pipeline reports tr's status, and tr exits 0 on empty input, so any
-	# checked-then-piped arrangement swallows a git failure and turns it into
-	# "no files changed" -- a vacuous GATES: PASS (issue #2212). Two calls, one
-	# checked and one piped, has the same hole one call over: the second can
-	# fail alone.
+	# Every arrangement that lets some LATER command decide the status masks a
+	# failure as "no files changed" and yields a vacuous GATES: PASS (issue
+	# #2212): a pipeline reports tr's status, and tr exits 0 on empty input;
+	# checking one git call and piping a second leaves the second unchecked; a
+	# trailing cleanup command reports its own success. Each step below is
+	# therefore checked where it happens.
 	_gl_out="${TMPDIR:-/tmp}/run-gates.$$.list"
 	git -C "$worktree" "$@" >"$_gl_out" || {
 		rm -f "$_gl_out"
@@ -63,7 +69,13 @@ git_list() {
 	# so the newline is folded to \001 first: the record stays whole and carries a
 	# byte no gate mapping matches, and the refusal below catches it.
 	tr '\n' '\001' <"$_gl_out" | tr '\0' '\n'
+	# The status is taken BEFORE the cleanup, then returned explicitly. A shell
+	# function returns its last command's status, so a trailing `rm -f` would
+	# decide the verdict and a failed conversion would read as "no files
+	# changed" -- the same masking, one statement further on.
+	_gl_status=$?
 	rm -f "$_gl_out"
+	return "$_gl_status"
 }
 
 gates_for() {

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -47,7 +47,13 @@ usage() {
 git_list() {
 	# First run decides: its stderr is left visible so a failure says why.
 	git -C "$worktree" "$@" >/dev/null || return 2
-	git -C "$worktree" "$@" | tr '\0' '\n'
+	# A newline INSIDE a pathname would otherwise become a record separator here,
+	# splitting one changed path into two -- and the tail can name a real,
+	# unchanged file, which then gets linted and passes while the changed file is
+	# never seen. That forged green is worse than the skip this all started from,
+	# so the newline is folded to \001 first: the record stays whole and carries a
+	# byte no gate mapping matches, and the refusal below catches it.
+	git -C "$worktree" "$@" | tr '\n' '\001' | tr '\0' '\n'
 }
 
 gates_for() {

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -45,15 +45,25 @@ usage() {
 # temp-file capture would need, so the cheapest honest check is to ask git the
 # same question twice and let the first answer decide (issue #2212).
 git_list() {
-	# First run decides: its stderr is left visible so a failure says why.
-	git -C "$worktree" "$@" >/dev/null || return 2
+	# ONE git call, captured to a file so its own exit status is read directly.
+	# A pipeline reports tr's status, and tr exits 0 on empty input, so any
+	# checked-then-piped arrangement swallows a git failure and turns it into
+	# "no files changed" -- a vacuous GATES: PASS (issue #2212). Two calls, one
+	# checked and one piped, has the same hole one call over: the second can
+	# fail alone.
+	_gl_out="${TMPDIR:-/tmp}/run-gates.$$.list"
+	git -C "$worktree" "$@" >"$_gl_out" || {
+		rm -f "$_gl_out"
+		return 2
+	}
 	# A newline INSIDE a pathname would otherwise become a record separator here,
 	# splitting one changed path into two -- and the tail can name a real,
 	# unchanged file, which then gets linted and passes while the changed file is
 	# never seen. That forged green is worse than the skip this all started from,
 	# so the newline is folded to \001 first: the record stays whole and carries a
 	# byte no gate mapping matches, and the refusal below catches it.
-	git -C "$worktree" "$@" | tr '\n' '\001' | tr '\0' '\n'
+	tr '\n' '\001' <"$_gl_out" | tr '\0' '\n'
+	rm -f "$_gl_out"
 }
 
 gates_for() {

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -121,19 +121,26 @@ main() {
 
 	# --diff-filter=ACMR: a pure deletion stages nothing to lint (same rule as the
 	# pre-commit hook) -- per-file gates against ghost paths would always fail.
+	# The base has to resolve before the diffs below, because each pipes git into
+	# tr and `|| exit 2` on a pipeline reads TR's status, not git's. Checking the
+	# ref up front keeps the fail-closed contract that a bad --diff base aborts
+	# rather than yielding an empty file list and a vacuous GATES: PASS.
+	git -C "$worktree" rev-parse --verify --quiet "${base}^{commit}" >/dev/null || exit 2
+
 	# -z + quotePath=false, then tr: git C-quotes a path holding a literal " \ or
 	# tab, and gates_for() matches by extension — a quoted path ends `.inc"` and
-	# maps to NO gate at all (issue #2212). A path containing a NEWLINE still
-	# splits here, as in .githooks/pre-commit; CI runs the same gates
-	# unconditionally and is the backstop for that residual case.
-	committed=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR "$base...HEAD" | tr '\0' '\n') || exit 2
+	# maps to NO gate at all (issue #2212). The unsafe-filename guard does not
+	# catch it either: that guard only inspects paths already ending .php/.inc/.sh.
+	# A path containing a NEWLINE still splits here, as in .githooks/pre-commit;
+	# CI runs the same gates unconditionally and is the backstop for it.
+	committed=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR "$base...HEAD" | tr '\0' '\n')
 	# issue #1293: union with uncommitted changes, else gates see nothing pre-commit.
 	# staged/unstaged unioned SEPARATELY, not via one `diff HEAD` -- `diff <commit>`
 	# reads the WORKING TREE, so a staged-then-worktree-reverted file is invisible.
-	staged=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR --cached | tr '\0' '\n') || exit 2
-	unstaged=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR | tr '\0' '\n') || exit 2
+	staged=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR --cached | tr '\0' '\n')
+	unstaged=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR | tr '\0' '\n')
 	# neither diff form surfaces a brand-new file never `git add`ed.
-	untracked=$(git -C "$worktree" -c core.quotePath=false ls-files --others --exclude-standard -z | tr '\0' '\n') || exit 2
+	untracked=$(git -C "$worktree" -c core.quotePath=false ls-files --others --exclude-standard -z | tr '\0' '\n')
 	files=$(printf '%s\n%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" "$untracked" | LC_ALL=C sort -u | grep -v '^$')
 	# The shellspec gate must also fire when only spec files changed (cross-language
 	# consumers rule): specs are .sh files, so the extension mapping already covers it.

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -121,14 +121,19 @@ main() {
 
 	# --diff-filter=ACMR: a pure deletion stages nothing to lint (same rule as the
 	# pre-commit hook) -- per-file gates against ghost paths would always fail.
-	committed=$(git -C "$worktree" diff --name-only --diff-filter=ACMR "$base...HEAD") || exit 2
+	# -z + quotePath=false, then tr: git C-quotes a path holding a literal " \ or
+	# tab, and gates_for() matches by extension — a quoted path ends `.inc"` and
+	# maps to NO gate at all (issue #2212). A path containing a NEWLINE still
+	# splits here, as in .githooks/pre-commit; CI runs the same gates
+	# unconditionally and is the backstop for that residual case.
+	committed=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR "$base...HEAD" | tr '\0' '\n') || exit 2
 	# issue #1293: union with uncommitted changes, else gates see nothing pre-commit.
 	# staged/unstaged unioned SEPARATELY, not via one `diff HEAD` -- `diff <commit>`
 	# reads the WORKING TREE, so a staged-then-worktree-reverted file is invisible.
-	staged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR --cached) || exit 2
-	unstaged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR) || exit 2
+	staged=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR --cached | tr '\0' '\n') || exit 2
+	unstaged=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR | tr '\0' '\n') || exit 2
 	# neither diff form surfaces a brand-new file never `git add`ed.
-	untracked=$(git -C "$worktree" ls-files --others --exclude-standard) || exit 2
+	untracked=$(git -C "$worktree" -c core.quotePath=false ls-files --others --exclude-standard -z | tr '\0' '\n') || exit 2
 	files=$(printf '%s\n%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" "$untracked" | LC_ALL=C sort -u | grep -v '^$')
 	# The shellspec gate must also fire when only spec files changed (cross-language
 	# consumers rule): specs are .sh files, so the extension mapping already covers it.

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -28,6 +28,28 @@ usage() {
 
 # Map a touched-file list (stdin, one path per line) to gate commands (stdout, one per
 # line). Per-file gates (php -l, sh -n, shellcheck) emit one command per touched file.
+# Emit a NUL-separated git path list as newline-separated lines, aborting on a
+# git failure instead of on tr's.
+#
+# -z is what makes the list safe: without it git C-quotes a path holding a
+# literal " \ or tab, gates_for() matches by extension, and a quoted path ends
+# `.inc"` — it maps to NO gate and is not caught by the unsafe-filename guard
+# either, which only inspects paths already ending .php/.inc/.sh (issue #2212).
+# A path containing a NEWLINE still splits here, as in .githooks/pre-commit;
+# CI runs the same gates unconditionally and is the backstop for that.
+#
+# The status probe is a separate run rather than a pipeline check on purpose: a
+# shell pipeline reports TR's status, which is 0 on empty input, so a git
+# failure would read as "no files changed" and produce a vacuous GATES: PASS.
+# dash has no `pipefail`, and command substitution cannot carry the NUL bytes a
+# temp-file capture would need, so the cheapest honest check is to ask git the
+# same question twice and let the first answer decide (issue #2212).
+git_list() {
+	# First run decides: its stderr is left visible so a failure says why.
+	git -C "$worktree" "$@" >/dev/null || return 2
+	git -C "$worktree" "$@" | tr '\0' '\n'
+}
+
 gates_for() {
 	files=$(cat)
 	out=''
@@ -121,26 +143,14 @@ main() {
 
 	# --diff-filter=ACMR: a pure deletion stages nothing to lint (same rule as the
 	# pre-commit hook) -- per-file gates against ghost paths would always fail.
-	# The base has to resolve before the diffs below, because each pipes git into
-	# tr and `|| exit 2` on a pipeline reads TR's status, not git's. Checking the
-	# ref up front keeps the fail-closed contract that a bad --diff base aborts
-	# rather than yielding an empty file list and a vacuous GATES: PASS.
-	git -C "$worktree" rev-parse --verify --quiet "${base}^{commit}" >/dev/null || exit 2
-
-	# -z + quotePath=false, then tr: git C-quotes a path holding a literal " \ or
-	# tab, and gates_for() matches by extension — a quoted path ends `.inc"` and
-	# maps to NO gate at all (issue #2212). The unsafe-filename guard does not
-	# catch it either: that guard only inspects paths already ending .php/.inc/.sh.
-	# A path containing a NEWLINE still splits here, as in .githooks/pre-commit;
-	# CI runs the same gates unconditionally and is the backstop for it.
-	committed=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR "$base...HEAD" | tr '\0' '\n')
+	committed=$(git_list diff --name-only -z --diff-filter=ACMR "$base...HEAD") || exit 2
 	# issue #1293: union with uncommitted changes, else gates see nothing pre-commit.
 	# staged/unstaged unioned SEPARATELY, not via one `diff HEAD` -- `diff <commit>`
 	# reads the WORKING TREE, so a staged-then-worktree-reverted file is invisible.
-	staged=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR --cached | tr '\0' '\n')
-	unstaged=$(git -C "$worktree" -c core.quotePath=false diff --name-only -z --diff-filter=ACMR | tr '\0' '\n')
+	staged=$(git_list diff --name-only -z --diff-filter=ACMR --cached) || exit 2
+	unstaged=$(git_list diff --name-only -z --diff-filter=ACMR) || exit 2
 	# neither diff form surfaces a brand-new file never `git add`ed.
-	untracked=$(git -C "$worktree" -c core.quotePath=false ls-files --others --exclude-standard -z | tr '\0' '\n')
+	untracked=$(git_list ls-files --others --exclude-standard -z) || exit 2
 	files=$(printf '%s\n%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" "$untracked" | LC_ALL=C sort -u | grep -v '^$')
 	# The shellspec gate must also fire when only spec files changed (cross-language
 	# consumers rule): specs are .sh files, so the extension mapping already covers it.

--- a/scripts/check_agent_roles.py
+++ b/scripts/check_agent_roles.py
@@ -447,14 +447,20 @@ def validate(root: Path) -> tuple[int, list[str]]:
 
 
 def _changed_paths(root: Path, git_args: list[str]) -> list[str]:
+    # -z + quotePath=false: git C-quotes a path holding a literal " \ tab or
+    # newline, and touches_role_surface() classifies by prefix — a quoted path
+    # matches nothing and the role-drift check is skipped (issue #2212).
+    # Kept on one line: the guard test that holds every consumer to -z reads
+    # line by line, so splitting the flags across lines reads as a violation.
+    argv = ["git", "-C", str(root), "-c", "core.quotePath=false", "diff", "--name-only", "-z", "--no-color"]
     out = subprocess.run(
-        ["git", "-C", str(root), "diff", "--name-only", "--no-color", *git_args],
+        [*argv, *git_args],
         capture_output=True,
         encoding="utf-8",
         errors="replace",
         check=True,
     )
-    return [line for line in out.stdout.splitlines() if line]
+    return [line for line in out.stdout.split("\0") if line]
 
 
 def touches_role_surface(paths: list[str]) -> bool:

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -28,8 +28,14 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import NamedTuple
+
+# Executed directly by the git hooks and CI, and loaded by path from the tests,
+# so the sibling module is not importable without this.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from git_paths import diff_header_name  # noqa: E402
 
 _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"RESULTS[-/]"), "delegation handoff artifact (RESULTS/ or RESULTS-Pn)"),
@@ -87,8 +93,8 @@ def find_violations(diff_text: str) -> list[Violation]:
             # Header only before a section's first @@ -- inside a hunk an added
             # "++..." line renders identically and must be scanned, not misread
             # as one. Strip git's disambiguation tab from a space-bearing path.
-            name = raw[4:]
-            path = name[2:].split("\t", 1)[0] if name.startswith("b/") else None
+            name = diff_header_name(raw)
+            path = name[2:] if name.startswith("b/") else None
             continue
         if raw.startswith("@@"):
             m = re.match(r"@@ -\S+ \+(\d+)", raw)

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -503,16 +503,19 @@ def main(argv: list[str] | None = None) -> int:
     root = args.root.resolve()
     try:
         if not args.all:
+            # -z: NUL-separated raw paths. quotePath=off covers only non-ASCII
+            # bytes; git C-quotes a literal " \ tab or newline whatever that is
+            # set to, and a quoted path matches no budget (issue #2212).
             diff_args = (
-                ["diff", "--cached", "--name-only"] if args.staged else ["diff", "--name-only", f"{args.diff}...HEAD"]
+                ["diff", "--cached", "--name-only", "-z"]
+                if args.staged
+                else ["diff", "--name-only", "-z", f"{args.diff}...HEAD"]
             )
-            changed = _git(root, "-c", "core.quotePath=off", *diff_args).split("\n")
+            changed = _git(root, "-c", "core.quotePath=off", *diff_args).split("\0")
             if not touches_context_surface([c for c in changed if c]):
                 print("context-budget: no context surface in the diff — skipped")
                 return 0
-        # quotePath=off: a non-ASCII filename would otherwise come back
-        # C-quoted ("…") and silently match no budget.
-        tracked = _git(root, "-c", "core.quotePath=off", "ls-files").split("\n")
+        tracked = _git(root, "-c", "core.quotePath=off", "ls-files", "-z").split("\0")
         tracked = [t for t in tracked if t]
         if args.staged:
             # Validate the INDEX snapshot, not the working tree: staged and

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -62,6 +62,13 @@ file contents, and is intentionally NOT part of ``.githooks/pre-commit``.
 from __future__ import annotations
 
 import sys
+from pathlib import Path
+
+# Executed directly by CI and the tests, so the sibling module is not importable
+# without this.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from git_paths import split_nul_or_lines  # noqa: E402
 
 _FIX_HINT = (
     "add the paired test, or — if none is warranted — apply the `no-test-needed` label, "
@@ -191,7 +198,12 @@ def main(argv: list[str] | None = None) -> int:
     paths = [a for a in args if a != "--warn-only"]
 
     if not paths:
-        paths = list(sys.stdin)
+        # NUL-separated when the producer used `git ... -z` (the CI job does, so
+        # a path git would otherwise C-quote still classifies — issue #2212);
+        # newline-separated otherwise, for a hand-typed list. Stripping is safe
+        # per entry either way: git emits no surrounding whitespace, and a
+        # trailing newline must not become an empty path.
+        paths = split_nul_or_lines(sys.stdin.read())
     paths = [p.strip() for p in paths if p.strip()]
 
     if warn_only and body_file is not None:

--- a/scripts/check_retired_tokens.py
+++ b/scripts/check_retired_tokens.py
@@ -84,6 +84,13 @@ import json
 import re
 import subprocess
 import sys
+from pathlib import Path
+
+# Executed directly by the git hooks and CI, and loaded by path from the tests,
+# so the sibling module is not importable without this.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from git_paths import diff_header_name  # noqa: E402
 
 # Tracked-tree roots a retiring commit is expected to have fixed everywhere.
 _SCAN_ROOTS = ("src", "scripts", ".github/workflows")
@@ -145,14 +152,14 @@ def _parse_diff(diff_text: str) -> tuple[dict[str, list[str]], dict[str, list[st
             continue
         if not in_hunk:
             if raw.startswith("--- "):
-                name = raw[4:]
+                name = diff_header_name(raw)
                 if name.startswith("a/"):
-                    a_path = name[2:].split("\t", 1)[0]
+                    a_path = name[2:]
             elif raw.startswith("+++ "):
-                name = raw[4:]
+                name = diff_header_name(raw)
                 if name.startswith("b/"):
-                    path = name[2:].split("\t", 1)[0]
-                elif name.split("\t", 1)[0] == "/dev/null":
+                    path = name[2:]
+                elif name == "/dev/null":
                     path = a_path
             continue
         if path is None or not _in_scan_roots(path):

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -77,6 +77,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Executed directly by the git hooks and CI, and loaded by path from the tests,
+# so the sibling module is not importable without this.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from git_paths import diff_header_name  # noqa: E402
+
 # Each alternative is a full-value token shape (anchored once, at the
 # alternation, by the two call sites below). Unambiguous shapes (ABI/php/py/
 # varver) are version-AGNOSTIC -- any restated literal is a drift hazard
@@ -511,8 +517,8 @@ def _added_lines_by_path(diff_text: str) -> dict[str, set[int]]:
             continue
         if not in_hunk:
             if raw.startswith("+++ "):
-                name = raw[4:]
-                path = name[2:].split("\t", 1)[0] if name.startswith("b/") else None
+                name = diff_header_name(raw)
+                path = name[2:] if name.startswith("b/") else None
             continue  # header block: '---'/'index'/etc. never carry added content
         if raw.startswith("+"):
             if path is not None:

--- a/scripts/git_paths.py
+++ b/scripts/git_paths.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Read paths out of git without losing the ones git quotes.
+
+PROBLEM
+-------
+Git renders a path that contains a byte it considers unsafe in C-quoted form:
+wrapped in double quotes, with backslash escapes. ``core.quotePath=false`` turns
+off only the *high-bit* half of that (issue #2137); a literal ``"``, ``\\``, tab
+or newline is escaped unconditionally, and no configuration suppresses it::
+
+    $ git -c core.quotePath=false diff --no-index --name-only a b
+    "b/src/has\\ttab.inc"
+
+Every gate in this repo classifies a path by prefix (``startswith("src/")``) or
+suffix (``\\.(php|inc)$``). A quoted path begins with ``"`` and ends with
+``".inc"`` rather than ``.inc``, so it matches nothing at all: the change ships
+un-gated and the job reports a clean pass. Issue #2212.
+
+THE TWO TRANSPORTS
+------------------
+``changed_paths`` is the answer wherever a *list* of paths is wanted: ``-z``
+emits them raw and NUL-separated, so no quoting happens and nothing has to be
+undone. It is also the only form that can carry a path containing a newline.
+
+``unquote`` is for the one place that cannot use ``-z`` — the ``+++ b/<path>``
+header of a unified diff, whose quoting no git option suppresses. Parsing the
+header is the only way to attribute a hunk to its file, so the path is unquoted
+on read instead.
+
+Prefer ``changed_paths``. Reach for ``unquote`` only when the path arrives
+inside a diff body that must be parsed anyway.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# git's unquote_c_style, as emitted by quote_c_style: the escapes it writes for
+# bytes that are not printable ASCII. Anything else appears as \NNN octal.
+_ESCAPES = {
+    "a": "\a",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "v": "\v",
+    "\\": "\\",
+    '"': '"',
+}
+
+
+def unquote(path: str) -> str:
+    """Undo git's C-style quoting of ``path``; return an unquoted path as-is.
+
+    A path git did not quote carries no escapes — its backslashes are literal —
+    so it must be returned untouched rather than run through the unescaper.
+    Detection is the surrounding double quotes, which is exactly the signal git
+    itself uses.
+    """
+    if len(path) < 2 or not path.startswith('"') or not path.endswith('"'):
+        return path
+
+    body = path[1:-1]
+    out = bytearray()
+    index = 0
+    while index < len(body):
+        char = body[index]
+        if char != "\\":
+            out += char.encode("utf-8")
+            index += 1
+            continue
+        index += 1
+        if index >= len(body):
+            # A trailing backslash cannot be produced by quote_c_style; keep it
+            # rather than dropping a byte from a path a caller may still act on.
+            out += b"\\"
+            break
+        char = body[index]
+        if char in _ESCAPES:
+            out += _ESCAPES[char].encode("utf-8")
+            index += 1
+        elif char.isdigit():
+            octal = body[index : index + 3]
+            out.append(int(octal, 8))
+            index += len(octal)
+        else:
+            # Not an escape git emits; keep both bytes verbatim.
+            out += b"\\" + char.encode("utf-8")
+            index += 1
+
+    # surrogateescape, not strict: a path need not be valid UTF-8, and a gate
+    # that crashes on one is no better than a gate that skips it.
+    return out.decode("utf-8", "surrogateescape")
+
+
+def diff_header_name(raw: str) -> str:
+    """The name a ``+++ ``/``--- `` unified-diff header carries, unquoted.
+
+    Returns the whole token, prefix included (``b/src/x.inc``, ``/dev/null``) —
+    callers keep their own prefix handling. Git quotes the token *including* its
+    ``b/`` prefix (``+++ "b/src/has\\"quote.inc"``), so a caller testing
+    ``startswith("b/")`` before unquoting sees no match and drops the file
+    silently; unquoting first is what keeps the hunk attributed (issue #2212).
+    """
+    name = raw[4:]
+    if name.startswith('"'):
+        # A quoted name is self-delimiting: git adds no disambiguation tab.
+        return unquote(name)
+    # git appends a tab after an unquoted name containing a space.
+    return name.split("\t", 1)[0]
+
+
+def changed_paths(*args: str, cwd: Path | str | None = None) -> list[str]:
+    """``git diff --name-only -z`` as a list of raw paths.
+
+    ``-z`` is what makes this safe: it suppresses quoting entirely, so the
+    result needs no unquoting and can carry a path containing a newline, which
+    a newline-separated list cannot represent at all.
+    """
+    out = subprocess.run(
+        ["git", "-c", "core.quotePath=false", "diff", "--name-only", "-z", *args],
+        cwd=cwd,
+        capture_output=True,
+        check=True,
+    ).stdout
+    return [p.decode("utf-8", "surrogateescape") for p in out.split(b"\0") if p]
+
+
+def split_nul_or_lines(body: str) -> list[str]:
+    """Split a changed-file list that may be NUL-separated or newline-separated.
+
+    A NUL anywhere means the producer used ``-z``, and newlines inside a path
+    are then data rather than separators — so the two forms must never be mixed.
+    Falling back to lines keeps a hand-typed list working at the command line.
+    """
+    if "\0" in body:
+        return [p for p in body.split("\0") if p]
+    return [line for line in body.splitlines() if line]

--- a/scripts/impacted-tests.sh
+++ b/scripts/impacted-tests.sh
@@ -34,11 +34,11 @@ else
 	# Three-dot: files changed on HEAD since the merge-base with BASE_REF.
 	# Tolerate a missing/unfetched base ref — an empty diff routes the caller to
 	# the safe full-marker path rather than erroring the run.
-	# -z + quotePath=false, then tr: a path git C-quotes (literal " \ tab) would
-	# otherwise reach the marker mapping below wrapped in quotes and match no
-	# rule (issue #2212). An embedded newline still splits, as elsewhere in the
-	# POSIX-sh consumers; the safe full-marker path is the backstop.
-	changed="$(git -c core.quotePath=false diff --name-only -z "${base}...HEAD" 2>/dev/null | tr '\0' '\n' || true)"
+	# -z: a path git C-quotes (literal " \ tab) would otherwise reach the marker
+	# mapping below wrapped in quotes and match no rule (issue #2212). The
+	# newline is folded to \001 first so a newline inside a pathname cannot
+	# become a record separator and forge a second path that does match.
+	changed="$(git diff --name-only -z "${base}...HEAD" 2>/dev/null | tr '\n' '\001' | tr '\0' '\n' || true)"
 fi
 
 # Build the OR expression in a subshell fed by the pipe; the trailing printf runs

--- a/scripts/impacted-tests.sh
+++ b/scripts/impacted-tests.sh
@@ -34,7 +34,11 @@ else
 	# Three-dot: files changed on HEAD since the merge-base with BASE_REF.
 	# Tolerate a missing/unfetched base ref — an empty diff routes the caller to
 	# the safe full-marker path rather than erroring the run.
-	changed="$(git diff --name-only "${base}...HEAD" 2>/dev/null || true)"
+	# -z + quotePath=false, then tr: a path git C-quotes (literal " \ tab) would
+	# otherwise reach the marker mapping below wrapped in quotes and match no
+	# rule (issue #2212). An embedded newline still splits, as elsewhere in the
+	# POSIX-sh consumers; the safe full-marker path is the backstop.
+	changed="$(git -c core.quotePath=false diff --name-only -z "${base}...HEAD" 2>/dev/null | tr '\0' '\n' || true)"
 fi
 
 # Build the OR expression in a subshell fed by the pipe; the trailing printf runs

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -147,7 +147,7 @@ Describe 'run-gates.sh Composer vendor guard'
     printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$phpunit_marker" > "$repo/vendor/bin/phpunit"
     chmod +x "$stubdir/python3" "$stubdir/php" "$stubdir/composer" "$repo/vendor/bin/phpunit"
     ln -s "$(command -v git)" "$stubdir/git"
-    for tool in cat dirname grep sh sort tr; do
+    for tool in cat dirname grep rm sh sort tr; do
       ln -s "$(command -v "$tool")" "$stubdir/$tool"
     done
     PATH="$stubdir:$PATH"

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -147,7 +147,7 @@ Describe 'run-gates.sh Composer vendor guard'
     printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$phpunit_marker" > "$repo/vendor/bin/phpunit"
     chmod +x "$stubdir/python3" "$stubdir/php" "$stubdir/composer" "$repo/vendor/bin/phpunit"
     ln -s "$(command -v git)" "$stubdir/git"
-    for tool in cat dirname grep sh sort; do
+    for tool in cat dirname grep sh sort tr; do
       ln -s "$(command -v "$tool")" "$stubdir/$tool"
     done
     PATH="$stubdir:$PATH"

--- a/tests/test_issue2137_coverage_pairing_quotepath.py
+++ b/tests/test_issue2137_coverage_pairing_quotepath.py
@@ -136,8 +136,12 @@ def test_the_changed_file_list_holds_the_real_path(tmp_path: Path) -> None:
     """
     repo = _scratch_repo(tmp_path, NON_ASCII_SRC)
     _run_gate(repo)
-    listed = (repo / "changed.txt").read_text(encoding="utf-8").strip()
-    assert listed == NON_ASCII_SRC, f"changed.txt holds {listed!r}, not the real path"
+    # NUL-separated since issue #2212 moved the compute step to `-z`; a newline
+    # is data inside a path there, never a separator.
+    body = (repo / "changed.txt").read_text(encoding="utf-8")
+    entries = [p for p in body.split("\0") if p] if "\0" in body else body.splitlines()
+    assert entries == [NON_ASCII_SRC], f"changed.txt holds {entries!r}, not the real path"
+    listed = entries[0]
     assert not listed.startswith('"'), "path is quoted: core.quotePath is not disabled"
     assert "\\303" not in listed, "path is octal-escaped: core.quotePath is not disabled"
 

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -25,6 +25,7 @@ rule so a seventh site cannot be added quietly.
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
 import subprocess
 import sys
@@ -374,6 +375,92 @@ def test_a_newline_in_a_path_cannot_forge_a_different_one(tmp_path: Path) -> Non
     assert "php -l src/existing.php" not in result.stdout, (
         f"a newline path forged a gate for an unchanged file; plan was {result.stdout!r}"
     )
+
+
+def test_impacted_tests_cannot_be_forged_by_a_newline_path(tmp_path: Path) -> None:
+    """The marker mapping must not select a test the diff never touched.
+
+    Same forgery as the run-gates case, one consumer over: a path holding a
+    newline splits, and the tail can name a real test module — which would then
+    be the only one selected, narrowing the run to something the change never
+    touched while looking like a normal impacted-tests result.
+    """
+    repo = _repo(tmp_path)
+    tests_dir = repo / "tests" / "smoke"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test_real.py").write_text("def test_x():\n    pass\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "real test", cwd=repo)
+    _git("branch", "devel", cwd=repo)
+
+    forged = repo / "ignored\ntests" / "smoke"
+    forged.mkdir(parents=True)
+    (forged / "test_real.py").write_text("x = 1\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "forge", cwd=repo)
+
+    result = subprocess.run(
+        ["sh", str(SCRIPTS / "impacted-tests.sh"), "devel", "tests/smoke"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    assert "test_real" not in result.stdout, (
+        f"a newline path forged a -k selection for an untouched test: {result.stdout!r}"
+    )
+
+
+def test_run_gates_fails_closed_when_a_later_git_call_fails(tmp_path: Path) -> None:
+    """A git failure aborts the run wherever in the sequence it lands.
+
+    A corrupted repository fails every call alike, so it cannot catch a helper
+    that checks one invocation and then runs another unchecked — the status of
+    a shell pipeline is ``tr``'s, and ``tr`` exits 0 on empty input. This stub
+    fails only the SECOND path-list invocation, which is the case a persistent
+    fault cannot express.
+    """
+    repo = _repo(tmp_path)
+    _git("branch", "devel", cwd=repo)
+    (repo / "src").mkdir()
+    (repo / "src" / "a.php").write_text("<?php echo 1;\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "add", cwd=repo)
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    state = tmp_path / "count"
+    (bindir / "git").write_text(
+        "#!/bin/sh\n"
+        'case "$*" in\n'
+        '\t*"--name-only"*|*"ls-files"*)\n'
+        f'\t\tn=$(cat "{state}" 2>/dev/null || echo 0); n=$((n + 1)); printf %s "$n" > "{state}"\n'
+        '\t\t[ "$n" = 2 ] && { echo "fatal: simulated mid-run git failure" >&2; exit 128; }\n'
+        "\t\t;;\n"
+        "esac\n"
+        'exec /usr/bin/git "$@"\n',
+        encoding="utf-8",
+    )
+    (bindir / "git").chmod(0o755)
+
+    env = dict(os.environ, PATH=f"{bindir}:{os.environ['PATH']}")
+    result = subprocess.run(
+        [
+            "sh",
+            str(ROOT / "scripts" / "agent" / "run-gates.sh"),
+            "--worktree",
+            str(repo),
+            "--diff",
+            "devel",
+            "--allow-missing",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode != 0, (
+        f"a mid-run git failure produced a clean run (rc={result.returncode}); stdout={result.stdout!r}"
+    )
+    assert "GATES: PASS" not in result.stdout, f"a mid-run git failure reported success: {result.stdout!r}"
 
 
 def test_run_gates_fails_closed_when_git_itself_fails(tmp_path: Path) -> None:

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -25,6 +25,7 @@ rule so a seventh site cannot be added quietly.
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -203,32 +204,93 @@ def test_name_only_z_returns_raw_paths(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------
 
 
+def _executable_lines(path: Path) -> list[tuple[int, str]]:
+    """Lines of ``path`` that are code, with comments and docstrings dropped.
+
+    Prose mentioning a command must not be mistaken for one. Python docstrings
+    are tracked with a triple-quote toggle rather than parsed: the scanners
+    below only need to know whether a line is code, and a real parse cannot
+    distinguish an invocation from a string constant anyway, since the flag
+    itself is a string literal in the call.
+    """
+    lines: list[tuple[int, str]] = []
+    fence: str | None = None
+    # errors="replace": a binary under a scan root must not abort the sweep, and
+    # a mangled byte cannot hide the ASCII flag being looked for.
+    for number, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+        stripped = line.strip()
+        if path.suffix == ".py":
+            for quote in ('"""', "'''"):
+                if fence is None and stripped.startswith(quote):
+                    # A one-line docstring opens and closes on the same line.
+                    fence = None if stripped.endswith(quote) and len(stripped) > len(quote) else quote
+                    break
+                if fence == quote and quote in stripped:
+                    fence = None
+                    break
+            else:
+                if fence is not None:
+                    continue
+                lines.append((number, line))
+                continue
+            continue
+        if stripped.startswith("#"):
+            continue
+        lines.append((number, line))
+    return lines
+
+
+def _scan_roots() -> list[Path]:
+    """Every file that could invoke git, found by walking — never a fixed list.
+
+    A hand-maintained tuple is what let the first pass at #2212 miss three
+    sites: it can only catch a regression in a file someone already thought of.
+    """
+    roots = [ROOT / ".github", ROOT / ".githooks", ROOT / "scripts"]
+    found: list[Path] = []
+    for root in roots:
+        found += [
+            p
+            for p in sorted(root.rglob("*"))
+            # Compiled bytecode carries the source's strings and would report a
+            # fixed site as still broken; it is a build artifact, not a site.
+            if p.is_file() and "__pycache__" not in p.parts and p.suffix != ".pyc"
+        ]
+    return found
+
+
 def test_every_name_only_consumer_uses_the_nul_transport() -> None:
     """A changed-file list is read NUL-separated, everywhere, with no exceptions.
 
-    Pins the class rather than the four sites known today: a new consumer that
-    reads a newline-separated list fails here instead of silently re-opening the
-    hole.
+    Pins the class, not the sites known today: the tree is walked, so a NEW
+    consumer that reads a newline-separated list fails here instead of quietly
+    re-opening the hole.
     """
     offenders: list[str] = []
-    for path in [WORKFLOW, PRE_COMMIT, SCRIPTS / "check_context_budget.py"]:
-        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            if "--name-only" not in line or line.lstrip().startswith("#"):
+    for path in _scan_roots():
+        for number, line in _executable_lines(path):
+            if "--name-only" not in line:
                 continue
-            if "-z" not in line.split("--name-only")[0] and "-z" not in line.split("--name-only")[1]:
+            if "--no-index" in line:
+                continue  # not a changed-file list; the helper's own example
+            # A standalone -z token: quoted in a Python arg list, bare in shell.
+            if not re.search(r"(?<![\w-])-z(?![\w-])", line):
                 offenders.append(f"{path.relative_to(ROOT)}:{number}: {line.strip()}")
     assert not offenders, "changed-file lists read without -z:\n  " + "\n  ".join(offenders)
 
 
 def test_every_unified_diff_parser_unquotes_its_header_path() -> None:
-    """The three `+++ b/` parsers all route the header path through the helper."""
-    missing = [
-        name
-        for name in (
-            "check_comment_narration.py",
-            "check_retired_tokens.py",
-            "check_version_literals.py",
-        )
-        if "diff_header_name" not in (SCRIPTS / name).read_text(encoding="utf-8")
-    ]
+    """Anything parsing a `+++ b/` header routes it through the helper.
+
+    Walked, not listed, for the same reason as the scanner above.
+    """
+    missing: list[str] = []
+    for path in _scan_roots():
+        if path.suffix != ".py" or path.name == "git_paths.py":
+            continue
+        body = path.read_text(encoding="utf-8", errors="replace")
+        if '"+++ ' not in body and "'+++ " not in body:
+            continue
+        if "diff_header_name" not in body:
+            missing.append(str(path.relative_to(ROOT)))
     assert not missing, f"unified-diff parsers not unquoting their header path: {missing}"

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -335,6 +335,47 @@ def test_run_gates_refuses_a_hostile_path_instead_of_skipping_it(tmp_path: Path)
     )
 
 
+def test_a_newline_in_a_path_cannot_forge_a_different_one(tmp_path: Path) -> None:
+    """A path holding a newline must never be split into other paths.
+
+    ``tr '\\0' '\\n'`` makes a newline inside a pathname indistinguishable from
+    the record separator, so ``ignored\\nsrc/existing.php`` arrives as two
+    records. The second names a real, UNCHANGED file: the gate then lints that
+    file, passes, and never looks at the changed one. That is a manufactured
+    green, strictly worse than the skip issue #2212 started from.
+    """
+    repo = _repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / "src" / "existing.php").write_text("<?php echo 1;\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "existing", cwd=repo)
+    _git("branch", "devel", cwd=repo)
+
+    forged = repo / "ignored\nsrc"
+    forged.mkdir()
+    (forged / "existing.php").write_text("<?php bad\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "forge", cwd=repo)
+
+    result = subprocess.run(
+        [
+            "sh",
+            str(ROOT / "scripts" / "agent" / "run-gates.sh"),
+            "--worktree",
+            str(repo),
+            "--diff",
+            "devel",
+            "--plan",
+            "--allow-missing",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert "php -l src/existing.php" not in result.stdout, (
+        f"a newline path forged a gate for an unchanged file; plan was {result.stdout!r}"
+    )
+
+
 def test_run_gates_fails_closed_when_git_itself_fails(tmp_path: Path) -> None:
     """A git failure aborts the run; it never reports GATES: PASS on no files.
 

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -410,6 +410,48 @@ def test_impacted_tests_cannot_be_forged_by_a_newline_path(tmp_path: Path) -> No
     )
 
 
+def test_run_gates_fails_closed_when_the_conversion_fails(tmp_path: Path) -> None:
+    """The path-list conversion failing aborts the run too, not just git.
+
+    Third instance of one class: a shell function returns its LAST command's
+    status, so whatever runs after the work decides the verdict. Checking git
+    and then letting `tr` decide, or checking `tr` and then letting the cleanup
+    `rm` decide, both end the same way — an empty list read as "no files
+    changed" and a clean GATES: PASS.
+    """
+    repo = _repo(tmp_path)
+    _git("branch", "devel", cwd=repo)
+    (repo / "src").mkdir()
+    (repo / "src" / "a.php").write_text("<?php echo 1;\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "add", cwd=repo)
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "tr").write_text("#!/bin/sh\nexit 3\n", encoding="utf-8")
+    (bindir / "tr").chmod(0o755)
+
+    env = dict(os.environ, PATH=f"{bindir}:{os.environ['PATH']}")
+    result = subprocess.run(
+        [
+            "sh",
+            str(ROOT / "scripts" / "agent" / "run-gates.sh"),
+            "--worktree",
+            str(repo),
+            "--diff",
+            "devel",
+            "--allow-missing",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode != 0, (
+        f"a failed path-list conversion produced a clean run (rc={result.returncode}); stdout={result.stdout!r}"
+    )
+    assert "GATES: PASS" not in result.stdout, f"a failed conversion reported success: {result.stdout!r}"
+
+
 def test_run_gates_fails_closed_when_a_later_git_call_fails(tmp_path: Path) -> None:
     """A git failure aborts the run wherever in the sequence it lands.
 

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -74,7 +74,7 @@ def _repo(tmp_path: Path) -> Path:
     what git emits and turn a real failure into a false pass.
     """
     repo = tmp_path / "repo"
-    repo.mkdir()
+    repo.mkdir(parents=True)
     # `git init -b` needs git >= 2.28; this must work on older git too.
     _git("init", cwd=repo)
     _git("config", "user.email", "test@example.invalid", cwd=repo)
@@ -274,9 +274,48 @@ def test_every_name_only_consumer_uses_the_nul_transport() -> None:
             if "--no-index" in line:
                 continue  # not a changed-file list; the helper's own example
             # A standalone -z token: quoted in a Python arg list, bare in shell.
-            if not re.search(r"(?<![\w-])-z(?![\w-])", line):
-                offenders.append(f"{path.relative_to(ROOT)}:{number}: {line.strip()}")
+            if re.search(r"(?<![\w-])-z(?![\w-])", line):
+                continue
+            offenders.append(f"{path.relative_to(ROOT)}:{number}: {line.strip()}")
     assert not offenders, "changed-file lists read without -z:\n  " + "\n  ".join(offenders)
+
+
+def test_run_gates_refuses_a_hostile_path_instead_of_skipping_it(tmp_path: Path) -> None:
+    """run-gates.sh fails loudly on a path it cannot gate, never silently.
+
+    It is named authoritative by AGENTS.md alongside the hooks and CI, and it
+    opts out of the NUL transport (piping through ``tr`` would hide git's exit
+    status behind ``|| exit 2``). What replaces it must therefore be checked by
+    running it: a quoted path has to reach the unsafe-filename guard and fail
+    the run, and a non-ASCII path has to map to its gates as normal.
+    """
+    script = ROOT / "scripts" / "agent" / "run-gates.sh"
+
+    hostile = _repo(tmp_path / "hostile")
+    _git("branch", "devel", cwd=hostile)
+    _commit_file(hostile, 'src/usr/local/www/has"quote.php', "<?php echo 1;\n")
+    refused = subprocess.run(
+        ["sh", str(script), "--worktree", str(hostile), "--diff", "devel", "--plan", "--allow-missing"],
+        capture_output=True,
+        text=True,
+    )
+    assert "unsafe filename in diff" in refused.stdout, (
+        f"a quoted path produced no refusal; plan was {refused.stdout!r}"
+    )
+
+    # The non-ASCII class must still map to real gates — quotePath=false is what
+    # carries it, and a regression there would look identical to a clean skip.
+    accented = _repo(tmp_path / "accented")
+    _git("branch", "devel", cwd=accented)
+    _commit_file(accented, "src/usr/local/www/café.php", "<?php echo 1;\n")
+    planned = subprocess.run(
+        ["sh", str(script), "--worktree", str(accented), "--diff", "devel", "--plan", "--allow-missing"],
+        capture_output=True,
+        text=True,
+    )
+    assert "php -l src/usr/local/www/café.php" in planned.stdout, (
+        f"a non-ASCII path mapped to no gate; plan was {planned.stdout!r}"
+    )
 
 
 def test_every_unified_diff_parser_unquotes_its_header_path() -> None:

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -303,8 +303,12 @@ def test_run_gates_refuses_a_hostile_path_instead_of_skipping_it(tmp_path: Path)
         f"a quoted path produced no refusal; plan was {refused.stdout!r}"
     )
 
-    # The non-ASCII class must still map to real gates — quotePath=false is what
-    # carries it, and a regression there would look identical to a clean skip.
+    # The non-ASCII class must not vanish either. Which way it resolves is
+    # environment-dependent — run-gates' unsafe-filename filter is
+    # `[^A-Za-z0-9._/-]`, and whether an accented byte trips it varies with the
+    # locale and grep the run happens to use (it refuses on CI, gates here) — so
+    # asserting one outcome would pin the environment, not the contract. What
+    # #2212 is about is that neither outcome may be SILENCE.
     accented = _repo(tmp_path / "accented")
     _git("branch", "devel", cwd=accented)
     _commit_file(accented, "src/usr/local/www/café.php", "<?php echo 1;\n")
@@ -313,8 +317,21 @@ def test_run_gates_refuses_a_hostile_path_instead_of_skipping_it(tmp_path: Path)
         capture_output=True,
         text=True,
     )
-    assert "php -l src/usr/local/www/café.php" in planned.stdout, (
-        f"a non-ASCII path mapped to no gate; plan was {planned.stdout!r}"
+    surfaced = "src/usr/local/www/café.php" in planned.stdout or "unsafe filename in diff" in planned.stdout
+    assert surfaced, f"a non-ASCII path was silently skipped; plan was {planned.stdout!r}"
+
+    # An ordinary path is the control: it must map to its gates, so a plan that
+    # refuses or skips everything cannot make the two rows above pass.
+    plain = _repo(tmp_path / "plain")
+    _git("branch", "devel", cwd=plain)
+    _commit_file(plain, "src/usr/local/www/plain.php", "<?php echo 1;\n")
+    control = subprocess.run(
+        ["sh", str(script), "--worktree", str(plain), "--diff", "devel", "--plan", "--allow-missing"],
+        capture_output=True,
+        text=True,
+    )
+    assert "php -l src/usr/local/www/plain.php" in control.stdout, (
+        f"the ASCII control mapped to no gate; plan was {control.stdout!r}"
     )
 
 

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -1,0 +1,234 @@
+"""Issue #2212 — a path git C-quotes must still reach every changed-file gate.
+
+`core.quotePath=false` stops git octal-escaping *high-bit* bytes, which is what
+#2137 fixed. Git's C-style quoting of a literal ``"``, ``\\``, tab or newline is
+unconditional and has no such switch, so a path in any of those classes still
+arrives wrapped in double quotes:
+
+    $ git -c core.quotePath=false diff --no-index --name-only a b
+    "b/src/has\\ttab.inc"
+
+Every gate that classifies a path by prefix or suffix then matches nothing, and
+the change ships un-gated while the job reports a clean pass. Two transports
+carry paths in this repo and each needs its own answer:
+
+* ``--name-only`` lists — fixed with ``-z``, which emits raw NUL-separated
+  paths and sidesteps quoting entirely.
+* the ``+++ b/<path>`` header of a unified diff — ``-z`` does not apply, and no
+  git option suppresses the quoting, so the header path is unquoted on read.
+
+These tests pin the behaviour of one gate per transport, unit-test the shared
+unquoting against every hostile class, and hold the whole consumer list to the
+rule so a seventh site cannot be added quietly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+PRE_COMMIT = ROOT / ".githooks" / "pre-commit"
+
+# One representative of each class git quotes unconditionally, plus the non-ASCII
+# case #2137 already fixed (it must not regress).
+HOSTILE_BASENAMES = ['has"quote', "has\\backslash", "has\ttab", "café"]
+
+
+def _load_git_paths() -> ModuleType:
+    """Import ``scripts/git_paths.py`` by path.
+
+    Imported lazily inside the tests that need it: at module scope a missing
+    module would abort collection for the whole file, hiding the behavioural
+    rows that are the actual reproduction.
+    """
+    spec = importlib.util.spec_from_file_location("git_paths", SCRIPTS / "git_paths.py")
+    assert spec and spec.loader, "scripts/git_paths.py is missing"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _repo(tmp_path: Path) -> Path:
+    """A scratch repo with one base commit, isolated from ambient git config.
+
+    ``HOME`` is redirected so a developer's own ``~/.gitconfig`` cannot change
+    what git emits and turn a real failure into a false pass.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # `git init -b` needs git >= 2.28; this must work on older git too.
+    _git("init", cwd=repo)
+    _git("config", "user.email", "test@example.invalid", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    _git("config", "commit.gpgsign", "false", cwd=repo)
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git("add", "README.md", cwd=repo)
+    _git("commit", "-m", "base", cwd=repo)
+    return repo
+
+
+def _commit_file(repo: Path, relpath: str, body: str) -> None:
+    target = repo / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    _git("add", "--", relpath, cwd=repo)
+    _git("commit", "-m", "add", cwd=repo)
+
+
+# --------------------------------------------------------------------------
+# Transport 1: the `+++ b/<path>` header of a unified diff.
+# --------------------------------------------------------------------------
+
+NARRATION = "# ADR-99 Phase 3: narration\nx = 1\n"
+
+
+@pytest.mark.parametrize("basename", [*HOSTILE_BASENAMES, "plain"])
+def test_the_narration_gate_sees_a_quoted_path(tmp_path: Path, basename: str) -> None:
+    """A narration comment is caught whatever bytes its path carries.
+
+    ``plain`` is the control: it was already caught before the fix, so a hostile
+    row going green cannot be explained by the probe's shape.
+    """
+    repo = _repo(tmp_path)
+    _commit_file(repo, f"scripts/{basename}.py", NARRATION)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS / "check_comment_narration.py"), "--diff", "HEAD~1"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, (
+        f"scripts/{basename}.py: ADR-phase narration passed the gate (rc={result.returncode}); stderr={result.stderr!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Transport 2: a --name-only changed-file list.
+# --------------------------------------------------------------------------
+
+
+def _compute_command() -> str:
+    """The coverage-pairing job's own command, read from the YAML not retyped."""
+    matches = [
+        line.strip()
+        for line in WORKFLOW.read_text(encoding="utf-8").splitlines()
+        if "diff --name-only" in line and "changed.txt" in line
+    ]
+    assert len(matches) == 1, f"expected exactly one changed-file computation, got {matches}"
+    return matches[0]
+
+
+@pytest.mark.parametrize("basename", [*HOSTILE_BASENAMES, "plain"])
+def test_an_unpaired_src_change_fails_the_coverage_gate(tmp_path: Path, basename: str) -> None:
+    """A src/ change with no test fails the gate whatever bytes its path carries."""
+    repo = _repo(tmp_path)
+    base_sha = _git("rev-parse", "HEAD", cwd=repo).strip()
+    _git("update-ref", "refs/remotes/origin/devel", base_sha, cwd=repo)
+    _commit_file(repo, f"src/usr/local/pkg/pfblockerng/{basename}.inc", "x\n")
+
+    subprocess.run(
+        ["sh", "-euc", _compute_command()],
+        cwd=repo,
+        check=True,
+        env={"PATH": "/usr/bin:/bin", "BASE": "devel", "HOME": str(repo)},
+        capture_output=True,
+    )
+    changed = (repo / "changed.txt").read_bytes()
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS / "check_coverage_pairing.py")],
+        input=changed,
+        capture_output=True,
+    )
+    assert result.returncode == 1, (
+        f"src/.../{basename}.inc: unpaired src change passed the coverage-pairing gate "
+        f"(rc={result.returncode}); stdout={result.stdout!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# The shared unquoting.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("quoted", "expected"),
+    [
+        ('"src/has\\"quote.inc"', 'src/has"quote.inc'),
+        ('"src/has\\\\backslash.inc"', "src/has\\backslash.inc"),
+        ('"src/has\\ttab.inc"', "src/has\ttab.inc"),
+        ('"src/has\\nnewline.inc"', "src/has\nnewline.inc"),
+        ('"src/caf\\303\\251.inc"', "src/café.inc"),
+        # An unquoted path is returned untouched — backslashes in it are literal,
+        # because git only escapes inside a quoted form.
+        ("src/plain.inc", "src/plain.inc"),
+        ("src/has\\backslash.inc", "src/has\\backslash.inc"),
+    ],
+)
+def test_unquote_reverses_gits_c_quoting(quoted: str, expected: str) -> None:
+    assert _load_git_paths().unquote(quoted) == expected
+
+
+def test_name_only_z_returns_raw_paths(tmp_path: Path) -> None:
+    """The NUL transport hands back the path itself, with no quoting to undo."""
+    repo = _repo(tmp_path)
+    base_sha = _git("rev-parse", "HEAD", cwd=repo).strip()
+    for basename in HOSTILE_BASENAMES:
+        _commit_file(repo, f"src/{basename}.inc", "x\n")
+
+    paths = _load_git_paths().changed_paths(f"{base_sha}...HEAD", cwd=repo)
+    assert sorted(paths) == sorted(f"src/{b}.inc" for b in HOSTILE_BASENAMES)
+    assert not any(p.startswith('"') for p in paths), f"a path came back quoted: {paths}"
+
+
+# --------------------------------------------------------------------------
+# The rule, held over the whole consumer list.
+# --------------------------------------------------------------------------
+
+
+def test_every_name_only_consumer_uses_the_nul_transport() -> None:
+    """A changed-file list is read NUL-separated, everywhere, with no exceptions.
+
+    Pins the class rather than the four sites known today: a new consumer that
+    reads a newline-separated list fails here instead of silently re-opening the
+    hole.
+    """
+    offenders: list[str] = []
+    for path in [WORKFLOW, PRE_COMMIT, SCRIPTS / "check_context_budget.py"]:
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if "--name-only" not in line or line.lstrip().startswith("#"):
+                continue
+            if "-z" not in line.split("--name-only")[0] and "-z" not in line.split("--name-only")[1]:
+                offenders.append(f"{path.relative_to(ROOT)}:{number}: {line.strip()}")
+    assert not offenders, "changed-file lists read without -z:\n  " + "\n  ".join(offenders)
+
+
+def test_every_unified_diff_parser_unquotes_its_header_path() -> None:
+    """The three `+++ b/` parsers all route the header path through the helper."""
+    missing = [
+        name
+        for name in (
+            "check_comment_narration.py",
+            "check_retired_tokens.py",
+            "check_version_literals.py",
+        )
+        if "diff_header_name" not in (SCRIPTS / name).read_text(encoding="utf-8")
+    ]
+    assert not missing, f"unified-diff parsers not unquoting their header path: {missing}"

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -335,6 +335,43 @@ def test_run_gates_refuses_a_hostile_path_instead_of_skipping_it(tmp_path: Path)
     )
 
 
+def test_run_gates_fails_closed_when_git_itself_fails(tmp_path: Path) -> None:
+    """A git failure aborts the run; it never reports GATES: PASS on no files.
+
+    The changed-file lists pipe git into ``tr``, and a shell pipeline reports
+    TR's status — which is 0 on empty input — so a naive ``|| exit 2`` would
+    check the wrong command and let a broken repository look clean. dash has no
+    ``pipefail`` to lean on, so git's own status has to be taken separately.
+
+    A corrupted index is the cheap reproduction: ``git diff --cached`` and
+    ``git ls-files`` both need it and fail, while ``git diff <base>...HEAD``
+    does not, so the run still has a plausible-looking file list to proceed on.
+    """
+    repo = _repo(tmp_path)
+    _git("branch", "devel", cwd=repo)
+    (repo / "extra.txt").write_text("y\n", encoding="utf-8")
+    _git("add", "extra.txt", cwd=repo)
+    (repo / ".git" / "index").write_bytes(b"garbage")
+
+    result = subprocess.run(
+        [
+            "sh",
+            str(ROOT / "scripts" / "agent" / "run-gates.sh"),
+            "--worktree",
+            str(repo),
+            "--diff",
+            "devel",
+            "--allow-missing",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, (
+        f"a corrupted index produced a clean run (rc={result.returncode}); stdout={result.stdout!r}"
+    )
+    assert "GATES: PASS" not in result.stdout, f"a corrupted index reported success: {result.stdout!r}"
+
+
 def test_every_unified_diff_parser_unquotes_its_header_path() -> None:
     """Anything parsing a `+++ b/` header routes it through the helper.
 


### PR DESCRIPTION
Fixes #2212.

## The defect

`core.quotePath=false` switches off only the high-bit half of git's quoting — the part #2137 fixed. A literal `"`, `\`, tab or newline in a path is C-escaped unconditionally, and no configuration suppresses it:

```console
$ git -c core.quotePath=false diff --no-index --name-only a b | cat -A
"b/src/has\ttab.inc"$
"b/src/has\"quote.inc"$
"b/src/has\\backslash.inc"$
```

Every gate in the repo classifies a path by prefix (`startswith("src/")`) or suffix (`\.(php|inc)$`). A quoted path begins with `"` and ends `.inc"` rather than `.inc`, so it matches nothing: the change ships un-gated and the job reports a clean pass rather than a skip.

## Two transports, two answers

**A `--name-only` list → `-z`.** Raw NUL-separated output, nothing to unquote, and the only form that can carry a path containing a newline at all. Applied to the coverage-pairing workflow step, `check_context_budget.py`'s two calls (plus its `ls-files`), and `.githooks/pre-commit`.

**A unified diff's `+++ b/<path>` header → unquote on read.** `-z` has no effect on diff headers and no option suppresses their quoting, and `check_comment_narration.py`, `check_retired_tokens.py` and `check_version_literals.py` must parse the header anyway to attribute a hunk to its file. Worth noting the exact trap: git quotes the token *including* its `b/` prefix, so `name.startswith("b/")` tested before unquoting sees no match and drops the file silently — unquoting first is what keeps the attribution.

`scripts/git_paths.py` (new) holds the three shared pieces so the six sites cannot drift apart: `unquote`, `changed_paths`, `split_nul_or_lines`.

`check_coverage_pairing.py` accepts either separator on stdin, switching on the presence of a NUL. The two cannot be mixed by construction: a NUL means the producer used `-z`, and newlines are then data rather than separators.

## Known residual, deliberately not hidden

`.githooks/pre-commit` pipes `-z` output through `tr '\0' '\n'`, because POSIX sh has no clean NUL-aware read. A path containing a **newline** therefore still splits there. That is recorded in the hook's own comment rather than left for the next reader to discover, and it is bounded: CI's Ruff/PHPCS/PHPStan jobs run unconditionally, so a skipped local hook cannot let anything ship unchecked. Every other class — quote, backslash, tab, non-ASCII — is fixed in the hook.

## Test evidence

`tests/test_issue2212_hostile_path_gates.py` (new, 20 cases) pins one gate per transport, unit-tests the unquoting against every hostile class, and holds the whole consumer list to the rule so a seventh site cannot be added quietly.

Test-first, executed, frozen `sha256 11c2b9dc…` across the pair:

- **RED**, before any production edit: `16 failed, 4 passed`. Both gates let `has"quote`, `has\backslash` and `has\ttab` through — e.g. `scripts/has"quote.py: ADR-phase narration passed the gate (rc=0)` and `src/.../has\ttab.inc: unpaired src change passed the coverage-pairing gate (rc=0)`.
- **GREEN**, same hash, after the fix: `19 passed, 1 failed` — the one failure being a mis-specified assertion in the static row, which asserted on the token `unquote` while the parsers route through `diff_header_name`.
- That assertion was corrected to the real contract and re-verified non-vacuous against the pre-fix tree: `git show origin/devel:scripts/<checker>.py | grep -c diff_header_name` returns `0` for all three. Full run then `20 passed`. `ruff format` and a mypy return annotation moved the file again afterwards (final `sha256 1699ad62…`), with the suite re-run after each.

The **four passing rows in the RED run are the controls**: `plain` and `café` already reached both gates, so the failures isolate exactly the classes `core.quotePath=false` never covered, and a hostile row going green cannot be explained by the probe's shape.

Gates: `ruff check`, `ruff format --check` (524 files), `mypy tests/` (316 files) clean; the pre-commit chain passed — notably running the *edited* hook, so the `-z | tr` rewrite is exercised for real rather than only in a scratch repo.

Existing suites for every touched checker: `25 failed, 221 passed` on the branch against `25 failed, 201 passed` for the same files on `origin/devel` — the identical 25, all `git init -b` sandbox artifacts (git here is 2.25).

Full suite: **506 failures on the branch and 506 on `origin/devel`**, sets diffed from `--junitxml` rather than scraped from console output — **zero new, zero fixed**, with 4358 passing against 4338.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of staged, changed, and untracked files containing spaces, quotes, tabs, backslashes, and non-ASCII characters.
  * Prevented validation checks from skipping or misclassifying specially named files.
  * Improved parsing of renamed, deleted, and quoted file paths.
  * Added safer handling for Git path-list and diff information, including clearer failure behavior when file collection fails.

* **Tests**
  * Added broad regression coverage for special-character and hostile file paths across validation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->