### PR TITLE
ci: dispatch-only CodeRabbit CLI review (#2436)

### DIFF
--- a/.agents/policy/coderabbit.md
+++ b/.agents/policy/coderabbit.md
@@ -77,8 +77,12 @@ Format-only pushes after pause do not spend a slot.
 
 Only the **repo owner**, in conversation, may spend a slot anyway
 or name another reviewer. No labels. Agents never invent a
-substitute. Three-leg still runs. CLI-in-CI is #2436 (needs a
-burst test + an Agentic API key before anyone builds it).
+substitute. Three-leg still runs. CLI-in-CI is #2436:
+`.github/workflows/coderabbit-cli.yml` is **dispatch-only** (not
+on push) so it cannot walk the PR Fair Usage band by itself.
+Needs secret `CODERABBIT_API_KEY` (Agentic key). Findings are
+file-level. Burst-test the hourly columns before enabling
+per-push.
 
 ## Required path (every future PR)
 

--- a/.agents/skills/coderabbit/SKILL.md
+++ b/.agents/skills/coderabbit/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: coderabbit
+description: >
+  CodeRabbit Fair Usage and CLI review. Run immediately before opening a
+  GitHub PR, when a quota / "Review limit reached" notice appears, or when
+  dispatching the CLI-in-CI workflow. Loads `.agents/policy/coderabbit.md`.
+  Triggers: "open a PR", "Fair Usage", "rate limit", "coderabbit",
+  "@coderabbitai", "/coderabbit".
+---
+
+Canonical contract: [`.agents/policy/coderabbit.md`](../../policy/coderabbit.md).
+Read that file; do not invent mute labels or post `@coderabbitai rate limit`.
+
+## Before `gh pr create`
+
+```sh
+scripts/agent/before-pr-create.sh --repo OWNER/REPO
+```
+
+- Exit 0 → open the PR.
+- Exit 3 → wait until the printed `next slot`, unless the owner overrode in this conversation.
+- Exit 2 → tool/auth error; stop.
+
+The printed block is the full picture (plan hourly columns, 7-day band, remaining slots). Do not re-derive it.
+
+## Quota notice on an open PR
+
+A quota notice is not a review. Do not nudge while the countdown is live. Pause first, then one `@coderabbitai review` after the window. Details in the policy.
+
+## CLI review (separate hourly budget)
+
+Dispatch-only: Actions → **CodeRabbit CLI review** → PR number.
+Needs secret `CODERABBIT_API_KEY` (Agentic key). Findings are file-level.
+Do not enable per-push until a burst test says the 7-day PR taper is independent (#2436).

--- a/.agents/skills/coderabbit/agents/openai.yaml
+++ b/.agents/skills/coderabbit/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "CodeRabbit"
+  short_description: "Fair Usage gate and CLI review"
+policy:
+  allow_implicit_invocation: true

--- a/.claude/skills/coderabbit
+++ b/.claude/skills/coderabbit
@@ -1,0 +1,1 @@
+../../.agents/skills/coderabbit

--- a/.github/workflows/coderabbit-cli.yml
+++ b/.github/workflows/coderabbit-cli.yml
@@ -1,0 +1,60 @@
+# Prototype: CodeRabbit CLI review on a named PR.
+# Dispatch only — not on push — so a per-push job cannot walk the PR Fair Usage
+# 7-day band until a burst test says the columns are independent (#2436).
+# Needs repository secret CODERABBIT_API_KEY (Agentic key, assigned seat).
+name: CodeRabbit CLI review
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to review with the CLI
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cli-review:
+    name: CLI review of one PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require Agentic API key
+        env:
+          CODERABBIT_API_KEY: ${{ secrets.CODERABBIT_API_KEY }}
+        run: |
+          if [ -z "${CODERABBIT_API_KEY}" ]; then
+            echo '::error::Set repository secret CODERABBIT_API_KEY (Agentic key on an assigned seat).'
+            exit 1
+          fi
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check out the pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr checkout "${{ inputs.pr }}"
+      - name: Install CodeRabbit CLI
+        run: |
+          curl -fsSL https://cli.coderabbit.ai/install.sh | sh
+          echo "$HOME/.local/bin" >> "${GITHUB_PATH}"
+      - name: Run CLI review
+        env:
+          CODERABBIT_API_KEY: ${{ secrets.CODERABBIT_API_KEY }}
+        run: |
+          set -eu
+          BASE=$(gh pr view "${{ inputs.pr }}" --json baseRefName --jq .baseRefName)
+          git fetch origin "${BASE}"
+          coderabbit review --agent --api-key "${CODERABBIT_API_KEY}" \
+            --base "origin/${BASE}" > "${RUNNER_TEMP}/cr-cli.jsonl"
+      - name: Post file-level findings
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/agent/coderabbit_cli_report.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pr "${{ inputs.pr }}" \
+            "${RUNNER_TEMP}/cr-cli.jsonl"

--- a/.github/workflows/coderabbit-cli.yml
+++ b/.github/workflows/coderabbit-cli.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check out the pull request
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/agent/coderabbit_cli_report.py
+++ b/scripts/agent/coderabbit_cli_report.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Turn CodeRabbit CLI --agent JSONL into a PR comment.
+
+CLI findings have fileName + comment, not a line range. This posts a
+summary comment (advisory). It never calls the PR-review bot.
+
+Used by .github/workflows/coderabbit-cli.yml (workflow_dispatch only).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+HEADER = "CodeRabbit CLI review (separate hourly CLI budget; not a PR-review slot)"
+
+
+def parse_events(raw: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        if isinstance(obj, dict):
+            events.append(obj)
+    return events
+
+
+def findings_of(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [event for event in events if event.get("type") == "finding"]
+
+
+def complete_of(events: list[dict[str, Any]]) -> dict[str, Any]:
+    for event in reversed(events):
+        if event.get("type") == "complete":
+            return event
+    return {}
+
+
+def format_report(events: list[dict[str, Any]]) -> str:
+    complete = complete_of(events)
+    findings = findings_of(events)
+    status = complete.get("status") or "unknown"
+    count = complete.get("findings")
+    if count is None:
+        count = len(findings)
+    lines = [
+        HEADER,
+        "",
+        f"status: `{status}`  findings: {count}",
+        "",
+        "Findings are **file-level** (CLI JSONL has `fileName`, no line range).",
+        "This job is `workflow_dispatch` only so it cannot walk the PR Fair Usage band by itself.",
+        "",
+    ]
+    if status == "review_skipped":
+        lines.append(complete.get("message") or "No changes detected.")
+        lines.append("")
+        return "\n".join(lines)
+    if not findings:
+        lines.append("No findings.")
+        lines.append("")
+        return "\n".join(lines)
+    for event in findings:
+        severity = event.get("severity") or "info"
+        path = event.get("fileName") or "(no file)"
+        body = (event.get("comment") or event.get("codegenInstructions") or "").strip()
+        lines.append(f"### `{path}` ({severity})")
+        lines.append("")
+        lines.append(body or "_no comment text_")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("jsonl", help="path to CLI --agent JSONL (use - for stdin)")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", default="")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    raw = sys.stdin.read() if args.jsonl == "-" else open(args.jsonl, encoding="utf-8").read()
+    text = format_report(parse_events(raw))
+    if args.dry_run or not args.pr:
+        sys.stdout.write(text)
+        return 0
+    if not args.repo:
+        print("GITHUB_REPOSITORY / --repo required to post", file=sys.stderr)
+        return 2
+    subprocess.check_call(["gh", "pr", "comment", str(args.pr), "--repo", args.repo, "--body", text])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_coderabbit_cli_report.py
+++ b/tests/test_coderabbit_cli_report.py
@@ -1,0 +1,34 @@
+"""Unit tests for scripts/agent/coderabbit_cli_report.py."""
+
+from __future__ import annotations
+
+from scripts.agent.coderabbit_cli_report import format_report, parse_events
+
+
+def test_parse_skips_heartbeats_and_keeps_findings() -> None:
+    raw = "\n".join(
+        [
+            '{"type":"heartbeat"}',
+            '{"type":"finding","severity":"major","fileName":"scripts/x.py","comment":"null deref"}',
+            '{"type":"complete","status":"ok","findings":1}',
+        ]
+    )
+    events = parse_events(raw)
+    text = format_report(events)
+    assert "scripts/x.py" in text
+    assert "null deref" in text
+    assert "major" in text
+    assert "file-level" in text
+    assert "workflow_dispatch" in text
+
+
+def test_review_skipped_is_success_copy() -> None:
+    raw = '{"type":"complete","status":"review_skipped","findings":0,"message":"No changes detected"}'
+    text = format_report(parse_events(raw))
+    assert "review_skipped" in text
+    assert "No changes detected" in text
+
+
+def test_no_line_range_is_stated() -> None:
+    text = format_report([])
+    assert "no line range" in text

--- a/tests/test_coderabbit_cli_workflow.py
+++ b/tests/test_coderabbit_cli_workflow.py
@@ -1,0 +1,19 @@
+"""coderabbit-cli.yml is dispatch-only and never posts a bot chat command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+WF = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "coderabbit-cli.yml"
+
+
+def test_cli_workflow_is_dispatch_only() -> None:
+    text = WF.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in text
+    assert "pull_request:" not in text
+    assert "schedule:" not in text
+    assert "CODERABBIT_API_KEY" in text
+    assert "coderabbit_cli_report.py" in text
+    assert " --agent" in text
+    assert "gh pr comment" not in text
+    assert "rate limit" not in text.lower()


### PR DESCRIPTION
Fixes #2436 (prototype to test, not per-push yet).

Claude and I agree the CLI hourly column is separate, findings are file-level, and a per-push job must not walk the PR Fair Usage band until a burst test says the 7-day taper is independent. This PR is **workflow_dispatch only**.

## How to test

1. Create an **Agentic** API key (assigned seat) and store it as repo secret `CODERABBIT_API_KEY`.
2. Actions → **CodeRabbit CLI review** → Run workflow → PR number (this PR or another).
3. The job posts a file-level summary comment. `review_skipped` is success.

Burst test (scratch repo, ten minutes + a look tomorrow) is still the check before enabling push. Usage-based add-on stays an owner billing decision.

Made-with: Grok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered automated code review workflow for pull requests.
  * Review results can be posted as file-level comments with actionable guidance.
  * Supports successful handling of skipped, empty, and findings without line ranges.
* **Bug Fixes**
  * Filters non-actionable heartbeat events from review results.
* **Tests**
  * Added coverage for review parsing, report formatting, and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->