### PR TITLE
fix(www): make the Software page's update check savable

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4925,7 +4925,9 @@ function pfb_software_cache_matches_install(array $cache, string $pkgname, strin
 	// to string emits "Array to string conversion" on every call before returning the same
 	// FALSE (issue #2367). A half that is present but not scalar names nothing, so it is
 	// refused before the cast -- including JSON null, which would otherwise coalesce to ''
-	// and match an install whose own name is empty.
+	// and match an install whose own name is empty. Both live callers reach this through
+	// pfb_software_read_cache(), which drops the same values a layer earlier; this stays for
+	// a caller that hands over a cache array from anywhere else.
 	if (array_key_exists('pkgname', $cache) && !is_scalar($cache['pkgname'])) {
 		return FALSE;
 	}
@@ -5173,8 +5175,9 @@ function pfb_software_read_cache(): array {
 	// latest/last_notified, the page's displayed fields, the install matcher. A non-scalar
 	// value (a hand-edit, a future writer) makes each of those casts emit "Array to string
 	// conversion" once per call, so it is dropped HERE rather than guarded at each site,
-	// where the next site added would be unguarded again (issue #2367). Every key this
-	// package writes is a scalar, so nothing it produces is lost.
+	// where the next site added would be unguarded again (issue #2367). Every key the writer
+	// stores is a scalar or NULL; a stored NULL drops too, which costs nothing because the
+	// only nullable one ('channel') is recomputed live and never read back from here.
 	return array_filter($data, static function ($value): bool {
 		return is_scalar($value);
 	});

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4921,10 +4921,17 @@ function pfb_channel_for_install(?string $repo, ?string $pkgname): ?string {
  * re-announce an already-notified version and blank the last-known latest.
  */
 function pfb_software_cache_matches_install(array $cache, string $pkgname, string $repo): bool {
-	if ((string) ($cache['pkgname'] ?? '') !== $pkgname) {
+	// The cache is a JSON file on disk, so a non-scalar can reach either half; casting one
+	// to string emits "Array to string conversion" on every call before returning the same
+	// FALSE (issue #2367). Neither can identify an install, so both are refused here.
+	$cached_name = $cache['pkgname'] ?? '';
+	if (!is_scalar($cached_name) || (string) $cached_name !== $pkgname) {
 		return FALSE;
 	}
-	return !array_key_exists('repo', $cache) || (string) $cache['repo'] === $repo;
+	if (!array_key_exists('repo', $cache)) {
+		return TRUE;
+	}
+	return is_scalar($cache['repo']) && (string) $cache['repo'] === $repo;
 }
 
 /*

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4923,9 +4923,13 @@ function pfb_channel_for_install(?string $repo, ?string $pkgname): ?string {
 function pfb_software_cache_matches_install(array $cache, string $pkgname, string $repo): bool {
 	// The cache is a JSON file on disk, so a non-scalar can reach either half; casting one
 	// to string emits "Array to string conversion" on every call before returning the same
-	// FALSE (issue #2367). Neither can identify an install, so both are refused here.
-	$cached_name = $cache['pkgname'] ?? '';
-	if (!is_scalar($cached_name) || (string) $cached_name !== $pkgname) {
+	// FALSE (issue #2367). A half that is present but not scalar names nothing, so it is
+	// refused before the cast -- including JSON null, which would otherwise coalesce to ''
+	// and match an install whose own name is empty.
+	if (array_key_exists('pkgname', $cache) && !is_scalar($cache['pkgname'])) {
+		return FALSE;
+	}
+	if ((string) ($cache['pkgname'] ?? '') !== $pkgname) {
 		return FALSE;
 	}
 	if (!array_key_exists('repo', $cache)) {
@@ -5162,7 +5166,18 @@ function pfb_software_read_cache(): array {
 		return array();
 	}
 	$data = json_decode($raw, TRUE);
-	return is_array($data) ? $data : array();
+	if (!is_array($data)) {
+		return array();
+	}
+	// Every consumer reads these values through a (string) cast -- the orchestrator's
+	// latest/last_notified, the page's displayed fields, the install matcher. A non-scalar
+	// value (a hand-edit, a future writer) makes each of those casts emit "Array to string
+	// conversion" once per call, so it is dropped HERE rather than guarded at each site,
+	// where the next site added would be unguarded again (issue #2367). Every key this
+	// package writes is a scalar, so nothing it produces is lost.
+	return array_filter($data, static function ($value): bool {
+		return is_scalar($value);
+	});
 }
 
 /*

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -179,11 +179,16 @@ $section->addInput(new Form_StaticText(
 $form->add($section);
 
 $section = new Form_Section('Updates');
+// The 5th argument is the token this box POSTS when ticked, and it is load-bearing:
+// pfSense defaults it to 'yes', which the save path's PFB_FILTER_ON_OFF rejects, so a
+// checked Save would persist the disabled token and the setting could never be turned
+// back on (issue #2367).
 $section->addInput(new Form_Checkbox(
 	'pfb_software_check',
 	'New version check',
 	'Enabled',
-	$pfb_sw_check
+	$pfb_sw_check,
+	'on'
 ))->setHelp('Periodically check for a new version and notify when one is available.');
 $form->add($section);
 

--- a/tests/php/SoftwareCacheMatchGuardTest.php
+++ b/tests/php/SoftwareCacheMatchGuardTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_software_cache_matches_install() reads two values out of a JSON cache file and casts
+ * them to string. The file is written by this package, but it is a file on disk: a truncated
+ * write, a hand-edit, or a future writer can put an array where a scalar belongs, and the
+ * cast then emits "Array to string conversion" into php_error.log on every call — noise the
+ * UI test tiers read as a page defect (issue #2367).
+ *
+ * The verdict was already right (a non-matching cache is not adopted); what these cases pin
+ * is that reaching it is silent.
+ */
+#[CoversFunction('pfb_software_cache_matches_install')]
+final class SoftwareCacheMatchGuardTest extends TestCase
+{
+	/**
+	 * Run the matcher with warnings captured rather than converted, so the assertion is
+	 * about what it emitted and not merely about not throwing.
+	 *
+	 * @param array<string,mixed> $cache
+	 * @return array{0:bool,1:list<string>}
+	 */
+	private function match(array $cache, string $pkgname, string $repo): array
+	{
+		$seen = [];
+		set_error_handler(static function (int $errno, string $msg) use (&$seen): bool {
+			$seen[] = $msg;
+			return TRUE;
+		});
+
+		try {
+			$verdict = pfb_software_cache_matches_install($cache, $pkgname, $repo);
+		} finally {
+			restore_error_handler();
+		}
+
+		return [$verdict, $seen];
+	}
+
+	/** An array-valued pkgname is rejected, and says nothing to the error log doing it. */
+	public function testArrayPkgnameIsRejectedSilently(): void
+	{
+		[$verdict, $seen] = $this->match(
+			['pkgname' => ['pfSense-pkg-pfBlockerNG'], 'repo' => 'pfblockerng-stable'],
+			'pfSense-pkg-pfBlockerNG',
+			'pfblockerng-stable'
+		);
+
+		$this->assertFalse($verdict, 'an array pkgname cannot identify the install');
+		$this->assertSame([], $seen, 'the matcher must not emit a diagnostic: ' . implode(' | ', $seen));
+	}
+
+	/** Same for the repo half, which is read only after the pkgname half matches. */
+	public function testArrayRepoIsRejectedSilently(): void
+	{
+		[$verdict, $seen] = $this->match(
+			['pkgname' => 'pfSense-pkg-pfBlockerNG', 'repo' => ['pfblockerng-stable']],
+			'pfSense-pkg-pfBlockerNG',
+			'pfblockerng-stable'
+		);
+
+		$this->assertFalse($verdict, 'an array repo cannot identify the catalogue');
+		$this->assertSame([], $seen, 'the matcher must not emit a diagnostic: ' . implode(' | ', $seen));
+	}
+
+	/**
+	 * The branches that must not change: a matching cache still matches, a repo-less cache
+	 * (every box that predates #2148) is still adopted, and a real mismatch is still refused.
+	 */
+	public function testScalarBranchesAreUnchanged(): void
+	{
+		[$match] = $this->match(
+			['pkgname' => 'pfSense-pkg-pfBlockerNG', 'repo' => 'pfblockerng-stable'],
+			'pfSense-pkg-pfBlockerNG',
+			'pfblockerng-stable'
+		);
+		$this->assertTrue($match, 'a cache describing this install matches');
+
+		[$legacy] = $this->match(
+			['pkgname' => 'pfSense-pkg-pfBlockerNG'],
+			'pfSense-pkg-pfBlockerNG',
+			'pfblockerng-stable'
+		);
+		$this->assertTrue($legacy, 'a cache with no repo key predates #2148 and is adopted');
+
+		[$other_repo] = $this->match(
+			['pkgname' => 'pfSense-pkg-pfBlockerNG', 'repo' => 'pfblockerng-edge'],
+			'pfSense-pkg-pfBlockerNG',
+			'pfblockerng-stable'
+		);
+		$this->assertFalse($other_repo, 'a cache from another catalogue is refused');
+
+		[$other_name] = $this->match(
+			['pkgname' => 'pfSense-pkg-pfBlockerNG-devel', 'repo' => 'pfblockerng-stable'],
+			'pfSense-pkg-pfBlockerNG',
+			'pfblockerng-stable'
+		);
+		$this->assertFalse($other_name, 'a cache naming another package is refused');
+	}
+}

--- a/tests/php/SoftwareCacheMatchGuardTest.php
+++ b/tests/php/SoftwareCacheMatchGuardTest.php
@@ -69,6 +69,30 @@ final class SoftwareCacheMatchGuardTest extends TestCase
 	}
 
 	/**
+	 * A present-but-null half is refused the same way an array one is. JSON's null reaches
+	 * PHP as null, and coalescing it to '' before the guard would let a cache that names
+	 * nothing match an install whose own name is empty — the asymmetry the guard exists to
+	 * remove, since the repo half already refuses null.
+	 */
+	public function testNullHalvesAreRefusedLikeAnyOtherNonScalar(): void
+	{
+		[$name_verdict, $name_seen] = $this->match(
+			['pkgname' => NULL, 'repo' => 'pfblockerng-stable'],
+			'',
+			'pfblockerng-stable'
+		);
+		$this->assertFalse($name_verdict, 'a null pkgname names no install, empty live name or not');
+		$this->assertSame([], $name_seen, 'the matcher must not emit a diagnostic: ' . implode(' | ', $name_seen));
+
+		[$repo_verdict] = $this->match(
+			['pkgname' => 'pfSense-pkg-pfBlockerNG', 'repo' => NULL],
+			'pfSense-pkg-pfBlockerNG',
+			''
+		);
+		$this->assertFalse($repo_verdict, 'a null repo names no catalogue, empty live repo or not');
+	}
+
+	/**
 	 * The branches that must not change: a matching cache still matches, a repo-less cache
 	 * (every box that predates #2148) is still adopted, and a real mismatch is still refused.
 	 */

--- a/tests/php/SoftwareCacheReadNormalisationTest.php
+++ b/tests/php/SoftwareCacheReadNormalisationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every consumer of the software-update cache reads its values with a ``(string)`` cast —
+ * the cron orchestrator's latest/last_notified, the Software page's displayed fields, the
+ * install matcher. A non-scalar value in the file therefore emits "Array to string
+ * conversion" at EACH of those call sites, once per call (issue #2367).
+ *
+ * Guarding each site would leave the next one to be written unguarded, so the value is
+ * dropped where the file becomes data: a key the reader cannot hand to a caster is a key no
+ * caller can use.
+ */
+#[CoversFunction('pfb_software_read_cache')]
+final class SoftwareCacheReadNormalisationTest extends TestCase
+{
+	private string $dbdir = '';
+	private bool $hadDbdir = FALSE;
+	private mixed $savedDbdir = NULL;
+
+	protected function setUp(): void
+	{
+		$this->dbdir = sys_get_temp_dir() . '/pfb_sw_cache_' . uniqid('', TRUE);
+		mkdir($this->dbdir, 0o755, TRUE);
+		$this->hadDbdir   = isset($GLOBALS['pfb']) && array_key_exists('dbdir', $GLOBALS['pfb']);
+		$this->savedDbdir = $GLOBALS['pfb']['dbdir'] ?? NULL;
+		$GLOBALS['pfb']['dbdir'] = $this->dbdir;
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadDbdir) {
+			$GLOBALS['pfb']['dbdir'] = $this->savedDbdir;
+		} else {
+			unset($GLOBALS['pfb']['dbdir']);
+		}
+		foreach ((array) glob($this->dbdir . '/*') as $file) {
+			@unlink((string) $file);
+		}
+		@rmdir($this->dbdir);
+	}
+
+	/** @param array<string,mixed> $payload */
+	private function writeCache(array $payload): void
+	{
+		file_put_contents(
+			$this->dbdir . '/software_update.json',
+			(string) json_encode($payload)
+		);
+	}
+
+	/**
+	 * The scalar keys the writer stores survive a read unchanged — the normalisation must
+	 * not cost the cache its contents.
+	 */
+	public function testScalarValuesSurvive(): void
+	{
+		$this->writeCache([
+			'pkgname'       => 'pfSense-pkg-pfBlockerNG',
+			'repo'          => 'pfblockerng-stable',
+			'channel'       => 'Stable',
+			'installed'     => '4.0.0',
+			'latest'        => '4.0.1',
+			'last_notified' => '',
+			'last_checked'  => 1755200000,
+		]);
+
+		$cache = pfb_software_read_cache();
+
+		$this->assertSame('pfSense-pkg-pfBlockerNG', $cache['pkgname']);
+		$this->assertSame('4.0.1', $cache['latest']);
+		$this->assertSame(1755200000, $cache['last_checked']);
+	}
+
+	/**
+	 * A non-scalar value is dropped, so a caller casting it never sees it. Asserted through
+	 * the cast every consumer performs, with warnings captured rather than converted — the
+	 * point is what the code EMITS, not merely what it returns.
+	 */
+	public function testNonScalarValuesAreDroppedSoConsumerCastsAreSilent(): void
+	{
+		$this->writeCache([
+			'pkgname'       => 'pfSense-pkg-pfBlockerNG',
+			'latest'        => ['4.0.1'],
+			'last_notified' => ['nested' => ['deep']],
+			'last_checked'  => 1755200000,
+		]);
+
+		$seen = [];
+		set_error_handler(static function (int $errno, string $msg) use (&$seen): bool {
+			$seen[] = $msg;
+			return TRUE;
+		});
+
+		try {
+			$cache  = pfb_software_read_cache();
+			// Exactly what the orchestrator and the page do with these two keys.
+			$latest = (string) ($cache['latest'] ?? '');
+			$last   = (string) ($cache['last_notified'] ?? '');
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame([], $seen, 'reading and casting the cache must be silent: ' . implode(' | ', $seen));
+		$this->assertArrayNotHasKey('latest', $cache, 'an array latest cannot be a version string');
+		$this->assertArrayNotHasKey('last_notified', $cache, 'an array last_notified cannot be a version string');
+		$this->assertSame('', $latest);
+		$this->assertSame('', $last);
+		// The scalars around it are untouched, so one bad key does not blank the cache.
+		$this->assertSame('pfSense-pkg-pfBlockerNG', $cache['pkgname']);
+		$this->assertSame(1755200000, $cache['last_checked']);
+	}
+
+	/** A file that is absent, empty, or not a JSON object still reads as an empty cache. */
+	public function testUnusableFilesStillReadAsEmpty(): void
+	{
+		$this->assertSame([], pfb_software_read_cache(), 'an absent cache file reads empty');
+
+		file_put_contents($this->dbdir . '/software_update.json', '');
+		$this->assertSame([], pfb_software_read_cache(), 'an empty cache file reads empty');
+
+		file_put_contents($this->dbdir . '/software_update.json', '{"latest": ');
+		$this->assertSame([], pfb_software_read_cache(), 'a truncated cache file reads empty');
+
+		file_put_contents($this->dbdir . '/software_update.json', '"just a string"');
+		$this->assertSame([], pfb_software_read_cache(), 'a non-object cache file reads empty');
+	}
+}

--- a/tests/php/SoftwareCheckPostRoundTripTest.php
+++ b/tests/php/SoftwareCheckPostRoundTripTest.php
@@ -25,43 +25,48 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 {
 	private const PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_software.php';
 
-	/** The config path the page's setting is stored at. */
-	private const PATH = 'installedpackages/pfblockerng/config/0/pfb_software_check';
-
 	/**
 	 * The value the rendered checkbox posts when ticked: the Form_Checkbox call's 5th
 	 * argument, or pfSense's default when the page omits it.
+	 *
+	 * Read from the comment-stripped, whitespace-collapsed source so a reformat of the call
+	 * (one line, re-indented, a comment between arguments) cannot change the answer.
 	 */
 	private function postedWhenChecked(): string
 	{
-		$source = (string) file_get_contents(self::PAGE);
-		$open   = strpos($source, "new Form_Checkbox(\n\t'pfb_software_check',");
-		$this->assertNotFalse($open, 'the Software page must build its check-for-updates checkbox');
+		$source = php_strip_whitespace(self::PAGE);
+		$found  = preg_match(
+			"/new Form_Checkbox\\(\\s*'pfb_software_check'\\s*,((?:[^()]|\\([^()]*\\))*)\\)/",
+			$source,
+			$m
+		);
+		$this->assertSame(1, $found, 'the Software page must build its check-for-updates checkbox');
 
-		$close = strpos($source, '))', $open);
-		$this->assertNotFalse($close, 'unterminated Form_Checkbox call for pfb_software_check');
-		$args = substr($source, $open, $close - $open);
-
-		// 4 constructor arguments before the value: name, title, description, checked.
-		$parts = array_map('trim', explode(',', $args));
-		if (count($parts) < 5 || $parts[4] === '') {
+		// name is consumed by the pattern, so what remains is title, description, checked
+		// and — when the page passes it — the posted value.
+		$args = array_map('trim', explode(',', $m[1]));
+		if (count($args) < 4 || $args[3] === '') {
 			return 'yes'; // pfSense's Form_Checkbox default.
 		}
 
-		return trim($parts[4], "'\"");
+		return trim($args[3], "'\"");
 	}
 
-	/** The page's save filter, asserted to still be the one modelled here. */
+	/**
+	 * The page's save filter, applied through the SAME constant the page names, so swapping
+	 * the page to another filter cannot leave this modelling the old one.
+	 */
 	private function saveFilter(string $posted): string
 	{
 		$source = php_strip_whitespace(self::PAGE);
-		$this->assertStringContainsString(
-			"pfb_filter(\$_POST['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: ''",
+		$found  = preg_match(
+			"/pfb_filter\\(\\\$_POST\\['pfb_software_check'\\] \\?\\? '', (PFB_FILTER_[A-Z_]+), 'software'\\) \\?: ''/",
 			$source,
-			'the modelled save expression no longer matches the page'
+			$m
 		);
+		$this->assertSame(1, $found, 'the modelled save expression no longer matches the page');
 
-		return pfb_filter($posted, PFB_FILTER_ON_OFF, 'software') ?: '';
+		return pfb_filter($posted, constant($m[1]), 'software') ?: '';
 	}
 
 	private bool $hadConfig = FALSE;
@@ -142,8 +147,8 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 		);
 		$this->assertSame(
 			$posted,
-			pfb_filter($posted, PFB_FILTER_ON_OFF, 'software'),
-			'the posted token must survive the save path unchanged'
+			$this->saveFilter($posted),
+			'the posted token must survive the page\'s own save path unchanged'
 		);
 	}
 }

--- a/tests/php/SoftwareCheckPostRoundTripTest.php
+++ b/tests/php/SoftwareCheckPostRoundTripTest.php
@@ -65,6 +65,15 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 			$m
 		);
 		$this->assertSame(1, $found, 'the modelled save expression no longer matches the page');
+		// Applied through the page's own constant so this cannot model a filter the page
+		// stopped using, AND pinned to the one that makes the round-trip meaningful: a save
+		// widened to accept a looser token set is a different contract, not a refactor.
+		$this->assertSame(
+			'PFB_FILTER_ON_OFF',
+			$m[1],
+			'the Save must keep filtering with PFB_FILTER_ON_OFF; a looser filter would accept tokens '
+			. 'that no longer round-trip through the toggle gateway'
+		);
 
 		return pfb_filter($posted, constant($m[1]), 'software') ?: '';
 	}

--- a/tests/php/SoftwareCheckPostRoundTripTest.php
+++ b/tests/php/SoftwareCheckPostRoundTripTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The Software page's "New version check" checkbox has to POST a token its own save path
+ * accepts (issue #2367).
+ *
+ * pfSense's Form_Checkbox posts 'yes' unless the caller passes a value:
+ * ``__construct($name, $title, $description, $checked, $value = 'yes')``. The save path
+ * filters with PFB_FILTER_ON_OFF, which accepts only 'on' and '' — so a checkbox built
+ * without that argument posts a token the filter rejects, and every Save, including one
+ * with the box ticked, persists the disabled token. The page then renders back unchecked
+ * and no UI path can turn the check back on.
+ *
+ * The posted token is read OUT OF THE PAGE here rather than assumed, so this stays a test
+ * of what the page does: drop the explicit value again and the extraction falls back to
+ * pfSense's 'yes' and these cases go red.
+ */
+#[CoversFunction('pfb_software_check_enabled')]
+final class SoftwareCheckPostRoundTripTest extends TestCase
+{
+	private const PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_software.php';
+
+	/** The config path the page's setting is stored at. */
+	private const PATH = 'installedpackages/pfblockerng/config/0/pfb_software_check';
+
+	/**
+	 * The value the rendered checkbox posts when ticked: the Form_Checkbox call's 5th
+	 * argument, or pfSense's default when the page omits it.
+	 */
+	private function postedWhenChecked(): string
+	{
+		$source = (string) file_get_contents(self::PAGE);
+		$open   = strpos($source, "new Form_Checkbox(\n\t'pfb_software_check',");
+		$this->assertNotFalse($open, 'the Software page must build its check-for-updates checkbox');
+
+		$close = strpos($source, '))', $open);
+		$this->assertNotFalse($close, 'unterminated Form_Checkbox call for pfb_software_check');
+		$args = substr($source, $open, $close - $open);
+
+		// 4 constructor arguments before the value: name, title, description, checked.
+		$parts = array_map('trim', explode(',', $args));
+		if (count($parts) < 5 || $parts[4] === '') {
+			return 'yes'; // pfSense's Form_Checkbox default.
+		}
+
+		return trim($parts[4], "'\"");
+	}
+
+	/** The page's save filter, asserted to still be the one modelled here. */
+	private function saveFilter(string $posted): string
+	{
+		$source = php_strip_whitespace(self::PAGE);
+		$this->assertStringContainsString(
+			"pfb_filter(\$_POST['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: ''",
+			$source,
+			'the modelled save expression no longer matches the page'
+		);
+
+		return pfb_filter($posted, PFB_FILTER_ON_OFF, 'software') ?: '';
+	}
+
+	private bool $hadConfig = FALSE;
+	private mixed $originalConfig = NULL;
+
+	protected function setUp(): void
+	{
+		$this->hadConfig = array_key_exists('config', $GLOBALS);
+		$this->originalConfig = $GLOBALS['config'] ?? NULL;
+		$GLOBALS['config'] = [];
+
+		// issue #1895: this field's write authorization is the package-manager page, not
+		// the package's own general page, so a write refuses without it and the round-trip
+		// below would read as the defect it is looking for.
+		$GLOBALS['pfb_test_allowed_pages'] = ['pkg_mgr_installed.php' => TRUE];
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['pfb_test_allowed_pages']);
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+	}
+
+	/**
+	 * Save with the box ticked persists ENABLED. This is the defect's direct oracle: with a
+	 * posted 'yes' the filter rejects the token, the page stores '', and the setting reads
+	 * back disabled however many times it is saved.
+	 */
+	public function testCheckedSavePersistsEnabled(): void
+	{
+		// Before: an unticked Save has left the setting off, so a green below is this
+		// save's doing and not the registry's enabled-by-default.
+		PfbConfig::write('gen/pfb_software_check', $this->saveFilter(''));
+		$this->assertFalse(pfb_software_check_enabled(), 'precondition: the check starts disabled');
+
+		PfbConfig::write('gen/pfb_software_check', $this->saveFilter($this->postedWhenChecked()));
+
+		$this->assertTrue(
+			pfb_software_check_enabled(),
+			'a Save with the box ticked must persist the enabled token; the posted value was '
+			. var_export($this->postedWhenChecked(), TRUE)
+		);
+	}
+
+	/**
+	 * The other branch: a browser omits an unticked checkbox entirely, and that absence has
+	 * to keep persisting the disabled token — the fix must not make the box unturnoffable.
+	 */
+	public function testUncheckedSavePersistsDisabled(): void
+	{
+		PfbConfig::write('gen/pfb_software_check', $this->saveFilter($this->postedWhenChecked()));
+		$this->assertTrue(pfb_software_check_enabled(), 'precondition: the check is enabled first');
+
+		// An absent POST key reaches the save path as ''.
+		PfbConfig::write('gen/pfb_software_check', $this->saveFilter(''));
+
+		$this->assertFalse(pfb_software_check_enabled(), 'an unticked Save must persist the disabled token');
+	}
+
+	/**
+	 * The trap itself, named: the page must pass its checkbox value explicitly. Sibling
+	 * pages that pass 'on' (pfblockerng_sync.php) round-trip; one that relies on the
+	 * default posts 'yes' and cannot.
+	 */
+	public function testCheckboxPostsATokenTheFilterAccepts(): void
+	{
+		$posted = $this->postedWhenChecked();
+
+		$this->assertNotSame(
+			'yes',
+			$posted,
+			"the checkbox must pass its value explicitly; pfSense's Form_Checkbox default 'yes' "
+			. 'is rejected by PFB_FILTER_ON_OFF'
+		);
+		$this->assertSame(
+			$posted,
+			pfb_filter($posted, PFB_FILTER_ON_OFF, 'software'),
+			'the posted token must survive the save path unchanged'
+		);
+	}
+}

--- a/tests/php/WwwCheckboxPostedValueTest.php
+++ b/tests/php/WwwCheckboxPostedValueTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every checkbox this package renders must say what it POSTS (issue #2367).
+ *
+ * pfSense's Form_Checkbox defaults its value argument to 'yes'
+ * (``__construct($name, $title, $description, $checked, $value = 'yes')``), while this
+ * package's save paths validate with PFB_FILTER_ON_OFF, which accepts only 'on' and ''.
+ * A checkbox built without the argument therefore renders and saves without error, and
+ * silently persists the DISABLED token every time — including when it is ticked, leaving no
+ * UI path back. The Software page shipped that way for a release.
+ *
+ * The page-specific round-trip lives in SoftwareCheckPostRoundTripTest; this is the class
+ * guard, so the next page to omit the argument fails here rather than after a user cannot
+ * re-enable a setting.
+ */
+final class WwwCheckboxPostedValueTest extends TestCase
+{
+	private const WWW = __DIR__ . '/../../src/usr/local/www';
+
+	/** @return list<string> every shipped PHP file under src/usr/local/www. */
+	private function pages(): array
+	{
+		$found = [];
+		$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(self::WWW, FilesystemIterator::SKIP_DOTS));
+		foreach ($it as $file) {
+			if ($file->isFile() && strtolower((string) $file->getExtension()) === 'php') {
+				$found[] = (string) $file->getPathname();
+			}
+		}
+		sort($found);
+
+		return $found;
+	}
+
+	/**
+	 * The constructor arguments of every ``new Form_Checkbox(...)`` in a file, comments and
+	 * line breaks already stripped so formatting cannot change the answer.
+	 *
+	 * @return list<list<string>>
+	 */
+	private function checkboxArgs(string $path): array
+	{
+		$source = php_strip_whitespace($path);
+		preg_match_all("/new Form_Checkbox\(((?:[^()]|\([^()]*\))*)\)/", $source, $matches);
+
+		$calls = [];
+		foreach ($matches[1] as $args) {
+			$calls[] = array_map('trim', explode(',', $args));
+		}
+
+		return $calls;
+	}
+
+	public function testEveryCheckboxPassesItsPostedValueExplicitly(): void
+	{
+		$offenders = [];
+		$seen      = 0;
+
+		foreach ($this->pages() as $page) {
+			foreach ($this->checkboxArgs($page) as $args) {
+				$seen++;
+				// name, title, description, checked, value: fewer than five arguments means
+				// the page inherits pfSense's 'yes'.
+				if (count($args) < 5 || $args[4] === '') {
+					$offenders[] = basename($page) . ': new Form_Checkbox(' . implode(', ', $args) . ')';
+				}
+			}
+		}
+
+		// A guard that finds nothing to guard is not a guard: if the sweep stops matching,
+		// this count goes to zero and says so instead of passing quietly.
+		$this->assertGreaterThan(20, $seen, 'the sweep found almost no checkboxes; its pattern has stopped matching');
+		$this->assertSame(
+			[],
+			$offenders,
+			"these checkboxes inherit pfSense's default posted value 'yes', which no PFB_FILTER_ON_OFF "
+			. "save path accepts:\n  " . implode("\n  ", $offenders)
+		);
+	}
+}

--- a/tests/php/WwwCheckboxPostedValueTest.php
+++ b/tests/php/WwwCheckboxPostedValueTest.php
@@ -114,6 +114,13 @@ final class WwwCheckboxPostedValueTest extends TestCase
 			while ($j < $count && is_array($tokens[$j]) && in_array($tokens[$j][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], TRUE)) {
 				$j++;
 			}
+			// A fully-qualified `new \Form_Checkbox(` is the same call; no page declares a
+			// namespace today, so this is only here to keep the shape from being a blind spot.
+			if ($j < $count && is_array($tokens[$j]) && $tokens[$j][0] === T_NS_SEPARATOR) {
+				$j++;
+			} elseif ($j < $count && $tokens[$j] === '\\') {
+				$j++;
+			}
 			if ($j >= $count || !is_array($tokens[$j]) || $tokens[$j][0] !== T_STRING || $tokens[$j][1] !== 'Form_Checkbox') {
 				continue;
 			}
@@ -166,6 +173,13 @@ final class WwwCheckboxPostedValueTest extends TestCase
 			self::splitArgs("'pfb_x', gettext('A, B'), 'Enabled', \$checked, 'on'"),
 			'a comma inside a nested call must not end that argument'
 		);
+		// The case above is also satisfied by quote-tracking alone; this one is not, so it
+		// is what actually holds the depth tracking honest.
+		$this->assertSame(
+			["'pfb_x'", 'max($a, $b)', "'Enabled'", '$rows[1, 2]', "'on'"],
+			self::splitArgs("'pfb_x', max(\$a, \$b), 'Enabled', \$rows[1, 2], 'on'"),
+			'an UNQUOTED comma inside a call or an index must not end that argument'
+		);
 		$this->assertSame(
 			["'pfb_x'", '"a \\", b"', "'Enabled'", '$checked'],
 			self::splitArgs("'pfb_x', \"a \\\", b\", 'Enabled', \$checked"),
@@ -194,7 +208,9 @@ final class WwwCheckboxPostedValueTest extends TestCase
 		// construct. An undercount means a page is unguarded without anything saying so.
 		$expected = 0;
 		foreach ($this->pages() as $page) {
-			$expected += substr_count(php_strip_whitespace($page), 'new Form_Checkbox');
+			$stripped  = php_strip_whitespace($page);
+			$expected += substr_count($stripped, 'new Form_Checkbox');
+			$expected += substr_count($stripped, 'new \\Form_Checkbox');
 		}
 		$this->assertGreaterThan(20, $expected, 'the sweep found almost no checkboxes; it has stopped matching');
 		$this->assertSame($expected, $seen, 'the sweep parsed fewer checkbox calls than the tree contains');

--- a/tests/php/WwwCheckboxPostedValueTest.php
+++ b/tests/php/WwwCheckboxPostedValueTest.php
@@ -38,6 +38,60 @@ final class WwwCheckboxPostedValueTest extends TestCase
 	}
 
 	/**
+	 * Split a PHP argument list on its TOP-LEVEL commas.
+	 *
+	 * A plain explode() would split inside a quoted title ("Enable, then reload") and inside
+	 * a nested call, counting arguments that are not there — which for this guard means a
+	 * page that omits the posted value reads as if it passed one.
+	 *
+	 * @return list<string>
+	 */
+	public static function splitArgs(string $args): array
+	{
+		$parts = [];
+		$current = '';
+		$quote = '';
+		$depth = 0;
+		$length = strlen($args);
+
+		for ($i = 0; $i < $length; $i++) {
+			$char = $args[$i];
+
+			if ($quote !== '') {
+				// Inside a string literal: a backslash escapes the next character, so an
+				// escaped quote does not end it.
+				if ($char === '\\' && $i + 1 < $length) {
+					$current .= $char . $args[++$i];
+					continue;
+				}
+				if ($char === $quote) {
+					$quote = '';
+				}
+				$current .= $char;
+				continue;
+			}
+
+			if ($char === "'" || $char === '"') {
+				$quote = $char;
+			} elseif ($char === '(' || $char === '[') {
+				$depth++;
+			} elseif ($char === ')' || $char === ']') {
+				$depth--;
+			} elseif ($char === ',' && $depth === 0) {
+				$parts[] = trim($current);
+				$current = '';
+				continue;
+			}
+
+			$current .= $char;
+		}
+
+		$parts[] = trim($current);
+
+		return $parts;
+	}
+
+	/**
 	 * The constructor arguments of every ``new Form_Checkbox(...)`` in a file, comments and
 	 * line breaks already stripped so formatting cannot change the answer.
 	 *
@@ -45,15 +99,78 @@ final class WwwCheckboxPostedValueTest extends TestCase
 	 */
 	private function checkboxArgs(string $path): array
 	{
-		$source = php_strip_whitespace($path);
-		preg_match_all("/new Form_Checkbox\(((?:[^()]|\([^()]*\))*)\)/", $source, $matches);
+		// Tokenised, not pattern-matched: a description like gettext('text (with parens)')
+		// nests deeper than any fixed regex, and a call the sweep cannot see is a page it
+		// cannot guard -- which is how a real offender would slip through.
+		$tokens = token_get_all(php_strip_whitespace($path));
+		$count  = count($tokens);
+		$calls  = [];
 
-		$calls = [];
-		foreach ($matches[1] as $args) {
-			$calls[] = array_map('trim', explode(',', $args));
+		for ($i = 0; $i < $count; $i++) {
+			if (!is_array($tokens[$i]) || $tokens[$i][0] !== T_NEW) {
+				continue;
+			}
+			$j = $i + 1;
+			while ($j < $count && is_array($tokens[$j]) && in_array($tokens[$j][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], TRUE)) {
+				$j++;
+			}
+			if ($j >= $count || !is_array($tokens[$j]) || $tokens[$j][0] !== T_STRING || $tokens[$j][1] !== 'Form_Checkbox') {
+				continue;
+			}
+			$k = $j + 1;
+			while ($k < $count && is_array($tokens[$k]) && $tokens[$k][0] === T_WHITESPACE) {
+				$k++;
+			}
+			if ($k >= $count || $tokens[$k] !== '(') {
+				continue;
+			}
+
+			$depth = 0;
+			$args  = '';
+			for ($n = $k; $n < $count; $n++) {
+				$text = is_array($tokens[$n]) ? $tokens[$n][1] : $tokens[$n];
+				if ($text === '(' || $text === '[') {
+					$depth++;
+					if ($depth === 1) {
+						continue;
+					}
+				} elseif ($text === ')' || $text === ']') {
+					$depth--;
+					if ($depth === 0) {
+						break;
+					}
+				}
+				$args .= $text;
+			}
+
+			$calls[] = self::splitArgs($args);
 		}
 
 		return $calls;
+	}
+
+	/**
+	 * The splitter is the guard's load-bearing half: miscount the arguments and a page that
+	 * omits its posted value reads as compliant. A comma inside a title is the realistic
+	 * shape ("Enable, then reload"), and a nested call is the other.
+	 */
+	public function testArgumentSplitterIgnoresCommasInsideLiteralsAndCalls(): void
+	{
+		$this->assertSame(
+			["'pfb_x'", "'Enable, then reload'", "'Enabled'", '$checked'],
+			self::splitArgs("'pfb_x', 'Enable, then reload', 'Enabled', \$checked"),
+			'a comma inside a quoted argument must not end that argument'
+		);
+		$this->assertSame(
+			["'pfb_x'", 'gettext(\'A, B\')', "'Enabled'", '$checked', "'on'"],
+			self::splitArgs("'pfb_x', gettext('A, B'), 'Enabled', \$checked, 'on'"),
+			'a comma inside a nested call must not end that argument'
+		);
+		$this->assertSame(
+			["'pfb_x'", '"a \\", b"', "'Enabled'", '$checked'],
+			self::splitArgs("'pfb_x', \"a \\\", b\", 'Enabled', \$checked"),
+			'an escaped quote must not end the literal it sits in'
+		);
 	}
 
 	public function testEveryCheckboxPassesItsPostedValueExplicitly(): void
@@ -72,9 +189,15 @@ final class WwwCheckboxPostedValueTest extends TestCase
 			}
 		}
 
-		// A guard that finds nothing to guard is not a guard: if the sweep stops matching,
-		// this count goes to zero and says so instead of passing quietly.
-		$this->assertGreaterThan(20, $seen, 'the sweep found almost no checkboxes; its pattern has stopped matching');
+		// A guard that silently sees only SOME of the calls is worse than one that sees none,
+		// so the sweep's own count is checked against a second, cruder count of the same
+		// construct. An undercount means a page is unguarded without anything saying so.
+		$expected = 0;
+		foreach ($this->pages() as $page) {
+			$expected += substr_count(php_strip_whitespace($page), 'new Form_Checkbox');
+		}
+		$this->assertGreaterThan(20, $expected, 'the sweep found almost no checkboxes; it has stopped matching');
+		$this->assertSame($expected, $seen, 'the sweep parsed fewer checkbox calls than the tree contains');
 		$this->assertSame(
 			[],
 			$offenders,

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -412,7 +412,17 @@ def test_software_page_toggle_post_roundtrip(
         with software_panel_forced(smoke_vm, "on"):
             page = webui.get(flow.page)
             assert "pfb-software-panel" in page.text, "Software panel override must expose reachable POST form"
-            assert (flow.field in scrape_form_fields(page.text)) is (original == flow.on)
+            rendered = scrape_form_fields(page.text)
+            assert (flow.field in rendered) is (original == flow.on)
+            # What the RENDERED box posts, not what this test would like it to post: the
+            # checkbox carried pfSense's default 'yes' for a release, which the save path
+            # rejects, so every Save persisted disabled while a hardcoded 'on' POST here
+            # kept passing (issue #2367).
+            if flow.field in rendered:
+                assert rendered[flow.field] == flow.on, (
+                    f"the rendered checkbox posts {rendered[flow.field]!r}; the save path accepts "
+                    f"only {flow.on!r}, so a ticked Save would persist disabled"
+                )
             _set_and_confirm(webui, smoke_vm, flow, flipped)
             page = webui.get(flow.page)
             assert "pfb-software-panel" in page.text

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -393,6 +393,17 @@ def test_toggle_flow_changes_effective_config(
             helpers.config_restore_state(smoke_vm, flow.config_path, original_state)
 
 
+def _pin_posted_value(rendered: dict[str, str], flow: ToggleFlow) -> bool:
+    """Assert a CHECKED box submits the token its save path accepts; report whether it ran."""
+    if flow.field not in rendered:
+        return False
+    assert rendered[flow.field] == flow.on, (
+        f"{flow.name}: the rendered checkbox posts {rendered[flow.field]!r}; the save path "
+        f"accepts only {flow.on!r}, so a ticked Save would persist disabled"
+    )
+    return True
+
+
 def test_software_page_toggle_post_roundtrip(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
@@ -417,20 +428,26 @@ def test_software_page_toggle_post_roundtrip(
             # What the RENDERED box posts, not what this test would like it to post: the
             # checkbox carried pfSense's default 'yes' for a release, which the save path
             # rejects, so every Save persisted disabled while a hardcoded 'on' POST here
-            # kept passing (issue #2367).
-            if flow.field in rendered:
-                assert rendered[flow.field] == flow.on, (
-                    f"the rendered checkbox posts {rendered[flow.field]!r}; the save path accepts "
-                    f"only {flow.on!r}, so a ticked Save would persist disabled"
-                )
+            # kept passing (issue #2367). A checkbox submits nothing while unchecked, so the
+            # pin runs on whichever GET below finds it checked -- and `pinned` makes "never
+            # checked, never asserted" a failure instead of a silent pass.
+            pinned = _pin_posted_value(rendered, flow)
             _set_and_confirm(webui, smoke_vm, flow, flipped)
             page = webui.get(flow.page)
             assert "pfb-software-panel" in page.text
-            assert (flow.field in scrape_form_fields(page.text)) is (flipped == flow.on)
+            rendered = scrape_form_fields(page.text)
+            assert (flow.field in rendered) is (flipped == flow.on)
+            pinned = _pin_posted_value(rendered, flow) or pinned
             _set_and_confirm(webui, smoke_vm, flow, original)
             page = webui.get(flow.page)
             assert "pfb-software-panel" in page.text
-            assert (flow.field in scrape_form_fields(page.text)) is (original == flow.on)
+            rendered = scrape_form_fields(page.text)
+            assert (flow.field in rendered) is (original == flow.on)
+            pinned = _pin_posted_value(rendered, flow) or pinned
+            assert pinned, (
+                "no GET rendered the checkbox checked, so the posted-value pin never ran "
+                "(issue #2367's whole point is the value a checked box submits)"
+            )
         helpers.config_restore_state(smoke_vm, flow.config_path, original_state)
         assert helpers.config_get_state(smoke_vm, flow.config_path) == original_state
     finally:

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2768,6 +2768,37 @@ def test_software_panel_channel_falls_back_to_the_package_name_off_repo(
     )
 
 
+def test_software_check_checkbox_posts_a_token_the_save_path_accepts(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """The "New version check" box must POST a token its own save path accepts (issue #2367).
+
+    pfSense's Form_Checkbox posts ``yes`` unless the page passes a value, and the save path
+    filters with PFB_FILTER_ON_OFF, which takes only ``on`` and ``''``. Built without that
+    argument the box renders fine and saves to disabled every time, including when ticked,
+    with no UI path back — so the rendered VALUE is the thing worth pinning, not the presence
+    of the control.
+
+    Scenario:
+      Given the override sentinel set to 'on' (so the page renders at all),
+      When the Software page is GET,
+      Then the pfb_software_check control renders with value="on".
+    """
+    with software_panel_forced(smoke_vm, "on"):
+        resp = webui.get(_SOFTWARE_PAGE)
+        result = evaluate_render(_SOFTWARE_PAGE, resp.status_code, resp.text, (_SOFTWARE_PANEL_MARKER,))
+        assert result.ok, f"Software page render oracle failed: {result.detail}"
+        body = resp.text
+
+    control = re.search(r'<input[^>]*\bname="pfb_software_check"[^>]*>', body)
+    assert control is not None, "the Software page must render the pfb_software_check control"
+    value = re.search(r'\bvalue="([^"]*)"', control.group(0))
+    assert value is not None and value.group(1) == "on", (
+        f"pfb_software_check renders {control.group(0)!r}; it must post 'on', the only enabled "
+        "token PFB_FILTER_ON_OFF accepts (pfSense's Form_Checkbox default 'yes' is rejected)"
+    )
+
+
 def test_software_actions_link_to_package_manager(
     smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2790,12 +2790,18 @@ def test_software_check_checkbox_posts_a_token_the_save_path_accepts(
         assert result.ok, f"Software page render oracle failed: {result.detail}"
         body = resp.text
 
-    control = re.search(r'<input[^>]*\bname="pfb_software_check"[^>]*>', body)
-    assert control is not None, "the Software page must render the pfb_software_check control"
-    value = re.search(r'\bvalue="([^"]*)"', control.group(0))
-    assert value is not None and value.group(1) == "on", (
-        f"pfb_software_check renders {control.group(0)!r}; it must post 'on', the only enabled "
-        "token PFB_FILTER_ON_OFF accepts (pfSense's Form_Checkbox default 'yes' is rejected)"
+    # scrape_form_fields() is the codebase's own attribute parser (quoting variants and
+    # all) and it reports a checkbox only when it is CHECKED, which is precisely the state
+    # whose posted value decides the save.
+    submitted = scrape_form_fields(body)
+    assert "pfb_software_check" in submitted, (
+        "the Software page must render the pfb_software_check control CHECKED here — the "
+        "registry default is enabled, and an unchecked box submits nothing to inspect"
+    )
+    assert submitted["pfb_software_check"] == "on", (
+        f"pfb_software_check posts {submitted['pfb_software_check']!r}; it must post 'on', the "
+        "only enabled token PFB_FILTER_ON_OFF accepts (pfSense's Form_Checkbox default 'yes' "
+        "is rejected, so a ticked Save would persist disabled)"
     )
 
 


### PR DESCRIPTION
## The defect

`pfblockerng_software.php` built its "New version check" checkbox without a value:

```php
$section->addInput(new Form_Checkbox(
	'pfb_software_check',
	'New version check',
	'Enabled',
	$pfb_sw_check
))
```

pfSense's `Form_Checkbox` defaults that argument — confirmed against upstream, not assumed:

```php
// pfsense/pfsense src/usr/local/www/classes/Form/Checkbox.class.php
public function __construct($name, $title, $description, $checked, $value = 'yes')
```

So the box posts `pfb_software_check=yes`. The save path filters with `PFB_FILTER_ON_OFF`,
which accepts `'on'` and `''` and nothing else, and the page then stores `?: ''`. Every Save
persisted **disabled** — including one with the box ticked — the page rendered back
unchecked, and no UI path could turn the update check back on. Sibling pages know the trap:
`pfblockerng_sync.php` passes `'on'` explicitly. This one now does too.

## Why the existing test did not catch it

`test_software_page_toggle_post_roundtrip` (Tier B) drives exactly this flow, and it was
green, because `_set_and_confirm` posts a hardcoded `'on'` rather than what the rendered
form carries. It tested the save path against a value the page never sends.

It now asserts the value the page actually renders before driving the POST, and a Tier-A
case pins the rendered token by itself:

```python
control = re.search(r'<input[^>]*\bname="pfb_software_check"[^>]*>', body)
value = re.search(r'\bvalue="([^"]*)"', control.group(0))
assert value is not None and value.group(1) == "on"
```

That pins this page. The class is pinned separately: `WwwCheckboxPostedValueTest` sweeps
every `new Form_Checkbox` under `src/usr/local/www` and fails on any that inherits pfSense's
default, so the next page to omit the argument is caught by a unit test rather than after a
user discovers a setting they cannot re-enable. It flags nothing today — an enumeration the
review reached independently across all 69 sites — and dropping the fixed page's 5th
argument turns it red naming that page.

## Second defect from the same review

An array-valued entry in the software-update cache reached a `(string)` cast in
`pfb_software_cache_matches_install()` and emitted `Array to string conversion` on every
call before returning the same `FALSE`.

Review found three sibling casts of the same JSON emitting the identical warning, so the fix
moved to where the file becomes data: `pfb_software_read_cache()` drops non-scalar values —
a key no caller can cast is a key no caller sees — and every key this package writes is a
scalar. The matcher keeps its own guard, because it is the one consumer whose verdict, not
just its log line, depends on the type; a present-but-null half is refused there too rather
than coalescing to `''` and matching an install whose own name is empty.

`release/3.3` still carries this defect and cannot mirror these tests (no PHPUnit suite, no
`tests/smoke/ui`); that is filed as #2377.

## Evidence

Test-first, in the CI image. `tests/php/SoftwareCheckPostRoundTripTest.php` reads the posted
token OUT of the page (5th constructor argument, else pfSense's `'yes'`) and runs it through
the page's own save expression, so it cannot drift into testing a hardcoded assumption:

```
RED  (84b3acfc, before the fix)
  1) testCheckedSavePersistsEnabled
     a Save with the box ticked must persist the enabled token; the posted value was 'yes'
  2) testUncheckedSavePersistsDisabled — precondition: the check is enabled first
  3) testCheckboxPostsATokenTheFilterAccepts — Failed asserting that two strings are not identical

RED  (c43415cc) for the cache guard
  -Array &0 []
  +Array &0 [ 0 => 'Array to string conversion' ]

GREEN (same two files, byte-identical: 84b3acfc / c43415cc)
  OK (6 tests, 26 assertions)
```

`scripts/agent/run-gates.sh --diff origin/devel`: GATES: PASS (pytest, ruff, mypy, `php -l`,
PHPUnit, PHPStan, PHPCS).

Fixes #2367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ww2ukwGJpwnRNtTPYdrLxf
