### PR TITLE
ci: enable actionlint's embedded shellcheck over run bodies

### DIFF
--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -224,8 +224,10 @@ jobs:
             done
             HAS_DEP_PKGS=1
           fi
-          echo "dep_pkg_dir=${DEP_PKG_DIR}" >> "$GITHUB_OUTPUT"
-          echo "has_dep_pkgs=${HAS_DEP_PKGS}" >> "$GITHUB_OUTPUT"
+          {
+            echo "dep_pkg_dir=${DEP_PKG_DIR}"
+            echo "has_dep_pkgs=${HAS_DEP_PKGS}"
+          } >> "$GITHUB_OUTPUT"
           # W1: a caller whose fan-out is per-version (smoke.yml/ui-tests.yml) must
           # override --dep-artifact-name so two same-major rows don't collide on
           # upload; blank (the default, safe for a per-major-deduped caller like

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -431,6 +431,7 @@ jobs:
           git worktree remove --force "$WT" || true
 
           BODY_FILE=$(mktemp)
+          # shellcheck disable=SC2016  # markdown backticks in the PR body, not expansions
           {
             printf '## Activate pfSense %s %s (box-verified)\n\n' "$CHANNEL" "$FAMILY"
             printf 'The %s image for `%s` was just published; these values were read from\n' "$CHANNEL" "$FAMILY"

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -114,6 +114,7 @@ jobs:
           # the download `pattern:` above.
           LOGS=$(sh scripts/module-durations-logs.sh smoke-artifacts)
           echo "Aggregating these shard logs:"
+          # shellcheck disable=SC2086  # deliberate word-split: one arg per log path (all ASCII)
           printf '  %s\n' $LOGS
           # shellcheck disable=SC2086  # deliberate word-split: one arg per log path (all ASCII)
           sh scripts/module-durations.sh $LOGS > tests/smoke/module-durations.txt

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -168,6 +168,7 @@ jobs:
           TITLE="[nightly-red] ${WF_NAME} failing on ${BRANCH}"
 
           BODY_FILE=$(mktemp)
+          # shellcheck disable=SC2016  # markdown backticks in the issue body, not expansions
           {
             if [ -n "${RUN_NUMBER:-}" ]; then
               printf '<!-- failure-run: %s:%s -->\n\n' "$RUN_NUMBER" "${RUN_ATTEMPT:-}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -351,6 +351,16 @@ jobs:
             echo "::error::actionlint red canary did not fail on a duplicate key"
             exit 1
           fi
+          # Second canary: actionlint SKIPS its embedded shellcheck pass in silence
+          # when the binary is unresolvable (exit 0, no diagnostic), so run-body
+          # coverage would go quiet if the image ever stopped shipping shellcheck.
+          # shellcheck disable=SC2016  # $CANARY is fixture text for actionlint to flag
+          printf 'on: push\njobs:\n  x:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo $CANARY\n' \
+            > "$RUNNER_TEMP/canary-sc.yml"
+          if "$AL" "$RUNNER_TEMP/canary-sc.yml" >/dev/null 2>&1; then
+            echo "::error::actionlint's embedded shellcheck pass is not running (shellcheck missing from the image?)"
+            exit 1
+          fi
           # find, not a bare *.yml glob: covers a future .yaml spelling too, and
           # never hands actionlint an unexpanded literal pattern.
           find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) -print0 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,6 +243,7 @@ jobs:
           # `head` on a quoted name reads nothing — the file's shebang would go
           # unchecked (issue #2212). The exemption fence moved inside the loop
           # for the same reason: a `grep` over the listing cannot see NULs.
+          # shellcheck disable=SC2016  # $f expands in the inner `sh -c` script, not here
           bad=$(git ls-files -z | xargs -0 sh -c '
             for f; do
               case $f in
@@ -333,10 +334,9 @@ jobs:
         # PyYAML-based checks could never see that class. actionlint's own parser
         # rejects what GitHub rejects, plus expression/schema errors. The binary
         # is baked into ci-runner (pinned + checksum-verified there, #2232).
-        # -shellcheck= : the embedded shellcheck-on-run-bodies pass is disabled —
-        # this repo's own ShellCheck gates carry that concern with their tuned
-        # scopes, and enabling it here would demand a repo-wide workflow sweep
-        # first (revisit with #2232).
+        # The embedded shellcheck pass over `run:` bodies is ON (#2241). It reads no
+        # .shellcheckrc (actionlint runs shellcheck --norc), and a body-level directive is
+        # ignored: suppress per statement with `# shellcheck disable=` inside the body.
         # Explicit file arguments, never auto-discovery: with no args actionlint
         # looks for a git project and, finding none, reports nothing and exits 0
         # — a silently green gate.
@@ -347,14 +347,14 @@ jobs:
           # motivated it (a duplicate job-level key) before it grades the tree.
           printf 'on: push\njobs:\n  x:\n    runs-on: ubuntu-latest\n    env:\n      A: "1"\n    env:\n      A: "2"\n    steps:\n      - run: "true"\n' \
             > "$RUNNER_TEMP/canary-dup.yml"
-          if "$AL" -shellcheck= "$RUNNER_TEMP/canary-dup.yml" >/dev/null 2>&1; then
+          if "$AL" "$RUNNER_TEMP/canary-dup.yml" >/dev/null 2>&1; then
             echo "::error::actionlint red canary did not fail on a duplicate key"
             exit 1
           fi
           # find, not a bare *.yml glob: covers a future .yaml spelling too, and
           # never hands actionlint an unexpanded literal pattern.
           find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) -print0 \
-            | xargs -0 "$AL" -shellcheck= -color
+            | xargs -0 "$AL" -color
 
   shell-tests:
     name: shellspec (POSIX sh)

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -602,6 +602,7 @@ jobs:
                 ]' matrix_current.json > "$NEWM"
 
               BODY_FILE=$(mktemp)
+              # shellcheck disable=SC2016  # markdown backticks in the PR body, not expansions
               {
                 printf '## Add pfSense %s %s (seen on the update servers)\n\n' "$CHANNEL" "$FAMILY"
                 printf 'The daily reconcile booted the current %s smoke image and found the\n' "$CHANNEL"
@@ -642,6 +643,7 @@ jobs:
               ' matrix_current.json > "$NEWM"
 
               BODY_FILE=$(mktemp)
+              # shellcheck disable=SC2016  # markdown backticks in the PR body, not expansions
               {
                 printf '## Mark pfSense %s %s GA\n\n' "$CHANNEL" "$FAMILY"
                 printf 'The daily reconcile saw a final (non-prerelease) build for the %s %s\n' "$CHANNEL" "$FAMILY"

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -175,3 +175,23 @@ def test_local_smoke_pins_the_current_ci_runner_series() -> None:
         f"local-smoke.sh pins ci-runner series {tags}, but .github/docker/VERSION is "
         f"{version} — a local run would exercise a different toolchain than CI ships"
     )
+
+
+# --------------------------------------------------------------------------- #
+# 3. The actionlint job keeps its embedded shellcheck pass.
+# --------------------------------------------------------------------------- #
+
+
+def test_actionlint_job_keeps_the_embedded_shellcheck_pass() -> None:
+    """`run:` bodies are shell that no other gate reads — the ShellCheck job
+    scans `src scripts .claude/hooks`, never `.github/workflows` (issue #2241).
+    actionlint's `-shellcheck=` (empty value) silently disables that pass, so a
+    quoting or word-splitting bug in a workflow body would reach `devel`
+    ungated."""
+    text = (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
+    invocations = [line.strip() for line in text.splitlines() if '"$AL"' in line]
+    assert invocations, "the actionlint job no longer invokes $AL — update this gate"
+    disabled = [line for line in invocations if "-shellcheck=" in line]
+    assert not disabled, (
+        "the actionlint job must not disable the embedded shellcheck pass over run: bodies:\n  " + "\n  ".join(disabled)
+    )

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -182,32 +182,30 @@ def test_local_smoke_pins_the_current_ci_runner_series() -> None:
 # --------------------------------------------------------------------------- #
 
 
-# `-shellcheck=V` and `-shellcheck V` both bind a value; an empty one (`=`, `''`,
-# `""`) disables the pass. `\` + newline is followed first, so a flag and its
-# value split across a continuation read as one invocation.
+# Any value at all, not just an empty one: actionlint skips the pass in silence
+# for every `-shellcheck` value it cannot resolve to a binary — `-shellcheck=`,
+# `-shellcheck ''`, a typo'd path, and `-shellcheck -color` (Go's flag package
+# binds `-color` as the value) all exit 0 with run bodies ungraded. The job
+# resolves shellcheck from PATH and the canary below proves it resolved, so the
+# flag has no legitimate use here; keeping it out also keeps the canary's argv
+# equivalent to the tree-grading argv.
 _SHELLCHECK_FLAG = re.compile(r"--?shellcheck\b")
-_SHELLCHECK_VALUE = re.compile(r"--?shellcheck(?:=(\S*)|\s+(\S+))")
 
 
 def _shellcheck_pass_disablers(text: str) -> list[str]:
-    """Every `-shellcheck` flag in ``text`` that binds an empty value, i.e.
-    switches actionlint's embedded pass off. Raises on a spelling this scanner
-    cannot read rather than reporting a vacuous pass."""
-    joined = re.sub(r"\\\n\s*", " ", text)
-    values = _SHELLCHECK_VALUE.findall(joined)
-    assert len(values) == len(_SHELLCHECK_FLAG.findall(joined)), (
-        "a -shellcheck flag is spelled in a form this scanner cannot read — update it, never let it pass vacuously"
-    )
-    return [f"-shellcheck={eq or space}" for eq, space in values if (eq or space) in ("", "''", '""')]
+    """Every `-shellcheck` flag handed to actionlint in ``text``. A `\\` + newline
+    is folded first, so a flag split from its invocation across a continuation is
+    still seen."""
+    return _SHELLCHECK_FLAG.findall(re.sub(r"\\\n\s*", " ", text))
 
 
 def test_actionlint_job_keeps_the_embedded_shellcheck_pass() -> None:
     """`run:` bodies are shell that no other gate reads — the ShellCheck job
     scans `src scripts .claude/hooks`, never `.github/workflows` (issue #2241).
-    An empty `-shellcheck` value disables that pass, so a quoting or
-    word-splitting bug in a workflow body would reach `devel` ungated. The job's
-    own second canary catches the runtime half (a missing binary makes actionlint
-    skip the pass in silence); this catches the source half."""
+    A `-shellcheck` value actionlint cannot resolve turns the pass off silently,
+    so a quoting or word-splitting bug in a workflow body would reach `devel`
+    ungated. The job's own canary catches the runtime half (a binary missing from
+    the image); this catches the source half."""
     text = (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
     assert '"$AL"' in text, "the actionlint job no longer invokes $AL — update this gate"
     assert "canary-sc.yml" in text, (
@@ -216,22 +214,21 @@ def test_actionlint_job_keeps_the_embedded_shellcheck_pass() -> None:
     )
     disablers = _shellcheck_pass_disablers(text)
     assert not disablers, (
-        "the actionlint job must not disable the embedded shellcheck pass over run: bodies:\n  "
-        + "\n  ".join(disablers)
+        "the actionlint job must not pass -shellcheck: every value actionlint cannot resolve "
+        f"disables the embedded pass over run: bodies, silently. Found: {disablers}"
     )
 
 
 def test_shellcheck_disabler_scanner_catches_every_spelling() -> None:
-    """Vacuity guard: the three spellings that actually disable the pass are all
-    reported, an explicit binary path is not, and an unreadable spelling raises."""
-    assert _shellcheck_pass_disablers('xargs -0 "$AL" -shellcheck= -color') == ["-shellcheck="]
-    assert _shellcheck_pass_disablers("\"$AL\" -shellcheck '' f.yml") == ["-shellcheck=''"]
-    assert _shellcheck_pass_disablers('"$AL" \\\n  -shellcheck=  -color') == ["-shellcheck="]
-    assert _shellcheck_pass_disablers('"$AL" -shellcheck=/usr/local/bin/shellcheck f.yml') == []
+    """Vacuity guard: every spelling that disables the pass is reported —
+    including the two that bind a value the flag's own line makes look harmless
+    (an explicit path, and `-color` swallowed as the value)."""
+    assert _shellcheck_pass_disablers('xargs -0 "$AL" -shellcheck= -color') == ["-shellcheck"]
+    assert _shellcheck_pass_disablers("\"$AL\" -shellcheck '' f.yml") == ["-shellcheck"]
+    assert _shellcheck_pass_disablers('"$AL" \\\n  -shellcheck=  -color') == ["-shellcheck"]
+    assert _shellcheck_pass_disablers('xargs -0 "$AL" -shellcheck -color') == ["-shellcheck"]
+    assert _shellcheck_pass_disablers('"$AL" -shellcheck=/usr/local/bin/shellcheck f.yml') == ["-shellcheck"]
+    assert _shellcheck_pass_disablers('"$AL" --shellcheck=/usr/bin/shellcheckk f.yml') == ["--shellcheck"]
     assert _shellcheck_pass_disablers('"$AL" -color f.yml') == []
-    try:
-        _shellcheck_pass_disablers('"$AL" -shellcheck')
-    except AssertionError:
-        pass
-    else:  # pragma: no cover - only reached if the scanner stops guarding itself
-        raise AssertionError("a valueless -shellcheck spelling must raise, not pass vacuously")
+    # The job's own comments say "shellcheck" a lot; only the FLAG may trip it.
+    assert _shellcheck_pass_disablers("# actionlint runs shellcheck --norc; see .shellcheckrc") == []

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -182,16 +182,56 @@ def test_local_smoke_pins_the_current_ci_runner_series() -> None:
 # --------------------------------------------------------------------------- #
 
 
+# `-shellcheck=V` and `-shellcheck V` both bind a value; an empty one (`=`, `''`,
+# `""`) disables the pass. `\` + newline is followed first, so a flag and its
+# value split across a continuation read as one invocation.
+_SHELLCHECK_FLAG = re.compile(r"--?shellcheck\b")
+_SHELLCHECK_VALUE = re.compile(r"--?shellcheck(?:=(\S*)|\s+(\S+))")
+
+
+def _shellcheck_pass_disablers(text: str) -> list[str]:
+    """Every `-shellcheck` flag in ``text`` that binds an empty value, i.e.
+    switches actionlint's embedded pass off. Raises on a spelling this scanner
+    cannot read rather than reporting a vacuous pass."""
+    joined = re.sub(r"\\\n\s*", " ", text)
+    values = _SHELLCHECK_VALUE.findall(joined)
+    assert len(values) == len(_SHELLCHECK_FLAG.findall(joined)), (
+        "a -shellcheck flag is spelled in a form this scanner cannot read — update it, never let it pass vacuously"
+    )
+    return [f"-shellcheck={eq or space}" for eq, space in values if (eq or space) in ("", "''", '""')]
+
+
 def test_actionlint_job_keeps_the_embedded_shellcheck_pass() -> None:
     """`run:` bodies are shell that no other gate reads — the ShellCheck job
     scans `src scripts .claude/hooks`, never `.github/workflows` (issue #2241).
-    actionlint's `-shellcheck=` (empty value) silently disables that pass, so a
-    quoting or word-splitting bug in a workflow body would reach `devel`
-    ungated."""
+    An empty `-shellcheck` value disables that pass, so a quoting or
+    word-splitting bug in a workflow body would reach `devel` ungated. The job's
+    own second canary catches the runtime half (a missing binary makes actionlint
+    skip the pass in silence); this catches the source half."""
     text = (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
-    invocations = [line.strip() for line in text.splitlines() if '"$AL"' in line]
-    assert invocations, "the actionlint job no longer invokes $AL — update this gate"
-    disabled = [line for line in invocations if "-shellcheck=" in line]
-    assert not disabled, (
-        "the actionlint job must not disable the embedded shellcheck pass over run: bodies:\n  " + "\n  ".join(disabled)
+    assert '"$AL"' in text, "the actionlint job no longer invokes $AL — update this gate"
+    assert "canary-sc.yml" in text, (
+        "the actionlint job lost its shellcheck canary — without it a ci-runner that stops "
+        "shipping shellcheck turns the run-body pass off silently"
     )
+    disablers = _shellcheck_pass_disablers(text)
+    assert not disablers, (
+        "the actionlint job must not disable the embedded shellcheck pass over run: bodies:\n  "
+        + "\n  ".join(disablers)
+    )
+
+
+def test_shellcheck_disabler_scanner_catches_every_spelling() -> None:
+    """Vacuity guard: the three spellings that actually disable the pass are all
+    reported, an explicit binary path is not, and an unreadable spelling raises."""
+    assert _shellcheck_pass_disablers('xargs -0 "$AL" -shellcheck= -color') == ["-shellcheck="]
+    assert _shellcheck_pass_disablers("\"$AL\" -shellcheck '' f.yml") == ["-shellcheck=''"]
+    assert _shellcheck_pass_disablers('"$AL" \\\n  -shellcheck=  -color') == ["-shellcheck="]
+    assert _shellcheck_pass_disablers('"$AL" -shellcheck=/usr/local/bin/shellcheck f.yml') == []
+    assert _shellcheck_pass_disablers('"$AL" -color f.yml') == []
+    try:
+        _shellcheck_pass_disablers('"$AL" -shellcheck')
+    except AssertionError:
+        pass
+    else:  # pragma: no cover - only reached if the scanner stops guarding itself
+        raise AssertionError("a valueless -shellcheck spelling must raise, not pass vacuously")

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -182,53 +182,96 @@ def test_local_smoke_pins_the_current_ci_runner_series() -> None:
 # --------------------------------------------------------------------------- #
 
 
-# Any value at all, not just an empty one: actionlint skips the pass in silence
-# for every `-shellcheck` value it cannot resolve to a binary — `-shellcheck=`,
+# Two flags silence the pass. `-shellcheck` with ANY value: actionlint skips the
+# pass in silence for every value it cannot resolve to a binary — `-shellcheck=`,
 # `-shellcheck ''`, a typo'd path, and `-shellcheck -color` (Go's flag package
-# binds `-color` as the value) all exit 0 with run bodies ungraded. The job
-# resolves shellcheck from PATH and the canary below proves it resolved, so the
-# flag has no legitimate use here; keeping it out also keeps the canary's argv
-# equivalent to the tree-grading argv.
-_SHELLCHECK_FLAG = re.compile(r"--?shellcheck\b")
+# binds `-color` as the value) all exit 0 with run bodies ungraded. `-ignore`:
+# a regex that filters matched messages out of the report, so `-ignore
+# 'shellcheck reported'` grades the tree and discards every finding. The job
+# resolves shellcheck from PATH and its canary proves the resolution, so neither
+# flag has a legitimate use here; keeping `-shellcheck` out also keeps the
+# canary's argv equivalent to the tree-grading argv.
+#
+# The left boundary matters: unanchored, the pattern matches the tail of any
+# hyphenated token, so the `paths-ignore:` keys and a `canary-shellcheck.yml`
+# filename would trip the gate. Comment lines are skipped for the same reason —
+# they document the flags, they cannot pass them.
+_PASS_SILENCER = re.compile(r"(?<![\w-])--?(?:shellcheck|ignore)\b")
 
 
-def _shellcheck_pass_disablers(text: str) -> list[str]:
-    """Every `-shellcheck` flag handed to actionlint in ``text``. A `\\` + newline
-    is folded first, so a flag split from its invocation across a continuation is
-    still seen."""
-    return _SHELLCHECK_FLAG.findall(re.sub(r"\\\n\s*", " ", text))
+def _pass_silencers(text: str) -> list[str]:
+    """Every non-comment line of ``text`` handing actionlint a flag that switches
+    its embedded shellcheck pass off or filters the pass's findings away, located
+    for the failure message. Line-agnostic by construction, so a flag split from
+    its invocation across a `\\` + newline continuation is still its own line."""
+    return [
+        f"test.yml:{n}: {line.strip()}"
+        for n, line in enumerate(text.splitlines(), 1)
+        if not line.lstrip().startswith("#") and _PASS_SILENCER.search(line)
+    ]
 
 
 def test_actionlint_job_keeps_the_embedded_shellcheck_pass() -> None:
     """`run:` bodies are shell that no other gate reads — the ShellCheck job
     scans `src scripts .claude/hooks`, never `.github/workflows` (issue #2241).
-    A `-shellcheck` value actionlint cannot resolve turns the pass off silently,
-    so a quoting or word-splitting bug in a workflow body would reach `devel`
-    ungated. The job's own canary catches the runtime half (a binary missing from
-    the image); this catches the source half."""
+    An unresolvable `-shellcheck` value turns the pass off silently and `-ignore`
+    discards its findings, either way letting a quoting or word-splitting bug in
+    a workflow body reach `devel` ungated. The job's own canary catches the
+    runtime half (a binary missing from the image); this catches the source
+    half."""
     text = (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
     assert '"$AL"' in text, "the actionlint job no longer invokes $AL — update this gate"
-    assert "canary-sc.yml" in text, (
-        "the actionlint job lost its shellcheck canary — without it a ci-runner that stops "
-        "shipping shellcheck turns the run-body pass off silently"
+    assert "echo $CANARY" in text, (
+        "the actionlint job lost its shellcheck canary — the fixture whose unquoted expansion "
+        "must fail actionlint is what proves the embedded pass ran at all, so without it a "
+        "ci-runner that stops shipping shellcheck turns run-body coverage off silently"
     )
-    disablers = _shellcheck_pass_disablers(text)
-    assert not disablers, (
-        "the actionlint job must not pass -shellcheck: every value actionlint cannot resolve "
-        f"disables the embedded pass over run: bodies, silently. Found: {disablers}"
+    silencers = _pass_silencers(text)
+    assert not silencers, (
+        "the actionlint job must pass neither -shellcheck (every value actionlint cannot "
+        "resolve disables the embedded pass over run: bodies, silently) nor -ignore (which "
+        "filters the pass's findings out of the report):\n  " + "\n  ".join(silencers)
     )
 
 
-def test_shellcheck_disabler_scanner_catches_every_spelling() -> None:
-    """Vacuity guard: every spelling that disables the pass is reported —
-    including the two that bind a value the flag's own line makes look harmless
-    (an explicit path, and `-color` swallowed as the value)."""
-    assert _shellcheck_pass_disablers('xargs -0 "$AL" -shellcheck= -color') == ["-shellcheck"]
-    assert _shellcheck_pass_disablers("\"$AL\" -shellcheck '' f.yml") == ["-shellcheck"]
-    assert _shellcheck_pass_disablers('"$AL" \\\n  -shellcheck=  -color') == ["-shellcheck"]
-    assert _shellcheck_pass_disablers('xargs -0 "$AL" -shellcheck -color') == ["-shellcheck"]
-    assert _shellcheck_pass_disablers('"$AL" -shellcheck=/usr/local/bin/shellcheck f.yml') == ["-shellcheck"]
-    assert _shellcheck_pass_disablers('"$AL" --shellcheck=/usr/bin/shellcheckk f.yml') == ["--shellcheck"]
-    assert _shellcheck_pass_disablers('"$AL" -color f.yml') == []
-    # The job's own comments say "shellcheck" a lot; only the FLAG may trip it.
-    assert _shellcheck_pass_disablers("# actionlint runs shellcheck --norc; see .shellcheckrc") == []
+def test_no_actionlint_config_filters_the_shellcheck_pass() -> None:
+    """`.github/actionlint.yaml` can drop messages per path (`paths: {glob:
+    {ignore: [regex]}}`, the skeleton `actionlint -init-config` writes). That
+    silences the tree while BOTH canaries stay green: they are graded from
+    `$RUNNER_TEMP`, outside the repo project, where no config applies."""
+    for name in ("actionlint.yaml", "actionlint.yml"):
+        config = ROOT / ".github" / name
+        if not config.exists():
+            continue
+        assert "shellcheck" not in config.read_text(encoding="utf-8").lower(), (
+            f".github/{name} filters shellcheck messages out of actionlint's report — run "
+            "bodies would go ungraded while the job's canaries, graded outside the project, "
+            "stay green"
+        )
+
+
+def test_pass_silencer_scanner_catches_every_spelling() -> None:
+    """Vacuity guard: every spelling that silences the pass is reported —
+    including the three that look harmless on their own line (an explicit path,
+    `-color` swallowed as the value, and an `-ignore` regex) — while prose and
+    hyphenated tokens are not."""
+    assert _pass_silencers('xargs -0 "$AL" -shellcheck= -color') == ['test.yml:1: xargs -0 "$AL" -shellcheck= -color']
+    assert _pass_silencers("\"$AL\" -shellcheck '' f.yml") == ["test.yml:1: \"$AL\" -shellcheck '' f.yml"]
+    assert _pass_silencers('"$AL" \\\n  -shellcheck=  -color') == ["test.yml:2: -shellcheck=  -color"]
+    assert _pass_silencers('xargs -0 "$AL" -shellcheck -color') == ['test.yml:1: xargs -0 "$AL" -shellcheck -color']
+    assert _pass_silencers('"$AL" -shellcheck=/usr/local/bin/shellcheck f.yml') == [
+        'test.yml:1: "$AL" -shellcheck=/usr/local/bin/shellcheck f.yml'
+    ]
+    assert _pass_silencers('"$AL" --shellcheck=/usr/bin/shellcheckk f.yml') == [
+        'test.yml:1: "$AL" --shellcheck=/usr/bin/shellcheckk f.yml'
+    ]
+    assert _pass_silencers("xargs -0 \"$AL\" -color -ignore 'shellcheck reported issue'") == [
+        "test.yml:1: xargs -0 \"$AL\" -color -ignore 'shellcheck reported issue'"
+    ]
+    assert _pass_silencers('"$AL" -color f.yml') == []
+    # Prose must not trip it: a comment cannot pass a flag, `paths-ignore:` and a
+    # `canary-shellcheck.yml` filename are not flags, and `--norc` is not one either.
+    assert _pass_silencers("          # never pass -shellcheck here, nor -ignore") == []
+    assert _pass_silencers("# actionlint runs shellcheck --norc; see .shellcheckrc") == []
+    assert _pass_silencers("      paths-ignore:\n        - '**.md'") == []
+    assert _pass_silencers('> "$RUNNER_TEMP/canary-shellcheck.yml"') == []


### PR DESCRIPTION
Closes #2241.

## Why

Workflow `run:` bodies were the only shell surface in the repo with no lint gate. The ShellCheck job scans `src scripts .claude/hooks`; the `actionlint` job passed `-shellcheck=`, switching actionlint's embedded shellcheck-on-run-bodies pass off pending the sweep this issue tracks. A quoting or word-splitting bug inside a `run:` body reached `devel` ungated.

## The sweep

18 findings across 6 workflows, **no bugs**. Each was audited against the flagged column before any suppression was accepted:

| finding | count | verdict |
| --- | --- | --- |
| SC2016 on `printf` format strings for PR/issue bodies | 14 | False positive — literal markdown backticks; none of the 14 single-quoted literals contains a `$` at all, every value is passed as a `%s` argument. Annotated. |
| SC2016 on the shebang gate's deferred `sh -c` script | 1 | False positive — `$f` and `$(head …)` are expanded by the inner shell fed by `xargs -0 … _`; deferring them is the point. Annotated. |
| SC2086 on the module-durations log word-split | 1 | False positive — deliberate split, already annotated one line below for the sibling call that requires it; quoting collapses the indentation. Annotated. |
| SC2129 on build-pkg-linux's `$GITHUB_OUTPUT` appends | 1 | **Real.** Fixed: the two appends are grouped into one redirect. |

One more surfaced during the work and is annotated: the new canary's own `printf` fixture, where `$CANARY` is text for actionlint to flag rather than an expansion — caught by the very gate this PR enables.

## Keeping the new coverage from going quiet

Enabling the pass is only half the job — there are four ways to silence it, three of them silent.

- **Missing binary.** actionlint skips the pass with no diagnostic and exit 0 when shellcheck is unresolvable. The job now runs a **second canary**: a fixture whose only defect is an unquoted expansion must fail actionlint before the tree is graded. Verified — a PATH stripped of shellcheck gives exit 0, so the canary fires.
- **`-shellcheck <value>`.** *Any* value actionlint cannot resolve disables the pass, including a typo'd path and `-shellcheck -color` (Go's flag package binds `-color` as the value). `tests/test_issue2231_workflow_hygiene.py` rejects the flag outright: the job resolves shellcheck from PATH and the canary proves the resolution, so the flag has no legitimate use here. That also keeps the canary's argv equivalent to the tree-grading argv.
- **`-ignore <regex>`.** Grades the tree, then filters the findings out of the report. Verified exit 1 → exit 0. Now rejected by the same guard.
- **`.github/actionlint.yaml` `paths.ignore`.** Same effect, per path, and invisible to both canaries — they grade from `$RUNNER_TEMP`, outside the repo project, where no config applies. A second test rejects a config that filters shellcheck messages. No such file exists today.

## Two constraints the job comment now records

- The embedded pass reads **no `.shellcheckrc`** (actionlint runs shellcheck `--norc`), so the repo-level suppressions (SC1091/SC2154/SC2038/SC2012) do not apply to `run:` bodies.
- A body-level directive at the top of a `run:` block is **ignored**; suppressions must sit directly above the statement.

## Verification

- The exact command the job now runs — `find` over `.github/workflows` piped into `xargs -0 actionlint -color` — exits 0 across all 23 workflows.
- Red canary re-proved without the flag: the duplicate-key fixture still fails actionlint (exit 1).
- Local actionlint 1.7.12 + shellcheck 0.11.0 match the versions baked into `ci-runner:4` (`ACTIONLINT_VERSION` / `SHELLCHECK_VERSION` in the ci-runner Dockerfile).
- Guard red/green matrix, 12 variants: RED for `-shellcheck=`, `-shellcheck ''`, a continuation split, `-shellcheck -color`, a typo'd path, an explicit valid path, `-ignore`, a deleted canary, and the base revision; GREEN for head, a comment mentioning the flags, and a canary rename.
- `python3 -m pytest` → 4926 passed, 4 skipped. ruff check + format clean, mypy clean.
- The first head passed the full CI matrix, including the `actionlint (workflow files)` job with the pass live in the container.

## Out of scope

Composite-action run bodies stay ungated — actionlint parses an action manifest as a workflow and rejects its `runs:` key, so `.github/actions/*/action.yml` cannot ride this gate.
