### PR TITLE
pfblockerng: add rc.d pkg.conf CA command interface

### DIFF
--- a/scripts/rc.d/pfblockerng_repo_generate.sh
+++ b/scripts/rc.d/pfblockerng_repo_generate.sh
@@ -271,9 +271,9 @@ _regen_one() {
 # previously-applied line anyway — revocation is handled synchronously by the
 # PHP side, not by this hook running backwards.
 _pkgconf_ca_reapply() {
+    PFB_CA_REAPPLY_CONSENT=off
     [ "${PFB_UPGRADE_LOCK_HELD:-1}" = 1 ] || return 0
     grep -q 'Plus' "${PFB_PRODUCT_LABEL}" 2>/dev/null || return 0
-    [ -e "${PFB_PKG_DIRTY}" ] && return 0
     # Consent gate, fail-closed. pfb_pkg_ca_consent is a registered config field
     # read on the PHP side at installedpackages/pfblockerng/config/0 --
     # PfbConfig::read('gen/pfb_pkg_ca_consent') -- meaning the element must be a
@@ -348,6 +348,8 @@ _pkgconf_ca_reapply() {
         ' "${PFB_CONFIG_XML}" 2>/dev/null)"
     [ "${_pcr_consent}" = 'on' ] || { unset _pcr_consent; return 0; }
     unset _pcr_consent
+    PFB_CA_REAPPLY_CONSENT=on
+    [ -e "${PFB_PKG_DIRTY}" ] && return 0
 
     # -h before -f: a symlink also passes -f, and the tmp+mv patch below would
     # replace the LINK's identity rather than editing through it to its target.
@@ -499,6 +501,73 @@ _pkgconf_ca_reapply() {
     return 0
 }
 
+_pkgconf_ca_sync_command() {
+    _pkgconf_ca_reapply
+    _pcr_owned_line="$(printf '\tSSL_CA_CERT_PATH=%s' "${PFB_SSL_CA_CERT_PATH}")"
+    if [ "${PFB_CA_REAPPLY_CONSENT:-off}" = on ] \
+        && ! grep -F -qx "${_pcr_owned_line}" "${PFB_PKG_CONF}" 2>/dev/null; then
+        return 1
+    fi
+    return 0
+}
+
+_pkgconf_ca_revoke() {
+    [ "${PFB_UPGRADE_LOCK_HELD:-}" = 1 ] || return 1
+    [ -e "${PFB_PKG_CONF}" ] && [ ! -h "${PFB_PKG_CONF}" ] \
+        && [ -f "${PFB_PKG_CONF}" ] && [ -r "${PFB_PKG_CONF}" ] || return 1
+    [ ! -e "${PFB_PKG_DIRTY}" ] || return 1
+    _pcr_original_sum="$(cksum < "${PFB_PKG_CONF}" 2>/dev/null)" || return 1
+    _pcr_open_count="$(grep -c '^PKG_ENV {$' "${PFB_PKG_CONF}" 2>/dev/null)" || _pcr_open_count=0
+    [ "${_pcr_open_count:-0}" -eq 1 ] || return 1
+    _pcr_block="$(sed -n '/^PKG_ENV {$/,/^}$/p' "${PFB_PKG_CONF}" 2>/dev/null)" || return 1
+    [ "$(printf '%s\n' "${_pcr_block}" | tail -n 1)" = '}' ] || return 1
+    _pcr_ca_file_count="$(grep -F -c 'SSL_CA_CERT_FILE' "${PFB_PKG_CONF}" 2>/dev/null)" || _pcr_ca_file_count=0
+    [ "${_pcr_ca_file_count:-0}" -eq 1 ] || return 1
+    _pcr_ca_file="$(printf '%s\n' "${_pcr_block}" | sed -n 's/^\tSSL_CA_CERT_FILE=//p')"
+    [ "$(printf '%s\n' "${_pcr_ca_file}" | grep -c .)" -eq 1 ] || return 1
+    case "${_pcr_ca_file}" in
+        /?*) ;;
+        *) return 1 ;;
+    esac
+    case "${_pcr_ca_file}" in
+        *[!A-Za-z0-9._/+-]*) return 1 ;;
+    esac
+    _pcr_target="$(printf '%s\n' "${_pcr_block}" | grep -F -x -c "	SSL_CA_CERT_PATH=${PFB_SSL_CA_CERT_PATH}" 2>/dev/null)" || _pcr_target=0
+    _pcr_any_path="$(grep -F -c 'SSL_CA_CERT_PATH' "${PFB_PKG_CONF}" 2>/dev/null)" || _pcr_any_path=0
+    _pcr_mid="$(printf '%s\n' "${_pcr_block}" | sed '1d;$d')"
+    _pcr_mid_opens="$(printf '%s\n' "${_pcr_mid}" | grep -c '{$' 2>/dev/null)" || _pcr_mid_opens=0
+    _pcr_mid_closes="$(printf '%s\n' "${_pcr_mid}" | grep -cx '}' 2>/dev/null)" || _pcr_mid_closes=0
+    [ "${_pcr_mid_opens:-0}" -eq "${_pcr_mid_closes:-0}" ] || return 1
+    if [ "${_pcr_any_path}" -eq 0 ]; then
+        return 0
+    fi
+    [ "${_pcr_target}" -eq 1 ] && [ "${_pcr_any_path}" -eq 1 ] || return 1
+    _pcr_tmp="${PFB_PKG_CONF}.tmp"
+    _pcr_had_no_trailing_nl=0
+    [ -n "$(tail -c1 "${PFB_PKG_CONF}" 2>/dev/null)" ] && _pcr_had_no_trailing_nl=1
+    if ! cp -p "${PFB_PKG_CONF}" "${_pcr_tmp}" 2>/dev/null \
+        || ! awk -v target="	SSL_CA_CERT_PATH=${PFB_SSL_CA_CERT_PATH}" '
+            !removed && $0 == target { removed = 1; next }
+            { print }
+        ' "${PFB_PKG_CONF}" > "${_pcr_tmp}" 2>/dev/null; then
+        rm -f "${_pcr_tmp}" 2>/dev/null
+        return 1
+    fi
+    if [ "${_pcr_had_no_trailing_nl}" -eq 1 ]; then
+        printf '%s' "$(cat "${_pcr_tmp}" 2>/dev/null)" > "${_pcr_tmp}" 2>/dev/null || {
+            rm -f "${_pcr_tmp}" 2>/dev/null
+            return 1
+        }
+    fi
+    _pcr_live_sum="$(cksum < "${PFB_PKG_CONF}" 2>/dev/null)" || _pcr_live_sum=''
+    if [ -z "${_pcr_live_sum}" ] || [ "${_pcr_live_sum}" != "${_pcr_original_sum}" ] \
+        || ! mv "${_pcr_tmp}" "${PFB_PKG_CONF}" 2>/dev/null; then
+        rm -f "${_pcr_tmp}" 2>/dev/null
+        return 1
+    fi
+    return 0
+}
+
 # Regenerate each channel's conf independently (channel keyed by conf path). Only
 # the channel(s) the box actually subscribed to are touched — _regen_one()'s
 # orphan guard skips every absent conf, so a box on one channel stays on that one
@@ -523,6 +592,17 @@ if [ "${PFB_UPGRADE_LOCK_HELD:-}" != 1 ] && [ -x "${PFB_LOCKF}" ]; then
     PFB_UPGRADE_LOCK_HELD=0
     export PFB_UPGRADE_LOCK_HELD
 fi
+
+case "${1:-}" in
+    ca-sync|ca-revoke)
+        [ "${PFB_UPGRADE_LOCK_HELD:-}" = 1 ] || exit 1
+        ;;
+esac
+
+case "${1:-}" in
+    ca-sync) _pkgconf_ca_sync_command; exit $? ;;
+    ca-revoke) _pkgconf_ca_revoke; exit $? ;;
+esac
 
 # Run as an rc.d service when rc.subr is present (the pfSense box); otherwise run
 # the regeneration directly (off-box: install.sh's bootstrap + the shellspec

--- a/tests/shell/generate_hook_pkgconf_spec.sh
+++ b/tests/shell/generate_hook_pkgconf_spec.sh
@@ -155,6 +155,167 @@ Describe 'pkgconf re-apply — consent on (C_ok, the production shape): patches 
     End
 End
 
+Describe 'pkg.conf command interface — ca-sync no-op and refusal statuses'
+    setup() {
+        _ci_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pc_interface_status.XXXXXX")"
+        _pc_box "${_ci_dir}"
+        cp "${PFB_PINNED}" "${PFB_PKG_CONF}"
+    }
+    cleanup() { rm -rf "${_ci_dir}"; _pc_unset_box; unset _ci_dir; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'ca-sync is successful and unchanged when consent is off'
+      _pc_config_xml off
+      When run sh "${HOOK}" ca-sync
+      The status should be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${PFB_PINNED}" && echo 0 || echo 1)" should equal 0
+    End
+
+    It 'ca-sync reports blocked consent truthfully'
+      _pc_config_xml on
+      printf 'DIRTY\n' > "${PFB_PKG_DIRTY}"
+      When run sh "${HOOK}" ca-sync
+      The status should not be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${PFB_PINNED}" && echo 0 || echo 1)" should equal 0
+    End
+
+    It 'ca-sync is successful when already patched'
+      cp "${PFB_EXPECTED_PATCHED}" "${PFB_PKG_CONF}"
+      _pc_config_xml on
+      When run sh "${HOOK}" ca-sync
+      The status should be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${PFB_EXPECTED_PATCHED}" && echo 0 || echo 1)" should equal 0
+    End
+End
+
+Describe 'pkg.conf command interface — ca-revoke absent is idempotent'
+    setup() {
+        _ci_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pc_interface_revoke_absent.XXXXXX")"
+        _pc_box "${_ci_dir}"
+        cp "${PFB_PINNED}" "${PFB_PKG_CONF}"
+    }
+    cleanup() { rm -rf "${_ci_dir}"; _pc_unset_box; unset _ci_dir; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'returns success without changing an unpatched recognized file'
+      When run sh "${HOOK}" ca-revoke
+      The status should be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${PFB_PINNED}" && echo 0 || echo 1)" should equal 0
+    End
+End
+
+Describe 'pkg.conf command interface — ca-revoke refuses unsafe shapes'
+    setup() {
+        _ci_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pc_interface_revoke_hostile.XXXXXX")"
+        _pc_box "${_ci_dir}"
+        cp "${PFB_EXPECTED_PATCHED}" "${PFB_PKG_CONF}"
+        cp "${PFB_PKG_CONF}" "${_ci_dir}/before.conf"
+    }
+    cleanup() { rm -rf "${_ci_dir}"; _pc_unset_box; unset _ci_dir; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'rejects a foreign CA path'
+      awk -v owned="\tSSL_CA_CERT_PATH=${PFB_SSL_CA_CERT_PATH}" '
+        $0 == owned { $0 = "\tSSL_CA_CERT_PATH=/foreign" }
+        { print }
+      ' "${PFB_PKG_CONF}" > "${PFB_PKG_CONF}.new"
+      mv "${PFB_PKG_CONF}.new" "${PFB_PKG_CONF}"
+      cp "${PFB_PKG_CONF}" "${_ci_dir}/before.conf"
+      When run sh "${HOOK}" ca-revoke
+      The status should not be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${_ci_dir}/before.conf" && echo 0 || echo 1)" should equal 0
+    End
+
+    It 'rejects duplicate owned lines'
+      awk -v line="\tSSL_CA_CERT_PATH=${PFB_SSL_CA_CERT_PATH}" '$0 == "}" && !done { print line; done = 1 } { print }' "${PFB_PKG_CONF}" > "${PFB_PKG_CONF}.new"
+      mv "${PFB_PKG_CONF}.new" "${PFB_PKG_CONF}"
+      cp "${PFB_PKG_CONF}" "${_ci_dir}/before.conf"
+      When run sh "${HOOK}" ca-revoke
+      The status should not be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${_ci_dir}/before.conf" && echo 0 || echo 1)" should equal 0
+    End
+
+    It 'rejects a second CA bundle key outside PKG_ENV'
+      printf '\tSSL_CA_CERT_FILE=/foreign\n' >> "${PFB_PKG_CONF}"
+      cp "${PFB_PKG_CONF}" "${_ci_dir}/before.conf"
+      When run sh "${HOOK}" ca-revoke
+      The status should not be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${_ci_dir}/before.conf" && echo 0 || echo 1)" should equal 0
+    End
+
+    It 'rejects a symlink without changing its target'
+      mv "${PFB_PKG_CONF}" "${_ci_dir}/real.conf"
+      ln -s "${_ci_dir}/real.conf" "${PFB_PKG_CONF}"
+      When run sh "${HOOK}" ca-revoke
+      The status should not be success
+      The value "$(cmp -s "${_ci_dir}/real.conf" "${_ci_dir}/before.conf" && echo 0 || echo 1)" should equal 0
+    End
+
+    It 'rejects a busy upgrade lock without changing the file'
+      printf '%s\n' '#!/bin/sh' 'exit 1' > "${PFB_LOCKF}"
+      chmod +x "${PFB_LOCKF}"
+      When run sh "${HOOK}" ca-revoke
+      The status should not be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${_ci_dir}/before.conf" && echo 0 || echo 1)" should equal 0
+    End
+
+    It 'rejects an unclosed PKG_ENV block'
+      sed '$d' "${PFB_PKG_CONF}" > "${PFB_PKG_CONF}.new"
+      mv "${PFB_PKG_CONF}.new" "${PFB_PKG_CONF}"
+      cp "${PFB_PKG_CONF}" "${_ci_dir}/before.conf"
+      When run sh "${HOOK}" ca-revoke
+      The status should not be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${_ci_dir}/before.conf" && echo 0 || echo 1)" should equal 0
+    End
+End
+
+Describe 'pkg.conf command interface — ca-sync reports effective consented patch'
+    setup() {
+        _ci_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pc_interface_sync.XXXXXX")"
+        _pc_box "${_ci_dir}"
+        cp "${PFB_PINNED}" "${PFB_PKG_CONF}"
+        _pc_config_xml on
+    }
+    cleanup() { rm -rf "${_ci_dir}"; _pc_unset_box; unset _ci_dir; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'ca-sync patches and returns success'
+      When run sh "${HOOK}" ca-sync
+      The status should be success
+      The stderr should include "INFO"
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${PFB_EXPECTED_PATCHED}" && echo 0 || echo 1)" should equal 0
+    End
+End
+
+Describe 'pkg.conf command interface — ca-revoke removes the owned line exactly'
+    setup() {
+        _ci_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pc_interface_revoke.XXXXXX")"
+        _pc_box "${_ci_dir}"
+        cp "${PFB_EXPECTED_PATCHED}" "${PFB_PKG_CONF}"
+        cp "${PFB_PINNED}" "${_ci_dir}/expected.conf"
+    }
+    cleanup() { rm -rf "${_ci_dir}"; _pc_unset_box; unset _ci_dir; }
+    Before 'setup'
+    After  'cleanup'
+
+    It 'ca-revoke restores the pinned bytes and returns success'
+      When run sh "${HOOK}" ca-revoke
+      The status should be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${_ci_dir}/expected.conf" && echo 0 || echo 1)" should equal 0
+    End
+
+    It 'ca-revoke still succeeds after the referenced CA bundle disappears'
+      rm -f "${PFB_SSL_CA_CERT_FILE}"
+      When run sh "${HOOK}" ca-revoke
+      The status should be success
+      The value "$(cmp -s "${PFB_PKG_CONF}" "${_ci_dir}/expected.conf" && echo 0 || echo 1)" should equal 0
+    End
+End
+
 Describe 'pkgconf re-apply — pkg subsystem dirty: byte-unchanged'
     setup() {
         _c1_dirty_dir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pc_pkg_dirty.XXXXXX")"


### PR DESCRIPTION
## Summary

- add explicit `ca-sync` and `ca-revoke` commands to the canonical rc.d hook
- keep normal boot/onestart non-fatal
- return truthful status for package-side calls under the existing upgrade lock
- preserve exact bytes, mode, trailing-newline state, and fail-closed hostile-shape behavior

This is the canonical writer prerequisite for deleting the duplicate PHP `pkg.conf` implementation on release/3.3 and devel.

## Test-first proof

Frozen hostile-input test hash: `2dd69dca2f216b2d7e9a09ad138af49ac484ca12`.

- RED: 119 examples, 1 failure — a second `SSL_CA_CERT_FILE` outside `PKG_ENV` was incorrectly accepted and the file changed.
- GREEN unchanged: 119 examples, 0 failures.

## Verification

`scripts/agent/run-gates.sh --diff origin/devel`: PASS

Part of #2553.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to synchronize or revoke the managed certificate authority configuration.
  * Synchronization now verifies consent and applies only valid, approved certificate paths.
  * Revocation safely removes the managed configuration while preserving file integrity.

* **Bug Fixes**
  * Prevented unauthorized, malformed, duplicate, or unsafe configuration changes.
  * Added handling for missing certificate bundles and existing package change markers.

* **Tests**
  * Added coverage for consent states, idempotent synchronization, revocation, invalid configurations, symlinks, locks, and missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->