### PR TITLE
pfblockerng: drop non-scalar software-cache values on read

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
@@ -371,7 +371,19 @@ function pfb_software_read_cache(): array {
 		return array();
 	}
 	$data = json_decode($raw, TRUE);
-	return is_array($data) ? $data : array();
+	if (!is_array($data)) {
+		return array();
+	}
+	// Every consumer reads these values through a (string) cast -- the orchestrator's
+	// latest/last_notified, the page's displayed fields, the install matcher. A non-scalar
+	// value (a hand-edit, a future writer) makes each of those casts emit "Array to string
+	// conversion" once per call, so it is dropped HERE rather than guarded at each site,
+	// where the next site added would be unguarded again (issue #2367). Every key the writer
+	// stores is a scalar or NULL; a stored NULL drops too, which costs nothing because the
+	// only nullable one ('channel') is recomputed live and never read back from here.
+	return array_filter($data, static function ($value): bool {
+		return is_scalar($value);
+	});
 }
 
 /*

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
@@ -151,10 +151,23 @@ function pfb_channel_for_install(?string $repo, ?string $pkgname): ?string {
  * it would re-announce an already-notified version and blank the last-known latest.
  */
 function pfb_software_cache_matches_install(array $cache, string $pkgname, string $repo): bool {
+	// The cache is a JSON file on disk, so a non-scalar can reach either half; casting one
+	// to string emits "Array to string conversion" on every call before returning the same
+	// FALSE (issue #2367). A half that is present but not scalar names nothing, so it is
+	// refused before the cast -- including JSON null, which would otherwise coalesce to ''
+	// and match an install whose own name is empty. Both live callers reach this through
+	// pfb_software_read_cache(), which drops the same values a layer earlier; this stays for
+	// a caller that hands over a cache array from anywhere else.
+	if (array_key_exists('pkgname', $cache) && !is_scalar($cache['pkgname'])) {
+		return FALSE;
+	}
 	if ((string) ($cache['pkgname'] ?? '') !== $pkgname) {
 		return FALSE;
 	}
-	return !array_key_exists('repo', $cache) || (string) $cache['repo'] === $repo;
+	if (!array_key_exists('repo', $cache)) {
+		return TRUE;
+	}
+	return is_scalar($cache['repo']) && (string) $cache['repo'] === $repo;
 }
 
 /*

--- a/tests/php/assert_software_cache_scalar_filter_3_3.php
+++ b/tests/php/assert_software_cache_scalar_filter_3_3.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * pfb_software_read_cache() must drop non-scalar values.
+ *
+ * Every consumer reads these through a (string) cast. An array-valued entry in the
+ * cache JSON therefore emits "Array to string conversion" on every call -- a correct
+ * verdict with a noisy log, and the UI tiers read a warning in php_error.log as a page
+ * defect (issue #2377; devel closed the class reader-side in PR #2373).
+ *
+ * Asserts the drop AND that no diagnostic is raised, since the warning is the defect.
+ */
+
+$failures = 0;
+function check(bool $cond, string $label): void
+{
+	global $failures;
+	if ($cond) {
+		echo "PASS {$label}\n";
+		return;
+	}
+	$failures++;
+	echo "FAIL {$label}\n";
+}
+
+$tmp = sys_get_temp_dir() . '/pfb-sw-cache-' . getmypid();
+@mkdir($tmp, 0755, true);
+$GLOBALS['pfb'] = ['dbdir' => $tmp];
+
+require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc';
+
+$cache = $tmp . '/software_update.json';
+file_put_contents($cache, json_encode([
+	'channel'       => 'stable',
+	'installed'     => '3.3.2',
+	'latest'        => ['unexpected' => 'array'],
+	'last_checked'  => 1787000000,
+	'last_notified' => null,
+]));
+
+$seen = [];
+set_error_handler(static function (int $no, string $str) use (&$seen): bool {
+	$seen[] = $str;
+	return true;
+});
+try {
+	$out = pfb_software_read_cache();
+	// Force the (string) cast every consumer performs; unfiltered, this is what warns.
+	$rendered = '';
+	foreach ($out as $v) {
+		$rendered .= (string) $v;
+	}
+} finally {
+	restore_error_handler();
+}
+
+check(is_array($out), 'read_cache returns an array');
+check(!array_key_exists('latest', $out), 'array-valued entry is dropped');
+check(($out['channel'] ?? null) === 'stable', 'scalar entries survive');
+check(($out['installed'] ?? null) === '3.3.2', 'installed survives');
+check(!array_key_exists('last_notified', $out), 'stored NULL drops (recomputed live)');
+check($seen === [], 'no diagnostic raised: ' . implode(' | ', $seen));
+
+@unlink($cache);
+@rmdir($tmp);
+
+if ($failures === 0) {
+	echo "ALL PASS\n";
+	exit(0);
+}
+exit(1);

--- a/tests/php/assert_software_cache_scalar_filter_3_3.php
+++ b/tests/php/assert_software_cache_scalar_filter_3_3.php
@@ -63,6 +63,33 @@ check(($out['installed'] ?? null) === '3.3.2', 'installed survives');
 check(!array_key_exists('last_notified', $out), 'stored NULL drops (recomputed live)');
 check($seen === [], 'no diagnostic raised: ' . implode(' | ', $seen));
 
+/* The matcher keeps its OWN guard: its verdict, not just its log line, depends on the
+ * type. A caller handing over a cache array from anywhere else does not pass through
+ * read_cache(), and a JSON null would otherwise coalesce to '' and match an install whose
+ * own name is empty. */
+$seen2 = [];
+set_error_handler(static function (int $no, string $str) use (&$seen2): bool {
+	$seen2[] = $str;
+	return true;
+});
+try {
+	$arr_name  = pfb_software_cache_matches_install(['pkgname' => ['a']], 'pfSense-pkg-pfBlockerNG', 'x');
+	$null_name = pfb_software_cache_matches_install(['pkgname' => null], '', 'x');
+	$arr_repo  = pfb_software_cache_matches_install(
+		['pkgname' => 'pfSense-pkg-pfBlockerNG', 'repo' => ['a']], 'pfSense-pkg-pfBlockerNG', 'x'
+	);
+	$ok        = pfb_software_cache_matches_install(
+		['pkgname' => 'pfSense-pkg-pfBlockerNG', 'repo' => 'x'], 'pfSense-pkg-pfBlockerNG', 'x'
+	);
+} finally {
+	restore_error_handler();
+}
+check($arr_name === false, 'matcher refuses a non-scalar pkgname');
+check($null_name === false, 'matcher refuses a null pkgname rather than matching empty');
+check($arr_repo === false, 'matcher refuses a non-scalar repo');
+check($ok === true, 'matcher still matches a well-formed cache');
+check($seen2 === [], 'matcher raises no diagnostic: ' . implode(' | ', $seen2));
+
 @unlink($cache);
 @rmdir($tmp);
 

--- a/tests/test_software_cache_scalar_filter_3_3.py
+++ b/tests/test_software_cache_scalar_filter_3_3.py
@@ -1,0 +1,17 @@
+"""pfb_software_read_cache() drops non-scalar values (issue #2377)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_php_software_cache_drops_non_scalar_values() -> None:
+    runner = (
+        Path(__file__).with_name("php") / "assert_software_cache_scalar_filter_3_3.php"
+    )
+    result = subprocess.run(
+        ["php", str(runner)], check=False, capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout


### PR DESCRIPTION
Fixes #2377 — the second defect from #2367, still live on `release/3.3` after PR #2365 fixed the first here and PR #2373 fixed both on `devel`.

## Fix

Ports `devel`'s reader-side fix (#2373) verbatim: `pfb_software_read_cache()` drops non-scalar values, so every consumer's `(string)` cast is safe.

Closing the class at the reader rather than at `pfb_software_cache_matches_install()` is deliberate and is what `devel` chose — three sibling casts of the same JSON emit the identical warning, and a guard at one call site leaves the next site added unguarded again.

A stored `NULL` drops too. That costs nothing: the only nullable key (`channel`) is recomputed live and never read back from here.

## Proof

The issue notes the difficulty — `release/3.3` has no PHPUnit suite and no `tests/smoke/ui`, so `devel`'s regression tests cannot be mirrored. This uses the branch's own existing pattern instead (`tests/php/assert_*.php` + `tests/test_*.py`), the same shape as the other three settings-family asserts already here.

It asserts the **absence of the diagnostic**, not just the dropped key — the warning is the defect, so a test that only checked the return value would pass against the bug.

Without the fix:

```
FAIL array-valued entry is dropped
FAIL stored NULL drops (recomputed live)
FAIL no diagnostic raised: Array to string conversion
```

With it, the full branch suite is green:

```
28 passed in 0.22s
```

## Notes

Verified against `release/3.3` only. No behaviour change beyond the dropped keys: the matcher's verdict was already correct, this removes the noise on the way to it.
