### PR TITLE
tests: cover off-branch release tags

### DIFF
--- a/tests/test_issue2143_git_classifier.py
+++ b/tests/test_issue2143_git_classifier.py
@@ -55,6 +55,25 @@ def test_classifier_validates_selected_sha_before_tag_classification(tmp_path: P
     )
 
 
+def test_classifier_rejects_tag_commit_off_release_branch(tmp_path: Path) -> None:
+    repo, _anchor, _current = _repo_with_release_line(tmp_path)
+    _git(repo, "checkout", "-q", "main")
+    off_branch = _commit(repo, "off branch")
+    _git(
+        repo,
+        "tag",
+        "-a",
+        "-m",
+        "testing",
+        "-m",
+        "pfBlockerNG-Release-Channel: testing",
+        "v4.0.1.a1",
+        off_branch,
+    )
+    with pytest.raises(ValueError, match="is not reachable from"):
+        derive_destinations_from_git("v4.0.1.a1", "release/4.0", repo, current_commit=off_branch)
+
+
 def test_classifier_rejects_moved_existing_tag(tmp_path: Path) -> None:
     repo, _anchor, current = _repo_with_release_line(tmp_path)
     moved = _commit(repo, "moved tag")


### PR DESCRIPTION
## Summary

- Add a real Git fixture whose selected release tag commit is off its release branch.
- Assert the existing ancestry guard rejects it with the documented error.

## Verification

- `python3 -m pytest -q tests/test_issue2143_git_classifier.py` — 10 passed
- `env -u CODEX_THREAD_ID scripts/agent/run-gates.sh --diff origin/devel` — pytest, ruff check, ruff format, and mypy passed

Fixes #2254

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release validation to reject annotated tags whose commits aren’t reachable from the selected release branch, even when supplied as the current source commit.

* **Tests**
  * Added regression coverage for this release-tag validation scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->