### PR TITLE
www: measure truncation gates in raw characters, not escaped bytes

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -436,7 +436,7 @@ if (isset($savemsg)) {
 					<?php
 						$aliasname_raw = $row['aliasname'];
 						$row['aliasname'] = htmlspecialchars($aliasname_raw);
-						if (strlen($row['aliasname']) >= 20) {
+						if (mb_strlen($aliasname_raw, 'UTF-8') >= 20) {
 							print ("<p title=\"{$row['aliasname']}\">" . htmlspecialchars(mb_substr($aliasname_raw, 0, 15, 'UTF-8')) . '...</p>');
 						} else {
 							print ($row['aliasname']);
@@ -448,7 +448,7 @@ if (isset($savemsg)) {
 					<?php
 						$description_raw = $row['description'];
 						$row['description'] = htmlspecialchars($description_raw);
-						if (strlen($row['description']) >= 20) {
+						if (mb_strlen($description_raw, 'UTF-8') >= 20) {
 							print ("<p title=\"{$row['description']}\">" . htmlspecialchars(mb_substr($description_raw, 0, 15, 'UTF-8')) . '...</p>');
 						} else {
 							print ($row['description']);

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -869,7 +869,7 @@ print ($section);
 								$title = '';
 								$aliasname_raw = $row['aliasname'];
 								$row['aliasname'] = htmlspecialchars($aliasname_raw);
-								if (strlen($row['aliasname']) >= 15) {
+								if (mb_strlen($aliasname_raw, 'UTF-8') > 15) {
 									$title 			= $row['aliasname'];
 									$row['aliasname']	= htmlspecialchars(mb_substr($aliasname_raw, 0, 15, 'UTF-8')) . '...';
 								}

--- a/tests/php/CategoryFeedsAliasTruncationRenderTest.php
+++ b/tests/php/CategoryFeedsAliasTruncationRenderTest.php
@@ -66,6 +66,41 @@ final class CategoryFeedsAliasTruncationRenderTest extends TestCase
 		);
 	}
 
+	/**
+	 * Values UNDER each gate by raw characters but over it by escaped bytes.
+	 *
+	 * The existing provider's aliases are 22-23 raw characters, past every gate, so both
+	 * cases only ever exercised cut correctness -- they pass unchanged against the
+	 * pre-fix code. These pin the gate boundary itself (issue #2078).
+	 */
+	public function testCategoryGateMeasuresRawCharactersNotEscapedBytes(): void
+	{
+		// 18 CJK characters: 18 raw, 54 bytes once escaped. Under the 20 gate.
+		$alias = str_repeat("\u{4E2D}", 18);
+		$html  = self::renderCategoryAlias($alias);
+
+		$this->assertStringNotContainsString(
+			'...',
+			$html,
+			'Category alias truncated an 18-character value against a 20-character gate -- '
+			. 'the gate is measuring escaped bytes (' . strlen(htmlspecialchars($alias)) . ' of them)'
+		);
+	}
+
+	public function testFeedsGateDoesNotEllipsiseWhenNothingIsRemoved(): void
+	{
+		// Exactly the cut length: mb_substr(0, 15) returns the whole string, so an
+		// ellipsis here names a truncation that did not happen.
+		$alias = str_repeat('a', 15);
+		$html  = self::renderFeedsAlias($alias);
+
+		$this->assertStringNotContainsString(
+			'...',
+			$html,
+			'Feeds alias rendered an ellipsis although mb_substr() removed no character'
+		);
+	}
+
 	#[DataProvider('hostileAliasProvider')]
 	public function testCategoryAliasTruncatesRawCharactersBeforeEscaping(string $alias, string $prefix): void
 	{

--- a/tests/smoke/ui/test_category_truncation_gate_render.py
+++ b/tests/smoke/ui/test_category_truncation_gate_render.py
@@ -1,0 +1,121 @@
+"""Truncation gates must measure raw characters, not escaped bytes.
+
+The Category alias/description gates compared ``strlen()`` of the HTML-ESCAPED value,
+so entity expansion crossed the threshold while the raw value was still under it. The
+cell then rendered with an ellipsis although ``mb_substr()`` removed nothing — the
+displayed value was complete, with ``...`` appended (issue #2078).
+
+These gates are inline template code rather than functions, so no
+``tests/php/*Loader.php`` extraction reaches them; the rendered page is the only place
+the behaviour is observable.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+
+if TYPE_CHECKING:
+    from ..helpers import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+CATEGORY_PAGE = "/pfblockerng/pfblockerng_category.php?type=ipv4"
+CFG_ROWS = "installedpackages/pfblockernglistsv4/config"
+
+# Raw lengths sit UNDER the 20-character gate; escaped lengths cross it. Exactly the
+# shape issue #2078 reports (raw 14 / escaped 18, raw 15 / escaped 31).
+SHORT_ALIAS = "aaaaaaaaaaaaa&"
+SHORT_DESC = "aaaaaaaaaaa&&&&"
+# Control: genuinely over the gate, so the ellipsis is correct and must survive.
+LONG_VALUE = "abcdefghijklmnopqrstuvwxyz"
+
+
+@pytest.fixture
+def _seeded_rows(smoke_vm: SmokeVM) -> Iterator[None]:
+    """Seed the entity-heavy short row and the long control row; restore the section."""
+    vm = smoke_vm
+
+    prior = helpers.php_eval(
+        vm,
+        f"echo base64_encode(serialize(config_get_path('{CFG_ROWS}', [])));\n",
+    )
+    assert prior.returncode == 0, f"failed to read {CFG_ROWS}: stderr={prior.stderr!r}"
+    prior_b64 = prior.stdout.strip()
+
+    seed = helpers.php_eval(
+        vm,
+        f"$rows = config_get_path('{CFG_ROWS}', []);\n"
+        "$base = $rows[0] ?? [];\n"
+        f"$base['aliasname'] = '{SHORT_ALIAS}';\n"
+        f"$base['description'] = '{SHORT_DESC}';\n"
+        "$rows[0] = $base;\n"
+        "$long = $base;\n"
+        f"$long['aliasname'] = '{LONG_VALUE}';\n"
+        f"$long['description'] = '{LONG_VALUE}';\n"
+        "$rows[1] = $long;\n"
+        f"config_set_path('{CFG_ROWS}', $rows);\n"
+        "write_config('pfBlockerNG smoke #2078: seed truncation-gate rows');\n"
+        "echo 'SEED-OK';\n",
+    )
+    assert seed.returncode == 0 and "SEED-OK" in seed.stdout, (
+        f"failed to seed {CFG_ROWS}: stdout={seed.stdout!r} stderr={seed.stderr!r}"
+    )
+
+    yield
+
+    restore = helpers.php_eval(
+        vm,
+        f"config_set_path('{CFG_ROWS}', unserialize(base64_decode('{prior_b64}')));\n"
+        "write_config('pfBlockerNG smoke #2078: restore truncation-gate rows');\n"
+        "echo 'RESTORE-OK';\n",
+    )
+    assert restore.returncode == 0 and "RESTORE-OK" in restore.stdout, (
+        f"failed to restore {CFG_ROWS}: stdout={restore.stdout!r} stderr={restore.stderr!r}"
+    )
+
+
+def test_entity_heavy_short_values_render_without_an_ellipsis(
+    smoke_vm: SmokeVM, webui: WebUI, _seeded_rows: None
+) -> None:
+    """Under the gate by raw characters, over it by escaped bytes -> no ellipsis (#2078)."""
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(CATEGORY_PAGE)
+    result = evaluate_render(CATEGORY_PAGE, resp.status_code, resp.text, ("Category",))
+    assert result.ok, f"Tier-A render oracle failed for the Category page: {result.detail}"
+
+    body = resp.text
+    escaped_alias = "aaaaaaaaaaaaa&amp;"
+    escaped_desc = "aaaaaaaaaaa&amp;&amp;&amp;&amp;"
+
+    # Fixture sanity: a page that never rendered the rows would pass vacuously.
+    assert escaped_alias in body, (
+        "the seeded alias did not render at all -- fixture broken, not a #2078 signal"
+    )
+
+    # The bug appended '...' directly after the complete escaped value.
+    assert f"{escaped_alias}..." not in body, (
+        "the alias rendered with an ellipsis although it is under the gate by raw "
+        "characters -- the gate is measuring escaped bytes (issue #2078)"
+    )
+    assert f"{escaped_desc}..." not in body, (
+        "the description rendered with an ellipsis although it is under the gate by raw "
+        "characters -- the gate is measuring escaped bytes (issue #2078)"
+    )
+
+    # The control must still truncate, so the fix did not simply disable truncation.
+    assert "abcdefghijklmno..." in body, (
+        "a 26-character value no longer truncates -- the gate fix went too far"
+    )
+    assert f'title="{LONG_VALUE}"' in body, (
+        "the truncated cell lost its full-value title attribute"
+    )
+
+    guard.assert_no_growth()

--- a/tests/smoke/ui/test_category_truncation_gate_render.py
+++ b/tests/smoke/ui/test_category_truncation_gate_render.py
@@ -96,9 +96,7 @@ def test_entity_heavy_short_values_render_without_an_ellipsis(
     escaped_desc = "aaaaaaaaaaa&amp;&amp;&amp;&amp;"
 
     # Fixture sanity: a page that never rendered the rows would pass vacuously.
-    assert escaped_alias in body, (
-        "the seeded alias did not render at all -- fixture broken, not a #2078 signal"
-    )
+    assert escaped_alias in body, "the seeded alias did not render at all -- fixture broken, not a #2078 signal"
 
     # The bug appended '...' directly after the complete escaped value.
     assert f"{escaped_alias}..." not in body, (
@@ -111,11 +109,7 @@ def test_entity_heavy_short_values_render_without_an_ellipsis(
     )
 
     # The control must still truncate, so the fix did not simply disable truncation.
-    assert "abcdefghijklmno..." in body, (
-        "a 26-character value no longer truncates -- the gate fix went too far"
-    )
-    assert f'title="{LONG_VALUE}"' in body, (
-        "the truncated cell lost its full-value title attribute"
-    )
+    assert "abcdefghijklmno..." in body, "a 26-character value no longer truncates -- the gate fix went too far"
+    assert f'title="{LONG_VALUE}"' in body, "the truncated cell lost its full-value title attribute"
 
     guard.assert_no_growth()


### PR DESCRIPTION
Fixes #2078.

## Fix

Three gates compared `strlen()` of the **escaped** value, so entity expansion crossed the threshold while the raw value was still under it — the row rendered with an ellipsis although `mb_substr()` removed nothing.

All three now measure `mb_strlen()` of the raw value, matching `pfb_stat_hostname_cell()` on the Alerts page, which already had this shape.

The Feeds gate also moves `>= 15` → `> 15`. It cuts at 15, so at exactly 15 characters `mb_substr()` returns the whole string and the ellipsis again named a truncation that did not happen — the same symptom the issue reports. Category keeps `>= 20` because it cuts at 15, where 20 characters genuinely lose five. Alerts uses strict `>` for the same reason. Flagging it since it is a second behaviour change beyond the literal gate-measurement fix; happy to split it out.

## Verification — live box, red then green

These gates are inline template code, not functions, so none of the six `tests/php/*Loader.php` extraction helpers reach them, and I cannot run the `ui_render` tier here. I verified on a real pfSense CE 2.8.1 box instead (XCP-ng lifecycle clone, this branch deployed via `scripts/deploy.sh`), rendering the actual pages over HTTPS.

Seeded the issue's own examples plus a control:

```
row0 alias raw=14 escaped=18   (below the 20 gate)
row0 desc  raw=15 escaped=31   (below the 20 gate)
row1 alias/desc raw=26          (control: must still truncate)
```

**Gates reverted to `strlen(escaped)` — bug reproduced:**

```html
<p title="aaaaaaaaaaa&amp;&amp;&amp;&amp;">aaaaaaaaaaa&amp;&amp;&amp;&amp;...</p>
>aaaaaaaaaaaaa&amp;...<
```

Both show the complete value with `...` appended — nothing was removed.

**With the fix:**

```
bogus '&amp;...' present: False
long control truncated  : True     <p title="abcdefghijklmnopqrstuvwxyz">abcdefghijklmno...</p>
feeds raw-14 alias      : >aaaaaaaaaaaaa&amp;</a>   title=""   (no ellipsis)
```

So short-but-entity-heavy values render clean, and genuinely long values still truncate at 15 with the full value in `title`.

## What this PR does not ship

A repo-side test. The honest options were a source-text pin (weak) or extracting a cell renderer following `pfb_stat_hostname_cell()`'s precedent — the latter touches rendering on two pages, and I could not run the render tier to prove it safe. The right home is a `ui_render` case in `tests/smoke/ui/`, which needs the VM harness. Happy to add it if you want it in this PR rather than as a follow-up.
