### PR TITLE
pfblockerng: define custom-row parser metadata

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -161,11 +161,12 @@ function pfb_dnsbl_alias_count_rebuild(string $path, int $current): int {
 	return $current + (pfb_count_lines($path) ?? 0);
 }
 
-/** @return array{header:string,custom:mixed,state:string,url:string} */
+/** @return array{header:string,custom:mixed,format:string,state:string,url:string} */
 function pfb_dnsbl_custom_row(string $aliasname, mixed $custom): array {
 	return [
 		'header' => "{$aliasname}_custom",
 		'custom' => $custom,
+		'format' => 'regex',
 		'state'  => 'Enabled',
 		'url'    => 'custom',
 	];

--- a/tests/php/DnsblCustomRowStateEnabledInvariantTest.php
+++ b/tests/php/DnsblCustomRowStateEnabledInvariantTest.php
@@ -6,9 +6,9 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Issue #1323 -- custom DNSBL rows must stay Enabled so the stale Hold guard
- * cannot suppress them. The three live sync routes share one row-construction
- * decision; behavior tests exercise that decision with each route's inputs.
+ * Issues #1323/#2114 -- custom rows must stay Enabled and carry explicit parser
+ * metadata. The three live sync routes share one row-construction decision;
+ * behavior tests exercise that decision with each route's inputs.
  */
 #[CoversFunction('pfb_dnsbl_custom_row')]
 #[CoversFunction('pfb_dnsbl_hold_stale_rebuild_skip')]
@@ -20,6 +20,7 @@ final class DnsblCustomRowStateEnabledInvariantTest extends TestCase
 			[
 				'header' => 'normalization_custom',
 				'custom' => 'normal.example',
+				'format' => 'regex',
 				'state'  => 'Enabled',
 				'url'    => 'custom',
 			],
@@ -33,6 +34,7 @@ final class DnsblCustomRowStateEnabledInvariantTest extends TestCase
 			[
 				'header' => 'download_custom',
 				'custom' => ['download.example', '||ads.download.example^'],
+				'format' => 'regex',
 				'state'  => 'Enabled',
 				'url'    => 'custom',
 			],
@@ -46,11 +48,33 @@ final class DnsblCustomRowStateEnabledInvariantTest extends TestCase
 			[
 				'header' => 'ip-alias_custom',
 				'custom' => "192.0.2.1\n198.51.100.7",
+				'format' => 'regex',
 				'state'  => 'Enabled',
 				'url'    => 'custom',
 			],
 			pfb_dnsbl_custom_row('ip-alias', "192.0.2.1\n198.51.100.7")
 		);
+	}
+
+	public function testIpAliasCustomRowSelectsRegexParserWithoutDiagnostics(): void
+	{
+		$diagnostics = [];
+		set_error_handler(
+			static function (int $severity, string $message) use (&$diagnostics): bool {
+				$diagnostics[] = $message;
+				return TRUE;
+			},
+			E_WARNING | E_DEPRECATED
+		);
+		try {
+			$row = pfb_dnsbl_custom_row('ip-alias', "192.0.2.1\n198.51.100.7");
+			$parser = $row['format'] == 'regex' ? 'regex' : 'auto';
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame('regex', $parser);
+		$this->assertSame([], $diagnostics);
 	}
 
 	public function testLiveSyncDispatchKeepsAllThreeRoutesOnSharedRowSeam(): void

--- a/tests/php/DnsblCustomRowStateEnabledInvariantTest.php
+++ b/tests/php/DnsblCustomRowStateEnabledInvariantTest.php
@@ -58,6 +58,20 @@ final class DnsblCustomRowStateEnabledInvariantTest extends TestCase
 
 	public function testIpAliasCustomRowSelectsRegexParserWithoutDiagnostics(): void
 	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		if (!is_string($source)) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		}
+		$marker = strpos($source, "// Set 'auto' format for all lists");
+		$start = $marker === FALSE ? FALSE : strpos($source, 'if (', $marker);
+		$end = $start === FALSE ? FALSE : strpos($source, '// issue #1925:', $start);
+		if ($start === FALSE || $end === FALSE) {
+			throw new RuntimeException('test bootstrap: IP parser-selection block not found');
+		}
+
+		$row = pfb_dnsbl_custom_row('ip-alias', "192.0.2.1\n198.51.100.7");
 		$diagnostics = [];
 		set_error_handler(
 			static function (int $severity, string $message) use (&$diagnostics): bool {
@@ -67,13 +81,12 @@ final class DnsblCustomRowStateEnabledInvariantTest extends TestCase
 			E_WARNING | E_DEPRECATED
 		);
 		try {
-			$row = pfb_dnsbl_custom_row('ip-alias', "192.0.2.1\n198.51.100.7");
-			$parser = $row['format'] == 'regex' ? 'regex' : 'auto';
+			eval(substr($source, $start, $end - $start));
 		} finally {
 			restore_error_handler();
 		}
 
-		$this->assertSame('regex', $parser);
+		$this->assertSame('regex', $pftype);
 		$this->assertSame([], $diagnostics);
 	}
 


### PR DESCRIPTION
## Summary

- synthesize custom rows with explicit `regex` parser metadata
- cover all three shared custom-row routes and warning-free IP parser selection

## Root cause

`pfb_dnsbl_custom_row()` omitted `format`, while the IP consumer read it before
falling through to extension-based parser selection. The supported IP Custom
List path therefore relied on missing-key coercion and emitted PHP diagnostics.
An explicit `regex` format preserves existing parsing and bypasses the irrelevant
extension lookup for the synthetic `custom` URL.

## Verification

- RED: `vendor/bin/phpunit tests/php/DnsblCustomRowStateEnabledInvariantTest.php`
  failed 4 of 6 tests on absent `format` and `auto` parser selection
- final reproduction-test hash: `61ca9fdfa7b1229085f0d8e422aa5ba93dbee900`
- GREEN: focused suite passed 6 tests / 11 assertions with the same test hash
- hostile mutation of the shipped parser branch failed on extension diagnostics
- `scripts/agent/run-gates.sh --diff origin/devel` passed PHPUnit, PHPStan,
  PHPCS, syntax checks, and Composer-vendor verification on rebased head

Fixes #2114

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
