### PR TITLE
pfblockerng: accept current Python package channels

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_python.sh
+++ b/src/usr/local/pkg/pfblockerng/pfb_python.sh
@@ -2,7 +2,8 @@
 # Resolve and execute pfBlockerNG's package-provided Python interpreter.
 #
 # Normal mode queries /usr/local/sbin/pkg for the installed
-# pfSense-pkg-pfBlockerNG, then reads its direct dependencies. The only
+# current pfSense-pkg-pfBlockerNG channel package (plus legacy -devel), then
+# reads its direct dependencies. The only
 # accepted direct dependency names are pyNN/pythonNN (NN is at least two
 # digits); module dependencies and ambiguous versions fail closed.
 #
@@ -52,14 +53,14 @@ else
 	)
 	pkg_status=$?
 	if [ "${pkg_status}" -ne 0 ]; then
-		fail "package-name query failed (expected pfSense-pkg-pfBlockerNG stable/devel/nightly via ${pkg_bin})"
+		fail "package-name query failed (expected a current pfSense-pkg-pfBlockerNG channel or legacy -devel via ${pkg_bin})"
 	fi
 
 	pkg_name=''
 	while IFS= read -r candidate || [ -n "${candidate}" ]; do
 		candidate_lc=$(printf '%s' "${candidate}" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 		case "${candidate_lc}" in
-			pfsense-pkg-pfblockerng|pfsense-pkg-pfblockerng-devel|pfsense-pkg-pfblockerng-nightly)
+			pfsense-pkg-pfblockerng|pfsense-pkg-pfblockerng-testing|pfsense-pkg-pfblockerng-edge|pfsense-pkg-pfblockerng-devel|pfsense-pkg-pfblockerng-nightly)
 				pkg_name=${candidate}
 				break
 				;;
@@ -68,7 +69,7 @@ else
 ${pkg_names}
 EOF
 	if [ -z "${pkg_name}" ]; then
-		fail "no valid pfBlockerNG package (expected stable/devel/nightly, got ${pkg_names:-none})"
+		fail "no valid pfBlockerNG package (expected a current channel or legacy -devel, got ${pkg_names:-none})"
 	fi
 
 	dependencies=$(

--- a/tests/shell/pfb_python_spec.sh
+++ b/tests/shell/pfb_python_spec.sh
@@ -82,14 +82,15 @@ EOF
         pfSense-pkg-pfBlockerNG-testing \
         pfSense-pkg-pfBlockerNG-edge \
         pfSense-pkg-pfBlockerNG-devel \
-        pfSense-pkg-pfBlockerNG-nightly
+        pfSense-pkg-pfBlockerNG-nightly \
+        PFSENSE-PKG-PFBLOCKERNG-EDGE
       do
         PFB_PKG_TEST_NAME="${pkg_name}" PFB_PKG_BIN="${pkg}" PFB_PYTHON_DIR="${bindir}" \
           "${wrapper}" --print-interpreter || return
       done
     }
     expected=$(printf '%s\n' "${bindir}/python3.11" "${bindir}/python3.11" "${bindir}/python3.11" \
-      "${bindir}/python3.11" "${bindir}/python3.11")
+      "${bindir}/python3.11" "${bindir}/python3.11" "${bindir}/python3.11")
     When call run_valid_packages
     The output should equal "${expected}"
     The status should be success

--- a/tests/shell/pfb_python_spec.sh
+++ b/tests/shell/pfb_python_spec.sh
@@ -63,21 +63,35 @@ EOF
     cleanup
   End
 
-  It 'accepts the first valid stable/devel/nightly package after unknown names'
+  It 'accepts every current package identity plus legacy devel after unknown names'
     setup
     pkg="${work}/pkg"
-    cat > "${pkg}" <<EOF
+    cat > "${pkg}" <<'EOF'
 #!/bin/sh
-if [ "\$2" = '-g' ]; then
-  printf '%s\n' 'unknown-package' 'PFSENSE-PKG-PFBLOCKERNG-devel'
+if [ "$2" = '-g' ]; then
+  printf '%s\n' 'unknown-package' "$PFB_PKG_TEST_NAME"
 else
-  [ "\$3" = 'PFSENSE-PKG-PFBLOCKERNG-devel' ] || exit 1
+  [ "$3" = "$PFB_PKG_TEST_NAME" ] || exit 1
   printf '%s\n' 'python311'
 fi
 EOF
     chmod +x "${pkg}"
-    When run env PFB_PKG_BIN="${pkg}" PFB_PYTHON_DIR="${bindir}" "${wrapper}" --print-interpreter
-    The output should equal "${bindir}/python3.11"
+    run_valid_packages() {
+      for pkg_name in \
+        pfSense-pkg-pfBlockerNG \
+        pfSense-pkg-pfBlockerNG-testing \
+        pfSense-pkg-pfBlockerNG-edge \
+        pfSense-pkg-pfBlockerNG-devel \
+        pfSense-pkg-pfBlockerNG-nightly
+      do
+        PFB_PKG_TEST_NAME="${pkg_name}" PFB_PKG_BIN="${pkg}" PFB_PYTHON_DIR="${bindir}" \
+          "${wrapper}" --print-interpreter || return
+      done
+    }
+    expected=$(printf '%s\n' "${bindir}/python3.11" "${bindir}/python3.11" "${bindir}/python3.11" \
+      "${bindir}/python3.11" "${bindir}/python3.11")
+    When call run_valid_packages
+    The output should equal "${expected}"
     The status should be success
     cleanup
   End

--- a/tests/smoke/test_smoke_lint_probe.py
+++ b/tests/smoke/test_smoke_lint_probe.py
@@ -117,6 +117,29 @@ _PY_PATH_OPEN = "<<<PFBPY>>>"
 _PY_PATH_CLOSE = "<<<PFBPYEND>>>"
 
 
+def _validated_python_paths(payload: str, out: str) -> tuple[str, str]:
+    fields = payload.split("\n")
+    assert len(fields) == 2, f"expected interpreter and wrapper paths: stdout={out!r}"
+    resolved, wrapper = fields
+    assert resolved, f"pfb_python_interpreter() returned an empty path: stdout={out!r}"
+    assert wrapper, f"PFB_PYTHON_WRAPPER was empty: stdout={out!r}"
+    return resolved, wrapper
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        pytest.param("\n/wrapper", "pfb_python_interpreter() returned an empty path", id="empty-interpreter"),
+        pytest.param("/interpreter\n", "PFB_PYTHON_WRAPPER was empty", id="empty-wrapper"),
+        pytest.param("/interpreter", "expected interpreter and wrapper paths", id="missing-wrapper"),
+        pytest.param("/interpreter\n/wrapper\nextra", "expected interpreter and wrapper paths", id="extra-field"),
+    ],
+)
+def test_python_path_fields_name_invalid_output(payload: str, message: str) -> None:
+    with pytest.raises(AssertionError, match=re.escape(message)):
+        _validated_python_paths(payload, f"{_PY_PATH_OPEN}{payload}{_PY_PATH_CLOSE}")
+
+
 def _guest_python(vm: SmokeVM) -> str:
     """The package Python wrapper on the guest, cross-checked with PHP.
 
@@ -138,11 +161,7 @@ def _guest_python(vm: SmokeVM) -> str:
     assert result.returncode == 0 and start != -1 and end != -1, (
         f"pfb_python_interpreter() resolution failed: rc={result.returncode} stdout={out!r} stderr={result.stderr!r}"
     )
-    fields = out[start + len(_PY_PATH_OPEN) : end].split("\n")
-    assert len(fields) == 2, f"expected interpreter and wrapper paths: stdout={out!r}"
-    resolved, wrapper = fields
-    assert resolved, f"pfb_python_interpreter() returned an empty path: stdout={out!r}"
-    assert wrapper, f"PFB_PYTHON_WRAPPER was empty: stdout={out!r}"
+    resolved, wrapper = _validated_python_paths(out[start + len(_PY_PATH_OPEN) : end], out)
     wrapper_result = vm.ssh(
         f"printf %s {_PY_PATH_OPEN!r}; {shlex.quote(wrapper)} --print-interpreter; printf %s {_PY_PATH_CLOSE!r}",
         timeout=120,

--- a/tests/smoke/test_smoke_lint_probe.py
+++ b/tests/smoke/test_smoke_lint_probe.py
@@ -138,7 +138,9 @@ def _guest_python(vm: SmokeVM) -> str:
     assert result.returncode == 0 and start != -1 and end != -1, (
         f"pfb_python_interpreter() resolution failed: rc={result.returncode} stdout={out!r} stderr={result.stderr!r}"
     )
-    resolved, wrapper = out[start + len(_PY_PATH_OPEN) : end].strip().splitlines()
+    fields = out[start + len(_PY_PATH_OPEN) : end].split("\n")
+    assert len(fields) == 2, f"expected interpreter and wrapper paths: stdout={out!r}"
+    resolved, wrapper = fields
     assert resolved, f"pfb_python_interpreter() returned an empty path: stdout={out!r}"
     assert wrapper, f"PFB_PYTHON_WRAPPER was empty: stdout={out!r}"
     wrapper_result = vm.ssh(


### PR DESCRIPTION
## Summary

- accept the current `stable`, `testing`, `edge`, and `nightly` package identities while retaining legacy `devel` compatibility
- cover every accepted package identity in the wrapper specification
- preserve empty resolver fields so smoke failures identify the missing interpreter or wrapper path

## Verification

- RED on `a08fcc34fc509877cc875e0fb077d6fc85520eee`: Plus 26.07 `test_py_compile_probe` selection failed all 3 cases at the two-field unpack (`3 failed, 964 deselected`)
- GREEN on `2d60b66d86a6416bb7cb742938723cb2de698a35`: same Plus 26.07 selection passed (`3 passed, 964 deselected`)
- `scripts/agent/run-gates.sh --diff origin/devel`
- focused ShellSpec: `6 examples, 0 failures`

CE appliance validation remains independently blocked by #2242.

Fixes #2263

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pfBlockerNG package detection for current, testing, edge, legacy development, and nightly package names.
  * Updated error messages to clearly identify supported package variants.
  * Improved interpreter and wrapper path resolution during smoke checks, including safer handling of missing, extra, or empty path values.

* **Tests**
  * Expanded coverage for Python interpreter resolution across all supported package identities and invalid path output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->