### PR TITLE
smoke: forward channel to Ports preparation

### DIFF
--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -187,7 +187,7 @@ sh scripts/sparse-clone-ports.sh \
     "https://github.com/pfBlockerNG/FreeBSD-ports" \
     "pfblockerng/use-github" \
     "$PORTS_DIR" \
-    "devel" "$_php_ver" "$_py_flavor" >&2
+    "$_CHANNEL" "$_php_ver" "$_py_flavor" >&2
 
 # ── Step 3: oras images (refresh when stale; pull when absent) ─────────────── #
 _oras_login_done=0

--- a/tests/shell/smoke_on_box_spec.sh
+++ b/tests/shell/smoke_on_box_spec.sh
@@ -145,10 +145,10 @@ STUBEOF
     SPARSE_EXIT=42
     export SPARSE_CHANNEL_FILE SPARSE_EXIT
 
-    When run sh "$SCRIPT" --ref HEAD --channel edge
+    When run sh "$SCRIPT" --ref HEAD --channel testing
     The status should equal 42
-    The stderr should include 'channel=edge'
-    The contents of file "$SPARSE_CHANNEL_FILE" should equal 'edge'
+    The stderr should include 'channel=testing'
+    The contents of file "$SPARSE_CHANNEL_FILE" should equal 'testing'
   End
 
   # ── LAN registry ref rewrite (issue #2247) ───────────────────────────────── #

--- a/tests/shell/smoke_on_box_spec.sh
+++ b/tests/shell/smoke_on_box_spec.sh
@@ -30,7 +30,8 @@ Describe 'smoke-on-box.sh (issue #2223)'
     # and the image refresh both shell out, and neither is what this spec covers.
     cat > "${FAKE_ROOT}/scripts/sparse-clone-ports.sh" <<'STUBEOF'
 #!/bin/sh
-exit 0
+[ -z "${SPARSE_CHANNEL_FILE:-}" ] || printf '%s\n' "$4" > "$SPARSE_CHANNEL_FILE"
+exit "${SPARSE_EXIT:-0}"
 STUBEOF
     chmod +x "${FAKE_ROOT}/scripts/sparse-clone-ports.sh"
     mkdir -p "${WORK}/bin"
@@ -135,6 +136,19 @@ STUBEOF
     When run sh "$SCRIPT" --not-a-real-flag
     The status should not equal 0
     The stderr should be present
+  End
+
+  It 'prepares the same channel selected for the package build'
+    # Stop at the sparse-Ports boundary: no image pull, host prep, package build or VM.
+    printf '0\n' > "${WORK}/port-floor"
+    SPARSE_CHANNEL_FILE="${WORK}/sparse-channel"
+    SPARSE_EXIT=42
+    export SPARSE_CHANNEL_FILE SPARSE_EXIT
+
+    When run sh "$SCRIPT" --ref HEAD --channel edge
+    The status should equal 42
+    The stderr should include 'channel=edge'
+    The contents of file "$SPARSE_CHANNEL_FILE" should equal 'edge'
   End
 
   # ── LAN registry ref rewrite (issue #2247) ───────────────────────────────── #


### PR DESCRIPTION
## Summary

- pass the selected Stable/Testing/Edge/Nightly channel to sparse Ports preparation;
- pin the `smoke-on-box.sh` CLI boundary with a direct shell regression test.

## Root cause

`smoke-on-box.sh` parsed and later built with `_CHANNEL`, but Step 2 still passed the retired literal `devel` to `sparse-clone-ports.sh`. Every local smoke run therefore stopped before package build.

## Verification

- RED: frozen test hash `73fb01dc4f0da6689ee9ef0d099b3a4ba30b9489` observed `devel` after selecting `edge`;
- GREEN: same hash, 15 examples under macOS `/bin/sh` and 15 under `dash`;
- neighboring plumbing suite: 50 examples passed, 2 real-build parity examples skipped by design;
- pre-commit impacted shell suite: 80 examples passed;
- `scripts/agent/run-gates.sh --diff origin/devel`: passed.

Fixes #2265

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The ports checkout now honors the configured channel instead of always using the development channel.
  - Smoke checks now correctly report the selected channel and propagate checkout failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->