### PR TITLE
ci(nightly): clone ports at the prepare SHA

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -238,7 +238,6 @@ jobs:
           MATRIX_DIGEST: ${{ needs.prepare.outputs.matrix_digest }}
           RUN_ID: nightly-${{ github.run_id }}-${{ matrix.freebsd_major }}
           PORTS_REPO: ${{ env.PORTS_REPO }}
-          PORTS_REF: ${{ env.PORTS_REF }}
         run: |
           set -eu
           export RUN_ROOT="$GITHUB_WORKSPACE/out"
@@ -263,7 +262,7 @@ jobs:
           PKG="$(
             sh "$TRUSTED_DIR/scripts/build-leg.sh" \
               --ports-repo "$PORTS_REPO" \
-              --ports-ref "$PORTS_REF" \
+              --ports-ref "$PORTS_SHA" \
               --channel nightly \
               --variant "$VARIANT" \
               --build-record build-record.json \

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -4,6 +4,8 @@ import itertools
 import re
 from pathlib import Path
 
+import pytest
+
 WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "nightly.yml"
 ALERT_WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "nightly-failure-alert.yml"
 
@@ -110,6 +112,50 @@ def test_nightly_failure_alert_watches_snapshot_workflow() -> None:
     text = ALERT_WORKFLOW.read_text(encoding="utf-8")
 
     assert '- "Nightly snapshot"' in text
+
+
+def _build_and_verify_step(text: str) -> str:
+    start = text.index("      - name: Build and verify package")
+    end = text.index("\n      - name: Upload verified build", start)
+    return text[start:end]
+
+
+def _build_leg_invocation(step: str) -> str:
+    marker = 'sh "$TRUSTED_DIR/scripts/build-leg.sh"'
+    start = step.index(marker)
+    end = step.index(")", start)
+    return step[start:end]
+
+
+def _assert_build_leg_pins_prepare_sha(build_leg: str) -> None:
+    assert '--ports-ref "$PORTS_SHA"' in build_leg
+    assert '--ports-ref "$PORTS_REF"' not in build_leg
+
+
+def test_build_step_clones_ports_at_prepare_sha() -> None:
+    """issue #2406: BUILD clones prepare's PORTS_SHA; PORTS_REF is ls-remote only."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    step = _build_and_verify_step(text)
+    build_leg = _build_leg_invocation(step)
+
+    _assert_build_leg_pins_prepare_sha(build_leg)
+    assert 'if [ "$ACTUAL_PORTS_SHA" != "$PORTS_SHA" ]; then' in step
+
+    prepare_start = text.index("      - name: Resolve pinned source, Ports, and live matrices")
+    prepare_end = text.index("\n      - name: Expose pinned plan", prepare_start)
+    prepare = text[prepare_start:prepare_end]
+    assert prepare.count('git ls-remote "$PORTS_URL"') == 1
+    assert "refs/heads/${PORTS_REF}" in prepare
+    assert 'echo "ports_sha=$PORTS_SHA"' in prepare
+
+
+def test_build_leg_ports_ref_pin_rejects_moving_branch() -> None:
+    """issue #2406: swapping SHA for REF on the build-leg line is RED."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    build_leg = _build_leg_invocation(_build_and_verify_step(text))
+    mutated = build_leg.replace('--ports-ref "$PORTS_SHA"', '--ports-ref "$PORTS_REF"', 1)
+    with pytest.raises(AssertionError):
+        _assert_build_leg_pins_prepare_sha(mutated)
 
 
 def test_build_step_builds_and_hands_off_dependency_packages() -> None:


### PR DESCRIPTION
Nightly `prepare` already pins a 40-hex `PORTS_SHA` from one `ls-remote` of `PORTS_REF`. BUILD still passed `--ports-ref "$PORTS_REF"` (the moving branch), then fail-closed when `ACTUAL_PORTS_SHA != PORTS_SHA`. A ports push during the matrix turned Nightly red instead of building the prepare snapshot.

This PR clones the prepare SHA:

- BUILD `build-leg.sh` now uses `--ports-ref "$PORTS_SHA"` (`needs.prepare.outputs.ports_sha`). Unused `PORTS_REF` env re-export dropped from that step.
- Post-clone `ACTUAL_PORTS_SHA == PORTS_SHA` check stays.
- `PORTS_REF` remains the prepare `ls-remote` input only (handoff still records the ref name).
- Contract test pins `--ports-ref "$PORTS_SHA"` on the BUILD invocation. `--ports-ref "$PORTS_REF"` on that line is RED (mutation canary).

Does not touch tagged `release.yml` (#2387) or `sparse-clone-ports.sh` / `build-leg.sh` (already SHA-capable).

Fixes #2406
Made-with: Grok

🤖 Generated by Grok and posted on behalf of @BBcan177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly builds now consistently use the resolved, pinned Ports revision, improving build reproducibility and preventing changes from a moving branch from affecting results.

* **Tests**
  * Added automated checks to verify pinned revision usage, validation, and branch lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->