### PR TITLE
install: fail closed when pkg reports a script failure

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -167,6 +167,9 @@ _pkg_mutate() {
         _mut_log=$(mktemp "${TMPDIR:-/tmp}/pfb-install-pkg.XXXXXX") ||
             die "${_mut_code}" "mktemp failed while capturing pkg output"
     fi
+    # die() exits the script; EXIT trap removes the file on that path too.
+    # /tmp on pfSense is a small RAM disk.
+    trap 'rm -f "${_mut_log}"' EXIT
     _mut_rc=0
     _pkg "$@" >"${_mut_log}" 2>&1 || _mut_rc=$?
     cat "${_mut_log}"
@@ -182,6 +185,8 @@ _pkg_mutate() {
                 ;;
         esac
     done < "${_mut_log}"
+    trap - EXIT
+    rm -f "${_mut_log}"
     unset _mut_code _mut_msg _mut_log _mut_rc _mut_line
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -150,6 +150,37 @@ _pkg() {
     fi
 }
 
+# _pkg_mutate DIE_CODE DIE_MSG ARGS... — mutating pkg verbs (install/delete).
+# Stream captured output, then die if pkg rc != 0 OR a line is
+# `pkg: * script failed` (pkg(8) can exit 0 after POST-INSTALL/DEINSTALL
+# still failed — the files are already in place; issue #2575).
+_pkg_mutate() {
+    _mut_code="$1"
+    shift
+    _mut_msg="$1"
+    shift
+    if [ -n "${ROOT}" ]; then
+        mkdir -p "${ROOT}/tmp" || die "${_mut_code}" "could not create ${ROOT}/tmp"
+        _mut_log="${ROOT}/tmp/pfb-install-pkg.log"
+    else
+        _mut_log="${TMPDIR:-/tmp}/pfb-install-pkg.log"
+    fi
+    _mut_rc=0
+    _pkg "$@" >"${_mut_log}" 2>&1 || _mut_rc=$?
+    cat "${_mut_log}"
+    if [ "${_mut_rc}" -ne 0 ]; then
+        die "${_mut_code}" "${_mut_msg}"
+    fi
+    while IFS= read -r _mut_line || [ -n "${_mut_line}" ]; do
+        case "${_mut_line}" in
+            'pkg: '*' script failed')
+                die "${_mut_code}" "pkg reported '${_mut_line}' — ${_mut_msg}"
+                ;;
+        esac
+    done < "${_mut_log}"
+    unset _mut_code _mut_msg _mut_log _mut_rc _mut_line
+}
+
 usage() {
     cat <<USAGE
 install.sh — put this pfSense box on a pfBlockerNG channel.
@@ -172,7 +203,7 @@ Exit codes:
   2  usage: unknown argument, unknown/missing --channel
   4  target unavailable: the hook could not resolve the conf, pkg update failed, the
      catalogue offers nothing, or pkg version -t gave no usable answer
-  5  a pkg operation (delete/install) failed
+  5  a pkg operation (delete/install) failed, including a package-script failure while pkg exited 0
   6  post-install verification failed
 USAGE
 }
@@ -387,8 +418,8 @@ pfb_channel_install() {
     for _iname in ${_installed_names}; do
         [ "${_iname}" = "${CANONICAL_PKG}" ] && continue
         printf '==> Removing %s\n' "${_iname}"
-        _pkg delete -y "${_iname}" ||
-            die 5 "\`pkg delete ${_iname}\` failed — re-run after fixing the cause, or finish manually: ${PKG_BIN} delete -y ${_iname}"
+        _pkg_mutate 5 "\`pkg delete ${_iname}\` failed — re-run after fixing the cause, or finish manually: ${PKG_BIN} delete -y ${_iname}" \
+            delete -y "${_iname}"
     done
 
     _canon_ver="$(_pkg query '%v' "${CANONICAL_PKG}" 2>/dev/null || true)"
@@ -415,13 +446,13 @@ pfb_channel_install() {
             fi
         fi
         printf '==> Reinstalling %s from %s (repository-qualified)\n' "${CANONICAL_PKG}" "${REPO_NAME}"
-        _pkg install -y -f -r "${REPO_NAME}" "${CANONICAL_PKG}-${OFFERED}" ||
-            die 5 "\`pkg install -f -r ${REPO_NAME} ${CANONICAL_PKG}-${OFFERED}\` failed — the previous build is still installed"
+        _pkg_mutate 5 "\`pkg install -f -r ${REPO_NAME} ${CANONICAL_PKG}-${OFFERED}\` failed — the previous build is still installed" \
+            install -y -f -r "${REPO_NAME}" "${CANONICAL_PKG}-${OFFERED}"
     else
         # 9d. Nothing canonical installed (fresh box, or right after 9a's deletes).
         printf '==> Installing %s from %s\n' "${CANONICAL_PKG}" "${REPO_NAME}"
-        _pkg install -y -r "${REPO_NAME}" "${CANONICAL_PKG}" ||
-            die 5 "\`pkg install -r ${REPO_NAME} ${CANONICAL_PKG}\` failed — no pfBlockerNG is currently installed; fix the cause, then finish with: ${PKG_BIN} install -y -r ${REPO_NAME} ${CANONICAL_PKG}"
+        _pkg_mutate 5 "\`pkg install -r ${REPO_NAME} ${CANONICAL_PKG}\` failed — no pfBlockerNG is currently installed; fix the cause, then finish with: ${PKG_BIN} install -y -r ${REPO_NAME} ${CANONICAL_PKG}" \
+            install -y -r "${REPO_NAME}" "${CANONICAL_PKG}"
     fi
 
     # 10. Prove the result — every claim is re-read from pkg after the fact.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,9 +161,11 @@ _pkg_mutate() {
     shift
     if [ -n "${ROOT}" ]; then
         mkdir -p "${ROOT}/tmp" || die "${_mut_code}" "could not create ${ROOT}/tmp"
-        _mut_log="${ROOT}/tmp/pfb-install-pkg.log"
+        _mut_log=$(mktemp "${ROOT}/tmp/pfb-install-pkg.XXXXXX") ||
+            die "${_mut_code}" "mktemp failed while capturing pkg output"
     else
-        _mut_log="${TMPDIR:-/tmp}/pfb-install-pkg.log"
+        _mut_log=$(mktemp "${TMPDIR:-/tmp}/pfb-install-pkg.XXXXXX") ||
+            die "${_mut_code}" "mktemp failed while capturing pkg output"
     fi
     _mut_rc=0
     _pkg "$@" >"${_mut_log}" 2>&1 || _mut_rc=$?
@@ -172,9 +174,11 @@ _pkg_mutate() {
         die "${_mut_code}" "${_mut_msg}"
     fi
     while IFS= read -r _mut_line || [ -n "${_mut_line}" ]; do
+        # Hook stdout often ends without a newline, so pkg's message is glued
+        # mid-line: ``thrown</pre>pkg: POST-INSTALL script failed``.
         case "${_mut_line}" in
-            'pkg: '*' script failed')
-                die "${_mut_code}" "pkg reported '${_mut_line}' — ${_mut_msg}"
+            *'pkg: '*' script failed'*)
+                die "${_mut_code}" "pkg reported a package-script failure — ${_mut_msg}"
                 ;;
         esac
     done < "${_mut_log}"

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -892,6 +892,32 @@ def test_postinstall_script_failed_glued_to_hook_output_exits_5_without_done() -
         assert "Done" not in proc.stdout
 
 
+def test_pkg_capture_log_is_removed_after_success() -> None:
+    """mktemp capture files live on a small RAM /tmp on the appliance; they
+    must not leak after a successful mutate."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(root, "stable")
+
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        leftovers = sorted(Path(root, "tmp").glob("pfb-install-pkg.*"))
+        assert leftovers == [], leftovers
+
+
+def test_pkg_capture_log_is_removed_after_script_failed() -> None:
+    """The die() path must remove the capture file too (same as the hook
+    staging mktemp)."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(
+            root,
+            "stable",
+            extra_env={"PFB_STUB_POSTINSTALL_FAIL": "1"},
+        )
+
+        assert proc.returncode == 5, proc.stdout + proc.stderr
+        leftovers = sorted(Path(root, "tmp").glob("pfb-install-pkg.*"))
+        assert leftovers == [], leftovers
+
+
 def test_benign_pkg_diagnostic_is_not_a_hook_failure() -> None:
     """A ``pkg: ``-prefixed warning that is not ``script failed`` must not
     abort a successful install."""

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -118,6 +118,12 @@ query)
 delete)
     _name="$3"
     rm -rf "${STATE:?}/${_name}"
+    if [ -n "${PFB_STUB_DEINSTALL_FAIL:-}" ]; then
+        printf 'pkg: DEINSTALL script failed\n' >&2
+    fi
+    if [ -n "${PFB_STUB_SCRIPT_FAILED_NOISE:-}" ]; then
+        printf 'the POST-INSTALL script failed to mention foo\n'
+    fi
     exit 0
     ;;
 install)
@@ -153,6 +159,12 @@ install)
     printf '%s' "${_repo}" > "${STATE}/${_name}/repo"
     if [ -n "${PFB_STUB_DELETE_CONFIG_XML:-}" ]; then
         rm -f "${PFB_STUB_DELETE_CONFIG_XML}"
+    fi
+    if [ -n "${PFB_STUB_POSTINSTALL_FAIL:-}" ]; then
+        printf 'pkg: POST-INSTALL script failed\n' >&2
+    fi
+    if [ -n "${PFB_STUB_SCRIPT_FAILED_NOISE:-}" ]; then
+        printf 'the POST-INSTALL script failed to mention foo\n'
     fi
     exit 0
     ;;
@@ -791,7 +803,65 @@ def test_empty_catalogue_leaves_a_pre_existing_target_conf_in_place() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# 13. pkg update failure: fails, no mutation, created stub removed
+# 13. pkg script-failed with rc 0 is still a failed install (issue #2575)
+# --------------------------------------------------------------------------- #
+
+
+def test_postinstall_script_failed_exits_5_without_done() -> None:
+    """pkg(8) can exit 0 after POST-INSTALL fails (files already extracted).
+    install.sh must not print Done or return 0 — lifecycle on smoke-1 showed
+    ``pkg: POST-INSTALL script failed`` followed by ``==> Done`` (issue #2575)."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(
+            root,
+            "stable",
+            extra_env={"PFB_STUB_POSTINSTALL_FAIL": "1"},
+        )
+
+        assert proc.returncode == 5, proc.stdout + proc.stderr
+        combined = proc.stdout + proc.stderr
+        assert "pkg: POST-INSTALL script failed" in combined, combined
+        assert "Done" not in proc.stdout
+
+
+def test_deinstall_script_failed_on_legacy_delete_exits_5_without_done() -> None:
+    """Same pkg(8) contract on delete: DEINSTALL can fail while pkg still
+    exits 0 and the identity is already gone. Fail closed (issue #2575)."""
+    with tempfile.TemporaryDirectory() as root:
+        _seed_installed(root, f"{_CANONICAL}-devel", "3.2.14_2", "pfblockerng")
+        _seed_conf_file(root, _LEGACY_CONF, "# legacy release conf\n")
+
+        proc = _run_install(
+            root,
+            "stable",
+            catalog=("4.0.0",),
+            extra_env={"PFB_STUB_DEINSTALL_FAIL": "1"},
+        )
+
+        assert proc.returncode == 5, proc.stdout + proc.stderr
+        combined = proc.stdout + proc.stderr
+        assert "pkg: DEINSTALL script failed" in combined, combined
+        assert "Done" not in proc.stdout
+
+
+def test_script_failed_without_pkg_prefix_is_not_a_hook_failure() -> None:
+    """Only ``pkg: <script> script failed`` is the hook-failure signal. A
+    coincidental ``script failed`` substring in pkg stdout must not fail the
+    run."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(
+            root,
+            "stable",
+            extra_env={"PFB_STUB_SCRIPT_FAILED_NOISE": "1"},
+        )
+
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "Done" in proc.stdout
+        assert "the POST-INSTALL script failed to mention foo" in proc.stdout
+
+
+# --------------------------------------------------------------------------- #
+# 13b. pkg update failure: fails, no mutation, created stub removed
 # --------------------------------------------------------------------------- #
 
 

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -119,10 +119,16 @@ delete)
     _name="$3"
     rm -rf "${STATE:?}/${_name}"
     if [ -n "${PFB_STUB_DEINSTALL_FAIL:-}" ]; then
+        if [ -n "${PFB_STUB_SCRIPT_FAILED_GLUED:-}" ]; then
+            printf '  thrown</pre>'
+        fi
         printf 'pkg: DEINSTALL script failed\n' >&2
     fi
     if [ -n "${PFB_STUB_SCRIPT_FAILED_NOISE:-}" ]; then
         printf 'the POST-INSTALL script failed to mention foo\n'
+    fi
+    if [ -n "${PFB_STUB_PKG_DIAG:-}" ]; then
+        printf 'pkg: Repository pfblockerng-stable has a missing meta file, using previous version\n'
     fi
     exit 0
     ;;
@@ -161,10 +167,16 @@ install)
         rm -f "${PFB_STUB_DELETE_CONFIG_XML}"
     fi
     if [ -n "${PFB_STUB_POSTINSTALL_FAIL:-}" ]; then
+        if [ -n "${PFB_STUB_SCRIPT_FAILED_GLUED:-}" ]; then
+            printf '  thrown</pre>'
+        fi
         printf 'pkg: POST-INSTALL script failed\n' >&2
     fi
     if [ -n "${PFB_STUB_SCRIPT_FAILED_NOISE:-}" ]; then
         printf 'the POST-INSTALL script failed to mention foo\n'
+    fi
+    if [ -n "${PFB_STUB_PKG_DIAG:-}" ]; then
+        printf 'pkg: Repository pfblockerng-stable has a missing meta file, using previous version\n'
     fi
     exit 0
     ;;
@@ -858,6 +870,41 @@ def test_script_failed_without_pkg_prefix_is_not_a_hook_failure() -> None:
         assert proc.returncode == 0, proc.stdout + proc.stderr
         assert "Done" in proc.stdout
         assert "the POST-INSTALL script failed to mention foo" in proc.stdout
+
+
+def test_postinstall_script_failed_glued_to_hook_output_exits_5_without_done() -> None:
+    """pfSense hook stdout often ends without a newline, so pkg's stderr is
+    glued: ``thrown</pre>pkg: POST-INSTALL script failed``. The matcher must
+    still fail closed (issue #2575, live legs.log)."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(
+            root,
+            "stable",
+            extra_env={
+                "PFB_STUB_POSTINSTALL_FAIL": "1",
+                "PFB_STUB_SCRIPT_FAILED_GLUED": "1",
+            },
+        )
+
+        assert proc.returncode == 5, proc.stdout + proc.stderr
+        combined = proc.stdout + proc.stderr
+        assert "pkg: POST-INSTALL script failed" in combined, combined
+        assert "Done" not in proc.stdout
+
+
+def test_benign_pkg_diagnostic_is_not_a_hook_failure() -> None:
+    """A ``pkg: ``-prefixed warning that is not ``script failed`` must not
+    abort a successful install."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(
+            root,
+            "stable",
+            extra_env={"PFB_STUB_PKG_DIAG": "1"},
+        )
+
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "Done" in proc.stdout
+        assert "pkg: Repository" in proc.stdout
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Fixes #2575.

On smoke-1 lifecycle (pfSense w/pfb, CE 2.8.1), `install.sh --channel <ch>` printed `==> Done` after `pkg: POST-INSTALL script failed` (and after `pkg: DEINSTALL script failed` on channel moves). `pkg` exits 0 because the files are already in place. `_pkg install || die 5` never fires. Step 10 then proves `%n`/`%R`/`%v`/payload and reports success.

The operator (and this harness) read a successful channel move. The PHP fatal is the real signal.

This PR is only the installer:

1. Mutating pkg verbs (`install` / `delete`) go through `_pkg_mutate`, which captures stdout+stderr, reprints it, and dies exit 5 if pkg rc != 0 **or** a line contains `pkg: * script failed` (including glued mid-line after hook output with no trailing newline).
2. Query/rquery/version/info stay on `_pkg` (they capture stdout).
3. Capture file is `mktemp`, not a fixed `/tmp` path.
4. No rollback of a package pkg already installed. Fail closed and say so.

Not in this PR: the POST-INSTALL PHP fatals themselves (#2572 / PR #2573; published 3.3.2 missing `logger()`).

## Tests

`uv run --locked pytest tests/test_channel_install.py` — **66 passed**.

Red before the glued-matcher edit (`hash-object` frozen through green):

- `tests/test_channel_install.py` `b01cf5c9ec9885f1ac0263ef07703049c2085e2e`

RED: stub glued `thrown</pre>` + `pkg: POST-INSTALL script failed` → install.sh exited 0 and printed Done.
GREEN: same file, zero edits — exit 5, no Done. Clean-line and no-`pkg:`-prefix noise rows still hold; a benign `pkg: Repository ...` warning does not abort.

Authorship: written with Grok, posted via @BBcan177.

🤖 Generated by Grok and posted on behalf of @BBcan177.