### PR TITLE
install: export SSL_CA_CERT_PATH for every pkg call (issue #2514)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,6 +27,9 @@
 #   PKG_BIN           pkg(8) binary path (default: /usr/local/sbin/pkg)
 #   PFBLOCKERNG_ROOT  filesystem root prefix (default: /)
 #   PFB_BASE_URL      catalog base (default: https://pfblockerng.github.io/pkg)
+#   PFB_SSL_CA_CERT_PATH  CA hash dir exported to pkg (default: <root>/etc/ssl/certs)
+#   PFB_SSL_CA_CERT_FILE  CA bundle exported to pkg (default: <root>/etc/ssl/cert.pem)
+#                         Each is exported only if it exists; set either to "" to opt out.
 #
 # Exit codes: see usage() below (kept in sync — the header is the interface doc).
 
@@ -70,23 +73,45 @@ die() {
 # Callers add -y themselves on verbs that take it (delete/install); read-only verbs
 # (query/rquery/version/info) ignore ASSUME_ALWAYS_YES harmlessly.
 #
-# SSL_CA_CERT_PATH (issue #2514): on pfSense Plus, pfSense-repo-setup writes a PKG_ENV
-# block into pkg.conf pinning SSL_CA_CERT_FILE to Netgate's private CA bundle, which
-# carries only Netgate CAs. libpkg applies that block with setenv(..., overwrite=1), so
-# a libfetch-based pkg (1.x) verifies against Netgate's CAs and nothing else, and every
+# CA locations (issue #2514): on pfSense Plus, pfSense-repo-setup writes a PKG_ENV block
+# into pkg.conf pinning SSL_CA_CERT_FILE to Netgate's private CA bundle, which carries
+# only Netgate CAs. libpkg applies that block with setenv(..., overwrite=1), so a
+# libfetch-based pkg (1.x) verifies against Netgate's CAs and nothing else, and every
 # fetch from a third-party catalog fails with "certificate verify failed". PKG_ENV never
-# sets SSL_CA_CERT_PATH, and libfetch loads file and path into the same store
-# (SSL_CTX_load_verify_locations(ctx, ca_cert_file, ca_cert_path)), so exporting the
-# path here survives the pin. This only mirrors what a libcurl-based pkg (2.x) already
-# does by default: peer verification stays fully enabled, the box's trust store is not
-# modified, and no vendor configuration is touched.
-PFB_SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH:-${ROOT}/etc/ssl/certs}"
+# sets SSL_CA_CERT_PATH, and libfetch loads file and path into one store
+# (SSL_CTX_load_verify_locations(ctx, ca_cert_file, ca_cert_path)), so exporting the path
+# survives the pin. That mirrors what a libcurl-based pkg (2.x) already does by default:
+# peer verification stays fully enabled, the trust store is not modified, and no vendor
+# configuration is touched.
+#
+# The bundle goes with it, because libfetch takes load_verify_locations() as soon as
+# EITHER variable is set and then never calls SSL_CTX_set_default_verify_paths(). On a box
+# with no pin (CE), exporting the path alone would therefore drop the default bundle from
+# the store, and FreeBSD ships /etc/ssl/certs EMPTY until certctl rehash populates it — so
+# path-only would turn a working stock box into this very failure. On Plus, PKG_ENV
+# overwrites this value with Netgate's bundle, which is what should happen there.
+#
+# Each is exported only when it exists, so pkg is never pointed at a missing location.
+# Setting either variable to the empty string opts that half out (hence `-`, not `:-`).
+PFB_SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH-${ROOT}/etc/ssl/certs}"
+PFB_SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE-${ROOT}/etc/ssl/cert.pem}"
 
+# Spelled out per combination so every path stays quoted: a single accumulated string
+# would have to be word-split to become separate env(1) operands, which breaks the moment
+# a location contains a space.
 _pkg() {
-    # A path that does not exist would be a no-op at best and could cost the pinned
-    # bundle its load, so it is only exported when the store is really there.
-    if [ -d "${PFB_SSL_CA_CERT_PATH}" ]; then
-        env ASSUME_ALWAYS_YES=yes SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
+    if [ -d "${PFB_SSL_CA_CERT_PATH}" ] && [ -f "${PFB_SSL_CA_CERT_FILE}" ]; then
+        env ASSUME_ALWAYS_YES=yes \
+            SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
+            SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE}" \
+            "${PKG_BIN}" "$@" </dev/null
+    elif [ -d "${PFB_SSL_CA_CERT_PATH}" ]; then
+        env ASSUME_ALWAYS_YES=yes \
+            SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
+            "${PKG_BIN}" "$@" </dev/null
+    elif [ -f "${PFB_SSL_CA_CERT_FILE}" ]; then
+        env ASSUME_ALWAYS_YES=yes \
+            SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE}" \
             "${PKG_BIN}" "$@" </dev/null
     else
         env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" "$@" </dev/null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,8 @@
 #   PFB_BASE_URL      catalog base (default: https://pfblockerng.github.io/pkg)
 #   PFB_SSL_CA_CERT_PATH  CA hash dir exported to pkg (default: <root>/etc/ssl/certs)
 #   PFB_SSL_CA_CERT_FILE  CA bundle exported to pkg (default: <root>/etc/ssl/cert.pem)
-#                         Each is exported only if it exists; set either to "" to opt out.
+#                         Exported only if present (dir non-missing, bundle non-empty);
+#                         set either to "" to opt that half out.
 #
 # Exit codes: see usage() below (kept in sync — the header is the interface doc).
 
@@ -91,8 +92,13 @@ die() {
 # path-only would turn a working stock box into this very failure. On Plus, PKG_ENV
 # overwrites this value with Netgate's bundle, which is what should happen there.
 #
-# Each is exported only when it exists, so pkg is never pointed at a missing location.
+# The bundle is checked with -s, not -f: load_verify_locations() reads the file eagerly and
+# abandons the path when that fails, so an empty or truncated bundle would take the whole
+# store down, while set_default_verify_paths() would have tolerated it.
+#
 # Setting either variable to the empty string opts that half out (hence `-`, not `:-`).
+# Opting the BUNDLE out on a box with no PKG_ENV pin leaves the path-only store this code
+# exists to avoid, so that half is for boxes whose bundle is known bad.
 PFB_SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH-${ROOT}/etc/ssl/certs}"
 PFB_SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE-${ROOT}/etc/ssl/cert.pem}"
 
@@ -100,7 +106,7 @@ PFB_SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE-${ROOT}/etc/ssl/cert.pem}"
 # would have to be word-split to become separate env(1) operands, which breaks the moment
 # a location contains a space.
 _pkg() {
-    if [ -d "${PFB_SSL_CA_CERT_PATH}" ] && [ -f "${PFB_SSL_CA_CERT_FILE}" ]; then
+    if [ -d "${PFB_SSL_CA_CERT_PATH}" ] && [ -s "${PFB_SSL_CA_CERT_FILE}" ]; then
         env ASSUME_ALWAYS_YES=yes \
             SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
             SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE}" \
@@ -109,7 +115,7 @@ _pkg() {
         env ASSUME_ALWAYS_YES=yes \
             SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
             "${PKG_BIN}" "$@" </dev/null
-    elif [ -f "${PFB_SSL_CA_CERT_FILE}" ]; then
+    elif [ -s "${PFB_SSL_CA_CERT_FILE}" ]; then
         env ASSUME_ALWAYS_YES=yes \
             SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE}" \
             "${PKG_BIN}" "$@" </dev/null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,8 +69,28 @@ die() {
 # header) + ASSUME_ALWAYS_YES so a stray prompt cannot wedge a non-interactive run.
 # Callers add -y themselves on verbs that take it (delete/install); read-only verbs
 # (query/rquery/version/info) ignore ASSUME_ALWAYS_YES harmlessly.
+#
+# SSL_CA_CERT_PATH (issue #2514): on pfSense Plus, pfSense-repo-setup writes a PKG_ENV
+# block into pkg.conf pinning SSL_CA_CERT_FILE to Netgate's private CA bundle, which
+# carries only Netgate CAs. libpkg applies that block with setenv(..., overwrite=1), so
+# a libfetch-based pkg (1.x) verifies against Netgate's CAs and nothing else, and every
+# fetch from a third-party catalog fails with "certificate verify failed". PKG_ENV never
+# sets SSL_CA_CERT_PATH, and libfetch loads file and path into the same store
+# (SSL_CTX_load_verify_locations(ctx, ca_cert_file, ca_cert_path)), so exporting the
+# path here survives the pin. This only mirrors what a libcurl-based pkg (2.x) already
+# does by default: peer verification stays fully enabled, the box's trust store is not
+# modified, and no vendor configuration is touched.
+PFB_SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH:-${ROOT}/etc/ssl/certs}"
+
 _pkg() {
-    env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" "$@" </dev/null
+    # A path that does not exist would be a no-op at best and could cost the pinned
+    # bundle its load, so it is only exported when the store is really there.
+    if [ -d "${PFB_SSL_CA_CERT_PATH}" ]; then
+        env ASSUME_ALWAYS_YES=yes SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
+            "${PKG_BIN}" "$@" </dev/null
+    else
+        env ASSUME_ALWAYS_YES=yes "${PKG_BIN}" "$@" </dev/null
+    fi
 }
 
 usage() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,7 +92,7 @@ die() {
 # path-only would turn a working stock box into this very failure. On Plus, PKG_ENV
 # overwrites this value with Netgate's bundle, which is what should happen there.
 #
-# The bundle is checked with -s, not -f: load_verify_locations() reads the file eagerly and
+# The bundle is checked with -f AND -s, because -s alone is TRUE for a directory: load_verify_locations() reads the file eagerly and
 # abandons the path when that fails, so an empty or truncated bundle would take the whole
 # store down, while set_default_verify_paths() would have tolerated it.
 #
@@ -106,7 +106,7 @@ PFB_SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE-${ROOT}/etc/ssl/cert.pem}"
 # would have to be word-split to become separate env(1) operands, which breaks the moment
 # a location contains a space.
 _pkg() {
-    if [ -d "${PFB_SSL_CA_CERT_PATH}" ] && [ -s "${PFB_SSL_CA_CERT_FILE}" ]; then
+    if [ -d "${PFB_SSL_CA_CERT_PATH}" ] && [ -f "${PFB_SSL_CA_CERT_FILE}" ] && [ -s "${PFB_SSL_CA_CERT_FILE}" ]; then
         env ASSUME_ALWAYS_YES=yes \
             SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
             SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE}" \
@@ -115,7 +115,7 @@ _pkg() {
         env ASSUME_ALWAYS_YES=yes \
             SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
             "${PKG_BIN}" "$@" </dev/null
-    elif [ -s "${PFB_SSL_CA_CERT_FILE}" ]; then
+    elif [ -f "${PFB_SSL_CA_CERT_FILE}" ] && [ -s "${PFB_SSL_CA_CERT_FILE}" ]; then
         env ASSUME_ALWAYS_YES=yes \
             SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE}" \
             "${PKG_BIN}" "$@" </dev/null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,8 +29,8 @@
 #   PFB_BASE_URL      catalog base (default: https://pfblockerng.github.io/pkg)
 #   PFB_SSL_CA_CERT_PATH  CA hash dir exported to pkg (default: <root>/etc/ssl/certs)
 #   PFB_SSL_CA_CERT_FILE  CA bundle exported to pkg (default: <root>/etc/ssl/cert.pem)
-#                         Exported only if present (dir non-missing, bundle non-empty);
-#                         set either to "" to opt that half out.
+#                         Exported only when the path is a directory and the bundle is a
+#                         non-empty regular file; set either to "" to opt that half out.
 #
 # Exit codes: see usage() below (kept in sync — the header is the interface doc).
 
@@ -92,9 +92,10 @@ die() {
 # path-only would turn a working stock box into this very failure. On Plus, PKG_ENV
 # overwrites this value with Netgate's bundle, which is what should happen there.
 #
-# The bundle is checked with -f AND -s, because -s alone is TRUE for a directory: load_verify_locations() reads the file eagerly and
-# abandons the path when that fails, so an empty or truncated bundle would take the whole
-# store down, while set_default_verify_paths() would have tolerated it.
+# The bundle is checked with -f AND -s. load_verify_locations() reads the file eagerly and
+# abandons the path when that read fails, so an empty or truncated bundle would take the
+# whole store down with it, a state set_default_verify_paths() would have tolerated. -s
+# alone is not enough because it is TRUE for a directory, whose size is nonzero.
 #
 # Setting either variable to the empty string opts that half out (hence `-`, not `:-`).
 # Opting the BUNDLE out on a box with no PKG_ENV pin leaves the path-only store this code
@@ -106,7 +107,8 @@ PFB_SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE-${ROOT}/etc/ssl/cert.pem}"
 # would have to be word-split to become separate env(1) operands, which breaks the moment
 # a location contains a space.
 _pkg() {
-    if [ -d "${PFB_SSL_CA_CERT_PATH}" ] && [ -f "${PFB_SSL_CA_CERT_FILE}" ] && [ -s "${PFB_SSL_CA_CERT_FILE}" ]; then
+    if [ -d "${PFB_SSL_CA_CERT_PATH}" ] &&
+        [ -f "${PFB_SSL_CA_CERT_FILE}" ] && [ -s "${PFB_SSL_CA_CERT_FILE}" ]; then
         env ASSUME_ALWAYS_YES=yes \
             SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
             SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE}" \

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -45,6 +45,7 @@ ROOT="${PFB_TEST_ROOT}"
 LOG="${ROOT}/pkg-invocations.log"
 printf '%s\n' "$*" >> "${LOG}"
 printf '%s\n' "${SSL_CA_CERT_PATH-<unset>}" >> "${ROOT}/pkg-ca-path.log"
+printf '%s\n' "${SSL_CA_CERT_FILE-<unset>}" >> "${ROOT}/pkg-ca-file.log"
 _stub_byte="$(head -c 1 2>/dev/null)"
 printf '%s' "${_stub_byte}" >> "${ROOT}/pkg-stdin"
 
@@ -208,6 +209,11 @@ def _pkg_ca_path_capture(root: str) -> Path:
     return Path(root) / "pkg-ca-path.log"
 
 
+def _pkg_ca_file_capture(root: str) -> Path:
+    """One line per pkg call: the SSL_CA_CERT_FILE it saw, or <unset>."""
+    return Path(root) / "pkg-ca-file.log"
+
+
 def _write_pkg_stub(root: str) -> str:
     """Install the fake pkg(8) binary under root/bin/pkg; return its path."""
     bin_dir = os.path.join(root, "bin")
@@ -221,7 +227,7 @@ def _write_pkg_stub(root: str) -> str:
     # CREATE, never truncate: _run_install re-seeds the stub on every call (including
     # repeated calls on the same root for idempotency/resume tests), and the log must
     # accumulate across those calls for callers that diff before/after content.
-    for p in (_pkg_stdin_capture(root), _pkg_log(root), _pkg_ca_path_capture(root)):
+    for p in (_pkg_stdin_capture(root), _pkg_log(root), _pkg_ca_path_capture(root), _pkg_ca_file_capture(root)):
         if not p.exists():
             p.write_text("")
     return stub_path
@@ -321,6 +327,7 @@ def _run_install(
         **(extra_env or {}),
     }
     env.pop("SSL_CA_CERT_PATH", None)
+    env.pop("SSL_CA_CERT_FILE", None)
     if update_fails:
         env["PFB_STUB_UPDATE_FAIL"] = "1"
     if version_t_broken:
@@ -1103,6 +1110,9 @@ def test_absent_ca_dir_leaves_ssl_ca_cert_path_unset() -> None:
         assert seen, "no pkg calls were made — the run cannot prove the guard"
         assert set(seen) == {"<unset>"}, f"expected SSL_CA_CERT_PATH unset, saw {sorted(set(seen))}"
 
+        files = _pkg_ca_file_capture(root).read_text().splitlines()
+        assert set(files) == {"<unset>"}, f"expected SSL_CA_CERT_FILE unset, saw {sorted(set(files))}"
+
 
 def test_ca_path_is_overridable() -> None:
     """PFB_SSL_CA_CERT_PATH overrides the default location."""
@@ -1116,3 +1126,90 @@ def test_ca_path_is_overridable() -> None:
         seen = _pkg_ca_path_capture(root).read_text().splitlines()
         assert seen, "no pkg calls were made — the run cannot prove the override"
         assert set(seen) == {str(override)}, f"override ignored, saw {sorted(set(seen))}"
+
+
+def _ca_bundle(root: str) -> Path:
+    return Path(root) / "etc" / "ssl" / "cert.pem"
+
+
+def test_ca_bundle_is_exported_alongside_the_path() -> None:
+    """The default bundle is exported too, so setting the path cannot shrink the store.
+
+    libfetch takes `SSL_CTX_load_verify_locations(file, path)` as soon as EITHER variable
+    is set, skipping `SSL_CTX_set_default_verify_paths()`. Exporting only the path would
+    therefore drop /etc/ssl/cert.pem from the store on a box that has no PKG_ENV pin (CE),
+    turning a working box into the very failure this change exists to fix whenever its
+    hashed directory is empty or stale. On Plus, PKG_ENV overwrites this value with
+    Netgate's bundle, which is exactly what should happen there.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        ca_dir = _ca_dir(root)
+        ca_dir.mkdir(parents=True)
+        bundle = _ca_bundle(root)
+        bundle.write_text("")
+
+        proc = _run_install(root, "stable")
+        assert proc.returncode == 0, proc.stderr
+
+        seen = _pkg_ca_file_capture(root).read_text().splitlines()
+        assert seen, "no pkg calls were made — the run cannot prove the export"
+        assert set(seen) == {str(bundle)}, (
+            f"expected every pkg call to export SSL_CA_CERT_FILE={bundle}, saw {sorted(set(seen))}"
+        )
+
+
+def test_absent_ca_bundle_leaves_ssl_ca_cert_file_unset() -> None:
+    """No bundle on the box -> nothing is exported (never point pkg at a missing file)."""
+    with tempfile.TemporaryDirectory() as root:
+        _ca_dir(root).mkdir(parents=True)
+        assert not _ca_bundle(root).exists()
+
+        proc = _run_install(root, "stable")
+        assert proc.returncode == 0, proc.stderr
+
+        seen = _pkg_ca_file_capture(root).read_text().splitlines()
+        assert seen, "no pkg calls were made — the run cannot prove the guard"
+        assert set(seen) == {"<unset>"}, f"expected SSL_CA_CERT_FILE unset, saw {sorted(set(seen))}"
+
+
+def test_ca_locations_survive_a_path_containing_a_space() -> None:
+    """Quoting holds: a location with a space reaches pkg intact, not word-split."""
+    with tempfile.TemporaryDirectory() as root:
+        spaced_dir = Path(root) / "ssl store" / "certs"
+        spaced_dir.mkdir(parents=True)
+        spaced_file = Path(root) / "ssl store" / "cert bundle.pem"
+        spaced_file.write_text("")
+
+        proc = _run_install(
+            root,
+            "stable",
+            extra_env={
+                "PFB_SSL_CA_CERT_PATH": str(spaced_dir),
+                "PFB_SSL_CA_CERT_FILE": str(spaced_file),
+            },
+        )
+        assert proc.returncode == 0, proc.stderr
+
+        paths = _pkg_ca_path_capture(root).read_text().splitlines()
+        files = _pkg_ca_file_capture(root).read_text().splitlines()
+        assert paths and files, "no pkg calls were made — the run cannot prove the quoting"
+        assert set(paths) == {str(spaced_dir)}, f"path mangled, saw {sorted(set(paths))}"
+        assert set(files) == {str(spaced_file)}, f"file mangled, saw {sorted(set(files))}"
+
+
+def test_bundle_without_a_directory_exports_only_the_bundle() -> None:
+    """Only the bundle present -> only it is exported (the third guard combination)."""
+    with tempfile.TemporaryDirectory() as root:
+        bundle = _ca_bundle(root)
+        bundle.parent.mkdir(parents=True)
+        bundle.write_text("")
+        assert not _ca_dir(root).exists()
+
+        proc = _run_install(root, "stable")
+        assert proc.returncode == 0, proc.stderr
+
+        paths = _pkg_ca_path_capture(root).read_text().splitlines()
+        files = _pkg_ca_file_capture(root).read_text().splitlines()
+        assert files, "no pkg calls were made — the run cannot prove the branch"
+        assert set(paths) == {"<unset>"}, f"expected SSL_CA_CERT_PATH unset, saw {sorted(set(paths))}"
+        assert set(files) == {str(bundle)}, f"expected the bundle exported, saw {sorted(set(files))}"

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1281,3 +1281,20 @@ def test_empty_bundle_file_is_not_exported() -> None:
         assert files, "no pkg calls were made — the run cannot prove the guard"
         assert set(files) == {"<unset>"}, f"empty bundle was exported, saw {sorted(set(files))}"
         assert set(paths) == {str(ca_dir)}, f"the path must still export, saw {sorted(set(paths))}"
+
+
+def test_directory_as_bundle_is_not_exported() -> None:
+    """A directory where the bundle should be is refused: `-s` alone is true for one."""
+    with tempfile.TemporaryDirectory() as root:
+        ca_dir = _ca_dir(root)
+        ca_dir.mkdir(parents=True)
+        _ca_bundle(root).mkdir(parents=True)  # a directory, not a bundle
+
+        proc = _run_install(root, "stable")
+        assert proc.returncode == 0, proc.stderr
+
+        files = _pkg_ca_file_capture(root).read_text().splitlines()
+        paths = _pkg_ca_path_capture(root).read_text().splitlines()
+        assert files, "no pkg calls were made — the run cannot prove the guard"
+        assert set(files) == {"<unset>"}, f"a directory was exported as the bundle, saw {sorted(set(files))}"
+        assert set(paths) == {str(ca_dir)}, f"the path must still export, saw {sorted(set(paths))}"

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -44,6 +44,7 @@ _PKG_STUB = r"""#!/bin/sh
 ROOT="${PFB_TEST_ROOT}"
 LOG="${ROOT}/pkg-invocations.log"
 printf '%s\n' "$*" >> "${LOG}"
+printf '%s\n' "${SSL_CA_CERT_PATH-<unset>}" >> "${ROOT}/pkg-ca-path.log"
 _stub_byte="$(head -c 1 2>/dev/null)"
 printf '%s' "${_stub_byte}" >> "${ROOT}/pkg-stdin"
 
@@ -202,6 +203,11 @@ def _pkg_stdin_capture(root: str) -> Path:
     return Path(root) / "pkg-stdin"
 
 
+def _pkg_ca_path_capture(root: str) -> Path:
+    """One line per pkg call: the SSL_CA_CERT_PATH it saw, or <unset>."""
+    return Path(root) / "pkg-ca-path.log"
+
+
 def _write_pkg_stub(root: str) -> str:
     """Install the fake pkg(8) binary under root/bin/pkg; return its path."""
     bin_dir = os.path.join(root, "bin")
@@ -215,7 +221,7 @@ def _write_pkg_stub(root: str) -> str:
     # CREATE, never truncate: _run_install re-seeds the stub on every call (including
     # repeated calls on the same root for idempotency/resume tests), and the log must
     # accumulate across those calls for callers that diff before/after content.
-    for p in (_pkg_stdin_capture(root), _pkg_log(root)):
+    for p in (_pkg_stdin_capture(root), _pkg_log(root), _pkg_ca_path_capture(root)):
         if not p.exists():
             p.write_text("")
     return stub_path
@@ -1047,3 +1053,64 @@ def test_install_script_parses_and_carries_required_hook_markers() -> None:
     assert "# PFB_EMBED_HOOK_END" in text
     assert text.startswith("#!/bin/sh\n")
     assert os.access(str(_SCRIPT), os.X_OK), "the repository copy must be executable"
+
+
+# --- SSL_CA_CERT_PATH export (issue #2514) ---------------------------------
+#
+# pfSense Plus pins pkg's CA bundle to Netgate's private CA via the PKG_ENV block
+# pfSense-repo-setup writes into pkg.conf. That bundle carries only Netgate CAs, and
+# libpkg applies it with setenv(..., overwrite=1), so libfetch-based pkg (1.x) ends up
+# with NO public roots and every fetch from our Pages catalog dies with
+# "Certificate verification failed for /C=US/O=ISRG/CN=Root YR".
+#
+# PKG_ENV never sets SSL_CA_CERT_PATH, and libfetch loads both file and path into one
+# store (SSL_CTX_load_verify_locations(ctx, ca_cert_file, ca_cert_path)), so exporting
+# the path survives the pin -- which is exactly what libcurl-based pkg (2.x) already
+# does by default. Verified red->green live on a Plus box with fetch(1).
+
+
+def _ca_dir(root: str) -> Path:
+    return Path(root) / "etc" / "ssl" / "certs"
+
+
+def test_every_pkg_call_exports_the_system_ca_path() -> None:
+    """Every pkg(8) invocation carries SSL_CA_CERT_PATH pointing at the box's store."""
+    with tempfile.TemporaryDirectory() as root:
+        ca_dir = _ca_dir(root)
+        ca_dir.mkdir(parents=True)
+        (ca_dir / "4042bcee.0").write_text("")  # a hashed store is never empty
+
+        proc = _run_install(root, "stable")
+        assert proc.returncode == 0, proc.stderr
+
+        seen = _pkg_ca_path_capture(root).read_text().split()
+        assert seen, "no pkg calls were made — the run cannot prove the export"
+        assert set(seen) == {str(ca_dir)}, (
+            f"expected every pkg call to export SSL_CA_CERT_PATH={ca_dir}, saw {sorted(set(seen))}"
+        )
+
+
+def test_absent_ca_dir_leaves_ssl_ca_cert_path_unset() -> None:
+    """No CA directory on the box -> nothing is exported (never point pkg at a missing path)."""
+    with tempfile.TemporaryDirectory() as root:
+        assert not _ca_dir(root).exists()
+
+        proc = _run_install(root, "stable")
+        assert proc.returncode == 0, proc.stderr
+
+        seen = _pkg_ca_path_capture(root).read_text().split()
+        assert seen, "no pkg calls were made — the run cannot prove the guard"
+        assert set(seen) == {"<unset>"}, f"expected SSL_CA_CERT_PATH unset, saw {sorted(set(seen))}"
+
+
+def test_ca_path_is_overridable() -> None:
+    """PFB_SSL_CA_CERT_PATH overrides the default location."""
+    with tempfile.TemporaryDirectory() as root:
+        override = Path(root) / "custom-store"
+        override.mkdir()
+
+        proc = _run_install(root, "stable", extra_env={"PFB_SSL_CA_CERT_PATH": str(override)})
+        assert proc.returncode == 0, proc.stderr
+
+        seen = _pkg_ca_path_capture(root).read_text().split()
+        assert set(seen) == {str(override)}, f"override ignored, saw {sorted(set(seen))}"

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -320,6 +320,7 @@ def _run_install(
         "PFB_TEST_ROOT": root,
         **(extra_env or {}),
     }
+    env.pop("SSL_CA_CERT_PATH", None)
     if update_fails:
         env["PFB_STUB_UPDATE_FAIL"] = "1"
     if version_t_broken:
@@ -1083,7 +1084,7 @@ def test_every_pkg_call_exports_the_system_ca_path() -> None:
         proc = _run_install(root, "stable")
         assert proc.returncode == 0, proc.stderr
 
-        seen = _pkg_ca_path_capture(root).read_text().split()
+        seen = _pkg_ca_path_capture(root).read_text().splitlines()
         assert seen, "no pkg calls were made — the run cannot prove the export"
         assert set(seen) == {str(ca_dir)}, (
             f"expected every pkg call to export SSL_CA_CERT_PATH={ca_dir}, saw {sorted(set(seen))}"
@@ -1098,7 +1099,7 @@ def test_absent_ca_dir_leaves_ssl_ca_cert_path_unset() -> None:
         proc = _run_install(root, "stable")
         assert proc.returncode == 0, proc.stderr
 
-        seen = _pkg_ca_path_capture(root).read_text().split()
+        seen = _pkg_ca_path_capture(root).read_text().splitlines()
         assert seen, "no pkg calls were made — the run cannot prove the guard"
         assert set(seen) == {"<unset>"}, f"expected SSL_CA_CERT_PATH unset, saw {sorted(set(seen))}"
 
@@ -1112,5 +1113,6 @@ def test_ca_path_is_overridable() -> None:
         proc = _run_install(root, "stable", extra_env={"PFB_SSL_CA_CERT_PATH": str(override)})
         assert proc.returncode == 0, proc.stderr
 
-        seen = _pkg_ca_path_capture(root).read_text().split()
+        seen = _pkg_ca_path_capture(root).read_text().splitlines()
+        assert seen, "no pkg calls were made — the run cannot prove the override"
         assert set(seen) == {str(override)}, f"override ignored, saw {sorted(set(seen))}"

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1158,7 +1158,7 @@ def test_ca_bundle_is_exported_alongside_the_path() -> None:
         ca_dir = _ca_dir(root)
         ca_dir.mkdir(parents=True)
         bundle = _ca_bundle(root)
-        bundle.write_text("")
+        bundle.write_text("# CA bundle\n")
 
         proc = _run_install(root, "stable")
         assert proc.returncode == 0, proc.stderr
@@ -1190,7 +1190,7 @@ def test_ca_locations_survive_a_path_containing_a_space() -> None:
         spaced_dir = Path(root) / "ssl store" / "certs"
         spaced_dir.mkdir(parents=True)
         spaced_file = Path(root) / "ssl store" / "cert bundle.pem"
-        spaced_file.write_text("")
+        spaced_file.write_text("# CA bundle\n")
 
         proc = _run_install(
             root,
@@ -1214,7 +1214,7 @@ def test_bundle_without_a_directory_exports_only_the_bundle() -> None:
     with tempfile.TemporaryDirectory() as root:
         bundle = _ca_bundle(root)
         bundle.parent.mkdir(parents=True)
-        bundle.write_text("")
+        bundle.write_text("# CA bundle\n")
         assert not _ca_dir(root).exists()
 
         proc = _run_install(root, "stable")
@@ -1232,7 +1232,7 @@ def test_empty_path_override_opts_out_of_the_directory() -> None:
     with tempfile.TemporaryDirectory() as root:
         _ca_dir(root).mkdir(parents=True)
         bundle = _ca_bundle(root)
-        bundle.write_text("")
+        bundle.write_text("# CA bundle\n")
 
         proc = _run_install(root, "stable", extra_env={"PFB_SSL_CA_CERT_PATH": ""})
         assert proc.returncode == 0, proc.stderr
@@ -1249,7 +1249,7 @@ def test_empty_bundle_override_opts_out_of_the_file() -> None:
     with tempfile.TemporaryDirectory() as root:
         ca_dir = _ca_dir(root)
         ca_dir.mkdir(parents=True)
-        _ca_bundle(root).write_text("")
+        _ca_bundle(root).write_text("# CA bundle\n")
 
         proc = _run_install(root, "stable", extra_env={"PFB_SSL_CA_CERT_FILE": ""})
         assert proc.returncode == 0, proc.stderr
@@ -1259,3 +1259,25 @@ def test_empty_bundle_override_opts_out_of_the_file() -> None:
         assert files, "no pkg calls were made — the run cannot prove the opt-out"
         assert set(files) == {"<unset>"}, f"opt-out ignored, saw {sorted(set(files))}"
         assert set(paths) == {str(ca_dir)}, f"the other half must still export, saw {sorted(set(paths))}"
+
+
+def test_empty_bundle_file_is_not_exported() -> None:
+    """A zero-byte bundle is refused, because loading it would cost the path too.
+
+    X509_STORE_load_locations() reads the file eagerly and abandons the CApath when that
+    read fails, so pointing pkg at a truncated /etc/ssl/cert.pem would break a box whose
+    hashed directory is perfectly healthy — a state set_default_verify_paths() tolerates.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        ca_dir = _ca_dir(root)
+        ca_dir.mkdir(parents=True)
+        _ca_bundle(root).write_text("")
+
+        proc = _run_install(root, "stable")
+        assert proc.returncode == 0, proc.stderr
+
+        files = _pkg_ca_file_capture(root).read_text().splitlines()
+        paths = _pkg_ca_path_capture(root).read_text().splitlines()
+        assert files, "no pkg calls were made — the run cannot prove the guard"
+        assert set(files) == {"<unset>"}, f"empty bundle was exported, saw {sorted(set(files))}"
+        assert set(paths) == {str(ca_dir)}, f"the path must still export, saw {sorted(set(paths))}"

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -34,6 +34,15 @@ _BASE_URL = "file:///pages-catalog-root"
 _DEFAULT_PAYLOAD_PATH = "/usr/local/pkg/pfblockerng.inc"
 _LEGACY_CONF = "pfblockerng.conf"
 
+# Ambient values for these would decide what the stub records instead of the script's own
+# behaviour, so _run_install drops them from the child environment.
+_CA_ENV_VARS = (
+    "SSL_CA_CERT_PATH",
+    "SSL_CA_CERT_FILE",
+    "PFB_SSL_CA_CERT_PATH",
+    "PFB_SSL_CA_CERT_FILE",
+)
+
 # The fake pkg(8): every call appends its argv (minus argv[0]) to pkg-invocations.log
 # and captures up to one byte of its own stdin (proving the caller redirected
 # </dev/null rather than leaving the piped script text on the fd). State lives under
@@ -222,7 +231,7 @@ def _write_pkg_stub(root: str) -> str:
     with open(stub_path, "w") as fh:
         fh.write(_PKG_STUB)
     os.chmod(stub_path, 0o755)
-    # Both files must pre-exist (possibly empty) so a run that makes zero pkg calls
+    # These capture files must pre-exist (possibly empty) so a run that makes zero pkg calls
     # (e.g. --help) still leaves assertable files for callers that check them. Only
     # CREATE, never truncate: _run_install re-seeds the stub on every call (including
     # repeated calls on the same root for idempotency/resume tests), and the log must
@@ -318,16 +327,19 @@ def _run_install(
         for p in info_paths:
             _seed_payload(root, p)
 
-    env = {
-        **os.environ,
-        "PFBLOCKERNG_ROOT": root,
-        "PKG_BIN": pkg_bin,
-        "PFB_BASE_URL": _BASE_URL,
-        "PFB_TEST_ROOT": root,
-        **(extra_env or {}),
-    }
-    env.pop("SSL_CA_CERT_PATH", None)
-    env.pop("SSL_CA_CERT_FILE", None)
+    # Strip every CA-related variable the developer's shell might carry BEFORE layering
+    # extra_env on top: popping afterwards would delete a test's own override, including
+    # the empty-string opt-out the tests below rely on.
+    env = {k: v for k, v in os.environ.items() if k not in _CA_ENV_VARS}
+    env.update(
+        {
+            "PFBLOCKERNG_ROOT": root,
+            "PKG_BIN": pkg_bin,
+            "PFB_BASE_URL": _BASE_URL,
+            "PFB_TEST_ROOT": root,
+            **(extra_env or {}),
+        }
+    )
     if update_fails:
         env["PFB_STUB_UPDATE_FAIL"] = "1"
     if version_t_broken:
@@ -1213,3 +1225,37 @@ def test_bundle_without_a_directory_exports_only_the_bundle() -> None:
         assert files, "no pkg calls were made — the run cannot prove the branch"
         assert set(paths) == {"<unset>"}, f"expected SSL_CA_CERT_PATH unset, saw {sorted(set(paths))}"
         assert set(files) == {str(bundle)}, f"expected the bundle exported, saw {sorted(set(files))}"
+
+
+def test_empty_path_override_opts_out_of_the_directory() -> None:
+    """PFB_SSL_CA_CERT_PATH="" exports no path — the documented opt-out (`-`, not `:-`)."""
+    with tempfile.TemporaryDirectory() as root:
+        _ca_dir(root).mkdir(parents=True)
+        bundle = _ca_bundle(root)
+        bundle.write_text("")
+
+        proc = _run_install(root, "stable", extra_env={"PFB_SSL_CA_CERT_PATH": ""})
+        assert proc.returncode == 0, proc.stderr
+
+        paths = _pkg_ca_path_capture(root).read_text().splitlines()
+        files = _pkg_ca_file_capture(root).read_text().splitlines()
+        assert paths, "no pkg calls were made — the run cannot prove the opt-out"
+        assert set(paths) == {"<unset>"}, f"opt-out ignored, saw {sorted(set(paths))}"
+        assert set(files) == {str(bundle)}, f"the other half must still export, saw {sorted(set(files))}"
+
+
+def test_empty_bundle_override_opts_out_of_the_file() -> None:
+    """PFB_SSL_CA_CERT_FILE="" exports no bundle, and the path is unaffected."""
+    with tempfile.TemporaryDirectory() as root:
+        ca_dir = _ca_dir(root)
+        ca_dir.mkdir(parents=True)
+        _ca_bundle(root).write_text("")
+
+        proc = _run_install(root, "stable", extra_env={"PFB_SSL_CA_CERT_FILE": ""})
+        assert proc.returncode == 0, proc.stderr
+
+        paths = _pkg_ca_path_capture(root).read_text().splitlines()
+        files = _pkg_ca_file_capture(root).read_text().splitlines()
+        assert files, "no pkg calls were made — the run cannot prove the opt-out"
+        assert set(files) == {"<unset>"}, f"opt-out ignored, saw {sorted(set(files))}"
+        assert set(paths) == {str(ca_dir)}, f"the other half must still export, saw {sorted(set(paths))}"


### PR DESCRIPTION
## What

`install.sh` exports `SSL_CA_CERT_PATH` for every `pkg(8)` call it makes, so third-party
repository fetches verify on pfSense Plus boxes whose `pkg` uses the libfetch backend.

## Why

`pfSense-repo-setup` regenerates `/usr/local/etc/pkg.conf` on Plus and appends:

```
PKG_ENV {
	SSL_CA_CERT_FILE=<netgate-ca.pem>
	SSL_CLIENT_CERT_FILE=...
	SSL_CLIENT_KEY_FILE=...
}
```

That bundle holds four Netgate CAs and no public roots. `libpkg` applies the block with
`setenv(key, value, 1)`, and libfetch then calls
`SSL_CTX_load_verify_locations(ctx, ca_cert_file, ca_cert_path)` with a NULL path, so the
verification store contains Netgate's CAs and nothing else — for every repository in the run.
Reported symptom:

```
Certificate verification failed for /C=US/O=ISRG/CN=Root YR
pkg: https://pfblockerng.github.io/pkg/stable/plus-26.07/meta.txz: Authentication error
```

The user's trust store is not at fault: `certctl list` shows `ISRG Root X1`, nothing ISRG is
distrusted, and `openssl s_client -CApath /etc/ssl/certs` verifies our host. `PKG_ENV` just never
sets `SSL_CA_CERT_PATH`, so an inherited value survives and is loaded alongside the pinned bundle.

A libcurl-based `pkg` (2.x) already does exactly this by default — verified on a live Plus 26.03.1
box running pkg 2.5.1:

```
CAfile: /etc/ssl/netgate-ca.pem
CApath: /etc/ssl/certs/
```

which is why Plus + pkg 2.x is unaffected, Plus + pkg 1.x is broken, and CE is unaffected (the
`PKG_ENV` block is gated on the Plus certificate and key existing).

## Security

Peer verification stays fully enabled. Nothing is disabled, no trust store is modified, no
distrust entry is removed, and no vendor configuration is edited. The change only adds the box's
own certctl-managed store next to Netgate's bundle, and only for pkg calls this script makes.
The export is skipped when the directory does not exist, and `PFB_SSL_CA_CERT_PATH` redirects it.

## Proof

Live red -> green on a Plus box using `fetch(1)`, which shares libfetch with pkg 1.x:

```
RED:   SSL_CA_CERT_FILE=<netgate-ca.pem>
       -> Certificate verification failed for /C=US/O=ISRG/CN=Root YR
GREEN: SSL_CA_CERT_FILE=<netgate-ca.pem> SSL_CA_CERT_PATH=/etc/ssl/certs
       -> Certificate subject: /CN=*.github.io
```

Confirmed end-to-end by the reporting user, whose install completed with the same override.

Test-first, via `scripts/run-in-docker.sh python -m pytest tests/test_channel_install.py`:

* RED: `test_every_pkg_call_exports_the_system_ca_path` and `test_ca_path_is_overridable` failed
  against devel's `install.sh`; re-derived by both review legs. Current test bytes hash to
  `61c785d63b2d1d90bfe70fc6995da6e2e963a293` (the original freeze `4f0cbf847e…` predates the
  review rounds below), 59 passed at head. The hash is stated for the current head only — it moves
  with every review round, so treat the mutation matrix below as the durable proof.
* Every guard is mutation-proven: reverting to path-only, dropping either `-d`/`-f` guard,
  unquoting a location, or exporting an empty value each turns tests red.
* `scripts/agent/run-gates.sh`: GATES PASS.

`pkg-site/install.sh` is a symlink to `scripts/install.sh`, so the published client script carries
the same change.

## Review rounds

Two blocking findings, both fixed in this branch:

* **Test-honesty**: `.split()` dropped empty fields, so a pkg call exporting an empty
  `SSL_CA_CERT_PATH` left no record and all tests still passed — demonstrated by mutating the
  `update` verb alone. Fixed in `8968f28e` (`splitlines()`), and that mutation is now red.
* **Security round 2 + correctness round 2**: `-f` admitted a zero-byte bundle, which
  `X509_STORE_load_locations()` would load eagerly and then abandon the CApath — breaking a box
  that works today. Now `-f` AND `-s`: `-s` alone is true for a directory, so both checks are
  needed, each pinned by its own test (`fad771b3`, `105bcd12`).
* **Test-honesty round 2**: the documented empty-string opt-out was unfalsifiable — switching the
  defaults back to `:-` passed. Pinned per half in `24df2e6e`, along with a harness fix: the
  environment strip now runs BEFORE `extra_env` is layered, since popping afterwards deleted the
  very overrides those tests pass in.
* **Security + correctness round 1 (found independently by both legs)**: the `-d`-only guard was a
  regression path on CE. libfetch takes `SSL_CTX_load_verify_locations(file, path)` as soon as
  either variable is set and otherwise `SSL_CTX_set_default_verify_paths()`, so exporting the path
  alone dropped `/etc/ssl/cert.pem` from the store — and FreeBSD ships `/etc/ssl/certs` empty until
  `certctl rehash` populates it. Fixed in `c0bcfc60`: both locations are exported, each guarded on
  its own existence, with a new test per branch and one for quoting.

## Not covered

`pfb_pkg_latest()` in `pfblockerng.inc` runs `pkg update -f -r` + `pkg rquery` against our repo and
fails the same way on affected boxes, silently (returns `''`, caller serves cache). That is the
second half of #2514 and is tracked in **#2516** — a `src/` PHP change with its own PHPUnit
coverage, deliberately kept out of this PR so the review scope stays coherent.

Bare `pkg upgrade` and the GUI Package Manager still fail on affected boxes, since only the calls
we make can carry the variables, and FreeBSD has no global environment file. Making those
work would mean editing Netgate's generated `pkg.conf`, which `pfSense-repo-setup` rewrites from
scratch on upgrades and branch switches. The upstream fix is one line in that generator
(`SSL_CA_CERT_PATH=/etc/ssl/certs` inside `PKG_ENV`), which preserves their pin and unbreaks every
third-party repository; worth reporting to Netgate separately.

Part of #2514
