### PR TITLE
Bound boot readiness work to its deadline

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4069,12 +4069,15 @@ def wait_boot_complete(
     snippet = "echo '<<BOOT>>' . (is_platform_booting() ? '1' : '0') . '<<END>>';"
     last = "?"
     last_metadata = "not checked"
-    while time.monotonic() < deadline:
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
         # Under boot load pfSsh.php (full config load+lock) can be slow; let one over-30s probe
         # retry on the remaining budget instead of aborting the whole wait. The deadline still
         # bounds it -- a persistently slow box times out loudly below.
         try:
-            out = php_eval(vm, snippet, timeout=30.0).stdout
+            out = php_eval(vm, snippet, timeout=min(30.0, remaining)).stdout
         except subprocess.TimeoutExpired:
             last = "timeout"
             continue
@@ -4083,15 +4086,26 @@ def wait_boot_complete(
             if last == "0":
                 if not require_pkg_metadata:
                     return
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
                 try:
-                    metadata = vm.ssh("/bin/test", "-f", "/var/run/pfSense_version.rc", timeout=30.0)
+                    metadata = vm.ssh(
+                        "/bin/test",
+                        "-f",
+                        "/var/run/pfSense_version.rc",
+                        timeout=min(30.0, remaining),
+                    )
                 except subprocess.TimeoutExpired:
                     last_metadata = "timeout"
                     continue
                 last_metadata = f"rc={metadata.returncode} stdout={metadata.stdout!r} stderr={metadata.stderr!r}"
                 if metadata.returncode == 0:
                     return
-        time.sleep(delay)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(delay, remaining))
     raise RuntimeError(
         f"pfSense boot did not settle after {timeout:.0f}s: is_platform_booting() last returned "
         f"{last!r} (expected '0'); /var/run/pfSense_version.rc last probe: {last_metadata}. "

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4071,7 +4071,7 @@ def wait_boot_complete(
     last_metadata = "not checked"
     while True:
         remaining = deadline - time.monotonic()
-        if remaining <= 0:
+        if not remaining > 0:
             break
         # Under boot load pfSsh.php (full config load+lock) can be slow; let one over-30s probe
         # retry on the remaining budget instead of aborting the whole wait. The deadline still
@@ -4087,7 +4087,7 @@ def wait_boot_complete(
                 if not require_pkg_metadata:
                     return
                 remaining = deadline - time.monotonic()
-                if remaining <= 0:
+                if not remaining > 0:
                     break
                 try:
                     metadata = vm.ssh(
@@ -4103,7 +4103,7 @@ def wait_boot_complete(
                 if metadata.returncode == 0:
                     return
         remaining = deadline - time.monotonic()
-        if remaining <= 0:
+        if not remaining > 0:
             break
         time.sleep(min(delay, remaining))
     raise RuntimeError(

--- a/tests/test_smoke_boot_deadline.py
+++ b/tests/test_smoke_boot_deadline.py
@@ -1,0 +1,85 @@
+"""Issue #2355: boot readiness work stays inside its advertised deadline."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import cast
+
+import pytest
+
+from tests.smoke import helpers
+
+
+def test_wait_boot_complete_caps_platform_probe_and_sleep_to_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monotonic_values = iter([0.0, 0.0, 0.4, 1.0])
+    probe_timeouts: list[float] = []
+    sleeps: list[float] = []
+
+    def fake_php_eval(
+        _vm: helpers.SmokeVM,
+        _snippet: str,
+        *,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        probe_timeouts.append(timeout)
+        return subprocess.CompletedProcess([], 0, "<<BOOT>>1<<END>>", "")
+
+    monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
+    monkeypatch.setattr(helpers.time, "sleep", sleeps.append)
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(RuntimeError, match="did not settle after 1s"):
+        helpers.wait_boot_complete(cast(helpers.SmokeVM, object()), timeout=1, delay=7)
+
+    assert probe_timeouts == [1.0]
+    assert sleeps == pytest.approx([0.6])
+
+
+def test_wait_boot_complete_caps_metadata_probe_to_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monotonic_values = iter([0.0, 0.0, 0.25, 1.0])
+    metadata_timeouts: list[float] = []
+    sleeps: list[float] = []
+
+    class FakeVM:
+        def ssh(self, *_remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            metadata_timeouts.append(timeout)
+            return subprocess.CompletedProcess([], 1, "", "")
+
+    monkeypatch.setattr(
+        helpers,
+        "php_eval",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
+    )
+    monkeypatch.setattr(helpers.time, "sleep", sleeps.append)
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(RuntimeError, match="did not settle after 1s"):
+        helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=1, delay=7)
+
+    assert metadata_timeouts == pytest.approx([0.75])
+    assert sleeps == []
+
+
+def test_wait_boot_complete_stops_when_platform_probe_spends_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monotonic_values = iter([0.0, 0.0, 1.0])
+
+    class FakeVM:
+        def ssh(self, *_remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            raise AssertionError("expired deadline reached metadata probe")
+
+    monkeypatch.setattr(
+        helpers,
+        "php_eval",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
+    )
+    monkeypatch.setattr(
+        helpers.time,
+        "sleep",
+        lambda _delay: (_ for _ in ()).throw(AssertionError("expired deadline reached sleep")),
+    )
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(RuntimeError, match="did not settle after 1s"):
+        helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=1, delay=7)

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -12,7 +12,6 @@ from tests.smoke import helpers
 
 def test_wait_boot_complete_waits_for_boot_metadata_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
     sentinel_statuses = iter([1, 0])
-    monotonic_values = iter([0.0, 0.0, 1.0, 2.0, 3.0])
     calls: list[tuple[str, ...]] = []
 
     class FakeVM:
@@ -28,7 +27,7 @@ def test_wait_boot_complete_waits_for_boot_metadata_sentinel(monkeypatch: pytest
         lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
     )
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
-    monkeypatch.setattr(helpers.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: 0.0)
 
     helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=3, delay=0)
 
@@ -36,6 +35,33 @@ def test_wait_boot_complete_waits_for_boot_metadata_sentinel(monkeypatch: pytest
         ("/bin/test", "-f", "/var/run/pfSense_version.rc"),
         ("/bin/test", "-f", "/var/run/pfSense_version.rc"),
     ]
+
+
+def test_wait_boot_complete_keeps_per_probe_cap_for_long_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    probe_timeouts: list[float] = []
+    metadata_timeouts: list[float] = []
+
+    class FakeVM:
+        def ssh(self, *_remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            metadata_timeouts.append(timeout)
+            return subprocess.CompletedProcess([], 0, "", "")
+
+    def fake_php_eval(
+        _vm: helpers.SmokeVM,
+        _snippet: str,
+        *,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        probe_timeouts.append(timeout)
+        return subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", "")
+
+    monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: 0.0)
+
+    helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=31)
+
+    assert probe_timeouts == [30.0]
+    assert metadata_timeouts == [30.0]
 
 
 def test_wait_boot_complete_plain_reboot_needs_only_platform_boot_flag(

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -64,6 +64,18 @@ def test_wait_boot_complete_keeps_per_probe_cap_for_long_deadline(monkeypatch: p
     assert metadata_timeouts == [30.0]
 
 
+def test_wait_boot_complete_nan_deadline_does_not_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        helpers,
+        "php_eval",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("NaN deadline reached platform probe")),
+    )
+    monkeypatch.setattr(helpers.time, "monotonic", lambda: 0.0)
+
+    with pytest.raises(RuntimeError, match="did not settle"):
+        helpers.wait_boot_complete(cast(helpers.SmokeVM, object()), timeout=float("nan"))
+
+
 def test_wait_boot_complete_plain_reboot_needs_only_platform_boot_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- cap the platform and metadata probes to the remaining boot deadline
- stop polling when a probe consumes the remaining budget
- cap retry sleep to the remaining deadline while preserving the 30-second per-probe maximum

## Verification

- frozen RED (`f9e51313791b3588fba3b1d7539a7913844c3c65`): 3 intended failures
- GREEN with the same test hash: 3 passed
- focused boot/reboot coverage: 9 passed
- `scripts/agent/run-gates.sh --diff origin/devel`: PASS
- live `scripts/local-smoke.sh --marker smoke --filter pfctl_ruleset_nonempty --no-two-vm`: 1 passed, 986 deselected on box `.32`; lease released

Fixes #2355

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot completion checks so they stop within the configured timeout.
  * Prevented status, metadata, and wait operations from exceeding the remaining time budget.
  * Ensured metadata checks and sleep intervals are skipped when the deadline expires.
  * Added safe handling for invalid timeout values, preventing unnecessary platform checks.

* **Tests**
  * Added coverage for timeout enforcement across platform and metadata checks.
  * Verified individual probes remain capped during long waits and deadlines are respected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->