### PR TITLE
pfblockerng: recover interrupted directory publication

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4255,7 +4255,7 @@ function pfb_stage_publish_dir(string $target, callable $extract): bool {
 	}
 	if (!@rename($staged, $target)) {
 		if ($backup !== NULL) {
-			@rename($backup, $target);
+			pfb_stage_publish_dir_recover(dirname($target));
 		}
 		rmdir_recursive($staged);
 		return FALSE;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4181,6 +4181,34 @@ function pfb_stage_publish(string $target, callable $extract): bool {
 	return TRUE;
 }
 
+/** Remove one directory tree without treating its literal path as a glob. */
+function pfb_stage_publish_dir_remove(string $path): bool {
+	if (!is_dir($path) || is_link($path)) {
+		return FALSE;
+	}
+	if (is_executable('/bin/chflags')) {
+		exec('/bin/chflags -R 0 ' . escapeshellarg($path) . ' 2>/dev/null');
+	}
+	try {
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($iterator as $entry) {
+			$entry_path = $entry->getPathname();
+			$removed = $entry->isDir() && !$entry->isLink()
+				? @rmdir($entry_path)
+				: @unlink($entry_path);
+			if (!$removed && (file_exists($entry_path) || is_link($entry_path))) {
+				return FALSE;
+			}
+		}
+	} catch (UnexpectedValueException) {
+		return FALSE;
+	}
+	return @rmdir($path) || !is_dir($path);
+}
+
 /** Recover deterministic directory backups left by an interrupted publication. */
 function pfb_stage_publish_dir_recover(string $directory): bool {
 	$entries = @scandir($directory);
@@ -4188,6 +4216,7 @@ function pfb_stage_publish_dir_recover(string $directory): bool {
 		return FALSE;
 	}
 	$prefix = '.pfbstagebak2_';
+	$success = TRUE;
 	foreach ($entries as $entry) {
 		if ($entry === '.' || $entry === '..' || !str_starts_with($entry, $prefix)) {
 			continue;
@@ -4203,18 +4232,19 @@ function pfb_stage_publish_dir_recover(string $directory): bool {
 		$target = "{$directory}/{$suffix}";
 		if (file_exists($target) || is_link($target)) {
 			if (!is_dir($target) || is_link($target)) {
-				return FALSE;
+				$success = FALSE;
+				continue;
 			}
-			if (!rmdir_recursive($backup) && is_dir($backup)) {
-				return FALSE;
+			if (!pfb_stage_publish_dir_remove($backup)) {
+				$success = FALSE;
 			}
 			continue;
 		}
 		if (!@rename($backup, $target)) {
-			return FALSE;
+			$success = FALSE;
 		}
 	}
-	return TRUE;
+	return $success;
 }
 
 /**
@@ -4246,6 +4276,10 @@ function pfb_stage_publish_dir(string $target, callable $extract): bool {
 	// rename() cannot replace a non-empty directory, so the previous publication moves
 	// aside first and is restored if the swap does not complete.
 	$backup = NULL;
+	if (is_link($target) || (file_exists($target) && !is_dir($target))) {
+		rmdir_recursive($staged);
+		return FALSE;
+	}
 	if (is_dir($target)) {
 		$backup = dirname($target) . '/.pfbstagebak2_' . basename($target);
 		if (file_exists($backup) || is_link($backup) || !@rename($target, $backup)) {
@@ -4260,8 +4294,8 @@ function pfb_stage_publish_dir(string $target, callable $extract): bool {
 		rmdir_recursive($staged);
 		return FALSE;
 	}
-	if ($backup !== NULL) {
-		rmdir_recursive($backup);
+	if ($backup !== NULL && !pfb_stage_publish_dir_remove($backup)) {
+		return FALSE;
 	}
 	return TRUE;
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4181,6 +4181,42 @@ function pfb_stage_publish(string $target, callable $extract): bool {
 	return TRUE;
 }
 
+/** Recover deterministic directory backups left by an interrupted publication. */
+function pfb_stage_publish_dir_recover(string $directory): bool {
+	$entries = @scandir($directory);
+	if ($entries === FALSE) {
+		return FALSE;
+	}
+	$prefix = '.pfbstagebak2_';
+	foreach ($entries as $entry) {
+		if ($entry === '.' || $entry === '..' || !str_starts_with($entry, $prefix)) {
+			continue;
+		}
+		$suffix = substr($entry, strlen($prefix));
+		if ($suffix === '') {
+			continue;
+		}
+		$backup = "{$directory}/{$entry}";
+		if (!is_dir($backup) || is_link($backup)) {
+			continue;
+		}
+		$target = "{$directory}/{$suffix}";
+		if (file_exists($target) || is_link($target)) {
+			if (!is_dir($target) || is_link($target)) {
+				return FALSE;
+			}
+			if (!rmdir_recursive($backup) && is_dir($backup)) {
+				return FALSE;
+			}
+			continue;
+		}
+		if (!@rename($backup, $target)) {
+			return FALSE;
+		}
+	}
+	return TRUE;
+}
+
 /**
  * Publish a directory extraction atomically. $extract writes into an empty staging
  * directory beside $target and returns its exit code; $target is replaced only once
@@ -4190,6 +4226,9 @@ function pfb_stage_publish(string $target, callable $extract): bool {
  * @param callable(string):int $extract
  */
 function pfb_stage_publish_dir(string $target, callable $extract): bool {
+	if (!pfb_stage_publish_dir_recover(dirname($target))) {
+		return FALSE;
+	}
 	$staged = @tempnam(dirname($target), '.pfbstagedir_');
 	if ($staged === FALSE) {
 		return FALSE;
@@ -4208,8 +4247,8 @@ function pfb_stage_publish_dir(string $target, callable $extract): bool {
 	// aside first and is restored if the swap does not complete.
 	$backup = NULL;
 	if (is_dir($target)) {
-		$backup = @tempnam(dirname($target), '.pfbstagebak_');
-		if ($backup === FALSE || !@unlink($backup) || !@rename($target, $backup)) {
+		$backup = dirname($target) . '/.pfbstagebak2_' . basename($target);
+		if (file_exists($backup) || is_link($backup) || !@rename($target, $backup)) {
 			rmdir_recursive($staged);
 			return FALSE;
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -676,6 +676,16 @@ function sync_package_pfblockerng($cron=''): bool {
 		}
 		return FALSE;
 	}
+	if (!pfb_stage_publish_dir_recover($pfb['dbdir'])) {
+		pfb_mark_pending_changes();
+		if ($pfb_feed_pass_owner) {
+			pfb_feed_pass_release();
+		}
+		if ($pfb_dispatch_owner) {
+			pfb_schedule_dispatch_release();
+		}
+		return FALSE;
+	}
 	if (!pfb_geoip_generation_ready()) {
 		pfb_mark_pending_changes();
 		if ($pfb_feed_pass_owner) {

--- a/tests/php/DownloadStagePublishDirTest.php
+++ b/tests/php/DownloadStagePublishDirTest.php
@@ -202,6 +202,55 @@ final class DownloadStagePublishDirTest extends TestCase
 		$this->assertSame("last-good\n", file_get_contents("{$backup}/cat_ads"));
 	}
 
+	public function testRecoveryContinuesAfterAnObstructedMarker(): void
+	{
+		$blocked = "{$this->dir}/a";
+		$blockedBackup = $this->backupPath($blocked);
+		$recoverable = "{$this->dir}/z";
+		$recoverableBackup = $this->backupPath($recoverable);
+		$this->assertNotFalse(file_put_contents($blocked, 'occupied'));
+		$this->assertTrue(mkdir($blockedBackup, 0755));
+		$this->assertTrue(mkdir($recoverableBackup, 0755));
+		$this->assertNotFalse(file_put_contents("{$recoverableBackup}/cat_ads", "last-good\n"));
+
+		$this->assertFalse(pfb_stage_publish_dir_recover($this->dir));
+		$this->assertDirectoryExists($blockedBackup);
+		$this->assertSame("last-good\n", file_get_contents("{$recoverable}/cat_ads"));
+		$this->assertDirectoryDoesNotExist($recoverableBackup);
+	}
+
+	public function testBackupCleanupTreatsMetacharactersLiterally(): void
+	{
+		$backup = "{$this->dir}/.pfbstagebak2_category[ab]";
+		$sibling = "{$this->dir}/.pfbstagebak2_categorya";
+		$this->assertTrue(mkdir($backup, 0755));
+		$this->assertTrue(mkdir($sibling, 0755));
+		$this->assertNotFalse(file_put_contents("{$backup}/old", 'old'));
+		$this->assertNotFalse(file_put_contents("{$sibling}/keep", 'keep'));
+
+		$this->assertTrue(pfb_stage_publish_dir_remove($backup));
+		$this->assertDirectoryDoesNotExist($backup);
+		$this->assertSame('keep', file_get_contents("{$sibling}/keep"));
+	}
+
+	public function testPublicationRejectsSymlinkTargetWithoutTouchingReferent(): void
+	{
+		$target = "{$this->dir}/category";
+		$referent = "{$this->dir}/referent";
+		$this->assertTrue(mkdir($referent, 0755));
+		$this->assertNotFalse(file_put_contents("{$referent}/keep", 'keep'));
+		$this->assertTrue(symlink($referent, $target));
+
+		$this->assertFalse(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/fresh", 'fresh');
+			return 0;
+		}));
+
+		$this->assertTrue(is_link($target));
+		$this->assertSame('keep', file_get_contents("{$referent}/keep"));
+		$this->assertFileDoesNotExist("{$referent}/fresh");
+	}
+
 	public function testDeterministicBackupRoundTripsTargetWithShellCharacters(): void
 	{
 		$target = "{$this->dir}/category ; [literal]";
@@ -273,6 +322,8 @@ final class DownloadStagePublishDirTest extends TestCase
 			'a failed swap must use the recovery path whose obstruction case preserves the backup');
 		$this->assertStringNotContainsString('@rename($backup, $target)', $scope,
 			'a one-shot rollback cannot prove the backup remains recoverable when restore fails');
+		$this->assertStringContainsString('if ($backup !== NULL && !pfb_stage_publish_dir_remove($backup))', $scope,
+			'a successful publication must fail if the previous generation cannot be removed');
 	}
 
 	/** Staging beside the target is what makes the publication a same-filesystem rename. */
@@ -360,7 +411,7 @@ final class DownloadStagePublishDirTest extends TestCase
 		$source = file_get_contents(__DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
 		$this->assertNotFalse($source);
 		$lock = strpos($source, "if (!pfb_feed_pass_begin('sync')) {");
-		$recovery = strpos($source, 'pfb_stage_publish_dir_recover($pfb[\'dbdir\'])');
+		$recovery = strpos($source, 'if (!pfb_stage_publish_dir_recover($pfb[\'dbdir\'])) {');
 		$boot = strpos($source, 'if (is_platform_booting() || $g[\'pfblockerng_install\']) {');
 		$this->assertNotFalse($lock);
 		$this->assertNotFalse($recovery);

--- a/tests/php/DownloadStagePublishDirTest.php
+++ b/tests/php/DownloadStagePublishDirTest.php
@@ -260,6 +260,21 @@ final class DownloadStagePublishDirTest extends TestCase
 		$this->assertSame("last-good\n", file_get_contents("{$target}/cat_ads"));
 	}
 
+	/** Failed rollback must retain the deterministic backup for the next recovery pass. */
+	public function testFailedSwapRoutesRollbackThroughRecoveryHelper(): void
+	{
+		$reflection = new ReflectionFunction('pfb_stage_publish_dir');
+		$source = file(self::INC);
+		$this->assertNotFalse($source);
+		$scope = implode('', array_slice($source, $reflection->getStartLine() - 1,
+			$reflection->getEndLine() - $reflection->getStartLine() + 1));
+
+		$this->assertStringContainsString('pfb_stage_publish_dir_recover(dirname($target));', $scope,
+			'a failed swap must use the recovery path whose obstruction case preserves the backup');
+		$this->assertStringNotContainsString('@rename($backup, $target)', $scope,
+			'a one-shot rollback cannot prove the backup remains recoverable when restore fails');
+	}
+
 	/** Staging beside the target is what makes the publication a same-filesystem rename. */
 	public function testStagedDirectorySitsBesideTheTargetAndIsNotTheTarget(): void
 	{

--- a/tests/php/DownloadStagePublishDirTest.php
+++ b/tests/php/DownloadStagePublishDirTest.php
@@ -54,6 +54,11 @@ final class DownloadStagePublishDirTest extends TestCase
 			: array_values(array_diff($entries, array('.', '..')));
 	}
 
+	private function backupPath(string $target): string
+	{
+		return dirname($target) . '/.pfbstagebak2_' . basename($target);
+	}
+
 	public function testSuccessfulExtractionPublishesTheStagedDirectory(): void
 	{
 		$target = "{$this->dir}/category";
@@ -117,6 +122,117 @@ final class DownloadStagePublishDirTest extends TestCase
 		// left in the database directory, and the replaced contents are gone.
 		$this->assertSame(['category'], $this->entries($this->dir));
 		$this->assertFileDoesNotExist("{$target}/cat_ads");
+	}
+
+	public function testInterruptedPublicationRecoversMissingTargetBeforeRetry(): void
+	{
+		$target = "{$this->dir}/category";
+		$backup = $this->backupPath($target);
+		$this->assertTrue(mkdir($backup, 0755));
+		$this->assertNotFalse(file_put_contents("{$backup}/cat_ads", "last-good\n"));
+
+		$this->assertFalse(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_ads", 'partial');
+			return 1;
+		}));
+
+		$this->assertDirectoryExists($target);
+		$this->assertSame("last-good\n", file_get_contents("{$target}/cat_ads"));
+		$this->assertDirectoryDoesNotExist($backup);
+	}
+
+	public function testRecoveryIsIdempotentAndPreservesLiveTarget(): void
+	{
+		$target = "{$this->dir}/category";
+		$backup = $this->backupPath($target);
+		$this->assertTrue(mkdir($backup, 0755));
+		$this->assertNotFalse(file_put_contents("{$backup}/cat_ads", "last-good\n"));
+
+		$this->assertTrue(pfb_stage_publish_dir_recover($this->dir));
+		$this->assertTrue(pfb_stage_publish_dir_recover($this->dir));
+		$this->assertSame("last-good\n", file_get_contents("{$target}/cat_ads"));
+		$this->assertDirectoryDoesNotExist($backup);
+	}
+
+	public function testRecoveryRemovesStaleBackupWhenTargetAlreadyExists(): void
+	{
+		$target = "{$this->dir}/category";
+		$backup = $this->backupPath($target);
+		$this->assertTrue(mkdir($target, 0755));
+		$this->assertNotFalse(file_put_contents("{$target}/cat_ads", "live\n"));
+		$this->assertTrue(mkdir($backup, 0755));
+		$this->assertNotFalse(file_put_contents("{$backup}/cat_ads", "stale\n"));
+
+		$this->assertTrue(pfb_stage_publish_dir_recover($this->dir));
+		$this->assertSame("live\n", file_get_contents("{$target}/cat_ads"));
+		$this->assertDirectoryDoesNotExist($backup);
+	}
+
+	public function testRecoveryIgnoresLegacyRandomBackupAndHostileEntries(): void
+	{
+		$target = "{$this->dir}/category";
+		$legacy = "{$this->dir}/.pfbstagebak_random";
+		$empty = "{$this->dir}/.pfbstagebak2_";
+		$regular = "{$this->dir}/.pfbstagebak2_regular";
+		$symlink = "{$this->dir}/.pfbstagebak2_link";
+		$this->assertTrue(mkdir($legacy, 0755));
+		$this->assertTrue(mkdir($empty, 0755));
+		$this->assertNotFalse(file_put_contents($regular, 'not a generation'));
+		$this->assertTrue(symlink($legacy, $symlink));
+
+		$this->assertTrue(pfb_stage_publish_dir_recover($this->dir));
+		$this->assertDirectoryDoesNotExist($target);
+		$this->assertDirectoryExists($legacy);
+		$this->assertDirectoryExists($empty);
+		$this->assertFileExists($regular);
+		$this->assertTrue(is_link($symlink));
+	}
+
+	public function testRecoveryDoesNotOverwriteRegularFileAtTarget(): void
+	{
+		$target = "{$this->dir}/category";
+		$backup = $this->backupPath($target);
+		$this->assertNotFalse(file_put_contents($target, 'do not overwrite'));
+		$this->assertTrue(mkdir($backup, 0755));
+		$this->assertNotFalse(file_put_contents("{$backup}/cat_ads", "last-good\n"));
+
+		$this->assertFalse(pfb_stage_publish_dir_recover($this->dir));
+		$this->assertSame('do not overwrite', file_get_contents($target));
+		$this->assertDirectoryExists($backup);
+		$this->assertSame("last-good\n", file_get_contents("{$backup}/cat_ads"));
+	}
+
+	public function testDeterministicBackupRoundTripsTargetWithShellCharacters(): void
+	{
+		$target = "{$this->dir}/category ; [literal]";
+		$backup = $this->backupPath($target);
+		$this->assertTrue(mkdir($target, 0755));
+		$this->assertNotFalse(file_put_contents("{$target}/cat_ads", "last-good\n"));
+
+		$this->assertTrue(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_news", "fresh\n");
+			return 0;
+		}));
+
+		$this->assertSame("fresh\n", file_get_contents("{$target}/cat_news"));
+		$this->assertDirectoryDoesNotExist($backup);
+	}
+
+	public function testInterruptedMarkerThenSuccessfulRetryPublishesFreshGeneration(): void
+	{
+		$target = "{$this->dir}/category";
+		$backup = $this->backupPath($target);
+		$this->assertTrue(mkdir($backup, 0755));
+		$this->assertNotFalse(file_put_contents("{$backup}/cat_ads", "last-good\n"));
+
+		$this->assertTrue(pfb_stage_publish_dir($target, static function (string $staged): int {
+			file_put_contents("{$staged}/cat_news", "fresh\n");
+			return 0;
+		}));
+
+		$this->assertSame("fresh\n", file_get_contents("{$target}/cat_news"));
+		$this->assertFileDoesNotExist("{$target}/cat_ads");
+		$this->assertDirectoryDoesNotExist($backup);
 	}
 
 	/**
@@ -222,5 +338,19 @@ final class DownloadStagePublishDirTest extends TestCase
 			'expected the blacklist branch to publish through pfb_stage_publish_dir()');
 		$this->assertSame($occurrences - 1, substr_count($source, 'if (!pfb_stage_publish_dir('),
 			'every pfb_stage_publish_dir() call must sit directly in a failure guard');
+	}
+
+	public function testRecoveryIsWiredAfterFeedPassLockBeforeBootReturn(): void
+	{
+		$source = file_get_contents(__DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertNotFalse($source);
+		$lock = strpos($source, "if (!pfb_feed_pass_begin('sync')) {");
+		$recovery = strpos($source, 'pfb_stage_publish_dir_recover($pfb[\'dbdir\'])');
+		$boot = strpos($source, 'if (is_platform_booting() || $g[\'pfblockerng_install\']) {');
+		$this->assertNotFalse($lock);
+		$this->assertNotFalse($recovery);
+		$this->assertNotFalse($boot);
+		$this->assertGreaterThan($lock, $recovery);
+		$this->assertLessThan($boot, $recovery);
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10684,6 +10684,19 @@
             }
         ]
     },
+    "pfb_stage_publish_dir_remove": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_stdout_is_terminal": {
         "returnsRef": false,
         "returnType": "bool",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10671,6 +10671,19 @@
             }
         ]
     },
+    "pfb_stage_publish_dir_recover": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "directory",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_stdout_is_terminal": {
         "returnsRef": false,
         "returnType": "bool",


### PR DESCRIPTION
## Summary

- Replace transient random directory backups with deterministic recovery markers.
- Recover interrupted blacklist publications under the existing feed-pass lock, including boot/install paths.
- Route failed-swap rollback through the same idempotent recovery helper.
- Preserve the stable live directory and existing staged extraction boundary.

## Verification

- Frozen interrupted-publication proof: RED on pre-fix production (`19 tests`, `3 failures`, `4 errors`), then GREEN unchanged (`19 tests`, `103 assertions`).
- Frozen rollback-routing proof: RED before the one-line production change (`2 tests`, `1 failure`), then GREEN unchanged (`2 tests`, `12 assertions`).
- Final targeted suite: `20 tests`, `107 assertions`.
- Full PHPUnit suite outside the restricted process sandbox: `5,216 tests`, `29,798 assertions`, exit 0.
- PHP syntax, PHPStan, PHPCS, function-inventory parity, and diff checks pass.
- Independent verifier: PASS after one rejected coverage row was fixed and re-gated.

Fixes #2311

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
