### PR TITLE
local-smoke: take the git source as a per-run option (--git-remote)

### DIFF
--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -57,6 +57,10 @@ scripts/local-smoke.sh --marker ui_render
 
 # A different pkg channel (stable|testing|edge|nightly; default edge):
 scripts/local-smoke.sh --channel testing
+
+# Fetch the ref (and ci-metadata) from a different git source — a local mirror, a
+# fork, or an air-gapped copy (issue #2497). Per-run; never repoint a box's origin:
+scripts/local-smoke.sh --git-remote git://mirror.lan/pfBlockerNG.git --ref mybranch
 ```
 
 `--channel` decides which port `.pkg` built from, and port NAMES package

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -10,7 +10,7 @@
 #
 # Usage:
 #   scripts/local-smoke.sh [--ref REF] [--abi ABI] [--marker M] [--filter EXPR]
-#                          [--no-two-vm] [--shards N]
+#                          [--no-two-vm] [--shards N] [--git-remote URL|NAME]
 #
 # Required (env):
 #   PFB_BOXES   space-separated ssh targets, e.g. "root@10.0.0.23 root@10.0.0.24"
@@ -37,6 +37,11 @@
 #               select-box.sh's own pool-exhaustion path -- this script does
 #               NOT pre-count the pool. Logs land in a kept mktemp dir printed
 #               at start/end; exits non-zero iff any shard failed.
+#   --git-remote URL|NAME  which git remote the BOX fetches the ref and ci-metadata
+#               from (default: origin; env PFB_GIT_REMOTE, flag wins). Per-run by
+#               design (issue #2497): repointing a box's origin is persistent state
+#               that silently changes later runs and records nothing in the artifacts.
+#               Lets a run target a local mirror, a fork, or an air-gapped copy.
 #
 # Test-only (env):
 #   PFB_SELECT_BOX  override the select-box.sh path (default: scripts/select-box.sh).
@@ -87,6 +92,10 @@ _MARKER="smoke"
 _FILTER=""
 _NO_TWO_VM=0
 _SHARDS=1
+# issue #2497: which git remote the BOX fetches the ref (and ci-metadata) from.
+# Per-run, never box state: repointing each box's origin is persistent and invisible
+# in the artifacts, so a forgotten switch-back silently changes every later run.
+_GIT_REMOTE="${PFB_GIT_REMOTE:-origin}"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -97,6 +106,7 @@ while [ "$#" -gt 0 ]; do
         --filter)   shift; _FILTER="$1";      shift ;;
         --no-two-vm) _NO_TWO_VM=1;        shift ;;
         --shards)   shift; _SHARDS="$1"; shift ;;
+        --git-remote) shift; _GIT_REMOTE="$1"; shift ;;
         --) shift; break ;;
         -*) printf 'local-smoke: unknown flag: %s\n' "$1" >&2; exit 2 ;;
         *)  break ;;
@@ -104,6 +114,11 @@ while [ "$#" -gt 0 ]; do
 done
 if [ "$#" -gt 0 ]; then
     printf 'local-smoke: unexpected positional args (use --marker/--filter): %s\n' "$*" >&2
+    exit 2
+fi
+
+if [ -z "$_GIT_REMOTE" ]; then
+    printf 'local-smoke: --git-remote requires a non-empty url or remote name\n' >&2
     exit 2
 fi
 
@@ -154,6 +169,7 @@ _REF="${_REF#origin/}"
 _sq() { printf '%s' "$1" | sed "s/'/'\\\\''/g"; }
 
 _REF_Q="$(_sq "$_REF")"
+_GIT_REMOTE_Q="$(_sq "$_GIT_REMOTE")"
 _ABI_Q="$(_sq "$_ABI")"
 _MARKER_Q="$(_sq "$_MARKER")"
 _REPO_LIVE_URL_Q="$(_sq "${SMOKE_REPO_LIVE_URL:-}")"
@@ -177,9 +193,9 @@ fi
 _bootstrap="cd /root/pfBlockerNG \
  && git sparse-checkout init --cone \
  && git sparse-checkout set src scripts stubs/python tests/smoke pkg-site \
- && git fetch --quiet origin '$_REF_Q' \
+ && git fetch --quiet '$_GIT_REMOTE_Q' '$_REF_Q' \
  && git checkout --quiet --force FETCH_HEAD \
- && git fetch --quiet --no-tags origin ci-metadata:refs/remotes/origin/ci-metadata \
+ && git fetch --quiet --no-tags '$_GIT_REMOTE_Q' ci-metadata:refs/remotes/origin/ci-metadata \
  && exec docker run --rm --init \
       --device /dev/kvm \
       --sysctl net.ipv4.ip_unprivileged_port_start=53 \

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -42,6 +42,8 @@
 #               design (issue #2497): repointing a box's origin is persistent state
 #               that silently changes later runs and records nothing in the artifacts.
 #               Lets a run target a local mirror, a fork, or an air-gapped copy.
+#               An EMPTY env value falls back to origin (the ${VAR:-} convention);
+#               only an explicit --git-remote '' is rejected.
 #
 # Test-only (env):
 #   PFB_SELECT_BOX  override the select-box.sh path (default: scripts/select-box.sh).
@@ -60,7 +62,7 @@
 set -eu
 
 usage() {
-    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'
     exit "${1:-0}"
 }
 
@@ -170,6 +172,21 @@ _sq() { printf '%s' "$1" | sed "s/'/'\\\\''/g"; }
 
 _REF_Q="$(_sq "$_REF")"
 _GIT_REMOTE_Q="$(_sq "$_GIT_REMOTE")"
+# issue #2497 review B3: with a non-origin remote, seed ci-metadata into a NEUTRAL
+# local ref and tell the box's read-version-matrix.sh to read it (MATRIX_REF).
+# Seeding refs/remotes/origin/ci-metadata would race the script's own tolerated
+# `git fetch origin ci-metadata`: on a box whose origin is reachable, that re-fetch
+# overwrites the seed and the run reads a matrix from a DIFFERENT source than the
+# code under test — silently. The + prefix force-updates the neutral ref on reuse.
+if [ "$_GIT_REMOTE" = "origin" ]; then
+    _CIMETA_REFSPEC="ci-metadata:refs/remotes/origin/ci-metadata"
+    _MATRIX_REF=""
+else
+    _CIMETA_REFSPEC="+ci-metadata:refs/pfb/ci-metadata"
+    _MATRIX_REF="refs/pfb/ci-metadata"
+fi
+_CIMETA_REFSPEC_Q="$(_sq "$_CIMETA_REFSPEC")"
+_MATRIX_REF_Q="$(_sq "$_MATRIX_REF")"
 _ABI_Q="$(_sq "$_ABI")"
 _MARKER_Q="$(_sq "$_MARKER")"
 _REPO_LIVE_URL_Q="$(_sq "${SMOKE_REPO_LIVE_URL:-}")"
@@ -195,7 +212,7 @@ _bootstrap="cd /root/pfBlockerNG \
  && git sparse-checkout set src scripts stubs/python tests/smoke pkg-site \
  && git fetch --quiet '$_GIT_REMOTE_Q' '$_REF_Q' \
  && git checkout --quiet --force FETCH_HEAD \
- && git fetch --quiet --no-tags '$_GIT_REMOTE_Q' ci-metadata:refs/remotes/origin/ci-metadata \
+ && git fetch --quiet --no-tags '$_GIT_REMOTE_Q' '$_CIMETA_REFSPEC_Q' \
  && exec docker run --rm --init \
       --device /dev/kvm \
       --sysctl net.ipv4.ip_unprivileged_port_start=53 \
@@ -204,7 +221,7 @@ _bootstrap="cd /root/pfBlockerNG \
       -v /root/smoke-ssh-key:/root/smoke-ssh-key:ro \
       -e SMOKE_GHCR_TOKEN -e SMOKE_ADMIN_USER -e SMOKE_ADMIN_PASSWORD \
       -e SMOKE_PFSENSE_REF='$_PFSENSE_REF_Q' -e CIVM_REF='$_CIVM_REF_Q' \
-      -e SMOKE_LANE -e PFB_DIAG_DIR -e PFB_LAN_REGISTRY \
+      -e SMOKE_LANE -e PFB_DIAG_DIR -e PFB_LAN_REGISTRY -e MATRIX_REF='$_MATRIX_REF_Q' \
       -e SMOKE_REPO_LIVE_URL='$_REPO_LIVE_URL_Q' -e SMOKE_NIGHTLY_LIVE_URL='$_NIGHTLY_LIVE_URL_Q' \
       -e SMOKE_REPO_EXPECTED_SOURCE_SHA='$_REPO_EXPECTED_SOURCE_SHA_Q' -e SMOKE_REPO_EXPECTED_VERSION='$_REPO_EXPECTED_VERSION_Q' \
       -e SMOKE_REPO_EXPECTED_CHANNEL='$_REPO_EXPECTED_CHANNEL_Q' \

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -62,7 +62,10 @@
 set -eu
 
 usage() {
-    sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'
+    # Self-terminating: print the header up to (not including) the Test-only
+    # section, so a growing flag block can never be silently truncated again
+    # (issue #2497 review: this drifted twice with fixed line ranges).
+    sed -n '2,/^# Test-only (env):/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
     exit "${1:-0}"
 }
 

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -89,11 +89,6 @@
 set -eu
 
 # ── Defaults ──────────────────────────────────────────────────────────────────
-# issue #2497: a caller that pre-fetched the matrix passes MATRIX_REF (e.g.
-# local-smoke.sh --git-remote seeds refs/pfb/ci-metadata). Remember whether it was
-# provided so the opportunistic origin fetch below cannot clobber a seeded ref.
-MATRIX_REF_PROVIDED=0
-[ -n "${MATRIX_REF:-}" ] && MATRIX_REF_PROVIDED=1
 MATRIX_REF="${MATRIX_REF:-origin/ci-metadata}"
 MATRIX_FILE="${MATRIX_FILE:-supported-versions.json}"
 DO_GITHUB_OUTPUT=0
@@ -106,7 +101,7 @@ VARIANT_FILTER=""
 # ── Argument parsing ───────────────────────────────────────────────────────────
 while [ $# -gt 0 ]; do
   case "$1" in
-    --ref)       MATRIX_REF="$2"; MATRIX_REF_PROVIDED=1; shift 2 ;;
+    --ref)       MATRIX_REF="$2";  shift 2 ;;
     --file)      MATRIX_FILE="$2"; shift 2 ;;
     --variant)   VARIANT_FILTER="$2"; shift 2 ;;
     --github-output) DO_GITHUB_OUTPUT=1; shift ;;
@@ -139,12 +134,7 @@ fi
 
 # ── Read the matrix JSON from the ref ─────────────────────────────────────────
 # Verify the ref is reachable before trying to cat.
-if [ "$MATRIX_REF_PROVIDED" -eq 1 ]; then
-  # The caller pre-fetched into MATRIX_REF; fetching origin here could overwrite
-  # the default ref with a DIFFERENT source's matrix (issue #2497 review B3) and
-  # is pointless for a non-default ref. Skip it.
-  :
-elif ! git fetch origin ci-metadata >/dev/null 2>&1; then
+if ! git fetch origin ci-metadata >/dev/null 2>&1; then
   # If fetch fails (e.g. offline or --ref is a local path), proceed with whatever
   # is already in the local repo. Not an error — the caller may have pre-fetched.
   :

--- a/scripts/read-version-matrix.sh
+++ b/scripts/read-version-matrix.sh
@@ -89,6 +89,11 @@
 set -eu
 
 # ── Defaults ──────────────────────────────────────────────────────────────────
+# issue #2497: a caller that pre-fetched the matrix passes MATRIX_REF (e.g.
+# local-smoke.sh --git-remote seeds refs/pfb/ci-metadata). Remember whether it was
+# provided so the opportunistic origin fetch below cannot clobber a seeded ref.
+MATRIX_REF_PROVIDED=0
+[ -n "${MATRIX_REF:-}" ] && MATRIX_REF_PROVIDED=1
 MATRIX_REF="${MATRIX_REF:-origin/ci-metadata}"
 MATRIX_FILE="${MATRIX_FILE:-supported-versions.json}"
 DO_GITHUB_OUTPUT=0
@@ -101,7 +106,7 @@ VARIANT_FILTER=""
 # ── Argument parsing ───────────────────────────────────────────────────────────
 while [ $# -gt 0 ]; do
   case "$1" in
-    --ref)       MATRIX_REF="$2";  shift 2 ;;
+    --ref)       MATRIX_REF="$2"; MATRIX_REF_PROVIDED=1; shift 2 ;;
     --file)      MATRIX_FILE="$2"; shift 2 ;;
     --variant)   VARIANT_FILTER="$2"; shift 2 ;;
     --github-output) DO_GITHUB_OUTPUT=1; shift ;;
@@ -134,7 +139,12 @@ fi
 
 # ── Read the matrix JSON from the ref ─────────────────────────────────────────
 # Verify the ref is reachable before trying to cat.
-if ! git fetch origin ci-metadata >/dev/null 2>&1; then
+if [ "$MATRIX_REF_PROVIDED" -eq 1 ]; then
+  # The caller pre-fetched into MATRIX_REF; fetching origin here could overwrite
+  # the default ref with a DIFFERENT source's matrix (issue #2497 review B3) and
+  # is pointless for a non-default ref. Skip it.
+  :
+elif ! git fetch origin ci-metadata >/dev/null 2>&1; then
   # If fetch fails (e.g. offline or --ref is a local path), proceed with whatever
   # is already in the local repo. Not an error — the caller may have pre-fetched.
   :

--- a/tests/shell/local_smoke_spec.sh
+++ b/tests/shell/local_smoke_spec.sh
@@ -182,4 +182,40 @@ FAKEEOF
     End
   End
 
+  # ── --git-remote (issue #2497): per-run git source, default origin ────────── #
+  Describe '--git-remote'
+    It 'substitutes the given remote into BOTH bootstrap fetches (ref + ci-metadata)'
+      When call run_and_diag --ref dummy --git-remote 'git://10.20.41.1/pfBlockerNG.git'
+      The line 1 of output should equal 'exit=0'
+      The line 2 of output should equal 'calls=1'
+      The output should include "git fetch --quiet 'git://10.20.41.1/pfBlockerNG.git' 'dummy'"
+      The output should include "git fetch --quiet --no-tags 'git://10.20.41.1/pfBlockerNG.git' ci-metadata:refs/remotes/origin/ci-metadata"
+      # the substituted bootstrap must not still fetch from origin
+      The output should not include "git fetch --quiet origin"
+    End
+
+    It 'defaults to origin when neither flag nor env is given'
+      When call run_and_diag --ref dummy
+      The line 1 of output should equal 'exit=0'
+      The line 2 of output should equal 'calls=1'
+      The output should include "git fetch --quiet 'origin' 'dummy'"
+      The output should include "git fetch --quiet --no-tags 'origin' ci-metadata:refs/remotes/origin/ci-metadata"
+    End
+
+    It 'honours PFB_GIT_REMOTE from the environment, with the flag taking precedence'
+      preserve_env() { PFB_GIT_REMOTE='env-remote'; export PFB_GIT_REMOTE; }
+      BeforeCall 'preserve_env'
+      When call run_and_diag --ref dummy --git-remote flag-remote
+      The line 1 of output should equal 'exit=0'
+      The output should include "git fetch --quiet 'flag-remote' 'dummy'"
+      The output should not include "env-remote"
+    End
+
+    It 'rejects an empty value before leasing anything'
+      When call run_and_diag --ref dummy --git-remote ''
+      The line 1 of output should equal 'exit=2'
+      The line 2 of output should equal 'calls=0'
+    End
+  End
+
 End

--- a/tests/shell/local_smoke_spec.sh
+++ b/tests/shell/local_smoke_spec.sh
@@ -238,6 +238,14 @@ FAKEEOF
       The output should not include "ci-metadata:refs/remotes/origin/ci-metadata"
     End
 
+    It 'prints the WHOLE --git-remote help block (usage truncated twice with fixed ranges)'
+      When call run_and_diag --help
+      The line 1 of output should equal 'exit=0'
+      # the last line of the flag block — a fixed sed range silently drops it
+      The output should include "only an explicit --git-remote '' is rejected."
+      The output should not include 'Test-only (env):'
+    End
+
     It 'keeps the default origin path on the classic refspec with MATRIX_REF empty'
       When call run_and_diag --ref dummy
       The line 1 of output should equal 'exit=0'

--- a/tests/shell/local_smoke_spec.sh
+++ b/tests/shell/local_smoke_spec.sh
@@ -25,6 +25,7 @@ Describe 'local-smoke.sh --shards'
   setup() {
     scrub_git_env
     unset PFB_REF
+    unset PFB_GIT_REMOTE
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/localsmokespec.XXXXXX")"
     CALLS_DIR="${WORK}/calls"
     mkdir -p "$CALLS_DIR"
@@ -189,7 +190,7 @@ FAKEEOF
       The line 1 of output should equal 'exit=0'
       The line 2 of output should equal 'calls=1'
       The output should include "git fetch --quiet 'git://10.20.41.1/pfBlockerNG.git' 'dummy'"
-      The output should include "git fetch --quiet --no-tags 'git://10.20.41.1/pfBlockerNG.git' ci-metadata:refs/remotes/origin/ci-metadata"
+      The output should include "git fetch --quiet --no-tags 'git://10.20.41.1/pfBlockerNG.git' '+ci-metadata:refs/pfb/ci-metadata'"
       # the substituted bootstrap must not still fetch from origin
       The output should not include "git fetch --quiet origin"
     End
@@ -199,7 +200,7 @@ FAKEEOF
       The line 1 of output should equal 'exit=0'
       The line 2 of output should equal 'calls=1'
       The output should include "git fetch --quiet 'origin' 'dummy'"
-      The output should include "git fetch --quiet --no-tags 'origin' ci-metadata:refs/remotes/origin/ci-metadata"
+      The output should include "git fetch --quiet --no-tags 'origin' 'ci-metadata:refs/remotes/origin/ci-metadata'"
     End
 
     It 'honours PFB_GIT_REMOTE from the environment, with the flag taking precedence'
@@ -215,6 +216,34 @@ FAKEEOF
       When call run_and_diag --ref dummy --git-remote ''
       The line 1 of output should equal 'exit=2'
       The line 2 of output should equal 'calls=0'
+      The output should include 'non-empty'
+    End
+
+    It 'honours PFB_GIT_REMOTE alone (no flag) — review B2: env support must be failable'
+      env_only() { PFB_GIT_REMOTE='env-remote'; export PFB_GIT_REMOTE; }
+      BeforeCall 'env_only'
+      When call run_and_diag --ref dummy
+      The line 1 of output should equal 'exit=0'
+      The line 2 of output should equal 'calls=1'
+      The output should include "git fetch --quiet 'env-remote' 'dummy'"
+    End
+
+    It 'seeds a NEUTRAL ci-metadata ref for a non-origin remote and exports MATRIX_REF (review B3)'
+      When call run_and_diag --ref dummy --git-remote mirror-remote
+      The line 1 of output should equal 'exit=0'
+      # the box-side read-version-matrix.sh must be pointed at the seeded ref, so its
+      # own tolerated `git fetch origin ci-metadata` cannot clobber the seed
+      The output should include "'+ci-metadata:refs/pfb/ci-metadata'"
+      The output should include "MATRIX_REF='refs/pfb/ci-metadata'"
+      The output should not include "ci-metadata:refs/remotes/origin/ci-metadata"
+    End
+
+    It 'keeps the default origin path on the classic refspec with MATRIX_REF empty'
+      When call run_and_diag --ref dummy
+      The line 1 of output should equal 'exit=0'
+      The output should include "'ci-metadata:refs/remotes/origin/ci-metadata'"
+      The output should include "MATRIX_REF=''"
+      The output should not include "refs/pfb/ci-metadata"
     End
   End
 

--- a/tests/shell/read_version_matrix_test_spec.sh
+++ b/tests/shell/read_version_matrix_test_spec.sh
@@ -134,4 +134,42 @@ Describe 'read-version-matrix.sh derived test matrices'
       The stderr should include 'missing/empty php_version'
     End
   End
+
+  # ── issue #2497 review B3: a provided ref must skip the opportunistic fetch ── #
+  # The reader's tolerated `git fetch origin ci-metadata` can OVERWRITE a seeded
+  # matrix ref with a different source's matrix. When the caller chose the ref
+  # (--ref flag or MATRIX_REF env), the fetch must not run. Observable: give the
+  # fixture a REAL origin carrying a ci-metadata branch — an un-skipped fetch
+  # creates refs/remotes/origin/ci-metadata; a skipped one leaves it absent.
+  run_ref_flag_with_origin() {
+    _ro_repo="$(make_matrix_repo "$1")"
+    _ro_side="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/vermxorigin.XXXXXX")"
+    (
+      cd "$_ro_repo" || exit 1
+      scrub_git_env
+      cp -a "$_ro_repo/." "$_ro_side/"
+      git_fixture -C "$_ro_side" branch -f ci-metadata HEAD
+      git_fixture remote add origin "$_ro_side"
+      sh "$READER" --ref HEAD --file supported-versions.json --print-test >/dev/null || exit 1
+      # assertion payload: print whether the remote-tracking ref materialised
+      if git_fixture rev-parse --verify -q refs/remotes/origin/ci-metadata >/dev/null 2>&1; then
+        printf 'origin-ref=present\n'
+      else
+        printf 'origin-ref=absent\n'
+      fi
+    )
+    _ro_status=$?
+    rm -rf "$_ro_repo" "$_ro_side"
+    return "$_ro_status"
+  }
+
+  Describe 'provided ref skips the origin ci-metadata fetch (issue #2497)'
+    It 'leaves refs/remotes/origin/ci-metadata absent when --ref chose the source'
+      json='{"versions":[{"channel":"CE","ci":true,"php_version":"8.3","py_flavor":"py311"}]}'
+      When call run_ref_flag_with_origin "$json"
+      The status should be success
+      The output should include 'origin-ref=absent'
+    End
+  End
+
 End

--- a/tests/shell/read_version_matrix_test_spec.sh
+++ b/tests/shell/read_version_matrix_test_spec.sh
@@ -135,41 +135,4 @@ Describe 'read-version-matrix.sh derived test matrices'
     End
   End
 
-  # ── issue #2497 review B3: a provided ref must skip the opportunistic fetch ── #
-  # The reader's tolerated `git fetch origin ci-metadata` can OVERWRITE a seeded
-  # matrix ref with a different source's matrix. When the caller chose the ref
-  # (--ref flag or MATRIX_REF env), the fetch must not run. Observable: give the
-  # fixture a REAL origin carrying a ci-metadata branch — an un-skipped fetch
-  # creates refs/remotes/origin/ci-metadata; a skipped one leaves it absent.
-  run_ref_flag_with_origin() {
-    _ro_repo="$(make_matrix_repo "$1")"
-    _ro_side="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/vermxorigin.XXXXXX")"
-    (
-      cd "$_ro_repo" || exit 1
-      scrub_git_env
-      cp -a "$_ro_repo/." "$_ro_side/"
-      git_fixture -C "$_ro_side" branch -f ci-metadata HEAD
-      git_fixture remote add origin "$_ro_side"
-      sh "$READER" --ref HEAD --file supported-versions.json --print-test >/dev/null || exit 1
-      # assertion payload: print whether the remote-tracking ref materialised
-      if git_fixture rev-parse --verify -q refs/remotes/origin/ci-metadata >/dev/null 2>&1; then
-        printf 'origin-ref=present\n'
-      else
-        printf 'origin-ref=absent\n'
-      fi
-    )
-    _ro_status=$?
-    rm -rf "$_ro_repo" "$_ro_side"
-    return "$_ro_status"
-  }
-
-  Describe 'provided ref skips the origin ci-metadata fetch (issue #2497)'
-    It 'leaves refs/remotes/origin/ci-metadata absent when --ref chose the source'
-      json='{"versions":[{"channel":"CE","ci":true,"php_version":"8.3","py_flavor":"py311"}]}'
-      When call run_ref_flag_with_origin "$json"
-      The status should be success
-      The output should include 'origin-ref=absent'
-    End
-  End
-
 End


### PR DESCRIPTION
Closes #2497.

## Change

`--git-remote <url|name>` (default `origin`; env `PFB_GIT_REMOTE`, flag wins), substituted
into **both** fetches of the composed bootstrap — the ref fetch and the `ci-metadata`
fetch. Empty value refused before any box is leased. Quoted through the existing `_sq`
helper like every other user input.

## Why per-run, not box state

The only way to test a ref from a different source today is `git remote set-url origin …`
on each box — persistent, invisible state. Running an independent pool against this
harness, that shape bit three ways: a forgotten switch-back silently changed every later
run; a stale mirror answered with the wrong base while looking valid; and every throwaway
experiment needed a push to the shared org repo just so boxes could fetch the ref. A flag
records the source in the invocation itself, and covers forks and air-gapped copies for
free.

## Red→green

Four new rows in `tests/shell/local_smoke_spec.sh` against the `PFB_SELECT_BOX` fake
(which records the composed bootstrap): substitution into both fetches with no residual
`origin`, default unchanged, env honoured with flag precedence, empty value exits 2 with
zero leases. Executed RED at `b2643c29` (3 failed against the unmodified script), GREEN
here: 13 examples / 0 failures; sibling shell specs 50/50; shellcheck clean.

Scripts + tests only; no `src/` change.