### PR TITLE
Fix plain reboot readiness probe

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3656,7 +3656,12 @@ def pfb_config_digest(vm: SmokeVM, *, timeout: float = 30.0) -> str:
 _BOOTTIME_SYSCTL = "sysctl -n kern.boottime"
 
 
-def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
+def reboot_vm(
+    vm: SmokeVM,
+    *,
+    timeout: float = DEFAULT_BOOT_TIMEOUT,
+    require_pkg_metadata: bool = False,
+) -> None:
     """Reboot, observe a changed ``kern.boottime``, then await full readiness.
 
     The boottime poll is the reboot event; ``timeout`` supplies independent salvage caps for
@@ -3731,9 +3736,9 @@ def reboot_vm(vm: SmokeVM, *, timeout: float = DEFAULT_BOOT_TIMEOUT) -> None:
         raise RuntimeError(
             f"reboot_vm: VM not ready after reboot (wait_ready exit {result.returncode}); stderr={result.stderr!r}"
         )
-    # Mirror the initial boot's post-wait_ready gate (conftest boot_vm): block until
-    # is_platform_booting() clears so a post-reboot pfBlockerNG sync cannot race boot (#559).
-    wait_boot_complete(vm)
+    # Plain smoke reboots need the platform boot flag. Upgrade-oriented callers can also
+    # require the package-metadata sentinel used by initial boot readiness.
+    wait_boot_complete(vm, require_pkg_metadata=require_pkg_metadata)
     flag = vm.ssh("/bin/test", "-f", PFB_CRON_DISABLE_PATH)
     if flag.returncode != 0:
         raise RuntimeError(f"reboot_vm: earlyshellcmd did not restore {PFB_CRON_DISABLE_PATH} before tests resumed")
@@ -4035,8 +4040,14 @@ def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 60, delay: float = 2.0) -
     )
 
 
-def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.0) -> None:
-    """Block until pfSense has finished booting and package metadata has settled.
+def wait_boot_complete(
+    vm: SmokeVM,
+    *,
+    timeout: float = 180.0,
+    delay: float = 3.0,
+    require_pkg_metadata: bool = True,
+) -> None:
+    """Block until pfSense has finished booting and, when requested, metadata has settled.
 
     pfSense's rc removes ``/var/run/booting`` only at the very END of bootup -- AFTER
     the web port (which ``wait_ready.sh`` keys on) already answers. So a fast box can
@@ -4070,6 +4081,8 @@ def wait_boot_complete(vm: SmokeVM, *, timeout: float = 180.0, delay: float = 3.
         if "<<BOOT>>" in out and "<<END>>" in out:
             last = out.split("<<BOOT>>", 1)[1].split("<<END>>", 1)[0].strip()
             if last == "0":
+                if not require_pkg_metadata:
+                    return
                 try:
                     metadata = vm.ssh("/bin/test", "-f", "/var/run/pfSense_version.rc", timeout=30.0)
                 except subprocess.TimeoutExpired:

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -36,3 +36,36 @@ def test_wait_boot_complete_waits_for_boot_metadata_sentinel(monkeypatch: pytest
         ("/bin/test", "-f", "/var/run/pfSense_version.rc"),
         ("/bin/test", "-f", "/var/run/pfSense_version.rc"),
     ]
+
+
+def test_wait_boot_complete_plain_reboot_needs_only_platform_boot_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    boot_values = iter(["1", "0"])
+    php_calls: list[str] = []
+
+    class FakeVM:
+        def ssh(self, *_remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            raise AssertionError("plain reboot must not probe package metadata")
+
+    def fake_php_eval(_vm: helpers.SmokeVM, snippet: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        php_calls.append(snippet)
+        return subprocess.CompletedProcess([], 0, f"<<BOOT>>{next(boot_values)}<<END>>", "")
+
+    monkeypatch.setattr(
+        helpers,
+        "php_eval",
+        fake_php_eval,
+    )
+    monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: 0.0)
+
+    helpers.wait_boot_complete(
+        cast(helpers.SmokeVM, FakeVM()),
+        timeout=3,
+        delay=0,
+        require_pkg_metadata=False,
+    )
+
+    assert len(php_calls) == 2
+    assert all("is_platform_booting" in snippet for snippet in php_calls)

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -88,6 +88,7 @@ def test_reboot_vm_waits_for_changed_boottime_before_readiness(
         helpers.reboot_vm(vm, timeout=5, require_pkg_metadata=require_pkg_metadata)
 
     assert ready_calls
+    assert "/sbin/reboot" in fake_vm.calls
     assert fake_vm.boottime_reads == 4
     assert boot_waits == [(vm, False if require_pkg_metadata is None else require_pkg_metadata)]
     assert cron_guards == [vm]

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -24,7 +24,11 @@ _BEFORE = "{ sec = 1751500000, usec = 123456 }"
 _AFTER = "{ sec = 1751500090, usec = 654321 }"
 
 
-def test_reboot_vm_waits_for_changed_boottime_before_readiness(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("require_pkg_metadata", [None, False, True])
+def test_reboot_vm_waits_for_changed_boottime_before_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    require_pkg_metadata: bool | None,
+) -> None:
     class FakeVM:
         ssh_key_path = "/tmp/id_ed25519"
         host = "127.0.0.1"
@@ -64,13 +68,26 @@ def test_reboot_vm_waits_for_changed_boottime_before_readiness(monkeypatch: pyte
 
     monkeypatch.setattr(helpers.subprocess, "run", fake_run)
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
-    monkeypatch.setattr(helpers, "wait_boot_complete", lambda vm: None)
+    boot_waits: list[tuple[helpers.SmokeVM, bool]] = []
+
+    def fake_wait_boot_complete(
+        candidate: helpers.SmokeVM,
+        *,
+        require_pkg_metadata: bool = True,
+    ) -> None:
+        boot_waits.append((candidate, require_pkg_metadata))
+
+    monkeypatch.setattr(helpers, "wait_boot_complete", fake_wait_boot_complete)
     monkeypatch.setattr(helpers, "wait_unbound_ready", lambda vm: None)
     cron_guards: list[object] = []
     monkeypatch.setattr(helpers, "_write_cron_disable_flag", lambda vm: cron_guards.append(vm))
 
-    helpers.reboot_vm(vm, timeout=5)
+    if require_pkg_metadata is None:
+        helpers.reboot_vm(vm, timeout=5)
+    else:
+        helpers.reboot_vm(vm, timeout=5, require_pkg_metadata=require_pkg_metadata)
 
     assert ready_calls
     assert fake_vm.boottime_reads == 4
+    assert boot_waits == [(vm, False if require_pkg_metadata is None else require_pkg_metadata)]
     assert cron_guards == [vm]


### PR DESCRIPTION
## Summary

- treat `is_platform_booting() == 0` as sufficient readiness for ordinary smoke-test reboots
- retain the `/var/run/pfSense_version.rc` gate for initial boot and callers that explicitly require package-metadata settlement
- expose that distinction through `reboot_vm(..., require_pkg_metadata=...)`

The previous shared reboot helper always required the package-metadata sentinel. A plain reboot does not guarantee that file is published, so RAM-disk reboot smoke stopped before its product assertions even though pfSense had finished booting.

## Verification

- frozen RED: 5 focused tests, 4 intended failures and 1 pass
- GREEN: 5 focused tests pass; 208 non-live smoke tests pass in the canonical CI container
- `scripts/run-in-docker.sh scripts/agent/run-gates.sh --diff origin/devel`: PASS
- live `scripts/local-smoke.sh --marker reboot --filter dnsbl_tld_wildcard`: 1 passed, 986 deselected on box `.38`; lease released
- independent review: PASS, including mutation proof that changing the public default to `True` fails the omitted-argument test row

Supports #1541; intentionally separate from the PSL implementation.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reboots can now optionally skip waiting for package metadata, enabling readiness checks based solely on platform boot completion.
  * Existing behavior continues to wait for package metadata by default when requested.

* **Tests**
  * Added coverage confirming metadata checks are skipped correctly during plain reboots.
  * Expanded reboot readiness tests across metadata-enabled, metadata-disabled, and default configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->