### PR TITLE
chore: leave test suites to CI

### DIFF
--- a/.agents/policy/git.md
+++ b/.agents/policy/git.md
@@ -53,12 +53,12 @@ Activate once after cloning: `sh scripts/setup-hooks.sh` (sets `core.hooksPath`)
 `git config core.hooksPath` not `.githooks`, agent runs it at session start
 (idempotent). Any GitHub Actions workflow that commits code runs it after checkout too.
 
-- **`pre-commit`** — fast linters/static-analysis, path-scoped to staged file types
-  (Python → ruff + `mypy tests/`; Markdown → markdownlint; shell → shebang gate + `sh -n` +
-  shellcheck + shellspec; PHP → `php -l` + PHPStan + PHPCS; URL-encoding check when
+- **`pre-commit`** — fast lint, style, and policy checks, path-scoped to staged file types
+  (Python → ruff; Markdown → markdownlint; shell → shebang gate + `sh -n` +
+  shellcheck; PHP → `php -l` + PHPCS; URL-encoding check when
   `*.sh`/`*.md` staged). NOT unit suites — run `python3 -m pytest` yourself while
-  iterating; CI is hard gate. Missing tool = reported + skipped. `--no-verify` bypass
-  is for humans, not agents.
+  iterating; tests and static analysis run in CI only. Missing tool = reported + skipped.
+  `--no-verify` bypass is for humans, not agents.
 - **`prepare-commit-msg`** — first aborts agent commit (`CLAUDECODE=1` or
   `CODEX_THREAD_ID` set) in **primary checkout** (agents commit only in linked
   worktrees — issue #1262; state-checked via `--git-dir` vs `--git-common-dir`, never

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,12 +1,11 @@
 #!/bin/sh
-# Runs the project's fast linters / static-analysis gates before each commit and
+# Runs the project's fast lint, style, and policy gates before each commit and
 # blocks the commit on any failure. Mirrors the lint commands in CLAUDE.md and
 # .github/workflows/test.yml.
 #
 # Two deliberate scoping rules keep this hook fast:
-#   1. The UNIT SUITES are NOT run here (no `pytest`, no `phpunit`) — too slow for
-#      a per-commit gate. CI (test.yml) is the correctness gate for both suites;
-#      run `python -m pytest` / `vendor/bin/phpunit` yourself while iterating.
+#   1. Test suites and static analysis run in CI only — too slow for a per-commit
+#      gate. Run them yourself while iterating when useful.
 #   2. Each language's gates run ONLY when this commit stages a file of that type
 #      (a PHP-only commit doesn't pay for the markdown/python/shell linters, etc.).
 #
@@ -61,9 +60,6 @@ staged_md=0;  staged_has '\.md$'        && staged_md=1
 staged_php=0; staged_has '\.(php|inc)$' && staged_php=1
 staged_xml=0; staged_has '\.xml$'       && staged_xml=1
 staged_sh=0;  staged_has '\.sh$'        && staged_sh=1
-# Spec plumbing (helper, extensionless bin/ shims, fixtures) impacts every shellspec
-# run but need not end in .sh -- it must open the shell block on its own.
-staged_specplumb=0; staged_has '^tests/shell/(spec_helper\.sh|bin/|fixtures/)' && staged_specplumb=1
 staged_yaml=0; staged_has '\.ya?ml$'    && staged_yaml=1
 staged_agentcfg=0
 printf '%s\n' "$staged_all" | grep -qE \
@@ -94,20 +90,6 @@ if [ "$staged_py" = 1 ]; then
 	else
 		skip ruff
 	fi
-
-	# mypy: type-check the test suite (config + tests.* strictness in pyproject.toml).
-	mypy_bin=''
-	if [ -x .venv/bin/mypy ]; then
-		mypy_bin=.venv/bin/mypy
-	elif have mypy; then
-		mypy_bin=mypy
-	fi
-	if [ -n "$mypy_bin" ]; then
-		step 'mypy tests/'
-		"$mypy_bin" tests/ || failed 'mypy tests/'
-	else
-		skip mypy
-	fi
 fi
 
 # Python interpreter resolution (used by the URL-encoding check below).
@@ -131,7 +113,7 @@ if [ "$staged_md" = 1 ]; then
 fi
 
 # =============================== Shell (*.sh) =============================== #
-if [ "$staged_sh" = 1 ] || [ "$staged_specplumb" = 1 ]; then
+if [ "$staged_sh" = 1 ]; then
 	# Forbid bash shebangs. The repo is #!/bin/sh POSIX (the FreeBSD/pfSense target
 	# has no /bin/bash, and macOS /bin/bash is the ancient 3.2). Scans ALL tracked
 	# files, so it also covers tests/ (not lint-globbed below).
@@ -176,43 +158,6 @@ if [ "$staged_sh" = 1 ] || [ "$staged_specplumb" = 1 ]; then
 			| xargs shellcheck --severity=info || failed 'shellcheck'
 	else
 		skip shellcheck
-	fi
-
-	# shellspec functional suite (gated on the tool, like shellcheck), scoped to the
-	# IMPACTED specs: staged spec files plus any spec that names a staged script's
-	# basename. The basename heuristic is blind to the pfb_source indirection, so a
-	# staged src/ shell script — or any staged spec-plumbing file (spec_helper, bin/,
-	# fixtures/) — runs the FULL suite instead. The full suite runs minutes (and an
-	# interrupted run can strand spec-mutated state); CI remains the full-suite hard gate.
-	# Run under dash when available: strict-POSIX ash sibling of FreeBSD
-	# /bin/sh (the appliance shell). bash-as-sh (macOS) masks divergences —
-	# e.g. a special-builtin redirection error aborts ash/dash but not bash.
-	if have shellspec; then
-		staged_shell=$(printf '%s\n' "$staged" | grep '\.sh$' || true)
-		if printf '%s\n' "$staged_shell" | grep -q '^src/' || [ "$staged_specplumb" = 1 ]; then
-			specs=$(ls tests/shell/*_spec.sh)
-		else
-			specs=$(printf '%s\n' "$staged_shell" | grep '^tests/shell/.*_spec\.sh$' || true)
-			for f in $(printf '%s\n' "$staged_shell" | grep -v '^tests/shell/'); do
-				specs="$specs
-$(grep -l -F "$(basename "$f")" tests/shell/*_spec.sh 2>/dev/null || true)"
-			done
-		fi
-		specs=$(printf '%s\n' "$specs" | grep -v '^$' | sort -u)
-		if [ -n "$specs" ]; then
-			step 'shellspec (impacted)'
-			if have dash; then
-				# shellcheck disable=SC2086 # specs is a newline list of repo paths
-				shellspec --shell "$(command -v dash)" $specs || failed 'shellspec (dash)'
-			else
-				# shellcheck disable=SC2086
-				shellspec $specs || failed 'shellspec'
-			fi
-		else
-			skip 'shellspec(no-impacted-specs)'
-		fi
-	else
-		skip shellspec
 	fi
 fi
 
@@ -316,9 +261,9 @@ if [ "$staged_php" = 1 ]; then
 	fi
 
 	# Composer PHP tools are unsafe against a missing, shared, or stale vendor tree.
-	# The guard is fail-closed and runs before every PHP analysis gate.
+	# The guard is fail-closed and runs before every PHP style gate.
 	if [ "$composer_vendor_ok" != 1 ]; then
-		printf '[pre-commit] Composer vendor check failed; skipping PHP analysis gates.\n' >&2
+		printf '[pre-commit] Composer vendor check failed; skipping PHP style gates.\n' >&2
 	else
 	# php -l syntax check (output shown only for files that fail).
 	if have php; then
@@ -330,17 +275,11 @@ if [ "$staged_php" = 1 ]; then
 		skip php
 	fi
 
-	# PHPStan (heavy; only when the Composer vendor tree is installed).
-	if [ -x vendor/bin/phpstan ]; then
-		step 'phpstan'
-		vendor/bin/phpstan analyse --no-progress --memory-limit=1G || failed 'phpstan'
-	fi
-
 	# PHPCS sniffs (only when the vendor tree is installed). Config auto-discovered
 	# from phpcs.xml.dist.
 	if [ -x vendor/bin/phpcs ]; then
 		step 'phpcs'
-		# issue #895: cap memory like the phpstan step above — phpcs tokenising a
+		# issue #895: cap memory because phpcs tokenising a
 		# large file (pfblockerng.inc ~19.5k lines) exhausts PHP's default 128M and
 		# aborts, which forces --no-verify and skips ALL gates. CI runs at
 		# memory_limit=-1 so it never OOMs there; this closes the local-only gap.

--- a/docs/reviews/2026-06-06-test-coverage-plan.md
+++ b/docs/reviews/2026-06-06-test-coverage-plan.md
@@ -38,7 +38,7 @@ branch**, and assert **before-state** in transition tests (per CLAUDE.md "Test c
   `composer install` once, then `vendor/bin/phpunit`.
 - **shellspec** (`tests/shell/`, `--shell sh`): `spec_helper.sh` puts `tests/shell/bin/` ahead of
   PATH so bare-name add-on binaries (`iprange`, …) hit deterministic shims; fixtures in
-  `tests/shell/fixtures/`. Gated in pre-commit + CI (`test.yml`). Run: `shellspec`.
+  `tests/shell/fixtures/`. Gated in CI (`test.yml`). Run locally: `shellspec`.
 - **pytest** (`tests/`): `conftest.py` copies Unbound injected globals onto `builtins` and
   resets the `pfb` dict + DBs per test; `stubs/python/unboundmodule.py` provides a recording
   `DNSMessage` (`DNSMessage.instances`) + permissive `_Struct` qstate/env. `make_qstate()` in

--- a/tests/shell/README.md
+++ b/tests/shell/README.md
@@ -18,7 +18,7 @@ shellspec --kcov              # with coverage (writes ./coverage/, needs kcov)
 
 Install per [`CONTRIBUTING.md`](../../CONTRIBUTING.md) ("Shell tests (shellspec)"),
 which pins the version CI verifies; `kcov` is only needed for `--kcov`.
-The pre-commit hook and CI run the suite automatically when `shellspec` is present.
+CI runs the suite automatically; local runs are explicit.
 
 ## Layout
 

--- a/tests/shell/precommit_composer_vendor_spec.sh
+++ b/tests/shell/precommit_composer_vendor_spec.sh
@@ -16,30 +16,26 @@ Describe '.githooks/pre-commit Composer vendor guard'
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitphpstub.XXXXXX")"
     checker_marker="$stubdir/checker-ran"
     php_marker="$stubdir/php-ran"
-    phpstan_marker="$stubdir/phpstan-ran"
     phpcs_marker="$stubdir/phpcs-ran"
     printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$php_marker" > "$stubdir/php"
-    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$phpstan_marker" > "$repo/vendor/bin/phpstan"
     printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$phpcs_marker" > "$repo/vendor/bin/phpcs"
-    chmod +x "$stubdir/php" "$repo/vendor/bin/phpstan" "$repo/vendor/bin/phpcs"
+    chmod +x "$stubdir/php" "$repo/vendor/bin/phpcs"
     PATH="$stubdir:$PATH"
   }
   cleanup() { rm -rf "$repo" "$stubdir"; }
   Before 'make_repo'
   After 'cleanup'
 
-  It 'fails closed before PHPStan and PHPCS when the checker is unavailable'
+  It 'fails closed before PHPCS when the checker is unavailable'
     When run sh -c "cd '$repo' && sh .githooks/pre-commit"
     The status should equal 1
-    The output should not include '[pre-commit] phpstan'
     The output should not include '[pre-commit] phpcs'
     The stderr should include '[pre-commit] FAILED: composer vendor'
     Assert [ ! -e "$php_marker" ]
-    Assert [ ! -e "$phpstan_marker" ]
     Assert [ ! -e "$phpcs_marker" ]
   End
 
-  It 'runs every PHP analysis gate when the Composer vendor checker succeeds'
+  It 'runs every PHP style gate when the Composer vendor checker succeeds'
     for interpreter in python python3; do
       printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$checker_marker" > "$stubdir/$interpreter"
     done
@@ -47,11 +43,9 @@ Describe '.githooks/pre-commit Composer vendor guard'
     When run sh -c "cd '$repo' && sh .githooks/pre-commit"
     The status should equal 0
     The output should include '[pre-commit] php -l'
-    The output should include '[pre-commit] phpstan'
     The output should include '[pre-commit] phpcs'
     Assert [ -e "$checker_marker" ]
     Assert [ -e "$php_marker" ]
-    Assert [ -e "$phpstan_marker" ]
     Assert [ -e "$phpcs_marker" ]
   End
 End

--- a/tests/test_ci_refresh_composer_vendor.py
+++ b/tests/test_ci_refresh_composer_vendor.py
@@ -197,7 +197,7 @@ def test_php_staging_jobs_install_composer_before_committing() -> None:
 def test_php_staging_jobs_pin_php_from_the_version_matrix() -> None:
     """The hook's PHP gates run on a supported PHP, not on whatever the runner ships.
 
-    Scenario: .githooks/pre-commit runs php -l, PHPStan and PHPCS.
+    Scenario: .githooks/pre-commit runs php -l and PHPCS.
     Given a job that puts those gates in front of its own commit,
     when the runner image changes its default PHP,
     then the gates must still run on a version supported-versions.json ships --

--- a/tests/test_local_hook_scope.py
+++ b/tests/test_local_hook_scope.py
@@ -1,0 +1,13 @@
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_local_git_hooks_leave_tests_and_static_analysis_to_ci() -> None:
+    commands = re.compile(r"\b(pytest|phpunit|shellspec|mypy|phpstan)\b")
+
+    for name in ("pre-commit", "pre-push"):
+        hook = (ROOT / ".githooks" / name).read_text(encoding="utf-8")
+        executable = "\n".join(line for line in hook.splitlines() if not line.lstrip().startswith("#"))
+        assert not commands.search(executable), f"{name} runs a CI-only test or static-analysis command"


### PR DESCRIPTION
## Summary

- Keep pre-commit limited to fast lint, style, syntax, and policy checks.
- Leave ShellSpec, mypy, and PHPStan to CI.
- Keep pre-push unchanged and free of test suites.

## Validation

- Red/green regression: `tests/test_local_hook_scope.py`
- Targeted pytest: 12 passed
- Targeted ShellSpec: 2 examples, 0 failures
- Updated pre-commit hook: passed in 19 seconds without tests or static analysis
- Ruff, markdownlint, `sh -n`, and focused hook checks passed

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
