### PR TITLE
smoke: address matrix legs by row identity, drop cross-row assertions (#2464)

### DIFF
--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -89,7 +89,9 @@ jobs:
           set -eu
           # `--print-ci` is the row-per-version view the reader filters on ci:true, so the only
           # invariant is that each row says so itself — never "which editions are allowed in
-          # CI" (Plus has been ci:true since ADR-24).
+          # CI" (Plus has been ci:true since ADR-24). `variant` is required below even though
+          # the reader defaults it to "": the smoke topology derives a catalog name from it,
+          # so a row without one yields a catalog like "-2.8" that no producer publishes.
           printf '%s' "$CI_MATRIX" | jq -e '
             length > 0 and all(.[]; . as $row |
               $row.ci == true and
@@ -100,9 +102,6 @@ jobs:
               ($row.php_version | test("^[0-9]+[.][0-9]+$")) and
               ($row.py_flavor | test("^py[0-9]+$"))
             )
-            # `variant` is required here even though the reader defaults it to "": the smoke
-            # topology derives this leg's catalog name from it, so a row without one produces
-            # a catalog like "-2.8" that no producer publishes.
           ' > /dev/null || {
             printf '::error::a CI row is not internally consistent, or is not ci:true\n'
             printf '%s' "$CI_MATRIX" | jq .

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -55,59 +55,72 @@ jobs:
           COUNT="$(printf '%s' "$CI_MATRIX" | jq 'length')"
           printf '\n%s CI entries\n' "$COUNT"
 
-      - name: Verify build matrix contains expected CE 2.8 entry
+      - name: Verify every build row is internally consistent
         env:
           BUILD_MATRIX: ${{ steps.matrices.outputs.build_matrix }}
         run: |
           set -eu
-          # Sanity: the seed must have the 2.8 CE entry with FreeBSD 15 + PHP 8.3.
-          ENTRY="$(printf '%s' "$BUILD_MATRIX" | jq -e '
-            .[] | select(.channel == "CE" and .pfsense_version == "2.8")  # version-literal-ok: sanity pin - asserts the seed carries the expected CE entry
-          ')" || {
-            printf '::error::BUILD matrix is missing the expected CE 2.8 entry\n'
+          # Row-local conformance only (issue #2464): every row is checked against ITS OWN
+          # fields. No edition -> FreeBSD major, edition -> php, or edition -> ci mapping is
+          # asserted anywhere: the matrix is a matrix, and two rows may legitimately share a
+          # build target (CE 2.9 and Plus 26.03 are both FreeBSD 16 / php 8.5) or an edition
+          # and a major (Plus 26.03 and Plus 26.07). `--print-build` also drops `.ci` and
+          # dedupes to one row per freebsd_major, so no edition-keyed count is meaningful here.
+          printf '%s' "$BUILD_MATRIX" | jq -e '
+            length > 0 and all(.[]; . as $row |
+              ($row.pfsense_version | test("^[0-9]+[.][0-9]+")) and
+              ($row.freebsd_version | startswith($row.freebsd_major + ".")) and
+              ($row.php_version | test("^[0-9]+[.][0-9]+$")) and
+              ($row.py_flavor | test("^py[0-9]+$")) and
+              ($row.channel | test("^(CE|Plus)$")) and
+              ($row.variant == $row.channel)
+            )
+          ' > /dev/null || {
+            printf '::error::a BUILD row is not internally consistent\n'
+            printf '%s' "$BUILD_MATRIX" | jq .
             exit 1
           }
-          FB="$(printf '%s' "$ENTRY" | jq -r '.freebsd_version')"
-          PHP="$(printf '%s' "$ENTRY" | jq -r '.php_version')"
-          CI_FLAG="$(printf '%s' "$ENTRY" | jq -r '.ci')"
-          if [ "$FB" != "15.0-RELEASE" ]; then
-            printf '::error::CE 2.8 freebsd_version expected 15.0-RELEASE, got %s\n' "$FB"
-            exit 1
-          fi
-          if [ "$PHP" != "8.3" ]; then
-            printf '::error::CE 2.8 php_version expected 8.3, got %s\n' "$PHP"
-            exit 1
-          fi
-          if [ "$CI_FLAG" != "true" ]; then
-            printf '::error::CE 2.8 ci expected true, got %s\n' "$CI_FLAG"
-            exit 1
-          fi
-          printf 'CE 2.8 entry OK: FreeBSD %s, PHP %s, ci=%s\n' "$FB" "$PHP" "$CI_FLAG"
+          printf 'every BUILD row is internally consistent\n'
 
-      - name: Verify Plus entry is ci:false
-        env:
-          BUILD_MATRIX: ${{ steps.matrices.outputs.build_matrix }}
-        run: |
-          set -eu
-          # Plus entries must never be in CI.
-          PLUS_CI="$(printf '%s' "$BUILD_MATRIX" | jq '[.[] | select(.channel == "Plus" and .ci == true)] | length')"
-          if [ "$PLUS_CI" -ne 0 ]; then
-            printf '::error::%s Plus entries have ci=true — Plus must always be ci:false\n' "$PLUS_CI"
-            exit 1
-          fi
-          printf 'Plus entries all have ci=false: OK\n'
-
-      - name: Verify CI matrix contains only CE entries
+      - name: Verify every CI row is internally consistent and ci:true
         env:
           CI_MATRIX: ${{ steps.matrices.outputs.ci_matrix }}
         run: |
           set -eu
-          NON_CE="$(printf '%s' "$CI_MATRIX" | jq '[.[] | select(.channel != "CE")] | length')"
-          if [ "$NON_CE" -ne 0 ]; then
-            printf '::error::CI matrix contains %s non-CE entries — only CE should be in CI\n' "$NON_CE"
+          # `--print-ci` is the row-per-version view the reader filters on ci:true, so the only
+          # invariant is that each row says so itself — never "which editions are allowed in
+          # CI" (Plus has been ci:true since ADR-24).
+          printf '%s' "$CI_MATRIX" | jq -e '
+            length > 0 and all(.[]; . as $row |
+              $row.ci == true and
+              ($row.channel | test("^(CE|Plus)$")) and
+              ($row.variant == $row.channel) and
+              ($row.freebsd_version | startswith($row.freebsd_major + ".")) and
+              ($row.php_version | test("^[0-9]+[.][0-9]+$")) and
+              ($row.py_flavor | test("^py[0-9]+$"))
+            )
+          ' > /dev/null || {
+            printf '::error::a CI row is not internally consistent, or is not ci:true\n'
+            printf '%s' "$CI_MATRIX" | jq .
             exit 1
-          fi
-          printf 'CI matrix contains only CE entries: OK\n'
+          }
+          printf 'every CI row is internally consistent and ci:true\n'
+
+      - name: Verify every CI row is uniquely identified by its version
+        env:
+          CI_MATRIX: ${{ steps.matrices.outputs.ci_matrix }}
+        run: |
+          set -eu
+          # The row identity the smoke topology addresses legs by (SMOKE_PFSENSE_VERSION,
+          # tests/smoke/_matrix.py). Duplicate versions would make a leg ambiguous.
+          printf '%s' "$CI_MATRIX" | jq -e '
+            ([.[].pfsense_version] | length) == ([.[].pfsense_version] | unique | length)
+          ' > /dev/null || {
+            printf '::error::two CI rows share a pfsense_version — a leg cannot be addressed\n'
+            printf '%s' "$CI_MATRIX" | jq -r '.[].pfsense_version'
+            exit 1
+          }
+          printf 'every CI row has a unique pfsense_version\n'
 
       - name: Verify reject-unknown behaviour (simulate unknown version lookup)
         run: |

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -45,12 +45,12 @@ jobs:
           COUNT="$(printf '%s' "$BUILD_MATRIX" | jq 'length')"
           printf '\n%s entries total\n' "$COUNT"
 
-      - name: Print CI matrix (ci:true CE entries only)
+      - name: Print CI matrix (every ci:true row)
         env:
           CI_MATRIX: ${{ steps.matrices.outputs.ci_matrix }}
         run: |
           set -eu
-          printf '=== CI matrix (ci:true CE entries only — fed to smoke fan-out) ===\n'
+          printf '=== CI matrix (every ci:true row — fed to smoke fan-out) ===\n'
           printf '%s' "$CI_MATRIX" | jq .
           COUNT="$(printf '%s' "$CI_MATRIX" | jq 'length')"
           printf '\n%s CI entries\n' "$COUNT"
@@ -100,6 +100,9 @@ jobs:
               ($row.php_version | test("^[0-9]+[.][0-9]+$")) and
               ($row.py_flavor | test("^py[0-9]+$"))
             )
+            # `variant` is required here even though the reader defaults it to "": the smoke
+            # topology derives this leg's catalog name from it, so a row without one produces
+            # a catalog like "-2.8" that no producer publishes.
           ' > /dev/null || {
             printf '::error::a CI row is not internally consistent, or is not ci:true\n'
             printf '%s' "$CI_MATRIX" | jq .

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -93,6 +93,7 @@ jobs:
           printf '%s' "$CI_MATRIX" | jq -e '
             length > 0 and all(.[]; . as $row |
               $row.ci == true and
+              ($row.pfsense_version | test("^[0-9]+[.][0-9]+")) and
               ($row.channel | test("^(CE|Plus)$")) and
               ($row.variant == $row.channel) and
               ($row.freebsd_version | startswith($row.freebsd_major + ".")) and

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1257,8 +1257,7 @@ Full design: ADR-39.
   distribution flow, **deselected from `-m smoke`**) — install-from-our-repo (no `-f`), cross-repo
   precedence (both directions vs a `netgate-decoy`), `pkg upgrade` `_1`→`_9`, and the catalog
   accepted from both generators. The ADR-20 **variant topology** (each leg's ABI / PHP / Python /
-  catalog, and the opposite-edition guard) is **derived entirely from the version matrix** — never
-  hardcoded CE/Plus: `tests/smoke/_matrix.py` (unit-tested off-box by `tests/test_smoke_matrix.py`)
+  catalog) is **derived entirely from the version matrix** — never hardcoded CE/Plus: `tests/smoke/_matrix.py` (unit-tested off-box by `tests/test_smoke_matrix.py`)
   reads `SMOKE_MATRIX_JSON` (smoke-single.yml injects `read-version-matrix.sh --print-ci` at job start —
   issue #1806 W3: never `--print-build`, which dedupes by `freebsd_major` and would hide a same-major
   second edition from this topology entirely — egress open), falls back to running that script, and
@@ -1267,7 +1266,16 @@ Full design: ADR-39.
   stays a CONCRETE guest ABI); when it matches more than one edition sharing a `freebsd_major`
   (issue #1806 — no `arch` left to disambiguate by), `SMOKE_IMAGE_REF` (already exported by
   smoke-single.yml) breaks the tie by image name, and `_own_entry()` refuses loudly rather than
-  silently picking one when it can't. Adding a pfSense version needs no edit here.
+  silently picking one when it can't. A leg is addressed by its OWN row identity —
+  `SMOKE_PFSENSE_VERSION`, exported per leg by smoke-single.yml and ui-tests.yml — and the
+  topology carries one Variant per ROW; a bare dispatch that names no leg falls back to the
+  matrix's first row, documented as arbitrary. Nothing maps an edition to an ABI, a php version,
+  or a release line, and no assertion compares one row against another (issue #2464): rows may
+  share a build target (CE 2.9 and Plus 26.03 are both FreeBSD:16 / php85) or an edition and a
+  major (Plus 26.03 / Plus 26.07 — keying the topology on (ABI, edition) had silently dropped
+  26.07 and pointed that leg at the plus-26.03 catalog). The retired ADR-20 "wrong variant is
+  rejected" case asserted a cross-row difference and is gone; each leg asserts conformance to its
+  own row instead. Adding a pfSense version needs no edit here.
   (`scripts/install-from-repo.sh` likewise derives its `py3xx-*` deps from the matrix, matching the
   box's FreeBSD major.) Dispatch: `gh workflow run smoke-single.yml -f
   pytest_marker=repo` (or `repo-install.yml` once it lands on `devel`). The gated

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1274,9 +1274,10 @@ Full design: ADR-39.
   or a release line, and no assertion compares one row against another (issue #2464): rows may
   share a build target (CE 2.9 and Plus 26.03 are both FreeBSD:16 / php85) or an edition and a
   major (Plus 26.03 / Plus 26.07 — keying the topology on (ABI, edition) had silently dropped
-  26.07 and pointed that leg at the plus-26.03 catalog). The retired ADR-20 "wrong variant is
-  rejected" case asserted a cross-row difference and is gone; each leg asserts conformance to its
-  own row instead. Adding a pfSense version needs no edit here.
+  26.07 and pointed that leg at the plus-26.03 catalog). ADR-20's "a package that is not this box's build must
+  not install" case survives, re-framed row-locally: the forged package's target is derived from
+  THIS leg's row (the next FreeBSD major, a php this row does not use), never from a sibling
+  row. Adding a pfSense version needs no edit here.
   (`scripts/install-from-repo.sh` likewise derives its `py3xx-*` deps from the matrix, matching the
   box's FreeBSD major.) Dispatch: `gh workflow run smoke-single.yml -f
   pytest_marker=repo` (or `repo-install.yml` once it lands on `devel`). The gated

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1257,7 +1257,8 @@ Full design: ADR-39.
   distribution flow, **deselected from `-m smoke`**) — install-from-our-repo (no `-f`), cross-repo
   precedence (both directions vs a `netgate-decoy`), `pkg upgrade` `_1`→`_9`, and the catalog
   accepted from both generators. The ADR-20 **variant topology** (each leg's ABI / PHP / Python /
-  catalog) is **derived entirely from the version matrix** — never hardcoded CE/Plus: `tests/smoke/_matrix.py` (unit-tested off-box by `tests/test_smoke_matrix.py`)
+  catalog) is **derived entirely from the version matrix** — never hardcoded CE/Plus:
+  `tests/smoke/_matrix.py` (unit-tested off-box by `tests/test_smoke_matrix.py`)
   reads `SMOKE_MATRIX_JSON` (smoke-single.yml injects `read-version-matrix.sh --print-ci` at job start —
   issue #1806 W3: never `--print-build`, which dedupes by `freebsd_major` and would hide a same-major
   second edition from this topology entirely — egress open), falls back to running that script, and

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -274,7 +274,7 @@ CI_MATRIX="$(printf '%s' "$_BUILD_ROLE_ENTRIES" | jq -c '
 if [ "${_VF_LOWER:-}" != "plus" ]; then
   CI_COUNT="$(printf '%s' "$CI_MATRIX" | jq 'length')"
   if [ "$CI_COUNT" -eq 0 ]; then
-    printf '::error::CI matrix is empty — no ci:true CE entries in %s\n' "$MATRIX_FILE" >&2
+    printf '::error::CI matrix is empty — no ci:true entries in %s\n' "$MATRIX_FILE" >&2
     exit 1
   fi
 fi

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -164,22 +164,24 @@ fi
 cd "$REPO_ROOT"
 
 # ── Derive build params from the ABI ─────────────────────────────────────── #
-# Extract FreeBSD major to pick the matching PHP version.
-# FreeBSD 15 = CE 2.8 (php 8.3); FreeBSD 16 = Plus 26.03 (php 8.5).
-# py_flavor is py311 for all current legs.
+# The FreeBSD major picks the matrix row; the row supplies php_version and py_flavor.
+# NEVER a major -> php table (issue #2464): "FreeBSD 15 means php 8.3" was the current
+# row set written down as a rule, so a new major silently built the wrong php, and the
+# same file already trusted the matrix for the dep .pkg flavor a few steps below.
+# --print-build is deduped to one row per major, which is exactly this lookup's key.
 _freebsd_major="${_ABI#FreeBSD:}"
 _freebsd_major="${_freebsd_major%%:*}"
-case "$_freebsd_major" in
-    15) _php_ver="8.3" ;;
-    16) _php_ver="8.5" ;;
-    *)
-        printf 'smoke-on-box: unknown FreeBSD major %s in ABI %s; defaulting to 8.3\n' \
-            "$_freebsd_major" "$_ABI" >&2
-        _php_ver="8.3"
-        ;;
-esac
-# ponytail: all current legs use py311; extend the case above when this changes.
-_py_flavor="py311"  # version-literal-ok: all current legs are py311 (see comment above)
+_BUILD_ROW="$(sh scripts/read-version-matrix.sh --print-build)" \
+    || { printf 'smoke-on-box: could not read the version matrix\n' >&2; exit 1; }
+_php_ver="$(printf '%s' "$_BUILD_ROW" | jq -r --arg maj "$_freebsd_major" \
+    '([.[] | select(.freebsd_major == $maj)][0].php_version) // ""')"
+_py_flavor="$(printf '%s' "$_BUILD_ROW" | jq -r --arg maj "$_freebsd_major" \
+    '([.[] | select(.freebsd_major == $maj)][0].py_flavor) // ""')"
+if [ -z "$_php_ver" ] || [ -z "$_py_flavor" ]; then
+    printf 'smoke-on-box: no matrix row for FreeBSD major %s (ABI %s) — refusing to guess php/py\n' \
+        "$_freebsd_major" "$_ABI" >&2
+    exit 1
+fi
 
 # ── Step 2: ports tree — bring to pfblockerng/use-github ───────────────────── #
 printf 'smoke-on-box: updating FreeBSD-ports at %s (php=%s %s)\n' \
@@ -302,19 +304,12 @@ printf 'smoke-on-box: pkg built: %s\n' "$SMOKE_PKG" >&2
 # extra_pkgs (port origins pfSense's own repo doesn't carry, e.g.
 # textproc/py-charset-normalizer for CE) and build each as a dep .pkg, from the
 # SAME ports tree build-leg.sh above just prepared/reused (no second clone).
-_BUILD_ROW="$(sh scripts/read-version-matrix.sh --print-build)" \
-    || { printf 'smoke-on-box: could not read the version matrix for extra_pkgs\n' >&2; exit 1; }
+# _BUILD_ROW was already read above (same --print-build view) — reuse it.
 _EXTRA_PKGS_JSON="$(printf '%s' "$_BUILD_ROW" | jq -c --arg maj "$_freebsd_major" \
     '([.[] | select(.freebsd_major == $maj)][0].extra_pkgs) // []')"
 _EXTRA_PKGS_COUNT="$(printf '%s' "$_EXTRA_PKGS_JSON" | jq 'length')"
-# This leg's OWN py_flavor from the SAME matrix row (already read above for
-# extra_pkgs) -- never the top-level hardcoded default: a dep .pkg's
-# python<NNN> RUN_DEPENDS must match the box's REAL flavor, which the matrix
-# already knows precisely, even while the branch-.pkg build above still uses
-# the hardcoded ceiling (see its own comment).
-_dep_py_flavor="$(printf '%s' "$_BUILD_ROW" | jq -r --arg maj "$_freebsd_major" \
-    '([.[] | select(.freebsd_major == $maj)][0].py_flavor) // ""')"
-[ -n "$_dep_py_flavor" ] || _dep_py_flavor="$_py_flavor"
+# The dep .pkgs use the SAME row-derived flavor as the branch .pkg above.
+_dep_py_flavor="$_py_flavor"
 SMOKE_DEP_PKGS=""
 if [ "$_EXTRA_PKGS_COUNT" -gt 0 ]; then
     _DEP_PKG_DIR="${REPO_ROOT}/out/deppkgs"

--- a/tests/shell/build_leg_ports_parity_env.sh
+++ b/tests/shell/build_leg_ports_parity_env.sh
@@ -97,14 +97,17 @@ pfsense_version = os.environ.get("PARITY_PFSENSE_VERSION", "")
 if not pfsense_version:
     import subprocess
 
-    rows = json.loads(
-        subprocess.run(
-            ["sh", str(Path(os.environ["PFB_ROOT"]) / "scripts" / "read-version-matrix.sh"), "--print-ci"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout
+    proc = subprocess.run(
+        ["sh", str(Path(os.environ["PFB_ROOT"]) / "scripts" / "read-version-matrix.sh"), "--print-ci"],
+        capture_output=True,
+        text=True,
+        check=False,
     )
+    if proc.returncode != 0:
+        # capture_output swallows the reader's own ::error:: line; re-emit it or the failure
+        # reads as an empty traceback.
+        raise SystemExit(f"read-version-matrix.sh --print-ci failed (rc={proc.returncode}): {proc.stderr.strip()}")
+    rows = json.loads(proc.stdout)
     matches = [
         r
         for r in rows

--- a/tests/shell/build_leg_ports_parity_env.sh
+++ b/tests/shell/build_leg_ports_parity_env.sh
@@ -118,7 +118,11 @@ if not pfsense_version:
             f"no matrix row for variant={variant} freebsd_major={major}; "
             f"set PARITY_PFSENSE_VERSION to name this leg's row"
         )
-    pfsense_version = str(matches[0]["pfsense_version"])
+    # Several rows can share (variant, major) — Plus 26.03 and 26.07 do. Any REAL row gives a
+    # valid route for this parity comparison (both sides of it use the same record), so pick
+    # the lowest version deterministically rather than by matrix order. Naming the leg exactly
+    # is the caller's job via PARITY_PFSENSE_VERSION.
+    pfsense_version = min(str(m["pfsense_version"]) for m in matches)
 row = {
     "pfsense_version": pfsense_version,
     "channel": variant,

--- a/tests/shell/build_leg_ports_parity_env.sh
+++ b/tests/shell/build_leg_ports_parity_env.sh
@@ -99,7 +99,7 @@ if not pfsense_version:
 
     rows = json.loads(
         subprocess.run(
-            ["sh", "scripts/read-version-matrix.sh", "--print-ci"],
+            ["sh", str(Path(os.environ["PFB_ROOT"]) / "scripts" / "read-version-matrix.sh"), "--print-ci"],
             capture_output=True,
             text=True,
             check=True,

--- a/tests/shell/build_leg_ports_parity_env.sh
+++ b/tests/shell/build_leg_ports_parity_env.sh
@@ -89,9 +89,33 @@ variant = os.environ["PARITY_VARIANT"]
 php = os.environ["PARITY_PHP"]
 py_flavor = os.environ["PARITY_PY_FLAVOR"]
 major = abi.split(":")[1]
-# A project record needs a valid pfSense version solely to derive its route. Keep
-# it deterministic while deriving the target ABI facts from the caller.
-pfsense_version = os.environ.get("PARITY_PFSENSE_VERSION", "2.8" if major == "15" else "2.9")
+# A project record needs a valid pfSense version solely to derive its route. Take it
+# from the caller, else look up a REAL matrix row for this (variant, major) — never a
+# major -> version table (issue #2464): "15 means 2.8, anything else means 2.9"
+# fabricated {Plus, 2.9}, a row that exists in no matrix, on every Plus leg.
+pfsense_version = os.environ.get("PARITY_PFSENSE_VERSION", "")
+if not pfsense_version:
+    import subprocess
+
+    rows = json.loads(
+        subprocess.run(
+            ["sh", "scripts/read-version-matrix.sh", "--print-ci"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+    matches = [
+        r
+        for r in rows
+        if str(r.get("freebsd_major")) == major and str(r.get("variant", "")).lower() == variant.lower()
+    ]
+    if not matches:
+        raise SystemExit(
+            f"no matrix row for variant={variant} freebsd_major={major}; "
+            f"set PARITY_PFSENSE_VERSION to name this leg's row"
+        )
+    pfsense_version = str(matches[0]["pfsense_version"])
 row = {
     "pfsense_version": pfsense_version,
     "channel": variant,

--- a/tests/shell/smoke_on_box_spec.sh
+++ b/tests/shell/smoke_on_box_spec.sh
@@ -167,6 +167,13 @@ STUBEOF
   It 'prepares the same channel selected for the package build'
     # Stop at the sparse-Ports boundary: no image pull, host prep, package build or VM.
     printf '0\n' > "${WORK}/port-floor"
+    # The php/py the ports prep is given come from this leg's matrix row (issue #2464),
+    # so the boundary needs the row present.
+    cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311","php_version":"8.3"}]'
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/read-version-matrix.sh"
     SPARSE_CHANNEL_FILE="${WORK}/sparse-channel"
     SPARSE_EXIT=42
     export SPARSE_CHANNEL_FILE SPARSE_EXIT
@@ -177,6 +184,27 @@ STUBEOF
     The contents of file "$SPARSE_CHANNEL_FILE" should equal 'testing'
   End
 
+  It 'refuses to build when the matrix has no row for this ABI major'
+    # issue #2464: the php/py a leg builds with come from ITS OWN matrix row. There is no
+    # major -> php table to fall back on, so an unknown major must stop the run rather than
+    # silently build a package with the wrong php.
+    printf '0\n' > "${WORK}/port-floor"
+    cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311","php_version":"8.3"}]'
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/read-version-matrix.sh"
+    SPARSE_CHANNEL_FILE="${WORK}/sparse-channel-unused"
+    SPARSE_EXIT=42
+    export SPARSE_CHANNEL_FILE SPARSE_EXIT
+
+    When run sh "$SCRIPT" --ref HEAD --abi FreeBSD:99:amd64
+    The status should not equal 0
+    The status should not equal 42
+    The stderr should include 'no matrix row for FreeBSD major 99'
+    The path "$SPARSE_CHANNEL_FILE" should not be exist
+  End
+
   It 'pulls both images into distinct container-local directories'
     printf '0\n' > "${WORK}/port-floor"
     cat > "${FAKE_ROOT}/scripts/build-leg.sh" <<'STUBEOF'
@@ -185,7 +213,7 @@ printf '%s\n' /tmp/fake.pkg
 STUBEOF
     cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
 #!/bin/sh
-printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311"}]'
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311","php_version":"8.3"}]'
 STUBEOF
     cat > "${FAKE_ROOT}/scripts/run-smoke.sh" <<'STUBEOF'
 #!/bin/sh
@@ -243,7 +271,7 @@ printf '%s\n' /tmp/fake.pkg
 STUBEOF
     cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
 #!/bin/sh
-printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311"}]'
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311","php_version":"8.3"}]'
 STUBEOF
     cat > "${FAKE_ROOT}/scripts/run-smoke.sh" <<'STUBEOF'
 #!/bin/sh
@@ -284,6 +312,11 @@ STUBEOF
 
   It 'propagates a direct image pull failure'
     printf '0\n' > "${WORK}/port-floor"
+    cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311","php_version":"8.3"}]'
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/read-version-matrix.sh"
     ORAS_PULL_EXIT=37
     export ORAS_PULL_EXIT
 
@@ -295,6 +328,11 @@ STUBEOF
 
   It 'rejects a descriptor that disagrees with the resolved digest before pulling'
     printf '0\n' > "${WORK}/port-floor"
+    cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311","php_version":"8.3"}]'
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/read-version-matrix.sh"
     ORAS_DESCRIPTOR_DIGEST=sha256:different
     export ORAS_DESCRIPTOR_DIGEST
 
@@ -318,7 +356,7 @@ printf '%s\n' /tmp/fake.pkg
 STUBEOF
     cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
 #!/bin/sh
-printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311"}]'
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311","php_version":"8.3"}]'
 STUBEOF
     chmod +x "${FAKE_ROOT}/scripts/build-leg.sh" "${FAKE_ROOT}/scripts/read-version-matrix.sh"
 
@@ -366,7 +404,7 @@ printf '%s\n' /tmp/fake.pkg
 STUBEOF
     cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
 #!/bin/sh
-printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311"}]'
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311","php_version":"8.3"}]'
 STUBEOF
     chmod +x "${FAKE_ROOT}/scripts/build-leg.sh" "${FAKE_ROOT}/scripts/read-version-matrix.sh"
 
@@ -405,7 +443,7 @@ printf '%s\n' /tmp/fake.pkg
 STUBEOF
     cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
 #!/bin/sh
-printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311"}]'
+printf '%s\n' '[{"freebsd_major":"15","extra_pkgs":[],"py_flavor":"py311","php_version":"8.3"}]'
 STUBEOF
     chmod +x "${FAKE_ROOT}/scripts/build-leg.sh" "${FAKE_ROOT}/scripts/read-version-matrix.sh"
 

--- a/tests/smoke/_matrix.py
+++ b/tests/smoke/_matrix.py
@@ -157,13 +157,14 @@ def _own_entry() -> Variant:
     version = os.environ.get("SMOKE_PFSENSE_VERSION", "").strip()
     if version:
         rows = [v for v in variants if v.version == version]
-        if not rows:
-            raise RuntimeError(
-                f"no matrix row for pfsense_version {version!r} (known: {sorted(v.version for v in variants)})"
-            )
         if len(rows) > 1:
             raise RuntimeError(f"pfsense_version {version!r} matches {len(rows)} matrix rows: {rows!r}")
-        return rows[0]
+        if rows:
+            return rows[0]
+        # Names no row, so it is not a row identity: scripts/smoke-on-box.sh exports the pfSense
+        # IMAGE TAG here (or a literal "?" for a digest-pinned ref), which need not equal any
+        # matrix pfsense_version. Fall through to ABI matching, which refuses ambiguity loudly
+        # on its own — nothing is silently mis-selected.
     abi = os.environ.get("SMOKE_ABI")
     if not abi:
         # Bare dispatch names no leg at all: fall back to the matrix's FIRST ROW. Deliberately

--- a/tests/smoke/_matrix.py
+++ b/tests/smoke/_matrix.py
@@ -9,8 +9,12 @@ unreachable); a local run falls back to running that script itself; when neither
 variant-topology cases SKIP. Per-leg selection still honours ``SMOKE_ABI`` / ``SMOKE_PHP_VERSION``
 / ``SMOKE_PY_FLAVOR`` (the fan-out exports them per matrix entry) plus ``SMOKE_IMAGE_REF``
 (issue #1806: disambiguates two editions sharing a freebsd_major, now that the matrix carries no
-``arch`` column) — SMOKE_ABI itself stays a CONCRETE guest ABI env var; a bare dispatch defaults to
-the matrix's CE entry. So adding a pfSense version to the matrix needs no edit here.
+``arch`` column) — SMOKE_ABI itself stays a CONCRETE guest ABI env var. A leg is addressed by its
+own row identity, ``SMOKE_PFSENSE_VERSION`` (exported per leg by smoke-single.yml and
+ui-tests.yml); a bare dispatch that names no leg falls back to the matrix's first row, an
+arbitrary but deterministic default. Nothing here maps an edition to an ABI, a php version, or a
+release line — two rows may share any of those (issue #2464). So adding a pfSense version to the
+matrix needs no edit here.
 
 Kept in its own stdlib-only module (no intra-package smoke imports) so the derivation is
 unit-testable off-box — see ``tests/test_smoke_matrix.py``.
@@ -34,14 +38,19 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 @dataclass(frozen=True)
 class Variant:
-    """A distributed pfSense variant, derived from a matrix entry: its pkg ``php`` dependency,
-    ABI, catalog dir, ``py`` flavor, and edition (``variant``)."""
+    """One MATRIX ROW, derived: its pkg ``php`` dependency, ABI, catalog dir, ``py`` flavor,
+    edition (``variant``) and the ``pfsense_version`` that identifies the row.
+
+    A row is identified by itself, never by a property it shares with a sibling: two rows may
+    share an edition and a FreeBSD major (Plus 26.03 / Plus 26.07), or a build target across
+    editions (CE 2.9 / Plus 26.03 are both FreeBSD:16 / php85) — issue #2464."""
 
     php: str
     abi: str
     catalog: str
     py: str
     variant: str
+    version: str
 
 
 def catalog_name(pfsense_version: str, variant: str) -> str:
@@ -92,8 +101,12 @@ def build_matrix() -> tuple[dict, ...] | None:
 
 
 def matrix_variants() -> list[Variant]:
-    """One Variant per distinct (ABI, edition) build target in the matrix. SKIPs when the matrix
-    is unavailable, so the topology cases never silently pass on hardcoded values."""
+    """One Variant per matrix ROW (duplicate rows collapse; distinct rows never do). SKIPs when
+    the matrix is unavailable, so the topology cases never silently pass on hardcoded values.
+
+    Keying this on (ABI, edition) is what issue #2464 removed: Plus 26.07 shares both with Plus
+    26.03, so it vanished from the topology and its leg silently resolved to the plus-26.03
+    catalog — a release line it does not build."""
     entries = build_matrix()
     if entries is None:
         pytest.skip(
@@ -101,7 +114,7 @@ def matrix_variants() -> list[Variant]:
             "readable by scripts/read-version-matrix.sh) — cannot derive the variant topology"
         )
     entries = cast(tuple[dict, ...], entries)
-    out: dict[tuple[str, str], Variant] = {}
+    out: dict[Variant, None] = {}
     for e in entries:
         major = str(e.get("freebsd_major", "")).strip()
         # issue #1806: the matrix carries no `arch` field at all any more (every
@@ -109,21 +122,28 @@ def matrix_variants() -> list[Variant]:
         # "amd64" here is an inert CPU placeholder, never read from the entry.
         abi = f"FreeBSD:{major}:amd64"
         variant = str(e.get("variant", "")).strip()
+        version = str(e.get("pfsense_version", "")).strip()
         out.setdefault(
-            (abi, variant),
             Variant(
                 php="php" + str(e.get("php_version", "")).replace(".", ""),
                 abi=abi,
-                catalog=catalog_name(str(e.get("pfsense_version", "")), variant),
+                catalog=catalog_name(version, variant),
                 py=str(e.get("py_flavor", "")).strip(),
                 variant=variant,
-            ),
+                version=version,
+            )
         )
-    return list(out.values())
+    return list(out)
 
 
 def _own_entry() -> Variant:
-    """This leg's variant: matched by SMOKE_ABI, else the matrix CE entry (bare dispatch).
+    """This leg's ROW: matched by SMOKE_PFSENSE_VERSION, else SMOKE_ABI, else the matrix CE
+    entry (bare dispatch).
+
+    SMOKE_PFSENSE_VERSION is the row's own identity and is exported for every leg by
+    smoke-single.yml and ui-tests.yml, so a leg never has to be inferred from a property it
+    shares with a sibling row (issue #2464). ABI matching stays as the fallback for a run that
+    sets only SMOKE_ABI.
 
     issue #1806: with `arch` retired, two editions CAN share a freebsd_major (not just an
     ADR-24 transition-window hypothetical) — SMOKE_ABI alone (a CONCRETE guest ABI env var;
@@ -134,10 +154,23 @@ def _own_entry() -> Variant:
     exactly one — a gate-A-era hazard this closes.
     """
     variants = matrix_variants()
+    version = os.environ.get("SMOKE_PFSENSE_VERSION", "").strip()
+    if version:
+        rows = [v for v in variants if v.version == version]
+        if not rows:
+            raise RuntimeError(
+                f"no matrix row for pfsense_version {version!r} (known: {sorted(v.version for v in variants)})"
+            )
+        if len(rows) > 1:
+            raise RuntimeError(f"pfsense_version {version!r} matches {len(rows)} matrix rows: {rows!r}")
+        return rows[0]
     abi = os.environ.get("SMOKE_ABI")
     if not abi:
-        ce = [v for v in variants if v.variant.lower() == "ce"]
-        abi = (ce[0] if ce else variants[0]).abi
+        # Bare dispatch names no leg at all: fall back to the matrix's FIRST ROW. Deliberately
+        # positional and documented as arbitrary — "the CE entry" was not a row identity once a
+        # second CE row existed (issue #2464), and an edition-keyed default then derived an ABI
+        # that several rows answer to. A leg that cares sets SMOKE_PFSENSE_VERSION.
+        return variants[0]
     matches = [v for v in variants if v.abi == abi]
     if not matches:
         raise RuntimeError(f"no matrix variant for ABI {abi!r} (known: {sorted(v.abi for v in variants)})")
@@ -181,13 +214,3 @@ def own_variant() -> Variant:
             f"matrix inconsistency: ABI {own.abi} maps to {own.php} but SMOKE_PHP_VERSION={env_php}"
         )
     return own
-
-
-def opposite_variant() -> Variant:
-    """The OTHER edition — the 'wrong' variant for this box (the forged package the wrong-variant
-    guard must reject): the first matrix variant of a different edition."""
-    own = own_variant()
-    others = [v for v in matrix_variants() if v.variant.lower() != own.variant.lower()]
-    if not others:
-        pytest.skip(f"matrix has no opposite-edition variant to {own.variant!r} — skipping the wrong-variant guard")
-    return others[0]

--- a/tests/smoke/_matrix.py
+++ b/tests/smoke/_matrix.py
@@ -137,8 +137,8 @@ def matrix_variants() -> list[Variant]:
 
 
 def _own_entry() -> Variant:
-    """This leg's ROW: matched by SMOKE_PFSENSE_VERSION, else SMOKE_ABI, else the matrix CE
-    entry (bare dispatch).
+    """This leg's ROW: matched by SMOKE_PFSENSE_VERSION, else SMOKE_ABI, else the matrix's
+    first row (bare dispatch).
 
     SMOKE_PFSENSE_VERSION is the row's own identity and is exported for every leg by
     smoke-single.yml and ui-tests.yml, so a leg never has to be inferred from a property it

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -390,8 +390,9 @@ def deploy(vm: SmokeVM, pkg_path: str | None = None, *, timeout: float = 300.0) 
     """Install the branch's built .pkg onto the guest via install-pkg.sh.
 
     ``pkg add`` registers the package in pkg's DB, resolves RUN_DEPENDS from the
-    LOCAL pkg db (the smoke image bakes them — scripts/misc/install_deps_CE_2.8.sh
-    — so this is OFFLINE, no repo round-trip), and runs POST-INSTALL (menus,
+    LOCAL pkg db (this leg's image bakes its own row's RUN_DEPENDS — the CE 2.8 image
+    from scripts/misc/install_deps_CE_2.8.sh, other rows from their own dep set — so
+    this is OFFLINE, no repo round-trip), and runs POST-INSTALL (menus,
     services, Unbound wiring) — fidelity
     the rsync overlay (``deploy.sh``) does not give. The .pkg is produced by the
     portable Linux build job (build-pkg-linux.yml); its path is ``pkg_path`` or ``SMOKE_PKG``.
@@ -1008,8 +1009,9 @@ def assert_hsts_loaded(vm: SmokeVM, name: str, *, timeout: float = 30.0) -> None
 # name cannot secretly resolve upstream. Egress stays OPEN through deploy + the
 # reload/DNSBL-update phase instead — that path needs a working resolver (see
 # CaseContext.__enter__) — and is restored for teardown. NOTE: `pkg add` (deploy)
-# is OFFLINE: pfBlockerNG's RUN_DEPENDS are baked into the smoke image
-# (scripts/misc/install_deps_CE_2.8.sh), so the install never needs egress.
+# is OFFLINE: pfBlockerNG's RUN_DEPENDS are baked into this leg's smoke image (the
+# row's own dep set; CE 2.8's is scripts/misc/install_deps_CE_2.8.sh), so the install
+# never needs egress.
 # Guarded by SMOKE_BLOCK_EGRESS (CI sets it) so a local `pytest -m smoke` never
 # touches the dev machine's firewall. Loopback stays up (the mock feed server is
 # reached via SLIRP 192.168.89.2 -> runner 127.0.0.1) and established flows (the

--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -374,10 +374,9 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
 
     # BACKSTOP: prove the deploy actually serves the nightly catalog from the runner
     # first (independent of the guest) — polls through first-deploy / DNS / cert lag.
-    # The varver to poll is read from the BOX itself via the _box_real_varver oracle —
-    # NEVER own_variant().catalog / the matrix: matrix_variants() dedupes by (abi,
-    # variant), so two same-major editions collapse onto the first, which would
-    # poll/serve the wrong catalog for this leg. This base already ends in /nightly,
+    # The varver to poll is read from the BOX itself via the _box_real_varver oracle:
+    # the guest, not the matrix, is the authority for which release line this leg
+    # runs. This base already ends in /nightly,
     # so the full subtree is the bare varver.
     varver = _box_real_varver(smoke_vm)
     poll_catalog_served(base_url, varver)

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1564,8 +1564,10 @@ def test_live_nightly_downgrade_requires_selected_semantic_repo(repo_vm: SmokeVM
 
 
 # =========================================================================== #
-# ADR-20 Phase 6 — variant-catalog live-VM cases (CE install, wrong-variant   #
-# guard, routing URL).                                                        #
+# ADR-20 Phase 6 — variant-catalog live-VM cases: this leg installs from ITS   #
+# OWN row's catalog, and the routing URL. The wrong-variant guard case is gone  #
+# (issue #2464): it asserted a difference between two matrix rows, which says   #
+# nothing about this build and is unfalsifiable when two rows share a target.   #
 #                                                                              #
 # Marker: @pytest.mark.repo  (inherited from pytestmark = pytest.mark.repo).  #
 # Deselected from default `python -m pytest` — dispatched via:                #

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -35,8 +35,9 @@ HOW (throwaway spike — the reusable `scripts/build-repo.sh` generator is Phase
 NOT built here):
 
   * The branch `.pkg` is built by the harness and handed in via `SMOKE_PKG`
-    (`scripts/build-pkg-portable.py` on a Linux runner — the VM's exact ABI:
-    `FreeBSD:15:amd64` / php83 / py311). We do NOT re-invoke the builder, and do
+    (`scripts/build-pkg-portable.py` on a Linux runner, for the ABI / php / Python
+    flavor THIS leg's matrix row declares — read back here via `own_variant()` and
+    `matrix_py_flavor()`, never assumed from the edition). We do NOT re-invoke the builder, and do
     NOT re-version it: priority (not version) is the precedence lever, so the real
     release `.pkg` is published as-is.
   * On the guest, the guest's OWN `pkg repo` (libpkg) builds the catalog from that
@@ -91,7 +92,6 @@ import pytest
 from . import helpers as h
 from ._matrix import (
     matrix_py_flavor,
-    opposite_variant,
     own_variant,
 )
 from .conftest import SmokeVM
@@ -468,15 +468,22 @@ def _zstd_compress(data: bytes) -> bytes:
     return subprocess.run([zstd, "-q", "-19", "-c"], input=data, stdout=subprocess.PIPE, check=True).stdout
 
 
-def read_compact_version(src_pkg: Path) -> str:
-    """The ``version`` recorded in a ``.pkg``'s ``+COMPACT_MANIFEST`` (the base to re-version from)."""
+def read_compact_manifest(src_pkg: Path) -> dict[str, object]:
+    """A ``.pkg``'s ``+COMPACT_MANIFEST``, decoded — the built package's own declared identity."""
     tar_bytes = _zstd_decompress(src_pkg.read_bytes())
     with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
         member = tf.extractfile("+COMPACT_MANIFEST")
         if member is None:
             raise RuntimeError(f"{src_pkg.name}: no +COMPACT_MANIFEST member — not a libpkg .pkg?")
         obj = json.loads(member.read())
-    version = obj.get("version")
+    if not isinstance(obj, dict):
+        raise RuntimeError(f"{src_pkg.name}: +COMPACT_MANIFEST is not an object (got {type(obj).__name__})")
+    return obj
+
+
+def read_compact_version(src_pkg: Path) -> str:
+    """The ``version`` recorded in a ``.pkg``'s ``+COMPACT_MANIFEST`` (the base to re-version from)."""
+    version = read_compact_manifest(src_pkg).get("version")
     if not isinstance(version, str) or not version:
         raise RuntimeError(f"{src_pkg.name}: +COMPACT_MANIFEST has no version string (got {version!r})")
     return version
@@ -1391,10 +1398,9 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
 
     # BACKSTOP: prove the deploy actually serves the catalog from the RUNNER first
     # (independent of the guest) — polls through first-deploy / DNS / cert lag. The
-    # varver to poll is read from the BOX itself via the _box_real_varver oracle —
-    # NEVER own_variant().catalog / the matrix: matrix_variants() dedupes by (abi,
-    # variant), so two same-major editions (e.g. Plus 26.03 + 26.07) collapse onto
-    # the first, which would poll/serve the wrong catalog for this leg. This
+    # varver to poll is read from the BOX itself via the _box_real_varver oracle: the
+    # guest, not the matrix, is the authority for which release line this leg runs.
+    # This
     # The caller passes a selected channel root, so the subtree is the bare varver.
     varver = _box_real_varver(repo_vm)
     poll_catalog_served(base_url, varver)
@@ -1640,65 +1646,6 @@ def build_repo_via_portable_named(
     return guest_catalog_dir
 
 
-def forge_variant_pkg(src_pkg: Path, out_dir: Path, *, target_php: str, target_abi: str) -> Path:
-    """Forge a fake .pkg for a DIFFERENT variant from the branch .pkg.
-
-    Re-reads the +COMPACT_MANIFEST, replaces every ``php8N`` dep key with
-    ``target_php``, sets the ``abi`` to ``target_abi``, and repacks. No payload
-    change — the dep/ABI-mismatch guard fires before pkg ever checks the files.
-    Used by the wrong-variant guard to fabricate the OPPOSITE variant for this
-    box (CE box -> Plus pkg; Plus box -> CE pkg). The returned .pkg is placed in
-    ``out_dir``.
-    """
-    tar_bytes = _zstd_decompress(src_pkg.read_bytes())
-    repacked = io.BytesIO()
-    pkg_name = ""
-    with (
-        tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tin,
-        tarfile.open(fileobj=repacked, mode="w", format=tarfile.USTAR_FORMAT) as tout,
-    ):
-        for member in tin.getmembers():
-            extracted = tin.extractfile(member) if member.isfile() else None
-            data = extracted.read() if extracted is not None else b""
-            if member.name in _PKG_MANIFEST_MEMBERS:
-                obj = json.loads(data)
-                # Swap every php8N dep for the target variant's php (CE manifest has
-                # php83; forging a Plus pkg makes it php85, and vice-versa).
-                if "deps" in obj:
-                    old_deps: dict[str, object] = obj["deps"]
-                    new_deps: dict[str, object] = {}
-                    for key, val in old_deps.items():
-                        if re.match(r"php8\d", key):
-                            # Replace the key; keep the value dict unchanged (origin/version are fictional).
-                            new_deps[target_php] = val
-                        else:
-                            new_deps[key] = val
-                    obj["deps"] = new_deps
-                # Set the target ABI: the box's own `pkg install` ABI-compatibility check is
-                # the guard under test (a concrete-vs-wildcard bucket no longer exists —
-                # issue #1806 — so this must be a wildcard ABI or the portable generator
-                # itself hard-rejects it; callers pass "FreeBSD:<opp_major>:*").
-                obj["abi"] = target_abi
-                pkg_name = obj.get("name", pkg_name)
-                data = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode() + b"\n"
-                ti = tarfile.TarInfo(name=member.name)
-                ti.size = len(data)
-                ti.mode = 0o644
-                ti.uid = ti.gid = 0
-                ti.uname, ti.gname = "root", "wheel"
-                ti.mtime = 0
-                ti.type = tarfile.REGTYPE
-                tout.addfile(ti, io.BytesIO(data))
-            else:
-                tout.addfile(member, io.BytesIO(data) if member.isfile() else None)
-    if not pkg_name:
-        raise RuntimeError(f"{src_pkg.name}: no +COMPACT_MANIFEST with a name — not a libpkg .pkg?")
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"{pkg_name}-{target_php}.pkg"
-    out_path.write_bytes(_zstd_compress(repacked.getvalue()))
-    return out_path
-
-
 def pkg_query_deps(vm: SmokeVM, *, timeout: float = 60.0) -> str:
     """Return the raw ``pkg query '%dn %dv' <PKG_NAME>`` output (dep names + versions).
 
@@ -1724,25 +1671,29 @@ def test_install_from_variant_catalog(repo_vm: SmokeVM, tmp_path: Path) -> None:
     Scenario: package installed from the variant-correct catalog for THIS box.
       Background: hermetic file:// catalog at ``<own.catalog>/`` directly (no ABI
       leaf). The variant (ABI / php / Python flavor) comes from the ci-metadata
-      matrix (SMOKE_ABI / SMOKE_PHP_VERSION / SMOKE_PY_FLAVOR), so the CE leg
-      asserts php83/FreeBSD:15 and the Plus leg asserts php85/FreeBSD:16 — no
-      hardcoded flavor.
+      matrix (SMOKE_ABI / SMOKE_PHP_VERSION / SMOKE_PY_FLAVOR), so each leg asserts
+      the deps ITS OWN matrix row declares — no hardcoded flavor.
+
+    The oracle is conformance to this leg's own matrix row, never a comparison with
+    another row (issue #2464). Two rows may legitimately share a build target — CE 2.9
+    and Plus 26.03 are both FreeBSD:16 / php85 — so "some other variant's php is absent"
+    asserts nothing about this build and is unfalsifiable exactly when the two rows agree.
 
     Given the package ABSENT and a variant-keyed catalog under ``<variant>/``
       built from the branch .pkg by the pure-Python generator,
     When ``pkg install -y <pkgname>`` resolves from this catalog,
-    Then ``pkg query '%dn %dv' <pkgname>`` shows the box's OWN php dep AND the matrix
-      Python flavor, the OPPOSITE variant's php dep is ABSENT, the version matches the
-      branch .pkg, and the origin is our repo.
+    Then ``pkg query '%dn %dv' <pkgname>`` shows the php dep AND the Python flavor this
+      leg's matrix row declares, the built .pkg's manifest ABI is the NO_ARCH wildcard on
+      that row's FreeBSD major, the version matches the branch .pkg, and the origin is
+      our repo.
     Assert BEFORE: ``pkg query '%n' <pkgname>`` returns empty (package absent).
-    Assert AFTER: dep list contains own php + Python flavor; opposite php absent; version
-      and origin correct.
+    Assert AFTER: dep list contains this row's php + Python flavor; manifest ABI matches
+      this row's FreeBSD major; version and origin correct.
     """
     pkg = os.environ.get("SMOKE_PKG")
     assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"
 
     own = own_variant()
-    opp = opposite_variant()
 
     # GIVEN: build the box's variant catalog with the variant-keyed dir on the runner,
     # ship to guest, write a NONE-signed file:// repo conf above pfSense.
@@ -1767,14 +1718,10 @@ def test_install_from_variant_catalog(repo_vm: SmokeVM, tmp_path: Path) -> None:
     combined = proc.stdout + proc.stderr
     assert "Missing dependency" not in combined, f"variant catalog: RUN_DEPENDS did not resolve:\n{combined}"
 
-    # THEN: dep list carries the box's OWN php + the matrix Python flavor, NOT the opposite php.
+    # THEN: dep list carries the php + Python flavor THIS leg's matrix row declares.
     deps_out = pkg_query_deps(repo_vm)
     assert own.php in deps_out, (
         f"{own.php} dep not satisfied after {own.abi} variant install; pkg query '%dn %dv' output:\n{deps_out}"
-    )
-    assert opp.php not in deps_out, (
-        f"opposite-variant dep {opp.php} should not appear in a {own.abi} install; "
-        f"pkg query '%dn %dv' output:\n{deps_out}"
     )
     py_flavor = matrix_py_flavor()
     assert py_flavor in deps_out, (
@@ -1785,156 +1732,21 @@ def test_install_from_variant_catalog(repo_vm: SmokeVM, tmp_path: Path) -> None:
     version = pkg_installed_version(repo_vm)
     assert version is not None, "variant install: pkg query %v returned empty after install"
 
+    # AND the .pkg this leg built declares the ABI its own matrix row implies: the NO_ARCH
+    # wildcard on that row's FreeBSD major (issue #1806 — the catalog is arch-less, so the
+    # manifest carries "FreeBSD:<major>:*", never the concrete guest ABI).
+    own_major = own.abi.split(":")[1]
+    manifest_abi = read_compact_manifest(Path(pkg)).get("abi")
+    assert manifest_abi == f"FreeBSD:{own_major}:*", (
+        f"built .pkg declares abi {manifest_abi!r}, but this leg's matrix row "
+        f"({own.variant} / {own.catalog} / {own.abi}) implies 'FreeBSD:{own_major}:*'"
+    )
+
 
 def vm_pkg_query_name(vm: SmokeVM, *, timeout: float = 60.0) -> str:
     """``pkg query '%n' <PKG_NAME>`` — the package name if installed, else empty string."""
     result = vm.ssh("pkg", "query", "%n", PKG_NAME, timeout=timeout)
     return result.stdout.strip() if result.returncode == 0 else ""
-
-
-# --------------------------------------------------------------------------- #
-# ADR-20 Case 2 — wrong-variant guard: box rejects the OPPOSITE variant        #
-# --------------------------------------------------------------------------- #
-
-
-@pytest.mark.timeout(900)
-def test_wrong_variant_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
-    """ADR-20 P6 CASE 2 — Installing the OPPOSITE variant's package on this box fails;
-    that variant's php dep is unsatisfied; the package is NOT installed after the attempt.
-
-    The box's own variant and the wrong (opposite) variant both come from the ci-metadata
-    matrix (SMOKE_ABI / SMOKE_PHP_VERSION), so this runs symmetrically: a CE box rejects a
-    forged Plus (php85/FreeBSD:16) package, and a Plus box rejects a forged CE
-    (php83/FreeBSD:15) package — no hardcoded direction.
-
-    Scenario: installing the opposite-variant package fails with an unsatisfied dep.
-      Background: hermetic file:// catalog at ``<opp.catalog>/`` directly (no ABI leaf).
-
-    Before-state ASSERT: the box's OWN package (``<own.catalog>/``) installs CLEANLY
-      (own php dep satisfied) — proves the own path is correct and the AFTER failure is
-      caused by the variant mismatch, not an unrelated setup issue.
-    Given the own package uninstalled and the repo conf pointing at the opposite-variant
-      catalog (ABI mismatch),
-    When ``pkg install -y <pkgname>`` from the opposite catalog,
-    Then the guard fires (non-zero exit, or the package is absent),
-      AND the error output is variant-attributable — it names the opposite php dep,
-      the opposite ABI, an ABI/OS-version rejection, or no installable candidate,
-      AND ``pkg query '%n' <pkgname>`` confirms the package is NOT installed.
-    """
-    pkg = os.environ.get("SMOKE_PKG")
-    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"
-    src = Path(pkg)
-
-    own = own_variant()
-    opp = opposite_variant()
-
-    # ---- Before-state: prove the box's OWN path works (the guard control) ----
-    own_catalog_dir = build_repo_via_portable_named(
-        repo_vm,
-        [src, *_smoke_dep_pkg_paths()],
-        tmp_path,
-        catalog_name=own.catalog,
-        guest_root=VARIANT_REPO_ROOT,
-    )
-    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
-    pkg_delete(repo_vm)
-    write_repo_conf(repo_vm, own_catalog_dir, ours_priority=pfsense_prio + 100)
-    pkg_update(repo_vm)
-
-    # Assert before-state: absent before the own-variant control install.
-    assert vm_pkg_query_name(repo_vm) == "", "package unexpectedly present before own-variant control install"
-
-    own_install = pkg_install_from_repo(repo_vm)
-    own_combined = own_install.stdout + own_install.stderr
-    assert "Missing dependency" not in own_combined, (
-        f"Control ({own.abi}) install: RUN_DEPENDS did not resolve:\n{own_combined}"
-    )
-    own_deps = pkg_query_deps(repo_vm)
-    assert own.php in own_deps, f"Control ({own.abi}) install: {own.php} not in deps; pkg query '%dn %dv':\n{own_deps}"
-    # Own install succeeded — this is the before-state anchor.
-
-    # ---- Forge the OPPOSITE variant's .pkg (opp.php dep, opp's freebsd_major ABI) ----
-    # The portable generator now hard-rejects a concrete ABI (issue #1806 — production
-    # catalogs only ever hold wildcard/NO_ARCH pkgs), so the forged ABI must be
-    # wildcarded to the opposite major: "FreeBSD:<opp_major>:*". This still exercises
-    # the guard under test (the box's own OS-major mismatch), just with the ABI shape
-    # a real catalog would actually carry.
-    opp_major = opp.abi.split(":")[1]
-    opp_pkg = forge_variant_pkg(src, tmp_path / "opp_forge", target_php=opp.php, target_abi=f"FreeBSD:{opp_major}:*")
-
-    # ---- Build the opposite-variant catalog in <opp.catalog>/ directly (no ABI leaf) ----
-    # Deliberately NOT folding _smoke_dep_pkg_paths() here: this catalog exists only to
-    # be REJECTED (wrong variant, not dep resolution), and its one package already
-    # belongs to the box's own freebsd_major — the dep .pkgs built for this leg would be
-    # redundant, not a second competing ABI (the generator's per-run major is now single).
-    opp_catalog_dir = build_repo_via_portable_named(
-        repo_vm,
-        [opp_pkg],
-        tmp_path,
-        catalog_name=opp.catalog,
-        guest_root=VARIANT_REPO_ROOT,
-    )
-
-    # Remove the own install; point conf at the opposite-variant catalog.
-    pkg_delete(repo_vm)
-    assert vm_pkg_query_name(repo_vm) == "", "package still present after pkg_delete"
-    write_repo_conf(repo_vm, opp_catalog_dir, ours_priority=pfsense_prio + 100)
-
-    try:
-        pkg_update(repo_vm)
-    except RuntimeError:
-        # pkg update may fail on ABI mismatch (this box vs the opposite ABI) — that
-        # is itself evidence the guard fired; treat as acceptable.
-        pass
-
-    # WHEN: attempt install of the opposite variant on this box.
-    install_result = repo_vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "install", "-y", PKG_NAME, timeout=300.0)
-
-    # THEN: either the install failed non-zero, or it "succeeded" but the dep was
-    # unsatisfied (pkg may exit 0 on some error paths but the package is absent).
-    install_failed = install_result.returncode != 0
-    install_output = install_result.stdout + install_result.stderr
-    package_installed = vm_pkg_query_name(repo_vm) != ""
-
-    # The guard must fire: either the install returned non-zero, or the package is absent.
-    assert install_failed or not package_installed, (
-        f"Wrong-variant guard did NOT fire: {opp.abi} package installed successfully on a {own.abi} box.\n"
-        f"pkg install rc={install_result.returncode}\n"
-        f"pkg install output:\n{install_output}\n"
-        f"pkg query '%n': {vm_pkg_query_name(repo_vm)!r}"
-    )
-    # AND the failure names a CAUSE, not merely a non-zero exit. `install_failed` is
-    # deliberately NOT one of these clauses: it is already asserted above, so including
-    # it made every other clause unreachable and the intent ("the error names the
-    # opposite php or an ABI rejection") went unpinned (issue #1965).
-    #
-    # These markers do not fully separate "wrong variant" from "empty/broken catalog":
-    # pkg reports both as "No packages available…". What they DO exclude is a failure
-    # that names no pkg-level cause at all — an unusable box, a transport error, a
-    # crashed ssh — which the old clause set silently accepted as the guard firing.
-    lowered = install_output.lower()
-    reasons = {
-        f"names the opposite php dep ({opp.php})": opp.php in install_output,
-        f"names the opposite ABI (FreeBSD:{opp_major})": f"freebsd:{opp_major}" in lowered,
-        "reports an ABI / OS-version rejection": any(
-            kw in lowered for kw in ("wrong abi", "wrong os version", "mismatch", "incompatible")
-        ),
-        "reports no installable candidate from the catalog": any(
-            kw in lowered for kw in ("no packages available", "not found", "missing dependency", "unable to find")
-        ),
-    }
-    assert any(reasons.values()), (
-        f"Wrong-variant install failed, but for no variant-attributable reason — the guard "
-        f"under test may not be what fired.\n"
-        f"expected the output to satisfy at least one of: {sorted(reasons)}\n"
-        f"actual: {reasons}\n"
-        f"rc={install_result.returncode}\n{install_output}"
-    )
-    # Package must NOT be installed after the failed attempt.
-    assert not package_installed, (
-        f"Wrong-variant guard: package IS installed despite expected failure; "
-        f"pkg query '%n': {vm_pkg_query_name(repo_vm)!r}"
-    )
 
 
 # ADR-20 Case 3 (legacy ${ABI}/ conf transition window) retired: issue #1806 made

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1400,7 +1400,6 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     # (independent of the guest) — polls through first-deploy / DNS / cert lag. The
     # varver to poll is read from the BOX itself via the _box_real_varver oracle: the
     # guest, not the matrix, is the authority for which release line this leg runs.
-    # This
     # The caller passes a selected channel root, so the subtree is the bare varver.
     varver = _box_real_varver(repo_vm)
     poll_catalog_served(base_url, varver)

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1565,9 +1565,10 @@ def test_live_nightly_downgrade_requires_selected_semantic_repo(repo_vm: SmokeVM
 
 # =========================================================================== #
 # ADR-20 Phase 6 — variant-catalog live-VM cases: this leg installs from ITS   #
-# OWN row's catalog, and the routing URL. The wrong-variant guard case is gone  #
-# (issue #2464): it asserted a difference between two matrix rows, which says   #
-# nothing about this build and is unfalsifiable when two rows share a target.   #
+# OWN row's catalog, a build target that is NOT this row's is refused, and the  #
+# routing URL. Both oracles are row-local (issue #2464): the forged package is  #
+# derived from this row, never from another row, which may share this row's     #
+# build target and make the forgery a no-op.                                    #
 #                                                                              #
 # Marker: @pytest.mark.repo  (inherited from pytestmark = pytest.mark.repo).  #
 # Deselected from default `python -m pytest` — dispatched via:                #

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1647,6 +1647,66 @@ def build_repo_via_portable_named(
     return guest_catalog_dir
 
 
+def forge_foreign_pkg(src_pkg: Path, out_dir: Path, *, target_php: str, target_abi: str) -> Path:
+    """Forge a .pkg that is NOT built for this box, from the branch .pkg.
+
+    Re-reads the +COMPACT_MANIFEST, replaces every ``php8N`` dep key with ``target_php``,
+    sets the ``abi`` to ``target_abi``, and repacks. No payload change — the dep/ABI
+    mismatch is refused before pkg ever reads the files.
+
+    The caller derives the target from THIS leg's own row (issue #2464: a FreeBSD major
+    and a php this row does not use), never from another matrix row — two rows may
+    legitimately share a build target, which would make the forgery a no-op.
+    """
+    tar_bytes = _zstd_decompress(src_pkg.read_bytes())
+    repacked = io.BytesIO()
+    pkg_name = ""
+    with (
+        tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tin,
+        tarfile.open(fileobj=repacked, mode="w", format=tarfile.USTAR_FORMAT) as tout,
+    ):
+        for member in tin.getmembers():
+            extracted = tin.extractfile(member) if member.isfile() else None
+            data = extracted.read() if extracted is not None else b""
+            if member.name in _PKG_MANIFEST_MEMBERS:
+                obj = json.loads(data)
+                # Swap every php8N dep for the target variant's php (CE manifest has
+                # php83; forging a Plus pkg makes it php85, and vice-versa).
+                if "deps" in obj:
+                    old_deps: dict[str, object] = obj["deps"]
+                    new_deps: dict[str, object] = {}
+                    for key, val in old_deps.items():
+                        if re.match(r"php8\d", key):
+                            # Replace the key; keep the value dict unchanged (origin/version are fictional).
+                            new_deps[target_php] = val
+                        else:
+                            new_deps[key] = val
+                    obj["deps"] = new_deps
+                # Set the target ABI: the box's own `pkg install` ABI-compatibility check is
+                # the guard under test (a concrete-vs-wildcard bucket no longer exists —
+                # issue #1806 — so this must be a wildcard ABI or the portable generator
+                # itself hard-rejects it; callers pass "FreeBSD:<opp_major>:*").
+                obj["abi"] = target_abi
+                pkg_name = obj.get("name", pkg_name)
+                data = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode() + b"\n"
+                ti = tarfile.TarInfo(name=member.name)
+                ti.size = len(data)
+                ti.mode = 0o644
+                ti.uid = ti.gid = 0
+                ti.uname, ti.gname = "root", "wheel"
+                ti.mtime = 0
+                ti.type = tarfile.REGTYPE
+                tout.addfile(ti, io.BytesIO(data))
+            else:
+                tout.addfile(member, io.BytesIO(data) if member.isfile() else None)
+    if not pkg_name:
+        raise RuntimeError(f"{src_pkg.name}: no +COMPACT_MANIFEST with a name — not a libpkg .pkg?")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{pkg_name}-{target_php}.pkg"
+    out_path.write_bytes(_zstd_compress(repacked.getvalue()))
+    return out_path
+
+
 def pkg_query_deps(vm: SmokeVM, *, timeout: float = 60.0) -> str:
     """Return the raw ``pkg query '%dn %dv' <PKG_NAME>`` output (dep names + versions).
 
@@ -1748,6 +1808,126 @@ def vm_pkg_query_name(vm: SmokeVM, *, timeout: float = 60.0) -> str:
     """``pkg query '%n' <PKG_NAME>`` — the package name if installed, else empty string."""
     result = vm.ssh("pkg", "query", "%n", PKG_NAME, timeout=timeout)
     return result.stdout.strip() if result.returncode == 0 else ""
+
+
+# --------------------------------------------------------------------------- #
+# ADR-20 Case 2 — a package that is NOT built for this box must not install    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.timeout(900)
+def test_foreign_build_target_catalog_fails(repo_vm: SmokeVM, tmp_path: Path) -> None:
+    """ADR-20 P6 CASE 2 — a .pkg whose build target contradicts THIS leg's row does not
+    install; the package is absent after the attempt.
+
+    The forged target is derived from this leg's own row (issue #2464): the next FreeBSD
+    major, and a php this row does not use. It is deliberately NOT "the other edition's"
+    package — two matrix rows may share a build target (CE 2.9 and Plus 26.03 are both
+    FreeBSD:16 / php85), which would make that forgery identical to the box's own build
+    and the assertion unfalsifiable. What ADR-20 asks is narrower and row-local: a build
+    that is not this row's must never install silently.
+
+    Before-state ASSERT: the box's OWN package installs CLEANLY (own php dep satisfied) —
+      proves the own path works, so the AFTER failure is the forgery, not broken setup.
+    Given the own package uninstalled and the repo conf pointing at the foreign catalog,
+    When ``pkg install -y <pkgname>`` runs against it,
+    Then the install fails or the package is absent, the output names a pkg-level cause
+      (the foreign php dep, the foreign ABI, an ABI/OS rejection, or no candidate),
+      AND ``pkg query '%n' <pkgname>`` confirms the package is NOT installed.
+    """
+    pkg = os.environ.get("SMOKE_PKG")
+    assert pkg and Path(pkg).is_file(), "SMOKE_PKG not set / not a file"
+    src = Path(pkg)
+
+    own = own_variant()
+    own_major = own.abi.split(":")[1]
+    # Derived from THIS row, not from a sibling row: the next major up, and any php that is
+    # not this row's. Both are what makes the package foreign to this box.
+    foreign_major = str(int(own_major) + 1)
+    foreign_php = "php83" if own.php != "php83" else "php85"
+    foreign_catalog = f"foreign-fbsd{foreign_major}"
+
+    # ---- Before-state: prove the box's OWN path works (the control) ----
+    own_catalog_dir = build_repo_via_portable_named(
+        repo_vm,
+        [src, *_smoke_dep_pkg_paths()],
+        tmp_path,
+        catalog_name=own.catalog,
+        guest_root=VARIANT_REPO_ROOT,
+    )
+    pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+    pkg_delete(repo_vm)
+    write_repo_conf(repo_vm, own_catalog_dir, ours_priority=pfsense_prio + 100)
+    pkg_update(repo_vm)
+    assert vm_pkg_query_name(repo_vm) == "", "package unexpectedly present before the control install"
+
+    own_install = pkg_install_from_repo(repo_vm)
+    own_combined = own_install.stdout + own_install.stderr
+    assert "Missing dependency" not in own_combined, (
+        f"Control ({own.abi}) install: RUN_DEPENDS did not resolve:\n{own_combined}"
+    )
+    own_deps = pkg_query_deps(repo_vm)
+    assert own.php in own_deps, f"Control ({own.abi}) install: {own.php} not in deps; pkg query '%dn %dv':\n{own_deps}"
+
+    # ---- Forge a .pkg for a build target this row does not have ----
+    # The portable generator hard-rejects a concrete ABI (issue #1806 — production catalogs
+    # only hold wildcard/NO_ARCH pkgs), so the forged ABI is wildcarded to the foreign major.
+    foreign_pkg = forge_foreign_pkg(
+        src, tmp_path / "foreign_forge", target_php=foreign_php, target_abi=f"FreeBSD:{foreign_major}:*"
+    )
+    # Deliberately NOT folding in _smoke_dep_pkg_paths(): this catalog exists only to be
+    # REJECTED (foreign build target, not dep resolution), and those deps belong to the
+    # box's own major.
+    foreign_catalog_dir = build_repo_via_portable_named(
+        repo_vm,
+        [foreign_pkg],
+        tmp_path,
+        catalog_name=foreign_catalog,
+        guest_root=VARIANT_REPO_ROOT,
+    )
+
+    pkg_delete(repo_vm)
+    assert vm_pkg_query_name(repo_vm) == "", "package still present after pkg_delete"
+    write_repo_conf(repo_vm, foreign_catalog_dir, ours_priority=pfsense_prio + 100)
+    try:
+        pkg_update(repo_vm)
+    except RuntimeError:
+        # pkg update may itself fail on the ABI mismatch — that IS the guard firing.
+        pass
+
+    install_result = repo_vm.ssh("env", "ASSUME_ALWAYS_YES=yes", "pkg", "install", "-y", PKG_NAME, timeout=300.0)
+    install_failed = install_result.returncode != 0
+    install_output = install_result.stdout + install_result.stderr
+    package_installed = vm_pkg_query_name(repo_vm) != ""
+
+    assert install_failed or not package_installed, (
+        f"Foreign-target guard did NOT fire: a FreeBSD:{foreign_major} package installed on a "
+        f"{own.abi} box.\npkg install rc={install_result.returncode}\n"
+        f"pkg install output:\n{install_output}\npkg query '%n': {vm_pkg_query_name(repo_vm)!r}"
+    )
+    # AND the failure names a CAUSE, not merely a non-zero exit. `install_failed` is
+    # deliberately NOT one of these clauses: it is already asserted above, so including it
+    # would make every other clause unreachable (issue #1965).
+    lowered = install_output.lower()
+    reasons = {
+        f"names the foreign php dep ({foreign_php})": foreign_php in install_output,
+        f"names the foreign ABI (FreeBSD:{foreign_major})": f"freebsd:{foreign_major}" in lowered,
+        "reports an ABI / OS-version rejection": any(
+            kw in lowered for kw in ("wrong abi", "wrong os version", "mismatch", "incompatible")
+        ),
+        "reports no installable candidate from the catalog": any(
+            kw in lowered for kw in ("no packages available", "not found", "missing dependency", "unable to find")
+        ),
+    }
+    assert any(reasons.values()), (
+        f"The foreign-target install failed, but for no attributable reason — the guard under "
+        f"test may not be what fired.\nexpected at least one of: {sorted(reasons)}\n"
+        f"actual: {reasons}\nrc={install_result.returncode}\n{install_output}"
+    )
+    assert not package_installed, (
+        f"Foreign-target guard: package IS installed despite the expected failure; "
+        f"pkg query '%n': {vm_pkg_query_name(repo_vm)!r}"
+    )
 
 
 # ADR-20 Case 3 (legacy ${ABI}/ conf transition window) retired: issue #1806 made

--- a/tests/test_build_pkg_portable.py
+++ b/tests/test_build_pkg_portable.py
@@ -1100,13 +1100,13 @@ def test_php_guard_is_derived_from_php_version(php_version: str) -> None:
     """The PHP guard is DERIVED from --php (strip the dot → phpXY / lang/phpXY).
 
     Whatever the matrix carries, exactly ONE php* dep appears and it is the derived
-    one — so no other edition's php token can leak in (the CE-vs-Plus discrimination).
+    one — so no php other than the one this build was asked for can leak in.
     """
     expected = "php" + php_version.replace(".", "")
     deps = dict(bpp._resolve_variant_deps(php_version=php_version, py_flavor="py311"))
     # The derived php dep is present with its real origin (libpkg requires a non-empty one).
     assert deps.get(expected) == f"lang/{expected}"
-    # Exactly one php* dep, and it IS the derived one (no other edition's php leaks in).
+    # Exactly one php* dep, and it IS the derived one (no other php leaks in).
     assert [n for n in deps if n.startswith("php")] == [expected]
 
 
@@ -1205,9 +1205,9 @@ def test_php_injects_variant_guard_via_cli(tmp_path: Path) -> None:
     full, _compact, _tf = _read_pkg(out / "testpkg-1.0_2.pkg")
     deps = full.get("deps", {})
     assert "foo" in deps  # Makefile RUN_DEPENDS still present
-    assert deps.get("php83", {}).get("origin") == "lang/php83"  # CE PHP guard, real origin
+    assert deps.get("php83", {}).get("origin") == "lang/php83"  # the requested PHP guard, real origin
     assert deps.get("python311", {}).get("origin") == "lang/python311"  # Python guard, real origin
-    assert "php85" not in deps  # the Plus discriminator stays absent
+    assert "php85" not in deps  # no php but the requested one (php85 is not an edition marker)
     assert "py311" not in deps  # the flavor token is NOT a dep name (would be unsatisfiable)
 
 

--- a/tests/test_smoke_leg_zero_selection_gate.py
+++ b/tests/test_smoke_leg_zero_selection_gate.py
@@ -213,7 +213,7 @@ def _two_leg_ce_plus_matrix() -> list[dict[str, str]]:
     """A representative MULTI-leg shape (>=2 ci:true amd64 legs, 3 shards each) -- unlike
     every other row in this file, which only ever builds a single-leg matrix. The gate is
     cardinality-agnostic and groups on image_name|pfsense_version, so the real
-    --print-ci row count (four today) does not belong in this fixture. Plus listed first:
+    --print-ci row count does not belong in this fixture. Plus listed first:
     that ordering is what makes the mutation probe below (grouping collapsed
     to one bucket) demonstrate a false PASS rather than an accidental correct
     result -- see that test's docstring."""

--- a/tests/test_smoke_leg_zero_selection_gate.py
+++ b/tests/test_smoke_leg_zero_selection_gate.py
@@ -210,9 +210,10 @@ def test_leg_fails_when_every_shard_of_a_full_scope_leg_is_empty(tmp_path: Path)
 
 
 def _two_leg_ce_plus_matrix() -> list[dict[str, str]]:
-    """Production shape (scripts/read-version-matrix.sh --print-ci): TWO ci:true
-    amd64 legs, CE 2.8 + Plus 26.03, 3 shards each -- unlike every other row in
-    this file, which only ever builds a single-leg matrix. Plus listed first:
+    """A representative MULTI-leg shape (>=2 ci:true amd64 legs, 3 shards each) -- unlike
+    every other row in this file, which only ever builds a single-leg matrix. The gate is
+    cardinality-agnostic and groups on image_name|pfsense_version, so the real
+    --print-ci row count (four today) does not belong in this fixture. Plus listed first:
     that ordering is what makes the mutation probe below (grouping collapsed
     to one bucket) demonstrate a false PASS rather than an accidental correct
     result -- see that test's docstring."""

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -2,7 +2,7 @@
 ADR-20 repo smoke. Loaded by path (like test_gen_landing) so no live-VM / conftest baggage.
 
 These pin that ALL ABI/PHP/Python/catalog facts come from the version matrix (never a literal):
-the JSON source of truth, the per-(ABI, edition) variant derivation, own/opposite selection,
+the JSON source of truth, the per-ROW variant derivation, this leg's own-row selection,
 and the env overrides — so adding a pfSense version to the matrix needs no edit in the smoke test.
 """
 

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -31,6 +31,13 @@ _MATRIX = (
     '{"pfsense_version":"26.03.1","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"Plus"}]'
 )
 
+# The same two rows with Plus FIRST — pins that the bare-dispatch default is "row 0",
+# never "the CE one" (issue #2464).
+_PLUS_FIRST_MATRIX = (
+    '[{"pfsense_version":"26.03.1","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"Plus"},'
+    '{"pfsense_version":"2.8.0","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"}]'
+)
+
 # Two editions sharing the SAME freebsd_major (issue #1806: with `arch` retired,
 # this is a real possible shape now, not just an ADR-24 transition-window
 # hypothetical) — exercises the SMOKE_IMAGE_REF disambiguation in _own_entry().
@@ -49,7 +56,14 @@ def _clear_matrix_cache() -> Any:
 
 
 def _set_env(monkeypatch: pytest.MonkeyPatch, **kv: str | None) -> None:
-    for k in ("SMOKE_MATRIX_JSON", "SMOKE_ABI", "SMOKE_PHP_VERSION", "SMOKE_PY_FLAVOR", "SMOKE_IMAGE_REF"):
+    for k in (
+        "SMOKE_MATRIX_JSON",
+        "SMOKE_ABI",
+        "SMOKE_PHP_VERSION",
+        "SMOKE_PY_FLAVOR",
+        "SMOKE_IMAGE_REF",
+        "SMOKE_PFSENSE_VERSION",
+    ):
         monkeypatch.delenv(k, raising=False)
     for k, v in kv.items():
         if v is not None:
@@ -90,35 +104,63 @@ def test_build_matrix_none_on_malformed_or_empty(monkeypatch: pytest.MonkeyPatch
         assert mx.build_matrix() is None
 
 
-def test_variants_derived_per_abi_edition(monkeypatch: pytest.MonkeyPatch) -> None:
-    """One Variant per (ABI, edition), php/catalog/py derived from the matrix entry."""
+def test_variants_derived_per_matrix_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One Variant per ROW, every field derived from that row.
+
+    Keyed by version, never by ABI: an ABI-keyed dict silently drops every row after the first
+    that shares an ABI, which would make this oracle vacuous on the real matrix (issue #2464).
+    """
     _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX)
-    by_abi = {v.abi: v for v in mx.matrix_variants()}
-    assert set(by_abi) == {"FreeBSD:15:amd64", "FreeBSD:16:amd64"}
-    assert by_abi["FreeBSD:15:amd64"] == mx.Variant("php83", "FreeBSD:15:amd64", "ce-2.8", "py311", "CE")
-    assert by_abi["FreeBSD:16:amd64"].php == "php85" and by_abi["FreeBSD:16:amd64"].catalog == "plus-26.03"
+    by_version = {v.version: v for v in mx.matrix_variants()}
+    assert set(by_version) == {"2.8.0", "26.03.1"}
+    assert by_version["2.8.0"] == mx.Variant(
+        php="php83", abi="FreeBSD:15:amd64", catalog="ce-2.8", py="py311", variant="CE", version="2.8.0"
+    )
+    assert by_version["26.03.1"] == mx.Variant(
+        php="php85", abi="FreeBSD:16:amd64", catalog="plus-26.03", py="py311", variant="Plus", version="26.03.1"
+    )
 
 
-def test_own_and_opposite_follow_smoke_abi(monkeypatch: pytest.MonkeyPatch) -> None:
-    """own = the SMOKE_ABI entry; opposite = the first entry of a DIFFERENT edition.
+def test_own_follows_smoke_abi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """own = the entry SMOKE_ABI selects, with that entry's own php/py/catalog.
 
-    Before/after: the CE leg's own is CE / opposite is Plus; flipping SMOKE_ABI to the Plus
-    box swaps both — proving the selection tracks the matrix, not a hardcoded side.
+    Before/after: pointing SMOKE_ABI at the FreeBSD:15 box derives the FreeBSD:15 row;
+    flipping it to FreeBSD:16 derives that row instead — the selection tracks the matrix,
+    never a hardcoded side.
     """
     _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX, SMOKE_ABI="FreeBSD:15:amd64", SMOKE_PHP_VERSION="8.3")
-    assert mx.own_variant().variant == "CE" and mx.own_variant().abi == "FreeBSD:15:amd64"
-    assert mx.opposite_variant().variant == "Plus"  # a different edition
+    own = mx.own_variant()
+    assert (own.abi, own.php, own.catalog) == ("FreeBSD:15:amd64", "php83", "ce-2.8")
 
     _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX, SMOKE_ABI="FreeBSD:16:amd64", SMOKE_PHP_VERSION="8.5")
-    assert mx.own_variant().variant == "Plus" and mx.own_variant().abi == "FreeBSD:16:amd64"
-    assert mx.opposite_variant().variant == "CE"
+    own = mx.own_variant()
+    assert (own.abi, own.php, own.catalog) == ("FreeBSD:16:amd64", "php85", "plus-26.03")
 
 
-def test_bare_dispatch_defaults_to_ce_entry(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no SMOKE_ABI, own defaults to the matrix's CE entry (the bare-dispatch default)."""
+def test_bare_dispatch_defaults_to_the_first_matrix_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no leg env at all, own defaults to the matrix's FIRST ROW — not to an edition.
+
+    issue #2464: "the CE entry" is not a row identity. The matrix holds two CE rows (CE 2.8 and
+    CE 2.9), so an edition-keyed default picks one of them by list position and then derives an
+    ABI that may match several rows. The bare-dispatch default is deliberately just "row 0",
+    documented as arbitrary; a leg that cares names itself with SMOKE_PFSENSE_VERSION.
+    """
     _set_env(monkeypatch, SMOKE_MATRIX_JSON=_MATRIX)
-    assert mx.own_variant().variant == "CE" and mx.matrix_abi() == "FreeBSD:15:amd64"
+    assert mx.own_variant().version == "2.8.0" and mx.matrix_abi() == "FreeBSD:15:amd64"
     assert mx.matrix_py_flavor() == "py311"
+
+    # A matrix whose first row is Plus defaults to THAT row: no edition preference survives.
+    mx.build_matrix.cache_clear()  # a second matrix in one case: the lru_cache would serve the first
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_PLUS_FIRST_MATRIX)
+    own = mx.own_variant()
+    assert (own.variant, own.catalog) == ("Plus", "plus-26.03")
+
+
+def test_two_rows_sharing_an_abi_are_not_collapsed_by_the_unit_oracle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rows sharing a FreeBSD major stay distinct — CE 2.9 and Plus 26.03 both are FreeBSD:16."""
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX)
+    same_abi = sorted(v.catalog for v in mx.matrix_variants() if v.abi == "FreeBSD:16:amd64")
+    assert same_abi == ["ce-2.9", "plus-26.03", "plus-26.07"]
 
 
 def test_env_overrides_win_over_matrix(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -231,3 +273,75 @@ def test_smoke_topology_excludes_route_only_via_ci_matrix_injection(monkeypatch:
     assert "FreeBSD:14:amd64" not in abis_after, (
         f"after: route-only ABI must remain absent from smoke topology; got {abis_after!r}"
     )
+
+
+# The LIVE 2026-08 matrix shape (issue #2464): FOUR rows, two of which (Plus 26.07 and
+# Plus 26.03) share an edition AND a FreeBSD major, and two of which (CE 2.9 and Plus
+# 26.03) share a build target across editions. Nothing about a row is derivable from
+# another row's edition or major.
+_LIVE_SHAPE_MATRIX = (
+    '[{"pfsense_version":"2.8","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
+    '{"pfsense_version":"26.03","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"Plus"},'
+    '{"pfsense_version":"26.07","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"Plus"},'
+    '{"pfsense_version":"2.9","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"CE"}]'
+)
+
+
+def test_every_matrix_row_derives_its_own_variant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """issue #2464 — one Variant per ROW. No row is collapsed into another's.
+
+    Keying the topology on (ABI, edition) silently dropped Plus 26.07 — it shares both
+    with Plus 26.03 — so that leg resolved to the ``plus-26.03`` catalog and asserted
+    against a release line it does not build. A matrix row is identified by its own
+    version, not by a property it happens to share with a sibling.
+    """
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX)
+    catalogs = sorted(v.catalog for v in mx.matrix_variants())
+    assert catalogs == ["ce-2.8", "ce-2.9", "plus-26.03", "plus-26.07"], (
+        f"a matrix row was collapsed into another: got {catalogs}"
+    )
+
+
+def test_own_row_selected_by_smoke_pfsense_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The leg's own row is addressed by SMOKE_PFSENSE_VERSION — the identity CI exports.
+
+    smoke-single.yml and ui-tests.yml export SMOKE_PFSENSE_VERSION alongside SMOKE_ABI for
+    every leg, so a leg never has to be inferred from properties it shares with siblings.
+    The Plus 26.07 leg must resolve to plus-26.07, not to the first FreeBSD:16 Plus row.
+    """
+    _set_env(
+        monkeypatch,
+        SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX,
+        SMOKE_PFSENSE_VERSION="26.07",
+        SMOKE_ABI="FreeBSD:16:amd64",
+        SMOKE_PHP_VERSION="8.5",
+        SMOKE_IMAGE_REF="ghcr.io/pfblockerng/pfsense-plus:16.0.0",
+    )
+    own = mx.own_variant()
+    assert (own.catalog, own.variant, own.php, own.abi) == ("plus-26.07", "Plus", "php85", "FreeBSD:16:amd64")
+
+    _set_env(
+        monkeypatch,
+        SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX,
+        SMOKE_PFSENSE_VERSION="26.03",
+        SMOKE_ABI="FreeBSD:16:amd64",
+        SMOKE_PHP_VERSION="8.5",
+        SMOKE_IMAGE_REF="ghcr.io/pfblockerng/pfsense-plus:16.0.0",
+    )
+    assert mx.own_variant().catalog == "plus-26.03"
+
+
+def test_own_row_selection_needs_no_edition_to_major_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two editions on ONE major resolve to their own rows — no CE-is-15 / Plus-is-16 rule.
+
+    CE 2.9 and Plus 26.03 share FreeBSD:16 and php85; only the row identity separates them.
+    """
+    for version, expected in (("2.9", "ce-2.9"), ("26.03", "plus-26.03")):
+        _set_env(
+            monkeypatch,
+            SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX,
+            SMOKE_PFSENSE_VERSION=version,
+            SMOKE_ABI="FreeBSD:16:amd64",
+            SMOKE_PHP_VERSION="8.5",
+        )
+        assert mx.own_variant().catalog == expected

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -345,3 +345,33 @@ def test_own_row_selection_needs_no_edition_to_major_mapping(monkeypatch: pytest
             SMOKE_PHP_VERSION="8.5",
         )
         assert mx.own_variant().catalog == expected
+
+
+def test_unknown_smoke_pfsense_version_falls_through_to_abi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A SMOKE_PFSENSE_VERSION that names no row is not a row identity — fall through to ABI.
+
+    scripts/smoke-on-box.sh exports the pfSense IMAGE TAG (or a literal "?" when the ref is
+    digest-pinned), which need not equal any matrix pfsense_version. Treating that as a row
+    identity turned a working local on-box run into a hard RuntimeError. The ABI path still
+    refuses ambiguity loudly on its own, so nothing is silently mis-selected.
+    """
+    for stray in ("?", "15.1.0", ""):
+        _set_env(
+            monkeypatch,
+            SMOKE_MATRIX_JSON=_MATRIX,
+            SMOKE_PFSENSE_VERSION=stray,
+            SMOKE_ABI="FreeBSD:15:amd64",
+        )
+        own = mx.own_variant()
+        assert (own.version, own.abi) == ("2.8.0", "FreeBSD:15:amd64"), f"stray={stray!r}"
+
+
+def test_ambiguous_smoke_pfsense_version_still_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two rows carrying the same pfsense_version is a matrix bug — refuse, never pick one."""
+    dupe = (
+        '[{"pfsense_version":"2.8","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
+        '{"pfsense_version":"2.8","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"Plus"}]'
+    )
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=dupe, SMOKE_PFSENSE_VERSION="2.8", SMOKE_ABI="FreeBSD:15:amd64")
+    with pytest.raises(RuntimeError, match="matches 2 matrix rows"):
+        mx.own_variant()

--- a/tests/test_smoke_matrix.py
+++ b/tests/test_smoke_matrix.py
@@ -158,7 +158,7 @@ def test_bare_dispatch_defaults_to_the_first_matrix_row(monkeypatch: pytest.Monk
 
 def test_two_rows_sharing_an_abi_are_not_collapsed_by_the_unit_oracle(monkeypatch: pytest.MonkeyPatch) -> None:
     """Rows sharing a FreeBSD major stay distinct — CE 2.9 and Plus 26.03 both are FreeBSD:16."""
-    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX)
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_COLLIDING_SHAPES_MATRIX)
     same_abi = sorted(v.catalog for v in mx.matrix_variants() if v.abi == "FreeBSD:16:amd64")
     assert same_abi == ["ce-2.9", "plus-26.03", "plus-26.07"]
 
@@ -275,11 +275,11 @@ def test_smoke_topology_excludes_route_only_via_ci_matrix_injection(monkeypatch:
     )
 
 
-# The LIVE 2026-08 matrix shape (issue #2464): FOUR rows, two of which (Plus 26.07 and
-# Plus 26.03) share an edition AND a FreeBSD major, and two of which (CE 2.9 and Plus
-# 26.03) share a build target across editions. Nothing about a row is derivable from
-# another row's edition or major.
-_LIVE_SHAPE_MATRIX = (
+# The two collision SHAPES a row-keyed topology must survive (issue #2464), not a snapshot
+# of the live matrix — a copy of the live row set here would just rot: two rows sharing an
+# edition AND a FreeBSD major, and two rows sharing a build target across editions. Nothing
+# about a row is derivable from another row's edition or major.
+_COLLIDING_SHAPES_MATRIX = (
     '[{"pfsense_version":"2.8","freebsd_major":"15","php_version":"8.3","py_flavor":"py311","variant":"CE"},'
     '{"pfsense_version":"26.03","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"Plus"},'
     '{"pfsense_version":"26.07","freebsd_major":"16","php_version":"8.5","py_flavor":"py311","variant":"Plus"},'
@@ -295,7 +295,7 @@ def test_every_matrix_row_derives_its_own_variant(monkeypatch: pytest.MonkeyPatc
     against a release line it does not build. A matrix row is identified by its own
     version, not by a property it happens to share with a sibling.
     """
-    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX)
+    _set_env(monkeypatch, SMOKE_MATRIX_JSON=_COLLIDING_SHAPES_MATRIX)
     catalogs = sorted(v.catalog for v in mx.matrix_variants())
     assert catalogs == ["ce-2.8", "ce-2.9", "plus-26.03", "plus-26.07"], (
         f"a matrix row was collapsed into another: got {catalogs}"
@@ -311,7 +311,7 @@ def test_own_row_selected_by_smoke_pfsense_version(monkeypatch: pytest.MonkeyPat
     """
     _set_env(
         monkeypatch,
-        SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX,
+        SMOKE_MATRIX_JSON=_COLLIDING_SHAPES_MATRIX,
         SMOKE_PFSENSE_VERSION="26.07",
         SMOKE_ABI="FreeBSD:16:amd64",
         SMOKE_PHP_VERSION="8.5",
@@ -322,7 +322,7 @@ def test_own_row_selected_by_smoke_pfsense_version(monkeypatch: pytest.MonkeyPat
 
     _set_env(
         monkeypatch,
-        SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX,
+        SMOKE_MATRIX_JSON=_COLLIDING_SHAPES_MATRIX,
         SMOKE_PFSENSE_VERSION="26.03",
         SMOKE_ABI="FreeBSD:16:amd64",
         SMOKE_PHP_VERSION="8.5",
@@ -339,7 +339,7 @@ def test_own_row_selection_needs_no_edition_to_major_mapping(monkeypatch: pytest
     for version, expected in (("2.9", "ce-2.9"), ("26.03", "plus-26.03")):
         _set_env(
             monkeypatch,
-            SMOKE_MATRIX_JSON=_LIVE_SHAPE_MATRIX,
+            SMOKE_MATRIX_JSON=_COLLIDING_SHAPES_MATRIX,
             SMOKE_PFSENSE_VERSION=version,
             SMOKE_ABI="FreeBSD:16:amd64",
             SMOKE_PHP_VERSION="8.5",

--- a/tests/test_version_literal_check.py
+++ b/tests/test_version_literal_check.py
@@ -478,7 +478,12 @@ def _matrix(entries: list[dict[str, str]]) -> dict[str, Any]:
     return {"versions": entries}
 
 
-def _current_shape_matrix() -> dict[str, Any]:
+def _two_row_matrix() -> dict[str, Any]:
+    """A two-row parser fixture — NOT a mirror of the live matrix.
+
+    The live-matrix tripwire is `check_version_literals.py --verify-matrix` in test.yml,
+    which reads ci-metadata itself. Restating the live row set here would just be a copy
+    that goes stale (issue #2464: it already missed Plus 26.07 and CE 2.9)."""
     return _matrix(
         [
             {
@@ -499,9 +504,9 @@ def _current_shape_matrix() -> dict[str, Any]:
     )
 
 
-def test_matrix_tokens_current_shape_covered() -> None:
-    uncovered = cvl.uncovered_matrix_tokens(_current_shape_matrix())
-    assert uncovered == [], f"the live-shape matrix must be fully covered; got {uncovered}"
+def test_matrix_tokens_two_row_shape_covered() -> None:
+    uncovered = cvl.uncovered_matrix_tokens(_two_row_matrix())
+    assert uncovered == [], f"every token of the fixture matrix must be covered; got {uncovered}"
 
 
 def test_matrix_tokens_emit_and_cover_wildcard_abi() -> None:
@@ -509,7 +514,7 @@ def test_matrix_tokens_emit_and_cover_wildcard_abi() -> None:
     active entry (issue #1806: all pfSense-pkg-pfBlockerNG ports are NO_ARCH), and
     the detection regex covers it — so a new wildcard literal in source/docs gets
     the same allow-list treatment as a concrete one, exercised by the tripwire."""
-    m = _current_shape_matrix()
+    m = _two_row_matrix()
     tokens = cvl._matrix_tokens(m)
     assert _FREEBSD15_WILDCARD in tokens
     assert "FreeBSD" + ":16:*" in tokens
@@ -562,7 +567,7 @@ def test_matrix_tokens_future_versions_uncovered() -> None:
 
 def test_verify_matrix_cli_exit_codes(tmp_path: Path) -> None:
     good = tmp_path / "good.json"
-    good.write_text(json.dumps(_current_shape_matrix()), encoding="utf-8")
+    good.write_text(json.dumps(_two_row_matrix()), encoding="utf-8")
     bad = tmp_path / "bad.json"
     bad_entry = {
         "pfsense_version": "27" + ".01",


### PR DESCRIPTION
## The defect

The version matrix is a **matrix**: an open-ended list of rows, each carrying its own
pfSense version, edition, FreeBSD major, php version and Python flavor. Several tests had
encoded a **relationship between rows** instead of conformance of a row to itself, and
those relationships stopped holding as rows were added:

| assumption | reality today |
| --- | --- |
| the other edition is a different build target | CE 2.9 and Plus 26.03 are both FreeBSD:16 / php85 |
| (ABI, edition) identifies a leg | Plus 26.03 and Plus 26.07 share both |
| "the CE entry" is a row | there are two CE rows (2.8, 2.9) |
| CE is FreeBSD 15 / php 8.3, Plus is FreeBSD 16 / php 8.5 | CE 2.9 is FreeBSD 16 / php 8.5 |
| the CI matrix is CE-only, Plus is never ci:true | two Plus rows are ci:true (since ADR-24) |

Issue #2464 reported the first row of that table as two failing cases on the CE 2.9
`repo-install.yml` leg. The rest of this PR is the same defect found elsewhere.

## What changed

**Smoke topology — `tests/smoke/_matrix.py`**

- `opposite_variant()` is **deleted**, together with the `test_wrong_variant_catalog_fails`
  case it existed for. "The other edition's package must be rejected" asserts nothing about
  this build; when two rows share a build target the assertion is unfalsifiable, and when
  they don't it is really testing pkg's own ABI check.
- `matrix_variants()` yields one Variant per **ROW**. Keying on (ABI, edition) dropped Plus
  26.07 entirely — probed against the live matrix before the fix:

  ```
  variants: [('CE','FreeBSD:15','php83','ce-2.8'), ('Plus','FreeBSD:16','php85','plus-26.03'),
             ('CE','FreeBSD:16','php85','ce-2.9')]     # 4 rows in, 3 out — 26.07 is gone
  ghcr.io/x/pfsense-plus:16.0.0 -> catalog='plus-26.03'  # the 26.07 leg, pointed at 26.03
  ```

  After: all four rows survive and each leg resolves to its own catalog (`2.8 -> ce-2.8`,
  `26.03 -> plus-26.03`, `26.07 -> plus-26.07`, `2.9 -> ce-2.9`).
- `_own_entry()` selects this leg's row by **`SMOKE_PFSENSE_VERSION`** — the row identity
  smoke-single.yml and ui-tests.yml already export per leg — before falling back to ABI
  matching. A bare dispatch that names no leg takes the matrix's first row, documented as
  arbitrary, instead of "the CE entry".
- `test_install_from_variant_catalog` drops the opposite-php assertion and gains a row-local
  one: the built `.pkg`'s manifest ABI must be the NO_ARCH wildcard on this row's FreeBSD
  major.

**Same defect elsewhere (found by a three-way sweep of the pytest, shellspec and smoke/php
suites)**

- `.github/workflows/test-version-matrix.yml` — three steps, all broken or vacuous against
  the live matrix, replaced by row-local conformance over every row:
  - "CI matrix contains only CE entries" → `[.[]|select(.channel != "CE")]|length` is **2**
    today, so the step exits 1.
  - "Plus entry is ci:false" → `--print-build` deletes `.ci` and dedupes Plus away, so the
    count is always 0: vacuous, and the invariant it claims is false.
  - "CE 2.8 is FreeBSD 15 / php 8.3 / ci:true" → reads `.ci` off a build row that no longer
    carries it (`null != "true"` → exit 1), and pins the edition→major→php mapping.
- `scripts/smoke-on-box.sh` mapped FreeBSD major → php in a `case` statement and hardcoded
  `py311`, defaulting an unknown major to php 8.3 with a warning. It now reads both from the
  matrix row it already looks up for `extra_pkgs`, and refuses when there is no row.
- `tests/shell/build_leg_ports_parity_env.sh` derived the version from the major (`"2.8" if
  major == "15" else "2.9"`), fabricating a `{Plus, 2.9}` row — which exists in no matrix —
  on every Plus leg. It now takes the caller's value or looks up a real row.
- Stale cross-row prose corrected in `test_repo_install.py`, `test_nightly_install.py`,
  `helpers.py`, `test_build_pkg_portable.py`, `test_version_literal_check.py`,
  `test_smoke_leg_zero_selection_gate.py` and `architecture-notes.md`.

## Verification

Test-first, red before green. Reviewers caught me quoting a hash of a file that kept
changing, twice — so the anchor here is the **command**, not a frozen digest. Re-run it
against whatever `tests/test_smoke_matrix.py` is at the branch tip and the counts below
reproduce; what the freeze rule actually asks is that the test bytes are identical
between the RED and GREEN halves of each proof, which holds because each proof reverts
only a production hunk in a `/tmp` copy and never touches the test file:

```
# unmutated
GREEN 19 passed

# revert the row-identity hunks (whole-Variant dedup + version-addressed selection)
RED   5 failed, 14 passed
        test_every_matrix_row_derives_its_own_variant
        test_own_row_selected_by_smoke_pfsense_version
        test_own_row_selection_needs_no_edition_to_major_mapping
        test_two_rows_sharing_an_abi_are_not_collapsed_by_the_unit_oracle
        test_ambiguous_smoke_pfsense_version_still_refuses

# revert the bare-dispatch hunk (back to "the CE entry")
RED   1 failed, 18 passed   test_bare_dispatch_defaults_to_the_first_matrix_row

# mutation: raise again when SMOKE_PFSENSE_VERSION names no row
RED   1 failed, 18 passed   test_unknown_smoke_pfsense_version_falls_through_to_abi

# mutation: let an ambiguous version silently pick rows[0] instead of refusing
RED   1 failed, 18 passed   test_ambiguous_smoke_pfsense_version_still_refuses

# mutation: smoke-on-box.sh defaults a missing row to php 8.3 instead of exiting
RED   shellspec: refuses to build when the matrix has no row for this ABI major
```

At the tip commit of this PR that file hashes
`4c645f6facbc212cd96176d26eef18d9f2906981ee9cd233814f500503243408` — recorded for
traceability, not as a claim that survives the next commit.

New shellspec coverage for the fail-closed path in `smoke-on-box.sh` (`no matrix row for
FreeBSD major 99` → non-zero, ports prep never runs): `23 examples, 0 failures`.

The workflow steps are shell, so they were verified by executing the new `jq` against the
live matrices, including a negative control:

```
BUILD rows consistent: OK
CI rows consistent + ci:true: OK
CI versions unique: OK
negative control (freebsd_version contradicting freebsd_major): correctly rejected
```

`scripts/agent/run-gates.sh`: `GATES: PASS` (pytest, ruff, mypy, shellcheck, shellspec,
markdownlint).

Not verifiable off-box: the smoke assertions themselves. The end-to-end proof is a
`repo-install.yml` dispatch on `devel` after merge — the CE 2.9 leg was 37 passed / 3 failed.

Part of #2464


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Version-specific build and installation checks now select the correct platform configuration, including rows that share ABI or edition details.
  * Invalid or missing platform configurations fail early with clearer diagnostics instead of falling back to hardcoded defaults.

* **Tests**
  * Expanded coverage for multi-version matrices, edition ordering, shared ABI scenarios, package manifests, and smoke-on-box workflows.
  * Updated validation to reflect matrix-driven PHP, Python, ABI, build, and CI requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

