### PR TITLE
smoke + image-refresh: fail closed on FreeBSD ABI/major drift (#2242 residual)

### DIFF
--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -355,6 +355,9 @@ jobs:
       # rewriting freebsd_major/freebsd_version (issue #2242).
       # Matrix writes remain auto-PR ONLY — never a ci-metadata push.
       # Contract pinned by tests/test_image_refresh_plan_contract.py.
+      # continue-on-error is deliberate: the image already published, so a failure here
+      # (including the refusal above) surfaces as an ::error:: annotation with no PR,
+      # never a red run.
       - name: Open activation PR (box-verified matrix update)
         continue-on-error: true
         env:
@@ -392,11 +395,19 @@ jobs:
           fi
 
           # The matrix is human-curated; a surprise major means a broken guest,
-          # not new truth — hard stop before any write (issue #2242).
+          # not new truth — hard stop before any write (issue #2242). An EMPTY side
+          # (unreachable on the live matrix, but must not go silent) warns naming
+          # which side is missing and proceeds as today rather than refusing.
           cur_major=$(printf '%s' "$ENTRY" | jq -r '.freebsd_major // ""')
           if [ -n "$freebsd_major" ] && [ -n "$cur_major" ] && [ "$freebsd_major" != "$cur_major" ]; then
             echo "::error::${CHANNEL} ${FAMILY}: guest reports FreeBSD major ${freebsd_major} (${freebsd_version}) but the matrix row says ${cur_major} — refusing to activate; the matrix is human-curated and a surprise major means a broken guest, not new truth (issue #2242)"
             exit 1
+          elif [ -z "$freebsd_major" ] && [ -n "$cur_major" ]; then
+            echo "::warning::${CHANNEL} ${FAMILY}: guest reported no freebsd_major fact — cannot verify against matrix major ${cur_major} (issue #2242)"
+          elif [ -n "$freebsd_major" ] && [ -z "$cur_major" ]; then
+            echo "::warning::${CHANNEL} ${FAMILY}: matrix row has no freebsd_major recorded — cannot verify against guest major ${freebsd_major} (issue #2242)"
+          elif [ -z "$freebsd_major" ] && [ -z "$cur_major" ]; then
+            echo "::warning::${CHANNEL} ${FAMILY}: neither guest nor matrix report a freebsd_major fact — skipping major verification (issue #2242)"
           fi
 
           NEWM=$(mktemp)

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -297,8 +297,12 @@ jobs:
       #   2. Same-version refreshes pass --upgrade-pkgs: pkg update -f + pkg upgrade
       #      -n (dry-run detect); ONLY if upgrades pending → pkg upgrade -y + reboot
       #      + wait SSH. Cross-version legs omit it; pfSense-upgrade owns the transition.
-      #      Same-version legs also pass --expect-freebsd-major (from matrix.freebsd_version)
-      #      so the published artifact's pkg ABI major must match the matrix row (issue #2242).
+      #      EVERY leg passes --expect-freebsd-major, derived from matrix.freebsd_version
+      #      (the TARGET row's value in both leg modes): the published artifact's pkg ABI
+      #      major must match the matrix row, whether refreshing in place or crossing a
+      #      major (issue #2242). Omitted when the derived value isn't plain digits (an
+      #      empty/malformed freebsd_version) — the artifact's own ABI-vs-kernel
+      #      self-consistency check in pfb_verify_artifact still applies regardless.
       #   3. Runs pfSense-upgrade (reboots the box), waits for version to change.
       #   4. Health gate: polls up to 300 s for webConfigurator HTTP or pfctl live
       #      ruleset; fail-closed (die → no publish) if neither answers.
@@ -328,8 +332,10 @@ jobs:
           export SMOKE_SSH_KEY="$GITHUB_WORKSPACE/smoke_key"
           UPGRADE_PKGS_FLAG=
           [ "$FROM_TAG" = "$TARGET_TAG" ] && UPGRADE_PKGS_FLAG=--upgrade-pkgs
-          EXPECT_MAJOR=
-          [ "$FROM_TAG" = "$TARGET_TAG" ] && EXPECT_MAJOR="${FREEBSD_VERSION%%.*}"
+          EXPECT_MAJOR=${FREEBSD_VERSION%%.*}
+          case "$EXPECT_MAJOR" in
+            ''|*[!0-9]*) EXPECT_MAJOR= ;;
+          esac
           sh scripts/image-upgrade.sh \
             ${FORCE_FLAG:+"$FORCE_FLAG"} \
             --from "$FROM_TAG" \

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -328,10 +328,8 @@ jobs:
           export SMOKE_SSH_KEY="$GITHUB_WORKSPACE/smoke_key"
           UPGRADE_PKGS_FLAG=
           [ "$FROM_TAG" = "$TARGET_TAG" ] && UPGRADE_PKGS_FLAG=--upgrade-pkgs
-          EXPECT_MAJOR_ARGS=
-          if [ "$FROM_TAG" = "$TARGET_TAG" ]; then
-            EXPECT_MAJOR_ARGS="--expect-freebsd-major ${FREEBSD_VERSION%%.*}"
-          fi
+          EXPECT_MAJOR=
+          [ "$FROM_TAG" = "$TARGET_TAG" ] && EXPECT_MAJOR="${FREEBSD_VERSION%%.*}"
           sh scripts/image-upgrade.sh \
             ${FORCE_FLAG:+"$FORCE_FLAG"} \
             --from "$FROM_TAG" \
@@ -344,7 +342,7 @@ jobs:
             --upgrade-timeout "${{ inputs.upgrade_timeout }}" \
             --facts-out "$PWD/box-facts.env" \
             ${UPGRADE_PKGS_FLAG:+"$UPGRADE_PKGS_FLAG"} \
-            $EXPECT_MAJOR_ARGS
+            ${EXPECT_MAJOR:+--expect-freebsd-major "$EXPECT_MAJOR"}
 
       # ── Activation PR: box-verified matrix update (issue #1837) ────────────
       # The upgrade leg is the only moment automation has SSH into a live box

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -297,6 +297,8 @@ jobs:
       #   2. Same-version refreshes pass --upgrade-pkgs: pkg update -f + pkg upgrade
       #      -n (dry-run detect); ONLY if upgrades pending → pkg upgrade -y + reboot
       #      + wait SSH. Cross-version legs omit it; pfSense-upgrade owns the transition.
+      #      Same-version legs also pass --expect-freebsd-major (from matrix.freebsd_version)
+      #      so the published artifact's pkg ABI major must match the matrix row (issue #2242).
       #   3. Runs pfSense-upgrade (reboots the box), waits for version to change.
       #   4. Health gate: polls up to 300 s for webConfigurator HTTP or pfctl live
       #      ruleset; fail-closed (die → no publish) if neither answers.
@@ -318,6 +320,7 @@ jobs:
           VARIANT: ${{ matrix.variant }}
           FORCE_FLAG: ${{ matrix.force_flag }}
           BRANCH: ${{ matrix.branch }}
+          FREEBSD_VERSION: ${{ matrix.freebsd_version }}
         run: |
           set -eu
           # Run-body export, not an env: map value — GitHub Actions never
@@ -325,6 +328,10 @@ jobs:
           export SMOKE_SSH_KEY="$GITHUB_WORKSPACE/smoke_key"
           UPGRADE_PKGS_FLAG=
           [ "$FROM_TAG" = "$TARGET_TAG" ] && UPGRADE_PKGS_FLAG=--upgrade-pkgs
+          EXPECT_MAJOR_ARGS=
+          if [ "$FROM_TAG" = "$TARGET_TAG" ]; then
+            EXPECT_MAJOR_ARGS="--expect-freebsd-major ${FREEBSD_VERSION%%.*}"
+          fi
           sh scripts/image-upgrade.sh \
             ${FORCE_FLAG:+"$FORCE_FLAG"} \
             --from "$FROM_TAG" \
@@ -336,17 +343,18 @@ jobs:
             --compression "${{ inputs.compression }}" \
             --upgrade-timeout "${{ inputs.upgrade_timeout }}" \
             --facts-out "$PWD/box-facts.env" \
-            ${UPGRADE_PKGS_FLAG:+"$UPGRADE_PKGS_FLAG"}
+            ${UPGRADE_PKGS_FLAG:+"$UPGRADE_PKGS_FLAG"} \
+            $EXPECT_MAJOR_ARGS
 
       # ── Activation PR: box-verified matrix update (issue #1837) ────────────
       # The upgrade leg is the only moment automation has SSH into a live box
       # running the NEW version. image-upgrade.sh gathered its facts
       # (box-facts.env); if the leg family's matrix entry is not yet
       # active-and-accurate, open ONE tracker/* PR setting ci: true and the
-      # box-verified php_version / py_flavor / freebsd_major. The full
-      # freebsd_version string only changes when the MAJOR moved (the matrix
-      # keeps its human convention, e.g. 16.0-RELEASE vs the box's
-      # 16.0-CURRENT); the raw box value is quoted in the PR body.
+      # box-verified php_version / py_flavor. The matrix is human-curated: a
+      # guest-reported freebsd_major that disagrees with the matrix row is a
+      # broken guest, not new truth, and hard-stops the step instead of
+      # rewriting freebsd_major/freebsd_version (issue #2242).
       # Matrix writes remain auto-PR ONLY — never a ci-metadata push.
       # Contract pinned by tests/test_image_refresh_plan_contract.py.
       - name: Open activation PR (box-verified matrix update)
@@ -385,18 +393,22 @@ jobs:
             exit 0
           fi
 
+          # The matrix is human-curated; a surprise major means a broken guest,
+          # not new truth — hard stop before any write (issue #2242).
+          cur_major=$(printf '%s' "$ENTRY" | jq -r '.freebsd_major // ""')
+          if [ -n "$freebsd_major" ] && [ -n "$cur_major" ] && [ "$freebsd_major" != "$cur_major" ]; then
+            echo "::error::${CHANNEL} ${FAMILY}: guest reports FreeBSD major ${freebsd_major} (${freebsd_version}) but the matrix row says ${cur_major} — refusing to activate; the matrix is human-curated and a surprise major means a broken guest, not new truth (issue #2242)"
+            exit 1
+          fi
+
           NEWM=$(mktemp)
           jq --arg v "$FAMILY" --arg c "$CHANNEL" \
-             --arg php "${php_version:-}" --arg py "${py_flavor:-}" \
-             --arg fbmaj "${freebsd_major:-}" --arg fb "${freebsd_version:-}" '
+             --arg php "${php_version:-}" --arg py "${py_flavor:-}" '
             (.versions[] | select(.pfsense_version == $v and .channel == $c
                                    and ((.arch // "amd64") == "amd64"))) |= (
               .ci = true
               | (if $php != "" then .php_version = $php else . end)
               | (if $py != "" then .py_flavor = $py else . end)
-              | (if $fbmaj != "" and .freebsd_major != $fbmaj
-                 then .freebsd_major = $fbmaj | .freebsd_version = $fb
-                 else . end)
             )' matrix_current.json > "$NEWM"
 
           # Semantic compare — immune to on-disk formatting drift.
@@ -442,9 +454,8 @@ jobs:
             printf '| Python flavor | `%s` |\n' "${py_flavor:-?}"
             printf '| FreeBSD | `%s` (major %s) |\n\n' "${freebsd_version:-?}" "${freebsd_major:-?}"
             printf 'This PR sets `ci: true` (the image now exists for the smoke fan-out) and\n'
-            printf 'corrects any drifted version fields. The full `freebsd_version` string is\n'
-            printf 'only rewritten when the MAJOR changed — the matrix keeps its human\n'
-            printf 'convention otherwise.\n\n'
+            printf 'corrects `php_version`/`py_flavor` from the box facts; a FreeBSD major\n'
+            printf 'mismatch refuses to activate instead of rewriting the matrix (issue #2242).\n\n'
             printf '_Opened automatically by image-refresh (issue #1837). Matrix changes are\n'
             printf 'PRs only — merging is a human decision and re-fires the reconcile._\n'
           } > "$BODY_FILE"

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -238,7 +238,7 @@ while [ $# -gt 0 ]; do
             shift 2 ;;
         --keep)            KEEP=1; shift ;;
         --force)           FORCE=1; shift ;;
-        -h|--help)         sed -n '2,115p' "$0"; exit 0 ;;
+        -h|--help)         sed -n '2,135p' "$0"; exit 0 ;;
         *)                 die "unknown option: $1" ;;
     esac
 done
@@ -669,7 +669,9 @@ pfb_publish_decision() {
 # Also refuses to publish when the artifact's own pkg ABI disagrees with its
 # kernel (a half-upgraded disk), or — when EXPECT_FREEBSD_MAJOR is set — when
 # the ABI major disagrees with the caller's expectation (issue #2242). The
-# artifact is the last word before a push.
+# artifact is the last word before a push. `uname -r` (the kernel that boots
+# the disk) is the reference for that self-consistency check; /bin/freebsd-version
+# is never read on the artifact.
 # FILE is the KVM host's out.qcow2 — the exact bytes the pushed local copy was
 # streamed from, so booting it there costs no second transfer. The boot writes
 # to that copy; the local one is already on disk and is what gets pushed.
@@ -695,8 +697,14 @@ pfb_verify_artifact() {
         || die "could not read kernel release from the exported artifact — refusing to publish"
     # abi_major: 2nd ':'-field of "FreeBSD:15:amd64"; kern_major: text before
     # the first '.' of "15.0-CURRENT" — both plain POSIX-parameter parsing.
+    # `set -f` disables globbing for the unquoted `$_pva_abi` word-split below: an
+    # ABI containing a literal `*` (e.g. a garbled probe) would otherwise glob-match
+    # a filename in cwd and silently hand back a real-looking digit major (issue #2242).
     # shellcheck disable=SC2086  # intentional: IFS=: word-splits the ABI string
-    _pva_abi_maj=$(IFS=:; set -- $_pva_abi; printf '%s' "${2:-}")
+    _pva_abi_maj=$(set -f; IFS=:; set -- $_pva_abi; printf '%s' "${2-}")
+    case "$_pva_abi_maj" in
+        '' | *[!0-9]*) die "could not read pkg ABI from the exported artifact — refusing to publish" ;;
+    esac
     _pva_kern_maj=${_pva_kern%%.*}
     if [ "$_pva_abi_maj" != "$_pva_kern_maj" ]; then
         die "exported artifact's pkg ABI ${_pva_abi} disagrees with its kernel ${_pva_kern} — refusing to publish (issue #2242)"

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -36,7 +36,9 @@
 # permanent on disk (fall back to an explicit bectl activate; fail closed —
 # issue #1858) -> power off cleanly -> compress on Proxmox -> stream back ->
 # boot the exported artifact once and refuse to publish it under a tag whose
-# family it does not come up with (issue #1858) -> push the new tag (local).
+# family it does not come up with, or whose pkg ABI disagrees with its own
+# kernel or the caller's --expect-freebsd-major (issues #1858, #2242) -> push
+# the new tag (local).
 # The source tag is left untouched, so the old image is always kept.
 #
 # Usage:
@@ -124,6 +126,12 @@
 #                    php_version, py_flavor, freebsd_version/major) into FILE
 #                    after the health gate — the activation-PR step consumes
 #                    them (issue #1837). Best-effort; default off.
+#   --expect-freebsd-major N  require the EXPORTED artifact's pkg ABI major to
+#                    equal N (digits only), in addition to it always having to
+#                    agree with the artifact's own kernel major — refuses to
+#                    publish a disk whose FreeBSD major silently drifted from
+#                    what the caller expected (issue #2242). Default empty =
+#                    only the ABI-vs-kernel self-consistency check applies.
 #   --keep           keep the work dirs (image copies, console log) afterwards
 #   --force          overwrite the target tag if it already exists
 #
@@ -182,6 +190,7 @@ UPGRADE_TIMEOUT=1200
 UPGRADE_PKGS=0
 BRANCH=""
 FACTS_OUT=""
+EXPECT_FREEBSD_MAJOR=""
 KEEP=0
 FORCE=0
 
@@ -221,6 +230,12 @@ while [ $# -gt 0 ]; do
         --upgrade-pkgs)    UPGRADE_PKGS=1; shift ;;
         --branch)          BRANCH="$2"; shift 2 ;;
         --facts-out)       FACTS_OUT="$2"; shift 2 ;;
+        --expect-freebsd-major)
+            EXPECT_FREEBSD_MAJOR="$2"
+            case "$EXPECT_FREEBSD_MAJOR" in
+                *[!0-9]*) die "--expect-freebsd-major must be digits only (got '$EXPECT_FREEBSD_MAJOR')" ;;
+            esac
+            shift 2 ;;
         --keep)            KEEP=1; shift ;;
         --force)           FORCE=1; shift ;;
         -h|--help)         sed -n '2,115p' "$0"; exit 0 ;;
@@ -651,7 +666,10 @@ pfb_publish_decision() {
 # publish it unless the version it actually comes up with belongs to TAG's
 # family. The running box is not proof: a box captured before its boot finished
 # made a 26.03.1 disk pass every in-run check and ship as :26.07 (issue #1858).
-# The artifact is the last word before a push.
+# Also refuses to publish when the artifact's own pkg ABI disagrees with its
+# kernel (a half-upgraded disk), or — when EXPECT_FREEBSD_MAJOR is set — when
+# the ABI major disagrees with the caller's expectation (issue #2242). The
+# artifact is the last word before a push.
 # FILE is the KVM host's out.qcow2 — the exact bytes the pushed local copy was
 # streamed from, so booting it there costs no second transfer. The boot writes
 # to that copy; the local one is already on disk and is what gets pushed.
@@ -662,21 +680,40 @@ pfb_verify_artifact() {
     # script (the #1844 rule above), and QPID must land in the top-level shell
     # so cleanup() can reap a wedged verification QEMU.
     pfb_boot_artifact_version "$_pva_file" > "${LOCAL_DIR}/verify-version"
-    _pva_ver=$(tr -d '\r' < "${LOCAL_DIR}/verify-version")
+    _pva_ver=$(sed -n '1p' "${LOCAL_DIR}/verify-version" | tr -d '\r')
+    _pva_abi=$(sed -n '2p' "${LOCAL_DIR}/verify-version" | tr -d '\r')
+    _pva_kern=$(sed -n '3p' "${LOCAL_DIR}/verify-version" | tr -d '\r')
     [ -n "$_pva_ver" ] \
         || die "could not read a version from the exported artifact — refusing to publish"
     _pva_fam=$(image_version_tag "$_pva_ver")
     if [ "$_pva_fam" != "$_pva_tag" ]; then
         die "exported artifact boots ${_pva_ver} (family ${_pva_fam}), not ${_pva_tag} — refusing to publish a mislabelled image"
     fi
-    log "artifact verified: boots ${_pva_ver}"
+    [ -n "$_pva_abi" ] \
+        || die "could not read pkg ABI from the exported artifact — refusing to publish"
+    [ -n "$_pva_kern" ] \
+        || die "could not read kernel release from the exported artifact — refusing to publish"
+    # abi_major: 2nd ':'-field of "FreeBSD:15:amd64"; kern_major: text before
+    # the first '.' of "15.0-CURRENT" — both plain POSIX-parameter parsing.
+    # shellcheck disable=SC2086  # intentional: IFS=: word-splits the ABI string
+    _pva_abi_maj=$(IFS=:; set -- $_pva_abi; printf '%s' "${2:-}")
+    _pva_kern_maj=${_pva_kern%%.*}
+    if [ "$_pva_abi_maj" != "$_pva_kern_maj" ]; then
+        die "exported artifact's pkg ABI ${_pva_abi} disagrees with its kernel ${_pva_kern} — refusing to publish (issue #2242)"
+    fi
+    if [ -n "$EXPECT_FREEBSD_MAJOR" ] && [ "$_pva_abi_maj" != "$EXPECT_FREEBSD_MAJOR" ]; then
+        die "exported artifact's pkg ABI ${_pva_abi} is FreeBSD major ${_pva_abi_maj}, expected ${EXPECT_FREEBSD_MAJOR} for ${_pva_tag} — refusing to publish (issue #2242)"
+    fi
+    log "artifact verified: boots ${_pva_ver} (pkg ABI ${_pva_abi}, kernel ${_pva_kern})"
 }
 # pfb_verify_artifact END
 
 # pfb_boot_artifact_version DISK — boot DISK once with the SAME topology the
 # upgrade ran under (same MACs, same SMBIOS uuid, same mgmt hostfwd; the upgrade
-# VM is already gone, so GUEST_PORT is free) and echo the guest's /etc/version.
-# Everything but that version goes to stderr — the caller reads stdout.
+# VM is already gone, so GUEST_PORT is free) and echo three lines: /etc/version,
+# pkg config ABI, uname -r (issue #2242 — the artifact's own ABI/kernel are what
+# pfb_verify_artifact checks). A value that could not be read is an empty line;
+# the line count stays fixed at 3. Everything else goes to stderr.
 pfb_boot_artifact_version() {
     _pbav_disk=$1
     log "booting the exported artifact to read the version it really comes up with" >&2
@@ -702,6 +739,8 @@ pfb_boot_artifact_version() {
     [ -n "$QPID" ] || die "verification boot did not write a pidfile (see ${REMOTE_DIR}/verify-console.log on the KVM host)"
     wait_guest_ssh "${VERIFY_BOOT_TIMEOUT:-600}" verify-console.log >&2
     _pbav_ver=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r')
+    _pbav_abi=$(ssh_guest '/usr/local/sbin/pkg config ABI' 2>/dev/null | tr -d '\r')
+    _pbav_kern=$(ssh_guest 'uname -r' 2>/dev/null | tr -d '\r')
     ssh_guest '/sbin/shutdown -p now' >/dev/null 2>&1 || true
     _pbav_elapsed=0
     while px "kill -0 $QPID 2>/dev/null"; do
@@ -712,7 +751,7 @@ pfb_boot_artifact_version() {
         sleep 3; _pbav_elapsed=$((_pbav_elapsed + 3))
     done
     QPID=""
-    printf '%s\n' "$_pbav_ver"
+    printf '%s\n%s\n%s\n' "$_pbav_ver" "$_pbav_abi" "$_pbav_kern"
 }
 
 # pfb_promote_be BEGIN

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -238,7 +238,7 @@ while [ $# -gt 0 ]; do
             shift 2 ;;
         --keep)            KEEP=1; shift ;;
         --force)           FORCE=1; shift ;;
-        -h|--help)         sed -n '2,135p' "$0"; exit 0 ;;
+        -h|--help)         sed -n '2,/^# Auth:/p' "$0"; exit 0 ;;
         *)                 die "unknown option: $1" ;;
     esac
 done

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -248,6 +248,9 @@ Describe 'image-upgrade.sh --expect-freebsd-major option parsing'
     When run script "$SCRIPT" --help
     The status should be success
     The output should include "require the EXPORTED artifact's pkg ABI major"
+    # the header's LAST lines: a numeric sed range drifts as options are added
+    The output should include '--force          overwrite the target tag'
+    The output should include 'Auth: as in image-publish.sh'
   End
 End
 

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -36,23 +36,28 @@ Describe 'image-upgrade.sh pre-push artifact verification'
   BeforeEach 'setup'
   AfterEach 'teardown'
 
-  # run_verify BOOTED TAG — drive the shipped verifier: it re-boots the EXPORTED
-  # artifact and compares the family it actually boots against the publish tag.
+  # run_verify BOOTED TAG [ABI] [KERNEL] [EXPECT] — drive the shipped verifier:
+  # it re-boots the EXPORTED artifact and compares the family it actually boots
+  # against the publish tag, then (issue #2242) the artifact's own pkg ABI
+  # against its kernel and, when EXPECT is given, against EXPECT. ABI/KERNEL
+  # default to an internally-consistent FreeBSD 16 pair so callers testing only
+  # the version/family guard don't have to spell them out.
   # This is the guard that catches the whole class, not just the one-shot-BE
   # case: whatever makes the disk differ from the box we observed, the artifact
   # itself is the last word before a push (issue #1858).
   run_verify() {
-    _booted="$1" _tag="$2" sh -c '
+    _booted="$1" _tag="$2" _abi="${3-FreeBSD:16:amd64}" _kern="${4-16.0-CURRENT}" _expect="${5-}" sh -c '
       set -e
       log()  { printf "==> %s\n" "$*"; }
       warn() { printf "WARNING: %s\n" "$*" >&2; }
       die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
       LOCAL_DIR="$2"
+      EXPECT_FREEBSD_MAJOR="$_expect"
       # the real tag rule, not a stub — the family comparison IS the guard
       . "$(dirname "$1")/image-lib.sh"
       eval "$(sed -n "/^# pfb_verify_artifact BEGIN/,/^# pfb_verify_artifact END/p" "$1")"
-      # stub the boot: report the version the exported disk comes up with
-      pfb_boot_artifact_version() { printf "%s\n" "$_booted"; }
+      # stub the boot: report the version/abi/kernel the exported disk comes up with
+      pfb_boot_artifact_version() { printf "%s\n%s\n%s\n" "$_booted" "$_abi" "$_kern"; }
       pfb_verify_artifact "$2/out.qcow2" "$_tag"
       printf "REACHED-AFTER-VERIFY\n"
     ' _ "$SCRIPT" "$WORK"
@@ -133,6 +138,69 @@ Describe 'image-upgrade.sh pre-push artifact verification'
     When call run_verify 26.07.1-RELEASE 26.07
     The status should be success
     The output should include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'passes when the artifact ABI and kernel major agree, no expectation given'
+    When call run_verify 26.07-BETA 26.07 'FreeBSD:16:amd64' '16.0-CURRENT'
+    The status should be success
+    The output should include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'refuses to publish when the artifact ABI disagrees with its own kernel'
+    When call run_verify 26.07-BETA 26.07 'FreeBSD:16:amd64' '15.0-CURRENT'
+    The status should be failure
+    The stderr should include 'disagrees with its kernel'
+    The output should not include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'refuses to publish when the artifact ABI major does not match --expect-freebsd-major'
+    When call run_verify 26.07-BETA 26.07 'FreeBSD:16:amd64' '16.0-CURRENT' 15
+    The status should be failure
+    The stderr should include 'expected 15'
+    The output should not include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'passes when the artifact ABI major matches --expect-freebsd-major'
+    When call run_verify 26.07-BETA 26.07 'FreeBSD:16:amd64' '16.0-CURRENT' 16
+    The status should be success
+    The output should include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'refuses to publish when the artifact never reports a pkg ABI'
+    When call run_verify 26.07-BETA 26.07 '' '16.0-CURRENT'
+    The status should be failure
+    The stderr should include 'could not read pkg ABI'
+    The output should not include 'REACHED-AFTER-VERIFY'
+  End
+End
+
+Describe 'image-upgrade.sh --expect-freebsd-major option parsing'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  # run_optparse ARGS... — drive the shipped option-parsing loop in isolation
+  # (extracted verbatim, real execution — not a stub), so the digit guard is
+  # proven against the actual case arm, not a grep proxy.
+  run_optparse() {
+    sh -c '
+      set -e
+      die() { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      _self="$1"; shift
+      eval "$(sed -n "/^while \[ \$# -gt 0 \]; do\$/,/^done\$/p" "$_self")"
+      printf "REACHED-AFTER-PARSE\n"
+    ' _ "$SCRIPT" "$@"
+  }
+
+  It 'rejects a non-numeric --expect-freebsd-major'
+    When call run_optparse --expect-freebsd-major abc
+    The status should be failure
+    The stderr should include 'digits only'
+    The output should not include 'REACHED-AFTER-PARSE'
+  End
+
+  It 'accepts a numeric --expect-freebsd-major'
+    When call run_optparse --expect-freebsd-major 16
+    The status should be success
+    The output should include 'REACHED-AFTER-PARSE'
   End
 End
 
@@ -290,7 +358,9 @@ Describe 'image-upgrade.sh verification boot command'
       wait_guest_ssh() { true; }
       ssh_guest() {
         case "$*" in
-          *"/etc/version"*) printf "26.07-BETA\n" ;;
+          *"/etc/version"*)     printf "26.07-BETA\n" ;;
+          *"pkg config ABI"*)   printf "FreeBSD:16:amd64\n" ;;
+          *"uname -r"*)         printf "16.0-CURRENT\n" ;;
         esac
       }
       pfb_boot_artifact_version /r/out.qcow2
@@ -308,6 +378,16 @@ Describe 'image-upgrade.sh verification boot command'
     The contents of file "$PXCMDS" should not include 'work.qcow2'
     The contents of file "$PXCMDS" should not include '/r/qemu.pid'
     The contents of file "$PXCMDS" should not include '/r/console.log'
+  End
+
+  It 'prints exactly three lines: version, pkg ABI, kernel release (issue #2242)'
+    When call run_bootcmd /r/work.qcow2
+    The status should be success
+    The stderr should include 'booting the exported artifact'
+    The lines of output should equal 3
+    The line 1 of output should equal '26.07-BETA'
+    The line 2 of output should equal 'FreeBSD:16:amd64'
+    The line 3 of output should equal '16.0-CURRENT'
   End
 
   It 'refuses to boot when the substitutions do not take'

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -79,7 +79,7 @@ Describe 'image-upgrade.sh pre-push artifact verification'
       eval "$(sed -n "/^# pfb_verify_artifact BEGIN/,/^# pfb_verify_artifact END/p" "$1")"
       pfb_boot_artifact_version() { printf "%s\n%s\n%s\n" "$_booted" "$_abi" "$_kern"; }
       mkdir -p "$2/globdir"
-      : > "$2/globdir/16"
+      true > "$2/globdir/16"
       cd "$2/globdir"
       pfb_verify_artifact "$2/out.qcow2" "$_tag"
       printf "REACHED-AFTER-VERIFY\n"

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -63,6 +63,29 @@ Describe 'image-upgrade.sh pre-push artifact verification'
     ' _ "$SCRIPT" "$WORK"
   }
 
+  # run_verify_glob BOOTED TAG ABI KERNEL — like run_verify, but first CDs into a
+  # scratch dir containing a file literally named "16": an unguarded
+  # `IFS=: set -- $_pva_abi` word-split lets an unquoted `*` field GLOB against real
+  # filenames in cwd instead of staying the literal text "*" (issue #2242).
+  run_verify_glob() {
+    _booted="$1" _tag="$2" _abi="$3" _kern="$4" sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      warn() { printf "WARNING: %s\n" "$*" >&2; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      LOCAL_DIR="$2"
+      EXPECT_FREEBSD_MAJOR=
+      . "$(dirname "$1")/image-lib.sh"
+      eval "$(sed -n "/^# pfb_verify_artifact BEGIN/,/^# pfb_verify_artifact END/p" "$1")"
+      pfb_boot_artifact_version() { printf "%s\n%s\n%s\n" "$_booted" "$_abi" "$_kern"; }
+      mkdir -p "$2/globdir"
+      : > "$2/globdir/16"
+      cd "$2/globdir"
+      pfb_verify_artifact "$2/out.qcow2" "$_tag"
+      printf "REACHED-AFTER-VERIFY\n"
+    ' _ "$SCRIPT" "$WORK"
+  }
+
   # run_verify_reap — drive the REAL boot helper (not the stub) into a wedged
   # boot and show where the verify VM pid ends up. cleanup() reaps $QPID from
   # the top-level shell: if the boot runs in a subshell/pipeline, the pid never
@@ -172,6 +195,20 @@ Describe 'image-upgrade.sh pre-push artifact verification'
     The stderr should include 'could not read pkg ABI'
     The output should not include 'REACHED-AFTER-VERIFY'
   End
+
+  It 'refuses to publish when the artifact never reports a kernel release'
+    When call run_verify 26.07-BETA 26.07 'FreeBSD:16:amd64' ''
+    The status should be failure
+    The stderr should include 'could not read kernel release'
+    The output should not include 'REACHED-AFTER-VERIFY'
+  End
+
+  It 'refuses to publish when the pkg ABI split would glob-match a real filename (issue #2242)'
+    When call run_verify_glob 26.07-BETA 26.07 'FreeBSD:*:amd64' '16.0-CURRENT'
+    The status should be failure
+    The stderr should include 'could not read pkg ABI'
+    The output should not include 'REACHED-AFTER-VERIFY'
+  End
 End
 
 Describe 'image-upgrade.sh --expect-freebsd-major option parsing'
@@ -201,6 +238,16 @@ Describe 'image-upgrade.sh --expect-freebsd-major option parsing'
     When call run_optparse --expect-freebsd-major 16
     The status should be success
     The output should include 'REACHED-AFTER-PARSE'
+  End
+
+  It '--help prints the whole header, past the old truncation point (issue #2242)'
+    # this option's own usage-doc line sits below the old sed cutoff -- a bare
+    # `--expect-freebsd-major` substring check would pass even truncated (the
+    # earlier flow narrative mentions the flag too), so assert the option-doc
+    # line itself, which exists only past the cutoff
+    When run script "$SCRIPT" --help
+    The status should be success
+    The output should include "require the EXPORTED artifact's pkg ABI major"
   End
 End
 

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -74,8 +74,13 @@ GUEST_IDENTITY_COMMAND = (
     "kernel_release=$(/usr/bin/uname -r 2>/dev/null || printf '?'); "
     "kernel_version=$(/usr/bin/uname -v 2>/dev/null || printf '?'); "
     "abi=$(/usr/local/sbin/pkg config ABI 2>/dev/null || printf '?'); "
-    "printf 'etc_version=%s\\nversionpatch=%s\\nkernel_release=%s\\nkernel_version=%s\\nabi=%s\\n' "
-    '"$etc_version" "$versionpatch" "$kernel_release" "$kernel_version" "$abi"'
+    "freebsd_version=$(/bin/freebsd-version 2>/dev/null || printf '?'); "
+    "pkg_client=$(/usr/local/sbin/pkg -v 2>/dev/null || printf '?'); "
+    "pkg_pkg=$(/usr/local/sbin/pkg query %v pkg 2>/dev/null || printf '?'); "
+    "printf 'etc_version=%s\\nversionpatch=%s\\nkernel_release=%s\\nkernel_version=%s\\nabi=%s\\n"
+    "freebsd_version=%s\\npkg_client=%s\\npkg_pkg=%s\\n' "
+    '"$etc_version" "$versionpatch" "$kernel_release" "$kernel_version" "$abi" '
+    '"$freebsd_version" "$pkg_client" "$pkg_pkg"'
 )
 
 # Host<->guest exposure baked into boot_vm.sh's hostfwd map (see RESULTS/01).
@@ -343,6 +348,19 @@ def _abi_os_major(abi: str) -> str:
     return ":".join(abi.split(":")[:2])
 
 
+def _abi_major(abi: str) -> str:
+    """Second ``:``-separated field of a pkg ABI string (``FreeBSD:15:amd64`` -> ``15``)."""
+    parts = abi.split(":")
+    return parts[1] if len(parts) > 1 else ""
+
+
+def _dot_major(value: str) -> str:
+    """Text before the first ``.`` (``15.0-CURRENT``/``1.21.3`` -> ``15``/``1``); a
+    missing/placeholder value (``?``, empty) passes through unchanged so it never
+    coincidentally equals a real digit major."""
+    return value.split(".", 1)[0]
+
+
 def _log_guest_identity(vm: SmokeVM) -> None:
     """Emit the booted guest facts needed to diagnose image/matrix drift."""
     result = vm.ssh(GUEST_IDENTITY_COMMAND, timeout=30.0)
@@ -357,12 +375,21 @@ def _log_guest_identity(vm: SmokeVM) -> None:
         f"expected_abi={os.environ.get('SMOKE_ABI', '?')}"
     )
     observed_abi = "?"
+    observed_freebsd_version = "?"
+    observed_pkg_client = "?"
+    observed_pkg_pkg = "?"
     for line in result.stdout.splitlines():
         print(f"PFB_GUEST_IDENTITY {line}")
         if line.startswith("abi="):
             observed_abi = line[len("abi=") :]
-    # issue #2242: live pfSense repository metadata rewrote the effective ABI mid-run;
-    # fail before pkg add rather than let a stale/foreign package land. Arch is
+        elif line.startswith("freebsd_version="):
+            observed_freebsd_version = line[len("freebsd_version=") :]
+        elif line.startswith("pkg_client="):
+            observed_pkg_client = line[len("pkg_client=") :]
+        elif line.startswith("pkg_pkg="):
+            observed_pkg_pkg = line[len("pkg_pkg=") :]
+    # issue #2242 row 1: live pfSense repository metadata rewrote the effective ABI
+    # mid-run; fail before pkg add rather than let a stale/foreign package land. Arch is
     # deliberately not compared — only OS/major.
     expected_abi = os.environ.get("SMOKE_ABI", "")
     if expected_abi and _abi_os_major(observed_abi) != _abi_os_major(expected_abi):
@@ -371,6 +398,23 @@ def _log_guest_identity(vm: SmokeVM) -> None:
             "(OS/major mismatch; issue #2242 — live pfSense repository metadata rewrote the "
             "effective ABI, refusing to pkg add)"
         )
+    if expected_abi:
+        # row 2: the userland major itself, independent of what pkg claims its ABI is.
+        expected_major = _abi_major(expected_abi)
+        if _dot_major(observed_freebsd_version) != expected_major:
+            raise RuntimeError(
+                f"guest /bin/freebsd-version {observed_freebsd_version} does not match expected "
+                f"SMOKE_ABI {expected_abi} (major mismatch; issue #2242 — a foreign FreeBSD "
+                "userland replaced the guest's own, refusing to pkg add)"
+            )
+        # row 3: the pkg CLIENT binary's own major vs the major of the pkg PACKAGE it
+        # thinks it has installed — a foreign pkg binary can replace the client without
+        # updating pkg's own package record, or vice versa.
+        if _dot_major(observed_pkg_client) != _dot_major(observed_pkg_pkg):
+            raise RuntimeError(
+                f"pkg client {observed_pkg_client} does not match the installed pkg package "
+                f"{observed_pkg_pkg} — a foreign pkg binary replaced the client (issue #2242)"
+            )
 
 
 @timed_step("boot_and_probe")

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -338,6 +338,11 @@ class BootHandle:
     log_file: BinaryIO = field(repr=False)
 
 
+def _abi_os_major(abi: str) -> str:
+    """First two ``:``-separated fields of a pkg ABI string (``FreeBSD:15``)."""
+    return ":".join(abi.split(":")[:2])
+
+
 def _log_guest_identity(vm: SmokeVM) -> None:
     """Emit the booted guest facts needed to diagnose image/matrix drift."""
     result = vm.ssh(GUEST_IDENTITY_COMMAND, timeout=30.0)
@@ -351,8 +356,21 @@ def _log_guest_identity(vm: SmokeVM) -> None:
         f"expected_version={os.environ.get('SMOKE_PFSENSE_VERSION', '?')} "
         f"expected_abi={os.environ.get('SMOKE_ABI', '?')}"
     )
+    observed_abi = "?"
     for line in result.stdout.splitlines():
         print(f"PFB_GUEST_IDENTITY {line}")
+        if line.startswith("abi="):
+            observed_abi = line[len("abi=") :]
+    # issue #2242: live pfSense repository metadata rewrote the effective ABI mid-run;
+    # fail before pkg add rather than let a stale/foreign package land. Arch is
+    # deliberately not compared — only OS/major.
+    expected_abi = os.environ.get("SMOKE_ABI", "")
+    if expected_abi and _abi_os_major(observed_abi) != _abi_os_major(expected_abi):
+        raise RuntimeError(
+            f"guest pkg ABI {observed_abi} does not match expected SMOKE_ABI {expected_abi} "
+            "(OS/major mismatch; issue #2242 — live pfSense repository metadata rewrote the "
+            "effective ABI, refusing to pkg add)"
+        )
 
 
 @timed_step("boot_and_probe")

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3660,12 +3660,18 @@ def reboot_vm(
     vm: SmokeVM,
     *,
     timeout: float = DEFAULT_BOOT_TIMEOUT,
-    require_pkg_metadata: bool = False,
+    require_pkg_metadata: bool = True,
 ) -> None:
     """Reboot, observe a changed ``kern.boottime``, then await full readiness.
 
     The boottime poll is the reboot event; ``timeout`` supplies independent salvage caps for
     that event and the subsequent readiness gate. No duration is asserted.
+
+    ``require_pkg_metadata`` defaults True: the reboot re-opens the same package-metadata ABI
+    transition window first boot has to wait out (``rc.update_pkg_metadata`` can still be
+    rewriting pkg's effective ABI after the guest answers SSH again), so every production
+    caller must wait on it too (issue #2242). Pass ``False`` only from a unit test proving the
+    flag itself.
     """
     # Fail FAST on an unreadable before-side: without it the proof is already lost, so
     # refusing to reboot saves the whole reboot+readiness cycle and leaves the box up in

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4046,6 +4046,21 @@ def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 60, delay: float = 2.0) -
     )
 
 
+# Single-probe replacement for the old bare `test -f` sentinel check (issue #2242 owner
+# residual 02:55): `pfSense-upgrade -uf` only publishes the sentinel on SUCCESS, so a
+# finished-but-failed run leaves it absent forever -- the old probe could not tell that
+# apart from "still running" and spun to the full timeout. One ssh round-trip answers
+# present/running/gone. Both alternatives are bracket-escaped (``[-]``, ``[.]``) so the
+# pattern text embedded in THIS command's own argv never satisfies itself as a match --
+# unescaped, `pgrep -f` matches its own invoking shell (verified live: an unescaped
+# `pfSense-upgrade` branch made every probe report "running" with no job anywhere).
+_METADATA_PROBE_CMD = (
+    "if /bin/test -f /var/run/pfSense_version.rc; then echo present; "
+    "elif /bin/pgrep -f 'pfSense[-]upgrade|rc[.]update_pkg_metadata' >/dev/null 2>&1; then echo running; "
+    "else echo gone; fi"
+)
+
+
 def wait_boot_complete(
     vm: SmokeVM,
     *,
@@ -4097,17 +4112,26 @@ def wait_boot_complete(
                     break
                 try:
                     metadata = vm.ssh(
-                        "/bin/test",
-                        "-f",
-                        "/var/run/pfSense_version.rc",
+                        "/bin/sh",
+                        "-c",
+                        _METADATA_PROBE_CMD,
                         timeout=min(30.0, remaining),
                     )
                 except subprocess.TimeoutExpired:
                     last_metadata = "timeout"
                     continue
                 last_metadata = f"rc={metadata.returncode} stdout={metadata.stdout!r} stderr={metadata.stderr!r}"
-                if metadata.returncode == 0:
+                word = metadata.stdout.strip()
+                if word == "present":
                     return
+                if word == "gone":
+                    print(
+                        "PFB_BOOT_METADATA sentinel=absent job=gone — pfSense metadata refresh exited "
+                        "without publishing /var/run/pfSense_version.rc (metadata FAILED, not still "
+                        "booting; issue #2242)"
+                    )
+                    return
+                # "running" (or an unrecognised word) -- job still working; keep polling.
         remaining = deadline - time.monotonic()
         if not remaining > 0:
             break

--- a/tests/test_image_refresh_plan_contract.py
+++ b/tests/test_image_refresh_plan_contract.py
@@ -333,6 +333,8 @@ class TestActivationPr:
     activated (ci: true) with the box-verified versions, via ONE tracker/* PR;
     freebsd_version only follows the box when the MAJOR changed."""
 
+    _last_proc: subprocess.CompletedProcess[str] | None = None
+
     def _run(
         self,
         tmp_path: Path,
@@ -342,6 +344,7 @@ class TestActivationPr:
         family: str = "26.07",
         pr_open: str = "",
         dry_run: str = "false",
+        expect_failure: bool = False,
     ) -> tuple[str, str, Path]:
         source = WORKFLOW.read_text(encoding="utf-8")
         step = source.split(f"      - name: {ACTIVATION_STEP}\n", 1)[1].split("\n      - name:", 1)[0]
@@ -376,7 +379,10 @@ class TestActivationPr:
             "VARIANT": "plus",
             "DRY_RUN": dry_run,
         }
-        subprocess.run(["bash", "-c", script], cwd=tmp_path, env=env, check=True, capture_output=True, text=True)
+        proc = subprocess.run(
+            ["bash", "-c", script], cwd=tmp_path, env=env, check=not expect_failure, capture_output=True, text=True
+        )
+        self._last_proc = proc
 
         def log(name: str) -> str:
             f = tmp_path / name
@@ -395,12 +401,19 @@ class TestActivationPr:
         # major unchanged (16) -> the human freebsd_version convention survives
         assert entry["freebsd_version"] == "16.0-RELEASE"
 
-    def test_major_change_rewrites_full_freebsd_version(self, tmp_path: Path) -> None:
+    def test_major_mismatch_refuses_to_activate(self, tmp_path: Path) -> None:
+        """issue #2242: a guest-reported FreeBSD major that disagrees with the
+        matrix row is a broken guest, not new truth — hard stop, no write."""
         facts = FACTS_857.replace("16.0-CURRENT", "17.0-CURRENT").replace("freebsd_major=16", "freebsd_major=17")
-        _, _, cwd = self._run(tmp_path, facts=facts)
-        entry = next(e for e in _pushed_matrix(cwd)["versions"] if e["pfsense_version"] == "26.07")
-        assert entry["freebsd_major"] == "17"
-        assert entry["freebsd_version"] == "17.0-CURRENT"
+        git_log, gh_log, _ = self._run(tmp_path, facts=facts, expect_failure=True)
+        proc = self._last_proc
+        assert proc is not None
+        assert proc.returncode != 0
+        assert "::error::" in proc.stdout
+        assert "17" in proc.stdout
+        assert "16" in proc.stdout
+        assert "push" not in git_log
+        assert "pr create" not in gh_log
 
     def test_active_and_accurate_entry_does_nothing(self, tmp_path: Path) -> None:
         facts = (

--- a/tests/test_image_refresh_plan_contract.py
+++ b/tests/test_image_refresh_plan_contract.py
@@ -330,8 +330,11 @@ def _pushed_matrix(tmp_path: Path) -> dict[str, Any]:
 
 class TestActivationPr:
     """Scenario (issue #1837): after a publish, the leg's matrix entry is
-    activated (ci: true) with the box-verified versions, via ONE tracker/* PR;
-    freebsd_version only follows the box when the MAJOR changed."""
+    activated (ci: true) with the box-verified php/py versions, via ONE
+    tracker/* PR. A FreeBSD major mismatch between the guest and the matrix
+    row refuses to activate (::error:: + exit 1, no write) instead of
+    rewriting freebsd_version/freebsd_major; either side being unrecorded
+    warns without blocking the activation (issue #2242)."""
 
     _last_proc: subprocess.CompletedProcess[str] | None = None
 
@@ -414,6 +417,35 @@ class TestActivationPr:
         assert "16" in proc.stdout
         assert "push" not in git_log
         assert "pr create" not in gh_log
+
+    def test_missing_matrix_freebsd_major_warns_and_proceeds(self, tmp_path: Path) -> None:
+        """issue #2242 C7: an empty side of the major comparison must not go silent —
+        the step warns naming the missing side, but still activates (unlike a real
+        mismatch, which hard-stops)."""
+        matrix = json.loads(json.dumps(PLUS_2607_MATRIX))
+        del matrix["versions"][1]["freebsd_major"]
+        facts = FACTS_857.replace("freebsd_major=16", "freebsd_major=17")
+        git_log, gh_log, cwd = self._run(tmp_path, facts=facts, matrix=matrix)
+        proc = self._last_proc
+        assert proc is not None
+        assert proc.returncode == 0
+        assert "::warning::" in proc.stdout
+        assert "17" in proc.stdout
+        assert "--force origin tracker/matrix-activate-plus-26.07" in git_log
+        assert "pr create" in gh_log
+
+    def test_missing_guest_freebsd_major_warns_and_proceeds(self, tmp_path: Path) -> None:
+        """issue #2242 C7: the guest side can also be empty (a facts probe that
+        never resolved it) — same warn-and-proceed contract."""
+        facts = FACTS_857.replace("freebsd_major=16\n", "")
+        git_log, gh_log, _ = self._run(tmp_path, facts=facts)
+        proc = self._last_proc
+        assert proc is not None
+        assert proc.returncode == 0
+        assert "::warning::" in proc.stdout
+        assert "16" in proc.stdout
+        assert "--force origin tracker/matrix-activate-plus-26.07" in git_log
+        assert "pr create" in gh_log
 
     def test_active_and_accurate_entry_does_nothing(self, tmp_path: Path) -> None:
         facts = (

--- a/tests/test_image_refresh_upgrade_contract.py
+++ b/tests/test_image_refresh_upgrade_contract.py
@@ -91,7 +91,25 @@ def test_self_refresh_leg_passes_expect_freebsd_major(tmp_path: Path) -> None:
     assert argv[argv.index("--expect-freebsd-major") + 1] == "15"
 
 
-def test_cross_version_leg_omits_expect_freebsd_major(tmp_path: Path) -> None:
-    """Direct/cross-version legs do not pass --expect-freebsd-major."""
+def test_cross_version_leg_passes_expect_freebsd_major(tmp_path: Path) -> None:
+    """issue #2242: cross-version legs ALSO pass --expect-freebsd-major —
+    matrix.freebsd_version is the TARGET row's value in both leg modes (the
+    version-tracker's direct-leg builder), so the self-consistency check applies
+    on every leg, not only same-version refreshes."""
     argv = _run_upgrade(tmp_path, from_tag="2.8", target_tag="2.9", force_flag="", freebsd_version="16.0-RELEASE")
+    assert "--expect-freebsd-major" in argv
+    assert argv[argv.index("--expect-freebsd-major") + 1] == "16"
+
+
+def test_missing_freebsd_version_omits_expect_freebsd_major(tmp_path: Path) -> None:
+    """An empty matrix.freebsd_version (unreachable on the live matrix) must not
+    derive a garbage major — the flag is simply omitted."""
+    argv = _run_upgrade(tmp_path, from_tag="2.8", target_tag="2.9", force_flag="", freebsd_version="")
+    assert "--expect-freebsd-major" not in argv
+
+
+def test_non_digit_freebsd_major_omits_expect_freebsd_major(tmp_path: Path) -> None:
+    """A freebsd_version with no leading digits (no dot to split on) must not
+    hand a non-numeric value to --expect-freebsd-major, which rejects it."""
+    argv = _run_upgrade(tmp_path, from_tag="2.8", target_tag="2.9", force_flag="", freebsd_version="15-STABLE")
     assert "--expect-freebsd-major" not in argv

--- a/tests/test_image_refresh_upgrade_contract.py
+++ b/tests/test_image_refresh_upgrade_contract.py
@@ -30,7 +30,14 @@ def _upgrade_script() -> str:
     return "\n".join(body)
 
 
-def _run_upgrade(tmp_path: Path, *, from_tag: str, target_tag: str, force_flag: str) -> list[str]:
+def _run_upgrade(
+    tmp_path: Path,
+    *,
+    from_tag: str,
+    target_tag: str,
+    force_flag: str,
+    freebsd_version: str = "15.0-RELEASE",
+) -> list[str]:
     """Run the workflow body with a fake ``sh`` and return image-upgrade argv."""
     fake_sh = tmp_path / "sh"
     fake_sh.write_text('#!/bin/sh\nprintf \'%s\\n\' "$@" > "$ARGV_OUT"\n', encoding="utf-8")
@@ -48,6 +55,7 @@ def _run_upgrade(tmp_path: Path, *, from_tag: str, target_tag: str, force_flag: 
         "FORCE_FLAG": force_flag,
         "BRANCH": "",
         "SMOKE_IMAGE": "ghcr.io/pfblockerng/pfsense-ce",
+        "FREEBSD_VERSION": freebsd_version,
     }
     subprocess.run(["bash", "-c", script], cwd=tmp_path, env=env, check=True, capture_output=True, text=True)
     return argv_file.read_text(encoding="utf-8").splitlines()
@@ -72,3 +80,18 @@ def test_upgrade_flag_follows_version_transition_not_force(
     argv = _run_upgrade(tmp_path, from_tag=from_tag, target_tag=target_tag, force_flag=force_flag)
     assert ("--upgrade-pkgs" in argv) is upgrade_pkgs
     assert ("--force" in argv) is force
+
+
+def test_self_refresh_leg_passes_expect_freebsd_major(tmp_path: Path) -> None:
+    """Same-version legs derive --expect-freebsd-major from matrix.freebsd_version
+    (issue #2242) — the self-consistency check still applies even though this
+    leg's freebsd_version provenance is otherwise out of scope."""
+    argv = _run_upgrade(tmp_path, from_tag="2.8", target_tag="2.8", force_flag="", freebsd_version="15.0-RELEASE")
+    assert "--expect-freebsd-major" in argv
+    assert argv[argv.index("--expect-freebsd-major") + 1] == "15"
+
+
+def test_cross_version_leg_omits_expect_freebsd_major(tmp_path: Path) -> None:
+    """Direct/cross-version legs do not pass --expect-freebsd-major."""
+    argv = _run_upgrade(tmp_path, from_tag="2.8", target_tag="2.9", force_flag="", freebsd_version="16.0-RELEASE")
+    assert "--expect-freebsd-major" not in argv

--- a/tests/test_image_refresh_upgrade_contract.py
+++ b/tests/test_image_refresh_upgrade_contract.py
@@ -103,7 +103,8 @@ def test_cross_version_leg_passes_expect_freebsd_major(tmp_path: Path) -> None:
 
 def test_missing_freebsd_version_omits_expect_freebsd_major(tmp_path: Path) -> None:
     """An empty matrix.freebsd_version (unreachable on the live matrix) must not
-    derive a garbage major — the flag is simply omitted."""
+    derive a garbage major — the flag is simply omitted. Pins the omission only;
+    the digits guard itself is proven by the non-digit sibling test."""
     argv = _run_upgrade(tmp_path, from_tag="2.8", target_tag="2.9", force_flag="", freebsd_version="")
     assert "--expect-freebsd-major" not in argv
 

--- a/tests/test_smoke_boot_identity.py
+++ b/tests/test_smoke_boot_identity.py
@@ -82,6 +82,99 @@ def test_log_guest_identity_empty_output_is_loud() -> None:
         smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, EmptyVM()))
 
 
+class _IdentityVM:
+    """A guest whose ssh(...) always returns the given identity probe stdout."""
+
+    def __init__(self, stdout: str) -> None:
+        self._stdout = stdout
+        self.calls: list[tuple[tuple[str, ...], float]] = []
+
+    def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+        self.calls.append((remote, timeout))
+        return subprocess.CompletedProcess(remote, 0, self._stdout, "")
+
+
+def _identity_stdout(abi_line: str | None) -> str:
+    lines = [
+        "etc_version=2.8.1-RELEASE",
+        "versionpatch=0",
+        "kernel_release=15.0-CURRENT",
+        "kernel_version=FreeBSD 15 build",
+    ]
+    if abi_line is not None:
+        lines.append(abi_line)
+    return "\n".join(lines) + "\n"
+
+
+def test_log_guest_identity_raises_on_abi_os_major_mismatch(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # issue #2242: live pfSense repository metadata rewrote the effective ABI mid-run
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:16:amd64"))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+    assert "FreeBSD:16:amd64" in str(exc_info.value)
+    assert "FreeBSD:15:amd64" in str(exc_info.value)
+    printed = capsys.readouterr().out
+    assert "PFB_GUEST_IDENTITY abi=FreeBSD:16:amd64" in printed, "diagnostics must survive the raise"
+
+
+def test_log_guest_identity_allows_matching_abi_os_major(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:amd64"))
+
+    smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))  # must not raise
+
+
+def test_log_guest_identity_skips_check_when_smoke_abi_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SMOKE_ABI", raising=False)
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:16:amd64"))
+
+    smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))  # must not raise
+
+
+def test_log_guest_identity_treats_empty_smoke_abi_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:16:amd64"))
+
+    smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))  # must not raise
+
+
+def test_log_guest_identity_raises_on_abi_fallback_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout("abi=?"))
+
+    with pytest.raises(RuntimeError, match=r"FreeBSD:15:amd64"):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
+def test_log_guest_identity_allows_arch_only_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    # arch is deliberately not compared here — only OS/major (issue #2242 scope)
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:aarch64"))
+
+    smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))  # must not raise
+
+
+def test_log_guest_identity_raises_when_abi_line_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout(None))
+
+    with pytest.raises(RuntimeError, match=r"FreeBSD:15:amd64"):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
+def test_log_guest_identity_raises_on_garbage_smoke_abi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "garbage")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:amd64"))
+
+    with pytest.raises(RuntimeError, match=r"garbage"):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
 def test_successful_deploy_emits_installer_diagnostics(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:

--- a/tests/test_smoke_boot_identity.py
+++ b/tests/test_smoke_boot_identity.py
@@ -27,7 +27,8 @@ def test_log_guest_identity_reports_observed_and_expected_facts(
                 0,
                 "etc_version=2.8.1-RELEASE\nversionpatch=0\n"
                 "kernel_release=15.0-CURRENT\nkernel_version=FreeBSD 15 build\n"
-                "abi=FreeBSD:15:amd64\n",
+                "abi=FreeBSD:15:amd64\nfreebsd_version=15.0-CURRENT\n"
+                "pkg_client=1.21.3\npkg_pkg=1.21.3_8\n",
                 "",
             )
 
@@ -47,12 +48,18 @@ def test_log_guest_identity_reports_observed_and_expected_facts(
         "PFB_GUEST_IDENTITY kernel_release=15.0-CURRENT",
         "PFB_GUEST_IDENTITY kernel_version=FreeBSD 15 build",
         "PFB_GUEST_IDENTITY abi=FreeBSD:15:amd64",
+        "PFB_GUEST_IDENTITY freebsd_version=15.0-CURRENT",
+        "PFB_GUEST_IDENTITY pkg_client=1.21.3",
+        "PFB_GUEST_IDENTITY pkg_pkg=1.21.3_8",
     ]
     assert "/bin/cat /etc/version" in smoke_conftest.GUEST_IDENTITY_COMMAND
     assert "/bin/cat /etc/versionpatch" in smoke_conftest.GUEST_IDENTITY_COMMAND
     assert "/usr/bin/uname -r" in smoke_conftest.GUEST_IDENTITY_COMMAND
     assert "/usr/bin/uname -v" in smoke_conftest.GUEST_IDENTITY_COMMAND
     assert "/usr/local/sbin/pkg config ABI" in smoke_conftest.GUEST_IDENTITY_COMMAND
+    assert "/bin/freebsd-version" in smoke_conftest.GUEST_IDENTITY_COMMAND
+    assert "/usr/local/sbin/pkg -v" in smoke_conftest.GUEST_IDENTITY_COMMAND
+    assert "/usr/local/sbin/pkg query %v pkg" in smoke_conftest.GUEST_IDENTITY_COMMAND
 
 
 def test_log_guest_identity_failure_is_loud_and_read_only() -> None:
@@ -94,7 +101,15 @@ class _IdentityVM:
         return subprocess.CompletedProcess(remote, 0, self._stdout, "")
 
 
-def _identity_stdout(abi_line: str | None) -> str:
+def _identity_stdout(
+    abi_line: str | None,
+    *,
+    freebsd_version_line: str = "freebsd_version=15.0-CURRENT",
+    pkg_client_line: str = "pkg_client=1.21.3",
+    pkg_pkg_line: str = "pkg_pkg=1.21.3_8",
+) -> str:
+    """Row-2/row-3 fields default to values consistent with the SMOKE_ABI major most
+    tests here use (15), so an abi-focused fixture doesn't accidentally trip rows 2/3."""
     lines = [
         "etc_version=2.8.1-RELEASE",
         "versionpatch=0",
@@ -103,6 +118,7 @@ def _identity_stdout(abi_line: str | None) -> str:
     ]
     if abi_line is not None:
         lines.append(abi_line)
+    lines += [freebsd_version_line, pkg_client_line, pkg_pkg_line]
     return "\n".join(lines) + "\n"
 
 
@@ -173,6 +189,92 @@ def test_log_guest_identity_raises_on_garbage_smoke_abi(monkeypatch: pytest.Monk
 
     with pytest.raises(RuntimeError, match=r"garbage"):
         smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
+# --- row 2: /bin/freebsd-version major vs SMOKE_ABI major (owner residual table) ---
+
+
+def test_log_guest_identity_raises_on_freebsd_version_major_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:amd64", freebsd_version_line="freebsd_version=16.0-CURRENT"))
+
+    with pytest.raises(RuntimeError, match=r"freebsd-version") as exc_info:
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+    assert "16.0-CURRENT" in str(exc_info.value)
+    assert "FreeBSD:15:amd64" in str(exc_info.value)
+
+
+def test_log_guest_identity_raises_on_freebsd_version_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:amd64", freebsd_version_line="freebsd_version=?"))
+
+    with pytest.raises(RuntimeError, match=r"freebsd-version"):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
+def test_log_guest_identity_allows_matching_freebsd_version_major(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    # a patch-level difference on the same major must not raise
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:amd64", freebsd_version_line="freebsd_version=15.1-RELEASE"))
+
+    smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))  # must not raise
+
+
+# --- row 3: pkg client major vs the installed pkg package's own major ---
+
+
+def test_log_guest_identity_raises_on_pkg_client_major_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(
+        _identity_stdout("abi=FreeBSD:15:amd64", pkg_client_line="pkg_client=2.7.5", pkg_pkg_line="pkg_pkg=1.21.3_8")
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"pkg client 2\.7\.5 does not match the installed pkg package 1\.21\.3_8",
+    ):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
+def test_log_guest_identity_allows_matching_pkg_client_major(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    # a patch-level difference on the same major must not raise
+    vm = _IdentityVM(
+        _identity_stdout("abi=FreeBSD:15:amd64", pkg_client_line="pkg_client=1.21.3", pkg_pkg_line="pkg_pkg=1.21.4_1")
+    )
+
+    smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))  # must not raise
+
+
+def test_log_guest_identity_raises_on_pkg_client_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:amd64", pkg_client_line="pkg_client=?"))
+
+    with pytest.raises(RuntimeError, match=r"pkg client"):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
+def test_log_guest_identity_raises_on_pkg_pkg_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:amd64", pkg_pkg_line="pkg_pkg=?"))
+
+    with pytest.raises(RuntimeError, match=r"pkg client"):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
+def test_log_guest_identity_skips_rows_2_and_3_when_smoke_abi_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SMOKE_ABI", raising=False)
+    vm = _IdentityVM(
+        _identity_stdout(
+            "abi=FreeBSD:16:amd64",
+            freebsd_version_line="freebsd_version=99.0-CURRENT",
+            pkg_client_line="pkg_client=9.9.9",
+            pkg_pkg_line="pkg_pkg=1.1.1",
+        )
+    )
+
+    smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))  # must not raise
 
 
 def test_successful_deploy_emits_installer_diagnostics(

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -1,4 +1,13 @@
-"""Issue #2242: boot readiness includes pfSense package metadata settlement."""
+"""Issue #2242: boot readiness includes pfSense package metadata settlement.
+
+Owner residual (2026-08-15 02:55): ``pfSense-upgrade -uf`` only publishes
+``/var/run/pfSense_version.rc`` on SUCCESS. A finished-but-failed run leaves the
+metadata job gone and the sentinel never written, so the old ``test -f`` probe
+spun until the full 180s timeout instead of recognising "job exited, no
+sentinel" as metadata FAILURE. The predicate now asks a single probe for one of
+three words (``present``/``running``/``gone``) and returns on either
+``present`` or ``gone`` -- only ``running`` keeps polling.
+"""
 
 from __future__ import annotations
 
@@ -9,17 +18,23 @@ import pytest
 
 from tests.smoke import helpers
 
+_PROBE_ARGV = ("/bin/sh", "-c", helpers._METADATA_PROBE_CMD)
 
-def test_wait_boot_complete_waits_for_boot_metadata_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
-    sentinel_statuses = iter([1, 0])
+
+def test_wait_boot_complete_waits_for_boot_metadata_sentinel(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The metadata job is still running on the first probe; the sentinel
+    appears by the second -- waits, no loud "metadata failed" line."""
+    probe_words = iter(["running", "present"])
     calls: list[tuple[str, ...]] = []
 
     class FakeVM:
         def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
             calls.append(remote)
-            if remote == ("/bin/test", "-f", "/var/run/pfSense_version.rc"):
-                return subprocess.CompletedProcess(remote, next(sentinel_statuses), "", "")
-            return subprocess.CompletedProcess(remote, 0, "", "")
+            if remote == _PROBE_ARGV:
+                return subprocess.CompletedProcess(remote, 0, next(probe_words), "")
+            return subprocess.CompletedProcess(remote, 1, "", "")
 
     monkeypatch.setattr(
         helpers,
@@ -27,14 +42,86 @@ def test_wait_boot_complete_waits_for_boot_metadata_sentinel(monkeypatch: pytest
         lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
     )
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
-    monkeypatch.setattr(helpers.time, "monotonic", lambda: 0.0)
 
-    helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=3, delay=0)
+    helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=2, delay=0)
 
-    assert calls == [
-        ("/bin/test", "-f", "/var/run/pfSense_version.rc"),
-        ("/bin/test", "-f", "/var/run/pfSense_version.rc"),
-    ]
+    assert calls == [_PROBE_ARGV, _PROBE_ARGV]
+    assert "PFB_BOOT_METADATA" not in capsys.readouterr().out
+
+
+def test_wait_boot_complete_returns_when_metadata_job_exits_without_sentinel(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #2242 owner residual 02:55: two probes see the job still running,
+    the third sees it gone with no sentinel published -- must return (not
+    time out) and print the one loud metadata-failure line."""
+    probe_words = ["running", "running", "gone"]
+    calls: list[tuple[str, ...]] = []
+
+    class FakeVM:
+        def __init__(self) -> None:
+            self._n = 0
+
+        def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            calls.append(remote)
+            # OLD-shape probe (pre-fix production code) never matches _PROBE_ARGV and
+            # always reports a non-zero rc here, so the pre-fix code cannot return early
+            # (its success test is bare `returncode == 0`) and instead spins to timeout --
+            # the RED failure this fixture proves is "raise on timeout", not a StopIteration
+            # or an argv-mismatch assertion error.
+            if remote != _PROBE_ARGV:
+                return subprocess.CompletedProcess(remote, 1, "", "")
+            word = probe_words[min(self._n, len(probe_words) - 1)]
+            self._n += 1
+            return subprocess.CompletedProcess(remote, 0, word, "")
+
+    monkeypatch.setattr(
+        helpers,
+        "php_eval",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
+    )
+    monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
+
+    helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=2, delay=0)
+
+    assert [c for c in calls if c == _PROBE_ARGV] == [_PROBE_ARGV] * 3
+    printed = capsys.readouterr().out
+    assert (
+        "PFB_BOOT_METADATA sentinel=absent job=gone — pfSense metadata refresh exited without "
+        "publishing /var/run/pfSense_version.rc (metadata FAILED, not still booting; issue #2242)"
+    ) in printed
+
+
+def test_wait_boot_complete_metadata_job_stuck_running_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The job never exits (always ``running``) -- the timeout path must still
+    raise, not spin forever or silently return."""
+    ticks = iter([0.0, 0.0] + [float(n) for n in range(1, 200)])
+
+    def fake_monotonic() -> float:
+        try:
+            return next(ticks)
+        except StopIteration:
+            return 1000.0
+
+    calls: list[tuple[str, ...]] = []
+
+    class FakeVM:
+        def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            calls.append(remote)
+            return subprocess.CompletedProcess(remote, 0, "running", "")
+
+    monkeypatch.setattr(
+        helpers,
+        "php_eval",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
+    )
+    monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(helpers.time, "monotonic", fake_monotonic)
+
+    with pytest.raises(RuntimeError, match="did not settle"):
+        helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=3, delay=0)
+
+    assert _PROBE_ARGV in calls
 
 
 def test_wait_boot_complete_keeps_per_probe_cap_for_long_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -44,7 +131,7 @@ def test_wait_boot_complete_keeps_per_probe_cap_for_long_deadline(monkeypatch: p
     class FakeVM:
         def ssh(self, *_remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
             metadata_timeouts.append(timeout)
-            return subprocess.CompletedProcess([], 0, "", "")
+            return subprocess.CompletedProcess([], 0, "present", "")
 
     def fake_php_eval(
         _vm: helpers.SmokeVM,

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -90,5 +90,5 @@ def test_reboot_vm_waits_for_changed_boottime_before_readiness(
     assert ready_calls
     assert "/sbin/reboot" in fake_vm.calls
     assert fake_vm.boottime_reads == 4
-    assert boot_waits == [(vm, False if require_pkg_metadata is None else require_pkg_metadata)]
+    assert boot_waits == [(vm, True if require_pkg_metadata is None else require_pkg_metadata)]
     assert cron_guards == [vm]


### PR DESCRIPTION
## Summary

Residual of #2242 (reopened 2026-08-15): the ABI-mismatch symptom that broke every CE leg was observed but never *guarded*. Three steps:

1. `smoke: fail the boot identity probe closed on an ABI OS/major mismatch` — `tests/smoke/conftest.py::_log_guest_identity` still prints every `PFB_GUEST_IDENTITY` line, then raises when `SMOKE_ABI` is set and the guest's `pkg config ABI` differs from it in OS or major (`FreeBSD:15` vs `FreeBSD:16`). Arch is deliberately not compared. `SMOKE_ABI` unset (local runs) → print-only. The probe already runs after the metadata wait and before `pkg add`, so this is the pre-deploy boundary.
2. `image-refresh: refuse to publish or activate a guest whose FreeBSD major drifted` —
   - `scripts/image-upgrade.sh`: `pfb_boot_artifact_version` reads `/etc/version`, `pkg config ABI`, `uname -r` from the one verification boot; `pfb_verify_artifact` (signature and wiring line unchanged) dies when ABI or kernel is unreadable, when the ABI's FreeBSD major disagrees with the kernel's, or — new `--expect-freebsd-major N` (digits only) — with the expected major.
   - `.github/workflows/image-refresh.yml`: self-refresh legs (`FROM_TAG == TARGET_TAG`) pass `--expect-freebsd-major ${matrix.freebsd_version%%.*}`; cross-version legs rely on the self-consistency check only. The activation step no longer rewrites `freebsd_major`/`freebsd_version` from guest facts: a differing major is `::error::` + `exit 1` before any branch push or PR (the matrix is human-curated; a surprise major is a broken guest, not new truth).

3. Step C (review round 1 + the owner's two later residual comments, 2026-08-15 02:09 and 02:55):
   - `reboot_vm` defaults to `require_pkg_metadata=True` — an in-test reboot re-opens the metadata ABI window, so every production reboot waits again.
   - `wait_boot_complete` metadata predicate: return when `is_platform_booting()==0` and either `/var/run/pfSense_version.rc` exists or no `pfSense-upgrade` / `rc.update_pkg_metadata` process remains (one three-word ssh probe: `present` / `running` / `gone`); `gone` without the sentinel prints a loud `PFB_BOOT_METADATA … metadata FAILED` line and returns instead of spinning to the timeout.
   - Identity probe rows 2 and 3 of the residual table: `/bin/freebsd-version` major must match `SMOKE_ABI`; `pkg -v` major must match `pkg query %v pkg` (a foreign pkg binary replacing the client). Three new `PFB_GUEST_IDENTITY` lines; every check independent, both values in every message.
   - `--expect-freebsd-major` on every leg (the matrix `freebsd_version` is the target row's on direct legs too), guarded to non-empty digits; activation warns (`::warning::`) when either side lacks `freebsd_major` instead of proceeding silently; `set -f` on the ABI split (glob-safe); kernel-unreadable refusal pinned by a spec row; `--help` range covers the whole header; docstrings/comments updated (kernel `uname -r` is the artifact reference; the activation step is `continue-on-error` by design).

## Evidence

Step A — `tests/test_smoke_boot_identity.py` frozen at `9f54ef366fa8dea14a70d61c1c6c7dd961f2e43b`: RED on untouched conftest `4 failed, 13 passed` (A1 mismatch, A4 `abi=?`, A6 no `abi=` line, A7 garbage `SMOKE_ABI` — all `DID NOT RAISE`); GREEN unchanged `17 passed`; mutation (compare forced false) → same 4 red. Independent verifier re-executed all of it: PASS.

Step B — `image_upgrade_be_spec.sh` frozen at `cdb0d324025bdc69e464952ef7c710f6c9670219`, `test_image_refresh_plan_contract.py` at `fc23bc4cabb09bb5ffcb438f4880030785d5d137`: RED with production at the parent commit — shellspec `21 examples, 7 failures` (B2 ABI≠kernel, B3 ABI≠expected, B5 unreadable ABI, B6b 3-line boot output, B11 option parse ×2, plus the old single-line "never reports a version" example), pytest `2 failed` (B7 activation refuses on major mismatch, B9 self-refresh passes the flag); GREEN unchanged `21 examples, 0 failures` / `24 passed`; mutations: drop ABI-vs-kernel compare → only B2 red; drop the activation `exit 1` → only B7 red. `test_image_refresh_upgrade_contract.py` was `ruff format`ted after its red run (implementer-reported red hash `7b391d04…`, committed `db5e4bb7…`); the verifier re-ran the red/green cycle against the committed content and it holds. Verifier gate: PASS.

Step C (each row executed RED against the untouched production file, frozen, then GREEN with zero test edits; hashes recorded at red):
- C1 `test_smoke_reboot_boottime.py` `0ef0f72e…`: RED `[(FakeVM, False)] == [(FakeVM, True)]` `1 failed, 2 passed` → GREEN `3 passed`.
- C2 `test_smoke_boot_metadata_wait.py` `f15bbc03…` (production at red = old wait logic plus only the new `_METADATA_PROBE_CMD` constant, hash `cedda73e…`, so the frozen test could import it): RED `3 failed, 3 passed` — sentinel test and job-gone test both `pfSense boot did not settle after 2s`, stuck-running test `DID NOT RAISE` → GREEN `6 passed`. Independent probe in the CI image: `pgrep -f 'pfSense[-]upgrade|rc[.]update_pkg_metadata'` does not match its own `sh -c` wrapper and does match a real `pfSense-upgrade` process.
- C3 `test_smoke_boot_identity.py` `ef4029a8…` (re-frozen `738bb095…` after a whitespace-only `ruff format`, re-verified green): RED `6 failed, 19 passed` (print-shape + five `DID NOT RAISE`) → GREEN `25 passed`.
- C4 kernel-unreadable spec row: guard already shipped, so mutation instead — guard deleted → `22 examples, 1 failure` (`expected … to include "could not read kernel release"`), restored → `0 failures`.
- C6 `test_image_refresh_upgrade_contract.py` `52ca6664…`: RED `test_cross_version_leg_passes_expect_freebsd_major` `1 failed, 6 passed` → GREEN `7 passed`.
- C7 `test_image_refresh_plan_contract.py` `ccbd958a…`: RED both `::warning::` tests `2 failed` → GREEN `21 passed`.
- C8+C9 `image_upgrade_be_spec.sh` `a7bc8279…`: RED glob row (`REACHED-AFTER-VERIFY` — a file named `16` matched as the ABI major) + `--help` row `24 examples, 2 failures` → GREEN `24 examples, 0 failures`; help row later tightened to assert the header's last lines (`--force`, `Auth:`), RED `24 examples, 1 failure` → marker-delimited `sed` → GREEN.
Round-2 legs re-executed the step-C red/green cycles and mutations independently.

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (CI image), re-run after rebase onto current `devel`.

Fixes #2242

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
