### PR TITLE
ci: validate live pfSense update branches

### DIFF
--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -295,6 +295,16 @@ ssh_guest() {
 # a new release branch such as 2_9_0 while the image still runs 2.8.1.
 pfb_switch_branch() {
     _psb_branch="$1"; _psb_log_dir="$2"
+    case "$_psb_branch" in
+        *\'*) die "--branch name must not contain a single quote: $_psb_branch" ;;
+    esac
+    if [ -z "$_psb_branch" ] || \
+       [ "$(printf '%s/' "$_psb_branch" | LC_ALL=C tr -d '0-9A-Za-z._-')" != '/' ]; then
+        die "invalid update branch name: $_psb_branch"
+    fi
+    case "$_psb_branch" in
+        [._-]*) die "invalid update branch name: $_psb_branch" ;;
+    esac
     log "switching pfSense update branch to '${_psb_branch}' (via pkg_switch_repo)"
 
     if ! _psb_catalog=$(ssh_guest '/usr/local/sbin/pfSense-repoc -p' 2>&1); then
@@ -652,13 +662,6 @@ fi
 # branch's versions. Fail-closed: a wrong/missing branch name aborts the run
 # rather than silently upgrading on the wrong (stable) branch.
 if [ -n "$BRANCH" ]; then
-    # Guard against a branch name containing a single quote (it would break the
-    # PHP string literal below). Branch names from ci-metadata are safe, but
-    # reject anything surprising rather than silently truncating or injecting.
-    case "$BRANCH" in
-        *\'*) die "--branch name must not contain a single quote: $BRANCH" ;;
-    esac
-
     pfb_switch_branch "$BRANCH" "$LOCAL_DIR"
 fi
 

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -109,7 +109,7 @@
 #                    subsequent pfSense-upgrade -c check sees the new branch's
 #                    versions. Use this to upgrade TO a pre-release or development
 #                    build. Branch names are dynamic — use the exact name reported by
-#                    pkg_list_repos() on that pfSense version. The script validates
+#                    pfSense-repoc -p on that pfSense version. The script validates
 #                    NAME against the list of available repos on the booted image and
 #                    fails if it is not found. Default empty = leave the image's
 #                    configured branch unchanged. Example (Plus pre-release):
@@ -287,6 +287,45 @@ ssh_guest() {
             root@127.0.0.1 "$@"
     fi
 }
+
+# pfb_switch_branch BEGIN
+# pfb_switch_branch NAME LOG_DIR — validate NAME against Netgate's live branch
+# catalogue, then persist and apply it through pfSense's supported config path.
+# pkg_list_repos() only reports installed repo configurations; it does not list
+# a new release branch such as 2_9_0 while the image still runs 2.8.1.
+pfb_switch_branch() {
+    _psb_branch="$1"; _psb_log_dir="$2"
+    log "switching pfSense update branch to '${_psb_branch}' (via pkg_switch_repo)"
+
+    if ! _psb_catalog=$(ssh_guest '/usr/local/sbin/pfSense-repoc -p' 2>&1); then
+        printf '%s\n' "$_psb_catalog" > "${_psb_log_dir}/branch-catalog.log"
+        die "could not list available pfSense update branches (see ${_psb_log_dir}/branch-catalog.log)"
+    fi
+    printf '%s\n' "$_psb_catalog" > "${_psb_log_dir}/branch-catalog.log"
+    _psb_names=$(printf '%s\n' "$_psb_catalog" | awk 'NF { print $1 }')
+    if ! printf '%s\n' "$_psb_names" | grep -Fqx "$_psb_branch"; then
+        _psb_available=$(printf '%s\n' "$_psb_names" | awk 'BEGIN { sep = "" } { printf "%s%s", sep, $0; sep = " " } END { print "" }')
+        die "branch '${_psb_branch}' not found on this image. Available repos: ${_psb_available:-<none listed; see ${_psb_log_dir}/branch-catalog.log>}"
+    fi
+
+    _psb_php=$(printf '%s\n' \
+        "require_once('pkg-utils.inc');" \
+        "config_set_path('system/pkg_repo_conf_path', '${_psb_branch}');" \
+        "write_config('image-upgrade: switch update branch to ${_psb_branch}');" \
+        "pkg_switch_repo();" \
+        "echo 'PFB_BRANCH_OK' . PHP_EOL;" \
+        "exec" \
+        "exit")
+    _psb_out=$(printf '%s\n' "$_psb_php" | ssh_guest 'pfSsh.php' 2>&1 || true)
+    printf '%s\n' "$_psb_out" > "${_psb_log_dir}/branch-switch.log"
+    if ! printf '%s' "$_psb_out" | grep -q 'PFB_BRANCH_OK'; then
+        die "branch switch to '${_psb_branch}' did not confirm success (PFB_BRANCH_OK not in output; see ${_psb_log_dir}/branch-switch.log)"
+    fi
+
+    log "branch switch confirmed — refreshing pkg catalogue (pkg update -f)"
+    ssh_guest 'pkg update -f' 2>&1 | tee "${_psb_log_dir}/pkg-update-branch.log" || true
+}
+# pfb_switch_branch END
 
 # pfb_upgrade_run BEGIN
 # pfb_upgrade_run CMD LABEL [LOG] — run a pfSense-upgrade invocation on the
@@ -620,39 +659,7 @@ if [ -n "$BRANCH" ]; then
         *\'*) die "--branch name must not contain a single quote: $BRANCH" ;;
     esac
 
-    log "switching pfSense update branch to '$BRANCH' (via pkg_switch_repo)"
-
-    # Build the pfSsh.php snippet. pfSsh.php reads PHP statements on stdin,
-    # then the literal line "exec", then "exit". It runs the snippet inside the
-    # pfSense PHP environment with all pfSense functions available.
-    _php=$(printf '%s\n' \
-        "require_once('pkg-utils.inc');" \
-        "\$repos = pkg_list_repos();" \
-        "\$names = array_column(\$repos, 'name');" \
-        "\$avail = implode(' ', \$names);" \
-        "if (!in_array('$BRANCH', \$names, true)) {" \
-        "    echo 'PFB_BRANCH_NOT_FOUND available=' . \$avail . PHP_EOL;" \
-        "} else {" \
-        "    config_set_path('system/pkg_repo_conf_path', '$BRANCH');" \
-        "    write_config('image-upgrade: switch update branch to $BRANCH');" \
-        "    pkg_switch_repo();" \
-        "    echo 'PFB_BRANCH_OK' . PHP_EOL;" \
-        "}" \
-        "exec" \
-        "exit")
-
-    _branch_out=$(printf '%s\n' "$_php" | ssh_guest 'pfSsh.php' 2>&1 | tee "$LOCAL_DIR/branch-switch.log" || true)
-
-    if printf '%s' "$_branch_out" | grep -q 'PFB_BRANCH_NOT_FOUND'; then
-        _avail=$(printf '%s' "$_branch_out" | grep 'PFB_BRANCH_NOT_FOUND' | sed 's/.*available=//')
-        die "branch '$BRANCH' not found on this image. Available repos: ${_avail:-<none listed; see $LOCAL_DIR/branch-switch.log>}"
-    fi
-    if ! printf '%s' "$_branch_out" | grep -q 'PFB_BRANCH_OK'; then
-        die "branch switch to '$BRANCH' did not confirm success (PFB_BRANCH_OK not in output; see $LOCAL_DIR/branch-switch.log)"
-    fi
-
-    log "branch switch confirmed — refreshing pkg catalogue (pkg update -f)"
-    ssh_guest 'pkg update -f' 2>&1 | tee "$LOCAL_DIR/pkg-update-branch.log" || true
+    pfb_switch_branch "$BRANCH" "$LOCAL_DIR"
 fi
 
 # --- check whether an OS upgrade is available ------------------------------

--- a/tests/shell/image_upgrade_branch_spec.sh
+++ b/tests/shell/image_upgrade_branch_spec.sh
@@ -51,6 +51,10 @@ Describe 'image-upgrade.sh update-branch selection'
     ' _ "$SCRIPT" "$WORK"
   }
 
+  run_newline_branch() {
+    run_branch_block available "$(printf 'bad\n2_9_0')"
+  }
+
   It 'accepts a live branch absent from pkg_list_repos'
     When call run_branch_block available 2_9_0
     The status should be success
@@ -82,5 +86,13 @@ Describe 'image-upgrade.sh update-branch selection'
     The status should be failure
     The stderr should include 'must not contain a single quote'
     The contents of file "$CALLS" should not include 'pfSense-repoc'
+  End
+
+  It 'rejects a newline before querying the catalogue'
+    When call run_newline_branch
+    The status should be failure
+    The stderr should include 'invalid update branch name'
+    The contents of file "$CALLS" should not include 'pfSense-repoc'
+    The contents of file "$CALLS" should not include 'pfSsh.php'
   End
 End

--- a/tests/shell/image_upgrade_branch_spec.sh
+++ b/tests/shell/image_upgrade_branch_spec.sh
@@ -1,0 +1,86 @@
+#shellcheck shell=sh
+# image_upgrade_branch_spec.sh — branch discovery must use pfSense-repoc's
+# available-branch catalogue, not pkg_list_repos()'s installed-repo view.
+
+Describe 'image-upgrade.sh update-branch selection'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgbranch.XXXXXX")"
+    CALLS="${WORK}/calls"
+    PAYLOAD="${WORK}/payload"
+    export WORK CALLS PAYLOAD
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  run_branch_block() {
+    _mode="$1" _requested="$2" sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      warn() { printf "WARNING: %s\n" "$*" >&2; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      ssh_guest() {
+        printf "%s\n" "$1" >> "$CALLS"
+        case "$1" in
+          "/usr/local/sbin/pfSense-repoc -p")
+            [ "$_mode" = catalogue-error ] && return 7
+            printf "2_9_0\t\tBeta Version (2.9.0)\n"
+            printf "2_8_1 (release) (default)\t\tCurrent Stable Version (2.8.1)\n"
+            ;;
+          pfSsh.php)
+            cat > "$PAYLOAD"
+            if grep -q pkg_list_repos "$PAYLOAD"; then
+              printf "PFB_BRANCH_NOT_FOUND available=2_8_1\n"
+            else
+              printf "PFB_BRANCH_OK\n"
+            fi
+            ;;
+          "pkg update -f") printf "catalogue refreshed\n" ;;
+        esac
+      }
+      # New code exposes its helper between these markers. On the old code the
+      # extraction is empty and the unchanged main-flow block still executes,
+      # giving a genuine RED against its pkg_list_repos() behavior.
+      eval "$(sed -n "/^# pfb_switch_branch BEGIN/,/^# pfb_switch_branch END/p" "$1")"
+      BRANCH="$_requested"
+      LOCAL_DIR="$2"
+      eval "$(sed -n "/^# --- optional: switch the pfSense update branch/,/^# --- check whether an OS upgrade is available/p" "$1")"
+      printf "REACHED-AFTER-BRANCH\n"
+    ' _ "$SCRIPT" "$WORK"
+  }
+
+  It 'accepts a live branch absent from pkg_list_repos'
+    When call run_branch_block available 2_9_0
+    The status should be success
+    The output should include 'REACHED-AFTER-BRANCH'
+    The contents of file "$CALLS" should include '/usr/local/sbin/pfSense-repoc -p'
+    The contents of file "$PAYLOAD" should include "config_set_path('system/pkg_repo_conf_path', '2_9_0')"
+    The contents of file "$PAYLOAD" should include 'pkg_switch_repo()'
+  End
+
+  It 'rejects an unknown branch before changing pfSense configuration'
+    When call run_branch_block available 2_10_0
+    The status should be failure
+    The stderr should include "branch '2_10_0' not found"
+    The stderr should include '2_9_0 2_8_1'
+    The contents of file "$CALLS" should not include 'pfSsh.php'
+    The output should not include 'REACHED-AFTER-BRANCH'
+  End
+
+  It 'fails closed when the authoritative catalogue cannot be read'
+    When call run_branch_block catalogue-error 2_9_0
+    The status should be failure
+    The stderr should include 'could not list available pfSense update branches'
+    The contents of file "$CALLS" should not include 'pfSsh.php'
+    The output should not include 'REACHED-AFTER-BRANCH'
+  End
+
+  It 'rejects a quote before querying the catalogue'
+    When call run_branch_block available "2_9_0'"
+    The status should be failure
+    The stderr should include 'must not contain a single quote'
+    The contents of file "$CALLS" should not include 'pfSense-repoc'
+  End
+End


### PR DESCRIPTION
Closes #2302.

## What changed

- validate requested pfSense update branches against the authoritative `pfSense-repoc -p` catalogue
- retain the existing supported `config_set_path()` + `pkg_switch_repo()` application path
- fail closed before configuration mutation when catalogue lookup fails or the branch is absent
- persist catalogue and switch diagnostics separately

## Verification

- Frozen test blob: `1ec5328f511840046502e9ace55abc2fbe193d17`
- RED against original production: 5 examples, 4 failures; live `2_9_0` was rejected because only `pkg_list_repos()` output `2_8_1`, while a newline-injected value was accepted
- GREEN unchanged: 5 examples, 0 failures
- Related image-upgrade ShellSpec: 24 examples, 0 failures
- Pre-commit ShellSpec: 45 examples, 0 failures
- `sh -n`, ShellCheck, `git diff --check`: pass
- `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS`
- Disposable pfb-box boot on `root@10.0.0.31`: `pfSense-repoc -p` listed `2_9_0`; shipped helper accepted it and persisted `system/pkg_repo_conf_path=2_9_0`

The pre-existing masking of a failed post-switch `pkg update -f` is outside this branch-discovery fix and is tracked in #2304.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
