### PR TITLE
agent: preserve uncertain rebuild locks

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,6 +7,6 @@ max_depth = 2
 
 [mcp_servers.token-savior-recall]
 command = "sh"
-args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 39148af7be7906c261b38d59676c49dd982b8763f6b57f3a69499f9e8eb49986 && exec sh "$root/scripts/mcp-token-savior.sh"''']
+args = ["-c", '''root=$(git rev-parse --show-toplevel) && python3 -c "import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)" "$root/scripts/mcp-token-savior.sh" 096dda2b2c617df7aa3bb3f3aa6445017fb68e737677a0b7392f24168d95a885 && exec sh "$root/scripts/mcp-token-savior.sh"''']
 env = { TOKEN_SAVIOR_CLIENT = "codex" }
 startup_timeout_sec = 120

--- a/scripts/mcp-token-savior.sh
+++ b/scripts/mcp-token-savior.sh
@@ -50,9 +50,11 @@ holder_alive() {
 	kill -0 "$1" 2>/dev/null && return 0
 	# kill -0 also fails with EPERM for a LIVE process this user may not signal,
 	# so its failure is not proof of death. ps answers regardless of ownership;
-	# no ps at all is no evidence, and doubt must never reap a held lock.
+	# no usable ps is no evidence, and doubt must never reap a held lock. The
+	# supported macOS/Linux ps implementations return 1 when no PID matched.
 	command -v ps >/dev/null 2>&1 || return 0
-	ps -p "$1" >/dev/null 2>&1
+	ps -p "$1" >/dev/null 2>&1 && return 0
+	[ "$?" -ne 1 ]
 }
 
 # stdout is the MCP stdio channel — install chatter must stay on stderr

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -349,6 +349,36 @@ EOF
     The file "${WORK}/venv/pip-args.log" should not be exist
   End
 
+  It 'keeps a lock when ps cannot execute its holder probe'
+    sh -c 'exit 0' &
+    unknown_pid=$!
+    wait "${unknown_pid}"
+    mkdir -p "${WORK}/venv.rebuild.lock"
+    printf '%s\n' "${unknown_pid}" > "${WORK}/venv.rebuild.lock/pid"
+    When run env PATH="${WORK}/shim:${PATH}" PS_EXIT=126 TS_VENV="${WORK}/venv" TS_LOCK_WAIT=2 sh "${SCRIPT}"
+    The status should be failure
+    The stderr should include 'concurrent rebuild'
+    The directory "${WORK}/venv.rebuild.lock" should be exist
+    The file "${WORK}/venv/pip-args.log" should not be exist
+  End
+
+  It 'keeps a lock when ps is unavailable'
+    mkdir -p "${WORK}/no-ps"
+    for tool in cat dirname mkdir rm sleep; do
+      ln -s "$(command -v "${tool}")" "${WORK}/no-ps/${tool}"
+    done
+    sh -c 'exit 0' &
+    unknown_pid=$!
+    wait "${unknown_pid}"
+    mkdir -p "${WORK}/venv.rebuild.lock"
+    printf '%s\n' "${unknown_pid}" > "${WORK}/venv.rebuild.lock/pid"
+    When run env PATH="${WORK}/no-ps" TS_VENV="${WORK}/venv" TS_LOCK_WAIT=2 /bin/sh "${SCRIPT}"
+    The status should be failure
+    The stderr should include 'concurrent rebuild'
+    The directory "${WORK}/venv.rebuild.lock" should be exist
+    The file "${WORK}/venv/pip-args.log" should not be exist
+  End
+
   It 'records its own live PID in the lock it holds'
     # Without this, the reap above would be unreachable in production: no holder
     # would ever leave a PID for a later session to test. The python3 wrapper runs

--- a/tests/shell/mcp_token_savior_spec.sh
+++ b/tests/shell/mcp_token_savior_spec.sh
@@ -224,6 +224,11 @@ PIPEOF
 chmod +x "\${venv}/bin/pip"
 EOF
     chmod +x "${WORK}/shim/python3"
+    cat > "${WORK}/shim/ps" << 'EOF'
+#!/bin/sh
+exit "${PS_EXIT:-1}"
+EOF
+    chmod +x "${WORK}/shim/ps"
   }
 
   cleanup() { [ -n "${WORK}" ] && rm -rf "${WORK}"; [ ! -d "${WORK}" ] || return 1; }
@@ -321,10 +326,23 @@ EOF
     # is the portable always-alive, never-ours case - unless this user IS root,
     # where kill -0 1 succeeds and the example would assert the plain live-holder
     # path instead, proving nothing about EPERM.
-    Skip if "running as root: kill -0 1 succeeds, so the fixture is not EPERM" [ "$(id -u)" -eq 0 ]
+    Skip if "kill -0 1 succeeds, so the fixture is not EPERM" sh -c 'kill -0 1 2>/dev/null'
     mkdir -p "${WORK}/venv.rebuild.lock"
     printf '1\n' > "${WORK}/venv.rebuild.lock/pid"
-    When run env PATH="${WORK}/shim:${PATH}" TS_VENV="${WORK}/venv" TS_LOCK_WAIT=2 sh "${SCRIPT}"
+    When run env PATH="${WORK}/shim:${PATH}" PS_EXIT=0 TS_VENV="${WORK}/venv" TS_LOCK_WAIT=2 sh "${SCRIPT}"
+    The status should be failure
+    The stderr should include 'concurrent rebuild'
+    The directory "${WORK}/venv.rebuild.lock" should be exist
+    The file "${WORK}/venv/pip-args.log" should not be exist
+  End
+
+  It 'keeps a lock when ps cannot determine whether the holder is alive'
+    sh -c 'exit 0' &
+    unknown_pid=$!
+    wait "${unknown_pid}"
+    mkdir -p "${WORK}/venv.rebuild.lock"
+    printf '%s\n' "${unknown_pid}" > "${WORK}/venv.rebuild.lock/pid"
+    When run env PATH="${WORK}/shim:${PATH}" PS_EXIT=127 TS_VENV="${WORK}/venv" TS_LOCK_WAIT=2 sh "${SCRIPT}"
     The status should be failure
     The stderr should include 'concurrent rebuild'
     The directory "${WORK}/venv.rebuild.lock" should be exist


### PR DESCRIPTION
## Summary

- preserve a Token-Savior rebuild lock when `ps` cannot inspect its recorded holder
- reap only an explicit `ps` no-match result
- make live, dead, denied, and unavailable-`ps` lock tests deterministic
- refresh the Codex launcher integrity pin

## Root cause

Managed macOS resolves `/bin/ps` but blocks execution. `holder_alive` treated every nonzero `ps` result as proof that the PID was dead, then removed a potentially live rebuild lock.

## Test-first proof

Initial frozen test hash: `a99cc24773572fba0479c04089976aaf02438140`

RED on unchanged production, then GREEN unchanged:

```
base: 31 examples, 1 failure
head: 31 examples, 0 failures
```

Final post-review test hash: `6c2174622ac9aba870bfaa237147295c54cbb860`

```
base: 33 examples, 2 failures (ps status 127 and 126)
head: 33 examples, 0 failures under dash and /bin/sh
```

The no-`ps` row pins preserved fail-safe behavior and kills a mutation that removes the existing command-absence guard.

## Verification

- `python3 -m pytest -q tests/test_cross_agent_tooling.py` — 7 passed
- `scripts/agent/run-gates.sh --diff origin/devel` — PASS after implementation and review fix
- `sh -n scripts/mcp-token-savior.sh tests/shell/mcp_token_savior_spec.sh` — PASS
- `shellcheck scripts/mcp-token-savior.sh` — PASS
- pre-commit impacted ShellSpec — 33 passed
- `git diff --check` — PASS

Fixes #2273

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lock handling during concurrent rebuilds by distinguishing confirmed inactive processes from inconclusive process checks.
  - Prevented unnecessary lock removal and reinstallation when process status cannot be verified reliably.
  - Preserved clear failure behavior when a rebuild may still be in progress.

- **Tests**
  - Expanded coverage for unavailable, permission-denied, and unexpected process-status results.
  - Updated test scenarios to adapt safely to the runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->