### PR TITLE
test: drive regex admission parity through main()

### DIFF
--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -96,9 +96,9 @@ def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
     as two separate branches (it needs the two distinct diagnostics), while the
     resolver calls the single composed ``_regex_is_catastrophic_shape``.
 
-    Sharing the literals only closes the literal-drift row. This closes the row the
-    #1711 parity tests actually existed for: a rule wired into one composition and
-    not the other silently reopens "the save page accepts it, the resolver drops it".
+    Sharing the literals only closes the literal-drift row. This pin is the
+    shape/budget axis only. Compile and control-character rejects are covered
+    by DnsblRegexEntryErrorTest (PHP probe) and are skipped here.
     """
     import io
 
@@ -153,17 +153,17 @@ def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
     blocks = ("(", ")", "(?:", "[a-z]", "a", ".", "+", "*", "{2}", "|", "\\", "$")
     corpus += ["".join(combination) for combination in itertools.product(blocks, repeat=4)]
 
+    compared = {True: 0, False: 0}
     for pattern in corpus:
         probe_rejects = main_rejects_shape(pattern)
         if probe_rejects is None:
             continue
+        compared[probe_rejects] += 1
         assert probe_rejects == _regex_is_catastrophic_shape(pattern), (
             f"probe and resolver disagree on {pattern!r}: "
             f"probe rejects={probe_rejects}, resolver rejects={_regex_is_catastrophic_shape(pattern)}"
         )
-    # Guard against a vacuously one-sided corpus.
-    assert any(_regex_is_catastrophic_shape(pattern) for pattern in corpus)
-    assert any(not _regex_is_catastrophic_shape(pattern) for pattern in corpus)
+    assert compared[True] and compared[False], f"corpus never exercised both verdicts: {compared}"
 
 
 def test_probe_and_resolver_both_reject_an_adjacent_quantifier_run() -> None:

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -100,12 +100,27 @@ def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
     #1711 parity tests actually existed for: a rule wired into one composition and
     not the other silently reopens "the save page accepts it, the resolver drops it".
     """
-    from pfb_dnsbl_regex_rules import (
-        _REGEX_BUDGET_MAX,
-        _regex_complexity_budget,
-        _regex_has_catastrophic_shape,
-        _regex_is_catastrophic_shape,
-    )
+    import io
+
+    from pfb_dnsbl_regex_rules import _REGEX_BUDGET_MAX, _regex_is_catastrophic_shape, main
+
+    def main_rejects_shape(pattern: str) -> bool | None:
+        """Return whether ``main()`` rejected for shape/budget, or None if it
+        skipped the line or rejected for compile/control (not this pin)."""
+        old_in, old_err = sys.stdin, sys.stderr
+        try:
+            sys.stdin = io.StringIO(pattern + "\n")
+            captured = io.StringIO()
+            sys.stderr = captured
+            rc = main(["probe"])
+        finally:
+            sys.stdin, sys.stderr = old_in, old_err
+        err = captured.getvalue()
+        if rc == 0:
+            return False
+        if "catastrophic-backtracking shape" in err or "too many quantifiers" in err:
+            return True
+        return None
 
     corpus = [
         "^ads\\.example\\.com$",
@@ -139,7 +154,9 @@ def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
     corpus += ["".join(combination) for combination in itertools.product(blocks, repeat=4)]
 
     for pattern in corpus:
-        probe_rejects = _regex_has_catastrophic_shape(pattern) or _regex_complexity_budget(pattern) > _REGEX_BUDGET_MAX
+        probe_rejects = main_rejects_shape(pattern)
+        if probe_rejects is None:
+            continue
         assert probe_rejects == _regex_is_catastrophic_shape(pattern), (
             f"probe and resolver disagree on {pattern!r}: "
             f"probe rejects={probe_rejects}, resolver rejects={_regex_is_catastrophic_shape(pattern)}"


### PR DESCRIPTION
Post-merge fix for commits CodeRabbit never finished reviewing (Fair Usage rate limit on #2022).

`test_probe_and_resolver_agree_on_every_admission_verdict` compared the composed predicate to its own body and never called `main()`.

## Change

Each corpus row now runs `main()`. Shape/budget rejects are compared to `_regex_is_catastrophic_shape`. Compile/control rejects are skipped (not this pin).

No new live-VM smoke: this is save-time probe vs resolver admission, already covered hermetically. UI-save smoke would only re-hit PHP `pfb_dnsbl_regex_validation_errors()`.

Please do not merge until Claude re-reviews.

Made-with: Grok

🤖 Generated by Grok and posted on behalf of @BBcan177.