### PR TITLE
smoke: close every pfBlockerNG notice in the software-update teardown

### DIFF
--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -198,8 +198,10 @@ def file_sha256(vm: SmokeVM, path: str, *, timeout: float = 60.0) -> str | None:
 # --------------------------------------------------------------------------- #
 # pfSense's notices API (upstream src/etc/inc/notices.inc):
 #   file_notice($id, $notice, $category="General", $url="", $priority=1, $local_only=false)
-#   get_notices()  -> array of {id, notice, category, url, priority, time} rows
-#   close_notice($id) -> removes every row whose id matches
+#   get_notices()  -> array of {id, notice, category, url, priority} rows keyed by timestamp,
+#                     or FALSE when the queue file is empty
+#   close_notice($id_or_key) -> removes ONE row: the row keyed by that timestamp, else the
+#                     oldest row whose id matches (then breaks)
 # pfSsh.php runs them in the fully-bootstrapped pfSense env (notices.inc is auto-loaded), the
 # same env the real cron uses, so this proves the cron-context delivery path end-to-end.
 
@@ -255,7 +257,7 @@ def count_matching_notices(vm: SmokeVM, needle: str, *, timeout: float = 120.0) 
     """
     snippet = (
         "$n = 0;\n"
-        "foreach (get_notices() as $row) {\n"
+        "foreach ((get_notices() ?: []) as $row) {\n"
         f"  if (strpos((string)($row['notice'] ?? ''), {_php_str(needle)}) !== FALSE) {{ $n++; }}\n"
         "}\n"
         f"echo {_php_str(_NOTICE_OPEN)} . $n . {_php_str(_NOTICE_CLOSE)};"
@@ -271,21 +273,32 @@ def count_matching_notices(vm: SmokeVM, needle: str, *, timeout: float = 120.0) 
 def close_all_notices(vm: SmokeVM, *, timeout: float = 120.0) -> None:
     """Close EVERY notice carrying our id — leave the VM CLEAN (teardown counterpart).
 
-    pfSense's ``close_notice($id)`` removes ONE row per call — the oldest with that id — and
-    the package itself files ``pfBlockerNG``-id notices too (schedule-migration and DNSBL-VIP
-    install warnings), so a single ``close_notice(NOTICE_ID)`` drained those and left every
+    pfSense's ``close_notice($id)`` removes ONE row per call — the first row in queue order
+    carrying that id (queue order is timestamp order, so the oldest) — and the package itself
+    files ``pfBlockerNG``-id notices too (e.g. schedule-migration and DNSBL-VIP install
+    warnings), so a single ``close_notice(NOTICE_ID)`` drained those and left every
     ``available (<channel>)`` row standing (issue #2465). Close by timestamp key instead, one
-    call per matching row, so the next case's ``count == 0`` before-state is genuinely clean.
+    call per matching row, then re-count: the teardown is its own oracle and raises if any
+    row of our id survives, so the next case's ``count == 0`` before-state is genuinely clean.
     """
     snippet = (
         "foreach ((get_notices() ?: []) as $key => $row) {\n"
         f"  if ((string)($row['id'] ?? '') === {_php_str(NOTICE_ID)}) {{ close_notice($key); }}\n"
         "}\n"
-        "echo 'OK';"
+        "$left = 0;\n"
+        "foreach ((get_notices() ?: []) as $row) {\n"
+        f"  if ((string)($row['id'] ?? '') === {_php_str(NOTICE_ID)}) {{ $left++; }}\n"
+        "}\n"
+        f"echo {_php_str(_NOTICE_OPEN)} . $left . {_php_str(_NOTICE_CLOSE)};"
     )
     out = _pfssh(vm, snippet, timeout=timeout)
-    if "OK" not in out:
-        raise RuntimeError(f"close_all_notices did not confirm: {out!r}")
+    start = out.find(_NOTICE_OPEN)
+    end = out.find(_NOTICE_CLOSE)
+    if start == -1 or end == -1:
+        raise RuntimeError(f"close_all_notices: no delimited count in pfSsh.php output: {out!r}")
+    left = int(out[start + len(_NOTICE_OPEN) : end])
+    if left != 0:
+        raise RuntimeError(f"close_all_notices left {left} notice(s) with id {NOTICE_ID!r} standing")
 
 
 def _php_str(value: str) -> str:

--- a/tests/smoke/test_software_update.py
+++ b/tests/smoke/test_software_update.py
@@ -247,11 +247,11 @@ def raise_notice(vm: SmokeVM, message: str, *, timeout: float = 120.0) -> None:
 def count_matching_notices(vm: SmokeVM, needle: str, *, timeout: float = 120.0) -> int:
     """How many ``get_notices()`` rows carry ``needle`` in their ``notice`` text (the oracle).
 
-    Counts by the message SUBSTRING (a per-version string), not the id: file_notice with a
-    repeated id REPLACES the prior row of that id (notices are id-keyed by their md5), so the
-    de-dupe being proven is the CALLER not re-raising — a count keyed on the version string is
-    what distinguishes "raised once" from "raised again at a new version". Delimited so
-    pfSsh.php's startup banner never pollutes the integer.
+    Counts by the message SUBSTRING (a per-version string), not the id: pfSense's
+    ``file_notice`` appends a row keyed by its timestamp and never replaces an earlier row
+    of the same id, so the de-dupe being proven is the CALLER not re-raising — a count keyed
+    on the version string is what distinguishes "raised once" from "raised again at a new
+    version". Delimited so pfSsh.php's startup banner never pollutes the integer.
     """
     snippet = (
         "$n = 0;\n"
@@ -269,9 +269,23 @@ def count_matching_notices(vm: SmokeVM, needle: str, *, timeout: float = 120.0) 
 
 
 def close_all_notices(vm: SmokeVM, *, timeout: float = 120.0) -> None:
-    """Close every notice carrying our id — leave the VM CLEAN (teardown counterpart)."""
-    snippet = f"close_notice({_php_str(NOTICE_ID)});\necho 'OK';"
-    _pfssh(vm, snippet, timeout=timeout)
+    """Close EVERY notice carrying our id — leave the VM CLEAN (teardown counterpart).
+
+    pfSense's ``close_notice($id)`` removes ONE row per call — the oldest with that id — and
+    the package itself files ``pfBlockerNG``-id notices too (schedule-migration and DNSBL-VIP
+    install warnings), so a single ``close_notice(NOTICE_ID)`` drained those and left every
+    ``available (<channel>)`` row standing (issue #2465). Close by timestamp key instead, one
+    call per matching row, so the next case's ``count == 0`` before-state is genuinely clean.
+    """
+    snippet = (
+        "foreach ((get_notices() ?: []) as $key => $row) {\n"
+        f"  if ((string)($row['id'] ?? '') === {_php_str(NOTICE_ID)}) {{ close_notice($key); }}\n"
+        "}\n"
+        "echo 'OK';"
+    )
+    out = _pfssh(vm, snippet, timeout=timeout)
+    if "OK" not in out:
+        raise RuntimeError(f"close_all_notices did not confirm: {out!r}")
 
 
 def _php_str(value: str) -> str:


### PR DESCRIPTION
Fixes #2465

## What

`close_all_notices()` in `tests/smoke/test_software_update.py` closed ONE notice, not all of them. pfSense's `close_notice($id)` removes a single row per call (the oldest carrying that id, then `break`), and `file_notice` appends timestamp-keyed rows and never replaces an earlier row of the same id — the helper's docstring claimed the opposite. On a repo-install leg the package's own installers have already filed `pfBlockerNG`-id notices (schedule-migration / DNSBL-VIP warnings), so every `close_notice('pfBlockerNG')` drained one of those and left the `available (<channel>)` rows from `test_file_notice_is_idempotent_per_version` and the positive journey standing; `test_software_check_setting_gates_background_check` then counted them (`assert 2 == 0`) before its disabled check ran.

The helper now iterates `get_notices()` and closes every row whose id is ours by its timestamp key, and confirms the snippet ran. `count_matching_notices`'s docstring is corrected to state the real `file_notice` semantics.

## Why it only shows in CI

Running the module alone is green: no earlier `pfBlockerNG`-id notices exist, so the single close happens to remove the right row. The `repo` leg runs `test_repo_install.py` first, whose installs file those notices, and the leak surfaces.

## Evidence

Red→green executed on a leased box with `scripts/local-smoke.sh --marker repo` (full leg, same argv shape as `repo-install.yml`); tails in the PR comments below.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.

## Evidence tails

Red (devel tip `b8f967fb5`, `scripts/local-smoke.sh --ref b8f967fb54b862129baefc8c0e41849c1ea9b808 --marker repo`, box `root@10.0.0.31`):

```
>           assert count_matching_notices(repo_vm, msg) == 0, "a notice existed before the disabled background check"
E           AssertionError: a notice existed before the disabled background check
E           assert 1 == 0
FAILED tests/smoke/test_software_update.py::test_software_check_setting_gates_background_check
===== 8 failed, 29 passed, 6 skipped, 946 deselected in 751.83s (0:12:31) ======
```

Green (this branch, same argv, `--ref c389b6726…`):

```
tests/smoke/test_software_update.py::test_software_check_setting_gates_background_check PFB_TIMING ssh:env ASSUME_ALWAYS_YES=yes pkg 2.60s
PASSED [ 93%]PFB_TIMING unblock_egress 0.00s
===== 7 failed, 30 passed, 6 skipped, 946 deselected in 753.06s (0:12:33) ======
```
(pytest's node id and its `PASSED` are split across two lines by the interleaved `PFB_TIMING` output; quoted verbatim.)

The 7 remaining failures in both runs are the same `gen_landing.py did not publish install.sh` set — the local box's sparse checkout omits `pkg-site/`; pre-existing and unrelated, tracked as #2475 (green in CI, which checks out the whole tree).

Note: the module run alone (`--filter test_software_update`) is green on the unfixed tip (7 passed) — the leak needs the earlier `pfBlockerNG`-id notices `test_repo_install.py`'s installs leave behind, which is why the reproduction is the full `repo` leg.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no notices are available.
  * Notice cleanup now closes matching notices individually and verifies that none remain.
  * Added an error when notices cannot be fully cleared.

* **Documentation**
  * Updated notice API documentation to reflect current result formats and single-notice closing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->