### PR TITLE
image-upgrade: fail the --upgrade-pkgs refresh closed on any FreeBSD ABI/major drift

### DIFF
--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -291,6 +291,43 @@ ssh_guest() {
     fi
 }
 
+# pfb_pkg_update_retry BEGIN
+# pfb_pkg_update_retry LOGFILE CONTEXT — refresh the pkg catalogue (`pkg update
+# -f`), retrying while pkg reports its own database busy/locked and dying on
+# any other failure. Shared by the --branch path and the --upgrade-pkgs path so
+# both honour the same PKG_LOCK_RETRIES/PKG_LOCK_INTERVAL knobs and fail
+# identically on a stuck lock or a genuine refresh error. CONTEXT names the
+# caller in the non-lock failure message.
+pfb_pkg_update_retry() {
+    _pkr_log="$1"; _pkr_context="$2"
+    true > "$_pkr_log"
+    _pkr_retries="${PKG_LOCK_RETRIES:-12}"
+    _pkr_interval="${PKG_LOCK_INTERVAL:-5}"
+    case "$_pkr_retries" in '' | *[!0-9]*) _pkr_retries=0 ;; esac
+    [ "$_pkr_retries" -ge 1 ] || die "PKG_LOCK_RETRIES must be a positive integer"
+    [ "$_pkr_retries" -le 12 ] || die "PKG_LOCK_RETRIES must be between 1 and 12"
+    case "$_pkr_interval" in *[!0-9]*) die "PKG_LOCK_INTERVAL must be a non-negative integer" ;; esac
+    [ "$_pkr_interval" -le 5 ] || die "PKG_LOCK_INTERVAL must be between 0 and 5"
+    _pkr_try=1
+    while true; do
+        _pkr_rc=0
+        _pkr_out=$(ssh_guest 'pkg update -f' 2>&1) || _pkr_rc=$?
+        printf '%s\n' "$_pkr_out" | tee -a "$_pkr_log"
+        [ "$_pkr_rc" -eq 0 ] && return 0
+        case "$_pkr_out" in
+            *'Cannot get an exclusive lock on a database'* | *'Package database is busy'*) ;;
+            *) die "pkg catalogue refresh failed after ${_pkr_context} (see $_pkr_log)" ;;
+        esac
+        if [ "$_pkr_try" -ge "$_pkr_retries" ]; then
+            die "pkg catalogue refresh still locked after ${_pkr_retries} attempts (see $_pkr_log)"
+        fi
+        warn "pkg catalogue refresh: pkg database locked; retry ${_pkr_try}/${_pkr_retries} in ${_pkr_interval}s"
+        _pkr_try=$((_pkr_try + 1))
+        sleep "$_pkr_interval"
+    done
+}
+# pfb_pkg_update_retry END
+
 # pfb_switch_branch BEGIN
 # pfb_switch_branch NAME LOG_DIR — validate NAME against Netgate's live branch
 # catalogue, then persist and apply it through pfSense's supported config path.
@@ -336,32 +373,7 @@ pfb_switch_branch() {
     fi
 
     log "branch switch confirmed — refreshing pkg catalogue (pkg update -f)"
-    _psb_pkg_log="${_psb_log_dir}/pkg-update-branch.log"
-    true > "$_psb_pkg_log"
-    _psb_retries="${PKG_LOCK_RETRIES:-12}"
-    _psb_interval="${PKG_LOCK_INTERVAL:-5}"
-    case "$_psb_retries" in '' | *[!0-9]*) _psb_retries=0 ;; esac
-    [ "$_psb_retries" -ge 1 ] || die "PKG_LOCK_RETRIES must be a positive integer"
-    [ "$_psb_retries" -le 12 ] || die "PKG_LOCK_RETRIES must be between 1 and 12"
-    case "$_psb_interval" in *[!0-9]*) die "PKG_LOCK_INTERVAL must be a non-negative integer" ;; esac
-    [ "$_psb_interval" -le 5 ] || die "PKG_LOCK_INTERVAL must be between 0 and 5"
-    _psb_try=1
-    while true; do
-        _psb_rc=0
-        _psb_out=$(ssh_guest 'pkg update -f' 2>&1) || _psb_rc=$?
-        printf '%s\n' "$_psb_out" | tee -a "$_psb_pkg_log"
-        [ "$_psb_rc" -eq 0 ] && return 0
-        case "$_psb_out" in
-            *'Cannot get an exclusive lock on a database'* | *'Package database is busy'*) ;;
-            *) die "pkg catalogue refresh failed after branch switch (see $_psb_pkg_log)" ;;
-        esac
-        if [ "$_psb_try" -ge "$_psb_retries" ]; then
-            die "pkg catalogue refresh still locked after ${_psb_retries} attempts (see $_psb_pkg_log)"
-        fi
-        warn "pkg catalogue refresh: pkg database locked; retry ${_psb_try}/${_psb_retries} in ${_psb_interval}s"
-        _psb_try=$((_psb_try + 1))
-        sleep "$_psb_interval"
-    done
+    pfb_pkg_update_retry "${_psb_log_dir}/pkg-update-branch.log" "branch switch"
 }
 # pfb_switch_branch END
 
@@ -435,6 +447,48 @@ pfb_pkg_refresh_verdict() {
     printf '%s\n' fail-closed
 }
 # pfb_pkg_refresh_verdict END
+
+# pfb_refresh_pkgs BEGIN
+# pfb_refresh_pkgs LOG_DIR — --upgrade-pkgs body, extracted verbatim (today's
+# semantics, unchanged) so the spec can drive it directly. Sets the global
+# PKG_WAS_UPGRADED (0 up to date, 1 after an applied upgrade).
+pfb_refresh_pkgs() {
+    _prp_log_dir="$1"
+
+    log "refreshing package catalogue (pkg update -f)"
+    # pkg update may print output; connection stays up (not a reboot command).
+    ssh_guest 'pkg update -f' 2>&1 | tee "${_prp_log_dir}/pkg-update.log" || true
+
+    # Dry-run detect: pkg prints "Your packages are up to date" when nothing is
+    # pending; otherwise it prints an upgrade plan (Number of packages to be
+    # upgraded / to be installed / to be reinstalled, etc.).  Parse the output —
+    # do NOT rely solely on exit code, as pkg(8) exit semantics vary by version.
+    log "checking for pending package upgrades (pkg upgrade -n)"
+    _prp_dry=$(ssh_guest 'pkg upgrade -n' 2>&1 | tee "${_prp_log_dir}/pkg-upgrade-dryrun.log" || true)
+    _prp_verdict=$(pfb_pkg_refresh_verdict "$_prp_dry")
+    if [ "$_prp_verdict" = up-to-date ]; then
+        log "packages already up to date — skipping pkg upgrade + reboot"
+        PKG_WAS_UPGRADED=0
+    elif [ "$_prp_verdict" = fail-closed ]; then
+        die "pkg upgrade -n did not report a plan or an up-to-date result (see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
+    else
+        log "package upgrades pending — running pkg upgrade -y"
+        # Do not pipe: tee's 0 would hide a failed apply (#1844 same class).
+        if ! ssh_guest 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y' >"${_prp_log_dir}/pkg-upgrade.log" 2>&1; then
+            cat "${_prp_log_dir}/pkg-upgrade.log"
+            die "pkg upgrade -y failed (see ${_prp_log_dir}/pkg-upgrade.log)"
+        fi
+        cat "${_prp_log_dir}/pkg-upgrade.log"
+        log "rebooting after pkg upgrade"
+        # /sbin/reboot drops the connection — expected; ignore the exit code.
+        ssh_guest '/sbin/reboot' 2>/dev/null || true
+        log "waiting for SSH after pkg-upgrade reboot..."
+        wait_guest_ssh 300
+        log "box is back after pkg-upgrade reboot"
+        PKG_WAS_UPGRADED=1
+    fi
+}
+# pfb_refresh_pkgs END
 
 # pfb_publish_decision BEGIN
 # PKG_WAS_UPGRADED OLD_VER POST_VER CHECK_CURRENT(0|1) -> skip-os | run-os | nothing-to-publish | fail-closed
@@ -709,38 +763,7 @@ log "current version on box: ${OLD_VER:-unknown}"
 # --- optional: upgrade baked deps (pkg update -f + conditional pkg upgrade) -
 PKG_WAS_UPGRADED=0
 if [ "$UPGRADE_PKGS" -eq 1 ]; then
-    log "refreshing package catalogue (pkg update -f)"
-    # pkg update may print output; connection stays up (not a reboot command).
-    ssh_guest 'pkg update -f' 2>&1 | tee "$LOCAL_DIR/pkg-update.log" || true
-
-    # Dry-run detect: pkg prints "Your packages are up to date" when nothing is
-    # pending; otherwise it prints an upgrade plan (Number of packages to be
-    # upgraded / to be installed / to be reinstalled, etc.).  Parse the output —
-    # do NOT rely solely on exit code, as pkg(8) exit semantics vary by version.
-    log "checking for pending package upgrades (pkg upgrade -n)"
-    _pkg_dry=$(ssh_guest 'pkg upgrade -n' 2>&1 | tee "$LOCAL_DIR/pkg-upgrade-dryrun.log" || true)
-    _pkg_verdict=$(pfb_pkg_refresh_verdict "$_pkg_dry")
-    if [ "$_pkg_verdict" = up-to-date ]; then
-        log "packages already up to date — skipping pkg upgrade + reboot"
-        PKG_WAS_UPGRADED=0
-    elif [ "$_pkg_verdict" = fail-closed ]; then
-        die "pkg upgrade -n did not report a plan or an up-to-date result (see $LOCAL_DIR/pkg-upgrade-dryrun.log)"
-    else
-        log "package upgrades pending — running pkg upgrade -y"
-        # Do not pipe: tee's 0 would hide a failed apply (#1844 same class).
-        if ! ssh_guest 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y' >"$LOCAL_DIR/pkg-upgrade.log" 2>&1; then
-            cat "$LOCAL_DIR/pkg-upgrade.log"
-            die "pkg upgrade -y failed (see $LOCAL_DIR/pkg-upgrade.log)"
-        fi
-        cat "$LOCAL_DIR/pkg-upgrade.log"
-        log "rebooting after pkg upgrade"
-        # /sbin/reboot drops the connection — expected; ignore the exit code.
-        ssh_guest '/sbin/reboot' 2>/dev/null || true
-        log "waiting for SSH after pkg-upgrade reboot..."
-        wait_guest_ssh 300
-        log "box is back after pkg-upgrade reboot"
-        PKG_WAS_UPGRADED=1
-    fi
+    pfb_refresh_pkgs "$LOCAL_DIR"
 fi
 
 # --- optional: switch the pfSense update branch ----------------------------

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -594,10 +594,16 @@ pfb_refresh_pkgs() {
     # The box-level ABI/kernel check above is not enough: pkg upgrade -y can
     # install a foreign-major package without moving the box's own reported
     # ABI/kernel major, so sweep every installed package's ABI directly.
-    _prp_pkg_abis=$(ssh_guest '/usr/local/sbin/pkg query "%n %q"' 2>/dev/null | tr -d '\r')
+    _prp_query_rc=0
+    _prp_pkg_abis=$(ssh_guest '/usr/local/sbin/pkg query "%n %q"' 2>/dev/null) || _prp_query_rc=$?
+    _prp_pkg_abis=$(printf '%s\n' "$_prp_pkg_abis" | tr -d '\r')
+    [ "$_prp_query_rc" -eq 0 ] \
+        || die "pkg query of installed package ABIs failed (rc=${_prp_query_rc}) after pkg-upgrade reboot — refusing to trust a partial list (issue #2299)"
     [ -n "$_prp_pkg_abis" ] \
         || die "could not read installed package ABIs after pkg-upgrade reboot (issue #2299)"
-    _prp_bad_abis=$(printf '%s\n' "$_prp_pkg_abis" | awk -v want="$_prp_abi0_major" '{ split($2, a, ":"); if (a[2] != want) print }')
+    # A fully wildcarded ABI (FreeBSD:*:*) is arch- and major-independent; blank
+    # lines are not packages.
+    _prp_bad_abis=$(printf '%s\n' "$_prp_pkg_abis" | awk -v want="$_prp_abi0_major" 'NF { split($2, a, ":"); if (a[2] != want && a[2] != "*") print }')
     if [ -n "$_prp_bad_abis" ]; then
         die "installed package(s) report a foreign FreeBSD ABI major after pkg-upgrade reboot (base ${_prp_abi0_major}; issue #2299): $(printf '%s\n' "$_prp_bad_abis" | head -n 10)"
     fi

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -472,6 +472,20 @@ pfb_kern_major() {
 # pfb_kern_major END
 
 # pfb_refresh_pkgs BEGIN
+# pfb_refuse_foreign_major TEXT BASE_MAJOR WHAT LOG — die when TEXT names any
+# FreeBSD:<major>: token whose major is not BASE_MAJOR. Applied to the dry-run
+# plan AND the applied -y log: an outdated pkg binary restricts the dry-run to
+# pkg's own self-upgrade, so a foreign-major listing can first appear in either.
+pfb_refuse_foreign_major() {
+    _prf_text=$1; _prf_base=$2; _prf_what=$3; _prf_log=$4
+    for _prf_tok in $(printf '%s\n' "$_prf_text" | grep -oE 'FreeBSD:[0-9]+:'); do
+        _prf_major=$(printf '%s' "$_prf_tok" | cut -d: -f2)
+        if [ "$_prf_major" != "$_prf_base" ]; then
+            die "${_prf_what} references FreeBSD:${_prf_major}: (base is FreeBSD:${_prf_base}:) — refusing to continue (issue #2299; see ${_prf_log})"
+        fi
+    done
+}
+
 # pfb_refresh_pkgs LOG_DIR — --upgrade-pkgs body: refresh the pkg catalogue and
 # apply any pending upgrade, gated on the FreeBSD ABI/kernel major staying put
 # throughout. The same-version daily refresh (image-refresh.yml, from==to) is
@@ -533,12 +547,7 @@ pfb_refresh_pkgs() {
     # just LIST a foreign-major package (an outdated pkg binary restricts the
     # dry-run to pkg's own self-upgrade, masking the real plan until -y
     # re-execs) — so scan every FreeBSD:<major>: token in the plan too.
-    for _prp_tok in $(printf '%s\n' "$_prp_dry" | grep -oE 'FreeBSD:[0-9]+:'); do
-        _prp_tok_major=$(printf '%s' "$_prp_tok" | cut -d: -f2)
-        if [ "$_prp_tok_major" != "$_prp_abi0_major" ]; then
-            die "pkg upgrade -n plan references FreeBSD:${_prp_tok_major}: (base is FreeBSD:${_prp_abi0_major}:) — refusing to continue (issue #2299; see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
-        fi
-    done
+    pfb_refuse_foreign_major "$_prp_dry" "$_prp_abi0_major" "pkg upgrade -n plan" "${_prp_log_dir}/pkg-upgrade-dryrun.log"
     _prp_verdict=$(pfb_pkg_refresh_verdict "$_prp_dry")
 
     if [ "$_prp_verdict" = up-to-date ]; then
@@ -566,6 +575,7 @@ pfb_refresh_pkgs() {
             die "pkg upgrade -y reports a FreeBSD major crossing (issue #2299; see ${_prp_log_dir}/pkg-upgrade.log)"
             ;;
     esac
+    pfb_refuse_foreign_major "$(cat "${_prp_log_dir}/pkg-upgrade.log")" "$_prp_abi0_major" "pkg upgrade -y log" "${_prp_log_dir}/pkg-upgrade.log"
     log "rebooting after pkg upgrade"
     # /sbin/reboot drops the connection — expected; ignore the exit code.
     ssh_guest '/sbin/reboot' 2>/dev/null || true

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -299,8 +299,9 @@ ssh_guest() {
 # -f`), retrying while pkg reports its own database busy/locked and dying on
 # any other failure. Shared by the --branch path and the --upgrade-pkgs path so
 # both honour the same PKG_LOCK_RETRIES/PKG_LOCK_INTERVAL knobs and fail
-# identically on a stuck lock or a genuine refresh error. CONTEXT names the
-# caller in the non-lock failure message.
+# identically on a stuck lock or a genuine refresh error. CONTEXT is inserted
+# verbatim after "failed" in the non-lock failure message and carries its own
+# preposition (e.g. "after branch switch", "during --upgrade-pkgs").
 pfb_pkg_update_retry() {
     _pkr_log="$1"; _pkr_context="$2"
     true > "$_pkr_log"
@@ -319,7 +320,7 @@ pfb_pkg_update_retry() {
         [ "$_pkr_rc" -eq 0 ] && return 0
         case "$_pkr_out" in
             *'Cannot get an exclusive lock on a database'* | *'Package database is busy'*) ;;
-            *) die "pkg catalogue refresh failed after ${_pkr_context} (see $_pkr_log)" ;;
+            *) die "pkg catalogue refresh failed ${_pkr_context} (see $_pkr_log)" ;;
         esac
         if [ "$_pkr_try" -ge "$_pkr_retries" ]; then
             die "pkg catalogue refresh still locked after ${_pkr_retries} attempts (see $_pkr_log)"
@@ -376,7 +377,7 @@ pfb_switch_branch() {
     fi
 
     log "branch switch confirmed — refreshing pkg catalogue (pkg update -f)"
-    pfb_pkg_update_retry "${_psb_log_dir}/pkg-update-branch.log" "branch switch"
+    pfb_pkg_update_retry "${_psb_log_dir}/pkg-update-branch.log" "after branch switch"
 }
 # pfb_switch_branch END
 
@@ -454,9 +455,10 @@ pfb_pkg_refresh_verdict() {
 # pfb_abi_major BEGIN
 # pfb_abi_major ABI — the FreeBSD major from `pkg config ABI` output
 # (FreeBSD:MAJOR:arch, e.g. FreeBSD:16:amd64 -> 16); empty when ABI carries no
-# second `:`-field (unset/garbled pkg config output — caller fails closed).
+# second `:`-field, or that field is not all-digits (unset/garbled pkg config
+# output — caller fails closed).
 pfb_abi_major() {
-    printf '%s\n' "$1" | awk -F: '{ print $2 }'
+    printf '%s\n' "$1" | awk -F: '$2 ~ /^[0-9]+$/ { print $2 }'
 }
 # pfb_abi_major END
 
@@ -476,23 +478,34 @@ pfb_kern_major() {
 # the one path that runs unattended with nobody watching the plan; letting it
 # swallow a repo-flip-driven ABI change (issue #2242) or a pkg-reported major
 # crossing installs foreign-major packages onto the running tag (issue #2299).
+# uname -r is the reference because it is the ALREADY-BOOTED kernel's major;
+# libpkg's own version is not snapshotted here — its package ABI is covered by
+# the post-reboot `pkg query '%n %q'` sweep below.
 # Sets the global PKG_WAS_UPGRADED (0 up to date, 1 after an applied upgrade).
 pfb_refresh_pkgs() {
     _prp_log_dir="$1"
 
-    _prp_abi0=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>&1 | tr -d '\r')
+    # 2>/dev/null + last-non-empty-line: ssh_guest always prints its
+    # known-hosts warning on stderr, and a foreign-major pkg binary warns on
+    # stderr too — either would corrupt a `2>&1` capture into a multi-line
+    # value (issue #2299).
+    _prp_abi0=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>/dev/null | tr -d '\r' | awk 'NF { v = $0 } END { print v }')
     _prp_abi0_major=$(pfb_abi_major "$_prp_abi0")
     [ -n "$_prp_abi0_major" ] \
         || die "could not read pkg ABI before pkg update -f (got: ${_prp_abi0:-<empty>})"
-    _prp_kern0=$(ssh_guest 'uname -r' 2>&1 | tr -d '\r')
+    _prp_kern0=$(ssh_guest 'uname -r' 2>/dev/null | tr -d '\r' | awk 'NF { v = $0 } END { print v }')
     _prp_kern0_major=$(pfb_kern_major "$_prp_kern0")
     [ -n "$_prp_kern0_major" ] \
         || die "could not read kernel version before pkg update -f (got: ${_prp_kern0:-<empty>})"
+    # Catch an already-mismatched box (e.g. a prior repo flip) before touching
+    # pkg at all — pkg update -f is not the place to discover it.
+    [ "$_prp_abi0_major" = "$_prp_kern0_major" ] \
+        || die "pkg ABI ${_prp_abi0} does not match kernel ${_prp_kern0} before pkg update -f — refusing to continue (issue #2299)"
 
     log "refreshing package catalogue (pkg update -f)"
-    pfb_pkg_update_retry "${_prp_log_dir}/pkg-update.log" "pkg refresh"
+    pfb_pkg_update_retry "${_prp_log_dir}/pkg-update.log" "during --upgrade-pkgs"
 
-    _prp_abi1=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>&1 | tr -d '\r')
+    _prp_abi1=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>/dev/null | tr -d '\r' | awk 'NF { v = $0 } END { print v }')
     _prp_abi1_major=$(pfb_abi_major "$_prp_abi1")
     [ -n "$_prp_abi1_major" ] \
         || die "could not read pkg ABI after pkg update -f (got: ${_prp_abi1:-<empty>})"
@@ -503,20 +516,30 @@ pfb_refresh_pkgs() {
     # Dry-run detect: pkg prints "Your packages are up to date" when nothing is
     # pending; otherwise it prints an upgrade plan, or — the case this gate
     # exists for — a FreeBSD major-crossing refusal. Parse the output; do NOT
-    # rely solely on exit code, pkg(8) exit semantics vary by version.
+    # rely solely on exit code: real pkg(8) exits 1 whenever a plan is PENDING
+    # (upstream pkg.c: dry_run -> rc=false) and 0 only when up to date, so a
+    # pending plan's rc=1 is normal, not a failure.
     log "checking for pending package upgrades (pkg upgrade -n)"
     _prp_dry_rc=0
     _prp_dry=$(ssh_guest 'pkg upgrade -n' 2>&1) || _prp_dry_rc=$?
     printf '%s\n' "$_prp_dry" | tee "${_prp_log_dir}/pkg-upgrade-dryrun.log"
     case "$_prp_dry" in
-        *'Major OS version upgrade detected'* | *'wrong architecture'*)
+        *'Major OS version upgrade detected'* | *'wrong architecture'* | \
+        *'Newer FreeBSD version'* | *'IGNORE_OSVERSION'*)
             die "pkg upgrade -n reports a FreeBSD major crossing (issue #2299; see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
             ;;
     esac
+    # The phrase gate above only catches pkg's own wording; a plan can also
+    # just LIST a foreign-major package (an outdated pkg binary restricts the
+    # dry-run to pkg's own self-upgrade, masking the real plan until -y
+    # re-execs) — so scan every FreeBSD:<major>: token in the plan too.
+    for _prp_tok in $(printf '%s\n' "$_prp_dry" | grep -oE 'FreeBSD:[0-9]+:'); do
+        _prp_tok_major=$(printf '%s' "$_prp_tok" | cut -d: -f2)
+        if [ "$_prp_tok_major" != "$_prp_abi0_major" ]; then
+            die "pkg upgrade -n plan references FreeBSD:${_prp_tok_major}: (base is FreeBSD:${_prp_abi0_major}:) — refusing to continue (issue #2299; see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
+        fi
+    done
     _prp_verdict=$(pfb_pkg_refresh_verdict "$_prp_dry")
-    if [ "$_prp_verdict" != up-to-date ] && [ "$_prp_dry_rc" -ne 0 ]; then
-        die "pkg upgrade -n failed (rc=${_prp_dry_rc}; see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
-    fi
 
     if [ "$_prp_verdict" = up-to-date ]; then
         log "packages already up to date — skipping pkg upgrade + reboot"
@@ -524,7 +547,7 @@ pfb_refresh_pkgs() {
         return 0
     fi
     if [ "$_prp_verdict" = fail-closed ]; then
-        die "pkg upgrade -n did not report a plan or an up-to-date result (see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
+        die "pkg upgrade -n did not report a plan or an up-to-date result (rc=${_prp_dry_rc}; see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
     fi
 
     log "package upgrades pending — running pkg upgrade -y"
@@ -534,6 +557,15 @@ pfb_refresh_pkgs() {
         die "pkg upgrade -y failed (see ${_prp_log_dir}/pkg-upgrade.log)"
     fi
     cat "${_prp_log_dir}/pkg-upgrade.log"
+    # The real cross-major plan can surface only here (pkg self-upgraded and
+    # re-exec'd under -y) — scan the applied log for the same phrases, before
+    # the reboot that would otherwise commit a foreign-major install.
+    case "$(cat "${_prp_log_dir}/pkg-upgrade.log")" in
+        *'Major OS version upgrade detected'* | *'wrong architecture'* | \
+        *'Newer FreeBSD version'* | *'IGNORE_OSVERSION'*)
+            die "pkg upgrade -y reports a FreeBSD major crossing (issue #2299; see ${_prp_log_dir}/pkg-upgrade.log)"
+            ;;
+    esac
     log "rebooting after pkg upgrade"
     # /sbin/reboot drops the connection — expected; ignore the exit code.
     ssh_guest '/sbin/reboot' 2>/dev/null || true
@@ -541,12 +573,23 @@ pfb_refresh_pkgs() {
     wait_guest_ssh 300
     log "box is back after pkg-upgrade reboot"
 
-    _prp_abi2=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>&1 | tr -d '\r')
+    _prp_abi2=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>/dev/null | tr -d '\r' | awk 'NF { v = $0 } END { print v }')
     _prp_abi2_major=$(pfb_abi_major "$_prp_abi2")
-    _prp_kern2=$(ssh_guest 'uname -r' 2>&1 | tr -d '\r')
+    _prp_kern2=$(ssh_guest 'uname -r' 2>/dev/null | tr -d '\r' | awk 'NF { v = $0 } END { print v }')
     _prp_kern2_major=$(pfb_kern_major "$_prp_kern2")
     if [ "$_prp_abi2_major" != "$_prp_abi0_major" ] || [ "$_prp_abi2_major" != "$_prp_kern2_major" ]; then
         die "pkg ABI ${_prp_abi2} (kernel ${_prp_kern2}) after pkg-upgrade reboot, was ${_prp_abi0} — refusing to continue (issue #2299)"
+    fi
+
+    # The box-level ABI/kernel check above is not enough: pkg upgrade -y can
+    # install a foreign-major package without moving the box's own reported
+    # ABI/kernel major, so sweep every installed package's ABI directly.
+    _prp_pkg_abis=$(ssh_guest '/usr/local/sbin/pkg query "%n %q"' 2>/dev/null | tr -d '\r')
+    [ -n "$_prp_pkg_abis" ] \
+        || die "could not read installed package ABIs after pkg-upgrade reboot (issue #2299)"
+    _prp_bad_abis=$(printf '%s\n' "$_prp_pkg_abis" | awk -v want="$_prp_abi0_major" '{ split($2, a, ":"); if (a[2] != want) print }')
+    if [ -n "$_prp_bad_abis" ]; then
+        die "installed package(s) report a foreign FreeBSD ABI major after pkg-upgrade reboot (base ${_prp_abi0_major}; issue #2299): $(printf '%s\n' "$_prp_bad_abis" | head -n 10)"
     fi
 
     PKG_WAS_UPGRADED=1

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -104,6 +104,9 @@
 #                    Default OFF; pass this flag to enable. build-image.yml does NOT
 #                    pass this flag (it calls this script directly), so callers that
 #                    only want the pfSense-upgrade step are unaffected.
+#                    Fail-closed (issue #2299): pkg's ABI and the kernel's FreeBSD
+#                    major must stay put across the refresh; a plan that crosses a
+#                    major, or a failed pkg update/upgrade, aborts the run.
 #   --branch NAME    switch the pfSense update branch to NAME before running the OS
 #                    upgrade. pfSense stores the selected branch in config.xml key
 #                    system/pkg_repo_conf_path; applying the change calls

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -448,45 +448,105 @@ pfb_pkg_refresh_verdict() {
 }
 # pfb_pkg_refresh_verdict END
 
+# pfb_abi_major BEGIN
+# pfb_abi_major ABI — the FreeBSD major from `pkg config ABI` output
+# (FreeBSD:MAJOR:arch, e.g. FreeBSD:16:amd64 -> 16); empty when ABI carries no
+# second `:`-field (unset/garbled pkg config output — caller fails closed).
+pfb_abi_major() {
+    printf '%s\n' "$1" | awk -F: '{ print $2 }'
+}
+# pfb_abi_major END
+
+# pfb_kern_major BEGIN
+# pfb_kern_major UNAME_R — the text before the first `.` in `uname -r` (e.g.
+# 15.0-RELEASE -> 15). A value with no dot (e.g. 15-STABLE) is returned whole,
+# so it fails a major-version compare instead of coincidentally matching.
+pfb_kern_major() {
+    printf '%s\n' "$1" | cut -d. -f1
+}
+# pfb_kern_major END
+
 # pfb_refresh_pkgs BEGIN
-# pfb_refresh_pkgs LOG_DIR — --upgrade-pkgs body, extracted verbatim (today's
-# semantics, unchanged) so the spec can drive it directly. Sets the global
-# PKG_WAS_UPGRADED (0 up to date, 1 after an applied upgrade).
+# pfb_refresh_pkgs LOG_DIR — --upgrade-pkgs body: refresh the pkg catalogue and
+# apply any pending upgrade, gated on the FreeBSD ABI/kernel major staying put
+# throughout. The same-version daily refresh (image-refresh.yml, from==to) is
+# the one path that runs unattended with nobody watching the plan; letting it
+# swallow a repo-flip-driven ABI change (issue #2242) or a pkg-reported major
+# crossing installs foreign-major packages onto the running tag (issue #2299).
+# Sets the global PKG_WAS_UPGRADED (0 up to date, 1 after an applied upgrade).
 pfb_refresh_pkgs() {
     _prp_log_dir="$1"
 
+    _prp_abi0=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>&1 | tr -d '\r')
+    _prp_abi0_major=$(pfb_abi_major "$_prp_abi0")
+    [ -n "$_prp_abi0_major" ] \
+        || die "could not read pkg ABI before pkg update -f (got: ${_prp_abi0:-<empty>})"
+    _prp_kern0=$(ssh_guest 'uname -r' 2>&1 | tr -d '\r')
+    _prp_kern0_major=$(pfb_kern_major "$_prp_kern0")
+    [ -n "$_prp_kern0_major" ] \
+        || die "could not read kernel version before pkg update -f (got: ${_prp_kern0:-<empty>})"
+
     log "refreshing package catalogue (pkg update -f)"
-    # pkg update may print output; connection stays up (not a reboot command).
-    ssh_guest 'pkg update -f' 2>&1 | tee "${_prp_log_dir}/pkg-update.log" || true
+    pfb_pkg_update_retry "${_prp_log_dir}/pkg-update.log" "pkg refresh"
+
+    _prp_abi1=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>&1 | tr -d '\r')
+    _prp_abi1_major=$(pfb_abi_major "$_prp_abi1")
+    [ -n "$_prp_abi1_major" ] \
+        || die "could not read pkg ABI after pkg update -f (got: ${_prp_abi1:-<empty>})"
+    if [ "$_prp_abi1_major" != "$_prp_abi0_major" ]; then
+        die "pkg ABI ${_prp_abi1} after pkg update -f, was ${_prp_abi0} — refusing to continue (issue #2299)"
+    fi
 
     # Dry-run detect: pkg prints "Your packages are up to date" when nothing is
-    # pending; otherwise it prints an upgrade plan (Number of packages to be
-    # upgraded / to be installed / to be reinstalled, etc.).  Parse the output —
-    # do NOT rely solely on exit code, as pkg(8) exit semantics vary by version.
+    # pending; otherwise it prints an upgrade plan, or — the case this gate
+    # exists for — a FreeBSD major-crossing refusal. Parse the output; do NOT
+    # rely solely on exit code, pkg(8) exit semantics vary by version.
     log "checking for pending package upgrades (pkg upgrade -n)"
-    _prp_dry=$(ssh_guest 'pkg upgrade -n' 2>&1 | tee "${_prp_log_dir}/pkg-upgrade-dryrun.log" || true)
+    _prp_dry_rc=0
+    _prp_dry=$(ssh_guest 'pkg upgrade -n' 2>&1) || _prp_dry_rc=$?
+    printf '%s\n' "$_prp_dry" | tee "${_prp_log_dir}/pkg-upgrade-dryrun.log"
+    case "$_prp_dry" in
+        *'Major OS version upgrade detected'* | *'wrong architecture'*)
+            die "pkg upgrade -n reports a FreeBSD major crossing (issue #2299; see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
+            ;;
+    esac
     _prp_verdict=$(pfb_pkg_refresh_verdict "$_prp_dry")
+    if [ "$_prp_verdict" != up-to-date ] && [ "$_prp_dry_rc" -ne 0 ]; then
+        die "pkg upgrade -n failed (rc=${_prp_dry_rc}; see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
+    fi
+
     if [ "$_prp_verdict" = up-to-date ]; then
         log "packages already up to date — skipping pkg upgrade + reboot"
         PKG_WAS_UPGRADED=0
-    elif [ "$_prp_verdict" = fail-closed ]; then
-        die "pkg upgrade -n did not report a plan or an up-to-date result (see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
-    else
-        log "package upgrades pending — running pkg upgrade -y"
-        # Do not pipe: tee's 0 would hide a failed apply (#1844 same class).
-        if ! ssh_guest 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y' >"${_prp_log_dir}/pkg-upgrade.log" 2>&1; then
-            cat "${_prp_log_dir}/pkg-upgrade.log"
-            die "pkg upgrade -y failed (see ${_prp_log_dir}/pkg-upgrade.log)"
-        fi
-        cat "${_prp_log_dir}/pkg-upgrade.log"
-        log "rebooting after pkg upgrade"
-        # /sbin/reboot drops the connection — expected; ignore the exit code.
-        ssh_guest '/sbin/reboot' 2>/dev/null || true
-        log "waiting for SSH after pkg-upgrade reboot..."
-        wait_guest_ssh 300
-        log "box is back after pkg-upgrade reboot"
-        PKG_WAS_UPGRADED=1
+        return 0
     fi
+    if [ "$_prp_verdict" = fail-closed ]; then
+        die "pkg upgrade -n did not report a plan or an up-to-date result (see ${_prp_log_dir}/pkg-upgrade-dryrun.log)"
+    fi
+
+    log "package upgrades pending — running pkg upgrade -y"
+    # Do not pipe: tee's 0 would hide a failed apply (#1844 same class).
+    if ! ssh_guest 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y' >"${_prp_log_dir}/pkg-upgrade.log" 2>&1; then
+        cat "${_prp_log_dir}/pkg-upgrade.log"
+        die "pkg upgrade -y failed (see ${_prp_log_dir}/pkg-upgrade.log)"
+    fi
+    cat "${_prp_log_dir}/pkg-upgrade.log"
+    log "rebooting after pkg upgrade"
+    # /sbin/reboot drops the connection — expected; ignore the exit code.
+    ssh_guest '/sbin/reboot' 2>/dev/null || true
+    log "waiting for SSH after pkg-upgrade reboot..."
+    wait_guest_ssh 300
+    log "box is back after pkg-upgrade reboot"
+
+    _prp_abi2=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>&1 | tr -d '\r')
+    _prp_abi2_major=$(pfb_abi_major "$_prp_abi2")
+    _prp_kern2=$(ssh_guest 'uname -r' 2>&1 | tr -d '\r')
+    _prp_kern2_major=$(pfb_kern_major "$_prp_kern2")
+    if [ "$_prp_abi2_major" != "$_prp_abi0_major" ] || [ "$_prp_abi2_major" != "$_prp_kern2_major" ]; then
+        die "pkg ABI ${_prp_abi2} (kernel ${_prp_kern2}) after pkg-upgrade reboot, was ${_prp_abi0} — refusing to continue (issue #2299)"
+    fi
+
+    PKG_WAS_UPGRADED=1
 }
 # pfb_refresh_pkgs END
 

--- a/tests/shell/image_upgrade_branch_retry_config_spec.sh
+++ b/tests/shell/image_upgrade_branch_retry_config_spec.sh
@@ -25,6 +25,7 @@ Describe 'image-upgrade.sh branch refresh retry configuration'
           "pkg update -f") printf "catalogue refreshed\n" ;;
         esac
       }
+      eval "$(sed -n "/^# pfb_pkg_update_retry BEGIN/,/^# pfb_pkg_update_retry END/p" "$1")"
       eval "$(sed -n "/^# pfb_switch_branch BEGIN/,/^# pfb_switch_branch END/p" "$1")"
       PKG_LOCK_RETRIES="$_retries"
       PKG_LOCK_INTERVAL="$_interval"

--- a/tests/shell/image_upgrade_branch_spec.sh
+++ b/tests/shell/image_upgrade_branch_spec.sh
@@ -64,6 +64,7 @@ Describe 'image-upgrade.sh update-branch selection'
       # New code exposes its helper between these markers. On the old code the
       # extraction is empty and the unchanged main-flow block still executes,
       # giving a genuine RED against its pkg_list_repos() behavior.
+      eval "$(sed -n "/^# pfb_pkg_update_retry BEGIN/,/^# pfb_pkg_update_retry END/p" "$1")"
       eval "$(sed -n "/^# pfb_switch_branch BEGIN/,/^# pfb_switch_branch END/p" "$1")"
       PKG_LOCK_RETRIES=2
       PKG_LOCK_INTERVAL=0

--- a/tests/shell/image_upgrade_pkgs_refresh_spec.sh
+++ b/tests/shell/image_upgrade_pkgs_refresh_spec.sh
@@ -23,15 +23,25 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
   BeforeEach 'setup'
   AfterEach 'teardown'
 
-  # run_refresh ABI0 KERN0 DRY DRY_RC UPGRADE_RC UPDMODE ABI1 ABI2 KERN2 — drive
-  # pfb_refresh_pkgs (plus the helpers it calls) with a stub ssh_guest that
-  # answers `pkg config ABI`/`uname -r` from ABI0/KERN0 on the 1st call,
-  # ABI1 on the 2nd (post `pkg update -f`), ABI2/KERN2 on the 3rd+
-  # (post-reboot) — defaulting each unset ABI1/ABI2/KERN2 to its snapshot, so
-  # a scenario only names the values it moves. UPDMODE shapes `pkg update -f`
-  # (transient-lock / permanent-lock / other-error / unset=succeeds).
+  # run_refresh ABI0 KERN0 DRY DRY_RC UPGRADE_RC UPDMODE ABI1 ABI2 KERN2
+  #   [UPGRADE_Y_OUT] [PKG_QUERY_OUT] [NOISE] — drive pfb_refresh_pkgs (plus
+  # the helpers it calls) with a stub ssh_guest that answers `pkg config
+  # ABI`/`uname -r` from ABI0/KERN0 on the 1st call, ABI1 on the 2nd (post
+  # `pkg update -f`), ABI2/KERN2 on the 3rd+ (post-reboot) — defaulting each
+  # unset ABI1/ABI2/KERN2 to its snapshot, so a scenario only names the values
+  # it moves. UPDMODE shapes `pkg update -f` (transient-lock / permanent-lock
+  # / other-error / unset=succeeds). UPGRADE_Y_OUT overrides `pkg upgrade -y`'s
+  # stdout (default: a plain "applying upgrades" line) so a scenario can plant
+  # the FreeBSD-major phrase in the POST-`-y` log (issue #2299, F3a).
+  # PKG_QUERY_OUT overrides `pkg query "%n %q"`'s stdout (default: one package
+  # reporting ABI0, so unrelated scenarios that reach the post-reboot sweep
+  # stay green). NOISE is 'ssh-banner' (every ssh_guest call also writes the
+  # real known_hosts stderr line) or 'abi-warn' (`pkg config ABI` also writes
+  # pkg's own foreign-major stderr warning) — neither may leak into a captured
+  # value (issue #2299, F2).
   run_refresh() {
     _abi0="$1" _kern0="$2" _dry="$3" _dryrc="$4" _upgraderc="$5" _updmode="$6" _abi1="$7" _abi2="$8" _kern2="$9" \
+    _upgy_out="${10}" _pkgquery_out="${11}" _noise="${12}" \
       sh -c '
         set -e
         log()  { printf "==> %s\n" "$*"; }
@@ -44,10 +54,14 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
         : "${_kern2:=$_kern0}"
         : "${_dryrc:=0}"
         : "${_upgraderc:=0}"
+        : "${_upgy_out:=applying upgrades}"
+        : "${_pkgquery_out:=baseline-pkg $_abi0}"
         ssh_guest() {
+          [ "$_noise" = ssh-banner ] && printf "Warning: Permanently added '"'"'[127.0.0.1]:2222'"'"' (ED25519) to the list of known hosts.\n" >&2
           printf "%s\n" "$*" >> "$CALLS"
           case "$*" in
             "/usr/local/sbin/pkg config ABI")
+              [ "$_noise" = abi-warn ] && printf "pkg: Warning: Major OS version upgrade detected -- consider setting IGNORE_OSVERSION\n" >&2
               _n=$(( $(cat "$ABI_N" 2>/dev/null || echo 0) + 1 )); printf "%s" "$_n" > "$ABI_N"
               case "$_n" in
                 1) printf "%s\n" "$_abi0" ;;
@@ -84,10 +98,13 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
               return "$_dryrc"
               ;;
             "env ASSUME_ALWAYS_YES=yes pkg upgrade -y")
-              printf "%s\n" "applying upgrades"
+              printf "%s\n" "$_upgy_out"
               return "$_upgraderc"
               ;;
             "/sbin/reboot") return 0 ;;
+            '"'"'/usr/local/sbin/pkg query "%n %q"'"'"')
+              printf "%s\n" "$_pkgquery_out"
+              ;;
           esac
         }
         eval "$(sed -n "/^# pfb_abi_major BEGIN/,/^# pfb_abi_major END/p" "$1")"
@@ -112,13 +129,22 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
     The contents of file "$CALLS" should not include 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
   End
 
-  # C2
-  It 'applies a pending plan, reboots, and re-verifies ABI/kernel major after'
-    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 0 0 '' '' '' ''
+  # C2 — real pkg(8) exits 1 (not 0) whenever a dry-run plan is PENDING
+  # (upstream pkg.c: dry_run -> rc=false); rc must not gate a pending verdict.
+  It 'applies a pending plan (dry-run rc=1, real pkg semantics), reboots, and re-verifies ABI/kernel major after'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' '' ''
     The status should be success
     The output should include 'PKG_WAS_UPGRADED=1'
     The output should include 'REACHED-AFTER-REFRESH'
     The contents of file "$CALLS" should include '/sbin/reboot'
+  End
+
+  # F1: keep one row covering the rc=0 pending case too (some pkg versions).
+  It 'applies a pending plan when the dry-run exits 0 (older/other pkg semantics)'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 0 0 '' '' '' ''
+    The status should be success
+    The output should include 'PKG_WAS_UPGRADED=1'
+    The output should include 'REACHED-AFTER-REFRESH'
   End
 
   # C3
@@ -139,21 +165,76 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
     The contents of file "$CALLS" should not include 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
   End
 
+  # F3 addendum (d) — BBcan177's fixture: the plan just LISTS a foreign-major
+  # package, with none of the phrase gate's wording — must still die, before -y.
+  It 'fails closed when the dry-run plan lists a foreign-major package with no crossing phrase'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'pkg: 1.21.3 -> 2.1.0 [FreeBSD:16:amd64]' 1 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'FreeBSD:16:'
+    The stderr should include 'issue #2299'
+    The output should not include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
+  End
+
+  # F3 addendum (e) — "Newer FreeBSD version" / IGNORE_OSVERSION wording.
+  It 'fails closed when the dry-run plan asks to IGNORE_OSVERSION'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Newer FreeBSD version for package foo-1.0: to ignore this error set IGNORE_OSVERSION=yes' 1 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'FreeBSD major'
+    The output should not include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
+  End
+
   # C5
   It 'fails closed when pkg upgrade -y itself fails (no || true swallow)'
-    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 0 1 '' '' '' ''
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 1 '' '' '' ''
     The status should be failure
     The stderr should include 'pkg upgrade'
     The output should not include 'REACHED-AFTER-REFRESH'
   End
 
+  # F3a — an outdated pkg binary restricts the dry-run to pkg's own
+  # self-upgrade; the real cross-major plan surfaces only in the -y log
+  # (after pkg re-execs). Must die BEFORE the reboot is recorded.
+  It 'fails closed when the pkg upgrade -y log reports a major OS crossing the dry-run never saw'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 1' 1 0 '' '' '' '' \
+      "$(printf 'pkg: 1.21.3_8 -> 2.1.0 [FreeBSD:16:amd64]\nMajor OS version upgrade detected, aborting other packages')"
+    The status should be failure
+    The stderr should include 'FreeBSD major'
+    The stderr should include 'pkg-upgrade.log'
+    The output should not include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include '/sbin/reboot'
+  End
+
   # C6
   It 'fails closed when the post-reboot ABI major differs from the snapshot'
-    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 0 0 '' '' 'FreeBSD:16:amd64' '16.0-RELEASE'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' 'FreeBSD:16:amd64' '16.0-RELEASE'
     The status should be failure
     The stderr should include 'FreeBSD:16:amd64'
     The stderr should include 'FreeBSD:15:amd64'
     The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  # F3b — the box-level ABI/kernel check can pass while a single installed
+  # package still carries a foreign-major ABI; the post-reboot pkg-query
+  # sweep must catch and NAME it.
+  It 'fails closed when a post-reboot installed package reports a foreign ABI major'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' '' '' \
+      '' 'straggler-pkg FreeBSD:16:amd64'
+    The status should be failure
+    The stderr should include 'straggler-pkg'
+    The stderr should include 'FreeBSD:16:amd64'
+    The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  # F3c — happy path: every installed package (including a wildcard-arch one)
+  # reports the same major as the box; must succeed.
+  It 'succeeds when every post-reboot installed package matches the box major'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' '' '' \
+      '' "$(printf 'pkgA FreeBSD:15:amd64\npkgB FreeBSD:15:*')"
+    The status should be success
+    The output should include 'PKG_WAS_UPGRADED=1'
+    The output should include 'REACHED-AFTER-REFRESH'
   End
 
   # C7
@@ -174,6 +255,37 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
     The output should not include 'REACHED-AFTER-REFRESH'
   End
 
+  # F4 — the ABI/kernel major must already agree BEFORE pkg update -f runs.
+  It 'fails closed when the initial ABI major does not match the initial kernel major'
+    When call run_refresh 'FreeBSD:16:amd64' '15.0-CURRENT' 'Your packages are up to date.' 0 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'FreeBSD:16:amd64'
+    The stderr should include '15.0-CURRENT'
+    The output should not include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include 'pkg update -f'
+  End
+
+  # F2 — a foreign-major pkg binary warns on stderr for ANY command; the
+  # capture must stay clean and the die message must name the two plain
+  # values, not garbled multi-line noise (also proves F4 fires past the noise).
+  It 'fails closed with a clean two-value message even when pkg config ABI warns on stderr'
+    When call run_refresh 'FreeBSD:16:amd64' '15.0-RELEASE' 'Your packages are up to date.' 0 0 '' '' '' '' '' '' abi-warn
+    The status should be failure
+    The stderr should include 'pkg ABI FreeBSD:16:amd64 does not match kernel 15.0-RELEASE'
+  End
+
+  # F2 — ssh's own known-hosts banner lands on stderr on EVERY call (proven by
+  # this scenario's stub firing it on every ssh_guest invocation); the happy
+  # pending-upgrade path must still succeed, since every value capture either
+  # discards ssh_guest's stderr or merges it into a channel this stub already
+  # exercises elsewhere (C1/C9) — none of them let raw noise corrupt a value.
+  It 'succeeds through a pending-upgrade refresh despite an ssh known-hosts banner on every call'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' '' '' '' '' ssh-banner
+    The status should be success
+    The output should include 'PKG_WAS_UPGRADED=1'
+    The output should include 'REACHED-AFTER-REFRESH'
+  End
+
   # C9
   It 'retries a transient pkg database lock on pkg update -f and continues'
     When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Your packages are up to date.' 0 0 'transient-lock' '' '' ''
@@ -191,6 +303,43 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
     The status should be failure
     The stderr should include 'pkg catalogue refresh failed'
     The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  # N1 — the third uncovered fail-closed path: the lock never clears.
+  It 'fails closed when the pkg database lock never clears'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Your packages are up to date.' 0 0 'permanent-lock' '' '' ''
+    The status should be failure
+    The stderr should include 'still locked'
+    The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  # N1 — pkg upgrade -n exits non-zero AND prints unparsable text (neither an
+  # up-to-date nor a plan phrase): the fail-closed verdict must still die, and
+  # the message must NAME the rc (mutation-sensitive: deleting the rc from the
+  # message turns this row red without touching the die/no-die outcome).
+  It 'fails closed on a non-zero dry-run rc with unparsable output (fail-closed verdict names the rc)'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'pkg: http://example.test: Not Found' 3 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'did not report a plan'
+    The stderr should include 'rc=3'
+    The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  # N1 — the same unparsable text at rc=0 must also die (content, not rc, is
+  # the fail-closed signal).
+  It 'fails closed on unparsable dry-run output at rc=0'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'pkg: http://example.test: Not Found' 0 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'did not report a plan'
+    The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  # N2 — a non-digit major (garbled `pkg config ABI`) must read as unreadable,
+  # never as a major that happens to compare unequal.
+  It 'fails closed when pkg config ABI answers a non-digit major'
+    When call run_refresh 'FreeBSD:15a:amd64' '15.0-RELEASE' 'Your packages are up to date.' 0 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'could not read'
   End
 
   # C11 — wiring: exactly one call site, and the extraction markers exist.
@@ -223,7 +372,7 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
   # Hostile: post-reboot kernel major with no dot (e.g. 15-STABLE) never
   # coincidentally strcmp-matches a numeric ABI major — it fails closed.
   It 'fails closed when the post-reboot kernel major has no dot to parse'
-    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 0 0 '' '' '' '15-STABLE'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' '' '15-STABLE'
     The status should be failure
     The stderr should include '15-STABLE'
     The stderr should include 'FreeBSD:15:amd64'

--- a/tests/shell/image_upgrade_pkgs_refresh_spec.sh
+++ b/tests/shell/image_upgrade_pkgs_refresh_spec.sh
@@ -176,9 +176,18 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
     The contents of file "$CALLS" should not include 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
   End
 
-  # F3 addendum (e) — "Newer FreeBSD version" / IGNORE_OSVERSION wording.
+  # F3 addendum (e) — each pkg(8) cross-major wording gets its own row, so
+  # dropping one alternative from the phrase list turns exactly one row red.
+  It 'fails closed when the dry-run plan reports a Newer FreeBSD version'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Newer FreeBSD version for package foo-1.0' 1 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'FreeBSD major'
+    The output should not include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
+  End
+
   It 'fails closed when the dry-run plan asks to IGNORE_OSVERSION'
-    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Newer FreeBSD version for package foo-1.0: to ignore this error set IGNORE_OSVERSION=yes' 1 0 '' '' '' ''
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'to ignore this error set IGNORE_OSVERSION=yes' 1 0 '' '' '' ''
     The status should be failure
     The stderr should include 'FreeBSD major'
     The output should not include 'REACHED-AFTER-REFRESH'

--- a/tests/shell/image_upgrade_pkgs_refresh_spec.sh
+++ b/tests/shell/image_upgrade_pkgs_refresh_spec.sh
@@ -90,7 +90,10 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
             "/sbin/reboot") return 0 ;;
           esac
         }
+        eval "$(sed -n "/^# pfb_abi_major BEGIN/,/^# pfb_abi_major END/p" "$1")"
+        eval "$(sed -n "/^# pfb_kern_major BEGIN/,/^# pfb_kern_major END/p" "$1")"
         eval "$(sed -n "/^# pfb_pkg_refresh_verdict BEGIN/,/^# pfb_pkg_refresh_verdict END/p" "$1")"
+        eval "$(sed -n "/^# pfb_pkg_update_retry BEGIN/,/^# pfb_pkg_update_retry END/p" "$1")"
         eval "$(sed -n "/^# pfb_refresh_pkgs BEGIN/,/^# pfb_refresh_pkgs END/p" "$1")"
         PKG_LOCK_RETRIES=2
         PKG_LOCK_INTERVAL=0
@@ -118,6 +121,78 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
     The contents of file "$CALLS" should include '/sbin/reboot'
   End
 
+  # C3
+  It 'fails closed when pkg upgrade -n reports a major OS version crossing'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Major OS version upgrade detected, aborting.' 0 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'FreeBSD major'
+    The output should not include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
+  End
+
+  # C4
+  It 'fails closed when pkg upgrade -n reports a wrong-architecture plan'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'wrong architecture: FreeBSD:15:* instead of FreeBSD:16:amd64' 0 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'FreeBSD major'
+    The output should not include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
+  End
+
+  # C5
+  It 'fails closed when pkg upgrade -y itself fails (no || true swallow)'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 0 1 '' '' '' ''
+    The status should be failure
+    The stderr should include 'pkg upgrade'
+    The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  # C6
+  It 'fails closed when the post-reboot ABI major differs from the snapshot'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 0 0 '' '' 'FreeBSD:16:amd64' '16.0-RELEASE'
+    The status should be failure
+    The stderr should include 'FreeBSD:16:amd64'
+    The stderr should include 'FreeBSD:15:amd64'
+    The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  # C7
+  It 'fails closed when pkg update -f itself rewrote the ABI major, before any dry-run'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Your packages are up to date.' 0 0 '' 'FreeBSD:16:amd64' '' ''
+    The status should be failure
+    The stderr should include 'FreeBSD:16:amd64'
+    The stderr should include 'FreeBSD:15:amd64'
+    The output should not include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include 'pkg upgrade -n'
+  End
+
+  # C8
+  It 'fails closed when the initial pkg config ABI cannot be read'
+    When call run_refresh '' '15.0-RELEASE' 'Your packages are up to date.' 0 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'could not read'
+    The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  # C9
+  It 'retries a transient pkg database lock on pkg update -f and continues'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Your packages are up to date.' 0 0 'transient-lock' '' '' ''
+    The status should be success
+    The stderr should include 'pkg database locked'
+    The output should include 'PKG_WAS_UPGRADED=0'
+    The output should include 'REACHED-AFTER-REFRESH'
+    The contents of file "${WORK}/pkg-update.log" should include 'Cannot get an exclusive lock'
+    The contents of file "${WORK}/pkg-update.log" should include 'catalogue refreshed'
+  End
+
+  # C10
+  It 'fails closed on a non-lock pkg update -f error (no || true swallow)'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Your packages are up to date.' 0 0 'other-error' '' '' ''
+    The status should be failure
+    The stderr should include 'pkg catalogue refresh failed'
+    The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
   # C11 — wiring: exactly one call site, and the extraction markers exist.
   It 'wires pfb_refresh_pkgs into the --upgrade-pkgs branch exactly once'
     When call grep -c '^    pfb_refresh_pkgs "\$LOCAL_DIR"$' "$SCRIPT"
@@ -127,5 +202,31 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
   It 'exposes the pfb_refresh_pkgs extraction markers'
     When call grep -cE '^# pfb_refresh_pkgs (BEGIN|END)$' "$SCRIPT"
     The output should equal 2
+  End
+
+  # Hostile: a `\r`-laced dry-run line still matches the up-to-date phrase.
+  It 'tolerates CRLF-mangled dry-run output when packages are up to date'
+    dry="$(printf 'Your packages are up to date.\r')"
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' "$dry" 0 0 '' '' '' ''
+    The status should be success
+    The output should include 'PKG_WAS_UPGRADED=0'
+  End
+
+  # Hostile: pkg config ABI answering a bare "?" (no `:` fields) is unreadable,
+  # same as empty — never treated as a major that happens to compare unequal.
+  It 'fails closed when pkg config ABI answers a bare "?"'
+    When call run_refresh '?' '15.0-RELEASE' 'Your packages are up to date.' 0 0 '' '' '' ''
+    The status should be failure
+    The stderr should include 'could not read'
+  End
+
+  # Hostile: post-reboot kernel major with no dot (e.g. 15-STABLE) never
+  # coincidentally strcmp-matches a numeric ABI major — it fails closed.
+  It 'fails closed when the post-reboot kernel major has no dot to parse'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 0 0 '' '' '' '15-STABLE'
+    The status should be failure
+    The stderr should include '15-STABLE'
+    The stderr should include 'FreeBSD:15:amd64'
+    The output should not include 'REACHED-AFTER-REFRESH'
   End
 End

--- a/tests/shell/image_upgrade_pkgs_refresh_spec.sh
+++ b/tests/shell/image_upgrade_pkgs_refresh_spec.sh
@@ -215,6 +215,16 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
     The contents of file "$CALLS" should not include '/sbin/reboot'
   End
 
+  It 'fails closed when the pkg upgrade -y log merely lists a foreign-major package'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 1' 1 0 '' '' '' '' \
+      'pkg: 1.21.3_8 -> 2.1.0 [FreeBSD:16:amd64]'
+    The status should be failure
+    The stderr should include 'FreeBSD:16:'
+    The stderr should include 'pkg-upgrade.log'
+    The output should not include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include '/sbin/reboot'
+  End
+
   # C6
   It 'fails closed when the post-reboot ABI major differs from the snapshot'
     When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' 'FreeBSD:16:amd64' '16.0-RELEASE'

--- a/tests/shell/image_upgrade_pkgs_refresh_spec.sh
+++ b/tests/shell/image_upgrade_pkgs_refresh_spec.sh
@@ -1,0 +1,131 @@
+#shellcheck shell=sh
+# image_upgrade_pkgs_refresh_spec.sh — pins pfb_refresh_pkgs, the --upgrade-pkgs
+# body image-refresh.yml runs unattended (from==to, no human watching the
+# plan). It must fail closed on any FreeBSD ABI/kernel major movement across
+# the refresh, and on a pkg-reported major crossing, instead of publishing
+# foreign-major packages onto the running tag (issue #2299 residual — a repo
+# flip rewriting ABI mid-refresh is issue #2242's mechanism).
+#
+# Hermetic: drives the shipped helper with a stub ssh_guest — no VM.
+
+Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgpkgs.XXXXXX")"
+    CALLS="${WORK}/calls"
+    ABI_N="${WORK}/abi-n"
+    KERN_N="${WORK}/kern-n"
+    UPD_N="${WORK}/upd-n"
+    export WORK CALLS ABI_N KERN_N UPD_N
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # run_refresh ABI0 KERN0 DRY DRY_RC UPGRADE_RC UPDMODE ABI1 ABI2 KERN2 — drive
+  # pfb_refresh_pkgs (plus the helpers it calls) with a stub ssh_guest that
+  # answers `pkg config ABI`/`uname -r` from ABI0/KERN0 on the 1st call,
+  # ABI1 on the 2nd (post `pkg update -f`), ABI2/KERN2 on the 3rd+
+  # (post-reboot) — defaulting each unset ABI1/ABI2/KERN2 to its snapshot, so
+  # a scenario only names the values it moves. UPDMODE shapes `pkg update -f`
+  # (transient-lock / permanent-lock / other-error / unset=succeeds).
+  run_refresh() {
+    _abi0="$1" _kern0="$2" _dry="$3" _dryrc="$4" _upgraderc="$5" _updmode="$6" _abi1="$7" _abi2="$8" _kern2="$9" \
+      sh -c '
+        set -e
+        log()  { printf "==> %s\n" "$*"; }
+        warn() { printf "WARNING: %s\n" "$*" >&2; }
+        die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+        sleep() { :; }
+        wait_guest_ssh() { :; }
+        : "${_abi1:=$_abi0}"
+        : "${_abi2:=$_abi0}"
+        : "${_kern2:=$_kern0}"
+        : "${_dryrc:=0}"
+        : "${_upgraderc:=0}"
+        ssh_guest() {
+          printf "%s\n" "$*" >> "$CALLS"
+          case "$*" in
+            "/usr/local/sbin/pkg config ABI")
+              _n=$(( $(cat "$ABI_N" 2>/dev/null || echo 0) + 1 )); printf "%s" "$_n" > "$ABI_N"
+              case "$_n" in
+                1) printf "%s\n" "$_abi0" ;;
+                2) printf "%s\n" "$_abi1" ;;
+                *) printf "%s\n" "$_abi2" ;;
+              esac
+              ;;
+            "uname -r")
+              _n=$(( $(cat "$KERN_N" 2>/dev/null || echo 0) + 1 )); printf "%s" "$_n" > "$KERN_N"
+              if [ "$_n" -eq 1 ]; then printf "%s\n" "$_kern0"; else printf "%s\n" "$_kern2"; fi
+              ;;
+            "pkg update -f")
+              _n=$(( $(cat "$UPD_N" 2>/dev/null || echo 0) + 1 )); printf "%s" "$_n" > "$UPD_N"
+              case "$_updmode" in
+                transient-lock)
+                  if [ "$_n" -eq 1 ]; then
+                    printf "%s\n" "pkg: Cannot get an exclusive lock on a database, it is locked by another process"
+                    return 1
+                  fi
+                  ;;
+                permanent-lock)
+                  printf "%s\n" "pkg: Package database is busy while closing!"
+                  return 1
+                  ;;
+                other-error)
+                  printf "%s\n" "pkg: repository FreeBSD has a wrong packagesite"
+                  return 9
+                  ;;
+              esac
+              printf "%s\n" "catalogue refreshed"
+              ;;
+            "pkg upgrade -n")
+              printf "%s\n" "$_dry"
+              return "$_dryrc"
+              ;;
+            "env ASSUME_ALWAYS_YES=yes pkg upgrade -y")
+              printf "%s\n" "applying upgrades"
+              return "$_upgraderc"
+              ;;
+            "/sbin/reboot") return 0 ;;
+          esac
+        }
+        eval "$(sed -n "/^# pfb_pkg_refresh_verdict BEGIN/,/^# pfb_pkg_refresh_verdict END/p" "$1")"
+        eval "$(sed -n "/^# pfb_refresh_pkgs BEGIN/,/^# pfb_refresh_pkgs END/p" "$1")"
+        PKG_LOCK_RETRIES=2
+        PKG_LOCK_INTERVAL=0
+        pfb_refresh_pkgs "$2"
+        printf "PKG_WAS_UPGRADED=%s\n" "$PKG_WAS_UPGRADED"
+        printf "REACHED-AFTER-REFRESH\n"
+      ' _ "$SCRIPT" "$WORK"
+  }
+
+  # C1
+  It 'skips the upgrade + reboot when packages are already up to date'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Your packages are up to date.' 0 0 '' '' '' ''
+    The status should be success
+    The output should include 'PKG_WAS_UPGRADED=0'
+    The output should include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should not include 'env ASSUME_ALWAYS_YES=yes pkg upgrade -y'
+  End
+
+  # C2
+  It 'applies a pending plan, reboots, and re-verifies ABI/kernel major after'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 0 0 '' '' '' ''
+    The status should be success
+    The output should include 'PKG_WAS_UPGRADED=1'
+    The output should include 'REACHED-AFTER-REFRESH'
+    The contents of file "$CALLS" should include '/sbin/reboot'
+  End
+
+  # C11 — wiring: exactly one call site, and the extraction markers exist.
+  It 'wires pfb_refresh_pkgs into the --upgrade-pkgs branch exactly once'
+    When call grep -c '^    pfb_refresh_pkgs "\$LOCAL_DIR"$' "$SCRIPT"
+    The output should equal 1
+  End
+
+  It 'exposes the pfb_refresh_pkgs extraction markers'
+    When call grep -cE '^# pfb_refresh_pkgs (BEGIN|END)$' "$SCRIPT"
+    The output should equal 2
+  End
+End

--- a/tests/shell/image_upgrade_pkgs_refresh_spec.sh
+++ b/tests/shell/image_upgrade_pkgs_refresh_spec.sh
@@ -33,6 +33,7 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
   # / other-error / unset=succeeds). UPGRADE_Y_OUT overrides `pkg upgrade -y`'s
   # stdout (default: a plain "applying upgrades" line) so a scenario can plant
   # the FreeBSD-major phrase in the POST-`-y` log (issue #2299, F3a).
+  # PKG_QUERY_RC (arg 13, default 0) is `pkg query`'s exit status.
   # PKG_QUERY_OUT overrides `pkg query "%n %q"`'s stdout (default: one package
   # reporting ABI0, so unrelated scenarios that reach the post-reboot sweep
   # stay green). NOISE is 'ssh-banner' (every ssh_guest call also writes the
@@ -41,7 +42,7 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
   # value (issue #2299, F2).
   run_refresh() {
     _abi0="$1" _kern0="$2" _dry="$3" _dryrc="$4" _upgraderc="$5" _updmode="$6" _abi1="$7" _abi2="$8" _kern2="$9" \
-    _upgy_out="${10}" _pkgquery_out="${11}" _noise="${12}" \
+    _upgy_out="${10}" _pkgquery_out="${11}" _noise="${12}" _pkgquery_rc="${13:-0}" \
       sh -c '
         set -e
         log()  { printf "==> %s\n" "$*"; }
@@ -104,6 +105,7 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
             "/sbin/reboot") return 0 ;;
             '"'"'/usr/local/sbin/pkg query "%n %q"'"'"')
               printf "%s\n" "$_pkgquery_out"
+              return "$_pkgquery_rc"
               ;;
           esac
         }
@@ -251,6 +253,22 @@ Describe 'image-upgrade.sh package refresh (--upgrade-pkgs)'
   It 'succeeds when every post-reboot installed package matches the box major'
     When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' '' '' \
       '' "$(printf 'pkgA FreeBSD:15:amd64\npkgB FreeBSD:15:*')"
+    The status should be success
+    The output should include 'PKG_WAS_UPGRADED=1'
+    The output should include 'REACHED-AFTER-REFRESH'
+  End
+
+  It 'fails closed when the post-reboot pkg query exits non-zero even with partial output'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' '' '' \
+      '' 'pkgA FreeBSD:15:amd64' '' 1
+    The status should be failure
+    The stderr should include 'pkg query'
+    The output should not include 'REACHED-AFTER-REFRESH'
+  End
+
+  It 'ignores blank lines and fully wildcarded ABIs in the post-reboot package sweep'
+    When call run_refresh 'FreeBSD:15:amd64' '15.0-RELEASE' 'Number of packages to be upgraded: 3' 1 0 '' '' '' '' \
+      '' "$(printf 'pkgA FreeBSD:15:amd64\n\npkgC FreeBSD:*:*')"
     The status should be success
     The output should include 'PKG_WAS_UPGRADED=1'
     The output should include 'REACHED-AFTER-REFRESH'


### PR DESCRIPTION
## Summary

Residual of #2299 (reopened 2026-08-15): the same-version image refresh (`image-refresh.yml` passes `--upgrade-pkgs` iff `from == to`) ran `pkg update -f` / `pkg upgrade -n` / `pkg upgrade -y` in `scripts/image-upgrade.sh` with every failure swallowed by `|| true` and no ABI / FreeBSD-major gate — the path by which a "healthy" 2.8 self-refresh could install FreeBSD-16 packages onto the `:2.8` tag (pairs with #2242).

Three commits:

1. `image-upgrade: extract pfb_refresh_pkgs and shared pkg-update retry` — pure extraction. The `--upgrade-pkgs` block becomes `pfb_refresh_pkgs LOG_DIR` (BEGIN/END markers, spec-drivable); the branch path's `pkg update -f` lock-retry loop becomes `pfb_pkg_update_retry LOGFILE CONTEXT`, shared by both callers with the branch path's messages byte-identical. Existing branch specs stay green.
2. `image-upgrade: gate --upgrade-pkgs on FreeBSD ABI/kernel major staying put` — the gates:
   - snapshot `pkg config ABI` + `uname -r` before `pkg update -f`; unreadable → die
   - `pkg update -f` failures fatal (lock errors retried via the shared helper)
   - ABI re-read after `pkg update -f`; major changed → die
   - `pkg upgrade -n` output containing `Major OS version upgrade detected` / `wrong architecture` → die; unexpected non-zero rc → die
   - `pkg upgrade -y` failure fatal
   - post-reboot ABI/kernel re-read; ABI major ≠ snapshot or ≠ kernel major → die
   - `PKG_WAS_UPGRADED` semantics unchanged
3. header doc line for the flag.

`pfb_verify_artifact` / `image-refresh.yml` are untouched here — those are #2242's PR.

## Evidence

New `tests/shell/image_upgrade_pkgs_refresh_spec.sh` (15 examples, C1–C11 + hostile rows), frozen at `589e0b2208f7711d98a5036325f23a116aa7f2f4`.

- RED against commit 1 (extraction only, no gates): `15 examples, 9 failures` — C3, C4, C6, C7, C8, C9, C10, hostile ABI `?`, hostile kernel `15-STABLE`.
- GREEN at commit 2, zero test edits: `15 examples, 0 failures`; full set (`image_upgrade_pkgs_refresh`, `_branch`, `_branch_retry_config`, `_be`, `_lock`, `_pkg_refresh` specs) `58 examples, 0 failures`.
- Mutations: re-add `|| true` on `pkg upgrade -y` → C5 red; drop post-reboot compare → C6 + kernel-no-dot red; delete the `pfb_refresh_pkgs "$LOCAL_DIR"` call → wiring example red.
- `sh -n`, `shellcheck`, `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (CI image). Independent small-tier verifier gate: PASS, no blocking findings.

Fixes #2299

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safer package refresh and upgrade handling.
  - Validates system compatibility before and after upgrades.
  - Retries temporary package database lock failures.
  - Aborts safely when upgrades fail or could cross major compatibility versions.
  - Reboots automatically after successful package upgrades.

- **Bug Fixes**
  - Improved handling of package refresh errors and unexpected command output.

- **Tests**
  - Added comprehensive coverage for retries, validation, failures, reboot behavior, and hostile output scenarios.

- **Documentation**
  - Documented package refresh safety requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->