### PR TITLE
tests: keep the doc scan out of agent worktrees

### DIFF
--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -20,6 +20,22 @@ def _ci_requirements() -> str:
     return (ROOT / ".github/docker/ci-requirements.txt").read_text(encoding="utf-8")
 
 
+def _docs_under(root: Path) -> list[Path]:
+    """The Markdown files this checkout is answerable for.
+
+    `.claude/worktrees/` is excluded by PATH, not by directory name: it holds per-task
+    agent worktrees — gitignored, one whole repository checkout each — so a name-based
+    skip would also drop a legitimate `worktrees/` directory elsewhere in the tree, while
+    walking into them grades OTHER branches' documentation at commits this checkout has no
+    say over. One worktree pinned before #2198 then reports an unpinned installer forever,
+    and no edit here can make the suite green (#2353). CI never sees it: a fresh
+    actions/checkout has no worktrees.
+    """
+    skip = {"node_modules", ".venv", "vendor", "plugins", ".git"}
+    worktrees = root / ".claude" / "worktrees"
+    return [path for path in root.rglob("*.md") if not skip & set(path.parts) and worktrees not in path.parents]
+
+
 def test_the_gate_deciding_pins_live_in_the_image_and_nowhere_else() -> None:
     """The toolchain moved from per-job installs into ci-runner. These pins decide gate
     verdicts, so they need exactly ONE home: a workflow that re-installs a pinned tool
@@ -87,14 +103,42 @@ def test_no_doc_offers_an_unpinned_shellspec_installer() -> None:
     """CONTRIBUTING.md's pinned instructions are only worth anything if they are the ones a
     contributor finds: tests/shell/README.md carried a second, unpinned install (`brew` +
     the upstream `curl | sh`) that CONTRIBUTING.md itself links to (#2198)."""
-    skip = {"node_modules", ".venv", "vendor", "plugins", ".git"}
     offenders = sorted(
         str(path.relative_to(ROOT))
-        for path in ROOT.rglob("*.md")
-        if not skip & set(path.parts) and "git.io/shellspec" in path.read_text(encoding="utf-8")
+        for path in _docs_under(ROOT)
+        if "git.io/shellspec" in path.read_text(encoding="utf-8")
     )
 
     assert offenders == [], (
         f"these docs still hand out an unpinned shellspec installer instead of pointing at"
         f" CONTRIBUTING.md's pinned instructions: {offenders}"
     )
+
+
+def test_the_doc_scan_ignores_agent_worktrees(tmp_path: Path) -> None:
+    """`.claude/worktrees/` holds per-task agent worktrees — gitignored, one whole
+    repository checkout each. Walking into them grades OTHER branches' documentation, at
+    commits this checkout has no say over, so a worktree pinned before #2198 reports an
+    unpinned installer forever and the suite cannot be made green from here (#2353)."""
+    (tmp_path / ".claude/worktrees/issue-1/docs").mkdir(parents=True)
+    (tmp_path / ".claude/worktrees/issue-1/CONTRIBUTING.md").write_text("stale", encoding="utf-8")
+    (tmp_path / ".claude/worktrees/issue-1/docs/deep.md").write_text("stale", encoding="utf-8")
+
+    assert _docs_under(tmp_path) == []
+
+
+def test_the_doc_scan_still_reaches_the_checkouts_own_docs(tmp_path: Path) -> None:
+    """The exclusion has to be the worktree directory and nothing more: a scan that skipped
+    `.claude/` wholesale, or simply returned nothing, would pass every assertion above while
+    guarding nothing at all."""
+    (tmp_path / "docs/misc").mkdir(parents=True)
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / "vendor").mkdir()
+    (tmp_path / "docs/misc/notes.md").write_text("kept", encoding="utf-8")
+    (tmp_path / ".claude/rules.md").write_text("kept", encoding="utf-8")
+    (tmp_path / "README.md").write_text("kept", encoding="utf-8")
+    (tmp_path / "vendor/upstream.md").write_text("skipped — not ours to grade", encoding="utf-8")
+
+    found = sorted(str(path.relative_to(tmp_path)) for path in _docs_under(tmp_path))
+
+    assert found == [".claude/rules.md", "README.md", "docs/misc/notes.md"]


### PR DESCRIPTION
## What

`test_no_doc_offers_an_unpinned_shellspec_installer` walked the whole repository root for
`*.md` with `.claude/worktrees/` absent from its skip set. That directory holds per-task
agent worktrees — gitignored, one full repository checkout each — so on any machine that
has done agent work the scan descends into every one of them and reports their
`CONTRIBUTING.md` and `tests/shell/README.md` as offenders.

Observed on a checkout with 53 worktrees, in the CI image:

```
$ scripts/run-in-docker.sh python3 -m pytest -q
FAILED tests/test_ci_tool_pins.py::test_no_doc_offers_an_unpinned_shellspec_installer
1 failed, 5027 passed, 6 skipped in 88.15s
```

A worktree pinned before #2198 reports an unpinned installer forever, so no edit in the
working checkout can make the suite green. CI never saw it — a fresh `actions/checkout` has
no worktrees — which is exactly why it survived. It became load-bearing with #2350, which
makes the container run the default and authoritative way to run the suite: a suite that
cannot go green locally is a suite whose verdict nobody reads.

## Fix

The enumeration moves into `_docs_under(root)` and excludes the worktree tree **by path**,
not by directory name — a name-based skip would also drop a legitimate `worktrees/`
directory elsewhere in the tree.

Only one test walked the repository root, so the exposure is bounded to this call site:

```
$ grep -rn "ROOT.rglob" tests/*.py
tests/test_ci_tool_pins.py:93:        for path in ROOT.rglob("*.md")
```

(`tests/test_bounded_flock.py`'s scanner is rooted at `src/`.)

## Tests

Two, and the second is the one that makes the first mean anything:

- `test_the_doc_scan_ignores_agent_worktrees` — a doc under `.claude/worktrees/…`, and a
  deeper one under `.claude/worktrees/…/docs/`, are not returned.
- `test_the_doc_scan_still_reaches_the_checkouts_own_docs` — `docs/misc/notes.md`,
  `README.md` and `.claude/rules.md` still are, while `vendor/` stays skipped. Without
  this, "skip everything" would pass the first assertion while guarding nothing, and a
  `.claude/`-wholesale exclusion would look identical.

Red → green, executed. The extraction of `_docs_under` landed first as a behaviour-
preserving refactor (existing assertions unchanged, still green); the new tests then ran
**red** against it — `Left contains 2 more items, first extra item: PosixPath('…/.claude/worktrees/issue-1/CONTRIBUTING.md')`
— and green after the exclusion. The two test bodies are byte-identical across both runs;
the only edit between them was `_docs_under` itself, which shares the module (recorded
whole-file hash at red: `8e58182`).

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (pytest, ruff check, ruff
format, mypy — all in `ci-runner:8`).

Part of #2353
