### PR TITLE
hooks: drop inherited PFB_ALLOW_HOST before the pre-commit PHP gates

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -274,6 +274,10 @@ if [ "$staged_php" = 1 ]; then
 	# is nothing to gain from grading syntax and sniffs against it. An unreachable
 	# container is a FAILED gate here, not a skip: a skipped gate reads greener than a
 	# failed one, so an unreachable image blocks the commit until it is reachable.
+	# The wrapper honours PFB_ALLOW_HOST, and that variable is commonly left exported by
+	# an ad-hoc run, direnv, or an agent shell -- so drop it here, exactly as
+	# scripts/agent/run-gates.sh does; the escape hatch stays on the wrapper for ad-hoc use.
+	unset PFB_ALLOW_HOST
 
 	# php -l syntax check (output shown only for files that fail). One container
 	# invocation for the whole tree, not one per file.

--- a/tests/shell/precommit_ci_image_spec.sh
+++ b/tests/shell/precommit_ci_image_spec.sh
@@ -73,6 +73,20 @@ Describe '.githooks/pre-commit PHP gates in the CI image'
     The stderr should not include 'skipped (tool not found)'
   End
 
+  It 'drops an inherited PFB_ALLOW_HOST so the PHP gates cannot silently grade on host PHP'
+    # The wrapper honours PFB_ALLOW_HOST by design, and that variable is commonly left
+    # exported by an ad-hoc run, direnv, or an agent shell. run-gates.sh drops it for
+    # the same reason (#2350); the hook's PHP block must too, or the "never against a
+    # host PHP" comment above the gates is a lie whenever the container is unreachable.
+    printf '#!/bin/sh\nprintf "allow_host=%%s\\n" "${PFB_ALLOW_HOST:-unset}"\nexit 0\n' \
+      > "$repo/scripts/run-in-docker.sh"
+    chmod +x "$repo/scripts/run-in-docker.sh"
+    When run sh -c "cd '$repo' && PFB_ALLOW_HOST=1 sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include 'allow_host=unset'
+    The output should not include 'allow_host=1'
+  End
+
   It 'still blocks the PHP gates when the Composer vendor guard fails'
     # The guard is fail-closed and ordered before the style gates; routing them through
     # the image must not reorder that.


### PR DESCRIPTION
## Summary

Residual of #2350 (reopened 2026-08-15): `.githooks/pre-commit` routed its PHP gates through `scripts/run-in-docker.sh` but never dropped an inherited `PFB_ALLOW_HOST`, so with the variable exported (ad-hoc run, direnv, agent shell) and no reachable container, `php -l` / PHPCS silently graded against host PHP — the exact mode `run-gates.sh` already closes with `unset PFB_ALLOW_HOST`.

- `.githooks/pre-commit`: `unset PFB_ALLOW_HOST` at the top of the PHP-gate block, same rationale comment as `run-gates.sh`. Escape hatch stays on the wrapper for ad-hoc use.
- `tests/shell/precommit_ci_image_spec.sh`: new example runs the real hook with `PFB_ALLOW_HOST=1` against a wrapper stub that echoes `allow_host=<value>`; asserts `allow_host=unset` and never `allow_host=1`.

## Evidence

Red (untouched hook), frozen test hash `61da302d1107d59948a63dbe3073a50a2f7920a6`:

```
1.2) The output should not include allow_host=1
   ... [pre-commit] php -l / allow_host=1 / [pre-commit] phpcs / allow_host=1
4 examples, 1 failure
```

Green (same hash, zero test edits): `4 examples, 0 failures`.
Mutation (replace `unset PFB_ALLOW_HOST` with `:`): `4 examples, 1 failure`.
`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (in the CI image).

Fixes #2350

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pre-commit validation to consistently use the intended PHP environment, even when host-PHP overrides are configured.

- **Tests**
  - Added regression coverage to verify that inherited host-PHP settings cannot affect Docker-based validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->