### PR TITLE
agent: hand run-gates.sh and impacted-tests.sh real paths (#2228)

### DIFF
--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -35,6 +35,17 @@ usage() {
 # no pipefail), turning a bad --diff ref into an empty file list instead of an error.
 git_paths() {
 	git -C "$worktree" "$@" > "$paths_tmp" || return 1
+	# A literal newline in a path cannot survive a line-based list: split on NUL it
+	# tears into fragments, so the tail gates a path that does not exist while the
+	# real file loses its `scripts/` prefix and is never shellchecked. -z output
+	# holds a newline byte ONLY in that case, so refuse it here and let the caller
+	# exit rather than act on a fabricated path. (No in-band sentinel: every byte
+	# but NUL and `/` is legal in a path, so a substituted marker would collide --
+	# a name containing \1 is exactly such a case.)
+	if tr -cd '\n' < "$paths_tmp" | grep -q ''; then
+		printf 'run-gates.sh: a changed path contains a newline; cannot map it to gates\n' >&2
+		return 1
+	fi
 	tr '\0' '\n' < "$paths_tmp"
 }
 
@@ -133,7 +144,9 @@ main() {
 
 	# Created with builtins only (no mktemp -- not POSIX, and this script's minimal-PATH
 	# contract is pinned by agent_run_gates_spec.sh). `set -C` makes the redirect fail
-	# rather than follow a planted file or symlink at the predictable name. `true >`,
+	# rather than follow a planted file or symlink at the predictable name; the writes
+	# in git_paths() are unguarded, so the residual swap window is bounded by /tmp's
+	# sticky bit, not by this check. `true >`,
 	# never `: >`: a redirection error on the SPECIAL builtin `:` exits the shell
 	# outright instead of yielding to `||` (issues #1172, #1850).
 	paths_tmp="${TMPDIR:-/tmp}/pfb-run-gates-paths.$$"

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -26,6 +26,18 @@ usage() {
 	exit 2
 }
 
+# Emit one real path per line from a `git ... -z` listing. The newline form C-quotes
+# any path holding a quote, backslash, control byte or non-ASCII byte, and the quoted
+# form matches no extension in gates_for() -- that file would select no gate at all
+# and the run would report a clean pass (issue #2228). A shell variable cannot hold a
+# NUL, so the listing lands in a temp file first: that keeps the caller's `|| exit 2`
+# watching GIT's status rather than tr's, which a pipeline would swallow (POSIX sh has
+# no pipefail), turning a bad --diff ref into an empty file list instead of an error.
+git_paths() {
+	git -C "$worktree" "$@" > "$paths_tmp" || return 1
+	tr '\0' '\n' < "$paths_tmp"
+}
+
 # Map a touched-file list (stdin, one path per line) to gate commands (stdout, one per
 # line). Per-file gates (php -l, sh -n, shellcheck) emit one command per touched file.
 gates_for() {
@@ -119,16 +131,27 @@ main() {
 	require_tool git
 	[ -n "$worktree" ] || worktree=$(git rev-parse --show-toplevel) || exit 2
 
+	# Created with builtins only (no mktemp -- not POSIX, and this script's minimal-PATH
+	# contract is pinned by agent_run_gates_spec.sh). `set -C` makes the redirect fail
+	# rather than follow a planted file or symlink at the predictable name. `true >`,
+	# never `: >`: a redirection error on the SPECIAL builtin `:` exits the shell
+	# outright instead of yielding to `||` (issues #1172, #1850).
+	paths_tmp="${TMPDIR:-/tmp}/pfb-run-gates-paths.$$"
+	( set -C; true > "$paths_tmp" ) || exit 2
+	trap 'rm -f "$paths_tmp"' EXIT
+	# dash runs no EXIT trap on an untrapped signal, so reap explicitly there too.
+	trap 'rm -f "$paths_tmp"; trap - EXIT; exit 130' INT TERM
+
 	# --diff-filter=ACMR: a pure deletion stages nothing to lint (same rule as the
 	# pre-commit hook) -- per-file gates against ghost paths would always fail.
-	committed=$(git -C "$worktree" diff --name-only --diff-filter=ACMR "$base...HEAD") || exit 2
+	committed=$(git_paths diff --name-only -z --diff-filter=ACMR "$base...HEAD") || exit 2
 	# issue #1293: union with uncommitted changes, else gates see nothing pre-commit.
 	# staged/unstaged unioned SEPARATELY, not via one `diff HEAD` -- `diff <commit>`
 	# reads the WORKING TREE, so a staged-then-worktree-reverted file is invisible.
-	staged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR --cached) || exit 2
-	unstaged=$(git -C "$worktree" diff --name-only --diff-filter=ACMR) || exit 2
+	staged=$(git_paths diff --name-only -z --diff-filter=ACMR --cached) || exit 2
+	unstaged=$(git_paths diff --name-only -z --diff-filter=ACMR) || exit 2
 	# neither diff form surfaces a brand-new file never `git add`ed.
-	untracked=$(git -C "$worktree" ls-files --others --exclude-standard) || exit 2
+	untracked=$(git_paths ls-files -z --others --exclude-standard) || exit 2
 	files=$(printf '%s\n%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" "$untracked" | LC_ALL=C sort -u | grep -v '^$')
 	# The shellspec gate must also fire when only spec files changed (cross-language
 	# consumers rule): specs are .sh files, so the extension mapping already covers it.

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -11,6 +11,10 @@
 #   --plan           print the gate commands that WOULD run, one per line, and exit
 #   --allow-missing  a missing tool reports SKIP without failing the run (default: fails)
 #
+# Exits 2 without running anything when a changed path holds a literal newline: such a
+# path cannot be carried by a line-based file list, and gating a torn fragment would lint
+# a path that does not exist while leaving the real file unchecked.
+#
 # Per-gate lines `GATE PASS|FAIL|SKIP: <cmd>`; a FAILING gate additionally prints its own
 # captured stdout+stderr immediately before its `GATE FAIL` line (a passing gate stays
 # fully suppressed); final line `GATES: PASS|FAIL`. Exit 0 only when nothing failed (and

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -9,7 +9,9 @@
 #                     any uncommitted (staged+unstaged+untracked, .gitignore-filtered)
 #                     changes vs HEAD (default origin/devel)
 #   --plan           print the gate commands that WOULD run, one per line, and exit
-#   --allow-missing  a missing tool reports SKIP without failing the run (default: fails)
+#   --allow-missing  a missing tool reports SKIP without failing the run (default: fails).
+#                    The Composer vendor checker is exempt: a missing interpreter there
+#                    FAILS regardless, so the PHP gates can never silently skip.
 #
 # Exits 2 without running anything when a changed path holds a literal newline: such a
 # path cannot be carried by a line-based file list, and gating a torn fragment would lint
@@ -157,7 +159,8 @@ main() {
 	( set -C; true > "$paths_tmp" ) || exit 2
 	trap 'rm -f "$paths_tmp"' EXIT
 	# dash runs no EXIT trap on an untrapped signal, so reap explicitly there too.
-	trap 'rm -f "$paths_tmp"; trap - EXIT; exit 130' INT TERM
+	trap 'rm -f "$paths_tmp"; trap - EXIT; exit 130' INT
+	trap 'rm -f "$paths_tmp"; trap - EXIT; exit 143' TERM
 
 	# --diff-filter=ACMR: a pure deletion stages nothing to lint (same rule as the
 	# pre-commit hook) -- per-file gates against ghost paths would always fail.

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -77,6 +77,7 @@ check_fixture_manifest() {
                 "$path" "$expected" "$actual" >> "$TMPF"
         fi
     done <<'EOF'
+agent_run_gates_git_spec.sh:2
 agent_run_gates_spec.sh:4
 agent_work_branch_spec.sh:5
 composer_cloud_install_spec.sh:4
@@ -84,6 +85,7 @@ git_no_docs_spec.sh:5
 githooks_pre_push_lease_spec.sh:33
 githooks_pre_push_tag_scheme_spec.sh:28
 githooks_prepare_commit_msg_guard_spec.sh:18
+impacted_tests_spec.sh:2
 pfblockerng_truncate_survival_spec.sh:4
 precommit_composer_vendor_spec.sh:2
 read_version_matrix_test_spec.sh:5

--- a/scripts/impacted-tests.sh
+++ b/scripts/impacted-tests.sh
@@ -34,7 +34,11 @@ else
 	# Three-dot: files changed on HEAD since the merge-base with BASE_REF.
 	# Tolerate a missing/unfetched base ref — an empty diff routes the caller to
 	# the safe full-marker path rather than erroring the run.
-	changed="$(git diff --name-only "${base}...HEAD" 2>/dev/null || true)"
+	# -z + tr: the newline form C-quotes a path holding a quote, backslash, control
+	# byte or non-ASCII byte, and the quoted form matches neither the "$dir"/test_*.py
+	# prefix nor the .py suffix — that module would drop out of the derived -k
+	# expression and simply never run (issue #2228).
+	changed="$(git diff --name-only -z "${base}...HEAD" 2>/dev/null | tr '\0' '\n' || true)"
 fi
 
 # Build the OR expression in a subshell fed by the pipe; the trailing printf runs

--- a/scripts/impacted-tests.sh
+++ b/scripts/impacted-tests.sh
@@ -37,8 +37,19 @@ else
 	# -z + tr: the newline form C-quotes a path holding a quote, backslash, control
 	# byte or non-ASCII byte, and the quoted form matches neither the "$dir"/test_*.py
 	# prefix nor the .py suffix — that module would drop out of the derived -k
-	# expression and simply never run (issue #2228).
+	# expression and simply never run (issue #2228). A missing/unfetched base ref
+	# still yields an empty list (git's failure is silenced, and tr then exits 0),
+	# routing the caller to its safe full-marker path.
 	changed="$(git diff --name-only -z "${base}...HEAD" 2>/dev/null | tr '\0' '\n' || true)"
+	# A path holding a literal newline tears into fragments matching neither the dir
+	# prefix nor the .py suffix, so that module would vanish from the expression
+	# while its siblings still narrowed the run. Detect it on the RAW NUL-separated
+	# stream, which carries a newline byte only in that case (no in-band sentinel is
+	# possible -- every byte but NUL and `/` is legal in a path), and emit nothing:
+	# empty routes the caller to its full-marker path, which runs everything.
+	if git diff --name-only -z "${base}...HEAD" 2>/dev/null | tr -cd '\n' | grep -q ''; then
+		changed=''
+	fi
 fi
 
 # Build the OR expression in a subshell fed by the pipe; the trailing printf runs

--- a/scripts/impacted-tests.sh
+++ b/scripts/impacted-tests.sh
@@ -8,8 +8,9 @@
 # the module name — so a dispatcher gets "only the tests I created/touched" for
 # free, with no coverage map to maintain.
 #
-# Empty output = no changed test modules under TEST_DIR. The caller then runs the
-# whole marker (a SAFE over-approximation — never under-runs), and the dispatcher
+# Empty output = no changed test modules under TEST_DIR, OR a changed path holding
+# a literal newline, which cannot be named in a `-k` expression at all. The caller then
+# runs the whole marker (a SAFE over-approximation — never under-runs), and the dispatcher
 # can pass an explicit `-k` to narrow to the tests covering changed NON-test code
 # (which a live-VM suite can't map automatically — the code runs on the guest,
 # out of any runner-side coverage).

--- a/tests/shell/agent_run_gates_git_spec.sh
+++ b/tests/shell/agent_run_gates_git_spec.sh
@@ -1,0 +1,79 @@
+#shellcheck shell=sh
+# run-gates.sh reads its touched-file list from git, and git C-quotes a path holding
+# a quote, backslash, control byte or non-ASCII byte. The quoted form matches no
+# extension in gates_for(), so NO gate is selected for that file and the run reports
+# a clean pass (issue #2228). The 'plain' row is the control: it already passed
+# before the fix, so a green hostile row is not a probe artefact.
+#
+# The sibling agent_run_gates_spec.sh pins gates_for() itself through the
+# AGENT_SOURCE_ONLY seam with no repository; these examples cover the git-reading
+# path that seam bypasses.
+
+Describe 'run-gates.sh over a C-quoted path'
+  SCRIPT="${PFB_ROOT}/scripts/agent/run-gates.sh"
+  gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+
+  make_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/rungateshostile.XXXXXX")"
+    git_fixture -C "$repo" init -q
+    gitc config commit.gpgsign false
+    mkdir -p "$repo/scripts"
+    printf 'base\n' > "$repo/README.md"
+    gitc add README.md
+    gitc commit -q -m base
+    gitc branch -f base HEAD
+  }
+  cleanup() { rm -rf "$repo"; }
+  Before 'make_repo'
+  After 'cleanup'
+
+  Describe 'aggregate gates'
+    Parameters
+      'plain'
+      'has"quote'
+      'has\backslash'
+      "$(printf 'has\ttab')"
+      "$(printf 'has\nnewline')"
+      "$(printf 'has\001control')"
+      'café'
+    End
+
+    It "selects the Python gates for a committed file named '$1'"
+      printf 'x = 1\n' > "$repo/scripts/$1.py"
+      gitc add -A
+      gitc commit -q -m hostile
+      When run sh "$SCRIPT" --worktree "$repo" --diff base --plan
+      The status should equal 0
+      The output should include 'python3 -m pytest'
+      The output should include 'ruff check .'
+      The stderr should equal ''
+    End
+  End
+
+  Describe 'per-file gates keep their injection guard'
+    # gates_for() deliberately drops a metacharacter-bearing path from the php -l /
+    # sh -n / shellcheck buckets, because run_gate re-parses those through `sh -c`.
+    # Handing it the REAL path must make that guard fire loudly -- the defect is the
+    # quoted path reaching it as a no-match and producing silence instead.
+    It 'reports an unsafe filename for a shell script whose name needs quoting'
+      printf '#!/bin/sh\necho hi\n' > "$repo/scripts/has\"quote.sh"
+      gitc add -A
+      gitc commit -q -m hostile
+      When run sh "$SCRIPT" --worktree "$repo" --diff base --plan
+      The status should equal 0
+      The output should include 'unsafe filename in diff'
+    End
+
+    It 'still emits the per-file gates for an ordinary shell script' # control
+      printf '#!/bin/sh\necho hi\n' > "$repo/scripts/plain.sh"
+      gitc add -A
+      gitc commit -q -m plain
+      When run sh "$SCRIPT" --worktree "$repo" --diff base --plan
+      The status should equal 0
+      The output should include 'sh -n scripts/plain.sh'
+      The output should include 'shellcheck scripts/plain.sh'
+      The output should not include 'unsafe filename in diff'
+    End
+  End
+End

--- a/tests/shell/agent_run_gates_git_spec.sh
+++ b/tests/shell/agent_run_gates_git_spec.sh
@@ -29,12 +29,13 @@ Describe 'run-gates.sh over a C-quoted path'
   After 'cleanup'
 
   Describe 'aggregate gates'
+    # No newline row here: such a path makes git_paths refuse the entire run, which
+    # the 'refuses the run' example below pins directly.
     Parameters
       'plain'
       'has"quote'
       'has\backslash'
       "$(printf 'has\ttab')"
-      "$(printf 'has\nnewline')"
       "$(printf 'has\001control')"
       'café'
     End
@@ -74,6 +75,33 @@ Describe 'run-gates.sh over a C-quoted path'
       The output should include 'sh -n scripts/plain.sh'
       The output should include 'shellcheck scripts/plain.sh'
       The output should not include 'unsafe filename in diff'
+    End
+
+    # A literal newline is the one byte a line-based path list cannot carry: split
+    # naively it yields fragments that gate a path which does not exist while the
+    # real file goes unlinted. Refusing is the only honest answer -- no in-band
+    # sentinel can stand in for it, since every byte but NUL and `/` is a legal
+    # path byte (the control-byte row above is exactly such a name).
+    It 'refuses the run when a changed path holds a newline'
+      printf '#!/bin/sh\necho hi\n' > "$repo/scripts/$(printf 'has\nnewline').sh"
+      gitc add -A
+      gitc commit -q -m hostile
+      When run sh "$SCRIPT" --worktree "$repo" --diff base --plan
+      The status should equal 2
+      The stderr should include 'contains a newline'
+      The output should not include 'sh -n newline.sh'
+      The output should not include 'shellcheck newline.sh'
+    End
+
+    # --plan always exits 0, so the guard's exit path needs its own example.
+    It 'fails the run for an unsafe filename outside --plan'
+      printf '#!/bin/sh\necho hi\n' > "$repo/scripts/has\"quote.sh"
+      gitc add -A
+      gitc commit -q -m hostile
+      When run sh "$SCRIPT" --worktree "$repo" --diff base --allow-missing
+      The status should equal 1
+      The output should include 'unsafe filename in diff'
+      The output should include 'GATES: FAIL'
     End
   End
 End

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -147,7 +147,11 @@ Describe 'run-gates.sh Composer vendor guard'
     printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$phpunit_marker" > "$repo/vendor/bin/phpunit"
     chmod +x "$stubdir/python3" "$stubdir/php" "$stubdir/composer" "$repo/vendor/bin/phpunit"
     ln -s "$(command -v git)" "$stubdir/git"
-    for tool in cat dirname grep sh sort; do
+    # The minimal-PATH contract for the script's own machinery: POSIX utilities only,
+    # never an optional toolchain. `tr` and `rm` joined it with the NUL-separated path
+    # listing and its temp file (issue #2228) -- that file is created with builtins
+    # rather than mktemp, but reaping it needs `rm`.
+    for tool in cat dirname grep rm sh sort tr; do
       ln -s "$(command -v "$tool")" "$stubdir/$tool"
     done
     PATH="$stubdir:$PATH"

--- a/tests/shell/git_fixture_manifest_spec.sh
+++ b/tests/shell/git_fixture_manifest_spec.sh
@@ -3,13 +3,15 @@
 
 Describe 'git fixture sweep manifest'
   GUARD="${PFB_ROOT}/scripts/git-env-scrub-guard.sh"
-  SWEPT_SPECS='agent_run_gates_spec.sh
+  SWEPT_SPECS='agent_run_gates_git_spec.sh
+agent_run_gates_spec.sh
 agent_work_branch_spec.sh
 composer_cloud_install_spec.sh
 git_no_docs_spec.sh
 githooks_pre_push_lease_spec.sh
 githooks_pre_push_tag_scheme_spec.sh
 githooks_prepare_commit_msg_guard_spec.sh
+impacted_tests_spec.sh
 pfblockerng_truncate_survival_spec.sh
 precommit_composer_vendor_spec.sh
 read_version_matrix_test_spec.sh

--- a/tests/shell/impacted_tests_spec.sh
+++ b/tests/shell/impacted_tests_spec.sh
@@ -44,4 +44,46 @@ tests/smoke/ui/test_render.py"
       The output should equal 'test_render'
     End
   End
+
+  # The PFB_IMPACTED_CHANGED_FILES seam above bypasses git entirely, so these
+  # examples cover the git-reading branch. git C-quotes a path holding a quote,
+  # backslash, control byte or non-ASCII byte, and the quoted form matches neither
+  # the "$dir"/test_*.py prefix nor the .py suffix -- the module drops out of the
+  # derived -k expression and simply never runs (issue #2228). The 'plain' row is
+  # the control.
+  Describe 'changed-file list read from git'
+    gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+
+    make_repo() {
+      scrub_git_env
+      repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/impactedhostile.XXXXXX")"
+      git_fixture -C "$repo" init -q
+      gitc config commit.gpgsign false
+      mkdir -p "$repo/tests/smoke"
+      printf 'base\n' > "$repo/README.md"
+      gitc add README.md
+      gitc commit -q -m base
+      gitc branch -f base HEAD
+    }
+    cleanup_repo() { rm -rf "$repo"; }
+    Before 'make_repo'
+    After 'cleanup_repo'
+
+    Parameters
+      'plain'
+      'has\backslash'
+      "$(printf 'has\ttab')"
+      "$(printf 'has\001control')"
+      'café'
+    End
+
+    It "selects a changed test module named 'test_$1.py'"
+      printf 'def test_x():\n    pass\n' > "$repo/tests/smoke/test_$1.py"
+      gitc add -A
+      gitc commit -q -m hostile
+      When run sh -c "cd '$repo' && sh '$SCRIPT' base tests/smoke"
+      The status should equal 0
+      The output should equal "test_$1"
+    End
+  End
 End

--- a/tests/shell/impacted_tests_spec.sh
+++ b/tests/shell/impacted_tests_spec.sh
@@ -69,21 +69,37 @@ tests/smoke/ui/test_render.py"
     Before 'make_repo'
     After 'cleanup_repo'
 
-    Parameters
-      'plain'
-      'has\backslash'
-      "$(printf 'has\ttab')"
-      "$(printf 'has\001control')"
-      'café'
+    Describe 'each escape class git quotes'
+      Parameters
+        'plain'
+        'has\backslash'
+        "$(printf 'has\ttab')"
+        "$(printf 'has\001control')"
+        'café'
+      End
+
+      It "selects a changed test module named 'test_$1.py'"
+        printf 'def test_x():\n    pass\n' > "$repo/tests/smoke/test_$1.py"
+        gitc add -A
+        gitc commit -q -m hostile
+        When run sh -c "cd '$repo' && sh '$SCRIPT' base tests/smoke"
+        The status should equal 0
+        The output should equal "test_$1"
+      End
     End
 
-    It "selects a changed test module named 'test_$1.py'"
-      printf 'def test_x():\n    pass\n' > "$repo/tests/smoke/test_$1.py"
+    # A literal newline cannot be expressed as a -k stem at all, so the module must
+    # NOT be quietly dropped from a narrowed expression: emitting nothing routes the
+    # caller to its full-marker path, which runs everything. The sibling module is
+    # what makes this failable -- without it the expression would be empty anyway.
+    It 'emits nothing when a changed path holds a newline, so the caller runs it all'
+      printf 'def test_x():\n    pass\n' > "$repo/tests/smoke/test_$(printf 'has\nnewline').py"
+      printf 'def test_y():\n    pass\n' > "$repo/tests/smoke/test_sibling.py"
       gitc add -A
       gitc commit -q -m hostile
       When run sh -c "cd '$repo' && sh '$SCRIPT' base tests/smoke"
       The status should equal 0
-      The output should equal "test_$1"
+      The output should equal ''
     End
   End
 End


### PR DESCRIPTION
Fixes #2228

The two changed-file consumers left out of #2229, now closed the same way.

Both read git's newline listing, which C-quotes any path holding a quote, backslash, control byte or non-ASCII byte. The quoted form matches no extension in `run-gates.sh`'s `gates_for()`, so no gate is selected for that file and the run reports a clean pass; in `impacted-tests.sh` it matches neither the `"$dir"/test_*.py` prefix nor the `.py` suffix, so the module drops out of the derived `-k` expression and never runs.

## Approach

Both now read `-z` listings.

`impacted-tests.sh` is a one-line `-z | tr` swap. `run-gates.sh` needed more care: a shell variable cannot hold a NUL, and `$(git … | tr)` would put each caller's `|| exit 2` on `tr`'s status rather than git's — POSIX sh has no `pipefail`, so a bad `--diff` ref would silently become an empty file list, which is the same silent-pass class this issue is about. The listing therefore lands in a temp file and the status check stays on git.

Two details that a shorter version would have got wrong, both caught by existing repo guards rather than by me:

- The temp file is created with builtins under `set -C`, not `mktemp` — `mktemp` is not POSIX, and `agent_run_gates_spec.sh` pins a minimal-PATH contract for the script's own machinery.
- `true >`, never `: >`: a redirection error on the **special** builtin `:` exits a non-interactive shell outright instead of yielding to `||`. `pfblockerng_truncate_survival_spec.sh` caught this (issues #1172, #1850).

`gates_for()`'s injection guard is deliberately left intact. Handing it a real metacharacter-bearing path makes it fire loudly and drop that file from the `php -l` / `sh -n` / `shellcheck` buckets — that is correct and is pinned as its own example. The defect was the quoted path arriving as a silent no-match instead.

`tr` and `rm` join the minimal-PATH allowlist. Both are POSIX; the contract still admits no optional toolchain.

## Tests

Neither git-reading path had any coverage: `agent_run_gates_spec.sh` drives `gates_for()` through the `AGENT_SOURCE_ONLY` seam with no repository, and `impacted_tests_spec.sh` feeds its list through the `PFB_IMPACTED_CHANGED_FILES` seam. Both bypass git entirely. The new examples use scratch repositories, parametrized over every escape class plus a plain-ASCII control row.

Red→green, executed on the untouched base (`de30758d`) via a detached worktree holding the frozen spec files, re-run after the review round so the numbers describe the FINAL artifacts:

| Artifact | `git hash-object` | Base (red) | With the fix (green) |
| --- | --- | --- | --- |
| `tests/shell/agent_run_gates_git_spec.sh` | `8a89ccc57d76a1a3f9700d536e8f9624582a58d4` | 13 failed of 20, both controls green | 11 passed |
| `tests/shell/impacted_tests_spec.sh` | `9a4bb41e8c62f6e7921a61d5d4e0641d3f2d4c26` | (same run) | 9 passed |

Both files are byte-identical between the two runs. Both new fixtures are registered in the two `git_fixture` manifest guards (`scripts/git-env-scrub-guard.sh` and `tests/shell/git_fixture_manifest_spec.sh`), whose own spec passes.

Full suites: `shellspec` 1236 examples, 0 failures, 0 warnings, 8 skips; `pytest` 4853 passed / 4 skipped; `shellcheck` and `sh -n` clean. Live self-check: the fixed `run-gates.sh --diff origin/devel --plan` correctly plans gates over this branch's own diff.

## Note on scope

A path holding a literal **newline** is handled by refusal, not by classification. No in-band sentinel can stand in for that byte — every byte except NUL and `/` is legal in a path, so any substituted marker collides with a real name, and the control-byte row in these specs is exactly such a name. `run-gates.sh` therefore refuses the run (exit 2, loud) and `impacted-tests.sh` emits nothing, which routes its caller to the full-marker path that runs everything. Both are fail-closed; neither fabricates a gate for a path that does not exist.

`impacted-tests.sh` emits a bare stem into a pytest `-k` expression, and pytest's expression parser accepts only a subset of the bytes a filename may hold. Probed: `café` and `has\backslash` compile; a tab or a control byte raises `SyntaxError`; a quote is rejected likewise. So for those classes the fix moves the failure from a **silent omission** to a **loud dispatch error** — better, but not a clean selection, and the coverage claim above holds to the script's own boundary rather than through pytest. A module named that way is not importable by pytest either, so there is nothing to select in the first place. The newline class is handled separately above, by emitting nothing.

An adjacent site outside this issue's scope — `tests/php/LogNowTokenRetiredTest.php`, which enumerates tracked files with PHP `exec()` over the newline listing — is tracked separately in #2235.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
