### PR TITLE
fix: do not treat schedule-seeded General as IP leftovers

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -581,10 +581,10 @@ $pfb_ip_section   = PfbConfig::readSection('installedpackages/pfblockerngipsetti
 $settings = array(	'enable_dup', 'enable_agg', 'suppression', 'enable_log', 'maxmind_locale', 'database_cc',
 			'inbound_interface', 'inbound_deny_action', 'outbound_interface', 'outbound_deny_action',
 			'enable_float', 'pass_order', 'autorule_suffix', 'killstates' );
-$has_migratable = false;
+$has_migratable = FALSE;
 foreach ($settings as $setting) {
 	if (array_key_exists($setting, $pfb_gen_section)) {
-		$has_migratable = true;
+		$has_migratable = TRUE;
 		break;
 	}
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -574,27 +574,34 @@ update_status(" General Tab -> IP Tab settings...");
 
 $pfb_gen_section  = PfbConfig::readSection('installedpackages/pfblockerng/config/0');
 $pfb_ip_section   = PfbConfig::readSection('installedpackages/pfblockerngipsettings/config/0');
-// issue #1772: gate on the OPERATOR view -- a marker-only General section (only
-// the installer's own settings_family, seeded before this region on every
-// install) is a genuinely fresh install; migrating it seeded 14 phantom blank
-// keys into the IP section. Same chokepoint as the #1770/#1771/#1775 reads.
-if (!empty(pfb_gconfig_operator_view($pfb_gen_section)) && empty($pfb_ip_section)) {
+// issue #1772: gate on the 14 source keys, not operator-view emptiness.
+// pfb_schedule_migrate() (via pfb_install_settings_family_finalize, above)
+// seeds schedule keys into General on a virgin box; those survive
+// pfb_gconfig_operator_view() and must not count as pre-existing IP settings.
+$settings = array(	'enable_dup', 'enable_agg', 'suppression', 'enable_log', 'maxmind_locale', 'database_cc',
+			'inbound_interface', 'inbound_deny_action', 'outbound_interface', 'outbound_deny_action',
+			'enable_float', 'pass_order', 'autorule_suffix', 'killstates' );
+$has_migratable = false;
+foreach ($settings as $setting) {
+	if (array_key_exists($setting, $pfb_gen_section)) {
+		$has_migratable = true;
+		break;
+	}
+}
+if ($has_migratable && empty($pfb_ip_section)) {
 
 	$pfb['gconfig'] = $pfb_gen_section;
 	$pfb['iconfig'] = $pfb_ip_section;
 
-	$settings = array(	'enable_dup', 'enable_agg', 'suppression', 'enable_log', 'maxmind_locale', 'database_cc',
-				'inbound_interface', 'inbound_deny_action', 'outbound_interface', 'outbound_deny_action',
-				'enable_float', 'pass_order', 'autorule_suffix', 'killstates' );
-
 	foreach ($settings as $setting) {
-		// issue #1772: ?? -- an absent key copies as '' with no
-		// Undefined-array-key warning, and a stored '0' migrates as '0'
-		// (the empty('0') falsiness class, issues #1787/#1792).
-		$pfb['iconfig'][$setting] = $pfb['gconfig'][$setting] ?? '';
-		if (isset($pfb['gconfig'][$setting])) {
-			unset($pfb['gconfig'][$setting]);
+		if (!array_key_exists($setting, $pfb['gconfig'])) {
+			continue;
 		}
+		// issue #1772: copy only keys that exist so a stored '0' stays '0'
+		// (the empty('0') falsiness class, issues #1787/#1792) and absent
+		// keys are not planted as ''.
+		$pfb['iconfig'][$setting] = $pfb['gconfig'][$setting];
+		unset($pfb['gconfig'][$setting]);
 	}
 	// issue #1921: pre-pass legacy reshape -- raw write-back keeps bystander values
 	// byte-identical for pfb_registry_pass()'s rename/grandfather decisions.

--- a/tests/php/InstallGeneralToIpMigrationTest.php
+++ b/tests/php/InstallGeneralToIpMigrationTest.php
@@ -115,4 +115,26 @@ final class InstallGeneralToIpMigrationTest extends TestCase
 		$this->assertSame('v4', $gen['settings_family'] ?? null,
 			'the installer marker must survive a real migration untouched');
 	}
+
+	public function testScheduleSeededGeneralDoesNotPlantBlankIpKeys(): void
+	{
+		// Current installer order: pfb_schedule_migrate() writes these
+		// into General before this region. They are not IP-tab leftovers.
+		$this->seedGeneralSection([
+			'settings_family' => 'v4',
+			'pfb_scheduled_feed_updates' => 'on',
+			'pfb_schedule_weekday' => '7',
+			'pfb_schedule_hour' => '0',
+			'pfb_schedule_minute' => '0',
+			'skipfeed' => '',
+		]);
+
+		pfb_install_oracle_gen_to_ip_region();
+
+		$this->assertSame([], $this->ipSection(),
+			'schedule keys in General are not IP leftovers -- do not plant the 14 blank IP keys');
+		$gen = $GLOBALS['config']['installedpackages']['pfblockerng']['config'][0];
+		$this->assertSame('on', $gen['pfb_scheduled_feed_updates'] ?? null);
+		$this->assertArrayNotHasKey('suppression', $this->ipSection());
+	}
 }

--- a/tests/php/InstallGeneralToIpMigrationTest.php
+++ b/tests/php/InstallGeneralToIpMigrationTest.php
@@ -135,6 +135,6 @@ final class InstallGeneralToIpMigrationTest extends TestCase
 			'schedule keys in General are not IP leftovers -- do not plant the 14 blank IP keys');
 		$gen = $GLOBALS['config']['installedpackages']['pfblockerng']['config'][0];
 		$this->assertSame('on', $gen['pfb_scheduled_feed_updates'] ?? null);
-		$this->assertArrayNotHasKey('suppression', $this->ipSection());
+		$this->assertSame('v4', $gen['settings_family'] ?? null);
 	}
 }

--- a/tests/smoke/test_install_hook.py
+++ b/tests/smoke/test_install_hook.py
@@ -127,7 +127,9 @@ def test_install_hook_succeeds(smoke_vm: SmokeVM) -> None:
     supp_lines = [line for line in out.splitlines() if line.startswith("SUPPRESSION=")]
     assert supp_lines, f"fresh-install suppression probe missing:\n{out}"
     supp = supp_lines[-1].split("=", 1)[1]
+    # Absence (__ABSENT__) is the intended pass: the General->IP copy did not
+    # fire. The registry may later write the registered default ('on'); an
+    # empty string is the planted-blank bug.
     assert supp != "", (
-        "fresh install planted ip/suppression as empty (General->IP copy fired "
-        f"on schedule-seeded General):\n{out}"
+        f"fresh install planted ip/suppression as empty (General->IP copy fired on schedule-seeded General):\n{out}"
     )

--- a/tests/smoke/test_install_hook.py
+++ b/tests/smoke/test_install_hook.py
@@ -46,6 +46,13 @@ sleep 2
 echo "=== pkg add (runs rc.packages POST-INSTALL) ==="
 env ASSUME_ALWAYS_YES=yes pkg add "$P" 2>&1
 echo "rc=$?"
+# Fresh-install IP suppression must not be planted as empty (schedule-seeded
+# General used to trip the General->IP copy and persist suppression off).
+php -r '
+require_once "config.inc";
+$v = config_get_path("installedpackages/pfblockerngipsettings/config/0/suppression", "__ABSENT__");
+echo "SUPPRESSION=" . (is_scalar($v) ? (string)$v : "__NONSCALAR__") . "\n";
+'
 # Leave the VM clean for the repo-install module (which expects the pkg ABSENT).
 env ASSUME_ALWAYS_YES=yes pkg delete -y "$NAME" >/dev/null 2>&1 || true
 """
@@ -117,3 +124,10 @@ def test_install_hook_succeeds(smoke_vm: SmokeVM) -> None:
     )
     ran = [p for p in _SUCCESS_PHRASES if p in out]
     assert ran, f"the install hook did not run the full pfBlockerNG setup:\n{out}"
+    supp_lines = [line for line in out.splitlines() if line.startswith("SUPPRESSION=")]
+    assert supp_lines, f"fresh-install suppression probe missing:\n{out}"
+    supp = supp_lines[-1].split("=", 1)[1]
+    assert supp != "", (
+        "fresh install planted ip/suppression as empty (General->IP copy fired "
+        f"on schedule-seeded General):\n{out}"
+    )


### PR DESCRIPTION
Post-merge fix for commits CodeRabbit never finished reviewing (Fair Usage rate limit on #1809).

`pfb_schedule_migrate()` now writes schedule keys into General before the General→IP copy. Operator-view looked non-empty and planted 14 blank IP keys, leaving `ip/suppression` off on a fresh install.

## Change

Gate on presence of any of the 14 source keys. Copy only keys that exist. Do not fill the rest with `''`.

## Tests

- PHPUnit: schedule-seeded General (no IP keys) must not write the IP section. Marker-only and real-legacy cases kept. Zero-valued `killstates` still migrates as `'0'`.
- Smoke: `test_install_hook_succeeds` now prints post-install `SUPPRESSION=` and fails if it is empty. Existing smoke still pins suppression off *after* install for RFC 5737 fixtures; that workaround stays.

Please do not merge until Claude re-reviews.

Made-with: Grok

🤖 Generated by Grok and posted on behalf of @BBcan177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration of General settings to IP settings by preserving configured values, including `0`, and avoiding creation of blank settings.
  * Prevented schedule-only configurations from generating unintended IP settings.

* **Tests**
  * Added regression coverage for configuration migration behavior.
  * Enhanced installation smoke tests to verify suppression settings are initialized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->