### PR TITLE
ci(release): fail attach-pkgs when artifacts are missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1363,7 +1363,7 @@ jobs:
         run: |
           set -eu
 
-          PKGS=$(find pkgs -name "*.pkg" 2>/dev/null | head -20)
+          PKGS=$(find pkgs -type f -name "*.pkg" 2>/dev/null | head -20)
           if [ -z "$PKGS" ]; then
             echo "::error::No .pkg artifacts to attach — download failed or build-pkgs-portable produced none."
             echo "Check the download and build-pkgs-portable job logs for details."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1299,18 +1299,17 @@ jobs:
           retention-days: 7
 
   # ── 2c. Attach .pkg artifacts to the GitHub Release ──────────────────────
-  # Downloads the .pkg from every build-pkgs leg (even failed ones — we
-  # skip missing downloads) and appends the row-identified assets to the
-  # already-published GitHub Release.
+  # Downloads the .pkg from every successful build-pkgs-portable leg and
+  # appends the row-identified assets to the GitHub Release. An empty pkgs/
+  # (download miss or every leg failed) fails this job (issue #2385).
   #
   # DEPENDENCY EDGES: attach-pkgs needs [prepare-release, release,
   # build-pkgs-portable, read-matrix] with if: !cancelled(), so it runs regardless of a
   # build-pkgs-portable failure (see build-pkgs-portable's header comment above,
   # "A leg's build failure...", for the full transitive chain).
   #
-  # A build-pkgs-portable failure makes attach-pkgs skip that leg's artifact but
-  # attach the rest (or skip entirely if release also failed); the draft
-  # healthcheck then fails closed on the missing asset.
+  # A partial build-pkgs-portable failure still attaches the legs that
+  # uploaded; a total miss fails here rather than publishing no .pkg.
   attach-pkgs:
     name: Attach .pkg artifacts to Release
     runs-on: ubuntu-latest
@@ -1323,9 +1322,9 @@ jobs:
     env:
       HOME: /tmp
     needs: [prepare-release, release, build-pkgs-portable, read-matrix]
-    # Run whenever release succeeded AND it was a real publish (not a dry-run);
-    # regardless of the build outcome. A build-pkgs-portable failure surfaces as a
-    # red leg but does not prevent attach-pkgs from completing with a warning.
+    # Run whenever release succeeded AND it was a real publish (not a dry-run),
+    # regardless of the build outcome. Empty or failed artifact download fails
+    # this job (issue #2385).
     if: ${{ !cancelled() && needs.release.result == 'success' && needs.release.outputs.dry_run == 'false' }}
     permissions:
       packages: read
@@ -1345,20 +1344,19 @@ jobs:
         # py311-charset-normalizer) are deliberate release assets, frozen
         # alongside the branch .pkgs for the pkg-repo publish + EOL/route-only
         # story. The draft healthcheck counts them (EXPECTED_PKGS).
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: pfBlockerNG-relpkg-*
           merge-multiple: true
           path: pkgs/
-        continue-on-error: true
 
       - name: Append .pkg files to the GitHub Release
         # Upload the renamed .pkg files to the still-DRAFT release using
         # `gh release upload` (the release is published later, by hand, once the notes
         # are written — immutable-release repos only accept assets while it is a draft).
-        # This is idempotent: re-uploading an asset with --clobber replaces it. If
-        # pkgs/ has no .pkg files (all builds failed), this step emits a warning and
-        # succeeds without uploading anything.
+        # This is idempotent: re-uploading an asset with --clobber replaces it.
+        # If pkgs/ has no .pkg files (download miss or every build failed), this
+        # step fails closed so a Release is never published with no .pkg.
         env:
           GH_TOKEN: ${{ github.token }}
           TAG:      ${{ needs.release.outputs.tag }}
@@ -1367,9 +1365,9 @@ jobs:
 
           PKGS=$(find pkgs -name "*.pkg" 2>/dev/null | head -20)
           if [ -z "$PKGS" ]; then
-            echo "::warning::No .pkg artifacts to attach — the build-pkgs-portable leg may have failed."
-            echo "Check the build-pkgs-portable job logs for details."
-            exit 0
+            echo "::error::No .pkg artifacts to attach — download failed or build-pkgs-portable produced none."
+            echo "Check the download and build-pkgs-portable job logs for details."
+            exit 1
           fi
 
           # Recurse: each build-pkgs-portable leg uploads its own single-file

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -474,9 +474,7 @@ def test_build_pkgs_portable_leg_step_carries_row_identity_and_abi() -> None:
 # --------------------------------------------------------------------------- #
 
 
-_ARTIFACT_ACTION_RE = re.compile(
-    r"uses:\s+actions/(?P<kind>upload|download)-artifact@v(?P<major>\d+)"
-)
+_ARTIFACT_ACTION_RE = re.compile(r"uses:\s+actions/(?P<kind>upload|download)-artifact@v(?P<major>\d+)")
 
 
 def test_attach_pkgs_downloads_every_leg_by_pattern_with_merge() -> None:

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -494,12 +494,14 @@ def test_release_yml_upload_and_download_artifact_majors_match() -> None:
     """issue #2385: a download-artifact major behind upload-artifact misses the
     .pkg artifacts and used to publish a Release with none attached."""
     text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-    uploads = {m.group("major") for m in _ARTIFACT_ACTION_RE.finditer(text) if m.group("kind") == "upload"}
-    downloads = {m.group("major") for m in _ARTIFACT_ACTION_RE.finditer(text) if m.group("kind") == "download"}
+    uploads = [m.group("major") for m in _ARTIFACT_ACTION_RE.finditer(text) if m.group("kind") == "upload"]
+    downloads = [m.group("major") for m in _ARTIFACT_ACTION_RE.finditer(text) if m.group("kind") == "download"]
     assert uploads, "release.yml must use actions/upload-artifact"
     assert downloads, "release.yml must use actions/download-artifact"
-    assert uploads == downloads, (
-        f"upload-artifact majors {sorted(uploads)} must equal download-artifact majors {sorted(downloads)}"
+    assert len(set(uploads)) == 1, f"upload-artifact majors {sorted(set(uploads))} must be uniform"
+    assert len(set(downloads)) == 1, f"download-artifact majors {sorted(set(downloads))} must be uniform"
+    assert uploads[0] == downloads[0], (
+        f"upload-artifact major {uploads[0]} must equal download-artifact major {downloads[0]}"
     )
 
 
@@ -509,8 +511,10 @@ def test_attach_pkgs_empty_pkgs_fails_the_step(tmp_path: Path) -> None:
     empty_branch = re.search(r'if \[ -z "\$PKGS" \]; then(?P<body>.*?)\n\s*fi', script, re.DOTALL)
     assert empty_branch is not None, script
     assert "exit 0" not in empty_branch.group("body"), empty_branch.group("body")
+    assert re.search(r'find pkgs -type f -name "\*\.pkg"', script), script
 
     (tmp_path / "pkgs").mkdir()
+    (tmp_path / "pkgs" / "empty.pkg").mkdir()
     completed = subprocess.run(
         ["dash", "-c", script],
         cwd=tmp_path,

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -474,6 +474,11 @@ def test_build_pkgs_portable_leg_step_carries_row_identity_and_abi() -> None:
 # --------------------------------------------------------------------------- #
 
 
+_ARTIFACT_ACTION_RE = re.compile(
+    r"uses:\s+actions/(?P<kind>upload|download)-artifact@v(?P<major>\d+)"
+)
+
+
 def test_attach_pkgs_downloads_every_leg_by_pattern_with_merge() -> None:
     jobs = _jobs(RELEASE_WORKFLOW)
     steps = _split_into_steps(jobs["attach-pkgs"])
@@ -482,6 +487,40 @@ def test_attach_pkgs_downloads_every_leg_by_pattern_with_merge() -> None:
     step_text = "\n".join(target[0])
     assert "pattern: pfBlockerNG-relpkg-*" in step_text, step_text
     assert "merge-multiple: true" in step_text, step_text
+    assert "continue-on-error:" not in step_text, (
+        "attach-pkgs download must not continue-on-error (issue #2385):\n" + step_text
+    )
+
+
+def test_release_yml_upload_and_download_artifact_majors_match() -> None:
+    """issue #2385: a download-artifact major behind upload-artifact misses the
+    .pkg artifacts and used to publish a Release with none attached."""
+    text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    uploads = {m.group("major") for m in _ARTIFACT_ACTION_RE.finditer(text) if m.group("kind") == "upload"}
+    downloads = {m.group("major") for m in _ARTIFACT_ACTION_RE.finditer(text) if m.group("kind") == "download"}
+    assert uploads, "release.yml must use actions/upload-artifact"
+    assert downloads, "release.yml must use actions/download-artifact"
+    assert uploads == downloads, (
+        f"upload-artifact majors {sorted(uploads)} must equal download-artifact majors {sorted(downloads)}"
+    )
+
+
+def test_attach_pkgs_empty_pkgs_fails_the_step(tmp_path: Path) -> None:
+    """issue #2385: empty pkgs/ (download miss) must fail attach, not exit 0."""
+    script = _step_run_script(_step(_jobs(RELEASE_WORKFLOW)["attach-pkgs"], "Append .pkg files"))
+    empty_branch = re.search(r'if \[ -z "\$PKGS" \]; then(?P<body>.*?)\n\s*fi', script, re.DOTALL)
+    assert empty_branch is not None, script
+    assert "exit 0" not in empty_branch.group("body"), empty_branch.group("body")
+
+    (tmp_path / "pkgs").mkdir()
+    completed = subprocess.run(
+        ["dash", "-c", script],
+        cwd=tmp_path,
+        env=os.environ | {"GH_TOKEN": "test-token", "TAG": "v4.0.0.a1"},
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0, completed.stdout + completed.stderr
 
 
 def test_attach_pkgs_upload_step_runs_under_posix_sh(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #2385.

`attach-pkgs` downloaded with `actions/download-artifact@v4` after `@v7` upload, `continue-on-error: true`, and `exit 0` on an empty `pkgs/`. A Release could publish with no `.pkg`.

- `download-artifact@v7` (same major as upload)
- drop `continue-on-error`
- empty `pkgs/` is `exit 1`

Made-with: Grok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release packaging now fails when no package artifacts are available, preventing incomplete releases from appearing successful.
  * Artifact downloads and uploads now use matching action versions for more reliable release handling.
  * Package uploads remain safe to retry without creating duplicate artifacts.

* **Tests**
  * Added coverage for artifact version consistency and empty-package failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->