### PR TITLE
smoke: validate reusable venv

### DIFF
--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -306,7 +306,7 @@ fi
 # The box ships python3 but not pytest; install the harness deps (version-pinned
 # by the checked-out ref's tests/smoke/requirements.txt, + pytest explicitly, the
 # same set CI installs) into ${REPO_ROOT}/.venv so run-smoke.sh's non-CI .venv
-# preference uses it. Idempotent: reuse an existing venv; pip is a no-op when the
+# preference uses it. Idempotent: reuse a valid existing venv; pip is a no-op when the
 # pinned deps are already satisfied.
 printf 'smoke-on-box: provisioning test venv (.venv)...\n' >&2
 _VENV_DIR="${REPO_ROOT}/.venv"
@@ -315,7 +315,9 @@ if [ -L "$_VENV_DIR" ] || { [ -e "$_VENV_DIR" ] && [ ! -d "$_VENV_DIR" ]; }; the
     printf 'smoke-on-box: refusing unsafe venv path: %s\n' "$_VENV_DIR" >&2
     exit 2
 fi
-[ -x "${_VENV_DIR}/bin/python" ] || python3 -m venv --clear "$_VENV_DIR"
+if [ ! -x "${_VENV_DIR}/bin/python" ] || ! "${_VENV_DIR}/bin/python" -m pip --version >/dev/null 2>&1; then
+    python3 -m venv --clear "$_VENV_DIR"
+fi
 "${REPO_ROOT}/.venv/bin/python" -m pip install --quiet --upgrade pip
 "${REPO_ROOT}/.venv/bin/python" -m pip install --quiet -r "${REPO_ROOT}/tests/smoke/requirements.txt" pytest
 

--- a/tests/shell/smoke_on_box_spec.sh
+++ b/tests/shell/smoke_on_box_spec.sh
@@ -183,6 +183,7 @@ STUBEOF
         "${FAKE_ROOT}/scripts/run-smoke.sh"
 
     mkdir -p "${FAKE_ROOT}/.venv/bin"
+    true > "${FAKE_ROOT}/.venv/reuse-sentinel"
     cat > "${FAKE_ROOT}/.venv/bin/python" <<'STUBEOF'
 #!/bin/sh
 exit 0
@@ -204,6 +205,7 @@ STUBEOF
     The stderr should include 'running smoke'
     The stdout should include "server=${FAKE_ROOT}/out/smoke-images/pfsense count=1"
     The stdout should include "client=${FAKE_ROOT}/out/smoke-images/civm count=1"
+    The file "${FAKE_ROOT}/.venv/reuse-sentinel" should be exist
     The contents of file "$VIEW_LOG" should include "ghcr.io/pfblockerng/pfsense-ce:2.8|/root/images/pfsense|${FAKE_ROOT}/out/smoke-images/pfsense"
     The contents of file "$VIEW_LOG" should include "ghcr.io/pfblockerng/civm:v1|/root/images/civm|${FAKE_ROOT}/out/smoke-images/civm"
   End
@@ -229,11 +231,17 @@ STUBEOF
     chmod +x "${FAKE_ROOT}/scripts/build-leg.sh" "${FAKE_ROOT}/scripts/read-version-matrix.sh"
 
     mkdir -p "${FAKE_ROOT}/.venv/bin"
-    ln -s "${WORK}/missing-python3" "${FAKE_ROOT}/.venv/bin/python"
+    cat > "${FAKE_ROOT}/.venv/bin/python" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' "$*" > "$VENV_PYTHON_ARGS_FILE"
+exit 1
+STUBEOF
+    chmod +x "${FAKE_ROOT}/.venv/bin/python"
     true > "${WORK}/smoke-ssh-key"
     SMOKE_SSH_KEY="${WORK}/smoke-ssh-key"
     VENV_ARGS_FILE="${WORK}/venv-args"
-    export SMOKE_SSH_KEY VENV_ARGS_FILE
+    VENV_PYTHON_ARGS_FILE="${WORK}/venv-python-args"
+    export SMOKE_SSH_KEY VENV_ARGS_FILE VENV_PYTHON_ARGS_FILE
 
     cat > "${WORK}/bin/python3" <<'STUBEOF'
 #!/bin/sh
@@ -249,6 +257,7 @@ STUBEOF
     When run sh "$SCRIPT" --ref HEAD --no-two-vm
     The status should equal 42
     The stderr should include 'provisioning test venv'
+    The contents of file "$VENV_PYTHON_ARGS_FILE" should equal '-m pip --version'
     The contents of file "$VENV_ARGS_FILE" should equal "-m venv --clear ${FAKE_ROOT}/.venv"
   End
 
@@ -291,6 +300,36 @@ STUBEOF
     The status should equal 2
     The stderr should include 'unsafe venv path'
     The file "${VENV_TARGET}/sentinel" should be exist
+  End
+
+  It 'refuses a non-directory venv root without clearing it'
+    printf '0\n' > "${WORK}/port-floor"
+
+    cat > "${FAKE_ROOT}/scripts/lib/oras-refresh.sh" <<'STUBEOF'
+pfb_lan_registry_active() { return 1; }
+pfb_rewrite_lan_registry() { printf '%s\n' "$1"; }
+pfb_oras_refresh() { :; }
+pfb_oras_ref_view() { mkdir -p "$3"; true > "$3/selected.qcow2"; }
+STUBEOF
+    cat > "${FAKE_ROOT}/scripts/build-leg.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' /tmp/fake.pkg
+STUBEOF
+    cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311"}]'
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/build-leg.sh" "${FAKE_ROOT}/scripts/read-version-matrix.sh"
+
+    printf 'sentinel\n' > "${FAKE_ROOT}/.venv"
+    true > "${WORK}/smoke-ssh-key"
+    SMOKE_SSH_KEY="${WORK}/smoke-ssh-key"
+    export SMOKE_SSH_KEY
+
+    When run sh "$SCRIPT" --ref HEAD --no-two-vm
+    The status should equal 2
+    The stderr should include 'unsafe venv path'
+    The contents of file "${FAKE_ROOT}/.venv" should equal 'sentinel'
   End
 
   # ── LAN registry ref rewrite (issue #2247) ───────────────────────────────── #


### PR DESCRIPTION
## Summary

- validate an existing live-smoke virtual environment by running `python -m pip --version` before reuse
- recreate executable but incomplete or damaged virtual environments
- preserve valid environments and refuse symlinked or non-directory `.venv` roots

## Verification

- RED: frozen `smoke_on_box_spec.sh` failed with 19 examples / 1 failure; the old path ran `pip install`, did not probe `pip --version`, and did not recreate the environment
- GREEN: focused dash ShellSpec passed 19 examples / 0 failures
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS (1,354 ShellSpec examples)
- frozen test hash: `5e0bb144ebbbf60cf3b08023cad08a287b956c33`

## Container image check

The regular CI image already installs Python 3.11, pip, and `.github/docker/ci-requirements.txt`. The VM/smoke image extends it and installs `tests/smoke/requirements.txt` plus Playwright Chromium. No image change is required; the repaired bootstrap covers the persistent leased-LXC live-smoke checkout.

Fixes #2270

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
