### PR TITLE
publish: dependency .pkg identity = filename, place-if-missing (#2468)

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1206,8 +1206,17 @@ Full design: ADR-39.
   branch `.pkg`s (frozen together — the EOL/route-only story wants this); the draft healthcheck
   counts one main asset per release row plus the total `extra_pkgs` entries. The publisher folds
   those attached dep `.pkg` assets into the served catalogue itself — `publish_catalogues.py`
-  verifies each one against its ROUTE row's ABI and `publish_release.py` drops it into the same
-  destination as the canonical package.
+  verifies each one against its ROUTE row's ABI. **A dependency `.pkg`'s identity is its
+  filename alone** (`<name>-<version>.pkg`, from the pinned ports tree) — never its bytes:
+  publishers place a dependency only when it is missing at a destination, and never
+  byte-compare or overwrite one already there. A tagged run's dependency assets are per-row
+  Release assets, each routed to its OWN row's varver by its `-<Variant>-<pfsense_version>`
+  suffix — never by ABI-matching every same-major declaring row, so two rows on the same
+  FreeBSD major can each carry their own build without colliding. Canonical packages keep the
+  strict byte-conflict check (`DestinationConflictError` on a same-name, different-bytes
+  destination). Nightly rebuilds its dependency every run and reuses the identical
+  place-if-missing rule, so a byte-only rebuild under an unchanged name-version is expected,
+  not an error (issue #2468).
 - **Generators:** `scripts/build-repo-portable.py` (primary catalog gen) and
   `scripts/build-repo.sh` (fallback + `--print-conf` conf template) both emit the client
   repo-conf; `priority: 100` — one equal priority across every project channel repo, above

--- a/scripts/publish_catalogues.py
+++ b/scripts/publish_catalogues.py
@@ -348,6 +348,10 @@ class VerifiedAsset:
     sha256: str
     manifest: Mapping[str, object]
     record: Mapping[str, object] | None = None
+    # (variant, pfsense_version) from a tagged dependency asset's own suffix (issue
+    # #2468 per-suffix routing target) — set only there; None for canonical (uses
+    # record.matrix_row) and Nightly dependency (no suffix) assets.
+    release_suffix: tuple[str, str] | None = None
 
 
 def _validate_asset_name(name: str) -> None:
@@ -513,6 +517,7 @@ def _verify_dependency_asset(
         raise AssetVerificationError(f"{asset_name}: dependency manifest version is missing or unsafe")
 
     canonical_name = f"{name}-{version}.pkg"
+    release_suffix: tuple[str, str] | None = None
     if intake.kind == "tagged":
         prefix = f"{name}-{version}-"
         if not asset_name.startswith(prefix):
@@ -526,6 +531,7 @@ def _verify_dependency_asset(
             raise AssetVerificationError(
                 f"{asset_name}: declared name does not carry a valid -<Variant>-<pfsense_version> Release-asset suffix"
             )
+        release_suffix = (variant, pfsense_version)
     elif asset_name != canonical_name:
         raise AssetVerificationError(
             f"{asset_name}: declared name does not match the package's manifest identity; expected {canonical_name!r}"
@@ -541,6 +547,7 @@ def _verify_dependency_asset(
         sha256=digest,
         manifest=manifest,
         record=None,
+        release_suffix=release_suffix,
     )
 
 

--- a/scripts/publish_catalogues.py
+++ b/scripts/publish_catalogues.py
@@ -503,8 +503,10 @@ def _verify_dependency_asset(
     dependency assets with the SAME ``-<Variant>-<pfsense_version>`` suffix it applies
     to the canonical package (the "Build the .pkg via build-leg.sh" step's
     ``RENAMED_DEP``); a nightly dependency artifact carries no such suffix. Which exact
-    ROUTE row a dep belongs to is decided later, by ABI, in verify_run (axis 9) — this
-    only needs the suffix to be well-formed, not tied to a specific row.
+    varver a tagged dep lands in is decided later, by that suffix, in
+    ``publish_release._build_targets`` (issue #2468) — axis 9 in verify_run only checks
+    the ABI against SOME ROUTE row. Here the suffix only has to be well-formed; it is
+    returned on the VerifiedAsset (``release_suffix``) for the publisher to route on.
     """
     brp = engine.build_repo_portable
     pfb_pkg = engine.pfb_pkg

--- a/scripts/publish_nightly.py
+++ b/scripts/publish_nightly.py
@@ -17,7 +17,19 @@ Nightly leg's canonical asset is targeted at every build-role ROUTE row whose
 therefore both receive the SAME canonical bytes — a genuine multi-destination fan-out,
 verified byte/checksum/provenance-identical by
 ``catalogue_assembly.verify_multi_destination_identity`` exactly as a tagged run's own
-fan-out is.
+fan-out is. A leg's dependency asset attaches only to the ROUTE rows sharing its major
+that also declare its origin (``extra_pkgs``) — never fed into that identity check
+(dependency identity is the filename alone, place-if-missing — see below).
+
+Dependency identity (issue #2468): reuses ``publish_release._drop_assets``/
+``_asset_map`` verbatim, so a dependency ``.pkg`` here follows the SAME rule as a
+tagged run's — identity is its filename (``<name>-<version>.pkg``), a destination
+already holding one is left exactly as-is (never read, never byte-compared, never
+overwritten), and a missing one is copied in. Nightly rebuilds its dependency every
+run, so this is expected, not an error: the ``py311-charset-normalizer`` dep that
+tripped ``publish_nightly`` on a byte-only rebuild (source commit changed, name/version
+did not — the symptom behind this issue) now simply stays whatever was already
+published. The canonical package keeps the strict byte-conflict check below.
 
 Staleness guard: this publisher runs inside the SAME workflow run that produced the
 handoff (``handoff["run_id"] == --source-run-id``); an inequality means a stale or
@@ -414,8 +426,9 @@ def publish(
             changed = True
         if not changed and not pr._catalogue_descriptor_complete(dest_dir, engine):
             changed = True
-        for src in asset_map.values():
-            source_index.setdefault(src.resolve(), []).append((_CHANNEL, varver))
+        # issue #2468: only the canonical asset feeds the fan-out identity index —
+        # see publish_release.publish's own comment on this same exclusion.
+        source_index.setdefault(target.canonical.work_path.resolve(), []).append((_CHANNEL, varver))
         if changed:
             ca.prune_retained(site_root, _CHANNEL, varver, engine=engine)
             ca.regenerate_catalogue(site_root, _CHANNEL, varver, engine=engine)

--- a/scripts/publish_nightly.py
+++ b/scripts/publish_nightly.py
@@ -421,8 +421,11 @@ def publish(
         target = targets[varver]
         asset_map = pr._asset_map(target)
         dest_dir = site_root / _CHANNEL / varver
-        changed = pr._drop_assets(dest_dir, asset_map)
-        if pr._evict_undeclared_deps(dest_dir, engine=engine, row=target.row):
+        # Evict before dropping, for the reason publish_release.publish spells out:
+        # place-if-missing would otherwise skip the incoming dependency and then
+        # unlink the undeclared leftover holding its name.
+        changed = pr._evict_undeclared_deps(dest_dir, engine=engine, row=target.row)
+        if pr._drop_assets(dest_dir, asset_map):
             changed = True
         if not changed and not pr._catalogue_descriptor_complete(dest_dir, engine):
             changed = True

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -337,8 +337,12 @@ def publish(engine: pc.Engine, run_result: pc.RunResult, pkg_repo: str | Path) -
         asset_map = _asset_map(target)
         for channel in intake.destinations:
             dest_dir = site_root / channel / varver
-            changed = _drop_assets(dest_dir, asset_map)
-            if _evict_undeclared_deps(dest_dir, engine=engine, row=target.row):
+            # Eviction runs FIRST: a dependency is placed only when its name is
+            # missing, so an undeclared leftover under that same name has to go
+            # before the drop, or the run would skip the incoming dependency and
+            # then unlink the leftover — publishing a catalogue without the extra.
+            changed = _evict_undeclared_deps(dest_dir, engine=engine, row=target.row)
+            if _drop_assets(dest_dir, asset_map):
                 changed = True
             if not changed and not _catalogue_descriptor_complete(dest_dir, engine):
                 changed = True

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -14,18 +14,30 @@ module only calls their public contracts. Never runs git: the caller (the releas
 workflow) owns staging exactly the touched directories, committing, and pushing —
 this module only reports which ``(channel, varver)`` directories it touched.
 
-No-op behaviour: a ``(channel, varver)`` target whose desired files (this run's
-canonical asset + any dependency assets that ABI-match its ROUTE row and whose
-origin is listed in that row's ``extra_pkgs``) are already
-present, byte-identical, at the destination AND whose catalog descriptor
-(meta.conf/data.pkg/packagesite.pkg) is complete is left untouched entirely — no
-copy, no prune, no regenerate. There is no ledger; "already published" is read
-straight off the files already on disk. A destination whose descriptor is
-incomplete (a prior run's write-back fault) is regenerated even when the ``.pkg``
-payload itself is unchanged. A destination file sharing an incoming asset's
-canonical name but carrying DIFFERENT bytes is never overwritten: same
-name/version with different bytes, source, or provenance raises
-``DestinationConflictError`` instead.
+Dependency identity (issue #2468): a dependency ``.pkg``'s identity is its filename
+alone (``<name>-<version>.pkg``, e.g. ``py311-charset-normalizer-3.4.0.pkg``) — a
+tagged Release asset's ``-<Variant>-<pfsense_version>`` suffix (``VerifiedAsset.
+release_suffix``) routes it to the varver of ITS OWN suffix row (``_build_targets``:
+that row must be one of this run's own canonical targets, must declare the dep's
+origin in ``extra_pkgs``, and its ABI must match — never by ABI-matching every
+same-major declaring row). A dependency already present at a destination is left
+exactly as-is — never read, never byte-compared, never overwritten — and one missing
+is copied in (``_drop_assets``). The canonical package keeps the strict rule below.
+Because a dependency is place-if-missing, it never feeds the multi-destination
+identity check (``_asset_map``/``publish``'s ``source_index``) — fan-out byte
+identity stays a canonical-package invariant only; a dep already differing at one
+destination but freshly placed at another is expected, not a divergence.
+
+No-op behaviour: a ``(channel, varver)`` target whose canonical asset is already
+present, byte-identical, at the destination (dependency assets are irrelevant to this
+check — see above) AND whose catalog descriptor (meta.conf/data.pkg/packagesite.pkg)
+is complete is left untouched entirely — no copy, no prune, no regenerate. There is no
+ledger; "already published" is read straight off the files already on disk. A
+destination whose descriptor is incomplete (a prior run's write-back fault) is
+regenerated even when the ``.pkg`` payload itself is unchanged. A destination
+CANONICAL file sharing an incoming asset's canonical name but carrying DIFFERENT
+bytes is never overwritten: same name/version with different bytes, source, or
+provenance raises ``DestinationConflictError`` instead.
 
 Nightly intake is not handled here: ``run()`` accepts only ``kind == "tagged"`` intake
 and fails closed otherwise.
@@ -198,39 +210,44 @@ def _build_targets(engine: pc.Engine, run_result: pc.RunResult) -> dict[str, _Ta
         targets[varver] = _Target(row=row, canonical=asset)
 
     for dep in run_result.dependency_assets:
-        # Same-major ABI is not enough: a CE extra must not land in a Plus
-        # catalogue whose extra_pkgs is empty (issue #2383).
-        matched = [
-            varver
-            for varver, target in targets.items()
-            if brp._pkg_matches_abi(dep.manifest, f"FreeBSD:{target.row['freebsd_major']}:*")
-            and _row_declares_dep(target.row, dep)
-        ]
-        if not matched:
-            raise PublishReleaseError(
-                f"dependency asset {dep.declared_name!r} matches no varver targeted "
-                "by this run's own canonical assets (ABI + extra_pkgs declaration)"
-            )
-        for varver in matched:
-            targets[varver].dependencies.append(dep)
+        # issue #2468: routes to the varver of the dep's OWN suffix row only — never
+        # by ABI-match against every same-major declaring row. That row must be a
+        # canonical target of this run, declare the dep's origin, and match ABI.
+        reject = PublishReleaseError(
+            f"dependency asset {dep.declared_name!r} matches no varver targeted "
+            "by this run's own canonical assets (per-suffix routing, ABI, and "
+            "extra_pkgs declaration)"
+        )
+        if dep.release_suffix is None:
+            raise reject
+        variant, pfsense_version = dep.release_suffix
+        varver = brp.catalog_name_from_version(pfsense_version, variant)
+        target = targets.get(varver)
+        if target is None:
+            raise reject
+        if not brp._pkg_matches_abi(dep.manifest, f"FreeBSD:{target.row['freebsd_major']}:*"):
+            raise reject
+        if not _row_declares_dep(target.row, dep):
+            raise reject
+        target.dependencies.append(dep)
 
     return targets
 
 
-def _asset_map(target: _Target) -> dict[str, Path]:
-    mapping = {target.canonical.canonical_name: target.canonical.work_path}
+def _asset_map(target: _Target) -> dict[str, pc.VerifiedAsset]:
+    mapping: dict[str, pc.VerifiedAsset] = {target.canonical.canonical_name: target.canonical}
     for dep in target.dependencies:
         existing = mapping.get(dep.canonical_name)
         if existing is not None:
-            if _files_identical(existing, dep.work_path):
-                continue
+            # issue #2468: two assets resolving to one canonical name always conflict
+            # — no byte-compare-then-tolerate branch; dependency identity is the
+            # filename alone, and per-suffix routing should make this unreachable.
             raise DestinationConflictError(
-                f"{dep.canonical_name}: two verified assets share this canonical name "
-                f"with different bytes — "
-                f"existing sha256={hashlib.sha256(existing.read_bytes()).hexdigest()}, "
-                f"incoming sha256={hashlib.sha256(dep.work_path.read_bytes()).hexdigest()}"
+                f"{dep.canonical_name}: two verified assets share this canonical name — "
+                f"{existing.declared_name!r} (sha256={existing.sha256}) and "
+                f"{dep.declared_name!r} (sha256={dep.sha256})"
             )
-        mapping[dep.canonical_name] = dep.work_path
+        mapping[dep.canonical_name] = dep
     return mapping
 
 
@@ -266,12 +283,17 @@ def _evict_undeclared_deps(dest_dir: Path, *, engine: pc.Engine, row: Mapping[st
     return evicted
 
 
-def _drop_assets(dest_dir: Path, asset_map: Mapping[str, Path]) -> bool:
+def _drop_assets(dest_dir: Path, asset_map: Mapping[str, pc.VerifiedAsset]) -> bool:
     dest_dir.mkdir(parents=True, exist_ok=True)
     changed = False
-    for name, src in asset_map.items():
+    for name, asset in asset_map.items():
         dest = dest_dir / name
+        src = asset.work_path
         if dest.is_file():
+            if asset.asset_class == "dependency":
+                # issue #2468: a dependency .pkg's identity IS its filename — place
+                # it only when missing, never byte-compare or overwrite an existing one.
+                continue
             if _files_identical(dest, src):
                 continue
             raise DestinationConflictError(
@@ -330,8 +352,10 @@ def publish(engine: pc.Engine, run_result: pc.RunResult, pkg_repo: str | Path) -
                     for dest in destinations:
                         if dest not in bucket:
                             bucket.append(dest)
-            for src in asset_map.values():
-                source_index.setdefault(src.resolve(), []).append((channel, varver))
+            # issue #2468: only the canonical asset feeds the fan-out identity index —
+            # a place-if-missing dependency skipped at one destination but placed
+            # fresh at another would otherwise falsely trip verify_multi_destination_identity.
+            source_index.setdefault(target.canonical.work_path.resolve(), []).append((channel, varver))
             if changed:
                 ca.prune_retained(site_root, channel, varver, engine=engine)
                 ca.regenerate_catalogue(site_root, channel, varver, engine=engine)

--- a/tests/test_issue2383_extra_pkgs_row_scope.py
+++ b/tests/test_issue2383_extra_pkgs_row_scope.py
@@ -64,7 +64,9 @@ def test_row_declares_dep_does_not_treat_abi_as_a_declaration() -> None:
 
 
 def test_build_targets_match_requires_row_declares_dep() -> None:
-    """_build_targets must consult _row_declares_dep for dest extra attach."""
+    """_build_targets must consult _row_declares_dep for dest extra attach — a
+    dependency's own suffix row must DECLARE its origin, or per-suffix routing
+    (issue #2468) rejects it as a gate, not merely a filter predicate."""
     source = inspect.getsource(pr._build_targets)
     assert "_row_declares_dep" in source
-    assert "and _row_declares_dep" in source or "and pr._row_declares_dep" in source
+    assert "if not _row_declares_dep" in source or "if not pr._row_declares_dep" in source

--- a/tests/test_publish_catalogues.py
+++ b/tests/test_publish_catalogues.py
@@ -621,6 +621,9 @@ class AssetVerificationTests(unittest.TestCase):
         self.assertEqual(asset.asset_class, "dependency")
         self.assertIsNone(asset.record)
         self.assertEqual(asset.canonical_name, "py311-charset-normalizer-3.4.0.pkg")
+        # issue #2468: the -<Variant>-<pfsense_version> suffix this asset carries is
+        # exposed for the publisher's own per-suffix routing, not just parsed and discarded.
+        self.assertEqual(asset.release_suffix, ("CE", "2.8"))
 
     def test_verify_dependency_asset_nightly_bare_name(self) -> None:
         intake = self._intake(channel="nightly", destinations='["nightly"]')
@@ -635,6 +638,8 @@ class AssetVerificationTests(unittest.TestCase):
         )
         self.assertEqual(asset.asset_class, "dependency")
         self.assertIsNone(asset.record)
+        # issue #2468: a Nightly dependency artifact carries no per-row suffix.
+        self.assertIsNone(asset.release_suffix)
 
     def test_dependency_tagged_bare_name_without_suffix_rejected(self) -> None:
         """A tagged dependency asset that is missing its -<Variant>-<pfsense_version>

--- a/tests/test_publish_catalogues.py
+++ b/tests/test_publish_catalogues.py
@@ -658,6 +658,31 @@ class AssetVerificationTests(unittest.TestCase):
                 work_dir=self.work_dir,
             )
 
+    def test_dependency_tagged_malformed_suffix_rejected(self) -> None:
+        """issue #2468 promotes the -<Variant>-<pfsense_version> suffix from a cosmetic
+        label into the routing key that decides which varver a dependency lands in, so
+        every malformed shape must be rejected here rather than routed somewhere by
+        accident: an empty version ('-CE-'), a bare version with no variant, and an
+        empty variant. (A well-formed suffix naming a row this run never built is a
+        routing rejection instead — publish_release's own target fan-in.)"""
+        intake = self._intake(channel="testing", destinations='["testing","edge"]')
+        path, digest = _wrap_dependency_pkg(self.tmp_path)
+        for malformed in (
+            "py311-charset-normalizer-3.4.0-CE-.pkg",
+            "py311-charset-normalizer-3.4.0-2.8.pkg",
+            "py311-charset-normalizer-3.4.0--2.8.pkg",
+        ):
+            with self.subTest(malformed=malformed), self.assertRaises(pc.AssetVerificationError) as ctx:
+                pc.verify_asset(
+                    _ENGINE,
+                    path,
+                    malformed,
+                    intake=intake,
+                    expected_sha256=digest,
+                    work_dir=self.work_dir,
+                )
+            self.assertIn("Release-asset suffix", str(ctx.exception))
+
     # --- hostile asset name rows ---
 
     def test_asset_name_with_parent_traversal_rejected(self) -> None:

--- a/tests/test_publish_nightly.py
+++ b/tests/test_publish_nightly.py
@@ -222,9 +222,10 @@ def _wrap_dependency_pkg(
     version: str,
     abi: str,
     local_name: str,
+    origin: str | None = None,
     payload: dict[str, bytes] | None = None,
 ) -> tuple[Path, str]:
-    manifest = {"name": name, "version": version, "abi": abi, "origin": f"textproc/{name}"}
+    manifest = {"name": name, "version": version, "abi": abi, "origin": origin or f"textproc/{name}"}
     compact = json.dumps(manifest, separators=(",", ":")).encode()
     members = [("+COMPACT_MANIFEST", compact, 0o644, 0)]
     # Extra members vary the archive BYTES under an identical manifest identity —
@@ -616,6 +617,72 @@ class DependencyPlaceIfMissingTests(_TempDirTestCase):
         canonical_name = f"pfSense-pkg-pfBlockerNG-{newer.pkg_version}.pkg"
         self.assertTrue((catalogue_dir / canonical_name).is_file())
         self.assertEqual(dep_path.read_bytes(), original_dep_bytes)
+
+    @_requires_engine
+    def test_dep_already_different_at_one_varver_does_not_trip_identity_check(self) -> None:
+        """issue #2468: two build-role ROUTE rows of one major (ce-2.8 + ce-2.9) both
+        declare the dep, so one leg's dep artifact reaches two catalogues. When one of
+        them already holds a byte-different build of that same name-version, the run
+        must still succeed: dependency bytes are deliberately NOT part of the
+        multi-destination fan-out identity invariant, which covers the canonical
+        package alone."""
+        stale_dir = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        stale_dir.mkdir(parents=True)
+        stale_path, _digest = _wrap_dependency_pkg(
+            stale_dir,
+            name=_CHARSET_NAME,
+            version="3.4.0",
+            abi="FreeBSD:15:*",
+            local_name=_CHARSET_PKG,
+            payload={"filler.bin": b"an-earlier-nights-build"},
+        )
+        stale_bytes = stale_path.read_bytes()
+
+        results_dir = self.new_results_dir()
+        handoff = _build_handoff(
+            _snapshot(),
+            legs=[_LegSpec(row=ROW_CE15)],
+            route_rows=[ROW_CE15, ROW_CE15_29],
+            assets_root=results_dir,
+        )
+        report = _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+        self.assertEqual(set(report.touched), {("nightly", "ce-2.8"), ("nightly", "ce-2.9")})
+        docs = self.pkg_repo / "docs" / "nightly"
+        self.assertEqual((docs / "ce-2.8" / _CHARSET_PKG).read_bytes(), stale_bytes)  # left as it was
+        fresh = docs / "ce-2.9" / _CHARSET_PKG
+        self.assertTrue(fresh.is_file())
+        self.assertNotEqual(fresh.read_bytes(), stale_bytes)  # this run's own build, placed where missing
+
+    @_requires_engine
+    def test_undeclared_same_name_leftover_replaced_by_this_runs_dependency(self) -> None:
+        """A Nightly destination holding a same-name dependency whose origin the row no
+        longer declares (the port moved category, issue #2403) must end ONE run
+        advertising the dependency this run verified — place-if-missing and eviction
+        together may never leave the catalogue with the extra silently absent."""
+        dest = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        dest.mkdir(parents=True)
+        _wrap_dependency_pkg(
+            dest,
+            name=_CHARSET_NAME,
+            version="3.4.0",
+            abi="FreeBSD:15:*",
+            local_name=_CHARSET_PKG,
+            origin="www/py-charset-normalizer",
+            payload={"filler.bin": b"leftover-from-the-other-category"},
+        )
+
+        handoff, results_dir, _snap = self.base_handoff()
+        report = _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+        self.assertEqual(report.touched, (("nightly", "ce-2.8"),))
+        published = dest / _CHARSET_PKG
+        self.assertTrue(published.is_file(), "this run's verified dependency is missing from the catalogue")
+        self.assertEqual(
+            _ENGINE.pfb_pkg.read_compact_manifest(published)["origin"],
+            f"textproc/{_CHARSET_NAME}",
+        )
+        self.assertIn(_CHARSET_NAME, _packagesite_names(dest))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_publish_nightly.py
+++ b/tests/test_publish_nightly.py
@@ -106,6 +106,11 @@ ROW_PLUS16_03 = _row(freebsd_major="16", pfsense_version="26.03", variant="Plus"
 ROW_PLUS16_07 = _row(freebsd_major="16", pfsense_version="26.07", variant="Plus")
 ROW_PLUS15_03 = _row(freebsd_major="15", pfsense_version="26.03", variant="Plus")
 ROW_ROUTE_ONLY_17 = _row(freebsd_major="17", pfsense_version="17.0", variant="CE", role="route-only")
+# Same major as ROW_CE15, ALSO declaring the charset extra — two build-role ROUTE
+# rows sharing one leg, both declaring the dep (issue #2468 coverage).
+ROW_CE15_29 = _row(
+    freebsd_major="15", pfsense_version="2.9", variant="CE", extra_pkgs=["textproc/py-charset-normalizer"]
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -217,10 +222,14 @@ def _wrap_dependency_pkg(
     version: str,
     abi: str,
     local_name: str,
+    payload: dict[str, bytes] | None = None,
 ) -> tuple[Path, str]:
     manifest = {"name": name, "version": version, "abi": abi, "origin": f"textproc/{name}"}
     compact = json.dumps(manifest, separators=(",", ":")).encode()
     members = [("+COMPACT_MANIFEST", compact, 0o644, 0)]
+    # Extra members vary the archive BYTES under an identical manifest identity —
+    # how a nightly rebuild of the same name-version ends up byte-distinct.
+    members.extend((member, data, 0o644, 0) for member, data in (payload or {}).items())
     path = directory / local_name
     _write_tar_pkg(path, members)
     return path, hashlib.sha256(path.read_bytes()).hexdigest()
@@ -242,6 +251,9 @@ class _LegSpec:
     # None = derive from row extra_pkgs (issue #2405: count must match).
     dep_specs: Sequence[tuple[str, str]] | None = None
     source_date_epoch: int = _EPOCH
+    # Extra archive member(s) so a rebuilt dep of the SAME name-version ends up
+    # byte-distinct from a prior leg's — issue #2468's place-if-missing rule.
+    dep_payload: dict[str, bytes] | None = None
 
 
 def _resolved_dep_specs(spec: _LegSpec) -> Sequence[tuple[str, str]]:
@@ -280,7 +292,7 @@ def _build_leg_result(snapshot: Any, spec: _LegSpec, *, assets_root: Path) -> di
     for name, version in _resolved_dep_specs(spec):
         dep_name = f"{name}-{version}.pkg"
         _dep_path, dep_digest = _wrap_dependency_pkg(
-            legdir, name=name, version=version, abi=f"FreeBSD:{major}:*", local_name=dep_name
+            legdir, name=name, version=version, abi=f"FreeBSD:{major}:*", local_name=dep_name, payload=spec.dep_payload
         )
         dep_artifacts.append({"abi": f"FreeBSD:{major}:*", "name": dep_name, "sha256": dep_digest})
     return {
@@ -564,6 +576,46 @@ class RetentionTests(_TempDirTestCase):
         self.assertEqual(len(remaining), keep)
         self.assertNotIn(f"pfSense-pkg-pfBlockerNG-{first_version}.pkg", remaining)
         self.assertTrue((catalogue_dir / dep_name).is_file())
+
+
+# --------------------------------------------------------------------------- #
+# issue #2468 nightly analogue: dependency identity = filename, place-if-missing,
+# never byte-compared or overwritten. Nightly rebuilds its dep every run.
+# --------------------------------------------------------------------------- #
+
+
+class DependencyPlaceIfMissingTests(_TempDirTestCase):
+    @_requires_engine
+    def test_rebuilt_dependency_different_bytes_publishes_without_conflict(self) -> None:
+        """RED CANARY (issue #2468), nightly analogue: Nightly rebuilds its
+        dependency every run from whatever source commit triggered it — new archive
+        bytes under the identical name-version is expected, not an error. A second
+        Nightly run publishing a byte-different rebuild of the same dep must succeed
+        without DestinationConflictError, and the already-published dep bytes must
+        stay untouched (place-if-missing, never compared, never overwritten)."""
+        handoff, results_dir, _snap = self.base_handoff()
+        first = _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+        self.assertTrue(first.touched)
+
+        catalogue_dir = self.pkg_repo / "docs" / "nightly" / "ce-2.8"
+        dep_path = catalogue_dir / "py311-charset-normalizer-3.4.0.pkg"
+        original_dep_bytes = dep_path.read_bytes()
+
+        newer = _snapshot(build_date=date(2026, 8, 5))
+        results_dir_2 = self.new_results_dir()
+        handoff_2 = _build_handoff(
+            newer,
+            legs=[_LegSpec(row=ROW_CE15, dep_payload={"filler.bin": b"rebuilt-from-new-source-commit"})],
+            route_rows=[ROW_CE15],
+            assets_root=results_dir_2,
+        )
+
+        second = _run(handoff=handoff_2, results_dir=results_dir_2, pkg_repo=self.pkg_repo)
+
+        self.assertTrue(second.touched)
+        canonical_name = f"pfSense-pkg-pfBlockerNG-{newer.pkg_version}.pkg"
+        self.assertTrue((catalogue_dir / canonical_name).is_file())
+        self.assertEqual(dep_path.read_bytes(), original_dep_bytes)
 
 
 # --------------------------------------------------------------------------- #
@@ -1216,6 +1268,32 @@ class SameMajorDestScopeTests(_TempDirTestCase):
         self.assertFalse((docs / "plus-26.03" / _CHARSET_PKG).exists())
         self.assertIn(_CHARSET_NAME, _packagesite_names(docs / "ce-2.8"))
         self.assertNotIn(_CHARSET_NAME, _packagesite_names(docs / "plus-26.03"))
+
+    @_requires_engine
+    def test_two_same_major_rows_both_declaring_dep_both_receive_it(self) -> None:
+        """issue #2468 coverage: two build-role ROUTE rows sharing one FreeBSD major
+        (ce-2.8 + ce-2.9, both major 15), BOTH declaring the same extra_pkgs origin,
+        both receive the identical dep bytes from the ONE leg that major built —
+        _route_targets's existing per-row extra_pkgs gate is unchanged by this issue,
+        only the place-if-missing rule for an already-published dep is new."""
+        snapshot = _snapshot()
+        results_dir = self.new_results_dir()
+        handoff = _build_handoff(
+            snapshot,
+            legs=[_LegSpec(row=ROW_CE15)],
+            route_rows=[ROW_CE15, ROW_CE15_29],
+            assets_root=results_dir,
+        )
+        report = _run(handoff=handoff, results_dir=results_dir, pkg_repo=self.pkg_repo)
+
+        self.assertEqual(set(report.touched), {("nightly", "ce-2.8"), ("nightly", "ce-2.9")})
+        docs = self.pkg_repo / "docs" / "nightly"
+        self.assertTrue((docs / "ce-2.8" / _CHARSET_PKG).is_file())
+        self.assertTrue((docs / "ce-2.9" / _CHARSET_PKG).is_file())
+        self.assertEqual(
+            (docs / "ce-2.8" / _CHARSET_PKG).read_bytes(),
+            (docs / "ce-2.9" / _CHARSET_PKG).read_bytes(),
+        )
 
     @_requires_engine
     def test_route_targets_continue_filter_required_for_same_major_plus(self) -> None:

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -268,13 +268,14 @@ def _wrap_dependency_pkg(
     version: str = "3.4.0",
     abi: str = "FreeBSD:15:*",
     local_name: str,
+    origin: str | None = None,
     payload: dict[str, bytes] | None = None,
 ) -> tuple[Path, str]:
     manifest = {
         "name": name,
         "version": version,
         "abi": abi,
-        "origin": f"textproc/{name}",
+        "origin": origin or f"textproc/{name}",
     }
     compact = json.dumps(manifest, separators=(",", ":")).encode()
     members = [("+COMPACT_MANIFEST", compact, 0o644, 0)]
@@ -294,6 +295,49 @@ def _canonical_declared_name(record: dict) -> str:
 
 def _dependency_declared_name(*, name: str, version: str, row: dict) -> str:
     return f"{name}-{version}-{row['variant']}-{row['pfsense_version']}.pkg"
+
+
+# Hand-built VerifiedAssets for the unit-level _build_targets rows: no archive on
+# disk, so each gate can be isolated from everything verify_asset/verify_run would
+# otherwise reject first.
+def _canonical_verified_asset(row: dict[str, object]) -> pc.VerifiedAsset:
+    record = _record(channel="edge", row=row, source_tag="v4.0.0.b1")
+    return pc.VerifiedAsset(
+        asset_class="canonical",
+        declared_name=_canonical_declared_name(record),
+        canonical_name=f"{_ENGINE.pfb_pkg.CANONICAL_EMITTED_IDENTITY}-{record['canonical_package_version']}.pkg",
+        work_path=Path("canonical.pkg"),
+        sha256="a" * 64,
+        manifest={},
+        record=record,
+    )
+
+
+def _dependency_verified_asset(
+    *,
+    abi: str,
+    release_suffix: tuple[str, str] | None,
+    name: str = "py311-charset-normalizer",
+    version: str = "3.4.0",
+) -> pc.VerifiedAsset:
+    return pc.VerifiedAsset(
+        asset_class="dependency",
+        declared_name=f"{name}-{version}.pkg",
+        canonical_name=f"{name}-{version}.pkg",
+        work_path=Path(f"{name}-{version}.pkg"),
+        sha256="b" * 64,
+        manifest={"name": name, "version": version, "abi": abi, "origin": f"textproc/{name}"},
+        release_suffix=release_suffix,
+    )
+
+
+def _run_result(*, canonical: pc.VerifiedAsset, dependency: pc.VerifiedAsset) -> pc.RunResult:
+    return pc.RunResult(
+        intake=pc.parse_intake(_REPO, "1", "v4.0.0.b1", '["edge"]', "10:1"),
+        canonical_assets=(canonical,),
+        dependency_assets=(dependency,),
+        build_route_rows=(ROW_CE,),
+    )
 
 
 def _populate_assets_dir(
@@ -902,10 +946,10 @@ class DependencyPlaceIfMissingTests(_TempDirTestCase):
     def test_asset_map_two_deps_same_canonical_name_rejected(self) -> None:
         """Unit test on _asset_map directly (issue #2468 coverage row 6): two
         dependency VerifiedAssets that resolve to the SAME canonical name always
-        conflict — no byte-compare-then-tolerate branch, no file reads. Never
-        reachable end-to-end from one tagged run (a real asset set cannot carry
-        two on-disk files sharing one declared filename); reachable via nightly
-        handoffs or direct API use."""
+        conflict — no byte-compare-then-tolerate branch, no file reads. Two assets
+        with the SAME suffix cannot reach this from one tagged run (they would be
+        one on-disk filename), but two differing suffixes whose varvers collapse
+        together (2.8 vs 2.8.1), a nightly handoff, or direct API use all can."""
         canonical = pc.VerifiedAsset(
             asset_class="canonical",
             declared_name="pfSense-pkg-pfBlockerNG-4.0.0.b1-CE-2.8.pkg",
@@ -942,6 +986,35 @@ class DependencyPlaceIfMissingTests(_TempDirTestCase):
         self.assertIn(dep_two.declared_name, message)
         self.assertIn(dep_one.sha256, message)
         self.assertIn(dep_two.sha256, message)
+
+        # The reject is unconditional: identical bytes are a duplicate too, not a
+        # tolerated dedupe (the branch this issue removed).
+        twin = pc.VerifiedAsset(**{**vars(dep_two), "sha256": dep_one.sha256})
+        with self.assertRaises(pr.DestinationConflictError):
+            pr._asset_map(pr._Target(row=ROW_CE, canonical=canonical, dependencies=[dep_one, twin]))
+
+    @_requires_engine
+    def test_dependency_without_release_suffix_rejected(self) -> None:
+        """_build_targets routes by suffix alone, so a dependency VerifiedAsset that
+        carries none has no target to resolve and must be rejected rather than
+        silently dropped (verify_asset always populates it on the tagged path; this
+        pins the module's own guard for any other caller)."""
+        canonical = _canonical_verified_asset(ROW_CE)
+        dep = _dependency_verified_asset(abi="FreeBSD:15:*", release_suffix=None)
+        with self.assertRaises(pr.PublishReleaseError) as ctx:
+            pr._build_targets(_ENGINE, _run_result(canonical=canonical, dependency=dep))
+        self.assertIn("matches no varver targeted", str(ctx.exception))
+
+    @_requires_engine
+    def test_dependency_abi_mismatch_rejected_by_build_targets_itself(self) -> None:
+        """The ABI gate inside _build_targets, isolated: the suffix names a real
+        canonical target that declares the origin, and only the manifest ABI is
+        wrong — so nothing downstream can produce this rejection for us."""
+        canonical = _canonical_verified_asset(ROW_CE)
+        dep = _dependency_verified_asset(abi="FreeBSD:16:*", release_suffix=("CE", "2.8"))
+        with self.assertRaises(pr.PublishReleaseError) as ctx:
+            pr._build_targets(_ENGINE, _run_result(canonical=canonical, dependency=dep))
+        self.assertIn("matches no varver targeted", str(ctx.exception))
 
     @_requires_engine
     def test_multi_channel_fanout_dep_differs_at_one_channel_no_identity_violation(self) -> None:
@@ -1004,6 +1077,37 @@ class DependencyPlaceIfMissingTests(_TempDirTestCase):
         self.assertEqual(testing_dep.read_bytes(), stale_bytes)  # untouched, already present
         self.assertTrue(edge_dep.is_file())
         self.assertNotEqual(edge_dep.read_bytes(), stale_bytes)  # placed fresh, missing before
+
+    @_requires_engine
+    def test_undeclared_same_name_leftover_replaced_by_this_runs_dependency(self) -> None:
+        """A destination holding a same-name dependency whose origin the row no longer
+        declares (the port moved category, issue #2403) must end ONE run advertising
+        the dependency this run actually verified. Place-if-missing skips a name
+        already on disk and eviction unlinks that undeclared leftover, so the two
+        together may never leave the catalogue with the extra silently absent."""
+        dest = self.pkg_repo / "docs" / "edge" / "ce-2.8"
+        dest.mkdir(parents=True)
+        _wrap_dependency_pkg(
+            dest,
+            version="3.4.0",
+            abi="FreeBSD:15:*",
+            local_name=_CHARSET_PKG,
+            origin="www/py-charset-normalizer",
+            payload={"filler.bin": b"leftover-from-the-other-category"},
+        )
+
+        assets_dir = self.new_assets_dir()
+        _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1")
+        report = _run(pkg_repo=self.pkg_repo, assets_dir=assets_dir, rows=(ROW_CE,), tag="v4.0.0.b1")
+
+        self.assertEqual(report.touched, (("edge", "ce-2.8"),))
+        published = dest / _CHARSET_PKG
+        self.assertTrue(published.is_file(), "this run's verified dependency is missing from the catalogue")
+        self.assertEqual(
+            _ENGINE.pfb_pkg.read_compact_manifest(published)["origin"],
+            "textproc/py311-charset-normalizer",
+        )
+        self.assertIn(_CHARSET_NAME, _packagesite_names(dest))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -118,6 +118,22 @@ ROW_ROUTE_ONLY_17: dict[str, object] = {
     "role": "route-only",
 }
 
+# A route-only row on FreeBSD 16 — lets a dependency's ABI clear axis 9 (S1's own
+# "ABI matches SOME ROUTE row" check) via a row OTHER than the one its own suffix
+# names, isolating publish_release's own suffix-row ABI cross-check (issue #2468).
+ROW_ROUTE_ONLY_16: dict[str, object] = {
+    "pfsense_version": "99.0",
+    "channel": "CE",
+    "freebsd_version": "16.0-RELEASE",
+    "freebsd_major": "16",
+    "php_version": "8.3",
+    "py_flavor": "py311",
+    "variant": "CE",
+    "status": "active",
+    "extra_pkgs": [],
+    "role": "route-only",
+}
+
 _THREE_ROWS = (ROW_CE, ROW_PLUS_03, ROW_PLUS_07)
 
 
@@ -655,49 +671,12 @@ class TargetResolutionTests(_TempDirTestCase):
         self.assertIn("same varver", str(ctx.exception))
 
     @_requires_engine
-    def test_two_dependency_assets_same_canonical_name_different_bytes_rejected(self) -> None:
-        """A tagged run declares its dependency assets per row, so two rows can both
-        carry name-version X. The same artifact renamed twice is legitimate — but
-        DIFFERENT bytes under one canonical name must fail closed: the per-target
-        asset map keys by canonical name, and collapsing the pair last-wins would
-        silently publish only the later asset with no conflict check at all
-        (issue #2231)."""
-        assets_dir = self.new_assets_dir()
-        digests = _populate_assets_dir(
-            assets_dir, rows=(ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN), source_tag="v4.0.0.b1", include_dependency=False
-        )
-        twin_digests: list[str] = []
-        for row, filler in ((ROW_PLUS_03_TWIN, b"built-by-leg-one"), (ROW_PLUS_07_TWIN, b"built-by-leg-two")):
-            declared = _dependency_declared_name(name="py311-twin", version="1.0.0", row=row)
-            _path, digest = _wrap_dependency_pkg(
-                assets_dir,
-                name="py311-twin",
-                version="1.0.0",
-                abi="FreeBSD:16:*",
-                local_name=declared,
-                payload={"filler.bin": filler},
-            )
-            digests[declared] = digest
-            twin_digests.append(digest)
-        (assets_dir / pr._DIGESTS_FILENAME).write_text(json.dumps(digests), encoding="utf-8")
-
-        with self.assertRaises(pr.DestinationConflictError) as ctx:
-            _run(
-                pkg_repo=self.pkg_repo,
-                assets_dir=assets_dir,
-                rows=(ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN),
-                tag="v4.0.0.b1",
-            )
-        self.assertIn("different bytes", str(ctx.exception))
-        # The operator-facing message names both builds — pin both digests.
-        for digest in twin_digests:
-            self.assertIn(f"sha256={digest}", str(ctx.exception))
-
-    @_requires_engine
     def test_same_dependency_renamed_per_row_with_identical_bytes_publishes(self) -> None:
-        """The legitimate twin of the rejection above: ONE artifact attached under two
-        per-row declared names (byte-identical) deduplicates and publishes into every
-        matching varver — never a conflict."""
+        """The byte-identical twin of DependencyPlaceIfMissingTests's own
+        same-major/different-bytes case: ONE artifact attached under two per-row
+        declared names (byte-identical) also publishes into every matching varver —
+        per-suffix routing (issue #2468) sends each to its own row's varver either
+        way; this pins the identical-bytes case never regresses alongside it."""
         assets_dir = self.new_assets_dir()
         digests = _populate_assets_dir(
             assets_dir, rows=(ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN), source_tag="v4.0.0.b1", include_dependency=False
@@ -797,6 +776,234 @@ class DestinationConflictTests(_TempDirTestCase):
         self.assertIn(str(published), message)
         self.assertIn("pfSense-pkg-pfBlockerNG-4.0.0.b1.pkg", message)
         self.assertEqual(published.read_bytes(), original_bytes)  # never overwritten
+
+
+# --------------------------------------------------------------------------- #
+# issue #2468 — dependency .pkg identity = filename: place-if-missing, never
+# byte-compared or overwritten. Canonical packages keep the strict conflict check.
+# --------------------------------------------------------------------------- #
+
+
+class DependencyPlaceIfMissingTests(_TempDirTestCase):
+    @_requires_engine
+    def test_stale_destination_dependency_bytes_untouched_canonical_published(self) -> None:
+        """RED CANARY (issue #2468): a destination already holding a byte-different
+        same-name dependency .pkg (e.g. left over from an older release) must never
+        block this run — the dependency's filename IS its identity; publishers place
+        it only when missing and never compare or overwrite it. The canonical
+        package still publishes normally alongside the untouched stale dependency."""
+        assets_dir = self.new_assets_dir()
+        digests = _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1", include_dependency=False)
+        declared = _dependency_declared_name(name="py311-charset-normalizer", version="3.4.0", row=ROW_CE)
+        _path, digest = _wrap_dependency_pkg(
+            assets_dir,
+            version="3.4.0",
+            abi="FreeBSD:15:*",
+            local_name=declared,
+            payload={"filler.bin": b"incoming-build"},
+        )
+        digests[declared] = digest
+        (assets_dir / pr._DIGESTS_FILENAME).write_text(json.dumps(digests), encoding="utf-8")
+
+        catalogue_dir = self.pkg_repo / "docs" / "edge" / "ce-2.8"
+        stale_dir = self.tmp / "stale-dep-seed"
+        stale_dir.mkdir()
+        stale_path, _stale_digest = _wrap_dependency_pkg(
+            stale_dir,
+            version="3.4.0",
+            abi="FreeBSD:15:*",
+            local_name="py311-charset-normalizer-3.4.0.pkg",
+            payload={"filler.bin": b"stale-build-from-an-older-release"},
+        )
+        stale_bytes = stale_path.read_bytes()
+        catalogue_dir.mkdir(parents=True)
+        (catalogue_dir / "py311-charset-normalizer-3.4.0.pkg").write_bytes(stale_bytes)
+
+        report = _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=assets_dir,
+            rows=(ROW_CE,),
+            tag="v4.0.0.b1",
+        )
+
+        self.assertFalse(report.noop)
+        self.assertTrue((catalogue_dir / "pfSense-pkg-pfBlockerNG-4.0.0.b1.pkg").is_file())
+        self.assertEqual((catalogue_dir / "py311-charset-normalizer-3.4.0.pkg").read_bytes(), stale_bytes)
+
+    @_requires_engine
+    def test_two_same_major_rows_each_own_dep_asset_lands_only_in_own_varver(self) -> None:
+        """Two same-major rows (plus-26.03 + plus-26.07, both FreeBSD 16) each carry
+        their OWN byte-different dep asset under the identical canonical name
+        (py311-twin-1.0.0.pkg). Per-suffix routing (issue #2468) sends each asset to
+        the varver of its OWN -<Variant>-<pfsense_version> suffix only — never by
+        same-major ABI match against every declaring row — so the two never collide
+        and the run succeeds, each varver holding only its own row's bytes."""
+        assets_dir = self.new_assets_dir()
+        digests = _populate_assets_dir(
+            assets_dir, rows=(ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN), source_tag="v4.0.0.b1", include_dependency=False
+        )
+        twin_bytes: dict[str, bytes] = {}
+        for row, filler in ((ROW_PLUS_03_TWIN, b"built-by-leg-one"), (ROW_PLUS_07_TWIN, b"built-by-leg-two")):
+            declared = _dependency_declared_name(name="py311-twin", version="1.0.0", row=row)
+            path, digest = _wrap_dependency_pkg(
+                assets_dir,
+                name="py311-twin",
+                version="1.0.0",
+                abi="FreeBSD:16:*",
+                local_name=declared,
+                payload={"filler.bin": filler},
+            )
+            digests[declared] = digest
+            twin_bytes[str(row["pfsense_version"])] = path.read_bytes()
+        (assets_dir / pr._DIGESTS_FILENAME).write_text(json.dumps(digests), encoding="utf-8")
+
+        report = _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=assets_dir,
+            rows=(ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN),
+            tag="v4.0.0.b1",
+        )
+
+        self.assertFalse(report.noop)
+        for row in (ROW_PLUS_03_TWIN, ROW_PLUS_07_TWIN):
+            row_varver = _ENGINE.build_repo_portable.catalog_name_from_version(row["pfsense_version"], row["variant"])
+            dep_path = self.pkg_repo / "docs" / "edge" / row_varver / "py311-twin-1.0.0.pkg"
+            self.assertTrue(dep_path.is_file(), row_varver)
+            self.assertEqual(dep_path.read_bytes(), twin_bytes[str(row["pfsense_version"])], row_varver)
+
+    @_requires_engine
+    def test_dependency_abi_mismatching_its_suffix_row_major_rejected(self) -> None:
+        """A dependency asset whose OWN suffix names a valid canonical target row,
+        but whose manifest ABI does not match that row's FreeBSD major, is rejected
+        — per-suffix routing never falls back to matching a DIFFERENT row by ABI.
+        ROW_ROUTE_ONLY_16 lets the ABI clear axis 9 (S1's own "matches SOME ROUTE
+        row" check) so this test isolates publish_release's own suffix-row check."""
+        assets_dir = self.new_assets_dir()
+        digests = _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1", include_dependency=False)
+        declared = _dependency_declared_name(name="py311-charset-normalizer", version="3.4.0", row=ROW_CE)
+        _path, digest = _wrap_dependency_pkg(
+            assets_dir,
+            version="3.4.0",
+            abi="FreeBSD:16:*",  # ROW_CE (its suffix row) is FreeBSD 15 — deliberate mismatch.
+            local_name=declared,
+        )
+        digests[declared] = digest
+        (assets_dir / pr._DIGESTS_FILENAME).write_text(json.dumps(digests), encoding="utf-8")
+
+        with self.assertRaises(pr.PublishReleaseError) as ctx:
+            _run(
+                pkg_repo=self.pkg_repo,
+                assets_dir=assets_dir,
+                rows=(ROW_CE, ROW_ROUTE_ONLY_16),
+                tag="v4.0.0.b1",
+            )
+        self.assertIn("matches no varver targeted", str(ctx.exception))
+
+    def test_asset_map_two_deps_same_canonical_name_rejected(self) -> None:
+        """Unit test on _asset_map directly (issue #2468 coverage row 6): two
+        dependency VerifiedAssets that resolve to the SAME canonical name always
+        conflict — no byte-compare-then-tolerate branch, no file reads. Never
+        reachable end-to-end from one tagged run (a real asset set cannot carry
+        two on-disk files sharing one declared filename); reachable via nightly
+        handoffs or direct API use."""
+        canonical = pc.VerifiedAsset(
+            asset_class="canonical",
+            declared_name="pfSense-pkg-pfBlockerNG-4.0.0.b1-CE-2.8.pkg",
+            canonical_name="pfSense-pkg-pfBlockerNG-4.0.0.b1.pkg",
+            work_path=Path("pfSense-pkg-pfBlockerNG-4.0.0.b1.pkg"),
+            sha256="a" * 64,
+            manifest={},
+            record={"matrix_row": ROW_CE},
+        )
+        dep_one = pc.VerifiedAsset(
+            asset_class="dependency",
+            declared_name="py311-twin-1.0.0-CE-2.8.pkg",
+            canonical_name="py311-twin-1.0.0.pkg",
+            work_path=Path("dep-one.pkg"),
+            sha256="b" * 64,
+            manifest={},
+            release_suffix=("CE", "2.8"),
+        )
+        dep_two = pc.VerifiedAsset(
+            asset_class="dependency",
+            declared_name="py311-twin-1.0.0-CE-2.8-again.pkg",
+            canonical_name="py311-twin-1.0.0.pkg",
+            work_path=Path("dep-two.pkg"),
+            sha256="c" * 64,
+            manifest={},
+            release_suffix=("CE", "2.8"),
+        )
+        target = pr._Target(row=ROW_CE, canonical=canonical, dependencies=[dep_one, dep_two])
+
+        with self.assertRaises(pr.DestinationConflictError) as ctx:
+            pr._asset_map(target)
+        message = str(ctx.exception)
+        self.assertIn(dep_one.declared_name, message)
+        self.assertIn(dep_two.declared_name, message)
+        self.assertIn(dep_one.sha256, message)
+        self.assertIn(dep_two.sha256, message)
+
+    @_requires_engine
+    def test_multi_channel_fanout_dep_differs_at_one_channel_no_identity_violation(self) -> None:
+        """issue #2468 coverage row 13: canonical is identical across a multi-channel
+        fan-out (verify_multi_destination_identity still enforces THAT), but a
+        dependency that already differs at ONE destination channel — because it was
+        placed there by an earlier run and this run's dep is missing at the OTHER
+        channel — must never trip the identity check. Dependencies are excluded
+        from source_index: fan-out byte identity is a canonical-package invariant."""
+        assets_dir = self.new_assets_dir()
+        digests = _populate_assets_dir(
+            assets_dir,
+            channel="testing",
+            rows=(ROW_CE,),
+            source_tag="v4.0.1.b1",
+            include_dependency=False,
+        )
+        declared = _dependency_declared_name(name="py311-charset-normalizer", version="3.4.0", row=ROW_CE)
+        _path, digest = _wrap_dependency_pkg(
+            assets_dir,
+            version="3.4.0",
+            abi="FreeBSD:15:*",
+            local_name=declared,
+            payload={"filler.bin": b"this-runs-build"},
+        )
+        digests[declared] = digest
+        (assets_dir / pr._DIGESTS_FILENAME).write_text(json.dumps(digests), encoding="utf-8")
+
+        testing_dir = self.pkg_repo / "docs" / "testing" / "ce-2.8"
+        testing_dir.mkdir(parents=True)
+        stale_dir = self.tmp / "stale-dep-seed"
+        stale_dir.mkdir()
+        stale_path, _stale_digest = _wrap_dependency_pkg(
+            stale_dir,
+            version="3.4.0",
+            abi="FreeBSD:15:*",
+            local_name="py311-charset-normalizer-3.4.0.pkg",
+            payload={"filler.bin": b"an-earlier-runs-build"},
+        )
+        stale_bytes = stale_path.read_bytes()
+        (testing_dir / "py311-charset-normalizer-3.4.0.pkg").write_bytes(stale_bytes)
+
+        report = _run(
+            pkg_repo=self.pkg_repo,
+            assets_dir=assets_dir,
+            rows=(ROW_CE,),
+            channel="testing",
+            destinations='["testing","edge"]',
+            tag="v4.0.1.b1",
+        )
+
+        self.assertEqual(set(report.touched), {("testing", "ce-2.8"), ("edge", "ce-2.8")})
+        testing_pkg = testing_dir / "pfSense-pkg-pfBlockerNG-4.0.1.b1.pkg"
+        edge_dir = self.pkg_repo / "docs" / "edge" / "ce-2.8"
+        edge_pkg = edge_dir / "pfSense-pkg-pfBlockerNG-4.0.1.b1.pkg"
+        self.assertEqual(testing_pkg.read_bytes(), edge_pkg.read_bytes())  # canonical still identical
+
+        testing_dep = testing_dir / "py311-charset-normalizer-3.4.0.pkg"
+        edge_dep = edge_dir / "py311-charset-normalizer-3.4.0.pkg"
+        self.assertEqual(testing_dep.read_bytes(), stale_bytes)  # untouched, already present
+        self.assertTrue(edge_dep.is_file())
+        self.assertNotEqual(edge_dep.read_bytes(), stale_bytes)  # placed fresh, missing before
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Replaces the reverted PR #2466 "dependency flow split" with one rule inside the existing publishers:

**A dependency `.pkg` at a destination is identified by its filename (`<name>-<version>.pkg`) — publishers place it if missing and never byte-compare or overwrite it.** Canonical packages keep today's strict byte-conflict check.

- `publish_catalogues.VerifiedAsset` carries the tagged Release-asset suffix `_verify_dependency_asset` already parses (`release_suffix = (variant, pfsense_version)`; `None` for canonical and Nightly assets).
- `publish_release._build_targets` routes each dependency asset to the varver of **its own suffix row** — never by ABI-matching every same-major declaring row. That row must be one of this run's canonical targets, must declare the dependency's origin in `extra_pkgs` (category-exact), and its ABI must match the row's FreeBSD major; otherwise the run is rejected as before (`matches no varver targeted …`).
- `publish_release._drop_assets` skips a dependency whose destination file already exists (no read, no compare). The canonical entry keeps `DestinationConflictError` on differing bytes.
- `_asset_map` maps canonical name → `VerifiedAsset` and rejects two assets sharing one canonical name unconditionally (the byte-compare-then-tolerate branch is gone).
- Both publishers feed only the canonical asset into the multi-destination fan-out identity index: fan-out byte identity stays a canonical-package invariant, so a dependency that already differs at one destination but is freshly placed at another is expected, not a divergence.
- `publish_nightly` reuses the shared helpers unchanged; `_route_targets`, retention/eviction (`_evict_undeclared_deps`, `prune_retained`) and every workflow are untouched.

Nothing from the reverted dependency flow comes back: no `publish_deps.py`, no `prepare-dep-ports.sh`, no `PORTS_DIR`, no ports checkout in publish jobs.

## Why

Nightly run 31946942035 aborted with `docs/nightly/ce-2.8/py311-charset-normalizer-3.4.4.pkg: already publishes a different build …` — a dependency rebuilt from a new source commit differs only in bytes (`SOURCE_DATE_EPOCH`) under the same `<name>-<version>` identity. Tagged copies would trip the same abort on the next release that rebuilds the dependency.

## Coverage

| Coverage-matrix row (issue #2468) | Test |
| --- | --- |
| one row with a dep (ce-2.8) | `test_first_publish_single_varver_with_dependency` (existing) |
| three rows, dep only in CE | `test_first_publish_three_varvers_dependency_only_in_ce` (existing) |
| two same-major rows, each with its own byte-different dep asset → each lands only in its own varver | `DependencyPlaceIfMissingTests::test_two_same_major_rows_each_own_dep_asset_lands_only_in_own_varver` (replaces the old reject-based test, whose premise this rule inverts) |
| dep asset whose suffix row is not a canonical target → reject | `TargetResolutionTests::test_dependency_matches_no_run_target_rejected` (existing) |
| dep asset whose suffix row does not declare its origin → reject | `SameMajorDestScopeTests::test_undeclared_twin_dep_against_empty_plus_extra_pkgs_rejected` (existing) |
| two dep assets with the same suffix and canonical name → reject | `DependencyPlaceIfMissingTests::test_asset_map_two_deps_same_canonical_name_rejected` |
| dep ABI mismatching its suffix row's major → reject | `DependencyPlaceIfMissingTests::test_dependency_abi_mismatching_its_suffix_row_major_rejected` |
| destination already holds the dep with DIFFERENT bytes → dep untouched, canonical published, no error (**the red canary**) | `DependencyPlaceIfMissingTests::test_stale_destination_dependency_bytes_untouched_canonical_published` (tagged) + `test_rebuilt_dependency_different_bytes_publishes_without_conflict` (nightly) |
| destination lacks the dep → placed, descriptor regenerated | existing publish-flow tests |
| canonical with different bytes at destination → still `DestinationConflictError` | `DestinationConflictTests`, `OutcomeTests::test_incomplete_descriptor_with_divergent_bytes_still_fails_closed` (existing, unchanged) |
| eviction: undeclared / other-category leftovers evicted, declared kept | `ExtraPkgsEvictionTests` (existing, unchanged) |
| exact republish → NOOP; incomplete descriptor → regenerated | `OutcomeTests` (existing, unchanged) |
| multi-channel fan-out, dep differs at one channel | `DependencyPlaceIfMissingTests::test_multi_channel_fanout_dep_differs_at_one_channel_no_identity_violation` |
| same-major CE dep must not land on Plus `extra_pkgs=[]` | `SameMajorDestScopeTests::test_same_major_dep_not_published_to_row_with_empty_extra_pkgs` (existing, unchanged) |
| nightly: two same-major ROUTE rows both declaring the dep both receive it | `test_two_same_major_rows_both_declaring_dep_both_receive_it` |

Hostile-input rows (missing suffix, malformed suffix, suffix outside the ROUTE matrix, `..`/`/` in the name, same canonical name under different suffixes) stay enforced by `publish_catalogues._verify_dependency_asset` / `_validate_asset_name` and their existing tests.

## Evidence

Red→green, test-first: the two canary tests were authored first, executed RED against untouched production code, frozen byte-identical, then re-run GREEN. Reproduced independently by the orchestrator in a scratch worktree holding this branch's tests with `scripts/publish_release.py` / `publish_nightly.py` / `publish_catalogues.py` restored to `origin/devel`:

```
$ scripts/run-in-docker.sh python3 -m pytest -q \
    tests/test_publish_release.py::DependencyPlaceIfMissingTests::test_stale_destination_dependency_bytes_untouched_canonical_published \
    tests/test_publish_nightly.py::DependencyPlaceIfMissingTests::test_rebuilt_dependency_different_bytes_publishes_without_conflict
E               publish_release.DestinationConflictError: /tmp/pub-nightly-test-cpgqwltd/pkg-repo/docs/nightly/ce-2.8/py311-charset-normalizer-3.4.0.pkg: already publishes a different build of py311-charset-normalizer-3.4.0.pkg — existing sha256=0acf91b3133c5e58b595e34504120d12c25b0a21931132894663b0da299c05c4, incoming sha256=c174933ea7d3ca9ca0a0f3ca099d006ca765d942dae14d31715fda86856c785e

scripts/publish_release.py:277: DestinationConflictError
=========================== short test summary info ============================
FAILED tests/test_publish_release.py::DependencyPlaceIfMissingTests::test_stale_destination_dependency_bytes_untouched_canonical_published
FAILED tests/test_publish_nightly.py::DependencyPlaceIfMissingTests::test_rebuilt_dependency_different_bytes_publishes_without_conflict
============================== 2 failed in 0.19s ===============================
```

Same two test files, byte-identical (`diff -q` clean between the red tree and this branch), against this branch's production code:

```
$ scripts/run-in-docker.sh python3 -m pytest -q <same two node ids>
============================== 2 passed in 0.18s ===============================
```

Suites and gates:

```
$ scripts/run-in-docker.sh python3 -m pytest -q tests/test_publish_release.py tests/test_publish_nightly.py \
    tests/test_publish_catalogues.py tests/test_issue2383_extra_pkgs_row_scope.py
184 passed in 3.52s          # 172 passed on this branch's base before the change

$ scripts/run-in-docker.sh python3 -m pytest -q tests/
5469 passed, 4 skipped in 63.72s

$ scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: python3 -m pytest
GATE PASS: ruff check .
GATE PASS: ruff format --check .
GATE PASS: mypy tests/
GATE PASS: npx markdownlint-cli2
GATES: PASS
```

Review round 2 (`c72e5662e`) fixed one blocking finding — `_drop_assets` ran before `_evict_undeclared_deps`, so a same-name leftover carrying an origin the row no longer declares was skipped over and then unlinked, publishing a catalogue without the dependency this run had verified. Both publishers now evict first. Red first, again:

```
$ scripts/run-in-docker.sh python3 -m pytest -q \
    tests/test_publish_release.py::DependencyPlaceIfMissingTests::test_undeclared_same_name_leftover_replaced_by_this_runs_dependency
E       AssertionError: False is not true : this run's verified dependency is missing from the catalogue
============================== 1 failed in 0.13s ===============================
```

after the reorder, with both test files byte-identical (`git hash-object` unchanged across the two runs): `184 passed`.

## Notes

- No workflow changes: `release.yml`'s dependency build/attach/healthcheck and `nightly.yml`'s dependency loop stay exactly as the revert left them.
- `#2467` (per-leg ports SHA) is already closed — it was moot after the revert.
- `#2190` / `#2221` / `#961` stay open until the first green live nightly runs through this path.

Fixes #2468

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency asset routing so releases are published only to matching version, ABI, and package targets.
  - Existing dependency files are now preserved during nightly and release publishing, avoiding unnecessary overwrites or conflicts.
  - Removed undeclared or stale dependency files before publishing current assets.
  - Added validation for malformed or missing release information and duplicate canonical assets.
  - Improved handling of dependencies shared across destinations and release channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->