### PR TITLE
ci(nightly): require dep_artifacts to cover extra_pkgs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -322,6 +322,16 @@ jobs:
               )"
             done
           fi
+          DEP_COPIED=0
+          for RESULT_PKG in result/*.pkg; do
+            [ -f "$RESULT_PKG" ] || continue
+            [ "$(basename "$RESULT_PKG")" = "$PKG_NAME" ] && continue
+            DEP_COPIED=$((DEP_COPIED + 1))
+          done
+          if [ "$DEP_COPIED" -ne "$ORIGIN_COUNT" ]; then
+            echo "::error::dep .pkg count ($DEP_COPIED) != extra_pkgs ($ORIGIN_COUNT)"
+            exit 1
+          fi
 
           jq -n \
             --argjson matrix_row "$MATRIX_ROW" \

--- a/scripts/nightly_provenance.py
+++ b/scripts/nightly_provenance.py
@@ -229,6 +229,12 @@ def build_handoff(
             leg_abi=f"FreeBSD:{major}:*",
             canonical_name=artifact["name"],
         )
+        # issue #2405: empty extra_pkgs still requires dep_artifacts == []
+        expected_deps = len(row.get("extra_pkgs") or [])
+        if len(dep_artifacts) != expected_deps:
+            raise ProvenanceError(
+                f"dep_artifacts count must match extra_pkgs (got {len(dep_artifacts)}, expected {expected_deps})"
+            )
         seen_majors.add(major)
         builds.append({"matrix_row": row, "record": record, "artifact": artifact, "dep_artifacts": dep_artifacts})
     if seen_majors != set(expected_rows):

--- a/tests/test_nightly_handoff.py
+++ b/tests/test_nightly_handoff.py
@@ -110,14 +110,16 @@ def test_handoff_rejects_version_for_different_source() -> None:
 
 
 def test_handoff_carries_one_dep_artifact_sorted() -> None:
-    result = _result()
+    row = _row()
+    row["extra_pkgs"] = ["textproc/py-charset-normalizer"]
+    result = _result(row)
     dep = {
         "abi": "FreeBSD:15:*",
         "name": "py311-charset-normalizer-3.4.0.pkg",
         "sha256": sha256(b"dep").hexdigest(),
     }
     result["dep_artifacts"] = [dep]
-    handoff = _call_handoff([result])
+    handoff = _call_handoff([result], build_rows=[row])
     assert handoff["builds"][0]["dep_artifacts"] == [dep]
 
 
@@ -135,9 +137,98 @@ def test_handoff_rejects_result_with_extra_unknown_field() -> None:
         _call_handoff([result])
 
 
+CHARSET_ORIGIN = "textproc/py-charset-normalizer"
+CHARSET_PKG = "py311-charset-normalizer-3.4.0.pkg"
+
+
+def _plus_row() -> dict[str, object]:
+    return {
+        "pfsense_version": "26.03",
+        "channel": "Plus",
+        "freebsd_version": "16.0-RELEASE",
+        "freebsd_major": "16",
+        "php_version": "8.3",
+        "py_flavor": "py311",
+        "variant": "Plus",
+        "status": "GA",
+        "extra_pkgs": [],
+    }
+
+
+def _charset_dep(*, abi: str = "FreeBSD:15:*") -> dict[str, str]:
+    return {
+        "abi": abi,
+        "name": CHARSET_PKG,
+        "sha256": sha256(b"dep").hexdigest(),
+    }
+
+
+def test_handoff_rejects_empty_dep_artifacts_when_extra_pkgs_declared() -> None:
+    """issue #2405: extra_pkgs=[charset] with dep_artifacts=[] must fail-close."""
+    row = _row()
+    row["extra_pkgs"] = [CHARSET_ORIGIN]
+    result = _result(row)
+    assert result["dep_artifacts"] == []
+    with pytest.raises(np.ProvenanceError, match="extra_pkgs"):
+        _call_handoff([result], build_rows=[row])
+
+
+def test_handoff_accepts_one_dep_artifact_for_declared_charset_extra() -> None:
+    """issue #2405: declared charset extra_pkgs with matching dep .pkg is accepted."""
+    row = _row()
+    row["extra_pkgs"] = [CHARSET_ORIGIN]
+    result = _result(row)
+    result["dep_artifacts"] = [_charset_dep()]
+    handoff = _call_handoff([result], build_rows=[row])
+    assert handoff["builds"][0]["dep_artifacts"] == [_charset_dep()]
+
+
+def test_handoff_rejects_undeclared_dep_artifact_when_extra_pkgs_empty() -> None:
+    """issue #2405: extra_pkgs=[] still requires dep_artifacts == []."""
+    row = _row()
+    assert row["extra_pkgs"] == []
+    result = _result(row)
+    result["dep_artifacts"] = [_charset_dep()]
+    with pytest.raises(np.ProvenanceError, match="extra_pkgs"):
+        _call_handoff([result], build_rows=[row])
+
+
+def test_handoff_rejects_extra_pkgs_length_two_with_one_dep_artifact() -> None:
+    """issue #2405: two origins / one .pkg (overwrite) is a count mismatch."""
+    row = _row()
+    row["extra_pkgs"] = ["net/py-foo", CHARSET_ORIGIN]
+    result = _result(row)
+    result["dep_artifacts"] = [_charset_dep()]
+    with pytest.raises(np.ProvenanceError, match="extra_pkgs"):
+        _call_handoff([result], build_rows=[row])
+
+
+def test_handoff_accepts_two_legs_only_ce_declares_charset() -> None:
+    """issue #2405: CE carries charset extra; Plus extra_pkgs=[] stays empty."""
+    ce_row = _row()
+    ce_row["extra_pkgs"] = [CHARSET_ORIGIN]
+    plus_row = _plus_row()
+    ce_result = _result(ce_row)
+    ce_result["dep_artifacts"] = [_charset_dep()]
+    plus_result = _result(plus_row)
+    assert plus_result["dep_artifacts"] == []
+
+    handoff = _call_handoff(
+        [ce_result, plus_result],
+        build_rows=[ce_row, plus_row],
+        route_rows=[ce_row, plus_row],
+    )
+    by_major = {str(build["matrix_row"]["freebsd_major"]): build for build in handoff["builds"]}
+    assert by_major["15"]["dep_artifacts"] == [_charset_dep()]
+    assert by_major["16"]["dep_artifacts"] == []
+    assert by_major["15"]["matrix_row"]["extra_pkgs"] == [CHARSET_ORIGIN]
+    assert by_major["16"]["matrix_row"]["extra_pkgs"] == []
+
+
 def test_handoff_accepts_same_dep_name_across_different_legs() -> None:
     row15 = _row()
-    row16 = {**_row(), "freebsd_major": "16", "freebsd_version": "16.0-RELEASE"}
+    row15["extra_pkgs"] = [CHARSET_ORIGIN]
+    row16 = {**_row(), "freebsd_major": "16", "freebsd_version": "16.0-RELEASE", "extra_pkgs": [CHARSET_ORIGIN]}
     result15 = _result(row15)
     result16 = _result(row16)
     dep_name = "py311-charset-normalizer-3.4.0.pkg"

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -158,6 +158,37 @@ def test_build_leg_ports_ref_pin_rejects_moving_branch() -> None:
         _assert_build_leg_pins_prepare_sha(mutated)
 
 
+_ORIGIN_COUNT_COMPARE = 'if [ "$DEP_COPIED" -ne "$ORIGIN_COUNT" ]; then'
+_DEP_PKG_GLOB = 'for DEP_PKG in "$DEP_PKG_DIR"/*.pkg;'
+
+
+def _assert_build_step_compares_dep_pkg_count(step: str) -> None:
+    """issue #2405: after the glob, ORIGIN_COUNT == copied dep *.pkg count."""
+    assert _DEP_PKG_GLOB in step
+    assert _ORIGIN_COUNT_COMPARE in step
+    assert step.index(_DEP_PKG_GLOB) < step.index(_ORIGIN_COUNT_COMPARE)
+    compare_tail = step[step.index(_ORIGIN_COUNT_COMPARE) :]
+    assert 'echo "::error::' in compare_tail
+    assert "exit 1" in compare_tail
+
+
+def test_build_step_compares_origin_count_to_copied_dep_pkgs() -> None:
+    """issue #2405: BUILD step compares ORIGIN_COUNT to copied dep *.pkg files."""
+    step = _build_and_verify_step(WORKFLOW.read_text(encoding="utf-8"))
+    _assert_build_step_compares_dep_pkg_count(step)
+    assert "result/*.pkg" in step
+
+
+def test_dropping_origin_count_compare_leaves_glob_and_goes_red() -> None:
+    """issue #2405: deleting the ORIGIN_COUNT compare, leaving the glob, is RED."""
+    step = _build_and_verify_step(WORKFLOW.read_text(encoding="utf-8"))
+    _assert_build_step_compares_dep_pkg_count(step)
+    mutated = step.replace(_ORIGIN_COUNT_COMPARE, "", 1)
+    assert _DEP_PKG_GLOB in mutated
+    with pytest.raises(AssertionError):
+        _assert_build_step_compares_dep_pkg_count(mutated)
+
+
 def test_build_step_builds_and_hands_off_dependency_packages() -> None:
     """issue #2146 S1: the BUILD leg also builds this leg's extra_pkgs dep
     .pkgs (issue #1806), with NO tagged-style rename, and folds them into

--- a/tests/test_publish_nightly.py
+++ b/tests/test_publish_nightly.py
@@ -229,11 +229,27 @@ def _wrap_dependency_pkg(
 # --------------------------------------------------------------------------- #
 
 
+_CHARSET_DEP_SPEC: tuple[str, str] = ("py311-charset-normalizer", "3.4.0")
+_CHARSET_ORIGIN = "textproc/py-charset-normalizer"
+
+
 @dataclass(frozen=True)
 class _LegSpec:
     row: dict[str, object]
-    dep_specs: Sequence[tuple[str, str]] = ()
+    # None = derive from row extra_pkgs (issue #2405: count must match).
+    dep_specs: Sequence[tuple[str, str]] | None = None
     source_date_epoch: int = _EPOCH
+
+
+def _resolved_dep_specs(spec: _LegSpec) -> Sequence[tuple[str, str]]:
+    if spec.dep_specs is not None:
+        return spec.dep_specs
+    extras = list(spec.row.get("extra_pkgs") or [])
+    if extras == [_CHARSET_ORIGIN]:
+        return (_CHARSET_DEP_SPEC,)
+    if extras:
+        raise AssertionError(f"fixture has no default dep for extra_pkgs={extras!r}")
+    return ()
 
 
 def _make_record(snapshot: _Snapshot, row: dict[str, object], epoch: int = _EPOCH) -> dict[str, object]:
@@ -257,7 +273,7 @@ def _build_leg_result(snapshot: Any, spec: _LegSpec, *, assets_root: Path) -> di
     canonical_name = f"{_ENGINE.pfb_pkg.CANONICAL_EMITTED_IDENTITY}-{snapshot.pkg_version}.pkg"
     _path, digest = _wrap_canonical_pkg(legdir, record, local_name=canonical_name)
     dep_artifacts = []
-    for name, version in spec.dep_specs:
+    for name, version in _resolved_dep_specs(spec):
         dep_name = f"{name}-{version}.pkg"
         _dep_path, dep_digest = _wrap_dependency_pkg(
             legdir, name=name, version=version, abi=f"FreeBSD:{major}:*", local_name=dep_name
@@ -516,7 +532,7 @@ class StaleTests(_TempDirTestCase):
 
 # --------------------------------------------------------------------------- #
 # T5 — retention: keep+1 canonical generations published sequentially, oldest
-# evicted, a dependency introduced on the FIRST (evicted) generation survives.
+# evicted; the charset extra (declared on every CE row, issue #2405) survives.
 # --------------------------------------------------------------------------- #
 
 
@@ -531,11 +547,10 @@ class RetentionTests(_TempDirTestCase):
             snapshot = _snapshot(build_date=date(2026, 8, 1 + seq))
             if seq == 0:
                 first_version = snapshot.pkg_version
-            dep_specs = [("py311-charset-normalizer", "3.4.0")] if seq == 0 else ()
             results_dir = self.new_results_dir()
             handoff = _build_handoff(
                 snapshot,
-                legs=[_LegSpec(row=ROW_CE15, dep_specs=dep_specs)],
+                legs=[_LegSpec(row=ROW_CE15)],
                 route_rows=[ROW_CE15],
                 assets_root=results_dir,
             )

--- a/tests/test_publish_nightly.py
+++ b/tests/test_publish_nightly.py
@@ -244,7 +244,8 @@ class _LegSpec:
 def _resolved_dep_specs(spec: _LegSpec) -> Sequence[tuple[str, str]]:
     if spec.dep_specs is not None:
         return spec.dep_specs
-    extras = list(spec.row.get("extra_pkgs") or [])
+    raw_extras = spec.row.get("extra_pkgs") or []
+    extras = list(raw_extras) if isinstance(raw_extras, (list, tuple)) else []
     if extras == [_CHARSET_ORIGIN]:
         return (_CHARSET_DEP_SPEC,)
     if extras:


### PR DESCRIPTION
`build_handoff` required the `dep_artifacts` key (#2146 S1) but not a payload that covers that row's `extra_pkgs`. A CE 2.8 handoff with `extra_pkgs=["textproc/py-charset-normalizer"]` and `dep_artifacts: []` was valid; `publish_nightly` then had nothing to copy.

The BUILD glob could also produce that empty list without failing: two origins that emit the same filename overwrite; a successful builder that writes no `.pkg` still uploaded `result/result.json`.

This PR fail-closes both holes:

- `build_handoff` rejects `len(dep_artifacts) != len(extra_pkgs or [])`. Empty `extra_pkgs` still requires `dep_artifacts == []`.
- Nightly BUILD step: after the glob, `ORIGIN_COUNT` must equal the number of `*.pkg` files copied into `result/` (excluding the canonical). Mismatch → `::error::` and exit 1.
- Workflow contract pins the `DEP_COPIED` vs `ORIGIN_COUNT` compare. Dropping that line, leaving the glob, is RED.

Does not fold #2190 `NIGHTLY_SOURCE_REF` or #2281 first publish.

Fixes #2405
Made-with: Grok

🤖 Generated by Grok and posted on behalf of @BBcan177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly builds now detect missing, undeclared, mismatched, or cross-build dependency packages and fail with a clear error.
  * Dependency packages are validated against the configured package list before build handoff.
  * Declared dependencies are preserved correctly during nightly artifact retention.

* **Tests**
  * Added coverage for valid and invalid dependency-package scenarios across supported build variants.
  * Added workflow checks to ensure dependency counts are compared during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->