### PR TITLE
tests: isolate shell specs from Codex sessions

### DIFF
--- a/tests/shell/spec_helper.sh
+++ b/tests/shell/spec_helper.sh
@@ -10,6 +10,8 @@ PFB_PKGDIR="${PFB_ROOT}/src/usr/local/pkg/pfblockerng"
 PFB_FIXTURES="${PFB_ROOT}/tests/shell/fixtures"
 PFB_SHIMS="${PFB_ROOT}/tests/shell/bin"
 
+unset CODEX_THREAD_ID
+
 # ── GIT_* scrub (ADR-47 P5) — sourced once, aliased as scrub_git_env ─────────
 # All git-touching specs call scrub_git_env in their setup() / subshells.
 # The alias keeps spec code readable; the underlying function is in the shared lib.


### PR DESCRIPTION
## Summary

- scrub the host Codex session marker from ShellSpec's shared environment
- keep explicit Codex path-selection coverage unchanged
- make the five claim-gate fixtures resolve their non-Codex paths identically inside and outside Codex

## Red to green

Reproduction spec hash stayed frozen at `7f81dedeea4db4e25ac10e220426401103aa4721`.

```text
$ CODEX_THREAD_ID=codex-red shellspec --shell "$(command -v dash)" tests/shell/agent_work_branch_spec.sh
28 examples, 5 failures

$ CODEX_THREAD_ID=codex-green shellspec --shell "$(command -v dash)" tests/shell/agent_work_branch_spec.sh
28 examples, 0 failures

$ env -u CODEX_THREAD_ID shellspec --shell "$(command -v dash)" tests/shell/agent_work_branch_spec.sh
28 examples, 0 failures
```

## Verification

```text
$ scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: sh -n tests/shell/spec_helper.sh
GATE PASS: shellspec --shell $(command -v dash || command -v sh)
GATES: PASS
```

Fixes #2528
Fixes #2542

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated shell test setup to remove inherited thread identifiers, improving test isolation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->