### PR TITLE
publish: evict undeclared extras and pin same-major dest scope

### DIFF
--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -296,6 +296,33 @@ def _flavor_signature(manifest: dict) -> str:
     return ",".join(sorted(flavored))
 
 
+_PY_FLAVOR_ORIGIN = re.compile(r"^(py)(?:\d+)?-")
+
+
+def _origin_key(value: object) -> tuple[str, str] | None:
+    """(category, unflavored last) for a port origin. Same rule as publish_release."""
+    if not isinstance(value, str) or "/" not in value:
+        return None
+    category, last = value.rsplit("/", 1)
+    if not category or not last:
+        return None
+    stripped = _PY_FLAVOR_ORIGIN.sub("", last, count=1)
+    return (category, stripped or last)
+
+
+def _row_declares_origin(row: Mapping[str, object], origin: object) -> bool:
+    """True iff this matrix row lists ``origin`` in extra_pkgs (issue #2403)."""
+    extras = row.get("extra_pkgs")
+    if not isinstance(extras, list):
+        return False
+    if origin in extras:
+        return True
+    key = _origin_key(origin)
+    if key is None:
+        return False
+    return any(_origin_key(extra) == key for extra in extras)
+
+
 def _pkg_matches_abi(manifest: dict, row_abi: str) -> bool:
     """True if a pre-supplied package's manifest ABI belongs to ``row_abi``'s
     FreeBSD major (OS+major only — the CPU/arch segment is never compared).
@@ -1068,14 +1095,17 @@ def build_repo_matrix(
       source when ``build_nightly`` is True, regardless of ``release_pkgs``.
       When ``None`` (the default), the existing build-from-source path is used unchanged.
 
-    ``dep_pkgs`` (optional, issue #1806) — pre-built dependency .pkg files (e.g.
-      py311-charset-normalizer, built by build-dep-pkg-portable.py) folded into BOTH
-      the release AND nightly catalogs of every build-role matrix entry whose ABI
-      matches (OS+major; see ``_pkg_matches_abi`` — a NO_ARCH dep's abi is CPU-
-      wildcarded). Folded AFTER retention (``retain_by_channel`` / ``_retain_newest``)
-      — NEVER before, or a dep would compete with real releases/nightlies for a
-      retention slot. Route-only (frozen EOL) entries never receive a dep pkg. A
-      dep pkg whose ABI matches no catalog it actually landed in is a hard
+    ``dep_pkgs`` (optional, issue #1806 / #2403) — pre-built dependency .pkg files
+      (e.g. py311-charset-normalizer, built by build-dep-pkg-portable.py) folded
+      into BOTH the release AND nightly catalogs of every build-role matrix entry
+      whose ABI matches (OS+major; see ``_pkg_matches_abi`` — a NO_ARCH dep's abi
+      is CPU-wildcarded) AND whose ``extra_pkgs`` declares the dep's origin (same
+      ``_row_declares_origin`` rule as ``publish_release`` / ``publish_nightly`` —
+      same-major ABI is not enough). Folded AFTER retention
+      (``retain_by_channel`` / ``_retain_newest``) — NEVER before, or a dep would
+      compete with real releases/nightlies for a retention slot. Route-only
+      (frozen EOL) entries never receive a dep pkg. A dep pkg that ABI-matches
+      and is declared by no catalog it actually landed in is a hard
       ``BuildRepoError`` (fail loud, never a silent drop) — matched is tracked only
       at the point a dep is folded into an EMITTED catalog, never merely because its
       ABI matched a row (issue #1806 gate-A finding: a matched-but-unemitted dep must
@@ -1179,7 +1209,9 @@ def build_repo_matrix(
             # in an emitted catalog (below), never merely because it matched this row —
             # marking it matched here unconditionally would let a matched-but-never-emitted
             # dep escape the end-of-run unmatched check (issue #1806 gate-A finding).
-            dep_for_abi = [p for p, m in dep_entries if _pkg_matches_abi(m, abi)]
+            dep_for_abi = [
+                p for p, m in dep_entries if _pkg_matches_abi(m, abi) and _row_declares_origin(entry, m.get("origin"))
+            ]
 
             if release_pkgs is not None:
                 # --- consume mode: serve release/<varver>/ from caller-supplied pre-built .pkg ---

--- a/scripts/publish_nightly.py
+++ b/scripts/publish_nightly.py
@@ -410,6 +410,8 @@ def publish(
         asset_map = pr._asset_map(target)
         dest_dir = site_root / _CHANNEL / varver
         changed = pr._drop_assets(dest_dir, asset_map)
+        if pr._evict_undeclared_deps(dest_dir, engine=engine, row=target.row):
+            changed = True
         if not changed and not pr._catalogue_descriptor_complete(dest_dir, engine):
             changed = True
         for src in asset_map.values():

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -148,32 +148,40 @@ class _Target:
     dependencies: list[pc.VerifiedAsset] = field(default_factory=list)
 
 
-def _origin_stem(value: object) -> str | None:
-    """Last path component of an origin, with a py / pyNNN flavor prefix stripped.
+def _origin_key(value: object) -> tuple[str, str] | None:
+    """(category, unflavored last) for a port origin.
 
     extra_pkgs lists port origins (textproc/py-charset-normalizer). Some
     manifests and test fixtures use the flavored package origin
     (textproc/py311-charset-normalizer). Those name the same extra.
+    Category is part of the identity: www/py-foo is not textproc/py-foo
+    (issue #2403).
     """
     if not isinstance(value, str) or "/" not in value:
         return None
-    last = value.rsplit("/", 1)[-1]
+    category, last = value.rsplit("/", 1)
+    if not category or not last:
+        return None
     stripped = _PY_FLAVOR_ORIGIN.sub("", last, count=1)
-    return stripped or last
+    return (category, stripped or last)
+
+
+def _row_declares_origin(row: Mapping[str, object], origin: object) -> bool:
+    """True iff this ROUTE/BUILD row lists ``origin`` in extra_pkgs."""
+    extras = row.get("extra_pkgs")
+    if not isinstance(extras, list):
+        return False
+    if origin in extras:
+        return True
+    key = _origin_key(origin)
+    if key is None:
+        return False
+    return any(_origin_key(extra) == key for extra in extras)
 
 
 def _row_declares_dep(row: Mapping[str, object], dep: pc.VerifiedAsset) -> bool:
     """True iff this ROUTE/BUILD row lists the dependency's origin in extra_pkgs."""
-    extras = row.get("extra_pkgs")
-    if not isinstance(extras, list):
-        return False
-    origin = dep.manifest.get("origin")
-    if origin in extras:
-        return True
-    stem = _origin_stem(origin)
-    if stem is None:
-        return False
-    return any(_origin_stem(extra) == stem for extra in extras)
+    return _row_declares_origin(row, dep.manifest.get("origin"))
 
 
 def _build_targets(engine: pc.Engine, run_result: pc.RunResult) -> dict[str, _Target]:
@@ -200,8 +208,8 @@ def _build_targets(engine: pc.Engine, run_result: pc.RunResult) -> dict[str, _Ta
         ]
         if not matched:
             raise PublishReleaseError(
-                f"dependency asset {dep.declared_name!r} ABI-matches no varver targeted "
-                "by this run's own canonical assets"
+                f"dependency asset {dep.declared_name!r} matches no varver targeted "
+                "by this run's own canonical assets (ABI + extra_pkgs declaration)"
             )
         for varver in matched:
             targets[varver].dependencies.append(dep)
@@ -230,6 +238,32 @@ def _files_identical(a: Path, b: Path) -> bool:
     if a.stat().st_size != b.stat().st_size:
         return False
     return a.read_bytes() == b.read_bytes()
+
+
+def _evict_undeclared_deps(dest_dir: Path, *, engine: pc.Engine, row: Mapping[str, object]) -> bool:
+    """Unlink non-catalog, non-canonical .pkg files this dest row does not declare.
+
+    issue #2402: prune_retained never touches dependency .pkg files, so a stray
+    extra already on an undeclaring dest survives attach and is re-indexed.
+    Scoped to this dest directory only. A declared leftover is kept even when
+    this run did not re-attach it.
+    """
+    if not dest_dir.is_dir():
+        return False
+    brp = engine.build_repo_portable
+    pfb_pkg = engine.pfb_pkg
+    evicted = False
+    for path in sorted(dest_dir.glob("*.pkg")):
+        if not path.is_file() or path.name in brp._CATALOG_PKG_FILES:
+            continue
+        manifest = pfb_pkg.read_compact_manifest(path)
+        if manifest.get("name") == pfb_pkg.CANONICAL_EMITTED_IDENTITY:
+            continue
+        if _row_declares_origin(row, manifest.get("origin")):
+            continue
+        path.unlink()
+        evicted = True
+    return evicted
 
 
 def _drop_assets(dest_dir: Path, asset_map: Mapping[str, Path]) -> bool:
@@ -282,6 +316,8 @@ def publish(engine: pc.Engine, run_result: pc.RunResult, pkg_repo: str | Path) -
         for channel in intake.destinations:
             dest_dir = site_root / channel / varver
             changed = _drop_assets(dest_dir, asset_map)
+            if _evict_undeclared_deps(dest_dir, engine=engine, row=target.row):
+                changed = True
             if not changed and not _catalogue_descriptor_complete(dest_dir, engine):
                 changed = True
             # Heal historical holes before prune: copy every canonical version

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -4229,3 +4229,26 @@ def test_dep_pkgs_same_major_plus_empty_extra_pkgs_does_not_receive_ce_extra(tmp
     plus_names = _names_in(out / "release" / "plus-26.03" / "packagesite.pkg")
     assert "py311-charset-normalizer" in ce_names
     assert "py311-charset-normalizer" not in plus_names
+
+
+def test_dep_pkgs_category_mismatch_is_undeclared(tmp_path: Path) -> None:
+    """www/py-foo does not satisfy a textproc/py-foo extra_pkgs row."""
+    out = tmp_path / "site"
+    dep_pkg = tmp_path / "py311-charset-normalizer-3.4.4.pkg"
+    make_pkg(
+        dep_pkg,
+        name="py311-charset-normalizer",
+        version="3.4.4",
+        abi="FreeBSD:15:*",
+        extra={"origin": "www/py311-charset-normalizer"},
+    )
+    ce = {**_CE, "extra_pkgs": ["textproc/py-charset-normalizer"]}
+
+    with pytest.raises(brp.BuildRepoError, match="ABI matches no emitted catalog"):
+        brp.build_repo_matrix(
+            [ce],
+            out,
+            builder=_stub_builder,
+            build_nightly=False,
+            dep_pkgs=[dep_pkg],
+        )

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -3956,7 +3956,9 @@ def test_cli_dep_pkgs_lands_in_release_and_nightly_same_abi_train(
 
     out = tmp_path / "site"
     mfile = tmp_path / "matrix.json"
-    mfile.write_text(json.dumps({"versions": [_CE, _PLUS]}))
+    ce = {**_CE, "extra_pkgs": ["net/py-charset-normalizer"]}
+    plus = {**_PLUS, "extra_pkgs": []}
+    mfile.write_text(json.dumps({"versions": [ce, plus]}))
 
     # Before-state: nothing built yet.
     assert not out.exists()
@@ -3999,7 +4001,8 @@ def test_cli_dep_pkgs_flag_is_repeatable(tmp_path: Path, monkeypatch: pytest.Mon
 
     out = tmp_path / "site"
     mfile = tmp_path / "matrix.json"
-    mfile.write_text(json.dumps({"versions": [_CE]}))
+    ce = {**_CE, "extra_pkgs": ["net/py-charset-normalizer", "net/py-idna"]}
+    mfile.write_text(json.dumps({"versions": [ce]}))
 
     rc = brp.main(
         [
@@ -4072,7 +4075,7 @@ def test_dep_pkgs_fold_after_retention_stable_pin_survives(tmp_path: Path) -> No
     # The ACTUAL production fold point: dep_pkgs never enters retain_by_channel's
     # candidate pool — it folds in strictly AFTER, so the stable pin is untouched.
     brp.build_repo_matrix(
-        [_CE],
+        [{**_CE, "extra_pkgs": ["net/py-charset-normalizer"]}],
         out,
         builder=_stub_builder,
         build_nightly=False,
@@ -4132,7 +4135,7 @@ def test_dep_pkgs_matched_but_never_emitted_still_raises(tmp_path: Path) -> None
 
     with pytest.raises(brp.BuildRepoError, match="dep"):
         brp.build_repo_matrix(
-            [_CE],
+            [{**_CE, "extra_pkgs": ["net/py-charset-normalizer"]}],
             out,
             builder=_stub_builder,
             build_nightly=False,
@@ -4169,7 +4172,12 @@ def test_dep_pkgs_route_only_entry_never_folds_dep_shared_major_build_entry_does
     # so it shares its major with the build entry below) + a build entry that shares
     # that SAME major (hypothetical: a Plus edition also targeting major 15).
     ce_eol_on_15 = {**_CE_EOL, "freebsd_major": "15"}
-    plus_on_15 = {**_PLUS, "pfsense_version": "15.0", "freebsd_major": "15"}
+    plus_on_15 = {
+        **_PLUS,
+        "pfsense_version": "15.0",
+        "freebsd_major": "15",
+        "extra_pkgs": ["net/py-charset-normalizer"],
+    }
 
     brp.build_repo_matrix(
         [ce_eol_on_15, plus_on_15],
@@ -4189,3 +4197,35 @@ def test_dep_pkgs_route_only_entry_never_folds_dep_shared_major_build_entry_does
     assert {o["name"] for o in route_only_objs} == {"pfBlockerNG-testing"}, (
         "a route-only entry must never receive a dep pkg, even sharing a major with a build entry"
     )
+
+
+def test_dep_pkgs_same_major_plus_empty_extra_pkgs_does_not_receive_ce_extra(tmp_path: Path) -> None:
+    """issue #2403: --dep-pkgs is dest-scoped by extra_pkgs, not ABI alone.
+
+    CE extra_pkgs declares textproc/py-charset-normalizer; Plus on the same
+    freebsd_major leaves extra_pkgs=[]. The extra must land only on CE.
+    """
+    out = tmp_path / "site"
+    dep_pkg = tmp_path / "py311-charset-normalizer-3.4.4.pkg"
+    make_pkg(
+        dep_pkg,
+        name="py311-charset-normalizer",
+        version="3.4.4",
+        abi="FreeBSD:15:*",
+        extra={"origin": "textproc/py-charset-normalizer"},
+    )
+    ce = {**_CE, "extra_pkgs": ["textproc/py-charset-normalizer"]}
+    plus = {**_PLUS, "freebsd_major": "15", "extra_pkgs": []}
+
+    brp.build_repo_matrix(
+        [ce, plus],
+        out,
+        builder=_stub_builder,
+        build_nightly=False,
+        dep_pkgs=[dep_pkg],
+    )
+
+    ce_names = _names_in(out / "release" / "ce-2.8" / "packagesite.pkg")
+    plus_names = _names_in(out / "release" / "plus-26.03" / "packagesite.pkg")
+    assert "py311-charset-normalizer" in ce_names
+    assert "py311-charset-normalizer" not in plus_names

--- a/tests/test_issue2383_extra_pkgs_row_scope.py
+++ b/tests/test_issue2383_extra_pkgs_row_scope.py
@@ -1,12 +1,15 @@
-"""Issue #2383: extra_pkgs deps attach only to ROUTE rows that declare them.
+"""Issue #2383 / #2403: extra_pkgs deps attach only to ROUTE rows that declare them.
 
 Same-major ABI is not enough. A CE extra must not enter a Plus catalogue
-whose extra_pkgs is empty. These cases are hermetic (no network).
+whose extra_pkgs is empty. Category is part of the origin identity:
+www/py-foo must not satisfy textproc/py-foo. These cases are hermetic
+(no network). Twin dest tests own their extra_pkgs rows; this module
+must not mutate shared Plus fixtures at import.
 """
 
 from __future__ import annotations
 
-import importlib
+import inspect
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -19,27 +22,6 @@ for _p in (_SCRIPTS, _TESTS):
         sys.path.insert(0, str(_p))
 
 import publish_release as pr
-
-_TWIN_ORIGIN = "textproc/py-twin"
-
-
-def _declare_twin_on_plus_rows() -> None:
-    """Pre-#2383 twin tests create textproc/py311-twin deps against Plus rows
-    whose extra_pkgs is []. After row-scoping those deps match no target.
-    ROW_PLUS_07 is a shallow copy of ROW_PLUS_03, so they share the list."""
-    for modname in ("tests.test_publish_release", "test_publish_release"):
-        try:
-            mod = importlib.import_module(modname)
-        except ImportError:
-            continue
-        extras = getattr(mod, "ROW_PLUS_03", {}).get("extra_pkgs")
-        if not isinstance(extras, list):
-            continue
-        if _TWIN_ORIGIN not in extras:
-            extras.append(_TWIN_ORIGIN)
-
-
-_declare_twin_on_plus_rows()
 
 
 def _dep(origin: str) -> SimpleNamespace:
@@ -63,6 +45,26 @@ def test_row_declares_dep_accepts_py_flavor_package_origin() -> None:
     assert pr._row_declares_dep(row, _dep("textproc/py311-charset-normalizer")) is True
 
 
+def test_row_declares_dep_rejects_different_category() -> None:
+    """issue #2403: www/py-foo must not satisfy textproc/py-foo."""
+    row = {"extra_pkgs": ["textproc/py-charset-normalizer"]}
+    assert pr._row_declares_dep(row, _dep("www/py-charset-normalizer")) is False
+    assert pr._row_declares_dep(row, _dep("www/py311-charset-normalizer")) is False
+
+
+def test_row_declares_dep_rejects_non_py_last_component_other_category() -> None:
+    """A non-py last component in another category is not the extra."""
+    row = {"extra_pkgs": ["textproc/py-charset-normalizer"]}
+    assert pr._row_declares_dep(row, _dep("security/charset-normalizer")) is False
+
+
 def test_row_declares_dep_does_not_treat_abi_as_a_declaration() -> None:
     """Vacuity: a row with no extra_pkgs never declares, even for a real origin."""
     assert pr._row_declares_dep({"freebsd_major": "15"}, _dep("textproc/py-charset-normalizer")) is False
+
+
+def test_build_targets_match_requires_row_declares_dep() -> None:
+    """Drop _row_declares_dep from _build_targets must RED the same-major dest case."""
+    source = inspect.getsource(pr._build_targets)
+    assert "_row_declares_dep" in source
+    assert "and _row_declares_dep" in source or "and pr._row_declares_dep" in source

--- a/tests/test_issue2383_extra_pkgs_row_scope.py
+++ b/tests/test_issue2383_extra_pkgs_row_scope.py
@@ -64,7 +64,7 @@ def test_row_declares_dep_does_not_treat_abi_as_a_declaration() -> None:
 
 
 def test_build_targets_match_requires_row_declares_dep() -> None:
-    """Drop _row_declares_dep from _build_targets must RED the same-major dest case."""
+    """_build_targets must consult _row_declares_dep for dest extra attach."""
     source = inspect.getsource(pr._build_targets)
     assert "_row_declares_dep" in source
     assert "and _row_declares_dep" in source or "and pr._row_declares_dep" in source

--- a/tests/test_publish_nightly.py
+++ b/tests/test_publish_nightly.py
@@ -1203,7 +1203,7 @@ class SameMajorDestScopeTests(_TempDirTestCase):
 
     @_requires_engine
     def test_route_targets_continue_filter_required_for_same_major_plus(self) -> None:
-        """Drop the Nightly `_row_declares_dep` continue and this dest case REDS."""
+        """Nightly dest attach must skip a dest whose row does not declare the extra."""
         source = inspect.getsource(pn._route_targets)
         self.assertIn("_row_declares_dep", source)
         self.assertIn("continue", source)

--- a/tests/test_publish_nightly.py
+++ b/tests/test_publish_nightly.py
@@ -22,6 +22,7 @@ validation would otherwise refuse to construct them honestly.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import io
 import itertools
 import json
@@ -100,8 +101,10 @@ def _row(
 
 
 ROW_CE15 = _row(freebsd_major="15", pfsense_version="2.8", variant="CE", extra_pkgs=["textproc/py-charset-normalizer"])
+ROW_CE15_NO_EXTRA = _row(freebsd_major="15", pfsense_version="2.8", variant="CE")
 ROW_PLUS16_03 = _row(freebsd_major="16", pfsense_version="26.03", variant="Plus")
 ROW_PLUS16_07 = _row(freebsd_major="16", pfsense_version="26.07", variant="Plus")
+ROW_PLUS15_03 = _row(freebsd_major="15", pfsense_version="26.03", variant="Plus")
 ROW_ROUTE_ONLY_17 = _row(freebsd_major="17", pfsense_version="17.0", variant="CE", role="route-only")
 
 
@@ -1050,6 +1053,160 @@ class IdentityPostConditionTests(_TempDirTestCase):
         ):
             _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
         self.assertIn("multi-destination identity violation", str(ctx.exception))
+
+
+def _packagesite_names(catalogue_dir: Path) -> set[str]:
+    catalog = catalogue_dir / "packagesite.pkg"
+    data = _ENGINE.pfb_pkg.zstd_decompress(catalog.read_bytes())
+    with tarfile.open(fileobj=io.BytesIO(data)) as tf:
+        member = tf.extractfile("packagesite.yaml")
+        assert member is not None
+        raw = member.read().decode()
+    return {json.loads(line)["name"] for line in raw.splitlines() if line}
+
+
+_CHARSET_PKG = "py311-charset-normalizer-3.4.0.pkg"
+_CHARSET_NAME = "py311-charset-normalizer"
+
+
+class ExtraPkgsEvictionTests(_TempDirTestCase):
+    """issue #2402: Nightly dest leftovers are unlinked before regenerate."""
+
+    def _plant_charset(self, dest_dir: Path, *, major: str) -> None:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        _wrap_dependency_pkg(
+            dest_dir,
+            name=_CHARSET_NAME,
+            version="3.4.0",
+            abi=f"FreeBSD:{major}:*",
+            local_name=_CHARSET_PKG,
+        )
+
+    @_requires_engine
+    def test_stale_plus_extra_evicted_on_new_canonical(self) -> None:
+        first = _snapshot(build_date=date(2026, 8, 4))
+        results_1 = self.new_results_dir()
+        handoff_1 = _build_handoff(
+            first, legs=[_LegSpec(row=ROW_PLUS16_03)], route_rows=[ROW_PLUS16_03], assets_root=results_1
+        )
+        _run(handoff=handoff_1, results_dir=results_1, pkg_repo=self.pkg_repo)
+        dest = self.pkg_repo / "docs" / "nightly" / "plus-26.03"
+        self._plant_charset(dest, major="16")
+
+        second = _snapshot(build_date=date(2026, 8, 5))
+        results_2 = self.new_results_dir()
+        handoff_2 = _build_handoff(
+            second, legs=[_LegSpec(row=ROW_PLUS16_03)], route_rows=[ROW_PLUS16_03], assets_root=results_2
+        )
+        report = _run(handoff=handoff_2, results_dir=results_2, pkg_repo=self.pkg_repo)
+        self.assertFalse(report.noop)
+        self.assertFalse((dest / _CHARSET_PKG).exists())
+        self.assertTrue((dest / f"pfSense-pkg-pfBlockerNG-{second.pkg_version}.pkg").is_file())
+        self.assertNotIn(_CHARSET_NAME, _packagesite_names(dest))
+
+    @_requires_engine
+    def test_stale_plus_extra_evicted_on_exact_republish(self) -> None:
+        snapshot = _snapshot()
+        results_1 = self.new_results_dir()
+        handoff = _build_handoff(
+            snapshot, legs=[_LegSpec(row=ROW_PLUS16_03)], route_rows=[ROW_PLUS16_03], assets_root=results_1
+        )
+        first = _run(handoff=handoff, results_dir=results_1, pkg_repo=self.pkg_repo)
+        self.assertFalse(first.noop)
+        dest = self.pkg_repo / "docs" / "nightly" / "plus-26.03"
+        self._plant_charset(dest, major="16")
+
+        results_2 = self.new_results_dir()
+        handoff_2 = _build_handoff(
+            snapshot, legs=[_LegSpec(row=ROW_PLUS16_03)], route_rows=[ROW_PLUS16_03], assets_root=results_2
+        )
+        second = _run(handoff=handoff_2, results_dir=results_2, pkg_repo=self.pkg_repo)
+        self.assertFalse(second.noop)
+        self.assertFalse((dest / _CHARSET_PKG).exists())
+        self.assertNotIn(_CHARSET_NAME, _packagesite_names(dest))
+
+    @_requires_engine
+    def test_declared_ce_extra_kept_on_new_canonical(self) -> None:
+        first = _snapshot(build_date=date(2026, 8, 4))
+        results_1 = self.new_results_dir()
+        handoff_1 = _build_handoff(
+            first,
+            legs=[_LegSpec(row=ROW_CE15, dep_specs=[("py311-charset-normalizer", "3.4.0")])],
+            route_rows=[ROW_CE15],
+            assets_root=results_1,
+        )
+        _run(handoff=handoff_1, results_dir=results_1, pkg_repo=self.pkg_repo)
+        dest = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        self.assertTrue((dest / _CHARSET_PKG).is_file())
+
+        second = _snapshot(build_date=date(2026, 8, 5))
+        results_2 = self.new_results_dir()
+        handoff_2 = _build_handoff(second, legs=[_LegSpec(row=ROW_CE15)], route_rows=[ROW_CE15], assets_root=results_2)
+        _run(handoff=handoff_2, results_dir=results_2, pkg_repo=self.pkg_repo)
+        self.assertTrue((dest / _CHARSET_PKG).is_file())
+        self.assertIn(_CHARSET_NAME, _packagesite_names(dest))
+
+    @_requires_engine
+    def test_undeclared_ce_extra_evicted_when_row_drops_extra_pkgs(self) -> None:
+        first = _snapshot(build_date=date(2026, 8, 4))
+        results_1 = self.new_results_dir()
+        handoff_1 = _build_handoff(
+            first,
+            legs=[_LegSpec(row=ROW_CE15, dep_specs=[("py311-charset-normalizer", "3.4.0")])],
+            route_rows=[ROW_CE15],
+            assets_root=results_1,
+        )
+        _run(handoff=handoff_1, results_dir=results_1, pkg_repo=self.pkg_repo)
+        dest = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        self.assertTrue((dest / _CHARSET_PKG).is_file())
+
+        second = _snapshot(build_date=date(2026, 8, 5))
+        results_2 = self.new_results_dir()
+        handoff_2 = _build_handoff(
+            second, legs=[_LegSpec(row=ROW_CE15_NO_EXTRA)], route_rows=[ROW_CE15_NO_EXTRA], assets_root=results_2
+        )
+        _run(handoff=handoff_2, results_dir=results_2, pkg_repo=self.pkg_repo)
+        self.assertFalse((dest / _CHARSET_PKG).exists())
+        self.assertNotIn(_CHARSET_NAME, _packagesite_names(dest))
+
+
+class SameMajorDestScopeTests(_TempDirTestCase):
+    """issue #2403: one Nightly major fans to CE + Plus; extra follows extra_pkgs."""
+
+    @_requires_engine
+    def test_same_major_dep_not_published_to_row_with_empty_extra_pkgs(self) -> None:
+        snapshot = _snapshot()
+        results_dir = self.new_results_dir()
+        handoff = _build_handoff(
+            snapshot,
+            legs=[_LegSpec(row=ROW_CE15, dep_specs=[("py311-charset-normalizer", "3.4.0")])],
+            route_rows=[ROW_CE15, ROW_PLUS15_03],
+            assets_root=results_dir,
+        )
+        captured: dict[str, set[str]] = {}
+        orig = pr._drop_assets
+
+        def _spy(dest_dir: Path, asset_map: dict) -> bool:
+            captured[dest_dir.name] = set(asset_map)
+            return orig(dest_dir, asset_map)
+
+        with mock.patch.object(pr, "_drop_assets", side_effect=_spy):
+            _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+        self.assertIn(_CHARSET_PKG, captured["ce-2.8"])
+        self.assertNotIn(_CHARSET_PKG, captured["plus-26.03"])
+        docs = self.pkg_repo / "docs" / "nightly"
+        self.assertTrue((docs / "ce-2.8" / _CHARSET_PKG).is_file())
+        self.assertFalse((docs / "plus-26.03" / _CHARSET_PKG).exists())
+        self.assertIn(_CHARSET_NAME, _packagesite_names(docs / "ce-2.8"))
+        self.assertNotIn(_CHARSET_NAME, _packagesite_names(docs / "plus-26.03"))
+
+    @_requires_engine
+    def test_route_targets_continue_filter_required_for_same_major_plus(self) -> None:
+        """Drop the Nightly `_row_declares_dep` continue and this dest case REDS."""
+        source = inspect.getsource(pn._route_targets)
+        self.assertIn("_row_declares_dep", source)
+        self.assertIn("continue", source)
 
 
 if __name__ == "__main__":

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -90,6 +90,21 @@ ROW_PLUS_03: dict[str, object] = {
 
 ROW_PLUS_07: dict[str, object] = {**ROW_PLUS_03, "pfsense_version": "26.07"}
 
+# Twin dest tests declare textproc/py-twin themselves (issue #2403). Own lists —
+# never mutate ROW_PLUS_03["extra_pkgs"] at import.
+ROW_PLUS_03_TWIN: dict[str, object] = {**ROW_PLUS_03, "extra_pkgs": ["textproc/py-twin"]}
+ROW_PLUS_07_TWIN: dict[str, object] = {**ROW_PLUS_07, "extra_pkgs": ["textproc/py-twin"]}
+
+# Same-major dest scope (issue #2403): Plus shares CE's FreeBSD major, extra_pkgs=[].
+ROW_PLUS_SAME_MAJOR: dict[str, object] = {
+    **ROW_PLUS_03,
+    "freebsd_version": "15.0-RELEASE",
+    "freebsd_major": "15",
+    "extra_pkgs": [],
+}
+
+ROW_CE_NO_EXTRA: dict[str, object] = {**ROW_CE, "extra_pkgs": []}
+
 ROW_ROUTE_ONLY_17: dict[str, object] = {
     "pfsense_version": "17.0",
     "channel": "CE",
@@ -649,10 +664,10 @@ class TargetResolutionTests(_TempDirTestCase):
         (issue #2231)."""
         assets_dir = self.new_assets_dir()
         digests = _populate_assets_dir(
-            assets_dir, rows=(ROW_PLUS_03, ROW_PLUS_07), source_tag="v4.0.0.b1", include_dependency=False
+            assets_dir, rows=(ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN), source_tag="v4.0.0.b1", include_dependency=False
         )
         twin_digests: list[str] = []
-        for row, filler in ((ROW_PLUS_03, b"built-by-leg-one"), (ROW_PLUS_07, b"built-by-leg-two")):
+        for row, filler in ((ROW_PLUS_03_TWIN, b"built-by-leg-one"), (ROW_PLUS_07_TWIN, b"built-by-leg-two")):
             declared = _dependency_declared_name(name="py311-twin", version="1.0.0", row=row)
             _path, digest = _wrap_dependency_pkg(
                 assets_dir,
@@ -670,7 +685,7 @@ class TargetResolutionTests(_TempDirTestCase):
             _run(
                 pkg_repo=self.pkg_repo,
                 assets_dir=assets_dir,
-                rows=(ROW_PLUS_03, ROW_PLUS_07),
+                rows=(ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN),
                 tag="v4.0.0.b1",
             )
         self.assertIn("different bytes", str(ctx.exception))
@@ -685,9 +700,9 @@ class TargetResolutionTests(_TempDirTestCase):
         matching varver — never a conflict."""
         assets_dir = self.new_assets_dir()
         digests = _populate_assets_dir(
-            assets_dir, rows=(ROW_PLUS_03, ROW_PLUS_07), source_tag="v4.0.0.b1", include_dependency=False
+            assets_dir, rows=(ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN), source_tag="v4.0.0.b1", include_dependency=False
         )
-        for row in (ROW_PLUS_03, ROW_PLUS_07):
+        for row in (ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN):
             declared = _dependency_declared_name(name="py311-twin", version="1.0.0", row=row)
             _path, digest = _wrap_dependency_pkg(
                 assets_dir,
@@ -702,7 +717,7 @@ class TargetResolutionTests(_TempDirTestCase):
         report = _run(
             pkg_repo=self.pkg_repo,
             assets_dir=assets_dir,
-            rows=(ROW_PLUS_03, ROW_PLUS_07),
+            rows=(ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN),
             tag="v4.0.0.b1",
         )
         self.assertFalse(report.noop)
@@ -1234,6 +1249,204 @@ class MainCliTests(_TempDirTestCase):
             code = pr.main(argv)
         self.assertEqual(code, 1)
         self.assertIn("::error::", err.getvalue())
+
+
+def _packagesite_names(catalogue_dir: Path) -> set[str]:
+    """Manifest `name` of every member in the dest's packagesite.pkg."""
+    catalog = catalogue_dir / "packagesite.pkg"
+    data = _ENGINE.pfb_pkg.zstd_decompress(catalog.read_bytes())
+    with tarfile.open(fileobj=io.BytesIO(data)) as tf:
+        member = tf.extractfile("packagesite.yaml")
+        assert member is not None
+        raw = member.read().decode()
+    return {json.loads(line)["name"] for line in raw.splitlines() if line}
+
+
+_CHARSET_PKG = "py311-charset-normalizer-3.4.0.pkg"
+_CHARSET_NAME = "py311-charset-normalizer"
+
+
+class ExtraPkgsEvictionTests(_TempDirTestCase):
+    """issue #2402: undeclared dest leftovers are unlinked before regenerate."""
+
+    def _plant_charset(self, dest_dir: Path, *, major: str) -> None:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        _wrap_dependency_pkg(
+            dest_dir,
+            name=_CHARSET_NAME,
+            version="3.4.0",
+            abi=f"FreeBSD:{major}:*",
+            local_name=_CHARSET_PKG,
+        )
+
+    @_requires_engine
+    def test_stale_plus_extra_evicted_on_new_canonical(self) -> None:
+        assets_1 = self.new_assets_dir()
+        _populate_assets_dir(assets_1, rows=(ROW_PLUS_03,), source_tag="v4.0.0.b1", include_dependency=False)
+        _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=assets_1,
+            rows=(ROW_PLUS_03,),
+            tag="v4.0.0.b1",
+        )
+        dest = self.pkg_repo / "docs" / "edge" / "plus-26.03"
+        self._plant_charset(dest, major="16")
+        self.assertTrue((dest / _CHARSET_PKG).is_file())
+
+        assets_2 = self.new_assets_dir()
+        _populate_assets_dir(assets_2, rows=(ROW_PLUS_03,), source_tag="v4.0.0.b2", include_dependency=False)
+        report = _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=assets_2,
+            rows=(ROW_PLUS_03,),
+            tag="v4.0.0.b2",
+        )
+        self.assertFalse(report.noop)
+        self.assertFalse((dest / _CHARSET_PKG).exists())
+        self.assertTrue((dest / "pfSense-pkg-pfBlockerNG-4.0.0.b2.pkg").is_file())
+        self.assertNotIn(_CHARSET_NAME, _packagesite_names(dest))
+
+    @_requires_engine
+    def test_stale_plus_extra_evicted_on_exact_republish(self) -> None:
+        assets = self.new_assets_dir()
+        _populate_assets_dir(assets, rows=(ROW_PLUS_03,), source_tag="v4.0.0.b1", include_dependency=False)
+        first = _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=assets,
+            rows=(ROW_PLUS_03,),
+            tag="v4.0.0.b1",
+        )
+        self.assertFalse(first.noop)
+        dest = self.pkg_repo / "docs" / "edge" / "plus-26.03"
+        self._plant_charset(dest, major="16")
+
+        second_assets = self.new_assets_dir()
+        _populate_assets_dir(second_assets, rows=(ROW_PLUS_03,), source_tag="v4.0.0.b1", include_dependency=False)
+        second = _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=second_assets,
+            rows=(ROW_PLUS_03,),
+            tag="v4.0.0.b1",
+        )
+        self.assertFalse(second.noop)
+        self.assertFalse((dest / _CHARSET_PKG).exists())
+        self.assertNotIn(_CHARSET_NAME, _packagesite_names(dest))
+
+    @_requires_engine
+    def test_declared_ce_extra_kept_on_new_canonical(self) -> None:
+        assets_1 = self.new_assets_dir()
+        _populate_assets_dir(assets_1, rows=(ROW_CE,), source_tag="v4.0.0.b1")
+        _run(pkg_repo=self.pkg_repo, assets_dir=assets_1, rows=(ROW_CE,), tag="v4.0.0.b1")
+        dest = self.pkg_repo / "docs" / "edge" / "ce-2.8"
+        self.assertTrue((dest / _CHARSET_PKG).is_file())
+
+        assets_2 = self.new_assets_dir()
+        _populate_assets_dir(assets_2, rows=(ROW_CE,), source_tag="v4.0.0.b2", include_dependency=False)
+        _run(pkg_repo=self.pkg_repo, assets_dir=assets_2, rows=(ROW_CE,), tag="v4.0.0.b2")
+        self.assertTrue((dest / _CHARSET_PKG).is_file())
+        self.assertIn(_CHARSET_NAME, _packagesite_names(dest))
+
+    @_requires_engine
+    def test_undeclared_ce_extra_evicted_when_row_drops_extra_pkgs(self) -> None:
+        assets_1 = self.new_assets_dir()
+        _populate_assets_dir(assets_1, rows=(ROW_CE,), source_tag="v4.0.0.b1")
+        _run(pkg_repo=self.pkg_repo, assets_dir=assets_1, rows=(ROW_CE,), tag="v4.0.0.b1")
+        dest = self.pkg_repo / "docs" / "edge" / "ce-2.8"
+        self.assertTrue((dest / _CHARSET_PKG).is_file())
+
+        assets_2 = self.new_assets_dir()
+        _populate_assets_dir(assets_2, rows=(ROW_CE_NO_EXTRA,), source_tag="v4.0.0.b2", include_dependency=False)
+        _run(pkg_repo=self.pkg_repo, assets_dir=assets_2, rows=(ROW_CE_NO_EXTRA,), tag="v4.0.0.b2")
+        self.assertFalse((dest / _CHARSET_PKG).exists())
+        self.assertNotIn(_CHARSET_NAME, _packagesite_names(dest))
+
+    @_requires_engine
+    def test_untargeted_dest_extra_left_in_place(self) -> None:
+        assets = self.new_assets_dir()
+        _populate_assets_dir(assets, rows=(ROW_PLUS_03,), source_tag="v4.0.0.b1", include_dependency=False)
+        _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=assets,
+            rows=(ROW_PLUS_03,),
+            tag="v4.0.0.b1",
+        )
+        other = self.pkg_repo / "docs" / "testing" / "plus-26.03"
+        self._plant_charset(other, major="16")
+        second_assets = self.new_assets_dir()
+        _populate_assets_dir(second_assets, rows=(ROW_PLUS_03,), source_tag="v4.0.0.b2", include_dependency=False)
+        _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=second_assets,
+            rows=(ROW_PLUS_03,),
+            tag="v4.0.0.b2",
+        )
+        self.assertTrue((other / _CHARSET_PKG).is_file())
+
+
+class SameMajorDestScopeTests(_TempDirTestCase):
+    """issue #2403: same-major CE extra must not land on Plus extra_pkgs=[]."""
+
+    @_requires_engine
+    def test_same_major_dep_not_published_to_row_with_empty_extra_pkgs(self) -> None:
+        rows = (ROW_CE, ROW_PLUS_SAME_MAJOR)
+        assets = self.new_assets_dir()
+        _populate_assets_dir(assets, channel="stable", rows=rows, source_tag="v4.0.0")
+        captured: dict[str, set[str]] = {}
+        orig = pr._drop_assets
+
+        def _spy(dest_dir: Path, asset_map: dict) -> bool:
+            captured[f"{dest_dir.parent.name}/{dest_dir.name}"] = set(asset_map)
+            return orig(dest_dir, asset_map)
+
+        with mock.patch.object(pr, "_drop_assets", side_effect=_spy):
+            _run(
+                pkg_repo=self.pkg_repo,
+                assets_dir=assets,
+                rows=rows,
+                channel="stable",
+                tag="v4.0.0",
+                destinations='["stable", "testing", "edge"]',
+            )
+
+        extra = _CHARSET_PKG
+        for channel in ("stable", "testing", "edge"):
+            self.assertIn(extra, captured[f"{channel}/ce-2.8"], channel)
+            self.assertNotIn(extra, captured[f"{channel}/plus-26.03"], channel)
+            ce_dir = self.pkg_repo / "docs" / channel / "ce-2.8"
+            plus_dir = self.pkg_repo / "docs" / channel / "plus-26.03"
+            self.assertTrue((ce_dir / extra).is_file(), channel)
+            self.assertFalse((plus_dir / extra).exists(), channel)
+            self.assertIn(_CHARSET_NAME, _packagesite_names(ce_dir))
+            self.assertNotIn(_CHARSET_NAME, _packagesite_names(plus_dir))
+
+    @_requires_engine
+    def test_undeclared_twin_dep_against_empty_plus_extra_pkgs_rejected(self) -> None:
+        """No import-time mutation: Plus extra_pkgs=[] does not accept py311-twin."""
+        assets = self.new_assets_dir()
+        digests = _populate_assets_dir(
+            assets, rows=(ROW_PLUS_03, ROW_PLUS_07), source_tag="v4.0.0.b1", include_dependency=False
+        )
+        for row in (ROW_PLUS_03, ROW_PLUS_07):
+            declared = _dependency_declared_name(name="py311-twin", version="1.0.0", row=row)
+            _path, digest = _wrap_dependency_pkg(
+                assets,
+                name="py311-twin",
+                version="1.0.0",
+                abi="FreeBSD:16:*",
+                local_name=declared,
+            )
+            digests[declared] = digest
+        (assets / pr._DIGESTS_FILENAME).write_text(json.dumps(digests), encoding="utf-8")
+        with self.assertRaises(pr.PublishReleaseError) as ctx:
+            _run(
+                pkg_repo=self.pkg_repo,
+                assets_dir=assets,
+                rows=(ROW_PLUS_03, ROW_PLUS_07),
+                tag="v4.0.0.b1",
+            )
+        self.assertIn("matches no varver targeted", str(ctx.exception))
+        for varver in ("plus-26.03", "plus-26.07"):
+            self.assertFalse((self.pkg_repo / "docs/edge" / varver / "py311-twin-1.0.0.pkg").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
After attach and before `regenerate_catalogue`, tagged and Nightly publish now unlink non-catalog, non-canonical `.pkg` files whose origin the dest ROUTE row does not declare. `prune_retained` stays canonical-only. An eviction marks the dest dirty so an exact republish cannot NOOP over a stale extra.

Same-major dest scope is now on devel, not ABI-isolated 15-vs-16 coverage:
- `_origin_key` compares `(category, unflavored last)` — `www/py-foo` does not satisfy `textproc/py-foo`
- Twin dest tests own `ROW_PLUS_*_TWIN` rows; import-time mutation of shared Plus `extra_pkgs` is gone
- `build_repo_matrix --dep-pkgs` uses the same `_row_declares_origin` rule
- Dropping `_row_declares_dep` from `_build_targets` REDS the new dest case (inspect canary + same-major asset_map spy)

Does not reopen #2383. Does not fold #2398 heal.

Fixes #2402
Fixes #2403
Made-with: Grok

🤖 Generated by Grok and posted on behalf of @BBcan177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency packages are routed only to destinations that explicitly declare them.
  * Improved matching prevents similarly named packages in different categories from being treated as equivalent.
  * Undeclared or stale dependencies are removed during nightly and release publishing while preserving declared packages and catalog files.
  * Dependency mismatch errors now include clearer ABI and package requirement details.

* **Tests**
  * Expanded coverage for dependency routing, cleanup, category isolation, and same-major release scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->