### PR TITLE
site: localize timestamps and add browse icons

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -138,6 +138,12 @@ def artifact_datetime(epoch: float) -> str:
     return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
 
+def _time_html(epoch: float) -> str:
+    """Semantic UTC instant with deterministic fallback text for browser localization."""
+    instant = datetime.fromtimestamp(epoch, tz=timezone.utc)
+    return f'<time datetime="{instant:%Y-%m-%dT%H:%M:%SZ}">{instant:%Y-%m-%d %H:%M UTC}</time>'
+
+
 def _build_record(manifest: dict) -> dict:
     """The embedded ``pfb_build_record`` annotation, parsed — ``{}`` when absent/bad.
 
@@ -296,6 +302,7 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
             if not is_pfblockerng_package(name):
                 continue  # a published dependency (issue #1806) — browsable, never a channel row
             deps = man.get("deps") or {}
+            published_epoch = artifact_epoch(man)
             pkgs.append(
                 {
                     "channel": channel,
@@ -303,7 +310,8 @@ def collect_packages(site: str, read_manifest: Callable[[str], dict] | None = No
                     "version": ver,
                     "abi": abi,
                     "size": os.path.getsize(path),
-                    "published": published_datetime(man),
+                    "published": artifact_datetime(published_epoch) if published_epoch is not None else "",
+                    "published_epoch": published_epoch,
                     "commit": commit_sha(man),
                     # PHP/Python the build targets, read from its RUN_DEPENDS — the fallback
                     # for an ABI the matrix doesn't cover (the matrix value wins when joined).
@@ -375,6 +383,7 @@ a.browse{display:inline-flex;align-items:center;min-height:46px;padding:.65rem 1
 a.browse:hover{border-color:var(--accent);background:var(--accent-soft);color:var(--accent)}
 table.autoindex td:first-child{white-space:normal;overflow-wrap:anywhere}
 table.autoindex td.num{white-space:nowrap}
+.entry-icon{display:inline-block;width:1.5em;margin-right:.25em;text-align:center}
 .listing-page .pkg-shell{min-height:calc(100vh - 68px)}
 .listing-hero{padding-bottom:2rem}
 .listing-hero h1{font-size:clamp(2.4rem,6vw,4.8rem)}
@@ -454,6 +463,14 @@ _COPY_JS = (
     "if(navigator.clipboard&&navigator.clipboard.writeText){"
     "navigator.clipboard.writeText(t).then(done).catch(function(){fb(t,done);});}"
     "else{fb(t,done);}});})();"
+)
+
+_LOCAL_TIME_JS = (
+    "(function(){function p(n){return String(n).padStart(2,'0');}"
+    "document.querySelectorAll('time[datetime]').forEach(function(t){"
+    "var d=new Date(t.dateTime);if(Number.isNaN(d.getTime()))return;"
+    "t.textContent=d.getFullYear()+'-'+p(d.getMonth()+1)+'-'+p(d.getDate())+' '+p(d.getHours())+':'+p(d.getMinutes());"
+    "});})();"
 )
 
 
@@ -767,13 +784,15 @@ def _versions_table_html(rows: list[dict], *, with_channel: bool) -> str:
 
 def _row_html(r: dict, *, with_channel: bool) -> str:
     channel_td = f"<td>{_esc(r['channel'])}</td>" if with_channel else ""
+    published_epoch = r.get("published_epoch")
+    published = _time_html(published_epoch) if published_epoch is not None else _or_dash(r.get("published", ""))
     return (
         f"<tr><td>{_or_dash(r.get('pfsense_version', ''))}</td>{channel_td}"
         f'<td><a href="./{_esc(r["rel"])}">{_esc(r["version"])}</a></td>'
         f"<td><code>{_esc(r['abi'])}</code></td>"
         f'<td class="num">{_or_dash(r.get("php", ""))}</td>'
         f'<td class="num">{_or_dash(r.get("py", ""))}</td>'
-        f'<td class="num">{_or_dash(r.get("published", ""))}</td>'
+        f'<td class="num">{published}</td>'
         f"<td>{commit_cell(r.get('commit', ''))}</td>"
         f'<td class="num">{_esc(human_size(r["size"]))}</td></tr>'
     )
@@ -1033,14 +1052,14 @@ def render_page(
         '<p class="blurb">Browse every channel, version and ABI &mdash; and the raw pkg(8) catalogs your '
         "firewall fetches &mdash; in a directory-style listing.</p>"
         '<p><a class="browse" href="./browse.html">&#128193; Browse the repository &rarr;</a></p></section>'
-        f"</main>{_SITE_FOOTER}<script>{_COPY_JS}</script></body></html>\n"
+        f"</main>{_SITE_FOOTER}<script>{_LOCAL_TIME_JS}{_COPY_JS}</script></body></html>\n"
     )
 
 
 def _epoch_cell(epoch: float | None) -> str:
     """The Last-modified cell for an optional epoch — an em dash when absent (issue
     #2450: never a file mtime)."""
-    return _or_dash(artifact_datetime(epoch) if epoch is not None else "")
+    return _time_html(epoch) if epoch is not None else _or_dash("")
 
 
 def _render_listing_html(title: str, home_href: str, rows: list[str]) -> str:
@@ -1058,8 +1077,13 @@ def _render_listing_html(title: str, home_href: str, rows: list[str]) -> str:
         f"<tbody>{''.join(rows)}</tbody></table></div>"
         '<p class="listing-note">Directory listing of the self-hosted pfBlockerNG pkg repository. '
         "pkg(8) fetches the catalog files (<code>meta.conf</code>, <code>packagesite.pkg</code>, …) directly.</p>"
-        f"</section></main>{_SITE_FOOTER}</body></html>\n"
+        f"</section></main>{_SITE_FOOTER}<script>{_LOCAL_TIME_JS}</script></body></html>\n"
     )
+
+
+def _entry_link(href: str, label: str, *, directory: bool) -> str:
+    icon = "&#128193;" if directory else "&#128196;"
+    return f'<a href="{_esc(href)}"><span class="entry-icon" aria-hidden="true">{icon}</span>{_esc(label)}</a>'
 
 
 def _root_files(built: dict[str, tuple[bytes, int]]) -> list[str]:
@@ -1083,16 +1107,14 @@ def render_browse_root(docs: str, built: dict[str, tuple[bytes, int]]) -> str:
     rows: list[str] = []
     for ch in CH_ORDER:
         if os.path.isdir(os.path.join(docs, ch)):
-            esc = _esc(ch)
             rows.append(
-                f'<tr><td><a href="./browse/{esc}/">{esc}/</a></td>'
+                f"<tr><td>{_entry_link(f'./browse/{ch}/', f'{ch}/', directory=True)}</td>"
                 '<td class="num">&mdash;</td><td class="num">&mdash;</td></tr>'
             )
     for name in _root_files(built):
         data, _mode = built[name]
-        esc = _esc(name)
         rows.append(
-            f'<tr><td><a href="./{esc}">{esc}</a></td>'
+            f"<tr><td>{_entry_link(f'./{name}', name, directory=False)}</td>"
             f'<td class="num">{_epoch_cell(None)}</td>'
             f'<td class="num">{_esc(human_size(len(data)))}</td></tr>'
         )
@@ -1126,7 +1148,7 @@ def _render_catalogue_browse_page(docs: str, full_rel: str) -> str:
     rows: list[str] = []
     parent_href = f"{climb}browse.html" if is_channel_root else "../"
     rows.append(
-        f'<tr><td><a href="{_esc(parent_href)}">../</a></td>'
+        f"<tr><td>{_entry_link(parent_href, '../', directory=True)}</td>"
         '<td class="num">&mdash;</td><td class="num">Parent Directory</td></tr>'
     )
 
@@ -1138,16 +1160,15 @@ def _render_catalogue_browse_page(docs: str, full_rel: str) -> str:
         (subdirs if os.path.isdir(os.path.join(src_dir, name)) else files).append(name)
 
     for name in subdirs:
-        esc = _esc(name)
         rows.append(
-            f'<tr><td><a href="./{esc}/">{esc}/</a></td><td class="num">&mdash;</td><td class="num">&mdash;</td></tr>'
+            f"<tr><td>{_entry_link(f'./{name}/', f'{name}/', directory=True)}</td>"
+            '<td class="num">&mdash;</td><td class="num">&mdash;</td></tr>'
         )
     for name in files:
         path = os.path.join(src_dir, name)
-        esc = _esc(name)
         target = f"{climb}{full_rel}/{name}"
         rows.append(
-            f'<tr><td><a href="{_esc(target)}">{esc}</a></td>'
+            f"<tr><td>{_entry_link(target, name, directory=False)}</td>"
             f'<td class="num">{_epoch_cell(_display_epoch(path))}</td>'
             f'<td class="num">{_esc(human_size(os.path.getsize(path)))}</td></tr>'
         )

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -174,8 +174,8 @@ def test_artifact_datetime_is_utc_minute_precision() -> None:
 def test_timestamp_html_keeps_utc_instant_and_localizes_in_the_browser(tmp_path: Path) -> None:
     """Generated dates retain a truthful UTC fallback and ISO instant, while the
     shipped script renders the visitor's local `YYYY-MM-DD HH:mm` without a suffix."""
-    epoch = datetime(2026, 8, 14, 19, 32, tzinfo=timezone.utc).timestamp()
-    timestamp = '<time datetime="2026-08-14T19:32:00Z">2026-08-14 19:32 UTC</time>'
+    epoch = datetime(2026, 8, 14, 19, 32, 17, tzinfo=timezone.utc).timestamp()
+    timestamp = '<time datetime="2026-08-14T19:32:17Z">2026-08-14 19:32 UTC</time>'
     assert gl._time_html(epoch) == timestamp
     assert gl._epoch_cell(epoch) == timestamp
 
@@ -191,7 +191,7 @@ def test_timestamp_html_keeps_utc_instant_and_localizes_in_the_browser(tmp_path:
         assert gl._LOCAL_TIME_JS in rendered
 
     runner = (
-        'var t={dateTime:"2026-08-14T19:32:00Z",textContent:"UTC fallback"};'
+        'var t={dateTime:"2026-08-14T19:32:17Z",textContent:"UTC fallback"};'
         "global.document={querySelectorAll:function(){return [t];}};"
         f"{gl._LOCAL_TIME_JS}"
         "process.stdout.write(t.textContent);"
@@ -207,7 +207,7 @@ def test_timestamp_html_keeps_utc_instant_and_localizes_in_the_browser(tmp_path:
         result = subprocess.run(["node", "-e", runner], env=env, check=True, capture_output=True, text=True)
         assert result.stdout == local_time
 
-    invalid_runner = runner.replace("2026-08-14T19:32:00Z", "invalid")
+    invalid_runner = runner.replace("2026-08-14T19:32:17Z", "invalid")
     invalid = subprocess.run(["node", "-e", invalid_runner], check=True, capture_output=True, text=True)
     assert invalid.stdout == "UTC fallback"
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -326,6 +326,7 @@ _FILE_MTIME = 1786750000  # 2026-08-14 23:26 UTC
 _SOURCE_SHA = "f2c5650a1768c5df2bf05fd2cd4ae938a2f566a8"
 _RECORD_DATE = "2026-08-14 19:32 UTC"
 _MTIME_DATE = "2026-08-14 23:26 UTC"
+_RECORD_TIME = '<time datetime="2026-08-14T19:32:00Z">2026-08-14 19:32 UTC</time>'
 
 
 def _write_pkg(path: Path, *, annotations: dict[str, str], name: str = _CANON, version: str = "3.3.2") -> None:
@@ -466,7 +467,8 @@ def test_write_site_record_only_pkg_drives_browse_and_landing(tmp_path: Path, mo
 
     listing = (site / "browse" / "stable" / "ce-2.8" / "index.html").read_text()
     pkg_row = _autoindex_row(listing, f"{_CANON}-3.3.2.pkg")
-    assert _RECORD_DATE in pkg_row
+    assert _RECORD_TIME in pkg_row
+    assert gl._LOCAL_TIME_JS in listing
     assert _MTIME_DATE not in pkg_row
     for plumbing in ("packagesite.pkg", "data.pkg", "meta.conf"):
         row = _autoindex_row(listing, plumbing)
@@ -475,7 +477,8 @@ def test_write_site_record_only_pkg_drives_browse_and_landing(tmp_path: Path, mo
         assert "&mdash;" in row
 
     landing = (site / "index.html").read_text()
-    assert _RECORD_DATE in landing
+    assert _RECORD_TIME in landing
+    assert gl._LOCAL_TIME_JS in landing
     assert _MTIME_DATE not in landing
     assert f"{gl.SOURCE_REPO_URL}/commit/{_SOURCE_SHA}" in landing
     assert f">{_SOURCE_SHA[:7]}<" in landing
@@ -711,6 +714,7 @@ def _pkg(channel: str, name: str, version: str, abi: str, rel: str, size: int = 
         "rel": rel,
         "size": size,
         "published": "2026-06-14 09:38 UTC",
+        "published_epoch": datetime(2026, 6, 14, 9, 38, tzinfo=timezone.utc).timestamp(),
         "commit": "9d4b0b4556edca49b856c093838ccd0e2e91736b",
     }
 
@@ -1172,6 +1176,8 @@ def test_older_releases_lists_retained_excludes_latest() -> None:
     stb_old = _pkg("stable", _CANON, "3.0.0", "FreeBSD:16:amd64", "s1.pkg")
     nightly = _pkg("nightly", _CANON, "3.2.16.20260614.9", "FreeBSD:16:amd64", "n.pkg")
     all_pkgs = [dev_new, dev_mid, dev_old, stb_new, stb_old, nightly]
+    dev_mid["published_epoch"] = _RECORD_EPOCH
+    stb_old["published_epoch"] = _RECORD_EPOCH
 
     # Before: the newest versions are NOT in older_releases (they live in the edition table).
     rows = gl.older_releases(all_pkgs)
@@ -1194,6 +1200,7 @@ def test_older_releases_lists_retained_excludes_latest() -> None:
     assert "<h4>pfSense CE</h4>" in stable and "<h4>pfSense CE</h4>" in testing
     assert "Older releases (1)" in stable and "3.0.0" in stable and "3.2.15" not in stable
     assert "Older releases (2)" in testing and "3.2.15" in testing and "3.2.14" in testing
+    assert _RECORD_TIME in stable and _RECORD_TIME in testing
     assert "3.0.0" not in testing
     assert "<th>Channel</th>" not in html and "<th>pfSense</th>" in html
 
@@ -1926,6 +1933,7 @@ def _eol_pkg(version: str, abi: str, varver: str, channel: str = "stable") -> di
         "rel": f"{channel}/{varver}/{_CANON}-{version}.pkg",
         "size": 42,
         "published": "2026-01-10 08:00 UTC",
+        "published_epoch": datetime(2026, 1, 10, 8, 0, tzinfo=timezone.utc).timestamp(),
         "commit": "aabbcc1122334455667788990011223344556677",
         "php": "",
         "py": "",
@@ -2168,12 +2176,14 @@ def test_eol_versions_ce_and_plus_split_into_separate_tables() -> None:
     # CE section: the CE EOL version appears; Plus EOL version does not.
     assert ">2.7<" in ce_section
     assert "3.1.0_5" in ce_section
+    assert '<time datetime="2026-01-10T08:00:00Z">2026-01-10 08:00 UTC</time>' in ce_section
     assert "25.03" not in ce_section
     assert "3.0.9_1" not in ce_section
 
     # Plus section: the Plus EOL version appears; CE EOL version does not.
     assert ">25.03<" in plus_section
     assert "3.0.9_1" in plus_section
+    assert '<time datetime="2026-01-10T08:00:00Z">2026-01-10 08:00 UTC</time>' in plus_section
     assert ">2.7<" not in plus_section
     assert "3.1.0_5" not in plus_section
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -19,6 +19,7 @@ import json
 import os
 import re
 import stat
+import subprocess
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -168,6 +169,47 @@ def test_artifact_datetime_is_utc_minute_precision() -> None:
     assert gl.artifact_datetime(morning) == "2026-06-14 03:05 UTC"
     assert gl.artifact_datetime(evening) == "2026-06-14 21:47 UTC"
     assert gl.artifact_datetime(morning) != gl.artifact_datetime(evening)  # same day, distinct
+
+
+def test_timestamp_html_keeps_utc_instant_and_localizes_in_the_browser(tmp_path: Path) -> None:
+    """Generated dates retain a truthful UTC fallback and ISO instant, while the
+    shipped script renders the visitor's local `YYYY-MM-DD HH:mm` without a suffix."""
+    epoch = datetime(2026, 8, 14, 19, 32, tzinfo=timezone.utc).timestamp()
+    timestamp = '<time datetime="2026-08-14T19:32:00Z">2026-08-14 19:32 UTC</time>'
+    assert gl._time_html(epoch) == timestamp
+    assert gl._epoch_cell(epoch) == timestamp
+
+    base = "https://pkg.pfblockerng.com"
+    package = _pkg("stable", _CANON, "3.3.2", "FreeBSD:15:*", "stable/ce-2.8/package.pkg")
+    package["published_epoch"] = epoch
+    page = gl.render_page(base, [package], _stub_conf, _fixture_site_tree(base))
+    assert timestamp in page
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    listing = gl.render_browse_root(str(docs), {})
+    for rendered in (page, listing):
+        assert gl._LOCAL_TIME_JS in rendered
+
+    runner = (
+        'var t={dateTime:"2026-08-14T19:32:00Z",textContent:"UTC fallback"};'
+        "global.document={querySelectorAll:function(){return [t];}};"
+        f"{gl._LOCAL_TIME_JS}"
+        "process.stdout.write(t.textContent);"
+    )
+    expected = {
+        "Europe/Amsterdam": "2026-08-14 21:32",
+        "America/New_York": "2026-08-14 15:32",
+        "Asia/Kolkata": "2026-08-15 01:02",
+        "Asia/Kathmandu": "2026-08-15 01:17",
+    }
+    for zone, local_time in expected.items():
+        env = dict(os.environ, TZ=zone)
+        result = subprocess.run(["node", "-e", runner], env=env, check=True, capture_output=True, text=True)
+        assert result.stdout == local_time
+
+    invalid_runner = runner.replace("2026-08-14T19:32:00Z", "invalid")
+    invalid = subprocess.run(["node", "-e", invalid_runner], check=True, capture_output=True, text=True)
+    assert invalid.stdout == "UTC fallback"
 
 
 def test_published_datetime_prefers_created_annotation() -> None:
@@ -1596,9 +1638,11 @@ def test_catalogue_browse_page_lists_dirs_files_and_parent(tmp_path: Path) -> No
     out = gl._render_catalogue_browse_page(str(docs), "stable/ce-2.8")
 
     assert "Index of /stable/ce-2.8" in out
-    assert '<a href="../">../</a>' in out  # Parent Directory row (not the channel root)
-    assert '<a href="./amd64/">amd64/</a>' in out  # subdir stays within the browse mirror
-    assert 'href="../../../stable/ce-2.8/notes.txt">notes.txt</a>' in out  # file climbs into the real tree
+    folder = '<span class="entry-icon" aria-hidden="true">&#128193;</span>'
+    file = '<span class="entry-icon" aria-hidden="true">&#128196;</span>'
+    assert f'<a href="../">{folder}../</a>' in out  # Parent Directory row (not the channel root)
+    assert f'<a href="./amd64/">{folder}amd64/</a>' in out  # subdir stays within the browse mirror
+    assert f'href="../../../stable/ce-2.8/notes.txt">{file}notes.txt</a>' in out
     assert "12 B" in out  # size column rendered
 
 
@@ -1613,10 +1657,14 @@ def test_browse_root_has_no_parent_and_channel_root_links_browse_html(tmp_path: 
     root = gl.render_browse_root(str(docs), built)
     assert "Index of /" in root
     assert "Parent Directory" not in root and 'href="../"' not in root
-    assert '<a href="./browse/stable/">stable/</a>' in root and '<a href="./browse/nightly/">nightly/</a>' in root
+    folder = '<span class="entry-icon" aria-hidden="true">&#128193;</span>'
+    file = '<span class="entry-icon" aria-hidden="true">&#128196;</span>'
+    assert f'<a href="./browse/stable/">{folder}stable/</a>' in root
+    assert f'<a href="./browse/nightly/">{folder}nightly/</a>' in root
+    assert f'<a href="./meta.json">{file}meta.json</a>' in root
 
     channel_page = gl._render_catalogue_browse_page(str(docs), "stable")
-    assert '<a href="../../browse.html">../</a>' in channel_page  # channel root's Parent -> browse.html
+    assert f'<a href="../../browse.html">{folder}../</a>' in channel_page  # channel root's Parent -> browse.html
 
     # A colon-ABI subdir links with the scheme-safe './' prefix, staying within the mirror.
     _touch(docs / "stable" / "FreeBSD:16:aarch64" / "x")
@@ -1704,7 +1752,9 @@ def test_write_site_emits_browse_pages_outside_the_catalogue_tree(tmp_path: Path
     assert (site / "index.html").is_file()
     assert '<a class="browse" href="./browse.html">' in (site / "index.html").read_text()
     browse = (site / "browse.html").read_text()
-    assert '<a href="./browse/stable/">stable/</a>' in browse
+    assert (
+        '<a href="./browse/stable/"><span class="entry-icon" aria-hidden="true">&#128193;</span>stable/</a>' in browse
+    )
     # A browse page exists at EVERY level under browse/ — intermediate dirs too.
     for rel in ("stable", "stable/ce-2.8", "stable/ce-2.8/FreeBSD:15:amd64"):
         assert (site / "browse" / rel / "index.html").is_file(), f"missing browse page at {rel}"
@@ -1712,7 +1762,10 @@ def test_write_site_emits_browse_pages_outside_the_catalogue_tree(tmp_path: Path
         assert not (site / rel / "index.html").is_file(), f"catalogue dir {rel} must carry no autoindex"
     # Intermediate dir lists its subdir; leaf lists the package + the catalog plumbing (a real
     # directory listing, unlike the old package-only view).
-    assert '<a href="./ce-2.8/">ce-2.8/</a>' in (site / "browse" / "stable" / "index.html").read_text()
+    assert (
+        '<a href="./ce-2.8/"><span class="entry-icon" aria-hidden="true">&#128193;</span>ce-2.8/</a>'
+        in (site / "browse" / "stable" / "index.html").read_text()
+    )
     leaf = (site / "browse" / "stable" / "ce-2.8" / "FreeBSD:15:amd64" / "index.html").read_text()
     assert f"{_CANON}-3.2.16.pkg" in leaf
     assert "packagesite.pkg" in leaf  # the catalog files ARE shown in a directory listing
@@ -1761,7 +1814,7 @@ def test_write_site_never_indexes_docs_staging(tmp_path: Path, monkeypatch: Any)
     assert "staging" not in browse
     # A real channel is unaffected — still gets its own browse page + browse link.
     assert (site / "browse" / "edge" / "ce-2.8" / "index.html").is_file()
-    assert '<a href="./browse/edge/">edge/</a>' in browse
+    assert '<a href="./browse/edge/"><span class="entry-icon" aria-hidden="true">&#128193;</span>edge/</a>' in browse
 
 
 def test_write_site_empty_site_root_renders_four_empty_cards_exit_zero(tmp_path: Path, monkeypatch: Any) -> None:
@@ -1819,8 +1872,10 @@ def test_browse_adapts_to_any_future_tree_shape(tmp_path: Path, monkeypatch: Any
     assert n == 2
     # browse.html lists the two catalogue channels.
     browse = (site / "browse.html").read_text()
-    assert '<a href="./browse/stable/">stable/</a>' in browse
-    assert '<a href="./browse/edge/">edge/</a>' in browse
+    assert (
+        '<a href="./browse/stable/"><span class="entry-icon" aria-hidden="true">&#128193;</span>stable/</a>' in browse
+    )
+    assert '<a href="./browse/edge/"><span class="entry-icon" aria-hidden="true">&#128193;</span>edge/</a>' in browse
     # A browse page exists at EVERY directory of the novel tree — arbitrary names + extra
     # depth — and NOTHING is written inside the real catalogue tree itself.
     for rel in (


### PR DESCRIPTION
## Summary

- emit semantic UTC `<time datetime>` elements for every package publication and browse modified timestamp
- localize those instants in the visitor's browser as `YYYY-MM-DD HH:mm`, with no displayed zone suffix
- add decorative native folder/file icons to root and nested browse entries

## Verification

- `scripts/agent/run-gates.sh --diff origin/devel` — PASS (`pytest`, Ruff check/format, mypy)
- `uv run pytest -q tests/test_gen_landing.py tests/test_issue2450_render_site_workflow.py` — 135 passed
- browser script verified under Amsterdam, New York, Kolkata, and Kathmandu time zones; `2026-08-14 19:32 UTC` becomes `2026-08-14 21:32` in Amsterdam
- rendered against the current 52-package catalogue; catalogue trees and CNAME unchanged
- generated landing and nested browse HTML passed structural validation
- combined date/icon contract RED before implementation and GREEN unchanged afterward; frozen test hash `2125c07fbe4ee6a7c92fc771707de0a0be9763fa`

Fixes #2530

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timestamps now display in each visitor’s local time while retaining UTC-based semantics.
  * Directory listings now show distinct file and folder icons.
* **Bug Fixes**
  * Invalid timestamps now fall back gracefully instead of displaying broken date information.
  * Updated generated pages consistently show localized timestamps and navigation icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->