### PR TITLE
test: isolate retired-token Git scan (#2342)

### DIFF
--- a/tests/php/LogNowTokenRetiredHostilePathTest.php
+++ b/tests/php/LogNowTokenRetiredHostilePathTest.php
@@ -69,4 +69,21 @@ final class LogNowTokenRetiredHostilePathTest extends TestCase
 		$result = pfb_test_run_process(['git', '-C', $this->root, 'ls-files', '-z', '--', 'src'], 10.0, $environment);
 		$this->assertSame("src/café.inc\0", $result['stdout']);
 	}
+
+	public function testRetiredTokenScanIgnoresInheritedGitContext(): void
+	{
+		$foreign = $this->root . '/foreign';
+		$this->assertTrue(mkdir($foreign));
+		$result = pfb_test_run_process(['git', '-C', $foreign, 'init', '-q'], 10.0, pfb_test_scrubbed_git_env());
+		$this->assertSame(0, $result['exit'], 'foreign git init failed: ' . $result['stderr']);
+
+		$phpunit = dirname(__DIR__, 2) . '/vendor/bin/phpunit';
+		$test = $this->root . '/tests/php/LogNowTokenRetiredTest.php';
+		$environment = pfb_test_scrubbed_git_env();
+		$environment['GIT_DIR'] = $foreign . '/.git';
+		$result = pfb_test_run_process([$phpunit, '--colors=never', '--no-configuration', $test], 10.0, $environment);
+
+		$this->assertSame(1, $result['exit'], "retired-token scan must ignore inherited Git context:\n{$result['stdout']}{$result['stderr']}");
+		$this->assertStringContainsString('src/café.inc:2', $result['stdout'] . $result['stderr']);
+	}
 }

--- a/tests/php/LogNowTokenRetiredHostilePathTest.php
+++ b/tests/php/LogNowTokenRetiredHostilePathTest.php
@@ -86,4 +86,18 @@ final class LogNowTokenRetiredHostilePathTest extends TestCase
 		$this->assertSame(1, $result['exit'], "retired-token scan must ignore inherited Git context:\n{$result['stdout']}{$result['stderr']}");
 		$this->assertStringContainsString('src/café.inc:2', $result['stdout'] . $result['stderr']);
 	}
+
+	public function testRetiredTokenScanRejectsEmptyTrackedSet(): void
+	{
+		$environment = pfb_test_scrubbed_git_env();
+		$result = pfb_test_run_process(['git', '-C', $this->root, 'rm', '-q', '--cached', 'src/café.inc'], 10.0, $environment);
+		$this->assertSame(0, $result['exit'], 'scratch git rm failed: ' . $result['stderr']);
+
+		$phpunit = dirname(__DIR__, 2) . '/vendor/bin/phpunit';
+		$test = $this->root . '/tests/php/LogNowTokenRetiredTest.php';
+		$result = pfb_test_run_process([$phpunit, '--colors=never', '--no-configuration', $test], 10.0, $environment);
+
+		$this->assertSame(1, $result['exit'], "retired-token scan must reject an empty tracked set:\n{$result['stdout']}{$result['stderr']}");
+		$this->assertStringContainsString('an empty scan must not pass', $result['stdout'] . $result['stderr']);
+	}
 }

--- a/tests/php/LogNowTokenRetiredTest.php
+++ b/tests/php/LogNowTokenRetiredTest.php
@@ -22,10 +22,12 @@ final class LogNowTokenRetiredTest extends TestCase
 
 		$result = pfb_test_run_process(
 			['git', '-C', $repoRoot, 'ls-files', '-z', '--', 'src/*.php', 'src/*.inc'],
-			10.0
+			10.0,
+			pfb_test_scrubbed_git_env()
 		);
 		$this->assertSame(0, $result['exit'], "git ls-files must succeed to enumerate tracked src/ files; got: {$result['stderr']}");
 		$files = array_filter(explode("\0", $result['stdout']), static fn(string $path): bool => $path !== '');
+		$this->assertNotEmpty($files, 'git ls-files must discover tracked src/ files; an empty scan must not pass');
 
 		$violations = [];
 		foreach ($files as $relpath) {


### PR DESCRIPTION
## Summary

- run the retired-token Git scan with the existing scrubbed Git environment
- fail closed when tracked source enumeration is empty
- reproduce the false-green result against an inherited foreign `GIT_DIR`

## Root cause

The scanner used the bounded process runner without its scrubbed Git environment. Inherited repository-routing variables therefore overrode `git -C`, and an empty successful `ls-files` result was accepted as a clean scan.

## Stack

Stacked on #2339 (`issue/2235-lognowtokenretiredtest`) because that PR introduces the bounded process runner used here.

## Verification

- Red on current stacked parent: focused scanner suite failed with 2 regression failures / 58 assertions
- Frozen reproducer hash: `b40cdb55bd5ba7f9ed88be0667eb64e4432f718e`
- Green: focused scanner suite passed, 5 tests / 60 assertions
- `scripts/agent/run-gates.sh --diff origin/issue/2235-lognowtokenretiredtest` passed: PHPUnit, PHPStan, PHPCS, and PHP syntax checks

Review follow-up: #2345 tracks the independently reproduced, pre-existing sibling scanner defect.

Fixes #2342

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
