### PR TITLE
smoke: retry `pkg repo` once when libpkg aborts (rc=134)

### DIFF
--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -317,9 +317,8 @@ _PKG_REPO_ABORT_RC = 134
 def pkg_repo_index(vm: SmokeVM, repo_dir: str) -> None:
     """``pkg repo <dir>`` on the guest — no key argument => an unsigned catalog.
 
-    Retries ONCE, and only when ``pkg`` itself died on SIGABRT (issue #2447): that is a
-    libpkg crash on an input the very next run indexes cleanly (replayed on a leased box:
-    same ref, same case, green), not a property of the catalog under test. Any other
+    Retries ONCE, and only when ``pkg`` itself died on SIGABRT (issue #2447): a
+    transient libpkg crash, not a property of the catalog under test. Any other
     non-zero exit raises on the first try, exactly as before.
     """
     remote = ("env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", repo_dir)
@@ -351,6 +350,9 @@ def build_repo_via_script(vm: SmokeVM, pkg_files: list[Path]) -> str:
     catalog triple ``pkg repo`` emits) is accepted by a real pfSense box, the
     live half of the build-side premise.
     """
+    # The script's own `pkg repo` runs un-retried (not routed through pkg_repo_index): the
+    # #2447 abort has only ever been seen on the direct call, and retrying here would mean
+    # re-running the whole script under test.
     real_varver = _box_real_varver(vm)
     _ssh_check(vm, "/bin/rm", "-rf", GUEST_PKG_IN_DIR, SCRIPT_REPO_ROOT)
     _ssh_check(vm, "/bin/mkdir", "-p", GUEST_PKG_IN_DIR, GUEST_SPIKE_DIR)

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -305,8 +305,34 @@ def build_guest_repo(vm: SmokeVM, repo_dir: str, pkg_files: list[Path]) -> None:
     _ssh_check(vm, "/bin/mkdir", "-p", repo_dir)
     for pkg in staged:
         _scp_to_guest(vm, pkg, f"{repo_dir}/{pkg.name}")
-    # `pkg repo <dir>` with no key argument => an unsigned catalog.
-    _ssh_check(vm, "env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", repo_dir)
+    pkg_repo_index(vm, repo_dir)
+
+
+# `pkg repo` exit status when libpkg aborts (SIGABRT, 128+6) — the guest's jemalloc runs
+# with assertions on and once in many runs trips one inside libpkg
+# (`Failed assertion: "alloc_ctx.szind != SC_NSIZES"` … `Abort trap`, issue #2447).
+_PKG_REPO_ABORT_RC = 134
+
+
+def pkg_repo_index(vm: SmokeVM, repo_dir: str) -> None:
+    """``pkg repo <dir>`` on the guest — no key argument => an unsigned catalog.
+
+    Retries ONCE, and only when ``pkg`` itself died on SIGABRT (issue #2447): that is a
+    libpkg crash on an input the very next run indexes cleanly (replayed on a leased box:
+    same ref, same case, green), not a property of the catalog under test. Any other
+    non-zero exit raises on the first try, exactly as before.
+    """
+    remote = ("env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", repo_dir)
+    result = vm.ssh(*remote, timeout=180.0)
+    if result.returncode == _PKG_REPO_ABORT_RC:
+        print(
+            f"PFB_NOTE pkg repo {repo_dir} aborted (rc={result.returncode}) — retrying once (#2447):\n{result.stderr}"
+        )
+        result = vm.ssh(*remote, timeout=180.0)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"guest cmd {remote!r} failed: rc={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
 
 
 def build_repo_via_script(vm: SmokeVM, pkg_files: list[Path]) -> str:

--- a/tests/test_issue2447_pkg_repo_abort_retry.py
+++ b/tests/test_issue2447_pkg_repo_abort_retry.py
@@ -1,0 +1,61 @@
+"""Issue #2447: ``pkg repo`` on the guest can SIGABRT (rc=134) inside libpkg (a jemalloc
+invalid-free assertion) once in many runs, on an input that indexes fine on the very
+next run. The catalog build retries that abort ONCE — and only that abort: any other
+failure (an rc=1 with a real error) still surfaces on the first try.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tests.smoke.test_repo_install import pkg_repo_index
+
+PKG_REPO = ("env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", "/tmp/pfb_repo_spike/upgrade")
+ABORT_STDERR = (
+    '<jemalloc>: jemalloc_jemalloc.c:2576: Failed assertion: "alloc_ctx.szind != SC_NSIZES"\n'
+    "Child process pid=90168 terminated abnormally: Abort trap\n"
+)
+
+
+class _FakeVM:
+    def __init__(self, results: list[subprocess.CompletedProcess[str]]) -> None:
+        self.results = iter(results)
+        self.calls: list[tuple[str, ...]] = []
+
+    def ssh(self, *remote: str, timeout: float) -> subprocess.CompletedProcess[str]:
+        self.calls.append(remote)
+        return next(self.results)
+
+
+def test_pkg_repo_retries_a_libpkg_abort_once() -> None:
+    aborted = subprocess.CompletedProcess(
+        (), 134, "Creating repository in /tmp/pfb_repo_spike/upgrade: .\n", ABORT_STDERR
+    )
+    success = subprocess.CompletedProcess((), 0, "", "")
+    vm = _FakeVM([aborted, success])
+
+    pkg_repo_index(vm, "/tmp/pfb_repo_spike/upgrade")  # type: ignore[arg-type]
+
+    assert vm.calls == [PKG_REPO, PKG_REPO]
+
+
+def test_pkg_repo_second_abort_raises_with_the_abort_output() -> None:
+    aborted = subprocess.CompletedProcess((), 134, "", ABORT_STDERR)
+    vm = _FakeVM([aborted, aborted])
+
+    with pytest.raises(RuntimeError, match=r"rc=134[\s\S]*Abort trap"):
+        pkg_repo_index(vm, "/tmp/pfb_repo_spike/upgrade")  # type: ignore[arg-type]
+
+    assert len(vm.calls) == 2
+
+
+def test_pkg_repo_does_not_retry_an_ordinary_failure() -> None:
+    failure = subprocess.CompletedProcess((), 1, "", "pkg: /tmp/pfb_repo_spike/upgrade: No such file or directory\n")
+    vm = _FakeVM([failure])
+
+    with pytest.raises(RuntimeError, match="No such file or directory"):
+        pkg_repo_index(vm, "/tmp/pfb_repo_spike/upgrade")  # type: ignore[arg-type]
+
+    assert len(vm.calls) == 1

--- a/tests/test_issue2447_pkg_repo_abort_retry.py
+++ b/tests/test_issue2447_pkg_repo_abort_retry.py
@@ -10,9 +10,9 @@ import subprocess
 
 import pytest
 
-from tests.smoke.test_repo_install import pkg_repo_index
+from tests.smoke.test_repo_install import UPGRADE_REPO_DIR, pkg_repo_index
 
-PKG_REPO = ("env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", "/tmp/pfb_repo_spike/upgrade")
+PKG_REPO = ("env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", UPGRADE_REPO_DIR)
 ABORT_STDERR = (
     '<jemalloc>: jemalloc_jemalloc.c:2576: Failed assertion: "alloc_ctx.szind != SC_NSIZES"\n'
     "Child process pid=90168 terminated abnormally: Abort trap\n"
@@ -25,28 +25,39 @@ class _FakeVM:
         self.calls: list[tuple[str, ...]] = []
 
     def ssh(self, *remote: str, timeout: float) -> subprocess.CompletedProcess[str]:
+        assert remote == PKG_REPO
+        assert timeout == 180.0  # the guest `pkg repo` budget build_guest_repo always had
         self.calls.append(remote)
         return next(self.results)
 
 
-def test_pkg_repo_retries_a_libpkg_abort_once() -> None:
-    aborted = subprocess.CompletedProcess(
-        (), 134, "Creating repository in /tmp/pfb_repo_spike/upgrade: .\n", ABORT_STDERR
-    )
+def test_pkg_repo_retries_a_libpkg_abort_once(capsys: pytest.CaptureFixture[str]) -> None:
+    aborted = subprocess.CompletedProcess((), 134, f"Creating repository in {UPGRADE_REPO_DIR}: .\n", ABORT_STDERR)
     success = subprocess.CompletedProcess((), 0, "", "")
     vm = _FakeVM([aborted, success])
 
-    pkg_repo_index(vm, "/tmp/pfb_repo_spike/upgrade")  # type: ignore[arg-type]
+    pkg_repo_index(vm, UPGRADE_REPO_DIR)  # type: ignore[arg-type]
 
     assert vm.calls == [PKG_REPO, PKG_REPO]
+    out = capsys.readouterr().out
+    assert f"PFB_NOTE pkg repo {UPGRADE_REPO_DIR} aborted (rc=134)" in out
+    assert ABORT_STDERR in out
 
 
 def test_pkg_repo_second_abort_raises_with_the_abort_output() -> None:
     aborted = subprocess.CompletedProcess((), 134, "", ABORT_STDERR)
     vm = _FakeVM([aborted, aborted])
 
-    with pytest.raises(RuntimeError, match=r"rc=134[\s\S]*Abort trap"):
-        pkg_repo_index(vm, "/tmp/pfb_repo_spike/upgrade")  # type: ignore[arg-type]
+    # The same `guest cmd (...) failed: rc=N` / stdout / stderr shape `_ssh_check` raises —
+    # that exact line is what issue #2447 was triaged from.
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"guest cmd \('env', 'ASSUME_ALWAYS_YES=yes', 'pkg', 'repo', '.*'\) failed: rc=134"
+            r"\nstdout:\n[\s\S]*stderr:\n[\s\S]*Abort trap"
+        ),
+    ):
+        pkg_repo_index(vm, UPGRADE_REPO_DIR)  # type: ignore[arg-type]
 
     assert len(vm.calls) == 2
 
@@ -56,6 +67,6 @@ def test_pkg_repo_does_not_retry_an_ordinary_failure() -> None:
     vm = _FakeVM([failure])
 
     with pytest.raises(RuntimeError, match="No such file or directory"):
-        pkg_repo_index(vm, "/tmp/pfb_repo_spike/upgrade")  # type: ignore[arg-type]
+        pkg_repo_index(vm, UPGRADE_REPO_DIR)  # type: ignore[arg-type]
 
     assert len(vm.calls) == 1


### PR DESCRIPTION
## Summary

`tests/smoke/test_repo_install.py::test_pkg_upgrade_moves_to_our_newer_build` went red on CE 2.8 (PR #2444 run [31906277729](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/31906277729)) with the guest's `pkg repo` dying on SIGABRT inside libpkg:

```
<jemalloc>: jemalloc_jemalloc.c:2576: Failed assertion: "alloc_ctx.szind != SC_NSIZES"
Child process pid=90168 terminated abnormally: Abort trap
```

(`dmesg`: `pid 90168 (pkg), jid 0, uid 0: exited on signal 6 (core dumped)`.) That is a jemalloc invalid-free check tripping inside libpkg — pfSense's FreeBSD-CURRENT base ships jemalloc with assertions on — not a property of the catalog under test.

### Reproduction attempt (executed)

Replayed the exact failing ref and case on a leased box: `scripts/local-smoke.sh --ref aaf8019d56d33eb537dab21da2c8657977f95342 --marker repo --filter test_pkg_upgrade_moves_to_our_newer_build --no-two-vm` → `1 passed, 988 deselected in 152.55s`. Every CE 2.8 nightly `repo-install` leg since 2026-08-07 indexed the same input cleanly, and the abort appears in none of their logs. One abort across all those runs, same input green on replay ⇒ a rare libpkg crash, not deterministic on the reversioned `.pkg`.

### Change

- Extract the guest `pkg repo <dir>` call into `pkg_repo_index()` and retry it **once, only on rc=134** (SIGABRT), printing the abort output as a `PFB_NOTE` line. Every other non-zero exit still raises on the first try, unchanged.
- Hermetic tests (`tests/test_issue2447_pkg_repo_abort_retry.py`): retry-once on abort; second abort raises with the abort output; an ordinary rc=1 is not retried.

### Red → green

- RED (frozen `git hash-object` `2c443009749ad59c90b435346cd0ccd411e4d43d`), production edit absent: `ImportError: cannot import name 'pkg_repo_index' from 'tests.smoke.test_repo_install'`.
- GREEN, same file byte-identical: `3 passed in 0.12s`.
- Gates (`scripts/agent/run-gates.sh`): pytest / ruff check / ruff format / mypy — `GATES: PASS`.
- Live: `local-smoke.sh --ref 01997b5c6a --marker repo --filter "test_pkg_upgrade_moves_to_our_newer_build or test_install_from_our_repo_lands_all_files"` on a leased box — result posted below when it finishes.

### Not in this PR

The CE 2.9 leg's redness has a different root cause: `repo-install.yml` fans out CE 2.8 and CE 2.9 with the same `image_name` (`pfsense-ce`), so both legs upload `pfBlockerNG-pkg-pfsense-ce-s0` / `pfBlockerNG-deppkgs-pfsense-ce-s0` and the CE 2.9 leg can download the FreeBSD:15 build (`pkg: wrong architecture: FreeBSD:15:* instead of FreeBSD:16:amd64`). Tracked separately (see the issue comment).

Fixes #2447

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package repository indexing reliability by retrying once after an unexpected abort.
  * Added clearer error reporting when indexing continues to fail.
  * Ordinary indexing failures are now reported immediately without unnecessary retries.

* **Tests**
  * Added coverage for retry behavior, repeated aborts, and standard failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->