### PR TITLE
select-box ignores termination signals until command exits

### DIFF
--- a/scripts/select-box.sh
+++ b/scripts/select-box.sh
@@ -65,6 +65,7 @@ pfb_scrub_git_env
 
 # ── State ─────────────────────────────────────────────────────────────────────
 _SB_LEASED_BOX=""
+_SB_CMD_PID=""
 RUN_ID=""
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
@@ -82,6 +83,14 @@ _sb_ssh() {
     # SC2086: word-split of PFB_SSH is intentional — it holds "ssh [opts...]"
     # shellcheck disable=SC2086
     ${PFB_SSH} "$1" "$2"
+}
+
+# _sb_ssh_start <target> <cmd-string>
+# Start the command transport asynchronously so signal traps run while we wait.
+_sb_ssh_start() {
+    # shellcheck disable=SC2086
+    ${PFB_SSH} "$1" "$2" &
+    _SB_CMD_PID=$!
 }
 
 # _sb_jitter_sleep
@@ -313,6 +322,14 @@ _sb_release_trap() {
     _sb_release "${RUN_ID}"
 }
 
+# _sb_signal_trap <status>
+# Stop the command transport, then let EXIT release the lease once.
+_sb_signal_trap() {
+    trap - HUP INT TERM
+    [ -z "$_SB_CMD_PID" ] || kill -TERM "$_SB_CMD_PID" 2>/dev/null || true
+    exit "$1"
+}
+
 # ── Argument parsing ───────────────────────────────────────────────────────────
 _SB_MODE="default"
 _SB_RELEASE_ID=""
@@ -369,9 +386,11 @@ if [ -z "${PFB_BOXES:-}" ]; then
     exit 1
 fi
 
-# Arm the EXIT/INT/TERM/HUP trap now. _SB_LEASED_BOX is empty until we successfully
-# lease, so the trap is a no-op until then.
-trap '_sb_release_trap' EXIT INT TERM HUP
+# EXIT owns cleanup; signal traps terminate with the conventional 128 + signo status.
+trap '_sb_release_trap' EXIT
+trap '_sb_signal_trap 129' HUP
+trap '_sb_signal_trap 130' INT
+trap '_sb_signal_trap 143' TERM
 
 # Pre-mint a session ID for reclaim-dir uniqueness (box-agnostic, unique per run).
 _SB_SID="$(od -An -tx1 -N4 /dev/urandom | tr -d ' \t\n')"
@@ -447,5 +466,6 @@ printf 'select-box: leased %s (RUN_ID=%s)\n' "$_SB_LEASED_BOX" "$RUN_ID" >&2
 # If a command was given (after --), run it on the leased box over ssh.
 # The EXIT trap releases the lease when this script exits (normally or on signal).
 if [ -n "$_SB_CMD" ]; then
-    _sb_ssh "$_SB_LEASED_BOX" "$_SB_CMD"
+    _sb_ssh_start "$_SB_LEASED_BOX" "$_SB_CMD"
+    wait "$_SB_CMD_PID"
 fi

--- a/scripts/select-box.sh
+++ b/scripts/select-box.sh
@@ -325,8 +325,15 @@ _sb_release_trap() {
 # _sb_signal_trap <status>
 # Stop the command transport, then let EXIT release the lease once.
 _sb_signal_trap() {
-    trap - HUP INT TERM
-    [ -z "$_SB_CMD_PID" ] || kill -TERM "$_SB_CMD_PID" 2>/dev/null || true
+    trap '' HUP INT TERM
+    if [ -n "$_SB_CMD_PID" ]; then
+        kill -TERM "$_SB_CMD_PID" 2>/dev/null || true
+        # ponytail: fixed local-transport grace; make configurable only if real SSH needs it.
+        sleep 1
+        kill -KILL "$_SB_CMD_PID" 2>/dev/null || true
+        wait "$_SB_CMD_PID" 2>/dev/null || true
+        _SB_CMD_PID=""
+    fi
     exit "$1"
 }
 

--- a/tests/shell/select_box_spec.sh
+++ b/tests/shell/select_box_spec.sh
@@ -31,6 +31,8 @@
 #                             proves rename-capture is NECESSARY.
 #   release           — --release frees only the matching-owner lock; a mismatched
 #                       RUN_ID does NOT free the lock.
+#   command signals   — INT/TERM/HUP stop the selector before its command completes,
+#                       return 128 + signo, and release exactly once.
 #   no-alias          — local-<...> and ci-<...> run-ids never collide.
 
 Describe 'select-box.sh'
@@ -127,6 +129,97 @@ SSHEOF
     The line 1 of output should equal 'rid-prefix=local-'
     The line 2 of output should equal 'box-set=yes'
     The line 3 of output should equal 'run-dir=yes'
+  End
+
+  command_signal_result() {
+    _signal="$1"
+    _expected_status="$2"
+    _ready="${WORK}/${_signal}.ready"
+    _remote_pid_file="${WORK}/${_signal}.pid"
+    _command_gate="${WORK}/${_signal}.gate"
+    _command_completed="${WORK}/${_signal}.completed"
+    _selector_err="${WORK}/${_signal}.err"
+    mkfifo "$_command_gate"
+    _command="printf '%s\\n' \"\$\$\" > '${_remote_pid_file}'; true > '${_ready}'; trap 'exit 0' INT TERM HUP; read _signal_gate < '${_command_gate}'; true > '${_command_completed}'"
+
+    (
+      trap - INT TERM HUP
+      exec sh "$SCRIPT" -- "$_command"
+    ) > "${WORK}/${_signal}.out" 2> "$_selector_err" &
+    _selector_pid=$!
+
+    _ready_checks=0
+    while [ ! -f "$_ready" ] && [ "$_ready_checks" -lt 100 ]; do
+      sleep 0.05
+      _ready_checks=$(( _ready_checks + 1 ))
+    done
+    if [ ! -f "$_ready" ]; then
+      kill -TERM "$_selector_pid" 2>/dev/null || true
+      wait "$_selector_pid" 2>/dev/null || true
+      printf 'ready=no (stuck/environment)\n'
+      return
+    fi
+
+    _remote_pid="$(cat "$_remote_pid_file")"
+    kill "-${_signal}" "$_selector_pid"
+
+    _exit_checks=0
+    while kill -0 "$_selector_pid" 2>/dev/null && [ "$_exit_checks" -lt 100 ]; do
+      sleep 0.05
+      _exit_checks=$(( _exit_checks + 1 ))
+    done
+    _exited_before_release=yes
+    if kill -0 "$_selector_pid" 2>/dev/null; then
+      _exited_before_release='no (stuck/environment)'
+      printf '\n' > "$_command_gate"
+    fi
+
+    wait "$_selector_pid"
+    _selector_status=$?
+
+    kill -TERM "$_remote_pid" 2>/dev/null || true
+
+    _release_count="$(grep -c '^select-box: released ' "$_selector_err" || true)"
+    _already_released_count="$(grep -c 'not found (already released)' "$_selector_err" || true)"
+    printf 'ready=yes\n'
+    printf 'selector-exited-before-command-release=%s\n' "$_exited_before_release"
+    printf 'status=%s expected=%s\n' "$_selector_status" "$_expected_status"
+    printf 'command-completed=%s\n' "$([ -f "$_command_completed" ] && echo yes || echo no)"
+    printf 'release-count=%s\n' "$_release_count"
+    printf 'already-released-count=%s\n' "$_already_released_count"
+  }
+
+  It 'INT stops a running command and releases its lease exactly once'
+    When call command_signal_result INT 130
+    The status should be success
+    The line 1 of output should equal 'ready=yes'
+    The line 2 of output should equal 'selector-exited-before-command-release=yes'
+    The line 3 of output should equal 'status=130 expected=130'
+    The line 4 of output should equal 'command-completed=no'
+    The line 5 of output should equal 'release-count=1'
+    The line 6 of output should equal 'already-released-count=0'
+  End
+
+  It 'TERM stops a running command and releases its lease exactly once'
+    When call command_signal_result TERM 143
+    The status should be success
+    The line 1 of output should equal 'ready=yes'
+    The line 2 of output should equal 'selector-exited-before-command-release=yes'
+    The line 3 of output should equal 'status=143 expected=143'
+    The line 4 of output should equal 'command-completed=no'
+    The line 5 of output should equal 'release-count=1'
+    The line 6 of output should equal 'already-released-count=0'
+  End
+
+  It 'HUP stops a running command and releases its lease exactly once'
+    When call command_signal_result HUP 129
+    The status should be success
+    The line 1 of output should equal 'ready=yes'
+    The line 2 of output should equal 'selector-exited-before-command-release=yes'
+    The line 3 of output should equal 'status=129 expected=129'
+    The line 4 of output should equal 'command-completed=no'
+    The line 5 of output should equal 'release-count=1'
+    The line 6 of output should equal 'already-released-count=0'
   End
 
   # ── two-contenders: both concurrent acquires succeed ───────────────────────

--- a/tests/shell/select_box_spec.sh
+++ b/tests/shell/select_box_spec.sh
@@ -304,6 +304,7 @@ SSHEOF
     _already_released_count="$(grep -c 'not found (already released)' "$_selector_err" || true)"
     printf 'ready=yes\n'
     printf 'release-started=yes\n'
+    printf 'release-finished=%s\n' "$([ -f "$_release_finished" ] && echo yes || echo no)"
     printf 'status=%s expected=143\n' "$_selector_status"
     printf 'lock-count=%s\n' "$_locks"
     printf 'release-count=%s\n' "$_release_count"
@@ -315,10 +316,11 @@ SSHEOF
     The status should be success
     The line 1 of output should equal 'ready=yes'
     The line 2 of output should equal 'release-started=yes'
-    The line 3 of output should equal 'status=143 expected=143'
-    The line 4 of output should equal 'lock-count=0'
-    The line 5 of output should equal 'release-count=1'
-    The line 6 of output should equal 'already-released-count=0'
+    The line 3 of output should equal 'release-finished=yes'
+    The line 4 of output should equal 'status=143 expected=143'
+    The line 5 of output should equal 'lock-count=0'
+    The line 6 of output should equal 'release-count=1'
+    The line 7 of output should equal 'already-released-count=0'
   End
 
   # ── two-contenders: both concurrent acquires succeed ───────────────────────

--- a/tests/shell/select_box_spec.sh
+++ b/tests/shell/select_box_spec.sh
@@ -73,6 +73,18 @@ while [ "$#" -gt 0 ]; do
 done
 # $1 is the target (skip); $2 is the remote command string.
 shift
+if [ -n "${PFB_TEST_RELEASE_GATE:-}" ]; then
+    case "$1" in
+        *"rm -rf"*)
+            true > "$PFB_TEST_RELEASE_STARTED"
+            read _release_gate < "$PFB_TEST_RELEASE_GATE"
+            sh -c "$1"
+            _release_status=$?
+            true > "$PFB_TEST_RELEASE_FINISHED"
+            exit "$_release_status"
+            ;;
+    esac
+fi
 exec sh -c "$1"
 SSHEOF
     chmod +x "${BIN}/ssh"
@@ -134,18 +146,19 @@ SSHEOF
   command_signal_result() {
     _signal="$1"
     _expected_status="$2"
+    _transport_mode="${3:-normal}"
     _ready="${WORK}/${_signal}.ready"
     _remote_pid_file="${WORK}/${_signal}.pid"
     _command_gate="${WORK}/${_signal}.gate"
     _command_completed="${WORK}/${_signal}.completed"
     _selector_err="${WORK}/${_signal}.err"
     mkfifo "$_command_gate"
-    _command="printf '%s\\n' \"\$\$\" > '${_remote_pid_file}'; true > '${_ready}'; trap 'exit 0' INT TERM HUP; read _signal_gate < '${_command_gate}'; true > '${_command_completed}'"
+    _remote_trap="trap 'exit 0' INT TERM HUP"
+    [ "$_transport_mode" = "ignore-term" ] && _remote_trap="trap '' TERM; trap 'exit 0' INT HUP"
+    _command="printf '%s\\n' \"\$\$\" > '${_remote_pid_file}'; true > '${_ready}'; ${_remote_trap}; read _signal_gate < '${_command_gate}'; true > '${_command_completed}'"
 
-    (
-      trap - INT TERM HUP
-      exec sh "$SCRIPT" -- "$_command"
-    ) > "${WORK}/${_signal}.out" 2> "$_selector_err" &
+    python3 -c 'import os, signal, sys; [signal.signal(sig, signal.SIG_DFL) for sig in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)]; os.execvp("sh", ["sh", *sys.argv[1:]])' \
+      "$SCRIPT" -- "$_command" > "${WORK}/${_signal}.out" 2> "$_selector_err" &
     _selector_pid=$!
 
     _ready_checks=0
@@ -177,7 +190,9 @@ SSHEOF
     wait "$_selector_pid"
     _selector_status=$?
 
-    kill -TERM "$_remote_pid" 2>/dev/null || true
+    _transport_alive=no
+    kill -0 "$_remote_pid" 2>/dev/null && _transport_alive=yes
+    kill -KILL "$_remote_pid" 2>/dev/null || true
 
     _release_count="$(grep -c '^select-box: released ' "$_selector_err" || true)"
     _already_released_count="$(grep -c 'not found (already released)' "$_selector_err" || true)"
@@ -185,6 +200,7 @@ SSHEOF
     printf 'selector-exited-before-command-release=%s\n' "$_exited_before_release"
     printf 'status=%s expected=%s\n' "$_selector_status" "$_expected_status"
     printf 'command-completed=%s\n' "$([ -f "$_command_completed" ] && echo yes || echo no)"
+    printf 'transport-alive-after-selector=%s\n' "$_transport_alive"
     printf 'release-count=%s\n' "$_release_count"
     printf 'already-released-count=%s\n' "$_already_released_count"
   }
@@ -196,8 +212,9 @@ SSHEOF
     The line 2 of output should equal 'selector-exited-before-command-release=yes'
     The line 3 of output should equal 'status=130 expected=130'
     The line 4 of output should equal 'command-completed=no'
-    The line 5 of output should equal 'release-count=1'
-    The line 6 of output should equal 'already-released-count=0'
+    The line 5 of output should equal 'transport-alive-after-selector=no'
+    The line 6 of output should equal 'release-count=1'
+    The line 7 of output should equal 'already-released-count=0'
   End
 
   It 'TERM stops a running command and releases its lease exactly once'
@@ -207,8 +224,9 @@ SSHEOF
     The line 2 of output should equal 'selector-exited-before-command-release=yes'
     The line 3 of output should equal 'status=143 expected=143'
     The line 4 of output should equal 'command-completed=no'
-    The line 5 of output should equal 'release-count=1'
-    The line 6 of output should equal 'already-released-count=0'
+    The line 5 of output should equal 'transport-alive-after-selector=no'
+    The line 6 of output should equal 'release-count=1'
+    The line 7 of output should equal 'already-released-count=0'
   End
 
   It 'HUP stops a running command and releases its lease exactly once'
@@ -218,6 +236,87 @@ SSHEOF
     The line 2 of output should equal 'selector-exited-before-command-release=yes'
     The line 3 of output should equal 'status=129 expected=129'
     The line 4 of output should equal 'command-completed=no'
+    The line 5 of output should equal 'transport-alive-after-selector=no'
+    The line 6 of output should equal 'release-count=1'
+    The line 7 of output should equal 'already-released-count=0'
+  End
+
+  It 'TERM escalates and reaps a transport that ignores TERM before releasing'
+    When call command_signal_result TERM 143 ignore-term
+    The status should be success
+    The line 1 of output should equal 'ready=yes'
+    The line 2 of output should equal 'selector-exited-before-command-release=yes'
+    The line 3 of output should equal 'status=143 expected=143'
+    The line 4 of output should equal 'command-completed=no'
+    The line 5 of output should equal 'transport-alive-after-selector=no'
+    The line 6 of output should equal 'release-count=1'
+    The line 7 of output should equal 'already-released-count=0'
+  End
+
+  repeated_signal_result() {
+    _ready="${WORK}/repeated.ready"
+    _remote_pid_file="${WORK}/repeated.pid"
+    _command_gate="${WORK}/repeated-command.gate"
+    _release_gate="${WORK}/repeated-release.gate"
+    _release_started="${WORK}/repeated-release.started"
+    _release_finished="${WORK}/repeated-release.finished"
+    _selector_err="${WORK}/repeated.err"
+    mkfifo "$_command_gate" "$_release_gate"
+    PFB_TEST_RELEASE_GATE="$_release_gate"
+    PFB_TEST_RELEASE_STARTED="$_release_started"
+    PFB_TEST_RELEASE_FINISHED="$_release_finished"
+    PFB_BOXES="root@10.0.0.23"
+    export PFB_TEST_RELEASE_GATE PFB_TEST_RELEASE_STARTED PFB_TEST_RELEASE_FINISHED
+    export PFB_BOXES
+    _command="printf '%s\\n' \"\$\$\" > '${_remote_pid_file}'; true > '${_ready}'; trap 'exit 0' TERM; read _signal_gate < '${_command_gate}'"
+
+    python3 -c 'import os, signal, sys; [signal.signal(sig, signal.SIG_DFL) for sig in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)]; os.execvp("sh", ["sh", *sys.argv[1:]])' \
+      "$SCRIPT" -- "$_command" > "${WORK}/repeated.out" 2> "$_selector_err" &
+    _selector_pid=$!
+
+    _ready_checks=0
+    while [ ! -f "$_ready" ] && [ "$_ready_checks" -lt 100 ]; do
+      sleep 0.05
+      _ready_checks=$(( _ready_checks + 1 ))
+    done
+    [ -f "$_ready" ] || { printf 'ready=no (stuck/environment)\n'; return; }
+
+    kill -TERM "$_selector_pid"
+    _release_checks=0
+    while [ ! -f "$_release_started" ] && [ "$_release_checks" -lt 100 ]; do
+      sleep 0.05
+      _release_checks=$(( _release_checks + 1 ))
+    done
+    [ -f "$_release_started" ] || { printf 'release-started=no (stuck/environment)\n'; return; }
+
+    kill -TERM "$_selector_pid"
+    printf '\n' > "$_release_gate"
+    wait "$_selector_pid"
+    _selector_status=$?
+
+    _finish_checks=0
+    while [ ! -f "$_release_finished" ] && [ "$_finish_checks" -lt 100 ]; do
+      sleep 0.05
+      _finish_checks=$(( _finish_checks + 1 ))
+    done
+    _locks="$(find "$LEASE_DIR" -type d -name '*.lock' | wc -l | tr -d ' ')"
+    _release_count="$(grep -c '^select-box: released ' "$_selector_err" || true)"
+    _already_released_count="$(grep -c 'not found (already released)' "$_selector_err" || true)"
+    printf 'ready=yes\n'
+    printf 'release-started=yes\n'
+    printf 'status=%s expected=143\n' "$_selector_status"
+    printf 'lock-count=%s\n' "$_locks"
+    printf 'release-count=%s\n' "$_release_count"
+    printf 'already-released-count=%s\n' "$_already_released_count"
+  }
+
+  It 'a repeated TERM cannot interrupt lease cleanup'
+    When call repeated_signal_result
+    The status should be success
+    The line 1 of output should equal 'ready=yes'
+    The line 2 of output should equal 'release-started=yes'
+    The line 3 of output should equal 'status=143 expected=143'
+    The line 4 of output should equal 'lock-count=0'
     The line 5 of output should equal 'release-count=1'
     The line 6 of output should equal 'already-released-count=0'
   End


### PR DESCRIPTION
## Summary

- Run the command transport asynchronously so POSIX signal traps execute while the selector waits.
- Stop and reap the transport on HUP, INT, or TERM before releasing the lease.
- Ignore repeated handled signals through cleanup and return the conventional `128 + signo` status.
- Keep `EXIT` as the sole lease-cleanup owner so every path releases exactly once.

## Verification

- Original red: `shellspec --shell "$(command -v dash)" tests/shell/select_box_spec.sh` produced 14 examples and 3 failures for HUP, INT, and TERM on test hash `11c2617fc6fbf3885dd567b69ee05d25b427ea75`.
- Original green: the same command and unchanged test hash produced 14 examples and 0 failures.
- Review-fix red: final tests against parent production produced 16 examples and 2 failures for a TERM-resistant transport and repeated TERM during cleanup, test hash `8493519efee4b19896566dc257a0fc82cf05bcc9`.
- Review-fix green: the same final test hash produced 16 examples and 0 failures.
- Final mechanical review assertion: test hash `c53db27676583d9174f882d6757495376260834c` produced 16 examples and 0 failures; suppressing its release-finished marker produced exactly 1 failure.
- `scripts/agent/run-gates.sh --diff origin/devel` produced `GATES: PASS`.
- GitHub CI is green on `f35594c7d72b9d49cbc33e6aea2f7884f44c620b`, including Linux `dash` ShellSpec.

Fixes #2568.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
