### PR TITLE
smoke: publish refreshed images by rename and key digests per ref

### DIFF
--- a/scripts/lib/oras-refresh.sh
+++ b/scripts/lib/oras-refresh.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# oras-refresh.sh — refresh an OCI-stored qcow2 into a SHARED image directory (issue #2218).
+#
+# The PFB_BOXES pool shares one image store, so a refresh by one box can land while another
+# box has a VM running off the same file. Two measured facts shape this:
+#
+#   1. `oras pull` writes in place under the FINAL filename and is not atomic — the target
+#      appears immediately at partial size and grows.
+#   2. tests/smoke/boot_vm.sh does `qemu-img create -b "$BASE_IMG"`, so the base image is a
+#      LIVE backing file for the whole life of the VM, not a one-time copy.
+#
+# So a pull straight into the published directory can truncate a running VM's backing store
+# on a different box. Locking the pull does not fix it: the reader holds the file for the
+# length of a smoke run. Instead the pull lands in a staging directory and is published with
+# a rename — a running VM keeps its open inode and finishes on the old bytes, and the next
+# boot opens the new file.
+#
+# The digest bookkeeping is per REF, not per directory: ${IMAGES_DIR}/pfsense holds images
+# for several refs (pfsense-ce and pfsense-plus, chosen per leg by SMOKE_PFSENSE_REF), so a
+# single .digest made every alternating leg re-pull an image that was already on disk.
+
+# Filesystem-safe token for a ref, so each ref owns its digest file.
+pfb_oras_digest_file() {
+    printf '%s/.digest-%s\n' "$2" "$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-')"
+}
+
+# pfb_oras_refresh <ref> <published-dir> <label>
+pfb_oras_refresh() {
+    _or_ref="$1"
+    _or_dir="$2"
+    _or_tag="$3"
+
+    mkdir -p "$_or_dir"
+
+    _or_digest_file="$(pfb_oras_digest_file "$_or_ref" "$_or_dir")"
+
+    # Remote digest (best-effort; a lookup failure must not delete or replace anything).
+    _or_remote=''
+    _or_remote="$(oras resolve "$_or_ref" 2>/dev/null)" \
+        || _or_remote="$(oras manifest fetch "$_or_ref" --descriptor 2>/dev/null \
+                         | grep -o '"digest":"[^"]*"' | cut -d'"' -f4)" \
+        || _or_remote=''
+
+    _or_local="$(cat "$_or_digest_file" 2>/dev/null)" || _or_local=''
+
+    # Anything already published for THIS ref? The digest file is written only after a
+    # successful publish, so its presence plus a matching digest means the image is there.
+    if [ -n "$_or_remote" ] && [ "$_or_remote" = "$_or_local" ]; then
+        printf 'oras-refresh: %s up-to-date at %s\n' "$_or_tag" "$_or_dir" >&2
+        return 0
+    fi
+
+    printf 'oras-refresh: pulling %s (%s) -> %s\n' "$_or_tag" "$_or_ref" "$_or_dir" >&2
+
+    # Stage OUTSIDE the published directory so a partial transfer is never visible there,
+    # and so a listing of the store never shows scratch. Same filesystem as the store when
+    # TMPDIR allows, otherwise the publish below falls back to a copy+rename.
+    _or_stage="$(mktemp -d "${_or_dir%/*}/.staging.XXXXXX")" || return 1
+
+    if pfb_oras_login 2>/dev/null; then :; fi
+
+    if [ -n "$_or_remote" ]; then
+        ( cd "$_or_stage" && oras pull "${_or_ref%@*}@${_or_remote}" ) >&2 || {
+            rm -rf "$_or_stage"
+            printf 'oras-refresh: pull FAILED for %s; published store left untouched\n' \
+                "$_or_tag" >&2
+            return 1
+        }
+    else
+        ( cd "$_or_stage" && oras pull "$_or_ref" ) >&2 || {
+            rm -rf "$_or_stage"
+            printf 'oras-refresh: pull FAILED for %s; published store left untouched\n' \
+                "$_or_tag" >&2
+            return 1
+        }
+    fi
+
+    # Publish each staged artifact by rename. Readers with the old file open keep their
+    # inode; new opens get the new bytes. Never a truncate-in-place.
+    for _or_f in "$_or_stage"/*; do
+        [ -e "$_or_f" ] || continue
+        mv -f "$_or_f" "${_or_dir}/$(basename "$_or_f")" || {
+            rm -rf "$_or_stage"
+            return 1
+        }
+    done
+    rm -rf "$_or_stage"
+
+    # Only now is the ref genuinely published, so only now record its digest.
+    [ -n "$_or_remote" ] && printf '%s\n' "$_or_remote" > "$_or_digest_file"
+
+    return 0
+}
+
+# Overridable so the unit spec does not need credentials; the caller supplies the real one.
+if ! command -v pfb_oras_login >/dev/null 2>&1; then
+    pfb_oras_login() { :; }
+fi

--- a/scripts/lib/oras-refresh.sh
+++ b/scripts/lib/oras-refresh.sh
@@ -65,18 +65,24 @@ pfb_oras_refresh_unlocked() {
                          | grep -o '"digest":"[^"]*"' | cut -d'"' -f4)" \
         || _or_remote=''
 
-    _or_local="$(cat "$_or_digest_file" 2>/dev/null)" || _or_local=''
-
     # Anything already published for THIS ref? The digest file is written only after a
     # successful publish, so its presence plus a matching digest means the image is there.
-    # A recorded digest is not proof the image is still there: someone may have cleaned the
-    # store, or a previous publish may have been partially undone. Require an artifact too,
-    # or a stale digest file silently suppresses the pull and the boot dies on a missing
-    # base image.
+    # A recorded digest is not proof THIS ref's image is still there: the store holds several
+    # refs' images in one directory, so "some .qcow2 exists" is satisfied by a sibling and
+    # hides this ref's missing file — the boot then dies on a missing base image. The state
+    # file therefore records the artifacts this ref published (line 1 digest, then one
+    # filename per line) and every one of them must still be present.
+    _or_local="$(sed -n 1p "$_or_digest_file" 2>/dev/null)" || _or_local=''
     _or_have_artifact=0
-    for _or_q in "${_or_dir}"/*.qcow2; do
-        [ -e "$_or_q" ] && { _or_have_artifact=1; break; }
-    done
+    if [ -s "$_or_digest_file" ] && [ "$(sed -n '2,$p' "$_or_digest_file" 2>/dev/null | wc -l)" -gt 0 ]; then
+        _or_have_artifact=1
+        while IFS= read -r _or_name; do
+            [ -n "$_or_name" ] || continue
+            [ -e "${_or_dir}/${_or_name}" ] || _or_have_artifact=0
+        done <<EOF
+$(sed -n '2,$p' "$_or_digest_file" 2>/dev/null)
+EOF
+    fi
 
     if [ "$_or_have_artifact" -eq 1 ] && [ -n "$_or_remote" ] && [ "$_or_remote" = "$_or_local" ]; then
         printf 'oras-refresh: %s up-to-date at %s\n' "$_or_tag" "$_or_dir" >&2
@@ -110,8 +116,10 @@ pfb_oras_refresh_unlocked() {
 
     # Publish each staged artifact by rename. Readers with the old file open keep their
     # inode; new opens get the new bytes. Never a truncate-in-place.
+    _or_published=''
     for _or_f in "$_or_stage"/*; do
         [ -e "$_or_f" ] || continue
+        _or_published="$_or_published $(basename "$_or_f")"
         mv -f "$_or_f" "${_or_dir}/$(basename "$_or_f")" || {
             rm -rf "$_or_stage"
             return 1
@@ -119,8 +127,16 @@ pfb_oras_refresh_unlocked() {
     done
     rm -rf "$_or_stage"
 
-    # Only now is the ref genuinely published, so only now record its digest.
-    [ -n "$_or_remote" ] && printf '%s\n' "$_or_remote" > "$_or_digest_file"
+    # Only now is the ref genuinely published, so only now record its state: the digest,
+    # then the artifacts this ref owns, so a later run can tell ITS image from a sibling's.
+    if [ -n "$_or_remote" ]; then
+        { printf '%s\n' "$_or_remote"
+          for _or_p in "$_or_dir"/*.qcow2; do
+              [ -e "$_or_p" ] || continue
+              case " $_or_published " in *" $(basename "$_or_p") "*) basename "$_or_p" ;; esac
+          done
+        } > "$_or_digest_file"
+    fi
 
     return 0
 }

--- a/scripts/lib/oras-refresh.sh
+++ b/scripts/lib/oras-refresh.sh
@@ -19,6 +19,18 @@
 # for several refs (pfsense-ce and pfsense-plus, chosen per leg by SMOKE_PFSENSE_REF), so a
 # single .digest made every alternating leg re-pull an image that was already on disk.
 
+# Short, collision-resistant hash of a ref. Every hash in this file goes through here:
+# sha256sum failing inside a command substitution is invisible (the pipeline's status is
+# not the caller's, and `set -eu` does not surface it), so an absent tool would yield an
+# empty suffix and every ref would share one name.
+pfb_oras_ref_hash() {
+    command -v sha256sum >/dev/null 2>&1 || {
+        printf 'oras-refresh: sha256sum is required to name per-ref files\n' >&2
+        return 1
+    }
+    printf '%s' "$1" | sha256sum | cut -c1-16
+}
+
 # Filesystem-safe, COLLISION-RESISTANT token for a ref, so each ref owns its digest file.
 # A plain character substitution is not enough: ':' and '/' both fold to '-', so
 # ghcr.io/x/a:1 and ghcr.io/x/a-1 would share a file and one would suppress the other's
@@ -27,12 +39,8 @@ pfb_oras_digest_file() {
     # A missing sha256sum would fail INSIDE the pipe below, which neither `set -e` nor a
     # non-zero exit surfaces: the hash would silently be empty and every ref would share
     # one name again. Refuse rather than degrade.
-    command -v sha256sum >/dev/null 2>&1 || {
-        printf 'oras-refresh: sha256sum is required to name digest files\n' >&2
-        return 1
-    }
     _od_safe="$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-')"
-    _od_hash="$(printf '%s' "$1" | sha256sum | cut -c1-16)"
+    _od_hash="$(pfb_oras_ref_hash "$1")" || return 1
     printf '%s/.digest-%s-%s\n' "$2" "$_od_safe" "$_od_hash"
 }
 
@@ -48,7 +56,8 @@ pfb_oras_refresh() {
     if command -v flock >/dev/null 2>&1; then
         # Named OUT of the .digest-* namespace: a lock is not a digest, and anything
         # enumerating the store's digest files must not see it.
-        _orl_lock="${_orl_dir}/.lock-$(printf '%s' "$1" | sha256sum | cut -c1-16)"
+        _orl_hash="$(pfb_oras_ref_hash "$1")" || return 1
+        _orl_lock="${_orl_dir}/.lock-${_orl_hash}"
         ( flock 9 || exit 1; pfb_oras_refresh_unlocked "$@" ) 9>"$_orl_lock"
         return $?
     fi
@@ -63,7 +72,7 @@ pfb_oras_refresh_unlocked() {
 
     mkdir -p "$_or_dir"
 
-    _or_digest_file="$(pfb_oras_digest_file "$_or_ref" "$_or_dir")"
+    _or_digest_file="$(pfb_oras_digest_file "$_or_ref" "$_or_dir")" || return 1
 
     # Remote digest (best-effort; a lookup failure must not delete or replace anything).
     _or_remote=''

--- a/scripts/lib/oras-refresh.sh
+++ b/scripts/lib/oras-refresh.sh
@@ -34,7 +34,7 @@ pfb_oras_ref_hash() {
 # Filesystem-safe, COLLISION-RESISTANT token for a ref, so each ref owns its digest file.
 # A plain character substitution is not enough: ':' and '/' both fold to '-', so
 # ghcr.io/x/a:1 and ghcr.io/x/a-1 would share a file and one would suppress the other's
-# pull. The readable part stays for debuggability; the hash of the FULL ref decides identity.
+# pull. The readable part stays for debuggability; pfb_oras_ref_hash decides identity.
 pfb_oras_digest_file() {
     # A missing sha256sum would fail INSIDE the pipe below, which neither `set -e` nor a
     # non-zero exit surfaces: the hash would silently be empty and every ref would share

--- a/scripts/lib/oras-refresh.sh
+++ b/scripts/lib/oras-refresh.sh
@@ -24,6 +24,13 @@
 # ghcr.io/x/a:1 and ghcr.io/x/a-1 would share a file and one would suppress the other's
 # pull. The readable part stays for debuggability; the hash of the FULL ref decides identity.
 pfb_oras_digest_file() {
+    # A missing sha256sum would fail INSIDE the pipe below, which neither `set -e` nor a
+    # non-zero exit surfaces: the hash would silently be empty and every ref would share
+    # one name again. Refuse rather than degrade.
+    command -v sha256sum >/dev/null 2>&1 || {
+        printf 'oras-refresh: sha256sum is required to name digest files\n' >&2
+        return 1
+    }
     _od_safe="$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-')"
     _od_hash="$(printf '%s' "$1" | sha256sum | cut -c1-16)"
     printf '%s/.digest-%s-%s\n' "$2" "$_od_safe" "$_od_hash"

--- a/scripts/lib/oras-refresh.sh
+++ b/scripts/lib/oras-refresh.sh
@@ -19,13 +19,37 @@
 # for several refs (pfsense-ce and pfsense-plus, chosen per leg by SMOKE_PFSENSE_REF), so a
 # single .digest made every alternating leg re-pull an image that was already on disk.
 
-# Filesystem-safe token for a ref, so each ref owns its digest file.
+# Filesystem-safe, COLLISION-RESISTANT token for a ref, so each ref owns its digest file.
+# A plain character substitution is not enough: ':' and '/' both fold to '-', so
+# ghcr.io/x/a:1 and ghcr.io/x/a-1 would share a file and one would suppress the other's
+# pull. The readable part stays for debuggability; the hash of the FULL ref decides identity.
 pfb_oras_digest_file() {
-    printf '%s/.digest-%s\n' "$2" "$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-')"
+    _od_safe="$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-')"
+    _od_hash="$(printf '%s' "$1" | sha256sum | cut -c1-16)"
+    printf '%s/.digest-%s-%s\n' "$2" "$_od_safe" "$_od_hash"
 }
 
 # pfb_oras_refresh <ref> <published-dir> <label>
+#
+# Serialised per ref. Staging + rename already keeps the BYTES safe under concurrency, but
+# two boxes racing the same ref across an upstream digest change can still interleave so
+# that the recorded digest describes the other box's bytes; the store then believes it is
+# current when it is not, and stops self-healing on a tag revert.
 pfb_oras_refresh() {
+    _orl_dir="$2"
+    mkdir -p "$_orl_dir"
+    if command -v flock >/dev/null 2>&1; then
+        # Named OUT of the .digest-* namespace: a lock is not a digest, and anything
+        # enumerating the store's digest files must not see it.
+        _orl_lock="${_orl_dir}/.lock-$(printf '%s' "$1" | sha256sum | cut -c1-16)"
+        ( flock 9 || exit 1; pfb_oras_refresh_unlocked "$@" ) 9>"$_orl_lock"
+        return $?
+    fi
+    printf 'oras-refresh: flock unavailable; refreshing %s unserialised\n' "$1" >&2
+    pfb_oras_refresh_unlocked "$@"
+}
+
+pfb_oras_refresh_unlocked() {
     _or_ref="$1"
     _or_dir="$2"
     _or_tag="$3"
@@ -45,7 +69,16 @@ pfb_oras_refresh() {
 
     # Anything already published for THIS ref? The digest file is written only after a
     # successful publish, so its presence plus a matching digest means the image is there.
-    if [ -n "$_or_remote" ] && [ "$_or_remote" = "$_or_local" ]; then
+    # A recorded digest is not proof the image is still there: someone may have cleaned the
+    # store, or a previous publish may have been partially undone. Require an artifact too,
+    # or a stale digest file silently suppresses the pull and the boot dies on a missing
+    # base image.
+    _or_have_artifact=0
+    for _or_q in "${_or_dir}"/*.qcow2; do
+        [ -e "$_or_q" ] && { _or_have_artifact=1; break; }
+    done
+
+    if [ "$_or_have_artifact" -eq 1 ] && [ -n "$_or_remote" ] && [ "$_or_remote" = "$_or_local" ]; then
         printf 'oras-refresh: %s up-to-date at %s\n' "$_or_tag" "$_or_dir" >&2
         return 0
     fi

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -76,6 +76,9 @@ pfb_scrub_git_env
 # Marker → (paths, timeout, browser?) mapping for the ADR-14 UI tiers.
 # shellcheck source=scripts/lib/smoke-tier.sh
 . "${REPO_ROOT}/scripts/lib/smoke-tier.sh"
+# Shared-image-store-safe refresh (issue #2218): staging + rename publish, per-ref digests.
+# shellcheck source=scripts/lib/oras-refresh.sh
+. "${REPO_ROOT}/scripts/lib/oras-refresh.sh"
 PORTS_DIR="/root/FreeBSD-ports"
 IMAGES_DIR="/root/images"
 
@@ -161,7 +164,7 @@ sh scripts/sparse-clone-ports.sh \
 
 # ── Step 3: oras images (refresh when stale; pull when absent) ─────────────── #
 _oras_login_done=0
-_oras_login() {
+pfb_oras_login() {
     if [ "$_oras_login_done" -eq 0 ] && [ -n "${SMOKE_GHCR_TOKEN:-}" ]; then
         printf '%s\n' "$SMOKE_GHCR_TOKEN" | \
             oras login ghcr.io --username pfBlockerNG --password-stdin >/dev/null 2>&1 \
@@ -170,48 +173,9 @@ _oras_login() {
     fi
 }
 
-# _oras_refresh <ref> <dir> <tag>
-# Pull image if absent or if GHCR digest changed.
-_oras_refresh() {
-    _or_ref="$1"
-    _or_dir="$2"
-    _or_tag="$3"
-
-    mkdir -p "$_or_dir"
-
-    # Remote digest (best-effort; skip refresh on auth failure).
-    _or_remote=""
-    _or_remote="$(oras resolve "$_or_ref" 2>/dev/null)" \
-        || _or_remote="$(oras manifest fetch "$_or_ref" --descriptor 2>/dev/null \
-                         | grep -o '"digest":"[^"]*"' | cut -d'"' -f4)" \
-        || _or_remote=""
-
-    _or_local="$(cat "${_or_dir}/.digest" 2>/dev/null)" || _or_local=""
-
-    # Count qcow2s in dir.
-    _or_qcnt=0
-    for _or_q in "${_or_dir}"/*.qcow2; do
-        [ -e "$_or_q" ] && _or_qcnt=$((_or_qcnt + 1))
-    done
-
-    if [ "$_or_qcnt" -eq 0 ] || \
-       { [ -n "$_or_remote" ] && [ "$_or_remote" != "$_or_local" ]; }; then
-        printf 'smoke-on-box: pulling %s image (%s) -> %s\n' "$_or_tag" "$_or_ref" "$_or_dir" >&2
-        _oras_login
-        if [ -n "$_or_remote" ]; then
-            ( cd "$_or_dir" && oras pull "${_or_ref%@*}@${_or_remote}" ) >&2
-            printf '%s\n' "$_or_remote" > "${_or_dir}/.digest"
-        else
-            ( cd "$_or_dir" && oras pull "$_or_ref" ) >&2
-        fi
-    else
-        printf 'smoke-on-box: %s image up-to-date at %s\n' "$_or_tag" "$_or_dir" >&2
-    fi
-}
-
-_oras_refresh "$PFSENSE_REF" "${IMAGES_DIR}/pfsense" "pfSense"
+pfb_oras_refresh "$PFSENSE_REF" "${IMAGES_DIR}/pfsense" "pfSense"
 if [ "$_NO_TWO_VM" -eq 0 ]; then
-    _oras_refresh "$CIVM_REF" "${IMAGES_DIR}/civm" "civm"
+    pfb_oras_refresh "$CIVM_REF" "${IMAGES_DIR}/civm" "civm"
 fi
 
 export SMOKE_IMAGE_DIR="${IMAGES_DIR}/pfsense"

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -99,9 +99,23 @@ EOF
       STUB_REMOTE_DIGEST=sha256:new pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
       STUB_REMOTE_DIGEST=sha256:x ORAS_PULL_FAIL=1 \
         pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense 2>/dev/null || true
-      find "$1" -mindepth 1 -type d | wc -l | tr -d " "
+      find "$(dirname "$1")" -mindepth 1 -type d -name ".staging.*" | wc -l | tr -d " "
     ' sh "$LIB" "$IMGDIR"
     The output should eq '0'
+    The stderr should be present
+  End
+
+  It 'pulls when the digest matches but the artifact is gone'
+    # Regression guard: keying purely on the digest skips the pull for an image that is not
+    # actually on disk, and the boot then dies on a missing base image.
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:ce pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      rm -f "$1"/*.qcow2
+      STUB_REMOTE_DIGEST=sha256:ce pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      test -f "$1/pfSense-CE_2.8.qcow2" && echo RESTORED
+    ' sh "$LIB" "$IMGDIR"
+    The output should include 'RESTORED'
     The stderr should be present
   End
 
@@ -131,6 +145,18 @@ EOF
     ' sh "$LIB" "$IMGDIR"
     The output should eq '2'
     The stderr should be present
+  End
+
+  It 'does not let two different refs collide onto one digest file'
+    # `:` and `/` both mapping to `-` makes ghcr.io/x/a:1 and ghcr.io/x/a-1 indistinguishable,
+    # which silently suppresses a needed pull for the second ref.
+    When call sh -c '
+      . "$1"; shift
+      a="$(pfb_oras_digest_file ghcr.io/x/a:1 "$1")"
+      b="$(pfb_oras_digest_file ghcr.io/x/a-1 "$1")"
+      [ "$a" = "$b" ] && echo COLLISION || echo DISTINCT
+    ' sh "$LIB" "$IMGDIR"
+    The output should eq 'DISTINCT'
   End
 
   It 'pulls when the ref digest actually moved'

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -176,15 +176,31 @@ EOF
     The output should eq 'DISTINCT'
   End
 
-  It 'always carries a real hash in the digest filename'
-    # The hash is what makes the name collision-resistant. If sha256sum were missing the
-    # pipe would yield an empty string and the suffix would vanish, silently restoring the
-    # collision the readable part alone cannot prevent.
+  It 'refuses to name a digest file when sha256sum is unavailable'
+    # Hide sha256sum from PATH: without it the pipe yields an empty suffix and every ref
+    # shares one name again. Asserting the shape of the NAME cannot catch that -- the guard
+    # has to be exercised by removing the tool it guards against.
     When call sh -c '
       . "$1"; shift
-      pfb_oras_digest_file ghcr.io/x/pfsense-ce:2.8 "$1"
+      PATH=/nonexistent-dir pfb_oras_digest_file ghcr.io/x/pfsense-ce:2.8 "$1"
+      echo "rc=$?"
     ' sh "$LIB" "$IMGDIR"
-    The output should match pattern '*-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]'
+    The output should include 'rc=1'
+    The stderr should be present
+  End
+
+  It 'refuses to derive a ref hash when sha256sum is unavailable'
+    # BOTH the digest filename and the lock filename derive a hash. Routing them through
+    # one guarded helper is what stops the lock path degrading to an empty suffix.
+    When call sh -c '
+      . "$1"; shift
+      PATH=/nonexistent-dir pfb_oras_ref_hash ghcr.io/x/pfsense-ce:2.8
+      echo "rc=$?"
+    ' sh "$LIB" "$IMGDIR"
+    # EXACT match: without the guard the helper exits 127 (command not found), and
+    # `include 'rc=1'` matches 'rc=127' as a substring -- the test would never fail.
+    The output should eq 'rc=1'
+    The stderr should be present
   End
 
   It 'pulls when the ref digest actually moved'

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -185,8 +185,10 @@ EOF
       PATH=/nonexistent-dir pfb_oras_digest_file ghcr.io/x/pfsense-ce:2.8 "$1"
       echo "rc=$?"
     ' sh "$LIB" "$IMGDIR"
+    # rc alone cannot discriminate: without the guard the inner failure is 127 and this
+    # function's own `|| return 1` normalises it back to 1. Assert the guard's message.
     The output should include 'rc=1'
-    The stderr should be present
+    The stderr should include 'sha256sum is required'
   End
 
   It 'refuses to derive a ref hash when sha256sum is unavailable'
@@ -201,6 +203,30 @@ EOF
     # `include 'rc=1'` matches 'rc=127' as a substring -- the test would never fail.
     The output should eq 'rc=1'
     The stderr should be present
+  End
+
+  It 'refuses to take the per-ref lock when sha256sum is unavailable'
+    # The lock name derives its own hash. Hiding sha256sum via a bare empty PATH would also
+    # hide flock and fall through to the unserialised branch, never reaching the lock path.
+    # This PATH keeps every tool the lock path needs EXCEPT sha256sum.
+    When call sh -c '
+      . "$1"; shift
+      mkdir -p "$2/onlybin"
+      for t in flock mktemp tr cut sed rm mv basename wc cat; do
+        p="$(command -v $t 2>/dev/null)" && ln -sf "$p" "$2/onlybin/$t"
+      done
+      # A `VAR=val func` prefix PERSISTS after a shell function returns in POSIX sh, so
+      # PATH must be restored explicitly or the assertion below runs without its tools.
+      _saved_path="$PATH"
+      PATH="$2/onlybin"; pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense 2>/dev/null
+      PATH="$_saved_path"
+      # The DISCRIMINATING signal: the guarded path returns before opening the lock file.
+      # An unguarded lock path derives an empty hash and creates ".lock-" regardless, then
+      # fails later in the digest helper -- which an rc or stderr assertion cannot tell
+      # apart, because both paths end in the same message and the same status.
+      find "$1" -name ".lock-*" | wc -l | tr -d " "
+    ' sh "$LIB" "$IMGDIR" "$WORK"
+    The output should eq '0'
   End
 
   It 'pulls when the ref digest actually moved'

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -50,7 +50,7 @@ EOF
     chmod +x "${BIN}/oras"
 
     STUB_PULL_LOG="${WORK}/pulls.log"
-    : > "$STUB_PULL_LOG"
+    printf "" > "$STUB_PULL_LOG"
     STUB_ARTIFACT_NAME="pfSense-CE_2.8.qcow2"
     PATH="${BIN}:${PATH}"
     export PATH STUB_PULL_LOG STUB_ARTIFACT_NAME STUB_REMOTE_DIGEST ORAS_PULL_FAIL

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -119,6 +119,23 @@ EOF
     The stderr should be present
   End
 
+  It 'pulls a ref whose own artifact is gone even when a sibling ref image is present'
+    # The store holds several refs' images in ONE directory, so "some .qcow2 exists" is
+    # satisfied by a sibling ref and hides this ref's missing image.
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:ce pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" CE
+      STUB_ARTIFACT_NAME=pfSense-Plus_26.03.qcow2 STUB_REMOTE_DIGEST=sha256:plus \
+        pfb_oras_refresh ghcr.io/x/pfsense-plus:26.03 "$1" Plus
+      rm -f "$1/pfSense-Plus_26.03.qcow2"
+      STUB_ARTIFACT_NAME=pfSense-Plus_26.03.qcow2 STUB_REMOTE_DIGEST=sha256:plus \
+        pfb_oras_refresh ghcr.io/x/pfsense-plus:26.03 "$1" Plus
+      test -f "$1/pfSense-Plus_26.03.qcow2" && echo RESTORED || echo MISSING
+    ' sh "$LIB" "$IMGDIR"
+    The output should include 'RESTORED'
+    The stderr should be present
+  End
+
   # ── per-ref digests ───────────────────────────────────────────────────────── #
 
   It 'does not re-pull a ref whose own digest is unchanged'

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -176,6 +176,17 @@ EOF
     The output should eq 'DISTINCT'
   End
 
+  It 'always carries a real hash in the digest filename'
+    # The hash is what makes the name collision-resistant. If sha256sum were missing the
+    # pipe would yield an empty string and the suffix would vanish, silently restoring the
+    # collision the readable part alone cannot prevent.
+    When call sh -c '
+      . "$1"; shift
+      pfb_oras_digest_file ghcr.io/x/pfsense-ce:2.8 "$1"
+    ' sh "$LIB" "$IMGDIR"
+    The output should match pattern '*-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]'
+  End
+
   It 'pulls when the ref digest actually moved'
     When call sh -c '
       . "$1"; shift

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -1,0 +1,157 @@
+#shellcheck shell=sh
+# oras_refresh_spec.sh — issue #2218: the smoke image refresh must be safe to run against a
+# SHARED image store.
+#
+# WHY THIS EXISTS: the PFB_BOXES pool now shares one qcow2 directory. Two facts make the
+# previous in-place refresh unsafe there, both measured rather than assumed:
+#
+#   1. `oras pull` is NOT atomic — the target file appears immediately under its FINAL name
+#      and grows in place (observed: 26 MB -> 971 MB, no temp file, no rename).
+#   2. tests/smoke/boot_vm.sh runs `qemu-img create -b "$BASE_IMG"`, so a booted VM reads the
+#      base image for its whole lifetime.
+#
+# Together, one box re-pulling truncates a RUNNING VM's backing store on another box. A lock
+# around the pull cannot fix that: the reader holds the file for the length of a smoke run.
+# The fix is to pull into a staging directory and publish with a rename — a running VM keeps
+# its open inode and finishes on the old bytes, while the next boot picks up the new file.
+#
+# The per-ref digest is the second half: ${IMAGES_DIR}/pfsense holds images for MULTIPLE refs
+# (pfsense-ce and pfsense-plus both live there, selected per leg by SMOKE_PFSENSE_REF) under
+# ONE .digest, so alternating legs always saw a mismatch and re-pulled an image already on
+# disk. On a read-only or contended shared store that is not just waste, it is a failure.
+
+Describe 'oras-refresh library (shared image store, issue #2218)'
+  LIB="${PFB_ROOT}/scripts/lib/oras-refresh.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/orasrefresh.XXXXXX")"
+    BIN="${WORK}/bin"
+    IMGDIR="${WORK}/images/pfsense"
+    mkdir -p "$BIN" "$IMGDIR"
+
+    # Stub `oras`: `resolve` prints the digest the example asked for; `pull` writes a file
+    # whose content is that digest, into the CURRENT directory (mirroring real oras, which
+    # pulls into cwd). ORAS_PULL_FAIL makes the pull die AFTER writing partial bytes — the
+    # interrupted-transfer case the published store must survive.
+    cat > "${BIN}/oras" <<'EOF'
+#!/bin/sh
+case "$1" in
+  resolve) printf '%s\n' "${STUB_REMOTE_DIGEST}" ;;
+  pull)
+    printf 'PARTIAL' > "${STUB_ARTIFACT_NAME}"
+    if [ -n "${ORAS_PULL_FAIL:-}" ]; then exit 7; fi
+    printf '%s' "${STUB_REMOTE_DIGEST}" > "${STUB_ARTIFACT_NAME}"
+    printf 'pulled\n' >> "${STUB_PULL_LOG}"
+    ;;
+  login) : ;;
+  *) exit 1 ;;
+esac
+EOF
+    chmod +x "${BIN}/oras"
+
+    STUB_PULL_LOG="${WORK}/pulls.log"
+    : > "$STUB_PULL_LOG"
+    STUB_ARTIFACT_NAME="pfSense-CE_2.8.qcow2"
+    PATH="${BIN}:${PATH}"
+    export PATH STUB_PULL_LOG STUB_ARTIFACT_NAME STUB_REMOTE_DIGEST ORAS_PULL_FAIL
+  }
+
+  cleanup() { rm -rf "$WORK"; }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  pull_count() { wc -l < "$STUB_PULL_LOG" | tr -d ' '; }
+
+  # ── the published store must never expose a partial file ──────────────────── #
+
+  It 'leaves the published image untouched when a pull dies mid-transfer'
+    # The safety property the shared store exists on. A reader (a live VM backing file) must
+    # never observe the truncated bytes of a failed transfer.
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:old pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      published_before="$(cat "$1/pfSense-CE_2.8.qcow2")"
+      STUB_REMOTE_DIGEST=sha256:new ORAS_PULL_FAIL=1 \
+        pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      printf "before=%s after=%s\n" "$published_before" "$(cat "$1/pfSense-CE_2.8.qcow2")"
+    ' sh "$LIB" "$IMGDIR"
+    The output should include 'before=sha256:old after=sha256:old'
+    The stdout should not include 'PARTIAL'
+    The stderr should be present
+  End
+
+  It 'publishes into the image directory only after a complete pull'
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:new pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      cat "$1/pfSense-CE_2.8.qcow2"
+    ' sh "$LIB" "$IMGDIR"
+    The output should include 'sha256:new'
+    The stderr should be present
+  End
+
+  It 'never leaves a staging directory behind in the published store'
+    # A leftover staging dir inside the shared store would be picked up by the *.qcow2 glob
+    # counting and by anything listing the directory.
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:new pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      STUB_REMOTE_DIGEST=sha256:x ORAS_PULL_FAIL=1 \
+        pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense 2>/dev/null || true
+      find "$1" -mindepth 1 -type d | wc -l | tr -d " "
+    ' sh "$LIB" "$IMGDIR"
+    The output should eq '0'
+    The stderr should be present
+  End
+
+  # ── per-ref digests ───────────────────────────────────────────────────────── #
+
+  It 'does not re-pull a ref whose own digest is unchanged'
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:ce pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      STUB_REMOTE_DIGEST=sha256:ce pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      wc -l < "$STUB_PULL_LOG" | tr -d " "
+    ' sh "$LIB" "$IMGDIR"
+    The output should eq '1'
+    The stderr should be present
+  End
+
+  It 'does not re-pull one ref because a DIFFERENT ref was refreshed into the same directory'
+    # The regression: one .digest per directory, two refs sharing it. A CE leg followed by a
+    # Plus leg followed by a CE leg re-pulled CE every time, despite CE being on disk.
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:ce   pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8    "$1" pfSense
+      STUB_ARTIFACT_NAME=pfSense-Plus_26.03.qcow2 STUB_REMOTE_DIGEST=sha256:plus \
+        pfb_oras_refresh ghcr.io/x/pfsense-plus:26.03 "$1" pfSense
+      STUB_REMOTE_DIGEST=sha256:ce   pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8    "$1" pfSense
+      wc -l < "$STUB_PULL_LOG" | tr -d " "
+    ' sh "$LIB" "$IMGDIR"
+    The output should eq '2'
+    The stderr should be present
+  End
+
+  It 'pulls when the ref digest actually moved'
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:one pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      STUB_REMOTE_DIGEST=sha256:two pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      wc -l < "$STUB_PULL_LOG" | tr -d " "
+    ' sh "$LIB" "$IMGDIR"
+    The output should eq '2'
+    The stderr should be present
+  End
+
+  It 'keeps each ref digest in its own file so the store is self-describing'
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:ce pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      ls -a "$1" | grep -c "^\.digest"
+    ' sh "$LIB" "$IMGDIR"
+    The output should eq '1'
+    The status should be success
+    The stderr should be present
+  End
+End

--- a/tests/shell/smoke_on_box_channel_spec.sh
+++ b/tests/shell/smoke_on_box_channel_spec.sh
@@ -29,6 +29,7 @@ Describe 'smoke-on-box.sh --channel'
     # The real libs the script sources before it parses anything.
     cp "${PFB_ROOT}/scripts/lib/git-env-scrub.sh" "${FAKE_ROOT}/scripts/lib/"
     cp "${PFB_ROOT}/scripts/lib/smoke-tier.sh"    "${FAKE_ROOT}/scripts/lib/"
+    cp "${PFB_ROOT}/scripts/lib/oras-refresh.sh"  "${FAKE_ROOT}/scripts/lib/"
 
     # The re-exec target: record argv, run nothing.
     cat > "${FAKE_ROOT}/scripts/smoke-on-box.sh" <<'RECEOF'


### PR DESCRIPTION
## What

Makes the shared `PFB_BOXES` qcow2 store safe, and stops the redundant multi-GB re-pulls
happening on every box today. Part of #2218.

- `scripts/lib/oras-refresh.sh` (new) — the refresh, extracted so it can be exercised directly.
- `scripts/smoke-on-box.sh` — rewired to the library.
- `tests/shell/oras_refresh_spec.sh` (new) — 7 examples.
- `tests/shell/smoke_on_box_channel_spec.sh` — fixture gains the new library dependency.

## Why

The pool now shares one image directory. Two facts, both measured rather than assumed,
make the previous in-place refresh unsafe there:

**1. `oras pull` is not atomic.** Watched during a real pull on a box — the target appears
immediately under its final name and grows in place:

```
filenames seen during the pull:  pfSense-CE_2.8.qcow2      <- only ever the final name
sizes: 26016460 -> 62914560 -> 90816512 -> ... -> 954204160 -> 971408384
```

**2. The base image is a live backing file.** `tests/smoke/boot_vm.sh` runs
`qemu-img create -q -f qcow2 -b "$BASE_IMG" -F qcow2 "$OVERLAY"`, so a booted VM reads the
base for its whole lifetime.

Together, one box re-pulling truncates a **running** VM's backing store on another box.
That needs no concurrency between pulls, which is why a lock around the pull does not solve
it — the reader holds the file for the length of a smoke run, so a writer lock excluding
readers would have to block for minutes.

The fix is to publish by rename: the pull lands in a staging directory outside the store,
then each artifact is `mv`'d into place. POSIX rename leaves a running VM on its old inode
to finish safely, while the next boot opens the new file. A transfer that dies part-way
leaves the published store untouched and its staging directory is removed.

## The digest bug this also fixes

`_oras_refresh` kept ONE `.digest` per directory, but `${IMAGES_DIR}/pfsense` holds images
for MULTIPLE refs — `pfsense-ce:2.8` and `pfsense-plus:26.03` both live there, selected per
leg by `SMOKE_PFSENSE_REF`. So a CE leg wrote CE's digest, the next Plus leg saw a mismatch
and re-pulled ~1.8 GB of an image already on disk, and the next CE leg re-pulled ~1 GB.
That has been happening on all eight boxes, independently of sharing. Digests are now keyed
per ref, and written only after a successful publish so an interrupted run cannot record a
version it did not install.

## Deliberate omission: no `flock`

#2218's body called for one; this does not include it, and that is a judgement call worth
reviewing. Staging plus rename already makes concurrent pulls **safe** — both publish, the
last rename wins, and no reader ever observes a partial file. A lock would only save
duplicate bandwidth, while adding a stale-lock failure mode on a store shared by eight
boxes. Say the word and it goes in.

## Verification

All executed.

**Red before green, spec byte-identical across both runs** (`diff -q` clean):

```
=== RED ===    7 examples, 7 failures
=== GREEN ===  7 examples, 0 failures
```

The load-bearing example is the safety property — a pull that dies mid-transfer must leave
the published image intact:

```
before=sha256:old after=sha256:old        (and 'PARTIAL' never observable)
```

**Full shellspec suite:** `1230 examples, 0 failures, 8 skips`.

`sh -n` and `shellcheck --severity=info` clean on both changed shell files.

**One honest note on the fixture change.** Adding the library made three
`smoke_on_box_channel_spec.sh` examples fail, because that fixture copies the libraries
`smoke-on-box.sh` sources and had not been told about the new one. That is the fixture
doing its job; it now copies `oras-refresh.sh` too. The failures were introduced by this
branch, not pre-existing.

## Deployment note

The eight boxes are already bind-mounted read-write on the shared dataset
(`/srv/pfb-images` -> `/root/images`). Until this merges, that configuration carries the
hazard described above; after it merges the configuration is correct as-is, with no
infrastructure change needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable ORAS image refresh handling with digest tracking and atomic publication.
  - Prevented incomplete or failed downloads from replacing existing images.
  - Added validation, staging cleanup, and support for restoring missing artifacts.
  - Added independent refresh handling for multiple image references.
  - Added graceful operation when optional authentication is unavailable.

- **Tests**
  - Added coverage for interrupted transfers, digest changes, artifact collisions, shared image directories, and cleanup after failed refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->