### PR TITLE
pfblockerng: carry the box's CA locations on the Software catalog reads (issue #2516)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5144,6 +5144,17 @@ function pfb_should_notify(?string $installed, ?string $latest, ?string $last_no
  */
 define('PFB_PKG_BIN', '/usr/local/sbin/pkg');
 
+/*
+ * The box's own CA locations, handed to every networked pkg call we make (issue #2514).
+ * On Plus, pfSense-repo-setup pins SSL_CA_CERT_FILE to a Netgate-only bundle through the
+ * PKG_ENV block in pkg.conf, which libpkg applies with setenv(key, value, 1) — so a value
+ * we pass for THAT variable is overwritten and lost. PKG_ENV never sets SSL_CA_CERT_PATH,
+ * and libfetch loads both into one store via
+ * SSL_CTX_load_verify_locations(ctx, ca_cert_file, ca_cert_path), so the path survives.
+ */
+define('PFB_SSL_CA_CERT_PATH', '/etc/ssl/certs');
+define('PFB_SSL_CA_CERT_FILE', '/etc/ssl/cert.pem');
+
 if (!defined('PFB_PYTHON_WRAPPER')) {
 	define('PFB_PYTHON_WRAPPER', __DIR__ . '/pfb_python.sh');
 }
@@ -5299,6 +5310,34 @@ function pfb_pkg_newest_version(array $versions): string {
  *   - DNS is unavailable (get_dnsavailable()) — never stall on a network read;
  *   - the rquery yields nothing (repo/conf absent).
  */
+/*
+ * Shell-ready `VAR=value ` assignments placing the box's CA locations in front of a pkg
+ * command, or '' when there is nothing safe to point at. Splice it BEFORE any wrapper so
+ * the assignments apply to the whole pipeline and are inherited by pkg itself.
+ *
+ * The bundle rides along with the path because libfetch stops calling
+ * SSL_CTX_set_default_verify_paths() as soon as EITHER variable is set: on a box with no
+ * pin, a path-only export would shrink the store to a directory FreeBSD ships empty until
+ * certctl rehash populates it. The bundle is required to be a NON-EMPTY REGULAR FILE
+ * because X509_STORE_load_locations() reads it eagerly and abandons the path when that
+ * read fails, so an empty or non-file bundle would cost the directory too. An empty
+ * argument opts that half out, mirroring install.sh's PFB_SSL_CA_CERT_* knobs.
+ */
+function pfb_pkg_ca_env_prefix(string $ca_path = PFB_SSL_CA_CERT_PATH, string $ca_file = PFB_SSL_CA_CERT_FILE): string {
+
+	$parts = array();
+	if ($ca_path !== '' && is_dir($ca_path)) {
+		$parts[] = 'SSL_CA_CERT_PATH=' . escapeshellarg($ca_path);
+	}
+	if ($ca_file !== '' && is_file($ca_file) && is_readable($ca_file) && (int) @filesize($ca_file) > 0) {
+		$parts[] = 'SSL_CA_CERT_FILE=' . escapeshellarg($ca_file);
+	}
+	if ($parts === array()) {
+		return '';
+	}
+	return implode(' ', $parts) . ' ';
+}
+
 function pfb_pkg_latest(string $pkgname, string $reponame): string {
 	if ($pkgname === '' || $reponame === '') {
 		return '';
@@ -5314,12 +5353,16 @@ function pfb_pkg_latest(string $pkgname, string $reponame): string {
 	// Bound both networked pkg calls with timeout(1) (same idiom as the hook runner) so a
 	// hung mirror can never stall the cron pass or the page's forced "Check now".
 	$tmo = '/usr/bin/timeout -s TERM -k 5 60 ';
+	// Both commands below open a socket, so both carry the CA locations (issue #2514). The
+	// prefix leads so the assignments cover timeout(1) and are inherited by pkg; the local
+	// `pkg query` reads elsewhere in this file never fetch and are deliberately untouched.
+	$ca = pfb_pkg_ca_env_prefix();
 	// Forced catalog refresh of the pfBlockerNG repo only; ignore failures (stale DB still reads).
 	// -f is required: Pages/file:// catalogs can keep an unchanged mtime/etag (issue #2379).
-	exec("{$tmo}{$bin} update -f -r {$repo} 2>/dev/null");
+	exec("{$ca}{$tmo}{$bin} update -f -r {$repo} 2>/dev/null");
 	$out = array();
 	$ret = -1;
-	exec("{$tmo}{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
+	exec("{$ca}{$tmo}{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
 	if ($ret !== 0 || $out === array()) {
 		return '';
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5300,17 +5300,6 @@ function pfb_pkg_newest_version(array $versions): string {
 }
 
 /*
- * The pfBlockerNG repo's latest version of $pkgname: `pkg update -f -r <repo>` (forced
- * refresh of just that repo's catalog DB) then `pkg rquery -r <repo> '%v' <pkgname>`.
- * Reads ONLY that repo ($reponame) — never -r pfSense / get_pkg_info (ADR-19 §2 "Read
- * latest"). Picks the newest rquery line with pkg_version_compare(); $out[0] is catalog
- * order, not newest (issue #2379). Returns '' (the caller then serves cache) when:
- *   - $pkgname/$reponame is empty;
- *   - the pkg subsystem is locked (is_subsystem_dirty('pkg')) — never fight a base update;
- *   - DNS is unavailable (get_dnsavailable()) — never stall on a network read;
- *   - the rquery yields nothing (repo/conf absent).
- */
-/*
  * Shell-ready `VAR=value ` assignments placing the box's CA locations in front of a pkg
  * command, or '' when there is nothing safe to point at. Splice it BEFORE any wrapper so
  * the assignments apply to the whole pipeline and are inherited by pkg itself.
@@ -5338,6 +5327,17 @@ function pfb_pkg_ca_env_prefix(string $ca_path = PFB_SSL_CA_CERT_PATH, string $c
 	return implode(' ', $parts) . ' ';
 }
 
+/*
+ * The pfBlockerNG repo's latest version of $pkgname: `pkg update -f -r <repo>` (forced
+ * refresh of just that repo's catalog DB) then `pkg rquery -r <repo> '%v' <pkgname>`.
+ * Reads ONLY that repo ($reponame) — never -r pfSense / get_pkg_info (ADR-19 §2 "Read
+ * latest"). Picks the newest rquery line with pkg_version_compare(); $out[0] is catalog
+ * order, not newest (issue #2379). Returns '' (the caller then serves cache) when:
+ *   - $pkgname/$reponame is empty;
+ *   - the pkg subsystem is locked (is_subsystem_dirty('pkg')) — never fight a base update;
+ *   - DNS is unavailable (get_dnsavailable()) — never stall on a network read;
+ *   - the rquery yields nothing (repo/conf absent).
+ */
 function pfb_pkg_latest(string $pkgname, string $reponame): string {
 	if ($pkgname === '' || $reponame === '') {
 		return '';

--- a/tests/php/PkgCaEnvPrefixTest.php
+++ b/tests/php/PkgCaEnvPrefixTest.php
@@ -36,8 +36,11 @@ final class PkgCaEnvPrefixTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach (['/certs/x.0', '/certs', '/cert.pem', '/bundle dir'] as $leaf) {
+		foreach (['/certs/x.0', '/certs', '/cert.pem', '/bundle dir', "/cert's dir"] as $leaf) {
 			$p = $this->root . $leaf;
+			if (is_file($p)) {
+				@chmod($p, 0o644);
+			}
 			if (is_file($p)) {
 				unlink($p);
 			} elseif (is_dir($p)) {
@@ -111,6 +114,22 @@ final class PkgCaEnvPrefixTest extends TestCase
 		);
 	}
 
+	public function testUnreadableBundleIsRefusedButTheDirectoryStillExports(): void
+	{
+		if (posix_getuid() === 0) {
+			$this->markTestSkipped('root reads mode-0000 files, so the guard cannot be observed as root');
+		}
+		$dir = $this->seedDir();
+		$file = $this->seedBundle();
+		chmod($file, 0o000);
+
+		$this->assertSame(
+			'SSL_CA_CERT_PATH=' . escapeshellarg($dir) . ' ',
+			pfb_pkg_ca_env_prefix($dir, $file),
+			'a bundle pkg cannot read would fail the eager load and cost the directory with it'
+		);
+	}
+
 	public function testDirectoryAtTheBundlePathIsRefused(): void
 	{
 		$dir = $this->seedDir();
@@ -164,15 +183,19 @@ final class PkgCaEnvPrefixTest extends TestCase
 
 	public function testLocationsWithShellMetacharactersAreQuoted(): void
 	{
-		$dir = $this->root . '/certs';
+		$dir = $this->root . "/cert's dir";
 		mkdir($dir, 0o755, true);
 		$file = $this->root . '/cert.pem';
 		file_put_contents($file, "x\n");
 
 		$prefix = pfb_pkg_ca_env_prefix($dir, $file);
 
-		$this->assertStringContainsString(escapeshellarg($dir), $prefix, 'the path must be quoted');
-		$this->assertStringContainsString(escapeshellarg($file), $prefix, 'the bundle must be quoted');
+		// Expectation written out by hand rather than through escapeshellarg(), which would
+		// pass for naive quoting too: a single quote must close, escape, and reopen.
+		$expected = "SSL_CA_CERT_PATH='" . $this->root . "/cert'\\''s dir' "
+			. "SSL_CA_CERT_FILE='" . $this->root . "/cert.pem' ";
+
+		$this->assertSame($expected, $prefix, 'a quote in a path must be shell-escaped, not passed through');
 		$this->assertStringEndsWith(' ', $prefix, 'the prefix must be splice-ready');
 	}
 
@@ -196,22 +219,20 @@ final class PkgCaEnvPrefixTest extends TestCase
 			$body,
 			'the catalog read must carry the CA locations'
 		);
-		// Asserting a COUNT would let a third, unprefixed exec() slip in unnoticed — which is
-		// the regression this test exists to catch. Assert the property instead: every command
-		// this function shells out must lead with the prefix.
-		$this->assertSame(
-			1,
-			preg_match_all('/exec\(/', $body) > 0 ? 1 : 0,
-			'pfb_pkg_latest() must still shell out at all'
-		);
-		preg_match_all('/exec\(\s*"([^"]*)"/', $body, $m);
-		$this->assertNotEmpty($m[1], 'no double-quoted exec() command found to inspect');
-		foreach ($m[1] as $cmd) {
+		// Inspect EVERY exec( site, not just the double-quoted ones: reading only string
+		// literals would let `$cmd = "..."; exec($cmd);` route around the prefix.
+		$offset = 0;
+		$sites = 0;
+		while (($at = strpos($body, 'exec(', $offset)) !== false) {
+			$sites++;
 			$this->assertStringStartsWith(
-				'{$ca}{$tmo}',
-				$cmd,
-				"every command pfb_pkg_latest() runs must carry the CA prefix before the timeout wrapper, found: {$cmd}"
+				'exec("{$ca}{$tmo}',
+				substr($body, $at, 40),
+				'every command pfb_pkg_latest() runs must be a literal leading with the CA prefix, found: '
+					. substr($body, $at, 40)
 			);
+			$offset = $at + 5;
 		}
+		$this->assertGreaterThan(0, $sites, 'pfb_pkg_latest() must still shell out at all');
 	}
 }

--- a/tests/php/PkgCaEnvPrefixTest.php
+++ b/tests/php/PkgCaEnvPrefixTest.php
@@ -116,8 +116,8 @@ final class PkgCaEnvPrefixTest extends TestCase
 
 	public function testUnreadableBundleIsRefusedButTheDirectoryStillExports(): void
 	{
-		if (posix_getuid() === 0) {
-			$this->markTestSkipped('root reads mode-0000 files, so the guard cannot be observed as root');
+		if (!function_exists('posix_getuid') || posix_getuid() === 0) {
+			$this->markTestSkipped('root reads mode-0000 files, and without ext-posix the uid is unknown');
 		}
 		$dir = $this->seedDir();
 		$file = $this->seedBundle();
@@ -221,6 +221,12 @@ final class PkgCaEnvPrefixTest extends TestCase
 		);
 		// Inspect EVERY exec( site, not just the double-quoted ones: reading only string
 		// literals would let `$cmd = "..."; exec($cmd);` route around the prefix.
+		//
+		// This pins spelling, deliberately: renaming $ca, reformatting the call across lines, or
+		// writing the token exec( in a comment all turn it red. That is the price of a source
+		// check, and it is the cheaper half of the trade while pkg cannot be intercepted here.
+		// It covers exec( only — system(), passthru() and backticks would pass unseen, and no
+		// call site in this function uses them.
 		$offset = 0;
 		$sites = 0;
 		while (($at = strpos($body, 'exec(', $offset)) !== false) {

--- a/tests/php/PkgCaEnvPrefixTest.php
+++ b/tests/php/PkgCaEnvPrefixTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2516 — the CA locations our networked pkg calls carry (issue #2514).
+ *
+ * Background: on pfSense Plus, pfSense-repo-setup writes a PKG_ENV block into pkg.conf
+ * pinning SSL_CA_CERT_FILE to a Netgate-only CA bundle, and libpkg applies that block with
+ * setenv(key, value, 1) — overwrite — so a value we pass for that variable loses. PKG_ENV
+ * never sets SSL_CA_CERT_PATH, and libfetch loads file and path into one store via
+ * SSL_CTX_load_verify_locations(ctx, ca_cert_file, ca_cert_path), so the path survives the
+ * pin and gives a third-party catalog read the public roots it was missing.
+ *
+ * The bundle rides along because libfetch stops calling SSL_CTX_set_default_verify_paths()
+ * as soon as EITHER variable is set: on a box with no pin, exporting the path alone would
+ * SHRINK the store to a directory FreeBSD ships empty until certctl rehash populates it.
+ *
+ * These pin the prefix builder, whose output is spliced in front of the two networked pkg
+ * commands in pfb_pkg_latest(). Every case asserts the exact string, so a guard that stops
+ * guarding is red rather than merely different.
+ */
+#[CoversFunction('pfb_pkg_ca_env_prefix')]
+final class PkgCaEnvPrefixTest extends TestCase
+{
+	private string $root = '';
+
+	protected function setUp(): void
+	{
+		$this->root = sys_get_temp_dir() . '/pfb-ca-' . bin2hex(random_bytes(6));
+		mkdir($this->root, 0o755, true);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (['/certs/x.0', '/certs', '/cert.pem', '/bundle dir'] as $leaf) {
+			$p = $this->root . $leaf;
+			if (is_file($p)) {
+				unlink($p);
+			} elseif (is_dir($p)) {
+				rmdir($p);
+			}
+		}
+		if (is_dir($this->root)) {
+			rmdir($this->root);
+		}
+	}
+
+	private function seedDir(): string
+	{
+		$dir = $this->root . '/certs';
+		mkdir($dir, 0o755, true);
+		file_put_contents($dir . '/x.0', "");
+		return $dir;
+	}
+
+	private function seedBundle(string $content = "-----BEGIN CERTIFICATE-----\n"): string
+	{
+		$file = $this->root . '/cert.pem';
+		file_put_contents($file, $content);
+		return $file;
+	}
+
+	public function testBothLocationsPresentAreBothExported(): void
+	{
+		$dir = $this->seedDir();
+		$file = $this->seedBundle();
+
+		$this->assertSame(
+			'SSL_CA_CERT_PATH=' . escapeshellarg($dir) . ' SSL_CA_CERT_FILE=' . escapeshellarg($file) . ' ',
+			pfb_pkg_ca_env_prefix($dir, $file),
+			'both locations exist, so both must reach pkg'
+		);
+	}
+
+	public function testMissingDirectoryExportsOnlyTheBundle(): void
+	{
+		$file = $this->seedBundle();
+
+		$this->assertSame(
+			'SSL_CA_CERT_FILE=' . escapeshellarg($file) . ' ',
+			pfb_pkg_ca_env_prefix($this->root . '/certs', $file),
+			'a missing directory must not be handed to pkg'
+		);
+	}
+
+	public function testMissingBundleExportsOnlyTheDirectory(): void
+	{
+		$dir = $this->seedDir();
+
+		$this->assertSame(
+			'SSL_CA_CERT_PATH=' . escapeshellarg($dir) . ' ',
+			pfb_pkg_ca_env_prefix($dir, $this->root . '/cert.pem'),
+			'a missing bundle must not be handed to pkg'
+		);
+	}
+
+	public function testEmptyBundleIsRefusedButTheDirectoryStillExports(): void
+	{
+		$dir = $this->seedDir();
+		$file = $this->seedBundle('');
+
+		$this->assertSame(
+			'SSL_CA_CERT_PATH=' . escapeshellarg($dir) . ' ',
+			pfb_pkg_ca_env_prefix($dir, $file),
+			'X509_STORE_load_locations() reads the file eagerly and abandons the path when that '
+			. 'read fails, so a zero-byte bundle would cost the directory too'
+		);
+	}
+
+	public function testDirectoryAtTheBundlePathIsRefused(): void
+	{
+		$dir = $this->seedDir();
+		$notABundle = $this->root . '/bundle dir';
+		mkdir($notABundle, 0o755, true);
+
+		$this->assertSame(
+			'SSL_CA_CERT_PATH=' . escapeshellarg($dir) . ' ',
+			pfb_pkg_ca_env_prefix($dir, $notABundle),
+			'a directory is not a bundle, however non-empty it looks'
+		);
+	}
+
+	public function testRegularFileAtTheDirectoryPathIsRefused(): void
+	{
+		$file = $this->seedBundle();
+		$notADir = $this->root . '/cert.pem';
+
+		$this->assertSame(
+			'SSL_CA_CERT_FILE=' . escapeshellarg($file) . ' ',
+			pfb_pkg_ca_env_prefix($notADir, $file),
+			'a regular file is not a hashed store, and CApath must be a directory'
+		);
+	}
+
+	public function testNeitherLocationPresentYieldsAnEmptyPrefix(): void
+	{
+		$this->assertSame(
+			'',
+			pfb_pkg_ca_env_prefix($this->root . '/certs', $this->root . '/cert.pem'),
+			'with nothing to point at, the command must be left exactly as it was'
+		);
+	}
+
+	public function testEmptyLocationOptsThatHalfOut(): void
+	{
+		$dir = $this->seedDir();
+		$file = $this->seedBundle();
+
+		$this->assertSame(
+			'SSL_CA_CERT_FILE=' . escapeshellarg($file) . ' ',
+			pfb_pkg_ca_env_prefix('', $file),
+			'an empty path is an opt-out, not a location to test'
+		);
+		$this->assertSame(
+			'SSL_CA_CERT_PATH=' . escapeshellarg($dir) . ' ',
+			pfb_pkg_ca_env_prefix($dir, ''),
+			'an empty bundle is an opt-out, not a location to test'
+		);
+	}
+
+	public function testLocationsWithShellMetacharactersAreQuoted(): void
+	{
+		$dir = $this->root . '/certs';
+		mkdir($dir, 0o755, true);
+		$file = $this->root . '/cert.pem';
+		file_put_contents($file, "x\n");
+
+		$prefix = pfb_pkg_ca_env_prefix($dir, $file);
+
+		$this->assertStringContainsString(escapeshellarg($dir), $prefix, 'the path must be quoted');
+		$this->assertStringContainsString(escapeshellarg($file), $prefix, 'the bundle must be quoted');
+		$this->assertStringEndsWith(' ', $prefix, 'the prefix must be splice-ready');
+	}
+
+	/**
+	 * Wiring: both networked commands in pfb_pkg_latest() must carry the prefix, and it has
+	 * to sit in FRONT of the timeout(1) wrapper so the assignments reach pkg itself. The
+	 * local `pkg query` reads are deliberately untouched — they never open a socket.
+	 */
+	public function testPkgLatestSplicesThePrefixBeforeTheTimeoutWrapper(): void
+	{
+		$src = (string) file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		$start = strpos($src, 'function pfb_pkg_latest(');
+		$this->assertNotFalse($start, 'pfb_pkg_latest() is missing');
+		$end = strpos($src, "\nfunction ", $start + 1);
+		$body = $end === false ? substr($src, $start) : substr($src, $start, $end - $start);
+
+		$this->assertStringContainsString(
+			'pfb_pkg_ca_env_prefix()',
+			$body,
+			'the catalog read must carry the CA locations'
+		);
+		$this->assertSame(
+			2,
+			preg_match_all('/exec\("\{\$ca\}\{\$tmo\}/', $body),
+			'both networked commands must place the CA prefix before the timeout wrapper'
+		);
+	}
+}

--- a/tests/php/PkgCaEnvPrefixTest.php
+++ b/tests/php/PkgCaEnvPrefixTest.php
@@ -196,10 +196,22 @@ final class PkgCaEnvPrefixTest extends TestCase
 			$body,
 			'the catalog read must carry the CA locations'
 		);
+		// Asserting a COUNT would let a third, unprefixed exec() slip in unnoticed — which is
+		// the regression this test exists to catch. Assert the property instead: every command
+		// this function shells out must lead with the prefix.
 		$this->assertSame(
-			2,
-			preg_match_all('/exec\("\{\$ca\}\{\$tmo\}/', $body),
-			'both networked commands must place the CA prefix before the timeout wrapper'
+			1,
+			preg_match_all('/exec\(/', $body) > 0 ? 1 : 0,
+			'pfb_pkg_latest() must still shell out at all'
 		);
+		preg_match_all('/exec\(\s*"([^"]*)"/', $body, $m);
+		$this->assertNotEmpty($m[1], 'no double-quoted exec() command found to inspect');
+		foreach ($m[1] as $cmd) {
+			$this->assertStringStartsWith(
+				'{$ca}{$tmo}',
+				$cmd,
+				"every command pfb_pkg_latest() runs must carry the CA prefix before the timeout wrapper, found: {$cmd}"
+			);
+		}
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -8879,6 +8879,26 @@
             }
         ]
     },
+    "pfb_pkg_ca_env_prefix": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "ca_path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'/etc/ssl/certs'"
+            },
+            {
+                "name": "ca_file",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'/etc/ssl/cert.pem'"
+            }
+        ]
+    },
     "pfb_pkg_installed_name": {
         "returnsRef": false,
         "returnType": "string",


### PR DESCRIPTION
## What

`pfb_pkg_latest()` now carries the box's own CA locations on its two networked pkg commands, so
the Software tab's catalog read works on pfSense Plus boxes subject to the Netgate CA pin.

## Why

Both commands in that function fetch from our repository:

```php
exec("{$ca}{$tmo}{$bin} update -f -r {$repo} 2>/dev/null");
exec("{$ca}{$tmo}{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
```

On Plus, `pfSense-repo-setup` writes a `PKG_ENV` block into `pkg.conf` pinning
`SSL_CA_CERT_FILE` to a Netgate-only CA bundle (#2514), so both verify against Netgate's CAs and
nothing else. **The failure is silent**: a non-zero `rquery` returns `''`, the caller serves the
cache, and the Software tab reports a stale "latest" forever with nothing in the UI or the log.

`libpkg` applies `PKG_ENV` with `setenv(key, value, 1)`, so passing `SSL_CA_CERT_FILE` ourselves is
overwritten. `PKG_ENV` never sets `SSL_CA_CERT_PATH`, and libfetch loads file and path into one
store, so the path survives the pin. The bundle rides along because libfetch stops calling
`SSL_CTX_set_default_verify_paths()` once either variable is set — the same reasoning and the same
guards as `install.sh` in PR #2515.

## Shape

`pfb_pkg_ca_env_prefix()` returns shell-ready assignments, or `''` when there is nothing safe to
point at:

* the path must be a **directory**, the bundle a **non-empty regular file** —
  `X509_STORE_load_locations()` reads the file eagerly and abandons the path when that read fails,
  so a zero-byte or non-file bundle would cost the directory too;
* an empty argument opts that half out, mirroring `install.sh`'s `PFB_SSL_CA_CERT_*` knobs;
* the prefix leads the command so the assignments cover `timeout(1)` and are inherited by pkg.

The four local `pkg query` reads elsewhere in this file never open a socket and are untouched (the tree has eight pkg shell-outs in total; the other two live in `pfb_python.sh` and are also local).

## Security

Peer verification stays fully enabled. No trust store is modified, no vendor configuration is
edited, and both locations are quoted with `escapeshellarg()`. This only adds the box's own
certctl-managed store next to whatever bundle is pinned.

## Proof

Test-first, via `scripts/run-in-docker.sh vendor/bin/phpunit`:

* RED before the edit: the 9-test file (blob `aa5f0974…`) against the parent's `pfblockerng.inc`
  gave 8 errors (function undefined) + 1 wiring failure; the same bytes against the implemented
  head gave `OK (9 tests)`. That is the frozen cycle.
* The file then GREW twice, so the **committed** blob is ``fa003e08f01ae9458f7e715a3f8993fe4d8e3817``, not the frozen one — each
  growth was a surviving mutation forcing a new case, and the committed file against the parent
  is still red. Recording the movement rather than quoting a stale digest: a single hash is not a
  durable artifact for a file that review rounds keep extending.
* Mutations, each red: drop the empty-bundle guard; drop `is_readable()`; weaken `is_dir()` to
  `file_exists()`; remove the prefix from either networked call; hide a command in a variable to
  route around the prefix; replace `escapeshellarg()` with naive quoting.
* Four mutations survived a first pass and each forced a real test:
  `testRegularFileAtTheDirectoryPathIsRefused`, `testUnreadableBundleIsRefusedButTheDirectoryStillExports`,
  the every-`exec(`-site wiring property, and a hand-written quoting expectation.
* Full PHP suite: 5341 tests, 0 failures. `scripts/agent/run-gates.sh`: GATES PASS.
* The function inventory golden is regenerated; the diff adds only `pfb_pkg_ca_env_prefix`.

## Not covered

`System > Package Manager` and bare `pkg upgrade` still fail on affected boxes — those are pkg
processes we do not launch, and PHP's `proc_open` in `pkg_call()` replaces the child environment
outright, so nothing external can reach them. That needs the `pkg.conf` route, designed under
**#2518** (consented, with a notice).

Part of #2516
