### PR TITLE
scripts: exclude nested impacted tests

### DIFF
--- a/scripts/impacted-tests.sh
+++ b/scripts/impacted-tests.sh
@@ -15,10 +15,8 @@
 # (which a live-VM suite can't map automatically — the code runs on the guest,
 # out of any runner-side coverage).
 #
-# The `tests/smoke/test_*.py` glob deliberately does NOT match `tests/smoke/ui/`
-# tests: the literal `test_` in the pattern must follow `$dir/` directly, and a
-# ui/ path has `ui/` there instead — so the smoke and UI workflows each pick up
-# only their own changed tests.
+# Only direct `TEST_DIR/test_*.py` modules match; subdirectories are excluded
+# before the shell glob, whose `*` can otherwise cross `/`.
 #
 # Test seam: PFB_IMPACTED_CHANGED_FILES (newline-separated paths) overrides the
 # git diff, so the pure filtering is exercisable without a git fixture.
@@ -60,6 +58,7 @@ printf '%s\n' "$changed" | {
 	while IFS= read -r f; do
 		[ -n "$f" ] || continue
 		case "$f" in
+			"$dir"/*/*) continue ;;
 			"$dir"/test_*.py) ;;   # a direct test module of THIS dir
 			*) continue ;;
 		esac

--- a/tests/shell/impacted_tests_spec.sh
+++ b/tests/shell/impacted_tests_spec.sh
@@ -21,8 +21,9 @@ tests/smoke/test_killstates.py"
       The output should equal 'test_dns_redirect or test_killstates'
     End
 
-    It 'excludes the ui/ subtree, src, and non-test infra (owned elsewhere / unmappable)'
+    It 'excludes subtrees, src, and non-test infra (owned elsewhere / unmappable)'
       changed="tests/smoke/test_dns_redirect.py
+tests/smoke/test_group/helper.py
 tests/smoke/ui/test_render.py
 src/usr/local/pkg/pfblockerng/pfb_unbound.py
 tests/smoke/conftest.py"
@@ -37,9 +38,10 @@ tests/smoke/conftest.py"
   End
 
   Describe 'ui dir (tests/smoke/ui)'
-    It 'picks only the changed UI test modules, not the smoke-root ones'
+    It 'picks only direct changed UI test modules, not smoke-root modules or subtrees'
       changed="tests/smoke/test_dns_redirect.py
-tests/smoke/ui/test_render.py"
+tests/smoke/ui/test_render.py
+tests/smoke/ui/test_group/helper.py"
       When call run_with "$changed" tests/smoke/ui
       The output should equal 'test_render'
     End


### PR DESCRIPTION
## Summary

- reject nested paths before matching direct impacted test modules
- cover smoke-root and UI `test_*` subdirectories
- correct the selector contract comment

## Verification

- RED: `shellspec tests/shell/impacted_tests_spec.sh` — 10 examples, 2 failures (`helper` over-selected for smoke and UI)
- frozen test hash: `0edb48471464b250ad871e78f1e68fc86086dd9a`
- GREEN: `shellspec tests/shell/impacted_tests_spec.sh` — 10 examples, 0 failures; same test hash
- `scripts/agent/run-gates.sh --diff origin/devel` — PASS after final rebase

Fixes #2236

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved impacted-test selection to include only direct test modules.
  * Excluded tests located in nested subdirectories from impacted-test results.

* **Tests**
  * Added coverage confirming nested smoke and UI test directories are excluded.
  * Verified direct test modules continue to be selected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->