### PR TITLE
ci: key smoke-single self-build pkg/deppkgs artifacts on pfsense_version (#2453)

### DIFF
--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -57,7 +57,7 @@ on:
         required: false
         default: "pfblockerng/use-github"
       artifact_name:
-        description: "Name of the uploaded .pkg artifact. Override to keep per-leg builds distinct in one run (the smoke fan-out builds a CE + a Plus .pkg in the same workflow run)."
+        description: "Name of the uploaded .pkg artifact. Override to keep per-leg builds distinct in one run — one name per matrix row (the fan-outs build CE 2.8/2.9 + Plus .pkgs in the same workflow run; image_name alone is not unique, issue #2453)."
         required: false
         default: "pfBlockerNG-pkg"
       extra_pkgs:
@@ -65,7 +65,7 @@ on:
         required: false
         default: "[]"
       dep_artifact_name:
-        description: "Name for the uploaded dep-pkgs artifact (ignored when extra_pkgs is empty). Blank (default) -> pfBlockerNG-deppkgs-fbsd<freebsd_major>, the self-build convention (one per major, safe when the caller's fan-out never builds two same-major rows in one run). A caller whose fan-out IS per-version (e.g. smoke.yml/ui-tests.yml matrixing over leg rows) must override this with a per-row-unique name (e.g. append -<image_name>) or two same-major rows collide on upload."
+        description: "Name for the uploaded dep-pkgs artifact (ignored when extra_pkgs is empty). Blank (default) -> pfBlockerNG-deppkgs-fbsd<freebsd_major>, the self-build convention (one per major, safe when the caller's fan-out never builds two same-major rows in one run). A caller whose fan-out IS per-version (e.g. smoke.yml/ui-tests.yml matrixing over leg rows) must override this with a per-row-unique name (e.g. append -<image_name>-<pfsense_version>; image_name alone is NOT unique — CE 2.8 and CE 2.9 share it, issue #2453) or two same-major rows collide on upload."
         required: false
         default: ""
   workflow_call:
@@ -104,7 +104,7 @@ on:
         type: string
         default: "[]"
       dep_artifact_name:
-        description: "Name for the uploaded dep-pkgs artifact (ignored when extra_pkgs is empty). Blank (default) -> pfBlockerNG-deppkgs-fbsd<freebsd_major>, the self-build convention (one per major, safe when the caller's fan-out never builds two same-major rows in one run). A caller whose fan-out IS per-version (e.g. smoke.yml/ui-tests.yml matrixing over leg rows) must override this with a per-row-unique name (e.g. append -<image_name>) or two same-major rows collide on upload."
+        description: "Name for the uploaded dep-pkgs artifact (ignored when extra_pkgs is empty). Blank (default) -> pfBlockerNG-deppkgs-fbsd<freebsd_major>, the self-build convention (one per major, safe when the caller's fan-out never builds two same-major rows in one run). A caller whose fan-out IS per-version (e.g. smoke.yml/ui-tests.yml matrixing over leg rows) must override this with a per-row-unique name (e.g. append -<image_name>-<pfsense_version>; image_name alone is NOT unique — CE 2.8 and CE 2.9 share it, issue #2453) or two same-major rows collide on upload."
         required: false
         type: string
         default: ""

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -129,7 +129,7 @@ on:
         required: false
         default: "[]"
       dep_artifact:
-        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<image_name>-s<shard>."
+        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<image_name>-<pfsense_version>-s<shard>."
         required: false
         default: ""
       checkout_ref:
@@ -255,7 +255,7 @@ on:
         type: string
         default: "[]"
       dep_artifact:
-        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<image_name>-s<shard>."
+        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<image_name>-<pfsense_version>-s<shard>."
         required: false
         type: string
         default: ""
@@ -306,8 +306,11 @@ jobs:
       php_version: ${{ inputs.php_version }}
       py_flavor: ${{ inputs.py_flavor }}
       # Per-leg artifact name: the fan-out builds a CE and a Plus .pkg in ONE run,
-      # so a shared name would collide / cross-feed. Keying on image_name keeps each
-      # leg's artifact distinct (and the download below follows build-pkg.outputs.artifact).
+      # so a shared name would collide / cross-feed. Keying on image_name AND
+      # pfsense_version keeps each leg's artifact distinct (issue #2453: CE 2.8 and
+      # CE 2.9 share image_name=pfsense-ce, so image_name alone let the CE 2.9 leg
+      # download the CE 2.8 FreeBSD:15 .pkg -> "wrong architecture"); the download
+      # below follows build-pkg.outputs.artifact.
       # The `-s<shard>` suffix (issue #797) keys it further: two shards of the SAME
       # leg each build their own .pkg on THIS path — only reached when pkg_artifact
       # is blank, so it never collides with the shared per-leg artifact smoke.yml builds.
@@ -316,7 +319,7 @@ jobs:
       # the dynamic name GH assigned, never matched by this literal elsewhere), so the
       # major-collapse naming that matters for cross-workflow/cross-run consumers
       # (release.yml/smoke.yml) buys nothing here.
-      artifact_name: pfBlockerNG-pkg-${{ inputs.image_name }}-s${{ inputs.shard }}
+      artifact_name: pfBlockerNG-pkg-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}
       # Optional Option-A validation: point the .pkg build at a FreeBSD-ports branch
       # carrying a new plist entry. Blank -> build-pkg-linux's own defaults
       # (pfBlockerNG/FreeBSD-ports @ pfblockerng/use-github), so a normal run is unchanged.
@@ -328,11 +331,11 @@ jobs:
       # uploads its dep artifact, which the "Download dep packages" step below
       # (same workflow, same run) then downloads.
       extra_pkgs: ${{ inputs.extra_pkgs }}
-      # W1: mirror artifact_name's OWN discriminator (image_name + shard) — this
+      # W1: mirror artifact_name's OWN discriminator (image_name + pfsense_version + shard) — this
       # build-pkg job's matrix (indirectly, one invocation per caller-side leg)
       # can share a run with sibling invocations of THIS reusable workflow (e.g.
       # repo-install.yml's fan-out); the plain per-major default would collide.
-      dep_artifact_name: pfBlockerNG-deppkgs-${{ inputs.image_name }}-s${{ inputs.shard }}
+      dep_artifact_name: pfBlockerNG-deppkgs-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}
 
   smoke:
     name: pytest -m smoke (live pfSense VM)
@@ -558,7 +561,7 @@ jobs:
         if: ${{ inputs.extra_pkgs != '' && inputs.extra_pkgs != '[]' }}
         uses: actions/download-artifact@v8
         with:
-          name: ${{ inputs.dep_artifact != '' && inputs.dep_artifact || format('pfBlockerNG-deppkgs-{0}-s{1}', inputs.image_name, inputs.shard) }}
+          name: ${{ inputs.dep_artifact != '' && inputs.dep_artifact || format('pfBlockerNG-deppkgs-{0}-{1}-s{2}', inputs.image_name, inputs.pfsense_version, inputs.shard) }}
           path: deppkgs
 
       - name: Export SMOKE_DEP_PKGS

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -315,8 +315,9 @@ jobs:
       # leg each build their own .pkg on THIS path — only reached when pkg_artifact
       # is blank, so it never collides with the shared per-leg artifact smoke.yml builds.
       # issue #1806: deliberately NOT the fbsd<major> convention — this artifact is
-      # produced and consumed entirely within THIS run (via build-pkg.outputs.artifact,
-      # the dynamic name GH assigned, never matched by this literal elsewhere), so the
+      # produced and consumed entirely within THIS run (the .pkg download follows
+      # build-pkg.outputs.artifact, which build-pkg-linux.yml echoes from this
+      # artifact_name input; the dep download below repeats the dep literal), so the
       # major-collapse naming that matters for cross-workflow/cross-run consumers
       # (release.yml/smoke.yml) buys nothing here.
       artifact_name: pfBlockerNG-pkg-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -750,7 +750,7 @@ slice in as the leftmost pytest args; `smoke-on-box.sh` forwards `--shard`/`--sh
 unchanged and independently refuses N>1 for any non-`smoke` marker, including the UI tier (a
 small, non-module-fungible suite that always runs as one unit). Diagnostics stay per-shard: CI
 names each leg's artifacts `smoke-diagnostics-<image_name>-<pfsense_version>-s<I>` and
-`pfBlockerNG-pkg-<image_name>-s<I>` (two shards of one leg each build their own `.pkg` — a shared
+`pfBlockerNG-pkg-<image_name>-<pfsense_version>-s<I>` (two shards of one leg each build their own `.pkg` — a shared
 cross-shard build is a deferred optimisation); local runs get one log file per shard under the
 `--shards` run's kept log dir.
 

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -750,9 +750,9 @@ slice in as the leftmost pytest args; `smoke-on-box.sh` forwards `--shard`/`--sh
 unchanged and independently refuses N>1 for any non-`smoke` marker, including the UI tier (a
 small, non-module-fungible suite that always runs as one unit). Diagnostics stay per-shard: CI
 names each leg's artifacts `smoke-diagnostics-<image_name>-<pfsense_version>-s<I>` and
-`pfBlockerNG-pkg-<image_name>-<pfsense_version>-s<I>` (two shards of one leg each build their own `.pkg` — a shared
-cross-shard build is a deferred optimisation); local runs get one log file per shard under the
-`--shards` run's kept log dir.
+`pfBlockerNG-pkg-<image_name>-<pfsense_version>-s<I>` (`pfBlockerNG-deppkgs-…` likewise; two shards
+of one leg each build their own `.pkg` — a shared cross-shard build is a deferred optimisation);
+local runs get one log file per shard under the `--shards` run's kept log dir.
 
 **Duration-balanced module sharding (#816).** `shard-modules.sh` splits by measured LOAD, not
 blind position, when it can: if `<test-dir>/module-durations.txt` exists it assigns modules by

--- a/tests/test_issue2453_smoke_single_artifact_names.py
+++ b/tests/test_issue2453_smoke_single_artifact_names.py
@@ -43,9 +43,30 @@ def test_dep_download_fallback_matches_self_build_name() -> None:
     assert DEP_DOWNLOAD in lines[0], lines[0]
 
 
+LEGACY_FORMS = (
+    "pfBlockerNG-pkg-${{ inputs.image_name }}-s${{",
+    "pfBlockerNG-deppkgs-${{ inputs.image_name }}-s${{",
+    "format('pfBlockerNG-deppkgs-{0}-s{1}', inputs.image_name, inputs.shard)",
+    "<image_name>-s<shard>",
+)
+
+
 def test_no_image_name_only_pkg_names_remain() -> None:
     text = SMOKE_SINGLE_WORKFLOW.read_text(encoding="utf-8")
-    assert "pfBlockerNG-pkg-${{ inputs.image_name }}-s${{" not in text
-    assert "pfBlockerNG-deppkgs-${{ inputs.image_name }}-s${{" not in text
-    assert "format('pfBlockerNG-deppkgs-{0}-s{1}', inputs.image_name, inputs.shard)" not in text
-    assert "<image_name>-s<shard>" not in text
+    for legacy in LEGACY_FORMS:
+        assert legacy not in text, legacy
+
+
+def test_legacy_forms_are_what_the_pre_fix_workflow_carried() -> None:
+    """Fixture for the negative sweep above: rebuild the pre-#2453 text by dropping
+    pfsense_version from every fixed site and check each LEGACY_FORMS entry hits it, so
+    a typo in a legacy pattern cannot turn the sweep vacuous."""
+    text = SMOKE_SINGLE_WORKFLOW.read_text(encoding="utf-8")
+    pre_fix = (
+        text.replace("-${{ inputs.pfsense_version }}-s${{", "-s${{")
+        .replace(DEP_DOWNLOAD, "format('pfBlockerNG-deppkgs-{0}-s{1}', inputs.image_name, inputs.shard)")
+        .replace("<image_name>-<pfsense_version>-s<shard>", "<image_name>-s<shard>")
+    )
+    assert pre_fix != text
+    for legacy in LEGACY_FORMS:
+        assert legacy in pre_fix, legacy

--- a/tests/test_issue2453_smoke_single_artifact_names.py
+++ b/tests/test_issue2453_smoke_single_artifact_names.py
@@ -1,0 +1,51 @@
+"""Pin issue #2453: smoke-single.yml's self-build (pkg_artifact blank) path must key its
+pkg / dep-pkgs artifact names on pfsense_version too, not only image_name + shard.
+
+repo-install.yml fans smoke-single.yml out over the ci-metadata matrix, and CE 2.8 / CE 2.9
+share image_name=pfsense-ce (Plus legs share pfsense-plus). With image_name-only names two
+per-version legs of ONE run upload the same artifact name and the CE 2.9 leg can download the
+CE 2.8 (FreeBSD:15) .pkg -> `pkg: wrong architecture: FreeBSD:15:* instead of FreeBSD:16:amd64`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE_SINGLE_WORKFLOW = ROOT / ".github/workflows/smoke-single.yml"
+
+PKG_NAME = "pfBlockerNG-pkg-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}"
+DEP_NAME = "pfBlockerNG-deppkgs-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}"
+DEP_DOWNLOAD = "format('pfBlockerNG-deppkgs-{0}-{1}-s{2}', inputs.image_name, inputs.pfsense_version, inputs.shard)"
+
+
+def _lines() -> list[str]:
+    return SMOKE_SINGLE_WORKFLOW.read_text(encoding="utf-8").splitlines()
+
+
+def _value_lines(key: str) -> list[str]:
+    return [line.strip() for line in _lines() if line.strip().startswith(f"{key}:") and "${{" in line]
+
+
+def test_self_build_pkg_artifact_name_carries_pfsense_version() -> None:
+    lines = _value_lines("artifact_name")
+    assert lines == [f"artifact_name: {PKG_NAME}"], lines
+
+
+def test_self_build_dep_artifact_name_carries_pfsense_version() -> None:
+    lines = _value_lines("dep_artifact_name")
+    assert lines == [f"dep_artifact_name: {DEP_NAME}"], lines
+
+
+def test_dep_download_fallback_matches_self_build_name() -> None:
+    lines = [line for line in _lines() if "inputs.dep_artifact != ''" in line]
+    assert len(lines) == 1, lines
+    assert DEP_DOWNLOAD in lines[0], lines[0]
+
+
+def test_no_image_name_only_pkg_names_remain() -> None:
+    text = SMOKE_SINGLE_WORKFLOW.read_text(encoding="utf-8")
+    assert "pfBlockerNG-pkg-${{ inputs.image_name }}-s${{" not in text
+    assert "pfBlockerNG-deppkgs-${{ inputs.image_name }}-s${{" not in text
+    assert "format('pfBlockerNG-deppkgs-{0}-s{1}', inputs.image_name, inputs.shard)" not in text
+    assert "<image_name>-s<shard>" not in text


### PR DESCRIPTION
## Summary

Part of #2453.

`repo-install.yml` fans `smoke-single.yml` out over the ci-metadata matrix, and CE 2.8 / CE 2.9 share `image_name: pfsense-ce` (Plus 26.03/26.07 share `pfsense-plus`). `smoke-single.yml`'s self-build path (`pkg_artifact` blank) named its `.pkg` / dep-pkgs artifacts by `image_name` + shard only, so both CE legs of one run uploaded the same artifact names and the CE 2.9 leg could download the CE 2.8 FreeBSD:15 build:

```
pkg: wrong architecture: FreeBSD:15:* instead of FreeBSD:16:amd64
```

## Change

- `artifact_name` / `dep_artifact_name` on the self-build `build-pkg` job now carry `pfsense_version`: `pfBlockerNG-{pkg,deppkgs}-<image_name>-<pfsense_version>-s<shard>` (same discriminator the `smoke-diagnostics` artifact already uses).
- The dep-pkgs download fallback (`inputs.dep_artifact` blank) uses the same name.
- Input descriptions, comments and the architecture note updated to match.

## Test

`tests/test_issue2453_smoke_single_artifact_names.py` pins the three names and rejects the old `image_name`-only forms. Executed RED against the unchanged workflow (4 failed), fix applied, re-run GREEN with the test file byte-identical (sha256 checked). `scripts/agent/run-gates.sh --diff devel`: GATES PASS.

## Verification (issue's acceptance step, run pre-merge)

`repo-install.yml` dispatched on `issue/2453`: [run 31951656991](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/31951656991).

- Artifact list — six distinct names, no duplicates: `pfBlockerNG-pkg-pfsense-{ce-2.8,ce-2.9,plus-26.03,plus-26.07}-s0`, `pfBlockerNG-deppkgs-pfsense-{ce-2.8,ce-2.9}-s0`.
- CE 2.9 leg: zero `wrong architecture` lines; 37 passed / 3 failed (down from 32 failures, all wrong-ABI, on the last devel nightly [31936391366](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/31936391366)).
- The 3 remaining CE 2.9 failures and the 1 failure on each other leg are pre-existing and unrelated to artifact naming — tracked in #2464 (variant tests assume opposite edition ⇒ different ABI/php; CE 2.9 vs Plus 26.03 share FreeBSD:16/php85) and #2465 (`test_software_check_setting_gates_background_check`, red on every leg on devel too).

Also covered by the same edit: `release-published.yml`'s `validate-live-pages-install` fans `smoke-single.yml` out per version on the self-build path and had the identical collision.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
