### PR TITLE
build-repo: retry pkg repo once on libpkg SIGABRT (#2447 residual)

### DIFF
--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -331,6 +331,12 @@ _pkg_repo_rc=0
 env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir" || _pkg_repo_rc=$?
 if [ "$_pkg_repo_rc" -eq 134 ]; then
     echo "build-repo: pkg repo aborted (rc=134) — retrying once (#2447)" >&2
+    # An aborted first run can leave a truncated descriptor. Retrying on
+    # top of it is the #2386 "descriptor exists ≠ complete" class. Drop
+    # only catalog files — keep the payload .pkg copies already laid out.
+    for _desc in meta meta.conf packagesite.pkg data.pkg packagesite.yaml data; do
+        rm -f "${dir}/${_desc}"
+    done
     _pkg_repo_rc=0
     env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir" || _pkg_repo_rc=$?
 fi

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -324,6 +324,19 @@ done
 echo "==> pkg repo ${dir}" >&2
 # No key argument => an unsigned (NONE-signed) catalog. ASSUME_ALWAYS_YES so
 # pkg never prompts in CI.
-env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir"
+# Retry ONCE on SIGABRT (rc=134): guest jemalloc assertion inside libpkg
+# (issue #2447). Any other non-zero exits immediately. Do not re-run this
+# script — the bucket was already wiped above.
+_pkg_repo_rc=0
+env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir" || _pkg_repo_rc=$?
+if [ "$_pkg_repo_rc" -eq 134 ]; then
+    echo "build-repo: pkg repo aborted (rc=134) — retrying once (#2447)" >&2
+    _pkg_repo_rc=0
+    env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir" || _pkg_repo_rc=$?
+fi
+[ "$_pkg_repo_rc" -eq 0 ] || {
+    echo "build-repo: pkg repo ${dir} failed (rc=${_pkg_repo_rc})" >&2
+    exit "$_pkg_repo_rc"
+}
 
 echo "==> built catalog (release channel) at release/${VARVER}" >&2

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -324,13 +324,17 @@ done
 echo "==> pkg repo ${dir}" >&2
 # No key argument => an unsigned (NONE-signed) catalog. ASSUME_ALWAYS_YES so
 # pkg never prompts in CI.
-# Retry ONCE on SIGABRT (rc=134): guest jemalloc assertion inside libpkg
-# (issue #2447). Any other non-zero exits immediately. Do not re-run this
-# script — the bucket was already wiped above.
+# Retry ONCE on SIGABRT (rc=134 = 128+6). One run printed a jemalloc
+# size-class assertion then Abort trap (#2447) — that is a death site,
+# not a proven root cause. Any other non-zero exits immediately. Do not
+# re-run this script — the bucket was already wiped above.
 _pkg_repo_rc=0
 env ASSUME_ALWAYS_YES=yes "$PKG_BIN" repo "$dir" || _pkg_repo_rc=$?
 if [ "$_pkg_repo_rc" -eq 134 ]; then
-    echo "build-repo: pkg repo aborted (rc=134) — retrying once (#2447)" >&2
+    echo "PFB_2447_RETRY pkg repo ${dir} aborted (rc=134) — retrying once" >&2
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        echo "::notice title=PFB_2447_RETRY::pkg repo ${dir} aborted (rc=134); retrying once. Count these; escalate if frequent or if the second attempt aborts." >&2
+    fi
     # An aborted first run can leave a truncated descriptor. Retrying on
     # top of it is the #2386 "descriptor exists ≠ complete" class. Drop
     # only catalog files — keep the payload .pkg copies already laid out.

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -282,6 +282,7 @@ EOF
   It 'drops truncated first-run descriptors before the retry'
     When call run_build_2447 abort-once
     The status should be success
+    The stderr should include 'retrying once (#2447)'
     The contents of file "${work}/out/release/ce-2.8/packagesite.pkg" should equal 'COMPLETE'
     The contents of file "${work}/out/release/ce-2.8/meta.conf" should equal 'COMPLETE'
     # Payload copies survive the descriptor wipe.

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -194,3 +194,82 @@ EOF
     The stderr should include 'FLAVOR COLLISION'
   End
 End
+
+Describe 'build-repo.sh pkg repo abort retry (issue #2447)'
+  # The layout stub above always succeeds on `pkg repo`. These rows use a
+  # counting stub so a first-try SIGABRT (rc=134) is retried once, and an
+  # ordinary rc=1 is not.
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/brrepo2447.XXXXXX")"
+    mkdir -p "${work}/bin" "${work}/in" "${work}/out"
+    : > "${work}/repo.count"
+
+    cat > "${work}/bin/pkg" <<'EOF'
+#!/bin/sh
+cmd="$1"; shift
+case "$cmd" in
+	query)
+		[ "$1" = "-F" ] || exit 64
+		f="$2"; fmt="$3"
+		name="$(sed -n 's/^name=//p' "$f")"
+		version="$(sed -n 's/^version=//p' "$f")"
+		abi="$(sed -n 's/^abi=//p' "$f")"
+		case "$fmt" in
+			'%q')    printf '%s\n' "$abi" ;;
+			'%n %v') printf '%s %s\n' "$name" "$version" ;;
+			'%n-%v') printf '%s-%s\n' "$name" "$version" ;;
+			'%dn')   sed -n 's/^dep=//p' "$f" ;;
+			*) exit 64 ;;
+		esac ;;
+	repo)
+		n=0
+		[ -f "${PFB_REPO_STUB_COUNT}" ] && n=$(cat "${PFB_REPO_STUB_COUNT}")
+		n=$((n + 1))
+		printf '%s\n' "$n" > "${PFB_REPO_STUB_COUNT}"
+		case "${PFB_REPO_STUB_MODE:-ok}" in
+			abort-once)
+				[ "$n" -eq 1 ] && exit 134
+				touch "$1/packagesite.pkg"
+				;;
+			fail)
+				echo "pkg: No such file or directory" >&2
+				exit 1
+				;;
+			*)
+				touch "$1/packagesite.pkg"
+				;;
+		esac ;;
+	*) exit 64 ;;
+esac
+EOF
+    chmod +x "${work}/bin/pkg"
+    printf 'name=%s\nversion=%s\nabi=%s\n' pfSense-pkg-pfBlockerNG 4.0.1 'FreeBSD:15:*' \
+      > "${work}/in/a.pkg"
+  }
+  cleanup() { rm -rf "$work"; }
+  Before 'setup'
+  After 'cleanup'
+
+  run_build() {
+    PATH="${work}/bin:${PATH}" PKG_BIN=pkg \
+      PFB_REPO_STUB_COUNT="${work}/repo.count" \
+      PFB_REPO_STUB_MODE="$1" \
+      sh "${PFB_ROOT}/scripts/build-repo.sh" --in "${work}/in" --out "${work}/out" --varver ce-2.8
+  }
+
+  It 'retries pkg repo once after rc=134 and ships the catalog'
+    When call run_build abort-once
+    The status should be success
+    The stderr should include 'retrying once (#2447)'
+    The path "${work}/out/release/ce-2.8/packagesite.pkg" should be exist
+    The contents of file "${work}/repo.count" should equal '2'
+  End
+
+  It 'does not retry an ordinary pkg repo failure'
+    When call run_build fail
+    The status should equal 1
+    The stderr should include 'failed (rc=1)'
+    The stderr should not include 'retrying once'
+    The contents of file "${work}/repo.count" should equal '1'
+  End
+End

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -201,7 +201,7 @@ Describe 'build-repo.sh pkg repo abort retry (issue #2447)'
   setup_2447() {
     work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/brrepo2447.XXXXXX")"
     mkdir -p "${work}/bin" "${work}/in" "${work}/out"
-    : > "${work}/repo.count"
+    true > "${work}/repo.count"
 
     cat > "${work}/bin/pkg" <<'EOF'
 #!/bin/sh

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -196,10 +196,9 @@ EOF
 End
 
 Describe 'build-repo.sh pkg repo abort retry (issue #2447)'
-  # The layout stub above always succeeds on `pkg repo`. These rows use a
-  # counting stub so a first-try SIGABRT (rc=134) is retried once, and an
-  # ordinary rc=1 is not.
-  setup() {
+  # Own helper names: a second `setup`/`cleanup` in this file would overwrite
+  # the layout block's functions (shellspec loads the whole file first).
+  setup_2447() {
     work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/brrepo2447.XXXXXX")"
     mkdir -p "${work}/bin" "${work}/in" "${work}/out"
     : > "${work}/repo.count"
@@ -228,15 +227,30 @@ case "$cmd" in
 		printf '%s\n' "$n" > "${PFB_REPO_STUB_COUNT}"
 		case "${PFB_REPO_STUB_MODE:-ok}" in
 			abort-once)
-				[ "$n" -eq 1 ] && exit 134
-				touch "$1/packagesite.pkg"
+				if [ "$n" -eq 1 ]; then
+					# Truncated first-run descriptors. A retry that
+					# does not unlink them would ship these as the
+					# catalog (#2386: descriptor exists ≠ complete).
+					printf 'TRUNCATED\n' > "$1/packagesite.pkg"
+					printf 'TRUNCATED\n' > "$1/meta.conf"
+					exit 134
+				fi
+				# Second run: if a leftover descriptor is still here,
+				# leave it — that is the fail-open we are pinning.
+				# Only write COMPLETE when the retry started clean.
+				if [ -f "$1/packagesite.pkg" ] || [ -f "$1/meta.conf" ]; then
+					:
+				else
+					printf 'COMPLETE\n' > "$1/packagesite.pkg"
+					printf 'COMPLETE\n' > "$1/meta.conf"
+				fi
 				;;
 			fail)
 				echo "pkg: No such file or directory" >&2
 				exit 1
 				;;
 			*)
-				touch "$1/packagesite.pkg"
+				printf 'COMPLETE\n' > "$1/packagesite.pkg"
 				;;
 		esac ;;
 	*) exit 64 ;;
@@ -246,11 +260,11 @@ EOF
     printf 'name=%s\nversion=%s\nabi=%s\n' pfSense-pkg-pfBlockerNG 4.0.1 'FreeBSD:15:*' \
       > "${work}/in/a.pkg"
   }
-  cleanup() { rm -rf "$work"; }
-  Before 'setup'
-  After 'cleanup'
+  cleanup_2447() { rm -rf "$work"; }
+  Before 'setup_2447'
+  After 'cleanup_2447'
 
-  run_build() {
+  run_build_2447() {
     PATH="${work}/bin:${PATH}" PKG_BIN=pkg \
       PFB_REPO_STUB_COUNT="${work}/repo.count" \
       PFB_REPO_STUB_MODE="$1" \
@@ -258,15 +272,24 @@ EOF
   }
 
   It 'retries pkg repo once after rc=134 and ships the catalog'
-    When call run_build abort-once
+    When call run_build_2447 abort-once
     The status should be success
     The stderr should include 'retrying once (#2447)'
     The path "${work}/out/release/ce-2.8/packagesite.pkg" should be exist
     The contents of file "${work}/repo.count" should equal '2'
   End
 
+  It 'drops truncated first-run descriptors before the retry'
+    When call run_build_2447 abort-once
+    The status should be success
+    The contents of file "${work}/out/release/ce-2.8/packagesite.pkg" should equal 'COMPLETE'
+    The contents of file "${work}/out/release/ce-2.8/meta.conf" should equal 'COMPLETE'
+    # Payload copies survive the descriptor wipe.
+    The path "${work}/out/release/ce-2.8/pfSense-pkg-pfBlockerNG-4.0.1.pkg" should be exist
+  End
+
   It 'does not retry an ordinary pkg repo failure'
-    When call run_build fail
+    When call run_build_2447 fail
     The status should equal 1
     The stderr should include 'failed (rc=1)'
     The stderr should not include 'retrying once'

--- a/tests/shell/build_repo_layout_spec.sh
+++ b/tests/shell/build_repo_layout_spec.sh
@@ -274,7 +274,7 @@ EOF
   It 'retries pkg repo once after rc=134 and ships the catalog'
     When call run_build_2447 abort-once
     The status should be success
-    The stderr should include 'retrying once (#2447)'
+    The stderr should include 'PFB_2447_RETRY'
     The path "${work}/out/release/ce-2.8/packagesite.pkg" should be exist
     The contents of file "${work}/repo.count" should equal '2'
   End
@@ -282,7 +282,7 @@ EOF
   It 'drops truncated first-run descriptors before the retry'
     When call run_build_2447 abort-once
     The status should be success
-    The stderr should include 'retrying once (#2447)'
+    The stderr should include 'PFB_2447_RETRY'
     The contents of file "${work}/out/release/ce-2.8/packagesite.pkg" should equal 'COMPLETE'
     The contents of file "${work}/out/release/ce-2.8/meta.conf" should equal 'COMPLETE'
     # Payload copies survive the descriptor wipe.

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -308,25 +308,31 @@ def build_guest_repo(vm: SmokeVM, repo_dir: str, pkg_files: list[Path]) -> None:
     pkg_repo_index(vm, repo_dir)
 
 
-# `pkg repo` exit status when libpkg aborts (SIGABRT, 128+6) — the guest's jemalloc runs
-# with assertions on and once in many runs trips one inside libpkg
-# (`Failed assertion: "alloc_ctx.szind != SC_NSIZES"` … `Abort trap`, issue #2447).
+# rc=134 is SIGABRT (128+6). One observed death site is jemalloc asserting
+# on a size-class index (`alloc_ctx.szind != SC_NSIZES`); that is not a
+# proven libpkg root cause (issue #2447).
 _PKG_REPO_ABORT_RC = 134
 
 
 def pkg_repo_index(vm: SmokeVM, repo_dir: str) -> None:
     """``pkg repo <dir>`` on the guest — no key argument => an unsigned catalog.
 
-    Retries ONCE, and only when ``pkg`` itself died on SIGABRT (issue #2447): a
-    transient libpkg crash, not a property of the catalog under test. Any other
-    non-zero exit raises on the first try, exactly as before.
+    Retries ONCE, and only when ``pkg`` itself died on SIGABRT (issue #2447).
+    That abort is a death site (one run: jemalloc size-class assertion), not
+    a diagnosed root cause. Any other non-zero exit raises on the first try.
     """
     remote = ("env", "ASSUME_ALWAYS_YES=yes", "pkg", "repo", repo_dir)
     result = vm.ssh(*remote, timeout=180.0)
     if result.returncode == _PKG_REPO_ABORT_RC:
         print(
-            f"PFB_NOTE pkg repo {repo_dir} aborted (rc={result.returncode}) — retrying once (#2447):\n{result.stderr}"
+            f"PFB_2447_RETRY pkg repo {repo_dir} aborted (rc={result.returncode}) — retrying once:\n{result.stderr}"
         )
+        if os.environ.get("GITHUB_ACTIONS"):
+            print(
+                f"::notice title=PFB_2447_RETRY::pkg repo {repo_dir} aborted "
+                f"(rc={result.returncode}); retrying once. Count these; escalate "
+                "if frequent or if the second attempt aborts."
+            )
         result = vm.ssh(*remote, timeout=180.0)
     if result.returncode != 0:
         raise RuntimeError(
@@ -350,9 +356,8 @@ def build_repo_via_script(vm: SmokeVM, pkg_files: list[Path]) -> str:
     catalog triple ``pkg repo`` emits) is accepted by a real pfSense box, the
     live half of the build-side premise.
     """
-    # The script's own `pkg repo` runs un-retried (not routed through pkg_repo_index): the
-    # #2447 abort has only ever been seen on the direct call, and retrying here would mean
-    # re-running the whole script under test.
+    # The script's own `pkg repo` now retries once on rc=134 inside build-repo.sh.
+    # Do not wrap the whole script here — that would wipe the bucket again.
     real_varver = _box_real_varver(vm)
     _ssh_check(vm, "/bin/rm", "-rf", GUEST_PKG_IN_DIR, SCRIPT_REPO_ROOT)
     _ssh_check(vm, "/bin/mkdir", "-p", GUEST_PKG_IN_DIR, GUEST_SPIKE_DIR)

--- a/tests/test_issue2447_pkg_repo_abort_retry.py
+++ b/tests/test_issue2447_pkg_repo_abort_retry.py
@@ -1,7 +1,7 @@
-"""Issue #2447: ``pkg repo`` on the guest can SIGABRT (rc=134) inside libpkg (a jemalloc
-invalid-free assertion) once in many runs, on an input that indexes fine on the very
-next run. The catalog build retries that abort ONCE — and only that abort: any other
-failure (an rc=1 with a real error) still surfaces on the first try.
+"""Issue #2447: ``pkg repo`` on the guest can SIGABRT (rc=134). One run printed a
+jemalloc size-class assertion then Abort trap; the same input usually indexes.
+That line is a death site, not a root cause. The catalog build retries that abort
+ONCE — and only that abort: any other failure still surfaces on the first try.
 """
 
 from __future__ import annotations
@@ -40,8 +40,24 @@ def test_pkg_repo_retries_a_libpkg_abort_once(capsys: pytest.CaptureFixture[str]
 
     assert vm.calls == [PKG_REPO, PKG_REPO]
     out = capsys.readouterr().out
-    assert f"PFB_NOTE pkg repo {UPGRADE_REPO_DIR} aborted (rc=134)" in out
+    assert f"PFB_2447_RETRY pkg repo {UPGRADE_REPO_DIR} aborted (rc=134)" in out
     assert ABORT_STDERR in out
+    assert "::notice title=PFB_2447_RETRY::" not in out
+
+
+def test_pkg_repo_retry_emits_a_countable_actions_notice(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    aborted = subprocess.CompletedProcess((), 134, "", ABORT_STDERR)
+    success = subprocess.CompletedProcess((), 0, "", "")
+    vm = _FakeVM([aborted, success])
+
+    pkg_repo_index(vm, UPGRADE_REPO_DIR)  # type: ignore[arg-type]
+
+    out = capsys.readouterr().out
+    assert "PFB_2447_RETRY" in out
+    assert "::notice title=PFB_2447_RETRY::" in out
 
 
 def test_pkg_repo_second_abort_raises_with_the_abort_output() -> None:

--- a/tests/test_issue2447_pkg_repo_abort_retry.py
+++ b/tests/test_issue2447_pkg_repo_abort_retry.py
@@ -62,6 +62,15 @@ def test_pkg_repo_second_abort_raises_with_the_abort_output() -> None:
     assert len(vm.calls) == 2
 
 
+def test_pkg_repo_first_success_does_not_retry() -> None:
+    success = subprocess.CompletedProcess((), 0, "", "")
+    vm = _FakeVM([success])
+
+    pkg_repo_index(vm, UPGRADE_REPO_DIR)  # type: ignore[arg-type]
+
+    assert vm.calls == [PKG_REPO]
+
+
 def test_pkg_repo_does_not_retry_an_ordinary_failure() -> None:
     failure = subprocess.CompletedProcess((), 1, "", "pkg: /tmp/pfb_repo_spike/upgrade: No such file or directory\n")
     vm = _FakeVM([failure])


### PR DESCRIPTION
Refs #2447 (residual after #2452). **Do not merge from this session — waiting for other agents.**

#2452 retried the **direct** guest `pkg repo` in `pkg_repo_index`. `build-repo.sh` still ran a single `pkg repo` after wiping the bucket. The abort is a guest jemalloc assertion, not a property of the inline caller, so `test_build_repo_script_catalog_is_accepted` was still exposed.

This retries **that one command** once, only on rc=134, then exits. Re-running the script would `rm -rf` the bucket again.

Pinned in `tests/shell/build_repo_layout_spec.sh` (abort-once → catalog; rc=1 → no retry) and a first-success row on `pkg_repo_index`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository creation now retries once when the package tool exits unexpectedly.
  * Other repository creation failures are reported and handled without unnecessary retries.
  * Successful repository creation runs only once.

* **Tests**
  * Added coverage for retry behavior, failure handling, catalog creation, and successful single-run execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->