### PR TITLE
install.sh: refuse an empty CA hash directory

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,12 +117,17 @@ PFB_SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE-${ROOT}/etc/ssl/cert.pem}"
 # which is what a hash dir is made of.
 _ca_path_populated() {
     [ -d "$1" ] || return 1
+    _cap_has_entry=0
     for _cap_entry in "$1"/*; do
         if [ -e "${_cap_entry}" ] || [ -L "${_cap_entry}" ]; then
-            return 0
+            _cap_has_entry=1
+            break
         fi
     done
-    return 1
+    unset _cap_entry
+    [ "${_cap_has_entry}" -eq 1 ] || { unset _cap_has_entry; return 1; }
+    unset _cap_has_entry
+    return 0
 }
 
 _pkg() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -108,6 +108,23 @@ PFB_SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE-${ROOT}/etc/ssl/cert.pem}"
 # Spelled out per combination so every path stays quoted: a single accumulated string
 # would have to be word-split to become separate env(1) operands, which breaks the moment
 # a location contains a space.
+# TRUE when the hash directory holds at least one entry. FreeBSD ships /etc/ssl/certs
+# EMPTY until `certctl rehash` populates it, and libfetch abandons
+# SSL_CTX_set_default_verify_paths() as soon as EITHER variable is set -- so exporting an
+# empty hash dir with no bundle beside it leaves an EMPTY store, strictly worse than
+# exporting nothing (issue #2524). Mirrors pfb_pkgconf_dir_populated() (pfblockerng.inc)
+# and the boot hook's glob loop: any non-dot entry counts, including a dangling symlink,
+# which is what a hash dir is made of.
+_ca_path_populated() {
+    [ -d "$1" ] || return 1
+    for _cap_entry in "$1"/*; do
+        if [ -e "${_cap_entry}" ] || [ -L "${_cap_entry}" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 _pkg() {
     if [ -d "${PFB_SSL_CA_CERT_PATH}" ] &&
         [ -f "${PFB_SSL_CA_CERT_FILE}" ] && [ -s "${PFB_SSL_CA_CERT_FILE}" ]; then
@@ -115,7 +132,7 @@ _pkg() {
             SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
             SSL_CA_CERT_FILE="${PFB_SSL_CA_CERT_FILE}" \
             "${PKG_BIN}" "$@" </dev/null
-    elif [ -d "${PFB_SSL_CA_CERT_PATH}" ]; then
+    elif _ca_path_populated "${PFB_SSL_CA_CERT_PATH}"; then
         env ASSUME_ALWAYS_YES=yes \
             SSL_CA_CERT_PATH="${PFB_SSL_CA_CERT_PATH}" \
             "${PKG_BIN}" "$@" </dev/null

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1093,6 +1093,19 @@ def _ca_dir(root: str) -> Path:
     return Path(root) / "etc" / "ssl" / "certs"
 
 
+def _seed_ca_dir(root: str) -> Path:
+    """Create the hash dir WITH an entry.
+
+    install.sh refuses to export an empty hash dir (issue #2524), so any case that is
+    about something else — the bundle half, a path with a space, an override — needs a
+    populated one or it exercises the emptiness guard by accident.
+    """
+    ca_dir = _ca_dir(root)
+    ca_dir.mkdir(parents=True, exist_ok=True)
+    (ca_dir / "deadbeef.0").write_text("-----BEGIN CERTIFICATE-----\n")
+    return ca_dir
+
+
 def test_every_pkg_call_exports_the_system_ca_path() -> None:
     """Every pkg(8) invocation carries SSL_CA_CERT_PATH pointing at the box's store."""
     with tempfile.TemporaryDirectory() as root:
@@ -1126,11 +1139,56 @@ def test_absent_ca_dir_leaves_ssl_ca_cert_path_unset() -> None:
         assert set(files) == {"<unset>"}, f"expected SSL_CA_CERT_FILE unset, saw {sorted(set(files))}"
 
 
+def test_empty_ca_dir_leaves_ssl_ca_cert_path_unset() -> None:
+    """An EMPTY hash dir must not be exported (issue #2524).
+
+    ``-d`` alone passes a directory that exists but holds nothing, and FreeBSD ships
+    /etc/ssl/certs empty until ``certctl rehash`` runs — the state of a stock box, not a
+    hypothetical. libfetch stops calling ``SSL_CTX_set_default_verify_paths()`` as soon as
+    EITHER variable is set, so exporting an empty hash dir with no bundle beside it leaves
+    an EMPTY store: strictly worse than exporting nothing at all. Matches the guard
+    ``pfb_pkgconf_dir_populated()`` and the boot hook already carry.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        _ca_dir(root).mkdir(parents=True)
+        assert _ca_dir(root).is_dir() and not any(_ca_dir(root).iterdir())
+        assert not _ca_bundle(root).exists(), "bundle must be absent to isolate the PATH-only branch"
+
+        proc = _run_install(root, "stable")
+        assert proc.returncode == 0, proc.stderr
+
+        seen = _pkg_ca_path_capture(root).read_text().splitlines()
+        assert seen, "no pkg calls were made — the run cannot prove the guard"
+        assert set(seen) == {"<unset>"}, (
+            f"an empty hash dir was exported as SSL_CA_CERT_PATH={sorted(set(seen))} — "
+            "that empties the trust store instead of widening it"
+        )
+
+
+def test_populated_ca_dir_is_still_exported() -> None:
+    """The guard must not cost the working case: one entry is enough to export the path."""
+    with tempfile.TemporaryDirectory() as root:
+        _ca_dir(root).mkdir(parents=True)
+        (_ca_dir(root) / "deadbeef.0").write_text("-----BEGIN CERTIFICATE-----\n")
+
+        proc = _run_install(root, "stable")
+        assert proc.returncode == 0, proc.stderr
+
+        seen = _pkg_ca_path_capture(root).read_text().splitlines()
+        assert seen, "no pkg calls were made — the run cannot prove the guard"
+        assert set(seen) == {str(_ca_dir(root))}, (
+            f"expected the populated hash dir to be exported, saw {sorted(set(seen))}"
+        )
+
+
 def test_ca_path_is_overridable() -> None:
     """PFB_SSL_CA_CERT_PATH overrides the default location."""
     with tempfile.TemporaryDirectory() as root:
         override = Path(root) / "custom-store"
         override.mkdir()
+        # Populated on purpose: an empty hash dir is refused by design (issue #2524), and
+        # this case is about the override being honoured, not about the emptiness guard.
+        (override / "deadbeef.0").write_text("-----BEGIN CERTIFICATE-----\n")
 
         proc = _run_install(root, "stable", extra_env={"PFB_SSL_CA_CERT_PATH": str(override)})
         assert proc.returncode == 0, proc.stderr
@@ -1248,7 +1306,7 @@ def test_empty_bundle_override_opts_out_of_the_file() -> None:
     """PFB_SSL_CA_CERT_FILE="" exports no bundle, and the path is unaffected."""
     with tempfile.TemporaryDirectory() as root:
         ca_dir = _ca_dir(root)
-        ca_dir.mkdir(parents=True)
+        _seed_ca_dir(root)
         _ca_bundle(root).write_text("# CA bundle\n")
 
         proc = _run_install(root, "stable", extra_env={"PFB_SSL_CA_CERT_FILE": ""})
@@ -1270,7 +1328,7 @@ def test_empty_bundle_file_is_not_exported() -> None:
     """
     with tempfile.TemporaryDirectory() as root:
         ca_dir = _ca_dir(root)
-        ca_dir.mkdir(parents=True)
+        _seed_ca_dir(root)
         _ca_bundle(root).write_text("")
 
         proc = _run_install(root, "stable")
@@ -1287,7 +1345,7 @@ def test_directory_as_bundle_is_not_exported() -> None:
     """A directory where the bundle should be is refused: `-s` alone is true for one."""
     with tempfile.TemporaryDirectory() as root:
         ca_dir = _ca_dir(root)
-        ca_dir.mkdir(parents=True)
+        _seed_ca_dir(root)
         _ca_bundle(root).mkdir(parents=True)  # a directory, not a bundle
 
         proc = _run_install(root, "stable")


### PR DESCRIPTION
Fixes #2524.

## Fix

`_pkg()`'s PATH-only branch was guarded by `-d` alone, which passes a directory that exists but holds nothing. Adds the populated-ness test the other two implementations from #2518 already carry — `pfb_pkgconf_dir_populated()` and the boot hook's glob loop — on the same reasoning: a patch that only *looks* applied is worse than no patch.

```sh
elif _ca_path_populated "${PFB_SSL_CA_CERT_PATH}"; then
```

Any non-dot entry counts, including a dangling symlink — which is what a hash dir is made of.

Only the PATH-only branch changes. The path+bundle branch keeps `-d`: with a valid bundle present the store is not empty, so an unpopulated hash dir beside it is harmless.

## Tests

Two new cases in the existing hermetic harness:

- `test_empty_ca_dir_leaves_ssl_ca_cert_path_unset` — the defect. Fails without the guard with `an empty hash dir was exported as SSL_CA_CERT_PATH=[...] — that empties the trust store instead of widening it`
- `test_populated_ca_dir_is_still_exported` — the guard must not cost the working case

## Existing tests I changed, and why

Four cases created the hash dir without populating it. Flagging these explicitly since touching existing assertions deserves scrutiny:

- `test_empty_bundle_override_opts_out_of_the_file`, `test_empty_bundle_file_is_not_exported`, `test_directory_as_bundle_is_not_exported` — all three are about the **bundle** half and assert the path still exports. An unpopulated dir made them exercise this guard by accident. Seeded via a shared `_seed_ca_dir()` helper; their subject and assertions are unchanged.
- `test_ca_path_is_overridable` — created an **empty** override dir and asserted it is exported. That is the behaviour this PR fixes. Its intent is "the override is honoured", so the fixture is seeded and the assertion kept.

Full file green: `61 passed`.

## Scope

Behaviour change is limited to the empty-hash-dir case, which previously produced an empty trust store. A box with a populated hash dir, a bundle, both, or neither is unaffected.
