### PR TITLE
pkg: stop embedding recipe CONFLICTS in package manifests

### DIFF
--- a/docs/build-pkg-portable.md
+++ b/docs/build-pkg-portable.md
@@ -299,6 +299,14 @@ ports-framework moves):
   Identical bytes for short paths; an install path over ustar's 100/155-char
   limits makes Python's `tarfile` raise — loud, and no port path comes close.
 - **Payload tar uid/gid**: libpkg on FreeBSD stamps `65534`, the tool `0`.
+- **Recipe `CONFLICTS` is deliberately not replayed** (issue #2259). libpkg's
+  manifest schema does parse a `conflicts` field, but real `make package` never
+  emits it — Netgate's own `pfSense-pkg-pfBlockerNG` artifact carries no
+  `conflicts` key in either manifest despite its port declaring `CONFLICTS=`
+  (probed from the upstream repo, 2026-08-09) — and guest libpkg aborts
+  `pkg add` registering a manifest conflict against a package that is not
+  installed (`NOT NULL constraint failed: pkg_conflicts.conflict_id`). Channel
+  mutual exclusion rides pkg's file-path collision detection instead.
   Extraction uses the manifest's `uname`/`gname` (`root`/`wheel`) either way.
 - **`licenselogic`**: the tool guesses `"and"` for >1 license; the framework
   emits `LICENSE_COMB` verbatim (`dual`/`multi`). No port has >1 license today.

--- a/scripts/build-pkg-portable.py
+++ b/scripts/build-pkg-portable.py
@@ -349,7 +349,6 @@ class Build:
     files: list[StagedFile] = field(default_factory=list)
     directories: list[str] = field(default_factory=list)
     scripts: dict[str, str] = field(default_factory=dict)
-    conflicts: list[str] = field(default_factory=list)
     annotations: dict[str, str] = field(default_factory=dict)
 
     @property
@@ -1153,8 +1152,11 @@ def make_manifest(b: Build, *, compact: bool) -> dict:
     # {"FreeBSD_version": <__FreeBSD_version of the build host>}).
     if b.annotations:
         m["annotations"] = b.annotations
-    if b.conflicts:
-        m["conflicts"] = b.conflicts
+    # A recipe CONFLICTS line deliberately does NOT surface here (issue #2259):
+    # real `make package` never embeds it (Netgate's 2.8.1 catalog has zero
+    # `conflicts` keys), and guest libpkg dies registering a conflict against a
+    # not-installed package (NOT NULL pkg_conflicts.conflict_id). Channel
+    # exclusivity rides pkg's file-path conflict detection instead.
     if compact:
         return m
     # `fflags: 0` matches `pkg create` (no file flags set). mtime is the staged file's
@@ -1895,7 +1897,6 @@ def run_build(args: argparse.Namespace) -> Build:
 
     b.directories = plist_dirs
     b.scripts = build_scripts(mk, portdir / "files")
-    b.conflicts = mk.get("CONFLICTS").split()
     # Declared RUN_DEPENDS/LIB_DEPENDS + the deps USES injects (php/python), as
     # `make package` records them. Dedup by name (declared win).
     deps: dict[str, Dep] = {}

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -2447,7 +2447,18 @@ def test_project_rejects_tracked_ports_symlink_outside_checkout(tmp_path: Path) 
     assert bpp.main(_project_args(ports, portdir, record, source=tmp_path / "source")) == 1
 
 
-def test_manifest_includes_recipe_conflicts(tmp_path: Path) -> None:
+def test_manifest_omits_recipe_conflicts(tmp_path: Path) -> None:
+    """A recipe CONFLICTS line must NOT surface in either manifest (issue #2259).
+
+    Real `make package`/`pkg repo` never embed CONFLICTS in a package: Netgate's
+    own 2.8.1 catalog carries zero `conflicts` keys even though the
+    pfSense-pkg-pfBlockerNG(-devel) ports declare CONFLICTS. Shipping the key
+    makes guest libpkg register a conflict row against a package that is not
+    installed and die with `NOT NULL constraint failed: pkg_conflicts.conflict_id`
+    on every `pkg add` (observed on CE 2.8.1 pkg 1.21 and Plus 26.03/26.07 pkg 2.x
+    alike). Channel exclusivity still holds via pkg's file-path conflict
+    detection — the channel packages ship the same file set.
+    """
     ports, portdir = _make_classic_port(tmp_path)
     makefile = portdir / "Makefile"
     makefile.write_text("CONFLICTS=\tfoo-* bar-*\n" + makefile.read_text())
@@ -2472,5 +2483,5 @@ def test_manifest_includes_recipe_conflicts(tmp_path: Path) -> None:
         == 0
     )
     full, compact, _ = _read_pkg(out / "testpkg-1.0_2.pkg")
-    assert full["conflicts"] == ["foo-*", "bar-*"]
-    assert compact["conflicts"] == ["foo-*", "bar-*"]
+    assert "conflicts" not in full, f"full +MANIFEST must omit conflicts, got {full.get('conflicts')!r}"
+    assert "conflicts" not in compact, f"+COMPACT_MANIFEST must omit conflicts, got {compact.get('conflicts')!r}"


### PR DESCRIPTION
## Problem

Every live-VM smoke leg has failed at `pkg add` since 2026-08-07 (issue #2259). On Plus 26.03/26.07 legs (and on the CE leg's branch-`.pkg` add on 2026-08-07, before the CE guests additionally started reporting a FreeBSD:16 ABI — that separate defect is tracked in #2242):

```
pkg: sqlite error while executing INSERT INTO pkg_conflicts(package_id, conflict_id) VALUES (438, (SELECT id FROM packages WHERE name = 'pfSense-pkg-pfBlockerNG')) in file pkgdb.c:2078: NOT NULL constraint failed: pkg_conflicts.conflict_id
```

## Root cause

Commit 0ddac96d ("pkg: harden normalized build provenance", 2026-08-05) started copying the port recipe's `CONFLICTS` line into both the full and compact package manifests. The first run that reached `pkg add` with such a package (2026-08-07 07:02) failed on every leg.

The parity premise was wrong: real `make package` never embeds `CONFLICTS` in a package — Netgate's own 2.8.1 catalog (`pfSense_v2_8_1` packagesite, probed 2026-08-09) contains zero `conflicts` keys even though the `pfSense-pkg-pfBlockerNG`/`-devel` ports both declare `CONFLICTS`. `CONFLICTS` is a ports-framework build/install-time check, not manifest data. Guest libpkg confirms why: when registering an installed package it inserts each manifest conflict via `SELECT id FROM packages WHERE name = …`, which returns NULL for a package that is not installed (the normal case — a box has at most one channel package), and the `NOT NULL` constraint on `pkg_conflicts.conflict_id` aborts the whole install. Both CE 2.8.1 (pkg 1.21, `pkgdb.c:1892`) and Plus 26.03/26.07 (pkg 2.x, `pkgdb.c:2078`) die identically.

## Fix

Drop the manifest emission (the `Build.conflicts` field, its assignment, and the two manifest lines). Channel exclusivity (#2251) is unaffected: the channel packages ship the same file paths, so pkg's own file-collision conflict detection still forces the swap on a channel switch.

## Tests

`test_manifest_includes_recipe_conflicts` is replaced by `test_manifest_omits_recipe_conflicts` (asserts neither manifest carries the key, with the rationale in its docstring). Test-first proof: the new test was run RED against the untouched builder (failing on `conflicts` present in the full manifest), frozen (`git hash-object` `fe25e3ce482ba659dfb9c5ceef9ac8b8dabd7bd2`), and re-run GREEN byte-identical after the fix. Full `tests/test_build_pkg_portable.py` module: 173 passed. Full pytest suite in the CI container: 5031 passed, 3 failed — exactly the documented container-only failures (process-group signal tests ×2, mtime race test).

Part of #2259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package manifests no longer include conflict declarations.
  * Full and compact manifests now consistently omit conflict entries from port recipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->