### PR TITLE
pkg-repo: require a channel and publish a safe bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,18 @@ Run the bootstrap **on the firewall** over SSH (as root), picking the channel yo
 want, then install the package:
 
 ```sh
-fetch -qo - https://pfblockerng.github.io/pkg/add-repo.sh | sh -s -- --channel stable
-pkg install pfSense-pkg-pfBlockerNG
+fetch -qo /tmp/add-repo.sh https://pfblockerng.github.io/pkg/add-repo.sh &&
+sh /tmp/add-repo.sh --channel stable &&
+pkg install -y -r pfblockerng-stable pfSense-pkg-pfBlockerNG
+```
+
+If pfBlockerNG is already installed (Netgate Package Manager, `pfSense-pkg-pfBlockerNG-devel`, or any leftover suffix), subscribe then migrate — `pkg install` will not move an existing package onto the new repository:
+
+```sh
+fetch -qo /tmp/add-repo.sh https://pfblockerng.github.io/pkg/add-repo.sh &&
+sh /tmp/add-repo.sh --channel stable &&
+fetch -qo /tmp/migrate-channel.sh https://pfblockerng.github.io/pkg/migrate-channel.sh &&
+sh /tmp/migrate-channel.sh --channel stable
 ```
 
 The bootstrap detects your pfSense edition and version, configures the matching
@@ -107,8 +117,10 @@ repository it came from and offers no upgrade across repositories, so a
 firewall that only gains a new conf silently keeps running its old build.
 
 ```sh
-fetch -qo - https://pfblockerng.github.io/pkg/add-repo.sh | sh -s -- --channel edge
-fetch -qo - https://pfblockerng.github.io/pkg/migrate-channel.sh | sh -s -- --channel edge
+fetch -qo /tmp/add-repo.sh https://pfblockerng.github.io/pkg/add-repo.sh &&
+sh /tmp/add-repo.sh --channel edge &&
+fetch -qo /tmp/migrate-channel.sh https://pfblockerng.github.io/pkg/migrate-channel.sh &&
+sh /tmp/migrate-channel.sh --channel edge
 ```
 
 `add-repo.sh` moves the subscription; `migrate-channel.sh` moves the installed

--- a/scripts/add-repo.sh
+++ b/scripts/add-repo.sh
@@ -6,10 +6,12 @@
 # edition/version, runs the hook once to resolve the conf now, then runs
 # `pkg update` and VERIFIES the package is visible from the channel's repo —
 # after which
-#   pkg install pfSense-pkg-pfBlockerNG   (or -y, no -f, no -r)
-# resolves deps and installs the pfBlockerNG build, and the stock
-# webConfigurator Install pulls it too via cross-repo resolution (ADR §2;
-# install is not repo-locked). Invocation forms: see --help.
+#   pkg install -y -r pfblockerng-<channel> pfSense-pkg-pfBlockerNG
+# resolves deps and installs the pfBlockerNG build from THIS channel. A box
+# that already has any pfSense-pkg-pfBlockerNG* (Netgate, -devel, leftover
+# suffix) must run migrate-channel.sh --channel <ch> instead — a bare
+# `pkg install` is a no-op on an already-installed name and will not move
+# %R. Invocation forms: see --help.
 #
 # WHY A HOOK DOES THE DETECTION: a pfSense OS upgrade can change the box's
 # edition/version (which moves the catalog subtree). The rc.d hook
@@ -33,7 +35,10 @@
 #   the box, reporting each removal — but only AFTER the new channel's catalogue is
 #   proven to serve this box, so a channel with no build for this edition/version
 #   can never strand a box by taking its working subscription with it. A run that
-#   fails leaves the repository configuration exactly as it found it.
+#   fails BEFORE the new catalogue verifies leaves the repository configuration
+#   exactly as it found it. AFTER verify, an interrupt keeps the proven new conf
+#   (peer retirement is one-way — restoring deleted peers would re-enable two
+#   equal-priority project repos).
 #
 #   Moving FORWARD is: re-run with the new `--channel`, then upgrade normally —
 #   ordinary `pkg` resolution applies only when the target version is higher
@@ -45,14 +50,10 @@
 #   (`pfSense-pkg-pfBlockerNG-devel`, `-nightly`) onto a channel is the job of the
 #   sibling `migrate-channel.sh`; this script configures repositories only.
 #
-#   LEGACY (unchanged; still the behaviour with NO argument): sets up the RELEASE
-#   repo `pfblockerng` — one shared catalog carrying BOTH the stable and devel
-#   packages, exactly like Netgate ships `pfSense-pkg-pfBlockerNG` and `-devel`
-#   from its single `pfSense` repo (the two packages CONFLICT — install one, see
-#   --help). `--channel release` is REJECTED — release is this legacy default,
-#   not one of the four channel names.
+#   `--channel` is REQUIRED (stable|testing|edge|nightly). There is no default:
+#   the old implicit `release/` tree is unpublished and `--channel release` is
+#   rejected. `--nightly` stays the alias for `--channel nightly`.
 #
-#   default                       -> conf pfblockerng.conf,          repo `pfblockerng`          (legacy release)
 #   --nightly / --channel nightly -> conf pfblockerng-nightly.conf,  repo `pfblockerng-nightly`
 #   --channel stable              -> conf pfblockerng-stable.conf,   repo `pfblockerng-stable`
 #   --channel testing             -> conf pfblockerng-testing.conf,  repo `pfblockerng-testing`
@@ -80,6 +81,12 @@
 #                     redirect conf/hook writes to a temp dir.
 #   PKG_BIN           pkg binary path (default: /usr/local/sbin/pkg); override
 #                     in tests to stub out pkg.
+#   PFB_ADD_REPO_RETIRE_HOOK
+#                     test-only: command run once after the first peer conf is
+#                     removed (used to inject SIGINT after retirement).
+#   PFB_ADD_REPO_DONE_HOOK
+#                     test-only: command run after drop_conf_backup (used to
+#                     inject SIGINT after a successful switch).
 
 set -eu
 
@@ -110,7 +117,7 @@ HOOK_SRC="${SCRIPT_DIR}/rc.d/pfblockerng_repo_generate.sh"
 pfb_emit_embedded_hook() {
     # PFB_EMBED_HOOK_BEGIN — do not edit; replaced by gen_landing.py at website-build time.
     printf 'add-repo: no embedded hook in this copy. Run from a checkout, or use the\n' >&2
-    printf '  published one-file bootstrap: fetch -qo - %s/add-repo.sh | sh\n' "${DEFAULT_BASE_URL}" >&2
+    printf '  published one-file bootstrap: fetch -qo /tmp/add-repo.sh %s/add-repo.sh && sh /tmp/add-repo.sh --channel <ch>\n' "${DEFAULT_BASE_URL}" >&2
     return 1
     # PFB_EMBED_HOOK_END
 }
@@ -122,7 +129,7 @@ CONF_PRIORITY=100
 # The marker the hook writes as the conf's first line (the verify target).
 CONF_MARKER="Generated at boot by pfblockerng_repo_generate"
 
-CHANNEL="release"
+CHANNEL=""
 PRINT_CONF=0
 BASE_URL="$DEFAULT_BASE_URL"
 CATALOG_PATH=""
@@ -135,32 +142,35 @@ Usage:
   add-repo.sh --channel stable|testing|edge|nightly
                                              subscribe to that channel, pkg update, verify
   add-repo.sh --nightly                      alias for --channel nightly
-  add-repo.sh                                legacy: the pre-channel shared release repo
   add-repo.sh --print-conf --channel <ch> --catalog-path <varver>
                                              print the repo conf to stdout and exit (no writes)
-  add-repo.sh --base-url <url> [--channel <ch>]
+  add-repo.sh --base-url <url> --channel <ch>
                                              override the catalog base (forks/staging)
+
+--channel is required (stable, testing, edge, or nightly). There is no default:
+the old implicit release/ tree is unpublished. --channel release is rejected.
 
 A box subscribes to EXACTLY ONE project channel repository: every channel serves the
 same canonical package at the same priority, and each channel's catalogue strictly
 contains its slower channels' files, so one repository is always sufficient.
 Subscribing therefore retires any other pfBlockerNG channel conf on the box.
 
-After subscribing, install the one canonical package:
-  pkg install pfSense-pkg-pfBlockerNG
+After subscribing:
+  New install:
+    pkg install -y -r pfblockerng-<channel> pfSense-pkg-pfBlockerNG
+  Existing install (Netgate, pfSense-pkg-pfBlockerNG-devel, or any leftover suffix):
+    migrate-channel.sh --channel <channel>
 
-To move to another channel, re-run with the new --channel and upgrade. Moving BACK to
-an older build is an explicit repository-qualified operation, e.g.
+To move to another channel, re-run with the new --channel then migrate-channel.sh.
+Moving BACK to an older build is an explicit repository-qualified operation, e.g.
   pkg install -f -r pfblockerng-edge pfSense-pkg-pfBlockerNG-<older-version>
 USAGE
 }
 
 # ── Arg parsing ────────────────────────────────────────────────────────────────
-# The channel is a FLAG, not a positional: default is the legacy release repo;
-# --channel <stable|testing|edge|nightly> selects a four-channel repo (issue #2147)
-# and --nightly stays the alias for --channel nightly. (The legacy release repo has
-# no stable/devel switch — both live in it; you pick the package at `pkg install`
-# time.)
+# The channel is a FLAG, not a positional. --channel is required
+# (stable|testing|edge|nightly); --nightly stays the alias for --channel nightly.
+# There is no implicit release default (issue #2384).
 while [ $# -gt 0 ]; do
     case "$1" in
         --nightly)      CHANNEL="nightly"; shift ;;
@@ -180,13 +190,16 @@ while [ $# -gt 0 ]; do
             BASE_URL="$2"; shift 2 ;;
         -h|--help)      usage; exit 0 ;;
         -*) printf 'add-repo: unknown option: %s (see --help)\n' "$1" >&2; exit 2 ;;
-        *)  printf 'add-repo: unexpected argument '\''%s'\'' — the channel is a flag (--nightly / --channel); the release repo is the default. See --help.\n' "$1" >&2; exit 2 ;;
+        *)  printf 'add-repo: unexpected argument '\''%s'\'' — the channel is a flag (--nightly / --channel). See --help.\n' "$1" >&2; exit 2 ;;
     esac
 done
 
+[ -n "${CHANNEL}" ] || {
+    printf 'add-repo: --channel is required (stable, testing, edge, or nightly); there is no default\n' >&2
+    exit 2
+}
+
 # ── Per-channel identity ───────────────────────────────────────────────────────
-# release (default) -> repo `pfblockerng`,          conf pfblockerng.conf,          `release/` subtree (legacy)
-#                      carries BOTH pfSense-pkg-pfBlockerNG (stable) and ...-devel
 # nightly           -> repo `pfblockerng-nightly`,  conf pfblockerng-nightly.conf,  `nightly/` subtree
 # stable            -> repo `pfblockerng-stable`,   conf pfblockerng-stable.conf,   `stable/` subtree
 # testing           -> repo `pfblockerng-testing`,  conf pfblockerng-testing.conf,  `testing/` subtree
@@ -195,8 +208,9 @@ done
 # `pfSense-pkg-pfBlockerNG` identity — channel is catalogue placement, not a
 # package-name suffix (the `-nightly` spelling is a native ports RECIPE name; the
 # published nightly artifact is canonical). PKG_NAMES: the package(s) the verify
-# step checks + the install hints printed. Only the legacy release repo carries
-# two; every channel repo carries exactly the canonical one.
+# step checks. Every channel repo carries exactly the canonical one. The legacy
+# `release` identity is kept only so an already-on-disk pfblockerng.conf can
+# still be named in PROJECT_CONFS for retirement; --channel release is rejected.
 case "$CHANNEL" in
     release)
         REPO_NAME="pfblockerng"
@@ -317,12 +331,13 @@ fi
 printf '==> Staging %s conf at %s (hook will resolve it)\n' "${CHANNEL}" "${CONF_PATH}"
 printf '# pfBlockerNG %s repo conf — pending boot-time generation (ADR-39).\n' "${CHANNEL}" > "${CONF_PATH}"
 
-# Undo everything THIS run did to the repository configuration, so a failed bootstrap
-# leaves the box exactly as it found it: a conf this run created is removed, and a conf
-# it truncated is restored byte-for-byte. Either way the box keeps a working
-# subscription — losing one is the destruction this ordering exists to prevent.
-# $1 = exit status (default 1; the signal trap passes 130).
+# Undo everything THIS run did to the repository configuration, so a failed
+# bootstrap BEFORE verify leaves the box exactly as it found it: a conf this
+# run created is removed, and a conf it truncated is restored byte-for-byte.
+# After verify the INT trap no longer calls this (issue #2397).
+# $1 = exit status (default 1; the pre-verify signal trap passes 130).
 abort_unstaged() {
+    _abort_rc="${1:-1}"
     if [ -n "${CONF_BACKUP}" ]; then
         mv -f "${CONF_BACKUP}" "${CONF_PATH}"
         CONF_BACKUP=""
@@ -331,7 +346,7 @@ abort_unstaged() {
         rm -f "${CONF_PATH}"
         printf '  Removed the conf this run staged; your previous subscription is untouched.\n' >&2
     fi
-    exit "${1:-1}"
+    exit "${_abort_rc}"
 }
 
 # On success the backup is redundant — drop it so no stray file is left in the repos dir.
@@ -372,23 +387,20 @@ fi
 printf '==> Conf resolved:\n'
 sed -n 's/^[[:space:]]*url:[[:space:]]*/    url: /p' "${CONF_PATH}" >&2
 
-# 5. pkg update (refresh catalogs, including the pfBlockerNG repo), then VERIFY a
-#    pfBlockerNG package is visible FROM the pfBlockerNG repo (not merely that pkg
-#    update ran). `pkg rquery -r <repo>` queries that ONE repo's catalog, so a
-#    still-enabled previous channel cannot mask a missing package here. Every
-#    channel repo carries the one canonical package; only the legacy release repo
-#    carries two (stable may not be published yet) — finding EITHER proves that
-#    repo loaded. Exit non-zero (fail loud) only if NONE present.
-# `pkg update` exits non-zero when ANY enabled repository fails to refresh — including
-# the channel this run is switching AWAY from, whose catalogue may be exactly what went
-# unpublished. Under `set -e` that would abort here: after the conf was staged, before
-# retirement, leaving the box subscribed to TWO project repositories at equal priority.
-# Route it through the same cleanup as every other failure instead.
-printf '==> pkg update (refreshing catalogs, including the pfBlockerNG repo)\n'
-env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" update -f >/dev/null || {
-    printf 'add-repo: %s update -f failed — catalogs were not refreshed.\n' "${PKG_BIN}" >&2
-    printf '  A repository is unreachable or serving an unreadable catalog.\n' >&2
-    printf '  Inspect with: %s -d update   (traces the catalog fetch)\n' "${PKG_BIN}" >&2
+# 5. pkg update scoped to THIS repo, then VERIFY a pfBlockerNG package is visible
+#    FROM the pfBlockerNG repo (not merely that pkg update ran). `pkg rquery -r
+#    <repo>` queries that ONE repo's catalog, so a still-enabled previous channel
+#    cannot mask a missing package here. An unscoped `pkg update -f` would fail
+#    closed if ANY enabled repository 404s — including a leftover pfblockerng.conf
+#    pointed at unpublished release/ — and abort the switch (issue #2384). Scope
+#    to REPO_NAME so a dead peer cannot veto the target.
+printf '==> pkg update -f -r %s (refreshing the staged pfBlockerNG catalog)\n' "${REPO_NAME}"
+env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" update -f -r "${REPO_NAME}" || {
+    printf 'add-repo: %s update -f -r %s failed — the staged catalog was not refreshed.\n' \
+        "${PKG_BIN}" "${REPO_NAME}" >&2
+    printf '  Repo '\''%s'\'' is unreachable or serving an unreadable catalog.\n' "${REPO_NAME}" >&2
+    printf '  Inspect with: %s -d update -r %s   (traces the catalog fetch)\n' \
+        "${PKG_BIN}" "${REPO_NAME}" >&2
     abort_unstaged
 }
 
@@ -397,12 +409,32 @@ found_any=0
 # Word-splitting the space-separated package list is intentional.
 # shellcheck disable=SC2086
 for pkg_name in $PKG_NAMES; do
-    if "${PKG_BIN}" rquery -r "${REPO_NAME}" '%n %v' "${pkg_name}" 2>/dev/null | grep -q .; then
-        # rquery lists EVERY version the catalogue retains, in catalogue order —
-        # report the newest one, which is what `pkg install` would resolve.
-        found="$("${PKG_BIN}" rquery -r "${REPO_NAME}" '%n-%v' "${pkg_name}" 2>/dev/null | sort -V | tail -n1)"
+    # rquery lists EVERY version the catalogue retains, in catalogue order.
+    # Pick the highest with `pkg version -t` — the comparator `pkg install`
+    # itself resolves by (issue #2393). sort -V is the wrong tool for
+    # PORTREVISION `_N` and pkg-safe prereleases.
+    TARGET_VERSION=""
+    for _offered in $("${PKG_BIN}" rquery -r "${REPO_NAME}" '%v' "${pkg_name}" 2>/dev/null || true); do
+        if [ -z "${TARGET_VERSION}" ]; then
+            TARGET_VERSION="${_offered}"
+            continue
+        fi
+        # A comparator that answers nothing would silently degrade this loop
+        # back to "keep the first line". Name the real cause instead.
+        _order="$("${PKG_BIN}" version -t "${_offered}" "${TARGET_VERSION}" 2>/dev/null || true)"
+        case "${_order}" in
+        '>') TARGET_VERSION="${_offered}" ;;
+        '<' | '=') ;;
+        *)
+            printf 'add-repo: %s version -t gave no usable answer comparing '\''%s'\'' and '\''%s'\'' — cannot tell which build %s would install\n' \
+                "${PKG_BIN}" "${_offered}" "${TARGET_VERSION}" "${REPO_NAME}" >&2
+            abort_unstaged
+            ;;
+        esac
+    done
+    if [ -n "${TARGET_VERSION}" ]; then
+        found="${pkg_name}-${TARGET_VERSION}"
         printf '==> OK: %s available from '\''%s'\''\n' "${found}" "${REPO_NAME}"
-        printf '    Install:  %s install %s\n' "${PKG_BIN}" "${pkg_name}"
         found_any=1
     fi
 done
@@ -410,22 +442,64 @@ if [ "${found_any}" -eq 0 ]; then
     printf 'add-repo: no pfBlockerNG package visible from repo '\''%s'\'' after pkg update.\n' "${REPO_NAME}" >&2
     printf '  Checked conf: %s\n' "${CONF_PATH}" >&2
     printf '  The catalog may not be published yet for this box'\''s variant, or the URL is unreachable.\n' >&2
-    printf '  Inspect with: %s -d update   (traces the catalog fetch)\n' "${PKG_BIN}" >&2
+    printf '  Inspect with: %s -d update -r %s   (traces the catalog fetch)\n' \
+        "${PKG_BIN}" "${REPO_NAME}" >&2
     abort_unstaged
+fi
+
+# The target catalogue is proven. From here an interrupt must KEEP the new
+# conf: abort_unstaged would delete it (no backup on a first subscribe) after
+# peers are already gone, leaving zero project repos (issue #2397).
+trap 'drop_conf_backup; exit 130' INT HUP TERM
+
+# Install hint: a leftover Netgate / -devel / suffixed identity is NOT moved
+# by this script (repos-only contract). Point those boxes at migrate-channel.sh
+# and never print a bare `pkg install pfSense-pkg-pfBlockerNG` (issue #2381).
+_installed="$("${PKG_BIN}" query -g '%n' 'pfSense-pkg-pfBlockerNG*' 2>/dev/null || true)"
+_installed="$(printf '%s\n' "${_installed}" | grep -v '^[[:space:]]*$' || true)"
+if [ -n "${_installed}" ]; then
+    printf '==> Repositories are configured; the running package has not moved.\n'
+    printf '%s\n' "${_installed}" | while IFS= read -r _iname; do
+        [ -n "${_iname}" ] || continue
+        _iver="$("${PKG_BIN}" query '%v' "${_iname}" 2>/dev/null || true)"
+        _irepo="$("${PKG_BIN}" query '%R' "${_iname}" 2>/dev/null || true)"
+        printf '    Installed: %s-%s (from repo %s)\n' \
+            "${_iname}" "${_iver:-unknown}" "${_irepo:-unknown}"
+    done
+    printf '    Next: fetch -qo /tmp/migrate-channel.sh %s/migrate-channel.sh &&\n' "${BASE_URL%/}"
+    printf '          sh /tmp/migrate-channel.sh --channel %s\n' "${CHANNEL}"
+else
+    printf '    Install:  pkg install -y -r %s pfSense-pkg-pfBlockerNG\n' "${REPO_NAME}"
 fi
 
 # 6. Only now enforce single-repository subscription: the target is proven usable, so
 #    retiring every OTHER project conf cannot strand the box. After this the box is
 #    subscribed to exactly one channel and `pkg` never has to choose between two
 #    equal-priority project repositories. Reported, never silent.
-printf '%s\n' "${PROJECT_CONFS}" | while IFS= read -r _other_conf; do
+#    The loop stays in this shell (here-doc, not a pipe) so a test-only retire
+#    hook can SIGINT the same process that holds the post-verify trap.
+while IFS= read -r _other_conf; do
     [ -n "${_other_conf}" ] || continue
     [ "${_other_conf}" = "${CONF_NAME}" ] && continue
     [ -f "${REPOS_DIR}/${_other_conf}" ] || continue
     printf '==> Retiring %s — a box subscribes to ONE pfBlockerNG channel\n' \
         "${REPOS_DIR}/${_other_conf}"
     rm -f "${REPOS_DIR}/${_other_conf}"
-done
+    if [ -n "${PFB_ADD_REPO_RETIRE_HOOK:-}" ]; then
+        _retire_hook="${PFB_ADD_REPO_RETIRE_HOOK}"
+        PFB_ADD_REPO_RETIRE_HOOK=""
+        # Test-only seam (issue #2397): inject SIGINT after the first peer rm.
+        eval "${_retire_hook}"
+    fi
+done <<EOF
+${PROJECT_CONFS}
+EOF
 drop_conf_backup
+
+if [ -n "${PFB_ADD_REPO_DONE_HOOK:-}" ]; then
+    _done_hook="${PFB_ADD_REPO_DONE_HOOK}"
+    PFB_ADD_REPO_DONE_HOOK=""
+    eval "${_done_hook}"
+fi
 
 printf '==> Done — conf at %s\n' "${CONF_PATH}"

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -400,16 +400,34 @@ def _manual_conf_details(conf_fn: Callable[[str], str], channel: str) -> str:
     )
 
 
-def _bootstrap_install(base: str, channel: str) -> str:
-    """A channel's unified command: the bootstrap one-liner + its `pkg install`.
+def _bootstrap_new_install(base: str, channel: str) -> str:
+    """File-form bootstrap + repo-qualified install for a clean box (issues #2381, #2390).
 
-    All four channels install the SAME canonical package (issue #2147) — `--channel
-    <ch>` selects the catalogue, uniformly across every card (not a nightly-only flag).
+    On-disk ``fetch`` then ``sh /tmp/add-repo.sh``, joined with ``&&`` so a failed
+    subscribe does not run ``pkg install``. ``-r pfblockerng-<channel>`` so the
+    install cannot resolve against Netgate. The pipe form (``fetch | sh -s``) is
+    not the published recipe: some ash builds re-read a function-body heredoc
+    from current stdin at call time.
     """
     return (
-        f"fetch -qo - {base}/add-repo.sh \\\n"
-        f"  | sh -s -- --base-url {base} --channel {channel}\n"
-        f"pkg install {CANONICAL_EMITTED_IDENTITY}"
+        f"fetch -qo /tmp/add-repo.sh {base}/add-repo.sh &&\n"
+        f"sh /tmp/add-repo.sh --base-url {base} --channel {channel} &&\n"
+        f"pkg install -y -r pfblockerng-{channel} {CANONICAL_EMITTED_IDENTITY}"
+    )
+
+
+def _bootstrap_existing_install(base: str, channel: str) -> str:
+    """File-form bootstrap + migrate-channel for an already-installed package.
+
+    ``pkg install`` does not move an existing ``pfSense-pkg-pfBlockerNG`` (or
+    leftover ``-devel`` / suffixed identity) onto the new repository. Existing
+    installs must run migrate-channel.sh after add-repo (issue #2381).
+    """
+    return (
+        f"fetch -qo /tmp/add-repo.sh {base}/add-repo.sh &&\n"
+        f"sh /tmp/add-repo.sh --base-url {base} --channel {channel} &&\n"
+        f"fetch -qo /tmp/migrate-channel.sh {base}/migrate-channel.sh &&\n"
+        f"sh /tmp/migrate-channel.sh --channel {channel}"
     )
 
 
@@ -456,18 +474,27 @@ _CARD_META: dict[str, dict[str, str]] = {
 
 
 def _channel_card(channel: str, base: str, latest: dict[str, str], conf_fn: Callable[[str], str]) -> str:
-    """One channel's install card: audience prose + the unified bootstrap/install command
-    + a collapsed manual-conf snippet. Every channel installs the ONE canonical package
-    (issue #2147) — channel is catalogue placement, never a name suffix."""
+    """One channel's install card: audience prose, and — only when published —
+    the new-install recipe, the existing-install migrate path, and a collapsed
+    manual-conf snippet. An unpublished channel keeps title/badge/blurb/"not yet
+    published" and ships no add-repo / pkg install / conf snippet (issue #2382)."""
     meta = _CARD_META[channel]
     badge = f" {meta['badge']}" if meta["badge"] else ""
-    return (
+    body = (
         f'<div class="card {channel}"><h3>{meta["title"]}{badge}</h3>'
         f'<p class="ver">{_ver_or_empty(latest, channel)}</p>'
         f'<p class="blurb">{meta["blurb"]}</p>'
-        f"{_copyable(_esc(_bootstrap_install(base, channel)))}"
-        f"{_manual_conf_details(conf_fn, channel)}</div>"
     )
+    if latest.get(channel):
+        devel = f"{CANONICAL_EMITTED_IDENTITY}-devel"
+        body += (
+            '<p class="blurb">New install:</p>'
+            f"{_copyable(_esc(_bootstrap_new_install(base, channel)))}"
+            f'<p class="blurb">Existing install (Netgate or leftover <code>{_esc(devel)}</code>):</p>'
+            f"{_copyable(_esc(_bootstrap_existing_install(base, channel)))}"
+            f"{_manual_conf_details(conf_fn, channel)}"
+        )
+    return f"{body}</div>"
 
 
 def _is_wildcard_abi(abi: str) -> bool:

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -616,6 +616,28 @@ def test_verify_reports_newest_version_when_catalogue_carries_several() -> None:
         assert "version -t" in log, f"verify must call pkg version -t, log was:\n{log}"
 
 
+def test_verify_reports_newest_version_when_catalogue_is_oldest_first() -> None:
+    """Reverse rquery order must still report 3.3.2 (issue #2393).
+
+    Newest-first fixtures stay green if verify takes the first line. Oldest-first
+    is the row that goes red if ``pkg version -t`` is ignored.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_add_repo(
+            root,
+            extra_args=("--channel", "stable"),
+            rquery_lines=(
+                "pfSense-pkg-pfBlockerNG-3.3.0",
+                "pfSense-pkg-pfBlockerNG-3.3.2",
+            ),
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "==> OK: pfSense-pkg-pfBlockerNG-3.3.2 available" in proc.stdout, (
+            f"verify must pick newest even when rquery lists oldest first:\n{proc.stdout}"
+        )
+        assert "version -t" in _pkg_log(root).read_text()
+
+
 def test_verify_picks_portrevision_via_pkg_version_t() -> None:
     """``pkg version -t`` must prefer PORTREVISION ``_2`` over ``_1`` of the same PORTVERSION."""
     with tempfile.TemporaryDirectory() as root:
@@ -625,6 +647,22 @@ def test_verify_picks_portrevision_via_pkg_version_t() -> None:
             rquery_lines=(
                 "pfSense-pkg-pfBlockerNG-3.3.2_2",
                 "pfSense-pkg-pfBlockerNG-3.3.2_1",
+            ),
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "==> OK: pfSense-pkg-pfBlockerNG-3.3.2_2 available" in proc.stdout, proc.stdout
+        assert "version -t" in _pkg_log(root).read_text()
+
+
+def test_verify_picks_portrevision_when_rquery_lists_older_revision_first() -> None:
+    """PORTREVISION pick must not depend on rquery order."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_add_repo(
+            root,
+            extra_args=("--channel", "stable"),
+            rquery_lines=(
+                "pfSense-pkg-pfBlockerNG-3.3.2_1",
+                "pfSense-pkg-pfBlockerNG-3.3.2_2",
             ),
         )
         assert proc.returncode == 0, proc.stderr

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -208,7 +208,7 @@ def _run_add_repo(
     unscoped_guard = ""
     if unscoped_update_fails and not update_fails:
         unscoped_guard = (
-            '  _saw_r=0\n'
+            "  _saw_r=0\n"
             '  _prev=""\n'
             '  for _a in "$@"; do\n'
             '    if [ "$_prev" = "-r" ]; then _saw_r=1; fi\n'
@@ -1198,12 +1198,7 @@ def test_leftover_release_conf_does_not_block_stable_switch() -> None:
         repos = _repos_dir(root)
         repos.mkdir(parents=True)
         leftover = repos / "pfblockerng.conf"
-        leftover.write_text(
-            "pfblockerng: {\n"
-            f'  url: "{_PAGES_BASE}/release/ce-2.8",\n'
-            "  enabled: yes\n"
-            "}\n"
-        )
+        leftover.write_text(f'pfblockerng: {{\n  url: "{_PAGES_BASE}/release/ce-2.8",\n  enabled: yes\n}}\n')
 
         proc = _run_add_repo(
             root,

--- a/tests/test_add_repo_conf.py
+++ b/tests/test_add_repo_conf.py
@@ -123,6 +123,22 @@ def _print_conf_sh(script: Path, catalog_path: str = _CE_28, base_url: str = _PA
     return proc.stdout
 
 
+def _pkg_log(root: str) -> Path:
+    """Invocation log written by the fake ``pkg`` stub under ``root``."""
+    return Path(root) / "pkg-invocations.log"
+
+
+def _parse_rquery_line(line: str) -> tuple[str, str]:
+    """Split a stub rquery fixture line into ``(name, version)``."""
+    if " " in line:
+        name, ver = line.split(" ", 1)
+        return name, ver
+    prefix = "pfSense-pkg-pfBlockerNG-"
+    if line.startswith(prefix):
+        return "pfSense-pkg-pfBlockerNG", line[len(prefix) :]
+    return line, line
+
+
 def _run_add_repo(
     root: str,
     *,
@@ -130,48 +146,117 @@ def _run_add_repo(
     extra_args: tuple[str, ...] = (),
     catalogue_empty: bool = False,
     update_fails: bool = False,
+    unscoped_update_fails: bool = False,
+    version_t_broken: bool = False,
     detection_fails: bool = False,
     rquery_lines: tuple[str, ...] | None = None,
+    installed_names: tuple[str, ...] = (),
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run add-repo.sh with PFBLOCKERNG_ROOT=root.
 
     PKG_BIN is overridden to a stub that answers `pkg rquery` with a plausible
-    package line, so the bootstrap reaches its success path; every other subcommand
-    is a silent success. The generator hook no longer calls `pkg` at all (arch-less
-    catalog; issue #1806 — it used to read `pkg config abi` only to derive the
-    now-retired per-arch leaf), so `rquery` is the only answer that matters.
-    add-repo.sh installs the generator hook into ``root`` and runs it; the hook
-    resolves the conf from ``root/etc/product_label`` (CE here — no "Plus") and
-    ``root/etc/version`` (2.8.1).
+    package line, implements `pkg version -t` (issue #2393), and logs every
+    invocation to ``root/pkg-invocations.log``. The generator hook no longer
+    calls `pkg` at all (arch-less catalog; issue #1806). add-repo.sh installs
+    the generator hook into ``root`` and runs it; the hook resolves the conf
+    from ``root/etc/product_label`` (CE here — no "Plus") and ``root/etc/version``
+    (2.8.1).
 
-    The three keyword flags each select one of the bootstrap's failure gates, all of
+    The keyword flags each select one of the bootstrap's failure gates, all of
     which must leave the box's repository configuration exactly as they found it
-    (issue #2148):
+    (issue #2148) when they fire *before* the new catalogue verifies:
 
     ``catalogue_empty``  `rquery` yields nothing — the channel has no build for this
                          box's variant.
-    ``update_fails``     `pkg update` exits non-zero — any enabled repository failed
-                         to refresh, including the one being switched away from.
+    ``update_fails``     `pkg update` exits non-zero even when scoped with ``-r``.
+    ``unscoped_update_fails``
+                         unscoped `pkg update` exits 1 (a leftover peer 404);
+                         ``update -f -r <repo>`` still succeeds.
+    ``version_t_broken`` `pkg version -t` prints garbage so the comparator guard
+                         must fail loud.
     ``detection_fails``  ``/etc/version`` is blank, so the generator hook cannot
                          resolve a varver and never writes the conf's marker line.
 
     ``rquery_lines`` replaces the stub's default single-package `rquery` answer with
-    the given lines verbatim — a catalogue that retains several versions of the one
+    the given lines — a catalogue that retains several versions of the one
     canonical package answers with one line per version.
+
+    ``installed_names`` is what ``pkg query -g '%n' 'pfSense-pkg-pfBlockerNG*'``
+    prints (issue #2381 install-hint).
     """
     bin_dir = os.path.join(root, "bin")
     os.makedirs(bin_dir, exist_ok=True)
 
     fake_pkg = os.path.join(bin_dir, "pkg")
+    log_path = _pkg_log(root)
     if rquery_lines is None:
         rquery_lines = () if catalogue_empty else ("pfSense-pkg-pfBlockerNG 4.0.0",)
-    rquery_reply = "".join(f"  printf '{line}\\n'\n" for line in rquery_lines)
-    update_reply = "  exit 1\n" if update_fails else "  exit 0\n"
+    pairs = [_parse_rquery_line(line) for line in rquery_lines]
+    # One case block that prints every offered version for the requested format.
+    rquery_fmt_body = ""
+    for name, ver in pairs:
+        rquery_fmt_body += (
+            '    case "$fmt" in\n'
+            f'      "%v") printf "%s\\n" "{ver}" ;;\n'
+            f'      "%n-%v") printf "%s\\n" "{name}-{ver}" ;;\n'
+            f'      "%n %v"|*) printf "%s\\n" "{name} {ver}" ;;\n'
+            "    esac\n"
+        )
+    installed_prints = "".join(f'    printf "%s\\n" "{n}"\n' for n in installed_names)
+    update_fail_line = "  exit 1\n" if update_fails else ""
+    unscoped_guard = ""
+    if unscoped_update_fails and not update_fails:
+        unscoped_guard = (
+            '  _saw_r=0\n'
+            '  _prev=""\n'
+            '  for _a in "$@"; do\n'
+            '    if [ "$_prev" = "-r" ]; then _saw_r=1; fi\n'
+            '    _prev="$_a"\n'
+            "  done\n"
+            '  if [ "$_saw_r" -eq 0 ]; then exit 1; fi\n'
+        )
+    version_t_body = (
+        '  printf "?\\n"\n  exit 0\n'
+        if version_t_broken
+        else (
+            '  _a="$3"; _b="$4"\n'
+            '  if [ "$_a" = "$_b" ]; then printf "=\\n"; exit 0; fi\n'
+            '  _first=$(printf "%s\\n%s\\n" "$_a" "$_b" | sort -V | head -n1)\n'
+            '  if [ "$_first" = "$_a" ]; then printf "<\\n"; else printf ">\\n"; fi\n'
+            "  exit 0\n"
+        )
+    )
     with open(fake_pkg, "w") as fh:
         fh.write(
             "#!/bin/sh\n# fake pkg stub for tests\n"
-            f'if [ "$1" = "rquery" ]; then\n{rquery_reply}  exit 0\nfi\n'
-            f'if [ "$1" = "update" ]; then\n{update_reply}fi\n'
+            f'printf "%s\\n" "$*" >> "{log_path}"\n'
+            'if [ "$1" = "version" ] && [ "$2" = "-t" ]; then\n'
+            f"{version_t_body}"
+            "fi\n"
+            'if [ "$1" = "rquery" ]; then\n'
+            '  fmt=""\n'
+            '  for _a in "$@"; do\n'
+            '    case "$_a" in %*) fmt="$_a" ;; esac\n'
+            "  done\n"
+            f"{rquery_fmt_body}"
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "update" ]; then\n'
+            f"{unscoped_guard}"
+            f"{update_fail_line}"
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "query" ]; then\n'
+            '  case "$*" in\n'
+            '    *"%n"*)\n'
+            f"{installed_prints}"
+            "      exit 0 ;;\n"
+            '    *"%v"*) printf "3.2.14_2\\n"; exit 0 ;;\n'
+            '    *"%R"*) printf "pfSense\\n"; exit 0 ;;\n'
+            "  esac\n"
+            "  exit 0\n"
+            "fi\n"
             "exit 0\n"
         )
     os.chmod(fake_pkg, 0o755)
@@ -189,6 +274,7 @@ def _run_add_repo(
         **os.environ,
         "PFBLOCKERNG_ROOT": root,
         "PKG_BIN": fake_pkg,
+        **(extra_env or {}),
     }
     argv = ["sh", str(_ADD_REPO), *(["--nightly"] if nightly else []), *extra_args]
     return subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
@@ -206,37 +292,32 @@ def _field(conf: str, key: str) -> str:
 # --------------------------------------------------------------------------- #
 
 
-def test_release_conf_byte_identical_across_all_three_generators() -> None:
-    """The release conf from add-repo.sh == build-repo.sh == build-repo-portable.py, byte-for-byte.
+def test_release_conf_byte_identical_across_producer_generators() -> None:
+    """Producer --print-conf still defaults to the legacy release tree, byte-for-byte.
 
-    All three generators receive the SAME ``--catalog-path`` and ``--base-url`` so the
-    resolved URL is deterministic and byte-identical output is meaningful.
-
-    Before-state: before this test, no conf file exists (pure --print-conf mode, no writes).
+    add-repo.sh no longer emits a release conf (``--channel`` is required and
+    ``release`` is rejected — issue #2384). The catalogue producers keep their
+    internal default for assembling unpublished/legacy trees.
     """
-    add = _print_conf_sh(_ADD_REPO)  # default = release channel
     build = _print_conf_sh(_BUILD_REPO)
     portable = _print_conf_portable()
 
-    # Before-state assertion: all three produce the SAME non-empty conf.
-    assert add, "add-repo.sh --print-conf produced empty output"
     assert build, "build-repo.sh --print-conf produced empty output"
     assert portable, "build-repo-portable.py --print-conf produced empty output"
-
-    # byte-identity
-    assert add == build, f"add-repo.sh and build-repo.sh drifted:\nadd:\n{add}\nbuild:\n{build}"
-    assert add == portable, f"add-repo.sh and build-repo-portable.py drifted:\nadd:\n{add}\nportable:\n{portable}"
+    assert build == portable, (
+        f"build-repo.sh and build-repo-portable.py drifted:\nbuild:\n{build}\nportable:\n{portable}"
+    )
 
 
 def test_release_conf_byte_identical_plus_26_03() -> None:
-    """Byte-identity holds for a Plus 26.03 box (second representative case)."""
+    """Producer byte-identity holds for a Plus 26.03 box (second representative case)."""
     cat = _PLUS_2603
-    add = _print_conf_sh(_ADD_REPO, cat)
     build = _print_conf_sh(_BUILD_REPO, cat)
     portable = _print_conf_portable(cat)
 
-    assert add == build, f"add-repo.sh vs build-repo.sh mismatch (plus-26.03):\nadd:\n{add}\nbuild:\n{build}"
-    assert add == portable, f"add-repo.sh vs portable mismatch (plus-26.03):\nadd:\n{add}\nportable:\n{portable}"
+    assert build == portable, (
+        f"build-repo.sh vs portable mismatch (plus-26.03):\nbuild:\n{build}\nportable:\n{portable}"
+    )
 
 
 def _hook_conf_env(repos: str) -> dict[str, str]:
@@ -289,7 +370,7 @@ def test_hook_output_byte_identical_to_print_conf_release() -> None:
     """
     with tempfile.TemporaryDirectory() as root:
         hook_conf = _run_hook(root, edition_label="pfSense", version="2.8.1", channel="release")
-    print_conf = _print_conf_sh(_ADD_REPO, _CE_28)
+    print_conf = _print_conf_sh(_BUILD_REPO, _CE_28)
     assert hook_conf == print_conf, f"hook vs --print-conf drift:\nhook:\n{hook_conf}\nprint-conf:\n{print_conf}"
 
 
@@ -345,12 +426,12 @@ def test_hook_orphan_guard_holds_for_every_channel(channel: str) -> None:
 @pytest.mark.parametrize(
     ("catalog_path", "channel_args", "repo_name", "expected_url"),
     [
-        # CE 2.8 — release channel
+        # CE 2.8 — stable channel
         (
             _CE_28,
-            (),
-            "pfblockerng",
-            f"{_PAGES_BASE}/release/{_CE_28}",
+            ("--channel", "stable"),
+            "pfblockerng-stable",
+            f"{_PAGES_BASE}/stable/{_CE_28}",
         ),
         # CE 2.8 — nightly channel
         (
@@ -359,12 +440,12 @@ def test_hook_orphan_guard_holds_for_every_channel(channel: str) -> None:
             "pfblockerng-nightly",
             f"{_PAGES_BASE}/nightly/{_CE_28}",
         ),
-        # Plus 26.03 — release channel
+        # Plus 26.03 — stable channel
         (
             _PLUS_2603,
-            (),
-            "pfblockerng",
-            f"{_PAGES_BASE}/release/{_PLUS_2603}",
+            ("--channel", "stable"),
+            "pfblockerng-stable",
+            f"{_PAGES_BASE}/stable/{_PLUS_2603}",
         ),
         # Plus 26.03 — nightly channel
         (
@@ -407,7 +488,7 @@ def test_add_repo_conf_resolved_url_shape(
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.parametrize("channel_args", [(), ("--nightly",)])
+@pytest.mark.parametrize("channel_args", [("--channel", "stable"), ("--nightly",)])
 @pytest.mark.parametrize(
     "generator",
     ["add-repo.sh", "build-repo.sh", "build-repo-portable.py"],
@@ -417,20 +498,21 @@ def test_no_abi_placeholder_in_any_generator_output(generator: str, channel_args
 
     ADR-39 contracts: the URL is fully resolved at bootstrap; the ${ABI} expansion
     trick from ADR-17/20 is retired because one ABI can map to multiple pfSense
-    versions (varver keying is mandatory).
+    versions (varver keying is mandatory). add-repo.sh requires ``--channel``
+    (issue #2384); producers may still default to release when no channel is given.
     """
     cat = _CE_28
     if generator == "add-repo.sh":
         conf = _print_conf_sh(_ADD_REPO, cat, _PAGES_BASE, *channel_args)
     elif generator == "build-repo.sh":
-        # build-repo.sh only has a release channel --print-conf
-        if channel_args:
+        # build-repo.sh --print-conf accepts --channel but not the --nightly alias.
+        if channel_args == ("--nightly",):
             pytest.skip("build-repo.sh does not support --nightly in --print-conf mode")
-        conf = _print_conf_sh(_BUILD_REPO, cat)
+        conf = _print_conf_sh(_BUILD_REPO, cat, _PAGES_BASE, *channel_args)
     else:
-        if channel_args:
+        if channel_args == ("--nightly",):
             pytest.skip("build-repo-portable.py has no --nightly alias (channels use --channel)")
-        conf = _print_conf_portable(cat)
+        conf = _print_conf_portable(cat, _PAGES_BASE, channel="stable")
 
     assert "${ABI}" not in conf, f"{generator} {channel_args}: found ${{ABI}} in conf:\n{conf}"
 
@@ -443,8 +525,8 @@ def test_no_abi_placeholder_in_any_generator_output(generator: str, channel_args
 @pytest.mark.parametrize(
     ("channel_args", "repo_name", "other_repo"),
     [
-        ((), "pfblockerng", "pfblockerng-nightly"),
-        (("--nightly",), "pfblockerng-nightly", "pfblockerng"),
+        (("--channel", "stable"), "pfblockerng-stable", "pfblockerng-nightly"),
+        (("--nightly",), "pfblockerng-nightly", "pfblockerng-stable"),
     ],
 )
 def test_add_repo_conf_fields_per_channel(
@@ -454,7 +536,7 @@ def test_add_repo_conf_fields_per_channel(
 ) -> None:
     """Both channels carry priority 100, mirror_type/signature_type none, enabled yes.
 
-    Default (no arg) -> ``pfblockerng`` (stable + devel); --nightly ->
+    ``--channel stable`` -> ``pfblockerng-stable``; --nightly ->
     ``pfblockerng-nightly``.  The OTHER repo name must not appear as a stanza key.
     """
     conf = _print_conf_sh(_ADD_REPO, _CE_28, _PAGES_BASE, *channel_args)
@@ -487,13 +569,13 @@ def test_conf_written_once_invariant() -> None:
     Then  the conf is byte-identical (no re-bootstrap drift).
     """
     with tempfile.TemporaryDirectory() as root:
-        conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng.conf"
+        conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng-stable.conf"
 
         # Given: conf does not exist (before-state)
         assert not conf_path.exists(), "conf should not exist before the first run"
 
         # When: first run writes the conf
-        _run_add_repo(root)
+        _run_add_repo(root, extra_args=("--channel", "stable"))
         assert conf_path.exists(), "conf should be written by add-repo.sh"
         content_first = conf_path.read_text()
 
@@ -502,7 +584,7 @@ def test_conf_written_once_invariant() -> None:
         assert "${ABI}" not in content_first
 
         # When: second run
-        _run_add_repo(root)
+        _run_add_repo(root, extra_args=("--channel", "stable"))
 
         # Then: identical conf
         content_second = conf_path.read_text()
@@ -514,11 +596,44 @@ def test_conf_written_once_invariant() -> None:
 def test_verify_reports_newest_version_when_catalogue_carries_several() -> None:
     """The ``==> OK:`` verify line names the NEWEST catalogue version of the package.
 
-    Live repro (2026-08-15): the stable ce-2.8 catalogue retains 3.3.0 alongside
-    3.3.2, ``pkg rquery`` lists every version, and the verify step reported the
-    FIRST row — telling the user 3.3.0 is what they would get. ``pkg install``
-    resolves the highest version, so the report must name that one.
+    Catalogue order is newest-first here so a regression that takes the last
+    rquery line (or drops ``pkg version -t``) cannot stay green (issue #2393).
     """
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_add_repo(
+            root,
+            extra_args=("--channel", "stable"),
+            rquery_lines=(
+                "pfSense-pkg-pfBlockerNG-3.3.2",
+                "pfSense-pkg-pfBlockerNG-3.3.0",
+            ),
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "==> OK: pfSense-pkg-pfBlockerNG-3.3.2 available" in proc.stdout, (
+            f"verify line must report the newest catalogue version:\n{proc.stdout}"
+        )
+        log = _pkg_log(root).read_text()
+        assert "version -t" in log, f"verify must call pkg version -t, log was:\n{log}"
+
+
+def test_verify_picks_portrevision_via_pkg_version_t() -> None:
+    """``pkg version -t`` must prefer PORTREVISION ``_2`` over ``_1`` of the same PORTVERSION."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_add_repo(
+            root,
+            extra_args=("--channel", "stable"),
+            rquery_lines=(
+                "pfSense-pkg-pfBlockerNG-3.3.2_2",
+                "pfSense-pkg-pfBlockerNG-3.3.2_1",
+            ),
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "==> OK: pfSense-pkg-pfBlockerNG-3.3.2_2 available" in proc.stdout, proc.stdout
+        assert "version -t" in _pkg_log(root).read_text()
+
+
+def test_verify_fails_if_pkg_version_t_is_unusable() -> None:
+    """A comparator that answers nothing must fail loud, not silently keep the first line."""
     with tempfile.TemporaryDirectory() as root:
         proc = _run_add_repo(
             root,
@@ -527,11 +642,10 @@ def test_verify_reports_newest_version_when_catalogue_carries_several() -> None:
                 "pfSense-pkg-pfBlockerNG-3.3.0",
                 "pfSense-pkg-pfBlockerNG-3.3.2",
             ),
+            version_t_broken=True,
         )
-        assert proc.returncode == 0, proc.stderr
-        assert "==> OK: pfSense-pkg-pfBlockerNG-3.3.2 available" in proc.stdout, (
-            f"verify line must report the newest catalogue version:\n{proc.stdout}"
-        )
+        assert proc.returncode != 0, proc.stdout
+        assert "version -t" in (proc.stdout + proc.stderr)
 
 
 # --------------------------------------------------------------------------- #
@@ -539,46 +653,55 @@ def test_verify_reports_newest_version_when_catalogue_carries_several() -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_default_writes_release_conf_then_nightly_replaces_it() -> None:
-    """The default writes ONLY the shared release conf; --nightly then REPLACES it.
+def test_omitted_channel_exits_2_and_writes_no_release_conf() -> None:
+    """No ``--channel`` is a usage error — never write the unpublished ``release/`` tree.
 
-    Scenario:
-    Given a fresh root (no conf files),
-    When  add-repo.sh runs with no argument,
-    Then  only ``pfblockerng.conf`` exists (no nightly conf, no legacy split conf);
-    When  add-repo.sh --nightly runs into the same root,
-    Then  ``pfblockerng-nightly.conf`` is the box's ONLY project conf — the release
-          conf is retired, because a box subscribes to one channel at a time.
+    Issue #2384: the old implicit default targeted ``…/release/`` (404 on live Pages).
     """
     with tempfile.TemporaryDirectory() as root:
-        repos = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos"
-        release = repos / "pfblockerng.conf"
-        nightly = repos / "pfblockerng-nightly.conf"
-        legacy_split = repos / "pfblockerng-devel.conf"
+        proc = _run_add_repo(root)
+        assert proc.returncode == 2, proc.stderr
+        assert "--channel is required" in proc.stderr, proc.stderr
+        repos = _repos_dir(root)
+        present = sorted(p.name for p in repos.glob("pfblockerng*.conf")) if repos.is_dir() else []
+        assert present == [], f"omitted --channel must write no project conf, found: {present}"
+        assert not (repos / "pfblockerng.conf").exists()
 
-        # Given: fresh root — no conf files (before-state)
-        assert not release.exists()
+
+def test_print_conf_requires_channel() -> None:
+    """``--print-conf`` without ``--channel`` is a usage error (no implicit release)."""
+    proc = subprocess.run(
+        ["sh", str(_ADD_REPO), "--print-conf", "--catalog-path", _CE_28],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2, proc.stderr
+    assert "--channel is required" in proc.stderr, proc.stderr
+    assert "release/" not in proc.stdout
+
+
+def test_stable_then_nightly_replaces_the_subscription() -> None:
+    """``--channel stable`` writes ONLY the stable conf; --nightly then REPLACES it."""
+    with tempfile.TemporaryDirectory() as root:
+        repos = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos"
+        stable = repos / "pfblockerng-stable.conf"
+        nightly = repos / "pfblockerng-nightly.conf"
+        release = repos / "pfblockerng.conf"
+
+        assert not stable.exists()
         assert not nightly.exists()
 
-        # When: default (no arg) → only the shared release conf
-        _run_add_repo(root)
-        assert release.exists(), "default must write the shared pfblockerng.conf"
-        assert not legacy_split.exists(), "default must NOT write a split pfblockerng-devel.conf"
-        assert not nightly.exists(), "default must NOT write the nightly conf"
-        release_bytes = release.read_text()
-        assert _PAGES_BASE in release_bytes, "release conf must contain the Pages base URL"
-        assert "${ABI}" not in release_bytes, "release conf must not contain ${ABI}"
+        _run_add_repo(root, extra_args=("--channel", "stable"))
+        assert stable.exists(), "--channel stable must write pfblockerng-stable.conf"
+        assert not release.exists(), "must not write the unpublished release conf"
+        assert not nightly.exists()
+        assert "/stable/" in stable.read_text()
 
-        # When: --nightly → takes over the subscription
         _run_add_repo(root, nightly=True)
         assert nightly.exists(), "--nightly must write pfblockerng-nightly.conf"
-        assert not release.exists(), "--nightly must retire the release subscription it replaced"
-        assert not legacy_split.exists(), "no pfblockerng-devel.conf is ever created"
-
-        # After-state: nightly conf has its own URL prefix
-        nightly_content = nightly.read_text()
-        assert "/nightly/" in nightly_content, "nightly conf must use the nightly/ channel path"
-        assert "${ABI}" not in nightly_content, "nightly conf must not contain ${ABI}"
+        assert not stable.exists(), "--nightly must retire the stable subscription it replaced"
+        assert "/nightly/" in nightly.read_text()
 
 
 # --------------------------------------------------------------------------- #
@@ -596,13 +719,13 @@ def test_primary_url_is_pages_url_not_worker() -> None:
           contain pkg.pfblockerng.workers.dev (the retired Worker).
     """
     with tempfile.TemporaryDirectory() as root:
-        conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng.conf"
+        conf_path = Path(root) / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng-stable.conf"
 
         # Given: conf absent (before-state)
         assert not conf_path.exists()
 
         # When: run add-repo.sh
-        _run_add_repo(root)
+        _run_add_repo(root, extra_args=("--channel", "stable"))
 
         # Then: conf written with Pages URL, not the old Worker URL
         assert conf_path.exists()
@@ -645,7 +768,7 @@ def test_add_repo_base_url_requires_a_value() -> None:
 @pytest.mark.parametrize(
     ("argv", "needle"),
     [
-        (["sh", str(_ADD_REPO), "--print-conf"], "catalog-path"),
+        (["sh", str(_ADD_REPO), "--print-conf", "--channel", "stable"], "catalog-path"),
         (["sh", str(_BUILD_REPO), "--print-conf"], "catalog-path"),
         ([sys.executable, str(_BUILD_REPO_PORTABLE), "--print-conf"], "catalog-path"),
     ],
@@ -781,7 +904,7 @@ def test_add_repo_live_bootstrap_leaves_other_channels_absent(channel: str) -> N
         )
 
 
-@pytest.mark.parametrize("previous", ["release", "stable", "nightly"])
+@pytest.mark.parametrize("previous", ["stable", "nightly"])
 def test_add_repo_live_bootstrap_replaces_a_previously_enabled_channel(previous: str) -> None:
     """Single-repository subscription: bootstrapping a channel retires the other one.
 
@@ -791,7 +914,7 @@ def test_add_repo_live_bootstrap_replaces_a_previously_enabled_channel(previous:
     repositories enabled at the same equal priority.
     """
     with tempfile.TemporaryDirectory() as root:
-        _run_add_repo(root, extra_args=() if previous == "release" else ("--channel", previous))
+        _run_add_repo(root, extra_args=("--channel", previous))
         previous_conf = _repos_dir(root) / _CHANNEL_CONF_NAMES[previous]
         assert previous_conf.exists(), f"before-state: the box must be subscribed to {previous}"
 
@@ -943,10 +1066,11 @@ def test_add_repo_help_advertises_the_canonical_identity_only() -> None:
     at a package no channel catalogue carries.
     """
     proc = subprocess.run(["sh", str(_ADD_REPO), "--help"], capture_output=True, text=True, check=True)
-    assert "pfSense-pkg-pfBlockerNG-devel" not in proc.stdout, (
-        f"--help must not advertise the retired -devel identity:\n{proc.stdout}"
+    assert "pkg install -y -r pfblockerng-" in proc.stdout, proc.stdout
+    assert "migrate-channel.sh --channel" in proc.stdout, proc.stdout
+    assert "pkg install pfSense-pkg-pfBlockerNG" not in proc.stdout, (
+        f"--help must not print a bare pkg install:\n{proc.stdout}"
     )
-    assert "pkg install pfSense-pkg-pfBlockerNG" in proc.stdout, proc.stdout
     for channel in _CHANNELS:
         assert channel in proc.stdout, f"--help must name the {channel!r} channel:\n{proc.stdout}"
 
@@ -1019,7 +1143,7 @@ def test_channel_bogus_rejected_with_valid_list(argv: list[str]) -> None:
     ids=["add-repo.sh", "build-repo.sh", "build-repo-portable.py"],
 )
 def test_channel_release_rejected(argv: list[str]) -> None:
-    """`--channel release` is REJECTED — release is the legacy default, not a four-channel name."""
+    """`--channel release` is REJECTED — release is not one of the four channel names."""
     proc = subprocess.run(argv, capture_output=True, text=True, check=False)
     assert proc.returncode == 2, proc.stderr
 
@@ -1053,3 +1177,110 @@ def test_print_conf_channel_still_requires_catalog_path(argv: list[str]) -> None
     proc = subprocess.run(argv, capture_output=True, text=True, check=False)
     assert proc.returncode != 0, proc.stderr
     assert "catalog-path" in proc.stderr.lower(), proc.stderr
+
+
+# --------------------------------------------------------------------------- #
+# #2384 leftover 404 peer / scoped update
+# #2381 install hint
+# #2397 SIGINT after retirement
+# --------------------------------------------------------------------------- #
+
+
+def test_leftover_release_conf_does_not_block_stable_switch() -> None:
+    """A leftover ``pfblockerng.conf`` pointed at unpublished ``release/`` must not
+    fail-close a ``--channel stable`` subscribe (issue #2384).
+
+    Unscoped ``pkg update -f`` would 404 on the leftover peer. The stub fails
+    any update that is not ``-r``-scoped; the switch must still succeed and
+    invoke ``update -f -r pfblockerng-stable``.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        repos = _repos_dir(root)
+        repos.mkdir(parents=True)
+        leftover = repos / "pfblockerng.conf"
+        leftover.write_text(
+            "pfblockerng: {\n"
+            f'  url: "{_PAGES_BASE}/release/ce-2.8",\n'
+            "  enabled: yes\n"
+            "}\n"
+        )
+
+        proc = _run_add_repo(
+            root,
+            extra_args=("--channel", "stable"),
+            unscoped_update_fails=True,
+        )
+
+        assert proc.returncode == 0, proc.stderr
+        assert (repos / "pfblockerng-stable.conf").exists()
+        assert not leftover.exists(), "leftover release conf must be retired after verify"
+        log = _pkg_log(root).read_text()
+        assert "update -f -r pfblockerng-stable" in log, f"update must be repo-scoped:\n{log}"
+        assert re.search(r"(?m)^update -f$", log) is None, f"must not run unscoped update -f:\n{log}"
+
+
+def test_install_hint_is_repo_qualified_when_nothing_is_installed() -> None:
+    """A clean box is told to ``pkg install -y -r pfblockerng-<ch> …``, never bare install."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_add_repo(root, extra_args=("--channel", "stable"))
+        assert proc.returncode == 0, proc.stderr
+        combined = proc.stdout + proc.stderr
+        assert "pkg install -y -r pfblockerng-stable pfSense-pkg-pfBlockerNG" in combined
+        assert "pkg install pfSense-pkg-pfBlockerNG" not in combined
+        assert "migrate-channel.sh" not in combined
+
+
+def test_install_hint_points_at_migrate_when_a_package_is_installed() -> None:
+    """Any leftover ``pfSense-pkg-pfBlockerNG*`` must print migrate-channel, not pkg install."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_add_repo(
+            root,
+            extra_args=("--channel", "stable"),
+            installed_names=("pfSense-pkg-pfBlockerNG-devel",),
+        )
+        assert proc.returncode == 0, proc.stderr
+        combined = proc.stdout + proc.stderr
+        assert "pfSense-pkg-pfBlockerNG-devel" in combined
+        assert "migrate-channel.sh --channel stable" in combined
+        assert "pkg install pfSense-pkg-pfBlockerNG" not in combined
+        assert "pkg install -y -r" not in combined
+
+
+def test_sigint_after_retiring_peer_keeps_the_target_conf() -> None:
+    """SIGINT after the first peer ``rm`` must keep the verified target (issue #2397).
+
+    Before the fix, abort_unstaged deleted the new conf (no backup on a first
+    subscribe) after nightly was already gone — zero project repos.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        first = _run_add_repo(root, extra_args=("--channel", "nightly"))
+        assert first.returncode == 0, first.stderr
+        assert (_repos_dir(root) / "pfblockerng-nightly.conf").exists()
+
+        proc = _run_add_repo(
+            root,
+            extra_args=("--channel", "edge"),
+            extra_env={"PFB_ADD_REPO_RETIRE_HOOK": "kill -s INT $$"},
+        )
+        assert proc.returncode == 130, proc.stdout + proc.stderr
+        present = {p.name for p in _repos_dir(root).glob("pfblockerng*.conf")}
+        assert present, "SIGINT after retirement must never leave zero project confs"
+        assert "pfblockerng-edge.conf" in present, f"verified target must remain, found {present}"
+
+
+def test_sigint_after_drop_conf_backup_keeps_the_target_conf() -> None:
+    """SIGINT after ``drop_conf_backup`` must still keep the verified target."""
+    with tempfile.TemporaryDirectory() as root:
+        first = _run_add_repo(root, extra_args=("--channel", "nightly"))
+        assert first.returncode == 0, first.stderr
+
+        proc = _run_add_repo(
+            root,
+            extra_args=("--channel", "edge"),
+            extra_env={"PFB_ADD_REPO_DONE_HOOK": "kill -s INT $$"},
+        )
+        assert proc.returncode == 130, proc.stdout + proc.stderr
+        present = {p.name for p in _repos_dir(root).glob("pfblockerng*.conf")}
+        assert present, "SIGINT after drop_conf_backup must never leave zero project confs"
+        assert "pfblockerng-edge.conf" in present, f"verified target must remain, found {present}"
+        assert "pfblockerng-nightly.conf" not in present

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -2014,7 +2014,7 @@ def test_published_add_repo_embeds_hook_and_installs_piped(tmp_path: Path, monke
         '  if [ "$_first" = "$3" ]; then printf "<\\n"; else printf ">\\n"; fi\n'
         "  exit 0\n"
         "fi\n"
-        "case \"$1\" in\n"
+        'case "$1" in\n'
         "  rquery)\n"
         '    fmt=""\n'
         '    for _a in "$@"; do case "$_a" in %*) fmt="$_a" ;; esac; done\n'

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -1089,9 +1089,12 @@ def _stub_conf(channel: str) -> str:
 
 
 def test_render_page_renders_all_four_channel_cards_with_correct_content() -> None:
-    """Row 1 of the coverage matrix: each of the four channels gets its own card — title,
-    audience prose anchor, the canonical install command, a `--channel <ch>` bootstrap
-    line, and its own manual-conf naming (via the injected conf_fn)."""
+    """Each of the four channels gets its own card — title, audience prose, badge.
+
+    An empty site is unpublished on every channel (issue #2382): cards keep the
+    "not yet published" blurb and must not ship add-repo / pkg install / conf
+    snippets.
+    """
     base = "https://pfblockerng.github.io/pkg"
     page = gl.render_page(base, [], _stub_conf)
 
@@ -1106,17 +1109,14 @@ def test_render_page_renders_all_four_channel_cards_with_correct_content() -> No
         assert f'<div class="card {ch}">' in page
         assert f"<h3>{title}" in page
         assert audience_anchor[ch] in page.lower()
-        # The uniform bootstrap flag + the ONE canonical install command.
-        assert f"--base-url {base} --channel {ch}" in page
-        assert f"pkg install {_CANON}" in page
-        # The per-channel manual conf snippet, injected via _stub_conf.
-        assert f"{ch}-conf-snippet" in page
-    # Every card installs the SAME package name — never a suffixed one.
-    assert f"{_CANON}-devel" not in page
-    assert f"{_CANON}-nightly" not in page
+        assert f"--channel {ch}" not in page
+        assert f"{ch}-conf-snippet" not in page
+    assert "add-repo.sh" not in page
+    assert "pkg install" not in page
     # Nightly keeps its stability badge.
     assert '<span class="badge">not for daily use</span>' in page
     assert "<code>YYYYMMDDHHMMSS.&lt;7-character source SHA&gt;</code>" in page
+    assert page.count("not yet published") == 4
 
 
 def test_render_page_shows_latest_and_empty_stable() -> None:
@@ -1161,20 +1161,26 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
     # not the whole page (the .tablewrap rule is what makes that scroll possible).
     assert '<div class="tablewrap"><table>' in page
     assert ".tablewrap{overflow-x:auto" in page
-    # Stable has no package -> empty state, NOT a bogus version (its line in the stable card).
+    # Stable (and edge) have no package -> empty state, no install recipe.
     assert "not yet published" in page
-    # One card per channel, each with a UNIFIED command: the bootstrap one-liner + that
-    # channel's `pkg install`, in the SAME snippet — every channel installs the ONE
-    # canonical package (issue #2147), selected via `--channel <ch>`.
-    assert f"sh -s -- --base-url {base} --channel stable\npkg install {_CANON}</pre>" in page
-    assert f"sh -s -- --base-url {base} --channel testing\npkg install {_CANON}</pre>" in page
-    assert f"sh -s -- --base-url {base} --channel edge\npkg install {_CANON}</pre>" in page
-    assert f"sh -s -- --base-url {base} --channel nightly\npkg install {_CANON}</pre>" in page
-    # One bootstrap per card.
-    assert page.count(f"fetch -qo - {base}/add-repo.sh") == 4
-    # The manual conf came from the injected conf function — one per channel.
-    for ch in gl.CH_ORDER:
-        assert f"{ch}-conf-snippet" in page
+    assert "--channel stable" not in page
+    assert "--channel edge" not in page
+    assert "stable-conf-snippet" not in page
+    assert "edge-conf-snippet" not in page
+    # Published channels (testing, nightly) get file-form recipes, &&-joined,
+    # repo-qualified install, and a migrate path (issues #2381, #2390).
+    assert f"fetch -qo /tmp/add-repo.sh {base}/add-repo.sh &amp;&amp;" in page
+    assert f"sh /tmp/add-repo.sh --base-url {base} --channel testing &amp;&amp;" in page
+    assert f"pkg install -y -r pfblockerng-testing {_CANON}" in page
+    assert f"sh /tmp/add-repo.sh --base-url {base} --channel nightly &amp;&amp;" in page
+    assert f"pkg install -y -r pfblockerng-nightly {_CANON}" in page
+    assert "migrate-channel.sh --channel testing" in page
+    assert "migrate-channel.sh --channel nightly" in page
+    assert "fetch -qo -" not in page
+    assert "sh -s --" not in page
+    assert "pkg install pfSense-pkg-pfBlockerNG</pre>" not in page
+    assert "testing-conf-snippet" in page
+    assert "nightly-conf-snippet" in page
     # The badge/title casing fix: no CSS capitalize that would mangle `pfSense-pkg-...`.
     assert "text-transform:capitalize" not in page
     # Card order follows CH_ORDER.
@@ -1218,15 +1224,16 @@ def test_render_page_snippets_have_copy_buttons() -> None:
     assert '<div class="snip">' in page
     btn = '<button class="copy" type="button" aria-label="Copy to clipboard">Copy</button>'
     assert btn in page
-    # A representative unified command is wrapped: button precedes its own <pre>, content intact
-    # (bootstrap + install in ONE snippet).
-    assert f"{btn}<pre>fetch -qo -" in page
-    assert f"\npkg install {_CANON}</pre>" in page
-    assert f"{btn}<pre>stable-conf-snippet</pre>" in page
+    # Only published channels (testing here) get copyable recipes + manual conf.
+    assert f"{btn}<pre>fetch -qo /tmp/add-repo.sh" in page
+    assert f"pkg install -y -r pfblockerng-testing {_CANON}</pre>" in page
+    assert "migrate-channel.sh --channel testing" in page
+    assert f"{btn}<pre>testing-conf-snippet</pre>" in page
+    assert "stable-conf-snippet" not in page
 
-    # Exactly the eight card snippets are copyable — a unified command + a manual conf in
-    # each of the four channel cards. Inline <code> is not copyable.
-    assert page.count('<button class="copy"') == 8
+    # Three copyable snippets on the one published card: new-install, existing-install,
+    # manual conf. Unpublished cards have none.
+    assert page.count('<button class="copy"') == 3
 
     # The styling + the behaviour that make the button work are shipped inline (static page).
     assert ".copy{" in page and ".snip{position:relative}" in page
@@ -1248,10 +1255,14 @@ def test_render_page_table_empty_when_no_packages() -> None:
 
 
 def test_render_page_empty_channel_shows_not_yet_published_for_every_card() -> None:
-    """Row 3 of the coverage matrix, plus the hostile empty-site-root row: with no packages
-    at all, every one of the four cards renders the empty state — exactly once each."""
+    """Empty site: four unpublished cards, zero recipes, zero manual conf, zero copy buttons."""
     page = gl.render_page("https://x/pkg", [], _stub_conf)
     assert page.count("not yet published") == 4
+    assert "add-repo.sh" not in page
+    assert "pkg install" not in page
+    assert "migrate-channel.sh" not in page
+    assert "-conf-snippet" not in page
+    assert '<button class="copy"' not in page
 
 
 def test_render_page_shared_version_across_stable_testing_edge() -> None:
@@ -1282,6 +1293,36 @@ def test_render_page_edge_ahead_of_testing_and_stable_shows_divergence() -> None
     assert '<p class="ver">Latest <code>4.0.0</code></p>' in page
     assert '<p class="ver">Latest <code>4.0.1.b1</code></p>' in page
     assert '<p class="ver">Latest <code>4.1.0.a1</code></p>' in page
+
+
+def test_unpublished_nightly_card_has_no_install_recipe() -> None:
+    """Issue #2382: unpublished Nightly keeps the badge/blurb and ships no recipe."""
+    pkgs = [_pkg("stable", _CANON, "3.3.2", "FreeBSD:15:*", "stable/ce-2.8/x.pkg")]
+    page = gl.render_page("https://pfblockerng.github.io/pkg", pkgs, _stub_conf)
+    nightly = page[page.index('"card nightly"') :]
+    # The nightly card ends at the next footer-ish boundary; search the nightly
+    # slice up to the published-packages heading.
+    nightly = nightly.split("<h2>Published packages</h2>", 1)[0]
+    assert "not yet published" in nightly
+    assert "add-repo.sh" not in nightly
+    assert "--channel nightly" not in nightly
+    assert "pkg install" not in nightly
+    assert "nightly-conf-snippet" not in nightly
+
+
+def test_published_stable_card_is_file_form_and_has_migrate() -> None:
+    """Published stable: file-form fetch, &&, -r pfblockerng-stable, migrate-channel."""
+    pkgs = [_pkg("stable", _CANON, "3.3.2", "FreeBSD:15:*", "stable/ce-2.8/x.pkg")]
+    base = "https://pfblockerng.github.io/pkg"
+    page = gl.render_page(base, pkgs, _stub_conf)
+    assert f"fetch -qo /tmp/add-repo.sh {base}/add-repo.sh &amp;&amp;" in page
+    assert f"sh /tmp/add-repo.sh --base-url {base} --channel stable &amp;&amp;" in page
+    assert f"pkg install -y -r pfblockerng-stable {_CANON}" in page
+    assert "migrate-channel.sh --channel stable" in page
+    assert f"{_CANON}-devel" in page
+    assert "stable-conf-snippet" in page
+    assert "fetch -qo -" not in page
+    assert "sh -s --" not in page
 
 
 def test_render_page_omits_internal_trust_and_channel_model() -> None:
@@ -1462,6 +1503,11 @@ def test_write_site_empty_site_root_renders_four_empty_cards_exit_zero(tmp_path:
     assert n == 0
     index_html = (site / "index.html").read_text()
     assert index_html.count("not yet published") == 4
+    assert "add-repo.sh" not in index_html
+    assert "pkg install" not in index_html
+    assert "migrate-channel.sh" not in index_html
+    assert "-conf-snippet" not in index_html
+    assert '<button class="copy"' not in index_html
 
 
 def test_browse_adapts_to_any_future_tree_shape(tmp_path: Path, monkeypatch: Any) -> None:
@@ -1909,9 +1955,9 @@ def test_published_add_repo_embeds_hook_and_installs_piped(tmp_path: Path, monke
 
     Given a fresh tmp directory with NO rc.d sibling hook present,
       And write_site produces site/add-repo.sh with the hook embedded,
-      And the script text is fed to sh via stdin (``sh -s -- --base-url ...``),
-    When add-repo.sh runs in the piped / non-checkout context (the legacy default
-      bootstrap — mechanics unchanged by the four-channel landing migration),
+      And the script text is fed to sh via stdin
+      (``sh -s -- --base-url ... --channel stable``),
+    When add-repo.sh runs in the piped / non-checkout context,
     Then the hook file is installed on disk (HOOK_SRC absent, embedded path used),
       And the installed hook is executable and contains the rc.d PROVIDE pragma,
       And the staged conf file contains the ``Generated at boot`` marker
@@ -1962,7 +2008,23 @@ def test_published_add_repo_embeds_hook_and_installs_piped(tmp_path: Path, monke
     fake_pkg = bin_dir / "pkg"
     fake_pkg.write_text(
         "#!/bin/sh\n"
-        "case \"$1\" in\n  rquery) printf 'pfSense-pkg-pfBlockerNG 4.0.0\\n'; exit 0 ;;\nesac\n"
+        'if [ "$1" = "version" ] && [ "$2" = "-t" ]; then\n'
+        '  if [ "$3" = "$4" ]; then printf "=\\n"; exit 0; fi\n'
+        '  _first=$(printf "%s\\n%s\\n" "$3" "$4" | sort -V | head -n1)\n'
+        '  if [ "$_first" = "$3" ]; then printf "<\\n"; else printf ">\\n"; fi\n'
+        "  exit 0\n"
+        "fi\n"
+        "case \"$1\" in\n"
+        "  rquery)\n"
+        '    fmt=""\n'
+        '    for _a in "$@"; do case "$_a" in %*) fmt="$_a" ;; esac; done\n'
+        '    case "$fmt" in\n'
+        '      %v) printf "4.0.0\\n" ;;\n'
+        '      %n-%v) printf "pfSense-pkg-pfBlockerNG-4.0.0\\n" ;;\n'
+        '      *) printf "pfSense-pkg-pfBlockerNG 4.0.0\\n" ;;\n'
+        "    esac\n"
+        "    exit 0 ;;\n"
+        "esac\n"
         "case \"$*\" in\n  'config abi') printf 'FreeBSD:15:amd64' ;;\nesac\n"
         "exit 0\n"
     )
@@ -1986,7 +2048,7 @@ def test_published_add_repo_embeds_hook_and_installs_piped(tmp_path: Path, monke
         "PKG_BIN": str(fake_pkg),
     }
     result = subprocess.run(
-        ["sh", "-s", "--", "--base-url", base],
+        ["sh", "-s", "--", "--base-url", base, "--channel", "stable"],
         input=published_text,
         text=True,
         capture_output=True,
@@ -2009,8 +2071,10 @@ def test_published_add_repo_embeds_hook_and_installs_piped(tmp_path: Path, monke
     assert "PROVIDE: pfblockerng_repo_generate" in hook_content, "installed hook must contain the rc.d PROVIDE pragma"
 
     # The staged conf contains the 'Generated at boot' marker, proving the hook
-    # was executed successfully by add-repo.sh's onestart step.
-    conf_path = root / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng.conf"
+    # was executed successfully by add-repo.sh's onestart step. --channel stable
+    # must write pfblockerng-stable.conf with the stable/ce-2.8 URL, never the
+    # unpublished release/ tree (issues #2384, #2390).
+    conf_path = root / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng-stable.conf"
     assert conf_path.exists(), (
         f"conf not written at {conf_path}\nadd-repo stdout:\n{result.stdout}\nadd-repo stderr:\n{result.stderr}"
     )
@@ -2018,6 +2082,10 @@ def test_published_add_repo_embeds_hook_and_installs_piped(tmp_path: Path, monke
     assert "Generated at boot by pfblockerng_repo_generate" in conf_text, (
         f"conf missing the 'Generated at boot' marker:\n{conf_text}"
     )
+    assert "pfblockerng-stable: {" in conf_text, conf_text
+    assert "/stable/ce-2.8" in conf_text, conf_text
+    assert "/release/" not in conf_text
+    assert not (root / "usr" / "local" / "etc" / "pkg" / "repos" / "pfblockerng.conf").exists()
 
 
 def test_write_site_publishes_migrate_channel_beside_the_bootstrap(tmp_path: Path, monkeypatch: Any) -> None:


### PR DESCRIPTION
Fixes #2384
Fixes #2393
Fixes #2397
Fixes #2381
Fixes #2382
Fixes #2390

Bare `add-repo` targeted unpublished `release/` and fail-closed on peer 404s. Landing advertised pipe-form install without `migrate-channel` and showed recipes for unpublished Nightly. Verify with `pkg version -t`; keep the new conf after verify if the run is interrupted.

Made-with: Grok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Installation now requires selecting a release channel: stable, testing, edge, or nightly.
  - Landing pages provide separate downloaded scripts for new installations and existing installations.
  - Existing installations can switch channels using a dedicated migration step.
  - Channel-specific installation instructions appear only when a version is available.

- **Bug Fixes**
  - Improved package version selection, including port revisions.
  - Repository updates are limited to the selected channel.
  - Existing installations remain unchanged unless migration is explicitly requested.
  - Installation failures and interruptions preserve the previously verified configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->