### PR TITLE
release: port v3.2.16 functional delta onto 3.3

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -29,12 +29,7 @@ import os
 global pfb
 pfb = {}
 
-if sys.version_info < (2, 8):
-    from ConfigParser import ConfigParser
-    pfb['py_v3'] = False
-else:
-    from configparser import ConfigParser
-    pfb['py_v3'] = True
+from configparser import ConfigParser
 
 from collections import defaultdict
 
@@ -578,44 +573,25 @@ def get_tld(qstate):
 
 
 def convert_ipv4(x):
-    global pfb
-
     ipv4 = ''
     if x:
-        if pfb['py_v3']:
-            ipv4 = "{}.{}.{}.{}" .format(x[2], x[3], x[4], x[5])
-        else:
-            ipv4 = "{}.{}.{}.{}" .format(ord(x[2]), ord(x[3]), ord(x[4]), ord(x[5]))
+        ipv4 = "{}.{}.{}.{}".format(x[2], x[3], x[4], x[5])
     return is_unknown(ipv4)
 
 
 def convert_ipv6(x):
-    global pfb
-
     ipv6 = ''
     if x:
-        if pfb['py_v3']:
-            ipv6 = "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}" \
-                .format(x[2],x[3],x[4],x[5],x[6],x[7],x[8],x[9],x[10],x[11],x[12],x[13],x[14],x[15],x[16],x[17])
-        else:
-            ipv6 = "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}" \
-                .format(ord(x[2]),ord(x[3]),ord(x[4]),ord(x[5]),ord(x[6]),ord(x[7]),ord(x[8]),ord(x[9]),ord(x[10]), \
-                ord(x[11]),ord(x[12]),ord(x[13]),ord(x[14]),ord(x[15]),ord(x[16]),ord(x[17]))
+        ipv6 = "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}" \
+            .format(x[2],x[3],x[4],x[5],x[6],x[7],x[8],x[9],x[10],x[11],x[12],x[13],x[14],x[15],x[16],x[17])
     return is_unknown(ipv6)
 
 
 def convert_other(x):
-    global pfb
-
     final = ''
     if x:
         for i in x[3:]:
-
-            if pfb['py_v3']:
-                val = i
-            else:
-                val = ord(i)
-
+            val = i
             if val == 0:
                 i = '|'
             elif 1 <= val <= 12:
@@ -629,9 +605,7 @@ def convert_other(x):
             elif val <= 33 or val > 126:
                 continue
             else:
-                if pfb['py_v3']:
-                    i = chr(i)
-
+                i = chr(i)
             final += i
         final = final.strip('.|')
     return is_unknown(final)
@@ -872,10 +846,7 @@ def get_details_reply(m_type, qinfo, qstate, rep, kwargs):
                                 if pfb['mod_ipaddress']:
                                     r_addr = convert_ipv6(x)
                                     try:
-                                        if pfb['py_v3']:
-                                            r_addr = ipaddress.ip_address(r_addr).compressed
-                                        else:
-                                            r_addr = ipaddress.ip_address(unicode(r_addr)).compressed
+                                        r_addr = ipaddress.ip_address(r_addr).compressed
                                     except Exception as e:
                                         sys.stderr.write("[pfBlockerNG]: Failed to compress IPv6: {}, {}" .format(r_addr, e))
                                         pass
@@ -920,23 +891,15 @@ def get_details_reply(m_type, qinfo, qstate, rep, kwargs):
 
     if pfb['python_maxmind'] and r_addr not in ('', 'Unknown', 'NXDOMAIN', 'NODATA', 'DNSSEC', 'SOA', 'NS'):
         try:
-            if pfb['py_v3']:
-                version = ipaddress.ip_address(r_addr).version
-            else:
-                version = ipaddress.ip_address(unicode(r_addr)).version
-
+            version = ipaddress.ip_address(r_addr).version
         except Exception as e:
             version = ''
             pass
 
         if version != '':
             try:
-                if pfb['py_v3']:
-                    isPrivate = ipaddress.ip_address(r_addr).is_private
-                    isLoopback = ipaddress.ip_address(r_addr).is_loopback
-                else:
-                    isPrivate = ipaddress.ip_address(unicode(r_addr)).is_private
-                    isLoopback = ipaddress.ip_address(unicode(r_addr)).is_loopback
+                isPrivate = ipaddress.ip_address(r_addr).is_private
+                isLoopback = ipaddress.ip_address(r_addr).is_loopback
 
                 if isPrivate:
                     iso_code = 'prv'
@@ -998,11 +961,11 @@ def get_details_reply(m_type, qinfo, qstate, rep, kwargs):
 def python_control_duration(duration):
 
     try:
-        if duration.isnumeric() and 0 < duration <= 3600:
+        if duration.isnumeric():
             duration = int(duration)
-            return duration
-        else:
-            return False
+            if 0 < duration <= 3600:
+                return duration
+        return False
     except Exception as e:
         sys.stderr.write("[pfBlockerNG] python_control_duration: {}" .format(e))
         pass
@@ -1272,10 +1235,7 @@ def operate(id, event, qstate, qdata):
 
                     elif control_command[1] == 'addbypass' or control_command[1] == 'removebypass':
                         b_ip = (control_command[2]).replace('-', '.')
-                        if pfb['py_v3']:
-                            isIPValid = ipaddress.ip_address(b_ip)
-                        else:
-                            isIPValid = ipaddress.ip_address(unicode(b_ip))
+                        isIPValid = ipaddress.ip_address(b_ip)
 
                         if isIPValid:
                             if not pfb['gpListDB']:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -10036,8 +10036,12 @@ function sync_package_pfblockerng($cron='') {
 	#	Assign Rules	#
 	#########################
 
+	// Any pfB alias not in this list will be killed.
+	$pfb_active_aliases = null;
+
 	// Only execute if autorules are defined or if an alias has been removed.
 	if ($pfb['autorules'] || $pfb['enable'] == '' || $pfb['remove']) {
+		$pfb_active_aliases = [];
 		$message = '';
 		if (!empty($pfb['deny_inbound']) || !empty($pfb['permit_inbound']) || !empty($pfb['match_inbound'])) {
 			if (empty($pfb['inbound_interfaces'])) {
@@ -10119,6 +10123,14 @@ function sync_package_pfblockerng($cron='') {
 									$other_rules[] = $rule;
 								}
 							}
+						}
+					}
+
+					// Track pfB aliases referenced by rules.
+					foreach (array('source', 'destination') as $rtype) {
+						if ((substr($rule[$rtype]['address'], 0, 4) == 'pfB_') &&
+						    !in_array($rule[$rtype]['address'], $pfb_active_aliases)) {
+							$pfb_active_aliases[] = $rule[$rtype]['address'];
 						}
 					}
 
@@ -10371,12 +10383,31 @@ function sync_package_pfblockerng($cron='') {
 			pfb_logger("{$log}\n", 1);
 		}
 
-		// Remove all pfB aliastables
 		exec("{$pfb['pfctl']} -s Tables | {$pfb['grep']} '^pfB_'", $pfb_tables);
 		if (isset($pfb_tables)) {
+			$final_alias = array();
+			$pfb_active_aliases = isset($pfb_active_aliases) ? array_unique($pfb_active_aliases) : [];
+			if ($pfb['repcheck'] && ($pfb['drep'] == 'on' || $pfb['prep'] == 'on')) {
+				if (!empty($pfb_alias_lists_all)) {
+					$final_alias = array_intersect(array_unique($pfb_alias_lists_all), $pfb_active_aliases);
+				}
+			} else {
+				if (!empty($pfb_alias_lists)) {
+					$final_alias = array_intersect(array_unique($pfb_alias_lists), $pfb_active_aliases);
+				}
+			}
 			foreach ($pfb_tables as $pfb_table) {
 				$pfb_table_esc = escapeshellarg($pfb_table);
-				exec("{$pfb['pfctl']} -t {$pfb_table_esc} -T kill 2>&1", $result);
+				$pfb_table_path_esc	= escapeshellarg("{$pfb['aliasdir']}/{$pfb_table}.txt");
+				if (in_array($pfb_table, $pfb_active_aliases)) {
+					if (in_array($pfb_table, $final_alias)) {
+						// Replace active pfB aliastables which have been updated
+						exec("{$pfb['pfctl']} -t {$pfb_table_esc} -T replace -f {$pfb_table_path_esc} 2>&1", $result);
+					}
+				} else {
+					// Remove inactive pfB aliastables
+					exec("{$pfb['pfctl']} -t {$pfb_table_esc} -T kill 2>&1", $result);
+				}
 			}
 		}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import builtins
+import sys
+from pathlib import Path
+
+
+class _DNSMessage:
+    def __init__(self, *_args: object) -> None:
+        self.answer: list[str] = []
+
+    def set_return_msg(self, qstate: object) -> bool:
+        qstate.return_msg.rep.security = 0
+        return True
+
+
+builtins.log_info = lambda _message: None
+builtins.DNSMessage = _DNSMessage
+for name, value in {
+    "MODULE_EVENT_NEW": 0,
+    "MODULE_EVENT_PASS": 1,
+    "RR_TYPE_AAAA": 28,
+    "RR_TYPE_TXT": 16,
+    "RR_TYPE_A": 1,
+    "RR_CLASS_IN": 1,
+    "PKT_QR": 0x8000,
+    "PKT_RA": 0x80,
+    "RCODE_NOERROR": 0,
+    "MODULE_ERROR": 3,
+    "MODULE_FINISHED": 4,
+}.items():
+    setattr(builtins, name, value)
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "src/usr/local/pkg/pfblockerng"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,19 +3,20 @@ from __future__ import annotations
 import builtins
 import sys
 from pathlib import Path
+from typing import Any
 
 
 class _DNSMessage:
     def __init__(self, *_args: object) -> None:
         self.answer: list[str] = []
 
-    def set_return_msg(self, qstate: object) -> bool:
+    def set_return_msg(self, qstate: Any) -> bool:
         qstate.return_msg.rep.security = 0
         return True
 
 
-builtins.log_info = lambda _message: None
-builtins.DNSMessage = _DNSMessage
+setattr(builtins, "log_info", lambda _message: None)
+setattr(builtins, "DNSMessage", _DNSMessage)
 for name, value in {
     "MODULE_EVENT_NEW": 0,
     "MODULE_EVENT_PASS": 1,

--- a/tests/php/assert_alias_table_reload_v3216.php
+++ b/tests/php/assert_alias_table_reload_v3216.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc');
+$failures = 0;
+$root = sys_get_temp_dir() . '/pfb_alias_reload_v3216_' . bin2hex(random_bytes(5));
+mkdir($root, 0700, true);
+$log = $root . '/pfctl.log';
+$pfctl = $root . '/pfctl';
+file_put_contents($pfctl, <<<'SH'
+#!/bin/sh
+if [ "$1" = "-s" ] && [ "$2" = "Tables" ]; then
+	printf '%s\n' pfB_updated pfB_unchanged pfB_inactive
+	exit 0
+fi
+printf '%s\n' "$*" >> "$PFB_TEST_PFCTL_LOG"
+SH);
+chmod($pfctl, 0700);
+putenv("PFB_TEST_PFCTL_LOG={$log}");
+
+function check(bool $condition, string $message): void
+{
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function same(mixed $expected, mixed $actual, string $message): void
+{
+	if ($expected !== $actual) {
+		throw new RuntimeException($message . ': expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+	}
+}
+
+function row(string $name, callable $test): void
+{
+	global $failures;
+	try {
+		$test();
+		echo "PASS {$name}\n";
+	} catch (Throwable $error) {
+		$failures++;
+		echo "FAIL {$name}: {$error->getMessage()}\n";
+	}
+}
+
+function source_slice(string $source, string $startNeedle, string $endNeedle, int $offset = 0): string
+{
+	$start = strpos($source, $startNeedle, $offset);
+	check($start !== false, "missing source marker {$startNeedle}");
+	$end = strpos($source, $endNeedle, $start);
+	check($end !== false && $end > $start, "missing source marker {$endNeedle}");
+	return substr($source, $start, $end - $start);
+}
+
+row('autorules and removal initialize active-alias tracking', static function () use ($source): void {
+	$start = strpos($source, '$pfb_active_aliases = null;');
+	check($start !== false, 'active-alias initialization missing');
+	$set = '$pfb_active_aliases = [];';
+	$end = strpos($source, $set, $start);
+	check($end !== false, 'active-alias rule-path initialization missing');
+	$snippet = substr($source, $start, $end + strlen($set) - $start) . "\n}";
+
+	foreach (
+		[
+			'autorules' => [['autorules' => true, 'enable' => 'on', 'remove' => false], []],
+			'removal' => [['autorules' => false, 'enable' => 'on', 'remove' => true], []],
+			'no rule work' => [['autorules' => false, 'enable' => 'on', 'remove' => false], null],
+		] as $name => [$pfb, $expected]
+	) {
+		$pfb_active_aliases = 'unset';
+		eval($snippet);
+		same($expected, $pfb_active_aliases, $name);
+	}
+});
+
+row('source and destination rule aliases are tracked uniquely', static function () use ($source): void {
+	$snippet = source_slice(
+		$source,
+		'// Track pfB aliases referenced by rules.',
+		"// Remove 'created' tag",
+	);
+	$pfb_active_aliases = [];
+	foreach (
+		[
+			['source' => ['address' => 'pfB_source'], 'destination' => ['address' => 'any']],
+			['source' => ['address' => 'pfB_source'], 'destination' => ['address' => 'pfB_destination']],
+		] as $rule
+	) {
+		eval($snippet);
+	}
+	same(['pfB_source', 'pfB_destination'], $pfb_active_aliases, 'tracked rule aliases');
+});
+
+row('updated active tables replace, unchanged active tables survive, inactive tables die', static function () use ($source, $pfctl, $root, $log): void {
+	$sync = strpos($source, 'function sync_package_pfblockerng');
+	$block = source_slice(
+		$source,
+		'exec("{$pfb[\'pfctl\']} -s Tables | {$pfb[\'grep\']} \'^pfB_\'", $pfb_tables);',
+		"\$pfb['filter_configure'] = TRUE;",
+		$sync,
+	);
+	foreach ([false, true] as $reputation) {
+		@unlink($log);
+		$pfb = [
+			'pfctl' => $pfctl,
+			'grep' => '/usr/bin/grep',
+			'aliasdir' => $root,
+			'repcheck' => $reputation,
+			'drep' => $reputation ? 'on' : '',
+			'prep' => '',
+		];
+		$pfb_active_aliases = ['pfB_updated', 'pfB_unchanged'];
+		$pfb_alias_lists = $reputation ? [] : ['pfB_updated'];
+		$pfb_alias_lists_all = $reputation ? ['pfB_updated'] : [];
+		unset($pfb_tables);
+		eval($block);
+		$commands = file($log, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
+		check(count(array_filter($commands, static fn(string $line): bool => str_contains($line, '-t pfB_updated -T replace -f '))) === 1, 'updated active table not replaced');
+		check(count(array_filter($commands, static fn(string $line): bool => str_contains($line, 'pfB_unchanged'))) === 0, 'unchanged active table was modified');
+		check(count(array_filter($commands, static fn(string $line): bool => $line === '-t pfB_inactive -T kill')) === 1, 'inactive table not killed');
+	}
+});
+
+@unlink($log);
+@unlink($pfctl);
+@rmdir($root);
+echo $failures === 0 ? "ALL PASS\n" : "{$failures} FAILURE(S)\n";
+exit($failures === 0 ? 0 : 1);

--- a/tests/test_alias_table_reload_v3216.py
+++ b/tests/test_alias_table_reload_v3216.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_alias_table_reload_runner() -> None:
+    runner = Path(__file__).with_name("php") / "assert_alias_table_reload_v3216.php"
+    result = subprocess.run(["php", str(runner)], check=False, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout

--- a/tests/test_pfb_unbound_v3216.py
+++ b/tests/test_pfb_unbound_v3216.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import ipaddress
+from types import SimpleNamespace
+
+import pytest
+
+import pfb_unbound
+
+
+@pytest.mark.parametrize(
+    ("wire", "expected"),
+    [
+        (bytes([0, 0, 192, 168, 1, 1]), "192.168.1.1"),
+        (bytes([0, 0, 255, 255, 255, 255]), "255.255.255.255"),
+        (b"", "Unknown"),
+        (None, "Unknown"),
+    ],
+)
+def test_convert_ipv4_uses_python3_byte_values(wire: bytes | None, expected: str) -> None:
+    assert pfb_unbound.convert_ipv4(wire) == expected
+
+
+@pytest.mark.parametrize(
+    ("wire", "expected"),
+    [
+        (bytes([0, 0] + [0] * 15 + [1]), "0000:0000:0000:0000:0000:0000:0000:0001"),
+        (
+            bytes([0, 0, 0x20, 0x01, 0x0D, 0xB8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+            "2001:0db8:0000:0000:0000:0000:0000:0001",
+        ),
+        (b"", "Unknown"),
+        (None, "Unknown"),
+    ],
+)
+def test_convert_ipv6_uses_python3_byte_values(wire: bytes | None, expected: str) -> None:
+    assert pfb_unbound.convert_ipv6(wire) == expected
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ([ord("A"), 0, ord("B")], "A|B"),
+        ([ord("A"), 1, ord("B")], "A.B"),
+        ([ord("A"), 13, ord("B")], "A"),
+        ([ord("A"), 32, ord("B")], "A B"),
+        ([ord("h"), 58, ord("1")], "h:1"),
+        ([ord("A"), 14, 200, ord("B")], "AB"),
+        ([], "Unknown"),
+    ],
+)
+def test_convert_other_uses_python3_byte_values(payload: list[int], expected: str) -> None:
+    assert pfb_unbound.convert_other(bytes([0, 0, 0, *payload])) == expected
+
+
+@pytest.mark.parametrize(
+    ("duration", "expected"),
+    [("abc", False), ("0", False), ("1", 1), ("3600", 3600), ("3601", False)],
+)
+def test_python_control_duration_enforces_numeric_bounds(duration: str, expected: int | bool) -> None:
+    assert pfb_unbound.python_control_duration(duration) == expected
+
+
+class _MaxMind:
+    def __init__(self) -> None:
+        self.addresses: list[str] = []
+
+    def get(self, address: str) -> dict[str, dict[str, str]]:
+        self.addresses.append(address)
+        return {"country": {"iso_code": "US"}}
+
+
+def test_reply_ipv6_is_compressed_before_maxmind_classification(monkeypatch: pytest.MonkeyPatch) -> None:
+    address = "2001:4860:4860::8888"
+    wire = bytes([0, 0, *ipaddress.ip_address(address).packed])
+    data = SimpleNamespace(count=1, rr_data=[wire])
+    rrset = SimpleNamespace(rk=SimpleNamespace(type_str="AAAA"), entry=SimpleNamespace(data=data))
+    rep = SimpleNamespace(an_numrrsets=1, rrsets=[rrset], ttl=300)
+    qinfo = SimpleNamespace(qname_str="example.test.", qtype_str="AAAA")
+    qstate = SimpleNamespace(qinfo=qinfo, return_msg=None, return_rcode=0)
+    reader = _MaxMind()
+    lines: list[str] = []
+    pfb_unbound.pfb.update(
+        sqlite3_resolver_con=False,
+        python_reply=True,
+        mod_ipaddress=True,
+        python_maxmind=True,
+    )
+    pfb_unbound.noAAAADB = {}
+    pfb_unbound.rcodeDB = {}
+    pfb_unbound.maxmindReader = reader
+    monkeypatch.setattr(pfb_unbound, "log_entry", lambda line, _path: lines.append(line))
+
+    assert pfb_unbound.get_details_reply("reply", None, qstate, rep, {"pfb_addr": "192.0.2.1"})
+    fields = lines[0].split(",")
+    assert fields[8:] == [address, "US"]
+    assert reader.addresses == [address]
+
+
+def _control_qstate(command: str) -> SimpleNamespace:
+    reply = SimpleNamespace(query_reply=SimpleNamespace(addr="127.0.0.1"), next=None)
+    return SimpleNamespace(
+        qinfo=SimpleNamespace(qtype=16, qtype_str="TXT", qname_str=f"{command}."),
+        mesh_info=SimpleNamespace(reply_list=reply),
+        return_msg=SimpleNamespace(rep=SimpleNamespace(security=0)),
+        return_rcode=None,
+        ext_state={},
+    )
+
+
+@pytest.mark.parametrize(("encoded", "address"), [("192-0-2-1", "192.0.2.1"), ("2001:db8::1", "2001:db8::1")])
+def test_python_control_addbypass_and_removebypass_parse_ip_addresses(encoded: str, address: str) -> None:
+    pfb_unbound.pfb.update(
+        noAAAADB=False,
+        safeSearchDB=False,
+        python_control=True,
+        mod_threading=False,
+        gpListDB=False,
+    )
+    pfb_unbound.gpListDB = {}
+
+    add = _control_qstate(f"python_control.addbypass.{encoded}")
+    assert pfb_unbound.operate(0, 0, add, None)
+    assert pfb_unbound.gpListDB == {address: 0}
+
+    remove = _control_qstate(f"python_control.removebypass.{encoded}")
+    assert pfb_unbound.operate(0, 0, remove, None)
+    assert pfb_unbound.gpListDB == {}


### PR DESCRIPTION
## Summary

- Port the supported-Python DNSBL resolver changes from v3.2.16.
- Preserve active pfB alias tables during filter reloads, replace updated active tables, and remove inactive tables.
- Add direct resolver coverage and a hermetic `pfctl` command test for the alias-table behavior.
- Keep the canonical v3.3 package identity and unrelated metadata unchanged.

## Why

v3.3.0 was based on v3.2.15 plus configuration-handling changes. This supplies the remaining v3.2.16 functional delta needed for the v3.3.1.r1 Testing release without pulling in the historical `-devel` package rename.

## Validation

- Frozen test proof: `RED-OK` against `origin/release/3.3`, then `GREEN-OK` against this commit.
- `python3 -m pytest -q`: 27 passed.
- PHP syntax checks pass for the production include and new PHP runner; only pre-existing legacy warnings are emitted.
- Production hunks exactly match the v3.2.15-to-v3.2.16 functional diff; `pfb_unbound.py` matches the v3.2.16 blob exactly.
- The modern canonical gate's pytest phase passes. Its repository-wide Ruff/mypy/Composer phases are not compatible with this historical release branch, which predates their configuration and helper scripts.

Closes #2277

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firewall alias synchronization so active aliases update correctly without disrupting unchanged rules.
  * Removed outdated Python 2 compatibility behavior, improving Python 3 configuration, IP, and byte handling.
  * Preserved accurate IPv4 and IPv6 processing, including bypass validation and MaxMind classification.

* **Tests**
  * Added coverage for alias reload behavior, IP conversion, control-duration validation, and bypass commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->