### PR TITLE
ci: scope 3.3 release gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ name: Release
 #   2. read-matrix / resolve-stamp / build-pkgs-portable / ui-suite / smoke-suite:
 #      build every artifact FROM THE PINNED SHA as workflow artifacts, then verify
 #      them — against that same source tree (issue #1859).  Whether the live suites
-#      run at all is the `run_suites` decision (alpha/beta skip them; rc + stable
-#      run them; `force_suites` forces them on except for the 3.3 bridge) — one code path, the
-#      verification phase is simply empty for an alpha/beta.  Which matrix rows may
-#      VETO is the released-status predicate (scripts/resolve-legs.sh, via
+#      run at all is the `run_suites` decision (the 3.3 bridge never runs them;
+#      otherwise alpha/beta skip, rc + stable run, and `force_suites` forces them
+#      on) — one code path whose verification phase is empty when suites are skipped.
+#      Which matrix rows may VETO is the released-status predicate (scripts/resolve-legs.sh, via
 #      `release_gate: true`).
 #
 #   3. tag-release (real only): the FIRST irreversible step.  Pushes the tag on the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ name: Release
 #      build every artifact FROM THE PINNED SHA as workflow artifacts, then verify
 #      them — against that same source tree (issue #1859).  Whether the live suites
 #      run at all is the `run_suites` decision (alpha/beta skip them; rc + stable
-#      always run them; `force_suites` forces them on) — one code path, the
+#      run them; `force_suites` forces them on except for the 3.3 bridge) — one code path, the
 #      verification phase is simply empty for an alpha/beta.  Which matrix rows may
 #      VETO is the released-status predicate (scripts/resolve-legs.sh, via
 #      `release_gate: true`).
@@ -524,7 +524,7 @@ jobs:
             *)          RUN_SUITES="true"  ;;
           esac
           # An API dispatch can send any casing for a boolean input; accept them all
-          # here because forcing the suites ON is always the safe direction.
+          # here because forcing the suites ON is the safe direction for lines that carry them.
           case "${FORCE_SUITES:-}" in
             [Tt][Rr][Uu][Ee]) RUN_SUITES="true" ;;
           esac
@@ -1392,13 +1392,14 @@ jobs:
       - name: Health-check the draft release is complete
         id: verify
         # Expected assets: the source archive + exactly one .pkg per release-matrix row
-        # PLUS one dep .pkg per extra_pkgs entry across every row. The
+        # PLUS one built dep .pkg per effective extra_pkgs entry. The
         # pfBlockerNG-relpkg-* sweep also picks up each row's dependency artifact.
         # A published release is stale for this draft handoff; never claim a
         # complete draft or allow notes mutation against it.
         env:
           GH_TOKEN:     ${{ github.token }}
           TAG:          ${{ needs.release.outputs.tag }}
+          SOURCE:       ${{ needs.release.outputs.source }}
           BUILD_MATRIX: ${{ needs.read-matrix.outputs.release_matrix }}
           PORTVERSION:  ${{ needs.read-matrix.outputs.portversion }}
         run: |
@@ -1412,10 +1413,15 @@ jobs:
             exit 1
           fi
 
+          ASSET_MATRIX="$BUILD_MATRIX"
+          if [ "$SOURCE" = "release/3.3" ]; then
+            ASSET_MATRIX=$(printf '%s' "$BUILD_MATRIX" | jq 'map(.extra_pkgs = [])')
+          fi
+
           # issue #1806 B1: the release-row count PLUS the total number of
-          # extra_pkgs entries across the release-matrix rows -- each
+          # built extra_pkgs entries across the effective asset rows -- each
           # dep .pkg is its own release asset (see attach-pkgs's comment).
-          EXPECTED_PKGS=$(printf '%s' "$BUILD_MATRIX" | jq '(length) + ([.[] | (.extra_pkgs // []) | length] | add // 0)')
+          EXPECTED_PKGS=$(printf '%s' "$ASSET_MATRIX" | jq '(length) + ([.[] | (.extra_pkgs // []) | length] | add // 0)')
           PKG_COUNT=$(printf '%s' "$META" | jq '[.assets[] | select(.name | endswith(".pkg"))] | length')
           SRC_COUNT=$(printf '%s' "$META" | jq '[.assets[] | select(.name | endswith(".tar.gz"))] | length')
 
@@ -1446,7 +1452,7 @@ jobs:
               FAIL=1
             fi
           done <<EOF_ROWS
-          $(printf '%s' "$BUILD_MATRIX" | jq -c '.[]')
+          $(printf '%s' "$ASSET_MATRIX" | jq -c '.[]')
           EOF_ROWS
           printf '%s' "$META" | jq -e '(.name // "") != "" and ((.body // "") | length) > 0' >/dev/null \
             || { echo "::error::release name or body is empty"; FAIL=1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,6 +528,8 @@ jobs:
           case "${FORCE_SUITES:-}" in
             [Tt][Rr][Uu][Ee]) RUN_SUITES="true" ;;
           esac
+          # release/3.3 is an installer-only bridge with no live smoke/UI corpus.
+          [ "$SOURCE" = "release/3.3" ] && RUN_SUITES="false"
           case "$release_channel" in
             stable) PKG_CHANNEL=stable ;;
             testing|edge) PKG_CHANNEL="$release_channel" ;;
@@ -1082,6 +1084,19 @@ jobs:
             git tag "${TAG}" "$COMMIT"
           fi
 
+      - name: Resolve release-line extras
+        id: extras
+        env:
+          SOURCE: ${{ github.event.inputs.source }}
+          MATRIX_EXTRA_PKGS: ${{ toJson(matrix.extra_pkgs) }}
+        run: |
+          set -eu
+          case "$SOURCE" in
+            release/3.3) EXTRA_PKGS='[]' ;;
+            *) EXTRA_PKGS="$MATRIX_EXTRA_PKGS" ;;
+          esac
+          echo "extra_pkgs=${EXTRA_PKGS}" >> "$GITHUB_OUTPUT"
+
       - name: Write the destination-bound build record
         env:
           TAG:           ${{ github.event.inputs.tag }}
@@ -1151,7 +1166,7 @@ jobs:
           MAJOR:        ${{ matrix.freebsd_major }}
           VARIANT:      ${{ matrix.variant }}
           PFSENSE_VERSION: ${{ matrix.pfsense_version }}
-          EXTRA_PKGS:   ${{ toJson(matrix.extra_pkgs) }}
+          EXTRA_PKGS:   ${{ steps.extras.outputs.extra_pkgs }}
         run: |
           set -eu
           # Keep generated Ports and package trees outside the pinned source checkout.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ on:
         type: boolean
 
       force_suites:
-        description: "Run the live smoke/UI suites even for an alpha/beta tag (issue #1855). rc + stable always run them; alpha/beta default to CI-green-on-the-release-commit as the mandatory gate."
+        description: "Run live smoke/UI for a supported alpha/beta. The 3.3 bridge has no live corpus and never runs them; other rc/stable releases always do."
         required: false
         default: false
         type: boolean
@@ -506,8 +506,8 @@ jobs:
         #     pipeline — so the ordering below is unchanged.
         #   prekind rc, or stable -> YES, in full, gated per the released-status
         #     predicate, and the tag/publish happen only on green.
-        # `force_suites` is the manual escape hatch: it can only ever ADD
-        # verification (rc/stable already run the suites unconditionally).
+        # `force_suites` can only ADD verification on lines that carry a live corpus;
+        # the release/3.3 bridge has none and stays off in every stage.
         env:
           INPUT_TAG:     ${{ github.event.inputs.tag }}
           INPUT_CHANNEL: ${{ github.event.inputs.channel }}
@@ -1298,11 +1298,11 @@ jobs:
         # Each build-pkgs-portable leg uploads its OWN row artifact, named
         # pfBlockerNG-relpkg-<variant>-<pfsense_version>; merge every
         # leg's artifact into pkgs/. The pattern also sweeps
-        # up each row's dependency artifact
-        # (issue #1806 B1) -- INTENTIONAL: dep .pkgs (e.g. CE's
+        # up each row's built dependency artifact
+        # (issue #1806 B1) -- INTENTIONAL when effective extras exist: dep .pkgs (e.g. CE's
         # py311-charset-normalizer) are deliberate release assets, frozen
         # alongside the branch .pkgs for the pkg-repo publish + EOL/route-only
-        # story. The draft healthcheck counts them (EXPECTED_PKGS).
+        # story. The draft healthcheck counts only the effective asset matrix.
         uses: actions/download-artifact@v7
         with:
           pattern: pfBlockerNG-relpkg-*

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -821,7 +821,13 @@ def test_published_workflow_rejects_release_flag_mismatch(
 # --------------------------------------------------------------------------- #
 
 
-def _run_suites_decision(tmp_path: Path, tag: str, force_suites: str) -> dict[str, str]:
+def _run_suites_decision(
+    tmp_path: Path,
+    tag: str,
+    force_suites: str,
+    *,
+    source: str = "release/4.0",
+) -> dict[str, str]:
     """Execute read-matrix's REAL channel/run_suites step body under sh."""
     script = _step_run_script(_step(_jobs()["read-matrix"], "Detect pkg channel from tag"))
     output_file = tmp_path / f"github_output_{tag}_{force_suites or 'unset'}"
@@ -832,8 +838,10 @@ def _run_suites_decision(tmp_path: Path, tag: str, force_suites: str) -> dict[st
         env={
             "PATH": "/usr/bin:/bin:/usr/local/bin",
             "INPUT_TAG": tag,
-            "INPUT_CHANNEL": "stable" if tag == "v4.0.0" else "edge",
-            "INPUT_SOURCE": "release/4.0",
+            "INPUT_CHANNEL": "stable"
+            if tag in {"v4.0.0", "v3.3.3"}
+            else ("testing" if tag.startswith("v3.3.3.") else "edge"),
+            "INPUT_SOURCE": source,
             "FORCE_SUITES": force_suites,
             "GITHUB_OUTPUT": str(output_file),
         },
@@ -873,6 +881,42 @@ def test_force_suites_turns_the_live_suites_back_on_for_an_alpha_or_beta(tmp_pat
 def test_force_suites_cannot_turn_the_live_suites_off(tmp_path: Path, tag: str) -> None:
     """rc/stable always verify; the input only ever ADDS verification."""
     assert _run_suites_decision(tmp_path, tag, "false")["run_suites"] == "true"
+
+
+@pytest.mark.parametrize("tag", ["v3.3.3.a1", "v3.3.3"])
+@pytest.mark.parametrize("force_suites", ["false", "true"])
+def test_release_33_never_runs_live_suites(tmp_path: Path, tag: str, force_suites: str) -> None:
+    outputs = _run_suites_decision(tmp_path, tag, force_suites, source="release/3.3")
+    assert outputs["run_suites"] == "false", outputs
+
+
+def _run_extra_pkgs_decision(tmp_path: Path, source: str, extra_pkgs: str) -> str:
+    script = _step_run_script(_step(_jobs()["build-pkgs-portable"], "Resolve release-line extras"))
+    output_file = tmp_path / "extra_pkgs_output"
+    output_file.write_text("")
+    completed = subprocess.run(  # noqa: S603
+        ["sh", "-c", script],
+        cwd=ROOT,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "SOURCE": source,
+            "MATRIX_EXTRA_PKGS": extra_pkgs,
+            "GITHUB_OUTPUT": str(output_file),
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    return output_file.read_text().removeprefix("extra_pkgs=").strip()
+
+
+def test_release_33_suppresses_matrix_extra_packages(tmp_path: Path) -> None:
+    assert _run_extra_pkgs_decision(tmp_path, "release/3.3", '["textproc/py-charset-normalizer"]') == "[]"
+
+
+def test_other_release_lines_keep_matrix_extra_packages(tmp_path: Path) -> None:
+    extras = '["textproc/py-charset-normalizer"]'
+    assert _run_extra_pkgs_decision(tmp_path, "release/4.0", extras) == extras
 
 
 def test_force_suites_input_is_declared_boolean_and_defaults_off() -> None:

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -36,6 +36,7 @@ the suite AND-gates fails here.
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
@@ -872,7 +873,7 @@ def test_run_suites_per_channel(tmp_path: Path, tag: str, expected_run_suites: s
 
 @pytest.mark.parametrize("tag", ["v4.0.0.a1", "v4.0.0.b1"])
 def test_force_suites_turns_the_live_suites_back_on_for_an_alpha_or_beta(tmp_path: Path, tag: str) -> None:
-    """The manual escape hatch: default off for alpha/beta, forceable per dispatch."""
+    """The manual escape hatch for release lines that carry live suites."""
     assert _run_suites_decision(tmp_path, tag, "false")["run_suites"] == "false"
     assert _run_suites_decision(tmp_path, tag, "true")["run_suites"] == "true"
 
@@ -917,6 +918,44 @@ def test_release_33_suppresses_matrix_extra_packages(tmp_path: Path) -> None:
 def test_other_release_lines_keep_matrix_extra_packages(tmp_path: Path) -> None:
     extras = '["textproc/py-charset-normalizer"]'
     assert _run_extra_pkgs_decision(tmp_path, "release/4.0", extras) == extras
+
+
+def test_build_record_keeps_the_original_release_33_matrix_row(tmp_path: Path) -> None:
+    script = _step_run_script(_step(_jobs()["build-pkgs-portable"], "Write the destination-bound build record"))
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    git_stub = bin_dir / "git"
+    git_stub.write_text("#!/bin/sh\nprintf '%s\\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'\n")
+    git_stub.chmod(0o755)
+    row = {
+        "variant": "CE",
+        "pfsense_version": "2.8",
+        "freebsd_major": "15",
+        "extra_pkgs": ["textproc/py-charset-normalizer"],
+    }
+    github_env = tmp_path / "github_env"
+    github_env.write_text("")
+    completed = subprocess.run(  # noqa: S603
+        ["sh", "-c", script],
+        cwd=ROOT,
+        env={
+            "PATH": f"{bin_dir}:/usr/bin:/bin:/usr/local/bin",
+            "TAG": "v3.3.3.a1",
+            "CHANNEL": "testing",
+            "SOURCE": "release/3.3",
+            "PORTVERSION": "3.3.3.a1",
+            "CLASSIFICATION": "alpha",
+            "COMMIT": "b" * 40,
+            "CREATED": "1",
+            "MATRIX_ROW": json.dumps(row),
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_ENV": str(github_env),
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert json.loads((tmp_path / "build-record.json").read_text())["matrix_row"] == row
 
 
 def test_force_suites_input_is_declared_boolean_and_defaults_off() -> None:

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -27,7 +27,7 @@ Two other parts ride along:
 * Part 2 -- only a RELEASED pfSense version may veto (see
   `tests/shell/resolve_legs_spec.sh` for the status predicate itself).
 * Part 3 -- our own alpha/beta tags skip the live suites (`run_suites`), with a
-  `force_suites` dispatch input as the manual escape hatch.
+  `force_suites` escape hatch only for release lines that carry a live corpus.
 
 The reachability tests walk the real `needs:` graph rather than asserting on one
 job's text, so ANY re-ordering that puts a mutation ahead of the build or ahead of
@@ -956,6 +956,19 @@ def test_build_record_keeps_the_original_release_33_matrix_row(tmp_path: Path) -
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert json.loads((tmp_path / "build-record.json").read_text())["matrix_row"] == row
+
+
+def test_release_33_decision_and_matrix_bindings_are_not_bypassed() -> None:
+    job = _jobs()["build-pkgs-portable"]
+    decision = "\n".join(_step(_jobs()["read-matrix"], "Detect pkg channel from tag"))
+    extras = "\n".join(_step(job, "Resolve release-line extras"))
+    record = "\n".join(_step(job, "Write the destination-bound build record"))
+    build = "\n".join(_step(job, "Build the .pkg via build-leg.sh"))
+
+    assert "INPUT_SOURCE:  ${{ github.event.inputs.source }}" in decision
+    assert "MATRIX_EXTRA_PKGS: ${{ toJson(matrix.extra_pkgs) }}" in extras
+    assert "MATRIX_ROW:    ${{ toJson(matrix) }}" in record
+    assert "EXTRA_PKGS:   ${{ steps.extras.outputs.extra_pkgs }}" in build
 
 
 def test_force_suites_input_is_declared_boolean_and_defaults_off() -> None:

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -1031,6 +1031,7 @@ def _run_healthcheck(
     assets_json: str,
     *,
     is_draft: bool = True,
+    source: str = "release/4.0",
 ) -> subprocess.CompletedProcess[str]:
     script = _healthcheck_script()
     bin_dir = tmp_path / "bin"
@@ -1045,6 +1046,7 @@ def _run_healthcheck(
         "TAG": "v0.0.0-test",
         "BUILD_MATRIX": build_matrix,
         "PORTVERSION": "4.0.0",
+        "SOURCE": source,
     }
     return subprocess.run(  # noqa: S603
         ["sh", "-c", script],
@@ -1121,5 +1123,22 @@ def test_healthcheck_counts_extra_pkgs_dep_assets_too(tmp_path: Path) -> None:
             '{"name":"pfSense-pkg-pfBlockerNG-4.0.0-Plus-26.03.pkg"},'
             '{"name":"py311-charset-normalizer-3.4.4-CE-2.8.pkg"}]'
         ),
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_healthcheck_release_33_ignores_matrix_extra_packages(tmp_path: Path) -> None:
+    completed = _run_healthcheck(
+        tmp_path,
+        build_matrix=(
+            '[{"variant":"CE","pfsense_version":"2.8","extra_pkgs":["textproc/py-charset-normalizer"]},'
+            '{"variant":"Plus","pfsense_version":"26.03","extra_pkgs":[]}]'
+        ),
+        assets_json=(
+            '[{"name":"pfBlockerNG-src.tar.gz"},'
+            '{"name":"pfSense-pkg-pfBlockerNG-4.0.0-CE-2.8.pkg"},'
+            '{"name":"pfSense-pkg-pfBlockerNG-4.0.0-Plus-26.03.pkg"}]'
+        ),
+        source="release/3.3",
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -1142,3 +1142,8 @@ def test_healthcheck_release_33_ignores_matrix_extra_packages(tmp_path: Path) ->
         source="release/3.3",
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_healthcheck_receives_the_release_source_binding() -> None:
+    step = "\n".join(_step(_jobs(RELEASE_WORKFLOW)["draft-healthcheck"], "Health-check the draft release"))
+    assert "SOURCE:       ${{ needs.release.outputs.source }}" in step


### PR DESCRIPTION
## What

Apply the owner-defined pre-4.0 boundary in the shared Release workflow:

- source release/3.3 always resolves run_suites=false, including stable and a forced alpha;
- source release/3.3 resolves the dependency-build loop input to [];
- draft healthcheck derives an asset-only matrix with no dependency assets for 3.3;
- every other release line keeps current suite, dependency, and healthcheck behavior.

The canonical build record executes with the original matrix row unchanged, preserving downstream ROUTE identity.

## Proof

Current test blobs:
- release decision/build-record/wiring tests: 4febf739a11bde7ce7ed4dfe9f62cf9d7077f36e
- draft-healthcheck/wiring tests: 5ddaaa62cdeac74c696abdac2c1d809d13d9bfa6

- Base is red for suite, extras, healthcheck, and wiring cases.
- Head: ten focused cases pass.
- 3.3 alpha/stable always skip live suites.
- 3.3 builds and expects no dependency assets.
- 4.x behavior is unchanged.
- Real build-record body preserves complete matrix_row.
- GitHub expression bindings for source, matrix, resolved extras, and healthcheck source are pinned.
- Canonical gate: PASS for pytest, Ruff lint/format, and mypy.
- actionlint and git diff --check: pass.
- No src changes.

Fixes #2566.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release 3.3 no longer runs live smoke or UI suites, including when forced.
  * Release 3.3 builds now exclude additional matrix dependency packages.
  * Artifact validation and draft health checks now correctly account for the release’s expected package set.
  * Other release lines continue using their configured dependency behavior.

* **Tests**
  * Added coverage to verify release-specific suite selection, package handling, artifacts, and health-check workflow wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->