### PR TITLE
release: keep build record outside source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1177,7 +1177,7 @@ jobs:
               "build_input_digest": "",
           }
           record["build_input_digest"] = build_input_digest(record)
-          Path("build-record.json").write_text(
+          Path(os.environ["RUNNER_TEMP"], "build-record.json").write_text(
               json.dumps(record, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n",
               encoding="utf-8",
           )
@@ -1202,10 +1202,9 @@ jobs:
           EXTRA_PKGS:   ${{ toJson(matrix.extra_pkgs) }}
         run: |
           set -eu
-          # Place the run-keyed out dir under $GITHUB_WORKSPACE/out so the
-          # rename step below finds this leg's .pkg without any path remapping.
+          # Keep generated Ports and package trees outside the pinned source checkout.
           # Run-body export, not an env: map value (issue #2231).
-          export PFB_RUN_ROOT="$GITHUB_WORKSPACE/out"
+          export PFB_RUN_ROOT="$RUNNER_TEMP/pfb-runs"
           export LEG
           RUN_ID="$(sh scripts/select-box.sh --print-id)"
           export RUN_ID
@@ -1220,7 +1219,7 @@ jobs:
             --py-flavor  "$PY" \
             --php        "$PHP" \
             --pkgversion "$PORTVERSION" \
-            --build-record "$GITHUB_WORKSPACE/build-record.json")"
+            --build-record "$RUNNER_TEMP/build-record.json")"
 
           PKG_DIR="$(dirname "$PKG")"
           echo "Built for FreeBSD ${MAJOR}:"

--- a/tests/test_issue2143_review_contract.py
+++ b/tests/test_issue2143_review_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 import textwrap
 from pathlib import Path
@@ -24,9 +25,11 @@ def _input_block(name: str) -> str:
     return "\n".join(block)
 
 
-def test_release_build_record_keeps_native_package_identity() -> None:
+def test_release_build_outputs_keep_source_checkout_clean_and_native_identity() -> None:
     assert '"destinations":' not in RELEASE
-    assert '--build-record "$GITHUB_WORKSPACE/build-record.json"' in RELEASE
+    assert '--build-record "$RUNNER_TEMP/build-record.json"' in RELEASE
+    assert 'export PFB_RUN_ROOT="$RUNNER_TEMP/pfb-runs"' in RELEASE
+    assert 'export PFB_RUN_ROOT="$GITHUB_WORKSPACE/out"' not in RELEASE
     assert 'RENAMED="${PKG_DIR}/${BASE}-${VARIANT}-${PFSENSE_VERSION}.pkg"' in RELEASE
     assert 'RENAMED_DEP="${DEP_PKG_DIR}/${DEP_BASE}-${VARIANT}-${PFSENSE_VERSION}.pkg"' in RELEASE
     record_step = RELEASE.split("name: Write the destination-bound build record", 1)[1]
@@ -66,6 +69,7 @@ def test_release_build_leg_passes_variant_to_builder(tmp_path: Path) -> None:
         "PHP": "8.3",
         "PORTVERSION": "4.0.1.a1",
         "GITHUB_WORKSPACE": str(ROOT),
+        "RUNNER_TEMP": str(tmp_path),
     }
     completed = subprocess.run(
         ["sh", "-c", textwrap.dedent(invocation.replace("sh scripts/build-leg.sh", f"sh {fake_builder}"))],
@@ -92,5 +96,54 @@ def test_release_build_leg_passes_variant_to_builder(tmp_path: Path) -> None:
         "--pkgversion",
         "4.0.1.a1",
         "--build-record",
-        f"{ROOT}/build-record.json",
+        f"{tmp_path}/build-record.json",
     ]
+
+
+def test_release_build_leg_places_generated_trees_outside_source(tmp_path: Path) -> None:
+    block = RELEASE.split("      - name: Build the .pkg via build-leg.sh", 1)[1]
+    invocation = textwrap.dedent(block.split("        run: |\n", 1)[1].split("          PKG_DIR=", 1)[0])
+    fake_dir = tmp_path / "fake scripts;safe"
+    fake_dir.mkdir()
+    fake_builder = fake_dir / "build-leg.sh"
+    fake_selector = fake_dir / "select-box.sh"
+    run_root_capture = tmp_path / "run-root"
+    fake_builder.write_text(
+        "#!/bin/sh\nprintf '%s\\n' \"$PFB_RUN_ROOT\" > \"$RUN_ROOT_CAPTURE\"\nprintf '%s\\n' result.pkg\n",
+        encoding="utf-8",
+    )
+    fake_builder.chmod(0o755)
+    fake_selector.write_text("#!/bin/sh\nprintf '%s\\n' release-test-run\n", encoding="utf-8")
+    fake_selector.chmod(0o755)
+    completed = subprocess.run(
+        [
+            "sh",
+            "-c",
+            invocation.replace("sh scripts/select-box.sh", f"sh {shlex.quote(str(fake_selector))}").replace(
+                "sh scripts/build-leg.sh", f"sh {shlex.quote(str(fake_builder))}"
+            ),
+        ],
+        cwd=ROOT,
+        env=os.environ
+        | {
+            "RUN_ROOT_CAPTURE": str(run_root_capture),
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_WORKSPACE": str(ROOT),
+            "LEG": "CE-2.8",
+            "MAJOR": "15",
+            "PHP": "8.3",
+            "PY": "py311",
+            "PKG_CHANNEL": "edge",
+            "VARIANT": "CE",
+            "PORTS_SHA": "ports-sha",
+            "ABI": "FreeBSD:15:amd64",
+            "PORTVERSION": "4.0.0.a1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    run_root = Path(run_root_capture.read_text(encoding="utf-8").strip())
+    assert run_root == tmp_path / "pfb-runs"
+    assert not run_root.is_relative_to(ROOT)

--- a/tests/test_issue2143_review_round2.py
+++ b/tests/test_issue2143_review_round2.py
@@ -36,6 +36,8 @@ def test_build_record_step_exports_ports_sha_to_the_python_child(tmp_path: Path)
     fake_git.chmod(0o755)
     workdir = tmp_path / "work"
     workdir.mkdir()
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
     completed = subprocess.run(
         ["sh", "-c", _build_record_script()],
         cwd=workdir,
@@ -44,6 +46,7 @@ def test_build_record_step_exports_ports_sha_to_the_python_child(tmp_path: Path)
             "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
             "PYTHONPATH": str(ROOT),
             "GITHUB_ENV": str(tmp_path / "github-env"),
+            "RUNNER_TEMP": str(runner_temp),
             "TAG": "v4.0.0",
             "CHANNEL": "stable",
             "SOURCE": "release/4.0",
@@ -58,7 +61,8 @@ def test_build_record_step_exports_ports_sha_to_the_python_child(tmp_path: Path)
         check=False,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    record = json.loads((workdir / "build-record.json").read_text(encoding="utf-8"))
+    assert not (workdir / "build-record.json").exists()
+    record = json.loads((runner_temp / "build-record.json").read_text(encoding="utf-8"))
     assert record["freebsd_ports_sha"] == "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
 


### PR DESCRIPTION
## Summary

- write each matrix row's destination-bound build record under `RUNNER_TEMP`
- keep its generated Ports and package trees under `RUNNER_TEMP` too
- pass that external path unchanged to the portable package builder
- pin the path and source-cleanliness contract in the existing workflow tests

## Root cause

The Release workflow wrote `build-record.json` and the run-keyed Ports/package trees into the pinned source checkout before invoking the portable builder. Its fail-closed source attestation correctly rejected those untracked changes.

## Verification

- Frozen RED 1: 3 focused failures with test SHA-256 values `88da4f348615b37388dc5bf795bb4596032aa20e65e3c8b157d20804bad1fc86` and `529a2bc56a645d3f90a8d03ff645600967b1f7e9c3a5e07661b0849cb1513a85`; GREEN: 9 passed unchanged
- Frozen RED 2: 1 focused run-root failure with test SHA-256 `49440d270c5dddae9f1b61a2967410fd9aadfdbf4f9ef037c9243f6889e4f0f5`; GREEN: 9 passed unchanged
- Executed-step regression check: 10 focused tests passed and proved the effective run root is outside the source checkout
- Record parity: old and new steps emitted identical 556-byte records, SHA-256 `062103aef29f2f686d7132c985aa56b8f4471cf980af61505e0fcc5005546afa`
- Release contract suite: 398 passed
- Canonical gate: 5,060 passed; six environment-only failures reran outside sandbox with scrubbed Git config, 184 passed

Closes #2329

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build records and generated build files are now stored in the runner’s temporary directory during releases, keeping the workspace clean.
  * Release verification now confirms generated files remain outside the source checkout and checks their temporary locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->