### PR TITLE
tests: synchronize DNSBL query expiry proof

### DIFF
--- a/tests/php/DnsblLogEventQueryAttributionTest.php
+++ b/tests/php/DnsblLogEventQueryAttributionTest.php
@@ -208,6 +208,16 @@ final class DnsblLogEventQueryAttributionTest extends TestCase
 		}
 	}
 
+	public function testReapRespondersSurfacesChildFailure(): void
+	{
+		$this->forkChild(static function (): void {
+			throw new RuntimeException('salvage cap expired / stuck or environment: waiting for the query-channel request marker');
+		});
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('salvage cap expired / stuck or environment: waiting for the query-channel request marker');
+		$this->reapResponders();
+	}
+
 	/**
 	 * Spawn a tracked process playing the query channel's Python side --
 	 * mirrors DnsblQueryClientTest::spawnResponder(). Answers with $replyTemplateJson

--- a/tests/php/DnsblQueryClientTest.php
+++ b/tests/php/DnsblQueryClientTest.php
@@ -848,7 +848,9 @@ final class DnsblQueryClientTest extends TestCase
 
 	public function testShortReplyTimeoutReturnsNullAndCleansUp(): void
 	{
-		$result = pfb_dnsbl_query('short-reply-timeout.example', 'A', 0.001);
+		// Start expiry only after publication, so scheduler latency cannot select the lock branch.
+		$now = fn (): float => file_exists($this->channel()) ? 1.0 : 0.0;
+		$result = pfb_dnsbl_query('short-reply-timeout.example', 'A', 0.001, $now);
 
 		$this->assertNull($result);
 		$logs = (string) @file_get_contents($GLOBALS['pfb']['errlog']);


### PR DESCRIPTION
## Summary

- Drive the 1 ms query-timeout row from the published request marker, so scheduler latency cannot select the lock-expiry branch.
- Prove at runtime that `reapResponders()` observes and surfaces a responder child failure before product assertions run.

## Root cause

The short-timeout test let one real-time budget cover both lock acquisition and reply waiting. Under load, the budget could expire before the request was published. The responder diagnostic pinned its callers but not the reaper body, so a valid no-op reaper mutant escaped the source-level proof.

## Evidence

Behavior-preserving baseline:

```text
DnsblQueryClientTest::testShortReplyTimeoutReturnsNullAndCleansUp
OK (1 test, 3 assertions)

DnsblLogEventQueryAttributionTest + salvage diagnostic
OK (6 tests, 61 assertions)
```

Runtime mutation proof:

```text
Valid no-op reapResponders() mutant:
Failed asserting that exception of type "RuntimeException" is thrown.
```

Affected suites after restoration:

```text
vendor/bin/phpunit tests/php/DnsblQueryClientTest.php \
  tests/php/DnsblLogEventQueryAttributionTest.php \
  tests/php/DnsblLogEventQueryAttributionSalvageDiagnosticTest.php
OK (36 tests, 209 assertions)
```

Exact rebased head, canonical CI image with `PFB_RUNNER=container` enforced:

```text
GATE PASS: python3 scripts/check_composer_vendor.py
GATE PASS: php -l tests/php/DnsblLogEventQueryAttributionTest.php
GATE PASS: php -l tests/php/DnsblQueryClientTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

Fixes #2088
Refs #1517

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
