### PR TITLE
test: isolate source lint Git context (#2345)

### DIFF
--- a/tests/php/SrcPhpDeprecationLintHostilePathTest.php
+++ b/tests/php/SrcPhpDeprecationLintHostilePathTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/support/ProcessRunner.php';
+
+final class SrcPhpDeprecationLintHostilePathTest extends TestCase
+{
+	private string $root;
+
+	protected function setUp(): void
+	{
+		$this->root = sys_get_temp_dir() . '/pfb_src_php_lint_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($this->root . '/tests/php/support', 0755, true));
+		$this->assertTrue(mkdir($this->root . '/src', 0755, true));
+		$this->assertTrue(copy(__DIR__ . '/SrcPhpDeprecationLintTest.php', $this->root . '/tests/php/SrcPhpDeprecationLintTest.php'));
+		$this->assertTrue(copy(__DIR__ . '/support/ProcessRunner.php', $this->root . '/tests/php/support/ProcessRunner.php'));
+		$this->assertNotFalse(file_put_contents($this->root . '/src/common.inc', "<?php\n"));
+		$this->assertNotFalse(file_put_contents($this->root . '/src/bad.inc', "<?php\nif (\n"));
+
+		foreach ([['init', '-q'], ['add', '--', 'src']] as $arguments) {
+			$result = pfb_test_run_process(['git', '-C', $this->root, ...$arguments], 10.0, pfb_test_scrubbed_git_env());
+			$this->assertSame(0, $result['exit'], 'scratch git failed: ' . $result['stderr']);
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->root);
+	}
+
+	public function testLintIgnoresForeignPartialGitIndex(): void
+	{
+		$foreign = $this->root . '/foreign';
+		$this->assertTrue(mkdir($foreign . '/src', 0755, true));
+		$this->assertNotFalse(file_put_contents($foreign . '/src/common.inc', "<?php\n"));
+
+		foreach ([['init', '-q'], ['add', '--', 'src/common.inc']] as $arguments) {
+			$result = pfb_test_run_process(['git', '-C', $foreign, ...$arguments], 10.0, pfb_test_scrubbed_git_env());
+			$this->assertSame(0, $result['exit'], 'foreign git failed: ' . $result['stderr']);
+		}
+
+		$environment = pfb_test_scrubbed_git_env();
+		$environment['GIT_DIR'] = $foreign . '/.git';
+		$result = pfb_test_run_process(
+			[
+				dirname(__DIR__, 2) . '/vendor/bin/phpunit',
+				'--colors=never',
+				'--no-configuration',
+				$this->root . '/tests/php/SrcPhpDeprecationLintTest.php',
+			],
+			10.0,
+			$environment
+		);
+
+		$this->assertSame(1, $result['exit'], "lint must scan the current checkout despite foreign Git context:\n{$result['stdout']}{$result['stderr']}");
+		$this->assertStringContainsString('src/bad.inc', $result['stdout'] . $result['stderr']);
+	}
+}

--- a/tests/php/SrcPhpDeprecationLintTest.php
+++ b/tests/php/SrcPhpDeprecationLintTest.php
@@ -91,31 +91,14 @@ final class SrcPhpDeprecationLintTest extends TestCase
 	private static function trackedPhpFiles(string $root): array
 	{
 		$cmd = ['git', '-C', $root, 'ls-files', '-z', '--', 'src/*.php', 'src/*.inc'];
-		$descriptors = [
-			0 => ['pipe', 'r'],
-			1 => ['pipe', 'w'],
-			2 => ['pipe', 'w'],
-		];
-
-		$proc = proc_open($cmd, $descriptors, $pipes, null, pfb_test_scrubbed_git_env());
-		if (!is_resource($proc)) {
-			throw new RuntimeException('test bootstrap: failed to spawn `' . implode(' ', $cmd) . '`');
-		}
-
-		fclose($pipes[0]);
-		$stdout = (string) stream_get_contents($pipes[1]);
-		$stderr = (string) stream_get_contents($pipes[2]);
-		fclose($pipes[1]);
-		fclose($pipes[2]);
-		$exitCode = proc_close($proc);
-
-		if ($exitCode !== 0) {
+		$result = pfb_test_run_process($cmd, 10.0, pfb_test_scrubbed_git_env());
+		if ($result['exit'] !== 0) {
 			throw new RuntimeException(
-				'test bootstrap: `' . implode(' ', $cmd) . "` exited {$exitCode}: {$stderr}"
+				'test bootstrap: `' . implode(' ', $cmd) . "` exited {$result['exit']}: {$result['stderr']}"
 			);
 		}
 
-		$relative = array_filter(explode("\0", $stdout), static fn(string $p): bool => $p !== '');
+		$relative = array_filter(explode("\0", $result['stdout']), static fn(string $p): bool => $p !== '');
 		$absolute = array_map(static fn(string $p): string => $root . '/' . $p, $relative);
 		sort($absolute);
 

--- a/tests/php/SrcPhpDeprecationLintTest.php
+++ b/tests/php/SrcPhpDeprecationLintTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/ProcessRunner.php';
+
 /**
  * Issue #1657 pinned url_compare() in pfblockerng_feeds.php after it declared
  * four optional parameters BEFORE the required $a_key, which PHP 8 deprecates
@@ -95,7 +97,7 @@ final class SrcPhpDeprecationLintTest extends TestCase
 			2 => ['pipe', 'w'],
 		];
 
-		$proc = proc_open($cmd, $descriptors, $pipes);
+		$proc = proc_open($cmd, $descriptors, $pipes, null, pfb_test_scrubbed_git_env());
 		if (!is_resource($proc)) {
 			throw new RuntimeException('test bootstrap: failed to spawn `' . implode(' ', $cmd) . '`');
 		}


### PR DESCRIPTION
## Summary

- scrub inherited Git routing before enumerating tracked PHP/INC source
- reproduce the false-green scan against a foreign nonempty partial index

## Root cause

`git -C` does not override inherited repository-routing variables such as `GIT_DIR`. The lint test therefore trusted a foreign index and could omit parse-broken files from the current checkout.

## Verification

- Red on `origin/devel`: focused hostile test failed because the nested scanner returned `OK (1 test, 3 assertions)` and exit 0
- Frozen hostile-test blob: `7cb7e896f609a6b87b14e47678bb1e2cc0e69ff5`
- Green: focused scanner tests passed, 2 tests / 17 assertions
- `scripts/agent/run-gates.sh --diff origin/devel` passed: PHP syntax, 5,233-test PHPUnit suite, PHPStan, and PHPCS

Fixes #2345

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage to ensure PHP deprecation linting scans the current checkout correctly when Git metadata points to another repository.
  - Improved test coverage for detecting deprecated files and reporting their paths.
  - Standardized process execution and environment handling in lint-related tests.
  - Added cleanup verification for temporary test checkouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->