### PR TITLE
build: dependency pkg bytes derive from the sdist epoch, never the ambient SOURCE_DATE_EPOCH

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1207,7 +1207,9 @@ Full design: ADR-39.
   counts one main asset per release row plus the total `extra_pkgs` entries. The publisher folds
   those attached dep `.pkg` assets into the served catalogue itself — `publish_catalogues.py`
   verifies each one against its ROUTE row's ABI and `publish_release.py` drops it into the same
-  destination as the canonical package.
+  destination as the canonical package. Dependency package bytes derive from the pinned sdist's
+  own timestamp (`build-dep-pkg-portable.py`), never the project `SOURCE_DATE_EPOCH` — the
+  invariant that lets the shared-bytes rule hold for deps too (issue #2454).
 - **Generators:** `scripts/build-repo-portable.py` (primary catalog gen) and
   `scripts/build-repo.sh` (fallback + `--print-conf` conf template) both emit the client
   repo-conf; `priority: 100` — one equal priority across every project channel repo, above

--- a/scripts/build-dep-pkg-portable.py
+++ b/scripts/build-dep-pkg-portable.py
@@ -241,19 +241,30 @@ def fetch_verified_sdist(port: PortFacts, dest_dir: Path, *, sha256: str, size: 
 
 def sdist_epoch(sdist: Path) -> int:
     """The dependency's OWN timestamp: the newest member mtime inside the
-    verified sdist tarball (upstream's release stamp). This — never the build
-    clock, never the ambient SOURCE_DATE_EPOCH — is what every mtime this tool
-    emits derives from (issue #2454). A sdist with no members, or whose
-    members all carry mtime 0, is refused: a dependency must carry its own
-    timestamp, and silently falling back elsewhere would just reintroduce the
-    leak this function exists to close."""
-    with tarfile.open(sdist) as tf:
-        newest = max((m.mtime for m in tf.getmembers()), default=0)
+    verified sdist tarball (upstream's release stamp), truncated to whole
+    seconds (pax fractional stamps truncate). This — never the build clock,
+    never the ambient SOURCE_DATE_EPOCH — is what every mtime this tool emits
+    derives from (issue #2454). A sdist with no members, or whose members all
+    carry mtime 0, is refused: a dependency must carry its own timestamp, and
+    silently falling back elsewhere would just reintroduce the leak this
+    function exists to close. A sdist that isn't actually a readable tar
+    archive, or whose newest member mtime falls outside the archive format's
+    representable range, is refused here too — naming this sdist — rather than
+    surfacing later as an uncaught traceback or a range error that blames the
+    wrong source."""
+    try:
+        with tarfile.open(sdist) as tf:
+            newest = max((m.mtime for m in tf.getmembers()), default=0)
+    except tarfile.TarError as exc:
+        raise DepPkgError(f"{sdist.name}: not a readable tar sdist: {exc}") from exc
     if newest <= 0:
         raise DepPkgError(
             f"{sdist}: no usable member mtime found in the sdist — a dependency must carry its own timestamp"
         )
-    return int(newest)
+    try:
+        return bpp._checked_mtime(int(newest), f"newest member mtime of {sdist.name}")
+    except bpp.BuildError as exc:
+        raise DepPkgError(str(exc)) from exc
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/build-dep-pkg-portable.py
+++ b/scripts/build-dep-pkg-portable.py
@@ -30,6 +30,12 @@
 # Requires: python3 (stdlib) + pip (BUILD_DEPENDS equivalent) + a zstd encoder
 # (see build-pkg-portable.py). Network is required (sdist fetch + pip's own
 # fetch of its build backend). Developer tool — not shipped in release archives.
+#
+# Dep .pkg bytes are a function of the pinned sdist ONLY, never the caller's
+# ambient SOURCE_DATE_EPOCH: the pfBlockerNG project build exports that for
+# ITS OWN commit, and reusing it here would stamp every dep with an unrelated
+# epoch that collides with the same-version dep already published from a
+# different pfBlockerNG commit (issue #2454).
 
 from __future__ import annotations
 
@@ -41,6 +47,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import urllib.request
 import zipfile
@@ -232,6 +239,23 @@ def fetch_verified_sdist(port: PortFacts, dest_dir: Path, *, sha256: str, size: 
     raise DepPkgError(f"failed to fetch {distfile} from any MASTER_SITES candidate:\n  " + "\n  ".join(errors))
 
 
+def sdist_epoch(sdist: Path) -> int:
+    """The dependency's OWN timestamp: the newest member mtime inside the
+    verified sdist tarball (upstream's release stamp). This — never the build
+    clock, never the ambient SOURCE_DATE_EPOCH — is what every mtime this tool
+    emits derives from (issue #2454). A sdist with no members, or whose
+    members all carry mtime 0, is refused: a dependency must carry its own
+    timestamp, and silently falling back elsewhere would just reintroduce the
+    leak this function exists to close."""
+    with tarfile.open(sdist) as tf:
+        newest = max((m.mtime for m in tf.getmembers()), default=0)
+    if newest <= 0:
+        raise DepPkgError(
+            f"{sdist}: no usable member mtime found in the sdist — a dependency must carry its own timestamp"
+        )
+    return int(newest)
+
+
 # --------------------------------------------------------------------------- #
 # Wheel build — BUILD_DEPENDS py-setuptools/py-wheel equivalent: `pip wheel`.
 # --------------------------------------------------------------------------- #
@@ -417,6 +441,12 @@ def stage_wheel(wheel: Path, stage_dir: Path, py_dotted: str) -> tuple[list[Path
 
 
 def build_dep_pkg(args: argparse.Namespace) -> Path:
+    """Build the dep .pkg. Every mtime the output carries — the wheel build's
+    own stamping, every staged-file mtime, the +MANIFEST files[*].mtime — is
+    pinned to ``sdist_epoch()``, NOT the ambient ``SOURCE_DATE_EPOCH`` a caller
+    may have exported for an unrelated pfBlockerNG project build: this
+    function overrides that env var for its own duration (restored in a
+    ``finally``) so the two builds never collide (issue #2454)."""
     port_dir = Path(args.ports).resolve() / args.port
     port = read_port(port_dir)
     py_dotted = python_dotted_version(args.py_flavor)  # validates the flavor too
@@ -427,49 +457,59 @@ def build_dep_pkg(args: argparse.Namespace) -> Path:
     with tempfile.TemporaryDirectory(prefix="pfbng-deppkg-") as td:
         tmp = Path(td)
         sdist = fetch_verified_sdist(port, tmp, sha256=sha256, size=size)
-        wheel = build_wheel(sdist, tmp)
+        dep_epoch = sdist_epoch(sdist)
 
-        stage = tmp / "stage"
-        site_files, script_files = stage_wheel(wheel, stage, py_dotted)
-        if not site_files:
-            raise DepPkgError(f"{wheel.name}: wheel contained no files")
+        prior_epoch = os.environ.get("SOURCE_DATE_EPOCH")
+        os.environ["SOURCE_DATE_EPOCH"] = str(dep_epoch)
+        try:
+            wheel = build_wheel(sdist, tmp)
 
-        portname = f"{args.py_flavor}-{port.portname}"
-        pyv = args.py_flavor[2:]  # "py311" -> "311"
+            stage = tmp / "stage"
+            site_files, script_files = stage_wheel(wheel, stage, py_dotted)
+            if not site_files:
+                raise DepPkgError(f"{wheel.name}: wheel contained no files")
 
-        files: list[Any] = []
-        for f in site_files:
-            files.append(bpp.StagedFile(install_path="/" + str(f.relative_to(stage)), src_in_stage=f, perm="0644"))
-        for f in script_files:
-            files.append(bpp.StagedFile(install_path="/" + str(f.relative_to(stage)), src_in_stage=f, perm="0555"))
+            portname = f"{args.py_flavor}-{port.portname}"
+            pyv = args.py_flavor[2:]  # "py311" -> "311"
 
-        build = bpp.Build(
-            portname=portname,
-            pkgversion=port.portversion,
-            origin=args.port,
-            comment=port.comment,
-            maintainer=port.maintainer,
-            categories=port.categories,
-            licenses=port.license.split(),
-            www=port.www,
-            desc=read_descr(port_dir, port.comment),
-            prefix="/usr/local",
-            # NO_ARCH: wildcard the CPU so one build serves every arch on this
-            # FreeBSD major (real `pkg create` does the same for a NO_ARCH port).
-            abi=f"FreeBSD:{args.freebsd_major}:*",
-            arch=f"freebsd:{args.freebsd_major}:*",
-            deps=[
-                bpp.Dep(name=f"python{pyv}", origin=f"lang/python{pyv}", version=args.python_dep_version),
-            ],
-            files=files,
-        )
+            files: list[Any] = []
+            for f in site_files:
+                files.append(bpp.StagedFile(install_path="/" + str(f.relative_to(stage)), src_in_stage=f, perm="0644"))
+            for f in script_files:
+                files.append(bpp.StagedFile(install_path="/" + str(f.relative_to(stage)), src_in_stage=f, perm="0555"))
 
-        out_dir = Path(args.out_dir)
-        out_dir.mkdir(parents=True, exist_ok=True)
-        out_path = out_dir / f"{build.pkgname}.pkg"
-        bpp.write_pkg(build, out_path, args.compression)
-        sys.stderr.write(f"==> wrote {out_path}  ({out_path.stat().st_size} bytes, {len(build.files)} files)\n")
-        return out_path
+            build = bpp.Build(
+                portname=portname,
+                pkgversion=port.portversion,
+                origin=args.port,
+                comment=port.comment,
+                maintainer=port.maintainer,
+                categories=port.categories,
+                licenses=port.license.split(),
+                www=port.www,
+                desc=read_descr(port_dir, port.comment),
+                prefix="/usr/local",
+                # NO_ARCH: wildcard the CPU so one build serves every arch on this
+                # FreeBSD major (real `pkg create` does the same for a NO_ARCH port).
+                abi=f"FreeBSD:{args.freebsd_major}:*",
+                arch=f"freebsd:{args.freebsd_major}:*",
+                deps=[
+                    bpp.Dep(name=f"python{pyv}", origin=f"lang/python{pyv}", version=args.python_dep_version),
+                ],
+                files=files,
+            )
+
+            out_dir = Path(args.out_dir)
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = out_dir / f"{build.pkgname}.pkg"
+            bpp.write_pkg(build, out_path, args.compression)
+            sys.stderr.write(f"==> wrote {out_path}  ({out_path.stat().st_size} bytes, {len(build.files)} files)\n")
+            return out_path
+        finally:
+            if prior_epoch is None:
+                os.environ.pop("SOURCE_DATE_EPOCH", None)
+            else:
+                os.environ["SOURCE_DATE_EPOCH"] = prior_epoch
 
 
 def main(argv: list[str]) -> int:

--- a/tests/test_build_dep_pkg_portable.py
+++ b/tests/test_build_dep_pkg_portable.py
@@ -337,6 +337,39 @@ def test_sdist_epoch_refuses_all_zero_mtimes(tmp_path: Path) -> None:
         bdp.sdist_epoch(sdist)
 
 
+def test_sdist_epoch_refuses_non_tar_file(tmp_path: Path) -> None:
+    """A malformed/verified-but-not-actually-tar sdist must raise DepPkgError,
+    not an uncaught tarfile.TarError — main() only catches DepPkgError."""
+    sdist = tmp_path / "notreally.tar.gz"
+    sdist.write_bytes(b"not a tar file at all, just garbage bytes" * 4)
+    with pytest.raises(bdp.DepPkgError, match="not a readable tar sdist"):
+        bdp.sdist_epoch(sdist)
+
+
+def test_sdist_epoch_refuses_mtime_above_ustar_range(tmp_path: Path) -> None:
+    """A member mtime above the ustar archive ceiling must fail inside
+    sdist_epoch() itself — naming the offending sdist — rather than surfacing
+    later from write_pkg's own range check with no sdist context."""
+    sdist = tmp_path / "toobig.tar.gz"
+    _write_sdist_tar(sdist, [0o77777777777 + 1])
+    with pytest.raises(bdp.DepPkgError, match=f"newest member mtime of {sdist.name}"):
+        bdp.sdist_epoch(sdist)
+
+
+def test_sdist_epoch_truncates_fractional_pax_mtime(tmp_path: Path) -> None:
+    """Real PyPI sdists are pax archives with fractional member mtimes;
+    sdist_epoch() truncates to whole seconds rather than propagating a float
+    SOURCE_DATE_EPOCH downstream."""
+    sdist = tmp_path / "pax.tar.gz"
+    with tarfile.open(sdist, "w:gz", format=tarfile.PAX_FORMAT) as tf:
+        data = b"member"
+        info = tarfile.TarInfo(name="pkg/file.txt")
+        info.size = len(data)
+        info.mtime = 1760412874.4126263
+        tf.addfile(info, io.BytesIO(data))
+    assert bdp.sdist_epoch(sdist) == 1760412874
+
+
 # --------------------------------------------------------------------------- #
 # Wheel build — exactly one PURE wheel, or refuse.
 # --------------------------------------------------------------------------- #
@@ -699,15 +732,44 @@ def test_build_dep_pkg_bytes_do_not_depend_on_ambient_source_date_epoch(
 
     for out_path in (out_path1, out_path2):
         full = _read_full_manifest(out_path)
+        assert full["files"], "manifest must list staged files"
         for install_path, entry in full["files"].items():
             assert entry["mtime"] == _FAKE_SDIST_MTIME, f"{install_path}: manifest mtime must be the sdist epoch"
 
         tar_bytes = pfb_pkg.zstd_decompress(out_path.read_bytes())
         with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
-            for member in tf.getmembers():
-                if member.name in ("+MANIFEST", "+COMPACT_MANIFEST"):
-                    continue
+            payload = [m for m in tf.getmembers() if m.name not in ("+MANIFEST", "+COMPACT_MANIFEST")]
+            assert payload, "archive must carry payload members besides the manifests"
+            for member in payload:
                 assert member.mtime == _FAKE_SDIST_MTIME, f"{member.name}: tar mtime must be the sdist epoch"
+
+
+def test_build_dep_pkg_uses_each_sdists_own_mtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_mock_network's sdist_mtime param actually drives the output: two builds
+    with distinct sdist mtimes produce different package bytes, and each one's
+    manifest files[*].mtime equals its OWN sdist mtime (never the other one's,
+    and never a shared/default value)."""
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+
+    mtime_a = 1_650_000_000
+    mtime_b = 1_700_000_500
+    assert mtime_a != _FAKE_SDIST_MTIME
+    assert mtime_b != _FAKE_SDIST_MTIME
+
+    _mock_network(monkeypatch, console_scripts=None, sdist_mtime=mtime_a)
+    out_a = bdp.build_dep_pkg(_build_args(ports_root, tmp_path / "out_a"))
+
+    _mock_network(monkeypatch, console_scripts=None, sdist_mtime=mtime_b)
+    out_b = bdp.build_dep_pkg(_build_args(ports_root, tmp_path / "out_b"))
+
+    assert out_a.read_bytes() != out_b.read_bytes(), "distinct sdist mtimes must produce distinct package bytes"
+
+    full_a = _read_full_manifest(out_a)
+    full_b = _read_full_manifest(out_b)
+    assert full_a["files"] and full_b["files"]
+    assert all(entry["mtime"] == mtime_a for entry in full_a["files"].values())
+    assert all(entry["mtime"] == mtime_b for entry in full_b["files"].values())
 
 
 def test_build_dep_pkg_restores_absent_source_date_epoch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -717,6 +779,46 @@ def test_build_dep_pkg_restores_absent_source_date_epoch(tmp_path: Path, monkeyp
     monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
 
     bdp.build_dep_pkg(_build_args(ports_root, tmp_path / "out"))
+
+    assert "SOURCE_DATE_EPOCH" not in os.environ
+
+
+def _raise_stage_wheel(*_args: Any, **_kwargs: Any) -> tuple[list[Path], list[Path]]:
+    raise RuntimeError("boom: stage_wheel exploded")
+
+
+def test_build_dep_pkg_restores_ambient_source_date_epoch_after_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The finally restore must also fire on the exception path (not merely the
+    success path both prior tests exercise): stage_wheel() raises AFTER the
+    env override is installed, and the ambient value must still come back."""
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+    _mock_network(monkeypatch, console_scripts=None)
+    monkeypatch.setattr(bdp, "stage_wheel", _raise_stage_wheel)
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "42")
+
+    with pytest.raises(RuntimeError, match="boom: stage_wheel exploded"):
+        bdp.build_dep_pkg(_build_args(ports_root, tmp_path / "out"))
+
+    assert os.environ["SOURCE_DATE_EPOCH"] == "42"
+
+
+def test_build_dep_pkg_restores_absent_source_date_epoch_after_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same as above for the absent-ambient-value case: an exception after the
+    override must still leave SOURCE_DATE_EPOCH absent, not stuck at the dep
+    epoch."""
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+    _mock_network(monkeypatch, console_scripts=None)
+    monkeypatch.setattr(bdp, "stage_wheel", _raise_stage_wheel)
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+
+    with pytest.raises(RuntimeError, match="boom: stage_wheel exploded"):
+        bdp.build_dep_pkg(_build_args(ports_root, tmp_path / "out"))
 
     assert "SOURCE_DATE_EPOCH" not in os.environ
 

--- a/tests/test_build_dep_pkg_portable.py
+++ b/tests/test_build_dep_pkg_portable.py
@@ -17,6 +17,7 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
 import subprocess
 import sys
 import tarfile
@@ -299,6 +300,44 @@ def test_fetch_verified_sdist_all_mirrors_failing_raises(tmp_path: Path, monkeyp
 
 
 # --------------------------------------------------------------------------- #
+# sdist_epoch — the dependency's OWN timestamp (newest member mtime inside the
+# verified sdist), never the build clock or ambient SOURCE_DATE_EPOCH
+# (issue #2454).
+# --------------------------------------------------------------------------- #
+
+
+def _write_sdist_tar(dest: Path, mtimes: list[int]) -> None:
+    with tarfile.open(dest, "w:gz") as tf:
+        for i, mtime in enumerate(mtimes):
+            data = f"member {i}".encode()
+            info = tarfile.TarInfo(name=f"pkg/file{i}.txt")
+            info.size = len(data)
+            info.mtime = mtime
+            tf.addfile(info, io.BytesIO(data))
+
+
+def test_sdist_epoch_is_the_newest_member_mtime(tmp_path: Path) -> None:
+    sdist = tmp_path / "fake.tar.gz"
+    _write_sdist_tar(sdist, [100, 300, 200])
+    assert bdp.sdist_epoch(sdist) == 300
+
+
+def test_sdist_epoch_refuses_empty_tar(tmp_path: Path) -> None:
+    sdist = tmp_path / "empty.tar.gz"
+    with tarfile.open(sdist, "w:gz"):
+        pass
+    with pytest.raises(bdp.DepPkgError, match="mtime"):
+        bdp.sdist_epoch(sdist)
+
+
+def test_sdist_epoch_refuses_all_zero_mtimes(tmp_path: Path) -> None:
+    sdist = tmp_path / "zero.tar.gz"
+    _write_sdist_tar(sdist, [0, 0])
+    with pytest.raises(bdp.DepPkgError, match="mtime"):
+        bdp.sdist_epoch(sdist)
+
+
+# --------------------------------------------------------------------------- #
 # Wheel build — exactly one PURE wheel, or refuse.
 # --------------------------------------------------------------------------- #
 
@@ -516,10 +555,26 @@ def test_stage_wheel_without_entry_points_yields_no_scripts(tmp_path: Path) -> N
 # --------------------------------------------------------------------------- #
 
 
-def _mock_network(monkeypatch: pytest.MonkeyPatch, *, console_scripts: str | None) -> None:
+# The sdist's own release stamp — fixed so `sdist_epoch()` has a real member
+# mtime to read, independent of whatever ambient SOURCE_DATE_EPOCH a test sets.
+_FAKE_SDIST_MTIME = 1700000000
+
+
+def _write_fake_sdist(dest: Path, *, mtime: int = _FAKE_SDIST_MTIME) -> None:
+    with tarfile.open(dest, "w:gz") as tf:
+        data = b"Metadata-Version: 1.0\n"
+        info = tarfile.TarInfo(name="charset_normalizer-3.4.4/PKG-INFO")
+        info.size = len(data)
+        info.mtime = mtime
+        tf.addfile(info, io.BytesIO(data))
+
+
+def _mock_network(
+    monkeypatch: pytest.MonkeyPatch, *, console_scripts: str | None, sdist_mtime: int = _FAKE_SDIST_MTIME
+) -> None:
     def fake_fetch(port: Any, dest_dir: Path, *, sha256: str, size: int) -> Path:
         dest = dest_dir / f"{port.distname}.tar.gz"
-        dest.write_bytes(b"mocked sdist bytes -- fetch is not exercised here")
+        _write_fake_sdist(dest, mtime=sdist_mtime)
         return dest
 
     def fake_build_wheel(sdist: Path, work_dir: Path) -> Path:
@@ -618,6 +673,87 @@ def test_build_dep_pkg_derives_portname_from_flavor_prefix(tmp_path: Path, monke
 
 
 # --------------------------------------------------------------------------- #
+# Ambient SOURCE_DATE_EPOCH independence (issue #2454): dep .pkg bytes are a
+# function of the pinned sdist ONLY, never the caller's ambient project epoch.
+# --------------------------------------------------------------------------- #
+
+
+def test_build_dep_pkg_bytes_do_not_depend_on_ambient_source_date_epoch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+    _mock_network(monkeypatch, console_scripts=None)
+
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1")
+    out_path1 = bdp.build_dep_pkg(_build_args(ports_root, tmp_path / "out1"))
+    assert os.environ["SOURCE_DATE_EPOCH"] == "1", "ambient value must be restored after the call"
+
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "2")
+    out_path2 = bdp.build_dep_pkg(_build_args(ports_root, tmp_path / "out2"))
+    assert os.environ["SOURCE_DATE_EPOCH"] == "2", "ambient value must be restored after the call"
+
+    assert out_path1.read_bytes() == out_path2.read_bytes(), (
+        "two builds of the same dep under different ambient SOURCE_DATE_EPOCH must be byte-identical"
+    )
+
+    for out_path in (out_path1, out_path2):
+        full = _read_full_manifest(out_path)
+        for install_path, entry in full["files"].items():
+            assert entry["mtime"] == _FAKE_SDIST_MTIME, f"{install_path}: manifest mtime must be the sdist epoch"
+
+        tar_bytes = pfb_pkg.zstd_decompress(out_path.read_bytes())
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+            for member in tf.getmembers():
+                if member.name in ("+MANIFEST", "+COMPACT_MANIFEST"):
+                    continue
+                assert member.mtime == _FAKE_SDIST_MTIME, f"{member.name}: tar mtime must be the sdist epoch"
+
+
+def test_build_dep_pkg_restores_absent_source_date_epoch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+    _mock_network(monkeypatch, console_scripts=None)
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+
+    bdp.build_dep_pkg(_build_args(ports_root, tmp_path / "out"))
+
+    assert "SOURCE_DATE_EPOCH" not in os.environ
+
+
+def test_build_wheel_runs_pip_with_the_dep_epoch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """build_wheel() is stubbed entirely here (like _mock_network does) — so
+    assert the dep epoch is live in os.environ["SOURCE_DATE_EPOCH"] at the
+    moment build_wheel() is called (the mechanism that makes the real `pip
+    wheel` subprocess, which copies os.environ, stamp the wheel with it)."""
+    ports_root = tmp_path / "ports"
+    _write_port(ports_root)
+
+    def fake_fetch(port: Any, dest_dir: Path, *, sha256: str, size: int) -> Path:
+        dest = dest_dir / f"{port.distname}.tar.gz"
+        _write_fake_sdist(dest)
+        return dest
+
+    captured: list[str | None] = []
+
+    def fake_build_wheel(sdist: Path, work_dir: Path) -> Path:
+        captured.append(os.environ.get("SOURCE_DATE_EPOCH"))
+        wheel_dir = work_dir / "wheel"
+        wheel_dir.mkdir(parents=True, exist_ok=True)
+        wheel = wheel_dir / "charset_normalizer-3.4.4-py3-none-any.whl"
+        _write_wheel(wheel, files={"charset_normalizer/__init__.py": b"x = 1\n"}, entry_points=None)
+        return wheel
+
+    monkeypatch.setattr(bdp, "fetch_verified_sdist", fake_fetch)
+    monkeypatch.setattr(bdp, "build_wheel", fake_build_wheel)
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "999")
+
+    bdp.build_dep_pkg(_build_args(ports_root, tmp_path / "out"))
+
+    assert captured == [str(_FAKE_SDIST_MTIME)]
+
+
+# --------------------------------------------------------------------------- #
 # CLI wiring
 # --------------------------------------------------------------------------- #
 
@@ -664,7 +800,7 @@ def test_main_stdout_is_only_the_pkg_path_line(
 
     def fake_fetch(port: Any, dest_dir: Path, *, sha256: str, size: int) -> Path:
         dest = dest_dir / f"{port.distname}.tar.gz"
-        dest.write_bytes(b"mocked sdist bytes")
+        _write_fake_sdist(dest)
         return dest
 
     def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
Fixes #2454.

## What

`scripts/build-dep-pkg-portable.py` builds dependency packages with an mtime derived from the **dependency's own pinned sdist** (newest member timestamp of the sha256-verified tarball, `sdist_epoch()`), setting `SOURCE_DATE_EPOCH` to that value for `pip wheel` + `write_pkg` and restoring the caller's ambient value afterwards. Before, the ambient `SOURCE_DATE_EPOCH` — the pfBlockerNG source commit's epoch, exported by `nightly.yml`/`release.yml` for the project build — leaked into every dependency `.pkg`, so a Nightly from a new source commit produced a byte-different `py311-charset-normalizer-3.4.4.pkg` and `publish_nightly.py` aborted on the shared-bytes rule (run 31946942035).

`build-pkg-portable.py` is untouched: the project package keeps honouring the ambient epoch.

## Tests

- `test_sdist_epoch_*` (newest member mtime; empty / all-zero refused)
- `test_build_dep_pkg_bytes_do_not_depend_on_ambient_source_date_epoch` — same port built under `SOURCE_DATE_EPOCH=1` and `=2` → byte-identical archives; tar member and manifest `files[*].mtime` equal the sdist epoch; ambient restored
- `test_build_dep_pkg_restores_absent_source_date_epoch`, `test_build_wheel_runs_pip_with_the_dep_epoch`
- Red 5 failed / green 46 passed (re-executed by an independent verifier with the final test file); full docker suite 5458 passed; `run-gates.sh --diff origin/devel` PASS.
- Real-world probe: `textproc/py-charset-normalizer` built twice from `pfBlockerNG/FreeBSD-ports@pfblockerng/use-github` under different ambient epochs → `cmp` identical (sha256 `51e732d6…`).

Live-tree note: the copies of `py311-charset-normalizer-3.4.4.pkg` already published before this fix carry clock/commit-derived mtimes and will differ from every future build. The Nightly copies were removed by hand once (pkg `bbc46e4`); the next Nightly republished them (pkg `a4145a928`) and a second Nightly on top of that published cleanly (the collision this PR fixes) — both runs used this branch's tools against `devel` source. The tagged copies on edge/testing/stable cannot be removed the same way (served catalogues, no republish possible pre-GA); that is #2457, `ready-for-human`.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency packages now use the source archive’s newest valid timestamp for generated files and package metadata.
  * Builds reject source archives without usable timestamps.
  * Ambient timestamp settings no longer affect package reproducibility and are restored after builds.

* **Tests**
  * Added coverage for timestamp selection, invalid archives, reproducible package output, and environment restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
