### PR TITLE
www: strip Unicode bidi controls in pfb_hsc()

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1902,7 +1902,28 @@ function pfb_hsc($value) {
 	// htmlspecialchars() return '' -- blanking the WHOLE string, not just the offending
 	// byte (issue #1814). With it, the invalid byte alone is replaced with U+FFFD and the
 	// rest of the value still renders.
-	return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+	$encoded = htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+	// Unicode bidirectional controls survive HTML encoding -- they are not metacharacters --
+	// and reverse the display order of everything after them, so a log-derived domain, feed
+	// name or hostname can render as something other than the bytes actually logged
+	// (issue #2041). Config text never reaches here carrying one: pfb_sanitize_text() strips
+	// \p{C} at the persist boundary (issue #1723). Log-derived values have no such gate.
+	//
+	// Stripped AFTER encoding, not before: ENT_SUBSTITUTE guarantees its output is valid
+	// UTF-8, and preg_replace()'s /u modifier returns NULL on invalid input -- stripping
+	// first would hand that NULL straight into the cell for exactly the malformed values
+	// #1814 exists to keep rendering. No entity htmlspecialchars() emits is in this set, so
+	// running after it cannot corrupt one.
+	//
+	// Only the bidi set, not all of \p{C}: this is the encode chokepoint for every Alerts
+	// and Reports cell, and \p{C} would also take newlines and tabs out of values that may
+	// legitimately carry them.
+	// The marks (U+061C, U+200E, U+200F), the embedding/override set (U+202A-U+202E) and
+	// the isolates (U+2066-U+2069). None carry textual content.
+	$stripped = preg_replace('/[\x{061C}\x{200E}\x{200F}\x{202A}-\x{202E}\x{2066}-\x{2069}]/u', '', $encoded);
+
+	return $stripped === NULL ? $encoded : $stripped;
 }
 
 // Truncate a RAW log/host-derived token to $length CHARACTERS (never bytes), so a

--- a/tests/php/AlertsBidiControlStripTest.php
+++ b/tests/php/AlertsBidiControlStripTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * pfb_hsc() strips Unicode bidirectional controls (issue #2041).
+ *
+ * htmlspecialchars() neutralises HTML metacharacters; bidi controls are not
+ * metacharacters, so they survived encoding and reversed the display order of
+ * everything after them. A log-derived domain, feed name or resolved hostname could
+ * therefore render as something other than the bytes actually logged.
+ *
+ * Config text never arrived carrying one -- pfb_sanitize_text() strips \p{C} at the
+ * persist boundary (issue #1723) -- but log-derived values have no such gate.
+ */
+#[CoversFunction('pfb_hsc')]
+final class AlertsBidiControlStripTest extends TestCase
+{
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		pfb_test_load_alerts_page_functions();
+	}
+
+	/** Every character the pattern names, each of which reorders what follows. */
+	public static function bidiControls(): array
+	{
+		return [
+			'ALM  U+061C' => ["\u{061C}"],
+			'LRM  U+200E' => ["\u{200E}"],
+			'RLM  U+200F' => ["\u{200F}"],
+			'LRE  U+202A' => ["\u{202A}"],
+			'RLE  U+202B' => ["\u{202B}"],
+			'PDF  U+202C' => ["\u{202C}"],
+			'LRO  U+202D' => ["\u{202D}"],
+			'RLO  U+202E' => ["\u{202E}"],
+			'LRI  U+2066' => ["\u{2066}"],
+			'RLI  U+2067' => ["\u{2067}"],
+			'FSI  U+2068' => ["\u{2068}"],
+			'PDI  U+2069' => ["\u{2069}"],
+		];
+	}
+
+	#[DataProvider('bidiControls')]
+	public function testBidiControlIsStripped(string $control): void
+	{
+		$out = pfb_hsc("evil{$control}gnp.exe");
+		$this->assertStringNotContainsString(
+			$control,
+			$out,
+			'bidi control survived encoding: ' . bin2hex($out)
+		);
+		$this->assertSame('evilgnp.exe', $out, 'surrounding text must be untouched');
+	}
+
+	/** The spoof from the issue: what is logged and what is displayed must agree. */
+	public function testOverrideCannotReverseADomain(): void
+	{
+		$logged = "safe\u{202E}gnp.exe";
+		$this->assertSame('safegnp.exe', pfb_hsc($logged));
+	}
+
+	/** HTML encoding is unchanged -- this must not become the only thing pfb_hsc does. */
+	public function testHtmlMetacharactersStillEncoded(): void
+	{
+		$this->assertSame(
+			'&lt;script&gt;alert(1)&lt;/script&gt;',
+			pfb_hsc('<script>alert(1)</script>')
+		);
+		$this->assertSame('&quot;&amp;&#039;', pfb_hsc('"&\''));
+	}
+
+	/**
+	 * Invalid UTF-8 must still render (issue #1814). preg_replace()'s /u modifier returns
+	 * NULL on malformed input, so stripping before encoding would blank exactly the values
+	 * ENT_SUBSTITUTE exists to preserve. Encoding first makes the input to preg valid.
+	 */
+	public function testInvalidUtf8StillRenders(): void
+	{
+		$out = pfb_hsc("abc\xC3\x28def");
+		$this->assertNotSame('', $out, 'invalid UTF-8 blanked the whole value');
+		$this->assertStringContainsString('abc', $out);
+		$this->assertStringContainsString('def', $out);
+	}
+
+	/** A bidi control adjacent to invalid UTF-8: both handled, neither blanks the value. */
+	public function testInvalidUtf8CarryingABidiControl(): void
+	{
+		$out = pfb_hsc("abc\xC3\x28\u{202E}def");
+		$this->assertNotSame('', $out);
+		$this->assertStringNotContainsString("\u{202E}", $out);
+		$this->assertStringContainsString('def', $out);
+	}
+
+	/** Characters that merely look exotic are content, not controls, and must survive. */
+	public function testNonControlUnicodeSurvives(): void
+	{
+		$this->assertSame('bücher.de', pfb_hsc('bücher.de'));
+		$this->assertSame('日本.jp', pfb_hsc('日本.jp'));
+	}
+}

--- a/tests/smoke/ui/test_alerts_bidi_control_render.py
+++ b/tests/smoke/ui/test_alerts_bidi_control_render.py
@@ -1,0 +1,117 @@
+"""Bidi controls in a log-derived value must not reach the rendered Alerts page.
+
+``pfb_hsc()`` encodes HTML metacharacters; Unicode bidirectional controls are not
+metacharacters, so before issue #2041 they survived encoding and reversed the display
+order of everything after them — a blocked domain could render as something other than
+the bytes ``dnsbl.log`` actually carries.
+
+Tier-A companion to ``tests/php/AlertsBidiControlStripTest.php``: the unit tests pin
+``pfb_hsc()`` itself, this pins that no path between the log line and the rendered cell
+re-introduces the control.
+
+The DNSBL stats view is the one that renders this row (``?view=dnsbl_stat``); the
+default Alerts view does not, so asserting against the default page would pass
+vacuously.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Iterator
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+
+if TYPE_CHECKING:
+    from ..helpers import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+DNSBL_LOG = "/var/log/pfblockerng/dnsbl.log"
+STATS_PAGE = "/pfblockerng/pfblockerng_alerts.php?view=dnsbl_stat"
+CFG_DNSBL_ENABLE = "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl"
+
+# U+202E RIGHT-TO-LEFT OVERRIDE between an innocuous prefix and a reversed-looking
+# suffix -- the canonical filename/domain spoof. Inert: never resolved, never fetched.
+RLO = "‮"
+SPOOF_DOM = f"evil-rv2041{RLO}gnp.exe"
+FIXED_TS = "2030-01-15 09:00:05"
+
+# dnsbl.log CSV shape: l_type,ts,domain,src_ip,agent,block_mode,group,final_domain,feed,dup,qtype
+_LOG_LINE = (
+    f"DNSBL-python,{FIXED_TS},{SPOOF_DOM},127.0.0.1,Python,"
+    f"DNSBL_TLD,RV2041Group,{SPOOF_DOM},RV2041Feed,+,A\n"
+)
+
+
+@pytest.fixture
+def _seeded_bidi_row(smoke_vm: SmokeVM) -> Iterator[None]:
+    """Seed the bidi-carrying dnsbl.log row; restore the log and the DNSBL toggle."""
+    vm = smoke_vm
+
+    prior_dnsbl = helpers.config_get(vm, CFG_DNSBL_ENABLE)
+    helpers.ensure_dnsbl_vip(vm)
+    helpers.set_dnsbl_enabled(vm, True)
+
+    log_dir = DNSBL_LOG.rsplit("/", 1)[0]
+    ensure = vm.ssh(f"mkdir -p {log_dir} && touch {DNSBL_LOG}", timeout=15)
+    assert ensure.returncode == 0, f"failed to ensure {DNSBL_LOG} exists: {ensure.stderr!r}"
+    size_before = vm.ssh("stat", "-f", "%z", DNSBL_LOG, timeout=15)
+    assert size_before.returncode == 0, f"failed to stat {DNSBL_LOG}: stderr={size_before.stderr!r}"
+    original_size = size_before.stdout.strip()
+
+    append = subprocess.run(
+        vm.ssh_argv("tee", "-a", DNSBL_LOG),
+        input=_LOG_LINE,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert append.returncode == 0, f"failed to append the fixture row to {DNSBL_LOG}: stderr={append.stderr!r}"
+
+    yield
+
+    restore_log = vm.ssh(f"truncate -s {original_size} {DNSBL_LOG}", timeout=15)
+    assert restore_log.returncode == 0, f"failed to restore {DNSBL_LOG} size: stderr={restore_log.stderr!r}"
+    size_after = vm.ssh("stat", "-f", "%z", DNSBL_LOG, timeout=15)
+    assert size_after.returncode == 0 and size_after.stdout.strip() == original_size, (
+        f"{DNSBL_LOG} restore did not take (before={original_size!r}, after={size_after.stdout.strip()!r})"
+    )
+
+    helpers.config_set(vm, CFG_DNSBL_ENABLE, prior_dnsbl)
+    assert helpers.config_get(vm, CFG_DNSBL_ENABLE) == prior_dnsbl, (
+        f"pfb_dnsbl toggle restore did not take (wanted {prior_dnsbl!r}) -- leaked to sibling tests"
+    )
+
+
+def test_bidi_override_does_not_reach_the_rendered_cell(
+    smoke_vm: SmokeVM, webui: WebUI, _seeded_bidi_row: None
+) -> None:
+    """The row renders, and carries no bidi control that could reverse it (issue #2041)."""
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+
+    resp = webui.get(STATS_PAGE)
+    result = evaluate_render(STATS_PAGE, resp.status_code, resp.text, ("Alert Settings",))
+    assert result.ok, f"Tier-A render oracle failed for the DNSBL stats page: {result.detail}"
+
+    body = resp.text
+    # Fixture sanity first: a page that never rendered the row would pass the bidi
+    # assertion vacuously.
+    assert "evil-rv2041" in body, (
+        "the seeded dnsbl.log row did not render at all -- fixture broken, not a #2041 signal"
+    )
+    assert RLO not in body, (
+        "U+202E reached the rendered Alerts markup -- a log-derived value can be displayed "
+        "reversed relative to the bytes actually logged (issue #2041)"
+    )
+    # The whole set pfb_hsc() strips, so a partial revert is caught too.
+    for ch in ("؜", "‎", "‏", "‪", "‫", "‬", "‭",
+               "⁦", "⁧", "⁨", "⁩"):
+        assert ch not in body, f"bidi control U+{ord(ch):04X} reached the rendered markup (issue #2041)"
+
+    guard.assert_no_growth()

--- a/tests/smoke/ui/test_alerts_bidi_control_render.py
+++ b/tests/smoke/ui/test_alerts_bidi_control_render.py
@@ -41,10 +41,7 @@ SPOOF_DOM = f"evil-rv2041{RLO}gnp.exe"
 FIXED_TS = "2030-01-15 09:00:05"
 
 # dnsbl.log CSV shape: l_type,ts,domain,src_ip,agent,block_mode,group,final_domain,feed,dup,qtype
-_LOG_LINE = (
-    f"DNSBL-python,{FIXED_TS},{SPOOF_DOM},127.0.0.1,Python,"
-    f"DNSBL_TLD,RV2041Group,{SPOOF_DOM},RV2041Feed,+,A\n"
-)
+_LOG_LINE = f"DNSBL-python,{FIXED_TS},{SPOOF_DOM},127.0.0.1,Python,DNSBL_TLD,RV2041Group,{SPOOF_DOM},RV2041Feed,+,A\n"
 
 
 @pytest.fixture
@@ -102,16 +99,13 @@ def test_bidi_override_does_not_reach_the_rendered_cell(
     body = resp.text
     # Fixture sanity first: a page that never rendered the row would pass the bidi
     # assertion vacuously.
-    assert "evil-rv2041" in body, (
-        "the seeded dnsbl.log row did not render at all -- fixture broken, not a #2041 signal"
-    )
+    assert "evil-rv2041" in body, "the seeded dnsbl.log row did not render at all -- fixture broken, not a #2041 signal"
     assert RLO not in body, (
         "U+202E reached the rendered Alerts markup -- a log-derived value can be displayed "
         "reversed relative to the bytes actually logged (issue #2041)"
     )
     # The whole set pfb_hsc() strips, so a partial revert is caught too.
-    for ch in ("؜", "‎", "‏", "‪", "‫", "‬", "‭",
-               "⁦", "⁧", "⁨", "⁩"):
+    for ch in ("؜", "‎", "‏", "‪", "‫", "‬", "‭", "⁦", "⁧", "⁨", "⁩"):
         assert ch not in body, f"bidi control U+{ord(ch):04X} reached the rendered markup (issue #2041)"
 
     guard.assert_no_growth()


### PR DESCRIPTION
Fixes #2041.

## Fix

`pfb_hsc()` now strips Unicode bidirectional controls after encoding: the marks (U+061C, U+200E, U+200F), the embedding/override set (U+202A–U+202E) and the isolates (U+2066–U+2069).

Two ordering decisions worth review:

**Strip after encoding, not before.** `ENT_SUBSTITUTE` guarantees valid UTF-8 output, and `preg_replace()`'s `/u` returns `NULL` on invalid input. Stripping first would hand that `NULL` straight into the cell for exactly the malformed values #1814 exists to keep rendering. No entity `htmlspecialchars()` emits falls in the stripped set, so running after cannot corrupt one. A `NULL` from `preg_replace()` falls back to the encoded value rather than blanking the cell.

**Only the bidi set, not all of `\p{C}`.** The issue offers either. This is the encode chokepoint for every Alerts and Reports cell, and `\p{C}` would also strip newlines and tabs from values that may legitimately carry them. The bidi set is what produces the spoof.

## Verification — live box, red then green

Reproduced on a real pfSense CE 2.8.1 box (XCP-ng lifecycle clone, this branch deployed via `scripts/deploy.sh`), by seeding a `dnsbl.log` row whose domain carries U+202E:

```
seeded hex: 6576696c e280ae 676e702e657865      ("evil" U+202E "gnp.exe")
```

**Before** — `pfblockerng_alerts.php?view=dnsbl_stat`:

```
raw U+202E count in HTML: 6
```

**After** the fix, same page, same seeded row:

```
raw U+202E count in HTML: 0
seeded row still rendered: True
```

So the row still displays; only the reordering characters are gone.

## Unit tests

`tests/php/AlertsBidiControlStripTest.php` — 17 tests, 35 assertions, via the existing `AlertsPageLoader`:

- each of the 12 controls individually stripped, surrounding text untouched
- the issue's spoof (`safe\u{202E}gnp.exe` → `safegnp.exe`)
- HTML metacharacters still encoded — this must not become the only thing `pfb_hsc()` does
- invalid UTF-8 still renders (#1814 regression guard)
- invalid UTF-8 *carrying* a bidi control — both handled, neither blanks the value
- non-control Unicode survives (`bücher.de`, `日本.jp`)

Mutation probe: replacing the strip with `$stripped = $encoded;` fails 14 of 17. Restored, all 17 pass. Whole Alerts suite green: `223 tests, 906 assertions`.

## Residual, deliberately not changed

The threats-page link still carries the true logged domain percent-encoded in its query string (`?domain=evil%E2%80%AEgnp.exe`). That is the lookup target and must remain the real value; percent-encoded it cannot reorder anything. If `pfblockerng_threats.php` renders that parameter it inherits this same chokepoint.

Tier-A UI coverage is the natural complement, as the issue notes; the live red→green above is what I could execute here.
