### PR TITLE
cron: correct the deferral guard's rationale (issue #2508)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
@@ -268,10 +268,14 @@ function pfblockerng_sync_cron(
 		// non-event for Force Check. Both reach here; only $force_all separates them
 		// (pfblockerng.php:255 passes nothing, :304 passes TRUE).
 		//
-		// Scheduled tick: another pass holds the lock, this tick stood down with its
-		// durable pending occurrence intact and the next tick retries. Exiting 1 there
-		// tells cron the run FAILED and produces recurring MTA noise with nothing
-		// actionable in it, so report success.
+		// Unattended cron verb: another pass holds the lock, this run stood down with its
+		// durable pending occurrence intact, and the next tick retries. Nothing failed, so
+		// a hand-run `pfblockerng.php cron` or a third-party wrapper must not be told one
+		// did -- and rc=0 is what tests/smoke/test_feed_pass_lock.py has asserted for this
+		// path since ee8af959. No SCHEDULED job reaches this: the installed entry is
+		// `cron-tick` (pfblockerng.inc pfblockerng_configure_tick_cron()), which returns
+		// void and exits 0, and any legacy bare `pfblockerng.php cron` entry is removed
+		// there on every sync pass.
 		//
 		// Force Check: the operator asked for an update NOW and did not get one. That
 		// must stay observable (SyncCronFeedPassDeferralTest pins it).


### PR DESCRIPTION
Closes #2508.

## What

The deferral guard's comment, added with #2491, justifies returning success like this:

> Exiting 1 there tells cron the run FAILED and produces recurring MTA noise with nothing
> actionable in it, so report success.

The exit-code behaviour is right; the rationale describes a path that does not exist.

## Why it cannot happen

- The installed crontab entry is `pfblockerng.php cron-tick`, not `cron`
  (`pfblockerng.inc`, `pfblockerng_configure_tick_cron()`).
- `cron-tick` calls `pfblockerng_tick()` (returns `void`) then a bare `exit;`, so it always
  exits 0. The boolean this guard returns never becomes an exit status on that path.
- Any legacy bare `pfblockerng.php cron ` entry is removed on every sync pass.
- The tick command redirects both streams into a log file (`>> {$log} 2>&1`). cron mails a
  job's *output*; there would be none.

## What it says now

#2491's own commit message has the accurate reason in its "SCOPE, stated precisely"
paragraph: what changes is the `cron` verb run by hand at the CLI or by a third-party
wrapper, and the change makes production agree with `tests/smoke/test_feed_pass_lock.py`,
which has asserted `rc=0` for this path since `ee8af959`. The comment now says that, and
names why no scheduled job is involved so the next reader does not re-derive it.

## Scope and evidence

Comment only — one hunk, no behaviour change, no test change. `php -l`, PHPUnit, phpcs and
`phpstan` (`[OK] No errors`) pass on the touched file.

Reviewed under `landing.md`'s self-review exemption (small, contained, single-hunk
comment change); the three lenses are recorded in an audit comment below rather than spawned
as legs. CodeRabbit is deliberately not asked for this one — `coderabbit.md` says not to
spend a slot on a comment-only round.

no-test-needed: comment-only change — one hunk, no executable line altered (verified: the diff has no non-comment +/- lines), so there is no behaviour a test could pin. The comment corrects a factual claim about which crontab entry exists; the facts it now states are already covered by the tests it cites.
