### PR TITLE
software: pick newest catalog version and stop lying about channel

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4843,8 +4843,8 @@ function pfb_wizard_dnsvip_settings(bool $auto, $vip4, $vip6): array {
  */
 
 /*
- * Channel a build is on, from its installed package NAME:
- *   pfSense-pkg-pfBlockerNG         -> 'stable'
+ * Channel leftover from an installed package NAME suffix (issue #2395):
+ *   pfSense-pkg-pfBlockerNG         -> NULL     (canonical name is not a channel)
  *   pfSense-pkg-pfBlockerNG-testing -> 'testing'
  *   pfSense-pkg-pfBlockerNG-edge    -> 'edge'
  *   pfSense-pkg-pfBlockerNG-devel   -> 'devel'   (retired port; installed boxes remain)
@@ -4857,12 +4857,10 @@ function pfb_wizard_dnsvip_settings(bool $auto, $vip4, $vip6): array {
  * boxes installed before the rename still carry it, and dropping it here would read them
  * as an unknown channel — i.e. not our build.
  *
- * issue #2148 narrowed this function's ROLE (its mapping is unchanged). Channel is now
- * catalogue placement — all four catalogues publish the canonical 'pfSense-pkg-pfBlockerNG'
- * — so pfb_channel_from_repo_name() is the authoritative channel signal and this is the
- * FALLBACK: the discriminator inside the legacy shared 'pfblockerng' repo, which carries
- * both the canonical and the -devel identity. It also remains the prefix/identity filter
- * inside pfb_pkg_installed_name().
+ * issue #2148 made channel catalogue placement: all four catalogues publish the canonical
+ * 'pfSense-pkg-pfBlockerNG', so an empty suffix cannot mean 'stable'. pfb_channel_from_repo_name()
+ * is authoritative; pfb_build_record.channel is next; this suffix map is leftovers only.
+ * Identity (is this our package at all) lives in pfb_pkg_is_our_name().
  */
 function pfb_channel_from_pkgname(?string $name): ?string {
 	if (!is_string($name) || $name === '') {
@@ -4875,7 +4873,7 @@ function pfb_channel_from_pkgname(?string $name): ?string {
 	$suffix = substr($lname, strlen('pfsense-pkg-pfblockerng'));
 	switch ($suffix) {
 		case '':
-			return 'stable';
+			return null;
 		case '-testing':
 			return 'testing';
 		case '-edge':
@@ -4887,6 +4885,23 @@ function pfb_channel_from_pkgname(?string $name): ?string {
 		default:
 			return null;
 	}
+}
+
+/*
+ * TRUE when $name is a pfBlockerNG package identity: the canonical name or a recognised
+ * leftover suffix. Used by pfb_pkg_installed_name() so dropping the empty-suffix -> stable
+ * lie (#2395) does not hide pfSense-pkg-pfBlockerNG from the install probe.
+ */
+function pfb_pkg_is_our_name(?string $name): bool {
+	if (!is_string($name) || $name === '') {
+		return FALSE;
+	}
+	$lname = strtolower($name);
+	if (!str_starts_with($lname, 'pfsense-pkg-pfblockerng')) {
+		return FALSE;
+	}
+	$suffix = substr($lname, strlen('pfsense-pkg-pfblockerng'));
+	return $suffix === '' || pfb_channel_from_pkgname($name) !== null;
 }
 
 /*
@@ -4928,18 +4943,57 @@ function pfb_channel_from_repo_name(?string $repo): ?string {
 }
 
 /*
- * The channel an install is on: the REPO decides, the NAME is the fallback (issue #2148).
- *
- * The two mappers above answer half the question each, and every caller needs both halves in
- * the same order — the Software page label, the cron notice text, and the cached channel. It
- * lives here as ONE function rather than as a repeated expression so the page and the notice
- * cannot drift into disagreeing about what channel a box is on.
- *
- * NULL when neither half recognises the install (a Netgate or hand-built package); callers
- * render that as 'unknown'.
+ * A recognised software channel token, or NULL. Used for pfb_build_record.channel and any
+ * other already-decoded annotation so a junk/foreign string cannot become a channel label.
  */
-function pfb_channel_for_install(?string $repo, ?string $pkgname): ?string {
-	return pfb_channel_from_repo_name($repo) ?? pfb_channel_from_pkgname($pkgname);
+function pfb_channel_recognized(?string $channel): ?string {
+	if (!is_string($channel) || $channel === '') {
+		return null;
+	}
+	switch (strtolower($channel)) {
+		case 'stable':
+		case 'testing':
+		case 'edge':
+		case 'devel':
+		case 'nightly':
+			return strtolower($channel);
+		default:
+			return null;
+	}
+}
+
+/*
+ * Channel from a pfb_build_record JSON blob (the package annotation), or NULL when the
+ * blob is missing/unparseable/has no recognised channel. Sideloaded GitHub Release
+ * assets carry this even when %R is empty (issue #2395).
+ */
+function pfb_channel_from_build_record(?string $json): ?string {
+	if (!is_string($json) || $json === '') {
+		return null;
+	}
+	$data = json_decode($json, TRUE);
+	if (!is_array($data) || !array_key_exists('channel', $data) || !is_string($data['channel'])) {
+		return null;
+	}
+	return pfb_channel_recognized($data['channel']);
+}
+
+/*
+ * The channel an install is on (issue #2148 / #2395).
+ *
+ * Precedence:
+ *   1. pfb_channel_from_repo_name($repo) when the %R is a pfblockerng-* catalogue;
+ *   2. a recognised $record_channel (pfb_build_record.channel from the installed .pkg);
+ *   3. a non-empty recognised name suffix (legacy leftovers);
+ *   4. NULL — callers render 'unknown'. Never invent 'stable' from the canonical name.
+ *
+ * $record_channel is the already-decoded annotation so this stays hermetic: live callers
+ * pass pfb_channel_from_build_record(pfb_pkg_annotation(...)); tests pass a literal.
+ */
+function pfb_channel_for_install(?string $repo, ?string $pkgname, ?string $record_channel = null): ?string {
+	return pfb_channel_from_repo_name($repo)
+		?? pfb_channel_recognized($record_channel)
+		?? pfb_channel_from_pkgname($pkgname);
 }
 
 /*
@@ -4998,6 +5052,37 @@ function pfb_software_is_our_build(?string $installed_repo): bool {
 		array('pfblockerng', 'pfblockerng-stable', 'pfblockerng-testing', 'pfblockerng-edge', 'pfblockerng-nightly'),
 		TRUE
 	);
+}
+
+/*
+ * TRUE only when pfSense Package Manager can see this origin (issue #2380).
+ * get_pkg_info() skips any pfSense-pkg-* whose %R is not exactly 'pfSense', so
+ * pkg_mgr_install.php reinstall/delete are dead on pfblockerng-* (and empty) origins.
+ */
+function pfb_software_pkgmgr_usable(?string $repo): bool {
+	return $repo === 'pfSense';
+}
+
+/*
+ * Update-now href. Package Manager only when %R is pfSense AND an update is available;
+ * otherwise '#' (the Software page disables the control and prints the CLI instead).
+ */
+function pfb_software_update_href(string $pkgname, string $repo, bool $update_available): string {
+	if (!$update_available || $pkgname === '' || !pfb_software_pkgmgr_usable($repo)) {
+		return '#';
+	}
+	return '/pkg_mgr_install.php?mode=reinstallpkg&pkg=' . rawurlencode($pkgname);
+}
+
+/*
+ * Uninstall href. Same origin gate as Update: never send a pfblockerng-* install to
+ * pkg_mgr_install.php?mode=delete (issue #2380).
+ */
+function pfb_software_uninstall_href(string $pkgname, string $repo): string {
+	if ($pkgname === '' || !pfb_software_pkgmgr_usable($repo)) {
+		return '#';
+	}
+	return '/pkg_mgr_install.php?mode=delete&pkg=' . rawurlencode($pkgname);
 }
 
 /*
@@ -5066,7 +5151,8 @@ if (!defined('PFB_PYTHON_WRAPPER')) {
 /*
  * The installed pfBlockerNG package NAME (e.g. 'pfSense-pkg-pfBlockerNG-devel'), read
  * from `pkg query '%n'` filtered to our prefix; '' when not installed via pkg or the
- * query fails. Feeds pfb_channel_from_pkgname().
+ * query fails. Feeds pfb_pkg_is_our_name() so the canonical identity still matches
+ * after empty-suffix stopped meaning 'stable' (issue #2395).
  */
 function pfb_pkg_installed_name(): string {
 	$out = array();
@@ -5080,7 +5166,7 @@ function pfb_pkg_installed_name(): string {
 	}
 	foreach ($out as $line) {
 		$line = trim($line);
-		if (pfb_channel_from_pkgname($line) !== null) {
+		if (pfb_pkg_is_our_name($line)) {
 			return $line;
 		}
 	}
@@ -5154,10 +5240,60 @@ function pfb_pkg_installed_repo(string $pkgname): string {
 }
 
 /*
- * The pfBlockerNG repo's latest version of $pkgname: `pkg update -r <repo>` (best-effort refresh of
- * just that repo's catalog DB) then `pkg rquery -r <repo> '%v' <pkgname>`. Reads ONLY that repo
- * ($reponame) — never -r pfSense / get_pkg_info (ADR-19 §2 "Read latest"). Returns ''
- * (the caller then serves cache) when:
+ * One installed-package annotation value (`pkg query '%At %Av'`), or '' when absent/failed.
+ * Used to read pfb_build_record off the live .pkg (issue #2395).
+ */
+function pfb_pkg_annotation(string $pkgname, string $key): string {
+	if ($pkgname === '' || $key === '') {
+		return '';
+	}
+	$out = array();
+	$ret = -1;
+	exec(escapeshellarg(PFB_PKG_BIN) . " query '%At %Av' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
+	if ($ret !== 0) {
+		return '';
+	}
+	foreach ($out as $line) {
+		$line = trim((string) $line);
+		$pos = strpos($line, ' ');
+		if ($pos === FALSE) {
+			continue;
+		}
+		if (substr($line, 0, $pos) === $key) {
+			return trim(substr($line, $pos + 1));
+		}
+	}
+	return '';
+}
+
+/*
+ * Newest non-empty version in $versions via pkg_version_compare() (issue #2379).
+ * Catalogues retain older builds; rquery lists them in catalog order, not version order.
+ * Nightly is YYYYMMDDHHMMSS.<7hex> — never lexical / PHP version_compare at the call site.
+ */
+function pfb_pkg_newest_version(array $versions): string {
+	$latest = '';
+	foreach ($versions as $line) {
+		if (!is_scalar($line)) {
+			continue;
+		}
+		$ver = trim((string) $line);
+		if ($ver === '') {
+			continue;
+		}
+		if ($latest === '' || pkg_version_compare($latest, $ver) === '<') {
+			$latest = $ver;
+		}
+	}
+	return $latest;
+}
+
+/*
+ * The pfBlockerNG repo's latest version of $pkgname: `pkg update -f -r <repo>` (forced
+ * refresh of just that repo's catalog DB) then `pkg rquery -r <repo> '%v' <pkgname>`.
+ * Reads ONLY that repo ($reponame) — never -r pfSense / get_pkg_info (ADR-19 §2 "Read
+ * latest"). Picks the newest rquery line with pkg_version_compare(); $out[0] is catalog
+ * order, not newest (issue #2379). Returns '' (the caller then serves cache) when:
  *   - $pkgname/$reponame is empty;
  *   - the pkg subsystem is locked (is_subsystem_dirty('pkg')) — never fight a base update;
  *   - DNS is unavailable (get_dnsavailable()) — never stall on a network read;
@@ -5178,12 +5314,16 @@ function pfb_pkg_latest(string $pkgname, string $reponame): string {
 	// Bound both networked pkg calls with timeout(1) (same idiom as the hook runner) so a
 	// hung mirror can never stall the cron pass or the page's forced "Check now".
 	$tmo = '/usr/bin/timeout -s TERM -k 5 60 ';
-	// Best-effort catalog refresh of the pfBlockerNG repo only; ignore failures (stale DB still reads).
-	exec("{$tmo}{$bin} update -r {$repo} 2>/dev/null");
+	// Forced catalog refresh of the pfBlockerNG repo only; ignore failures (stale DB still reads).
+	// -f is required: Pages/file:// catalogs can keep an unchanged mtime/etag (issue #2379).
+	exec("{$tmo}{$bin} update -f -r {$repo} 2>/dev/null");
 	$out = array();
 	$ret = -1;
 	exec("{$tmo}{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
-	return ($ret === 0 && isset($out[0])) ? trim($out[0]) : '';
+	if ($ret !== 0 || $out === array()) {
+		return '';
+	}
+	return pfb_pkg_newest_version($out);
 }
 
 /*
@@ -5262,10 +5402,11 @@ function pfb_software_write_cache(array $cache): void {
  *   3. Read latest from the repo the package was INSTALLED from (guarded inside
  *      pfb_pkg_latest()). An empty latest (pkg locked / no DNS / repo absent) preserves the
  *      cached latest so the page keeps showing the last-known value rather than regressing
- *      to ''.
- *   4. Refresh the cache (pkgname/repo/channel/installed/latest/last_checked) and, when
- *      pfb_should_notify() says so, raise a DE-DUPED file_notice and persist
- *      last_notified = latest (so repeated ticks at the same latest do not renotify).
+ *      to ''. A failed live read does NOT advance last_checked (issue #2379).
+ *   4. Refresh the cache (pkgname/repo/channel/installed/latest; last_checked only on a
+ *      successful live read) and, when pfb_should_notify() says so, raise a DE-DUPED
+ *      file_notice and persist last_notified = latest (so repeated ticks at the same
+ *      latest do not renotify).
  *
  * Best-effort throughout: it returns the cache array and never throws, so wiring it into
  * the cron pass can never break a feed update. $force (the page's "Check now" button) bypasses
@@ -5311,40 +5452,61 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 	$repo = array_key_exists('installed_repo', $io)
 		? (string) $io['installed_repo']
 		: pfb_pkg_installed_repo($pkgname);
-	// Repo-first, name-fallback, through the ONE shared accessor so the cached channel,
-	// the notice text and the Software page label can never disagree.
-	$channel = pfb_channel_for_install($repo, $pkgname);
+	// Repo, then build-record, then leftover name suffix — the ONE shared accessor so the
+	// cached channel, the notice text and the Software page label can never disagree.
+	// Tests inject $io['record_channel'] (or omit it to mean "no annotation"); the live
+	// path ($io empty) reads pfb_build_record off the installed package (issue #2395).
+	if (array_key_exists('record_channel', $io)) {
+		$record_channel = is_string($io['record_channel']) ? $io['record_channel'] : null;
+	} elseif ($io === array() && $pkgname !== '') {
+		$record_channel = pfb_channel_from_build_record(pfb_pkg_annotation($pkgname, 'pfb_build_record'));
+	} else {
+		$record_channel = null;
+	}
+	$channel = pfb_channel_for_install($repo, $pkgname, $record_channel);
 
 	$cache = pfb_software_read_cache();
 
 	// 3. Read latest from the installed repo; keep the cached value when the live read is
-	// unavailable.
+	// unavailable. last_checked advances only on a successful live read (issue #2379).
 	if (array_key_exists('latest', $io)) {
-		$latest = (string) $io['latest'];
+		$live_latest = (string) $io['latest'];
 	} else {
-		$latest = pfb_pkg_latest($pkgname, $repo);
+		$live_latest = pfb_pkg_latest($pkgname, $repo);
 	}
+	$live_ok = ($live_latest !== '');
 	// Only reuse cached latest/last_notified when the cache belongs to the SAME install.
 	// pfb_software_cache_matches_install() is the whole question — name AND repo — and the
 	// Software page gates its DISPLAYED values on the identical call, so the two can never
 	// disagree about which cache is current.
 	$cache_matches_install = pfb_software_cache_matches_install($cache, $pkgname, $repo);
-	if ($latest === '' && $cache_matches_install) {
+	if (!$live_ok && $cache_matches_install) {
 		$latest = (string) ($cache['latest'] ?? '');
+	} else {
+		$latest = $live_latest;
 	}
 
 	$last_notified = $cache_matches_install ? (string) ($cache['last_notified'] ?? '') : '';
+	$kept_checked = ($cache_matches_install && array_key_exists('last_checked', $cache))
+		? $cache['last_checked']
+		: null;
 
 	// 4. Refresh the cache. last_notified is written from the scoped value so a cache left
 	// by a different install (a different package name OR a different catalogue) is reset
-	// rather than carried forward.
+	// rather than carried forward. last_checked stays put when the live catalog read failed.
 	$cache['pkgname']       = $pkgname;
 	$cache['repo']          = $repo;
 	$cache['channel']       = $channel;
 	$cache['installed']     = $installed;
 	$cache['latest']        = $latest;
 	$cache['last_notified'] = $last_notified;
-	$cache['last_checked']  = time();
+	if ($live_ok) {
+		$cache['last_checked'] = time();
+	} elseif ($kept_checked !== null) {
+		$cache['last_checked'] = $kept_checked;
+	} else {
+		unset($cache['last_checked']);
+	}
 
 	if (pfb_should_notify($installed, $latest, $last_notified, $enabled)) {
 		file_notice('pfBlockerNG', "pfBlockerNG {$latest} available ({$channel})", 'pfBlockerNG', '/pfblockerng/pfblockerng_software.php', 1);

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -22,10 +22,9 @@
 
 // ADR-19: the "Software" page — show the installed pfBlockerNG channel/version vs our-repo
 // latest (from the cron-maintained cache), toggle the "Check for new versions" setting, and
-// offer Check / Update / Uninstall. The Update and Uninstall actions are SHORTCUTS to pfSense's
-// base-system Package Manager (pkg_mgr_install.php): it runs pkg and streams its own progress
-// from a page that SURVIVES pfBlockerNG's own removal/upgrade, so this page never self-hosts a
-// pkg dispatch (no detached daemon, no live-tail endpoint, no state files to vanish mid-operation).
+// offer Check / Update / Uninstall. Update and Uninstall link to pfSense Package Manager
+// ONLY when %R is pfSense (Netgate). A pfblockerng-* origin is invisible there (issue #2380),
+// so those controls are disabled and the page prints the repo-qualified pkg CLI instead.
 
 require_once('guiconfig.inc');
 require_once('globals.inc');
@@ -61,21 +60,23 @@ if (!isAllowedPage('pkg_mgr_installed.php')) {
 }
 
 // Resolve the installed package + channel ONCE (used by display + the action shortcuts).
-// issue #2148: channel is CATALOGUE placement — all four catalogues publish the canonical
-// 'pfSense-pkg-pfBlockerNG', so the repo the package came from names the channel, with the
-// name as the fallback for the legacy shared repo. pfb_channel_for_install() is that one
-// rule, shared with pfb_software_update_check() so the page label and the notice text
-// cannot drift apart.
+// issue #2148 / #2395: channel is CATALOGUE placement — all four catalogues publish the
+// canonical 'pfSense-pkg-pfBlockerNG'. Repo first, then pfb_build_record.channel, then a
+// leftover name suffix. pfb_channel_for_install() is that one rule, shared with
+// pfb_software_update_check() so the page label and the notice text cannot drift apart.
 $pfb_sw_pkgname	= pfb_pkg_installed_name();
 $pfb_sw_repo	= pfb_pkg_installed_repo($pfb_sw_pkgname);
-$pfb_sw_channel	= pfb_channel_for_install($pfb_sw_repo, $pfb_sw_pkgname);
+$pfb_sw_record	= ($pfb_sw_pkgname !== '')
+	? pfb_channel_from_build_record(pfb_pkg_annotation($pfb_sw_pkgname, 'pfb_build_record'))
+	: null;
+$pfb_sw_channel	= pfb_channel_for_install($pfb_sw_repo, $pfb_sw_pkgname, $pfb_sw_record);
 
 // The "Check for new versions" setting (default ENABLED — the registry default since
 // issue #1887). The accessor reads the gateway itself; no raw value handling here.
 $pfb_sw_check	= pfb_software_check_enabled();
 
 // Which (POST-guarded) action was requested. Only the cache-refreshing Check runs here now;
-// Update/Uninstall are plain links to pkg_mgr_install.php, not POST actions.
+// Update/Uninstall are links (or disabled CLI help), not POST actions.
 $pfb_sw_action = '';
 if ($_POST && !empty($_POST['pfb_sw_action'])) {
 	$pfb_sw_action = (string) $_POST['pfb_sw_action'];
@@ -207,43 +208,55 @@ $btn_check->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setWidth
 $section->addInput(new Form_StaticText(null, $btn_check))
 	->setHelp('Check for a new version now.');
 
-// Update now — a LINK to pfSense's Package Manager (reinstallpkg = pfSense's own single-package
-// upgrade path; pkg resolves the newest candidate, which is ours by repo priority). The base page
-// runs pkg and streams progress from a page that survives the swap. Enabled only when an update
-// is available and the package name is known.
-$pfb_pkg_arg = rawurlencode((string) $pfb_sw_pkgname);
-// The href itself is the gate (an anchor's disabled/aria-disabled are advisory only, so a
-// stray activation must land nowhere actionable): a real reinstall target ONLY when an update
-// is available and the package name is known, else '#'. The disabled styling is the visual cue.
+// Update / Uninstall. Package Manager only sees %R=pfSense (issue #2380). A pfblockerng-*
+// origin is disabled here with the repo-qualified pkg CLI; never emit pkg_mgr_install.php
+// for that origin (those pages hide the package and a reinstall can resolve against -r pfSense).
+$pfb_sw_pkgmgr		= pfb_software_pkgmgr_usable($pfb_sw_repo);
+$pfb_sw_update_href	= pfb_software_update_href($pfb_sw_pkgname, $pfb_sw_repo, $update_available);
+$pfb_sw_uninstall_href	= pfb_software_uninstall_href($pfb_sw_pkgname, $pfb_sw_repo);
+$pfb_sw_cli_pkg		= ($pfb_sw_pkgname !== '') ? $pfb_sw_pkgname : 'pfSense-pkg-pfBlockerNG';
+$pfb_sw_cli_repo	= ($pfb_sw_repo !== '') ? $pfb_sw_repo : '<repo>';
+
 $btn_update = new Form_Button(
 	'pfb_sw_update',
 	'Update now',
-	($update_available && $pfb_sw_pkgname !== '') ? "/pkg_mgr_install.php?mode=reinstallpkg&pkg={$pfb_pkg_arg}" : '#',
+	$pfb_sw_update_href,
 	'fa-solid fa-download'
 );
 $btn_update->removeClass('btn-primary')->addClass('btn-warning btn-xs')->setWidth(2);
-if (!$update_available || $pfb_sw_pkgname === '') {
+if ($pfb_sw_update_href === '#') {
 	$btn_update->addClass('disabled')->setAttribute('disabled', 'disabled')->setAttribute('aria-disabled', 'true');
 }
+if ($pfb_sw_pkgmgr) {
+	$pfb_sw_update_help = 'Install the latest version via the pfSense Package Manager. Available only when an update is found.';
+} else {
+	$pfb_sw_update_help = 'Package Manager cannot see this origin. To update, run <code>pkg install -y -r '
+		. htmlspecialchars($pfb_sw_cli_repo) . ' ' . htmlspecialchars($pfb_sw_cli_pkg)
+		. '</code> from the shell.';
+}
 $section->addInput(new Form_StaticText(null, $btn_update))
-	->setHelp('Install the latest version via the pfSense Package Manager. Available only when an update is found.');
+	->setHelp($pfb_sw_update_help);
 
-// Uninstall — a link straight to pfSense's Package Manager delete flow (its own confirm step runs
-// there). #697: this is a `pkg delete`, which the pre-deinstall detects as a removal and fully tears
-// down (uninstall = OFF), so no intent marker is needed. (A package Update is `pkg install -f`, a
-// different op the pre-deinstall keeps live.)
+// Uninstall. #697: a `pkg delete` is a removal (pre-deinstall tears down). Package Manager
+// delete is only offered for a Netgate-origin install.
 $btn_uninstall = new Form_Button(
 	'pfb_sw_uninstall',
 	'Uninstall',
-	($pfb_sw_pkgname !== '') ? "/pkg_mgr_install.php?mode=delete&pkg={$pfb_pkg_arg}" : '#',
+	$pfb_sw_uninstall_href,
 	'fa-solid fa-trash-can'
 );
 $btn_uninstall->removeClass('btn-primary')->addClass('btn-danger btn-xs')->setWidth(2);
-if ($pfb_sw_pkgname === '') {
+if ($pfb_sw_uninstall_href === '#') {
 	$btn_uninstall->addClass('disabled')->setAttribute('disabled', 'disabled')->setAttribute('aria-disabled', 'true');
 }
+if ($pfb_sw_pkgmgr) {
+	$pfb_sw_uninstall_help = 'Remove pfBlockerNG from this firewall via the pfSense Package Manager (it will ask you to confirm).';
+} else {
+	$pfb_sw_uninstall_help = 'Package Manager cannot see this origin. To uninstall, run <code>pkg delete '
+		. htmlspecialchars($pfb_sw_cli_pkg) . '</code> from the shell.';
+}
 $section->addInput(new Form_StaticText(null, $btn_uninstall))
-	->setHelp('Remove pfBlockerNG from this firewall via the pfSense Package Manager (it will ask you to confirm).');
+	->setHelp($pfb_sw_uninstall_help);
 $form->add($section);
 
 print($form);
@@ -253,8 +266,8 @@ print($form);
 //<![CDATA[
 events.push(function() {
 
-	// Check now is the only in-page action left — a cache refresh POSTed back to this page.
-	// Update / Uninstall are plain links to the Package Manager (no JS, no POST).
+	// Check now is the only in-page action — a cache refresh POSTed back to this page.
+	// Update / Uninstall are plain links to the Package Manager only when %R is pfSense.
 	$('#pfb_sw_check').click(function(e) {
 		e.preventDefault();
 		var f = document.forms[0];

--- a/tests/php/SoftwareUpdateCheckTest.php
+++ b/tests/php/SoftwareUpdateCheckTest.php
@@ -278,7 +278,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 	 * is on. The orchestrator reads latest from the repo the package was INSTALLED from
 	 * (`pkg query %R`, injected here as $io['installed_repo']) — under single-repository
 	 * subscription that is the only repo it can upgrade within — and labels the cache
-	 * repo-first, name-fallback: pfb_channel_from_repo_name() ?? pfb_channel_from_pkgname().
+	 * repo, then build-record, then leftover name suffix (issue #2395).
 	 */
 
 	/**
@@ -468,9 +468,11 @@ final class SoftwareUpdateCheckTest extends TestCase
 			// note: NO 'latest' key -> forces the guarded live read.
 		]);
 
-		// Then: cached latest preserved, last_notified intact, no NEW notice.
+		// Then: cached latest preserved, last_notified intact, last_checked NOT advanced,
+		// no NEW notice (issue #2379).
 		$this->assertSame('3.2.0_9', $cache['latest'], 'after: cached latest preserved when pkg locked');
 		$this->assertSame('3.2.0_9', $cache['last_notified'], 'after: de-dupe state intact');
+		$this->assertSame(100, $cache['last_checked'], 'after: last_checked must not advance on a failed live read');
 		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: no notice while locked');
 	}
 
@@ -501,6 +503,7 @@ final class SoftwareUpdateCheckTest extends TestCase
 		]);
 
 		$this->assertSame('3.2.0_9', $cache['latest'], 'after: cached latest preserved when no DNS');
+		$this->assertSame(100, $cache['last_checked'], 'after: last_checked must not advance on a failed live read');
 		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'after: no notice without DNS');
 	}
 
@@ -704,6 +707,24 @@ final class SoftwareUpdateCheckTest extends TestCase
 	}
 
 	/**
+	 * pfb_pkg_latest() must force-refresh the named catalog and pick newest via the
+	 * compare helper — not `$out[0]` and not `pkg update -r` without `-f` (issue #2379).
+	 */
+	public function testPkgLatestSourceForcesRefreshAndPicksNewest(): void
+	{
+		$src = (string) file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		$start = strpos($src, 'function pfb_pkg_latest(');
+		$this->assertNotFalse($start, 'pfb_pkg_latest() is missing');
+		$end = strpos($src, "\nfunction ", $start + 1);
+		$body = $end === false ? substr($src, $start) : substr($src, $start, $end - $start);
+		$this->assertStringContainsString('update -f -r', $body, 'Software catalog reads must force-refresh');
+		$this->assertStringContainsString('pfb_pkg_newest_version($out)', $body, 'rquery lines must go through the newest-version picker');
+		$this->assertStringNotContainsString('$out[0]', $body, 'pfb_pkg_latest must not return the first rquery line');
+	}
+
+	/**
 	 * Same pre-#2148 cache, but the live read is unavailable (pkg locked / no DNS).
 	 * The cached latest must be served rather than regressing to '' — the exact
 	 * regression the offline guard exists to prevent.
@@ -730,6 +751,26 @@ final class SoftwareUpdateCheckTest extends TestCase
 		]);
 
 		$this->assertSame('3.2.0_9', $cache['latest'], 'the last-known latest must not regress to empty');
+		$this->assertSame(1, $cache['last_checked'], 'a failed live read must not rewrite last_checked');
+	}
+
+	/**
+	 * A sideloaded canonical package with a testing build-record must not be labelled
+	 * stable, and the injected annotation must reach the cache (issue #2395).
+	 */
+	public function testCanonicalNameUsesInjectedBuildRecordChannel(): void
+	{
+		$this->setCheck('on');
+		$cache = pfb_software_update_check(false, [
+			'installed_name' => 'pfSense-pkg-pfBlockerNG',
+			'installed'      => '3.3.2',
+			'installed_repo' => '',
+			'record_channel' => 'testing',
+			'provenance_ok'  => TRUE,
+			'latest'         => '3.3.2',
+		]);
+		$this->assertSame('testing', $cache['channel'], 'annotation must beat the empty-suffix name');
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'up to date: no notice');
 	}
 
 	/**

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -17,24 +17,30 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversFunction('pfb_channel_from_pkgname')]
 #[CoversFunction('pfb_channel_from_repo_name')]
+#[CoversFunction('pfb_channel_from_build_record')]
+#[CoversFunction('pfb_channel_recognized')]
 #[CoversFunction('pfb_channel_for_install')]
+#[CoversFunction('pfb_pkg_is_our_name')]
+#[CoversFunction('pfb_pkg_newest_version')]
 #[CoversFunction('pfb_software_cache_matches_install')]
 #[CoversFunction('pfb_software_is_our_build')]
+#[CoversFunction('pfb_software_pkgmgr_usable')]
+#[CoversFunction('pfb_software_update_href')]
+#[CoversFunction('pfb_software_uninstall_href')]
 #[CoversFunction('pfb_update_available')]
 #[CoversFunction('pfb_software_check_enabled')]
 #[CoversFunction('pfb_should_notify')]
 final class SoftwareUpdateDecisionTest extends TestCase
 {
 	/*
-	 * ---- pfb_channel_from_pkgname() — package name -> channel ----
-	 * The installed package name is authoritative for "what channel am I on". Each of
-	 * the three shipped names maps to its channel; anything else (incl. empty/null) is
-	 * an UNKNOWN channel -> null, the safe default (no feature without a known channel).
+	 * ---- pfb_channel_from_pkgname() — leftover name suffix -> channel (issue #2395) ----
+	 * The canonical name is NOT a channel (all four catalogues publish it). Only a
+	 * non-empty recognised suffix maps; empty/null/foreign -> null.
 	 */
 	public static function channelProvider(): array
 	{
 		return [
-			'stable: bare release name'   => ['pfSense-pkg-pfBlockerNG', 'stable'],
+			'canonical: empty suffix is not a channel' => ['pfSense-pkg-pfBlockerNG', null],
 			'devel: -devel suffix'        => ['pfSense-pkg-pfBlockerNG-devel', 'devel'],
 			'testing: -testing suffix'    => ['pfSense-pkg-pfBlockerNG-testing', 'testing'],
 			'edge: -edge suffix'          => ['pfSense-pkg-pfBlockerNG-edge', 'edge'],
@@ -90,27 +96,31 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	}
 
 	/*
-	 * ---- pfb_channel_for_install() — the ONE derivation both callers use (issue #2148) ----
-	 * The Software page label and the cron notice text must never disagree about what
-	 * channel a box is on, so the repo-first/name-fallback composition lives in one
-	 * function rather than as a repeated expression at each call site. Pinned here on all
-	 * three outcomes: the repo decides when it names a channel, the name decides when the
-	 * repo is the legacy shared catalogue (or is absent, as on a sideloaded `pkg add`),
-	 * and neither recognising the install yields null for the caller to render 'unknown'.
+	 * ---- pfb_channel_for_install() — the ONE derivation both callers use (#2148 / #2395) ----
+	 * Precedence: recognised repo, then a valid pfb_build_record.channel, then a leftover
+	 * name suffix. The canonical name alone is never 'stable'.
 	 */
 	public static function channelForInstallProvider(): array
 	{
 		return [
-			// The repo WINS over the name: this is the whole point of the cutover — the
-			// canonical identity lives in every catalogue, so the name would say 'stable'.
+			// The repo WINS over the name and over an annotation.
 			'edge catalogue beats the canonical name' => ['pfblockerng-edge', 'pfSense-pkg-pfBlockerNG', 'edge'],
 			'testing catalogue beats the name'        => ['pfblockerng-testing', 'pfSense-pkg-pfBlockerNG', 'testing'],
-			// Legacy shared repo: it names no channel, so the NAME still discriminates.
+			'repo beats annotation'                   => ['pfblockerng-edge', 'pfSense-pkg-pfBlockerNG', 'edge', 'testing'],
+			// Legacy shared repo: it names no channel. A leftover suffix still maps;
+			// the canonical name does not invent 'stable'.
 			'legacy repo falls back to -devel'        => ['pfblockerng', 'pfSense-pkg-pfBlockerNG-devel', 'devel'],
-			'legacy repo falls back to canonical'     => ['pfblockerng', 'pfSense-pkg-pfBlockerNG', 'stable'],
+			'legacy repo + canonical name -> unknown' => ['pfblockerng', 'pfSense-pkg-pfBlockerNG', null],
 			// A sideloaded `pkg add` records no repo at all — the Tier-A deploy's case.
-			'no repo falls back to the name'          => ['', 'pfSense-pkg-pfBlockerNG-nightly', 'nightly'],
-			'null repo falls back to the name'        => [null, 'pfSense-pkg-pfBlockerNG', 'stable'],
+			'no repo falls back to the name suffix'   => ['', 'pfSense-pkg-pfBlockerNG-nightly', 'nightly'],
+			'sideload -edge suffix'                   => ['', 'pfSense-pkg-pfBlockerNG-edge', 'edge'],
+			'sideload canonical is not stable'        => ['', 'pfSense-pkg-pfBlockerNG', null],
+			'null repo + canonical name -> unknown'   => [null, 'pfSense-pkg-pfBlockerNG', null],
+			// Annotation fills in when repo and suffix cannot.
+			'empty repo + annotation testing'         => ['', 'pfSense-pkg-pfBlockerNG', 'testing', 'testing'],
+			'annotation beats empty suffix'           => [null, 'pfSense-pkg-pfBlockerNG', 'edge', 'edge'],
+			// Netgate origin still accepts a leftover suffix (devel leftover).
+			'netgate repo + devel suffix -> devel'    => ['pfSense', 'pfSense-pkg-pfBlockerNG-devel', 'devel'],
 			// Neither half recognises it: a Netgate or hand-built package.
 			'netgate repo, foreign name -> null'      => ['pfSense', 'pfSense-pkg-suricata', null],
 			'unknown repo, unknown name -> null'      => ['whatever', '', null],
@@ -118,9 +128,143 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	}
 
 	#[DataProvider('channelForInstallProvider')]
-	public function testChannelForInstall(?string $repo, ?string $pkgname, ?string $expected): void
+	public function testChannelForInstall(
+		?string $repo,
+		?string $pkgname,
+		?string $expected,
+		?string $recordChannel = null
+	): void {
+		$this->assertSame($expected, pfb_channel_for_install($repo, $pkgname, $recordChannel));
+	}
+
+	/*
+	 * ---- pfb_channel_from_build_record() / pfb_channel_recognized() ----
+	 */
+	public static function buildRecordProvider(): array
 	{
-		$this->assertSame($expected, pfb_channel_for_install($repo, $pkgname));
+		return [
+			'testing annotation' => ['{"channel":"testing"}', 'testing'],
+			'stable annotation'  => ['{"channel":"stable"}', 'stable'],
+			'EDGE mixed case'    => ['{"channel":"EDGE"}', 'edge'],
+			'junk channel'       => ['{"channel":"beta"}', null],
+			'missing channel'    => ['{"source_sha":"abc"}', null],
+			'not json'           => ['{not json', null],
+			'empty'              => ['', null],
+			'null'               => [null, null],
+		];
+	}
+
+	#[DataProvider('buildRecordProvider')]
+	public function testChannelFromBuildRecord(?string $json, ?string $expected): void
+	{
+		$this->assertSame($expected, pfb_channel_from_build_record($json));
+	}
+
+	/*
+	 * ---- pfb_pkg_is_our_name() — identity after empty-suffix stopped meaning stable ----
+	 */
+	public static function ourNameProvider(): array
+	{
+		return [
+			'canonical'     => ['pfSense-pkg-pfBlockerNG', true],
+			'devel leftover'=> ['pfSense-pkg-pfBlockerNG-devel', true],
+			'edge leftover' => ['pfSense-pkg-pfBlockerNG-edge', true],
+			'foreign pkg'   => ['pfSense-pkg-suricata', false],
+			'foreign suffix'=> ['pfSense-pkg-pfBlockerNG-beta', false],
+			'empty'         => ['', false],
+			'null'          => [null, false],
+		];
+	}
+
+	#[DataProvider('ourNameProvider')]
+	public function testPkgIsOurName(?string $name, bool $expected): void
+	{
+		$this->assertSame($expected, pfb_pkg_is_our_name($name));
+	}
+
+	/*
+	 * ---- pfb_pkg_newest_version() — rquery lines, not $out[0] (issue #2379) ----
+	 */
+	public static function newestVersionProvider(): array
+	{
+		return [
+			'3.3.0 then 3.3.2'           => [['3.3.0', '3.3.2'], '3.3.2'],
+			'3.3.2 then 3.3.0'           => [['3.3.2', '3.3.0'], '3.3.2'],
+			'single 3.3.2'               => [['3.3.2'], '3.3.2'],
+			'empty / blanks skipped'     => [['', '3.3.0', '  ', '3.3.2'], '3.3.2'],
+			'empty list'                 => [[], ''],
+			'nightly dated'              => [['20260801', '20260814_2'], '20260814_2'],
+			'nightly timestamp.hex'      => [['20260801120000.abc1234', '20260814120000.def5678'], '20260814120000.def5678'],
+		];
+	}
+
+	#[DataProvider('newestVersionProvider')]
+	public function testPkgNewestVersion(array $versions, string $expected): void
+	{
+		$this->assertSame($expected, pfb_pkg_newest_version($versions));
+	}
+
+	/*
+	 * ---- Software-page action hrefs (issue #2380) ----
+	 * pkg_mgr_install.php only when %R is pfSense. Channel origins stay on '#'.
+	 */
+	public static function updateHrefProvider(): array
+	{
+		$pkg = 'pfSense-pkg-pfBlockerNG';
+		$pm = '/pkg_mgr_install.php?mode=reinstallpkg&pkg=' . rawurlencode($pkg);
+		return [
+			'Netgate + update'            => [$pkg, 'pfSense', true, $pm],
+			'Netgate + no update'         => [$pkg, 'pfSense', false, '#'],
+			'channel-stable + update'     => [$pkg, 'pfblockerng-stable', true, '#'],
+			'channel-testing + update'    => [$pkg, 'pfblockerng-testing', true, '#'],
+			'legacy pfblockerng + update' => [$pkg, 'pfblockerng', true, '#'],
+			'empty repo + update'         => [$pkg, '', true, '#'],
+			'empty pkgname'               => ['', 'pfSense', true, '#'],
+		];
+	}
+
+	#[DataProvider('updateHrefProvider')]
+	public function testSoftwareUpdateHref(string $pkgname, string $repo, bool $available, string $expected): void
+	{
+		$this->assertSame($expected, pfb_software_update_href($pkgname, $repo, $available));
+	}
+
+	public static function uninstallHrefProvider(): array
+	{
+		$pkg = 'pfSense-pkg-pfBlockerNG';
+		$pm = '/pkg_mgr_install.php?mode=delete&pkg=' . rawurlencode($pkg);
+		return [
+			'Netgate'         => [$pkg, 'pfSense', $pm],
+			'channel-stable'  => [$pkg, 'pfblockerng-stable', '#'],
+			'channel-edge'    => [$pkg, 'pfblockerng-edge', '#'],
+			'empty repo'      => [$pkg, '', '#'],
+			'empty pkgname'   => ['', 'pfSense', '#'],
+		];
+	}
+
+	#[DataProvider('uninstallHrefProvider')]
+	public function testSoftwareUninstallHref(string $pkgname, string $repo, string $expected): void
+	{
+		$this->assertSame($expected, pfb_software_uninstall_href($pkgname, $repo));
+	}
+
+	public function testSoftwarePageDoesNotHardcodePkgMgrForAllOrigins(): void
+	{
+		$src = (string) file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_software.php'
+		);
+		$this->assertStringContainsString('pfb_software_update_href', $src);
+		$this->assertStringContainsString('pfb_software_uninstall_href', $src);
+		$this->assertStringNotContainsString(
+			'mode=reinstallpkg&pkg={$pfb_pkg_arg}',
+			$src,
+			'channel-origin installs must not emit a hardcoded Package Manager reinstall href'
+		);
+		$this->assertStringNotContainsString(
+			'mode=delete&pkg={$pfb_pkg_arg}',
+			$src,
+			'channel-origin installs must not emit a hardcoded Package Manager delete href'
+		);
 	}
 
 	/*
@@ -215,6 +359,8 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		return [
 			'newer latest -> available'        => ['3.2.0_5', '3.2.0_6', true],
 			'newer minor -> available'         => ['3.2.0', '3.2.1', true],
+			'3.3.0 vs 3.3.2 -> available'      => ['3.3.0', '3.3.2', true],
+			'3.3.2 vs 3.3.0 -> not available'  => ['3.3.2', '3.3.0', false],
 			'equal -> not available'           => ['3.2.0', '3.2.0', false],
 			'older latest -> not available'    => ['3.2.0_6', '3.2.0_5', false],
 			'nightly newer date -> available'  => ['20260101', '20260615', true],

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -1073,6 +1073,26 @@
                 "variadic": false,
                 "type": "?string",
                 "default": null
+            },
+            {
+                "name": "record_channel",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_channel_from_build_record": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "json",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
             }
         ]
     },
@@ -1095,6 +1115,19 @@
         "params": [
             {
                 "name": "repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_channel_recognized": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "channel",
                 "byRef": false,
                 "variadic": false,
                 "type": "?string",
@@ -8813,6 +8846,26 @@
             }
         ]
     },
+    "pfb_pkg_annotation": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "key",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_pkg_argv_subcommand": {
         "returnsRef": false,
         "returnType": "string",
@@ -8857,6 +8910,19 @@
             }
         ]
     },
+    "pfb_pkg_is_our_name": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "name",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
     "pfb_pkg_latest": {
         "returnsRef": false,
         "returnType": "string",
@@ -8873,6 +8939,19 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "string",
+                "default": null
+            }
+        ]
+    },
+    "pfb_pkg_newest_version": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "versions",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
                 "default": null
             }
         ]
@@ -10528,6 +10607,19 @@
             }
         ]
     },
+    "pfb_software_pkgmgr_usable": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": null
+            }
+        ]
+    },
     "pfb_software_provenance_ok": {
         "returnsRef": false,
         "returnType": "bool",
@@ -10537,6 +10629,26 @@
         "returnsRef": false,
         "returnType": "array",
         "params": []
+    },
+    "pfb_software_uninstall_href": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
     },
     "pfb_software_update_check": {
         "returnsRef": false,
@@ -10555,6 +10667,33 @@
                 "variadic": false,
                 "type": "?array",
                 "default": "NULL"
+            }
+        ]
+    },
+    "pfb_software_update_href": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "update_available",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
             }
         ]
     },

--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -931,9 +931,7 @@ def test_software_check_picks_newest_retained_catalog_version(repo_vm: SmokeVM, 
         build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [low_pkg, high_pkg])
         pkg_update_our_repo(repo_vm, OURS_REPO_NAME)
 
-        rquery = _ssh_check(
-            repo_vm, "pkg", "rquery", "-r", OURS_REPO_NAME, "%v", PKG_NAME, timeout=60.0
-        ).stdout.strip()
+        rquery = _ssh_check(repo_vm, "pkg", "rquery", "-r", OURS_REPO_NAME, "%v", PKG_NAME, timeout=60.0).stdout.strip()
         lines = [line.strip() for line in rquery.splitlines() if line.strip()]
         assert low in lines and high in lines, f"catalog must retain both versions, rquery={rquery!r}"
 

--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -899,6 +899,62 @@ def test_software_positive_journey_on_our_repo_install(repo_vm: SmokeVM, tmp_pat
         repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)
 
 
+@pytest.mark.timeout(600)
+def test_software_check_picks_newest_retained_catalog_version(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """issue #2379: Check now stores the newest rquery version, not ``$out[0]``.
+
+    Channel catalogues retain older builds. Stable's live shape is ``3.3.0`` then
+    ``3.3.2``. The shipped picker must take the newest line via ``pkg_version_compare()``.
+
+    Given ``<V>_9`` installed FROM our repo and a file:// catalog that retains both
+        ``<V>_1`` and ``<V>_9`` (older first),
+    When the shipped ``pfb_software_update_check`` runs,
+    Then cache ``latest`` is ``<V>_9`` (not the first rquery line) and Status is
+        up-to-date because Latest == installed.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"
+    src = Path(pkg)
+    base_version = read_compact_version(src)
+    low = f"{base_version}_1"
+    high = f"{base_version}_9"
+    assert low != high
+
+    try:
+        install_our_build_at(repo_vm, high, src, tmp_path, "high")
+        assert pkg_installed_version(repo_vm) == high
+        assert pkg_repo_origin(repo_vm) == OURS_REPO_NAME
+
+        low_pkg = reversion_pkg(src, low, tmp_path / "low")
+        high_pkg = reversion_pkg(src, high, tmp_path / "high_retain")
+        # Older first so a $out[0] picker would report low.
+        build_guest_repo(repo_vm, UPGRADE_REPO_DIR, [low_pkg, high_pkg])
+        pkg_update_our_repo(repo_vm, OURS_REPO_NAME)
+
+        rquery = _ssh_check(
+            repo_vm, "pkg", "rquery", "-r", OURS_REPO_NAME, "%v", PKG_NAME, timeout=60.0
+        ).stdout.strip()
+        lines = [line.strip() for line in rquery.splitlines() if line.strip()]
+        assert low in lines and high in lines, f"catalog must retain both versions, rquery={rquery!r}"
+
+        clear_software_state(repo_vm)
+        set_software_check(repo_vm, "on")
+        run_update_check_on_box(repo_vm)
+
+        cache = read_software_cache(repo_vm)
+        assert cache.get("installed") == high, f"installed {cache.get('installed')!r} != {high!r}"
+        assert cache.get("latest") == high, (
+            f"latest must be the newest retained version {high!r}, not rquery $out[0]; "
+            f"got {cache.get('latest')!r} from lines {lines!r}"
+        )
+        assert cache.get("latest") != low, "picker must not take the older retained version"
+    finally:
+        clear_software_state(repo_vm)
+        clear_software_check(repo_vm)
+        pkg_delete(repo_vm)
+        repo_vm.ssh("/bin/rm", "-rf", UPGRADE_REPO_DIR, timeout=60.0)
+
+
 # --------------------------------------------------------------------------- #
 # (f) "Check for new versions" gating — disabled vs enabled, background vs manual, live
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2813,33 +2813,28 @@ def test_software_check_checkbox_posts_a_token_the_save_path_accepts(
 def test_software_actions_link_to_package_manager(
     smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:
-    """Update/Uninstall are LINKS to pfSense's base-system Package Manager (issue #684).
+    """Update/Uninstall reach Package Manager only when ``%R`` is ``pfSense`` (issue #2380).
 
-    The Software page no longer self-hosts the pkg operation (no detached daemon, no ``?ajax=tail``
-    live tail). The Update and Uninstall controls are anchors to ``pkg_mgr_install.php`` — the
-    base-system page that runs pkg and shows its own progress from a page that SURVIVES pfBlockerNG's
-    own removal/upgrade.
+    pfSense ``get_pkg_info()`` skips any ``pfSense-pkg-*`` whose origin is not exactly
+    ``pfSense``. A ``pfblockerng-*`` (or empty sideload) origin therefore must not emit
+    ``pkg_mgr_install.php?mode=reinstallpkg|delete``. Netgate-origin installs keep the
+    #684 shortcuts.
 
     Scenario:
       Given the override sentinel set to 'on' (so the provenance gate passes),
       When the Software page is GET,
-      Then the Uninstall control is an ``<a>`` whose href links directly to the Package Manager
-          delete flow (``pkg_mgr_install.php?mode=delete&pkg=…``) — #697 removed the ?do=uninstall
-          intent-marker detour, since a delete always tears pfBlockerNG down;
-      And the Update control's href GATES on update-availability (CodeRabbit #685): with no cached
-          newer version it is inert (``href="#"``, disabled), and with a newer version cached it is an
-          actionable ``pkg_mgr_install.php?mode=reinstallpkg&pkg=…`` link — the href, not just CSS,
-          is the gate (an anchor's ``disabled``/``aria-disabled`` are advisory only);
-      And the page carries NO in-page pkg machinery — no ``?ajax=tail`` poller, no ``pfb_output``
-          textarea (the historical post-uninstall redirects were POST-only machinery, so they
-          left no GET-observable trace to assert on — see #791);
+      Then Update's href is inert ('#') when no update is cached;
+      And Uninstall / Update never point at ``pkg_mgr_install.php`` unless ``%R`` is
+          ``pfSense``;
+      And the page carries NO in-page pkg machinery — no ``?ajax=tail`` poller, no
+          ``pfb_output`` textarea;
       And the clean render oracle (200, no Fatal/Warning/Notice, marker present) holds.
-
-    Fail-before / pass-after: the pre-#684 page ran ``pkg`` from a detached daemon and tailed it via
-    ``?ajax=tail`` into a ``pfb_output`` textarea — so the ``pkg_mgr_install.php`` hrefs were absent
-    and ``?ajax=tail`` / ``pfb_output`` were present, inverting the assertions below.
     """
     software_cache = "/var/db/pfblockerng/software_update.json"
+    pkgname = pkg_identity.branch_pkg_name(os.environ.get("SMOKE_PKG"))
+    repo_probe = smoke_vm.ssh("/usr/local/sbin/pkg", "query", "%R", pkgname)
+    installed_repo = repo_probe.stdout.strip() if repo_probe.returncode == 0 else ""
+    pkgmgr_ok = installed_repo == "pfSense"
 
     def _update_anchor(body: str) -> str:
         tag = re.search(r'<a\b[^>]*id=["\']pfb_sw_update["\'][^>]*>', body)
@@ -2866,14 +2861,21 @@ def test_software_actions_link_to_package_manager(
         )
         assert re.search(r'href=["\']#["\']', up_tag), f"Update href must be inert ('#') when no update: {up_tag!r}"
 
-        # Uninstall is ALWAYS actionable (removal does not gate on availability) and links DIRECTLY
-        # to pfSense's Package Manager delete flow. #697 removed the ?do=uninstall intent-marker
-        # detour: a delete always tears pfBlockerNG down, so no marker is needed.
         un_tag = re.search(r'<a\b[^>]*id=["\']pfb_sw_uninstall["\'][^>]*>', body)
         assert un_tag is not None, f"Uninstall control is not an <a> link in {_SOFTWARE_PAGE} body"
-        assert _has_pkgmgr_href(un_tag.group(0), "delete"), (
-            f"Uninstall link must target pkg_mgr_install.php?mode=delete, got: {un_tag.group(0)!r}"
-        )
+        if pkgmgr_ok:
+            assert _has_pkgmgr_href(un_tag.group(0), "delete"), (
+                f"Netgate-origin Uninstall must target pkg_mgr_install.php?mode=delete, got: {un_tag.group(0)!r}"
+            )
+        else:
+            assert not _has_pkgmgr_href(un_tag.group(0), "delete"), (
+                f"channel/sideload Uninstall must not emit pkg_mgr_install.php (issue #2380), "
+                f"%R={installed_repo!r}, got: {un_tag.group(0)!r}"
+            )
+            assert re.search(r'href=["\']#["\']', un_tag.group(0)), (
+                f"channel/sideload Uninstall href must be inert ('#'): {un_tag.group(0)!r}"
+            )
+            assert "pkg_mgr_install.php" not in body or "Package Manager cannot see this origin" in body
         assert "?do=uninstall" not in un_tag.group(0), (
             "Uninstall must NOT route through the removed ?do=uninstall handler (#697)"
         )
@@ -2885,25 +2887,29 @@ def test_software_actions_link_to_package_manager(
         assert "?ajax=tail" not in body, "Software page must no longer host the ?ajax=tail poller"
         assert 'name="pfb_output"' not in body, "Software page must no longer render the pfb_output textarea"
 
-        # (B) Seed a newer cached 'latest' → update available → the Update href becomes the actionable
-        #     reinstallpkg link (the ON branch of the availability gate). 99.0.0 > any real installed
-        #     version, so pfb_update_available() is TRUE regardless of the branch build. The seed
-        #     carries the installed package's own name because the page only trusts a cache that
-        #     describes the install it is looking at (issue #2148); a nameless cache is not one.
+        # (B) Seed a newer cached 'latest' → update available. Package Manager reinstall is
+        #     only for %R=pfSense; a channel/sideload origin stays on '#' (issue #2380).
         try:
             smoke_vm.ssh("/bin/rm", "-f", software_cache)
             seed = json.dumps(
                 {
-                    "pkgname": pkg_identity.branch_pkg_name(os.environ.get("SMOKE_PKG")),
+                    "pkgname": pkgname,
                     "latest": "99.0.0",
                     "last_checked": 1,
                 }
             )
             _seed_vm_file(smoke_vm, software_cache, seed)
             up_tag2 = _update_anchor(webui.get(_SOFTWARE_PAGE).text)
-            assert _has_pkgmgr_href(up_tag2, "reinstallpkg"), (
-                f"Update link must target pkg_mgr_install.php?mode=reinstallpkg when an update exists: {up_tag2!r}"
-            )
+            if pkgmgr_ok:
+                assert _has_pkgmgr_href(up_tag2, "reinstallpkg"), (
+                    f"Netgate-origin Update must target pkg_mgr_install.php?mode=reinstallpkg "
+                    f"when an update exists: {up_tag2!r}"
+                )
+            else:
+                assert not _has_pkgmgr_href(up_tag2, "reinstallpkg"), (
+                    f"channel/sideload Update must not emit pkg_mgr_install.php (issue #2380), "
+                    f"%R={installed_repo!r}, got: {up_tag2!r}"
+                )
         finally:
             smoke_vm.ssh("/bin/rm", "-f", software_cache)
 


### PR DESCRIPTION
Fixes #2379
Fixes #2395
Fixes #2380

Software Latest was `$out[0]` (oldest retained). Channel was inferred from the package name, so a channel-repo install looked like stable. Pick newest with `pkg version -t` and report the repo that provided it.

Made-with: Grok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved package channel detection using repository information, build metadata, and package naming.
  * Software update and uninstall actions now appear only for packages from the official pfSense repository.
  * Packages from other sources display appropriate repository-specific command guidance.
  * Update checks now refresh the relevant catalog and select the newest available package version.

* **Bug Fixes**
  * Failed update checks no longer overwrite valid cached version information or check timestamps.
  * Package installations without channel suffixes are now identified correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->