### PR TITLE
smoke: wait for boot metadata settlement

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4009,12 +4009,13 @@ def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.
     the timeout RAISES loudly rather than returning, so a never-completing boot fails the
     run instead of silently racing. The boot flag can clear while
     ``rc.update_pkg_metadata`` still runs ``pfSense-upgrade`` and temporarily rewrites
-    pkg's effective ABI, so that boot job must also be gone before deployment.
+    pkg's effective ABI. That job atomically publishes ``pfSense_version.rc`` only after
+    both update phases finish, so the per-boot file is the stable completion signal.
     """
     deadline = time.monotonic() + timeout
     snippet = "echo '<<BOOT>>' . (is_platform_booting() ? '1' : '0') . '<<END>>';"
     last = "?"
-    last_pkg_processes = "not checked"
+    last_metadata = "not checked"
     while time.monotonic() < deadline:
         # Under boot load pfSsh.php (full config load+lock) can be slow; let one over-30s probe
         # retry on the remaining budget instead of aborting the whole wait. The deadline still
@@ -4028,30 +4029,17 @@ def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.
             last = out.split("<<BOOT>>", 1)[1].split("<<END>>", 1)[0].strip()
             if last == "0":
                 try:
-                    processes = vm.ssh("/bin/ps", "axww", "-o", "pid=", "-o", "comm=", "-o", "args=", timeout=30.0)
+                    metadata = vm.ssh("/bin/test", "-f", "/var/run/pfSense_version.rc", timeout=30.0)
                 except subprocess.TimeoutExpired:
-                    last_pkg_processes = "timeout"
+                    last_metadata = "timeout"
                     continue
-                if processes.returncode != 0:
-                    last_pkg_processes = (
-                        f"probe rc={processes.returncode} stdout={processes.stdout!r} stderr={processes.stderr!r}"
-                    )
-                else:
-                    active = []
-                    for line in processes.stdout.splitlines():
-                        fields = line.split(None, 2)
-                        if len(fields) != 3:
-                            continue
-                        _pid, command, arguments = fields
-                        if command == "sh" and arguments.startswith("/bin/sh /etc/rc.update_pkg_metadata"):
-                            active.append(line)
-                    last_pkg_processes = "\n".join(active) or "none"
-                    if not active:
-                        return
+                last_metadata = f"rc={metadata.returncode} stdout={metadata.stdout!r} stderr={metadata.stderr!r}"
+                if metadata.returncode == 0:
+                    return
         time.sleep(delay)
     raise RuntimeError(
         f"pfSense boot did not settle after {timeout:.0f}s: is_platform_booting() last returned "
-        f"{last!r} (expected '0'); boot package processes last observed: {last_pkg_processes!r}. "
+        f"{last!r} (expected '0'); /var/run/pfSense_version.rc last probe: {last_metadata}. "
         f"pfBlockerNG updates would race boot-time state."
     )
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3994,7 +3994,7 @@ def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 60, delay: float = 2.0) -
 
 
 def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.0) -> None:
-    """Block until pfSense has FINISHED booting (``is_platform_booting()`` false).
+    """Block until pfSense has finished booting and package metadata has settled.
 
     pfSense's rc removes ``/var/run/booting`` only at the very END of bootup -- AFTER
     the web port (which ``wait_ready.sh`` keys on) already answers. So a fast box can
@@ -4007,11 +4007,14 @@ def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.
 
     This is a last-resort poll of production-side state we cannot signal (issue #456);
     the timeout RAISES loudly rather than returning, so a never-completing boot fails the
-    run instead of silently racing.
+    run instead of silently racing. The boot flag can clear while
+    ``rc.update_pkg_metadata`` still runs ``pfSense-upgrade`` and temporarily rewrites
+    pkg's effective ABI, so that boot job must also be gone before deployment.
     """
     deadline = time.monotonic() + timeout
     snippet = "echo '<<BOOT>>' . (is_platform_booting() ? '1' : '0') . '<<END>>';"
     last = "?"
+    last_pkg_processes = "not checked"
     while time.monotonic() < deadline:
         # Under boot load pfSsh.php (full config load+lock) can be slow; let one over-30s probe
         # retry on the remaining budget instead of aborting the whole wait. The deadline still
@@ -4024,12 +4027,32 @@ def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.
         if "<<BOOT>>" in out and "<<END>>" in out:
             last = out.split("<<BOOT>>", 1)[1].split("<<END>>", 1)[0].strip()
             if last == "0":
-                return
+                try:
+                    processes = vm.ssh("/bin/ps", "axww", "-o", "pid=", "-o", "comm=", "-o", "args=", timeout=30.0)
+                except subprocess.TimeoutExpired:
+                    last_pkg_processes = "timeout"
+                    continue
+                if processes.returncode != 0:
+                    last_pkg_processes = (
+                        f"probe rc={processes.returncode} stdout={processes.stdout!r} stderr={processes.stderr!r}"
+                    )
+                else:
+                    active = []
+                    for line in processes.stdout.splitlines():
+                        fields = line.split(None, 2)
+                        if len(fields) != 3:
+                            continue
+                        _pid, command, arguments = fields
+                        if command == "sh" and arguments.startswith("/bin/sh /etc/rc.update_pkg_metadata"):
+                            active.append(line)
+                    last_pkg_processes = "\n".join(active) or "none"
+                    if not active:
+                        return
         time.sleep(delay)
     raise RuntimeError(
-        f"pfSense still booting after {timeout:.0f}s: is_platform_booting() last returned "
-        f"{last!r} (expected '0'). /var/run/booting never cleared -- pfBlockerNG updates "
-        f"would abort as boot-time syncs."
+        f"pfSense boot did not settle after {timeout:.0f}s: is_platform_booting() last returned "
+        f"{last!r} (expected '0'); boot package processes last observed: {last_pkg_processes!r}. "
+        f"pfBlockerNG updates would race boot-time state."
     )
 
 

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -1,0 +1,39 @@
+"""Issue #2242: boot readiness includes pfSense package metadata settlement."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import cast
+
+import pytest
+
+from tests.smoke import helpers
+
+
+def test_wait_boot_complete_waits_for_boot_pkg_processes(monkeypatch: pytest.MonkeyPatch) -> None:
+    process_outputs = iter(
+        [
+            "123 sh /bin/sh /etc/rc.update_pkg_metadata now\n456 sh /bin/sh /usr/local/libexec/pfSense-upgrade -uf\n",
+            "",
+        ]
+    )
+    calls: list[tuple[str, ...]] = []
+
+    class FakeVM:
+        def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            calls.append(remote)
+            return subprocess.CompletedProcess(remote, 0, next(process_outputs), "")
+
+    monkeypatch.setattr(
+        helpers,
+        "php_eval",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
+    )
+    monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
+
+    helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), delay=0)
+
+    assert calls == [
+        ("/bin/ps", "axww", "-o", "pid=", "-o", "comm=", "-o", "args="),
+        ("/bin/ps", "axww", "-o", "pid=", "-o", "comm=", "-o", "args="),
+    ]

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -10,19 +10,17 @@ import pytest
 from tests.smoke import helpers
 
 
-def test_wait_boot_complete_waits_for_boot_pkg_processes(monkeypatch: pytest.MonkeyPatch) -> None:
-    process_outputs = iter(
-        [
-            "123 sh /bin/sh /etc/rc.update_pkg_metadata now\n456 sh /bin/sh /usr/local/libexec/pfSense-upgrade -uf\n",
-            "",
-        ]
-    )
+def test_wait_boot_complete_waits_for_boot_metadata_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    sentinel_statuses = iter([1, 0])
+    monotonic_values = iter([0.0, 0.0, 1.0, 2.0, 3.0])
     calls: list[tuple[str, ...]] = []
 
     class FakeVM:
         def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
             calls.append(remote)
-            return subprocess.CompletedProcess(remote, 0, next(process_outputs), "")
+            if remote == ("/bin/test", "-f", "/var/run/pfSense_version.rc"):
+                return subprocess.CompletedProcess(remote, next(sentinel_statuses), "", "")
+            return subprocess.CompletedProcess(remote, 0, "", "")
 
     monkeypatch.setattr(
         helpers,
@@ -30,10 +28,11 @@ def test_wait_boot_complete_waits_for_boot_pkg_processes(monkeypatch: pytest.Mon
         lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
     )
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: next(monotonic_values))
 
-    helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), delay=0)
+    helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=3, delay=0)
 
     assert calls == [
-        ("/bin/ps", "axww", "-o", "pid=", "-o", "comm=", "-o", "args="),
-        ("/bin/ps", "axww", "-o", "pid=", "-o", "comm=", "-o", "args="),
+        ("/bin/test", "-f", "/var/run/pfSense_version.rc"),
+        ("/bin/test", "-f", "/var/run/pfSense_version.rc"),
     ]


### PR DESCRIPTION
## Summary

- keep the shared smoke boot gate closed until pfSense publishes its per-boot metadata completion sentinel
- use `/var/run/pfSense_version.rc`, written atomically only after both upgrade phases finish
- report the last sentinel probe on bounded timeout

Closes #2242.

## Root cause

Fresh pfb-box sampling of the immutable CE 2.8 image proved the effective pkg ABI is transient:

1. booted CE 2.8.1 / kernel 1500029 / `FreeBSD:15:amd64`
2. changed to `FreeBSD:16:amd64` while `/etc/rc.update_pkg_metadata now` ran `pfSense-upgrade -uf`
3. returned to `FreeBSD:15:amd64` five seconds later during `pfSense-upgrade -C`
4. remained ABI 15 after the parent boot job exited

The existing `is_platform_booting()` gate cleared before that asynchronous job completed, allowing deployment inside the transient ABI-16 window. Process inference was rejected during review because the wrapper backgrounds its children; pfSense's atomic per-boot result file is the stable signal.

## Verification

- Frozen regression blob: `a5c00fcd5d5f39d5bfe422ea644f4cb107815627`
- RED on the prior PR head: 1 failed; helper called the non-portable path and did not poll the sentinel
- GREEN unchanged: 1 passed; helper observed sentinel absent, then present, using `/bin/test`
- Focused boot/reboot/identity suite: 9 passed
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS
- Live pfb-box CE 2.8 run at exact head `3de12129e3187be07d0f1e936803fc8cc1ba8297`: 12 passed, 959 deselected
  - immutable image digest `sha256:f4ee5814c6ca38fcb4323d81aaa19533cc622af26aeab38933ac84b9cdb57db1`
  - `PFB_TIMING boot_and_probe 119.58s`
  - `PFB_GUEST_IDENTITY abi=FreeBSD:15:amd64`
  - dependency and pfBlockerNG installs both saw `FreeBSD:15:amd64`
  - both installs logged `boot_pkg_processes=none`

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
