### PR TITLE
Per-section policy for feed entries at public-suffix boundaries

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -274,6 +274,43 @@ readable and unchanged.
 self-contained synthetic corpus (`legacy/benchmarks/_corpus_raw.py`) and never imports
 `pfb_unbound.py` or touches the interchange format.
 
+### Feed-at-suffix policy — issue #2371
+
+Two `PfbConfig`-registered selects, `dnsbl/pfb_psl_feed_private_policy` (PSL PRIVATE —
+shared domains, e.g. `github.io`) and `dnsbl/pfb_psl_feed_icann_policy` (public suffix),
+each a `PfbFeedSuffixPolicy` enum (`ignore`/`apex`/`honor`, absent → Honor), govern what
+a **FEED**-provenance rule does when its normalized name resolves EXACTLY to its
+winning public suffix. **USER**-provenance rows (Custom_List, sovereign ABP) are exempt
+in every state.
+
+**Enforcement points** (`pfb_unbound.py`): both the plain `tld_wildcard_classify()`
+loop and the ABP reconcile-fold loop run every suffix-apex FEED row through
+`_dnsbl_suffix_feed_policy()` — `ignore` drops the entry (tallied `suffix_drop`); `apex`
+demotes a would-be wildcard ZONE anchor to an exact-apex DATA block (tallied
+`suffix_demote`); `honor` leaves the row alone (pre-#2371 behaviour) — an explicit ABP
+wildcard rule can still blanket the suffix even under `honor`. A policy != `honor` is
+ALSO a third authority load gate in `_dnsbl_config_from_manifest()`, applying
+regardless of Wildcard Blocking (ABP zones exist independently of it, #1255). The two
+tally buckets ride the existing reject-stats bucket enumeration (`_tally_reject()`)
+PHP already consumes.
+
+**Defaults.** A fresh install seeds BOTH selects `apex`/`apex` (owner decision
+2026-08-14): `pfb_psl_feed_policy_is_fresh_install()` reads the DNSBL section's
+fresh-install-ness BEFORE the registry pass runs, and `pfb_install_psl_feed_policy_seed()`
+writes the seed AFTER it — deliberately not a `pfb_migration_registry()` grandfather
+map, since #1921's ABSENT map is OLDCFG-only and would misfire on a genuinely-fresh
+install too. An existing (upgraded) install is instead grandfathered `honor`/`honor` —
+byte-identical to pre-#2371 behaviour — because the registry's absent/empty default for
+both keys is `''`, which `PfbFeedSuffixPolicy` reads as Honor.
+
+**UI** (issue #2371 Step 3): both fields render as `Form_Select`s on
+`pfblockerng_dnsbl.php`, read/written exclusively through `PfbConfig` (never a raw
+`config_*_path`), placed near Wildcard Blocking but NOT gated by any checkbox
+show/hide — the policy is feed-wide and independent of Wildcard Blocking. POST
+sanitises to a bare word; any token outside the three-value vocabulary normalises to
+Honor via the enum's own fail-safe `fromStored()`/`fromLegacy()` fallback (same
+principle as `PfbToggle`/`PfbIdnMode`). Pinned by `tests/php/DnsblPslPolicyUiTest.php`.
+
 ### ADR-10 — zero-downtime DNSBL data swap
 
 A DNSBL **DATA** update is a **zero-downtime background swap — no Unbound restart**. The module

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -3989,7 +3989,8 @@ class BuildResult:
     ``rejects`` is the ADR-48 (issue #789) per-entry reject tally -- (feed, group)
     -> {'shape': n, 'wire_cap': m} -- for every domain target a normalise-fail (or
     the reconcile() wire-cap fold-drop) rejected; a diagnostic count, not consumed
-    by any decision.
+    by any decision. issue #2371 rides the same tally with two sparse buckets,
+    'suffix_drop' and 'suffix_demote' (present only when they fire).
     """
 
     data_db: dict[str, dict[str, Any]]
@@ -4504,16 +4505,18 @@ def parse(line: str) -> ParsedEntry | None:
 
 # ADR-48 (issue #789): the per-entry reject tally build()/parse_abp()/
 # reconcile() accumulate into, keyed (feed, group) -> {'shape': n, 'wire_cap': m}.
-# A plain dict (no class): the shape never grows past the two RESOLVED buckets
-# (ADR §2 item 4), so a helper that does the defaulting is all this needs.
+# issue #2371 rides the same tally with two sparse buckets, 'suffix_drop' and
+# 'suffix_demote' -- added to a row only when they actually fire, so the
+# pre-#2371 2-key row shape stays byte-identical when they never do.
 RejectTally = dict[tuple[str, str], dict[str, int]]
 
 
 def _tally_reject(tally: RejectTally, feed: str, group: str, bucket: str) -> None:
-    """Increment ``bucket`` ('shape' | 'wire_cap') for (feed, group) in ``tally``,
-    defaulting a fresh {'shape': 0, 'wire_cap': 0} row on first hit."""
+    """Increment ``bucket`` ('shape' | 'wire_cap' | 'suffix_drop' | 'suffix_demote')
+    for (feed, group) in ``tally``, defaulting a fresh {'shape': 0, 'wire_cap': 0}
+    row on first hit (a #2371 suffix bucket is added to the row on demand)."""
     counts = tally.setdefault((feed, group), {"shape": 0, "wire_cap": 0})
-    counts[bucket] += 1
+    counts[bucket] = counts.get(bucket, 0) + 1
 
 
 def _dnsbl_within_wire_caps(host: str) -> bool:
@@ -4614,6 +4617,22 @@ def tld_wildcard_classify(
     if domain == registrable:
         return DNSBL_CLASS_ZONE, domain
     return DNSBL_CLASS_DATA, domain
+
+
+def _dnsbl_suffix_feed_policy(name: str, rules: PslRules, private_policy: str, icann_policy: str) -> str | None:
+    """issue #2371: the feed-at-suffix policy governing ``name``, or ``None``
+    when ``name`` is not exactly its own winning public suffix (normal
+    handling). Section is PRIVATE iff the winning rule's ``private_active`` is
+    True, else ICANN. O(name labels) via the already-indexed
+    ``resolve_public_suffix`` -- no per-entry scan over the shipped ruleset.
+    """
+    try:
+        resolution = resolve_public_suffix(name, rules)
+    except ValueError:
+        return None
+    if name != resolution.public_suffix:
+        return None
+    return private_policy if resolution.private_active else icann_policy
 
 
 # --------------------------------------------------------------------------- #
@@ -5221,7 +5240,10 @@ def build(
     ADR-48 (issue #789): every domain target a normalise-fail rejects (permit path,
     plain path, both parse_abp() call sites) and the reconcile() wire-cap fold-drop
     are tallied into ``BuildResult.rejects`` (bucket 'shape' | 'wire_cap', keyed
-    (feed, group)) -- accounting only, no gate DECISION changes.
+    (feed, group)) -- accounting only, no gate DECISION changes. issue #2371 adds a
+    real gate: a FEED entry AT its winning public suffix is dropped ('ignore',
+    tallied 'suffix_drop') or a wildcard ZONE anchor demoted to exact DATA ('apex',
+    tallied 'suffix_demote'); USER provenance is exempt in every state.
     """
     tld_wildcard_blacklist = list(config.get("tld_wildcard_blacklist", []))
     tld_wildcard_exclusion = list(config.get("tld_wildcard_exclusion", []))
@@ -5235,6 +5257,12 @@ def build(
     if not isinstance(psl_rules, PslRules):
         raise ValueError("psl_rules must be parsed PslRules")
     psl_classification_rules = psl_rules if bool(config.get("psl_wildcard_enabled", True)) else PslRules()
+    # issue #2371: feed-at-suffix policy, keyed off the RAW psl_rules (never the
+    # wildcard-gated psl_classification_rules) -- ABP zones exist independently
+    # of Wildcard Blocking (#1255), so the policy must apply even when it's OFF.
+    psl_feed_private_policy = str(config.get("psl_feed_private_policy", "honor"))
+    psl_feed_icann_policy = str(config.get("psl_feed_icann_policy", "honor"))
+    psl_feed_policy_active = psl_feed_private_policy != "honor" or psl_feed_icann_policy != "honor"
 
     data_db: dict[str, dict[str, Any]] = {}
     zone_db: dict[str, dict[str, Any]] = {}
@@ -5396,6 +5424,15 @@ def build(
             # Only BLOCK is produced by the lite path (ABP-ready seam; module header).
             if entry.kind != DNSBL_KIND_BLOCK:
                 continue
+            # issue #2371: FEED entry AT a suffix boundary, state 'ignore' -> drop
+            # (tallied). 'apex'/'honor' need no plain-path change: an exact apex
+            # DATA block is already today's outcome (#1541 never wildcards a
+            # plain suffix entry).
+            if provenance == RULE_PROV_FEED and psl_feed_policy_active:
+                policy = _dnsbl_suffix_feed_policy(domain, psl_rules, psl_feed_private_policy, psl_feed_icann_policy)
+                if policy == "ignore":
+                    _tally_reject(rejects, feed, group, "suffix_drop")
+                    continue
             idx = index_for(feed, group)
             cls, key = tld_wildcard_classify(
                 domain,
@@ -5421,11 +5458,24 @@ def build(
         result = reconcile(abp_rules, {}, exclusion, tally=rejects)
         important_rules = important_rules or result.important_rules
 
-        # Domain blocks -> dataDB/zoneDB (carry band + $important).
+        # Domain blocks -> dataDB/zoneDB (carry band + $important). issue #2371:
+        # a FEED rule AT a suffix boundary is dropped ('ignore') or demoted from
+        # ZONE to DATA at the SAME key ('apex', band/important/log preserved) --
+        # ABP ALLOW rules, irreducible regex, and reduced-allow domains never
+        # reach this loop, so policy governs BLOCK emission only.
         for b in result.block_domains:
+            cls = b.cls
+            if b.provenance == RULE_PROV_FEED and psl_feed_policy_active:
+                policy = _dnsbl_suffix_feed_policy(b.key, psl_rules, psl_feed_private_policy, psl_feed_icann_policy)
+                if policy == "ignore":
+                    _tally_reject(rejects, b.feed or "DNSBL", b.group or "DNSBL", "suffix_drop")
+                    continue
+                if policy == "apex" and cls == DNSBL_CLASS_ZONE:
+                    _tally_reject(rejects, b.feed or "DNSBL", b.group or "DNSBL", "suffix_demote")
+                    cls = DNSBL_CLASS_DATA
             idx = index_for(b.feed or "DNSBL", b.group or "DNSBL")
             payload = {"log": b.log or "1", "index": idx, "important": b.important, "band": b.band}
-            if b.cls == DNSBL_CLASS_ZONE:
+            if cls == DNSBL_CLASS_ZONE:
                 zone_db[b.key] = payload
             else:
                 data_db[b.key] = payload
@@ -5705,19 +5755,28 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
     file (``pfb["pfb_py_psl"]``)
     gated by ``pfb["python_tld_wildcard"]`` or TLD-Allow, mirroring
     ``pfb["pfb_py_hsts"]``/``pfb["python_hsts"]``. A manifest ``config.tld_master`` key (a stale pre-#1255
-    shape) is ignored entirely. With either gate ON, a missing/corrupt authority
-    raises (fail-closed, no silent empty rule set); with both OFF it is never
-    opened.
+    shape) is ignored entirely. issue #2371 adds a THIRD gate: either
+    ``psl_feed_private_policy`` or ``psl_feed_icann_policy`` != "honor" also
+    requires the authority (ABP zones exist independently of Wildcard
+    Blocking, #1255). With any gate ON, a missing/corrupt authority raises
+    (fail-closed, no silent empty rule set); with all OFF it is never opened.
     ``tld_wildcard_blacklist`` / ``tld_wildcard_exclusion`` / ``user_whitelist`` /
     ``user_unlock`` are passed through as lists. Missing keys
     within the required ``config`` object default empty.
     """
     config = manifest.get("config", {})
 
+    private_policy = str(pfb.get("psl_feed_private_policy", "honor"))
+    icann_policy = str(pfb.get("psl_feed_icann_policy", "honor"))
     psl_path = pfb.get("pfb_py_psl", "")
     psl_rules = _load_psl_authority(
         psl_path,
-        enabled=bool(pfb.get("python_tld_wildcard", False) or pfb.get("tld_allow", False)),
+        enabled=bool(
+            pfb.get("python_tld_wildcard", False)
+            or pfb.get("tld_allow", False)
+            or private_policy != "honor"
+            or icann_policy != "honor"
+        ),
     )
 
     # ADR-07: the static-cap flag reaches build() via the ini-derived pfb setting
@@ -5730,6 +5789,8 @@ def _dnsbl_config_from_manifest(manifest: dict[str, Any], base_dir: str) -> dict
         "psl_rules": psl_rules,
         "psl_wildcard_enabled": bool(pfb.get("python_tld_wildcard", False)),
         "psl_include_private": bool(pfb.get("psl_include_private", True)),
+        "psl_feed_private_policy": private_policy,
+        "psl_feed_icann_policy": icann_policy,
         "tld_wildcard_blacklist": list(config.get("tld_wildcard_blacklist", [])),
         "tld_wildcard_exclusion": list(config.get("tld_wildcard_exclusion", [])),
         "user_whitelist": list(config.get("user_whitelist", [])),
@@ -5835,20 +5896,24 @@ def dnsbl_emit_count(count_path: str, count: int) -> bool:
 
 def dnsbl_emit_reject_stats(stats_path: str, rejects: RejectTally) -> bool:
     """Write the ADR-48 (issue #789) per-entry reject tally to ``pfb_py_reject_stats``
-    as a JSON array of ``{"feed", "group", "shape", "wire_cap"}`` rows, one per
-    (feed, group) with a NONZERO bucket -- PHP reads it after a DNSBL run and emits
-    the canonical ``stage=entries`` line per nonzero bucket (Python never logs the
-    line itself; sinks stay PHP-only). An empty ``rejects`` still writes ``"[]"`` so
-    PHP can tell "ran, zero rejects" from "no artifact" (fresh boot / an old python
-    module that predates this file). Atomic temp + ``os.replace`` (mirrors
-    ``_reload_write_applied``): a partial write can never leave PHP reading a
-    truncated/corrupt artifact. Returns True on success.
+    as a JSON array of ``{"feed", "group", "shape", "wire_cap"}`` rows (issue #2371
+    adds ``"suffix_drop"``/``"suffix_demote"``, present only on a row that actually
+    tallied one), one per (feed, group) with a NONZERO bucket -- PHP reads it after a
+    DNSBL run and emits the canonical ``stage=entries`` line per nonzero bucket
+    (Python never logs the line itself; sinks stay PHP-only). An empty ``rejects``
+    still writes ``"[]"`` so PHP can tell "ran, zero rejects" from "no artifact"
+    (fresh boot / an old python module that predates this file). Atomic temp +
+    ``os.replace`` (mirrors ``_reload_write_applied``): a partial write can never
+    leave PHP reading a truncated/corrupt artifact. Returns True on success.
     """
-    entries = [
-        {"feed": feed, "group": group, "shape": counts["shape"], "wire_cap": counts["wire_cap"]}
-        for (feed, group), counts in sorted(rejects.items())
-        if counts["shape"] or counts["wire_cap"]
-    ]
+    entries = []
+    for (feed, group), counts in sorted(rejects.items()):
+        row = {"feed": feed, "group": group, "shape": counts["shape"], "wire_cap": counts["wire_cap"]}
+        for bucket in ("suffix_drop", "suffix_demote"):
+            if counts.get(bucket):
+                row[bucket] = counts[bucket]
+        if row["shape"] or row["wire_cap"] or "suffix_drop" in row or "suffix_demote" in row:
+            entries.append(row)
     tmp = "{}.tmp".format(stats_path)
     try:
         with open(tmp, "w", encoding="utf-8") as fh:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1529,10 +1529,10 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["tld_allow_list"] = []
     pfb["psl_include_private"] = True
     pfb["psl_allow_private"] = False
-    # issue #2371: feed-at-suffix PSL policy, per PSL section. Default "honor" (today's
-    # pre-#2371 behaviour) -- the ini load below recomputes this from the loaded value,
-    # validated against {"ignore", "apex", "honor"}, else "honor". No consumer yet
-    # (Step 2 of #2371 adds enforcement).
+    # issue #2371: feed-at-suffix PSL policy, per PSL section. Default "honor" -- the
+    # ini load below recomputes this from the loaded value, validated against
+    # {"ignore", "apex", "honor"}, else "honor"; build() enforces it on FEED entries
+    # at suffix boundaries.
     pfb["psl_feed_private_policy"] = "honor"
     pfb["psl_feed_icann_policy"] = "honor"
     pfb["python_tld_seg"] = 0
@@ -4073,7 +4073,7 @@ class Snapshot:
     psl_allow_private: bool = False
     # issue #2371: feed-at-suffix PSL policy, per PSL section. "honor" default keeps every
     # hand-built legacy Snapshot fixture (this file and its tests) decision-identical
-    # without passing these explicitly. No consumer yet (Step 2 of #2371).
+    # without passing these explicitly; build() reads them from the manifest config.
     psl_feed_private_policy: str = "honor"
     psl_feed_icann_policy: str = "honor"
     # issue #1074: identity of this snapshot for decisionDB memo stamping; auto-assigned,
@@ -5424,10 +5424,14 @@ def build(
             # Only BLOCK is produced by the lite path (ABP-ready seam; module header).
             if entry.kind != DNSBL_KIND_BLOCK:
                 continue
-            # issue #2371: FEED entry AT a suffix boundary, state 'ignore' -> drop
-            # (tallied). 'apex'/'honor' need no plain-path change: an exact apex
-            # DATA block is already today's outcome (#1541 never wildcards a
-            # plain suffix entry).
+            # issue #2371: FEED entry AT a suffix boundary, judged against the
+            # FULL PSL (the policy's view is independent of the PRIVATE
+            # recognition toggle): 'ignore' -> drop (tallied); 'apex' -> any
+            # ZONE the classifier yields is demoted back to an exact apex DATA
+            # block (tallied) -- with PRIVATE recognition OFF the ICANN-only
+            # classifier sees a PRIVATE apex as a registrable domain and would
+            # otherwise blanket the suffix.
+            policy = None
             if provenance == RULE_PROV_FEED and psl_feed_policy_active:
                 policy = _dnsbl_suffix_feed_policy(domain, psl_rules, psl_feed_private_policy, psl_feed_icann_policy)
                 if policy == "ignore":
@@ -5444,7 +5448,10 @@ def build(
             # Non-ABP block: band 1 (downloaded feed) or 5 (USER Custom_List); never
             # $important (the plain path has no $options grammar).
             payload = {"log": log_flag, "index": idx, "important": False, "band": block_band}
-            if cls == DNSBL_CLASS_ZONE:
+            if cls == DNSBL_CLASS_ZONE and policy == "apex":
+                _tally_reject(rejects, feed, group, "suffix_demote")
+                data_db[domain] = payload
+            elif cls == DNSBL_CLASS_ZONE:
                 zone_db[key] = payload  # last-wins (dict; ADR-06 SS2 attribution change)
             else:
                 data_db[key] = payload

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -780,6 +780,8 @@ def _build_swap_snapshot() -> Snapshot | None:
         tld_allow_roots=_selected_tld_roots(pfb.get("tld_allow_list", ())),
         psl_include_private=bool(pfb.get("psl_include_private", True)),
         psl_allow_private=bool(pfb.get("psl_allow_private", False)),
+        psl_feed_private_policy=str(pfb.get("psl_feed_private_policy", "honor")),
+        psl_feed_icann_policy=str(pfb.get("psl_feed_icann_policy", "honor")),
     )
 
 
@@ -1527,6 +1529,12 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["tld_allow_list"] = []
     pfb["psl_include_private"] = True
     pfb["psl_allow_private"] = False
+    # issue #2371: feed-at-suffix PSL policy, per PSL section. Default "honor" (today's
+    # pre-#2371 behaviour) -- the ini load below recomputes this from the loaded value,
+    # validated against {"ignore", "apex", "honor"}, else "honor". No consumer yet
+    # (Step 2 of #2371 adds enforcement).
+    pfb["psl_feed_private_policy"] = "honor"
+    pfb["psl_feed_icann_policy"] = "honor"
     pfb["python_tld_seg"] = 0
     # issue #1255: DNSBL Wildcard Blocking (TLD) -- a DIFFERENT feature from
     # tld_allow ("TLD Allow") above. Gates the public-suffix oracle exactly like
@@ -1765,6 +1773,21 @@ def init_standard(id: int, env: module_env) -> bool:
                 pfb["psl_include_private"] = config.getboolean("MAIN", "psl_include_private")
             if config.has_option("MAIN", "psl_allow_private"):
                 pfb["psl_allow_private"] = config.getboolean("MAIN", "psl_allow_private")
+            # issue #2371: feed-at-suffix PSL policy. Validate against the recognised
+            # vocabulary; a missing option, an empty value, or an unrecognised token all
+            # keep the "honor" default set above (mirrors the idn_mode read above).
+            if config.has_option("MAIN", "psl_feed_private_policy"):
+                _raw_feed_private_policy = config.get("MAIN", "psl_feed_private_policy").strip().lower()
+                if _raw_feed_private_policy in ("ignore", "apex", "honor"):
+                    pfb["psl_feed_private_policy"] = _raw_feed_private_policy
+                else:
+                    pfb["psl_feed_private_policy"] = "honor"
+            if config.has_option("MAIN", "psl_feed_icann_policy"):
+                _raw_feed_icann_policy = config.get("MAIN", "psl_feed_icann_policy").strip().lower()
+                if _raw_feed_icann_policy in ("ignore", "apex", "honor"):
+                    pfb["psl_feed_icann_policy"] = _raw_feed_icann_policy
+                else:
+                    pfb["psl_feed_icann_policy"] = "honor"
             if config.has_option("MAIN", "dnsbl_ipv4"):
                 pfb["dnsbl_ipv4"] = config.get("MAIN", "dnsbl_ipv4")
             if config.has_option("MAIN", "dnsbl_ipv6"):
@@ -2052,6 +2075,8 @@ def init_standard(id: int, env: module_env) -> bool:
             tld_allow_roots=_selected_tld_roots(pfb.get("tld_allow_list", ())),
             psl_include_private=bool(pfb.get("psl_include_private", True)),
             psl_allow_private=bool(pfb.get("psl_allow_private", False)),
+            psl_feed_private_policy=str(pfb.get("psl_feed_private_policy", "honor")),
+            psl_feed_icann_policy=str(pfb.get("psl_feed_icann_policy", "honor")),
         )
 
     rebuild_and_swap(_init_build_snapshot, emit_counts=False)
@@ -4045,6 +4070,11 @@ class Snapshot:
     tld_allow_roots: tuple[str, ...] | None = None
     psl_include_private: bool = True
     psl_allow_private: bool = False
+    # issue #2371: feed-at-suffix PSL policy, per PSL section. "honor" default keeps every
+    # hand-built legacy Snapshot fixture (this file and its tests) decision-identical
+    # without passing these explicitly. No consumer yet (Step 2 of #2371).
+    psl_feed_private_policy: str = "honor"
+    psl_feed_icann_policy: str = "honor"
     # issue #1074: identity of this snapshot for decisionDB memo stamping; auto-assigned,
     # never passed by builders.
     gen: int = field(default_factory=lambda: next(_snapshot_gen))
@@ -4067,6 +4097,8 @@ class Snapshot:
             "tld_allow_roots": self.tld_allow_roots or (),
             "psl_include_private": self.psl_include_private,
             "psl_allow_private": self.psl_allow_private,
+            "psl_feed_private_policy": self.psl_feed_private_policy,
+            "psl_feed_icann_policy": self.psl_feed_icann_policy,
         }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -94,6 +94,37 @@ function pfb_install_registry_writeback(
 	$flush('[pfBlockerNG] Save installation settings');
 }
 
+/**
+ * issue #2371: apply the fresh-install feed-at-suffix PSL policy seed. $fresh is
+ * pfb_psl_feed_policy_is_fresh_install()'s PRE-migration read, captured by the
+ * installer before pfb_run_migrations()/pfb_registry_pass() run; this seam itself
+ * must be called by the installer AFTER pfb_install_registry_writeback() -- see
+ * pfb_psl_feed_policy_is_fresh_install()'s docblock for why (folding the seed into
+ * pfb_migration_registry() would flip pfb_registry_pass()'s NEWCFG/OLDCFG mode for
+ * every OTHER registered dnsbl/* field once the seeded keys make the section
+ * non-empty). A no-op (no write, no flush) when $fresh is FALSE -- an existing
+ * install's absent keys stay absent and read Honor via the registry default.
+ *
+ * DI seam (mirrors pfb_install_registry_writeback() above) so tests exercise this
+ * EXACT function rather than a hand-copied reimplementation: a mutation to this body
+ * is caught by both the installer's real call site (source-scan, see
+ * InstallPrePassWriteOrderTest.php's pattern) and a direct DI-based unit test.
+ */
+function pfb_install_psl_feed_policy_seed(
+	bool $fresh,
+	?callable $write = NULL,
+	?callable $flush = NULL
+): void {
+	if (!$fresh) {
+		return;
+	}
+	$write ??= 'PfbConfig::writeSystem';
+	$flush ??= 'write_config';
+	$write('dnsbl/pfb_psl_feed_private_policy', 'apex');
+	$write('dnsbl/pfb_psl_feed_icann_policy', 'apex');
+	$flush('pfBlockerNG: seeded feed-at-suffix PSL policy defaults for fresh install (issue #2371)');
+}
+
 function pfb_install_probe_cleanup(?callable $purge = NULL): void {
 	$purge ??= 'pfb_purge_probe_bodies';
 	$purge();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2438,6 +2438,13 @@ function pfb_dnsbl_reload_fingerprint(array $pfb): string {
 	$allow = $allow instanceof PfbToggle ? $allow->value : (is_bool($allow) ? ($allow ? 'on' : 'off') : (string) $allow);
 	$paths[] = "\0pfb-psl-policy:include={$include}";
 	$paths[] = "\0pfb-psl-policy:allow={$allow}";
+	// issue #2371: salt the feed-at-suffix PSL policy fields too, same sentinel family.
+	$feed_private_policy = $pfb['dnsbl_psl_feed_private_policy'] ?? PfbFeedSuffixPolicy::Honor;
+	$feed_icann_policy = $pfb['dnsbl_psl_feed_icann_policy'] ?? PfbFeedSuffixPolicy::Honor;
+	$feed_private_policy = $feed_private_policy instanceof PfbFeedSuffixPolicy ? $feed_private_policy->value : (string) $feed_private_policy;
+	$feed_icann_policy = $feed_icann_policy instanceof PfbFeedSuffixPolicy ? $feed_icann_policy->value : (string) $feed_icann_policy;
+	$paths[] = "\0pfb-psl-policy:feed_private={$feed_private_policy}";
+	$paths[] = "\0pfb-psl-policy:feed_icann={$feed_icann_policy}";
 	return pfb_dnsbl_loaded_fingerprint($paths);
 }
 
@@ -3274,6 +3281,8 @@ function pfb_global() {
 	$pfb['dnsbl_tld_allow']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['tld_allow'] ?? '');			// DNSBL Resolver TLD Allow option
 	$pfb['dnsbl_psl_include_private'] = PfbConfig::read('dnsbl/pfb_psl_include_private');			// PSL PRIVATE recognition (default On)
 	$pfb['dnsbl_psl_allow_private'] = PfbConfig::read('dnsbl/pfb_psl_allow_private');			// PSL PRIVATE TLD-Allow precision (default Off)
+	$pfb['dnsbl_psl_feed_private_policy'] = PfbConfig::read('dnsbl/pfb_psl_feed_private_policy');	// issue #2371: feed-at-suffix PSL PRIVATE policy (PfbFeedSuffixPolicy enum; absent -> Honor)
+	$pfb['dnsbl_psl_feed_icann_policy'] = PfbConfig::read('dnsbl/pfb_psl_feed_icann_policy');		// issue #2371: feed-at-suffix PSL ICANN policy (PfbFeedSuffixPolicy enum; absent -> Honor)
 	$pfb['dnsbl_py_nolog']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_py_nolog'] ?? '');			// DNSBL Resolver python - Log events via DNSBL Webserver vs python
 	$pfb['dnsbl_noaaaa']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_noaaaa'] ?? '');			// DNSBL Resolver python no AAAA
 	$pfb['dnsbl_noaaaa_list']=$pfb['dnsblconfig']['pfb_noaaaa_list'] ?? '';	// DNSBL Resolver python no AAAA list
@@ -10065,6 +10074,8 @@ function pfb_unbound_python_ini($mode, ?string $now = NULL): string {
 	$python_tld_wildcard = !empty($dnsbl_tld_wildcard) ? 'on' : 'off';
 	$psl_include_private = ($pfb['dnsbl_psl_include_private'] === PfbToggle::On) ? 'on' : 'off';
 	$psl_allow_private = ($pfb['dnsbl_psl_allow_private'] === PfbToggle::On) ? 'on' : 'off';
+	$psl_feed_private_policy = $pfb['dnsbl_psl_feed_private_policy']->toStored();
+	$psl_feed_icann_policy = $pfb['dnsbl_psl_feed_icann_policy']->toStored();
 
 	$idn_mode = $pfb['dnsbl_idn']->toStored();
 	$python_idn = ($pfb['dnsbl_idn'] === PfbIdnMode::All) ? 'on' : 'off';
@@ -10109,6 +10120,8 @@ python_hsts	= {$python_hsts}
 python_tld_wildcard	= {$python_tld_wildcard}
 psl_include_private	= {$psl_include_private}
 psl_allow_private	= {$psl_allow_private}
+psl_feed_private_policy	= {$psl_feed_private_policy}
+psl_feed_icann_policy	= {$psl_feed_icann_policy}
 python_idn	= {$python_idn}
 idn_mode	= {$idn_mode}
 python_idn_block_malicious	= {$python_idn_block_malicious}
@@ -12430,6 +12443,39 @@ function pfb_control_legacy_seed($dconfig) {
 	}
 	$dconfig['pfb_control_legacy_seeded'] = 'on';
 	return $dconfig;
+}
+
+
+// issue #2371: fresh-install detector for the feed-at-suffix PSL policy fields
+// (dnsbl/pfb_psl_feed_private_policy, dnsbl/pfb_psl_feed_icann_policy). Same
+// empty($dconfig)-on-the-operator-view idiom as pfb_schedule_migrate's $is_fresh, but
+// DELIBERATELY NOT an entry in pfb_migration_registry() and NOT called from
+// pfb_run_migrations(): every pfb_migration_registry() entry's write lands BEFORE
+// pfb_registry_pass() re-reads the section for its own per-section NEWCFG/OLDCFG mode
+// decision (issue #1921) -- seeding new keys into an otherwise-EMPTY dnsbl section
+// there would flip that section's mode to OLDCFG for every OTHER registered dnsbl/*
+// field before the pass ever sees it, wrongly applying an ABSENT-grandfather map meant
+// only for a genuine upgrade. Confirmed against dnsbl/pfb_dnsbl_lenient (grandfather
+// ABSENT -> 'on') via an executed probe: the same latent interaction already reaches
+// gen/pfb_alias_delta_mode through pfb_schedule_migrate (#2308) today, empirically
+// observed to yield 'replace' instead of the intended fresh-install 'auto'. #2371 does
+// not fix that pre-existing interaction; it avoids adding a second instance of it by
+// keeping this seed OUTSIDE pfb_migration_registry() entirely.
+//
+// pfblockerng_install.inc calls this on the section read BEFORE pfb_run_migrations()/
+// pfb_registry_pass() run, then -- only when it returns TRUE -- applies the seed via
+// PfbConfig::writeSystem() AFTER pfb_install_registry_writeback() has already persisted
+// the registry pass's own (unrelated) '' defaults for these two fields.
+//
+// $dconfig is the DNSBL-settings 'config/0' node, read pre-mutation. Returns TRUE iff
+// the section is genuinely fresh (empty under the operator view -- issues
+// #1770/#1771/#1775), else FALSE.
+function pfb_psl_feed_policy_is_fresh_install($dconfig) {
+
+	if (!is_array($dconfig)) {
+		return FALSE;
+	}
+	return empty(pfb_gconfig_operator_view($dconfig));
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1222,7 +1222,8 @@ function pfb_archive_unsafe_member(?array $names): ?string {
 
 // ADR-48 (issue #789): reads the Python-emitted per-entry reject tally
 // artifact (pfb_py_reject_stats.json -- build()'s normalise() domain-shape rejects
-// and #753 wire-cap rejects, bucketed shape/wire_cap, per feed/group) and emits
+// and #753 wire-cap rejects, bucketed shape/wire_cap, per feed/group; issue #2371
+// adds suffix_drop/suffix_demote) and emits
 // ONE canonical stage=entries line per (feed, nonzero bucket) via pfb_validate_log().
 // Missing, unreadable, corrupt, or non-array JSON is a silent no-op -- a fresh boot
 // or an old python module that predates the artifact, never an error. Python only
@@ -1242,7 +1243,7 @@ function pfb_emit_entry_reject_stats(string $path): void {
 			continue;
 		}
 		$feed = (string) $entry['feed'];
-		foreach (array('shape', 'wire_cap') as $bucket) {
+		foreach (array('shape', 'wire_cap', 'suffix_drop', 'suffix_demote') as $bucket) {
 			$count = (isset($entry[$bucket]) && is_scalar($entry[$bucket])) ? (int) $entry[$bucket] : 0;
 			if ($count > 0) {
 				pfb_validate_log($feed, 'entries', $bucket, (string) $count);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -154,7 +154,7 @@ enum PfbIdnMode: string implements PfbStoredEnum
 // pre-#2371 behaviour). Absent, present '', and any unknown/junk stored token all
 // read as Honor -- fail-safe, same "never silently drop or demote" principle as
 // PfbToggle's Off/PfbIdnMode's Off fallback. Step 1 of #2371 registers and plumbs
-// this enum only; no enforcement consumer reads it yet.
+// this enum only; pfb_unbound.py build() enforces the stored policy.
 enum PfbFeedSuffixPolicy: string implements PfbStoredEnum
 {
 	use PfbStoredEnumAdapter;
@@ -1326,7 +1326,7 @@ function pfb_cfg_registry(): array
 		// never via this registry default; a fresh install is instead seeded 'apex' by
 		// pfb_psl_feed_policy_is_fresh_install() + pfblockerng_install.inc's post-registry-
 		// pass write (owner decision 2026-08-14: apex/apex for new installs, honor/honor
-		// grandfathered for existing ones). No enforcement consumer yet (#2371 Step 2).
+		// grandfathered for existing ones). pfb_unbound.py build() enforces the policy.
 		'dnsbl/pfb_psl_feed_private_policy' => [
 			'default'        => '',
 			'read_adapter'   => 'pfb_cfg_feed_suffix_policy_read',

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -148,6 +148,29 @@ enum PfbIdnMode: string implements PfbStoredEnum
 	}
 }
 
+// PfbFeedSuffixPolicy — issue #2371: per-PSL-section policy governing what a
+// FEED-provenance rule may do when its name resolves to a public suffix of that
+// section. Ignore (drop), Apex (demote to an exact apex block), Honor (today's
+// pre-#2371 behaviour). Absent, present '', and any unknown/junk stored token all
+// read as Honor -- fail-safe, same "never silently drop or demote" principle as
+// PfbToggle's Off/PfbIdnMode's Off fallback. Step 1 of #2371 registers and plumbs
+// this enum only; no enforcement consumer reads it yet.
+enum PfbFeedSuffixPolicy: string implements PfbStoredEnum
+{
+	use PfbStoredEnumAdapter;
+
+	case Ignore = 'ignore';
+	case Apex   = 'apex';
+	case Honor  = 'honor';
+
+	// Parse-fallback (unknown/non-scalar/'' -> Honor). NOT the absent default (the
+	// registry's, also '' -- both paths land on Honor via this same fallback).
+	public static function default(): static
+	{
+		return self::Honor;
+	}
+}
+
 // PfbAliasDeltaMode — ADR-40 alias-table apply mechanism selector.
 //   Auto    ('auto')    — default; delta for small churn (< ~5%), full replace for
 //                         initial load / boot / large churn.
@@ -659,6 +682,19 @@ function pfb_cfg_idn_mode_write(PfbIdnMode|string $mode): string
 {
 	$mode = $mode instanceof PfbIdnMode ? $mode : PfbIdnMode::fromStored($mode);
 	return $mode->toStored();
+}
+
+/** Read a PfbFeedSuffixPolicy from a raw stored value (absent/''/unknown -> Honor). */
+function pfb_cfg_feed_suffix_policy_read(mixed $stored): PfbFeedSuffixPolicy
+{
+	return PfbFeedSuffixPolicy::fromStored($stored);
+}
+
+/** Write a PfbFeedSuffixPolicy (enum or legacy string) back to its stored string. */
+function pfb_cfg_feed_suffix_policy_write(PfbFeedSuffixPolicy|string $policy): string
+{
+	$policy = $policy instanceof PfbFeedSuffixPolicy ? $policy : PfbFeedSuffixPolicy::fromStored($policy);
+	return $policy->toStored();
 }
 
 /** Read a PfbTop1mSource from a raw stored value (legacy 'alexa' -> Tranco, 'domcop' -> OpenPageRank). */
@@ -1282,6 +1318,29 @@ function pfb_cfg_registry(): array
 			'read_adapter'   => 'pfb_cfg_toggle_read',
 			'write_adapter'  => 'pfb_cfg_toggle_write',
 			'no_grandfather' => 'new PSL PRIVATE TLD-Allow policy; absent uses the default OFF',
+		],
+
+		// issue #2371: per-PSL-section policy for FEED-provenance rules landing at a
+		// public-suffix boundary (Ignore/Apex/Honor). Default '' so an absent key reads
+		// Honor -- today's pre-#2371 behaviour -- via the PfbFeedSuffixPolicy adapter,
+		// never via this registry default; a fresh install is instead seeded 'apex' by
+		// pfb_psl_feed_policy_is_fresh_install() + pfblockerng_install.inc's post-registry-
+		// pass write (owner decision 2026-08-14: apex/apex for new installs, honor/honor
+		// grandfathered for existing ones). No enforcement consumer yet (#2371 Step 2).
+		'dnsbl/pfb_psl_feed_private_policy' => [
+			'default'        => '',
+			'read_adapter'   => 'pfb_cfg_feed_suffix_policy_read',
+			'write_adapter'  => 'pfb_cfg_feed_suffix_policy_write',
+			'no_grandfather' => 'new FEED-suffix policy (#2371); absent/empty reads Honor (current pre-#2371 behaviour) on every upgrade -- the fresh-install apex/apex seed is a one-time install-time write (pfb_psl_feed_policy_is_fresh_install()), deliberately NOT a registry grandfather map, since issue #1921\'s ABSENT map is OLDCFG-only and would wrongly also apply to a genuinely-fresh install',
+		],
+
+		// issue #2371: ICANN-section sibling of pfb_psl_feed_private_policy above --
+		// same vocabulary, same default/seed/grandfather reasoning.
+		'dnsbl/pfb_psl_feed_icann_policy' => [
+			'default'        => '',
+			'read_adapter'   => 'pfb_cfg_feed_suffix_policy_read',
+			'write_adapter'  => 'pfb_cfg_feed_suffix_policy_write',
+			'no_grandfather' => 'new FEED-suffix policy (#2371); absent/empty reads Honor (current pre-#2371 behaviour) on every upgrade -- the fresh-install apex/apex seed is a one-time install-time write (pfb_psl_feed_policy_is_fresh_install()), deliberately NOT a registry grandfather map, since issue #1921\'s ABSENT map is OLDCFG-only and would wrongly also apply to a genuinely-fresh install',
 		],
 
 		// issue #1921: TLD Allow sort order for the python list emit. Default ''.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -26,6 +26,14 @@ require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 global $g, $pfb;
 pfb_global();
 
+// issue #2371: capture the DNSBL-settings section's fresh-install-ness BEFORE any
+// migration or the registry pass runs -- see pfb_psl_feed_policy_is_fresh_install()'s
+// docblock (pfblockerng.inc) for why this must be read pre-mutation and applied only
+// after pfb_install_registry_writeback() below.
+$pfb_psl_feed_policy_fresh_install = pfb_psl_feed_policy_is_fresh_install(
+	PfbConfig::readSection('installedpackages/pfblockerngdnsblsettings/config/0')
+);
+
 $pfb_installed_family = pfb_install_settings_family_capture_restore();
 pfb_global();
 // Set 'Install flag' to skip sync process during installations.
@@ -934,6 +942,18 @@ foreach (PFB_SECTIONS as $pfb_registry_section) {
 pfb_install_registry_writeback($pfb_registry_sections);
 unset($pfb_registry_sections, $pfb_registry_section);
 update_status(" done.\n");
+
+// issue #2371: apply the fresh-install feed-at-suffix PSL policy seed captured at the
+// top of this file, now that the registry pass has already persisted its own (unrelated)
+// '' defaults for these two fields -- see pfb_psl_feed_policy_is_fresh_install()'s
+// docblock (pfblockerng.inc) for why this runs AFTER pfb_install_registry_writeback()
+// rather than as a pfb_migration_registry() entry.
+if ($pfb_psl_feed_policy_fresh_install) {
+	PfbConfig::writeSystem('dnsbl/pfb_psl_feed_private_policy', 'apex');
+	PfbConfig::writeSystem('dnsbl/pfb_psl_feed_icann_policy', 'apex');
+	write_config('pfBlockerNG: seeded feed-at-suffix PSL policy defaults for fresh install (issue #2371)');
+}
+unset($pfb_psl_feed_policy_fresh_install);
 
 unset($g['pfblockerng_install']);	// Remove 'Install flag'
 update_status("Upgrading... done\n\nCustom commands completed ... ");

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -945,14 +945,10 @@ update_status(" done.\n");
 
 // issue #2371: apply the fresh-install feed-at-suffix PSL policy seed captured at the
 // top of this file, now that the registry pass has already persisted its own (unrelated)
-// '' defaults for these two fields -- see pfb_psl_feed_policy_is_fresh_install()'s
-// docblock (pfblockerng.inc) for why this runs AFTER pfb_install_registry_writeback()
-// rather than as a pfb_migration_registry() entry.
-if ($pfb_psl_feed_policy_fresh_install) {
-	PfbConfig::writeSystem('dnsbl/pfb_psl_feed_private_policy', 'apex');
-	PfbConfig::writeSystem('dnsbl/pfb_psl_feed_icann_policy', 'apex');
-	write_config('pfBlockerNG: seeded feed-at-suffix PSL policy defaults for fresh install (issue #2371)');
-}
+// '' defaults for these two fields -- see pfb_psl_feed_policy_is_fresh_install()'s and
+// pfb_install_psl_feed_policy_seed()'s docblocks (pfblockerng.inc) for why this runs
+// AFTER pfb_install_registry_writeback() rather than as a pfb_migration_registry() entry.
+pfb_install_psl_feed_policy_seed($pfb_psl_feed_policy_fresh_install);
 unset($pfb_psl_feed_policy_fresh_install);
 
 unset($g['pfblockerng_install']);	// Remove 'Install flag'

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -1152,7 +1152,7 @@ $psl_feed_policy_options = array(
 );
 $psl_feed_policy_help = '<ul>'
 	. '<li><strong>Ignore entirely</strong> - the feed entry is dropped (counted in the reject stats).</li>'
-	. '<li><strong>Block the suffix apex only</strong> - only the exact suffix name is blocked; every registrant under it stays reachable.</li>'
+	. '<li><strong>Block the suffix apex only</strong> - only the exact suffix name is blocked; this entry no longer affects names under the suffix (other list entries still apply).</li>'
 	. '<li><strong>Honor list rules</strong> - the list is honored as written, including an explicit ABP wildcard rule that may still blanket the suffix.</li>'
 	. '</ul>'
 	. 'A Custom List or a sovereign ABP list entry is never affected by this policy. Intentional whole-suffix blocking belongs in '

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -73,6 +73,11 @@ $pconfig['pfb_py_reply']	= PfbConfig::read('dnsbl/pfb_py_reply');
 $pconfig['pfb_hsts']		= PfbConfig::read('dnsbl/pfb_hsts');
 $pconfig['pfb_psl_include_private'] = PfbConfig::read('dnsbl/pfb_psl_include_private');
 $pconfig['pfb_psl_allow_private'] = PfbConfig::read('dnsbl/pfb_psl_allow_private');
+// issue #2371: feed-at-suffix policy selects (PfbFeedSuffixPolicy enum; absent -> Honor).
+// ->value gives the runtime option key the <select> options below carry (same idiom as
+// pfb_idn above).
+$pconfig['pfb_psl_feed_private_policy'] = PfbConfig::read('dnsbl/pfb_psl_feed_private_policy')->value;
+$pconfig['pfb_psl_feed_icann_policy'] = PfbConfig::read('dnsbl/pfb_psl_feed_icann_policy')->value;
 // ADR-08: IDN mode selector (Off | All-IDN | Confusable). PfbConfig::read() returns a
 // PfbIdnMode enum (legacy 'on' -> All; alpha-only 'all', legacy 'off', and '' -> Off);
 // enum value gives the runtime option key that the <select> options below carry.
@@ -829,6 +834,13 @@ if ($_POST) {
 			$pfb['dconfig']['tld_wildcard']		= pfb_filter($_POST['tld_wildcard'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$psl_include_private = pfb_filter($_POST['pfb_psl_include_private'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';
 			$psl_allow_private = pfb_filter($_POST['pfb_psl_allow_private'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl') ?: '';
+			// issue #2371: feed-at-suffix policy selects. PFB_FILTER_WORD only checks shape
+			// (word chars) -- the canonicalisation to the three-token vocabulary (anything
+			// else -> Honor) happens in PfbConfig::write()'s write_adapter
+			// (pfb_cfg_feed_suffix_policy_write -> PfbFeedSuffixPolicy::fromStored), same
+			// fail-safe principle as PfbToggle/PfbIdnMode's unknown-token fallback.
+			$psl_feed_private_policy = pfb_filter($_POST['pfb_psl_feed_private_policy'] ?? '', PFB_FILTER_WORD, 'dnsbl') ?: '';
+			$psl_feed_icann_policy = pfb_filter($_POST['pfb_psl_feed_icann_policy'] ?? '', PFB_FILTER_WORD, 'dnsbl') ?: '';
 			$pfb['dconfig']['pfb_control']		= pfb_filter($_POST['pfb_control'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['pfb_control_legacy']	= pfb_filter($_POST['pfb_control_legacy'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['pfb_dnsbl_nonat']	= pfb_filter($_POST['pfb_dnsbl_nonat'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
@@ -975,6 +987,8 @@ if ($_POST) {
 			PfbConfig::writeSection('installedpackages/pfblockerngdnsblsettings/config/0', $pfb['dconfig']);
 			PfbConfig::write('dnsbl/pfb_psl_include_private', $psl_include_private);
 			PfbConfig::write('dnsbl/pfb_psl_allow_private', $psl_allow_private);
+			PfbConfig::write('dnsbl/pfb_psl_feed_private_policy', $psl_feed_private_policy);
+			PfbConfig::write('dnsbl/pfb_psl_feed_icann_policy', $psl_feed_icann_policy);
 
 			// Save DoH/DoT/DoQ blocking fields via gateway (registered keys in pfblockerngsafesearch)
 			PfbConfig::write('ss/safesearch_doh', $_POST['safesearch_doh'] ?: 'Disable');
@@ -1125,6 +1139,40 @@ $section->addInput(new Form_Checkbox(
 	pfb_cfg_toggle_read($pconfig['tld_wildcard']) === PfbToggle::On,
 	'on'
 ))->setHelp($dnsbl_text);
+
+// issue #2371: feed-at-suffix policy selects. Feed-wide and independent of Wildcard
+// Blocking (and of each other) -- deliberately NOT behind a hideCheckbox() show/hide,
+// so placement here (near Wildcard Blocking, for topical proximity) never implies a
+// dependency on it. Applies only to Feed-provenance rows; a Custom List or a sovereign
+// ABP list entry is never affected by either select.
+$psl_feed_policy_options = array(
+	'ignore'	=> 'Ignore entirely',
+	'apex'		=> 'Block the suffix apex only',
+	'honor'		=> 'Honor list rules',
+);
+$psl_feed_policy_help = '<ul>'
+	. '<li><strong>Ignore entirely</strong> - the feed entry is dropped (counted in the reject stats).</li>'
+	. '<li><strong>Block the suffix apex only</strong> - only the exact suffix name is blocked; every registrant under it stays reachable.</li>'
+	. '<li><strong>Honor list rules</strong> - the list is honored as written, including an explicit ABP wildcard rule that may still blanket the suffix.</li>'
+	. '</ul>'
+	. 'A Custom List or a sovereign ABP list entry is never affected by this policy. Intentional whole-suffix blocking belongs in '
+	. '<strong>TLD Blacklist</strong> below (dotted entries supported).';
+
+$section->addInput(new Form_Select(
+	'pfb_psl_feed_private_policy',
+	gettext('Feed entries at shared-hosting suffixes (PSL PRIVATE)'),
+	$pconfig['pfb_psl_feed_private_policy'],
+	$psl_feed_policy_options
+))->setHelp('Applies only to a Feed entry named exactly at a PSL PRIVATE suffix (shared domains such as github.io -- not private DNS).'
+	. $psl_feed_policy_help);
+
+$section->addInput(new Form_Select(
+	'pfb_psl_feed_icann_policy',
+	gettext('Feed entries at public suffixes (ICANN)'),
+	$pconfig['pfb_psl_feed_icann_policy'],
+	$psl_feed_policy_options
+))->setHelp('Applies only to a Feed entry named exactly at an ICANN (public) suffix.'
+	. $psl_feed_policy_help);
 
 $section->addInput(new Form_Checkbox(
 	'pfb_psl_include_private',

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -604,6 +604,35 @@ final class CfgGatewayTest extends TestCase
 	}
 
 	/**
+	 * issue #2371: dnsbl/pfb_psl_feed_private_policy + dnsbl/pfb_psl_feed_icann_policy --
+	 * absent/''/unknown all read Honor (grandfather + fail-safe: an unrecognised stored
+	 * value must never throw or silently drop/demote a feed entry); every canonical
+	 * token round-trips through PfbConfig::write().
+	 */
+	public function testFeedSuffixPolicyDefaultsRoundTripsAndHostileInput(): void
+	{
+		$privatePath = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_private_policy';
+		$icannPath   = 'installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_icann_policy';
+
+		foreach (['dnsbl/pfb_psl_feed_private_policy' => $privatePath, 'dnsbl/pfb_psl_feed_icann_policy' => $icannPath] as $key => $path) {
+			$this->assertNull(config_get_path($path), "before: {$key} must be absent");
+			$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read($key), "{$key}: absent -> Honor");
+
+			foreach ([PfbFeedSuffixPolicy::Ignore, PfbFeedSuffixPolicy::Apex, PfbFeedSuffixPolicy::Honor] as $value) {
+				PfbConfig::write($key, $value);
+				$this->assertSame($value, PfbConfig::read($key), "{$key}: {$value->value} must round-trip");
+				$this->assertSame($value->value, config_get_path($path), "{$key}: stored token must be canonical '{$value->value}'");
+			}
+
+			// Hostile input: present '', legacy/junk, and case-mismatched tokens all read Honor.
+			foreach (['', 'suppress', 'IGNORE', 'Apex', ' apex', 'legacy-junk'] as $hostile) {
+				$this->seedConfig($path, $hostile);
+				$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read($key), "{$key}: stored '{$hostile}' must read Honor, never throw");
+			}
+		}
+	}
+
+	/**
 	 * issue #1907: dnsbl/pfb_cache, dnsbl/pfb_py_reply, dnsbl/pfb_hsts, ip/suppression --
 	 * same default-on shape as pfb_idn_block_malicious/pfb_keep above. Absent resolves
 	 * to On; present empty and legacy 'off' resolve to Off; present 'on' resolves to On.
@@ -1283,6 +1312,9 @@ final class CfgGatewayTest extends TestCase
 			'pfb_idn_escalate_suspicious',
 			'pfb_psl_include_private',
 			'pfb_psl_allow_private',
+			// issue #2371: feed-at-suffix PSL policy fields
+			'pfb_psl_feed_private_policy',
+			'pfb_psl_feed_icann_policy',
 			'pfb_regex',
 			'pfb_regex_list',
 			'pfb_regex_cap',
@@ -2383,6 +2415,7 @@ final class CfgGatewayTest extends TestCase
 			'pfb_cfg_idn_mode_read'         => ['on', 'confusable', 'off', 'all', 'junk'],
 			'pfb_cfg_top1m_source_read'     => ['tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare', 'alexa', 'domcop', 'junk'],
 			'pfb_cfg_alias_delta_mode_read' => ['auto', 'delta', 'replace', '', 'junk'],
+			'pfb_cfg_feed_suffix_policy_read' => ['ignore', 'apex', 'honor', '', 'junk'],
 		];
 
 		$tested = 0;
@@ -2732,6 +2765,8 @@ final class CfgGatewayTest extends TestCase
 			'dnsbl_interface' => 'lo0',           // unadapted, plain.
 			'pfb_dnsvip4'     => '',              // unadapted, plain.
 			'top1m_token'     => 'QWJjMTIz',      // unadapted, plain (base64-shaped).
+			// issue #2371: adapted (feed_suffix_policy), HOSTILE junk -> normalises to Honor.
+			'pfb_psl_feed_private_policy' => 'suppress',
 		];
 
 		PfbConfig::writeSection($section, $data);
@@ -2745,6 +2780,9 @@ final class CfgGatewayTest extends TestCase
 		$this->assertSame('lo0', $result['dnsbl_interface'], 'unadapted dnsbl_interface is byte-identical');
 		$this->assertSame('', $result['pfb_dnsvip4'], 'unadapted pfb_dnsvip4 is byte-identical');
 		$this->assertSame('QWJjMTIz', $result['top1m_token'], 'unadapted top1m_token is byte-identical');
+		$this->assertSame('honor', $result['pfb_psl_feed_private_policy'], "hostile 'suppress' normalises to 'honor'");
+		$this->assertArrayNotHasKey('pfb_psl_feed_icann_policy', $result,
+			'a key absent from the input section blob stays absent (writeSection never materialises an untouched sibling)');
 	}
 
 	/**

--- a/tests/php/CfgRegistryGrandfatherGateTest.php
+++ b/tests/php/CfgRegistryGrandfatherGateTest.php
@@ -289,7 +289,12 @@ final class CfgRegistryGrandfatherGateTest extends TestCase
 	public function testPslPolicyKeysHaveNoLegacyNameOrGrandfatherSeed(): void
 	{
 		$registry = pfb_cfg_registry();
-		foreach (['dnsbl/pfb_psl_include_private', 'dnsbl/pfb_psl_allow_private'] as $key) {
+		foreach ([
+			'dnsbl/pfb_psl_include_private',
+			'dnsbl/pfb_psl_allow_private',
+			'dnsbl/pfb_psl_feed_private_policy',
+			'dnsbl/pfb_psl_feed_icann_policy',
+		] as $key) {
 			$this->assertArrayHasKey($key, $registry);
 			$this->assertArrayNotHasKey('old_name', $registry[$key]);
 			$this->assertArrayNotHasKey('grandfather', $registry[$key]);

--- a/tests/php/DnsblLoadedFingerprintTest.php
+++ b/tests/php/DnsblLoadedFingerprintTest.php
@@ -542,4 +542,32 @@ final class DnsblLoadedFingerprintTest extends TestCase
 		$allow_private['dnsbl_psl_allow_private'] = PfbToggle::On;
 		$this->assertNotSame($default, pfb_dnsbl_reload_fingerprint($allow_private));
 	}
+
+	/** issue #2371: the feed-at-suffix PSL policy fields salt the reload fingerprint too. */
+	public function testFeedSuffixPolicySaltsChangeReloadFingerprint(): void
+	{
+		$pfb = $this->reloadFpBasePfb();
+		$default = pfb_dnsbl_reload_fingerprint($pfb);
+
+		$explicit_defaults = $pfb;
+		$explicit_defaults['dnsbl_psl_feed_private_policy'] = PfbFeedSuffixPolicy::Honor;
+		$explicit_defaults['dnsbl_psl_feed_icann_policy'] = PfbFeedSuffixPolicy::Honor;
+		$this->assertSame($default, pfb_dnsbl_reload_fingerprint($explicit_defaults),
+			'explicit Honor must match the implicit default -- same fingerprint');
+
+		$private_ignore = $pfb;
+		$private_ignore['dnsbl_psl_feed_private_policy'] = PfbFeedSuffixPolicy::Ignore;
+		$fp_private_ignore = pfb_dnsbl_reload_fingerprint($private_ignore);
+		$this->assertNotSame($default, $fp_private_ignore);
+
+		$icann_apex = $pfb;
+		$icann_apex['dnsbl_psl_feed_icann_policy'] = PfbFeedSuffixPolicy::Apex;
+		$fp_icann_apex = pfb_dnsbl_reload_fingerprint($icann_apex);
+		$this->assertNotSame($default, $fp_icann_apex);
+		$this->assertNotSame($fp_private_ignore, $fp_icann_apex,
+			'changing the PRIVATE vs ICANN policy independently must produce distinct fingerprints');
+
+		// Stable when unchanged: two calls with the identical (non-default) values agree.
+		$this->assertSame($fp_private_ignore, pfb_dnsbl_reload_fingerprint($private_ignore));
+	}
 }

--- a/tests/php/DnsblPslPolicyUiTest.php
+++ b/tests/php/DnsblPslPolicyUiTest.php
@@ -83,6 +83,26 @@ final class DnsblPslPolicyUiTest extends TestCase
 		] as $term) {
 			$this->assertStringContainsString($term, $source, "feed-suffix-policy UI must contain '{$term}'");
 		}
+
+		// The option ARRAY itself must carry all three value => label pairs: the
+		// labels are also quoted in the help bullets, so a bare substring check
+		// cannot see an option vanish from the <select>. Pin the array literal.
+		$this->assertSame(
+			1,
+			preg_match('/\$psl_feed_policy_options\s*=\s*array\s*\((.*?)\);/s', $source, $optionsArray),
+			'the $psl_feed_policy_options array literal must exist'
+		);
+		foreach ([
+			"'ignore'" => "'Ignore entirely'",
+			"'apex'" => "'Block the suffix apex only'",
+			"'honor'" => "'Honor list rules'",
+		] as $value => $label) {
+			$this->assertMatchesRegularExpression(
+				'/' . preg_quote($value, '/') . '\s*=>\s*' . preg_quote($label, '/') . '/',
+				$optionsArray[1],
+				"select option {$value} => {$label} must live in the options array itself"
+			);
+		}
 	}
 
 	/** Both selects are gateway-backed reads/writes; never a config_*_path bypass. */

--- a/tests/php/DnsblPslPolicyUiTest.php
+++ b/tests/php/DnsblPslPolicyUiTest.php
@@ -51,4 +51,101 @@ final class DnsblPslPolicyUiTest extends TestCase
 		$this->assertStringNotContainsString("config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_", $source);
 		$this->assertStringNotContainsString("config_set_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_", $source);
 	}
+
+	/**
+	 * issue #2371 Step 3: the two feed-at-suffix policy selects render with their
+	 * labels and all three option texts, plus the outcome-based help vocabulary.
+	 */
+	public function testFeedSuffixPolicySelectsRenderLabelsAndOptions(): void
+	{
+		$source = self::source();
+		foreach ([
+			'Feed entries at shared-hosting suffixes (PSL PRIVATE)',
+			'Feed entries at public suffixes (ICANN)',
+			'Ignore entirely',
+			'Block the suffix apex only',
+			'Honor list rules',
+			// Runtime-effect vocabulary (issue #2371 Step 2): drop counted in the
+			// reject stats; exact apex block only; honor including explicit wildcard.
+			'reject stats',
+			'exact suffix name is blocked',
+			'explicit',
+			'wildcard',
+			// User-defined lists are never affected by this feed-only policy.
+			'Custom List',
+			'never affected',
+			// Intentional whole-suffix blocking belongs in TLD Blacklist (dotted entries).
+			'TLD Blacklist',
+			'dotted entries',
+			// PRIVATE-select-specific: PSL PRIVATE means shared domains, not private DNS.
+			'github.io',
+			'not private DNS',
+		] as $term) {
+			$this->assertStringContainsString($term, $source, "feed-suffix-policy UI must contain '{$term}'");
+		}
+	}
+
+	/** Both selects are gateway-backed reads/writes; never a config_*_path bypass. */
+	public function testFeedSuffixPolicySelectsUseRegisteredGatewayKeysOnly(): void
+	{
+		$source = self::source();
+		$this->assertStringContainsString("PfbConfig::read('dnsbl/pfb_psl_feed_private_policy')", $source);
+		$this->assertStringContainsString("PfbConfig::read('dnsbl/pfb_psl_feed_icann_policy')", $source);
+		$this->assertStringContainsString("PfbConfig::write('dnsbl/pfb_psl_feed_private_policy'", $source);
+		$this->assertStringContainsString("PfbConfig::write('dnsbl/pfb_psl_feed_icann_policy'", $source);
+		$this->assertStringNotContainsString("config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_", $source);
+		$this->assertStringNotContainsString("config_set_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_", $source);
+	}
+
+	/** The word "suppression" is never used anywhere on the page (issue #2371 wording rule). */
+	public function testSuppressionWordNeverAppearsOnPage(): void
+	{
+		$source = self::source();
+		$this->assertStringNotContainsStringIgnoringCase('suppression', $source);
+	}
+
+	/**
+	 * POST sanitation: an unknown token must persist as Honor, never verbatim
+	 * (issue #2371 Step 3 contract row 6). #993: the page's own POST/session-gated
+	 * save branch has no PHPUnit harness, so the exact sanitizer binding shipped is
+	 * pinned by source window here, and its behaviour is proven by driving the same
+	 * real functions (pfb_filter() then PfbConfig::write(), whose write_adapter is
+	 * pfb_cfg_feed_suffix_policy_write()) the page's save branch calls.
+	 */
+	public function testUnknownFeedSuffixPolicyTokenSanitizesToHonor(): void
+	{
+		$source = self::source();
+		foreach ([
+			'pfb_psl_feed_private_policy' => "\$psl_feed_private_policy = pfb_filter(\$_POST['pfb_psl_feed_private_policy'] ?? '', PFB_FILTER_WORD, 'dnsbl') ?: '';",
+			'pfb_psl_feed_icann_policy' => "\$psl_feed_icann_policy = pfb_filter(\$_POST['pfb_psl_feed_icann_policy'] ?? '', PFB_FILTER_WORD, 'dnsbl') ?: '';",
+		] as $bare => $needle) {
+			$this->assertStringContainsString($needle, $source, "{$bare}: sanitizer binding missing");
+			$this->assertStringContainsString("PfbConfig::write('dnsbl/{$bare}', \${$this->postVarFor($bare)})", $source, "{$bare}: gateway write missing");
+		}
+
+		// Behaviour: drive the exact chain the save binding invokes.
+		$GLOBALS['config'] = [];
+		$hostile = pfb_filter('bogus', PFB_FILTER_WORD, 'dnsbl') ?: '';
+		$this->assertSame('bogus', $hostile, 'precondition: PFB_FILTER_WORD accepts the word-shaped hostile token');
+
+		PfbConfig::write('dnsbl/pfb_psl_feed_private_policy', $hostile);
+		PfbConfig::write('dnsbl/pfb_psl_feed_icann_policy', $hostile);
+
+		$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read('dnsbl/pfb_psl_feed_private_policy'));
+		$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read('dnsbl/pfb_psl_feed_icann_policy'));
+		$this->assertSame(
+			'honor',
+			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_private_policy')
+		);
+		$this->assertSame(
+			'honor',
+			config_get_path('installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_icann_policy')
+		);
+	}
+
+	/** The page's local sanitized-variable name for a given registered field. */
+	private function postVarFor(string $bare): string
+	{
+		return $bare === 'pfb_psl_feed_private_policy' ? 'psl_feed_private_policy' : 'psl_feed_icann_policy';
+	}
 }

--- a/tests/php/PfbEmitEntryRejectStatsTest.php
+++ b/tests/php/PfbEmitEntryRejectStatsTest.php
@@ -164,6 +164,59 @@ final class PfbEmitEntryRejectStatsTest extends TestCase
 		$this->assertSame('', file_get_contents($log), 'corrupt JSON must emit nothing, never throw');
 	}
 
+	public function testIssue2371SuffixBucketsEmitTheirOwnCanonicalLines(): void
+	{
+		// Given: an artifact row carrying the #2371 suffix_drop/suffix_demote
+		// buckets alongside a zero legacy pair (Python emits them sparsely --
+		// only present when they fired -- but the reader must not assume
+		// every key exists).
+		$log = $this->seedLogSinks();
+		$stats = $this->statsFile(json_encode([
+			['feed' => 'FeedC', 'group' => 'GroupC', 'suffix_drop' => 2, 'suffix_demote' => 1],
+		]));
+
+		// When: the artifact is read.
+		pfb_emit_entry_reject_stats($stats);
+
+		// Then: one canonical line per #2371 bucket, exact shape.
+		$logContents = (string) file_get_contents($log);
+		$expectedDrop = pfb_validate_log_line('FeedC', 'entries', 'suffix_drop', '2');
+		$expectedDemote = pfb_validate_log_line('FeedC', 'entries', 'suffix_demote', '1');
+		$this->assertMatchesRegularExpression(
+			$this->stampedLinePattern($expectedDrop),
+			$logContents,
+			"expected <{$expectedDrop}> in <{$logContents}>"
+		);
+		$this->assertMatchesRegularExpression(
+			$this->stampedLinePattern($expectedDemote),
+			$logContents,
+			"expected <{$expectedDemote}> in <{$logContents}>"
+		);
+	}
+
+	public function testIssue2371AbsentSuffixBucketsEmitNoLines(): void
+	{
+		// Given: a legacy-shaped row that never carries the #2371 keys at all
+		// (the pre-#2371 artifact shape).
+		$log = $this->seedLogSinks();
+		$stats = $this->statsFile(json_encode([
+			['feed' => 'FeedD', 'group' => 'GroupD', 'shape' => 1],
+		]));
+
+		pfb_emit_entry_reject_stats($stats);
+
+		$logContents = (string) file_get_contents($log);
+		$this->assertDoesNotMatchRegularExpression(
+			$this->stampedLinePattern(pfb_validate_log_line('FeedD', 'entries', 'suffix_drop', '0')),
+			$logContents,
+			"an absent bucket must not log a line, got <{$logContents}>"
+		);
+		$this->assertMatchesRegularExpression(
+			$this->stampedLinePattern(pfb_validate_log_line('FeedD', 'entries', 'shape', '1')),
+			$logContents
+		);
+	}
+
 	public function testNonScalarFieldsAreSkippedSilently(): void
 	{
 		// Given: syntactically valid JSON whose values have hostile SHAPES -- an

--- a/tests/php/PfbEmitEntryRejectStatsTest.php
+++ b/tests/php/PfbEmitEntryRejectStatsTest.php
@@ -166,13 +166,19 @@ final class PfbEmitEntryRejectStatsTest extends TestCase
 
 	public function testIssue2371SuffixBucketsEmitTheirOwnCanonicalLines(): void
 	{
-		// Given: an artifact row carrying the #2371 suffix_drop/suffix_demote
-		// buckets alongside a zero legacy pair (Python emits them sparsely --
-		// only present when they fired -- but the reader must not assume
-		// every key exists).
+		// Given: an artifact row shaped the way the Python writer actually
+		// emits it -- shape/wire_cap ALWAYS present (zero included), the #2371
+		// suffix buckets present only because they fired.
 		$log = $this->seedLogSinks();
 		$stats = $this->statsFile(json_encode([
-			['feed' => 'FeedC', 'group' => 'GroupC', 'suffix_drop' => 2, 'suffix_demote' => 1],
+			[
+				'feed' => 'FeedC',
+				'group' => 'GroupC',
+				'shape' => 0,
+				'wire_cap' => 0,
+				'suffix_drop' => 2,
+				'suffix_demote' => 1,
+			],
 		]));
 
 		// When: the artifact is read.
@@ -197,10 +203,10 @@ final class PfbEmitEntryRejectStatsTest extends TestCase
 	public function testIssue2371AbsentSuffixBucketsEmitNoLines(): void
 	{
 		// Given: a legacy-shaped row that never carries the #2371 keys at all
-		// (the pre-#2371 artifact shape).
+		// (the pre-#2371 artifact shape: shape/wire_cap always written).
 		$log = $this->seedLogSinks();
 		$stats = $this->statsFile(json_encode([
-			['feed' => 'FeedD', 'group' => 'GroupD', 'shape' => 1],
+			['feed' => 'FeedD', 'group' => 'GroupD', 'shape' => 1, 'wire_cap' => 0],
 		]));
 
 		pfb_emit_entry_reject_stats($stats);
@@ -210,6 +216,11 @@ final class PfbEmitEntryRejectStatsTest extends TestCase
 			$this->stampedLinePattern(pfb_validate_log_line('FeedD', 'entries', 'suffix_drop', '0')),
 			$logContents,
 			"an absent bucket must not log a line, got <{$logContents}>"
+		);
+		$this->assertStringNotContainsString(
+			'suffix_demote',
+			$logContents,
+			"an absent suffix_demote bucket must not log a line, got <{$logContents}>"
 		);
 		$this->assertMatchesRegularExpression(
 			$this->stampedLinePattern(pfb_validate_log_line('FeedD', 'entries', 'shape', '1')),

--- a/tests/php/PslFeedPolicyPipelineOrderingTest.php
+++ b/tests/php/PslFeedPolicyPipelineOrderingTest.php
@@ -27,9 +27,13 @@ final class PslFeedPolicyPipelineOrderingTest extends TestCase
 	}
 
 	/**
-	 * Reproduces pfblockerng_install.inc's exact call order for a genuinely fresh
-	 * install: capture freshness BEFORE any mutation, run migrations, run the
-	 * registry pass, THEN apply the #2371 seed only if freshness was TRUE.
+	 * RE-IMPLEMENTS pfblockerng_install.inc's documented call order for a
+	 * genuinely fresh install (capture freshness BEFORE any mutation, run
+	 * migrations, run the registry pass, THEN apply the #2371 seed only if
+	 * freshness was TRUE) -- it does not execute the installer file, which
+	 * cannot be include()'d off-appliance. The real file's ordering is pinned
+	 * separately by testInstallerCallsTheSeamAfterRegistryWriteback below;
+	 * only the two together prove ordering safety.
 	 */
 	private function runInstallSequence(): array
 	{
@@ -178,6 +182,15 @@ final class PslFeedPolicyPipelineOrderingTest extends TestCase
 		$path = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
 		$source = php_strip_whitespace($path);
 		$this->assertNotSame('', $source, 'installer source must be readable');
+
+		$capture = strpos($source, 'pfb_psl_feed_policy_is_fresh_install(');
+		$this->assertNotFalse($capture, 'installer must capture freshness via pfb_psl_feed_policy_is_fresh_install()');
+
+		// Migrations run through pfb_install_settings_family_finalize()'s seam
+		// (its $migrations callable defaults to pfb_run_migrations).
+		$migrations = strpos($source, 'pfb_install_settings_family_finalize(');
+		$this->assertNotFalse($migrations, 'installer must run the migration registry via its finalize seam');
+		$this->assertLessThan($migrations, $capture, 'freshness must be captured BEFORE any migration mutates a section');
 
 		$writeback = strpos($source, 'pfb_install_registry_writeback($pfb_registry_sections);');
 		$this->assertNotFalse($writeback, 'installer must dispatch its registry pass through the writeback seam');

--- a/tests/php/PslFeedPolicyPipelineOrderingTest.php
+++ b/tests/php/PslFeedPolicyPipelineOrderingTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2371 — the full install-order interaction: pfb_run_migrations() ->
+ * pfb_registry_pass() -> the #2371 post-pass seed, proving the deviation from
+ * pfb_migration_registry() (see pfb_psl_feed_policy_is_fresh_install()'s docblock,
+ * pfblockerng.inc, and tests/php/PslFeedPolicySeedTest.php for the predicate's own
+ * unit tests) is load-bearing and not just theoretical.
+ */
+#[CoversFunction('pfb_psl_feed_policy_is_fresh_install')]
+#[CoversFunction('pfb_install_psl_feed_policy_seed')]
+#[CoversFunction('pfb_registry_pass')]
+#[CoversFunction('pfb_run_migrations')]
+final class PslFeedPolicyPipelineOrderingTest extends TestCase
+{
+	private const DNSBL_SECTION = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_file_notices'] = [];
+	}
+
+	/**
+	 * Reproduces pfblockerng_install.inc's exact call order for a genuinely fresh
+	 * install: capture freshness BEFORE any mutation, run migrations, run the
+	 * registry pass, THEN apply the #2371 seed only if freshness was TRUE.
+	 */
+	private function runInstallSequence(): array
+	{
+		$fresh = pfb_psl_feed_policy_is_fresh_install(PfbConfig::readSection(self::DNSBL_SECTION));
+
+		pfb_run_migrations();
+
+		$sections = [];
+		foreach (PFB_SECTIONS as $section) {
+			$sections[$section] = PfbConfig::readSection($section);
+		}
+		foreach (pfb_registry_pass($sections) as $section => $blob) {
+			PfbConfig::writeSectionRawSystem($section, $blob);
+		}
+
+		// The REAL seam pfblockerng_install.inc calls -- not a hand-copied
+		// reimplementation, so a mutation to its body is caught here too.
+		pfb_install_psl_feed_policy_seed($fresh);
+
+		return PfbConfig::readSection(self::DNSBL_SECTION);
+	}
+
+	/**
+	 * Row 3: a genuinely fresh install (nothing configured beforehand) ends with both
+	 * keys 'apex' after the full pipeline runs.
+	 */
+	public function testFreshInstallEndsWithBothKeysApex(): void
+	{
+		$dnsbl = $this->runInstallSequence();
+
+		$this->assertSame('apex', $dnsbl['pfb_psl_feed_private_policy'] ?? NULL);
+		$this->assertSame('apex', $dnsbl['pfb_psl_feed_icann_policy'] ?? NULL);
+	}
+
+	/**
+	 * The load-bearing regression guard for keeping this seed OUT of
+	 * pfb_migration_registry(): a genuinely fresh install must not corrupt a SIBLING
+	 * registered dnsbl/* field's own NEWCFG default. dnsbl/pfb_dnsbl_lenient carries a
+	 * grandfather map (ABSENT -> 'on') that only an OLDCFG (existing-install) section
+	 * may apply; its correct fresh-install value is the registered default 'off'.
+	 */
+	public function testFreshInstallDoesNotCorruptSiblingFieldGrandfatherMode(): void
+	{
+		$dnsbl = $this->runInstallSequence();
+
+		$this->assertSame('off', $dnsbl['pfb_dnsbl_lenient'] ?? NULL,
+			'a genuinely fresh install must take the NEWCFG default (off) for pfb_dnsbl_lenient, '
+			. 'never the OLDCFG absent-grandfather (on) -- proves the #2371 seed running AFTER '
+			. 'the registry pass, not as a pfb_migration_registry() entry, is load-bearing');
+	}
+
+	/**
+	 * Row 4: an existing install (already has unrelated operator configuration, but
+	 * never touched these two keys) ends the pipeline with BOTH keys NEVER seeded
+	 * 'apex' -- the #2371 seed does not fire (fresh == FALSE). pfb_registry_pass()
+	 * itself DOES materialise its own registered default '' for the two keys once the
+	 * section is OLDCFG (absent + no grandfather map -> stable_default, same branch
+	 * that seeds every other un-grandfathered field on this section, e.g. top1m_source
+	 * -> 'tranco'); '' is not 'apex' and PfbConfig::read() resolves it to Honor exactly
+	 * like a genuinely absent key would.
+	 */
+	public function testUpgradeInstallLeavesBothKeysAbsent(): void
+	{
+		PfbConfig::writeSectionRawSystem(self::DNSBL_SECTION, ['pfb_dnsbl' => 'on', 'dnsbl_interface' => 'lo0']);
+
+		$dnsbl = $this->runInstallSequence();
+
+		$this->assertNotSame('apex', $dnsbl['pfb_psl_feed_private_policy'] ?? NULL,
+			'upgrade must never seed apex -- that seed only fires on a genuinely fresh install');
+		$this->assertNotSame('apex', $dnsbl['pfb_psl_feed_icann_policy'] ?? NULL,
+			'upgrade must never seed apex -- that seed only fires on a genuinely fresh install');
+		$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read('dnsbl/pfb_psl_feed_private_policy'));
+		$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read('dnsbl/pfb_psl_feed_icann_policy'));
+	}
+
+	/**
+	 * Idempotency at the pipeline level: running the WHOLE sequence a second time
+	 * (simulating a package reinstall over an already-seeded box) is a no-op for these
+	 * two keys -- the section is no longer empty, so freshness reads FALSE and the
+	 * seed step never fires again.
+	 */
+	public function testSecondPipelineRunIsNoOpForAlreadySeededKeys(): void
+	{
+		$first  = $this->runInstallSequence();
+		$second = $this->runInstallSequence();
+
+		$this->assertSame('apex', $first['pfb_psl_feed_private_policy'] ?? NULL);
+		$this->assertSame($first['pfb_psl_feed_private_policy'], $second['pfb_psl_feed_private_policy'] ?? NULL);
+		$this->assertSame($first['pfb_psl_feed_icann_policy'], $second['pfb_psl_feed_icann_policy'] ?? NULL);
+	}
+
+	/**
+	 * DI-based unit test of pfb_install_psl_feed_policy_seed() itself (mirrors
+	 * InstallPrePassWriteOrderTest::testRegistryWritebackSeamFlushesAfterReturnedSectionWrites()
+	 * for pfb_install_registry_writeback()): $fresh == TRUE writes BOTH keys, in order,
+	 * THEN flushes exactly once with the documented message.
+	 */
+	public function testSeamWritesBothKeysThenFlushesWhenFresh(): void
+	{
+		$order = [];
+		pfb_install_psl_feed_policy_seed(
+			TRUE,
+			static function (string $key, mixed $value) use (&$order): void {
+				$order[] = "write:{$key}={$value}";
+			},
+			static function (string $message) use (&$order): void {
+				$order[] = "flush:{$message}";
+			}
+		);
+		$this->assertSame(
+			[
+				'write:dnsbl/pfb_psl_feed_private_policy=apex',
+				'write:dnsbl/pfb_psl_feed_icann_policy=apex',
+				'flush:pfBlockerNG: seeded feed-at-suffix PSL policy defaults for fresh install (issue #2371)',
+			],
+			$order
+		);
+	}
+
+	/** DI-based unit test: $fresh == FALSE writes and flushes NOTHING. */
+	public function testSeamIsNoOpWhenNotFresh(): void
+	{
+		$order = [];
+		pfb_install_psl_feed_policy_seed(
+			FALSE,
+			static function (string $key, mixed $value) use (&$order): void {
+				$order[] = "write:{$key}={$value}";
+			},
+			static function (string $message) use (&$order): void {
+				$order[] = "flush:{$message}";
+			}
+		);
+		$this->assertSame([], $order);
+	}
+
+	/**
+	 * Wiring proof (mirrors InstallPrePassWriteOrderTest::
+	 * testRegistryPassWritebackRunsBeforeFinalConfigFlush()): the REAL installer file
+	 * dispatches through this seam exactly once, AFTER pfb_install_registry_writeback().
+	 * php_strip_whitespace gives an executable-code pin without comments/docblocks
+	 * satisfying the ordering contract; pfblockerng_install.inc cannot be include()'d
+	 * safely off-appliance (see InstallPrePassWriteOrderTest's docblock).
+	 */
+	public function testInstallerCallsTheSeamAfterRegistryWriteback(): void
+	{
+		$path = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
+		$source = php_strip_whitespace($path);
+		$this->assertNotSame('', $source, 'installer source must be readable');
+
+		$writeback = strpos($source, 'pfb_install_registry_writeback($pfb_registry_sections);');
+		$this->assertNotFalse($writeback, 'installer must dispatch its registry pass through the writeback seam');
+
+		$seam = strpos($source, 'pfb_install_psl_feed_policy_seed($pfb_psl_feed_policy_fresh_install);');
+		$this->assertNotFalse($seam, 'installer must dispatch the #2371 seed through pfb_install_psl_feed_policy_seed()');
+		$this->assertSame(1, substr_count($source, 'pfb_install_psl_feed_policy_seed($pfb_psl_feed_policy_fresh_install);'));
+		$this->assertGreaterThan($writeback, $seam, 'the #2371 seed must run AFTER the registry writeback, never before');
+	}
+}

--- a/tests/php/PslFeedPolicySeedTest.php
+++ b/tests/php/PslFeedPolicySeedTest.php
@@ -6,17 +6,19 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * issue #2371 — pfb_psl_feed_policy_is_fresh_install() + the install-time seed it
- * gates (pfblockerng_install.inc: PfbConfig::writeSystem('dnsbl/pfb_psl_feed_*_policy',
- * 'apex') after pfb_install_registry_writeback()).
+ * issue #2371 — pfb_psl_feed_policy_is_fresh_install() unit tests. The full
+ * install-order interaction (pfb_run_migrations() -> pfb_registry_pass() -> the
+ * #2371 post-pass seed) is a SEPARATE TestCase in
+ * tests/php/PslFeedPolicyPipelineOrderingTest.php -- PHPUnit only discovers ONE
+ * TestCase per file, so a second class here would silently never run.
  *
- * This is deliberately NOT a pfb_migration_registry() entry -- see
+ * This predicate is deliberately NOT a pfb_migration_registry() entry -- see
  * pfb_psl_feed_policy_is_fresh_install()'s docblock (pfblockerng.inc) for why folding
  * a fresh-install seed into the migration driver (which runs BEFORE pfb_registry_pass()
  * re-reads the section for its own NEWCFG/OLDCFG mode decision) would wrongly flip that
  * decision for every OTHER registered dnsbl/* field once the seeded keys make the
- * section non-empty. Part 2 of this file (TestFreshInstallPipelineOrdering) proves that
- * ordering choice against the real pipeline rather than reasoning about it.
+ * section non-empty. PslFeedPolicyPipelineOrderingTest proves that ordering choice
+ * against the real pipeline rather than reasoning about it.
  */
 #[CoversFunction('pfb_psl_feed_policy_is_fresh_install')]
 final class PslFeedPolicySeedTest extends TestCase
@@ -68,113 +70,5 @@ final class PslFeedPolicySeedTest extends TestCase
 			pfb_psl_feed_policy_is_fresh_install($dconfig),
 			pfb_psl_feed_policy_is_fresh_install($dconfig)
 		);
-	}
-}
-
-/**
- * Part 2 -- the full install-order interaction: pfb_run_migrations() ->
- * pfb_registry_pass() -> the #2371 post-pass seed, proving the deviation from
- * pfb_migration_registry() is load-bearing and not just theoretical.
- */
-#[CoversFunction('pfb_psl_feed_policy_is_fresh_install')]
-#[CoversFunction('pfb_registry_pass')]
-#[CoversFunction('pfb_run_migrations')]
-final class TestFreshInstallPipelineOrdering extends TestCase
-{
-	private const DNSBL_SECTION = 'installedpackages/pfblockerngdnsblsettings/config/0';
-
-	protected function setUp(): void
-	{
-		$GLOBALS['config'] = [];
-		$GLOBALS['pfb_test_file_notices'] = [];
-	}
-
-	/**
-	 * Reproduces pfblockerng_install.inc's exact call order for a genuinely fresh
-	 * install: capture freshness BEFORE any mutation, run migrations, run the
-	 * registry pass, THEN apply the #2371 seed only if freshness was TRUE.
-	 */
-	private function runInstallSequence(): array
-	{
-		$fresh = pfb_psl_feed_policy_is_fresh_install(PfbConfig::readSection(self::DNSBL_SECTION));
-
-		pfb_run_migrations();
-
-		$sections = [];
-		foreach (PFB_SECTIONS as $section) {
-			$sections[$section] = PfbConfig::readSection($section);
-		}
-		foreach (pfb_registry_pass($sections) as $section => $blob) {
-			PfbConfig::writeSectionRawSystem($section, $blob);
-		}
-
-		if ($fresh) {
-			PfbConfig::writeSystem('dnsbl/pfb_psl_feed_private_policy', 'apex');
-			PfbConfig::writeSystem('dnsbl/pfb_psl_feed_icann_policy', 'apex');
-		}
-
-		return PfbConfig::readSection(self::DNSBL_SECTION);
-	}
-
-	/**
-	 * Row 3: a genuinely fresh install (nothing configured beforehand) ends with both
-	 * keys 'apex' after the full pipeline runs.
-	 */
-	public function testFreshInstallEndsWithBothKeysApex(): void
-	{
-		$dnsbl = $this->runInstallSequence();
-
-		$this->assertSame('apex', $dnsbl['pfb_psl_feed_private_policy'] ?? NULL);
-		$this->assertSame('apex', $dnsbl['pfb_psl_feed_icann_policy'] ?? NULL);
-	}
-
-	/**
-	 * The load-bearing regression guard for keeping this seed OUT of
-	 * pfb_migration_registry(): a genuinely fresh install must not corrupt a SIBLING
-	 * registered dnsbl/* field's own NEWCFG default. dnsbl/pfb_dnsbl_lenient carries a
-	 * grandfather map (ABSENT -> 'on') that only an OLDCFG (existing-install) section
-	 * may apply; its correct fresh-install value is the registered default 'off'.
-	 */
-	public function testFreshInstallDoesNotCorruptSiblingFieldGrandfatherMode(): void
-	{
-		$dnsbl = $this->runInstallSequence();
-
-		$this->assertSame('off', $dnsbl['pfb_dnsbl_lenient'] ?? NULL,
-			'a genuinely fresh install must take the NEWCFG default (off) for pfb_dnsbl_lenient, '
-			. 'never the OLDCFG absent-grandfather (on) -- proves the #2371 seed running AFTER '
-			. 'the registry pass, not as a pfb_migration_registry() entry, is load-bearing');
-	}
-
-	/**
-	 * Row 4: an existing install (already has unrelated operator configuration, but
-	 * never touched these two keys) ends the pipeline with BOTH keys still absent --
-	 * PfbConfig::read() then resolves that absence to Honor via the registry default.
-	 */
-	public function testUpgradeInstallLeavesBothKeysAbsent(): void
-	{
-		PfbConfig::writeSectionRawSystem(self::DNSBL_SECTION, ['pfb_dnsbl' => 'on', 'dnsbl_interface' => 'lo0']);
-
-		$dnsbl = $this->runInstallSequence();
-
-		$this->assertArrayNotHasKey('pfb_psl_feed_private_policy', $dnsbl);
-		$this->assertArrayNotHasKey('pfb_psl_feed_icann_policy', $dnsbl);
-		$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read('dnsbl/pfb_psl_feed_private_policy'));
-		$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read('dnsbl/pfb_psl_feed_icann_policy'));
-	}
-
-	/**
-	 * Idempotency at the pipeline level: running the WHOLE sequence a second time
-	 * (simulating a package reinstall over an already-seeded box) is a no-op for these
-	 * two keys -- the section is no longer empty, so freshness reads FALSE and the
-	 * seed step never fires again.
-	 */
-	public function testSecondPipelineRunIsNoOpForAlreadySeededKeys(): void
-	{
-		$first  = $this->runInstallSequence();
-		$second = $this->runInstallSequence();
-
-		$this->assertSame('apex', $first['pfb_psl_feed_private_policy'] ?? NULL);
-		$this->assertSame($first['pfb_psl_feed_private_policy'], $second['pfb_psl_feed_private_policy'] ?? NULL);
-		$this->assertSame($first['pfb_psl_feed_icann_policy'], $second['pfb_psl_feed_icann_policy'] ?? NULL);
 	}
 }

--- a/tests/php/PslFeedPolicySeedTest.php
+++ b/tests/php/PslFeedPolicySeedTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2371 — pfb_psl_feed_policy_is_fresh_install() + the install-time seed it
+ * gates (pfblockerng_install.inc: PfbConfig::writeSystem('dnsbl/pfb_psl_feed_*_policy',
+ * 'apex') after pfb_install_registry_writeback()).
+ *
+ * This is deliberately NOT a pfb_migration_registry() entry -- see
+ * pfb_psl_feed_policy_is_fresh_install()'s docblock (pfblockerng.inc) for why folding
+ * a fresh-install seed into the migration driver (which runs BEFORE pfb_registry_pass()
+ * re-reads the section for its own NEWCFG/OLDCFG mode decision) would wrongly flip that
+ * decision for every OTHER registered dnsbl/* field once the seeded keys make the
+ * section non-empty. Part 2 of this file (TestFreshInstallPipelineOrdering) proves that
+ * ordering choice against the real pipeline rather than reasoning about it.
+ */
+#[CoversFunction('pfb_psl_feed_policy_is_fresh_install')]
+final class PslFeedPolicySeedTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	// -----------------------------------------------------------------------
+	// Part 1 -- pfb_psl_feed_policy_is_fresh_install() unit tests.
+	// -----------------------------------------------------------------------
+
+	/** Row 3: a genuinely empty section is fresh. */
+	public function testEmptySectionIsFresh(): void
+	{
+		$this->assertTrue(pfb_psl_feed_policy_is_fresh_install([]));
+	}
+
+	/** A marker-only section (installer bookkeeping stripped) is still fresh. */
+	public function testSettingsFamilyMarkerOnlySectionIsFresh(): void
+	{
+		$this->assertTrue(pfb_psl_feed_policy_is_fresh_install(['settings_family' => '4.0']));
+	}
+
+	/** Row 4: any genuine operator configuration makes the section non-fresh. */
+	public function testPopulatedSectionIsNotFresh(): void
+	{
+		$this->assertFalse(pfb_psl_feed_policy_is_fresh_install(['pfb_dnsbl' => 'on']));
+	}
+
+	/** Row 4 (continued): a section that already carries either seeded key is not fresh. */
+	public function testAlreadySeededSectionIsNotFresh(): void
+	{
+		$this->assertFalse(pfb_psl_feed_policy_is_fresh_install(['pfb_psl_feed_private_policy' => 'apex']));
+	}
+
+	/** Non-array input never throws; treated as not fresh (defensive). */
+	public function testNonArrayInputIsNotFresh(): void
+	{
+		$this->assertFalse(pfb_psl_feed_policy_is_fresh_install(null));
+	}
+
+	/** Idempotent by construction: a pure predicate returns the same answer every call. */
+	public function testIsIdempotentAcrossRepeatedCalls(): void
+	{
+		$dconfig = [];
+		$this->assertSame(
+			pfb_psl_feed_policy_is_fresh_install($dconfig),
+			pfb_psl_feed_policy_is_fresh_install($dconfig)
+		);
+	}
+}
+
+/**
+ * Part 2 -- the full install-order interaction: pfb_run_migrations() ->
+ * pfb_registry_pass() -> the #2371 post-pass seed, proving the deviation from
+ * pfb_migration_registry() is load-bearing and not just theoretical.
+ */
+#[CoversFunction('pfb_psl_feed_policy_is_fresh_install')]
+#[CoversFunction('pfb_registry_pass')]
+#[CoversFunction('pfb_run_migrations')]
+final class TestFreshInstallPipelineOrdering extends TestCase
+{
+	private const DNSBL_SECTION = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_file_notices'] = [];
+	}
+
+	/**
+	 * Reproduces pfblockerng_install.inc's exact call order for a genuinely fresh
+	 * install: capture freshness BEFORE any mutation, run migrations, run the
+	 * registry pass, THEN apply the #2371 seed only if freshness was TRUE.
+	 */
+	private function runInstallSequence(): array
+	{
+		$fresh = pfb_psl_feed_policy_is_fresh_install(PfbConfig::readSection(self::DNSBL_SECTION));
+
+		pfb_run_migrations();
+
+		$sections = [];
+		foreach (PFB_SECTIONS as $section) {
+			$sections[$section] = PfbConfig::readSection($section);
+		}
+		foreach (pfb_registry_pass($sections) as $section => $blob) {
+			PfbConfig::writeSectionRawSystem($section, $blob);
+		}
+
+		if ($fresh) {
+			PfbConfig::writeSystem('dnsbl/pfb_psl_feed_private_policy', 'apex');
+			PfbConfig::writeSystem('dnsbl/pfb_psl_feed_icann_policy', 'apex');
+		}
+
+		return PfbConfig::readSection(self::DNSBL_SECTION);
+	}
+
+	/**
+	 * Row 3: a genuinely fresh install (nothing configured beforehand) ends with both
+	 * keys 'apex' after the full pipeline runs.
+	 */
+	public function testFreshInstallEndsWithBothKeysApex(): void
+	{
+		$dnsbl = $this->runInstallSequence();
+
+		$this->assertSame('apex', $dnsbl['pfb_psl_feed_private_policy'] ?? NULL);
+		$this->assertSame('apex', $dnsbl['pfb_psl_feed_icann_policy'] ?? NULL);
+	}
+
+	/**
+	 * The load-bearing regression guard for keeping this seed OUT of
+	 * pfb_migration_registry(): a genuinely fresh install must not corrupt a SIBLING
+	 * registered dnsbl/* field's own NEWCFG default. dnsbl/pfb_dnsbl_lenient carries a
+	 * grandfather map (ABSENT -> 'on') that only an OLDCFG (existing-install) section
+	 * may apply; its correct fresh-install value is the registered default 'off'.
+	 */
+	public function testFreshInstallDoesNotCorruptSiblingFieldGrandfatherMode(): void
+	{
+		$dnsbl = $this->runInstallSequence();
+
+		$this->assertSame('off', $dnsbl['pfb_dnsbl_lenient'] ?? NULL,
+			'a genuinely fresh install must take the NEWCFG default (off) for pfb_dnsbl_lenient, '
+			. 'never the OLDCFG absent-grandfather (on) -- proves the #2371 seed running AFTER '
+			. 'the registry pass, not as a pfb_migration_registry() entry, is load-bearing');
+	}
+
+	/**
+	 * Row 4: an existing install (already has unrelated operator configuration, but
+	 * never touched these two keys) ends the pipeline with BOTH keys still absent --
+	 * PfbConfig::read() then resolves that absence to Honor via the registry default.
+	 */
+	public function testUpgradeInstallLeavesBothKeysAbsent(): void
+	{
+		PfbConfig::writeSectionRawSystem(self::DNSBL_SECTION, ['pfb_dnsbl' => 'on', 'dnsbl_interface' => 'lo0']);
+
+		$dnsbl = $this->runInstallSequence();
+
+		$this->assertArrayNotHasKey('pfb_psl_feed_private_policy', $dnsbl);
+		$this->assertArrayNotHasKey('pfb_psl_feed_icann_policy', $dnsbl);
+		$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read('dnsbl/pfb_psl_feed_private_policy'));
+		$this->assertSame(PfbFeedSuffixPolicy::Honor, PfbConfig::read('dnsbl/pfb_psl_feed_icann_policy'));
+	}
+
+	/**
+	 * Idempotency at the pipeline level: running the WHOLE sequence a second time
+	 * (simulating a package reinstall over an already-seeded box) is a no-op for these
+	 * two keys -- the section is no longer empty, so freshness reads FALSE and the
+	 * seed step never fires again.
+	 */
+	public function testSecondPipelineRunIsNoOpForAlreadySeededKeys(): void
+	{
+		$first  = $this->runInstallSequence();
+		$second = $this->runInstallSequence();
+
+		$this->assertSame('apex', $first['pfb_psl_feed_private_policy'] ?? NULL);
+		$this->assertSame($first['pfb_psl_feed_private_policy'], $second['pfb_psl_feed_private_policy'] ?? NULL);
+		$this->assertSame($first['pfb_psl_feed_icann_policy'], $second['pfb_psl_feed_icann_policy'] ?? NULL);
+	}
+}

--- a/tests/php/PythonTldWildcardIniEmitTest.php
+++ b/tests/php/PythonTldWildcardIniEmitTest.php
@@ -117,6 +117,22 @@ final class PythonTldWildcardIniEmitTest extends TestCase
 		$this->assertMatchesRegularExpression('/^psl_allow_private\s*=\s*on$/m', $flipped);
 	}
 
+	public function testFeedSuffixPolicyDefaultsAndExplicitValuesReachPythonIni(): void
+	{
+		$ini = $this->emit('');
+		$this->assertMatchesRegularExpression('/^psl_feed_private_policy\s*=\s*honor$/m', $ini);
+		$this->assertMatchesRegularExpression('/^psl_feed_icann_policy\s*=\s*honor$/m', $ini);
+
+		PfbConfig::writeSystem('dnsbl/pfb_psl_feed_private_policy', PfbFeedSuffixPolicy::Ignore);
+		PfbConfig::writeSystem('dnsbl/pfb_psl_feed_icann_policy', PfbFeedSuffixPolicy::Apex);
+		pfb_global();
+		pfb_unbound_python('enabled');
+		$flipped = file_get_contents($GLOBALS['pfb']['unbound_py_conf']);
+		$this->assertNotFalse($flipped);
+		$this->assertMatchesRegularExpression('/^psl_feed_private_policy\s*=\s*ignore$/m', $flipped);
+		$this->assertMatchesRegularExpression('/^psl_feed_icann_policy\s*=\s*apex$/m', $flipped);
+	}
+
 	public function testStoredIdnMaliciousOffReachesPythonIni(): void
 	{
 		PfbConfig::writeSystem('dnsbl/pfb_idn', 'confusable');

--- a/tests/php/RegistryPassTest.php
+++ b/tests/php/RegistryPassTest.php
@@ -79,6 +79,12 @@ final class RegistryPassTest extends TestCase
 			$this->assertArrayNotHasKey($retired, $result[self::GEN_SECTION]);
 		}
 		$this->assertSame('tranco', $result[self::DNSBL_SECTION]['top1m_source'] ?? NULL);
+		// issue #2371: the pass's own NEWCFG default for these two is the registered
+		// default '' (-> Honor), NEVER 'apex' -- the fresh-install apex/apex seed is a
+		// separate, later, install-time write (pfb_psl_feed_policy_is_fresh_install()),
+		// not something pfb_registry_pass() itself performs.
+		$this->assertSame('', $result[self::DNSBL_SECTION]['pfb_psl_feed_private_policy'] ?? NULL);
+		$this->assertSame('', $result[self::DNSBL_SECTION]['pfb_psl_feed_icann_policy'] ?? NULL);
 		$this->assertSame('Disable', $result[self::SS_SECTION]['safesearch_enable'] ?? NULL);
 		$this->assertSame('', $result[self::IP_SECTION]['v6suppression'] ?? NULL);
 		$this->assertSame('', $result[self::REP_SECTION]['enable_rep'] ?? NULL);

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5352,6 +5352,33 @@
             }
         ]
     },
+    "pfb_install_psl_feed_policy_seed": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "fresh",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "write",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            },
+            {
+                "name": "flush",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_install_registry_writeback": {
         "returnsRef": false,
         "returnType": "void",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -947,6 +947,32 @@
             }
         ]
     },
+    "pfb_cfg_feed_suffix_policy_read": {
+        "returnsRef": false,
+        "returnType": "PfbFeedSuffixPolicy",
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
+    "pfb_cfg_feed_suffix_policy_write": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "policy",
+                "byRef": false,
+                "variadic": false,
+                "type": "PfbFeedSuffixPolicy|string",
+                "default": null
+            }
+        ]
+    },
     "pfb_cfg_idn_mode_read": {
         "returnsRef": false,
         "returnType": "PfbIdnMode",
@@ -8928,6 +8954,19 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_psl_feed_policy_is_fresh_install": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "dconfig",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
                 "default": null
             }
         ]

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -191,6 +191,9 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerngdnsblsettings/config/0/tld_allow',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_include_private',
 		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_allow_private',
+		// issue #2371: feed-at-suffix PSL policy fields.
+		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_private_policy',
+		'installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_icann_policy',
 		// issue #1921: TLD Allow sort + bucket scalars (renamed from pfb_pytld* by #1898).
 		'installedpackages/pfblockerngdnsblsettings/config/0/tld_allow_sort',
 		'installedpackages/pfblockerngdnsblsettings/config/0/tld_allow_gtld',

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -512,6 +512,128 @@ def test_gateway_dnsbl_lenient_save_roundtrip(
 
 
 # --------------------------------------------------------------------------- #
+# issue #2371 Step 3: ADR-29 gateway save->reload round-trip for BOTH feed-at-suffix
+# policy selects (pfb_psl_feed_private_policy / pfb_psl_feed_icann_policy).
+# --------------------------------------------------------------------------- #
+
+_CFG_FEED_PRIVATE_POLICY = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_private_policy"
+_CFG_FEED_ICANN_POLICY = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_feed_icann_policy"
+
+
+def test_gateway_dnsbl_feed_suffix_policy_save_roundtrip(
+    browser_page: Page,
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    dnsbl_vip_ready_browser: None,
+    screenshot_dir: Path,
+) -> None:
+    """pfb_psl_feed_private_policy / pfb_psl_feed_icann_policy round-trip through the
+    DNSBL page and the gateway (issue #2371 Step 3).
+
+    Same idiom as ``test_gateway_dnsbl_lenient_save_roundtrip`` above, extended to TWO
+    independent ``<select>`` fields (instead of one checkbox) so a field-swap bug (the
+    save binding for one field accidentally writing the other's key) is caught: each
+    field is driven to a DIFFERENT non-default token ('apex' for PRIVATE, 'ignore' for
+    ICANN).
+
+    Scenario: ADR-29 gateway save->reload round-trip for the feed-at-suffix policy
+      selects on the DNSBL page.
+      Background: pfBlockerNG deployed; DNSBL VIP seeded; webConfigurator authenticated.
+
+    Given the current stored token of both fields (read via config_get oracle; an
+      absent/unrecognised token reads as 'honor' per PfbFeedSuffixPolicy's fail-safe
+      default -- see CfgGatewayTest.php),
+    When the DNSBL page is POST-saved with BOTH selects set to a non-default value,
+    Then config.xml holds the CANONICAL token for both keys; AND the DNSBL page,
+      navigated fresh in the browser, renders both selects at the matching value; AND a
+      second POST restores each field's original value with the same two assertions
+      (both directions).
+    """
+    page = browser_page
+
+    original_private = helpers.config_get(smoke_vm, _CFG_FEED_PRIVATE_POLICY) or "honor"
+    original_icann = helpers.config_get(smoke_vm, _CFG_FEED_ICANN_POLICY) or "honor"
+    flipped_private = "apex" if original_private != "apex" else "honor"
+    flipped_icann = "ignore" if original_icann != "ignore" else "honor"
+
+    try:
+        # ---- FLIP: POST both selects to a non-default, DISTINCT value ---- #
+        resp = webui.post(
+            DNSBL_PAGE,
+            {
+                "pfb_psl_feed_private_policy": flipped_private,
+                "pfb_psl_feed_icann_policy": flipped_icann,
+            },
+            timeout=_DNSBL_POST_TIMEOUT,
+        )
+        assert "Sign In" not in resp.text, "feed-suffix-policy flip POST lost the session"
+
+        # Config oracle: both stored tokens must match the flipped selection.
+        stored_private_flip = helpers.config_get(smoke_vm, _CFG_FEED_PRIVATE_POLICY)
+        assert stored_private_flip == flipped_private, (
+            f"pfb_psl_feed_private_policy gateway FAIL after flip: stored {stored_private_flip!r}, "
+            f"expected {flipped_private!r}"
+        )
+        stored_icann_flip = helpers.config_get(smoke_vm, _CFG_FEED_ICANN_POLICY)
+        assert stored_icann_flip == flipped_icann, (
+            f"pfb_psl_feed_icann_policy gateway FAIL after flip: stored {stored_icann_flip!r}, "
+            f"expected {flipped_icann!r}"
+        )
+
+        # DOM oracle: reload the DNSBL page and assert both selects show the flipped value.
+        _open(page, webui, DNSBL_PAGE)
+        sel_private_flip = page.locator("#pfb_psl_feed_private_policy")
+        sel_icann_flip = page.locator("#pfb_psl_feed_icann_policy")
+        expect(sel_private_flip).to_be_attached(timeout=JS_TIMEOUT_MS)
+        expect(sel_icann_flip).to_be_attached(timeout=JS_TIMEOUT_MS)
+        expect(sel_private_flip).to_have_value(flipped_private, timeout=JS_TIMEOUT_MS)
+        expect(sel_icann_flip).to_have_value(flipped_icann, timeout=JS_TIMEOUT_MS)
+        _shot(page, screenshot_dir, "gateway_dnsbl_feed_suffix_policy_after_flip")
+
+        # ---- RESTORE: POST both selects back to their original values ---- #
+        resp = webui.post(
+            DNSBL_PAGE,
+            {
+                "pfb_psl_feed_private_policy": original_private,
+                "pfb_psl_feed_icann_policy": original_icann,
+            },
+            timeout=_DNSBL_POST_TIMEOUT,
+        )
+        assert "Sign In" not in resp.text, "feed-suffix-policy restore POST lost the session"
+
+        # Config oracle: both stored tokens must match the restored (original) selection.
+        stored_private_restore = helpers.config_get(smoke_vm, _CFG_FEED_PRIVATE_POLICY)
+        assert stored_private_restore == original_private, (
+            f"pfb_psl_feed_private_policy gateway FAIL after restore: stored {stored_private_restore!r}, "
+            f"expected {original_private!r}"
+        )
+        stored_icann_restore = helpers.config_get(smoke_vm, _CFG_FEED_ICANN_POLICY)
+        assert stored_icann_restore == original_icann, (
+            f"pfb_psl_feed_icann_policy gateway FAIL after restore: stored {stored_icann_restore!r}, "
+            f"expected {original_icann!r}"
+        )
+
+        # DOM oracle: reload and assert both selects show the restored (original) value.
+        _open(page, webui, DNSBL_PAGE)
+        sel_private_restore = page.locator("#pfb_psl_feed_private_policy")
+        sel_icann_restore = page.locator("#pfb_psl_feed_icann_policy")
+        expect(sel_private_restore).to_be_attached(timeout=JS_TIMEOUT_MS)
+        expect(sel_icann_restore).to_be_attached(timeout=JS_TIMEOUT_MS)
+        expect(sel_private_restore).to_have_value(original_private, timeout=JS_TIMEOUT_MS)
+        expect(sel_icann_restore).to_have_value(original_icann, timeout=JS_TIMEOUT_MS)
+        _shot(page, screenshot_dir, "gateway_dnsbl_feed_suffix_policy_after_restore")
+
+    finally:
+        # Belt-and-suspenders: restore both fields to their original stored token on any
+        # mid-flip abort (config_set writes the raw token verbatim -- both original
+        # values captured above are already-canonical PfbFeedSuffixPolicy tokens).
+        if helpers.config_get(smoke_vm, _CFG_FEED_PRIVATE_POLICY) != original_private:
+            helpers.config_set(smoke_vm, _CFG_FEED_PRIVATE_POLICY, original_private)
+        if helpers.config_get(smoke_vm, _CFG_FEED_ICANN_POLICY) != original_icann:
+            helpers.config_set(smoke_vm, _CFG_FEED_ICANN_POLICY, original_icann)
+
+
+# --------------------------------------------------------------------------- #
 # PR #660 (ADR-36/37): DNS-Redirect + DoT/DoQ-Block interface quick-fill and
 # Exception-Alias autocomplete. Both are browser-only behaviours an HTTP POST
 # cannot reach, so they live in the Tier-B browser tier per the CLAUDE.md mandate.

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -551,10 +551,25 @@ def test_gateway_dnsbl_feed_suffix_policy_save_roundtrip(
     """
     page = browser_page
 
-    original_private = helpers.config_get(smoke_vm, _CFG_FEED_PRIVATE_POLICY) or "honor"
-    original_icann = helpers.config_get(smoke_vm, _CFG_FEED_ICANN_POLICY) or "honor"
+    # issue #1947: capture exact presence + raw token so the teardown restores the
+    # stored state VERBATIM (an absent key stays absent, never materialised 'honor').
+    original_private_state = helpers.config_get_state(smoke_vm, _CFG_FEED_PRIVATE_POLICY)
+    original_icann_state = helpers.config_get_state(smoke_vm, _CFG_FEED_ICANN_POLICY)
+    original_private = original_private_state[1] if original_private_state[0] else "honor"
+    original_icann = original_icann_state[1] if original_icann_state[0] else "honor"
     flipped_private = "apex" if original_private != "apex" else "honor"
     flipped_icann = "ignore" if original_icann != "ignore" else "honor"
+
+    # #2371 matrix row 15: pre-existing legacy keys must survive the saves
+    # byte-identically -- capture sentinel states up front.
+    legacy_sentinels = {
+        path: helpers.config_get_state(smoke_vm, path)
+        for path in (
+            "installedpackages/pfblockerngdnsblsettings/config/0/tld_wildcard",
+            "installedpackages/pfblockerngdnsblsettings/config/0/tld_allow",
+            "installedpackages/pfblockerngdnsblsettings/config/0/pfb_psl_include_private",
+        )
+    }
 
     try:
         # ---- FLIP: POST both selects to a non-default, DISTINCT value ---- #
@@ -623,14 +638,17 @@ def test_gateway_dnsbl_feed_suffix_policy_save_roundtrip(
         expect(sel_icann_restore).to_have_value(original_icann, timeout=JS_TIMEOUT_MS)
         _shot(page, screenshot_dir, "gateway_dnsbl_feed_suffix_policy_after_restore")
 
+        # Matrix row 15: the legacy sentinel keys are byte-identical after both saves.
+        for path, state in legacy_sentinels.items():
+            assert helpers.config_get_state(smoke_vm, path) == state, (
+                f"legacy key {path} changed across the feed-suffix-policy saves"
+            )
+
     finally:
-        # Belt-and-suspenders: restore both fields to their original stored token on any
-        # mid-flip abort (config_set writes the raw token verbatim -- both original
-        # values captured above are already-canonical PfbFeedSuffixPolicy tokens).
-        if helpers.config_get(smoke_vm, _CFG_FEED_PRIVATE_POLICY) != original_private:
-            helpers.config_set(smoke_vm, _CFG_FEED_PRIVATE_POLICY, original_private)
-        if helpers.config_get(smoke_vm, _CFG_FEED_ICANN_POLICY) != original_icann:
-            helpers.config_set(smoke_vm, _CFG_FEED_ICANN_POLICY, original_icann)
+        # issue #1947: restore the exact captured presence/raw state on any exit --
+        # an originally-absent key is deleted again, never left materialised.
+        helpers.config_restore_state(smoke_vm, _CFG_FEED_PRIVATE_POLICY, original_private_state)
+        helpers.config_restore_state(smoke_vm, _CFG_FEED_ICANN_POLICY, original_icann_state)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -130,6 +130,11 @@ PAGE_TABLE: tuple[Page, ...] = (
             "Recognize Shared-Hosting Suffixes (PSL PRIVATE)",
             "Allow Only Selected Domain Suffixes",
             "Allow Shared-Hosting Suffixes (PSL PRIVATE)",
+            # issue #2371 Step 3: the two feed-at-suffix policy selects render with
+            # their labels and (one representative) option text.
+            "Feed entries at shared-hosting suffixes (PSL PRIVATE)",
+            "Feed entries at public suffixes (ICANN)",
+            "Block the suffix apex only",
         ),
     ),
     # feeds.php is split into IPv4/IPv6/DNSBL ?type sub-tabs (ADR-16 Phase 3). Each type

--- a/tests/test_adr10_snapshot_equivalence.py
+++ b/tests/test_adr10_snapshot_equivalence.py
@@ -51,6 +51,9 @@ _CONTAINER_KEYS = frozenset(
         "tld_allow_roots",
         "psl_include_private",
         "psl_allow_private",
+        # issue #2371: feed-at-suffix PSL policy fields (plumbing only, no consumer yet).
+        "psl_feed_private_policy",
+        "psl_feed_icann_policy",
     }
 )
 
@@ -93,6 +96,9 @@ def _build(
 # One shared tuple: the equivalence proof compares container values with `is`,
 # and Python does not guarantee identity for equal tuple literals.
 _TLD_ALLOW_ROOTS = ("com", "net", "org")
+# issue #2371: shared for the same `is`-identity reason as _TLD_ALLOW_ROOTS above --
+# the equivalence proof compares container values with `is`, not `==`.
+_HONOR = "honor"
 
 
 def _snapshot_from_result(result: P.BuildResult, *, hsts: dict[str, Any] | None = None) -> P.Snapshot:
@@ -113,6 +119,8 @@ def _snapshot_from_result(result: P.BuildResult, *, hsts: dict[str, Any] | None 
         tld_allow_roots=_TLD_ALLOW_ROOTS,
         psl_include_private=True,
         psl_allow_private=False,
+        psl_feed_private_policy=_HONOR,
+        psl_feed_icann_policy=_HONOR,
     )
 
 
@@ -132,6 +140,8 @@ def _legacy_containers(result: P.BuildResult, *, hsts: dict[str, Any] | None = N
         "tld_allow_roots": _TLD_ALLOW_ROOTS,
         "psl_include_private": True,
         "psl_allow_private": False,
+        "psl_feed_private_policy": _HONOR,
+        "psl_feed_icann_policy": _HONOR,
     }
 
 

--- a/tests/test_adr10_snapshot_equivalence.py
+++ b/tests/test_adr10_snapshot_equivalence.py
@@ -51,7 +51,7 @@ _CONTAINER_KEYS = frozenset(
         "tld_allow_roots",
         "psl_include_private",
         "psl_allow_private",
-        # issue #2371: feed-at-suffix PSL policy fields (plumbing only, no consumer yet).
+        # issue #2371: feed-at-suffix PSL policy fields (enforced in build()).
         "psl_feed_private_policy",
         "psl_feed_icann_policy",
     }

--- a/tests/test_issue2371_feed_suffix_policy.py
+++ b/tests/test_issue2371_feed_suffix_policy.py
@@ -519,3 +519,13 @@ class TestPlainSuffixPolicyWithPrivateRecognitionOff:
         )
         assert "github.io" in result.zone_db
         assert _reject_row(result, feed="FEED", group="GRP").get("suffix_demote", 0) == 0
+
+    def test_private_honor_not_demoted_while_icann_policy_arms_the_gate(self) -> None:
+        # Mixed-policy axis: the entry's OWN section policy is honor, the OTHER
+        # section's non-honor value merely keeps the policy machinery active. A
+        # demotion guard that fires on any active policy (not the entry's own
+        # apex) would wrongly demote this classifier ZONE.
+        result = _run_build(["github.io"], private_policy="honor", icann_policy="apex", include_private=False)
+        assert "github.io" in result.zone_db
+        assert "github.io" not in result.data_db
+        assert _reject_row(result).get("suffix_demote", 0) == 0

--- a/tests/test_issue2371_feed_suffix_policy.py
+++ b/tests/test_issue2371_feed_suffix_policy.py
@@ -1,0 +1,480 @@
+"""Issue #2371 Step 2 -- enforce the feed-at-suffix PSL policy.
+
+Step 1 (commit 48130739 + 97b3a505) registered the two per-section policy fields
+(``psl_feed_private_policy`` / ``psl_feed_icann_policy``, tokens
+``ignore|apex|honor``) end to end from ini through ``Snapshot`` -- with no
+consumer. This file pins the Step-2 consumer: a FEED-provenance entry whose
+normalized name sits exactly at its winning public suffix is dropped
+(``ignore``), demoted from a wildcard ZONE to an exact-apex DATA block
+(``apex``), or left alone (``honor``), in BOTH emission paths (the plain
+``tld_wildcard_classify()`` loop and the ABP reconcile-fold loop in
+``build()``) -- FEED provenance only, USER (``Custom_List``/ABP) rules keep
+full power in every state. Every drop/demotion is tallied into
+``BuildResult.rejects`` under new ``'suffix_drop'`` / ``'suffix_demote'``
+buckets. A policy other than ``honor`` is also a third authority load gate in
+``_dnsbl_config_from_manifest()``, independent of Wildcard Blocking
+(``python_tld_wildcard``) / TLD-Allow.
+
+Pure pytest, stdlib only, no Unbound symbols (CI-runnable).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pfb_unbound as P
+
+# A small, self-contained PSL fixture (not the shipped file) exercising every
+# shape the coverage matrix needs: a PRIVATE exact suffix (github.io) whose
+# ICANN parent (io) differs; an ICANN exact two-label suffix (co.uk); an ICANN
+# wildcard family with a sibling exception (*.ck / !www.ck); and an IDNA
+# punycode ICANN apex (xn--p1ai).
+PSL = """// ===BEGIN ICANN DOMAINS===
+com
+io
+co.uk
+xn--p1ai
+*.ck
+!www.ck
+// ===END ICANN DOMAINS===
+// ===BEGIN PRIVATE DOMAINS===
+github.io
+// ===END PRIVATE DOMAINS===
+"""
+
+
+def _rules() -> P.PslRules:
+    return P.parse_psl_rules(PSL)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers: drive build() over a synthetic single-feed manifest + in-memory
+# line_reader (same idiom as tests/test_adr21_abp_per_line.py), with the PSL
+# rules + the two new policy fields threaded through the config blob.
+# --------------------------------------------------------------------------- #
+
+
+def _run_build(
+    lines: list[str],
+    *,
+    private_policy: str = "honor",
+    icann_policy: str = "honor",
+    provenance: str = "feed",
+    feed: str = "FEED",
+    group: str = "GRP",
+    log_flag: str = "1",
+    psl_wildcard_enabled: bool = True,
+) -> P.BuildResult:
+    raw_key = "feed.raw"
+    manifest = {
+        "feeds": [
+            {
+                "feed": feed,
+                "group": group,
+                "log_flag": log_flag,
+                "provenance": provenance,
+                "raw": raw_key,
+            }
+        ]
+    }
+    config: dict[str, Any] = {
+        "psl_rules": _rules(),
+        "psl_wildcard_enabled": psl_wildcard_enabled,
+        "tld_wildcard_blacklist": [],
+        "tld_wildcard_exclusion": [],
+        "user_whitelist": [],
+        "psl_feed_private_policy": private_policy,
+        "psl_feed_icann_policy": icann_policy,
+    }
+
+    def reader(raw: str) -> list[str]:
+        assert raw == raw_key
+        return list(lines)
+
+    return P.build(manifest, config, line_reader=reader)
+
+
+def _block_payload(result: P.BuildResult, domain: str) -> dict[str, Any]:
+    if domain in result.zone_db:
+        return result.zone_db[domain]
+    return result.data_db[domain]
+
+
+def _reject_row(result: P.BuildResult, feed: str = "FEED", group: str = "GRP") -> dict[str, int]:
+    return result.rejects.get((feed, group), {})
+
+
+# --------------------------------------------------------------------------- #
+# Unit tests for the suffix predicate itself, incl. hostile inputs.
+# --------------------------------------------------------------------------- #
+
+
+class TestSuffixFeedPolicyPredicate:
+    def test_private_apex_returns_private_policy(self) -> None:
+        assert P._dnsbl_suffix_feed_policy("github.io", _rules(), "ignore", "apex") == "ignore"
+
+    def test_icann_apex_returns_icann_policy(self) -> None:
+        assert P._dnsbl_suffix_feed_policy("co.uk", _rules(), "ignore", "apex") == "apex"
+
+    def test_wildcard_derived_boundary_is_at_boundary(self) -> None:
+        """Hostile input: foo.ck sits one label under the *.ck wildcard family --
+        it IS the winning public suffix (at-boundary), even though 'ck' itself
+        carries no explicit PSL rule."""
+        assert P._dnsbl_suffix_feed_policy("foo.ck", _rules(), "x", "ignore") == "ignore"
+
+    def test_exception_carved_name_is_not_at_boundary(self) -> None:
+        """Hostile input: www.ck resolves via the !www.ck exception to public
+        suffix 'ck' -- www.ck (2 labels) != 'ck' (1 label), so it is a
+        registrable domain under the suffix, never the suffix itself."""
+        assert P._dnsbl_suffix_feed_policy("www.ck", _rules(), "ignore", "ignore") is None
+
+    def test_bare_tld_in_exception_bearing_family_resolves_icann_section(self) -> None:
+        """The exception-carved family's own bare TLD ('ck') falls back to
+        itself (no explicit rule) and resolves ICANN (private_active False),
+        proving the exception sibling never leaks PRIVATE section on it."""
+        assert P._dnsbl_suffix_feed_policy("ck", _rules(), "x", "ignore") == "ignore"
+
+    def test_punycode_apex_is_at_boundary(self) -> None:
+        assert P._dnsbl_suffix_feed_policy("xn--p1ai", _rules(), "x", "apex") == "apex"
+
+    def test_invalid_name_is_not_at_boundary(self) -> None:
+        """Hostile input: a name normalise() already accepted (underscore is a
+        valid DNSBL label char, #723) but _psl_normalize_name() rejects (IDNA
+        charset) -- ValueError is caught, never propagated, and treated as
+        'not at a boundary' (normal handling)."""
+        assert P._dnsbl_suffix_feed_policy("foo_bar.com", _rules(), "ignore", "ignore") is None
+
+    def test_non_suffix_registrable_is_not_at_boundary(self) -> None:
+        assert P._dnsbl_suffix_feed_policy("example.com", _rules(), "ignore", "ignore") is None
+
+    def test_deep_subdomain_is_not_at_boundary(self) -> None:
+        assert P._dnsbl_suffix_feed_policy("a.b.example.github.io", _rules(), "ignore", "ignore") is None
+
+
+# --------------------------------------------------------------------------- #
+# Row 1 / 3: plain feed entry AT a suffix, PRIVATE and ICANN sections.
+# --------------------------------------------------------------------------- #
+
+
+class TestPlainSuffixPolicy:
+    def test_private_ignore_drops_and_tallies(self) -> None:
+        result = _run_build(["github.io"], private_policy="ignore", icann_policy="honor")
+        assert "github.io" not in result.data_db
+        assert "github.io" not in result.zone_db
+        assert _reject_row(result)["suffix_drop"] == 1
+
+    def test_private_apex_is_exact_data(self) -> None:
+        result = _run_build(["github.io"], private_policy="apex", icann_policy="honor")
+        assert result.data_db["github.io"]["band"] == P.PRIO_FEED_BLOCK
+        assert "github.io" not in result.zone_db
+        assert _reject_row(result).get("suffix_demote", 0) == 0
+
+    def test_private_honor_is_exact_data(self) -> None:
+        result = _run_build(["github.io"], private_policy="honor", icann_policy="honor")
+        assert "github.io" in result.data_db
+        assert "github.io" not in result.zone_db
+
+    def test_icann_ignore_drops_and_tallies(self) -> None:
+        result = _run_build(["co.uk"], private_policy="honor", icann_policy="ignore")
+        assert "co.uk" not in result.data_db
+        assert "co.uk" not in result.zone_db
+        assert _reject_row(result)["suffix_drop"] == 1
+
+    def test_icann_apex_is_exact_data(self) -> None:
+        result = _run_build(["co.uk"], private_policy="honor", icann_policy="apex")
+        assert "co.uk" in result.data_db
+        assert "co.uk" not in result.zone_db
+
+    def test_icann_honor_is_exact_data(self) -> None:
+        result = _run_build(["co.uk"], private_policy="honor", icann_policy="honor")
+        assert "co.uk" in result.data_db
+        assert "co.uk" not in result.zone_db
+
+
+# --------------------------------------------------------------------------- #
+# Row 2 / 4: ABP explicit wildcard anchor AT a suffix, PRIVATE and ICANN.
+# --------------------------------------------------------------------------- #
+
+
+class TestAbpSuffixPolicy:
+    def test_private_ignore_drops_and_tallies(self) -> None:
+        result = _run_build(["||github.io^"], private_policy="ignore", icann_policy="honor")
+        assert "github.io" not in result.data_db
+        assert "github.io" not in result.zone_db
+        assert _reject_row(result)["suffix_drop"] == 1
+
+    def test_private_apex_demotes_zone_to_data_and_tallies(self) -> None:
+        result = _run_build(["||github.io^$important"], private_policy="apex", icann_policy="honor")
+        assert "github.io" not in result.zone_db
+        payload = result.data_db["github.io"]
+        # band/important/log preserved across the demotion (only cls changes).
+        assert payload["important"] is True
+        assert payload["log"] == "1"
+        assert _reject_row(result)["suffix_demote"] == 1
+
+    def test_private_honor_stays_wildcard_zone(self) -> None:
+        result = _run_build(["||github.io^"], private_policy="honor", icann_policy="honor")
+        assert "github.io" in result.zone_db
+        assert "github.io" not in result.data_db
+
+    def test_icann_ignore_drops_and_tallies(self) -> None:
+        result = _run_build(["||co.uk^"], private_policy="honor", icann_policy="ignore")
+        assert "co.uk" not in result.data_db
+        assert "co.uk" not in result.zone_db
+        assert _reject_row(result)["suffix_drop"] == 1
+
+    def test_icann_apex_demotes_zone_to_data_and_tallies(self) -> None:
+        result = _run_build(["||co.uk^"], private_policy="honor", icann_policy="apex")
+        assert "co.uk" not in result.zone_db
+        assert "co.uk" in result.data_db
+        assert _reject_row(result)["suffix_demote"] == 1
+
+    def test_icann_honor_stays_wildcard_zone(self) -> None:
+        result = _run_build(["||co.uk^"], private_policy="honor", icann_policy="honor")
+        assert "co.uk" in result.zone_db
+        assert "co.uk" not in result.data_db
+
+
+# --------------------------------------------------------------------------- #
+# Row 5: the WINNING rule's section governs, not a fixed per-domain guess.
+# --------------------------------------------------------------------------- #
+
+
+class TestWinningRuleSectionSelectsPolicy:
+    def test_private_rule_beats_icann_parent(self) -> None:
+        # github.io's PRIVATE rule wins over its ICANN parent 'io' -- the
+        # PRIVATE policy governs, the ICANN policy must be irrelevant here.
+        result = _run_build(["github.io"], private_policy="ignore", icann_policy="apex")
+        assert "github.io" not in result.data_db
+        assert "github.io" not in result.zone_db
+
+    def test_exception_fallback_name_uses_icann_policy(self) -> None:
+        # 'ck' resolves ICANN (private_active False) in a ruleset that carries
+        # a sibling exception (!www.ck) -- the ICANN policy governs.
+        result = _run_build(["ck"], private_policy="honor", icann_policy="ignore")
+        assert "ck" not in result.data_db
+        assert "ck" not in result.zone_db
+
+
+# --------------------------------------------------------------------------- #
+# Row 6: USER (Custom_List / sovereign ABP) provenance is exempt in EVERY state.
+# --------------------------------------------------------------------------- #
+
+
+class TestUserProvenanceSovereignty:
+    def test_user_plain_entry_never_dropped_or_demoted(self) -> None:
+        result = _run_build(["github.io"], private_policy="ignore", icann_policy="ignore", provenance="user")
+        assert "github.io" in result.data_db
+        assert _reject_row(result, feed="FEED", group="GRP").get("suffix_drop", 0) == 0
+
+    def test_user_abp_wildcard_never_dropped_or_demoted(self) -> None:
+        result = _run_build(["||github.io^"], private_policy="ignore", icann_policy="ignore", provenance="user")
+        assert "github.io" in result.zone_db
+        assert "github.io" not in result.data_db
+        assert _reject_row(result).get("suffix_drop", 0) == 0
+        assert _reject_row(result).get("suffix_demote", 0) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Row 7: non-suffix names are classification-byte-identical under a
+# restrictive policy vs. honor/honor -- the SAME corpus run twice.
+# --------------------------------------------------------------------------- #
+
+
+class TestNonSuffixNamesUnaffected:
+    _CORPUS = [
+        "example.com",  # registrable under a two-label-absent (fallback) suffix -> ZONE
+        "a.b.example.github.io",  # deep subdomain under a PRIVATE suffix -> DATA
+        "sub.co.uk",  # registrable under the ICANN suffix co.uk -> ZONE
+    ]
+
+    def test_plain_corpus_identical_under_restrictive_and_honor(self) -> None:
+        honor = _run_build(list(self._CORPUS), private_policy="honor", icann_policy="honor")
+        restrictive = _run_build(list(self._CORPUS), private_policy="ignore", icann_policy="ignore")
+        assert restrictive.data_db == honor.data_db
+        assert restrictive.zone_db == honor.zone_db
+        assert restrictive.rejects == honor.rejects
+
+    def test_abp_corpus_identical_under_restrictive_and_honor(self) -> None:
+        lines = [f"||{d}^" for d in self._CORPUS]
+        honor = _run_build(lines, private_policy="honor", icann_policy="honor")
+        restrictive = _run_build(lines, private_policy="apex", icann_policy="apex")
+        assert restrictive.data_db == honor.data_db
+        assert restrictive.zone_db == honor.zone_db
+
+
+# --------------------------------------------------------------------------- #
+# Row 8: Wildcard Blocking OFF -- ABP zones exist independently (#1255);
+# policy must still apply, using the (raw) loaded PSL rules regardless of the
+# classifier's own psl_wildcard_enabled gate.
+# --------------------------------------------------------------------------- #
+
+
+class TestWildcardBlockingOffPolicyStillApplies:
+    def test_apex_demotes_with_wildcard_blocking_off(self) -> None:
+        result = _run_build(["||co.uk^"], private_policy="honor", icann_policy="apex", psl_wildcard_enabled=False)
+        assert "co.uk" not in result.zone_db
+        assert "co.uk" in result.data_db
+
+    def test_ignore_drops_with_wildcard_blocking_off(self) -> None:
+        result = _run_build(["||co.uk^"], private_policy="honor", icann_policy="ignore", psl_wildcard_enabled=False)
+        assert "co.uk" not in result.zone_db
+        assert "co.uk" not in result.data_db
+        assert _reject_row(result)["suffix_drop"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Row 9 / 10: the third authority load gate.
+# --------------------------------------------------------------------------- #
+
+
+def _manifest(path: Path, *, authority_text: str | bytes) -> tuple[Path, Path]:
+    authority = path / "dnsbl_psl"
+    if isinstance(authority_text, bytes):
+        authority.write_bytes(authority_text)
+    else:
+        authority.write_text(authority_text, encoding="utf-8")
+    raw = path / "feed.raw"
+    raw.write_text("example.com\n", encoding="utf-8")
+    manifest = path / "pfb_py_sources.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "feeds": [{"raw": raw.name, "feed": "feed", "group": "group", "log_flag": "1"}],
+                "config": {"tld_wildcard_blacklist": [], "tld_wildcard_exclusion": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest, authority
+
+
+class TestLoadGate:
+    def test_policy_alone_opens_the_authority(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        manifest, authority = _manifest(tmp_path, authority_text=PSL)
+        monkeypatch.setitem(P.pfb, "pfb_py_psl", str(authority))
+        monkeypatch.setitem(P.pfb, "python_tld_wildcard", False)
+        monkeypatch.setitem(P.pfb, "tld_allow", False)
+        monkeypatch.setitem(P.pfb, "psl_feed_private_policy", "apex")
+        monkeypatch.setitem(P.pfb, "psl_feed_icann_policy", "honor")
+
+        result = P.dnsbl_build_from_manifest(str(manifest))
+
+        assert result is not None
+        assert result.psl_rules.private_exact == ("github.io",)
+
+    def test_policy_alone_fails_closed_on_corrupt_authority(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest, authority = _manifest(tmp_path, authority_text=b"\xff")
+        monkeypatch.setitem(P.pfb, "pfb_py_psl", str(authority))
+        monkeypatch.setitem(P.pfb, "python_tld_wildcard", False)
+        monkeypatch.setitem(P.pfb, "tld_allow", False)
+        monkeypatch.setitem(P.pfb, "psl_feed_private_policy", "ignore")
+        monkeypatch.setitem(P.pfb, "psl_feed_icann_policy", "honor")
+
+        assert P.dnsbl_build_from_manifest(str(manifest)) is None
+
+    def test_both_honor_and_both_old_gates_off_never_opens_authority(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Extends the existing "not opened while OFF" idiom
+        # (test_psl_authority_loader_off_is_exact_only_without_open) up through
+        # the composed three-gate expression in _dnsbl_config_from_manifest(),
+        # rather than the lower-level _load_psl_authority() call alone.
+        manifest, authority = _manifest(tmp_path, authority_text=PSL)
+        monkeypatch.setitem(P.pfb, "pfb_py_psl", str(authority))
+        monkeypatch.setitem(P.pfb, "python_tld_wildcard", False)
+        monkeypatch.setitem(P.pfb, "tld_allow", False)
+        monkeypatch.setitem(P.pfb, "psl_feed_private_policy", "honor")
+        monkeypatch.setitem(P.pfb, "psl_feed_icann_policy", "honor")
+
+        def guarded_open(path: Any, *a: Any, **k: Any) -> Any:
+            # Only the AUTHORITY path must stay unopened -- the manifest JSON
+            # itself (and the feed raw it references) legitimately opens.
+            if str(path) == str(authority):
+                pytest.fail("authority opened with both gates off and honor/honor")
+            return open(path, *a, **k)  # noqa: SIM115 -- delegating wrapper, not a leak
+
+        monkeypatch.setattr(P, "open", guarded_open, raising=False)
+
+        result = P.dnsbl_build_from_manifest(str(manifest))
+
+        assert result is not None
+        assert result.psl_rules == P.PslRules()
+
+
+# --------------------------------------------------------------------------- #
+# Row 11: tally -- ignore-drop and apex-demote counted under the right
+# bucket + (feed, group); honor tallies nothing new.
+# --------------------------------------------------------------------------- #
+
+
+class TestRejectTally:
+    def test_honor_tallies_nothing_new(self) -> None:
+        result = _run_build(["github.io", "||co.uk^"], private_policy="honor", icann_policy="honor")
+        assert result.rejects == {}
+
+    def test_drop_and_demote_attributed_per_feed_group(self) -> None:
+        result = _run_build(
+            ["github.io", "||co.uk^"],
+            private_policy="ignore",
+            icann_policy="apex",
+            feed="MyFeed",
+            group="MyGroup",
+        )
+        row = result.rejects[("MyFeed", "MyGroup")]
+        assert row["suffix_drop"] == 1
+        assert row["suffix_demote"] == 1
+
+    def test_reject_stats_writer_emits_new_buckets(self, tmp_path: Path) -> None:
+        out = tmp_path / "pfb_py_reject_stats.json"
+        tally = {("F", "G"): {"shape": 0, "wire_cap": 0, "suffix_drop": 2, "suffix_demote": 1}}
+        assert P.dnsbl_emit_reject_stats(str(out), tally) is True
+        written = json.loads(out.read_text())
+        assert written == [{"feed": "F", "group": "G", "shape": 0, "wire_cap": 0, "suffix_drop": 2, "suffix_demote": 1}]
+
+    def test_reject_stats_writer_row_shape_unchanged_for_legacy_buckets(self, tmp_path: Path) -> None:
+        """The pre-#2371 2-key row shape must stay byte-identical when only
+        shape/wire_cap ever fired for that (feed, group) -- no gratuitous
+        suffix_drop:0 / suffix_demote:0 padding on every row."""
+        out = tmp_path / "pfb_py_reject_stats.json"
+        tally = {("RejFeed", "RejGroup"): {"shape": 3, "wire_cap": 5}}
+        assert P.dnsbl_emit_reject_stats(str(out), tally) is True
+        written = json.loads(out.read_text())
+        assert written == [{"feed": "RejFeed", "group": "RejGroup", "shape": 3, "wire_cap": 5}]
+
+
+# --------------------------------------------------------------------------- #
+# Row 12: ABP allow/regex rules and allow_domains at suffix-shaped names are
+# untouched -- policy governs BLOCK emission only.
+# --------------------------------------------------------------------------- #
+
+
+class TestAllowAndRegexUntouched:
+    def test_allow_rule_at_suffix_survives_ignore(self) -> None:
+        result = _run_build(["||github.io^", "@@||github.io^"], private_policy="ignore", icann_policy="ignore")
+        # The BLOCK anchor was dropped by policy...
+        assert "github.io" not in result.data_db
+        assert "github.io" not in result.zone_db
+        # ...but the ALLOW anchor at the exact same suffix name is untouched.
+        assert "github.io" in result.white_db
+
+    def test_irreducible_regex_at_suffix_shape_survives_ignore(self) -> None:
+        # An irreducible pattern (alternation) never folds into block_domains,
+        # so it never reaches the suffix-policy check at all.
+        result = _run_build(["/(a|b)\\.github\\.io$/"], private_policy="ignore", icann_policy="ignore")
+        assert len(result.regex_db) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Row 13: #1541 regression pins stay green -- exercised via the shared suites
+# in the verification command list (test_pfb_unbound.py suffix-apex classes,
+# test_adr21_abp_per_line.py, test_adr31_precedence_oracle.py), not restated
+# here.
+# --------------------------------------------------------------------------- #

--- a/tests/test_issue2371_feed_suffix_policy.py
+++ b/tests/test_issue2371_feed_suffix_policy.py
@@ -68,6 +68,7 @@ def _run_build(
     group: str = "GRP",
     log_flag: str = "1",
     psl_wildcard_enabled: bool = True,
+    include_private: bool = True,
 ) -> P.BuildResult:
     raw_key = "feed.raw"
     manifest = {
@@ -84,6 +85,7 @@ def _run_build(
     config: dict[str, Any] = {
         "psl_rules": _rules(),
         "psl_wildcard_enabled": psl_wildcard_enabled,
+        "psl_include_private": include_private,
         "tld_wildcard_blacklist": [],
         "tld_wildcard_exclusion": [],
         "user_whitelist": [],
@@ -473,8 +475,47 @@ class TestAllowAndRegexUntouched:
 
 
 # --------------------------------------------------------------------------- #
-# Row 13: #1541 regression pins stay green -- exercised via the shared suites
-# in the verification command list (test_pfb_unbound.py suffix-apex classes,
-# test_adr21_abp_per_line.py, test_adr31_precedence_oracle.py), not restated
-# here.
+# The #1541 apex/ABP-anchor invariants live in test_pfb_unbound.py's
+# suffix-apex classes, test_adr21_abp_per_line.py, and
+# test_adr31_precedence_oracle.py; this file adds only the policy axis.
 # --------------------------------------------------------------------------- #
+
+
+# --------------------------------------------------------------------------- #
+# PR #2378 review F1: PRIVATE recognition OFF must not let 'apex' leak a ZONE.
+# --------------------------------------------------------------------------- #
+
+
+class TestPlainSuffixPolicyWithPrivateRecognitionOff:
+    """With PSL PRIVATE recognition OFF the classifier's ICANN-only view sees a
+    PRIVATE apex as a registrable domain and would wildcard it. The policy's
+    view is the FULL PSL, so 'apex' demotes that would-be ZONE to an exact apex
+    block; 'ignore' still drops; 'honor' keeps the classifier's outcome."""
+
+    def test_private_apex_demotes_classifier_zone_and_tallies(self) -> None:
+        result = _run_build(["github.io"], private_policy="apex", icann_policy="honor", include_private=False)
+        assert "github.io" not in result.zone_db
+        assert result.data_db["github.io"]["band"] == P.PRIO_FEED_BLOCK
+        assert _reject_row(result)["suffix_demote"] == 1
+
+    def test_private_ignore_still_drops_and_tallies(self) -> None:
+        result = _run_build(["github.io"], private_policy="ignore", icann_policy="honor", include_private=False)
+        assert "github.io" not in result.data_db
+        assert "github.io" not in result.zone_db
+        assert _reject_row(result)["suffix_drop"] == 1
+
+    def test_private_honor_keeps_classifier_zone(self) -> None:
+        result = _run_build(["github.io"], private_policy="honor", icann_policy="honor", include_private=False)
+        assert "github.io" in result.zone_db
+        assert _reject_row(result).get("suffix_demote", 0) == 0
+
+    def test_user_provenance_keeps_zone_even_under_apex(self) -> None:
+        result = _run_build(
+            ["github.io"],
+            private_policy="apex",
+            icann_policy="apex",
+            include_private=False,
+            provenance="user",
+        )
+        assert "github.io" in result.zone_db
+        assert _reject_row(result, feed="FEED", group="GRP").get("suffix_demote", 0) == 0

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -10,6 +10,7 @@ from configparser import ConfigParser
 from typing import Any
 
 import pytest
+import unboundmodule
 
 # Unbound injects these as module-level globals at runtime; conftest copies them
 # from the unboundmodule stub onto builtins so pfb_unbound (which references them
@@ -3334,6 +3335,70 @@ class TestParseIniInt:
         parsed = _parse_ini_int(config, "MAIN", "python_tld_seg")
         result = parsed if parsed is not None else current_default
         assert result == 9, f"expected 9, got {result!r}"
+
+
+class TestFeedSuffixPolicyIniRead:
+    """issue #2371: init_standard()'s MAIN-section reads for psl_feed_private_policy /
+    psl_feed_icann_policy. Drives the PRODUCTION boundary (a real ini file +
+    init_standard()) rather than a copied implementation, mirroring
+    test_adr28_cfg_adapters.py's _production_boundary helper for idn_mode."""
+
+    def _read(self, tmp_path: Any, monkeypatch: Any, **options: str) -> tuple[str, str]:
+        lines = ["[MAIN]", "python_enable = false"]
+        for key, value in options.items():
+            lines.append(f"{key} = {value}")
+        (tmp_path / "pfb_unbound.ini").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        pfb_unbound.pfb["mod_maxminddb_e"] = "stub"
+        try:
+            assert pfb_unbound.init_standard(0, unboundmodule.module_env()) is True
+            return (
+                pfb_unbound.pfb["psl_feed_private_policy"],
+                pfb_unbound.pfb["psl_feed_icann_policy"],
+            )
+        finally:
+            pfb_unbound.deinit(0)
+
+    def test_absent_options_default_honor(self, tmp_path: Any, monkeypatch: Any) -> None:
+        private, icann = self._read(tmp_path, monkeypatch)
+        assert private == "honor"
+        assert icann == "honor"
+
+    def test_each_canonical_value_round_trips(self, tmp_path: Any, monkeypatch: Any) -> None:
+        for value in ("ignore", "apex", "honor"):
+            private, icann = self._read(
+                tmp_path, monkeypatch, psl_feed_private_policy=value, psl_feed_icann_policy=value
+            )
+            assert private == value
+            assert icann == value
+
+    def test_independent_per_section_values(self, tmp_path: Any, monkeypatch: Any) -> None:
+        private, icann = self._read(
+            tmp_path, monkeypatch, psl_feed_private_policy="ignore", psl_feed_icann_policy="apex"
+        )
+        assert private == "ignore"
+        assert icann == "apex"
+
+    def test_empty_value_defaults_honor(self, tmp_path: Any, monkeypatch: Any) -> None:
+        private, icann = self._read(tmp_path, monkeypatch, psl_feed_private_policy="", psl_feed_icann_policy="")
+        assert private == "honor"
+        assert icann == "honor"
+
+    def test_garbage_value_defaults_honor(self, tmp_path: Any, monkeypatch: Any) -> None:
+        private, icann = self._read(
+            tmp_path, monkeypatch, psl_feed_private_policy="BOGUS", psl_feed_icann_policy="also-bogus"
+        )
+        assert private == "honor"
+        assert icann == "honor"
+
+    def test_uppercase_canonical_value_is_normalised(self, tmp_path: Any, monkeypatch: Any) -> None:
+        # Hostile-input row: 'APEX' must not be silently accepted as a different token,
+        # nor rejected -- it is the recognised value, case-folded, same as idn_mode's read.
+        private, icann = self._read(
+            tmp_path, monkeypatch, psl_feed_private_policy="APEX", psl_feed_icann_policy="IGNORE"
+        )
+        assert private == "apex"
+        assert icann == "ignore"
 
 
 class TestResolveFeedGroup:

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -271,12 +271,27 @@ def test_snapshot_containers_capture_psl_policy_without_global_reads() -> None:
         tld_allow_roots=("io",),
         psl_include_private=False,
         psl_allow_private=True,
+        # issue #2371: feed-at-suffix PSL policy fields (plumbing only, no consumer yet).
+        psl_feed_private_policy="ignore",
+        psl_feed_icann_policy="apex",
     )
     containers = snapshot.containers()
     assert containers["psl_rules"] is rules
     assert containers["tld_allow_roots"] == ("io",)
     assert containers["psl_include_private"] is False
     assert containers["psl_allow_private"] is True
+    assert containers["psl_feed_private_policy"] == "ignore"
+    assert containers["psl_feed_icann_policy"] == "apex"
+
+
+def test_snapshot_feed_suffix_policy_defaults_honor_for_legacy_fixtures() -> None:
+    """issue #2371: a Snapshot built the pre-#2371 way (no policy kwargs -- every legacy
+    hand-built fixture in this suite) must default both new fields to "honor", never
+    KeyError or silently pick a stricter state."""
+    snapshot = P.Snapshot({}, {}, {}, {}, {}, {}, {})
+    containers = snapshot.containers()
+    assert containers["psl_feed_private_policy"] == "honor"
+    assert containers["psl_feed_icann_policy"] == "honor"
 
 
 def test_snapshot_empty_tld_allow_roots_ignore_later_global_selection(

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -271,7 +271,7 @@ def test_snapshot_containers_capture_psl_policy_without_global_reads() -> None:
         tld_allow_roots=("io",),
         psl_include_private=False,
         psl_allow_private=True,
-        # issue #2371: feed-at-suffix PSL policy fields (plumbing only, no consumer yet).
+        # issue #2371: feed-at-suffix PSL policy fields (enforced in build()).
         psl_feed_private_policy="ignore",
         psl_feed_icann_policy="apex",
     )


### PR DESCRIPTION
## Summary

Implements the per-section policy for automated feed entries at public-suffix boundaries, per the issue packet (design settled with the owner on the PR #2363 review thread and the 2026-08-14 session).

- **Model.** Two gateway-backed selects, one per PSL section — *Feed entries at shared-hosting suffixes (PSL PRIVATE)* and *Feed entries at public suffixes (ICANN)* — each with three states applying to FEED-provenance rules whose name resolves to a public suffix of that section: **Ignore entirely** (entry dropped, tallied), **Block the suffix apex only** (plain entries and explicit ABP wildcards demoted to an exact apex block, demotions tallied), **Honor list rules** (today's behavior: plain entries block the apex, explicit ABP wildcards blanket the suffix). Plain entries are never wildcard-promoted in any state — the #1541 invariant stands. User-defined lists are sovereign in every state; intentional whole-suffix blocking remains a dotted TLD Blacklist entry.
- **Defaults and grandfathering (owner decision, 2026-08-14).** Fresh installs seed **apex/apex**; existing installs read absent keys as **honor/honor** — byte-identical upgrade behavior. This is an owner-authorized exception to the closed grandfather set. The seed runs outside the migration registry: seeding through `pfb_migration_registry()` would flip the section's NEWCFG/OLDCFG mode and corrupt sibling fresh-install defaults — a pre-existing instance of that bug class was found and reproduced during this work and is tracked as #2372. Freshness is captured before any migration mutates the section and the seed applies after the registry pass, with an ordering regression guard.
- **Enforcement.** One suffix predicate (a name equals its winning public suffix; the winning rule's section picks the policy) applied at both emission points — the plain classification loop and the ABP `block_domains` fold. Demotion preserves band, importance, logging, and attribution. A third authority load gate opens `dnsbl_psl` whenever either policy is not `honor`, even with Wildcard Blocking off (ABP zones exist independently, #1255); missing or corrupt authority fails closed exactly as #1541 specifies. `suffix_drop`/`suffix_demote` ride the rejects ledger per feed/group, sparse (pre-existing row shapes stay byte-identical), and surface through the existing reject-stats emission.
- **UI/docs.** The selects sit in the DNSBL settings section, ungated by any toggle (their effect is feed-wide); help text is outcome-based, never uses the word "suppression" (reserved for the alert Suppression feature), and states that PSL PRIVATE means shared domains such as `github.io`, not private DNS. The DNSBL/ABP pipeline architecture notes document the mechanism.

## Verification

- Each step carried an executed, frozen red→green proof and an independent verifier gate: Step 1 (fields/seed/ini/Snapshot/fingerprint) passed after one corrected re-run — the verifier's killer mutation exposed a PHPUnit-undiscovered test class, which now runs in CI and gates the install-ordering contract; Step 2 (enforcement) passed with 8/8 verifier mutations killed and a build-time perf probe (20k entries, active-vs-honor ratio 1.65×, O(labels) predicate reusing the indexed matcher); Step 3 (UI/docs) passed red→green on the page-contract tests.
- Full pytest, PHPUnit, phpstan, phpcs, ruff, mypy, markdownlint green via the canonical gate runner at every step.
- Tier-A render markers and the Tier-B save-roundtrip browser test are authored in this PR; their first execution is this PR's UI CI leg.

Fixes #2371

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

https://claude.ai/code/session_0139YoJ3mEXqeNfS5LNnfE3K


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate feed-at-suffix policies for ICANN and private suffixes.
  * Choose whether matching feed entries are honored, limited to the suffix apex, or ignored.
  * Added explanatory settings and support for independent policy configuration.
  * Fresh installations default both policies to blocking the suffix apex, while existing installations retain current behavior.
* **Improvements**
  * Reject statistics now distinguish suffix entries that are dropped or demoted.
  * Policy changes are reflected when DNSBL configuration reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->