### PR TITLE
pkg-repo: four-channel client bootstrap and migration (`#2148`)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,7 +327,7 @@ Full options: [`scripts/deploy.sh`](scripts/deploy.sh).
 
 ### How the `pkg` repository is published (GitHub Pages)
 
-The self-hosted repository (installed per the [README](README.md#option-2--this-forks-self-hosted-pkg-repository))
+The self-hosted repository (installed per the [README](README.md#installation))
 is a **derived index** — there is no stateful store to maintain. The
 **separate [`pfBlockerNG/pkg`](https://github.com/pfBlockerNG/pkg) repo** holds the served
 tree and GitHub Pages publishes it straight from that repo's `main`; it carries no workflow
@@ -351,11 +351,18 @@ is installing a retained older version rather than re-deploying a site.
   moves the box to a different varver.
 - **NONE-signed, TLS-anchored.** No signing key in CI; trust is HTTPS to the Pages host. The
   catalog is served at the project's GitHub Pages URL, e.g.
-  **`https://pfblockerng.github.io/pkg/release/ce-2.8`**.
+  **`https://pfblockerng.github.io/pkg/stable/ce-2.8`**.
 - **Generators.** `scripts/build-repo-portable.py` is the primary — pure Python (stdlib +
   `zstd`), no libpkg, run on a plain Linux runner. `scripts/build-repo.sh` (real `pkg repo`
   in a FreeBSD VM) is the fidelity fallback, and is also the single `--print-conf` source the
   bootstrap (`scripts/add-repo.sh`) and the inline conf in the README reuse byte-for-byte.
+- **Client scripts.** The Pages root serves both halves of a channel switch, published by
+  `scripts/gen_landing.py` from their repository copies: `add-repo.sh` (subscription — writes
+  one channel conf, retires every other project conf, installs the boot-time regenerator hook)
+  and `migrate-channel.sh` (the installed package — repository-qualified replacement of a
+  legacy suffixed identity or a canonical build on the wrong repo, then verification). Both
+  take the same mandatory `--channel <stable|testing|edge|nightly>`. Adding a repository alone
+  never moves an installed package, so neither script substitutes for the other (issue #2148).
 - **Triggers.** `pfBlockerNG/pkg` carries no workflow of its own — it holds the served tree and
   GitHub Pages publishes it from `main`. This repo does the publishing: the `publish-pkg-repo`
   job in `release-published.yml` runs on the real `release: published` event, and

--- a/README.md
+++ b/README.md
@@ -67,51 +67,79 @@ under the **Apache License 2.0**.
 > main installation page: current versions, ready-to-copy commands, and older
 > releases, per pfSense edition.
 
-Run the bootstrap **on the firewall** over SSH (as root), then install the
-package for the channel you want:
+Run the bootstrap **on the firewall** over SSH (as root), picking the channel you
+want, then install the package:
 
 ```sh
-fetch -qo - https://pfblockerng.github.io/pkg/add-repo.sh | sh
-pkg install pfSense-pkg-pfBlockerNG-devel    # or: pfSense-pkg-pfBlockerNG (stable)
+fetch -qo - https://pfblockerng.github.io/pkg/add-repo.sh | sh -s -- --channel stable
+pkg install pfSense-pkg-pfBlockerNG
 ```
 
-The bootstrap detects your pfSense edition, version, and architecture,
-configures the matching package catalog, and keeps it correct automatically
-across pfSense OS upgrades. The repository takes precedence over the Netgate
-catalog, so the webConfigurator's **Install**/**Update** buttons pick up its
-builds too.
+The bootstrap detects your pfSense edition and version, configures the matching
+package catalog, and keeps it correct automatically across pfSense OS upgrades.
+The repository takes precedence over the Netgate catalog, so the
+webConfigurator's **Install**/**Update** buttons pick up its builds too.
 
-Three channels are available — the packages conflict, so install **one**:
+Four channels are available. They all publish the **same** package name —
+`pfSense-pkg-pfBlockerNG` — from separate catalogs, so a firewall subscribes to
+**exactly one** channel and the bootstrap removes any other pfBlockerNG
+repository it finds:
 
-| Channel | Package | For |
-|---------|---------|-----|
-| **Stable** | `pfSense-pkg-pfBlockerNG` | Production use |
-| **Development** | `pfSense-pkg-pfBlockerNG-devel` | Latest features, early testing |
-| **Nightly** | `pfSense-pkg-pfBlockerNG-nightly` | Bleeding edge (see [Nightly channel](#nightly-channel)) |
+| Channel | `--channel` | For |
+|---------|-------------|-----|
+| **Stable** | `stable` | Production use |
+| **Testing** | `testing` | Prereleases validating the next stable |
+| **Edge** | `edge` | Prereleases opening the next release family |
+| **Nightly** | `nightly` | Bleeding edge, rebuilt from the development tip |
 
-Choose **stable** unless you specifically want to track development builds.
+Choose **stable** unless you specifically want to track prerelease builds.
 
-Stable and development are also available from pfSense's built-in Package
-Manager (**System ▸ Package Manager ▸ Available Packages**), built and shipped
-by Netgate — see [Other installation methods](#other-installation-methods).
+pfBlockerNG is also available from pfSense's built-in Package Manager
+(**System ▸ Package Manager ▸ Available Packages**), built and shipped by
+Netgate — see [Other installation methods](#other-installation-methods).
 
 Once installed, the interface lives in the webConfigurator under
 **Firewall ▸ pfBlockerNG**.
+
+### Switching channels
+
+Switching is **two** commands, and the second one is not optional. Adding a
+repository does not move an installed package: `pkg` keeps it pinned to the
+repository it came from and offers no upgrade across repositories, so a
+firewall that only gains a new conf silently keeps running its old build.
+
+```sh
+fetch -qo - https://pfblockerng.github.io/pkg/add-repo.sh | sh -s -- --channel edge
+fetch -qo - https://pfblockerng.github.io/pkg/migrate-channel.sh | sh -s -- --channel edge
+```
+
+`add-repo.sh` moves the subscription; `migrate-channel.sh` moves the installed
+package onto it, replaces a legacy suffixed install
+(`pfSense-pkg-pfBlockerNG-devel`, `-nightly`) with the canonical package, and
+verifies the result — identity, source repository, version, installed files, and
+your pfBlockerNG configuration — before reporting success. It refuses to touch
+anything it cannot verify, and going **back** to a slower channel works the same
+way (that direction is a downgrade, which is exactly the operation it performs).
+
+> [!CAUTION]
+> Back up the pfSense configuration (**Diagnostics ▸ Backup & Restore**) before
+> moving to an older version. Older package artifacts remain available, but may
+> not understand state written by a newer package; configuration or enforcement
+> may fail. Recover by restoring that pre-move backup.
 
 ## Version upgrades
 
 The **Software** tab shows your channel and installed version against the
 repository's latest, and can check for and install updates for you. Upgrades
-always stay **within the same channel** (stable to stable, devel to devel,
-nightly to nightly); to switch channels, reinstall as in
-[Installation](#installation). A daily background check also
+stay **within the channel you are subscribed to**; to move to a different one,
+see [Switching channels](#switching-channels). A daily background check also
 raises a pfSense notification — once per new version — when a newer build is
 available; a checkbox on the tab turns it off.
 
 Upgrading from the command line works too:
 
 ```sh
-pkg upgrade pfSense-pkg-pfBlockerNG-devel        # or the installed package name
+pkg upgrade pfSense-pkg-pfBlockerNG
 ```
 
 > [!NOTE]
@@ -186,31 +214,25 @@ search for `pfBlockerNG`, and install **pfBlockerNG** (stable) or
 **pfBlockerNG-devel** (development). These builds are published by Netgate and
 generally lag this repository's releases.
 
-### Nightly channel
+### Migrating a legacy install
 
-To track the development tip rebuilt every night, opt into the separate
-`nightly` channel:
-
-```sh
-fetch -qo - https://pfblockerng.github.io/pkg/add-repo.sh | sh -s -- --nightly
-pkg install pfSense-pkg-pfBlockerNG-nightly
-```
-
-The nightly package **replaces** a stable or `-devel` install (they conflict).
-Recent nightly builds remain in the catalog for diagnostics and reproducibility.
+Installs made before the four-channel catalogs carry a suffixed package name —
+`pfSense-pkg-pfBlockerNG-devel` or `pfSense-pkg-pfBlockerNG-nightly`. Those
+names are no longer published, so they receive no further updates. Move one onto
+a channel with the two commands in
+[Switching channels](#switching-channels): `migrate-channel.sh` removes the
+legacy package, installs the canonical `pfSense-pkg-pfBlockerNG` from the
+channel you named, and verifies your configuration survived.
 
 ### Retained package versions
 
-The catalog keeps several recent versions of the stable and devel packages.
-[repository landing page](https://pfblockerng.github.io/pkg) lists the
-retained versions per pfSense edition, with their commit and date.
-
-> [!CAUTION]
-> Package downgrade is unsupported. Older package artifacts remain available,
-> but may not understand state written by a newer package; configuration or
-> enforcement may fail. Back up the pfSense
-> configuration before upgrading. Recover by restoring that pre-upgrade backup
-> or reinstalling the current package and continuing forward.
+Each channel catalog keeps several recent versions, and a faster channel also
+keeps everything its slower channels still carry — so an older build stays
+available in the catalog you are already subscribed to. The
+[repository landing page](https://pfblockerng.github.io/pkg) lists the retained
+versions per pfSense edition, with their commit and date. Moving to one of them
+is a channel-style downgrade; see the caution under
+[Switching channels](#switching-channels).
 
 ### Building from the FreeBSD ports tree
 

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1121,10 +1121,32 @@ Full design: ADR-39.
   at a time (issue #2251); `pkg update` + verify). All three `--print-conf`
   producers take `--channel <stable|testing|edge|nightly>` (repo `pfblockerng-<channel>`, conf
   `pfblockerng-<channel>.conf`, URL `<base>/<channel>/<varver>`, issue #2147). Live bootstrap
-  still covers only the legacy default (`pfblockerng.conf`, the old bundled release repo) and
-  nightly; `--channel stable|testing|edge` live bootstrap plus the rc.d hook's per-channel
-  regeneration land with issue #2148. The emitted conf is byte-identical across the producers
+  covers all four channels plus the legacy default (`pfblockerng.conf`, the old bundled release
+  repo), and enforces single-repository subscription by retiring every other project conf; the
+  rc.d hook regenerates each of the five confs that EXISTS, so a channel the box switched away
+  from stays gone across a pfSense OS upgrade (issue #2148). The emitted conf is byte-identical
+  across the producers
   (drift-pinned in `tests/test_add_repo_conf.py` + `tests/test_build_repo_portable.py`).
+- **Channel switching is two operations, not one:** `scripts/add-repo.sh --channel <ch>` moves
+  the SUBSCRIPTION; `scripts/migrate-channel.sh --channel <ch>` moves the INSTALLED PACKAGE.
+  Both are published at the Pages root by `scripts/gen_landing.py` (`write_add_repo` /
+  `write_migrate_channel`). The second is load-bearing, not tidiness: measured on CE 2.8.1 /
+  `pkg` 1.21.3, `pkg upgrade` never leaves the repository a package was installed from while
+  that repo is enabled and still offers it — neither `CONSERVATIVE_UPGRADE=false` nor a higher
+  `priority:` changes that — so a box that only gains a conf silently keeps its old build. And
+  every channel catalogue publishes the ONE canonical `pfSense-pkg-pfBlockerNG`, so a legacy
+  suffixed identity (`-devel`, `-nightly`/`-NIGHTLY`) has no upgrade path until it is replaced.
+  `migrate-channel.sh` fails BEFORE any mutation on a mismatched subscription, no/multiple/
+  unrecognised installed identity, or a target catalogue that does not offer the canonical
+  package; it then runs `pkg install -f -r <repo>` (canonical, wrong repo — also the reverse
+  move, since the target may be OLDER) or `pkg delete` + `pkg install -r <repo>` (legacy
+  identity), and verifies identity, `%R`, version, the `pkg info -l` payload, and the surviving
+  `installedpackages/pfblockerng` section before reporting success. Distinct exit codes per
+  failure class; pinned by `tests/shell/migrate_channel_spec.sh`.
+  On the box, channel provenance is read from the INSTALLED REPO, never the package name:
+  `pfb_channel_from_repo_name()` maps `pfblockerng-<ch>` → channel and
+  `pfb_software_is_our_build()` accepts all five project repos, so a stable/testing/edge
+  subscriber keeps the Software tab, the priv `match[]` line, and the update notice.
 - **Repo smoke flow:** `tests/smoke/test_repo_install.py` carries its **own marker `repo`** (a
   distribution flow, **deselected from `-m smoke`**) — install-from-our-repo (no `-f`), cross-repo
   precedence (both directions vs a `netgate-decoy`), `pkg upgrade` `_1`→`_9`, and the catalog

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -306,20 +306,36 @@ chmod 755 "${ON_BOX_HOOK}"
 #    the same "never delete what cannot be replaced" rule the sibling
 #    migrate-channel.sh is built around. Retirement is step 6, after the verify.
 mkdir -p "${REPOS_DIR}"
-CONF_PREEXISTED=0
-[ -f "${CONF_PATH}" ] && CONF_PREEXISTED=1
+# Staging TRUNCATES the conf, so "it existed" is not enough to undo it — a re-subscribe
+# to the channel the box is already on would be left holding the one-line stub, i.e. a
+# conf that subscribes to nothing. Keep the previous body aside instead.
+CONF_BACKUP=""
+if [ -f "${CONF_PATH}" ]; then
+    CONF_BACKUP="${CONF_PATH}.pfb-prev.$$"
+    cp "${CONF_PATH}" "${CONF_BACKUP}"
+fi
 printf '==> Staging %s conf at %s (hook will resolve it)\n' "${CHANNEL}" "${CONF_PATH}"
 printf '# pfBlockerNG %s repo conf — pending boot-time generation (ADR-39).\n' "${CHANNEL}" > "${CONF_PATH}"
 
-# Undo a conf THIS run created, so a failed bootstrap leaves the box's repository
-# configuration exactly as it found it. A conf that already existed is left alone —
-# removing it would be the destruction this ordering exists to prevent.
+# Undo everything THIS run did to the repository configuration, so a failed bootstrap
+# leaves the box exactly as it found it: a conf this run created is removed, and a conf
+# it truncated is restored byte-for-byte. Either way the box keeps a working
+# subscription — losing one is the destruction this ordering exists to prevent.
 abort_unstaged() {
-    if [ "${CONF_PREEXISTED}" -eq 0 ]; then
+    if [ -n "${CONF_BACKUP}" ]; then
+        mv -f "${CONF_BACKUP}" "${CONF_PATH}"
+        printf '  Restored the previous %s conf; your subscription is unchanged.\n' "${CHANNEL}" >&2
+    else
         rm -f "${CONF_PATH}"
         printf '  Removed the conf this run staged; your previous subscription is untouched.\n' >&2
     fi
     exit 1
+}
+
+# On success the backup is redundant — drop it so no stray file is left in the repos dir.
+drop_conf_backup() {
+    [ -n "${CONF_BACKUP}" ] && rm -f "${CONF_BACKUP}"
+    CONF_BACKUP=""
 }
 
 # 3. Run the hook once now to resolve the conf for THIS box (it also runs every
@@ -354,8 +370,18 @@ sed -n 's/^[[:space:]]*url:[[:space:]]*/    url: /p' "${CONF_PATH}" >&2
 #    channel repo carries the one canonical package; only the legacy release repo
 #    carries two (stable may not be published yet) — finding EITHER proves that
 #    repo loaded. Exit non-zero (fail loud) only if NONE present.
+# `pkg update` exits non-zero when ANY enabled repository fails to refresh — including
+# the channel this run is switching AWAY from, whose catalogue may be exactly what went
+# unpublished. Under `set -e` that would abort here: after the conf was staged, before
+# retirement, leaving the box subscribed to TWO project repositories at equal priority.
+# Route it through the same cleanup as every other failure instead.
 printf '==> pkg update (refreshing catalogs, including the pfBlockerNG repo)\n'
-env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" update -f >/dev/null
+env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" update -f >/dev/null || {
+    printf 'add-repo: %s update -f failed — catalogs were not refreshed.\n' "${PKG_BIN}" >&2
+    printf '  A repository is unreachable or serving an unreadable catalog.\n' >&2
+    printf '  Inspect with: %s -d update   (traces the catalog fetch)\n' "${PKG_BIN}" >&2
+    abort_unstaged
+}
 
 printf '==> Verifying pfBlockerNG package(s) are visible from repo '\''%s'\''\n' "${REPO_NAME}"
 found_any=0
@@ -389,5 +415,6 @@ printf '%s\n' "${PROJECT_CONFS}" | while IFS= read -r _other_conf; do
         "${REPOS_DIR}/${_other_conf}"
     rm -f "${REPOS_DIR}/${_other_conf}"
 done
+drop_conf_backup
 
 printf '==> Done — conf at %s\n' "${CONF_PATH}"

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
-# add-repo.sh — bootstrap pfBlockerNG's self-hosted pkg repository on a pfSense
-# box (ADR-17, the client side). Run it ON the pfSense box. It installs the
-# boot-time repo-conf generator rc.d hook (ADR-39), stubs the repo conf so the
-# hook regenerates it for THIS box's edition/version, runs the hook once
-# to resolve the conf now, then runs `pkg update` and VERIFIES the package is
-# visible from the pfBlockerNG repo — after which
-#   pkg install pfSense-pkg-pfBlockerNG-devel   (or -y, no -f, no -r)
+# add-repo.sh — subscribe a pfSense box to ONE pfBlockerNG pkg channel (ADR-17,
+# the client side). Run it ON the pfSense box. It installs the boot-time
+# repo-conf generator rc.d hook (ADR-39), retires any other pfBlockerNG channel
+# conf, stubs this channel's conf so the hook regenerates it for THIS box's
+# edition/version, runs the hook once to resolve the conf now, then runs
+# `pkg update` and VERIFIES the package is visible from the channel's repo —
+# after which
+#   pkg install pfSense-pkg-pfBlockerNG   (or -y, no -f, no -r)
 # resolves deps and installs the pfBlockerNG build, and the stock
 # webConfigurator Install pulls it too via cross-repo resolution (ADR §2;
 # install is not repo-locked). Invocation forms: see --help.
@@ -22,29 +23,37 @@
 #   canonical package `pfSense-pkg-pfBlockerNG` (channel is catalogue placement,
 #   not a package-name suffix). Select one with `--channel <ch>`.
 #
-#   LEGACY (unchanged; still the default with NO argument): sets up the RELEASE
+#   SINGLE-REPOSITORY SUBSCRIPTION (issue #2148): a box enables EXACTLY ONE
+#   project channel repository. Every channel repo shares one priority (100) and
+#   `pkg` does not order across equal-priority repositories, so two enabled
+#   channels would leave the selected build undetermined. Each channel catalogue
+#   strictly contains its slower channels' files (edge ⊇ testing ⊇ stable), so one
+#   repository always suffices — including for an in-repo rollback on a faster
+#   channel. Subscribing therefore RETIRES every other pfBlockerNG channel conf on
+#   the box, reporting each removal.
+#
+#   Moving FORWARD is: re-run with the new `--channel`, then upgrade normally —
+#   ordinary `pkg` resolution applies only when the target version is higher
+#   (`pkg` orders versions numerically, component-wise, never by date). Moving
+#   BACK is an explicit repository-qualified downgrade/reinstall; disabling a
+#   faster repository is not itself a downgrade.
+#
+#   Moving an EXISTING install off a legacy suffixed identity
+#   (`pfSense-pkg-pfBlockerNG-devel`, `-nightly`) onto a channel is the job of the
+#   sibling `migrate-channel.sh`; this script configures repositories only.
+#
+#   LEGACY (unchanged; still the behaviour with NO argument): sets up the RELEASE
 #   repo `pfblockerng` — one shared catalog carrying BOTH the stable and devel
 #   packages, exactly like Netgate ships `pfSense-pkg-pfBlockerNG` and `-devel`
 #   from its single `pfSense` repo (the two packages CONFLICT — install one, see
 #   --help). `--channel release` is REJECTED — release is this legacy default,
 #   not one of the four channel names.
 #
-#   `--nightly` (or `--channel nightly`) sets up the SEPARATE `pfblockerng-nightly`
-#   repo instead (its own `nightly/` catalog path). Bleeding edge — NOT for daily
-#   use: the only guarantee is that CI passed (devel still carries a stability
-#   target; nightly does not):
-#       pkg install pfSense-pkg-pfBlockerNG-nightly
-#
-#   LIVE BOOTSTRAP STATUS: only the legacy default (release) and nightly channels
-#   run the live bootstrap (rc.d hook install + pkg update + verify) today.
-#   `--channel stable|testing|edge` is --print-conf-only until issue #2148 lands
-#   per-channel boot-time conf generation — the live path exits 2 for those three.
-#
-#   default                      -> conf pfblockerng.conf,          repo `pfblockerng`          (legacy release)
+#   default                       -> conf pfblockerng.conf,          repo `pfblockerng`          (legacy release)
 #   --nightly / --channel nightly -> conf pfblockerng-nightly.conf,  repo `pfblockerng-nightly`
-#   --channel stable              -> conf pfblockerng-stable.conf,   repo `pfblockerng-stable`   (--print-conf only; #2148)
-#   --channel testing             -> conf pfblockerng-testing.conf,  repo `pfblockerng-testing`  (--print-conf only; #2148)
-#   --channel edge                -> conf pfblockerng-edge.conf,     repo `pfblockerng-edge`     (--print-conf only; #2148)
+#   --channel stable              -> conf pfblockerng-stable.conf,   repo `pfblockerng-stable`
+#   --channel testing             -> conf pfblockerng-testing.conf,  repo `pfblockerng-testing`
+#   --channel edge                -> conf pfblockerng-edge.conf,     repo `pfblockerng-edge`
 #
 # THE CONF (single source of truth — byte-identical to `build-repo.sh --print-conf`,
 # `build-repo-portable.py --print-conf`, and what the rc.d hook writes):
@@ -117,22 +126,29 @@ CATALOG_PATH=""
 
 usage() {
     cat <<'USAGE'
-add-repo.sh — bootstrap pfBlockerNG's self-hosted pkg repository (run ON the pfSense box).
+add-repo.sh — subscribe this pfSense box to ONE pfBlockerNG pkg channel (run ON the box).
 
 Usage:
-  add-repo.sh                                set up the release repo (stable + devel), pkg update, verify
-  add-repo.sh --nightly                      set up the nightly repo instead (bleeding edge; not for daily use)
-  add-repo.sh --channel nightly              same as --nightly
-  add-repo.sh --channel stable|testing|edge  NOT YET LIVE — exits 2; per-channel boot-time conf
-                                              generation lands with issue #2148. Use --print-conf
-                                              --channel <ch> --catalog-path <varver> to inspect the conf now.
-  add-repo.sh --print-conf [--nightly | --channel <stable|testing|edge|nightly>] --catalog-path <varver>
+  add-repo.sh --channel stable|testing|edge|nightly
+                                             subscribe to that channel, pkg update, verify
+  add-repo.sh --nightly                      alias for --channel nightly
+  add-repo.sh                                legacy: the pre-channel shared release repo
+  add-repo.sh --print-conf --channel <ch> --catalog-path <varver>
                                              print the repo conf to stdout and exit (no writes)
-  add-repo.sh --base-url <url> [--nightly]   override the catalog base (forks/staging)
+  add-repo.sh --base-url <url> [--channel <ch>]
+                                             override the catalog base (forks/staging)
 
-After the release bootstrap, install ONE of (the packages conflict):
-  pkg install pfSense-pkg-pfBlockerNG          # stable
-  pkg install pfSense-pkg-pfBlockerNG-devel    # development tree
+A box subscribes to EXACTLY ONE project channel repository: every channel serves the
+same canonical package at the same priority, and each channel's catalogue strictly
+contains its slower channels' files, so one repository is always sufficient.
+Subscribing therefore retires any other pfBlockerNG channel conf on the box.
+
+After subscribing, install the one canonical package:
+  pkg install pfSense-pkg-pfBlockerNG
+
+To move to another channel, re-run with the new --channel and upgrade. Moving BACK to
+an older build is an explicit repository-qualified operation, e.g.
+  pkg install -f -r pfblockerng-edge pfSense-pkg-pfBlockerNG-<older-version>
 USAGE
 }
 
@@ -174,9 +190,10 @@ done
 # edge              -> repo `pfblockerng-edge`,     conf pfblockerng-edge.conf,     `edge/` subtree
 # The four channels (stable/testing/edge/nightly) all carry the ONE canonical
 # `pfSense-pkg-pfBlockerNG` identity — channel is catalogue placement, not a
-# package-name suffix. PKG_NAMES: the package(s) the verify step checks + the
-# install hints printed (the legacy release repo carries two; every other
-# channel carries one).
+# package-name suffix (the `-nightly` spelling is a native ports RECIPE name; the
+# published nightly artifact is canonical). PKG_NAMES: the package(s) the verify
+# step checks + the install hints printed. Only the legacy release repo carries
+# two; every channel repo carries exactly the canonical one.
 case "$CHANNEL" in
     release)
         REPO_NAME="pfblockerng"
@@ -186,7 +203,7 @@ case "$CHANNEL" in
     nightly)
         REPO_NAME="pfblockerng-nightly"
         CONF_NAME="pfblockerng-nightly.conf"
-        PKG_NAMES="pfSense-pkg-pfBlockerNG-nightly"
+        PKG_NAMES="pfSense-pkg-pfBlockerNG"
         ;;
     stable)
         REPO_NAME="pfblockerng-stable"
@@ -205,6 +222,18 @@ case "$CHANNEL" in
         ;;
 esac
 CONF_PATH="${REPOS_DIR}/${CONF_NAME}"
+
+# Every project conf this script may ever have written. Exactly ONE of them may be
+# enabled at a time: the channel repos share one priority (100) and pkg does not
+# order across equal-priority repositories, so two enabled channels would make the
+# build a box receives depend on nothing the user can see. Each channel catalogue
+# strictly contains its slower channels' files, so one repository is always enough
+# — including for an in-repo rollback on a faster channel (issue #2148).
+PROJECT_CONFS="pfblockerng.conf
+pfblockerng-stable.conf
+pfblockerng-testing.conf
+pfblockerng-edge.conf
+pfblockerng-nightly.conf"
 
 # ── The conf body (single source of truth; byte-identical to the hook + the
 #    build-repo[-portable] --print-conf generators) ──────────────────────────────
@@ -244,23 +273,8 @@ if [ "$PRINT_CONF" -eq 1 ]; then
     exit 0
 fi
 
-# ── Live-bootstrap channel gate ─────────────────────────────────────────────────
-# Per-channel boot-time conf generation (stable/testing/edge) lands with issue
-# #2148; until then only the legacy default (release) and nightly bootstrap live
-# here (the rc.d hook only knows those two channels). --print-conf already
-# exited above for every channel, so this only gates the live path.
-case "$CHANNEL" in
-    stable|testing|edge)
-        printf 'add-repo: live bootstrap for --channel %s is not implemented yet — per-channel\n' "${CHANNEL}" >&2
-        printf '  boot-time conf generation lands with issue #2148.\n' >&2
-        printf '  Until then, use the default (release) or --nightly for live bootstrap, or:\n' >&2
-        printf '    add-repo.sh --print-conf --channel %s --catalog-path <varver>\n' "${CHANNEL}" >&2
-        printf '  to inspect the conf now.\n' >&2
-        exit 2
-        ;;
-esac
-
 # ── Live bootstrap ─────────────────────────────────────────────────────────────
+
 command -v "$PKG_BIN" >/dev/null 2>&1 || {
     printf 'add-repo: '\''%s'\'' not found — run this ON a pfSense box\n' "$PKG_BIN" >&2
     exit 1
@@ -278,27 +292,43 @@ else
 fi
 chmod 755 "${ON_BOX_HOOK}"
 
-# 2. Stub the conf so the hook regenerates it (the hook only rewrites confs that
+# 2. Enforce single-repository subscription: retire every OTHER project conf. The
+#    box ends up subscribed to exactly one channel, so `pkg` never has to choose
+#    between two equal-priority project repositories. Reported, never silent.
+mkdir -p "${REPOS_DIR}"
+printf '%s\n' "${PROJECT_CONFS}" | while IFS= read -r _other_conf; do
+    [ -n "${_other_conf}" ] || continue
+    [ "${_other_conf}" = "${CONF_NAME}" ] && continue
+    [ -f "${REPOS_DIR}/${_other_conf}" ] || continue
+    printf '==> Retiring %s — a box subscribes to ONE pfBlockerNG channel\n' \
+        "${REPOS_DIR}/${_other_conf}"
+    rm -f "${REPOS_DIR}/${_other_conf}"
+done
+
+# 3. Stub the conf so the hook regenerates it (the hook only rewrites confs that
 #    already exist — an absent channel stays absent). The stub is overwritten in
-#    place by the hook in step 3; it is left intact only if detection fails, in
+#    place by the hook in step 4; it is left intact only if detection fails, in
 #    which case the marker check below fails loud.
 printf '==> Staging %s conf at %s (hook will resolve it)\n' "${CHANNEL}" "${CONF_PATH}"
-mkdir -p "${REPOS_DIR}"
 printf '# pfBlockerNG %s repo conf — pending boot-time generation (ADR-39).\n' "${CHANNEL}" > "${CONF_PATH}"
 
-# 3. Run the hook once now to resolve the conf for THIS box (it also runs every
-#    boot via rc.d). Pass the box paths explicitly so a non-default
-#    PFBLOCKERNG_ROOT (tests) and --base-url (forks/staging) are honored.
+# 4. Run the hook once now to resolve the conf for THIS box (it also runs every
+#    boot via rc.d). Pass every channel path explicitly so a non-default
+#    PFBLOCKERNG_ROOT (tests) and --base-url (forks/staging) are honored — an
+#    omitted override would fall back to the real /usr/local path.
 printf '==> Running the generator hook to resolve the conf now\n'
 PFB_RELEASE_CONF="${REPOS_DIR}/pfblockerng.conf" \
+PFB_STABLE_CONF="${REPOS_DIR}/pfblockerng-stable.conf" \
+PFB_TESTING_CONF="${REPOS_DIR}/pfblockerng-testing.conf" \
+PFB_EDGE_CONF="${REPOS_DIR}/pfblockerng-edge.conf" \
 PFB_NIGHTLY_CONF="${REPOS_DIR}/pfblockerng-nightly.conf" \
 PFB_BASE_URL="${BASE_URL}" \
 PFB_PRODUCT_LABEL="${ROOT}/etc/product_label" \
 PFB_VERSION_FILE="${ROOT}/etc/version" \
     sh "${ON_BOX_HOOK}" onestart || true
 
-# 4. Verify the hook resolved the conf (the marker line is present). If detection
-#    failed the stub from step 2 survives (no marker) — fail loud.
+# 5. Verify the hook resolved the conf (the marker line is present). If detection
+#    failed the stub from step 3 survives (no marker) — fail loud.
 if ! grep -q "${CONF_MARKER}" "${CONF_PATH}" 2>/dev/null; then
     printf 'add-repo: the generator hook did not resolve %s (no marker line).\n' "${CONF_PATH}" >&2
     printf '  Variant detection may have failed. Inspect: sh %s onestart\n' "${ON_BOX_HOOK}" >&2
@@ -307,15 +337,16 @@ fi
 printf '==> Conf resolved:\n'
 sed -n 's/^[[:space:]]*url:[[:space:]]*/    url: /p' "${CONF_PATH}" >&2
 
-# 5. pkg update (refresh catalogs, including the pfBlockerNG repo).
+# 6. pkg update (refresh catalogs, including the pfBlockerNG repo).
 printf '==> pkg update (refreshing catalogs, including the pfBlockerNG repo)\n'
 env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" update -f >/dev/null
 
-# 6. VERIFY a pfBlockerNG package is visible FROM the pfBlockerNG repo (not merely that pkg
+# 7. VERIFY a pfBlockerNG package is visible FROM the pfBlockerNG repo (not merely that pkg
 #    update ran). `pkg rquery -r <repo>` queries that ONE repo's catalog; a hit
-#    means the pfBlockerNG catalog loaded and carries the package. The release repo carries
-#    two (stable may not be published yet) — finding EITHER proves the repo
-#    loaded; nightly carries one. Exit non-zero (fail loud) only if NONE present.
+#    means the pfBlockerNG catalog loaded and carries the package. Every channel repo
+#    carries the one canonical package; only the legacy release repo carries two
+#    (stable may not be published yet) — finding EITHER proves that repo loaded.
+#    Exit non-zero (fail loud) only if NONE present.
 printf '==> Verifying pfBlockerNG package(s) are visible from repo '\''%s'\''\n' "${REPO_NAME}"
 found_any=0
 # Word-splitting the space-separated package list is intentional.

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -321,15 +321,17 @@ printf '# pfBlockerNG %s repo conf — pending boot-time generation (ADR-39).\n'
 # leaves the box exactly as it found it: a conf this run created is removed, and a conf
 # it truncated is restored byte-for-byte. Either way the box keeps a working
 # subscription — losing one is the destruction this ordering exists to prevent.
+# $1 = exit status (default 1; the signal trap passes 130).
 abort_unstaged() {
     if [ -n "${CONF_BACKUP}" ]; then
         mv -f "${CONF_BACKUP}" "${CONF_PATH}"
+        CONF_BACKUP=""
         printf '  Restored the previous %s conf; your subscription is unchanged.\n' "${CHANNEL}" >&2
     else
         rm -f "${CONF_PATH}"
         printf '  Removed the conf this run staged; your previous subscription is untouched.\n' >&2
     fi
-    exit 1
+    exit "${1:-1}"
 }
 
 # On success the backup is redundant — drop it so no stray file is left in the repos dir.
@@ -337,6 +339,13 @@ drop_conf_backup() {
     [ -n "${CONF_BACKUP}" ] && rm -f "${CONF_BACKUP}"
     CONF_BACKUP=""
 }
+
+# An interrupt lands in the same half-applied state a failure does, so it gets the same
+# treatment rather than just a tidy-up: the conf goes back to what it was. Both traps are
+# needed — EXIT sweeps the backup on every ordinary path, and the signal trap has to exit
+# itself or the script would carry on past the handler.
+trap 'drop_conf_backup' EXIT
+trap 'abort_unstaged 130' INT HUP TERM
 
 # 3. Run the hook once now to resolve the conf for THIS box (it also runs every
 #    boot via rc.d). Pass every channel path explicitly so a non-default

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -30,7 +30,10 @@
 #   strictly contains its slower channels' files (edge ⊇ testing ⊇ stable), so one
 #   repository always suffices — including for an in-repo rollback on a faster
 #   channel. Subscribing therefore RETIRES every other pfBlockerNG channel conf on
-#   the box, reporting each removal.
+#   the box, reporting each removal — but only AFTER the new channel's catalogue is
+#   proven to serve this box, so a channel with no build for this edition/version
+#   can never strand a box by taking its working subscription with it. A run that
+#   fails leaves the repository configuration exactly as it found it.
 #
 #   Moving FORWARD is: re-run with the new `--channel`, then upgrade normally —
 #   ordinary `pkg` resolution applies only when the target version is higher
@@ -292,27 +295,34 @@ else
 fi
 chmod 755 "${ON_BOX_HOOK}"
 
-# 2. Enforce single-repository subscription: retire every OTHER project conf. The
-#    box ends up subscribed to exactly one channel, so `pkg` never has to choose
-#    between two equal-priority project repositories. Reported, never silent.
-mkdir -p "${REPOS_DIR}"
-printf '%s\n' "${PROJECT_CONFS}" | while IFS= read -r _other_conf; do
-    [ -n "${_other_conf}" ] || continue
-    [ "${_other_conf}" = "${CONF_NAME}" ] && continue
-    [ -f "${REPOS_DIR}/${_other_conf}" ] || continue
-    printf '==> Retiring %s — a box subscribes to ONE pfBlockerNG channel\n' \
-        "${REPOS_DIR}/${_other_conf}"
-    rm -f "${REPOS_DIR}/${_other_conf}"
-done
-
-# 3. Stub the conf so the hook regenerates it (the hook only rewrites confs that
+# 2. Stage the conf so the hook regenerates it (the hook only rewrites confs that
 #    already exist — an absent channel stays absent). The stub is overwritten in
-#    place by the hook in step 4; it is left intact only if detection fails, in
+#    place by the hook in step 3; it is left intact only if detection fails, in
 #    which case the marker check below fails loud.
+#
+#    Every OTHER project conf stays in place for now. Retiring it here — before the
+#    target catalogue is known to work — would destroy a working subscription on
+#    behalf of one that may not be published for this box's variant yet, which is
+#    the same "never delete what cannot be replaced" rule the sibling
+#    migrate-channel.sh is built around. Retirement is step 6, after the verify.
+mkdir -p "${REPOS_DIR}"
+CONF_PREEXISTED=0
+[ -f "${CONF_PATH}" ] && CONF_PREEXISTED=1
 printf '==> Staging %s conf at %s (hook will resolve it)\n' "${CHANNEL}" "${CONF_PATH}"
 printf '# pfBlockerNG %s repo conf — pending boot-time generation (ADR-39).\n' "${CHANNEL}" > "${CONF_PATH}"
 
-# 4. Run the hook once now to resolve the conf for THIS box (it also runs every
+# Undo a conf THIS run created, so a failed bootstrap leaves the box's repository
+# configuration exactly as it found it. A conf that already existed is left alone —
+# removing it would be the destruction this ordering exists to prevent.
+abort_unstaged() {
+    if [ "${CONF_PREEXISTED}" -eq 0 ]; then
+        rm -f "${CONF_PATH}"
+        printf '  Removed the conf this run staged; your previous subscription is untouched.\n' >&2
+    fi
+    exit 1
+}
+
+# 3. Run the hook once now to resolve the conf for THIS box (it also runs every
 #    boot via rc.d). Pass every channel path explicitly so a non-default
 #    PFBLOCKERNG_ROOT (tests) and --base-url (forks/staging) are honored — an
 #    omitted override would fall back to the real /usr/local path.
@@ -327,26 +337,26 @@ PFB_PRODUCT_LABEL="${ROOT}/etc/product_label" \
 PFB_VERSION_FILE="${ROOT}/etc/version" \
     sh "${ON_BOX_HOOK}" onestart || true
 
-# 5. Verify the hook resolved the conf (the marker line is present). If detection
-#    failed the stub from step 3 survives (no marker) — fail loud.
+# 4. Verify the hook resolved the conf (the marker line is present). If detection
+#    failed the stub from step 2 survives (no marker) — fail loud.
 if ! grep -q "${CONF_MARKER}" "${CONF_PATH}" 2>/dev/null; then
     printf 'add-repo: the generator hook did not resolve %s (no marker line).\n' "${CONF_PATH}" >&2
     printf '  Variant detection may have failed. Inspect: sh %s onestart\n' "${ON_BOX_HOOK}" >&2
-    exit 1
+    abort_unstaged
 fi
 printf '==> Conf resolved:\n'
 sed -n 's/^[[:space:]]*url:[[:space:]]*/    url: /p' "${CONF_PATH}" >&2
 
-# 6. pkg update (refresh catalogs, including the pfBlockerNG repo).
+# 5. pkg update (refresh catalogs, including the pfBlockerNG repo), then VERIFY a
+#    pfBlockerNG package is visible FROM the pfBlockerNG repo (not merely that pkg
+#    update ran). `pkg rquery -r <repo>` queries that ONE repo's catalog, so a
+#    still-enabled previous channel cannot mask a missing package here. Every
+#    channel repo carries the one canonical package; only the legacy release repo
+#    carries two (stable may not be published yet) — finding EITHER proves that
+#    repo loaded. Exit non-zero (fail loud) only if NONE present.
 printf '==> pkg update (refreshing catalogs, including the pfBlockerNG repo)\n'
 env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" update -f >/dev/null
 
-# 7. VERIFY a pfBlockerNG package is visible FROM the pfBlockerNG repo (not merely that pkg
-#    update ran). `pkg rquery -r <repo>` queries that ONE repo's catalog; a hit
-#    means the pfBlockerNG catalog loaded and carries the package. Every channel repo
-#    carries the one canonical package; only the legacy release repo carries two
-#    (stable may not be published yet) — finding EITHER proves that repo loaded.
-#    Exit non-zero (fail loud) only if NONE present.
 printf '==> Verifying pfBlockerNG package(s) are visible from repo '\''%s'\''\n' "${REPO_NAME}"
 found_any=0
 # Word-splitting the space-separated package list is intentional.
@@ -364,6 +374,20 @@ if [ "${found_any}" -eq 0 ]; then
     printf '  Checked conf: %s\n' "${CONF_PATH}" >&2
     printf '  The catalog may not be published yet for this box'\''s variant, or the URL is unreachable.\n' >&2
     printf '  Inspect with: %s -d update   (traces the catalog fetch)\n' "${PKG_BIN}" >&2
-    exit 1
+    abort_unstaged
 fi
+
+# 6. Only now enforce single-repository subscription: the target is proven usable, so
+#    retiring every OTHER project conf cannot strand the box. After this the box is
+#    subscribed to exactly one channel and `pkg` never has to choose between two
+#    equal-priority project repositories. Reported, never silent.
+printf '%s\n' "${PROJECT_CONFS}" | while IFS= read -r _other_conf; do
+    [ -n "${_other_conf}" ] || continue
+    [ "${_other_conf}" = "${CONF_NAME}" ] && continue
+    [ -f "${REPOS_DIR}/${_other_conf}" ] || continue
+    printf '==> Retiring %s — a box subscribes to ONE pfBlockerNG channel\n' \
+        "${REPOS_DIR}/${_other_conf}"
+    rm -f "${REPOS_DIR}/${_other_conf}"
+done
+
 printf '==> Done — conf at %s\n' "${CONF_PATH}"

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -373,6 +373,19 @@ def _bootstrap_install(base: str, channel: str) -> str:
     )
 
 
+def _channel_switch_commands(base: str) -> str:
+    """The copyable two-step channel switch: move the subscription, then move the
+    installed package. Adding the target repository alone is a documented silent
+    no-op (`pkg` never leaves a package's origin repository), so both lines ship
+    together (issue #2148)."""
+    return (
+        f"fetch -qo - {base}/add-repo.sh \\\n"
+        f"  | sh -s -- --base-url {base} --channel <ch>\n"
+        f"fetch -qo - {base}/migrate-channel.sh \\\n"
+        "  | sh -s -- --channel <ch>"
+    )
+
+
 # Per-channel card copy: title, optional badge, and the audience/cadence prose. Fixed
 # content decisions for the four-channel model, issue #2147 step A (the landing page):
 # Stable = final tagged releases; Testing = nonzero-patch prereleases validating the
@@ -429,11 +442,12 @@ def _channel_card(channel: str, base: str, latest: dict[str, str], conf_fn: Call
     )
 
 
-def _trust_section_html() -> str:
+def _trust_section_html(base: str) -> str:
     """The trust/provenance section: what 'installing from this repo' actually means
-    under the four-channel model (issue #2147). Static prose — no catalogue-signing
-    claim anywhere; the NONE-signed trust anchor is HTTPS/TLS to the Pages host
-    (mirrors add-repo.sh's own conf comment).
+    under the four-channel model (issue #2147). No catalogue-signing claim anywhere;
+    the NONE-signed trust anchor is HTTPS/TLS to the Pages host (mirrors add-repo.sh's
+    own conf comment). *base* is woven into the channel-switching subsection, whose
+    two client scripts are both served from it (issue #2148).
     """
     return (
         "<h2>Trust &amp; channel model</h2>"
@@ -480,9 +494,18 @@ def _trust_section_html() -> str:
         "commit that produced it; repository priority decides which build <code>pkg</code> selects when "
         "both are enabled.</p>"
         "<h3>Channel switching</h3>"
-        '<p class="blurb">There is no in-UI channel switcher here by design &mdash; channel selection is '
-        "repository configuration (documented above); client tooling for it is tracked separately "
-        "(issue #2148).</p>"
+        '<p class="blurb">Switching channels is two steps, and the second one is not optional. '
+        f"<code>{_esc(base)}/add-repo.sh</code> run with <code>--channel &lt;ch&gt;</code> moves the "
+        "<em>subscription</em>: it writes that channel's conf and retires every other project conf. "
+        "It does not move the <em>installed package</em> &mdash; <code>pkg</code> keeps an installed "
+        "package pinned to its origin repository and offers no upgrade across repositories, so a box "
+        "that only gains a conf silently keeps running its old build. "
+        f"<code>{_esc(base)}/migrate-channel.sh</code> run with the same "
+        "<code>--channel &lt;ch&gt;</code> performs the repository-qualified operation that actually "
+        "moves it, replaces a legacy suffixed identity "
+        "(<code>-devel</code>, <code>-nightly</code>) with the canonical package, and verifies the "
+        "result before reporting success. There is no in-UI channel switcher by design.</p>"
+        f"{_copyable(_esc(_channel_switch_commands(base)))}"
     )
 
 
@@ -924,7 +947,7 @@ def render_page(
         f"package (<code>{CANONICAL_EMITTED_IDENTITY}</code>) from its own repository &mdash; see "
         "Trust &amp; channel model below for how the four relate.</p>"
         f'<h2>Channels</h2><div class="cards">{cards}</div>'
-        f"{_trust_section_html()}"
+        f"{_trust_section_html(base)}"
         f"<h2>Published packages</h2>{_packages_html(pkgs, matrix)}"
         f"{eol_block}"
         "<h2>Repository files</h2>"
@@ -1068,6 +1091,23 @@ def write_add_repo(site: str, addrepo: str) -> None:
     os.chmod(out_path, 0o755)
 
 
+def write_migrate_channel(site: str, addrepo: str) -> None:
+    """Publish ``migrate-channel.sh`` verbatim to *site*/migrate-channel.sh.
+
+    Resolved as a sibling of *addrepo* in the repository ``scripts/`` directory. Unlike
+    ``add-repo.sh`` it has nothing to embed — it depends on no sibling file — so the
+    published copy is byte-identical to the tested repository copy, which is what keeps
+    the served script from drifting away from its shellspec (issue #2148).
+    """
+    scripts_dir = os.path.dirname(os.path.abspath(addrepo))
+    with open(os.path.join(scripts_dir, "migrate-channel.sh")) as fh:
+        text = fh.read()
+    out_path = os.path.join(site, "migrate-channel.sh")
+    with open(out_path, "w") as fh:
+        fh.write(text)
+    os.chmod(out_path, 0o755)
+
+
 def _conf_via_addrepo(addrepo: str, base: str, channel: str) -> str:
     # add-repo.sh selects the channel EXPLICITLY via --channel <ch> (issue #2147) — every
     # one of the four channels now has its own repo/conf (pfblockerng-<channel>), unlike
@@ -1116,8 +1156,10 @@ def write_site(site: str, base: str, addrepo: str, matrix: list[dict] | None = N
         subdirs, files = _dir_entries(site, rel)
         with open(os.path.join(site, rel, "index.html"), "w") as fh:
             fh.write(render_autoindex(rel, subdirs, files))
-    # Publish a self-contained add-repo.sh with the hook embedded for `fetch | sh`.
+    # Publish a self-contained add-repo.sh with the hook embedded for `fetch | sh`,
+    # and its sibling migrate-channel.sh — both halves of a channel switch (issue #2148).
     write_add_repo(site, addrepo)
+    write_migrate_channel(site, addrepo)
     return len(pkgs)
 
 

--- a/scripts/migrate-channel.sh
+++ b/scripts/migrate-channel.sh
@@ -233,10 +233,21 @@ printf '==> Installed: %s-%s (from repo %s)\n' \
 # highest with `pkg version -t`, which is the comparator `pkg` itself resolves by.
 TARGET_VERSION=""
 for _offered in $("${PKG_BIN}" rquery -r "${TARGET_REPO}" '%v' "${CANONICAL_PKG}" 2>/dev/null || true); do
-	if [ -z "${TARGET_VERSION}" ] ||
-		[ "$("${PKG_BIN}" version -t "${_offered}" "${TARGET_VERSION}" 2>/dev/null)" = ">" ]; then
+	if [ -z "${TARGET_VERSION}" ]; then
 		TARGET_VERSION="${_offered}"
+		continue
 	fi
+	# A comparator that answers nothing would silently degrade this loop back to "keep
+	# the first line", and the step-6 version check would then fail a migration that
+	# actually succeeded. Name the real cause instead of dying on the symptom.
+	_order="$("${PKG_BIN}" version -t "${_offered}" "${TARGET_VERSION}" 2>/dev/null || true)"
+	case "${_order}" in
+	'>') TARGET_VERSION="${_offered}" ;;
+	'<' | '=') ;;
+	*)
+		die 4 "\`${PKG_BIN} version -t\` gave no usable answer comparing '${_offered}' and '${TARGET_VERSION}' — cannot tell which build ${TARGET_REPO} would install"
+		;;
+	esac
 done
 [ -n "${TARGET_VERSION}" ] ||
 	die 4 "repo '${TARGET_REPO}' does not offer ${CANONICAL_PKG} — run \`pkg update -f\`, and check the ${CHANNEL} catalogue has a build for this pfSense edition/version"

--- a/scripts/migrate-channel.sh
+++ b/scripts/migrate-channel.sh
@@ -224,16 +224,31 @@ printf '==> Installed: %s-%s (from repo %s)\n' \
 # `pkg rquery -r <repo>` reads that ONE repo's catalogue. Checked before any
 # mutation so a typo'd/unpublished channel can never leave the box with the old
 # package deleted and nothing to install.
-TARGET_VERSION="$("${PKG_BIN}" rquery -r "${TARGET_REPO}" '%v' "${CANONICAL_PKG}" 2>/dev/null || true)"
-TARGET_VERSION="$(printf '%s' "${TARGET_VERSION}" | head -n 1)"
+#
+# A catalogue holds MORE than one version of the canonical package — retention keeps
+# several, and containment back-fills a faster channel with its slower channels'
+# builds — so rquery prints one line per offered version in catalogue order. Taking
+# the first would name a build `pkg install` is not going to choose, and the
+# post-migration version check would then fail a perfectly good migration. Pick the
+# highest with `pkg version -t`, which is the comparator `pkg` itself resolves by.
+TARGET_VERSION=""
+for _offered in $("${PKG_BIN}" rquery -r "${TARGET_REPO}" '%v' "${CANONICAL_PKG}" 2>/dev/null || true); do
+	if [ -z "${TARGET_VERSION}" ] ||
+		[ "$("${PKG_BIN}" version -t "${_offered}" "${TARGET_VERSION}" 2>/dev/null)" = ">" ]; then
+		TARGET_VERSION="${_offered}"
+	fi
+done
 [ -n "${TARGET_VERSION}" ] ||
 	die 4 "repo '${TARGET_REPO}' does not offer ${CANONICAL_PKG} — run \`pkg update -f\`, and check the ${CHANNEL} catalogue has a build for this pfSense edition/version"
 
 printf '==> Target:    %s-%s (repo %s)\n' "${CANONICAL_PKG}" "${TARGET_VERSION}" "${TARGET_REPO}"
 
 # ── 4. No-op: already canonical, already on the target repo ────────────────────
-# Reported, never silent. This is the ordinary outcome of switching between two
-# channels that currently serve the identical tagged artifact.
+# Reported, never silent. Reached by re-running the script after a migration that
+# already completed, or by naming the channel the box is on. A switch BETWEEN two
+# channels serving the identical tagged artifact does NOT land here — its installed
+# repo differs, so it takes the repository-qualified reinstall below and ends with
+# the same version served from the new catalogue.
 if [ "${INSTALLED_KIND}" = "canonical" ] && [ "${INSTALLED_REPO}" = "${TARGET_REPO}" ]; then
 	printf '==> Already on the %s channel as %s-%s — nothing to do.\n' \
 		"${CHANNEL}" "${INSTALLED_NAME}" "${INSTALLED_VERSION}"
@@ -262,7 +277,7 @@ if [ "${INSTALLED_KIND}" = "legacy" ]; then
 		die 5 "\`pkg delete ${INSTALLED_NAME}\` failed — the box is unchanged apart from that failed operation; re-run after fixing the cause"
 	printf '==> Installing %s from %s\n' "${CANONICAL_PKG}" "${TARGET_REPO}"
 	env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" install -y -r "${TARGET_REPO}" "${CANONICAL_PKG}" ||
-		die 5 "\`pkg install -r ${TARGET_REPO} ${CANONICAL_PKG}\` failed AFTER ${INSTALLED_NAME} was removed — the box currently has NO pfBlockerNG installed; re-run this script to complete the migration"
+		die 5 "\`pkg install -r ${TARGET_REPO} ${CANONICAL_PKG}\` failed AFTER ${INSTALLED_NAME} was removed — the box currently has NO pfBlockerNG installed; fix the cause, then finish with: ${PKG_BIN} install -y -r ${TARGET_REPO} ${CANONICAL_PKG}"
 else
 	# Canonical identity, wrong repo. `-f` forces the reinstall even when the
 	# target version equals or is OLDER than the installed one: crossing

--- a/scripts/migrate-channel.sh
+++ b/scripts/migrate-channel.sh
@@ -1,0 +1,315 @@
+#!/bin/sh
+# migrate-channel.sh — move an ALREADY-INSTALLED pfBlockerNG onto one of the four
+# pkg channels (issue #2148, the client side of ADR-17). Run it ON the pfSense box,
+# AFTER `add-repo.sh --channel <ch>` has subscribed the box to that channel.
+#
+# WHY THIS EXISTS SEPARATELY FROM add-repo.sh: adding a repository is not a
+# migration. `pkg` never moves an installed package to a different repository on
+# its own while the repository it was installed from is enabled and still offers
+# that package — measured on pfSense CE 2.8.1 / pkg 1.21.3, and neither
+# CONSERVATIVE_UPGRADE=false nor a higher `priority:` changes it. So a box that
+# merely gains a channel conf keeps running its old build forever, silently. And
+# the four channel catalogues publish only the ONE canonical identity
+# `pfSense-pkg-pfBlockerNG`, so a box carrying a legacy suffixed identity
+# (`-devel`, `-nightly`/`-NIGHTLY`, `-testing`, `-edge`) has no upgrade path at all
+# until that identity is replaced. This script performs that replacement with a
+# repository-qualified operation and then PROVES the result.
+#
+# DIVISION OF LABOUR
+#   add-repo.sh          configures repositories only — writes this channel's conf,
+#                        retires every other project conf (single-repository
+#                        subscription), installs the boot-time regenerator hook.
+#   migrate-channel.sh   moves the installed package onto the subscribed channel.
+#
+#   Run add-repo.sh FIRST. This script refuses to touch the installed package
+#   while the box's repository configuration does not match --channel, because a
+#   second enabled project repository makes `pkg`'s later choices undetermined
+#   (all project repos share priority 100 and `pkg` does not order across
+#   equal-priority repositories).
+#
+# WHAT IT DOES
+#   1. Requires an explicit --channel; there is no default target.
+#   2. Fails BEFORE any mutation on: a repository configuration that is not exactly
+#      the requested channel, no pfBlockerNG installed, more than one installed,
+#      an unrecognised identity, or a target catalogue that does not offer the
+#      canonical package.
+#   3. Canonical already on the target repo  -> reported no-op, nothing mutated.
+#      Canonical on some other repo          -> `pkg install -f -r <target>`.
+#      Legacy suffixed identity              -> `pkg delete` + `pkg install -r <target>`.
+#   4. Verifies afterwards: exactly the canonical identity installed, `%R` equal to
+#      the target repo, the version the target catalogue offered, every path in
+#      `pkg info -l` present on disk, and the `installedpackages/pfblockerng`
+#      config section preserved across the mutation.
+#
+# CONFIGURATION PRESERVATION is the package's own lifecycle hooks (the existing
+# capture/restore around install), not something this script re-implements. It only
+# checks that the section survived, so a silent loss cannot be reported as success.
+#
+# EXIT CODES (each failure class is distinguishable by a script wrapping this one)
+#   0  success, including a reported no-op
+#   1  environment: `pkg` binary missing
+#   2  usage: missing/unknown/wrong-case --channel, unknown flag
+#   3  installed state: none, more than one, or an unrecognised pfBlockerNG identity
+#   4  target unavailable: repo not subscribed, stale multi-repo config, or the
+#      canonical package absent from the target catalogue
+#   5  the package operation itself failed
+#   6  post-migration verification failed (the box is NOT in the requested state)
+#
+# POSIX sh; quoted expansions; absolute path for the privileged `pkg` binary.
+# Env:
+#   PFBLOCKERNG_ROOT  filesystem root prefix (default: /); override in tests to
+#                     redirect the conf/config.xml reads to a temp dir.
+#   PKG_BIN           pkg binary path (default: /usr/local/sbin/pkg); override
+#                     in tests to stub out pkg.
+
+set -eu
+
+PKG_BIN="${PKG_BIN:-/usr/local/sbin/pkg}"
+
+PFBLOCKERNG_ROOT="${PFBLOCKERNG_ROOT:-/}"
+ROOT="${PFBLOCKERNG_ROOT%/}"
+REPOS_DIR="${ROOT}/usr/local/etc/pkg/repos"
+CONFIG_XML="${ROOT}/cf/conf/config.xml"
+
+# The one identity every channel catalogue publishes. Channel is catalogue
+# placement, never a package-name suffix (issue #2142/#2164).
+CANONICAL_PKG="pfSense-pkg-pfBlockerNG"
+
+# Every project conf add-repo.sh may ever have written. Exactly one may be present.
+PROJECT_CONFS="pfblockerng.conf
+pfblockerng-stable.conf
+pfblockerng-testing.conf
+pfblockerng-edge.conf
+pfblockerng-nightly.conf"
+
+CHANNEL=""
+
+die() {
+	_die_code="$1"
+	shift
+	printf 'migrate-channel.sh: %s\n' "$*" >&2
+	exit "${_die_code}"
+}
+
+usage() {
+	cat <<'EOF'
+Usage: migrate-channel.sh --channel <stable|testing|edge|nightly>
+
+Move an already-installed pfBlockerNG onto a pkg channel. Run
+`add-repo.sh --channel <ch>` FIRST — that subscribes the box to the channel;
+this script moves the installed package onto it.
+
+  --channel <ch>   REQUIRED target channel: stable, testing, edge or nightly.
+                   `release` is the legacy shared repo, not a channel, and is
+                   rejected. Channel names are lower-case.
+  -h, --help       this text.
+
+Before running: back up your configuration (Diagnostics > Backup & Restore).
+To go back afterwards: re-run `add-repo.sh --channel <previous>` and then this
+script with that channel — moving to an OLDER version is a repository-qualified
+downgrade, which is exactly what this script performs.
+
+Exit codes: 0 ok/no-op, 1 no pkg, 2 usage, 3 installed state, 4 target
+unavailable, 5 pkg operation failed, 6 verification failed.
+EOF
+}
+
+# ── Arg parsing ────────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--channel)
+		[ $# -ge 2 ] || die 2 "--channel requires a value"
+		CHANNEL="$2"
+		shift 2
+		;;
+	--channel=*)
+		CHANNEL="${1#--channel=}"
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		usage >&2
+		die 2 "unknown argument: $1"
+		;;
+	esac
+done
+
+[ -n "${CHANNEL}" ] || {
+	usage >&2
+	die 2 "--channel is required; there is no default target channel"
+}
+
+# Exact, lower-case match only. `release` is the legacy shared repo (it carries
+# both the canonical and the -devel identity) and is deliberately not a target:
+# migrating INTO it would reintroduce the ambiguity this ticket removes.
+case "${CHANNEL}" in
+stable | testing | edge | nightly) ;;
+release)
+	die 2 "'release' is the legacy shared repo, not a channel — pick stable, testing, edge or nightly"
+	;;
+*)
+	die 2 "unknown channel '${CHANNEL}' — expected one of: stable testing edge nightly (lower-case)"
+	;;
+esac
+
+TARGET_REPO="pfblockerng-${CHANNEL}"
+TARGET_CONF="pfblockerng-${CHANNEL}.conf"
+
+# ── 1. The box must already be subscribed to EXACTLY this channel ──────────────
+# Checked before anything else because it is free and because a mismatch is the
+# one failure a user hits by running this script out of order. A second enabled
+# project repo is not a tidiness problem: `pkg` does not order across
+# equal-priority repositories, so whatever this script installs could be replaced
+# by the other repo's build on the next upgrade.
+[ -f "${REPOS_DIR}/${TARGET_CONF}" ] ||
+	die 4 "not subscribed to the ${CHANNEL} channel (${REPOS_DIR}/${TARGET_CONF} is absent) — run: add-repo.sh --channel ${CHANNEL}"
+
+_stray=""
+for _conf in ${PROJECT_CONFS}; do
+	[ "${_conf}" = "${TARGET_CONF}" ] && continue
+	[ -f "${REPOS_DIR}/${_conf}" ] || continue
+	_stray="${_stray}${_stray:+ }${_conf}"
+done
+[ -z "${_stray}" ] ||
+	die 4 "another pfBlockerNG repository is still configured (${_stray}) — a box subscribes to exactly one channel; run: add-repo.sh --channel ${CHANNEL}"
+
+command -v "${PKG_BIN}" >/dev/null 2>&1 ||
+	die 1 "pkg binary not found at ${PKG_BIN} (run this on the pfSense box, or set PKG_BIN)"
+
+# ── 2. Classify the installed identity ─────────────────────────────────────────
+# `-g` makes the trailing '*' a glob; without it `pkg query` treats the pattern as
+# an exact name and matches nothing (the same trap pfb_pkg_installed_name() names).
+# A query miss is "not installed", not an error, so its non-zero status is absorbed.
+INSTALLED_NAMES="$("${PKG_BIN}" query -g '%n' "${CANONICAL_PKG}*" 2>/dev/null || true)"
+INSTALLED_NAMES="$(printf '%s\n' "${INSTALLED_NAMES}" | grep -v '^[[:space:]]*$' || true)"
+
+_count="$(printf '%s\n' "${INSTALLED_NAMES}" | grep -c '[^[:space:]]' || true)"
+
+[ "${_count}" -ne 0 ] ||
+	die 3 "no pfBlockerNG package is installed — nothing to migrate; install from the ${CHANNEL} channel with: pkg install ${CANONICAL_PKG}"
+[ "${_count}" -eq 1 ] ||
+	die 3 "$(printf 'more than one pfBlockerNG package is installed:\n%s\nRemove all but one before migrating.' "${INSTALLED_NAMES}")"
+
+INSTALLED_NAME="${INSTALLED_NAMES}"
+
+# Suffix classification against the shipped set — the same enumeration
+# pfb_channel_from_pkgname() carries in pfblockerng.inc, lower-cased so the
+# historical `-NIGHTLY` spelling (ADR-18) is recognised. An identity outside the
+# set is NOT assumed migratable: it may be a fork or a hand-built package whose
+# configuration this script cannot reason about.
+_suffix="$(printf '%s' "${INSTALLED_NAME}" | tr '[:upper:]' '[:lower:]')"
+_suffix="${_suffix#pfsense-pkg-pfblockerng}"
+case "${_suffix}" in
+"")
+	INSTALLED_KIND="canonical"
+	;;
+-devel | -testing | -edge | -nightly)
+	INSTALLED_KIND="legacy"
+	;;
+*)
+	die 3 "unrecognised pfBlockerNG identity '${INSTALLED_NAME}' — refusing to migrate a package this script does not ship"
+	;;
+esac
+
+INSTALLED_REPO="$("${PKG_BIN}" query '%R' "${INSTALLED_NAME}" 2>/dev/null || true)"
+INSTALLED_VERSION="$("${PKG_BIN}" query '%v' "${INSTALLED_NAME}" 2>/dev/null || true)"
+
+printf '==> Installed: %s-%s (from repo %s)\n' \
+	"${INSTALLED_NAME}" "${INSTALLED_VERSION:-unknown}" "${INSTALLED_REPO:-unknown}"
+
+# ── 3. The target catalogue must actually offer the canonical package ──────────
+# `pkg rquery -r <repo>` reads that ONE repo's catalogue. Checked before any
+# mutation so a typo'd/unpublished channel can never leave the box with the old
+# package deleted and nothing to install.
+TARGET_VERSION="$("${PKG_BIN}" rquery -r "${TARGET_REPO}" '%v' "${CANONICAL_PKG}" 2>/dev/null || true)"
+TARGET_VERSION="$(printf '%s' "${TARGET_VERSION}" | head -n 1)"
+[ -n "${TARGET_VERSION}" ] ||
+	die 4 "repo '${TARGET_REPO}' does not offer ${CANONICAL_PKG} — run \`pkg update -f\`, and check the ${CHANNEL} catalogue has a build for this pfSense edition/version"
+
+printf '==> Target:    %s-%s (repo %s)\n' "${CANONICAL_PKG}" "${TARGET_VERSION}" "${TARGET_REPO}"
+
+# ── 4. No-op: already canonical, already on the target repo ────────────────────
+# Reported, never silent. This is the ordinary outcome of switching between two
+# channels that currently serve the identical tagged artifact.
+if [ "${INSTALLED_KIND}" = "canonical" ] && [ "${INSTALLED_REPO}" = "${TARGET_REPO}" ]; then
+	printf '==> Already on the %s channel as %s-%s — nothing to do.\n' \
+		"${CHANNEL}" "${INSTALLED_NAME}" "${INSTALLED_VERSION}"
+	exit 0
+fi
+
+# ── 5. Record the config section, then mutate ──────────────────────────────────
+# The package's own lifecycle hooks preserve `installedpackages/pfblockerng`
+# across the replacement. Recording presence here turns a silent loss into a
+# verification failure instead of a reported success.
+CONFIG_SECTION_BEFORE=0
+if [ -f "${CONFIG_XML}" ] && grep -q '<pfblockerng>' "${CONFIG_XML}" 2>/dev/null; then
+	CONFIG_SECTION_BEFORE=1
+fi
+
+printf '==> Back up your configuration first if you have not (Diagnostics > Backup & Restore).\n'
+
+if [ "${INSTALLED_KIND}" = "legacy" ]; then
+	# A legacy suffixed identity is a DIFFERENT package name, so `pkg install` can
+	# never replace it — the two would simply coexist (or conflict). Delete first,
+	# then install the canonical one from the target repo. The delete runs the
+	# outgoing package's PRE-UNINSTALL, which is where its configuration capture
+	# lives; the install runs the incoming package's restore.
+	printf '==> Removing the legacy identity %s\n' "${INSTALLED_NAME}"
+	env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" delete -y "${INSTALLED_NAME}" ||
+		die 5 "\`pkg delete ${INSTALLED_NAME}\` failed — the box is unchanged apart from that failed operation; re-run after fixing the cause"
+	printf '==> Installing %s from %s\n' "${CANONICAL_PKG}" "${TARGET_REPO}"
+	env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" install -y -r "${TARGET_REPO}" "${CANONICAL_PKG}" ||
+		die 5 "\`pkg install -r ${TARGET_REPO} ${CANONICAL_PKG}\` failed AFTER ${INSTALLED_NAME} was removed — the box currently has NO pfBlockerNG installed; re-run this script to complete the migration"
+else
+	# Canonical identity, wrong repo. `-f` forces the reinstall even when the
+	# target version equals or is OLDER than the installed one: crossing
+	# repositories is exactly the case ordinary `pkg upgrade` refuses, and moving
+	# to a slower channel is a downgrade by design (each channel catalogue
+	# strictly contains its slower channels' files, so the older build is there).
+	printf '==> Reinstalling %s from %s (repository-qualified)\n' "${CANONICAL_PKG}" "${TARGET_REPO}"
+	env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" install -f -y -r "${TARGET_REPO}" "${CANONICAL_PKG}" ||
+		die 5 "\`pkg install -f -r ${TARGET_REPO} ${CANONICAL_PKG}\` failed — the previous build is still installed"
+fi
+
+# ── 6. Prove the result ────────────────────────────────────────────────────────
+# Every claim this script makes is re-read from pkg after the fact. A migration
+# that "ran" but left the box on the old repo, the old identity, or with missing
+# payload files is a FAILURE, not a success with a warning.
+FINAL_NAMES="$("${PKG_BIN}" query -g '%n' "${CANONICAL_PKG}*" 2>/dev/null || true)"
+FINAL_NAMES="$(printf '%s\n' "${FINAL_NAMES}" | grep -v '^[[:space:]]*$' || true)"
+[ "${FINAL_NAMES}" = "${CANONICAL_PKG}" ] ||
+	die 6 "$(printf 'expected exactly %s installed after migration, found:\n%s' "${CANONICAL_PKG}" "${FINAL_NAMES:-(none)}")"
+
+FINAL_REPO="$("${PKG_BIN}" query '%R' "${CANONICAL_PKG}" 2>/dev/null || true)"
+[ "${FINAL_REPO}" = "${TARGET_REPO}" ] ||
+	die 6 "${CANONICAL_PKG} reports repo '${FINAL_REPO:-unknown}', expected '${TARGET_REPO}' — the box is not on the ${CHANNEL} channel"
+
+FINAL_VERSION="$("${PKG_BIN}" query '%v' "${CANONICAL_PKG}" 2>/dev/null || true)"
+[ "${FINAL_VERSION}" = "${TARGET_VERSION}" ] ||
+	die 6 "${CANONICAL_PKG} reports version '${FINAL_VERSION:-unknown}', expected '${TARGET_VERSION}' from ${TARGET_REPO}"
+
+# Payload inventory: `pkg info -l` lists the installed file manifest, one
+# tab-indented absolute path per line after a header. A missing path means the
+# install did not land completely, which `pkg install`'s exit status alone does
+# not always reveal. The header line has no leading slash, so grep drops it.
+_missing="$(
+	"${PKG_BIN}" info -l "${CANONICAL_PKG}" 2>/dev/null |
+		sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' |
+		grep '^/' |
+		while IFS= read -r _path; do
+			[ -e "${ROOT}${_path}" ] || printf '%s\n' "${_path}"
+		done
+)"
+[ -z "${_missing}" ] ||
+	die 6 "$(printf 'the installed payload is incomplete — these files listed by pkg info -l are missing:\n%s' "${_missing}")"
+
+if [ "${CONFIG_SECTION_BEFORE}" -eq 1 ]; then
+	grep -q '<pfblockerng>' "${CONFIG_XML}" 2>/dev/null ||
+		die 6 "the installedpackages/pfblockerng section is gone from ${CONFIG_XML} — restore your configuration backup"
+fi
+
+printf '==> Done — %s-%s installed from %s (%s channel).\n' \
+	"${CANONICAL_PKG}" "${FINAL_VERSION}" "${FINAL_REPO}" "${CHANNEL}"

--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -192,9 +192,11 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
     stage_paths="docs/.nojekyll"
     [ -f "${PKG_REPO}/docs/index.html" ] && stage_paths="${stage_paths} docs/index.html"
     [ -f "${PKG_REPO}/docs/browse.html" ] && stage_paths="${stage_paths} docs/browse.html"
-    # write_site() also publishes a self-contained add-repo.sh into the site root —
-    # the landing page's bootstrap one-liner fetches it from there.
+    # write_site() also publishes the two client scripts into the site root — the
+    # landing page's bootstrap one-liner and its channel-switch snippet fetch them
+    # from there, so an unstaged copy serves a 404 into `sh`.
     [ -f "${PKG_REPO}/docs/add-repo.sh" ] && stage_paths="${stage_paths} docs/add-repo.sh"
+    [ -f "${PKG_REPO}/docs/migrate-channel.sh" ] && stage_paths="${stage_paths} docs/migrate-channel.sh"
     for target in $touched; do
         stage_paths="${stage_paths} docs/${target}"
     done

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -118,7 +118,7 @@ EOF
 
 # Regenerate one conf IF it exists (orphan guard: an absent conf stays absent —
 # we never create a channel the user didn't bootstrap).
-# $1 = conf path, $2 = channel word (release|nightly), $3 = repo name.
+# $1 = conf path, $2 = channel word (release|stable|testing|edge|nightly), $3 = repo name.
 _regen_one() {
     _ro_conf="$1"
     _ro_channel="$2"

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -52,7 +52,17 @@
 name="pfblockerng_repo_generate"
 
 # On-box paths (installed by add-repo.sh). Override via env for tests.
+#
+# One path per channel repository (issue #2148). `release` is the legacy shared
+# repo that carried both the stable and the -devel package; the four channel
+# repos each own a <channel>/<varver>/ catalogue serving the ONE canonical
+# package. A box subscribes to exactly ONE of these — the orphan guard in
+# _regen_one() is what keeps regeneration from re-enabling a channel the user
+# switched away from.
 : "${PFB_RELEASE_CONF:=/usr/local/etc/pkg/repos/pfblockerng.conf}"
+: "${PFB_STABLE_CONF:=/usr/local/etc/pkg/repos/pfblockerng-stable.conf}"
+: "${PFB_TESTING_CONF:=/usr/local/etc/pkg/repos/pfblockerng-testing.conf}"
+: "${PFB_EDGE_CONF:=/usr/local/etc/pkg/repos/pfblockerng-edge.conf}"
 : "${PFB_NIGHTLY_CONF:=/usr/local/etc/pkg/repos/pfblockerng-nightly.conf}"
 : "${PFB_PRODUCT_LABEL:=/etc/product_label}"
 : "${PFB_VERSION_FILE:=/etc/version}"
@@ -129,9 +139,15 @@ _regen_one() {
     fi
 }
 
-# Regenerate each channel's conf independently (channel keyed by filename).
+# Regenerate each channel's conf independently (channel keyed by conf path). Only
+# the channel(s) the box actually subscribed to are touched — _regen_one()'s
+# orphan guard skips every absent conf, so a box on one channel stays on that one
+# channel across a reboot (single-repository subscription, issue #2148).
 pfblockerng_repo_generate_start() {
     _regen_one "${PFB_RELEASE_CONF}" 'release' 'pfblockerng'
+    _regen_one "${PFB_STABLE_CONF}"  'stable'  'pfblockerng-stable'
+    _regen_one "${PFB_TESTING_CONF}" 'testing' 'pfblockerng-testing'
+    _regen_one "${PFB_EDGE_CONF}"    'edge'    'pfblockerng-edge'
     _regen_one "${PFB_NIGHTLY_CONF}" 'nightly' 'pfblockerng-nightly'
     return 0
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4648,22 +4648,28 @@ function pfb_channel_for_install(?string $repo, ?string $pkgname): ?string {
 }
 
 /*
- * Does a software-update cache describe an install from $repo? (issue #2148)
+ * Does a software-update cache describe the install currently on this box? (issue #2148)
  *
- * All four catalogues publish the ONE canonical identity, so the package NAME cannot tell
- * two catalogues apart — the recorded repo can. Both consumers of the cache ask this same
- * question: the cron orchestrator, deciding whether the cached latest/last_notified may be
- * reused, and the Software page, deciding whether the cached latest/last-checked/status may
- * be DISPLAYED. They must agree, because the orchestrator's reset lands only on the next
- * tick: between a channel migration and that tick the page would otherwise show the new
- * channel beside the previous catalogue's version and an "Update available" verdict for a
- * channel the box is no longer on.
+ * An install is identified by BOTH halves, because either can change alone:
+ *   - the REPO, since all four catalogues publish the one canonical identity, so the name
+ *     cannot tell two catalogues apart — a channel switch changes only this;
+ *   - the NAME, since the legacy shared 'pfblockerng' catalogue carries both
+ *     pfSense-pkg-pfBlockerNG and ...-devel — an in-repo identity swap changes only this.
+ *
+ * Both consumers of the cache ask this one question, and must ask the WHOLE of it: the
+ * cron orchestrator, deciding whether cached latest/last_notified may be reused, and the
+ * Software page, deciding whether cached latest/last-checked/status may be DISPLAYED. The
+ * orchestrator's reset lands only on the next tick, so a page asking a looser question
+ * shows the new install's label beside the previous one's version and verdict until then.
  *
  * A cache with NO 'repo' key predates #2148. That is not a catalogue change — it is every
- * existing box, once — so it is adopted rather than discarded; discarding it would
+ * existing box, once — so that half is adopted rather than discarded; discarding it would
  * re-announce an already-notified version and blank the last-known latest.
  */
-function pfb_software_cache_matches_repo(array $cache, string $repo): bool {
+function pfb_software_cache_matches_install(array $cache, string $pkgname, string $repo): bool {
+	if ((string) ($cache['pkgname'] ?? '') !== $pkgname) {
+		return FALSE;
+	}
 	return !array_key_exists('repo', $cache) || (string) $cache['repo'] === $repo;
 }
 
@@ -4998,14 +5004,11 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 	} else {
 		$latest = pfb_pkg_latest($pkgname, $repo);
 	}
-	// Only reuse cached latest/last_notified when the cache belongs to the SAME install —
-	// same package name AND same repository (pfb_software_cache_matches_repo(), the same
-	// predicate the Software page gates its displayed values on). issue #2148: all four
-	// catalogues publish the one canonical identity, so a catalogue switch leaves the NAME
-	// unchanged and a name-only scope would serve the old catalogue's version as the new
-	// one's, with its last_notified swallowing the first genuine notice for the new one.
-	$cache_matches_install = (($cache['pkgname'] ?? '') === $pkgname)
-		&& pfb_software_cache_matches_repo($cache, $repo);
+	// Only reuse cached latest/last_notified when the cache belongs to the SAME install.
+	// pfb_software_cache_matches_install() is the whole question — name AND repo — and the
+	// Software page gates its DISPLAYED values on the identical call, so the two can never
+	// disagree about which cache is current.
+	$cache_matches_install = pfb_software_cache_matches_install($cache, $pkgname, $repo);
 	if ($latest === '' && $cache_matches_install) {
 		$latest = (string) ($cache['latest'] ?? '');
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4633,6 +4633,41 @@ function pfb_channel_from_repo_name(?string $repo): ?string {
 }
 
 /*
+ * The channel an install is on: the REPO decides, the NAME is the fallback (issue #2148).
+ *
+ * The two mappers above answer half the question each, and every caller needs both halves in
+ * the same order — the Software page label, the cron notice text, and the cached channel. It
+ * lives here as ONE function rather than as a repeated expression so the page and the notice
+ * cannot drift into disagreeing about what channel a box is on.
+ *
+ * NULL when neither half recognises the install (a Netgate or hand-built package); callers
+ * render that as 'unknown'.
+ */
+function pfb_channel_for_install(?string $repo, ?string $pkgname): ?string {
+	return pfb_channel_from_repo_name($repo) ?? pfb_channel_from_pkgname($pkgname);
+}
+
+/*
+ * Does a software-update cache describe an install from $repo? (issue #2148)
+ *
+ * All four catalogues publish the ONE canonical identity, so the package NAME cannot tell
+ * two catalogues apart — the recorded repo can. Both consumers of the cache ask this same
+ * question: the cron orchestrator, deciding whether the cached latest/last_notified may be
+ * reused, and the Software page, deciding whether the cached latest/last-checked/status may
+ * be DISPLAYED. They must agree, because the orchestrator's reset lands only on the next
+ * tick: between a channel migration and that tick the page would otherwise show the new
+ * channel beside the previous catalogue's version and an "Update available" verdict for a
+ * channel the box is no longer on.
+ *
+ * A cache with NO 'repo' key predates #2148. That is not a catalogue change — it is every
+ * existing box, once — so it is adopted rather than discarded; discarding it would
+ * re-announce an already-notified version and blank the last-known latest.
+ */
+function pfb_software_cache_matches_repo(array $cache, string $repo): bool {
+	return !array_key_exists('repo', $cache) || (string) $cache['repo'] === $repo;
+}
+
+/*
  * Provenance gate (2026-06-15 amendment; widened by issue #2148): TRUE only when the build
  * was installed FROM one of OUR repos — the legacy shared 'pfblockerng' (stable + the
  * retired -devel identity) or one of the four per-channel catalogues
@@ -4950,11 +4985,9 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 	$repo = array_key_exists('installed_repo', $io)
 		? (string) $io['installed_repo']
 		: pfb_pkg_installed_repo($pkgname);
-	// Repo-first, name-fallback: the legacy shared 'pfblockerng' repo carries BOTH the
-	// canonical and the -devel identity, so it names no channel and the NAME still decides
-	// there. Everything the user SEES (this cache, the notice text, the Software page label)
-	// derives the channel this way.
-	$channel = pfb_channel_from_repo_name($repo) ?? pfb_channel_from_pkgname($pkgname);
+	// Repo-first, name-fallback, through the ONE shared accessor so the cached channel,
+	// the notice text and the Software page label can never disagree.
+	$channel = pfb_channel_for_install($repo, $pkgname);
 
 	$cache = pfb_software_read_cache();
 
@@ -4966,12 +4999,13 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 		$latest = pfb_pkg_latest($pkgname, $repo);
 	}
 	// Only reuse cached latest/last_notified when the cache belongs to the SAME install —
-	// same package name AND same repository. issue #2148: all four catalogues publish the
-	// one canonical identity, so a catalogue switch leaves the NAME unchanged and a
-	// name-only scope would serve the old catalogue's version as the new one's (and its
-	// last_notified would swallow the first genuine notice for the new catalogue).
+	// same package name AND same repository (pfb_software_cache_matches_repo(), the same
+	// predicate the Software page gates its displayed values on). issue #2148: all four
+	// catalogues publish the one canonical identity, so a catalogue switch leaves the NAME
+	// unchanged and a name-only scope would serve the old catalogue's version as the new
+	// one's, with its last_notified swallowing the first genuine notice for the new one.
 	$cache_matches_install = (($cache['pkgname'] ?? '') === $pkgname)
-		&& (($cache['repo'] ?? '') === $repo);
+		&& pfb_software_cache_matches_repo($cache, $repo);
 	if ($latest === '' && $cache_matches_install) {
 		$latest = (string) ($cache['latest'] ?? '');
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4554,14 +4554,20 @@ function pfb_wizard_dnsvip_settings(bool $auto, $vip4, $vip6): array {
  *   pfSense-pkg-pfBlockerNG-edge    -> 'edge'
  *   pfSense-pkg-pfBlockerNG-devel   -> 'devel'   (retired port; installed boxes remain)
  *   pfSense-pkg-pfBlockerNG-NIGHTLY -> 'nightly' (ADR-18)
- * Anything unrecognised/empty -> NULL. The installed name is authoritative for "what
- * channel am I on" (ADR-19 §2 channel detection). Suffix match is case-insensitive so
- * the NIGHTLY/devel spellings are tolerant.
+ * Anything unrecognised/empty -> NULL. Suffix match is case-insensitive so the
+ * NIGHTLY/devel spellings are tolerant.
  *
  * issue #2166: the ports tree replaced the -devel recipe with -testing/-edge/-nightly, so
  * a build from the current CI channel reports one of those names. -devel stays mapped:
  * boxes installed before the rename still carry it, and dropping it here would read them
  * as an unknown channel — i.e. not our build.
+ *
+ * issue #2148 narrowed this function's ROLE (its mapping is unchanged). Channel is now
+ * catalogue placement — all four catalogues publish the canonical 'pfSense-pkg-pfBlockerNG'
+ * — so pfb_channel_from_repo_name() is the authoritative channel signal and this is the
+ * FALLBACK: the discriminator inside the legacy shared 'pfblockerng' repo, which carries
+ * both the canonical and the -devel identity. It also remains the prefix/identity filter
+ * inside pfb_pkg_installed_name().
  */
 function pfb_channel_from_pkgname(?string $name): ?string {
 	if (!is_string($name) || $name === '') {
@@ -4589,36 +4595,60 @@ function pfb_channel_from_pkgname(?string $name): ?string {
 }
 
 /*
- * The pkg repo "read latest" maps to, for a given channel (2026-06-14 + 2026-06-15
- * amendments): stable AND the pre-release channels share ONE repo 'pfblockerng' (the
- * channel selects the package, not a per-channel repo); 'nightly' is the sole
- * separately-channelled build, repo 'pfblockerng-nightly'. An unrecognised channel ->
- * NULL (no repo to read from). Per-channel catalogues are #2148's cutover, not this.
+ * Channel a build is on, from the pkg REPOSITORY it was installed from (`pkg query '%R'`):
+ *   pfblockerng-stable  -> 'stable'
+ *   pfblockerng-testing -> 'testing'
+ *   pfblockerng-edge    -> 'edge'
+ *   pfblockerng-nightly -> 'nightly'
+ * Anything else -> NULL.
+ *
+ * issue #2148 (four-channel cutover): every channel catalogue publishes the ONE canonical
+ * package identity 'pfSense-pkg-pfBlockerNG' — channel is catalogue placement, never a
+ * package-name suffix — so the installed NAME can no longer say which channel a box is on.
+ * A box subscribes to exactly one project repository at a time, so the recorded repo is both
+ * the only repo the package can upgrade within and the authoritative channel signal.
+ *
+ * The LEGACY shared repo 'pfblockerng' returns NULL deliberately: it carries BOTH
+ * pfSense-pkg-pfBlockerNG and pfSense-pkg-pfBlockerNG-devel, so there the NAME still
+ * discriminates and callers fall back to pfb_channel_from_pkgname(). Matching is EXACT
+ * (unlike the name mapper's case-insensitive suffixes): we author every one of these conf
+ * names ourselves, so a case variant is a repo we never created, not a spelling of ours.
  */
-function pfb_pkg_repo_name_for_channel(?string $channel): ?string {
-	switch ($channel) {
-		case 'stable':
-		case 'testing':
-		case 'edge':
-		case 'devel':
-			return 'pfblockerng';
-		case 'nightly':
-			return 'pfblockerng-nightly';
+function pfb_channel_from_repo_name(?string $repo): ?string {
+	if (!is_string($repo) || $repo === '') {
+		return null;
+	}
+	switch ($repo) {
+		case 'pfblockerng-stable':
+			return 'stable';
+		case 'pfblockerng-testing':
+			return 'testing';
+		case 'pfblockerng-edge':
+			return 'edge';
+		case 'pfblockerng-nightly':
+			return 'nightly';
 		default:
 			return null;
 	}
 }
 
 /*
- * Provenance gate (2026-06-15 amendment): TRUE only when the build was installed FROM
- * one of OUR repos — 'pfblockerng' (stable+devel) or 'pfblockerng-nightly'. The repo is
- * read from `pkg query '%R' <pkgname>`. A Netgate-installed add-on (repo 'pfSense'),
- * an empty/'unknown' origin, or anything else -> FALSE: the Software tab, the page, the
- * priv match[] line, AND the cron notice all gate on this so a stock build shows none of
- * them.
+ * Provenance gate (2026-06-15 amendment; widened by issue #2148): TRUE only when the build
+ * was installed FROM one of OUR repos — the legacy shared 'pfblockerng' (stable + the
+ * retired -devel identity) or one of the four per-channel catalogues
+ * 'pfblockerng-stable' / '-testing' / '-edge' / '-nightly'. The repo is read from
+ * `pkg query '%R' <pkgname>`. A Netgate-installed add-on (repo 'pfSense'), an empty/'unknown'
+ * origin, or anything else -> FALSE: the Software tab, the page, the priv match[] line, AND
+ * the cron notice all gate on this so a stock build shows none of them. Before #2148 only the
+ * first and last were listed, so a box moved onto a -stable/-testing/-edge catalogue read as
+ * not-our-build and silently lost the whole feature.
  */
 function pfb_software_is_our_build(?string $installed_repo): bool {
-	return in_array($installed_repo, array('pfblockerng', 'pfblockerng-nightly'), TRUE);
+	return in_array(
+		$installed_repo,
+		array('pfblockerng', 'pfblockerng-stable', 'pfblockerng-testing', 'pfblockerng-edge', 'pfblockerng-nightly'),
+		TRUE
+	);
 }
 
 /*
@@ -4674,7 +4704,9 @@ function pfb_should_notify(?string $installed, ?string $latest, ?string $last_no
  * target — this is the binary pfSense itself and our add-repo.sh/build-repo.sh shell to.
  * The base /usr/sbin/pkg bootstrap stub does NOT report the repository origin ('%R') the
  * same way, so the provenance gate read FALSE on a genuine our-repo install when it was
- * used; the port binary returns the recorded repo name ('pfblockerng').
+ * used; the port binary returns the recorded repo name (issue #2148: the legacy shared
+ * 'pfblockerng' or one of the per-channel 'pfblockerng-<channel>' catalogues), which is
+ * now the authoritative channel signal AND the repo latest is read from.
  */
 define('PFB_PKG_BIN', '/usr/local/sbin/pkg');
 
@@ -4756,6 +4788,11 @@ function pfb_pkg_installed_version(string $pkgname): string {
 /*
  * The repo $pkgname was installed FROM via `pkg query '%R'` (the provenance signal the
  * 2026-06-15 gate keys on); '' when absent/failed. Fed to pfb_software_is_our_build().
+ *
+ * issue #2148 made this the single authoritative signal: under one-repository-at-a-time
+ * subscription the recorded repo is the ONLY repo the package can upgrade within, so it is
+ * also the repo pfb_software_update_check() reads latest from and (via
+ * pfb_channel_from_repo_name()) the channel it reports.
  */
 function pfb_pkg_installed_repo(string $pkgname): string {
 	if ($pkgname === '') {
@@ -4853,18 +4890,19 @@ function pfb_software_write_cache(array $cache): void {
  *
  * Order is deliberate:
  *   1. Resolve installed name + version. These can be injected for unit tests via
- *      $io ['installed_name','installed','latest']; absent keys fall through to the
- *      live pfb_pkg_*() shellout.
+ *      $io ['installed_name','installed','installed_repo','latest']; absent keys fall
+ *      through to the live pfb_pkg_*() shellout.
  *   2. PROVENANCE GATE FIRST: gate on pfb_software_provenance_ok() — the SAME predicate
  *      that decides whether the Software PAGE is displayable (our-repo install, honouring
  *      the hidden CI/support override) — so a build that cannot show the page never runs
  *      the background check or raises an update notice, even if "Check for new versions"
  *      remains enabled from a prior our-repo install. Injectable via $io['provenance_ok']
  *      for off-box tests.
- *   3. Read our-repo latest for the channel's repo (guarded inside pfb_pkg_latest()).
- *      An empty latest (pkg locked / no DNS / repo absent) preserves the cached latest so
- *      the page keeps showing the last-known value rather than regressing to ''.
- *   4. Refresh the cache (channel/installed/latest/last_checked) and, when
+ *   3. Read latest from the repo the package was INSTALLED from (guarded inside
+ *      pfb_pkg_latest()). An empty latest (pkg locked / no DNS / repo absent) preserves the
+ *      cached latest so the page keeps showing the last-known value rather than regressing
+ *      to ''.
+ *   4. Refresh the cache (pkgname/repo/channel/installed/latest/last_checked) and, when
  *      pfb_should_notify() says so, raise a DE-DUPED file_notice and persist
  *      last_notified = latest (so repeated ticks at the same latest do not renotify).
  *
@@ -4903,30 +4941,48 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 		return pfb_software_read_cache();
 	}
 
-	$channel = pfb_channel_from_pkgname($pkgname);
-	$repo    = pfb_pkg_repo_name_for_channel($channel);
+	// issue #2148: the INSTALLED REPOSITORY is authoritative — never a channel->repo mapping.
+	// All four catalogues publish the ONE canonical identity 'pfSense-pkg-pfBlockerNG', and a
+	// box subscribes to exactly one project repo at a time (all at priority 100, so pkg would
+	// not order across them anyway), which makes the recorded '%R' both the only repo this
+	// install can upgrade within and the channel it is on. Correct for legacy 'pfblockerng'
+	// installs too: that is exactly where their upgrades come from.
+	$repo = array_key_exists('installed_repo', $io)
+		? (string) $io['installed_repo']
+		: pfb_pkg_installed_repo($pkgname);
+	// Repo-first, name-fallback: the legacy shared 'pfblockerng' repo carries BOTH the
+	// canonical and the -devel identity, so it names no channel and the NAME still decides
+	// there. Everything the user SEES (this cache, the notice text, the Software page label)
+	// derives the channel this way.
+	$channel = pfb_channel_from_repo_name($repo) ?? pfb_channel_from_pkgname($pkgname);
 
 	$cache = pfb_software_read_cache();
 
-	// 3. Read our-repo latest; keep the cached value when the live read is unavailable.
+	// 3. Read latest from the installed repo; keep the cached value when the live read is
+	// unavailable.
 	if (array_key_exists('latest', $io)) {
 		$latest = (string) $io['latest'];
 	} else {
-		$latest = pfb_pkg_latest($pkgname, (string) $repo);
+		$latest = pfb_pkg_latest($pkgname, $repo);
 	}
-	// Only reuse cached latest/last_notified when the cache belongs to the SAME installed
-	// package — after a channel switch (stable<->devel<->nightly) a stale value must not
-	// drive a wrong notice or suppress the first valid one for the new package.
-	$cache_matches_pkg = (($cache['pkgname'] ?? '') === $pkgname);
-	if ($latest === '' && $cache_matches_pkg) {
+	// Only reuse cached latest/last_notified when the cache belongs to the SAME install —
+	// same package name AND same repository. issue #2148: all four catalogues publish the
+	// one canonical identity, so a catalogue switch leaves the NAME unchanged and a
+	// name-only scope would serve the old catalogue's version as the new one's (and its
+	// last_notified would swallow the first genuine notice for the new catalogue).
+	$cache_matches_install = (($cache['pkgname'] ?? '') === $pkgname)
+		&& (($cache['repo'] ?? '') === $repo);
+	if ($latest === '' && $cache_matches_install) {
 		$latest = (string) ($cache['latest'] ?? '');
 	}
 
-	$last_notified = $cache_matches_pkg ? (string) ($cache['last_notified'] ?? '') : '';
+	$last_notified = $cache_matches_install ? (string) ($cache['last_notified'] ?? '') : '';
 
 	// 4. Refresh the cache. last_notified is written from the scoped value so a cache left
-	// by a different package (channel switch) is reset rather than carried forward.
+	// by a different install (a different package name OR a different catalogue) is reset
+	// rather than carried forward.
 	$cache['pkgname']       = $pkgname;
+	$cache['repo']          = $repo;
 	$cache['channel']       = $channel;
 	$cache['installed']     = $installed;
 	$cache['latest']        = $latest;
@@ -4947,9 +5003,10 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
  *
  * Live wrapper over the pure pfb_software_is_our_build() (ADR-19 2026-06-15
  * amendment): reads the installed package's provenance from `pkg query '%R'`
- * and returns true ONLY when pfBlockerNG was installed from one of OUR repos
- * (`pfblockerng` / `pfblockerng-nightly`). A Netgate-ports install (repo
- * 'pfSense'/unknown/'') returns false.
+ * and returns true ONLY when pfBlockerNG was installed from one of OUR repos —
+ * the legacy shared `pfblockerng` or one of the four per-channel catalogues
+ * `pfblockerng-stable|-testing|-edge|-nightly` (issue #2148). A Netgate-ports
+ * install (repo 'pfSense'/unknown/'') returns false.
  *
  * The Software tab append, the pfblockerng_software.php top-of-file guard, and
  * the priv match line all gate on this single predicate so a Netgate-installed

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -61,8 +61,13 @@ if (!isAllowedPage('pkg_mgr_installed.php')) {
 }
 
 // Resolve the installed package + channel ONCE (used by display + the action shortcuts).
+// issue #2148: channel is CATALOGUE placement — all four catalogues publish the canonical
+// 'pfSense-pkg-pfBlockerNG', so the repo the package came from names the channel. The legacy
+// shared 'pfblockerng' repo carries two identities and names none, so fall back to the name
+// there. Same derivation as pfb_software_update_check(), so page and notice never disagree.
 $pfb_sw_pkgname	= pfb_pkg_installed_name();
-$pfb_sw_channel	= pfb_channel_from_pkgname($pfb_sw_pkgname);
+$pfb_sw_repo	= pfb_pkg_installed_repo($pfb_sw_pkgname);
+$pfb_sw_channel	= pfb_channel_from_repo_name($pfb_sw_repo) ?? pfb_channel_from_pkgname($pfb_sw_pkgname);
 
 // The "Check for new versions" setting (default ENABLED — the registry default since
 // issue #1887). The accessor reads the gateway itself; no raw value handling here.

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -125,14 +125,15 @@ pfb_print_pending_changes_box();
 // from the cron-maintained cache (empty/unknown renders a clean "Not checked yet" — never a
 // warning — so the page passes ui_render on the first GET, before any check has run).
 //
-// issue #2148: the cache is trusted only while it describes an install from the repository
-// the box is on NOW. pfb_software_update_check() rescopes it on a catalogue change, but that
-// lands on the next tick — so between a channel migration and that tick this page would
-// otherwise pair the new channel's label with the PREVIOUS catalogue's version and an
-// "Update available"/"Up to date" verdict for a channel the box has left. Same predicate as
-// the orchestrator's, so the two can never disagree about which cache is current.
+// issue #2148: the cache is trusted only while it describes the install the box carries
+// NOW — the same package name from the same repository. pfb_software_update_check()
+// rescopes it on a change, but that lands on the next tick, so between a channel migration
+// (or an in-repo identity swap on the legacy shared catalogue) and that tick this page
+// would otherwise pair the current install's label with the PREVIOUS one's version and an
+// "Update available"/"Up to date" verdict it has no business showing. Identical call to the
+// orchestrator's, so the two can never disagree about which cache is current.
 $cache		= pfb_software_read_cache();
-$cache_current	= pfb_software_cache_matches_repo($cache, $pfb_sw_repo);
+$cache_current	= pfb_software_cache_matches_install($cache, $pfb_sw_pkgname, $pfb_sw_repo);
 $cached_latest	= $cache_current ? (string) ($cache['latest'] ?? '') : '';
 $installed_ver	= pfb_pkg_installed_version($pfb_sw_pkgname);
 $disp_channel	= $pfb_sw_channel ?: gettext('unknown');

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -62,12 +62,13 @@ if (!isAllowedPage('pkg_mgr_installed.php')) {
 
 // Resolve the installed package + channel ONCE (used by display + the action shortcuts).
 // issue #2148: channel is CATALOGUE placement — all four catalogues publish the canonical
-// 'pfSense-pkg-pfBlockerNG', so the repo the package came from names the channel. The legacy
-// shared 'pfblockerng' repo carries two identities and names none, so fall back to the name
-// there. Same derivation as pfb_software_update_check(), so page and notice never disagree.
+// 'pfSense-pkg-pfBlockerNG', so the repo the package came from names the channel, with the
+// name as the fallback for the legacy shared repo. pfb_channel_for_install() is that one
+// rule, shared with pfb_software_update_check() so the page label and the notice text
+// cannot drift apart.
 $pfb_sw_pkgname	= pfb_pkg_installed_name();
 $pfb_sw_repo	= pfb_pkg_installed_repo($pfb_sw_pkgname);
-$pfb_sw_channel	= pfb_channel_from_repo_name($pfb_sw_repo) ?? pfb_channel_from_pkgname($pfb_sw_pkgname);
+$pfb_sw_channel	= pfb_channel_for_install($pfb_sw_repo, $pfb_sw_pkgname);
 
 // The "Check for new versions" setting (default ENABLED — the registry default since
 // issue #1887). The accessor reads the gateway itself; no raw value handling here.
@@ -123,19 +124,28 @@ pfb_print_pending_changes_box();
 // always known on an installed box. Only the our-repo "latest" + status + last-checked come
 // from the cron-maintained cache (empty/unknown renders a clean "Not checked yet" — never a
 // warning — so the page passes ui_render on the first GET, before any check has run).
+//
+// issue #2148: the cache is trusted only while it describes an install from the repository
+// the box is on NOW. pfb_software_update_check() rescopes it on a catalogue change, but that
+// lands on the next tick — so between a channel migration and that tick this page would
+// otherwise pair the new channel's label with the PREVIOUS catalogue's version and an
+// "Update available"/"Up to date" verdict for a channel the box has left. Same predicate as
+// the orchestrator's, so the two can never disagree about which cache is current.
 $cache		= pfb_software_read_cache();
+$cache_current	= pfb_software_cache_matches_repo($cache, $pfb_sw_repo);
+$cached_latest	= $cache_current ? (string) ($cache['latest'] ?? '') : '';
 $installed_ver	= pfb_pkg_installed_version($pfb_sw_pkgname);
 $disp_channel	= $pfb_sw_channel ?: gettext('unknown');
 $disp_installed	= ($installed_ver !== '') ? $installed_ver : gettext('unknown');
-$disp_latest	= !empty($cache['latest']) ? (string) $cache['latest'] : gettext('Not checked yet');
-$disp_checked	= !empty($cache['last_checked'])
+$disp_latest	= ($cached_latest !== '') ? $cached_latest : gettext('Not checked yet');
+$disp_checked	= ($cache_current && !empty($cache['last_checked']))
 			? date('Y-m-d H:i:s', (int) $cache['last_checked'])
 			: gettext('never');
 
-$update_available = pfb_update_available($installed_ver, (string) ($cache['latest'] ?? ''));
+$update_available = pfb_update_available($installed_ver, $cached_latest);
 if ($update_available) {
 	$disp_status = '<span class="text-warning">' . gettext('Update available') . '</span>';
-} elseif (!empty($cache['latest'])) {
+} elseif ($cached_latest !== '') {
 	$disp_status = '<span class="text-success">' . gettext('Up to date') . '</span>';
 } else {
 	$disp_status = gettext('Not checked yet');

--- a/tests/php/SoftwareUpdateCheckTest.php
+++ b/tests/php/SoftwareUpdateCheckTest.php
@@ -666,4 +666,100 @@ final class SoftwareUpdateCheckTest extends TestCase
 		pfb_software_update_check(false, $this->ourBuildIo('3.2.0_1', '3.2.0_10'));
 		$this->assertCount(2, $GLOBALS['pfb_test_file_notices'], 'tick 4: still two notices total (de-duped)');
 	}
+
+	/*
+	 * ---- A cache written BEFORE #2148 belongs to this install, not a foreign one ----
+	 *
+	 * The reuse scope gained a `repo` component so a catalogue switch cannot serve the old
+	 * catalogue's latest as the new one's. Every cache written before that change has NO
+	 * `repo` key, which is not a catalogue change — it is the one-time upgrade every
+	 * existing box performs. Reading it as foreign would re-announce a version the box has
+	 * already been notified about and drop the cached latest the offline guard preserves.
+	 */
+	public function testPreCutoverCacheIsAdoptedAndDoesNotReNotify(): void
+	{
+		$this->setCheck('on');
+		// A cache in the pre-#2148 shape: no 'repo' key, already notified for 3.2.0_9.
+		file_put_contents($this->cacheFile(), json_encode([
+			'pkgname'       => 'pfSense-pkg-pfBlockerNG',
+			'channel'       => 'stable',
+			'installed'     => '3.2.0_1',
+			'latest'        => '3.2.0_9',
+			'last_notified' => '3.2.0_9',
+			'last_checked'  => 1,
+		]));
+		$this->assertArrayNotHasKey('repo', (array) $this->readCache(), 'before: the cache predates the repo scope');
+
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG',
+			'installed_repo' => 'pfblockerng',
+			'installed'      => '3.2.0_1',
+			'provenance_ok'  => TRUE,
+			'latest'         => '3.2.0_9',
+		]);
+
+		$this->assertSame('3.2.0_9', $cache['last_notified'], 'the already-announced version must survive the upgrade');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'an existing box must not be re-notified once');
+		$this->assertSame('pfblockerng', $cache['repo'], 'the tick records the repo the cache was missing');
+	}
+
+	/**
+	 * Same pre-#2148 cache, but the live read is unavailable (pkg locked / no DNS).
+	 * The cached latest must be served rather than regressing to '' — the exact
+	 * regression the offline guard exists to prevent.
+	 */
+	public function testPreCutoverCacheStillServesLatestWhenTheLiveReadFails(): void
+	{
+		$this->setCheck('on');
+		file_put_contents($this->cacheFile(), json_encode([
+			'pkgname'       => 'pfSense-pkg-pfBlockerNG',
+			'channel'       => 'stable',
+			'installed'     => '3.2.0_1',
+			'latest'        => '3.2.0_9',
+			'last_notified' => '3.2.0_9',
+			'last_checked'  => 1,
+		]));
+		$this->assertSame('3.2.0_9', $this->readCache()['latest'], 'before: a last-known latest is cached');
+
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG',
+			'installed_repo' => 'pfblockerng',
+			'installed'      => '3.2.0_1',
+			'provenance_ok'  => TRUE,
+			'latest'         => '',
+		]);
+
+		$this->assertSame('3.2.0_9', $cache['latest'], 'the last-known latest must not regress to empty');
+	}
+
+	/**
+	 * The scope still does its job: a cache carrying a DIFFERENT repo is foreign, so its
+	 * latest and last_notified are dropped. This is the case the repo component was added
+	 * for, and it must survive the pre-cutover carve-out above.
+	 */
+	public function testCacheFromAnotherCatalogueIsStillDiscarded(): void
+	{
+		$this->setCheck('on');
+		file_put_contents($this->cacheFile(), json_encode([
+			'pkgname'       => 'pfSense-pkg-pfBlockerNG',
+			'repo'          => 'pfblockerng-stable',
+			'channel'       => 'stable',
+			'installed'     => '3.2.0_1',
+			'latest'        => '3.2.0_9',
+			'last_notified' => '3.2.0_9',
+			'last_checked'  => 1,
+		]));
+		$this->assertSame('pfblockerng-stable', $this->readCache()['repo'], 'before: the cache is stable-scoped');
+
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG',
+			'installed_repo' => 'pfblockerng-edge',
+			'installed'      => '3.2.0_1',
+			'provenance_ok'  => TRUE,
+			'latest'         => '3.2.0_9',
+		]);
+
+		$this->assertSame('pfblockerng-edge', $cache['repo'], 'the cache is rescoped to the new catalogue');
+		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'the new catalogue gets its own first notice');
+	}
 }

--- a/tests/php/SoftwareUpdateCheckTest.php
+++ b/tests/php/SoftwareUpdateCheckTest.php
@@ -19,13 +19,16 @@ use PHPUnit\Framework\TestCase;
  * notice fired?) and the AFTER-state so green proves the side-effect was CAUSED by the
  * input, not pre-existing.
  *
- * The IO is doubled by passing $io = ['installed_name','installed','provenance_ok','latest']
- * to the orchestrator (its documented unit-test seam). 'provenance_ok' (bool) replaces the
- * old 'installed_repo' key: the orchestrator now delegates repo-string discrimination to
- * pfb_software_provenance_ok() (the page-displayability predicate); per-repo branch coverage
- * for pfb_software_is_our_build() lives in SoftwareUpdateDecisionTest. file_notice /
- * is_subsystem_dirty / get_dnsavailable are doubled in pfsense_doubles.php, driven via
- * $GLOBALS (pfb_test_file_notices / pfb_test_pkg_locked / pfb_test_dns_available).
+ * The IO is doubled by passing $io = ['installed_name','installed','installed_repo',
+ * 'provenance_ok','latest'] to the orchestrator (its documented unit-test seam).
+ * 'provenance_ok' (bool) replaces the old repo-string gate: the orchestrator delegates
+ * repo-string discrimination to pfb_software_provenance_ok() (the page-displayability
+ * predicate); per-repo branch coverage for pfb_software_is_our_build() lives in
+ * SoftwareUpdateDecisionTest. 'installed_repo' is the `pkg query %R` origin the four-channel
+ * cutover (#2148) made authoritative for BOTH which catalogue latest is read from and which
+ * channel the cache reports. file_notice / is_subsystem_dirty / get_dnsavailable are doubled
+ * in pfsense_doubles.php, driven via $GLOBALS (pfb_test_file_notices / pfb_test_pkg_locked /
+ * pfb_test_dns_available).
  */
 #[CoversFunction('pfb_software_update_check')]
 #[CoversFunction('pfb_software_cache_file')]
@@ -265,6 +268,162 @@ final class SoftwareUpdateCheckTest extends TestCase
 		pfb_software_update_check(false, $openIo);
 		$this->assertNotNull($this->readCache(), 'gate open: cache must be written');
 		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'gate open: notice must fire');
+	}
+
+	/*
+	 * ---- issue #2148: the INSTALLED REPOSITORY is authoritative ----
+	 *
+	 * Four-channel cutover: all four catalogues publish the ONE canonical identity
+	 * 'pfSense-pkg-pfBlockerNG', so the package NAME can no longer say which channel a box
+	 * is on. The orchestrator reads latest from the repo the package was INSTALLED from
+	 * (`pkg query %R`, injected here as $io['installed_repo']) — under single-repository
+	 * subscription that is the only repo it can upgrade within — and labels the cache
+	 * repo-first, name-fallback: pfb_channel_from_repo_name() ?? pfb_channel_from_pkgname().
+	 */
+
+	/**
+	 * Given a CANONICAL install ('pfSense-pkg-pfBlockerNG', no channel in the name) whose
+	 * recorded origin is the EDGE catalogue,
+	 * When the check runs,
+	 * Then latest is read from that catalogue and the cache + notice report channel 'edge'.
+	 * Before #2148 these exact inputs reported 'stable' (name-derived) and read the shared
+	 * 'pfblockerng' repo — an edge subscriber was offered stable's versions.
+	 */
+	public function testCanonicalNameOnEdgeCatalogueReportsEdgeChannel(): void
+	{
+		// Given: clean before-state.
+		$this->setCheck('on');
+		$this->assertNull($this->readCache(), 'before: no cache file');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice');
+
+		// When.
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG',
+			'installed'      => '3.2.0_1',
+			'installed_repo' => 'pfblockerng-edge',
+			'provenance_ok'  => TRUE,
+			'latest'         => '3.2.0_9',
+		]);
+
+		// Then: the installed catalogue is the one read, and it names the channel.
+		$this->assertSame('pfblockerng-edge', $cache['repo'], 'latest must be read from the INSTALLED repo, not a channel->repo mapping');
+		$this->assertSame('edge', $cache['channel'], 'channel must follow the installed repo, not the channel-less package name');
+		$this->assertSame($this->readCache(), $cache, 'the on-disk cache carries the same repo/channel');
+		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'after: exactly one notice');
+		$this->assertStringContainsString('3.2.0_9 available (edge)', $GLOBALS['pfb_test_file_notices'][0]['notice']);
+	}
+
+	/**
+	 * The name-FALLBACK half of the same rule. Given a legacy '-devel' install whose origin
+	 * is the LEGACY SHARED repo 'pfblockerng' (which carries two package identities, so the
+	 * repo cannot name a channel),
+	 * When the check runs,
+	 * Then latest is read from that shared repo and the channel falls back to the package
+	 * name — 'devel', unchanged. Pairs with the edge case above so repo-first is proven a
+	 * real branch rather than a blanket repo-only rule that would break legacy boxes.
+	 */
+	public function testLegacySharedRepoFallsBackToPackageNameChannel(): void
+	{
+		$this->setCheck('on');
+		$this->assertNull($this->readCache(), 'before: no cache file');
+
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG-devel',
+			'installed'      => '3.2.0_1',
+			'installed_repo' => 'pfblockerng',
+			'provenance_ok'  => TRUE,
+			'latest'         => '3.2.0_9',
+		]);
+
+		$this->assertSame('pfblockerng', $cache['repo'], 'the legacy shared repo is still the repo read');
+		$this->assertSame('devel', $cache['channel'], 'the legacy shared repo names no channel -> fall back to the package name');
+		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'after: exactly one notice');
+		$this->assertStringContainsString('3.2.0_9 available (devel)', $GLOBALS['pfb_test_file_notices'][0]['notice']);
+	}
+
+	/**
+	 * Transition proof for a NIGHTLY subscriber that moved onto the stable catalogue while
+	 * keeping the canonical identity.
+	 *
+	 * BEFORE: origin 'pfblockerng-nightly' -> cache channel 'nightly', repo read = nightly.
+	 * AFTER:  same package name, origin now 'pfblockerng-stable' -> channel 'stable', repo
+	 *         read = the stable catalogue.
+	 * Green proves the repo string (not the package name, which never changed) drives both.
+	 */
+	public function testChannelAndRepoFollowARepositorySwitch(): void
+	{
+		$this->setCheck('on');
+
+		// BEFORE: subscribed to the nightly catalogue.
+		$before = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG',
+			'installed'      => '3.2.0_1',
+			'installed_repo' => 'pfblockerng-nightly',
+			'provenance_ok'  => TRUE,
+			'latest'         => '3.2.0_9',
+		]);
+		$this->assertSame('nightly', $before['channel'], 'before: nightly catalogue names the channel');
+		$this->assertSame('pfblockerng-nightly', $before['repo'], 'before: nightly catalogue is the repo read');
+
+		// AFTER: the very same package name, now recorded against the stable catalogue.
+		$after = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG',
+			'installed'      => '3.2.0_1',
+			'installed_repo' => 'pfblockerng-stable',
+			'provenance_ok'  => TRUE,
+			'latest'         => '3.2.0_9',
+		]);
+		$this->assertSame('stable', $after['channel'], 'after: the repo switch moved the reported channel');
+		$this->assertSame('pfblockerng-stable', $after['repo'], 'after: latest is read from the new catalogue');
+	}
+
+	/**
+	 * The cache-reuse scope must follow the REPO too, not just the package name (#2148).
+	 *
+	 * Pre-cutover the cached latest/last_notified were reused whenever the installed NAME
+	 * matched — safe while each channel had its own name. Now all four catalogues publish
+	 * the SAME canonical identity, so a catalogue switch keeps the name identical and the
+	 * name-only scope would carry the OLD catalogue's version across.
+	 *
+	 * Given a cache written for the canonical package on the EDGE catalogue (latest
+	 *       3.2.0_99, already notified),
+	 * When the box is now recorded against the STABLE catalogue and the live read is
+	 *      unavailable (pkg locked, no injected latest),
+	 * Then the edge latest is NOT served as stable's, and the de-dupe state is reset so the
+	 *      first genuine stable notice is not swallowed.
+	 */
+	public function testCatalogueSwitchUnderOneNameDoesNotReuseStaleCache(): void
+	{
+		// Given: a prior tick on the edge catalogue announced 3.2.0_99.
+		$this->setCheck('on');
+		pfb_software_write_cache([
+			'pkgname'       => 'pfSense-pkg-pfBlockerNG',
+			'repo'          => 'pfblockerng-edge',
+			'channel'       => 'edge',
+			'installed'     => '3.2.0_1',
+			'latest'        => '3.2.0_99',
+			'last_checked'  => 100,
+			'last_notified' => '3.2.0_99',
+		]);
+		$before = $this->readCache();
+		$this->assertSame('3.2.0_99', $before['latest'], 'before: the edge catalogue latest is cached');
+		$this->assertSame('pfSense-pkg-pfBlockerNG', $before['pkgname'], 'before: cached under the canonical name the new catalogue also uses');
+
+		// When: same canonical name, now on the stable catalogue, live read unavailable.
+		$GLOBALS['pfb_test_pkg_locked'] = true;
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG',
+			'installed'      => '3.2.0_1',
+			'installed_repo' => 'pfblockerng-stable',
+			'provenance_ok'  => TRUE,
+			// no 'latest' -> the guarded live read returns '' (pkg locked).
+		]);
+
+		// Then: nothing from the edge catalogue leaks into the stable cache.
+		$this->assertSame('stable', $cache['channel'], 'after: cache rekeyed to the stable catalogue');
+		$this->assertSame('', (string) ($cache['latest'] ?? ''), "after: edge's latest must NOT be served as stable's");
+		$this->assertSame('', (string) ($cache['last_notified'] ?? ''), 'after: de-dupe state reset for the new catalogue');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: no notice (no known latest yet)');
 	}
 
 	/*

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversFunction('pfb_channel_from_pkgname')]
 #[CoversFunction('pfb_channel_from_repo_name')]
+#[CoversFunction('pfb_channel_for_install')]
+#[CoversFunction('pfb_software_cache_matches_repo')]
 #[CoversFunction('pfb_software_is_our_build')]
 #[CoversFunction('pfb_update_available')]
 #[CoversFunction('pfb_software_check_enabled')]
@@ -85,6 +87,69 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	public function testChannelFromRepoName(?string $repo, ?string $expected): void
 	{
 		$this->assertSame($expected, pfb_channel_from_repo_name($repo));
+	}
+
+	/*
+	 * ---- pfb_channel_for_install() — the ONE derivation both callers use (issue #2148) ----
+	 * The Software page label and the cron notice text must never disagree about what
+	 * channel a box is on, so the repo-first/name-fallback composition lives in one
+	 * function rather than as a repeated expression at each call site. Pinned here on all
+	 * three outcomes: the repo decides when it names a channel, the name decides when the
+	 * repo is the legacy shared catalogue (or is absent, as on a sideloaded `pkg add`),
+	 * and neither recognising the install yields null for the caller to render 'unknown'.
+	 */
+	public static function channelForInstallProvider(): array
+	{
+		return [
+			// The repo WINS over the name: this is the whole point of the cutover — the
+			// canonical identity lives in every catalogue, so the name would say 'stable'.
+			'edge catalogue beats the canonical name' => ['pfblockerng-edge', 'pfSense-pkg-pfBlockerNG', 'edge'],
+			'testing catalogue beats the name'        => ['pfblockerng-testing', 'pfSense-pkg-pfBlockerNG', 'testing'],
+			// Legacy shared repo: it names no channel, so the NAME still discriminates.
+			'legacy repo falls back to -devel'        => ['pfblockerng', 'pfSense-pkg-pfBlockerNG-devel', 'devel'],
+			'legacy repo falls back to canonical'     => ['pfblockerng', 'pfSense-pkg-pfBlockerNG', 'stable'],
+			// A sideloaded `pkg add` records no repo at all — the Tier-A deploy's case.
+			'no repo falls back to the name'          => ['', 'pfSense-pkg-pfBlockerNG-nightly', 'nightly'],
+			'null repo falls back to the name'        => [null, 'pfSense-pkg-pfBlockerNG', 'stable'],
+			// Neither half recognises it: a Netgate or hand-built package.
+			'netgate repo, foreign name -> null'      => ['pfSense', 'pfSense-pkg-suricata', null],
+			'unknown repo, unknown name -> null'      => ['whatever', '', null],
+		];
+	}
+
+	#[DataProvider('channelForInstallProvider')]
+	public function testChannelForInstall(?string $repo, ?string $pkgname, ?string $expected): void
+	{
+		$this->assertSame($expected, pfb_channel_for_install($repo, $pkgname));
+	}
+
+	/*
+	 * ---- pfb_software_cache_matches_repo() — is this cache still ours? (issue #2148) ----
+	 * Two consumers ask it: the cron orchestrator, deciding whether cached
+	 * latest/last_notified may be REUSED, and the Software page, deciding whether cached
+	 * latest/last-checked/status may be DISPLAYED. They must answer identically — the
+	 * orchestrator's rescope lands only on the next tick, so a page using a looser rule
+	 * would pair the new channel's label with the previous catalogue's version in between.
+	 * A cache with NO repo key predates the scope and is adopted, not discarded: that is
+	 * every existing box exactly once, and discarding it re-notifies an announced version.
+	 */
+	public static function cacheMatchesRepoProvider(): array
+	{
+		return [
+			'same catalogue'                  => [['repo' => 'pfblockerng-edge'], 'pfblockerng-edge', TRUE],
+			'different catalogue'             => [['repo' => 'pfblockerng-stable'], 'pfblockerng-edge', FALSE],
+			'legacy repo vs a channel repo'   => [['repo' => 'pfblockerng'], 'pfblockerng-stable', FALSE],
+			'pre-#2148 cache: no repo key'    => [['pkgname' => 'pfSense-pkg-pfBlockerNG'], 'pfblockerng', TRUE],
+			'empty cache: nothing recorded'   => [[], 'pfblockerng-edge', TRUE],
+			'recorded empty vs a real repo'   => [['repo' => ''], 'pfblockerng-edge', FALSE],
+			'recorded empty vs empty (sideload)' => [['repo' => ''], '', TRUE],
+		];
+	}
+
+	#[DataProvider('cacheMatchesRepoProvider')]
+	public function testCacheMatchesRepo(array $cache, string $repo, bool $expected): void
+	{
+		$this->assertSame($expected, pfb_software_cache_matches_repo($cache, $repo));
 	}
 
 	/*

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_channel_from_pkgname')]
 #[CoversFunction('pfb_channel_from_repo_name')]
 #[CoversFunction('pfb_channel_for_install')]
-#[CoversFunction('pfb_software_cache_matches_repo')]
+#[CoversFunction('pfb_software_cache_matches_install')]
 #[CoversFunction('pfb_software_is_our_build')]
 #[CoversFunction('pfb_update_available')]
 #[CoversFunction('pfb_software_check_enabled')]
@@ -124,32 +124,46 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	}
 
 	/*
-	 * ---- pfb_software_cache_matches_repo() — is this cache still ours? (issue #2148) ----
-	 * Two consumers ask it: the cron orchestrator, deciding whether cached
-	 * latest/last_notified may be REUSED, and the Software page, deciding whether cached
-	 * latest/last-checked/status may be DISPLAYED. They must answer identically — the
-	 * orchestrator's rescope lands only on the next tick, so a page using a looser rule
-	 * would pair the new channel's label with the previous catalogue's version in between.
-	 * A cache with NO repo key predates the scope and is adopted, not discarded: that is
+	 * ---- pfb_software_cache_matches_install() — is this cache still ours? (#2148) ----
+	 * Two consumers ask it, and must ask the WHOLE of it: the cron orchestrator, deciding
+	 * whether cached latest/last_notified may be REUSED, and the Software page, deciding
+	 * whether cached latest/last-checked/status may be DISPLAYED. They must answer
+	 * identically — the orchestrator's rescope lands only on the next tick, so a page
+	 * asking a looser question pairs the current install's label with the previous one's
+	 * version and verdict in between.
+	 *
+	 * Both halves matter because either can change alone: a channel switch keeps the
+	 * canonical NAME and changes the repo, while an identity swap inside the legacy
+	 * shared catalogue (canonical <-> -devel) keeps the REPO and changes the name.
+	 *
+	 * A cache with no repo key predates the scope and is adopted, not discarded: that is
 	 * every existing box exactly once, and discarding it re-notifies an announced version.
 	 */
-	public static function cacheMatchesRepoProvider(): array
+	public static function cacheMatchesInstallProvider(): array
 	{
+		$canonical = 'pfSense-pkg-pfBlockerNG';
+		$devel = 'pfSense-pkg-pfBlockerNG-devel';
 		return [
-			'same catalogue'                  => [['repo' => 'pfblockerng-edge'], 'pfblockerng-edge', TRUE],
-			'different catalogue'             => [['repo' => 'pfblockerng-stable'], 'pfblockerng-edge', FALSE],
-			'legacy repo vs a channel repo'   => [['repo' => 'pfblockerng'], 'pfblockerng-stable', FALSE],
-			'pre-#2148 cache: no repo key'    => [['pkgname' => 'pfSense-pkg-pfBlockerNG'], 'pfblockerng', TRUE],
-			'empty cache: nothing recorded'   => [[], 'pfblockerng-edge', TRUE],
-			'recorded empty vs a real repo'   => [['repo' => ''], 'pfblockerng-edge', FALSE],
-			'recorded empty vs empty (sideload)' => [['repo' => ''], '', TRUE],
+			// Repo half.
+			'same install'                => [['pkgname' => $canonical, 'repo' => 'pfblockerng-edge'], $canonical, 'pfblockerng-edge', TRUE],
+			'channel switch'              => [['pkgname' => $canonical, 'repo' => 'pfblockerng-stable'], $canonical, 'pfblockerng-edge', FALSE],
+			'legacy repo vs channel repo' => [['pkgname' => $canonical, 'repo' => 'pfblockerng'], $canonical, 'pfblockerng-stable', FALSE],
+			'recorded empty vs a repo'    => [['pkgname' => $canonical, 'repo' => ''], $canonical, 'pfblockerng-edge', FALSE],
+			'sideload: both empty'        => [['pkgname' => $canonical, 'repo' => ''], $canonical, '', TRUE],
+			// Name half — the in-repo identity swap the legacy shared catalogue allows.
+			'identity swap, same repo'    => [['pkgname' => $devel, 'repo' => 'pfblockerng'], $canonical, 'pfblockerng', FALSE],
+			'identity swap, no repo key'  => [['pkgname' => $devel], $canonical, 'pfblockerng', FALSE],
+			// Pre-#2148 caches carry a name but no repo: adopted on the repo half.
+			'pre-#2148 cache'             => [['pkgname' => $canonical], $canonical, 'pfblockerng', TRUE],
+			// A cache that names no install describes none.
+			'empty cache'                 => [[], $canonical, 'pfblockerng-edge', FALSE],
 		];
 	}
 
-	#[DataProvider('cacheMatchesRepoProvider')]
-	public function testCacheMatchesRepo(array $cache, string $repo, bool $expected): void
+	#[DataProvider('cacheMatchesInstallProvider')]
+	public function testCacheMatchesInstall(array $cache, string $pkgname, string $repo, bool $expected): void
 	{
-		$this->assertSame($expected, pfb_software_cache_matches_repo($cache, $repo));
+		$this->assertSame($expected, pfb_software_cache_matches_install($cache, $pkgname, $repo));
 	}
 
 	/*

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  * before-state asserted at each tick so green proves the transition CAUSED the flip.
  */
 #[CoversFunction('pfb_channel_from_pkgname')]
-#[CoversFunction('pfb_pkg_repo_name_for_channel')]
+#[CoversFunction('pfb_channel_from_repo_name')]
 #[CoversFunction('pfb_software_is_our_build')]
 #[CoversFunction('pfb_update_available')]
 #[CoversFunction('pfb_software_check_enabled')]
@@ -55,44 +55,59 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	}
 
 	/*
-	 * ---- pfb_pkg_repo_name_for_channel() — channel -> our repo to read latest from ----
-	 * 2026-06-14 + 2026-06-15 amendments: stable AND devel share ONE repo 'pfblockerng'
-	 * (the channel selects the package, not a per-channel repo); 'nightly' is the sole
-	 * separately-channelled build, repo 'pfblockerng-nightly'. Unknown channel -> null.
+	 * ---- pfb_channel_from_repo_name() — installed repo -> channel (issue #2148) ----
+	 * Four-channel cutover: every channel catalogue publishes the ONE canonical identity
+	 * 'pfSense-pkg-pfBlockerNG', so the NAME can no longer say which channel a box is on —
+	 * the repository it was installed from (`pkg query %R`) is authoritative. Each of the
+	 * four per-channel repos maps to its channel; the LEGACY shared 'pfblockerng' repo maps
+	 * to null ON PURPOSE (it carries both the stable and -devel identities, so there the
+	 * name still discriminates and the caller must fall back to pfb_channel_from_pkgname()).
+	 * A foreign repo, '', null and a near-miss like 'pfblockerng-edgey' are all null: an
+	 * unknown catalogue must never be read as a channel.
 	 */
-	public static function repoForChannelProvider(): array
+	public static function channelFromRepoNameProvider(): array
 	{
 		return [
-			'stable -> shared pfblockerng'  => ['stable', 'pfblockerng'],
-			'devel -> shared pfblockerng'   => ['devel', 'pfblockerng'],
-			'testing -> shared pfblockerng' => ['testing', 'pfblockerng'],
-			'edge -> shared pfblockerng'    => ['edge', 'pfblockerng'],
-			'nightly -> pfblockerng-nightly' => ['nightly', 'pfblockerng-nightly'],
-			'unknown channel -> null'        => ['beta', null],
-			'null channel -> null'           => [null, null],
+			'stable catalogue'            => ['pfblockerng-stable', 'stable'],
+			'testing catalogue'           => ['pfblockerng-testing', 'testing'],
+			'edge catalogue'              => ['pfblockerng-edge', 'edge'],
+			'nightly catalogue'           => ['pfblockerng-nightly', 'nightly'],
+			'legacy shared repo -> null'  => ['pfblockerng', null],
+			'near-miss suffix -> null'    => ['pfblockerng-edgey', null],
+			'foreign prefix -> null'      => ['other-pfblockerng-edge', null],
+			'netgate repo -> null'        => ['pfSense', null],
+			'empty repo -> null'          => ['', null],
+			'null repo -> null'           => [null, null],
 		];
 	}
 
-	#[DataProvider('repoForChannelProvider')]
-	public function testRepoNameForChannel(?string $channel, ?string $expected): void
+	#[DataProvider('channelFromRepoNameProvider')]
+	public function testChannelFromRepoName(?string $repo, ?string $expected): void
 	{
-		$this->assertSame($expected, pfb_pkg_repo_name_for_channel($channel));
+		$this->assertSame($expected, pfb_channel_from_repo_name($repo));
 	}
 
 	/*
-	 * ---- pfb_software_is_our_build() — the provenance gate (2026-06-15) ----
-	 * TRUE only for a build installed FROM one of OUR repos ('pfblockerng' /
-	 * 'pfblockerng-nightly', the `pkg query %R` origin). A Netgate-installed add-on
-	 * (repo 'pfSense'), an empty/'unknown' origin, or anything else -> FALSE. Both sides
-	 * pinned: this single predicate gates the tab, the page guard, the priv match[] line,
-	 * AND the cron notice, so a false positive would leak the whole feature onto a stock
-	 * build and a false negative would hide it from our users.
+	 * ---- pfb_software_is_our_build() — the provenance gate (2026-06-15, widened #2148) ----
+	 * TRUE only for a build installed FROM one of OUR repos — the `pkg query %R` origin.
+	 * Issue #2148 made that FIVE repos: the legacy shared 'pfblockerng' (stable + the
+	 * retired -devel identity) plus the four per-channel catalogues
+	 * 'pfblockerng-stable|-testing|-edge|-nightly'. A box subscribed to any of the new
+	 * catalogues must keep the Software tab, the priv match[] line and the update notice;
+	 * before the widening they all read as NOT-our-build and silently lost the feature.
+	 * A Netgate-installed add-on (repo 'pfSense'), an empty/'unknown' origin, or anything
+	 * else -> FALSE. Both sides pinned: this single predicate gates the tab, the page
+	 * guard, the priv match[] line, AND the cron notice, so a false positive would leak
+	 * the whole feature onto a stock build and a false negative would hide it from ours.
 	 */
 	public static function provenanceProvider(): array
 	{
 		return [
 			// Ours -> present.
-			'ours: pfblockerng (stable+devel)'   => ['pfblockerng', true],
+			'ours: legacy pfblockerng (stable+devel)' => ['pfblockerng', true],
+			'ours: pfblockerng-stable'           => ['pfblockerng-stable', true],
+			'ours: pfblockerng-testing'          => ['pfblockerng-testing', true],
+			'ours: pfblockerng-edge'             => ['pfblockerng-edge', true],
 			'ours: pfblockerng-nightly'          => ['pfblockerng-nightly', true],
 			// Not ours -> absent.
 			'netgate: pfSense repo'              => ['pfSense', false],
@@ -100,6 +115,7 @@ final class SoftwareUpdateDecisionTest extends TestCase
 			'literal unknown'                    => ['unknown', false],
 			'null origin'                        => [null, false],
 			'foreign repo'                       => ['netgate-decoy', false],
+			'near-miss catalogue'                => ['pfblockerng-edgey', false],
 		];
 	}
 

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -982,6 +982,26 @@
             }
         ]
     },
+    "pfb_channel_for_install": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            },
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
     "pfb_channel_from_pkgname": {
         "returnsRef": false,
         "returnType": "?string",
@@ -9381,6 +9401,26 @@
         "returnsRef": false,
         "returnType": "string",
         "params": []
+    },
+    "pfb_software_cache_matches_repo": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "cache",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
     },
     "pfb_software_check_enabled": {
         "returnsRef": false,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -9402,7 +9402,7 @@
         "returnType": "string",
         "params": []
     },
-    "pfb_software_cache_matches_repo": {
+    "pfb_software_cache_matches_install": {
         "returnsRef": false,
         "returnType": "bool",
         "params": [
@@ -9411,6 +9411,13 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "array",
+                "default": null
+            },
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
                 "default": null
             },
             {

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -995,6 +995,19 @@
             }
         ]
     },
+    "pfb_channel_from_repo_name": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
     "pfb_cidr_subtract_v6": {
         "returnsRef": false,
         "returnType": "array",
@@ -8502,19 +8515,6 @@
         "returnsRef": false,
         "returnType": "string",
         "params": []
-    },
-    "pfb_pkg_repo_name_for_channel": {
-        "returnsRef": false,
-        "returnType": "?string",
-        "params": [
-            {
-                "name": "channel",
-                "byRef": false,
-                "variadic": false,
-                "type": "?string",
-                "default": null
-            }
-        ]
     },
     "pfb_pkg_ver": {
         "returnsRef": false,

--- a/tests/shell/generate_hook_spec.sh
+++ b/tests/shell/generate_hook_spec.sh
@@ -56,11 +56,14 @@ EOF
 }
 
 # Stand up a stubbed box in dir $1: product_label=$2, version=$3.
-# Exports every PFB_* override the hook reads. A logging `pkg` stub is placed
-# on PATH so a BARE `pkg` invocation is caught — the hook has no PFB_PKG_BIN-
-# style override to intercept separately, and calls it under no mechanism at
-# all (issue #1806) — pure regression guard. Conf files are NOT created here —
-# each example stages the conf(s) it wants the hook to (not) regenerate.
+# Exports every PFB_* override the hook reads — ALL FIVE conf paths, because an
+# override the spec omits falls back to its /usr/local/etc/pkg/repos/ default and
+# the hook would then regenerate the REAL box's conf mid-suite. A logging `pkg`
+# stub is placed on PATH so a BARE `pkg` invocation is caught — the hook has no
+# PFB_PKG_BIN-style override to intercept separately, and calls it under no
+# mechanism at all (issue #1806) — pure regression guard. Conf files are NOT
+# created here — each example stages the conf(s) it wants the hook to (not)
+# regenerate.
 _make_box() {
     _mb_dir="$1"
     mkdir -p "${_mb_dir}/repos" "${_mb_dir}/bin"
@@ -69,21 +72,27 @@ _make_box() {
     _make_pkg_stub "${_mb_dir}/bin/pkg"
 
     PFB_RELEASE_CONF="${_mb_dir}/repos/pfblockerng.conf"
+    PFB_STABLE_CONF="${_mb_dir}/repos/pfblockerng-stable.conf"
+    PFB_TESTING_CONF="${_mb_dir}/repos/pfblockerng-testing.conf"
+    PFB_EDGE_CONF="${_mb_dir}/repos/pfblockerng-edge.conf"
     PFB_NIGHTLY_CONF="${_mb_dir}/repos/pfblockerng-nightly.conf"
     PFB_PRODUCT_LABEL="${_mb_dir}/product_label"
     PFB_VERSION_FILE="${_mb_dir}/version"
     PKG_STUB_LOG="${_mb_dir}/pkg_calls.log"
     PATH="${_mb_dir}/bin:${PATH}"
-    export PFB_RELEASE_CONF PFB_NIGHTLY_CONF PFB_PRODUCT_LABEL PFB_VERSION_FILE \
-           PKG_STUB_LOG PATH
+    export PFB_RELEASE_CONF PFB_STABLE_CONF PFB_TESTING_CONF PFB_EDGE_CONF \
+           PFB_NIGHTLY_CONF PFB_PRODUCT_LABEL PFB_VERSION_FILE PKG_STUB_LOG PATH
 }
 
 _unset_box() {
-    unset PFB_RELEASE_CONF PFB_NIGHTLY_CONF PFB_PRODUCT_LABEL PFB_VERSION_FILE \
-          PKG_STUB_LOG
+    unset PFB_RELEASE_CONF PFB_STABLE_CONF PFB_TESTING_CONF PFB_EDGE_CONF \
+          PFB_NIGHTLY_CONF PFB_PRODUCT_LABEL PFB_VERSION_FILE PKG_STUB_LOG
 }
 
-# ── ORPHAN: neither conf present → nothing written, pkg never invoked ──────────
+# How many conf files the box currently carries — the single-subscription oracle.
+_conf_count() { ls -1 "$1"/repos | wc -l | tr -d ' '; }
+
+# ── ORPHAN: no conf present → nothing written, pkg never invoked ───────────────
 
 Describe 'generate hook — orphan: no conf present'
     setup() {
@@ -94,19 +103,141 @@ Describe 'generate hook — orphan: no conf present'
     Before 'setup'
     After  'cleanup'
 
-    It 'before-state: neither conf exists'
-      The path "${PFB_RELEASE_CONF}" should not be exist
-      The path "${PFB_NIGHTLY_CONF}" should not be exist
+    It 'before-state: no channel conf exists'
+      The value "$(_conf_count "${_o_dir}")" should equal 0
     End
 
     It 'writes nothing, never invokes pkg, and exits 0'
       When run sh "${HOOK}" onestart
       The status should be success
-      The path "${PFB_RELEASE_CONF}" should not be exist
-      The path "${PFB_NIGHTLY_CONF}" should not be exist
+      The value "$(_conf_count "${_o_dir}")" should equal 0
       # The orphan guard returns before detection, and detection itself never
       # touches pkg (arch-less; issue #1806).
       The path "${PKG_STUB_LOG}" should not be exist
+    End
+End
+
+# ── PER-CHANNEL REGENERATION (issue #2148) ────────────────────────────────────
+#
+# Before #2148 the hook knew only the legacy release conf and nightly, so a box
+# subscribed to stable/testing/edge kept a stale <varver> forever after a pfSense
+# OS upgrade. Each channel now regenerates from the same canonical body, and the
+# orphan guard still holds per channel so regeneration can never re-enable a
+# channel the user switched away from (single-repository subscription).
+
+Describe 'generate hook — regenerate the stable conf (CE)'
+    setup() {
+        _st_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_stable.XXXXXX")"
+        _make_box "${_st_dir}" "pfSense" "2.8.1"
+        printf '# stub pending\n' > "${PFB_STABLE_CONF}"
+    }
+    cleanup() { rm -rf "${_st_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: only the stable conf exists, and it is the unresolved stub'
+      The contents of file "${PFB_STABLE_CONF}" should include "pending"
+      The value "$(_conf_count "${_st_dir}")" should equal 1
+    End
+
+    It 'resolves the stable catalogue and keeps every other channel unsubscribed'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_STABLE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/stable/ce-2.8"'
+      The contents of file "${PFB_STABLE_CONF}" should include "pfblockerng-stable: {"
+      The contents of file "${PFB_STABLE_CONF}" should include "stable channel"
+      The contents of file "${PFB_STABLE_CONF}" should not include "pending"
+      The value "$(_conf_count "${_st_dir}")" should equal 1
+    End
+End
+
+Describe 'generate hook — regenerate the testing conf (Plus)'
+    setup() {
+        _te_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_testing.XXXXXX")"
+        _make_box "${_te_dir}" "pfSense Plus" "26.03.1"
+        printf '# stub pending\n' > "${PFB_TESTING_CONF}"
+    }
+    cleanup() { rm -rf "${_te_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: only the testing conf exists, and it is the unresolved stub'
+      The contents of file "${PFB_TESTING_CONF}" should include "pending"
+      The value "$(_conf_count "${_te_dir}")" should equal 1
+    End
+
+    It 'resolves the Plus testing catalogue and keeps every other channel unsubscribed'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_TESTING_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/testing/plus-26.03"'
+      The contents of file "${PFB_TESTING_CONF}" should include "pfblockerng-testing: {"
+      The value "$(_conf_count "${_te_dir}")" should equal 1
+    End
+End
+
+Describe 'generate hook — regenerate the edge conf across a pfSense OS upgrade'
+    # The upgrade case is the whole reason the hook runs at boot: the box moved
+    # from CE 2.7 to CE 2.8, so the edge subscription must follow to the new
+    # varver instead of pointing at a catalogue that no longer receives builds.
+    setup() {
+        _ed_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_edge.XXXXXX")"
+        _make_box "${_ed_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_EDGE_CONF}" <<'STALE'
+# Generated at boot by pfblockerng_repo_generate (ADR-39)
+pfblockerng-edge: {
+  url: "https://pfblockerng.github.io/pkg/edge/ce-2.7",
+  enabled: yes
+}
+STALE
+    }
+    cleanup() { rm -rf "${_ed_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the edge conf still points at the pre-upgrade ce-2.7 catalogue'
+      The contents of file "${PFB_EDGE_CONF}" should include "edge/ce-2.7"
+      The contents of file "${PFB_EDGE_CONF}" should not include "edge/ce-2.8"
+    End
+
+    It 'rewrites the edge conf to the box current varver, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_EDGE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/edge/ce-2.8"'
+      The contents of file "${PFB_EDGE_CONF}" should not include "ce-2.7"
+      The path "${PKG_STUB_LOG}" should not be exist
+    End
+End
+
+Describe 'generate hook — a subscribed channel never re-enables the one it replaced'
+    # Single-repository subscription (issue #2148): the user switched from the
+    # legacy release repo to edge. Boot regeneration must not resurrect release.
+    setup() {
+        _sw_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_switch.XXXXXX")"
+        _make_box "${_sw_dir}" "pfSense" "2.8.1"
+        printf '# stub pending\n' > "${PFB_EDGE_CONF}"
+    }
+    cleanup() { rm -rf "${_sw_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: edge is the only subscription; the legacy release conf is gone'
+      The path "${PFB_EDGE_CONF}" should be exist
+      The path "${PFB_RELEASE_CONF}" should not be exist
+    End
+
+    It 'regenerates edge alone and leaves release, stable, testing and nightly absent'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_EDGE_CONF}" should include "pfblockerng-edge: {"
+      The path "${PFB_RELEASE_CONF}" should not be exist
+      The path "${PFB_STABLE_CONF}" should not be exist
+      The path "${PFB_TESTING_CONF}" should not be exist
+      The path "${PFB_NIGHTLY_CONF}" should not be exist
+      The value "$(_conf_count "${_sw_dir}")" should equal 1
     End
 End
 

--- a/tests/shell/migrate_channel_spec.sh
+++ b/tests/shell/migrate_channel_spec.sh
@@ -1,0 +1,609 @@
+#shellcheck shell=sh
+# migrate-channel.sh — move an installed pfBlockerNG onto one of the four pkg
+# channels (issue #2148).
+#
+# WHY A PROGRAMMABLE pkg STUB: every behaviour worth pinning here is a decision
+# about pkg STATE — which identity is installed, which repo it came from, what the
+# target catalogue offers, and what the box looks like afterwards. A stub that only
+# logged its arguments could prove the script CALLED something; it could not prove
+# the script refuses to mutate a box it cannot verify, or that a downgrade actually
+# lands the older version. So the stub below keeps real state in three tab-separated
+# files (installed / catalog / payload) and mutates it, and the examples assert the
+# resulting state, not the command line.
+#
+# Behavioural contracts pinned here:
+#   usage        — --channel is mandatory; `release`, an unknown name and a
+#                  wrong-case name are all rejected (exit 2) with pkg never invoked.
+#   pre-flight   — an unsubscribed target, or a second project conf still on the
+#                  box, fails (exit 4) BEFORE pkg is invoked at all.
+#   inventory    — none / more than one / an unrecognised pfBlockerNG identity
+#                  fails (exit 3) before any mutation.
+#   availability — a target catalogue that does not offer the canonical package
+#                  fails (exit 4) with the installed package untouched.
+#   no-op        — canonical already on the target repo reports and mutates nothing.
+#   legacy       — a suffixed identity (-devel, and the historical -NIGHTLY
+#                  spelling) is deleted and replaced by the canonical package from
+#                  the target repo.
+#   reverse      — a repository-qualified `install -f` lands an OLDER version when
+#                  moving to a slower channel.
+#   verification — a mutation that leaves the wrong repo, an incomplete payload, or
+#                  a lost config section fails (exit 6) instead of reporting success.
+#
+# Before-and-after mandate (CLAUDE.md): every migrating example asserts the
+# installed identity/version/repo BEFORE the run, so green proves the migration
+# caused the change rather than merely matching a pre-existing state.
+#
+# Tip: run with `shellspec tests/shell/migrate_channel_spec.sh` from the repo root.
+
+SCRIPT="${PFB_ROOT}/scripts/migrate-channel.sh"
+
+TAB="$(printf '\t')"
+
+# ── the programmable pkg stub ─────────────────────────────────────────────────
+#
+# State files under $PFB_STUB_DIR:
+#   installed  name<TAB>version<TAB>repo   — the box's installed packages
+#   catalog    repo<TAB>name<TAB>version   — what each repo offers
+#   payload    absolute path per line      — the canonical package's file manifest
+#   calls.log  one line per invocation     — created only when pkg is actually run
+#
+# Knobs (env, all optional): PFB_STUB_FAIL_INSTALL, PFB_STUB_FAIL_DELETE,
+# PFB_STUB_INSTALL_REPO (land in a different repo than requested),
+# PFB_STUB_SKIP_PAYLOAD (a manifest path install deliberately does not create),
+# PFB_STUB_DROP_CONFIG (install wipes the config section).
+_write_pkg_stub() {
+    cat > "$1" <<'STUB'
+#!/bin/sh
+set -u
+_d="${PFB_STUB_DIR}"
+_root="${PFBLOCKERNG_ROOT%/}"
+printf '%s\n' "$*" >> "${_d}/calls.log"
+_tab="$(printf '\t')"
+
+_field() { # _field <file> <key-col> <key> <want-col>
+    awk -F"${_tab}" -v k="$3" -v kc="$2" -v wc="$4" '$kc == k { print $wc; found=1 } END { exit !found }' "$1"
+}
+
+_cmd="$1"; shift
+case "${_cmd}" in
+query)
+    if [ "$1" = "-g" ]; then
+        shift
+        _prefix="${2%\*}"
+        awk -F"${_tab}" -v p="${_prefix}" 'index($1, p) == 1 { print $1; found=1 } END { exit !found }' "${_d}/installed"
+        exit $?
+    fi
+    case "$1" in
+    '%R') _field "${_d}/installed" 1 "$2" 3 ;;
+    '%v') _field "${_d}/installed" 1 "$2" 2 ;;
+    *) exit 64 ;;
+    esac
+    exit $?
+    ;;
+rquery)
+    [ "$1" = "-r" ] || exit 64
+    _repo="$2"; shift 2
+    [ "$1" = '%v' ] || exit 64
+    awk -F"${_tab}" -v r="${_repo}" -v n="$2" '$1 == r && $2 == n { print $3; found=1 } END { exit !found }' "${_d}/catalog"
+    exit $?
+    ;;
+delete)
+    [ "${PFB_STUB_FAIL_DELETE:-0}" = "1" ] && exit 1
+    shift # -y
+    awk -F"${_tab}" -v n="$1" '$1 != n' "${_d}/installed" > "${_d}/installed.new"
+    mv "${_d}/installed.new" "${_d}/installed"
+    exit 0
+    ;;
+install)
+    [ "${PFB_STUB_FAIL_INSTALL:-0}" = "1" ] && exit 1
+    while [ $# -gt 0 ]; do
+        case "$1" in
+        -f | -y) shift ;;
+        -r) _repo="$2"; shift 2 ;;
+        *) _name="$1"; shift ;;
+        esac
+    done
+    _ver="$(awk -F"${_tab}" -v r="${_repo}" -v n="${_name}" '$1 == r && $2 == n { print $3 }' "${_d}/catalog")"
+    [ -n "${_ver}" ] || exit 1
+    awk -F"${_tab}" -v n="${_name}" '$1 != n' "${_d}/installed" > "${_d}/installed.new"
+    printf '%s\t%s\t%s\n' "${_name}" "${_ver}" "${PFB_STUB_INSTALL_REPO:-${_repo}}" >> "${_d}/installed.new"
+    mv "${_d}/installed.new" "${_d}/installed"
+    while IFS= read -r _p; do
+        [ -n "${_p}" ] || continue
+        [ "${_p}" = "${PFB_STUB_SKIP_PAYLOAD:-}" ] && continue
+        mkdir -p "${_root}$(dirname "${_p}")"
+        : > "${_root}${_p}"
+    done < "${_d}/payload"
+    if [ "${PFB_STUB_DROP_CONFIG:-0}" = "1" ]; then
+        printf '<pfsense></pfsense>\n' > "${_root}/cf/conf/config.xml"
+    fi
+    exit 0
+    ;;
+info)
+    [ "$1" = "-l" ] || exit 64
+    _v="$(_field "${_d}/installed" 1 "$2" 2)" || exit 70
+    printf '%s-%s:\n' "$2" "${_v}"
+    while IFS= read -r _p; do
+        [ -n "${_p}" ] || continue
+        printf '\t%s\n' "${_p}"
+    done < "${_d}/payload"
+    exit 0
+    ;;
+*)
+    exit 64
+    ;;
+esac
+STUB
+    chmod +x "$1"
+}
+
+# Stand up a stubbed box in a fresh tmpdir. $1 = the conf(s) to place, as a
+# space-separated list of channel conf basenames. Installed packages, catalogue
+# rows and the payload manifest are seeded by the per-example helpers below.
+_make_box() {
+    _mb_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/migrate_ch.XXXXXX")"
+    mkdir -p "${_mb_dir}/usr/local/etc/pkg/repos" "${_mb_dir}/cf/conf" "${_mb_dir}/stub"
+    : > "${_mb_dir}/stub/installed"
+    : > "${_mb_dir}/stub/catalog"
+    : > "${_mb_dir}/stub/payload"
+    _write_pkg_stub "${_mb_dir}/stub/pkg"
+    printf '<pfsense><installedpackages><pfblockerng><enable>on</enable></pfblockerng></installedpackages></pfsense>\n' \
+        > "${_mb_dir}/cf/conf/config.xml"
+
+    BOX="${_mb_dir}"
+    PFBLOCKERNG_ROOT="${_mb_dir}"
+    PKG_BIN="${_mb_dir}/stub/pkg"
+    PFB_STUB_DIR="${_mb_dir}/stub"
+    export PFBLOCKERNG_ROOT PKG_BIN PFB_STUB_DIR
+    unset _mb_dir
+}
+
+_unset_box() {
+    unset PFBLOCKERNG_ROOT PKG_BIN PFB_STUB_DIR BOX \
+          PFB_STUB_FAIL_INSTALL PFB_STUB_FAIL_DELETE PFB_STUB_INSTALL_REPO \
+          PFB_STUB_SKIP_PAYLOAD PFB_STUB_DROP_CONFIG
+}
+
+_subscribe()   { : > "${BOX}/usr/local/etc/pkg/repos/pfblockerng-$1.conf"; }
+_legacy_conf() { : > "${BOX}/usr/local/etc/pkg/repos/pfblockerng.conf"; }
+_install()     { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "${PFB_STUB_DIR}/installed"; }
+_publish()     { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "${PFB_STUB_DIR}/catalog"; }
+_manifest()    { printf '%s\n' "$@" >> "${PFB_STUB_DIR}/payload"; }
+
+# The oracles the examples assert on.
+_installed_names()   { cut -f1 "${PFB_STUB_DIR}/installed" | tr '\n' ' ' | sed 's/ *$//'; }
+_installed_version() { awk -F"${TAB}" -v n="$1" '$1 == n { print $2 }' "${PFB_STUB_DIR}/installed"; }
+_installed_repo()    { awk -F"${TAB}" -v n="$1" '$1 == n { print $3 }' "${PFB_STUB_DIR}/installed"; }
+_pkg_calls()         { cat "${PFB_STUB_DIR}/calls.log" 2>/dev/null || true; }
+
+# ── USAGE: the target channel is explicit or the script refuses ───────────────
+#
+# There is deliberately no default: the whole point of the ticket is that a box
+# ends up on the channel its operator NAMED. A silent default would be the exact
+# "existing configured users are never silently moved" failure.
+
+Describe 'migrate-channel.sh — the target channel is mandatory and exact'
+    setup() { _make_box; _subscribe stable; }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'refuses to run with no --channel and never invokes pkg'
+      When run sh "${SCRIPT}"
+      The status should equal 2
+      The stderr should include "--channel is required"
+      The stderr should include "Usage:"
+      The path "${PFB_STUB_DIR}/calls.log" should not be exist
+    End
+
+    It 'rejects the legacy shared repo as a target'
+      When run sh "${SCRIPT}" --channel release
+      The status should equal 2
+      The stderr should include "'release' is the legacy shared repo"
+      The path "${PFB_STUB_DIR}/calls.log" should not be exist
+    End
+
+    It 'rejects a wrong-case channel rather than guessing'
+      When run sh "${SCRIPT}" --channel Stable
+      The status should equal 2
+      The stderr should include "unknown channel 'Stable'"
+    End
+
+    It 'rejects an unknown channel'
+      When run sh "${SCRIPT}" --channel devel
+      The status should equal 2
+      The stderr should include "unknown channel 'devel'"
+    End
+
+    It 'prints usage for --help without touching the box'
+      When run sh "${SCRIPT}" --help
+      The status should be success
+      The stdout should include "add-repo.sh --channel <ch>"
+      The path "${PFB_STUB_DIR}/calls.log" should not be exist
+    End
+End
+
+# ── PRE-FLIGHT: the repository configuration must already match ───────────────
+#
+# add-repo.sh owns repository configuration; this script owns the installed
+# package. Running them out of order is the mistake a user actually makes, so it
+# must fail loudly and BEFORE pkg is invoked — not half-way through a delete.
+
+Describe 'migrate-channel.sh — the box must already be subscribed to the target'
+    setup() { _make_box; _install "pfSense-pkg-pfBlockerNG-devel" "3.2.15" "pfblockerng"; _legacy_conf; }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the box carries the legacy identity and only the legacy conf'
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG-devel"
+      The path "${BOX}/usr/local/etc/pkg/repos/pfblockerng-edge.conf" should not be exist
+    End
+
+    It 'fails before invoking pkg when the target channel is not subscribed'
+      When run sh "${SCRIPT}" --channel edge
+      The status should equal 4
+      The stderr should include "not subscribed to the edge channel"
+      The stderr should include "add-repo.sh --channel edge"
+      The path "${PFB_STUB_DIR}/calls.log" should not be exist
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG-devel"
+    End
+End
+
+Describe 'migrate-channel.sh — exactly one project repository may be configured'
+    # A second enabled project repo is not untidiness: every project repo shares
+    # priority 100 and pkg does not order across equal-priority repositories, so
+    # whatever this script installs could be silently replaced on the next upgrade.
+    setup() {
+        _make_box
+        _subscribe testing
+        _legacy_conf
+        _install "pfSense-pkg-pfBlockerNG" "4.0.0" "pfblockerng"
+        _publish "pfblockerng-testing" "pfSense-pkg-pfBlockerNG" "4.0.1"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: both the testing conf and the legacy conf are present'
+      The path "${BOX}/usr/local/etc/pkg/repos/pfblockerng-testing.conf" should be exist
+      The path "${BOX}/usr/local/etc/pkg/repos/pfblockerng.conf" should be exist
+    End
+
+    It 'fails before invoking pkg and names the stray conf'
+      When run sh "${SCRIPT}" --channel testing
+      The status should equal 4
+      The stderr should include "another pfBlockerNG repository is still configured"
+      The stderr should include "pfblockerng.conf"
+      The path "${PFB_STUB_DIR}/calls.log" should not be exist
+      The value "$(_installed_repo pfSense-pkg-pfBlockerNG)" should equal "pfblockerng"
+    End
+End
+
+# ── INVENTORY: refuse any installed state the script cannot reason about ──────
+
+Describe 'migrate-channel.sh — nothing installed'
+    setup() { _make_box; _subscribe stable; _publish "pfblockerng-stable" "pfSense-pkg-pfBlockerNG" "4.0.0"; }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'reports that there is nothing to migrate and installs nothing'
+      When run sh "${SCRIPT}" --channel stable
+      The status should equal 3
+      The stderr should include "no pfBlockerNG package is installed"
+      The value "$(_installed_names)" should equal ""
+      The value "$(_pkg_calls)" should not include "install"
+    End
+End
+
+Describe 'migrate-channel.sh — a mixed installation'
+    setup() {
+        _make_box
+        _subscribe stable
+        _install "pfSense-pkg-pfBlockerNG" "4.0.0" "pfblockerng"
+        _install "pfSense-pkg-pfBlockerNG-devel" "3.2.15" "pfblockerng"
+        _publish "pfblockerng-stable" "pfSense-pkg-pfBlockerNG" "4.0.0"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'refuses to guess which one to keep, and mutates nothing'
+      When run sh "${SCRIPT}" --channel stable
+      The status should equal 3
+      The stderr should include "more than one pfBlockerNG package is installed"
+      The stderr should include "pfSense-pkg-pfBlockerNG-devel"
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG pfSense-pkg-pfBlockerNG-devel"
+      The value "$(_pkg_calls)" should not include "delete"
+    End
+End
+
+Describe 'migrate-channel.sh — an identity the project never shipped'
+    setup() {
+        _make_box
+        _subscribe stable
+        _install "pfSense-pkg-pfBlockerNG-fork" "9.9.9" "somewhere"
+        _publish "pfblockerng-stable" "pfSense-pkg-pfBlockerNG" "4.0.0"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'refuses to migrate a package whose configuration it cannot reason about'
+      When run sh "${SCRIPT}" --channel stable
+      The status should equal 3
+      The stderr should include "unrecognised pfBlockerNG identity"
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG-fork"
+      The value "$(_pkg_calls)" should not include "delete"
+    End
+End
+
+# ── AVAILABILITY: never delete what cannot be replaced ────────────────────────
+
+Describe 'migrate-channel.sh — the target catalogue offers nothing'
+    setup() {
+        _make_box
+        _subscribe edge
+        _install "pfSense-pkg-pfBlockerNG-devel" "3.2.15" "pfblockerng"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the legacy identity is installed'
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG-devel"
+    End
+
+    It 'fails on the catalogue read and leaves the installed package alone'
+      When run sh "${SCRIPT}" --channel edge
+      The status should equal 4
+      The stderr should include "does not offer pfSense-pkg-pfBlockerNG"
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG-devel"
+      The value "$(_pkg_calls)" should not include "delete"
+      The stdout should include "Installed: pfSense-pkg-pfBlockerNG-devel"
+    End
+End
+
+# ── NO-OP: already there ──────────────────────────────────────────────────────
+
+Describe 'migrate-channel.sh — already on the requested channel'
+    setup() {
+        _make_box
+        _subscribe edge
+        _install "pfSense-pkg-pfBlockerNG" "4.1.0.a1" "pfblockerng-edge"
+        _publish "pfblockerng-edge" "pfSense-pkg-pfBlockerNG" "4.1.0.a1"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'reports the no-op and performs no package operation'
+      When run sh "${SCRIPT}" --channel edge
+      The status should be success
+      The stdout should include "Already on the edge channel"
+      The value "$(_pkg_calls)" should not include "install"
+      The value "$(_pkg_calls)" should not include "delete"
+      The value "$(_installed_version pfSense-pkg-pfBlockerNG)" should equal "4.1.0.a1"
+    End
+End
+
+# ── LEGACY SUFFIXED IDENTITY -> CANONICAL ─────────────────────────────────────
+
+Describe 'migrate-channel.sh — pfSense-pkg-pfBlockerNG-devel onto stable'
+    setup() {
+        _make_box
+        _subscribe stable
+        _install "pfSense-pkg-pfBlockerNG-devel" "3.2.15" "pfblockerng"
+        _publish "pfblockerng-stable" "pfSense-pkg-pfBlockerNG" "4.0.0"
+        _manifest "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the box carries the retired -devel identity from the legacy repo'
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG-devel"
+      The value "$(_installed_repo pfSense-pkg-pfBlockerNG-devel)" should equal "pfblockerng"
+    End
+
+    It 'replaces it with the canonical package from the stable repo'
+      When run sh "${SCRIPT}" --channel stable
+      The status should be success
+      The stdout should include "Removing the legacy identity pfSense-pkg-pfBlockerNG-devel"
+      The stdout should include "Done"
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG"
+      The value "$(_installed_repo pfSense-pkg-pfBlockerNG)" should equal "pfblockerng-stable"
+      The value "$(_installed_version pfSense-pkg-pfBlockerNG)" should equal "4.0.0"
+      The value "$(_pkg_calls)" should include "delete -y pfSense-pkg-pfBlockerNG-devel"
+      The value "$(_pkg_calls)" should include "install -y -r pfblockerng-stable pfSense-pkg-pfBlockerNG"
+    End
+End
+
+Describe 'migrate-channel.sh — the historical -NIGHTLY spelling is recognised'
+    # ADR-18 shipped the nightly identity upper-cased. Dropping it from the shipped
+    # set would read those boxes as an unknown identity and strand them.
+    setup() {
+        _make_box
+        _subscribe nightly
+        _install "pfSense-pkg-pfBlockerNG-NIGHTLY" "20260601" "pfblockerng-nightly"
+        _publish "pfblockerng-nightly" "pfSense-pkg-pfBlockerNG" "20260807"
+        _manifest "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the upper-cased legacy identity is installed'
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG-NIGHTLY"
+    End
+
+    It 'migrates it to the canonical nightly package'
+      When run sh "${SCRIPT}" --channel nightly
+      The status should be success
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG"
+      The value "$(_installed_version pfSense-pkg-pfBlockerNG)" should equal "20260807"
+      The stdout should include "Removing the legacy identity pfSense-pkg-pfBlockerNG-NIGHTLY"
+      The value "$(_pkg_calls)" should include "delete -y pfSense-pkg-pfBlockerNG-NIGHTLY"
+    End
+End
+
+# ── REVERSE MOVEMENT: a repository-qualified downgrade ────────────────────────
+
+Describe 'migrate-channel.sh — moving back from edge to stable installs the older build'
+    # Ordinary `pkg upgrade` will not do this: the target version is LOWER and it
+    # lives in a different repository. `pkg install -f -r <repo>` is the proven form.
+    setup() {
+        _make_box
+        _subscribe stable
+        _install "pfSense-pkg-pfBlockerNG" "4.1.0.a1" "pfblockerng-edge"
+        _publish "pfblockerng-stable" "pfSense-pkg-pfBlockerNG" "4.0.0"
+        _manifest "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the newer edge build is installed from the edge repo'
+      The value "$(_installed_version pfSense-pkg-pfBlockerNG)" should equal "4.1.0.a1"
+      The value "$(_installed_repo pfSense-pkg-pfBlockerNG)" should equal "pfblockerng-edge"
+    End
+
+    It 'forces the reinstall from the stable repo and lands the lower version'
+      When run sh "${SCRIPT}" --channel stable
+      The status should be success
+      The value "$(_installed_version pfSense-pkg-pfBlockerNG)" should equal "4.0.0"
+      The value "$(_installed_repo pfSense-pkg-pfBlockerNG)" should equal "pfblockerng-stable"
+      The stdout should include "Reinstalling pfSense-pkg-pfBlockerNG from pfblockerng-stable (repository-qualified)"
+      The value "$(_pkg_calls)" should include "install -f -y -r pfblockerng-stable pfSense-pkg-pfBlockerNG"
+      The value "$(_pkg_calls)" should not include "delete"
+    End
+End
+
+Describe 'migrate-channel.sh — switching between channels serving the identical artifact'
+    # Stable, testing and edge intentionally carry the same bytes for one tagged
+    # release. The installed VERSION is then unchanged, but the subscription the
+    # package upgrades within must still move — that is the whole operation.
+    setup() {
+        _make_box
+        _subscribe testing
+        _install "pfSense-pkg-pfBlockerNG" "4.0.0" "pfblockerng-edge"
+        _publish "pfblockerng-testing" "pfSense-pkg-pfBlockerNG" "4.0.0"
+        _manifest "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the identical version is installed, but from the edge repo'
+      The value "$(_installed_version pfSense-pkg-pfBlockerNG)" should equal "4.0.0"
+      The value "$(_installed_repo pfSense-pkg-pfBlockerNG)" should equal "pfblockerng-edge"
+    End
+
+    It 'keeps the version and moves the origin repository to testing'
+      When run sh "${SCRIPT}" --channel testing
+      The status should be success
+      The value "$(_installed_version pfSense-pkg-pfBlockerNG)" should equal "4.0.0"
+      The value "$(_installed_repo pfSense-pkg-pfBlockerNG)" should equal "pfblockerng-testing"
+      The stdout should include "Reinstalling pfSense-pkg-pfBlockerNG from pfblockerng-testing (repository-qualified)"
+    End
+End
+
+# ── FAILURE CANNOT REPORT SUCCESS ─────────────────────────────────────────────
+
+Describe 'migrate-channel.sh — the replacement install fails after the delete'
+    setup() {
+        _make_box
+        _subscribe stable
+        _install "pfSense-pkg-pfBlockerNG-devel" "3.2.15" "pfblockerng"
+        _publish "pfblockerng-stable" "pfSense-pkg-pfBlockerNG" "4.0.0"
+        PFB_STUB_FAIL_INSTALL=1
+        export PFB_STUB_FAIL_INSTALL
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'reports the box is left with no pfBlockerNG and tells the user to re-run'
+      When run sh "${SCRIPT}" --channel stable
+      The status should equal 5
+      The stdout should include "Removing the legacy identity pfSense-pkg-pfBlockerNG-devel"
+      The stderr should include "the box currently has NO pfBlockerNG installed"
+      The value "$(_installed_names)" should equal ""
+    End
+End
+
+Describe 'migrate-channel.sh — the install lands in a different repository'
+    setup() {
+        _make_box
+        _subscribe stable
+        _install "pfSense-pkg-pfBlockerNG" "4.0.0" "pfblockerng-edge"
+        _publish "pfblockerng-stable" "pfSense-pkg-pfBlockerNG" "4.0.0"
+        _manifest "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+        PFB_STUB_INSTALL_REPO="pfblockerng-edge"
+        export PFB_STUB_INSTALL_REPO
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'fails verification rather than claiming the channel switch succeeded'
+      When run sh "${SCRIPT}" --channel stable
+      The status should equal 6
+      The stdout should include "Reinstalling pfSense-pkg-pfBlockerNG from pfblockerng-stable (repository-qualified)"
+      The stderr should include "the box is not on the stable channel"
+    End
+End
+
+Describe 'migrate-channel.sh — the installed payload is incomplete'
+    setup() {
+        _make_box
+        _subscribe stable
+        _install "pfSense-pkg-pfBlockerNG-devel" "3.2.15" "pfblockerng"
+        _publish "pfblockerng-stable" "pfSense-pkg-pfBlockerNG" "4.0.0"
+        _manifest "/usr/local/pkg/pfblockerng/pfblockerng.inc" "/usr/local/www/pfblockerng/pfblockerng_software.php"
+        PFB_STUB_SKIP_PAYLOAD="/usr/local/www/pfblockerng/pfblockerng_software.php"
+        export PFB_STUB_SKIP_PAYLOAD
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'fails verification and names the missing file'
+      When run sh "${SCRIPT}" --channel stable
+      The status should equal 6
+      The stdout should include "Installing pfSense-pkg-pfBlockerNG from pfblockerng-stable"
+      The stderr should include "the installed payload is incomplete"
+      The stderr should include "pfblockerng_software.php"
+    End
+End
+
+Describe 'migrate-channel.sh — the configuration section is lost'
+    # Configuration preservation is the package lifecycle hooks' job, not this
+    # script's. Checking it here is what stops a silent loss being reported as a
+    # successful migration.
+    setup() {
+        _make_box
+        _subscribe stable
+        _install "pfSense-pkg-pfBlockerNG-devel" "3.2.15" "pfblockerng"
+        _publish "pfblockerng-stable" "pfSense-pkg-pfBlockerNG" "4.0.0"
+        _manifest "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+        PFB_STUB_DROP_CONFIG=1
+        export PFB_STUB_DROP_CONFIG
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the config carries the pfblockerng section'
+      The contents of file "${BOX}/cf/conf/config.xml" should include "<pfblockerng>"
+    End
+
+    It 'fails verification and points at the configuration backup'
+      When run sh "${SCRIPT}" --channel stable
+      The status should equal 6
+      The stdout should include "Installing pfSense-pkg-pfBlockerNG from pfblockerng-stable"
+      The stderr should include "installedpackages/pfblockerng section is gone"
+      The stderr should include "restore your configuration backup"
+    End
+End

--- a/tests/shell/migrate_channel_spec.sh
+++ b/tests/shell/migrate_channel_spec.sh
@@ -136,6 +136,7 @@ version)
     # `pkg version -t <a> <b>` -> '>' | '=' | '<'. The script uses it to pick the build
     # `install` will resolve, so the two must agree — both go through `sort -V` here.
     [ "$1" = "-t" ] || exit 64
+    [ "${PFB_STUB_BREAK_VERSION:-0}" = "1" ] && exit 64
     if [ "$2" = "$3" ]; then
         printf '=\n'
     elif [ "$(printf '%s\n%s\n' "$2" "$3" | sort -V | tail -n 1)" = "$2" ]; then
@@ -177,7 +178,7 @@ _make_box() {
 _unset_box() {
     unset PFBLOCKERNG_ROOT PKG_BIN PFB_STUB_DIR BOX \
           PFB_STUB_FAIL_INSTALL PFB_STUB_FAIL_DELETE PFB_STUB_INSTALL_REPO \
-          PFB_STUB_SKIP_PAYLOAD PFB_STUB_DROP_CONFIG
+          PFB_STUB_SKIP_PAYLOAD PFB_STUB_DROP_CONFIG PFB_STUB_BREAK_VERSION
 }
 
 _subscribe()   { true > "${BOX}/usr/local/etc/pkg/repos/pfblockerng-$1.conf"; }
@@ -558,6 +559,20 @@ Describe 'migrate-channel.sh — a catalogue offering several builds'
       The value "$(_installed_version pfSense-pkg-pfBlockerNG)" should equal "4.1.0.a1"
       The value "$(_installed_repo pfSense-pkg-pfBlockerNG)" should equal "pfblockerng-edge"
       The stdout should include "Done"
+    End
+
+    It 'names the comparator when it cannot answer, instead of dying on the symptom'
+      # A degraded `pkg version -t` would silently reduce the loop to "keep the first
+      # line" — the exact behaviour this replaced — and the migration would then fail
+      # its own post-install version check with no hint as to why.
+      PFB_STUB_BREAK_VERSION=1
+      export PFB_STUB_BREAK_VERSION
+      When run sh "${SCRIPT}" --channel edge
+      The status should equal 4
+      The stdout should include "Installed: pfSense-pkg-pfBlockerNG-devel"
+      The stderr should include "gave no usable answer comparing"
+      The value "$(_pkg_calls)" should not include "install"
+      The value "$(_installed_names)" should equal "pfSense-pkg-pfBlockerNG-devel"
     End
 End
 

--- a/tests/shell/migrate_channel_spec.sh
+++ b/tests/shell/migrate_channel_spec.sh
@@ -103,7 +103,10 @@ install)
         *) _name="$1"; shift ;;
         esac
     done
-    _ver="$(awk -F"${_tab}" -v r="${_repo}" -v n="${_name}" '$1 == r && $2 == n { print $3 }' "${_d}/catalog")"
+    # Real `pkg install` resolves the HIGHEST version the repo offers, and a catalogue
+    # routinely offers several (retention + containment). `sort -V` stands in for pkg's
+    # component-wise numeric ordering.
+    _ver="$(awk -F"${_tab}" -v r="${_repo}" -v n="${_name}" '$1 == r && $2 == n { print $3 }' "${_d}/catalog" | sort -V | tail -n 1)"
     [ -n "${_ver}" ] || exit 1
     awk -F"${_tab}" -v n="${_name}" '$1 != n' "${_d}/installed" > "${_d}/installed.new"
     printf '%s\t%s\t%s\n' "${_name}" "${_ver}" "${PFB_STUB_INSTALL_REPO:-${_repo}}" >> "${_d}/installed.new"
@@ -127,6 +130,19 @@ info)
         [ -n "${_p}" ] || continue
         printf '\t%s\n' "${_p}"
     done < "${_d}/payload"
+    exit 0
+    ;;
+version)
+    # `pkg version -t <a> <b>` -> '>' | '=' | '<'. The script uses it to pick the build
+    # `install` will resolve, so the two must agree — both go through `sort -V` here.
+    [ "$1" = "-t" ] || exit 64
+    if [ "$2" = "$3" ]; then
+        printf '=\n'
+    elif [ "$(printf '%s\n%s\n' "$2" "$3" | sort -V | tail -n 1)" = "$2" ]; then
+        printf '>\n'
+    else
+        printf '<\n'
+    fi
     exit 0
     ;;
 *)
@@ -509,6 +525,42 @@ Describe 'migrate-channel.sh — switching between channels serving the identica
     End
 End
 
+Describe 'migrate-channel.sh — a catalogue offering several builds'
+    # The ordinary shape, not an edge case: retention keeps the newest few builds and
+    # containment back-fills a faster channel with its slower channels' builds, so a
+    # channel catalogue routinely offers more than one version of the canonical
+    # package. `pkg install` resolves the HIGHEST, so the script must predict the same
+    # one — naming any other would fail its own post-migration version check and report
+    # a successful migration as broken.
+    setup() {
+        _make_box
+        _subscribe edge
+        _install "pfSense-pkg-pfBlockerNG-devel" "3.2.15" "pfblockerng"
+        # Deliberately NOT in ascending catalogue order: taking the first line would
+        # pick 4.0.0, and taking the last would pick 3.9.0.
+        _publish "pfblockerng-edge" "pfSense-pkg-pfBlockerNG" "4.0.0"
+        _publish "pfblockerng-edge" "pfSense-pkg-pfBlockerNG" "4.1.0.a1"
+        _publish "pfblockerng-edge" "pfSense-pkg-pfBlockerNG" "3.9.0"
+        _manifest "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+    }
+    cleanup() { rm -rf "${BOX}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the edge catalogue offers three builds, unordered'
+      The value "$(wc -l < "${PFB_STUB_DIR}/catalog" | tr -d ' ')" should equal "3"
+    End
+
+    It 'targets the highest build the catalogue offers, not the first one listed'
+      When run sh "${SCRIPT}" --channel edge
+      The status should be success
+      The stdout should include "Target:    pfSense-pkg-pfBlockerNG-4.1.0.a1"
+      The value "$(_installed_version pfSense-pkg-pfBlockerNG)" should equal "4.1.0.a1"
+      The value "$(_installed_repo pfSense-pkg-pfBlockerNG)" should equal "pfblockerng-edge"
+      The stdout should include "Done"
+    End
+End
+
 # ── FAILURE CANNOT REPORT SUCCESS ─────────────────────────────────────────────
 
 Describe 'migrate-channel.sh — the replacement install fails after the delete'
@@ -524,11 +576,16 @@ Describe 'migrate-channel.sh — the replacement install fails after the delete'
     Before 'setup'
     After  'cleanup'
 
-    It 'reports the box is left with no pfBlockerNG and tells the user to re-run'
+    It 'reports the empty box and hands over a command that actually finishes the job'
+      # NOT "re-run this script": with nothing installed it exits 3 ("nothing to
+      # migrate") — see the "nothing installed" Describe above — so a re-run would
+      # strand the operator at the one moment the box has no pfBlockerNG at all.
       When run sh "${SCRIPT}" --channel stable
       The status should equal 5
       The stdout should include "Removing the legacy identity pfSense-pkg-pfBlockerNG-devel"
       The stderr should include "the box currently has NO pfBlockerNG installed"
+      The stderr should include "install -y -r pfblockerng-stable pfSense-pkg-pfBlockerNG"
+      The stderr should not include "re-run this script"
       The value "$(_installed_names)" should equal ""
     End
 End

--- a/tests/shell/migrate_channel_spec.sh
+++ b/tests/shell/migrate_channel_spec.sh
@@ -112,7 +112,7 @@ install)
         [ -n "${_p}" ] || continue
         [ "${_p}" = "${PFB_STUB_SKIP_PAYLOAD:-}" ] && continue
         mkdir -p "${_root}$(dirname "${_p}")"
-        : > "${_root}${_p}"
+        true > "${_root}${_p}"
     done < "${_d}/payload"
     if [ "${PFB_STUB_DROP_CONFIG:-0}" = "1" ]; then
         printf '<pfsense></pfsense>\n' > "${_root}/cf/conf/config.xml"
@@ -143,9 +143,9 @@ STUB
 _make_box() {
     _mb_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/migrate_ch.XXXXXX")"
     mkdir -p "${_mb_dir}/usr/local/etc/pkg/repos" "${_mb_dir}/cf/conf" "${_mb_dir}/stub"
-    : > "${_mb_dir}/stub/installed"
-    : > "${_mb_dir}/stub/catalog"
-    : > "${_mb_dir}/stub/payload"
+    true > "${_mb_dir}/stub/installed"
+    true > "${_mb_dir}/stub/catalog"
+    true > "${_mb_dir}/stub/payload"
     _write_pkg_stub "${_mb_dir}/stub/pkg"
     printf '<pfsense><installedpackages><pfblockerng><enable>on</enable></pfblockerng></installedpackages></pfsense>\n' \
         > "${_mb_dir}/cf/conf/config.xml"
@@ -164,8 +164,8 @@ _unset_box() {
           PFB_STUB_SKIP_PAYLOAD PFB_STUB_DROP_CONFIG
 }
 
-_subscribe()   { : > "${BOX}/usr/local/etc/pkg/repos/pfblockerng-$1.conf"; }
-_legacy_conf() { : > "${BOX}/usr/local/etc/pkg/repos/pfblockerng.conf"; }
+_subscribe()   { true > "${BOX}/usr/local/etc/pkg/repos/pfblockerng-$1.conf"; }
+_legacy_conf() { true > "${BOX}/usr/local/etc/pkg/repos/pfblockerng.conf"; }
 _install()     { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "${PFB_STUB_DIR}/installed"; }
 _publish()     { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "${PFB_STUB_DIR}/catalog"; }
 _manifest()    { printf '%s\n' "$@" >> "${PFB_STUB_DIR}/payload"; }

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -136,12 +136,15 @@ for dirpath, _dirs, _files in os.walk(site):
         continue
     with open(os.path.join(dirpath, "index.html"), "w") as fh:
         fh.write(f"autoindex stub: {rel}\n")
-# write_site() also publishes a self-contained add-repo.sh into the site root.
+# write_site() also publishes BOTH client scripts into the site root.
 with open(os.path.join(site, "add-repo.sh"), "w") as fh:
     fh.write("#!/bin/sh\n# add-repo stub\n")
+with open(os.path.join(site, "migrate-channel.sh"), "w") as fh:
+    fh.write("#!/bin/sh\n# migrate-channel stub\n")
 print("landing stub written")
 PY
     echo '#!/bin/sh' > "${base}/fake-src/scripts/add-repo.sh"
+    echo '#!/bin/sh' > "${base}/fake-src/scripts/migrate-channel.sh"
 
     # --- fake publish_nightly.py — the Nightly-mode counterpart to the
     # publish_release.py stub above. Same doubling rationale: real handoff/asset
@@ -323,10 +326,12 @@ JSON
     The path "${base}/pkg-repo/docs/edge/index.html" should be exist
     committed="$(git_fixture -C "${base}/pkg-repo" show --stat --format= HEAD | tr -s ' ' | sed 's/^ *//;s/ .*//')"
     The variable committed should include 'docs/edge/index.html'
-    # write_site() publishes add-repo.sh into the site root on the same walk;
-    # the bootstrap one-liner on the landing page fetches it from there, so an
-    # unstaged copy means the published site serves a 404 for it.
+    # write_site() publishes BOTH client scripts into the site root on the same
+    # walk; the landing page's bootstrap one-liner and its channel-switch snippet
+    # fetch them from there, so an unstaged copy means the published site serves a
+    # 404 into `sh` for the half it omits (issue #2148).
     The variable committed should include 'docs/add-repo.sh'
+    The variable committed should include 'docs/migrate-channel.sh'
   End
 
   It 'never sweeps a stray untracked file or an unrelated dirty tracked file into the commit'
@@ -419,6 +424,7 @@ JSON
     printf 'autoindex stub: edge\n' > "${base}/pkg-repo/docs/edge/index.html"
     printf 'autoindex stub: edge/ce-2.8\n' > "${base}/pkg-repo/docs/edge/ce-2.8/index.html"
     printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
+    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
     # docs/.nojekyll is truncate-and-recreated unconditionally whenever the
     # script has any touched target (regardless of whether the target itself
     # changed) — pre-seed it too, or its own first-ever creation would be a
@@ -426,6 +432,7 @@ JSON
     true > "${base}/pkg-repo/docs/.nojekyll"
     ( cd "${base}/pkg-repo" && git_fixture add docs/index.html docs/browse.html \
         docs/edge/index.html docs/edge/ce-2.8/index.html docs/.nojekyll docs/add-repo.sh \
+        docs/migrate-channel.sh \
         && git_fixture commit -q -m preseed-landing \
         && git_fixture push -q origin main )
     original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -3032,6 +3032,86 @@ def test_edge_rollback_stays_within_the_edge_repository(
     assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve on the rollback:\n{combined}"
 
 
+@pytest.mark.timeout(1800)  # bootstrap edge + install + re-subscribe to stable + migrate down.
+def test_migrate_channel_moves_a_canonical_install_down_to_a_slower_channel(
+    repo_vm: SmokeVM,
+    channel_catalogs: ChannelCatalogs,
+) -> None:
+    """REVERSE MOVE: a canonical install on ``edge`` lands on ``stable``'s OLDER build.
+
+    This is ``migrate-channel.sh``'s other branch — the box already carries the canonical
+    identity, just from the wrong repository — and it is the branch every channel-to-channel
+    transition takes, in both directions. The legacy-identity case cannot stand in for it:
+    that one deletes and installs afresh, while this one must make ``pkg`` move an installed
+    package ACROSS repositories and DOWN a version, which ordinary ``pkg upgrade`` refuses
+    outright. The script emits an UNPINNED ``pkg install -f -y -r <repo> <name>`` for it, so
+    only a live ``pkg`` can show that the repository qualification alone selects the older
+    build; the in-repo rollback case above pins an explicit ``<name>-<version>``, a form the
+    script never produces.
+
+    Scenario: moving from edge back to stable.
+
+    Given the box subscribed to edge and running edge's newer canonical build (BEFORE
+      asserted: ``%v`` is edge's version, ``%R`` is ``pfblockerng-edge``),
+    When  ``add-repo.sh --channel stable`` re-subscribes it (repositories only — the
+      installed package must still report the edge repo at that point, asserted), and then
+      ``migrate-channel.sh --channel stable`` runs,
+    Then  it exits 0, the box still carries exactly the canonical identity, its ``%R`` is
+      now ``pfblockerng-stable``, and its ``%v`` is stable's OLDER version — a downgrade
+      performed by repository qualification alone.
+    """
+    source_channel, target_channel = "edge", "stable"
+    source_repo = channel_repo_name(source_channel)
+    target_repo = channel_repo_name(target_channel)
+    newer = channel_catalogs.versions[source_channel]
+    older = channel_catalogs.versions[target_channel]
+    assert newer != older, f"the transition pair must differ (both {newer!r})"
+
+    reset_channel_subscription(repo_vm)
+
+    # GIVEN: the box on edge, running edge's own build from edge's repository.
+    run_add_repo_sh(repo_vm, channel_catalogs.base_url, channel=source_channel)
+    pkg_install_qualified(repo_vm, source_repo, CANONICAL_PKG_NAME)
+    assert pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME) == newer, (
+        f"BEFORE: expected edge's build {newer!r}, got {pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME)!r}"
+    )
+    assert pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME) == source_repo, (
+        f"BEFORE: installed from {pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME)!r}, expected {source_repo!r}"
+    )
+
+    # WHEN (1): re-subscribe to the slower channel. Repositories ONLY.
+    run_add_repo_sh(repo_vm, channel_catalogs.base_url, channel=target_channel)
+    assert project_confs_present(repo_vm) == {channel_conf_name(target_channel)}, (
+        f"re-subscribing to {target_channel} left {sorted(project_confs_present(repo_vm))} behind"
+    )
+    assert pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME) == source_repo, (
+        "add-repo.sh moved the INSTALLED package's origin repository — configuring a repository is not a migration"
+    )
+    assert pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME) == newer, (
+        "add-repo.sh changed the installed version — it configures repositories only"
+    )
+
+    # WHEN (2): migrate. The script's own unpinned `install -f -r` has to do the work.
+    proc = run_migrate_channel_sh(repo_vm, "--channel", target_channel)
+    assert proc.returncode == 0, (
+        f"migrate-channel.sh --channel {target_channel} exited {proc.returncode}\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+    # THEN: same identity, new repository, OLDER version.
+    assert installed_pfblockerng_names(repo_vm) == [CANONICAL_PKG_NAME], (
+        f"AFTER: expected only {CANONICAL_PKG_NAME}, found {installed_pfblockerng_names(repo_vm)}"
+    )
+    assert pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME) == target_repo, (
+        f"AFTER: reports repo {pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME)!r}, expected {target_repo!r}"
+    )
+    assert pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME) == older, (
+        f"AFTER: expected the downgrade to {older!r}, got "
+        f"{pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME)!r} — a repository-qualified "
+        "reinstall did not move the box down to the slower channel's build"
+    )
+
+
 @pytest.mark.timeout(1200)  # legacy bootstrap + install + a refused migration.
 def test_migrate_channel_refuses_an_unsubscribed_channel_before_mutating(
     repo_vm: SmokeVM,

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -84,6 +84,7 @@ import urllib.parse
 import urllib.request
 from collections.abc import Iterator
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -419,26 +420,37 @@ def build_repo_via_portable(vm: SmokeVM, pkg_files: list[Path], tmp_path: Path) 
     return PORTABLE_REPO_ROOT
 
 
-def run_add_repo_sh(vm: SmokeVM, base_url: str, *, timeout: float = 300.0) -> subprocess.CompletedProcess[str]:
-    """Stage the SHIPPED ``scripts/add-repo.sh`` and run it (default release repo) against ``base_url``.
+def run_add_repo_sh(
+    vm: SmokeVM,
+    base_url: str,
+    *,
+    channel: str | None = None,
+    timeout: float = 300.0,
+) -> subprocess.CompletedProcess[str]:
+    """Stage the SHIPPED ``scripts/add-repo.sh`` and run it against ``base_url``.
 
     Drives the real client bootstrap on the box: it writes the production conf to
-    ``/usr/local/etc/pkg/repos/pfblockerng.conf`` (here pointed at a local
+    ``/usr/local/etc/pkg/repos/pfblockerng<-channel>.conf`` (here pointed at a local
     ``file://`` catalog via the script's own ``--base-url`` override — the github.io
-    default and a live HTTPS add-repo.sh run are a post-deploy note), runs ``pkg
-    update``, and VERIFIES the package is visible from OUR repo. A non-zero exit (its
-    verify step failing) raises with the captured output. ``base_url`` points at the
-    catalog ROOT; add-repo.sh installs+runs the generator hook, which resolves the
-    box's ``<channel>/<varver>`` subtree (arch-less, NO_ARCH — issue #1806), so the
-    catalog MUST live under ``<base_url>/<channel>/<varver>/``.
+    default and a live HTTPS add-repo.sh run are a post-deploy note), retires every
+    OTHER project conf, runs ``pkg update``, and VERIFIES the package is visible from
+    that repo. A non-zero exit (its verify step failing) raises with the captured
+    output. ``base_url`` points at the catalog ROOT; add-repo.sh installs+runs the
+    generator hook, which resolves the box's ``<channel>/<varver>`` subtree (arch-less,
+    NO_ARCH — issue #1806), so the catalog MUST live under
+    ``<base_url>/<channel>/<varver>/``.
+
+    ``channel`` selects one of the four channel repositories (issue #2148); omitted, the
+    script's own default — the legacy shared release repo ``pfblockerng`` — applies.
     """
+    channel_args = () if channel is None else ("--channel", channel)
     _ssh_check(vm, "/bin/mkdir", "-p", GUEST_SPIKE_DIR, GUEST_ADD_REPO_RCD_DIR)
     _scp_to_guest(vm, ADD_REPO_SH, GUEST_ADD_REPO_SH)
     _scp_to_guest(vm, ADD_REPO_GENERATE_HOOK_SRC, f"{GUEST_ADD_REPO_RCD_DIR}/pfblockerng_repo_generate.sh")
-    result = vm.ssh("/bin/sh", GUEST_ADD_REPO_SH, "--base-url", base_url, timeout=timeout)
+    result = vm.ssh("/bin/sh", GUEST_ADD_REPO_SH, "--base-url", base_url, *channel_args, timeout=timeout)
     if result.returncode != 0:
         raise RuntimeError(
-            f"add-repo.sh --base-url {base_url} failed: rc={result.returncode}\n"
+            f"add-repo.sh --base-url {base_url} {' '.join(channel_args)} failed: rc={result.returncode}\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
     return result
@@ -644,20 +656,43 @@ def pkg_update(vm: SmokeVM, *, timeout: float = 240.0) -> None:
         )
 
 
-def pkg_installed_version(vm: SmokeVM, *, timeout: float = 60.0) -> str | None:
-    """The installed ``%v`` of the package, or ``None`` if absent (the before/after oracle)."""
-    result = vm.ssh("pkg", "query", "%v", PKG_NAME, timeout=timeout)
+def pkg_installed_version_of(vm: SmokeVM, name: str, *, timeout: float = 60.0) -> str | None:
+    """The installed ``%v`` of ``name``, or ``None`` if absent (the before/after oracle).
+
+    Takes the package name because the four-channel cases (issue #2148) reason about
+    THREE identities on one box — the branch build, the canonical
+    ``pfSense-pkg-pfBlockerNG`` every channel publishes, and the legacy
+    ``pfSense-pkg-pfBlockerNG-devel`` a migration replaces.
+    """
+    result = vm.ssh("pkg", "query", "%v", name, timeout=timeout)
     if result.returncode == 0:
         return result.stdout.strip() or None
     if result.returncode == 1:
         return None
     raise RuntimeError(
-        f"pkg query {PKG_NAME} failed: rc={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        f"pkg query {name} failed: rc={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
 
 
+def pkg_repo_origin_of(vm: SmokeVM, name: str, *, timeout: float = 60.0) -> str | None:
+    """The repo ``%R`` ``name`` was fetched from, or ``None`` if it is not installed."""
+    result = vm.ssh("pkg", "query", "%R", name, timeout=timeout)
+    if result.returncode == 0:
+        return result.stdout.strip() or None
+    if result.returncode == 1:
+        return None
+    raise RuntimeError(
+        f"pkg query %R {name} failed: rc={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def pkg_installed_version(vm: SmokeVM, *, timeout: float = 60.0) -> str | None:
+    """The installed ``%v`` of the branch package, or ``None`` if absent."""
+    return pkg_installed_version_of(vm, PKG_NAME, timeout=timeout)
+
+
 def pkg_repo_origin(vm: SmokeVM, *, timeout: float = 60.0) -> str:
-    """The repo ``%R`` the installed package was fetched from (the precedence oracle)."""
+    """The repo ``%R`` the installed branch package was fetched from (the precedence oracle)."""
     return _ssh_check(vm, "pkg", "query", "%R", PKG_NAME, timeout=timeout).stdout.strip()
 
 
@@ -2293,3 +2328,781 @@ def test_generate_hook_rewrites_stale_varver_and_resolves(repo_vm: SmokeVM, tmp_
         # staged hook never survives into a later module sharing this guest.
         repo_vm.ssh("/bin/rm", "-f", GUEST_HOOK_PATH, timeout=60.0)
         # REPO_CONF is cleaned by the repo_vm module fixture teardown.
+
+
+# =========================================================================== #
+# issue #2148 — the four-channel client contract                              #
+#                                                                              #
+# Four channels — stable, testing, edge, nightly — each own a pkg repository   #
+# `pfblockerng-<channel>` (conf `pfblockerng-<channel>.conf`) and ALL FOUR     #
+# publish the ONE canonical identity `pfSense-pkg-pfBlockerNG`: channel is     #
+# catalogue placement, never a package-name suffix. The legacy shared release  #
+# repo `pfblockerng` (conf `pfblockerng.conf`) is the only one that ever       #
+# carried a suffixed identity (`pfSense-pkg-pfBlockerNG-devel`).               #
+#                                                                              #
+# Two consequences the cases below pin on a real box:                          #
+#   * SINGLE-REPOSITORY SUBSCRIPTION — every project repo shares priority 100  #
+#     and `pkg` does not order across equal-priority repositories, so exactly  #
+#     ONE project conf may exist. `add-repo.sh --channel <ch>` retires the      #
+#     others.                                                                  #
+#   * The installed package NAME can no longer identify the channel, so the    #
+#     repository it came from (`pkg query '%R'`) is the only authority — and   #
+#     `pkg` never moves an installed package across repositories on its own,   #
+#     which is why `migrate-channel.sh` exists.                                #
+#                                                                              #
+# Marker: @pytest.mark.repo (inherited from pytestmark).                       #
+# Dispatch: gh workflow run smoke-single.yml -f pytest_marker=repo             #
+# =========================================================================== #
+
+# The four channels, in the order add-repo.sh and migrate-channel.sh enumerate them.
+CHANNELS = ("stable", "testing", "edge", "nightly")
+
+# The ONE identity every channel catalogue publishes, and the legacy suffixed identity a
+# box installed from the shared release repo still carries until it is migrated.
+CANONICAL_PKG_NAME = "pfSense-pkg-pfBlockerNG"
+LEGACY_DEVEL_PKG_NAME = f"{CANONICAL_PKG_NAME}-devel"
+
+# The on-box repo-conf directory — derived from REPO_CONF so the two can never drift.
+PKG_REPOS_DIR = REPO_CONF.rsplit("/", 1)[0]
+LEGACY_RELEASE_CONF_NAME = REPO_CONF.rsplit("/", 1)[1]
+
+# Every conf add-repo.sh may ever have written. Exactly ONE may be present on a box;
+# `test_project_conf_names_match_the_shipped_scripts` pins this tuple to the scripts.
+PROJECT_CONF_NAMES = (LEGACY_RELEASE_CONF_NAME, *(f"pfblockerng-{channel}.conf" for channel in CHANNELS))
+
+# Guest root for the four channel catalogues + the legacy release catalogue (isolated
+# from GUEST_SPIKE_DIR so the ADR-17 cases above are unaffected).
+CHANNEL_REPO_ROOT = "/tmp/pfb_channel_repo"
+
+# The user-run migration script under test, and where it is staged on the guest.
+MIGRATE_CHANNEL_SH = Path(__file__).resolve().parents[2] / "scripts" / "migrate-channel.sh"
+GUEST_MIGRATE_CHANNEL_SH = f"{GUEST_SPIKE_DIR}/migrate-channel.sh"
+
+# Distinct PORTREVISIONs per catalogue, so `pkg query %v` alone identifies WHICH
+# catalogue served a build (a `%R` assertion that happened to be right for the wrong
+# reason cannot hide behind an identical version). `edge` carries TWO: `_3` is its own
+# build and `_1` is the stable-era build it still contains — each channel catalogue
+# strictly contains its slower channels' files, which is what makes an in-repo
+# rollback on a faster channel possible without switching repositories.
+CHANNEL_REVISIONS = {"stable": "_1", "testing": "_2", "edge": "_3", "nightly": "_4"}
+EDGE_ROLLBACK_REVISION = CHANNEL_REVISIONS["stable"]
+# The legacy `-devel` build sits ABOVE every channel build, so nothing about a migration
+# off it can be explained by ordinary version ordering — only by the repository-qualified
+# replacement `migrate-channel.sh` performs.
+LEGACY_REVISION = "_9"
+# Which slower channels' builds each catalogue ALSO carries. Strict containment
+# (edge ⊇ testing ⊇ stable) is what the in-repo rollback case rides on; expressed as
+# data so no case has to branch on a channel name.
+CHANNEL_CONTAINED_BUILDS: dict[str, tuple[str, ...]] = {"edge": ("stable",)}
+
+
+def channel_repo_name(channel: str) -> str:
+    """The pkg repository name a channel's conf declares (the ``%R`` a install reports)."""
+    return f"pfblockerng-{channel}"
+
+
+def channel_conf_name(channel: str) -> str:
+    """The conf FILE name add-repo.sh writes for a channel."""
+    return f"pfblockerng-{channel}.conf"
+
+
+def previous_channel(channel: str) -> str:
+    """A deterministic OTHER channel to subscribe to first, so a switch has a before-state.
+
+    Each case seeds its own previous subscription rather than relying on whatever a
+    sibling test happened to leave behind — the cases below must pass in any order and
+    in isolation.
+    """
+    return CHANNELS[(CHANNELS.index(channel) + 1) % len(CHANNELS)]
+
+
+def rename_pkg(src_pkg: Path, new_name: str, out_dir: Path) -> Path:
+    """Move a built ``.pkg`` onto a different package IDENTITY, payload untouched.
+
+    The sibling of :func:`reversion_pkg`: it rewrites ``version``, this rewrites ``name``
+    (and the trailing segment of ``origin``, which is the port the name comes from) in
+    BOTH manifests — ``pkg`` reads ``+COMPACT_MANIFEST`` for the catalogue and
+    ``+MANIFEST`` on install, so a package renamed in only one registers under the other
+    name. Every other manifest field and every payload member is copied through verbatim.
+
+    This is what lets ONE branch build stand in for both identities the four-channel
+    cutover has to reconcile: the canonical ``pfSense-pkg-pfBlockerNG`` the channel
+    catalogues publish, and the legacy ``pfSense-pkg-pfBlockerNG-devel`` an unmigrated
+    box still carries. Returns the written ``<new_name>-<version>.pkg`` under ``out_dir``.
+    """
+    tar_bytes = _zstd_decompress(src_pkg.read_bytes())
+    repacked = io.BytesIO()
+    version = ""
+    with (
+        tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tin,
+        tarfile.open(fileobj=repacked, mode="w", format=tarfile.USTAR_FORMAT) as tout,
+    ):
+        for member in tin.getmembers():
+            extracted = tin.extractfile(member) if member.isfile() else None
+            data = extracted.read() if extracted is not None else b""
+            if member.name in _PKG_MANIFEST_MEMBERS:
+                obj = json.loads(data)
+                obj["name"] = new_name
+                origin = obj.get("origin")
+                if isinstance(origin, str) and "/" in origin:
+                    obj["origin"] = f"{origin.rsplit('/', 1)[0]}/{new_name}"
+                version = obj.get("version", version)
+                data = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode() + b"\n"
+                ti = tarfile.TarInfo(name=member.name)
+                ti.size = len(data)
+                ti.mode = 0o644
+                ti.uid = ti.gid = 0
+                ti.uname, ti.gname = "root", "wheel"
+                ti.mtime = 0
+                ti.type = tarfile.REGTYPE
+                tout.addfile(ti, io.BytesIO(data))
+            else:
+                tout.addfile(member, io.BytesIO(data) if member.isfile() else None)
+    if not version:
+        raise RuntimeError(f"{src_pkg.name}: no +COMPACT_MANIFEST/+MANIFEST with a version — not a libpkg .pkg?")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{new_name}-{version}.pkg"
+    out_path.write_bytes(_zstd_compress(repacked.getvalue()))
+    return out_path
+
+
+def _synthetic_pkg(path: Path, *, name: str, version: str, origin: str) -> Path:
+    """Write a minimal libpkg-shaped ``.pkg`` (both manifests + one payload member).
+
+    Hermetic input for the ``rename_pkg`` round-trip: real enough to exercise the
+    manifest rewrite without a multi-megabyte branch artifact or a booted guest.
+    """
+    manifest = {"name": name, "version": version, "origin": origin, "abi": "FreeBSD:15:*"}
+    body = json.dumps(manifest, separators=(",", ":")).encode() + b"\n"
+    payload = b"#!/bin/sh\necho pfb payload\n"
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w", format=tarfile.USTAR_FORMAT) as tf:
+        members = [(member, body) for member in _PKG_MANIFEST_MEMBERS]
+        members.append(("/usr/local/bin/pfb_probe", payload))
+        for member_name, data in members:
+            ti = tarfile.TarInfo(name=member_name)
+            ti.size = len(data)
+            ti.mode = 0o644
+            ti.uid = ti.gid = 0
+            ti.uname, ti.gname = "root", "wheel"
+            ti.mtime = 0
+            ti.type = tarfile.REGTYPE
+            tf.addfile(ti, io.BytesIO(data))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_zstd_compress(buf.getvalue()))
+    return path
+
+
+def _pkg_manifests(pkg_path: Path) -> dict[str, dict]:
+    """Both manifest members of a ``.pkg``, parsed — the oracle for an identity rewrite."""
+    tar_bytes = _zstd_decompress(pkg_path.read_bytes())
+    out: dict[str, dict] = {}
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+        for member in tf.getmembers():
+            if member.name in _PKG_MANIFEST_MEMBERS:
+                extracted = tf.extractfile(member)
+                assert extracted is not None, f"{member.name} is not a regular file in {pkg_path.name}"
+                out[member.name] = json.loads(extracted.read())
+    return out
+
+
+def _pkg_payload(pkg_path: Path) -> dict[str, bytes]:
+    """Every NON-manifest member of a ``.pkg``, by name — the payload-passthrough oracle."""
+    tar_bytes = _zstd_decompress(pkg_path.read_bytes())
+    out: dict[str, bytes] = {}
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+        for member in tf.getmembers():
+            if member.name in _PKG_MANIFEST_MEMBERS or not member.isfile():
+                continue
+            extracted = tf.extractfile(member)
+            assert extracted is not None, f"{member.name} is not readable in {pkg_path.name}"
+            out[member.name] = extracted.read()
+    return out
+
+
+def test_rename_pkg_rewrites_both_manifests_and_keeps_the_payload(tmp_path: Path) -> None:
+    """HERMETIC (no VM): ``rename_pkg`` moves a ``.pkg`` onto a different package IDENTITY.
+
+    The four-channel cases below need two identities forged from ONE branch build: the
+    canonical ``pfSense-pkg-pfBlockerNG`` every channel catalogue publishes, and the
+    legacy ``pfSense-pkg-pfBlockerNG-devel`` a box being migrated still carries. Both
+    manifests must move in lockstep — ``pkg`` reads ``+COMPACT_MANIFEST`` for the
+    catalogue and ``+MANIFEST`` on install, so rewriting only the first would publish a
+    catalogue entry named canonical that REGISTERS as ``-devel``, and every migration
+    assertion below would then be measuring the wrong thing.
+
+    Given a ``.pkg`` whose BOTH manifests name ``pfSense-pkg-pfBlockerNG-devel``,
+    When  ``rename_pkg`` retargets it at ``pfSense-pkg-pfBlockerNG``,
+    Then  the written file is ``<canonical>-<version>.pkg``, BOTH manifests carry the
+      canonical name and a canonical ``origin``, version/ABI are untouched, and every
+      payload member survives byte-identical.
+    """
+    src = _synthetic_pkg(
+        tmp_path / "src" / f"{LEGACY_DEVEL_PKG_NAME}-1.2.3_4.pkg",
+        name=LEGACY_DEVEL_PKG_NAME,
+        version="1.2.3_4",
+        origin=f"net/{LEGACY_DEVEL_PKG_NAME}",
+    )
+
+    # BEFORE: the source really does carry the legacy identity in BOTH manifests.
+    before = _pkg_manifests(src)
+    assert sorted(before) == sorted(_PKG_MANIFEST_MEMBERS), f"synthetic .pkg is missing a manifest: {sorted(before)}"
+    for member, obj in before.items():
+        assert obj["name"] == LEGACY_DEVEL_PKG_NAME, f"BEFORE: {member} names {obj['name']!r}"
+
+    out = rename_pkg(src, CANONICAL_PKG_NAME, tmp_path / "renamed")
+
+    # AFTER: the identity moved everywhere it is recorded, and nothing else moved.
+    assert out.name == f"{CANONICAL_PKG_NAME}-1.2.3_4.pkg", f"unexpected output filename {out.name!r}"
+    after = _pkg_manifests(out)
+    assert sorted(after) == sorted(_PKG_MANIFEST_MEMBERS), f"rename dropped a manifest: {sorted(after)}"
+    for member, obj in after.items():
+        assert obj["name"] == CANONICAL_PKG_NAME, f"AFTER: {member} still names {obj['name']!r}"
+        assert obj["origin"] == f"net/{CANONICAL_PKG_NAME}", f"AFTER: {member} origin is {obj['origin']!r}"
+        assert obj["version"] == "1.2.3_4", f"AFTER: {member} version drifted to {obj['version']!r}"
+        assert obj["abi"] == "FreeBSD:15:*", f"AFTER: {member} abi drifted to {obj['abi']!r}"
+    assert _pkg_payload(out) == _pkg_payload(src), (
+        "rename_pkg altered the payload — the forged build is no longer the branch build"
+    )
+
+
+def test_project_conf_names_match_the_shipped_scripts() -> None:
+    """HERMETIC (no VM): the conf set this module sweeps IS the set the scripts manage.
+
+    ``PROJECT_CONF_NAMES`` drives both the per-channel parametrization and every
+    "exactly one project conf" assertion below. Add a fifth channel to ``add-repo.sh``'s
+    ``PROJECT_CONFS`` (or ``migrate-channel.sh``'s) without adding it here and the live
+    cases keep passing while silently covering one channel less and leaving its conf
+    unswept — a coverage hole that looks exactly like green. Both scripts are pinned, so
+    the two enumerations also cannot drift apart from each other.
+    """
+    for script in (ADD_REPO_SH, MIGRATE_CHANNEL_SH):
+        block = re.search(r'(?ms)^PROJECT_CONFS="(.*?)"', script.read_text())
+        assert block is not None, f"{script.name}: no PROJECT_CONFS list to compare against"
+        declared = tuple(line.strip() for line in block.group(1).splitlines() if line.strip())
+        assert declared == PROJECT_CONF_NAMES, (
+            f"{script.name} manages {declared}, this module sweeps {PROJECT_CONF_NAMES}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# On-guest subscription state — read + reset explicitly, never inherited
+# --------------------------------------------------------------------------- #
+
+
+def _write_guest_file(vm: SmokeVM, remote_path: str, body: str, *, timeout: float = 60.0) -> None:
+    """Write ``body`` to ``remote_path`` on the guest (the module's ``tee`` idiom)."""
+    result = subprocess.run(
+        vm.ssh_argv("tee", remote_path),
+        input=body,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"writing {remote_path} failed: rc={result.returncode} {result.stderr!r}")
+
+
+def project_confs_present(vm: SmokeVM, *, timeout: float = 60.0) -> set[str]:
+    """Which project confs actually exist under the on-box repos dir.
+
+    Effective state read off the box (the CLAUDE.md rule), not inferred from what a
+    script printed: this is the oracle for single-repository subscription.
+    """
+    result = vm.ssh("/bin/ls", "-1", PKG_REPOS_DIR, timeout=timeout)
+    if result.returncode != 0:  # the dir does not exist yet => no project conf
+        return set()
+    return {line.strip() for line in result.stdout.splitlines()} & set(PROJECT_CONF_NAMES)
+
+
+def remove_project_confs(vm: SmokeVM, *, timeout: float = 60.0) -> None:
+    """Delete EVERY project conf from the box."""
+    vm.ssh("/bin/rm", "-f", *(f"{PKG_REPOS_DIR}/{name}" for name in PROJECT_CONF_NAMES), timeout=timeout)
+
+
+def installed_pfblockerng_names(vm: SmokeVM, *, timeout: float = 60.0) -> list[str]:
+    """Every installed pfBlockerNG IDENTITY, sorted — the box's identity oracle.
+
+    ``-g`` makes the trailing ``*`` a glob; without it ``pkg query`` treats the pattern
+    as an exact name and matches nothing. This is the same query ``migrate-channel.sh``
+    classifies the box with, so a case asserting on it asserts on what the script sees.
+    A query miss is "nothing installed" (rc=1), not an error.
+    """
+    result = vm.ssh("pkg", "query", "-g", "%n", f"{CANONICAL_PKG_NAME}*", timeout=timeout)
+    if result.returncode not in (0, 1):
+        raise RuntimeError(
+            f"pkg query -g %n failed: rc={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return sorted(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def reset_channel_subscription(vm: SmokeVM) -> None:
+    """Return the box to "no project repo, no pfBlockerNG" — the explicit per-test reset.
+
+    Every case below builds its own before-state from here, so none of them depends on a
+    sibling having run first (or on the order pytest happens to pick for the
+    parametrized channels).
+    """
+    for name in (PKG_NAME, CANONICAL_PKG_NAME, LEGACY_DEVEL_PKG_NAME):
+        vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "delete", "-y", name, timeout=300.0)
+    remove_project_confs(vm)
+
+
+def pkg_install_qualified(
+    vm: SmokeVM,
+    repo_name: str,
+    target: str,
+    *,
+    force: bool = False,
+    timeout: float = 600.0,
+) -> subprocess.CompletedProcess[str]:
+    """``pkg install [-f] -y -r <repo> <target>`` — a REPOSITORY-QUALIFIED install.
+
+    ``-r`` pins WHICH catalogue serves the package, which is the whole point once every
+    channel publishes the same identity at the same priority. ``force`` adds ``-f``, the
+    only way to move to an equal-or-OLDER build (``pkg upgrade`` refuses a downgrade);
+    ``target`` may be a bare name or an exact ``<name>-<version>``.
+    """
+    force_args = ("-f",) if force else ()
+    remote = ("env", "ASSUME_ALWAYS_YES=yes", "pkg", "install", *force_args, "-y", "-r", repo_name, target)
+    result = _pkg_retry(vm, *remote, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pkg install -r {repo_name} {target} failed: rc={result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def run_migrate_channel_sh(vm: SmokeVM, *args: str, timeout: float = 900.0) -> subprocess.CompletedProcess[str]:
+    """Stage the SHIPPED ``scripts/migrate-channel.sh`` and run it with ``args``.
+
+    Returns the completed process WITHOUT raising: the refusal case asserts on the exit
+    code (4 = target unavailable) and on stderr, so a raising helper would hide it.
+    """
+    _ssh_check(vm, "/bin/mkdir", "-p", GUEST_SPIKE_DIR)
+    _scp_to_guest(vm, MIGRATE_CHANNEL_SH, GUEST_MIGRATE_CHANNEL_SH)
+    return vm.ssh("/bin/sh", GUEST_MIGRATE_CHANNEL_SH, *args, timeout=timeout)
+
+
+# --------------------------------------------------------------------------- #
+# Module fixture — the four channel catalogues + the legacy release catalogue
+# --------------------------------------------------------------------------- #
+
+
+class ChannelCatalogs(NamedTuple):
+    """What the four-channel cases need to know about the catalogues staged on the guest."""
+
+    root: str
+    """Guest catalogue root; ``<root>/<channel>/<varver>/`` is what the hook resolves."""
+    varver: str
+    """The box's own ``<varver>`` the catalogues are published under."""
+    versions: dict[str, str]
+    """channel -> the canonical version THAT channel serves (so ``%v`` identifies it)."""
+    legacy_version: str
+    """The ``-devel`` version the legacy release catalogue serves."""
+    edge_rollback_version: str
+    """The older canonical build ALSO carried by ``pfblockerng-edge`` (containment)."""
+
+    @property
+    def base_url(self) -> str:
+        """The ``--base-url`` add-repo.sh is driven with."""
+        return f"file://{self.root}"
+
+
+@pytest.fixture(scope="module")
+def channel_catalogs(repo_vm: SmokeVM, tmp_path_factory: pytest.TempPathFactory) -> Iterator[ChannelCatalogs]:
+    """Publish all four channel catalogues plus the legacy release catalogue on the guest.
+
+    ONE branch build stands in for every identity and every channel: ``rename_pkg`` forges
+    the canonical ``pfSense-pkg-pfBlockerNG`` and the legacy ``pfSense-pkg-pfBlockerNG-devel``
+    from it, and ``reversion_pkg`` gives each catalogue its OWN PORTREVISION, so
+    ``pkg query %v`` alone says which catalogue served a build.
+
+    ``pfblockerng-edge`` deliberately carries TWO canonical builds — its own ``_3`` and the
+    stable-era ``_1`` — because each channel catalogue strictly contains its slower
+    channels' files. That containment is what makes an in-repo rollback on a faster channel
+    possible, and it cannot be asserted against a single-version catalogue.
+
+    The legacy release catalogue carries ONLY the ``-devel`` identity: a box needing
+    migration is one that installed the suffixed package, and stocking the canonical one
+    beside it would let a migration "succeed" without ever crossing repositories.
+
+    Setup only — every case resets its own subscription state, so this fixture never
+    establishes an ordering between them.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"  # repo_vm already gated this
+    src = Path(pkg)
+    forge_dir = tmp_path_factory.mktemp("channel_forge")
+    base_version = read_compact_version(src)
+    real_varver = _box_real_varver(repo_vm)
+    dep_pkgs = _smoke_dep_pkg_paths()
+
+    canonical_src = rename_pkg(src, CANONICAL_PKG_NAME, forge_dir / "canonical")
+    legacy_src = rename_pkg(src, LEGACY_DEVEL_PKG_NAME, forge_dir / "legacy")
+    versions = {channel: f"{base_version}{rev}" for channel, rev in CHANNEL_REVISIONS.items()}
+    builds = {
+        channel: reversion_pkg(canonical_src, version, forge_dir / f"build_{channel}")
+        for channel, version in versions.items()
+    }
+    legacy_version = f"{base_version}{LEGACY_REVISION}"
+    legacy_build = reversion_pkg(legacy_src, legacy_version, forge_dir / "build_legacy")
+    edge_rollback_version = f"{base_version}{EDGE_ROLLBACK_REVISION}"
+
+    try:
+        for channel in CHANNELS:
+            # Each catalogue carries its own build plus everything its slower channels
+            # still hold — the containment that makes an in-repo rollback possible.
+            staged = [builds[channel], *(builds[slower] for slower in CHANNEL_CONTAINED_BUILDS.get(channel, ()))]
+            build_repo_via_portable_named(
+                repo_vm,
+                [*staged, *dep_pkgs],
+                tmp_path_factory.mktemp(f"catalog_{channel}"),
+                catalog_name=f"{channel}/{real_varver}",
+                guest_root=CHANNEL_REPO_ROOT,
+            )
+        build_repo_via_portable_named(
+            repo_vm,
+            [legacy_build, *dep_pkgs],
+            tmp_path_factory.mktemp("catalog_release"),
+            catalog_name=f"release/{real_varver}",
+            guest_root=CHANNEL_REPO_ROOT,
+        )
+        yield ChannelCatalogs(
+            root=CHANNEL_REPO_ROOT,
+            varver=real_varver,
+            versions=versions,
+            legacy_version=legacy_version,
+            edge_rollback_version=edge_rollback_version,
+        )
+    finally:
+        reset_channel_subscription(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", CHANNEL_REPO_ROOT, timeout=60.0)
+        repo_vm.ssh("/bin/rm", "-f", GUEST_MIGRATE_CHANNEL_SH, timeout=60.0)
+        # add-repo.sh installs the generator hook at the PRODUCTION rc.d path; drop it so
+        # a staged hook never survives into a later module sharing this guest.
+        repo_vm.ssh("/bin/rm", "-f", GUEST_HOOK_PATH, timeout=60.0)
+
+
+# --------------------------------------------------------------------------- #
+# The four-channel cases
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(900)  # two full add-repo.sh bootstraps (each a `pkg update -f`) > the 30s cap.
+@pytest.mark.parametrize("channel", CHANNELS)
+def test_add_repo_channel_leaves_exactly_one_project_conf(
+    repo_vm: SmokeVM,
+    channel_catalogs: ChannelCatalogs,
+    channel: str,
+) -> None:
+    """SINGLE-REPOSITORY SUBSCRIPTION: subscribing to a channel RETIRES every other one.
+
+    All five project repos share ``priority: 100`` and ``pkg`` does not order across
+    equal-priority repositories, so two enabled project confs make the build a box
+    receives depend on nothing the user can see. ``add-repo.sh --channel <ch>`` must
+    therefore leave exactly ONE conf behind — and say so, never silently.
+
+    Scenario: switching channels retires the previous subscription.
+      Background: the four channel catalogues + the legacy release catalogue, file://.
+
+    Given the box is subscribed to ANOTHER channel and additionally carries a stale
+      legacy ``pfblockerng.conf`` (as a pre-#2148 bootstrap or a restored config backup
+      leaves behind) — asserted as the BEFORE state, target conf absent,
+    When  ``add-repo.sh --base-url file://<root> --channel <ch>`` runs,
+    Then  ``<repos>/`` holds EXACTLY ``pfblockerng-<ch>.conf`` (both the previous
+      channel's conf and the legacy conf are gone), each retirement was REPORTED, the
+      surviving conf declares repo ``pfblockerng-<ch>`` at this box's ``<channel>/<varver>``
+      subtree, and ``pkg``'s own merged view (``pkg -vv``) shows that repo at priority 100
+      with no other project repo enabled.
+    """
+    previous = previous_channel(channel)
+    legacy_conf_path = f"{PKG_REPOS_DIR}/{LEGACY_RELEASE_CONF_NAME}"
+    reset_channel_subscription(repo_vm)
+
+    # GIVEN: subscribed to ANOTHER channel, plus a stale legacy conf beside it.
+    run_add_repo_sh(repo_vm, channel_catalogs.base_url, channel=previous)
+    _write_guest_file(
+        repo_vm,
+        legacy_conf_path,
+        _repo_block(OURS_REPO_NAME, f"{channel_catalogs.root}/release/{channel_catalogs.varver}", 100),
+    )
+    before = project_confs_present(repo_vm)
+    assert before == {channel_conf_name(previous), LEGACY_RELEASE_CONF_NAME}, (
+        f"BEFORE: expected the {previous} conf + the stale legacy conf, found {sorted(before)}"
+    )
+
+    # WHEN: subscribe to the target channel.
+    proc = run_add_repo_sh(repo_vm, channel_catalogs.base_url, channel=channel)
+
+    # THEN: exactly one project conf survives — this channel's.
+    after = project_confs_present(repo_vm)
+    assert after == {channel_conf_name(channel)}, (
+        f"AFTER --channel {channel}: expected only {channel_conf_name(channel)}, found {sorted(after)}"
+    )
+
+    # THEN: each retirement was reported (the script's "reported, never silent" rule).
+    for retired in (channel_conf_name(previous), LEGACY_RELEASE_CONF_NAME):
+        assert f"Retiring {PKG_REPOS_DIR}/{retired}" in proc.stdout, (
+            f"add-repo.sh removed {retired} without reporting it:\n{proc.stdout}"
+        )
+
+    # THEN: the surviving conf really is THIS channel's repository + subtree.
+    conf_body = _ssh_check(repo_vm, "/bin/cat", f"{PKG_REPOS_DIR}/{channel_conf_name(channel)}").stdout
+    assert f"{channel_repo_name(channel)}: {{" in conf_body, (
+        f"{channel_conf_name(channel)} does not declare repo {channel_repo_name(channel)!r}:\n{conf_body}"
+    )
+    assert f"/{channel}/{channel_catalogs.varver}" in conf_body, (
+        f"{channel_conf_name(channel)} does not point at the {channel}/{channel_catalogs.varver} subtree:\n{conf_body}"
+    )
+
+    # THEN (effective state, not just files): pkg's merged config has ONE project repo.
+    assert repo_priority(repo_vm, channel_repo_name(channel)) == 100, (
+        f"pkg does not see {channel_repo_name(channel)} at priority 100 (got "
+        f"{repo_priority(repo_vm, channel_repo_name(channel))})"
+    )
+    for other in (OURS_REPO_NAME, *(channel_repo_name(c) for c in CHANNELS if c != channel)):
+        assert repo_priority(repo_vm, other) == 0, (
+            f"pkg still has project repo {other!r} enabled after subscribing to {channel}"
+        )
+
+
+@pytest.mark.timeout(1800)  # legacy bootstrap + install + channel bootstrap + a real migration.
+def test_migrate_channel_replaces_the_legacy_identity_with_the_canonical_one(
+    repo_vm: SmokeVM,
+    channel_catalogs: ChannelCatalogs,
+) -> None:
+    """CANONICAL REPLACEMENT: a box on the legacy ``-devel`` identity ends up on the
+    canonical one, installed FROM the target channel repository.
+
+    The four channel catalogues publish only ``pfSense-pkg-pfBlockerNG``, so a box
+    carrying ``pfSense-pkg-pfBlockerNG-devel`` has no upgrade path at all until that
+    identity is REPLACED — ``pkg`` will not rename a package, and adding a repository
+    does not move an installed one. ``migrate-channel.sh`` performs the replacement.
+
+    The legacy build here is a HIGHER PORTREVISION than the channel build it is replaced
+    by, so nothing about this transition can be explained by version ordering: it happens
+    only because the operation is repository-qualified.
+
+    Scenario: legacy suffixed identity -> canonical identity on the stable channel.
+      Background: the legacy release catalogue serves ``-devel``; ``pfblockerng-stable``
+        serves the canonical package.
+
+    Given the box installed ``pfSense-pkg-pfBlockerNG-devel`` from the legacy
+      ``pfblockerng`` repo and the canonical identity is ABSENT (BEFORE asserted),
+    When  ``add-repo.sh --channel stable`` subscribes the box (repositories only — the
+      installed identity must be UNCHANGED at that point, asserted), and then
+      ``migrate-channel.sh --channel stable`` runs,
+    Then  it exits 0, the box carries EXACTLY ``pfSense-pkg-pfBlockerNG``, its ``%R`` is
+      ``pfblockerng-stable``, its ``%v`` is the version that catalogue serves, the legacy
+      identity is GONE, and the script reported the completed migration.
+    """
+    channel = "stable"
+    target_repo = channel_repo_name(channel)
+    target_version = channel_catalogs.versions[channel]
+    reset_channel_subscription(repo_vm)
+
+    # GIVEN: a box on the LEGACY shared release repo, carrying the suffixed identity.
+    run_add_repo_sh(repo_vm, channel_catalogs.base_url)  # no --channel => the legacy release repo
+    pkg_install_qualified(repo_vm, OURS_REPO_NAME, LEGACY_DEVEL_PKG_NAME)
+    assert installed_pfblockerng_names(repo_vm) == [LEGACY_DEVEL_PKG_NAME], (
+        f"BEFORE: expected only the legacy identity, found {installed_pfblockerng_names(repo_vm)}"
+    )
+    assert pkg_repo_origin_of(repo_vm, LEGACY_DEVEL_PKG_NAME) == OURS_REPO_NAME, (
+        f"BEFORE: the legacy build came from {pkg_repo_origin_of(repo_vm, LEGACY_DEVEL_PKG_NAME)!r}, "
+        f"expected the legacy release repo {OURS_REPO_NAME!r}"
+    )
+    assert pkg_installed_version_of(repo_vm, LEGACY_DEVEL_PKG_NAME) == channel_catalogs.legacy_version, (
+        f"BEFORE: legacy build is at {pkg_installed_version_of(repo_vm, LEGACY_DEVEL_PKG_NAME)!r}, "
+        f"expected {channel_catalogs.legacy_version!r}"
+    )
+    assert pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME) is None, (
+        "BEFORE: the canonical identity is already installed — nothing left to prove"
+    )
+
+    # WHEN (1): subscribe to the target channel. This configures REPOSITORIES ONLY.
+    run_add_repo_sh(repo_vm, channel_catalogs.base_url, channel=channel)
+    assert project_confs_present(repo_vm) == {channel_conf_name(channel)}, (
+        f"subscribing to {channel} left {sorted(project_confs_present(repo_vm))} behind"
+    )
+    assert installed_pfblockerng_names(repo_vm) == [LEGACY_DEVEL_PKG_NAME], (
+        "add-repo.sh moved the INSTALLED package — configuring a repository is not a "
+        "migration, and pkg does not cross repositories on its own"
+    )
+
+    # WHEN (2): run the migration.
+    proc = run_migrate_channel_sh(repo_vm, "--channel", channel)
+    assert proc.returncode == 0, (
+        f"migrate-channel.sh --channel {channel} exited {proc.returncode}\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+    # THEN: exactly the canonical identity, from the target channel's repository.
+    # (Payload completeness is the script's own step 6 — `pkg info -l` sweep — so a
+    # rc=0 already carries it; re-walking the file list here would only restate it.)
+    assert installed_pfblockerng_names(repo_vm) == [CANONICAL_PKG_NAME], (
+        f"AFTER: expected only {CANONICAL_PKG_NAME}, found {installed_pfblockerng_names(repo_vm)}"
+    )
+    assert pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME) == target_repo, (
+        f"AFTER: canonical build reports repo {pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME)!r}, "
+        f"expected {target_repo!r} — the box is not on the {channel} channel"
+    )
+    assert pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME) == target_version, (
+        f"AFTER: canonical build is at {pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME)!r}, "
+        f"expected {target_version!r} — the version {target_repo} serves"
+    )
+    assert pkg_installed_version_of(repo_vm, LEGACY_DEVEL_PKG_NAME) is None, (
+        "AFTER: the legacy identity is STILL installed — it was not replaced, it was joined"
+    )
+    assert f"==> Done — {CANONICAL_PKG_NAME}-{target_version} installed from {target_repo}" in proc.stdout, (
+        f"migrate-channel.sh did not report the completed migration:\n{proc.stdout}"
+    )
+
+
+@pytest.mark.timeout(1800)  # bootstrap + install the newer build + a forced in-repo downgrade.
+def test_edge_rollback_stays_within_the_edge_repository(
+    repo_vm: SmokeVM,
+    channel_catalogs: ChannelCatalogs,
+) -> None:
+    """IN-REPO ROLLBACK: a box on ``edge`` moves BACK to an older build WITHOUT switching
+    repositories, because ``pfblockerng-edge`` already contains it.
+
+    Each channel catalogue strictly contains its slower channels' files (edge ⊇ testing ⊇
+    stable), so "go back to the stable-era build" is a repository-qualified operation
+    inside the one repo the box is subscribed to — not a re-subscription. If it required
+    switching repos, single-repository subscription would be unworkable for anyone on a
+    faster channel, so this is the case that makes that design hold.
+
+    ``-f`` is required: ``pkg upgrade`` refuses to move DOWN, and the exact
+    ``<name>-<version>`` picks the older of the two builds the edge catalogue carries.
+
+    Scenario: rolling back on edge.
+      Background: ``pfblockerng-edge`` serves BOTH the edge build and the older
+        stable-era build of the canonical package.
+
+    Given the box subscribed to edge and running the NEWER edge build (BEFORE asserted:
+      ``%v`` is edge's version, ``%R`` is ``pfblockerng-edge``),
+    When  ``pkg install -f -y -r pfblockerng-edge pfSense-pkg-pfBlockerNG-<older>`` runs,
+    Then  ``%v`` is the OLDER version, ``%R`` is STILL ``pfblockerng-edge``, the box still
+      carries exactly the canonical identity, and its subscription is untouched —
+      ``pfblockerng-edge.conf`` is still the only project conf on the box.
+    """
+    channel = "edge"
+    target_repo = channel_repo_name(channel)
+    newer = channel_catalogs.versions[channel]
+    older = channel_catalogs.edge_rollback_version
+    assert newer != older, f"the rollback pair must differ (both {newer!r})"
+
+    reset_channel_subscription(repo_vm)
+    run_add_repo_sh(repo_vm, channel_catalogs.base_url, channel=channel)
+
+    # GIVEN: the box on edge's OWN (newer) build, from the edge repository.
+    pkg_install_qualified(repo_vm, target_repo, CANONICAL_PKG_NAME)
+    assert pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME) == newer, (
+        f"BEFORE: expected edge's build {newer!r}, got {pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME)!r}"
+    )
+    assert pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME) == target_repo, (
+        f"BEFORE: installed from {pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME)!r}, expected {target_repo!r}"
+    )
+    assert project_confs_present(repo_vm) == {channel_conf_name(channel)}, (
+        f"BEFORE: expected only {channel_conf_name(channel)}, found {sorted(project_confs_present(repo_vm))}"
+    )
+
+    # WHEN: roll back WITHIN the edge repository, repository-qualified and forced.
+    proc = pkg_install_qualified(repo_vm, target_repo, f"{CANONICAL_PKG_NAME}-{older}", force=True)
+
+    # THEN: the box moved DOWN a version and did NOT move repository.
+    assert pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME) == older, (
+        f"AFTER: rollback did not move {newer!r} -> {older!r}; now at "
+        f"{pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME)!r}"
+    )
+    assert pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME) == target_repo, (
+        f"AFTER: the rollback changed the repository to "
+        f"{pkg_repo_origin_of(repo_vm, CANONICAL_PKG_NAME)!r}, expected to stay on {target_repo!r}"
+    )
+    assert installed_pfblockerng_names(repo_vm) == [CANONICAL_PKG_NAME], (
+        f"AFTER: expected only {CANONICAL_PKG_NAME}, found {installed_pfblockerng_names(repo_vm)}"
+    )
+    assert project_confs_present(repo_vm) == {channel_conf_name(channel)}, (
+        f"AFTER: the rollback changed the subscription to {sorted(project_confs_present(repo_vm))}"
+    )
+    combined = proc.stdout + proc.stderr
+    assert "Missing dependency" not in combined, f"RUN_DEPENDS did not resolve on the rollback:\n{combined}"
+
+
+@pytest.mark.timeout(1200)  # legacy bootstrap + install + a refused migration.
+def test_migrate_channel_refuses_an_unsubscribed_channel_before_mutating(
+    repo_vm: SmokeVM,
+    channel_catalogs: ChannelCatalogs,
+) -> None:
+    """UNHAPPY PATH: migrating to a channel the box is not subscribed to fails BEFORE any
+    mutation — the installed identity is left exactly as it was.
+
+    ``migrate-channel.sh`` deletes the legacy package before installing the canonical one,
+    so an ordering bug (check the target repo AFTER the delete) would leave a box with NO
+    pfBlockerNG at all. The subscription check must therefore come first, and "first" is
+    only provable by asserting the installed state is byte-for-byte unchanged after the
+    refusal — an exit code alone cannot distinguish "refused" from "half-migrated".
+
+    Scenario: migrating without running add-repo.sh first.
+
+    Given the box carries ``pfSense-pkg-pfBlockerNG-devel`` from the legacy repo and
+      ``pfblockerng-nightly.conf`` does NOT exist (BEFORE asserted),
+    When  ``migrate-channel.sh --channel nightly`` runs,
+    Then  it exits 4, names the unconfigured channel and the add-repo.sh command that
+      fixes it, prints NOTHING about the box's state (it never got that far), and the
+      legacy identity is still installed at the same version from the same repository,
+      with the canonical identity still absent.
+    """
+    target = "nightly"
+    reset_channel_subscription(repo_vm)
+
+    # GIVEN: a box on the legacy repo, never subscribed to the target channel.
+    run_add_repo_sh(repo_vm, channel_catalogs.base_url)  # no --channel => the legacy release repo
+    pkg_install_qualified(repo_vm, OURS_REPO_NAME, LEGACY_DEVEL_PKG_NAME)
+    before_names = installed_pfblockerng_names(repo_vm)
+    before_version = pkg_installed_version_of(repo_vm, LEGACY_DEVEL_PKG_NAME)
+    before_origin = pkg_repo_origin_of(repo_vm, LEGACY_DEVEL_PKG_NAME)
+    assert before_names == [LEGACY_DEVEL_PKG_NAME], f"BEFORE: expected the legacy identity, found {before_names}"
+    assert before_version == channel_catalogs.legacy_version, (
+        f"BEFORE: legacy build is at {before_version!r}, expected {channel_catalogs.legacy_version!r}"
+    )
+    assert channel_conf_name(target) not in project_confs_present(repo_vm), (
+        f"BEFORE: the box is already subscribed to {target} — the refusal cannot be exercised"
+    )
+
+    # WHEN: ask to migrate onto the unconfigured channel.
+    proc = run_migrate_channel_sh(repo_vm, "--channel", target)
+
+    # THEN: refused with the "target unavailable" code, and told how to fix it.
+    assert proc.returncode == 4, (
+        f"expected exit 4 (target unavailable), got {proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    assert f"not subscribed to the {target} channel" in proc.stderr, (
+        f"the refusal does not name the unconfigured channel:\n{proc.stderr}"
+    )
+    assert f"add-repo.sh --channel {target}" in proc.stderr, (
+        f"the refusal does not point at the command that fixes it:\n{proc.stderr}"
+    )
+
+    # THEN: it refused BEFORE classifying the box, let alone mutating it.
+    assert "==> Installed:" not in proc.stdout, (
+        f"the subscription check ran AFTER the box was classified:\n{proc.stdout}"
+    )
+    assert installed_pfblockerng_names(repo_vm) == before_names, (
+        f"the refused migration changed the installed identities: {before_names} -> "
+        f"{installed_pfblockerng_names(repo_vm)}"
+    )
+    assert pkg_installed_version_of(repo_vm, LEGACY_DEVEL_PKG_NAME) == before_version, (
+        f"the refused migration changed the installed version: {before_version!r} -> "
+        f"{pkg_installed_version_of(repo_vm, LEGACY_DEVEL_PKG_NAME)!r}"
+    )
+    assert pkg_repo_origin_of(repo_vm, LEGACY_DEVEL_PKG_NAME) == before_origin, (
+        f"the refused migration changed the installed repo: {before_origin!r} -> "
+        f"{pkg_repo_origin_of(repo_vm, LEGACY_DEVEL_PKG_NAME)!r}"
+    )
+    assert pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME) is None, (
+        "the refused migration installed the canonical package anyway"
+    )

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2840,10 +2840,19 @@ def test_software_actions_link_to_package_manager(
 
         # (B) Seed a newer cached 'latest' → update available → the Update href becomes the actionable
         #     reinstallpkg link (the ON branch of the availability gate). 99.0.0 > any real installed
-        #     version, so pfb_update_available() is TRUE regardless of the branch build.
+        #     version, so pfb_update_available() is TRUE regardless of the branch build. The seed
+        #     carries the installed package's own name because the page only trusts a cache that
+        #     describes the install it is looking at (issue #2148); a nameless cache is not one.
         try:
             smoke_vm.ssh("/bin/rm", "-f", software_cache)
-            _seed_vm_file(smoke_vm, software_cache, '{"latest": "99.0.0", "last_checked": 1}')
+            seed = json.dumps(
+                {
+                    "pkgname": pkg_identity.branch_pkg_name(os.environ.get("SMOKE_PKG")),
+                    "latest": "99.0.0",
+                    "last_checked": 1,
+                }
+            )
+            _seed_vm_file(smoke_vm, software_cache, seed)
             up_tag2 = _update_anchor(webui.get(_SOFTWARE_PAGE).text)
             assert _has_pkgmgr_href(up_tag2, "reinstallpkg"), (
                 f"Update link must target pkg_mgr_install.php?mode=reinstallpkg when an update exists: {up_tag2!r}"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2738,6 +2738,10 @@ def test_software_panel_channel_falls_back_to_the_package_name_off_repo(
     pkgname = pkg_identity.branch_pkg_name(os.environ.get("SMOKE_PKG"))
 
     repo_probe = smoke_vm.ssh("/usr/local/sbin/pkg", "query", "%R", pkgname)
+    assert repo_probe.returncode == 0, (
+        f"could not read the installed repo for {pkgname!r} "
+        f"(rc={repo_probe.returncode}): {(repo_probe.stderr or repo_probe.stdout).strip()!r}"
+    )
     installed_repo = repo_probe.stdout.strip()
     assert not installed_repo.startswith("pfblockerng-"), (
         f"before-state broken: this deploy reports channel repo {installed_repo!r}, so it "
@@ -2745,7 +2749,10 @@ def test_software_panel_channel_falls_back_to_the_package_name_off_repo(
     )
 
     with software_panel_forced(smoke_vm, "on"):
-        body = webui.get(_SOFTWARE_PAGE).text
+        resp = webui.get(_SOFTWARE_PAGE)
+        result = evaluate_render(_SOFTWARE_PAGE, resp.status_code, resp.text, (_SOFTWARE_PANEL_MARKER,))
+        assert result.ok, f"Software page render oracle failed: {result.detail}"
+        body = resp.text
 
     panel = re.search(rf'<span id="{_SOFTWARE_PANEL_MARKER}">([^<]*)</span>', body)
     assert panel is not None, f"the {_SOFTWARE_PANEL_MARKER} span is absent from the Software page body"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -28,6 +28,7 @@ and the access note for Phase 5, NOT silently dropped.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import uuid
@@ -37,7 +38,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from .. import helpers
+from .. import helpers, pkg_identity
 from .render_oracle import PhpErrorLogGuard, evaluate_render
 from .test_category import _snapshot_node
 from .test_category_edit import CFG_DNSBL, CFG_IPV4, _del_rowid, _free_rowid
@@ -2708,6 +2709,51 @@ def test_software_page_renders_when_override_forces_on(
         # The tab is injected everywhere on an enabled build — the positive of the tab-absent test.
         general = webui.get(_GENERAL_PAGE)
         assert _SOFTWARE_TAB_HREF in general.text, "the Software tab must be PRESENT when the gate is forced on"
+
+
+def test_software_panel_channel_falls_back_to_the_package_name_off_repo(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """The rendered channel survives an install whose repo names no channel (issue #2148).
+
+    All four channel catalogues publish the ONE canonical ``pfSense-pkg-pfBlockerNG``, so the
+    page derives the channel from the repo the package came from (``pkg query %R`` ->
+    ``pfblockerng-<ch>``) and falls back to the package NAME only when that repo names no
+    channel. The Tier-A deploy is exactly that case: an offline ``pkg add -f`` sideload leaves
+    ``%R`` empty, which is what makes it able to prove the fallback branch at all.
+
+    Scenario:
+      Given the sideload deploy, whose installed ``%R`` is NOT one of the channel repos
+          (asserted as the before-state — the fallback is only under test while that holds),
+      And the hidden override forcing the provenance gate on,
+      When the Software page is GET,
+      Then the ``pfb-software-panel`` marker renders the channel the BUILT ARTIFACT reports
+          (`pkg_identity.branch_channel`, never a hard-coded name — issue #2166), not the
+          literal repo string and not the ``unknown`` placeholder.
+
+    Fail-before/pass-after: a repo-only derivation with no name fallback renders ``unknown``
+    here, and a derivation that leaked the repo through renders the empty repo string.
+    """
+    expected_channel = pkg_identity.branch_channel(os.environ.get("SMOKE_PKG"))
+    pkgname = pkg_identity.branch_pkg_name(os.environ.get("SMOKE_PKG"))
+
+    repo_probe = smoke_vm.ssh("/usr/local/sbin/pkg", "query", "%R", pkgname)
+    installed_repo = repo_probe.stdout.strip()
+    assert not installed_repo.startswith("pfblockerng-"), (
+        f"before-state broken: this deploy reports channel repo {installed_repo!r}, so it "
+        "exercises the repo branch, not the name fallback this case is written for"
+    )
+
+    with software_panel_forced(smoke_vm, "on"):
+        body = webui.get(_SOFTWARE_PAGE).text
+
+    panel = re.search(rf'<span id="{_SOFTWARE_PANEL_MARKER}">([^<]*)</span>', body)
+    assert panel is not None, f"the {_SOFTWARE_PANEL_MARKER} span is absent from the Software page body"
+    rendered = panel.group(1).strip()
+    assert rendered == expected_channel, (
+        f"Software panel rendered channel {rendered!r}, expected {expected_channel!r} "
+        f"(installed {pkgname!r} from repo {installed_repo!r})"
+    )
 
 
 def test_software_actions_link_to_package_manager(

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -124,7 +124,13 @@ def _print_conf_sh(script: Path, catalog_path: str = _CE_28, base_url: str = _PA
 
 
 def _run_add_repo(
-    root: str, *, nightly: bool = False, extra_args: tuple[str, ...] = (), catalogue_empty: bool = False
+    root: str,
+    *,
+    nightly: bool = False,
+    extra_args: tuple[str, ...] = (),
+    catalogue_empty: bool = False,
+    update_fails: bool = False,
+    detection_fails: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Run add-repo.sh with PFBLOCKERNG_ROOT=root.
 
@@ -137,26 +143,38 @@ def _run_add_repo(
     resolves the conf from ``root/etc/product_label`` (CE here — no "Plus") and
     ``root/etc/version`` (2.8.1).
 
-    ``catalogue_empty`` makes `rquery` yield nothing — a channel with no build
-    published for this box's variant. That is the failure path which must leave the
-    box's repository configuration exactly as it found it (issue #2148).
+    The three keyword flags each select one of the bootstrap's failure gates, all of
+    which must leave the box's repository configuration exactly as they found it
+    (issue #2148):
+
+    ``catalogue_empty``  `rquery` yields nothing — the channel has no build for this
+                         box's variant.
+    ``update_fails``     `pkg update` exits non-zero — any enabled repository failed
+                         to refresh, including the one being switched away from.
+    ``detection_fails``  ``/etc/version`` is blank, so the generator hook cannot
+                         resolve a varver and never writes the conf's marker line.
     """
     bin_dir = os.path.join(root, "bin")
     os.makedirs(bin_dir, exist_ok=True)
 
     fake_pkg = os.path.join(bin_dir, "pkg")
     rquery_reply = "" if catalogue_empty else "  printf 'pfSense-pkg-pfBlockerNG 4.0.0\\n'\n"
+    update_reply = "  exit 1\n" if update_fails else "  exit 0\n"
     with open(fake_pkg, "w") as fh:
         fh.write(
-            f'#!/bin/sh\n# fake pkg stub for tests\nif [ "$1" = "rquery" ]; then\n{rquery_reply}  exit 0\nfi\nexit 0\n'
+            "#!/bin/sh\n# fake pkg stub for tests\n"
+            f'if [ "$1" = "rquery" ]; then\n{rquery_reply}  exit 0\nfi\n'
+            f'if [ "$1" = "update" ]; then\n{update_reply}fi\n'
+            "exit 0\n"
         )
     os.chmod(fake_pkg, 0o755)
 
-    # CE 2.8.1 box fixture: /etc/version + /etc/product_label (no "Plus" → CE).
+    # CE 2.8.1 box fixture: /etc/version + /etc/product_label (no "Plus" → CE). A blank
+    # version is how the hook's variant detection is made to fail.
     etc_dir = os.path.join(root, "etc")
     os.makedirs(etc_dir, exist_ok=True)
     with open(os.path.join(etc_dir, "version"), "w") as fh:
-        fh.write("2.8.1\n")
+        fh.write("" if detection_fails else "2.8.1\n")
     with open(os.path.join(etc_dir, "product_label"), "w") as fh:
         fh.write("pfSense\n")
 
@@ -787,22 +805,81 @@ def test_add_repo_unpublished_channel_leaves_the_previous_subscription_intact() 
         )
 
 
-def test_add_repo_failed_reswitch_keeps_a_conf_it_did_not_create() -> None:
-    """The failure cleanup removes only what THIS run staged.
+def test_add_repo_failed_reswitch_restores_the_conf_it_did_not_create() -> None:
+    """The failure cleanup restores what THIS run truncated, not merely leaves a file.
 
-    Re-running the bootstrap for the channel the box is already on, against a
-    catalogue that has gone empty, must not delete that existing subscription —
-    removing it would be the very destruction the deferred retirement prevents.
+    Staging overwrites the conf in place, so re-running the bootstrap for the channel
+    the box is already on destroys the working conf before it can fail. "The file still
+    exists" is not enough — a one-line staging stub subscribes to nothing, which is the
+    same stranded box the deferred retirement exists to prevent. The previous body has
+    to come back byte-for-byte.
+
+    Variant detection is what fails here, deliberately. It is the only gate that fires
+    while the conf is still the stub: an empty catalogue fails later, by which point the
+    hook has already regenerated the same body the box started with, so that path cannot
+    tell a restore from a no-op.
     """
     with tempfile.TemporaryDirectory() as root:
         _run_add_repo(root, extra_args=("--channel", "edge"))
         edge_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES["edge"]
         assert edge_conf.exists(), "before-state: the box must be subscribed to edge"
+        edge_before = edge_conf.read_text()
+        assert "pfblockerng-edge: {" in edge_before, "before-state: the conf must carry a real repo stanza"
 
-        proc = _run_add_repo(root, extra_args=("--channel", "edge"), catalogue_empty=True)
+        proc = _run_add_repo(root, extra_args=("--channel", "edge"), detection_fails=True)
 
-        assert proc.returncode != 0, "an empty catalogue must still fail loudly"
-        assert edge_conf.exists(), "a conf the run did not create must survive its failure"
+        assert proc.returncode != 0, "an unresolvable conf must fail loudly"
+        assert edge_conf.read_text() == edge_before, (
+            f"the pre-existing conf must come back byte-identical, not as a stub:\n{edge_conf.read_text()}"
+        )
+        assert not list(_repos_dir(root).glob("*.pfb-prev.*")), "the restore must leave no backup file behind"
+
+
+def test_add_repo_failed_detection_leaves_the_previous_subscription_intact() -> None:
+    """The OTHER failure gate: the generator hook could not resolve a varver.
+
+    A blank ``/etc/version`` leaves the staged conf without its marker line, and the
+    bootstrap fails there — earlier than the catalogue verify, and before any
+    retirement. The box must still come out of it subscribed exactly as it went in.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        _run_add_repo(root, extra_args=("--channel", "nightly"))
+        nightly_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES["nightly"]
+        stable_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES["stable"]
+        nightly_before = nightly_conf.read_text()
+
+        proc = _run_add_repo(root, extra_args=("--channel", "stable"), detection_fails=True)
+
+        assert proc.returncode != 0, "a hook that cannot resolve the conf must fail loudly"
+        assert not stable_conf.exists(), (
+            f"the unresolved conf this run staged must be removed:\n{proc.stdout}\n{proc.stderr}"
+        )
+        assert nightly_conf.read_text() == nightly_before, "the previous subscription must be untouched"
+
+
+def test_add_repo_failed_pkg_update_leaves_exactly_one_project_conf() -> None:
+    """``pkg update`` failing must not strand the box on TWO project repositories.
+
+    ``pkg update`` exits non-zero when ANY enabled repository fails to refresh —
+    including the channel the box is switching away from, whose catalogue going
+    unpublished is precisely why someone switches. Retirement happens after this point,
+    so an unhandled failure here would leave both confs enabled at the same priority,
+    which the script itself documents as unsupported: ``pkg`` does not order across
+    equal-priority repositories, so the build the box receives becomes undetermined.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        _run_add_repo(root, extra_args=("--channel", "testing"))
+        testing_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES["testing"]
+        testing_before = testing_conf.read_text()
+
+        proc = _run_add_repo(root, extra_args=("--channel", "edge"), update_fails=True)
+
+        assert proc.returncode != 0, "a failed pkg update must fail loudly"
+        present = {p.name for p in _repos_dir(root).glob("pfblockerng*.conf")}
+        assert present == {_CHANNEL_CONF_NAMES["testing"]}, (
+            f"expected the box to still be on testing alone, found {sorted(present)}:\n{proc.stdout}\n{proc.stderr}"
+        )
+        assert testing_conf.read_text() == testing_before, "the surviving subscription must be unchanged"
 
 
 def test_add_repo_channel_nightly_live_bootstrap_matches_flag_nightly() -> None:

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -124,27 +124,32 @@ def _print_conf_sh(script: Path, catalog_path: str = _CE_28, base_url: str = _PA
 
 
 def _run_add_repo(
-    root: str, *, nightly: bool = False, extra_args: tuple[str, ...] = ()
+    root: str, *, nightly: bool = False, extra_args: tuple[str, ...] = (), catalogue_empty: bool = False
 ) -> subprocess.CompletedProcess[str]:
     """Run add-repo.sh with PFBLOCKERNG_ROOT=root.
 
-    PKG_BIN is overridden to a stub that exits 0 (no output) for every
-    subcommand — add-repo.sh's own live-bootstrap steps (`pkg update`, `pkg
-    rquery`) tolerate that; the generator hook no longer calls `pkg` at all
-    (arch-less catalog; issue #1806 — it used to read `pkg config abi` only to
-    derive the now-retired per-arch leaf). add-repo.sh installs the generator
-    hook into ``root`` and runs it; the hook resolves the conf from
-    ``root/etc/product_label`` (CE here — no "Plus") and ``root/etc/version``
-    (2.8.1). We assert only that the conf file was written; exit code is
-    irrelevant (the rquery verify fails because the stub is empty).
+    PKG_BIN is overridden to a stub that answers `pkg rquery` with a plausible
+    package line, so the bootstrap reaches its success path; every other subcommand
+    is a silent success. The generator hook no longer calls `pkg` at all (arch-less
+    catalog; issue #1806 — it used to read `pkg config abi` only to derive the
+    now-retired per-arch leaf), so `rquery` is the only answer that matters.
+    add-repo.sh installs the generator hook into ``root`` and runs it; the hook
+    resolves the conf from ``root/etc/product_label`` (CE here — no "Plus") and
+    ``root/etc/version`` (2.8.1).
+
+    ``catalogue_empty`` makes `rquery` yield nothing — a channel with no build
+    published for this box's variant. That is the failure path which must leave the
+    box's repository configuration exactly as it found it (issue #2148).
     """
     bin_dir = os.path.join(root, "bin")
     os.makedirs(bin_dir, exist_ok=True)
 
-    # pkg stub: exits 0 (no output) for every subcommand.
     fake_pkg = os.path.join(bin_dir, "pkg")
+    rquery_reply = "" if catalogue_empty else "  printf 'pfSense-pkg-pfBlockerNG 4.0.0\\n'\n"
     with open(fake_pkg, "w") as fh:
-        fh.write("#!/bin/sh\n# fake pkg stub for tests\nexit 0\n")
+        fh.write(
+            f'#!/bin/sh\n# fake pkg stub for tests\nif [ "$1" = "rquery" ]; then\n{rquery_reply}  exit 0\nfi\nexit 0\n'
+        )
     os.chmod(fake_pkg, 0o755)
 
     # CE 2.8.1 box fixture: /etc/version + /etc/product_label (no "Plus" → CE).
@@ -751,6 +756,53 @@ def test_add_repo_live_bootstrap_replaces_a_previously_enabled_channel(previous:
         assert _CHANNEL_CONF_NAMES[previous] in (proc.stdout + proc.stderr), (
             f"the switch must report retiring {previous}:\n{proc.stdout}\n{proc.stderr}"
         )
+
+
+def test_add_repo_unpublished_channel_leaves_the_previous_subscription_intact() -> None:
+    """A channel with no build for this box must not cost the box its working subscription.
+
+    Retiring the other project confs BEFORE proving the target catalogue serves this
+    box would strand it: the previous channel is gone, the new one has nothing to
+    install, and the box has no way back short of remembering which channel it was on.
+
+    Scenario: given a box subscribed to nightly, when the user bootstraps edge and the
+    edge catalogue turns out to carry nothing for this variant, then the run fails
+    loudly AND the box is still subscribed to nightly alone — the staged edge conf is
+    removed, so the repository configuration is exactly what it was before.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        _run_add_repo(root, extra_args=("--channel", "nightly"))
+        nightly_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES["nightly"]
+        edge_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES["edge"]
+        assert nightly_conf.exists(), "before-state: the box must be subscribed to nightly"
+        nightly_before = nightly_conf.read_text()
+
+        proc = _run_add_repo(root, extra_args=("--channel", "edge"), catalogue_empty=True)
+
+        assert proc.returncode != 0, f"an unpublished channel must fail loudly:\n{proc.stdout}\n{proc.stderr}"
+        assert nightly_conf.exists(), "the previous subscription must survive a failed switch"
+        assert nightly_conf.read_text() == nightly_before, "the previous subscription must be left byte-identical"
+        assert not edge_conf.exists(), (
+            f"a failed switch must not leave the unusable conf behind:\n{proc.stdout}\n{proc.stderr}"
+        )
+
+
+def test_add_repo_failed_reswitch_keeps_a_conf_it_did_not_create() -> None:
+    """The failure cleanup removes only what THIS run staged.
+
+    Re-running the bootstrap for the channel the box is already on, against a
+    catalogue that has gone empty, must not delete that existing subscription —
+    removing it would be the very destruction the deferred retirement prevents.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        _run_add_repo(root, extra_args=("--channel", "edge"))
+        edge_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES["edge"]
+        assert edge_conf.exists(), "before-state: the box must be subscribed to edge"
+
+        proc = _run_add_repo(root, extra_args=("--channel", "edge"), catalogue_empty=True)
+
+        assert proc.returncode != 0, "an empty catalogue must still fail loudly"
+        assert edge_conf.exists(), "a conf the run did not create must survive its failure"
 
 
 def test_add_repo_channel_nightly_live_bootstrap_matches_flag_nightly() -> None:

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -123,7 +123,9 @@ def _print_conf_sh(script: Path, catalog_path: str = _CE_28, base_url: str = _PA
     return proc.stdout
 
 
-def _run_add_repo(root: str, *, nightly: bool = False, extra_args: tuple[str, ...] = ()) -> None:
+def _run_add_repo(
+    root: str, *, nightly: bool = False, extra_args: tuple[str, ...] = ()
+) -> subprocess.CompletedProcess[str]:
     """Run add-repo.sh with PFBLOCKERNG_ROOT=root.
 
     PKG_BIN is overridden to a stub that exits 0 (no output) for every
@@ -159,7 +161,7 @@ def _run_add_repo(root: str, *, nightly: bool = False, extra_args: tuple[str, ..
         "PKG_BIN": fake_pkg,
     }
     argv = ["sh", str(_ADD_REPO), *(["--nightly"] if nightly else []), *extra_args]
-    subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
+    return subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
 
 
 def _field(conf: str, key: str) -> str:
@@ -207,13 +209,23 @@ def test_release_conf_byte_identical_plus_26_03() -> None:
     assert add == portable, f"add-repo.sh vs portable mismatch (plus-26.03):\nadd:\n{add}\nportable:\n{portable}"
 
 
+def _hook_conf_env(repos: str) -> dict[str, str]:
+    """Every ``PFB_*_CONF`` override the hook reads, pointed inside ``repos``.
+
+    Passing ALL of them is mandatory for hermeticity: an override the test omits
+    falls back to its ``/usr/local/etc/pkg/repos/`` default, so the hook would
+    regenerate the REAL box's conf during a test run.
+    """
+    return {f"PFB_{channel.upper()}_CONF": os.path.join(repos, name) for channel, name in _CHANNEL_CONF_NAMES.items()}
+
+
 def _run_hook(root: str, *, edition_label: str, version: str, channel: str) -> str:
     """Run the generator hook off-box against a stubbed box; return the conf it wrote.
 
-    ``channel`` selects which conf the hook regenerates (release|nightly): we stage
-    only that one so the orphan guard leaves the other absent. The hook runs the
-    *_start path directly off-box (no /etc/rc.subr present). No `pkg` stub needed —
-    the hook is arch-less (issue #1806) and no longer calls `pkg` at all.
+    ``channel`` selects which conf the hook regenerates: we stage only that one so
+    the orphan guard leaves every other channel absent. The hook runs the *_start
+    path directly off-box (no /etc/rc.subr present). No `pkg` stub needed — the
+    hook is arch-less (issue #1806) and no longer calls `pkg` at all.
     """
     repos = os.path.join(root, "repos")
     os.makedirs(repos, exist_ok=True)
@@ -225,15 +237,13 @@ def _run_hook(root: str, *, edition_label: str, version: str, channel: str) -> s
     with open(ver, "w") as fh:
         fh.write(version + "\n")
 
-    conf_name = "pfblockerng.conf" if channel == "release" else "pfblockerng-nightly.conf"
-    conf_path = os.path.join(repos, conf_name)
+    conf_path = os.path.join(repos, _CHANNEL_CONF_NAMES[channel])
     with open(conf_path, "w") as fh:
         fh.write("# stub pending\n")
 
     env = {
         **os.environ,
-        "PFB_RELEASE_CONF": os.path.join(repos, "pfblockerng.conf"),
-        "PFB_NIGHTLY_CONF": os.path.join(repos, "pfblockerng-nightly.conf"),
+        **_hook_conf_env(repos),
         "PFB_PRODUCT_LABEL": label,
         "PFB_VERSION_FILE": ver,
     }
@@ -260,6 +270,40 @@ def test_hook_output_byte_identical_to_print_conf_nightly_plus() -> None:
     print_conf = _print_conf_sh(_ADD_REPO, _PLUS_2603, _PAGES_BASE, "--nightly")
     assert hook_conf == print_conf, (
         f"hook nightly vs --print-conf drift:\nhook:\n{hook_conf}\nprint-conf:\n{print_conf}"
+    )
+
+
+@pytest.mark.parametrize("channel", _CHANNELS)
+def test_hook_regenerates_every_channel_byte_identical_to_print_conf(channel: str) -> None:
+    """The boot hook resolves EVERY channel's conf, byte-identical to --print-conf.
+
+    Boot regeneration is what keeps a subscription correct across a pfSense OS
+    upgrade (the varver moves). Before issue #2148 the hook knew only the legacy
+    release conf and nightly, so a box subscribed to stable/testing/edge would keep
+    a stale URL forever; every channel is now regenerated from the same body.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        hook_conf = _run_hook(root, edition_label="pfSense", version="2.8.1", channel=channel)
+    print_conf = _print_conf_sh(_ADD_REPO, _CE_28, _PAGES_BASE, "--channel", channel)
+    assert hook_conf == print_conf, (
+        f"hook {channel} vs --print-conf drift:\nhook:\n{hook_conf}\nprint-conf:\n{print_conf}"
+    )
+
+
+@pytest.mark.parametrize("channel", _CHANNELS)
+def test_hook_orphan_guard_holds_for_every_channel(channel: str) -> None:
+    """The hook never CREATES a conf: a channel the user did not subscribe to stays absent.
+
+    This guard is what makes boot regeneration compatible with single-repository
+    subscription — regenerating one channel must never re-enable a channel the user
+    switched away from.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        _run_hook(root, edition_label="pfSense", version="2.8.1", channel=channel)
+        repos = Path(root) / "repos"
+        present = sorted(p.name for p in repos.iterdir())
+    assert present == [_CHANNEL_CONF_NAMES[channel]], (
+        f"staging only {channel!r} must leave exactly that conf behind, found: {present}"
     )
 
 
@@ -438,19 +482,20 @@ def test_conf_written_once_invariant() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Release / nightly non-clobber: two distinct conf files, channels independent
+# Single-repository subscription: one project conf on the box at a time
 # --------------------------------------------------------------------------- #
 
 
-def test_default_writes_release_conf_and_nightly_writes_its_own() -> None:
-    """The default writes ONLY the shared release conf; --nightly writes ONLY the nightly one.
+def test_default_writes_release_conf_then_nightly_replaces_it() -> None:
+    """The default writes ONLY the shared release conf; --nightly then REPLACES it.
 
     Scenario:
     Given a fresh root (no conf files),
     When  add-repo.sh runs with no argument,
     Then  only ``pfblockerng.conf`` exists (no nightly conf, no legacy split conf);
     When  add-repo.sh --nightly runs into the same root,
-    Then  ``pfblockerng-nightly.conf`` is added, and the release conf is byte-unchanged.
+    Then  ``pfblockerng-nightly.conf`` is the box's ONLY project conf — the release
+          conf is retired, because a box subscribes to one channel at a time.
     """
     with tempfile.TemporaryDirectory() as root:
         repos = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos"
@@ -471,10 +516,10 @@ def test_default_writes_release_conf_and_nightly_writes_its_own() -> None:
         assert _PAGES_BASE in release_bytes, "release conf must contain the Pages base URL"
         assert "${ABI}" not in release_bytes, "release conf must not contain ${ABI}"
 
-        # When: --nightly → adds its own conf, leaves the release conf byte-unchanged
+        # When: --nightly → takes over the subscription
         _run_add_repo(root, nightly=True)
         assert nightly.exists(), "--nightly must write pfblockerng-nightly.conf"
-        assert release.read_text() == release_bytes, "--nightly must not touch the release conf"
+        assert not release.exists(), "--nightly must retire the release subscription it replaced"
         assert not legacy_split.exists(), "no pfblockerng-devel.conf is ever created"
 
         # After-state: nightly conf has its own URL prefix
@@ -568,12 +613,9 @@ def test_print_conf_requires_catalog_path(argv: list[str], needle: str) -> None:
 # Four-channel expression (issue #2147 step B) — stable/testing/edge/nightly
 # --------------------------------------------------------------------------- #
 #
-# Live per-channel boot-time conf generation (stable/testing/edge) lands with
-# issue #2148; until then --print-conf renders all four channels, and only the
-# legacy default (release) + nightly channels bootstrap live. The rc.d hook
-# (pfblockerng_repo_generate.sh) is untouched — its 2-channel byte-identity
-# test above (test_hook_output_byte_identical_to_print_conf_*) is a DEFERRAL
-# row for #2148, not extended here.
+# Issue #2148 closed the deferral: all four channels now bootstrap live and the
+# rc.d hook regenerates every one of them, so the byte-identity contract above is
+# asserted against the hook per channel, not only for release + nightly.
 
 
 @pytest.mark.parametrize("channel", _CHANNELS)
@@ -635,58 +677,80 @@ def test_four_channel_no_abi_placeholder(generator: str, channel: str) -> None:
     assert "${ABI}" not in conf, f"{generator} {channel}: found ${{ABI}} in conf:\n{conf}"
 
 
-def test_add_repo_channel_conf_name_mapping_source_pin() -> None:
-    """add-repo.sh's CHANNEL case maps every channel to its conf filename.
-
-    Live per-channel boot-time write for stable/testing/edge is unreachable until
-    issue #2148 (see test_add_repo_live_bootstrap_rejects_unimplemented_channels
-    below) — pin the CONF_NAME mapping at the source until a live test can cover it.
-    """
-    src = _ADD_REPO.read_text()
-    for channel in (*_CHANNELS, "release"):
-        conf_name = _CHANNEL_CONF_NAMES[channel]
-        assert f'CONF_NAME="{conf_name}"' in src, f"missing CONF_NAME mapping for {channel!r} in add-repo.sh"
-
-
 # --------------------------------------------------------------------------- #
-# add-repo.sh live-bootstrap channel gate
+# add-repo.sh live bootstrap — every channel (issue #2148)
 # --------------------------------------------------------------------------- #
 
 
-def _add_repo_stub_root(root: str) -> dict[str, str]:
-    """Build a CE 2.8.1 box fixture + pkg stub under root; return the env to run with."""
-    bin_dir = os.path.join(root, "bin")
-    os.makedirs(bin_dir, exist_ok=True)
-    fake_pkg = os.path.join(bin_dir, "pkg")
-    with open(fake_pkg, "w") as fh:
-        fh.write("#!/bin/sh\n# fake pkg stub for tests\nexit 0\n")
-    os.chmod(fake_pkg, 0o755)
-    return {**os.environ, "PFBLOCKERNG_ROOT": root, "PKG_BIN": fake_pkg}
+def _repos_dir(root: str) -> Path:
+    return Path(root) / "usr" / "local" / "etc" / "pkg" / "repos"
 
 
-@pytest.mark.parametrize("channel", ["stable", "testing", "edge"])
-def test_add_repo_live_bootstrap_rejects_unimplemented_channels(channel: str) -> None:
-    """Live bootstrap for stable/testing/edge is not implemented — exits 2, names #2148.
+@pytest.mark.parametrize("channel", _CHANNELS)
+def test_add_repo_live_bootstrap_writes_the_channel_conf(channel: str) -> None:
+    """Every channel bootstraps live: the box ends up with that channel's resolved conf.
 
-    Scenario: given PFBLOCKERNG_ROOT + a stub PKG_BIN (a live box would use the real
-    ones), when add-repo.sh --channel <ch> runs with NO --print-conf, then it exits 2
-    with a message pointing at issue #2148 (the ticket that lands per-channel
-    boot-time conf generation) instead of attempting to bootstrap.
+    Scenario: given a CE 2.8.1 box fixture with no pfBlockerNG conf, when
+    ``add-repo.sh --channel <ch>`` runs (no ``--print-conf``), then the box carries
+    ``pfblockerng-<ch>.conf`` resolved by the boot hook — the stanza is keyed by the
+    channel's own repo name and the url's channel segment is that channel.
     """
     with tempfile.TemporaryDirectory() as root:
-        env = _add_repo_stub_root(root)
-        proc = subprocess.run(
-            ["sh", str(_ADD_REPO), "--channel", channel],
-            env=env,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert proc.returncode == 2, proc.stderr
-        assert "#2148" in proc.stderr, f"live-bootstrap rejection for {channel!r} must name #2148:\n{proc.stderr}"
+        conf_path = _repos_dir(root) / _CHANNEL_CONF_NAMES[channel]
+        assert not conf_path.exists(), "before-state: the channel conf must be absent"
 
-        conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / _CHANNEL_CONF_NAMES[channel]
-        assert not conf_path.exists(), f"rejected channel {channel!r} must write nothing:\n{conf_path}"
+        _run_add_repo(root, extra_args=("--channel", channel))
+
+        assert conf_path.exists(), f"--channel {channel} must write {conf_path.name}"
+        conf = conf_path.read_text()
+        assert f"{_CHANNEL_REPO_NAMES[channel]}: {{" in conf, f"{channel}: wrong repo stanza:\n{conf}"
+        assert f'url: "{_PAGES_BASE}/{channel}/ce-2.8"' in conf, f"{channel}: wrong resolved url:\n{conf}"
+        assert "Generated at boot by pfblockerng_repo_generate" in conf, (
+            f"{channel}: the boot hook did not resolve the conf:\n{conf}"
+        )
+        assert "pending" not in conf, f"{channel}: the staging stub survived:\n{conf}"
+
+
+@pytest.mark.parametrize("channel", _CHANNELS)
+def test_add_repo_live_bootstrap_leaves_other_channels_absent(channel: str) -> None:
+    """A bootstrap creates exactly ONE project channel conf — never a sibling.
+
+    The orphan guard is what makes single-repository subscription reachable: the boot
+    hook regenerates only confs that exist, so a channel the user never bootstrapped
+    must not appear as a side effect of bootstrapping another one.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        _run_add_repo(root, extra_args=("--channel", channel))
+
+        present = sorted(p.name for p in _repos_dir(root).iterdir()) if _repos_dir(root).is_dir() else []
+        assert present == [_CHANNEL_CONF_NAMES[channel]], (
+            f"--channel {channel} must leave exactly its own conf behind, found: {present}"
+        )
+
+
+@pytest.mark.parametrize("previous", ["release", "stable", "nightly"])
+def test_add_repo_live_bootstrap_replaces_a_previously_enabled_channel(previous: str) -> None:
+    """Single-repository subscription: bootstrapping a channel retires the other one.
+
+    Scenario: given a box already subscribed to ``previous``, when the user bootstraps
+    ``edge``, then the box is subscribed to edge ALONE — the previous channel's conf is
+    gone and the removal is reported, so the box never ends up with two project
+    repositories enabled at the same equal priority.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        _run_add_repo(root, extra_args=() if previous == "release" else ("--channel", previous))
+        previous_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES[previous]
+        assert previous_conf.exists(), f"before-state: the box must be subscribed to {previous}"
+
+        proc = _run_add_repo(root, extra_args=("--channel", "edge"))
+
+        assert (_repos_dir(root) / _CHANNEL_CONF_NAMES["edge"]).exists(), "edge must be subscribed after the switch"
+        assert not previous_conf.exists(), (
+            f"{previous} must be unsubscribed by the switch — two project repos is not a supported configuration"
+        )
+        assert _CHANNEL_CONF_NAMES[previous] in (proc.stdout + proc.stderr), (
+            f"the switch must report retiring {previous}:\n{proc.stdout}\n{proc.stderr}"
+        )
 
 
 def test_add_repo_channel_nightly_live_bootstrap_matches_flag_nightly() -> None:
@@ -695,13 +759,29 @@ def test_add_repo_channel_nightly_live_bootstrap_matches_flag_nightly() -> None:
         _run_add_repo(root_flag, nightly=True)
         _run_add_repo(root_channel, extra_args=("--channel", "nightly"))
 
-        conf_flag = Path(root_flag) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng-nightly.conf"
-        conf_channel = Path(root_channel) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng-nightly.conf"
+        conf_flag = _repos_dir(root_flag) / "pfblockerng-nightly.conf"
+        conf_channel = _repos_dir(root_channel) / "pfblockerng-nightly.conf"
         assert conf_flag.exists(), "--nightly must write pfblockerng-nightly.conf"
         assert conf_channel.exists(), "--channel nightly must write pfblockerng-nightly.conf"
         assert conf_flag.read_text() == conf_channel.read_text(), (
             "--channel nightly must byte-match --nightly's live-bootstrap output"
         )
+
+
+def test_add_repo_help_advertises_the_canonical_identity_only() -> None:
+    """``--help`` steers users to the four channels and the ONE canonical package.
+
+    The legacy ``-devel`` install hint is retired: every channel serves
+    ``pfSense-pkg-pfBlockerNG``, so advertising a suffixed identity would send users
+    at a package no channel catalogue carries.
+    """
+    proc = subprocess.run(["sh", str(_ADD_REPO), "--help"], capture_output=True, text=True, check=True)
+    assert "pfSense-pkg-pfBlockerNG-devel" not in proc.stdout, (
+        f"--help must not advertise the retired -devel identity:\n{proc.stdout}"
+    )
+    assert "pkg install pfSense-pkg-pfBlockerNG" in proc.stdout, proc.stdout
+    for channel in _CHANNELS:
+        assert channel in proc.stdout, f"--help must name the {channel!r} channel:\n{proc.stdout}"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -823,6 +823,14 @@ def test_add_repo_failed_reswitch_restores_the_conf_it_did_not_create() -> None:
         _run_add_repo(root, extra_args=("--channel", "edge"))
         edge_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES["edge"]
         assert edge_conf.exists(), "before-state: the box must be subscribed to edge"
+        # Re-subscribe once SUCCESSFULLY. This is the run that takes a backup — the
+        # conf now pre-exists — so it is the only one that can show the backup being
+        # cleaned up afterwards. The failing run below cannot: its restore consumes
+        # the backup on the way past, whether or not the success path would have.
+        _run_add_repo(root, extra_args=("--channel", "edge"))
+        assert not list(_repos_dir(root).glob("*.pfb-prev.*")), (
+            "a successful bootstrap must leave no conf backup behind"
+        )
         edge_before = edge_conf.read_text()
         assert "pfblockerng-edge: {" in edge_before, "before-state: the conf must carry a real repo stanza"
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -1044,7 +1044,8 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
     assert f"sh -s -- --base-url {base} --channel testing\npkg install {_CANON}</pre>" in page
     assert f"sh -s -- --base-url {base} --channel edge\npkg install {_CANON}</pre>" in page
     assert f"sh -s -- --base-url {base} --channel nightly\npkg install {_CANON}</pre>" in page
-    assert page.count(f"fetch -qo - {base}/add-repo.sh") == 4  # one bootstrap per card
+    # One bootstrap per card, plus the channel-switch snippet's first step (issue #2148).
+    assert page.count(f"fetch -qo - {base}/add-repo.sh") == 5
     # The manual conf came from the injected conf function — one per channel.
     for ch in gl.CH_ORDER:
         assert f"{ch}-conf-snippet" in page
@@ -1097,9 +1098,10 @@ def test_render_page_snippets_have_copy_buttons() -> None:
     assert f"\npkg install {_CANON}</pre>" in page
     assert f"{btn}<pre>stable-conf-snippet</pre>" in page
 
-    # Exactly the eight command snippets are copyable (a unified command + a manual conf in each
-    # of the four channel cards) — inline <code> is not.
-    assert page.count('<button class="copy"') == 8
+    # Exactly the nine command snippets are copyable — a unified command + a manual conf in
+    # each of the four channel cards, plus the two-step channel switch (issue #2148). Inline
+    # <code> is not copyable.
+    assert page.count('<button class="copy"') == 9
 
     # The styling + the behaviour that make the button work are shipped inline (static page).
     assert ".copy{" in page and ".snip{position:relative}" in page
@@ -1211,6 +1213,33 @@ def test_render_page_trust_section_present_and_accurate() -> None:
     assert "additionally retains any canonical package one of its slower channels still retains" in page
     assert "Netgate" in page
     assert "commit" in page.lower() and "created" in page.lower()
+
+
+def test_render_page_channel_switching_documents_the_migration_tooling() -> None:
+    """Channel switching is a TWO-step client operation, and the page must say so.
+
+    Before issue #2148 landed, the section deferred: "client tooling for it is tracked
+    separately (issue #2148)". That deferral is now false — `add-repo.sh --channel <ch>`
+    moves the subscription and `migrate-channel.sh --channel <ch>` moves the installed
+    package onto it. Adding the repository alone is the documented silent no-op (`pkg`
+    keeps an installed package pinned to its origin repository), so a page that names
+    only the first step would actively mislead.
+    """
+    page = gl.render_page("https://x/pkg", [], _stub_conf)
+
+    assert "Channel switching" in page
+    # The deferral is retired — reintroducing it fails here.
+    assert "tracked separately" not in page
+    # Both steps, in order, both fetchable from this site.
+    switch_step_1 = "https://x/pkg/add-repo.sh"
+    switch_step_2 = "https://x/pkg/migrate-channel.sh"
+    assert switch_step_1 in page
+    assert switch_step_2 in page
+    assert page.rindex(switch_step_1) < page.rindex(switch_step_2)
+    # The mandatory flag, rendered escaped in the prose and literal in the snippet.
+    assert "--channel &lt;ch&gt;" in page
+    # The reason the second step exists at all — adding a conf moves nothing.
+    assert "origin repository" in page
 
 
 def test_render_autoindex_lists_dirs_files_and_parent() -> None:
@@ -1890,6 +1919,34 @@ def test_published_add_repo_embeds_hook_and_installs_piped(tmp_path: Path, monke
     assert "Generated at boot by pfblockerng_repo_generate" in conf_text, (
         f"conf missing the 'Generated at boot' marker:\n{conf_text}"
     )
+
+
+def test_write_site_publishes_migrate_channel_beside_the_bootstrap(tmp_path: Path, monkeypatch: Any) -> None:
+    """The migration script is served from the Pages root, exactly like add-repo.sh.
+
+    A user switching channels reaches the site, not a git checkout, so both halves of
+    the operation must be fetchable from the same base URL. Unlike add-repo.sh,
+    migrate-channel.sh has no sibling file to embed — it is published verbatim, and a
+    byte-for-byte comparison is what stops the published copy drifting from the tested
+    repository copy.
+    """
+    import subprocess
+
+    site = tmp_path / "site"
+    site.mkdir()
+    monkeypatch.setattr(gl, "_conf_via_addrepo", lambda addrepo, base, ch: f"{ch}-conf")
+
+    gl.write_site(str(site), f"file://{site}", str(_ADD_REPO_REAL))
+
+    published = site / "migrate-channel.sh"
+    assert published.exists(), "write_site must publish site/migrate-channel.sh"
+    assert os.access(str(published), os.X_OK), "the published migration script must be executable"
+    published_text = published.read_text()
+    assert published_text == (_SCRIPTS_DIR / "migrate-channel.sh").read_text(), (
+        "the published migrate-channel.sh must be byte-identical to the repository copy"
+    )
+    sh_n = subprocess.run(["sh", "-n"], input=published_text, text=True, capture_output=True)
+    assert sh_n.returncode == 0, f"sh -n failed on published migrate-channel.sh:\n{sh_n.stderr}"
 
 
 # ── write_site / CLI interface — call-compatible with publish-pkg-repo.sh ─────

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -1862,11 +1862,19 @@ def test_published_add_repo_embeds_hook_and_installs_piped(tmp_path: Path, monke
 
     root = tmp_path / "root"
 
-    # pkg stub: exits 0; answers 'pkg config abi' with a real ABI.
+    # pkg stub: answers 'pkg config abi' with a real ABI, and 'pkg rquery' with a package
+    # line so the bootstrap reaches its success path — a bootstrap whose catalogue verify
+    # fails removes the conf it staged (issue #2148), which is exactly what this test
+    # asserts got written.
     bin_dir = root / "bin"
     bin_dir.mkdir(parents=True)
     fake_pkg = bin_dir / "pkg"
-    fake_pkg.write_text("#!/bin/sh\ncase \"$*\" in\n  'config abi') printf 'FreeBSD:15:amd64' ;;\nesac\nexit 0\n")
+    fake_pkg.write_text(
+        "#!/bin/sh\n"
+        "case \"$1\" in\n  rquery) printf 'pfSense-pkg-pfBlockerNG 4.0.0\\n'; exit 0 ;;\nesac\n"
+        "case \"$*\" in\n  'config abi') printf 'FreeBSD:15:amd64' ;;\nesac\n"
+        "exit 0\n"
+    )
     fake_pkg.chmod(0o755)
 
     # CE 2.8.1 box fixture: /etc/version + /etc/product_label (no 'Plus' -> CE).


### PR DESCRIPTION
Fixes #2148.

## What this is

`add-repo.sh` already moved the **subscription** (landed in the first commit on this branch). Nothing moved the **installed package** — and adding a repository does not move one.

Measured on pfSense CE 2.8.1 / `pkg` 1.21.3: `pkg upgrade` never leaves the repository a package was installed from while that repo is enabled and still offers it; neither `CONSERVATIVE_UPGRADE=false` (verified applied via `pkg -vv`) nor a higher `priority:` changes that. And every channel catalogue publishes only the canonical `pfSense-pkg-pfBlockerNG`, so a box carrying a legacy suffixed identity (`-devel`, `-nightly`/`-NIGHTLY`) has no upgrade path at all. Both cases are silent today: no error, no upgrade offered.

## Changes

### `scripts/migrate-channel.sh` (new)

The second half of a channel switch. Mandatory `--channel <stable|testing|edge|nightly>`; `release`, a bogus name and a wrong-case name are all rejected.

Fails **before touching the installed package** when:

- the box is not subscribed to exactly that channel (missing target conf, or a second project conf still present) — `pkg` is not even invoked;
- the installed state is none, more than one, or an identity the project never shipped;
- the target catalogue does not offer the canonical package.

Then, per installed kind:

| Installed | Operation |
|---|---|
| canonical, already on the target repo | reported no-op, nothing mutated |
| canonical, other repo | `pkg install -f -y -r <repo>` — also the **reverse** move, since the target may be older |
| legacy suffixed identity | `pkg delete -y <name>` + `pkg install -y -r <repo>` |

Afterwards it proves the result: exactly the canonical identity installed, `%R` equal to the target repo, the version the catalogue offered, every path in `pkg info -l` present on disk, and the `installedpackages/pfblockerng` section surviving the mutation. Distinct exit code per failure class (0 ok/no-op, 1 no pkg, 2 usage, 3 installed state, 4 target unavailable, 5 pkg operation failed, 6 verification failed).

Configuration preservation remains the package's own lifecycle hooks. The script does not re-implement it — it only refuses to report a silent loss as success.

### `pfblockerng.inc` — channel provenance from the installed repo

Under one canonical identity across four catalogues the package **name** no longer identifies a channel. So:

- `pfb_pkg_repo_name_for_channel()` **deleted** (no shim, no alias — zero callers remain outside the historical `.ADRs/` record).
- `pfb_channel_from_repo_name()` added: `pfblockerng-<ch>` → channel; the legacy shared `pfblockerng`, `pfSense`, `''`, `null` → `null` (the legacy repo carries two identities, so there the name still discriminates).
- `pfb_software_is_our_build()` accepts all five project repos. **This was a real bug**: a box subscribed to `pfblockerng-stable|-testing|-edge` read as *not our build* and silently lost the Software tab, the priv `match[]` line and the update notice.
- `pfb_software_update_check()` reads latest from the repo the package came from (`$io['installed_repo']` injectable), and derives the channel repo-first / name-fallback. Cache scope moved from `pkgname` to `pkgname`+`repo`: a channel switch keeps the name identical, so the old scope served the previous catalogue's latest and let its `last_notified` swallow the first genuine notice for the new one.
- `pfblockerng_software.php` derives the channel through the same expression, so page and notice cannot disagree.

### Publishing and docs

- `gen_landing.py` publishes `migrate-channel.sh` beside `add-repo.sh` (byte-identical to the repository copy) and the landing page documents the two-step switch instead of deferring it to this issue.
- README: four-channel install table, a **Switching channels** section, a legacy-install migration section; the stale `-devel`/`--nightly` instructions are gone.
- CONTRIBUTING + `docs/misc/architecture-notes.md` updated; the notes no longer claim this ticket has not landed.

## Verification

Test-first, executed, not reasoned through.

**`tests/shell/migrate_channel_spec.sh`** — new, 28 examples over a programmable `pkg` stub that keeps real state (installed / catalog / payload), so the examples assert resulting box state rather than command lines. Covers usage rejection, both pre-flight refusals with `pkg` never invoked, the three inventory refusals, catalogue unavailability, the no-op, `-devel` and the historical `-NIGHTLY` spellings, the reverse move landing an older version, an identical-artifact switch, and all four verification failures (install failed after delete, wrong repo, incomplete payload, lost config section).

**PHP** — two red→green cycles, zero test edits between red and green in each. Frozen test hashes at red: `SoftwareUpdateDecisionTest.php` `46998bd7317d66393daae8d538594df3a9b60de5`, `SoftwareUpdateCheckTest.php` `70d56f74720f34aea5da4512602867895d2d81a8`.

**`tests/test_gen_landing.py`** — frozen at `7a4f100e665d4bd550fdeb1498ea6dca418fcf9b`; RED 4 failed / 70 passed (the two new tests plus the two snippet-count contracts), GREEN 74 passed with zero test edits.

**`tests/smoke/test_repo_install.py`** — 2 hermetic runner-side cases (executed: the `.pkg` rename forge, and a guard pinning both scripts' `PROJECT_CONFS` list to the module's own) plus 6 live-VM cases gated on the suite's existing `smoke_vm` / `SMOKE_PKG` skips: per-channel single-repository subscription, legacy identity → canonical, in-repo rollback within `pfblockerng-edge`, and an unsubscribed target refused before mutation.

Canonical gates on the full tree:

```text
python3 -m pytest -q      -> 5016 passed, 4 skipped in 194.38s
vendor/bin/phpunit        -> 5004 tests, 28688 assertions, 0 failures (5 consecutive runs)
ruff check .              -> All checks passed!
ruff format --check .     -> 526 files already formatted
mypy tests/               -> Success: no issues found in 318 source files
shellcheck                -> clean (add-repo.sh, migrate-channel.sh, the rc.d hook)
shellspec (full)          -> 1312 examples, 4 failures
```

The 4 shellspec failures are `tests/shell/pfblockerng_suppress_spec.sh` only and are environmental: `command -v iprange` is empty on this workstation and the spec fails loud by design rather than skipping (ADR-53 §1.2; CI installs the real binary). They touch none of this change's files, and the same 4 were present before it.

**Disclosure:** one full PHPUnit run early in the session reported `Failures: 1` on this same tree; the output was consumed by a `tail` and the failing test's identity was lost. Five subsequent full runs on the identical tree are clean (exit 0, same 5004/28688 counts). No PHP source changed between the failing run and the clean ones, so it is not attributable to this diff, but it is recorded here rather than dropped.

No release was performed and no production package catalogue was mutated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stable, testing, edge, and nightly package channels.
  - Added guided channel switching with configuration preservation and rollback support.
  - Added migration support for existing and legacy installations.
  - Added downloadable channel-switching tools and instructions to the landing page.

- **Bug Fixes**
  - Improved channel detection using repository and package information.
  - Prevented stale update information after switching channels.
  - Added safeguards against incomplete or incorrect migrations.
  - Ensured only one channel subscription remains active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->