### PR TITLE
ci: run every gate in the CI runner image

### DIFF
--- a/.agents/policy/testing.md
+++ b/.agents/policy/testing.md
@@ -24,23 +24,21 @@ Tests = how change proves itself. **Five non-negotiable principles govern every 
 
 ## Running tests
 
-```sh
-python3 -m pytest        # from repo root; run after ANY change to pfb_unbound.py or tests/
-composer install        # once; if it 403s in a managed cloud session, run
-                        # scripts/composer-cloud-install.sh instead (issue #950)
-vendor/bin/phpunit      # PHP suite: loads the REAL pfblockerng.inc off-appliance
-```
-
-**Running a suite inside the CI toolchain — `scripts/run-in-docker.sh <cmd>`.** Wraps any repo command in `ghcr.io/pfblockerng/ci-runner`, the image the gates grade with, so a local red/green answers the same question CI does. Also the faster path on Apple Silicon (59 s vs 201 s for `python3 -m pytest -q`: the suite is process-spawn bound and Linux `fork`/`exec` is far cheaper than macOS). Prefer it when **reproducing a CI-only failure**, when the host toolchain versions differ from the matrix, or for any long suite run on Apple Silicon.
+**Every suite runs inside the CI toolchain — `scripts/run-in-docker.sh <cmd>`** (issue #2350). Wraps any repo command in `ghcr.io/pfblockerng/ci-runner`, the image `test.yml` runs every job inside, so a local red/green answers the same question CI does. Also the faster path on Apple Silicon (59 s vs 201 s for `python3 -m pytest -q`: the suite is process-spawn bound and Linux `fork`/`exec` is far cheaper than macOS). This is the default way to run anything, not an option reserved for reproducing a CI-only failure.
 
 ```sh
 scripts/run-in-docker.sh python3 -m pytest -q      # any command, same argv
+scripts/run-in-docker.sh vendor/bin/phpunit        # PHP suite: loads the REAL .inc off-appliance
 scripts/run-in-docker.sh shellspec --shell dash
+scripts/run-in-docker.sh composer install          # if it 403s in a managed cloud session,
+                                                   # scripts/composer-cloud-install.sh (issue #950)
 PFB_VM=1 scripts/run-in-docker.sh ...              # ci-runner-vm (qemu, oras, Playwright)
 PFB_BUILD=1 scripts/run-in-docker.sh ...           # build the image locally, no GHCR login
 ```
 
-**It never refuses to run, so verify WHERE it ran before claiming a containerised result.** Docker missing, daemon down, image unpullable (the packages are private today), a failed build, no work tree — each prints one reason line and execs on the host instead. That line is lost to `2>/dev/null` and to a captured `$(...)`, so the fact rides the environment: **`PFB_RUNNER` is `container` or `host`, and unset when the wrapper was not involved.** Reporting "ran in the CI image" on a `PFB_RUNNER=host` run is a fabricated verification claim — check it, or say "on the host". Container/host differences are real and known: the process-group signal tests and one mtime race test fail in the container, and platform-gated cases skip differently. **CI grades on Linux, so the container is the closer answer where they disagree** — but a fallback run is a HOST run and carries the host's verdict.
+**It runs in the container or not at all.** Docker missing, daemon down, image unpullable (the packages are private today), a failed build, no work tree — each prints one reason line and exits **125**, docker's own "could not run the container" status, so a caller can tell it apart from the wrapped command going red. `scripts/agent/run-gates.sh` routes every gate through it and treats 125 as a gate FAILURE, never a skip; `.githooks/pre-commit` routes its two PHP style gates the same way and keeps its other linters host-native.
+
+**`PFB_ALLOW_HOST=1` restores the old degrade-to-host behaviour**, and then WHERE it ran has to be verified before any containerised claim. The reason line is lost to `2>/dev/null` and to a captured `$(...)`, so the fact rides the environment: **`PFB_RUNNER` is `container` or `host`, and unset when the wrapper was not involved.** Reporting "ran in the CI image" on a `PFB_RUNNER=host` run is a fabricated verification claim — check it, or say "on the host". Container/host differences are real and known: the process-group signal tests and one mtime race test fail in the container, and platform-gated cases skip differently. **CI grades on Linux, so the container is the authoritative answer where they disagree** — a host run carries only the host's verdict.
 
 Environment gotchas that read as fake "baseline failures" — fix env, never dismiss red: pytest suite needs **zstd encoder** (`zstd` binary or `zstandard` module); bare managed-cloud container lacks one and ~70 pkg/repo tests fail — `SessionStart` hook auto-installs it (manual: `pip3 install zstandard`). PHPUnit permission-denial tests (`chmod 0555` fixtures) **skip under root** via `posix_getuid() === 0` guard — root bypasses file permissions, so root run cannot simulate denial (red there means guard missing, not code broke). Any other local-only failure: diagnose before dismissing — if genuinely pre-existing on base branch, **file tracking issue** (exemplars #791, #894); never leave as folklore.
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,9 @@
 #
 # Each check also runs only when its tool is available: a contributor missing a
 # tool is warned and that check is skipped, never blocked (CI is the hard gate),
-# except the mandatory Composer vendor guard for staged PHP.
+# except the mandatory Composer vendor guard for staged PHP and the two PHP style
+# gates, which run in the CI runner image and fail when it cannot be reached
+# (issue #2350).
 # All applicable checks run even after one fails, so every problem is reported in
 # a single pass. Bypass in an emergency with `git commit --no-verify`.
 #
@@ -265,15 +267,21 @@ if [ "$staged_php" = 1 ]; then
 	if [ "$composer_vendor_ok" != 1 ]; then
 		printf '[pre-commit] Composer vendor check failed; skipping PHP style gates.\n' >&2
 	else
-	# php -l syntax check (output shown only for files that fail).
-	if have php; then
-		step 'php -l'
-		find src \( -name '*.php' -o -name '*.inc' \) | sort | while IFS= read -r f; do
-			out=$(php -l "$f" 2>&1) || { printf '%s\n' "$out" >&2; exit 1; }
-		done || failed 'php -l'
-	else
-		skip php
-	fi
+	# Both PHP gates run inside the CI runner image, never against a host PHP (issue
+	# #2350). Every other check in this hook keeps its host tool -- a commit gate that
+	# hard-requires Docker is too heavy -- but PHP is the exception: the matrix pins 8.3
+	# and 8.5, a host PHP is whichever version that machine happens to carry, and there
+	# is nothing to gain from grading syntax and sniffs against it. An unreachable
+	# container is a FAILED gate here, not a skip: a skipped gate reads greener than a
+	# failed one, and `git commit --no-verify` is the deliberate way past it.
+
+	# php -l syntax check (output shown only for files that fail). One container
+	# invocation for the whole tree, not one per file.
+	step 'php -l'
+	scripts/run-in-docker.sh sh -c '
+		find src \( -name "*.php" -o -name "*.inc" \) | sort | while IFS= read -r f; do
+			out=$(php -l "$f" 2>&1) || { printf "%s\n" "$out" >&2; exit 1; }
+		done' || failed 'php -l'
 
 	# PHPCS sniffs (only when the vendor tree is installed). Config auto-discovered
 	# from phpcs.xml.dist.
@@ -283,7 +291,7 @@ if [ "$staged_php" = 1 ]; then
 		# large file (pfblockerng.inc ~19.5k lines) exhausts PHP's default 128M and
 		# aborts, which forces --no-verify and skips ALL gates. CI runs at
 		# memory_limit=-1 so it never OOMs there; this closes the local-only gap.
-		vendor/bin/phpcs -d memory_limit=1G || failed 'phpcs'
+		scripts/run-in-docker.sh vendor/bin/phpcs -d memory_limit=1G || failed 'phpcs'
 	else
 		skip phpcs
 	fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -273,7 +273,7 @@ if [ "$staged_php" = 1 ]; then
 	# and 8.5, a host PHP is whichever version that machine happens to carry, and there
 	# is nothing to gain from grading syntax and sniffs against it. An unreachable
 	# container is a FAILED gate here, not a skip: a skipped gate reads greener than a
-	# failed one, and `git commit --no-verify` is the deliberate way past it.
+	# failed one, so an unreachable image blocks the commit until it is reachable.
 
 	# php -l syntax check (output shown only for files that fail). One container
 	# invocation for the whole tree, not one per file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ plus behavioural doubles for the pfSense runtime functions) — see
 [`tests/php/README.md`](tests/php/README.md). Deep pfSense-runtime integration
 stays the live-VM smoke's job (ADR-04).
 
-To run any of these inside the same image CI grades with, prefix the command with
+Run any of these inside the same image CI grades with by prefixing the command with
 `scripts/run-in-docker.sh`:
 
 ```sh
@@ -160,17 +160,26 @@ scripts/run-in-docker.sh vendor/bin/phpunit
 scripts/run-in-docker.sh                       # no command: an interactive shell
 ```
 
-Worth doing when a failure reproduces only in CI, or when your local Python/PHP/Node
-differs from the matrix. On Apple Silicon it is also simply faster for the Python
-suite — 59 s against 201 s, measured back to back — because the suite is
-process-spawn bound and Linux `fork`/`exec` costs far less than macOS.
+This is the recommended way to run the suites, not just a fallback for a failure that
+reproduces only in CI: every job in `test.yml` executes inside this image, so a local
+verdict from it is the verdict the PR will get. On Apple Silicon it is also simply
+faster for the Python suite — 59 s against 201 s, measured back to back — because the
+suite is process-spawn bound and Linux `fork`/`exec` costs far less than macOS.
 
-It never refuses to run: if Docker is missing, the daemon is down, or the image
-cannot be pulled (the packages are private for now — `PFB_BUILD=1` builds it locally
-instead), it prints why and runs the command on the host. `PFB_RUNNER` is set to
-`container` or `host` so you can tell which happened after the fact, and a few tests
-legitimately differ between the two: the process-group signal cases and one mtime
-race fail under Linux containers, and platform-gated cases skip differently.
+It runs in the container or not at all: if Docker is missing, the daemon is down, or
+the image cannot be pulled (the packages are private for now — `PFB_BUILD=1` builds it
+locally instead), it prints why and exits 125 rather than quietly grading against your
+host toolchain. `PFB_ALLOW_HOST=1` opts back into a host run when that is what you
+want; `PFB_RUNNER` is then set to `container` or `host` so you can tell which happened
+after the fact. A few tests legitimately differ between the two: the process-group
+signal cases and one mtime race fail under Linux containers, and platform-gated cases
+skip differently.
+
+`scripts/agent/run-gates.sh` routes every gate it runs through this wrapper, and the
+`pre-commit` hook routes its `php -l` and PHPCS gates the same way — those two need a
+PHP matching the matrix, which a host PHP is not. The hook's other linters (ruff,
+ShellCheck, markdownlint, the Python policy checks) still run natively, so committing
+does not require Docker unless the commit stages PHP.
 
 ### Shell tests (shellspec)
 

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -3,6 +3,11 @@
 # Mechanical runner for the "Canonical gates" table (CLAUDE.md stays the documented
 # source; this script implements it -- change them together).
 #
+# Every gate runs inside the CI runner image via scripts/run-in-docker.sh (issue #2350),
+# so the toolchain grading a local run is the toolchain grading the PR. An unreachable
+# container is a gate FAILURE, not a skip; PFB_ALLOW_HOST=1 in the environment is the
+# documented escape hatch and is honoured by the wrapper, not by this script.
+#
 # Usage: run-gates.sh [--worktree PATH] [--diff BASE] [--plan] [--allow-missing]
 #   --worktree       repo checkout to run in (default: cwd's repo root)
 #   --diff BASE      compute touched files: BASE...HEAD merge-base diff UNIONED with
@@ -99,16 +104,68 @@ gates_for() {
 	printf '%s' "$out"
 }
 
+# The Composer vendor guard is fail-closed: a failure there stops the run before any
+# Composer-backed PHP gate, which is unsafe against a missing or stale vendor tree. Matched
+# by substring rather than by whole-command equality because wrap_gates() below rewrites
+# the command text, and a comparison against the unwrapped literal would silently stop
+# recognising it — turning the hard stop into an ordinary gate failure.
+is_vendor_gate() {
+	case "$1" in
+	*'scripts/check_composer_vendor.py'*) return 0 ;;
+	esac
+	return 1
+}
+
+# Every gate runs in the CI runner image rather than against whatever the host happens to
+# have installed: test.yml executes each of its jobs inside ghcr.io/pfblockerng/ci-runner,
+# so a gate graded anywhere else answers a different question (issue #2350). gates_for()
+# stays the pure file-type -> canonical-command mapping its own spec pins; the wrapping
+# happens once, here.
+#
+# `sh -c '<cmd>'` and not a bare argv: the shellspec gate's text carries a command
+# substitution that has to resolve to the CONTAINER's dash — expanded host-side it yields
+# a path the image does not have. Single-quoting is safe because gates_for() already drops
+# any filename outside [A-Za-z0-9._/-] from the per-file buckets.
+#
+# The injection guard is NOT wrapped. It is a refusal, not a gate: it needs no toolchain,
+# and routing it through a container would make "this diff has an unsafe filename" depend
+# on docker being reachable.
+wrap_gates() {
+	while IFS= read -r c; do
+		[ -n "$c" ] || continue
+		case "$c" in
+		"printf 'unsafe filename in diff"*) printf '%s\n' "$c" ;;
+		*) printf "scripts/run-in-docker.sh sh -c '%s'\n" "$c" ;;
+		esac
+	done
+}
+
+# The per-gate report line names the GATE, not the plumbing. wrap_gates() puts the same
+# `scripts/run-in-docker.sh sh -c '...'` around every command, so repeating it on each
+# PASS/FAIL line would push the thing that actually failed off to the right for no added
+# information -- and a failing gate already prints the wrapper's own reason line above its
+# verdict. --plan still prints the real invocation, which is what gets copy-pasted.
+gate_label() {
+	case "$1" in
+	"scripts/run-in-docker.sh sh -c '"*)
+		label=${1#scripts/run-in-docker.sh sh -c \'}
+		printf '%s' "${label%\'}"
+		;;
+	*) printf '%s' "$1" ;;
+	esac
+}
+
 run_gate() {
 	# $1 = command line
+	label=$(gate_label "$1")
 	tool=${1%% *}
 	if ! (cd "$worktree" && { command -v "$tool" >/dev/null 2>&1 || [ -x "$tool" ]; }); then
-		if [ "$1" = 'python3 scripts/check_composer_vendor.py' ]; then
-			printf 'GATE FAIL: %s (TOOL-MISSING: %s)\n' "$1" "$tool"
+		if is_vendor_gate "$1"; then
+			printf 'GATE FAIL: %s (TOOL-MISSING: %s)\n' "$label" "$tool"
 			overall=1
 			return 1
 		fi
-		printf 'GATE SKIP: %s (TOOL-MISSING: %s)\n' "$1" "$tool"
+		printf 'GATE SKIP: %s (TOOL-MISSING: %s)\n' "$label" "$tool"
 		[ "$allow_missing" -eq 1 ] || overall=1
 		return 0
 	fi
@@ -122,13 +179,13 @@ run_gate() {
 	gate_output=$(cd "$worktree" && sh -c "$1" </dev/null 2>&1)
 	gate_status=$?
 	if [ "$gate_status" -eq 0 ]; then
-		printf 'GATE PASS: %s\n' "$1"
+		printf 'GATE PASS: %s\n' "$label"
 		return 0
 	fi
 	[ -z "$gate_output" ] || printf '%s\n' "$gate_output"
-	printf 'GATE FAIL: %s\n' "$1"
+	printf 'GATE FAIL: %s\n' "$label"
 	overall=1
-	[ "$1" = 'python3 scripts/check_composer_vendor.py' ] && return 1
+	is_vendor_gate "$1" && return 1
 	return 0
 }
 
@@ -175,7 +232,7 @@ main() {
 	files=$(printf '%s\n%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" "$untracked" | LC_ALL=C sort -u | grep -v '^$')
 	# The shellspec gate must also fire when only spec files changed (cross-language
 	# consumers rule): specs are .sh files, so the extension mapping already covers it.
-	cmds=$(printf '%s\n' "$files" | gates_for)
+	cmds=$(printf '%s\n' "$files" | gates_for | wrap_gates)
 
 	if [ "$plan" -eq 1 ]; then
 		printf '%s' "$cmds"
@@ -189,7 +246,7 @@ main() {
 		while IFS= read -r c; do
 			[ -n "$c" ] || continue
 			if ! run_gate "$c"; then
-				[ "$c" = 'python3 scripts/check_composer_vendor.py' ] && break
+				is_vendor_gate "$c" && break
 			fi
 		done
 		echo "OVERALL=$overall"

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -193,6 +193,12 @@ main() {
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
 	scrub_git_env "$0"
+	# The wrapper honours PFB_ALLOW_HOST, and run_gate suppresses a PASSING gate's output
+	# entirely -- so an inherited PFB_ALLOW_HOST would restore the silent host fallback
+	# here: rows of GATE PASS with nothing on screen naming the toolchain that produced
+	# them. This runner's verdict is a CI-parity verdict by definition, so it drops the
+	# variable outright; the escape hatch stays on the wrapper for ad-hoc use.
+	unset PFB_ALLOW_HOST
 	while [ $# -gt 0 ]; do
 		case "$1" in
 			--worktree) worktree=$2; shift 2 ;;

--- a/scripts/run-in-docker.sh
+++ b/scripts/run-in-docker.sh
@@ -25,17 +25,26 @@
 # Platform-gated cases may skip differently from a host run. CI grades on Linux,
 # so the container is the closer answer where they disagree.
 #
-# IT ALWAYS RUNS THE COMMAND. Every reason the container cannot be reached — docker
-# missing, daemon down, image absent and unpullable, a local build that fails, not even a
-# git work tree — prints one line naming that reason and then runs on the host instead.
-# The container is an optimisation, and a wrapper that refuses to run is worse than no
-# wrapper; naming the reason is what keeps a host run from being mistaken for a graded one.
+# IT RUNS IN THE CONTAINER OR NOT AT ALL. Every reason the container cannot be reached —
+# docker missing, daemon down, image absent and unpullable, a local build that fails, not
+# even a git work tree — prints one line naming that reason and exits 125 (docker's own
+# "could not run the container" status, so a caller can tell it apart from the wrapped
+# command going red).
+#
+# It used to degrade to a host run instead, on the reasoning that a wrapper which refuses
+# to run is worse than no wrapper. That holds for a convenience and fails for a gate: the
+# gates and the git hooks route through here now (issue #2350), and a run graded against
+# the host toolchain is not the run CI performs — every job in test.yml executes inside
+# this exact image. PFB_ALLOW_HOST=1 restores the old behaviour where that trade is still
+# the right one.
 #
 # Env:
 #   PFB_IMAGE   full image ref (default: ghcr.io/pfblockerng/ci-runner:<VERSION>)
 #   PFB_VM      non-empty -> use the ci-runner-vm image (qemu, oras, Playwright)
 #   PFB_BUILD   non-empty -> build the image locally instead of pulling (needs no
 #               credentials, which is the point while the packages are private)
+#   PFB_ALLOW_HOST  non-empty -> run on the host when no container can be reached,
+#               instead of refusing (the pre-#2350 behaviour; still says why)
 #   PFB_DOCKER_ARGS  extra args for `docker run` (e.g. "-e FOO=bar --network none")
 
 set -eu
@@ -46,22 +55,27 @@ if [ "$#" -eq 0 ]; then
 	set -- sh
 fi
 
-# The container is an optimisation, not a requirement: the command runs either way. Every
-# reason we cannot reach it is a fallback rather than an error, because refusing to run at
-# all would make this wrapper worse than typing the command directly — but each says WHY,
-# so a run that quietly graded on the host toolchain is never mistaken for a container one.
-# PFB_RUNNER travels with the process because the stderr line does not survive the ways
-# this gets used: `2>/dev/null` deletes it, a captured `$(...)` never shows it, and in a
-# long test run it scrolls past thousands of lines. `exec` rules out a closing summary, so
-# the fact has to be carried in-band — anything downstream, or `env | grep PFB_RUNNER`,
-# can then tell a host run from a graded one without having watched the scrollback.
+# Every reason we cannot reach a container ends here, and every one of them says WHY —
+# a refusal that does not name its cause just moves the debugging somewhere worse. The
+# override is named in the same breath, so the message is never a dead end.
+#
+# Under PFB_ALLOW_HOST the old degrade-to-host path runs instead. PFB_RUNNER travels with
+# the process there because the stderr line does not survive the ways this gets used:
+# `2>/dev/null` deletes it, a captured `$(...)` never shows it, and in a long test run it
+# scrolls past thousands of lines. `exec` rules out a closing summary, so the fact has to
+# be carried in-band — anything downstream, or `env | grep PFB_RUNNER`, can then tell a
+# host run from a graded one without having watched the scrollback.
 fallback() {
 	reason="$1"
 	shift
-	echo "run-in-docker: ${reason} — running on the host instead" >&2
-	PFB_RUNNER=host
-	export PFB_RUNNER
-	exec "$@"
+	if [ -n "${PFB_ALLOW_HOST:-}" ]; then
+		echo "run-in-docker: ${reason} — running on the host instead (PFB_ALLOW_HOST)" >&2
+		PFB_RUNNER=host
+		export PFB_RUNNER
+		exec "$@"
+	fi
+	echo "run-in-docker: ${reason} — refusing to run on the host (set PFB_ALLOW_HOST=1 to override)" >&2
+	exit 125
 }
 
 command -v docker >/dev/null 2>&1 ||

--- a/tests/shell/agent_run_gates_git_spec.sh
+++ b/tests/shell/agent_run_gates_git_spec.sh
@@ -156,6 +156,26 @@ Describe 'run-gates.sh over a C-quoted path'
       The contents of file "$repo/wrapper.log" should include 'mypy tests/'
     End
 
+    It 'drops an inherited PFB_ALLOW_HOST so no gate can silently grade on the host'
+      # The wrapper honours PFB_ALLOW_HOST by design, and run_gate suppresses a PASSING
+      # gate's output entirely -- so an exported PFB_ALLOW_HOST would put the silent host
+      # fallback straight back: rows of GATE PASS with nothing on screen saying which
+      # toolchain produced them. This runner's verdict is a CI-parity verdict by
+      # definition, so it drops the variable; the escape hatch stays on the wrapper for
+      # ad-hoc use.
+      mkdir -p "$repo/scripts"
+      printf '#!/bin/sh\nprintf "allow_host=%%s\\n" "${PFB_ALLOW_HOST:-unset}" >&2\nexit 1\n' \
+        > "$repo/scripts/run-in-docker.sh"
+      chmod +x "$repo/scripts/run-in-docker.sh"
+      printf 'x = 1\n' > "$repo/scripts/mod.py"
+      gitc add -A
+      gitc commit -q -m python
+      When run sh -c "PFB_ALLOW_HOST=1 sh '$SCRIPT' --worktree '$repo' --diff base"
+      The status should equal 1
+      The output should include 'allow_host=unset'
+      The output should not include 'allow_host=1'
+    End
+
     It 'fails the gate when the container is unreachable instead of skipping it'
       # The defect this pins: a missing host tool used to report `GATE SKIP`, and a
       # skipped gate reads greener than a failed one. With the run routed through the

--- a/tests/shell/agent_run_gates_git_spec.sh
+++ b/tests/shell/agent_run_gates_git_spec.sh
@@ -104,4 +104,78 @@ Describe 'run-gates.sh over a C-quoted path'
       The output should include 'GATES: FAIL'
     End
   End
+
+  # ── every gate runs in the CI runner image (issue #2350) ───────────────────── #
+  #
+  # The gates an agent runs locally and the gates CI runs must be the same binaries:
+  # every job in test.yml executes inside ghcr.io/pfblockerng/ci-runner, so a gate
+  # graded against whatever the host happens to have installed answers a different
+  # question. gates_for() stays a pure file-type -> canonical-command mapping (pinned
+  # by the sibling agent_run_gates_spec.sh); the wrapping happens once, in main().
+  Describe 'CI-image routing'
+    It 'wraps every planned gate in the CI runner image'
+      printf 'x = 1\n' > "$repo/scripts/mod.py"
+      gitc add -A
+      gitc commit -q -m python
+      When run sh "$SCRIPT" --worktree "$repo" --diff base --plan
+      The status should equal 0
+      # `sh -c` and not a bare argv: the shellspec gate's command text contains a
+      # command substitution that must resolve to the CONTAINER's dash, not the host's.
+      The line 1 of output should equal "scripts/run-in-docker.sh sh -c 'python3 -m pytest'"
+      The line 2 of output should equal "scripts/run-in-docker.sh sh -c 'ruff check .'"
+      The output should not include 'PFB_ALLOW_HOST'
+    End
+
+    It 'keeps the command substitution inside the container for the shellspec gate'
+      # Expanded host-side this resolves to /opt/homebrew/bin/dash, a path that does
+      # not exist in the image — the gate would die on an unusable --shell argument.
+      printf '#!/bin/sh\necho hi\n' > "$repo/scripts/plain.sh"
+      gitc add -A
+      gitc commit -q -m shell
+      When run sh "$SCRIPT" --worktree "$repo" --diff base --plan
+      The status should equal 0
+      # shellcheck disable=SC2016 # the literal $( ) must survive into the container
+      The output should include "run-in-docker.sh sh -c 'shellspec --shell \$(command -v dash || command -v sh)'"
+    End
+
+    It 'executes the gate through the wrapper rather than the host tool'
+      # A stub wrapper proves the routing end to end: the real gate binaries are never
+      # invoked, so a run that reached them would leave the marker unwritten.
+      mkdir -p "$repo/scripts"
+      printf '#!/bin/sh\necho "WRAPPED $*" >> "%s"\nexit 0\n' "$repo/wrapper.log" \
+        > "$repo/scripts/run-in-docker.sh"
+      chmod +x "$repo/scripts/run-in-docker.sh"
+      printf 'x = 1\n' > "$repo/scripts/mod.py"
+      gitc add -A
+      gitc commit -q -m python
+      When run sh "$SCRIPT" --worktree "$repo" --diff base
+      The status should equal 0
+      The output should include 'GATES: PASS'
+      The output should not include 'TOOL-MISSING'
+      The contents of file "$repo/wrapper.log" should include 'python3 -m pytest'
+      The contents of file "$repo/wrapper.log" should include 'mypy tests/'
+    End
+
+    It 'fails the gate when the container is unreachable instead of skipping it'
+      # The defect this pins: a missing host tool used to report `GATE SKIP`, and a
+      # skipped gate reads greener than a failed one. With the run routed through the
+      # image there is no host tool to be missing — a wrapper that cannot reach a
+      # container is a hard FAIL, and --allow-missing must not soften it either.
+      mkdir -p "$repo/scripts"
+      printf '#!/bin/sh\necho "no container" >&2\nexit 125\n' > "$repo/scripts/run-in-docker.sh"
+      chmod +x "$repo/scripts/run-in-docker.sh"
+      printf 'x = 1\n' > "$repo/scripts/mod.py"
+      gitc add -A
+      gitc commit -q -m python
+      When run sh "$SCRIPT" --worktree "$repo" --diff base --allow-missing
+      The status should equal 1
+      # The stub's own stderr, which run_gate captures and prints before GATE FAIL:
+      # without it a red run proves only that SOME gate failed, not that the gate
+      # reached the wrapper at all.
+      The output should include 'no container'
+      The output should include 'GATE FAIL'
+      The output should not include 'GATE SKIP'
+      The output should include 'GATES: FAIL'
+    End
+  End
 End

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -141,6 +141,12 @@ Describe 'run-gates.sh Composer vendor guard'
     gitc config commit.gpgsign false
     mkdir -p "$repo/src" "$repo/vendor/bin" "$repo/scripts"
     printf 'base\n' > "$repo/README"
+    # Every gate is routed through the CI runner image (issue #2350). A passthrough
+    # wrapper keeps these examples about the RUNNER's own ordering and reporting logic
+    # rather than about whether docker is reachable from the test host. It lands in the
+    # BASE commit so it never appears in the diff and never plans shell gates of its own.
+    printf '#!/bin/sh\nexec "$@"\n' > "$repo/scripts/run-in-docker.sh"
+    chmod +x "$repo/scripts/run-in-docker.sh"
     gitc add -A; gitc commit -qm base
     base_sha=$(gitc rev-parse HEAD)
     printf '<?php echo 1;\n' > "$repo/src/a.php"
@@ -199,11 +205,15 @@ Describe 'run-gates.sh Composer vendor guard'
     The output should not include 'GATES: PASS'
   End
 
-  It 'fails closed under --allow-missing when the Composer checker interpreter is unavailable'
-    mv "$stubdir/python3" "$stubdir/python3.disabled"
+  It 'fails closed under --allow-missing when the CI runner wrapper is unavailable'
+    # The vendor guard is the one gate a missing tool may never soften into a SKIP: every
+    # Composer-backed gate downstream of it is unsafe against an unverified vendor tree.
+    # With the run routed through the CI image (issue #2350) the tool that can go missing
+    # is the wrapper itself -- the interpreter now lives in the image, not on the host.
+    rm -f "$repo/scripts/run-in-docker.sh"
     When run sh -c "PATH='$stubdir' sh '$script' --worktree '$repo' --diff '$base_sha' --allow-missing"
     The status should equal 1
-    The output should include 'GATE FAIL: python3 scripts/check_composer_vendor.py (TOOL-MISSING: python3)'
+    The output should include 'GATE FAIL: python3 scripts/check_composer_vendor.py (TOOL-MISSING: scripts/run-in-docker.sh)'
     The output should not include 'GATE SKIP: python3 scripts/check_composer_vendor.py'
     The output should not include 'GATE PASS: php -l src/a.php'
     The output should not include 'GATE PASS: vendor/bin/phpunit'
@@ -244,6 +254,11 @@ Describe 'run-gates.sh main (fixture repo, stubbed tools)'
     # Under scripts/ so the files are in shellcheck's scope (src, scripts, .claude/hooks).
     mkdir -p "$repo/scripts"
     printf '#!/bin/sh\n# gone-marker: content distinct from kept.sh so git reports a\n# genuine deletion (identical content collapses to an R100 rename)\ntrue\n' > "$repo/scripts/gone.sh"
+    # Passthrough CI-image wrapper (issue #2350): these examples pin the runner's own
+    # ordering, capture and verdict logic, not docker reachability. It lands in the BASE
+    # commit so it stays out of the diff and plans no shell gates of its own.
+    printf '#!/bin/sh\nexec "$@"\n' > "$repo/scripts/run-in-docker.sh"
+    chmod +x "$repo/scripts/run-in-docker.sh"
     gitc add -A; gitc commit -qm base
     base_sha=$(gitc rev-parse HEAD)
     gitc rm -q scripts/gone.sh   # also prunes the now-empty scripts/ dir

--- a/tests/shell/precommit_ci_image_spec.sh
+++ b/tests/shell/precommit_ci_image_spec.sh
@@ -1,0 +1,85 @@
+#shellcheck shell=sh
+# .githooks/pre-commit PHP gates run in the CI runner image, never against a host PHP
+# (issue #2350).
+#
+# WHY ONLY THE PHP GATES: a commit hook that hard-requires Docker is too heavy a gate, so
+# the fast host-native linters (ruff, shellcheck, sh -n, markdownlint, the Python policy
+# checkers) keep running exactly where they always did. PHP is the exception — the repo's
+# only PHP consumer is this project, the matrix pins 8.3 and 8.5, and a host PHP is
+# whichever version that machine happens to carry. There is nothing to gain from grading
+# `php -l` and PHPCS against it, and a silent version divergence to lose.
+#
+# The hook prepends Homebrew's bin to PATH by design, so "assert the host php was not
+# found" is not a property this spec can hold on a developer machine. It asserts the
+# positive instead: the gate command reaches the WRAPPER, and a planted host `php` on
+# PATH is never invoked.
+
+Describe '.githooks/pre-commit PHP gates in the CI image'
+  gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+
+  make_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitimage.XXXXXX")"
+    git_fixture -C "$repo" init -q
+    gitc config commit.gpgsign false
+    mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
+    cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+    printf '<?php echo 1;\n' > "$repo/src/a.php"
+    gitc add src/a.php
+
+    wrapper_log="$repo/wrapper.log"
+    # exit 0 by default; WRAPPER_RC lets an example make the container unreachable.
+    printf '#!/bin/sh\nprintf "%%s\\n" "$*" >> "%s"\nexit "${WRAPPER_RC:-0}"\n' "$wrapper_log" \
+      > "$repo/scripts/run-in-docker.sh"
+    chmod +x "$repo/scripts/run-in-docker.sh"
+
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitimagestub.XXXXXX")"
+    host_php_marker="$stubdir/host-php-ran"
+    # A host php AND a host phpcs, both of which must stay untouched: this is the exact
+    # thing the change removes from the hook's reach.
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$host_php_marker" > "$stubdir/php"
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$host_php_marker" > "$repo/vendor/bin/phpcs"
+    # The Composer vendor guard is fail-closed and runs before every PHP style gate, so
+    # it has to succeed for those gates to be reached at all.
+    for interpreter in python python3; do
+      printf '#!/bin/sh\nexit 0\n' > "$stubdir/$interpreter"
+    done
+    chmod +x "$stubdir/php" "$stubdir/python" "$stubdir/python3" "$repo/vendor/bin/phpcs"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup() { rm -rf "$repo" "$stubdir"; }
+  Before 'make_repo'
+  After 'cleanup'
+
+  It 'sends php -l and phpcs through the wrapper and never runs the host PHP'
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include '[pre-commit] php -l'
+    The output should include '[pre-commit] phpcs'
+    The contents of file "$wrapper_log" should include 'php -l'
+    The contents of file "$wrapper_log" should include 'phpcs'
+    Assert [ ! -e "$host_php_marker" ]
+  End
+
+  It 'fails the commit when the container is unreachable'
+    # The defect direction that matters: the hook used to report `skipped (tool not
+    # found)` for an absent php, and a skipped gate reads greener than a failed one.
+    # An unreachable container is a FAILED gate, and it blocks the commit.
+    export WRAPPER_RC=125
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should include '[pre-commit] php -l'
+    The stderr should include '[pre-commit] FAILED: php -l'
+    The stderr should not include 'skipped (tool not found)'
+  End
+
+  It 'still blocks the PHP gates when the Composer vendor guard fails'
+    # The guard is fail-closed and ordered before the style gates; routing them through
+    # the image must not reorder that.
+    rm -f "$stubdir/python" "$stubdir/python3"
+    When run sh -c "cd '$repo' && PATH='$stubdir:/usr/bin:/bin' sh .githooks/pre-commit"
+    The status should equal 1
+    The stderr should include '[pre-commit] FAILED: composer vendor'
+    Assert [ ! -e "$wrapper_log" ]
+  End
+End

--- a/tests/shell/precommit_composer_vendor_spec.sh
+++ b/tests/shell/precommit_composer_vendor_spec.sh
@@ -8,10 +8,16 @@ Describe '.githooks/pre-commit Composer vendor guard'
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitphp.XXXXXX")"
     git_fixture -C "$repo" init -q
     gitc config commit.gpgsign false
-    mkdir -p "$repo/.githooks" "$repo/src" "$repo/vendor/bin"
+    mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
     printf '<?php echo 1;\n' > "$repo/src/a.php"
     gitc add src/a.php
+    # The PHP style gates run in the CI runner image (issue #2350); a passthrough
+    # wrapper keeps these examples about the vendor guard's ORDERING, which is what
+    # they pin, rather than about docker reachability. The sibling
+    # precommit_ci_image_spec.sh covers the routing itself.
+    printf '#!/bin/sh\nexec "$@"\n' > "$repo/scripts/run-in-docker.sh"
+    chmod +x "$repo/scripts/run-in-docker.sh"
 
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitphpstub.XXXXXX")"
     checker_marker="$stubdir/checker-ran"

--- a/tests/shell/precommit_hostile_path_spec.sh
+++ b/tests/shell/precommit_hostile_path_spec.sh
@@ -14,8 +14,16 @@ Describe '.githooks/pre-commit with a C-quoted path'
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommithostile.XXXXXX")"
     git_fixture -C "$repo" init -q
     gitc config commit.gpgsign false
-    mkdir -p "$repo/.githooks" "$repo/src" "$repo/vendor/bin"
+    mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+    # The PHP style gates run in the CI runner image (issue #2350). A passthrough
+    # wrapper keeps this spec about WHICH gates the hook decides to run — what it is
+    # actually pinning — rather than about docker reachability. Git-excluded, because
+    # the examples stage with `add -A`: a staged .sh would switch on the hook's SHELL
+    # gates too and change what each row is measuring.
+    printf 'scripts/\n' > "$repo/.git/info/exclude"
+    printf '#!/bin/sh\nexec "$@"\n' > "$repo/scripts/run-in-docker.sh"
+    chmod +x "$repo/scripts/run-in-docker.sh"
 
     # Stubs stand in for the real analysis tools: this spec pins WHICH gates the
     # hook decides to run and what its own scans see, not what those tools conclude.

--- a/tests/shell/run_in_docker_spec.sh
+++ b/tests/shell/run_in_docker_spec.sh
@@ -1,31 +1,33 @@
 #shellcheck shell=sh
-# run_in_docker_fallback_spec.sh — the wrapper's one hard invariant: it always runs the
-# command it was given.
+# run_in_docker_spec.sh — the wrapper's one hard invariant: a command it accepts runs in
+# the CI runner image, or it does not run at all.
 #
-# WHY THIS EXISTS: the wrapper is an optimisation (the CI toolchain, and ~3x faster than
-# the host for the pytest suite on Apple Silicon), but the images it wants are currently
-# PRIVATE, so on a machine without a GHCR login every path to a container fails. A wrapper
-# that refuses to run in that situation is worse than no wrapper — you would stop reaching
-# for it, which is how a convenience becomes a liability.
+# WHY THIS CHANGED (issue #2350): the wrapper used to degrade every unreachable-container
+# path to a host run, on the reasoning that a wrapper which refuses to run is worse than
+# no wrapper. That reasoning holds for a convenience and fails for a gate. The gates and
+# the hooks now route through here, and a run graded against the host toolchain is not the
+# run CI performs — every workflow job in test.yml executes inside this exact image. So an
+# unreachable container is a REFUSAL, and the escape hatch is explicit: PFB_ALLOW_HOST=1
+# restores the old degrade-to-host behaviour for ad-hoc use.
 #
-# So every failure to reach a container degrades to a host run. The property that makes
-# that safe rather than sloppy is the MESSAGE: each fallback names the reason it happened,
-# because the failure mode being designed against is not "the command did not run", it is
-# "the command ran on the host and I thought it ran in the container". A silent fallback
-# would be the bug. Hence every example below asserts both halves — the command ran, and
-# the run said why it was not containerised.
+# Two properties are asserted on every refusal, because "did not run" and "ran somewhere
+# else" fail in opposite directions:
+#   1. the command did NOT execute (a marker file settles it — asserting on stdout cannot,
+#      since the docker stub echoes the argv it was handed and the argv contains the
+#      command's own text);
+#   2. stderr names the reason AND the override, so a refusal is never a dead end.
 #
 # The docker stub answers by exit code alone (STUB_*_RC), which is all the wrapper reads.
 # `docker run` is the exception: it echoes, so the examples that must prove the container
 # path was NOT abandoned have something positive to assert on.
 
-Describe 'run-in-docker.sh host fallback'
+Describe 'run-in-docker.sh'
   SCRIPT="${PFB_ROOT}/scripts/run-in-docker.sh"
 
   setup() {
     # Mandatory per spec_helper: the script under test asks git for the work tree, the
     # toplevel and the common dir, so an inherited GIT_* answers for the fixture and the
-    # fallback examples stop falling back.
+    # refusal examples stop refusing.
     scrub_git_env
     WORK="$(mktemp -d)"
     STUB="${WORK}/bin"
@@ -60,19 +62,15 @@ STUB_EOF
     ( cd "$PFB_ROOT" && PATH="$STUB_PATH" "$SCRIPT" "$@" )
   }
 
-  # `docker run` is stubbed, so a containerised command never executes. A marker FILE
-  # settles which side ran without ambiguity: asserting on stdout cannot, because the
-  # stub echoes the argv it was handed, and the argv contains the command's own text.
-
   real_docker_on_std_path() {
     PATH=/usr/bin:/bin:/usr/sbin:/sbin command -v docker >/dev/null 2>&1
   }
 
-  # ── the container path still wins when a container is available ──────────── #
+  # ── the container path ────────────────────────────────────────────────────── #
 
   It 'runs in the container when the image is already on the machine'
-    # The negative examples below only mean something if this one proves the wrapper
-    # does not simply always fall back.
+    # The refusal examples below only mean something if this one proves the wrapper
+    # does not simply always refuse.
     export STUB_INSPECT_RC=0
     When call wrapper sh -c "echo ran > '${WORK}/host_ran'"
     The status should be success
@@ -82,7 +80,7 @@ STUB_EOF
     # a wrapper that dropped its trailing "$@" would start an empty container and pass.
     The output should include 'host_ran'
     The path "${WORK}/host_ran" should not be exist
-    The stderr should not include 'running on the host'
+    The stderr should not include 'host'
   End
 
   It 'uses an init process to reap orphaned grandchildren'
@@ -100,97 +98,106 @@ STUB_EOF
     The output should include 'DOCKER_RUN'
     The output should include 'host_ran'
     The path "${WORK}/host_ran" should not be exist
-    The stderr should not include 'running on the host'
+    The stderr should not include 'host'
   End
 
-  # ── every way of not getting a container ─────────────────────────────────── #
+  # ── every way of not getting a container is now a refusal ─────────────────── #
+  #
+  # 125 and not 1: the exit status has to be distinguishable from the wrapped command's
+  # own failure, or a caller cannot tell "the gate went red" from "the gate never ran".
+  # It is docker's own reserved "could not run the container" status.
 
-  It 'falls back, saying so, when docker is not installed'
+  It 'refuses, saying so, when docker is not installed'
     Skip if 'a real docker is on the standard PATH' real_docker_on_std_path
     rm -f "${STUB}/docker"
-    When call wrapper sh -c 'echo HOST_RAN'
-    The status should be success
-    The output should include 'HOST_RAN'
+    When call wrapper sh -c "echo ran > '${WORK}/host_ran'"
+    The status should equal 125
+    The path "${WORK}/host_ran" should not be exist
     The stderr should include 'docker is not installed'
-    The stderr should include 'running on the host'
+    The stderr should include 'PFB_ALLOW_HOST=1'
   End
 
-  It 'falls back, saying so, when the daemon is unreachable'
+  It 'refuses, saying so, when the daemon is unreachable'
     export STUB_INFO_RC=1
-    When call wrapper sh -c 'echo HOST_RAN'
-    The status should be success
-    The output should include 'HOST_RAN'
+    When call wrapper sh -c "echo ran > '${WORK}/host_ran'"
+    The status should equal 125
+    The path "${WORK}/host_ran" should not be exist
     The stderr should include 'daemon is not reachable'
+    The stderr should include 'PFB_ALLOW_HOST=1'
   End
 
-  It 'falls back, saying so, when the image is absent and cannot be pulled'
-    # The live case today: the packages are private, so an unauthenticated pull 401s.
+  It 'refuses, saying so, when the image is absent and cannot be pulled'
+    # The live case on a machine with no GHCR login: the packages are private, so an
+    # unauthenticated pull 401s. The reason is only useful if it also names the cure.
     export STUB_INSPECT_RC=1 STUB_PULL_RC=1
-    When call wrapper sh -c 'echo HOST_RAN'
-    The status should be success
-    The output should include 'HOST_RAN'
+    When call wrapper sh -c "echo ran > '${WORK}/host_ran'"
+    The status should equal 125
+    The path "${WORK}/host_ran" should not be exist
     The stderr should include 'could not be pulled'
-    # The reason is only useful if it also names the cure.
     The stderr should include 'PFB_BUILD=1'
   End
 
-  It 'falls back, saying so, when an explicitly requested build fails'
-    # PFB_BUILD is the documented answer to the previous example, so it is the one path
-    # where the user has already been told "this will work" — it failing silently, or
-    # refusing to run, would be the worst of the set.
+  It 'refuses, saying so, when an explicitly requested build fails'
     export PFB_BUILD=1 STUB_INSPECT_RC=1 STUB_BUILD_RC=1
-    When call wrapper sh -c 'echo HOST_RAN'
-    The status should be success
-    The output should include 'HOST_RAN'
+    When call wrapper sh -c "echo ran > '${WORK}/host_ran'"
+    The status should equal 125
+    The path "${WORK}/host_ran" should not be exist
     The stderr should include 'failed to build'
   End
 
-  It 'falls back, saying so, outside a git work tree'
+  It 'refuses, saying so, outside a git work tree'
     export STUB_INSPECT_RC=0
-    When run sh -c "cd '$WORK' && PATH='$STUB_PATH' '$SCRIPT' sh -c 'echo HOST_RAN'"
-    The status should be success
-    The output should include 'HOST_RAN'
+    When run sh -c "cd '$WORK' && PATH='$STUB_PATH' '$SCRIPT' sh -c \"echo ran > '${WORK}/host_ran'\""
+    The status should equal 125
+    The path "${WORK}/host_ran" should not be exist
     The stderr should include 'not inside a git work tree'
   End
 
-  It 'falls back, saying so, in a checkout with no VERSION file'
+  It 'refuses, saying so, in a checkout with no VERSION file'
     # A shallow or historical checkout that predates the CI images: there is a repo to
     # mount, but nothing naming which image belongs to it.
     git_fixture init -q "${WORK}/repo"
     export STUB_INSPECT_RC=0
-    When run sh -c "cd '${WORK}/repo' && PATH='$STUB_PATH' '$SCRIPT' sh -c 'echo HOST_RAN'"
-    The status should be success
-    The output should include 'HOST_RAN'
+    When run sh -c "cd '${WORK}/repo' && PATH='$STUB_PATH' '$SCRIPT' sh -c \"echo ran > '${WORK}/host_ran'\""
+    The status should equal 125
+    The path "${WORK}/host_ran" should not be exist
     The stderr should include 'VERSION'
     The stderr should include 'PFB_IMAGE'
   End
 
-  # ── the fallback is a real exec, not a swallow ───────────────────────────── #
+  # ── PFB_ALLOW_HOST restores the degrade-to-host behaviour ─────────────────── #
 
-  It 'propagates the exit status of a host-run command'
+  It 'falls back to the host, saying so, under PFB_ALLOW_HOST'
+    export STUB_INFO_RC=1 PFB_ALLOW_HOST=1
+    When call wrapper sh -c 'echo HOST_RAN'
+    The status should be success
+    The output should include 'HOST_RAN'
+    The stderr should include 'daemon is not reachable'
+    The stderr should include 'running on the host'
+  End
+
+  It 'propagates the exit status of a host-run command under PFB_ALLOW_HOST'
     # `exec` and not a wrapped call: a fallback that reported success for a failing
     # command would turn a red gate green, which is the one outcome worse than refusing.
-    export STUB_INFO_RC=1
+    export STUB_INFO_RC=1 PFB_ALLOW_HOST=1
     When call wrapper sh -c 'exit 42'
     The status should eq 42
     The stderr should include 'running on the host'
   End
 
-  It 'still names the reason when the command itself is absent'
+  It 'still names the reason when the command itself is absent under PFB_ALLOW_HOST'
     # The fallback must not become the explanation for an unrelated failure.
-    export STUB_INFO_RC=1
+    export STUB_INFO_RC=1 PFB_ALLOW_HOST=1
     When call wrapper definitely-not-a-real-command
     The status should not eq 0
     The stderr should include 'running on the host'
   End
 
-  # ── telling the two runs apart after the fact ────────────────────────────── #
-
   It 'marks a host run in the environment, where a pipe cannot lose it'
     # The stderr line is the primary signal, but `2>/dev/null` deletes it and a captured
     # $(...) never shows it — so the fact travels with the process too, or a script that
     # graded on the host toolchain has no way to know it did.
-    export STUB_INFO_RC=1
+    export STUB_INFO_RC=1 PFB_ALLOW_HOST=1
     When call wrapper sh -c 'echo "runner=${PFB_RUNNER:-unset}"'
     The status should be success
     The output should include 'runner=host'
@@ -214,7 +221,7 @@ STUB_EOF
     When call wrapper true
     The status should be success
     The stderr should include 'building'
-    # ...and then actually uses what it built, rather than falling back after a fine build.
+    # ...and then actually uses what it built, rather than refusing after a fine build.
     The output should include 'DOCKER_RUN'
   End
 End


### PR DESCRIPTION
## What

Route local gate and test runs through `ghcr.io/pfblockerng/ci-runner`, the image every
`test.yml` job already executes inside, so a local verdict is the verdict the PR gets.

## Why

`scripts/run-in-docker.sh` existed but was opt-in, and by design it degraded to a host run
on every path that could not reach a container. Nothing routed through it: both
`scripts/agent/run-gates.sh` and `.githooks/pre-commit` invoked `pytest`, `php`, PHPUnit,
PHPCS, `shellspec`, `ruff` and `mypy` directly.

Two consequences. A local gate graded against whatever the host happened to have
installed. And removing a host tool did not push the run into the container — it made the
gate **skip**: `GATE SKIP: <cmd> (TOOL-MISSING: <tool>)` from the runner, `skipped (tool
not found)` from the hook. A skipped gate reads greener than a failed one, which is the
worse of the two failure modes.

## Changes

- **`scripts/run-in-docker.sh` refuses instead of degrading.** Every unreachable-container
  path prints its reason and exits **125** — docker's own "could not run the container"
  status, so a caller can tell it apart from the wrapped command going red.
  `PFB_ALLOW_HOST=1` restores the previous behaviour for ad-hoc use, and still says why.
- **`scripts/agent/run-gates.sh` wraps every planned gate** in
  `scripts/run-in-docker.sh sh -c '...'`. `sh -c` rather than a bare argv because the
  shellspec gate's command substitution has to resolve to the *container's* `dash`;
  expanded host-side it yields a path the image does not have. `gates_for()` stays the pure
  file-type → canonical-command mapping its own spec pins — the wrapping happens once, in
  `main()`. The unsafe-filename guard is deliberately **not** wrapped: it is a refusal, not
  a gate, and must not start depending on docker. Report lines keep the canonical command
  text so the failing gate stays legible; `--plan` prints the real invocation.
- **`.githooks/pre-commit` routes only its two PHP style gates** (`php -l`, PHPCS) through
  the image, and fails rather than skipping when it cannot be reached. Everything else in
  the hook stays host-native — a commit gate that hard-requires Docker is too heavy, and
  PHP is the one tool whose host version is meaningless against a matrix pinning 8.3 and
  8.5. Committing still needs no Docker unless the commit stages PHP.

## Tests

Test-first, red → green, tests frozen byte-identical across both runs
(`git hash-object`: `d575abc`, `3af3afd`, `9c57120`).

- `tests/shell/run_in_docker_spec.sh` (renamed from `run_in_docker_fallback_spec.sh`) —
  every unreachable-container path now refuses: exit 125, the command provably did not run
  (marker file), stderr names both the reason and the override. `PFB_ALLOW_HOST=1` examples
  keep the degrade path covered.
- `tests/shell/agent_run_gates_git_spec.sh` — new `CI-image routing` group: `--plan` emits
  the wrapped form, the shellspec substitution survives into the container, execution goes
  through the wrapper (stub logs the argv), and an unreachable container is a `GATE FAIL`
  with no `GATE SKIP` even under `--allow-missing`.
- `tests/shell/precommit_ci_image_spec.sh` (new) — the hook's PHP gates reach the wrapper,
  a planted host `php` is never invoked, and an unreachable container blocks the commit.
- Existing fixtures in `agent_run_gates_spec.sh`, `precommit_composer_vendor_spec.sh` and
  `precommit_hostile_path_spec.sh` gain a passthrough wrapper stub so they keep pinning
  what they were written to pin (ordering, capture, verdicts, stage classification) rather
  than docker reachability. The `--allow-missing` vendor-guard example now removes the
  wrapper instead of the host interpreter, which is where "the tool is missing" lives now.

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (full shellspec suite,
1324 examples, 0 failures, run in `ci-runner:8`; markdownlint green).

## Docs

`.agents/policy/testing.md` and `CONTRIBUTING.md` updated: the wrapper is the default way
to run a suite, 125 is the refusal status, `PFB_ALLOW_HOST=1` is the escape hatch, and
`PFB_RUNNER` still has to be checked before any containerised claim.

Part of #2350


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-commit PHP checks now run through the CI Docker environment instead of host tools.
  * Commits fail clearly when Docker, the required image, or mandatory Composer validation is unavailable.
  * Container failures are reported as failures rather than being silently skipped.

* **Improvements**
  * Host execution can be explicitly restored with an override setting.
  * Gate reporting and execution behavior are now more consistent and transparent.

* **Tests**
  * Added coverage for container routing, failure handling, Composer validation, and pre-commit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->