### PR TITLE
pkg: use canonical project URLs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -484,7 +484,7 @@ jobs:
       # (already declared). smoke_repo_* (generic channel URL) lands when that
       # 48k callee can be updated; actionlint rejects undeclared inputs.
       pytest_filter: test_install_from_live_nightly_url
-      smoke_nightly_live_url: https://pfblockerng.github.io/pkg/nightly
+      smoke_nightly_live_url: https://pkg.pfblockerng.com/nightly
       smoke_nightly_expected_source_sha: ${{ needs.prepare.outputs.source_sha }}
       smoke_nightly_expected_version: ${{ needs.prepare.outputs.pkg_version }}
     secrets: inherit

--- a/.github/workflows/pkg-render-site.yml
+++ b/.github/workflows/pkg-render-site.yml
@@ -88,7 +88,7 @@ jobs:
         env:
           SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
           ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}
-          BASE_URL: https://pfblockerng.github.io/pkg
+          BASE_URL: https://pkg.pfblockerng.com
         # Path env vars are exported HERE, not in the env: map above — GitHub
         # Actions never shell-expands env-map values, so `$GITHUB_WORKSPACE`
         # there reaches the job as a literal dollar-string (issue #2231). The

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -369,7 +369,7 @@ jobs:
       extra_pkgs: ${{ toJson(matrix.extra_pkgs) }}
       pytest_marker: repo
       pytest_filter: test_install_from_live_pages_url
-      smoke_repo_live_url: https://pfblockerng.github.io/pkg/${{ needs.publish-pkg-repo.outputs.staging_prefix }}/${{ matrix.channel }}
+      smoke_repo_live_url: https://pkg.pfblockerng.com/${{ needs.publish-pkg-repo.outputs.staging_prefix }}/${{ matrix.channel }}
       smoke_repo_expected_source_sha: ${{ needs.resolve.outputs.source_sha }}
       smoke_repo_expected_version: ${{ needs.resolve.outputs.portversion }}
       smoke_repo_expected_channel: ${{ needs.resolve.outputs.channel }}

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -85,7 +85,7 @@ on:
         required: false
         default: "1"
       smoke_nightly_live_url:
-        description: "Live nightly Pages base URL for test_install_from_live_nightly_url (e.g. https://pfblockerng.github.io/pkg/nightly). Blank -> SKIP."
+        description: "Live nightly Pages base URL for test_install_from_live_nightly_url (e.g. https://pkg.pfblockerng.com/nightly). Blank -> SKIP."
         required: false
         default: ""
       smoke_nightly_expected_source_sha:
@@ -97,7 +97,7 @@ on:
         required: false
         default: ""
       smoke_repo_live_url:
-        description: "Live channel Pages base URL for test_install_from_live_pages_url (e.g. https://pfblockerng.github.io/pkg/stable). Blank -> SKIP."
+        description: "Live channel Pages base URL for test_install_from_live_pages_url (e.g. https://pkg.pfblockerng.com/stable). Blank -> SKIP."
         required: false
         default: ""
       smoke_repo_expected_source_sha:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -436,7 +436,7 @@ is installing a retained older version rather than re-deploying a site.
   moves the box to a different varver.
 - **NONE-signed, TLS-anchored.** No signing key in CI; trust is HTTPS to the Pages host. The
   catalog is served at the project's GitHub Pages URL, e.g.
-  **`https://pfblockerng.github.io/pkg/stable/ce-2.8`**.
+  **`https://pkg.pfblockerng.com/stable/ce-2.8`**.
 - **Generators.** `scripts/build-repo-portable.py` is the primary — pure Python (stdlib +
   `zstd`), no libpkg, run on a plain Linux runner. `scripts/build-repo.sh` (real `pkg repo`
   in a FreeBSD VM) is the fidelity fallback, and both share the exact `--print-conf` shape

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ under the **Apache License 2.0**.
 
 > [!NOTE]
 > For day-to-day usage and configuration, start with the
-> [official pfBlockerNG documentation](https://pfblockerng.github.io/).
+> [official pfBlockerNG documentation](https://pfblockerng.com/).
 
 ## Features
 
@@ -61,14 +61,14 @@ under the **Apache License 2.0**.
 
 > [!TIP]
 > The package repository's landing page —
-> **[pfblockerng.github.io/pkg](https://pfblockerng.github.io/pkg)** — is the
+> **[pkg.pfblockerng.com](https://pkg.pfblockerng.com)** — is the
 > main installation page: current versions, ready-to-copy commands, and older
 > releases, per pfSense edition.
 
 Run this **on the firewall** over SSH (as root), picking the channel you want:
 
 ```sh
-fetch -qo - https://pfblockerng.github.io/pkg/install.sh | sh -s -- --channel stable
+fetch -qo - https://pkg.pfblockerng.com/install.sh | sh -s -- --channel stable
 ```
 
 One command from **any** starting state: a fresh firewall, an existing Netgate
@@ -109,7 +109,7 @@ Run the same one-liner as [Installation](#installation), just with a
 different `--channel`:
 
 ```sh
-fetch -qo - https://pfblockerng.github.io/pkg/install.sh | sh -s -- --channel edge
+fetch -qo - https://pkg.pfblockerng.com/install.sh | sh -s -- --channel edge
 ```
 
 It moves the subscription, moves the installed package onto it, replaces a
@@ -149,7 +149,7 @@ pkg upgrade pfSense-pkg-pfBlockerNG
 
 ## Usage
 
-The [official documentation](https://pfblockerng.github.io/) is the
+The [official documentation](https://pfblockerng.com/) is the
 general configuration reference. Two additions are worth calling out.
 
 ### Update Hooks
@@ -228,7 +228,7 @@ channel you named, and verifies your configuration survived.
 Each channel catalog keeps several recent versions, and a faster channel also
 keeps everything its slower channels still carry — so an older build stays
 available in the catalog you are already subscribed to. The
-[repository landing page](https://pfblockerng.github.io/pkg) lists the retained
+[repository landing page](https://pkg.pfblockerng.com) lists the retained
 versions per pfSense edition, with their commit and date. Moving to one of them
 is a channel-style downgrade; see the caution under
 [Switching channels](#switching-channels).
@@ -243,9 +243,9 @@ channel recipe you want, e.g. `net/pfSense-pkg-pfBlockerNG-edge` (the line the
 ## Documentation
 
 - **Using pfBlockerNG:**
-  [official user documentation](https://pfblockerng.github.io/).
+  [official user documentation](https://pfblockerng.com/).
 - **Installing project builds:**
-  [package repository](https://pfblockerng.github.io/pkg).
+  [package repository](https://pkg.pfblockerng.com).
 - **Developing, testing, and releasing this package:**
   [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1105,7 +1105,7 @@ points install.sh's own `PFB_BASE_URL` default at the site's own base first (iss
 B3/F3), then the hook body is spliced into THAT text's `PFB_EMBED_HOOK` block — a
 single-quoted heredoc (`cat <<'PFB_HOOK_HEREDOC'`) so
 none of the hook's dollar-signs or backticks are expanded. Published at
-`pfblockerng.github.io/pkg/install.sh`, what the README's one-liners
+`pkg.pfblockerng.com/install.sh`, what the README's one-liners
 (`fetch -qo - <base>/install.sh | sh -s -- --channel <ch>`) point to.
 
 Full design: ADR-39.
@@ -1136,7 +1136,7 @@ Full design: ADR-39.
   (`scripts/live_gate_matrix.py`) fans the CI legs
   whose varver was touched out per destination; `validate-live-pages-install` runs `smoke-single.yml`
   (`pytest_marker: repo`, `test_install_from_live_pages_url`) per leg against
-  `https://pfblockerng.github.io/pkg/staging/<seg>/<channel>` with expected version = portversion and
+  `https://pkg.pfblockerng.com/staging/<seg>/<channel>` with expected version = portversion and
   expected `pfb_build_record.source_sha` = the tag commit — the staged URL's last segment is the
   channel, so `build-repo-portable.py --print-conf` derives the real `pfblockerng-<channel>` repo
   name and the box's `%R` matches. `promote-pkg-repo` (`always()`, only when the stage succeeded and
@@ -1292,7 +1292,7 @@ Full design: ADR-39.
   (`scripts/install-from-repo.sh` likewise derives its `py3xx-*` deps from the matrix, matching the
   box's FreeBSD major.) Dispatch: `gh workflow run smoke-single.yml -f
   pytest_marker=repo` (or `repo-install.yml` once it lands on `devel`). The gated
-  `test_install_from_live_pages_url` (`SMOKE_REPO_LIVE_URL`) hits the real `pfblockerng.github.io`
+  `test_install_from_live_pages_url` (`SMOKE_REPO_LIVE_URL`) hits the real `pkg.pfblockerng.com`
   URL — post-merge (a new `workflow_dispatch` workflow is only dispatchable from the default
   branch).
 

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -66,7 +66,7 @@ META_CONF = (
 # base Netgate `pfSense` repo (priority 0) because priority — not version —
 # decides cross-repo resolution. Base URL is this repo's GitHub Pages root
 # (ADR-39; the Cloudflare Worker has been retired).
-DEFAULT_BASE_URL = "https://pfblockerng.github.io/pkg"
+DEFAULT_BASE_URL = "https://pkg.pfblockerng.com"
 CONF_PRIORITY = 100
 
 # Per-channel repo-conf stanza key (issue #2147 step B): the four channels

--- a/scripts/build-repo.sh
+++ b/scripts/build-repo.sh
@@ -44,7 +44,7 @@ set -eu
 # an OS upgrade. priority sits above the base Netgate `pfSense` repo (ships 0)
 # because priority — not version — decides cross-repo resolution; that is the
 # lever that makes the pfBlockerNG build win. Override the base with --base-url for a fork.
-DEFAULT_BASE_URL="https://pfblockerng.github.io/pkg"
+DEFAULT_BASE_URL="https://pkg.pfblockerng.com"
 CONF_PRIORITY=100
 
 # Per-channel repo-conf stanza key (issue #2147 step B): the four channels

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -1179,7 +1179,7 @@ def _render_catalogue_browse_page(docs: str, full_rel: str) -> str:
 # carries — replaced with the SITE's own base at render time (issues #2416 /
 # B3/F3) so a fork or staged prefix ships an installer that resolves against
 # itself without requiring every user to override PFB_BASE_URL by hand.
-_BASE_URL_DEFAULT_LINE = 'PFB_BASE_URL="${PFB_BASE_URL:-https://pfblockerng.github.io/pkg}"'
+_BASE_URL_DEFAULT_LINE = 'PFB_BASE_URL="${PFB_BASE_URL:-https://pkg.pfblockerng.com}"'
 
 
 def _shell_single_quote(value: str) -> str:
@@ -1452,7 +1452,7 @@ def write_site(site: str, base: str, site_tree: str, matrix: list[dict] | None =
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Render the pkg-site tree onto the pkg repo's docs/ and mirror it there.")
     ap.add_argument("site", help="the docs/ tree to render into (the built catalog trees already live there)")
-    ap.add_argument("base_url", help="the Pages base URL, e.g. https://pfblockerng.github.io/pkg")
+    ap.add_argument("base_url", help="the Pages base URL, e.g. https://pkg.pfblockerng.com")
     ap.add_argument("--site-tree", required=True, help="the pkg-site/ source tree to render (this repo's pkg-site/)")
     ap.add_argument(
         "--matrix",

--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -1452,7 +1452,7 @@ def write_site(site: str, base: str, site_tree: str, matrix: list[dict] | None =
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Render the pkg-site tree onto the pkg repo's docs/ and mirror it there.")
     ap.add_argument("site", help="the docs/ tree to render into (the built catalog trees already live there)")
-    ap.add_argument("base_url", help="the Pages base URL, e.g. https://pkg.pfblockerng.com")
+    ap.add_argument("base_url", help="the package repository base URL, e.g. https://pkg.pfblockerng.com")
     ap.add_argument("--site-tree", required=True, help="the pkg-site/ source tree to render (this repo's pkg-site/)")
     ap.add_argument(
         "--matrix",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,12 +21,12 @@
 #   install.sh -h|--help                                  this text
 #
 # Published at ${PFB_BASE_URL}/install.sh; run ON the box:
-#   fetch -qo - https://pfblockerng.github.io/pkg/install.sh | sh -s -- --channel stable
+#   fetch -qo - https://pkg.pfblockerng.com/install.sh | sh -s -- --channel stable
 #
 # Env (all overridable; forks/staging/tests set these):
 #   PKG_BIN           pkg(8) binary path (default: /usr/local/sbin/pkg)
 #   PFBLOCKERNG_ROOT  filesystem root prefix (default: /)
-#   PFB_BASE_URL      catalog base (default: https://pfblockerng.github.io/pkg)
+#   PFB_BASE_URL      catalog base (default: https://pkg.pfblockerng.com)
 #   PFB_SSL_CA_CERT_PATH  CA hash dir exported to pkg (default: <root>/etc/ssl/certs)
 #   PFB_SSL_CA_CERT_FILE  CA bundle exported to pkg (default: <root>/etc/ssl/cert.pem)
 #                         Each half is guarded independently and exported on its own: the
@@ -47,7 +47,7 @@ HOOK_SRC="${SCRIPT_DIR}/rc.d/pfblockerng_repo_generate.sh"
 PKG_BIN="${PKG_BIN:-/usr/local/sbin/pkg}"
 PFBLOCKERNG_ROOT="${PFBLOCKERNG_ROOT:-/}"
 ROOT="${PFBLOCKERNG_ROOT%/}"
-PFB_BASE_URL="${PFB_BASE_URL:-https://pfblockerng.github.io/pkg}"
+PFB_BASE_URL="${PFB_BASE_URL:-https://pkg.pfblockerng.com}"
 
 CANONICAL_PKG="pfSense-pkg-pfBlockerNG"
 REPOS_DIR="${ROOT}/usr/local/etc/pkg/repos"

--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -105,7 +105,7 @@ name="pfblockerng_repo_generate"
 # of its own. Deliberately NOT named PFB_DEFAULT_BASE_URL: gen_landing.py injects
 # a variable of that name into install.sh, and the published installer carries
 # this hook embedded in it.
-PFB_FALLBACK_BASE_URL='https://pfblockerng.github.io/pkg'
+PFB_FALLBACK_BASE_URL='https://pkg.pfblockerng.com'
 
 CONF_PRIORITY=100
 
@@ -140,7 +140,7 @@ _detect_catalog() {
 # WHY (issue #2459): at boot there is no environment, so composing the url from
 # a hardcoded default rewrote every conf to the primary Pages site — a fork
 # site, a staging prefix and a `file://` guest catalogue all silently became
-# https://pfblockerng.github.io/pkg, redirecting where the box fetches packages
+# https://pkg.pfblockerng.com, redirecting where the box fetches packages
 # from. Reading the base back out of the conf keeps the OS-upgrade job the hook
 # exists for (move the <varver>) without moving anything else.
 #

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -556,7 +556,7 @@ $section->addInput(new Form_StaticText(
 	<a target="_blank" rel="noopener noreferrer" href="https://forum.netgate.com/user/bbcan177">BBcan177</a><br />
 
 	<ul class="list-inline" style="margin-top: 4px; margin-bottom: -2px; border-style: outset; border-bottom-color: #8B181B; border-right-color: #8B181B; border-width: 2px;">
-		<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">
+		<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://pfblockerng.com">
 			<span style="color: #8B181B;" class="fa-solid fa-globe"></span> HomePage</a></li>
 		<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://twitter.com/intent/follow?screen_name=BBcan177">
 			<span style="color: #8B181B;" class="fa-brands fa-twitter"></span> Follow on X formerly Twitter</a></li>
@@ -573,7 +573,7 @@ $section->addInput(new Form_StaticText(
 </div>
 
 <div style="width: 25%; height: 170px; float: right;">
-	<a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">
+	<a target="_blank" rel="noopener noreferrer" href="https://pfblockerng.com">
 
 <svg width="180.0pt" height="180.0pt" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="30 225 560 470" style="enable-background:new 30 225 560 470;" xml:space="preserve">

--- a/src/usr/local/www/pfblockerng/www/dnsbl_default.php
+++ b/src/usr/local/www/pfblockerng/www/dnsbl_default.php
@@ -160,7 +160,7 @@
 				</tbody>
 			</table>
 			<div>Powered by: <strong>pfBlockerNG DNSBL</strong>&emsp;
-				<a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">pfBlockerNG.com</a>
+				<a target="_blank" rel="noopener noreferrer" href="https://pfblockerng.com">pfBlockerNG.com</a>
 			</div>
 		</div>
 	</div>

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -35,7 +35,7 @@
 				<a target="_blank" rel="noopener noreferrer" href="https://forum.netgate.com/user/bbcan177">BBcan177</a><br />
 
 			<ul class="list-inline" style="margin-top: 4px; margin-bottom: -2px; border-style: outset; border-bottom-color: #8B181B; border-right-color: #8B181B; border-width: 2px;">
-				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">
+				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://pfblockerng.com">
 					<span style="color: #8B181B;" class="fa-solid fa-globe"></span> HomePage</a></li>
 				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://twitter.com/intent/follow?screen_name=BBcan177">
 					<span style="color: #8B181B;" class="fa-brands fa-twitter"></span> Follow on Twitter</a></li>
@@ -54,7 +54,7 @@
 			</ul>
 		</div>
 		<div style="width: 25%; height: 170px; float: right;">
-			<a target="_blank" rel="noopener noreferrer" href="http://pfblockerng.com">
+			<a target="_blank" rel="noopener noreferrer" href="https://pfblockerng.com">
 		<svg width="180.0pt" height="180.0pt" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="120 225 560 470" style="enable-background:new 120 225 560 470;" xml:space="preserve">
 		<style type="text/css">
 			.st0{fill:#8B181B;}

--- a/tests/shell/generate_hook_spec.sh
+++ b/tests/shell/generate_hook_spec.sh
@@ -152,7 +152,7 @@ Describe 'generate hook — regenerate the stable conf (CE)'
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PFB_STABLE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/stable/ce-2.8"'
+      The contents of file "${PFB_STABLE_CONF}" should include 'url: "https://pkg.pfblockerng.com/stable/ce-2.8"'
       The contents of file "${PFB_STABLE_CONF}" should include "pfblockerng-stable: {"
       The contents of file "${PFB_STABLE_CONF}" should include "stable channel"
       The contents of file "${PFB_STABLE_CONF}" should not include "pending"
@@ -179,7 +179,7 @@ Describe 'generate hook — regenerate the testing conf (Plus)'
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PFB_TESTING_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/testing/plus-26.03"'
+      The contents of file "${PFB_TESTING_CONF}" should include 'url: "https://pkg.pfblockerng.com/testing/plus-26.03"'
       The contents of file "${PFB_TESTING_CONF}" should include "pfblockerng-testing: {"
       The value "$(_conf_count "${_te_dir}")" should equal 1
     End
@@ -195,7 +195,7 @@ Describe 'generate hook — regenerate the edge conf across a pfSense OS upgrade
         cat > "${PFB_EDGE_CONF}" <<'STALE'
 # Generated at boot by pfblockerng_repo_generate (ADR-39)
 pfblockerng-edge: {
-  url: "https://pfblockerng.github.io/pkg/edge/ce-2.7",
+  url: "https://pkg.pfblockerng.com/edge/ce-2.7",
   enabled: yes
 }
 STALE
@@ -213,7 +213,7 @@ STALE
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PFB_EDGE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/edge/ce-2.8"'
+      The contents of file "${PFB_EDGE_CONF}" should include 'url: "https://pkg.pfblockerng.com/edge/ce-2.8"'
       The contents of file "${PFB_EDGE_CONF}" should not include "ce-2.7"
       The path "${PKG_STUB_LOG}" should not be exist
     End
@@ -306,7 +306,7 @@ Describe 'generate hook — regenerate nightly conf (Plus)'
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PFB_NIGHTLY_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/nightly/plus-26.03"'
+      The contents of file "${PFB_NIGHTLY_CONF}" should include 'url: "https://pkg.pfblockerng.com/nightly/plus-26.03"'
       The contents of file "${PFB_NIGHTLY_CONF}" should include "pfblockerng-nightly: {"
       The contents of file "${PFB_NIGHTLY_CONF}" should include "nightly channel"
       The path "${PFB_RELEASE_CONF}" should not be exist
@@ -334,7 +334,7 @@ Describe 'generate hook — pre-release suffix strip (Plus BETA)'
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PFB_STABLE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/stable/plus-26.07"'
+      The contents of file "${PFB_STABLE_CONF}" should include 'url: "https://pkg.pfblockerng.com/stable/plus-26.07"'
       The contents of file "${PFB_STABLE_CONF}" should not include "plus-26.07-BETA"
     End
 End
@@ -357,7 +357,7 @@ Describe 'generate hook — pre-release suffix strip (CE RC)'
       When run sh "${HOOK}" onestart
       The status should be success
       The stderr should include "regenerated"
-      The contents of file "${PFB_EDGE_CONF}" should include 'url: "https://pfblockerng.github.io/pkg/edge/ce-2.9"'
+      The contents of file "${PFB_EDGE_CONF}" should include 'url: "https://pkg.pfblockerng.com/edge/ce-2.9"'
       The contents of file "${PFB_EDGE_CONF}" should not include "ce-2.9-RC"
     End
 End
@@ -372,7 +372,7 @@ Describe 'generate hook — unconditional rewrite of a stale-varver conf'
         cat > "${PFB_TESTING_CONF}" <<'EOF'
 # old generated body
 pfblockerng-testing: {
-  url: "https://pfblockerng.github.io/pkg/testing/ce-2.7",
+  url: "https://pkg.pfblockerng.com/testing/ce-2.7",
   enabled: yes
 }
 EOF
@@ -432,7 +432,7 @@ End
 # Issue #2459. `_regen_one` used to compose the url from PFB_BASE_URL alone,
 # defaulting to the primary Pages site. At boot there is no env, so a fork site,
 # a staging prefix and a `file://` guest catalogue were all silently rewritten to
-# `https://pfblockerng.github.io/pkg` — a redirect of where the box fetches
+# `https://pkg.pfblockerng.com` — a redirect of where the box fetches
 # packages from. The base now comes from the conf the hook is about to rewrite
 # (its url's `<base>/<channel>/<varver>` shape), so only the varver moves; an
 # explicit PFB_BASE_URL still wins, and a url the hook cannot parse as its own
@@ -463,7 +463,7 @@ FILEURL
       The status should be success
       The stderr should include "regenerated"
       The contents of file "${PFB_STABLE_CONF}" should include 'url: "file:///root/pfb_repo/stable/ce-2.8"'
-      The contents of file "${PFB_STABLE_CONF}" should not include "pfblockerng.github.io"
+      The contents of file "${PFB_STABLE_CONF}" should not include "pkg.pfblockerng.com"
     End
 End
 
@@ -492,7 +492,7 @@ STAGEURL
       The status should be success
       The stderr should include "regenerated"
       The contents of file "${PFB_EDGE_CONF}" should include 'url: "https://fork.example.org/pkg/staging/pr-7/edge/ce-2.8"'
-      The contents of file "${PFB_EDGE_CONF}" should not include "pfblockerng.github.io"
+      The contents of file "${PFB_EDGE_CONF}" should not include "pkg.pfblockerng.com"
     End
 End
 
@@ -527,7 +527,7 @@ FOREIGN
       The stderr should include "WARNING"
       The stderr should include "did not write"
       The value "$(cksum < "${PFB_NIGHTLY_CONF}")" should equal "${_fo_sum}"
-      The contents of file "${PFB_NIGHTLY_CONF}" should not include "pfblockerng.github.io"
+      The contents of file "${PFB_NIGHTLY_CONF}" should not include "pkg.pfblockerng.com"
     End
 End
 
@@ -612,9 +612,9 @@ UNTERM
       The status should be success
       The stderr should include "did not write"
       The value "$(cat "${PFB_STABLE_CONF}" "${PFB_EDGE_CONF}" "${PFB_NIGHTLY_CONF}" | cksum)" should equal "${_up_sums}"
-      The contents of file "${PFB_STABLE_CONF}" should not include "pfblockerng.github.io"
-      The contents of file "${PFB_EDGE_CONF}" should not include "pfblockerng.github.io"
-      The contents of file "${PFB_NIGHTLY_CONF}" should not include "pfblockerng.github.io"
+      The contents of file "${PFB_STABLE_CONF}" should not include "pkg.pfblockerng.com"
+      The contents of file "${PFB_EDGE_CONF}" should not include "pkg.pfblockerng.com"
+      The contents of file "${PFB_NIGHTLY_CONF}" should not include "pkg.pfblockerng.com"
     End
 End
 
@@ -748,7 +748,7 @@ CONFSLASH
       The status should be success
       The stderr should include "regenerated"
       The contents of file "${PFB_TESTING_CONF}" should include 'url: "https://fork.example.org/pkg/testing/ce-2.8"'
-      The contents of file "${PFB_TESTING_CONF}" should not include "pfblockerng.github.io"
+      The contents of file "${PFB_TESTING_CONF}" should not include "pkg.pfblockerng.com"
     End
 End
 
@@ -781,7 +781,7 @@ UPCASE
       The status should be success
       The stderr should include "did not write"
       The value "$(cksum < "${PFB_EDGE_CONF}")" should equal "${_uc_sum}"
-      The contents of file "${PFB_EDGE_CONF}" should not include "pfblockerng.github.io"
+      The contents of file "${PFB_EDGE_CONF}" should not include "pkg.pfblockerng.com"
     End
 End
 
@@ -797,7 +797,7 @@ Describe 'generate hook — a pre-#1806 arch-leaf conf is frozen, not healed'
         cat > "${PFB_NIGHTLY_CONF}" <<'ARCHLEAF'
 # Generated at boot by pfblockerng_repo_generate (ADR-39)
 pfblockerng-nightly: {
-  url: "https://pfblockerng.github.io/pkg/nightly/ce-2.7/FreeBSD:15:amd64",
+  url: "https://pkg.pfblockerng.com/nightly/ce-2.7/FreeBSD:15:amd64",
   enabled: yes
 }
 ARCHLEAF

--- a/tests/shell/render_pkg_site_spec.sh
+++ b/tests/shell/render_pkg_site_spec.sh
@@ -142,7 +142,7 @@ PY
     common_env() {
         PFB_SRC="${base}/fake-src"
         PKG_REPO="${base}/pkg-repo"
-        BASE_URL=https://pfblockerng.github.io/pkg
+        BASE_URL=https://pkg.pfblockerng.com
         SOURCE_RUN_ID=10:1
         ROUTE_MATRIX='[{"freebsd_major":"15","pfsense_version":"2.8","variant":"ce","php_version":"8.3","py_flavor":"py311","arch":"amd64"}]'
         export PFB_SRC PKG_REPO BASE_URL SOURCE_RUN_ID ROUTE_MATRIX

--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -80,7 +80,7 @@ CONF = "/usr/local/etc/pkg/repos/pfb_nightly_smoke.conf"
 # Phase-5d — live nightly Pages URL check (dispatch-only; gated on SMOKE_NIGHTLY_LIVE_URL).
 # Unset -> SKIP (the file:// VM-acceptance above is the always-on proof).
 LIVE_NIGHTLY_URL_ENV = "SMOKE_NIGHTLY_LIVE_URL"
-DEFAULT_LIVE_NIGHTLY_URL = "https://pfblockerng.github.io/pkg/nightly"
+DEFAULT_LIVE_NIGHTLY_URL = "https://pkg.pfblockerng.com/nightly"
 NIGHTLY_LIVE_CONF = "/usr/local/etc/pkg/repos/pfb_nightly_live_smoke.conf"
 
 # The rc.packages install hook aborts with one of these when the registration name
@@ -325,7 +325,7 @@ def _live_nightly_url() -> str | None:
     """The live nightly Pages base to test against, or None to SKIP.
 
     Gated on ``SMOKE_NIGHTLY_LIVE_URL``: set it to the deployed nightly base
-    (e.g. ``https://pfblockerng.github.io/pkg/nightly``) after a nightly publish
+    (e.g. ``https://pkg.pfblockerng.com/nightly``) after a nightly publish
     dispatch; leave it unset and the test SKIPS.  A bare ``1``/``true`` selects
     the default base.
     """

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -157,11 +157,11 @@ LIVE_EXPECTED_VERSION_ENV = "SMOKE_REPO_EXPECTED_VERSION"
 LIVE_EXPECTED_CHANNEL_ENV = "SMOKE_REPO_EXPECTED_CHANNEL"
 NIGHTLY_EXPECTED_SOURCE_SHA_ENV = "SMOKE_NIGHTLY_EXPECTED_SOURCE_SHA"
 NIGHTLY_EXPECTED_VERSION_ENV = "SMOKE_NIGHTLY_EXPECTED_VERSION"
-DEFAULT_LIVE_BASE_URL = "https://pfblockerng.github.io/pkg/stable"
+DEFAULT_LIVE_BASE_URL = "https://pkg.pfblockerng.com/stable"
 # GitHub Pages' anycast IPs. The smoke harness sandboxes guest DNS to a mock that
-# only answers `uuid-*.com`, so `pfblockerng.github.io` does not resolve on the guest. Pinning
+# only answers `uuid-*.com`, so `pkg.pfblockerng.com` does not resolve on the guest. Pinning
 # the Pages IPs in the guest /etc/hosts lets `pkg`'s HTTPS fetch reach Pages by name
-# (TLS SNI still presents `pfblockerng.github.io`, validated by GitHub's *.github.io cert) without
+# (TLS SNI still presents `pkg.pfblockerng.com`, validated by the Pages custom-domain cert) without
 # touching the resolver. Egress is OPEN for this flow (_ensure_egress_open).
 PAGES_IPS = ("185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153")
 
@@ -1224,7 +1224,7 @@ def _live_base_url() -> str | None:
     """The live Pages base to test against, or None to SKIP.
 
     Gated on ``SMOKE_REPO_LIVE_URL``: set it to the deployed base (e.g.
-    ``https://pfblockerng.github.io/pkg/stable``, or a staged
+    ``https://pkg.pfblockerng.com/stable``, or a staged
     ``.../pkg/staging/<seg>/<channel>`` root pre-promote, issue #2389) to run the live
     check after a publish dispatch; leave it unset and the test SKIPS (the always-on
     proof is the file:// VM-acceptance above). A bare ``1``/``true`` selects the

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -454,7 +454,7 @@ def test_page_renders_clean(page: Page, webui: WebUI, php_error_log_guard: PhpEr
 # out-of-scope target="_blank" links, so a whole-body sweep would false-positive.
 # Each url is a stable href in the named page's source.
 _NOOPENER_RENDER_CASES: tuple[tuple[str, str], ...] = (
-    ("/pfblockerng/pfblockerng_general.php", "http://pfblockerng.com"),
+    ("/pfblockerng/pfblockerng_general.php", "https://pfblockerng.com"),
     ("/pfblockerng/pfblockerng_general.php", "https://forum.netgate.com/user/bbcan177"),
     # ?type=geoip: the MaxMind attribution callout only prints in the category page's
     # GeoIP view (source guards it with `$gtype == 'geoip'`).

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -661,7 +661,7 @@ def test_print_conf_matches_template(capsys: pytest.CaptureFixture[str]) -> None
     assert rc == 0
     out = capsys.readouterr().out
     assert "pfblockerng: {" in out  # the shared release repo (stable + testing)
-    assert 'url: "https://pfblockerng.github.io/pkg/release/ce-2.8/amd64"' in out
+    assert 'url: "https://pkg.pfblockerng.com/release/ce-2.8/amd64"' in out
     assert "${ABI}" not in out, "ADR-39: ${ABI} must not appear in the resolved conf"
     assert "signature_type: none," in out
     assert "priority: 100," in out
@@ -683,7 +683,7 @@ def test_print_conf_accepts_selected_channel_root(capsys: pytest.CaptureFixture[
         [
             "--print-conf",
             "--base-url",
-            "https://pfblockerng.github.io/pkg/docs/edge",
+            "https://pkg.pfblockerng.com/docs/edge",
             "--channel",
             "edge",
             "--catalog-path",
@@ -693,7 +693,7 @@ def test_print_conf_accepts_selected_channel_root(capsys: pytest.CaptureFixture[
     assert rc == 0
     out = capsys.readouterr().out
     assert "pfblockerng-edge: {" in out
-    assert 'url: "https://pfblockerng.github.io/pkg/docs/edge/ce-2.8"' in out
+    assert 'url: "https://pkg.pfblockerng.com/docs/edge/ce-2.8"' in out
 
 
 def test_print_conf_infers_selected_channel_root(capsys: pytest.CaptureFixture[str]) -> None:
@@ -702,7 +702,7 @@ def test_print_conf_infers_selected_channel_root(capsys: pytest.CaptureFixture[s
         [
             "--print-conf",
             "--base-url",
-            "https://pfblockerng.github.io/pkg/docs/edge",
+            "https://pkg.pfblockerng.com/docs/edge",
             "--catalog-path",
             "ce-2.8",
         ]
@@ -710,7 +710,7 @@ def test_print_conf_infers_selected_channel_root(capsys: pytest.CaptureFixture[s
     assert rc == 0
     out = capsys.readouterr().out
     assert "pfblockerng-edge: {" in out
-    assert 'url: "https://pfblockerng.github.io/pkg/docs/edge/ce-2.8"' in out
+    assert 'url: "https://pkg.pfblockerng.com/docs/edge/ce-2.8"' in out
 
 
 def test_print_conf_does_not_treat_host_as_channel(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -462,7 +462,7 @@ def test_write_site_record_only_pkg_drives_browse_and_landing(tmp_path: Path, mo
     assert pfb_pkg.PFB_BUILD_RECORD_KEY in annotations
 
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
+    n = gl.write_site(str(site), "https://pkg.pfblockerng.com/", str(_PKG_SITE_DIR))
     assert n == 1
 
     listing = (site / "browse" / "stable" / "ce-2.8" / "index.html").read_text()
@@ -493,7 +493,7 @@ def test_write_site_out_of_range_created_on_project_pkg_renders_dash(tmp_path: P
     os.utime(pkg, (_FILE_MTIME, _FILE_MTIME))
 
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
+    n = gl.write_site(str(site), "https://pkg.pfblockerng.com/", str(_PKG_SITE_DIR))
     assert n == 1
     listing = (site / "browse" / "stable" / "ce-2.8" / "index.html").read_text()
     row = _autoindex_row(listing, pkg.name)
@@ -1345,7 +1345,7 @@ def test_render_page_renders_all_four_channel_cards_with_correct_content() -> No
     "not yet published" blurb and must not ship an install recipe, a bare pkg
     install, or a conf snippet.
     """
-    base = "https://pfblockerng.github.io/pkg"
+    base = "https://pkg.pfblockerng.com"
     page = gl.render_page(base, [], _stub_conf, _fixture_site_tree(base))
 
     titles = {"stable": "Stable", "testing": "Testing", "edge": "Edge", "nightly": "Nightly"}
@@ -1374,10 +1374,10 @@ def test_generated_pages_share_the_main_site_chrome_and_keep_channel_accents(tmp
     """Landing and browse pages use the main site's chrome while package channels
     retain their existing blue, amber, purple, and red status cues."""
     page = gl.render_page(
-        "https://pfblockerng.github.io/pkg",
+        "https://pkg.pfblockerng.com",
         [],
         _stub_conf,
-        _fixture_site_tree("https://pfblockerng.github.io/pkg"),
+        _fixture_site_tree("https://pkg.pfblockerng.com"),
     )
     docs = tmp_path / "docs"
     docs.mkdir()
@@ -1432,7 +1432,7 @@ def test_render_page_shows_latest_and_empty_stable() -> None:
         _mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311"),
         _mx("FreeBSD:16:aarch64", "26.03", "Plus", "8.5", "py311"),
     ]
-    base = "https://pfblockerng.github.io/pkg"
+    base = "https://pkg.pfblockerng.com"
     page = gl.render_page(base, pkgs, _stub_conf, _fixture_site_tree(base), matrix)
 
     # Latest versions surfaced for the present channels.
@@ -1510,7 +1510,7 @@ def test_render_page_snippets_have_copy_buttons() -> None:
     """
     pkgs = [_pkg("testing", _CANON, "3.2.16", "FreeBSD:15:amd64", "testing/ce-2.8/FreeBSD:15:amd64/d.pkg")]
     page = gl.render_page(
-        "https://pfblockerng.github.io/pkg", pkgs, _stub_conf, _fixture_site_tree("https://pfblockerng.github.io/pkg")
+        "https://pkg.pfblockerng.com", pkgs, _stub_conf, _fixture_site_tree("https://pkg.pfblockerng.com")
     )
 
     # The button + wrapper exist, and the <pre> payload is unchanged (button is a sibling).
@@ -1518,9 +1518,7 @@ def test_render_page_snippets_have_copy_buttons() -> None:
     btn = '<button class="copy" type="button" aria-label="Copy to clipboard">Copy</button>'
     assert btn in page
     # Only published channels (testing here) get a copyable recipe + manual conf.
-    assert (
-        f"{btn}<pre>fetch -qo - https://pfblockerng.github.io/pkg/install.sh | sh -s -- --channel testing</pre>" in page
-    )
+    assert f"{btn}<pre>fetch -qo - https://pkg.pfblockerng.com/install.sh | sh -s -- --channel testing</pre>" in page
     assert f"{btn}<pre>testing-conf-snippet</pre>" in page
     assert "stable-conf-snippet" not in page
 
@@ -1595,7 +1593,7 @@ def test_unpublished_nightly_card_has_no_install_recipe() -> None:
     """Issue #2382: unpublished Nightly keeps the badge/blurb and ships no recipe."""
     pkgs = [_pkg("stable", _CANON, "3.3.2", "FreeBSD:15:*", "stable/ce-2.8/x.pkg")]
     page = gl.render_page(
-        "https://pfblockerng.github.io/pkg", pkgs, _stub_conf, _fixture_site_tree("https://pfblockerng.github.io/pkg")
+        "https://pkg.pfblockerng.com", pkgs, _stub_conf, _fixture_site_tree("https://pkg.pfblockerng.com")
     )
     nightly = page[page.index('"card nightly"') :]
     # The nightly card ends at the next footer-ish boundary; search the nightly
@@ -1614,7 +1612,7 @@ def test_published_card_recipe_is_the_one_line_channel_installer() -> None:
     follow-up: the single install.sh is the SOLE client entry point on the landing
     cards)."""
     pkgs = [_pkg("stable", _CANON, "3.3.2", "FreeBSD:15:*", "stable/ce-2.8/x.pkg")]
-    base = "https://pfblockerng.github.io/pkg"
+    base = "https://pkg.pfblockerng.com"
     page = gl.render_page(base, pkgs, _stub_conf, _fixture_site_tree(base))
     # Anchored to the <pre> element boundary so a trailing `sh -s --` (or any other
     # tail) fails this assertion rather than slipping past a bare substring check.
@@ -1730,7 +1728,7 @@ def test_write_site_keeps_dependency_packages_browsable(tmp_path: Path, monkeypa
     monkeypatch.setattr(gl, "read_compact_manifest", lambda p: manifests[os.path.basename(p)])
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
+    n = gl.write_site(str(site), "https://pkg.pfblockerng.com/", str(_PKG_SITE_DIR))
 
     assert n == 1  # the count is pfBlockerNG packages, not everything published
     # No index.html is ever written INSIDE the catalogue tree any more (issue #2450).
@@ -1752,7 +1750,7 @@ def test_write_site_emits_browse_pages_outside_the_catalogue_tree(tmp_path: Path
     monkeypatch.setattr(gl, "read_compact_manifest", lambda p: manifest)
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
+    n = gl.write_site(str(site), "https://pkg.pfblockerng.com/", str(_PKG_SITE_DIR))
 
     assert n == 1
     # Landing page (root) links to the browse entry; browse.html exists and lists the top dirs.
@@ -1802,7 +1800,7 @@ def test_write_site_never_indexes_docs_staging(tmp_path: Path, monkeypatch: Any)
     monkeypatch.setattr(gl, "read_compact_manifest", lambda p: manifest)
     monkeypatch.setattr(gl, "_conf_via_portable", lambda base, ch: f"{ch}-conf")
 
-    n = gl.write_site(str(site), "https://pfblockerng.github.io/pkg/", str(_PKG_SITE_DIR))
+    n = gl.write_site(str(site), "https://pkg.pfblockerng.com/", str(_PKG_SITE_DIR))
 
     # The staged package never counts toward a real channel (it sits under an
     # unrecognized top-level dir, exactly like any other stray future dir).
@@ -2204,10 +2202,10 @@ def test_eol_versions_section_absent_from_rendered_page_when_no_route_only() -> 
     matrix = [_mx("FreeBSD:15:amd64", "2.8", "CE", "8.3", "py311")]
 
     page = gl.render_page(
-        "https://pfblockerng.github.io/pkg",
+        "https://pkg.pfblockerng.com",
         pkgs,
         _stub_conf,
-        _fixture_site_tree("https://pfblockerng.github.io/pkg"),
+        _fixture_site_tree("https://pkg.pfblockerng.com"),
         matrix,
     )
 
@@ -2240,10 +2238,10 @@ def test_eol_versions_section_present_in_rendered_page_with_route_only() -> None
     ]
 
     page = gl.render_page(
-        "https://pfblockerng.github.io/pkg",
+        "https://pkg.pfblockerng.com",
         [live_pkg, eol_ce, eol_plus],
         _stub_conf,
-        _fixture_site_tree("https://pfblockerng.github.io/pkg"),
+        _fixture_site_tree("https://pkg.pfblockerng.com"),
         matrix,
     )
 
@@ -2279,7 +2277,7 @@ def test_conf_via_portable_matches_real_build_repo_portable_contract() -> None:
     live publish workflow. All four channels are exercised (branch coverage) — every
     one of them has its OWN repo/conf (issue #2147).
     """
-    base: str = "https://pfblockerng.github.io/pkg"
+    base: str = "https://pkg.pfblockerng.com"
 
     for channel in gl.CH_ORDER:
         conf: str = gl._conf_via_portable(base, channel)
@@ -3176,7 +3174,7 @@ def test_readme_install_snippets_match_the_pkg_site_recipes() -> None:
     channels = _README_FETCH_RE.findall(readme)
     assert channels, "README.md carries no fetch|sh --channel snippet to check"
 
-    base = "https://pfblockerng.github.io/pkg"
+    base = "https://pkg.pfblockerng.com"
     for line in readme.splitlines():
         m = _README_FETCH_RE.search(line)
         if not m:

--- a/tests/test_issue2389_live_pages_gate.py
+++ b/tests/test_issue2389_live_pages_gate.py
@@ -28,7 +28,7 @@ def test_nightly_post_publish_passes_live_identity() -> None:
     assert "uses: ./.github/workflows/smoke-single.yml" in job
     assert "pytest_marker: repo" in job
     assert "pytest_filter: test_install_from_live_nightly_url" in job
-    assert "smoke_nightly_live_url: https://pfblockerng.github.io/pkg/nightly" in job
+    assert "smoke_nightly_live_url: https://pkg.pfblockerng.com/nightly" in job
     assert "smoke_nightly_expected_source_sha: ${{ needs.prepare.outputs.source_sha }}" in job
     assert "smoke_nightly_expected_version: ${{ needs.prepare.outputs.pkg_version }}" in job
     # smoke_repo_* is the GENERIC channel input (smoke-single.yml declares it,
@@ -147,4 +147,4 @@ def test_release_published_prepare_live_gate_uses_shared_matrix_builder() -> Non
 def test_default_live_base_url_is_stable() -> None:
     from tests.smoke import test_repo_install as repo_install
 
-    assert repo_install.DEFAULT_LIVE_BASE_URL == "https://pfblockerng.github.io/pkg/stable"
+    assert repo_install.DEFAULT_LIVE_BASE_URL == "https://pkg.pfblockerng.com/stable"

--- a/tests/test_issue2450_render_site_workflow.py
+++ b/tests/test_issue2450_render_site_workflow.py
@@ -59,7 +59,7 @@ def test_render_site_job_runs_the_renderer_with_full_env_contract() -> None:
     assert "sh scripts/render-pkg-site.sh" in step
     assert "SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}" in step
     assert "ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}" in step
-    assert "BASE_URL: https://pfblockerng.github.io/pkg" in step
+    assert "BASE_URL: https://pkg.pfblockerng.com" in step
     assert 'export PFB_SRC="$GITHUB_WORKSPACE"' in step
     assert 'export PKG_REPO="$GITHUB_WORKSPACE/pkg-repo"' in step
 

--- a/tests/test_issue2540_canonical_urls.py
+++ b/tests/test_issue2540_canonical_urls.py
@@ -1,0 +1,38 @@
+"""Active tracked files use the canonical package and main-site endpoints."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+TEST_PATH = Path(__file__).relative_to(ROOT)
+LEGACY_PACKAGE_HOST = ".".join(("pfblockerng", "github", "io"))
+INSECURE_MAIN_URL = "http://" + ".".join(("pfblockerng", "com"))
+
+
+def test_active_files_have_no_retired_project_endpoints() -> None:
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    findings: list[str] = []
+
+    for raw_path in tracked:
+        if not raw_path:
+            continue
+        path = Path(os.fsdecode(raw_path))
+        if path == TEST_PATH or path.parts[0] == "legacy":
+            continue
+        file_path = ROOT / path
+        if not file_path.is_file():
+            continue
+        text = file_path.read_bytes().decode("utf-8", errors="replace")
+        for line_number, line in enumerate(text.splitlines(), 1):
+            if LEGACY_PACKAGE_HOST in line or INSECURE_MAIN_URL in line:
+                findings.append(f"{path}:{line_number}: {line}")
+
+    assert not findings, "retired active endpoints remain:\n" + "\n".join(findings)

--- a/tests/test_repo_conf_generators.py
+++ b/tests/test_repo_conf_generators.py
@@ -10,7 +10,7 @@ ADR-39 rework: the conf URL is now a DIRECT, fully-resolved GitHub Pages URL
 (NO_ARCH — all three pfSense-pkg-pfBlockerNG ports are NO_ARCH, so one varver
 serves every arch of its FreeBSD major):
 
-    https://pfblockerng.github.io/pkg/<channel>/<varver>
+    https://pkg.pfblockerng.com/<channel>/<varver>
 
 The ``<varver>`` segment is resolved by the boot-time ``rc.d`` generator hook
 (``pfblockerng_repo_generate.sh``), whose detection is folded in (ADR-39): edition =
@@ -50,7 +50,7 @@ _BUILD_REPO = _SCRIPTS / "build-repo.sh"
 _BUILD_REPO_PORTABLE = _SCRIPTS / "build-repo-portable.py"
 _HOOK = _SCRIPTS / "rc.d" / "pfblockerng_repo_generate.sh"
 
-_PAGES_BASE = "https://pfblockerng.github.io/pkg"
+_PAGES_BASE = "https://pkg.pfblockerng.com"
 
 # Representative catalog paths for byte-identity and URL-shape tests.
 _CE_28 = "ce-2.8"


### PR DESCRIPTION
## What changed

- switch package repository defaults, generated commands, publishing workflows, and live smoke inputs to `https://pkg.pfblockerng.com`
- switch active documentation links to `https://pfblockerng.com`
- normalize the remaining package UI links from HTTP to HTTPS
- update renderer, installer, repository-generator, smoke, shell, and UI expectations
- add a tree-wide regression test that rejects retired active endpoints while excluding immutable history

## Why

The package and main sites now use custom domains. The legacy GitHub Pages hosts redirect correctly, but generated package configuration and operator-facing commands should use the canonical endpoints directly.

Live verification before the change:

- the new package installer URL returns `200` with shell content
- the old package URL redirects to the new package host
- the new main-site URL returns `200`
- the old main-site URL redirects to the new main host

## Verification

- frozen red/green test `tests/test_issue2540_canonical_urls.py`, hash `2ea4d34309fb70b3beb18d8b15d6396f9e856555`
  - RED against untouched `devel`: failed with the retired workflow, docs, installer, UI, and test endpoints
  - GREEN unchanged: `1 passed`
- focused Python: `418 passed, 139 skipped`
- focused ShellSpec: `63 examples, 0 failures`
- full repository gates: `GATES: PASS`
- pre-commit hook: all invoked checks passed

Part of #2540.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package repositories and installers now use the canonical `https://pkg.pfblockerng.com` host.
  * Nightly and stable package channels are available through updated canonical URLs.

* **Bug Fixes**
  * Updated pfBlockerNG links to use secure HTTPS connections.

* **Tests**
  * Added coverage to detect retired package-host URLs and insecure site links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->