### PR TITLE
smoke: keep polling when the post-boot metadata job has not started

### DIFF
--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -830,9 +830,11 @@ PFB_METADATA_PROBE='if /bin/test -f /var/run/pfSense_version.rc; then echo prese
 pfb_wait_pkg_metadata() {
     _pwpm_timeout="${1:-${METADATA_TIMEOUT:-600}}"
     _pwpm_interval="${METADATA_INTERVAL:-5}"
-    # A zero, negative or non-numeric interval would pin the elapsed counter and
-    # leave the deadline unreachable, i.e. an unbounded wait. Floor it.
+    # An unusable interval pins the elapsed counter and an unusable cap makes the
+    # deadline test error on every iteration ("Illegal number"); either way the
+    # loop never reaches its failure path, i.e. an unbounded wait. Floor both.
     [ "$_pwpm_interval" -ge 1 ] 2>/dev/null || _pwpm_interval=5
+    [ "$_pwpm_timeout" -ge 0 ] 2>/dev/null || _pwpm_timeout=600
     _pwpm_elapsed=0
     _pwpm_seen=0
     log "waiting for the pfSense package metadata refresh to settle"

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -99,7 +99,11 @@
 #   Env knobs (mainly for the spec): VERIFY_BOOT_TIMEOUT — seconds to wait for
 #   the artifact-verification boot's SSH (default: 600); PROMOTE_TIMEOUT /
 #   PROMOTE_INTERVAL — seconds to wait / poll step for pfSense's own boot
-#   verification to promote the new BE (defaults: 300 / 10).
+#   verification to promote the new BE (defaults: 300 / 10); METADATA_TIMEOUT /
+#   METADATA_INTERVAL — seconds to wait / poll step for pfSense's post-boot
+#   package metadata refresh to settle (defaults: 600 / 5). Every boot wait adds
+#   the metadata wait to its own budget, so a boot wait's worst case is its own
+#   timeout PLUS METADATA_TIMEOUT.
 #   --upgrade-pkgs   before pfSense-upgrade, run `pkg update -f` + `pkg upgrade -y`
 #                    to upgrade baked deps (qemu-guest-agent, etc.) to their latest
 #                    versions; reboots the guest and waits for SSH before proceeding.
@@ -891,8 +895,11 @@ pfb_wait_upgraded_box() {
 
 # wait_guest_ssh BEGIN
 # wait_guest_ssh TIMEOUT [CONSOLE] — poll until root SSH answers or TIMEOUT
-# seconds elapse; CONSOLE names the boot's console log for the failure message
-# (the verification boot writes verify-console.log, not console.log).
+# seconds elapse, then until the package metadata refresh has settled; CONSOLE
+# names the boot's console log for the failure message (the verification boot
+# writes verify-console.log, not console.log). TIMEOUT bounds the SSH poll only,
+# so the call's worst case is TIMEOUT + METADATA_TIMEOUT — both hard caps, and
+# both end by dying rather than returning.
 #
 # Answering SSH is not a settled box. Every caller here goes straight on to read
 # pkg's ABI, apply a pkg upgrade, sample the exported artifact's ABI, or power the

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -806,9 +806,59 @@ pfb_be_is_permanent() {
 }
 # pfb_promote_be END
 
+# pfb_wait_pkg_metadata BEGIN
+# The three-word predicate tests/smoke/helpers.py drives (issues #2242, #2458): one
+# round-trip answers present / running / gone. Both alternatives are bracket-escaped
+# (`[-]`, `[.]`) so the pattern text in this command's own argv never satisfies itself
+# as a `pgrep -f` match. pfSense's root login shell is tcsh, so it runs under /bin/sh.
+PFB_METADATA_PROBE='if /bin/test -f /var/run/pfSense_version.rc; then echo present; elif /bin/pgrep -f "pfSense[-]upgrade|rc[.]update_pkg_metadata" >/dev/null 2>&1; then echo running; else echo gone; fi'
+
+# pfb_wait_pkg_metadata [TIMEOUT] — block until pfSense's post-boot package metadata
+# refresh has published /var/run/pfSense_version.rc, which rc.update_pkg_metadata does
+# only after `pfSense-upgrade -uf` finishes both phases. While that job runs it rewrites
+# pkg's effective ABI, so reading `pkg config ABI` / `pkg query`, applying a pkg upgrade
+# or powering the VM off mid-refresh samples or freezes a half-written state (#2242).
+#
+# `gone` is not a verdict on its own: the boot flag clears before the job starts, so it
+# means "not started yet" until a `running` probe has been seen and "exited without the
+# sentinel" after one. Only `present` is success; both failure shapes die loudly rather
+# than let the caller proceed against an unsettled box (#2458).
+pfb_wait_pkg_metadata() {
+    _pwpm_timeout="${1:-${METADATA_TIMEOUT:-600}}"
+    _pwpm_interval="${METADATA_INTERVAL:-5}"
+    _pwpm_elapsed=0
+    _pwpm_seen=0
+    log "waiting for the pfSense package metadata refresh to settle"
+    while true; do
+        # 2>/dev/null + last-non-empty-line for the same reason pfb_refresh_pkgs does it:
+        # ssh_guest always prints a known-hosts warning on stderr (issue #2299).
+        _pwpm_word=$(ssh_guest "/bin/sh -c '${PFB_METADATA_PROBE}'" 2>/dev/null | tr -d '\r' | awk 'NF { v = $0 } END { print v }')
+        if [ "$_pwpm_word" = present ]; then
+            return 0
+        fi
+        if [ "$_pwpm_word" = running ]; then
+            _pwpm_seen=1
+        elif [ "$_pwpm_word" = gone ] && [ "$_pwpm_seen" -eq 1 ]; then
+            die "pfSense package metadata refresh exited without publishing /var/run/pfSense_version.rc — the job was seen running and is now gone, so the refresh FAILED (issues #2242, #2458)"
+        fi
+        if [ "$_pwpm_elapsed" -ge "$_pwpm_timeout" ]; then
+            die "pfSense package metadata did not settle within ${_pwpm_timeout}s (last probe: ${_pwpm_word:-<empty>}) — refusing to read pkg state or power the box off mid-refresh (issues #2242, #2458)"
+        fi
+        sleep "$_pwpm_interval"
+        _pwpm_elapsed=$((_pwpm_elapsed + _pwpm_interval))
+    done
+}
+# pfb_wait_pkg_metadata END
+
+# wait_guest_ssh BEGIN
 # wait_guest_ssh TIMEOUT [CONSOLE] — poll until root SSH answers or TIMEOUT
 # seconds elapse; CONSOLE names the boot's console log for the failure message
 # (the verification boot writes verify-console.log, not console.log).
+#
+# Answering SSH is not a settled box. Every caller here goes straight on to read
+# pkg's ABI, apply a pkg upgrade, sample the exported artifact's ABI, or power the
+# verify VM off — all of which race pfSense's post-boot metadata refresh — so the
+# metadata wait belongs here, once, rather than at each call site (issue #2458).
 wait_guest_ssh() {
     _wgs_timeout="$1"
     _wgs_console="${2:-console.log}"
@@ -818,7 +868,9 @@ wait_guest_ssh() {
             die "VM did not answer SSH within ${_wgs_timeout}s (see $REMOTE_DIR/${_wgs_console} on the KVM host)"
         sleep 5; _wgs_elapsed=$((_wgs_elapsed + 5))
     done
+    pfb_wait_pkg_metadata
 }
+# wait_guest_ssh END
 
 # nth_mac N — echo the Nth line (0-based) of the newline-separated MAC list, i.e.
 # the MAC for NIC net${N}. Mirrors boot_vm.sh so every NIC gets the source-VM MAC.

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -826,6 +826,9 @@ PFB_METADATA_PROBE='if /bin/test -f /var/run/pfSense_version.rc; then echo prese
 pfb_wait_pkg_metadata() {
     _pwpm_timeout="${1:-${METADATA_TIMEOUT:-600}}"
     _pwpm_interval="${METADATA_INTERVAL:-5}"
+    # A zero, negative or non-numeric interval would pin the elapsed counter and
+    # leave the deadline unreachable, i.e. an unbounded wait. Floor it.
+    [ "$_pwpm_interval" -ge 1 ] 2>/dev/null || _pwpm_interval=5
     _pwpm_elapsed=0
     _pwpm_seen=0
     log "waiting for the pfSense package metadata refresh to settle"
@@ -849,6 +852,42 @@ pfb_wait_pkg_metadata() {
     done
 }
 # pfb_wait_pkg_metadata END
+
+# pfb_wait_upgraded_box BEGIN
+# pfb_wait_upgraded_box OLD_VERSION LOG — block until the box pfSense-upgrade
+# rebooted comes back reporting a version other than OLD_VERSION, then until its
+# package metadata refresh has settled. Sets the global NEW_VER; dies if the
+# version never changes within UPGRADE_TIMEOUT.
+#
+# This path never reaches wait_guest_ssh, so it needs its own settle gate. The
+# version poll is not one: /etc/version is written by the installer BEFORE
+# rc.update_pkg_metadata runs, so it can answer while pkg's effective ABI is
+# still being rewritten (issues #2242, #2458). Everything after this point reads
+# or writes the pkg database — the dependency reconcile's `pkg query` / `pkg
+# install` / `pkg delete` / `pkg info -e`, the health gate — and then powers the
+# disk off for export, so a half-written refresh would be captured into the
+# published artifact.
+pfb_wait_upgraded_box() {
+    _pwub_old=$1
+    _pwub_log=$2
+    log "waiting for the upgraded box to come back..."
+    NEW_VER=""
+    _pwub_elapsed=0
+    sleep 20  # let the reboot begin so we don't read the pre-reboot version
+    while [ "$_pwub_elapsed" -lt "$UPGRADE_TIMEOUT" ]; do
+        _pwub_v=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)
+        if [ -n "$_pwub_v" ] && [ "$_pwub_v" != "$_pwub_old" ]; then
+            NEW_VER="$_pwub_v"
+            break
+        fi
+        sleep 15; _pwub_elapsed=$((_pwub_elapsed + 15))
+    done
+    if [ -z "$NEW_VER" ]; then
+        die "version did not change within ${UPGRADE_TIMEOUT}s (still '${_pwub_old}'; see ${_pwub_log})"
+    fi
+    pfb_wait_pkg_metadata
+}
+# pfb_wait_upgraded_box END
 
 # wait_guest_ssh BEGIN
 # wait_guest_ssh TIMEOUT [CONSOLE] — poll until root SSH answers or TIMEOUT
@@ -1041,21 +1080,7 @@ if [ "$SKIP_OS_UPGRADE" -eq 0 ]; then
     pfb_call_site_upgrade "$LOCAL_DIR/upgrade.log"
 
     # --- wait for the new version to come up -----------------------------------
-    log "waiting for the upgraded box to come back..."
-    NEW_VER=""
-    _elapsed=0
-    sleep 20  # let the reboot begin so we don't read the pre-reboot version
-    while [ "$_elapsed" -lt "$UPGRADE_TIMEOUT" ]; do
-        _v=$(ssh_guest 'cat /etc/version' 2>/dev/null | tr -d '\r' || true)
-        if [ -n "$_v" ] && [ "$_v" != "$OLD_VER" ]; then
-            NEW_VER="$_v"
-            break
-        fi
-        sleep 15; _elapsed=$((_elapsed + 15))
-    done
-    if [ -z "$NEW_VER" ]; then
-        die "version did not change within ${UPGRADE_TIMEOUT}s (still '${OLD_VER}'; see $LOCAL_DIR/upgrade.log)"
-    fi
+    pfb_wait_upgraded_box "$OLD_VER" "$LOCAL_DIR/upgrade.log"
 fi
 log "upgraded: ${OLD_VER} -> ${NEW_VER}"
 

--- a/tests/shell/image_upgrade_metadata_wait_spec.sh
+++ b/tests/shell/image_upgrade_metadata_wait_spec.sh
@@ -133,6 +133,44 @@ Describe 'image-upgrade.sh package-metadata wait'
     ' _ "$SCRIPT"
   }
 
+  # run_wait_counted TIMEOUT_ARG — same stub, but counting probes and letting the
+  # interval fall back too, so the number of probes before the wait dies is a
+  # direct readout of the effective cap: probes = cap / interval + 1.
+  run_wait_counted() {
+    _arg="$1" timeout 20 sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      eval "$(sed -n "/^# pfb_wait_pkg_metadata BEGIN/,/^# pfb_wait_pkg_metadata END/p" "$1")"
+      sleep() { :; }
+      ssh_guest() {
+        _n=$(cat "$COUNT"); _n=$((_n + 1)); printf "%s\n" "$_n" > "$COUNT"
+        printf "gone\r\n"
+      }
+      pfb_wait_pkg_metadata "$_arg"
+    ' _ "$SCRIPT"
+  }
+
+  It 'falls back to the documented 600s cap when the timeout is unusable'
+    # Pins the fallback VALUE, not just that something bounded happens: with the
+    # 5s interval fallback, a 600s cap is 121 probes. A fallback of 0 would be 1.
+    When call run_wait_counted not-a-number
+    The status should be failure
+    The stderr should include 'did not settle'
+    The contents of file "$COUNT" should equal '121'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  It 'treats a zero timeout as fail-on-first-probe, not as unusable'
+    # Pins the -ge 0 boundary: 0 is a legitimate cap meaning "probe once, then
+    # give up", so it must NOT be swept into the 600s fallback.
+    When call run_wait_counted 0
+    The status should be failure
+    The stderr should include 'did not settle'
+    The contents of file "$COUNT" should equal '1'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
   It 'stays bounded when the timeout is not a number'
     When call run_wait_bad_timeout
     The status should be failure

--- a/tests/shell/image_upgrade_metadata_wait_spec.sh
+++ b/tests/shell/image_upgrade_metadata_wait_spec.sh
@@ -31,6 +31,9 @@ Describe 'image-upgrade.sh package-metadata wait'
 
   # run_wait WORDS — drive pfb_wait_pkg_metadata with a stub ssh_guest that
   # answers the space-separated WORDS in order, repeating the last one forever.
+  # The cap has headroom over the longest row (the late-start row succeeds on
+  # probe 4) so that reordering the deadline check cannot flip a row to a
+  # timeout failure for a reason it does not pin.
   run_wait() {
     _words="$1" sh -c '
       set -e
@@ -53,7 +56,7 @@ Describe 'image-upgrade.sh package-metadata wait'
         [ -n "$_pick" ] || _pick=$_w
         printf "%s\r\n" "$_pick"
       }
-      pfb_wait_pkg_metadata "${METADATA_TIMEOUT:-4}"
+      pfb_wait_pkg_metadata "${METADATA_TIMEOUT:-10}"
     ' _ "$SCRIPT"
   }
 

--- a/tests/shell/image_upgrade_metadata_wait_spec.sh
+++ b/tests/shell/image_upgrade_metadata_wait_spec.sh
@@ -117,6 +117,29 @@ Describe 'image-upgrade.sh package-metadata wait'
     ' _ "$SCRIPT"
   }
 
+  # A non-numeric cap makes the `-ge` deadline test error on every iteration
+  # (dash: "Illegal number"), so the loop never reaches its failure path — the
+  # same unbounded-wait class as a zero interval, on the other variable.
+  run_wait_bad_timeout() {
+    timeout 10 sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      eval "$(sed -n "/^# pfb_wait_pkg_metadata BEGIN/,/^# pfb_wait_pkg_metadata END/p" "$1")"
+      METADATA_INTERVAL=1
+      sleep() { :; }
+      ssh_guest() { printf "gone\r\n"; }
+      pfb_wait_pkg_metadata not-a-number
+    ' _ "$SCRIPT"
+  }
+
+  It 'stays bounded when the timeout is not a number'
+    When call run_wait_bad_timeout
+    The status should be failure
+    The stderr should include 'did not settle'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
   It 'stays bounded when the poll interval is zero'
     When call run_wait_zero_interval
     The status should be failure

--- a/tests/shell/image_upgrade_metadata_wait_spec.sh
+++ b/tests/shell/image_upgrade_metadata_wait_spec.sh
@@ -80,10 +80,42 @@ Describe 'image-upgrade.sh package-metadata wait'
     The stdout should include 'waiting for the pfSense package metadata refresh'
   End
 
+  It 'dies when the job never stops running before the deadline'
+    # The stuck-job row. `running` forever is not success and not a reason to
+    # return; the wait ends through the deadline, loudly.
+    When call run_wait 'running'
+    The status should be failure
+    The stderr should include 'did not settle'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
   It 'dies when the job never appears before the deadline'
     # A box where the metadata job never runs must not be handed to `pkg add`
     # or powered off silently: the wait ends by dying, never by returning.
     When call run_wait 'gone'
+    The status should be failure
+    The stderr should include 'did not settle'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  # run_wait_zero_interval — METADATA_INTERVAL=0 would leave the elapsed counter
+  # pinned at 0 and the deadline unreachable, i.e. an unbounded wait. `timeout`
+  # bounds the example so a regression fails the row instead of hanging the suite.
+  run_wait_zero_interval() {
+    timeout 10 sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      eval "$(sed -n "/^# pfb_wait_pkg_metadata BEGIN/,/^# pfb_wait_pkg_metadata END/p" "$1")"
+      METADATA_INTERVAL=0
+      sleep() { :; }
+      ssh_guest() { printf "gone\r\n"; }
+      pfb_wait_pkg_metadata 4
+    ' _ "$SCRIPT"
+  }
+
+  It 'stays bounded when the poll interval is zero'
+    When call run_wait_zero_interval
     The status should be failure
     The stderr should include 'did not settle'
     The stdout should include 'waiting for the pfSense package metadata refresh'
@@ -108,5 +140,56 @@ Describe 'image-upgrade.sh package-metadata wait'
     When call run_ssh_wait
     The status should be success
     The output should include 'metadata-waited'
+  End
+
+  # The OS-upgrade path never calls wait_guest_ssh: after pfSense-upgrade reboots
+  # the box it polls /etc/version itself and breaks the moment the version
+  # differs. /etc/version is written by the installer BEFORE
+  # rc.update_pkg_metadata runs, so that poll answers while pkg's effective ABI
+  # is still being rewritten -- and everything after it reads or writes the pkg
+  # database (dependency reconcile, health gate) and then powers the disk off for
+  # export. It needs the same settle gate (issue #2458).
+  #
+  # run_upgraded_wait VERSIONS — drive pfb_wait_upgraded_box with a stub guest
+  # answering the space-separated VERSIONS in order, repeating the last forever.
+  run_upgraded_wait() {
+    _words="$1" sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      eval "$(sed -n "/^# pfb_wait_upgraded_box BEGIN/,/^# pfb_wait_upgraded_box END/p" "$1")"
+      UPGRADE_TIMEOUT=45
+      sleep() { :; }
+      pfb_wait_pkg_metadata() { printf "metadata-waited\n"; }
+      ssh_guest() {
+        _n=$(cat "$COUNT"); _n=$((_n + 1)); printf "%s\n" "$_n" > "$COUNT"
+        _i=0
+        _pick=
+        for _w in $_words; do
+          _i=$((_i + 1))
+          if [ -z "$_pick" ] && [ "$_i" -ge "$_n" ]; then
+            _pick=$_w
+          fi
+        done
+        [ -n "$_pick" ] || _pick=$_w
+        printf "%s\r\n" "$_pick"
+      }
+      pfb_wait_upgraded_box 2.8.0-RELEASE /tmp/upgrade.log
+      printf "NEW_VER=%s\n" "$NEW_VER"
+    ' _ "$SCRIPT"
+  }
+
+  It 'waits for package metadata after the upgraded box reports its new version'
+    When call run_upgraded_wait '2.8.0-RELEASE 2.8.0-RELEASE 2.9.0-RELEASE'
+    The status should be success
+    The output should include 'NEW_VER=2.9.0-RELEASE'
+    The output should include 'metadata-waited'
+  End
+
+  It 'dies when the upgraded box never reports a new version'
+    When call run_upgraded_wait '2.8.0-RELEASE'
+    The status should be failure
+    The stderr should include 'version did not change'
+    The output should not include 'metadata-waited'
   End
 End

--- a/tests/shell/image_upgrade_metadata_wait_spec.sh
+++ b/tests/shell/image_upgrade_metadata_wait_spec.sh
@@ -1,0 +1,112 @@
+#shellcheck shell=sh
+# image_upgrade_metadata_wait_spec.sh — issue #2458.
+#
+# image-upgrade.sh reads `pkg config ABI`, runs `pkg upgrade`, samples the
+# exported artifact's ABI and powers the verify VM off, each one immediately
+# after wait_guest_ssh returns. SSH answering is not a settled box: pfSense
+# clears its boot flag before rc.update_pkg_metadata starts, and that job
+# rewrites pkg's effective ABI while it runs (#2242 measured ABI 15 with no
+# metadata process at 10:16:37Z and ABI 16 with the job active 26s later).
+#
+# So wait_guest_ssh also waits for the metadata job, using the same three-word
+# predicate tests/smoke/helpers.py uses: `gone` before any `running` means the
+# job has not started, `gone` after one means it died without publishing the
+# sentinel, and only `present` is done.
+#
+# Hermetic: lifts the helpers out of the script and drives them with a stub
+# guest runner — no VM, no ssh.
+
+Describe 'image-upgrade.sh package-metadata wait'
+  SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
+
+  setup() {
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgmeta.XXXXXX")"
+    COUNT="${WORK}/count"
+    printf '0\n' > "$COUNT"
+    export WORK COUNT
+  }
+  teardown() { rm -rf "$WORK"; }
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  # run_wait WORDS — drive pfb_wait_pkg_metadata with a stub ssh_guest that
+  # answers the space-separated WORDS in order, repeating the last one forever.
+  run_wait() {
+    _words="$1" sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      warn() { printf "WARNING: %s\n" "$*" >&2; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      eval "$(sed -n "/^# pfb_wait_pkg_metadata BEGIN/,/^# pfb_wait_pkg_metadata END/p" "$1")"
+      METADATA_INTERVAL=1
+      sleep() { :; }
+      ssh_guest() {
+        _n=$(cat "$COUNT"); _n=$((_n + 1)); printf "%s\n" "$_n" > "$COUNT"
+        _i=0
+        _pick=
+        for _w in $_words; do
+          _i=$((_i + 1))
+          if [ -z "$_pick" ] && [ "$_i" -ge "$_n" ]; then
+            _pick=$_w
+          fi
+        done
+        [ -n "$_pick" ] || _pick=$_w
+        printf "%s\r\n" "$_pick"
+      }
+      pfb_wait_pkg_metadata "${METADATA_TIMEOUT:-4}"
+    ' _ "$SCRIPT"
+  }
+
+  It 'keeps polling when the first probe finds no metadata job yet'
+    # `gone` on the first probe is the normal boot (#2242's 10:16:37Z sample),
+    # not a finished job — so the wait must not stop there.
+    When call run_wait 'gone gone running present'
+    The status should be success
+    The contents of file "$COUNT" should equal '4'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  It 'returns as soon as the sentinel is present'
+    When call run_wait 'running present'
+    The status should be success
+    The contents of file "$COUNT" should equal '2'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  It 'dies when the job is seen running and then disappears with no sentinel'
+    When call run_wait 'running gone'
+    The status should be failure
+    The stderr should include 'pfSense_version.rc'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  It 'dies when the job never appears before the deadline'
+    # A box where the metadata job never runs must not be handed to `pkg add`
+    # or powered off silently: the wait ends by dying, never by returning.
+    When call run_wait 'gone'
+    The status should be failure
+    The stderr should include 'did not settle'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  # run_ssh_wait — drive the REAL wait_guest_ssh with SSH answering
+  # immediately, and record whether it waits for package metadata too.
+  run_ssh_wait() {
+    sh -c '
+      set -e
+      log()  { printf "==> %s\n" "$*"; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      eval "$(sed -n "/^# wait_guest_ssh BEGIN/,/^# wait_guest_ssh END/p" "$1")"
+      sleep() { :; }
+      ssh_guest() { :; }
+      pfb_wait_pkg_metadata() { printf "metadata-waited\n"; }
+      wait_guest_ssh 30
+    ' _ "$SCRIPT"
+  }
+
+  It 'waits for package metadata before any caller reads pkg state'
+    When call run_ssh_wait
+    The status should be success
+    The output should include 'metadata-waited'
+  End
+End

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4052,8 +4052,11 @@ def wait_unbound_ready(vm: SmokeVM, *, attempts: int = 60, delay: float = 2.0) -
 # residual 02:55): `pfSense-upgrade -uf` only publishes the sentinel on SUCCESS, so a
 # finished-but-failed run leaves it absent forever -- the old probe could not tell that
 # apart from "still running" and spun to the full timeout. One ssh round-trip answers
-# present/running/gone. Both alternatives are bracket-escaped (``[-]``, ``[.]``) so the
-# pattern text embedded in THIS command's own argv never satisfies itself as a match --
+# present/running/gone. `gone` alone is NOT a verdict (issue #2458): the boot flag can
+# clear before rc.update_pkg_metadata starts, so it reads "not started yet" until a
+# `running` probe has been seen and "died without the sentinel" after one. Both
+# alternatives are bracket-escaped (``[-]``, ``[.]``) so the pattern text
+# embedded in THIS command's own argv never satisfies itself as a match --
 # unescaped, `pgrep -f` matches its own invoking shell (verified live: an unescaped
 # `pfSense-upgrade` branch made every probe report "running" with no job anywhere).
 _METADATA_PROBE_CMD = (
@@ -4087,11 +4090,17 @@ def wait_boot_complete(
     ``rc.update_pkg_metadata`` still runs ``pfSense-upgrade`` and temporarily rewrites
     pkg's effective ABI. That job atomically publishes ``pfSense_version.rc`` only after
     both update phases finish, so the per-boot file is the stable completion signal.
+
+    That job can also start AFTER the boot flag clears (issue #2458; #2242 measured the
+    metadata process absent at 10:16:37Z and active 26s later), so an absent job is only
+    conclusive once the job has been observed running -- and then it means the refresh
+    FAILED, which raises rather than letting callers pkg-add through the ABI flip window.
     """
     deadline = time.monotonic() + timeout
     snippet = "echo '<<BOOT>>' . (is_platform_booting() ? '1' : '0') . '<<END>>';"
     last = "?"
     last_metadata = "not checked"
+    seen_metadata_job = False
     while True:
         remaining = deadline - time.monotonic()
         if not remaining > 0:
@@ -4126,14 +4135,17 @@ def wait_boot_complete(
                 word = metadata.stdout.strip()
                 if word == "present":
                     return
-                if word == "gone":
-                    print(
-                        "PFB_BOOT_METADATA sentinel=absent job=gone — pfSense metadata refresh exited "
-                        "without publishing /var/run/pfSense_version.rc (metadata FAILED, not still "
-                        "booting; issue #2242)"
+                if word == "running":
+                    seen_metadata_job = True
+                elif word == "gone" and seen_metadata_job:
+                    raise RuntimeError(
+                        "PFB_BOOT_METADATA sentinel=absent job=gone — pfSense metadata refresh "
+                        "started and then exited without publishing /var/run/pfSense_version.rc "
+                        "(metadata FAILED, not still booting; issues #2242, #2458). Last probe: "
+                        f"{last_metadata}"
                     )
-                    return
-                # "running" (or an unrecognised word) -- job still working; keep polling.
+                # A `gone` before any `running` means the job has not STARTED yet, and an
+                # unrecognised word means we cannot tell -- either way keep polling.
         remaining = deadline - time.monotonic()
         if not remaining > 0:
             break

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -28,10 +28,10 @@ _PROBE_ARGV = ("/bin/sh", "-c", helpers._METADATA_PROBE_CMD)
 
 
 def test_wait_boot_complete_waits_for_boot_metadata_sentinel(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The metadata job is still running on the first probe; the sentinel
-    appears by the second -- waits, no loud "metadata failed" line."""
+    appears by the second -- the waiter polls again rather than giving up."""
     probe_words = iter(["running", "present"])
     calls: list[tuple[str, ...]] = []
 
@@ -52,7 +52,6 @@ def test_wait_boot_complete_waits_for_boot_metadata_sentinel(
     helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=2, delay=0)
 
     assert calls == [_PROBE_ARGV, _PROBE_ARGV]
-    assert "PFB_BOOT_METADATA" not in capsys.readouterr().out
 
 
 def test_wait_boot_complete_keeps_polling_when_first_probe_finds_no_metadata_job(
@@ -94,7 +93,7 @@ def test_wait_boot_complete_keeps_polling_when_first_probe_finds_no_metadata_job
 
 
 def test_wait_boot_complete_accepts_a_metadata_job_that_starts_late(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Issue #2458: the #2242 timestamps (absent at 10:16:37Z, active at
     10:17:03Z) are the NORMAL boot, so ``gone`` then ``running`` then
@@ -120,7 +119,6 @@ def test_wait_boot_complete_accepts_a_metadata_job_that_starts_late(
     helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=5, delay=0)
 
     assert [c for c in calls if c == _PROBE_ARGV] == [_PROBE_ARGV] * 3
-    assert "PFB_BOOT_METADATA" not in capsys.readouterr().out
 
 
 def test_wait_boot_complete_raises_when_metadata_job_exits_without_sentinel(

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -1,12 +1,18 @@
-"""Issue #2242: boot readiness includes pfSense package metadata settlement.
+"""Issue #2458: boot readiness must not treat a not-yet-started metadata job as done.
 
-Owner residual (2026-08-15 02:55): ``pfSense-upgrade -uf`` only publishes
-``/var/run/pfSense_version.rc`` on SUCCESS. A finished-but-failed run leaves the
-metadata job gone and the sentinel never written, so the old ``test -f`` probe
-spun until the full 180s timeout instead of recognising "job exited, no
-sentinel" as metadata FAILURE. The predicate now asks a single probe for one of
-three words (``present``/``running``/``gone``) and returns on either
-``present`` or ``gone`` -- only ``running`` keeps polling.
+Issue #2242 taught ``wait_boot_complete`` that ``pfSense-upgrade -uf`` only
+publishes ``/var/run/pfSense_version.rc`` on SUCCESS, so a finished-but-failed
+run leaves the sentinel absent forever. The fix returned on ``gone`` -- which
+also matches the FIRST probe of a perfectly healthy boot, because
+``is_platform_booting()`` can clear seconds BEFORE ``rc.update_pkg_metadata``
+starts (#2242 measured ABI 15 with no metadata process at 10:16:37Z and ABI 16
+with the job active at 10:17:03Z). Callers then ran ``pkg add`` straight
+through the ABI flip window.
+
+``gone`` is therefore not a verdict on its own: it means "job not started yet"
+until a ``running`` probe has been seen, and "job died without the sentinel"
+after one. The waiter keeps polling in the first case and RAISES in the second;
+only ``present`` is success.
 """
 
 from __future__ import annotations
@@ -49,12 +55,82 @@ def test_wait_boot_complete_waits_for_boot_metadata_sentinel(
     assert "PFB_BOOT_METADATA" not in capsys.readouterr().out
 
 
-def test_wait_boot_complete_returns_when_metadata_job_exits_without_sentinel(
+def test_wait_boot_complete_keeps_polling_when_first_probe_finds_no_metadata_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #2458: ``gone`` on the FIRST probe means rc.update_pkg_metadata has
+    not started yet, not that it finished. The waiter must keep polling, and a
+    job that never appears must end the wait by RAISING, never by returning and
+    letting callers pkg-add through the ABI flip window."""
+    ticks = iter([0.0, 0.0] + [float(n) for n in range(1, 200)])
+
+    def fake_monotonic() -> float:
+        try:
+            return next(ticks)
+        except StopIteration:
+            return 1000.0
+
+    calls: list[tuple[str, ...]] = []
+
+    class FakeVM:
+        def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            calls.append(remote)
+            if remote != _PROBE_ARGV:
+                return subprocess.CompletedProcess(remote, 1, "", "")
+            return subprocess.CompletedProcess(remote, 0, "gone", "")
+
+    monkeypatch.setattr(
+        helpers,
+        "php_eval",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
+    )
+    monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(helpers.time, "monotonic", fake_monotonic)
+
+    with pytest.raises(RuntimeError, match="did not settle"):
+        helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=10, delay=0)
+
+    assert len([c for c in calls if c == _PROBE_ARGV]) >= 2
+
+
+def test_wait_boot_complete_accepts_a_metadata_job_that_starts_late(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Issue #2242 owner residual 02:55: two probes see the job still running,
-    the third sees it gone with no sentinel published -- must return (not
-    time out) and print the one loud metadata-failure line."""
+    """Issue #2458: the #2242 timestamps (absent at 10:16:37Z, active at
+    10:17:03Z) are the NORMAL boot, so ``gone`` then ``running`` then
+    ``present`` must succeed quietly -- a waiter that treats ``gone`` as
+    terminal fails closed on every healthy boot."""
+    probe_words = iter(["gone", "running", "present"])
+    calls: list[tuple[str, ...]] = []
+
+    class FakeVM:
+        def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
+            calls.append(remote)
+            if remote != _PROBE_ARGV:
+                return subprocess.CompletedProcess(remote, 1, "", "")
+            return subprocess.CompletedProcess(remote, 0, next(probe_words), "")
+
+    monkeypatch.setattr(
+        helpers,
+        "php_eval",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, "<<BOOT>>0<<END>>", ""),
+    )
+    monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
+
+    helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=5, delay=0)
+
+    assert [c for c in calls if c == _PROBE_ARGV] == [_PROBE_ARGV] * 3
+    assert "PFB_BOOT_METADATA" not in capsys.readouterr().out
+
+
+def test_wait_boot_complete_raises_when_metadata_job_exits_without_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #2458 (replaces the #2242-era row that pinned the fail-open, which
+    required ``running, running, gone`` to RETURN): once the job has been seen
+    running, ``gone`` with no sentinel is a FAILED metadata refresh. Returning
+    there let ``pkg add`` / the artifact ABI sample / ``shutdown -p`` proceed
+    against a box whose pkg ABI was mid-rewrite, so it must raise."""
     probe_words = ["running", "running", "gone"]
     calls: list[tuple[str, ...]] = []
 
@@ -64,11 +140,6 @@ def test_wait_boot_complete_returns_when_metadata_job_exits_without_sentinel(
 
         def ssh(self, *remote: str, timeout: float = 60.0) -> subprocess.CompletedProcess[str]:
             calls.append(remote)
-            # OLD-shape probe (pre-fix production code) never matches _PROBE_ARGV and
-            # always reports a non-zero rc here, so the pre-fix code cannot return early
-            # (its success test is bare `returncode == 0`) and instead spins to timeout --
-            # the RED failure this fixture proves is "raise on timeout", not a StopIteration
-            # or an argv-mismatch assertion error.
             if remote != _PROBE_ARGV:
                 return subprocess.CompletedProcess(remote, 1, "", "")
             word = probe_words[min(self._n, len(probe_words) - 1)]
@@ -82,14 +153,10 @@ def test_wait_boot_complete_returns_when_metadata_job_exits_without_sentinel(
     )
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
 
-    helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=2, delay=0)
+    with pytest.raises(RuntimeError, match="metadata refresh"):
+        helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=5, delay=0)
 
     assert [c for c in calls if c == _PROBE_ARGV] == [_PROBE_ARGV] * 3
-    printed = capsys.readouterr().out
-    assert (
-        "PFB_BOOT_METADATA sentinel=absent job=gone — pfSense metadata refresh exited without "
-        "publishing /var/run/pfSense_version.rc (metadata FAILED, not still booting; issue #2242)"
-    ) in printed
 
 
 def test_wait_boot_complete_metadata_job_stuck_running_times_out(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

`wait_boot_complete` (tests/smoke/helpers.py) returned as soon as its metadata probe
answered `gone`. The reasoning behind that (issue #2242) was sound but incomplete: an
absent `rc.update_pkg_metadata` process with no `/var/run/pfSense_version.rc` does mean
the refresh failed — but only once the job has actually been seen running.

`is_platform_booting()` can clear before the job starts. Issue #2242 comment 5252000168
measured exactly that:

```
10:16:37Z  ABI 15, metadata process absent
10:17:03Z  ABI 16, rc.update_pkg_metadata / pfSense-upgrade -uf active
```

So on a healthy boot the first probe is very often `gone`, the waiter returned, and
callers — `pkg add`, the image-upgrade ABI sample, `shutdown -p` of the verify VM — ran
straight through the ABI flip window.

## Change

`gone` is now read positionally rather than as a verdict:

| Probe sequence | Behaviour |
| --- | --- |
| `gone` (first probe) | keep polling — the job has not started |
| `gone, gone, …` to the deadline | raise (the existing loud timeout) |
| `gone, running, present` | return — the late start is the normal boot |
| `running, present` | return |
| `running, gone` | **raise** — the job started and died with no sentinel |

`scripts/image-upgrade.sh` had the same gap on the shell side, on two distinct paths.

For the paths that reach `wait_guest_ssh`, the metadata wait now lives inside it:
`pfb_refresh_pkgs` reads `pkg config ABI` / `pkg query` and applies `pkg upgrade`, and
`pfb_boot_artifact_version` samples the artifact's ABI and then powers the verify VM off,
each immediately after that TCP-only probe returns. Putting the gate in the shared waiter
covers all three of those call sites at once.

The OS-upgrade path does **not** reach `wait_guest_ssh` — review round 1 caught this.
After `pfSense-upgrade` reboots the box it polls `cat /etc/version` in its own loop and
breaks the instant the version differs, and `/etc/version` is written by the installer
before `rc.update_pkg_metadata` runs. Everything downstream then reads or writes the pkg
database (the dependency reconcile's `pkg query` / `pkg install` / `pkg delete` /
`pkg info -e`, then the health gate) before powering the disk off for export — and that
disk becomes the published artifact. That poll is now `pfb_wait_upgraded_box`, which keeps
the version check and adds the same gate.

Both use the same three-word probe as the Python side, run under `/bin/sh` because
pfSense's root login shell is tcsh.

Suggestion 3 from the issue (also matching `pkg-static` / `lockf` children) is **not**
implemented: `rc.update_pkg_metadata` and its `pfSense-upgrade` parent outlive their
children, so the existing pattern already covers the whole window those children run in.
Happy to add it if that premise turns out to be wrong.

## Test note — this rewrites a currently-green row

As called out in the issue, `test_wait_boot_complete_returns_when_metadata_job_exits_without_sentinel`
required `running, running, gone` to **return**. That is precisely the behaviour that had
to change, so the row encoded the bug. It is replaced, not dropped:

- `test_wait_boot_complete_raises_when_metadata_job_exits_without_sentinel` — same
  sequence, now asserting the raise.
- `test_wait_boot_complete_keeps_polling_when_first_probe_finds_no_metadata_job` — new;
  `gone` forever must keep polling and end in the timeout raise, never an early return.
- `test_wait_boot_complete_accepts_a_metadata_job_that_starts_late` — new; the #2242
  timestamp sequence `gone, running, present` must succeed quietly, so the fix cannot
  trade a fail-open for a fail-closed on every normal boot.

The replacement set is a superset of what the removed row covered.
`tests/shell/image_upgrade_metadata_wait_spec.sh` pins the same rows on the shell side,
plus the fact that `wait_guest_ssh` waits for metadata at all, that `pfb_wait_upgraded_box`
does too, and that a zero poll interval cannot make the wait unbounded.

## Verification

**Round 1.** Red→green, tests frozen byte-identical across both runs (`git hash-object`
`b52623e4e0f19bc54258e07f7e795280a5538005` and `9eee6b96f80bca977e0ad0b2a52034b2b34f986c`
before and after the production edit):

```
# RED, production reverted
scripts/run-in-docker.sh python3 -m pytest -q tests/test_smoke_boot_metadata_wait.py
  3 failed, 5 passed
scripts/run-in-docker.sh shellspec --shell dash tests/shell/image_upgrade_metadata_wait_spec.sh
  5 examples, 5 failures

# GREEN, same test files
scripts/run-in-docker.sh python3 -m pytest -q tests/test_smoke_boot_metadata_wait.py
  8 passed
scripts/run-in-docker.sh shellspec --shell dash tests/shell/image_upgrade_metadata_wait_spec.sh
  5 examples, 0 failures
```

**Round 2** (the review fixes). The three new shellspec rows executed RED against the
round-1 production code and GREEN after, spec frozen byte-identical across both runs at
`dd860e5830f979d68c3a144e95feaac8e5788d80`:

```
# RED, production at 387d5ea7
scripts/run-in-docker.sh shellspec --shell dash tests/shell/image_upgrade_metadata_wait_spec.sh
  1) … stays bounded when the poll interval is zero
  2) … waits for package metadata after the upgraded box reports its new version
  3) … dies when the upgraded box never reports a new version
  9 examples, 3 failures

# GREEN, same spec file
  9 examples, 0 failures
```

Canonical gates (re-run after every round):

```
scripts/agent/run-gates.sh --diff origin/devel
  GATE PASS: python3 -m pytest
  GATE PASS: ruff check .
  GATE PASS: ruff format --check .
  GATE PASS: mypy tests/
  GATE PASS: sh -n scripts/image-upgrade.sh
  GATE PASS: shellcheck scripts/image-upgrade.sh
  GATE PASS: sh -n tests/shell/image_upgrade_metadata_wait_spec.sh
  GATE PASS: shellspec --shell dash
  GATES: PASS
```

A live leg on a leased box is running to confirm a real pfSense boot still settles through
the new predicate (every smoke VM reaches `wait_boot_complete(vm)` with
`require_pkg_metadata=True` via `tests/smoke/conftest.py`); the result is posted below
before merge.

Part of #2458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-upgrade reliability by waiting for package metadata to finish settling before health checks, verification, and shutdown.
  * Correctly distinguishes delayed metadata startup, successful completion, and failed or timed-out refreshes.
  * Prevents upgrades from proceeding when package metadata never completes or the version does not update.

* **Tests**
  * Added coverage for delayed startup, failed refreshes, timeouts, and upgraded-version detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->