### PR TITLE
smoke: select shared images by refreshed ref

### DIFF
--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -149,6 +149,16 @@ export SMOKE_PKG="$(sh scripts/build-leg.sh --ports-dir /root/FreeBSD-ports)"
 PFSENSE_REF="${SMOKE_PFSENSE_REF:-ghcr.io/pfblockerng/pfsense-ce:2.8}"
 CIVM_REF="${SMOKE_CLIENT_IMAGE_REF:-ghcr.io/pfblockerng/civm:v1}"
 . scripts/lib/oras-refresh.sh
+PFB_ORAS_FLAGS=''
+if pfb_lan_registry_active; then
+    PFSENSE_REF="$(pfb_rewrite_lan_registry "$PFSENSE_REF")"
+    CIVM_REF="$(pfb_rewrite_lan_registry "$CIVM_REF")"
+    PFB_ORAS_FLAGS=--plain-http
+elif [ -n "${SMOKE_GHCR_TOKEN:-}" ]; then
+    printf '%s\n' "$SMOKE_GHCR_TOKEN" | \
+        oras login ghcr.io --username pfBlockerNG --password-stdin
+fi
+export PFB_ORAS_FLAGS
 pfb_oras_refresh "$PFSENSE_REF" /root/images/pfsense pfSense
 pfb_oras_refresh "$CIVM_REF" /root/images/civm civm
 pfb_oras_ref_view "$PFSENSE_REF" /root/images/pfsense out/smoke-images/pfsense

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -134,47 +134,6 @@ wrappers. Shared `scripts/lib/git-env-scrub.sh` scrubs six GIT_\* vars that
 pre-commit hook exports; every script sources it at entry so git fixture repos never
 corrupted by inherited GIT_DIR.
 
-## Manual run (advanced: on-box directly, no orchestrator)
-
-If already on box or want to iterate without lease overhead:
-
-```sh
-# On the box:
-cd /root/pfBlockerNG
-git fetch && git checkout <REF>
-
-# Set required env (normally provided by smoke-on-box.sh):
-export SMOKE_SSH_KEY=/root/smoke-ssh-key
-export SMOKE_PKG="$(sh scripts/build-leg.sh --ports-dir /root/FreeBSD-ports)"
-PFSENSE_REF="${SMOKE_PFSENSE_REF:-ghcr.io/pfblockerng/pfsense-ce:2.8}"
-CIVM_REF="${SMOKE_CLIENT_IMAGE_REF:-ghcr.io/pfblockerng/civm:v1}"
-. scripts/lib/oras-refresh.sh
-PFB_ORAS_FLAGS=''
-if pfb_lan_registry_active; then
-    PFSENSE_REF="$(pfb_rewrite_lan_registry "$PFSENSE_REF")"
-    CIVM_REF="$(pfb_rewrite_lan_registry "$CIVM_REF")"
-    PFB_ORAS_FLAGS=--plain-http
-elif [ -n "${SMOKE_GHCR_TOKEN:-}" ]; then
-    printf '%s\n' "$SMOKE_GHCR_TOKEN" | \
-        oras login ghcr.io --username pfBlockerNG --password-stdin
-fi
-export PFB_ORAS_FLAGS
-pfb_oras_refresh "$PFSENSE_REF" /root/images/pfsense pfSense
-pfb_oras_refresh "$CIVM_REF" /root/images/civm civm
-pfb_oras_ref_view "$PFSENSE_REF" /root/images/pfsense out/smoke-images/pfsense
-pfb_oras_ref_view "$CIVM_REF" /root/images/civm out/smoke-images/civm
-export SMOKE_IMAGE_DIR="$PWD/out/smoke-images/pfsense"
-export SMOKE_CLIENT_IMAGE_DIR="$PWD/out/smoke-images/civm"
-export SMOKE_STUB_DNS_ADDR=127.0.0.1
-export SMOKE_STUB_DNS_PORT=53
-
-sudo sysctl -w net.ipv4.ip_unprivileged_port_start=53
-pkill -9 -f qemu-system-x86_64 2>/dev/null || true
-
-# Run (same argv as CI):
-sh scripts/run-smoke.sh --paths tests/smoke -m smoke --timeout 30 --filter "test_dns_redirect"
-```
-
 ## The two-VM topology
 
 Many cases (`test_dns_redirect.py`, anything depending on `lan_interface`) need

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -146,8 +146,15 @@ git fetch && git checkout <REF>
 # Set required env (normally provided by smoke-on-box.sh):
 export SMOKE_SSH_KEY=/root/smoke-ssh-key
 export SMOKE_PKG="$(sh scripts/build-leg.sh --ports-dir /root/FreeBSD-ports)"
-export SMOKE_IMAGE_DIR=/root/images/pfsense
-export SMOKE_CLIENT_IMAGE_DIR=/root/images/civm
+PFSENSE_REF="${SMOKE_PFSENSE_REF:-ghcr.io/pfblockerng/pfsense-ce:2.8}"
+CIVM_REF="${SMOKE_CLIENT_IMAGE_REF:-ghcr.io/pfblockerng/civm:v1}"
+. scripts/lib/oras-refresh.sh
+pfb_oras_refresh "$PFSENSE_REF" /root/images/pfsense pfSense
+pfb_oras_refresh "$CIVM_REF" /root/images/civm civm
+pfb_oras_ref_view "$PFSENSE_REF" /root/images/pfsense out/smoke-images/pfsense
+pfb_oras_ref_view "$CIVM_REF" /root/images/civm out/smoke-images/civm
+export SMOKE_IMAGE_DIR="$PWD/out/smoke-images/pfsense"
+export SMOKE_CLIENT_IMAGE_DIR="$PWD/out/smoke-images/civm"
 export SMOKE_STUB_DNS_ADDR=127.0.0.1
 export SMOKE_STUB_DNS_PORT=53
 
@@ -168,8 +175,8 @@ civm OCI image at `ghcr.io/pfblockerng/civm:v1` (~600 MB). qcow2 named
 `pfSense-CE-v1.qcow2` and its OCI annotation says "pfSense CE" — **that label is templated
 lie**; image is Debian client, not pfSense.
 
-`SMOKE_CLIENT_IMAGE_DIR` must hold **exactly one** `*.qcow2`, so keep in own directory
-separate from `SMOKE_IMAGE_DIR`.
+Each `SMOKE_*_IMAGE_DIR` view must hold **exactly one** `*.qcow2`; the shared stores may
+hold several ref-specific images.
 
 ## Building the `.pkg` off-FreeBSD (CI reference)
 

--- a/scripts/lib/oras-refresh.sh
+++ b/scripts/lib/oras-refresh.sh
@@ -44,6 +44,41 @@ pfb_oras_digest_file() {
     printf '%s/.digest-%s-%s\n' "$2" "$_od_safe" "$_od_hash"
 }
 
+# Expose exactly one recorded qcow2 for a ref without copying the shared payload.
+pfb_oras_ref_view() {
+    _orv_ref="$1"
+    _orv_store="$2"
+    _orv_view="$3"
+    _orv_state="$(pfb_oras_digest_file "$_orv_ref" "$_orv_store")" || return 1
+    _orv_count=0
+    _orv_name=''
+    _orv_names=''
+    while IFS= read -r _orv_line; do
+        case "$_orv_line" in
+            *.qcow2)
+                _orv_count=$((_orv_count + 1))
+                _orv_name="$_orv_line"
+                _orv_names="${_orv_names:+$_orv_names }$_orv_line"
+                ;;
+        esac
+    done <<EOF
+$(sed -n '2,$p' "$_orv_state" 2>/dev/null)
+EOF
+    if [ "$_orv_count" -ne 1 ]; then
+        printf 'oras-refresh: ref %s records %s qcow2 artifacts in %s: %s\n' \
+            "$_orv_ref" "$_orv_count" "$_orv_store" "${_orv_names:-<none>}" >&2
+        return 1
+    fi
+    if [ ! -f "${_orv_store}/${_orv_name}" ]; then
+        printf 'oras-refresh: recorded artifact missing for %s: %s\n' \
+            "$_orv_ref" "${_orv_store}/${_orv_name}" >&2
+        return 1
+    fi
+    rm -rf "$_orv_view"
+    mkdir -p "$_orv_view"
+    ln -s "${_orv_store}/${_orv_name}" "${_orv_view}/${_orv_name}"
+}
+
 # pfb_oras_refresh <ref> <published-dir> <label>
 #
 # Serialised per ref. Staging + rename already keeps the BYTES safe under concurrency, but

--- a/scripts/lib/oras-refresh.sh
+++ b/scripts/lib/oras-refresh.sh
@@ -189,14 +189,20 @@ EOF
 
     # Only now is the ref genuinely published, so only now record its state: the digest,
     # then the artifacts this ref owns, so a later run can tell ITS image from a sibling's.
-    if [ -n "$_or_remote" ]; then
-        { printf '%s\n' "$_or_remote"
-          for _or_p in "$_or_dir"/*.qcow2; do
-              [ -e "$_or_p" ] || continue
-              case " $_or_published " in *" $(basename "$_or_p") "*) basename "$_or_p" ;; esac
-          done
-        } > "$_or_digest_file"
-    fi
+    _or_state_tmp="$(mktemp "${_or_dir}/.state.XXXXXX")" || return 1
+    { printf '%s\n' "$_or_remote"
+      for _or_p in "$_or_dir"/*.qcow2; do
+          [ -e "$_or_p" ] || continue
+          case " $_or_published " in *" $(basename "$_or_p") "*) basename "$_or_p" ;; esac
+      done
+    } > "$_or_state_tmp" || {
+        rm -f "$_or_state_tmp"
+        return 1
+    }
+    mv -f "$_or_state_tmp" "$_or_digest_file" || {
+        rm -f "$_or_state_tmp"
+        return 1
+    }
 
     return 0
 }

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -210,9 +210,14 @@ if [ "$_NO_TWO_VM" -eq 0 ]; then
     pfb_oras_refresh "$CIVM_REF" "${IMAGES_DIR}/civm" "civm"
 fi
 
-export SMOKE_IMAGE_DIR="${IMAGES_DIR}/pfsense"
+_IMAGE_VIEW_ROOT="${REPO_ROOT}/out/smoke-images"
+SMOKE_IMAGE_DIR="${_IMAGE_VIEW_ROOT}/pfsense"
+pfb_oras_ref_view "$PFSENSE_REF" "${IMAGES_DIR}/pfsense" "$SMOKE_IMAGE_DIR"
+export SMOKE_IMAGE_DIR
 if [ "$_NO_TWO_VM" -eq 0 ]; then
-    export SMOKE_CLIENT_IMAGE_DIR="${IMAGES_DIR}/civm"
+    SMOKE_CLIENT_IMAGE_DIR="${_IMAGE_VIEW_ROOT}/civm"
+    pfb_oras_ref_view "$CIVM_REF" "${IMAGES_DIR}/civm" "$SMOKE_CLIENT_IMAGE_DIR"
+    export SMOKE_CLIENT_IMAGE_DIR
     export NO_TWO_VM=0
 else
     export NO_TWO_VM=1

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -232,25 +232,31 @@ EOF
       ref=ghcr.io/x/pfsense-ce:2.8
       STUB_REMOTE_DIGEST=sha256:old pfb_oras_refresh "$ref" "$1" CE || exit 1
       mkdir -p "$3/bin"
-      RACE_REAL_BASENAME="$(command -v basename)"
-      cat > "$3/bin/basename" <<"EOF"
+      RACE_REAL_MV="$(command -v mv)"
+      RACE_REAL_CP="$(command -v cp)"
+      cat > "$3/bin/mv" <<"EOF"
 #!/bin/sh
-count="$(cat "$RACE_COUNT" 2>/dev/null || echo 0)"
-count=$((count + 1))
-printf "%s\n" "$count" > "$RACE_COUNT"
-if [ "$count" -eq 3 ]; then
+case "${0##*/}" in
+  mv) real="$RACE_REAL_MV" ;;
+  cp) real="$RACE_REAL_CP" ;;
+esac
+case "$3" in
+  */.digest-*)
+    [ "${0##*/}" = mv ] || true > "$3"
     true > "$RACE_READY"
     tries=0
     while [ ! -e "$RACE_RELEASE" ] && [ "$tries" -lt 500 ]; do
-        sleep 0.01
-        tries=$((tries + 1))
+      sleep 0.01
+      tries=$((tries + 1))
     done
-fi
-exec "$RACE_REAL_BASENAME" "$@"
+    ;;
+esac
+exec "$real" "$@"
 EOF
-      chmod +x "$3/bin/basename"
-      RACE_COUNT="$3/count" RACE_READY="$3/ready" RACE_RELEASE="$3/release"
-      export RACE_REAL_BASENAME RACE_COUNT RACE_READY RACE_RELEASE
+      chmod +x "$3/bin/mv"
+      ln "$3/bin/mv" "$3/bin/cp"
+      RACE_READY="$3/ready" RACE_RELEASE="$3/release"
+      export RACE_REAL_MV RACE_REAL_CP RACE_READY RACE_RELEASE
       PATH="$3/bin:$PATH" STUB_REMOTE_DIGEST=sha256:new \
         pfb_oras_refresh "$ref" "$1" CE &
       refresh_pid=$!

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -45,6 +45,7 @@ case "$1" in
     ;;
   manifest)
     # oras manifest fetch <ref> --descriptor -- only reached when resolve fails.
+    if [ -n "${STUB_MANIFEST_FAIL:-}" ]; then exit 1; fi
     printf '{"digest":"%s"}\n' "${STUB_REMOTE_DIGEST}"
     ;;
   pull)
@@ -71,7 +72,7 @@ EOF
     STUB_ARTIFACT_NAME="pfSense-CE_2.8.qcow2"
     PATH="${BIN}:${PATH}"
     export PATH STUB_PULL_LOG STUB_CWD_LOG STUB_ARGV_LOG STUB_ARTIFACT_NAME \
-        STUB_REMOTE_DIGEST ORAS_PULL_FAIL STUB_RESOLVE_FAIL
+        STUB_REMOTE_DIGEST ORAS_PULL_FAIL STUB_RESOLVE_FAIL STUB_MANIFEST_FAIL
   }
 
   cleanup() { rm -rf "$WORK"; }
@@ -211,6 +212,70 @@ EOF
   End
 
   # ── per-ref consumer views ────────────────────────────────────────────────── #
+
+  It 'records pulled artifacts when digest lookup is unavailable'
+    When call sh -c '
+      . "$1"; shift
+      STUB_RESOLVE_FAIL=1 STUB_MANIFEST_FAIL=1 \
+        pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" CE || exit 1
+      pfb_oras_ref_view ghcr.io/x/pfsense-ce:2.8 "$1" "$2"
+      find "$2" -maxdepth 1 -name "*.qcow2" | wc -l | tr -d " "
+    ' sh "$LIB" "$IMGDIR" "${WORK}/view"
+    The status should equal 0
+    The stdout should equal '1'
+    The stderr should be present
+  End
+
+  It 'keeps ref state readable while a concurrent refresh publishes it'
+    When call sh -c '
+      . "$1"; shift
+      ref=ghcr.io/x/pfsense-ce:2.8
+      STUB_REMOTE_DIGEST=sha256:old pfb_oras_refresh "$ref" "$1" CE || exit 1
+      mkdir -p "$3/bin"
+      RACE_REAL_BASENAME="$(command -v basename)"
+      cat > "$3/bin/basename" <<"EOF"
+#!/bin/sh
+count="$(cat "$RACE_COUNT" 2>/dev/null || echo 0)"
+count=$((count + 1))
+printf "%s\n" "$count" > "$RACE_COUNT"
+if [ "$count" -eq 3 ]; then
+    : > "$RACE_READY"
+    tries=0
+    while [ ! -e "$RACE_RELEASE" ] && [ "$tries" -lt 500 ]; do
+        sleep 0.01
+        tries=$((tries + 1))
+    done
+fi
+exec "$RACE_REAL_BASENAME" "$@"
+EOF
+      chmod +x "$3/bin/basename"
+      RACE_COUNT="$3/count" RACE_READY="$3/ready" RACE_RELEASE="$3/release"
+      export RACE_REAL_BASENAME RACE_COUNT RACE_READY RACE_RELEASE
+      PATH="$3/bin:$PATH" STUB_REMOTE_DIGEST=sha256:new \
+        pfb_oras_refresh "$ref" "$1" CE &
+      refresh_pid=$!
+      tries=0
+      while [ ! -e "$RACE_READY" ] && [ "$tries" -lt 500 ]; do
+        sleep 0.01
+        tries=$((tries + 1))
+      done
+      if [ ! -e "$RACE_READY" ]; then
+        : > "$RACE_RELEASE"
+        wait "$refresh_pid"
+        echo TIMEOUT
+        exit 1
+      fi
+      pfb_oras_ref_view "$ref" "$1" "$2"
+      view_rc=$?
+      : > "$RACE_RELEASE"
+      wait "$refresh_pid"
+      refresh_rc=$?
+      printf "view_rc=%s refresh_rc=%s\n" "$view_rc" "$refresh_rc"
+    ' sh "$LIB" "$IMGDIR" "${WORK}/view" "${WORK}/race"
+    The status should equal 0
+    The stdout should equal 'view_rc=0 refresh_rc=0'
+    The stderr should be present
+  End
 
   It 'exposes only the selected ref when sibling images share the store'
     When call sh -c '

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -239,7 +239,7 @@ count="$(cat "$RACE_COUNT" 2>/dev/null || echo 0)"
 count=$((count + 1))
 printf "%s\n" "$count" > "$RACE_COUNT"
 if [ "$count" -eq 3 ]; then
-    : > "$RACE_READY"
+    true > "$RACE_READY"
     tries=0
     while [ ! -e "$RACE_RELEASE" ] && [ "$tries" -lt 500 ]; do
         sleep 0.01
@@ -260,14 +260,14 @@ EOF
         tries=$((tries + 1))
       done
       if [ ! -e "$RACE_READY" ]; then
-        : > "$RACE_RELEASE"
+        true > "$RACE_RELEASE"
         wait "$refresh_pid"
         echo TIMEOUT
         exit 1
       fi
       pfb_oras_ref_view "$ref" "$1" "$2"
       view_rc=$?
-      : > "$RACE_RELEASE"
+      true > "$RACE_RELEASE"
       wait "$refresh_pid"
       refresh_rc=$?
       printf "view_rc=%s refresh_rc=%s\n" "$view_rc" "$refresh_rc"

--- a/tests/shell/oras_refresh_spec.sh
+++ b/tests/shell/oras_refresh_spec.sh
@@ -210,6 +210,68 @@ EOF
     The output should eq 'DISTINCT'
   End
 
+  # ── per-ref consumer views ────────────────────────────────────────────────── #
+
+  It 'exposes only the selected ref when sibling images share the store'
+    When call sh -c '
+      . "$1"; shift
+      STUB_REMOTE_DIGEST=sha256:ce pfb_oras_refresh ghcr.io/x/pfsense-ce:2.8 "$1" CE
+      STUB_ARTIFACT_NAME=pfSense-Plus_26.03.qcow2 STUB_REMOTE_DIGEST=sha256:plus \
+        pfb_oras_refresh ghcr.io/x/pfsense-plus:26.03 "$1" Plus
+      pfb_oras_ref_view ghcr.io/x/pfsense-ce:2.8 "$1" "$2"
+      printf "store=%s view=%s selected=%s\n" \
+        "$(find "$1" -maxdepth 1 -name "*.qcow2" | wc -l | tr -d " ")" \
+        "$(find "$2" -maxdepth 1 -name "*.qcow2" | wc -l | tr -d " ")" \
+        "$(basename "$(readlink "$2/pfSense-CE_2.8.qcow2")")"
+    ' sh "$LIB" "$IMGDIR" "${WORK}/view"
+    The status should equal 0
+    The stdout should equal 'store=2 view=1 selected=pfSense-CE_2.8.qcow2'
+    The stderr should be present
+  End
+
+  It 'refuses a ref state with no qcow2 and preserves the prior view'
+    mkdir -p "${WORK}/view"
+    true > "${WORK}/view/sentinel"
+    When call sh -c '
+      . "$1"; shift
+      state="$(pfb_oras_digest_file ghcr.io/x/empty:1 "$1")"
+      printf "sha256:empty\n" > "$state"
+      pfb_oras_ref_view ghcr.io/x/empty:1 "$1" "$2"
+    ' sh "$LIB" "$IMGDIR" "${WORK}/view"
+    The status should equal 1
+    The stderr should include 'ref ghcr.io/x/empty:1 records 0 qcow2 artifacts'
+    The file "${WORK}/view/sentinel" should be exist
+  End
+
+  It 'refuses a ref state with multiple qcow2 files and names them'
+    mkdir -p "${WORK}/view"
+    true > "${WORK}/view/sentinel"
+    When call sh -c '
+      . "$1"; shift
+      state="$(pfb_oras_digest_file ghcr.io/x/multiple:1 "$1")"
+      printf "sha256:multiple\na.qcow2\nb.qcow2\n" > "$state"
+      true > "$1/a.qcow2"
+      true > "$1/b.qcow2"
+      pfb_oras_ref_view ghcr.io/x/multiple:1 "$1" "$2"
+    ' sh "$LIB" "$IMGDIR" "${WORK}/view"
+    The status should equal 1
+    The stderr should include 'records 2 qcow2 artifacts'
+    The stderr should include 'a.qcow2 b.qcow2'
+    The file "${WORK}/view/sentinel" should be exist
+  End
+
+  It 'refuses a recorded qcow2 that is missing from the shared store'
+    When call sh -c '
+      . "$1"; shift
+      state="$(pfb_oras_digest_file ghcr.io/x/missing:1 "$1")"
+      printf "sha256:missing\nmissing.qcow2\n" > "$state"
+      pfb_oras_ref_view ghcr.io/x/missing:1 "$1" "$2"
+    ' sh "$LIB" "$IMGDIR" "${WORK}/view"
+    The status should equal 1
+    The stderr should include 'recorded artifact missing for ghcr.io/x/missing:1'
+    The path "${WORK}/view" should not be exist
+  End
+
   It 'refuses to name a digest file when sha256sum is unavailable'
     # Hide sha256sum from PATH: without it the pipe yields an empty suffix and every ref
     # shares one name again. Asserting the shape of the NAME cannot catch that -- the guard

--- a/tests/shell/smoke_on_box_spec.sh
+++ b/tests/shell/smoke_on_box_spec.sh
@@ -151,6 +151,63 @@ STUBEOF
     The contents of file "$SPARSE_CHANNEL_FILE" should equal 'testing'
   End
 
+  It 'exposes only the selected image for each refreshed ref'
+    printf '0\n' > "${WORK}/port-floor"
+
+    cat > "${FAKE_ROOT}/scripts/lib/oras-refresh.sh" <<'STUBEOF'
+pfb_lan_registry_active() { return 1; }
+pfb_rewrite_lan_registry() { printf '%s\n' "$1"; }
+pfb_oras_refresh() { :; }
+pfb_oras_ref_view() {
+    printf '%s|%s|%s\n' "$1" "$2" "$3" >> "$VIEW_LOG"
+    mkdir -p "$3"
+    true > "$3/selected.qcow2"
+}
+STUBEOF
+    cat > "${FAKE_ROOT}/scripts/build-leg.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' /tmp/fake.pkg
+STUBEOF
+    cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311"}]'
+STUBEOF
+    cat > "${FAKE_ROOT}/scripts/run-smoke.sh" <<'STUBEOF'
+#!/bin/sh
+printf 'server=%s count=%s\n' "$SMOKE_IMAGE_DIR" \
+    "$(find "$SMOKE_IMAGE_DIR" -maxdepth 1 -name '*.qcow2' | wc -l | tr -d ' ')"
+printf 'client=%s count=%s\n' "$SMOKE_CLIENT_IMAGE_DIR" \
+    "$(find "$SMOKE_CLIENT_IMAGE_DIR" -maxdepth 1 -name '*.qcow2' | wc -l | tr -d ' ')"
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/build-leg.sh" "${FAKE_ROOT}/scripts/read-version-matrix.sh" \
+        "${FAKE_ROOT}/scripts/run-smoke.sh"
+
+    mkdir -p "${FAKE_ROOT}/.venv/bin"
+    cat > "${FAKE_ROOT}/.venv/bin/python" <<'STUBEOF'
+#!/bin/sh
+exit 0
+STUBEOF
+    chmod +x "${FAKE_ROOT}/.venv/bin/python"
+    true > "${WORK}/smoke-ssh-key"
+    SMOKE_SSH_KEY="${WORK}/smoke-ssh-key"
+    VIEW_LOG="${WORK}/views"
+    export SMOKE_SSH_KEY VIEW_LOG
+
+    cat > "${WORK}/bin/pkill" <<'STUBEOF'
+#!/bin/sh
+exit 0
+STUBEOF
+    chmod +x "${WORK}/bin/pkill"
+
+    When run sh "$SCRIPT" --ref HEAD
+    The status should equal 0
+    The stderr should include 'running smoke'
+    The stdout should include "server=${FAKE_ROOT}/out/smoke-images/pfsense count=1"
+    The stdout should include "client=${FAKE_ROOT}/out/smoke-images/civm count=1"
+    The contents of file "$VIEW_LOG" should include "ghcr.io/pfblockerng/pfsense-ce:2.8|/root/images/pfsense|${FAKE_ROOT}/out/smoke-images/pfsense"
+    The contents of file "$VIEW_LOG" should include "ghcr.io/pfblockerng/civm:v1|/root/images/civm|${FAKE_ROOT}/out/smoke-images/civm"
+  End
+
   It 'clears an invalid existing venv before recreating it'
     printf '0\n' > "${WORK}/port-floor"
 
@@ -159,6 +216,7 @@ STUBEOF
 pfb_lan_registry_active() { return 1; }
 pfb_rewrite_lan_registry() { printf '%s\n' "$1"; }
 pfb_oras_refresh() { :; }
+pfb_oras_ref_view() { mkdir -p "$3"; true > "$3/selected.qcow2"; }
 STUBEOF
     cat > "${FAKE_ROOT}/scripts/build-leg.sh" <<'STUBEOF'
 #!/bin/sh
@@ -201,6 +259,7 @@ STUBEOF
 pfb_lan_registry_active() { return 1; }
 pfb_rewrite_lan_registry() { printf '%s\n' "$1"; }
 pfb_oras_refresh() { :; }
+pfb_oras_ref_view() { mkdir -p "$3"; true > "$3/selected.qcow2"; }
 STUBEOF
     cat > "${FAKE_ROOT}/scripts/build-leg.sh" <<'STUBEOF'
 #!/bin/sh


### PR DESCRIPTION
## Summary

- select the qcow2 recorded for each refreshed ORAS ref instead of exposing the whole shared store
- keep shared payloads in place and publish per-run symlink views for pfSense and client images
- fail closed when ref state records zero, multiple, or missing qcow2 payloads

## Verification

- TDD RED: frozen integration spec saw zero images in both expected per-ref views
- ShellSpec with dash: 60 examples, 0 failures
- ShellSpec with `/bin/sh`: 43 examples, 0 failures
- impacted pre-commit suite: 87 examples, 0 failures
- live smoke on `root@10.0.0.34`: VM ready in 43s; Stable, Testing, Edge, and Nightly repository cases passed
- canonical gates: touched-file syntax and ShellCheck passed; full ShellSpec reached 1,350 examples with one unrelated pre-existing macOS EPERM-holder failure in `mcp_token_savior_spec.sh`

Fixes #2218

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-reference image views that expose only the selected QCOW2 image without copying shared image data.
  * Smoke-test environments now use isolated image views for more reliable single-VM and two-VM runs.
  * Added validation to detect missing, ambiguous, or unavailable image artifacts.

* **Bug Fixes**
  * Prevented smoke tests from accidentally using images belonging to another reference.
  * Improved consistency when refreshing images and creating views concurrently.

* **Tests**
  * Added coverage for image selection, error handling, and server/client smoke-test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->