### PR TITLE
cron: a deferred scheduled pass exits cleanly; Force Check still reports it

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
@@ -252,7 +252,8 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 // $scope — 'both' (default), 'ip', or 'dnsbl'; filters which list types are probed.
 //   Defaults to 'both' so existing callers (case 'cron') are unchanged.
 function pfblockerng_sync_cron(
-	$force_all = FALSE,
+	// issue #2491: typed because the RETURN VALUE now depends on its truthiness.
+	bool $force_all = FALSE,
 	$scope = 'both',
 	bool $pending_change = FALSE,
 	bool $clear_hashes = FALSE
@@ -263,7 +264,18 @@ function pfblockerng_sync_cron(
 		|| !is_resource($GLOBALS['pfb_schedule_dispatch_lock']);
 	if (!pfb_schedule_dispatch_begin()) {
 		pfb_logger("\n Scheduled feed pass deferred: dispatcher lock unavailable; durable pending occurrences retained.\n", 1);
-		return FALSE;
+		// issue #2491: a deferral is benign for the UNATTENDED cron verb and a real
+		// non-event for Force Check. Both reach here; only $force_all separates them
+		// (pfblockerng.php:255 passes nothing, :304 passes TRUE).
+		//
+		// Scheduled tick: another pass holds the lock, this tick stood down with its
+		// durable pending occurrence intact and the next tick retries. Exiting 1 there
+		// tells cron the run FAILED and produces recurring MTA noise with nothing
+		// actionable in it, so report success.
+		//
+		// Force Check: the operator asked for an update NOW and did not get one. That
+		// must stay observable (SyncCronFeedPassDeferralTest pins it).
+		return !$force_all;
 	}
 
 	// issue #1175: serialize feed passes -- same ownership discipline as
@@ -274,7 +286,9 @@ function pfblockerng_sync_cron(
 		if ($pfb_dispatch_owner) {
 			pfb_schedule_dispatch_release();
 		}
-		return FALSE;
+		// issue #2491: benign for the scheduled tick, observable for Force Check —
+		// see the dispatcher-lock guard above.
+		return !$force_all;
 	}
 	if ($force_all) {
 		$dirs = pfb_force_scope_dirs($scope, $pfb['origdir'], $pfb['dnsorigdir']);

--- a/tests/php/CronDeferralExitCodeTest.php
+++ b/tests/php/CronDeferralExitCodeTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc';
+
+/**
+ * Issue #2491: a DEFERRED scheduled feed pass is a benign skip, not a failure.
+ *
+ * `pfblockerng.php:255` is `exit(pfblockerng_sync_cron() ? 0 : 1)`, and the tick
+ * consumer (`pfblockerng_extra.inc:5988`) discards the return value entirely, so this
+ * boolean's only meaning is the cron process's exit code.
+ *
+ * Three paths return FALSE today, and they are not the same kind of event:
+ *
+ *   cron.inc:266  dispatcher lock unavailable  -> deferred, occurrences retained
+ *   cron.inc:277  feed lock unavailable        -> deferred, occurrences retained
+ *   cron.inc:306  runtime model/state missing  -> genuine failure (logged as logtype 2)
+ *
+ * The first two mean another pass is already doing the work and this tick stood down
+ * with its durable pending occurrence intact — the next tick retries. Reporting that as
+ * exit 1 tells cron (and any operator wrapper or MTA) the run FAILED when nothing was
+ * lost, producing recurring noise with no actionable content. The code's own wording
+ * says as much: "deferred ... durable pending occurrences retained".
+ *
+ * The third is a real failure and must keep exiting non-zero, otherwise this change
+ * would trade false alarms for silent breakage.
+ *
+ * Rows 1-2 are RED before the fix (they return FALSE); row 3 is the before-state guard
+ * that keeps the fix honest and passes both before and after.
+ */
+final class CronDeferralExitCodeTest extends TestCase
+{
+	private string $dbdir = '';
+	private bool $hadPfb = FALSE;
+	private array $originalPfb = [];
+	private bool $hadConfig = FALSE;
+	private mixed $originalConfig = NULL;
+
+	/** Raw fds simulating ANOTHER process holding a lock. */
+	private $feedLockFp = NULL;
+	private $dispatchLockFp = NULL;
+
+	protected function setUp(): void
+	{
+		$this->hadPfb         = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb    = $GLOBALS['pfb'] ?? [];
+		$this->hadConfig      = array_key_exists('config', $GLOBALS);
+		$this->originalConfig = $GLOBALS['config'] ?? NULL;
+
+		$this->dbdir = sys_get_temp_dir() . '/pfb_cron_defer_' . uniqid('', TRUE);
+		mkdir($this->dbdir, 0755, TRUE);
+
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dbdir'              => $this->dbdir,
+			'schedule_state_dir' => $this->dbdir,
+			'log'                => "{$this->dbdir}/pfblockerng.log",
+			'errlog'             => "{$this->dbdir}/error.log",
+			'runlog'             => "{$this->dbdir}/run.log",
+			'pending_marker'     => "{$this->dbdir}/pfb_pending_changes",
+		]);
+		$GLOBALS['config'] = [];
+
+		// No inherited locks: a leaked handle would make a deferral row pass vacuously
+		// (the reentrancy short-circuit returns TRUE without ever reaching the guard).
+		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ([$this->feedLockFp, $this->dispatchLockFp] as $fp) {
+			if (is_resource($fp)) {
+				@flock($fp, LOCK_UN);
+				@fclose($fp);
+			}
+		}
+		$this->feedLockFp = $this->dispatchLockFp = NULL;
+
+		pfb_feed_pass_release();
+		if (isset($GLOBALS['pfb_schedule_dispatch_lock']) && is_resource($GLOBALS['pfb_schedule_dispatch_lock'])) {
+			@flock($GLOBALS['pfb_schedule_dispatch_lock'], LOCK_UN);
+			@fclose($GLOBALS['pfb_schedule_dispatch_lock']);
+		}
+		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+
+		foreach (glob("{$this->dbdir}/*") ?: [] as $path) {
+			is_dir($path) ? @rmdir($path) : @unlink($path);
+		}
+		@rmdir($this->dbdir);
+
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+	}
+
+	private function mainLog(): string
+	{
+		$log = $GLOBALS['pfb']['log'];
+		return is_file($log) ? (string) file_get_contents($log) : '';
+	}
+
+	public function testDispatcherLockHeldExitsCleanly(): void
+	{
+		$this->dispatchLockFp = fopen("{$this->dbdir}/pfb_schedule_dispatch.lock", 'c');
+		$this->assertIsResource($this->dispatchLockFp, 'test setup: could not open the dispatcher lock');
+		$this->assertTrue(flock($this->dispatchLockFp, LOCK_EX), 'test setup: could not hold the dispatcher lock');
+
+		$result = pfblockerng_sync_cron();
+
+		$this->assertStringContainsString('dispatcher lock unavailable', $this->mainLog(),
+			'before-state: the run must actually have taken the dispatcher-deferral path');
+		$this->assertTrue($result,
+			'a deferred pass retains its occurrences and retries next tick — cron must exit 0 (issue #2491)');
+	}
+
+	public function testFeedPassLockHeldExitsCleanly(): void
+	{
+		$this->feedLockFp = fopen("{$this->dbdir}/pfb_feed_pass.lock", 'c');
+		$this->assertIsResource($this->feedLockFp, 'test setup: could not open the feed-pass lock');
+		$this->assertTrue(flock($this->feedLockFp, LOCK_EX), 'test setup: could not hold the feed-pass lock');
+
+		$result = pfblockerng_sync_cron();
+
+		$this->assertStringContainsString('feed lock unavailable', $this->mainLog(),
+			'before-state: the run must actually have taken the feed-pass deferral path');
+		$this->assertTrue($result,
+			'a deferred pass retains its occurrences and retries next tick — cron must exit 0 (issue #2491)');
+	}
+
+	public function testRuntimeUnavailableStillFails(): void
+	{
+		// Reach the genuine-failure guard with BOTH LOCKS HEALTHY. Do not do this by
+		// pointing schedule_state_dir at a missing directory: the dispatcher lock file
+		// lives there too, so the run would take the DEFERRAL path instead and this row
+		// would pass for the wrong reason (it did, before this was corrected).
+		// An unparseable state file makes pfb_schedule_state_read() return NULL
+		// (pfblockerng_extra.inc) while both locks acquire normally.
+		file_put_contents("{$this->dbdir}/pfb_schedule_state.json", 'not json at all');
+
+		$result = pfblockerng_sync_cron();
+
+		$log = $this->mainLog();
+		$this->assertStringContainsString('runtime unavailable', $log,
+			'before-state: the run must actually have reached the genuine-failure guard');
+		$this->assertStringNotContainsString('lock unavailable', $log,
+			'this row must not be taking a deferral path — that would pass for the wrong reason');
+		$this->assertFalse($result,
+			'a genuine runtime failure must KEEP exiting non-zero — this fix must not trade '
+			. 'false alarms for silent breakage (issue #2491)');
+	}
+}

--- a/tests/php/CronDeferralExitCodeTest.php
+++ b/tests/php/CronDeferralExitCodeTest.php
@@ -18,15 +18,27 @@ require_once __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_cron.in
  *   cron.inc:266  dispatcher lock unavailable  -> deferred, occurrences retained
  *   cron.inc:277  feed lock unavailable        -> deferred, occurrences retained
  *   cron.inc:306  runtime model/state missing  -> genuine failure (logged as logtype 2)
+ *                   (inside `if (\$scheduled_runtime)`, so cron-path only —
+ *                    unreachable under Force Check)
  *
- * The first two mean another pass is already doing the work and this tick stood down
- * with its durable pending occurrence intact — the next tick retries. Reporting that as
- * exit 1 tells cron (and any operator wrapper or MTA) the run FAILED when nothing was
- * lost, producing recurring noise with no actionable content. The code's own wording
+ * The first two mean another pass is already doing the work and the run stood down with
+ * its durable pending occurrence intact — the next tick retries. The code's own wording
  * says as much: "deferred ... durable pending occurrences retained".
+ *
+ * SCOPE, precisely: the installed crontab entry is `pfblockerng.php cron-tick`
+ * (pfblockerng.inc:7665), which always exits 0 and whose feed dispatch discards this
+ * boolean — and pfblockerng.inc:7685 actively REMOVES any legacy `pfblockerng.php cron`
+ * entry on every sync pass. So no scheduled job has surfaced this exit code. What
+ * changes is the `cron` verb run by hand at the CLI or by a third-party wrapper: it no
+ * longer reports failure for a benign deferral, which also makes production agree with
+ * tests/smoke/test_feed_pass_lock.py:127 for the first time.
  *
  * The third is a real failure and must keep exiting non-zero, otherwise this change
  * would trade false alarms for silent breakage.
+ *
+ * The benign reading applies ONLY to the unattended cron verb. Force Check
+ * (`pfblockerng.php:304`, `$force_all = TRUE`) means an operator asked for an update NOW
+ * and did not get one — that stays observable, as `SyncCronFeedPassDeferralTest` pins.
  *
  * Rows 1-2 are RED before the fix (they return FALSE); row 3 is the before-state guard
  * that keeps the fix honest and passes both before and after.
@@ -134,6 +146,38 @@ final class CronDeferralExitCodeTest extends TestCase
 			'before-state: the run must actually have taken the feed-pass deferral path');
 		$this->assertTrue($result,
 			'a deferred pass retains its occurrences and retries next tick — cron must exit 0 (issue #2491)');
+	}
+
+	public function testForceCheckDeferralStaysObservable(): void
+	{
+		$this->feedLockFp = fopen("{$this->dbdir}/pfb_feed_pass.lock", 'c');
+		$this->assertIsResource($this->feedLockFp, 'test setup: could not open the feed-pass lock');
+		$this->assertTrue(flock($this->feedLockFp, LOCK_EX), 'test setup: could not hold the feed-pass lock');
+
+		// $force_all = TRUE is the Force Check caller (pfblockerng.php:304).
+		$result = pfblockerng_sync_cron(TRUE);
+
+		$this->assertStringContainsString('feed lock unavailable', $this->mainLog(),
+			'before-state: the run must actually have taken the feed-pass deferral path');
+		$this->assertFalse($result,
+			'an operator-initiated Force Check that was deferred must still report failure — '
+			. 'the benign reading is for the unattended cron verb only (issue #2491)');
+	}
+
+	public function testForceCheckDispatcherDeferralStaysObservable(): void
+	{
+		// Without this row, reverting the dispatcher guard to a bare `return TRUE`
+		// fails nothing: the feed-lock row below covers only that one guard.
+		$this->dispatchLockFp = fopen("{$this->dbdir}/pfb_schedule_dispatch.lock", 'c');
+		$this->assertIsResource($this->dispatchLockFp, 'test setup: could not open the dispatcher lock');
+		$this->assertTrue(flock($this->dispatchLockFp, LOCK_EX), 'test setup: could not hold the dispatcher lock');
+
+		$result = pfblockerng_sync_cron(TRUE);
+
+		$this->assertStringContainsString('dispatcher lock unavailable', $this->mainLog(),
+			'before-state: the run must actually have taken the dispatcher-deferral path');
+		$this->assertFalse($result,
+			'Force Check deferred at the dispatcher lock must still report failure (issue #2491)');
 	}
 
 	public function testRuntimeUnavailableStillFails(): void

--- a/tests/php/SyncCronFeedPassDeferralTest.php
+++ b/tests/php/SyncCronFeedPassDeferralTest.php
@@ -70,7 +70,15 @@ final class SyncCronFeedPassDeferralTest extends TestCase
 		$beforeLedger = file_get_contents("{$this->dbdir}/pfb_due_ledger.json");
 		$beforeState = file_get_contents("{$stateDir}/pfb_schedule_state.json");
 
-		$this->assertFalse(pfblockerng_sync_cron(), 'feed-lock deferral must be observable by Force Check');
+		// issue #2491: this row's no-args call is the ORIGINAL deliberate intent (#1315:
+		// the tick's advisory busy probe, i.e. the $force_all = FALSE path); the
+		// "Force Check" wording was a later addition and is the half that was wrong.
+		// The cron path now reports a deferral as success, so the expectation flips —
+		// but the call stays on the cron path, because the state/cache assertions below
+		// are this file's reason to exist and they must keep covering it.
+		// Force Check's own return contract is pinned in CronDeferralExitCodeTest.
+		$this->assertTrue(pfblockerng_sync_cron(),
+			'a deferred scheduled pass reports success, and must still preserve state');
 
 		$this->assertSame($beforeLedger, file_get_contents("{$this->dbdir}/pfb_due_ledger.json"),
 			'lost feed-pass lock must not mutate the runtime cache');

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -13481,7 +13481,7 @@
                 "name": "force_all",
                 "byRef": false,
                 "variadic": false,
-                "type": null,
+                "type": "bool",
                 "default": "false"
             },
             {


### PR DESCRIPTION
Closes #2491.

## The question the issue asked

Is a deferred feed pass a failure (exit 1) or a benign skip (exit 0)? `tests/smoke/test_feed_pass_lock.py:127` asserts `rc == 0`; production returned FALSE, and `pfblockerng.php:255` is `exit(... ? 0 : 1)`.

## The answer this PR implements

**It depends on the caller** — which is what made the question hard. There are two:

| Caller | Meaning | Deferral |
| --- | --- | --- |
| `pfblockerng.php:255` `cron` verb | passive invocation, no args | **exit 0** |
| `pfblockerng.php:304` Force Check | operator pressed Run Now (`pfb_runnow_forcecheck`) | **exit 1** |

Both guards return `!$force_all`. The genuine-failure guard (runtime model/state unavailable, logtype 2) is **untouched** and still returns FALSE — a row pins that, so this cannot trade false alarms for silent breakage.

## Scope — stated precisely, because my first version overstated it

An earlier draft of this PR claimed the *scheduled tick* was exiting 1 and generating cron/MTA noise. **That was wrong**, and review caught it:

- the installed crontab entry is `pfblockerng.php cron-tick` (`pfblockerng.inc:7665`), which always exits 0 and whose feed dispatch (`pfblockerng_extra.inc:5988`) **discards** this boolean
- `pfblockerng.inc:7685` actively **removes** any legacy `pfblockerng.php cron` entry on every sync pass

So no scheduled job has ever surfaced this exit code. What actually changes is the `cron` verb run **by hand at the CLI or by a third-party wrapper**, and production now agrees with the smoke assertion for the first time — that assertion has expected `rc=0` since `ee8af959` while production returned FALSE, so it evidences intent rather than a verified contract.

The benefit is therefore narrower than first claimed. It is still the right semantic (the interactive operator sees the deferral line on STDOUT via `pfb_logger` case 1), but it should be judged on accurate facts.

## An existing test's expectation flips — here is why that is legitimate

`SyncCronFeedPassDeferralTest` line 73 asserted FALSE while calling the **cron** path with no args, under the message *"must be observable by Force Check"*. Git history resolves the conflation: `2dd4faa4` (#1315) introduced the row with the no-args call and **no return assertion at all** — the class docblock names the tick's advisory-probe race — and the "Force Check" message was bolted on later by `eae4a032`.

So the **call** is the deliberate intent and the **message** is the newer artefact. An earlier draft of this PR changed the call to match the message; review proved that dropped the only coverage of the #1315 cron-path state-preservation guarantee (a cron-path-only regression was caught on `devel` and by nothing on that head). The row now keeps its no-args call, flips to `assertTrue`, and keeps every state/cache assertion. Differential mutation confirms it: injecting `if (!$force_all) { pfb_due_ledger_set_pending(...); }` fails that row.

## Known asymmetry, deliberately not fixed here

`pfb_trigger` — the ADR-43 replacement funnel — routes to `sync_package_pfblockerng()`, whose identical deferral guards (`pfblockerng_apply.inc:662-678`) still return FALSE. This PR fixes the older verb and leaves the modern one inconsistent. Filed separately rather than widened here.

## Red→green

`tests/php/CronDeferralExitCodeTest.php`, five rows: both deferral paths, Force Check at **each** lock, and the genuine-failure path. Every row asserts the log names its own path **before** asserting the return value.

That guard earned itself twice: the first draft of the genuine-failure row forced it by pointing `schedule_state_dir` at a missing directory — but the dispatcher lock file lives there too, so the row was silently taking the *deferral* path. And review found the dispatcher guard was only half-pinned (reverting it to a bare `return TRUE` failed nothing); the fifth row closes that.

Executed RED at `02303bdc` against unmodified `src/` (3 tests, 11 assertions, 2 failures, both on the return-value assertion). Full suite **5327 tests / 0 failures**, warnings unchanged at 29; phpstan `[OK] No errors`; phpcs clean; `function_inventory.json` regenerated via the documented path (one line, `null` → `bool`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled synchronization runs now complete successfully when temporarily deferred by an active lock.
  - Force Check operations continue to report deferrals as failures, making them visible for follow-up.
  - Genuine runtime errors continue to return failure status.

- **Tests**
  - Added coverage for dispatcher and feed-pass lock deferrals, Force Check behavior, and runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->