### PR TITLE
pfblockerng: keep schedule config standalone

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4764,6 +4764,9 @@ function pfb_schedule_runtime_model(array $general, array $sections, array $extr
 /** Build the scheduled-feed runtime image from the config gateway. */
 function pfb_schedule_runtime_config(): ?array
 {
+	$valid_blacklist_identity = static fn (mixed $value): bool =>
+		is_string($value) && $value !== '' && $value !== '0'
+		&& preg_match('/^[a-zA-Z0-9,_-]+$/D', $value) === 1;
 	$scheduled = PfbConfig::read('gen/pfb_scheduled_feed_updates');
 	if ($scheduled instanceof PfbToggle) {
 		$scheduled = $scheduled->toStored();
@@ -4783,8 +4786,7 @@ function pfb_schedule_runtime_config(): ?array
 	$blacklist_frequency = $blacklist['blacklist_freq'] ?? 'Never';
 	$blacklist_selected = $blacklist['blacklist_selected'] ?? '';
 	if (!is_string($blacklist_selected)
-		|| ($blacklist_selected !== ''
-			&& pfb_filter($blacklist_selected, PFB_FILTER_CSV, 'Schedule blacklist selection') !== $blacklist_selected)) {
+		|| ($blacklist_selected !== '' && !$valid_blacklist_identity($blacklist_selected))) {
 		return NULL;
 	}
 	$selected = array_flip(explode(',', $blacklist_selected));
@@ -4793,7 +4795,7 @@ function pfb_schedule_runtime_config(): ?array
 			$xml = $item['xml'] ?? NULL;
 			if (!is_array($item)
 				|| !is_string($xml) || $xml === '' || str_contains($xml, ',')
-				|| pfb_filter($xml, PFB_FILTER_CSV, 'Schedule blacklist identity') !== $xml
+				|| !$valid_blacklist_identity($xml)
 				|| !is_string($item['title'] ?? NULL)
 				|| !is_string($item['feed'] ?? NULL)) {
 				return NULL;

--- a/tests/php/ExtrasScheduleRuntimeTest.php
+++ b/tests/php/ExtrasScheduleRuntimeTest.php
@@ -291,5 +291,13 @@ final class ExtrasScheduleRuntimeTest extends TestCase
 			]],
 		]);
 		$this->assertNull(pfb_schedule_runtime_config());
+
+		config_set_path('installedpackages/pfblockerngblacklist', [
+			'blacklist_enable' => 'Enable', 'blacklist_selected' => '0', 'blacklist_freq' => 'EveryDay',
+			'item' => [[
+				'xml' => '0', 'selected' => 'yes', 'title' => 'Zero', 'feed' => 'https://example.test/zero',
+			]],
+		]);
+		$this->assertNull(pfb_schedule_runtime_config());
 	}
 }

--- a/tests/php/QuarterHourMigrationTest.php
+++ b/tests/php/QuarterHourMigrationTest.php
@@ -32,10 +32,29 @@ final class QuarterHourMigrationTest extends TestCase
 		));
 	}
 
-	public function testScheduleMigrationWorksWhenExtraModuleIsLoadedStandalone(): void
+	public function testScheduleRuntimeWorksWhenExtraModuleIsLoadedStandalone(): void
 	{
 		$extra = var_export(__DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc', TRUE);
 		$script = <<<PHP
+\$standalone_config = [
+	'installedpackages/pfblockerng/config/0/pfb_scheduled_feed_updates' => 'on',
+	'installedpackages/pfblockerng/config/0/pfb_schedule_weekday' => '7',
+	'installedpackages/pfblockerng/config/0/pfb_schedule_hour' => '6',
+	'installedpackages/pfblockerng/config/0/pfb_schedule_minute' => '45',
+	'installedpackages/pfblockernglistsv4/config' => [],
+	'installedpackages/pfblockernglistsv6/config' => [],
+	'installedpackages/pfblockerngdnsbl/config' => [],
+	'installedpackages/pfblockerngblacklist' => [
+		'blacklist_enable' => 'Enable',
+		'blacklist_selected' => 'ut1',
+		'blacklist_freq' => 'EveryDay',
+		'item' => [['xml' => 'ut1', 'selected' => 'ads', 'title' => 'UT1', 'feed' => 'https://example.test/ut1']],
+	],
+];
+function config_get_path(string \$path, mixed \$default = NULL): mixed
+{
+	return \$GLOBALS['standalone_config'][\$path] ?? \$default;
+}
 require {$extra};
 \$gen = 'installedpackages/pfblockerng/config/0';
 \$v4 = 'installedpackages/pfblockernglistsv4/config';
@@ -66,7 +85,12 @@ require {$extra};
 	],
 ];
 \$extras = pfb_schedule_extra_plan(\$model, ['schema' => 1, 'items' => []], strtotime('2026-01-07 07:00:00 UTC'), new DateTimeZone('UTC'));
-echo json_encode(['group' => \$migrated[\$v4][0], 'extras_due' => \$extras['due']], JSON_THROW_ON_ERROR);
+\$runtime = pfb_schedule_runtime_config();
+echo json_encode([
+	'group' => \$migrated[\$v4][0],
+	'extras_due' => \$extras['due'],
+	'blacklist_enabled' => \$runtime['entries']['extra:bl']['enabled'] ?? NULL,
+], JSON_THROW_ON_ERROR);
 PHP;
 		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
 		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
@@ -118,6 +142,7 @@ PHP;
 		$this->assertSame('45', $group['schedule_minute']);
 		$this->assertArrayNotHasKey('dow', $group);
 		$this->assertSame(['extra:dcc'], $output['extras_due']);
+		$this->assertTrue($output['blacklist_enabled']);
 	}
 
 	public function testRegistryAddsCanonicalScheduleFieldsAndFreshSkipfeedDefault(): void


### PR DESCRIPTION
## Summary

- keep `pfb_schedule_runtime_config()` usable through the established standalone `pfblockerng_extra.inc` scheduler seam;
- validate blacklist identities locally with the existing `PFB_FILTER_CSV` character contract, including its historical rejection of string `"0"`;
- extend the standalone scheduler child test to exercise a populated blacklist configuration.

This takes the issue's leaf-runtime option without adding another include file: the affected scheduler function's transitive path remains in `pfblockerng_extra.inc`, and the two calls into `pfblockerng.inc` are removed.

## Verification

- Red: `vendor/bin/phpunit --filter testScheduleRuntimeWorksWhenExtraModuleIsLoadedStandalone tests/php/QuarterHourMigrationTest.php` failed with `Call to undefined function pfb_filter()`; frozen test hash `bb71f756eac2937926df32699b3d4c5645e9f499`.
- Compatibility mutation: the added string-`"0"` row failed against the initial local validator because it omitted `pfb_filter()`'s historical `empty("0")` rejection, then passed after parity was restored; test hash `ae72cd2cc4333ecbc362871424d6cd136eeed184`. This is preservation coverage, not an untouched-base RED.
- Green: both focused tests passed unchanged (`2 tests, 12 assertions`).
- Canonical diff gate: `scripts/agent/run-gates.sh --diff origin/devel` — PHP syntax, 5,366 PHPUnit tests, PHPStan, and PHPCS all passed.

Fixes #2495

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for blacklist identities, accepting only properly formatted values.
  * Prevented the invalid identity `"0"` from being used in blacklist selections and item identifiers.
  * Invalid blacklist configuration is now handled safely without causing runtime errors.
  * Improved schedule migration and runtime configuration handling, including preservation of enabled blacklist entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->