### PR TITLE
ci: fix release asset upload loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1376,7 +1376,7 @@ jobs:
           # artifact, and merge-multiple downloads them all flat under pkgs/ --
           # a non-recursive pkgs/*.pkg glob would already find them, but find
           # -type f is used here (and above) to stay robust either way.
-          find pkgs -type f -name "*.pkg" -print0 | while IFS= read -r -d '' f; do
+          find pkgs -type f -name "*.pkg" -print | while IFS= read -r f; do
             echo "Uploading: $(basename "$f")"
             gh release upload "$TAG" "$f" --clobber
           done

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -484,6 +484,49 @@ def test_attach_pkgs_downloads_every_leg_by_pattern_with_merge() -> None:
     assert "merge-multiple: true" in step_text, step_text
 
 
+def test_attach_pkgs_upload_step_runs_under_posix_sh(tmp_path: Path) -> None:
+    script = _step_run_script(_step(_jobs(RELEASE_WORKFLOW)["attach-pkgs"], "Append .pkg files"))
+    assert "read -r -d" not in script
+    pkg_dir = tmp_path / "pkgs" / "CE row;safe"
+    pkg_dir.mkdir(parents=True)
+    packages = [pkg_dir / "first package.pkg", pkg_dir / "second.pkg"]
+    for package in packages:
+        package.touch()
+
+    fake_bin = tmp_path / "fake bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text('#!/bin/sh\nprintf \'%s\\0\' "$@" >> "$UPLOAD_LOG"\n', encoding="utf-8")
+    fake_gh.chmod(0o755)
+    upload_log = tmp_path / "uploads"
+    env = os.environ | {
+        "GH_TOKEN": "test-token",
+        "TAG": "v4.0.0.a1",
+        "UPLOAD_LOG": str(upload_log),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+    }
+
+    completed = subprocess.run(
+        ["dash", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    args = upload_log.read_bytes().split(b"\0")[:-1]
+    calls = {tuple(args[offset : offset + 5]) for offset in range(0, len(args), 5)}
+    assert calls == {
+        (b"release", b"upload", b"v4.0.0.a1", os.fsencode(package.relative_to(tmp_path)), b"--clobber")
+        for package in packages
+    }
+
+    fake_gh.write_text("#!/bin/sh\nexit 7\n", encoding="utf-8")
+    failed = subprocess.run(["dash", "-c", script], cwd=tmp_path, env=env, capture_output=True, text=True)
+    assert failed.returncode != 0, failed.stdout + failed.stderr
+
+
 # --------------------------------------------------------------------------- #
 # ui-suite / smoke-suite: re-enabled, gated on build-pkgs-portable, exact prefix
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- replace the Bash-only `read -d` release-asset loop with POSIX `read`
- execute the extracted workflow step under `dash`
- prove hostile package paths are quoted and upload failures propagate

Closes #2331.

## Root cause

The release job uses POSIX `sh`, but its package loop used `read -d ''`. In run 31753462486, dash rejected `-d`; the pipeline still returned success, so the draft healthcheck later found zero package assets.

## Test-first evidence

Frozen test file SHA-256: `75590ac6d7aecd56787a71fbf16bf08eaf49f826b608571037ceb784dc51705f`

- RED before workflow edit: `read -r -d` portability assertion failed
- GREEN unchanged after edit: focused regression passed
- release workflow tests: 225 passed
- Ruff: passed
- actionlint: passed
- `scripts/agent/run-gates.sh --diff origin/devel`: passed

## Recovery

The six exact artifacts from run 31753462486 were downloaded and manually attached to the still-draft `v4.0.0.a1` Release. Publishing and package-catalogue mutation remain untouched.
