### PR TITLE
ci: hand every changed-file gate real paths, not git's C-escapes (#2212)

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -43,7 +43,7 @@
           },
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/check_retired_tokens.py\" 7f671b73835f8e8c39cdb244489cdcbc471ecdc8a4cc361a5d8de4680284b97a && exec python3 \"$root/scripts/check_retired_tokens.py\" --claude-hook",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/check_retired_tokens.py\" d4fd466410b16b2847d3fafcfb2808c82babc7d42ad9a4ea520056e22a0f1bd4 && exec python3 \"$root/scripts/check_retired_tokens.py\" --claude-hook",
             "timeout": 30,
             "statusMessage": "Checking retired tokens"
           }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -48,10 +48,13 @@ skip() { skipped="${skipped} $1"; }
 
 # --- Stage classification: run a language's gates ONLY when this commit stages a
 #     file of that type. (diff-filter ACMR = added/copied/modified/renamed; a pure
-#     deletion stages nothing to lint.) Nothing staged -> nothing to do. ---
-staged_all=$(git diff --cached --name-only --diff-filter=ACMRD)
+#     deletion stages nothing to lint.) Nothing staged -> nothing to do.
+#     -z + tr: the newline listing C-quotes a path holding a quote, backslash,
+#     control byte or non-ASCII byte, so the suffix regexes below match nothing
+#     and that commit's language gates silently never run (issue #2212). ---
+staged_all=$(git diff --cached --name-only -z --diff-filter=ACMRD | tr '\0' '\n')
 [ -n "$staged_all" ] || exit 0
-staged=$(git diff --cached --name-only --diff-filter=ACMR)
+staged=$(git diff --cached --name-only -z --diff-filter=ACMR | tr '\0' '\n')
 staged_has() { printf '%s\n' "$staged" | grep -qE "$1"; }
 staged_py=0;  staged_has '\.py$'        && staged_py=1
 staged_md=0;  staged_has '\.md$'        && staged_md=1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -141,18 +141,25 @@ if [ "$staged_sh" = 1 ] || [ "$staged_specplumb" = 1 ]; then
 	# is canonical for a migrated skill, .claude/skills/<name> either the same
 	# content (pre-migration) or a symlink onto it — exempt both prefixes so
 	# this stays correct regardless of migration state.
-	git ls-files \
-		| grep -v -e '^\.claude/skills/git-guardrails-claude-code/' \
-			-e '^\.agents/skills/git-guardrails-claude-code/' \
-			-e '^plugins/' \
-		| while IFS= read -r f; do
-		case $(head -n1 "$f" 2>/dev/null) in
-		'#!'*bash*)
-			printf '[pre-commit] bash shebang not allowed (use #!/bin/sh): %s\n' "$f" >&2
-			exit 1
-			;;
-		esac
-	done || failed 'shebang policy'
+	# -z + xargs -0, never a newline listing: git C-quotes a path holding a
+	# quote, backslash, control byte or non-ASCII byte, and `head` on a quoted
+	# name reads nothing — that file's shebang would go unchecked (issue #2212).
+	# The exemption fence sits inside the loop for the same reason: a `grep`
+	# over the listing cannot see NULs.
+	git ls-files -z | xargs -0 sh -c '
+		for f; do
+			case $f in
+			.claude/skills/git-guardrails-claude-code/*) continue ;;
+			.agents/skills/git-guardrails-claude-code/*) continue ;;
+			plugins/*) continue ;;
+			esac
+			case $(head -n1 "$f" 2>/dev/null) in
+			"#!"*bash*)
+				printf "[pre-commit] bash shebang not allowed (use #!/bin/sh): %s\n" "$f" >&2
+				exit 1
+				;;
+			esac
+		done' _ || failed 'shebang policy'
 
 	# sh -n parse gate (src + scripts + tests + .claude/hooks; cheap, tool-free).
 	step 'shell (sh -n)'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,15 +234,20 @@ jobs:
         # Vendored third-party plugin trees are exempt (upstream content, never
         # runs on the box; same fence as .githooks/pre-commit).
         run: |
-          find_bash_shebangs() {
-            while IFS= read -r f; do
-              case $(head -n1 "$f" 2>/dev/null) in '#!'*bash*) echo "$f" ;; esac
-            done
-          }
-          bad=$(git ls-files | grep -v \
-            -e '^\.claude/skills/git-guardrails-claude-code/' \
-            -e '^\.agents/skills/git-guardrails-claude-code/' \
-            -e '^plugins/' | find_bash_shebangs)
+          # -z + xargs -0, never a newline-separated listing: git C-quotes a path
+          # holding a quote, backslash, control byte or non-ASCII byte, and
+          # `head` on a quoted name reads nothing — the file's shebang would go
+          # unchecked (issue #2212). The exemption fence moved inside the loop
+          # for the same reason: a `grep` over the listing cannot see NULs.
+          bad=$(git ls-files -z | xargs -0 sh -c '
+            for f; do
+              case $f in
+                .claude/skills/git-guardrails-claude-code/*) continue ;;
+                .agents/skills/git-guardrails-claude-code/*) continue ;;
+                plugins/*) continue ;;
+              esac
+              case $(head -n1 "$f" 2>/dev/null) in "#!"*bash*) echo "$f" ;; esac
+            done' _)
           if [ -n "$bad" ]; then
             echo "bash shebang not allowed (use #!/bin/sh):"; echo "$bad"; exit 1
           fi
@@ -758,12 +763,13 @@ jobs:
         run: |
           set -eu
           git fetch --no-tags origin "$BASE:refs/remotes/origin/$BASE"
-          # core.quotePath=false: git's default wraps any non-ASCII path in quotes
-          # and octal-escapes it, and check_coverage_pairing.py classifies by
+          # -z: git wraps a path in quotes and C-escapes it when it holds a
+          # non-ASCII byte (issue #2137) or a quote/backslash/control byte
+          # (issue #2212), and check_coverage_pairing.py classifies by
           # startswith("src/") — so a quoted path matches no rule and an unpaired
-          # src/ change passes silently (issue #2137).
-          git -c core.quotePath=false diff --name-only "origin/$BASE...HEAD" > changed.txt
-          echo "Changed files vs origin/$BASE:"; cat changed.txt
+          # src/ change passes silently. NUL separators carry the real bytes.
+          git diff --name-only -z "origin/$BASE...HEAD" > changed.txt
+          echo "Changed files vs origin/$BASE:"; tr '\0' '\n' < changed.txt
 
       - name: Enforce src<->tests and www<->ui coverage pairing
         # ubuntu-latest ships python3. --warn-only downgrades a violation to a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,6 +234,10 @@ jobs:
         # Vendored third-party plugin trees are exempt (upstream content, never
         # runs on the box; same fence as .githooks/pre-commit).
         run: |
+          # pipefail: a step with no `shell:` keyword runs under `bash -e {0}`
+          # (no pipefail), so a failing `git ls-files` would become an empty
+          # listing and pass this gate silently.
+          set -o pipefail
           # -z + xargs -0, never a newline-separated listing: git C-quotes a path
           # holding a quote, backslash, control byte or non-ASCII byte, and
           # `head` on a quoted name reads nothing — the file's shebang would go

--- a/scripts/_git_paths.py
+++ b/scripts/_git_paths.py
@@ -45,8 +45,14 @@ def unquote_git_path(field: str) -> str:
             out.append(_C_ESCAPES[raw[i + 1]])
             i += 2
         elif 0x30 <= raw[i + 1] <= 0x37:
-            out.append(int(raw[i + 1 : i + 4], 8) & 0xFF)
-            i += 4
+            # git always emits exactly three octal digits; scanning for however
+            # many are actually there keeps the decode total on forged input
+            # rather than raising mid-run.
+            end = i + 1
+            while end < len(raw) and end < i + 4 and 0x30 <= raw[end] <= 0x37:
+                end += 1
+            out.append(int(raw[i + 1 : end], 8) & 0xFF)
+            i = end
         else:
             out.append(raw[i + 1])
             i += 2

--- a/scripts/_git_paths.py
+++ b/scripts/_git_paths.py
@@ -1,0 +1,72 @@
+"""Real paths out of git's C-quoted output.
+
+git wraps a path in double quotes and C-escapes it whenever the path holds a
+double quote, a backslash or a control byte. That quoting is unconditional:
+``core.quotePath`` only governs whether HIGH-BIT bytes are escaped too. Every
+changed-file gate in this repo classifies a path by prefix or suffix, so a
+quoted path matches no rule and its file skips the gate while the job still
+reports a clean pass (issue #2212).
+
+``git ... -z`` emits raw NUL-separated paths and is the fix wherever it exists
+(``--name-only``, ``ls-files``). A unified diff's ``---``/``+++`` header has no
+``-z`` form, so those parsers decode the header here instead.
+"""
+
+from __future__ import annotations
+
+# git emits these named escapes plus 3-digit octal for any other escaped byte.
+_C_ESCAPES = {
+    ord("a"): 0x07,
+    ord("b"): 0x08,
+    ord("f"): 0x0C,
+    ord("n"): 0x0A,
+    ord("r"): 0x0D,
+    ord("t"): 0x09,
+    ord("v"): 0x0B,
+    ord('"'): 0x22,
+    ord("\\"): 0x5C,
+}
+
+
+def unquote_git_path(field: str) -> str:
+    """Decode one C-quoted git path field; an unquoted field is returned as-is."""
+    if len(field) < 2 or not (field.startswith('"') and field.endswith('"')):
+        return field
+    # Byte-level: an octal escape names a BYTE of a multi-byte character, so the
+    # escapes have to be resolved before the result is decoded as text.
+    raw = field[1:-1].encode("utf-8", "surrogateescape")
+    out = bytearray()
+    i = 0
+    while i < len(raw):
+        if raw[i] != 0x5C or i + 1 >= len(raw):
+            out.append(raw[i])
+            i += 1
+        elif raw[i + 1] in _C_ESCAPES:
+            out.append(_C_ESCAPES[raw[i + 1]])
+            i += 2
+        elif 0x30 <= raw[i + 1] <= 0x37:
+            out.append(int(raw[i + 1 : i + 4], 8) & 0xFF)
+            i += 4
+        else:
+            out.append(raw[i + 1])
+            i += 2
+    return out.decode("utf-8", "surrogateescape")
+
+
+def diff_header_name(field: str) -> str:
+    """Decode the name field of a unified-diff ``---``/``+++`` header line.
+
+    ``field`` is everything after the leading marker and space. git appends a
+    literal tab to it when the path holds a space, and C-quotes the whole
+    ``a/``/``b/``-prefixed name (tab marker left OUTSIDE the quotes) when the
+    path holds a quote, backslash or control byte. Returned with the prefix
+    still attached — the caller decides which side it wants.
+    """
+    if field.startswith('"'):
+        return unquote_git_path(field.rstrip("\t"))
+    return field.split("\t", 1)[0]
+
+
+def nul_paths(listing: str) -> list[str]:
+    """Split a ``git ... -z`` listing into paths, dropping the empty tail."""
+    return [path for path in listing.split("\0") if path]

--- a/scripts/check_agent_roles.py
+++ b/scripts/check_agent_roles.py
@@ -41,6 +41,8 @@ import tomllib
 from pathlib import Path
 from typing import NamedTuple
 
+from _git_paths import nul_paths
+
 _ROLES_DOC = ".agents/policy/agent-roles.md"
 _TIERS_CONF = ".agents/model-tiers.conf"
 _CODEX_AGENTS = ".codex/agents"
@@ -447,14 +449,16 @@ def validate(root: Path) -> tuple[int, list[str]]:
 
 
 def _changed_paths(root: Path, git_args: list[str]) -> list[str]:
+    # -z: the newline form C-quotes any path holding a quote, backslash, control
+    # byte or non-ASCII byte, and a quoted path matches no role surface.
     out = subprocess.run(
-        ["git", "-C", str(root), "diff", "--name-only", "--no-color", *git_args],
+        ["git", "-C", str(root), "diff", "--name-only", "-z", "--no-color", *git_args],
         capture_output=True,
         encoding="utf-8",
         errors="replace",
         check=True,
     )
-    return [line for line in out.stdout.splitlines() if line]
+    return nul_paths(out.stdout)
 
 
 def touches_role_surface(paths: list[str]) -> bool:

--- a/scripts/check_comment_narration.py
+++ b/scripts/check_comment_narration.py
@@ -31,6 +31,8 @@ import sys
 from pathlib import PurePosixPath
 from typing import NamedTuple
 
+from _git_paths import diff_header_name
+
 _PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"RESULTS[-/]"), "delegation handoff artifact (RESULTS/ or RESULTS-Pn)"),
     # Capitalised only: ADR narration always writes "Phase N"; ordinary prose
@@ -86,9 +88,9 @@ def find_violations(diff_text: str) -> list[Violation]:
         if not in_hunk and raw.startswith("+++ "):
             # Header only before a section's first @@ -- inside a hunk an added
             # "++..." line renders identically and must be scanned, not misread
-            # as one. Strip git's disambiguation tab from a space-bearing path.
-            name = raw[4:]
-            path = name[2:].split("\t", 1)[0] if name.startswith("b/") else None
+            # as one.
+            name = diff_header_name(raw[4:])
+            path = name[2:] if name.startswith("b/") else None
             continue
         if raw.startswith("@@"):
             m = re.match(r"@@ -\S+ \+(\d+)", raw)

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -476,7 +476,11 @@ def run_checks(root: Path, tracked: list[str]) -> list[str]:
 
 
 def _git(root: Path, *args: str) -> str:
-    proc = subprocess.run(["git", "-C", str(root), *args], capture_output=True, text=True, check=True)
+    # encoding pinned, not locale-derived: a -z listing carries raw path bytes,
+    # and under LANG=C a non-ASCII one would raise instead of being classified.
+    proc = subprocess.run(
+        ["git", "-C", str(root), *args], capture_output=True, encoding="utf-8", errors="replace", check=True
+    )
     return proc.stdout
 
 

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -57,6 +57,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from _git_paths import nul_paths
+
 BOOTSTRAP_BUDGET = 10_240
 ADAPTER_BUDGET = 8_192
 POLICY_BUDGET = 12_288
@@ -504,16 +506,16 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if not args.all:
             diff_args = (
-                ["diff", "--cached", "--name-only"] if args.staged else ["diff", "--name-only", f"{args.diff}...HEAD"]
+                ["diff", "--cached", "--name-only", "-z"]
+                if args.staged
+                else ["diff", "--name-only", "-z", f"{args.diff}...HEAD"]
             )
-            changed = _git(root, "-c", "core.quotePath=off", *diff_args).split("\n")
-            if not touches_context_surface([c for c in changed if c]):
+            if not touches_context_surface(nul_paths(_git(root, *diff_args))):
                 print("context-budget: no context surface in the diff — skipped")
                 return 0
-        # quotePath=off: a non-ASCII filename would otherwise come back
-        # C-quoted ("…") and silently match no budget.
-        tracked = _git(root, "-c", "core.quotePath=off", "ls-files").split("\n")
-        tracked = [t for t in tracked if t]
+        # -z: git C-quotes any path holding a quote, backslash, control byte or
+        # (by default) a non-ASCII byte, and a quoted path matches no budget.
+        tracked = nul_paths(_git(root, "ls-files", "-z"))
         if args.staged:
             # Validate the INDEX snapshot, not the working tree: staged and
             # worktree content can diverge, and the commit ships the index.

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -198,7 +198,9 @@ def main(argv: list[str] | None = None) -> int:
         # (issues #2137, #2212). A newline-separated stream still works, so the
         # positional/`echo`-piped entry points keep classifying identically.
         stdin = sys.stdin.read()
-        paths = stdin.split("\0") if "\0" in stdin else stdin.splitlines()
+        # split("\n"), not splitlines(): the latter also breaks on \f, \x85 and
+        # the Unicode line separators, which are ordinary path bytes here.
+        paths = stdin.split("\0") if "\0" in stdin else stdin.split("\n")
     paths = [p.strip() for p in paths if p.strip()]
 
     if warn_only and body_file is not None:

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -10,7 +10,7 @@ job in ``.github/workflows/test.yml`` (see the ``coverage-pairing`` job) — nev
 in ``.githooks/pre-commit``, because pre-commit only ever sees ONE commit's
 staged files, not the whole PR's diff against its base; the pairing question
 ("did this PR's *src* change ship *any* test?") is only answerable with the full
-PR diff, which is what the CI job computes via ``git diff --name-only
+PR diff, which is what the CI job computes via ``git diff --name-only -z
 origin/<base>...HEAD`` and pipes into this script over stdin.
 
 THE TWO RULES
@@ -166,10 +166,11 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entry point.
 
     Positional args are changed paths (used by tests); with none, changed paths
-    are read newline-separated from stdin — how the CI job pipes
-    ``git diff --name-only`` output in. Both entry points are normalized the
-    same way (surrounding whitespace stripped, blank entries dropped), so a
-    padded positional arg and a trailing-newline stdin line classify identically.
+    are read from stdin — NUL-separated as the CI job pipes ``git diff
+    --name-only -z`` output in, newline-separated otherwise. Every entry point is
+    normalized the same way (surrounding whitespace stripped, blank entries
+    dropped), so a padded positional arg and a trailing-newline stdin line
+    classify identically.
 
     ``--pr-body-file <path>`` (passed by the CI job iff the ``no-test-needed``
     label is set, alongside ``--warn-only``): the file holds the PR body; when

--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -191,7 +191,13 @@ def main(argv: list[str] | None = None) -> int:
     paths = [a for a in args if a != "--warn-only"]
 
     if not paths:
-        paths = list(sys.stdin)
+        # NUL-separated is the CI job's transport (`git diff --name-only -z`):
+        # the newline form C-quotes a path holding a quote, backslash, control
+        # byte or non-ASCII byte, and a quoted path matches no rule at all
+        # (issues #2137, #2212). A newline-separated stream still works, so the
+        # positional/`echo`-piped entry points keep classifying identically.
+        stdin = sys.stdin.read()
+        paths = stdin.split("\0") if "\0" in stdin else stdin.splitlines()
     paths = [p.strip() for p in paths if p.strip()]
 
     if warn_only and body_file is not None:

--- a/scripts/check_retired_tokens.py
+++ b/scripts/check_retired_tokens.py
@@ -85,6 +85,8 @@ import re
 import subprocess
 import sys
 
+from _git_paths import diff_header_name
+
 # Tracked-tree roots a retiring commit is expected to have fixed everywhere.
 _SCAN_ROOTS = ("src", "scripts", ".github/workflows")
 
@@ -145,14 +147,14 @@ def _parse_diff(diff_text: str) -> tuple[dict[str, list[str]], dict[str, list[st
             continue
         if not in_hunk:
             if raw.startswith("--- "):
-                name = raw[4:]
+                name = diff_header_name(raw[4:])
                 if name.startswith("a/"):
-                    a_path = name[2:].split("\t", 1)[0]
+                    a_path = name[2:]
             elif raw.startswith("+++ "):
-                name = raw[4:]
+                name = diff_header_name(raw[4:])
                 if name.startswith("b/"):
-                    path = name[2:].split("\t", 1)[0]
-                elif name.split("\t", 1)[0] == "/dev/null":
+                    path = name[2:]
+                elif name == "/dev/null":
                     path = a_path
             continue
         if path is None or not _in_scan_roots(path):

--- a/scripts/check_version_literals.py
+++ b/scripts/check_version_literals.py
@@ -77,6 +77,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from _git_paths import diff_header_name
+
 # Each alternative is a full-value token shape (anchored once, at the
 # alternation, by the two call sites below). Unambiguous shapes (ABI/php/py/
 # varver) are version-AGNOSTIC -- any restated literal is a drift hazard
@@ -511,8 +513,8 @@ def _added_lines_by_path(diff_text: str) -> dict[str, set[int]]:
             continue
         if not in_hunk:
             if raw.startswith("+++ "):
-                name = raw[4:]
-                path = name[2:].split("\t", 1)[0] if name.startswith("b/") else None
+                name = diff_header_name(raw[4:])
+                path = name[2:] if name.startswith("b/") else None
             continue  # header block: '---'/'index'/etc. never carry added content
         if raw.startswith("+"):
             if path is not None:

--- a/tests/shell/precommit_hostile_path_spec.sh
+++ b/tests/shell/precommit_hostile_path_spec.sh
@@ -63,6 +63,7 @@ Describe '.githooks/pre-commit with a C-quoted path'
       'has"quote'
       'has\backslash'
       "$(printf 'has\ttab')"
+      "$(printf 'has\nnewline')"
       "$(printf 'has\001control')"
       'café'
     End

--- a/tests/shell/precommit_hostile_path_spec.sh
+++ b/tests/shell/precommit_hostile_path_spec.sh
@@ -1,11 +1,12 @@
 #shellcheck shell=sh
-# .githooks/pre-commit stage classification: git C-quotes a staged path that holds
-# a double quote, a backslash or a control byte, so the hook's suffix regexes
-# (`\.(php|inc)$` and friends) match nothing and that commit's language gates
-# silently never run (issue #2212). The 'plain' row is the control — it already
-# passed before the fix, so a green hostile row is not a probe artefact.
+# .githooks/pre-commit and C-quoted paths: git C-quotes a path that holds a double
+# quote, a backslash, a control byte or (by default) a non-ASCII byte, so the
+# hook's suffix regexes match nothing and the tracked-file scans read nothing —
+# that commit's language gates silently never run and its shebang goes unchecked
+# (issue #2212). The 'plain' row is the control: it already passed before the fix,
+# so a green hostile row is not a probe artefact.
 
-Describe '.githooks/pre-commit stage classification'
+Describe '.githooks/pre-commit with a C-quoted path'
   gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
 
   make_repo() {
@@ -17,37 +18,62 @@ Describe '.githooks/pre-commit stage classification'
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
 
     # Stubs stand in for the real analysis tools: this spec pins WHICH gates the
-    # hook decides to run, not what they conclude.
+    # hook decides to run and what its own scans see, not what those tools conclude.
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommithostilestub.XXXXXX")"
     php_marker="$stubdir/php-ran"
     printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$php_marker" > "$stubdir/php"
-    for interpreter in python python3; do
-      printf '#!/bin/sh\nexit 0\n' > "$stubdir/$interpreter"
-      chmod +x "$stubdir/$interpreter"
+    chmod +x "$stubdir/php"
+    for tool in python python3 shellcheck shellspec markdownlint-cli2; do
+      printf '#!/bin/sh\nexit 0\n' > "$stubdir/$tool"
+      chmod +x "$stubdir/$tool"
     done
     printf '#!/bin/sh\nexit 0\n' > "$repo/vendor/bin/phpstan"
     printf '#!/bin/sh\nexit 0\n' > "$repo/vendor/bin/phpcs"
-    chmod +x "$stubdir/php" "$repo/vendor/bin/phpstan" "$repo/vendor/bin/phpcs"
+    chmod +x "$repo/vendor/bin/phpstan" "$repo/vendor/bin/phpcs"
     PATH="$stubdir:$PATH"
   }
   cleanup() { rm -rf "$repo" "$stubdir"; }
   Before 'make_repo'
   After 'cleanup'
 
-  Parameters
-    'plain'
-    'has"quote'
-    'has\backslash'
-    "$(printf 'has\ttab')"
-    "$(printf 'has\nnewline')"
+  Describe 'stage classification'
+    Parameters
+      'plain'
+      'has"quote'
+      'has\backslash'
+      "$(printf 'has\ttab')"
+      "$(printf 'has\nnewline')"
+      "$(printf 'has\001control')"
+      'café'
+    End
+
+    It "runs the PHP gates for a staged file named '$1'"
+      printf '<?php echo 1;\n' > "$repo/src/$1.php"
+      gitc add -A
+      When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+      The status should equal 0
+      The output should include '[pre-commit] php -l'
+      Assert [ -e "$php_marker" ]
+    End
   End
 
-  It "runs the PHP gates for a staged file named '$1'"
-    printf '<?php echo 1;\n' > "$repo/src/$1.php"
-    gitc add -A
-    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
-    The status should equal 0
-    The output should include '[pre-commit] php -l'
-    Assert [ -e "$php_marker" ]
+  Describe 'shebang policy scan'
+    Parameters
+      'plain'
+      'has"quote'
+      'has\backslash'
+      "$(printf 'has\ttab')"
+      "$(printf 'has\001control')"
+      'café'
+    End
+
+    It "rejects a bash shebang in a tracked file named '$1'"
+      printf '#!/bin/bash\necho hi\n' > "$repo/src/$1.sh"
+      gitc add -A
+      When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+      The status should equal 1
+      The stderr should include 'bash shebang not allowed'
+      The output should include '[pre-commit] shebang policy'
+    End
   End
 End

--- a/tests/shell/precommit_hostile_path_spec.sh
+++ b/tests/shell/precommit_hostile_path_spec.sh
@@ -1,0 +1,53 @@
+#shellcheck shell=sh
+# .githooks/pre-commit stage classification: git C-quotes a staged path that holds
+# a double quote, a backslash or a control byte, so the hook's suffix regexes
+# (`\.(php|inc)$` and friends) match nothing and that commit's language gates
+# silently never run (issue #2212). The 'plain' row is the control — it already
+# passed before the fix, so a green hostile row is not a probe artefact.
+
+Describe '.githooks/pre-commit stage classification'
+  gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+
+  make_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommithostile.XXXXXX")"
+    git_fixture -C "$repo" init -q
+    gitc config commit.gpgsign false
+    mkdir -p "$repo/.githooks" "$repo/src" "$repo/vendor/bin"
+    cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+
+    # Stubs stand in for the real analysis tools: this spec pins WHICH gates the
+    # hook decides to run, not what they conclude.
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommithostilestub.XXXXXX")"
+    php_marker="$stubdir/php-ran"
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$php_marker" > "$stubdir/php"
+    for interpreter in python python3; do
+      printf '#!/bin/sh\nexit 0\n' > "$stubdir/$interpreter"
+      chmod +x "$stubdir/$interpreter"
+    done
+    printf '#!/bin/sh\nexit 0\n' > "$repo/vendor/bin/phpstan"
+    printf '#!/bin/sh\nexit 0\n' > "$repo/vendor/bin/phpcs"
+    chmod +x "$stubdir/php" "$repo/vendor/bin/phpstan" "$repo/vendor/bin/phpcs"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup() { rm -rf "$repo" "$stubdir"; }
+  Before 'make_repo'
+  After 'cleanup'
+
+  Parameters
+    'plain'
+    'has"quote'
+    'has\backslash'
+    "$(printf 'has\ttab')"
+    "$(printf 'has\nnewline')"
+  End
+
+  It "runs the PHP gates for a staged file named '$1'"
+    printf '<?php echo 1;\n' > "$repo/src/$1.php"
+    gitc add -A
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include '[pre-commit] php -l'
+    Assert [ -e "$php_marker" ]
+  End
+End

--- a/tests/test_issue2137_coverage_pairing_quotepath.py
+++ b/tests/test_issue2137_coverage_pairing_quotepath.py
@@ -136,15 +136,20 @@ def test_the_changed_file_list_holds_the_real_path(tmp_path: Path) -> None:
     """
     repo = _scratch_repo(tmp_path, NON_ASCII_SRC)
     _run_gate(repo)
-    listed = (repo / "changed.txt").read_text(encoding="utf-8").strip()
+    listed = (repo / "changed.txt").read_text(encoding="utf-8").strip("\0\n")
     assert listed == NON_ASCII_SRC, f"changed.txt holds {listed!r}, not the real path"
-    assert not listed.startswith('"'), "path is quoted: core.quotePath is not disabled"
-    assert "\\303" not in listed, "path is octal-escaped: core.quotePath is not disabled"
+    assert not listed.startswith('"'), "path is quoted: the listing is not NUL-separated"
+    assert "\\303" not in listed, "path is octal-escaped: the listing is not NUL-separated"
 
 
-def test_the_workflow_disables_quotepath_on_its_own_command() -> None:
-    """The fix lives on the command, so a rewrite that drops the flag fails here."""
+def test_the_workflow_emits_a_nul_separated_listing() -> None:
+    """The fix lives on the command, so a rewrite that drops -z fails here.
+
+    ``-z`` supersedes the original ``core.quotePath=false`` pin: that flag only
+    stopped HIGH-BIT bytes being escaped, leaving a quote/backslash/control byte
+    in a path quoted anyway (issue #2212).
+    """
     command = _compute_command()
-    assert re.search(r"\bgit\s+-c\s+core\.quotePath=false\b", command), (
-        f"changed-file computation must disable core.quotePath: {command!r}"
+    assert re.search(r"\bgit\s+diff\s+--name-only\s+-z\b", command), (
+        f"changed-file computation must emit NUL-separated paths: {command!r}"
     )

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -1,0 +1,263 @@
+"""Changed-file gates must classify a path git C-quotes, never skip it silently.
+
+git wraps a path in double quotes and C-escapes it whenever the path holds a
+double quote, a backslash or a control byte (tab, newline). That quoting is
+unconditional: ``core.quotePath=false`` only stops HIGH-BIT bytes being escaped,
+so the fix for the non-ASCII class left this one open (issue #2212). Every gate
+covered here classifies a changed path by prefix or suffix, so a quoted path
+matches no rule at all — its file skips the gate while the job still reports a
+clean pass.
+
+Each test drives the gate the way CI or the hook drives it, over a scratch
+repository holding one hostile path, and asserts the gate SEES that file. The
+``plain`` row is the control: it already passed before the fix, so a green
+hostile row cannot be explained away by the probe shape.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from tests._workflow_steps import extract_step
+from tests.gitenv import scrubbed_git_env
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+
+
+def _load(name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, ROOT / "scripts" / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+car = _load("check_agent_roles")
+ccb = _load("check_context_budget")
+crt = _load("check_retired_tokens")
+
+# One filename stem per escape class git applies, plus an ASCII control. The
+# non-ASCII stem is the class the earlier fix closed — it must stay closed.
+HOSTILE_STEMS = {
+    "plain": "plain",
+    "quote": 'has"quote',
+    "backslash": "has\\backslash",
+    "tab": "has\ttab",
+    "newline": "has\nnewline",
+    "non-ascii": "café",
+}
+QUOTED_CLASSES = [name for name in HOSTILE_STEMS if name != "plain"]
+
+
+def _git(*args: str, cwd: Path) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+        errors="surrogateescape",
+        env=scrubbed_git_env(drop_git_vars=True),
+    )
+    return proc.stdout
+
+
+def _scratch_repo(tmp_path: Path, files: dict[str, str]) -> Path:
+    """A repo whose HEAD adds ``files`` on top of a base commit tagged ``devel``.
+
+    ``refs/remotes/origin/devel`` is written directly rather than standing up a
+    second repository to clone from — the gates only ever name it as a diff base.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", cwd=repo)
+    _git("config", "user.email", "test@example.invalid", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    _git("config", "commit.gpgsign", "false", cwd=repo)
+
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git("add", "README.md", cwd=repo)
+    _git("commit", "-m", "base", cwd=repo)
+    _git("update-ref", "refs/remotes/origin/devel", _git("rev-parse", "HEAD", cwd=repo).strip(), cwd=repo)
+    _git("branch", "-f", "devel", "HEAD", cwd=repo)
+
+    for rel, content in files.items():
+        target = repo / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "add the hostile path", cwd=repo)
+    return repo
+
+
+def _step_body(step_name: str) -> str:
+    """The shell of a workflow step, read from the YAML rather than retyped.
+
+    Retyping would let the workflow drift away from the test while both stayed
+    green, so the ``run:`` block is extracted from the file CI executes.
+    """
+    body = extract_step(WORKFLOW.read_text(encoding="utf-8"), step_name)
+    _, marker, script = body.partition("run: |\n")
+    assert marker, f"step {step_name!r} has no run: block"
+    return textwrap.dedent(script)
+
+
+# ── coverage-pairing (the src<->tests gate) ──────────────────────────────────
+
+
+def _compute_command() -> str:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    matches = [line.strip() for line in text.splitlines() if "diff --name-only" in line and "changed.txt" in line]
+    assert len(matches) == 1, f"expected exactly one changed-file computation, got {matches}"
+    return matches[0]
+
+
+def _run_coverage_pairing(repo: Path) -> subprocess.CompletedProcess[bytes]:
+    subprocess.run(
+        ["sh", "-euc", _compute_command()],
+        cwd=repo,
+        check=True,
+        env={"PATH": "/usr/bin:/bin", "BASE": "devel", "HOME": str(repo)},
+        capture_output=True,
+    )
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "check_coverage_pairing.py")],
+        input=(repo / "changed.txt").read_bytes(),
+        capture_output=True,
+    )
+
+
+@pytest.mark.parametrize("klass", list(HOSTILE_STEMS))
+def test_an_unpaired_src_change_fails_the_coverage_pairing_gate(tmp_path: Path, klass: str) -> None:
+    """A src/ change shipping no test fails the gate whatever bytes its path carries."""
+    rel = f"src/usr/local/pkg/pfblockerng/{HOSTILE_STEMS[klass]}.inc"
+    result = _run_coverage_pairing(_scratch_repo(tmp_path, {rel: "x\n"}))
+    assert result.returncode == 1, (
+        f"{klass}: unpaired {rel!r} passed the coverage-pairing gate (rc={result.returncode}); stdout={result.stdout!r}"
+    )
+    assert b"coverage pairing violated" in result.stdout.lower()
+
+
+# ── bash-shebang gate (tracked-file listing) ─────────────────────────────────
+
+
+@pytest.mark.parametrize("klass", list(HOSTILE_STEMS))
+def test_a_bash_shebang_is_rejected_whatever_the_path(tmp_path: Path, klass: str) -> None:
+    """The shebang gate reads every tracked file, including a C-quoted one."""
+    rel = f"scripts/{HOSTILE_STEMS[klass]}.sh"
+    repo = _scratch_repo(tmp_path, {rel: "#!/bin/bash\necho hi\n"})
+    result = subprocess.run(
+        ["sh", "-c", _step_body("Forbid bash shebangs")],
+        cwd=repo,
+        capture_output=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(repo)},
+    )
+    assert result.returncode == 1, (
+        f"{klass}: bash shebang in {rel!r} passed the gate (rc={result.returncode}); stdout={result.stdout!r}"
+    )
+
+
+# ── diff-header parsers (+++ b/<path>) ───────────────────────────────────────
+
+
+def _run_checker(script: str, repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / script), *args],
+        cwd=repo,
+        capture_output=True,
+        encoding="utf-8",
+        errors="surrogateescape",
+        env=scrubbed_git_env(drop_git_vars=True),
+    )
+
+
+@pytest.mark.parametrize("klass", list(HOSTILE_STEMS))
+def test_comment_narration_reads_a_hostile_path(tmp_path: Path, klass: str) -> None:
+    """Process narration added to a C-quoted path is still a violation."""
+    rel = f"scripts/{HOSTILE_STEMS[klass]}.py"
+    repo = _scratch_repo(tmp_path, {rel: "# Phase 4: wire the thing\nx = 1\n"})
+    result = _run_checker("check_comment_narration.py", repo, "--diff", "devel")
+    assert result.returncode == 1, (
+        f"{klass}: narration in {rel!r} passed the gate (rc={result.returncode}); stderr={result.stderr!r}"
+    )
+    assert "ADR phase narration" in result.stderr
+
+
+@pytest.mark.parametrize("klass", list(HOSTILE_STEMS))
+def test_version_literals_reads_a_hostile_path(tmp_path: Path, klass: str) -> None:
+    """A hardcoded version literal added to a C-quoted path is still a violation."""
+    rel = f"scripts/{HOSTILE_STEMS[klass]}.sh"
+    repo = _scratch_repo(tmp_path, {rel: '#!/bin/sh\nabi="FreeBSD:14"\necho "$abi"\n'})
+    result = _run_checker("check_version_literals.py", repo, "--diff", "devel")
+    assert result.returncode == 1, (
+        f"{klass}: version literal in {rel!r} passed the gate (rc={result.returncode}); stdout={result.stdout!r}"
+    )
+
+
+@pytest.mark.parametrize("klass", list(HOSTILE_STEMS))
+def test_retired_tokens_maps_a_hostile_path_to_its_real_name(
+    tmp_path: Path, klass: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The diff parser keys added lines by the real path, not the quoted header.
+
+    A path that never enters the per-path maps contributes no removed lines, so
+    its retirement is invisible to the straggler search. Driven through the
+    tool's OWN diff command so the assertion covers its transport, not a
+    hand-rolled one.
+    """
+    rel = f"scripts/{HOSTILE_STEMS[klass]}.sh"
+    repo = _scratch_repo(tmp_path, {rel: "#!/bin/sh\necho retired_probe\n"})
+    monkeypatch.chdir(repo)
+    _, added = crt._parse_diff(crt._git_diff(["devel...HEAD"]))
+    assert rel in added, f"{klass}: parsed paths {sorted(added)} do not include {rel!r}"
+
+
+# ── --name-only listings ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("klass", QUOTED_CLASSES)
+def test_agent_roles_changed_paths_are_real_paths(tmp_path: Path, klass: str) -> None:
+    """A C-quoted role-surface path must still trigger role validation."""
+    rel = f".agents/policy/{HOSTILE_STEMS[klass]}.md"
+    repo = _scratch_repo(tmp_path, {rel: "text\n"})
+    changed = car._changed_paths(repo, ["devel...HEAD"])
+    assert rel in changed, f"{klass}: changed paths {changed} do not include {rel!r}"
+    assert car.touches_role_surface(changed)
+
+
+@pytest.mark.parametrize("klass", QUOTED_CLASSES)
+def test_context_budget_does_not_skip_a_hostile_context_surface(
+    tmp_path: Path, klass: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A C-quoted policy file must not read as "no context surface in the diff".
+
+    The skip short-circuits before any budget is measured, so a quoted path
+    silently exempts the whole run rather than one file.
+    """
+    rel = f".agents/policy/{HOSTILE_STEMS[klass]}.md"
+    repo = _scratch_repo(tmp_path, {rel: "text\n"})
+    ccb.main(["--diff", "devel", "--root", str(repo)])
+    assert "no context surface in the diff" not in capsys.readouterr().out, (
+        f"{klass}: {rel!r} was classified as no context surface"
+    )
+
+
+def test_every_changed_file_gate_reads_a_nul_separated_listing() -> None:
+    """The gates that transport a path list use -z, the only quote-proof form.
+
+    Pins the cause, not just the symptom: a rewrite that drops -z and goes back
+    to newline-separated output re-opens every row above at once.
+    """
+    assert re.search(r"\bgit\s+diff\s+--name-only\s+-z\b", _compute_command()), _compute_command()
+    shebang = _step_body("Forbid bash shebangs")
+    assert re.search(r"\bgit\s+ls-files\s+-z\b", shebang), shebang

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -54,6 +54,10 @@ HOSTILE_STEMS = {
     "backslash": "has\\backslash",
     "tab": "has\ttab",
     "newline": "has\nnewline",
+    # A control byte outside git's named-escape set (\a\b\f\n\r\t\v) is escaped
+    # in OCTAL, and that stays true under core.quotePath=false — this row is the
+    # only one that reaches the octal decode path.
+    "control-byte": "has\x01control",
     "non-ascii": "café",
 }
 QUOTED_CLASSES = [name for name in HOSTILE_STEMS if name != "plain"]
@@ -156,8 +160,10 @@ def test_a_bash_shebang_is_rejected_whatever_the_path(tmp_path: Path, klass: str
     """The shebang gate reads every tracked file, including a C-quoted one."""
     rel = f"scripts/{HOSTILE_STEMS[klass]}.sh"
     repo = _scratch_repo(tmp_path, {rel: "#!/bin/bash\necho hi\n"})
+    # bash -e is the shell GitHub gives a `run:` block with no `shell:` keyword;
+    # running the step under anything else would not exercise its real wiring.
     result = subprocess.run(
-        ["sh", "-c", _step_body("Forbid bash shebangs")],
+        ["bash", "-e", "-c", _step_body("Forbid bash shebangs")],
         cwd=repo,
         capture_output=True,
         env={"PATH": "/usr/bin:/bin", "HOME": str(repo)},

--- a/tests/test_issue2212_hostile_path_gates.py
+++ b/tests/test_issue2212_hostile_path_gates.py
@@ -206,8 +206,11 @@ def test_version_literals_reads_a_hostile_path(tmp_path: Path, klass: str) -> No
     repo = _scratch_repo(tmp_path, {rel: '#!/bin/sh\nabi="FreeBSD:14"\necho "$abi"\n'})
     result = _run_checker("check_version_literals.py", repo, "--diff", "devel")
     assert result.returncode == 1, (
-        f"{klass}: version literal in {rel!r} passed the gate (rc={result.returncode}); stdout={result.stdout!r}"
+        f"{klass}: version literal in {rel!r} passed the gate (rc={result.returncode}); stderr={result.stderr!r}"
     )
+    # rc 1 alone would also cover an uncaught crash; the report line is what
+    # proves the gate reached a verdict about this file.
+    assert "Hardcoded pfSense/FreeBSD version literal" in result.stderr, result.stderr
 
 
 @pytest.mark.parametrize("klass", list(HOSTILE_STEMS))


### PR DESCRIPTION
Fixes #2212

Closes the escape class `core.quotePath=false` never covered.

git C-quotes a path whenever it holds a double quote, a backslash or a control
byte (tab, newline). That quoting is unconditional — `core.quotePath` only
governs whether high-bit bytes are escaped as well — so #2211's fix for the
non-ASCII class left this one wide open. Every changed-file gate in the repo
classifies by prefix or suffix, so a quoted path matches no rule at all: the
file skips the gate and the job still reports a clean pass.

## Approach

Transport, not classifier. The gates keep judging real bytes strictly; the
wiring is what changed.

| Site | Fix |
| --- | --- |
| `test.yml` coverage-pairing | `git diff --name-only -z`; `check_coverage_pairing.py` splits stdin on NUL (a newline-separated stream still classifies identically, so the red canary and the positional entry point are unchanged) |
| `test.yml` bash-shebang gate | `git ls-files -z \| xargs -0`; the vendored-tree exemption moved inside the loop, since `grep` cannot see NULs |
| `scripts/check_context_budget.py` | `-z` on both the changed-file diff and `ls-files` |
| `scripts/check_agent_roles.py` | `-z` on the changed-file diff (it had no `core.quotePath` pin at all) |
| `scripts/check_comment_narration.py` | header decode |
| `scripts/check_version_literals.py` | header decode |
| `scripts/check_retired_tokens.py` | header decode (both `+++ b/` and the deleted-file `--- a/` path) |
| `.githooks/pre-commit` | `-z \| tr` for the stage classification |

A unified diff's `+++`/`---` header has no `-z` form, so the three diff parsers
decode the header instead, through one new shared helper
(`scripts/_git_paths.py`). The helper also resolves octal escapes, so it closes
the non-ASCII class independently of any `core.quotePath` setting — which is why
the coverage-pairing command drops that now-redundant pin in favour of `-z`.

`.codex/hooks.json` re-pins the `check_retired_tokens.py` integrity SHA-256.

## Tests

`tests/test_issue2212_hostile_path_gates.py` drives each gate the way CI or the
hook drives it, over a scratch repository holding one hostile path, parametrized
over every escape class (quote, backslash, tab, newline, non-ASCII) plus a plain
ASCII control row. `tests/shell/precommit_hostile_path_spec.sh` does the same for
the pre-commit hook's stage classification.

Red→green, executed on the untouched base (`3e10109c`) via a detached worktree
holding the frozen test files, re-run after every review round so the numbers
describe the FINAL artifacts:

| Artifact | `git hash-object` | Base (red) | With the fix (green) |
| --- | --- | --- | --- |
| `tests/test_issue2212_hostile_path_gates.py` | `e24f63a679d2ecefd76a72a921f16da571ef57ed` | 38 failed, 10 passed | 48 passed |
| `tests/shell/precommit_hostile_path_spec.sh` | `2a3826c486ce577d0c5cda5613b7151d8c168eda` | 12 failed of 14 | 14 passed |

Both files are byte-identical between the two runs. The rows that pass on the
base are the plain-ASCII controls plus the classes the `#2137` fix already
closed — a green hostile row therefore cannot be a probe artefact.
`tests/test_issue2137_*` follows the coverage-pairing transport change and still
pins the non-ASCII class.

Full suites: `pytest` 4921 passed / 4 skipped; `shellspec` 1241 examples, 0
failures; `ruff check`, `ruff format --check`, `mypy tests/` clean.

## Deliberately out of scope

The same tree-wide sweep found two more `--name-only` consumers that are
developer tooling rather than PR gates — `scripts/agent/run-gates.sh` (local gate
selection) and `scripts/impacted-tests.sh` (test selection). Both have the same
blind spot, neither has an existing git-fixture spec, and shipping the one-line
transport swap untested would violate the coverage mandate. Tracked separately
in #2228.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository checks and automation to correctly handle filenames containing spaces, quotes, backslashes, control characters, newlines, tabs, and non-ASCII characters.
  - Prevented changed-file analysis from skipping or misclassifying files with unusual names.
  - Preserved accurate Bash shebang, coverage, comment, version, token, role, and context checks.

- **Tests**
  - Added broad regression coverage for special-character paths across local hooks and continuous integration checks.
  - Verified safe and complete changed-file detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->