### PR TITLE
smoke: retry pkg add through the guest's boot-time database lock

### DIFF
--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -82,6 +82,39 @@ ssh_t() {
     ssh ${SSH_OPTS} "$SSH_TARGET" /bin/sh -c "$_sq"
 }
 
+
+# issue #2237: a first-boot pfSense runs its own pkg(8) activity, and `pkg add`
+# then dies on "Cannot get an exclusive lock on a database" (observed on the
+# containerized runner fleet, run 31229687348). Retry ONLY that signature,
+# bounded per the waits policy: hard attempt cap, loud DISTINCT give-up. Any
+# other pkg-add failure (e.g. "Missing dependency") stays immediate — see the
+# header: those mean a bad image/dep set, and retrying would just mask them.
+# Seams (spec-only): PFB_INSTALL_PKG_RETRY_MAX / PFB_INSTALL_PKG_RETRY_DELAY.
+PKG_LOCK_RETRY_MAX="${PFB_INSTALL_PKG_RETRY_MAX:-12}"
+PKG_LOCK_RETRY_DELAY="${PFB_INSTALL_PKG_RETRY_DELAY:-5}"
+
+pkg_add_lock_retry() {
+    _pkg_remote=$1
+    _try=1
+    while true; do
+        _rc=0
+        _out=$(ssh_t "env ASSUME_ALWAYS_YES=yes pkg add '${_pkg_remote}'" 2>&1) || _rc=$?
+        if [ -n "$_out" ]; then printf '%s\n' "$_out"; fi
+        if [ "$_rc" -eq 0 ]; then return 0; fi
+        case "$_out" in
+            *'Cannot get an exclusive lock on a database'* | *'Package database is busy'*) ;;
+            *) return "$_rc" ;;
+        esac
+        if [ "$_try" -ge "$PKG_LOCK_RETRY_MAX" ]; then
+            echo "install-pkg: guest pkg database still locked after ${PKG_LOCK_RETRY_MAX} attempts — giving up (issue #2237)" >&2
+            return "$_rc"
+        fi
+        echo "install-pkg: guest pkg database locked (boot-time pkg activity); retry ${_try}/${PKG_LOCK_RETRY_MAX} in ${PKG_LOCK_RETRY_DELAY}s" >&2
+        _try=$((_try + 1))
+        sleep "$PKG_LOCK_RETRY_DELAY"
+    done
+}
+
 REMOTE="/tmp/$(basename "$PKGFILE")"
 
 # issue #1806 D2: install any SMOKE_DEP_PKGS FIRST, in the given order. `set -eu`
@@ -95,7 +128,7 @@ for _dep in ${SMOKE_DEP_PKGS:-}; do
     # shellcheck disable=SC2086
     scp ${SCP_OPTS} "$_dep" "${SSH_TARGET}:${_dep_remote}"
     echo "==> pkg add ${_dep_remote} (dep, from SMOKE_DEP_PKGS)"
-    ssh_t "env ASSUME_ALWAYS_YES=yes pkg add '${_dep_remote}'"
+    pkg_add_lock_retry "$_dep_remote"
 done
 
 echo "==> Copying $(basename "$PKGFILE") to ${SSH_TARGET}:${REMOTE}"
@@ -107,7 +140,7 @@ scp ${SCP_OPTS} "$PKGFILE" "${SSH_TARGET}:${REMOTE}"
 # pfBlockerNG's RUN_DEPENDS (convention), so this runs offline and then executes
 # the package's POST-INSTALL hooks. A "Missing dependency" error here = bad image.
 echo "==> pkg add ${REMOTE} (deps pre-baked; offline)"
-ssh_t "env ASSUME_ALWAYS_YES=yes pkg add '${REMOTE}'"
+pkg_add_lock_retry "$REMOTE"
 
 # POST-INSTALL restarts Unbound asynchronously; wait for it before the caller
 # queries the resolver (see feedback: poll the real readiness signal).

--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -92,6 +92,20 @@ ssh_t() {
 # Seams (spec-only): PFB_INSTALL_PKG_RETRY_MAX / PFB_INSTALL_PKG_RETRY_DELAY.
 PKG_LOCK_RETRY_MAX="${PFB_INSTALL_PKG_RETRY_MAX:-12}"
 PKG_LOCK_RETRY_DELAY="${PFB_INSTALL_PKG_RETRY_DELAY:-5}"
+# A non-integer cap makes the -ge comparison silently FALSE and the loop
+# unbounded — the same trap publish-pkg-repo.sh guards its MAX_PUSH_ATTEMPTS
+# against. Reject bad values before any ssh/sleep runs; 0 delay is valid.
+case "$PKG_LOCK_RETRY_MAX" in '' | *[!0-9]*) PKG_LOCK_RETRY_MAX=0 ;; esac
+[ "$PKG_LOCK_RETRY_MAX" -ge 1 ] || {
+    echo "install-pkg: PFB_INSTALL_PKG_RETRY_MAX must be a positive integer" >&2
+    exit 1
+}
+case "$PKG_LOCK_RETRY_DELAY" in
+    *[!0-9]*)
+        echo "install-pkg: PFB_INSTALL_PKG_RETRY_DELAY must be a non-negative integer" >&2
+        exit 1
+        ;;
+esac
 
 pkg_add_lock_retry() {
     _pkg_remote=$1

--- a/tests/shell/install_pkg_spec.sh
+++ b/tests/shell/install_pkg_spec.sh
@@ -45,6 +45,22 @@ printf '%s\n' "$_a" >> "$SSH_LOG"
 case "$_a" in
     *unbound-control*) exit 0 ;;
 esac
+# Lock mode (issue #2237): while $WORK/lock.remaining holds N > 0, each pkg add
+# decrements it and fails with the REAL guest lock signature (observed verbatim
+# in run 31229687348) -- the transient/persistent lock cases drive this.
+case "$_a" in
+    *"pkg add"*)
+        if [ -f "${WORK}/lock.remaining" ]; then
+            _n=$(cat "${WORK}/lock.remaining")
+            if [ "$_n" -gt 0 ]; then
+                echo $((_n - 1)) > "${WORK}/lock.remaining"
+                echo "pkg: Package database is busy while closing!" >&2
+                echo "pkg: Cannot get an exclusive lock on a database, it is locked by another process" >&2
+                exit 1
+            fi
+        fi
+        ;;
+esac
 case "$_a" in
     *"${FAIL_PKG_ADD_MATCH:-__pfb_never_match__}"*) exit 1 ;;
 esac
@@ -113,6 +129,46 @@ SCPEOF
     The contents of file "$SCP_LOG" should include "$DEP1"
     The contents of file "$SCP_LOG" should not include "$DEP2"
     The contents of file "$SCP_LOG" should not include "$PKGFILE"
+    The result of function pkg_add_count should equal 1
+  End
+
+  # ── issue #2237: the guest pkg database can be locked by first-boot pkg activity ── #
+
+  It 'retries through a transient guest pkg-database lock and installs'
+    # The defect: one boot-time lock collision failed the whole deploy (run
+    # 31229687348). Two locked attempts then a free database must succeed.
+    echo 2 > "${WORK}/lock.remaining"
+    PFB_INSTALL_PKG_RETRY_DELAY=0
+    export PFB_INSTALL_PKG_RETRY_DELAY
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be success
+    # 2 locked attempts + the succeeding one, all for the same branch pkg.
+    The result of function pkg_add_count should equal 3
+    The stderr should include 'retry 1/'
+    The stderr should include 'retry 2/'
+  End
+
+  It 'gives up loudly after the bounded retry cap when the lock never clears'
+    echo 99 > "${WORK}/lock.remaining"
+    PFB_INSTALL_PKG_RETRY_DELAY=0
+    PFB_INSTALL_PKG_RETRY_MAX=3
+    export PFB_INSTALL_PKG_RETRY_DELAY PFB_INSTALL_PKG_RETRY_MAX
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be failure
+    The result of function pkg_add_count should equal 3
+    # The give-up is DISTINCT from an ordinary pkg-add failure and names the cap.
+    The stderr should include 'still locked after 3 attempts'
+    The stderr should include 'issue #2237'
+    The stdout should include 'Cannot get an exclusive lock'
+  End
+
+  It 'never retries a non-lock pkg-add failure'
+    FAIL_PKG_ADD_MATCH="$(basename "$PKGFILE")"
+    PFB_INSTALL_PKG_RETRY_DELAY=0
+    export FAIL_PKG_ADD_MATCH PFB_INSTALL_PKG_RETRY_DELAY
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be failure
+    # A missing-dependency-style failure is not a lock: exactly one attempt.
     The result of function pkg_add_count should equal 1
   End
 End

--- a/tests/shell/install_pkg_spec.sh
+++ b/tests/shell/install_pkg_spec.sh
@@ -162,6 +162,37 @@ SCPEOF
     The stdout should include 'Cannot get an exclusive lock'
   End
 
+  It 'rejects a non-integer retry cap before touching the guest'
+    # A bad cap would make the -ge comparison silently false and the retry
+    # loop unbounded — refuse it up front, before any scp/ssh runs.
+    PFB_INSTALL_PKG_RETRY_MAX=abc
+    export PFB_INSTALL_PKG_RETRY_MAX
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be failure
+    The stderr should include 'PFB_INSTALL_PKG_RETRY_MAX must be a positive integer'
+    The contents of file "$SCP_LOG" should equal ''
+  End
+
+  It 'rejects a non-integer retry delay before touching the guest'
+    PFB_INSTALL_PKG_RETRY_DELAY=1.5
+    export PFB_INSTALL_PKG_RETRY_DELAY
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be failure
+    The stderr should include 'PFB_INSTALL_PKG_RETRY_DELAY must be a non-negative integer'
+    The contents of file "$SCP_LOG" should equal ''
+  End
+
+  It 'honours the minimum cap of one attempt'
+    echo 99 > "${WORK}/lock.remaining"
+    PFB_INSTALL_PKG_RETRY_DELAY=0
+    PFB_INSTALL_PKG_RETRY_MAX=1
+    export PFB_INSTALL_PKG_RETRY_DELAY PFB_INSTALL_PKG_RETRY_MAX
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be failure
+    The result of function pkg_add_count should equal 1
+    The stderr should include 'still locked after 1 attempts'
+  End
+
   It 'never retries a non-lock pkg-add failure'
     FAIL_PKG_ADD_MATCH="$(basename "$PKGFILE")"
     PFB_INSTALL_PKG_RETRY_DELAY=0


### PR DESCRIPTION
Fixes #2237

First real containerized smoke run (31229687348) reached the guest and then every test errored at deploy: first-boot pfSense holds the pkg(8) database, and `install-pkg.sh` ran a single unguarded `pkg add`:

```
pkg: Package database is busy while closing!
pkg: Cannot get an exclusive lock on a database, it is locked by another process
```

## What

`pkg_add_lock_retry()` wraps BOTH `pkg add` call sites (deps + branch pkg — one guard in the shared path, not per-caller): retry **only** the lock signature, bounded (12 × 5 s default), with a loud, distinct give-up naming the cap and the issue. Any other failure ("Missing dependency", …) stays immediate per the script's existing contract. Spec seams `PFB_INSTALL_PKG_RETRY_MAX`/`_DELAY`.

## Tests (red→green, executed)

`tests/shell/install_pkg_spec.sh` — the ssh stub gained a lock mode replaying the observed guest signature verbatim:

- transient lock (2 locked attempts, then free) → deploy succeeds, 3 attempts — **RED before** (script died on the first lock), GREEN after; spec byte-identical across the runs (`git hash-object` `164c9e1c…`).
- lock never clears (cap 3) → fails with `still locked after 3 attempts` + `issue #2237` — RED before.
- non-lock failure → exactly one attempt (no-retry pin, green both sides).

Full canonical gates PASS (the first run tripped the `:`-idiom retirement guard in `pfblockerng_truncate_survival_spec.sh` — `while :` → `while true`).

Live Tier-B validation: smoke-single will be re-dispatched from devel after merge (PR CI cannot see this lane).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Package installation now automatically retries temporary package-database lock failures.
  - Retry attempts are bounded and configurable, preventing indefinite installation attempts.
  - Invalid retry settings are detected before installation begins.
  - Non-lock-related installation failures continue to fail immediately.
  - Improved diagnostics are provided when all retry attempts are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->