### PR TITLE
ci: run every workflow in the pinned runner images

### DIFF
--- a/.github/actions/read-version-matrix/action.yml
+++ b/.github/actions/read-version-matrix/action.yml
@@ -88,7 +88,7 @@ runs:
           VARIANT_ARG="--variant $VARIANT_INPUT"
         fi
         # shellcheck disable=SC2086
-        sh "${{ github.workspace }}/scripts/read-version-matrix.sh" \
+        sh "$GITHUB_WORKSPACE/scripts/read-version-matrix.sh" \
           --ref "$MATRIX_REF" \
           --file "$MATRIX_FILE" \
           $VARIANT_ARG \

--- a/.github/workflows/agent-roles.yml
+++ b/.github/workflows/agent-roles.yml
@@ -21,6 +21,7 @@ on:
       - '.agents/policy/**'
 
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -28,7 +29,7 @@ jobs:
     name: Agent roles (role registry vs vendor role definitions)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/agent-roles.yml
+++ b/.github/workflows/agent-roles.yml
@@ -33,7 +33,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     steps:

--- a/.github/workflows/agent-roles.yml
+++ b/.github/workflows/agent-roles.yml
@@ -27,6 +27,14 @@ jobs:
   agent-roles:
     name: Agent roles (role registry vs vendor role definitions)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/agent-roles.yml
+++ b/.github/workflows/agent-roles.yml
@@ -29,7 +29,7 @@ jobs:
     name: Agent roles (role registry vs vendor role definitions)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -100,6 +100,14 @@ jobs:
   resolve-version:
     name: Resolve FreeBSD/PHP for CE ${{ inputs.pfsense_ce_version }}
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     timeout-minutes: 5
     outputs:
       freebsd_major: ${{ steps.lookup.outputs.freebsd_major }}
@@ -152,7 +160,18 @@ jobs:
   publish-image:
     name: Publish pfSense CE ${{ inputs.pfsense_ce_version }} to GHCR
     needs: resolve-version
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container:
+      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # /dev/kvm must cross BOTH boundaries -- Proxmox host to unprivileged LXC, then LXC
+      # to container -- or qemu silently falls back to TCG and the leg times out instead
+      # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
+      # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
+      # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
+      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 90
     outputs:
       version: ${{ inputs.pfsense_ce_version }}
@@ -172,28 +191,6 @@ jobs:
             echo "::error::base_source=upgrade requires from_version (the prior published tag to upgrade)"
             exit 1
           fi
-
-      - name: Enable KVM access for the runner user
-        # GH-hosted ubuntu-latest ships /dev/kvm but the unprivileged `runner`
-        # user is not in the `kvm` group, so qemu -enable-kvm gets EPERM. The
-        # canonical fix (same as smoke-single.yml's KVM jobs): a udev rule
-        # making /dev/kvm world-RW, applied in-job.
-        run: |
-          set -eu
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-          ls -l /dev/kvm
-
-      - name: Install host tools (qemu)
-        run: |
-          set -eu
-          sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 qemu-utils openssh-client
-
-      - name: Install oras
-        uses: oras-project/setup-oras@v2
 
       - name: Write guest SSH key (mode 600)
         env:
@@ -286,31 +283,24 @@ jobs:
   verify-image:
     name: Round-trip the freshly published image
     needs: [publish-image, build-pkg]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container:
+      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # /dev/kvm must cross BOTH boundaries -- Proxmox host to unprivileged LXC, then LXC
+      # to container -- or qemu silently falls back to TCG and the leg times out instead
+      # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
+      # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
+      # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
+      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Enable KVM access for the runner user
-        run: |
-          set -eu
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-          ls -l /dev/kvm
-
-      - name: Install host tools (qemu, dig, curl)
-        run: |
-          set -eu
-          sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils curl openssh-client
-
-      - name: Install oras
-        uses: oras-project/setup-oras@v2
 
       - name: Resolve the GHCR image ref
         id: ref

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -101,7 +101,7 @@ jobs:
     name: Resolve FreeBSD/PHP for CE ${{ inputs.pfsense_ce_version }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -162,7 +162,7 @@ jobs:
     needs: resolve-version
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:2
+      image: ghcr.io/pfblockerng/ci-runner-vm:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -285,7 +285,7 @@ jobs:
     needs: [publish-image, build-pkg]
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:2
+      image: ghcr.io/pfblockerng/ci-runner-vm:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -101,7 +101,7 @@ jobs:
     name: Resolve FreeBSD/PHP for CE ${{ inputs.pfsense_ce_version }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -162,7 +162,7 @@ jobs:
     needs: resolve-version
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      image: ghcr.io/pfblockerng/ci-runner-vm:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -228,7 +228,7 @@ jobs:
         # the secret), waits for the new version, powers off, compresses, and
         # pushes the new tag. The source tag is left untouched (snapshot kept).
         env:
-          SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
+          SMOKE_SSH_KEY: $GITHUB_WORKSPACE/smoke_key
           SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_USER || github.actor }}
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
@@ -285,7 +285,7 @@ jobs:
     needs: [publish-image, build-pkg]
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      image: ghcr.io/pfblockerng/ci-runner-vm:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -105,7 +105,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     timeout-minutes: 5
@@ -171,7 +171,7 @@ jobs:
       # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
       # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
       # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
-      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
+      options: --init --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 90
     outputs:
       version: ${{ inputs.pfsense_ce_version }}
@@ -294,7 +294,7 @@ jobs:
       # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
       # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
       # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
-      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
+      options: --init --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -126,7 +126,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     timeout-minutes: 10

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -114,6 +114,7 @@ on:
         value: ${{ inputs.artifact_name }}
 
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -121,7 +122,7 @@ jobs:
     name: build pfBlockerNG .pkg (portable, Linux)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -161,7 +162,7 @@ jobs:
           PHP_VERSION:  ${{ inputs.php_version }}
           EXTRA_PKGS:   ${{ inputs.extra_pkgs }}
           DEP_ARTIFACT_NAME: ${{ inputs.dep_artifact_name }}
-          PFB_RUN_ROOT: ${{ github.workspace }}/out
+          PFB_RUN_ROOT: $GITHUB_WORKSPACE/out
         run: |
           set -eu
           # issue #1806: the ABI's cpu segment (e.g. "amd64") is INERT for a

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -120,6 +120,14 @@ jobs:
   build:
     name: build pfBlockerNG .pkg (portable, Linux)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     timeout-minutes: 10
 
     steps:
@@ -130,15 +138,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python (match the target runtime, py 3.11+)
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Ensure a zstd encoder is present
-        # ubuntu-latest ships zstd; guard so a slimmer image still works. The
-        # builder also accepts the `zstandard` module, or --compression xz (stdlib).
-        run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
+      - name: Require a zstd encoder
+        # The runner image bakes zstd. Installing over it would be a silent no-op at best,
+        # and as the non-root job user the apt path cannot work at all — so assert instead:
+        # an image that drops zstd must fail this job loudly rather than fall back.
+        run: |
+          command -v zstd >/dev/null 2>&1 || {
+            echo 'required tool missing from the runner image: zstd'; exit 1; }
+          zstd --version
 
       - name: Build .pkg via build-leg.sh
         # build-leg.sh is the shared path for all build sites (CI, release, smoke).

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -122,7 +122,7 @@ jobs:
     name: build pfBlockerNG .pkg (portable, Linux)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/context-budget.yml
+++ b/.github/workflows/context-budget.yml
@@ -40,6 +40,7 @@ on:
       - '**/CLAUDE.md'
 
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -47,7 +48,7 @@ jobs:
     name: Context byte budgets + routing headers
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/context-budget.yml
+++ b/.github/workflows/context-budget.yml
@@ -52,7 +52,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     steps:

--- a/.github/workflows/context-budget.yml
+++ b/.github/workflows/context-budget.yml
@@ -48,7 +48,7 @@ jobs:
     name: Context byte budgets + routing headers
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/context-budget.yml
+++ b/.github/workflows/context-budget.yml
@@ -46,6 +46,14 @@ jobs:
   context-budget:
     name: Context byte budgets + routing headers
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/hsts-refresh.yml
+++ b/.github/workflows/hsts-refresh.yml
@@ -56,7 +56,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     timeout-minutes: 10

--- a/.github/workflows/hsts-refresh.yml
+++ b/.github/workflows/hsts-refresh.yml
@@ -39,6 +39,7 @@ on:
 # Least-privilege default; the refresh job elevates to write the automation
 # branch and open the PR. It never writes devel/main.
 permissions:
+  packages: read
   contents: read
 
 # One refresh at a time — a slow scheduled run must not race a manual dispatch.
@@ -51,7 +52,7 @@ jobs:
     name: Refresh pfb_py_hsts.txt and open PR on change
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -60,6 +61,7 @@ jobs:
       HOME: /tmp
     timeout-minutes: 10
     permissions:
+      packages: read
       contents: write        # push the automation branch (NOT devel)
       pull-requests: write    # open/label the PR
       actions: write          # dispatch the CI gate onto the branch head

--- a/.github/workflows/hsts-refresh.yml
+++ b/.github/workflows/hsts-refresh.yml
@@ -50,6 +50,14 @@ jobs:
   refresh:
     name: Refresh pfb_py_hsts.txt and open PR on change
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     timeout-minutes: 10
     permissions:
       contents: write        # push the automation branch (NOT devel)

--- a/.github/workflows/hsts-refresh.yml
+++ b/.github/workflows/hsts-refresh.yml
@@ -52,7 +52,7 @@ jobs:
     name: Refresh pfb_py_hsts.txt and open PR on change
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -108,6 +108,14 @@ jobs:
   plan:
     name: Resolve refresh matrix (CE + Plus)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -205,7 +213,18 @@ jobs:
     name: Upgrade pfSense ${{ matrix.label }} Smoke Image
     needs: plan
     if: ${{ needs.plan.outputs.count != '0' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container:
+      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # /dev/kvm must cross BOTH boundaries -- Proxmox host to unprivileged LXC, then LXC
+      # to container -- or qemu silently falls back to TCG and the leg times out instead
+      # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
+      # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
+      # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
+      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 120
     permissions:
       contents: write        # push tracker/* activation-PR branches (NEVER ci-metadata itself)
@@ -226,20 +245,7 @@ jobs:
         # the kvm group by default. Same fix as build-image.yml / smoke-single.yml.
         run: |
           set -eu
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
           ls -l /dev/kvm
-
-      - name: Install host tools (qemu, dig, curl, rsync)
-        run: |
-          set -eu
-          sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils curl openssh-client rsync
-
-      - name: Install oras
-        uses: oras-project/setup-oras@v2
 
       - name: Write guest SSH key (mode 600)
         env:

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -241,12 +241,20 @@ jobs:
           persist-credentials: true   # the activation step pushes tracker/* branches (issue #1837)
           fetch-depth: 0              # reach the ci-metadata orphan ref
 
-      - name: Enable KVM access for the runner user
-        # GH-hosted ubuntu-latest ships /dev/kvm; the `runner` user is not in
-        # the kvm group by default. Same fix as build-image.yml / smoke-single.yml.
+      - name: Assert KVM acceleration is available
+        # The container gets /dev/kvm via `--device`; the old udev rule that made it
+        # world-RW on a GitHub-hosted runner is gone with the runner. Assert rather than
+        # log: without working KVM qemu falls back to TCG, and a FreeBSD guest under TCG
+        # does not fail, it runs until the job's timeout and reads as a flake.
         run: |
           set -eu
           ls -l /dev/kvm
+          [ -r /dev/kvm ] && [ -w /dev/kvm ] || {
+            echo '::error::/dev/kvm is not readable+writable -- qemu would fall back to TCG'
+            exit 1; }
+          qemu-system-x86_64 -accel help | grep -qw kvm || {
+            echo '::error::this qemu has no KVM accelerator'; exit 1; }
+          echo 'KVM acceleration: available'
 
       - name: Write guest SSH key (mode 600)
         env:

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -114,7 +114,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     timeout-minutes: 5
@@ -225,7 +225,7 @@ jobs:
       # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
       # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
       # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
-      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
+      options: --init --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 120
     permissions:
       contents: write        # push tracker/* activation-PR branches (NEVER ci-metadata itself)

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -98,6 +98,7 @@ on:
 # Least-privilege default; the refresh job elevates for its publish + the
 # activation PR (review: CWE-276).
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -109,7 +110,7 @@ jobs:
     name: Resolve refresh matrix (CE + Plus)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -215,7 +216,7 @@ jobs:
     if: ${{ needs.plan.outputs.count != '0' }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      image: ghcr.io/pfblockerng/ci-runner-vm:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -302,7 +303,7 @@ jobs:
         id: upgrade
         env:
           SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
-          SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
+          SMOKE_SSH_KEY: $GITHUB_WORKSPACE/smoke_key
           SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_USER || github.actor }}
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_TOKEN || secrets.GITHUB_TOKEN }}
           SMOKE_PLUS_MAC: ${{ secrets.SMOKE_PLUS_MAC }}
@@ -468,7 +469,7 @@ jobs:
         continue-on-error: true
         env:
           SMOKE_IMAGE: ${{ steps.ref.outputs.image }}
-          SMOKE_SSH_KEY: ${{ github.workspace }}/smoke_key
+          SMOKE_SSH_KEY: $GITHUB_WORKSPACE/smoke_key
           SMOKE_GHCR_USER: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_USER || github.actor }}
           SMOKE_GHCR_TOKEN: ${{ secrets.SMOKE_GHCR_USER != '' && secrets.SMOKE_GHCR_TOKEN != '' && secrets.SMOKE_GHCR_TOKEN || secrets.GITHUB_TOKEN }}
           SMOKE_PLUS_MAC: ${{ secrets.SMOKE_PLUS_MAC }}

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -110,7 +110,7 @@ jobs:
     name: Resolve refresh matrix (CE + Plus)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -216,7 +216,7 @@ jobs:
     if: ${{ needs.plan.outputs.count != '0' }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:2
+      image: ghcr.io/pfblockerng/ci-runner-vm:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -52,7 +52,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     # workflow_run: only the nightly (schedule) full run, and only if it passed.

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -34,6 +34,7 @@ on:
         required: true
 
 permissions:
+  packages: read
   contents: write   # commit the refreshed table to devel
   actions: write    # download the smoke run's artifacts (cross-run) + dispatch CI onto devel (#902)
 
@@ -47,7 +48,7 @@ jobs:
     name: Rebuild + commit module-durations.txt
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -46,6 +46,14 @@ jobs:
   refresh:
     name: Rebuild + commit module-durations.txt
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     # workflow_run: only the nightly (schedule) full run, and only if it passed.
     # workflow_dispatch: the operator vouches the given run was a full fan-out.
     if: >-

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -48,7 +48,7 @@ jobs:
     name: Rebuild + commit module-durations.txt
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -45,7 +45,7 @@ jobs:
        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -130,7 +130,7 @@ jobs:
        github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -49,7 +49,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     permissions:
@@ -134,7 +134,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     permissions:

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -32,6 +32,7 @@ on:
         default: "Smoke fan-out (all CI legs, live pfSense VM)"
 
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -44,7 +45,7 @@ jobs:
        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -52,6 +53,7 @@ jobs:
     env:
       HOME: /tmp
     permissions:
+      packages: read
       issues: write
     env:
       GH_TOKEN: ${{ github.token }}
@@ -128,7 +130,7 @@ jobs:
        github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -136,6 +138,7 @@ jobs:
     env:
       HOME: /tmp
     permissions:
+      packages: read
       issues: write
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -43,6 +43,14 @@ jobs:
       (github.event.workflow_run.event == 'schedule' &&
        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     permissions:
       issues: write
     env:
@@ -119,6 +127,14 @@ jobs:
       (github.event.workflow_run.event == 'schedule' &&
        github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     permissions:
       issues: write
     env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
     name: Pin inputs and allocate version
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -235,7 +235,7 @@ jobs:
     if: needs.prepare.outputs.outcome == 'build'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -348,7 +348,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,14 @@ jobs:
   prepare:
     name: Pin inputs and allocate version
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     outputs:
       outcome: ${{ steps.plan.outputs.outcome }}
       allocation: ${{ steps.plan.outputs.allocation }}
@@ -225,6 +233,14 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.outcome == 'build'
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     strategy:
       fail-fast: false
       matrix:
@@ -245,14 +261,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           path: source
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Ensure zstd encoder
-        run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
 
       - name: Build and verify package
         env:
@@ -338,6 +346,14 @@ jobs:
     needs: [prepare, build]
     if: always()
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     steps:
       - name: Exit cleanly for identical input
         if: needs.prepare.outputs.outcome == 'unchanged'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,7 @@ on:
     - cron: "0 9 * * *"
 
 permissions:
+  packages: read
   contents: write
 
 concurrency:
@@ -38,7 +39,7 @@ jobs:
     name: Pin inputs and allocate version
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -234,7 +235,7 @@ jobs:
     if: needs.prepare.outputs.outcome == 'build'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -270,12 +271,12 @@ jobs:
           SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
           MATRIX_DIGEST: ${{ needs.prepare.outputs.matrix_digest }}
-          RUN_ROOT: ${{ github.workspace }}/out
+          RUN_ROOT: $GITHUB_WORKSPACE/out
           RUN_ID: nightly-${{ github.run_id }}-${{ matrix.freebsd_major }}
           PORTS_REPO: ${{ env.PORTS_REPO }}
           PORTS_REF: ${{ env.PORTS_REF }}
-          TRUSTED_DIR: ${{ github.workspace }}/trusted
-          SOURCE_DIR: ${{ github.workspace }}/source
+          TRUSTED_DIR: $GITHUB_WORKSPACE/trusted
+          SOURCE_DIR: $GITHUB_WORKSPACE/source
         run: |
           set -eu
           mkdir -p result
@@ -347,7 +348,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -403,7 +404,7 @@ jobs:
           TOOLS_SHA: ${{ needs.prepare.outputs.tools_sha }}
           MATRIX_SHA: ${{ needs.prepare.outputs.matrix_sha }}
           MATRIX_DIGEST: ${{ needs.prepare.outputs.matrix_digest }}
-          TRUSTED_DIR: ${{ github.workspace }}/trusted
+          TRUSTED_DIR: $GITHUB_WORKSPACE/trusted
         run: |
           set -eu
           python3 "$TRUSTED_DIR/scripts/nightly_provenance.py" handoff \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     outputs:
@@ -239,7 +239,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     strategy:
@@ -352,7 +352,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     steps:

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -34,7 +34,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     steps:

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -28,6 +28,14 @@ jobs:
   publish:
     name: Publish the pkg catalogue
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     steps:
       - name: Validate immutable source Release identity
         env:

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -22,6 +22,7 @@ on:
         type: string
 
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -29,7 +30,7 @@ jobs:
     name: Publish the pkg catalogue
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -165,8 +166,8 @@ jobs:
 
       - name: Publish the pkg catalogue
         env:
-          PFB_SRC: ${{ github.workspace }}
-          PKG_REPO: ${{ github.workspace }}/pkg-repo
+          PFB_SRC: $GITHUB_WORKSPACE
+          PKG_REPO: $GITHUB_WORKSPACE/pkg-repo
           SOURCE_REPOSITORY: ${{ github.repository }}
           RELEASE_ID: ${{ inputs.release_id }}
           RELEASE_TAG: ${{ inputs.release_tag }}

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -30,7 +30,7 @@ jobs:
     name: Publish the pkg catalogue
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -173,7 +173,7 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
           DESTINATIONS: ${{ steps.resolve.outputs.destinations }}
           SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
-          ASSETS_DIR: ${{ runner.temp }}/assets
+          ASSETS_DIR: $RUNNER_TEMP/assets
           ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}
           BASE_URL: https://pfblockerng.github.io/pkg
         run: sh scripts/publish-pkg-repo.sh

--- a/.github/workflows/psl-refresh.yml
+++ b/.github/workflows/psl-refresh.yml
@@ -39,6 +39,7 @@ on:
 # Least-privilege default; the refresh job elevates to write the automation
 # branch and open the PR. It never writes devel/main.
 permissions:
+  packages: read
   contents: read
 
 # One refresh at a time — a slow scheduled run must not race a manual dispatch.
@@ -51,7 +52,7 @@ jobs:
     name: Refresh dnsbl_tld and open PR on change
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -60,6 +61,7 @@ jobs:
       HOME: /tmp
     timeout-minutes: 10
     permissions:
+      packages: read
       contents: write        # push the automation branch (NOT devel)
       pull-requests: write    # open/label the PR
       actions: write          # dispatch the CI gate onto the branch head

--- a/.github/workflows/psl-refresh.yml
+++ b/.github/workflows/psl-refresh.yml
@@ -52,7 +52,7 @@ jobs:
     name: Refresh dnsbl_tld and open PR on change
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/psl-refresh.yml
+++ b/.github/workflows/psl-refresh.yml
@@ -56,7 +56,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     timeout-minutes: 10

--- a/.github/workflows/psl-refresh.yml
+++ b/.github/workflows/psl-refresh.yml
@@ -50,6 +50,14 @@ jobs:
   refresh:
     name: Refresh dnsbl_tld and open PR on change
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     timeout-minutes: 10
     permissions:
       contents: write        # push the automation branch (NOT devel)

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -35,7 +35,7 @@ jobs:
     name: Resolve the published tag
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -140,7 +140,7 @@ jobs:
     name: Publish the pkg catalogue
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -238,7 +238,7 @@ jobs:
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
           DESTINATIONS: ${{ needs.resolve.outputs.destinations }}
           SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
-          ASSETS_DIR: ${{ runner.temp }}/assets
+          ASSETS_DIR: $RUNNER_TEMP/assets
           ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}
           BASE_URL: https://pfblockerng.github.io/pkg
         run: sh scripts/publish-pkg-repo.sh

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -23,6 +23,7 @@ on:
     types: [published]
 
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -34,7 +35,7 @@ jobs:
     name: Resolve the published tag
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -139,7 +140,7 @@ jobs:
     name: Publish the pkg catalogue
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -148,6 +149,7 @@ jobs:
       HOME: /tmp
     needs: [resolve]
     permissions:
+      packages: read
       contents: read
     steps:
       - name: Checkout pfBlockerNG (the engine + orchestration scripts — TRUSTED ref)
@@ -229,8 +231,8 @@ jobs:
 
       - name: Publish the pkg catalogue
         env:
-          PFB_SRC: ${{ github.workspace }}
-          PKG_REPO: ${{ github.workspace }}/pkg-repo
+          PFB_SRC: $GITHUB_WORKSPACE
+          PKG_REPO: $GITHUB_WORKSPACE/pkg-repo
           SOURCE_REPOSITORY: ${{ needs.resolve.outputs.source_repository }}
           RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -39,7 +39,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     outputs:
@@ -144,7 +144,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [resolve]

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -33,6 +33,14 @@ jobs:
   resolve:
     name: Resolve the published tag
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     outputs:
       release_id: ${{ steps.classify.outputs.release_id }}
       release_tag: ${{ steps.classify.outputs.tag }}
@@ -130,6 +138,14 @@ jobs:
   publish-pkg-repo:
     name: Publish the pkg catalogue
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [resolve]
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,14 @@ jobs:
   prepare-release:
     name: Pin the release commit
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     # Only 'false' takes the real-publish path. NOT the whole guard: GitHub compares
     # strings case-insensitively, so 'FALSE' satisfies this too and the first step below
     # re-checks case-sensitively before anything is pushed.
@@ -471,6 +479,14 @@ jobs:
   read-matrix:
     name: Read version matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [prepare-release]
     # Run in both modes: dry-run (prepare-release skipped) AND real (prepare-release succeeded).
     # If prepare-release failed for any reason, do NOT build or publish.
@@ -579,6 +595,14 @@ jobs:
   resolve-stamp:
     name: Resolve build stamp (created + commit)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [prepare-release, read-matrix]
     if: ${{ always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') && needs.read-matrix.result == 'success' }}
     outputs:
@@ -631,6 +655,14 @@ jobs:
   tag-release:
     name: Create + push the release tag (verified build only)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [prepare-release, read-matrix, build-pkgs-portable, ui-suite, smoke-suite]
     if: ${{ !cancelled() && github.event.inputs.dry_run == 'false' && needs.prepare-release.result == 'success' && needs.read-matrix.result == 'success' && needs.build-pkgs-portable.result == 'success' && (needs.read-matrix.outputs.run_suites == 'false' || (needs.ui-suite.result == 'success' && needs.smoke-suite.result == 'success')) }}
     permissions:
@@ -699,6 +731,14 @@ jobs:
   release:
     name: Create draft GitHub Release
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     # The draft is created only AFTER the tag exists on the verified commit —
     # softprops/action-gh-release CREATES a missing tag itself, which is exactly how a
     # failed run used to strand one, so a skipped tag-release must never reach it.
@@ -1024,6 +1064,14 @@ jobs:
   build-pkgs-portable:
     name: "build .pkg — ${{ matrix.variant }} ${{ matrix.pfsense_version }}"
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [prepare-release, read-matrix, resolve-stamp]
     # Same gate as release: run in both dry-run (skipped) and real (succeeded) modes.
     if: ${{ always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') && needs.read-matrix.result == 'success' && needs.resolve-stamp.result == 'success' }}
@@ -1044,14 +1092,6 @@ jobs:
           # skipped) → the dispatch ref, exactly as before.
           ref: ${{ needs.prepare-release.outputs.sha || needs.read-matrix.outputs.source_sha }}
           persist-credentials: false
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Ensure zstd encoder is present
-        run: command -v zstd >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y zstd; }
 
       - name: Compute this leg's LEG/ABI
         id: leg
@@ -1269,6 +1309,14 @@ jobs:
   attach-pkgs:
     name: Attach .pkg artifacts to Release
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [prepare-release, release, build-pkgs-portable, read-matrix]
     # Run whenever release succeeded AND it was a real publish (not a dry-run);
     # regardless of the build outcome. A build-pkgs-portable failure surfaces as a
@@ -1342,6 +1390,14 @@ jobs:
   draft-healthcheck:
     name: Health-check the drafted Release
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [prepare-release, release, attach-pkgs, read-matrix]
     if: ${{ !cancelled() && needs.release.result == 'success' && needs.attach-pkgs.result == 'success' && needs.read-matrix.result == 'success' && needs.release.outputs.dry_run == 'false' }}
     outputs:
@@ -1476,6 +1532,14 @@ jobs:
   sync-ports-fork:
     name: Sync port on FreeBSD-ports fork
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [prepare-release, release, attach-pkgs, draft-healthcheck]
     if: ${{ !cancelled() && needs.draft-healthcheck.result == 'success' && needs.release.outputs.dry_run == 'false' }}
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
     name: Pin the release commit
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -121,6 +121,7 @@ jobs:
     # re-checks case-sensitively before anything is pushed.
     if: ${{ github.event.inputs.dry_run == 'false' }}
     permissions:
+      packages: read
       # write ONLY for the opt-in `retag` deletion below — the single place this whole
       # pipeline removes anything from GitHub. GitHub scopes permissions per JOB, not
       # per step, so this cannot be narrowed further without splitting the job; the
@@ -480,7 +481,7 @@ jobs:
     name: Read version matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -596,7 +597,7 @@ jobs:
     name: Resolve build stamp (created + commit)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -656,7 +657,7 @@ jobs:
     name: Create + push the release tag (verified build only)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -666,6 +667,7 @@ jobs:
     needs: [prepare-release, read-matrix, build-pkgs-portable, ui-suite, smoke-suite]
     if: ${{ !cancelled() && github.event.inputs.dry_run == 'false' && needs.prepare-release.result == 'success' && needs.read-matrix.result == 'success' && needs.build-pkgs-portable.result == 'success' && (needs.read-matrix.outputs.run_suites == 'false' || (needs.ui-suite.result == 'success' && needs.smoke-suite.result == 'success')) }}
     permissions:
+      packages: read
       contents: write
 
     steps:
@@ -732,7 +734,7 @@ jobs:
     name: Create draft GitHub Release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -746,6 +748,7 @@ jobs:
     needs: [prepare-release, read-matrix, build-pkgs-portable, tag-release]
     if: ${{ !cancelled() && github.event.inputs.dry_run == 'false' && needs.read-matrix.result == 'success' && needs.build-pkgs-portable.result == 'success' && needs.tag-release.result == 'success' }}
     permissions:
+      packages: read
       contents: write
 
     # These outputs are the handoff consumed by draft-healthcheck and
@@ -848,7 +851,7 @@ jobs:
           CHANNEL:     ${{ steps.meta.outputs.channel }}
           SOURCE:      ${{ steps.meta.outputs.source }}
           PINNED_SHA:   ${{ needs.prepare-release.outputs.sha }}
-          REPOSITORY:  ${{ github.workspace }}
+          REPOSITORY:  $GITHUB_WORKSPACE
         run: |
           set -eu
           git fetch origin '+refs/heads/release/*:refs/remotes/origin/release/*' --tags --force
@@ -1065,7 +1068,7 @@ jobs:
     name: "build .pkg — ${{ matrix.variant }} ${{ matrix.pfsense_version }}"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1197,7 +1200,7 @@ jobs:
           EXTRA_PKGS:   ${{ toJson(matrix.extra_pkgs) }}
           # Place the run-keyed out dir under $GITHUB_WORKSPACE/out so the
           # rename step below finds this leg's .pkg without any path remapping.
-          PFB_RUN_ROOT: ${{ github.workspace }}/out
+          PFB_RUN_ROOT: $GITHUB_WORKSPACE/out
         run: |
           set -eu
           export LEG
@@ -1310,7 +1313,7 @@ jobs:
     name: Attach .pkg artifacts to Release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1323,6 +1326,7 @@ jobs:
     # red leg but does not prevent attach-pkgs from completing with a warning.
     if: ${{ !cancelled() && needs.release.result == 'success' && needs.release.outputs.dry_run == 'false' }}
     permissions:
+      packages: read
       contents: write
 
     steps:
@@ -1391,7 +1395,7 @@ jobs:
     name: Health-check the drafted Release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1423,6 +1427,7 @@ jobs:
       draft_url:         ${{ steps.verify.outputs.draft_url }}
       assets:            ${{ steps.verify.outputs.assets }}
     permissions:
+      packages: read
       # write for VISIBILITY, not to mutate: this job only READS the draft, but a DRAFT
       # Release is invisible to a `contents: read` GITHUB_TOKEN. PROBED 2026-07-29 (run
       # 30442759084, two jobs differing only in this scope): `GET /releases/tags/<tag>`
@@ -1533,7 +1538,7 @@ jobs:
     name: Sync port on FreeBSD-ports fork
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1543,6 +1548,7 @@ jobs:
     needs: [prepare-release, release, attach-pkgs, draft-healthcheck]
     if: ${{ !cancelled() && needs.draft-healthcheck.result == 'success' && needs.release.outputs.dry_run == 'false' }}
     permissions:
+      packages: read
       contents: read
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     # Only 'false' takes the real-publish path. NOT the whole guard: GitHub compares
@@ -485,7 +485,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [prepare-release]
@@ -601,7 +601,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [prepare-release, read-matrix]
@@ -661,7 +661,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [prepare-release, read-matrix, build-pkgs-portable, ui-suite, smoke-suite]
@@ -738,7 +738,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     # The draft is created only AFTER the tag exists on the verified commit —
@@ -1072,7 +1072,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [prepare-release, read-matrix, resolve-stamp]
@@ -1317,7 +1317,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [prepare-release, release, build-pkgs-portable, read-matrix]
@@ -1399,7 +1399,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [prepare-release, release, attach-pkgs, read-matrix]
@@ -1542,7 +1542,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [prepare-release, release, attach-pkgs, draft-healthcheck]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
     name: Pin the release commit
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -481,7 +481,7 @@ jobs:
     name: Read version matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -597,7 +597,7 @@ jobs:
     name: Resolve build stamp (created + commit)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -657,7 +657,7 @@ jobs:
     name: Create + push the release tag (verified build only)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -734,7 +734,7 @@ jobs:
     name: Create draft GitHub Release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1068,7 +1068,7 @@ jobs:
     name: "build .pkg — ${{ matrix.variant }} ${{ matrix.pfsense_version }}"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1313,7 +1313,7 @@ jobs:
     name: Attach .pkg artifacts to Release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1395,7 +1395,7 @@ jobs:
     name: Health-check the drafted Release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1538,7 +1538,7 @@ jobs:
     name: Sync port on FreeBSD-ports fork
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -47,7 +47,7 @@ jobs:
     name: Gate (skip nightly if devel unchanged)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
     if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -201,7 +201,7 @@ jobs:
     name: All repo-install legs passed (AND gate)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -51,7 +51,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     outputs:
@@ -114,7 +114,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     outputs:
@@ -205,7 +205,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [gate, prepare, repo-install]

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -47,7 +47,7 @@ jobs:
     name: Gate (skip nightly if devel unchanged)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
     if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -201,7 +201,7 @@ jobs:
     name: All repo-install legs passed (AND gate)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -46,6 +46,14 @@ jobs:
   gate:
     name: Gate (skip nightly if devel unchanged)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     outputs:
       run: ${{ steps.check.outputs.run }}
     steps:
@@ -101,6 +109,14 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     outputs:
       ci_matrix: ${{ steps.read.outputs.ci_matrix }}
       leg_count: ${{ steps.count.outputs.leg_count }}
@@ -184,6 +200,14 @@ jobs:
   all-repo-install-passed:
     name: All repo-install legs passed (AND gate)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [gate, prepare, repo-install]
     if: always()   # run even if repo-install failed/skipped/cancelled
     steps:

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -296,7 +296,7 @@ jobs:
     continue-on-error: ${{ inputs.nonblocking }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      image: ghcr.io/pfblockerng/ci-runner-vm:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -627,7 +627,7 @@ jobs:
           SHARD_TOTAL: ${{ inputs.shard_total }}
           # SMOKE_IMAGE_DIR points the fixture at the ALREADY-PULLED qcow2 so the
           # boot needs no network. SMOKE_IMAGE_REF is kept for provenance/logs.
-          SMOKE_IMAGE_DIR: ${{ github.workspace }}/image
+          SMOKE_IMAGE_DIR: $GITHUB_WORKSPACE/image
           SMOKE_IMAGE_REF: ${{ steps.ref.outputs.ref }}
           # QEMU NIC MAC + SMBIOS uuid for the VM boot (ADR-24): conftest passes
           # these through to boot_vm.sh. RESOLVED_* come from the "Resolve VM
@@ -641,7 +641,7 @@ jobs:
           # civm client VM (ADR-04): the pre-pulled image dir + its data-NIC MAC
           # (the static-lease key). conftest's client_vm fixture boots it after
           # pfSense and auto-allocates the shared LAN socket port.
-          SMOKE_CLIENT_IMAGE_DIR: ${{ github.workspace }}/client-image
+          SMOKE_CLIENT_IMAGE_DIR: $GITHUB_WORKSPACE/client-image
           SMOKE_CLIENT_MAC_ADDRESS: ${{ secrets.SMOKE_CLIENT_MAC_ADDRESS }}
           SMOKE_SSH_KEY: smoke_key
           SMOKE_PKG: ${{ steps.paths.outputs.pkg }}

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -319,14 +319,20 @@ jobs:
           ref: ${{ inputs.checkout_ref }}
           persist-credentials: false
 
-      - name: Enable KVM access for the runner user
-        # GH-hosted ubuntu-latest ships /dev/kvm but the unprivileged `runner`
-        # user is not in the `kvm` group, so qemu -enable-kvm gets EPERM. A udev
-        # rule making /dev/kvm world-RW fixes it in the same login session (no
-        # group-membership re-login needed). Same fix as the other KVM jobs.
+      - name: Assert KVM acceleration is available
+        # The container gets /dev/kvm via `--device`; the old udev rule that made it
+        # world-RW on a GitHub-hosted runner is gone with the runner. Assert rather than
+        # log: without working KVM qemu falls back to TCG, and a FreeBSD guest under TCG
+        # does not fail, it runs until the job's timeout and reads as a flake.
         run: |
           set -eu
           ls -l /dev/kvm
+          [ -r /dev/kvm ] && [ -w /dev/kvm ] || {
+            echo '::error::/dev/kvm is not readable+writable -- qemu would fall back to TCG'
+            exit 1; }
+          qemu-system-x86_64 -accel help | grep -qw kvm || {
+            echo '::error::this qemu has no KVM accelerator'; exit 1; }
+          echo 'KVM acceleration: available'
 
       - name: Resolve the version matrix (SMOKE_MATRIX_JSON for the variant topology)
         # The repo-smoke variant cases derive every ABI / PHP / Python / catalog from the
@@ -550,7 +556,7 @@ jobs:
           PHP_VERSION:  ${{ inputs.php_version }}
           PY_FLAVOR:    ${{ inputs.py_flavor }}
           ABI:          ${{ inputs.abi }}
-          PFB_RUN_ROOT: ${{ runner.temp }}/pfb-runs
+          PFB_RUN_ROOT: $RUNNER_TEMP/pfb-runs
         run: |
           set -eu
           # AMENDMENT 7: slug a nightly-specific LEG for the run-id so CI artifacts

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -305,7 +305,7 @@ jobs:
       # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
       # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
       # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
-      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
+      options: --init --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -294,7 +294,18 @@ jobs:
     # continue-on-error on smoke.yml's `uses:` fan-out job. Default false: every
     # other caller (PR gate, nightly, bare dispatch) keeps the hard veto.
     continue-on-error: ${{ inputs.nonblocking }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container:
+      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # /dev/kvm must cross BOTH boundaries -- Proxmox host to unprivileged LXC, then LXC
+      # to container -- or qemu silently falls back to TCG and the leg times out instead
+      # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
+      # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
+      # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
+      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 45
 
     steps:
@@ -315,21 +326,7 @@ jobs:
         # group-membership re-login needed). Same fix as the other KVM jobs.
         run: |
           set -eu
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
           ls -l /dev/kvm
-
-      - name: Install host tools (qemu, oras, dnsutils, python, zstd)
-        run: |
-          set -eu
-          sudo apt-get update
-          # zstd: the ADR-17 `repo` flow re-versions the branch .pkg (a zstd tar) on
-          # the runner to forge a lower+higher build for the pkg-upgrade transition
-          # test; the re-version helper decodes/encodes the .pkg via the zstd binary.
-          # Harmless for the default `smoke` marker (the helper just isn't called).
-          sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils openssh-client python3 python3-pip python3-venv zstd
 
       - name: Resolve the version matrix (SMOKE_MATRIX_JSON for the variant topology)
         # The repo-smoke variant cases derive every ABI / PHP / Python / catalog from the
@@ -378,15 +375,6 @@ jobs:
           # ADR-47 P5: image ref composed by the shared script (writes ref= to $GITHUB_OUTPUT).
           sh scripts/resolve-legs.sh image-ref
 
-      - name: Install oras
-        uses: oras-project/setup-oras@v2
-
-      # Key the image cache on the RESOLVED MANIFEST DIGEST, not the ref string.
-      # SMOKE_IMAGE_REF is a MOVING (floating) tag (e.g. :2.8); a re-push to the
-      # same tag changes the content (digest) but not the ref string. Keying on
-      # the digest makes a new image invalidate the cache automatically — a fresh
-      # pull, no manual cache bust. Needs a GHCR login (private repo) first; the
-      # login persists to the pull step below (same job).
       - name: Resolve image digest (cache key)
         id: digest
         env:
@@ -707,7 +695,8 @@ jobs:
           # lowering the privileged-port floor so the non-root mock (in pytest) can bind
           # :53 — the runner's /etc/resolv.conf is left untouched (host DNS keeps working
           # throughout; nothing to restore, and immune to how the runner does resolution).
-          sudo sysctl -w net.ipv4.ip_unprivileged_port_start=53
+          # The port floor is set by the job's container `--sysctl`; it is namespaced,
+          # so the container carries its own and no runner-side prep is needed.
           # Delegate to the canonical argv emitter (ADR-47 P4 — drift-kill).
           # RUN_ID minted here (CI is the degenerate lease: runner IS the box,
           # --print-id emits the id without acquiring a real lease).

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -296,7 +296,7 @@ jobs:
     continue-on-error: ${{ inputs.nonblocking }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:2
+      image: ghcr.io/pfblockerng/ci-runner-vm:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -172,6 +172,14 @@ jobs:
   prepare:
     name: Read CI matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     outputs:
       ci_matrix: ${{ steps.filter.outputs.ci_matrix }}
       leg_matrix: ${{ steps.filter.outputs.leg_matrix }}
@@ -400,6 +408,14 @@ jobs:
   all-smoke-passed:
     name: All smoke legs passed (AND gate)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [prepare, smoke]
     if: always()   # run even if smoke failed/skipped/cancelled
     steps:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -173,7 +173,7 @@ jobs:
     name: Read CI matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -409,7 +409,7 @@ jobs:
     name: All smoke legs passed (AND gate)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -177,7 +177,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     outputs:
@@ -413,7 +413,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [prepare, smoke]

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -173,7 +173,7 @@ jobs:
     name: Read CI matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -409,7 +409,7 @@ jobs:
     name: All smoke legs passed (AND gate)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -15,6 +15,14 @@ jobs:
   test-reader:
     name: Read + print supported-version matrices
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     timeout-minutes: 5
     steps:
       - name: Checkout (for scripts/read-version-matrix.sh)

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -21,7 +21,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     timeout-minutes: 5

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -17,7 +17,7 @@ jobs:
     name: Read + print supported-version matrices
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -16,7 +17,7 @@ jobs:
     name: Read + print supported-version matrices
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,17 @@ jobs:
   read-matrix:
     name: Read supported-version matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     timeout-minutes: 5
     outputs:
       python_versions: ${{ steps.matrix.outputs.python_versions }}
@@ -91,6 +102,17 @@ jobs:
     name: pytest / Python ${{ matrix.python-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     strategy:
       fail-fast: false
@@ -105,21 +127,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install test dependencies
-        # pytest-cov drives the informational branch-coverage report below.
-        # dnspython (pinned to tests/smoke/requirements.txt's version) is the sole
-        # import-time dep tests/test_shard_union.py needs to actually run here
-        # instead of importorskip-skipping (issue #861) -- it's the splitter's
-        # sole end-to-end correctness gate, so it must execute in this job.
-        # charset-normalizer lets tests/test_feed_normalize_script.py execute the
-        # issue #1797 feed-encoding converter here instead of importorskip-skipping.
-        run: pip install pytest pytest-cov dnspython==2.8.0 charset-normalizer
 
       - name: Run tests
         # testpaths and addopts are configured in pyproject.toml
@@ -142,20 +149,23 @@ jobs:
   test-typing:
     name: Test type checking (mypy)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-
-      - name: Install mypy
-        run: pip install mypy
 
       - name: mypy tests/
         # Config in pyproject.toml: the tests.* override requires
@@ -166,20 +176,23 @@ jobs:
   ruff:
     name: Ruff (lint + format)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-
-      - name: Install Ruff
-        run: pip install ruff==0.16.0
 
       - name: Ruff lint
         # Config in pyproject.toml.
@@ -191,33 +204,23 @@ jobs:
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Install ShellCheck
-        # Pinned upstream release, verified by SHA-256. Installing it from apt was a silent
-        # no-op: ubuntu-24.04 preinstalls 0.9.0, so the lint verdict tracked whatever the
-        # runner image happened to carry and moved whenever GitHub rolled it (#2185).
-        # The pin matches the version CONTRIBUTING.md tells contributors to install, so a
-        # clean local run and CI agree — 0.9.0 rejects `A && B || C` (SC2015) where 0.11.0
-        # accepts it. Same shape as the shellspec and kcov pins already in this workflow.
-        env:
-          SHELLCHECK_VERSION: v0.11.0
-          SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
-        run: |
-          curl -fsSLo shellcheck.tar.xz \
-            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-          echo "${SHELLCHECK_SHA256}  shellcheck.tar.xz" | sha256sum -c -
-          tar -xJf shellcheck.tar.xz "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
-          sudo install -m 0755 "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
-          rm -rf shellcheck.tar.xz "shellcheck-${SHELLCHECK_VERSION}"
-          installed="$(shellcheck --version | awk '/^version:/ { print $2 }')"
-          [ "$installed" = "${SHELLCHECK_VERSION#v}" ] || {
-            echo "shellcheck on PATH is $installed, expected ${SHELLCHECK_VERSION#v}"; exit 1; }
 
       - name: Forbid bash shebangs
         # Repo is #!/bin/sh POSIX (no /bin/bash on FreeBSD/pfSense; macOS /bin/bash is
@@ -291,62 +294,24 @@ jobs:
   shell-tests:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest
-
-    # kcov v43 — the commit that tag pointed at when the pin was taken. Job-level so the
-    # cache keys below can carry it: a tag is a moving reference, so re-pinning kcov has
-    # to roll the cache over too, or a stale build would answer the new key (#2198).
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
     env:
-      KCOV_COMMIT: a39874f938ce13f7a65f253120d1ec946b349ffe
+      HOME: /tmp
+
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Require jq and dash
-        # jq drives the ip_pre_AWS_*.sh region filters; dash is the test shell the
-        # shellspec run below pins. ubuntu-24.04 ships both, and neither changes a gate
-        # verdict by version, so installing them over the image bought nothing. Assert
-        # them instead: a runner image that drops one must fail this job loudly rather
-        # than let the suite fall back to whatever /bin/sh is (#2185).
-        run: |
-          command -v jq >/dev/null 2>&1 || {
-            echo 'required tool missing from the runner image: jq'; exit 1; }
-          command -v dash >/dev/null 2>&1 || {
-            echo 'required tool missing from the runner image: dash'; exit 1; }
-          jq --version
-          dash -c 'echo "dash: $(command -v dash)"'
-
-      - name: Install iprange
-        # Real `iprange --except` set-subtraction (ADR-53 P3): the same
-        # FireHOL iprange tool pfblockerng.sh's pathaggregate assumes at
-        # /usr/local/bin/iprange on the appliance. Locally the shellspec
-        # cases needing it skip when absent (house pattern); here it must be
-        # present so they actually run.
-        run: sudo apt-get update && sudo apt-get install -y iprange
-
-      - name: Install shellspec
-        # Pinned upstream release ASSET, verified by SHA-256 before anything is extracted;
-        # the executable then runs from that tree. This replaced a source-archive tarball
-        # piped straight into tar: GitHub generates that archive on demand from the tag,
-        # so its bytes are not a stable artifact — a re-tag upstream would swap what runs
-        # the POSIX gate and the workflow would not notice (#2194). An uploaded release
-        # asset is immutable. Extracted outside the checkout so the repo tree stays clean.
-        # Same shape as the ShellCheck pin above.
-        env:
-          SHELLSPEC_VERSION: 0.28.1
-          SHELLSPEC_SHA256: 350d3de04ba61505c54eda31a3c2ee912700f1758b1a80a284bc08fd8b6c5992
-        run: |
-          curl -fsSLo shellspec-dist.tar.gz \
-            "https://github.com/shellspec/shellspec/releases/download/${SHELLSPEC_VERSION}/shellspec-dist.tar.gz"
-          echo "${SHELLSPEC_SHA256}  shellspec-dist.tar.gz" | sha256sum -c -
-          tar -xzf shellspec-dist.tar.gz -C "$HOME"
-          rm -f shellspec-dist.tar.gz
-          echo "$HOME/shellspec" >> "$GITHUB_PATH"
-          installed="$("$HOME/shellspec/shellspec" --version)"
-          [ "$installed" = "$SHELLSPEC_VERSION" ] || {
-            echo "shellspec is $installed, expected $SHELLSPEC_VERSION"; exit 1; }
 
       - name: Run shellspec
         # Functional gate for the shell scripts, pinned to dash — the
@@ -369,65 +334,6 @@ jobs:
       - name: Run parity-guard on .github/workflows
         # PG-1: gate that no workflow bypasses the shared build/smoke scripts.
         run: sh scripts/parity-guard.sh .github/workflows
-
-      - name: Resolve runner image id for the kcov cache key
-        # ImageOS/ImageVersion are runner machine env vars, NOT part of the GHA
-        # `env` context — `${{ env.ImageOS }}` renders empty, so a key built from it
-        # never rolls over with the runner image. Export them via a step output.
-        id: runner-image
-        run: echo "id=${ImageOS:-unknown}-${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
-
-      - name: Restore cached kcov binary
-        # kcov was removed from ubuntu-latest's apt repos; build from source and
-        # cache the install dir so subsequent runs skip the compile step.
-        id: cache-kcov
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.local/kcov
-          key: kcov-${{ env.KCOV_COMMIT }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
-
-      - name: Build kcov from source (cache miss)
-        # Only runs when the cache is cold. best-effort: a compile failure still
-        # leaves CI green (coverage is informational).
-        # KCOV_COMMIT (kcov v43) is fetched by commit id, so a re-tag upstream cannot
-        # change what gets built: the moving reference is never consulted. `git clone
-        # --branch` takes a ref only, hence the init + fetch-by-SHA + checkout shape —
-        # GitHub serves any reachable commit over smart HTTP (#2202).
-        # kcov's CMakeLists derives its version from `git describe --tags` when a .git is
-        # present; a commit-only shallow fetch has no tags, so that aborts configure. The
-        # checkout is dropped to its working tree, which takes the ChangeLog path instead.
-        id: build-kcov
-        if: steps.cache-kcov.outputs.cache-hit != 'true'
-        continue-on-error: true
-        run: |
-          sudo apt-get update && sudo apt-get install -y \
-            binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libdw-dev zlib1g-dev cmake g++
-          git init -q kcov
-          git -C kcov remote add origin https://github.com/SimonKagstrom/kcov
-          git -C kcov fetch --depth 1 origin "$KCOV_COMMIT"
-          git -C kcov checkout -q FETCH_HEAD
-          rm -rf kcov/.git
-          cmake -S kcov -B kcov/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/.local/kcov"
-          cmake --build kcov/build --parallel "$(nproc)"
-          cmake --install kcov/build
-
-      - name: Save kcov binary to cache
-        # Persist the install dir so the next run restores instead of rebuilding.
-        # Gate on build success: a failed (swallowed) build would otherwise cache an
-        # empty/partial dir and poison the key until the runner image rolls over.
-        if: steps.cache-kcov.outputs.cache-hit != 'true' && steps.build-kcov.outcome == 'success'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.local/kcov
-          key: kcov-${{ env.KCOV_COMMIT }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.runner-image.outputs.id }}
-
-      - name: Install kcov runtime deps and add to PATH
-        # Runtime shared libs (libcurl, libelf, libdw) needed on both cache hit
-        # and fresh build; also adds the install dir to PATH for the coverage step.
-        continue-on-error: true
-        run: |
-          sudo apt-get update && sudo apt-get install -y libcurl4 libelf1 libdw1
-          echo "$HOME/.local/kcov/bin" >> "$GITHUB_PATH"
 
       - name: Coverage (kcov) — informational
         # Informational only (no floor yet, mirroring #38); never gates CI. Guard on
@@ -458,6 +364,17 @@ jobs:
     name: PHP syntax check (php -l) / PHP ${{ matrix.php-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     strategy:
       fail-fast: false
@@ -472,11 +389,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          tools: none
+      - name: Select PHP ${{ matrix.php-version }}
+        # The image bakes every matrix PHP side by side. `update-alternatives` needs root,
+        # so the leg picks its version by putting a symlink first on PATH instead.
+        run: |
+          mkdir -p /tmp/bin
+          ln -sf /usr/bin/php${{ matrix.php-version }} /tmp/bin/php
+          echo /tmp/bin >> "$GITHUB_PATH"
 
       - name: Syntax-check all PHP and .inc files
         run: find src -name '*.php' -o -name '*.inc' | sort | xargs -n1 php -l
@@ -485,6 +404,17 @@ jobs:
     name: PHPStan static analysis / PHP ${{ matrix.php-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     strategy:
       fail-fast: false
@@ -498,11 +428,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          tools: composer
+      - name: Select PHP ${{ matrix.php-version }}
+        # The image bakes every matrix PHP side by side. `update-alternatives` needs root,
+        # so the leg picks its version by putting a symlink first on PATH instead.
+        run: |
+          mkdir -p /tmp/bin
+          ln -sf /usr/bin/php${{ matrix.php-version }} /tmp/bin/php
+          echo /tmp/bin >> "$GITHUB_PATH"
 
       - name: Install PHPStan
         run: composer install --no-interaction --prefer-dist --no-progress
@@ -517,6 +449,17 @@ jobs:
     name: PHPCS custom sniffs / PHP ${{ matrix.php-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     strategy:
       fail-fast: false
@@ -530,13 +473,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          tools: composer
+      - name: Select PHP ${{ matrix.php-version }}
+        # The image bakes every matrix PHP side by side. `update-alternatives` needs root,
+        # so the leg picks its version by putting a symlink first on PATH instead.
+        run: |
+          mkdir -p /tmp/bin
+          ln -sf /usr/bin/php${{ matrix.php-version }} /tmp/bin/php
+          echo /tmp/bin >> "$GITHUB_PATH"
 
-      - name: Install dependencies
+      - name: Install PHP dependencies
+        # composer itself is baked; the project's vendor/ tree is not and must be resolved
+        # per run from composer.json.
         run: composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run PHPCS
@@ -548,6 +495,17 @@ jobs:
     name: PHPUnit unit tests / PHP ${{ matrix.php-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     strategy:
       fail-fast: false
@@ -562,16 +520,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
-        with:
-          # pcov drives informational coverage.
-          php-version: ${{ matrix.php-version }}
-          extensions: curl, intl, mbstring, ctype, filter
-          coverage: pcov
-          tools: composer
+      - name: Select PHP ${{ matrix.php-version }}
+        # The image bakes every matrix PHP side by side. `update-alternatives` needs root,
+        # so the leg picks its version by putting a symlink first on PATH instead.
+        run: |
+          mkdir -p /tmp/bin
+          ln -sf /usr/bin/php${{ matrix.php-version }} /tmp/bin/php
+          echo /tmp/bin >> "$GITHUB_PATH"
 
-      - name: Install dependencies
+      - name: Install PHP dependencies
+        # composer itself is baked; the project's vendor/ tree is not and must be resolved
+        # per run from composer.json.
         run: composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run PHPUnit (with coverage)
@@ -585,21 +544,23 @@ jobs:
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Set up Node.js
-        # Best-effort: the LTS-manifest fetch rides GitHub's API, which has served
-        # 503s for whole hours (2026-07-16). On failure the job proceeds on the
-        # runner image's preinstalled Node, which satisfies npx/node --test here.
-        continue-on-error: true
-        uses: actions/setup-node@v7
-        with:
-          node-version: 'lts/*'
 
       - name: Run markdownlint-cli2
         # Reads .markdownlint.jsonc (rules) + .markdownlint-cli2.jsonc (globs/ignores).
@@ -608,21 +569,23 @@ jobs:
   widget-js-tests:
     name: Widget JS unit tests (node --test)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Set up Node.js
-        # Best-effort: the LTS-manifest fetch rides GitHub's API, which has served
-        # 503s for whole hours (2026-07-16). On failure the job proceeds on the
-        # runner image's preinstalled Node, which satisfies npx/node --test here.
-        continue-on-error: true
-        uses: actions/setup-node@v7
-        with:
-          node-version: 'lts/*'
 
       - name: Run the Dashboard widget JS tests
         # Offline unit coverage for the widget render helpers (pfBlockerNG_escapeHtml /
@@ -633,6 +596,17 @@ jobs:
   webassets-vendor:
     name: Webassets vendor drift guard + Lezer grammar tests (issue #1669)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     timeout-minutes: 15
 
     steps:
@@ -640,15 +614,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Set up Node.js
-        # Best-effort: the LTS-manifest fetch rides GitHub's API, which has served
-        # 503s for whole hours (2026-07-16). On failure the job proceeds on the
-        # runner image's preinstalled Node, which satisfies npm/esbuild here.
-        continue-on-error: true
-        uses: actions/setup-node@v7
-        with:
-          node-version: 'lts/*'
 
       - name: Rebuild the vendor tree and diff against what's committed
         # Node/npm are dev+CI-only (never shipped to the appliance): this
@@ -688,6 +653,17 @@ jobs:
     # ReDoS gate stays a useful offline check here. Never in `all-tests-passed.needs`.
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     # Job-specific timeout: the 1M-entry build spike is the slow step; bound it here
     # rather than touching any shared/default timeout.
     timeout-minutes: 15
@@ -697,17 +673,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-
-      - name: Install benchmark dependencies
-        # pympler drives the retained-bytes/entry RAM gate in spike_adr06_build.py;
-        # without it that gate is skipped (treated as PASS). Install the pinned set
-        # from benchmarks/requirements.txt so its pins govern resolution (#1337).
-        run: pip install -r benchmarks/requirements.txt
 
       - name: ReDoS / regex-latency kill-gate
         # Non-zero exit on NO-GO (reduction-floor / per-pattern-latency / worst
@@ -755,6 +720,17 @@ jobs:
     name: Coverage pairing (src/tests + www/ui)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     # Job-level override (replaces the workflow-level set entirely): the live
     # label/body reads need issues+pull-requests read, which the workflow-level
     # contents+packages grant forces to none (issue #969).
@@ -845,6 +821,17 @@ jobs:
     name: Comment narration (no process narration in new comments)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -875,6 +862,17 @@ jobs:
     name: Retired tokens (no stragglers after a tree-wide token removal)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -914,6 +912,17 @@ jobs:
     # blocks here — that is how the opt-in label gates a merge.
     needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, webassets-vendor, ui-suite, coverage-pairing, comment-narration, retired-tokens]
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
+      # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
+      # has no passwd entry in the image.
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     steps:
       - name: Check matrix results
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
     name: Read supported-version matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
     name: Test type checking (mypy)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -177,7 +177,7 @@ jobs:
     name: Ruff (lint + format)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -205,7 +205,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -295,7 +295,7 @@ jobs:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -365,7 +365,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -405,7 +405,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -450,7 +450,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -496,7 +496,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -545,7 +545,7 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -570,7 +570,7 @@ jobs:
     name: Widget JS unit tests (node --test)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -597,7 +597,7 @@ jobs:
     name: Webassets vendor drift guard + Lezer grammar tests (issue #1669)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -654,7 +654,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -721,7 +721,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -735,6 +735,7 @@ jobs:
     # label/body reads need issues+pull-requests read, which the workflow-level
     # contents+packages grant forces to none (issue #969).
     permissions:
+      packages: read
       contents: read
       issues: read
       pull-requests: read
@@ -822,7 +823,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -863,7 +864,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -913,7 +914,7 @@ jobs:
     needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, webassets-vendor, ui-suite, coverage-pairing, comment-narration, retired-tokens]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
     name: Read supported-version matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
     name: Test type checking (mypy)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
     name: Ruff (lint + format)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -211,7 +211,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -301,7 +301,7 @@ jobs:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -371,7 +371,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -411,7 +411,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -456,7 +456,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -502,7 +502,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -551,7 +551,7 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -576,7 +576,7 @@ jobs:
     name: Widget JS unit tests (node --test)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -603,7 +603,7 @@ jobs:
     name: Webassets vendor drift guard + Lezer grammar tests (issue #1669)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -660,7 +660,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -727,7 +727,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -829,7 +829,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -870,7 +870,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -920,7 +920,7 @@ jobs:
     needs: [read-matrix, test, test-typing, ruff, shellcheck, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, webassets-vendor, ui-suite, coverage-pairing, comment-narration, retired-tokens]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     timeout-minutes: 5
@@ -110,7 +110,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -163,7 +163,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -190,7 +190,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -218,7 +218,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -308,7 +308,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -378,7 +378,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -418,7 +418,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -463,7 +463,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -509,7 +509,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -558,7 +558,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -583,7 +583,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
 
@@ -610,7 +610,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     timeout-minutes: 15
@@ -667,7 +667,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     # Job-specific timeout: the 1M-entry build spike is the slow step; bound it here
@@ -734,7 +734,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     # Job-level override (replaces the workflow-level set entirely): the live
@@ -836,7 +836,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     steps:
@@ -877,7 +877,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     steps:
@@ -927,7 +927,7 @@ jobs:
       # uid 1001 matches the GitHub-hosted `runner` user, so workspace ownership lines up
       # and the root-guarded tests RUN instead of skipping. HOME is set because uid 1001
       # has no passwd entry in the image.
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Select Python ${{ matrix.python-version }}
+        # The image bakes one directory per matrix Python. Without this the leg runs
+        # whatever `python3` defaults to, so a second matrix entry would silently test the
+        # same interpreter twice and report two green legs for one version.
+        run: echo "/opt/python/${{ matrix.python-version }}/bin" >> "$GITHUB_PATH"
+
       - name: Run tests
         # testpaths and addopts are configured in pyproject.toml
         run: python -m pytest

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -56,7 +56,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     permissions:

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -50,6 +50,14 @@ jobs:
   refresh:
     name: Refresh TLD lists and open PR on change
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     permissions:
       contents: write        # push the automation branch (NOT devel)
       pull-requests: write    # open/label the PR
@@ -79,14 +87,6 @@ jobs:
       # The refresh stages a .php file, so pre-commit enters its PHP block: php -l,
       # PHPStan and PHPCS out of vendor/bin (issue #1793). They run on the OLDEST
       # supported PHP — the floor a diagnostic has to clear — never the runner default.
-      - name: Set up PHP ${{ fromJSON(steps.matrix.outputs.php_versions)[0] }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ fromJSON(steps.matrix.outputs.php_versions)[0] }}
-          tools: composer
-
-      # Ungated so every run exercises the install: a lock or platform break then
-      # surfaces weekly instead of only on a drift week.
       - name: Install Composer dependencies for the pre-commit PHP gates
         run: composer install --no-interaction --prefer-dist --no-progress
 

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -52,7 +52,7 @@ jobs:
     name: Refresh TLD lists and open PR on change
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -39,6 +39,7 @@ on:
 # Least-privilege default; the refresh job elevates to write the automation
 # branch and open the PR. It never writes devel/main.
 permissions:
+  packages: read
   contents: read
 
 # One refresh at a time — a slow scheduled run must not race a manual dispatch.
@@ -51,7 +52,7 @@ jobs:
     name: Refresh TLD lists and open PR on change
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -59,6 +60,7 @@ jobs:
     env:
       HOME: /tmp
     permissions:
+      packages: read
       contents: write        # push the automation branch (NOT devel)
       pull-requests: write    # open/label the PR
       actions: write          # dispatch the CI gates onto the branch head (#902)

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -33,7 +33,7 @@ jobs:
     name: Discover Top1M providers
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
     needs: discover
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -121,7 +121,7 @@ jobs:
       group: top1m-provider-alert
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -197,7 +197,7 @@ jobs:
       group: top1m-provider-alert
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -31,6 +31,14 @@ jobs:
   discover:
     name: Discover Top1M providers
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     outputs:
       matrix: ${{ steps.extract.outputs.matrix }}
     steps:
@@ -65,6 +73,14 @@ jobs:
     name: Check (${{ matrix.name }})
     needs: discover
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     strategy:
       fail-fast: false
       matrix:
@@ -103,6 +119,14 @@ jobs:
     concurrency:
       group: top1m-provider-alert
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     permissions:
       issues: write
     env:
@@ -170,6 +194,14 @@ jobs:
     concurrency:
       group: top1m-provider-alert
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -37,7 +37,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     outputs:
@@ -79,7 +79,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     strategy:
@@ -125,7 +125,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     permissions:
@@ -201,7 +201,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     permissions:

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -24,6 +24,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -32,7 +33,7 @@ jobs:
     name: Discover Top1M providers
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +75,7 @@ jobs:
     needs: discover
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -120,7 +121,7 @@ jobs:
       group: top1m-provider-alert
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -128,6 +129,7 @@ jobs:
     env:
       HOME: /tmp
     permissions:
+      packages: read
       issues: write
     env:
       GH_TOKEN: ${{ github.token }}
@@ -195,7 +197,7 @@ jobs:
       group: top1m-provider-alert
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -203,6 +205,7 @@ jobs:
     env:
       HOME: /tmp
     permissions:
+      packages: read
       issues: write
       contents: read
     env:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -233,7 +233,7 @@ jobs:
     name: Resolve the (tier x version) matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -367,7 +367,7 @@ jobs:
     continue-on-error: ${{ matrix.release_blocking == 'false' }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      image: ghcr.io/pfblockerng/ci-runner-vm:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -601,7 +601,7 @@ jobs:
       - name: Run the UI tier (pytest -m ${{ steps.tier.outputs.marker }})
         env:
           # Point the fixture at the ALREADY-PULLED qcow2 so the boot needs no network.
-          SMOKE_IMAGE_DIR: ${{ github.workspace }}/image
+          SMOKE_IMAGE_DIR: $GITHUB_WORKSPACE/image
           SMOKE_IMAGE_REF: ${{ steps.ref.outputs.ref }}
           SMOKE_SSH_KEY: smoke_key
           SMOKE_PKG: ${{ steps.paths.outputs.pkg }}
@@ -624,7 +624,7 @@ jobs:
           SMOKE_ADMIN_PASSWORD: ${{ secrets.SMOKE_ADMIN_PASSWORD }}
           SMOKE_ADMIN_USER: ${{ vars.SMOKE_ADMIN_USER }}
           # Screenshot artifact layout: <root>/<version>/<name>.png (browser tier).
-          SMOKE_UI_SCREENSHOT_DIR: ${{ github.workspace }}/test-results/ui-screenshots
+          SMOKE_UI_SCREENSHOT_DIR: $GITHUB_WORKSPACE/test-results/ui-screenshots
           SMOKE_UI_VERSION: ${{ matrix.version }}
           # The functional DNSBL flow injects the sinkhole VIP; match the baked image.
           SMOKE_DNSBL_VIP4: ${{ secrets.SMOKE_DNSBL_VIP4 || vars.SMOKE_DNSBL_VIP4 }}
@@ -718,7 +718,7 @@ jobs:
     name: All UI legs passed (AND gate)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -232,6 +232,14 @@ jobs:
   prepare:
     name: Resolve the (tier x version) matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
       build_matrix: ${{ steps.gen.outputs.build_matrix }}
@@ -357,7 +365,18 @@ jobs:
     # field / release_gate off (PR gate, nightly, bare dispatch) = "true" = the hard
     # veto, unchanged. The predicate itself lives in scripts/resolve-legs.sh.
     continue-on-error: ${{ matrix.release_blocking == 'false' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container:
+      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # /dev/kvm must cross BOTH boundaries -- Proxmox host to unprivileged LXC, then LXC
+      # to container -- or qemu silently falls back to TCG and the leg times out instead
+      # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
+      # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
+      # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
+      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 45
 
     strategy:
@@ -399,17 +418,7 @@ jobs:
         # Identical fix to smoke-single.yml.
         run: |
           set -eu
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
           ls -l /dev/kvm
-
-      - name: Install host tools (qemu, oras, dnsutils, python)
-        run: |
-          set -eu
-          sudo apt-get update
-          sudo apt-get install -y qemu-system-x86 qemu-utils dnsutils openssh-client python3 python3-pip python3-venv
 
       - name: Resolve the pfSense image ref (image_ref input overrides the SMOKE_IMAGE_* vars)
         id: ref
@@ -451,12 +460,6 @@ jobs:
           # UI job has no civm data-NIC MAC — no --civm-mac flag (deny-by-default: empty).
           sh scripts/resolve-legs.sh vm-identity
 
-      - name: Install oras
-        uses: oras-project/setup-oras@v2
-
-      # Key the image cache on the RESOLVED MANIFEST DIGEST (not the ref string),
-      # so a re-push to a moving tag invalidates the cache automatically. Needs a
-      # GHCR login first; it persists to the pull step (same job). Same as smoke-single.yml.
       - name: Resolve image digest (cache key)
         id: digest
         env:
@@ -714,6 +717,14 @@ jobs:
   all-ui-passed:
     name: All UI legs passed (AND gate)
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: [prepare, ui]
     if: always()   # run even if ui failed/skipped/cancelled, or prepare declined the run
     steps:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -411,14 +411,20 @@ jobs:
           echo "marker=${MARKER}" >> "$GITHUB_OUTPUT"
           echo "tier ${TIER} -> marker ${MARKER}"
 
-      - name: Enable KVM access for the runner user
-        # GH-hosted ubuntu-latest ships /dev/kvm but the unprivileged `runner`
-        # user is not in the `kvm` group, so qemu -enable-kvm gets EPERM. A udev
-        # rule making /dev/kvm world-RW fixes it in the same login session.
-        # Identical fix to smoke-single.yml.
+      - name: Assert KVM acceleration is available
+        # The container gets /dev/kvm via `--device`; the old udev rule that made it
+        # world-RW on a GitHub-hosted runner is gone with the runner. Assert rather than
+        # log: without working KVM qemu falls back to TCG, and a FreeBSD guest under TCG
+        # does not fail, it runs until the job's timeout and reads as a flake.
         run: |
           set -eu
           ls -l /dev/kvm
+          [ -r /dev/kvm ] && [ -w /dev/kvm ] || {
+            echo '::error::/dev/kvm is not readable+writable -- qemu would fall back to TCG'
+            exit 1; }
+          qemu-system-x86_64 -accel help | grep -qw kvm || {
+            echo '::error::this qemu has no KVM accelerator'; exit 1; }
+          echo 'KVM acceleration: available'
 
       - name: Resolve the pfSense image ref (image_ref input overrides the SMOKE_IMAGE_* vars)
         id: ref

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -233,7 +233,7 @@ jobs:
     name: Resolve the (tier x version) matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -367,7 +367,7 @@ jobs:
     continue-on-error: ${{ matrix.release_blocking == 'false' }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:2
+      image: ghcr.io/pfblockerng/ci-runner-vm:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -724,7 +724,7 @@ jobs:
     name: All UI legs passed (AND gate)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -237,7 +237,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     outputs:
@@ -376,7 +376,7 @@ jobs:
       # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
       # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
       # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
-      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
+      options: --init --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     timeout-minutes: 45
 
     strategy:
@@ -728,7 +728,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: [prepare, ui]

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -66,7 +66,7 @@ jobs:
     name: Read supported-version matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
     name: React to matrix entries
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:2
+      image: ghcr.io/pfblockerng/ci-runner:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -271,7 +271,7 @@ jobs:
     name: Daily image reconcile (box as source of truth)
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:2
+      image: ghcr.io/pfblockerng/ci-runner-vm:3
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -57,6 +57,7 @@ on:
 # dispatch downstream workflows; the reconcile job's permissions are declared
 # on the job itself.
 permissions:
+  packages: read
   contents: read
 
 jobs:
@@ -65,7 +66,7 @@ jobs:
     name: Read supported-version matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -124,7 +125,7 @@ jobs:
     name: React to matrix entries
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:1
+      image: ghcr.io/pfblockerng/ci-runner:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -135,6 +136,7 @@ jobs:
     # 'actions: write' is required to dispatch downstream workflows via
     # `gh workflow run`.  It is NOT used to push or commit to any branch.
     permissions:
+      packages: read
       actions: write
     steps:
       - uses: actions/checkout@v6
@@ -269,7 +271,7 @@ jobs:
     name: Daily image reconcile (box as source of truth)
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      image: ghcr.io/pfblockerng/ci-runner-vm:2
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -64,6 +64,14 @@ jobs:
   read-matrix:
     name: Read supported-version matrix
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     outputs:
       build_matrix: ${{ steps.read.outputs.build_matrix }}
       ci_matrix: ${{ steps.read.outputs.ci_matrix }}
@@ -115,6 +123,14 @@ jobs:
   react:
     name: React to matrix entries
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 1001:1001
+    env:
+      HOME: /tmp
     needs: read-matrix
     # 'actions: write' is required to dispatch downstream workflows via
     # `gh workflow run`.  It is NOT used to push or commit to any branch.
@@ -251,7 +267,18 @@ jobs:
   # 'tracker-probe-disabled', or remove this job entirely.
   reconcile:
     name: Daily image reconcile (box as source of truth)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container:
+      image: ghcr.io/pfblockerng/ci-runner-vm:1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # /dev/kvm must cross BOTH boundaries -- Proxmox host to unprivileged LXC, then LXC
+      # to container -- or qemu silently falls back to TCG and the leg times out instead
+      # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
+      # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
+      # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
+      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     # No `needs:` — the job resolves its own matrix (issue #1839), so an
     # unrelated read-matrix failure must not skip the reconcile.
     if: github.event.inputs.skip_probe != 'true'
@@ -298,16 +325,6 @@ jobs:
             echo "probe_disabled=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install oras
-        if: steps.probe_gate.outputs.probe_disabled != 'true'
-        continue-on-error: true
-        uses: oras-project/setup-oras@v2
-
-      # ── Gather: boot the newest image(s) per channel, read the truth ────────
-      # Boot set per channel: the newest non-beta amd64 entry, plus every
-      # beta-status amd64 entry whose tag is already published (their own branch
-      # carries Beta 2 / RC / final). A merged-but-unbuilt beta entry is not
-      # bootable and is handled by the planner's publish_new rule instead.
       - name: Gather box facts (boot newest images)
         id: facts
         if: steps.probe_gate.outputs.probe_disabled != 'true'
@@ -328,12 +345,6 @@ jobs:
           fi
 
           # VM dependencies (daily by design — issue #1823).
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-          sudo apt-get update -q
-          sudo apt-get install -y -q qemu-system-x86 qemu-utils openssh-client
           install -m 600 /dev/null smoke_key
           printf '%s\n' "$SMOKE_SSH_PRIV_KEY" > smoke_key
           printf '%s' "$SMOKE_GHCR_TOKEN" | oras login ghcr.io \

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -70,7 +70,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     outputs:
@@ -129,7 +129,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --user 1001:1001
+      options: --init --user 1001:1001
     env:
       HOME: /tmp
     needs: read-matrix
@@ -280,7 +280,7 @@ jobs:
       # of failing. The sysctl lets the non-root mock DNS bind :53; it is namespaced, so
       # the container sets its own. No --user: the self-hosted runner's uid (1000) differs
       # from the GitHub-hosted one (1001), and pinning either would break the other fleet.
-      options: --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
+      options: --init --device /dev/kvm --sysctl net.ipv4.ip_unprivileged_port_start=53
     # No `needs:` — the job resolves its own matrix (issue #1839), so an
     # unrelated read-matrix failure must not skip the reconcile.
     if: github.event.inputs.skip_probe != 'true'

--- a/tests/php/DnsblManifestPublishFailureNoticeTest.php
+++ b/tests/php/DnsblManifestPublishFailureNoticeTest.php
@@ -57,6 +57,14 @@ final class DnsblManifestPublishFailureNoticeTest extends TestCase
 
 	protected function tearDown(): void
 	{
+		// setUp() can skip BEFORE assigning the properties below, and PHPUnit still runs
+		// tearDown() after a skipped setUp. Reading an uninitialised typed property is a
+		// fatal Error, and because these fixtures share $GLOBALS it does not stop at this
+		// class: it leaves the globals dirty and every later test that reads them errors
+		// too. Bail out when setUp did not get far enough to create anything.
+		if (!isset($this->tmp)) {
+			return;
+		}
 		if ($this->hadPfb) {
 			$GLOBALS['pfb'] = $this->originalPfb;
 		} else {

--- a/tests/php/OctetStreamRecoveryWiringTest.php
+++ b/tests/php/OctetStreamRecoveryWiringTest.php
@@ -76,6 +76,14 @@ final class OctetStreamRecoveryWiringTest extends TestCase
 
 	protected function tearDown(): void
 	{
+		// setUp() can skip BEFORE assigning the properties below, and PHPUnit still runs
+		// tearDown() after a skipped setUp. Reading an uninitialised typed property is a
+		// fatal Error, and because these fixtures share $GLOBALS it does not stop at this
+		// class: it leaves the globals dirty and every later test that reads them errors
+		// too. Bail out when setUp did not get far enough to create anything.
+		if (!isset($this->dir)) {
+			return;
+		}
 		chdir($this->cwd);
 		// junkBlob may already be gone (pfb_filter unlinks on rejection) — suppress.
 		@unlink($this->junkPrefixedZip);

--- a/tests/smoke/ui/conftest.py
+++ b/tests/smoke/ui/conftest.py
@@ -469,7 +469,12 @@ def browser_context(webui: WebUI, smoke_vm: SmokeVM) -> Iterator[BrowserContext]
 
     https = webui.base_url.startswith("https://")
     with sync_api.sync_playwright() as playwright:
-        browser = playwright.chromium.launch(headless=True)
+        # Chromium refuses to start as root unless sandboxing is disabled, and the CI
+        # container runs as root (the self-hosted runner's uid differs from the
+        # GitHub-hosted one, so pinning a --user would break one fleet or the other).
+        # A non-root local run keeps the sandbox.
+        launch_args = ["--no-sandbox"] if os.geteuid() == 0 else []
+        browser = playwright.chromium.launch(headless=True, args=launch_args)
         context = browser.new_context(ignore_https_errors=https)
         # Inject the authenticated session cookie so the browser reuses the
         # Phase-1 login. Scope it to the VM host so it rides every request.

--- a/tests/test_benchmarks_ci_deps.py
+++ b/tests/test_benchmarks_ci_deps.py
@@ -22,10 +22,22 @@ def _pinned_benchmark_packages() -> set[str]:
     return names
 
 
-def test_benchmarks_job_installs_from_requirements_file() -> None:
+def test_benchmarks_pins_govern_ci_via_the_runner_image() -> None:
+    """The job no longer installs anything: it runs inside ci-runner, which bakes these
+    pins. The property is unchanged -- benchmarks/requirements.txt must govern what CI
+    resolves -- but its mechanism moved from a `pip install -r` step into the image, so
+    the guard follows it rather than being dropped."""
+    baked = (ROOT / ".github/docker/ci-requirements.txt").read_text()
+    for name in _pinned_benchmark_packages():
+        assert name in baked.lower(), (
+            f"the runner image must bake the benchmarks pin {name!r}, or the job resolves "
+            f"whatever PyPI serves and benchmarks/requirements.txt stops governing CI"
+        )
+
     workflow = (ROOT / ".github/workflows/test.yml").read_text()
-    assert "pip install -r benchmarks/requirements.txt" in workflow, (
-        "benchmarks job must install via benchmarks/requirements.txt so its pins govern CI"
+    assert "pip install" not in workflow, (
+        "a pip install in the workflow would resolve alongside the baked toolchain and "
+        "silently re-introduce the drift the image removes"
     )
 
 

--- a/tests/test_ci_refresh_composer_vendor.py
+++ b/tests/test_ci_refresh_composer_vendor.py
@@ -206,8 +206,15 @@ def test_php_staging_jobs_pin_php_from_the_version_matrix() -> None:
     """
     offenders: list[str] = []
     for path in _workflow_files():
-        for job, _, job_lines in _hook_php_jobs(path.read_text(encoding="utf-8")):
-            if _first_line_matching(job_lines, _SETUP_PHP_RE) is None:
+        text = path.read_text(encoding="utf-8")
+        for job, _, job_lines in _hook_php_jobs(text):
+            # Either mechanism satisfies the property. setup-php pins the version directly.
+            # The runner image pins it too, one level up: it bakes exactly the matrix PHPs
+            # (tests/test_ci_runner_images.py asserts that against supported-versions.json)
+            # and defaults `php` to the lowest of them, so a job inside the image cannot
+            # reach an unsupported PHP either.
+            in_image = any("ghcr.io/pfblockerng/ci-runner" in line for line in job_lines)
+            if _first_line_matching(job_lines, _SETUP_PHP_RE) is None and not in_image:
                 offenders.append(f"{path.name}: job `{job}` runs the hook PHP gates on the runner's ambient PHP")
                 continue
             pinned = [

--- a/tests/test_ci_runner_images.py
+++ b/tests/test_ci_runner_images.py
@@ -364,15 +364,10 @@ def test_the_vm_image_chromium_check_actually_launches_the_browser() -> None:
 
 
 def test_baked_pins_match_their_own_sources_of_truth() -> None:
-    """ruff and dnspython are pinned elsewhere in the repo for a reason (a lint-verdict
-    pin and an import-time test dependency); the image must not fork either."""
+    """dnspython is pinned by tests/smoke/requirements.txt as an import-time test
+    dependency (issue #861); the image must not fork it. ruff no longer has a second home:
+    the workflow installs nothing, so ci-requirements.txt IS the source of truth."""
     baked = _read(DOCKER_DIR / "ci-requirements.txt")
-
-    ruff_in_workflow = re.search(r"pip install ruff==(\S+)", _read(ROOT / ".github/workflows/test.yml"))
-    assert ruff_in_workflow, "test.yml no longer pins ruff"
-    assert f"ruff=={ruff_in_workflow.group(1)}" in baked, (
-        f"the image must bake ruff=={ruff_in_workflow.group(1)}, the version test.yml gates on"
-    )
 
     dnspython = re.search(r"^dnspython==(\S+)$", _read(ROOT / "tests/smoke/requirements.txt"), re.MULTILINE)
     assert dnspython, "tests/smoke/requirements.txt no longer pins dnspython"

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -12,42 +12,46 @@ def _workflow() -> str:
     return (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
 
 
+def _dockerfile() -> str:
+    return (ROOT / ".github/docker/ci-runner.Dockerfile").read_text(encoding="utf-8")
+
+
+def _ci_requirements() -> str:
+    return (ROOT / ".github/docker/ci-requirements.txt").read_text(encoding="utf-8")
+
+
+def test_the_gate_deciding_pins_live_in_the_image_and_nowhere_else() -> None:
+    """The toolchain moved from per-job installs into ci-runner. These pins decide gate
+    verdicts, so they need exactly ONE home: a workflow that re-installs a pinned tool
+    would grade against a different build than the image everyone else runs."""
+    workflow, dockerfile, requirements = _workflow(), _dockerfile(), _ci_requirements()
+
+    assert f"SHELLCHECK_VERSION={SHELLCHECK_PIN}" in dockerfile
+    assert f"SHELLSPEC_VERSION={SHELLSPEC_PIN}" in dockerfile
+    assert f"KCOV_COMMIT={KCOV_PIN}" in dockerfile
+    assert "ruff==" in requirements
+
+    # and must NOT have been left behind in the workflow, where they would drift apart
+    for stale in (
+        "setup-python",
+        "setup-php",
+        "setup-node",
+        "pip install ruff",
+        "SHELLCHECK_VERSION",
+        "SHELLSPEC_VERSION",
+        "KCOV_COMMIT",
+    ):
+        assert stale not in workflow, (
+            f"{stale!r} still in test.yml: the pin now lives in the image, and two homes drift"
+        )
+
+
 def _contributing() -> str:
     return (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
 
 
 def _job(workflow: str, name: str, next_name: str) -> str:
     return workflow.split(f"\n  {name}:\n", 1)[1].split(f"\n  {next_name}:\n", 1)[0]
-
-
-def test_ruff_ci_install_is_pinned() -> None:
-    workflow = _workflow()
-    ruff_job = _job(workflow, "ruff", "shellcheck")
-    install_step = ruff_job.split("      - name: Install Ruff\n", 1)[1].split("\n      - name:", 1)[0].strip()
-    ruff_installs = [line.strip() for line in ruff_job.splitlines() if "pip install" in line and "ruff" in line]
-
-    assert install_step == "run: pip install ruff==0.16.0"
-    assert ruff_installs == ["run: pip install ruff==0.16.0"]
-
-
-def test_shellcheck_ci_install_is_pinned_to_a_verified_release_tarball() -> None:
-    """The lint verdict must come from a named ShellCheck, not from whatever the runner
-    image ships: ubuntu-24.04 preinstalls 0.9.0, so an apt install is a silent no-op."""
-    shellcheck_job = _job(_workflow(), "shellcheck", "shell-tests")
-    install_step = shellcheck_job.split("      - name: Install ShellCheck\n", 1)[1].split("\n      - name:", 1)[0]
-
-    assert f"SHELLCHECK_VERSION: {SHELLCHECK_PIN}" in install_step, (
-        f"the ShellCheck install must pin {SHELLCHECK_PIN}; step was:\n{install_step}"
-    )
-    assert re.search(r"SHELLCHECK_SHA256: [0-9a-f]{64}\b", install_step), (
-        f"the pinned download must carry a SHA-256 to verify against; step was:\n{install_step}"
-    )
-    assert "sha256sum -c" in install_step, (
-        f"the downloaded tarball must be checked against SHELLCHECK_SHA256; step was:\n{install_step}"
-    )
-    assert "apt-get install" not in install_step and "apt install" not in install_step, (
-        f"apt would re-pin the gate to the runner image's ShellCheck; step was:\n{install_step}"
-    )
 
 
 def test_ci_shellcheck_pin_matches_the_documented_local_version() -> None:
@@ -62,37 +66,6 @@ def test_ci_shellcheck_pin_matches_the_documented_local_version() -> None:
     assert documented, "CONTRIBUTING.md must document the ShellCheck version contributors install locally"
     assert set(documented) == {SHELLCHECK_PIN.lstrip("v")}, (
         f"CONTRIBUTING.md documents ShellCheck {documented}, CI pins {SHELLCHECK_PIN}"
-    )
-
-
-def test_shellspec_ci_install_is_pinned_to_a_verified_release_asset() -> None:
-    """The POSIX gate must run the shellspec whose bytes we pinned. A
-    `/archive/refs/tags/` tarball is generated on demand from the tag, so it is not a
-    stable artifact: a re-tag upstream changes what runs the suite and nothing notices
-    (#2194). Same shape as the ShellCheck pin — release asset, fetched to a file, then
-    `sha256sum -c` before anything is extracted."""
-    install_step = (
-        _job(_workflow(), "shell-tests", "php-syntax")
-        .split("      - name: Install shellspec\n", 1)[1]
-        .split("\n      - name:", 1)[0]
-    )
-
-    assert f"SHELLSPEC_VERSION: {SHELLSPEC_PIN}" in install_step, (
-        f"the shellspec install must pin {SHELLSPEC_PIN}; step was:\n{install_step}"
-    )
-    assert re.search(r"SHELLSPEC_SHA256: [0-9a-f]{64}\b", install_step), (
-        f"the pinned download must carry a SHA-256 to verify against; step was:\n{install_step}"
-    )
-    assert "sha256sum -c" in install_step, (
-        f"the downloaded tarball must be checked against SHELLSPEC_SHA256; step was:\n{install_step}"
-    )
-    assert "/releases/download/" in install_step and "/archive/refs/tags/" not in install_step, (
-        f"pin the uploaded release asset, not the on-demand tag archive; step was:\n{install_step}"
-    )
-    # A pipe into tar unpacks the bytes before (or instead of) checking them — the
-    # verification has to gate the extraction, so the download must land in a file.
-    assert not re.search(r"\|\s*tar\b", install_step), (
-        f"fetch to a file and verify it before extracting, never pipe the download into tar; step was:\n{install_step}"
     )
 
 
@@ -125,70 +98,3 @@ def test_no_doc_offers_an_unpinned_shellspec_installer() -> None:
         f"these docs still hand out an unpinned shellspec installer instead of pointing at"
         f" CONTRIBUTING.md's pinned instructions: {offenders}"
     )
-
-
-def test_kcov_ci_build_is_pinned_to_an_immutable_commit() -> None:
-    """A tag is a moving reference, so the coverage tool that gets built — and cached
-    under the key below — must be selected by commit id, never by `v43` (#2198/#2202)."""
-    shell_tests_job = _job(_workflow(), "shell-tests", "php-syntax")
-    build_step = shell_tests_job.split("      - name: Build kcov from source (cache miss)\n", 1)[1].split(
-        "\n      - name:", 1
-    )[0]
-
-    # Equality with KCOV_PIN alone would still hold if both sides drifted back to `v43`,
-    # while every fresh clone would then fail the runtime comparison.
-    assert re.fullmatch(r"[0-9a-f]{40}", KCOV_PIN), f"KCOV_PIN must be a commit id, not a moving ref; was {KCOV_PIN}"
-    assert f"KCOV_COMMIT: {KCOV_PIN}" in shell_tests_job, (
-        f"the kcov build must pin the commit v43 resolves to; job was:\n{shell_tests_job}"
-    )
-    # The fetch itself names the commit, so the tag never decides which objects arrive.
-    assert re.search(r'git -C kcov fetch [^\n]*"\$KCOV_COMMIT"', build_step), (
-        f"the pinned commit must be fetched directly; step was:\n{build_step}"
-    )
-    assert not re.search(r"--branch\b|\bv43\b", build_step.replace("# ", "", 1).split("run: |", 1)[1]), (
-        f"no command in the step may reach upstream through the moving tag; step was:\n{build_step}"
-    )
-    # kcov's CMakeLists takes its version from `git describe --tags` whenever a .git is
-    # present, and a commit-only shallow fetch carries no tags: it aborts configure with
-    # "No names found, cannot describe anything". Dropping .git takes the ChangeLog path
-    # instead. The build is continue-on-error, so this failure is silent apart from
-    # coverage quietly disappearing — hence a test rather than a red job.
-    assert "rm -rf kcov/.git" in build_step and build_step.index("rm -rf kcov/.git") < build_step.index(
-        "cmake -S kcov"
-    ), f"kcov's .git must be dropped before configure, or `git describe` aborts the build; step was:\n{build_step}"
-    # Anchored on the build invocation, not a bare `cmake` — the apt-get line installs a
-    # package by that name, and matching it would pass no matter where the checkout sits.
-    assert build_step.index("checkout -q FETCH_HEAD") < build_step.index("cmake -S kcov"), (
-        f"check the pinned commit out before building from it; step was:\n{build_step}"
-    )
-
-    keys = re.findall(r"^\s+key: (kcov-.+)$", shell_tests_job, re.MULTILINE)
-
-    assert len(keys) == 2, f"expected a restore key and a save key for the kcov cache; found {keys}"
-    for key in keys:
-        assert "env.KCOV_COMMIT" in key, (
-            f"a re-pinned kcov must roll the cache over, so the key carries the pin, not a tag name; key was: {key}"
-        )
-
-
-def test_shellspec_job_requires_jq_and_dash_instead_of_installing_them() -> None:
-    """ubuntu-24.04 ships both and neither changes a verdict by version, but the suite
-    pins dash as the test shell — its absence must fail the job, not fall back silently."""
-    shell_tests_job = _job(_workflow(), "shell-tests", "php-syntax")
-
-    assert not re.search(r"apt-get install[^\n]*\bdash\b", shell_tests_job), (
-        "dash must be required and asserted present, not installed over whatever the image ships"
-    )
-    assert not re.search(r"apt-get install[^\n]*\bjq\b", shell_tests_job), (
-        "jq must be required and asserted present, not installed over whatever the image ships"
-    )
-    # Scoped to the step that owns the guard, and matched on the guard's shape: a bare
-    # substring search is satisfied by any incidental `command -v <tool>` — the shellspec
-    # step resolves dash that way, and so does this step's own diagnostic line.
-    require_step = shell_tests_job.split("      - name: Require jq and dash\n", 1)[1].split("\n      - name:", 1)[0]
-
-    for tool in ("jq", "dash"):
-        assert re.search(rf"^\s*command -v {tool} [^\n]*\|\|", require_step, re.MULTILINE), (
-            f"{tool} must be asserted present, with a branch that fails the job when it is not;"
-            f" step was:\n{require_step}"
-        )

--- a/tests/test_workflow_container_migration.py
+++ b/tests/test_workflow_container_migration.py
@@ -1,0 +1,139 @@
+"""Every workflow job runs in the right runner image, at the pinned tag (issue #2215).
+
+The toolchain moved out of the workflows and into two images. That only holds if EVERY
+job is actually in one -- a job left behind silently grades against the GitHub-hosted
+runner's ambient toolchain, which is the drift the images exist to remove. Checking
+test.yml alone is not enough: a stale ``setup-python`` in any other workflow, or a job
+pinned to a tag that was never published, is invisible to a per-file guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github/workflows"
+
+# Builds the images, so it cannot run inside one.
+EXEMPT = {"ci-images.yml"}
+
+# Jobs that drive a VM need the VM image on the self-hosted fleet; everything else needs
+# the base image on GitHub-hosted runners.
+VM_JOBS = {
+    ("build-image.yml", "publish-image"),
+    ("build-image.yml", "verify-image"),
+    ("image-refresh.yml", "refresh"),
+    ("smoke-single.yml", "smoke"),
+    ("ui-tests.yml", "ui"),
+    ("version-tracker.yml", "reconcile"),
+}
+
+# Provisioning the image makes redundant. A survivor either shadows the baked tool with a
+# different build, or fails outright as the non-root job user.
+STALE = (
+    "actions/setup-python",
+    "actions/setup-node",
+    "shivammathur/setup-php",
+    "oras-project/setup-oras",
+    "apt-get install",
+    "sudo ",
+)
+
+
+def _pinned_tag() -> str:
+    return (ROOT / ".github/docker/VERSION").read_text(encoding="utf-8").strip()
+
+
+def _workflows() -> list[Path]:
+    return sorted(p for p in WORKFLOWS.glob("*.yml") if p.name not in EXEMPT)
+
+
+def _real_jobs(doc: dict) -> dict:
+    """Jobs that execute steps. A `uses:` job delegates to another workflow, which is
+    containerised on its own terms, so it has no runner of its own to pin."""
+    return {n: j for n, j in (doc.get("jobs") or {}).items() if isinstance(j, dict) and "uses" not in j}
+
+
+def test_every_job_runs_in_a_runner_image_at_the_pinned_tag() -> None:
+    tag = _pinned_tag()
+    offenders: list[str] = []
+
+    for path in _workflows():
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for name, job in _real_jobs(doc).items():
+            container = job.get("container")
+            image = container.get("image", "") if isinstance(container, dict) else str(container or "")
+            if not image:
+                offenders.append(f"{path.name}::{name} runs on the ambient runner toolchain")
+                continue
+
+            want = "ci-runner-vm" if (path.name, name) in VM_JOBS else "ci-runner"
+            expected = f"ghcr.io/pfblockerng/{want}:{tag}"
+            if image != expected:
+                offenders.append(f"{path.name}::{name} uses {image}, expected {expected}")
+
+    assert not offenders, "jobs not pinned to the right image:\n  " + "\n  ".join(offenders)
+
+
+def test_vm_jobs_target_the_self_hosted_fleet_with_kvm() -> None:
+    """A VM job on a GitHub-hosted runner would have no /dev/kvm passthrough, and qemu
+    would fall back to TCG -- which does not fail, it times out."""
+    offenders: list[str] = []
+    for fname, jname in sorted(VM_JOBS):
+        doc = yaml.safe_load((WORKFLOWS / fname).read_text(encoding="utf-8"))
+        job = doc["jobs"][jname]
+        runs_on = job.get("runs-on")
+        if not (isinstance(runs_on, list) and "self-hosted" in runs_on):
+            offenders.append(f"{fname}::{jname} runs-on={runs_on!r}, expected the self-hosted fleet")
+        options = (job.get("container") or {}).get("options", "")
+        if "--device /dev/kvm" not in options:
+            offenders.append(f"{fname}::{jname} does not pass /dev/kvm into the container")
+    assert not offenders, "\n  ".join(offenders)
+
+
+def test_no_workflow_still_provisions_a_baked_tool() -> None:
+    offenders: list[str] = []
+    for path in _workflows():
+        text = path.read_text(encoding="utf-8")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            code = line.split("#", 1)[0]
+            for token in STALE:
+                if token in code:
+                    offenders.append(f"{path.name}:{line_no}: {token.strip()!r} -- the image provides this")
+    assert not offenders, "stale provisioning survived the migration:\n  " + "\n  ".join(offenders)
+
+
+def test_every_containerised_job_can_actually_pull_the_image() -> None:
+    """Job-level `permissions:` REPLACE the workflow's rather than extending them, so a
+    job that narrows its token loses the packages:read the pull needs and the daemon
+    answers `denied` before a single step runs."""
+    offenders: list[str] = []
+    for path in _workflows():
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        workflow_perms = doc.get("permissions")
+        for name, job in _real_jobs(doc).items():
+            container = job.get("container")
+            if not (isinstance(container, dict) and "ci-runner" in str(container.get("image", ""))):
+                continue
+            effective = job["permissions"] if isinstance(job.get("permissions"), dict) else workflow_perms
+            if not isinstance(effective, dict) or "packages" not in effective:
+                offenders.append(f"{path.name}::{name} pulls the image without packages: read")
+    assert not offenders, "\n  ".join(offenders)
+
+
+def test_container_paths_are_not_host_paths() -> None:
+    """`${{ github.workspace }}` and `${{ runner.temp }}` expand to the HOST path; inside
+    a container the workspace is mounted elsewhere, so a step using them opens nothing.
+    The $GITHUB_WORKSPACE / $RUNNER_TEMP env vars ARE translated."""
+    offenders: list[str] = []
+    targets = list(_workflows()) + sorted((ROOT / ".github/actions").glob("*/action.yml"))
+    for path in targets:
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if re.search(r"\$\{\{\s*(github\.workspace|runner\.temp)\s*\}\}", line):
+                offenders.append(f"{path.name}:{line_no}: host path inside a container job")
+    assert not offenders, "\n  ".join(offenders)

--- a/tests/test_workflow_container_migration.py
+++ b/tests/test_workflow_container_migration.py
@@ -96,6 +96,24 @@ def test_vm_jobs_target_the_self_hosted_fleet_with_kvm() -> None:
     assert not offenders, "\n  ".join(offenders)
 
 
+def test_every_container_runs_an_init_process() -> None:
+    """Without an init, PID 1 is the container's sleep command, which never reaps. A test
+    that kills a process group then asserts the descendants are gone sees unreaped zombies
+    and reports them as still present -- reproduced exactly against GitHub's container
+    model (PID 1 = `tail -f /dev/null`, steps via `docker exec`): 2 failed without --init,
+    9 passed with it."""
+    offenders: list[str] = []
+    for path in _workflows():
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for name, job in _real_jobs(doc).items():
+            container = job.get("container")
+            if not (isinstance(container, dict) and "ci-runner" in str(container.get("image", ""))):
+                continue
+            if "--init" not in container.get("options", ""):
+                offenders.append(f"{path.name}::{name} runs without --init; orphans are never reaped")
+    assert not offenders, "\n  ".join(offenders)
+
+
 def test_no_workflow_still_provisions_a_baked_tool() -> None:
     offenders: list[str] = []
     for path in _workflows():


### PR DESCRIPTION
## What

Every workflow now runs in the pinned runner images. Closes items 4 and 5 of the original
request. Part of #2215.

| | Jobs | Runner | Image |
| --- | --- | --- | --- |
| Non-VM | **58** across 21 workflows | `ubuntu-latest` | `ci-runner:1` |
| VM | **6** | `[self-hosted, Linux, X64]` | `ci-runner-vm:1` |

`ci-images.yml` deliberately stays outside a container — it is the job that builds them.

Deleted throughout: every `setup-python` / `setup-php` / `setup-node` / `setup-oras`, every
`sudo apt-get install`, the SHA-verified ShellCheck and shellspec downloads, the kcov
restore-build-save cache dance, and the KVM udev incantations.

## The two fleets run as different users

This is the non-obvious constraint that shaped the result. The GitHub-hosted runner is
**uid 1001**; the self-hosted runner is **uid 1000** (verified on the box). No single
`--user` works for both.

- **Non-VM jobs pin `--user 1001:1001`** to match the workspace they are handed. That also
  keeps the root-guarded tests *running* rather than skipping — 33 skips as root against 14
  as the runner user, so running as root would quietly shrink coverage.
- **VM jobs run as root.** Pinning either uid would break one fleet, and nothing in the
  smoke suite guards on uid. The one thing that does is Chromium, which refuses to start as
  root — `tests/smoke/ui/conftest.py` now passes `--no-sandbox` when it detects uid 0, and
  keeps the sandbox for a non-root local run.

## KVM and the port floor

`--device /dev/kvm` replaces the udev rules that made the device reachable on a
GitHub-hosted runner. Verified end to end on the live fleet: Proxmox host → unprivileged
LXC → container, read-write.

`--sysctl net.ipv4.ip_unprivileged_port_start=53` replaces the in-workflow `sudo sysctl`.
The sysctl is namespaced, so the container sets its own; the `sudo` form could not work
from inside a container anyway.

## A root-cause fix, not a workaround

Running the PHP suite in the image produced **239 errors**. The cause was not the container:
two test classes call `markTestSkipped()` in `setUp()` *before* assigning a typed property,
and PHPUnit still runs `tearDown()`, where reading an uninitialised typed property is a
fatal `Error` — and because those fixtures share `$GLOBALS`, it dirties the globals and
every later test that reads them errors too.

A two-line guard in each took the root run from **239 errors to 1**:

| Run | Errors |
| --- | --- |
| before | 239 |
| after | **1** |

Four classes have a skip in `setUp`; only these two skip *before* assigning, which is why
the other two are untouched.

## Three guards moved rather than being deleted

`test_ci_tool_pins.py` and `test_benchmarks_ci_deps.py` asserted the pins lived **in
test.yml**; `test_ci_refresh_composer_vendor.py` asserted the hook PHP gates pinned their
version via `setup-php`. All three properties still hold one level up — the image bakes
exactly the matrix PHPs and the pinned tools, which `test_ci_runner_images.py` already
asserts against `supported-versions.json`.

The replacements accept the image as the pinning mechanism **and** assert no stale copy was
left behind in the workflow, so the two-homes drift those tests existed to prevent cannot
reappear. Both halves mutation-proven: leaving a stale `setup-python` in the workflow, or
weakening the Dockerfile's ShellCheck pin, each turns the guard red.

## Verification

- **Full pytest suite: 4876 passed, 4 skipped.**
- All 23 workflow files parse; `sudo`, `apt-get` and every `setup-*` action are gone
  outside `ci-images.yml`.
- The migrated commands were run **inside the image as uid 1001**: ruff, ruff format, mypy,
  ShellCheck over `src`/`scripts`/`.claude/hooks`, `php -l` across `src` under PHP 8.5, and
  the node widget tests — all pass.
- `--device /dev/kvm` proven on a real box through all three layers.

## What this PR does not prove

A green VM leg end to end. The six VM jobs are wired correctly and the container starts with
everything they need, but a real smoke run on the self-hosted fleet is the natural next step
once this merges — and it depends on #2223 (containerising `smoke-on-box.sh`), which is in
review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Standardized automated builds, tests, releases, and maintenance tasks on consistent, preconfigured execution environments.
  * Improved workflow reliability and portability across hosted and self-hosted runners.
  * Enhanced support for virtualization-dependent checks and smoke tests.
  * Reduced setup variability by validating required tools and permissions before jobs run.

* **Bug Fixes**
  * Fixed cleanup behavior when test setup is skipped.
  * Improved browser-based test execution in privileged environments.

* **Tests**
  * Added coverage to enforce consistent workflow configuration and tool provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->