### PR TITLE
pfblockerng: require 3.3 before 4.x; parse v-prefixed nightly

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -64,9 +64,11 @@ function pfb_install_settings_family_capture_restore(
 	$target_rank = (is_string($installed_family) && isset(PFB_SETTINGS_FAMILY_RANK[$installed_family]))
 		? PFB_SETTINGS_FAMILY_RANK[$installed_family]
 		: NULL;
-	// Owner ruling #2158: 3.3 is the migration floor. A 4.x package must not
-	// accept a missing/3.2 source; only a 3.3 target may bootstrap a bare marker.
-	if ($target_rank !== NULL && $target_rank > $bridge_rank && $source_rank < $bridge_rank) {
+	// Owner ruling #2158: 3.3 is the migration floor. Skip the guard when
+	// owned sections are empty (first install); current() defaults missing
+	// markers to '3.2', which is indistinguishable from a real 3.2 box.
+	if ($target_rank !== NULL && $target_rank > $bridge_rank && $source_rank < $bridge_rank
+		&& pfb_settings_family_owned_sections() !== []) {
 		throw new RuntimeException('pfBlockerNG: install the 3.3 bridge before a 4.x family');
 	}
 	if ($source_family === NULL || !$save($source_family)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -56,10 +56,22 @@ function pfb_install_settings_family_capture_restore(
 	$from_version ??= 'pfb_settings_family_from_version';
 	$replace ??= 'pfb_settings_family_replace';
 	$source_family = $current();
+	$installed_family = $from_version((string) $version());
+	$bridge_rank = PFB_SETTINGS_FAMILY_RANK['3.3'];
+	$source_rank = (is_string($source_family) && isset(PFB_SETTINGS_FAMILY_RANK[$source_family]))
+		? PFB_SETTINGS_FAMILY_RANK[$source_family]
+		: -1;
+	$target_rank = (is_string($installed_family) && isset(PFB_SETTINGS_FAMILY_RANK[$installed_family]))
+		? PFB_SETTINGS_FAMILY_RANK[$installed_family]
+		: NULL;
+	// Owner ruling #2158: 3.3 is the migration floor. A 4.x package must not
+	// accept a missing/3.2 source; only a 3.3 target may bootstrap a bare marker.
+	if ($target_rank !== NULL && $target_rank > $bridge_rank && $source_rank < $bridge_rank) {
+		throw new RuntimeException('pfBlockerNG: install the 3.3 bridge before a 4.x family');
+	}
 	if ($source_family === NULL || !$save($source_family)) {
 		throw new RuntimeException('pfBlockerNG: unable to save source settings family');
 	}
-	$installed_family = $from_version((string) $version());
 	if ($installed_family === NULL || !$replace($installed_family)) {
 		$replace($source_family);
 		throw new RuntimeException('pfBlockerNG: unable to restore settings family');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2239,7 +2239,9 @@ const PFB_NIGHTLY_SETTINGS_FAMILY = '4.1';
 
 function pfb_settings_family_from_version(string $version): ?string
 {
-	$version = trim($version);
+	// pfb_pkg_ver() prefixes 'v'; strip before the nightly stamp so POST-INSTALL
+	// can map vYYYYMMDDHHMMSS.<sha7> to 4.1 (otherwise the stamp never matches).
+	$version = ltrim(trim($version), 'vV');
 	if (preg_match('/^(\d{14})\.[0-9a-f]{7}$/', $version, $match) === 1) {
 		$timestamp = $match[1];
 		return checkdate((int) substr($timestamp, 4, 2), (int) substr($timestamp, 6, 2), (int) substr($timestamp, 0, 4))
@@ -2249,7 +2251,6 @@ function pfb_settings_family_from_version(string $version): ?string
 			? PFB_NIGHTLY_SETTINGS_FAMILY
 			: NULL;
 	}
-	$version = ltrim($version, 'vV');
 	if (preg_match('/^(\d+\.\d+)(?:\.\d+)?(?:[.-].*)?$/', $version, $match) !== 1
 		|| !isset(PFB_SETTINGS_FAMILY_RANK[$match[1]])) {
 		return NULL;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -2239,9 +2239,12 @@ const PFB_NIGHTLY_SETTINGS_FAMILY = '4.1';
 
 function pfb_settings_family_from_version(string $version): ?string
 {
-	// pfb_pkg_ver() prefixes 'v'; strip before the nightly stamp so POST-INSTALL
-	// can map vYYYYMMDDHHMMSS.<sha7> to 4.1 (otherwise the stamp never matches).
-	$version = ltrim(trim($version), 'vV');
+	// pfb_pkg_ver() prefixes exactly one 'v'; strip that one character before
+	// the nightly stamp so POST-INSTALL can map vYYYYMMDDHHMMSS.<sha7> to 4.1.
+	$version = trim($version);
+	if ($version !== '' && ($version[0] === 'v' || $version[0] === 'V')) {
+		$version = substr($version, 1);
+	}
 	if (preg_match('/^(\d{14})\.[0-9a-f]{7}$/', $version, $match) === 1) {
 		$timestamp = $match[1];
 		return checkdate((int) substr($timestamp, 4, 2), (int) substr($timestamp, 6, 2), (int) substr($timestamp, 0, 4))
@@ -2264,14 +2267,11 @@ function pfb_settings_family_current(): ?string
 	return is_string($value) && isset(PFB_SETTINGS_FAMILY_RANK[$value]) ? $value : NULL;
 }
 
-function pfb_settings_family_save(string $family): bool
+function pfb_settings_family_owned_sections(): array
 {
-	if (!isset(PFB_SETTINGS_FAMILY_RANK[$family])) {
-		return FALSE;
-	}
 	$installed = config_get_path('installedpackages', []);
 	if (!is_array($installed)) {
-		return TRUE;
+		return [];
 	}
 	$owned = [];
 	foreach ($installed as $section => $value) {
@@ -2279,6 +2279,15 @@ function pfb_settings_family_save(string $family): bool
 			$owned[(string) $section] = $value;
 		}
 	}
+	return $owned;
+}
+
+function pfb_settings_family_save(string $family): bool
+{
+	if (!isset(PFB_SETTINGS_FAMILY_RANK[$family])) {
+		return FALSE;
+	}
+	$owned = pfb_settings_family_owned_sections();
 	if ($owned === []) {
 		return TRUE;
 	}

--- a/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
+++ b/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
@@ -8,6 +8,35 @@ final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
 {
 	private const INSTALL = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
 
+	private string $root;
+
+	protected function setUp(): void
+	{
+		$this->root = sys_get_temp_dir() . '/pfb_cap_' . bin2hex(random_bytes(5));
+		mkdir($this->root, 0700, TRUE);
+		$GLOBALS['pfb']['dbdir'] = $this->root;
+		$GLOBALS['config'] = [
+			'installedpackages' => [
+				'pfblockerng' => ['config' => ['0' => ['pfb_keep' => 'off']]],
+			],
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		unset($GLOBALS['config'], $GLOBALS['pfb']['dbdir']);
+		if (!is_dir($this->root)) {
+			return;
+		}
+		foreach (scandir($this->root) ?: [] as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			@unlink($this->root . '/' . $entry);
+		}
+		@rmdir($this->root);
+	}
+
 	public function testPostInstallCapturesSourceBeforeTargetRestoreAndMigrations(): void
 	{
 		$order = [];
@@ -71,6 +100,97 @@ final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
 			);
 		}
 		$this->assertSame(['current', 'version', 'from:v20260819010101.abcdef1'], $order);
+	}
+
+	public function testFirstInstallWithNoOwnedSectionsAllowsFourX(): void
+	{
+		$GLOBALS['config'] = ['installedpackages' => []];
+		$this->assertSame('3.2', pfb_settings_family_current());
+		$order = [];
+		$installed = pfb_install_settings_family_capture_restore(
+			NULL,
+			static function (string $family) use (&$order): bool {
+				$order[] = "save:{$family}";
+				return TRUE;
+			},
+			static function () use (&$order): string {
+				$order[] = 'version';
+				return '4.0.0.a1';
+			},
+			static function (string $version) use (&$order): string {
+				$order[] = "from:{$version}";
+				return '4.0';
+			},
+			static function (string $family) use (&$order): bool {
+				$order[] = "replace:{$family}";
+				return TRUE;
+			}
+		);
+		$this->assertSame('4.0', $installed);
+		$this->assertSame(['version', 'from:4.0.0.a1', 'save:3.2', 'replace:4.0'], $order);
+	}
+
+	public function testProductionCurrentMissingMarkerWithOwnedConfigCannotSkipBridge(): void
+	{
+		$this->assertSame('3.2', pfb_settings_family_current());
+		$order = [];
+		try {
+			pfb_install_settings_family_capture_restore(
+				NULL,
+				static function (string $family) use (&$order): bool {
+					$order[] = "save:{$family}";
+					return TRUE;
+				},
+				static function () use (&$order): string {
+					$order[] = 'version';
+					return '4.0.0.a1';
+				},
+				static function (string $version) use (&$order): string {
+					$order[] = "from:{$version}";
+					return '4.0';
+				},
+				static function (string $family) use (&$order): bool {
+					$order[] = "replace:{$family}";
+					return TRUE;
+				}
+			);
+			$this->fail('owned 3.2-default config must not skip the 3.3 bridge onto 4.x');
+		} catch (RuntimeException $error) {
+			$this->assertSame(
+				'pfBlockerNG: install the 3.3 bridge before a 4.x family',
+				$error->getMessage()
+			);
+		}
+		$this->assertSame(['version', 'from:4.0.0.a1'], $order);
+	}
+
+	public function testThreeTwoCanInstallThreeThreeBridge(): void
+	{
+		$order = [];
+		$installed = pfb_install_settings_family_capture_restore(
+			static function () use (&$order): string {
+				$order[] = 'current';
+				return '3.2';
+			},
+			static function (string $family) use (&$order): bool {
+				$order[] = "save:{$family}";
+				return TRUE;
+			},
+			static function () use (&$order): string {
+				$order[] = 'version';
+				return '3.3.2';
+			},
+			static function (string $version) use (&$order): string {
+				$order[] = "from:{$version}";
+				return '3.3';
+			},
+			static function (string $family) use (&$order): bool {
+				$order[] = "replace:{$family}";
+				return TRUE;
+			}
+		);
+		$this->assertSame('3.3', $installed);
+		$this->assertSame(['current', 'version', 'from:3.3.2', 'save:3.2', 'replace:3.3'], $order);
 	}
 
 	public function testCaptureAndRestoreFailuresStopBeforeLaterEffects(): void

--- a/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
+++ b/tests/php/PfbSettingsFamilyPostInstallCaptureTest.php
@@ -14,7 +14,7 @@ final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
 		$installed = pfb_install_settings_family_capture_restore(
 			static function () use (&$order): string {
 				$order[] = 'current';
-				return '3.2';
+				return '3.3';
 			},
 			static function (string $family) use (&$order): bool {
 				$order[] = "save:{$family}";
@@ -44,9 +44,33 @@ final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
 
 		$this->assertSame('4.0', $installed);
 		$this->assertSame(
-			['current', 'save:3.2', 'version', 'from:4.0.0', 'replace:4.0', 'migrations', 'record:4.0'],
+			['current', 'version', 'from:4.0.0', 'save:3.3', 'replace:4.0', 'migrations', 'record:4.0'],
 			$order
 		);
+	}
+
+	public function testThreeTwoCannotSkipThreeThreeBridgeToFourX(): void
+	{
+		$order = [];
+		try {
+			pfb_install_settings_family_capture_restore(
+				static function () use (&$order): string { $order[] = 'current'; return '3.2'; },
+				static function (string $family) use (&$order): bool { $order[] = "save:{$family}"; return TRUE; },
+				static function () use (&$order): string { $order[] = 'version'; return 'v20260819010101.abcdef1'; },
+				static function (string $version) use (&$order): string {
+					$order[] = "from:{$version}";
+					return '4.1';
+				},
+				static function (string $family) use (&$order): bool { $order[] = "replace:{$family}"; return TRUE; }
+			);
+			$this->fail('3.2 must not skip the 3.3 bridge onto a 4.x family');
+		} catch (RuntimeException $error) {
+			$this->assertSame(
+				'pfBlockerNG: install the 3.3 bridge before a 4.x family',
+				$error->getMessage()
+			);
+		}
+		$this->assertSame(['current', 'version', 'from:v20260819010101.abcdef1'], $order);
 	}
 
 	public function testCaptureAndRestoreFailuresStopBeforeLaterEffects(): void
@@ -54,7 +78,7 @@ final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
 		$order = [];
 		try {
 			pfb_install_settings_family_capture_restore(
-			static function () use (&$order): string { $order[] = 'current'; return '3.2'; },
+			static function () use (&$order): string { $order[] = 'current'; return '3.3'; },
 			static function () use (&$order): bool { $order[] = 'save'; return FALSE; },
 			static fn (): string => '4.0.0',
 			static fn (string $version): string => '4.0',
@@ -88,7 +112,7 @@ final class PfbSettingsFamilyPostInstallCaptureTest extends TestCase
 			}
 			$targetRestore = $target === NULL ? [] : ['replace:4.1'];
 			$this->assertSame(
-				['current', 'save:3.3', 'version', 'from-version', ...$targetRestore, 'replace:3.3'],
+				['current', 'version', 'from-version', 'save:3.3', ...$targetRestore, 'replace:3.3'],
 				$order
 			);
 		}

--- a/tests/php/PfbSettingsFamilyTest.php
+++ b/tests/php/PfbSettingsFamilyTest.php
@@ -67,6 +67,9 @@ final class PfbSettingsFamilyTest extends TestCase
 		$this->assertSame('4.0', pfb_settings_family_from_version('4.0.0'));
 		$this->assertSame('4.1', pfb_settings_family_from_version('4.1.0'));
 		$this->assertSame('4.1', pfb_settings_family_from_version('20260819010101.abcdef1'));
+		// pfb_pkg_ver() prefixes 'v'; POST-INSTALL on nightly was failing closed as NULL (lab finding 16).
+		$this->assertSame('4.1', pfb_settings_family_from_version('v20260819010101.abcdef1'));
+		$this->assertSame('3.3', pfb_settings_family_from_version('v3.3.2'));
 		$this->assertNull(pfb_settings_family_from_version('5.0.1'));
 		$this->assertNull(pfb_settings_family_from_version('20260230010101.abcdef1'));
 		$this->assertNull(pfb_settings_family_from_version('20260819010101.ABCDEF1'));
@@ -280,7 +283,7 @@ final class PfbSettingsFamilyTest extends TestCase
 	{
 		$order = [];
 		$family = pfb_install_settings_family_capture_restore(
-			static function () use (&$order): string { $order[] = 'current'; return '3.2'; },
+			static function () use (&$order): string { $order[] = 'current'; return '3.3'; },
 			static function (string $value) use (&$order): bool { $order[] = 'save'; return TRUE; },
 			static function () use (&$order): string { $order[] = 'version'; return '4.0.0'; },
 			static function (string $value) use (&$order): string { $order[] = 'from-version'; return '4.0'; },
@@ -292,7 +295,7 @@ final class PfbSettingsFamilyTest extends TestCase
 			static function (string $value) use (&$order): bool { $order[] = 'record'; return TRUE; }
 		);
 		$this->assertSame('4.0', $family);
-		$this->assertSame(['current', 'save', 'version', 'from-version', 'replace', 'migrations', 'record'], $order);
+		$this->assertSame(['current', 'version', 'from-version', 'save', 'replace', 'migrations', 'record'], $order);
 	}
 
 	/**

--- a/tests/php/PfbSettingsFamilyTest.php
+++ b/tests/php/PfbSettingsFamilyTest.php
@@ -70,6 +70,8 @@ final class PfbSettingsFamilyTest extends TestCase
 		// pfb_pkg_ver() prefixes 'v'; POST-INSTALL on nightly was failing closed as NULL (lab finding 16).
 		$this->assertSame('4.1', pfb_settings_family_from_version('v20260819010101.abcdef1'));
 		$this->assertSame('3.3', pfb_settings_family_from_version('v3.3.2'));
+		$this->assertSame('4.0', pfb_settings_family_from_version('v4.0.0.a1'));
+		$this->assertNull(pfb_settings_family_from_version('vv4.0.0'));
 		$this->assertNull(pfb_settings_family_from_version('5.0.1'));
 		$this->assertNull(pfb_settings_family_from_version('20260230010101.abcdef1'));
 		$this->assertNull(pfb_settings_family_from_version('20260819010101.ABCDEF1'));

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10580,6 +10580,11 @@
             }
         ]
     },
+    "pfb_settings_family_owned_sections": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": []
+    },
     "pfb_settings_family_pre_uninstall": {
         "returnsRef": false,
         "returnType": "void",


### PR DESCRIPTION
## Summary

Fixes #2572.

On smoke-1 lifecycle (pfSense w/pfb, CE 2.8.1):

- A **3.2.8_1** box could take **nightly** without ever installing 3.3. Owner ruling on #2158: 3.3 is the migration floor.
- Nightly POST-INSTALL threw `unable to restore settings family` because `pfb_pkg_ver()` prefixes `v` and `pfb_settings_family_from_version()` matched the nightly stamp **before** stripping `v`. Residual of #2532.

This PR is the **devel** side only:

1. Strip **one** leading `v`/`V` before the nightly date regex so `vYYYYMMDDHHMMSS.` is family `4.1` (`pfb_pkg_ver()` adds exactly one).
2. If the target family ranks above `3.3` and the source ranks below it **and owned `installedpackages/pfblockerng*` sections exist**, fail closed **before** save/replace with `pfBlockerNG: install the 3.3 bridge before a 4.x family`.
3. A first-ever install (no owned sections) is exempt: `current()` maps a missing marker to the registry default `'3.2'`, which is indistinguishable from a real 3.2 box. Empty owned sections mean there is nothing to bridge.
4. `3.3` → `4.x` still saves, restores, records. `3.2` → `3.3` (target at the bridge) still proceeds.

Not in this PR: republishing 3.3.2 with the `logger()` fallbacks from #2534; a live lifecycle re-run with a package built from this head; `install.sh` treating `pkg: POST-INSTALL script failed` as success (separate follow-up).

## Tests

PHPUnit (`ci-runner:11`, PHP 8.3.33): `PfbSettingsFamilyTest` + `PfbSettingsFamilyPostInstallCaptureTest` (+ Integrity on the save() extract) — **26 tests, 128 assertions, OK** on the two named classes.

Red before the production follow-up (`hash-object` frozen through green):

- `PfbSettingsFamilyPostInstallCaptureTest.php` `d82fd39357d7df724c19bb23a2ed251d19559335`
- `PfbSettingsFamilyTest.php` `7e0e1ae88a0e909096033ef3f9df25ec96f50e6b`

Red: first-ever install with production `current()` and empty `installedpackages` threw the bridge exception; `from_version('vv4.0.0')` returned `'4.0'`.

Green: same files, zero edits — empty owned allows 4.x; owned + missing marker still blocks; `vv4.0.0` is NULL.

## Review follow-up

Head `8e374d09` applies the adversarial-review blocking finding: exempt bootstrap. See the review-reply comment for the ledger.

Authorship: written with Grok, posted via @BBcan177.

🤖 Generated by Grok and posted on behalf of @BBcan177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented upgrades from version 3.2 directly to 4.x when existing pfBlockerNG settings require the 3.3 bridge.
  - Added clear installation errors for unsupported upgrade paths.
  - Improved handling of version strings with a leading “v,” including nightly versions.
  - Preserved safe, fail-closed behavior for existing configurations while allowing first-time installations and supported bridge upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->