### PR TITLE
publish: backfill faster catalogues from slower retained versions

### DIFF
--- a/scripts/catalogue_assembly.py
+++ b/scripts/catalogue_assembly.py
@@ -221,6 +221,104 @@ def _protected_versions(site_root: Path, channel: str, varver: str, *, engine: E
     return frozenset(versions)
 
 
+def _files_byte_identical(a: Path, b: Path) -> bool:
+    """True iff ``a`` and ``b`` hold the same bytes. Size first — a new build
+    almost always differs there, so most calls never read either file."""
+    if a.stat().st_size != b.stat().st_size:
+        return False
+    return a.read_bytes() == b.read_bytes()
+
+
+def _canonical_filename(manifest: Mapping[str, object]) -> str:
+    return f"{manifest['name']}-{manifest['version']}.pkg"
+
+
+def _iter_canonical_packages(catalogue_dir: Path, *, engine: Engine) -> list[tuple[Path, str]]:
+    """Canonical ``.pkg`` files in ``catalogue_dir`` as ``(path, filename)``.
+
+    Catalog descriptor files and non-canonical (dependency) packages are skipped,
+    matching ``_protected_versions`` / ``prune_retained`` so a dependency can
+    never be copied or compared as a containment source.
+    """
+    pfb_pkg = engine.pfb_pkg
+    brp = engine.build_repo_portable
+    found: list[tuple[Path, str]] = []
+    for path in sorted(catalogue_dir.glob("*.pkg")):
+        if not path.is_file() or path.name in brp._CATALOG_PKG_FILES:
+            continue
+        manifest = pfb_pkg.read_compact_manifest(path)
+        if manifest.get("name") != pfb_pkg.CANONICAL_EMITTED_IDENTITY:
+            continue
+        found.append((path, _canonical_filename(manifest)))
+    return found
+
+
+def backfill_from_slower_channels(
+    site_root: str | Path,
+    channel: str,
+    varver: str,
+    *,
+    engine: Engine,
+) -> dict[Path, list[tuple[str, str]]]:
+    """Copy every canonical package still retained on a slower tagged channel
+    for this ``varver`` onto ``channel`` (byte-identical).
+
+    Nightly is untagged and independent: this function never copies from it or
+    into it (``_SLOWER_CHANNELS["nightly"]`` is empty, and a nightly destination
+    returns immediately). A same-name, different-byte collision — dest vs source,
+    or two slower sources disagreeing with each other — is a hard error.
+
+    Returns a ``source_index`` fragment: each newly-copied source path maps to
+    the ``(channel, varver)`` destinations that now hold those bytes (every
+    slower origin that carried the package, plus ``channel``). Already-identical
+    destinations are left untouched and omitted from the result.
+    """
+    site_root = Path(site_root)
+    if channel == "nightly":
+        _validate_channel(channel)
+        _validate_varver(varver, engine)
+        return {}
+
+    dest_dir = _catalogue_dir(site_root, channel, varver, engine)
+    # name -> first source, then every slower (channel, path) that carries it
+    first_source: dict[str, Path] = {}
+    origins: dict[str, list[tuple[str, Path]]] = {}
+    for slower_channel in _SLOWER_CHANNELS[channel]:
+        if slower_channel == "nightly":
+            continue
+        slower_dir = site_root / slower_channel / varver
+        if not slower_dir.is_dir():
+            continue
+        for path, name in _iter_canonical_packages(slower_dir, engine=engine):
+            existing = first_source.get(name)
+            if existing is not None and not _files_byte_identical(existing, path):
+                raise CatalogueAssemblyError(
+                    f"{name}: slower channels disagree on bytes for {varver} — "
+                    f"{existing} sha256={hashlib.sha256(existing.read_bytes()).hexdigest()}, "
+                    f"{path} sha256={hashlib.sha256(path.read_bytes()).hexdigest()}"
+                )
+            if existing is None:
+                first_source[name] = path
+            origins.setdefault(name, []).append((slower_channel, path))
+
+    copied: dict[Path, list[tuple[str, str]]] = {}
+    for name, src in first_source.items():
+        dest = dest_dir / name
+        if dest.is_file():
+            if _files_byte_identical(dest, src):
+                continue
+            raise CatalogueAssemblyError(
+                f"{dest}: already publishes a different build of {name} — "
+                f"existing sha256={hashlib.sha256(dest.read_bytes()).hexdigest()}, "
+                f"incoming sha256={hashlib.sha256(src.read_bytes()).hexdigest()}"
+            )
+        shutil.copy2(src, dest)
+        destinations = [(slower, varver) for slower, _path in origins[name]]
+        destinations.append((channel, varver))
+        copied[src.resolve()] = destinations
+    return copied
+
+
 def prune_retained(
     site_root: str | Path,
     channel: str,

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -284,6 +284,16 @@ def publish(engine: pc.Engine, run_result: pc.RunResult, pkg_repo: str | Path) -
             changed = _drop_assets(dest_dir, asset_map)
             if not changed and not _catalogue_descriptor_complete(dest_dir, engine):
                 changed = True
+            # Heal historical holes before prune: copy every canonical version
+            # still on a slower tagged channel (never nightly) onto this dest.
+            copied = ca.backfill_from_slower_channels(site_root, channel, varver, engine=engine)
+            if copied:
+                changed = True
+                for src, destinations in copied.items():
+                    bucket = source_index.setdefault(src, [])
+                    for dest in destinations:
+                        if dest not in bucket:
+                            bucket.append(dest)
             for src in asset_map.values():
                 source_index.setdefault(src.resolve(), []).append((channel, varver))
             if changed:

--- a/tests/test_catalogue_assembly.py
+++ b/tests/test_catalogue_assembly.py
@@ -982,6 +982,176 @@ class ContainmentAwarePruningTests(_TempDirTestCase):
         self.assertIn("dep-edge.pkg", _pkg_names(edge_dir))
 
 
+# --------------------------------------------------------------------------- #
+# Containment backfill: prune-only protection cannot create a missing package.
+# Faster tagged catalogues must be copied onto from slower ones (byte-identical)
+# so edge superset-of testing superset-of stable. Nightly is independent.
+# --------------------------------------------------------------------------- #
+
+
+class ContainmentBackfillTests(_TempDirTestCase):
+    @_requires_engine
+    def test_copies_missing_canonical_from_slower(self) -> None:
+        out = self.tmp / "out"
+        testing_dir = out / "testing" / "ce-2.8"
+        edge_dir = out / "edge" / "ce-2.8"
+        _seed_canonical(self.tmp, testing_dir, ["1.0.0"])
+        _seed_canonical(self.tmp, edge_dir, ["2.0.0"])
+        slower = testing_dir / "pfSense-pkg-pfBlockerNG-1.0.0.pkg"
+
+        copied = ca.backfill_from_slower_channels(out, "edge", "ce-2.8", engine=_ENGINE)
+
+        dest = edge_dir / "pfSense-pkg-pfBlockerNG-1.0.0.pkg"
+        self.assertTrue(dest.is_file())
+        self.assertEqual(dest.read_bytes(), slower.read_bytes())
+        self.assertEqual(list(copied), [slower.resolve()])
+        self.assertEqual(copied[slower.resolve()], [("testing", "ce-2.8"), ("edge", "ce-2.8")])
+
+    @_requires_engine
+    def test_already_identical_is_noop(self) -> None:
+        out = self.tmp / "out"
+        testing_dir = out / "testing" / "ce-2.8"
+        edge_dir = out / "edge" / "ce-2.8"
+        _seed_canonical(self.tmp, testing_dir, ["1.0.0"])
+        _drop(edge_dir, testing_dir / "pfSense-pkg-pfBlockerNG-1.0.0.pkg")
+
+        copied = ca.backfill_from_slower_channels(out, "edge", "ce-2.8", engine=_ENGINE)
+
+        self.assertEqual(copied, {})
+        self.assertEqual(_pkg_names(edge_dir), ["pfSense-pkg-pfBlockerNG-1.0.0.pkg"])
+
+    @_requires_engine
+    def test_same_name_different_bytes_rejected(self) -> None:
+        out = self.tmp / "out"
+        testing_dir = out / "testing" / "ce-2.8"
+        edge_dir = out / "edge" / "ce-2.8"
+        _seed_canonical(self.tmp, testing_dir, ["1.0.0"])
+        _drop(
+            edge_dir,
+            _canonical_pkg(
+                self.tmp,
+                version="1.0.0",
+                origin="net/pfSense-pkg-pfBlockerNG-EVIL",
+                local_name="pfSense-pkg-pfBlockerNG-1.0.0.pkg",
+            ),
+        )
+
+        with self.assertRaises(ca.CatalogueAssemblyError) as ctx:
+            ca.backfill_from_slower_channels(out, "edge", "ce-2.8", engine=_ENGINE)
+        self.assertIn("different build", str(ctx.exception))
+        self.assertNotEqual(
+            (testing_dir / "pfSense-pkg-pfBlockerNG-1.0.0.pkg").read_bytes(),
+            (edge_dir / "pfSense-pkg-pfBlockerNG-1.0.0.pkg").read_bytes(),
+        )
+
+    @_requires_engine
+    def test_slower_sources_disagreeing_bytes_rejected(self) -> None:
+        out = self.tmp / "out"
+        stable_dir = out / "stable" / "ce-2.8"
+        testing_dir = out / "testing" / "ce-2.8"
+        edge_dir = out / "edge" / "ce-2.8"
+        _seed_canonical(self.tmp, stable_dir, ["1.0.0"])
+        _drop(
+            testing_dir,
+            _canonical_pkg(
+                self.tmp,
+                version="1.0.0",
+                origin="net/pfSense-pkg-pfBlockerNG-EVIL",
+                local_name="pfSense-pkg-pfBlockerNG-1.0.0.pkg",
+            ),
+        )
+        edge_dir.mkdir(parents=True)
+
+        with self.assertRaises(ca.CatalogueAssemblyError) as ctx:
+            ca.backfill_from_slower_channels(out, "edge", "ce-2.8", engine=_ENGINE)
+        self.assertIn("slower channels disagree", str(ctx.exception))
+        self.assertEqual(_pkg_names(edge_dir), [])
+
+    @_requires_engine
+    def test_dependency_never_copied(self) -> None:
+        out = self.tmp / "out"
+        testing_dir = out / "testing" / "ce-2.8"
+        edge_dir = out / "edge" / "ce-2.8"
+        _seed_canonical(self.tmp, testing_dir, ["1.0.0"])
+        _drop(
+            testing_dir,
+            _dep_pkg(
+                self.tmp,
+                name="py311-charset-normalizer",
+                version="3.4.0",
+                local_name="py311-charset-normalizer-3.4.0.pkg",
+            ),
+        )
+        edge_dir.mkdir(parents=True)
+
+        copied = ca.backfill_from_slower_channels(out, "edge", "ce-2.8", engine=_ENGINE)
+
+        self.assertIn("pfSense-pkg-pfBlockerNG-1.0.0.pkg", _pkg_names(edge_dir))
+        self.assertNotIn("py311-charset-normalizer-3.4.0.pkg", _pkg_names(edge_dir))
+        self.assertEqual(len(copied), 1)
+
+    @_requires_engine
+    def test_nightly_destination_copies_nothing(self) -> None:
+        out = self.tmp / "out"
+        testing_dir = out / "testing" / "ce-2.8"
+        nightly_dir = out / "nightly" / "ce-2.8"
+        _seed_canonical(self.tmp, testing_dir, ["1.0.0"])
+        nightly_dir.mkdir(parents=True)
+
+        copied = ca.backfill_from_slower_channels(out, "nightly", "ce-2.8", engine=_ENGINE)
+
+        self.assertEqual(copied, {})
+        self.assertEqual(_pkg_names(nightly_dir), [])
+
+    @_requires_engine
+    def test_nightly_source_never_copied(self) -> None:
+        out = self.tmp / "out"
+        nightly_dir = out / "nightly" / "ce-2.8"
+        edge_dir = out / "edge" / "ce-2.8"
+        _seed_canonical(self.tmp, nightly_dir, ["1.0.0"])
+        edge_dir.mkdir(parents=True)
+
+        copied = ca.backfill_from_slower_channels(out, "edge", "ce-2.8", engine=_ENGINE)
+
+        self.assertEqual(copied, {})
+        self.assertEqual(_pkg_names(edge_dir), [])
+
+    @_requires_engine
+    def test_stable_has_nothing_to_backfill(self) -> None:
+        out = self.tmp / "out"
+        testing_dir = out / "testing" / "ce-2.8"
+        stable_dir = out / "stable" / "ce-2.8"
+        _seed_canonical(self.tmp, testing_dir, ["1.0.0"])
+        stable_dir.mkdir(parents=True)
+
+        copied = ca.backfill_from_slower_channels(out, "stable", "ce-2.8", engine=_ENGINE)
+
+        self.assertEqual(copied, {})
+        self.assertEqual(_pkg_names(stable_dir), [])
+
+    @_requires_engine
+    def test_backfill_then_prune_keeps_slower_version_outside_keep_window(self) -> None:
+        # Slower still has 1.0.0; faster only has newer keep-window versions.
+        # After backfill + prune, 1.0.0 exists on faster (heal + protection).
+        out = self.tmp / "out"
+        testing_dir = out / "testing" / "ce-2.8"
+        edge_dir = out / "edge" / "ce-2.8"
+        newer = [f"2.0.{i}" for i in range(ca.DEFAULT_RETENTION_KEEP)]
+        _seed_canonical(self.tmp, testing_dir, ["1.0.0"])
+        _seed_canonical(self.tmp, edge_dir, newer)
+        slower = testing_dir / "pfSense-pkg-pfBlockerNG-1.0.0.pkg"
+
+        copied = ca.backfill_from_slower_channels(out, "edge", "ce-2.8", engine=_ENGINE)
+        evicted = ca.prune_retained(out, "edge", "ce-2.8", engine=_ENGINE)
+
+        dest = edge_dir / "pfSense-pkg-pfBlockerNG-1.0.0.pkg"
+        self.assertTrue(dest.is_file())
+        self.assertEqual(dest.read_bytes(), slower.read_bytes())
+        self.assertEqual(list(copied), [slower.resolve()])
+        self.assertEqual(evicted, ())
+        self.assertIn("pfSense-pkg-pfBlockerNG-1.0.0.pkg", _pkg_names(edge_dir))
+
+
 class SlowerChannelsConsistencyTests(unittest.TestCase):
     # Pure constant-shape checks, no engine/fixtures needed.
     def test_keys_match_known_channels(self) -> None:

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -1002,6 +1002,96 @@ class OutcomeTests(_TempDirTestCase):
         self.assertIn(f"pfSense-pkg-pfBlockerNG-4.0.0.b{ca_default_keep() + 1}.pkg", remaining)
 
 
+# --------------------------------------------------------------------------- #
+# Containment backfill (issue #2398): a slower-channel generation omitted from
+# a faster catalogue must be copied byte-identically before prune. Nightly is
+# outside this reconciliation.
+# --------------------------------------------------------------------------- #
+
+
+class ContainmentBackfillPublishTests(_TempDirTestCase):
+    def _seed_canonical(self, channel: str, varver: str, record: dict) -> Path:
+        """Drop one already-canonical .pkg into docs/<channel>/<varver>/."""
+        dest_dir = self.pkg_repo / "docs" / channel / varver
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        name = f"{_ENGINE.pfb_pkg.CANONICAL_EMITTED_IDENTITY}-{record['canonical_package_version']}.pkg"
+        scratch = self.tmp / f"seed-{next(self._assets_counter)}"
+        scratch.mkdir()
+        src, _digest = _wrap_canonical_pkg(scratch, record, local_name=name)
+        dest = dest_dir / name
+        dest.write_bytes(src.read_bytes())
+        return dest
+
+    @_requires_engine
+    def test_edge_heals_testing_version_omitted_from_edge(self) -> None:
+        # Red canary: testing/ce-2.8 has 3.2.10, edge/ce-2.8 does not.
+        # A new testing publish (destinations testing+edge) must copy it.
+        seeded = self._seed_canonical(
+            "testing",
+            "ce-2.8",
+            _record(channel="stable", row=ROW_CE, source_tag="v3.2.10"),
+        )
+        self.assertFalse(
+            (self.pkg_repo / "docs" / "edge" / "ce-2.8" / "pfSense-pkg-pfBlockerNG-3.2.10.pkg").exists()
+        )
+
+        assets_dir = self.new_assets_dir()
+        _populate_assets_dir(
+            assets_dir,
+            channel="testing",
+            rows=(ROW_CE,),
+            source_tag="v3.2.16.a1",
+            include_dependency=False,
+        )
+        report = _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=assets_dir,
+            rows=(ROW_CE,),
+            channel="testing",
+            destinations='["testing","edge"]',
+            tag="v3.2.16.a1",
+        )
+
+        self.assertEqual(set(report.touched), {("testing", "ce-2.8"), ("edge", "ce-2.8")})
+        edge_pkg = self.pkg_repo / "docs" / "edge" / "ce-2.8" / "pfSense-pkg-pfBlockerNG-3.2.10.pkg"
+        self.assertTrue(edge_pkg.is_file())
+        self.assertEqual(edge_pkg.read_bytes(), seeded.read_bytes())
+        self.assertTrue(
+            (self.pkg_repo / "docs" / "edge" / "ce-2.8" / "pfSense-pkg-pfBlockerNG-3.2.16.a1.pkg").is_file()
+        )
+
+    @_requires_engine
+    def test_nightly_catalogue_not_healed_by_tagged_publish(self) -> None:
+        seeded = self._seed_canonical(
+            "testing",
+            "ce-2.8",
+            _record(channel="stable", row=ROW_CE, source_tag="v3.2.10"),
+        )
+        nightly_dir = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        nightly_dir.mkdir(parents=True)
+
+        assets_dir = self.new_assets_dir()
+        _populate_assets_dir(
+            assets_dir,
+            channel="testing",
+            rows=(ROW_CE,),
+            source_tag="v3.2.16.a1",
+            include_dependency=False,
+        )
+        _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=assets_dir,
+            rows=(ROW_CE,),
+            channel="testing",
+            destinations='["testing","edge"]',
+            tag="v3.2.16.a1",
+        )
+
+        self.assertTrue(seeded.is_file())
+        self.assertFalse((nightly_dir / "pfSense-pkg-pfBlockerNG-3.2.10.pkg").exists())
+        self.assertFalse((nightly_dir / "pfSense-pkg-pfBlockerNG-3.2.16.a1.pkg").exists())
+
+
 def ca_default_keep() -> int:
     return ca.DEFAULT_RETENTION_KEEP
 

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -1060,6 +1060,10 @@ class ContainmentBackfillPublishTests(_TempDirTestCase):
 
     @_requires_engine
     def test_nightly_catalogue_not_healed_by_tagged_publish(self) -> None:
+        # Hostile dest list includes nightly so backfill(channel="nightly")
+        # actually runs. The dest guard must still refuse to copy the slower
+        # tagged generation onto nightly. A testing+edge-only dest list never
+        # invokes that path and cannot fail this contract.
         seeded = self._seed_canonical(
             "testing",
             "ce-2.8",
@@ -1081,13 +1085,12 @@ class ContainmentBackfillPublishTests(_TempDirTestCase):
             assets_dir=assets_dir,
             rows=(ROW_CE,),
             channel="testing",
-            destinations='["testing","edge"]',
+            destinations='["testing","edge","nightly"]',
             tag="v3.2.16.a1",
         )
 
         self.assertTrue(seeded.is_file())
         self.assertFalse((nightly_dir / "pfSense-pkg-pfBlockerNG-3.2.10.pkg").exists())
-        self.assertFalse((nightly_dir / "pfSense-pkg-pfBlockerNG-3.2.16.a1.pkg").exists())
 
 
 def ca_default_keep() -> int:

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -1060,10 +1060,11 @@ class ContainmentBackfillPublishTests(_TempDirTestCase):
 
     @_requires_engine
     def test_nightly_catalogue_not_healed_by_tagged_publish(self) -> None:
-        # Hostile dest list includes nightly so backfill(channel="nightly")
-        # actually runs. The dest guard must still refuse to copy the slower
-        # tagged generation onto nightly. A testing+edge-only dest list never
-        # invokes that path and cannot fail this contract.
+        # publish_release rejects nightly dests (kind!=tagged). This case pins
+        # that a tagged dest list does not walk an existing nightly tree.
+        # backfill(channel="nightly") is catalogue_assembly's pin
+        # (test_nightly_destination_copies_nothing). Mixing nightly into
+        # tagged dests is IntakeError (test below).
         seeded = self._seed_canonical(
             "testing",
             "ce-2.8",
@@ -1085,12 +1086,29 @@ class ContainmentBackfillPublishTests(_TempDirTestCase):
             assets_dir=assets_dir,
             rows=(ROW_CE,),
             channel="testing",
-            destinations='["testing","edge","nightly"]',
+            destinations='["testing","edge"]',
             tag="v3.2.16.a1",
         )
 
         self.assertTrue(seeded.is_file())
         self.assertFalse((nightly_dir / "pfSense-pkg-pfBlockerNG-3.2.10.pkg").exists())
+        self.assertFalse((nightly_dir / "pfSense-pkg-pfBlockerNG-3.2.16.a1.pkg").exists())
+
+    @_requires_engine
+    def test_tagged_destinations_cannot_include_nightly(self) -> None:
+        assets_dir = self.new_assets_dir()
+        assets_dir.mkdir()
+        (assets_dir / pr._DIGESTS_FILENAME).write_text(json.dumps({"x.pkg": "0" * 64}), encoding="utf-8")
+        with self.assertRaises(pc.IntakeError) as ctx:
+            _run(
+                pkg_repo=self.pkg_repo,
+                assets_dir=assets_dir,
+                rows=(ROW_CE,),
+                channel="testing",
+                destinations='["testing","edge","nightly"]',
+                tag="v3.2.16.a1",
+            )
+        self.assertIn("nightly must not be combined", str(ctx.exception))
 
 
 def ca_default_keep() -> int:

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -1031,9 +1031,7 @@ class ContainmentBackfillPublishTests(_TempDirTestCase):
             "ce-2.8",
             _record(channel="stable", row=ROW_CE, source_tag="v3.2.10"),
         )
-        self.assertFalse(
-            (self.pkg_repo / "docs" / "edge" / "ce-2.8" / "pfSense-pkg-pfBlockerNG-3.2.10.pkg").exists()
-        )
+        self.assertFalse((self.pkg_repo / "docs" / "edge" / "ce-2.8" / "pfSense-pkg-pfBlockerNG-3.2.10.pkg").exists())
 
         assets_dir = self.new_assets_dir()
         _populate_assets_dir(


### PR DESCRIPTION
Fixes #2398.

Retention refused to evict a version a slower channel still had, but never copied a missing slower generation onto edge/testing. In-repo rollback on a faster channel was therefore incomplete.

`backfill_from_slower_channels` copies byte-identical canonical packages from slower tagged channels onto the dest before prune/regenerate. Nightly is excluded.

Made-with: Grok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tagged channel publishing now automatically backfills missing canonical packages from slower tagged channels.
  - Backfilled packages are copied byte-for-byte and retained during cleanup.
  - Release publishing tracks package sources across destinations to keep contents consistent.

- **Bug Fixes**
  - Conflicting package contents are detected and prevented from being published.
  - Dependencies and packages from nightly or stable channels are excluded from backfilling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->