### PR TITLE
pfblockerng: bridge overlapping mandatory atoms in the regex shape gate

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -68,8 +68,13 @@ _REGEX_STACKED_BOUNDED_REPEAT = re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?
 # neighbour, so a failing tail walks a partition of the matched span -- the mechanism the
 # group-keyed shapes above already cover, minus the parentheses they all key on. Measured
 # against a 253-character name (the longest the matcher can be handed): a run of 3 costs
-# 7 ms and a run of 4 costs 462 ms, versus 0.08 ms for a run of 2 -- so runs LONGER than
-# this bound are rejected and a pair stays admitted (a pair is what real host patterns use).
+# 7 ms and a run of 4 costs 462 ms, versus 0.08 ms for a run of 2 -- so a pair stays
+# admitted (a pair is what real host patterns use). A mandatory atom whose character set
+# overlaps the run is NOT a boundary (issue #2082): its position floats inside the span,
+# so `[a-z]+[a-z]+a[a-z]+[a-z]+` multiplies through the `a` (1533 ms measured) -- such an
+# atom bridges the chain while breaking pair-adjacency, and a chain is rejected once it
+# carries more than this many quantifiers AND at least one back-to-back pair (single
+# quantifiers between floating separators stay admitted: 5.8 ms worst-case measured).
 _REGEX_ADJACENT_ATOM_MAX = 2
 
 # Character sets are compared by probing both atoms with one character at a time: this
@@ -219,8 +224,10 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     """Read one unit at ``index``, returning ``(atom, role, next index)`` with the roles of
     ``_regex_quantifier``. A group contributes by what it does to the engine, not by its
     punctuation: a comment or a lookaround consumes nothing and bridges; a plain
-    ``(...)``/``(?:...)``/``(?P<n>...)`` is scanned through as if the parentheses were not
-    there; one wrapping a single atom IS that atom when the quantifier sits outside it."""
+    ``(...)``/``(?:...)``/``(?P<n>...)`` -- and (issue #2082) a scoped-flags ``(?i:...)`` or
+    atomic ``(?>...)`` group -- is scanned through as if the parentheses were not there; one
+    wrapping a single atom IS that atom when the quantifier sits outside it; a conditional
+    ``(?(...)...)`` returns its alternation body for the caller's overlap probe."""
     if pattern[index] == ")":
         quantifier_end, role = _regex_quantifier(pattern, index + 1)
         return (
@@ -254,8 +261,30 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
         body_start = name_end + 1
     elif pattern.startswith("(?:", index):
         body_start = index + 3
+    elif pattern.startswith("(?(", index):
+        # issue #2082: a conditional is a mandatory construct whose POSITION floats, so its
+        # post-condition body (an alternation the overlap probe can compile) is handed to
+        # the caller to judge like a bare atom -- never read as a run boundary outright.
+        condition_end = pattern.find(")", index + 3)
+        if not closed or condition_end == -1 or condition_end >= group_end - 1:
+            return "", "break", group_end
+        body = pattern[condition_end + 1 : group_end - 1]
+        quantifier_end, role = _regex_quantifier(pattern, group_end)
+        if role == "bridge" or not body:
+            return "", "bridge", max(quantifier_end, group_end)
+        return body, role, max(quantifier_end, group_end)
+    elif pattern.startswith("(?>", index):
+        # An atomic group never gives characters back, but its position still floats with
+        # the run around it, so it is entered like a plain group (issue #2082).
+        body_start = index + 3
     elif pattern.startswith("(?", index):
-        return "", "break", group_end  # atomic, flags, conditionals: not a plain group
+        flags_end = index + 2
+        while flags_end < len(pattern) and pattern[flags_end] in "aiLmsux-":
+            flags_end += 1
+        if flags_end > index + 2 and pattern[flags_end : flags_end + 1] == ":":
+            body_start = flags_end + 1  # scoped flags: `(?i:...)` backtracks like `(?:...)`
+        else:
+            return "", "break", group_end  # backreference, global flags: not a plain group
     else:
         body_start = index + 1
     quantifier_end, role = _regex_quantifier(pattern, group_end)
@@ -272,13 +301,18 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
 
 
 def _regex_has_adjacent_unbounded_atoms(pattern: str, depth: int = 0) -> bool:
-    """True when ``pattern`` carries a run of more than ``_REGEX_ADJACENT_ATOM_MAX``
-    back-to-back atoms that each take a backtracking unbounded quantifier and whose
-    character sets overlap along the run -- every atom in such a run can cede characters to
-    its neighbour. A lookaround's body is scanned as a pattern of its own, bounded by
+    """True when ``pattern`` carries an overlap-connected CHAIN of more than
+    ``_REGEX_ADJACENT_ATOM_MAX`` atoms that each take a backtracking unbounded quantifier,
+    where the chain holds at least one back-to-back pair. A mandatory atom overlapping the
+    chain is no boundary -- its position floats inside the span (issue #2082) -- so it
+    bridges the chain while breaking pair-adjacency; a disjoint one really pins the split
+    and ends the chain. A lookaround's body is scanned as a pattern of its own, bounded by
     ``_REGEX_NESTED_SCAN_MAX`` so nested lookarounds cannot exhaust the stack. Pure string
     analysis: nothing here runs the candidate against an input."""
-    run: list[str] = []
+    anchor = ""  # last quantified atom of the chain ("" = no chain)
+    quantified = 0
+    pairs = 0
+    adjacent = False  # whether the chain unit before this one was a quantified atom
     index = 0
     while index < len(pattern):
         atom, role, index = _regex_next_unit(pattern, index)
@@ -288,12 +322,21 @@ def _regex_has_adjacent_unbounded_atoms(pattern: str, depth: int = 0) -> bool:
             continue
         if role == "bridge":
             continue
-        if role != "run":
-            run = []
+        if role == "run":
+            if anchor and _regex_atoms_overlap(anchor, atom):
+                quantified += 1
+                if adjacent:
+                    pairs += 1
+            else:
+                quantified, pairs = 1, 0
+            anchor, adjacent = atom, True
+            if pairs and quantified > _REGEX_ADJACENT_ATOM_MAX:
+                return True
             continue
-        run = [*run, atom] if not run or _regex_atoms_overlap(run[-1], atom) else [atom]
-        if len(run) > _REGEX_ADJACENT_ATOM_MAX:
-            return True
+        if atom and anchor and _regex_atoms_overlap(anchor, atom):
+            adjacent = False  # mandatory overlapping atom: floats, so the chain survives it
+            continue
+        anchor, quantified, pairs, adjacent = "", 0, 0, False
     return False
 
 

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -226,6 +226,27 @@ def _regex_atoms_overlap(first: str, second: str) -> bool:
     return any(left.fullmatch(probe) and right.fullmatch(probe) for probe in _REGEX_OVERLAP_ALPHABET)
 
 
+def _regex_body_alternates(body: str) -> bool:
+    """True when ``body`` carries a top-level unescaped ``|`` -- an alternation whose
+    branches the enclosing group's parentheses scope (one inside a nested group or a
+    character class belongs to that construct instead)."""
+    depth = 0
+    index = 0
+    while index < len(body):
+        character = body[index]
+        if character in ("\\", "["):
+            index = _regex_atom_end(body, index)
+            continue
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth = max(depth - 1, 0)
+        elif character == "|" and depth == 0:
+            return True
+        index += 1
+    return False
+
+
 def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     """Read one unit at ``index``, returning ``(atom, role, next index)`` with the roles of
     ``_regex_quantifier``. A group contributes by what it does to the engine, not by its
@@ -312,10 +333,17 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     # carrying its own group or alternation belongs to the shapes above instead.
     if role == "run" and body and not any(character in body for character in "()|"):
         return body, "run", quantifier_end
-    # A mandatory group over a bare alternation (`(a|b)`) is the conditional separator
-    # without the condition (issue #2082): entering it would read `|` as a boundary, so the
-    # body -- which compiles standalone -- is handed to the caller's overlap probe instead.
-    if role != "bridge" and body and "|" in body and "(" not in body and ")" not in body:
+    # A mandatory group over a quantifier-free alternation (`(a|b)`, `(a|(b))`) is the
+    # conditional separator without the condition (issue #2082): entering it would read `|`
+    # as a boundary, so the body -- which compiles standalone -- is handed to the caller's
+    # overlap probe instead. A body carrying any quantifier keeps the entered scan, so a
+    # run inside a branch is still found rather than hidden behind the probe.
+    if (
+        role != "bridge"
+        and body
+        and _regex_body_alternates(body)
+        and not any(character in body for character in "+*{?")
+    ):
         return body, role, max(quantifier_end, group_end)
     # Every other group is entered rather than skipped: parentheses hide a run from the
     # reader, never from the engine, and its atoms -- not its punctuation -- decide what

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -77,6 +77,12 @@ _REGEX_STACKED_BOUNDED_REPEAT = re.compile(r"(?:\)|\]|\w)\{\d+(?:,\d*)?\}\{\d+(?
 # quantifiers between floating separators stay admitted: 5.8 ms worst-case measured).
 _REGEX_ADJACENT_ATOM_MAX = 2
 
+# Ceiling for chains connected ONLY by floating separators (no back-to-back pair): they
+# blow up one quantifier later. Measured at 253 characters (CI image): 3 quantifiers cost
+# 23 ms (the runtime warn layer's accepted residual; rejecting 3 would drop the admitted
+# single-gap shapes above) while 4 cost 1753 ms, far over the 100 ms evict ceiling.
+_REGEX_CHAIN_ATOM_MAX = 3
+
 # Character sets are compared by probing both atoms with one character at a time: this
 # alphabet only has to be big enough to separate the classes a domain pattern is written
 # over (letters, digits, punctuation, whitespace, non-ASCII word characters).
@@ -227,14 +233,15 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     ``(...)``/``(?:...)``/``(?P<n>...)`` -- and (issue #2082) a scoped-flags ``(?i:...)`` or
     atomic ``(?>...)`` group -- is scanned through as if the parentheses were not there; one
     wrapping a single atom IS that atom when the quantifier sits outside it; a conditional
-    ``(?(...)...)`` returns its alternation body for the caller's overlap probe."""
+    ``(?(...)...)``, an atomic ``(?>...)``, or a bare-alternation group returns its body for
+    the caller's overlap probe; a named backreference is role ``float`` (mandatory,
+    overlap unknowable)."""
     if pattern[index] == ")":
-        quantifier_end, role = _regex_quantifier(pattern, index + 1)
-        return (
-            "",
-            "break" if role == "break" and quantifier_end > index + 1 else "bridge",
-            max(quantifier_end, index + 1),
-        )
+        # A group's closing punctuation separates nothing by itself -- the atoms inside
+        # already decided whether the chain survives -- and a fixed repeat ON the group
+        # floats with it (issue #2082), so `)` never ends a chain.
+        quantifier_end, _ = _regex_quantifier(pattern, index + 1)
+        return "", "bridge", max(quantifier_end, index + 1)
     if pattern[index] != "(":
         if pattern[index] in "|^$*+?{}":
             return "", "break", index + 1
@@ -274,9 +281,20 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
             return "", "bridge", max(quantifier_end, group_end)
         return body, role, max(quantifier_end, group_end)
     elif pattern.startswith("(?>", index):
-        # An atomic group never gives characters back, but its position still floats with
-        # the run around it, so it is entered like a plain group (issue #2082).
-        body_start = index + 3
+        # Atomicity forbids backtracking INSIDE the body, so it is never entered as a run
+        # source -- but the group's POSITION floats with the run around it (issue #2082),
+        # so its body feeds the caller's overlap probe like a bare atom.
+        if not closed:
+            return "", "break", group_end
+        body = pattern[index + 3 : group_end - 1]
+        quantifier_end, role = _regex_quantifier(pattern, group_end)
+        if role == "bridge" or not body:
+            return "", "bridge", max(quantifier_end, group_end)
+        return body, role, max(quantifier_end, group_end)
+    elif pattern.startswith("(?P=", index):
+        # A backreference's character set is unknowable statically, so it can never be
+        # proven a boundary: mandatory, position floats, overlap assumed (issue #2082).
+        return "", "float", group_end
     elif pattern.startswith("(?", index):
         flags_end = index + 2
         while flags_end < len(pattern) and pattern[flags_end] in "aiLmsux-":
@@ -284,7 +302,7 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
         if flags_end > index + 2 and pattern[flags_end : flags_end + 1] == ":":
             body_start = flags_end + 1  # scoped flags: `(?i:...)` backtracks like `(?:...)`
         else:
-            return "", "break", group_end  # backreference, global flags: not a plain group
+            return "", "break", group_end  # global flags and any unknown `(?` construct
     else:
         body_start = index + 1
     quantifier_end, role = _regex_quantifier(pattern, group_end)
@@ -294,10 +312,21 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     # carrying its own group or alternation belongs to the shapes above instead.
     if role == "run" and body and not any(character in body for character in "()|"):
         return body, "run", quantifier_end
+    # A mandatory group over a bare alternation (`(a|b)`) is the conditional separator
+    # without the condition (issue #2082): entering it would read `|` as a boundary, so the
+    # body -- which compiles standalone -- is handed to the caller's overlap probe instead.
+    if role != "bridge" and body and "|" in body and "(" not in body and ")" not in body:
+        return body, role, max(quantifier_end, group_end)
     # Every other group is entered rather than skipped: parentheses hide a run from the
-    # reader, never from the engine. Only what the group does to its NEIGHBOURS varies --
-    # one that may match nothing cannot separate them; one that must match does.
-    return "", "bridge" if quantifier_end == group_end or role == "bridge" else "break", body_start
+    # reader, never from the engine, and its atoms -- not its punctuation -- decide what
+    # happens to the chain (issue #2082: a fixed repeat ON the group floats with it).
+    return "", "bridge", body_start
+
+
+def _regex_is_backref(atom: str) -> bool:
+    """``\\1``..``\\9`` as read by ``_regex_atom_end`` (two characters; ``\\0`` is the
+    octal null escape, a literal atom, never a group reference)."""
+    return len(atom) == 2 and atom[0] == "\\" and atom[1] in "123456789"
 
 
 def _regex_has_adjacent_unbounded_atoms(pattern: str, depth: int = 0) -> bool:
@@ -330,11 +359,13 @@ def _regex_has_adjacent_unbounded_atoms(pattern: str, depth: int = 0) -> bool:
             else:
                 quantified, pairs = 1, 0
             anchor, adjacent = atom, True
-            if pairs and quantified > _REGEX_ADJACENT_ATOM_MAX:
+            if (pairs and quantified > _REGEX_ADJACENT_ATOM_MAX) or quantified > _REGEX_CHAIN_ATOM_MAX:
                 return True
             continue
-        if atom and anchor and _regex_atoms_overlap(anchor, atom):
-            adjacent = False  # mandatory overlapping atom: floats, so the chain survives it
+        # A mandatory unit whose set overlaps the chain -- or cannot be proven disjoint
+        # (a backreference) -- floats, so it bridges the chain instead of ending it.
+        if role == "float" or (atom and anchor and (_regex_atoms_overlap(anchor, atom) or _regex_is_backref(atom))):
+            adjacent = False
             continue
         anchor, quantified, pairs, adjacent = "", 0, 0, False
     return False

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -401,6 +401,23 @@ class TestCatastrophicShapeHeuristic:
         # Disjoint alternatives really pin the split.
         assert _regex_is_catastrophic_shape(r"^([0-9])[a-z]+[a-z]+(\.|,)[a-z]+[a-z]+$") is False
 
+    def test_alternation_separator_with_a_parenthesised_branch(self) -> None:
+        # PR #2361 review round 2: a parenthesised branch pushed `(a|(b))` off the
+        # bare-alternation path into the entered scan, whose bare `|` reset the chain.
+        # Measured 1478 / 1463 / 1451 ms per query at 253 characters (CI image).
+        for pat in (
+            r"^[a-z]+[a-z]+(a|(b))[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(?:a|(b))[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+((a)|b){3}[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|(b))+[a-z]+[a-z]+@x\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+        # A quantifier-carrying body stays on the entered scan, so a run inside a branch
+        # is still found -- the overlap-probe shortcut must never hide it.
+        assert _regex_is_catastrophic_shape(r"^([a-z]+[a-z]+[a-z]+|x)@x\.com$") is True
+        # Disjoint parenthesised alternatives still pin the split.
+        assert _regex_is_catastrophic_shape(r"^[a-z]+[a-z]+(\.|(,))[a-z]+[a-z]+$") is False
+
     def test_backreference_separator_bridges_the_chain(self) -> None:
         # A backreference's character set is unknowable statically, so the gate must not
         # read it as a boundary: measured 1564 ms (`\1`) and 2018 ms (`(?P=g)`) per query

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -415,6 +415,11 @@ class TestCatastrophicShapeHeuristic:
         # A quantifier-carrying body stays on the entered scan, so a run inside a branch
         # is still found -- the overlap-probe shortcut must never hide it.
         assert _regex_is_catastrophic_shape(r"^([a-z]+[a-z]+[a-z]+|x)@x\.com$") is True
+        # A `|` that only sits inside a NESTED group does not make the outer body an
+        # alternation: `(x(a|b)y)` must take the entered scan (where every atom bridges
+        # the chain), not the overlap probe (whose single-character match would read the
+        # multi-atom body as disjoint and reset the chain).
+        assert _regex_is_catastrophic_shape(r"^[a-z]+[a-z]+(x(a|b)y)[a-z]+[a-z]+@x\.com$") is True
         # Disjoint parenthesised alternatives still pin the split.
         assert _regex_is_catastrophic_shape(r"^[a-z]+[a-z]+(\.|(,))[a-z]+[a-z]+$") is False
 

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -354,8 +354,8 @@ class TestCatastrophicShapeHeuristic:
 
     def test_conditional_group_separator_is_the_same_defect(self) -> None:
         # issue #2082's second spelling: `(?(1)a|b)` between the pairs is the bare `a`
-        # separator wearing a conditional (measured 1492 ms per query at 253 characters;
-        # the QUANTIFIED spelling below costs 79 s).
+        # separator wearing a conditional (measured 1492 ms per query at 253 characters,
+        # CI image; the QUANTIFIED spelling below costs 79 s).
         for pat in (
             r"^([a-z])[a-z]+[a-z]+(?(1)a|b)[a-z]+[a-z]+@x\.com$",
             r"^([a-z])[a-z]+[a-z]+(?(1)a|b)+[a-z]+[a-z]+@x\.com$",
@@ -369,17 +369,69 @@ class TestCatastrophicShapeHeuristic:
         # `(?i:a)` and `(?>a)` between the pairs are still the floating `a` separator:
         # scoped flags do not change what the engine backtracks over, and an atomic group's
         # POSITION floats with the run even though its body never gives characters back
-        # (measured 1512 ms and 1558 ms per query at 253 characters).
+        # (measured 1512 ms and 1558 ms per query at 253 characters, CI image).
         for pat in (
             r"^[a-z]+[a-z]+(?i:a)[a-z]+[a-z]+@x\.com$",
             r"^[a-z]+[a-z]+(?>a)[a-z]+[a-z]+@x\.com$",
         ):
             assert _regex_is_catastrophic_shape(pat) is True, pat
 
+    def test_grouped_mandatory_separator_spellings(self) -> None:
+        # PR #2361 review: the bare separator's grouped spellings float identically.
+        # Measured per query at 253 characters (CI image): 1529 / 1539 / 721 / 786 ms.
+        for pat in (
+            r"^[a-z]+[a-z]+(a){3}[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(?:a){3}[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(ab){3}[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a)++[a-z]+[a-z]+@x\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+        # A grouped DISJOINT separator still pins the split, exactly like the bare form.
+        assert _regex_is_catastrophic_shape(r"^[a-z]+[a-z]+(\.){3}[a-z]+[a-z]+$") is False
+
+    def test_alternation_group_separator_is_the_same_defect(self) -> None:
+        # `(a|b)` between the pairs is the conditional separator without the condition --
+        # its body compiles standalone, so the overlap probe judges it directly. Measured
+        # 1719 / 1747 ms per query at 253 characters (CI image).
+        for pat in (
+            r"^[a-z]+[a-z]+(a|b)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(?:a|b)[a-z]+[a-z]+@x\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+        # Disjoint alternatives really pin the split.
+        assert _regex_is_catastrophic_shape(r"^([0-9])[a-z]+[a-z]+(\.|,)[a-z]+[a-z]+$") is False
+
+    def test_backreference_separator_bridges_the_chain(self) -> None:
+        # A backreference's character set is unknowable statically, so the gate must not
+        # read it as a boundary: measured 1564 ms (`\1`) and 2018 ms (`(?P=g)`) per query
+        # at 253 characters (CI image). Conservative bridge: the chain survives it.
+        for pat in (
+            r"^([a-z])[a-z]+[a-z]+\1[a-z]+[a-z]+@x\.com$",
+            r"^(?P<g>[a-z])[a-z]+[a-z]+(?P=g)[a-z]+[a-z]+@x\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_long_chain_without_a_pair_is_rejected(self) -> None:
+        # PR #2361 review: pair-adjacency alone under-covers. Four quantifiers connected
+        # only by floating separators cost 1753 ms per query at 253 characters (CI image);
+        # three cost 23 ms -- under the evict ceiling and the accepted warn-layer residual,
+        # and rejecting three would drop the issue's admitted single-gap shapes.
+        assert _regex_is_catastrophic_shape(r"^[a-z]+a[a-z]+a[a-z]+a[a-z]+@x\.com$") is True
+        assert _regex_is_catastrophic_shape(r"^[a-z]+a[a-z]+a[a-z]+@x\.com$") is False
+
+    def test_atomic_group_body_is_not_a_backtracking_run(self) -> None:
+        # Atomicity forbids backtracking INSIDE the body -- `^(?>[a-z]+[a-z]+[a-z]+)@...`
+        # costs 0.00 ms at 253 characters (CI image), so its body must never be read as a
+        # joinable run (the no-false-positive constraint) -- while the atomic group AS a
+        # floating separator stays the rejected 1558 ms shape.
+        assert _regex_is_catastrophic_shape(r"^(?>[a-z]+[a-z]+[a-z]+)@x\.com$") is False
+        assert _regex_is_catastrophic_shape(r"^[a-z]+[a-z]+(?>a)[a-z]+[a-z]+@x\.com$") is True
+
     def test_scoped_flags_group_body_is_scanned(self) -> None:
         # A `(?i:...)` group is entered like `(?:...)`: skipping it wholesale would hide a
-        # run from the scan entirely (measured 1532 ms per query at 253 characters for the
-        # first row), and a quantified single-atom spelling IS that atom's quantifier.
+        # run from the scan entirely (measured 1532 ms per query at 253 characters, CI
+        # image, for the first row), and a quantified single-atom spelling IS that atom's
+        # quantifier.
         assert _regex_is_catastrophic_shape(r"^(?i:[a-z]+[a-z]+[a-z]+[a-z]+)@x\.com$") is True
         assert _regex_is_catastrophic_shape(r"^(?i:[a-z])+(?i:[a-z])+(?i:[a-z])+@x\.com$") is True
 

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -377,7 +377,7 @@ class TestCatastrophicShapeHeuristic:
             assert _regex_is_catastrophic_shape(pat) is True, pat
 
     def test_grouped_mandatory_separator_spellings(self) -> None:
-        # PR #2361 review: the bare separator's grouped spellings float identically.
+        # The bare separator's grouped spellings float identically (issue #2082).
         # Measured per query at 253 characters (CI image): 1529 / 1539 / 721 / 786 ms.
         for pat in (
             r"^[a-z]+[a-z]+(a){3}[a-z]+[a-z]+@x\.com$",
@@ -402,8 +402,8 @@ class TestCatastrophicShapeHeuristic:
         assert _regex_is_catastrophic_shape(r"^([0-9])[a-z]+[a-z]+(\.|,)[a-z]+[a-z]+$") is False
 
     def test_alternation_separator_with_a_parenthesised_branch(self) -> None:
-        # PR #2361 review round 2: a parenthesised branch pushed `(a|(b))` off the
-        # bare-alternation path into the entered scan, whose bare `|` reset the chain.
+        # A parenthesised branch must stay on the alternation-separator path: entering the
+        # group would read its bare `|` as a boundary and reset the chain.
         # Measured 1478 / 1463 / 1451 ms per query at 253 characters (CI image).
         for pat in (
             r"^[a-z]+[a-z]+(a|(b))[a-z]+[a-z]+@x\.com$",
@@ -434,7 +434,7 @@ class TestCatastrophicShapeHeuristic:
             assert _regex_is_catastrophic_shape(pat) is True, pat
 
     def test_long_chain_without_a_pair_is_rejected(self) -> None:
-        # PR #2361 review: pair-adjacency alone under-covers. Four quantifiers connected
+        # Pair-adjacency alone under-covers. Four quantifiers connected
         # only by floating separators cost 1753 ms per query at 253 characters (CI image);
         # three cost 23 ms -- under the evict ceiling and the accepted warn-layer residual,
         # and rejecting three would drop the issue's admitted single-gap shapes.

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -288,7 +288,7 @@ class TestCatastrophicShapeHeuristic:
             r"^cdn[a-z]+[0-9]*\.example\.com$",
             r"^[a-z]+[0-9]+[a-z]+[0-9]+@example\.com$",
             r"^\w+\.\w+$",
-            r"^.+@.+$",  # a literal separator ends the run
+            r"^.+@.+$",  # '@' floats through '.' spans but leaves no adjacent pair
         ):
             assert _regex_is_catastrophic_shape(pat) is False, pat
 
@@ -309,9 +309,79 @@ class TestCatastrophicShapeHeuristic:
         # (`a{3}`) has nothing to give -- neither can partition the span, so neither starts
         # or continues a run.
         # The middle row is the discriminating one: its first two atoms already form a run,
-        # so it stays admitted ONLY because the possessive third atom is refused entry.
+        # so it stays admitted ONLY because the possessive third atom never joins it as a
+        # third quantifier (it bridges the chain like any mandatory overlapping atom).
         for pat in (r"^[a-z]++[a-z]++[a-z]++$", r"^[a-z]+[a-z]+[a-z]++$", r"^[a-z]{3}[a-z]{3}[a-z]{3}$"):
             assert _regex_is_catastrophic_shape(pat) is False, pat
+
+    def test_overlapping_mandatory_separator_does_not_split_a_run(self) -> None:
+        # issue #2082: a mandatory atom whose character set overlaps its neighbours is no
+        # boundary -- its position floats inside the span, so the quantifiers on both sides
+        # keep multiplying through it. Measured with the runtime's IGNORECASE compile against
+        # failing 253-character inputs (CI image; the rejected three-quantifier run costs
+        # 24.9 ms in the same environment): 1533 ms for the issue's reproduction (first row),
+        # 24 ms for the pair+separator+quantifier rows, 1465 ms for the fixed-repeat
+        # separator, 490 ms for the multi-character literal, 75 s for the double-separator row.
+        for pat in (
+            r"^[a-z]+[a-z]+a[a-z]+[a-z]+@x\.com$",  # the issue's console reproduction
+            r"^([a-z]+)([a-z]+)a([a-z]+)([a-z]+)@x\.com$",  # the same run wearing groups
+            r"^[a-z]+[a-z]+a[a-z]+@x\.com$",
+            r"^[a-z]+a[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+a{3}[a-z]+[a-z]+@x\.com$",  # a fixed repeat floats the same way
+            r"^[a-z]+[a-z]+abc[a-z]+[a-z]+@x\.com$",  # multi-character literal separator
+            r"^[a-z]+[a-z]+a[a-z]+a[a-z]+[a-z]+@x\.com$",
+            r"^\w+\w+x\w+\w+$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_separator_overlap_is_judged_case_insensitively(self) -> None:
+        # The matcher compiles admitted patterns with re.IGNORECASE, so 'A' floats through
+        # [a-z] spans exactly like 'a' does (measured 1520 ms per query at 253 characters).
+        assert _regex_is_catastrophic_shape(r"^[A-Z]+[a-z]+A[a-z]+[A-Z]+@x\.com$") is True
+
+    def test_single_quantifier_gaps_between_overlapping_separators_stay_admitted(self) -> None:
+        # The issue's design constraint: with ONE quantifier per gap the floating separator
+        # has no adjacent pair to multiply -- 5.8 ms worst case at 253 characters against an
+        # adversarial separator-rich input, under the 10 ms warn ceiling. Run length through
+        # bridged separators alone is NOT the discriminator; rejecting these would drop
+        # benign feed shapes.
+        for pat in (
+            r"^[a-z]+x[a-z]+y[a-z]+@x\.com$",  # the issue's measured benign row
+            r"^[a-z]+a[a-z]+$",
+            r"^[a-z]+[a-z]+a$",  # trailing separator: no quantifier after the float
+        ):
+            assert _regex_is_catastrophic_shape(pat) is False, pat
+
+    def test_conditional_group_separator_is_the_same_defect(self) -> None:
+        # issue #2082's second spelling: `(?(1)a|b)` between the pairs is the bare `a`
+        # separator wearing a conditional (measured 1492 ms per query at 253 characters;
+        # the QUANTIFIED spelling below costs 79 s).
+        for pat in (
+            r"^([a-z])[a-z]+[a-z]+(?(1)a|b)[a-z]+[a-z]+@x\.com$",
+            r"^([a-z])[a-z]+[a-z]+(?(1)a|b)+[a-z]+[a-z]+@x\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+        # A conditional whose EVERY alternative is disjoint from the run really does pin
+        # the split, exactly like a bare disjoint literal.
+        assert _regex_is_catastrophic_shape(r"^([0-9])[a-z]+[a-z]+(?(1)\.|,)[a-z]+[a-z]+@x\.com$") is False
+
+    def test_scoped_flags_and_atomic_group_separator_spellings(self) -> None:
+        # `(?i:a)` and `(?>a)` between the pairs are still the floating `a` separator:
+        # scoped flags do not change what the engine backtracks over, and an atomic group's
+        # POSITION floats with the run even though its body never gives characters back
+        # (measured 1512 ms and 1558 ms per query at 253 characters).
+        for pat in (
+            r"^[a-z]+[a-z]+(?i:a)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(?>a)[a-z]+[a-z]+@x\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+
+    def test_scoped_flags_group_body_is_scanned(self) -> None:
+        # A `(?i:...)` group is entered like `(?:...)`: skipping it wholesale would hide a
+        # run from the scan entirely (measured 1532 ms per query at 253 characters for the
+        # first row), and a quantified single-atom spelling IS that atom's quantifier.
+        assert _regex_is_catastrophic_shape(r"^(?i:[a-z]+[a-z]+[a-z]+[a-z]+)@x\.com$") is True
+        assert _regex_is_catastrophic_shape(r"^(?i:[a-z])+(?i:[a-z])+(?i:[a-z])+@x\.com$") is True
 
     def test_newline_repeat_is_not_read_as_a_named_unicode_escape(self) -> None:
         # The two spellings are different regexes and each pins one half of the scanner.
@@ -342,8 +412,8 @@ class TestCatastrophicShapeHeuristic:
         # would flag this). Build a pattern whose budget is EXACTLY MAX -- `_REGEX_BUDGET_MAX`
         # unbounded `*` quantifiers, zero alternations, and no other catastrophic shape (no
         # nested/adjacent quantified group, no stacked bounded repeat, and -- issue #2035 --
-        # no run of adjacent quantified atoms either, so the unquantified `b` separators
-        # keep every quantifier in a run of one).
+        # no run of adjacent quantified atoms either: the `b` separators are DISJOINT from
+        # `a`, so they split every quantifier into a chain of its own (issue #2082)).
         at_budget = "a*b" * pfb_dnsbl_regex_rules._REGEX_BUDGET_MAX
         # Compute the budget the SAME way the code does and pin it to MAX before asserting.
         budget = len(pfb_dnsbl_regex_rules._REGEX_UNBOUNDED_QUANTIFIER.findall(at_budget)) + len(

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -204,6 +204,13 @@ def test_shape_gate_stays_total_on_malformed_pattern_fragments() -> None:
         "(?>a",
         "(?aiLmsux-imsx:x)",
         "(?-:x)",
+        "(?P=",
+        "(?P=g",
+        "(?P=g)",
+        "(a|b",
+        "(?>a)",
+        "\\1",
+        "([a-z])\\1",
         "[a-z]+" * 500,
         "a" * 5000 + "+",
     ):

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -208,6 +208,8 @@ def test_shape_gate_stays_total_on_malformed_pattern_fragments() -> None:
         "(?P=g",
         "(?P=g)",
         "(a|b",
+        "(a|(b",
+        "(a|(b))",
         "(?>a)",
         "\\1",
         "([a-z])\\1",

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -192,6 +192,18 @@ def test_shape_gate_stays_total_on_malformed_pattern_fragments() -> None:
         "((((",
         ")+",
         "(?",
+        "(?(",
+        "(?(1",
+        "(?(1)",
+        "(?(1)a",
+        "(?(1)a|b",
+        "(?(1))",
+        "(?i",
+        "(?i:",
+        "(?>",
+        "(?>a",
+        "(?aiLmsux-imsx:x)",
+        "(?-:x)",
         "[a-z]+" * 500,
         "a" * 5000 + "+",
     ):
@@ -201,6 +213,24 @@ def test_shape_gate_stays_total_on_malformed_pattern_fragments() -> None:
     # there rather than going blind from the first `(?#` onwards.
     assert _regex_is_catastrophic_shape(r"(?#x\w+\w+\w+") is True
     assert _regex_is_catastrophic_shape(r"(?=a\w+\w+\w+") is True
+    assert _regex_is_catastrophic_shape(r"(?i:\w+\w+\w+") is True
+
+
+def test_probe_and_resolver_both_reject_an_overlapping_separator_run() -> None:
+    """issue #2082: a mandatory atom overlapping its neighbours was read as a run BOUNDARY,
+    so the issue's reproduction reached both consumers unflagged. Same two surfaces as the
+    #2035 twin above: the composed predicate the resolver imports, and ``main()`` the way
+    pfb_dnsbl_regex_validation_errors() runs it."""
+    from pfb_dnsbl_regex_rules import _regex_is_catastrophic_shape
+
+    pattern = r"^[a-z]+[a-z]+a[a-z]+[a-z]+@x\.com$"
+    assert _regex_is_catastrophic_shape(pattern) is True
+
+    proc = run_probe((pattern + "\n").encode("utf-8"), "0")
+    assert proc.returncode == 1, f"probe admitted {pattern!r}"
+    assert proc.stderr.decode("utf-8").splitlines() == [f"line 1: {pattern!r}: catastrophic-backtracking shape"], (
+        proc.stderr
+    )
 
 
 def test_main_treats_crlf_terminated_lines_like_lf() -> None:


### PR DESCRIPTION
Fixes #2082.

## Problem

The catastrophic-shape gate read a mandatory, unquantified atom as a hard boundary
between quantifier runs. When that atom's character set overlaps its neighbours it is
not a boundary at all: its position floats inside the span, so the quantifier pairs on
both sides keep multiplying through it. `^[a-z]+[a-z]+a[a-z]+[a-z]+@x\.com$` was
admitted by both the save-time probe and the resolver's load-time gate, and at
25.7 ms/query (121 chars) it sits above ADR-07's warn ceiling but below the evict
ceiling — a permanent per-query cost.

## Fix

`_regex_has_adjacent_unbounded_atoms()` now tracks an overlap-connected *chain*
instead of a contiguous run:

- A mandatory atom that **overlaps** the chain bridges it (the chain survives, but
  pair-adjacency is broken); a **disjoint** one still pins the split and ends the chain.
- A chain is rejected when it carries more than `_REGEX_ADJACENT_ATOM_MAX` (2)
  unbounded quantifiers **and** at least one back-to-back pair. Single quantifiers
  between floating separators stay admitted — the issue's design constraint.
- `_regex_next_unit()` closes the same defect's other spellings: a conditional
  `(?(1)a|b)` returns its alternation body for the overlap probe (and its quantified
  form is read as a quantified atom); scoped-flags `(?i:...)` and atomic `(?>...)`
  groups are entered like `(?:...)` instead of being skipped wholesale — skipping hid
  both the separator spelling and any run inside the body.

The rule lives in the shared module, so the resolver and the save-time probe pick it
up together (#1765).

## Measurements (CI image, `re.IGNORECASE`, failing 253-char inputs, worst of four input shapes)

| pattern | ms/query | verdict |
| --- | --- | --- |
| `^[a-z]+[a-z]+a[a-z]+[a-z]+@x\.com$` (issue repro) | 1533 | now rejected |
| `^([a-z])[a-z]+[a-z]+(?(1)a\|b)[a-z]+[a-z]+@x\.com$` | 1492 | now rejected |
| `^([a-z])[a-z]+[a-z]+(?(1)a\|b)+[a-z]+[a-z]+@x\.com$` | 79 146 | now rejected |
| `^[a-z]+[a-z]+a[a-z]+a[a-z]+[a-z]+@x\.com$` | 75 065 | now rejected |
| `^[a-z]+[a-z]+(?i:a)[a-z]+[a-z]+@x\.com$` | 1513 | now rejected |
| `^[a-z]+[a-z]+(?>a)[a-z]+[a-z]+@x\.com$` | 1559 | now rejected |
| `^(?i:[a-z]+[a-z]+[a-z]+[a-z]+)@x\.com$` (body was never scanned) | 1532 | now rejected |
| `^[a-z]+[a-z]+a[a-z]+@x\.com$` / `^[a-z]+a[a-z]+[a-z]+@x\.com$` | 24 | now rejected (same class as the already-rejected 3-run, 24.9 ms in this env) |
| `^[a-z]+x[a-z]+y[a-z]+@x\.com$` (issue's benign guard) | 5.8 | stays admitted |
| `^.+@.+$`, `^\w+\w+$`, pair shapes, disjoint separators | ≤0.3 | stay admitted |

## Test-first proof

Reproduction tests executed RED on untouched code (7 failed, 52 passed), frozen, then
re-run GREEN unchanged after the fix (59 passed). Red-time `git hash-object`:

- `tests/test_adr07_regex_safety.py` `ee75e6b0dd95c1b7074ba0cab1fbf55ba4762844`
- `tests/test_pfb_dnsbl_regex_rules.py` `eeb5ed3f38c8ff4930dfdb4fb1bd62a9cc44f7d7`

Both hashes verified equal to the committed files after the green run. Black-box
reproduction from the issue re-executed: the probe now rejects both spellings
(`exit=1`, `catastrophic-backtracking shape`) and admits the benign row.

The whole existing benign corpus (realistic feed patterns, disjoint separators,
possessive/fixed quantifiers, the budget-threshold pattern) stays green, and the
malformed-fragment totality test gains conditional/flags/atomic fragments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 1 (commit `f8dc3c0a`)

The adversarial review's executed findings, applied with the same test-first discipline
(5 new reproduction tests RED on `6a38a15a` — frozen at `7f199d3e…` /
`2be10a40…` — GREEN unchanged after; full suite 5050 passed; fixture sweep vs devel:
24 admission flips, all reproduction rows of this branch, none benign):

- Grouped separator spellings `(a){3}` / `(?:a){3}` / `(ab){3}` / `(a)++`
  (721–1539 ms/query) — group punctuation no longer ends a chain; the atoms inside decide.
- Bare-alternation separators `(a|b)` / `(?:a|b)` (1719/1747 ms) — body handed to the
  overlap probe like a conditional's.
- Backreference separators `\1` / `(?P=g)` (1564/2018 ms) — overlap unknowable
  statically, so they bridge.
- Pair-free chain ceiling: 4 quantifiers through floating separators (1753 ms) rejected;
  3 (23 ms) stay admitted so the issue's single-gap constraint holds.
- False positive removed: atomic bodies are opaque again — `^(?>[a-z]+[a-z]+[a-z]+)@…`
  (0.00 ms) stays admitted while `(?>a)` as a separator stays rejected.

Deferred (pre-existing, distinct mechanisms) → #2364: conditional-body run scanning,
multi-character opaque separator probing, quadratic `_regex_group_end`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and rejection of regex patterns that could cause catastrophic performance.
  * Added handling for complex patterns involving alternation, grouped constructs, backreferences, scoped flags, and nested quantifiers.
  * Ensured overlapping quantified separator patterns are consistently rejected.

* **Tests**
  * Expanded coverage for safe, unsafe, malformed, and borderline regex patterns.
  * Added regression checks for command-line and resolver validation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->