### PR TITLE
smoke: add pkg-site to the local-smoke sparse checkout

### DIFF
--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -111,7 +111,8 @@ tests collected) would fail that shard spuriously. `N` should stay at or under f
 
 1. `local-smoke.sh` leases one box from `PFB_BOXES` via `select-box.sh -- <bootstrap>`.
 2. On box, `smoke-on-box.sh` (invoked by bootstrap) runs in order:
-   - `git sparse-checkout` (only `src`, `scripts`, `tests/smoke` — 13 MB of 38 MB tree),
+   - `git sparse-checkout` (only `src`, `scripts`, `stubs/python`, `tests/smoke`, `pkg-site` —
+     13 MB of a 34 MB tree),
      then `git fetch` + `git checkout FETCH_HEAD`. Ref resolved HERE; container
      runs already-resolved tree and never fetches.
    - `sparse-clone-ports.sh` to bring `/root/FreeBSD-ports` to `pfblockerng/use-github`.

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -176,7 +176,7 @@ fi
 
 _bootstrap="cd /root/pfBlockerNG \
  && git sparse-checkout init --cone \
- && git sparse-checkout set src scripts stubs/python tests/smoke \
+ && git sparse-checkout set src scripts stubs/python tests/smoke pkg-site \
  && git fetch --quiet origin '$_REF_Q' \
  && git checkout --quiet --force FETCH_HEAD \
  && git fetch --quiet --no-tags origin ci-metadata:refs/remotes/origin/ci-metadata \

--- a/tests/shell/local_smoke_container_spec.sh
+++ b/tests/shell/local_smoke_container_spec.sh
@@ -17,8 +17,9 @@
 #     the namespaced sysctl replaces it, so if it is dropped the mock DNS fails to bind.
 #   * the bind mounts — the repo, ports tree and guest SSH key live on the box and must be
 #     visible inside; image artifacts stay in the disposable container writable layer.
-#   * the sparse checkout — a smoke leg reads src/, scripts/, stubs/python/ and tests/smoke/.
-#     Checking out the whole tree costs 38 MB against 13 MB for what it uses.
+#   * the sparse checkout — a smoke leg reads src/, scripts/, stubs/python/, tests/smoke/
+#     and pkg-site/ (the channel-installer cases render it through gen_landing.py).
+#     Checking out the whole tree costs 34 MB against 13 MB for what it uses.
 #
 # The flag-encoding examples are inherited responsibility: smoke_on_box_channel_spec.sh used
 # to pin that a --channel carrying shell metacharacters survived the re-exec argv rebuild.
@@ -187,10 +188,11 @@ EOF
 
   It 'checks out only the paths a smoke leg reads'
     # src/ (the .pkg build), scripts/ (the harness), stubs/python/ (root conftest's
-    # unboundmodule import) and tests/smoke/ (the suite). Excludes .ADRs, tests/php and
-    # plugins, none of which smoke touches.
+    # unboundmodule import), tests/smoke/ (the suite) and pkg-site/ (the site tree the
+    # channel-installer cases render through gen_landing.py --site-tree, issue #2450).
+    # Excludes .ADRs, tests/php and plugins, none of which smoke touches.
     When call bootstrap --ref dummy
-    The output should include 'git sparse-checkout set src scripts stubs/python tests/smoke'
+    The output should include 'git sparse-checkout set src scripts stubs/python tests/smoke pkg-site'
   End
 
   It 'still fetches the ci-metadata orphan ref the version matrix reads'


### PR DESCRIPTION
## Summary

Since #2450 the channel-installer cases in `tests/smoke/test_repo_install.py` render the
published `install.sh` from this repo's `pkg-site/` tree (`gen_landing.py --site-tree`).
The on-box sparse checkout in `scripts/local-smoke.sh` never included that path, so on a
local `--marker repo` leg seven cases failed identically with
`AssertionError: gen_landing.py did not publish install.sh`, while the same cases passed
in CI, where `repo-install.yml` checks out the whole tree.

`pkg-site` is the only missing path: `gen_landing.py` otherwise resolves everything it
reads from its own `scripts/` directory, which is already in the sparse set.

## Changes

- `scripts/local-smoke.sh`: add `pkg-site` to the on-box `git sparse-checkout set`.
- `tests/shell/local_smoke_container_spec.sh`: the pinned bootstrap assertion now expects
  the new sparse set, with the rationale recorded alongside it.
- `docs/misc/local-smoke-debian.md`: the prose mirror of the sparse set matched the script
  again; the tree-size figures were re-measured in the process (13 MB of a 34 MB tree,
  previously recorded as 13 MB of 38 MB).

## Test evidence

`scripts/run-in-docker.sh shellspec --shell dash tests/shell/local_smoke_container_spec.sh`

- RED, with only the spec edit applied: `16 examples, 1 failure` —
  `The output should include git sparse-checkout set src scripts stubs/python tests/smoke pkg-site`.
- GREEN, after the `local-smoke.sh` edit, with the spec byte-identical: `16 examples, 0 failures`.

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS`.

Part of #2475

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated local smoke checks to include the `pkg-site` directory in sparse checkouts.
  * Fixed channel-installer smoke tests that require the site tree to be available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->