### PR TITLE
pfblockerng: define logger()/localize_text() fallbacks on CE

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -304,4 +304,47 @@ function pfb_install_settings_family_finalize(?callable $record = NULL): void
 		throw new RuntimeException('pfBlockerNG: unable to record 3.3 settings family');
 	}
 }
+
+// logger() and localize_text() are pfSense-core helpers (src/etc/inc/util.inc)
+// on pfSense Plus / master, but absent from released pfSense CE <= 2.8.1. Define
+// fallbacks ONLY when core does not provide them, so this package runs on both:
+// where core has them (Plus/master) these definitions are skipped and core wins
+// unchanged; on CE 2.8.1 they fill the gap. Behaviour mirrors the core versions.
+if (!function_exists('localize_text')) {
+	function localize_text(...$args) {
+		$arg0_len = strlen($args[0]);
+		if (($arg0_len > 0) && ($arg0_len < 4096)) {
+			$args[0] = gettext($args[0]);
+		}
+		return (count($args) == 1) ? $args[0] : sprintf(...$args);
+	}
+}
+
+if (!function_exists('logger')) {
+	function logger(int $priority, mixed $message, ?string $prefix = null, ?int $facilities = null): void {
+		$log_prefix = match ($priority) {
+			LOG_EMERG	=> 'EMERGENCY',
+			LOG_ALERT	=> 'ALERT',
+			LOG_CRIT	=> 'CRITICAL',
+			LOG_ERR		=> 'ERROR',
+			LOG_WARNING	=> 'WARNING',
+			LOG_NOTICE	=> 'NOTICE',
+			LOG_INFO	=> 'INFO',
+			LOG_DEBUG	=> 'DEBUG',
+			default		=> 'DEBUG'
+		};
+		if (isset($prefix)) {
+			$log_prefix .= ' [' . gettext($prefix) . ']';
+		}
+		$pri = isset($facilities) ? ($priority | $facilities) : $priority;
+		if (is_string($message)) {
+			$message = str_replace(PHP_EOL, '', $message);
+			$log_string = (strlen($message) > 0) ? "{$log_prefix} {$message}" : $log_prefix;
+		} else {
+			$log_string = $log_prefix . ' ' . str_replace(PHP_EOL, '', var_export($message, TRUE));
+		}
+		syslog($pri, $log_string);
+	}
+}
+
 ?>

--- a/tests/php/assert_logger_shim_3_3.php
+++ b/tests/php/assert_logger_shim_3_3.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * logger() and localize_text() are pfSense-core helpers on Plus/master but are
+ * absent from released CE <= 2.8.1. pfblockerng.inc calls both, so extra.inc
+ * must supply guarded fallbacks or every caller fatals on CE. Regression cover
+ * for a shipped 3.3.2 that reached CE 2.8.1 without them: sync_package_pfblockerng()
+ * died on "Call to undefined function logger()" and pfb_filter never started.
+ */
+
+$GLOBALS['config'] = [];
+$GLOBALS['pfb'] = [];
+
+function config_get_path(string $path, mixed $default = null): mixed
+{
+	return $default;
+}
+
+function config_set_path(string $path, mixed $value): void
+{
+}
+
+function write_config(string $desc = ''): void
+{
+}
+
+function pfb_global(): void
+{
+}
+
+$failures = 0;
+function check(bool $cond, string $label): void
+{
+	global $failures;
+	if ($cond) {
+		echo "PASS {$label}\n";
+		return;
+	}
+	$failures++;
+	echo "FAIL {$label}\n";
+}
+
+/* Neither helper exists in this process before extra.inc is loaded — the same
+ * starting condition as a CE 2.8.1 box. */
+check(!function_exists('logger'), 'logger() absent before extra.inc');
+check(!function_exists('localize_text'), 'localize_text() absent before extra.inc');
+
+$extra = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+require_once $extra;
+
+check(function_exists('logger'), 'extra.inc defines logger() fallback');
+check(function_exists('localize_text'), 'extra.inc defines localize_text() fallback');
+
+/* The guards must be conditional so core wins on Plus/master. */
+$source = file_get_contents($extra);
+check(
+	is_string($source) && str_contains($source, "if (!function_exists('logger'))"),
+	'logger() fallback is guarded by function_exists'
+);
+check(
+	is_string($source) && str_contains($source, "if (!function_exists('localize_text'))"),
+	'localize_text() fallback is guarded by function_exists'
+);
+
+/* Behaviour: single argument passes through, extra arguments format. */
+check(localize_text('plain string') === 'plain string', 'localize_text() returns single argument');
+check(localize_text('%s-%s', 'a', 'b') === 'a-b', 'localize_text() formats with sprintf');
+
+/* logger() must accept the call shape pfblockerng.inc uses and not throw. */
+$threw = false;
+try {
+	logger(LOG_NOTICE, localize_text('regression probe'), 'pfBlockerNG');
+} catch (Throwable $e) {
+	$threw = true;
+}
+check(!$threw, 'logger(priority, message, prefix) callable without error');
+
+if ($failures === 0) {
+	echo "ALL PASS\n";
+	exit(0);
+}
+exit(1);

--- a/tests/test_logger_shim_3_3.py
+++ b/tests/test_logger_shim_3_3.py
@@ -1,0 +1,18 @@
+"""logger()/localize_text() fallbacks for pfSense CE <= 2.8.1."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_php_logger_and_localize_text_fallbacks_defined() -> None:
+    runner = Path(__file__).with_name("php") / "assert_logger_shim_3_3.php"
+    result = subprocess.run(
+        ["php", str(runner)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout


### PR DESCRIPTION
Fixes the stable-channel half of the lifecycle findings. Companion to #2532 (the `devel`/nightly settings-family cluster) — different branch, different root cause, deliberately kept separate.

## Problem

`logger()` and `localize_text()` are pfSense-core helpers (`src/etc/inc/util.inc`) on Plus/master, but **absent from released CE ≤ 2.8.1**. `pfblockerng.inc` has 18 call sites for them, so on CE any path reaching one fatals.

Shipped 3.3.2 hits this whenever pfBlockerNG is **enabled**:

```
runtime  sync_package_pfblockerng()
         PHP Fatal error: Call to undefined function localize_text()  pfblockerng.inc:10428
install  POST-INSTALL script failed
         PHP Fatal error: Call to undefined function logger()         pfblockerng.inc:10570
```

Boxes where the package was never enabled do not reach the calls (`$log` stays empty), which is why it went unnoticed — a fresh install looks clean.

Verified absent on the target: `function_exists('logger')` and `function_exists('localize_text')` both `false`, and no definition anywhere on the filesystem or in this branch.

## Fix

`devel` already carries guarded fallbacks in `pfblockerng_extra.inc`; this ports that block **verbatim** (43 lines, byte-identical). Both stay behind `function_exists()`, so core wins unchanged on Plus/master and the fallbacks only fill the gap on CE.

`extra.inc` is already the designated place for this — `pfblockerng.inc` loads it as *"'include functions' not yet merged into pfSense"*.

## Test

Adds `tests/php/assert_logger_shim_3_3.php` + `tests/test_logger_shim_3_3.py` in this branch's existing style. Covers that both functions are undefined beforehand, that `extra.inc` defines them, that **both definitions are guarded** by `function_exists`, and their behaviour (single-arg passthrough, sprintf formatting, the `logger(priority, message, prefix)` call shape `pfblockerng.inc` uses).

Confirmed the test actually catches the bug — with the source block reverted it fails with the same fatal seen on the box:

```
PHP Fatal error: Uncaught Error: Call to undefined function localize_text()
FAILED tests/test_logger_shim_3_3.py::test_php_logger_and_localize_text_fallbacks_defined
```

`27 passed` before, `28 passed` after.

## Verified on a real box

pfSense CE 2.8.1-RELEASE, a pfSense template with pfBlockerNG installed and enabled, upgraded Netgate 3.2.8_1 → 3.3.2 via `install.sh --channel stable` (XCP-ng lifecycle tier).

Before the patch:

```
LEG=L1-bridge-stable  EXIT=0  VER=3.3.2(pfblockerng-stable)  ERRS=1
    └─ first error: undefined function logger
```

After copying the patched `extra.inc` onto the box:

```
php -l                                   No syntax errors detected
function_exists('logger'|'localize_text')  bool(true) bool(true)
sync_package_pfblockerng()                 returned cleanly
/tmp/PHP_errors.log                        (none)
```

and the previously-fatal call at `pfblockerng.inc:10570` now reaches syslog, formatted by the shim:

```
NOTICE [pfBlockerNG] Starting firewall filter daemon
INFO   [pfBlockerNG] Firewall Filter Service started
```

Note: `is_service_running('pfb_filter')` still reports `false` even though the service's own log lines show it starting. That looks like a separate pidfile/naming discrepancy, unrelated to this change — flagging it rather than folding it in.

## Note on reach

The same 3.3.2 artifact is published byte-identically to `stable`, `testing` and `edge`. Merging this does not help boxes already on 3.3.2 until there is a new build to publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with pfSense versions that lack built-in localization and logging helpers.
  * Added fallback localization and syslog logging behavior while preserving available core functionality.

* **Tests**
  * Added regression coverage for fallback availability, formatting, logging, and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->