### PR TITLE
pfblockerng: fix standalone resolver failure logging

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc
@@ -24,8 +24,6 @@
 require_once('config.inc');
 require_once('globals.inc');
 
-define('LOG_PREFIX_PKG_PFBLOCKERNG', 'pfBlockerNG');
-
 global $g;
 
 config_read_file(false, true);
@@ -102,7 +100,8 @@ function pfb_python_mount($python_mode, $verbose, $type_mount, $type_umount, $ty
 
 			if ($retval != 0) {
 				$log_err = "Failed to mount /{$folder}";
-				logger(LOG_ERR, "[Unbound-pymod]: {$log_err}", LOG_PREFIX_PKG_PFBLOCKERNG);
+				// Issue #2537: logger() is unavailable on CE's non-verbose resolver path.
+				log_error("[Unbound-pymod]: {$log_err}");
 				if ($verbose) {
 					pfb_logger("\n   {$log_err}", 1);
 				}
@@ -148,7 +147,7 @@ function pfb_python_mount($python_mode, $verbose, $type_mount, $type_umount, $ty
 		}
 		else {
 			$log_err = "Failed to unmount /{$folder}";
-			logger(LOG_ERR, "[Unbound-pymod]: {$log_err}", LOG_PREFIX_PKG_PFBLOCKERNG);
+			log_error("[Unbound-pymod]: {$log_err}");
 			if ($verbose) {
 				pfb_logger("\n   {$log_err}", 1);
 			}

--- a/tests/php/assert_logger_shim_3_3.php
+++ b/tests/php/assert_logger_shim_3_3.php
@@ -47,6 +47,57 @@ function check(bool $cond, string $label): void
 check(!function_exists('logger'), 'logger() absent before extra.inc');
 check(!function_exists('localize_text'), 'localize_text() absent before extra.inc');
 
+/* Standalone resolver setup must log mount failures without the package fallback. */
+$unbound = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfb_unbound_include.inc';
+$unbound_source = file_get_contents($unbound);
+check(
+	is_string($unbound_source)
+		&& preg_match('/function pfb_python_mount\\b.*?^\\}/ms', $unbound_source, $mount_function) === 1,
+	'pfb_python_mount() source is readable'
+);
+
+$mount_errors = [];
+function log_error(string $message): void
+{
+	global $mount_errors;
+	$mount_errors[] = $message;
+}
+
+function safe_mkdir(string $path): void
+{
+}
+
+eval($mount_function[0]);
+foreach (
+	[
+		[TRUE, 'pfb-test-no-mounted-fs', 'mount'],
+		[FALSE, '', 'unmount'],
+	] as [$python_mode, $grep_string, $operation]
+) {
+	$threw = FALSE;
+	try {
+		pfb_python_mount(
+			$python_mode,
+			FALSE,
+			'pfb-test-invalid',
+			'pfb-test-invalid',
+			'',
+			'pfb-test-noop',
+			$grep_string
+		);
+	} catch (Throwable $e) {
+		$threw = TRUE;
+	}
+	check(!$threw, "{$operation} failure logs without logger() fallback");
+}
+check(
+	$mount_errors === [
+		'[Unbound-pymod]: Failed to mount /pfb-test-noop',
+		'[Unbound-pymod]: Failed to unmount /pfb-test-noop',
+	],
+	'mount and unmount failures use log_error()'
+);
+
 $extra = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
 require_once $extra;
 

--- a/tests/php/assert_logger_shim_3_3.php
+++ b/tests/php/assert_logger_shim_3_3.php
@@ -57,23 +57,44 @@ check(
 );
 
 $mount_errors = [];
+$mount_exists = FALSE;
+$mount_command_fails = FALSE;
 function log_error(string $message): void
 {
 	global $mount_errors;
 	$mount_errors[] = $message;
 }
 
+function pfb_test_exec(string $command, mixed &$output, mixed &$retval): void
+{
+	global $mount_exists, $mount_command_fails;
+	if (str_starts_with($command, '/sbin/mount |')) {
+		$output = $mount_exists ? ['fixture mounted'] : [];
+		$retval = $mount_exists ? 0 : 1;
+		return;
+	}
+	$output = $mount_command_fails ? ['forced failure'] : [];
+	$retval = $mount_command_fails ? 1 : 0;
+}
+
 function safe_mkdir(string $path): void
 {
 }
 
-eval($mount_function[0]);
+$mount_source = str_replace('exec(', 'pfb_test_exec(', $mount_function[0], $exec_count);
+check($exec_count === 5, 'all pfb_python_mount() commands are isolated');
+eval($mount_source);
 foreach (
 	[
-		[TRUE, 'pfb-test-no-mounted-fs', 'mount'],
-		[FALSE, '', 'unmount'],
-	] as [$python_mode, $grep_string, $operation]
+		[TRUE, FALSE, TRUE, 'mount failure', '[Unbound-pymod]: Failed to mount /pfb-test-noop'],
+		[TRUE, FALSE, FALSE, 'mount success', NULL],
+		[FALSE, TRUE, TRUE, 'unmount failure', '[Unbound-pymod]: Failed to unmount /pfb-test-noop'],
+		[FALSE, TRUE, FALSE, 'unmount success', NULL],
+	] as [$python_mode, $mounted, $command_fails, $operation, $expected_error]
 ) {
+	$mount_exists = $mounted;
+	$mount_command_fails = $command_fails;
+	$error_count = count($mount_errors);
 	$threw = FALSE;
 	try {
 		pfb_python_mount(
@@ -83,12 +104,18 @@ foreach (
 			'pfb-test-invalid',
 			'',
 			'pfb-test-noop',
-			$grep_string
+			'fixture'
 		);
 	} catch (Throwable $e) {
 		$threw = TRUE;
 	}
-	check(!$threw, "{$operation} failure logs without logger() fallback");
+	$logged_expected = $expected_error === NULL
+		? count($mount_errors) === $error_count
+		: count($mount_errors) === $error_count + 1 && end($mount_errors) === $expected_error;
+	check(
+		!$threw && $logged_expected,
+		"{$operation} logs without logger() fallback"
+	);
 }
 check(
 	$mount_errors === [


### PR DESCRIPTION
## Problem

`pfb_unbound_include.inc` runs standalone during resolver setup, before the
package's guarded `logger()` fallback is available. On released pfSense CE,
failed mount or unmount operations therefore call an undefined function and
replace the original diagnostic with a fatal error.

`devel` already fixed the same two paths in #516. The maintained
`release/3.3` line still contained the vulnerable calls.

## Fix

Use pfSense core `log_error()` for both failure paths and remove the now-unused
package log-prefix constant. The verbose `pfb_logger()` diagnostics remain
unchanged.

## Test

Extended the existing CE logger harness to execute both failure branches before
loading the package fallback.

Frozen test file:

```text
03d9eb75c6a835ee81bb710d59fa31dbc834e509  tests/php/assert_logger_shim_3_3.php
```

Before the production change:

```text
FAIL mount failure logs without logger() fallback
PASS mount success logs without logger() fallback
FAIL unmount failure logs without logger() fallback
PASS unmount success logs without logger() fallback
FAIL mount and unmount failures use log_error()
```

After the production change:

```text
PASS mount failure logs without logger() fallback
PASS mount success logs without logger() fallback
PASS unmount failure logs without logger() fallback
PASS unmount success logs without logger() fallback
PASS mount and unmount failures use log_error()
ALL PASS
```

Full branch suite:

```text
37 passed in 2.84s
```

Fixes #2537

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for resolver mount and unmount failures.
  * Prevented failures from depending on unavailable logging functionality.
* **Tests**
  * Added regression coverage for successful and failed mount/unmount scenarios.
  * Verified that errors are recorded correctly without causing unexpected exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->