### PR TITLE
smoke: reach the LAN registry by explicit ref over plain HTTP

### DIFF
--- a/scripts/lib/oras-refresh.sh
+++ b/scripts/lib/oras-refresh.sh
@@ -75,9 +75,13 @@ pfb_oras_refresh_unlocked() {
     _or_digest_file="$(pfb_oras_digest_file "$_or_ref" "$_or_dir")" || return 1
 
     # Remote digest (best-effort; a lookup failure must not delete or replace anything).
+    # ${PFB_ORAS_FLAGS:-} is unquoted by design: empty expands to zero words (POSIX
+    # word splitting), '--plain-http' expands to one -- the LAN-registry caller
+    # (smoke-on-box.sh, issue #2247) sets it once, every oras call here picks it up.
     _or_remote=''
-    _or_remote="$(oras resolve "$_or_ref" 2>/dev/null)" \
-        || _or_remote="$(oras manifest fetch "$_or_ref" --descriptor 2>/dev/null \
+    # shellcheck disable=SC2086  # intentional: unquoted default-empty flag var, see above
+    _or_remote="$(oras resolve ${PFB_ORAS_FLAGS:-} "$_or_ref" 2>/dev/null)" \
+        || _or_remote="$(oras manifest fetch ${PFB_ORAS_FLAGS:-} "$_or_ref" --descriptor 2>/dev/null \
                          | grep -o '"digest":"[^"]*"' | cut -d'"' -f4)" \
         || _or_remote=''
 
@@ -118,14 +122,16 @@ EOF
     if pfb_oras_login 2>/dev/null; then :; fi
 
     if [ -n "$_or_remote" ]; then
-        ( cd "$_or_stage" && oras pull "${_or_ref%@*}@${_or_remote}" ) >&2 || {
+        # shellcheck disable=SC2086  # intentional: unquoted default-empty flag var, see above
+        ( cd "$_or_stage" && oras pull ${PFB_ORAS_FLAGS:-} "${_or_ref%@*}@${_or_remote}" ) >&2 || {
             rm -rf "$_or_stage"
             printf 'oras-refresh: pull FAILED for %s; published store left untouched\n' \
                 "$_or_tag" >&2
             return 1
         }
     else
-        ( cd "$_or_stage" && oras pull "$_or_ref" ) >&2 || {
+        # shellcheck disable=SC2086  # intentional: unquoted default-empty flag var, see above
+        ( cd "$_or_stage" && oras pull ${PFB_ORAS_FLAGS:-} "$_or_ref" ) >&2 || {
             rm -rf "$_or_stage"
             printf 'oras-refresh: pull FAILED for %s; published store left untouched\n' \
                 "$_or_tag" >&2
@@ -164,3 +170,36 @@ EOF
 if ! command -v pfb_oras_login >/dev/null 2>&1; then
     pfb_oras_login() { :; }
 fi
+
+# ── LAN registry override (issue #2247) ─────────────────────────────────────── #
+# The box fleet reaches a LAN-only zot cache (anonymous, read-only, plain HTTP --
+# no TLS, no login) instead of ghcr.io when PFB_LAN_REGISTRY is set in the box's
+# own environment (delivered via /etc/environment + PAM, or threaded in by
+# smoke-on-box.sh's caller). The ref rewrite, the --plain-http flag (PFB_ORAS_FLAGS
+# above) and the ghcr.io login skip (smoke-on-box.sh) all key off the ONE guard
+# below so they can never disagree about which mode is active.
+
+# pfb_lan_registry_active — true (0) when PFB_LAN_REGISTRY is set to a non-empty
+# value. `PFB_LAN_REGISTRY=` (empty but set) is treated the same as unset.
+pfb_lan_registry_active() {
+    [ -n "${PFB_LAN_REGISTRY:-}" ]
+}
+
+# pfb_rewrite_lan_registry <ref>
+#
+# Rewrites a LEADING `ghcr.io/` to `${PFB_LAN_REGISTRY}/`; anything else passes
+# through unchanged. Single choke point: covers both a script's own ghcr.io/...
+# default and a caller-injected full ghcr.io/... ref alike, since both take the
+# same prefix form. Only the prefix is touched, so a tag or `@sha256:...` digest
+# suffix survives intact. PFB_LAN_REGISTRY with a trailing slash is NOT supported
+# (would double the `/`); use a bare host[:port] value.
+pfb_rewrite_lan_registry() {
+    if ! pfb_lan_registry_active; then
+        printf '%s\n' "$1"
+        return 0
+    fi
+    case "$1" in
+        ghcr.io/*) printf '%s/%s\n' "$PFB_LAN_REGISTRY" "${1#ghcr.io/}" ;;
+        *)         printf '%s\n' "$1" ;;
+    esac
+}

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -203,13 +203,15 @@ fi
 #                      `sysctl -w`, which a container cannot perform against the host.
 #   the bind mounts    repo, shared image store, ports tree and guest key all live on the
 #                      box; without them every run re-clones and re-pulls.
-#   --add-host ...     issue #2230: routes ghcr.io to the box's LAN zot mirror when
-#                      PFB_LAN_REGISTRY is set in the BOX's own environment -- the
-#                      `${...:+...}` is left UNEXPANDED here (escaped `\$`) so the
-#                      remote shell resolves it, not this caller; unset expands to
-#                      zero words, so the flag is silently absent (today's behavior).
-#   the CA mount       the LAN mirror's cert validates against the box's bundle; the
-#                      container's stock CA store lacks the fleet CA that signed it.
+#   the image ref      issue #2247: box-side-expanded `${PFB_LAN_REGISTRY:-ghcr.io}/...`
+#                      (escaped `\$` -- left UNEXPANDED here so the remote box shell
+#                      resolves it against ITS OWN /etc/environment, not this caller's);
+#                      unset falls back to ghcr.io, today's behavior. -e PFB_LAN_REGISTRY
+#                      carries the same var into the container so scripts/smoke-on-box.sh
+#                      and scripts/lib/oras-refresh.sh can rewrite refs and route oras
+#                      --plain-http against the LAN registry themselves. Supersedes the
+#                      --add-host hijack + CA-bundle mount from #2230: one mechanism, no
+#                      private PKI (owner decision 2026-08-08).
 # Ref-stable: the one-liner is the only part that has to work across refs;
 # smoke-on-box.sh handles everything else.
 # shellcheck disable=SC2089  # quoting: _ob_flags is pre-encoded for remote sh
@@ -222,15 +224,13 @@ _bootstrap="cd /root/pfBlockerNG \
  && exec docker run --rm \
       --device /dev/kvm \
       --sysctl net.ipv4.ip_unprivileged_port_start=53 \
-      \${PFB_LAN_REGISTRY:+--add-host ghcr.io:\$PFB_LAN_REGISTRY} \
       -v /root/pfBlockerNG:/root/pfBlockerNG \
       -v /root/images:/root/images \
       -v /root/FreeBSD-ports:/root/FreeBSD-ports \
       -v /root/smoke-ssh-key:/root/smoke-ssh-key:ro \
-      -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro \
-      -e SMOKE_GHCR_TOKEN -e SMOKE_PFSENSE_REF -e CIVM_REF -e SMOKE_LANE -e PFB_DIAG_DIR \
+      -e SMOKE_GHCR_TOKEN -e SMOKE_PFSENSE_REF -e CIVM_REF -e SMOKE_LANE -e PFB_DIAG_DIR -e PFB_LAN_REGISTRY \
       -w /root/pfBlockerNG \
-      ghcr.io/pfblockerng/ci-runner-vm:4 \
+      \${PFB_LAN_REGISTRY:-ghcr.io}/pfblockerng/ci-runner-vm:4 \
       sh scripts/smoke-on-box.sh $_ob_flags"
 
 printf 'local-smoke: leasing box (REF=%s marker=%s%s)\n' \

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -31,6 +31,10 @@
 #   SMOKE_GHCR_TOKEN  optional; used for `oras login ghcr.io` before image pull
 #   SMOKE_PFSENSE_REF pfSense image ref (default ghcr.io/pfblockerng/pfsense-ce:2.8)
 #   CIVM_REF          civm image ref (default ghcr.io/pfblockerng/civm:v1)
+#   PFB_LAN_REGISTRY  issue #2247: when set (box's own /etc/environment), rewrite a
+#                     leading ghcr.io/ in PFSENSE_REF/CIVM_REF to
+#                     "${PFB_LAN_REGISTRY}/", add --plain-http to every oras call,
+#                     and skip the token-based ghcr.io login (anonymous LAN cache).
 #
 # Test-only (env):
 #   PFB_ONBOX_REPO_ROOT  override the repo path (default /root/pfBlockerNG). Points the
@@ -88,6 +92,24 @@ IMAGES_DIR="/root/images"
 PFSENSE_REF="${SMOKE_PFSENSE_REF:-ghcr.io/pfblockerng/pfsense-ce:2.8}"
 CIVM_REF="${CIVM_REF:-ghcr.io/pfblockerng/civm:v1}"
 
+# ── LAN registry override (issue #2247) ─────────────────────────────────────── #
+# Single choke point: covers this script's own ghcr.io/... defaults above AND a
+# caller-injected full ghcr.io/... ref alike (pfb_rewrite_lan_registry only
+# touches a LEADING ghcr.io/, so a ref that already points elsewhere is a no-op).
+PFSENSE_REF="$(pfb_rewrite_lan_registry "$PFSENSE_REF")"
+CIVM_REF="$(pfb_rewrite_lan_registry "$CIVM_REF")"
+
+# oras-refresh.sh's four oras invocations consume this (default empty -> unquoted
+# expansion is zero words, i.e. no flag); set once here rather than repeating the
+# flag at each call site. Exported: SC1091 is disabled repo-wide (.shellcheckrc),
+# so shellcheck never follows the `.` of oras-refresh.sh from this file and reads
+# this var as dead without it.
+PFB_ORAS_FLAGS=""
+if pfb_lan_registry_active; then
+    PFB_ORAS_FLAGS="--plain-http"
+fi
+export PFB_ORAS_FLAGS
+
 # ── Arg parsing ───────────────────────────────────────────────────────────── #
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -112,9 +134,11 @@ done
 printf 'smoke-on-box: running at ref %s\n' "$_REF" >&2
 # Echo the whole resolved configuration, not just the ref: a flag that silently
 # failed to parse otherwise shows up only as a leg that quietly ran the default.
-printf 'smoke-on-box: config abi=%s channel=%s marker=%s filter=%s shard=%s/%s two-vm=%s\n' \
+# pfsense_ref/civm_ref are echoed AFTER their LAN-registry rewrite (issue #2247), so
+# a wrong rewrite is visible here rather than only three steps later, mid pull.
+printf 'smoke-on-box: config abi=%s channel=%s marker=%s filter=%s shard=%s/%s two-vm=%s pfsense_ref=%s civm_ref=%s\n' \
     "$_ABI" "$_CHANNEL" "$_MARKER" "${_FILTER:-<none>}" "$_SHARD" "$_SHARD_TOTAL" \
-    "$([ "$_NO_TWO_VM" -eq 1 ] && echo no || echo yes)" >&2
+    "$([ "$_NO_TWO_VM" -eq 1 ] && echo no || echo yes)" "$PFSENSE_REF" "$CIVM_REF" >&2
 
 # Checked FIRST: this is a property of how we were INVOKED, so failing here costs
 # nothing, while discovering it after the ports refresh and the image pull wastes minutes
@@ -167,14 +191,19 @@ sh scripts/sparse-clone-ports.sh \
 
 # ── Step 3: oras images (refresh when stale; pull when absent) ─────────────── #
 _oras_login_done=0
-pfb_oras_login() {
-    if [ "$_oras_login_done" -eq 0 ] && [ -n "${SMOKE_GHCR_TOKEN:-}" ]; then
-        printf '%s\n' "$SMOKE_GHCR_TOKEN" | \
-            oras login ghcr.io --username pfBlockerNG --password-stdin >/dev/null 2>&1 \
-            || true
-        _oras_login_done=1
-    fi
-}
+# issue #2247: the LAN registry is anonymous read-only -- when it is active, leave
+# oras-refresh.sh's own no-op pfb_oras_login stub in effect (sourced above) rather
+# than defining the real token-based ghcr.io login here.
+if ! pfb_lan_registry_active; then
+    pfb_oras_login() {
+        if [ "$_oras_login_done" -eq 0 ] && [ -n "${SMOKE_GHCR_TOKEN:-}" ]; then
+            printf '%s\n' "$SMOKE_GHCR_TOKEN" | \
+                oras login ghcr.io --username pfBlockerNG --password-stdin >/dev/null 2>&1 \
+                || true
+            _oras_login_done=1
+        fi
+    }
+fi
 
 pfb_oras_refresh "$PFSENSE_REF" "${IMAGES_DIR}/pfsense" "pfSense"
 if [ "$_NO_TWO_VM" -eq 0 ]; then

--- a/tests/shell/local_smoke_container_spec.sh
+++ b/tests/shell/local_smoke_container_spec.sh
@@ -76,9 +76,13 @@ EOF
   # ── the container invocation ─────────────────────────────────────────────── #
 
   It 'runs the leg inside the VM runner image'
+    # The image ref itself (box-side-expanded against PFB_LAN_REGISTRY, issue #2247)
+    # is pinned by its own example below; this one only needs the runner image name,
+    # which no longer sits directly after a literal 'ghcr.io/' -- that prefix is now
+    # the variable-default half of a `${PFB_LAN_REGISTRY:-ghcr.io}` fragment.
     When call bootstrap --ref dummy
     The output should include 'docker run'
-    The output should include 'ghcr.io/pfblockerng/ci-runner-vm'
+    The output should include 'pfblockerng/ci-runner-vm:4'
   End
 
   It 'passes /dev/kvm into the container'
@@ -94,23 +98,39 @@ EOF
     The output should include '--sysctl net.ipv4.ip_unprivileged_port_start=53'
   End
 
-  It 'add-hosts ghcr.io to the LAN registry, expanded box-side (issue #2230)'
-    # The box fleet hijacks ghcr.io via /etc/hosts to the LAN zot mirror
-    # (10.0.0.111). PFB_LAN_REGISTRY lives in the BOX's /etc/environment, not
-    # the orchestrator's -- so this must survive as an UNEXPANDED ${...:+...}
-    # fragment in the bootstrap string handed to select-box.sh, and expand only
-    # once the remote shell runs it. Unset on the fake box here: `:+` on an
-    # unset var is zero words, so nothing to assert its expansion against --
-    # this pins the literal fragment survives the caller-side double quotes.
+  It 'expands the ci-runner-vm image ref against the LAN registry, box-side (issue #2247)'
+    # The box fleet routes to the LAN zot cache via PFB_LAN_REGISTRY, which lives in
+    # the BOX's /etc/environment, not the orchestrator's -- so this must survive as
+    # an UNEXPANDED ${...:-...} fragment in the bootstrap string handed to
+    # select-box.sh, and expand only once the remote shell runs it. Unset on the
+    # fake box here: `:-` on an unset var falls back to ghcr.io, so this pins the
+    # literal fragment survives the caller-side double quotes rather than asserting
+    # its (unreachable, from here) expansion.
     When call bootstrap --ref dummy
-    The output should include '${PFB_LAN_REGISTRY:+--add-host ghcr.io:$PFB_LAN_REGISTRY}'
+    The output should include '${PFB_LAN_REGISTRY:-ghcr.io}/pfblockerng/ci-runner-vm:4'
   End
 
-  It 'mounts the CA bundle so TLS against the LAN registry validates (issue #2230)'
-    # zot's cert SANs DNS:ghcr.io + IP:10.0.0.111; the container needs the
-    # system CA bundle to validate it, same as the box does.
+  It 'no longer add-hosts ghcr.io to the LAN registry (issue #2247)'
+    # Superseded by the parameterized image ref above: routing is now an explicit
+    # ref, not a /etc/hosts hijack -- the owner decision that dropped the private
+    # PKI landed by #2230 in favour of one mechanism, no TLS to a LAN-only cache.
     When call bootstrap --ref dummy
-    The output should include '-v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro'
+    The output should not include '--add-host'
+  End
+
+  It 'no longer mounts a CA bundle into the container (issue #2247)'
+    # Superseded: the LAN registry now serves plain HTTP (owner decision 2026-08-08
+    # in issue #2247), so there is no TLS cert to validate and nothing to carry a
+    # fleet CA bundle in for.
+    When call bootstrap --ref dummy
+    The output should not include 'ca-certificates.crt'
+  End
+
+  It 'passes PFB_LAN_REGISTRY into the container (issue #2247)'
+    # smoke-on-box.sh and oras-refresh.sh, running INSIDE the container, need the
+    # var themselves to rewrite ghcr.io refs and route oras --plain-http.
+    When call bootstrap --ref dummy
+    The output should include '-e PFB_LAN_REGISTRY'
   End
 
   It 'mounts the repo, the shared image store, the ports tree and the guest key'

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -338,6 +338,18 @@ EOF
     The stderr should be present
   End
 
+  It 'passes a byte-exact resolve argv when PFB_ORAS_FLAGS is unset (no empty word)'
+    # A quoted "${PFB_ORAS_FLAGS:-}" would inject an empty argv word here while
+    # the count-based guard above stays green; pin the exact argv instead.
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:new pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      grep "^resolve " "$STUB_ARGV_LOG"
+    ' sh "$LIB" "$IMGDIR"
+    The output should eq 'resolve ghcr.io/x/pfsense-ce:2.8'
+    The stderr should be present
+  End
+
   It 'pfb_lan_registry_active reports set vs unset vs empty-but-set'
     When call sh -c '
       . "$1"; shift

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -35,8 +35,18 @@ Describe 'oras-refresh library (shared image store, issue #2218)'
     # interrupted-transfer case the published store must survive.
     cat > "${BIN}/oras" <<'EOF'
 #!/bin/sh
+# Record the FULL argv every invocation gets, so a spec can assert which flags
+# reached which subcommand (issue #2247: PFB_ORAS_FLAGS threading).
+printf '%s\n' "$*" >> "${STUB_ARGV_LOG}"
 case "$1" in
-  resolve) printf '%s\n' "${STUB_REMOTE_DIGEST}" ;;
+  resolve)
+    if [ -n "${STUB_RESOLVE_FAIL:-}" ]; then exit 1; fi
+    printf '%s\n' "${STUB_REMOTE_DIGEST}"
+    ;;
+  manifest)
+    # oras manifest fetch <ref> --descriptor -- only reached when resolve fails.
+    printf '{"digest":"%s"}\n' "${STUB_REMOTE_DIGEST}"
+    ;;
   pull)
     # Where the transfer lands (real oras pulls into cwd) — the staging-location
     # example asserts on this.
@@ -54,11 +64,14 @@ EOF
 
     STUB_PULL_LOG="${WORK}/pulls.log"
     STUB_CWD_LOG="${WORK}/cwds.log"
+    STUB_ARGV_LOG="${WORK}/argv.log"
     printf "" > "$STUB_PULL_LOG"
     printf "" > "$STUB_CWD_LOG"
+    printf "" > "$STUB_ARGV_LOG"
     STUB_ARTIFACT_NAME="pfSense-CE_2.8.qcow2"
     PATH="${BIN}:${PATH}"
-    export PATH STUB_PULL_LOG STUB_CWD_LOG STUB_ARTIFACT_NAME STUB_REMOTE_DIGEST ORAS_PULL_FAIL
+    export PATH STUB_PULL_LOG STUB_CWD_LOG STUB_ARGV_LOG STUB_ARTIFACT_NAME \
+        STUB_REMOTE_DIGEST ORAS_PULL_FAIL STUB_RESOLVE_FAIL
   }
 
   cleanup() { rm -rf "$WORK"; }
@@ -270,5 +283,85 @@ EOF
     The output should eq '1'
     The status should be success
     The stderr should be present
+  End
+
+  # ── LAN registry oras flag threading (issue #2247) ───────────────────────── #
+  #
+  # smoke-on-box.sh sets PFB_ORAS_FLAGS='--plain-http' when PFB_LAN_REGISTRY is set
+  # (LAN zot cache, anonymous, plain HTTP, no TLS). Every oras invocation this file
+  # makes must pick it up unquoted from the SAME variable, not a copy re-derived at
+  # each call site.
+
+  It 'threads PFB_ORAS_FLAGS into the resolve call'
+    When call sh -c '
+      . "$1"; shift
+      PFB_ORAS_FLAGS="--plain-http" STUB_REMOTE_DIGEST=sha256:new \
+        pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      grep "^resolve " "$STUB_ARGV_LOG"
+    ' sh "$LIB" "$IMGDIR"
+    The output should include 'resolve --plain-http ghcr.io/x/pfsense-ce:2.8'
+    The stderr should be present
+  End
+
+  It 'threads PFB_ORAS_FLAGS into the pull call'
+    When call sh -c '
+      . "$1"; shift
+      PFB_ORAS_FLAGS="--plain-http" STUB_REMOTE_DIGEST=sha256:new \
+        pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      grep "^pull " "$STUB_ARGV_LOG"
+    ' sh "$LIB" "$IMGDIR"
+    The output should include 'pull --plain-http'
+    The stderr should be present
+  End
+
+  It 'threads PFB_ORAS_FLAGS into the manifest-fetch fallback'
+    # Only reached when `oras resolve` itself fails.
+    When call sh -c '
+      . "$1"; shift
+      PFB_ORAS_FLAGS="--plain-http" STUB_REMOTE_DIGEST=sha256:new STUB_RESOLVE_FAIL=1 \
+        pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      grep "^manifest " "$STUB_ARGV_LOG"
+    ' sh "$LIB" "$IMGDIR"
+    The output should include 'manifest fetch --plain-http ghcr.io/x/pfsense-ce:2.8 --descriptor'
+    The stderr should be present
+  End
+
+  It 'does not add --plain-http to any oras call when PFB_ORAS_FLAGS is unset'
+    # Regression guard for the hosted-CI fallback: an unset flag must not sneak
+    # into the argv the ephemeral-runner leg (PFB_LAN_REGISTRY unset) sends.
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:new pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" pfSense
+      grep -c -- "--plain-http" "$STUB_ARGV_LOG" || true
+    ' sh "$LIB" "$IMGDIR"
+    The output should eq '0'
+    The stderr should be present
+  End
+
+  It 'pfb_lan_registry_active reports set vs unset vs empty-but-set'
+    When call sh -c '
+      . "$1"; shift
+      PFB_LAN_REGISTRY=10.0.0.111 pfb_lan_registry_active && echo set
+      unset PFB_LAN_REGISTRY
+      pfb_lan_registry_active || echo unset
+      PFB_LAN_REGISTRY= pfb_lan_registry_active || echo empty-unset
+    ' sh "$LIB"
+    The output should equal "$(printf 'set\nunset\nempty-unset')"
+  End
+
+  It 'pfb_rewrite_lan_registry rewrites only a leading ghcr.io/ prefix, tail intact'
+    When call sh -c '
+      . "$1"; shift
+      PFB_LAN_REGISTRY=10.0.0.111 pfb_rewrite_lan_registry ghcr.io/pfblockerng/pfsense-ce:2.8
+      PFB_LAN_REGISTRY=10.0.0.111 \
+        pfb_rewrite_lan_registry ghcr.io/pfblockerng/pfsense-ce:2.8@sha256:deadbeef
+      PFB_LAN_REGISTRY=10.0.0.111 pfb_rewrite_lan_registry quay.io/pfblockerng/pfsense-ce:2.8
+      unset PFB_LAN_REGISTRY
+      pfb_rewrite_lan_registry ghcr.io/pfblockerng/pfsense-ce:2.8
+    ' sh "$LIB"
+    The line 1 of output should equal '10.0.0.111/pfblockerng/pfsense-ce:2.8'
+    The line 2 of output should equal '10.0.0.111/pfblockerng/pfsense-ce:2.8@sha256:deadbeef'
+    The line 3 of output should equal 'quay.io/pfblockerng/pfsense-ce:2.8'
+    The line 4 of output should equal 'ghcr.io/pfblockerng/pfsense-ce:2.8'
   End
 End

--- a/tests/shell/smoke_on_box_spec.sh
+++ b/tests/shell/smoke_on_box_spec.sh
@@ -136,4 +136,75 @@ STUBEOF
     The status should not equal 0
     The stderr should be present
   End
+
+  # ── LAN registry ref rewrite (issue #2247) ───────────────────────────────── #
+  #
+  # The config echo (config abi=... pfsense_ref=... civm_ref=...) fires BEFORE the
+  # port-floor gate exits, so it is the seam these examples use to observe the
+  # rewrite without letting the run reach real host prep (pkill, venv, oras pulls).
+  # pfsense_ref/civm_ref are echoed AFTER their rewrite by construction (single
+  # choke point right after PFSENSE_REF/CIVM_REF resolve).
+
+  It 'rewrites the default ghcr.io pfsense/civm refs to the LAN registry when set'
+    PFB_LAN_REGISTRY=10.0.0.111
+    export PFB_LAN_REGISTRY
+    When run sh "$SCRIPT" --ref HEAD
+    The status should equal 1
+    The stderr should include 'pfsense_ref=10.0.0.111/pfblockerng/pfsense-ce:2.8'
+    The stderr should include 'civm_ref=10.0.0.111/pfblockerng/civm:v1'
+  End
+
+  It 'rewrites a workflow-injected full ghcr.io ref the same way'
+    # Covers both script defaults (above) and a full ref a caller injects via
+    # SMOKE_PFSENSE_REF/CIVM_REF -- one choke point, same rewrite either way.
+    PFB_LAN_REGISTRY=10.0.0.111
+    SMOKE_PFSENSE_REF=ghcr.io/pfblockerng/pfsense-ce:2.9
+    CIVM_REF=ghcr.io/pfblockerng/civm:v2
+    export PFB_LAN_REGISTRY SMOKE_PFSENSE_REF CIVM_REF
+    When run sh "$SCRIPT" --ref HEAD
+    The status should equal 1
+    The stderr should include 'pfsense_ref=10.0.0.111/pfblockerng/pfsense-ce:2.9'
+    The stderr should include 'civm_ref=10.0.0.111/pfblockerng/civm:v2'
+  End
+
+  It 'leaves a ref that does not start with ghcr.io/ untouched even when the var is set'
+    PFB_LAN_REGISTRY=10.0.0.111
+    SMOKE_PFSENSE_REF=quay.io/pfblockerng/pfsense-ce:2.8
+    export PFB_LAN_REGISTRY SMOKE_PFSENSE_REF
+    When run sh "$SCRIPT" --ref HEAD
+    The status should equal 1
+    The stderr should include 'pfsense_ref=quay.io/pfblockerng/pfsense-ce:2.8'
+  End
+
+  It 'leaves refs untouched when PFB_LAN_REGISTRY is unset (hosted-CI fallback)'
+    When run sh "$SCRIPT" --ref HEAD
+    The status should equal 1
+    The stderr should include 'pfsense_ref=ghcr.io/pfblockerng/pfsense-ce:2.8'
+    The stderr should include 'civm_ref=ghcr.io/pfblockerng/civm:v1'
+  End
+
+  It 'keeps an @digest suffix intact when rewriting to the LAN registry'
+    PFB_LAN_REGISTRY=10.0.0.111
+    SMOKE_PFSENSE_REF=ghcr.io/pfblockerng/pfsense-ce:2.8@sha256:deadbeef
+    export PFB_LAN_REGISTRY SMOKE_PFSENSE_REF
+    When run sh "$SCRIPT" --ref HEAD
+    The status should equal 1
+    The stderr should include 'pfsense_ref=10.0.0.111/pfblockerng/pfsense-ce:2.8@sha256:deadbeef'
+  End
+
+  It 'joins a port-bearing LAN registry with exactly one slash'
+    PFB_LAN_REGISTRY=10.0.0.111:80
+    export PFB_LAN_REGISTRY
+    When run sh "$SCRIPT" --ref HEAD
+    The status should equal 1
+    The stderr should include 'pfsense_ref=10.0.0.111:80/pfblockerng/pfsense-ce:2.8'
+  End
+
+  It 'treats an empty-but-set PFB_LAN_REGISTRY as unset'
+    PFB_LAN_REGISTRY=
+    export PFB_LAN_REGISTRY
+    When run sh "$SCRIPT" --ref HEAD
+    The status should equal 1
+    The stderr should include 'pfsense_ref=ghcr.io/pfblockerng/pfsense-ce:2.8'
+  End
 End

--- a/tests/test_issue2230_lan_registry.py
+++ b/tests/test_issue2230_lan_registry.py
@@ -109,9 +109,8 @@ def _flag_stray_refs(blocks: dict[str, str]) -> list[str]:
 def test_self_hosted_container_jobs_pull_through_the_lan_registry() -> None:
     """Every self-hosted job with a `container.image` must route the pull
     through `${{ vars.PFB_LAN_REGISTRY || 'ghcr.io' }}/...` (issue #2230): the
-    box fleet hijacks ghcr.io via /etc/hosts to the LAN zot mirror at
-    10.0.0.111, and a literal ref skips that routing silently rather than
-    failing loudly."""
+    variable points the self-hosted fleet at the LAN zot mirror, and a literal
+    ref skips that routing silently rather than failing loudly."""
     offenders: list[str] = []
     checked = 0
     for path in _workflow_files():


### PR DESCRIPTION
## What

Replaces the box-side LAN-registry routing from #2230 — `/etc/hosts` hijack of `ghcr.io`, fleet-CA TLS, `--add-host` + CA-bundle mount into the leg container — with the same explicit-ref mechanism the workflows already use, over plain HTTP. Part of #2247.

- **`scripts/local-smoke.sh`**: the bootstrap's `docker run` image is box-side-expanded `${PFB_LAN_REGISTRY:-ghcr.io}/pfblockerng/ci-runner-vm:4`; the `--add-host` fragment and the CA-bundle mount are removed; `-e PFB_LAN_REGISTRY` carries the variable into the container.
- **`scripts/lib/oras-refresh.sh`**: new `pfb_lan_registry_active` + `pfb_rewrite_lan_registry` helpers (single choke point — a leading `ghcr.io/` rewrites to `${PFB_LAN_REGISTRY}/`, tags and `@sha256` digests survive, everything else passes through); `${PFB_ORAS_FLAGS:-}` threaded into all four oras invocations.
- **`scripts/smoke-on-box.sh`**: rewrites `PFSENSE_REF`/`CIVM_REF` at the choke point right after their defaults resolve (covers workflow-injected refs too); sets `PFB_ORAS_FLAGS="--plain-http"` when the LAN registry is active; defines the token-based ghcr login only when it is not (the LAN cache is anonymous read-only).
- Specs: bootstrap assertions replaced (parameterized image, no `--add-host`, no CA mount, env passthrough); rewrite matrix (default/injected/non-ghcr/digest-suffix/port/empty-but-set/unset rows); oras flag threading observed via an argv-recording stub.

With `PFB_LAN_REGISTRY` unset (hosted-CI ephemeral leg), behavior is byte-identical to today — verified by the unset spec rows.

## Why

Owner decision (2026-08-08, #2247): every box pull is repo-orchestrated, so explicit refs cover everything the hijack covered with one mechanism fleet-wide — and for a LAN-only cache on owner-controlled CTs, plain HTTP scoped to the one registry IP beats maintaining a private CA (content-addressed digests still self-verify). The infra half (zot to :80, PKI teardown, `insecure-registries` + Hub mirror on the 8 CTs) follows after merge, per the issue.

## Testing

- Test-first red→green, re-derived twice from committed bytes (orchestrator + independent verifier): 16 RED failures against pre-change production — including the two negative assertions failing against the genuinely-present `--add-host`/CA-mount fragments — then 47 examples / 0 failures GREEN, spec hashes byte-identical across red and green.
- `scripts/agent/run-gates.sh --diff origin/devel`: all gates pass (shellspec under dash, shellcheck, sh -n).
- Hostile rows executed under dash: digest-suffix ref, port-bearing registry value, non-ghcr ref, empty-but-set, unset — all match the specs.
- Re-ran the spec trio green after rebasing onto current devel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using a local LAN registry for container images.
  * Added configurable ORAS command-line flags.
  * Preserved image tags and digests when rewriting registry references.
  * Enabled plain HTTP access for configured LAN registries.

* **Bug Fixes**
  * Improved image resolution and fallback behavior across registry operations.

* **Tests**
  * Expanded coverage for registry overrides, ORAS flags, digests, ports, and default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->