### PR TITLE
ci: allow release-branch test dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install test dependencies
-        run: pip install pytest
+        run: pip install pytest pyyaml
 
       - name: Run tests
         # testpaths and addopts are configured in pyproject.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
       - devel
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/tests/test_release_branch_workflow_dispatch.py
+++ b/tests/test_release_branch_workflow_dispatch.py
@@ -5,6 +5,12 @@ from pathlib import Path
 
 def test_tests_workflow_has_manual_dispatch() -> None:
     workflow = (Path(__file__).parents[1] / ".github/workflows/test.yml").read_text()
-    triggers = workflow.split("\non:\n", 1)[1].split("\njobs:\n", 1)[0]
+    lines = workflow.splitlines()
+    start = lines.index("on:") + 1
+    triggers = []
+    for line in lines[start:]:
+        if line and not line[0].isspace():
+            break
+        triggers.append(line)
 
-    assert "\n  workflow_dispatch:\n" in triggers
+    assert "  workflow_dispatch:" in triggers

--- a/tests/test_release_branch_workflow_dispatch.py
+++ b/tests/test_release_branch_workflow_dispatch.py
@@ -2,15 +2,14 @@
 
 from pathlib import Path
 
+import yaml
+
 
 def test_tests_workflow_has_manual_dispatch() -> None:
-    workflow = (Path(__file__).parents[1] / ".github/workflows/test.yml").read_text()
-    lines = workflow.splitlines()
-    start = lines.index("on:") + 1
-    triggers = []
-    for line in lines[start:]:
-        if line and not line[0].isspace():
-            break
-        triggers.append(line)
+    source = (Path(__file__).parents[1] / ".github/workflows/test.yml").read_text()
+    workflow = yaml.load(source, Loader=yaml.BaseLoader)
+    assert isinstance(workflow, dict)
 
-    assert "  workflow_dispatch:" in triggers
+    triggers = workflow.get("on")
+    assert isinstance(triggers, dict)
+    assert "workflow_dispatch" in triggers

--- a/tests/test_release_branch_workflow_dispatch.py
+++ b/tests/test_release_branch_workflow_dispatch.py
@@ -1,0 +1,10 @@
+"""The release branch must be able to produce an exact-head CI check."""
+
+from pathlib import Path
+
+
+def test_tests_workflow_has_manual_dispatch() -> None:
+    workflow = (Path(__file__).parents[1] / ".github/workflows/test.yml").read_text()
+    triggers = workflow.split("\non:\n", 1)[1].split("\njobs:\n", 1)[0]
+
+    assert "\n  workflow_dispatch:\n" in triggers


### PR DESCRIPTION
## What

Add the missing workflow_dispatch trigger to the release/3.3 Tests workflow and verify the parsed GitHub Actions trigger map.

## Why

The v3.3.3.a1 release run 32279958611 stopped before any mutation because release-ci-gate.sh correctly requires an exact-head Tests result for merge commit 3e259bfb9. PR checks belong to the pre-merge head, push CI excludes release/3.3, and a manual dispatch returned HTTP 422 because this trigger was absent.

This keeps the release gate strict and creates the one legitimate way to test the actual release-branch head.

## Proof

Final frozen test blob: 10a9e7dae4a19c156a087b8fe1580ed394efaf2f

- RED unchanged against untouched release/3.3: one failure because parsed on has no workflow_dispatch.
- GREEN unchanged against this head.
- Hostile mutations: block-scalar and multiline-quoted decoys are valid YAML but both fail.
- Complete release suite: 38 passed.
- actionlint: pass.
- git diff --check: pass.

Review found two test-honesty holes in line-based parsing. The final assertion uses PyYAML BaseLoader and checks the actual parsed on.workflow_dispatch mapping; the release workflow installs that explicit test dependency.

Fixes #2560

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to manually run the test workflow.

* **Tests**
  * Added validation to ensure manual workflow execution remains configured correctly.

* **Chores**
  * Added YAML parsing support to the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->