### PR TITLE
Retire user-configurable tick interval

### DIFF
--- a/.ADRs/ADR_25_Group_Policy_DNSBL/ADR.md
+++ b/.ADRs/ADR_25_Group_Policy_DNSBL/ADR.md
@@ -161,7 +161,7 @@ during school hours". pfSense already ships a native scheduler: the `<schedules>
 section (Firewall > Schedules), referenced by firewall rules via a `sched` name and evaluated
 by `filter_get_time_based_rule_status()`. None of it is wired into the DNSBL decision path.
 (Updated 2026-07-03 for ADR-43, amended 2026-07-12 for issue #1204: package scheduling is now
-**one cron tick** — `pfblockerng.php cron-tick` every `pfb_tick_interval` minutes reading the
+**one cron tick** — `pfblockerng.php cron-tick` every 15 minutes reading the
 due-ledger — and an
 already-landed PHP time-window evaluator exists, `pfb_quiet_hours` +
 `pfb_quiet_hours_in_window()` in `pfblockerng_extra.inc`, a precedent/possible reuse for this

--- a/.ADRs/ADR_33_Auto_Feed_Management/ADR.md
+++ b/.ADRs/ADR_33_Auto_Feed_Management/ADR.md
@@ -201,7 +201,7 @@ further actions).
 - Prompt: `03_Mode_Setting.txt`
 - Register **`pfb_feed_mgmt_mode`** (`off`/`notify`/`auto`, default `off`) — renamed
   2026-07-03 to match the `pfb_*` convention of the sibling registered keys
-  (`pfb_agg_types`, `pfb_alias_delta_mode`, `pfb_tick_interval`) — in `pfb_cfg_registry()`
+  (`pfb_agg_types`, `pfb_alias_delta_mode`) — in `pfb_cfg_registry()`
   (+ `since`) + the RequireConfigGateway sniff `$registeredPaths`; read/write via `PfbConfig`.
   Mode values ⇒ a **backed enum** per ADR-28 item 1 (the `PfbIdnMode` pattern), not a plain
   string; add the field's row to the `docs/misc/config-gateway.md` inventory. No reconcile

--- a/.ADRs/ADR_43_Update_And_Scheduling_Revamp/04_Single_Tick_Cron.txt
+++ b/.ADRs/ADR_43_Update_And_Scheduling_Revamp/04_Single_Tick_Cron.txt
@@ -83,3 +83,8 @@ HANDOFF — write `.ADRs/ADR_43_Update_And_Scheduling_Revamp/RESULTS/04_Results.
 Record: the tick verb name + dispatch logic; the single-tick crontab line + default freq knob (PfbConfig
 key); how legacy knobs seed the ledger; the #468 persist integration; cadence/jitter test results;
 the reboot smoke result; the go-ahead for Phase 5.
+
+POST-MERGE AMENDMENT — 2026-08-11 (issue #2090)
+The tick-frequency-knob requirements above are historical. The cron-tick cadence is fixed at */15;
+pfb_tick_interval is no longer registered or supported through config/CLI. A stale raw config.xml
+value remains stored but inert, with no schema migration.

--- a/.ADRs/ADR_43_Update_And_Scheduling_Revamp/ADR.md
+++ b/.ADRs/ADR_43_Update_And_Scheduling_Revamp/ADR.md
@@ -380,3 +380,15 @@ Phase 6 is the GUI; Phase 7 is migration/docs/live proof.
 - **The cron consolidation cannot preserve cadence + jitter + avoid the boot stampede** without
   regression (Phase 4 pins fail). Then keep the separate `dcc`/`bl` jobs (their jitter is in crontab)
   and apply the tick only to the feed `cron` + `ss_refresh`; the rest of the ADR stands.
+
+## 8. Post-merge amendments
+
+### 2026-08-11 — fixed tick cadence (issue #2090)
+
+The configurable tick-frequency requirements in §2.G, §3, §5, and Phase 4 remain above as the
+historical decision. They are superseded by issue #2090:
+
+- The single `cron-tick` entry runs at a fixed `*/15` cadence.
+- `pfb_tick_interval` is no longer a registered `PfbConfig` field or supported config/CLI knob.
+- A stale raw `pfb_tick_interval` value in `config.xml` is left unchanged but is inert; no schema
+  migration is performed.

--- a/.ADRs/ADR_43_Update_And_Scheduling_Revamp/RESULTS/04_Results.txt
+++ b/.ADRs/ADR_43_Update_And_Scheduling_Revamp/RESULTS/04_Results.txt
@@ -121,3 +121,7 @@ Post-fix verification:
   python -m pytest -q                                       → 1882 passed, 4 skipped
 
 ADR-RESUME: branch=adr/43-update-and-scheduling-revamp next-phase=5
+
+POST-MERGE AMENDMENT — 2026-08-11 (issue #2090)
+The configurable pfb_tick_interval implementation recorded above was retired. cron-tick now uses a
+fixed */15 cadence; the registry key and clamp are removed, and stale raw config.xml values are inert.

--- a/.ADRs/ADR_43_Update_And_Scheduling_Revamp/RESULTS/07_Results.txt
+++ b/.ADRs/ADR_43_Update_And_Scheduling_Revamp/RESULTS/07_Results.txt
@@ -83,3 +83,7 @@ ADR-43 implementation complete on the branch. Ready to land via PR (rebase-only)
 dispatch the live-VM fan-out for acceptance.
 
 ADR-RESUME: branch=adr/43-update-and-scheduling-revamp next-phase=DONE
+
+POST-MERGE AMENDMENT — 2026-08-11 (issue #2090)
+The two-knob description above is historical. pfb_tick_interval was retired; cron-tick now uses a
+fixed */15 cadence, while pfb_quiet_hours remains the only advanced scheduling knob.

--- a/.ADRs/ADR_49_Plain_Text_Sanity_Scan/02_Config_And_Wire.txt
+++ b/.ADRs/ADR_49_Plain_Text_Sanity_Scan/02_Config_And_Wire.txt
@@ -162,3 +162,7 @@ Include:
   `<header>_v4` in the log line, per the ADR-48 handoff), and that the flag is
   set via config (no GUI) so the smoke sets pfb_feed_sanity='on' directly.
 - PHPUnit/phpstan/phpcs summaries; commit hash + push confirmation.
+
+POST-ACCEPTANCE ADDENDUM — 2026-08-11 (issue #2090)
+The comparison to ADR-43's pfb_tick_interval above is historical: that scheduler knob was retired,
+and cron-tick now runs at a fixed */15 cadence. pfb_feed_sanity remains a supported config-only knob.

--- a/.ADRs/ADR_61_Sync_Status_Ledger/ADR.md
+++ b/.ADRs/ADR_61_Sync_Status_Ledger/ADR.md
@@ -498,3 +498,9 @@ section is the authoritative correction.**
 Absent/corrupt-ledger reads remain fail-safe current-runtime behaviour. Historical
 "downgrade-safe" wording does not establish an older-package compatibility requirement. Package
 downgrade is unsupported; no inverse ledger conversion or downgrade-only test is required.
+
+## Amendment — 2026-08-11: fixed tick cadence (issue #2090)
+
+The `pfb_tick_interval` wording in §7 step 3 is historical. "Within one tick interval" now means
+within one fixed 15-minute tick; there is no registered `pfb_tick_interval` config/CLI knob. A stale
+raw value may remain in `config.xml`, but scheduling ignores it.

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1437,7 +1437,7 @@ window. `PFB_TRIGGER` values are unchanged across the migration, so the ADR-12 h
 ### One trigger-tick + the due-ledger
 
 The four legacy cron families (`cron`/`dcc`/`bl`/`ss_refresh`) collapse to **one** crontab entry —
-`*/<pfb_tick_interval> … pfblockerng.php cron-tick` (default every **15 min**). `cron-tick` is the
+`*/15 … pfblockerng.php cron-tick` (fixed every **15 min**). `cron-tick` is the
 cron-only wrapper: it runs the tick unless `/var/db/pfblockerng/.pfb_cron_disable` exists, in which
 case it logs `[ Disabled by … ]` and dispatches nothing (issue #1204 — the smoke suite's scheduler
 off switch; the Update page reports the suppression). The direct `pfblockerng.php tick` verb is
@@ -1502,10 +1502,9 @@ so every re-fetched feed re-ingests regardless of content. A read-only **Schedul
 from the ledger (last-run / next-due per job); a tidied update-log pane. No raw verb strings in
 the UI.
 
-Two registered `PfbConfig` knobs (ADR-29), both with safe defaults and **no GUI control** — set via
-config/CLI for advanced tuning:
+One registered `PfbConfig` knob remains (ADR-29), with a safe default and **no GUI control** — set
+via config/CLI for advanced tuning:
 
-- **`pfb_tick_interval`** (default `15`) — tick cadence in minutes; `*/N` in crontab.
 - **`pfb_quiet_hours`** (default `''` = apply immediately) — maintenance window that defers apply.
 
 ### Tests & DoD

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -438,7 +438,7 @@ originally because `pfblockerng_extra.inc` hosts `PfbConfig` itself (gateway can
 through itself) and `pfblockerng_migrate.inc` predates registry. `pfblockerng_extra.inc` has
 since grown well beyond gateway — also hosts real dispatch/scheduling logic (e.g.
 ADR-43 due-ledger API and `pfblockerng_tick()`). That code is registered-field-adjacent (reads
-`pfb_interval`/`pfb_quiet_hours`/`pfb_tick_interval` via `PfbConfig::read()` already) but sniff
+`pfb_interval`/`pfb_quiet_hours` via `PfbConfig::read()` already) but sniff
 cannot enforce it there — any new code landing in this file must self-police `PfbConfig` usage for
 registered keys (direct `config_get_path`/`config_set_path` on one is rule violation sniff
 will not catch); rely on manual review, not mechanical gate.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7173,8 +7173,8 @@ function pfblockerng_cron_exists($pfb_cmd, $pfb_min, $pfb_hour, $pfb_mday, $pfb_
 
 // issue #1204: extracted from sync_package_pfblockerng() so PHPUnit can pin the
 // tick cron's install/teardown behaviour without driving the whole sync pass.
-function pfblockerng_configure_tick_cron(bool $enabled, int $tick_min, string $log): void {
-	$pfb_tick_min = '*/' . $tick_min;
+function pfblockerng_configure_tick_cron(bool $enabled, string $log): void {
+	$pfb_tick_min = '*/15';
 	$pfb_tick_cmd = "/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron-tick >> {$log} 2>&1";
 
 	if ($enabled) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -4808,11 +4808,11 @@ function sync_package_pfblockerng($cron='') {
 	#	Define/Apply CRON Jobs		#
 	#########################################
 
-	// ADR-43: one trigger-tick replaces the cron/dcc/ss_refresh/bl fleet.
-	// A single */pfb_tick_interval cron entry fires; the tick reads the due-ledger
+	// ADR-43: one fixed 15-minute trigger-tick replaces the cron/dcc/ss_refresh/bl fleet.
+	// A single */15 cron entry fires; the tick reads the due-ledger
 	// and dispatches each job only when its entry says "due". clearip/cleardnsbl
 	// are out of scope (ADR-30 territory) and remain as separate jobs below.
-	pfblockerng_configure_tick_cron($pfb['enable'] === PfbToggle::On, pfb_tick_interval_clamp(PfbConfig::read('gen/pfb_tick_interval')), $pfb['log']);
+	pfblockerng_configure_tick_cron($pfb['enable'] === PfbToggle::On, $pfb['log']);
 
 	// Define pfBlockerNG clear [ dnsbl and/or IP ] counter CRON job
 	foreach (array( 'clearip', 'cleardnsbl') as $type) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -989,16 +989,6 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'ADR-40 companion; delta mode is new in 4.0, grandfathered installs run \'replace\' where batch is inert',
 		],
 
-		// ADR-43: tick-cron dispatch interval in minutes (1–60). Default '15'.
-		// One cron tick fires every */pfb_tick_interval; jobs run only when due
-		// per the due-ledger. Default 15 matches the tightest existing job (ss_refresh).
-		'gen/pfb_tick_interval' => [
-			'default'       => '15',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
-			'no_grandfather' => 'ADR-43 trigger-tick engine replaces the cron fleet uniformly for all installs (accepted redesign, no per-install variance)',
-		],
-
 		// ADR-43: optional apply-on-change maintenance window ("HH:MM-HH:MM", local time).
 		// When set: detected changes outside the window are deferred (pending); the first tick
 		// inside the window applies them. Empty string (default) = apply immediately (no deferral).
@@ -3814,21 +3804,6 @@ function pfb_due_ledger_mark_ran_anchored(
 }
 
 /**
- * pfb_tick_interval_clamp — clamp a raw pfb_tick_interval config value to a valid cron minute.
- *
- * Accepts the raw string from PfbConfig::read('gen/pfb_tick_interval') and returns an int
- * suitable for use as the cron minute field (1–60). Non-numeric or out-of-range values
- * are clamped: 0 → 1, >60 → 60, non-int (e.g. 'abc') → 1.
- *
- * @param string $raw   Raw config value (e.g. '15', '0', '100', 'abc').
- * @return int          Clamped interval in [1, 60].
- */
-function pfb_tick_interval_clamp(string $raw): int
-{
-	return max(1, min(60, (int) $raw));
-}
-
-/**
  * pfb_next_tick_boundary — when does the next cron tick fire?
  *
  * The ADR-43 scheduler is one cron tick that fires every $tick_min minutes (the cron minute
@@ -3837,7 +3812,7 @@ function pfb_tick_interval_clamp(string $raw): int
  * the Update page can show "next run at" and "time remaining" for the actual scheduled cron
  * (not the legacy per-feed interval cadence).
  *
- * @param int $tick_min  Clamped tick interval in minutes (see pfb_tick_interval_clamp).
+ * @param int $tick_min  Tick interval in minutes (the scheduler passes fixed 15).
  * @param int $cur_hour  Current hour (0–23).
  * @param int $cur_min   Current minute (0–59).
  * @param int $cur_sec   Current second (0–59).

--- a/src/usr/local/www/pfblockerng/pfblockerng_update.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_update.php
@@ -220,11 +220,11 @@ $tab_array_sub = pfb_edit_hooks_tabs('run');
 display_top_tabs($tab_array_sub, TRUE);
 pfb_print_pending_changes_box(TRUE);
 
-// ADR-43: the scheduler is a single */pfb_tick_interval cron tick that fires every hour ('*'),
+// ADR-43: the scheduler is a single fixed */15 cron tick,
 // installed iff pfBlockerNG is enabled (the feed `interval` only gates the feed job *inside* the
 // tick, not the tick itself). So the "NEXT Scheduled CRON Event" tracks the tick boundary; the
 // per-feed cadence lives in the Schedule view below.
-$pfb_tick_min = pfb_tick_interval_clamp(PfbConfig::read('gen/pfb_tick_interval'));
+$pfb_tick_min = 15;
 
 if ($pfb['enable'] === PfbToggle::On) {
 	list($next_hour, $next_min, $sec_remain) =

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -812,56 +812,33 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// ADR-43 — pfb_tick_interval (plain string; tick-cron dispatch interval)
+	// ADR-43 — pfb_tick_interval retirement
 	// -----------------------------------------------------------------------
 
 	/**
-	 * pfb_tick_interval absent key returns the registered default '15'.
+	 * Retired pfb_tick_interval remains inert: PfbConfig rejects the key while raw XML stays untouched.
 	 *
 	 * Scenario:
-	 *   Background: pfb_tick_interval is a plain-string field; default = '15'.
-	 *     Given no stored value.
-	 *     When PfbConfig::read('gen/pfb_tick_interval').
-	 *     Then '15' is returned (registered default).
+	 *   Given a stale stored value of '30'.
+	 *   When the retired gateway key is read.
+	 *   Then it throws InvalidArgumentException and does not rewrite the raw config value.
 	 */
-	public function testPfbTickIntervalAbsentKeyReturnsDefault(): void
+	public function testRetiredPfbTickIntervalIsUnknownAndRawValueUnchanged(): void
 	{
 		$path = 'installedpackages/pfblockerng/config/0/pfb_tick_interval';
-
-		// Before: absent.
-		$this->assertNull(config_get_path($path), 'before: pfb_tick_interval must be absent');
-
-		// When/Then: absent → default '15'.
-		$result = PfbConfig::read('gen/pfb_tick_interval');
-		$this->assertSame('15', $result, 'pfb_tick_interval absent -> default 15');
-	}
-
-	/**
-	 * pfb_tick_interval round-trips losslessly for a non-default value.
-	 *
-	 * Scenario:
-	 *   Background: pfb_tick_interval is a plain-string field.
-	 *     Given stored = '30'.
-	 *     When PfbConfig::write('gen/pfb_tick_interval', PfbConfig::read('gen/pfb_tick_interval')).
-	 *     Then stored string == '30' (write(read('30')) == '30').
-	 */
-	public function testPfbTickIntervalRoundTrip(): void
-	{
-		$path = 'installedpackages/pfblockerng/config/0/pfb_tick_interval';
-
-		// Given: '30' stored.
 		$this->seedConfig($path, '30');
+		$this->assertSame('30', config_get_path($path), "before: stale pfb_tick_interval seed is '30'");
 
-		// Before: raw value is '30'.
-		$this->assertSame('30', config_get_path($path), "before: pfb_tick_interval seed is '30'");
+		$caught = NULL;
+		try {
+			PfbConfig::read('gen/pfb_tick_interval');
+		} catch (InvalidArgumentException $exception) {
+			$caught = $exception;
+		}
 
-		// When: read -> write.
-		$val = PfbConfig::read('gen/pfb_tick_interval');
-		$this->assertSame('30', $val, "read: pfb_tick_interval '30' -> '30'");
-
-		// After: write back produces '30'.
-		PfbConfig::write('gen/pfb_tick_interval', $val);
-		$this->assertSame('30', config_get_path($path), "write(read('30'))=='30' for pfb_tick_interval");
+		$this->assertInstanceOf(InvalidArgumentException::class, $caught,
+			'retired pfb_tick_interval must be rejected as an unknown gateway key');
+		$this->assertSame('30', config_get_path($path), 'retired key read must leave stale raw value unchanged');
 	}
 
 	// -----------------------------------------------------------------------
@@ -1256,8 +1233,7 @@ final class CfgGatewayTest extends TestCase
 			// ADR-40: alias-table apply mode + batch size
 			'pfb_alias_delta_mode',
 			'pfb_alias_delta_batch',
-			// ADR-43: tick-cron dispatch interval + apply-on-change window
-			'pfb_tick_interval',
+			// ADR-43: apply-on-change window
 			'pfb_quiet_hours',
 			// issue #1109: log-retention trim hysteresis margin percent
 			'pfb_log_trim_margin_pct',
@@ -2846,7 +2822,7 @@ final class CfgGatewayTest extends TestCase
 		$fixture_path = __DIR__ . '/fixtures/cfg_registry_pre1931_parity.json';
 		$fixture      = json_decode((string) file_get_contents($fixture_path), TRUE);
 		$this->assertIsArray($fixture, 'parity fixture must decode to an array');
-		$this->assertCount(103, $fixture, 'parity fixture must carry exactly 103 entries (guards a truncated oracle)');
+		$this->assertCount(102, $fixture, 'parity fixture must carry exactly 102 entries (guards a truncated oracle)');
 
 		$alias_of_section = array_flip(PFB_SECTIONS);
 		$registry         = pfb_cfg_registry();

--- a/tests/php/TickCronInstallTest.php
+++ b/tests/php/TickCronInstallTest.php
@@ -67,25 +67,21 @@ final class TickCronInstallTest extends TestCase
 	{
 		$this->assertSame([], $this->cronCommands());
 
-		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, self::LOG);
 
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 	}
 
 	public function testEnableRemovesStaleCronTickBeforeReinstall(): void
 	{
-		// A pre-existing cron-tick entry at a DIFFERENT interval (interval changed
-		// 30 -> 15 across a settings save) must not linger alongside the fresh one.
-		// The MINUTE field is the discriminator: both entries carry the same command,
-		// so asserting the command alone would pass even if the stale */30 survived.
 		$this->seedCronItem(0, self::CRON_TICK_CMD, '*/30');
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 		$this->assertSame('*/30', config_get_path('cron/item/0/minute'), 'before: the stale interval is in place');
 
-		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, self::LOG);
 
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
-		$this->assertSame('*/15', config_get_path('cron/item/0/minute'), 'after: the entry carries the NEW interval');
+		$this->assertSame('*/15', config_get_path('cron/item/0/minute'), 'after: the entry carries the fixed interval');
 	}
 
 	public function testEnableReplacesACronTickEntryWhoseCommandChanged(): void
@@ -98,7 +94,7 @@ final class TickCronInstallTest extends TestCase
 		$this->seedCronItem(0, $stale, '*/15');
 		$this->assertSame([$stale], $this->cronCommands());
 
-		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, self::LOG);
 
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands(), 'the stale-command entry must not linger beside the fresh one');
 	}
@@ -110,7 +106,7 @@ final class TickCronInstallTest extends TestCase
 		$this->seedCronItem(0, self::LEGACY_TICK_CMD, '*/15');
 		$this->assertSame([self::LEGACY_TICK_CMD], $this->cronCommands());
 
-		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, self::LOG);
 
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 	}
@@ -119,7 +115,7 @@ final class TickCronInstallTest extends TestCase
 	{
 		$this->seedCronItem(0, self::CRON_TICK_CMD, '*/15');
 
-		pfblockerng_configure_tick_cron(FALSE, 15, self::LOG);
+		pfblockerng_configure_tick_cron(FALSE, self::LOG);
 
 		$this->assertSame([], $this->cronCommands());
 	}
@@ -129,7 +125,7 @@ final class TickCronInstallTest extends TestCase
 		// A box that upgraded straight into 'disabled' must still lose its old tick entry.
 		$this->seedCronItem(0, self::LEGACY_TICK_CMD, '*/15');
 
-		pfblockerng_configure_tick_cron(FALSE, 15, self::LOG);
+		pfblockerng_configure_tick_cron(FALSE, self::LOG);
 
 		$this->assertSame([], $this->cronCommands());
 	}
@@ -143,10 +139,10 @@ final class TickCronInstallTest extends TestCase
 		// legacy entry left to absorb it) exposes a too-loose needle.
 		$this->seedCronItem(0, '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php cron >> ' . self::LOG . ' 2>&1', '0');
 
-		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, self::LOG);
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands(), 'first sync: legacy cron removed, cron-tick installed');
 
-		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, self::LOG);
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands(), 'steady-state resync: the cron-tick entry must survive the migration teardown');
 	}
 
@@ -157,7 +153,7 @@ final class TickCronInstallTest extends TestCase
 		$this->seedCronItem(2, '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php bl >> ' . self::LOG . ' 2>&1', '0');
 		$this->assertCount(3, $this->cronCommands());
 
-		pfblockerng_configure_tick_cron(TRUE, 15, self::LOG);
+		pfblockerng_configure_tick_cron(TRUE, self::LOG);
 
 		$this->assertSame([self::CRON_TICK_CMD], $this->cronCommands());
 	}

--- a/tests/php/TickCronTest.php
+++ b/tests/php/TickCronTest.php
@@ -293,44 +293,6 @@ final class TickCronTest extends TestCase
 			'bl jitter must differ from dcc jitter (independent spread)');
 	}
 
-	// -----------------------------------------------------------------------
-	// pfb_tick_interval_clamp — cron minute field safety.
-	// -----------------------------------------------------------------------
-
-	/**
-	 * pfb_tick_interval_clamp maps invalid raw values to a valid [1, 60] minute interval.
-	 *
-	 * The cron minute field must be a positive integer ≤ 60; '0' produces "* /0" which
-	 * is invalid, '100' produces "* /100" which is a silent no-op, 'abc' breaks cron parsing.
-	 *
-	 * Scenario:
-	 *   Given raw values: '0' (zero), '100' (over-max), 'abc' (non-numeric), '15' (valid).
-	 *   When pfb_tick_interval_clamp($raw).
-	 *   Then: '0' → 1, '100' → 60, 'abc' → 1, '15' → 15.
-	 *
-	 * Red→green: before the clamp, '0' produced an invalid "* /0" cron entry.
-	 */
-	public function testTickIntervalClampPinsInvalidValues(): void
-	{
-		// Below minimum: clamp to 1.
-		$this->assertSame(1,  pfb_tick_interval_clamp('0'),
-			"clamp('0'): expected 1 (*/0 is invalid cron); got " . pfb_tick_interval_clamp('0'));
-		// Above maximum: clamp to 60.
-		$this->assertSame(60, pfb_tick_interval_clamp('100'),
-			"clamp('100'): expected 60 (*/100 is a no-op); got " . pfb_tick_interval_clamp('100'));
-		// Non-numeric: (int)'abc' = 0, clamps to 1.
-		$this->assertSame(1,  pfb_tick_interval_clamp('abc'),
-			"clamp('abc'): expected 1 (non-numeric coerces to 0); got " . pfb_tick_interval_clamp('abc'));
-		// Valid value passes through unchanged.
-		$this->assertSame(15, pfb_tick_interval_clamp('15'),
-			"clamp('15'): expected 15 (valid value unchanged); got " . pfb_tick_interval_clamp('15'));
-		// Boundary: 1 and 60 are both valid.
-		$this->assertSame(1,  pfb_tick_interval_clamp('1'),
-			"clamp('1'): expected 1 (minimum valid); got " . pfb_tick_interval_clamp('1'));
-		$this->assertSame(60, pfb_tick_interval_clamp('60'),
-			"clamp('60'): expected 60 (maximum valid); got " . pfb_tick_interval_clamp('60'));
-	}
-
 	/**
 	 * mark_ran writes jitter = 0 for cron (no jitter on feed sync).
 	 *

--- a/tests/php/fixtures/cfg_registry_pre1931_parity.json
+++ b/tests/php/fixtures/cfg_registry_pre1931_parity.json
@@ -234,12 +234,6 @@
         "read_adapter": null,
         "write_adapter": null
     },
-    "pfb_tick_interval": {
-        "section": "installedpackages/pfblockerng/config/0",
-        "default": "15",
-        "read_adapter": null,
-        "write_adapter": null
-    },
     "pfb_quiet_hours": {
         "section": "installedpackages/pfblockerng/config/0",
         "default": "",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10261,19 +10261,6 @@
             }
         ]
     },
-    "pfb_tick_interval_clamp": {
-        "returnsRef": false,
-        "returnType": "int",
-        "params": [
-            {
-                "name": "raw",
-                "byRef": false,
-                "variadic": false,
-                "type": "string",
-                "default": null
-            }
-        ]
-    },
     "pfb_tick_seed": {
         "returnsRef": false,
         "returnType": "string",
@@ -12098,13 +12085,6 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "bool",
-                "default": null
-            },
-            {
-                "name": "tick_min",
-                "byRef": false,
-                "variadic": false,
-                "type": "int",
                 "default": null
             },
             {

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -156,8 +156,7 @@ class RequireConfigGatewaySniff implements Sniff
 		// ADR-40: alias-table apply mode + batch size
 		'installedpackages/pfblockerng/config/0/pfb_alias_delta_mode',
 		'installedpackages/pfblockerng/config/0/pfb_alias_delta_batch',
-		// ADR-43: tick-cron dispatch interval + apply-on-change window
-		'installedpackages/pfblockerng/config/0/pfb_tick_interval',
+		// ADR-43: apply-on-change window
 		'installedpackages/pfblockerng/config/0/pfb_quiet_hours',
 		// issue #1109: log-retention trim hysteresis margin percent
 		'installedpackages/pfblockerng/config/0/pfb_log_trim_margin_pct',

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3378,8 +3378,8 @@ _BASELINE_DEL_SECTIONS = (
 # write-site in this module + the apply/tick tests: the IP master switch (enable_cb), the
 # ADR-38 syslog toggle (log_syslog), the cron knobs (pfb_dailystart/pfb_reuse/pfb_interval), the
 # managed-objects keep flag (pfb_keep), the ADR-11 aggregate selector (pfb_agg_types) and
-# the ADR-43 PfbConfig knobs (pfb_quiet_hours/pfb_tick_interval). Unset (not section-
-# deleted) so the section's install defaults survive.
+# the ADR-43 PfbConfig knob (pfb_quiet_hours). The retired pfb_tick_interval cleanup stays
+# inert for stale config.xml values and is deliberately not read by production.
 _BASELINE_GLOBAL_KEYS = (
     "enable_cb",
     "log_syslog",
@@ -3388,6 +3388,7 @@ _BASELINE_GLOBAL_KEYS = (
     "pfb_reuse",
     "pfb_agg_types",
     "pfb_quiet_hours",
+    # Retired scheduler knob: stale raw XML is cleaned between smoke cases, never read.
     "pfb_tick_interval",
     # Update Frequency: test_log_age_retention writes 'Disabled' to gate the tick's feed-cron
     # dispatch; leaked forward it silently disables dispatch for every later module

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -1921,7 +1921,7 @@ def test_update_page_cron_status_reports_scheduled_tick(
 ) -> None:
     """Cron Status reports the scheduled tick, NOT "[ Missing cron task ]".
 
-    ADR-43 installs ONE ``*/pfb_tick_interval`` cron tick whenever pfBlockerNG is
+    ADR-43 installs ONE fixed ``*/15`` cron tick whenever pfBlockerNG is
     enabled. The Update page previously probed the crontab with the legacy
     interval/min/24hour signature, which never matches that tick, so it falsely
     rendered "[ Missing cron task ]" and a time derived from the feed cadence. This
@@ -1971,7 +1971,7 @@ def test_update_page_cron_status_reports_scheduled_tick(
         assert not looks_like_login_page(body), "Update page GET returned the login form (session lost)"
         assert "Missing cron task" not in body, (
             "Cron Status still shows '[ Missing cron task ]' although the cron-tick cron IS "
-            "installed — the page must probe the */N cron-tick signature, not the legacy "
+            "installed — the page must probe the */15 cron-tick signature, not the legacy "
             "interval/min/24hour cron"
         )
         assert "NEXT Scheduled CRON Event will run at" in body, "Cron Status header missing from the Update page"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -753,13 +753,15 @@ def test_update_page_cron_status_without_flag_never_misreports_missing_cron(
     manual config cleanup is needed; the harness flag (outside config.xml) still needs its
     own restore.
 
-    Given the master switch ON, a fresh sync pass (installs the current cron-tick entry),
+    Given the master switch ON, stale pfb_tick_interval=30, and a fresh sync pass,
         and the harness flag removed,
     When GET pfblockerng_update.php,
     Then the cron-status line shows neither the harness banner nor '[ Missing cron task ]'.
     """
     flag = helpers.PFB_CRON_DISABLE_PATH
     helpers.set_package_enabled(smoke_vm, True)
+    helpers.config_set(smoke_vm, _CFG_TICK_INTERVAL, "30")
+    assert helpers.config_get(smoke_vm, _CFG_TICK_INTERVAL) == "30", "stale tick interval seed must remain raw 30"
     helpers.reload(smoke_vm, "update")
     rm = smoke_vm.ssh("rm", "-f", flag)
     assert rm.returncode == 0, f"failed to remove {flag}: rc={rm.returncode} {rm.stderr!r}"
@@ -769,6 +771,14 @@ def test_update_page_cron_status_without_flag_never_misreports_missing_cron(
         assert result.ok, f"Update page render oracle failed: {result.detail}"
         assert f"[ Disabled by {flag} ]" not in resp.text, (
             "Update page still shows the harness disable banner after the flag was removed"
+        )
+        cron_lines = [
+            line.split()
+            for line in smoke_vm.ssh("/usr/bin/grep", "pfblockerng.php cron-tick", "/etc/crontab").stdout.splitlines()
+            if "cron-tick" in line
+        ]
+        assert len(cron_lines) == 1 and cron_lines[0][0] == "*/15", (
+            f"stale pfb_tick_interval=30 must still install exactly one fixed */15 cron-tick entry; got {cron_lines!r}"
         )
         assert "[ Missing cron task ]" not in resp.text, (
             "Update page misreports '[ Missing cron task ]' on a healthy, enabled, synced box -- "
@@ -1252,6 +1262,7 @@ def test_update_page_schedule_shows_seconds_precision(
 
 
 _CFG_PFB_ENABLE = "installedpackages/pfblockerng/config/0/enable_cb"
+_CFG_TICK_INTERVAL = "installedpackages/pfblockerng/config/0/pfb_tick_interval"
 _DNSBL_STAT_DB = "/var/unbound/pfb_py_dnsbl.sqlite"
 _WIDGET_PAGE = "/widgets/widgets/pfblockerng.widget.php"
 


### PR DESCRIPTION
## Summary

- Remove the user-accessible `gen/pfb_tick_interval` config/CLI knob and its clamp helper.
- Install and verify one fixed `*/15` scheduler tick while leaving stale raw XML inert.
- Keep the Update page, config registry, active documentation, and historical ADR amendments aligned with the fixed cadence.

All other original #2090 scheduler work is not planned. This PR does not add one-minute ticks, calendar anchors, or alternate cadence mechanics.

## Verification

- Frozen behavior-test blobs:
  - `TickCronInstallTest.php`: `a54ebf26f561b6a69c4b828016d195871ba7cc4d`
  - `TickCronTest.php`: `a43a49e7290db6de94327ee0abd9b367f679906d`
  - `CfgGatewayTest.php`: `48a8b91c10e55f2f29def1295425c5ba0fac61e3`
  - `test_render_smoke.py`: `f3f473e00988727301a29fbac8686b03b200e249`
  - `helpers.py`: `b026ab8f3c9071493fceac75a21534e1081ff055`
- Exact-base RED command (three PHP behavior files): 165 tests / 1,973 assertions, with 8 expected old-signature `TypeError`s and 1 expected retired-key failure.
- Exact-head GREEN for the same three files: 165 tests / 1,978 assertions.
- Exact-head GREEN including function-inventory parity: 166 tests / 1,984 assertions.
- Canonical exact-head gates: PASS, including 5,022 PHPUnit tests, PHPStan, PHPCS, Python, and Markdown checks.
- Live Plus 26.03 RED: [run 31457709625](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/31457709625) installed `*/30` from stale config instead of `*/15`.
- Live Plus 26.03 exact-head functional GREEN: [run 31461757983](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/31461757983).
- Live Plus 26.03 exact-head Tier-A render GREEN: [run 31461758002](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/31461758002).
- Three independent review lenses: PASS. CodeRabbit's sole minor comment was fixed, reverified, replied to, and resolved.

Fixes #2090

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
