### PR TITLE
repo-hook: preserve the catalog base a conf was generated from (#2459)

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1038,12 +1038,23 @@ one-pkg-run lag. The boot-time generator hook below closes that lag.
 **`rc.d` generator hook (`scripts/rc.d/pfblockerng_repo_generate.sh`).** Installed on-box by
 `install.sh` (issue #2416 follow-up: one script, `--channel` parameterized) into
 `/usr/local/etc/rc.d/`; runs at every boot. It is a pure conf **regenerator**: for each of the four channel conf files that
-exists, it detects the box's `<varver>` (arch-less, issue #1806) and **unconditionally
-overwrites** the conf with the canonical body (channel-correct URL + a marker comment). The
+exists, it detects the box's `<varver>` (arch-less, issue #1806) and overwrites the conf with
+the canonical body (channel-correct URL + a marker comment). The
 legacy shared release conf (`pfblockerng.conf`, pre-#2148) is retired by install.sh and
 NEVER regenerated — a leftover survives byte-unchanged. **No `pkg` call, no network, no
-snapshot, no reconcile, no parse-and-compare** — re-deriving the conf from scratch is
+snapshot, no reconcile** — re-deriving the conf from scratch is
 strictly simpler than diffing and patching one in place, and never wrong. Key properties:
+
+- **The catalog BASE is not re-derived (issue #2459):** an explicit `PFB_BASE_URL` wins
+  (`install.sh` drives the hook with one precisely to MOVE a box onto another base);
+  otherwise the base is read back out of the conf's own `url:`, whose canonical shape is
+  `<base>/<channel>/<varver>`. Only the `<varver>` moves, so a fork site, a staging prefix
+  and a smoke guest's `file://` catalogue survive a boot with no environment instead of
+  being redirected to the primary Pages site. A conf with no `url:` line at all (an
+  `install.sh` stub pending first generation) falls back to the built-in default; a `url:`
+  the hook could not have written — unparseable, foreign channel segment, a varver segment
+  carrying a query string, a base that is a bare scheme — leaves the conf byte-unchanged
+  with a warning.
 
 - **Self-guarding:** a channel conf is regenerated only if it already exists; if none of the
   four channel confs is present the hook is a complete no-op (an orphaned hook left after

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -3,12 +3,18 @@
 # regenerator (ADR-39). Installed by install.sh.
 #
 # WHAT IT DOES (and nothing more): for each pfBlockerNG pkg-repo conf file that
-# EXISTS, it detects this box's pfSense edition/version and UNCONDITIONALLY
-# overwrites the conf with the canonical body — a fully-resolved GitHub Pages
-# catalog URL for the box's variant (ADR-17 / ADR-20) plus a marker comment.
-# No pkg call, no network fetch, no snapshot, no parse-and-compare, no
-# reconcile. It is a pure conf REGENERATOR: re-deriving the conf from scratch is
-# strictly simpler — and never wrong — than diffing and patching one in place.
+# EXISTS, it detects this box's pfSense edition/version and overwrites the conf
+# with the canonical body — a fully-resolved catalog URL for the box's variant
+# (ADR-17 / ADR-20) plus a marker comment. No pkg call, no network fetch, no
+# snapshot, no reconcile. It is a conf REGENERATOR: re-deriving the conf from
+# scratch is strictly simpler — and never wrong — than diffing and patching one
+# in place.
+#
+# The one thing it does NOT re-derive is the catalog BASE. With no environment
+# (which is every boot) the base is read back out of the conf's own url, so only
+# the <varver> moves; a fork site, a staging prefix and a `file://` guest
+# catalogue survive a reboot instead of being redirected to the primary Pages
+# site, and a url this hook could not have written is left alone (issue #2459).
 #
 # WHY AT BOOT: a pfSense OS upgrade can change the box's edition/version (which
 # requires a reboot), which moves the catalog subtree. Regenerating every boot
@@ -66,7 +72,13 @@ name="pfblockerng_repo_generate"
 : "${PFB_NIGHTLY_CONF:=/usr/local/etc/pkg/repos/pfblockerng-nightly.conf}"
 : "${PFB_PRODUCT_LABEL:=/etc/product_label}"
 : "${PFB_VERSION_FILE:=/etc/version}"
-: "${PFB_BASE_URL:=https://pfblockerng.github.io/pkg}"
+# The catalog base. NOT defaulted into PFB_BASE_URL: an explicitly exported
+# PFB_BASE_URL (install.sh, the smoke guests, a fork bootstrap) must stay
+# distinguishable from "nothing in the environment", because at boot the base
+# comes from the conf itself — see _base_from_conf() and issue #2459. The
+# built-in default is used only for a conf that carries no url at all (an
+# install.sh stub still pending its first generation).
+PFB_DEFAULT_BASE_URL='https://pfblockerng.github.io/pkg'
 
 CONF_PRIORITY=100
 
@@ -90,6 +102,36 @@ _detect_catalog() {
     _dc_mm="$(printf '%s' "${_dc_ver}" | cut -d- -f1 | cut -d. -f1,2)"
     [ -n "${_dc_mm}" ] || return 1
     printf '%s-%s' "${_dc_edition}" "${_dc_mm}"
+}
+
+# Recover the catalog base a conf was last generated from. $1 = conf path,
+# $2 = channel word. The canonical url is "<base>/<channel>/<varver>", so the
+# base is what is left after stripping the two trailing segments — and the
+# channel segment MUST equal this conf's own channel, which is what makes the
+# url recognisably one this hook wrote.
+#
+# WHY (issue #2459): at boot there is no environment, so composing the url from
+# a hardcoded default rewrote every conf to the primary Pages site — a fork
+# site, a staging prefix and a `file://` guest catalogue all silently became
+# https://pfblockerng.github.io/pkg, redirecting where the box fetches packages
+# from. Reading the base back out of the conf keeps the OS-upgrade job the hook
+# exists for (move the <varver>) without moving anything else.
+#
+# Prints the base on success. Returns 1 when the conf carries no url line at all
+# (an install.sh stub pending first generation — the caller falls back to the
+# built-in default); 2 when the url is of a shape this hook never emits (a
+# hand-written or foreign conf — the caller leaves it alone).
+_base_from_conf() {
+    _bc_conf="$1"
+    _bc_channel="$2"
+    _bc_url="$(sed -n 's/^[[:space:]]*url:[[:space:]]*"\([^"]*\)".*/\1/p' "${_bc_conf}" 2>/dev/null | head -n 1)"
+    [ -n "${_bc_url}" ] || return 1
+    _bc_head="${_bc_url%/*}"
+    [ "${_bc_head}" != "${_bc_url}" ] || return 2
+    [ "${_bc_head##*/}" = "${_bc_channel}" ] || return 2
+    _bc_base="${_bc_head%/*}"
+    [ -n "${_bc_base}" ] && [ "${_bc_base}" != "${_bc_head}" ] || return 2
+    printf '%s' "${_bc_base}"
 }
 
 # Emit the canonical conf body. $1 = channel word, $2 = repo name, $3 = url.
@@ -124,12 +166,28 @@ _regen_one() {
     _ro_channel="$2"
     _ro_repo="$3"
     [ -f "${_ro_conf}" ] || return 0
+    # Base: an explicit PFB_BASE_URL wins (install.sh drives the hook with one
+    # precisely to MOVE a box onto another base); otherwise it is read back out
+    # of the conf, so a boot with no environment preserves it (issue #2459).
+    if [ -n "${PFB_BASE_URL:-}" ]; then
+        _ro_base="${PFB_BASE_URL}"
+    else
+        _ro_base="$(_base_from_conf "${_ro_conf}" "${_ro_channel}")"
+        _ro_rc=$?
+        if [ "${_ro_rc}" -eq 1 ]; then
+            _ro_base="${PFB_DEFAULT_BASE_URL}"
+        elif [ "${_ro_rc}" -ne 0 ]; then
+            printf '[%s] WARNING: %s carries a foreign url — leaving it unchanged\n' \
+                "${name}" "${_ro_conf}" >&2
+            return 0
+        fi
+    fi
     _ro_catalog="$(_detect_catalog)" || {
         printf '[%s] WARNING: variant detection failed — leaving %s unchanged\n' \
             "${name}" "${_ro_conf}" >&2
         return 0
     }
-    _ro_url="${PFB_BASE_URL%/}/${_ro_channel}/${_ro_catalog}"
+    _ro_url="${_ro_base%/}/${_ro_channel}/${_ro_catalog}"
     if _emit_conf "${_ro_channel}" "${_ro_repo}" "${_ro_url}" > "${_ro_conf}.tmp" 2>/dev/null \
         && mv "${_ro_conf}.tmp" "${_ro_conf}" 2>/dev/null; then
         printf '[%s] INFO: regenerated %s -> %s\n' "${name}" "${_ro_conf}" "${_ro_url}" >&2

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -146,11 +146,13 @@ _base_from_conf() {
     _bc_url="${_bc_url%/}"
     _bc_head="${_bc_url%/*}"
     [ "${_bc_head}" != "${_bc_url}" ] || return 2
-    # The trailing segment must be a varver this hook emits — _detect_catalog()
-    # above produces exactly `ce-` or `plus-` followed by major.minor, nothing
-    # else. Anything looser accepts a directory the operator chose (and would
-    # then replace it), or a url carrying a query string or fragment (and would
-    # drop credentials they put there while rewriting the path).
+    # The trailing segment must be shaped like the varver _detect_catalog()
+    # above emits: a `ce-` or `plus-` prefix followed by major.minor. Anything
+    # looser accepts a directory the operator chose (and would then replace it),
+    # or a url carrying a query string or fragment (and would drop credentials
+    # they put there while rewriting the path). Deliberately a shape check and
+    # not an equality one — the point is to recognise OUR url, including the
+    # pre-upgrade varver we are about to move off.
     _bc_varver="${_bc_url##*/}"
     case "${_bc_varver}" in
         ce-[0-9]* | plus-[0-9]*) ;;

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -75,10 +75,14 @@ name="pfblockerng_repo_generate"
 # The catalog base. NOT defaulted into PFB_BASE_URL: an explicitly exported
 # PFB_BASE_URL (install.sh, the smoke guests, a fork bootstrap) must stay
 # distinguishable from "nothing in the environment", because at boot the base
-# comes from the conf itself — see _base_from_conf() and issue #2459. The
-# built-in default is used only for a conf that carries no url at all (an
-# install.sh stub still pending its first generation).
-PFB_DEFAULT_BASE_URL='https://pfblockerng.github.io/pkg'
+# comes from the conf itself — see _base_from_conf() and issue #2459.
+#
+# The fallback below is reached only by a conf that carries no url line at all —
+# today only the off-box test harnesses, since install.sh always supplies a base
+# of its own. Deliberately NOT named PFB_DEFAULT_BASE_URL: gen_landing.py injects
+# a variable of that name into install.sh, and the published installer carries
+# this hook embedded in it.
+PFB_FALLBACK_BASE_URL='https://pfblockerng.github.io/pkg'
 
 CONF_PRIORITY=100
 
@@ -117,20 +121,43 @@ _detect_catalog() {
 # from. Reading the base back out of the conf keeps the OS-upgrade job the hook
 # exists for (move the <varver>) without moving anything else.
 #
-# Prints the base on success. Returns 1 when the conf carries no url line at all
-# (an install.sh stub pending first generation — the caller falls back to the
-# built-in default); 2 when the url is of a shape this hook never emits (a
-# hand-written or foreign conf — the caller leaves it alone).
+# Prints the base on success. Returns 1 ONLY when the conf carries no url line at
+# all (an install.sh stub pending first generation — the caller falls back to the
+# built-in default); 2 whenever a url IS present but is not one this hook could
+# have written (the caller leaves the conf alone). The discriminator is the
+# presence of the url line, never whether the pattern below matched it:
+# unquoted and single-quoted strings are valid UCL an operator can hand-write,
+# and an unterminated quote is what a botched hand edit leaves behind — treating
+# any of those as a pending stub would rewrite them from the built-in default,
+# which is the redirect this whole guard exists to prevent.
 _base_from_conf() {
     _bc_conf="$1"
     _bc_channel="$2"
     _bc_url="$(sed -n 's/^[[:space:]]*url:[[:space:]]*"\([^"]*\)".*/\1/p' "${_bc_conf}" 2>/dev/null | head -n 1)"
-    [ -n "${_bc_url}" ] || return 1
+    if [ -z "${_bc_url}" ]; then
+        grep -q '^[[:space:]]*url[[:space:]]*:' "${_bc_conf}" 2>/dev/null && return 2
+        return 1
+    fi
+    # One trailing slash is still our shape — a conf frozen as foreign over it
+    # would sit on a stale varver forever after an OS upgrade.
+    _bc_url="${_bc_url%/}"
     _bc_head="${_bc_url%/*}"
     [ "${_bc_head}" != "${_bc_url}" ] || return 2
+    # The trailing segment must look like a varver this hook emits. A url
+    # carrying a query string or fragment is not one: rewriting the path would
+    # silently drop credentials the operator put there.
+    case "${_bc_url##*/}" in
+        '' | *[!a-z0-9.-]*) return 2 ;;
+    esac
     [ "${_bc_head##*/}" = "${_bc_channel}" ] || return 2
     _bc_base="${_bc_head%/*}"
-    [ -n "${_bc_base}" ] && [ "${_bc_base}" != "${_bc_head}" ] || return 2
+    [ "${_bc_base}" != "${_bc_head}" ] || return 2
+    # A bare scheme is what is left when the channel segment was in fact the
+    # host (e.g. "https://nightly/ce-2.7") — rebuilding from it yields a
+    # malformed url, so that conf is foreign too.
+    case "${_bc_base}" in
+        '' | *: | *:/) return 2 ;;
+    esac
     printf '%s' "${_bc_base}"
 }
 
@@ -170,15 +197,15 @@ _regen_one() {
     # precisely to MOVE a box onto another base); otherwise it is read back out
     # of the conf, so a boot with no environment preserves it (issue #2459).
     if [ -n "${PFB_BASE_URL:-}" ]; then
-        _ro_base="${PFB_BASE_URL}"
+        _ro_base="${PFB_BASE_URL%/}"
     else
         _ro_base="$(_base_from_conf "${_ro_conf}" "${_ro_channel}")"
         _ro_rc=$?
         if [ "${_ro_rc}" -eq 1 ]; then
-            _ro_base="${PFB_DEFAULT_BASE_URL}"
+            _ro_base="${PFB_FALLBACK_BASE_URL}"
         elif [ "${_ro_rc}" -ne 0 ]; then
-            printf '[%s] WARNING: %s carries a foreign url — leaving it unchanged\n' \
-                "${name}" "${_ro_conf}" >&2
+            printf '[%s] WARNING: %s carries a url this hook did not write (expected <base>/%s/<varver>) — leaving it unchanged; re-run install.sh --channel %s to re-point it\n' \
+                "${name}" "${_ro_conf}" "${_ro_channel}" "${_ro_channel}" >&2
             return 0
         fi
     fi
@@ -187,7 +214,9 @@ _regen_one() {
             "${name}" "${_ro_conf}" >&2
         return 0
     }
-    _ro_url="${_ro_base%/}/${_ro_channel}/${_ro_catalog}"
+    # No %/ here: a base derived from the conf is already bare, except for the
+    # degenerate "file://" (a catalogue rooted at /), whose slash is load-bearing.
+    _ro_url="${_ro_base}/${_ro_channel}/${_ro_catalog}"
     if _emit_conf "${_ro_channel}" "${_ro_repo}" "${_ro_url}" > "${_ro_conf}.tmp" 2>/dev/null \
         && mv "${_ro_conf}.tmp" "${_ro_conf}" 2>/dev/null; then
         printf '[%s] INFO: regenerated %s -> %s\n' "${name}" "${_ro_conf}" "${_ro_url}" >&2

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -146,20 +146,29 @@ _base_from_conf() {
     _bc_url="${_bc_url%/}"
     _bc_head="${_bc_url%/*}"
     [ "${_bc_head}" != "${_bc_url}" ] || return 2
-    # The trailing segment must look like a varver this hook emits. A url
-    # carrying a query string or fragment is not one: rewriting the path would
-    # silently drop credentials the operator put there.
-    case "${_bc_url##*/}" in
-        '' | *[!a-z0-9.-]*) return 2 ;;
+    # The trailing segment must be a varver this hook emits — _detect_catalog()
+    # above produces exactly `ce-` or `plus-` followed by major.minor, nothing
+    # else. Anything looser accepts a directory the operator chose (and would
+    # then replace it), or a url carrying a query string or fragment (and would
+    # drop credentials they put there while rewriting the path).
+    _bc_varver="${_bc_url##*/}"
+    case "${_bc_varver}" in
+        ce-[0-9]* | plus-[0-9]*) ;;
+        *) return 2 ;;
+    esac
+    case "${_bc_varver#*-}" in
+        *[!0-9.]*) return 2 ;;
     esac
     [ "${_bc_head##*/}" = "${_bc_channel}" ] || return 2
     _bc_base="${_bc_head%/*}"
     [ "${_bc_base}" != "${_bc_head}" ] || return 2
-    # A bare scheme is what is left when the channel segment was in fact the
-    # host (e.g. "https://nightly/ce-2.7") — rebuilding from it yields a
-    # malformed url, so that conf is foreign too.
+    # The base must carry a whole scheme separator. Without one it is either a
+    # bare scheme — what is left when the channel segment was in fact the host,
+    # e.g. "https://nightly/ce-2.7" — or a one-slash scheme, neither of which
+    # this hook emits and both of which rebuild into a malformed url.
     case "${_bc_base}" in
-        '' | *: | *:/) return 2 ;;
+        *://*) ;;
+        *) return 2 ;;
     esac
     printf '%s' "${_bc_base}"
 }

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -135,7 +135,10 @@ _base_from_conf() {
     _bc_channel="$2"
     _bc_url="$(sed -n 's/^[[:space:]]*url:[[:space:]]*"\([^"]*\)".*/\1/p' "${_bc_conf}" 2>/dev/null | head -n 1)"
     if [ -z "${_bc_url}" ]; then
-        grep -q '^[[:space:]]*url[[:space:]]*:' "${_bc_conf}" 2>/dev/null && return 2
+        # -i: a conf spelling the key `URL:` matches neither the extractor above
+        # nor a case-sensitive presence check, and taking it for a conf with no
+        # url at all would clobber it from the fallback base.
+        grep -qi '^[[:space:]]*url[[:space:]]*:' "${_bc_conf}" 2>/dev/null && return 2
         return 1
     fi
     # One trailing slash is still our shape — a conf frozen as foreign over it

--- a/tests/shell/generate_hook_spec.sh
+++ b/tests/shell/generate_hook_spec.sh
@@ -819,3 +819,45 @@ ARCHLEAF
       The value "$(cksum < "${PFB_NIGHTLY_CONF}")" should equal "${_al_sum}"
     End
 End
+
+Describe 'generate hook — the varver segment must be one this hook emits'
+    # `<channel>/<anything>` is not our shape: only `<edition>-<major.minor>` is,
+    # and `_detect_catalog` emits exactly `ce-` or `plus-` prefixes. Accepting a
+    # foreign leaf preserved the operator's base but still replaced their
+    # directory. A scheme with one slash is malformed and equally not ours.
+    setup() {
+        _ns_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_notshape.XXXXXX")"
+        _make_box "${_ns_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_STABLE_CONF}" <<'NOTVARVER'
+pfblockerng-stable: {
+  url: "https://mirror.example.net/pkg/stable/mycustomdir",
+  enabled: yes
+}
+NOTVARVER
+        cat > "${PFB_EDGE_CONF}" <<'ONESLASH'
+pfblockerng-edge: {
+  url: "https:/mirror.example.net/pkg/edge/ce-2.7",
+  enabled: yes
+}
+ONESLASH
+        _ns_sums="$(cat "${PFB_STABLE_CONF}" "${PFB_EDGE_CONF}" | cksum)"
+    }
+    cleanup() { rm -rf "${_ns_dir}"; _unset_box; unset _ns_sums; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: one url has a non-catalog leaf, one a one-slash scheme'
+      The contents of file "${PFB_STABLE_CONF}" should include "stable/mycustomdir"
+      The contents of file "${PFB_EDGE_CONF}" should include 'url: "https:/mirror.example.net/pkg/edge/ce-2.7"'
+    End
+
+    It 'leaves both byte-unchanged, warns, and exits 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "did not write"
+      The value "$(cat "${PFB_STABLE_CONF}" "${PFB_EDGE_CONF}" | cksum)" should equal "${_ns_sums}"
+      The contents of file "${PFB_STABLE_CONF}" should include "mycustomdir"
+      The contents of file "${PFB_EDGE_CONF}" should include "ce-2.7"
+      The contents of file "${PFB_EDGE_CONF}" should not include "ce-2.8"
+    End
+End

--- a/tests/shell/generate_hook_spec.sh
+++ b/tests/shell/generate_hook_spec.sh
@@ -421,3 +421,140 @@ Describe 'generate hook — fail-proof: detection failure leaves conf unchanged'
         End
     End
 End
+
+# ── DEST BASE: the hook preserves the base its conf was generated from ────────
+#
+# Issue #2459. `_regen_one` used to compose the url from PFB_BASE_URL alone,
+# defaulting to the primary Pages site. At boot there is no env, so a fork site,
+# a staging prefix and a `file://` guest catalogue were all silently rewritten to
+# `https://pfblockerng.github.io/pkg` — a redirect of where the box fetches
+# packages from. The base now comes from the conf the hook is about to rewrite
+# (its url's `<base>/<channel>/<varver>` shape), so only the varver moves; an
+# explicit PFB_BASE_URL still wins, and a url the hook cannot parse as its own
+# is left alone instead of being clobbered.
+
+Describe 'generate hook — a file:// catalogue base survives a boot with no env'
+    setup() {
+        _fb_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_fileurl.XXXXXX")"
+        _make_box "${_fb_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_STABLE_CONF}" <<'FILEURL'
+# Generated at boot by pfblockerng_repo_generate (ADR-39)
+pfblockerng-stable: {
+  url: "file:///root/pfb_repo/stable/ce-2.7",
+  enabled: yes
+}
+FILEURL
+    }
+    cleanup() { rm -rf "${_fb_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the conf points at the file:// catalogue with a stale varver'
+      The contents of file "${PFB_STABLE_CONF}" should include 'url: "file:///root/pfb_repo/stable/ce-2.7"'
+    End
+
+    It 'keeps the file:// base and only moves the varver, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_STABLE_CONF}" should include 'url: "file:///root/pfb_repo/stable/ce-2.8"'
+      The contents of file "${PFB_STABLE_CONF}" should not include "pfblockerng.github.io"
+    End
+End
+
+Describe 'generate hook — a staging-prefixed fork base survives a boot with no env'
+    setup() {
+        _sp_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_stageurl.XXXXXX")"
+        _make_box "${_sp_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_EDGE_CONF}" <<'STAGEURL'
+# Generated at boot by pfblockerng_repo_generate (ADR-39)
+pfblockerng-edge: {
+  url: "https://fork.example.org/pkg/staging/pr-7/edge/ce-2.7",
+  enabled: yes
+}
+STAGEURL
+    }
+    cleanup() { rm -rf "${_sp_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the conf carries the fork site and its staging prefix'
+      The contents of file "${PFB_EDGE_CONF}" should include 'url: "https://fork.example.org/pkg/staging/pr-7/edge/ce-2.7"'
+    End
+
+    It 'keeps host and staging prefix and only moves the varver, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_EDGE_CONF}" should include 'url: "https://fork.example.org/pkg/staging/pr-7/edge/ce-2.8"'
+      The contents of file "${PFB_EDGE_CONF}" should not include "pfblockerng.github.io"
+    End
+End
+
+Describe 'generate hook — a url the hook did not write is left alone'
+    # The channel segment does not match the conf's channel, so this url is not
+    # one this hook generated: rewriting it would silently move the box to
+    # another catalogue. Leave it, warn, exit 0.
+    setup() {
+        _fo_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_foreign.XXXXXX")"
+        _make_box "${_fo_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_NIGHTLY_CONF}" <<'FOREIGN'
+# hand-written by the operator — FOREIGN-CONF
+pfblockerng-nightly: {
+  url: "https://mirror.example.net/custom-layout",
+  enabled: yes
+}
+FOREIGN
+        _fo_sum="$(cksum < "${PFB_NIGHTLY_CONF}")"
+    }
+    cleanup() { rm -rf "${_fo_dir}"; _unset_box; unset _fo_sum; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the conf carries a url of a shape the hook never emits'
+      The contents of file "${PFB_NIGHTLY_CONF}" should include "FOREIGN-CONF"
+      The contents of file "${PFB_NIGHTLY_CONF}" should include 'url: "https://mirror.example.net/custom-layout"'
+    End
+
+    It 'leaves the conf byte-unchanged, warns, and exits 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "WARNING"
+      The stderr should include "foreign url"
+      The value "$(cksum < "${PFB_NIGHTLY_CONF}")" should equal "${_fo_sum}"
+      The contents of file "${PFB_NIGHTLY_CONF}" should not include "pfblockerng.github.io"
+    End
+End
+
+Describe 'generate hook — an explicit PFB_BASE_URL still overrides the conf base'
+    # install.sh drives the hook with PFB_BASE_URL set, precisely to MOVE a box
+    # onto another base; the conf-derived base must not defeat that.
+    setup() {
+        _ov_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_override.XXXXXX")"
+        _make_box "${_ov_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_TESTING_CONF}" <<'OLDBASE'
+# Generated at boot by pfblockerng_repo_generate (ADR-39)
+pfblockerng-testing: {
+  url: "file:///root/pfb_repo/testing/ce-2.8",
+  enabled: yes
+}
+OLDBASE
+        PFB_BASE_URL="https://override.example/pkg"
+        export PFB_BASE_URL
+    }
+    cleanup() { rm -rf "${_ov_dir}"; _unset_box; unset PFB_BASE_URL; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the conf still carries the old file:// base'
+      The contents of file "${PFB_TESTING_CONF}" should include "file:///root/pfb_repo/testing"
+    End
+
+    It 'rewrites to the base given in the environment, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_TESTING_CONF}" should include 'url: "https://override.example/pkg/testing/ce-2.8"'
+      The contents of file "${PFB_TESTING_CONF}" should not include "file:///root/pfb_repo"
+    End
+End

--- a/tests/shell/generate_hook_spec.sh
+++ b/tests/shell/generate_hook_spec.sh
@@ -751,3 +751,71 @@ CONFSLASH
       The contents of file "${PFB_TESTING_CONF}" should not include "pfblockerng.github.io"
     End
 End
+
+Describe 'generate hook — the url-line discriminator ignores case'
+    # A hand-edited conf spelling the key `URL:` matches neither the extractor
+    # nor a case-sensitive presence check, so it would be taken for a conf with
+    # no url at all and rewritten from the fallback base — the same defect class
+    # as an unparseable url, reached through a different variant.
+    setup() {
+        _uc_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_upcase.XXXXXX")"
+        _make_box "${_uc_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_EDGE_CONF}" <<'UPCASE'
+pfblockerng-edge: {
+  URL: "https://decoy.example.org/pkg/edge/ce-2.7",
+  enabled: yes
+}
+UPCASE
+        _uc_sum="$(cksum < "${PFB_EDGE_CONF}")"
+    }
+    cleanup() { rm -rf "${_uc_dir}"; _unset_box; unset _uc_sum; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the conf spells the key in upper case'
+      The contents of file "${PFB_EDGE_CONF}" should include 'URL: "https://decoy.example.org/pkg/edge/ce-2.7"'
+    End
+
+    It 'leaves the conf byte-unchanged, warns, and exits 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "did not write"
+      The value "$(cksum < "${PFB_EDGE_CONF}")" should equal "${_uc_sum}"
+      The contents of file "${PFB_EDGE_CONF}" should not include "pfblockerng.github.io"
+    End
+End
+
+Describe 'generate hook — a pre-#1806 arch-leaf conf is frozen, not healed'
+    # Before issue #1806 the url carried a per-arch leaf: <base>/<channel>/
+    # <varver>/<arch>. The old hook healed one on the next boot; the dest-base
+    # guard now freezes it, because a url of that shape is indistinguishable
+    # from any other four-segment tail. The warning names the install.sh re-run
+    # that re-points it — this row pins that deliberate trade.
+    setup() {
+        _al_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_archleaf.XXXXXX")"
+        _make_box "${_al_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_NIGHTLY_CONF}" <<'ARCHLEAF'
+# Generated at boot by pfblockerng_repo_generate (ADR-39)
+pfblockerng-nightly: {
+  url: "https://pfblockerng.github.io/pkg/nightly/ce-2.7/FreeBSD:15:amd64",
+  enabled: yes
+}
+ARCHLEAF
+        _al_sum="$(cksum < "${PFB_NIGHTLY_CONF}")"
+    }
+    cleanup() { rm -rf "${_al_dir}"; _unset_box; unset _al_sum; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the conf carries the retired per-arch leaf'
+      The contents of file "${PFB_NIGHTLY_CONF}" should include "ce-2.7/FreeBSD:15:amd64"
+    End
+
+    It 'leaves it byte-unchanged and points at the install.sh re-run, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "did not write"
+      The stderr should include "install.sh --channel nightly"
+      The value "$(cksum < "${PFB_NIGHTLY_CONF}")" should equal "${_al_sum}"
+    End
+End

--- a/tests/shell/generate_hook_spec.sh
+++ b/tests/shell/generate_hook_spec.sh
@@ -2,11 +2,12 @@
 # pfblockerng_repo_generate.sh — boot-time repo-conf regenerator (ADR-39;
 # arch-less/NO_ARCH since issue #1806).
 #
-# The hook is a pure REGENERATOR: for each of our conf files that EXISTS, it
-# detects the box's <varver> and unconditionally overwrites the conf with the
-# canonical body. No pkg call at all (issue #1806 retired the `pkg config abi`
-# read — arch-less catalogs have no per-arch leaf left to detect), no network,
-# no snapshot, no reconcile.
+# The hook is a REGENERATOR: for each of our conf files that EXISTS, it detects
+# the box's <varver> and overwrites the conf with the canonical body. No pkg
+# call at all (issue #1806 retired the `pkg config abi` read — arch-less
+# catalogs have no per-arch leaf left to detect), no network, no snapshot, no
+# reconcile. The one thing it does NOT re-derive is the catalog BASE — see the
+# DEST BASE contract below (issue #2459).
 #
 # Behavioural contracts pinned here:
 #   orphan      — neither conf present → nothing written, pkg never invoked, exit 0.
@@ -17,6 +18,10 @@
 #                 unchanged (issue #2416).
 #   unconditional — a STALE-varver conf is rewritten to the box's current varver
 #                 (before: stale present; after: stale gone, current present).
+#   dest base   — the base the conf was generated from survives a boot with no
+#                 environment (fork site, staging prefix, file:// catalogue); an
+#                 explicit PFB_BASE_URL still wins; a url this hook could not
+#                 have written leaves the conf byte-unchanged (issue #2459).
 #   detection   — edition = "/etc/product_label contains 'Plus'": Plus vs CE; the
 #                 varver prefix and the catalog path follow. Version-only —
 #                 arch-less (issue #1806): the hook never calls `pkg` at all.
@@ -520,7 +525,7 @@ FOREIGN
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "WARNING"
-      The stderr should include "foreign url"
+      The stderr should include "did not write"
       The value "$(cksum < "${PFB_NIGHTLY_CONF}")" should equal "${_fo_sum}"
       The contents of file "${PFB_NIGHTLY_CONF}" should not include "pfblockerng.github.io"
     End
@@ -556,5 +561,193 @@ OLDBASE
       The stderr should include "regenerated"
       The contents of file "${PFB_TESTING_CONF}" should include 'url: "https://override.example/pkg/testing/ce-2.8"'
       The contents of file "${PFB_TESTING_CONF}" should not include "file:///root/pfb_repo"
+    End
+End
+
+# ── The "no url at all" branch must not swallow an UNPARSEABLE url ────────────
+#
+# The stub-vs-foreign discriminator is "does the conf carry a url line", NOT
+# "did our double-quoted pattern match one". Unquoted and single-quoted strings
+# are valid UCL that libpkg reads fine, so an operator can hand-write one; an
+# unterminated quote is what a botched hand edit leaves behind. None of those
+# are a pending install.sh stub, and rewriting them from the built-in default
+# would silently redirect the box — the very defect of issue #2459.
+
+Describe 'generate hook — a url line it cannot parse is foreign, not a stub'
+    setup() {
+        _up_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_unparsed.XXXXXX")"
+        _make_box "${_up_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_STABLE_CONF}" <<'UNQUOTED'
+pfblockerng-stable: {
+  url: file:///root/pfb_repo/stable/ce-2.7,
+  enabled: yes
+}
+UNQUOTED
+        cat > "${PFB_EDGE_CONF}" <<'SINGLEQ'
+pfblockerng-edge: {
+  url: 'https://fork.example.org/pkg/edge/ce-2.7',
+  enabled: yes
+}
+SINGLEQ
+        cat > "${PFB_NIGHTLY_CONF}" <<'UNTERM'
+pfblockerng-nightly: {
+  url: "https://fork.example.org/pkg/nightly/ce-2.7,
+  enabled: yes
+}
+UNTERM
+        _up_sums="$(cat "${PFB_STABLE_CONF}" "${PFB_EDGE_CONF}" "${PFB_NIGHTLY_CONF}" | cksum)"
+    }
+    cleanup() { rm -rf "${_up_dir}"; _unset_box; unset _up_sums; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: three confs carry a url line our pattern cannot parse'
+      The contents of file "${PFB_STABLE_CONF}" should include "url: file:///root/pfb_repo/stable/ce-2.7"
+      The contents of file "${PFB_EDGE_CONF}" should include "url: 'https://fork.example.org/pkg/edge/ce-2.7'"
+      The contents of file "${PFB_NIGHTLY_CONF}" should include 'url: "https://fork.example.org/pkg/nightly/ce-2.7,'
+    End
+
+    It 'leaves all three byte-unchanged, warns, and exits 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "did not write"
+      The value "$(cat "${PFB_STABLE_CONF}" "${PFB_EDGE_CONF}" "${PFB_NIGHTLY_CONF}" | cksum)" should equal "${_up_sums}"
+      The contents of file "${PFB_STABLE_CONF}" should not include "pfblockerng.github.io"
+      The contents of file "${PFB_EDGE_CONF}" should not include "pfblockerng.github.io"
+      The contents of file "${PFB_NIGHTLY_CONF}" should not include "pfblockerng.github.io"
+    End
+End
+
+Describe 'generate hook — a varver segment it never emits is foreign too'
+    # The channel segment matching is not enough: the last segment must also look
+    # like a varver this hook wrote. A query string carries credentials an
+    # operator put there, and dropping it while rewriting the path would break
+    # the subscription silently; a host literally named after the channel would
+    # collapse the base to a bare scheme.
+    setup() {
+        _vv_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_varver.XXXXXX")"
+        _make_box "${_vv_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_TESTING_CONF}" <<'QUERY'
+pfblockerng-testing: {
+  url: "https://mirror.example.net/pkg/testing/ce-2.7?token=abc",
+  enabled: yes
+}
+QUERY
+        cat > "${PFB_NIGHTLY_CONF}" <<'BARESCHEME'
+pfblockerng-nightly: {
+  url: "https://nightly/ce-2.7",
+  enabled: yes
+}
+BARESCHEME
+        _vv_sums="$(cat "${PFB_TESTING_CONF}" "${PFB_NIGHTLY_CONF}" | cksum)"
+    }
+    cleanup() { rm -rf "${_vv_dir}"; _unset_box; unset _vv_sums; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: one url carries a query string, one has the channel as its host'
+      The contents of file "${PFB_TESTING_CONF}" should include "ce-2.7?token=abc"
+      The contents of file "${PFB_NIGHTLY_CONF}" should include 'url: "https://nightly/ce-2.7"'
+    End
+
+    It 'leaves both byte-unchanged, warns, and exits 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "did not write"
+      The value "$(cat "${PFB_TESTING_CONF}" "${PFB_NIGHTLY_CONF}" | cksum)" should equal "${_vv_sums}"
+      The contents of file "${PFB_TESTING_CONF}" should include "token=abc"
+      The contents of file "${PFB_NIGHTLY_CONF}" should not include "https:/nightly"
+    End
+End
+
+# ── Base composition edge cases ───────────────────────────────────────────────
+
+Describe 'generate hook — a catalogue rooted at / keeps its third slash'
+    # `file:///stable/ce-2.7` derives the base `file://`. Stripping a trailing
+    # slash off THAT (which the env branch must do, and only the env branch)
+    # would emit `file://stable/...` — a host-form url pointing somewhere else
+    # entirely, written with an INFO line rather than a warning.
+    setup() {
+        _fr_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_fsroot.XXXXXX")"
+        _make_box "${_fr_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_STABLE_CONF}" <<'FSROOT'
+# Generated at boot by pfblockerng_repo_generate (ADR-39)
+pfblockerng-stable: {
+  url: "file:///stable/ce-2.7",
+  enabled: yes
+}
+FSROOT
+    }
+    cleanup() { rm -rf "${_fr_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the catalogue root is the filesystem root'
+      The contents of file "${PFB_STABLE_CONF}" should include 'url: "file:///stable/ce-2.7"'
+    End
+
+    It 'regenerates to a path url, not a host url, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_STABLE_CONF}" should include 'url: "file:///stable/ce-2.8"'
+      The contents of file "${PFB_STABLE_CONF}" should not include "file://stable"
+    End
+End
+
+Describe 'generate hook — an env base with a trailing slash does not double it'
+    setup() {
+        _ts_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_envslash.XXXXXX")"
+        _make_box "${_ts_dir}" "pfSense" "2.8.1"
+        printf '# stub pending\n' > "${PFB_EDGE_CONF}"
+        PFB_BASE_URL="https://fork.example.org/pkg/"
+        export PFB_BASE_URL
+    }
+    cleanup() { rm -rf "${_ts_dir}"; _unset_box; unset PFB_BASE_URL; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the conf is the unresolved stub'
+      The contents of file "${PFB_EDGE_CONF}" should include "pending"
+    End
+
+    It 'emits exactly one slash between base and channel, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_EDGE_CONF}" should include 'url: "https://fork.example.org/pkg/edge/ce-2.8"'
+      The contents of file "${PFB_EDGE_CONF}" should not include "pkg//edge"
+    End
+End
+
+Describe 'generate hook — one trailing slash on a conf url is tolerated'
+    # A conf whose url is otherwise exactly our shape but carries a trailing
+    # slash is still one we wrote (or a harmless hand edit of one); freezing it
+    # as foreign would strand the box on a stale varver after an OS upgrade.
+    setup() {
+        _cs_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/gen_confslash.XXXXXX")"
+        _make_box "${_cs_dir}" "pfSense" "2.8.1"
+        cat > "${PFB_TESTING_CONF}" <<'CONFSLASH'
+# Generated at boot by pfblockerng_repo_generate (ADR-39)
+pfblockerng-testing: {
+  url: "https://fork.example.org/pkg/testing/ce-2.7/",
+  enabled: yes
+}
+CONFSLASH
+    }
+    cleanup() { rm -rf "${_cs_dir}"; _unset_box; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'before-state: the conf url carries a trailing slash and a stale varver'
+      The contents of file "${PFB_TESTING_CONF}" should include 'url: "https://fork.example.org/pkg/testing/ce-2.7/"'
+    End
+
+    It 'keeps the fork base and moves the varver, exit 0'
+      When run sh "${HOOK}" onestart
+      The status should be success
+      The stderr should include "regenerated"
+      The contents of file "${PFB_TESTING_CONF}" should include 'url: "https://fork.example.org/pkg/testing/ce-2.8"'
+      The contents of file "${PFB_TESTING_CONF}" should not include "pfblockerng.github.io"
     End
 End


### PR DESCRIPTION
## Problem

`scripts/rc.d/pfblockerng_repo_generate.sh` composed every conf's `url:` from `PFB_BASE_URL`, defaulting to the primary Pages site, and `_regen_one` rewrote each conf it found unconditionally. At boot there is no environment, so after one reboot a fork Pages site, a `PUBLISH_STAGE=stage` prefix, and a smoke guest's `file://` catalogue all converged on `https://pfblockerng.github.io/pkg` — a silent redirect of where the box fetches packages from.

As raised in the issue discussion, baking a base into the installed hook would not have closed this. The hook rewrote confs it never wrote, from a base it composed itself: a `file://` guest catalogue has no derivable base at all, and re-running `install.sh` with a different `--channel` would leave a baked constant stale.

## Fix

The base is now read back out of the conf the hook is about to rewrite. The canonical url is `<base>/<channel>/<varver>`, so stripping the two trailing segments recovers the base. Only the `<varver>` moves, which is the OS-upgrade job the hook exists for.

Resolution order, per conf:

1. A non-empty `PFB_BASE_URL` in the environment wins — `install.sh` drives the hook with one precisely in order to move a box onto another base, and it remains the repair path for any conf the boot hook refuses.
2. Otherwise the base is derived from the conf's existing url.
3. A conf with no `url:` line **at all** falls back to the built-in base. That branch is reachable today only by the off-box test harnesses; `install.sh` always supplies a base of its own.
4. A `url:` this hook could not have written leaves the conf **byte-unchanged**, with a warning naming the expected shape and the `install.sh --channel` re-run that re-points it. The hook still exits 0 — it must never wedge boot.

What counts as "could not have written", each pinned by a test: a url line the extractor cannot parse (unquoted or single-quoted UCL, an unterminated quote, or the key spelled `URL:`) — the discriminator is the *presence* of a url line, never whether the pattern matched it; a channel segment that is not this conf's channel; a trailing segment that is not varver-shaped (a query string would otherwise be dropped while the path was rewritten, discarding credentials the operator put there); and a derived base that is a bare scheme (the channel word was in fact the host, which produced a malformed url). One trailing slash is tolerated rather than frozen, and the `%/` strip applies to the environment branch alone so that a base of exactly `file://` — a catalogue rooted at `/` — keeps its load-bearing third slash.

`PFB_BASE_URL` is no longer defaulted inside the hook, so "explicitly set" stays distinguishable from "nothing in the environment". The built-in constant is deliberately named `PFB_FALLBACK_BASE_URL`: `gen_landing.py` injects a `PFB_DEFAULT_BASE_URL` of its own into `install.sh`, and the published installer carries this hook embedded in it.

### One deliberate behaviour trade

A conf still carrying the retired pre-#1806 per-arch leaf (`<base>/<channel>/<varver>/<arch>`) used to be healed on the next boot; it is now frozen and warned about instead, because a url of that shape is indistinguishable from any other foreign four-segment tail. Re-running `install.sh --channel <ch>` re-points it, and the warning says so. Exposure is limited to a `pfblockerng-nightly.conf` predating #1806 — the four per-channel conf names post-date arch-less publishing.

## Tests

Eleven examples added to `tests/shell/generate_hook_spec.sh`, each following the file's before-state/after-state mandate, with `cksum` byte-oracles on every "left unchanged" row. Red → green, executed in the CI image with `scripts/run-in-docker.sh shellspec tests/shell/generate_hook_spec.sh`:

| Rows | RED | GREEN |
| --- | --- | --- |
| base preserved (`file://`, staging prefix), foreign url left alone | 31 examples, 3 failures | 31, 0 |
| unparseable url line, non-varver trailing segment | 35 examples, 2 failures | 35, 0 |
| `file://` root slash, conf trailing slash | 41 examples, 2 failures | 41, 0 |
| `URL:` key case | 45 examples, 1 failure | 45, 0 |

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (includes the whole shellspec suite under `dash`). `tests/test_channel_install.py`, `tests/test_gen_landing.py`, `tests/test_repo_conf_generators.py` → 218 passed.

`docs/misc/architecture-notes.md` and the spec's contract header, both of which still described the rewrite as unconditional, are updated to match.

Fixes #2459
Part of #2416

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Repository catalog generation now preserves existing catalog sources when no override is configured.
  - Explicit base URL settings continue to take precedence, with improved handling for missing, unsupported, or malformed URLs.
  - Generated catalog links update channel and version paths without unexpectedly changing the established source.
  - Added safeguards for URL formatting edge cases and retired catalog paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->