### PR TITLE
ci-metadata: correct CE 2.9 toolchain

### DIFF
--- a/supported-versions.json
+++ b/supported-versions.json
@@ -65,9 +65,9 @@
     {
       "pfsense_version": "2.9",
       "channel": "CE",
-      "freebsd_version": "15.0-RELEASE",
-      "freebsd_major": "15",
-      "php_version": "8.3",
+      "freebsd_version": "16.0-RELEASE",
+      "freebsd_major": "16",
+      "php_version": "8.5",
       "py_flavor": "py311",
       "variant": "CE",
       "status": "beta",


### PR DESCRIPTION
## Summary

- Correct pfSense CE 2.9 from FreeBSD major 15 to 16.
- Correct its PHP build target from 8.3 to 8.5.
- Preserve Python 3.11 and the conservative CE dependency-package policy.

## Root cause

PR #2219 seeded the new CE 2.9 row from CE 2.8 and explicitly warned that the
FreeBSD fields required verification. The inherited toolchain values were merged
unchanged.

Netgate's current version table identifies CE 2.9 as FreeBSD 16.0-CURRENT.
Existing upgrade run 31283006846 independently shows repository packages changing
from FreeBSD ABI 15 to 16, installing PHP 8.5.7, and retaining Python 3.11.

## Impact

Release and Nightly builders now emit CE 2.9 packages with `FreeBSD:16:*` and
PHP 8.5 dependencies instead of the incompatible FreeBSD 15/PHP 8.3 metadata.

## Verification

- Frozen CE 2.9 FreeBSD assertion: RED before edit, GREEN afterward.
- Frozen CE 2.9 PHP assertion: RED before edit, GREEN afterward.
- `scripts/read-version-matrix.sh --ref issue/2280-publish-corrected-edge-release --print-build`
  emits CE 2.8 as FreeBSD 15/PHP 8.3 and CE 2.9 as FreeBSD 16/PHP 8.5.
- Same-major PHP/Python consistency assertion passes.
- `jq empty supported-versions.json`
- `git diff --check`

Refs #2280.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pfSense 2.9 CE compatibility information to reflect FreeBSD 16.0 and PHP 8.5.
  * Updated the associated major version to 16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->