### PR TITLE
fix: do not publish a failed or guessed package refresh

### DIFF
--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -445,6 +445,11 @@ pfb_publish_decision() {
     _old=$2
     _post=$3
     _current=$4
+    if [ "$_pkg" -eq 1 ] && [ -z "$_post" ]; then
+        # Verified apply but no version string — do not publish OLD_VER as a guess.
+        printf '%s\n' fail-closed
+        return 0
+    fi
     if [ "$_pkg" -eq 1 ] && [ -n "$_post" ] && [ "$_post" != "$_old" ]; then
         printf '%s\n' skip-os
         return 0
@@ -766,6 +771,9 @@ fi
 _decision=$(pfb_publish_decision "${PKG_WAS_UPGRADED}" "${OLD_VER}" "${_post_pkg_ver}" "${_check_current}")
 SKIP_OS_UPGRADE=0
 NEW_VER=""
+if [ "$_decision" = fail-closed ]; then
+    die "post-apply version probe empty; not publishing a guess at '${OLD_VER}'"
+fi
 if [ "$_decision" = nothing-to-publish ]; then
     log "no OS upgrade available — box is current at '${OLD_VER}'; nothing to publish."
     exit 0

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -21,10 +21,13 @@
 #
 # Flow: pull the current image from GHCR (local) -> stream it to the Proxmox host
 # -> boot it under QEMU/KVM there (read-write, with internet) ->
-# [optional: pkg update -f + pkg upgrade, reboot, wait SSH back] ->
-# check for an available OS upgrade (pfSense-upgrade -c); if the box is already
-# current, exit 0 WITHOUT publishing -> else run pfSense-upgrade over an SSH jump
-# -> wait for /etc/version to change + reboot -> reconcile pfBlockerNG's baked
+# [optional: pkg update -f + verified pkg upgrade, reboot, wait SSH back] ->
+# check for an available OS upgrade (pfSense-upgrade -c). Current and no
+# verified package apply -> exit 0 without publishing. Current after a
+# verified package apply (or /etc/version already moved, e.g. BETA->RC) ->
+# publish without running pfSense-upgrade or the version-change poll.
+# Otherwise run pfSense-upgrade over an SSH jump -> wait for /etc/version
+# to change + reboot -> reconcile pfBlockerNG's baked
 # RUN_DEPENDS against the NEW version's matrix row (install what's missing, e.g.
 # after a py_flavor flip; shed stale old-flavor/extra packages; verify pkg info -e
 # + a python import probe, fail-closed) -> health-gate (webConfigurator HTTP
@@ -415,6 +418,24 @@ pfb_call_site_upgrade() {
 }
 # pfb_call_site END
 
+# pfb_pkg_refresh_verdict BEGIN
+# Dry-run text -> up-to-date | pending | fail-closed.
+# "pending" only when pkg printed an upgrade/install/reinstall plan.
+# Anything else (fetch error, lock, empty) is fail-closed — not a publish signal.
+pfb_pkg_refresh_verdict() {
+    _dry=$1
+    if printf '%s' "$_dry" | grep -q 'Your packages are up to date'; then
+        printf '%s\n' up-to-date
+        return 0
+    fi
+    if printf '%s' "$_dry" | grep -qE 'Number of packages to be (upgraded|installed|reinstalled)'; then
+        printf '%s\n' pending
+        return 0
+    fi
+    printf '%s\n' fail-closed
+}
+# pfb_pkg_refresh_verdict END
+
 # pfb_verify_artifact BEGIN
 # pfb_verify_artifact FILE TAG — boot the EXPORTED qcow2 once and refuse to
 # publish it unless the version it actually comes up with belongs to TAG's
@@ -664,12 +685,20 @@ if [ "$UPGRADE_PKGS" -eq 1 ]; then
     # do NOT rely solely on exit code, as pkg(8) exit semantics vary by version.
     log "checking for pending package upgrades (pkg upgrade -n)"
     _pkg_dry=$(ssh_guest 'pkg upgrade -n' 2>&1 | tee "$LOCAL_DIR/pkg-upgrade-dryrun.log" || true)
-    if printf '%s' "$_pkg_dry" | grep -q 'Your packages are up to date'; then
+    _pkg_verdict=$(pfb_pkg_refresh_verdict "$_pkg_dry")
+    if [ "$_pkg_verdict" = up-to-date ]; then
         log "packages already up to date — skipping pkg upgrade + reboot"
         PKG_WAS_UPGRADED=0
+    elif [ "$_pkg_verdict" = fail-closed ]; then
+        die "pkg upgrade -n did not report a plan or an up-to-date result (see $LOCAL_DIR/pkg-upgrade-dryrun.log)"
     else
         log "package upgrades pending — running pkg upgrade -y"
-        ssh_guest 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y' 2>&1 | tee "$LOCAL_DIR/pkg-upgrade.log" || true
+        # Do not pipe: tee's 0 would hide a failed apply (#1844 same class).
+        if ! ssh_guest 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y' >"$LOCAL_DIR/pkg-upgrade.log" 2>&1; then
+            cat "$LOCAL_DIR/pkg-upgrade.log"
+            die "pkg upgrade -y failed (see $LOCAL_DIR/pkg-upgrade.log)"
+        fi
+        cat "$LOCAL_DIR/pkg-upgrade.log"
         log "rebooting after pkg upgrade"
         # /sbin/reboot drops the connection — expected; ignore the exit code.
         ssh_guest '/sbin/reboot' 2>/dev/null || true
@@ -692,55 +721,61 @@ fi
 
 # --- check whether an OS upgrade is available ------------------------------
 # pfSense-upgrade -c reports the available version without applying it. Parsing
-# is best-effort (the wording varies by release); the AUTHORITATIVE signal is
-# the /etc/version change after the upgrade run below. If the check clearly says
-# the box is already current there is nothing to publish -> graceful no-op exit.
-log "checking for an available OS upgrade (pfSense-upgrade -c)"
-UPGRADE_CHECK=$(pfb_call_site_check "$LOCAL_DIR/upgrade-check.log")
-printf '%s\n' "$UPGRADE_CHECK" | sed 's/^/    /'
-if printf '%s' "$UPGRADE_CHECK" | grep -qiE 'up.to.date|already.*(latest|current)|no [a-z ]*update'; then
-    if [ "$UPGRADE_PKGS" -eq 0 ] || [ "$PKG_WAS_UPGRADED" -eq 0 ]; then
-    log "no OS upgrade available — box is current at '${OLD_VER}'; nothing to publish."
-    exit 0
+# is best-effort (the wording varies by release). Current and no verified
+# package apply -> nothing to publish. Current after a verified package apply,
+# or /etc/version already moved by pkg (BETA->RC), -> publish without
+# pfSense-upgrade or the version-change poll.
+SKIP_OS_UPGRADE=0
+NEW_VER=""
+if [ "$PKG_WAS_UPGRADED" -eq 1 ]; then
+    _post_pkg_ver=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)
+    if [ -n "$_post_pkg_ver" ] && [ "$_post_pkg_ver" != "$OLD_VER" ]; then
+        NEW_VER="$_post_pkg_ver"
+        SKIP_OS_UPGRADE=1
+        log "package refresh moved /etc/version ${OLD_VER} -> ${NEW_VER}; skipping OS upgrade."
     fi
 fi
-
-# --- run the pfSense upgrade -----------------------------------------------
-log "running pfSense upgrade (this reboots the box; up to ${UPGRADE_TIMEOUT}s)"
-# Connection will drop when the box reboots — that is expected, so ignore it.
-# The lock retry still applies: a refused upgrade must never be mistaken for a
-# started one (issue #1844).
-pfb_call_site_upgrade "$LOCAL_DIR/upgrade.log"
-
-# --- wait for the new version to come up -----------------------------------
-log "waiting for the upgraded box to come back..."
-NEW_VER=""
-_elapsed=0
-sleep 20  # let the reboot begin so we don't read the pre-reboot version
-while [ "$_elapsed" -lt "$UPGRADE_TIMEOUT" ]; do
-    _v=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)
-    if [ -n "$_v" ] && [ "$_v" != "$OLD_VER" ]; then
-        NEW_VER="$_v"
-        break
-    fi
-    sleep 15; _elapsed=$((_elapsed + 15))
-done
-if [ -z "$NEW_VER" ]; then
-    # Version unchanged: a graceful no-op only if pfSense-upgrade reports the box
-    # is already current (the pre-check missed it); otherwise a genuine stuck/failed
-    # upgrade — fail-closed.
-    if printf '%s\n%s' "$UPGRADE_CHECK" "$(cat "$LOCAL_DIR/upgrade.log" 2>/dev/null)" \
-        | grep -qiE 'up.to.date|already.*(latest|current)|no [a-z ]*update'; then
-        if [ "$UPGRADE_PKGS" -eq 1 ] && [ "$PKG_WAS_UPGRADED" -eq 1 ]; then
-            NEW_VER="$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)"
+if [ "$SKIP_OS_UPGRADE" -eq 0 ]; then
+    log "checking for an available OS upgrade (pfSense-upgrade -c)"
+    UPGRADE_CHECK=$(pfb_call_site_check "$LOCAL_DIR/upgrade-check.log")
+    printf '%s\n' "$UPGRADE_CHECK" | sed 's/^/    /'
+    if printf '%s' "$UPGRADE_CHECK" | grep -qiE 'up.to.date|already.*(latest|current)|no [a-z ]*update'; then
+        if [ "$PKG_WAS_UPGRADED" -eq 1 ]; then
+            NEW_VER=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)
             NEW_VER="${NEW_VER:-$OLD_VER}"
-            log "no OS upgrade applied — package refresh updated the image at '${NEW_VER}', continuing publish."
+            SKIP_OS_UPGRADE=1
+            log "no OS upgrade available — package refresh updated the image at '${NEW_VER}', continuing publish."
         else
-            log "no OS upgrade applied — box is current at '${OLD_VER}'; nothing to publish."
+            log "no OS upgrade available — box is current at '${OLD_VER}'; nothing to publish."
             exit 0
         fi
     fi
-    die "version did not change within ${UPGRADE_TIMEOUT}s (still '${OLD_VER}'; see $LOCAL_DIR/upgrade.log)"
+fi
+
+if [ "$SKIP_OS_UPGRADE" -eq 0 ]; then
+    # --- run the pfSense upgrade -----------------------------------------------
+    log "running pfSense upgrade (this reboots the box; up to ${UPGRADE_TIMEOUT}s)"
+    # Connection will drop when the box reboots — that is expected, so ignore it.
+    # The lock retry still applies: a refused upgrade must never be mistaken for a
+    # started one (issue #1844).
+    pfb_call_site_upgrade "$LOCAL_DIR/upgrade.log"
+
+    # --- wait for the new version to come up -----------------------------------
+    log "waiting for the upgraded box to come back..."
+    NEW_VER=""
+    _elapsed=0
+    sleep 20  # let the reboot begin so we don't read the pre-reboot version
+    while [ "$_elapsed" -lt "$UPGRADE_TIMEOUT" ]; do
+        _v=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)
+        if [ -n "$_v" ] && [ "$_v" != "$OLD_VER" ]; then
+            NEW_VER="$_v"
+            break
+        fi
+        sleep 15; _elapsed=$((_elapsed + 15))
+    done
+    if [ -z "$NEW_VER" ]; then
+        die "version did not change within ${UPGRADE_TIMEOUT}s (still '${OLD_VER}'; see $LOCAL_DIR/upgrade.log)"
+    fi
 fi
 log "upgraded: ${OLD_VER} -> ${NEW_VER}"
 

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -437,16 +437,20 @@ pfb_pkg_refresh_verdict() {
 # pfb_pkg_refresh_verdict END
 
 # pfb_publish_decision BEGIN
-# PKG_WAS_UPGRADED OLD_VER POST_VER CHECK_CURRENT(0|1) -> skip-os | run-os | nothing-to-publish
+# PKG_WAS_UPGRADED OLD_VER POST_VER CHECK_CURRENT(0|1) -> skip-os | run-os | nothing-to-publish | fail-closed
 # A wording miss on pfSense-upgrade -c plus no version change is run-os (then die
 # if the version still does not move). Do not guess a publish.
+# Empty POST after a verified apply is always fail-closed, including
+# ``1 <old> '' 0`` (OS upgrade available). We do not know what the box is
+# running; run-os would also be a guess. The next dispatch can upgrade.
 pfb_publish_decision() {
     _pkg=$1
     _old=$2
     _post=$3
     _current=$4
     if [ "$_pkg" -eq 1 ] && [ -z "$_post" ]; then
-        # Verified apply but no version string — do not publish OLD_VER as a guess.
+        # Verified apply but no version string — do not publish OLD_VER, and
+        # do not run-os either (CHECK_CURRENT is ignored here on purpose).
         printf '%s\n' fail-closed
         return 0
     fi

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -428,13 +428,38 @@ pfb_pkg_refresh_verdict() {
         printf '%s\n' up-to-date
         return 0
     fi
-    if printf '%s' "$_dry" | grep -qE 'Number of packages to be (upgraded|installed|reinstalled)'; then
+    if printf '%s' "$_dry" | grep -qiE 'Number of packages to be (upgraded|installed|reinstalled|removed|downgraded)'; then
         printf '%s\n' pending
         return 0
     fi
     printf '%s\n' fail-closed
 }
 # pfb_pkg_refresh_verdict END
+
+# pfb_publish_decision BEGIN
+# PKG_WAS_UPGRADED OLD_VER POST_VER CHECK_CURRENT(0|1) -> skip-os | run-os | nothing-to-publish
+# A wording miss on pfSense-upgrade -c plus no version change is run-os (then die
+# if the version still does not move). Do not guess a publish.
+pfb_publish_decision() {
+    _pkg=$1
+    _old=$2
+    _post=$3
+    _current=$4
+    if [ "$_pkg" -eq 1 ] && [ -n "$_post" ] && [ "$_post" != "$_old" ]; then
+        printf '%s\n' skip-os
+        return 0
+    fi
+    if [ "$_current" -eq 1 ]; then
+        if [ "$_pkg" -eq 1 ]; then
+            printf '%s\n' skip-os
+        else
+            printf '%s\n' nothing-to-publish
+        fi
+        return 0
+    fi
+    printf '%s\n' run-os
+}
+# pfb_publish_decision END
 
 # pfb_verify_artifact BEGIN
 # pfb_verify_artifact FILE TAG — boot the EXPORTED qcow2 once and refuse to
@@ -725,31 +750,30 @@ fi
 # package apply -> nothing to publish. Current after a verified package apply,
 # or /etc/version already moved by pkg (BETA->RC), -> publish without
 # pfSense-upgrade or the version-change poll.
-SKIP_OS_UPGRADE=0
-NEW_VER=""
+_post_pkg_ver=""
 if [ "$PKG_WAS_UPGRADED" -eq 1 ]; then
     _post_pkg_ver=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)
-    if [ -n "$_post_pkg_ver" ] && [ "$_post_pkg_ver" != "$OLD_VER" ]; then
-        NEW_VER="$_post_pkg_ver"
-        SKIP_OS_UPGRADE=1
-        log "package refresh moved /etc/version ${OLD_VER} -> ${NEW_VER}; skipping OS upgrade."
-    fi
 fi
-if [ "$SKIP_OS_UPGRADE" -eq 0 ]; then
+_check_current=0
+if [ "$PKG_WAS_UPGRADED" -eq 0 ] || [ -z "$_post_pkg_ver" ] || [ "$_post_pkg_ver" = "$OLD_VER" ]; then
     log "checking for an available OS upgrade (pfSense-upgrade -c)"
     UPGRADE_CHECK=$(pfb_call_site_check "$LOCAL_DIR/upgrade-check.log")
     printf '%s\n' "$UPGRADE_CHECK" | sed 's/^/    /'
     if printf '%s' "$UPGRADE_CHECK" | grep -qiE 'up.to.date|already.*(latest|current)|no [a-z ]*update'; then
-        if [ "$PKG_WAS_UPGRADED" -eq 1 ]; then
-            NEW_VER=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)
-            NEW_VER="${NEW_VER:-$OLD_VER}"
-            SKIP_OS_UPGRADE=1
-            log "no OS upgrade available — package refresh updated the image at '${NEW_VER}', continuing publish."
-        else
-            log "no OS upgrade available — box is current at '${OLD_VER}'; nothing to publish."
-            exit 0
-        fi
+        _check_current=1
     fi
+fi
+_decision=$(pfb_publish_decision "${PKG_WAS_UPGRADED}" "${OLD_VER}" "${_post_pkg_ver}" "${_check_current}")
+SKIP_OS_UPGRADE=0
+NEW_VER=""
+if [ "$_decision" = nothing-to-publish ]; then
+    log "no OS upgrade available — box is current at '${OLD_VER}'; nothing to publish."
+    exit 0
+fi
+if [ "$_decision" = skip-os ]; then
+    NEW_VER="${_post_pkg_ver:-$OLD_VER}"
+    SKIP_OS_UPGRADE=1
+    log "skipping OS upgrade — publishing package refresh at '${NEW_VER}'."
 fi
 
 if [ "$SKIP_OS_UPGRADE" -eq 0 ]; then

--- a/tests/shell/image_upgrade_pkg_refresh_spec.sh
+++ b/tests/shell/image_upgrade_pkg_refresh_spec.sh
@@ -1,0 +1,57 @@
+#shellcheck shell=sh
+# image_upgrade_pkg_refresh_spec.sh — pins --upgrade-pkgs publish decisions.
+#
+# A same-family pkg refresh must not fall into the OS version-change poll
+# (20 minute timeout) and must not treat a failed or unclear pkg apply as
+# a publish signal.
+
+Describe 'image-upgrade.sh package-refresh verdict'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  run_verdict() {
+    _dry="$1" sh -c '
+      eval "$(sed -n "/^# pfb_pkg_refresh_verdict BEGIN/,/^# pfb_pkg_refresh_verdict END/p" "$1")"
+      pfb_pkg_refresh_verdict "$_dry"
+    ' _ "$SCRIPT"
+  }
+
+  It 'reports up-to-date when pkg says so'
+    When call run_verdict 'Your packages are up to date.'
+    The status should be success
+    The output should equal 'up-to-date'
+  End
+
+  It 'reports pending only when pkg printed a plan'
+    When call run_verdict 'Number of packages to be upgraded: 3'
+    The status should be success
+    The output should equal 'pending'
+  End
+
+  It 'fail-closes on a fetch error with no plan'
+    When call run_verdict 'pkg: http://example.test: Not Found'
+    The status should be success
+    The output should equal 'fail-closed'
+  End
+
+  It 'fail-closes on empty dry-run output'
+    When call run_verdict ''
+    The status should be success
+    The output should equal 'fail-closed'
+  End
+End
+
+Describe 'image-upgrade.sh skips the OS poll after a verified package apply'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  It 'does not call pfb_call_site_upgrade when SKIP_OS_UPGRADE is set by the pkg path'
+    When call grep -n 'SKIP_OS_UPGRADE' "$SCRIPT"
+    The status should be success
+    The output should include 'SKIP_OS_UPGRADE=1'
+  End
+
+  It 'does not pipe pkg upgrade -y into tee'
+    When call grep -n "pkg upgrade -y" "$SCRIPT"
+    The status should be success
+    The output should not include 'pkg upgrade -y'"'"' 2>&1 | tee'
+  End
+End

--- a/tests/shell/image_upgrade_pkg_refresh_spec.sh
+++ b/tests/shell/image_upgrade_pkg_refresh_spec.sh
@@ -27,6 +27,18 @@ Describe 'image-upgrade.sh package-refresh verdict'
     The output should equal 'pending'
   End
 
+  It 'treats a removal-only plan as pending'
+    When call run_verdict 'Number of packages to be REMOVED: 1'
+    The status should be success
+    The output should equal 'pending'
+  End
+
+  It 'treats a downgrade plan as pending'
+    When call run_verdict 'Number of packages to be downgraded: 2'
+    The status should be success
+    The output should equal 'pending'
+  End
+
   It 'fail-closes on a fetch error with no plan'
     When call run_verdict 'pkg: http://example.test: Not Found'
     The status should be success
@@ -40,18 +52,37 @@ Describe 'image-upgrade.sh package-refresh verdict'
   End
 End
 
-Describe 'image-upgrade.sh skips the OS poll after a verified package apply'
+Describe 'image-upgrade.sh publish decision after a package apply'
   SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
 
-  It 'does not call pfb_call_site_upgrade when SKIP_OS_UPGRADE is set by the pkg path'
-    When call grep -n 'SKIP_OS_UPGRADE' "$SCRIPT"
+  run_decision() {
+    _pkg="$1" _old="$2" _post="$3" _cur="$4" sh -c '
+      eval "$(sed -n "/^# pfb_publish_decision BEGIN/,/^# pfb_publish_decision END/p" "$1")"
+      pfb_publish_decision "$_pkg" "$_old" "$_post" "$_cur"
+    ' _ "$SCRIPT"
+  }
+
+  It 'skips the OS poll when pkg already moved /etc/version'
+    When call run_decision 1 26.07-BETA 26.07-RC 0
     The status should be success
-    The output should include 'SKIP_OS_UPGRADE=1'
+    The output should equal 'skip-os'
   End
 
-  It 'does not pipe pkg upgrade -y into tee'
-    When call grep -n "pkg upgrade -y" "$SCRIPT"
+  It 'skips the OS poll when -c is current after a verified apply'
+    When call run_decision 1 26.07 26.07 1
     The status should be success
-    The output should not include 'pkg upgrade -y'"'"' 2>&1 | tee'
+    The output should equal 'skip-os'
+  End
+
+  It 'exits with nothing to publish when current and no apply'
+    When call run_decision 0 26.07 26.07 1
+    The status should be success
+    The output should equal 'nothing-to-publish'
+  End
+
+  It 'runs the OS upgrade when -c is not current'
+    When call run_decision 0 26.07 26.07 0
+    The status should be success
+    The output should equal 'run-os'
   End
 End

--- a/tests/shell/image_upgrade_pkg_refresh_spec.sh
+++ b/tests/shell/image_upgrade_pkg_refresh_spec.sh
@@ -85,4 +85,10 @@ Describe 'image-upgrade.sh publish decision after a package apply'
     The status should be success
     The output should equal 'run-os'
   End
+
+  It 'fail-closes when apply succeeded but the version probe is empty'
+    When call run_decision 1 26.07 '' 1
+    The status should be success
+    The output should equal 'fail-closed'
+  End
 End


### PR DESCRIPTION
Post-merge fix for commits CodeRabbit never finished reviewing (Fair Usage rate limit on #2186).

Same-family `--upgrade-pkgs` sat in the OS version-change poll for up to 20 minutes, then published. A failed or unclear `pkg apply` still set `PKG_WAS_UPGRADED` after reboot.

## Change

- Dry-run must print an upgrade/install/reinstall plan; otherwise fail closed.
- `pkg upgrade -y` is not piped (exit status is kept). Failure does not reboot or publish.
- After a verified package apply: if `/etc/version` already moved (BETA→RC) or `-c` says current, publish without `pfSense-upgrade` or the poll.

## Tests

Hermetic shellspec on `pfb_pkg_refresh_verdict` (up-to-date / pending / fail-closed). Live image-upgrade smoke is not added: a 20-minute poll cannot be exercised on the guest smoke VM.

Please do not merge until Claude re-reviews.

Made-with: Grok

🤖 Generated by Grok and posted on behalf of @BBcan177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade status detection for current, pending, failed, and inconclusive package updates.
  * Upgrade failures now stop the process instead of being masked.
  * Prevented unnecessary operating system upgrades when package updates already complete the required refresh.
  * Publishing now occurs only after a verified version change.
* **Tests**
  * Added coverage for package refresh outcomes and operating system upgrade decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->