### PR TITLE
pfblockerng: add feed schedule primitives

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3550,7 +3550,7 @@ function pfb_schedule_next_occurrence(
 	}
 
 	$interval = max(1, $valid_cadences[$cadence]);
-	$limit = $reference + (8 * 86400);
+	$limit = $reference + (15 * 86400);
 	$candidate = $reference + 1;
 	while ($candidate <= $limit) {
 		$local = (new DateTimeImmutable('@' . $candidate))->setTimezone($timezone);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3507,6 +3507,155 @@ function pfb_flock_bounded($fp, int $operation, float $timeout_s, ?bool &$timed_
 // ---------------------------------------------------------------------------
 
 /**
+ * Return the first local quarter-hour occurrence strictly after a reference.
+ *
+ * The scan walks real instants, rather than constructing local timestamps, so
+ * nonexistent spring-forward slots are skipped and repeated fall-back slots
+ * remain observable.
+ */
+function pfb_schedule_next_occurrence(
+	string $cadence,
+	int    $weekday,
+	int    $hour,
+	int    $minute,
+	int    $reference
+): ?int {
+	$valid_cadences = [
+		'Never'    => 0,
+		'01hour'   => 1,
+		'02hours'  => 2,
+		'03hours'  => 3,
+		'04hours'  => 4,
+		'06hours'  => 6,
+		'08hours'  => 8,
+		'12hours'  => 12,
+		'EveryDay' => 0,
+		'Weekly'   => 0,
+	];
+	if (!array_key_exists($cadence, $valid_cadences)) {
+		throw new InvalidArgumentException('unsupported schedule cadence');
+	}
+	if ($weekday < 1 || $weekday > 7) {
+		throw new InvalidArgumentException('schedule weekday must be 1..7');
+	}
+	if ($hour < 0 || $hour > 23) {
+		throw new InvalidArgumentException('schedule hour must be 0..23');
+	}
+	if (!in_array($minute, [0, 15, 30, 45], TRUE)) {
+		throw new InvalidArgumentException('schedule minute must be 0, 15, 30, or 45');
+	}
+	if ($cadence === 'Never') {
+		return NULL;
+	}
+
+	$interval = max(1, $valid_cadences[$cadence]);
+	$limit = $reference + (8 * 86400);
+	$candidate = $reference + 1;
+	while ($candidate <= $limit) {
+		$parts = explode('/', date('N/G/i/s', $candidate));
+		if ($parts[3] === '00' && ((int) $parts[2] % 15) === 0) {
+			break;
+		}
+		$candidate++;
+	}
+	while ($candidate <= $limit) {
+		$parts = explode('/', date('N/G/i/s', $candidate));
+		$local_weekday = (int) $parts[0];
+		$local_hour = (int) $parts[1];
+		$local_minute = (int) $parts[2];
+		$matches = match ($cadence) {
+			'01hour' => $local_minute === $minute,
+			'02hours', '03hours', '04hours', '06hours', '08hours', '12hours'
+				=> $local_minute === $minute && (($local_hour - $hour) % $interval) === 0,
+			'EveryDay' => $local_hour === $hour && $local_minute === $minute,
+			'Weekly' => $local_weekday === $weekday && $local_hour === $hour && $local_minute === $minute,
+			default => FALSE,
+		};
+		if ($matches) {
+			return $candidate;
+		}
+		$candidate += 900;
+	}
+	return NULL;
+}
+
+/**
+ * Select due feeds and the earliest future wake from normalized schedules.
+ *
+ * This is pure: callers provide all group state and both clock readings.
+ */
+function pfb_schedule_plan(array $groups, array $default_schedule, ?int $since, int $now): array
+{
+	$validate_schedule = static function (mixed $schedule): void {
+		if (!is_array($schedule)
+			|| !array_key_exists('weekday', $schedule)
+			|| !array_key_exists('hour', $schedule)
+			|| !array_key_exists('minute', $schedule)
+			|| !is_int($schedule['weekday'])
+			|| !is_int($schedule['hour'])
+			|| !is_int($schedule['minute'])
+			|| $schedule['weekday'] < 1
+			|| $schedule['weekday'] > 7
+			|| $schedule['hour'] < 0
+			|| $schedule['hour'] > 23
+			|| !in_array($schedule['minute'], [0, 15, 30, 45], TRUE)) {
+			throw new InvalidArgumentException('malformed normalized schedule');
+		}
+	};
+	$validate_schedule($default_schedule);
+
+	$due = [];
+	$next_due = NULL;
+	foreach ($groups as $key => $group) {
+		if (!is_string($key) || $key === ''
+			|| !is_array($group)
+			|| !array_key_exists('cadence', $group)
+			|| !array_key_exists('enabled', $group)
+			|| !array_key_exists('has_active_rows', $group)
+			|| !array_key_exists('override', $group)
+			|| !is_string($group['cadence'])
+			|| !is_bool($group['enabled'])
+			|| !is_bool($group['has_active_rows'])) {
+			throw new InvalidArgumentException('malformed normalized feed group');
+		}
+		if ($group['override'] !== NULL) {
+			$validate_schedule($group['override']);
+		}
+		$effective = $group['override'] ?? $default_schedule;
+		$occurrence = pfb_schedule_next_occurrence(
+			$group['cadence'],
+			$effective['weekday'],
+			$effective['hour'],
+			$effective['minute'],
+			$now
+		);
+		$eligible = $group['enabled'] && $group['has_active_rows'] && $group['cadence'] !== 'Never';
+		if (!$eligible) {
+			continue;
+		}
+		if ($since === NULL) {
+			$due[] = $key;
+		} else {
+			$past = pfb_schedule_next_occurrence(
+				$group['cadence'],
+				$effective['weekday'],
+				$effective['hour'],
+				$effective['minute'],
+				$since
+			);
+			if ($past !== NULL && $past <= $now) {
+				$due[] = $key;
+			}
+		}
+		if ($occurrence !== NULL && ($next_due === NULL || $occurrence < $next_due)) {
+			$next_due = $occurrence;
+		}
+	}
+
+	return ['due' => $due, 'next_due' => $next_due];
+}
+
+/**
  * pfb_due_ledger_seeded_jitter — deterministic jitter offset for a job/seed pair.
  *
  * Returns a stable offset in [1, $max] for $max > 0, or 0 for $max === 0.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -3518,7 +3518,8 @@ function pfb_schedule_next_occurrence(
 	int    $weekday,
 	int    $hour,
 	int    $minute,
-	int    $reference
+	int    $reference,
+	DateTimeZone $timezone
 ): ?int {
 	$valid_cadences = [
 		'Never'    => 0,
@@ -3552,14 +3553,16 @@ function pfb_schedule_next_occurrence(
 	$limit = $reference + (8 * 86400);
 	$candidate = $reference + 1;
 	while ($candidate <= $limit) {
-		$parts = explode('/', date('N/G/i/s', $candidate));
+		$local = (new DateTimeImmutable('@' . $candidate))->setTimezone($timezone);
+		$parts = explode('/', $local->format('N/G/i/s'));
 		if ($parts[3] === '00' && ((int) $parts[2] % 15) === 0) {
 			break;
 		}
 		$candidate++;
 	}
 	while ($candidate <= $limit) {
-		$parts = explode('/', date('N/G/i/s', $candidate));
+		$local = (new DateTimeImmutable('@' . $candidate))->setTimezone($timezone);
+		$parts = explode('/', $local->format('N/G/i/s'));
 		$local_weekday = (int) $parts[0];
 		$local_hour = (int) $parts[1];
 		$local_minute = (int) $parts[2];
@@ -3584,7 +3587,13 @@ function pfb_schedule_next_occurrence(
  *
  * This is pure: callers provide all group state and both clock readings.
  */
-function pfb_schedule_plan(array $groups, array $default_schedule, ?int $since, int $now): array
+function pfb_schedule_plan(
+	array $groups,
+	array $default_schedule,
+	?int $since,
+	int $now,
+	DateTimeZone $timezone
+): array
 {
 	$validate_schedule = static function (mixed $schedule): void {
 		if (!is_array($schedule)
@@ -3627,7 +3636,8 @@ function pfb_schedule_plan(array $groups, array $default_schedule, ?int $since, 
 			$effective['weekday'],
 			$effective['hour'],
 			$effective['minute'],
-			$now
+			$now,
+			$timezone
 		);
 		$eligible = $group['enabled'] && $group['has_active_rows'] && $group['cadence'] !== 'Never';
 		if (!$eligible) {
@@ -3641,7 +3651,8 @@ function pfb_schedule_plan(array $groups, array $default_schedule, ?int $since, 
 				$effective['weekday'],
 				$effective['hour'],
 				$effective['minute'],
-				$since
+				$since,
+				$timezone
 			);
 			if ($past !== NULL && $past <= $now) {
 				$due[] = $key;

--- a/tests/php/AnchoredSchedulePrimitivesTest.php
+++ b/tests/php/AnchoredSchedulePrimitivesTest.php
@@ -101,7 +101,19 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		);
 	}
 
-	public function testNextOccurrenceRejectsMalformedInputsAndNeverReturnsNull(): void
+	public function testNextOccurrenceUsesNonzeroPhaseForEveryMultiHourCadence(): void
+	{
+		$reference = $this->timestamp('2026-01-05 00:00:00');
+		foreach (['02hours', '03hours', '04hours', '06hours', '08hours', '12hours'] as $cadence) {
+			$this->assertSame(
+				$this->timestamp('2026-01-05 01:00:00'),
+				pfb_schedule_next_occurrence($cadence, 1, 1, 0, $reference, $this->scheduleTimezone),
+				"{$cadence} must honor a nonzero hourly phase"
+			);
+		}
+	}
+
+	public function testNextOccurrenceReturnsNullOnlyForNeverAndRejectsMalformedInputs(): void
 	{
 		$reference = $this->timestamp('2026-01-05 00:00:00');
 		$this->assertNull(pfb_schedule_next_occurrence('Never', 1, 0, 0, $reference, $this->scheduleTimezone));
@@ -144,6 +156,18 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 			$this->timestamp('2026-11-01 01:15:00 EST'),
 			pfb_schedule_next_occurrence('EveryDay', 7, 1, 15, (int) $first, $timezone),
 			'repeated fall-back local slot must be observed twice'
+		);
+	}
+
+	public function testWeeklyOccurrenceSearchCrossesMissingSpringForwardWeek(): void
+	{
+		$timezone = new DateTimeZone('America/New_York');
+		$reference = $this->timestamp('2026-03-01 02:15:00 EST');
+
+		$this->assertSame(
+			$this->timestamp('2026-03-15 02:15:00 EDT'),
+			pfb_schedule_next_occurrence('Weekly', 7, 2, 15, $reference, $timezone),
+			'weekly search must continue after a nonexistent DST occurrence'
 		);
 	}
 
@@ -251,7 +275,6 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		$validDefault = ['weekday' => 1, 'hour' => 4, 'minute' => 0];
 		$validGroup = ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL];
 		$invalid = [
-			[['feed' => $validGroup], 'not-an-array'],
 			[['feed' => 42], $validDefault],
 			[[1 => $validGroup], $validDefault],
 			[['feed' => ['enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]], $validDefault],
@@ -268,9 +291,16 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 			try {
 				pfb_schedule_plan($groups, $default, NULL, $this->timestamp('2026-01-05 00:00:00'), $this->scheduleTimezone);
 				$this->fail('malformed normalized schedule unexpectedly accepted');
-			} catch (Throwable $e) {
+			} catch (InvalidArgumentException $e) {
 				$this->assertNotSame('', $e->getMessage());
 			}
 		}
+	}
+
+	public function testSchedulePlanRejectsNonArrayDefaultScheduleWithTypeError(): void
+	{
+		$groups = ['feed' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]];
+		$this->expectException(TypeError::class);
+		pfb_schedule_plan($groups, 'not-an-array', NULL, $this->timestamp('2026-01-05 00:00:00'), $this->scheduleTimezone);
 	}
 }

--- a/tests/php/AnchoredSchedulePrimitivesTest.php
+++ b/tests/php/AnchoredSchedulePrimitivesTest.php
@@ -13,11 +13,13 @@ use PHPUnit\Framework\TestCase;
 final class AnchoredSchedulePrimitivesTest extends TestCase
 {
 	private string $timezone;
+	private DateTimeZone $scheduleTimezone;
 
 	protected function setUp(): void
 	{
 		$this->timezone = date_default_timezone_get();
-	date_default_timezone_set('UTC');
+		date_default_timezone_set('UTC');
+		$this->scheduleTimezone = new DateTimeZone('UTC');
 	}
 
 	protected function tearDown(): void
@@ -46,7 +48,7 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		];
 
 		foreach ($cases as [$cadence, $weekday, $hour, $minute, $expected]) {
-			$actual = pfb_schedule_next_occurrence($cadence, $weekday, $hour, $minute, $reference);
+			$actual = pfb_schedule_next_occurrence($cadence, $weekday, $hour, $minute, $reference, $this->scheduleTimezone);
 			$this->assertSame(
 				$this->timestamp($expected),
 				$actual,
@@ -57,7 +59,7 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		$beforeSunday = $this->timestamp('2026-01-11 23:59:59');
 		$this->assertSame(
 			$this->timestamp('2026-01-12 00:00:00'),
-			pfb_schedule_next_occurrence('Weekly', 1, 0, 0, $beforeSunday),
+			pfb_schedule_next_occurrence('Weekly', 1, 0, 0, $beforeSunday, $this->scheduleTimezone),
 			'Sunday-to-Monday weekly wrap must use ISO weekday values'
 		);
 	}
@@ -67,16 +69,16 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		$slot = $this->timestamp('2026-02-03 10:15:00');
 		$this->assertSame(
 			$slot,
-			pfb_schedule_next_occurrence('EveryDay', 7, 10, 15, $slot - 1)
+			pfb_schedule_next_occurrence('EveryDay', 7, 10, 15, $slot - 1, $this->scheduleTimezone)
 		);
 		$this->assertSame(
 			$this->timestamp('2026-02-04 10:15:00'),
-			pfb_schedule_next_occurrence('EveryDay', 7, 10, 15, $slot),
+			pfb_schedule_next_occurrence('EveryDay', 7, 10, 15, $slot, $this->scheduleTimezone),
 			'exact reference slot must be skipped'
 		);
 		$this->assertSame(
 			$this->timestamp('2026-02-04 10:15:00'),
-			pfb_schedule_next_occurrence('EveryDay', 7, 10, 15, $slot + 1),
+			pfb_schedule_next_occurrence('EveryDay', 7, 10, 15, $slot + 1, $this->scheduleTimezone),
 			'immediately-after reference slot must be skipped'
 		);
 
@@ -84,16 +86,25 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 			$expected = $this->timestamp("2026-02-03 10:" . str_pad((string) $minute, 2, '0', STR_PAD_LEFT) . ':00');
 			$this->assertSame(
 				$expected,
-				pfb_schedule_next_occurrence('01hour', 7, 10, $minute, $expected - 1),
+				pfb_schedule_next_occurrence('01hour', 7, 10, $minute, $expected - 1, $this->scheduleTimezone),
 				"quarter-hour minute {$minute} must be selectable"
 			);
 		}
 	}
 
+	public function testNextOccurrenceWrapsAcrossMonthAndYearBoundaries(): void
+	{
+		$reference = $this->timestamp('2026-12-31 23:59:59');
+		$this->assertSame(
+			$this->timestamp('2027-01-01 00:00:00'),
+			pfb_schedule_next_occurrence('EveryDay', 1, 0, 0, $reference, $this->scheduleTimezone)
+		);
+	}
+
 	public function testNextOccurrenceRejectsMalformedInputsAndNeverReturnsNull(): void
 	{
 		$reference = $this->timestamp('2026-01-05 00:00:00');
-		$this->assertNull(pfb_schedule_next_occurrence('Never', 1, 0, 0, $reference));
+		$this->assertNull(pfb_schedule_next_occurrence('Never', 1, 0, 0, $reference, $this->scheduleTimezone));
 
 		$invalid = [
 			['Never', 0, 0, 0],
@@ -107,7 +118,7 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		];
 		foreach ($invalid as [$cadence, $weekday, $hour, $minute]) {
 			try {
-				pfb_schedule_next_occurrence($cadence, $weekday, $hour, $minute, $reference);
+				pfb_schedule_next_occurrence($cadence, $weekday, $hour, $minute, $reference, $this->scheduleTimezone);
 				$this->fail("invalid {$cadence} schedule unexpectedly accepted");
 			} catch (InvalidArgumentException $e) {
 				$this->assertNotSame('', $e->getMessage());
@@ -118,21 +129,34 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 	public function testNextOccurrencePreservesLocalDstSlotsByScanningActualInstants(): void
 	{
 		date_default_timezone_set('America/New_York');
+		$timezone = new DateTimeZone('America/New_York');
 		$springReference = $this->timestamp('2026-03-08 01:00:00 EST');
 		$this->assertSame(
 			$this->timestamp('2026-03-09 02:15:00 EDT'),
-			pfb_schedule_next_occurrence('EveryDay', 7, 2, 15, $springReference),
+			pfb_schedule_next_occurrence('EveryDay', 7, 2, 15, $springReference, $timezone),
 			'nonexistent spring-forward local slot must be skipped'
 		);
 
 		$fallBefore = $this->timestamp('2026-11-01 00:00:00 EDT');
-		$first = pfb_schedule_next_occurrence('EveryDay', 7, 1, 15, $fallBefore);
+		$first = pfb_schedule_next_occurrence('EveryDay', 7, 1, 15, $fallBefore, $timezone);
 		$this->assertSame($this->timestamp('2026-11-01 01:15:00 EDT'), $first);
 		$this->assertSame(
 			$this->timestamp('2026-11-01 01:15:00 EST'),
-			pfb_schedule_next_occurrence('EveryDay', 7, 1, 15, (int) $first),
+			pfb_schedule_next_occurrence('EveryDay', 7, 1, 15, (int) $first, $timezone),
 			'repeated fall-back local slot must be observed twice'
 		);
+	}
+
+	public function testInjectedTimezoneMakesOccurrenceIndependentOfAmbientTimezone(): void
+	{
+		$timezone = new DateTimeZone('America/New_York');
+		$reference = $this->timestamp('2026-01-05 00:00:00');
+		date_default_timezone_set('UTC');
+		$first = pfb_schedule_next_occurrence('EveryDay', 1, 2, 15, $reference, $timezone);
+		date_default_timezone_set('America/New_York');
+		$second = pfb_schedule_next_occurrence('EveryDay', 1, 2, 15, $reference, $timezone);
+
+		$this->assertSame($first, $second, 'injected timezone must override ambient timezone');
 	}
 
 	public function testSchedulePlanUsesInheritedAndOverriddenSchedulesInInputOrder(): void
@@ -148,7 +172,7 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		];
 		$since = $this->timestamp('2026-01-05 01:00:00');
 		$now = $this->timestamp('2026-01-05 03:00:00');
-		$result = pfb_schedule_plan($groups, $default, $since, $now);
+		$result = pfb_schedule_plan($groups, $default, $since, $now, $this->scheduleTimezone);
 
 		$this->assertSame(['inherited', 'overridden'], $result['due']);
 		$this->assertSame($this->timestamp('2026-01-06 02:15:00'), $result['next_due']);
@@ -164,7 +188,7 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 				'override' => ['weekday' => 7, 'hour' => 5, 'minute' => 15]],
 		];
 		$now = $this->timestamp('2026-01-05 04:00:00');
-		$result = pfb_schedule_plan($groups, $default, NULL, $now);
+		$result = pfb_schedule_plan($groups, $default, NULL, $now, $this->scheduleTimezone);
 
 		$this->assertSame(['first', 'shared', 'weekly'], $result['due']);
 		$this->assertSame($this->timestamp('2026-01-05 05:00:00'), $result['next_due']);
@@ -175,9 +199,9 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		$default = ['weekday' => 1, 'hour' => 4, 'minute' => 0];
 		$groups = ['feed' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]];
 		$slot = $this->timestamp('2026-01-05 04:00:00');
-		$this->assertSame(['feed'], pfb_schedule_plan($groups, $default, $slot - 1, $slot)['due']);
-		$this->assertSame([], pfb_schedule_plan($groups, $default, $slot, $slot)['due']);
-		$this->assertSame([], pfb_schedule_plan($groups, $default, $slot + 1, $slot)['due']);
+		$this->assertSame(['feed'], pfb_schedule_plan($groups, $default, $slot - 1, $slot, $this->scheduleTimezone)['due']);
+		$this->assertSame([], pfb_schedule_plan($groups, $default, $slot, $slot, $this->scheduleTimezone)['due']);
+		$this->assertSame([], pfb_schedule_plan($groups, $default, $slot + 1, $slot, $this->scheduleTimezone)['due']);
 	}
 
 	public function testSchedulePlanCollapsesMultipleMissedOccurrencesIntoOneDueResult(): void
@@ -186,10 +210,40 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		$groups = ['feed' => ['cadence' => '01hour', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]];
 		$since = $this->timestamp('2026-01-05 00:01:00');
 		$now = $this->timestamp('2026-01-05 05:00:00');
-		$result = pfb_schedule_plan($groups, $default, $since, $now);
+		$result = pfb_schedule_plan($groups, $default, $since, $now, $this->scheduleTimezone);
 
 		$this->assertSame(['feed'], $result['due'], 'five missed hourly slots must produce one due group');
 		$this->assertSame($this->timestamp('2026-01-05 06:00:00'), $result['next_due']);
+	}
+
+	public function testSchedulePlanPreservesFamilyKeysIsIdempotentAndTiesNextWake(): void
+	{
+		$default = ['weekday' => 1, 'hour' => 4, 'minute' => 0];
+		$groups = [
+			'ipv4_feed' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL],
+			'ipv6_feed' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL],
+			'dnsbl_feed' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL],
+		];
+		$slot = $this->timestamp('2026-01-05 04:00:00');
+		$first = pfb_schedule_plan($groups, $default, $slot - 1, $slot, $this->scheduleTimezone);
+		$second = pfb_schedule_plan($groups, $default, $slot - 1, $slot, $this->scheduleTimezone);
+
+		$this->assertSame(['ipv4_feed', 'ipv6_feed', 'dnsbl_feed'], $first['due']);
+		$this->assertSame($slot + 86400, $first['next_due']);
+		$this->assertSame($first, $second, 'identical pure inputs must produce identical plans');
+	}
+
+	public function testSchedulePlanReturnsNoWakeWhenNoEligibleGroupsRemain(): void
+	{
+		$default = ['weekday' => 1, 'hour' => 4, 'minute' => 0];
+		$groups = [
+			'disabled' => ['cadence' => 'EveryDay', 'enabled' => FALSE, 'has_active_rows' => TRUE, 'override' => NULL],
+			'empty' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => FALSE, 'override' => NULL],
+			'never' => ['cadence' => 'Never', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL],
+		];
+		$result = pfb_schedule_plan($groups, $default, NULL, $this->timestamp('2026-01-05 04:00:00'), $this->scheduleTimezone);
+
+		$this->assertSame(['due' => [], 'next_due' => NULL], $result);
 	}
 
 	public function testSchedulePlanRejectsMalformedNormalizedShapesWithoutCoercion(): void
@@ -197,6 +251,8 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 		$validDefault = ['weekday' => 1, 'hour' => 4, 'minute' => 0];
 		$validGroup = ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL];
 		$invalid = [
+			[['feed' => $validGroup], 'not-an-array'],
+			[['feed' => 42], $validDefault],
 			[[1 => $validGroup], $validDefault],
 			[['feed' => ['enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]], $validDefault],
 			[['feed' => ['cadence' => 1, 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]], $validDefault],
@@ -210,9 +266,9 @@ final class AnchoredSchedulePrimitivesTest extends TestCase
 
 		foreach ($invalid as [$groups, $default]) {
 			try {
-				pfb_schedule_plan($groups, $default, NULL, $this->timestamp('2026-01-05 00:00:00'));
+				pfb_schedule_plan($groups, $default, NULL, $this->timestamp('2026-01-05 00:00:00'), $this->scheduleTimezone);
 				$this->fail('malformed normalized schedule unexpectedly accepted');
-			} catch (InvalidArgumentException $e) {
+			} catch (Throwable $e) {
 				$this->assertNotSame('', $e->getMessage());
 			}
 		}

--- a/tests/php/AnchoredSchedulePrimitivesTest.php
+++ b/tests/php/AnchoredSchedulePrimitivesTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pure calendar and feed-plan primitives for the quarter-hour scheduler.
+ *
+ * The production seam is intentionally unreachable from runtime callers in this
+ * slice. These tests pin the public contracts before the scheduler wiring lands.
+ */
+final class AnchoredSchedulePrimitivesTest extends TestCase
+{
+	private string $timezone;
+
+	protected function setUp(): void
+	{
+		$this->timezone = date_default_timezone_get();
+	date_default_timezone_set('UTC');
+	}
+
+	protected function tearDown(): void
+	{
+		date_default_timezone_set($this->timezone);
+	}
+
+	private function timestamp(string $local): int
+	{
+		return (new DateTimeImmutable($local))->getTimestamp();
+	}
+
+	public function testNextOccurrenceCoversEverySupportedCadenceAndWrapsSundayToMonday(): void
+	{
+		$reference = $this->timestamp('2026-01-05 00:00:01');
+		$cases = [
+			['01hour', 1, 0, 15, '2026-01-05 00:15:00'],
+			['02hours', 1, 2, 30, '2026-01-05 00:30:00'],
+			['03hours', 1, 3, 45, '2026-01-05 00:45:00'],
+			['04hours', 1, 4, 00, '2026-01-05 04:00:00'],
+			['06hours', 1, 6, 15, '2026-01-05 00:15:00'],
+			['08hours', 1, 8, 30, '2026-01-05 00:30:00'],
+			['12hours', 1, 12, 45, '2026-01-05 00:45:00'],
+			['EveryDay', 1, 23, 00, '2026-01-05 23:00:00'],
+			['Weekly', 1, 0, 15, '2026-01-05 00:15:00'],
+		];
+
+		foreach ($cases as [$cadence, $weekday, $hour, $minute, $expected]) {
+			$actual = pfb_schedule_next_occurrence($cadence, $weekday, $hour, $minute, $reference);
+			$this->assertSame(
+				$this->timestamp($expected),
+				$actual,
+				"{$cadence} did not select its first local slot"
+			);
+		}
+
+		$beforeSunday = $this->timestamp('2026-01-11 23:59:59');
+		$this->assertSame(
+			$this->timestamp('2026-01-12 00:00:00'),
+			pfb_schedule_next_occurrence('Weekly', 1, 0, 0, $beforeSunday),
+			'Sunday-to-Monday weekly wrap must use ISO weekday values'
+		);
+	}
+
+	public function testNextOccurrenceUsesStrictAfterReferenceAndAllQuarterMinutes(): void
+	{
+		$slot = $this->timestamp('2026-02-03 10:15:00');
+		$this->assertSame(
+			$slot,
+			pfb_schedule_next_occurrence('EveryDay', 7, 10, 15, $slot - 1)
+		);
+		$this->assertSame(
+			$this->timestamp('2026-02-04 10:15:00'),
+			pfb_schedule_next_occurrence('EveryDay', 7, 10, 15, $slot),
+			'exact reference slot must be skipped'
+		);
+		$this->assertSame(
+			$this->timestamp('2026-02-04 10:15:00'),
+			pfb_schedule_next_occurrence('EveryDay', 7, 10, 15, $slot + 1),
+			'immediately-after reference slot must be skipped'
+		);
+
+		foreach ([0, 15, 30, 45] as $minute) {
+			$expected = $this->timestamp("2026-02-03 10:" . str_pad((string) $minute, 2, '0', STR_PAD_LEFT) . ':00');
+			$this->assertSame(
+				$expected,
+				pfb_schedule_next_occurrence('01hour', 7, 10, $minute, $expected - 1),
+				"quarter-hour minute {$minute} must be selectable"
+			);
+		}
+	}
+
+	public function testNextOccurrenceRejectsMalformedInputsAndNeverReturnsNull(): void
+	{
+		$reference = $this->timestamp('2026-01-05 00:00:00');
+		$this->assertNull(pfb_schedule_next_occurrence('Never', 1, 0, 0, $reference));
+
+		$invalid = [
+			['Never', 0, 0, 0],
+			['bogus', 1, 0, 0],
+			['01hour', 0, 0, 0],
+			['01hour', 8, 0, 0],
+			['01hour', 1, -1, 0],
+			['01hour', 1, 24, 0],
+			['01hour', 1, 0, 1],
+			['01hour', 1, 0, 60],
+		];
+		foreach ($invalid as [$cadence, $weekday, $hour, $minute]) {
+			try {
+				pfb_schedule_next_occurrence($cadence, $weekday, $hour, $minute, $reference);
+				$this->fail("invalid {$cadence} schedule unexpectedly accepted");
+			} catch (InvalidArgumentException $e) {
+				$this->assertNotSame('', $e->getMessage());
+			}
+		}
+	}
+
+	public function testNextOccurrencePreservesLocalDstSlotsByScanningActualInstants(): void
+	{
+		date_default_timezone_set('America/New_York');
+		$springReference = $this->timestamp('2026-03-08 01:00:00 EST');
+		$this->assertSame(
+			$this->timestamp('2026-03-09 02:15:00 EDT'),
+			pfb_schedule_next_occurrence('EveryDay', 7, 2, 15, $springReference),
+			'nonexistent spring-forward local slot must be skipped'
+		);
+
+		$fallBefore = $this->timestamp('2026-11-01 00:00:00 EDT');
+		$first = pfb_schedule_next_occurrence('EveryDay', 7, 1, 15, $fallBefore);
+		$this->assertSame($this->timestamp('2026-11-01 01:15:00 EDT'), $first);
+		$this->assertSame(
+			$this->timestamp('2026-11-01 01:15:00 EST'),
+			pfb_schedule_next_occurrence('EveryDay', 7, 1, 15, (int) $first),
+			'repeated fall-back local slot must be observed twice'
+		);
+	}
+
+	public function testSchedulePlanUsesInheritedAndOverriddenSchedulesInInputOrder(): void
+	{
+		$default = ['weekday' => 7, 'hour' => 2, 'minute' => 15];
+		$groups = [
+			'inherited' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL],
+			'overridden' => ['cadence' => 'Weekly', 'enabled' => TRUE, 'has_active_rows' => TRUE,
+				'override' => ['weekday' => 1, 'hour' => 2, 'minute' => 30]],
+			'disabled' => ['cadence' => 'EveryDay', 'enabled' => FALSE, 'has_active_rows' => TRUE, 'override' => NULL],
+			'empty' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => FALSE, 'override' => NULL],
+			'never' => ['cadence' => 'Never', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL],
+		];
+		$since = $this->timestamp('2026-01-05 01:00:00');
+		$now = $this->timestamp('2026-01-05 03:00:00');
+		$result = pfb_schedule_plan($groups, $default, $since, $now);
+
+		$this->assertSame(['inherited', 'overridden'], $result['due']);
+		$this->assertSame($this->timestamp('2026-01-06 02:15:00'), $result['next_due']);
+	}
+
+	public function testSchedulePlanMissingSinceRunsEachEligibleGroupOnceAndFindsSharedWake(): void
+	{
+		$default = ['weekday' => 1, 'hour' => 4, 'minute' => 0];
+		$groups = [
+			'first' => ['cadence' => '01hour', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL],
+			'shared' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL],
+			'weekly' => ['cadence' => 'Weekly', 'enabled' => TRUE, 'has_active_rows' => TRUE,
+				'override' => ['weekday' => 7, 'hour' => 5, 'minute' => 15]],
+		];
+		$now = $this->timestamp('2026-01-05 04:00:00');
+		$result = pfb_schedule_plan($groups, $default, NULL, $now);
+
+		$this->assertSame(['first', 'shared', 'weekly'], $result['due']);
+		$this->assertSame($this->timestamp('2026-01-05 05:00:00'), $result['next_due']);
+	}
+
+	public function testSchedulePlanAdvancingSincePreventsDuplicateDueAndHonorsSinceAfterNow(): void
+	{
+		$default = ['weekday' => 1, 'hour' => 4, 'minute' => 0];
+		$groups = ['feed' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]];
+		$slot = $this->timestamp('2026-01-05 04:00:00');
+		$this->assertSame(['feed'], pfb_schedule_plan($groups, $default, $slot - 1, $slot)['due']);
+		$this->assertSame([], pfb_schedule_plan($groups, $default, $slot, $slot)['due']);
+		$this->assertSame([], pfb_schedule_plan($groups, $default, $slot + 1, $slot)['due']);
+	}
+
+	public function testSchedulePlanCollapsesMultipleMissedOccurrencesIntoOneDueResult(): void
+	{
+		$default = ['weekday' => 1, 'hour' => 0, 'minute' => 0];
+		$groups = ['feed' => ['cadence' => '01hour', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]];
+		$since = $this->timestamp('2026-01-05 00:01:00');
+		$now = $this->timestamp('2026-01-05 05:00:00');
+		$result = pfb_schedule_plan($groups, $default, $since, $now);
+
+		$this->assertSame(['feed'], $result['due'], 'five missed hourly slots must produce one due group');
+		$this->assertSame($this->timestamp('2026-01-05 06:00:00'), $result['next_due']);
+	}
+
+	public function testSchedulePlanRejectsMalformedNormalizedShapesWithoutCoercion(): void
+	{
+		$validDefault = ['weekday' => 1, 'hour' => 4, 'minute' => 0];
+		$validGroup = ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL];
+		$invalid = [
+			[[1 => $validGroup], $validDefault],
+			[['feed' => ['enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]], $validDefault],
+			[['feed' => ['cadence' => 1, 'enabled' => TRUE, 'has_active_rows' => TRUE, 'override' => NULL]], $validDefault],
+			[['feed' => ['cadence' => 'EveryDay', 'enabled' => 'on', 'has_active_rows' => TRUE, 'override' => NULL]], $validDefault],
+			[['feed' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE,
+				'override' => ['weekday' => 1, 'hour' => '4', 'minute' => 0]]], $validDefault],
+			[['feed' => ['cadence' => 'EveryDay', 'enabled' => TRUE, 'has_active_rows' => TRUE,
+				'override' => ['weekday' => 1, 'hour' => 4]]], $validDefault],
+			[['feed' => $validGroup], ['weekday' => 1, 'hour' => 4, 'minute' => 1]],
+		];
+
+		foreach ($invalid as [$groups, $default]) {
+			try {
+				pfb_schedule_plan($groups, $default, NULL, $this->timestamp('2026-01-05 00:00:00'));
+				$this->fail('malformed normalized schedule unexpectedly accepted');
+			} catch (InvalidArgumentException $e) {
+				$this->assertNotSame('', $e->getMessage());
+			}
+		}
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -9260,6 +9260,13 @@
                 "variadic": false,
                 "type": "int",
                 "default": null
+            },
+            {
+                "name": "timezone",
+                "byRef": false,
+                "variadic": false,
+                "type": "DateTimeZone",
+                "default": null
             }
         ]
     },
@@ -9293,6 +9300,13 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "int",
+                "default": null
+            },
+            {
+                "name": "timezone",
+                "byRef": false,
+                "variadic": false,
+                "type": "DateTimeZone",
                 "default": null
             }
         ]

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -9222,6 +9222,81 @@
             }
         ]
     },
+    "pfb_schedule_next_occurrence": {
+        "returnsRef": false,
+        "returnType": "?int",
+        "params": [
+            {
+                "name": "cadence",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "weekday",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "hour",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "minute",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "reference",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_schedule_plan": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "groups",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "default_schedule",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "since",
+                "byRef": false,
+                "variadic": false,
+                "type": "?int",
+                "default": null
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
     "pfb_select_reload_aliases": {
         "returnsRef": false,
         "returnType": "array",


### PR DESCRIPTION
## Summary

- add pure, clock-injected calendar primitives for anchored feed schedules
- compute once-only due groups and the earliest future shared wake
- make appliance-local timezone context explicit and keep production behavior unchanged until runtime cutover

## Verification

- `vendor/bin/phpunit tests/php/AnchoredSchedulePrimitivesTest.php` — 13 tests, 53 assertions
- focused scheduler and inventory suites — 81 tests, 208 assertions
- `composer phpstan` — no errors
- `composer phpcs -- --standard=phpcs.xml.dist src/` — pass
- strict-after mutation — 6 focused failures; restored suite passes with frozen test hash `e0d29798acef347560ee54b058f5a83887820ad0`
- ambient-timezone regression — fails on the pre-fix commit and passes with explicit `DateTimeZone`

The full local PHPUnit run reached environment-restricted paths (`/bin/ps`, fixture PHP servers, and a generated PHPStan report); focused affected suites are green and GitHub CI remains authoritative.

Fixes #2307

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schedule planning for feed groups with recurring cadence support and quarter-hour timing.
  * Supports inherited and group-specific schedules, due-item detection, and next-run calculation.
  * Handles daylight-saving transitions, calendar boundaries, disabled schedules, and shared wake times.

* **Bug Fixes**
  * Added validation for malformed scheduling inputs and duplicate processing of missed occurrences.

* **Tests**
  * Added coverage for cadence rules, time zones, schedule inheritance, ordering, idempotence, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->