### PR TITLE
apply: name the failed precondition when sync aborts

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -660,6 +660,9 @@ function sync_package_pfblockerng($cron=''): bool {
 	$pfb_dispatch_owner = !isset($GLOBALS['pfb_schedule_dispatch_lock'])
 		|| !is_resource($GLOBALS['pfb_schedule_dispatch_lock']);
 	if (!pfb_schedule_dispatch_begin()) {
+		// issue #2496: pfblockerng.php exits 1 on a FALSE from this function with no
+		// other output, so every guard must name itself or the failure is undiagnosable.
+		pfb_logger("\n sync aborted: dispatcher lock unavailable; pending changes retained.\n", 1);
 		pfb_mark_pending_changes();
 		return FALSE;
 	}
@@ -678,6 +681,7 @@ function sync_package_pfblockerng($cron=''): bool {
 		return FALSE;
 	}
 	if (!pfb_stage_publish_dir_recover($pfb['dbdir'])) {
+		pfb_logger("\n sync aborted: stage/publish recovery failed in {$pfb['dbdir']}; pending changes retained.\n", 1);
 		pfb_mark_pending_changes();
 		if ($pfb_feed_pass_owner) {
 			pfb_feed_pass_release();
@@ -688,6 +692,7 @@ function sync_package_pfblockerng($cron=''): bool {
 		return FALSE;
 	}
 	if (!pfb_geoip_generation_ready()) {
+		pfb_logger("\n sync aborted: GeoIP generation swap in progress; pending changes retained.\n", 1);
 		pfb_mark_pending_changes();
 		if ($pfb_feed_pass_owner) {
 			pfb_feed_pass_release();

--- a/tests/php/SyncFeedPassDeferralTest.php
+++ b/tests/php/SyncFeedPassDeferralTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/SyncPrereqSeedTrait.php';
+
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,6 +24,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class SyncFeedPassDeferralTest extends TestCase
 {
+	use SyncPrereqSeedTrait;
+
 	private string $dbdir = '';
 	private bool $hadPfb = FALSE;
 	private array $originalPfb = [];
@@ -109,51 +113,6 @@ final class SyncFeedPassDeferralTest extends TestCase
 		@rmdir($dir);
 	}
 
-	/** The minimum config pfb_global() (called at the top of sync_package_pfblockerng()) needs. */
-	private function seedSyncPrereqs(): void
-	{
-		$gen   = 'installedpackages/pfblockerng/config/0';
-		$ip    = 'installedpackages/pfblockerngipsettings/config/0';
-		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
-
-		config_set_path("{$gen}/pfb_min",        '0');
-		config_set_path("{$gen}/pfb_hour",       '0');
-		config_set_path("{$gen}/pfb_dailystart", '0');
-		config_set_path("{$gen}/skipfeed",       '0');
-		config_set_path("{$gen}/pfb_interval",   '24');
-		config_set_path("{$gen}/pfb_quiet_hours", '');
-
-		config_set_path("{$ip}/suppression",     '');
-		config_set_path("{$ip}/database_cc",     '');
-		config_set_path("{$ip}/maxmind_locale",  'en');
-		config_set_path("{$ip}/asn_reporting",   'disabled');
-		config_set_path("{$ip}/asn_token",       '');
-		config_set_path("{$ip}/maxmind_account", '');
-		config_set_path("{$ip}/maxmind_key",     '');
-
-		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
-
-		config_set_path("{$dnsbl}/pfb_dnsvip4",     '');
-		config_set_path("{$dnsbl}/pfb_dnsvip6",     '');
-		config_set_path("{$dnsbl}/pfb_dnsport",     '8081');
-		config_set_path("{$dnsbl}/pfb_dnsport_ssl", '8443');
-		config_set_path("{$dnsbl}/top1m_enable",    '');
-		config_set_path("{$dnsbl}/pfb_cache",       '');
-		config_set_path("{$dnsbl}/pfb_py_reply",    '');
-		config_set_path("{$dnsbl}/pfb_regex",       '');
-		config_set_path("{$dnsbl}/pfb_regex_list",  '');
-		config_set_path("{$dnsbl}/pfb_cname",       '');
-		config_set_path("{$dnsbl}/tld_allow",       '');
-		config_set_path("{$dnsbl}/pfb_py_nolog",    '');
-		config_set_path("{$dnsbl}/pfb_noaaaa",      '');
-		config_set_path("{$dnsbl}/pfb_noaaaa_list", '');
-		config_set_path("{$dnsbl}/pfb_gp",          '');
-		config_set_path("{$dnsbl}/pfb_gp_bypass_list", '');
-
-		if (!isset($GLOBALS['g']['unbound_chroot_path'])) {
-			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
-		}
-	}
 
 	/** Hold the feed-pass lock as ANOTHER process would -- a second, independent fd. */
 	private function holdLockAsAnotherProcess(): void

--- a/tests/php/SyncGuardLoggingTest.php
+++ b/tests/php/SyncGuardLoggingTest.php
@@ -39,6 +39,10 @@ final class SyncGuardLoggingTest extends TestCase
 	private string $dir = '';
 	private bool $hadPfb = FALSE;
 	private array $originalPfb = [];
+	// seedSyncPrereqs() sets this when absent; restore it so the seeded value cannot
+	// leak into a later test (CLAUDE.md: self-encapsulated, never order-dependent).
+	private bool $hadChrootPath = FALSE;
+	private mixed $originalChrootPath = NULL;
 	/** @var array<int, resource> */
 	private array $rawFps = [];
 
@@ -52,6 +56,8 @@ final class SyncGuardLoggingTest extends TestCase
 	{
 		$this->hadPfb      = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->hadChrootPath      = array_key_exists('unbound_chroot_path', $GLOBALS['g'] ?? []);
+		$this->originalChrootPath = $GLOBALS['g']['unbound_chroot_path'] ?? NULL;
 
 		$this->dir = sys_get_temp_dir() . '/pfb_sync_guard_' . uniqid('', TRUE);
 		mkdir("{$this->dir}/db", 0755, TRUE);
@@ -112,6 +118,11 @@ final class SyncGuardLoggingTest extends TestCase
 			$GLOBALS['pfb'] = $this->originalPfb;
 		} else {
 			unset($GLOBALS['pfb']);
+		}
+		if ($this->hadChrootPath) {
+			$GLOBALS['g']['unbound_chroot_path'] = $this->originalChrootPath;
+		} else {
+			unset($GLOBALS['g']['unbound_chroot_path']);
 		}
 	}
 

--- a/tests/php/SyncGuardLoggingTest.php
+++ b/tests/php/SyncGuardLoggingTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/SyncPrereqSeedTrait.php';
+
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,6 +31,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class SyncGuardLoggingTest extends TestCase
 {
+	use SyncPrereqSeedTrait;
+
 	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
 	private const EXTRA = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
 
@@ -63,6 +67,10 @@ final class SyncGuardLoggingTest extends TestCase
 		]);
 		// A previous test (or a reentrant caller) must not lend us its locks.
 		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+
+		// Seed the config keys pfb_global() reads, so these rows do not add
+		// "Undefined array key" trigger listings to the suite's warning detail.
+		$this->seedSyncPrereqs();
 	}
 
 	protected function tearDown(): void
@@ -129,6 +137,14 @@ final class SyncGuardLoggingTest extends TestCase
 	public function testStagePublishRecoverFailureLogsThePrecondition(): void
 	{
 		// scandir(FALSE) path: dbdir vanished out from under the run.
+		//
+		// This reaches the stage/publish guard only because pfb_feed_pass_acquire()
+		// FAILS OPEN (pfblockerng.inc:17685): with dbdir gone its lock fopen() fails, it
+		// logs "Feed pass lock: open failed [...], proceeding unlocked" and returns TRUE,
+		// so pfb_feed_pass_begin('sync') — which runs FIRST — does not abort the sync.
+		// If that policy ever flips to fail-closed this row goes RED (the log would carry
+		// the feed-pass skip wording instead of stage/publish), which is the correct
+		// signal: the row would no longer be testing what it claims.
 		$GLOBALS['pfb']['dbdir'] = "{$this->dir}/db-nonexistent";
 
 		$this->assertFalse(sync_package_pfblockerng('noupdates'),

--- a/tests/php/SyncGuardLoggingTest.php
+++ b/tests/php/SyncGuardLoggingTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2496: sync_package_pfblockerng()'s silent precondition guards must log.
+ *
+ * pfblockerng.php:255 is `exit(pfblockerng_sync_cron() ? 0 : 1)`, so a FALSE from
+ * sync_package_pfblockerng() surfaces as rc=1 with empty stdout AND stderr. Three of
+ * its four early guards return FALSE without writing anything anywhere, which made a
+ * 13-test smoke failure undiagnosable until the guards were hand-instrumented:
+ *
+ *   pfblockerng_apply.inc  pfb_schedule_dispatch_begin() FALSE   — silent
+ *   pfblockerng_apply.inc  pfb_stage_publish_dir_recover() FALSE — silent
+ *   pfblockerng_apply.inc  pfb_geoip_generation_ready() FALSE    — silent
+ *
+ * (The fourth, pfb_feed_pass_begin(), logs its own skip inside the callee — pinned by
+ * FeedPassLockTest row 11 — so it is deliberately NOT covered here: a call-site line
+ * would double-log.)
+ *
+ * Each row forces exactly one guard to fire, asserts sync_package_pfblockerng()
+ * returns FALSE (the before-state, already true), and asserts the main log names the
+ * failed precondition (the change under test — RED before the fix).
+ *
+ * Environment recipe mirrors FeedPassLockTest: temp dbdir/state dir, $pfb['log'] at a
+ * temp path, locks held via raw fds where a guard needs contention.
+ */
+final class SyncGuardLoggingTest extends TestCase
+{
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	private const EXTRA = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+
+	private string $dir = '';
+	private bool $hadPfb = FALSE;
+	private array $originalPfb = [];
+	/** @var array<int, resource> */
+	private array $rawFps = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once self::EXTRA;
+		require_once self::APPLY;
+	}
+
+	protected function setUp(): void
+	{
+		$this->hadPfb      = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+
+		$this->dir = sys_get_temp_dir() . '/pfb_sync_guard_' . uniqid('', TRUE);
+		mkdir("{$this->dir}/db", 0755, TRUE);
+		mkdir("{$this->dir}/state", 0755, TRUE);
+		mkdir("{$this->dir}/cc", 0755, TRUE);
+
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dbdir'              => "{$this->dir}/db",
+			'schedule_state_dir' => "{$this->dir}/state",
+			'ccdir'              => "{$this->dir}/cc",
+			'log'                => "{$this->dir}/pfblockerng.log",
+			'errlog'             => "{$this->dir}/error.log",
+		]);
+		// A previous test (or a reentrant caller) must not lend us its locks.
+		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->rawFps as $fp) {
+			if (is_resource($fp)) {
+				@flock($fp, LOCK_UN);
+				@fclose($fp);
+			}
+		}
+		$this->rawFps = [];
+		// Release anything the function under test acquired before its guard fired.
+		if (isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock'])) {
+			@flock($GLOBALS['pfb_feed_pass_lock'], LOCK_UN);
+			@fclose($GLOBALS['pfb_feed_pass_lock']);
+		}
+		if (isset($GLOBALS['pfb_schedule_dispatch_lock']) && is_resource($GLOBALS['pfb_schedule_dispatch_lock'])) {
+			@flock($GLOBALS['pfb_schedule_dispatch_lock'], LOCK_UN);
+			@fclose($GLOBALS['pfb_schedule_dispatch_lock']);
+		}
+		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+
+		$paths = array_merge(
+			glob("{$this->dir}/db/*") ?: [],
+			glob("{$this->dir}/state/*") ?: [],
+			glob("{$this->dir}/cc/*") ?: [],
+			glob("{$this->dir}/cc/.*") ?: [],
+			glob("{$this->dir}/*") ?: [],
+		);
+		foreach ($paths as $path) {
+			if (basename($path) === '.' || basename($path) === '..') {
+				continue;
+			}
+			is_dir($path) ? @rmdir($path) : @unlink($path);
+		}
+		@rmdir($this->dir);
+
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+	}
+
+	private function mainLog(): string
+	{
+		$log = $GLOBALS['pfb']['log'];
+		return is_file($log) ? (string) file_get_contents($log) : '';
+	}
+
+	public function testDispatchLockUnavailableLogsThePrecondition(): void
+	{
+		$holder = fopen("{$this->dir}/state/pfb_schedule_dispatch.lock", 'c');
+		$this->assertIsResource($holder, 'test setup: could not open the dispatch lock');
+		$this->rawFps[] = $holder;
+		$this->assertTrue(flock($holder, LOCK_EX), 'test setup: could not hold the dispatch lock');
+
+		$this->assertFalse(sync_package_pfblockerng('noupdates'),
+			'before-state: a held dispatcher lock must abort the sync');
+		$this->assertStringContainsString('dispatcher lock', $this->mainLog(),
+			'the aborted sync must log WHICH precondition failed (issue #2496): dispatcher lock');
+	}
+
+	public function testStagePublishRecoverFailureLogsThePrecondition(): void
+	{
+		// scandir(FALSE) path: dbdir vanished out from under the run.
+		$GLOBALS['pfb']['dbdir'] = "{$this->dir}/db-nonexistent";
+
+		$this->assertFalse(sync_package_pfblockerng('noupdates'),
+			'before-state: an unrecoverable stage/publish dir must abort the sync');
+		$this->assertStringContainsString('stage/publish', $this->mainLog(),
+			'the aborted sync must log WHICH precondition failed (issue #2496): stage/publish recovery');
+	}
+
+	public function testGeoipGenerationSwapLogsThePrecondition(): void
+	{
+		touch("{$this->dir}/cc/.pfb_generation_swapping");
+
+		$this->assertFalse(sync_package_pfblockerng('noupdates'),
+			'before-state: an in-flight GeoIP generation swap must abort the sync');
+		$this->assertStringContainsString('GeoIP generation', $this->mainLog(),
+			'the aborted sync must log WHICH precondition failed (issue #2496): GeoIP generation swap');
+	}
+}

--- a/tests/php/SyncPrereqSeedTrait.php
+++ b/tests/php/SyncPrereqSeedTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Shared minimum config seeding for tests that call sync_package_pfblockerng().
+ *
+ * pfb_global() reads ~two dozen config keys unconditionally. Without them PHP emits
+ * "Undefined array key" warnings from production code — harmless (nothing fails, and
+ * the same sites are already triggered by other tests) but it grows the suite's
+ * warning-detail output and buries real signal.
+ *
+ * Extracted from SyncFeedPassDeferralTest so every sync-calling test seeds the SAME
+ * minimum rather than each inventing its own (issue #2496 review nitpick).
+ */
+trait SyncPrereqSeedTrait
+{
+	/** The minimum config pfb_global() (called at the top of sync_package_pfblockerng()) needs. */
+	private function seedSyncPrereqs(): void
+	{
+		$gen   = 'installedpackages/pfblockerng/config/0';
+		$ip    = 'installedpackages/pfblockerngipsettings/config/0';
+		$dnsbl = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+		config_set_path("{$gen}/pfb_min",        '0');
+		config_set_path("{$gen}/pfb_hour",       '0');
+		config_set_path("{$gen}/pfb_dailystart", '0');
+		config_set_path("{$gen}/skipfeed",       '0');
+		config_set_path("{$gen}/pfb_interval",   '24');
+		config_set_path("{$gen}/pfb_quiet_hours", '');
+
+		config_set_path("{$ip}/suppression",     '');
+		config_set_path("{$ip}/database_cc",     '');
+		config_set_path("{$ip}/maxmind_locale",  'en');
+		config_set_path("{$ip}/asn_reporting",   'disabled');
+		config_set_path("{$ip}/asn_token",       '');
+		config_set_path("{$ip}/maxmind_account", '');
+		config_set_path("{$ip}/maxmind_key",     '');
+
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+
+		config_set_path("{$dnsbl}/pfb_dnsvip4",     '');
+		config_set_path("{$dnsbl}/pfb_dnsvip6",     '');
+		config_set_path("{$dnsbl}/pfb_dnsport",     '8081');
+		config_set_path("{$dnsbl}/pfb_dnsport_ssl", '8443');
+		config_set_path("{$dnsbl}/top1m_enable",    '');
+		config_set_path("{$dnsbl}/pfb_cache",       '');
+		config_set_path("{$dnsbl}/pfb_py_reply",    '');
+		config_set_path("{$dnsbl}/pfb_regex",       '');
+		config_set_path("{$dnsbl}/pfb_regex_list",  '');
+		config_set_path("{$dnsbl}/pfb_cname",       '');
+		config_set_path("{$dnsbl}/tld_allow",       '');
+		config_set_path("{$dnsbl}/pfb_py_nolog",    '');
+		config_set_path("{$dnsbl}/pfb_noaaaa",      '');
+		config_set_path("{$dnsbl}/pfb_noaaaa_list", '');
+		config_set_path("{$dnsbl}/pfb_gp",          '');
+		config_set_path("{$dnsbl}/pfb_gp_bypass_list", '');
+
+		if (!isset($GLOBALS['g']['unbound_chroot_path'])) {
+			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		}
+	}
+}


### PR DESCRIPTION
Closes #2496.

## Problem

`pfblockerng.php:255` is `exit(pfblockerng_sync_cron() ? 0 : 1)`, so a FALSE from
`sync_package_pfblockerng()` surfaces as **rc=1 with empty stdout AND stderr**. Three of
its four early guards return FALSE without writing anything anywhere:

| Guard | Callee logs? |
| --- | --- |
| `pfb_schedule_dispatch_begin()` | no — silent |
| `pfb_feed_pass_begin('sync')` | **yes** (pinned by `FeedPassLockTest` row 11) — untouched here |
| `pfb_stage_publish_dir_recover()` | no — silent |
| `pfb_geoip_generation_ready()` | no — pure predicate |

Observed live: a 13-test smoke failure whose only symptom was the silent rc=1,
undiagnosable until these guards were hand-instrumented (#2492's investigation).

## Change

One `pfb_logger` line per silent guard, wording parallel to the cron-side guards
("…; pending changes retained" — which is true: each guard already calls
`pfb_mark_pending_changes()`). The feed-pass guard is deliberately untouched to avoid
double-logging its callee's existing skip line.

## Red→green

`tests/php/SyncGuardLoggingTest.php` — one row per silent guard, each forcing exactly
that precondition (held dispatch lock via raw flock; vanished dbdir; GeoIP swap marker)
and asserting both the before-state (FALSE — passing already) and the log content (the
change under test). Executed RED at `37c95c25`: 3 failures, all on the log assertion,
none on the before-state. GREEN here: 3 tests, 8 assertions, 0 failures.

Gates: php -l, phpunit, phpcs, phpstan `[OK] No errors`.

## Note for reviewers

The issue originally claimed four silent guards; reading each callee corrected that to
three (comment trail on #2496). The environment recipe mirrors `FeedPassLockTest`
(temp dbdir/state/cc dirs, `$pfb['log']` at a temp path, locks held via raw fds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer error messages when synchronization is stopped because required safeguards are unavailable.
  * Confirmed that pending changes are retained when synchronization cannot proceed.

* **Tests**
  * Added coverage for lock, recovery, and GeoIP update safeguards.
  * Improved shared test setup for synchronization prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->