### PR TITLE
smoke: fail closed on branch catalogue refresh

### DIFF
--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -335,6 +335,11 @@ pfb_switch_branch() {
     log "branch switch confirmed — refreshing pkg catalogue (pkg update -f)"
     _psb_pkg_log="${_psb_log_dir}/pkg-update-branch.log"
     true > "$_psb_pkg_log"
+    _psb_retries="${PKG_LOCK_RETRIES:-12}"
+    _psb_interval="${PKG_LOCK_INTERVAL:-5}"
+    case "$_psb_retries" in '' | *[!0-9]*) _psb_retries=0 ;; esac
+    [ "$_psb_retries" -ge 1 ] || die "PKG_LOCK_RETRIES must be a positive integer"
+    case "$_psb_interval" in *[!0-9]*) die "PKG_LOCK_INTERVAL must be a non-negative integer" ;; esac
     _psb_try=1
     while true; do
         _psb_rc=0
@@ -345,12 +350,12 @@ pfb_switch_branch() {
             *'Cannot get an exclusive lock on a database'* | *'Package database is busy'*) ;;
             *) die "pkg catalogue refresh failed after branch switch (see $_psb_pkg_log)" ;;
         esac
-        if [ "$_psb_try" -ge "${PKG_LOCK_RETRIES:-12}" ]; then
-            die "pkg catalogue refresh still locked after ${PKG_LOCK_RETRIES:-12} attempts (see $_psb_pkg_log)"
+        if [ "$_psb_try" -ge "$_psb_retries" ]; then
+            die "pkg catalogue refresh still locked after ${_psb_retries} attempts (see $_psb_pkg_log)"
         fi
-        warn "pkg catalogue refresh: pkg database locked; retry ${_psb_try}/${PKG_LOCK_RETRIES:-12} in ${PKG_LOCK_INTERVAL:-5}s"
+        warn "pkg catalogue refresh: pkg database locked; retry ${_psb_try}/${_psb_retries} in ${_psb_interval}s"
         _psb_try=$((_psb_try + 1))
-        sleep "${PKG_LOCK_INTERVAL:-5}"
+        sleep "$_psb_interval"
     done
 }
 # pfb_switch_branch END

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -339,7 +339,9 @@ pfb_switch_branch() {
     _psb_interval="${PKG_LOCK_INTERVAL:-5}"
     case "$_psb_retries" in '' | *[!0-9]*) _psb_retries=0 ;; esac
     [ "$_psb_retries" -ge 1 ] || die "PKG_LOCK_RETRIES must be a positive integer"
+    [ "$_psb_retries" -le 12 ] || die "PKG_LOCK_RETRIES must be between 1 and 12"
     case "$_psb_interval" in *[!0-9]*) die "PKG_LOCK_INTERVAL must be a non-negative integer" ;; esac
+    [ "$_psb_interval" -le 5 ] || die "PKG_LOCK_INTERVAL must be between 0 and 5"
     _psb_try=1
     while true; do
         _psb_rc=0

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -333,7 +333,25 @@ pfb_switch_branch() {
     fi
 
     log "branch switch confirmed — refreshing pkg catalogue (pkg update -f)"
-    ssh_guest 'pkg update -f' 2>&1 | tee "${_psb_log_dir}/pkg-update-branch.log" || true
+    _psb_pkg_log="${_psb_log_dir}/pkg-update-branch.log"
+    true > "$_psb_pkg_log"
+    _psb_try=1
+    while true; do
+        _psb_rc=0
+        _psb_out=$(ssh_guest 'pkg update -f' 2>&1) || _psb_rc=$?
+        printf '%s\n' "$_psb_out" | tee -a "$_psb_pkg_log"
+        [ "$_psb_rc" -eq 0 ] && return 0
+        case "$_psb_out" in
+            *'Cannot get an exclusive lock on a database'* | *'Package database is busy'*) ;;
+            *) die "pkg catalogue refresh failed after branch switch (see $_psb_pkg_log)" ;;
+        esac
+        if [ "$_psb_try" -ge "${PKG_LOCK_RETRIES:-12}" ]; then
+            die "pkg catalogue refresh still locked after ${PKG_LOCK_RETRIES:-12} attempts (see $_psb_pkg_log)"
+        fi
+        warn "pkg catalogue refresh: pkg database locked; retry ${_psb_try}/${PKG_LOCK_RETRIES:-12} in ${PKG_LOCK_INTERVAL:-5}s"
+        _psb_try=$((_psb_try + 1))
+        sleep "${PKG_LOCK_INTERVAL:-5}"
+    done
 }
 # pfb_switch_branch END
 

--- a/tests/shell/image_upgrade_branch_retry_config_spec.sh
+++ b/tests/shell/image_upgrade_branch_retry_config_spec.sh
@@ -1,0 +1,36 @@
+#shellcheck shell=sh
+
+Describe 'image-upgrade.sh branch refresh retry configuration'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  run_with_config() {
+    _retries="$1" _interval="$2" sh -c '
+      log()  { :; }
+      warn() { :; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      ssh_guest() {
+        case "$1" in
+          "/usr/local/sbin/pfSense-repoc -p") printf "2_9_0\n" ;;
+          pfSsh.php) cat >/dev/null; printf "PFB_BRANCH_OK\n" ;;
+          "pkg update -f") printf "catalogue refreshed\n" ;;
+        esac
+      }
+      eval "$(sed -n "/^# pfb_switch_branch BEGIN/,/^# pfb_switch_branch END/p" "$1")"
+      PKG_LOCK_RETRIES="$_retries"
+      PKG_LOCK_INTERVAL="$_interval"
+      pfb_switch_branch 2_9_0 "$2"
+    ' _ "$SCRIPT" "${SHELLSPEC_TMPBASE:-/tmp}"
+  }
+
+  It 'rejects a non-integer retry cap before refreshing'
+    When call run_with_config invalid 0
+    The status should be failure
+    The stderr should include 'PKG_LOCK_RETRIES must be a positive integer'
+  End
+
+  It 'rejects a non-integer retry interval before refreshing'
+    When call run_with_config 2 invalid
+    The status should be failure
+    The stderr should include 'PKG_LOCK_INTERVAL must be a non-negative integer'
+  End
+End

--- a/tests/shell/image_upgrade_branch_retry_config_spec.sh
+++ b/tests/shell/image_upgrade_branch_retry_config_spec.sh
@@ -3,12 +3,22 @@
 Describe 'image-upgrade.sh branch refresh retry configuration'
   SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
 
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgbranch-config.XXXXXX")"
+    CALLS="${WORK}/calls"
+    export WORK CALLS
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
   run_with_config() {
     _retries="$1" _interval="$2" sh -c '
       log()  { :; }
       warn() { :; }
       die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
       ssh_guest() {
+        printf "%s\n" "$1" >> "$CALLS"
         case "$1" in
           "/usr/local/sbin/pfSense-repoc -p") printf "2_9_0\n" ;;
           pfSsh.php) cat >/dev/null; printf "PFB_BRANCH_OK\n" ;;
@@ -19,18 +29,20 @@ Describe 'image-upgrade.sh branch refresh retry configuration'
       PKG_LOCK_RETRIES="$_retries"
       PKG_LOCK_INTERVAL="$_interval"
       pfb_switch_branch 2_9_0 "$2"
-    ' _ "$SCRIPT" "${SHELLSPEC_TMPBASE:-/tmp}"
+    ' _ "$SCRIPT" "$WORK"
   }
 
   It 'rejects a non-integer retry cap before refreshing'
     When call run_with_config invalid 0
     The status should be failure
     The stderr should include 'PKG_LOCK_RETRIES must be a positive integer'
+    The contents of file "$CALLS" should not include 'pkg update -f'
   End
 
   It 'rejects a non-integer retry interval before refreshing'
     When call run_with_config 2 invalid
     The status should be failure
     The stderr should include 'PKG_LOCK_INTERVAL must be a non-negative integer'
+    The contents of file "$CALLS" should not include 'pkg update -f'
   End
 End

--- a/tests/shell/image_upgrade_branch_retry_config_spec.sh
+++ b/tests/shell/image_upgrade_branch_retry_config_spec.sh
@@ -45,4 +45,18 @@ Describe 'image-upgrade.sh branch refresh retry configuration'
     The stderr should include 'PKG_LOCK_INTERVAL must be a non-negative integer'
     The contents of file "$CALLS" should not include 'pkg update -f'
   End
+
+  It 'rejects a retry cap above the production maximum before refreshing'
+    When call run_with_config 13 0
+    The status should be failure
+    The stderr should include 'PKG_LOCK_RETRIES must be between 1 and 12'
+    The contents of file "$CALLS" should not include 'pkg update -f'
+  End
+
+  It 'rejects a retry interval above the production maximum before refreshing'
+    When call run_with_config 2 6
+    The status should be failure
+    The stderr should include 'PKG_LOCK_INTERVAL must be between 0 and 5'
+    The contents of file "$CALLS" should not include 'pkg update -f'
+  End
 End

--- a/tests/shell/image_upgrade_branch_spec.sh
+++ b/tests/shell/image_upgrade_branch_spec.sh
@@ -9,7 +9,9 @@ Describe 'image-upgrade.sh update-branch selection'
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgbranch.XXXXXX")"
     CALLS="${WORK}/calls"
     PAYLOAD="${WORK}/payload"
-    export WORK CALLS PAYLOAD
+    COUNT="${WORK}/count"
+    printf '0\n' > "$COUNT"
+    export WORK CALLS PAYLOAD COUNT
   }
   teardown() { rm -rf "$WORK"; }
   BeforeEach 'setup'
@@ -37,13 +39,34 @@ Describe 'image-upgrade.sh update-branch selection'
               printf "PFB_BRANCH_OK\n"
             fi
             ;;
-          "pkg update -f") printf "catalogue refreshed\n" ;;
+          "pkg update -f")
+            _n=$(cat "$COUNT"); _n=$((_n + 1)); printf "%s\n" "$_n" > "$COUNT"
+            case "$_mode" in
+              transient-lock)
+                if [ "$_n" -eq 1 ]; then
+                  printf "%s\n" "pkg: Cannot get an exclusive lock on a database, it is locked by another process"
+                  return 1
+                fi
+                ;;
+              permanent-lock)
+                printf "%s\n" "pkg: Package database is busy while closing!"
+                return 1
+                ;;
+              refresh-error)
+                printf "%s\n" "REFRESH FAILED"
+                return 9
+                ;;
+            esac
+            printf "catalogue refreshed\n"
+            ;;
         esac
       }
       # New code exposes its helper between these markers. On the old code the
       # extraction is empty and the unchanged main-flow block still executes,
       # giving a genuine RED against its pkg_list_repos() behavior.
       eval "$(sed -n "/^# pfb_switch_branch BEGIN/,/^# pfb_switch_branch END/p" "$1")"
+      PKG_LOCK_RETRIES=2
+      PKG_LOCK_INTERVAL=0
       BRANCH="$_requested"
       LOCAL_DIR="$2"
       eval "$(sed -n "/^# --- optional: switch the pfSense update branch/,/^# --- check whether an OS upgrade is available/p" "$1")"
@@ -62,6 +85,36 @@ Describe 'image-upgrade.sh update-branch selection'
     The contents of file "$CALLS" should include '/usr/local/sbin/pfSense-repoc -p'
     The contents of file "$PAYLOAD" should include "config_set_path('system/pkg_repo_conf_path', '2_9_0')"
     The contents of file "$PAYLOAD" should include 'pkg_switch_repo()'
+    The contents of file "${WORK}/pkg-update-branch.log" should include 'catalogue refreshed'
+    The contents of file "$COUNT" should equal '1'
+  End
+
+  It 'retries a transient pkg database lock and preserves every attempt'
+    When call run_branch_block transient-lock 2_9_0
+    The status should be success
+    The stderr should include 'pkg database locked'
+    The output should include 'REACHED-AFTER-BRANCH'
+    The contents of file "${WORK}/pkg-update-branch.log" should include 'Cannot get an exclusive lock'
+    The contents of file "${WORK}/pkg-update-branch.log" should include 'catalogue refreshed'
+    The contents of file "$COUNT" should equal '2'
+  End
+
+  It 'fails closed when the pkg database lock never clears'
+    When call run_branch_block permanent-lock 2_9_0
+    The status should be failure
+    The stderr should include 'still locked after 2 attempts'
+    The output should not include 'REACHED-AFTER-BRANCH'
+    The contents of file "${WORK}/pkg-update-branch.log" should include 'Package database is busy'
+    The contents of file "$COUNT" should equal '2'
+  End
+
+  It 'fails closed without retrying a non-lock catalogue refresh error'
+    When call run_branch_block refresh-error 2_9_0
+    The status should be failure
+    The stderr should include 'pkg catalogue refresh failed'
+    The output should not include 'REACHED-AFTER-BRANCH'
+    The contents of file "${WORK}/pkg-update-branch.log" should include 'REFRESH FAILED'
+    The contents of file "$COUNT" should equal '1'
   End
 
   It 'rejects an unknown branch before changing pfSense configuration'


### PR DESCRIPTION
## Summary

- Retry only known transient pkg database lock failures after switching a pfSense update branch.
- Preserve every catalogue-refresh attempt in `pkg-update-branch.log`.
- Stop before `pfSense-upgrade -c` when refresh fails or the bounded lock retry is exhausted.

## Verification

- Red: `shellspec --shell dash tests/shell/image_upgrade_branch_spec.sh` — 8 examples, 3 failures on pre-fix production; frozen test hash `b15ba1d871d69ebf03cfc2481e1394508d7286ef`.
- Review-fix red: current retry-config test on pre-fix `78ad2889` — 4 examples, 2 failures; frozen hash `8bc1297a82cdb9df6d7f9e94d37b785b9209f41e`.
- Green: focused branch and retry-config suites — 12 examples, 0 failures; hashes `b15ba1d871d69ebf03cfc2481e1394508d7286ef` and `8bc1297a82cdb9df6d7f9e94d37b785b9209f41e`.
- `scripts/agent/run-gates.sh --diff origin/devel` — PASS (`sh -n`, ShellCheck, full dash ShellSpec).
- Independent Standards and Spec review axes — clean after two resolved findings.

Fixes #2304

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
