### PR TITLE
fix(pkg-repo): publish client scripts on a catalogue no-op

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1135,7 +1135,11 @@ Full design: ADR-39.
   Deployment is atomic per run: `publish-pkg-repo.sh` stages ONLY the touched
   `(channel, varver)` dirs (never `git add -A`) and aborts before any git mutation on a
   publisher failure, so a partial or failed run cannot erase another channel
-  (pinned by `tests/shell/publish_pkg_repo_spec.sh`). Trust model is unchanged
+  (pinned by `tests/shell/publish_pkg_repo_spec.sh`). On a catalogue no-op it still
+  regenerates the two deterministic client scripts (`gen_landing.py
+  --client-scripts-only`) and commits exactly `docs/add-repo.sh` +
+  `docs/migrate-channel.sh` iff their bytes drifted (issue #2408) — the timestamped
+  landing/browse/autoindex pages remain publish-only. Trust model is unchanged
   (`signature_type: none`, HTTPS/TLS to the Pages host — no catalogue-signing key); the landing
   page (`scripts/gen_landing.py`) documents the channel audiences, shared-bytes fan-out,
   single-repository subscription, and the explicit repository-qualified downgrade rule. The

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -1164,7 +1164,21 @@ def main(argv: list[str] | None = None) -> int:
         "php_version, py_flavor}) — splits the packages table by pfSense edition. Omitted -> "
         "a single 'Other builds' table from manifest data.",
     )
+    ap.add_argument(
+        "--client-scripts-only",
+        action="store_true",
+        help="write only the two deterministic client scripts (add-repo.sh, "
+        "migrate-channel.sh); no landing/browse/autoindex pages. Used by "
+        "publish-pkg-repo.sh's catalogue-NOOP path (issue #2408) — the pages embed a "
+        "generation timestamp, so writing them there would manufacture a commit on "
+        "every run.",
+    )
     args = ap.parse_args(argv)
+    if args.client_scripts_only:
+        write_add_repo(args.site, args.add_repo)
+        write_migrate_channel(args.site, args.add_repo)
+        print("client scripts written: add-repo.sh, migrate-channel.sh")
+        return 0
     matrix = None
     if args.matrix:
         with open(args.matrix) as fh:

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -1175,6 +1175,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = ap.parse_args(argv)
     if args.client_scripts_only:
+        if args.matrix:
+            ap.error("--client-scripts-only writes no landing page — --matrix cannot apply")
         write_add_repo(args.site, args.add_repo)
         write_migrate_channel(args.site, args.add_repo)
         print("client scripts written: add-repo.sh, migrate-channel.sh")

--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -20,7 +20,8 @@
 # is `exit 1` on the spot, before any git add ever runs. There is no
 # `git add -A` / `git add .` anywhere below — only the exact touched (channel,
 # varver) directories the publisher reports, plus the landing page's own
-# output and docs/.nojekyll.
+# output and docs/.nojekyll; on a catalogue no-op, only the two regenerated
+# client scripts (issue #2408).
 #
 # On a rejected push (another run advanced origin/main first), the ENTIRE cycle
 # reruns from a fresh sync — not a rebase of the local commit — because
@@ -155,83 +156,107 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
     trap - EXIT
     rm -f "$out_file"
 
+    script_refresh=0
     if [ -z "$touched" ]; then
-        echo "publish-pkg-repo: NOOP — nothing touched, nothing to commit."
-        exit 0
-    fi
+        # --- catalogue unchanged: the client scripts may still have drifted ---
+        # docs/add-repo.sh and docs/migrate-channel.sh are generated from the
+        # PFB_SRC checkout, not from the release assets, so a script-only fix
+        # must ship even when every destination already matches (issue #2408).
+        # Only the deterministic script pair is regenerated here — the
+        # landing/browse/autoindex pages embed a generation timestamp, and
+        # writing them on a no-op would manufacture a commit on every run.
+        python3 "${PFB_SRC}/scripts/gen_landing.py" \
+            "${PKG_REPO}/docs" "$BASE_URL" "${PFB_SRC}/scripts/add-repo.sh" \
+            --client-scripts-only
+        git -C "$PKG_REPO" add -- docs/add-repo.sh docs/migrate-channel.sh
+        if git -C "$PKG_REPO" diff --cached --quiet; then
+            echo "publish-pkg-repo: NOOP — nothing touched, nothing to commit."
+            exit 0
+        fi
+        echo "publish-pkg-repo: catalogue unchanged — client script(s) drifted; committing a script refresh."
+        script_refresh=1
+    else
+        # --- landing page regen — only for an actual publish ---------------
+        # Never on the catalogue-NOOP path above: gen_landing.py's page output
+        # embeds a generation timestamp, so running it there would manufacture
+        # a diff (and therefore a commit) on every run even when no catalogue
+        # changed.
+        #
+        # landing_matrix.json's abi expression (pinned by
+        # tests/shell/publish_pkg_repo_spec.sh): freebsd_major alone feeds the
+        # CPU-wildcarded ABI string. The retired `arch` matrix field is never
+        # interpolated — every published .pkg is NO_ARCH, so the honest ABI is the
+        # wildcard the packages themselves carry, never a per-arch value. The two
+        # modes share this ONE transform, differing only in the matrix array's
+        # source: tagged's pinned $ROUTE_MATRIX, nightly's own handoff-carried
+        # route_matrix (the handoff is what this run actually verified against —
+        # never a freshly re-read live matrix, which could have moved since).
+        case "$PUBLISH_KIND" in
+            tagged) landing_input="$ROUTE_MATRIX" ;;
+            nightly) landing_input="$(jq -ec '.route_matrix' "$HANDOFF_FILE")" ;;
+        esac
+        landing_matrix_file=$(mktemp)
+        printf '%s' "$landing_input" | jq -c \
+            '[.[] | {abi: "FreeBSD:\(.freebsd_major):*", pfsense_version, variant, php_version, py_flavor}]' \
+            >"$landing_matrix_file"
+        python3 "${PFB_SRC}/scripts/gen_landing.py" \
+            "${PKG_REPO}/docs" "$BASE_URL" "${PFB_SRC}/scripts/add-repo.sh" \
+            --matrix "$landing_matrix_file"
+        rm -f "$landing_matrix_file"
+        true >"${PKG_REPO}/docs/.nojekyll"
 
-    # --- landing page regen — only for an actual publish -------------------
-    # Skipped entirely on a no-op above: gen_landing.py embeds a generation
-    # timestamp, so running it unconditionally would manufacture a diff (and
-    # therefore a commit) on every run even when no catalogue changed.
-    #
-    # landing_matrix.json's abi expression (pinned by
-    # tests/shell/publish_pkg_repo_spec.sh): freebsd_major alone feeds the
-    # CPU-wildcarded ABI string. The retired `arch` matrix field is never
-    # interpolated — every published .pkg is NO_ARCH, so the honest ABI is the
-    # wildcard the packages themselves carry, never a per-arch value. The two
-    # modes share this ONE transform, differing only in the matrix array's
-    # source: tagged's pinned $ROUTE_MATRIX, nightly's own handoff-carried
-    # route_matrix (the handoff is what this run actually verified against —
-    # never a freshly re-read live matrix, which could have moved since).
-    case "$PUBLISH_KIND" in
-        tagged) landing_input="$ROUTE_MATRIX" ;;
-        nightly) landing_input="$(jq -ec '.route_matrix' "$HANDOFF_FILE")" ;;
-    esac
-    landing_matrix_file=$(mktemp)
-    printf '%s' "$landing_input" | jq -c \
-        '[.[] | {abi: "FreeBSD:\(.freebsd_major):*", pfsense_version, variant, php_version, py_flavor}]' \
-        >"$landing_matrix_file"
-    python3 "${PFB_SRC}/scripts/gen_landing.py" \
-        "${PKG_REPO}/docs" "$BASE_URL" "${PFB_SRC}/scripts/add-repo.sh" \
-        --matrix "$landing_matrix_file"
-    rm -f "$landing_matrix_file"
-    true >"${PKG_REPO}/docs/.nojekyll"
-
-    # --- stage EXACTLY what changed — never -A / . --------------------------
-    stage_paths="docs/.nojekyll"
-    [ -f "${PKG_REPO}/docs/index.html" ] && stage_paths="${stage_paths} docs/index.html"
-    [ -f "${PKG_REPO}/docs/browse.html" ] && stage_paths="${stage_paths} docs/browse.html"
-    # write_site() also publishes the two client scripts into the site root — the
-    # landing page's bootstrap one-liner and its channel-switch snippet fetch them
-    # from there, so an unstaged copy serves a 404 into `sh`.
-    [ -f "${PKG_REPO}/docs/add-repo.sh" ] && stage_paths="${stage_paths} docs/add-repo.sh"
-    [ -f "${PKG_REPO}/docs/migrate-channel.sh" ] && stage_paths="${stage_paths} docs/migrate-channel.sh"
-    for target in $touched; do
-        stage_paths="${stage_paths} docs/${target}"
-    done
-    # gen_landing.py's all_dirs() regenerates a per-directory autoindex at
-    # EVERY existing level, not just this run's touched targets — stage every
-    # directory's index.html too, matching what actually changed on disk.
-    docs_root="${PKG_REPO}/docs"
-    dir_indexes=$(find "$docs_root" -mindepth 1 -type d -print | while IFS= read -r d; do
-        [ -f "${d}/index.html" ] && printf 'docs/%s/index.html\n' "${d#"${docs_root}/"}"
-    done)
-    stage_paths="${stage_paths}
+        # --- stage EXACTLY what changed — never -A / . ----------------------
+        stage_paths="docs/.nojekyll"
+        [ -f "${PKG_REPO}/docs/index.html" ] && stage_paths="${stage_paths} docs/index.html"
+        [ -f "${PKG_REPO}/docs/browse.html" ] && stage_paths="${stage_paths} docs/browse.html"
+        # write_site() also publishes the two client scripts into the site root — the
+        # landing page's bootstrap one-liner and its channel-switch snippet fetch them
+        # from there, so an unstaged copy serves a 404 into `sh`.
+        [ -f "${PKG_REPO}/docs/add-repo.sh" ] && stage_paths="${stage_paths} docs/add-repo.sh"
+        [ -f "${PKG_REPO}/docs/migrate-channel.sh" ] && stage_paths="${stage_paths} docs/migrate-channel.sh"
+        for target in $touched; do
+            stage_paths="${stage_paths} docs/${target}"
+        done
+        # gen_landing.py's all_dirs() regenerates a per-directory autoindex at
+        # EVERY existing level, not just this run's touched targets — stage every
+        # directory's index.html too, matching what actually changed on disk.
+        docs_root="${PKG_REPO}/docs"
+        dir_indexes=$(find "$docs_root" -mindepth 1 -type d -print | while IFS= read -r d; do
+            [ -f "${d}/index.html" ] && printf 'docs/%s/index.html\n' "${d#"${docs_root}/"}"
+        done)
+        stage_paths="${stage_paths}
 ${dir_indexes}"
-    # shellcheck disable=SC2086  # stage_paths is a controlled, space/newline-separated pathspec list
-    git -C "$PKG_REPO" add -- $stage_paths
+        # shellcheck disable=SC2086  # stage_paths is a controlled, space/newline-separated pathspec list
+        git -C "$PKG_REPO" add -- $stage_paths
 
-    if git -C "$PKG_REPO" diff --cached --quiet; then
-        echo "publish-pkg-repo: NOOP — the publisher reported changes but nothing is staged; discarding."
-        git -C "$PKG_REPO" reset --quiet
-        exit 0
+        if git -C "$PKG_REPO" diff --cached --quiet; then
+            echo "publish-pkg-repo: NOOP — the publisher reported changes but nothing is staged; discarding."
+            git -C "$PKG_REPO" reset --quiet
+            exit 0
+        fi
     fi
 
-    case "$PUBLISH_KIND" in
-        tagged)
-            commit_message=$(printf 'publish: %s -> %s\n\npfBlockerNG-Release-Tag: %s\npfBlockerNG-Source-Run-Id: %s\n' \
-                "$RELEASE_TAG" "$DESTINATIONS" "$RELEASE_TAG" "$SOURCE_RUN_ID")
-            ;;
-        nightly)
-            # jq -er: a missing/null pkg_version aborts here (via
-            # set -e) before any commit — same containment rule as a non-zero
-            # exit from the publisher itself further up.
-            nightly_pkg_version=$(jq -er '.pkg_version' "$HANDOFF_FILE")
-            commit_message=$(printf 'publish: nightly %s -> ["nightly"]\n\npfBlockerNG-Nightly-Version: %s\npfBlockerNG-Source-Run-Id: %s\n' \
-                "$nightly_pkg_version" "$nightly_pkg_version" "$SOURCE_RUN_ID")
-            ;;
-    esac
+    if [ "$script_refresh" -eq 1 ]; then
+        # Mode-independent: the refresh carries no release/nightly identity —
+        # its content comes from PFB_SRC, so the run id is the whole provenance.
+        commit_message=$(printf 'publish: refresh client scripts\n\npfBlockerNG-Source-Run-Id: %s\n' \
+            "$SOURCE_RUN_ID")
+    else
+        case "$PUBLISH_KIND" in
+            tagged)
+                commit_message=$(printf 'publish: %s -> %s\n\npfBlockerNG-Release-Tag: %s\npfBlockerNG-Source-Run-Id: %s\n' \
+                    "$RELEASE_TAG" "$DESTINATIONS" "$RELEASE_TAG" "$SOURCE_RUN_ID")
+                ;;
+            nightly)
+                # jq -er: a missing/null pkg_version aborts here (via
+                # set -e) before any commit — same containment rule as a non-zero
+                # exit from the publisher itself further up.
+                nightly_pkg_version=$(jq -er '.pkg_version' "$HANDOFF_FILE")
+                commit_message=$(printf 'publish: nightly %s -> ["nightly"]\n\npfBlockerNG-Nightly-Version: %s\npfBlockerNG-Source-Run-Id: %s\n' \
+                    "$nightly_pkg_version" "$nightly_pkg_version" "$SOURCE_RUN_ID")
+                ;;
+        esac
+    fi
     # Fixed bot identity via per-invocation -c flags, not repo config: a bare CI
     # checkout carries no git identity, and this script must not depend on one
     # being configured elsewhere (matches release.yml/module-durations.yml's

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -422,12 +422,30 @@ JSON
     The result of function remote_head_now should equal "$original_remote_head"
   End
 
+  # Fixture for the client-script-refresh examples: a catalogue no-op with
+  # drifted scripts, plus every trap an over-broad stage could sweep in —
+  # committed landing pages whose bytes DIFFER from the stub generator's
+  # output (a regression that regenerates the timestamped pages on a no-op
+  # produces a real diff there), an untracked file, and a dirty tracked file
+  # (either of which a `git add -A`/`.` regression would commit).
+  seed_refresh_drift() {
+    printf 'old landing\n' > "${base}/pkg-repo/docs/index.html"
+    printf 'old browse\n' > "${base}/pkg-repo/docs/browse.html"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/index.html docs/browse.html \
+        && git_fixture commit -q -m preseed-landing && git_fixture push -q origin main )
+    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
+    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
+    echo debris > "${base}/pkg-repo/debris.txt"
+    echo dirty >> "${base}/pkg-repo/README.txt"
+  }
+
   It 'ships a client-script refresh when the catalogue is a no-op but the scripts drifted'
     # The seed tree carries NO committed client scripts — maximal drift. A
     # catalogue no-op must still publish the pair: the scripts are generated
     # from PFB_SRC, not from release assets, so a script-only fix was
     # otherwise unshippable via a republish of an already-published release
     # (issue #2408).
+    seed_refresh_drift
     export FAKE_MODE=noop
     When run script "$script"
     The status should equal 0
@@ -437,24 +455,23 @@ JSON
     The output should not include 'publish-pkg-repo: NOOP'
     The stderr should include 'main'
     The result of function remote_head_now should not equal "$original_remote_head"
-    committed="$(git_fixture -C "${base}/pkg-repo" show --stat --format= HEAD | tr -s ' ' | sed 's/^ *//;s/ .*//')"
-    The variable committed should include 'docs/add-repo.sh'
-    The variable committed should include 'docs/migrate-channel.sh'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
+    The variable committed should equal 'docs/add-repo.sh docs/migrate-channel.sh'
   End
 
-  It 'a client-script refresh stages ONLY the two scripts and says so in the commit'
-    # No landing/browse/autoindex page may ride along (they embed a generation
-    # timestamp — regenerating them on a no-op would manufacture a commit every
-    # run), and the commit subject + run-id trailer must identify the refresh.
+  It 'a client-script refresh commits EXACTLY the two scripts and says so in the commit'
+    # Exact-list equality: no landing/browse/autoindex page, no untracked or
+    # unrelated dirty file may ride along (the seeded traps above would each
+    # break the equality), and the commit subject + run-id trailer must
+    # identify the refresh.
+    seed_refresh_drift
     export FAKE_MODE=noop
     When run script "$script"
     The status should equal 0
     The output should include 'ADVANCE'
     The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --stat --format= HEAD | tr -s ' ' | sed 's/^ *//;s/ .*//')"
-    The variable committed should not include 'docs/index.html'
-    The variable committed should not include 'docs/browse.html'
-    The variable committed should not include 'README.txt'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
+    The variable committed should equal 'docs/add-repo.sh docs/migrate-channel.sh'
     msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
     The variable msg should include 'publish: refresh client scripts'
     The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1'
@@ -745,6 +762,27 @@ HOOK
     The output should include 'NOOP'
     The result of function local_head_now should equal "$original_head"
     The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'n5b: nightly mode ships the same mode-independent client-script refresh'
+    # The refresh branch precedes the PUBLISH_KIND commit-message split and
+    # must never acquire nightly identity: no jq pkg_version read, no
+    # pfBlockerNG-Nightly-Version trailer (the handoff fixture carries a
+    # pkg_version, so the nightly arm COULD produce one — this pins that the
+    # refresh arm does not route through it).
+    nightly_env
+    seed_refresh_drift
+    export FAKE_MODE=noop
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
+    The variable committed should equal 'docs/add-repo.sh docs/migrate-channel.sh'
+    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
+    The variable msg should include 'publish: refresh client scripts'
+    The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1'
+    The variable msg should not include 'pfBlockerNG-Nightly-Version'
   End
 
   It 'n6: nightly mode commit message carries the nightly version subject and trailers, ignoring tagged vars'

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -112,6 +112,15 @@ import sys
 
 site = sys.argv[1]
 argv = sys.argv[1:]
+if "--client-scripts-only" in argv:
+    # Mirrors the real generator's script-only mode (issue #2408): ONLY the two
+    # client scripts are written — no landing/browse/autoindex output.
+    with open(os.path.join(site, "add-repo.sh"), "w") as fh:
+        fh.write("#!/bin/sh\n# add-repo stub\n")
+    with open(os.path.join(site, "migrate-channel.sh"), "w") as fh:
+        fh.write("#!/bin/sh\n# migrate-channel stub\n")
+    print("client scripts stub written")
+    sys.exit(0)
 # Records the exact --matrix file this run was fed, byte for byte, when
 # FAKE_LANDING_MATRIX_RECORD is set — publish-pkg-repo.sh's own job (not
 # gen_landing.py's) is choosing that file's SOURCE (tagged: $ROUTE_MATRIX;
@@ -395,13 +404,60 @@ JSON
 
   # --- no-op path --------------------------------------------------------
 
-  It 'commits nothing on a no-op run'
+  It 'commits nothing on a no-op run with current client scripts'
+    # The catalogue-NOOP path still regenerates the two client scripts
+    # (issue #2408) — pre-seed them byte-identical to the stub generator's
+    # output so the full-NOOP branch is reached honestly, not via drift.
+    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
+    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
+        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
+    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
+    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
     export FAKE_MODE=noop
     When run script "$script"
     The status should equal 0
     The output should include 'NOOP'
     The result of function local_head_now should equal "$original_head"
     The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'ships a client-script refresh when the catalogue is a no-op but the scripts drifted'
+    # The seed tree carries NO committed client scripts — maximal drift. A
+    # catalogue no-op must still publish the pair: the scripts are generated
+    # from PFB_SRC, not from release assets, so a script-only fix was
+    # otherwise unshippable via a republish of an already-published release
+    # (issue #2408).
+    export FAKE_MODE=noop
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    # The wrapper's own no-op verdict must not appear; the publisher's
+    # "NOOP: every destination already matches" line legitimately does.
+    The output should not include 'publish-pkg-repo: NOOP'
+    The stderr should include 'main'
+    The result of function remote_head_now should not equal "$original_remote_head"
+    committed="$(git_fixture -C "${base}/pkg-repo" show --stat --format= HEAD | tr -s ' ' | sed 's/^ *//;s/ .*//')"
+    The variable committed should include 'docs/add-repo.sh'
+    The variable committed should include 'docs/migrate-channel.sh'
+  End
+
+  It 'a client-script refresh stages ONLY the two scripts and says so in the commit'
+    # No landing/browse/autoindex page may ride along (they embed a generation
+    # timestamp — regenerating them on a no-op would manufacture a commit every
+    # run), and the commit subject + run-id trailer must identify the refresh.
+    export FAKE_MODE=noop
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --stat --format= HEAD | tr -s ' ' | sed 's/^ *//;s/ .*//')"
+    The variable committed should not include 'docs/index.html'
+    The variable committed should not include 'docs/browse.html'
+    The variable committed should not include 'README.txt'
+    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
+    The variable msg should include 'publish: refresh client scripts'
+    The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1'
   End
 
   It 'commits nothing when a reported touched target leaves the tree unchanged'
@@ -674,6 +730,15 @@ HOOK
 
   It 'n5: nightly mode NOOP output commits nothing'
     nightly_env
+    # Same pre-seed as the tagged no-op example: the catalogue-NOOP path
+    # regenerates the client scripts (issue #2408), so a true no-op needs them
+    # current in the seed tree.
+    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
+    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
+        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
+    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
+    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
     export FAKE_MODE=noop
     When run script "$script"
     The status should equal 0

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 # Load scripts/gen_landing.py (a script path, not an installed module).
 _SPEC = importlib.util.spec_from_file_location(
     "gen_landing", Path(__file__).resolve().parent.parent / "scripts" / "gen_landing.py"
@@ -2052,3 +2054,23 @@ def test_main_client_scripts_only_writes_scripts_and_nothing_else(tmp_path: Path
     assert sorted(p.name for p in site.iterdir()) == ["add-repo.sh", "migrate-channel.sh"]
     embedded = (site / "add-repo.sh").read_text()
     assert f"cat <<'{gl._HOOK_HEREDOC}'" in embedded, "the boot hook must be embedded, not left as the stub body"
+
+
+def test_main_client_scripts_only_rejects_matrix(tmp_path: Path) -> None:
+    """``--client-scripts-only`` with ``--matrix`` is a usage error, not a silent ignore.
+
+    The matrix drives the landing page's per-edition tables, which this mode never
+    writes — accepting both would let a caller believe the matrix was applied.
+    """
+    site = tmp_path / "site"
+    site.mkdir()
+    matrix_file = tmp_path / "matrix.json"
+    matrix_file.write_text("[]")
+
+    with pytest.raises(SystemExit) as exc:
+        gl.main(
+            [str(site), "https://x/pkg", str(_ADD_REPO_REAL), "--client-scripts-only", "--matrix", str(matrix_file)]
+        )
+
+    assert exc.value.code == 2
+    assert list(site.iterdir()) == [], "a usage error must write nothing"

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -2034,3 +2034,21 @@ def test_main_cli_accepts_the_production_positional_and_matrix_flag_shape(tmp_pa
 
     assert rc == 0
     assert (site / "index.html").is_file()
+
+
+def test_main_client_scripts_only_writes_scripts_and_nothing_else(tmp_path: Path) -> None:
+    """``--client-scripts-only`` publishes ONLY the two deterministic client scripts.
+
+    publish-pkg-repo.sh's catalogue-NOOP path (issue #2408) uses this mode to ship a
+    script-only fix; writing any timestamped landing/browse/autoindex page here would
+    manufacture a commit on every republish run instead.
+    """
+    site = tmp_path / "site"
+    site.mkdir()
+
+    rc = gl.main([str(site), "https://x/pkg", str(_ADD_REPO_REAL), "--client-scripts-only"])
+
+    assert rc == 0
+    assert sorted(p.name for p in site.iterdir()) == ["add-repo.sh", "migrate-channel.sh"]
+    embedded = (site / "add-repo.sh").read_text()
+    assert f"cat <<'{gl._HOOK_HEREDOC}'" in embedded, "the boot hook must be embedded, not left as the stub body"


### PR DESCRIPTION
## Problem

`publish-pkg-repo.sh` exits `NOOP — nothing touched, nothing to commit` as soon as the publisher reports no catalogue cell updated — before the landing/script regeneration step. The two client scripts (`docs/add-repo.sh`, `docs/migrate-channel.sh`) are generated from the PFB_SRC checkout, not from release assets, so a script-only fix can never ship by re-dispatching `pkg-republish.yml` for an already-published release. Observed on run 31851561987 (republish of v3.3.2 from a devel tip carrying an add-repo.sh fix); the fix had to be pushed manually as pfBlockerNG/pkg@85f8de8.

## Fix

- `gen_landing.py`: new `--client-scripts-only` mode — writes only `add-repo.sh` (hook embedded) and `migrate-channel.sh`, both deterministic; no landing/browse/autoindex pages.
- `publish-pkg-repo.sh`: on an empty touched-list, run that mode, stage exactly the two scripts, and NOOP only if the staged diff is empty. Otherwise commit as `publish: refresh client scripts` (with the `pfBlockerNG-Source-Run-Id` trailer) and push through the existing retry loop. The timestamped pages remain publish-only — regenerating them on a no-op would manufacture a commit on every run, which is why the early exit existed.

## Tests (red first, frozen, re-run green unchanged)

- `tests/shell/publish_pkg_repo_spec.sh` (hash `6803a37f…` red and green):
  - new: a catalogue no-op with drifted scripts ships a refresh commit (was: NOOP, remote unmoved — RED pre-fix);
  - new: the refresh stages ONLY the two scripts, and the commit carries the refresh subject + run-id trailer (RED pre-fix);
  - updated: both true-no-op examples (tagged + nightly) pre-seed current client scripts so the full-NOOP branch is reached honestly.
- `tests/test_gen_landing.py` (hash `ebfc2322…`): `--client-scripts-only` writes the two scripts and nothing else, with the boot hook embedded (RED pre-fix: argparse rejects the flag).

Gates: full `run-gates.sh` PASS (pytest, ruff, mypy, sh -n, shellcheck, shellspec).

Fixes #2408

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a client-scripts-only generation mode that refreshes repository setup and channel migration scripts without rebuilding landing pages or indexes.
  * The mode prevents incompatible matrix generation.

* **Bug Fixes**
  * No-op publishing now detects changed client scripts and creates a focused refresh commit.
  * Unchanged scripts remain a true no-op, avoiding unnecessary commits.

* **Tests**
  * Added coverage for client-script-only generation, invalid option combinations, script drift detection, and tagged or nightly no-op publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->