### PR TITLE
tests: restore Alerts whitelist derived state

### DIFF
--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -71,6 +71,41 @@ DNSBL_UNLOCK_STORE = "/tmp/dnsbl_unlock"
 # host since issue #1412 (never a feed CIDR) -- see _ip_unlock_hosts() below.
 IP_UNLOCK_STORE = "/tmp/ip_unlock"
 
+DERIVED_WHITELIST_FILES = (
+    "/var/unbound/pfb_py_whitelist.txt",
+    "/var/unbound/pfb_py_sources.json",
+)
+
+
+def _snapshot_guest_files(vm: helpers.SmokeVM) -> dict[str, str | None]:
+    snapshot: dict[str, str | None] = {}
+    for path in DERIVED_WHITELIST_FILES:
+        result = vm.ssh("cat", path)
+        if result.returncode == 0:
+            snapshot[path] = result.stdout
+        elif vm.ssh("test", "!", "-e", path).returncode == 0:
+            snapshot[path] = None
+        else:
+            raise RuntimeError(f"failed to read existing {path}: {result.stderr!r}")
+    return snapshot
+
+
+def _restore_guest_files(vm: helpers.SmokeVM, snapshot: dict[str, str | None]) -> None:
+    for path, content in snapshot.items():
+        if content is None:
+            result = vm.ssh("rm", "-f", path)
+        else:
+            result = subprocess.run(
+                vm.ssh_argv("tee", path),
+                input=content,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        if result.returncode != 0:
+            raise RuntimeError(f"failed to restore {path}: {result.stderr!r}")
+
 
 def _csrf(webui: WebUI) -> str:
     """GET the alerts page and return its freshly-injected ``__csrf_magic`` token.
@@ -333,6 +368,7 @@ def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
     vm = smoke_vm
     domain = helpers.unique_domain("uiwl")
     original = helpers.config_get(vm, CFG_WHITELIST)
+    original_derived = _snapshot_guest_files(vm)
     try:
         # BEFORE: the unique domain is not in the whitelist.
         assert domain not in _suppression_entries(vm, CFG_WHITELIST), (
@@ -387,24 +423,32 @@ def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
             f".{domain} still in the DNSBL Whitelist after entry_delete=delete_domainwildcard"
         )
     finally:
-        cleanup = helpers.php_eval(
-            vm,
-            "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
-            "$had_manifest = file_exists($pfb['unbound_py_sources']);\n"
-            f"config_set_path('{CFG_WHITELIST}', '{original}');\n"
-            "write_config('pfBlockerNG smoke: restore suppression');\n"
-            "pfb_unbound_python_whitelist('alerts');\n"
-            "$patched = pfb_unbound_python_sources_whitelist();\n"
-            "if ($had_manifest && !$patched) { exit(1); }\n"
-            "pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);\n"
-            "echo 'OK';",
-        )
-        if cleanup.returncode != 0 or "OK" not in cleanup.stdout:
-            helpers.restore_pfb_config_baseline(vm, snapshot_path=UI_CONFIG_SNAPSHOT)
-            raise RuntimeError(
-                f"Alerts whitelist cleanup failed: rc={cleanup.returncode} "
-                f"stderr={cleanup.stderr!r} stdout={cleanup.stdout!r}"
+        try:
+            cleanup = helpers.php_eval(
+                vm,
+                "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+                "$had_manifest = file_exists($pfb['unbound_py_sources']);\n"
+                f"config_set_path('{CFG_WHITELIST}', '{original}');\n"
+                "write_config('pfBlockerNG smoke: restore suppression');\n"
+                "pfb_unbound_python_whitelist('alerts');\n"
+                "$patched = pfb_unbound_python_sources_whitelist();\n"
+                "if ($had_manifest && !$patched) { exit(1); }\n"
+                "$was_active = pfb_unbound_py_mode_active();\n"
+                "pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);\n"
+                "if ($was_active && !pfb_dnsbl_converged()) { exit(1); }\n"
+                "echo 'OK';",
             )
+            if cleanup.returncode != 0 or "OK" not in cleanup.stdout:
+                raise RuntimeError(
+                    f"Alerts whitelist cleanup failed: rc={cleanup.returncode} "
+                    f"stderr={cleanup.stderr!r} stdout={cleanup.stdout!r}"
+                )
+        except Exception:
+            try:
+                _restore_guest_files(vm, original_derived)
+            finally:
+                helpers.restore_pfb_config_baseline(vm, snapshot_path=UI_CONFIG_SNAPSHOT)
+            raise
 
 
 def test_addwhitelistdom_exclude_writes_tld_exclusion_and_entry_delete_removes_it(

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -388,8 +388,12 @@ def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
     finally:
         helpers.php_eval(
             vm,
+            "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
             f"config_set_path('{CFG_WHITELIST}', '{original}');\n"
             "write_config('pfBlockerNG smoke: restore suppression');\n"
+            "pfb_unbound_python_whitelist('alerts');\n"
+            "pfb_unbound_python_sources_whitelist();\n"
+            "pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);\n"
             "echo 'OK';",
         )
 

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from .. import helpers
+from .conftest import UI_CONFIG_SNAPSHOT
 from .webui import extract_csrf_token, looks_like_login_page, row_containing
 
 if TYPE_CHECKING:
@@ -386,16 +387,24 @@ def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
             f".{domain} still in the DNSBL Whitelist after entry_delete=delete_domainwildcard"
         )
     finally:
-        helpers.php_eval(
+        cleanup = helpers.php_eval(
             vm,
             "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+            "$had_manifest = file_exists($pfb['unbound_py_sources']);\n"
             f"config_set_path('{CFG_WHITELIST}', '{original}');\n"
             "write_config('pfBlockerNG smoke: restore suppression');\n"
             "pfb_unbound_python_whitelist('alerts');\n"
-            "pfb_unbound_python_sources_whitelist();\n"
+            "$patched = pfb_unbound_python_sources_whitelist();\n"
+            "if ($had_manifest && !$patched) { exit(1); }\n"
             "pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);\n"
             "echo 'OK';",
         )
+        if cleanup.returncode != 0 or "OK" not in cleanup.stdout:
+            helpers.restore_pfb_config_baseline(vm, snapshot_path=UI_CONFIG_SNAPSHOT)
+            raise RuntimeError(
+                f"Alerts whitelist cleanup failed: rc={cleanup.returncode} "
+                f"stderr={cleanup.stderr!r} stdout={cleanup.stdout!r}"
+            )
 
 
 def test_addwhitelistdom_exclude_writes_tld_exclusion_and_entry_delete_removes_it(

--- a/tests/smoke/ui/test_alerts_cleanup.py
+++ b/tests/smoke/ui/test_alerts_cleanup.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import base64
 import json
+import subprocess
 from typing import TYPE_CHECKING
 
 import pytest
 
 from .. import helpers
 from . import test_alerts
+from .conftest import UI_CONFIG_SNAPSHOT
 
 if TYPE_CHECKING:
     from .webui import WebUI
@@ -19,12 +22,24 @@ WHITELIST_PATH = "/var/unbound/pfb_py_whitelist.txt"
 MANIFEST_PATH = "/var/unbound/pfb_py_sources.json"
 
 
-def _derived_whitelist_entries(vm: helpers.SmokeVM) -> tuple[set[str], set[str] | None]:
-    whitelist = {
-        line.partition(",")[0] for line in helpers.read_log_file(vm, WHITELIST_PATH).splitlines() if line.strip()
-    }
-    manifest_raw = helpers.read_log_file(vm, MANIFEST_PATH)
-    if not manifest_raw:
+def _optional_guest_file(vm: helpers.SmokeVM, path: str) -> str | None:
+    result = vm.ssh("cat", path)
+    if result.returncode == 0:
+        return result.stdout
+    missing = vm.ssh("test", "!", "-e", path)
+    assert missing.returncode == 0, f"failed to read existing {path}: {result.stderr!r}"
+    return None
+
+
+def _derived_whitelist_entries(vm: helpers.SmokeVM) -> tuple[set[str] | None, set[str] | None]:
+    whitelist_raw = _optional_guest_file(vm, WHITELIST_PATH)
+    whitelist = (
+        None
+        if whitelist_raw is None
+        else {line.partition(",")[0] for line in whitelist_raw.splitlines() if line.strip()}
+    )
+    manifest_raw = _optional_guest_file(vm, MANIFEST_PATH)
+    if manifest_raw is None:
         return whitelist, None
     manifest = json.loads(manifest_raw)
     return whitelist, set(manifest["config"]["user_whitelist"])
@@ -36,31 +51,62 @@ def test_addwhitelistdom_failure_restores_derived_unbound_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An assertion failure after whitelist POST leaves no derived Unbound entry."""
-    original = helpers.config_get(smoke_vm, test_alerts.CFG_WHITELIST)
-    original_entries = test_alerts._suppression_entries(smoke_vm, test_alerts.CFG_WHITELIST)
-    suppression_entries = test_alerts._suppression_entries
-    added_entries: set[str] = set()
+    baseline = helpers.unique_domain("uiwlbase")
+    try:
+        encoded = base64.b64encode(f"{baseline}\n".encode()).decode()
+        helpers.config_set(smoke_vm, test_alerts.CFG_WHITELIST, encoded)
+        seeded = helpers.php_eval(
+            smoke_vm,
+            "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+            "pfb_unbound_python_whitelist('alerts');\n"
+            "echo 'OK';",
+        )
+        assert seeded.returncode == 0 and "OK" in seeded.stdout, seeded.stderr
+        manifest_seed = json.dumps({"version": 1, "config": {"user_whitelist": [baseline]}, "feeds": {}})
+        written = subprocess.run(
+            smoke_vm.ssh_argv("tee", MANIFEST_PATH),
+            input=manifest_seed,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert written.returncode == 0, written.stderr
 
-    def fail_after_post(vm: helpers.SmokeVM, cfg_path: str) -> set[str]:
-        entries = suppression_entries(vm, cfg_path)
-        if added := entries - original_entries:
-            added_entries.update(added)
-            normalised = {entry.removeprefix("www.") for entry in added}
-            whitelist, manifest = _derived_whitelist_entries(vm)
-            assert normalised <= whitelist, f"POST did not add {normalised!r} to {WHITELIST_PATH}"
-            if manifest is not None:
-                assert added <= manifest, f"POST did not add {added!r} to manifest user_whitelist"
-            raise RuntimeError("injected assertion failure after whitelist POST")
-        return entries
+        original = helpers.config_get(smoke_vm, test_alerts.CFG_WHITELIST)
+        original_entries = test_alerts._suppression_entries(smoke_vm, test_alerts.CFG_WHITELIST)
+        original_derived = _derived_whitelist_entries(smoke_vm)
+        suppression_entries = test_alerts._suppression_entries
+        added_entries: set[str] = set()
+        reloads_after_post: int | None = None
 
-    monkeypatch.setattr(test_alerts, "_suppression_entries", fail_after_post)
-    with pytest.raises(RuntimeError, match="injected assertion failure after whitelist POST"):
-        test_alerts.test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(webui, smoke_vm)
+        def fail_after_post(vm: helpers.SmokeVM, cfg_path: str) -> set[str]:
+            nonlocal reloads_after_post
+            entries = suppression_entries(vm, cfg_path)
+            if added := entries - original_entries:
+                added_entries.update(added)
+                normalised = {entry.removeprefix("www.") for entry in added}
+                whitelist, manifest = _derived_whitelist_entries(vm)
+                assert whitelist is not None and normalised <= whitelist, (
+                    f"POST did not add {normalised!r} to {WHITELIST_PATH}"
+                )
+                assert manifest is not None and added <= manifest, (
+                    f"POST did not add {added!r} to manifest user_whitelist"
+                )
+                reloads_after_post = helpers.count_log_marker(vm, helpers.PFB_LOG, "Reloading Unbound Resolver")
+                raise RuntimeError("injected assertion failure after whitelist POST")
+            return entries
 
-    assert helpers.config_get(smoke_vm, test_alerts.CFG_WHITELIST) == original
-    assert added_entries, "failure injection did not observe the whitelist POST mutation"
-    normalised = {entry.removeprefix("www.") for entry in added_entries}
-    whitelist, manifest = _derived_whitelist_entries(smoke_vm)
-    assert normalised.isdisjoint(whitelist), f"failed test leaked {normalised!r} into {WHITELIST_PATH}"
-    if manifest is not None:
-        assert added_entries.isdisjoint(manifest), f"failed test leaked {added_entries!r} into manifest user_whitelist"
+        monkeypatch.setattr(test_alerts, "_suppression_entries", fail_after_post)
+        with pytest.raises(RuntimeError, match="injected assertion failure after whitelist POST"):
+            test_alerts.test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(webui, smoke_vm)
+
+        assert helpers.config_get(smoke_vm, test_alerts.CFG_WHITELIST) == original
+        assert added_entries, "failure injection did not observe the whitelist POST mutation"
+        assert _derived_whitelist_entries(smoke_vm) == original_derived
+        assert reloads_after_post is not None
+        assert helpers.count_log_marker(smoke_vm, helpers.PFB_LOG, "Reloading Unbound Resolver") > reloads_after_post, (
+            "failed-test cleanup did not reload Unbound"
+        )
+    finally:
+        helpers.restore_pfb_config_baseline(smoke_vm, snapshot_path=UI_CONFIG_SNAPSHOT)

--- a/tests/smoke/ui/test_alerts_cleanup.py
+++ b/tests/smoke/ui/test_alerts_cleanup.py
@@ -1,0 +1,66 @@
+"""Failure-path isolation for Alerts whitelist UI coverage."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from . import test_alerts
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_e2e
+
+WHITELIST_PATH = "/var/unbound/pfb_py_whitelist.txt"
+MANIFEST_PATH = "/var/unbound/pfb_py_sources.json"
+
+
+def _derived_whitelist_entries(vm: helpers.SmokeVM) -> tuple[set[str], set[str] | None]:
+    whitelist = {
+        line.partition(",")[0] for line in helpers.read_log_file(vm, WHITELIST_PATH).splitlines() if line.strip()
+    }
+    manifest_raw = helpers.read_log_file(vm, MANIFEST_PATH)
+    if not manifest_raw:
+        return whitelist, None
+    manifest = json.loads(manifest_raw)
+    return whitelist, set(manifest["config"]["user_whitelist"])
+
+
+def test_addwhitelistdom_failure_restores_derived_unbound_state(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An assertion failure after whitelist POST leaves no derived Unbound entry."""
+    original = helpers.config_get(smoke_vm, test_alerts.CFG_WHITELIST)
+    original_entries = test_alerts._suppression_entries(smoke_vm, test_alerts.CFG_WHITELIST)
+    suppression_entries = test_alerts._suppression_entries
+    added_entries: set[str] = set()
+
+    def fail_after_post(vm: helpers.SmokeVM, cfg_path: str) -> set[str]:
+        entries = suppression_entries(vm, cfg_path)
+        if added := entries - original_entries:
+            added_entries.update(added)
+            normalised = {entry.removeprefix("www.") for entry in added}
+            whitelist, manifest = _derived_whitelist_entries(vm)
+            assert normalised <= whitelist, f"POST did not add {normalised!r} to {WHITELIST_PATH}"
+            if manifest is not None:
+                assert added <= manifest, f"POST did not add {added!r} to manifest user_whitelist"
+            raise RuntimeError("injected assertion failure after whitelist POST")
+        return entries
+
+    monkeypatch.setattr(test_alerts, "_suppression_entries", fail_after_post)
+    with pytest.raises(RuntimeError, match="injected assertion failure after whitelist POST"):
+        test_alerts.test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(webui, smoke_vm)
+
+    assert helpers.config_get(smoke_vm, test_alerts.CFG_WHITELIST) == original
+    assert added_entries, "failure injection did not observe the whitelist POST mutation"
+    normalised = {entry.removeprefix("www.") for entry in added_entries}
+    whitelist, manifest = _derived_whitelist_entries(smoke_vm)
+    assert normalised.isdisjoint(whitelist), f"failed test leaked {normalised!r} into {WHITELIST_PATH}"
+    if manifest is not None:
+        assert added_entries.isdisjoint(manifest), f"failed test leaked {added_entries!r} into manifest user_whitelist"

--- a/tests/smoke/ui/test_alerts_cleanup.py
+++ b/tests/smoke/ui/test_alerts_cleanup.py
@@ -22,23 +22,15 @@ WHITELIST_PATH = "/var/unbound/pfb_py_whitelist.txt"
 MANIFEST_PATH = "/var/unbound/pfb_py_sources.json"
 
 
-def _optional_guest_file(vm: helpers.SmokeVM, path: str) -> str | None:
-    result = vm.ssh("cat", path)
-    if result.returncode == 0:
-        return result.stdout
-    missing = vm.ssh("test", "!", "-e", path)
-    assert missing.returncode == 0, f"failed to read existing {path}: {result.stderr!r}"
-    return None
-
-
 def _derived_whitelist_entries(vm: helpers.SmokeVM) -> tuple[set[str] | None, set[str] | None]:
-    whitelist_raw = _optional_guest_file(vm, WHITELIST_PATH)
+    snapshot = test_alerts._snapshot_guest_files(vm)
+    whitelist_raw = snapshot[WHITELIST_PATH]
     whitelist = (
         None
         if whitelist_raw is None
         else {line.partition(",")[0] for line in whitelist_raw.splitlines() if line.strip()}
     )
-    manifest_raw = _optional_guest_file(vm, MANIFEST_PATH)
+    manifest_raw = snapshot[MANIFEST_PATH]
     if manifest_raw is None:
         return whitelist, None
     manifest = json.loads(manifest_raw)
@@ -52,6 +44,7 @@ def test_addwhitelistdom_failure_restores_derived_unbound_state(
 ) -> None:
     """An assertion failure after whitelist POST leaves no derived Unbound entry."""
     baseline = helpers.unique_domain("uiwlbase")
+    session_derived = test_alerts._snapshot_guest_files(smoke_vm)
     try:
         encoded = base64.b64encode(f"{baseline}\n".encode()).decode()
         helpers.config_set(smoke_vm, test_alerts.CFG_WHITELIST, encoded)
@@ -62,7 +55,7 @@ def test_addwhitelistdom_failure_restores_derived_unbound_state(
             "echo 'OK';",
         )
         assert seeded.returncode == 0 and "OK" in seeded.stdout, seeded.stderr
-        manifest_seed = json.dumps({"version": 1, "config": {"user_whitelist": [baseline]}, "feeds": {}})
+        manifest_seed = json.dumps({"version": 1, "config": {"user_whitelist": [baseline]}, "feeds": []}, indent=4)
         written = subprocess.run(
             smoke_vm.ssh_argv("tee", MANIFEST_PATH),
             input=manifest_seed,
@@ -75,7 +68,7 @@ def test_addwhitelistdom_failure_restores_derived_unbound_state(
 
         original = helpers.config_get(smoke_vm, test_alerts.CFG_WHITELIST)
         original_entries = test_alerts._suppression_entries(smoke_vm, test_alerts.CFG_WHITELIST)
-        original_derived = _derived_whitelist_entries(smoke_vm)
+        original_derived = test_alerts._snapshot_guest_files(smoke_vm)
         suppression_entries = test_alerts._suppression_entries
         added_entries: set[str] = set()
         reloads_after_post: int | None = None
@@ -103,10 +96,13 @@ def test_addwhitelistdom_failure_restores_derived_unbound_state(
 
         assert helpers.config_get(smoke_vm, test_alerts.CFG_WHITELIST) == original
         assert added_entries, "failure injection did not observe the whitelist POST mutation"
-        assert _derived_whitelist_entries(smoke_vm) == original_derived
+        assert test_alerts._snapshot_guest_files(smoke_vm) == original_derived
         assert reloads_after_post is not None
         assert helpers.count_log_marker(smoke_vm, helpers.PFB_LOG, "Reloading Unbound Resolver") > reloads_after_post, (
             "failed-test cleanup did not reload Unbound"
         )
     finally:
-        helpers.restore_pfb_config_baseline(smoke_vm, snapshot_path=UI_CONFIG_SNAPSHOT)
+        try:
+            test_alerts._restore_guest_files(smoke_vm, session_derived)
+        finally:
+            helpers.restore_pfb_config_baseline(smoke_vm, snapshot_path=UI_CONFIG_SNAPSHOT)


### PR DESCRIPTION
Fixes #2129

## Summary

- reproduce the Alerts whitelist failure-path leak before fixture teardown can mask it
- load pfBlockerNG in the test cleanup and mirror the production whitelist, manifest, and Unbound reconciliation

## Verification

- RED: frozen test blob `8b49e96bbcec8c7da27d3451c20d881b40068c26` failed because `/var/unbound/pfb_py_whitelist.txt` retained the injected domain
- GREEN: pushed head `77a0ed54` passed the original success path and frozen failure path (`2 passed, 607 deselected`)
- `scripts/run-in-docker.sh scripts/agent/run-gates.sh --diff origin/devel` (`GATES: PASS`)

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after Alerts whitelist failures to restore whitelist and Unbound state reliably.
  * Added fallback restoration when cleanup cannot rebuild the expected configuration.

* **Tests**
  * Added end-to-end coverage for failed whitelist updates, state restoration, and required Unbound reloads.
  * Enhanced smoke-test verification of whitelist and manifest cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->