### PR TITLE
publish: refresh_landing republish knob; retire add-repo.sh / migrate-channel.sh from the site

### DIFF
--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -20,6 +20,11 @@ on:
         description: Immutable source Release tag
         required: true
         type: string
+      refresh_landing:
+        description: Re-render the landing page/autoindexes even when the catalogue is unchanged (client-script or card changes)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   packages: read
@@ -173,6 +178,7 @@ jobs:
           SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
           ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}
           BASE_URL: https://pfblockerng.github.io/pkg
+          PUBLISH_REFRESH_LANDING: ${{ inputs.refresh_landing && '1' || '0' }}
         # Path env vars are exported HERE, not in the env: map above — GitHub
         # Actions never shell-expands env-map values, so `$GITHUB_WORKSPACE`
         # there reaches the job as a literal dollar-string (issue #2231). The

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1173,10 +1173,13 @@ Full design: ADR-39.
   (tagged + `PUBLISH_STAGE=direct` only; `pkg-republish.yml`'s `refresh_landing` input)
   forces the full landing regen on that same no-op path, for shipping a landing
   template/card fix via a republish of an already-published release (issue #2416
-  follow-up). Both that no-op path and a real publish also sweep any retired
-  client script (`RETIRED_CLIENT_SCRIPTS`: `add-repo.sh`, `migrate-channel.sh`,
-  superseded by `install.sh`) still present on the live site out of the same
-  commit. Trust model is unchanged
+  follow-up). Any retired client script (`RETIRED_CLIENT_SCRIPTS`: `add-repo.sh`,
+  `migrate-channel.sh`, superseded by `install.sh`) still present on the live
+  site is swept out of the same commit, but only when that commit also
+  regenerates the landing page — a `PUBLISH_REFRESH_LANDING=1` no-op, a
+  direct/nightly real publish, or `PUBLISH_STAGE=promote` — never the
+  knob-off no-op or a `PUBLISH_STAGE=stage` run, which would 404 a script the
+  live `index.html` still links. Trust model is unchanged
   (`signature_type: none`, HTTPS/TLS to the Pages host — no catalogue-signing key); the landing
   page (`scripts/gen_landing.py`) documents the channel audiences, shared-bytes fan-out,
   single-repository subscription, and the explicit repository-qualified downgrade rule. The

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1169,7 +1169,14 @@ Full design: ADR-39.
   regenerates the one deterministic client script (`gen_landing.py
   --client-scripts-only`: `install.sh`, issue #2416) and commits it if it
   drifted (issue #2408) — the timestamped
-  landing/browse/autoindex pages remain publish-only. Trust model is unchanged
+  landing/browse/autoindex pages remain publish-only unless `PUBLISH_REFRESH_LANDING=1`
+  (tagged + `PUBLISH_STAGE=direct` only; `pkg-republish.yml`'s `refresh_landing` input)
+  forces the full landing regen on that same no-op path, for shipping a landing
+  template/card fix via a republish of an already-published release (issue #2416
+  follow-up). Both that no-op path and a real publish also sweep any retired
+  client script (`RETIRED_CLIENT_SCRIPTS`: `add-repo.sh`, `migrate-channel.sh`,
+  superseded by `install.sh`) still present on the live site out of the same
+  commit. Trust model is unchanged
   (`signature_type: none`, HTTPS/TLS to the Pages host — no catalogue-signing key); the landing
   page (`scripts/gen_landing.py`) documents the channel audiences, shared-bytes fan-out,
   single-repository subscription, and the explicit repository-qualified downgrade rule. The

--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -23,7 +23,10 @@
 # output and docs/.nojekyll; on a catalogue no-op, only the regenerated
 # client script (issue #2408) unless PUBLISH_REFRESH_LANDING=1 (issue #2416
 # follow-up) — see below. Any retired client script still on the live site is
-# swept in the same commit either way.
+# swept ONLY in a commit that also regenerates the landing page — a
+# PUBLISH_REFRESH_LANDING=1 no-op, a direct/nightly real publish, or a
+# "promote" — never a knob-off (default) no-op or a "stage" no-op/run, which
+# would 404 a script the live index.html still links.
 #
 # On a rejected push (another run advanced origin/main first), the ENTIRE cycle
 # reruns from a fresh sync — not a rebase of the local commit — because
@@ -430,6 +433,7 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                 exit 1
             }
             landing_regen_and_stage
+            remove_retired_client_scripts
             commit_message=$(printf 'publish: %s -> %s\n\npfBlockerNG-Release-Tag: %s\npfBlockerNG-Source-Run-Id: %s\npfBlockerNG-Promoted-From: %s\n' \
                 "$RELEASE_TAG" "$DESTINATIONS" "$RELEASE_TAG" "$SOURCE_RUN_ID" "$STAGING_PREFIX")
             ;;
@@ -544,6 +548,11 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                 # follow-up).
                 if [ "$PUBLISH_REFRESH_LANDING" = 1 ]; then
                     landing_regen_and_stage
+                    # Only here: the sweep must never ride a commit that does not
+                    # also regenerate the landing page — the live index.html still
+                    # links every RETIRED_CLIENT_SCRIPTS entry, so a knob-off sweep
+                    # would 404 it.
+                    remove_retired_client_scripts
                 else
                     python3 "${PFB_SRC}/scripts/gen_landing.py" \
                         "${PKG_REPO}/docs" "$BASE_URL" \
@@ -555,7 +564,6 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                     # shellcheck disable=SC2086  # client_script_paths is a controlled, space-separated pathspec list
                     git -C "$PKG_REPO" add -- $client_script_paths
                 fi
-                remove_retired_client_scripts
                 if git -C "$PKG_REPO" diff --cached --quiet; then
                     if [ "$PUBLISH_STAGE" = stage ]; then
                         emit_stage_outputs true
@@ -576,10 +584,10 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                 stage_commit=1
             else
                 # --- landing page regen — only for an actual publish ---------------
-                # Never on the catalogue-NOOP path above: gen_landing.py's page output
-                # embeds a generation timestamp, so running it there would manufacture
-                # a diff (and therefore a commit) on every run even when no catalogue
-                # changed.
+                # Unless PUBLISH_REFRESH_LANDING=1, never on the catalogue-NOOP path
+                # above: gen_landing.py's page output embeds a generation timestamp,
+                # so running it there would manufacture a diff (and therefore a
+                # commit) on every run even when no catalogue changed.
                 #
                 # landing_matrix.json's abi expression (pinned by
                 # tests/shell/publish_pkg_repo_spec.sh): freebsd_major alone feeds the

--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -21,7 +21,9 @@
 # `git add -A` / `git add .` anywhere below — only the exact touched (channel,
 # varver) directories the publisher reports, plus the landing page's own
 # output and docs/.nojekyll; on a catalogue no-op, only the regenerated
-# client script (issue #2408).
+# client script (issue #2408) unless PUBLISH_REFRESH_LANDING=1 (issue #2416
+# follow-up) — see below. Any retired client script still on the live site is
+# swept in the same commit either way.
 #
 # On a rejected push (another run advanced origin/main first), the ENTIRE cycle
 # reruns from a fresh sync — not a rebase of the local commit — because
@@ -75,6 +77,15 @@
 #   PUBLISH_STAGE           "direct" (default), "stage", "promote", or "discard";
 #                        anything else is a usage error. Only "direct" is valid
 #                        when PUBLISH_KIND=nightly.
+#   PUBLISH_REFRESH_LANDING "0" (default) or "1"; on an otherwise catalogue-NOOP
+#                        run, "1" regenerates the FULL landing page
+#                        (index.html/browse.html/every autoindex) instead of
+#                        just CLIENT_SCRIPTS — for shipping a landing
+#                        template/card fix via a republish of an
+#                        already-published release (issue #2416 follow-up).
+#                        Valid only with PUBLISH_KIND=tagged and
+#                        PUBLISH_STAGE=direct; any other combination is a usage
+#                        error.
 #   MAX_PUSH_ATTEMPTS      bounded retry count (default 5)
 # Optional — PUBLISH_STAGE=stage only, when GITHUB_ACTIONS-style outputs are
 # wanted:
@@ -119,6 +130,12 @@ set -eu
 # list and the direct/promote stage_paths list below.
 CLIENT_SCRIPTS="install.sh"
 
+# Scripts the landing generator used to publish before the issue #2416
+# follow-up collapsed every client entry point down to install.sh above —
+# gen_landing.py no longer writes them, but a republish of an
+# already-published release must still sweep them off an already-live site.
+RETIRED_CLIENT_SCRIPTS="add-repo.sh migrate-channel.sh"
+
 PUBLISH_KIND="${PUBLISH_KIND:-tagged}"
 case "$PUBLISH_KIND" in
     tagged | nightly) ;;
@@ -133,6 +150,15 @@ case "$PUBLISH_STAGE" in
     direct | stage | promote | discard) ;;
     *)
         echo "::error::PUBLISH_STAGE must be 'direct', 'stage', 'promote', or 'discard', got '${PUBLISH_STAGE}'" >&2
+        exit 1
+        ;;
+esac
+
+PUBLISH_REFRESH_LANDING="${PUBLISH_REFRESH_LANDING:-0}"
+case "$PUBLISH_REFRESH_LANDING" in
+    0 | 1) ;;
+    *)
+        echo "::error::PUBLISH_REFRESH_LANDING must be '0' or '1', got '${PUBLISH_REFRESH_LANDING}'" >&2
         exit 1
         ;;
 esac
@@ -177,6 +203,13 @@ esac
 # snapshot is out of scope here (see the header docblock).
 if [ "$PUBLISH_KIND" = nightly ] && [ "$PUBLISH_STAGE" != direct ]; then
     echo "::error::PUBLISH_STAGE must be 'direct' when PUBLISH_KIND=nightly, got '${PUBLISH_STAGE}'" >&2
+    exit 1
+fi
+
+# PUBLISH_REFRESH_LANDING=1 only makes sense on the real single-push publish
+# flow — stage/promote/discard and nightly keep their own flows untouched.
+if [ "$PUBLISH_REFRESH_LANDING" = 1 ] && { [ "$PUBLISH_KIND" != tagged ] || [ "$PUBLISH_STAGE" != direct ]; }; then
+    echo "::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct, got PUBLISH_KIND='${PUBLISH_KIND}' PUBLISH_STAGE='${PUBLISH_STAGE}'" >&2
     exit 1
 fi
 
@@ -245,6 +278,16 @@ remove_docs_staging_tree() {
         git -C "$PKG_REPO" rm -r --quiet docs/staging
     fi
     rm -rf "${PKG_REPO}/docs/staging"
+}
+
+# Stages the removal of every RETIRED_CLIENT_SCRIPTS entry still present on the
+# live site, so the deletion rides the same commit as whatever else this run is
+# already about to commit (NOOP script/landing refresh, or a real publish).
+# --ignore-unmatch is a no-op once a script is already gone.
+remove_retired_client_scripts() {
+    for retired in $RETIRED_CLIENT_SCRIPTS; do
+        git -C "$PKG_REPO" rm -q --ignore-unmatch -- "docs/${retired}"
+    done
 }
 
 # Relocates every $touched (channel, varver) target under
@@ -487,22 +530,32 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
 
             script_refresh=0
             if [ -z "$touched" ]; then
-                # --- catalogue unchanged: the client scripts may still have drifted ---
+                # --- catalogue unchanged: the client scripts (or, with
+                # PUBLISH_REFRESH_LANDING=1, the whole landing page) may still have
+                # drifted --------------------------------------------------------
                 # Every client script (CLIENT_SCRIPTS) is generated from the PFB_SRC
                 # checkout, not from the release assets, so a script-only fix must ship
                 # even when every destination already matches (issue #2408, issue #2416).
-                # Only the deterministic script set is regenerated here — the
-                # landing/browse/autoindex pages embed a generation timestamp, and
-                # writing them on a no-op would manufacture a commit on every run.
-                python3 "${PFB_SRC}/scripts/gen_landing.py" \
-                    "${PKG_REPO}/docs" "$BASE_URL" \
-                    --client-scripts-only
-                client_script_paths=""
-                for client_script in $CLIENT_SCRIPTS; do
-                    client_script_paths="${client_script_paths} docs/${client_script}"
-                done
-                # shellcheck disable=SC2086  # client_script_paths is a controlled, space-separated pathspec list
-                git -C "$PKG_REPO" add -- $client_script_paths
+                # By default only the deterministic script set is regenerated here —
+                # the landing/browse/autoindex pages embed a generation timestamp, and
+                # writing them on every no-op would manufacture a commit on every run.
+                # PUBLISH_REFRESH_LANDING=1 (validated tagged+direct-only above) opts
+                # into the full regen instead, for a landing-only fix (issue #2416
+                # follow-up).
+                if [ "$PUBLISH_REFRESH_LANDING" = 1 ]; then
+                    landing_regen_and_stage
+                else
+                    python3 "${PFB_SRC}/scripts/gen_landing.py" \
+                        "${PKG_REPO}/docs" "$BASE_URL" \
+                        --client-scripts-only
+                    client_script_paths=""
+                    for client_script in $CLIENT_SCRIPTS; do
+                        client_script_paths="${client_script_paths} docs/${client_script}"
+                    done
+                    # shellcheck disable=SC2086  # client_script_paths is a controlled, space-separated pathspec list
+                    git -C "$PKG_REPO" add -- $client_script_paths
+                fi
+                remove_retired_client_scripts
                 if git -C "$PKG_REPO" diff --cached --quiet; then
                     if [ "$PUBLISH_STAGE" = stage ]; then
                         emit_stage_outputs true
@@ -511,7 +564,11 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                     echo "publish-pkg-repo: NOOP — nothing touched, nothing to commit."
                     exit 0
                 fi
-                echo "publish-pkg-repo: catalogue unchanged — client script(s) drifted; committing a script refresh."
+                if [ "$PUBLISH_REFRESH_LANDING" = 1 ]; then
+                    echo "publish-pkg-repo: catalogue unchanged — PUBLISH_REFRESH_LANDING=1; committing a landing refresh."
+                else
+                    echo "publish-pkg-repo: catalogue unchanged — client script(s) drifted; committing a script refresh."
+                fi
                 script_refresh=1
             elif [ "$PUBLISH_STAGE" = stage ]; then
                 # --- stage: relocate the publisher's output, never serve it --------
@@ -534,6 +591,7 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                 # route_matrix (the handoff is what this run actually verified against —
                 # never a freshly re-read live matrix, which could have moved since).
                 landing_regen_and_stage
+                remove_retired_client_scripts
 
                 # --- stage EXACTLY what changed — never -A / . ----------------------
                 if git -C "$PKG_REPO" diff --cached --quiet; then
@@ -546,8 +604,13 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
             if [ "$script_refresh" -eq 1 ]; then
                 # Mode-independent: the refresh carries no release/nightly identity —
                 # its content comes from PFB_SRC, so the run id is the whole provenance.
-                commit_message=$(printf 'publish: refresh client scripts\n\npfBlockerNG-Source-Run-Id: %s\n' \
-                    "$SOURCE_RUN_ID")
+                if [ "$PUBLISH_REFRESH_LANDING" = 1 ]; then
+                    commit_message=$(printf 'publish: refresh landing page\n\npfBlockerNG-Source-Run-Id: %s\n' \
+                        "$SOURCE_RUN_ID")
+                else
+                    commit_message=$(printf 'publish: refresh client scripts\n\npfBlockerNG-Source-Run-Id: %s\n' \
+                        "$SOURCE_RUN_ID")
+                fi
             elif [ "$PUBLISH_STAGE" = stage ]; then
                 commit_message=$(printf 'publish: stage %s -> %s\n\npfBlockerNG-Release-Tag: %s\npfBlockerNG-Source-Run-Id: %s\npfBlockerNG-Staging-Prefix: %s\n' \
                     "$RELEASE_TAG" "$DESTINATIONS" "$RELEASE_TAG" "$SOURCE_RUN_ID" "$stage_prefix")

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -743,6 +743,26 @@ JSON
     The result of function remote_head_now should equal "$original_remote_head"
   End
 
+  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_STAGE=promote, before any git call'
+    export PUBLISH_REFRESH_LANDING=1
+    export PUBLISH_STAGE=promote
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_STAGE=discard, before any git call'
+    export PUBLISH_REFRESH_LANDING=1
+    export PUBLISH_STAGE=discard
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
   It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_KIND=nightly, before any git call'
     nightly_env
     export PUBLISH_REFRESH_LANDING=1
@@ -766,7 +786,10 @@ JSON
   # replaced by the single --channel install.sh, issue #2416 follow-up) must be
   # swept off an already-live site by a republish -----------------------------
 
-  It 'retired: a catalogue+script NOOP still ships a commit that removes retired client scripts'
+  It 'retired: PUBLISH_REFRESH_LANDING=1 sweeps retired client scripts into the landing-regen NOOP commit'
+    # The sweep only ever rides a commit that ALSO regenerates the landing page —
+    # the knob-off NOOP path below never sweeps (the live index.html still links
+    # the retired scripts; a knob-off sweep would 404 it without a regen).
     write_client_script_stubs
     # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
     ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
@@ -775,15 +798,43 @@ JSON
     printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
     ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
         && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
+    export PUBLISH_REFRESH_LANDING=1
     export FAKE_MODE=noop
     When run script "$script"
     The status should equal 0
     The output should include 'ADVANCE'
     The stderr should include 'main'
     committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should equal 'docs/add-repo.sh docs/migrate-channel.sh'
+    The variable committed should include 'docs/add-repo.sh'
+    The variable committed should include 'docs/migrate-channel.sh'
+    The variable committed should include 'docs/index.html'
     The path "${base}/pkg-repo/docs/add-repo.sh" should not be exist
     The path "${base}/pkg-repo/docs/migrate-channel.sh" should not be exist
+  End
+
+  It 'retired: PUBLISH_REFRESH_LANDING unset leaves retired scripts in place on the catalogue+script NOOP — no landing regen, no 404'
+    # The retired-script sweep must never run without a landing regen in the
+    # same commit — the live index.html still links docs/add-repo.sh, so a
+    # knob-off sweep would 404 it. Knob unset (default '0') on an otherwise
+    # true NOOP must leave the retired scripts untouched and commit nothing.
+    write_client_script_stubs
+    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
+    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
+        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
+    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
+    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
+        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
+    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
+    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
+    export FAKE_MODE=noop
+    When run script "$script"
+    The status should equal 0
+    The output should include 'NOOP'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+    The path "${base}/pkg-repo/docs/add-repo.sh" should be exist
+    The path "${base}/pkg-repo/docs/migrate-channel.sh" should be exist
   End
 
   It 'retired: a real publish also removes retired client scripts still present on the site'
@@ -1243,6 +1294,34 @@ HOOK
     The variable out should include 'noop=true'
   End
 
+  It 's4b: stage full no-op with retired scripts present leaves them untouched — PUBLISH_REFRESH_LANDING is always 0 under stage'
+    # PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_STAGE=stage (see the
+    # refresh-landing rejection examples above), so the knob is always '0' here
+    # — the shared no-op branch must never sweep retired scripts on a stage run
+    # either.
+    export PUBLISH_STAGE=stage
+    write_client_script_stubs
+    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
+    (cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
+        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main)
+    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
+    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
+        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
+    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
+    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
+    export FAKE_MODE=noop
+    export GITHUB_OUTPUT="${base}/github_output.txt"
+    true >"$GITHUB_OUTPUT"
+    When run script "$script"
+    The status should equal 0
+    The output should include 'NOOP'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+    The path "${base}/pkg-repo/docs/add-repo.sh" should be exist
+    The path "${base}/pkg-repo/docs/migrate-channel.sh" should be exist
+  End
+
   It 's5: stage removes a stale docs/staging tree from an earlier crashed run in the same commit as the new one'
     export PUBLISH_STAGE=stage
     mkdir -p "${base}/pkg-repo/docs/staging/OLD/edge/ce-2.8"
@@ -1373,6 +1452,29 @@ HOOK
     porcelain="$(git_fixture -C "${base}/pkg-repo" status --porcelain)"
     The variable porcelain should include 'README.txt'
     The variable porcelain should include 'debris.txt'
+  End
+
+  It 'p1b: promote also sweeps retired client scripts still present on the live site'
+    # promote runs landing_regen_and_stage (it IS a landing regen — the step
+    # that goes live), so the retired-script sweep belongs there too, same as
+    # the direct real-publish path.
+    seed_staged_tree
+    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
+    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
+        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
+    export PUBLISH_STAGE=promote
+    export STAGING_PREFIX=staging/10-1
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
+    The variable committed should include 'docs/add-repo.sh'
+    The variable committed should include 'docs/migrate-channel.sh'
+    The variable committed should include 'docs/edge/ce-2.8/marker.pkg'
+    The path "${base}/pkg-repo/docs/add-repo.sh" should not be exist
+    The path "${base}/pkg-repo/docs/migrate-channel.sh" should not be exist
   End
 
   It 'p2: promote never invokes the publisher'

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -701,6 +701,122 @@ JSON
     The result of function remote_head_now should equal "$original_remote_head"
   End
 
+  # --- PUBLISH_REFRESH_LANDING (issue #2416 follow-up: republish of an
+  # already-published release must be able to refresh the landing page, not
+  # just the client scripts) ------------------------------------------------
+
+  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 forces a full landing regen on the NOOP path, committing index.html plus the client script'
+    export PUBLISH_REFRESH_LANDING=1
+    export FAKE_MODE=noop
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    The path "${base}/pkg-repo/docs/index.html" should be exist
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
+    The variable committed should include 'docs/index.html'
+    The variable committed should include 'docs/install.sh'
+    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
+    The variable msg should include 'publish: refresh landing page'
+    The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1'
+  End
+
+  It 'refresh-landing: PUBLISH_REFRESH_LANDING unset leaves the NOOP path unchanged — no landing regen'
+    write_client_script_stubs
+    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
+    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
+        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
+    export FAKE_MODE=noop
+    When run script "$script"
+    The status should equal 0
+    The output should include 'NOOP'
+    The path "${base}/pkg-repo/docs/index.html" should not be exist
+  End
+
+  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_STAGE=stage, before any git call'
+    export PUBLISH_REFRESH_LANDING=1
+    export PUBLISH_STAGE=stage
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_KIND=nightly, before any git call'
+    nightly_env
+    export PUBLISH_REFRESH_LANDING=1
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'refresh-landing: rejects a PUBLISH_REFRESH_LANDING value other than 0 or 1, before any git call'
+    export PUBLISH_REFRESH_LANDING=yes
+    When run script "$script"
+    The status should equal 1
+    The stderr should include "::error::PUBLISH_REFRESH_LANDING must be '0' or '1', got 'yes'"
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  # --- retired client scripts (docs/add-repo.sh, docs/migrate-channel.sh —
+  # replaced by the single --channel install.sh, issue #2416 follow-up) must be
+  # swept off an already-live site by a republish -----------------------------
+
+  It 'retired: a catalogue+script NOOP still ships a commit that removes retired client scripts'
+    write_client_script_stubs
+    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
+    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
+        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
+    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
+    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
+        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
+    export FAKE_MODE=noop
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
+    The variable committed should equal 'docs/add-repo.sh docs/migrate-channel.sh'
+    The path "${base}/pkg-repo/docs/add-repo.sh" should not be exist
+    The path "${base}/pkg-repo/docs/migrate-channel.sh" should not be exist
+  End
+
+  It 'retired: a real publish also removes retired client scripts still present on the site'
+    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
+    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
+    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
+        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
+    The variable committed should include 'docs/add-repo.sh'
+    The variable committed should include 'docs/migrate-channel.sh'
+    The variable committed should include 'docs/edge/ce-2.8/marker.pkg'
+    The path "${base}/pkg-repo/docs/add-repo.sh" should not be exist
+    The path "${base}/pkg-repo/docs/migrate-channel.sh" should not be exist
+  End
+
+  It 'retired: retired client scripts absent from the site never error the run'
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
+    The variable committed should not include 'add-repo.sh'
+    The variable committed should not include 'migrate-channel.sh'
+  End
+
   # --- a damaged working tree must never reach a commit --------------------
 
   It 'never commits or pushes a mid-regeneration fault, even though the working tree is left damaged'

--- a/tests/test_issue2143_republish_workflow.py
+++ b/tests/test_issue2143_republish_workflow.py
@@ -40,11 +40,9 @@ _IDENTITY_VALUES = {
     },
 }
 _SOURCE_RUN_ID_VALUE = "${{ github.run_id }}:${{ github.run_attempt }}"
-# issue #2416 follow-up: pkg-republish.yml's own `refresh_landing` workflow_dispatch
-# input (never `github.event.inputs.*`, which would read `${{ }}` context syntax
-# from the wrong namespace under `workflow_dispatch` — `inputs.*` is the one that
-# resolves) toggled to the '0'/'1' string publish-pkg-repo.sh's own
-# PUBLISH_REFRESH_LANDING case-statement parses.
+# pkg-republish.yml's Boolean `refresh_landing` input maps to the '0'/'1' string
+# publish-pkg-repo.sh's PUBLISH_REFRESH_LANDING parses; `inputs.*` keeps the Boolean
+# (`github.event.inputs.*` would stringify it, making "false" truthy).
 _PUBLISH_REFRESH_LANDING_VALUE = "${{ inputs.refresh_landing && '1' || '0' }}"
 
 

--- a/tests/test_issue2143_republish_workflow.py
+++ b/tests/test_issue2143_republish_workflow.py
@@ -40,6 +40,12 @@ _IDENTITY_VALUES = {
     },
 }
 _SOURCE_RUN_ID_VALUE = "${{ github.run_id }}:${{ github.run_attempt }}"
+# issue #2416 follow-up: pkg-republish.yml's own `refresh_landing` workflow_dispatch
+# input (never `github.event.inputs.*`, which would read `${{ }}` context syntax
+# from the wrong namespace under `workflow_dispatch` — `inputs.*` is the one that
+# resolves) toggled to the '0'/'1' string publish-pkg-repo.sh's own
+# PUBLISH_REFRESH_LANDING case-statement parses.
+_PUBLISH_REFRESH_LANDING_VALUE = "${{ inputs.refresh_landing && '1' || '0' }}"
 
 
 def test_manual_republish_requires_exact_release_identity() -> None:
@@ -60,6 +66,15 @@ def test_republish_and_published_callbacks_forward_exact_run_identity() -> None:
             assert f"{key}: {value}" in step
         assert f"SOURCE_RUN_ID: {_SOURCE_RUN_ID_VALUE}" in step
         assert "gh release list" not in workflow
+
+
+def test_republish_env_carries_refresh_landing_toggle_expression() -> None:
+    # PUBLISHED (release-published.yml) never sets PUBLISH_REFRESH_LANDING — its
+    # "Stage the pkg catalogue" step always runs PUBLISH_STAGE=stage, and the knob
+    # is a usage error there (publish-pkg-repo.sh rejects PUBLISH_REFRESH_LANDING=1
+    # unless PUBLISH_STAGE=direct) — only REPUBLISH carries the toggle.
+    step = extract_step(REPUBLISH, _STEP_NAMES[REPUBLISH])
+    assert f"PUBLISH_REFRESH_LANDING: {_PUBLISH_REFRESH_LANDING_VALUE}" in step
 
 
 def test_manual_republish_rejects_release_selector_before_api(tmp_path: Path) -> None:


### PR DESCRIPTION
Part of #2416. Enables the "republish the website" the owner asked for after #2444/#2448 without a new release.

## What

- `scripts/publish-pkg-repo.sh`: `PUBLISH_REFRESH_LANDING=1` (tagged + `direct` only; rejected for stage/promote/discard/nightly) makes the catalogue-NOOP path run the full landing regeneration instead of `--client-scripts-only`, so card/recipe changes reach the site without a catalogue change. `RETIRED_CLIENT_SCRIPTS` (`add-repo.sh`, `migrate-channel.sh`) are `git rm`'d only in a commit that also regenerates the landing page — a `refresh_landing` no-op, a direct/nightly real publish, or `promote` — never by the knob-off (default) no-op or a `stage` run, which would otherwise 404 a script the live `index.html` still links. The publisher never removed retired files before.
- `.github/workflows/pkg-republish.yml`: boolean input `refresh_landing` (default false) → `PUBLISH_REFRESH_LANDING`.
- architecture-notes: one sentence each.

## Proof

`tests/shell/publish_pkg_repo_spec.sh` +13 examples across two red-first rounds (6 red on the untouched script, hash `94a65bff` frozen through green → 71/0; then 3 red for the sweep gating/promote, hash `90bcc6c8` frozen → 76/0): refresh forces full regen on NOOP; knob unset keeps the old behaviour and leaves retired scripts in place; rejected under `stage`/`promote`/`discard` and under nightly; invalid value rejected; retired scripts swept on a refresh no-op, a real publish and promote, untouched on a stage no-op, absent → no error. `test_issue2143_republish_workflow.py` pins the `refresh_landing` env expression. `run-gates.sh --diff origin/devel` PASS; actionlint clean.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional workflow setting to regenerate the package landing page and autoindex during tagged republishing.
  * Retired client scripts are now removed during landing refreshes, publishes, and promotes.
  * Catalogue-only refreshes continue to update client scripts without regenerating the full landing page.

* **Bug Fixes**
  * Added validation to reject invalid refresh settings and unsupported publishing modes.

* **Tests**
  * Expanded coverage for landing refreshes, script cleanup, workflow forwarding, and no-op publishing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->