### PR TITLE
tests: keep mutating Alerts flow out of ui_render tier

### DIFF
--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -312,7 +312,6 @@ def test_dnsbl_remove_rejects_missing_type(
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.ui_render
 def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,


### PR DESCRIPTION
## Summary

- remove the `ui_render` marker from the mutating Alerts whitelist flow
- retain the module-level `ui_e2e` marker and all state-transition assertions

## Verification

- RED: Tier-A exclusion assertion exited 1 because `ui_render` collected the test
- GREEN: same assertion exited 0 with no test collected; `ui_e2e` collected exactly the test
- `python3 -m pytest -q`: 5068 passed, 4 skipped
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS
- live pfSense Tier B: 1 passed, 607 deselected

Fixes #2296

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated alert-related test coverage by removing an unnecessary test classification.
  * Test behavior and validation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->