### PR TITLE
pfblockerng: backport CA consent fixes to 3.3

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -32,7 +32,7 @@ if (file_exists('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc')) {
 	require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');	// 'include functions' not yet merged into pfSense
 }
 if (file_exists('/usr/local/pkg/pfblockerng/pfblockerng_software.inc')) {
-	require_once('/usr/local/pkg/pfblockerng/pfblockerng_software.inc');	// issue #2360: ADR-19 Software tab + update-check backport (self-contained)
+	require_once('/usr/local/pkg/pfblockerng/pfblockerng_software.inc');	// issue #2360: ADR-19 Software tab + update-check backport
 }
 
 define('LOG_PREFIX_PKG_PFBLOCKERNG', 'pfBlockerNG');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -29,23 +29,49 @@ final class PfbConfig
 	public static function read(string $key): mixed
 	{
 		self::assertRegistered($key);
-		return config_get_path('installedpackages/pfblockerng/config/0/settings_family', NULL);
+		return config_get_path(self::path($key), NULL);
+	}
+
+	public static function write(string $key, mixed $value): void
+	{
+		self::assertRegistered($key);
+		if ($key !== 'gen/pfb_pkg_ca_consent' || !function_exists('isAllowedPage') || !isAllowedPage('pkg_mgr_installed.php')) {
+			throw new RuntimeException("PfbConfig: write of key '{$key}' denied");
+		}
+		self::writeValue($key, $value);
 	}
 
 	public static function writeSystem(string $key, mixed $value): void
 	{
 		self::assertRegistered($key);
-		if (!is_string($value) || !isset(PFB_SETTINGS_FAMILY_RANK[$value])) {
-			throw new InvalidArgumentException('PfbConfig: invalid settings family');
-		}
-		config_set_path('installedpackages/pfblockerng/config/0/settings_family', $value);
+		self::writeValue($key, $value);
 	}
 
 	private static function assertRegistered(string $key): void
 	{
-		if ($key !== 'gen/settings_family') {
+		if (!in_array($key, ['gen/settings_family', 'gen/pfb_pkg_ca_consent'], TRUE)) {
 			throw new InvalidArgumentException("PfbConfig: key '{$key}' is not registered");
 		}
+	}
+
+	private static function path(string $key): string
+	{
+		return match ($key) {
+			'gen/settings_family' => 'installedpackages/pfblockerng/config/0/settings_family',
+			'gen/pfb_pkg_ca_consent' => 'installedpackages/pfblockerng/config/0/pfb_pkg_ca_consent',
+		};
+	}
+
+	private static function writeValue(string $key, mixed $value): void
+	{
+		if ($key === 'gen/settings_family') {
+			if (!is_string($value) || !isset(PFB_SETTINGS_FAMILY_RANK[$value])) {
+				throw new InvalidArgumentException('PfbConfig: invalid settings family');
+			}
+		} elseif (!is_string($value) || !in_array($value, ['on', ''], TRUE)) {
+			throw new InvalidArgumentException('PfbConfig: invalid CA consent');
+		}
+		config_set_path(self::path($key), $value);
 	}
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
@@ -543,7 +543,37 @@ function pfb_pkgconf_write_atomic(string $file, string $content, string $expecte
 	}
 }
 
-function pfb_pkgconf_ca_state(?string $file = NULL, ?bool $is_plus = NULL): string {
+function pfb_pkgconf_ca_patched(string $text, string $ca_path): bool {
+	if (substr_count($text, 'SSL_CA_CERT_FILE') !== 1 || substr_count($text, 'SSL_CA_CERT_PATH') !== 1) {
+		return FALSE;
+	}
+	$lines = explode("\n", $text);
+	$bounds = pfb_pkgconf_block_bounds($lines);
+	if ($bounds === NULL) {
+		return FALSE;
+	}
+	$ca_file_count = 0;
+	$path_count = 0;
+	for ($i = $bounds[0] + 1; $i < $bounds[1]; $i++) {
+		if (strpos($lines[$i], "\tSSL_CA_CERT_FILE=") === 0) {
+			$ca_file = substr($lines[$i], strlen("\tSSL_CA_CERT_FILE="));
+			if (preg_match('#^/[A-Za-z0-9._/+-]+\z#', $ca_file) !== 1) {
+				return FALSE;
+			}
+			$ca_file_count++;
+		}
+		if ($lines[$i] === "\tSSL_CA_CERT_PATH={$ca_path}") {
+			$path_count++;
+		}
+	}
+	return $ca_file_count === 1 && $path_count === 1;
+}
+
+function pfb_pkgconf_ca_state(
+	?string $file = NULL,
+	?bool $is_plus = NULL,
+	string $ca_path = PFB_SSL_CA_CERT_PATH
+): string {
 	$file ??= PFB_PKG_CONF;
 	if ($is_plus === NULL) {
 		$product = @file_get_contents('/etc/product_label');
@@ -559,26 +589,7 @@ function pfb_pkgconf_ca_state(?string $file = NULL, ?bool $is_plus = NULL): stri
 	if (pfb_pkgconf_ca_needed($text)) {
 		return 'needed';
 	}
-	$lines = explode("\n", $text);
-	$bounds = pfb_pkgconf_block_bounds($lines);
-	if ($bounds === NULL) {
-		return '';
-	}
-	$ca_file_count = 0;
-	$has_path = FALSE;
-	for ($i = $bounds[0] + 1; $i < $bounds[1]; $i++) {
-		if (strpos($lines[$i], "\tSSL_CA_CERT_FILE=") === 0) {
-			$ca_file = substr($lines[$i], strlen("\tSSL_CA_CERT_FILE="));
-			if (preg_match('#^/[A-Za-z0-9._/+-]+\z#', $ca_file) !== 1) {
-				return '';
-			}
-			$ca_file_count++;
-		}
-		if (strpos($lines[$i], "\tSSL_CA_CERT_PATH=") === 0) {
-			$has_path = TRUE;
-		}
-	}
-	return ($ca_file_count === 1 && $has_path) ? 'patched' : '';
+	return pfb_pkgconf_ca_patched($text, $ca_path) ? 'patched' : '';
 }
 
 function pfb_pkgconf_ca_sync(bool $consent, ?string $file = NULL, string $ca_path = PFB_SSL_CA_CERT_PATH): bool {
@@ -594,17 +605,18 @@ function pfb_pkgconf_ca_sync(bool $consent, ?string $file = NULL, string $ca_pat
 	$patched = '';
 	if ($consent) {
 		$patched = pfb_pkgconf_ca_add($text, $ca_path);
-		if ($patched !== '') {
-			$ca_file = '';
-			foreach (explode("\n", $text) as $line) {
-				if (strpos($line, "\tSSL_CA_CERT_FILE=") === 0) {
-					$ca_file = substr($line, strlen("\tSSL_CA_CERT_FILE="));
-					break;
-				}
+		if ($patched === '') {
+			return pfb_pkgconf_ca_patched($text, $ca_path);
+		}
+		$ca_file = '';
+		foreach (explode("\n", $text) as $line) {
+			if (strpos($line, "\tSSL_CA_CERT_FILE=") === 0) {
+				$ca_file = substr($line, strlen("\tSSL_CA_CERT_FILE="));
+				break;
 			}
-			if (!pfb_pkgconf_safe_ca_file($ca_file) || !pfb_pkgconf_dir_populated($ca_path)) {
-				return FALSE;
-			}
+		}
+		if (!pfb_pkgconf_safe_ca_file($ca_file) || !pfb_pkgconf_dir_populated($ca_path)) {
+			return FALSE;
 		}
 	} else {
 		$patched = pfb_pkgconf_ca_remove($text, $ca_path);
@@ -641,14 +653,14 @@ function pfb_pkgconf_ca_tick(
 		}
 		$file = $file ?? PFB_PKG_CONF;
 		$consent = pfb_pkg_ca_consent_enabled();
-		$state = pfb_pkgconf_ca_state($file, $is_plus);
+		$state = pfb_pkgconf_ca_state($file, $is_plus, $ca_path);
 		if ($state === '') {
 			pfb_pkgconf_ca_clear_notice_sentinel();
 			return;
 		}
 		if ($consent) {
 			pfb_pkgconf_ca_sync(TRUE, $file, $ca_path);
-			$state = pfb_pkgconf_ca_state($file, $is_plus);
+			$state = pfb_pkgconf_ca_state($file, $is_plus, $ca_path);
 			if ($state !== 'needed') {
 				pfb_pkgconf_ca_clear_notice_sentinel();
 				return;
@@ -699,15 +711,15 @@ function pfb_pkgconf_ca_apply(
 	?bool $is_plus = NULL
 ): bool {
 	$file = $file ?? PFB_PKG_CONF;
-	if (pfb_pkgconf_ca_state($file, $is_plus) === '') {
-		return TRUE;
-	}
 	$consent = $token === 'on';
+	if (pfb_pkgconf_ca_state($file, $is_plus, $ca_path) === '') {
+		return !$consent || $was_consented;
+	}
 	if (!$consent && !$was_consented) {
 		return TRUE;
 	}
 	$ok = pfb_pkgconf_ca_sync($consent, $file, $ca_path);
-	if (!$consent && pfb_pkgconf_ca_state($file, $is_plus) === 'needed') {
+	if (!$consent && pfb_pkgconf_ca_state($file, $is_plus, $ca_path) === 'needed') {
 		@file_put_contents(pfb_pkgconf_ca_notice_sentinel(), pfb_pkgconf_ca_notice_signature($file));
 	}
 	return $ok;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
@@ -237,6 +237,10 @@ function pfb_software_check_enabled(): bool {
 	return pfb_software_check_config_read();
 }
 
+function pfb_pkg_ca_consent_enabled(): bool {
+	return PfbConfig::read('gen/pfb_pkg_ca_consent') === 'on';
+}
+
 /*
  * The notify state machine: TRUE iff a `file_notice` should fire THIS tick.
  *
@@ -271,6 +275,22 @@ function pfb_should_notify(?string $installed, ?string $latest, ?string $last_no
  * authoritative channel signal AND the repo latest is read from.
  */
 define('PFB_PKG_BIN', '/usr/local/sbin/pkg');
+
+define('PFB_SSL_CA_CERT_PATH', '/etc/ssl/certs');
+define('PFB_SSL_CA_CERT_FILE', '/etc/ssl/cert.pem');
+define('PFB_PKG_CONF', '/usr/local/etc/pkg.conf');
+define('PFB_UPGRADE_LOCK', '/tmp/pfSense-upgrade.lock');
+
+function pfb_pkg_ca_env_prefix(string $ca_path = PFB_SSL_CA_CERT_PATH, string $ca_file = PFB_SSL_CA_CERT_FILE): string {
+	$parts = [];
+	if ($ca_path !== '' && !is_link($ca_path) && is_dir($ca_path) && is_readable($ca_path)) {
+		$parts[] = 'SSL_CA_CERT_PATH=' . escapeshellarg($ca_path);
+	}
+	if ($ca_file !== '' && !is_link($ca_file) && is_file($ca_file) && is_readable($ca_file) && (int) @filesize($ca_file) > 0) {
+		$parts[] = 'SSL_CA_CERT_FILE=' . escapeshellarg($ca_file);
+	}
+	return $parts === [] ? '' : implode(' ', $parts) . ' ';
+}
 
 /*
  * The installed pfBlockerNG package NAME (e.g. 'pfSense-pkg-pfBlockerNG-devel'), read
@@ -328,6 +348,20 @@ function pfb_pkg_installed_repo(string $pkgname): string {
 	return ($ret === 0 && isset($out[0])) ? trim($out[0]) : '';
 }
 
+function pfb_pkg_newest_version(array $versions): string {
+	$latest = '';
+	foreach ($versions as $line) {
+		if (!is_scalar($line)) {
+			continue;
+		}
+		$version = trim((string) $line);
+		if ($version !== '' && ($latest === '' || pkg_version_compare($latest, $version) === '<')) {
+			$latest = $version;
+		}
+	}
+	return $latest;
+}
+
 /*
  * The pfBlockerNG repo's latest version of $pkgname: `pkg update -r <repo>` (best-effort refresh of
  * just that repo's catalog DB) then `pkg rquery -r <repo> '%v' <pkgname>`. Reads ONLY that repo
@@ -353,12 +387,330 @@ function pfb_pkg_latest(string $pkgname, string $reponame): string {
 	// Bound both networked pkg calls with timeout(1) (same idiom as the hook runner) so a
 	// hung mirror can never stall the cron pass or the page's forced "Check now".
 	$tmo = '/usr/bin/timeout -s TERM -k 5 60 ';
+	$ca = pfb_pkg_ca_env_prefix();
 	// Best-effort catalog refresh of the pfBlockerNG repo only; ignore failures (stale DB still reads).
-	exec("{$tmo}{$bin} update -r {$repo} 2>/dev/null");
+	exec("{$ca}{$tmo}{$bin} update -f -r {$repo} 2>/dev/null");
 	$out = array();
 	$ret = -1;
-	exec("{$tmo}{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
-	return ($ret === 0 && isset($out[0])) ? trim($out[0]) : '';
+	exec("{$ca}{$tmo}{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
+	return ($ret === 0 && $out !== []) ? pfb_pkg_newest_version($out) : '';
+}
+
+function pfb_pkgconf_block_bounds(array $lines): ?array {
+	$open_idx = NULL;
+	$open_count = 0;
+	foreach ($lines as $i => $line) {
+		if ($line === 'PKG_ENV {') {
+			$open_count++;
+			$open_idx = $i;
+		}
+	}
+	if ($open_count !== 1) {
+		return NULL;
+	}
+	$close_idx = NULL;
+	for ($i = $open_idx + 1; $i < count($lines); $i++) {
+		if ($lines[$i] === '}') {
+			$close_idx = $i;
+			break;
+		}
+	}
+	if ($close_idx === NULL) {
+		return NULL;
+	}
+	$mid_opens = 0;
+	$mid_closes = 0;
+	for ($i = $open_idx + 1; $i < $close_idx; $i++) {
+		if (substr($lines[$i], -1) === '{') {
+			$mid_opens++;
+		}
+		if ($lines[$i] === '}') {
+			$mid_closes++;
+		}
+	}
+	return $mid_opens === $mid_closes ? [$open_idx, $close_idx] : NULL;
+}
+
+function pfb_pkgconf_ca_needed(string $text): bool {
+	if (strpos($text, 'SSL_CA_CERT_PATH') !== FALSE) {
+		return FALSE;
+	}
+	$lines = explode("\n", $text);
+	$bounds = pfb_pkgconf_block_bounds($lines);
+	if ($bounds === NULL) {
+		return FALSE;
+	}
+	[$open_idx, $close_idx] = $bounds;
+	$ca_file_count = 0;
+	for ($i = $open_idx + 1; $i < $close_idx; $i++) {
+		if (strpos($lines[$i], "\tSSL_CA_CERT_FILE=") !== 0) {
+			continue;
+		}
+		$ca_file = substr($lines[$i], strlen("\tSSL_CA_CERT_FILE="));
+		if (preg_match('#^/[A-Za-z0-9._/+-]+\z#', $ca_file) !== 1) {
+			return FALSE;
+		}
+		$ca_file_count++;
+	}
+	return $ca_file_count === 1;
+}
+
+function pfb_pkgconf_ca_add(string $text, string $ca_path): string {
+	if (!pfb_pkgconf_ca_needed($text) || preg_match('#^/[A-Za-z0-9._/+-]+\z#', $ca_path) !== 1) {
+		return '';
+	}
+	$lines = explode("\n", $text);
+	$bounds = pfb_pkgconf_block_bounds($lines);
+	if ($bounds === NULL) {
+		return '';
+	}
+	[, $close_idx] = $bounds;
+	array_splice($lines, $close_idx, 0, ["\tSSL_CA_CERT_PATH={$ca_path}"]);
+	return implode("\n", $lines);
+}
+
+function pfb_pkgconf_ca_remove(string $text, string $ca_path): string {
+	$lines = explode("\n", $text);
+	$bounds = pfb_pkgconf_block_bounds($lines);
+	if ($bounds === NULL) {
+		return '';
+	}
+	$target = "\tSSL_CA_CERT_PATH={$ca_path}";
+	for ($i = $bounds[0] + 1; $i < $bounds[1]; $i++) {
+		if ($lines[$i] === $target) {
+			array_splice($lines, $i, 1);
+			return implode("\n", $lines);
+		}
+	}
+	return '';
+}
+
+function pfb_pkgconf_safe_ca_file(string $path): bool {
+	return $path !== '' && !is_link($path) && is_file($path) && is_readable($path) && (int) @filesize($path) > 0;
+}
+
+function pfb_pkgconf_dir_populated(string $dir): bool {
+	if (is_link($dir) || !is_dir($dir) || !is_readable($dir)) {
+		return FALSE;
+	}
+	foreach (@scandir($dir) ?: [] as $entry) {
+		if ($entry !== '' && $entry[0] !== '.') {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+function pfb_pkgconf_write_atomic(string $file, string $content, string $expected): bool {
+	if (is_link($file) || !is_file($file) || !is_readable($file)) {
+		return FALSE;
+	}
+	$dir = dirname($file);
+	if (is_link($dir) || !is_dir($dir) || !is_writable($dir)) {
+		return FALSE;
+	}
+	$mode = @fileperms($file);
+	$tmp = @tempnam($dir, '.pfbpkgconf_');
+	if (!is_string($tmp) || is_link($tmp)) {
+		return FALSE;
+	}
+	$written = @file_put_contents($tmp, $content, LOCK_EX);
+	$exact = $written === strlen($content) && @file_get_contents($tmp) === $content;
+	if (!$exact || ($mode !== FALSE && !@chmod($tmp, $mode & 0777))) {
+		@unlink($tmp);
+		return FALSE;
+	}
+	$lock = @fopen(getenv('PFB_UPGRADE_LOCK') ?: PFB_UPGRADE_LOCK, 'c');
+	if ($lock === FALSE || !@flock($lock, LOCK_EX | LOCK_NB)) {
+		if (is_resource($lock)) { @fclose($lock); }
+		@unlink($tmp);
+		return FALSE;
+	}
+	try {
+		if ((function_exists('is_subsystem_dirty') && is_subsystem_dirty('pkg'))
+			|| is_link($file) || @file_get_contents($file) !== $expected) {
+			@unlink($tmp);
+			return FALSE;
+		}
+		if (!@rename($tmp, $file)) {
+			@unlink($tmp);
+			return FALSE;
+		}
+		return @file_get_contents($file) === $content;
+	} finally {
+		@flock($lock, LOCK_UN);
+		@fclose($lock);
+	}
+}
+
+function pfb_pkgconf_ca_state(?string $file = NULL, ?bool $is_plus = NULL): string {
+	$file ??= PFB_PKG_CONF;
+	if ($is_plus === NULL) {
+		$product = @file_get_contents('/etc/product_label');
+		$is_plus = $product !== FALSE && strpos($product, 'Plus') !== FALSE;
+	}
+	if (!$is_plus || is_link($file) || !is_file($file) || !is_readable($file)) {
+		return '';
+	}
+	$text = @file_get_contents($file);
+	if ($text === FALSE) {
+		return '';
+	}
+	if (pfb_pkgconf_ca_needed($text)) {
+		return 'needed';
+	}
+	$lines = explode("\n", $text);
+	$bounds = pfb_pkgconf_block_bounds($lines);
+	if ($bounds === NULL) {
+		return '';
+	}
+	$ca_file_count = 0;
+	$has_path = FALSE;
+	for ($i = $bounds[0] + 1; $i < $bounds[1]; $i++) {
+		if (strpos($lines[$i], "\tSSL_CA_CERT_FILE=") === 0) {
+			$ca_file = substr($lines[$i], strlen("\tSSL_CA_CERT_FILE="));
+			if (preg_match('#^/[A-Za-z0-9._/+-]+\z#', $ca_file) !== 1) {
+				return '';
+			}
+			$ca_file_count++;
+		}
+		if (strpos($lines[$i], "\tSSL_CA_CERT_PATH=") === 0) {
+			$has_path = TRUE;
+		}
+	}
+	return ($ca_file_count === 1 && $has_path) ? 'patched' : '';
+}
+
+function pfb_pkgconf_ca_sync(bool $consent, ?string $file = NULL, string $ca_path = PFB_SSL_CA_CERT_PATH): bool {
+	$file ??= PFB_PKG_CONF;
+	if ((function_exists('is_subsystem_dirty') && is_subsystem_dirty('pkg'))
+		|| is_link($file) || !is_file($file) || !is_readable($file)) {
+		return FALSE;
+	}
+	$text = @file_get_contents($file);
+	if ($text === FALSE) {
+		return FALSE;
+	}
+	$patched = '';
+	if ($consent) {
+		$patched = pfb_pkgconf_ca_add($text, $ca_path);
+		if ($patched !== '') {
+			$ca_file = '';
+			foreach (explode("\n", $text) as $line) {
+				if (strpos($line, "\tSSL_CA_CERT_FILE=") === 0) {
+					$ca_file = substr($line, strlen("\tSSL_CA_CERT_FILE="));
+					break;
+				}
+			}
+			if (!pfb_pkgconf_safe_ca_file($ca_file) || !pfb_pkgconf_dir_populated($ca_path)) {
+				return FALSE;
+			}
+		}
+	} else {
+		$patched = pfb_pkgconf_ca_remove($text, $ca_path);
+	}
+	return $patched === '' ? TRUE : pfb_pkgconf_write_atomic($file, $patched, $text);
+}
+
+function pfb_pkgconf_ca_notice_sentinel(): string {
+	global $pfb;
+	return ($pfb['dbdir'] ?? '/var/db/pfblockerng') . '/.pkg_ca_notice';
+}
+
+function pfb_pkgconf_ca_clear_notice_sentinel(): void {
+	@unlink(pfb_pkgconf_ca_notice_sentinel());
+}
+
+function pfb_pkgconf_ca_notice_signature(string $file): string {
+	clearstatcache(TRUE, $file);
+	$stat = @stat($file);
+	return $stat === FALSE ? '' : $stat['ino'] . ':' . $stat['mtime'] . ':' . $stat['size'];
+}
+
+/* Best-effort cron retry and notice pass; provenance denial never mutates or notifies. */
+function pfb_pkgconf_ca_tick(
+	?bool $provenance_ok = NULL,
+	?string $file = NULL,
+	string $ca_path = PFB_SSL_CA_CERT_PATH,
+	?bool $is_plus = NULL
+): void {
+	try {
+		$provenance_ok = $provenance_ok ?? pfb_software_provenance_ok();
+		if (!$provenance_ok) {
+			return;
+		}
+		$file = $file ?? PFB_PKG_CONF;
+		$consent = pfb_pkg_ca_consent_enabled();
+		$state = pfb_pkgconf_ca_state($file, $is_plus);
+		if ($state === '') {
+			pfb_pkgconf_ca_clear_notice_sentinel();
+			return;
+		}
+		if ($consent) {
+			pfb_pkgconf_ca_sync(TRUE, $file, $ca_path);
+			$state = pfb_pkgconf_ca_state($file, $is_plus);
+			if ($state !== 'needed') {
+				pfb_pkgconf_ca_clear_notice_sentinel();
+				return;
+			}
+		} elseif ($state !== 'needed') {
+			pfb_pkgconf_ca_clear_notice_sentinel();
+			return;
+		}
+
+		$sentinel = pfb_pkgconf_ca_notice_sentinel();
+		$signature = pfb_pkgconf_ca_notice_signature($file);
+		$notified = is_file($sentinel) ? @file_get_contents($sentinel) : FALSE;
+		if ($notified === FALSE || $notified !== $signature) {
+			file_notice(
+				'pfBlockerNG',
+				"pkg on this firewall trusts only Netgate's CA bundle, so pfBlockerNG and any "
+				. 'other third-party repository cannot be installed or upgraded. Enable the '
+				. 'pkg.conf CA path on the pfBlockerNG Software page to add one SSL_CA_CERT_PATH '
+				. 'line to ' . PFB_PKG_CONF . '; pfBlockerNG re-applies that line at every boot '
+				. 'and scheduled (cron) pass once enabled.',
+				'pfBlockerNG',
+				'/pfblockerng/pfblockerng_software.php',
+				1
+			);
+			@file_put_contents($sentinel, $signature);
+		}
+	} catch (Throwable) {
+		return;
+	}
+}
+
+/* Persist consent only when the conditional Software-page section was rendered. */
+function pfb_pkgconf_ca_save(array $post): string {
+	if (!isset($post['pfb_pkg_ca_consent_shown'])) {
+		return (string) (PfbConfig::read('gen/pfb_pkg_ca_consent') ?? '');
+	}
+	$token = pfb_filter($post['pfb_pkg_ca_consent'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '';
+	PfbConfig::write('gen/pfb_pkg_ca_consent', $token);
+	return $token;
+}
+
+/* Caller must flush config after save() and before this file mutation. */
+function pfb_pkgconf_ca_apply(
+	string $token,
+	bool $was_consented,
+	?string $file = NULL,
+	string $ca_path = PFB_SSL_CA_CERT_PATH,
+	?bool $is_plus = NULL
+): bool {
+	$file = $file ?? PFB_PKG_CONF;
+	if (pfb_pkgconf_ca_state($file, $is_plus) === '') {
+		return TRUE;
+	}
+	$consent = $token === 'on';
+	if (!$consent && !$was_consented) {
+		return TRUE;
+	}
+	$ok = pfb_pkgconf_ca_sync($consent, $file, $ca_path);
+	if (!$consent && pfb_pkgconf_ca_state($file, $is_plus) === 'needed') {
+		@file_put_contents(pfb_pkgconf_ca_notice_sentinel(), pfb_pkgconf_ca_notice_signature($file));
+	}
+	return $ok;
 }
 
 /*

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
@@ -636,7 +636,10 @@ function pfb_pkgconf_ca_clear_notice_sentinel(): void {
 function pfb_pkgconf_ca_notice_signature(string $file): string {
 	clearstatcache(TRUE, $file);
 	$stat = @stat($file);
-	return $stat === FALSE ? '' : $stat['ino'] . ':' . $stat['mtime'] . ':' . $stat['size'];
+	$content = @file_get_contents($file);
+	return $stat === FALSE || $content === FALSE
+		? ''
+		: $stat['ino'] . ':' . $stat['mtime'] . ':' . $stat['size'] . ':' . hash('sha256', $content);
 }
 
 /* Best-effort cron retry and notice pass; provenance denial never mutates or notifies. */

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
@@ -23,18 +23,13 @@
 /*
  * issue #2360 — ADR-19 channel-provenance + software-update-check backport, step 1.
  *
- * Self-contained ADR-19 backport: every function this file needs lives in this file (or
- * PHP/pfSense core) — nothing here requires pfblockerng_extra.inc. Deliberately NOT wired
- * into PfbConfig/PfbToggle on this branch (owner directive: zero touch to shared,
- * already-functional 3.3 code — pfblockerng_extra.inc stays byte-identical to its
- * pristine 3.3 state on this step). devel remains the canonical shape (PfbConfig registry
- * + PfbToggle enum); pfb_software_check_config_read()/_write() below are a narrow,
- * file-local stand-in for that one config field, matching devel's enabled/disabled
- * semantics exactly (see their docblock).
+ * The CA-consent extension uses the release-local PfbConfig in pfblockerng_extra.inc;
+ * production entry points and direct test consumers load extra.inc before this file.
+ * pfb_software_check_config_read()/_write() remain the narrow file-local stand-in for
+ * the older software-check field, matching devel's enabled/disabled semantics.
  *
  * Ported wholesale from devel's pfblockerng.inc (ADR-19 section). No tests ship on this
- * branch (owner ruling, issue #2360); a standalone off-repo assertion harness exercised
- * this file in isolation (never extra.inc) to prove the self-containment.
+ * branch (owner ruling, issue #2360); release/3.3 assertion runners exercise it directly.
  */
 
 /*
@@ -501,7 +496,12 @@ function pfb_pkgconf_dir_populated(string $dir): bool {
 	return FALSE;
 }
 
-function pfb_pkgconf_write_atomic(string $file, string $content, string $expected): bool {
+function pfb_pkgconf_write_atomic(
+	string $file,
+	string $content,
+	string $expected,
+	?string $lock_file = NULL
+): bool {
 	if (is_link($file) || !is_file($file) || !is_readable($file)) {
 		return FALSE;
 	}
@@ -520,7 +520,7 @@ function pfb_pkgconf_write_atomic(string $file, string $content, string $expecte
 		@unlink($tmp);
 		return FALSE;
 	}
-	$lock = @fopen(getenv('PFB_UPGRADE_LOCK') ?: PFB_UPGRADE_LOCK, 'c');
+	$lock = @fopen($lock_file ?? PFB_UPGRADE_LOCK, 'c');
 	if ($lock === FALSE || !@flock($lock, LOCK_EX | LOCK_NB)) {
 		if (is_resource($lock)) { @fclose($lock); }
 		@unlink($tmp);
@@ -592,7 +592,12 @@ function pfb_pkgconf_ca_state(
 	return pfb_pkgconf_ca_patched($text, $ca_path) ? 'patched' : '';
 }
 
-function pfb_pkgconf_ca_sync(bool $consent, ?string $file = NULL, string $ca_path = PFB_SSL_CA_CERT_PATH): bool {
+function pfb_pkgconf_ca_sync(
+	bool $consent,
+	?string $file = NULL,
+	string $ca_path = PFB_SSL_CA_CERT_PATH,
+	?string $lock_file = NULL
+): bool {
 	$file ??= PFB_PKG_CONF;
 	if ((function_exists('is_subsystem_dirty') && is_subsystem_dirty('pkg'))
 		|| is_link($file) || !is_file($file) || !is_readable($file)) {
@@ -621,7 +626,7 @@ function pfb_pkgconf_ca_sync(bool $consent, ?string $file = NULL, string $ca_pat
 	} else {
 		$patched = pfb_pkgconf_ca_remove($text, $ca_path);
 	}
-	return $patched === '' ? TRUE : pfb_pkgconf_write_atomic($file, $patched, $text);
+	return $patched === '' ? TRUE : pfb_pkgconf_write_atomic($file, $patched, $text, $lock_file);
 }
 
 function pfb_pkgconf_ca_notice_sentinel(): string {
@@ -647,7 +652,8 @@ function pfb_pkgconf_ca_tick(
 	?bool $provenance_ok = NULL,
 	?string $file = NULL,
 	string $ca_path = PFB_SSL_CA_CERT_PATH,
-	?bool $is_plus = NULL
+	?bool $is_plus = NULL,
+	?string $lock_file = NULL
 ): void {
 	try {
 		$provenance_ok = $provenance_ok ?? pfb_software_provenance_ok();
@@ -662,7 +668,7 @@ function pfb_pkgconf_ca_tick(
 			return;
 		}
 		if ($consent) {
-			pfb_pkgconf_ca_sync(TRUE, $file, $ca_path);
+			pfb_pkgconf_ca_sync(TRUE, $file, $ca_path, $lock_file);
 			$state = pfb_pkgconf_ca_state($file, $is_plus, $ca_path);
 			if ($state !== 'needed') {
 				pfb_pkgconf_ca_clear_notice_sentinel();
@@ -711,7 +717,8 @@ function pfb_pkgconf_ca_apply(
 	bool $was_consented,
 	?string $file = NULL,
 	string $ca_path = PFB_SSL_CA_CERT_PATH,
-	?bool $is_plus = NULL
+	?bool $is_plus = NULL,
+	?string $lock_file = NULL
 ): bool {
 	$file = $file ?? PFB_PKG_CONF;
 	$consent = $token === 'on';
@@ -721,11 +728,55 @@ function pfb_pkgconf_ca_apply(
 	if (!$consent && !$was_consented) {
 		return TRUE;
 	}
-	$ok = pfb_pkgconf_ca_sync($consent, $file, $ca_path);
+	$ok = pfb_pkgconf_ca_sync($consent, $file, $ca_path, $lock_file);
 	if (!$consent && pfb_pkgconf_ca_state($file, $is_plus, $ca_path) === 'needed') {
 		@file_put_contents(pfb_pkgconf_ca_notice_sentinel(), pfb_pkgconf_ca_notice_signature($file));
 	}
 	return $ok;
+}
+
+/* Add the conditional Software-page consent controls through the shipped Form API. */
+function pfb_pkgconf_ca_add_form_controls($form, string $state, bool $consent): void {
+	if (!in_array($state, array('needed', 'patched'), TRUE)) {
+		return;
+	}
+	$help = sprintf(
+		gettext('This control adds or removes exactly one SSL_CA_CERT_PATH=/etc/ssl/certs line in %s. '),
+		PFB_PKG_CONF
+	);
+	if ($state === 'patched') {
+		$help .= gettext(
+			'That line is currently present in the PKG_ENV block, so pkg can reach '
+			. 'pfBlockerNG\'s repository over TLS. '
+		);
+	} elseif ($consent) {
+		$help .= gettext(
+			'Consent is on, but pfBlockerNG has not been able to add the line yet; '
+			. 'it will keep retrying automatically. '
+		);
+	} else {
+		$help .= gettext(
+			'Right now, pkg trusts only Netgate\'s own certificate bundle, so it '
+			. 'cannot install or update pfBlockerNG through the Package Manager or a plain '
+			. '<code>pkg install</code> in the shell. Checking this box restores the public root '
+			. 'certificate store pkg needs to reach that repository. '
+		);
+	}
+	$help .= gettext(
+		'pfBlockerNG re-applies the line at boot and on every scheduled (cron) pass. '
+		. 'Unchecking this removes only that one line; the rest of the file is left as pfSense wrote it.'
+	);
+
+	$section = new Form_Section(gettext('Package manager CA trust'));
+	$section->addInput(new Form_Checkbox(
+		'pfb_pkg_ca_consent',
+		gettext('Allow pfBlockerNG to manage the pkg.conf CA path'),
+		gettext('Enabled'),
+		$consent,
+		'on'
+	))->setHelp($help);
+	$form->add($section);
+	$form->addGlobal(new Form_Input('pfb_pkg_ca_consent_shown', 'pfb_pkg_ca_consent_shown', 'hidden', '1'));
 }
 
 /*

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -186,6 +186,9 @@ if (in_array($argv[1], array('update', 'updateip', 'updatednsbl', 'dc', 'dcc', '
 			if (function_exists('pfb_software_update_check')) {
 				try { pfb_software_update_check(); } catch (Throwable $e) { /* best-effort */ }
 			}
+			if (function_exists('pfb_pkgconf_ca_tick')) {
+				try { pfb_pkgconf_ca_tick(); } catch (Throwable $e) { /* best-effort */ }
+			}
 			break;
 		case 'updateip':	// Sync 'Force Reload IP only'
 		case 'updatednsbl':	// Sync 'Force Reload DNSBL only'

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -298,7 +298,7 @@ $section->addInput(new Form_StaticText(
 	<a target="_blank" href="https://forum.netgate.com/user/bbcan177">BBcan177</a><br />
 
 	<ul class="list-inline" style="margin-top: 4px; margin-bottom: -2px; border-style: outset; border-bottom-color: #8B181B; border-right-color: #8B181B; border-width: 2px;">
-		<li class="list-inline-item"><a target="_blank" href="http://pfblockerng.com">
+		<li class="list-inline-item"><a target="_blank" href="https://pfblockerng.com">
 			<span style="color: #8B181B;" class="fa-solid fa-globe"></span> HomePage</a></li>
 		<li class="list-inline-item"><a target="_blank" href="https://twitter.com/intent/follow?screen_name=BBcan177">
 			<span style="color: #8B181B;" class="fa-brands fa-twitter"></span> Follow on X formerly Twitter</a></li>
@@ -315,7 +315,7 @@ $section->addInput(new Form_StaticText(
 </div>
 
 <div style="width: 25%; height: 170px; float: right;">
-	<a target="_blank" href="http://pfblockerng.com">
+	<a target="_blank" href="https://pfblockerng.com">
 
 <svg width="180.0pt" height="180.0pt" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="30 225 560 470" style="enable-background:new 30 225 560 470;" xml:space="preserve">

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -98,10 +98,14 @@ if ($_POST && isset($_POST['save'])) {
 		header('Location: /pfblockerng/pfblockerng_software.php');
 		exit;
 	}
-	$input_errors[] = 'The setting was saved, but pfBlockerNG could not update ' . PFB_PKG_CONF
-		. ' right now (its CA certificate directory may be missing or empty -- try running '
-		. '`certctl rehash` from the shell). pfBlockerNG will retry automatically at the next '
-		. 'boot or scheduled run.';
+	$input_errors[] = sprintf(
+		gettext(
+			'The setting was saved, but pfBlockerNG could not update %s right now (its CA '
+			. 'certificate directory may be missing or empty -- try running `certctl rehash` '
+			. 'from the shell). pfBlockerNG will retry automatically at the next boot or scheduled run.'
+		),
+		PFB_PKG_CONF
+	);
 }
 
 // Read after the save block so a failed CA sync re-render shows the just-posted software choice.
@@ -209,34 +213,7 @@ $form->add($section);
 // Render the consent control only for a recognised Plus pkg.conf shape.
 $pfb_ca_state = pfb_pkgconf_ca_state();
 if ($pfb_ca_state !== '') {
-	$pfb_ca_consent = pfb_pkg_ca_consent_enabled();
-	$pfb_ca_help = 'This control adds or removes exactly one SSL_CA_CERT_PATH=/etc/ssl/certs line in '
-		. PFB_PKG_CONF . '. ';
-	if ($pfb_ca_state === 'patched') {
-		$pfb_ca_help .= 'That line is currently present in the PKG_ENV block, so pkg can reach '
-			. 'pfBlockerNG\'s repository over TLS. ';
-	} elseif ($pfb_ca_state === 'needed' && $pfb_ca_consent) {
-		$pfb_ca_help .= 'Consent is on, but pfBlockerNG has not been able to add the line yet; '
-			. 'it will keep retrying automatically. ';
-	} else {
-		$pfb_ca_help .= 'Right now, pkg trusts only Netgate\'s own certificate bundle, so it '
-			. 'cannot install or update pfBlockerNG through the Package Manager or a plain '
-			. '<code>pkg install</code> in the shell. Checking this box restores the public root '
-			. 'certificate store pkg needs to reach that repository. ';
-	}
-	$pfb_ca_help .= 'pfBlockerNG re-applies the line at boot and on every scheduled (cron) pass. '
-		. 'Unchecking this removes only that one line; the rest of the file is left as pfSense wrote it.';
-
-	$section = new Form_Section('Package manager CA trust');
-	$section->addInput(new Form_Checkbox(
-		'pfb_pkg_ca_consent',
-		'Allow pfBlockerNG to manage the pkg.conf CA path',
-		'Enabled',
-		$pfb_ca_consent,
-		'on'
-	))->setHelp($pfb_ca_help);
-	$form->add($section);
-	$form->addGlobal(new Form_Input('pfb_pkg_ca_consent_shown', 'pfb_pkg_ca_consent_shown', 'hidden', '1'));
+	pfb_pkgconf_ca_add_form_controls($form, $pfb_ca_state, pfb_pkg_ca_consent_enabled());
 }
 
 $section = new Form_Section('Actions');

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -76,7 +76,6 @@ $pfb_sw_channel	= pfb_channel_for_install($pfb_sw_repo, $pfb_sw_pkgname);
 // The "Check for new versions" setting (default ENABLED). The accessor reads the
 // file-local config accessor (pfb_software_check_config_read() in pfblockerng_software.inc);
 // no raw value handling here.
-$pfb_sw_check	= pfb_software_check_enabled();
 
 // Which (POST-guarded) action was requested. Only the cache-refreshing Check runs here now;
 // Update/Uninstall are plain links to pkg_mgr_install.php, not POST actions.
@@ -85,14 +84,28 @@ if ($_POST && !empty($_POST['pfb_sw_action'])) {
 	$pfb_sw_action = (string) $_POST['pfb_sw_action'];
 }
 
+$input_errors = array();
+
 // "Save" the settings (standard pfSense CSRF POST). A checkbox is absent from the POST when
 // unticked, so persist the owner-ruled empty Off token; an absent config key defaults On.
 if ($_POST && isset($_POST['save'])) {
 	pfb_software_check_config_write((pfb_filter($_POST['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '') === 'on');
+	$pfb_ca_was_consented = pfb_pkg_ca_consent_enabled();
+	$pfb_ca_token = pfb_pkgconf_ca_save($_POST);
 	write_config('[pfBlockerNG] save Software settings');
-	header('Location: /pfblockerng/pfblockerng_software.php');
-	exit;
+	$pfb_ca_ok = pfb_pkgconf_ca_apply($pfb_ca_token, $pfb_ca_was_consented);
+	if ($pfb_ca_ok) {
+		header('Location: /pfblockerng/pfblockerng_software.php');
+		exit;
+	}
+	$input_errors[] = 'The setting was saved, but pfBlockerNG could not update ' . PFB_PKG_CONF
+		. ' right now (its CA certificate directory may be missing or empty -- try running '
+		. '`certctl rehash` from the shell). pfBlockerNG will retry automatically at the next '
+		. 'boot or scheduled run.';
 }
+
+// Read after the save block so a failed CA sync re-render shows the just-posted software choice.
+$pfb_sw_check	= pfb_software_check_enabled();
 
 // "Check now" — a manual, explicit cache refresh from the pfBlockerNG repo, then redisplay. $force=true
 // bypasses the "Check for new versions" enable-gate so a one-off check always works.
@@ -105,6 +118,10 @@ if ($pfb_sw_action === 'check') {
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Software'));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '@self');
 include_once('head.inc');
+
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
 
 // Define default Alerts Tab href link (Top row) — same pattern as every sibling page.
 $get_req = pfb_alerts_default_page();
@@ -188,6 +205,39 @@ $section->addInput(new Form_Checkbox(
 	'on'
 ))->setHelp('Periodically check for a new version and notify when one is available.');
 $form->add($section);
+
+// Render the consent control only for a recognised Plus pkg.conf shape.
+$pfb_ca_state = pfb_pkgconf_ca_state();
+if ($pfb_ca_state !== '') {
+	$pfb_ca_consent = pfb_pkg_ca_consent_enabled();
+	$pfb_ca_help = 'This control adds or removes exactly one SSL_CA_CERT_PATH=/etc/ssl/certs line in '
+		. PFB_PKG_CONF . '. ';
+	if ($pfb_ca_state === 'patched') {
+		$pfb_ca_help .= 'That line is currently present in the PKG_ENV block, so pkg can reach '
+			. 'pfBlockerNG\'s repository over TLS. ';
+	} elseif ($pfb_ca_state === 'needed' && $pfb_ca_consent) {
+		$pfb_ca_help .= 'Consent is on, but pfBlockerNG has not been able to add the line yet; '
+			. 'it will keep retrying automatically. ';
+	} else {
+		$pfb_ca_help .= 'Right now, pkg trusts only Netgate\'s own certificate bundle, so it '
+			. 'cannot install or update pfBlockerNG through the Package Manager or a plain '
+			. '<code>pkg install</code> in the shell. Checking this box restores the public root '
+			. 'certificate store pkg needs to reach that repository. ';
+	}
+	$pfb_ca_help .= 'pfBlockerNG re-applies the line at boot and on every scheduled (cron) pass. '
+		. 'Unchecking this removes only that one line; the rest of the file is left as pfSense wrote it.';
+
+	$section = new Form_Section('Package manager CA trust');
+	$section->addInput(new Form_Checkbox(
+		'pfb_pkg_ca_consent',
+		'Allow pfBlockerNG to manage the pkg.conf CA path',
+		'Enabled',
+		$pfb_ca_consent,
+		'on'
+	))->setHelp($pfb_ca_help);
+	$form->add($section);
+	$form->addGlobal(new Form_Input('pfb_pkg_ca_consent_shown', 'pfb_pkg_ca_consent_shown', 'hidden', '1'));
+}
 
 $section = new Form_Section('Actions');
 

--- a/src/usr/local/www/pfblockerng/www/dnsbl_default.php
+++ b/src/usr/local/www/pfblockerng/www/dnsbl_default.php
@@ -153,7 +153,7 @@
 				</tbody>
 			</table>
 			<div>Powered by: <strong>pfBlockerNG DNSBL</strong>&emsp;
-				<a target="_blank" href="http://pfblockerng.com">pfBlockerNG.com</a>
+				<a target="_blank" href="https://pfblockerng.com">pfBlockerNG.com</a>
 			</div>
 		</div>
 	</div>

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -36,7 +36,7 @@
 				<a target="_blank" href="https://forum.netgate.com/user/bbcan177">BBcan177</a><br />
 
 			<ul class="list-inline" style="margin-top: 4px; margin-bottom: -2px; border-style: outset; border-bottom-color: #8B181B; border-right-color: #8B181B; border-width: 2px;">
-				<li class="list-inline-item"><a target="_blank" href="http://pfblockerng.com">
+				<li class="list-inline-item"><a target="_blank" href="https://pfblockerng.com">
 					<span style="color: #8B181B;" class="fa-solid fa-globe"></span> HomePage</a></li>
 				<li class="list-inline-item"><a target="_blank" href="https://twitter.com/intent/follow?screen_name=BBcan177">
 					<span style="color: #8B181B;" class="fa-brands fa-twitter"></span> Follow on Twitter</a></li>
@@ -55,7 +55,7 @@
 			</ul>
 		</div>
 		<div style="width: 25%; height: 170px; float: right;">
-			<a target="_blank" href="http://pfblockerng.com">
+			<a target="_blank" href="https://pfblockerng.com">
 		<svg width="180.0pt" height="180.0pt" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="120 225 560 470" style="enable-background:new 120 225 560 470;" xml:space="preserve">
 		<style type="text/css">
 			.st0{fill:#8B181B;}

--- a/tests/php/assert_pkg_ca_core_3_3.php
+++ b/tests/php/assert_pkg_ca_core_3_3.php
@@ -159,12 +159,12 @@ row('parser add/remove is exact and byte preserving', static function () use (&$
 
 row('state and sync enforce Plus filesystem guards', static function () use (&$pkgconf, &$base, &$bundle): void {
 	file_put_contents($pkgconf, str_replace('/tmp/bundle.pem', $bundle, $base));
-	same('needed', pfb_pkgconf_ca_state($pkgconf, true), 'needed state');
+	same('needed', pfb_pkgconf_ca_state($pkgconf, true, $GLOBALS['pfb']['dbdir'] . '/certs'), 'needed state');
 	$GLOBALS['dirty'] = false;
 	check(pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'sync add');
-	same('patched', pfb_pkgconf_ca_state($pkgconf, true), 'patched state');
+	same('patched', pfb_pkgconf_ca_state($pkgconf, true, $GLOBALS['pfb']['dbdir'] . '/certs'), 'patched state');
 	check(pfb_pkgconf_ca_sync(false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'sync remove');
-	same('needed', pfb_pkgconf_ca_state($pkgconf, true), 'removed state');
+	same('needed', pfb_pkgconf_ca_state($pkgconf, true, $GLOBALS['pfb']['dbdir'] . '/certs'), 'removed state');
 	$GLOBALS['dirty'] = true;
 	check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'dirty refused');
 	$GLOBALS['dirty'] = false;

--- a/tests/php/assert_pkg_ca_core_3_3.php
+++ b/tests/php/assert_pkg_ca_core_3_3.php
@@ -47,7 +47,8 @@ function is_subsystem_dirty(string $name): bool
 
 function pkg_version_compare(string $left, string $right): string
 {
-	return version_compare($left, $right);
+	$result = version_compare($left, $right);
+	return $result < 0 ? '<' : ($result > 0 ? '>' : '=');
 }
 
 function pfb_filter(mixed $value, int $type, string $key): string
@@ -68,7 +69,7 @@ require_once $software;
 $failures = 0;
 $root = sys_get_temp_dir() . '/pfb_pkg_ca_3_3_' . bin2hex(random_bytes(5));
 mkdir($root . '/certs', 0700, true);
-putenv("PFB_UPGRADE_LOCK={$root}/upgrade.lock");
+$lockfile = $root . '/upgrade.lock';
 $hash = $root . '/certs/hash.0';
 file_put_contents($hash, 'x');
 $GLOBALS['pfb']['dbdir'] = $root;
@@ -157,40 +158,40 @@ row('parser add/remove is exact and byte preserving', static function () use (&$
 	check(!pfb_pkgconf_ca_needed("PKG_ENV {\n\tX={\n}\n\tSSL_CA_CERT_FILE=/tmp/a\n}\n"), 'nested block');
 });
 
-row('state and sync enforce Plus filesystem guards', static function () use (&$pkgconf, &$base, &$bundle): void {
+row('state and sync enforce Plus filesystem guards', static function () use (&$pkgconf, &$base, &$bundle, &$lockfile): void {
 	file_put_contents($pkgconf, str_replace('/tmp/bundle.pem', $bundle, $base));
 	same('needed', pfb_pkgconf_ca_state($pkgconf, true, $GLOBALS['pfb']['dbdir'] . '/certs'), 'needed state');
 	$GLOBALS['dirty'] = false;
-	check(pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'sync add');
+	check(pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', $lockfile), 'sync add');
 	same('patched', pfb_pkgconf_ca_state($pkgconf, true, $GLOBALS['pfb']['dbdir'] . '/certs'), 'patched state');
-	check(pfb_pkgconf_ca_sync(false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'sync remove');
+	check(pfb_pkgconf_ca_sync(false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', $lockfile), 'sync remove');
 	same('needed', pfb_pkgconf_ca_state($pkgconf, true, $GLOBALS['pfb']['dbdir'] . '/certs'), 'removed state');
 	$GLOBALS['dirty'] = true;
-	check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'dirty refused');
+	check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', $lockfile), 'dirty refused');
 	$GLOBALS['dirty'] = false;
 	@unlink($GLOBALS['pfb']['dbdir'] . '/certs/hash.0');
 	file_put_contents($pkgconf, "PKG_ENV {\n\tSSL_CA_CERT_FILE={$bundle}\n}\n");
-	check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'empty cert dir refused');
+	check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', $lockfile), 'empty cert dir refused');
 	file_put_contents($GLOBALS['pfb']['dbdir'] . '/certs/hash.0', 'x');
-	check(pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'populated cert dir');
+	check(pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', $lockfile), 'populated cert dir');
 });
 
-row('save apply and tick are best effort', static function () use (&$pkgconf, &$base, &$bundle): void {
+row('save apply and tick are best effort', static function () use (&$pkgconf, &$base, &$bundle, &$lockfile): void {
 	$GLOBALS['config'] = [];
 	PfbConfig::writeSystem('gen/pfb_pkg_ca_consent', 'on');
 	same('on', pfb_pkgconf_ca_save([]), 'hidden section does not revoke');
 	same('', pfb_pkgconf_ca_save(['pfb_pkg_ca_consent_shown' => '1']), 'unchecked token');
 	file_put_contents($pkgconf, str_replace('/tmp/bundle.pem', $bundle, $base));
 	PfbConfig::writeSystem('gen/pfb_pkg_ca_consent', 'on');
-	check(pfb_pkgconf_ca_apply('on', false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true), 'apply');
+	check(pfb_pkgconf_ca_apply('on', false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true, $lockfile), 'apply');
 	$GLOBALS['notices'] = [];
-	pfb_pkgconf_ca_tick(false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true);
+	pfb_pkgconf_ca_tick(false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true, $lockfile);
 	check(count($GLOBALS['notices']) === 0, 'provenance denial is silent');
 	file_put_contents($pkgconf, str_replace('/tmp/bundle.pem', $bundle, $base));
 	@unlink($GLOBALS['pfb']['dbdir'] . '/certs/hash.0');
-	pfb_pkgconf_ca_tick(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true);
+	pfb_pkgconf_ca_tick(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true, $lockfile);
 	check(count($GLOBALS['notices']) === 1, 'notice');
-	pfb_pkgconf_ca_tick(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true);
+	pfb_pkgconf_ca_tick(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true, $lockfile);
 	check(count($GLOBALS['notices']) === 1, 'notice dedupe');
 });
 

--- a/tests/php/assert_pkg_ca_core_3_3.php
+++ b/tests/php/assert_pkg_ca_core_3_3.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['config'] = [];
+$GLOBALS['pfb'] = [];
+$GLOBALS['allowed'] = true;
+$GLOBALS['dirty'] = false;
+$GLOBALS['notices'] = [];
+define('PFB_FILTER_ON_OFF', 1);
+
+function config_get_path(string $path, mixed $default = null): mixed
+{
+	$value = $GLOBALS['config'];
+	foreach (explode('/', trim($path, '/')) as $part) {
+		if (!is_array($value) || !array_key_exists($part, $value)) {
+			return $default;
+		}
+		$value = $value[$part];
+	}
+	return $value;
+}
+
+function config_set_path(string $path, mixed $value): void
+{
+	$parts = explode('/', trim($path, '/'));
+	$cursor =& $GLOBALS['config'];
+	foreach ($parts as $part) {
+		if (!is_array($cursor)) {
+			$cursor = [];
+		}
+		$cursor[$part] ??= [];
+		$cursor =& $cursor[$part];
+	}
+	$cursor = $value;
+}
+
+function isAllowedPage(string $page): bool
+{
+	return $page === 'pkg_mgr_installed.php' && $GLOBALS['allowed'];
+}
+
+function is_subsystem_dirty(string $name): bool
+{
+	return $name === 'pkg' && $GLOBALS['dirty'];
+}
+
+function pkg_version_compare(string $left, string $right): string
+{
+	return version_compare($left, $right);
+}
+
+function pfb_filter(mixed $value, int $type, string $key): string
+{
+	return $value === 'on' ? 'on' : '';
+}
+
+function file_notice(mixed ...$args): void
+{
+	$GLOBALS['notices'][] = $args;
+}
+
+$extra = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+$software = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc';
+require_once $extra;
+require_once $software;
+
+$failures = 0;
+$root = sys_get_temp_dir() . '/pfb_pkg_ca_3_3_' . bin2hex(random_bytes(5));
+mkdir($root . '/certs', 0700, true);
+putenv("PFB_UPGRADE_LOCK={$root}/upgrade.lock");
+$hash = $root . '/certs/hash.0';
+file_put_contents($hash, 'x');
+$GLOBALS['pfb']['dbdir'] = $root;
+$bundle = $root . '/bundle.pem';
+file_put_contents($bundle, "CA\n");
+$pkgconf = $root . '/pkg.conf';
+$base = "PKG_ENV {\n\tSSL_CA_CERT_FILE=/tmp/bundle.pem\n\tOTHER=value\n}\nTAIL\n";
+
+function row(string $name, callable $check): void
+{
+	global $failures;
+	try {
+		$check();
+		echo "PASS {$name}\n";
+	} catch (Throwable $error) {
+		$failures++;
+		echo "FAIL {$name}: {$error->getMessage()}\n";
+	}
+}
+
+function check(bool $condition, string $message): void
+{
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+function same(mixed $expected, mixed $actual, string $message): void
+{
+	if ($expected !== $actual) {
+		throw new RuntimeException($message . ' expected=' . var_export($expected, true) . ' actual=' . var_export($actual, true));
+	}
+}
+
+row('config gateway registers consent and preserves settings family', static function (): void {
+	$GLOBALS['config'] = [];
+	same(null, PfbConfig::read('gen/pfb_pkg_ca_consent'), 'absent consent');
+	PfbConfig::writeSystem('gen/pfb_pkg_ca_consent', 'on');
+	same('on', PfbConfig::read('gen/pfb_pkg_ca_consent'), 'stored consent');
+	check(pfb_pkg_ca_consent_enabled(), 'consent accessor');
+	PfbConfig::writeSystem('gen/pfb_pkg_ca_consent', '');
+	check(!pfb_pkg_ca_consent_enabled(), 'off accessor');
+	PfbConfig::writeSystem('gen/settings_family', '3.3');
+	same('3.3', PfbConfig::read('gen/settings_family'), 'family seam');
+	foreach ([['gen/pfb_pkg_ca_consent', 'yes'], ['gen/pfb_pkg_ca_consent', null], ['gen/unknown', 'on']] as $bad) {
+		$thrown = false;
+		try {
+			PfbConfig::writeSystem($bad[0], $bad[1]);
+		} catch (Throwable) {
+			$thrown = true;
+		}
+		check($thrown, 'bad gateway input rejected');
+	}
+});
+
+row('web write requires software privilege and canonical token', static function (): void {
+	$GLOBALS['config'] = [];
+	$GLOBALS['allowed'] = false;
+	$thrown = false;
+	try { PfbConfig::write('gen/pfb_pkg_ca_consent', 'on'); } catch (Throwable) { $thrown = true; }
+	check($thrown, 'privilege denied');
+	$GLOBALS['allowed'] = true;
+	PfbConfig::write('gen/pfb_pkg_ca_consent', 'on');
+	same('on', PfbConfig::read('gen/pfb_pkg_ca_consent'), 'privileged write');
+	$GLOBALS['allowed'] = true;
+});
+
+row('CA environment prefix validates each half and shell quotes', static function (): void {
+	$dir = $GLOBALS['pfb']['dbdir'] . "/ca dir's";
+	mkdir($dir, 0700, true);
+	$file = $GLOBALS['pfb']['dbdir'] . "/ca file's.pem";
+	file_put_contents($file, 'x');
+	same("SSL_CA_CERT_PATH='" . str_replace("'", "'\\''", $dir) . "' SSL_CA_CERT_FILE='" . str_replace("'", "'\\''", $file) . "' ", pfb_pkg_ca_env_prefix($dir, $file), 'quoted prefix');
+	same("SSL_CA_CERT_FILE='" . str_replace("'", "'\\''", $file) . "' ", pfb_pkg_ca_env_prefix('', $file), 'empty path keeps bundle');
+	file_put_contents($file, '');
+	same("SSL_CA_CERT_PATH='" . str_replace("'", "'\\''", $dir) . "' ", pfb_pkg_ca_env_prefix($dir, $file), 'empty bundle omitted');
+});
+
+row('parser add/remove is exact and byte preserving', static function () use (&$base): void {
+	$patched = pfb_pkgconf_ca_add($base, '/etc/ssl/certs');
+	check($patched !== '' && str_contains($patched, "\tSSL_CA_CERT_PATH=/etc/ssl/certs\n}"), 'add line');
+	same($base, pfb_pkgconf_ca_remove($patched, '/etc/ssl/certs'), 'round trip');
+	check(!pfb_pkgconf_ca_needed("PKG_ENV {\n\tSSL_CA_CERT_FILE=relative\n}\n"), 'unsafe file path');
+	check(!pfb_pkgconf_ca_needed("PKG_ENV {\n\tSSL_CA_CERT_FILE=/tmp/a\n\tSSL_CA_CERT_FILE=/tmp/b\n}\n"), 'duplicate file key');
+	check(!pfb_pkgconf_ca_needed("PKG_ENV {\n\tSSL_CA_CERT_FILE=/tmp/a\n\tSSL_CA_CERT_PATH=/tmp/foreign\n}\n"), 'foreign path');
+	check(!pfb_pkgconf_ca_needed("PKG_ENV {\n\tX={\n}\n\tSSL_CA_CERT_FILE=/tmp/a\n}\n"), 'nested block');
+});
+
+row('state and sync enforce Plus filesystem guards', static function () use (&$pkgconf, &$base, &$bundle): void {
+	file_put_contents($pkgconf, str_replace('/tmp/bundle.pem', $bundle, $base));
+	same('needed', pfb_pkgconf_ca_state($pkgconf, true), 'needed state');
+	$GLOBALS['dirty'] = false;
+	check(pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'sync add');
+	same('patched', pfb_pkgconf_ca_state($pkgconf, true), 'patched state');
+	check(pfb_pkgconf_ca_sync(false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'sync remove');
+	same('needed', pfb_pkgconf_ca_state($pkgconf, true), 'removed state');
+	$GLOBALS['dirty'] = true;
+	check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'dirty refused');
+	$GLOBALS['dirty'] = false;
+	@unlink($GLOBALS['pfb']['dbdir'] . '/certs/hash.0');
+	file_put_contents($pkgconf, "PKG_ENV {\n\tSSL_CA_CERT_FILE={$bundle}\n}\n");
+	check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'empty cert dir refused');
+	file_put_contents($GLOBALS['pfb']['dbdir'] . '/certs/hash.0', 'x');
+	check(pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'populated cert dir');
+});
+
+row('save apply and tick are best effort', static function () use (&$pkgconf, &$base, &$bundle): void {
+	$GLOBALS['config'] = [];
+	PfbConfig::writeSystem('gen/pfb_pkg_ca_consent', 'on');
+	same('on', pfb_pkgconf_ca_save([]), 'hidden section does not revoke');
+	same('', pfb_pkgconf_ca_save(['pfb_pkg_ca_consent_shown' => '1']), 'unchecked token');
+	file_put_contents($pkgconf, str_replace('/tmp/bundle.pem', $bundle, $base));
+	PfbConfig::writeSystem('gen/pfb_pkg_ca_consent', 'on');
+	check(pfb_pkgconf_ca_apply('on', false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true), 'apply');
+	$GLOBALS['notices'] = [];
+	pfb_pkgconf_ca_tick(false, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true);
+	check(count($GLOBALS['notices']) === 0, 'provenance denial is silent');
+	file_put_contents($pkgconf, str_replace('/tmp/bundle.pem', $bundle, $base));
+	@unlink($GLOBALS['pfb']['dbdir'] . '/certs/hash.0');
+	pfb_pkgconf_ca_tick(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true);
+	check(count($GLOBALS['notices']) === 1, 'notice');
+	pfb_pkgconf_ca_tick(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', true);
+	check(count($GLOBALS['notices']) === 1, 'notice dedupe');
+});
+
+row('both networked pkg commands carry the CA prefix before timeout', static function () use (&$software): void {
+	$source = file_get_contents($software);
+	check(is_string($source), 'software source readable');
+	check(substr_count($source, 'exec("{$ca}{$tmo}{$bin}') === 2, 'both networked calls prefixed');
+	check(strpos($source, 'exec("{$tmo}{$bin} update') === false, 'no unprefixed update call');
+	check(strpos($source, 'exec("{$tmo}{$bin} rquery') === false, 'no unprefixed rquery call');
+});
+
+function remove_tree(string $path): void
+{
+	if (!is_dir($path)) { return; }
+	foreach (scandir($path) ?: [] as $entry) {
+		if ($entry === '.' || $entry === '..') { continue; }
+		$child = $path . '/' . $entry;
+		is_dir($child) && !is_link($child) ? remove_tree($child) : @unlink($child);
+	}
+	@rmdir($path);
+}
+
+remove_tree($root);
+echo $failures === 0 ? "ALL PASS\n" : "{$failures} FAILURES\n";
+exit($failures === 0 ? 0 : 1);

--- a/tests/php/assert_pkg_ca_hardening_3_3.php
+++ b/tests/php/assert_pkg_ca_hardening_3_3.php
@@ -137,6 +137,26 @@ row('pkg.conf symlink is never followed or replaced', static function () use ($r
 	@unlink($link);
 });
 
+row('foreign and duplicate CA paths never report owned success', static function () use ($pkgconf, $base): void {
+	$foreign = str_replace("}\n", "\tSSL_CA_CERT_PATH=/tmp/foreign\n}\n", $base);
+	file_put_contents($pkgconf, $foreign);
+	check(pfb_pkgconf_ca_state($pkgconf, true) === '', 'foreign path state unsupported');
+	check(!pfb_pkgconf_ca_sync(true, $pkgconf, '/etc/ssl/certs'), 'foreign path sync refused');
+	check(!pfb_pkgconf_ca_apply('on', false, $pkgconf, '/etc/ssl/certs', true), 'foreign path apply refused');
+	check(file_get_contents($pkgconf) === $foreign, 'foreign path bytes preserved');
+
+	$duplicate = str_replace(
+		"}\n",
+		"\tSSL_CA_CERT_PATH=/etc/ssl/certs\n\tSSL_CA_CERT_PATH=/etc/ssl/certs\n}\n",
+		$base
+	);
+	file_put_contents($pkgconf, $duplicate);
+	check(pfb_pkgconf_ca_state($pkgconf, true) === '', 'duplicate path state unsupported');
+	check(!pfb_pkgconf_ca_sync(true, $pkgconf, '/etc/ssl/certs'), 'duplicate path sync refused');
+	check(!pfb_pkgconf_ca_apply('on', false, $pkgconf, '/etc/ssl/certs', true), 'duplicate path apply refused');
+	check(file_get_contents($pkgconf) === $duplicate, 'duplicate path bytes preserved');
+});
+
 function remove_tree(string $path): void
 {
 	if (!is_dir($path)) {

--- a/tests/php/assert_pkg_ca_hardening_3_3.php
+++ b/tests/php/assert_pkg_ca_hardening_3_3.php
@@ -157,6 +157,17 @@ row('foreign and duplicate CA paths never report owned success', static function
 	check(file_get_contents($pkgconf) === $duplicate, 'duplicate path bytes preserved');
 });
 
+row('notice signature detects same-metadata content rewrites', static function () use ($root): void {
+	$file = $root . '/signature.conf';
+	file_put_contents($file, 'AAAA');
+	touch($file, 1000000000);
+	$first = pfb_pkgconf_ca_notice_signature($file);
+	file_put_contents($file, 'BBBB');
+	touch($file, 1000000000);
+	$second = pfb_pkgconf_ca_notice_signature($file);
+	check($first !== $second, 'same inode, mtime, and size still changes signature');
+});
+
 function remove_tree(string $path): void
 {
 	if (!is_dir($path)) {

--- a/tests/php/assert_pkg_ca_hardening_3_3.php
+++ b/tests/php/assert_pkg_ca_hardening_3_3.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+$GLOBALS['config'] = [];
+$GLOBALS['pfb'] = [];
+$GLOBALS['dirty'] = false;
+
+function config_get_path(string $path, mixed $default = null): mixed
+{
+	$value = $GLOBALS['config'];
+	foreach (explode('/', trim($path, '/')) as $part) {
+		if (!is_array($value) || !array_key_exists($part, $value)) {
+			return $default;
+		}
+		$value = $value[$part];
+	}
+	return $value;
+}
+
+function config_set_path(string $path, mixed $value): void
+{
+	$cursor =& $GLOBALS['config'];
+	foreach (explode('/', trim($path, '/')) as $part) {
+		$cursor[$part] ??= [];
+		$cursor =& $cursor[$part];
+	}
+	$cursor = $value;
+}
+
+function isAllowedPage(string $page): bool
+{
+	return $page === 'pkg_mgr_installed.php';
+}
+
+function is_subsystem_dirty(string $name): bool
+{
+	return $name === 'pkg' && $GLOBALS['dirty'];
+}
+
+function pkg_version_compare(string $left, string $right): string
+{
+	$result = version_compare($left, $right);
+	return $result < 0 ? '<' : ($result > 0 ? '>' : '=');
+}
+
+$extra = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
+$software = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc';
+require_once $extra;
+require_once $software;
+
+$failures = 0;
+$root = sys_get_temp_dir() . '/pfb_pkg_ca_hardening_3_3_' . bin2hex(random_bytes(5));
+mkdir($root . '/certs', 0700, true);
+$GLOBALS['pfb']['dbdir'] = $root;
+file_put_contents($root . '/certs/hash.0', 'x');
+$bundle = $root . '/bundle.pem';
+file_put_contents($bundle, "CA\n");
+$pkgconf = $root . '/pkg.conf';
+$base = "PKG_ENV {\n\tSSL_CA_CERT_FILE={$bundle}\n}\n";
+file_put_contents($pkgconf, $base);
+$lockfile = $root . '/upgrade.lock';
+putenv("PFB_UPGRADE_LOCK={$lockfile}");
+
+function row(string $name, callable $check): void
+{
+	global $failures;
+	try {
+		$check();
+		echo "PASS {$name}\n";
+	} catch (Throwable $error) {
+		$failures++;
+		echo "FAIL {$name}: {$error->getMessage()}\n";
+	}
+}
+
+function check(bool $condition, string $message): void
+{
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+row('forced refresh and newest catalog version stay pinned', static function () use ($software): void {
+	check(pfb_pkg_newest_version(['1.9.9', '1.10.0', '1.2.0', [], '']) === '1.10.0', 'newest version selection');
+	$source = file_get_contents($software);
+	check(is_string($source), 'software source readable');
+	check(str_contains($source, 'exec("{$ca}{$tmo}{$bin} update -f -r {$repo}'), 'forced prefixed update');
+	check(str_contains($source, 'return ($ret === 0 && $out !== []) ? pfb_pkg_newest_version($out) :'), 'newest result wiring');
+});
+
+row('CA prefix refuses symlinks and invalid bundles', static function () use ($root, $bundle): void {
+	$path_link = $root . '/certs-link';
+	$bundle_link = $root . '/bundle-link.pem';
+	symlink($root . '/certs', $path_link);
+	symlink($bundle, $bundle_link);
+	check(!str_contains(pfb_pkg_ca_env_prefix($path_link, $bundle), 'SSL_CA_CERT_PATH'), 'symlink path omitted');
+	check(!str_contains(pfb_pkg_ca_env_prefix($root . '/certs', $bundle_link), 'SSL_CA_CERT_FILE'), 'symlink bundle omitted');
+	check(!str_contains(pfb_pkg_ca_env_prefix($root . '/certs', $root . '/certs'), 'SSL_CA_CERT_FILE'), 'directory bundle omitted');
+	file_put_contents($bundle, '');
+	check(!str_contains(pfb_pkg_ca_env_prefix($root . '/certs', $bundle), 'SSL_CA_CERT_FILE'), 'empty bundle omitted');
+	file_put_contents($bundle, "CA\n");
+	@unlink($path_link);
+	@unlink($bundle_link);
+});
+
+row('parser refuses CRLF and preserves no-final-newline bytes', static function () use ($base): void {
+	$crlf = str_replace("\n", "\r\n", $base);
+	check(!pfb_pkgconf_ca_needed($crlf), 'CRLF shape refused rather than guessed');
+	$no_final = rtrim($base, "\n");
+	$patched = pfb_pkgconf_ca_add($no_final, '/etc/ssl/certs');
+	check($patched !== '', 'no-final-newline shape patched');
+	check(pfb_pkgconf_ca_remove($patched, '/etc/ssl/certs') === $no_final, 'no-final-newline round trip');
+	check(!pfb_pkgconf_ca_needed("# SSL_CA_CERT_PATH=/tmp/fake\n{$base}"), 'comment token refuses patch');
+});
+
+row('atomic writer refuses stale content and lock contention', static function () use ($pkgconf, $base, $lockfile): void {
+	check(!pfb_pkgconf_write_atomic($pkgconf, "new\n", "stale\n"), 'stale expected bytes refused');
+	check(file_get_contents($pkgconf) === $base, 'stale refusal preserves file');
+	$lock = fopen($lockfile, 'c');
+	check(is_resource($lock) && flock($lock, LOCK_EX | LOCK_NB), 'fixture lock acquired');
+	try {
+		check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'contended upgrade lock refused');
+		check(file_get_contents($pkgconf) === $base, 'lock refusal preserves file');
+	} finally {
+		flock($lock, LOCK_UN);
+		fclose($lock);
+	}
+});
+
+row('pkg.conf symlink is never followed or replaced', static function () use ($root, $pkgconf): void {
+	$link = $root . '/pkg-link.conf';
+	symlink($pkgconf, $link);
+	check(pfb_pkgconf_ca_state($link, true) === '', 'symlink state unsupported');
+	check(!pfb_pkgconf_ca_sync(true, $link, $root . '/certs'), 'symlink sync refused');
+	check(is_link($link), 'symlink survives');
+	@unlink($link);
+});
+
+function remove_tree(string $path): void
+{
+	if (!is_dir($path)) {
+		return;
+	}
+	foreach (scandir($path) ?: [] as $entry) {
+		if ($entry === '.' || $entry === '..') {
+			continue;
+		}
+		$child = $path . '/' . $entry;
+		is_dir($child) && !is_link($child) ? remove_tree($child) : @unlink($child);
+	}
+	@rmdir($path);
+}
+
+remove_tree($root);
+echo $failures === 0 ? "ALL PASS\n" : "{$failures} FAILURES\n";
+exit($failures === 0 ? 0 : 1);

--- a/tests/php/assert_pkg_ca_hardening_3_3.php
+++ b/tests/php/assert_pkg_ca_hardening_3_3.php
@@ -60,7 +60,6 @@ $pkgconf = $root . '/pkg.conf';
 $base = "PKG_ENV {\n\tSSL_CA_CERT_FILE={$bundle}\n}\n";
 file_put_contents($pkgconf, $base);
 $lockfile = $root . '/upgrade.lock';
-putenv("PFB_UPGRADE_LOCK={$lockfile}");
 
 function row(string $name, callable $check): void
 {
@@ -115,12 +114,12 @@ row('parser refuses CRLF and preserves no-final-newline bytes', static function 
 });
 
 row('atomic writer refuses stale content and lock contention', static function () use ($pkgconf, $base, $lockfile): void {
-	check(!pfb_pkgconf_write_atomic($pkgconf, "new\n", "stale\n"), 'stale expected bytes refused');
+	check(!pfb_pkgconf_write_atomic($pkgconf, "new\n", "stale\n", $lockfile), 'stale expected bytes refused');
 	check(file_get_contents($pkgconf) === $base, 'stale refusal preserves file');
 	$lock = fopen($lockfile, 'c');
 	check(is_resource($lock) && flock($lock, LOCK_EX | LOCK_NB), 'fixture lock acquired');
 	try {
-		check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs'), 'contended upgrade lock refused');
+		check(!pfb_pkgconf_ca_sync(true, $pkgconf, $GLOBALS['pfb']['dbdir'] . '/certs', $lockfile), 'contended upgrade lock refused');
 		check(file_get_contents($pkgconf) === $base, 'lock refusal preserves file');
 	} finally {
 		flock($lock, LOCK_UN);

--- a/tests/php/assert_pkg_ca_ui_render_3_3.php
+++ b/tests/php/assert_pkg_ca_ui_render_3_3.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+if (!function_exists('gettext')) {
+	function gettext(string $text): string
+	{
+		return $text;
+	}
+}
+
+function pkg_version_compare(string $left, string $right): string
+{
+	$result = version_compare($left, $right);
+	return $result < 0 ? '<' : ($result > 0 ? '>' : '=');
+}
+
+class Form
+{
+	public array $sections = [];
+	public array $globals = [];
+
+	public function add(object $section): void
+	{
+		$this->sections[] = $section;
+	}
+
+	public function addGlobal(object $input): void
+	{
+		$this->globals[] = $input;
+	}
+}
+
+class Form_Section
+{
+	public array $inputs = [];
+
+	public function __construct(public string $title)
+	{
+	}
+
+	public function addInput(object $input): object
+	{
+		$this->inputs[] = $input;
+		return $input;
+	}
+}
+
+class Form_Checkbox
+{
+	public string $help = '';
+
+	public function __construct(
+		public string $name,
+		public string $label,
+		public string $description,
+		public bool $checked,
+		public string $value
+	) {
+	}
+
+	public function setHelp(string $help): self
+	{
+		$this->help = $help;
+		return $this;
+	}
+}
+
+class Form_Input
+{
+	public function __construct(
+		public string $name,
+		public string $label,
+		public string $type,
+		public string $value
+	) {
+	}
+}
+
+$root_path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng';
+require_once $root_path . '/pfblockerng_extra.inc';
+require_once $root_path . '/pfblockerng_software.inc';
+
+$failures = 0;
+
+function row(string $name, callable $check): void
+{
+	global $failures;
+	try {
+		$check();
+		echo "PASS {$name}\n";
+	} catch (Throwable $error) {
+		$failures++;
+		echo "FAIL {$name}: {$error->getMessage()}\n";
+	}
+}
+
+function check(bool $condition, string $message): void
+{
+	if (!$condition) {
+		throw new RuntimeException($message);
+	}
+}
+
+row('consent controls execute through the shipped form helper', static function (): void {
+	$form = new Form();
+	pfb_pkgconf_ca_add_form_controls($form, 'needed', false);
+	check(count($form->sections) === 1, 'one consent section rendered');
+	$section = $form->sections[0];
+	check($section->title === 'Package manager CA trust', 'section title');
+	check(count($section->inputs) === 1 && $section->inputs[0] instanceof Form_Checkbox, 'checkbox rendered');
+	$checkbox = $section->inputs[0];
+	check($checkbox->name === 'pfb_pkg_ca_consent', 'checkbox name');
+	check($checkbox->value === 'on' && !$checkbox->checked, 'checkbox token and state');
+	check(str_contains($checkbox->help, 'SSL_CA_CERT_PATH=/etc/ssl/certs'), 'owned line help');
+	check(str_contains($checkbox->help, 're-applies the line at boot'), 'reapply help');
+	check(count($form->globals) === 1, 'hidden marker rendered');
+	check($form->globals[0]->name === 'pfb_pkg_ca_consent_shown', 'hidden marker name');
+
+	$invalid = new Form();
+	pfb_pkgconf_ca_add_form_controls($invalid, '', true);
+	check($invalid->sections === [] && $invalid->globals === [], 'unsupported state renders nothing');
+});
+
+row('upgrade lock is explicit test injection, never environment-controlled', static function (): void {
+	$writer = new ReflectionFunction('pfb_pkgconf_write_atomic');
+	$sync = new ReflectionFunction('pfb_pkgconf_ca_sync');
+	$apply = new ReflectionFunction('pfb_pkgconf_ca_apply');
+	$tick = new ReflectionFunction('pfb_pkgconf_ca_tick');
+	check($writer->getNumberOfParameters() === 4, 'writer accepts lock path');
+	check($sync->getNumberOfParameters() === 4, 'sync threads lock path');
+	check($apply->getNumberOfParameters() === 6, 'apply threads lock path');
+	check($tick->getNumberOfParameters() === 5, 'tick threads lock path');
+	$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc');
+	check(is_string($source) && !str_contains($source, "getenv('PFB_UPGRADE_LOCK')"), 'no environment lock override');
+});
+
+echo $failures === 0 ? "ALL PASS\n" : "{$failures} FAILURES\n";
+exit($failures === 0 ? 0 : 1);

--- a/tests/php/assert_software_cache_scalar_filter_3_3.php
+++ b/tests/php/assert_software_cache_scalar_filter_3_3.php
@@ -29,7 +29,9 @@ $tmp = sys_get_temp_dir() . '/pfb-sw-cache-' . getmypid();
 @mkdir($tmp, 0755, true);
 $GLOBALS['pfb'] = ['dbdir' => $tmp];
 
-require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc';
+$root_path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng';
+require_once $root_path . '/pfblockerng_extra.inc';
+require_once $root_path . '/pfblockerng_software.inc';
 
 $cache = $tmp . '/software_update.json';
 file_put_contents($cache, json_encode([

--- a/tests/test_pkg_ca_core_3_3.py
+++ b/tests/test_pkg_ca_core_3_3.py
@@ -1,0 +1,18 @@
+"""Release/3.3 CA-consent core subprocess assertions."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_php_assertion_runner() -> None:
+    runner = Path(__file__).with_name("php") / "assert_pkg_ca_core_3_3.php"
+    result = subprocess.run(
+        ["php", str(runner)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout

--- a/tests/test_pkg_ca_hardening_3_3.py
+++ b/tests/test_pkg_ca_hardening_3_3.py
@@ -1,0 +1,18 @@
+"""Release/3.3 CA backport hardening and catalog behavior."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_php_hardening_runner() -> None:
+    runner = Path(__file__).with_name("php") / "assert_pkg_ca_hardening_3_3.php"
+    result = subprocess.run(
+        ["php", str(runner)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout

--- a/tests/test_pkg_ca_integration_3_3.py
+++ b/tests/test_pkg_ca_integration_3_3.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).parents[1]
 SOFTWARE_PAGE = ROOT / "src/usr/local/www/pfblockerng/pfblockerng_software.php"
+SOFTWARE_CORE = ROOT / "src/usr/local/pkg/pfblockerng/pfblockerng_software.inc"
 CRON_PAGE = ROOT / "src/usr/local/www/pfblockerng/pfblockerng.php"
 URL_FILES = (
     ROOT / "src/usr/local/www/pfblockerng/pfblockerng_general.php",
@@ -15,11 +16,16 @@ URL_FILES = (
 )
 
 
+def _between(source: str, start: str, end: str) -> str:
+    assert start in source, f"anchor not found: {start!r}"
+    tail = source.split(start, 1)[1]
+    assert end in tail, f"anchor not found: {end!r}"
+    return tail.split(end, 1)[0]
+
+
 def test_save_persists_consent_before_applying_pkg_conf() -> None:
     source = SOFTWARE_PAGE.read_text()
-    save = source.split("if ($_POST && isset($_POST['save'])) {", 1)[1].split(
-        '// "Check now"', 1
-    )[0]
+    save = _between(source, "if ($_POST && isset($_POST['save'])) {", '// "Check now"')
     positions = [
         save.index("$pfb_ca_was_consented = pfb_pkg_ca_consent_enabled();"),
         save.index("$pfb_ca_token = pfb_pkgconf_ca_save($_POST);"),
@@ -33,26 +39,28 @@ def test_save_persists_consent_before_applying_pkg_conf() -> None:
 
 
 def test_ui_is_conditional_and_posts_an_explicit_consent_token() -> None:
-    source = SOFTWARE_PAGE.read_text()
+    page = SOFTWARE_PAGE.read_text()
+    source = SOFTWARE_CORE.read_text()
+    assert "pfb_pkgconf_ca_add_form_controls($form, $pfb_ca_state, pfb_pkg_ca_consent_enabled());" in page
     for token in (
-        "$pfb_ca_state = pfb_pkgconf_ca_state();",
-        "if ($pfb_ca_state !== '') {",
-        "$pfb_ca_consent = pfb_pkg_ca_consent_enabled();",
+        "function pfb_pkgconf_ca_add_form_controls(",
         "new Form_Checkbox(\n\t\t'pfb_pkg_ca_consent'",
-        "\n\t\t'on'\n\t))->setHelp($pfb_ca_help);",
+        "\n\t\t'on'\n\t))->setHelp($help);",
         "new Form_Input('pfb_pkg_ca_consent_shown', 'pfb_pkg_ca_consent_shown', 'hidden', '1')",
         "SSL_CA_CERT_PATH=/etc/ssl/certs",
         "Unchecking this removes only that one line",
         "re-applies the line at boot and on every scheduled (cron) pass",
     ):
         assert token in source
-    assert "config_get_path" not in source
-    assert "gen/pfb_pkg_ca_consent" not in source
+    assert "$pfb_ca_state = pfb_pkgconf_ca_state();" in page
+    assert "if ($pfb_ca_state !== '') {" in page
+    assert "config_get_path" not in page
+    assert "gen/pfb_pkg_ca_consent" not in page
 
 
 def test_cron_keeps_feed_sync_and_adds_best_effort_ca_tick() -> None:
     source = CRON_PAGE.read_text()
-    case = source.split("case 'cron':", 1)[1].split("\n\t\tcase 'updateip':", 1)[0]
+    case = _between(source, "case 'cron':", "\n\t\tcase 'updateip':")
     feed = case.index("pfblockerng_sync_cron();")
     update = case.index("pfb_software_update_check();")
     tick = case.index("pfb_pkgconf_ca_tick();")

--- a/tests/test_pkg_ca_integration_3_3.py
+++ b/tests/test_pkg_ca_integration_3_3.py
@@ -1,0 +1,75 @@
+"""Release/3.3 CA-consent page, cron, and URL integration seam."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+SOFTWARE_PAGE = ROOT / "src/usr/local/www/pfblockerng/pfblockerng_software.php"
+CRON_PAGE = ROOT / "src/usr/local/www/pfblockerng/pfblockerng.php"
+URL_FILES = (
+    ROOT / "src/usr/local/www/pfblockerng/pfblockerng_general.php",
+    ROOT / "src/usr/local/www/pfblockerng/www/dnsbl_default.php",
+    ROOT / "src/usr/local/www/wizards/pfblockerng_wizard.xml",
+)
+
+
+def test_save_persists_consent_before_applying_pkg_conf() -> None:
+    source = SOFTWARE_PAGE.read_text()
+    save = source.split("if ($_POST && isset($_POST['save'])) {", 1)[1].split(
+        '// "Check now"', 1
+    )[0]
+    positions = [
+        save.index("$pfb_ca_was_consented = pfb_pkg_ca_consent_enabled();"),
+        save.index("$pfb_ca_token = pfb_pkgconf_ca_save($_POST);"),
+        save.index("write_config('[pfBlockerNG] save Software settings');"),
+        save.index("$pfb_ca_ok = pfb_pkgconf_ca_apply($pfb_ca_token, $pfb_ca_was_consented);"),
+    ]
+    assert positions == sorted(positions)
+    assert "pfb_software_check_config_write(" in save
+    assert "if ($pfb_ca_ok)" in save
+    assert "$input_errors[]" in save
+
+
+def test_ui_is_conditional_and_posts_an_explicit_consent_token() -> None:
+    source = SOFTWARE_PAGE.read_text()
+    for token in (
+        "$pfb_ca_state = pfb_pkgconf_ca_state();",
+        "if ($pfb_ca_state !== '') {",
+        "$pfb_ca_consent = pfb_pkg_ca_consent_enabled();",
+        "new Form_Checkbox(\n\t\t'pfb_pkg_ca_consent'",
+        "\n\t\t'on'\n\t))->setHelp($pfb_ca_help);",
+        "new Form_Input('pfb_pkg_ca_consent_shown', 'pfb_pkg_ca_consent_shown', 'hidden', '1')",
+        "SSL_CA_CERT_PATH=/etc/ssl/certs",
+        "Unchecking this removes only that one line",
+        "re-applies the line at boot and on every scheduled (cron) pass",
+    ):
+        assert token in source
+    assert "config_get_path" not in source
+    assert "gen/pfb_pkg_ca_consent" not in source
+
+
+def test_cron_keeps_feed_sync_and_adds_best_effort_ca_tick() -> None:
+    source = CRON_PAGE.read_text()
+    case = source.split("case 'cron':", 1)[1].split("\n\t\tcase 'updateip':", 1)[0]
+    feed = case.index("pfblockerng_sync_cron();")
+    update = case.index("pfb_software_update_check();")
+    tick = case.index("pfb_pkgconf_ca_tick();")
+    assert feed < update < tick
+    assert case.count("function_exists('pfb_software_update_check')") == 1
+    assert case.count("function_exists('pfb_pkgconf_ca_tick')") == 1
+    assert case.count("try { pfb_software_update_check(); }") == 1
+    assert case.count("try { pfb_pkgconf_ca_tick(); }") == 1
+
+
+def test_active_project_links_are_https_and_canonical() -> None:
+    insecure = "http://" + "pfblockerng.com"
+    retired = "https://" + "pfblockerng.github.io"
+    for path in URL_FILES:
+        source = path.read_text()
+        assert insecure not in source
+        assert retired not in source
+    assert URL_FILES[0].read_text().count("https://pfblockerng.com") == 2
+    assert URL_FILES[1].read_text().count("https://pfblockerng.com") == 1
+    assert URL_FILES[2].read_text().count("https://pfblockerng.com") == 2

--- a/tests/test_pkg_ca_ui_render_3_3.py
+++ b/tests/test_pkg_ca_ui_render_3_3.py
@@ -1,0 +1,18 @@
+"""Release/3.3 rendered consent controls and lock injection seam."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_php_ui_render_runner() -> None:
+    runner = Path(__file__).with_name("php") / "assert_pkg_ca_ui_render_3_3.php"
+    result = subprocess.run(
+        ["php", str(runner)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout


### PR DESCRIPTION
## What changed

- add the box CA directory and bundle to both networked Software catalog reads
- port the final consented `pkg.conf` parser, guarded one-line patch/revoke, atomic write, lock/concurrency checks, retry, and notice dedupe
- extend the release-local `PfbConfig` boundary with the consent token and Software-page privilege gate
- add the conditional consent control with durable save-before-apply ordering
- retry consented application from the existing 3.3 cron path
- update the five shipped main-site links to `https://pfblockerng.com`
- add release-native PHP assertion runners and pytest wrappers for core, hostile filesystem/parser cases, UI/cron wiring, and URL migration

## Release adaptation

The canonical `install.sh` and boot rc.d hook are package-site artifacts published from `devel`; release package archives exclude `scripts/`. This PR therefore does not duplicate that infrastructure. It ports the package-side state, UI, Software catalog calls, and cron retry that those already-landed scripts consume.

This is a manual adaptation because the 3.3 branch has a smaller `PfbConfig`, keeps `pfb_pkg_latest()` in `pfblockerng_software.inc`, and embeds cron in `pfblockerng.php`. Semantic source provenance:

- CA catalog environment: `fd5eb5b4c` through `f0dddeb60`
- consent core/UI/retry final state: `714f6337e` through `f23a7c1c5`
- installer/empty-hash guards already published from devel: PRs #2515 and #2536
- canonical URL migration landed on devel: PR #2543 / `72317ff2d`

## Security and consent boundary

Detection never writes. `pkg.conf` changes only after the admin explicitly enables the control on the Software page and that token is flushed to configuration. The patch preserves Netgate's exact `SSL_CA_CERT_FILE` and every other byte, adds only `SSL_CA_CERT_PATH=/etc/ssl/certs` inside the one recognized `PKG_ENV` block, and refuses malformed, duplicate, unsafe, symlinked, empty-CA, locked, or concurrently changed inputs. Revocation removes only the exact owned line. TLS and package-signature verification remain enabled.

## Verification

- Core frozen tests:
  - PHP hash `924070dd48a7fcccc3bb91b1f918c397e50df4cd`
  - Python hash `b1c7a344f489b776163425999b1fe3c84407c2cc`
  - RED on untouched `release/3.3`: 7 failures
  - GREEN unchanged: pass / `ALL PASS`
- Integration frozen test hash `a0144978f7f10ebc53b9b8a16c004eb50b4f5f32`
  - RED before UI/cron/URL wiring: 4 failures
  - GREEN unchanged: 4 passed
- Full release suite after final rebase: `35 passed`
- PHP syntax, XML syntax, diff whitespace, URL scans, and independent verifier gates passed

Fixes #2540.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added package manager CA trust controls to software settings.
  - Added consent persistence and automatic package configuration synchronization.
  - Added safe handling for CA paths, version selection, retries, and synchronization notices.

- **Bug Fixes**
  - Improved validation and protection against invalid or unsafe package configuration changes.
  - Package updates now consistently use the selected CA trust settings.

- **Style**
  - Updated pfBlockerNG project links to use HTTPS.

- **Tests**
  - Added coverage for consent workflows, configuration hardening, synchronization, cron processing, and HTTPS links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->