### PR TITLE
nightly: publish the verified handoff into four-channel nightly catalogues

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -327,13 +327,62 @@ jobs:
           PKG_NAME="$(basename "$PKG")"
           PKG_SHA="$(sha256sum "$PKG" | cut -d' ' -f1)"
           cp "$PKG" "result/$PKG_NAME"
+
+          # issue #1806 B1 / issue #2146 S1: this leg's extra_pkgs dependency
+          # ports (RUN_DEPENDS pfSense CE's own repo doesn't carry, e.g.
+          # textproc/py-charset-normalizer) -- SAME build tool release.yml's
+          # tagged dep-build loop uses, from the SAME ports checkout
+          # build-leg.sh just prepared above (never a second clone). UNLIKE
+          # release.yml, Nightly never renames these: nightly assets keep
+          # their canonical <name>-<version>.pkg filename (publish_catalogues.py
+          # _verify_dependency_asset requires a nightly intake's declared name
+          # to equal the package's own manifest identity).
+          DEP_PKG_DIR="${RUN_ROOT}/${RUN_ID}/deppkgs"
+          DEP_ARTIFACTS_JSON="[]"
+          EXTRA_PKGS="$(jq -c '.extra_pkgs // []' row.json)"
+          ORIGIN_COUNT="$(printf '%s' "$EXTRA_PKGS" | jq 'length // 0')"
+          if [ "$ORIGIN_COUNT" -gt 0 ]; then
+            mkdir -p "$DEP_PKG_DIR"
+            I=0
+            while [ "$I" -lt "$ORIGIN_COUNT" ]; do
+              ORIGIN="$(printf '%s' "$EXTRA_PKGS" | jq -r ".[$I]")"
+              # sparse-clone-ports.sh's checkout only includes the
+              # pfBlockerNG port's OWN RUN_DEPENDS -- extra_pkgs is a
+              # matrix-level concept it doesn't know about, so this origin's
+              # dir was never materialized. Add it explicitly (idempotent;
+              # cone mode already set by sparse-clone-ports.sh).
+              git -C "$PORTS_DIR" sparse-checkout add "$ORIGIN"
+              python3 "$TRUSTED_DIR/scripts/build-dep-pkg-portable.py" \
+                --ports "$PORTS_DIR" \
+                --port "$ORIGIN" \
+                --py-flavor "$PY_FLAVOR" \
+                --freebsd-major "$FREEBSD_MAJOR" \
+                --out-dir "$DEP_PKG_DIR"
+              I=$((I + 1))
+            done
+            for DEP_PKG in "$DEP_PKG_DIR"/*.pkg; do
+              [ -f "$DEP_PKG" ] || continue
+              DEP_NAME="$(basename "$DEP_PKG")"
+              DEP_SHA="$(sha256sum "$DEP_PKG" | cut -d' ' -f1)"
+              cp "$DEP_PKG" "result/$DEP_NAME"
+              DEP_ARTIFACTS_JSON="$(
+                printf '%s' "$DEP_ARTIFACTS_JSON" | jq \
+                  --arg abi "FreeBSD:${FREEBSD_MAJOR}:*" \
+                  --arg name "$DEP_NAME" \
+                  --arg sha256 "$DEP_SHA" \
+                  '. + [{abi: $abi, name: $name, sha256: $sha256}]'
+              )"
+            done
+          fi
+
           jq -n \
             --argjson matrix_row "$MATRIX_ROW" \
             --slurpfile record build-record.json \
             --arg abi "FreeBSD:${FREEBSD_MAJOR}:*" \
             --arg name "$PKG_NAME" \
             --arg sha256 "$PKG_SHA" \
-            '{matrix_row: $matrix_row, record: $record[0], artifact: {abi: $abi, name: $name, sha256: $sha256}}' \
+            --argjson dep_artifacts "$DEP_ARTIFACTS_JSON" \
+            '{matrix_row: $matrix_row, record: $record[0], artifact: {abi: $abi, name: $name, sha256: $sha256}, dep_artifacts: $dep_artifacts}' \
             > result/result.json
 
       - name: Upload verified build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -534,3 +534,99 @@ jobs:
             echo "::error::persisted nightly-state.json does not match the local state document"
             exit 1
           fi
+
+  # ── Publish the pkg catalogue (ADR-17, issue #2146 S3) ──────────────────────
+  # The only production catalogue mutation in the whole Nightly flow. Runs after
+  # the handoff job's own verified handoff succeeds -- never races it, never on
+  # a skipped/failed/unchanged outcome. See scripts/publish-pkg-repo.sh
+  # (PUBLISH_KIND=nightly), the only thing here that touches git.
+  publish-pkg-repo:
+    name: "Publish the pkg catalogue"
+    needs: [prepare, handoff]
+    if: needs.prepare.outputs.outcome == 'build' && needs.handoff.result == 'success'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:4
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --init --user 1001:1001
+    env:
+      HOME: /tmp
+    permissions:
+      packages: read
+      contents: read
+    steps:
+      - name: Checkout trusted workflow tools (the engine + orchestration scripts — TRUSTED ref)
+        uses: actions/checkout@v6
+        with:
+          # SECURITY: publish-pkg-repo.sh below is EXECUTED AS SHELL and, via
+          # publish_nightly.py, holds an App token able to push to
+          # pfBlockerNG/pkg. Same rule as release-published.yml's own
+          # publish-pkg-repo job: pin the revision the workflow's own `prepare`
+          # job already resolved (needs.prepare.outputs.tools_sha), never a
+          # floating ref that could move between this run's start and now.
+          ref: ${{ needs.prepare.outputs.tools_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          path: trusted
+
+      - name: Generate GitHub App token (pkg)
+        id: app-token
+        # Mint a short-lived installation token from the PKG GitHub App, scoped to
+        # pfBlockerNG/pkg with Contents:write. The App installation already holds
+        # "Read and write access to actions, code, and copilot agent settings" —
+        # create-github-app-token NARROWS the minted token to only the permission(s)
+        # listed, so contents:write here (not actions:write) is the whole reason
+        # the token can push code. REQUIRES the App to be installed on pkg with
+        # Contents:write; if it is not, this step fails loudly.
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
+          owner: pfBlockerNG
+          repositories: pkg
+          permission-contents: write
+
+      - name: Checkout pfBlockerNG/pkg
+        uses: actions/checkout@v6
+        with:
+          repository: pfBlockerNG/pkg
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true # publish-pkg-repo.sh pushes via this token
+          path: pkg-repo
+          fetch-depth: 1
+
+      - name: Download verified publisher handoff
+        uses: actions/download-artifact@v7
+        with:
+          name: nightly-handoff-${{ github.run_id }}
+          path: handoff
+
+      - name: Download every BUILD result
+        uses: actions/download-artifact@v7
+        with:
+          pattern: nightly-result-*
+          path: results
+          merge-multiple: false
+
+      - name: Publish the pkg catalogue
+        # Path env vars are exported in the run body, not an env: map — GitHub
+        # Actions never shell-expands env-map values, so `$GITHUB_WORKSPACE`
+        # there would reach the job as a literal dollar-string (issue #2231).
+        run: |
+          set -eu
+          export PFB_SRC="$GITHUB_WORKSPACE/trusted"
+          export PKG_REPO="$GITHUB_WORKSPACE/pkg-repo"
+          export HANDOFF_FILE="$GITHUB_WORKSPACE/handoff/nightly-handoff.json"
+          export RESULTS_DIR="$GITHUB_WORKSPACE/results"
+          export PUBLISH_KIND=nightly
+          # A "re-run failed jobs" click on just this job keeps the SAME
+          # github.run_id but mints a NEW github.run_attempt — publish_nightly.py
+          # rejects that mismatch against the handoff's own recorded run_id
+          # outright (stale-callback doctrine, issue #2146 S2's publish_nightly.py
+          # _validate_handoff). Re-run the WHOLE workflow instead of just this job.
+          export SOURCE_RUN_ID="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          export BASE_URL=https://pfblockerng.github.io/pkg
+          sh trusted/scripts/publish-pkg-repo.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -626,7 +626,17 @@ jobs:
           # github.run_id but mints a NEW github.run_attempt — publish_nightly.py
           # rejects that mismatch against the handoff's own recorded run_id
           # outright (stale-callback doctrine, issue #2146 S2's publish_nightly.py
-          # _validate_handoff). Re-run the WHOLE workflow instead of just this job.
+          # _validate_handoff).
+          #
+          # Re-running the WHOLE workflow does NOT recover a failed publish either:
+          # the handoff job already persisted this run's allocation to
+          # nightly-state.json (nightly-state branch) BEFORE this job ran, so an
+          # identical-input re-run just reallocates outcome=unchanged and skips
+          # build+publish entirely — the snapshot stays RECORDED but UNPUBLISHED.
+          # Interim recovery: delete the stranded record for this run from
+          # nightly-state.json on the nightly-state branch, then re-run the whole
+          # workflow (reallocates, rebuilds, publishes into a clean destination).
+          # The proper republish valve is tracked as issue #2245.
           export SOURCE_RUN_ID="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
           export BASE_URL=https://pfblockerng.github.io/pkg
           sh trusted/scripts/publish-pkg-repo.sh

--- a/scripts/nightly_provenance.py
+++ b/scripts/nightly_provenance.py
@@ -48,6 +48,11 @@ _ARTIFACT_FIELDS = {"abi", "name", "sha256"}
 _SHA = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 _DIGEST = re.compile(r"^[0-9a-f]{64}$")
 _ABI = re.compile(r"^FreeBSD:[0-9]+:(?:[A-Za-z0-9._+-]+|\*)$")
+# Dependency .pkg filename (issue #2146 S1): printable-ASCII segment charset
+# (excludes '/', '\\', control bytes incl. newline) ending in the literal
+# ".pkg" suffix; ".." is rejected separately below (the charset alone would
+# allow it mid-string, e.g. "a..pkg").
+_DEP_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*\.pkg$")
 
 
 @dataclass(frozen=True)
@@ -118,6 +123,43 @@ def _validate_artifacts(value: object) -> list[dict[str, str]]:
             raise ProvenanceError("artifact.sha256 must be lowercase 64-character hex")
         artifacts.append({"abi": abi, "name": name, "sha256": digest})
     return sorted(artifacts, key=lambda item: item["abi"])
+
+
+def _validate_dep_artifacts(value: object, *, leg_abi: str, canonical_name: str) -> list[dict[str, str]]:
+    """Validate one BUILD leg's extra_pkgs dependency .pkgs (issue #2146 S1).
+
+    Unlike _validate_artifacts (the canonical per-leg artifact, unique ABI
+    ACROSS the whole handoff), a leg may ship zero or more dependency
+    packages, all sharing that SAME leg's own wildcard ABI -- uniqueness here
+    is per (abi, name) WITHIN this one leg only, never across the handoff (a
+    different leg/major may legitimately carry a dep .pkg of the same name).
+    Dep names come from build output filenames, so they are untrusted input:
+    reject path separators, "..", control bytes, and anything not ending in
+    the literal ".pkg" suffix.
+    """
+    if not isinstance(value, list):
+        raise ProvenanceError("dep_artifacts must be a list")
+    artifacts: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in value:
+        if not isinstance(item, dict):
+            raise ProvenanceError("dep_artifacts entry must be an object")
+        _exact_fields(item, _ARTIFACT_FIELDS, "dep_artifacts entry")
+        abi, name, digest = item["abi"], item["name"], item["sha256"]
+        if abi != leg_abi:
+            raise ProvenanceError("dep_artifacts entry abi must match the leg's wildcard ABI")
+        if not isinstance(name, str) or ".." in name or not _DEP_NAME.fullmatch(name):
+            raise ProvenanceError("dep_artifacts entry name is unsafe or malformed")
+        if name == canonical_name:
+            raise ProvenanceError("dep_artifacts entry name must not equal the canonical artifact name")
+        if not isinstance(digest, str) or not _DIGEST.fullmatch(digest):
+            raise ProvenanceError("dep_artifacts entry sha256 must be lowercase 64-character hex")
+        key = (abi, name)
+        if key in seen:
+            raise ProvenanceError("dep_artifacts entries must be unique per (abi, name) within a leg")
+        seen.add(key)
+        artifacts.append({"abi": abi, "name": name, "sha256": digest})
+    return sorted(artifacts, key=lambda item: item["name"])
 
 
 def validate_state(state: object) -> dict[str, object]:
@@ -364,7 +406,7 @@ def build_handoff(
     for result in results:
         if not isinstance(result, dict):
             raise ProvenanceError("BUILD result must be an object")
-        if set(result) != {"matrix_row", "record", "artifact"}:
+        if set(result) != {"matrix_row", "record", "artifact", "dep_artifacts"}:
             raise ProvenanceError("BUILD result has unexpected fields")
         row = validate_build_matrix_row(dict(result["matrix_row"]))
         major = str(row["freebsd_major"])
@@ -382,8 +424,13 @@ def build_handoff(
         artifact = _validate_artifacts([result["artifact"]])[0]
         if artifact["name"] != f"pfSense-pkg-pfBlockerNG-{candidate.allocation.pkg_version}.pkg":
             raise ProvenanceError("BUILD artifact name does not match Nightly allocation")
+        dep_artifacts = _validate_dep_artifacts(
+            result["dep_artifacts"],
+            leg_abi=f"FreeBSD:{major}:*",
+            canonical_name=artifact["name"],
+        )
         seen_majors.add(major)
-        builds.append({"matrix_row": row, "record": record, "artifact": artifact})
+        builds.append({"matrix_row": row, "record": record, "artifact": artifact, "dep_artifacts": dep_artifacts})
     if seen_majors != set(expected_rows):
         raise ProvenanceError("BUILD results do not cover every BUILD matrix row")
 

--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -122,8 +122,12 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
     # same idiom as `touched=$(...) || true` further down.
     publish_rc=0
     case "$PUBLISH_KIND" in
+        tagged) publisher_script="publish_release.py" ;;
+        nightly) publisher_script="publish_nightly.py" ;;
+    esac
+    case "$PUBLISH_KIND" in
         tagged)
-            python3 "${PFB_SRC}/scripts/publish_release.py" \
+            python3 "${PFB_SRC}/scripts/${publisher_script}" \
                 --source-repository "$SOURCE_REPOSITORY" \
                 --release-id "$RELEASE_ID" \
                 --release-tag "$RELEASE_TAG" \
@@ -134,7 +138,7 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                 --route-matrix "$ROUTE_MATRIX" >"$out_file" 2>&1 || publish_rc=$?
             ;;
         nightly)
-            python3 "${PFB_SRC}/scripts/publish_nightly.py" \
+            python3 "${PFB_SRC}/scripts/${publisher_script}" \
                 --handoff "$HANDOFF_FILE" \
                 --results-dir "$RESULTS_DIR" \
                 --pkg-repo "$PKG_REPO" \
@@ -142,7 +146,7 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
             ;;
     esac
     if [ "$publish_rc" -ne 0 ]; then
-        echo "::error::publish_${PUBLISH_KIND}.py failed — aborting before any git mutation" >&2
+        echo "::error::${publisher_script} failed — aborting before any git mutation" >&2
         cat "$out_file" >&2
         exit 1
     fi
@@ -172,7 +176,7 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
     # never a freshly re-read live matrix, which could have moved since).
     case "$PUBLISH_KIND" in
         tagged) landing_input="$ROUTE_MATRIX" ;;
-        nightly) landing_input="$(jq -c '.route_matrix' "$HANDOFF_FILE")" ;;
+        nightly) landing_input="$(jq -ec '.route_matrix' "$HANDOFF_FILE")" ;;
     esac
     landing_matrix_file=$(mktemp)
     printf '%s' "$landing_input" | jq -c \

--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -1,51 +1,86 @@
 #!/bin/sh
-# publish-pkg-repo.sh — verify + publish a tagged release's .pkg assets into the
-# pfBlockerNG/pkg catalogue tree, then commit + fast-forward-push the result.
+# publish-pkg-repo.sh — verify + publish a Tagged release's or a Nightly snapshot's
+# .pkg assets into the pfBlockerNG/pkg catalogue tree, then commit + fast-forward-push
+# the result.
 #
-# The release job's own checkout runs this — PFB_SRC/scripts/publish_release.py
-# does the verify+assemble work (never runs git itself); this script owns the ONLY
-# git mutation in the whole flow: syncing PKG_REPO to origin/main, staging exactly
-# what publish_release.py reports touched, committing, and pushing.
+# PUBLISH_KIND selects the mode (default "tagged" when unset):
+#   tagged   PFB_SRC/scripts/publish_release.py verifies + assembles a tagged
+#            Release's assets against the pinned ROUTE matrix.
+#   nightly  PFB_SRC/scripts/publish_nightly.py verifies + assembles a verified
+#            Nightly handoff's assets, fanned out to every ROUTE varver sharing
+#            each build's FreeBSD major.
+# Neither publisher ever runs git itself; this script owns the ONLY git mutation
+# in the whole flow: syncing PKG_REPO to origin/main, staging exactly what the
+# publisher reports touched, committing, and pushing.
 #
-# CONTAINMENT: a publish_release.py failure — verification, or a mid-regeneration
+# CONTAINMENT: a publisher failure — verification, or a mid-regeneration
 # write-back fault inside catalogue_assembly.py — must never reach a commit. This
 # script enforces that structurally: every git mutation (add/commit/push) happens
-# strictly AFTER a successful publish_release.py run, and a non-zero exit from it
+# strictly AFTER a successful publisher run, and a non-zero exit from it
 # is `exit 1` on the spot, before any git add ever runs. There is no
 # `git add -A` / `git add .` anywhere below — only the exact touched (channel,
-# varver) directories publish_release.py reports, plus the landing page's own
+# varver) directories the publisher reports, plus the landing page's own
 # output and docs/.nojekyll.
 #
 # On a rejected push (another run advanced origin/main first), the ENTIRE cycle
 # reruns from a fresh sync — not a rebase of the local commit — because
-# publish_release.py's retention/regeneration must see the racing run's tree, not
+# the publisher's retention/regeneration must see the racing run's tree, not
 # stale local state.
 #
-# Required environment:
-#   PFB_SRC             pfBlockerNG source-repo checkout (this repo; also exported
-#                        for publish_release.py's own engine loading)
-#   PKG_REPO             pfBlockerNG/pkg checkout, already cloned with a credentialed
+# Required environment — every mode:
+#   PFB_SRC              pfBlockerNG source-repo checkout (this repo; also exported
+#                        for the publisher's own engine loading)
+#   PKG_REPO              pfBlockerNG/pkg checkout, already cloned with a credentialed
 #                        remote (this script only fetches/checks out/pushes `main`)
-#   SOURCE_REPOSITORY, RELEASE_ID, RELEASE_TAG, DESTINATIONS, SOURCE_RUN_ID
-#                        the publish_release.py intake — see its --help
-#   ASSETS_DIR            directory of downloaded .pkg assets + digests.json sidecar
-#   ROUTE_MATRIX          the pinned ROUTE matrix, compact JSON array text
-#   BASE_URL              Pages base URL passed to gen_landing.py
-# Optional:
-#   MAX_PUSH_ATTEMPTS     bounded retry count (default 5)
+#   SOURCE_RUN_ID          identifies this run to the publisher (tagged:
+#                        publish_release.py intake; nightly: must equal the
+#                        handoff's own run_id — see publish_nightly.py --help)
+#   BASE_URL               Pages base URL passed to gen_landing.py
+# Optional — every mode:
+#   PUBLISH_KIND           "tagged" (default) or "nightly"; anything else is a
+#                        usage error
+#   MAX_PUSH_ATTEMPTS      bounded retry count (default 5)
+#
+# Required environment — PUBLISH_KIND=tagged only:
+#   SOURCE_REPOSITORY, RELEASE_ID, RELEASE_TAG, DESTINATIONS
+#                        the rest of the publish_release.py intake — see its --help
+#   ASSETS_DIR             directory of downloaded .pkg assets + digests.json sidecar
+#   ROUTE_MATRIX           the pinned ROUTE matrix, compact JSON array text
+#
+# Required environment — PUBLISH_KIND=nightly only:
+#   HANDOFF_FILE            path to the verified nightly_provenance.build_handoff JSON
+#   RESULTS_DIR             directory of downloaded nightly-result-<major>/ legs
 
 set -eu
 
+PUBLISH_KIND="${PUBLISH_KIND:-tagged}"
+case "$PUBLISH_KIND" in
+    tagged | nightly) ;;
+    *)
+        echo "::error::PUBLISH_KIND must be 'tagged' or 'nightly', got '${PUBLISH_KIND}'" >&2
+        exit 1
+        ;;
+esac
+
 : "${PFB_SRC:?PFB_SRC is required}"
 : "${PKG_REPO:?PKG_REPO is required}"
-: "${SOURCE_REPOSITORY:?SOURCE_REPOSITORY is required}"
-: "${RELEASE_ID:?RELEASE_ID is required}"
-: "${RELEASE_TAG:?RELEASE_TAG is required}"
-: "${DESTINATIONS:?DESTINATIONS is required}"
 : "${SOURCE_RUN_ID:?SOURCE_RUN_ID is required}"
-: "${ASSETS_DIR:?ASSETS_DIR is required}"
-: "${ROUTE_MATRIX:?ROUTE_MATRIX is required}"
 : "${BASE_URL:?BASE_URL is required}"
+
+case "$PUBLISH_KIND" in
+    tagged)
+        : "${SOURCE_REPOSITORY:?SOURCE_REPOSITORY is required}"
+        : "${RELEASE_ID:?RELEASE_ID is required}"
+        : "${RELEASE_TAG:?RELEASE_TAG is required}"
+        : "${DESTINATIONS:?DESTINATIONS is required}"
+        : "${ASSETS_DIR:?ASSETS_DIR is required}"
+        : "${ROUTE_MATRIX:?ROUTE_MATRIX is required}"
+        ;;
+    nightly)
+        : "${HANDOFF_FILE:?HANDOFF_FILE is required}"
+        : "${RESULTS_DIR:?RESULTS_DIR is required}"
+        ;;
+esac
 MAX_PUSH_ATTEMPTS="${MAX_PUSH_ATTEMPTS:-5}"
 # A bound below 1 (or a non-numeric one) makes the retry loop body unreachable, so the
 # script would report a push rejection for a push it never attempted.
@@ -67,8 +102,8 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
 
     # --- verify + assemble (never runs git) --------------------------------
     # A non-zero exit here is fatal to the WHOLE run, on the spot: no git add,
-    # no commit, no push follows. publish_release.py's own stderr (already
-    # tagged ::error:: on failure) reaches the job log via the redirect below.
+    # no commit, no push follows. The publisher's own stderr (already tagged
+    # ::error:: on failure) reaches the job log via the redirect below.
     out_file=$(mktemp)
     # Cleanup is a trap, deliberately NOT a manual `rm -f` paired with the
     # failure branch's `exit 1` below: an `rm` immediately before an `exit`
@@ -80,17 +115,34 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
     # script exit, however that exit happens; nothing on the path between here
     # and there depends on `$out_file` already being gone.
     trap 'rm -f "$out_file"' EXIT
-    if ! python3 "${PFB_SRC}/scripts/publish_release.py" \
-        --source-repository "$SOURCE_REPOSITORY" \
-        --release-id "$RELEASE_ID" \
-        --release-tag "$RELEASE_TAG" \
-        --destinations "$DESTINATIONS" \
-        --source-run-id "$SOURCE_RUN_ID" \
-        --assets-dir "$ASSETS_DIR" \
-        --pkg-repo "$PKG_REPO" \
-        --route-matrix "$ROUTE_MATRIX" >"$out_file" 2>&1
-    then
-        echo "::error::publish_release.py failed — aborting before any git mutation" >&2
+    # `cmd || publish_rc=$?` — not `if ! cmd; then` — because the command to run
+    # differs per mode: the failure must be captured from inside a `case` arm,
+    # and a non-final component of an OR list (the assignment is always the
+    # list's own last, always-successful component) is exempt from `set -e`,
+    # same idiom as `touched=$(...) || true` further down.
+    publish_rc=0
+    case "$PUBLISH_KIND" in
+        tagged)
+            python3 "${PFB_SRC}/scripts/publish_release.py" \
+                --source-repository "$SOURCE_REPOSITORY" \
+                --release-id "$RELEASE_ID" \
+                --release-tag "$RELEASE_TAG" \
+                --destinations "$DESTINATIONS" \
+                --source-run-id "$SOURCE_RUN_ID" \
+                --assets-dir "$ASSETS_DIR" \
+                --pkg-repo "$PKG_REPO" \
+                --route-matrix "$ROUTE_MATRIX" >"$out_file" 2>&1 || publish_rc=$?
+            ;;
+        nightly)
+            python3 "${PFB_SRC}/scripts/publish_nightly.py" \
+                --handoff "$HANDOFF_FILE" \
+                --results-dir "$RESULTS_DIR" \
+                --pkg-repo "$PKG_REPO" \
+                --source-run-id "$SOURCE_RUN_ID" >"$out_file" 2>&1 || publish_rc=$?
+            ;;
+    esac
+    if [ "$publish_rc" -ne 0 ]; then
+        echo "::error::publish_${PUBLISH_KIND}.py failed — aborting before any git mutation" >&2
         cat "$out_file" >&2
         exit 1
     fi
@@ -113,9 +165,17 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
     # tests/shell/publish_pkg_repo_spec.sh): freebsd_major alone feeds the
     # CPU-wildcarded ABI string. The retired `arch` matrix field is never
     # interpolated — every published .pkg is NO_ARCH, so the honest ABI is the
-    # wildcard the packages themselves carry, never a per-arch value.
+    # wildcard the packages themselves carry, never a per-arch value. The two
+    # modes share this ONE transform, differing only in the matrix array's
+    # source: tagged's pinned $ROUTE_MATRIX, nightly's own handoff-carried
+    # route_matrix (the handoff is what this run actually verified against —
+    # never a freshly re-read live matrix, which could have moved since).
+    case "$PUBLISH_KIND" in
+        tagged) landing_input="$ROUTE_MATRIX" ;;
+        nightly) landing_input="$(jq -c '.route_matrix' "$HANDOFF_FILE")" ;;
+    esac
     landing_matrix_file=$(mktemp)
-    printf '%s' "$ROUTE_MATRIX" | jq -c \
+    printf '%s' "$landing_input" | jq -c \
         '[.[] | {abi: "FreeBSD:\(.freebsd_major):*", pfsense_version, variant, php_version, py_flavor}]' \
         >"$landing_matrix_file"
     python3 "${PFB_SRC}/scripts/gen_landing.py" \
@@ -147,13 +207,25 @@ ${dir_indexes}"
     git -C "$PKG_REPO" add -- $stage_paths
 
     if git -C "$PKG_REPO" diff --cached --quiet; then
-        echo "publish-pkg-repo: NOOP — publish_release.py reported changes but nothing is staged; discarding."
+        echo "publish-pkg-repo: NOOP — the publisher reported changes but nothing is staged; discarding."
         git -C "$PKG_REPO" reset --quiet
         exit 0
     fi
 
-    commit_message=$(printf 'publish: %s -> %s\n\npfBlockerNG-Release-Tag: %s\npfBlockerNG-Source-Run-Id: %s\n' \
-        "$RELEASE_TAG" "$DESTINATIONS" "$RELEASE_TAG" "$SOURCE_RUN_ID")
+    case "$PUBLISH_KIND" in
+        tagged)
+            commit_message=$(printf 'publish: %s -> %s\n\npfBlockerNG-Release-Tag: %s\npfBlockerNG-Source-Run-Id: %s\n' \
+                "$RELEASE_TAG" "$DESTINATIONS" "$RELEASE_TAG" "$SOURCE_RUN_ID")
+            ;;
+        nightly)
+            # jq -er: a missing/null allocation.pkg_version aborts here (via
+            # set -e) before any commit — same containment rule as a non-zero
+            # exit from the publisher itself further up.
+            nightly_pkg_version=$(jq -er '.allocation.pkg_version' "$HANDOFF_FILE")
+            commit_message=$(printf 'publish: nightly %s -> ["nightly"]\n\npfBlockerNG-Nightly-Version: %s\npfBlockerNG-Source-Run-Id: %s\n' \
+                "$nightly_pkg_version" "$nightly_pkg_version" "$SOURCE_RUN_ID")
+            ;;
+    esac
     # Fixed bot identity via per-invocation -c flags, not repo config: a bare CI
     # checkout carries no git identity, and this script must not depend on one
     # being configured elsewhere (matches release.yml/module-durations.yml's

--- a/scripts/publish_nightly.py
+++ b/scripts/publish_nightly.py
@@ -40,7 +40,7 @@ contracts, plus established private cross-module seams in the same spirit as
 (``publish_catalogues._canonical_record``/``_normalize_route_matrix``/
 ``_validate_asset_name``, ``publish_release._Target``/``_asset_map``/``_drop_assets``/
 ``_catalogue_descriptor_complete``, ``nightly_provenance._validate_allocation``/
-``_validate_artifacts``/``_validate_dep_artifacts``) — never copies their logic.
+``_validate_artifacts``/``_validate_dep_artifacts``/``_DIGEST``) — never copies their logic.
 
 stdlib-only, Python 3.11. The engine is loaded via ``publish_catalogues.load_engine()``
 — explicit ``src_root`` or the ``PFB_SRC`` environment variable, same as
@@ -163,6 +163,20 @@ def _validate_handoff(handoff: object, *, engine: pc.Engine, source_run_id: str)
         raise PublishNightlyError("handoff allocation.source_sha does not match the top-level source_sha")
     if allocation.ports_sha != ports_sha:
         raise PublishNightlyError("handoff allocation.ports_sha does not match the top-level ports_sha")
+
+    # Re-run the input-digest cross-check nightly_provenance.build_handoff itself
+    # performs at handoff-creation time: nothing else in this handoff's shape ties
+    # matrix_digest to allocation.input_digest, so without this a forged
+    # matrix_digest would sail through untouched.
+    matrix_digest = handoff["matrix_digest"]
+    if not isinstance(matrix_digest, str) or not np._DIGEST.fullmatch(matrix_digest):
+        raise PublishNightlyError("handoff matrix_digest must be lowercase 64-character hex")
+    expected_input_digest = np.combined_nightly_input_digest(source_sha, ports_sha, matrix_digest)
+    if allocation.input_digest != expected_input_digest:
+        raise PublishNightlyError(
+            "handoff allocation.input_digest does not match source_sha/ports_sha/matrix_digest "
+            "(tampered or corrupt handoff)"
+        )
 
     builds_raw = handoff["builds"]
     if not isinstance(builds_raw, list) or not builds_raw:
@@ -360,7 +374,10 @@ def _reject_stale(site_root: Path, varver: str, engine: pc.Engine, incoming_vers
             continue
         if path.name == incoming_name:
             present = True
-        key = pfb_pkg.pkg_version_sort_key(manifest["version"])
+        version = manifest.get("version")
+        if not isinstance(version, str) or not version:
+            raise PublishNightlyError(f"corrupt published canonical package manifest (missing 'version'): {path}")
+        key = pfb_pkg.pkg_version_sort_key(version)
         if newest_key is None or key > newest_key:
             newest_key = key
     if not present and newest_key is not None and pfb_pkg.pkg_version_sort_key(incoming_version) < newest_key:

--- a/scripts/publish_nightly.py
+++ b/scripts/publish_nightly.py
@@ -1,0 +1,500 @@
+"""Nightly-handoff publisher — CLI entry point (issue #2146 step S2).
+
+Consumes the already-verified Nightly handoff (``nightly_provenance.build_handoff``'s
+own return shape, read back from disk as untrusted JSON) and assembles it into the
+``nightly/<varver>/`` catalogues: re-validate the handoff's own shape/identity, verify
+every referenced ``.pkg`` artifact from BYTES (never trusting the handoff's own literal
+``record``/``matrix_row``/``artifact`` echoes — those are audit trail, not proof), fan
+each per-FreeBSD-major build out to every ROUTE varver sharing that major, then drop,
+prune, and regenerate exactly like ``publish_release.py`` does for a tagged run.
+
+Per-major fan-out (``scripts/read-version-matrix.sh`` header, "why builds are per-major
+but ROUTE is per-version"): every ``pfSense-pkg-pfBlockerNG`` port is NO_ARCH, so ONE
+wildcard-ABI Nightly build serves every pfSense edition/version sharing a FreeBSD
+major — unlike a tagged run's ROUTE matrix (one canonical asset per EXACT version), a
+Nightly leg's canonical asset is targeted at every build-role ROUTE row whose
+``freebsd_major`` matches. Two Plus versions on the same major (e.g. 26.03 + 26.07)
+therefore both receive the SAME canonical bytes — a genuine multi-destination fan-out,
+verified byte/checksum/provenance-identical by
+``catalogue_assembly.verify_multi_destination_identity`` exactly as a tagged run's own
+fan-out is.
+
+Staleness guard: this publisher runs inside the SAME workflow run that produced the
+handoff (``handoff["run_id"] == --source-run-id``); an inequality means a stale or
+foreign handoff replay and is rejected before any other check. There is still no
+durable ledger here (issue #2146's tree-is-state doctrine, same as
+``catalogue_assembly.py``): "already published" is read straight off
+``nightly/<varver>/`` itself. Because Nightly's version ordering is a single run-wide
+monotonic date/revision (unlike a tagged run's per-varver semver), a destination
+already holding a NEWER canonical version than this run's own is refused outright
+(``StaleNightlyError``) rather than silently skipped or overwritten — a stale rerun of
+an old workflow attempt must never regress a catalogue a newer run already advanced.
+
+Tagged intake is not handled here: ``publish_release.py`` owns it, and this module never
+imports git or touches any tagged-flow paths.
+
+Never edits ``publish_catalogues.py`` / ``catalogue_assembly.py`` / ``publish_release.py``
+/ ``nightly_provenance.py`` (all frozen/gated) — this module only calls their public
+contracts, plus established private cross-module seams in the same spirit as
+``catalogue_assembly.py``'s own engine-private dereferences
+(``publish_catalogues._canonical_record``/``_normalize_route_matrix``/
+``_validate_asset_name``, ``publish_release._Target``/``_asset_map``/``_drop_assets``/
+``_catalogue_descriptor_complete``, ``nightly_provenance._validate_allocation``/
+``_validate_artifacts``/``_validate_dep_artifacts``) — never copies their logic.
+
+stdlib-only, Python 3.11. The engine is loaded via ``publish_catalogues.load_engine()``
+— explicit ``src_root`` or the ``PFB_SRC`` environment variable, same as
+``publish_release.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+# Same sys.path idiom as publish_release.py — scripts/ is not a package, and running
+# this file directly only puts ITS OWN directory on sys.path for free.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import catalogue_assembly as ca
+import nightly_provenance as np
+import publish_catalogues as pc
+import publish_release as pr
+
+_CHANNEL = "nightly"
+_LEG_DIR_PREFIX = "nightly-result-"
+
+
+class PublishNightlyError(Exception):
+    """A handoff-shape, routing, or CLI-level failure this module itself detected.
+
+    Engine errors (``pc.PublishError`` / ``ca.CatalogueAssemblyError`` /
+    ``pr.PublishReleaseError`` (incl. its ``DestinationConflictError`` subclass, raised
+    by the reused ``pr._drop_assets``/``pr._asset_map``) / ``np.ProvenanceError`` / the
+    dynamically-loaded ``pfb_pkg.PkgError``/``build_repo_portable.BuildRepoError``)
+    propagate UNWRAPPED — this module never re-derives a check those already make."""
+
+
+class StaleNightlyError(PublishNightlyError):
+    """A destination already holds a canonical version NEWER than this run's own, and
+    this run's version is not already present there. Nightly has one run-wide
+    monotonic date/revision (unlike a tagged run's per-varver semver) — a stale rerun
+    must never regress a catalogue a newer run already advanced past it."""
+
+
+# --------------------------------------------------------------------------- #
+# Handoff validation — re-checks the shape/identity nightly_provenance.build_handoff
+# already enforced at handoff-creation time, because this reads the handoff back as
+# untrusted JSON off disk, not the in-memory value build_handoff returned.
+# --------------------------------------------------------------------------- #
+
+_HANDOFF_FIELDS = frozenset(
+    {
+        "schema",
+        "kind",
+        "run_id",
+        "source_ref",
+        "ports_repo",
+        "ports_ref",
+        "allocation",
+        "source_sha",
+        "ports_sha",
+        "tools_sha",
+        "matrix_sha",
+        "matrix_digest",
+        "build_matrix",
+        "route_matrix",
+        "builds",
+    }
+)
+_BUILD_ENTRY_FIELDS = frozenset({"matrix_row", "record", "artifact", "dep_artifacts"})
+
+
+@dataclass(frozen=True)
+class _ValidatedHandoff:
+    allocation: object  # release_version.NightlyAllocation (via nightly_provenance)
+    source_sha: str
+    ports_sha: str
+    route_matrix: list[Mapping[str, object]]
+    # Each entry: {"matrix_row": normalized dict, "artifact": {abi,name,sha256},
+    # "dep_artifacts": [{abi,name,sha256}, ...]}. The handoff's own literal "record"
+    # field is intentionally NOT carried past the shape check below — this module
+    # never trusts it; per-canonical provenance is always re-derived from the
+    # downloaded .pkg's own annotation by publish_catalogues.verify_asset instead.
+    builds: list[dict[str, object]]
+
+
+def _validate_handoff(handoff: object, *, engine: pc.Engine, source_run_id: str) -> _ValidatedHandoff:
+    if not isinstance(handoff, dict):
+        raise PublishNightlyError("handoff must be a JSON object")
+    keys = set(handoff)
+    if keys != _HANDOFF_FIELDS:
+        missing = sorted(_HANDOFF_FIELDS - keys)
+        unknown = sorted(keys - _HANDOFF_FIELDS)
+        raise PublishNightlyError(f"handoff exact fields required (missing={missing}, unknown={unknown})")
+    if handoff["schema"] != 1:
+        raise PublishNightlyError(f"handoff schema must be 1, got {handoff['schema']!r}")
+    if handoff["kind"] != "nightly-handoff":
+        raise PublishNightlyError(f"handoff kind must be 'nightly-handoff', got {handoff['kind']!r}")
+    run_id = handoff["run_id"]
+    if run_id != source_run_id:
+        raise PublishNightlyError(
+            f"handoff run_id {run_id!r} does not match --source-run-id {source_run_id!r} — "
+            "this publisher only accepts the handoff produced by its OWN workflow run "
+            "(a mismatch is a stale or foreign handoff replay)"
+        )
+
+    source_sha = handoff["source_sha"]
+    ports_sha = handoff["ports_sha"]
+    if not isinstance(source_sha, str) or not isinstance(ports_sha, str):
+        raise PublishNightlyError("handoff source_sha/ports_sha must be strings")
+
+    # Reuse nightly_provenance's OWN allocation validator rather than re-deriving the
+    # NightlyAllocation shape/date-revision rules here.
+    allocation = np._validate_allocation(handoff["allocation"])
+    if allocation.source_sha != source_sha:
+        raise PublishNightlyError("handoff allocation.source_sha does not match the top-level source_sha")
+    if allocation.ports_sha != ports_sha:
+        raise PublishNightlyError("handoff allocation.ports_sha does not match the top-level ports_sha")
+
+    builds_raw = handoff["builds"]
+    if not isinstance(builds_raw, list) or not builds_raw:
+        raise PublishNightlyError("handoff builds must be a non-empty list")
+
+    pfb_pkg = engine.pfb_pkg
+    normalized_builds: list[dict[str, object]] = []
+    majors: set[str] = set()
+    for entry in builds_raw:
+        if not isinstance(entry, dict) or set(entry) != _BUILD_ENTRY_FIELDS:
+            raise PublishNightlyError(f"handoff build entry exact fields required: {sorted(_BUILD_ENTRY_FIELDS)}")
+        matrix_row = pfb_pkg.validate_build_matrix_row(entry["matrix_row"])
+        major = str(matrix_row["freebsd_major"])
+        if major in majors:
+            raise PublishNightlyError(f"handoff builds contain duplicate FreeBSD major {major!r}")
+        majors.add(major)
+        # Same per-result shape nightly_provenance.build_handoff itself validates —
+        # reused verbatim rather than re-deriving the artifact/dep_artifacts rules.
+        artifact = np._validate_artifacts([entry["artifact"]])[0]
+        dep_artifacts = np._validate_dep_artifacts(
+            entry["dep_artifacts"], leg_abi=f"FreeBSD:{major}:*", canonical_name=artifact["name"]
+        )
+        normalized_builds.append({"matrix_row": matrix_row, "artifact": artifact, "dep_artifacts": dep_artifacts})
+
+    route_matrix = handoff["route_matrix"]
+    if not isinstance(route_matrix, list) or not route_matrix:
+        raise PublishNightlyError("handoff route_matrix must be a non-empty list")
+
+    return _ValidatedHandoff(
+        allocation=allocation,
+        source_sha=source_sha,
+        ports_sha=ports_sha,
+        route_matrix=route_matrix,
+        builds=normalized_builds,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Asset discovery + verification — one leg directory per BUILD major.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class _Leg:
+    major: str
+    matrix_row: Mapping[str, object]
+    canonical: pc.VerifiedAsset
+    dependencies: tuple[pc.VerifiedAsset, ...]
+
+
+def _verify_builds(
+    engine: pc.Engine,
+    intake: pc.Intake,
+    validated: _ValidatedHandoff,
+    results_dir: Path,
+    work_dir: Path,
+) -> list[_Leg]:
+    legs: list[_Leg] = []
+    for index, entry in enumerate(validated.builds):
+        matrix_row = entry["matrix_row"]
+        assert isinstance(matrix_row, Mapping)
+        major = str(matrix_row["freebsd_major"])
+        legdir = results_dir / f"{_LEG_DIR_PREFIX}{major}"
+        artifact = entry["artifact"]
+        assert isinstance(artifact, Mapping)
+
+        # Reject a hostile name BEFORE it is ever joined onto legdir — the same
+        # bare-filename guard verify_asset applies to its own `asset_name` argument,
+        # invoked here proactively rather than after a path has already been built
+        # from untrusted input.
+        pc._validate_asset_name(artifact["name"])
+        canonical_path = legdir / artifact["name"]
+        if not canonical_path.is_file():
+            raise PublishNightlyError(f"missing canonical asset for FreeBSD {major}: {canonical_path}")
+        canonical_asset = pc.verify_asset(
+            engine,
+            canonical_path,
+            artifact["name"],
+            intake=intake,
+            expected_sha256=artifact["sha256"],
+            work_dir=work_dir / f"leg-{index}-canonical",
+        )
+        record = pc._canonical_record(canonical_asset)
+        allocation = validated.allocation
+        if record["canonical_package_version"] != allocation.pkg_version:  # type: ignore[union-attr]
+            raise PublishNightlyError(
+                f"FreeBSD {major} canonical asset version {record['canonical_package_version']!r} "
+                f"does not match allocation.pkg_version {allocation.pkg_version!r}"  # type: ignore[union-attr]
+            )
+        if record["source_sha"] != validated.source_sha:
+            raise PublishNightlyError(f"FreeBSD {major} canonical asset source_sha does not match handoff source_sha")
+        if record["freebsd_ports_sha"] != validated.ports_sha:
+            raise PublishNightlyError(
+                f"FreeBSD {major} canonical asset freebsd_ports_sha does not match handoff ports_sha"
+            )
+        if record["matrix_row"] != matrix_row:
+            raise PublishNightlyError(
+                f"FreeBSD {major} canonical asset matrix_row does not match this build entry's matrix_row"
+            )
+
+        dependencies: list[pc.VerifiedAsset] = []
+        dep_artifacts = entry["dep_artifacts"]
+        assert isinstance(dep_artifacts, list)
+        for dep_index, dep in enumerate(dep_artifacts):
+            pc._validate_asset_name(dep["name"])
+            dep_path = legdir / dep["name"]
+            if not dep_path.is_file():
+                raise PublishNightlyError(f"missing dependency asset {dep['name']!r} for FreeBSD {major}: {dep_path}")
+            dependencies.append(
+                pc.verify_asset(
+                    engine,
+                    dep_path,
+                    dep["name"],
+                    intake=intake,
+                    expected_sha256=dep["sha256"],
+                    work_dir=work_dir / f"leg-{index}-dep-{dep_index}",
+                )
+            )
+
+        legs.append(
+            _Leg(major=major, matrix_row=matrix_row, canonical=canonical_asset, dependencies=tuple(dependencies))
+        )
+    return legs
+
+
+# --------------------------------------------------------------------------- #
+# Route targeting — fan each leg out to every build-role ROUTE row sharing its
+# FreeBSD major. Route-only rows are never targeted (no frozen Nightly assets).
+# --------------------------------------------------------------------------- #
+
+
+def _route_targets(
+    engine: pc.Engine,
+    route_matrix_rows: Sequence[Mapping[str, object]],
+    legs: Sequence[_Leg],
+) -> dict[str, pr._Target]:
+    brp = engine.build_repo_portable
+    build_rows, _route_only_rows = pc._normalize_route_matrix(engine, route_matrix_rows)
+
+    targets: dict[str, pr._Target] = {}
+    used_majors: set[str] = set()
+    for row in build_rows.values():
+        major = str(row["freebsd_major"])
+        matches = [leg for leg in legs if leg.major == major]
+        if not matches:
+            raise PublishNightlyError(
+                f"ROUTE build row {row['variant']}/{row['pfsense_version']} (FreeBSD {major}) has no built asset"
+            )
+        if len(matches) > 1:
+            raise PublishNightlyError(
+                f"ROUTE build row {row['variant']}/{row['pfsense_version']} (FreeBSD {major}) matches more than "
+                "one built asset — forged handoff"
+            )
+        leg = matches[0]
+        varver = brp.catalog_name_from_version(row["pfsense_version"], row["variant"])
+        if varver in targets:
+            raise PublishNightlyError(f"two ROUTE build rows resolve to the same varver {varver!r}")
+
+        dependencies: list[pc.VerifiedAsset] = []
+        for dep in leg.dependencies:
+            if not brp._pkg_matches_abi(dep.manifest, f"FreeBSD:{major}:*"):
+                raise PublishNightlyError(f"{dep.declared_name!r}: dependency ABI does not match FreeBSD major {major}")
+            dependencies.append(dep)
+
+        targets[varver] = pr._Target(row=row, canonical=leg.canonical, dependencies=dependencies)
+        used_majors.add(major)
+
+    unused = {leg.major for leg in legs} - used_majors
+    if unused:
+        raise PublishNightlyError(
+            f"canonical asset(s) for FreeBSD major(s) {sorted(unused)!r} serve no ROUTE build row"
+        )
+    return targets
+
+
+# --------------------------------------------------------------------------- #
+# Stale-version tree check — BEFORE any write, for every target.
+# --------------------------------------------------------------------------- #
+
+
+def _reject_stale(site_root: Path, varver: str, engine: pc.Engine, incoming_version: str) -> None:
+    catalogue_dir = site_root / _CHANNEL / varver
+    if not catalogue_dir.is_dir():
+        return  # first publish for this varver — nothing to be stale against
+    pfb_pkg = engine.pfb_pkg
+    brp = engine.build_repo_portable
+    incoming_name = f"{pfb_pkg.CANONICAL_EMITTED_IDENTITY}-{incoming_version}.pkg"
+    present = False
+    newest_key = None
+    for path in sorted(catalogue_dir.glob("*.pkg")):
+        if not path.is_file() or path.name in brp._CATALOG_PKG_FILES:
+            continue
+        manifest = pfb_pkg.read_compact_manifest(path)
+        if manifest.get("name") != pfb_pkg.CANONICAL_EMITTED_IDENTITY:
+            continue
+        if path.name == incoming_name:
+            present = True
+        key = pfb_pkg.pkg_version_sort_key(manifest["version"])
+        if newest_key is None or key > newest_key:
+            newest_key = key
+    if not present and newest_key is not None and pfb_pkg.pkg_version_sort_key(incoming_version) < newest_key:
+        raise StaleNightlyError(
+            f"{_CHANNEL}/{varver}: incoming version {incoming_version!r} is older than the newest already-published "
+            "canonical version — stale run cannot replace newer catalogue state"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Publish — mirrors publish_release.publish()'s body over a fixed "nightly" channel.
+# --------------------------------------------------------------------------- #
+
+
+def publish(
+    engine: pc.Engine,
+    pkg_repo: str | Path,
+    targets: Mapping[str, pr._Target],
+    incoming_version: str,
+) -> pr.PublishReport:
+    site_root = Path(pkg_repo) / pr._SITE_SUBDIR
+
+    for varver in sorted(targets):
+        _reject_stale(site_root, varver, engine, incoming_version)
+
+    touched: list[tuple[str, str]] = []
+    source_index: dict[Path, list[tuple[str, str]]] = {}
+    for varver in sorted(targets):
+        target = targets[varver]
+        asset_map = pr._asset_map(target)
+        dest_dir = site_root / _CHANNEL / varver
+        changed = pr._drop_assets(dest_dir, asset_map)
+        if not changed and not pr._catalogue_descriptor_complete(dest_dir, engine):
+            changed = True
+        for src in asset_map.values():
+            source_index.setdefault(src.resolve(), []).append((_CHANNEL, varver))
+        if changed:
+            ca.prune_retained(site_root, _CHANNEL, varver, engine=engine)
+            ca.regenerate_catalogue(site_root, _CHANNEL, varver, engine=engine)
+            touched.append((_CHANNEL, varver))
+
+    if source_index:
+        ca.verify_multi_destination_identity(engine, site_root, source_index)
+
+    return pr.PublishReport(touched=tuple(touched))
+
+
+# --------------------------------------------------------------------------- #
+# run() — handoff -> verify -> route -> publish. main() is a thin CLI wrapper.
+# --------------------------------------------------------------------------- #
+
+
+def run(
+    *,
+    handoff_path: str | Path,
+    results_dir: str | Path,
+    pkg_repo: str | Path,
+    source_run_id: str,
+    engine: pc.Engine | None = None,
+) -> pr.PublishReport:
+    engine = engine if engine is not None else pc.load_engine()
+
+    handoff_path = Path(handoff_path)
+    try:
+        raw = handoff_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublishNightlyError(f"cannot read {handoff_path}: {exc}") from exc
+    try:
+        handoff_raw = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PublishNightlyError(f"{handoff_path} is not valid JSON: {exc}") from exc
+
+    validated = _validate_handoff(handoff_raw, engine=engine, source_run_id=source_run_id)
+    intake = pc.parse_intake(pc.EXPECTED_SOURCE_REPOSITORY, "", "", '["nightly"]', source_run_id)
+
+    with tempfile.TemporaryDirectory(prefix="publish-nightly-verify-") as work_dir:
+        legs = _verify_builds(engine, intake, validated, Path(results_dir), Path(work_dir))
+        targets = _route_targets(engine, validated.route_matrix, legs)
+        # publish() reads VerifiedAsset.work_path, which lives under work_dir — must
+        # run to completion BEFORE this context manager tears work_dir down.
+        return publish(engine, pkg_repo, targets, validated.allocation.pkg_version)  # type: ignore[union-attr]
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify a Nightly handoff's .pkg assets and publish them into the "
+            "pfBlockerNG/pkg nightly catalogue tree (never runs git)."
+        )
+    )
+    parser.add_argument("--handoff", required=True, help="the verified nightly_provenance.build_handoff JSON")
+    parser.add_argument("--results-dir", required=True, help="directory of downloaded nightly-result-<major>/ legs")
+    parser.add_argument(
+        "--pkg-repo",
+        required=True,
+        help="the checked-out pfBlockerNG/pkg working tree (site is <pkg-repo>/docs)",
+    )
+    parser.add_argument("--source-run-id", required=True, help="must equal the handoff's own run_id")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    try:
+        engine = pc.load_engine()
+    except pc.EngineError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    try:
+        report = run(
+            handoff_path=args.handoff,
+            results_dir=args.results_dir,
+            pkg_repo=args.pkg_repo,
+            source_run_id=args.source_run_id,
+            engine=engine,
+        )
+    except (
+        PublishNightlyError,
+        pc.PublishError,
+        ca.CatalogueAssemblyError,
+        pr.PublishReleaseError,
+        np.ProvenanceError,
+        engine.pfb_pkg.PkgError,
+        engine.build_repo_portable.BuildRepoError,
+    ) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    for line in report.describe():
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -252,8 +252,13 @@ PY
     RESULTS_DIR="${base}/results"
     export PUBLISH_KIND HANDOFF_FILE RESULTS_DIR
     mkdir -p "$RESULTS_DIR"
+    # DELIBERATELY a different row than common_env's own $ROUTE_MATRIX (freebsd
+    # 15/2.8/CE/8.3/py311) -- n9 stages the landing matrix on this handoff row
+    # and asserts against ITS values; if the nightly arm ever regressed to
+    # reading $ROUTE_MATRIX instead, the assertion must fail on a value
+    # mismatch, not pass on accidental byte-identity between the two fixtures.
     cat > "$HANDOFF_FILE" <<'JSON'
-{"run_id":"10:1","allocation":{"pkg_version":"26.08.0001"},"route_matrix":[{"freebsd_major":"15","pfsense_version":"2.8","variant":"CE","php_version":"8.3","py_flavor":"py311"}]}
+{"run_id":"10:1","allocation":{"pkg_version":"26.08.0001"},"route_matrix":[{"freebsd_major":"16","pfsense_version":"2.9","variant":"Plus","php_version":"8.4","py_flavor":"py312"}]}
 JSON
   }
 
@@ -641,6 +646,25 @@ HOOK
     The result of function remote_head_now should equal "$original_remote_head"
   End
 
+  It 'n4c: nightly mode missing allocation.pkg_version aborts before any commit, even after staging'
+    # jq -er '.allocation.pkg_version' HANDOFF_FILE builds the commit message --
+    # this handoff is otherwise valid (the stubbed publisher succeeds and
+    # reports an "updated" target, so staging has ALREADY happened by the time
+    # this read runs) but its allocation object carries no pkg_version key at
+    # all, so jq -er sees a null result and aborts (set -e) before the commit
+    # that would otherwise follow. Same containment guarantee as a non-zero
+    # publisher exit (n4a/n4b): a damaged/incomplete run must never reach a
+    # commit, however late in the pipeline the fault is discovered.
+    nightly_env
+    printf '%s' '{"run_id":"10:1","allocation":{},"route_matrix":[{"freebsd_major":"16","pfsense_version":"2.9","variant":"Plus","php_version":"8.4","py_flavor":"py312"}]}' > "$HANDOFF_FILE"
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=nightly/ce-2.8
+    When run script "$script"
+    The status should equal 1
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
   It 'n5: nightly mode NOOP output commits nothing'
     nightly_env
     export FAKE_MODE=noop
@@ -692,6 +716,12 @@ HOOK
   End
 
   It 'n9: nightly mode derives the landing matrix from the handoff route_matrix, not $ROUTE_MATRIX'
+    # nightly_env's handoff route_matrix (freebsd 16/2.9/Plus/8.4/py312) is
+    # DELIBERATELY a different row than common_env's own $ROUTE_MATRIX
+    # (freebsd 15/2.8/CE/8.3/py311, still exported here): asserting the
+    # HANDOFF row's own values is what a wrong `landing_input="$ROUTE_MATRIX"`
+    # read in the nightly arm would actually fail on -- byte-identical
+    # fixtures would let that regression pass silently.
     nightly_env
     export FAKE_MODE=success
     export FAKE_TOUCHED=nightly/ce-2.8
@@ -701,6 +731,7 @@ HOOK
     The output should include 'ADVANCE'
     The stderr should include 'main'
     seen="$(cat "${base}/landing-matrix-seen.json")"
-    The variable seen should equal '[{"abi":"FreeBSD:15:*","pfsense_version":"2.8","variant":"CE","php_version":"8.3","py_flavor":"py311"}]'
+    The variable seen should equal '[{"abi":"FreeBSD:16:*","pfsense_version":"2.9","variant":"Plus","php_version":"8.4","py_flavor":"py312"}]'
+    The variable seen should not include '"pfsense_version":"2.8"'
   End
 End

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -111,6 +111,18 @@ import os
 import sys
 
 site = sys.argv[1]
+argv = sys.argv[1:]
+# Records the exact --matrix file this run was fed, byte for byte, when
+# FAKE_LANDING_MATRIX_RECORD is set — publish-pkg-repo.sh's own job (not
+# gen_landing.py's) is choosing that file's SOURCE (tagged: $ROUTE_MATRIX;
+# nightly: the handoff's own route_matrix), so the nightly-mode spec examples
+# assert against this record rather than re-deriving the transform themselves.
+if "--matrix" in argv:
+    matrix_path = argv[argv.index("--matrix") + 1]
+    record_path = os.environ.get("FAKE_LANDING_MATRIX_RECORD")
+    if record_path:
+        with open(matrix_path, encoding="utf-8") as src, open(record_path, "w", encoding="utf-8") as dst:
+            dst.write(src.read())
 with open(os.path.join(site, "index.html"), "w") as fh:
     fh.write("landing stub\n")
 with open(os.path.join(site, "browse.html"), "w") as fh:
@@ -130,6 +142,68 @@ with open(os.path.join(site, "add-repo.sh"), "w") as fh:
 print("landing stub written")
 PY
     echo '#!/bin/sh' > "${base}/fake-src/scripts/add-repo.sh"
+
+    # --- fake publish_nightly.py — the Nightly-mode counterpart to the
+    # publish_release.py stub above. Same doubling rationale: real handoff/asset
+    # verification is publish_nightly.py's own unit suite
+    # (tests/test_publish_nightly.py); this script's OWN job — the git mutation
+    # and mode-routing around it — is what this spec exercises. Always reads the
+    # handoff JSON (mirrors the real module's own read+parse-first behaviour) so
+    # an invalid HANDOFF_FILE fails here, before any git mutation, exactly like a
+    # real verification failure would.
+    cat >"${base}/fake-src/scripts/publish_nightly.py" <<'PY'
+import json
+import os
+import sys
+
+
+def _arg(name, argv):
+    return argv[argv.index(name) + 1]
+
+
+def main():
+    argv = sys.argv[1:]
+    pkg_repo = _arg("--pkg-repo", argv)
+    handoff_path = _arg("--handoff", argv)
+    mode = os.environ.get("FAKE_MODE", "success")
+
+    # Records the exact argv this invocation received, for the spec's own
+    # assertions -- proves the wrapper forwards all four flags with the right
+    # values, not just that SOME python3 call happened.
+    record_path = os.environ.get("FAKE_INVOCATION_RECORD")
+    if record_path:
+        with open(record_path, "w") as fh:
+            fh.write("\n".join(argv))
+
+    try:
+        with open(handoff_path, encoding="utf-8") as fh:
+            json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"::error::simulated handoff read/parse failure: {exc}", file=sys.stderr)
+        return 1
+
+    if mode == "fail":
+        print("::error::simulated nightly publish fault", file=sys.stderr)
+        return 1
+
+    if mode == "noop":
+        print("NOOP: every destination already matches this run's verified assets")
+        return 0
+
+    for target in os.environ.get("FAKE_TOUCHED", "").split(","):
+        target = target.strip()
+        if not target:
+            continue
+        target_dir = os.path.join(pkg_repo, "docs", target)
+        os.makedirs(target_dir, exist_ok=True)
+        with open(os.path.join(target_dir, "marker.pkg"), "w") as fh:
+            fh.write(target)
+        print(f"updated {target}")
+    return 0
+
+
+sys.exit(main())
+PY
 
     common_env() {
         PFB_SRC="${base}/fake-src"
@@ -164,6 +238,23 @@ PY
     # failure would let an unreadable repository (deleted ref, broken .git, detached
     # HEAD after a failed checkout -B) pass as "HEAD did not move".
     git_fixture -C "${base}/pkg-repo" rev-parse main 2>/dev/null || echo "UNRESOLVABLE-main"
+  }
+
+  # --- PUBLISH_KIND=nightly fixture ------------------------------------------
+  # Layered on top of common_env (already exported by setup()): keeps the shared
+  # vars (PFB_SRC/PKG_REPO/SOURCE_RUN_ID/BASE_URL) and adds the nightly-only ones.
+  # Tagged-only vars are deliberately left exported by common_env in most nightly
+  # examples -- proving they are IGNORED, not merely absent (see the "does not
+  # leak a tagged trailer" example) -- except where a test explicitly unsets them.
+  nightly_env() {
+    PUBLISH_KIND=nightly
+    HANDOFF_FILE="${base}/nightly-handoff.json"
+    RESULTS_DIR="${base}/results"
+    export PUBLISH_KIND HANDOFF_FILE RESULTS_DIR
+    mkdir -p "$RESULTS_DIR"
+    cat > "$HANDOFF_FILE" <<'JSON'
+{"run_id":"10:1","allocation":{"pkg_version":"26.08.0001"},"route_matrix":[{"freebsd_major":"15","pfsense_version":"2.8","variant":"CE","php_version":"8.3","py_flavor":"py311"}]}
+JSON
   }
 
   # --- landing_matrix ABI expression pins: the transform lives in this script,
@@ -457,5 +548,159 @@ HOOK
     The stderr should not include 'push rejected'
     The output should not include 'sync attempt 2/'
     The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  # --- PUBLISH_KIND=nightly (issue #2146 S3) --------------------------------
+
+  It 'n1: nightly mode invokes publish_nightly.py with the four required flags and publishes on updated output'
+    nightly_env
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=nightly/ce-2.8
+    export FAKE_INVOCATION_RECORD="${base}/nightly-invocation.txt"
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    invocation="$(cat "${base}/nightly-invocation.txt")"
+    The variable invocation should include '--handoff'
+    The variable invocation should include "$HANDOFF_FILE"
+    The variable invocation should include '--results-dir'
+    The variable invocation should include "$RESULTS_DIR"
+    The variable invocation should include '--pkg-repo'
+    The variable invocation should include "${base}/pkg-repo"
+    The variable invocation should include '--source-run-id'
+    The variable invocation should include '10:1'
+  End
+
+  It 'n2a: nightly mode fails before any git call when HANDOFF_FILE is missing'
+    nightly_env
+    unset HANDOFF_FILE
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=nightly/ce-2.8
+    When run script "$script"
+    The status should equal 2
+    The stderr should include 'HANDOFF_FILE is required'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'n2b: nightly mode fails before any git call when RESULTS_DIR is missing'
+    nightly_env
+    unset RESULTS_DIR
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=nightly/ce-2.8
+    When run script "$script"
+    The status should equal 2
+    The stderr should include 'RESULTS_DIR is required'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'n2c: nightly mode fails before any git call when SOURCE_RUN_ID is missing'
+    nightly_env
+    unset SOURCE_RUN_ID
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=nightly/ce-2.8
+    When run script "$script"
+    The status should equal 2
+    The stderr should include 'SOURCE_RUN_ID is required'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'n3: nightly mode does not require any tagged-only env var'
+    nightly_env
+    unset SOURCE_REPOSITORY RELEASE_ID RELEASE_TAG DESTINATIONS ASSETS_DIR ROUTE_MATRIX
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=nightly/ce-2.8
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+  End
+
+  It 'n4a: nightly mode publisher failure aborts before any git mutation'
+    nightly_env
+    export FAKE_MODE=fail
+    When run script "$script"
+    The status should equal 1
+    The stderr should include 'simulated nightly publish fault'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'n4b: nightly mode invalid handoff JSON fails via the publisher before any git mutation'
+    nightly_env
+    printf 'not json' > "$HANDOFF_FILE"
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=nightly/ce-2.8
+    When run script "$script"
+    The status should equal 1
+    The stderr should include 'simulated handoff read/parse failure'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'n5: nightly mode NOOP output commits nothing'
+    nightly_env
+    export FAKE_MODE=noop
+    When run script "$script"
+    The status should equal 0
+    The output should include 'NOOP'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'n6: nightly mode commit message carries the nightly version subject and trailers, ignoring tagged vars'
+    nightly_env
+    # Tagged vars (RELEASE_TAG=v4.0.0.b1 etc.) remain exported by common_env --
+    # proves PUBLISH_KIND=nightly ignores them rather than leaking a tagged
+    # trailer into the nightly commit message.
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=nightly/ce-2.8
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
+    The variable msg should include 'publish: nightly 26.08.0001 -> ["nightly"]'
+    The variable msg should include 'pfBlockerNG-Nightly-Version: 26.08.0001'
+    The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1'
+    The variable msg should not include 'pfBlockerNG-Release-Tag'
+    The variable msg should not include 'v4.0.0.b1'
+  End
+
+  It 'n7: rejects an invalid PUBLISH_KIND value before any git call'
+    export PUBLISH_KIND=bogus
+    When run script "$script"
+    The status should equal 1
+    The stderr should include "::error::PUBLISH_KIND must be 'tagged' or 'nightly', got 'bogus'"
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'n8: PUBLISH_KIND unset still defaults to the tagged behaviour'
+    unset PUBLISH_KIND
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
+    The variable msg should include 'pfBlockerNG-Release-Tag: v4.0.0.b1'
+  End
+
+  It 'n9: nightly mode derives the landing matrix from the handoff route_matrix, not $ROUTE_MATRIX'
+    nightly_env
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=nightly/ce-2.8
+    export FAKE_LANDING_MATRIX_RECORD="${base}/landing-matrix-seen.json"
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    seen="$(cat "${base}/landing-matrix-seen.json")"
+    The variable seen should equal '[{"abi":"FreeBSD:15:*","pfsense_version":"2.8","variant":"CE","php_version":"8.3","py_flavor":"py311"}]'
   End
 End

--- a/tests/test_nightly_handoff.py
+++ b/tests/test_nightly_handoff.py
@@ -56,8 +56,25 @@ def _plan() -> tuple[np.Candidate, dict[str, object], dict[str, object]]:
             "name": f"pfSense-pkg-pfBlockerNG-{candidate.allocation.pkg_version}.pkg",
             "sha256": sha256(b"pkg").hexdigest(),
         },
+        "dep_artifacts": [],
     }
     return candidate, state, result
+
+
+def _call_handoff(result: dict[str, object], *, candidate: np.Candidate, state: dict[str, object]) -> dict[str, object]:
+    return np.build_handoff(
+        candidate=candidate,
+        state=state,
+        build_rows=[_row()],
+        route_rows=[_row(ci=True)],
+        results=[result],
+        source_sha="a" * 40,
+        ports_sha="b" * 40,
+        tools_sha="e" * 40,
+        matrix_sha="d" * 40,
+        matrix_digest="c" * 64,
+        run_id="123",
+    )
 
 
 def test_handoff_accepts_complete_build_and_route_rows() -> None:
@@ -88,6 +105,8 @@ def test_handoff_accepts_complete_build_and_route_rows() -> None:
     assert isinstance(route_matrix[1], dict) and route_matrix[1]["role"] == "route-only"
     assert route_matrix[1]["ci"] is False
     assert "role" not in route_matrix[0]
+    # R2: a leg with no extra_pkgs (Plus shape) carries an empty dep_artifacts.
+    assert builds[0]["dep_artifacts"] == []
 
 
 def test_handoff_rejects_missing_build_result() -> None:
@@ -130,3 +149,99 @@ def test_handoff_rejects_forged_input_digest() -> None:
             matrix_digest="c" * 64,
             run_id="123",
         )
+
+
+def test_handoff_carries_one_dep_artifact_sorted() -> None:
+    """R1: a CE-major-15 leg's single extra_pkgs dep .pkg is accepted and
+    carried through the handoff."""
+    candidate, state, result = _plan()
+    dep = {
+        "abi": "FreeBSD:15:*",
+        "name": "py311-charset-normalizer-3.4.0.pkg",
+        "sha256": sha256(b"dep").hexdigest(),
+    }
+    result["dep_artifacts"] = [dep]
+
+    handoff = _call_handoff(result, candidate=candidate, state=state)
+
+    builds = handoff["builds"]
+    assert isinstance(builds, list)
+    assert builds[0]["dep_artifacts"] == [dep]
+
+
+def test_handoff_rejects_result_missing_dep_artifacts_key() -> None:
+    """R3: dep_artifacts is a required field on every BUILD result."""
+    candidate, state, result = _plan()
+    del result["dep_artifacts"]
+
+    with pytest.raises(np.ProvenanceError, match="unexpected fields"):
+        _call_handoff(result, candidate=candidate, state=state)
+
+
+def test_handoff_rejects_result_with_extra_unknown_field() -> None:
+    """R4: an unrecognized field on a BUILD result is still rejected."""
+    candidate, state, result = _plan()
+    result["bogus"] = "nope"
+
+    with pytest.raises(np.ProvenanceError, match="unexpected fields"):
+        _call_handoff(result, candidate=candidate, state=state)
+
+
+def test_handoff_accepts_same_dep_name_across_different_legs() -> None:
+    """R10: dep_artifacts uniqueness is per-leg, not global -- two legs on
+    different FreeBSD majors may each carry a dep .pkg with the same
+    filename."""
+    state = np.empty_state()
+    candidate = np.allocate_candidate(
+        state,
+        build_date=date(2026, 8, 4),
+        source_sha="a" * 40,
+        ports_sha="b" * 40,
+        matrix_digest="c" * 64,
+    )
+    row15 = _row()
+    row16 = dict(_row())
+    row16["freebsd_major"] = "16"
+    row16["freebsd_version"] = "16.0-RELEASE"
+    record15 = np.make_build_record(allocation=candidate.allocation, matrix_row=row15, source_date_epoch=1_800_000_000)
+    record16 = np.make_build_record(allocation=candidate.allocation, matrix_row=row16, source_date_epoch=1_800_000_000)
+    dep_name = "py311-charset-normalizer-3.4.0.pkg"
+    result15 = {
+        "matrix_row": row15,
+        "record": record15,
+        "artifact": {
+            "abi": "FreeBSD:15:*",
+            "name": f"pfSense-pkg-pfBlockerNG-{candidate.allocation.pkg_version}.pkg",
+            "sha256": sha256(b"pkg15").hexdigest(),
+        },
+        "dep_artifacts": [{"abi": "FreeBSD:15:*", "name": dep_name, "sha256": sha256(b"dep15").hexdigest()}],
+    }
+    result16 = {
+        "matrix_row": row16,
+        "record": record16,
+        "artifact": {
+            "abi": "FreeBSD:16:*",
+            "name": f"pfSense-pkg-pfBlockerNG-{candidate.allocation.pkg_version}.pkg",
+            "sha256": sha256(b"pkg16").hexdigest(),
+        },
+        "dep_artifacts": [{"abi": "FreeBSD:16:*", "name": dep_name, "sha256": sha256(b"dep16").hexdigest()}],
+    }
+
+    handoff = np.build_handoff(
+        candidate=candidate,
+        state=state,
+        build_rows=[row15, row16],
+        route_rows=[_row(ci=True)],
+        results=[result15, result16],
+        source_sha="a" * 40,
+        ports_sha="b" * 40,
+        tools_sha="e" * 40,
+        matrix_sha="d" * 40,
+        matrix_digest="c" * 64,
+        run_id="123",
+    )
+
+    builds = handoff["builds"]
+    assert isinstance(builds, list)
+    names = {str(b["matrix_row"]["freebsd_major"]): b["dep_artifacts"][0]["name"] for b in builds}
+    assert names["15"] == names["16"] == dep_name

--- a/tests/test_nightly_provenance.py
+++ b/tests/test_nightly_provenance.py
@@ -206,3 +206,83 @@ def test_complete_rejects_malformed_artifacts_json(tmp_path: Path) -> None:
 def test_malformed_durable_state_fails_closed(state: dict[str, object]) -> None:
     with pytest.raises((TypeError, ValueError, np.ProvenanceError)):
         np.validate_state(state)
+
+
+# --- dep_artifacts (issue #2146 S1) -----------------------------------------
+# One BUILD leg's dependency .pkgs (issue #1806 extra_pkgs, Nightly-side): a
+# leg may ship zero or more, all sharing the leg's OWN wildcard ABI. Unlike
+# canonical `artifact` (`_validate_artifacts`, unique ABI across the whole
+# handoff), uniqueness here is per (abi, name) WITHIN one leg only.
+
+
+def _dep(
+    *,
+    abi: str = "FreeBSD:15:*",
+    name: str = "py311-charset-normalizer-3.4.0.pkg",
+    sha: str = sha256(b"dep").hexdigest(),
+) -> dict[str, str]:
+    return {"abi": abi, "name": name, "sha256": sha}
+
+
+def test_validate_dep_artifacts_accepts_empty_list() -> None:
+    assert np._validate_dep_artifacts([], leg_abi="FreeBSD:15:*", canonical_name="canonical.pkg") == []
+
+
+def test_validate_dep_artifacts_sorts_by_name() -> None:
+    deps = [_dep(name="b.pkg"), _dep(name="a.pkg")]
+    result = np._validate_dep_artifacts(deps, leg_abi="FreeBSD:15:*", canonical_name="canonical.pkg")
+    assert [item["name"] for item in result] == ["a.pkg", "b.pkg"]
+
+
+@pytest.mark.parametrize("abi", ["FreeBSD:16:*", "FreeBSD:15:amd64"])
+def test_validate_dep_artifacts_rejects_abi_not_equal_to_leg(abi: str) -> None:
+    with pytest.raises(np.ProvenanceError, match="abi"):
+        np._validate_dep_artifacts([_dep(abi=abi)], leg_abi="FreeBSD:15:*", canonical_name="canonical.pkg")
+
+
+def test_validate_dep_artifacts_rejects_duplicate_name_within_leg() -> None:
+    deps = [_dep(), _dep()]
+    with pytest.raises(np.ProvenanceError, match="unique"):
+        np._validate_dep_artifacts(deps, leg_abi="FreeBSD:15:*", canonical_name="canonical.pkg")
+
+
+def test_validate_dep_artifacts_rejects_name_equal_to_canonical() -> None:
+    with pytest.raises(np.ProvenanceError, match="canonical"):
+        np._validate_dep_artifacts([_dep(name="canonical.pkg")], leg_abi="FreeBSD:15:*", canonical_name="canonical.pkg")
+
+
+@pytest.mark.parametrize("name", ["../evil.pkg", "a/b.pkg", "a\\b.pkg", "evil\n.pkg", "no-suffix", ""])
+def test_validate_dep_artifacts_rejects_hostile_names(name: str) -> None:
+    with pytest.raises(np.ProvenanceError, match="name"):
+        np._validate_dep_artifacts([_dep(name=name)], leg_abi="FreeBSD:15:*", canonical_name="canonical.pkg")
+
+
+@pytest.mark.parametrize("sha", [sha256(b"dep").hexdigest().upper(), sha256(b"dep").hexdigest()[:-1], "z" * 64])
+def test_validate_dep_artifacts_rejects_malformed_sha256(sha: str) -> None:
+    with pytest.raises(np.ProvenanceError, match="sha256"):
+        np._validate_dep_artifacts([_dep(sha=sha)], leg_abi="FreeBSD:15:*", canonical_name="canonical.pkg")
+
+
+def test_validate_dep_artifacts_rejects_non_list() -> None:
+    with pytest.raises(np.ProvenanceError, match="list"):
+        np._validate_dep_artifacts(
+            {"abi": "FreeBSD:15:*", "name": "x.pkg", "sha256": sha256(b"x").hexdigest()},
+            leg_abi="FreeBSD:15:*",
+            canonical_name="canonical.pkg",
+        )
+
+
+def test_complete_never_receives_dep_artifacts_only_canonical() -> None:
+    """R12: durable state is fed ONLY canonical per-leg artifacts (nightly.yml's
+    ``jq '[.builds[].artifact]'`` step) -- dep_artifacts never reaches
+    np.complete or persisted state, regardless of how many dep .pkgs a leg
+    built."""
+    first = _candidate(np.empty_state())
+    canonical = _artifact(first.allocation)
+    state = np.complete(np.empty_state(), first, [canonical], run_id="100")
+
+    records = state["records"]
+    assert isinstance(records, list) and len(records) == 1
+    artifacts = records[0]["artifacts"]
+    assert artifacts == [canonical]
+    assert all(set(item) == {"abi", "name", "sha256"} for item in artifacts)

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -1,10 +1,30 @@
 """Static contract for the branch-independent Nightly workflow."""
 
+import itertools
 import re
 from pathlib import Path
 
 WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "nightly.yml"
 ALERT_WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "nightly-failure-alert.yml"
+
+
+def _extract_indented_block(text: str, anchor: str) -> str:
+    """Return the ``anchor:`` line plus every following line indented deeper than
+    it (blank lines pass through), stopping at the first line back at or above
+    the anchor's own indent.
+
+    Replaces a fixed-width slice: a hardcoded character count silently
+    truncates (or reads past the block into an unrelated sibling key) the
+    moment the block's rendered length drifts from the guess.
+    """
+    lines = text.splitlines()
+    anchor_index = next(i for i, line in enumerate(lines) if line.strip() == anchor)
+    anchor_indent = len(lines[anchor_index]) - len(lines[anchor_index].lstrip(" "))
+    body = itertools.takewhile(
+        lambda line: not line.strip() or (len(line) - len(line.lstrip(" "))) > anchor_indent,
+        lines[anchor_index + 1 :],
+    )
+    return "\n".join([lines[anchor_index], *body])
 
 
 def _extract_job(text: str, job_name: str) -> str:
@@ -163,8 +183,7 @@ def test_publish_pkg_repo_job_permissions_are_read_only() -> None:
     minted App token (create-github-app-token), never GITHUB_TOKEN."""
     text = WORKFLOW.read_text(encoding="utf-8")
     job = _extract_job(text, "publish-pkg-repo")
-    perms_start = job.index("permissions:")
-    perms_block = job[perms_start : perms_start + 120]
+    perms_block = _extract_indented_block(job, "permissions:")
     assert "packages: read" in perms_block
     assert "contents: read" in perms_block
     assert "contents: write" not in perms_block
@@ -243,10 +262,15 @@ def test_publish_pkg_repo_job_invokes_the_trusted_wrapper_with_nightly_kind() ->
 def test_publish_pkg_repo_job_documents_the_rerun_staleness_property() -> None:
     """W9: a "re-run failed jobs" attempt (new run_attempt against the SAME
     run_id) is REJECTED by publish_nightly.py's own handoff run_id equality
-    check -- documented in-workflow so that recovery path isn't mistaken for
-    safe; the whole workflow must be re-run instead."""
+    check -- documented in-workflow. A whole-workflow re-run does NOT recover a
+    failed publish either (the handoff job already persisted the allocation to
+    nightly-state.json before this job ran, so an identical-input re-run is a
+    green no-op that skips build+publish) -- the interim recovery is deleting
+    the stranded nightly-state.json record, and the real fix is issue #2245."""
     text = WORKFLOW.read_text(encoding="utf-8")
     job = _extract_job(text, "publish-pkg-repo")
     assert "re-run" in job.lower() or "rerun" in job.lower()
     assert "run_id" in job.lower()
     assert "reject" in job.lower()
+    assert "nightly-state.json" in job
+    assert "#2245" in job

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -1,9 +1,27 @@
 """Static contract for the branch-independent Nightly workflow."""
 
+import re
 from pathlib import Path
 
 WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "nightly.yml"
 ALERT_WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "nightly-failure-alert.yml"
+
+
+def _extract_job(text: str, job_name: str) -> str:
+    """Return the body of a top-level ``  <job_name>:`` job block, bounded to the
+    next sibling job at the same (2-space) indentation, or end-of-file.
+
+    Mirrors ``tests/_workflow_steps.extract_step``'s sibling-boundary idea, one
+    indentation level up (job keys, not `- name:` step items).
+    """
+    marker = re.compile(rf"^  {re.escape(job_name)}:\n", re.MULTILINE)
+    match = marker.search(text)
+    assert match is not None, f"job {job_name!r} not found in workflow"
+    start = match.end()
+    sibling = re.compile(r"^  [A-Za-z0-9_-]+:\n", re.MULTILINE)
+    next_match = sibling.search(text, start)
+    end = next_match.start() if next_match else len(text)
+    return text[start:end]
 
 
 def test_nightly_workflow_exists_and_is_branch_independent() -> None:
@@ -121,3 +139,114 @@ def test_handoff_step_artifact_extraction_stays_canonical_only() -> None:
 
     assert "jq '[.builds[].artifact]' nightly-handoff.json > artifacts.json" in step
     assert "dep_artifacts" not in step
+
+
+# --------------------------------------------------------------------------- #
+# issue #2146 S3 — the publish-pkg-repo job: the only production catalogue
+# mutation, gated on prepare's outcome AND the handoff job's own success.
+# --------------------------------------------------------------------------- #
+
+
+def test_publish_pkg_repo_job_gates_on_prepare_and_handoff() -> None:
+    """W1/W2: needs + if exact -- the only production catalogue mutation runs
+    strictly after the verified handoff, and only on an actual build outcome."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    job = _extract_job(text, "publish-pkg-repo")
+
+    assert 'name: "Publish the pkg catalogue"' in job
+    assert "needs: [prepare, handoff]" in job
+    assert "if: needs.prepare.outputs.outcome == 'build' && needs.handoff.result == 'success'" in job
+
+
+def test_publish_pkg_repo_job_permissions_are_read_only() -> None:
+    """W3: job-level permissions never carry contents: write -- the push rides the
+    minted App token (create-github-app-token), never GITHUB_TOKEN."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    job = _extract_job(text, "publish-pkg-repo")
+    perms_start = job.index("permissions:")
+    perms_block = job[perms_start : perms_start + 120]
+    assert "packages: read" in perms_block
+    assert "contents: read" in perms_block
+    assert "contents: write" not in perms_block
+
+
+def test_publish_pkg_repo_job_checks_out_pinned_trusted_tools() -> None:
+    """W4: trusted-tools checkout pinned to prepare's own tools_sha, path trusted --
+    same pinned-checkout idiom every other job in this workflow already uses, and
+    the security rationale release-published.yml's own pinned checkout documents
+    (this step is EXECUTED AS SHELL and, via publish_nightly.py, holds an App
+    token able to push to pfBlockerNG/pkg)."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    job = _extract_job(text, "publish-pkg-repo")
+    assert "ref: ${{ needs.prepare.outputs.tools_sha }}" in job
+    assert "path: trusted" in job
+    assert "SECURITY" in job
+
+
+def test_publish_pkg_repo_job_mints_scoped_app_token() -> None:
+    """W5: mirrors release-published.yml's own App-token step -- same secrets,
+    same narrowed permission-contents: write, scoped to pfBlockerNG/pkg."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    job = _extract_job(text, "publish-pkg-repo")
+    assert "actions/create-github-app-token@v3" in job
+    assert "app-id: ${{ secrets.PKG_GITHUB_APP_ID }}" in job
+    assert "private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}" in job
+    assert "owner: pfBlockerNG" in job
+    assert "repositories: pkg" in job
+    assert "permission-contents: write" in job
+
+
+def test_publish_pkg_repo_job_checks_out_pkg_repo_with_app_token() -> None:
+    """W6: pfBlockerNG/pkg checkout carries the minted token with
+    persist-credentials true (publish-pkg-repo.sh's push rides this checkout's
+    own credential helper)."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    job = _extract_job(text, "publish-pkg-repo")
+    assert "repository: pfBlockerNG/pkg" in job
+    assert "ref: main" in job
+    assert "token: ${{ steps.app-token.outputs.token }}" in job
+    assert "persist-credentials: true" in job
+    assert "path: pkg-repo" in job
+    assert "fetch-depth: 1" in job
+
+
+def test_publish_pkg_repo_job_downloads_both_handoff_and_result_artifacts() -> None:
+    """W7: both artifact downloads -- the single-file handoff and every
+    nightly-result-<major>/ leg, merge-multiple false (one directory per leg,
+    matching what the handoff job's own download step already requires)."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    job = _extract_job(text, "publish-pkg-repo")
+    assert "name: nightly-handoff-${{ github.run_id }}" in job
+    assert "path: handoff" in job
+    assert "pattern: nightly-result-*" in job
+    assert "path: results" in job
+    assert "merge-multiple: false" in job
+
+
+def test_publish_pkg_repo_job_invokes_the_trusted_wrapper_with_nightly_kind() -> None:
+    """W8: PUBLISH_KIND=nightly, SOURCE_RUN_ID = run_id:run_attempt (same
+    composition as the handoff job's own stale-callback identity), path env vars
+    exported in the RUN BODY not the env: map (issue #2231), and the wrapper is
+    invoked from the TRUSTED checkout, never the pkg-repo one."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    job = _extract_job(text, "publish-pkg-repo")
+    assert "PUBLISH_KIND=nightly" in job
+    assert 'SOURCE_RUN_ID="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"' in job
+    assert 'PFB_SRC="$GITHUB_WORKSPACE/trusted"' in job
+    assert 'PKG_REPO="$GITHUB_WORKSPACE/pkg-repo"' in job
+    assert 'HANDOFF_FILE="$GITHUB_WORKSPACE/handoff/nightly-handoff.json"' in job
+    assert 'RESULTS_DIR="$GITHUB_WORKSPACE/results"' in job
+    assert "BASE_URL=https://pfblockerng.github.io/pkg" in job
+    assert "sh trusted/scripts/publish-pkg-repo.sh" in job
+
+
+def test_publish_pkg_repo_job_documents_the_rerun_staleness_property() -> None:
+    """W9: a "re-run failed jobs" attempt (new run_attempt against the SAME
+    run_id) is REJECTED by publish_nightly.py's own handoff run_id equality
+    check -- documented in-workflow so that recovery path isn't mistaken for
+    safe; the whole workflow must be re-run instead."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    job = _extract_job(text, "publish-pkg-repo")
+    assert "re-run" in job.lower() or "rerun" in job.lower()
+    assert "run_id" in job.lower()
+    assert "reject" in job.lower()

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -79,3 +79,45 @@ def test_nightly_failure_alert_watches_snapshot_workflow() -> None:
     text = ALERT_WORKFLOW.read_text(encoding="utf-8")
 
     assert '- "Nightly snapshot"' in text
+
+
+def test_build_step_builds_and_hands_off_dependency_packages() -> None:
+    """issue #2146 S1: the BUILD leg also builds this leg's extra_pkgs dep
+    .pkgs (issue #1806), with NO tagged-style rename, and folds them into
+    result.json's dep_artifacts."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    start = text.index("      - name: Build and verify package")
+    end = text.index("\n      - name: Upload verified build", start)
+    step = text[start:end]
+
+    # W1: build-dep-pkg-portable.py invoked with the full flag set.
+    assert "build-dep-pkg-portable.py" in step
+    assert "--ports" in step
+    assert "--port" in step
+    assert "--py-flavor" in step
+    assert "--freebsd-major" in step
+    assert "--out-dir" in step
+
+    # W2: loop driven by the matrix row's extra_pkgs, sparse-checkout add per origin.
+    assert ".extra_pkgs" in step
+    assert 'git -C "$PORTS_DIR" sparse-checkout add "$ORIGIN"' in step
+
+    # W3: no rename -- nightly dep .pkgs keep their canonical filename.
+    assert "-${VARIANT}-${PFSENSE_VERSION}.pkg" not in step
+    assert "RENAMED_DEP" not in step
+
+    # W4: result.json construction includes dep_artifacts.
+    assert "dep_artifacts" in step
+    assert "DEP_ARTIFACTS_JSON" in step
+
+
+def test_handoff_step_artifact_extraction_stays_canonical_only() -> None:
+    """W5: the handoff step's durable-state artifact extraction remains
+    canonical-only -- dep_artifacts must never reach `complete`/state.json."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    start = text.index("      - name: Create verified publisher handoff")
+    end = text.index("\n      - name: Upload verified publisher handoff", start)
+    step = text[start:end]
+
+    assert "jq '[.builds[].artifact]' nightly-handoff.json > artifacts.json" in step
+    assert "dep_artifacts" not in step

--- a/tests/test_publish_nightly.py
+++ b/tests/test_publish_nightly.py
@@ -470,6 +470,37 @@ class StaleTests(_TempDirTestCase):
         after = {p.name: p.read_bytes() for p in catalogue_dir.iterdir()}
         self.assertEqual(after, before)
 
+    @_requires_engine
+    def test_published_manifest_missing_version_rejected_cleanly(self) -> None:
+        """N3b: a catalogue-resident canonical .pkg whose manifest somehow lacks
+        'version' (a corrupt or foreign write -- this publisher's own write
+        path always carries one) must reject with a clean PublishNightlyError
+        naming the corrupt file, not a raw KeyError out of
+        manifest["version"]. The fixture writes the tar directly (bypassing
+        _wrap_canonical_pkg, which always injects version) since that is the
+        only way to construct this shape."""
+        handoff, results_dir, _alloc = self.base_handoff()
+        _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+        catalogue_dir = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        corrupt_name = "pfSense-pkg-pfBlockerNG-99.99.9999.pkg"
+        corrupt_path = catalogue_dir / corrupt_name
+        manifest = {"name": _ENGINE.pfb_pkg.CANONICAL_EMITTED_IDENTITY, "abi": "FreeBSD:15:*"}
+        _write_tar_pkg(
+            corrupt_path,
+            [("+COMPACT_MANIFEST", json.dumps(manifest, separators=(",", ":")).encode(), 0o644, 0)],
+        )
+
+        newer_alloc = _allocation(build_date=date(2026, 8, 20))
+        results_dir_2 = self.new_results_dir()
+        handoff_2 = _build_handoff(
+            newer_alloc, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_dir_2
+        )
+
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=handoff_2, results_dir=results_dir_2, pkg_repo=self.pkg_repo)
+        self.assertIn(str(corrupt_path), str(ctx.exception))
+
 
 # --------------------------------------------------------------------------- #
 # T5 — retention: keep+1 canonical generations published sequentially, oldest
@@ -639,6 +670,34 @@ class HandoffIntegrityTests(_TempDirTestCase):
             _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
         self.assertIn("ports_sha", str(ctx.exception))
 
+    @_requires_engine
+    def test_tampered_matrix_digest_input_digest_mismatch_rejected(self) -> None:
+        """N2: re-run nightly_provenance.build_handoff's OWN input-digest
+        cross-check at publish time too -- a handoff whose matrix_digest was
+        swapped for a different (still well-formed) value no longer matches
+        allocation.input_digest, which build_handoff computed from the
+        ORIGINAL matrix_digest at handoff-creation time. Without this
+        re-check, a forged matrix_digest sails through untouched: nothing else
+        in the handoff shape depends on it."""
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        self.assertNotEqual(mutated["matrix_digest"], "d" * 64)
+        mutated["matrix_digest"] = "d" * 64
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("input_digest", str(ctx.exception))
+
+    @_requires_engine
+    def test_matrix_digest_malformed_shape_rejected(self) -> None:
+        """N2: matrix_digest shape (lowercase 64-character hex) is validated
+        BEFORE it is ever fed to combined_nightly_input_digest."""
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        mutated["matrix_digest"] = "not-hex"
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("matrix_digest", str(ctx.exception))
+
 
 # --------------------------------------------------------------------------- #
 # T7 — routing rejections.
@@ -703,6 +762,40 @@ class RoutingTests(_TempDirTestCase):
         with self.assertRaises(pn.PublishNightlyError) as ctx:
             pn._route_targets(_ENGINE, [ROW_CE15], [leg_a, leg_b])
         self.assertIn("more than one built asset", str(ctx.exception))
+
+    @_requires_engine
+    def test_dep_abi_mismatch_rejected_via_route_targets(self) -> None:
+        """N3a: a leg's dependency manifest ABI that does NOT belong to that
+        leg's own FreeBSD major (a forged handoff -- a genuine
+        nightly_provenance.build_handoff run would never construct this
+        shape, since _validate_dep_artifacts pins every dep to the leg's own
+        wildcard ABI) is rejected by _route_targets's own ABI cross-check,
+        exercised directly via hand-built _Leg/VerifiedAsset objects, same
+        idiom as test_two_legs_same_major_rejected_via_route_targets above."""
+        allocation = _allocation()
+        record = np.make_build_record(allocation=allocation, matrix_row=ROW_CE15, source_date_epoch=_EPOCH)
+        canonical = pc.VerifiedAsset(
+            asset_class="canonical",
+            declared_name="a.pkg",
+            canonical_name="a.pkg",
+            work_path=Path("a.pkg"),
+            sha256="0" * 64,
+            manifest={},
+            record=record,
+        )
+        mismatched_dep = pc.VerifiedAsset(
+            asset_class="dependency",
+            declared_name="dep.pkg",
+            canonical_name="dep.pkg",
+            work_path=Path("dep.pkg"),
+            sha256="1" * 64,
+            manifest={"abi": "FreeBSD:16:*"},
+        )
+        leg = pn._Leg(major="15", matrix_row=ROW_CE15, canonical=canonical, dependencies=(mismatched_dep,))
+
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            pn._route_targets(_ENGINE, [ROW_CE15], [leg])
+        self.assertIn("dependency ABI does not match FreeBSD major", str(ctx.exception))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_publish_nightly.py
+++ b/tests/test_publish_nightly.py
@@ -1,0 +1,953 @@
+"""Tests for scripts/publish_nightly.py — issue #2146 step S2 (Nightly-handoff
+publisher CLI): re-validate the verified Nightly handoff
+(nightly_provenance.build_handoff's own shape, read back as untrusted JSON), verify
+every referenced .pkg asset from BYTES (publish_catalogues.verify_asset — never
+trusting the handoff's own literal record/matrix_row/artifact echoes), fan each
+per-FreeBSD-major build out to every ROUTE varver sharing that major, then assemble
+nightly/<varver>/ catalogues with retention
+(catalogue_assembly.prune_retained/regenerate_catalogue/verify_multi_destination_identity
+— reused, never re-derived). No git, no network.
+
+Fixture .pkg archives mirror tests/test_publish_release.py's _wrap_canonical_pkg /
+_wrap_dependency_pkg (duplicated here, matching this repo's per-file fixture
+convention) but WITHOUT the tagged -<Variant>-<pfsense_version> suffix: Nightly's
+canonical/dependency declared names equal the package's own manifest identity.
+Build records are minted via nightly_provenance.make_build_record with a genuine
+NightlyAllocation (nightly_provenance.allocate_candidate over an empty durable state
+— no chained history needed for these fixtures, each allocation is independent).
+Handoffs are assembled via nightly_provenance.build_handoff itself wherever the
+scenario is a legitimate one; hostile/forged scenarios mutate a valid handoff's OWN
+dict after the fact (JSON round-tripped, `_mutate`), since build_handoff's own
+validation would otherwise refuse to construct them honestly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import itertools
+import json
+import os
+import sys
+import tarfile
+import tempfile
+import unittest
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import catalogue_assembly as ca
+import nightly_provenance as np
+import publish_catalogues as pc
+import publish_nightly as pn
+import publish_release as pr
+from _srcrepo import SourceRepoError, resolve_src_root
+
+try:
+    _SRC_ROOT = resolve_src_root()
+    _ENGINE = pc.load_engine(_SRC_ROOT)
+    _ENGINE_SKIP_REASON = ""
+except SourceRepoError as exc:  # pragma: no cover - environment gap, not a behaviour regression
+    _SRC_ROOT = None
+    _ENGINE = None
+    _ENGINE_SKIP_REASON = str(exc)
+
+_requires_engine = unittest.skipIf(_ENGINE is None, _ENGINE_SKIP_REASON)
+
+_REPO = pc.EXPECTED_SOURCE_REPOSITORY
+_RUN_ID = "555000111:1"
+_SOURCE_SHA = "a" * 40
+_PORTS_SHA = "b" * 40
+_TOOLS_SHA = "e" * 40
+_MATRIX_SHA = "d" * 40
+_MATRIX_DIGEST = "c" * 64
+_EPOCH = 1_800_000_000
+
+_pkg_counter = itertools.count()
+
+
+# --------------------------------------------------------------------------- #
+# ROUTE/BUILD matrix rows — mirrors tests/test_publish_release.py's ROW_* shape.
+# --------------------------------------------------------------------------- #
+
+
+def _row(
+    *,
+    freebsd_major: str = "15",
+    pfsense_version: str = "2.8",
+    variant: str = "CE",
+    extra_pkgs: Sequence[str] = (),
+    role: str | None = None,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "pfsense_version": pfsense_version,
+        "channel": variant,
+        "freebsd_version": f"{freebsd_major}.0-RELEASE",
+        "freebsd_major": freebsd_major,
+        "php_version": "8.3",
+        "py_flavor": "py311",
+        "variant": variant,
+        "status": "active",
+        "extra_pkgs": list(extra_pkgs),
+    }
+    if role is not None:
+        row["role"] = role
+    return row
+
+
+ROW_CE15 = _row(freebsd_major="15", pfsense_version="2.8", variant="CE", extra_pkgs=["textproc/py-charset-normalizer"])
+ROW_PLUS16_03 = _row(freebsd_major="16", pfsense_version="26.03", variant="Plus")
+ROW_PLUS16_07 = _row(freebsd_major="16", pfsense_version="26.07", variant="Plus")
+ROW_ROUTE_ONLY_17 = _row(freebsd_major="17", pfsense_version="17.0", variant="CE", role="route-only")
+
+
+# --------------------------------------------------------------------------- #
+# Allocation + genuine .pkg archive fixture builders.
+# --------------------------------------------------------------------------- #
+
+
+def _allocation(
+    *,
+    build_date: date = date(2026, 8, 4),
+    source_sha: str = _SOURCE_SHA,
+    ports_sha: str = _PORTS_SHA,
+    matrix_digest: str = _MATRIX_DIGEST,
+) -> Any:
+    candidate = np.allocate_candidate(
+        np.empty_state(),
+        build_date=build_date,
+        source_sha=source_sha,
+        ports_sha=ports_sha,
+        matrix_digest=matrix_digest,
+    )
+    return candidate.allocation
+
+
+def _write_tar_pkg(path: Path, members: list[tuple[str, bytes, int, int]]) -> None:
+    pfb_pkg = _ENGINE.pfb_pkg
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tf:
+        for name, data, mode, mtime in members:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mode = mode
+            info.mtime = mtime
+            tf.addfile(info, io.BytesIO(data))
+    path.write_bytes(pfb_pkg.zstd_compress(raw.getvalue(), pfb_pkg.PkgError, "zstd unavailable"))
+
+
+def _wrap_canonical_pkg(directory: Path, record: dict, *, local_name: str) -> tuple[Path, str]:
+    """A full, validate_project_pkg-shaped canonical .pkg carrying ``record`` as its
+    pfb_build_record annotation, under its bare Nightly name (no -<Variant>-<version>
+    suffix). Returns (path, sha256 of the bytes)."""
+    pfb_pkg = _ENGINE.pfb_pkg
+    row = record["matrix_row"]
+    version = record["canonical_package_version"]
+    epoch = record["source_date_epoch"]
+    major = row["freebsd_major"]
+
+    payload = {
+        pfb_pkg._INFO_PATH: (
+            f"<pfsensepkgs><package><name>pfBlockerNG</name><version>{version}</version></package></pfsensepkgs>"
+        ).encode(),
+        "/usr/local/pkg/pfblockerng/pfb_stub.py": b"print('ok')\n",
+    }
+    common = {
+        "name": pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+        "origin": "net/pfSense-pkg-pfBlockerNG",
+        "version": version,
+        "abi": f"FreeBSD:{major}:*",
+        "arch": f"freebsd:{major}:*",
+        "prefix": "/usr/local",
+        "annotations": {pfb_pkg.PFB_BUILD_RECORD_KEY: json.dumps(record, separators=(",", ":"), sort_keys=True)},
+    }
+    php_dep = "php" + row["php_version"].replace(".", "")
+    python_dep = "python" + row["py_flavor"][2:]
+    deps = {
+        php_dep: {"origin": f"lang/{php_dep}", "version": "1.0"},
+        python_dep: {"origin": f"lang/{python_dep}", "version": "1.0"},
+    }
+    files = {
+        name: {
+            "sum": "1$" + hashlib.sha256(data).hexdigest(),
+            "perm": "0644",
+            "mtime": epoch,
+            "size": len(data),
+        }
+        for name, data in payload.items()
+    }
+    full = {
+        **common,
+        "deps": deps,
+        "files": files,
+        "scripts": {
+            "install": "#!/bin/sh\n/usr/local/bin/php -f /etc/rc.packages pfSense-pkg-pfBlockerNG ${2}\n",
+            "deinstall": "#!/bin/sh\n/usr/local/bin/php -f /etc/rc.packages pfSense-pkg-pfBlockerNG ${2}\n",
+        },
+    }
+    compact = {**common, "deps": deps}
+
+    members = [
+        ("+COMPACT_MANIFEST", json.dumps(compact, separators=(",", ":")).encode(), 0o644, 0),
+        ("+MANIFEST", json.dumps(full, separators=(",", ":")).encode(), 0o644, 0),
+    ]
+    members.extend((name, data, 0o644, epoch) for name, data in payload.items())
+    path = directory / local_name
+    _write_tar_pkg(path, members)
+    return path, hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _wrap_dependency_pkg(
+    directory: Path,
+    *,
+    name: str,
+    version: str,
+    abi: str,
+    local_name: str,
+) -> tuple[Path, str]:
+    manifest = {"name": name, "version": version, "abi": abi, "origin": f"textproc/{name}"}
+    compact = json.dumps(manifest, separators=(",", ":")).encode()
+    members = [("+COMPACT_MANIFEST", compact, 0o644, 0)]
+    path = directory / local_name
+    _write_tar_pkg(path, members)
+    return path, hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# Leg / handoff assembly — one _LegSpec per BUILD major, folded into a genuine
+# nightly_provenance.build_handoff() call.
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class _LegSpec:
+    row: dict[str, object]
+    dep_specs: Sequence[tuple[str, str]] = ()
+    source_date_epoch: int = _EPOCH
+
+
+def _build_leg_result(allocation: Any, spec: _LegSpec, *, assets_root: Path) -> dict[str, Any]:
+    """Mint one leg's genuine record + canonical/dep .pkg archives under
+    assets_root/nightly-result-<major>/, and return the handoff-shaped `result` dict
+    nightly_provenance.build_handoff itself expects as one entry of `results`."""
+    major = str(spec.row["freebsd_major"])
+    legdir = assets_root / f"{pn._LEG_DIR_PREFIX}{major}"
+    legdir.mkdir(parents=True, exist_ok=True)
+    record = np.make_build_record(allocation=allocation, matrix_row=spec.row, source_date_epoch=spec.source_date_epoch)
+    canonical_name = f"{_ENGINE.pfb_pkg.CANONICAL_EMITTED_IDENTITY}-{allocation.pkg_version}.pkg"
+    _path, digest = _wrap_canonical_pkg(legdir, record, local_name=canonical_name)
+    dep_artifacts = []
+    for name, version in spec.dep_specs:
+        dep_name = f"{name}-{version}.pkg"
+        _dep_path, dep_digest = _wrap_dependency_pkg(
+            legdir, name=name, version=version, abi=f"FreeBSD:{major}:*", local_name=dep_name
+        )
+        dep_artifacts.append({"abi": f"FreeBSD:{major}:*", "name": dep_name, "sha256": dep_digest})
+    return {
+        "matrix_row": spec.row,
+        "record": record,
+        "artifact": {"abi": f"FreeBSD:{major}:*", "name": canonical_name, "sha256": digest},
+        "dep_artifacts": dep_artifacts,
+    }
+
+
+def _build_handoff(
+    allocation: Any,
+    *,
+    legs: Sequence[_LegSpec],
+    route_rows: Sequence[dict[str, object]],
+    assets_root: Path,
+    run_id: str = _RUN_ID,
+    source_sha: str = _SOURCE_SHA,
+    ports_sha: str = _PORTS_SHA,
+) -> dict[str, Any]:
+    results = [_build_leg_result(allocation, spec, assets_root=assets_root) for spec in legs]
+    build_rows = [spec.row for spec in legs]
+    candidate = np.Candidate(allocation=allocation, generation=0)
+    return np.build_handoff(
+        candidate=candidate,
+        state=np.empty_state(),
+        build_rows=build_rows,
+        route_rows=list(route_rows),
+        results=results,
+        source_sha=source_sha,
+        ports_sha=ports_sha,
+        tools_sha=_TOOLS_SHA,
+        matrix_sha=_MATRIX_SHA,
+        matrix_digest=_MATRIX_DIGEST,
+        run_id=run_id,
+    )
+
+
+def _mutate(handoff: dict[str, Any]) -> dict[str, Any]:
+    """A fully independent, mutable deep copy (JSON round-trip)."""
+    return json.loads(json.dumps(handoff))
+
+
+def _run(
+    *,
+    handoff: dict[str, Any],
+    results_dir: Path,
+    pkg_repo: Path,
+    source_run_id: str = _RUN_ID,
+) -> pr.PublishReport:
+    handoff_path = results_dir.parent / f"handoff-{next(_pkg_counter)}.json"
+    handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+    return pn.run(
+        handoff_path=handoff_path,
+        results_dir=results_dir,
+        pkg_repo=pkg_repo,
+        source_run_id=source_run_id,
+        engine=_ENGINE,
+    )
+
+
+class _TempDirTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="pub-nightly-test-")
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.pkg_repo = self.tmp / "pkg-repo"
+        self._dir_counter = itertools.count()
+
+    def new_results_dir(self) -> Path:
+        results_dir = self.tmp / f"results-{next(self._dir_counter)}"
+        results_dir.mkdir(parents=True)
+        return results_dir
+
+    def base_handoff(self) -> tuple[dict[str, Any], Path, Any]:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_dir
+        )
+        return handoff, results_dir, allocation
+
+
+# --------------------------------------------------------------------------- #
+# T1 — happy fan-out: 2 legs, 3 ROUTE rows -> 3 catalogues.
+# --------------------------------------------------------------------------- #
+
+
+class HappyFanOutTests(_TempDirTestCase):
+    @_requires_engine
+    def test_two_legs_three_route_rows_three_catalogues(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        legs = [
+            _LegSpec(row=ROW_CE15, dep_specs=[("py311-charset-normalizer", "3.4.0")]),
+            _LegSpec(row=ROW_PLUS16_03),
+        ]
+        route_rows = [ROW_CE15, ROW_PLUS16_03, ROW_PLUS16_07]
+        handoff = _build_handoff(allocation, legs=legs, route_rows=route_rows, assets_root=results_dir)
+
+        report = _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+        self.assertEqual(
+            set(report.touched),
+            {("nightly", "ce-2.8"), ("nightly", "plus-26.03"), ("nightly", "plus-26.07")},
+        )
+        docs = self.pkg_repo / "docs" / "nightly"
+        canonical_name = f"pfSense-pkg-pfBlockerNG-{allocation.pkg_version}.pkg"
+        self.assertTrue((docs / "ce-2.8" / canonical_name).is_file())
+        self.assertTrue((docs / "ce-2.8" / "py311-charset-normalizer-3.4.0.pkg").is_file())
+        self.assertTrue((docs / "plus-26.03" / canonical_name).is_file())
+        self.assertTrue((docs / "plus-26.07" / canonical_name).is_file())
+        self.assertFalse((docs / "plus-26.03" / "py311-charset-normalizer-3.4.0.pkg").exists())
+        self.assertFalse((docs / "plus-26.07" / "py311-charset-normalizer-3.4.0.pkg").exists())
+        self.assertEqual(
+            (docs / "plus-26.03" / canonical_name).read_bytes(),
+            (docs / "plus-26.07" / canonical_name).read_bytes(),
+        )
+        for varver in ("ce-2.8", "plus-26.03", "plus-26.07"):
+            self.assertTrue((docs / varver / "meta.conf").is_file(), varver)
+            self.assertTrue((docs / varver / "data.pkg").is_file(), varver)
+            self.assertTrue((docs / varver / "packagesite.pkg").is_file(), varver)
+
+
+# --------------------------------------------------------------------------- #
+# T2 — identical rerun is a NOOP.
+# --------------------------------------------------------------------------- #
+
+
+class NoopTests(_TempDirTestCase):
+    @_requires_engine
+    def test_identical_rerun_is_noop(self) -> None:
+        handoff, results_dir, allocation = self.base_handoff()
+        first = _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertTrue(first.touched)
+
+        catalogue_dir = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        canonical_name = f"pfSense-pkg-pfBlockerNG-{allocation.pkg_version}.pkg"
+        before_mtime = (catalogue_dir / canonical_name).stat().st_mtime_ns
+        before_bytes = (catalogue_dir / canonical_name).read_bytes()
+
+        second = _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+        self.assertEqual(second.touched, ())
+        self.assertTrue(second.noop)
+        self.assertEqual(
+            second.describe(),
+            ["NOOP: every destination already matches this run's verified assets"],
+        )
+        self.assertEqual((catalogue_dir / canonical_name).stat().st_mtime_ns, before_mtime)
+        self.assertEqual((catalogue_dir / canonical_name).read_bytes(), before_bytes)
+
+
+# --------------------------------------------------------------------------- #
+# T3 — same version, different bytes already at a destination: fail closed.
+# --------------------------------------------------------------------------- #
+
+
+class ConflictTests(_TempDirTestCase):
+    @_requires_engine
+    def test_same_version_different_bytes_rejected(self) -> None:
+        results_dir_1 = self.new_results_dir()
+        allocation = _allocation()
+        handoff_1 = _build_handoff(
+            allocation, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_dir_1
+        )
+        first = _run(handoff=handoff_1, results_dir=results_dir_1, pkg_repo=self.pkg_repo)
+        self.assertEqual(first.touched, (("nightly", "ce-2.8"),))
+
+        catalogue_dir = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        canonical_name = f"pfSense-pkg-pfBlockerNG-{allocation.pkg_version}.pkg"
+        original_bytes = (catalogue_dir / canonical_name).read_bytes()
+
+        # SAME allocation (same day/version, same source_sha/ports_sha) but a
+        # DIFFERENT source_date_epoch -- genuinely different archive bytes under the
+        # identical canonical name, with every OTHER cross-checked field unchanged.
+        results_dir_2 = self.new_results_dir()
+        handoff_2 = _build_handoff(
+            allocation,
+            legs=[_LegSpec(row=ROW_CE15, source_date_epoch=_EPOCH + 1)],
+            route_rows=[ROW_CE15],
+            assets_root=results_dir_2,
+        )
+
+        with self.assertRaises(pr.DestinationConflictError) as ctx:
+            _run(handoff=handoff_2, results_dir=results_dir_2, pkg_repo=self.pkg_repo)
+        self.assertIn(str(catalogue_dir / canonical_name), str(ctx.exception))
+        self.assertEqual((catalogue_dir / canonical_name).read_bytes(), original_bytes)
+
+
+# --------------------------------------------------------------------------- #
+# T4 — a destination holding a NEWER version rejects an older/absent incoming
+# version BEFORE any write.
+# --------------------------------------------------------------------------- #
+
+
+class StaleTests(_TempDirTestCase):
+    @_requires_engine
+    def test_older_absent_version_rejected_before_any_write(self) -> None:
+        newer_alloc = _allocation(build_date=date(2026, 8, 10))
+        results_dir_1 = self.new_results_dir()
+        handoff_1 = _build_handoff(
+            newer_alloc, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_dir_1
+        )
+        first = _run(handoff=handoff_1, results_dir=results_dir_1, pkg_repo=self.pkg_repo)
+        self.assertTrue(first.touched)
+
+        catalogue_dir = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        before = {p.name: p.read_bytes() for p in catalogue_dir.iterdir()}
+
+        older_alloc = _allocation(build_date=date(2026, 8, 5))
+        results_dir_2 = self.new_results_dir()
+        handoff_2 = _build_handoff(
+            older_alloc, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_dir_2
+        )
+
+        with self.assertRaises(pn.StaleNightlyError) as ctx:
+            _run(handoff=handoff_2, results_dir=results_dir_2, pkg_repo=self.pkg_repo)
+        self.assertIn("stale", str(ctx.exception).lower())
+
+        after = {p.name: p.read_bytes() for p in catalogue_dir.iterdir()}
+        self.assertEqual(after, before)
+
+
+# --------------------------------------------------------------------------- #
+# T5 — retention: keep+1 canonical generations published sequentially, oldest
+# evicted, a dependency introduced on the FIRST (evicted) generation survives.
+# --------------------------------------------------------------------------- #
+
+
+class RetentionTests(_TempDirTestCase):
+    @_requires_engine
+    def test_retention_evicts_oldest_canonical_dep_survives(self) -> None:
+        keep = ca.DEFAULT_RETENTION_KEEP
+        catalogue_dir = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        dep_name = "py311-charset-normalizer-3.4.0.pkg"
+        first_version = None
+        for seq in range(keep + 1):
+            allocation = _allocation(build_date=date(2026, 8, 1 + seq))
+            if seq == 0:
+                first_version = allocation.pkg_version
+            dep_specs = [("py311-charset-normalizer", "3.4.0")] if seq == 0 else ()
+            results_dir = self.new_results_dir()
+            handoff = _build_handoff(
+                allocation,
+                legs=[_LegSpec(row=ROW_CE15, dep_specs=dep_specs)],
+                route_rows=[ROW_CE15],
+                assets_root=results_dir,
+            )
+            _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+        remaining = sorted(p.name for p in catalogue_dir.glob("pfSense-pkg-pfBlockerNG-*.pkg"))
+        self.assertEqual(len(remaining), keep)
+        self.assertNotIn(f"pfSense-pkg-pfBlockerNG-{first_version}.pkg", remaining)
+        self.assertTrue((catalogue_dir / dep_name).is_file())
+
+
+# --------------------------------------------------------------------------- #
+# T6 — handoff integrity rejections.
+# --------------------------------------------------------------------------- #
+
+
+class HandoffIntegrityTests(_TempDirTestCase):
+    @_requires_engine
+    def test_intake_kind_is_nightly(self) -> None:
+        intake = pc.parse_intake(_REPO, "", "", '["nightly"]', _RUN_ID)
+        self.assertEqual(intake.kind, "nightly")
+
+    @_requires_engine
+    def test_sha256_mismatch_vs_file_bytes_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        mutated["builds"][0]["artifact"]["sha256"] = "0" * 64
+        with self.assertRaises(pc.AssetVerificationError):
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+    @_requires_engine
+    def test_record_version_mismatches_allocation_rejected(self) -> None:
+        results_dir = self.new_results_dir()
+        real_alloc = _allocation(build_date=date(2026, 8, 4))
+        forged_alloc = _allocation(build_date=date(2026, 8, 9))
+        handoff = _build_handoff(
+            real_alloc, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_dir
+        )
+        legdir = results_dir / f"{pn._LEG_DIR_PREFIX}15"
+        forged_record = np.make_build_record(allocation=forged_alloc, matrix_row=ROW_CE15, source_date_epoch=_EPOCH)
+        forged_name = f"pfSense-pkg-pfBlockerNG-{forged_alloc.pkg_version}.pkg"
+        _path, forged_digest = _wrap_canonical_pkg(legdir, forged_record, local_name=forged_name)
+
+        mutated = _mutate(handoff)
+        mutated["builds"][0]["artifact"] = {"abi": "FreeBSD:15:*", "name": forged_name, "sha256": forged_digest}
+
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("allocation.pkg_version", str(ctx.exception))
+
+    @_requires_engine
+    def test_run_id_mismatch_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo, source_run_id="some-other-run")
+        self.assertIn("run_id", str(ctx.exception))
+
+    @_requires_engine
+    def test_kind_wrong_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        mutated["kind"] = "tagged-handoff"
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("kind", str(ctx.exception))
+
+    @_requires_engine
+    def test_schema_wrong_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        mutated["schema"] = 2
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("schema", str(ctx.exception))
+
+    @_requires_engine
+    def test_top_level_field_missing_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        del mutated["source_ref"]
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("exact fields", str(ctx.exception))
+
+    @_requires_engine
+    def test_top_level_field_extra_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        mutated["bogus"] = "nope"
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("exact fields", str(ctx.exception))
+
+    @_requires_engine
+    def test_build_entry_field_missing_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        del mutated["builds"][0]["dep_artifacts"]
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("build entry", str(ctx.exception))
+
+    @_requires_engine
+    def test_build_entry_field_extra_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        mutated["builds"][0]["bogus"] = 1
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("build entry", str(ctx.exception))
+
+    @_requires_engine
+    def test_duplicate_build_majors_rejected(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation,
+            legs=[_LegSpec(row=ROW_CE15), _LegSpec(row=ROW_PLUS16_03)],
+            route_rows=[ROW_CE15, ROW_PLUS16_03],
+            assets_root=results_dir,
+        )
+        mutated = _mutate(handoff)
+        mutated["builds"][1]["matrix_row"]["freebsd_major"] = mutated["builds"][0]["matrix_row"]["freebsd_major"]
+        mutated["builds"][1]["matrix_row"]["freebsd_version"] = mutated["builds"][0]["matrix_row"]["freebsd_version"]
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("duplicate", str(ctx.exception))
+
+    @_requires_engine
+    def test_allocation_source_sha_mismatch_top_level_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        mutated["source_sha"] = "f" * 40
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("source_sha", str(ctx.exception))
+
+    @_requires_engine
+    def test_allocation_ports_sha_mismatch_top_level_rejected(self) -> None:
+        handoff, results_dir, _alloc = self.base_handoff()
+        mutated = _mutate(handoff)
+        mutated["ports_sha"] = "f" * 40
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("ports_sha", str(ctx.exception))
+
+
+# --------------------------------------------------------------------------- #
+# T7 — routing rejections.
+# --------------------------------------------------------------------------- #
+
+
+class RoutingTests(_TempDirTestCase):
+    @_requires_engine
+    def test_route_row_major_has_no_asset_rejected(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15, ROW_PLUS16_03], assets_root=results_dir
+        )
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("no built asset", str(ctx.exception))
+
+    @_requires_engine
+    def test_canonical_asset_serving_zero_route_rows_rejected(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation,
+            legs=[_LegSpec(row=ROW_CE15), _LegSpec(row=ROW_PLUS16_03)],
+            route_rows=[ROW_CE15],
+            assets_root=results_dir,
+        )
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("serve no ROUTE build row", str(ctx.exception))
+
+    @_requires_engine
+    def test_two_legs_same_major_rejected_via_route_targets(self) -> None:
+        """The routing-level defensive duplicate-major guard, exercised directly
+        (bypassing handoff validation, which already has its OWN dup-major test
+        above) via two hand-built VerifiedAsset/_Leg objects sharing one major."""
+        allocation = _allocation()
+        record_a = np.make_build_record(allocation=allocation, matrix_row=ROW_CE15, source_date_epoch=_EPOCH)
+        record_b = np.make_build_record(allocation=allocation, matrix_row=ROW_CE15, source_date_epoch=_EPOCH + 1)
+        asset_a = pc.VerifiedAsset(
+            asset_class="canonical",
+            declared_name="a.pkg",
+            canonical_name="a.pkg",
+            work_path=Path("a.pkg"),
+            sha256="0" * 64,
+            manifest={},
+            record=record_a,
+        )
+        asset_b = pc.VerifiedAsset(
+            asset_class="canonical",
+            declared_name="b.pkg",
+            canonical_name="b.pkg",
+            work_path=Path("b.pkg"),
+            sha256="1" * 64,
+            manifest={},
+            record=record_b,
+        )
+        leg_a = pn._Leg(major="15", matrix_row=ROW_CE15, canonical=asset_a, dependencies=())
+        leg_b = pn._Leg(major="15", matrix_row=ROW_CE15, canonical=asset_b, dependencies=())
+
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            pn._route_targets(_ENGINE, [ROW_CE15], [leg_a, leg_b])
+        self.assertIn("more than one built asset", str(ctx.exception))
+
+
+# --------------------------------------------------------------------------- #
+# T8 — dependency verification failures.
+# --------------------------------------------------------------------------- #
+
+
+class DependencyTests(_TempDirTestCase):
+    @_requires_engine
+    def test_dep_file_missing_from_leg_dir_rejected(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation,
+            legs=[_LegSpec(row=ROW_CE15, dep_specs=[("py311-charset-normalizer", "3.4.0")])],
+            route_rows=[ROW_CE15],
+            assets_root=results_dir,
+        )
+        (results_dir / f"{pn._LEG_DIR_PREFIX}15" / "py311-charset-normalizer-3.4.0.pkg").unlink()
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("missing dependency asset", str(ctx.exception))
+
+    @_requires_engine
+    def test_dep_sha_mismatch_rejected(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation,
+            legs=[_LegSpec(row=ROW_CE15, dep_specs=[("py311-charset-normalizer", "3.4.0")])],
+            route_rows=[ROW_CE15],
+            assets_root=results_dir,
+        )
+        mutated = _mutate(handoff)
+        mutated["builds"][0]["dep_artifacts"][0]["sha256"] = "0" * 64
+        with self.assertRaises(pc.AssetVerificationError):
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+    @_requires_engine
+    def test_dep_tagged_style_suffixed_name_rejected(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation,
+            legs=[_LegSpec(row=ROW_CE15, dep_specs=[("py311-charset-normalizer", "3.4.0")])],
+            route_rows=[ROW_CE15],
+            assets_root=results_dir,
+        )
+        legdir = results_dir / f"{pn._LEG_DIR_PREFIX}15"
+        suffixed_name = "py311-charset-normalizer-3.4.0-CE-2.8.pkg"
+        (legdir / "py311-charset-normalizer-3.4.0.pkg").rename(legdir / suffixed_name)
+        mutated = _mutate(handoff)
+        mutated["builds"][0]["dep_artifacts"][0]["name"] = suffixed_name
+        with self.assertRaises(pc.AssetVerificationError) as ctx:
+            _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("declared name", str(ctx.exception))
+
+
+# --------------------------------------------------------------------------- #
+# T10 — a route-only row is never targeted, and errors on nothing.
+# --------------------------------------------------------------------------- #
+
+
+class RouteOnlyTests(_TempDirTestCase):
+    @_requires_engine
+    def test_route_only_row_not_targeted_no_error(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15, ROW_ROUTE_ONLY_17], assets_root=results_dir
+        )
+        report = _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertEqual(report.touched, (("nightly", "ce-2.8"),))
+        self.assertFalse((self.pkg_repo / "docs" / "nightly" / "ce-17.0").exists())
+
+
+# --------------------------------------------------------------------------- #
+# T11 — missing results dir / missing canonical file -> a clean rejection, not a
+# raw OSError traceback.
+# --------------------------------------------------------------------------- #
+
+
+class MissingFileTests(_TempDirTestCase):
+    @_requires_engine
+    def test_missing_results_dir_clean_error(self) -> None:
+        scratch = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(allocation, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=scratch)
+        missing_dir = self.tmp / "does-not-exist"
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=handoff, results_dir=missing_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("missing canonical asset", str(ctx.exception))
+
+    @_requires_engine
+    def test_missing_canonical_file_clean_error(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_dir
+        )
+        canonical_name = f"pfSense-pkg-pfBlockerNG-{allocation.pkg_version}.pkg"
+        (results_dir / f"{pn._LEG_DIR_PREFIX}15" / canonical_name).unlink()
+        with self.assertRaises(pn.PublishNightlyError) as ctx:
+            _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("missing canonical asset", str(ctx.exception))
+
+
+# --------------------------------------------------------------------------- #
+# T12 — hostile artifact names, rejected BEFORE any path join.
+# --------------------------------------------------------------------------- #
+
+
+class HostileNameTests(_TempDirTestCase):
+    @_requires_engine
+    def test_hostile_canonical_artifact_name_rejected(self) -> None:
+        for hostile in ("../x.pkg", "a/b.pkg", "a\\b.pkg"):
+            with self.subTest(hostile=hostile):
+                results_dir = self.new_results_dir()
+                allocation = _allocation()
+                handoff = _build_handoff(
+                    allocation, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_dir
+                )
+                mutated = _mutate(handoff)
+                mutated["builds"][0]["artifact"]["name"] = hostile
+                with self.assertRaises((pc.AssetVerificationError, np.ProvenanceError)):
+                    _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+    @_requires_engine
+    def test_hostile_dep_artifact_name_rejected(self) -> None:
+        for hostile in ("../x.pkg", "a/b.pkg", "a\\b.pkg"):
+            with self.subTest(hostile=hostile):
+                results_dir = self.new_results_dir()
+                allocation = _allocation()
+                handoff = _build_handoff(
+                    allocation,
+                    legs=[_LegSpec(row=ROW_CE15, dep_specs=[("py311-charset-normalizer", "3.4.0")])],
+                    route_rows=[ROW_CE15],
+                    assets_root=results_dir,
+                )
+                mutated = _mutate(handoff)
+                mutated["builds"][0]["dep_artifacts"][0]["name"] = hostile
+                with self.assertRaises((pc.AssetVerificationError, np.ProvenanceError)):
+                    _run(handoff=mutated, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+
+# --------------------------------------------------------------------------- #
+# T13 — main() CLI wrapper.
+# --------------------------------------------------------------------------- #
+
+
+class MainCliTests(_TempDirTestCase):
+    @_requires_engine
+    def test_main_invalid_json_exit_1_with_error(self) -> None:
+        results_dir = self.new_results_dir()
+        handoff_path = self.tmp / "bad.json"
+        handoff_path.write_text("not json", encoding="utf-8")
+        argv = [
+            "--handoff",
+            str(handoff_path),
+            "--results-dir",
+            str(results_dir),
+            "--pkg-repo",
+            str(self.pkg_repo),
+            "--source-run-id",
+            _RUN_ID,
+        ]
+        with (
+            mock.patch.dict(os.environ, {"PFB_SRC": str(_SRC_ROOT)}),
+            mock.patch("sys.stderr", new_callable=io.StringIO) as err,
+        ):
+            code = pn.main(argv)
+        self.assertEqual(code, 1)
+        self.assertIn("::error::", err.getvalue())
+
+    @_requires_engine
+    def test_main_success_prints_updated_and_returns_zero(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_dir
+        )
+        handoff_path = self.tmp / "handoff.json"
+        handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+        argv = [
+            "--handoff",
+            str(handoff_path),
+            "--results-dir",
+            str(results_dir),
+            "--pkg-repo",
+            str(self.pkg_repo),
+            "--source-run-id",
+            _RUN_ID,
+        ]
+        with (
+            mock.patch.dict(os.environ, {"PFB_SRC": str(_SRC_ROOT)}),
+            mock.patch("sys.stdout", new_callable=io.StringIO) as out,
+        ):
+            code = pn.main(argv)
+        self.assertEqual(code, 0)
+        self.assertIn("updated nightly/ce-2.8", out.getvalue())
+
+
+# --------------------------------------------------------------------------- #
+# T14 — publish() must actually WIRE catalogue_assembly.verify_multi_destination_
+# identity over a genuine Plus fan-out (plus-26.03 + plus-26.07, same canonical
+# bytes), not merely have access to a function that works in isolation.
+# --------------------------------------------------------------------------- #
+
+
+class IdentityPostConditionTests(_TempDirTestCase):
+    @_requires_engine
+    def test_multi_destination_divergence_aborts_publish(self) -> None:
+        results_dir = self.new_results_dir()
+        allocation = _allocation()
+        handoff = _build_handoff(
+            allocation,
+            legs=[_LegSpec(row=ROW_PLUS16_03)],
+            route_rows=[ROW_PLUS16_03, ROW_PLUS16_07],
+            assets_root=results_dir,
+        )
+        canonical_name = f"pfSense-pkg-pfBlockerNG-{allocation.pkg_version}.pkg"
+        divergent_alloc = _allocation(build_date=date(2026, 8, 20))
+        divergent_dir = self.tmp / "divergent"
+        divergent_dir.mkdir()
+        divergent_record = np.make_build_record(
+            allocation=divergent_alloc, matrix_row=ROW_PLUS16_03, source_date_epoch=_EPOCH
+        )
+        divergent_path, _digest = _wrap_canonical_pkg(divergent_dir, divergent_record, local_name="divergent.pkg")
+        divergent_bytes = divergent_path.read_bytes()
+
+        real_regenerate = pn.ca.regenerate_catalogue
+
+        def corrupting_regenerate(site_root: str | Path, channel: str, varver: str, *, engine: pc.Engine) -> None:
+            real_regenerate(site_root, channel, varver, engine=engine)
+            if varver == "plus-26.07":
+                target = Path(site_root) / channel / varver / canonical_name
+                target.write_bytes(divergent_bytes)
+
+        with (
+            mock.patch.object(pn.ca, "regenerate_catalogue", side_effect=corrupting_regenerate),
+            self.assertRaises(pn.ca.CatalogueAssemblyError) as ctx,
+        ):
+            _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertIn("multi-destination identity violation", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2146

## What

Completes the Nightly publish leg — the last open lane on #2146. Nightly publishing has been dead in production since `pfBlockerNG/pkg` PR #19 removed the old `publish.yml`; the tagged path landed in #2207, and this PR wires the equivalent Nightly path end to end:

1. **Build side** (`10e08c78`): the Nightly build legs now build each BUILD-matrix row's `extra_pkgs` dependency packages (issue #1806 — e.g. `textproc/py-charset-normalizer` for CE, which pfSense's own repo does not carry) with canonical, unsuffixed names. `result.json` and the verified publisher handoff carry a new per-leg `dep_artifacts` list, validated by a dedicated validator in `nightly_provenance.py`. Durable `nightly-state` schema is unchanged — state still records only the canonical artifacts.
2. **Publisher** (`5855e095`): new `scripts/publish_nightly.py`. It re-validates the handoff as untrusted JSON (exact field sets, allocation validity, `run_id` equality with the invoking run — a stale re-run attempt is rejected by design), verifies every `.pkg` from bytes via `publish_catalogues.verify_asset`, fans each per-FreeBSD-major build out to every build-role ROUTE varver sharing that major (packages are NO_ARCH; one build serves every version on its major), folds each leg's dependency packages in per served row, applies a stale-version tree check (an older, absent version can never regress a catalogue a newer run advanced), and assembles `nightly/<varver>/` with retention through the existing `catalogue_assembly` seams. Helpers are reused from `publish_release.py`/`publish_catalogues.py` — nothing copied. Stdout contract (`updated <channel>/<varver>` / NOOP) is byte-shared via `pr.PublishReport`.
3. **Wiring** (`106eb5a2`, `1f934016`): `scripts/publish-pkg-repo.sh` gains a `PUBLISH_KIND=nightly` mode driving `publish_nightly.py` through the same sync → verify/assemble → stage → commit → fast-forward-push cycle (tagged mode byte-compatible; landing matrix derived from the handoff's pinned `route_matrix`; nightly commit trailers `pfBlockerNG-Nightly-Version` + `pfBlockerNG-Source-Run-Id`). `nightly.yml` gains a `publish-pkg-repo` job mirroring `release-published.yml`'s: gated on a successful build + handoff, read-only job permissions, pinned trusted-tools checkout, GitHub App token narrowed to `contents:write` on `pfBlockerNG/pkg`, artifact downloads, and the single git-touching wrapper invocation.

## Notes

- Retention stays at the uniform `DEFAULT_RETENTION_KEEP = 5` via the existing channel-specific seam (`retention_keep_count`). Exact per-channel counts are deliberately deferred to the #2149 staging rehearsal per the map's "Not yet specified" section (the old nightly channel kept 14 — trivially restorable through the seam if staging wants it).
- A "re-run failed jobs" attempt on the publish job alone is rejected by the `run_id`/attempt equality check (stale-callback doctrine) — re-run the whole workflow instead; documented in the workflow.
- Live prerequisite (also carried by `release-published.yml`, not new here): the PKG GitHub App must be installed on `pfBlockerNG/pkg` with Contents:write.

## Verification

- Test-first red→green executed per step (RED outputs, frozen hashes, and GREEN re-runs recorded in the step handoffs; each step independently gated by a verifier that re-ran the gates, re-executed the red proof, and read the full diff; two gate findings on the spec pins were fixed in `1f934016` with executed mutation-kill proofs).
- Full gates green at head: `pytest` 4917 passed, 4 skipped, `ruff check`/`ruff format --check`, `mypy tests/`, `sh -n`/`shellcheck` on `publish-pkg-repo.sh`, `shellspec --shell dash` 1258 examples 0 failures, `actionlint` clean on `nightly.yml`.
- No release was performed and no production catalogue was mutated by this PR's development or verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly builds now include verified dependency packages and their checksums in results.
  * Added automated nightly package-catalogue publishing with validation, routing, retention, and safe rerun handling.
  * Added support for nightly and tagged publishing modes.

* **Bug Fixes**
  * Added safeguards against invalid, duplicate, mismatched, or unsafe package artifacts.
  * Prevented stale or conflicting catalogue updates from being published.

* **Tests**
  * Expanded coverage for dependency validation, nightly publishing, workflow gating, artifact handling, routing, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->