### PR TITLE
ci: ride ci-runner series 4 and lint workflows with the baked actionlint

### DIFF
--- a/.github/workflows/agent-roles.yml
+++ b/.github/workflows/agent-roles.yml
@@ -29,7 +29,7 @@ jobs:
     name: Agent roles (role registry vs vendor role definitions)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -101,7 +101,7 @@ jobs:
     name: Resolve FreeBSD/PHP for CE ${{ inputs.pfsense_ce_version }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -162,7 +162,7 @@ jobs:
     needs: resolve-version
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:3
+      image: ghcr.io/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -287,7 +287,7 @@ jobs:
     needs: [publish-image, build-pkg]
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:3
+      image: ghcr.io/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -122,7 +122,7 @@ jobs:
     name: build pfBlockerNG .pkg (portable, Linux)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-images.yml
+++ b/.github/workflows/ci-images.yml
@@ -185,6 +185,7 @@ jobs:
             node --version; composer --version
             shellcheck --version | sed -n "s/^version: /shellcheck /p"
             echo "shellspec $(shellspec --version)"
+            echo "actionlint $(actionlint -version | head -n1)"
             kcov --version'
           docker run --rm "${IMAGE_REPO}/ci-runner-vm:${TAG}" sh -c '
             qemu-system-x86_64 --version | head -n1; oras version | head -n2'

--- a/.github/workflows/context-budget.yml
+++ b/.github/workflows/context-budget.yml
@@ -48,7 +48,7 @@ jobs:
     name: Context byte budgets + routing headers
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hsts-refresh.yml
+++ b/.github/workflows/hsts-refresh.yml
@@ -52,7 +52,7 @@ jobs:
     name: Refresh pfb_py_hsts.txt and open PR on change
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -110,7 +110,7 @@ jobs:
     name: Resolve refresh matrix (CE + Plus)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -216,7 +216,7 @@ jobs:
     if: ${{ needs.plan.outputs.count != '0' }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:3
+      image: ghcr.io/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -48,7 +48,7 @@ jobs:
     name: Rebuild + commit module-durations.txt
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -45,7 +45,7 @@ jobs:
        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -129,7 +129,7 @@ jobs:
        github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
     name: Pin inputs and allocate version
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -235,7 +235,7 @@ jobs:
     if: needs.prepare.outputs.outcome == 'build'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -350,7 +350,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -30,7 +30,7 @@ jobs:
     name: Publish the pkg catalogue
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/psl-refresh.yml
+++ b/.github/workflows/psl-refresh.yml
@@ -52,7 +52,7 @@ jobs:
     name: Refresh dnsbl_tld and open PR on change
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -35,7 +35,7 @@ jobs:
     name: Resolve the published tag
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -140,7 +140,7 @@ jobs:
     name: Publish the pkg catalogue
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
     name: Pin the release commit
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -481,7 +481,7 @@ jobs:
     name: Read version matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -597,7 +597,7 @@ jobs:
     name: Resolve build stamp (created + commit)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -657,7 +657,7 @@ jobs:
     name: Create + push the release tag (verified build only)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -734,7 +734,7 @@ jobs:
     name: Create draft GitHub Release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1070,7 +1070,7 @@ jobs:
     name: "build .pkg — ${{ matrix.variant }} ${{ matrix.pfsense_version }}"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1316,7 +1316,7 @@ jobs:
     name: Attach .pkg artifacts to Release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1398,7 +1398,7 @@ jobs:
     name: Health-check the drafted Release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1541,7 +1541,7 @@ jobs:
     name: Sync port on FreeBSD-ports fork
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -47,7 +47,7 @@ jobs:
     name: Gate (skip nightly if devel unchanged)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
     if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -201,7 +201,7 @@ jobs:
     name: All repo-install legs passed (AND gate)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -296,7 +296,7 @@ jobs:
     continue-on-error: ${{ inputs.nonblocking }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:3
+      image: ghcr.io/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -173,7 +173,7 @@ jobs:
     name: Read CI matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -409,7 +409,7 @@ jobs:
     name: All smoke legs passed (AND gate)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -17,7 +17,7 @@ jobs:
     name: Read + print supported-version matrices
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
     name: Read supported-version matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
     name: Test type checking (mypy)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
     name: Ruff (lint + format)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -211,7 +211,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -310,7 +310,7 @@ jobs:
     name: actionlint (workflow files)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -327,22 +327,12 @@ jobs:
         with:
           persist-credentials: false # lint-only job; no git writes
 
-      - name: Install actionlint (pinned; interim download until #2232 bakes it into ci-runner)
+      - name: Lint the workflow files
         # GitHub silently disables a workflow whose YAML its parser rejects (a
         # duplicate mapping key disabled five scheduled workflows — issue #2231);
         # PyYAML-based checks could never see that class. actionlint's own parser
-        # rejects what GitHub rejects, plus expression/schema errors.
-        env:
-          ACTIONLINT_VERSION: 1.7.12
-          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
-        run: |
-          set -eu
-          curl -fsSLo "$RUNNER_TEMP/actionlint.tar.gz" \
-            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          echo "${ACTIONLINT_SHA256}  $RUNNER_TEMP/actionlint.tar.gz" | sha256sum -c -
-          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
-
-      - name: Lint the workflow files
+        # rejects what GitHub rejects, plus expression/schema errors. The binary
+        # is baked into ci-runner (pinned + checksum-verified there, #2232).
         # -shellcheck= : the embedded shellcheck-on-run-bodies pass is disabled —
         # this repo's own ShellCheck gates carry that concern with their tuned
         # scopes, and enabling it here would demand a repo-wide workflow sweep
@@ -352,7 +342,7 @@ jobs:
         # — a silently green gate.
         run: |
           set -eu
-          AL="$RUNNER_TEMP/actionlint"
+          AL=/usr/local/bin/actionlint
           # Red canary: the gate must be able to fail on the exact class that
           # motivated it (a duplicate job-level key) before it grades the tree.
           printf 'on: push\njobs:\n  x:\n    runs-on: ubuntu-latest\n    env:\n      A: "1"\n    env:\n      A: "2"\n    steps:\n      - run: "true"\n' \
@@ -370,7 +360,7 @@ jobs:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -440,7 +430,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -480,7 +470,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -525,7 +515,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -571,7 +561,7 @@ jobs:
     needs: read-matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -620,7 +610,7 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -645,7 +635,7 @@ jobs:
     name: Widget JS unit tests (node --test)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -672,7 +662,7 @@ jobs:
     name: Webassets vendor drift guard + Lezer grammar tests (issue #1669)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -729,7 +719,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_benchmarks }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -796,7 +786,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -899,7 +889,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -940,7 +930,7 @@ jobs:
     needs: [read-matrix, test, test-typing, ruff, shellcheck, actionlint, shell-tests, php-syntax, php-static-analysis, php-codesniffer, php-unit, markdownlint, widget-js-tests, webassets-vendor, ui-suite, coverage-pairing, comment-narration]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -52,7 +52,7 @@ jobs:
     name: Refresh TLD lists and open PR on change
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -33,7 +33,7 @@ jobs:
     name: Discover Top1M providers
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
     needs: discover
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -121,7 +121,7 @@ jobs:
       group: top1m-provider-alert
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -196,7 +196,7 @@ jobs:
       group: top1m-provider-alert
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -233,7 +233,7 @@ jobs:
     name: Resolve the (tier x version) matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -367,7 +367,7 @@ jobs:
     continue-on-error: ${{ matrix.release_blocking == 'false' }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:3
+      image: ghcr.io/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -726,7 +726,7 @@ jobs:
     name: All UI legs passed (AND gate)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -66,7 +66,7 @@ jobs:
     name: Read supported-version matrix
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
     name: React to matrix entries
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/pfblockerng/ci-runner:3
+      image: ghcr.io/pfblockerng/ci-runner:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -271,7 +271,7 @@ jobs:
     name: Daily image reconcile (box as source of truth)
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:3
+      image: ghcr.io/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -135,6 +135,21 @@ def test_env_map_scanner_catches_a_planted_offence() -> None:
 # --------------------------------------------------------------------------- #
 
 
+def test_workflows_pin_the_current_ci_runner_series() -> None:
+    """Every container job must ride the series `.github/docker/VERSION` names —
+    the invariant lost with the retired migration test (PR #2233), resurrected
+    here where CI actually executes it. A stale pin runs a whole job family on
+    an old toolchain while the gates read as green (issue #2232)."""
+    version = int((ROOT / ".github/docker/VERSION").read_text(encoding="utf-8").strip())
+    offenders: list[str] = []
+    for path in _workflow_files():
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for tag in re.findall(r"ghcr\.io/pfblockerng/ci-runner(?:-vm)?:([0-9]+)", line):
+                if int(tag) != version:
+                    offenders.append(f"{path.relative_to(ROOT)}:{line_no}: series {tag} != {version}")
+    assert not offenders, "workflow image pins must match .github/docker/VERSION:\n  " + "\n  ".join(offenders)
+
+
 def test_local_smoke_pins_the_current_ci_runner_series() -> None:
     version = int((ROOT / ".github/docker/VERSION").read_text(encoding="utf-8").strip())
     text = (ROOT / "scripts/local-smoke.sh").read_text(encoding="utf-8")

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -14,8 +14,9 @@ disables silently. These gates cover what actionlint cannot:
    a value reaches the job as a literal dollar-string (schema-legal, so
    actionlint accepts it). Paths derived from runner variables belong in
    ``run:`` bodies.
-2. ``scripts/local-smoke.sh`` runs the same ci-runner image series the
-   workflows pin (``.github/docker/VERSION``) — no other gate scans that file.
+2. Every workflow ``image:`` pin rides the series ``.github/docker/VERSION``
+   names — a stale pin runs a whole job family on an old toolchain silently.
+3. ``scripts/local-smoke.sh`` runs that same series — no other gate scans it.
 """
 
 from __future__ import annotations
@@ -131,7 +132,7 @@ def test_env_map_scanner_catches_a_planted_offence() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# 2. local-smoke.sh runs the pinned image series.
+# 2. Workflows and local-smoke.sh run the pinned image series.
 # --------------------------------------------------------------------------- #
 
 


### PR DESCRIPTION
Fixes #2232 (step 2 of 2; step 1 was PR #2239 — series 4 published by the devel `ci-images` run 31238878234, `success`).

## What

- Repoint all 64 container-image pins across 22 workflows to `ci-runner:4` / `ci-runner-vm:4`.
- test.yml `actionlint` job: drop the interim download step — the baked, checksum-verified binary runs instead (canary + explicit file args unchanged).
- `ci-images.yml` toolchain report logs the baked actionlint version (PR #2239 review nit).
- **New gate:** `test_workflows_pin_the_current_ci_runner_series` — every workflow `image:` tag must equal `.github/docker/VERSION`. This resurrects the invariant lost with the retired migration test, in a module that actually executes in CI, and closes the gap both #2239 reviews flagged.

## Red→green (executed)

The gate's natural red IS the pre-repoint tree: against `origin/devel` workflows (VERSION 4, pins 3) it fails listing all 64 stale pins; against this head it passes. Re-executed on the committed bytes after formatting (`1 failed` on devel workflow bytes → `4 passed` on HEAD, module hash `84fd594d…`). Full canonical gates PASS; local actionlint clean over the repointed tree.

This PR's own CI is the live proof of the baked binary: the actionlint job now runs `/usr/local/bin/actionlint` from `ci-runner:4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
