### PR TITLE
chore: spend CodeRabbit slots on the first real look

### DIFF
--- a/.agents/policy/landing.md
+++ b/.agents/policy/landing.md
@@ -61,6 +61,7 @@ Judge availability per-PR with **10-minute acknowledgement window** anchored on 
 
 - **ACK** (any CodeRabbit message) → **quota fast-path first**: if ONLY content is rate-limit notice (no review content) whose own "Next review available in" time is **> 5 minutes**, drop CodeRabbit immediately — no finished-wait; surface skip. Notice quoting ≤ 5 minutes, or any real review content beside it, → wait for finished review.
 - **NOACK** → nudge **once** (`@coderabbitai review` as top-level comment), then re-run ack wait with fresh 10-minute window anchored on *now* (`--since`). ACK → proceed as above; still silent → CodeRabbit unavailable; adversarial review carry review step. Never second nudge.
+- **Spend quota on the first real look.** `.coderabbit.yaml` auto-pauses incremental reviews after two reviewed commits. After a finished review (not a quota notice), do **not** `@coderabbitai review` again for format-only, comment-only, or mechanical review-fix pushes — those commits are why Fair Usage tripped during the Aug 15 landing loop. Nudge again only when a later commit changes product behaviour, and never while the latest CodeRabbit comment is a quota notice whose wait is **> 5 minutes**.
 
 Waiting on finished review (`--until finished`; handle matching case-insensitive and anchored — never append `[bot]` yourself):
 
@@ -68,7 +69,7 @@ Waiting on finished review (`--until finished`; handle matching case-insensitive
 - **QUOTA `<mins>`** — reviewer did not review, is rate-limited. **5-minute rule**: `mins > 5` (or unparsable) → drop handle and continue; `mins ≤ 5` → wait ~5 minutes (self-exiting background sleep, never foreground), nudge once, re-arm in finished-only mode with `--since` now; ANY further problem on nudged wait → give up on CodeRabbit — never block on it twice. Before acting, eyeball PR for posted content (stale notice can sit beside completed review — content wins). Always surface skipped reviewer; skipped bot never reported as "PR clean".
 - **NOTPRESENT** — zero engagement within presence window (~5 min): handle not reviewing this PR; skip without blocking (not failure).
 - **DECLINE** (base isn't default branch) — post one comment asking for full review (`@coderabbitai trigger full review and tell me when you are finished`), re-arm **finished-only** with `--since` now (never re-trigger on repeat decline).
-- **PAUSE** (branch too active) — post `@coderabbitai resume` once, re-arm finished-only.
+- **PAUSE** (branch too active) — if the latest commits are format-only or mechanical review-fixes, leave paused (same spend rule as ACK). If product behaviour changed, post `@coderabbitai resume` once, re-arm finished-only.
 - **TIMEOUT** — first check for **silent pause** (walkthrough stuck with no terminal result): treat as PAUSE. Otherwise report and ask: keep waiting or proceed.
 - CodeRabbit acked but never finished → proceed on adversarial review, note timeout (nudge is no-ack only); late review folds in before merge gate.
 - Bot's wording drifts — diagnostics show finished/declined review the matcher missed: read comment body and adjust patterns instead of waiting out timeout.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,14 +1,57 @@
-# CodeRabbit configuration. Keep automated review focused on maintained code,
-# tests, and tooling; documentation/history and copied third-party content do
-# not produce actionable findings here.
+# CodeRabbit configuration.
+#
+# Reviews are beneficial and stay advisory (they never gate merge). Each
+# automatic incremental review still spends one Fair Usage slot, so keep
+# auto-review on the first look plus one follow-up, then pause. Nudge with
+# `@coderabbitai review` only when product behaviour changed after that.
+# See .agents/policy/landing.md "CodeRabbit availability".
 reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    # Default is 5. Format-only / review-fix pushes on an active PR were
+    # burning the hourly allowance before the next product PR opened.
+    auto_pause_after_reviewed_commits: 2
+    ignore_title_keywords:
+      - "WIP"
+      - "[skip review]"
+    labels:
+      - "!WIP"
+
   path_filters:
     # Documentation and historical artifacts.
     - "!**/*.md"
     - "!docs/**"
     - "!legacy/**"
-    # Vendored agent content and bundled web dependencies.
-    - "!.agents/skills/**"
+    # Agent policy and vendored content.
+    - "!.agents/**"
     - "!.claude/skills/**"
     - "!plugins/**"
     - "!src/usr/local/www/pfblockerng/vendor/**"
+
+  path_instructions:
+    - path: ".github/workflows/**"
+      instructions: >-
+        Fail closed on missing package artifacts. Upload and download
+        artifact actions must share one major. Do not invent undeclared
+        workflow_call inputs. Nightly BUILD must clone ports at the
+        prepare SHA, not PORTS_REF.
+    - path: "scripts/publish*.py"
+      instructions: >-
+        Destination folder is not pfb_build_record.channel after
+        containment fan-out: record.channel stays the tag primary.
+        extra_pkgs attach and evict by ROUTE row, not ABI alone.
+        Nightly destinations never mix with tagged dests.
+    - path: "scripts/catalogue_assembly.py"
+      instructions: >-
+        Backfill copies slower tagged channels onto faster dests before
+        prune. Nightly is neither a source nor a dest. Undeclared extra
+        .pkgs on a dest this run targets must be unlinked before
+        regenerate.
+    - path: "tests/**"
+      instructions: >-
+        A negative assertion needs a fixture that can fail it. Do not
+        treat ABI-only dest isolation as extra_pkgs row-scope coverage.
+        Do not monkeypatch the production reader a write_site date pin
+        is supposed to exercise.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -53,5 +53,5 @@ reviews:
       instructions: >-
         A negative assertion needs a fixture that can fail it. Do not
         treat ABI-only dest isolation as extra_pkgs row-scope coverage.
-        Do not monkeypatch the production reader a write_site date pin
-        is supposed to exercise.
+        A write_site date pin must call production read_compact_manifest
+        on a real compact-manifest fixture. Do not monkeypatch that reader.


### PR DESCRIPTION
CodeRabbit reviews stay beneficial and advisory. The Aug 15 landing loop burned Fair Usage on incremental reviews of ruff-format and review-fix pushes, so later product PRs (#2407) only got a quota notice.

- `.coderabbit.yaml`: `auto_pause_after_reviewed_commits: 2`, skip `WIP` titles/labels
- path instructions for workflows, publish, catalogue assembly, and tests
- landing.md: after a finished review, do not `@coderabbitai review` again for format-only / mechanical fix commits

Does not disable auto-review. `@coderabbitai review` still works when product behaviour changes.

Made-with: Grok

🤖 Generated by Grok and posted on behalf of @BBcan177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated code review configuration and coverage.
  * Added clearer review guidance for workflows, publishing, catalogue assembly, and tests.
  * Refined handling of work-in-progress and skipped reviews.
  * Added review labels and incremental review controls to streamline ongoing changes.
  * Broadened exclusions for non-relevant paths.
  * No user-facing product changes are included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->