### PR TITLE
publish-pkg-repo: do not stage leftover dest autoindexes

### DIFF
--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -26,7 +26,9 @@
 # On a rejected push (another run advanced origin/main first), the ENTIRE cycle
 # reruns from a fresh sync — not a rebase of the local commit — because
 # the publisher's retention/regeneration must see the racing run's tree, not
-# stale local state.
+# stale local state. checkout -B restores tracked files; `git clean -fd -- docs`
+# drops untracked leftovers under docs/ (issue #2407) so a dest autoindex
+# without its .pkgs cannot survive into landing_regen_and_stage.
 #
 # PUBLISH_STAGE additionally selects WHEN a tagged catalogue commit becomes the
 # live Pages site (issue #2389 — gate-before-announce). docs/ on `main` IS the
@@ -290,8 +292,11 @@ promote_from_staging() {
 }
 
 # Shared by "direct" (non-noop) and "promote": regenerate the landing page and
-# stage exactly the landing output plus every $touched target's directory, the
-# same explicit-pathspec discipline as the rest of this script.
+# stage the landing output, every $touched target's directory, that dest's
+# channel-level autoindex, and already-tracked dest/channel autoindexes
+# gen_landing rewrote. Never a site-wide find of every docs/**/index.html —
+# an untracked leftover dest from a rejected push is not this run's
+# (issue #2407).
 landing_regen_and_stage() {
     case "$PUBLISH_KIND" in
         tagged) landing_input="$ROUTE_MATRIX" ;;
@@ -314,22 +319,17 @@ landing_regen_and_stage() {
     [ -f "${PKG_REPO}/docs/migrate-channel.sh" ] && stage_paths="${stage_paths} docs/migrate-channel.sh"
     for target in $touched; do
         stage_paths="${stage_paths} docs/${target}"
+        ch="${target%%/*}"
+        [ -f "${PKG_REPO}/docs/${ch}/index.html" ] && stage_paths="${stage_paths} docs/${ch}/index.html"
     done
-    docs_root="${PKG_REPO}/docs"
-    # `if`/`fi`, never `[ -f ... ] && printf` — the last directory `find` enumerates
-    # (order is not alphabetical; whatever readdir(3) returns) can legitimately have
-    # no index.html (gen_landing.py never writes one under docs/staging, issue
-    # #2389), and an `&&`-chained test's own falsy status becomes the whole `while`
-    # loop's exit status on its last iteration, which `set -e` then treats as this
-    # `dir_indexes=$(...)` assignment failing — aborting the script AFTER the
-    # publisher already ran and BEFORE any git add/commit (issue #2389).
-    dir_indexes=$(find "$docs_root" -mindepth 1 -type d -print | while IFS= read -r d; do
-        if [ -f "${d}/index.html" ]; then
-            printf 'docs/%s/index.html\n' "${d#"${docs_root}/"}"
-        fi
-    done)
-    stage_paths="${stage_paths}
-${dir_indexes}"
+    # Already-tracked dest/channel autoindexes only. ls-files cannot name a
+    # dest that is not in the index, so a leftover dest autoindex cannot
+    # appear here (issue #2407).
+    tracked_indexes=$(git -C "$PKG_REPO" ls-files -- 'docs/*/index.html' 'docs/*/*/index.html')
+    if [ -n "$tracked_indexes" ]; then
+        stage_paths="${stage_paths}
+${tracked_indexes}"
+    fi
     # shellcheck disable=SC2086  # stage_paths is a controlled, space/newline-separated pathspec list
     git -C "$PKG_REPO" add -- $stage_paths
 }
@@ -355,6 +355,10 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
     echo "publish-pkg-repo: sync attempt ${attempt}/${MAX_PUSH_ATTEMPTS} — fetching origin/main"
     git -C "$PKG_REPO" fetch --quiet origin main
     git -C "$PKG_REPO" checkout --quiet -B main origin/main
+    # checkout -B restores tracked files. Untracked leftovers from a rejected
+    # push (dest autoindex without its .pkgs) survive unless cleaned. Scope
+    # to docs/ so G1 debris at the repo root stays untracked (issue #2407).
+    git -C "$PKG_REPO" clean -fd -- docs
 
     stage_commit=0
 

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -388,6 +388,73 @@ JSON
     The variable porcelain should include 'debris.txt'
   End
 
+  # --- leftover dest autoindex from a rejected push (issue #2407) -----------
+  # checkout -B restores tracked files but leaves an untracked dest index
+  # from a previous attempt. A site-wide find of every docs/**/index.html
+  # would stage that leftover without its .pkgs. These examples plant the
+  # leftover before the script runs; the commit must not include it. The
+  # file may be cleaned (git clean -fd -- docs) or stay untracked — either
+  # is correct. G1 debris/README stay uncommitted. Re-introducing an
+  # unscope find that still walks leftover dests turns the first example
+  # RED if the leftover survives into landing_regen_and_stage.
+
+  It 'does not stage an untracked leftover dest autoindex from a previous rejected push'
+    mkdir -p "${base}/pkg-repo/docs/nightly/ce-2.8"
+    printf 'orphan autoindex\n' > "${base}/pkg-repo/docs/nightly/ce-2.8/index.html"
+    echo dirty >> "${base}/pkg-repo/README.txt"
+    echo stray > "${base}/pkg-repo/debris.txt"
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
+    The variable committed should not include 'docs/nightly/ce-2.8/index.html'
+    The variable committed should include 'docs/edge/ce-2.8/marker.pkg'
+    The variable committed should not include 'README.txt'
+    The variable committed should not include 'debris.txt'
+    tracked_leftover="$(git_fixture -C "${base}/pkg-repo" ls-files -- docs/nightly/ce-2.8/index.html)"
+    The variable tracked_leftover should equal ''
+    porcelain="$(git_fixture -C "${base}/pkg-repo" status --porcelain)"
+    The variable porcelain should include 'README.txt'
+    The variable porcelain should include 'debris.txt'
+  End
+
+  It 'does not stage leftover dest payload next to an orphan autoindex'
+    mkdir -p "${base}/pkg-repo/docs/nightly/ce-2.8"
+    printf 'orphan autoindex\n' > "${base}/pkg-repo/docs/nightly/ce-2.8/index.html"
+    printf 'leftover\n' > "${base}/pkg-repo/docs/nightly/ce-2.8/marker.pkg"
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
+    The variable committed should not include 'docs/nightly/ce-2.8/index.html'
+    The variable committed should not include 'docs/nightly/ce-2.8/marker.pkg'
+    tracked_leftover="$(git_fixture -C "${base}/pkg-repo" ls-files -- docs/nightly/ce-2.8)"
+    The variable tracked_leftover should equal ''
+  End
+
+  It 'still stages a rewrite of an already-tracked channel autoindex'
+    printf 'old channel index\n' > "${base}/pkg-repo/docs/edge/index.html"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/edge/index.html \
+        && git_fixture commit -q -m preseed-channel-index \
+        && git_fixture push -q origin main )
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
+    The variable committed should include 'docs/edge/index.html'
+    rewritten="$(cat "${base}/pkg-repo/docs/edge/index.html")"
+    The variable rewritten should equal 'autoindex stub: edge'
+  End
+
   # --- the script must be self-sufficient for git identity -----------------
 
   It 'commits with a fixed bot identity even when no git identity is configured anywhere'

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -389,16 +389,15 @@ JSON
   End
 
   # --- leftover dest autoindex from a rejected push (issue #2407) -----------
-  # checkout -B restores tracked files but leaves an untracked dest index
-  # from a previous attempt. A site-wide find of every docs/**/index.html
-  # would stage that leftover without its .pkgs. These examples plant the
-  # leftover before the script runs; the commit must not include it. The
-  # file may be cleaned (git clean -fd -- docs) or stay untracked — either
-  # is correct. G1 debris/README stay uncommitted. Re-introducing an
-  # unscope find that still walks leftover dests turns the first example
-  # RED if the leftover survives into landing_regen_and_stage.
+  # Dual defense: `git clean -fd -- docs` after checkout -B, and dest
+  # autoindex staging via `git ls-files` (already-tracked only), never a
+  # site-wide find. Each pin below is independent — dropping only one
+  # defense must turn that pin RED.
 
-  It 'does not stage an untracked leftover dest autoindex from a previous rejected push'
+  It 'cleans an untracked leftover dest autoindex off disk after checkout -B'
+    # Clean pin: leftover must not exist on disk after ADVANCE. Dropping
+    # `git clean -fd -- docs` leaves the untracked dest (ls-files will not
+    # stage it) and this example goes RED. G1 debris/README stay uncommitted.
     mkdir -p "${base}/pkg-repo/docs/nightly/ce-2.8"
     printf 'orphan autoindex\n' > "${base}/pkg-repo/docs/nightly/ce-2.8/index.html"
     echo dirty >> "${base}/pkg-repo/README.txt"
@@ -409,6 +408,7 @@ JSON
     The status should equal 0
     The output should include 'ADVANCE'
     The stderr should include 'main'
+    The path "${base}/pkg-repo/docs/nightly/ce-2.8/index.html" should not be exist
     committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
     The variable committed should not include 'docs/nightly/ce-2.8/index.html'
     The variable committed should include 'docs/edge/ce-2.8/marker.pkg'
@@ -421,7 +421,9 @@ JSON
     The variable porcelain should include 'debris.txt'
   End
 
-  It 'does not stage leftover dest payload next to an orphan autoindex'
+  It 'cleans leftover dest payload next to an orphan autoindex and never tracks it'
+    # Clean pin for the leftover .pkg as well: both paths gone from disk.
+    # marker.pkg must also stay out of the commit and the index.
     mkdir -p "${base}/pkg-repo/docs/nightly/ce-2.8"
     printf 'orphan autoindex\n' > "${base}/pkg-repo/docs/nightly/ce-2.8/index.html"
     printf 'leftover\n' > "${base}/pkg-repo/docs/nightly/ce-2.8/marker.pkg"
@@ -431,11 +433,37 @@ JSON
     The status should equal 0
     The output should include 'ADVANCE'
     The stderr should include 'main'
+    The path "${base}/pkg-repo/docs/nightly/ce-2.8/index.html" should not be exist
+    The path "${base}/pkg-repo/docs/nightly/ce-2.8/marker.pkg" should not be exist
     committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
     The variable committed should not include 'docs/nightly/ce-2.8/index.html'
     The variable committed should not include 'docs/nightly/ce-2.8/marker.pkg'
     tracked_leftover="$(git_fixture -C "${base}/pkg-repo" ls-files -- docs/nightly/ce-2.8)"
     The variable tracked_leftover should equal ''
+  End
+
+  It 'stages a rewrite of an already-tracked dest autoindex that this run did not touch'
+    # ls-files dest-level pin: origin already tracks docs/nightly/ce-2.8/index.html
+    # and this run only touches edge/ce-2.8. gen_landing rewrites every existing
+    # dest autoindex; only the ls-files dest-index stage picks this one up.
+    # Dropping that stage leaves the rewrite unstaged and this example goes RED,
+    # even if git clean remains (the file is tracked, so clean cannot remove it).
+    # Distinct from the touched-channel docs/edge/index.html rewrite below.
+    mkdir -p "${base}/pkg-repo/docs/nightly/ce-2.8"
+    printf 'old dest index\n' > "${base}/pkg-repo/docs/nightly/ce-2.8/index.html"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/nightly/ce-2.8/index.html \
+        && git_fixture commit -q -m preseed-nightly-dest-index \
+        && git_fixture push -q origin main )
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
+    The variable committed should include 'docs/nightly/ce-2.8/index.html'
+    rewritten="$(git_fixture -C "${base}/pkg-repo" show HEAD:docs/nightly/ce-2.8/index.html)"
+    The variable rewritten should equal 'autoindex stub: nightly/ce-2.8'
   End
 
   It 'still stages a rewrite of an already-tracked channel autoindex'


### PR DESCRIPTION
## Problem

After a rejected push, `checkout -B main origin/main` restores tracked files but leaves an untracked dest `index.html` from the failed attempt. `landing_regen_and_stage` then `find`-walked every `docs/**/index.html` and staged that leftover without its `.pkg`s. The next run (different `touched` dest) could publish a Pages listing that 404s the packages it names.

G1 (`debris.txt` / dirty `README.txt`) never planted an untracked dest-level `index.html`, so dropping or un-scoping the find stayed green.

## Fix

- After `checkout -B`, `git clean -fd -- docs` so a retry starts from origin's tree. Scoped to `docs/` so G1 debris at the repo root stays untracked.
- Autoindex staging is no longer a site-wide find. Stage `docs/<touched>/` (already), `docs/<channel>/index.html` for each touched channel, plus already-tracked dest/channel autoindexes `gen_landing` rewrote (`git ls-files`). A leftover dest that is not in `touched` and was not on `origin/main` cannot enter the pathspec.

`PUBLISH_STAGE` stage/promote/discard is unchanged: clean runs before those arms; tracked `docs/staging/` survives.

## Tests (`tests/shell/publish_pkg_repo_spec.sh`)

- untracked `docs/nightly/ce-2.8/index.html` + `FAKE_TOUCHED=edge/ce-2.8` — ADVANCE; leftover not in the commit; not tracked; G1 debris/README still uncommitted
- same leftover + `docs/nightly/ce-2.8/marker.pkg` — neither file in the commit
- existing tracked `docs/edge/index.html` rewrite from stub `gen_landing` — still staged
- existing G1 example unchanged

Local: `shellspec --shell /usr/bin/dash tests/shell/publish_pkg_repo_spec.sh` — 60 examples, 0 failures.

Fixes #2407
Made-with: Grok

🤖 Generated by Grok and posted on behalf of @BBcan177.