### PR TITLE
pfblockerng: preserve fresh-install defaults across migrations

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -336,8 +336,9 @@ fail-closed on conflicting pair with `file_notice()` naming keys and never value
 grandfather helpers, and #1898 seeding pass with **one registry-driven loop**, called at
 end of `pfblockerng_install.inc` after `pfb_run_migrations()` and after ADR-53
 `pfBlockerNGSuppress` alias conversion (which keys on literal absence of
-`ip/v4suppression` and must observe pre-pass state). The installer captures each section's
-mode before migrations via `pfb_registry_section_modes()` and supplies it to the pass:
+`ip/v4suppression` and must observe pre-pass state). After restoring the target settings
+family, the installer captures each section's mode before migrations via
+`pfb_registry_section_modes()` and supplies it to the pass:
 `OLDCFG` iff the pre-migration section was non-empty under `pfb_gconfig_operator_view()`
 (installer's `settings_family` marker never reads as operator data — #1770/#1771/#1775).
 Direct callers that omit the mode map retain the original behavior of computing it from

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -336,9 +336,12 @@ fail-closed on conflicting pair with `file_notice()` naming keys and never value
 grandfather helpers, and #1898 seeding pass with **one registry-driven loop**, called at
 end of `pfblockerng_install.inc` after `pfb_run_migrations()` and after ADR-53
 `pfBlockerNGSuppress` alias conversion (which keys on literal absence of
-`ip/v4suppression` and must observe pre-pass state). Mode computed **per section**:
-`OLDCFG` iff section non-empty under `pfb_gconfig_operator_view()` (installer's
-`settings_family` marker never reads as operator data — #1770/#1771/#1775). Per key:
+`ip/v4suppression` and must observe pre-pass state). The installer captures each section's
+mode before migrations via `pfb_registry_section_modes()` and supplies it to the pass:
+`OLDCFG` iff the pre-migration section was non-empty under `pfb_gconfig_operator_view()`
+(installer's `settings_family` marker never reads as operator data — #1770/#1771/#1775).
+Direct callers that omit the mode map retain the original behavior of computing it from
+the pass input. Per key:
 
 - **NEWCFG** — seed registry default (stabilised through entry's own grandfather map
   so seeded value can never be re-mapped by later run).

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -82,6 +82,7 @@ function pfb_install_settings_family_finalize(
 
 function pfb_install_registry_writeback(
 	array $sections,
+	?array $modes = NULL,
 	?callable $pass = NULL,
 	?callable $write_section = NULL,
 	?callable $flush = NULL
@@ -89,7 +90,7 @@ function pfb_install_registry_writeback(
 	$pass ??= 'pfb_registry_pass';
 	$write_section ??= 'PfbConfig::writeSectionSystem';
 	$flush ??= 'write_config';
-	foreach ($pass($sections) as $path => $blob) {
+	foreach ($pass($sections, NULL, $modes) as $path => $blob) {
 		$write_section($path, $blob);
 	}
 	$flush('[pfBlockerNG] Save installation settings');
@@ -12831,6 +12832,18 @@ function pfb_legacy_key_rename_migrate($sections) {
 }
 
 
+/** @return array<string, string> Section path => NEWCFG/OLDCFG map. */
+function pfb_registry_section_modes(array $sections): array {
+
+	$modes = array();
+	foreach (PFB_SECTIONS as $section) {
+		$blob = $sections[$section] ?? array();
+		$modes[$section] = is_array($blob) && !empty(pfb_gconfig_operator_view($blob)) ? 'OLDCFG' : 'NEWCFG';
+	}
+	return $modes;
+}
+
+
 /**
  * pfb_registry_pass — the one registry-driven install/upgrade pass (issue #1921).
  *
@@ -12887,24 +12900,22 @@ function pfb_legacy_key_rename_migrate($sections) {
  *                                pass took).
  * @param  array|null $registry  Defaults to pfb_cfg_registry(); parameter exists only so
  *                                a fixture registry can drive the pass in tests.
+ * @param  array|null $modes     Optional pre-migration section path => NEWCFG/OLDCFG map.
  * @return array                 Section path => blob map, changed sections only.
  */
-function pfb_registry_pass(array $sections, ?array $registry = NULL): array {
+function pfb_registry_pass(array $sections, ?array $registry = NULL, ?array $modes = NULL): array {
 
 	$registry = $registry ?? pfb_cfg_registry();
 
-	// Mode decided ONCE per section, over the pre-mutation input -- an earlier key's
-	// rename/seed within the same section must never flip a later key's mode.
 	$original = array();
-	$modes    = array();
 	foreach (PFB_SECTIONS as $section) {
 		$blob = $sections[$section] ?? array();
 		if (!is_array($blob)) {
 			$blob = array();
 		}
 		$original[$section] = $blob;
-		$modes[$section]    = !empty(pfb_gconfig_operator_view($blob)) ? 'OLDCFG' : 'NEWCFG';
 	}
+	$modes = $modes ?? pfb_registry_section_modes($original);
 
 	$result    = $original;
 	$conflicts = array();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -26,20 +26,22 @@ require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 global $g, $pfb;
 pfb_global();
 
-// issues #2371/#2372: capture section modes and DNSBL freshness before migrations mutate
-// their inputs; both values drive post-migration work below.
+// issue #2371: capture DNSBL freshness before settings-family restore or migrations mutate it.
+$pfb_psl_feed_policy_fresh_install = pfb_psl_feed_policy_is_fresh_install(
+	PfbConfig::readSection(PFB_SECTIONS['dnsbl'])
+);
+
+$pfb_installed_family = pfb_install_settings_family_capture_restore();
+pfb_global();
+
+// issue #2372: capture modes from the restored target family before migrations mutate it.
 $pfb_registry_sections = array();
 foreach (PFB_SECTIONS as $pfb_registry_section) {
 	$pfb_registry_sections[$pfb_registry_section] = PfbConfig::readSection($pfb_registry_section);
 }
 $pfb_registry_modes = pfb_registry_section_modes($pfb_registry_sections);
-$pfb_psl_feed_policy_fresh_install = pfb_psl_feed_policy_is_fresh_install(
-	$pfb_registry_sections[PFB_SECTIONS['dnsbl']]
-);
 unset($pfb_registry_sections, $pfb_registry_section);
 
-$pfb_installed_family = pfb_install_settings_family_capture_restore();
-pfb_global();
 // Set 'Install flag' to skip sync process during installations.
 $g['pfblockerng_install'] = TRUE;
 $pfb['hook_lifecycle'] = 'install';

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -26,13 +26,17 @@ require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 global $g, $pfb;
 pfb_global();
 
-// issue #2371: capture the DNSBL-settings section's fresh-install-ness BEFORE any
-// migration or the registry pass runs -- see pfb_psl_feed_policy_is_fresh_install()'s
-// docblock (pfblockerng.inc) for why this must be read pre-mutation and applied only
-// after pfb_install_registry_writeback() below.
+// issues #2371/#2372: capture section modes and DNSBL freshness before migrations mutate
+// their inputs; both values drive post-migration work below.
+$pfb_registry_sections = array();
+foreach (PFB_SECTIONS as $pfb_registry_section) {
+	$pfb_registry_sections[$pfb_registry_section] = PfbConfig::readSection($pfb_registry_section);
+}
+$pfb_registry_modes = pfb_registry_section_modes($pfb_registry_sections);
 $pfb_psl_feed_policy_fresh_install = pfb_psl_feed_policy_is_fresh_install(
-	PfbConfig::readSection('installedpackages/pfblockerngdnsblsettings/config/0')
+	$pfb_registry_sections[PFB_SECTIONS['dnsbl']]
 );
+unset($pfb_registry_sections, $pfb_registry_section);
 
 $pfb_installed_family = pfb_install_settings_family_capture_restore();
 pfb_global();
@@ -946,8 +950,8 @@ $pfb_registry_sections = array();
 foreach (PFB_SECTIONS as $pfb_registry_section) {
 	$pfb_registry_sections[$pfb_registry_section] = PfbConfig::readSection($pfb_registry_section);
 }
-pfb_install_registry_writeback($pfb_registry_sections);
-unset($pfb_registry_sections, $pfb_registry_section);
+pfb_install_registry_writeback($pfb_registry_sections, $pfb_registry_modes);
+unset($pfb_registry_sections, $pfb_registry_section, $pfb_registry_modes);
 update_status(" done.\n");
 
 // issue #2371: apply the fresh-install feed-at-suffix PSL policy seed captured at the

--- a/tests/php/InstallPrePassWriteOrderTest.php
+++ b/tests/php/InstallPrePassWriteOrderTest.php
@@ -19,6 +19,9 @@ final class InstallPrePassWriteOrderTest extends TestCase
 		$this->assertNotSame('', $source, 'installer source must be readable');
 		$capture = strpos($source, '$pfb_registry_modes = pfb_registry_section_modes($pfb_registry_sections);');
 		$this->assertNotFalse($capture, 'installer must capture registry modes before migrations');
+		$restore = strpos($source, 'pfb_install_settings_family_capture_restore();');
+		$this->assertNotFalse($restore, 'installer must restore the target settings family');
+		$this->assertLessThan($capture, $restore, 'registry modes must describe the restored target settings family');
 		$migrations = strpos($source, 'pfb_install_settings_family_finalize($pfb_installed_family);');
 		$this->assertNotFalse($migrations, 'installer must run migrations through the settings-family seam');
 		$this->assertLessThan($migrations, $capture, 'registry modes must be captured before migrations mutate sections');

--- a/tests/php/InstallPrePassWriteOrderTest.php
+++ b/tests/php/InstallPrePassWriteOrderTest.php
@@ -17,9 +17,16 @@ final class InstallPrePassWriteOrderTest extends TestCase
 	{
 		$source = php_strip_whitespace(self::INSTALL);
 		$this->assertNotSame('', $source, 'installer source must be readable');
-		$call = strpos($source, 'pfb_install_registry_writeback($pfb_registry_sections);');
+		$capture = strpos($source, '$pfb_registry_modes = pfb_registry_section_modes($pfb_registry_sections);');
+		$this->assertNotFalse($capture, 'installer must capture registry modes before migrations');
+		$migrations = strpos($source, 'pfb_install_settings_family_finalize($pfb_installed_family);');
+		$this->assertNotFalse($migrations, 'installer must run migrations through the settings-family seam');
+		$this->assertLessThan($migrations, $capture, 'registry modes must be captured before migrations mutate sections');
+
+		$call = strpos($source, 'pfb_install_registry_writeback($pfb_registry_sections, $pfb_registry_modes);');
 		$this->assertNotFalse($call, 'installer must dispatch its registry pass through the writeback seam');
-		$this->assertSame(1, substr_count($source, 'pfb_install_registry_writeback($pfb_registry_sections);'));
+		$this->assertSame(1, substr_count($source,
+			'pfb_install_registry_writeback($pfb_registry_sections, $pfb_registry_modes);'));
 		$prepass = substr($source, 0, $call);
 		$this->assertFalse(str_contains($prepass, 'PfbConfig::writeSectionSystem('), 'system writes must not precede registry pass');
 		$this->assertLessThan(strrpos($source, 'return TRUE;'), $call, 'registry writeback must complete before installer return');
@@ -28,10 +35,12 @@ final class InstallPrePassWriteOrderTest extends TestCase
 	public function testRegistryWritebackSeamFlushesAfterReturnedSectionWrites(): void
 	{
 		$order = [];
+		$modes = ['installedpackages/pfblockerng' => 'NEWCFG'];
 		pfb_install_registry_writeback(
 			['installedpackages/pfblockerng' => ['raw' => 'value']],
-			static function (array $sections) use (&$order): array {
-				$order[] = 'registry-pass';
+			$modes,
+			static function (array $sections, ?array $registry, ?array $received_modes) use (&$order): array {
+				$order[] = 'registry-pass:' . $received_modes['installedpackages/pfblockerng'];
 				return $sections;
 			},
 			static function (string $path, array $blob) use (&$order): void {
@@ -42,7 +51,7 @@ final class InstallPrePassWriteOrderTest extends TestCase
 			}
 		);
 		$this->assertSame(
-			['registry-pass', 'write-section:installedpackages/pfblockerng', 'write-config:[pfBlockerNG] Save installation settings'],
+			['registry-pass:NEWCFG', 'write-section:installedpackages/pfblockerng', 'write-config:[pfBlockerNG] Save installation settings'],
 			$order
 		);
 	}

--- a/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
+++ b/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
@@ -103,9 +103,12 @@ final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
 		$source = php_strip_whitespace(self::INSTALL);
 		$this->assertNotSame('', $source, 'installer source must be readable');
 		$capture = strpos($source, 'pfb_install_settings_family_capture_restore();');
+		$modes = strpos($source, '$pfb_registry_modes = pfb_registry_section_modes($pfb_registry_sections);');
 		$finalize = strpos($source, 'pfb_install_settings_family_finalize($pfb_installed_family);');
-		$this->assertNotFalse($capture, 'installer must capture/restore settings before migrations');
+		$this->assertNotFalse($capture, 'installer must capture and restore settings before migrations');
+		$this->assertNotFalse($modes, 'installer must capture registry modes from the restored settings family');
 		$this->assertNotFalse($finalize, 'installer must finalize settings after legacy migration');
-		$this->assertLessThan($finalize, $capture);
+		$this->assertLessThan($modes, $capture, 'target settings must be restored before registry modes are captured');
+		$this->assertLessThan($finalize, $modes, 'registry modes must be captured before migrations mutate sections');
 	}
 }

--- a/tests/php/PslFeedPolicyPipelineOrderingTest.php
+++ b/tests/php/PslFeedPolicyPipelineOrderingTest.php
@@ -37,15 +37,19 @@ final class PslFeedPolicyPipelineOrderingTest extends TestCase
 	 */
 	private function runInstallSequence(): array
 	{
-		$fresh = pfb_psl_feed_policy_is_fresh_install(PfbConfig::readSection(self::DNSBL_SECTION));
-
-		pfb_run_migrations();
-
 		$sections = [];
 		foreach (PFB_SECTIONS as $section) {
 			$sections[$section] = PfbConfig::readSection($section);
 		}
-		foreach (pfb_registry_pass($sections) as $section => $blob) {
+		$fresh = pfb_psl_feed_policy_is_fresh_install($sections[self::DNSBL_SECTION]);
+		$modes = pfb_registry_section_modes($sections);
+
+		pfb_run_migrations();
+
+		foreach (PFB_SECTIONS as $section) {
+			$sections[$section] = PfbConfig::readSection($section);
+		}
+		foreach (pfb_registry_pass($sections, NULL, $modes) as $section => $blob) {
 			PfbConfig::writeSectionRawSystem($section, $blob);
 		}
 

--- a/tests/php/PslFeedPolicyPipelineOrderingTest.php
+++ b/tests/php/PslFeedPolicyPipelineOrderingTest.php
@@ -192,7 +192,8 @@ final class PslFeedPolicyPipelineOrderingTest extends TestCase
 		$this->assertNotFalse($migrations, 'installer must run the migration registry via its finalize seam');
 		$this->assertLessThan($migrations, $capture, 'freshness must be captured BEFORE any migration mutates a section');
 
-		$writeback = strpos($source, 'pfb_install_registry_writeback($pfb_registry_sections);');
+		$writeback = strpos($source,
+			'pfb_install_registry_writeback($pfb_registry_sections, $pfb_registry_modes);');
 		$this->assertNotFalse($writeback, 'installer must dispatch its registry pass through the writeback seam');
 
 		$seam = strpos($source, 'pfb_install_psl_feed_policy_seed($pfb_psl_feed_policy_fresh_install);');

--- a/tests/php/QuarterHourMigrationTest.php
+++ b/tests/php/QuarterHourMigrationTest.php
@@ -147,6 +147,21 @@ PHP;
 		$this->assertSame('6', $bounded[self::GEN]['skipfeed']);
 	}
 
+	public function testFreshMigrationPreservesRegistryFreshInstallDefaults(): void
+	{
+		$modes = array_fill_keys(array_values(PFB_SECTIONS), 'NEWCFG');
+		pfb_run_migrations();
+
+		$sections = [];
+		foreach (PFB_SECTIONS as $section) {
+			$sections[$section] = PfbConfig::readSection($section);
+		}
+		$result = pfb_registry_pass($sections, NULL, $modes);
+
+		$this->assertSame('auto', $result[self::GEN]['pfb_alias_delta_mode'] ?? NULL,
+			'a migration that seeds a fresh section must not activate its upgrade grandfather defaults');
+	}
+
 	public function testFreshMigrationPersistsSundayUniformSlotAndSkipfeed(): void
 	{
 		pfb_run_migrations();

--- a/tests/php/RegistryPassTest.php
+++ b/tests/php/RegistryPassTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
  * the caller (pfblockerng_install.inc) persists the result.
  */
 #[CoversFunction('pfb_registry_pass')]
+#[CoversFunction('pfb_registry_section_modes')]
 final class RegistryPassTest extends TestCase
 {
 	private const GEN_SECTION   = 'installedpackages/pfblockerng/config/0';
@@ -60,6 +61,45 @@ final class RegistryPassTest extends TestCase
 	// -----------------------------------------------------------------------
 	// 1 -- Mode / seed
 	// -----------------------------------------------------------------------
+
+	public function testSectionModesUseOperatorViewAcrossEveryRegisteredSection(): void
+	{
+		$modes = pfb_registry_section_modes([
+			self::GEN_SECTION   => [],
+			self::DNSBL_SECTION => ['settings_family' => '4.0'],
+			self::SS_SECTION    => ['safesearch' => 'on'],
+			self::IP_SECTION    => 'not-an-array',
+			self::REP_SECTION   => ['enable_rep' => 'on'],
+		]);
+
+		$this->assertSame([
+			self::GEN_SECTION   => 'NEWCFG',
+			self::DNSBL_SECTION => 'NEWCFG',
+			self::SS_SECTION    => 'OLDCFG',
+			self::IP_SECTION    => 'NEWCFG',
+			self::REP_SECTION   => 'OLDCFG',
+		], $modes);
+	}
+
+	public function testFreshMigrationUsesCapturedRegistryModes(): void
+	{
+		$sections = [];
+		foreach (PFB_SECTIONS as $section) {
+			$sections[$section] = PfbConfig::readSection($section);
+		}
+		$modes = pfb_registry_section_modes($sections);
+
+		pfb_run_migrations();
+		$this->assertSame('on', config_get_path(self::GEN_SECTION . '/pfb_scheduled_feed_updates'),
+			'the schedule migration must seed General before registry reconciliation');
+
+		foreach (PFB_SECTIONS as $section) {
+			$sections[$section] = PfbConfig::readSection($section);
+		}
+		$result = pfb_registry_pass($sections, NULL, $modes);
+
+		$this->assertSame('auto', $result[self::GEN_SECTION]['pfb_alias_delta_mode'] ?? NULL);
+	}
 
 	/** Row 1: every registered field seeded at default on a genuinely fresh install. */
 	public function testFreshEmptySectionsSeedEveryRegisteredFieldAtDefault(): void

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5424,6 +5424,13 @@
                 "default": null
             },
             {
+                "name": "modes",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            },
+            {
                 "name": "pass",
                 "byRef": false,
                 "variadic": false,
@@ -9325,6 +9332,26 @@
                 "variadic": false,
                 "type": "?array",
                 "default": "NULL"
+            },
+            {
+                "name": "modes",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_registry_section_modes": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "sections",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
             }
         ]
     },


### PR DESCRIPTION
## Summary

- Capture each registered section's `NEWCFG`/`OLDCFG` mode before migrations mutate configuration.
- Supply the captured modes to the trailing registry pass while preserving existing direct-call behavior.
- Add cross-phase regression, installer wiring, and function-inventory coverage.

## Verification

- Frozen RED: `QuarterHourMigrationTest::testFreshMigrationPreservesRegistryFreshInstallDefaults` expected `auto`, received `replace`.
- Unchanged GREEN test hash: `533b99fbf832ad2f3acbf5c8502de10699f86e1b`.
- Focused PHPUnit: 50 tests, 324 assertions.
- Canonical gate: 5,360-test PHPUnit suite, PHPStan, PHPCS, markdownlint, and policy checks passed.

Fixes #2372

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved fresh-install registry defaults during migrations and post-install processing.
  * Improved registry handling by capturing section modes before configuration changes.
  * Ensured restored settings and migration results are processed in the correct order.

* **Tests**
  * Added coverage for registry mode detection across supported configuration sections.
  * Added integration tests validating fresh-install defaults and registry writeback sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->