### PR TITLE
test: handle hostile tracked PHP paths (#2235)

### DIFF
--- a/tests/php/LogNowTokenRetiredHostilePathTest.php
+++ b/tests/php/LogNowTokenRetiredHostilePathTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class LogNowTokenRetiredHostilePathTest extends TestCase
+{
+	private string $root;
+
+	protected function setUp(): void
+	{
+		$this->root = sys_get_temp_dir() . '/pfb_log_now_path_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($this->root . '/tests/php', 0755, true));
+		$this->assertTrue(mkdir($this->root . '/src', 0755, true));
+		$this->assertTrue(copy(__DIR__ . '/LogNowTokenRetiredTest.php', $this->root . '/tests/php/LogNowTokenRetiredTest.php'));
+		$this->assertNotFalse(file_put_contents($this->root . '/src/café.inc', "<?php\npfb_logger('x', 1, ' [ NOW ]');\n"));
+
+		$output = [];
+		exec('git -C ' . escapeshellarg($this->root) . ' init -q 2>&1', $output, $exit);
+		$this->assertSame(0, $exit, 'scratch git init failed: ' . implode("\n", $output));
+		$output = [];
+		exec('git -C ' . escapeshellarg($this->root) . ' config core.quotePath true 2>&1', $output, $exit);
+		$this->assertSame(0, $exit, 'scratch git config failed: ' . implode("\n", $output));
+		$output = [];
+		exec('git -C ' . escapeshellarg($this->root) . ' add -- src 2>&1', $output, $exit);
+		$this->assertSame(0, $exit, 'scratch git add failed: ' . implode("\n", $output));
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->root);
+	}
+
+	public function testRetiredTokenScanReportsHostileTrackedPath(): void
+	{
+		$phpunit = dirname(__DIR__, 2) . '/vendor/bin/phpunit';
+		$test = $this->root . '/tests/php/LogNowTokenRetiredTest.php';
+
+		exec(escapeshellarg($phpunit) . ' --colors=never --no-configuration ' . escapeshellarg($test) . ' 2>&1', $output, $exit);
+
+		$this->assertSame(1, $exit, "retired-token scan must fail for the hostile tracked path:\n" . implode("\n", $output));
+		$this->assertStringContainsString('src/café.inc:2', implode("\n", $output));
+	}
+}

--- a/tests/php/LogNowTokenRetiredHostilePathTest.php
+++ b/tests/php/LogNowTokenRetiredHostilePathTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/ProcessRunner.php';
+
 final class LogNowTokenRetiredHostilePathTest extends TestCase
 {
 	private string $root;
@@ -12,19 +14,16 @@ final class LogNowTokenRetiredHostilePathTest extends TestCase
 	{
 		$this->root = sys_get_temp_dir() . '/pfb_log_now_path_' . bin2hex(random_bytes(8));
 		$this->assertTrue(mkdir($this->root . '/tests/php', 0755, true));
+		$this->assertTrue(mkdir($this->root . '/tests/php/support', 0755, true));
 		$this->assertTrue(mkdir($this->root . '/src', 0755, true));
 		$this->assertTrue(copy(__DIR__ . '/LogNowTokenRetiredTest.php', $this->root . '/tests/php/LogNowTokenRetiredTest.php'));
+		$this->assertTrue(copy(__DIR__ . '/support/ProcessRunner.php', $this->root . '/tests/php/support/ProcessRunner.php'));
 		$this->assertNotFalse(file_put_contents($this->root . '/src/café.inc', "<?php\npfb_logger('x', 1, ' [ NOW ]');\n"));
 
-		$output = [];
-		exec('git -C ' . escapeshellarg($this->root) . ' init -q 2>&1', $output, $exit);
-		$this->assertSame(0, $exit, 'scratch git init failed: ' . implode("\n", $output));
-		$output = [];
-		exec('git -C ' . escapeshellarg($this->root) . ' config core.quotePath true 2>&1', $output, $exit);
-		$this->assertSame(0, $exit, 'scratch git config failed: ' . implode("\n", $output));
-		$output = [];
-		exec('git -C ' . escapeshellarg($this->root) . ' add -- src 2>&1', $output, $exit);
-		$this->assertSame(0, $exit, 'scratch git add failed: ' . implode("\n", $output));
+		foreach ([['init', '-q'], ['config', 'core.quotePath', 'true'], ['add', '--', 'src']] as $arguments) {
+			$result = pfb_test_run_process(['git', '-C', $this->root, ...$arguments], 10.0, pfb_test_scrubbed_git_env());
+			$this->assertSame(0, $result['exit'], 'scratch git failed: ' . $result['stderr']);
+		}
 	}
 
 	protected function tearDown(): void
@@ -37,9 +36,37 @@ final class LogNowTokenRetiredHostilePathTest extends TestCase
 		$phpunit = dirname(__DIR__, 2) . '/vendor/bin/phpunit';
 		$test = $this->root . '/tests/php/LogNowTokenRetiredTest.php';
 
-		exec(escapeshellarg($phpunit) . ' --colors=never --no-configuration ' . escapeshellarg($test) . ' 2>&1', $output, $exit);
+		$result = pfb_test_run_process([$phpunit, '--colors=never', '--no-configuration', $test], 10.0);
 
-		$this->assertSame(1, $exit, "retired-token scan must fail for the hostile tracked path:\n" . implode("\n", $output));
-		$this->assertStringContainsString('src/café.inc:2', implode("\n", $output));
+		$this->assertSame(1, $result['exit'], "retired-token scan must fail for the hostile tracked path:\n{$result['stdout']}{$result['stderr']}");
+		$this->assertStringContainsString('src/café.inc:2', $result['stdout'] . $result['stderr']);
+	}
+
+	public function testProcessRunnerKillsChildAtHardDeadline(): void
+	{
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('STUCK/ENVIRONMENT: process exceeded hard deadline');
+
+		pfb_test_run_process([PHP_BINARY, '-r', 'sleep(5);'], 0.05);
+	}
+
+	public function testScratchGitIgnoresInheritedRepositoryContext(): void
+	{
+		$originalGitDir = getenv('GIT_DIR');
+		$originalGlobalConfig = getenv('GIT_CONFIG_GLOBAL');
+		putenv('GIT_DIR=/foreign/repository');
+		putenv('GIT_CONFIG_GLOBAL=/foreign/config');
+		try {
+			$environment = pfb_test_scrubbed_git_env();
+		} finally {
+			putenv($originalGitDir === false ? 'GIT_DIR' : "GIT_DIR={$originalGitDir}");
+			putenv($originalGlobalConfig === false ? 'GIT_CONFIG_GLOBAL' : "GIT_CONFIG_GLOBAL={$originalGlobalConfig}");
+		}
+		$this->assertArrayNotHasKey('GIT_DIR', $environment);
+		$this->assertSame('/dev/null', $environment['GIT_CONFIG_GLOBAL']);
+		$this->assertSame('/dev/null', $environment['GIT_CONFIG_SYSTEM']);
+
+		$result = pfb_test_run_process(['git', '-C', $this->root, 'ls-files', '-z', '--', 'src'], 10.0, $environment);
+		$this->assertSame("src/café.inc\0", $result['stdout']);
 	}
 }

--- a/tests/php/LogNowTokenRetiredHostilePathTest.php
+++ b/tests/php/LogNowTokenRetiredHostilePathTest.php
@@ -36,7 +36,7 @@ final class LogNowTokenRetiredHostilePathTest extends TestCase
 		$phpunit = dirname(__DIR__, 2) . '/vendor/bin/phpunit';
 		$test = $this->root . '/tests/php/LogNowTokenRetiredTest.php';
 
-		$result = pfb_test_run_process([$phpunit, '--colors=never', '--no-configuration', $test], 10.0);
+		$result = pfb_test_run_process([$phpunit, '--colors=never', '--no-configuration', $test], 10.0, pfb_test_scrubbed_git_env());
 
 		$this->assertSame(1, $result['exit'], "retired-token scan must fail for the hostile tracked path:\n{$result['stdout']}{$result['stderr']}");
 		$this->assertStringContainsString('src/café.inc:2', $result['stdout'] . $result['stderr']);

--- a/tests/php/LogNowTokenRetiredTest.php
+++ b/tests/php/LogNowTokenRetiredTest.php
@@ -18,8 +18,19 @@ final class LogNowTokenRetiredTest extends TestCase
 	{
 		$repoRoot = dirname(__DIR__, 2);
 
-		exec('git -C ' . escapeshellarg($repoRoot) . " ls-files -- 'src/*.php' 'src/*.inc' 2>&1", $files, $exit);
-		$this->assertSame(0, $exit, 'git ls-files must succeed to enumerate tracked src/ files; got: ' . implode("\n", $files));
+		$proc = proc_open(
+			['git', '-C', $repoRoot, 'ls-files', '-z', '--', 'src/*.php', 'src/*.inc'],
+			[1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+			$pipes
+		);
+		$this->assertIsResource($proc, 'git ls-files must start to enumerate tracked src/ files');
+		$stdout = (string) stream_get_contents($pipes[1]);
+		$stderr = (string) stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$exit = proc_close($proc);
+		$this->assertSame(0, $exit, "git ls-files must succeed to enumerate tracked src/ files; got: {$stderr}");
+		$files = array_filter(explode("\0", $stdout), static fn(string $path): bool => $path !== '');
 
 		$violations = [];
 		foreach ($files as $relpath) {

--- a/tests/php/LogNowTokenRetiredTest.php
+++ b/tests/php/LogNowTokenRetiredTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/ProcessRunner.php';
+
 /**
  * issue #1008 retired pfb_logger()'s '[ NOW ]' opt-in scrub (LogTimestampBaselineTest
  * pins the writer side); issue #1047 found 9 pfblockerng.php call sites still carrying
@@ -18,19 +20,12 @@ final class LogNowTokenRetiredTest extends TestCase
 	{
 		$repoRoot = dirname(__DIR__, 2);
 
-		$proc = proc_open(
+		$result = pfb_test_run_process(
 			['git', '-C', $repoRoot, 'ls-files', '-z', '--', 'src/*.php', 'src/*.inc'],
-			[1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
-			$pipes
+			10.0
 		);
-		$this->assertIsResource($proc, 'git ls-files must start to enumerate tracked src/ files');
-		$stdout = (string) stream_get_contents($pipes[1]);
-		$stderr = (string) stream_get_contents($pipes[2]);
-		fclose($pipes[1]);
-		fclose($pipes[2]);
-		$exit = proc_close($proc);
-		$this->assertSame(0, $exit, "git ls-files must succeed to enumerate tracked src/ files; got: {$stderr}");
-		$files = array_filter(explode("\0", $stdout), static fn(string $path): bool => $path !== '');
+		$this->assertSame(0, $result['exit'], "git ls-files must succeed to enumerate tracked src/ files; got: {$result['stderr']}");
+		$files = array_filter(explode("\0", $result['stdout']), static fn(string $path): bool => $path !== '');
 
 		$violations = [];
 		foreach ($files as $relpath) {

--- a/tests/php/support/ProcessRunner.php
+++ b/tests/php/support/ProcessRunner.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/** @return array{stdout: string, stderr: string, exit: int} */
+function pfb_test_run_process(array $command, float $timeoutSeconds = 10.0, ?array $environment = null): array
+{
+	$process = proc_open(
+		$command,
+		[0 => ['file', '/dev/null', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+		$pipes,
+		null,
+		$environment
+	);
+	if (!is_resource($process)) {
+		throw new RuntimeException('test bootstrap: failed to start `' . implode(' ', $command) . '`');
+	}
+
+	stream_set_blocking($pipes[1], false);
+	stream_set_blocking($pipes[2], false);
+	$deadline = hrtime(true) + (int) ($timeoutSeconds * 1_000_000_000);
+	$attemptLimit = max(1, (int) ceil($timeoutSeconds * 100) + 1);
+	$attempts = 0;
+	$stdout = '';
+	$stderr = '';
+
+	do {
+		$stdout .= (string) stream_get_contents($pipes[1]);
+		$stderr .= (string) stream_get_contents($pipes[2]);
+		$status = proc_get_status($process);
+		if (!$status['running']) {
+			break;
+		}
+		usleep(10_000);
+	} while (++$attempts < $attemptLimit && hrtime(true) < $deadline);
+
+	if ($status['running']) {
+		proc_terminate($process);
+		usleep(100_000);
+		$status = proc_get_status($process);
+		if ($status['running']) {
+			proc_terminate($process, 9);
+		}
+	}
+
+	$stdout .= (string) stream_get_contents($pipes[1]);
+	$stderr .= (string) stream_get_contents($pipes[2]);
+	fclose($pipes[1]);
+	fclose($pipes[2]);
+	$closeExit = proc_close($process);
+
+	if ($attempts >= $attemptLimit || hrtime(true) >= $deadline) {
+		throw new RuntimeException('STUCK/ENVIRONMENT: process exceeded hard deadline: `' . implode(' ', $command) . '`');
+	}
+
+	return ['stdout' => $stdout, 'stderr' => $stderr, 'exit' => $status['exitcode'] >= 0 ? $status['exitcode'] : $closeExit];
+}
+
+/** @return array<string, string> */
+function pfb_test_scrubbed_git_env(): array
+{
+	$environment = getenv();
+	if (!is_array($environment)) {
+		$environment = [];
+	}
+	foreach (array_keys($environment) as $name) {
+		if (str_starts_with($name, 'GIT_')) {
+			unset($environment[$name]);
+		}
+	}
+	$environment['GIT_CONFIG_GLOBAL'] = '/dev/null';
+	$environment['GIT_CONFIG_SYSTEM'] = '/dev/null';
+
+	return $environment;
+}


### PR DESCRIPTION
## Summary

- enumerate tracked PHP and INC files with `git ls-files -z`
- split the result on NUL bytes so Git never C-quotes hostile paths
- prove a tracked non-ASCII path containing the retired token is reported
- bound all added subprocess waits and isolate scratch Git from caller configuration

## Root cause

`exec()` split Git's newline listing while Git C-quoted non-ASCII and other hostile path bytes. The quoted path failed `is_file()` and silently narrowed the retired-token scan.

## Verification

- Red: `vendor/bin/phpunit tests/php/LogNowTokenRetiredHostilePathTest.php` — failed because the nested scanner exited 0 and skipped `src/café.inc`
- Frozen reproducer hash: `2b684389c352f0b6f24876f6ae531b3f1f7f1d09`
- Green: focused scanner tests — 4 tests, 37 assertions
- `scripts/agent/run-gates.sh --diff origin/devel` — all gates passed after rebase

Review follow-up: #2342 tracks the pre-existing scanner-wide inherited Git-context false green.

Fixes #2235

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for retired log-token scanning, including UTF-8 file paths and accurate path and line reporting.
  - Added validation that stalled processes are terminated at strict time limits.
  - Improved test reliability by isolating Git configuration and inherited environment settings.
  - Strengthened tracked-file discovery checks and process output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->