### PR TITLE
pfblockerng: preserve 3.3 settings across nightly upgrades

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -61,6 +61,7 @@ function pfb_install_settings_family_capture_restore(
 	}
 	$installed_family = $from_version((string) $version());
 	if ($installed_family === NULL || !$replace($installed_family)) {
+		$replace($source_family);
 		throw new RuntimeException('pfBlockerNG: unable to restore settings family');
 	}
 	return $installed_family;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2234,11 +2234,22 @@ final class PfbConfig
 
 // Settings-family snapshots capture only pfBlockerNG-owned installedpackages sections. Foreign
 // config remains live while the registered marker records the exact schema family.
-const PFB_SETTINGS_FAMILY_RANK = ['3.2' => 0, '4.0' => 1, '4.1' => 2];
+const PFB_SETTINGS_FAMILY_RANK = ['3.2' => 0, '3.3' => 1, '4.0' => 2, '4.1' => 3];
+const PFB_NIGHTLY_SETTINGS_FAMILY = '4.1';
 
 function pfb_settings_family_from_version(string $version): ?string
 {
-	$version = ltrim(trim($version), 'vV');
+	$version = trim($version);
+	if (preg_match('/^(\d{14})\.[0-9a-f]{7}$/', $version, $match) === 1) {
+		$timestamp = $match[1];
+		return checkdate((int) substr($timestamp, 4, 2), (int) substr($timestamp, 6, 2), (int) substr($timestamp, 0, 4))
+			&& (int) substr($timestamp, 8, 2) < 24
+			&& (int) substr($timestamp, 10, 2) < 60
+			&& (int) substr($timestamp, 12, 2) < 60
+			? PFB_NIGHTLY_SETTINGS_FAMILY
+			: NULL;
+	}
+	$version = ltrim($version, 'vV');
 	if (preg_match('/^(\d+\.\d+)(?:\.\d+)?(?:[.-].*)?$/', $version, $match) !== 1
 		|| !isset(PFB_SETTINGS_FAMILY_RANK[$match[1]])) {
 		return NULL;

--- a/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
+++ b/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
@@ -67,6 +67,33 @@ final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
 		$this->assertSame(['current', 'save'], $order);
 	}
 
+	public function testTargetResolutionAndRestoreFailuresRollBackToSource(): void
+	{
+		foreach ([NULL, '4.1'] as $target) {
+			$order = [];
+			try {
+				pfb_install_settings_family_capture_restore(
+					static function () use (&$order): string { $order[] = 'current'; return '3.3'; },
+					static function (string $family) use (&$order): bool { $order[] = "save:{$family}"; return TRUE; },
+					static function () use (&$order): string { $order[] = 'version'; return 'nightly'; },
+					static function () use (&$order, $target): ?string { $order[] = 'from-version'; return $target; },
+					static function (string $family) use (&$order): bool {
+						$order[] = "replace:{$family}";
+						return $family === '3.3';
+					}
+				);
+				$this->fail('target failure must restore the saved source and fail closed');
+			} catch (RuntimeException $error) {
+				$this->assertSame('pfBlockerNG: unable to restore settings family', $error->getMessage());
+			}
+			$targetRestore = $target === NULL ? [] : ['replace:4.1'];
+			$this->assertSame(
+				['current', 'save:3.3', 'version', 'from-version', ...$targetRestore, 'replace:3.3'],
+				$order
+			);
+		}
+	}
+
 	/**
 	 * The installer performs appliance-only migrations and service changes, so a direct include
 	 * is destructive/off-appliance. php_strip_whitespace keeps this pin executable-code-only.

--- a/tests/php/PfbSettingsFamilyTest.php
+++ b/tests/php/PfbSettingsFamilyTest.php
@@ -63,9 +63,22 @@ final class PfbSettingsFamilyTest extends TestCase
 		PfbConfig::write('gen/settings_family', '9.0');
 		$this->assertNull(pfb_settings_family_current());
 		$this->assertSame('3.2', pfb_settings_family_from_version('3.2.0'));
+		$this->assertSame('3.3', pfb_settings_family_from_version('3.3.0'));
 		$this->assertSame('4.0', pfb_settings_family_from_version('4.0.0'));
 		$this->assertSame('4.1', pfb_settings_family_from_version('4.1.0'));
+		$this->assertSame('4.1', pfb_settings_family_from_version('20260819010101.abcdef1'));
 		$this->assertNull(pfb_settings_family_from_version('5.0.1'));
+		$this->assertNull(pfb_settings_family_from_version('20260230010101.abcdef1'));
+		$this->assertNull(pfb_settings_family_from_version('20260819010101.ABCDEF1'));
+		$this->assertNull(pfb_settings_family_from_version('20260819010101.abcdef'));
+	}
+
+	public function testThreeThreeMarkerCanBeSnapshottedBeforeUpgrade(): void
+	{
+		$this->assertTrue(pfb_settings_family_record('3.3'));
+		$this->assertSame('3.3', pfb_settings_family_current());
+		pfb_settings_family_pre_uninstall();
+		$this->assertFileExists($this->root . '/settings-3.3.xml');
 	}
 
 	public function testSaveAndReplacePreserveOwnedSubtreeAndUnrelatedConfig(): void


### PR DESCRIPTION
## Summary

- recognize settings family 3.3 between 3.2 and 4.0
- map the existing strict bare nightly version format to current family 4.1
- restore the saved source snapshot before failing a target-family restore
- keep the missing-marker default at 3.2

The release/3.3 pre-deinstall guard landed separately in #2547.

## Test-first proof

RED on untouched production: 22 tests, 101 assertions, 3 failures.

Frozen test hashes:
- `c5e09dd8200ab865f897f00dd1cba06e6e0277bf` — `PfbSettingsFamilyTest.php`
- `137a5f37a686b48ed7c2b0bc1ecd31bf83d445a6` — `PfbSettingsFamilyPostInstallCaptureTest.php`

GREEN unchanged: 22 tests, 112 assertions.

## Verification

`scripts/agent/run-gates.sh --diff origin/devel`: PASS
- PHPUnit: PASS
- PHPStan: PASS
- PHPCS: PASS
- PHP lint and Composer vendor integrity: PASS

Closes #2532

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved settings restoration by falling back to the original settings family when the target family is unavailable or cannot be restored.
  - Added safer rollback behavior when restoration fails, preventing incomplete follow-up actions.

- **Compatibility**
  - Added support for recognizing nightly builds and the new settings family.
  - Improved validation for timestamp-based versions and malformed version identifiers.
  - Preserved settings from the 3.3 family during upgrade and removal workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->