### PR TITLE
smoke: repair container bootstrap

### DIFF
--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -183,7 +183,7 @@ fi
 # The bootstrap string:
 #   1. cd to the repo on the box
 #   2. narrow the working tree to the paths a smoke leg reads (src/ builds the .pkg,
-#      scripts/ is the harness, tests/smoke/ is the suite). 38 MB of tracked files
+#      scripts/ is the harness, stubs/python/ supports root conftest, tests/smoke/ is the suite). 38 MB of tracked files
 #      against 13 MB for what a leg actually uses; .ADRs/, tests/php/ and plugins/ are
 #      the bulk of the difference and none of them is read here.
 #   3. fetch the requested ref and check out its FETCHED TIP (FETCH_HEAD) — NOT a
@@ -217,7 +217,7 @@ fi
 # shellcheck disable=SC2089  # quoting: _ob_flags is pre-encoded for remote sh
 _bootstrap="cd /root/pfBlockerNG \
  && git sparse-checkout init --cone \
- && git sparse-checkout set src scripts tests/smoke \
+ && git sparse-checkout set src scripts stubs/python tests/smoke \
  && git fetch --quiet origin '$_REF_Q' \
  && git checkout --quiet --force FETCH_HEAD \
  && git fetch --quiet --no-tags origin ci-metadata:refs/remotes/origin/ci-metadata \

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -304,7 +304,7 @@ fi
 # preference uses it. Idempotent: reuse an existing venv; pip is a no-op when the
 # pinned deps are already satisfied.
 printf 'smoke-on-box: provisioning test venv (.venv)...\n' >&2
-[ -x "${REPO_ROOT}/.venv/bin/python" ] || python3 -m venv "${REPO_ROOT}/.venv"
+[ -x "${REPO_ROOT}/.venv/bin/python" ] || python3 -m venv --clear "${REPO_ROOT}/.venv"
 "${REPO_ROOT}/.venv/bin/python" -m pip install --quiet --upgrade pip
 "${REPO_ROOT}/.venv/bin/python" -m pip install --quiet -r "${REPO_ROOT}/tests/smoke/requirements.txt" pytest
 

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -304,7 +304,13 @@ fi
 # preference uses it. Idempotent: reuse an existing venv; pip is a no-op when the
 # pinned deps are already satisfied.
 printf 'smoke-on-box: provisioning test venv (.venv)...\n' >&2
-[ -x "${REPO_ROOT}/.venv/bin/python" ] || python3 -m venv --clear "${REPO_ROOT}/.venv"
+_VENV_DIR="${REPO_ROOT}/.venv"
+# `venv --clear` follows a directory symlink and erases its target before failing.
+if [ -L "$_VENV_DIR" ] || { [ -e "$_VENV_DIR" ] && [ ! -d "$_VENV_DIR" ]; }; then
+    printf 'smoke-on-box: refusing unsafe venv path: %s\n' "$_VENV_DIR" >&2
+    exit 2
+fi
+[ -x "${_VENV_DIR}/bin/python" ] || python3 -m venv --clear "$_VENV_DIR"
 "${REPO_ROOT}/.venv/bin/python" -m pip install --quiet --upgrade pip
 "${REPO_ROOT}/.venv/bin/python" -m pip install --quiet -r "${REPO_ROOT}/tests/smoke/requirements.txt" pytest
 

--- a/tests/shell/local_smoke_container_spec.sh
+++ b/tests/shell/local_smoke_container_spec.sh
@@ -15,8 +15,8 @@
 #     the namespaced sysctl replaces it, so if it is dropped the mock DNS fails to bind.
 #   * the bind mounts — the repo, the shared image store, the ports tree and the guest SSH
 #     key all live on the box and must be visible inside, or every run re-clones and re-pulls.
-#   * the sparse checkout — a smoke leg reads only src/, scripts/ and tests/smoke/. Checking
-#     out the whole tree costs 38 MB against 13 MB for what it uses.
+#   * the sparse checkout — a smoke leg reads src/, scripts/, stubs/python/ and tests/smoke/.
+#     Checking out the whole tree costs 38 MB against 13 MB for what it uses.
 #
 # The flag-encoding examples are inherited responsibility: smoke_on_box_channel_spec.sh used
 # to pin that a --channel carrying shell metacharacters survived the re-exec argv rebuild.
@@ -144,11 +144,11 @@ EOF
   # ── the sparse checkout ──────────────────────────────────────────────────── #
 
   It 'checks out only the paths a smoke leg reads'
-    # src/ (the .pkg build), scripts/ (the harness) and tests/smoke/ (the suite). Excludes
-    # .ADRs (8.2 MB), tests/php (5.2 MB) and plugins (2.7 MB), none of which smoke touches.
+    # src/ (the .pkg build), scripts/ (the harness), stubs/python/ (root conftest's
+    # unboundmodule import) and tests/smoke/ (the suite). Excludes .ADRs, tests/php and
+    # plugins, none of which smoke touches.
     When call bootstrap --ref dummy
-    The output should include 'sparse-checkout'
-    The output should include 'src scripts tests/smoke'
+    The output should include 'git sparse-checkout set src scripts stubs/python tests/smoke'
   End
 
   It 'still fetches the ci-metadata orphan ref the version matrix reads'

--- a/tests/shell/smoke_on_box_spec.sh
+++ b/tests/shell/smoke_on_box_spec.sh
@@ -194,6 +194,46 @@ STUBEOF
     The contents of file "$VENV_ARGS_FILE" should equal "-m venv --clear ${FAKE_ROOT}/.venv"
   End
 
+  It 'refuses a symlinked venv root without clearing its target'
+    printf '0\n' > "${WORK}/port-floor"
+
+    cat > "${FAKE_ROOT}/scripts/lib/oras-refresh.sh" <<'STUBEOF'
+pfb_lan_registry_active() { return 1; }
+pfb_rewrite_lan_registry() { printf '%s\n' "$1"; }
+pfb_oras_refresh() { :; }
+STUBEOF
+    cat > "${FAKE_ROOT}/scripts/build-leg.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' /tmp/fake.pkg
+STUBEOF
+    cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311"}]'
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/build-leg.sh" "${FAKE_ROOT}/scripts/read-version-matrix.sh"
+
+    VENV_TARGET="${WORK}/external-venv-target"
+    mkdir -p "$VENV_TARGET" "${FAKE_ROOT}/tests/smoke"
+    true > "${VENV_TARGET}/sentinel"
+    true > "${FAKE_ROOT}/tests/smoke/requirements.txt"
+    ln -s "$VENV_TARGET" "${FAKE_ROOT}/.venv"
+    true > "${WORK}/smoke-ssh-key"
+    SMOKE_SSH_KEY="${WORK}/smoke-ssh-key"
+    PIP_NO_INDEX=1
+    export SMOKE_SSH_KEY PIP_NO_INDEX
+
+    cat > "${WORK}/bin/pkill" <<'STUBEOF'
+#!/bin/sh
+exit 0
+STUBEOF
+    chmod +x "${WORK}/bin/pkill"
+
+    When run sh "$SCRIPT" --ref HEAD --no-two-vm
+    The status should equal 2
+    The stderr should include 'unsafe venv path'
+    The file "${VENV_TARGET}/sentinel" should be exist
+  End
+
   # ── LAN registry ref rewrite (issue #2247) ───────────────────────────────── #
   #
   # The config echo (config abi=... pfsense_ref=... civm_ref=...) fires BEFORE the

--- a/tests/shell/smoke_on_box_spec.sh
+++ b/tests/shell/smoke_on_box_spec.sh
@@ -151,6 +151,49 @@ STUBEOF
     The contents of file "$SPARSE_CHANNEL_FILE" should equal 'testing'
   End
 
+  It 'clears an invalid existing venv before recreating it'
+    printf '0\n' > "${WORK}/port-floor"
+
+    # Reach only the venv boundary: package/image work is unrelated and remains stubbed.
+    cat > "${FAKE_ROOT}/scripts/lib/oras-refresh.sh" <<'STUBEOF'
+pfb_lan_registry_active() { return 1; }
+pfb_rewrite_lan_registry() { printf '%s\n' "$1"; }
+pfb_oras_refresh() { :; }
+STUBEOF
+    cat > "${FAKE_ROOT}/scripts/build-leg.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' /tmp/fake.pkg
+STUBEOF
+    cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311"}]'
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/build-leg.sh" "${FAKE_ROOT}/scripts/read-version-matrix.sh"
+
+    mkdir -p "${FAKE_ROOT}/.venv/bin"
+    ln -s "${WORK}/missing-python3" "${FAKE_ROOT}/.venv/bin/python"
+    true > "${WORK}/smoke-ssh-key"
+    SMOKE_SSH_KEY="${WORK}/smoke-ssh-key"
+    VENV_ARGS_FILE="${WORK}/venv-args"
+    export SMOKE_SSH_KEY VENV_ARGS_FILE
+
+    cat > "${WORK}/bin/python3" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' "$*" > "$VENV_ARGS_FILE"
+exit 42
+STUBEOF
+    cat > "${WORK}/bin/pkill" <<'STUBEOF'
+#!/bin/sh
+exit 0
+STUBEOF
+    chmod +x "${WORK}/bin/python3" "${WORK}/bin/pkill"
+
+    When run sh "$SCRIPT" --ref HEAD --no-two-vm
+    The status should equal 42
+    The stderr should include 'provisioning test venv'
+    The contents of file "$VENV_ARGS_FILE" should equal "-m venv --clear ${FAKE_ROOT}/.venv"
+  End
+
   # ── LAN registry ref rewrite (issue #2247) ───────────────────────────────── #
   #
   # The config echo (config abi=... pfsense_ref=... civm_ref=...) fires BEFORE the


### PR DESCRIPTION
## Summary

- include `stubs/python` in the live-smoke sparse checkout so root `tests/conftest.py` can import `unboundmodule`
- recreate an invalid persistent test venv with `python3 -m venv --clear`
- cover both bootstrap contracts with executed shell tests

## Root cause

The persistent checkout crosses two execution environments. Its host-created venv can retain a Python symlink that is invalid inside `ci-runner-vm`, while the container bootstrap's sparse checkout omitted the Python stub imported by the repository-level pytest configuration.

## Verification

- Frozen RED test hashes: `84f0b4765d6a90b77524f9bef422ed5876af660f`, `b7864228acb2c4102ef4b0e85bed5af7b40eb66e`
- RED: 29 examples, 2 exact failures (missing sparse path; missing `venv --clear`)
- GREEN: focused dash and `/bin/sh`, 29 examples, 0 failures
- Related dash shell suite: 76 examples, 0 failures
- Pre-commit impacted suite: 92 examples, 0 failures
- `sh -n` and ShellCheck pass for both production scripts
- `PYTHONPATH=stubs/python python3 -m pytest --collect-only -q tests/smoke/test_repo_install.py`: 25 tests collected
- Live run `local-100034-1786295338-349154bdbf823965`: package and dependency build passed; venv provisioned; pytest imported root configuration and collected 966 tests. The run then exposed a distinct shared-image-directory fixture mismatch, outside this PR.
- Canonical gates reached 1344 ShellSpec examples; the sole failure is the pre-existing macOS EPERM-holder case in `tests/shell/mcp_token_savior_spec.sh`, unrelated to this diff.

Fixes #2268

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local smoke-test setup by ensuring required Python stub files are included.
  - Recreates existing virtual environments when they are invalid, improving recovery and preventing stale or broken environments from blocking smoke tests.

- **Tests**
  - Added coverage for invalid virtual-environment recovery.
  - Updated checkout validation to confirm all required smoke-test paths are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->