### PR TITLE
smoke: do not require pfb_global() in pin_cron_due

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1184,27 +1184,18 @@ def pin_cron_due(vm: SmokeVM) -> int:
     """
     sentinel_open, sentinel_close = "<<<HOUR>>>", "<<<END>>>"
     snippet = (
-        # issue #2492: pfblockerng.inc FIRST, extra.inc second — the order the working
-        # sibling snippets use (test_schedule_runtime.py:122, test_smoke_tick.py:627).
-        # Loading extra.inc first and pfblockerng.inc second was measured to leave the
-        # guest reporting "A valid config file could not be recovered" (12/12 runs).
-        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        # It is defined
-        # there (pfblockerng.inc:3211) and pfblockerng_extra.inc has no requires at all, so
-        # requiring extra.inc alone left the call fatal under pfSsh.php ("Call to undefined
-        # function pfb_global()"), erroring every test that uses this helper.
-        #
-        # extra.inc is not self-contained: it calls 39 symbols it does not define. On this
-        # path pfb_schedule_runtime_config() reaches pfb_filter()/PFB_FILTER_CSV
-        # (pfblockerng.inc:1672 and :466), short-circuited only while blacklist_selected is
-        # empty. So dropping the pfb_global() call instead would merely move the fatal to
-        # pfb_filter() on any box where a blacklist provider has been selected.
-        #
-        # This matches the sibling snippets that already load it under php_eval:
-        # test_schedule_runtime.py:122, test_smoke_ip_recompute.py:911, helpers.py:4414,
-        # test_smoke_tick.py:627 — including one that calls write_config() afterwards.
-        "pfb_global();\n"
+        # issue #2492: pfb_global() lives in pfblockerng.inc (:3211) and extra.inc requires
+        # nothing, so a bare call is fatal under pfSsh.php and errors every test using this
+        # helper. MEASURED, do not "fix" by requiring pfblockerng.inc here:
+        #   guard (this)                -> 19 passed / 3 failed
+        #   require after extra.inc     -> 12 passed / 13 failed, guest reports
+        #                                  "A valid config file could not be recovered" x12
+        #   require before extra.inc    -> 25 errors, reproduced twice
+        # Nothing below needs $pfb: the only read is schedule_state_dir, which no production
+        # code assigns — every consumer uses the same `?? '/usr/local/etc'` fallback, and
+        # pfblockerng_cron.inc:291 reads exactly where this writes.
+        "if (function_exists('pfb_global')) { pfb_global(); }\n"
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['pfb_reuse'] = '';\n"
         "$g['pfb_scheduled_feed_updates'] = 'on';\n"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1195,6 +1195,8 @@ def pin_cron_due(vm: SmokeVM) -> int:
         # Nothing below needs $pfb: the only read is schedule_state_dir, which no production
         # code assigns — every consumer uses the same `?? '/usr/local/etc'` fallback, and
         # pfblockerng_cron.inc:291 reads exactly where this writes.
+        # Latent (#2495): pfb_schedule_runtime_config() reaches pfb_filter()/
+        # PFB_FILTER_CSV (pfblockerng.inc-only) once blacklist_selected is populated.
         "if (function_exists('pfb_global')) { pfb_global(); }\n"
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['pfb_reuse'] = '';\n"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1184,8 +1184,13 @@ def pin_cron_due(vm: SmokeVM) -> int:
     """
     sentinel_open, sentinel_close = "<<<HOUR>>>", "<<<END>>>"
     snippet = (
+        # issue #2492: pfblockerng.inc FIRST, extra.inc second — the order the working
+        # sibling snippets use (test_schedule_runtime.py:122, test_smoke_tick.py:627).
+        # Loading extra.inc first and pfblockerng.inc second was measured to leave the
+        # guest reporting "A valid config file could not be recovered" (12/12 runs).
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        # issue #2492: load pfblockerng.inc BEFORE calling pfb_global(). It is defined
+        # It is defined
         # there (pfblockerng.inc:3211) and pfblockerng_extra.inc has no requires at all, so
         # requiring extra.inc alone left the call fatal under pfSsh.php ("Call to undefined
         # function pfb_global()"), erroring every test that uses this helper.
@@ -1199,7 +1204,6 @@ def pin_cron_due(vm: SmokeVM) -> int:
         # This matches the sibling snippets that already load it under php_eval:
         # test_schedule_runtime.py:122, test_smoke_ip_recompute.py:911, helpers.py:4414,
         # test_smoke_tick.py:627 — including one that calls write_config() afterwards.
-        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
         "pfb_global();\n"
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['pfb_reuse'] = '';\n"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1185,18 +1185,11 @@ def pin_cron_due(vm: SmokeVM) -> int:
     sentinel_open, sentinel_close = "<<<HOUR>>>", "<<<END>>>"
     snippet = (
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        # issue #2492: pfb_global() lives in pfblockerng.inc (:3211) and extra.inc requires
-        # nothing, so a bare call is fatal under pfSsh.php and errors every test using this
-        # helper. MEASURED, do not "fix" by requiring pfblockerng.inc here:
-        #   guard (this)                -> 19 passed / 3 failed
-        #   require after extra.inc     -> 12 passed / 13 failed, guest reports
-        #                                  "A valid config file could not be recovered" x12
-        #   require before extra.inc    -> 25 errors, reproduced twice
-        # Nothing below needs $pfb: the only read is schedule_state_dir, which no production
-        # code assigns — every consumer uses the same `?? '/usr/local/etc'` fallback, and
-        # pfblockerng_cron.inc:291 reads exactly where this writes.
-        # Latent (#2495): pfb_schedule_runtime_config() reaches pfb_filter()/
-        # PFB_FILTER_CSV (pfblockerng.inc-only) once blacklist_selected is populated.
+        # issue #2492: pfb_global() lives in pfblockerng.inc, which extra.inc does not
+        # require, so a bare call is fatal here. Guard rather than requiring
+        # pfblockerng.inc: that was measured to break the loaded config (see #2492).
+        # Nothing below needs $pfb — schedule_state_dir has no assigner and every
+        # consumer shares the `?? '/usr/local/etc'` fallback used below.
         "if (function_exists('pfb_global')) { pfb_global(); }\n"
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['pfb_reuse'] = '';\n"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1185,7 +1185,14 @@ def pin_cron_due(vm: SmokeVM) -> int:
     sentinel_open, sentinel_close = "<<<HOUR>>>", "<<<END>>>"
     snippet = (
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        "pfb_global();\n"
+        # issue #2492: pfb_global() lives in pfblockerng.inc, which extra.inc does NOT
+        # require, so under pfSsh.php eval the bare call is fatal ("Call to undefined
+        # function pfb_global()"). Do NOT fix that by requiring pfblockerng.inc here:
+        # measured, it removes the fatal but breaks the already-loaded, locked config
+        # ("A valid config file could not be recovered"), which is the eval-scope gotcha
+        # in docs/misc/local-smoke-debian.md. The call is not needed — it only populates
+        # $pfb, and the sole use below already falls back to /usr/local/etc.
+        "if (function_exists('pfb_global')) { pfb_global(); }\n"
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['pfb_reuse'] = '';\n"
         "$g['pfb_scheduled_feed_updates'] = 'on';\n"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1185,14 +1185,22 @@ def pin_cron_due(vm: SmokeVM) -> int:
     sentinel_open, sentinel_close = "<<<HOUR>>>", "<<<END>>>"
     snippet = (
         "require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');\n"
-        # issue #2492: pfb_global() lives in pfblockerng.inc, which extra.inc does NOT
-        # require, so under pfSsh.php eval the bare call is fatal ("Call to undefined
-        # function pfb_global()"). Do NOT fix that by requiring pfblockerng.inc here:
-        # measured, it removes the fatal but breaks the already-loaded, locked config
-        # ("A valid config file could not be recovered"), which is the eval-scope gotcha
-        # in docs/misc/local-smoke-debian.md. The call is not needed — it only populates
-        # $pfb, and the sole use below already falls back to /usr/local/etc.
-        "if (function_exists('pfb_global')) { pfb_global(); }\n"
+        # issue #2492: load pfblockerng.inc BEFORE calling pfb_global(). It is defined
+        # there (pfblockerng.inc:3211) and pfblockerng_extra.inc has no requires at all, so
+        # requiring extra.inc alone left the call fatal under pfSsh.php ("Call to undefined
+        # function pfb_global()"), erroring every test that uses this helper.
+        #
+        # extra.inc is not self-contained: it calls 39 symbols it does not define. On this
+        # path pfb_schedule_runtime_config() reaches pfb_filter()/PFB_FILTER_CSV
+        # (pfblockerng.inc:1672 and :466), short-circuited only while blacklist_selected is
+        # empty. So dropping the pfb_global() call instead would merely move the fatal to
+        # pfb_filter() on any box where a blacklist provider has been selected.
+        #
+        # This matches the sibling snippets that already load it under php_eval:
+        # test_schedule_runtime.py:122, test_smoke_ip_recompute.py:911, helpers.py:4414,
+        # test_smoke_tick.py:627 — including one that calls write_config() afterwards.
+        "require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');\n"
+        "pfb_global();\n"
         f"$g = config_get_path({_php_str(CFG_GLOBAL)}, array());\n"
         "$g['pfb_reuse'] = '';\n"
         "$g['pfb_scheduled_feed_updates'] = 'on';\n"

--- a/tests/smoke/test_log_age_retention.py
+++ b/tests/smoke/test_log_age_retention.py
@@ -50,6 +50,9 @@ PFB_LOGDIR = "/var/log/pfblockerng"
 PFB_DBDIR = "/var/db/pfblockerng"
 
 _PFB_EXTRA_INC = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
+# issue #2492: extra.inc has no requires of its own, so anything calling pfb_global()
+# (defined in pfblockerng.inc:3211) must load this too.
+_PFB_MAIN_INC = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
 
 # Host-side (non-chrooted) PHP-written CSV log; timestamp at CSV field 0.
 LOG_IP_BLOCKLOG = f"{PFB_LOGDIR}/ip_block.log"
@@ -129,6 +132,10 @@ def _prime_idle_schedule(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     """Publish completed schedule state and a matching future runtime cache."""
     snippet = (
         f"require_once('{_PFB_EXTRA_INC}');"
+        # issue #2492: pfb_global() lives in pfblockerng.inc and extra.inc requires
+        # nothing, so without this the call is fatal under pfSsh.php and errors every
+        # test in this module at fixture setup.
+        f"require_once('{_PFB_MAIN_INC}');"
         "pfb_global();"
         "$now = time();"
         "$state_dir = $pfb['schedule_state_dir'] ?? '/usr/local/etc';"

--- a/tests/smoke/test_log_age_retention.py
+++ b/tests/smoke/test_log_age_retention.py
@@ -132,6 +132,8 @@ def _prime_idle_schedule(vm: SmokeVM, *, timeout: float = 60.0) -> None:
         # issue #2492: guard, do not require pfblockerng.inc — see the measured
         # comparison at helpers.py pin_cron_due. Nothing here needs $pfb beyond
         # schedule_state_dir, which uses the same production fallback below.
+        # Latent (#2495): pfb_schedule_runtime_config() reaches pfb_filter()/
+        # PFB_FILTER_CSV (pfblockerng.inc-only) once blacklist_selected is populated.
         "if (function_exists('pfb_global')) { pfb_global(); }"
         "$now = time();"
         "$state_dir = $pfb['schedule_state_dir'] ?? '/usr/local/etc';"

--- a/tests/smoke/test_log_age_retention.py
+++ b/tests/smoke/test_log_age_retention.py
@@ -50,9 +50,6 @@ PFB_LOGDIR = "/var/log/pfblockerng"
 PFB_DBDIR = "/var/db/pfblockerng"
 
 _PFB_EXTRA_INC = "/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
-# issue #2492: extra.inc has no requires of its own, so anything calling pfb_global()
-# (defined in pfblockerng.inc:3211) must load this too.
-_PFB_MAIN_INC = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
 
 # Host-side (non-chrooted) PHP-written CSV log; timestamp at CSV field 0.
 LOG_IP_BLOCKLOG = f"{PFB_LOGDIR}/ip_block.log"
@@ -132,11 +129,10 @@ def _prime_idle_schedule(vm: SmokeVM, *, timeout: float = 60.0) -> None:
     """Publish completed schedule state and a matching future runtime cache."""
     snippet = (
         f"require_once('{_PFB_EXTRA_INC}');"
-        # issue #2492: pfb_global() lives in pfblockerng.inc and extra.inc requires
-        # nothing, so without this the call is fatal under pfSsh.php and errors every
-        # test in this module at fixture setup.
-        f"require_once('{_PFB_MAIN_INC}');"
-        "pfb_global();"
+        # issue #2492: guard, do not require pfblockerng.inc — see the measured
+        # comparison at helpers.py pin_cron_due. Nothing here needs $pfb beyond
+        # schedule_state_dir, which uses the same production fallback below.
+        "if (function_exists('pfb_global')) { pfb_global(); }"
         "$now = time();"
         "$state_dir = $pfb['schedule_state_dir'] ?? '/usr/local/etc';"
         "$model = pfb_schedule_runtime_config();"

--- a/tests/test_smoke_pfb_global_requires.py
+++ b/tests/test_smoke_pfb_global_requires.py
@@ -34,13 +34,12 @@ the file. Both remedies satisfy the invariant pinned here.
 
 from __future__ import annotations
 
+import importlib
 import re
 import subprocess
 from pathlib import Path
 
 import pytest
-
-from tests.smoke import helpers
 
 _SMOKE_DIR = Path(__file__).resolve().parents[1] / "tests" / "smoke"
 _GUARD = "function_exists('pfb_global')"
@@ -64,6 +63,16 @@ _MAIN_CONST = re.compile(r"""(?m)^\s*\w+\s*=\s*["'][^"']*/pfblockerng\.inc["']""
 _WINDOW = 8000
 
 
+def _live_helpers():  # -> module
+    # Resolve at CALL time, never at import time: tests/test_adr47_conftest_lane.py
+    # deliberately EVICTS tests.smoke.helpers from sys.modules and re-imports it (to
+    # test import-time env reads), orphaning any module-level binding taken during
+    # collection. A patch applied to the orphan is invisible to code holding the new
+    # instance — observed as this file passing standalone and failing in the full
+    # suite with the REAL php_eval running ('object' has no attribute 'ssh_argv').
+    return importlib.import_module("tests.smoke.helpers")
+
+
 def _capture_emitted_snippet(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     seen: list[str] = []
 
@@ -75,7 +84,7 @@ def _capture_emitted_snippet(monkeypatch: pytest.MonkeyPatch) -> list[str]:
         # changes, the helper raises and this row fails LOUD (re-shape the fake then).
         return subprocess.CompletedProcess([], 0, "OK<<<HOUR>>>7<<<END>>>", "")
 
-    monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
+    monkeypatch.setattr(_live_helpers(), "php_eval", fake_php_eval)
     return seen
 
 
@@ -95,7 +104,7 @@ def _assert_snippet_safe(snippet: str, *, origin: str) -> None:
 
 def test_pin_cron_due_emits_safe_php(monkeypatch: pytest.MonkeyPatch) -> None:
     seen = _capture_emitted_snippet(monkeypatch)
-    assert helpers.pin_cron_due(object()) == 7  # type: ignore[arg-type]
+    assert _live_helpers().pin_cron_due(object()) == 7  # type: ignore[arg-type]
     assert len(seen) == 1, f"expected exactly one php_eval, got {len(seen)}"
     _assert_snippet_safe(seen[0], origin="pin_cron_due")
 
@@ -104,7 +113,11 @@ def test_prime_idle_schedule_emits_safe_php(monkeypatch: pytest.MonkeyPatch) -> 
     # The second historical site (its module fixture errored every test in the file).
     # Imported here, not exercised via the live suite, precisely so scope=impacted
     # cannot skip it.
-    from tests.smoke import test_log_age_retention as tlar
+    tlar = importlib.import_module("tests.smoke.test_log_age_retention")
+    if getattr(tlar, "h", None) is not _live_helpers():
+        # tlar's `h` is a stale instance from before an eviction — re-import so the
+        # helper under test calls the same module object the patch lands on.
+        tlar = importlib.reload(tlar)
 
     seen = _capture_emitted_snippet(monkeypatch)
     tlar._prime_idle_schedule(object())  # type: ignore[arg-type]

--- a/tests/test_smoke_pfb_global_requires.py
+++ b/tests/test_smoke_pfb_global_requires.py
@@ -15,13 +15,15 @@ Coverage here is TWO-TIER, honestly labelled:
 
 * **Executable rows** for the two historical sites — ``pin_cron_due`` and
   ``_prime_idle_schedule`` — run the real helper against a monkeypatched ``php_eval``
-  and assert the emitted PHP. These are the real guard; both are mutation-verified.
+  and assert the emitted PHP. These are the primary tier; both are mutation-verified.
+  (Their snippet checks are substring-based too, so the evasions below apply to both
+  tiers — "executable" means exercising the real helper, not parsing PHP.)
 * **A source sweep** over ``tests/smoke/`` as a tripwire for NEW call sites. It is
   per-occurrence (a call must have a guard or a require in the PRECEDING window, so a
   later snippet's require cannot excuse an earlier bare call), but it reads Python
   source, not emitted PHP — string concatenation, negated guards
   (``!function_exists``), or exotic call shapes can evade it. It is a tripwire, not a
-  proof; the executable rows are the proof for the sites that have burned us.
+  proof; the executable rows are the stronger tier for the sites that have burned us.
 
 Which remedy is correct per snippet is EMPIRICAL, not stylistic: for ``pin_cron_due``
 the require was measured worse than the guard (19 passed/3 failed guarded; 12/13 with

--- a/tests/test_smoke_pfb_global_requires.py
+++ b/tests/test_smoke_pfb_global_requires.py
@@ -7,22 +7,27 @@ requires only extra.inc and then calls ``pfb_global()`` is fatal under ``pfSsh.p
     PHP ERROR: Uncaught Error: Call to undefined function pfb_global()
 
 That errored every smoke test using ``pin_cron_due()`` (24 occurrences in one full run)
-and every test in ``test_log_age_retention.py`` at fixture setup.
+and every test in ``test_log_age_retention.py`` at fixture setup. The defect has been
+introduced TWICE (most recently by ``074b359c``), and smoke dispatch defaults to
+``scope=impacted``, so a re-introduction can land without any leg that exercises it.
 
-A snippet is SAFE if either holds:
+Coverage here is TWO-TIER, honestly labelled:
 
-* it requires ``pfblockerng.inc`` (so the symbol exists), or
-* it guards the call with ``function_exists('pfb_global')``.
+* **Executable rows** for the two historical sites — ``pin_cron_due`` and
+  ``_prime_idle_schedule`` — run the real helper against a monkeypatched ``php_eval``
+  and assert the emitted PHP. These are the real guard; both are mutation-verified.
+* **A source sweep** over ``tests/smoke/`` as a tripwire for NEW call sites. It is
+  per-occurrence (a call must have a guard or a require in the PRECEDING window, so a
+  later snippet's require cannot excuse an earlier bare call), but it reads Python
+  source, not emitted PHP — string concatenation, negated guards
+  (``!function_exists``), or exotic call shapes can evade it. It is a tripwire, not a
+  proof; the executable rows are the proof for the sites that have burned us.
 
-Both are accepted deliberately. Which one is correct for a given snippet is an empirical
-question, not a stylistic one — for ``pin_cron_due`` the require was measured WORSE than
-the guard (19 passed/3 failed guarded, versus 12/13 with the require after extra.inc and
-25 errors with it before), so that call site guards. Other snippets legitimately require
-it. This row pins only the invariant both satisfy.
-
-Pinned hermetically because the defect has been introduced TWICE (most recently by
-``074b359c``) and smoke dispatch defaults to ``scope=impacted``, so a re-introduction can
-land without any leg that exercises it.
+Which remedy is correct per snippet is EMPIRICAL, not stylistic: for ``pin_cron_due``
+the require was measured worse than the guard (19 passed/3 failed guarded; 12/13 with
+the require after extra.inc — guest reporting "A valid config file could not be
+recovered" x12; 25 errors, twice, with it before). Other snippets legitimately require
+the file. Both remedies satisfy the invariant pinned here.
 """
 
 from __future__ import annotations
@@ -35,53 +40,109 @@ import pytest
 
 from tests.smoke import helpers
 
-_MAIN_INC = "pfblockerng.inc"
-_GUARD = "function_exists('pfb_global')"
 _SMOKE_DIR = Path(__file__).resolve().parents[1] / "tests" / "smoke"
+_GUARD = "function_exists('pfb_global')"
 
-# A call that is NOT preceded on the same line by the function_exists guard.
-_UNGUARDED_CALL = re.compile(r"(?<!function_exists\('pfb_global'\)\) \{ )pfb_global\(\);")
+# A call-shaped occurrence in source: pfb_global ( ) ;  with optional spacing.
+_CALL = re.compile(r"pfb_global\s*\(\s*\)\s*;")
+
+# A require/include whose target is the MAIN inc. Deliberately does NOT match
+# pfblockerng_extra.inc (the dot must follow "pfblockerng"), and does not match prose
+# mentions in comments/docstrings ("do not require pfblockerng.inc" has no require-().
+_REQUIRE_MAIN = re.compile(r"require(?:_once)?\s*\([^)\n]{0,200}pfblockerng\.inc")
+
+# A Python constant holding the main-inc path (e.g. _PFB_INC = ".../pfblockerng.inc").
+# Checked file-wide: a file that defines such a constant is requiring the file through
+# it. Weaker than the windowed require check; accepted as tripwire slack.
+_MAIN_CONST = re.compile(r"""(?m)^\s*\w+\s*=\s*["'][^"']*/pfblockerng\.inc["']""")
+
+# How far back (in characters) a require/guard may sit from the call it licenses.
+# Sized for the worst legitimate case in-tree: test_schedule_runtime.py keeps one
+# r-string snippet whose require sits ~80 lines above its second call.
+_WINDOW = 8000
 
 
-def test_pin_cron_due_does_not_call_pfb_global_unguarded(monkeypatch: pytest.MonkeyPatch) -> None:
-    """pin_cron_due's emitted PHP must not call pfb_global() without a guard or the require."""
+def _capture_emitted_snippet(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     seen: list[str] = []
 
     def fake_php_eval(_vm: object, snippet: str, **_kw: object) -> subprocess.CompletedProcess[str]:
         seen.append(snippet)
+        # Shaped to satisfy each helper's own success check: pin_cron_due parses the
+        # sentinel pair; _prime_idle_schedule only wants "OK" in stdout. The literals
+        # duplicate pin_cron_due's local sentinels on purpose — if that protocol
+        # changes, the helper raises and this row fails LOUD (re-shape the fake then).
         return subprocess.CompletedProcess([], 0, "OK<<<HOUR>>>7<<<END>>>", "")
 
     monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
+    return seen
 
+
+def _assert_snippet_safe(snippet: str, *, origin: str) -> None:
+    """The emitted PHP must load the symbol or guard the call — checked on the SNIPPET,
+    so a require elsewhere in the same file cannot excuse it (each php_eval is a fresh
+    PHP process; nothing carries over between snippets)."""
+    assert "pfb_global" in snippet, f"{origin}: row is vacuous if the call vanished — rewrite it"
+    if _REQUIRE_MAIN.search(snippet):
+        return
+    assert _GUARD in snippet, (
+        f"{origin} calls pfb_global() with neither a require of pfblockerng.inc nor a "
+        f"function_exists guard; under pfSsh.php that is 'Call to undefined function "
+        f"pfb_global()' (issue #2492)"
+    )
+
+
+def test_pin_cron_due_emits_safe_php(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _capture_emitted_snippet(monkeypatch)
     assert helpers.pin_cron_due(object()) == 7  # type: ignore[arg-type]
     assert len(seen) == 1, f"expected exactly one php_eval, got {len(seen)}"
-    snippet = seen[0]
+    _assert_snippet_safe(seen[0], origin="pin_cron_due")
 
-    assert "pfb_global" in snippet, "row is vacuous if the call vanished entirely — rewrite it"
-    if _MAIN_INC in snippet:
-        return  # symbol is loaded; safe
-    assert _GUARD in snippet, (
-        "pin_cron_due calls pfb_global() with neither a require of pfblockerng.inc nor a "
-        "function_exists guard; under pfSsh.php that is 'Call to undefined function "
-        "pfb_global()' (issue #2492)"
-    )
-    assert not _UNGUARDED_CALL.search(snippet), "a second, unguarded pfb_global() call slipped in"
+
+def test_prime_idle_schedule_emits_safe_php(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The second historical site (its module fixture errored every test in the file).
+    # Imported here, not exercised via the live suite, precisely so scope=impacted
+    # cannot skip it.
+    from tests.smoke import test_log_age_retention as tlar
+
+    seen = _capture_emitted_snippet(monkeypatch)
+    tlar._prime_idle_schedule(object())  # type: ignore[arg-type]
+    assert len(seen) == 1, f"expected exactly one php_eval, got {len(seen)}"
+    _assert_snippet_safe(seen[0], origin="_prime_idle_schedule")
+
+
+def _swept_sources() -> list[Path]:
+    # Collection-time filter instead of pytest.skip: the #2359 skip-allowlist gate
+    # fails ANY skip not in tests/skip-allowlist.txt, so a skip-per-uninvolved-file
+    # design (107 of them) reds the main CI job outright.
+    out = []
+    for p in sorted(_SMOKE_DIR.rglob("*.py")):
+        if p.name == "__init__.py":
+            continue
+        if _CALL.search(p.read_text(encoding="utf-8")):
+            out.append(p)
+    return out
 
 
 @pytest.mark.parametrize(
     "source",
-    sorted(p for p in _SMOKE_DIR.rglob("*.py") if p.name != "__init__.py"),
-    ids=lambda p: p.name,
+    _swept_sources(),
+    ids=lambda p: p.relative_to(_SMOKE_DIR).as_posix(),
 )
-def test_no_smoke_source_calls_pfb_global_unguarded(source: Path) -> None:
-    """Sweep every smoke source, so a third call site is caught here, not by a red suite."""
+def test_no_new_bare_pfb_global_call_site(source: Path) -> None:
+    """Tripwire: every call-shaped pfb_global(); must have a guard or a main-inc
+    require in the text WINDOW preceding it (or the file defines a main-inc path
+    constant). Preceding-only is deliberate: a require in a LATER snippet cannot
+    license an earlier call, and comment prose matches neither pattern."""
     text = source.read_text(encoding="utf-8")
-    if "pfb_global" not in text:
-        pytest.skip("does not mention pfb_global")
-    if _MAIN_INC in text or _GUARD in text:
-        return  # loads the symbol, or guards the call
-    assert not _UNGUARDED_CALL.search(text), (
-        f"{source.name} calls pfb_global() with neither a require of {_MAIN_INC} nor a "
-        f"function_exists guard. pfblockerng_extra.inc defines neither pfb_global() nor "
-        f"any require, so the call is fatal under pfSsh.php (issue #2492)."
-    )
+    file_has_const = bool(_MAIN_CONST.search(text))
+    for m in _CALL.finditer(text):
+        window = text[max(0, m.start() - _WINDOW) : m.start()]
+        if _GUARD in window or _REQUIRE_MAIN.search(window) or file_has_const:
+            continue
+        line = text.count("\n", 0, m.start()) + 1
+        raise AssertionError(
+            f"{source.relative_to(_SMOKE_DIR).as_posix()}:{line} calls pfb_global() with "
+            f"no function_exists guard and no require of pfblockerng.inc in the preceding "
+            f"{_WINDOW} chars. pfblockerng_extra.inc defines neither the symbol nor any "
+            f"require, so this is fatal under pfSsh.php (issue #2492)."
+        )

--- a/tests/test_smoke_pfb_global_requires.py
+++ b/tests/test_smoke_pfb_global_requires.py
@@ -1,0 +1,82 @@
+"""Issue #2492: a snippet calling ``pfb_global()`` must load ``pfblockerng.inc``.
+
+``pfb_global()`` is defined in ``src/usr/local/pkg/pfblockerng/pfblockerng.inc``
+(:3211). ``pfblockerng_extra.inc`` contains no ``require``/``include`` at all, so a
+snippet that requires only extra.inc and then calls ``pfb_global()`` is fatal under
+``pfSsh.php``::
+
+    PHP ERROR: Uncaught Error: Call to undefined function pfb_global()
+
+That errored every smoke test using ``pin_cron_due()`` (24 occurrences in one full
+run) and every test in ``test_log_age_retention.py`` at fixture setup.
+
+This defect has been introduced TWICE (most recently by ``074b359c``), which is why
+it is pinned here rather than left to the live suite: smoke dispatch defaults to
+``scope=impacted``, so a re-introduction can land without any leg that exercises it.
+
+The rows below assert the emitted PHP, hermetically — no VM, no box.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.smoke import helpers
+
+_MAIN_INC = "pfblockerng.inc"
+_SMOKE_DIR = Path(__file__).resolve().parents[1] / "tests" / "smoke"
+
+
+def _capture_snippet(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every snippet handed to ``php_eval`` instead of running it."""
+    seen: list[str] = []
+
+    def fake_php_eval(_vm: object, snippet: str, **_kw: object) -> subprocess.CompletedProcess[str]:
+        seen.append(snippet)
+        # Enough stdout for pin_cron_due's own success check to pass.
+        return subprocess.CompletedProcess([], 0, "OK<<<HOUR>>>7<<<END>>>", "")
+
+    monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
+    return seen
+
+
+def test_pin_cron_due_loads_pfb_global_home_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pin_cron_due must require pfblockerng.inc before calling pfb_global()."""
+    seen = _capture_snippet(monkeypatch)
+
+    assert helpers.pin_cron_due(object()) == 7  # type: ignore[arg-type]
+
+    assert len(seen) == 1, f"expected exactly one php_eval, got {len(seen)}"
+    snippet = seen[0]
+    assert "pfb_global();" in snippet, "row is vacuous if the call was removed — rewrite it"
+    call_at = snippet.index("pfb_global();")
+    require_at = snippet.find(f"require_once('/usr/local/pkg/pfblockerng/{_MAIN_INC}')")
+    assert require_at != -1, (
+        f"pin_cron_due calls pfb_global() without requiring {_MAIN_INC}; "
+        "under pfSsh.php that is 'Call to undefined function pfb_global()' (issue #2492)"
+    )
+    assert require_at < call_at, f"{_MAIN_INC} must be required BEFORE pfb_global() is called"
+
+
+@pytest.mark.parametrize(
+    "source",
+    sorted(p for p in _SMOKE_DIR.rglob("*.py") if p.name != "__init__.py"),
+    ids=lambda p: p.name,
+)
+def test_no_smoke_snippet_calls_pfb_global_without_its_home_file(source: Path) -> None:
+    """No smoke module may call pfb_global() unless it also loads pfblockerng.inc.
+
+    Sweeps every smoke source rather than the two known sites, so a third call site
+    added later is caught by this row instead of by a red suite.
+    """
+    text = source.read_text(encoding="utf-8")
+    if "pfb_global();" not in text:
+        pytest.skip("does not call pfb_global()")
+    assert _MAIN_INC in text, (
+        f"{source.name} calls pfb_global() but never references {_MAIN_INC}. "
+        f"pfblockerng_extra.inc defines neither pfb_global() nor any require, so the "
+        f"call is fatal under pfSsh.php (issue #2492)."
+    )

--- a/tests/test_smoke_pfb_global_requires.py
+++ b/tests/test_smoke_pfb_global_requires.py
@@ -6,30 +6,24 @@ requires only extra.inc and then calls ``pfb_global()`` is fatal under ``pfSsh.p
 
     PHP ERROR: Uncaught Error: Call to undefined function pfb_global()
 
-That errored every smoke test using ``pin_cron_due()`` (24 occurrences in one full run)
-and every test in ``test_log_age_retention.py`` at fixture setup. The defect has been
-introduced TWICE (most recently by ``074b359c``), and smoke dispatch defaults to
-``scope=impacted``, so a re-introduction can land without any leg that exercises it.
+Without it, every smoke test using ``pin_cron_due()`` and every test in
+``test_log_age_retention.py`` errors at fixture setup. The defect has been introduced
+twice, and smoke dispatch defaults to ``scope=impacted``, so a re-introduction can land
+without any leg that exercises it — hence a hermetic pin here.
 
-Coverage here is TWO-TIER, honestly labelled:
+A snippet is SAFE if it requires ``pfblockerng.inc`` OR guards the call with
+``function_exists``. Both are accepted: which one suits a given snippet is an empirical
+question (for ``pin_cron_due`` the require was measured to break the loaded config — see
+issue #2492), not a stylistic one.
 
-* **Executable rows** for the two historical sites — ``pin_cron_due`` and
-  ``_prime_idle_schedule`` — run the real helper against a monkeypatched ``php_eval``
-  and assert the emitted PHP. These are the primary tier; both are mutation-verified.
-  (Their snippet checks are substring-based too, so the evasions below apply to both
-  tiers — "executable" means exercising the real helper, not parsing PHP.)
+Coverage is two-tier:
+
+* **Executable rows** for the two known sites run the real helper against a
+  monkeypatched ``php_eval`` and assert the emitted PHP.
 * **A source sweep** over ``tests/smoke/`` as a tripwire for NEW call sites. It is
-  per-occurrence (a call must have a guard or a require in the PRECEDING window, so a
-  later snippet's require cannot excuse an earlier bare call), but it reads Python
-  source, not emitted PHP — string concatenation, negated guards
-  (``!function_exists``), or exotic call shapes can evade it. It is a tripwire, not a
-  proof; the executable rows are the stronger tier for the sites that have burned us.
-
-Which remedy is correct per snippet is EMPIRICAL, not stylistic: for ``pin_cron_due``
-the require was measured worse than the guard (19 passed/3 failed guarded; 12/13 with
-the require after extra.inc — guest reporting "A valid config file could not be
-recovered" x12; 25 errors, twice, with it before). Other snippets legitimately require
-the file. Both remedies satisfy the invariant pinned here.
+  per-occurrence (a require in a LATER snippet cannot excuse an earlier bare call), but
+  it reads Python source, not emitted PHP: string concatenation, negated guards, or
+  exotic call shapes evade it. Tripwire, not proof.
 """
 
 from __future__ import annotations
@@ -136,6 +130,15 @@ def _swept_sources() -> list[Path]:
             continue
         if _CALL.search(p.read_text(encoding="utf-8")):
             out.append(p)
+    if not out:
+        # An empty parametrize list would emit a skip, which the #2359 allowlist gate
+        # then fails as an unallowlisted skip — a confusing way to learn the sweep
+        # covers nothing. Fail collection with the actual reason instead.
+        raise RuntimeError(
+            "pfb_global() sweep matched no files under tests/smoke — either every call "
+            "site was removed (delete this sweep) or _CALL no longer matches the call "
+            "shape (fix the pattern). Refusing to report vacuous coverage."
+        )
     return out
 
 

--- a/tests/test_smoke_pfb_global_requires.py
+++ b/tests/test_smoke_pfb_global_requires.py
@@ -1,24 +1,33 @@
-"""Issue #2492: a snippet calling ``pfb_global()`` must load ``pfblockerng.inc``.
+"""Issue #2492: never call ``pfb_global()`` unguarded without loading its home file.
 
-``pfb_global()`` is defined in ``src/usr/local/pkg/pfblockerng/pfblockerng.inc``
-(:3211). ``pfblockerng_extra.inc`` contains no ``require``/``include`` at all, so a
-snippet that requires only extra.inc and then calls ``pfb_global()`` is fatal under
-``pfSsh.php``::
+``pfb_global()`` is defined in ``src/usr/local/pkg/pfblockerng/pfblockerng.inc`` (:3211).
+``pfblockerng_extra.inc`` contains no ``require``/``include`` at all, so a snippet that
+requires only extra.inc and then calls ``pfb_global()`` is fatal under ``pfSsh.php``::
 
     PHP ERROR: Uncaught Error: Call to undefined function pfb_global()
 
-That errored every smoke test using ``pin_cron_due()`` (24 occurrences in one full
-run) and every test in ``test_log_age_retention.py`` at fixture setup.
+That errored every smoke test using ``pin_cron_due()`` (24 occurrences in one full run)
+and every test in ``test_log_age_retention.py`` at fixture setup.
 
-This defect has been introduced TWICE (most recently by ``074b359c``), which is why
-it is pinned here rather than left to the live suite: smoke dispatch defaults to
-``scope=impacted``, so a re-introduction can land without any leg that exercises it.
+A snippet is SAFE if either holds:
 
-The rows below assert the emitted PHP, hermetically — no VM, no box.
+* it requires ``pfblockerng.inc`` (so the symbol exists), or
+* it guards the call with ``function_exists('pfb_global')``.
+
+Both are accepted deliberately. Which one is correct for a given snippet is an empirical
+question, not a stylistic one — for ``pin_cron_due`` the require was measured WORSE than
+the guard (19 passed/3 failed guarded, versus 12/13 with the require after extra.inc and
+25 errors with it before), so that call site guards. Other snippets legitimately require
+it. This row pins only the invariant both satisfy.
+
+Pinned hermetically because the defect has been introduced TWICE (most recently by
+``074b359c``) and smoke dispatch defaults to ``scope=impacted``, so a re-introduction can
+land without any leg that exercises it.
 """
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -27,38 +36,36 @@ import pytest
 from tests.smoke import helpers
 
 _MAIN_INC = "pfblockerng.inc"
+_GUARD = "function_exists('pfb_global')"
 _SMOKE_DIR = Path(__file__).resolve().parents[1] / "tests" / "smoke"
 
+# A call that is NOT preceded on the same line by the function_exists guard.
+_UNGUARDED_CALL = re.compile(r"(?<!function_exists\('pfb_global'\)\) \{ )pfb_global\(\);")
 
-def _capture_snippet(monkeypatch: pytest.MonkeyPatch) -> list[str]:
-    """Record every snippet handed to ``php_eval`` instead of running it."""
+
+def test_pin_cron_due_does_not_call_pfb_global_unguarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pin_cron_due's emitted PHP must not call pfb_global() without a guard or the require."""
     seen: list[str] = []
 
     def fake_php_eval(_vm: object, snippet: str, **_kw: object) -> subprocess.CompletedProcess[str]:
         seen.append(snippet)
-        # Enough stdout for pin_cron_due's own success check to pass.
         return subprocess.CompletedProcess([], 0, "OK<<<HOUR>>>7<<<END>>>", "")
 
     monkeypatch.setattr(helpers, "php_eval", fake_php_eval)
-    return seen
-
-
-def test_pin_cron_due_loads_pfb_global_home_file(monkeypatch: pytest.MonkeyPatch) -> None:
-    """pin_cron_due must require pfblockerng.inc before calling pfb_global()."""
-    seen = _capture_snippet(monkeypatch)
 
     assert helpers.pin_cron_due(object()) == 7  # type: ignore[arg-type]
-
     assert len(seen) == 1, f"expected exactly one php_eval, got {len(seen)}"
     snippet = seen[0]
-    assert "pfb_global();" in snippet, "row is vacuous if the call was removed — rewrite it"
-    call_at = snippet.index("pfb_global();")
-    require_at = snippet.find(f"require_once('/usr/local/pkg/pfblockerng/{_MAIN_INC}')")
-    assert require_at != -1, (
-        f"pin_cron_due calls pfb_global() without requiring {_MAIN_INC}; "
-        "under pfSsh.php that is 'Call to undefined function pfb_global()' (issue #2492)"
+
+    assert "pfb_global" in snippet, "row is vacuous if the call vanished entirely — rewrite it"
+    if _MAIN_INC in snippet:
+        return  # symbol is loaded; safe
+    assert _GUARD in snippet, (
+        "pin_cron_due calls pfb_global() with neither a require of pfblockerng.inc nor a "
+        "function_exists guard; under pfSsh.php that is 'Call to undefined function "
+        "pfb_global()' (issue #2492)"
     )
-    assert require_at < call_at, f"{_MAIN_INC} must be required BEFORE pfb_global() is called"
+    assert not _UNGUARDED_CALL.search(snippet), "a second, unguarded pfb_global() call slipped in"
 
 
 @pytest.mark.parametrize(
@@ -66,17 +73,15 @@ def test_pin_cron_due_loads_pfb_global_home_file(monkeypatch: pytest.MonkeyPatch
     sorted(p for p in _SMOKE_DIR.rglob("*.py") if p.name != "__init__.py"),
     ids=lambda p: p.name,
 )
-def test_no_smoke_snippet_calls_pfb_global_without_its_home_file(source: Path) -> None:
-    """No smoke module may call pfb_global() unless it also loads pfblockerng.inc.
-
-    Sweeps every smoke source rather than the two known sites, so a third call site
-    added later is caught by this row instead of by a red suite.
-    """
+def test_no_smoke_source_calls_pfb_global_unguarded(source: Path) -> None:
+    """Sweep every smoke source, so a third call site is caught here, not by a red suite."""
     text = source.read_text(encoding="utf-8")
-    if "pfb_global();" not in text:
-        pytest.skip("does not call pfb_global()")
-    assert _MAIN_INC in text, (
-        f"{source.name} calls pfb_global() but never references {_MAIN_INC}. "
-        f"pfblockerng_extra.inc defines neither pfb_global() nor any require, so the "
-        f"call is fatal under pfSsh.php (issue #2492)."
+    if "pfb_global" not in text:
+        pytest.skip("does not mention pfb_global")
+    if _MAIN_INC in text or _GUARD in text:
+        return  # loads the symbol, or guards the call
+    assert not _UNGUARDED_CALL.search(text), (
+        f"{source.name} calls pfb_global() with neither a require of {_MAIN_INC} nor a "
+        f"function_exists guard. pfblockerng_extra.inc defines neither pfb_global() nor "
+        f"any require, so the call is fatal under pfSsh.php (issue #2492)."
     )

--- a/tests/test_smoke_pfb_global_requires.py
+++ b/tests/test_smoke_pfb_global_requires.py
@@ -48,7 +48,7 @@ _CALL = re.compile(r"pfb_global\s*\(\s*\)\s*;")
 
 # A require/include whose target is the MAIN inc. Deliberately does NOT match
 # pfblockerng_extra.inc (the dot must follow "pfblockerng"), and does not match prose
-# mentions in comments/docstrings ("do not require pfblockerng.inc" has no require-().
+# mentions in comments/docstrings ("do not require pfblockerng.inc" has no require-paren).
 _REQUIRE_MAIN = re.compile(r"require(?:_once)?\s*\([^)\n]{0,200}pfblockerng\.inc")
 
 # A Python constant holding the main-inc path (e.g. _PFB_INC = ".../pfblockerng.inc").

--- a/tests/test_smoke_pfb_global_requires.py
+++ b/tests/test_smoke_pfb_global_requires.py
@@ -38,6 +38,7 @@ import importlib
 import re
 import subprocess
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -63,7 +64,7 @@ _MAIN_CONST = re.compile(r"""(?m)^\s*\w+\s*=\s*["'][^"']*/pfblockerng\.inc["']""
 _WINDOW = 8000
 
 
-def _live_helpers():  # -> module
+def _live_helpers() -> ModuleType:
     # Resolve at CALL time, never at import time: tests/test_adr47_conftest_lane.py
     # deliberately EVICTS tests.smoke.helpers from sys.modules and re-imports it (to
     # test import-time env reads), orphaning any module-level binding taken during


### PR DESCRIPTION
Closes #2492.

## Problem

`pin_cron_due()` evals a snippet requiring only `pfblockerng_extra.inc`, then calls
`pfb_global()` — defined in `pfblockerng.inc:3211`. `extra.inc` requires nothing, so under
`pfSsh.php` eval the call is fatal:

```
PHP ERROR: Uncaught Error: Call to undefined function pfb_global()
```

**24 occurrences in one full-suite run**, failing every feed-detector cron test that uses
the helper. Pre-existing — present in unpatched runs.

## Probed on a live guest before changing anything

```
PFBDIAG main_included=0 extra_included=1 fn_pfb_global=0 fn_config_get_path=1 files=37
```

- `main_included=0` — `pfblockerng.inc` genuinely is not loaded, so `require_once` was
  never a silent no-op
- `fn_config_get_path=1` — the eval environment is healthy; pfSense core is fully available
- `extra.inc` loads fine and simply does not provide the symbol

## Why this does NOT add the missing require

Tried first, and it is worse. Adding
`require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc')` removes the fatal
(rc 255 -> 0) but corrupts the guest config:

```
A valid config file could not be recovered. Currently running PHP scripts may encounter errors.
```

Present only in the patched run, absent from every unpatched run. Loading that file inside
`pfSsh.php`'s eval breaks the already-loaded, locked config — the gotcha documented in
`docs/misc/local-smoke-debian.md` ("some pfSense functions are not callable from pfSsh.php
eval … need full rc environment"). The comment in this diff records that so nobody repeats it.

## The change

`pfb_global()` is not needed here. It only populates `$pfb`, and the sole use below already
falls back:

```php
$state_dir = $pfb['schedule_state_dir'] ?? '/usr/local/etc';
```

So the call is guarded rather than satisfied.

## Verification (executed, on a live box)

Against `devel` at 45a91079 (post-#2485), filter `test_cron or test_adr62`:

| | Result |
| --- | --- |
| before | ~12 failing |
| after | **19 passed, 3 failed** |

The 3 remaining failures are unrelated and already filed:

- `test_cron_verb_skips_while_feed_pass_lock_held` -> #2491 (deferred-pass exit code; a
  product decision, deliberately not touched here)
- `test_cron_304_skips_unchanged_remote_feed` -> #2489
- `test_cron_lastmod_304_skips_unchanged_feed` -> #2489

Ruff clean. Test-harness only; no `src/` change.

Environment: independent 4-box Debian 13 LXC pool, `ci-runner-vm:9`, `pfsense-ce:2.8`
(`etc_version=2.8.1-RELEASE`, `FreeBSD:15:amd64`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failures when processing scheduled tasks in environments where an optional helper is unavailable.
  * Improved compatibility for command-line task execution.
  * Ensured scheduled-task setup continues safely when optional functionality is not loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->