### PR TITLE
smoke: route self-hosted fleet pulls through the LAN registry cache

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -162,7 +162,7 @@ jobs:
     needs: resolve-version
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:4
+      image: ${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -287,7 +287,7 @@ jobs:
     needs: [publish-image, build-pkg]
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:4
+      image: ${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -216,7 +216,7 @@ jobs:
     if: ${{ needs.plan.outputs.count != '0' }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:4
+      image: ${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -296,7 +296,7 @@ jobs:
     continue-on-error: ${{ inputs.nonblocking }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:4
+      image: ${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -367,7 +367,7 @@ jobs:
     continue-on-error: ${{ matrix.release_blocking == 'false' }}
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:4
+      image: ${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -271,7 +271,7 @@ jobs:
     name: Daily image reconcile (box as source of truth)
     runs-on: [self-hosted, Linux, X64]
     container:
-      image: ghcr.io/pfblockerng/ci-runner-vm:4
+      image: ${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/pfblockerng/ci-runner-vm:4
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -203,6 +203,13 @@ fi
 #                      `sysctl -w`, which a container cannot perform against the host.
 #   the bind mounts    repo, shared image store, ports tree and guest key all live on the
 #                      box; without them every run re-clones and re-pulls.
+#   --add-host ...     issue #2230: routes ghcr.io to the box's LAN zot mirror when
+#                      PFB_LAN_REGISTRY is set in the BOX's own environment -- the
+#                      `${...:+...}` is left UNEXPANDED here (escaped `\$`) so the
+#                      remote shell resolves it, not this caller; unset expands to
+#                      zero words, so the flag is silently absent (today's behavior).
+#   the CA mount       the LAN mirror's cert validates against the system bundle; the
+#                      container carries no CA store of its own to check it against.
 # Ref-stable: the one-liner is the only part that has to work across refs;
 # smoke-on-box.sh handles everything else.
 # shellcheck disable=SC2089  # quoting: _ob_flags is pre-encoded for remote sh
@@ -215,10 +222,12 @@ _bootstrap="cd /root/pfBlockerNG \
  && exec docker run --rm \
       --device /dev/kvm \
       --sysctl net.ipv4.ip_unprivileged_port_start=53 \
+      \${PFB_LAN_REGISTRY:+--add-host ghcr.io:\$PFB_LAN_REGISTRY} \
       -v /root/pfBlockerNG:/root/pfBlockerNG \
       -v /root/images:/root/images \
       -v /root/FreeBSD-ports:/root/FreeBSD-ports \
       -v /root/smoke-ssh-key:/root/smoke-ssh-key:ro \
+      -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro \
       -e SMOKE_GHCR_TOKEN -e SMOKE_PFSENSE_REF -e CIVM_REF -e SMOKE_LANE -e PFB_DIAG_DIR \
       -w /root/pfBlockerNG \
       ghcr.io/pfblockerng/ci-runner-vm:4 \

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -208,8 +208,8 @@ fi
 #                      `${...:+...}` is left UNEXPANDED here (escaped `\$`) so the
 #                      remote shell resolves it, not this caller; unset expands to
 #                      zero words, so the flag is silently absent (today's behavior).
-#   the CA mount       the LAN mirror's cert validates against the system bundle; the
-#                      container carries no CA store of its own to check it against.
+#   the CA mount       the LAN mirror's cert validates against the box's bundle; the
+#                      container's stock CA store lacks the fleet CA that signed it.
 # Ref-stable: the one-liner is the only part that has to work across refs;
 # smoke-on-box.sh handles everything else.
 # shellcheck disable=SC2089  # quoting: _ob_flags is pre-encoded for remote sh

--- a/tests/shell/local_smoke_container_spec.sh
+++ b/tests/shell/local_smoke_container_spec.sh
@@ -94,6 +94,25 @@ EOF
     The output should include '--sysctl net.ipv4.ip_unprivileged_port_start=53'
   End
 
+  It 'add-hosts ghcr.io to the LAN registry, expanded box-side (issue #2230)'
+    # The box fleet hijacks ghcr.io via /etc/hosts to the LAN zot mirror
+    # (10.0.0.111). PFB_LAN_REGISTRY lives in the BOX's /etc/environment, not
+    # the orchestrator's -- so this must survive as an UNEXPANDED ${...:+...}
+    # fragment in the bootstrap string handed to select-box.sh, and expand only
+    # once the remote shell runs it. Unset on the fake box here: `:+` on an
+    # unset var is zero words, so nothing to assert its expansion against --
+    # this pins the literal fragment survives the caller-side double quotes.
+    When call bootstrap --ref dummy
+    The output should include '${PFB_LAN_REGISTRY:+--add-host ghcr.io:$PFB_LAN_REGISTRY}'
+  End
+
+  It 'mounts the CA bundle so TLS against the LAN registry validates (issue #2230)'
+    # zot's cert SANs DNS:ghcr.io + IP:10.0.0.111; the container needs the
+    # system CA bundle to validate it, same as the box does.
+    When call bootstrap --ref dummy
+    The output should include '-v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro'
+  End
+
   It 'mounts the repo, the shared image store, the ports tree and the guest key'
     When call bootstrap --ref dummy
     The output should include '/root/pfBlockerNG:/root/pfBlockerNG'

--- a/tests/test_issue2230_lan_registry.py
+++ b/tests/test_issue2230_lan_registry.py
@@ -1,11 +1,10 @@
 """Self-hosted fleet pulls route through the LAN zot registry (issue #2230).
 
 Deliberately stdlib-only, mirroring tests/test_issue2231_workflow_hygiene.py: the
-CI pytest leg runs inside ci-runner, which bakes no PyYAML. Workflow-schema
-validation is actionlint's job (the `actionlint` job in test.yml; #2232); this
-is a stray-ref guard actionlint cannot express — a self-hosted `container.image`
-naming a literal `ghcr.io/...` ref is schema-legal but bypasses the LAN registry
-routing, silently reverting every pull on that job to the public path.
+CI pytest leg runs inside ci-runner, which bakes no PyYAML. This is a stray-ref
+guard actionlint cannot express — a self-hosted container image naming a literal
+`ghcr.io/...` ref is schema-legal but bypasses the LAN registry routing,
+silently reverting every pull on that job to the public path.
 
 Only `runs-on:` blocks naming `self-hosted` AND carrying a `container.image` are
 in scope: GitHub-hosted jobs cannot reach the LAN registry (10.0.0.111) at all,
@@ -24,7 +23,31 @@ _EXPECTED_IMAGE_PREFIX = "${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/"
 _JOBS_KEY = re.compile(r"^jobs:\s*$", re.MULTILINE)
 _JOB_HEADER = re.compile(r"^  ([A-Za-z0-9_.-]+):\s*(?:#.*)?$")
 _SELF_HOSTED = re.compile(r"runs-on:.*self-hosted")
-_IMAGE_LINE = re.compile(r"^\s*image:\s*(\S.*?)\s*$", re.MULTILINE)
+# `container:` either as a map (image: on a deeper-indented line below) or as
+# the `container: <ref>` string shorthand — both are schema-legal.
+_CONTAINER_LINE = re.compile(r"^(\s*)container:\s*(\S.*?)?\s*$")
+_IMAGE_KEY = re.compile(r"^\s*image:\s*(\S.*?)\s*$")
+
+
+def _container_image(block: str) -> str | None:
+    """The job's `container` image ref only — `services.*.image` and any other
+    `image:` key outside the `container:` mapping are out of scope."""
+    lines = block.splitlines()
+    for i, line in enumerate(lines):
+        container = _CONTAINER_LINE.match(line)
+        if not container:
+            continue
+        if container.group(2):
+            return container.group(2)
+        indent = len(container.group(1))
+        for sub in lines[i + 1 :]:
+            if sub.strip() and (len(sub) - len(sub.lstrip())) <= indent:
+                break
+            image = _IMAGE_KEY.match(sub)
+            if image:
+                return image.group(1)
+        return None
+    return None
 
 
 def _workflow_files() -> list[Path]:
@@ -75,10 +98,10 @@ def _flag_stray_refs(blocks: dict[str, str]) -> list[str]:
     for name, block in blocks.items():
         if not _SELF_HOSTED.search(block):
             continue
-        image_match = _IMAGE_LINE.search(block)
-        if image_match is None:
+        image = _container_image(block)
+        if image is None:
             continue
-        if not image_match.group(1).startswith(_EXPECTED_IMAGE_PREFIX):
+        if not image.startswith(_EXPECTED_IMAGE_PREFIX):
             flagged.append(name)
     return flagged
 
@@ -96,7 +119,7 @@ def test_self_hosted_container_jobs_pull_through_the_lan_registry() -> None:
         for name in blocks:
             if not _SELF_HOSTED.search(blocks[name]):
                 continue
-            if _IMAGE_LINE.search(blocks[name]) is None:
+            if _container_image(blocks[name]) is None:
                 continue
             checked += 1
         for name in _flag_stray_refs(blocks):
@@ -112,9 +135,9 @@ def test_self_hosted_container_jobs_pull_through_the_lan_registry() -> None:
 
 
 def test_scanner_catches_a_planted_stray_ref() -> None:
-    """Vacuity guard for the scanner itself: a self-hosted job with a literal
-    ref is flagged, the LAN-registry expression form is not, and a
-    GitHub-hosted job with a literal ref is never even considered."""
+    """The scanner flags a self-hosted job with a literal container ref (map or
+    string shorthand), passes the LAN-registry expression form, and ignores
+    GitHub-hosted jobs, jobs without a container, and `services.*.image`."""
     fixture = (
         "jobs:\n"
         "  ok:\n"
@@ -129,11 +152,21 @@ def test_scanner_catches_a_planted_stray_ref() -> None:
         "    runs-on: ubuntu-latest\n"
         "    container:\n"
         "      image: ghcr.io/pfblockerng/ci-runner:4\n"
+        "  stray-shorthand:\n"
+        "    runs-on: [self-hosted, Linux, X64]\n"
+        "    container: ghcr.io/pfblockerng/ci-runner-vm:4\n"
+        "  services-only:\n"
+        "    runs-on: [self-hosted, Linux, X64]\n"
+        "    services:\n"
+        "      redis:\n"
+        "        image: ghcr.io/pfblockerng/ci-runner:4\n"
         "  no-container:\n"
         "    runs-on: [self-hosted, Linux, X64]\n"
         "    steps:\n"
         "      - run: echo hi\n"
     )
     blocks = dict(_job_blocks(fixture))
-    assert set(blocks) == {"ok", "stray", "hosted", "no-container"}, blocks
-    assert _flag_stray_refs(blocks) == ["stray"], _flag_stray_refs(blocks)
+    expected = {"ok", "stray", "hosted", "stray-shorthand", "services-only", "no-container"}
+    assert set(blocks) == expected, blocks
+    assert _flag_stray_refs(blocks) == ["stray", "stray-shorthand"], _flag_stray_refs(blocks)
+    assert _container_image(blocks["services-only"]) is None, "services.*.image must stay out of scope"

--- a/tests/test_issue2230_lan_registry.py
+++ b/tests/test_issue2230_lan_registry.py
@@ -1,0 +1,139 @@
+"""Self-hosted fleet pulls route through the LAN zot registry (issue #2230).
+
+Deliberately stdlib-only, mirroring tests/test_issue2231_workflow_hygiene.py: the
+CI pytest leg runs inside ci-runner, which bakes no PyYAML. Workflow-schema
+validation is actionlint's job (the `actionlint` job in test.yml; #2232); this
+is a stray-ref guard actionlint cannot express — a self-hosted `container.image`
+naming a literal `ghcr.io/...` ref is schema-legal but bypasses the LAN registry
+routing, silently reverting every pull on that job to the public path.
+
+Only `runs-on:` blocks naming `self-hosted` AND carrying a `container.image` are
+in scope: GitHub-hosted jobs cannot reach the LAN registry (10.0.0.111) at all,
+so their literal `ghcr.io/...` refs are correct and must never be flagged.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+_EXPECTED_IMAGE_PREFIX = "${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/"
+
+_JOBS_KEY = re.compile(r"^jobs:\s*$", re.MULTILINE)
+_JOB_HEADER = re.compile(r"^  ([A-Za-z0-9_.-]+):\s*(?:#.*)?$")
+_SELF_HOSTED = re.compile(r"runs-on:.*self-hosted")
+_IMAGE_LINE = re.compile(r"^\s*image:\s*(\S.*?)\s*$", re.MULTILINE)
+
+
+def _workflow_files() -> list[Path]:
+    workflows = ROOT / ".github/workflows"
+    files = sorted([*workflows.glob("*.yml"), *workflows.glob("*.yaml")])
+    assert files, "no workflow files found — wrong ROOT?"
+    return files
+
+
+def _job_blocks(text: str) -> list[tuple[str, str]]:
+    """Split the ``jobs:`` mapping into ``(job_name, block_text)`` pairs.
+
+    Job entries sit at 2-space indent directly under a top-level ``jobs:`` key;
+    everything more-indented (or blank) belongs to that job until the next
+    2-space-indent header or a dedent back to column 0."""
+    jobs_start = _JOBS_KEY.search(text)
+    if not jobs_start:
+        return []
+    blocks: list[tuple[str, list[str]]] = []
+    current_name: str | None = None
+    current_lines: list[str] = []
+    for line in text[jobs_start.end() :].splitlines():
+        header = _JOB_HEADER.match(line)
+        if header:
+            if current_name is not None:
+                blocks.append((current_name, current_lines))
+            current_name = header.group(1)
+            current_lines = [line]
+            continue
+        if current_name is None:
+            continue
+        if line and not line[0].isspace():
+            # Dedented out of the jobs: mapping entirely.
+            blocks.append((current_name, current_lines))
+            current_name = None
+            current_lines = []
+            continue
+        current_lines.append(line)
+    if current_name is not None:
+        blocks.append((current_name, current_lines))
+    return [(name, "\n".join(lns)) for name, lns in blocks]
+
+
+def _flag_stray_refs(blocks: dict[str, str]) -> list[str]:
+    """Return the names of self-hosted+container jobs whose image is not the
+    LAN-registry expression."""
+    flagged: list[str] = []
+    for name, block in blocks.items():
+        if not _SELF_HOSTED.search(block):
+            continue
+        image_match = _IMAGE_LINE.search(block)
+        if image_match is None:
+            continue
+        if not image_match.group(1).startswith(_EXPECTED_IMAGE_PREFIX):
+            flagged.append(name)
+    return flagged
+
+
+def test_self_hosted_container_jobs_pull_through_the_lan_registry() -> None:
+    """Every self-hosted job with a `container.image` must route the pull
+    through `${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/...` (issue #2230): the
+    box fleet hijacks ghcr.io via /etc/hosts to the LAN zot mirror at
+    10.0.0.111, and a literal ref skips that routing silently rather than
+    failing loudly."""
+    offenders: list[str] = []
+    checked = 0
+    for path in _workflow_files():
+        blocks = dict(_job_blocks(path.read_text(encoding="utf-8")))
+        for name in blocks:
+            if not _SELF_HOSTED.search(blocks[name]):
+                continue
+            if _IMAGE_LINE.search(blocks[name]) is None:
+                continue
+            checked += 1
+        for name in _flag_stray_refs(blocks):
+            offenders.append(f"{path.relative_to(ROOT)} job {name!r}")
+    assert checked >= 6, (
+        f"expected at least 6 self-hosted container jobs (issue #2230's six sites), found {checked} "
+        "— job-block scanner regressed or the workflows changed shape"
+    )
+    assert not offenders, (
+        "self-hosted container jobs must pull via ${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/... "
+        "not a literal ghcr.io ref (issue #2230):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_scanner_catches_a_planted_stray_ref() -> None:
+    """Vacuity guard for the scanner itself: a self-hosted job with a literal
+    ref is flagged, the LAN-registry expression form is not, and a
+    GitHub-hosted job with a literal ref is never even considered."""
+    fixture = (
+        "jobs:\n"
+        "  ok:\n"
+        "    runs-on: [self-hosted, Linux, X64]\n"
+        "    container:\n"
+        "      image: ${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/pfblockerng/ci-runner-vm:4\n"
+        "  stray:\n"
+        "    runs-on: [self-hosted, Linux, X64]\n"
+        "    container:\n"
+        "      image: ghcr.io/pfblockerng/ci-runner-vm:4\n"
+        "  hosted:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    container:\n"
+        "      image: ghcr.io/pfblockerng/ci-runner:4\n"
+        "  no-container:\n"
+        "    runs-on: [self-hosted, Linux, X64]\n"
+        "    steps:\n"
+        "      - run: echo hi\n"
+    )
+    blocks = dict(_job_blocks(fixture))
+    assert set(blocks) == {"ok", "stray", "hosted", "no-container"}, blocks
+    assert _flag_stray_refs(blocks) == ["stray"], _flag_stray_refs(blocks)

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -137,18 +137,15 @@ def test_env_map_scanner_catches_a_planted_offence() -> None:
 
 
 def test_workflows_pin_the_current_ci_runner_series() -> None:
-    """Every container job must ride the series `.github/docker/VERSION` names —
-    the invariant lost with the retired migration test (PR #2233), resurrected
-    here where CI actually executes it. A stale pin runs a whole job family on
-    an old toolchain while the gates read as green (issue #2232).
+    """Every container job must ride the series `.github/docker/VERSION` names.
+    A stale pin runs a whole job family on an old toolchain while the gates
+    read as green.
 
     The series lives in the trailing `/pfblockerng/ci-runner(-vm)?:N` path
     segment regardless of what prefixes it: a bare `ghcr.io/...` ref (hosted
     jobs) or the `${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/...` expression
-    (self-hosted jobs, issue #2230) both name the same series the same way.
-    Matching only `ghcr\\.io/...` would silently stop scanning the six
-    self-hosted sites the day #2230 landed — the floor assertion below is the
-    tripwire for that regression."""
+    (self-hosted jobs) both name the same series the same way. The floor
+    assertion below trips if a regex change stops matching either form."""
     version = int((ROOT / ".github/docker/VERSION").read_text(encoding="utf-8").strip())
     offenders: list[str] = []
     refs_found = 0
@@ -158,12 +155,13 @@ def test_workflows_pin_the_current_ci_runner_series() -> None:
                 refs_found += 1
                 if int(tag) != version:
                     offenders.append(f"{path.relative_to(ROOT)}:{line_no}: series {tag} != {version}")
-    # Today's count (issue #2230): 64 total ci-runner(-vm) refs across workflows
-    # + actions. A regex that stops matching the expression-form sites would
-    # scan fewer refs and pass vacuously instead of failing loudly.
+    # The floor is the exact ref count across workflows + actions at last
+    # update. A regex that stops matching one ref form would scan fewer refs
+    # and pass vacuously instead of failing loudly.
     assert refs_found >= 64, (
         f"only found {refs_found} ci-runner(-vm) refs, expected at least 64 — "
-        "the series regex likely stopped matching some ref form"
+        "either the series regex stopped matching a ref form (fix the regex) or "
+        "refs were legitimately removed (recount and lower the floor)"
     )
     assert not offenders, "workflow image pins must match .github/docker/VERSION:\n  " + "\n  ".join(offenders)
 

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -140,14 +140,31 @@ def test_workflows_pin_the_current_ci_runner_series() -> None:
     """Every container job must ride the series `.github/docker/VERSION` names —
     the invariant lost with the retired migration test (PR #2233), resurrected
     here where CI actually executes it. A stale pin runs a whole job family on
-    an old toolchain while the gates read as green (issue #2232)."""
+    an old toolchain while the gates read as green (issue #2232).
+
+    The series lives in the trailing `/pfblockerng/ci-runner(-vm)?:N` path
+    segment regardless of what prefixes it: a bare `ghcr.io/...` ref (hosted
+    jobs) or the `${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/...` expression
+    (self-hosted jobs, issue #2230) both name the same series the same way.
+    Matching only `ghcr\\.io/...` would silently stop scanning the six
+    self-hosted sites the day #2230 landed — the floor assertion below is the
+    tripwire for that regression."""
     version = int((ROOT / ".github/docker/VERSION").read_text(encoding="utf-8").strip())
     offenders: list[str] = []
+    refs_found = 0
     for path in _workflow_files():
         for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            for tag in re.findall(r"ghcr\.io/pfblockerng/ci-runner(?:-vm)?:([0-9]+)", line):
+            for tag in re.findall(r"/pfblockerng/ci-runner(?:-vm)?:([0-9]+)", line):
+                refs_found += 1
                 if int(tag) != version:
                     offenders.append(f"{path.relative_to(ROOT)}:{line_no}: series {tag} != {version}")
+    # Today's count (issue #2230): 64 total ci-runner(-vm) refs across workflows
+    # + actions. A regex that stops matching the expression-form sites would
+    # scan fewer refs and pass vacuously instead of failing loudly.
+    assert refs_found >= 64, (
+        f"only found {refs_found} ci-runner(-vm) refs, expected at least 64 — "
+        "the series regex likely stopped matching some ref form"
+    )
     assert not offenders, "workflow image pins must match .github/docker/VERSION:\n  " + "\n  ".join(offenders)
 
 


### PR DESCRIPTION
## What

Routes the self-hosted fleet's image pulls through the LAN zot registry cache (`10.0.0.111`, CT111 `pfb-registry`), with a byte-identical fallback to `ghcr.io` while the repo variable is unset. Part of #2230.

- **Six self-hosted `container.image` refs** (`build-image.yml` ×2, `image-refresh.yml`, `smoke-single.yml`, `ui-tests.yml`, `version-tracker.yml`) become `${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/pfblockerng/ci-runner-vm:4`. GitHub-hosted jobs keep literal `ghcr.io` refs — they cannot reach the LAN registry.
- **`scripts/local-smoke.sh`** `_bootstrap` `docker run` gains a box-side-expanded `${PFB_LAN_REGISTRY:+--add-host ghcr.io:$PFB_LAN_REGISTRY}` and a read-only bind of the box's CA bundle — the on-box smoke leg runs `smoke-on-box.sh` *inside* `ci-runner-vm`, whose container gets a docker-generated `/etc/hosts` and no fleet CA, so without these the qcow2 `oras` pulls would silently bypass the box's `/etc/hosts` hijack.
- **Series gate** (`test_issue2231_workflow_hygiene.py`): the pin-scan regex is loosened to match both literal and expression-form refs, with a floor assertion (≥64 refs, today's exact count) so regex rot fails loudly.
- **New guard** (`test_issue2230_lan_registry.py`): every self-hosted job with a `container.image` must use the expression form — a literal `ghcr.io` ref in a self-hosted container job fails CI. Includes a planted-fixture self-test proving the scanner flags a stray ref and ignores hosted jobs.
- **`local_smoke_container_spec.sh`**: two assertions on the constructed bootstrap string (add-host fragment, CA mount) via the existing extraction seam.

## Why

Every box pulled the same multi-GB artifacts from ghcr over the WAN independently. The registry (zot v2.1.20, on-demand sync, anonymous read-only) plus the boxes' hosts-hijack now serves those pulls on the LAN; this PR closes the two repo-side gaps: the runner-side container pulls (explicit expression refs) and the container-boundary hole in the on-box leg. Design + live verification evidence: [#2230 design comment](https://github.com/pfBlockerNG/pfBlockerNG/issues/2230#issuecomment-5225233248) and [infra checkpoint](https://github.com/pfBlockerNG/pfBlockerNG/issues/2230#issuecomment-5225340360).

Pushes are untouched and cannot regress: publish paths keep literal `ghcr.io`, runner CTs are not hijacked, and zot rejects pushes (anonymous read-only — verified live with a loud `authentication required`).

## Testing

- Test-first red→green executed: new guard test failed naming exactly the six sites, shellspec failed the two new assertions, both green after the production edits with committed test bytes re-verified red→green by an independent verifier.
- `scripts/agent/run-gates.sh --diff origin/devel`: all gates pass (pytest, ruff, mypy, sh -n, shellcheck, shellspec under dash, markdownlint n/a).
- `actionlint` on the five touched workflows: no new findings (pre-existing SC2016 info-level hits verified identical on `origin/devel`).
- Behavior while `vars.PFB_LAN_REGISTRY` is unset is byte-identical to today (fallback expression + zero-word `:+` expansion); the variable gets set only after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Container images used by automated workflows can now be pulled from a configurable local registry, with GitHub Container Registry remaining the default.
  * Local smoke testing now supports local registry image expansion and mounts the host certificate bundle read-only.

* **Tests**
  * Added coverage validating local registry usage, certificate mounting, workflow image scanning, and image version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->