### PR TITLE
pkg Pages: standalone render-website workflow, called by publish/republish/nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -502,7 +502,9 @@ jobs:
     uses: ./.github/workflows/pkg-render-site.yml
     with:
       source_ref: "${{ needs.prepare.outputs.tools_sha }}"
-    secrets: inherit
+    secrets:
+      PKG_GITHUB_APP_ID: ${{ secrets.PKG_GITHUB_APP_ID }}
+      PKG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
 
   validate-live-pages-install:
     name: Live Pages pkg install

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -494,8 +494,15 @@ jobs:
           # Failed Nightly? Dispatch another one. No durable allocation exists to
           # recover or replay; each invocation gets its own timestamped version.
           export SOURCE_RUN_ID="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
-          export BASE_URL=https://pfblockerng.github.io/pkg
           sh trusted/scripts/publish-pkg-repo.sh
+
+  render-site:
+    name: Render the pkg website
+    needs: [prepare, publish-pkg-repo]
+    uses: ./.github/workflows/pkg-render-site.yml
+    with:
+      source_ref: "${{ needs.prepare.outputs.tools_sha }}"
+    secrets: inherit
 
   validate-live-pages-install:
     name: Live Pages pkg install

--- a/.github/workflows/pkg-render-site.yml
+++ b/.github/workflows/pkg-render-site.yml
@@ -1,0 +1,103 @@
+name: Render pkg website
+
+# Renders everything under pfBlockerNG/pkg's docs/ EXCEPT the catalogue-owned
+# trees (stable/testing/edge/nightly/staging) from this repo's pkg-site/ via
+# scripts/render-pkg-site.sh (issue #2450 step 3). Every catalogue-publishing
+# workflow (release-published.yml, pkg-republish.yml, nightly.yml) calls this
+# AFTER its own publish job commits the catalogue; a bare workflow_dispatch
+# re-renders the site on demand. This workflow never verifies a release --
+# publishing the catalogue stays each caller's own job.
+
+on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: pfBlockerNG ref providing scripts/gen_landing.py + pkg-site/
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: pfBlockerNG ref providing scripts/gen_landing.py + pkg-site/ (blank = the ref this dispatch itself ran on)
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  packages: read
+  contents: read
+
+jobs:
+  render:
+    name: Render the pkg website
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pkg-render-site
+      cancel-in-progress: false
+    container:
+      image: ghcr.io/pfblockerng/ci-runner:9
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --init --user 1001:1001
+    env:
+      HOME: /tmp
+    steps:
+      - name: Checkout pfBlockerNG (the engine + orchestration scripts)
+        uses: actions/checkout@v6
+        with:
+          # SECURITY: render-pkg-site.sh below is EXECUTED AS SHELL and, via the
+          # minted App token, can push to pfBlockerNG/pkg — pin the ref explicitly,
+          # never trust a floating default. A workflow_call caller forwards its own
+          # trusted ref; a bare dispatch runs at the ref it was dispatched on.
+          ref: ${{ inputs.source_ref || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate GitHub App token (pkg)
+        id: app-token
+        # Mint a short-lived installation token from the PKG GitHub App, scoped to
+        # pfBlockerNG/pkg with Contents:write — create-github-app-token NARROWS the
+        # token to only the permission(s) listed, so contents:write here (not
+        # actions:write) is the whole reason the token can push code.
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
+          owner: pfBlockerNG
+          repositories: pkg
+          permission-contents: write
+
+      - name: Checkout pfBlockerNG/pkg
+        uses: actions/checkout@v6
+        with:
+          repository: pfBlockerNG/pkg
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true # render-pkg-site.sh pushes via this token
+          path: pkg-repo
+          fetch-depth: 1
+
+      - name: Read the pinned ROUTE matrix
+        id: route
+        run: |
+          set -eu
+          git fetch --no-tags --depth 1 origin \
+            "+refs/heads/ci-metadata:refs/remotes/origin/ci-metadata"
+          ROUTE_MATRIX=$(sh scripts/read-version-matrix.sh --print-route | jq -c .)
+          echo "route_matrix=${ROUTE_MATRIX}" >> "$GITHUB_OUTPUT"
+
+      - name: Render the pkg website
+        env:
+          SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
+          ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}
+          BASE_URL: https://pfblockerng.github.io/pkg
+        # Path env vars are exported HERE, not in the env: map above — GitHub
+        # Actions never shell-expands env-map values, so `$GITHUB_WORKSPACE`
+        # there reaches the job as a literal dollar-string (issue #2231). The
+        # run body is where a shell expands the container-translated value.
+        run: |
+          set -eu
+          export PFB_SRC="$GITHUB_WORKSPACE"
+          export PKG_REPO="$GITHUB_WORKSPACE/pkg-repo"
+          sh scripts/render-pkg-site.sh

--- a/.github/workflows/pkg-render-site.yml
+++ b/.github/workflows/pkg-render-site.yml
@@ -15,6 +15,11 @@ on:
         description: pfBlockerNG ref providing scripts/gen_landing.py + pkg-site/
         required: true
         type: string
+    secrets:
+      PKG_GITHUB_APP_ID:
+        required: true
+      PKG_GITHUB_APP_PRIVATE_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       source_ref:

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -192,4 +192,6 @@ jobs:
     uses: ./.github/workflows/pkg-render-site.yml
     with:
       source_ref: "${{ github.workflow_sha }}"
-    secrets: inherit
+    secrets:
+      PKG_GITHUB_APP_ID: ${{ secrets.PKG_GITHUB_APP_ID }}
+      PKG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -7,7 +7,10 @@ name: Trigger pkg repository republish
 # FAILED run means the App ID / private key is missing, misconfigured, or lacks
 # Contents:write on pfBlockerNG/pkg. issue #2146: there is no workflow in
 # pfBlockerNG/pkg any more — this run does the verify + assemble + commit + push
-# itself, exactly like release-published.yml's job.
+# itself, exactly like release-published.yml's job. This job republishes the
+# catalogue ONLY; the render-site job below (pkg-render-site.yml, issue #2450
+# step 3) renders the site around it afterward — the two are separate concerns
+# with disjoint docs/ ownership.
 
 on:
   workflow_dispatch:
@@ -20,11 +23,6 @@ on:
         description: Immutable source Release tag
         required: true
         type: string
-      refresh_landing:
-        description: Re-render the landing page/autoindexes even when the catalogue is unchanged (client-script or card changes)
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   packages: read
@@ -177,8 +175,6 @@ jobs:
           DESTINATIONS: ${{ steps.resolve.outputs.destinations }}
           SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
           ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}
-          BASE_URL: https://pfblockerng.github.io/pkg
-          PUBLISH_REFRESH_LANDING: ${{ inputs.refresh_landing && '1' || '0' }}
         # Path env vars are exported HERE, not in the env: map above — GitHub
         # Actions never shell-expands env-map values, so `$GITHUB_WORKSPACE`
         # there reaches the job as a literal dollar-string (issue #2231). The
@@ -189,3 +185,11 @@ jobs:
           export PKG_REPO="$GITHUB_WORKSPACE/pkg-repo"
           export ASSETS_DIR="$RUNNER_TEMP/assets"
           sh scripts/publish-pkg-repo.sh
+
+  render-site:
+    name: Render the pkg website
+    needs: publish
+    uses: ./.github/workflows/pkg-render-site.yml
+    with:
+      source_ref: "${{ github.workflow_sha }}"
+    secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -506,4 +506,6 @@ jobs:
     uses: ./.github/workflows/pkg-render-site.yml
     with:
       source_ref: "${{ github.workflow_sha }}"
-    secrets: inherit
+    secrets:
+      PKG_GITHUB_APP_ID: ${{ secrets.PKG_GITHUB_APP_ID }}
+      PKG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -151,10 +151,13 @@ jobs:
   # run does everything: verify the published Release's .pkg assets against the
   # pinned ROUTE matrix (scripts/publish_release.py, loading the engine straight
   # out of THIS checkout via PFB_SRC), drop them into pkg's docs/<channel>/<varver>/,
-  # prune + regenerate each touched catalogue, regenerate the landing page, and
-  # commit + fast-forward-push the result to pkg's own `main` — GitHub Pages serves
-  # that branch directly (build_type: legacy), so the push IS the deployment. See
-  # scripts/publish-pkg-repo.sh, the only thing here that touches git.
+  # prune + regenerate each touched catalogue, and commit + fast-forward-push the
+  # result to pkg's own `main` — GitHub Pages serves that branch directly
+  # (build_type: legacy), so the push IS the deployment. See
+  # scripts/publish-pkg-repo.sh, the only thing here that touches git. The site
+  # AROUND the catalogue (landing page, browse view, install.sh, …) is the
+  # render-site job's own concern (below, issue #2450 step 3) — this job never
+  # touches it.
   publish-pkg-repo:
     name: Stage the pkg catalogue
     runs-on: ubuntu-latest
@@ -172,18 +175,17 @@ jobs:
       contents: read
     # issue #2389: this job only STAGES (the "Stage the pkg catalogue" step below
     # pins PUBLISH_STAGE to the stage mode) — it is NOT the deploy/announce.
-    # Nothing is visible under <channel>/<varver> or on the landing page until
-    # promote-pkg-repo — the actual deploy/announce step — runs the SAME script
-    # in `promote` mode, downstream of a green validate-live-pages-install.
+    # Nothing is visible under <channel>/<varver> until promote-pkg-repo — the
+    # actual deploy/announce step — runs the SAME script in `promote` mode,
+    # downstream of a green validate-live-pages-install.
     # staging_prefix/touched/noop are the per-run identity that gate +
     # promote/discard consume without re-deriving them (pin-consumed-downstream,
-    # #2387); route_matrix carries the ROUTE step's already-fetched matrix
-    # through so promote-pkg-repo never re-reads the live ci-metadata ref itself.
+    # #2387). No route_matrix output (issue #2450 step 3): promote-pkg-repo never
+    # ran the publisher itself, so ROUTE_MATRIX was always vestigial there.
     outputs:
       staging_prefix: ${{ steps.stage.outputs.staging_prefix }}
       touched: ${{ steps.stage.outputs.touched }}
       noop: ${{ steps.stage.outputs.noop }}
-      route_matrix: ${{ steps.route.outputs.route_matrix }}
     steps:
       - name: Checkout pfBlockerNG (the engine + orchestration scripts — TRUSTED ref)
         uses: actions/checkout@v6
@@ -271,11 +273,10 @@ jobs:
           DESTINATIONS: ${{ needs.resolve.outputs.destinations }}
           SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
           ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}
-          BASE_URL: https://pfblockerng.github.io/pkg
           # issue #2389: stage under docs/staging/<seg>/<channel>/<varver> instead
           # of publishing directly — nothing is visible under <channel>/<varver>
-          # or on the landing page until promote-pkg-repo runs the SAME script in
-          # `promote` mode, after a green live-install gate.
+          # until promote-pkg-repo runs the SAME script in `promote` mode, after a
+          # green live-install gate.
           PUBLISH_STAGE: stage
         # Path env vars are exported HERE, not in the env: map above — GitHub
         # Actions never shell-expands env-map values, so `$GITHUB_WORKSPACE`
@@ -406,10 +407,13 @@ jobs:
 
   # ── 4. Promote the pkg catalogue — the actual announce (issue #2389) ───────
   # This is the ONLY job that makes a publish visible: the catalogue only becomes
-  # reachable under <channel>/<varver> and the landing page only regenerates once
-  # this job runs the SAME script in `promote` mode. A red or skipped live-install
-  # gate flips PUBLISH_STAGE to `discard` instead — the staged tree is deleted and
-  # this job then fails the run (below) so nothing was silently announced.
+  # reachable under <channel>/<varver> once this job runs the SAME script in
+  # `promote` mode. A red or skipped live-install gate flips PUBLISH_STAGE to
+  # `discard` instead — the staged tree is deleted and this job then fails the
+  # run (below) so nothing was silently announced. The landing page itself is
+  # NOT regenerated here any more (issue #2450 step 3): render-site (below)
+  # renders it afterward, whenever this job's own publish (publish-pkg-repo)
+  # succeeded — after a promote, a discard, or a catalogue no-op alike.
   promote-pkg-repo:
     name: Promote the pkg catalogue
     runs-on: ubuntu-latest
@@ -465,8 +469,6 @@ jobs:
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
           DESTINATIONS: ${{ needs.resolve.outputs.destinations }}
           SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
-          ROUTE_MATRIX: ${{ needs.publish-pkg-repo.outputs.route_matrix }}
-          BASE_URL: https://pfblockerng.github.io/pkg
           STAGING_PREFIX: ${{ needs.publish-pkg-repo.outputs.staging_prefix }}
           # promote iff BOTH the matrix-prep and every live-install leg it fanned
           # out over came back green; anything else (a red leg, a red prep, a
@@ -490,3 +492,18 @@ jobs:
             echo "::error::live Pages install gate did not pass (prepare-live-gate or validate-live-pages-install failed/cancelled) — staging discarded, nothing announced"
             exit 1
           fi
+
+  # ── 5. Render the pkg website (issue #2450 step 3) ──────────────────────────
+  # Runs whenever this run's own publish-pkg-repo succeeded, regardless of what
+  # promote-pkg-repo did with it: a promote, a discard, and a catalogue no-op
+  # (where promote-pkg-repo is skipped entirely, issue #2408) are all cases the
+  # render must reflect, and the render is idempotent + always correct for the
+  # catalogue as it stands — a NOOP render commits nothing.
+  render-site:
+    name: Render the pkg website
+    needs: [publish-pkg-repo, promote-pkg-repo]
+    if: always() && needs.publish-pkg-repo.result == 'success'
+    uses: ./.github/workflows/pkg-render-site.yml
+    with:
+      source_ref: "${{ github.workflow_sha }}"
+    secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -403,20 +403,24 @@ is installing a retained older version rather than re-deploying a site.
   `zstd`), no libpkg, run on a plain Linux runner. `scripts/build-repo.sh` (real `pkg repo`
   in a FreeBSD VM) is the fidelity fallback, and both share the exact `--print-conf` shape
   the inline conf in the README reuses byte-for-byte.
-- **Client scripts.** The Pages root serves one self-contained `install.sh`, parameterized
-  by `--channel` (issue #2416 follow-up) — the SOLE client entry point — published by
-  `scripts/gen_landing.py` from `scripts/install.sh` (subscription, install/move,
-  legacy-identity replacement, and verification, folded into one idempotent script — no
-  repository-only step that can leave a box subscribed but not installed). The boot-time
-  regenerator hook is embedded the same way.
+- **Site tree.** `pkg-site/` (this repo) is the declared, non-catalogue site tree —
+  `install.sh`, `--channel`-parameterized (issue #2416 follow-up) — the SOLE client entry
+  point — and `recipes/<channel>.sh` (the verbatim card text each channel's landing card
+  shows). `scripts/render-pkg-site.sh` mirrors it 1:1 into `pkg`'s `docs/`, `{base}`-substituted
+  and with the boot-time regenerator hook embedded, alongside the dynamic pages it also renders
+  (landing `index.html`, `browse.html`, `browse/<channel>/<varver>/index.html`) — all of it
+  OUTSIDE the catalogue trees (issue #2450).
 - **Triggers.** `pfBlockerNG/pkg` carries no workflow of its own — it holds the served tree and
   GitHub Pages publishes it from `main`. This repo does the publishing: the `publish-pkg-repo`
   job in `release-published.yml` runs on the real `release: published` event, and
   `pkg-republish.yml` re-runs the same flow on manual dispatch. Both mint a GitHub App token
   scoped to `pfBlockerNG/pkg` with `contents: write` (`actions/create-github-app-token@v3`,
   secrets `PKG_GITHUB_APP_ID` + `PKG_GITHUB_APP_PRIVATE_KEY`), then run
-  `scripts/publish-pkg-repo.sh`, which commits the assembled catalogue into `pkg`. A publish
-  failure never breaks the Release or the ports PR.
+  `scripts/publish-pkg-repo.sh`, which commits the assembled catalogue into `pkg` — nothing
+  else. Each of those, plus `nightly.yml`'s own `publish-pkg-repo` job, then calls
+  `pkg-render-site.yml` (a reusable `workflow_call`, also directly `workflow_dispatch`-able) to
+  render the site around that catalogue; a publish failure never breaks the Release or the ports
+  PR.
 
 See [ADR-17](legacy/ADRs/ADR_17_Pkg_Repository/ADR.md) for the full design.
 

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1088,10 +1088,11 @@ predecessor four `install-<channel>.sh` wrappers + shared `install-common.sh` sp
 retired; unifying them was an owner ruling (2026-08). The repository copy
 (`scripts/install.sh`) shells out to the sibling `scripts/rc.d/pfblockerng_repo_generate.sh`,
 resolved via `dirname "$0"`, which fails when **piped** into `sh` (`$0` is then `sh`, not the
-script path). `gen_landing.py`'s `write_install_script()` publishes a self-contained
-`site/install.sh` via TWO splices: `_bake_base_url` points install.sh's own `PFB_BASE_URL`
-default at the site's own base first (issue #2416 B3/F3), then the hook body is spliced into
-THAT text's `PFB_EMBED_HOOK` block — a single-quoted heredoc (`cat <<'PFB_HOOK_HEREDOC'`) so
+script path). `gen_landing.py`'s `build_site_tree()` — the generic pkg-site/ tree-build
+pass (issue #2450) — applies TWO splices to install.sh's site-tree copy: `_bake_base_url`
+points install.sh's own `PFB_BASE_URL` default at the site's own base first (issue #2416
+B3/F3), then the hook body is spliced into THAT text's `PFB_EMBED_HOOK` block — a
+single-quoted heredoc (`cat <<'PFB_HOOK_HEREDOC'`) so
 none of the hook's dollar-signs or backticks are expanded. Published at
 `pfblockerng.github.io/pkg/install.sh`, what the README's one-liners
 (`fetch -qo - <base>/install.sh | sh -s -- --channel <ch>`) point to.

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1110,16 +1110,18 @@ Full design: ADR-39.
   per-asset `digest`, and run `scripts/publish-pkg-repo.sh`. That script calls
   `scripts/publish_release.py` (structured intake, per-asset and whole-run verification,
   catalogue assembly via `scripts/catalogue_assembly.py` and per-channel retention — never git),
-  regenerates the landing page, then commits and force-free pushes the touched catalogue
-  directories. Routing comes from the dispatch's ordered `destinations` tuple; there is no
-  latest-release discovery. `nightly.yml`'s own `publish-pkg-repo` job runs the same script with
-  `PUBLISH_KIND=nightly` (`scripts/publish_nightly.py`) off the verified nightly handoff.
+  then commits and force-free pushes the touched catalogue directories — nothing else; the site
+  around the catalogue is `pkg-render-site.yml`'s job, called after (issue #2450, below). Routing
+  comes from the dispatch's ordered `destinations` tuple; there is no latest-release discovery.
+  `nightly.yml`'s own `publish-pkg-repo` job runs the same script with `PUBLISH_KIND=nightly`
+  (`scripts/publish_nightly.py`) off the verified nightly handoff.
 - **Gate-before-announce for tagged publishes (issue #2389):** `docs/` on `pkg` `main` IS the
   Pages site, so a plain publish announces the moment it pushes. `release-published.yml` therefore
   runs `publish-pkg-repo.sh` with `PUBLISH_STAGE=stage`: the publisher runs against the real tree
   (containment-aware pruning stays correct), every touched `<channel>/<varver>` is relocated under
-  `docs/staging/<run_id>-<attempt>/` with the original bytes restored in place, no landing/client
-  script regen, one push. `prepare-live-gate` (`scripts/live_gate_matrix.py`) fans the CI legs
+  `docs/staging/<run_id>-<attempt>/` with the original bytes restored in place, one push (never a
+  site render — that is never this job's concern, staged or not). `prepare-live-gate`
+  (`scripts/live_gate_matrix.py`) fans the CI legs
   whose varver was touched out per destination; `validate-live-pages-install` runs `smoke-single.yml`
   (`pytest_marker: repo`, `test_install_from_live_pages_url`) per leg against
   `https://pfblockerng.github.io/pkg/staging/<seg>/<channel>` with expected version = portversion and
@@ -1127,14 +1129,17 @@ Full design: ADR-39.
   channel, so `build-repo-portable.py --print-conf` derives the real `pfblockerng-<channel>` repo
   name and the box's `%R` matches. `promote-pkg-repo` (`always()`, only when the stage succeeded and
   was not a no-op) runs `PUBLISH_STAGE=promote` on green (staged dirs moved into place, staging
-  tree dropped, landing regenerated, one push — the announce) or `PUBLISH_STAGE=discard` on any red
-  leg (staging tree dropped, run fails). A stage-mode run whose catalogue is a no-op still ships a
-  drifted client-script refresh and reports `noop=true`, which skips the gate. A target the publisher
-  reports as updated but whose bytes did not change (`git status --porcelain` empty) is dropped from
-  staging; a promote whose prefix holds no `<channel>/<varver>` fails loudly. Workflow-level
-  `concurrency` serialises publishes. `PUBLISH_STAGE=direct` (default) keeps today's single-push
-  path for `nightly.yml` (publish-then-gate, PR #2404) and `pkg-republish.yml`; nightly with any
-  other value is a usage error. `smoke-single.yml` exposes the generic `smoke_repo_live_url` /
+  tree dropped, one push — the announce) or `PUBLISH_STAGE=discard` on any red leg (staging tree
+  dropped, run fails). A stage-mode run whose catalogue is a no-op reports `noop=true`, which skips
+  the gate and `promote-pkg-repo` entirely. A target the publisher reports as updated but whose
+  bytes did not change (`git status --porcelain` empty) is dropped from staging; a promote whose
+  prefix holds no `<channel>/<varver>` fails loudly. Workflow-level `concurrency` serialises
+  publishes. `render-site` (`pkg-render-site.yml`, issue #2450) runs after regardless — `if:
+  always() && needs.publish-pkg-repo.result == 'success'` — so a promote, a discard, and a
+  catalogue no-op alike still get a current site; it never gates on `promote-pkg-repo`'s own
+  result. `PUBLISH_STAGE=direct` (default) keeps today's single-push path for `nightly.yml`
+  (publish-then-gate, PR #2404) and `pkg-republish.yml`; nightly with any other value is a usage
+  error. `smoke-single.yml` exposes the generic `smoke_repo_live_url` /
   `smoke_repo_expected_source_sha` / `smoke_repo_expected_version` /
   `smoke_repo_expected_channel` inputs beside the nightly trio
   (`SMOKE_REPO_EXPECTED_CHANNEL` is required when a live URL is set);
@@ -1165,21 +1170,28 @@ Full design: ADR-39.
   Deployment is atomic per run: `publish-pkg-repo.sh` stages ONLY the touched
   `(channel, varver)` dirs (never `git add -A`) and aborts before any git mutation on a
   publisher failure, so a partial or failed run cannot erase another channel
-  (pinned by `tests/shell/publish_pkg_repo_spec.sh`). On a catalogue no-op it still
-  regenerates the one deterministic client script (`gen_landing.py
-  --client-scripts-only`: `install.sh`, issue #2416) and commits it if it
-  drifted (issue #2408) — the timestamped
-  landing/browse/autoindex pages remain publish-only unless `PUBLISH_REFRESH_LANDING=1`
-  (tagged + `PUBLISH_STAGE=direct` only; `pkg-republish.yml`'s `refresh_landing` input)
-  forces the full landing regen on that same no-op path, for shipping a landing
-  template/card fix via a republish of an already-published release (issue #2416
-  follow-up). Any retired client script (`RETIRED_CLIENT_SCRIPTS`: `add-repo.sh`,
-  `migrate-channel.sh`, superseded by `install.sh`) still present on the live
-  site is swept out of the same commit, but only when that commit also
-  regenerates the landing page — a `PUBLISH_REFRESH_LANDING=1` no-op, a
-  direct/nightly real publish, or `PUBLISH_STAGE=promote` — never the
-  knob-off no-op or a `PUBLISH_STAGE=stage` run, which would 404 a script the
-  live `index.html` still links. Trust model is unchanged
+  (pinned by `tests/shell/publish_pkg_repo_spec.sh`). It never touches the site around
+  the catalogue any more (issue #2450): that split into its own renderer. `pkg-site/`
+  (this repo) is the declared site tree — `install.sh` (`{base}`-substituted, hook
+  embedded via the same bake-and-splice idiom as before) and `recipes/<channel>.sh`
+  (the verbatim card text each channel's landing card shows) — mirrored 1:1 into
+  `pkg`'s `docs/`. `scripts/render-pkg-site.sh` renders it plus the dynamic pages
+  (landing `index.html`, `browse.html`, and `browse/<channel>/<varver>/index.html`)
+  entirely OUTSIDE the catalogue trees, via `gen_landing.py --site-tree`, and
+  commits + pushes only if something changed (a NOOP writes nothing; rendering never
+  reads a file's mtime, so byte-identical inputs never manufacture a commit). It is
+  wired into CI as `pkg-render-site.yml`: a `workflow_call` every catalogue publisher
+  (`release-published.yml`, `pkg-republish.yml`, `nightly.yml`) invokes AFTER its own
+  catalogue commit, or a bare `workflow_dispatch` to re-render on demand. Ownership of
+  `docs/` is two disjoint prefixes — the publisher writes only
+  `docs/{stable,testing,edge,nightly,staging}/**`, the renderer writes everything
+  else — each enforced by its own `git diff --cached` guard before any commit, so a
+  regressed renderer can never silently touch a catalogue path or vice versa. One
+  operator step remains manual, once, after the first successful render: delete the
+  legacy per-directory `index.html` autoindexes still sitting inside the live catalogue
+  dirs by hand — that cleanup is deliberately not script logic (a renderer that could
+  reach into a catalogue-owned path to delete something is the exact hazard the guard
+  exists to prevent). Trust model is unchanged
   (`signature_type: none`, HTTPS/TLS to the Pages host — no catalogue-signing key); the landing
   page (`scripts/gen_landing.py`) documents the channel audiences, shared-bytes fan-out,
   single-repository subscription, and the explicit repository-qualified downgrade rule. The

--- a/pkg-site/install.sh
+++ b/pkg-site/install.sh
@@ -1,0 +1,1 @@
+../scripts/install.sh

--- a/pkg-site/recipes/edge.sh
+++ b/pkg-site/recipes/edge.sh
@@ -1,0 +1,1 @@
+fetch -qo - {base}/install.sh | sh -s -- --channel edge

--- a/pkg-site/recipes/nightly.sh
+++ b/pkg-site/recipes/nightly.sh
@@ -1,0 +1,1 @@
+fetch -qo - {base}/install.sh | sh -s -- --channel nightly

--- a/pkg-site/recipes/stable.sh
+++ b/pkg-site/recipes/stable.sh
@@ -1,0 +1,1 @@
+fetch -qo - {base}/install.sh | sh -s -- --channel stable

--- a/pkg-site/recipes/testing.sh
+++ b/pkg-site/recipes/testing.sh
@@ -1,0 +1,1 @@
+fetch -qo - {base}/install.sh | sh -s -- --channel testing

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -1134,9 +1134,14 @@ def _shell_single_quote(value: str) -> str:
 def _bake_base_url(script_text: str, base: str) -> str:
     """Replace install.sh's hardcoded ``PFB_BASE_URL`` default with *base*.
 
-    Raises if the line is not found EXACTLY once — a drifted install.sh must fail
-    the site build loudly rather than silently publish an installer that still
-    defaults to the upstream URL.
+    Only called by ``build_site_tree`` when the default-URL line occurs at least
+    once; raises if it occurs MORE than once, so a doubled line still fails the
+    site build loudly. A script carrying ZERO occurrences is never routed here at
+    all — ``build_site_tree`` leaves it unbaked, silently — so the invariant that
+    the repository's own ``scripts/install.sh`` always carries this line EXACTLY
+    once is pinned by the test suite
+    (``test_scripts_install_sh_carries_the_bake_line_and_both_embed_markers``),
+    not enforced by this function.
 
     *base* is baked in as a single-quoted ``PFB_DEFAULT_BASE_URL`` literal, then
     referenced through a second, unquoted ``${PFB_BASE_URL:-${PFB_DEFAULT_BASE_URL}}``
@@ -1222,7 +1227,7 @@ def build_site_tree(tree: str, base: str) -> dict[str, tuple[bytes, int]]:
                 text = data.decode("utf-8")
                 if text.count(_BASE_URL_DEFAULT_LINE) >= 1:
                     text = _bake_base_url(text, base)
-                if _HOOK_EMBED_BEGIN in text:
+                if _HOOK_EMBED_BEGIN in text or _HOOK_EMBED_END in text:
                     with open(hook_path) as hf:
                         hook_text = hf.read()
                     text = _embed_hook(text, hook_text)
@@ -1245,13 +1250,30 @@ def _catalogue_prefix(rel: str) -> str | None:
 
 def _prune_empty_dirs(root: str) -> None:
     """Remove every directory under *root* left empty by ``sync_site``'s deletions
-    (never *root* itself). Bottom-up, re-checking live directory contents at each
-    step so a cascade (a leaf's removal emptying its parent) prunes fully."""
+    (never *root* itself, never a catalogue-owned tree). Bottom-up, re-checking
+    live directory contents at each step so a cascade (a leaf's removal emptying
+    its parent) prunes fully."""
     for dirpath, _dirs, _files in os.walk(root, topdown=False):
         if dirpath == root:
             continue
+        rel = os.path.relpath(dirpath, root).replace(os.sep, "/")
+        if _catalogue_prefix(rel) is not None:
+            continue  # catalogue-owned — never touched, no exceptions
         if not os.listdir(dirpath):
             os.rmdir(dirpath)
+
+
+def _symlinked_component(docs: str, rel: str) -> str | None:
+    """The first path, walking from *docs* down to ``docs/<rel>`` inclusive, that is
+    a symlink — or None if none is. Used by ``sync_site`` to refuse writing THROUGH
+    a symlink (a directory component or the leaf itself) planted inside docs/, which
+    would otherwise let a write escape the tree entirely."""
+    current = docs
+    for part in rel.split("/"):
+        current = os.path.join(current, part)
+        if os.path.islink(current):
+            return current
+    return None
 
 
 def sync_site(docs: str, desired: dict[str, tuple[bytes, int]]) -> tuple[list[str], list[str]]:
@@ -1262,12 +1284,22 @@ def sync_site(docs: str, desired: dict[str, tuple[bytes, int]]) -> tuple[list[st
     WRITE one from *desired* in the first place. A one-time cleanup of a legacy
     autoindex leftover under a catalogue dir (from the generator this replaces) is
     an operator task run once after the first successful publish with this script,
-    never logic this script carries forward. Returns ``(written, deleted)``, each
-    the sorted "/"-relative paths.
+    never logic this script carries forward. Every desired path is also validated
+    BEFORE the first write — a `..` segment or a leading `/`, or a symlink sitting
+    anywhere between docs/ and the write target (leaf or intermediate directory) —
+    so no partial write can ever land, and none can escape docs/.
+    Returns ``(written, deleted)``, each the sorted "/"-relative paths.
     """
     for rel in desired:
         if _catalogue_prefix(rel) is not None:
             raise ValueError(f"desired site path {rel!r} sits under a catalogue-owned prefix — refusing to write")
+        if rel.startswith("/") or any(segment == ".." for segment in rel.split("/")):
+            raise ValueError(f"desired site path {rel!r} is not a safe relative path — refusing to write")
+        symlinked = _symlinked_component(docs, rel)
+        if symlinked is not None:
+            raise ValueError(
+                f"desired site path {rel!r} resolves through a symlink at {symlinked!r} — refusing to write"
+            )
 
     for rel, (data, mode) in desired.items():
         out_path = os.path.join(docs, *rel.split("/"))

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -3,7 +3,8 @@
 # tree (this repo's pkg-site/: install.sh, per-channel recipes, .nojekyll, …),
 # renders the dynamic pages (landing index.html, browse.html, and a browse/<ch>/…
 # view of every catalogue tree), and mirrors the result into the pkg repo's docs/ —
-# write every desired file, delete everything extraneous. Run by pfBlockerNG/pkg's
+# write every desired file, delete everything extraneous outside the catalogue
+# trees, touch nothing inside them. Run by pfBlockerNG/pkg's
 # publish.yml AFTER the per-channel catalog trees are built under <site>/.
 #
 # It is the human-facing sibling of build-repo-portable.py: that tool emits the
@@ -53,10 +54,11 @@ _CHANNELS: frozenset[str] = frozenset(CH_ORDER)
 # this top-level dir (issue #2389) -- files there stay served, but this generator
 # never indexes, browses, or writes it (CATALOGUE_DIRS below).
 STAGING_TOP_DIR = "staging"
-# Publisher-owned top-level prefixes: the renderer may never write, delete, or
-# autoindex anything under one of these (issue #2450) — the one exception is a
-# one-time sweep of a legacy `index.html` leftover (sync_site). Derived from
-# CH_ORDER + STAGING_TOP_DIR so the two never drift apart.
+# Publisher-owned top-level prefixes: the renderer may never add, modify, or
+# delete anything under one of these — no exceptions (issue #2450; a stray legacy
+# autoindex `index.html` under one of these is an operator's one-time cleanup after
+# the first publish with this script, never logic this script performs). Derived
+# from CH_ORDER + STAGING_TOP_DIR so the two never drift apart.
 CATALOGUE_DIRS: tuple[str, ...] = (*CH_ORDER, STAGING_TOP_DIR)
 # Embed markers in a site-tree .sh file that delimit the hook placeholder body.
 _HOOK_EMBED_BEGIN = "# PFB_EMBED_HOOK_BEGIN"
@@ -1092,7 +1094,7 @@ def _render_catalogue_browse_page(docs: str, full_rel: str) -> str:
     files: list[str] = []
     for name in sorted(os.listdir(src_dir)):
         if name == "index.html":
-            continue  # a legacy autoindex leftover — never repository content (issue #2450)
+            continue  # a leftover autoindex is never repository content (issue #2450)
         (subdirs if os.path.isdir(os.path.join(src_dir, name)) else files).append(name)
 
     for name in subdirs:
@@ -1254,11 +1256,14 @@ def _prune_empty_dirs(root: str) -> None:
 
 def sync_site(docs: str, desired: dict[str, tuple[bytes, int]]) -> tuple[list[str], list[str]]:
     """Mirror *desired* into *docs*: write every desired file, then delete whatever
-    under docs is neither under a ``CATALOGUE_DIRS`` prefix nor in *desired* — plus a
-    one-time sweep of a legacy ``index.html`` leftover under a catalogue prefix
-    (issue #2450). Every OTHER file under a catalogue prefix is left untouched: the
-    assert below makes the renderer unable to write one from *desired* in the first
-    place. Returns ``(written, deleted)``, each the sorted "/"-relative paths.
+    under docs is neither under a ``CATALOGUE_DIRS`` prefix nor in *desired* (issue
+    #2450). A catalogue-prefixed path is never added, modified, or deleted here —
+    strictly, with no exception: the assert below makes the renderer unable to even
+    WRITE one from *desired* in the first place. A one-time cleanup of a legacy
+    autoindex leftover under a catalogue dir (from the generator this replaces) is
+    an operator task run once after the first successful publish with this script,
+    never logic this script carries forward. Returns ``(written, deleted)``, each
+    the sorted "/"-relative paths.
     """
     for rel in desired:
         if _catalogue_prefix(rel) is not None:
@@ -1280,12 +1285,8 @@ def sync_site(docs: str, desired: dict[str, tuple[bytes, int]]) -> tuple[list[st
             if os.path.islink(full):
                 continue  # never follow/touch a symlink inside docs
             rel = f"{rel_dir}/{fname}" if rel_dir else fname
-            prefix = _catalogue_prefix(rel)
-            if prefix is not None:
-                if fname == "index.html":
-                    os.remove(full)
-                    deleted.append(rel)
-                continue  # every other catalogue-owned file is untouched
+            if _catalogue_prefix(rel) is not None:
+                continue  # catalogue-owned — never touched, no exceptions
             if rel not in desired:
                 os.remove(full)
                 deleted.append(rel)

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
-# gen_landing.py — generate the human-navigable landing page + per-directory
-# indexes for the self-hosted pkg repository (ADR-17). Run by pfBlockerNG/pkg's
+# gen_landing.py — the pkg-site renderer (issue #2450). Builds the declared site
+# tree (this repo's pkg-site/: install.sh, per-channel recipes, .nojekyll, …),
+# renders the dynamic pages (landing index.html, browse.html, and a browse/<ch>/…
+# view of every catalogue tree), and mirrors the result into the pkg repo's docs/ —
+# write every desired file, delete everything extraneous. Run by pfBlockerNG/pkg's
 # publish.yml AFTER the per-channel catalog trees are built under <site>/.
 #
 # It is the human-facing sibling of build-repo-portable.py: that tool emits the
 # machine catalog pkg(8) fetches; this one renders a styled index over it —
 # channel install cards (stable / testing / edge / nightly), a Version x ABI table
-# read from each .pkg's own manifest, and a clean per-directory listing that shows
-# the package(s) but not the pkg(8) catalog plumbing (meta.conf/packagesite.pkg/...).
+# read from each .pkg's own manifest, and a browse view that shows the package(s)
+# without writing anything inside the publisher-owned catalogue trees.
 #
 # Four-channel catalogue model (issue #2147): every channel serves the ONE canonical
 # package (pfb_pkg.CANONICAL_EMITTED_IDENTITY) from its own <channel>/<varver>/
@@ -15,10 +18,16 @@
 # the legacy two-repo / suffixed-package model (release/nightly repos,
 # -devel/-nightly identities) is retired from this generator.
 #
+# Deterministic: rendering never reads a file's mtime. An artifact's Published/Last
+# modified cell is its manifest `created` annotation, else the embedded build
+# record's `source_date_epoch`, else an em dash — never a filesystem timestamp — so
+# a second render of the same inputs is byte-identical (a NOOP republish never
+# manufactures a commit).
+#
 # Stdlib only + the `zstd` binary (to read a .pkg's +COMPACT_MANIFEST). Dev-only
 # tooling — not shipped in release archives (those contain only src/).
 #
-# Usage: gen_landing.py <site-dir> <pages-base-url>
+# Usage: gen_landing.py <docs-dir> <pages-base-url> --site-tree <pkg-site-dir> [--matrix <file>]
 from __future__ import annotations
 
 import argparse
@@ -26,6 +35,7 @@ import html
 import json
 import os
 import re
+import stat
 import subprocess
 import sys
 from collections.abc import Callable, Iterable
@@ -41,21 +51,17 @@ CH_ORDER: list[str] = ["stable", "testing", "edge", "nightly"]
 _CHANNELS: frozenset[str] = frozenset(CH_ORDER)
 # publish-pkg-repo.sh's PUBLISH_STAGE=stage relocates a not-yet-gated publish under
 # this top-level dir (issue #2389) -- files there stay served, but this generator
-# never indexes or links it: it is unreachable from a fresh checkout of the site
-# until promote-pkg-repo.sh's `promote` mode moves it into a real channel, and a
-# concurrent `direct` publish (nightly.yml/pkg-republish.yml, both outside
-# release-published.yml's own concurrency group) could otherwise regenerate this
-# page mid-stage and make the un-gated tree browsable.
+# never indexes, browses, or writes it (CATALOGUE_DIRS below).
 STAGING_TOP_DIR = "staging"
-# Embed markers in install.sh that delimit the hook placeholder body.
+# Publisher-owned top-level prefixes: the renderer may never write, delete, or
+# autoindex anything under one of these (issue #2450) — the one exception is a
+# one-time sweep of a legacy `index.html` leftover (sync_site). Derived from
+# CH_ORDER + STAGING_TOP_DIR so the two never drift apart.
+CATALOGUE_DIRS: tuple[str, ...] = (*CH_ORDER, STAGING_TOP_DIR)
+# Embed markers in a site-tree .sh file that delimit the hook placeholder body.
 _HOOK_EMBED_BEGIN = "# PFB_EMBED_HOOK_BEGIN"
 _HOOK_EMBED_END = "# PFB_EMBED_HOOK_END"
 _HOOK_HEREDOC = "PFB_HOOK_HEREDOC"
-# Every deterministic client script this generator publishes at the site root: the
-# ONE install.sh (issue #2416 follow-up) — parameterized by --channel, the sole
-# client entry point (subscribe + install + switch + upgrade) for all four
-# channels. The predecessor four-script-per-channel bootstrap is gone.
-CLIENT_SCRIPTS: tuple[str, ...] = ("install.sh",)
 # The source repo a .pkg is built from — base for the per-artifact commit link.
 SOURCE_REPO_URL = "https://github.com/pfBlockerNG/pfBlockerNG"
 
@@ -148,10 +154,12 @@ def _build_record(manifest: dict) -> dict:
     return record if isinstance(record, dict) else {}
 
 
-def artifact_epoch(manifest: dict, mtime: float) -> float:
-    """Resolve the display epoch: ``created``, then ``source_date_epoch``, then mtime.
+def artifact_epoch(manifest: dict) -> float | None:
+    """Resolve the display epoch: ``created``, then ``source_date_epoch``, else None.
 
-    Shared by the landing table (``published_datetime``) and the autoindex
+    Never a file mtime (issue #2450): a rendered page must not depend on when a
+    file happened to be (re)written, or a NOOP republish would still change bytes.
+    Shared by the landing table (``published_datetime``) and the browse view
     (``_display_epoch``) so the two surfaces cannot drift (issue #2401).
     """
     annotations = manifest.get("annotations")
@@ -166,21 +174,35 @@ def artifact_epoch(manifest: dict, mtime: float) -> float:
             return value
         except (TypeError, ValueError, OverflowError, OSError):
             continue  # malformed or out-of-range — try the next source
-    return float(mtime)
+    return None
 
 
-def published_datetime(manifest: dict, mtime_epoch: float) -> str:
-    """The artifact's creation datetime (UTC, minute precision).
+def published_datetime(manifest: dict) -> str:
+    """The artifact's creation datetime (UTC, minute precision), or "" when unknown.
 
     Prefer the ``created`` build annotation — the source commit's committer epoch,
-    baked into the .pkg at build time, so it reflects when the artifact's CODE was
-    created and survives every daily republish/re-download (a nightly is rebuilt and a
-    release asset re-downloaded each run, which would otherwise reset the mtime to
-    'today'). No build site stamps ``created`` today (issue #2375), so next prefer
-    the embedded build record's ``source_date_epoch``. Fall back to the .pkg's mtime
-    only when neither is readable.
+    baked into the .pkg at build time — then the embedded build record's
+    ``source_date_epoch``. Never a file mtime (issue #2450): the caller renders ""
+    through ``_or_dash`` as an em dash, keeping the cell deterministic across every
+    republish instead of showing "today".
     """
-    return artifact_datetime(artifact_epoch(manifest, mtime_epoch))
+    epoch = artifact_epoch(manifest)
+    return artifact_datetime(epoch) if epoch is not None else ""
+
+
+def _display_epoch(path: str) -> float | None:
+    """The epoch a browse-view row shows: a package's embedded creation epoch, else
+    None (issue #2450: never a file mtime). Catalog plumbing and every non-package
+    file always resolve to None (``is_package_file`` is the gate). An unreadable or
+    unannotated package also resolves to None rather than crashing the render.
+    """
+    if not is_package_file(os.path.basename(path)):
+        return None
+    try:
+        manifest = read_compact_manifest(path)
+    except Exception:  # corrupt/foreign .pkg — a listing must never crash the publish
+        return None
+    return artifact_epoch(manifest)
 
 
 def commit_sha(manifest: dict) -> str:
@@ -249,9 +271,9 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
     A package's channel is read from its catalogue placement — the top-level directory
     under <site> (issue #2147) — never from its name. A package sitting under an
     unrecognized top-level dir (a legacy release/nightly-suffixed tree, a stray future
-    dir) is not attributed to any channel and is dropped from this list entirely; it
-    stays reachable via the raw directory autoindex, which walks disk directly and
-    never calls this function.
+    dir, ``staging/``) is not attributed to any channel and is dropped from this list
+    entirely; it stays reachable via the raw catalogue tree, which this generator never
+    autoindexes but never removes either.
     """
     if read_manifest is None:
         read_manifest = read_compact_manifest
@@ -277,7 +299,7 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
                     "version": ver,
                     "abi": abi,
                     "size": os.path.getsize(path),
-                    "published": published_datetime(man, os.path.getmtime(path)),
+                    "published": published_datetime(man),
                     "commit": commit_sha(man),
                     # PHP/Python the build targets, read from its RUN_DEPENDS — the fallback
                     # for an ABI the matrix doesn't cover (the matrix value wins when joined).
@@ -464,16 +486,32 @@ _CARD_META: dict[str, dict[str, str]] = {
 }
 
 
-def _channel_card(channel: str, base: str, latest: dict[str, str], conf_fn: Callable[[str], str]) -> str:
-    """One channel's install card: audience prose, and — only when published —
-    the ONE-line piped installer recipe and a collapsed manual-conf snippet.
-    An unpublished channel keeps title/badge/blurb/"not yet published" and ships no
-    install recipe or conf snippet (issue #2382).
+def _recipe_text(site_tree: dict[str, tuple[bytes, int]], channel: str) -> str:
+    """The stripped, already-{base}-substituted recipe for *channel* — the ONE-line
+    piped install command a published card's copyable block shows verbatim (issue
+    #2450). Raises when a PUBLISHED channel has no ``recipes/<channel>.sh`` in the
+    built site tree: a missing recipe must fail the build loudly, never render a
+    card with no install command.
+    """
+    key = f"recipes/{channel}.sh"
+    entry = site_tree.get(key)
+    if entry is None:
+        raise ValueError(f"missing site-tree recipe for a published channel: {key}")
+    data, _mode = entry
+    return data.decode("utf-8").strip()
 
-    The recipe is the single piped ``install.sh --channel <channel>`` (issue #2416
-    follow-up) — ONE idempotent script, parameterized by channel, that converges
-    from ANY starting state, so the card no longer needs to distinguish "new" from
-    "existing" installs, nor ship a script per channel.
+
+def _channel_card(
+    channel: str,
+    latest: dict[str, str],
+    conf_fn: Callable[[str], str],
+    site_tree: dict[str, tuple[bytes, int]],
+) -> str:
+    """One channel's install card: audience prose, and — only when published —
+    the ONE-line piped installer recipe (read verbatim from the built site tree's
+    ``recipes/<channel>.sh``) and a collapsed manual-conf snippet. An unpublished
+    channel keeps title/badge/blurb/"not yet published" and ships no install recipe
+    or conf snippet (issue #2382).
     """
     meta = _CARD_META[channel]
     badge = f" {meta['badge']}" if meta["badge"] else ""
@@ -485,7 +523,7 @@ def _channel_card(channel: str, base: str, latest: dict[str, str], conf_fn: Call
     if latest.get(channel):
         body += (
             '<p class="blurb">Install, upgrade, or switch to this channel (any starting state):</p>'
-            f"{_copyable(_esc(f'fetch -qo - {base}/install.sh | sh -s -- --channel {channel}'))}"
+            f"{_copyable(_esc(_recipe_text(site_tree, channel)))}"
             f"{_manual_conf_details(conf_fn, channel)}"
         )
     return f"{body}</div>"
@@ -687,7 +725,7 @@ def _row_html(r: dict, *, with_channel: bool) -> str:
         f"<td><code>{_esc(r['abi'])}</code></td>"
         f'<td class="num">{_or_dash(r.get("php", ""))}</td>'
         f'<td class="num">{_or_dash(r.get("py", ""))}</td>'
-        f'<td class="num">{_esc(r.get("published", ""))}</td>'
+        f'<td class="num">{_or_dash(r.get("published", ""))}</td>'
         f"<td>{commit_cell(r.get('commit', ''))}</td>"
         f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
     )
@@ -924,11 +962,13 @@ def render_page(
     base: str,
     pkgs: list[dict],
     conf_fn: Callable[[str], str],
+    site_tree: dict[str, tuple[bytes, int]],
     matrix: list[dict] | None = None,
 ) -> str:
-    """Render the root landing page."""
+    """Render the root landing page. ``site_tree`` is the BUILT site tree (issue
+    #2450) — the source of each published channel's recipe text."""
     latest = latest_versions(pkgs)
-    cards = "".join(_channel_card(ch, base, latest, conf_fn) for ch in CH_ORDER)
+    cards = "".join(_channel_card(ch, latest, conf_fn, site_tree) for ch in CH_ORDER)
     eol_block = _eol_versions_html(pkgs, matrix)
     return (
         '<!doctype html><html lang="en"><head><meta charset="utf-8">'
@@ -955,93 +995,22 @@ def render_page(
     )
 
 
-def _is_staging_path(rel: str) -> bool:
-    """True for ``STAGING_TOP_DIR`` itself or anything under it (issue #2389)."""
-    return rel.replace(os.sep, "/").split("/", 1)[0] == STAGING_TOP_DIR
+def _epoch_cell(epoch: float | None) -> str:
+    """The Last-modified cell for an optional epoch — an em dash when absent (issue
+    #2450: never a file mtime)."""
+    return _or_dash(artifact_datetime(epoch) if epoch is not None else "")
 
 
-def all_dirs(site: str) -> list[str]:
-    """Every directory under ``site`` (relative path, "/"-separated), excluding the site root
-    and the un-gated ``STAGING_TOP_DIR`` subtree, sorted. Used to emit a browsable autoindex
-    at EVERY level (GitHub Pages has no autoindex)."""
-    out = [
-        os.path.relpath(d, site)
-        for d, _x, _f in os.walk(site)
-        if os.path.relpath(d, site) != "." and not _is_staging_path(os.path.relpath(d, site))
-    ]
-    return sorted(out)
-
-
-# Generated HTML + Pages plumbing that an autoindex listing hides (it is not repository content).
-_INDEX_HIDDEN = frozenset({"index.html", "browse.html", ".nojekyll"})
-
-
-def _dir_entries(site: str, rel: str) -> tuple[list[str], list[tuple[str, int, float]]]:
-    """The immediate children of ``site/rel``: (subdir names, file (name, size, mtime) tuples),
-    each sorted, with the generated index pages + Pages plumbing hidden."""
-    d = os.path.join(site, rel) if rel else site
-    subdirs: list[str] = []
-    files: list[tuple[str, int, float]] = []
-    for name in sorted(os.listdir(d)):
-        if name in _INDEX_HIDDEN:
-            continue
-        p = os.path.join(d, name)
-        if os.path.isdir(p):
-            subdirs.append(name)
-        else:
-            st = os.stat(p)
-            files.append((name, st.st_size, _display_epoch(p, st.st_mtime)))
-    return subdirs, files
-
-
-def _display_epoch(path: str, mtime: float) -> float:
-    """The epoch a listing row shows: a package's embedded creation epoch, else mtime.
-
-    Catalog plumbing is not a package: ``is_package_file`` keeps those rows on
-    mtime (issue #2401). Unreadable or unannotated packages keep the mtime.
-    """
-    if not is_package_file(os.path.basename(path)):
-        return mtime
-    try:
-        manifest = read_compact_manifest(path)
-    except Exception:  # corrupt/foreign .pkg — a listing must never crash the publish
-        return mtime
-    return artifact_epoch(manifest, mtime)
-
-
-def render_autoindex(
-    rel: str, subdirs: list[str], files: list[tuple[str, int, float]], *, is_root: bool = False
-) -> str:
-    """A FreeBSD/Debian-style directory listing for ``rel`` (the browse root when ``is_root``).
-
-    Subdirs link to ``./<name>/`` and files to ``./<name>`` (the ``./`` prefix keeps a colon-bearing
-    ABI segment like ``FreeBSD:15:amd64`` a relative path, not a URI scheme — RFC 3986 §4.2). A
-    "Parent Directory" row (``../``) is shown except at the browse root."""
-    title = f"/{rel}" if rel else "/"
-    rows = []
-    if not is_root:
-        rows.append(
-            '<tr><td><a href="../">../</a></td><td class="num">&mdash;</td><td class="num">Parent Directory</td></tr>'
-        )
-    for name in subdirs:
-        rows.append(
-            f'<tr><td><a href="./{_esc(name)}/">{_esc(name)}/</a></td>'
-            '<td class="num">&mdash;</td><td class="num">&mdash;</td></tr>'
-        )
-    for name, size, mtime in files:
-        rows.append(
-            f'<tr><td><a href="./{_esc(name)}">{_esc(name)}</a></td>'
-            f'<td class="num">{_esc(artifact_datetime(mtime))}</td>'
-            f'<td class="num">{_esc(human_size(size))}</td></tr>'
-        )
-    # "repository home" climbs to the site root (which serves the human landing page).
-    home = "./" if is_root else "../" * (rel.count("/") + 1)
+def _render_listing_html(title: str, home_href: str, rows: list[str]) -> str:
+    """The shared directory-listing page shell — the landing/browse chrome around a
+    Name | Last modified | Size table, used by both browse.html and every
+    browse/<ch>/… page."""
     return (
         '<!doctype html><html lang="en"><head><meta charset="utf-8">'
         '<meta name="viewport" content="width=device-width, initial-scale=1">'
         f"<title>pfBlockerNG pkg — Index of {_esc(title)}</title><style>{_CSS}</style></head>"
         f'<body><div class="wrap"><header><h1>Index of {_esc(title)}</h1>'
-        f'<p><a href="{_esc(home)}">&larr; pfBlockerNG repository home</a></p></header>'
+        f'<p><a href="{_esc(home_href)}">&larr; pfBlockerNG repository home</a></p></header>'
         '<div class="tablewrap"><table class="autoindex"><thead><tr>'
         "<th>Name</th><th>Last modified</th><th>Size</th></tr></thead>"
         f"<tbody>{''.join(rows)}</tbody></table></div>"
@@ -1051,46 +1020,100 @@ def render_autoindex(
     )
 
 
-def _embed_hook(script_text: str, hook_text: str) -> str:
-    """Splice *hook_text* into *script_text* between the PFB_EMBED_HOOK markers.
-
-    The stub body (everything between the BEGIN and END marker lines, inclusive) is
-    replaced with a single-quoted heredoc that prints the hook verbatim — no variable
-    or command expansion in the emitted content, regardless of what the hook contains.
-    The resulting script is self-contained and safe to pipe into ``sh``. Used by
-    ``write_install_script`` — splices directly into install.sh's own text (the
-    PFB_EMBED_HOOK markers live in install.sh itself, issue #2416 follow-up: the
-    earlier per-channel-stub + install-common.sh split, and its extra PFB_EMBED_COMMON
-    splice, are gone).
+def _root_files(built: dict[str, tuple[bytes, int]]) -> list[str]:
+    """The site-tree's own root-level file names, sorted; the generated pages are
+    hidden (not repository content). Sourced from ``built`` — never a disk listing
+    — since sync_site's own contract makes the site tree's root files the ONLY
+    things that can ever survive at the docs root besides a catalogue dir (issue
+    #2450): reading disk here would see this run's write only after it happens,
+    an ordering hazard that broke determinism (a rendered page must reflect the
+    tree being written THIS run, not whatever a previous run left behind).
     """
-    lines = script_text.splitlines(keepends=True)
-    begin_idx = next(
-        (i for i, ln in enumerate(lines) if _HOOK_EMBED_BEGIN in ln),
-        None,
-    )
-    end_idx = next(
-        (i for i, ln in enumerate(lines) if _HOOK_EMBED_END in ln),
-        None,
-    )
-    if begin_idx is None or end_idx is None or begin_idx >= end_idx:
-        raise ValueError(f"script is missing the embed markers ({_HOOK_EMBED_BEGIN!r} / {_HOOK_EMBED_END!r})")
-    if _HOOK_HEREDOC in hook_text:
-        raise ValueError(
-            f"hook text contains the heredoc delimiter {_HOOK_HEREDOC!r} — choose a different delimiter or fix the hook"
+    hidden = {"index.html", "browse.html", ".nojekyll"}
+    return sorted(name for name in built if "/" not in name and name not in hidden)
+
+
+def render_browse_root(docs: str, built: dict[str, tuple[bytes, int]]) -> str:
+    """docs/browse.html — the top-level entry point: one row per present catalogue
+    channel (CH_ORDER order; ``staging`` is never listed, issue #2389) linking into
+    its own browse/<ch>/ page, then every root-level site-tree file linking directly.
+    """
+    rows: list[str] = []
+    for ch in CH_ORDER:
+        if os.path.isdir(os.path.join(docs, ch)):
+            esc = _esc(ch)
+            rows.append(
+                f'<tr><td><a href="./browse/{esc}/">{esc}/</a></td>'
+                '<td class="num">&mdash;</td><td class="num">&mdash;</td></tr>'
+            )
+    for name in _root_files(built):
+        data, _mode = built[name]
+        esc = _esc(name)
+        rows.append(
+            f'<tr><td><a href="./{esc}">{esc}</a></td>'
+            f'<td class="num">{_epoch_cell(None)}</td>'
+            f'<td class="num">{_esc(human_size(len(data)))}</td></tr>'
         )
-    # Build the replacement: keep the BEGIN marker line, inject the heredoc, keep END.
-    heredoc_lines = [
-        lines[begin_idx],
-        f"    cat <<'{_HOOK_HEREDOC}'\n",
-        hook_text if hook_text.endswith("\n") else hook_text + "\n",
-        f"{_HOOK_HEREDOC}\n",
-        lines[end_idx],
-    ]
-    return "".join(lines[:begin_idx] + heredoc_lines + lines[end_idx + 1 :])
+    return _render_listing_html("/", "./", rows)
+
+
+def _catalogue_subdirs(docs: str, channel: str) -> list[str]:
+    """Every docs-relative dir at or below <docs>/<channel> — the channel root
+    itself plus each directory nested under it, sorted, "/"-separated."""
+    root = os.path.join(docs, channel)
+    out = [channel]
+    for dirpath, dirs, _files in os.walk(root):
+        for d in dirs:
+            rel = os.path.relpath(os.path.join(dirpath, d), docs).replace(os.sep, "/")
+            out.append(rel)
+    return sorted(out)
+
+
+def _render_catalogue_browse_page(docs: str, full_rel: str) -> str:
+    """One ``browse/<full_rel>/index.html`` page — ``full_rel`` is ``"<channel>"``
+    or ``"<channel>/<sub>/…"``, a real directory under docs/. Subdirs link within
+    the browse mirror (``./<name>/``); files link OUT into the real catalogue tree
+    via a climb-to-root-then-descend relative path, since the browse tree and the
+    catalogue tree are siblings under docs/, not the same directory (issue #2450).
+    """
+    src_dir = os.path.join(docs, *full_rel.split("/"))
+    depth = full_rel.count("/") + 2  # hops from browse/<full_rel>/ up to the docs root
+    climb = "../" * depth
+    is_channel_root = "/" not in full_rel
+
+    rows: list[str] = []
+    parent_href = f"{climb}browse.html" if is_channel_root else "../"
+    rows.append(
+        f'<tr><td><a href="{_esc(parent_href)}">../</a></td>'
+        '<td class="num">&mdash;</td><td class="num">Parent Directory</td></tr>'
+    )
+
+    subdirs: list[str] = []
+    files: list[str] = []
+    for name in sorted(os.listdir(src_dir)):
+        if name == "index.html":
+            continue  # a legacy autoindex leftover — never repository content (issue #2450)
+        (subdirs if os.path.isdir(os.path.join(src_dir, name)) else files).append(name)
+
+    for name in subdirs:
+        esc = _esc(name)
+        rows.append(
+            f'<tr><td><a href="./{esc}/">{esc}/</a></td><td class="num">&mdash;</td><td class="num">&mdash;</td></tr>'
+        )
+    for name in files:
+        path = os.path.join(src_dir, name)
+        esc = _esc(name)
+        target = f"{climb}{full_rel}/{name}"
+        rows.append(
+            f'<tr><td><a href="{_esc(target)}">{esc}</a></td>'
+            f'<td class="num">{_epoch_cell(_display_epoch(path))}</td>'
+            f'<td class="num">{_esc(human_size(os.path.getsize(path)))}</td></tr>'
+        )
+    return _render_listing_html(f"/{full_rel}", climb, rows)
 
 
 # The exact hardcoded PFB_BASE_URL default line install.sh's repository copy
-# carries — replaced with the SITE's own base at publish time (issues #2416 /
+# carries — replaced with the SITE's own base at render time (issues #2416 /
 # B3/F3) so a fork or staged prefix ships an installer that resolves against
 # itself without requiring every user to override PFB_BASE_URL by hand.
 _BASE_URL_DEFAULT_LINE = 'PFB_BASE_URL="${PFB_BASE_URL:-https://pfblockerng.github.io/pkg}"'
@@ -1134,33 +1157,141 @@ def _bake_base_url(script_text: str, base: str) -> str:
     return script_text.replace(_BASE_URL_DEFAULT_LINE, replacement, 1)
 
 
-def write_install_script(site: str, base: str) -> list[str]:
-    """Write a self-contained ``install.sh`` to *site*/install.sh — the SOLE client
-    entry point for all four channels (issue #2416 follow-up): subscribe + install +
-    switch + upgrade, one idempotent script, parameterized by ``--channel``.
+def _embed_hook(script_text: str, hook_text: str) -> str:
+    """Splice *hook_text* into *script_text* between the PFB_EMBED_HOOK markers.
 
-    The repository copy lives at ``<scripts_dir>/install.sh`` and
-    ``<scripts_dir>/rc.d/`` holds the boot hook, where ``scripts_dir`` is this
-    file's own directory (gen_landing.py lives directly in ``scripts/``). The
-    published script is built in two splices: ``_bake_base_url`` points install.sh's
-    own ``PFB_BASE_URL`` default at *base*, then ``_embed_hook`` replaces its
-    ``pfb_emit_embedded_hook`` stub body with the boot hook via a single-quoted
-    heredoc — so the result needs no sibling file when piped into ``sh``. Returns
-    the file name written, e.g. ``["install.sh"]``.
+    The stub body (everything between the BEGIN and END marker lines, inclusive) is
+    replaced with a single-quoted heredoc that prints the hook verbatim — no variable
+    or command expansion in the emitted content, regardless of what the hook contains.
+    The resulting script is self-contained and safe to pipe into ``sh``. Used by
+    ``build_site_tree`` on every ``.sh`` site-tree file carrying the markers (today,
+    only install.sh) — the PFB_EMBED_HOOK markers live in the script's own text.
+    """
+    lines = script_text.splitlines(keepends=True)
+    begin_idx = next(
+        (i for i, ln in enumerate(lines) if _HOOK_EMBED_BEGIN in ln),
+        None,
+    )
+    end_idx = next(
+        (i for i, ln in enumerate(lines) if _HOOK_EMBED_END in ln),
+        None,
+    )
+    if begin_idx is None or end_idx is None or begin_idx >= end_idx:
+        raise ValueError(f"script is missing the embed markers ({_HOOK_EMBED_BEGIN!r} / {_HOOK_EMBED_END!r})")
+    if _HOOK_HEREDOC in hook_text:
+        raise ValueError(
+            f"hook text contains the heredoc delimiter {_HOOK_HEREDOC!r} — choose a different delimiter or fix the hook"
+        )
+    # Build the replacement: keep the BEGIN marker line, inject the heredoc, keep END.
+    heredoc_lines = [
+        lines[begin_idx],
+        f"    cat <<'{_HOOK_HEREDOC}'\n",
+        hook_text if hook_text.endswith("\n") else hook_text + "\n",
+        f"{_HOOK_HEREDOC}\n",
+        lines[end_idx],
+    ]
+    return "".join(lines[:begin_idx] + heredoc_lines + lines[end_idx + 1 :])
+
+
+def build_site_tree(tree: str, base: str) -> dict[str, tuple[bytes, int]]:
+    """Build the desired site-tree files from the declared source ``tree`` (this
+    repo's ``pkg-site/``, issue #2450): every regular file under it (symlinks
+    followed, dotfiles included), keyed by its "/"-relative path.
+
+    A ``.sh`` file gets ``_bake_base_url`` applied when install.sh's default-URL
+    line occurs (raising on more than one occurrence — a drifted script), then
+    ``_embed_hook`` applied when the hook markers occur — today only ``install.sh``
+    matches either. Every file whose bytes decode as UTF-8 then gets its literal
+    ``{base}`` token substituted with *base* (the site's channel recipes use it;
+    nothing else in the tree carries the token, so this is a no-op elsewhere).
+    The source file's permission bits (the exec bit) are preserved.
     """
     scripts_dir = os.path.dirname(os.path.abspath(__file__))
     hook_path = os.path.join(scripts_dir, "rc.d", "pfblockerng_repo_generate.sh")
-    with open(hook_path) as fh:
-        hook_text = fh.read()
-    with open(os.path.join(scripts_dir, "install.sh")) as fh:
-        script_text = fh.read()
-    script_text = _bake_base_url(script_text, base)
-    out_text = _embed_hook(script_text, hook_text)
-    out_path = os.path.join(site, "install.sh")
-    with open(out_path, "w") as fh:
-        fh.write(out_text)
-    os.chmod(out_path, 0o755)
-    return ["install.sh"]
+    out: dict[str, tuple[bytes, int]] = {}
+    for dirpath, _dirs, files in os.walk(tree, followlinks=True):
+        for fname in files:
+            path = os.path.join(dirpath, fname)
+            rel = os.path.relpath(path, tree).replace(os.sep, "/")
+            with open(path, "rb") as fh:
+                data = fh.read()
+            mode = stat.S_IMODE(os.stat(path).st_mode)
+            if fname.endswith(".sh"):
+                text = data.decode("utf-8")
+                if text.count(_BASE_URL_DEFAULT_LINE) >= 1:
+                    text = _bake_base_url(text, base)
+                if _HOOK_EMBED_BEGIN in text:
+                    with open(hook_path) as hf:
+                        hook_text = hf.read()
+                    text = _embed_hook(text, hook_text)
+                data = text.encode("utf-8")
+            try:
+                text = data.decode("utf-8")
+            except UnicodeDecodeError:
+                pass  # binary file — copied verbatim, no {base} substitution possible
+            else:
+                data = text.replace("{base}", base).encode("utf-8")
+            out[rel] = (data, mode)
+    return out
+
+
+def _catalogue_prefix(rel: str) -> str | None:
+    """The ``CATALOGUE_DIRS`` entry *rel* sits under, or None."""
+    seg = rel.split("/", 1)[0]
+    return seg if seg in CATALOGUE_DIRS else None
+
+
+def _prune_empty_dirs(root: str) -> None:
+    """Remove every directory under *root* left empty by ``sync_site``'s deletions
+    (never *root* itself). Bottom-up, re-checking live directory contents at each
+    step so a cascade (a leaf's removal emptying its parent) prunes fully."""
+    for dirpath, _dirs, _files in os.walk(root, topdown=False):
+        if dirpath == root:
+            continue
+        if not os.listdir(dirpath):
+            os.rmdir(dirpath)
+
+
+def sync_site(docs: str, desired: dict[str, tuple[bytes, int]]) -> tuple[list[str], list[str]]:
+    """Mirror *desired* into *docs*: write every desired file, then delete whatever
+    under docs is neither under a ``CATALOGUE_DIRS`` prefix nor in *desired* — plus a
+    one-time sweep of a legacy ``index.html`` leftover under a catalogue prefix
+    (issue #2450). Every OTHER file under a catalogue prefix is left untouched: the
+    assert below makes the renderer unable to write one from *desired* in the first
+    place. Returns ``(written, deleted)``, each the sorted "/"-relative paths.
+    """
+    for rel in desired:
+        if _catalogue_prefix(rel) is not None:
+            raise ValueError(f"desired site path {rel!r} sits under a catalogue-owned prefix — refusing to write")
+
+    for rel, (data, mode) in desired.items():
+        out_path = os.path.join(docs, *rel.split("/"))
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        with open(out_path, "wb") as fh:
+            fh.write(data)
+        os.chmod(out_path, mode)
+
+    deleted: list[str] = []
+    for dirpath, _dirs, files in os.walk(docs, followlinks=False):
+        rel_dir = os.path.relpath(dirpath, docs).replace(os.sep, "/")
+        rel_dir = "" if rel_dir == "." else rel_dir
+        for fname in files:
+            full = os.path.join(dirpath, fname)
+            if os.path.islink(full):
+                continue  # never follow/touch a symlink inside docs
+            rel = f"{rel_dir}/{fname}" if rel_dir else fname
+            prefix = _catalogue_prefix(rel)
+            if prefix is not None:
+                if fname == "index.html":
+                    os.remove(full)
+                    deleted.append(rel)
+                continue  # every other catalogue-owned file is untouched
+            if rel not in desired:
+                os.remove(full)
+                deleted.append(rel)
+
+    _prune_empty_dirs(docs)
+    return sorted(desired), sorted(deleted)
 
 
 def _conf_via_portable(base: str, channel: str) -> str:
@@ -1191,71 +1322,56 @@ def _conf_via_portable(base: str, channel: str) -> str:
     return out.stdout.rstrip("\n")
 
 
-def write_site(site: str, base: str, matrix: list[dict] | None = None) -> int:
-    """Generate the human landing page (root index.html), a browsable autoindex at EVERY
-    directory level (so the whole tree is folder-navigable on GitHub Pages, which has no
-    autoindex), and a root ``browse.html`` entry point the landing page links to. Returns the
-    count of pfBlockerNG packages indexed — published dependencies are browsable but not
-    ours to count (issue #1863)."""
+def write_site(site: str, base: str, site_tree: str, matrix: list[dict] | None = None) -> int:
+    """Render the pkg-site tree onto *site* (docs/) and mirror it there (issue
+    #2450): build the site tree from *site_tree*, collect the published packages,
+    render the landing page + the browse view (root + every catalogue dir, never
+    writing inside a catalogue tree), then ``sync_site``. Returns the count of
+    pfBlockerNG packages indexed — published dependencies are browsable but not
+    ours to count (issue #1863).
+    """
     base = base.rstrip("/")
     pkgs = collect_packages(site)
+    built = build_site_tree(site_tree, base)
 
     def conf_fn(channel: str) -> str:
         return _conf_via_portable(base, channel)
 
-    # The human landing page stays the site root; browse.html is the directory-style entry.
-    with open(os.path.join(site, "index.html"), "w") as fh:
-        fh.write(render_page(base, pkgs, conf_fn, matrix))
-    root_subdirs, root_files = _dir_entries(site, "")
-    root_subdirs = [d for d in root_subdirs if d != STAGING_TOP_DIR]
-    with open(os.path.join(site, "browse.html"), "w") as fh:
-        fh.write(render_autoindex("", root_subdirs, root_files, is_root=True))
-    # An autoindex index.html in every directory (intermediate + leaf), so each level is browsable.
-    for rel in all_dirs(site):
-        subdirs, files = _dir_entries(site, rel)
-        with open(os.path.join(site, rel, "index.html"), "w") as fh:
-            fh.write(render_autoindex(rel, subdirs, files))
-    # Publish the ONE deterministic client script — the ONLY client entry point
-    # (issue #2416 follow-up): a self-contained install.sh, parameterized by
-    # --channel.
-    write_install_script(site, base)
+    desired = dict(built)
+    # A rendered page always wins over a same-named site-tree file (H4, issue #2450).
+    desired["index.html"] = (render_page(base, pkgs, conf_fn, built, matrix).encode(), 0o644)
+    desired["browse.html"] = (render_browse_root(site, built).encode(), 0o644)
+    for ch in CH_ORDER:
+        if not os.path.isdir(os.path.join(site, ch)):
+            continue
+        for full_rel in _catalogue_subdirs(site, ch):
+            page = _render_catalogue_browse_page(site, full_rel)
+            desired[f"browse/{full_rel}/index.html"] = (page.encode(), 0o644)
+
+    written, deleted = sync_site(site, desired)
+    print(
+        f"pkg-site: {len(written)} file(s) written, {len(deleted)} removed; {len(pkgs)} pfBlockerNG package(s) indexed"
+    )
     return len(pkgs)
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description="Generate the pkg-repo landing page + per-dir indexes.")
-    ap.add_argument("site", help="the built catalog tree (output of build-repo-portable.py)")
+    ap = argparse.ArgumentParser(description="Render the pkg-site tree onto the pkg repo's docs/ and mirror it there.")
+    ap.add_argument("site", help="the docs/ tree to render into (the built catalog trees already live there)")
     ap.add_argument("base_url", help="the Pages base URL, e.g. https://pfblockerng.github.io/pkg")
+    ap.add_argument("--site-tree", required=True, help="the pkg-site/ source tree to render (this repo's pkg-site/)")
     ap.add_argument(
         "--matrix",
         help="supported-versions build matrix JSON (list of {abi, pfsense_version, variant, "
         "php_version, py_flavor}) — splits the packages table by pfSense edition. Omitted -> "
         "a single 'Other builds' table from manifest data.",
     )
-    ap.add_argument(
-        "--client-scripts-only",
-        action="store_true",
-        help=f"write only the deterministic client scripts ({', '.join(CLIENT_SCRIPTS)}); "
-        "no landing/browse/autoindex pages. Used by publish-pkg-repo.sh's catalogue-NOOP "
-        "path (issue #2408) — the pages embed a generation timestamp, so writing them "
-        "there would manufacture a commit on every run.",
-    )
     args = ap.parse_args(argv)
-    if args.client_scripts_only:
-        if args.matrix:
-            ap.error("--client-scripts-only writes no landing page — --matrix cannot apply")
-        write_install_script(args.site, args.base_url)
-        print(f"client scripts written: {', '.join(CLIENT_SCRIPTS)}")
-        return 0
     matrix = None
     if args.matrix:
         with open(args.matrix) as fh:
             matrix = json.load(fh)
-    n = write_site(args.site, args.base_url, matrix)
-    print(
-        f"landing page + browse.html + {len(all_dirs(args.site))} dir index(es) written; "
-        f"{n} pfBlockerNG package(s) indexed"
-    )
+    write_site(args.site, args.base_url, args.site_tree, matrix)
     return 0
 
 

--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -256,10 +256,13 @@ stage_touched_targets() {
 # per-target `git add` above (and promote_from_staging's `git mv`) against a
 # hostile or drifted "updated <path>" report reaching outside the catalogue
 # trees — a `..`-bearing target is the canonical case, never structurally
-# impossible from a shell loop alone.
+# impossible from a shell loop alone. `--no-renames`: git's own default rename
+# detection can fold a non-catalogue deletion into a similar-enough addition
+# under a catalogue path, so `--name-only` alone would show only the catalogue
+# path and hide the deletion.
 assert_catalogue_only_staged() {
     catalogue_alt=$(printf '%s' "$CATALOGUE_DIRS" | tr ' ' '|')
-    staged=$(git -C "$PKG_REPO" diff --cached --name-only)
+    staged=$(git -C "$PKG_REPO" diff --cached --name-only --no-renames)
     bad=$(printf '%s\n' "$staged" | grep -vE "^docs/(${catalogue_alt})/" || true)
     if [ -n "$bad" ]; then
         echo "::error::publisher commit touched non-catalogue path(s):" >&2

--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 # publish-pkg-repo.sh — verify + publish a Tagged release's or a Nightly snapshot's
 # .pkg assets into the pfBlockerNG/pkg catalogue tree, then commit + fast-forward-push
-# the result.
+# the result. Site rendering is NOT this script's job: pfBlockerNG/pkg's docs/ site
+# (index.html, browse/, .nojekyll, install.sh, …) is render-pkg-site.sh's own,
+# separately dispatched (issue #2450 step 2). This script owns catalogue paths
+# only: docs/<stable|testing|edge|nightly>/<varver>/ and docs/staging/<segment>/.
 #
 # PUBLISH_KIND selects the mode (default "tagged" when unset):
 #   tagged   PFB_SRC/scripts/publish_release.py verifies + assembles a tagged
@@ -19,41 +22,33 @@
 # strictly AFTER a successful publisher run, and a non-zero exit from it
 # is `exit 1` on the spot, before any git add ever runs. There is no
 # `git add -A` / `git add .` anywhere below — only the exact touched (channel,
-# varver) directories the publisher reports, plus the landing page's own
-# output and docs/.nojekyll; on a catalogue no-op, only the regenerated
-# client script (issue #2408) unless PUBLISH_REFRESH_LANDING=1 (issue #2416
-# follow-up) — see below. Any retired client script still on the live site is
-# swept ONLY in a commit that also regenerates the landing page — a
-# PUBLISH_REFRESH_LANDING=1 no-op, a direct/nightly real publish, or a
-# "promote" — never a knob-off (default) no-op or a "stage" no-op/run, which
-# would 404 a script the live index.html still links.
+# varver) directories the publisher reports. A second, independent guard runs
+# right before every commit (every mode): the staged diff must touch ONLY
+# docs/<stable|testing|edge|nightly|staging>/ paths — catches a hostile or buggy
+# "updated <path>" report (e.g. a `..`-bearing target) that the per-target `git
+# add` alone would otherwise trust blindly.
 #
 # On a rejected push (another run advanced origin/main first), the ENTIRE cycle
 # reruns from a fresh sync — not a rebase of the local commit — because
-# the publisher's retention/regeneration must see the racing run's tree, not
-# stale local state. checkout -B restores tracked files; `git clean -fd -- docs`
-# drops untracked leftovers under docs/ (issue #2407) so a dest autoindex
-# without its .pkgs cannot survive into landing_regen_and_stage.
+# the publisher's retention must see the racing run's tree, not stale local
+# state. checkout -B restores tracked files; `git clean -fd -- docs` drops
+# untracked leftovers under docs/ (issue #2407) so a dest autoindex without its
+# .pkgs cannot survive into the next attempt.
 #
 # PUBLISH_STAGE additionally selects WHEN a tagged catalogue commit becomes the
 # live Pages site (issue #2389 — gate-before-announce). docs/ on `main` IS the
 # Pages site, so a plain publish (PUBLISH_STAGE=direct, the default) commits the
-# catalogue and the landing page atomically, and nothing can be live-gated before
-# announce. The three extra values split that into a stage-then-promote flow:
+# catalogue directly. The three extra values split that into a stage-then-promote
+# flow:
 #   stage    run the publisher exactly as "direct" does, against the real tree,
 #            then relocate its output under docs/staging/<run-segment>/ instead
 #            of leaving it at its real (channel, varver) location — restoring
 #            the original bytes there — so a live install can be gated against
-#            the staged path while nothing else on the site moves. No landing
-#            regen: staging is never served as the site. The catalogue-no-op
-#            path is the ONE exception — it still regenerates + pushes the
-#            deterministic client script (docs/install.sh, the --channel
-#            parameterized installer; issue #2408, issue #2416, shared with
-#            "direct") even though nothing was staged, and reports
-#            GITHUB_OUTPUT noop=true.
+#            the staged path while nothing else on the site moves. A catalogue
+#            no-op stages nothing and reports GITHUB_OUTPUT noop=true.
 #   promote  move a previously staged tree (STAGING_PREFIX) into its real
-#            location and run the landing regen — this is the step that
-#            actually goes live. Never runs the publisher.
+#            location — this is the step that actually goes live. Never runs
+#            the publisher.
 #   discard  drop a previously staged tree (STAGING_PREFIX) without ever going
 #            live. Never runs the publisher.
 # promote/discard act on STAGING_PREFIX as staged (a prior "stage" run's own
@@ -73,22 +68,12 @@
 #                        segment: `:` is translated to `-` (the real workflows
 #                        set SOURCE_RUN_ID="<run_id>:<run_attempt>"), and it must
 #                        otherwise match [0-9A-Za-z_:-]+.
-#   BASE_URL               Pages base URL passed to gen_landing.py
 # Optional — every mode:
 #   PUBLISH_KIND           "tagged" (default) or "nightly"; anything else is a
 #                        usage error
 #   PUBLISH_STAGE           "direct" (default), "stage", "promote", or "discard";
 #                        anything else is a usage error. Only "direct" is valid
 #                        when PUBLISH_KIND=nightly.
-#   PUBLISH_REFRESH_LANDING "0" (default) or "1"; on an otherwise catalogue-NOOP
-#                        run, "1" regenerates the FULL landing page
-#                        (index.html/browse.html/every autoindex) instead of
-#                        just CLIENT_SCRIPTS — for shipping a landing
-#                        template/card fix via a republish of an
-#                        already-published release (issue #2416 follow-up).
-#                        Valid only with PUBLISH_KIND=tagged and
-#                        PUBLISH_STAGE=direct; any other combination is a usage
-#                        error.
 #   MAX_PUSH_ATTEMPTS      bounded retry count (default 5)
 # Optional — PUBLISH_STAGE=stage only, when GITHUB_ACTIONS-style outputs are
 # wanted:
@@ -105,16 +90,15 @@
 #
 # Required environment — PUBLISH_KIND=tagged, PUBLISH_STAGE=promote only:
 #   RELEASE_TAG, DESTINATIONS  the promote commit message's own trailers
-#   ROUTE_MATRIX             landing_regen_and_stage's tagged-mode matrix source
-#                        Never ASSETS_DIR — promote never runs publish_release.py,
-#                        and the workflow's promote-pkg-repo job does not export it
-#                        (issue #2389); SOURCE_REPOSITORY/RELEASE_ID are exported
-#                        there but unused by promote, so they are not required.
+#                        Never ASSETS_DIR/ROUTE_MATRIX — promote never runs
+#                        publish_release.py or any renderer, and the workflow's
+#                        promote-pkg-repo job does not export ASSETS_DIR (issue
+#                        #2389).
 #
 # Required environment — PUBLISH_KIND=tagged, PUBLISH_STAGE=discard only:
-#   (none beyond the unconditional PFB_SRC/PKG_REPO/SOURCE_RUN_ID/BASE_URL and
-#   STAGING_PREFIX below) — discard only removes a staged tree and commits the
-#   removal; it never runs the publisher or the landing regen.
+#   (none beyond the unconditional PFB_SRC/PKG_REPO/SOURCE_RUN_ID above) —
+#   discard only removes a staged tree and commits the removal; it never runs
+#   the publisher.
 #
 # Required environment — PUBLISH_KIND=nightly only:
 #   HANDOFF_FILE            path to the verified nightly_provenance.build_handoff JSON
@@ -126,18 +110,6 @@
 #                        staging/[0-9A-Za-z_-]+
 
 set -eu
-
-# Every deterministic client script gen_landing.py publishes at the site root:
-# the one --channel-parameterized installer (issue #2416 follow-up) — the SOLE
-# client entry point. Single source of truth for both the catalogue-NOOP `git add`
-# list and the direct/promote stage_paths list below.
-CLIENT_SCRIPTS="install.sh"
-
-# Scripts the landing generator used to publish before the issue #2416
-# follow-up collapsed every client entry point down to install.sh above —
-# gen_landing.py no longer writes them, but a republish of an
-# already-published release must still sweep them off an already-live site.
-RETIRED_CLIENT_SCRIPTS="add-repo.sh migrate-channel.sh"
 
 PUBLISH_KIND="${PUBLISH_KIND:-tagged}"
 case "$PUBLISH_KIND" in
@@ -157,28 +129,18 @@ case "$PUBLISH_STAGE" in
         ;;
 esac
 
-PUBLISH_REFRESH_LANDING="${PUBLISH_REFRESH_LANDING:-0}"
-case "$PUBLISH_REFRESH_LANDING" in
-    0 | 1) ;;
-    *)
-        echo "::error::PUBLISH_REFRESH_LANDING must be '0' or '1', got '${PUBLISH_REFRESH_LANDING}'" >&2
-        exit 1
-        ;;
-esac
-
 : "${PFB_SRC:?PFB_SRC is required}"
 : "${PKG_REPO:?PKG_REPO is required}"
 : "${SOURCE_RUN_ID:?SOURCE_RUN_ID is required}"
-: "${BASE_URL:?BASE_URL is required}"
 
 case "$PUBLISH_KIND" in
     tagged)
         # Required-var set depends on PUBLISH_STAGE: direct/stage run the publisher
-        # (needs the full publish_release.py intake); promote only regenerates the
-        # landing page + writes a commit trailer (needs a strict subset); discard
-        # needs nothing here at all (issue #2389) — the workflow's promote-pkg-repo
-        # job never exports ASSETS_DIR, so requiring it unconditionally broke every
-        # promote/discard; only what each mode reads is required.
+        # (needs the full publish_release.py intake); promote only writes a commit
+        # + its own trailers (needs a strict subset); discard needs nothing here at
+        # all (issue #2389) — the workflow's promote-pkg-repo job never exports
+        # ASSETS_DIR, so requiring it unconditionally broke every promote/discard;
+        # only what each mode reads is required.
         case "$PUBLISH_STAGE" in
             direct | stage)
                 : "${SOURCE_REPOSITORY:?SOURCE_REPOSITORY is required}"
@@ -191,7 +153,6 @@ case "$PUBLISH_KIND" in
             promote)
                 : "${RELEASE_TAG:?RELEASE_TAG is required}"
                 : "${DESTINATIONS:?DESTINATIONS is required}"
-                : "${ROUTE_MATRIX:?ROUTE_MATRIX is required}"
                 ;;
             discard) ;;
         esac
@@ -206,13 +167,6 @@ esac
 # snapshot is out of scope here (see the header docblock).
 if [ "$PUBLISH_KIND" = nightly ] && [ "$PUBLISH_STAGE" != direct ]; then
     echo "::error::PUBLISH_STAGE must be 'direct' when PUBLISH_KIND=nightly, got '${PUBLISH_STAGE}'" >&2
-    exit 1
-fi
-
-# PUBLISH_REFRESH_LANDING=1 only makes sense on the real single-push publish
-# flow — stage/promote/discard and nightly keep their own flows untouched.
-if [ "$PUBLISH_REFRESH_LANDING" = 1 ] && { [ "$PUBLISH_KIND" != tagged ] || [ "$PUBLISH_STAGE" != direct ]; }; then
-    echo "::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct, got PUBLISH_KIND='${PUBLISH_KIND}' PUBLISH_STAGE='${PUBLISH_STAGE}'" >&2
     exit 1
 fi
 
@@ -270,7 +224,12 @@ esac
 
 export PFB_SRC
 
-# --- shell helpers (PUBLISH_STAGE stage/promote/discard) --------------------
+# Catalogue-owned top-level prefixes — MUST equal render-pkg-site.sh's own
+# CATALOGUE_DIRS (the two scripts own disjoint, complementary halves of docs/).
+CATALOGUE_DIRS="stable testing edge nightly staging"
+
+# --- shell helpers (PUBLISH_STAGE stage/promote/discard, plus the
+# catalogue-only guard shared by every mode) ---------------------------------
 
 # Removes any docs/staging tree entirely — used both to sweep a stale tree left
 # by an earlier crashed "stage" run (before laying down a fresh one) and, on
@@ -283,14 +242,31 @@ remove_docs_staging_tree() {
     rm -rf "${PKG_REPO}/docs/staging"
 }
 
-# Stages the removal of every RETIRED_CLIENT_SCRIPTS entry still present on the
-# live site, so the deletion rides the same commit as whatever else this run is
-# already about to commit (NOOP script/landing refresh, or a real publish).
-# --ignore-unmatch is a no-op once a script is already gone.
-remove_retired_client_scripts() {
-    for retired in $RETIRED_CLIENT_SCRIPTS; do
-        git -C "$PKG_REPO" rm -q --ignore-unmatch -- "docs/${retired}"
+# Direct/nightly mode only: stage exactly docs/<target> for every $touched —
+# never -A. A hostile or drifted "updated <target>" report reaching outside
+# docs/<catalogue dir>/ is caught by assert_catalogue_only_staged below, not here.
+stage_touched_targets() {
+    for target in $touched; do
+        git -C "$PKG_REPO" add -- "docs/${target}"
     done
+}
+
+# GUARD, called right before every `git commit` below, in every mode: the
+# staged diff must touch ONLY docs/<CATALOGUE_DIRS>/ paths. Backstops the
+# per-target `git add` above (and promote_from_staging's `git mv`) against a
+# hostile or drifted "updated <path>" report reaching outside the catalogue
+# trees — a `..`-bearing target is the canonical case, never structurally
+# impossible from a shell loop alone.
+assert_catalogue_only_staged() {
+    catalogue_alt=$(printf '%s' "$CATALOGUE_DIRS" | tr ' ' '|')
+    staged=$(git -C "$PKG_REPO" diff --cached --name-only)
+    bad=$(printf '%s\n' "$staged" | grep -vE "^docs/(${catalogue_alt})/" || true)
+    if [ -n "$bad" ]; then
+        echo "::error::publisher commit touched non-catalogue path(s):" >&2
+        printf '%s\n' "$bad" >&2
+        git -C "$PKG_REPO" reset --quiet
+        exit 1
+    fi
 }
 
 # Relocates every $touched (channel, varver) target under
@@ -344,54 +320,6 @@ promote_from_staging() {
     remove_docs_staging_tree
 }
 
-# Shared by "direct" (non-noop) and "promote": regenerate the landing page and
-# stage the landing output, every $touched target's directory, that dest's
-# channel-level autoindex, and already-tracked dest/channel autoindexes
-# gen_landing rewrote. Never a site-wide find of every docs/**/index.html —
-# an untracked leftover dest from a rejected push is not this run's
-# (issue #2407).
-landing_regen_and_stage() {
-    case "$PUBLISH_KIND" in
-        tagged) landing_input="$ROUTE_MATRIX" ;;
-        nightly) landing_input="$(jq -ec '.route_matrix' "$HANDOFF_FILE")" ;;
-    esac
-    landing_matrix_file=$(mktemp)
-    printf '%s' "$landing_input" | jq -c \
-        '[.[] | {abi: "FreeBSD:\(.freebsd_major):*", pfsense_version, variant, php_version, py_flavor}]' \
-        >"$landing_matrix_file"
-    python3 "${PFB_SRC}/scripts/gen_landing.py" \
-        "${PKG_REPO}/docs" "$BASE_URL" \
-        --matrix "$landing_matrix_file"
-    rm -f "$landing_matrix_file"
-    true >"${PKG_REPO}/docs/.nojekyll"
-
-    stage_paths="docs/.nojekyll"
-    [ -f "${PKG_REPO}/docs/index.html" ] && stage_paths="${stage_paths} docs/index.html"
-    [ -f "${PKG_REPO}/docs/browse.html" ] && stage_paths="${stage_paths} docs/browse.html"
-    for client_script in $CLIENT_SCRIPTS; do
-        if [ ! -f "${PKG_REPO}/docs/${client_script}" ]; then
-            echo "::error::gen_landing.py did not write docs/${client_script} (CLIENT_SCRIPTS/generator drift)" >&2
-            exit 1
-        fi
-        stage_paths="${stage_paths} docs/${client_script}"
-    done
-    for target in $touched; do
-        stage_paths="${stage_paths} docs/${target}"
-        ch="${target%%/*}"
-        [ -f "${PKG_REPO}/docs/${ch}/index.html" ] && stage_paths="${stage_paths} docs/${ch}/index.html"
-    done
-    # Already-tracked dest/channel autoindexes only. ls-files cannot name a
-    # dest that is not in the index, so a leftover dest autoindex cannot
-    # appear here (issue #2407).
-    tracked_indexes=$(git -C "$PKG_REPO" ls-files -- 'docs/*/index.html' 'docs/*/*/index.html')
-    if [ -n "$tracked_indexes" ]; then
-        stage_paths="${stage_paths}
-${tracked_indexes}"
-    fi
-    # shellcheck disable=SC2086  # stage_paths is a controlled, space/newline-separated pathspec list
-    git -C "$PKG_REPO" add -- $stage_paths
-}
-
 # GITHUB_OUTPUT for PUBLISH_STAGE=stage only ($1 = noop true|false). $touched is
 # newline-separated "channel/varver" tokens, possibly empty.
 emit_stage_outputs() {
@@ -418,22 +346,17 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
     # to docs/ so G1 debris at the repo root stays untracked (issue #2407).
     git -C "$PKG_REPO" clean -fd -- docs
 
-    stage_commit=0
-
     case "$PUBLISH_STAGE" in
         promote)
             # --- promote: move a staged tree live; never runs the publisher ---
             promote_from_staging
             # A staged prefix carrying no (channel, varver) directory at all (a
-            # stray file, an empty tree) is not a valid promote — regenerating the
-            # landing page and committing would announce nothing while still
-            # advancing main, silently.
+            # stray file, an empty tree) is not a valid promote — committing
+            # would advance main while promoting nothing, silently.
             [ -n "$touched" ] || {
                 echo "::error::PUBLISH_STAGE=promote: no <channel>/<varver> under docs/${STAGING_PREFIX}" >&2
                 exit 1
             }
-            landing_regen_and_stage
-            remove_retired_client_scripts
             commit_message=$(printf 'publish: %s -> %s\n\npfBlockerNG-Release-Tag: %s\npfBlockerNG-Source-Run-Id: %s\npfBlockerNG-Promoted-From: %s\n' \
                 "$RELEASE_TAG" "$DESTINATIONS" "$RELEASE_TAG" "$SOURCE_RUN_ID" "$STAGING_PREFIX")
             ;;
@@ -518,7 +441,7 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
             # byte-identical content, a mid-fix regression). Filtering here, before
             # stage_touched's own mv, means the empty-touched branch just below
             # (unconditional for every mode) already handles "all dropped" as the
-            # ordinary STAGE NOOP case — no separate code path needed.
+            # ordinary NOOP case — no separate code path needed.
             if [ "$PUBLISH_STAGE" = stage ] && [ -n "$touched" ]; then
                 real_touched=""
                 for target in $touched; do
@@ -532,76 +455,20 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                 touched="$real_touched"
             fi
 
-            script_refresh=0
             if [ -z "$touched" ]; then
-                # --- catalogue unchanged: the client scripts (or, with
-                # PUBLISH_REFRESH_LANDING=1, the whole landing page) may still have
-                # drifted --------------------------------------------------------
-                # Every client script (CLIENT_SCRIPTS) is generated from the PFB_SRC
-                # checkout, not from the release assets, so a script-only fix must ship
-                # even when every destination already matches (issue #2408, issue #2416).
-                # By default only the deterministic script set is regenerated here —
-                # the landing/browse/autoindex pages embed a generation timestamp, and
-                # writing them on every no-op would manufacture a commit on every run.
-                # PUBLISH_REFRESH_LANDING=1 (validated tagged+direct-only above) opts
-                # into the full regen instead, for a landing-only fix (issue #2416
-                # follow-up).
-                if [ "$PUBLISH_REFRESH_LANDING" = 1 ]; then
-                    landing_regen_and_stage
-                    # Only here: the sweep must never ride a commit that does not
-                    # also regenerate the landing page — the live index.html still
-                    # links every RETIRED_CLIENT_SCRIPTS entry, so a knob-off sweep
-                    # would 404 it.
-                    remove_retired_client_scripts
-                else
-                    python3 "${PFB_SRC}/scripts/gen_landing.py" \
-                        "${PKG_REPO}/docs" "$BASE_URL" \
-                        --client-scripts-only
-                    client_script_paths=""
-                    for client_script in $CLIENT_SCRIPTS; do
-                        client_script_paths="${client_script_paths} docs/${client_script}"
-                    done
-                    # shellcheck disable=SC2086  # client_script_paths is a controlled, space-separated pathspec list
-                    git -C "$PKG_REPO" add -- $client_script_paths
+                # --- catalogue unchanged: nothing to stage or commit ----------------
+                if [ "$PUBLISH_STAGE" = stage ]; then
+                    emit_stage_outputs true
+                    echo "publish-pkg-repo: STAGE NOOP — nothing to gate."
                 fi
-                if git -C "$PKG_REPO" diff --cached --quiet; then
-                    if [ "$PUBLISH_STAGE" = stage ]; then
-                        emit_stage_outputs true
-                        echo "publish-pkg-repo: STAGE NOOP — nothing to gate."
-                    fi
-                    echo "publish-pkg-repo: NOOP — nothing touched, nothing to commit."
-                    exit 0
-                fi
-                if [ "$PUBLISH_REFRESH_LANDING" = 1 ]; then
-                    echo "publish-pkg-repo: catalogue unchanged — PUBLISH_REFRESH_LANDING=1; committing a landing refresh."
-                else
-                    echo "publish-pkg-repo: catalogue unchanged — client script(s) drifted; committing a script refresh."
-                fi
-                script_refresh=1
+                echo "publish-pkg-repo: NOOP — nothing touched, nothing to commit."
+                exit 0
             elif [ "$PUBLISH_STAGE" = stage ]; then
                 # --- stage: relocate the publisher's output, never serve it --------
                 stage_touched
-                stage_commit=1
             else
-                # --- landing page regen — only for an actual publish ---------------
-                # Unless PUBLISH_REFRESH_LANDING=1, never on the catalogue-NOOP path
-                # above: gen_landing.py's page output embeds a generation timestamp,
-                # so running it there would manufacture a diff (and therefore a
-                # commit) on every run even when no catalogue changed.
-                #
-                # landing_matrix.json's abi expression (pinned by
-                # tests/shell/publish_pkg_repo_spec.sh): freebsd_major alone feeds the
-                # CPU-wildcarded ABI string. The retired `arch` matrix field is never
-                # interpolated — every published .pkg is NO_ARCH, so the honest ABI is the
-                # wildcard the packages themselves carry, never a per-arch value. The two
-                # modes share this ONE transform, differing only in the matrix array's
-                # source: tagged's pinned $ROUTE_MATRIX, nightly's own handoff-carried
-                # route_matrix (the handoff is what this run actually verified against —
-                # never a freshly re-read live matrix, which could have moved since).
-                landing_regen_and_stage
-                remove_retired_client_scripts
-
-                # --- stage EXACTLY what changed — never -A / . ----------------------
+                # --- direct/nightly: stage EXACTLY what changed — never -A / . -----
+                stage_touched_targets
                 if git -C "$PKG_REPO" diff --cached --quiet; then
                     echo "publish-pkg-repo: NOOP — the publisher reported changes but nothing is staged; discarding."
                     git -C "$PKG_REPO" reset --quiet
@@ -609,17 +476,7 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                 fi
             fi
 
-            if [ "$script_refresh" -eq 1 ]; then
-                # Mode-independent: the refresh carries no release/nightly identity —
-                # its content comes from PFB_SRC, so the run id is the whole provenance.
-                if [ "$PUBLISH_REFRESH_LANDING" = 1 ]; then
-                    commit_message=$(printf 'publish: refresh landing page\n\npfBlockerNG-Source-Run-Id: %s\n' \
-                        "$SOURCE_RUN_ID")
-                else
-                    commit_message=$(printf 'publish: refresh client scripts\n\npfBlockerNG-Source-Run-Id: %s\n' \
-                        "$SOURCE_RUN_ID")
-                fi
-            elif [ "$PUBLISH_STAGE" = stage ]; then
+            if [ "$PUBLISH_STAGE" = stage ]; then
                 commit_message=$(printf 'publish: stage %s -> %s\n\npfBlockerNG-Release-Tag: %s\npfBlockerNG-Source-Run-Id: %s\npfBlockerNG-Staging-Prefix: %s\n' \
                     "$RELEASE_TAG" "$DESTINATIONS" "$RELEASE_TAG" "$SOURCE_RUN_ID" "$stage_prefix")
             else
@@ -641,6 +498,8 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
             ;;
     esac
 
+    assert_catalogue_only_staged
+
     # Fixed bot identity via per-invocation -c flags, not repo config: a bare CI
     # checkout carries no git identity, and this script must not depend on one
     # being configured elsewhere (matches release.yml/module-durations.yml's
@@ -654,15 +513,10 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
         printf '%s\n' "$push_out" >&2
         echo "publish-pkg-repo: ADVANCE — pushed $(git -C "$PKG_REPO" rev-parse HEAD)"
         if [ "$PUBLISH_STAGE" = stage ]; then
-            # stage_commit=0 here means the ADVANCE was a script-only refresh
-            # (script_refresh=1: touched was empty, but the client scripts had
-            # drifted) — there is nothing to gate, so this is a noop from the
-            # caller's point of view even though a commit landed.
-            if [ "$stage_commit" -eq 1 ]; then
-                emit_stage_outputs false
-            else
-                emit_stage_outputs true
-            fi
+            # The only way to reach a commit under PUBLISH_STAGE=stage is via
+            # stage_touched (the empty-touched branch above always exits 0
+            # first) — there is always something to gate here.
+            emit_stage_outputs false
         fi
         exit 0
     fi

--- a/scripts/render-pkg-site.sh
+++ b/scripts/render-pkg-site.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+# render-pkg-site.sh — renders the pkg website (everything under pfBlockerNG/pkg's
+# docs/ EXCEPT the catalogue-owned trees) from this repo's pkg-site/ via
+# gen_landing.py, then commits + pushes the result onto docs/ on `main`. Split out
+# from publish-pkg-repo.sh (issue #2450 step 2): that script owns catalogue paths
+# only (docs/<stable|testing|edge|nightly>/<varver>/, docs/staging/<segment>/);
+# this script is the SOLE place that renders and ships the site around them —
+# dispatched independently, after a publish or on its own.
+#
+# GUARD: a render commit may never touch a catalogue-owned path (CATALOGUE_DIRS,
+# which MUST equal gen_landing.py's own constant of the same name) — enforced by
+# a name-only diff right after staging, before any commit. A violation resets the
+# index and exits 1, no exceptions (gen_landing.py's own sync_site() already
+# refuses to write one; this is the shell-side backstop).
+#
+# On a rejected push, the ENTIRE cycle re-syncs + re-renders from a fresh
+# origin/main checkout (never a rebase of the local commit) — same rationale as
+# publish-pkg-repo.sh's own retry loop: the renderer must see the racing run's
+# tree, not stale local state.
+#
+# Required environment:
+#   PFB_SRC          pfBlockerNG source-repo checkout — provides
+#                    scripts/gen_landing.py and pkg-site/
+#   PKG_REPO         pfBlockerNG/pkg checkout, already cloned with a credentialed
+#                    remote (this script only fetches/checks out/pushes `main`)
+#   BASE_URL         Pages base URL passed to gen_landing.py
+#   SOURCE_RUN_ID    provenance trailer on the render commit
+#   ROUTE_MATRIX     the pinned ROUTE matrix, compact JSON array text (same shape
+#                    the publisher receives) — transformed into gen_landing.py's
+#                    --matrix input below
+# Optional:
+#   MAX_PUSH_ATTEMPTS  bounded retry count (default 5)
+
+set -eu
+
+# Publisher-owned top-level prefixes a render commit may never touch — MUST equal
+# gen_landing.py's own CATALOGUE_DIRS constant.
+CATALOGUE_DIRS="stable testing edge nightly staging"
+
+: "${PFB_SRC:?PFB_SRC is required}"
+: "${PKG_REPO:?PKG_REPO is required}"
+: "${BASE_URL:?BASE_URL is required}"
+: "${SOURCE_RUN_ID:?SOURCE_RUN_ID is required}"
+: "${ROUTE_MATRIX:?ROUTE_MATRIX is required}"
+
+MAX_PUSH_ATTEMPTS="${MAX_PUSH_ATTEMPTS:-5}"
+# A bound below 1 (or a non-numeric one) makes the retry loop body unreachable, so
+# the script would report a push rejection for a push it never attempted.
+case "$MAX_PUSH_ATTEMPTS" in
+    '' | *[!0-9]*) MAX_PUSH_ATTEMPTS=0 ;;
+esac
+[ "$MAX_PUSH_ATTEMPTS" -ge 1 ] || {
+    echo "::error::MAX_PUSH_ATTEMPTS must be a positive integer" >&2
+    exit 1
+}
+
+# gen_landing.py's own --matrix transform (shared with publish-pkg-repo.sh's
+# publisher intake): freebsd_major alone feeds the CPU-wildcarded ABI string.
+# The retired `arch` matrix field is never interpolated — every published .pkg is
+# NO_ARCH, so the honest ABI is the wildcard the packages themselves carry.
+# ROUTE_MATRIX is constant across retries, so this runs once, up front.
+matrix_file=$(mktemp)
+trap 'rm -f "$matrix_file"' EXIT
+printf '%s' "$ROUTE_MATRIX" | jq -c \
+    '[.[] | {abi: "FreeBSD:\(.freebsd_major):*", pfsense_version, variant, php_version, py_flavor}]' \
+    >"$matrix_file"
+
+attempt=1
+while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
+    echo "render-pkg-site: sync attempt ${attempt}/${MAX_PUSH_ATTEMPTS} — fetching origin/main"
+    git -C "$PKG_REPO" fetch --quiet origin main
+    git -C "$PKG_REPO" checkout --quiet -B main origin/main
+    # checkout -B restores tracked files; untracked leftovers from a rejected
+    # push survive unless cleaned. Scope to docs/ so debris at the repo root
+    # stays untracked (matches publish-pkg-repo.sh, issue #2407).
+    git -C "$PKG_REPO" clean -fd -- docs
+
+    # A non-zero exit here is fatal to the WHOLE run, on the spot: no git add, no
+    # commit, no push follows (same containment idiom as publish-pkg-repo.sh's
+    # own publisher call).
+    render_out=$(mktemp)
+    trap 'rm -f "$render_out" "$matrix_file"' EXIT
+    render_rc=0
+    python3 "${PFB_SRC}/scripts/gen_landing.py" \
+        "${PKG_REPO}/docs" "$BASE_URL" \
+        --site-tree "${PFB_SRC}/pkg-site" \
+        --matrix "$matrix_file" >"$render_out" 2>&1 || render_rc=$?
+    if [ "$render_rc" -ne 0 ]; then
+        echo "::error::gen_landing.py failed — aborting before any git mutation" >&2
+        cat "$render_out" >&2
+        exit 1
+    fi
+    cat "$render_out"
+    trap 'rm -f "$matrix_file"' EXIT
+    rm -f "$render_out"
+
+    # No `git add -A` without the guard below to back it: gen_landing.py's own
+    # sync_site() already refuses to write inside a catalogue prefix, but this
+    # is the independent, structural check that a broken/regressed renderer
+    # cannot silently defeat.
+    git -C "$PKG_REPO" add -A -- docs
+
+    catalogue_pathspec=""
+    for catalogue_dir in $CATALOGUE_DIRS; do
+        catalogue_pathspec="${catalogue_pathspec} docs/${catalogue_dir}"
+    done
+    # shellcheck disable=SC2086  # catalogue_pathspec is a controlled, space-separated pathspec list
+    touched_catalogue=$(git -C "$PKG_REPO" diff --cached --name-only -- $catalogue_pathspec)
+    if [ -n "$touched_catalogue" ]; then
+        echo "::error::render touched catalogue-owned path(s):" >&2
+        printf '%s\n' "$touched_catalogue" >&2
+        git -C "$PKG_REPO" reset --quiet
+        exit 1
+    fi
+
+    if git -C "$PKG_REPO" diff --cached --quiet; then
+        echo "render-pkg-site: NOOP — site already current."
+        exit 0
+    fi
+
+    short_sha=$(git -C "$PFB_SRC" rev-parse --short HEAD 2>/dev/null || echo unknown)
+    commit_message=$(printf 'render: pkg website (%s)\n\npfBlockerNG-Source-Run-Id: %s\n' "$short_sha" "$SOURCE_RUN_ID")
+
+    # Fixed bot identity via per-invocation -c flags, not repo config — same
+    # rationale as publish-pkg-repo.sh: a bare CI checkout carries no git
+    # identity, and this script must not depend on one being configured elsewhere.
+    git -C "$PKG_REPO" \
+        -c user.name="github-actions[bot]" \
+        -c user.email="github-actions[bot]@users.noreply.github.com" \
+        commit --quiet -m "$commit_message"
+
+    if push_out=$(git -C "$PKG_REPO" push origin HEAD:main 2>&1); then
+        printf '%s\n' "$push_out" >&2
+        echo "render-pkg-site: ADVANCE — pushed $(git -C "$PKG_REPO" rev-parse HEAD)"
+        exit 0
+    fi
+    printf '%s\n' "$push_out" >&2
+
+    # Retry only a genuine non-fast-forward rejection (another run advanced
+    # main); anything else (auth, network, protected-branch policy) is a hard
+    # failure and must not be retried.
+    if ! printf '%s' "$push_out" | grep -qiE 'non-fast-forward|fetch first|\[rejected\]'; then
+        echo "::error::push failed for a reason other than remote contention — aborting without retry" >&2
+        exit 1
+    fi
+
+    echo "render-pkg-site: push rejected (attempt ${attempt}/${MAX_PUSH_ATTEMPTS}) — another run advanced main; re-syncing and retrying" >&2
+    attempt=$((attempt + 1))
+done
+
+echo "::error::push rejected ${MAX_PUSH_ATTEMPTS} times in a row; giving up" >&2
+exit 1

--- a/scripts/render-pkg-site.sh
+++ b/scripts/render-pkg-site.sh
@@ -104,8 +104,12 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
     for catalogue_dir in $CATALOGUE_DIRS; do
         catalogue_pathspec="${catalogue_pathspec} docs/${catalogue_dir}"
     done
+    # --no-renames for the same reason as publish-pkg-repo.sh's own guard: a
+    # rename-shaped diff must never be folded away before this check sees it,
+    # even though the pathspec's own ordering already makes this script safe
+    # without it — belt-and-suspenders symmetry with the publisher's guard.
     # shellcheck disable=SC2086  # catalogue_pathspec is a controlled, space-separated pathspec list
-    touched_catalogue=$(git -C "$PKG_REPO" diff --cached --name-only -- $catalogue_pathspec)
+    touched_catalogue=$(git -C "$PKG_REPO" diff --cached --name-only --no-renames -- $catalogue_pathspec)
     if [ -n "$touched_catalogue" ]; then
         echo "::error::render touched catalogue-owned path(s):" >&2
         printf '%s\n' "$touched_catalogue" >&2

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -97,6 +97,26 @@ def main():
                 print(f"updated {target}")
         return 0
 
+    if mode == "rename_fold":
+        # g1c (hostile): a rename-SHAPED diff. docs/index.html (non-catalogue,
+        # already tracked) is deleted, and a NEW catalogue-owned file is added
+        # carrying its exact bytes -- git's own default rename detection pairs
+        # a genuine delete with a genuine add of near-identical content, so
+        # `git diff --cached --name-only` (no --no-renames) shows ONLY the
+        # catalogue-side name, hiding the non-catalogue deletion entirely. The
+        # wrapper's guard must not depend on that git default.
+        docs_dir = os.path.join(pkg_repo, "docs")
+        with open(os.path.join(docs_dir, "index.html"), "rb") as fh:
+            index_bytes = fh.read()
+        target_dir = os.path.join(docs_dir, "edge", "ce-2.8")
+        os.makedirs(target_dir, exist_ok=True)
+        with open(os.path.join(target_dir, "data.pkg"), "wb") as fh:
+            fh.write(index_bytes)
+        os.remove(os.path.join(docs_dir, "index.html"))
+        print("updated index.html")
+        print("updated edge/ce-2.8")
+        return 0
+
     for target in os.environ.get("FAKE_TOUCHED", "").split(","):
         target = target.strip()
         if not target:
@@ -261,6 +281,36 @@ JSON
     The stderr should include '::error::publisher commit touched non-catalogue path(s):'
     The result of function local_head_now should equal "$original_head"
     The result of function remote_head_now should equal "$original_remote_head"
+    staged="$(git_fixture -C "${base}/pkg-repo" diff --cached --name-only)"
+    The variable staged should equal ''
+  End
+
+  It 'g1c: a rename-shaped diff (non-catalogue file deleted, similar bytes added under a catalogue path) is still rejected'
+    # Fixture: seed a tracked docs/index.html (>=200 bytes -- past git's default
+    # rename-similarity threshold) and drop the pre-existing docs/edge/ce-2.8/data.pkg
+    # from HEAD, so the stub's own recreation of data.pkg below is a genuine ADD, not
+    # a MODIFY -- required for git's default rename detection to even consider pairing
+    # it with the deletion of docs/index.html (a same-path modify can never become R).
+    content=""
+    i=0
+    while [ "$i" -lt 200 ]; do
+        content="${content}x"
+        i=$((i + 1))
+    done
+    printf '%s\n' "$content" > "${base}/pkg-repo/docs/index.html"
+    git_fixture -C "${base}/pkg-repo" add docs/index.html
+    git_fixture -C "${base}/pkg-repo" rm -q docs/edge/ce-2.8/data.pkg
+    git_fixture -C "${base}/pkg-repo" commit -q -m 'g1c fixture: seed docs/index.html, drop data.pkg'
+    git_fixture -C "${base}/pkg-repo" push -q origin main
+    pretest_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
+    pretest_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
+    export FAKE_MODE=rename_fold
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::publisher commit touched non-catalogue path(s):'
+    The stderr should include 'docs/index.html'
+    The result of function local_head_now should equal "$pretest_head"
+    The result of function remote_head_now should equal "$pretest_remote_head"
     staged="$(git_fixture -C "${base}/pkg-repo" diff --cached --name-only)"
     The variable staged should equal ''
   End

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -1,19 +1,24 @@
 #shellcheck shell=sh
 # publish_pkg_repo_spec.sh — scripts/publish-pkg-repo.sh.
 #
-# publish_release.py and gen_landing.py are stubbed (a fake PFB_SRC checkout, see
-# setup()): git mutation is the ONLY thing this script owns, and it is exactly what
-# this spec exercises — network/engine verification is publish_release.py's own,
-# already-covered PFB_SRC=... python3 -m unittest suite (pkg repo). Fixture: a bare
-# "remote" origin plus a working PKG_REPO clone already carrying one committed
-# catalogue directory (docs/edge/ce-2.8), mirroring what the release job's checkout
-# looks like before this script runs.
+# publish_release.py and publish_nightly.py are stubbed (a fake PFB_SRC checkout,
+# see setup()): git mutation is the ONLY thing this script owns, and it is exactly
+# what this spec exercises — network/engine verification is each publisher's own,
+# already-covered PFB_SRC=... python3 -m unittest suite (pkg repo). Site rendering
+# is NOT this script's job (issue #2450 step 2) — render-pkg-site.sh's own spec
+# (render_pkg_site_spec.sh) covers that. Fixture: a bare "remote" origin plus a
+# working PKG_REPO clone already carrying one committed catalogue directory
+# (docs/edge/ce-2.8), mirroring what the release job's checkout looks like before
+# this script runs.
 #
-# CONTAINMENT: the fault-injection case is the load-bearing one —
-# the stub simulates catalogue_assembly.py's own documented failure mode (a
-# mid-regeneration write-back fault: wipe the catalog descriptor files, leave an
-# orphaned .pkg, THEN exit non-zero) and this spec asserts the damaged working tree
-# never reaches a commit, and the bare origin never moves.
+# CONTAINMENT: two independent guards are exercised here. The publisher
+# fault-injection case (a mid-regeneration write-back fault: wipe the catalog
+# descriptor files, leave an orphaned .pkg, THEN exit non-zero) asserts the
+# damaged working tree never reaches a commit and the bare origin never moves.
+# The catalogue-only-staged guard (g1/g1b) asserts a hostile or drifted "updated
+# <path>" report that reaches outside docs/<stable|testing|edge|nightly|staging>/
+# is rejected before any commit, even though the per-target `git add` alone would
+# otherwise trust the report blindly.
 
 Describe 'publish-pkg-repo.sh'
   script="${PFB_ROOT}/scripts/publish-pkg-repo.sh"
@@ -42,8 +47,8 @@ Describe 'publish-pkg-repo.sh'
     original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
     original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
 
-    # --- fake PFB_SRC: stub publish_release.py + gen_landing.py -------------
-    # Real network/engine verification is publish_release.py's own unit suite
+    # --- fake PFB_SRC: stub publish_release.py + publish_nightly.py ---------
+    # Real network/engine verification is each publisher's own unit suite
     # (pkg repo); this script's OWN job is the git mutation around it, so the
     # python calls are doubled here rather than re-verified.
     mkdir -p "${base}/fake-src/scripts"
@@ -96,76 +101,24 @@ def main():
         target = target.strip()
         if not target:
             continue
-        target_dir = os.path.join(pkg_repo, "docs", target)
-        os.makedirs(target_dir, exist_ok=True)
-        with open(os.path.join(target_dir, "marker.pkg"), "w") as fh:
-            fh.write(target)
+        # Hostile/drifted report (g1/g1b): a `..`-bearing target resolves
+        # OUTSIDE docs/ entirely — the wrapper's own containment guard (never
+        # this stub) is what must catch it, so this writes directly to the
+        # resolved path instead of assuming target is always a fresh directory.
+        if ".." in target.split("/"):
+            resolved = os.path.normpath(os.path.join(pkg_repo, "docs", target))
+            with open(resolved, "a") as fh:
+                fh.write("\ntraversal\n")
+        else:
+            target_dir = os.path.join(pkg_repo, "docs", target)
+            os.makedirs(target_dir, exist_ok=True)
+            with open(os.path.join(target_dir, "marker.pkg"), "w") as fh:
+                fh.write(target)
         print(f"updated {target}")
     return 0
 
 
 sys.exit(main())
-PY
-    cat >"${base}/fake-src/scripts/gen_landing.py" <<'PY'
-import os
-import sys
-
-site = sys.argv[1]
-argv = sys.argv[1:]
-# ONE deterministic client script since issue #2416 follow-up: install.sh,
-# --channel parameterized, is the SOLE client entry point. Stub body text is the
-# script's own base name (sans .sh) so existing pre-seeded fixture bytes below
-# ("# install stub\n") keep matching byte-for-byte.
-CLIENT_SCRIPTS = ("install.sh",)
-
-
-def _write_client_scripts(site):
-    # FAKE_OMIT_CLIENT_SCRIPT simulates a generator that silently produced fewer
-    # scripts than CLIENT_SCRIPTS names (a drifted generator/wrapper pairing) —
-    # the wrapper's own fail-closed guard is what this exercises, never gen_landing.py.
-    omit = os.environ.get("FAKE_OMIT_CLIENT_SCRIPT", "")
-    for name in CLIENT_SCRIPTS:
-        if name == omit:
-            continue
-        with open(os.path.join(site, name), "w") as fh:
-            fh.write(f"#!/bin/sh\n# {name[:-len('.sh')]} stub\n")
-
-
-if "--client-scripts-only" in argv:
-    # Mirrors the real generator's script-only mode (issue #2408): ONLY the
-    # deterministic client scripts are written — no landing/browse/autoindex output.
-    _write_client_scripts(site)
-    print("client scripts stub written")
-    sys.exit(0)
-# Records the exact --matrix file this run was fed, byte for byte, when
-# FAKE_LANDING_MATRIX_RECORD is set — publish-pkg-repo.sh's own job (not
-# gen_landing.py's) is choosing that file's SOURCE (tagged: $ROUTE_MATRIX;
-# nightly: the handoff's own route_matrix), so the nightly-mode spec examples
-# assert against this record rather than re-deriving the transform themselves.
-if "--matrix" in argv:
-    matrix_path = argv[argv.index("--matrix") + 1]
-    record_path = os.environ.get("FAKE_LANDING_MATRIX_RECORD")
-    if record_path:
-        with open(matrix_path, encoding="utf-8") as src, open(record_path, "w", encoding="utf-8") as dst:
-            dst.write(src.read())
-with open(os.path.join(site, "index.html"), "w") as fh:
-    fh.write("landing stub\n")
-with open(os.path.join(site, "browse.html"), "w") as fh:
-    fh.write("browse stub\n")
-# Mirrors the real generator's all_dirs()/write_site(): a per-directory
-# autoindex at EVERY existing level, not just this run's touched targets. The
-# site-wide walk is the property being pinned, so the stub must walk it too.
-# Skips docs/staging (issue #2389: gen_landing.py never indexes it) so the
-# spec examples can exercise a real index-less directory under docs/.
-for dirpath, _dirs, _files in os.walk(site):
-    rel = os.path.relpath(dirpath, site)
-    if rel == "." or rel == "staging" or rel.startswith("staging" + os.sep):
-        continue
-    with open(os.path.join(dirpath, "index.html"), "w") as fh:
-        fh.write(f"autoindex stub: {rel}\n")
-# write_site() also publishes every client script into the site root.
-_write_client_scripts(site)
-print("landing stub written")
 PY
 
     # --- fake publish_nightly.py — the Nightly-mode counterpart to the
@@ -240,8 +193,7 @@ PY
         SOURCE_RUN_ID=10:1
         ASSETS_DIR="${base}/assets"
         ROUTE_MATRIX='[{"freebsd_major":"15","pfsense_version":"2.8","variant":"CE","php_version":"8.3","py_flavor":"py311"}]'
-        BASE_URL=https://pfblockerng.github.io/pkg
-        export PFB_SRC PKG_REPO SOURCE_REPOSITORY RELEASE_ID RELEASE_TAG DESTINATIONS SOURCE_RUN_ID ASSETS_DIR ROUTE_MATRIX BASE_URL
+        export PFB_SRC PKG_REPO SOURCE_REPOSITORY RELEASE_ID RELEASE_TAG DESTINATIONS SOURCE_RUN_ID ASSETS_DIR ROUTE_MATRIX
     }
     common_env
     mkdir -p "${base}/assets"
@@ -265,26 +217,9 @@ PY
     git_fixture -C "${base}/pkg-repo" rev-parse main 2>/dev/null || echo "UNRESOLVABLE-main"
   }
 
-  # The one deterministic client script (issue #2416 follow-up: install.sh,
-  # --channel parameterized, is the SOLE client entry point), and its docs/-relative
-  # path — shared by every preseed/assertion below so a future addition only needs
-  # bumping in one place.
-  CLIENT_SCRIPT_NAMES="install.sh"
-  CLIENT_SCRIPT_PATHS="docs/install.sh"
-  SORTED_CLIENT_SCRIPT_PATHS="docs/install.sh"
-
-  # Writes every client-script stub, byte-identical to the fake gen_landing.py's
-  # own output, into docs/ — used to preseed a "current scripts" state.
-  write_client_script_stubs() {
-    for _name in ${CLIENT_SCRIPT_NAMES}; do
-        _base="${_name%.sh}"
-        printf '#!/bin/sh\n# %s stub\n' "${_base}" > "${base}/pkg-repo/docs/${_name}"
-    done
-  }
-
   # --- PUBLISH_KIND=nightly fixture ------------------------------------------
   # Layered on top of common_env (already exported by setup()): keeps the shared
-  # vars (PFB_SRC/PKG_REPO/SOURCE_RUN_ID/BASE_URL) and adds the nightly-only ones.
+  # vars (PFB_SRC/PKG_REPO/SOURCE_RUN_ID) and adds the nightly-only ones.
   # Tagged-only vars are deliberately left exported by common_env in most nightly
   # examples -- proving they are IGNORED, not merely absent (see the "does not
   # leak a tagged trailer" example) -- except where a test explicitly unsets them.
@@ -294,126 +229,59 @@ PY
     RESULTS_DIR="${base}/results"
     export PUBLISH_KIND HANDOFF_FILE RESULTS_DIR
     mkdir -p "$RESULTS_DIR"
-    # DELIBERATELY a different row than common_env's own $ROUTE_MATRIX (freebsd
-    # 15/2.8/CE/8.3/py311) -- n9 stages the landing matrix on this handoff row
-    # and asserts against ITS values; if the nightly arm ever regressed to
-    # reading $ROUTE_MATRIX instead, the assertion must fail on a value
-    # mismatch, not pass on accidental byte-identity between the two fixtures.
     cat > "$HANDOFF_FILE" <<'JSON'
 {"run_id":"10:1","pkg_version":"20260804153045.aaaaaaa","route_matrix":[{"freebsd_major":"16","pfsense_version":"2.9","variant":"Plus","php_version":"8.4","py_flavor":"py312"}]}
 JSON
   }
 
-  # --- landing_matrix ABI expression pins: the transform lives in this script,
-  # so the properties pfBlockerNG/pkg's own retired test pinned live here now ---
+  # --- g1/g1b: the catalogue-only-staged guard (issue #2450 step 2) ----------
+  # A hostile or drifted "updated <path>" report is the load-bearing red canary:
+  # the per-target `git add -- docs/<target>` alone would stage whatever git
+  # resolves that pathspec to, however it escapes docs/ — this guard is the
+  # only thing that catches it, on every mode, right before every commit.
 
-  It 'never interpolates the retired arch matrix field'
-    When run sh -c "! grep -Fq '\\(.arch)' '${script}'"
+  It 'g1 (hostile): refuses to commit when the staged diff reaches outside the catalogue trees'
+    export FAKE_MODE=success
+    export FAKE_TOUCHED='../README.txt'
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::publisher commit touched non-catalogue path(s):'
+    The stderr should include 'README.txt'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+    staged="$(git_fixture -C "${base}/pkg-repo" diff --cached --name-only)"
+    The variable staged should equal ''
+  End
+
+  It 'g1b (hostile): refuses a traversal target that resolves outside docs/ but still inside the repo'
+    export FAKE_MODE=success
+    export FAKE_TOUCHED='stable/../../x'
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::publisher commit touched non-catalogue path(s):'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+    staged="$(git_fixture -C "${base}/pkg-repo" diff --cached --name-only)"
+    The variable staged should equal ''
+  End
+
+  It 'g2: a direct publish commits ONLY docs/<channel>/<varver> paths'
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    When run script "$script"
     The status should equal 0
-  End
-
-  It 'contains exactly one abi FreeBSD wildcard expression'
-    When run sh -c "grep -o 'abi: \"FreeBSD:[^\"]*\"' '${script}' | wc -l | tr -d ' '"
-    The output should equal 1
-  End
-
-  It 'the abi expression as written emits the NO_ARCH wildcard for freebsd_major'
-    abi_expr="$(grep -o 'abi: "FreeBSD:[^"]*"' "$script" | head -1)"
-    When run sh -c "printf '%s' '{\"freebsd_major\":\"15\"}' | jq -c '{ ${abi_expr} }'"
-    The output should equal '{"abi":"FreeBSD:15:*"}'
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
+    The variable committed should equal 'docs/edge/ce-2.8/marker.pkg'
   End
 
   # --- success path ----------------------------------------------------------
 
-  It 'commits and pushes exactly the touched directory plus the landing page'
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=edge/ce-2.8
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The result of function local_head_now should not equal "$original_head"
-    The result of function remote_head_now should not equal "$original_remote_head"
-    The path "${base}/pkg-repo/docs/edge/ce-2.8/marker.pkg" should be exist
-    The path "${base}/pkg-repo/docs/index.html" should be exist
-  End
-
-  It 'fails closed when the generator silently omits a client script'
-    # CodeRabbit finding: landing_regen_and_stage's `[ -f ... ] && stage_paths=...`
-    # SKIPS a missing client script instead of failing — a drifted generator/wrapper
-    # pairing (CLIENT_SCRIPTS names a script the generator no longer writes) would
-    # silently ship no script at all, never caught. The wrapper must die instead,
-    # naming the missing file, and commit nothing.
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=edge/ce-2.8
-    export FAKE_OMIT_CLIENT_SCRIPT=install.sh
-    When run script "$script"
-    The status should not equal 0
-    The stderr should include 'install.sh'
-    The result of function local_head_now should equal "$original_head"
-    The result of function remote_head_now should equal "$original_remote_head"
-  End
-
-  It 'stages nothing outside the touched target and the landing page'
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=edge/ce-2.8
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --stat --format= HEAD | tr -s ' ' | sed 's/^ *//;s/ .*//')"
-    The variable committed should include 'docs/edge/ce-2.8/marker.pkg'
-    The variable committed should include 'docs/index.html'
-    The variable committed should include 'docs/.nojekyll'
-  End
-
-  It 'stages the channel-level autoindex gen_landing.py regenerates for every existing directory'
-    # gen_landing.py's all_dirs() walks the WHOLE docs/ tree on every run,
-    # regenerating a per-directory autoindex at every level — not just the
-    # (channel, varver) directory this run touched. docs/edge/index.html sits
-    # one level ABOVE docs/edge/ce-2.8 (the touched target), so it is never
-    # swept in by the touched-target pathspec and must be staged separately.
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=edge/ce-2.8
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    The path "${base}/pkg-repo/docs/edge/index.html" should be exist
-    committed="$(git_fixture -C "${base}/pkg-repo" show --stat --format= HEAD | tr -s ' ' | sed 's/^ *//;s/ .*//')"
-    The variable committed should include 'docs/edge/index.html'
-    # write_site() publishes the client script into the site root on the same
-    # walk; the landing page's install one-liner fetches it from there, so an
-    # unstaged copy means the published site serves a 404 into `sh` (issue #2416).
-    The variable committed should include 'docs/install.sh'
-  End
-
-  It 'a stray index-less docs/staging dir (leftover from a crashed stage run) never aborts the dir_indexes collector'
-    # gen_landing.py never writes an index.html under docs/staging (issue #2389)
-    # -- reachable here because a `direct` publish (this script's default mode,
-    # used by nightly.yml/pkg-republish.yml) can run while a stray docs/staging
-    # tree is still sitting on disk from an earlier crashed "stage" run.
-    # docs/staging/10-1/stable/ce-2.8 is the DEEPEST, alphabetically LAST entry
-    # `find -type d` enumerates under docs/ in this fixture, so `[ -f "$d/index.html"
-    # ] && printf ...` (no `if`/`fi`) makes the while loop's own exit status 1 on
-    # its last iteration -- `dir_indexes=$(...)` then aborts the whole script under
-    # `set -e`, after the publisher already ran, before any git add/commit.
-    mkdir -p "${base}/pkg-repo/docs/staging/10-1/stable/ce-2.8"
-    echo stray >"${base}/pkg-repo/docs/staging/10-1/stable/ce-2.8/stray.pkg"
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=edge/ce-2.8
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --stat --format= HEAD | tr -s ' ' | sed 's/^ *//;s/ .*//')"
-    The variable committed should not include 'docs/staging'
-    The path "${base}/pkg-repo/docs/staging/10-1/stable/ce-2.8/index.html" should not be exist
-  End
-
   It 'never sweeps a stray untracked file or an unrelated dirty tracked file into the commit'
     # Proves the explicit pathspec, not `git add -A`/`.`, is what runs —
     # debris.txt is untracked, README.txt is tracked but outside every
-    # (channel, varver) target and outside the landing page's own output.
+    # (channel, varver) target.
     export FAKE_MODE=success
     export FAKE_TOUCHED=edge/ce-2.8
     echo dirty >> "${base}/pkg-repo/README.txt"
@@ -431,15 +299,14 @@ JSON
   End
 
   # --- leftover dest autoindex from a rejected push (issue #2407) -----------
-  # Dual defense: `git clean -fd -- docs` after checkout -B, and dest
-  # autoindex staging via `git ls-files` (already-tracked only), never a
-  # site-wide find. Each pin below is independent — dropping only one
-  # defense must turn that pin RED.
+  # Dual defense: `git clean -fd -- docs` after checkout -B, and the explicit
+  # per-target pathspec, never a site-wide add. Each pin below is independent —
+  # dropping only one defense must turn that pin RED.
 
   It 'cleans an untracked leftover dest autoindex off disk after checkout -B'
     # Clean pin: leftover must not exist on disk after ADVANCE. Dropping
-    # `git clean -fd -- docs` leaves the untracked dest (ls-files will not
-    # stage it) and this example goes RED. G1 debris/README stay uncommitted.
+    # `git clean -fd -- docs` leaves the untracked dest and this example goes
+    # RED. G1 debris/README stay uncommitted.
     mkdir -p "${base}/pkg-repo/docs/nightly/ce-2.8"
     printf 'orphan autoindex\n' > "${base}/pkg-repo/docs/nightly/ce-2.8/index.html"
     echo dirty >> "${base}/pkg-repo/README.txt"
@@ -484,47 +351,6 @@ JSON
     The variable tracked_leftover should equal ''
   End
 
-  It 'stages a rewrite of an already-tracked dest autoindex that this run did not touch'
-    # ls-files dest-level pin: origin already tracks docs/nightly/ce-2.8/index.html
-    # and this run only touches edge/ce-2.8. gen_landing rewrites every existing
-    # dest autoindex; only the ls-files dest-index stage picks this one up.
-    # Dropping that stage leaves the rewrite unstaged and this example goes RED,
-    # even if git clean remains (the file is tracked, so clean cannot remove it).
-    # Distinct from the touched-channel docs/edge/index.html rewrite below.
-    mkdir -p "${base}/pkg-repo/docs/nightly/ce-2.8"
-    printf 'old dest index\n' > "${base}/pkg-repo/docs/nightly/ce-2.8/index.html"
-    ( cd "${base}/pkg-repo" && git_fixture add docs/nightly/ce-2.8/index.html \
-        && git_fixture commit -q -m preseed-nightly-dest-index \
-        && git_fixture push -q origin main )
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=edge/ce-2.8
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
-    The variable committed should include 'docs/nightly/ce-2.8/index.html'
-    rewritten="$(git_fixture -C "${base}/pkg-repo" show HEAD:docs/nightly/ce-2.8/index.html)"
-    The variable rewritten should equal 'autoindex stub: nightly/ce-2.8'
-  End
-
-  It 'still stages a rewrite of an already-tracked channel autoindex'
-    printf 'old channel index\n' > "${base}/pkg-repo/docs/edge/index.html"
-    ( cd "${base}/pkg-repo" && git_fixture add docs/edge/index.html \
-        && git_fixture commit -q -m preseed-channel-index \
-        && git_fixture push -q origin main )
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=edge/ce-2.8
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
-    The variable committed should include 'docs/edge/index.html'
-    rewritten="$(cat "${base}/pkg-repo/docs/edge/index.html")"
-    The variable rewritten should equal 'autoindex stub: edge'
-  End
-
   # --- the script must be self-sufficient for git identity -----------------
 
   It 'commits with a fixed bot identity even when no git identity is configured anywhere'
@@ -566,16 +392,7 @@ JSON
 
   # --- no-op path --------------------------------------------------------
 
-  It 'commits nothing on a no-op run with current client scripts'
-    # The catalogue-NOOP path still regenerates every client script
-    # (issue #2408, issue #2416) — pre-seed them byte-identical to the stub
-    # generator's output so the full-NOOP branch is reached honestly, not via drift.
-    write_client_script_stubs
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
-    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
-    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
+  It 'commits nothing on a no-op run'
     export FAKE_MODE=noop
     When run script "$script"
     The status should equal 0
@@ -584,114 +401,11 @@ JSON
     The result of function remote_head_now should equal "$original_remote_head"
   End
 
-  # Fixture for the client-script-refresh examples: a catalogue no-op with
-  # drifted scripts, plus every trap an over-broad stage could sweep in —
-  # committed landing pages whose bytes DIFFER from the stub generator's
-  # output (a regression that regenerates the timestamped pages on a no-op
-  # produces a real diff there), an untracked file, and a dirty tracked file
-  # (either of which a `git add -A`/`.` regression would commit).
-  seed_refresh_drift() {
-    printf 'old landing\n' > "${base}/pkg-repo/docs/index.html"
-    printf 'old browse\n' > "${base}/pkg-repo/docs/browse.html"
-    ( cd "${base}/pkg-repo" && git_fixture add docs/index.html docs/browse.html \
-        && git_fixture commit -q -m preseed-landing && git_fixture push -q origin main )
-    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
-    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
-    echo debris > "${base}/pkg-repo/debris.txt"
-    echo dirty >> "${base}/pkg-repo/README.txt"
-  }
-
-  It 'ships a client-script refresh when the catalogue is a no-op but the scripts drifted'
-    # The seed tree carries NO committed client scripts — maximal drift. A
-    # catalogue no-op must still publish every one of them: the scripts are
-    # generated from PFB_SRC, not from release assets, so a script-only fix was
-    # otherwise unshippable via a republish of an already-published release
-    # (issue #2408, issue #2416).
-    seed_refresh_drift
-    export FAKE_MODE=noop
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    # The wrapper's own no-op verdict must not appear; the publisher's
-    # "NOOP: every destination already matches" line legitimately does.
-    The output should not include 'publish-pkg-repo: NOOP'
-    The stderr should include 'main'
-    The result of function remote_head_now should not equal "$original_remote_head"
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should equal "$SORTED_CLIENT_SCRIPT_PATHS"
-  End
-
-  It 'a client-script refresh commits EXACTLY the four scripts and says so in the commit'
-    # Exact-list equality: no landing/browse/autoindex page, no untracked or
-    # unrelated dirty file may ride along (the seeded traps above would each
-    # break the equality), and the commit subject + run-id trailer must
-    # identify the refresh.
-    seed_refresh_drift
-    export FAKE_MODE=noop
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should equal "$SORTED_CLIENT_SCRIPT_PATHS"
-    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
-    The variable msg should include 'publish: refresh client scripts'
-    The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1'
-  End
-
-  It 'a stale single client script still ships a refresh that touches only it'
-    # issue #2416 follow-up made install.sh the SOLE client entry point. Pre-seed it
-    # stale (byte-different from the stub generator's current output) with nothing
-    # else dirty: the refresh is reached, and the resulting commit touches ONLY
-    # that one script.
-    printf '#!/bin/sh\n# stale install\n' > "${base}/pkg-repo/docs/install.sh"
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
-    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
-    export FAKE_MODE=noop
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    The result of function remote_head_now should not equal "$original_remote_head"
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should equal 'docs/install.sh'
-  End
-
   It 'commits nothing when a reported touched target leaves the tree unchanged'
     # publish_release.py reports "updated edge/ce-2.8" but writes nothing
     # under docs/ — the tree itself never changed, so `git diff --cached
-    # --quiet` after staging must find nothing to commit. Pre-seeds
-    # docs/index.html with byte-identical content to what the (also stubbed)
-    # gen_landing.py would regenerate, so the landing-page step contributes no
-    # diff either — the discard path is reached honestly, not bypassed by an
-    # incidental landing-page change.
-    git_fixture -C "${base}/pkg-repo" fetch -q origin
-    git_fixture -C "${base}/pkg-repo" checkout -q main
-    printf 'landing stub\n' > "${base}/pkg-repo/docs/index.html"
-    # The stub gen_landing.py also regenerates browse.html and a per-directory
-    # autoindex at every existing level (edge/ and edge/ce-2.8/, mirroring the
-    # real generator) — pre-seed those identically too, or their own
-    # first-ever creation would be a genuine diff and mask the branch this
-    # test means to reach.
-    printf 'browse stub\n' > "${base}/pkg-repo/docs/browse.html"
-    printf 'autoindex stub: edge\n' > "${base}/pkg-repo/docs/edge/index.html"
-    printf 'autoindex stub: edge/ce-2.8\n' > "${base}/pkg-repo/docs/edge/ce-2.8/index.html"
-    write_client_script_stubs
-    # docs/.nojekyll is truncate-and-recreated unconditionally whenever the
-    # script has any touched target (regardless of whether the target itself
-    # changed) — pre-seed it too, or its own first-ever creation would be a
-    # genuine diff and mask the branch this test means to reach.
-    true > "${base}/pkg-repo/docs/.nojekyll"
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    ( cd "${base}/pkg-repo" && git_fixture add docs/index.html docs/browse.html \
-        docs/edge/index.html docs/edge/ce-2.8/index.html docs/.nojekyll $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-landing \
-        && git_fixture push -q origin main )
-    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
-    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
-
+    # --quiet` after staging must find nothing to commit — the discard path,
+    # not the guard, is what this reaches.
     export FAKE_MODE=phantom
     export FAKE_TOUCHED=edge/ce-2.8
     When run script "$script"
@@ -699,173 +413,6 @@ JSON
     The output should include 'NOOP'
     The result of function local_head_now should equal "$original_head"
     The result of function remote_head_now should equal "$original_remote_head"
-  End
-
-  # --- PUBLISH_REFRESH_LANDING (issue #2416 follow-up: republish of an
-  # already-published release must be able to refresh the landing page, not
-  # just the client scripts) ------------------------------------------------
-
-  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 forces a full landing regen on the NOOP path, committing index.html plus the client script'
-    export PUBLISH_REFRESH_LANDING=1
-    export FAKE_MODE=noop
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    The path "${base}/pkg-repo/docs/index.html" should be exist
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should include 'docs/index.html'
-    The variable committed should include 'docs/install.sh'
-    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
-    The variable msg should include 'publish: refresh landing page'
-    The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1'
-  End
-
-  It 'refresh-landing: PUBLISH_REFRESH_LANDING unset leaves the NOOP path unchanged — no landing regen'
-    write_client_script_stubs
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
-    export FAKE_MODE=noop
-    When run script "$script"
-    The status should equal 0
-    The output should include 'NOOP'
-    The path "${base}/pkg-repo/docs/index.html" should not be exist
-  End
-
-  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_STAGE=stage, before any git call'
-    export PUBLISH_REFRESH_LANDING=1
-    export PUBLISH_STAGE=stage
-    When run script "$script"
-    The status should equal 1
-    The stderr should include '::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct'
-    The result of function local_head_now should equal "$original_head"
-    The result of function remote_head_now should equal "$original_remote_head"
-  End
-
-  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_STAGE=promote, before any git call'
-    export PUBLISH_REFRESH_LANDING=1
-    export PUBLISH_STAGE=promote
-    When run script "$script"
-    The status should equal 1
-    The stderr should include '::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct'
-    The result of function local_head_now should equal "$original_head"
-    The result of function remote_head_now should equal "$original_remote_head"
-  End
-
-  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_STAGE=discard, before any git call'
-    export PUBLISH_REFRESH_LANDING=1
-    export PUBLISH_STAGE=discard
-    When run script "$script"
-    The status should equal 1
-    The stderr should include '::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct'
-    The result of function local_head_now should equal "$original_head"
-    The result of function remote_head_now should equal "$original_remote_head"
-  End
-
-  It 'refresh-landing: PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_KIND=nightly, before any git call'
-    nightly_env
-    export PUBLISH_REFRESH_LANDING=1
-    When run script "$script"
-    The status should equal 1
-    The stderr should include '::error::PUBLISH_REFRESH_LANDING=1 requires PUBLISH_KIND=tagged and PUBLISH_STAGE=direct'
-    The result of function local_head_now should equal "$original_head"
-    The result of function remote_head_now should equal "$original_remote_head"
-  End
-
-  It 'refresh-landing: rejects a PUBLISH_REFRESH_LANDING value other than 0 or 1, before any git call'
-    export PUBLISH_REFRESH_LANDING=yes
-    When run script "$script"
-    The status should equal 1
-    The stderr should include "::error::PUBLISH_REFRESH_LANDING must be '0' or '1', got 'yes'"
-    The result of function local_head_now should equal "$original_head"
-    The result of function remote_head_now should equal "$original_remote_head"
-  End
-
-  # --- retired client scripts (docs/add-repo.sh, docs/migrate-channel.sh —
-  # replaced by the single --channel install.sh, issue #2416 follow-up) must be
-  # swept off an already-live site by a republish -----------------------------
-
-  It 'retired: PUBLISH_REFRESH_LANDING=1 sweeps retired client scripts into the landing-regen NOOP commit'
-    # The sweep only ever rides a commit that ALSO regenerates the landing page —
-    # the knob-off NOOP path below never sweeps (the live index.html still links
-    # the retired scripts; a knob-off sweep would 404 it without a regen).
-    write_client_script_stubs
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
-    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
-    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
-    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
-        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
-    export PUBLISH_REFRESH_LANDING=1
-    export FAKE_MODE=noop
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should include 'docs/add-repo.sh'
-    The variable committed should include 'docs/migrate-channel.sh'
-    The variable committed should include 'docs/index.html'
-    The path "${base}/pkg-repo/docs/add-repo.sh" should not be exist
-    The path "${base}/pkg-repo/docs/migrate-channel.sh" should not be exist
-  End
-
-  It 'retired: PUBLISH_REFRESH_LANDING unset leaves retired scripts in place on the catalogue+script NOOP — no landing regen, no 404'
-    # The retired-script sweep must never run without a landing regen in the
-    # same commit — the live index.html still links docs/add-repo.sh, so a
-    # knob-off sweep would 404 it. Knob unset (default '0') on an otherwise
-    # true NOOP must leave the retired scripts untouched and commit nothing.
-    write_client_script_stubs
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
-    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
-    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
-    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
-        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
-    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
-    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
-    export FAKE_MODE=noop
-    When run script "$script"
-    The status should equal 0
-    The output should include 'NOOP'
-    The result of function local_head_now should equal "$original_head"
-    The result of function remote_head_now should equal "$original_remote_head"
-    The path "${base}/pkg-repo/docs/add-repo.sh" should be exist
-    The path "${base}/pkg-repo/docs/migrate-channel.sh" should be exist
-  End
-
-  It 'retired: a real publish also removes retired client scripts still present on the site'
-    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
-    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
-    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
-        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=edge/ce-2.8
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should include 'docs/add-repo.sh'
-    The variable committed should include 'docs/migrate-channel.sh'
-    The variable committed should include 'docs/edge/ce-2.8/marker.pkg'
-    The path "${base}/pkg-repo/docs/add-repo.sh" should not be exist
-    The path "${base}/pkg-repo/docs/migrate-channel.sh" should not be exist
-  End
-
-  It 'retired: retired client scripts absent from the site never error the run'
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=edge/ce-2.8
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
-    The variable committed should not include 'add-repo.sh'
-    The variable committed should not include 'migrate-channel.sh'
   End
 
   # --- a damaged working tree must never reach a commit --------------------
@@ -1095,42 +642,12 @@ HOOK
 
   It 'n5: nightly mode NOOP output commits nothing'
     nightly_env
-    # Same pre-seed as the tagged no-op example: the catalogue-NOOP path
-    # regenerates every client script (issue #2408, issue #2416), so a true
-    # no-op needs them all current in the seed tree.
-    write_client_script_stubs
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
-    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
-    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
     export FAKE_MODE=noop
     When run script "$script"
     The status should equal 0
     The output should include 'NOOP'
     The result of function local_head_now should equal "$original_head"
     The result of function remote_head_now should equal "$original_remote_head"
-  End
-
-  It 'n5b: nightly mode ships the same mode-independent client-script refresh'
-    # The refresh branch precedes the PUBLISH_KIND commit-message split and
-    # must never acquire nightly identity: no jq pkg_version read, no
-    # pfBlockerNG-Nightly-Version trailer (the handoff fixture carries a
-    # pkg_version, so the nightly arm COULD produce one — this pins that the
-    # refresh arm does not route through it).
-    nightly_env
-    seed_refresh_drift
-    export FAKE_MODE=noop
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should equal "$SORTED_CLIENT_SCRIPT_PATHS"
-    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
-    The variable msg should include 'publish: refresh client scripts'
-    The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1'
-    The variable msg should not include 'pfBlockerNG-Nightly-Version'
   End
 
   It 'n6: nightly mode commit message carries the nightly version subject and trailers, ignoring tagged vars'
@@ -1173,42 +690,14 @@ HOOK
     The variable msg should include 'pfBlockerNG-Release-Tag: v4.0.0.b1'
   End
 
-  It 'n9: nightly mode derives the landing matrix from the handoff route_matrix, not $ROUTE_MATRIX'
-    # nightly_env's handoff route_matrix (freebsd 16/2.9/Plus/8.4/py312) is
-    # DELIBERATELY a different row than common_env's own $ROUTE_MATRIX
-    # (freebsd 15/2.8/CE/8.3/py311, still exported here): asserting the
-    # HANDOFF row's own values is what a wrong `landing_input="$ROUTE_MATRIX"`
-    # read in the nightly arm would actually fail on -- byte-identical
-    # fixtures would let that regression pass silently.
-    nightly_env
-    export FAKE_MODE=success
-    export FAKE_TOUCHED=nightly/ce-2.8
-    export FAKE_LANDING_MATRIX_RECORD="${base}/landing-matrix-seen.json"
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    seen="$(cat "${base}/landing-matrix-seen.json")"
-    The variable seen should equal '[{"abi":"FreeBSD:16:*","pfsense_version":"2.9","variant":"Plus","php_version":"8.4","py_flavor":"py312"}]'
-    The variable seen should not include '"pfsense_version":"2.8"'
-  End
-
   # --- PUBLISH_STAGE=stage|promote|discard (issue #2389 S1, gate-before-announce) --
   # docs/ on `main` IS the Pages site, so a plain tagged publish commits the
-  # catalogue and the landing page atomically and nothing can be live-gated before
-  # announce. common_env's SOURCE_RUN_ID is "10:1" (colon, matching the real
+  # catalogue atomically and nothing can be live-gated before announce.
+  # common_env's SOURCE_RUN_ID is "10:1" (colon, matching the real
   # release-published.yml workflow) -- PUBLISH_STAGE=stage translates it to the
   # dash-form staging segment "10-1" throughout these examples.
 
   It 's1: stage relocates a touched target under docs/staging/<segment>, restoring the original at its real location'
-    # Materialize + commit every client script BEFORE the run (as a prior "direct"
-    # publish would have left them) so the negative assertions below can actually
-    # FAIL on a regression — a stage run that never wrote them in the first place
-    # would pass those assertions vacuously (issue #2416 CodeRabbit finding).
-    write_client_script_stubs
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    ( cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main )
     export PUBLISH_STAGE=stage
     export FAKE_MODE=success
     export FAKE_TOUCHED=edge/ce-2.8
@@ -1222,16 +711,8 @@ HOOK
     The path "${base}/pkg-repo/docs/edge/ce-2.8/marker.pkg" should not be exist
     original="$(cat "${base}/pkg-repo/docs/edge/ce-2.8/meta.conf")"
     The variable original should equal 'seed'
-    The path "${base}/pkg-repo/docs/index.html" should not be exist
-    # No landing regen during "stage" (staging is never served) — the client script
-    # (already on disk/tracked from the preseed above) is not touched, staged, or
-    # re-committed by this run. Every candidate path was materialized above so each
-    # negative assertion can actually fail.
     committed="$(git_fixture -C "${base}/pkg-repo" show --stat --format= HEAD | tr -s ' ' | sed 's/^ *//;s/ .*//')"
     The variable committed should include 'docs/staging/10-1/edge/ce-2.8/marker.pkg'
-    The variable committed should not include 'docs/index.html'
-    The path "${base}/pkg-repo/docs/install.sh" should be exist
-    The variable committed should not include 'docs/install.sh'
     msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
     The variable msg should include 'publish: stage v4.0.0.b1 -> ["edge"]'
     The variable msg should include 'pfBlockerNG-Release-Tag: v4.0.0.b1'
@@ -1273,14 +754,8 @@ HOOK
     The variable out should include 'noop=false'
   End
 
-  It 's4: stage full no-op (nothing touched, scripts current) writes noop=true and prints STAGE NOOP'
+  It 's4: stage full no-op (nothing touched) writes noop=true and prints STAGE NOOP'
     export PUBLISH_STAGE=stage
-    write_client_script_stubs
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    (cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main)
-    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
-    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
     export FAKE_MODE=noop
     export GITHUB_OUTPUT="${base}/github_output.txt"
     true >"$GITHUB_OUTPUT"
@@ -1292,34 +767,6 @@ HOOK
     The result of function remote_head_now should equal "$original_remote_head"
     out="$(cat "$GITHUB_OUTPUT")"
     The variable out should include 'noop=true'
-  End
-
-  It 's4b: stage full no-op with retired scripts present leaves them untouched — PUBLISH_REFRESH_LANDING is always 0 under stage'
-    # PUBLISH_REFRESH_LANDING=1 is rejected under PUBLISH_STAGE=stage (see the
-    # refresh-landing rejection examples above), so the knob is always '0' here
-    # — the shared no-op branch must never sweep retired scripts on a stage run
-    # either.
-    export PUBLISH_STAGE=stage
-    write_client_script_stubs
-    # shellcheck disable=SC2086  # CLIENT_SCRIPT_PATHS is a controlled, space-separated pathspec list
-    (cd "${base}/pkg-repo" && git_fixture add $CLIENT_SCRIPT_PATHS \
-        && git_fixture commit -q -m preseed-scripts && git_fixture push -q origin main)
-    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
-    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
-    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
-        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
-    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
-    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
-    export FAKE_MODE=noop
-    export GITHUB_OUTPUT="${base}/github_output.txt"
-    true >"$GITHUB_OUTPUT"
-    When run script "$script"
-    The status should equal 0
-    The output should include 'NOOP'
-    The result of function local_head_now should equal "$original_head"
-    The result of function remote_head_now should equal "$original_remote_head"
-    The path "${base}/pkg-repo/docs/add-repo.sh" should be exist
-    The path "${base}/pkg-repo/docs/migrate-channel.sh" should be exist
   End
 
   It 's5: stage removes a stale docs/staging tree from an earlier crashed run in the same commit as the new one'
@@ -1373,27 +820,6 @@ HOOK
     The result of function remote_head_now should equal "$original_remote_head"
   End
 
-  It 's8: stage mode client-script refresh (nothing touched, scripts drifted) still emits noop=true'
-    # The workflow (S2) keys its live-gate dispatch on GITHUB_OUTPUT noop != 'true'
-    # -- a script-only refresh has nothing staged to gate, so it must report
-    # noop=true (touched=[]) even though a real commit landed on main (ADVANCE).
-    export PUBLISH_STAGE=stage
-    seed_refresh_drift
-    export FAKE_MODE=noop
-    export GITHUB_OUTPUT="${base}/github_output.txt"
-    true >"$GITHUB_OUTPUT"
-    When run script "$script"
-    The status should equal 0
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should equal "$SORTED_CLIENT_SCRIPT_PATHS"
-    out="$(cat "$GITHUB_OUTPUT")"
-    The variable out should include 'staging_prefix=staging/10-1'
-    The variable out should include 'touched=[]'
-    The variable out should include 'noop=true'
-  End
-
   It 's9: stage drops a phantom-touched target (publisher reported it, the tree never changed) instead of staging it'
     # publish_release.py's own touched-report and the tree's real state can, in
     # principle, disagree (the "phantom" FAKE_MODE above exists for exactly this).
@@ -1409,8 +835,9 @@ HOOK
     When run script "$script"
     The status should equal 0
     The output should include 'publish-pkg-repo: stage — edge/ce-2.8 reported updated but unchanged; not staged'
-    The output should include 'ADVANCE'
-    The stderr should include 'main'
+    The output should include 'NOOP'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
     The path "${base}/pkg-repo/docs/staging" should not be exist
     original="$(cat "${base}/pkg-repo/docs/edge/ce-2.8/meta.conf")"
     The variable original should equal 'seed'
@@ -1426,7 +853,7 @@ HOOK
         && git_fixture commit -q -m preseed-staged && git_fixture push -q origin main)
   }
 
-  It 'p1: promote moves a staged tree live, regenerates the landing page, and never sweeps unrelated dirty/untracked files'
+  It 'p1: promote moves a staged tree live and never sweeps unrelated dirty/untracked files'
     seed_staged_tree
     echo dirty >>"${base}/pkg-repo/README.txt"
     echo stray >"${base}/pkg-repo/debris.txt"
@@ -1440,9 +867,6 @@ HOOK
     marker="$(cat "${base}/pkg-repo/docs/edge/ce-2.8/marker.pkg")"
     The variable marker should equal 'edge/ce-2.8'
     The path "${base}/pkg-repo/docs/staging" should not be exist
-    The path "${base}/pkg-repo/docs/index.html" should be exist
-    landing="$(cat "${base}/pkg-repo/docs/index.html")"
-    The variable landing should equal 'landing stub'
     msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
     The variable msg should include 'publish: v4.0.0.b1 -> ["edge"]'
     The variable msg should include 'pfBlockerNG-Promoted-From: staging/10-1'
@@ -1454,27 +878,22 @@ HOOK
     The variable porcelain should include 'debris.txt'
   End
 
-  It 'p1b: promote also sweeps retired client scripts still present on the live site'
-    # promote runs landing_regen_and_stage (it IS a landing regen — the step
-    # that goes live), so the retired-script sweep belongs there too, same as
-    # the direct real-publish path.
+  It 'g3: promote commits only catalogue paths'
+    # edge/ce-2.8 already exists (from the base fixture's own seed commit), so
+    # promote_from_staging's own `git rm -r` + `git mv` legitimately touches
+    # every file at that location (the 3 pre-existing ones plus the promoted
+    # marker.pkg), not just one — the invariant this pins is that EVERY touched
+    # path is catalogue-owned, never an exact single-file count.
     seed_staged_tree
-    printf '#!/bin/sh\n# add-repo stub\n' > "${base}/pkg-repo/docs/add-repo.sh"
-    printf '#!/bin/sh\n# migrate-channel stub\n' > "${base}/pkg-repo/docs/migrate-channel.sh"
-    ( cd "${base}/pkg-repo" && git_fixture add docs/add-repo.sh docs/migrate-channel.sh \
-        && git_fixture commit -q -m preseed-retired-scripts && git_fixture push -q origin main )
     export PUBLISH_STAGE=promote
     export STAGING_PREFIX=staging/10-1
     When run script "$script"
     The status should equal 0
     The output should include 'ADVANCE'
     The stderr should include 'main'
-    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
-    The variable committed should include 'docs/add-repo.sh'
-    The variable committed should include 'docs/migrate-channel.sh'
-    The variable committed should include 'docs/edge/ce-2.8/marker.pkg'
-    The path "${base}/pkg-repo/docs/add-repo.sh" should not be exist
-    The path "${base}/pkg-repo/docs/migrate-channel.sh" should not be exist
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD)"
+    non_catalogue="$(printf '%s\n' "$committed" | grep -vE '^docs/(stable|testing|edge|nightly|staging)/' || true)"
+    The variable non_catalogue should equal ''
   End
 
   It 'p2: promote never invokes the publisher'

--- a/tests/shell/render_pkg_site_spec.sh
+++ b/tests/shell/render_pkg_site_spec.sh
@@ -195,10 +195,11 @@ PY
   # --- r2: NOOP ----------------------------------------------------------------
 
   It 'r2: a second run over already-rendered content is a NOOP'
-    sh "$script" >/dev/null 2>&1
+    seed_rc=0
+    sh "$script" >/dev/null 2>&1 || seed_rc=$?
+    [ "$seed_rc" -eq 0 ] || { echo "seed render failed with ${seed_rc}" >&2; return 1; }
     original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
     original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
-    export FAKE_RENDER_MODE=noop
     When run script "$script"
     The status should equal 0
     The output should include 'NOOP'

--- a/tests/shell/render_pkg_site_spec.sh
+++ b/tests/shell/render_pkg_site_spec.sh
@@ -1,0 +1,376 @@
+#shellcheck shell=sh
+# render_pkg_site_spec.sh — scripts/render-pkg-site.sh.
+#
+# gen_landing.py is stubbed (a fake PFB_SRC checkout, see setup()): this script's
+# own job is the git sync/guard/commit/push mechanics AROUND the renderer, which
+# is exactly what this spec exercises. The real renderer's own byte-for-byte
+# output (site-tree rendering, packages table, browse pages) is pinned by
+# tests/test_gen_landing.py — never re-verified here. Fixture: a bare "remote"
+# origin plus a working PKG_REPO clone already carrying one committed catalogue
+# directory (docs/edge/ce-2.8) with a legacy in-tree autoindex (issue #2450
+# ruling: never swept by this script or gen_landing.py — a one-time operator
+# cleanup, never script logic), a retired docs/add-repo.sh, and stale
+# docs/index.html content, mirroring what a first run of this script sees on an
+# already-published site.
+#
+# GUARD: the catalogue-containment case is the load-bearing one — the stub can
+# simulate a renderer that (mistakenly or maliciously) rewrites a file inside a
+# catalogue-owned tree, and this spec asserts that commit never happens and the
+# bare origin never moves.
+
+Describe 'render-pkg-site.sh'
+  script="${PFB_ROOT}/scripts/render-pkg-site.sh"
+
+  setup() {
+    scrub_git_env
+    base="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/renderpkgsite.XXXXXX")"
+
+    # --- bare origin + a working PKG_REPO clone with one committed catalogue ---
+    git_fixture init -q --bare "${base}/remote.git"
+    git_fixture clone -q "${base}/remote.git" "${base}/pkg-repo" 2>/dev/null
+    git_fixture -C "${base}/pkg-repo" config user.email pub@example.com
+    git_fixture -C "${base}/pkg-repo" config user.name pub
+    git_fixture -C "${base}/pkg-repo" config commit.gpgsign false
+    mkdir -p "${base}/pkg-repo/docs/edge/ce-2.8"
+    echo seed > "${base}/pkg-repo/docs/edge/ce-2.8/meta.conf"
+    echo seed > "${base}/pkg-repo/docs/edge/ce-2.8/data.pkg"
+    echo seed > "${base}/pkg-repo/docs/edge/ce-2.8/packagesite.pkg"
+    # Legacy in-tree autoindex under a catalogue dir, from the generator this
+    # replaces — issue #2450 ruling: this script (and gen_landing.py) must never
+    # touch it; sweeping it is a one-time operator cleanup, never script logic.
+    printf 'legacy autoindex\n' > "${base}/pkg-repo/docs/edge/ce-2.8/index.html"
+    printf '#!/bin/sh\n# old add-repo\n' > "${base}/pkg-repo/docs/add-repo.sh"
+    printf 'old index\n' > "${base}/pkg-repo/docs/index.html"
+    echo seed > "${base}/pkg-repo/README.txt"
+    ( cd "${base}/pkg-repo" && git_fixture checkout -q -b main \
+        && git_fixture add docs README.txt && git_fixture commit -q -m seed \
+        && git_fixture push -q origin main )
+    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
+    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
+    legacy_index_before="$(cat "${base}/pkg-repo/docs/edge/ce-2.8/index.html")"
+
+    # --- fake PFB_SRC: a real (tiny) git checkout, so the render commit's own
+    # "render: pkg website (<short sha>)" subject is deterministically pinnable,
+    # plus a stubbed gen_landing.py + an (unused by the stub, present for
+    # realism) pkg-site/ tree ------------------------------------------------
+    mkdir -p "${base}/fake-src/scripts" "${base}/fake-src/pkg-site"
+    cat >"${base}/fake-src/scripts/gen_landing.py" <<'PY'
+import os
+import subprocess
+import sys
+
+argv = sys.argv[1:]
+mode = os.environ.get("FAKE_RENDER_MODE", "default")
+
+# Pins the WRAPPER's own invocation shape: <docs> <base> --site-tree <dir>
+# --matrix <file>. The real generator's own argparse contract (and its
+# rendered byte content) is pinned by tests/test_gen_landing.py -- never
+# re-verified here.
+if len(argv) != 6 or argv[2] != "--site-tree" or argv[4] != "--matrix":
+    print("::error::unexpected gen_landing.py argv shape", file=sys.stderr)
+    sys.exit(2)
+
+docs = argv[0]
+base_url = argv[1]
+matrix_file = argv[argv.index("--matrix") + 1]
+
+record_path = os.environ.get("FAKE_MATRIX_DUMP")
+if record_path:
+    with open(matrix_file, encoding="utf-8") as src, open(record_path, "w", encoding="utf-8") as dst:
+        dst.write(src.read())
+
+# r6: simulates another run advancing origin/main WHILE this run renders --
+# a real competing commit, pushed from a second clone, so the retried run's
+# final tree provably contains both changes (not just a rejected-push message).
+compete_remote = os.environ.get("FAKE_COMPETE_REMOTE")
+compete_marker = os.environ.get("FAKE_COMPETE_MARKER")
+if compete_remote and compete_marker and not os.path.exists(compete_marker):
+    compete_clone = os.environ["FAKE_COMPETE_CLONE"]
+    git_env = dict(os.environ, GIT_CONFIG_GLOBAL="/dev/null", GIT_CONFIG_SYSTEM="/dev/null")
+    subprocess.run(["git", "clone", "-q", compete_remote, compete_clone], check=True, env=git_env)
+    # The bare origin's own HEAD symref was never repointed at "main" (only
+    # refs/heads/main was ever pushed to it), so a plain clone leaves no local
+    # branch checked out -- an explicit checkout -B is what the real scripts
+    # themselves do, and what makes `git commit`/`push origin main` below valid.
+    subprocess.run(["git", "-C", compete_clone, "checkout", "-q", "-B", "main", "origin/main"], check=True, env=git_env)
+    with open(os.path.join(compete_clone, "COMPETING.txt"), "w") as fh:
+        fh.write("race")
+    subprocess.run(["git", "-C", compete_clone, "add", "COMPETING.txt"], check=True, env=git_env)
+    subprocess.run(
+        ["git", "-C", compete_clone, "-c", "user.email=c@c.com", "-c", "user.name=competitor",
+         "commit", "-q", "-m", "competing change"],
+        check=True, env=git_env,
+    )
+    subprocess.run(["git", "-C", compete_clone, "push", "-q", "origin", "main"], check=True, env=git_env)
+    with open(compete_marker, "w") as fh:
+        fh.write("done")
+
+if mode == "fail":
+    with open(os.path.join(docs, "junk.html"), "w") as fh:
+        fh.write("junk")
+    print("::error::simulated renderer failure", file=sys.stderr)
+    sys.exit(1)
+
+if mode == "noop":
+    # Writes nothing -- the committed state (from a prior "default" run) is
+    # already current.
+    print("pkg-site: 0 file(s) written, 0 removed; 0 pfBlockerNG package(s) indexed")
+    sys.exit(0)
+
+if mode == "touch-catalogue":
+    with open(os.path.join(docs, "edge", "ce-2.8", "meta.conf"), "w") as fh:
+        fh.write("tampered")
+
+os.makedirs(os.path.join(docs, "browse", "edge", "ce-2.8"), exist_ok=True)
+with open(os.path.join(docs, "index.html"), "w") as fh:
+    fh.write(f"rendered {base_url}")
+with open(os.path.join(docs, ".nojekyll"), "w") as fh:
+    fh.write("")
+with open(os.path.join(docs, "browse", "edge", "ce-2.8", "index.html"), "w") as fh:
+    fh.write("browse stub")
+add_repo = os.path.join(docs, "add-repo.sh")
+if os.path.exists(add_repo):
+    os.remove(add_repo)
+print("pkg-site: 3 file(s) written, 1 removed; 1 pfBlockerNG package(s) indexed")
+PY
+    ( cd "${base}/fake-src" && git_fixture init -q . \
+        && git_fixture config user.email src@example.com && git_fixture config user.name src \
+        && git_fixture config commit.gpgsign false \
+        && git_fixture add -A && git_fixture commit -q -m fake-src-seed )
+    fake_src_sha="$(git_fixture -C "${base}/fake-src" rev-parse --short HEAD)"
+
+    common_env() {
+        PFB_SRC="${base}/fake-src"
+        PKG_REPO="${base}/pkg-repo"
+        BASE_URL=https://pfblockerng.github.io/pkg
+        SOURCE_RUN_ID=10:1
+        ROUTE_MATRIX='[{"freebsd_major":"15","pfsense_version":"2.8","variant":"ce","php_version":"8.3","py_flavor":"py311","arch":"amd64"}]'
+        export PFB_SRC PKG_REPO BASE_URL SOURCE_RUN_ID ROUTE_MATRIX
+    }
+    common_env
+  }
+
+  cleanup() {
+    rm -rf "$base"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  remote_head_now() {
+    git_fixture -C "${base}/remote.git" rev-parse refs/heads/main
+  }
+  local_head_now() {
+    git_fixture -C "${base}/pkg-repo" rev-parse main 2>/dev/null || echo "UNRESOLVABLE-main"
+  }
+
+  # --- r1: success path -------------------------------------------------------
+
+  It 'r1: renders and pushes ONE commit touching exactly the renderer output, deleting the retired script'
+    echo dirty >> "${base}/pkg-repo/README.txt"
+    export FAKE_MATRIX_DUMP="${base}/matrix-seen.json"
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    commit_count="$(git_fixture -C "${base}/pkg-repo" rev-list --count main)"
+    The variable commit_count should equal 2
+    committed="$(git_fixture -C "${base}/pkg-repo" show --name-only --format= HEAD | sort | xargs)"
+    The variable committed should equal 'docs/.nojekyll docs/add-repo.sh docs/browse/edge/ce-2.8/index.html docs/index.html'
+    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
+    The variable msg should include "render: pkg website (${fake_src_sha})"
+    The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1'
+    # README.txt (dirtied above, at the repo root) is never swept -- only
+    # `git add -A -- docs` runs, never a repo-wide add.
+    porcelain="$(git_fixture -C "${base}/pkg-repo" status --porcelain)"
+    The variable porcelain should include 'README.txt'
+    # The legacy in-tree autoindex under the catalogue dir is untouched, in the
+    # working tree AND in the pushed commit.
+    legacy_after="$(cat "${base}/pkg-repo/docs/edge/ce-2.8/index.html")"
+    The variable legacy_after should equal "$legacy_index_before"
+    tracked_legacy="$(git_fixture -C "${base}/pkg-repo" show HEAD:docs/edge/ce-2.8/index.html)"
+    The variable tracked_legacy should equal "$legacy_index_before"
+  End
+
+  # --- r2: NOOP ----------------------------------------------------------------
+
+  It 'r2: a second run over already-rendered content is a NOOP'
+    sh "$script" >/dev/null 2>&1
+    original_remote_head="$(git_fixture -C "${base}/remote.git" rev-parse refs/heads/main)"
+    original_head="$(git_fixture -C "${base}/pkg-repo" rev-parse main)"
+    export FAKE_RENDER_MODE=noop
+    When run script "$script"
+    The status should equal 0
+    The output should include 'NOOP'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  # --- r3: GUARD red canary ------------------------------------------------
+
+  It 'r3 (hostile): a renderer that rewrites a catalogue-owned path is rejected before any commit'
+    export FAKE_RENDER_MODE=touch-catalogue
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::render touched catalogue-owned path(s):'
+    The stderr should include 'docs/edge/ce-2.8/meta.conf'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+    staged="$(git_fixture -C "${base}/pkg-repo" diff --cached --name-only)"
+    The variable staged should equal ''
+  End
+
+  # --- r4: renderer failure -------------------------------------------------
+
+  It 'r4: a renderer failure aborts before any git mutation'
+    export FAKE_RENDER_MODE=fail
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::gen_landing.py failed — aborting before any git mutation'
+    The stderr should include 'simulated renderer failure'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  # --- r5: matrix transform --------------------------------------------------
+
+  It 'r5: feeds gen_landing.py the same abi transform the publisher used to, never interpolating arch'
+    export ROUTE_MATRIX='[{"freebsd_major":"15","pfsense_version":"2.8","variant":"ce","php_version":"8.3","py_flavor":"py311","arch":"amd64"}]'
+    export FAKE_MATRIX_DUMP="${base}/matrix-seen.json"
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    seen="$(cat "${base}/matrix-seen.json")"
+    The variable seen should equal '[{"abi":"FreeBSD:15:*","pfsense_version":"2.8","variant":"ce","php_version":"8.3","py_flavor":"py311"}]'
+  End
+
+  # --- r6: the push resync-retry loop, with a REAL competing commit ----------
+
+  It 'r6: a rejected push (a competing commit lands mid-render) re-syncs, re-renders, and pushes on the next attempt'
+    export FAKE_COMPETE_REMOTE="${base}/remote.git"
+    export FAKE_COMPETE_CLONE="${base}/compete-clone"
+    export FAKE_COMPETE_MARKER="${base}/compete-marker"
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The output should include 'sync attempt 2'
+    The stderr should include 'push rejected (attempt 1'
+    tree_entries="$(git_fixture -C "${base}/pkg-repo" ls-tree -r --name-only HEAD)"
+    The variable tree_entries should include 'COMPETING.txt'
+    The variable tree_entries should include 'docs/index.html'
+    commit_count="$(git_fixture -C "${base}/pkg-repo" rev-list --count main)"
+    The variable commit_count should equal 3
+  End
+
+  # --- r7: MAX_PUSH_ATTEMPTS validation ---------------------------------------
+
+  It 'r7a: refuses a MAX_PUSH_ATTEMPTS that cannot produce a single attempt, before any git call'
+    export MAX_PUSH_ATTEMPTS=0
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::MAX_PUSH_ATTEMPTS must be a positive integer'
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'r7b: refuses a non-numeric MAX_PUSH_ATTEMPTS, before any git call'
+    export MAX_PUSH_ATTEMPTS=many
+    When run script "$script"
+    The status should equal 1
+    The stderr should include '::error::MAX_PUSH_ATTEMPTS must be a positive integer'
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  # --- r8: missing required env -----------------------------------------------
+
+  It 'r8a: fails before any git call when PFB_SRC is missing'
+    unset PFB_SRC
+    When run script "$script"
+    The status should not equal 0
+    The stderr should include 'PFB_SRC is required'
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'r8b: fails before any git call when PKG_REPO is missing'
+    unset PKG_REPO
+    When run script "$script"
+    The status should not equal 0
+    The stderr should include 'PKG_REPO is required'
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'r8c: fails before any git call when BASE_URL is missing'
+    unset BASE_URL
+    When run script "$script"
+    The status should not equal 0
+    The stderr should include 'BASE_URL is required'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'r8d: fails before any git call when SOURCE_RUN_ID is missing'
+    unset SOURCE_RUN_ID
+    When run script "$script"
+    The status should not equal 0
+    The stderr should include 'SOURCE_RUN_ID is required'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 'r8e: fails before any git call when ROUTE_MATRIX is missing'
+    unset ROUTE_MATRIX
+    When run script "$script"
+    The status should not equal 0
+    The stderr should include 'ROUTE_MATRIX is required'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  # --- r9: fixed bot identity --------------------------------------------------
+
+  It 'r9: commits with a fixed bot identity even when no git identity is configured anywhere'
+    git_fixture -C "${base}/pkg-repo" config --unset user.email
+    git_fixture -C "${base}/pkg-repo" config --unset user.name
+    export GIT_CONFIG_GLOBAL=/dev/null
+    export GIT_CONFIG_SYSTEM=/dev/null
+    unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    author="$(git_fixture -C "${base}/pkg-repo" log -1 --format='%an <%ae>')"
+    committer="$(git_fixture -C "${base}/pkg-repo" log -1 --format='%cn <%ce>')"
+    The variable author should equal 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+    The variable committer should equal 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+  End
+
+  # --- r10: a hard push failure is not remote contention ----------------------
+
+  It 'r10: an authentication-shaped push failure makes exactly one attempt and does not retry'
+    cat > "${base}/pkg-repo/.git/hooks/pre-push" <<'HOOK'
+#!/bin/sh
+echo "fatal: Authentication failed for the requested URL" >&2
+exit 1
+HOOK
+    chmod +x "${base}/pkg-repo/.git/hooks/pre-push"
+    When run script "$script"
+    The status should equal 1
+    The stderr should include 'Authentication failed'
+    The stderr should include 'aborting without retry'
+    The stderr should not include 'push rejected'
+    The output should not include 'sync attempt 2/'
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  # --- hostile: SOURCE_RUN_ID is never evaluated ------------------------------
+
+  It 'hostile: a SOURCE_RUN_ID with spaces and quotes lands verbatim in the commit trailer only'
+    export SOURCE_RUN_ID='10:1 with spaces and "quotes"'
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    msg="$(git_fixture -C "${base}/pkg-repo" log -1 --format=%B)"
+    The variable msg should include 'pfBlockerNG-Source-Run-Id: 10:1 with spaces and "quotes"'
+  End
+End

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -2937,9 +2937,9 @@ def test_edge_rollback_stays_within_the_edge_repository(
 # entry point: EVERY starting state (fresh box, legacy -devel, a Netgate-      #
 # origin canonical install, another channel) folds                            #
 # into ONE idempotent state machine, published by                             #
-# gen_landing.py exactly the way the live website build does it                #
-# (--client-scripts-only, no landing/browse pages). These cases run the        #
-# PUBLISHED form -- the hook embedded, no sibling file on                      #
+# gen_landing.py exactly the way the live website build does it (rendering     #
+# the repo's pkg-site/ tree via --site-tree; issue #2450). These cases run     #
+# the PUBLISHED form -- the hook embedded, no sibling file on                  #
 # disk -- piped into /bin/sh on the guest, the `fetch | sh` shape a user       #
 # actually runs. Each starting state gets its own case, and every case         #
 # proves a second run is a true no-op (conf/hook bytes + installed version     #
@@ -2955,6 +2955,7 @@ def test_edge_rollback_stays_within_the_edge_repository(
 # script in this module is driven — build-repo-portable.py, build-repo.sh — never
 # imported directly).
 GEN_LANDING_PY = Path(__file__).resolve().parents[2] / "scripts" / "gen_landing.py"
+PKG_SITE_DIR = Path(__file__).resolve().parents[2] / "pkg-site"
 
 # The four stdout markers install.sh's converge step (9) guards every mutating
 # pkg call with; a no-op second run must print NONE of them.
@@ -2973,7 +2974,7 @@ def run_channel_installer(
     by ``--channel``.
 
     Generates the self-contained published form the SAME way the live website build
-    does it (``gen_landing.py <site> <base> --client-scripts-only``): the hook is
+    does it (``gen_landing.py <site> <base> --site-tree <pkg-site>``): the hook is
     embedded via the PFB_EMBED splice, install.sh's own ``PFB_BASE_URL`` default
     baked to *base_url* (issue #2416 B3/F3), no sibling file needed on disk. The env
     override below rides alongside it (harmless, keeps the staged/prefix shape a
@@ -2989,8 +2990,8 @@ def run_channel_installer(
     unredirected stdin would consume trailing script bytes). Returns WITHOUT
     raising — the refusal case (case 5 below) asserts on a non-zero exit.
     """
-    # --client-scripts-only always overwrites the same install.sh file, so one
-    # shared site dir per test is fine even across repeated/multi-channel calls.
+    # A full render always overwrites the same install.sh file, so one shared site
+    # dir per test is fine even across repeated/multi-channel calls.
     site_dir = tmp_path / "site"
     site_dir.mkdir(parents=True, exist_ok=True)
     gen = subprocess.run(
@@ -2999,7 +3000,8 @@ def run_channel_installer(
             str(GEN_LANDING_PY),
             str(site_dir),
             base_url,
-            "--client-scripts-only",
+            "--site-tree",
+            str(PKG_SITE_DIR),
         ],
         capture_output=True,
         text=True,
@@ -3008,8 +3010,7 @@ def run_channel_installer(
     )
     if gen.returncode != 0:
         raise RuntimeError(
-            f"gen_landing.py --client-scripts-only failed: rc={gen.returncode}\n"
-            f"stdout:\n{gen.stdout}\nstderr:\n{gen.stderr}"
+            f"gen_landing.py --site-tree failed: rc={gen.returncode}\nstdout:\n{gen.stdout}\nstderr:\n{gen.stderr}"
         )
     local_script = site_dir / "install.sh"
     assert local_script.is_file(), f"gen_landing.py did not publish {local_script.name}"

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -2734,28 +2734,34 @@ def test_sync_site_writes_every_desired_file_and_deletes_extraneous(tmp_path: Pa
     )
 
 
-def test_sync_site_legacy_index_html_swept_from_every_catalogue_dir(tmp_path: Path) -> None:
-    """R9: a pre-existing legacy index.html anywhere under a catalogue prefix is
-    deleted (the one-time sweep); every sibling file (meta.conf/.pkg bytes) is
-    left byte-for-byte untouched; nothing is ever WRITTEN under a catalogue prefix."""
+def test_sync_site_leaves_a_legacy_index_html_under_a_catalogue_dir_untouched(tmp_path: Path) -> None:
+    """R9: a pre-existing legacy index.html anywhere under a catalogue prefix is left
+    byte-for-byte alone by the renderer — no add/modify/delete under a catalogue
+    prefix, ever (owner ruling: any one-time cleanup of such a leftover is an
+    operator task run once after the first publish with this script, never logic
+    carried in the script itself). Every sibling file (meta.conf/.pkg bytes) is
+    likewise untouched, and the render is byte-identical before/after."""
     docs = tmp_path / "docs"
-    _touch(docs / "stable" / "index.html")
-    _touch(docs / "stable" / "ce-2.8" / "index.html")
+    stable_index = docs / "stable" / "index.html"
+    cell_index = docs / "stable" / "ce-2.8" / "index.html"
+    _touch(stable_index)
+    _touch(cell_index)
     meta = docs / "stable" / "ce-2.8" / "meta.conf"
     meta.parent.mkdir(parents=True, exist_ok=True)
     meta.write_bytes(b"version = 2;\n")
     pkg = docs / "stable" / "ce-2.8" / f"{_CANON}-1.0.0.pkg"
     pkg.write_bytes(b"pkg-bytes")
+    before = _snapshot(docs)
 
     written, deleted = gl.sync_site(str(docs), {})
 
     assert written == []
-    assert "stable/index.html" in deleted
-    assert "stable/ce-2.8/index.html" in deleted
-    assert not (docs / "stable" / "index.html").exists()
-    assert not (docs / "stable" / "ce-2.8" / "index.html").exists()
+    assert deleted == []
+    assert stable_index.is_file()
+    assert cell_index.is_file()
     assert meta.read_bytes() == b"version = 2;\n"
     assert pkg.read_bytes() == b"pkg-bytes"
+    assert _snapshot(docs) == before
 
 
 def test_sync_site_refuses_a_desired_path_under_a_catalogue_prefix(tmp_path: Path) -> None:

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -2700,6 +2700,35 @@ def test_build_site_tree_two_default_url_lines_raises(tmp_path: Path) -> None:
         gl.build_site_tree(str(tree), "https://x/pkg")
 
 
+def test_build_site_tree_half_marked_sh_raises(tmp_path: Path) -> None:
+    """Blocking finding, PR #2451 review: build_site_tree used to trigger
+    ``_embed_hook`` ONLY when the BEGIN marker was present, so a ``.sh`` carrying
+    just the END marker (a drifted/half-edited script) fell through unpatched and
+    unraised. The trigger now fires on EITHER marker being present, so a half-marked
+    file always reaches ``_embed_hook``'s own missing-marker ``ValueError`` instead
+    of silently publishing broken content."""
+    tree = tmp_path / "tree"
+    _write_tree_file(tree, "half.sh", f"#!/bin/sh\n{gl._HOOK_EMBED_END}\n".encode())
+
+    with pytest.raises(ValueError, match="embed markers"):
+        gl.build_site_tree(str(tree), "https://x/pkg")
+
+
+def test_scripts_install_sh_carries_the_bake_line_and_both_embed_markers() -> None:
+    """Drift pin (blocking finding, PR #2451 review): build_site_tree only bakes or
+    hook-embeds a .sh file when ITS OWN trigger substring occurs in the text — a
+    correct, intentional design (recipes/*.sh carry neither and must stay
+    untouched by either splice). That design depends on the repository's own
+    ``scripts/install.sh`` — the ONE file in the real pkg-site/ tree that carries
+    both — never drifting to a partial set; install.sh changes only via a reviewed
+    PR, so this pin (not runtime code) is what keeps a drifted repository copy
+    from silently publishing an unbaked or unpatched installer."""
+    text = (_SCRIPTS_DIR / "install.sh").read_text()
+    assert text.count(gl._BASE_URL_DEFAULT_LINE) == 1
+    assert text.count(gl._HOOK_EMBED_BEGIN) == 1
+    assert text.count(gl._HOOK_EMBED_END) == 1
+
+
 # ── sync_site: mirror the desired tree into docs/, never touching a catalogue dir ──
 
 
@@ -2764,6 +2793,24 @@ def test_sync_site_leaves_a_legacy_index_html_under_a_catalogue_dir_untouched(tm
     assert _snapshot(docs) == before
 
 
+def test_sync_site_never_prunes_an_empty_catalogue_owned_dir(tmp_path: Path) -> None:
+    """`_prune_empty_dirs` must skip catalogue-owned trees, matching the "never
+    added, modified, or deleted here — no exception" contract sync_site's own
+    docstring states (CodeRabbit finding id 3791471640, PR #2451 review N3): an
+    empty ``docs/staging/`` (never git-visible, but reachable via a partial
+    publisher run) and an empty ``docs/stable/empty/`` both survive."""
+    docs = tmp_path / "docs"
+    (docs / "staging").mkdir(parents=True)
+    (docs / "stable" / "empty").mkdir(parents=True)
+
+    written, deleted = gl.sync_site(str(docs), {})
+
+    assert written == []
+    assert deleted == []
+    assert (docs / "staging").is_dir()
+    assert (docs / "stable" / "empty").is_dir()
+
+
 def test_sync_site_refuses_a_desired_path_under_a_catalogue_prefix(tmp_path: Path) -> None:
     """H3: a desired site path rooted under a catalogue prefix raises BEFORE writing
     anything — the renderer must be structurally unable to write there."""
@@ -2792,6 +2839,55 @@ def test_sync_site_never_follows_a_symlink_inside_docs(tmp_path: Path) -> None:
 
     assert written == [] and deleted == []
     assert (docs / "link.txt").is_symlink()
+
+
+def test_sync_site_refuses_to_write_through_a_symlinked_leaf(tmp_path: Path) -> None:
+    """A pre-existing symlink AT a desired path (e.g. a leftover ``install.sh`` ->
+    outside docs/) must never be written through — the write pass raises before
+    touching it, and the symlink's target is left byte-for-byte alone (PR #2451
+    review N2: the write pass used to follow it while the delete pass already
+    refused to)."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    victim = tmp_path / "outside" / "victim.txt"
+    victim.parent.mkdir(parents=True)
+    victim.write_text("untouched")
+    (docs / "install.sh").symlink_to(victim)
+
+    with pytest.raises(ValueError, match="symlink"):
+        gl.sync_site(str(docs), {"install.sh": (b"RENDERED\n", 0o755)})
+
+    assert victim.read_text() == "untouched"
+    assert (docs / "install.sh").is_symlink()
+
+
+def test_sync_site_refuses_to_write_through_a_symlinked_directory(tmp_path: Path) -> None:
+    """A symlinked DIRECTORY component between docs/ and the write target (e.g. a
+    leftover ``browse`` -> ``stable``) must also be refused — the write pass walks
+    every path component, not just the leaf."""
+    docs = tmp_path / "docs"
+    (docs / "stable").mkdir(parents=True)
+    (docs / "browse").symlink_to(docs / "stable")
+
+    with pytest.raises(ValueError, match="symlink"):
+        gl.sync_site(str(docs), {"browse/edge/ce-2.8/index.html": (b"<html></html>", 0o644)})
+
+    assert (docs / "browse").is_symlink()
+    assert not (docs / "stable" / "edge").exists()
+
+
+def test_sync_site_refuses_a_desired_key_containing_a_traversal_segment(tmp_path: Path) -> None:
+    """A desired key carrying a `..` segment must never be written — even though
+    ``write_site`` never produces one today, an internal caller passing one would
+    otherwise write straight through it (PR #2451 review N2)."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    outside_marker = tmp_path / "x.txt"
+
+    with pytest.raises(ValueError, match="safe relative path"):
+        gl.sync_site(str(docs), {"../x.txt": (b"escaped\n", 0o644)})
+
+    assert not outside_marker.exists()
 
 
 # ── render_page / _channel_card: recipe text from the built site tree ─────────

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -1,20 +1,24 @@
-"""Tests for scripts/gen_landing.py — the human-navigable pkg-repo landing page.
+"""Tests for scripts/gen_landing.py — the pkg-site renderer (issue #2450).
 
-The generator turns a built four-channel catalogue tree (stable/testing/edge/nightly,
-issue #2147) into a styled index: channel install cards, a Version x ABI table read
-from each .pkg manifest, and per-dir listings that show packages but hide pkg(8) catalog
-plumbing. Most cases inject the manifest reader or exercise pure render helpers. The
-record-epoch HTML pin (issue #2401) builds a real libpkg fixture for the listing
-and landing rows.
+The generator builds the declared pkg-site/ tree (install.sh, per-channel recipes,
+.nojekyll), renders the dynamic pages (landing index.html, browse.html, and a
+browse/<channel>/… view of every catalogue tree), and mirrors the result into
+docs/ — write every desired file, delete everything extraneous, never touching a
+catalogue-owned tree. Most cases inject the manifest reader or exercise pure render
+helpers. The record-epoch HTML pin (issue #2401) builds a real libpkg fixture for
+the browse and landing rows; rendering never reads a file's mtime.
 """
 
 from __future__ import annotations
 
+import html
 import importlib.util
 import inspect
 import io
 import json
 import os
+import re
+import stat
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,11 +35,22 @@ assert _SPEC and _SPEC.loader
 gl = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(gl)
 
-# Paths to the real scripts — used wherever tests exercise the live integration
-# (write_site + write_install_script) rather than fake fixtures.
+# Paths to the real scripts/site tree — used wherever tests exercise the live
+# integration (write_site + build_site_tree) rather than fake fixtures.
 _SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+_PKG_SITE_DIR = Path(__file__).resolve().parent.parent / "pkg-site"
 
 _CANON = gl.CANONICAL_EMITTED_IDENTITY  # "pfSense-pkg-pfBlockerNG" — the ONE channel-agnostic identity
+
+
+def _fixture_site_tree(base: str) -> dict[str, tuple[bytes, int]]:
+    """A minimal built site tree for pure render_page/card tests: one recipe per
+    channel, {base}-substituted — mirrors what build_site_tree(PKG-SITE, base)
+    would produce for pkg-site/recipes/*.sh without touching the real files."""
+    return {
+        f"recipes/{ch}.sh": (f"fetch -qo - {base}/install.sh | sh -s -- --channel {ch}\n".encode(), 0o644)
+        for ch in gl.CH_ORDER
+    }
 
 
 # ── Pure helpers ──────────────────────────────────────────────────────────────
@@ -156,30 +171,27 @@ def test_artifact_datetime_is_utc_minute_precision() -> None:
 
 
 def test_published_datetime_prefers_created_annotation() -> None:
-    """Scenario: a daily republish must NOT reset an artifact's shown creation time.
+    """Scenario: the published datetime never depends on when a file was written.
 
     Given a .pkg whose manifest carries a `created` build annotation (the source
-    commit epoch) AND a much-later mtime (a re-download/rebuild 'today'),
+    commit epoch),
     When the published datetime is computed,
-    Then the annotation wins — so a rebuilt channel stops showing the republish date.
-    And with no annotation, it falls back to the mtime.
+    Then the annotation wins,
+    And with no annotation (or a malformed/out-of-range one), it resolves to ""
+    — never a file mtime (issue #2450) — which the caller renders as an em dash.
     """
     commit_epoch = datetime(2026, 6, 10, 5, 52, tzinfo=timezone.utc).timestamp()
-    republish_mtime = datetime(2026, 6, 14, 9, 38, tzinfo=timezone.utc).timestamp()
     manifest_with = {"annotations": {"commit": "deadbeef", "created": str(int(commit_epoch))}}
-    assert gl.published_datetime(manifest_with, republish_mtime) == "2026-06-10 05:52 UTC"
-    # No annotation -> mtime fallback.
-    assert gl.published_datetime({"annotations": {}}, republish_mtime) == "2026-06-14 09:38 UTC"
-    assert gl.published_datetime({}, republish_mtime) == "2026-06-14 09:38 UTC"
-    # Malformed annotation -> mtime fallback, not a crash.
-    assert gl.published_datetime({"annotations": {"created": "nope"}}, republish_mtime) == "2026-06-14 09:38 UTC"
-    # Numeric-but-out-of-range epoch (inf / huge) -> mtime fallback, not a crash on the
-    # whole page (datetime.fromtimestamp raises OverflowError/OSError, not ValueError).
-    assert gl.published_datetime({"annotations": {"created": "1e309"}}, republish_mtime) == "2026-06-14 09:38 UTC"
-    assert (
-        gl.published_datetime({"annotations": {"created": "999999999999999999"}}, republish_mtime)
-        == "2026-06-14 09:38 UTC"
-    )
+    assert gl.published_datetime(manifest_with) == "2026-06-10 05:52 UTC"
+    # No annotation -> unknown, never a mtime.
+    assert gl.published_datetime({"annotations": {}}) == ""
+    assert gl.published_datetime({}) == ""
+    # Malformed annotation -> unknown, not a crash.
+    assert gl.published_datetime({"annotations": {"created": "nope"}}) == ""
+    # Numeric-but-out-of-range epoch (inf / huge) -> unknown, not a crash on the whole
+    # page (datetime.fromtimestamp raises OverflowError/OSError, not ValueError).
+    assert gl.published_datetime({"annotations": {"created": "1e309"}}) == ""
+    assert gl.published_datetime({"annotations": {"created": "999999999999999999"}}) == ""
 
 
 def test_published_datetime_falls_back_to_build_record_epoch() -> None:
@@ -188,26 +200,23 @@ def test_published_datetime_falls_back_to_build_record_epoch() -> None:
     Given a .pkg whose only annotation is `pfb_build_record` (the release/nightly
     builders stamp the record, and nothing stamps `created` — issue #2375),
     When the published datetime is computed,
-    Then the record's `source_date_epoch` wins over the checkout mtime,
+    Then the record's `source_date_epoch` wins,
     And a bare `created` annotation still takes precedence over the record,
-    And a malformed/incomplete record falls back to mtime instead of crashing.
+    And a malformed/incomplete record resolves to "" instead of crashing.
     """
     import json
 
     commit_epoch = datetime(2026, 8, 14, 19, 32, tzinfo=timezone.utc).timestamp()
-    republish_mtime = datetime(2026, 8, 14, 22, 5, tzinfo=timezone.utc).timestamp()
     record = json.dumps({"source_date_epoch": int(commit_epoch), "source_sha": "f" * 40})
     manifest_record_only = {"annotations": {"pfb_build_record": record}}
-    assert gl.published_datetime(manifest_record_only, republish_mtime) == "2026-08-14 19:32 UTC"
+    assert gl.published_datetime(manifest_record_only) == "2026-08-14 19:32 UTC"
     # `created` still wins when both are present.
     created_epoch = datetime(2026, 8, 1, 0, 0, tzinfo=timezone.utc).timestamp()
     both = {"annotations": {"created": str(int(created_epoch)), "pfb_build_record": record}}
-    assert gl.published_datetime(both, republish_mtime) == "2026-08-01 00:00 UTC"
-    # Malformed record JSON, record without the key, non-numeric epoch -> mtime fallback.
+    assert gl.published_datetime(both) == "2026-08-01 00:00 UTC"
+    # Malformed record JSON, record without the key, non-numeric epoch -> unknown.
     for bad in ("{not json", json.dumps({}), json.dumps({"source_date_epoch": "nope"})):
-        assert (
-            gl.published_datetime({"annotations": {"pfb_build_record": bad}}, republish_mtime) == "2026-08-14 22:05 UTC"
-        )
+        assert gl.published_datetime({"annotations": {"pfb_build_record": bad}}) == ""
 
 
 def test_commit_sha_falls_back_to_build_record_source_sha() -> None:
@@ -228,21 +237,27 @@ def test_commit_sha_falls_back_to_build_record_source_sha() -> None:
     assert gl.commit_sha({"annotations": {"pfb_build_record": "{not json"}}) == ""
 
 
-def test_dir_entries_use_record_epoch_for_pkg_files(tmp_path: Path, monkeypatch: Any) -> None:
-    """Scenario: the per-directory listing must not show the publish run's mtime for packages.
+def test_display_epoch_uses_record_epoch_for_pkg_files_never_mtime(tmp_path: Path, monkeypatch: Any) -> None:
+    """Scenario: a browse-view row must not show the publish run's mtime for packages.
 
-    Given a cell directory holding a .pkg (whose embedded build record carries
-    source_date_epoch) and a catalog plumbing file,
-    When the directory entries are scanned,
-    Then the .pkg row carries the record epoch while the plumbing file keeps its mtime,
-    And an unreadable .pkg (corrupt/foreign) falls back to its mtime instead of crashing.
+    Given a .pkg (whose embedded build record carries source_date_epoch) and a
+    catalog plumbing file, both with an arbitrary mtime,
+    When each file's display epoch is resolved,
+    Then the .pkg resolves to the record epoch while the plumbing file resolves to
+    None (never its mtime, issue #2450),
+    And an unreadable .pkg (corrupt/foreign) also resolves to None instead of crashing.
     """
     record_epoch = int(datetime(2026, 8, 14, 19, 32, tzinfo=timezone.utc).timestamp())
     project = tmp_path / "pfSense-pkg-pfBlockerNG-3.3.2.pkg"
     project.write_bytes(b"not a real pkg")
-    (tmp_path / "broken.pkg").write_bytes(b"also not a pkg")
-    (tmp_path / "packagesite.pkg").write_bytes(b"catalog")
-    (tmp_path / "meta.conf").write_text("meta")
+    broken = tmp_path / "broken.pkg"
+    broken.write_bytes(b"also not a pkg")
+    site_pkg = tmp_path / "packagesite.pkg"
+    site_pkg.write_bytes(b"catalog")
+    meta = tmp_path / "meta.conf"
+    meta.write_text("meta")
+    for path in (project, broken, site_pkg, meta):
+        os.utime(path, (1_700_000_000, 1_700_000_000))
 
     def fake_read(path: str) -> dict:
         if path.endswith("broken.pkg"):
@@ -250,24 +265,16 @@ def test_dir_entries_use_record_epoch_for_pkg_files(tmp_path: Path, monkeypatch:
         return {"annotations": {"pfb_build_record": json.dumps({"source_date_epoch": record_epoch})}}
 
     monkeypatch.setattr(gl, "read_compact_manifest", fake_read)
-    _, files = gl._dir_entries(str(tmp_path), "")
-    by_name = {name: mtime for name, _size, mtime in files}
-    assert by_name["pfSense-pkg-pfBlockerNG-3.3.2.pkg"] == float(record_epoch)
-    assert by_name["broken.pkg"] == os.stat(tmp_path / "broken.pkg").st_mtime
-    assert by_name["meta.conf"] == os.stat(tmp_path / "meta.conf").st_mtime
-    # Catalog plumbing stays on mtime even when the stub would hand it a record
+    assert gl._display_epoch(str(project)) == float(record_epoch)
+    assert gl._display_epoch(str(broken)) is None
+    assert gl._display_epoch(str(meta)) is None
+    # Catalog plumbing stays None even when the stub would hand it a record
     # (is_package_file is the gate — issue #2401 leftover of path.endswith(".pkg")).
-    assert by_name["packagesite.pkg"] == os.stat(tmp_path / "packagesite.pkg").st_mtime
-    # Out-of-range epoch (inf) must fall back to mtime, not crash the renderer later.
-    monkeypatch.setattr(
-        gl,
-        "read_compact_manifest",
-        lambda _p: {"annotations": {"created": "1e309"}},
-    )
-    _, files = gl._dir_entries(str(tmp_path), "")
-    by_name = {name: mtime for name, _size, mtime in files}
-    assert by_name["broken.pkg"] == os.stat(tmp_path / "broken.pkg").st_mtime
-    assert by_name[project.name] == os.stat(project).st_mtime
+    assert gl._display_epoch(str(site_pkg)) is None
+    # Out-of-range epoch (inf) resolves to None, not a crash later.
+    monkeypatch.setattr(gl, "read_compact_manifest", lambda _p: {"annotations": {"created": "1e309"}})
+    assert gl._display_epoch(str(broken)) is None
+    assert gl._display_epoch(str(project)) is None
 
 
 # Record-only fixture used by the write_site HTML pin (issue #2401). Epochs are
@@ -330,22 +337,20 @@ def _record_only_cell(root: Path) -> tuple[Path, Path]:
     return root, cell
 
 
-def test_artifact_epoch_prefers_created_then_record_then_mtime() -> None:
-    """One resolver: created annotation, then pfb_build_record, then the file mtime."""
+def test_artifact_epoch_prefers_created_then_record_then_none() -> None:
+    """One resolver: created annotation, then pfb_build_record, else None — never mtime."""
     record = json.dumps({"source_date_epoch": _RECORD_EPOCH, "source_sha": _SOURCE_SHA})
     created = {"annotations": {"created": "10", pfb_pkg.PFB_BUILD_RECORD_KEY: record}}
-    assert gl.artifact_epoch(created, float(_FILE_MTIME)) == 10.0
-    assert gl.artifact_epoch({"annotations": {pfb_pkg.PFB_BUILD_RECORD_KEY: record}}, float(_FILE_MTIME)) == float(
+    assert gl.artifact_epoch(created) == 10.0
+    assert gl.artifact_epoch({"annotations": {pfb_pkg.PFB_BUILD_RECORD_KEY: record}}) == float(_RECORD_EPOCH)
+    # Out-of-range created falls through to the record, then to None.
+    assert gl.artifact_epoch({"annotations": {"created": "1e309", pfb_pkg.PFB_BUILD_RECORD_KEY: record}}) == float(
         _RECORD_EPOCH
     )
-    # Out-of-range created falls through to the record, then to mtime.
-    assert gl.artifact_epoch(
-        {"annotations": {"created": "1e309", pfb_pkg.PFB_BUILD_RECORD_KEY: record}}, float(_FILE_MTIME)
-    ) == float(_RECORD_EPOCH)
-    assert gl.artifact_epoch({"annotations": {"created": "1e309"}}, float(_FILE_MTIME)) == float(_FILE_MTIME)
-    assert gl.artifact_epoch({}, float(_FILE_MTIME)) == float(_FILE_MTIME)
-    assert gl.artifact_epoch({"annotations": ["not", "a", "map"]}, float(_FILE_MTIME)) == float(_FILE_MTIME)
-    assert gl.artifact_epoch({"annotations": "created=1"}, float(_FILE_MTIME)) == float(_FILE_MTIME)
+    assert gl.artifact_epoch({"annotations": {"created": "1e309"}}) is None
+    assert gl.artifact_epoch({}) is None
+    assert gl.artifact_epoch({"annotations": ["not", "a", "map"]}) is None
+    assert gl.artifact_epoch({"annotations": "created=1"}) is None
 
 
 def test_published_datetime_and_display_epoch_share_artifact_epoch(tmp_path: Path, monkeypatch: Any) -> None:
@@ -356,27 +361,27 @@ def test_published_datetime_and_display_epoch_share_artifact_epoch(tmp_path: Pat
     assert "artifact_epoch(" in src_disp
 
     sentinel = 1111111111.0
-    seen: list[tuple[dict, float]] = []
+    seen: list[dict] = []
 
-    def fake_epoch(manifest: dict, mtime: float) -> float:
-        seen.append((manifest, mtime))
+    def fake_epoch(manifest: dict) -> float:
+        seen.append(manifest)
         return sentinel
 
     monkeypatch.setattr(gl, "artifact_epoch", fake_epoch)
-    assert gl.published_datetime({"annotations": {"created": "1"}}, 9.0) == gl.artifact_datetime(sentinel)
+    assert gl.published_datetime({"annotations": {"created": "1"}}) == gl.artifact_datetime(sentinel)
 
     pkg = tmp_path / f"{_CANON}-3.3.2.pkg"
     pkg.write_bytes(b"x")
     monkeypatch.setattr(gl, "read_compact_manifest", lambda _p: {"annotations": {}})
-    assert gl._display_epoch(str(pkg), 22.0) == sentinel
+    assert gl._display_epoch(str(pkg)) == sentinel
     assert len(seen) == 2
 
 
-def test_catalog_pkg_keeps_mtime_when_manifest_reader_returns_record(tmp_path: Path, monkeypatch: Any) -> None:
+def test_catalog_pkg_never_shown_via_a_stubbed_project_record(tmp_path: Path, monkeypatch: Any) -> None:
     """packagesite.pkg / data.pkg must not inherit a stubbed project record.
 
     is_package_file is the gate: even if read_compact_manifest would return the
-    project record for every path, catalog .pkg files keep their mtime.
+    project record for every path, catalog .pkg files resolve to None (issue #2450).
     """
     cell = tmp_path / "cell"
     cell.mkdir()
@@ -386,8 +391,6 @@ def test_catalog_pkg_keeps_mtime_when_manifest_reader_returns_record(tmp_path: P
     project.write_bytes(b"pkg")
     site_pkg.write_bytes(b"catalog")
     data_pkg.write_bytes(b"data")
-    for path in (project, site_pkg, data_pkg):
-        os.utime(path, (_FILE_MTIME, _FILE_MTIME))
 
     record = json.dumps({"source_date_epoch": _RECORD_EPOCH, "source_sha": _SOURCE_SHA})
     monkeypatch.setattr(
@@ -395,18 +398,17 @@ def test_catalog_pkg_keeps_mtime_when_manifest_reader_returns_record(tmp_path: P
         "read_compact_manifest",
         lambda _p: {"annotations": {pfb_pkg.PFB_BUILD_RECORD_KEY: record}},
     )
-    _, files = gl._dir_entries(str(cell), "")
-    by_name = {name: mtime for name, _size, mtime in files}
-    assert by_name[project.name] == float(_RECORD_EPOCH)
-    assert by_name["packagesite.pkg"] == float(_FILE_MTIME)
-    assert by_name["data.pkg"] == float(_FILE_MTIME)
+    assert gl._display_epoch(str(project)) == float(_RECORD_EPOCH)
+    assert gl._display_epoch(str(site_pkg)) is None
+    assert gl._display_epoch(str(data_pkg)) is None
 
 
-def test_write_site_record_only_pkg_drives_listing_and_landing(tmp_path: Path, monkeypatch: Any) -> None:
+def test_write_site_record_only_pkg_drives_browse_and_landing(tmp_path: Path, monkeypatch: Any) -> None:
     """A real record-only compact-manifest fixture drives write_site (issue #2401).
 
-    The cell listing and the landing Published / Commit cells show the record
-    epoch / source_sha, not the file mtime.
+    The browse-view row and the landing Published / Commit cells show the record
+    epoch / source_sha; a plumbing sibling's row shows an em dash, never a mtime
+    (issue #2450: no epoch ever falls back to a file's mtime).
     """
     site, cell = _record_only_cell(tmp_path / "site")
     # Prove the archive is a real record-only compact manifest before rendering.
@@ -417,17 +419,18 @@ def test_write_site_record_only_pkg_drives_listing_and_landing(tmp_path: Path, m
     assert pfb_pkg.PFB_BUILD_RECORD_KEY in annotations
 
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/")
+    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
     assert n == 1
 
-    listing = (cell / "index.html").read_text()
+    listing = (site / "browse" / "stable" / "ce-2.8" / "index.html").read_text()
     pkg_row = _autoindex_row(listing, f"{_CANON}-3.3.2.pkg")
     assert _RECORD_DATE in pkg_row
     assert _MTIME_DATE not in pkg_row
     for plumbing in ("packagesite.pkg", "data.pkg", "meta.conf"):
         row = _autoindex_row(listing, plumbing)
         assert _RECORD_DATE not in row
-        assert _MTIME_DATE in row
+        assert _MTIME_DATE not in row
+        assert "&mdash;" in row
 
     landing = (site / "index.html").read_text()
     assert _RECORD_DATE in landing
@@ -436,8 +439,8 @@ def test_write_site_record_only_pkg_drives_listing_and_landing(tmp_path: Path, m
     assert f">{_SOURCE_SHA[:7]}<" in landing
 
 
-def test_write_site_out_of_range_created_on_project_pkg_falls_back(tmp_path: Path, monkeypatch: Any) -> None:
-    """created=1e309 on the project .pkg falls back to mtime; write_site does not raise."""
+def test_write_site_out_of_range_created_on_project_pkg_renders_dash(tmp_path: Path, monkeypatch: Any) -> None:
+    """created=1e309 on the project .pkg renders an em dash; write_site does not raise."""
     site = tmp_path / "site"
     cell = site / "stable" / "ce-2.8"
     pkg = cell / f"{_CANON}-3.3.2.pkg"
@@ -445,12 +448,14 @@ def test_write_site_out_of_range_created_on_project_pkg_falls_back(tmp_path: Pat
     os.utime(pkg, (_FILE_MTIME, _FILE_MTIME))
 
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/")
+    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
     assert n == 1
-    listing = (cell / "index.html").read_text()
-    assert _MTIME_DATE in _autoindex_row(listing, pkg.name)
+    listing = (site / "browse" / "stable" / "ce-2.8" / "index.html").read_text()
+    row = _autoindex_row(listing, pkg.name)
+    assert _MTIME_DATE not in row
+    assert "&mdash;" in row
     landing = (site / "index.html").read_text()
-    assert _MTIME_DATE in landing
+    assert _MTIME_DATE not in landing
 
 
 def test_commit_cell_links_valid_sha_and_dashes_missing() -> None:
@@ -598,10 +603,15 @@ def test_collect_packages_and_write_site_skip_unknown_top_level_dir(tmp_path: Pa
 
     Given a catalog tree with a real 'stable/' channel package AND a stray unrecognized
     top-level dir ('quarantine/') holding what looks like a canonical package,
-    When packages are collected / the site is written,
-    Then only the real channel's package counts, the stray dir's file never appears in
-    the packages table/cards, and write_site still succeeds (the stray dir stays
-    browsable via its own autoindex — the directory walk doesn't consult channel_of_path).
+    When packages are collected,
+    Then only the real channel's package counts and the stray dir's file never appears
+    in the packages table/cards.
+    When the site is written,
+    Then write_site still succeeds — but the stray dir, sitting under neither a
+    CATALOGUE_DIRS prefix nor the site tree, is swept by the mirror (issue #2450: the
+    renderer owns everything outside the catalogue trees, so an unrecognized top-level
+    dir is extraneous, not "browsable" — that model retired with the old per-dir
+    autoindex).
     """
     site = tmp_path / "site"
     _touch(site / "stable" / "ce-2.8" / f"{_CANON}-1.0.0.pkg")
@@ -617,15 +627,15 @@ def test_collect_packages_and_write_site_skip_unknown_top_level_dir(tmp_path: Pa
 
     monkeypatch.setattr(gl, "read_compact_manifest", fake_read)
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
-    n = gl.write_site(str(site), "https://x/pkg")
+    n = gl.write_site(str(site), "https://x/pkg", str(_PKG_SITE_DIR))
 
     assert n == 1
     index_html = (site / "index.html").read_text()
     assert "9.9.9" not in index_html
-    # Still browsable: the stray dir gets its own autoindex, and appears in browse.html.
-    assert (site / "quarantine" / "ce-2.8" / "index.html").is_file()
+    # Swept by the mirror: not a catalogue prefix, not part of the site tree.
+    assert not (site / "quarantine").exists()
     browse = (site / "browse.html").read_text()
-    assert '<a href="./quarantine/">quarantine/</a>' in browse
+    assert "quarantine" not in browse
 
 
 def test_write_site_resolves_latest_version_per_channel_from_path_fixtures(tmp_path: Path, monkeypatch: Any) -> None:
@@ -1287,7 +1297,7 @@ def test_render_page_renders_all_four_channel_cards_with_correct_content() -> No
     install, or a conf snippet.
     """
     base = "https://pfblockerng.github.io/pkg"
-    page = gl.render_page(base, [], _stub_conf)
+    page = gl.render_page(base, [], _stub_conf, _fixture_site_tree(base))
 
     titles = {"stable": "Stable", "testing": "Testing", "edge": "Edge", "nightly": "Nightly"}
     audience_anchor = {
@@ -1330,7 +1340,7 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
         _mx("FreeBSD:16:aarch64", "26.03", "Plus", "8.5", "py311"),
     ]
     base = "https://pfblockerng.github.io/pkg"
-    page = gl.render_page(base, pkgs, _stub_conf, matrix)
+    page = gl.render_page(base, pkgs, _stub_conf, _fixture_site_tree(base), matrix)
 
     # Latest versions surfaced for the present channels.
     assert "3.2.16.20260614.9" in page
@@ -1406,7 +1416,9 @@ def test_render_page_snippets_have_copy_buttons() -> None:
       inline <code> spans, and unpublished cards have none.
     """
     pkgs = [_pkg("testing", _CANON, "3.2.16", "FreeBSD:15:amd64", "testing/ce-2.8/FreeBSD:15:amd64/d.pkg")]
-    page = gl.render_page("https://pfblockerng.github.io/pkg", pkgs, _stub_conf)
+    page = gl.render_page(
+        "https://pfblockerng.github.io/pkg", pkgs, _stub_conf, _fixture_site_tree("https://pfblockerng.github.io/pkg")
+    )
 
     # The button + wrapper exist, and the <pre> payload is unchanged (button is a sibling).
     assert '<div class="snip">' in page
@@ -1429,22 +1441,26 @@ def test_render_page_snippets_have_copy_buttons() -> None:
     assert "<script>" in page  # the handler is wired
 
 
-def test_autoindex_has_no_copy_affordance() -> None:
-    """The copy button/script live only on the landing page, not the directory autoindex."""
-    out = gl.render_autoindex("stable", ["amd64"], [("notes.txt", 12, 1_700_000_000.0)])
+def test_autoindex_has_no_copy_affordance(tmp_path: Path) -> None:
+    """The copy button/script live only on the landing page, not a browse page."""
+    docs = tmp_path / "docs"
+    _touch(docs / "stable" / "amd64" / "notes.txt")
+
+    out = gl._render_catalogue_browse_page(str(docs), "stable")
+
     assert 'class="copy"' not in out
     assert "navigator.clipboard" not in out
 
 
 def test_render_page_table_empty_when_no_packages() -> None:
-    page = gl.render_page("https://x/pkg", [], _stub_conf)
+    page = gl.render_page("https://x/pkg", [], _stub_conf, _fixture_site_tree("https://x/pkg"))
     assert "No packages published yet." in page
     assert '<a class="browse" href="./browse.html">' in page  # browse link present even when empty
 
 
 def test_render_page_empty_channel_shows_not_yet_published_for_every_card() -> None:
     """Empty site: four unpublished cards, zero recipes, zero manual conf, zero copy buttons."""
-    page = gl.render_page("https://x/pkg", [], _stub_conf)
+    page = gl.render_page("https://x/pkg", [], _stub_conf, _fixture_site_tree("https://x/pkg"))
     assert page.count("not yet published") == 4
     assert "pkg install" not in page
     assert "install.sh" not in page
@@ -1461,7 +1477,7 @@ def test_render_page_shared_version_across_stable_testing_edge() -> None:
         _pkg("testing", _CANON, ver, "FreeBSD:15:*", f"testing/ce-2.8/x-{ver}.pkg"),
         _pkg("edge", _CANON, ver, "FreeBSD:15:*", f"edge/ce-2.8/x-{ver}.pkg"),
     ]
-    page = gl.render_page("https://x/pkg", pkgs, _stub_conf)
+    page = gl.render_page("https://x/pkg", pkgs, _stub_conf, _fixture_site_tree("https://x/pkg"))
 
     # Same version string surfaces on stable, testing, AND edge's card (3 occurrences).
     assert page.count(f'<p class="ver">Latest <code>{ver}</code></p>') == 3
@@ -1475,7 +1491,7 @@ def test_render_page_edge_ahead_of_testing_and_stable_shows_divergence() -> None
         _pkg("testing", _CANON, "4.0.1.b1", "FreeBSD:15:*", "testing/ce-2.8/x.pkg"),
         _pkg("edge", _CANON, "4.1.0.a1", "FreeBSD:15:*", "edge/ce-2.8/x.pkg"),
     ]
-    page = gl.render_page("https://x/pkg", pkgs, _stub_conf)
+    page = gl.render_page("https://x/pkg", pkgs, _stub_conf, _fixture_site_tree("https://x/pkg"))
 
     assert '<p class="ver">Latest <code>4.0.0</code></p>' in page
     assert '<p class="ver">Latest <code>4.0.1.b1</code></p>' in page
@@ -1485,7 +1501,9 @@ def test_render_page_edge_ahead_of_testing_and_stable_shows_divergence() -> None
 def test_unpublished_nightly_card_has_no_install_recipe() -> None:
     """Issue #2382: unpublished Nightly keeps the badge/blurb and ships no recipe."""
     pkgs = [_pkg("stable", _CANON, "3.3.2", "FreeBSD:15:*", "stable/ce-2.8/x.pkg")]
-    page = gl.render_page("https://pfblockerng.github.io/pkg", pkgs, _stub_conf)
+    page = gl.render_page(
+        "https://pfblockerng.github.io/pkg", pkgs, _stub_conf, _fixture_site_tree("https://pfblockerng.github.io/pkg")
+    )
     nightly = page[page.index('"card nightly"') :]
     # The nightly card ends at the next footer-ish boundary; search the nightly
     # slice up to the published-packages heading.
@@ -1504,7 +1522,7 @@ def test_published_card_recipe_is_the_one_line_channel_installer() -> None:
     cards)."""
     pkgs = [_pkg("stable", _CANON, "3.3.2", "FreeBSD:15:*", "stable/ce-2.8/x.pkg")]
     base = "https://pfblockerng.github.io/pkg"
-    page = gl.render_page(base, pkgs, _stub_conf)
+    page = gl.render_page(base, pkgs, _stub_conf, _fixture_site_tree(base))
     # Anchored to the <pre> element boundary so a trailing `sh -s --` (or any other
     # tail) fails this assertion rather than slipping past a bare substring check.
     assert f"<pre>fetch -qo - {base}/install.sh | sh -s -- --channel stable</pre>" in page
@@ -1515,7 +1533,7 @@ def test_published_card_recipe_is_the_one_line_channel_installer() -> None:
 
 def test_render_page_omits_internal_trust_and_channel_model() -> None:
     """Development and implementation details do not leak into the user-facing page."""
-    page = gl.render_page("https://x/pkg", [], _stub_conf)
+    page = gl.render_page("https://x/pkg", [], _stub_conf, _fixture_site_tree("https://x/pkg"))
 
     assert "Every channel installs the same canonical package" not in page
     assert "Trust &amp; channel model" not in page
@@ -1524,40 +1542,53 @@ def test_render_page_omits_internal_trust_and_channel_model() -> None:
     assert "Channel switching" not in page
 
 
-def test_render_autoindex_lists_dirs_files_and_parent() -> None:
-    """A non-root autoindex shows a Parent Directory row, subdirs (name/), and files (name+size),
-    with './'-prefixed hrefs so a colon-bearing ABI segment stays a relative path."""
-    out = gl.render_autoindex(
-        "stable/ce-2.8",
-        ["amd64"],
-        [("notes.txt", 12, 1_700_000_000.0)],
-    )
+def test_catalogue_browse_page_lists_dirs_files_and_parent(tmp_path: Path) -> None:
+    """A non-channel-root browse page shows a Parent Directory row, subdirs (name/),
+    and files (name+size), the file linking OUT of browse/ into the real tree."""
+    docs = tmp_path / "docs"
+    _touch(docs / "stable" / "ce-2.8" / "amd64" / "placeholder")
+    (docs / "stable" / "ce-2.8" / "notes.txt").write_bytes(b"x" * 12)
+
+    out = gl._render_catalogue_browse_page(str(docs), "stable/ce-2.8")
+
     assert "Index of /stable/ce-2.8" in out
-    assert '<a href="../">../</a>' in out  # Parent Directory row
-    assert '<a href="./amd64/">amd64/</a>' in out  # subdir, trailing slash
-    assert '<a href="./notes.txt">notes.txt</a>' in out  # file
+    assert '<a href="../">../</a>' in out  # Parent Directory row (not the channel root)
+    assert '<a href="./amd64/">amd64/</a>' in out  # subdir stays within the browse mirror
+    assert 'href="../../../stable/ce-2.8/notes.txt">notes.txt</a>' in out  # file climbs into the real tree
     assert "12 B" in out  # size column rendered
 
 
-def test_render_autoindex_root_has_no_parent_and_is_colon_safe() -> None:
-    """The browse root omits Parent Directory; an ABI dir with ':' links via './' (RFC 3986 §4.2)."""
-    out = gl.render_autoindex("", ["stable", "nightly"], [("meta.json", 99, 1_700_000_000.0)], is_root=True)
-    assert "Index of /" in out
-    assert "Parent Directory" not in out and 'href="../"' not in out
-    assert '<a href="./stable/">stable/</a>' in out and '<a href="./nightly/">nightly/</a>' in out
-    # A colon-ABI subdir would link with the scheme-safe './' prefix.
-    deep = gl.render_autoindex("stable", ["FreeBSD:16:aarch64"], [])
+def test_browse_root_has_no_parent_and_channel_root_links_browse_html(tmp_path: Path) -> None:
+    """browse.html has no Parent Directory row; a channel-root browse page's Parent
+    Directory instead links back to browse.html (issue #2450)."""
+    docs = tmp_path / "docs"
+    _touch(docs / "stable" / "ce-2.8" / "x")
+    _touch(docs / "nightly" / "ce-2.8" / "x")
+    built = {"meta.json": (b"x" * 99, 0o644)}
+
+    root = gl.render_browse_root(str(docs), built)
+    assert "Index of /" in root
+    assert "Parent Directory" not in root and 'href="../"' not in root
+    assert '<a href="./browse/stable/">stable/</a>' in root and '<a href="./browse/nightly/">nightly/</a>' in root
+
+    channel_page = gl._render_catalogue_browse_page(str(docs), "stable")
+    assert '<a href="../../browse.html">../</a>' in channel_page  # channel root's Parent -> browse.html
+
+    # A colon-ABI subdir links with the scheme-safe './' prefix, staying within the mirror.
+    _touch(docs / "stable" / "FreeBSD:16:aarch64" / "x")
+    deep = gl._render_catalogue_browse_page(str(docs), "stable")
     assert 'href="./FreeBSD:16:aarch64/"' in deep
 
 
-def test_render_autoindex_escapes_special_chars_in_names() -> None:
+def test_catalogue_browse_page_escapes_special_chars_in_names(tmp_path: Path) -> None:
     """Hostile input: a filename carrying HTML-special characters renders escaped, never
     raw markup — a directory listing walks whatever bytes are on disk."""
-    out = gl.render_autoindex(
-        "stable/ce-2.8",
-        ["<script>evil"],
-        [("py311-charset<script>&normalizer-3.4.4.pkg", 12, 1_700_000_000.0)],
-    )
+    docs = tmp_path / "docs"
+    _touch(docs / "stable" / "ce-2.8" / "<script>evil" / "placeholder")
+    (docs / "stable" / "ce-2.8" / "py311-charset<script>&normalizer-3.4.4.pkg").write_bytes(b"x" * 12)
+
+    out = gl._render_catalogue_browse_page(str(docs), "stable/ce-2.8")
+
     assert "<script>evil" not in out.split("<tbody>")[1].replace("&lt;script&gt;evil", "")
     assert "&lt;script&gt;evil" in out
     assert "&lt;script&gt;&amp;normalizer" in out or "py311-charset&lt;script&gt;&amp;normalizer" in out
@@ -1569,17 +1600,17 @@ def test_render_page_handles_varver_dir_with_spaces_no_crash() -> None:
     and never breaks out of the relative-link scheme (no raw path escape)."""
     weird = _pkg("stable", _CANON, "1.0.0", "FreeBSD:15:*", "stable/ce 2.8 beta/pfSense-pkg-pfBlockerNG-1.0.0.pkg")
 
-    page = gl.render_page("https://x/pkg", [weird], _stub_conf)
+    page = gl.render_page("https://x/pkg", [weird], _stub_conf, _fixture_site_tree("https://x/pkg"))
 
     assert "1.0.0" in page
     assert 'href="./stable/ce 2.8 beta/pfSense-pkg-pfBlockerNG-1.0.0.pkg"' in page
 
 
 def test_write_site_keeps_dependency_packages_browsable(tmp_path: Path, monkeypatch: Any) -> None:
-    """A dependency package stays in the directory listing while leaving the page alone.
+    """A dependency package stays in the browse view while leaving the landing page alone.
 
     Filtering it out of the channel tables (issue #1863) must not make it unreachable: the
-    autoindex is how a user gets at everything we publish, including the CE-only
+    browse view is how a user gets at everything we publish, including the CE-only
     `py311-charset-normalizer` (issue #1806). The returned count is OUR packages.
     """
     site = tmp_path / "site"
@@ -1600,43 +1631,50 @@ def test_write_site_keeps_dependency_packages_browsable(tmp_path: Path, monkeypa
     monkeypatch.setattr(gl, "read_compact_manifest", lambda p: manifests[os.path.basename(p)])
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/")
+    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
 
     assert n == 1  # the count is pfBlockerNG packages, not everything published
-    listing = (site / "stable" / "ce-2.8" / "index.html").read_text()
+    # No index.html is ever written INSIDE the catalogue tree any more (issue #2450).
+    assert not (site / "stable" / "ce-2.8" / "index.html").is_file()
+    listing = (site / "browse" / "stable" / "ce-2.8" / "index.html").read_text()
     assert "py311-charset-normalizer-3.4.4.pkg" in listing  # still reachable by browsing
     assert "3.4.4" not in (site / "index.html").read_text()  # but never on the landing page
 
 
-def test_write_site_emits_browse_and_autoindex_at_every_level(tmp_path: Path, monkeypatch: Any) -> None:
-    """write_site emits the landing page, browse.html, and an autoindex index.html at EVERY
-    directory level (intermediate dirs too) so the whole tree is folder-navigable."""
+def test_write_site_emits_browse_pages_outside_the_catalogue_tree(tmp_path: Path, monkeypatch: Any) -> None:
+    """write_site emits the landing page, browse.html, and a browse/<ch>/… page at EVERY
+    directory level of a present channel (intermediate dirs too) — all OUTSIDE the
+    catalogue tree itself (issue #2450): nothing is ever written under stable/…"""
     site = tmp_path / "site"
     _touch(site / "stable" / "ce-2.8" / "FreeBSD:15:amd64" / f"{_CANON}-3.2.16.pkg")
     _touch(site / "stable" / "ce-2.8" / "FreeBSD:15:amd64" / "packagesite.pkg")
-    _touch(site / "meta.json")
 
     manifest = {"name": _CANON, "version": "3.2.16", "abi": "FreeBSD:15:amd64"}
     monkeypatch.setattr(gl, "read_compact_manifest", lambda p: manifest)
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/")
+    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
 
     assert n == 1
     # Landing page (root) links to the browse entry; browse.html exists and lists the top dirs.
     assert (site / "index.html").is_file()
     assert '<a class="browse" href="./browse.html">' in (site / "index.html").read_text()
     browse = (site / "browse.html").read_text()
-    assert '<a href="./stable/">stable/</a>' in browse
-    # An autoindex index.html exists at EVERY level — intermediate dirs too, not just the leaf.
+    assert '<a href="./browse/stable/">stable/</a>' in browse
+    # A browse page exists at EVERY level under browse/ — intermediate dirs too.
     for rel in ("stable", "stable/ce-2.8", "stable/ce-2.8/FreeBSD:15:amd64"):
-        assert (site / rel / "index.html").is_file(), f"missing autoindex at {rel}"
+        assert (site / "browse" / rel / "index.html").is_file(), f"missing browse page at {rel}"
+        # ...and NOTHING is ever written inside the real catalogue tree.
+        assert not (site / rel / "index.html").is_file(), f"catalogue dir {rel} must carry no autoindex"
     # Intermediate dir lists its subdir; leaf lists the package + the catalog plumbing (a real
     # directory listing, unlike the old package-only view).
-    assert '<a href="./ce-2.8/">ce-2.8/</a>' in (site / "stable" / "index.html").read_text()
-    leaf = (site / "stable" / "ce-2.8" / "FreeBSD:15:amd64" / "index.html").read_text()
+    assert '<a href="./ce-2.8/">ce-2.8/</a>' in (site / "browse" / "stable" / "index.html").read_text()
+    leaf = (site / "browse" / "stable" / "ce-2.8" / "FreeBSD:15:amd64" / "index.html").read_text()
     assert f"{_CANON}-3.2.16.pkg" in leaf
     assert "packagesite.pkg" in leaf  # the catalog files ARE shown in a directory listing
+    # The file link climbs OUT of browse/ back into the real catalogue tree: 4 hops
+    # (browse, stable, ce-2.8, FreeBSD:15:amd64) up to the docs root, then back down.
+    assert 'href="../../../../stable/ce-2.8/FreeBSD:15:amd64/packagesite.pkg"' in leaf
     # The generated index pages themselves are hidden from listings (not repository content).
     assert "browse.html" not in browse.split("<tbody>")[1]
 
@@ -1644,10 +1682,11 @@ def test_write_site_emits_browse_and_autoindex_at_every_level(tmp_path: Path, mo
 def test_write_site_never_indexes_docs_staging(tmp_path: Path, monkeypatch: Any) -> None:
     """A staged (not-yet-gated) tree under docs/staging/<seg>/<channel>/<varver>/ (issue
     #2389's stage->gate->promote flow) stays SERVED as plain files, but write_site must
-    never emit an autoindex under it and must never link it from the root/browse
+    never emit a browse page under it and must never link it from the root/browse
     listing -- a concurrent `direct` publish (nightly.yml, pkg-republish.yml -- both
     outside release-published.yml's concurrency group) during a stage window would
-    otherwise make the un-gated staged tree browsable."""
+    otherwise make the un-gated staged tree browsable. It is also never touched by the
+    mirror sweep (issue #2450: ``staging`` is a CATALOGUE_DIRS prefix)."""
     site = tmp_path / "site"
     _touch(site / "edge" / "ce-2.8" / "FreeBSD:15:amd64" / f"{_CANON}-3.2.16.pkg")
     _touch(site / "edge" / "ce-2.8" / "FreeBSD:15:amd64" / "packagesite.pkg")
@@ -1659,24 +1698,26 @@ def test_write_site_never_indexes_docs_staging(tmp_path: Path, monkeypatch: Any)
     monkeypatch.setattr(gl, "read_compact_manifest", lambda p: manifest)
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/")
+    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
 
     # The staged package never counts toward a real channel (it sits under an
     # unrecognized top-level dir, exactly like any other stray future dir).
     assert n == 1
     # The staged files themselves are untouched -- still served, just not indexed.
     assert (site / "staging" / "10-1" / "stable" / "ce-2.8" / "meta.conf").is_file()
-    # No autoindex anywhere under docs/staging.
+    assert (site / "staging" / "10-1" / "stable" / "ce-2.8" / "data.pkg").is_file()
+    assert (site / "staging" / "10-1" / "stable" / "ce-2.8" / "packagesite.pkg").is_file()
+    # No browse page anywhere for staging.
+    assert not (site / "browse" / "staging").exists()
     assert not list(site.glob("staging/**/index.html"))
-    assert not (site / "staging" / "index.html").is_file()
     # Root/browse listing carries no link to staging at all.
     root_index = (site / "index.html").read_text()
     browse = (site / "browse.html").read_text()
     assert "staging" not in root_index
-    assert 'href="./staging/"' not in browse
-    # A real channel is unaffected — still gets its own autoindex + browse link.
-    assert (site / "edge" / "ce-2.8" / "index.html").is_file()
-    assert 'href="./edge/"' in browse
+    assert "staging" not in browse
+    # A real channel is unaffected — still gets its own browse page + browse link.
+    assert (site / "browse" / "edge" / "ce-2.8" / "index.html").is_file()
+    assert '<a href="./browse/edge/">edge/</a>' in browse
 
 
 def test_write_site_empty_site_root_renders_four_empty_cards_exit_zero(tmp_path: Path, monkeypatch: Any) -> None:
@@ -1686,7 +1727,7 @@ def test_write_site_empty_site_root_renders_four_empty_cards_exit_zero(tmp_path:
     site.mkdir()
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    n = gl.write_site(str(site), "https://x/pkg")
+    n = gl.write_site(str(site), "https://x/pkg", str(_PKG_SITE_DIR))
 
     assert n == 0
     index_html = (site / "index.html").read_text()
@@ -1700,13 +1741,13 @@ def test_browse_adapts_to_any_future_tree_shape(tmp_path: Path, monkeypatch: Any
     """Scenario: the browse view is derived purely by walking the tree — no hardcoded layout.
 
     Given a deliberately NOVEL tree under two real channels ('stable', 'edge') — extra
-    nesting beneath the channel dir, an `_archive/` subtree, an exotic ABI no current matrix
-    entry covers, and a stray top-level file,
+    nesting beneath the channel dir, an `_archive/` subtree, and an exotic ABI no
+    current matrix entry covers,
     When write_site runs,
-    Then an autoindex index.html appears at EVERY level (whatever the names/depth), browse.html
-    lists the new top-level entries, packages are discovered wherever they live under a KNOWN
-    channel, and the deepest dir's autoindex still climbs correctly — proving a future folder
-    restructure below the channel segment needs NO code change.
+    Then a browse page appears at EVERY level (whatever the names/depth), browse.html
+    lists the two real channels, packages are discovered wherever they live under a
+    KNOWN channel, and the deepest browse page still climbs correctly — proving a
+    future folder restructure below the channel segment needs NO code change.
     """
     site = tmp_path / "site"
     # A structure we do NOT use today: +1 nesting level, an archive subtree, an ABI/varver the
@@ -1718,7 +1759,6 @@ def test_browse_adapts_to_any_future_tree_shape(tmp_path: Path, monkeypatch: Any
     ]
     for rel in novel:
         _touch(site / rel)
-    _touch(site / "CHECKSUMS.txt")
 
     # The manifest is read from each .pkg wherever it sits (path-agnostic); every package
     # carries the ONE canonical name — channel comes from the path, not the name.
@@ -1729,16 +1769,16 @@ def test_browse_adapts_to_any_future_tree_shape(tmp_path: Path, monkeypatch: Any
     monkeypatch.setattr(gl, "read_compact_manifest", fake_manifest)
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    n = gl.write_site(str(site), "https://x/pkg/")
+    n = gl.write_site(str(site), "https://x/pkg/", str(_PKG_SITE_DIR))
 
     # Packages found wherever they live (both novel locations), not by an assumed path.
     assert n == 2
-    # browse.html lists the top-level entries (both real channels + the stray file).
+    # browse.html lists the two catalogue channels.
     browse = (site / "browse.html").read_text()
-    assert '<a href="./stable/">stable/</a>' in browse
-    assert '<a href="./edge/">edge/</a>' in browse
-    assert '<a href="./CHECKSUMS.txt">CHECKSUMS.txt</a>' in browse
-    # An autoindex exists at EVERY directory of the novel tree — arbitrary names + extra depth.
+    assert '<a href="./browse/stable/">stable/</a>' in browse
+    assert '<a href="./browse/edge/">edge/</a>' in browse
+    # A browse page exists at EVERY directory of the novel tree — arbitrary names + extra
+    # depth — and NOTHING is written inside the real catalogue tree itself.
     for rel in (
         "stable",
         "stable/ce-2.9",
@@ -1748,11 +1788,13 @@ def test_browse_adapts_to_any_future_tree_shape(tmp_path: Path, monkeypatch: Any
         "edge/_archive/plus-99.03",
         "edge/_archive/plus-99.03/FreeBSD:99:powerpc64",
     ):
-        assert (site / rel / "index.html").is_file(), f"no autoindex generated at {rel}"
-    # The deepest dir lists its package and climbs to the repository root (depth-correct home link).
-    deep = (site / "stable/ce-2.9/FreeBSD:16:riscv64/extra" / "index.html").read_text()
+        assert (site / "browse" / rel / "index.html").is_file(), f"no browse page generated at {rel}"
+        assert not (site / rel / "index.html").is_file(), f"catalogue dir {rel} must carry no autoindex"
+    # The deepest browse page lists its package and climbs to the repository root
+    # (depth-correct home link: browse + 4 real segments = 5 hops to the docs root).
+    deep = (site / "browse" / "stable/ce-2.9/FreeBSD:16:riscv64/extra" / "index.html").read_text()
     assert f"{_CANON}-9.9.9.pkg" in deep
-    assert 'href="../../../../"' in deep  # 4 levels deep -> 4 hops to the site root
+    assert 'href="../../../../../"' in deep  # repository-home link: 5 hops to the docs root
 
 
 # ── EOL pfSense versions ──────────────────────────────────────────────────────
@@ -2052,7 +2094,13 @@ def test_eol_versions_section_absent_from_rendered_page_when_no_route_only() -> 
     pkgs = [_pkg("testing", _CANON, "3.2.16", "FreeBSD:15:amd64", "d.pkg")]
     matrix = [_mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311")]
 
-    page = gl.render_page("https://pfblockerng.github.io/pkg", pkgs, _stub_conf, matrix)
+    page = gl.render_page(
+        "https://pfblockerng.github.io/pkg",
+        pkgs,
+        _stub_conf,
+        _fixture_site_tree("https://pfblockerng.github.io/pkg"),
+        matrix,
+    )
 
     assert "EOL pfSense versions" not in page
 
@@ -2082,7 +2130,13 @@ def test_eol_versions_section_present_in_rendered_page_with_route_only() -> None
         _mx_eol("FreeBSD:15:aarch64", "25.03", "Plus", "8.3", "py311"),
     ]
 
-    page = gl.render_page("https://pfblockerng.github.io/pkg", [live_pkg, eol_ce, eol_plus], _stub_conf, matrix)
+    page = gl.render_page(
+        "https://pfblockerng.github.io/pkg",
+        [live_pkg, eol_ce, eol_plus],
+        _stub_conf,
+        _fixture_site_tree("https://pfblockerng.github.io/pkg"),
+        matrix,
+    )
 
     # EOL section is present, after 'Published packages'.
     assert "EOL pfSense versions" in page
@@ -2165,9 +2219,10 @@ def test_embed_hook_keeps_the_marker_lines_around_the_heredoc_in_the_output() ->
 
 
 def test_write_site_publishes_install_script(tmp_path: Path, monkeypatch: Any) -> None:
-    """write_site() publishes a self-contained install.sh (issue #2416 follow-up) —
-    the SOLE client entry point for all four channels: the boot hook is embedded via
-    the PFB_EMBED_HOOK splice, so the published script needs no sibling file on disk.
+    """write_site() publishes a self-contained install.sh from the pkg-site tree
+    (issue #2450) — the SOLE client entry point for all four channels: the boot
+    hook is embedded via the PFB_EMBED_HOOK splice, so the published script needs
+    no sibling file on disk. Sibling recipes/*.sh are also mirrored.
     """
     import subprocess
 
@@ -2175,11 +2230,13 @@ def test_write_site_publishes_install_script(tmp_path: Path, monkeypatch: Any) -
     site.mkdir()
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    gl.write_site(str(site), f"file://{site}")
+    gl.write_site(str(site), f"file://{site}", str(_PKG_SITE_DIR))
 
-    assert sorted(p.name for p in site.iterdir() if p.name.startswith("install")) == sorted(gl.CLIENT_SCRIPTS), (
+    assert sorted(p.name for p in site.iterdir() if p.name.startswith("install")) == ["install.sh"], (
         "write_site must publish EXACTLY install.sh, no per-channel/legacy scripts"
     )
+    for ch in gl.CH_ORDER:
+        assert (site / "recipes" / f"{ch}.sh").is_file(), f"missing mirrored recipe for {ch}"
 
     published = site / "install.sh"
     assert published.exists(), "write_site must produce site/install.sh"
@@ -2210,7 +2267,7 @@ def test_published_installer_runs_piped_with_embedded_hook(tmp_path: Path, monke
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
     base = f"file://{site}"
-    gl.write_site(str(site), base)
+    gl.write_site(str(site), base, str(_PKG_SITE_DIR))
     published_text = (site / "install.sh").read_text()
 
     root = tmp_path / "root"
@@ -2286,7 +2343,7 @@ def test_published_installer_never_treats_the_on_box_hook_as_its_checkout_source
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
     base = f"file://{site}"
-    gl.write_site(str(site), base)
+    gl.write_site(str(site), base, str(_PKG_SITE_DIR))
     published_text = (site / "install.sh").read_text()
 
     root = tmp_path / "root"
@@ -2361,7 +2418,7 @@ def test_published_installer_saved_to_disk_still_replaces_a_stale_on_box_hook(tm
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
     base = f"file://{site}"
-    gl.write_site(str(site), base)
+    gl.write_site(str(site), base, str(_PKG_SITE_DIR))
     published_text = (site / "install.sh").read_text()
 
     root = tmp_path / "root"
@@ -2430,7 +2487,7 @@ def test_write_site_bakes_the_sites_base_url_into_the_published_installer(tmp_pa
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
     fork_base = "https://fork.example.org/mypkg"
-    gl.write_site(str(site), fork_base)
+    gl.write_site(str(site), fork_base, str(_PKG_SITE_DIR))
 
     text = (site / "install.sh").read_text()
     assert f"PFB_DEFAULT_BASE_URL='{fork_base}'" in text, (
@@ -2500,7 +2557,7 @@ def test_write_site_bakes_a_base_url_containing_shell_metacharacters_as_inert_da
 
     probe = tmp_path / "pwned"
     evil_base = f"https://evil.example.org/$(touch {probe})`touch {probe}`'\"&"
-    gl.write_site(str(site), evil_base)
+    gl.write_site(str(site), evil_base, str(_PKG_SITE_DIR))
 
     published_text = (site / "install.sh").read_text()
     sh_n = subprocess.run(["sh", "-n"], input=published_text, text=True, capture_output=True)
@@ -2551,69 +2608,410 @@ def test_write_site_bakes_a_base_url_containing_shell_metacharacters_as_inert_da
     )
 
 
-# ── write_site / CLI interface — call-compatible with publish-pkg-repo.sh ─────
+# ── build_site_tree: the pkg-site source tree, baked + {base}-substituted ─────
 
 
-def test_write_site_signature_matches_publish_pkg_repo_call_site() -> None:
-    """Pins the write_site(site, base, matrix=None) signature that
-    publish-pkg-repo.sh's `python3 gen_landing.py <site> <base> --matrix <f>`
-    invocation (via main()) depends on — a rename/reorder here breaks production silently.
-    """
+def _write_tree_file(root: Path, rel: str, content: bytes, *, mode: int = 0o644) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    path.chmod(mode)
+    return path
+
+
+def test_build_site_tree_copies_a_plain_file_verbatim_and_preserves_mode(tmp_path: Path) -> None:
+    """R1: a tree file with no .sh/{base} relevance is copied byte-for-byte, mode kept —
+    both an executable and a non-executable fixture file."""
+    tree = tmp_path / "tree"
+    _write_tree_file(tree, "bin/tool", b"#!/bin/sh\necho hi\n", mode=0o755)
+    _write_tree_file(tree, "notes.txt", b"just some bytes, no markers here\n", mode=0o644)
+
+    built = gl.build_site_tree(str(tree), "https://x/pkg")
+
+    data, mode = built["bin/tool"]
+    assert data == b"#!/bin/sh\necho hi\n"
+    assert stat.S_IMODE(mode) == 0o755
+    data, mode = built["notes.txt"]
+    assert data == b"just some bytes, no markers here\n"
+    assert stat.S_IMODE(mode) == 0o644
+
+
+def test_build_site_tree_bakes_and_embeds_install_sh(tmp_path: Path) -> None:
+    """R2: a .sh carrying BOTH the default-URL line and the embed markers gets baked
+    and hook-embedded — exercised against the REAL scripts/install.sh via a symlink,
+    mirroring the pkg-site/install.sh convention."""
+    tree = tmp_path / "tree"
+    tree.mkdir()
+    (tree / "install.sh").symlink_to(_SCRIPTS_DIR / "install.sh")
+
+    built = gl.build_site_tree(str(tree), "https://fork.example/pkg")
+
+    data, mode = built["install.sh"]
+    text = data.decode()
+    assert "PFB_DEFAULT_BASE_URL='https://fork.example/pkg'" in text
+    assert f"cat <<'{gl._HOOK_HEREDOC}'" in text
+    assert stat.S_IMODE(mode) == 0o755  # the real install.sh is executable
+
+
+def test_build_site_tree_recipe_only_substitutes_base_no_bake_no_embed(tmp_path: Path) -> None:
+    """R3: a .sh file with neither the default-URL line nor the embed markers gets
+    ONLY its {base} token substituted — the recipe convention."""
+    tree = tmp_path / "tree"
+    _write_tree_file(tree, "recipes/stable.sh", b"fetch -qo - {base}/install.sh | sh -s -- --channel stable\n")
+
+    built = gl.build_site_tree(str(tree), "https://x/pkg")
+
+    data, _mode = built["recipes/stable.sh"]
+    assert data == b"fetch -qo - https://x/pkg/install.sh | sh -s -- --channel stable\n"
+
+
+def test_build_site_tree_substitutes_base_in_non_sh_utf8_and_copies_binary_unchanged(tmp_path: Path) -> None:
+    """R4: a non-.sh UTF-8 file with {base} gets it substituted; a binary (non-UTF-8)
+    file is copied unchanged, never crashing the {base} substitution pass."""
+    tree = tmp_path / "tree"
+    _write_tree_file(tree, "readme.txt", "see {base}/install.sh\n".encode())
+    binary = bytes(range(256))
+    _write_tree_file(tree, "blob.bin", binary)
+
+    built = gl.build_site_tree(str(tree), "https://x/pkg")
+
+    assert built["readme.txt"][0] == b"see https://x/pkg/install.sh\n"
+    assert built["blob.bin"][0] == binary
+
+
+def test_build_site_tree_mirrors_a_dotfile(tmp_path: Path) -> None:
+    """R5: a dotfile (.nojekyll) in the tree is mirrored like any other file."""
+    tree = tmp_path / "tree"
+    _write_tree_file(tree, ".nojekyll", b"")
+
+    built = gl.build_site_tree(str(tree), "https://x/pkg")
+
+    assert built[".nojekyll"] == (b"", 0o644)
+
+
+def test_build_site_tree_two_default_url_lines_raises(tmp_path: Path) -> None:
+    """H6: a .sh carrying the default-URL line TWICE fails loud (existing _bake_base_url
+    rule), never silently baking the first occurrence."""
+    tree = tmp_path / "tree"
+    doubled = f"{gl._BASE_URL_DEFAULT_LINE}\n{gl._BASE_URL_DEFAULT_LINE}\n"
+    _write_tree_file(tree, "bad.sh", doubled.encode())
+
+    with pytest.raises(ValueError, match="found 2"):
+        gl.build_site_tree(str(tree), "https://x/pkg")
+
+
+# ── sync_site: mirror the desired tree into docs/, never touching a catalogue dir ──
+
+
+def test_sync_site_writes_every_desired_file_and_deletes_extraneous(tmp_path: Path) -> None:
+    """R10: extraneous renderer-side files (legacy scripts, a stray browse/ leftover,
+    a junk dir) are removed and their now-empty parent dirs pruned; a stray non-index
+    file INSIDE a catalogue dir survives untouched."""
+    docs = tmp_path / "docs"
+    _touch(docs / "add-repo.sh")
+    _touch(docs / "migrate-channel.sh")
+    _touch(docs / "browse" / "edge" / "old-varver" / "index.html")
+    _touch(docs / "junk" / "x.txt")
+    _touch(docs / "testing" / "ce-2.9" / "whatever")
+
+    desired = {"install.sh": (b"#!/bin/sh\n", 0o755)}
+    written, deleted = gl.sync_site(str(docs), desired)
+
+    assert written == ["install.sh"]
+    assert (docs / "install.sh").read_bytes() == b"#!/bin/sh\n"
+    assert not (docs / "add-repo.sh").exists()
+    assert not (docs / "migrate-channel.sh").exists()
+    assert not (docs / "browse").exists()  # emptied and pruned
+    assert not (docs / "junk").exists()
+    assert (docs / "testing" / "ce-2.9" / "whatever").is_file()  # catalogue-owned, untouched
+    assert sorted(deleted) == sorted(
+        [
+            "add-repo.sh",
+            "browse/edge/old-varver/index.html",
+            "junk/x.txt",
+            "migrate-channel.sh",
+        ]
+    )
+
+
+def test_sync_site_legacy_index_html_swept_from_every_catalogue_dir(tmp_path: Path) -> None:
+    """R9: a pre-existing legacy index.html anywhere under a catalogue prefix is
+    deleted (the one-time sweep); every sibling file (meta.conf/.pkg bytes) is
+    left byte-for-byte untouched; nothing is ever WRITTEN under a catalogue prefix."""
+    docs = tmp_path / "docs"
+    _touch(docs / "stable" / "index.html")
+    _touch(docs / "stable" / "ce-2.8" / "index.html")
+    meta = docs / "stable" / "ce-2.8" / "meta.conf"
+    meta.parent.mkdir(parents=True, exist_ok=True)
+    meta.write_bytes(b"version = 2;\n")
+    pkg = docs / "stable" / "ce-2.8" / f"{_CANON}-1.0.0.pkg"
+    pkg.write_bytes(b"pkg-bytes")
+
+    written, deleted = gl.sync_site(str(docs), {})
+
+    assert written == []
+    assert "stable/index.html" in deleted
+    assert "stable/ce-2.8/index.html" in deleted
+    assert not (docs / "stable" / "index.html").exists()
+    assert not (docs / "stable" / "ce-2.8" / "index.html").exists()
+    assert meta.read_bytes() == b"version = 2;\n"
+    assert pkg.read_bytes() == b"pkg-bytes"
+
+
+def test_sync_site_refuses_a_desired_path_under_a_catalogue_prefix(tmp_path: Path) -> None:
+    """H3: a desired site path rooted under a catalogue prefix raises BEFORE writing
+    anything — the renderer must be structurally unable to write there."""
+    docs = tmp_path / "docs"
+    _touch(docs / "existing.txt")
+    desired = {"install.sh": (b"x", 0o644), "stable/x": (b"evil", 0o644)}
+
+    with pytest.raises(ValueError, match="catalogue-owned"):
+        gl.sync_site(str(docs), desired)
+
+    assert not (docs / "install.sh").exists()  # nothing written — checked before any write
+    assert (docs / "existing.txt").is_file()  # untouched
+
+
+def test_sync_site_never_follows_a_symlink_inside_docs(tmp_path: Path) -> None:
+    """A symlink living directly under docs/ (not inside a catalogue prefix) is
+    skipped by the walk — never deleted, never mistaken for a desired/extraneous
+    regular file."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    target = tmp_path / "outside.txt"
+    target.write_text("outside")
+    (docs / "link.txt").symlink_to(target)
+
+    written, deleted = gl.sync_site(str(docs), {})
+
+    assert written == [] and deleted == []
+    assert (docs / "link.txt").is_symlink()
+
+
+# ── render_page / _channel_card: recipe text from the built site tree ─────────
+
+
+def test_channel_card_recipe_is_verbatim_built_tree_text() -> None:
+    """R6: a published channel's card shows recipes/<channel>.sh's built (already
+    {base}-substituted) text verbatim, HTML-escaped."""
+    base = "https://x/pkg"
+    pkgs = [_pkg("stable", _CANON, "1.0.0", "FreeBSD:15:*", "stable/ce-2.8/x.pkg")]
+    site_tree = {"recipes/stable.sh": (f"fetch -qo - {base}/install.sh | sh -s -- --channel stable\n".encode(), 0o644)}
+
+    page = gl.render_page(base, pkgs, _stub_conf, site_tree)
+
+    assert f"<pre>fetch -qo - {base}/install.sh | sh -s -- --channel stable</pre>" in page
+
+
+def test_channel_card_missing_recipe_for_published_channel_raises() -> None:
+    """R6: a published channel with NO recipes/<channel>.sh in the site tree fails
+    loudly, naming the missing path — never a silently blank recipe."""
+    pkgs = [_pkg("stable", _CANON, "1.0.0", "FreeBSD:15:*", "stable/ce-2.8/x.pkg")]
+
+    with pytest.raises(ValueError, match="recipes/stable.sh"):
+        gl.render_page("https://x/pkg", pkgs, _stub_conf, {})
+
+
+def test_channel_card_hostile_recipe_text_escaped_and_base_substituted() -> None:
+    """H1: a recipe carrying HTML-special characters and a literal $ is HTML-escaped
+    in the card exactly once (no double-escaping), with {base} still substituted."""
+    base = "https://x/pkg"
+    pkgs = [_pkg("stable", _CANON, "1.0.0", "FreeBSD:15:*", "stable/ce-2.8/x.pkg")]
+    hostile = 'fetch -qo - {base}/i.sh | sh -s -- --channel "<stable>" && echo $HOME\n'
+    site_tree = {"recipes/stable.sh": (hostile.replace("{base}", base).encode(), 0o644)}
+
+    page = gl.render_page(base, pkgs, _stub_conf, site_tree)
+
+    escaped = html.escape(hostile.replace("{base}", base).strip())
+    assert f"<pre>{escaped}</pre>" in page
+    assert "&amp;lt;" not in page  # never double-escaped
+    assert '<stable>"' not in page  # the raw (unescaped) text never appears
+
+
+def test_write_site_base_with_trailing_slash_stripped_once(tmp_path: Path, monkeypatch: Any) -> None:
+    """H2: write_site strips a trailing '/' from base ONCE before it drives
+    build_site_tree's {base} substitution (existing rstrip("/") behaviour) — the
+    published recipe carries exactly one slash between base and install.sh."""
+    site = tmp_path / "site"
+    _touch(site / "stable" / "ce-2.8" / f"{_CANON}-1.0.0.pkg")
+    monkeypatch.setattr(gl, "read_compact_manifest", lambda p: {"name": _CANON, "version": "1.0.0", "abi": "x"})
+    monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
+
+    gl.write_site(str(site), "https://x/pkg/", str(_PKG_SITE_DIR))
+
+    recipe = (site / "recipes" / "stable.sh").read_text()
+    assert recipe == "fetch -qo - https://x/pkg/install.sh | sh -s -- --channel stable\n"
+    assert "https://x/pkg//install.sh" not in recipe
+
+
+# ── write_site / main(): the pkg-site renderer CLI (issue #2450) ──────────────
+
+
+def test_write_site_signature_pins_the_positional_shape() -> None:
+    """Pins write_site(site, base, site_tree, matrix=None) — a rename/reorder here
+    breaks step 2's (render-pkg-site.sh) call site silently."""
     sig = inspect.signature(gl.write_site)
-    assert list(sig.parameters) == ["site", "base", "matrix"]
+    assert list(sig.parameters) == ["site", "base", "site_tree", "matrix"]
     assert sig.parameters["matrix"].default is None
 
 
-def test_main_cli_accepts_the_production_positional_and_matrix_flag_shape(tmp_path: Path, monkeypatch: Any) -> None:
-    """main(argv) accepts exactly the shape publish-pkg-repo.sh invokes:
-    <site> <base_url> --matrix <file>."""
+def test_main_cli_accepts_the_production_positional_and_flag_shape(tmp_path: Path, monkeypatch: Any) -> None:
+    """main(argv) accepts <site> <base_url> --site-tree <tree> --matrix <file>."""
     site = tmp_path / "site"
     site.mkdir()
     matrix_file = tmp_path / "matrix.json"
     matrix_file.write_text("[]")
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    rc = gl.main([str(site), "https://x/pkg", "--matrix", str(matrix_file)])
+    rc = gl.main([str(site), "https://x/pkg", "--site-tree", str(_PKG_SITE_DIR), "--matrix", str(matrix_file)])
 
     assert rc == 0
     assert (site / "index.html").is_file()
 
 
-def test_main_client_scripts_only_writes_scripts_and_nothing_else(tmp_path: Path) -> None:
-    """``--client-scripts-only`` publishes ONLY the deterministic client script:
-    install.sh, --channel parameterized — the SOLE client entry point (issue #2416
-    follow-up).
-
-    publish-pkg-repo.sh's catalogue-NOOP path (issue #2408) uses this mode to ship a
-    script-only fix; writing any timestamped landing/browse/autoindex page here would
-    manufacture a commit on every republish run instead.
-    """
+def test_main_requires_site_tree(tmp_path: Path) -> None:
+    """R14: --site-tree is REQUIRED — a missing flag is a usage error, exit != 0,
+    nothing written."""
     site = tmp_path / "site"
     site.mkdir()
 
-    rc = gl.main([str(site), "https://x/pkg", "--client-scripts-only"])
+    with pytest.raises(SystemExit) as exc:
+        gl.main([str(site), "https://x/pkg"])
 
-    assert rc == 0
-    assert sorted(p.name for p in site.iterdir()) == sorted(gl.CLIENT_SCRIPTS)
-    installer = (site / "install.sh").read_text()
-    assert f"cat <<'{gl._HOOK_HEREDOC}'" in installer, (
-        "install.sh's boot hook must be embedded, not left as the stub body"
-    )
+    assert exc.value.code != 0
+    assert list(site.iterdir()) == []
 
 
-def test_main_client_scripts_only_rejects_matrix(tmp_path: Path) -> None:
-    """``--client-scripts-only`` with ``--matrix`` is a usage error, not a silent ignore.
-
-    The matrix drives the landing page's per-edition tables, which this mode never
-    writes — accepting both would let a caller believe the matrix was applied.
-    """
+def test_main_client_scripts_only_flag_is_gone(tmp_path: Path) -> None:
+    """R14: --client-scripts-only no longer exists — passing it is an argparse
+    usage error, not a silently-ignored flag."""
     site = tmp_path / "site"
+    site.mkdir()
+
+    with pytest.raises(SystemExit) as exc:
+        gl.main([str(site), "https://x/pkg", "--site-tree", str(_PKG_SITE_DIR), "--client-scripts-only"])
+
+    assert exc.value.code == 2
+    assert list(site.iterdir()) == []
+
+
+def test_main_production_shape_with_real_pkg_site_and_matrix(tmp_path: Path, monkeypatch: Any) -> None:
+    """The full production CLI shape: gen_landing.py <docs> <base> --site-tree
+    <pkg-site> --matrix <file>, against the REAL pkg-site/ tree."""
+    site = tmp_path / "docs"
     site.mkdir()
     matrix_file = tmp_path / "matrix.json"
     matrix_file.write_text("[]")
+    monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    with pytest.raises(SystemExit) as exc:
-        gl.main([str(site), "https://x/pkg", "--client-scripts-only", "--matrix", str(matrix_file)])
+    rc = gl.main([str(site), "https://x/pkg", "--site-tree", str(_PKG_SITE_DIR), "--matrix", str(matrix_file)])
 
-    assert exc.value.code == 2
-    assert list(site.iterdir()) == [], "a usage error must write nothing"
+    assert rc == 0
+    assert (site / "install.sh").is_file()
+    assert (site / ".nojekyll").is_file()
+    assert (site / "index.html").is_file()
+    assert (site / "browse.html").is_file()
+
+
+# ── Determinism: two renders of the same input are byte-identical (issue #2450) ──
+
+
+def _snapshot(root: Path) -> dict[str, bytes]:
+    return {str(p.relative_to(root)): p.read_bytes() for p in root.rglob("*") if p.is_file() and not p.is_symlink()}
+
+
+def test_write_site_is_deterministic_across_two_renders_even_with_mtime_churn(tmp_path: Path, monkeypatch: Any) -> None:
+    """R12: rendering the SAME inputs twice produces byte-identical output — even
+    when a file's mtime changes between runs (no mtime ever leaks into a render).
+    A .pkg with no epoch at all, and its meta.conf sibling, both render an em dash.
+    """
+    site = tmp_path / "site"
+    cell = site / "stable" / "ce-2.8"
+    pkg = cell / f"{_CANON}-1.0.0.pkg"
+    _write_pkg(pkg, annotations={}, version="1.0.0")
+    (cell / "meta.conf").write_text("version = 2;\n")
+    monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
+
+    gl.write_site(str(site), "https://x/pkg", str(_PKG_SITE_DIR))
+    first = _snapshot(site)
+
+    listing = (site / "browse" / "stable" / "ce-2.8" / "index.html").read_text()
+    assert "&mdash;" in _autoindex_row(listing, pkg.name)
+    assert "&mdash;" in _autoindex_row(listing, "meta.conf")
+
+    # Touch every file's mtime forward between runs — must not change a single byte.
+    for p in site.rglob("*"):
+        if p.is_file() and not p.is_symlink():
+            os.utime(p, (2_000_000_000, 2_000_000_000))
+
+    gl.write_site(str(site), "https://x/pkg", str(_PKG_SITE_DIR))
+    second = _snapshot(site)
+
+    assert first == second
+
+
+# ── README drift guard + install.sh symlink (issue #2450) ─────────────────────
+
+_README_FETCH_RE = re.compile(r"fetch -qo - .*install\.sh \| sh -s -- --channel (\w+)")
+
+
+def test_readme_install_snippets_match_the_pkg_site_recipes() -> None:
+    """R15: every README install one-liner equals its pkg-site/recipes/<ch>.sh with
+    {base} substituted to the production base URL — the README never drifts from
+    the recipe the renderer actually ships."""
+    readme = (Path(__file__).resolve().parent.parent / "README.md").read_text()
+    channels = _README_FETCH_RE.findall(readme)
+    assert channels, "README.md carries no fetch|sh --channel snippet to check"
+
+    base = "https://pfblockerng.github.io/pkg"
+    for line in readme.splitlines():
+        m = _README_FETCH_RE.search(line)
+        if not m:
+            continue
+        ch = m.group(1)
+        recipe = (_PKG_SITE_DIR / "recipes" / f"{ch}.sh").read_text().replace("{base}", base).strip()
+        assert line.strip() == recipe, f"README {ch} snippet drifted from pkg-site/recipes/{ch}.sh"
+
+
+def test_pkg_site_install_sh_is_a_symlink_to_scripts_install_sh() -> None:
+    """R16: pkg-site/install.sh is a git symlink resolving to scripts/install.sh —
+    the repository copy stays the one source of truth."""
+    link = _PKG_SITE_DIR / "install.sh"
+    assert link.is_symlink()
+    assert os.path.realpath(link) == os.path.realpath(_SCRIPTS_DIR / "install.sh")
+
+
+# ── Hostile: a site-tree file shadowing a rendered page name (issue #2450) ────
+
+
+def test_rendered_page_wins_over_a_same_named_site_tree_file(tmp_path: Path, monkeypatch: Any) -> None:
+    """H4: a site-tree file literally named index.html/browse.html loses to the
+    rendered page of the same name — the render always wins."""
+    tree = tmp_path / "tree"
+    _write_tree_file(tree, "index.html", b"<p>not the real landing page</p>")
+    _write_tree_file(tree, "browse.html", b"<p>not the real browse page</p>")
+    site = tmp_path / "site"
+    site.mkdir()
+    monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
+
+    gl.write_site(str(site), "https://x/pkg", str(tree))
+
+    assert "not the real landing page" not in (site / "index.html").read_text()
+    assert "not the real browse page" not in (site / "browse.html").read_text()
+
+
+def test_write_site_empty_tree_and_docs_renders_four_cards_no_crash(tmp_path: Path, monkeypatch: Any) -> None:
+    """H5: an almost-empty site tree (only .nojekyll, no recipes) over empty docs
+    still renders four 'not yet published' cards without crashing — no channel is
+    published, so the missing recipes are never looked up."""
+    tree = tmp_path / "tree"
+    _write_tree_file(tree, ".nojekyll", b"")
+    site = tmp_path / "site"
+    site.mkdir()
+    monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
+
+    n = gl.write_site(str(site), "https://x/pkg", str(tree))
+
+    assert n == 0
+    index_html = (site / "index.html").read_text()
+    assert index_html.count("not yet published") == 4

--- a/tests/test_issue2143_republish_workflow.py
+++ b/tests/test_issue2143_republish_workflow.py
@@ -40,10 +40,6 @@ _IDENTITY_VALUES = {
     },
 }
 _SOURCE_RUN_ID_VALUE = "${{ github.run_id }}:${{ github.run_attempt }}"
-# pkg-republish.yml's Boolean `refresh_landing` input maps to the '0'/'1' string
-# publish-pkg-repo.sh's PUBLISH_REFRESH_LANDING parses; `inputs.*` keeps the Boolean
-# (`github.event.inputs.*` would stringify it, making "false" truthy).
-_PUBLISH_REFRESH_LANDING_VALUE = "${{ inputs.refresh_landing && '1' || '0' }}"
 
 
 def test_manual_republish_requires_exact_release_identity() -> None:
@@ -64,15 +60,6 @@ def test_republish_and_published_callbacks_forward_exact_run_identity() -> None:
             assert f"{key}: {value}" in step
         assert f"SOURCE_RUN_ID: {_SOURCE_RUN_ID_VALUE}" in step
         assert "gh release list" not in workflow
-
-
-def test_republish_env_carries_refresh_landing_toggle_expression() -> None:
-    # PUBLISHED (release-published.yml) never sets PUBLISH_REFRESH_LANDING — its
-    # "Stage the pkg catalogue" step always runs PUBLISH_STAGE=stage, and the knob
-    # is a usage error there (publish-pkg-repo.sh rejects PUBLISH_REFRESH_LANDING=1
-    # unless PUBLISH_STAGE=direct) — only REPUBLISH carries the toggle.
-    step = extract_step(REPUBLISH, _STEP_NAMES[REPUBLISH])
-    assert f"PUBLISH_REFRESH_LANDING: {_PUBLISH_REFRESH_LANDING_VALUE}" in step
 
 
 def test_manual_republish_rejects_release_selector_before_api(tmp_path: Path) -> None:

--- a/tests/test_issue2389_live_pages_gate.py
+++ b/tests/test_issue2389_live_pages_gate.py
@@ -61,8 +61,12 @@ def test_release_published_stages_before_gate() -> None:
     # PUBLISH_STAGE value drifted away from "stage" (issue #2389).
     assert re.search(r"^\s+PUBLISH_STAGE: stage\s*$", job, re.MULTILINE), job
     assert "id: stage" in job
-    for out in ("staging_prefix", "touched", "noop", "route_matrix"):
+    # route_matrix is NOT a publish-pkg-repo output any more (issue #2450 step 3):
+    # promote-pkg-repo no longer reads it (publish-pkg-repo.sh's promote arm never
+    # required ROUTE_MATRIX), so the job stopped exporting an output nothing consumes.
+    for out in ("staging_prefix", "touched", "noop"):
         assert re.search(rf"^      {out}:", job, re.MULTILINE), f"publish-pkg-repo missing output {out!r}:\n{job}"
+    assert not re.search(r"^      route_matrix:", job, re.MULTILINE), job
 
 
 def test_release_published_resolve_exports_gate_identity() -> None:
@@ -93,16 +97,17 @@ def test_release_published_promotes_only_after_green_gate() -> None:
     assert "'promote'" in job
     assert "'discard'" in job
     assert "STAGING_PREFIX: ${{ needs.publish-pkg-repo.outputs.staging_prefix }}" in job
-    assert "ROUTE_MATRIX: ${{ needs.publish-pkg-repo.outputs.route_matrix }}" in job
     assert "exit 1" in job
 
 
 def test_release_published_promote_env_never_supplies_assets_dir() -> None:
     """publish-pkg-repo.sh's promote arm requires SOURCE_REPOSITORY, RELEASE_ID,
-    RELEASE_TAG, DESTINATIONS, SOURCE_RUN_ID, ROUTE_MATRIX, BASE_URL, STAGING_PREFIX,
-    and PUBLISH_STAGE -- but never ASSETS_DIR (issue #2389: the
-    script's tagged-mode env guard used to require ASSETS_DIR unconditionally,
-    which broke every promote since this job never exports it)."""
+    RELEASE_TAG, DESTINATIONS, SOURCE_RUN_ID, STAGING_PREFIX, and PUBLISH_STAGE --
+    but never ASSETS_DIR (issue #2389: the script's tagged-mode env guard used to
+    require ASSETS_DIR unconditionally, which broke every promote since this job
+    never exports it) nor ROUTE_MATRIX/BASE_URL (issue #2450 step 3: promote never
+    ran the publisher or a renderer, so both were always vestigial there; rendering
+    is now render-site's own job, downstream, with its own BASE_URL)."""
     job = _extract_job(_workflow("release-published.yml"), "promote-pkg-repo")
     for var in (
         "SOURCE_REPOSITORY",
@@ -110,13 +115,13 @@ def test_release_published_promote_env_never_supplies_assets_dir() -> None:
         "RELEASE_TAG",
         "DESTINATIONS",
         "SOURCE_RUN_ID",
-        "ROUTE_MATRIX",
-        "BASE_URL",
         "STAGING_PREFIX",
         "PUBLISH_STAGE",
     ):
         assert re.search(rf"^\s+{var}:", job, re.MULTILINE), f"promote-pkg-repo env missing {var!r}:\n{job}"
     assert not re.search(r"^\s+ASSETS_DIR:\s*", job, re.MULTILINE)
+    assert not re.search(r"^\s+ROUTE_MATRIX:\s*", job, re.MULTILINE)
+    assert not re.search(r"^\s+BASE_URL:\s*", job, re.MULTILINE)
 
 
 def test_release_published_serialises_publishes() -> None:

--- a/tests/test_issue2450_render_site_workflow.py
+++ b/tests/test_issue2450_render_site_workflow.py
@@ -77,15 +77,39 @@ def test_render_site_job_serialises_via_job_level_concurrency() -> None:
     assert re.search(r"^\s+concurrency:\n\s+group: \S+\n\s+cancel-in-progress: false\s*$", job, re.MULTILINE), job
 
 
+def test_render_site_workflow_declares_an_explicit_secrets_contract() -> None:
+    """Least-privilege secrets (CodeRabbit finding, PR #2451 review): workflow_call
+    must declare exactly the two secrets the render job needs, both required — so a
+    caller can never fall back to forwarding every repository/org secret."""
+    on_block = RENDER.split("on:", 1)[1].split("permissions:", 1)[0]
+    call_block = on_block.split("workflow_call:", 1)[1].split("workflow_dispatch:", 1)[0]
+    secrets_block = call_block.split("secrets:", 1)[1]
+    assert re.search(r"^\s+PKG_GITHUB_APP_ID:\n\s+required: true\s*$", secrets_block, re.MULTILINE), secrets_block
+    assert re.search(r"^\s+PKG_GITHUB_APP_PRIVATE_KEY:\n\s+required: true\s*$", secrets_block, re.MULTILINE), (
+        secrets_block
+    )
+
+
 # --------------------------------------------------------------------------- #
 # 2. Every publisher workflow calls it after its own publish job.
 # --------------------------------------------------------------------------- #
+
+# The explicit two-key secrets map every render-site caller must use instead of
+# `secrets: inherit` (least-privilege, CodeRabbit finding, PR #2451 review) —
+# PKG_GITHUB_APP_ID and PKG_GITHUB_APP_PRIVATE_KEY are the ONLY secrets
+# pkg-render-site.yml's own `workflow_call.secrets` block declares.
+_EXPLICIT_RENDER_SECRETS = (
+    "PKG_GITHUB_APP_ID: ${{ secrets.PKG_GITHUB_APP_ID }}",
+    "PKG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}",
+)
 
 
 def test_pkg_republish_calls_render_site_after_publish() -> None:
     job = _extract_job(REPUBLISH, "render-site")
     assert "uses: ./.github/workflows/pkg-render-site.yml" in job
-    assert "secrets: inherit" in job
+    assert "secrets: inherit" not in job
+    for line in _EXPLICIT_RENDER_SECRETS:
+        assert line in job, job
     assert "needs: publish" in job or "needs: [publish]" in job
     assert 'source_ref: "${{ github.workflow_sha }}"' in job or "source_ref: ${{ github.workflow_sha }}" in job
 
@@ -93,7 +117,9 @@ def test_pkg_republish_calls_render_site_after_publish() -> None:
 def test_release_published_calls_render_site_after_publish_and_promote() -> None:
     job = _extract_job(PUBLISHED, "render-site")
     assert "uses: ./.github/workflows/pkg-render-site.yml" in job
-    assert "secrets: inherit" in job
+    assert "secrets: inherit" not in job
+    for line in _EXPLICIT_RENDER_SECRETS:
+        assert line in job, job
     assert "needs: [publish-pkg-repo, promote-pkg-repo]" in job
     assert "if: always() && needs.publish-pkg-repo.result == 'success'" in job
     assert 'source_ref: "${{ github.workflow_sha }}"' in job or "source_ref: ${{ github.workflow_sha }}" in job
@@ -102,7 +128,9 @@ def test_release_published_calls_render_site_after_publish_and_promote() -> None
 def test_nightly_calls_render_site_after_publish_with_trusted_ref() -> None:
     job = _extract_job(NIGHTLY, "render-site")
     assert "uses: ./.github/workflows/pkg-render-site.yml" in job
-    assert "secrets: inherit" in job
+    assert "secrets: inherit" not in job
+    for line in _EXPLICIT_RENDER_SECRETS:
+        assert line in job, job
     assert "needs: [prepare, publish-pkg-repo]" in job
     assert (
         'source_ref: "${{ needs.prepare.outputs.tools_sha }}"' in job

--- a/tests/test_issue2450_render_site_workflow.py
+++ b/tests/test_issue2450_render_site_workflow.py
@@ -1,0 +1,162 @@
+"""Issue #2450 step 3: pkg-render-site.yml wired into every catalogue publisher.
+
+scripts/render-pkg-site.sh (step 2) renders the pkg website (everything under
+pkg's docs/ EXCEPT the catalogue-owned trees) from this repo's pkg-site/. This
+step wires it into CI: a reusable + dispatchable workflow that runs it, called
+by every catalogue-publishing workflow after its own publish job, plus removes
+the retired PUBLISH_REFRESH_LANDING/BASE_URL knobs those publishers no longer
+need (publish-pkg-repo.sh dropped both when site rendering split out).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+RENDER = (WORKFLOWS / "pkg-render-site.yml").read_text(encoding="utf-8")
+REPUBLISH = (WORKFLOWS / "pkg-republish.yml").read_text(encoding="utf-8")
+PUBLISHED = (WORKFLOWS / "release-published.yml").read_text(encoding="utf-8")
+NIGHTLY = (WORKFLOWS / "nightly.yml").read_text(encoding="utf-8")
+
+
+def _extract_job(text: str, job_name: str) -> str:
+    """Return the body of a top-level ``  <job_name>:`` job block, bounded to the
+    next sibling job at the same (2-space) indentation, or end-of-file.
+
+    Same sibling-boundary idiom as tests/_workflow_steps.extract_step and the
+    other workflow suites' own ``_extract_job`` (tests/test_issue2389_live_pages_gate.py,
+    tests/test_nightly_workflow_contract.py) — duplicated locally rather than
+    imported, matching their own convention.
+    """
+    marker = re.compile(rf"^  {re.escape(job_name)}:\n", re.MULTILINE)
+    match = marker.search(text)
+    assert match is not None, f"job {job_name!r} not found"
+    start = match.end()
+    nxt = re.search(r"^  [A-Za-z0-9_-]+:\n", text[start:], re.MULTILINE)
+    end = start + nxt.start() if nxt else len(text)
+    return text[start:end]
+
+
+# --------------------------------------------------------------------------- #
+# 1. pkg-render-site.yml itself.
+# --------------------------------------------------------------------------- #
+
+
+def test_render_site_workflow_declares_both_triggers_with_source_ref() -> None:
+    on_block = RENDER.split("on:", 1)[1].split("permissions:", 1)[0]
+    assert "workflow_call:" in on_block
+    assert "workflow_dispatch:" in on_block
+    assert on_block.count("source_ref:") == 2
+
+
+def test_render_site_job_runs_the_renderer_with_full_env_contract() -> None:
+    job = _extract_job(RENDER, "render")
+    step = job.split("- name: Render the pkg website", 1)[1]
+    assert "sh scripts/render-pkg-site.sh" in step
+    assert "SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}" in step
+    assert "ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}" in step
+    assert "BASE_URL: https://pfblockerng.github.io/pkg" in step
+    assert 'export PFB_SRC="$GITHUB_WORKSPACE"' in step
+    assert 'export PKG_REPO="$GITHUB_WORKSPACE/pkg-repo"' in step
+
+
+def test_render_site_job_pins_source_ref_and_credentials() -> None:
+    job = _extract_job(RENDER, "render")
+    assert "ref: ${{ inputs.source_ref || github.sha }}" in job
+    assert "permission-contents: write" in job
+    assert "repositories: pkg" in job
+    assert "persist-credentials: true" in job
+
+
+def test_render_site_job_serialises_via_job_level_concurrency() -> None:
+    job = _extract_job(RENDER, "render")
+    assert re.search(r"^\s+concurrency:\n\s+group: \S+\n\s+cancel-in-progress: false\s*$", job, re.MULTILINE), job
+
+
+# --------------------------------------------------------------------------- #
+# 2. Every publisher workflow calls it after its own publish job.
+# --------------------------------------------------------------------------- #
+
+
+def test_pkg_republish_calls_render_site_after_publish() -> None:
+    job = _extract_job(REPUBLISH, "render-site")
+    assert "uses: ./.github/workflows/pkg-render-site.yml" in job
+    assert "secrets: inherit" in job
+    assert "needs: publish" in job or "needs: [publish]" in job
+    assert 'source_ref: "${{ github.workflow_sha }}"' in job or "source_ref: ${{ github.workflow_sha }}" in job
+
+
+def test_release_published_calls_render_site_after_publish_and_promote() -> None:
+    job = _extract_job(PUBLISHED, "render-site")
+    assert "uses: ./.github/workflows/pkg-render-site.yml" in job
+    assert "secrets: inherit" in job
+    assert "needs: [publish-pkg-repo, promote-pkg-repo]" in job
+    assert "if: always() && needs.publish-pkg-repo.result == 'success'" in job
+    assert 'source_ref: "${{ github.workflow_sha }}"' in job or "source_ref: ${{ github.workflow_sha }}" in job
+
+
+def test_nightly_calls_render_site_after_publish_with_trusted_ref() -> None:
+    job = _extract_job(NIGHTLY, "render-site")
+    assert "uses: ./.github/workflows/pkg-render-site.yml" in job
+    assert "secrets: inherit" in job
+    assert "needs: [prepare, publish-pkg-repo]" in job
+    assert (
+        'source_ref: "${{ needs.prepare.outputs.tools_sha }}"' in job
+        or "source_ref: ${{ needs.prepare.outputs.tools_sha }}" in job
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3. Retired knobs are gone from every publisher; BASE_URL lives only in the
+#    render workflow.
+# --------------------------------------------------------------------------- #
+
+
+def test_no_publisher_step_still_sets_the_retired_knobs() -> None:
+    for name, text in (
+        ("pkg-republish.yml", REPUBLISH),
+        ("release-published.yml", PUBLISHED),
+        ("nightly.yml", NIGHTLY),
+    ):
+        assert "BASE_URL" not in text, f"{name} still sets BASE_URL — that belongs to pkg-render-site.yml alone"
+        assert "refresh_landing" not in text, f"{name} still carries the retired refresh_landing input"
+        assert "PUBLISH_REFRESH_LANDING" not in text, f"{name} still sets the retired PUBLISH_REFRESH_LANDING knob"
+
+
+def test_no_other_github_workflow_references_the_retired_knobs() -> None:
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        assert "refresh_landing" not in text, f"{path.relative_to(ROOT)} still references refresh_landing"
+        assert "PUBLISH_REFRESH_LANDING" not in text, (
+            f"{path.relative_to(ROOT)} still references PUBLISH_REFRESH_LANDING"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# 4. CATALOGUE_DIRS stays pinned identical across both shell scripts and
+#    gen_landing.py's own constant of the same name.
+# --------------------------------------------------------------------------- #
+
+_SPEC = importlib.util.spec_from_file_location("gen_landing", ROOT / "scripts" / "gen_landing.py")
+assert _SPEC and _SPEC.loader
+gl = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(gl)
+
+
+def _shell_catalogue_dirs(script_relpath: str) -> tuple[str, ...]:
+    text = (ROOT / script_relpath).read_text(encoding="utf-8")
+    match = re.search(r'^CATALOGUE_DIRS="([^"]*)"$', text, re.MULTILINE)
+    assert match is not None, f'{script_relpath} has no CATALOGUE_DIRS="..." literal'
+    return tuple(match.group(1).split())
+
+
+def test_render_pkg_site_sh_catalogue_dirs_matches_gen_landing() -> None:
+    assert _shell_catalogue_dirs("scripts/render-pkg-site.sh") == gl.CATALOGUE_DIRS
+
+
+def test_publish_pkg_repo_sh_catalogue_dirs_matches_gen_landing() -> None:
+    assert _shell_catalogue_dirs("scripts/publish-pkg-repo.sh") == gl.CATALOGUE_DIRS

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -313,7 +313,9 @@ def test_publish_pkg_repo_job_invokes_the_trusted_wrapper_with_nightly_kind() ->
     """W8: PUBLISH_KIND=nightly, SOURCE_RUN_ID = run_id:run_attempt (same
     composition as the handoff job's own stale-callback identity), path env vars
     exported in the RUN BODY not the env: map (issue #2231), and the wrapper is
-    invoked from the TRUSTED checkout, never the pkg-repo one."""
+    invoked from the TRUSTED checkout, never the pkg-repo one. BASE_URL is gone
+    (issue #2450 step 3): publish-pkg-repo.sh no longer renders anything --
+    render-site's own job carries BASE_URL for the site renderer instead."""
     text = WORKFLOW.read_text(encoding="utf-8")
     job = _extract_job(text, "publish-pkg-repo")
     assert "PUBLISH_KIND=nightly" in job
@@ -322,7 +324,7 @@ def test_publish_pkg_repo_job_invokes_the_trusted_wrapper_with_nightly_kind() ->
     assert 'PKG_REPO="$GITHUB_WORKSPACE/pkg-repo"' in job
     assert 'HANDOFF_FILE="$GITHUB_WORKSPACE/handoff/nightly-handoff.json"' in job
     assert 'RESULTS_DIR="$GITHUB_WORKSPACE/results"' in job
-    assert "BASE_URL=https://pfblockerng.github.io/pkg" in job
+    assert "BASE_URL" not in job
     assert "sh trusted/scripts/publish-pkg-repo.sh" in job
 
 


### PR DESCRIPTION
Part of #2450 (the issue closes after the first live render + the one-time manual cleanup, see below).

## What

Splits **publishing a catalogue** from **rendering the pkg website**, per the owner rulings on #2450:

- **`pkg-site/`** — the declared site tree, mirrored 1:1 into pkg `docs/`: `.nojekyll`, `install.sh` (symlink to `scripts/install.sh`; `.sh` files get the existing base-URL bake + hook embed at render time), `recipes/<channel>.sh` (the copyable per-channel install block, `{base}` substituted). Nothing in the renderer names a specific site file beyond the `recipes/<channel>.sh` convention.
- **`scripts/gen_landing.py`** now renders the landing page, `browse.html`, and `browse/<channel>/<varver>/index.html` pages **outside** the catalogue trees (links resolve into them), builds the site tree, and **mirrors** the result into `docs/` (`sync_site`: copy + delete extraneous; never touches `CATALOGUE_DIRS = stable/testing/edge/nightly/staging`). No mtimes anywhere in the output → deterministic; a re-render on unchanged input is a NOOP. `--client-scripts-only`, `CLIENT_SCRIPTS`, `RETIRED_CLIENT_SCRIPTS`, `PUBLISH_REFRESH_LANDING` are gone.
- **`scripts/render-pkg-site.sh`** (new) — sync pkg to `origin/main`, render, `git add -A -- docs`, guard (staged diff must not touch a catalogue prefix), NOOP → exit 0, else commit `render: pkg website (<sha>)` and push with the bounded non-fast-forward retry loop.
- **`scripts/publish-pkg-repo.sh`** — catalogue only: stages exactly `docs/<channel>/<varver>` targets (+ staging trees), asserts before every commit that the staged diff contains only catalogue-owned paths (path-traversal-safe: checks post-`git add` normalised names). Catalogue NOOP commits nothing.
- **`.github/workflows/pkg-render-site.yml`** (new; `workflow_call` + `workflow_dispatch`, `source_ref` input) — called by `release-published.yml` (after promote/discard, whenever the publisher succeeded), `pkg-republish.yml`, `nightly.yml`; also dispatchable alone to re-render the site on demand, no release verification.

## Tests

- `tests/test_gen_landing.py` (115): tree build, `{base}` substitution, bake/embed, recipe cards (verbatim + hostile escaping), browse pages + link math, mirror property, catalogue-prefix refusal, determinism under mtime churn, README-vs-recipes drift guard, CLI shape.
- `tests/shell/render_pkg_site_spec.sh` (16) + rewritten `tests/shell/publish_pkg_repo_spec.sh` (51): both guards red-canaried (renderer touching a catalogue file; publisher fed `updated ../README.txt`), NOOP, retry on competing push, bot identity, matrix transform.
- `tests/test_issue2450_render_site_workflow.py` (11): render workflow shape, every publisher calls it with the right `source_ref` + `secrets: inherit`, no publisher sets the retired knobs, `CATALOGUE_DIRS` pinned equal across gen_landing + both scripts.
- Full docker pytest `5442 passed`; shellspec `1405 examples, 0 failures`; `run-gates.sh --diff origin/devel` PASS; actionlint clean.

## After merge (operator steps, tracked on the issue)

1. `gh workflow run pkg-render-site.yml --ref devel` → one render commit on pkg `main` (new landing cards, `install.sh` published, `add-repo.sh`/`migrate-channel.sh` swept, `browse/**` pages), second run NOOP.
2. One-time by hand: delete the legacy `index.html` files inside the live catalogue dirs of pfBlockerNG/pkg (renderer deliberately never touches those trees).

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated rendering and publishing of the package website after catalogue updates.
  - Added installation commands for stable, testing, nightly, and edge channels.
  - Improved website generation with synchronized site content, browse pages, embedded installer hooks, and safer handling of package metadata.

- **Bug Fixes**
  - Package publication now limits changes to catalogue content, protecting website and unrelated files.
  - Rendering is deterministic and no longer relies on filesystem timestamps.
  - Improved handling of failed renders, stale files, and concurrent publication attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->