### PR TITLE
landing: remove internal channel details

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -373,19 +373,6 @@ def _bootstrap_install(base: str, channel: str) -> str:
     )
 
 
-def _channel_switch_commands(base: str) -> str:
-    """The copyable two-step channel switch: move the subscription, then move the
-    installed package. Adding the target repository alone is a documented silent
-    no-op (`pkg` never leaves a package's origin repository), so both lines ship
-    together (issue #2148)."""
-    return (
-        f"fetch -qo - {base}/add-repo.sh \\\n"
-        f"  | sh -s -- --base-url {base} --channel <ch>\n"
-        f"fetch -qo - {base}/migrate-channel.sh \\\n"
-        "  | sh -s -- --channel <ch>"
-    )
-
-
 # Per-channel card copy: title, optional badge, and the audience/cadence prose. Fixed
 # content decisions for the four-channel model, issue #2147 step A (the landing page):
 # Stable = final tagged releases; Testing = nonzero-patch prereleases validating the
@@ -439,73 +426,6 @@ def _channel_card(channel: str, base: str, latest: dict[str, str], conf_fn: Call
         f'<p class="blurb">{meta["blurb"]}</p>'
         f"{_copyable(_esc(_bootstrap_install(base, channel)))}"
         f"{_manual_conf_details(conf_fn, channel)}</div>"
-    )
-
-
-def _trust_section_html(base: str) -> str:
-    """The trust/provenance section: what 'installing from this repo' actually means
-    under the four-channel model (issue #2147). No catalogue-signing claim anywhere;
-    the NONE-signed trust anchor is HTTPS/TLS to the Pages host (mirrors add-repo.sh's
-    own conf comment). *base* is woven into the channel-switching subsection, whose
-    two client scripts are both served from it (issue #2148).
-    """
-    return (
-        "<h2>Trust &amp; channel model</h2>"
-        "<h3>One tagged artifact, several catalogues</h3>"
-        '<p class="blurb">Stable, Testing, and Edge may intentionally serve the exact same canonical '
-        "package &mdash; same name, same version, same bytes &mdash; because a single tagged release "
-        "always fans out to every channel its tag kind reaches: a Stable final lands in Stable, Testing, "
-        "and Edge; a Testing prerelease lands in Testing and Edge; an Edge patch-zero prerelease lands "
-        "in Edge alone. Edge's own latest simply moves ahead numerically once a new release family "
-        "opens there &mdash; the fan-out itself never depends on what else has been published. This is "
-        "catalogue placement, not separate builds, and not a repository-priority policy.</p>"
-        "<h3>Trust model</h3>"
-        '<p class="blurb">Every repository conf sets <code>signature_type: none</code> &mdash; there is '
-        "no catalogue-signing key. The trust anchor is HTTPS/TLS to this Pages host.</p>"
-        "<h3>Single-repository subscription</h3>"
-        '<p class="blurb">A box subscribes to exactly one channel repository at a time. The four '
-        "channel repos share one equal priority (<code>100</code>), above the base Netgate "
-        "<code>pfSense</code> repo (priority <code>0</code>); live <code>pkg</code> resolution at equal "
-        "priority ignores version ordering between repos, and upgrades of an installed package never "
-        "leave its origin repository &mdash; so enabling a second project channel repo is not how "
-        "channel selection works. This is safe because each channel catalogue strictly contains "
-        "everything its slower channels carry: Edge holds every package Testing does, and Testing holds "
-        "every package Stable does, so a Stable final always lands in Stable, Testing, and Edge; a "
-        "Testing prerelease always lands in Testing and Edge; an Edge patch-zero prerelease lands in "
-        "Edge alone. One subscription therefore already has every package a box could need, because "
-        "<code>pkg</code> orders versions numerically, component-wise &mdash; never by release date: if "
-        "Edge holds <code>4.0.0.a2</code> and a later <code>3.2.16.a3</code> or <code>3.2.17</code> is "
-        "published into it, the latest in Edge stays <code>4.0.0.a2</code>, and the older build stays in "
-        "the Edge catalogue as in-repo rollback material. Switching forward (to a higher version) is "
-        "replacing the enabled conf with the faster channel's and upgrading normally. Rolling back is an "
-        "explicit repository-qualified downgrade/reinstall &mdash; available within the same repo on a "
-        "faster channel (containment keeps the older build around), or after switching the conf to a "
-        "slower channel. Removing a channel means removing its conf. Identical name/version across "
-        "catalogues remains valid only because the bytes and provenance are identical.</p>"
-        "<h3>Retention</h3>"
-        '<p class="blurb">Each <code>&lt;channel&gt;/&lt;varver&gt;/</code> catalogue retains the newest '
-        "5 canonical packages; a faster channel additionally retains any canonical package one of "
-        "its slower channels still retains, so containment (Edge &supe; Testing &supe; Stable) "
-        "survives retention, not only fan-out. Dependency packages are not pruned.</p>"
-        "<h3>Netgate identity</h3>"
-        '<p class="blurb">The canonical package shares its name with the pfBlockerNG package Netgate '
-        "ships in its own <code>pfSense</code> repo &mdash; provenance differs. Every build published "
-        "here carries <code>commit</code>/<code>created</code> annotations linking it to the source "
-        "commit that produced it; repository priority decides which build <code>pkg</code> selects when "
-        "both are enabled.</p>"
-        "<h3>Channel switching</h3>"
-        '<p class="blurb">Switching channels is two steps, and the second one is not optional. '
-        f"<code>{_esc(base)}/add-repo.sh</code> run with <code>--channel &lt;ch&gt;</code> moves the "
-        "<em>subscription</em>: it writes that channel's conf and retires every other project conf. "
-        "It does not move the <em>installed package</em> &mdash; <code>pkg</code> keeps an installed "
-        "package pinned to its origin repository and offers no upgrade across repositories, so a box "
-        "that only gains a conf silently keeps running its old build. "
-        f"<code>{_esc(base)}/migrate-channel.sh</code> run with the same "
-        "<code>--channel &lt;ch&gt;</code> performs the repository-qualified operation that actually "
-        "moves it, replaces a legacy suffixed identity "
-        "(<code>-devel</code>, <code>-nightly</code>) with the canonical package, and verifies the "
-        "result before reporting success. There is no in-UI channel switcher by design.</p>"
-        f"{_copyable(_esc(_channel_switch_commands(base)))}"
     )
 
 
@@ -943,11 +863,8 @@ def render_page(
         "<header><h1>pfBlockerNG</h1>"
         "<p>Self-hosted FreeBSD <code>pkg</code> repository for pfSense&nbsp;CE &amp; pfSense&nbsp;Plus.</p></header>"
         "<p>Install pfBlockerNG straight from this repository: pick a channel below and run its "
-        f"commands on your firewall (as <code>root</code>). Every channel installs the same canonical "
-        f"package (<code>{CANONICAL_EMITTED_IDENTITY}</code>) from its own repository &mdash; see "
-        "Trust &amp; channel model below for how the four relate.</p>"
+        "commands on your firewall (as <code>root</code>).</p>"
         f'<h2>Channels</h2><div class="cards">{cards}</div>'
-        f"{_trust_section_html(base)}"
         f"<h2>Published packages</h2>{_packages_html(pkgs, matrix)}"
         f"{eol_block}"
         "<h2>Repository files</h2>"

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -1044,8 +1044,8 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
     assert f"sh -s -- --base-url {base} --channel testing\npkg install {_CANON}</pre>" in page
     assert f"sh -s -- --base-url {base} --channel edge\npkg install {_CANON}</pre>" in page
     assert f"sh -s -- --base-url {base} --channel nightly\npkg install {_CANON}</pre>" in page
-    # One bootstrap per card, plus the channel-switch snippet's first step (issue #2148).
-    assert page.count(f"fetch -qo - {base}/add-repo.sh") == 5
+    # One bootstrap per card.
+    assert page.count(f"fetch -qo - {base}/add-repo.sh") == 4
     # The manual conf came from the injected conf function — one per channel.
     for ch in gl.CH_ORDER:
         assert f"{ch}-conf-snippet" in page
@@ -1098,10 +1098,9 @@ def test_render_page_snippets_have_copy_buttons() -> None:
     assert f"\npkg install {_CANON}</pre>" in page
     assert f"{btn}<pre>stable-conf-snippet</pre>" in page
 
-    # Exactly the nine command snippets are copyable — a unified command + a manual conf in
-    # each of the four channel cards, plus the two-step channel switch (issue #2148). Inline
-    # <code> is not copyable.
-    assert page.count('<button class="copy"') == 9
+    # Exactly the eight card snippets are copyable — a unified command + a manual conf in
+    # each of the four channel cards. Inline <code> is not copyable.
+    assert page.count('<button class="copy"') == 8
 
     # The styling + the behaviour that make the button work are shipped inline (static page).
     assert ".copy{" in page and ".snip{position:relative}" in page
@@ -1129,10 +1128,9 @@ def test_render_page_empty_channel_shows_not_yet_published_for_every_card() -> N
     assert page.count("not yet published") == 4
 
 
-def test_render_page_shared_version_across_stable_testing_edge_and_trust_prose() -> None:
+def test_render_page_shared_version_across_stable_testing_edge() -> None:
     """Row 4: the SAME canonical pkg name+version fixture present in stable/testing/edge
-    means all three cards show the same version, and the trust section's shared-bytes
-    prose is present."""
+    means all three cards show the same version."""
     ver = "4.0.0"
     pkgs = [
         _pkg("stable", _CANON, ver, "FreeBSD:15:*", f"stable/ce-2.8/x-{ver}.pkg"),
@@ -1143,9 +1141,6 @@ def test_render_page_shared_version_across_stable_testing_edge_and_trust_prose()
 
     # Same version string surfaces on stable, testing, AND edge's card (3 occurrences).
     assert page.count(f'<p class="ver">Latest <code>{ver}</code></p>') == 3
-    # The shared-bytes trust prose.
-    assert "same name, same version, same bytes" in page
-    assert "fans out to every channel" in page
 
 
 def test_render_page_edge_ahead_of_testing_and_stable_shows_divergence() -> None:
@@ -1163,83 +1158,15 @@ def test_render_page_edge_ahead_of_testing_and_stable_shows_divergence() -> None
     assert '<p class="ver">Latest <code>4.1.0.a1</code></p>' in page
 
 
-def test_render_page_trust_section_present_and_accurate() -> None:
-    """The trust/provenance section documents signature_type: none, priority
-    equality, the single-repository-subscription / strict-containment /
-    numeric-ordering model, repository-qualified downgrades, and containment-aware
-    retention — with NO catalogue-signing claim anywhere outside the explicit 'no
-    signing key' sentence (a deliberately failable assertion, not a vacuous one), and
-    NO retired equal-priority-version-arbitration claim."""
+def test_render_page_omits_internal_trust_and_channel_model() -> None:
+    """Development and implementation details do not leak into the user-facing page."""
     page = gl.render_page("https://x/pkg", [], _stub_conf)
 
-    assert "signature_type: none" in page
-    # The ONE place 'signing' may appear: the explicit no-signing-key sentence.
-    assert "no catalogue-signing key" in page
-    # Allowlist, not substring-count: strip the two legitimate framings, then NO
-    # sign-rooted wording may remain — a rephrased signing claim anywhere fails here.
-    residue = page.lower().replace("signature_type: none", "").replace("no catalogue-signing key", "")
-    assert "signing" not in residue
-    assert "signed" not in residue
-    assert "signature" not in residue
-    # Priority-equality prose (still true — priority decides project-vs-Netgate, ADR-17).
-    assert "equal priority" in page
-    assert "<code>100</code>" in page
-    assert "Single-repository subscription" in page
-    assert "subscribes to exactly one channel repository" in page
-    # The retired multi-repo-version-arbitration claim must be gone — reintroducing it
-    # fails this tripwire.
-    assert "selects the highest compatible version across" not in page
-    # Strict-containment prose + numeric-ordering statement, pinned via the owner's own
-    # worked example (4.0.0.a2 outranking a later-published 3.2.x).
-    assert "strictly contains everything its slower channels carry" in page
-    assert "orders versions numerically, component-wise" in page
-    assert "<code>4.0.0.a2</code>" in page
-    # Rollback is in-repo on a faster channel; the repository-qualified downgrade
-    # string is retained verbatim.
-    assert "repository-qualified downgrade" in page
-    assert "containment keeps the older build around" in page
-    # The retired conditional-fan-out phrasing must be gone; the unconditional fan-out
-    # is stated as an unqualified "always".
-    assert "until a later release family opens a new Edge" not in page
-    assert "always fans out to every channel" in page
-    # Retention count — pinned to the publisher's constant so the page cannot silently
-    # drift from the real retention policy. Also pins the containment-survives-
-    # retention wording (issue #2146 R1 review, PR #2253): a faster channel's own
-    # keep-count churn must never be described as unconditional once it can protect a
-    # slower channel's still-retained version.
-    import catalogue_assembly
-
-    assert f"retains the newest {catalogue_assembly.DEFAULT_RETENTION_KEEP}" in page
-    assert "additionally retains any canonical package one of its slower channels still retains" in page
-    assert "Netgate" in page
-    assert "commit" in page.lower() and "created" in page.lower()
-
-
-def test_render_page_channel_switching_documents_the_migration_tooling() -> None:
-    """Channel switching is a TWO-step client operation, and the page must say so.
-
-    Before issue #2148 landed, the section deferred: "client tooling for it is tracked
-    separately (issue #2148)". That deferral is now false — `add-repo.sh --channel <ch>`
-    moves the subscription and `migrate-channel.sh --channel <ch>` moves the installed
-    package onto it. Adding the repository alone is the documented silent no-op (`pkg`
-    keeps an installed package pinned to its origin repository), so a page that names
-    only the first step would actively mislead.
-    """
-    page = gl.render_page("https://x/pkg", [], _stub_conf)
-
-    assert "Channel switching" in page
-    # The deferral is retired — reintroducing it fails here.
-    assert "tracked separately" not in page
-    # Both steps, in order, both fetchable from this site.
-    switch_step_1 = "https://x/pkg/add-repo.sh"
-    switch_step_2 = "https://x/pkg/migrate-channel.sh"
-    assert switch_step_1 in page
-    assert switch_step_2 in page
-    assert page.rindex(switch_step_1) < page.rindex(switch_step_2)
-    # The mandatory flag, rendered escaped in the prose and literal in the snippet.
-    assert "--channel &lt;ch&gt;" in page
-    # The reason the second step exists at all — adding a conf moves nothing.
-    assert "origin repository" in page
+    assert "Every channel installs the same canonical package" not in page
+    assert "Trust &amp; channel model" not in page
+    assert "signature_type: none" not in page
+    assert "Single-repository subscription" not in page
+    assert "Channel switching" not in page
 
 
 def test_render_autoindex_lists_dirs_files_and_parent() -> None:


### PR DESCRIPTION
Fixes #2287

Removes the internal Trust and channel model section, its channel-switching implementation prose, and the introductory canonical-package sentence from the public landing page.

Verification:

- focused removal assertions: RED before production edit, GREEN unchanged
- `python3 -m pytest -q tests/test_gen_landing.py`: 73 passed
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS

After merge, the production page will be regenerated with the publisher's existing wildcard-ABI matrix transform so current packages group under pfSense CE and pfSense Plus.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified the landing page by removing channel-switching instructions and trust-model explanations.
  - Updated introductory guidance to focus on running channel commands with root permissions.
- **Tests**
  - Updated landing-page checks for the revised content and controls.
  - Added coverage confirming removed trust and channel-model terminology does not appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->