### PR TITLE
agent: resolve an abbreviated wait-checks --sha at arm time

### DIFF
--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -82,11 +82,9 @@ checks_to_buckets() {
 	'
 }
 
-# Resolve the pin to the full 40-character OID every head read returns. Without --sha
-# that is the PR's head; with one it is that ref, which the caller may have abbreviated
-# -- and the pre-verdict identity check compares against `headRefOid`, which is always
-# full, so an unexpanded pin could only ever report STALE (#2476). Resolving here also
-# turns an unknown ref into a loud GH-ERROR instead of a blind poll.
+# Resolve the pin to the full 40-character OID `headRefOid` always returns: a `--sha`
+# ref may be abbreviated, and the pre-verdict identity check compares against that OID,
+# so an unexpanded pin could only ever report STALE (#2476).
 resolve_pin() {
 	if [ "$sha_set" -eq 0 ]; then
 		gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid

--- a/scripts/agent/wait-checks.sh
+++ b/scripts/agent/wait-checks.sh
@@ -3,7 +3,8 @@
 # The single implementation of the CI wait the pr-merge skill used to inline.
 #
 # Usage: wait-checks.sh --repo OWNER/REPO --pr N [options]
-#   --sha SHA           pin polling to this commit (default: PR's head SHA at arm time)
+#   --sha SHA           pin polling to this commit (default: PR's head SHA at arm time).
+#                      May be abbreviated: it is resolved to the full OID at arm time.
 #   --exclude REGEX    check-name exclusion, matched against the LOWERCASED check name
 #                      (so an all-lowercase pattern is effectively case-insensitive; an
 #                      uppercase one matches nothing). The default is ANCHORED to the
@@ -81,6 +82,19 @@ checks_to_buckets() {
 	'
 }
 
+# Resolve the pin to the full 40-character OID every head read returns. Without --sha
+# that is the PR's head; with one it is that ref, which the caller may have abbreviated
+# -- and the pre-verdict identity check compares against `headRefOid`, which is always
+# full, so an unexpanded pin could only ever report STALE (#2476). Resolving here also
+# turns an unknown ref into a loud GH-ERROR instead of a blind poll.
+resolve_pin() {
+	if [ "$sha_set" -eq 0 ]; then
+		gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid
+	else
+		gh_bounded api "repos/$repo/commits/$sha" --jq .sha
+	fi
+}
+
 main() {
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
@@ -125,27 +139,26 @@ main() {
 	# PFB_WAIT_DEADLINE (epoch seconds) overrides for tests/ops.
 	deadline=${PFB_WAIT_DEADLINE:-$(( $(date +%s) + max_iter * interval + 300 ))}
 
+	# Bounded retry (same 3-strike tolerance as the poll loop below) before
+	# failing loud: a single transient blip on the very first call -- right
+	# after a force-push, exactly when this wait is armed and the API is
+	# least settled -- must not kill the whole wait. Still capped by the
+	# wall-clock deadline via gh_bounded; a wait that still cannot pin a SHA
+	# after that tolerance is exhausted must fail loudly, never poll blind.
 	ghfail=0
-	if [ "$sha_set" -eq 0 ]; then
-		# Bounded retry (same 3-strike tolerance as the poll loop below) before
-		# failing loud: a single transient blip on the very first call -- right
-		# after a force-push, exactly when this wait is armed and the API is
-		# least settled -- must not kill the whole wait. Still capped by the
-		# wall-clock deadline via gh_bounded; a wait that still cannot pin a SHA
-		# after that tolerance is exhausted must fail loudly, never poll blind.
-		while true; do
-			if sha=$(gh_bounded pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid) && [ -n "$sha" ]; then
-				break
-			fi
-			ghfail=$((ghfail + 1))
-			if [ "$ghfail" -ge 3 ]; then
-				printf 'GH-ERROR\n%s\n' "$sha"
-				exit 1
-			fi
-			sleep_bounded "$interval" || { printf 'GH-ERROR\n%s\n' "$sha"; exit 1; }
-		done
-		ghfail=0
-	fi
+	while true; do
+		if resolved=$(resolve_pin) && [ -n "$resolved" ]; then
+			sha=$resolved
+			break
+		fi
+		ghfail=$((ghfail + 1))
+		if [ "$ghfail" -ge 3 ]; then
+			printf 'GH-ERROR\n%s\n' "$resolved"
+			exit 1
+		fi
+		sleep_bounded "$interval" || { printf 'GH-ERROR\n%s\n' "$resolved"; exit 1; }
+	done
+	ghfail=0
 
 	i=0
 	while [ "$i" -lt "$max_iter" ]; do

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -724,8 +724,17 @@ case "$argv" in
 		;;
 	*"/commits/"*)
 		# The arm-time pin resolution (#2476): the real endpoint expands an
-		# abbreviated ref to the commit's full 40-character OID.
+		# abbreviated ref to the commit's full 40-character OID. Serving the
+		# canned value on ANY ref would let a resolution of the WRONG ref pass,
+		# so GH_STUB_EXPECT_RAW_SHA pins the ref actually asked for, exactly as
+		# GH_STUB_EXPECT_SHA pins the polled one above.
 		[ -z "${GH_STUB_RESOLVE_FAIL:-}" ] || { printf '%s\n' 'HTTP 422' >&2; exit 1; }
+		if [ -n "${GH_STUB_EXPECT_RAW_SHA:-}" ]; then
+			case "$argv" in
+				*"/commits/$GH_STUB_EXPECT_RAW_SHA "*|*"/commits/$GH_STUB_EXPECT_RAW_SHA") ;;
+				*) exit 1 ;;
+			esac
+		fi
 		printf '%s\n' "${GH_STUB_RESOLVED_SHA:-${GH_STUB_HEAD_SHA_1:-}}"
 		;;
 	*)
@@ -829,12 +838,28 @@ STUB
     full_sha='cccccccccccccccccccccccccccccccccccccccc'
     export GH_STUB_HEAD_SHA_1="$full_sha"
     export GH_STUB_RESOLVED_SHA="$full_sha"
+    export GH_STUB_EXPECT_RAW_SHA='ccccccccc'
     export GH_STUB_EXPECT_SHA="$full_sha"
     export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
     export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
     When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha ccccccccc --interval 0 --max-iter 1
     The status should equal 0
     The line 1 of output should equal "pinned=$full_sha"
+    The line 3 of output should equal 'PASS'
+    The output should not include 'STALE'
+  End
+
+  # The example above pins the polled address too, so the pre-fix script died at the
+  # address rather than at the identity check. Here the API accepts the abbreviated
+  # address -- as GitHub really does -- which is the shape that reported STALE.
+  It 'reports the real verdict, never STALE, for an abbreviated --sha the API resolves'
+    full_sha='cccccccccccccccccccccccccccccccccccccccc'
+    export GH_STUB_HEAD_SHA_1="$full_sha"
+    export GH_STUB_RESOLVED_SHA="$full_sha"
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha ccccccccc --interval 0 --max-iter 1
+    The status should equal 0
     The line 3 of output should equal 'PASS'
     The output should not include 'STALE'
   End

--- a/tests/shell/agent_wait_checks_spec.sh
+++ b/tests/shell/agent_wait_checks_spec.sh
@@ -722,6 +722,12 @@ case "$argv" in
 			esac
 		fi
 		;;
+	*"/commits/"*)
+		# The arm-time pin resolution (#2476): the real endpoint expands an
+		# abbreviated ref to the commit's full 40-character OID.
+		[ -z "${GH_STUB_RESOLVE_FAIL:-}" ] || { printf '%s\n' 'HTTP 422' >&2; exit 1; }
+		printf '%s\n' "${GH_STUB_RESOLVED_SHA:-${GH_STUB_HEAD_SHA_1:-}}"
+		;;
 	*)
 		exit 1
 		;;
@@ -802,7 +808,7 @@ STUB
     The line 3 of output should equal 'PASS'
   End
 
-  It '--sha skips arm-time resolution (never calls pr view to resolve) but still re-verifies before the verdict'
+  It '--sha resolves without a pr view (that read stays for the pre-verdict re-verification)'
     explicit_sha='cccccccccccccccccccccccccccccccccccccccc'
     export GH_STUB_PRVIEW_COUNT_FILE="$stubdir/prview-count"
     export GH_STUB_HEAD_SHA_1="$explicit_sha"
@@ -813,6 +819,32 @@ STUB
     The status should equal 0
     The line 3 of output should equal 'PASS'
     The contents of file "$GH_STUB_PRVIEW_COUNT_FILE" should equal '1'
+  End
+
+  # #2476: `headRefOid` is always the full 40-character OID, so an abbreviated --sha
+  # could never equal it at the pre-verdict identity check -- a completed, fully green
+  # wait was discarded as STALE. The pin is resolved to the full OID at arm time, so
+  # both the SHA-addressed polls and `pinned=` carry the resolved value.
+  It 'resolves an abbreviated --sha to the full OID, reaching the verdict instead of STALE'
+    full_sha='cccccccccccccccccccccccccccccccccccccccc'
+    export GH_STUB_HEAD_SHA_1="$full_sha"
+    export GH_STUB_RESOLVED_SHA="$full_sha"
+    export GH_STUB_EXPECT_SHA="$full_sha"
+    export GH_STUB_CHECK_RUNS='{"check_runs":[{"name":"pytest","status":"completed","conclusion":"success"}]}'
+    export GH_STUB_STATUS_PAYLOAD='{"statuses":[]}'
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha ccccccccc --interval 0 --max-iter 1
+    The status should equal 0
+    The line 1 of output should equal "pinned=$full_sha"
+    The line 3 of output should equal 'PASS'
+    The output should not include 'STALE'
+  End
+
+  It 'fails loudly with GH-ERROR when the --sha pin cannot be resolved, never polling an unresolved ref'
+    export GH_STUB_RESOLVE_FAIL=1
+    When run sh scripts/agent/wait-checks.sh --repo o/r --pr 1 --sha nosuchsha --interval 0 --max-iter 1
+    The status should equal 1
+    The line 1 of output should equal 'GH-ERROR'
+    The output should include 'HTTP 422'
   End
 
   It 'fails loudly with GH-ERROR when arm-time SHA resolution itself errors (gh exits nonzero)'


### PR DESCRIPTION
## Summary

`scripts/agent/wait-checks.sh --sha <abbrev>` polled the right commit but could never return its verdict. The pre-verdict head re-verification compares the pin to `headRefOid`, which is always the full 40-character OID, so an abbreviated pin always mismatched and a completed, fully green wait was reported `STALE` — a verdict that reads as "the head moved", which is a different and real condition.

The pin is now resolved to a full OID at arm time, before any polling:

- no `--sha` → `gh pr view --json headRefOid` (unchanged);
- `--sha <ref>` → `gh api repos/O/R/commits/<ref> --jq .sha`, which expands any ref without requiring a local checkout of that commit.

Both branches share the existing 3-strike bounded retry, so the SHA-addressed polls and the `pinned=` detail line both carry the resolved OID. A ref GitHub cannot resolve now fails loudly as `GH-ERROR` instead of polling a nonexistent commit to a blind `TIMEOUT`.

## Tests

`tests/shell/agent_wait_checks_spec.sh`, in the SHA-pinning group:

- an abbreviated `--sha` against a stub serving the full OID reaches `PASS`, prints `pinned=<full OID>`, and polls the SHA-addressed endpoints with the resolved value (`GH_STUB_EXPECT_SHA`);
- an unresolvable pin exits 1 with `GH-ERROR` and surfaces the transport error.

The stub gained the commits-endpoint call shape the resolution uses.

Red before the fix, green after, with the spec file byte-identical across both runs (`sha256 4863ddf343528b530ac102ab7bacc6105b379b6415c1e568de4f479bce0b1d08`):

```
$ scripts/run-in-docker.sh shellspec tests/shell/agent_wait_checks_spec.sh
92 examples, 2 failures      # before
92 examples, 0 failures      # after
```

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS`.

Part of #2476

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.
