### PR TITLE
pfblockerng: serialize filter reload with live punch

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -4755,8 +4755,7 @@ function sync_package_pfblockerng($cron='') {
 		// Remove any IPs in Alerts unlock feature
 		unlink_if_exists("{$pfb['ip_unlock']}");
 
-		require_once('filter.inc');
-		filter_configure_sync();
+		mwexec('/etc/rc.filter_configure_sync');
 
 		// Stop/Restart pfb_filter service for new rule changes
 		if ($pfb['enable'] !== PfbToggle::On) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -4756,7 +4756,7 @@ function sync_package_pfblockerng($cron='') {
 		unlink_if_exists("{$pfb['ip_unlock']}");
 
 		require_once('filter.inc');
-		filter_configure();
+		filter_configure_sync();
 
 		// Stop/Restart pfb_filter service for new rule changes
 		if ($pfb['enable'] !== PfbToggle::On) {


### PR DESCRIPTION
## Summary

- Run pfSense's synchronous rc filter reload while `sync_package_pfblockerng()` still holds the feed-pass lock.
- Prevent the queued reload from rebuilding a live-punched table during or immediately after the Alerts suppress/unlock carve.

## Root cause

`filter_configure()` only queued a `filter reload` event. The pfBlockerNG update then released `pfb_feed_pass.lock`, allowing an Alerts live punch to run before the queued worker rebuilt the table from its canonical mirror. Depending on the interleaving, the worker either restored the punched host or erased the CIDR remainders before the parent entry was deleted.

Running `/etc/rc.filter_configure_sync` synchronously at the same site completes that existing reload inside the existing feed-pass lock and supplies pfSense's required filter, shaper, IPsec, and VPN runtime environment. This adds no retry, sleep, timeout, or lock.

## Validation

- Recorded RED: nightly CE 2.8 run 30797028776 at `dd75c81c` produced the required unlock IPv4/IPv6 failures with the byte-frozen test file hash `57a290d9c1440f881f20c28f096bfcd6a0e54ce4`. Later PR #2127 samples corroborate the recurrence but included an unrelated test-file edit, so they are not claimed as byte-identical RED proof.
- Exact-head GREEN (`0db1100a1e33ca916930bfda6df419fec8c73f07`), expanded frozen selector covering suppress/unlock over IPv4/IPv6:
  - CE 2.8 run 31457960464: 4 passed, 591 deselected.
  - Plus 26.03 runs 31458532553, 31458586632, and 31458591178: 4 passed, 591 deselected in each of three independent samples.
- Three additional CE 2.8 samples (31457960438, 31457960454, 31458282242) never deployed the package or executed a test: the guest package ABI had changed to FreeBSD 16 before the workflow installed its FreeBSD 15 dependency. They are setup errors, not regression results.
- Event synchronization: the package update now consumes the synchronous rc completion while holding the feed-pass lock; the Alerts POST returns only after the synchronous live punch completes. No sleeps, retry loop, or widened timeout.
- `vendor/bin/phpunit tests/php/LivePunchPlanTest.php tests/php/AlertsLivePunchApplyTest.php tests/php/LivePunchRunTest.php` — 29 tests, 233 assertions passed.
- `scripts/agent/run-gates.sh --diff origin/devel` — PHP syntax, 5,024-test PHPUnit suite, PHPStan, and PHPCS passed.
- Independent contract and hostile correctness reviews passed at the exact head.

no-test-needed: The existing Alerts live carve tests are the exact regression tests, already produced the recorded RED failures, and remained byte-identical for the GREEN proof.

Fixes #2153

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
