### PR TITLE
agents: reject shared bindings outside role tiers

### DIFF
--- a/scripts/check_agent_roles.py
+++ b/scripts/check_agent_roles.py
@@ -108,6 +108,10 @@ class Role(NamedTuple):
     copilot: tuple[tuple[str, str], ...]
 
 
+def _common_tiers(bound: list[Role]) -> set[str]:
+    return set(bound[0].tiers).intersection(*(role.tiers for role in bound[1:]))
+
+
 def _parse_tiers_conf(text: str, problems: list[str]) -> dict[str, str]:
     """Parse KEY=VALUE tier lines; require exactly the six known keys, once each."""
     values: dict[str, str] = {}
@@ -242,7 +246,7 @@ def _check_claude_workflows(
             problems.append(f"role(s) {names}: missing Claude workflow {_CLAUDE_WORKFLOWS}/{target}.js")
             continue
         pins = _scan_model_pins(path)
-        allowed = {tier for role in bound for tier in role.tiers}
+        allowed = _common_tiers(bound)
         for pin in sorted(set(pins)):
             tier = model_tier.get(pin)
             if tier is None:
@@ -278,7 +282,7 @@ def _check_codex_agents(
             problems.append(f"{_CODEX_AGENTS}/{target}.toml: unparsable TOML: {exc}")
             continue
         model, sandbox = data.get("model"), data.get("sandbox_mode")
-        allowed = {tiers_conf.get(f"{tier.upper()}_CODEX") for role in bound for tier in role.tiers} - {None}
+        allowed = {tiers_conf.get(f"{tier.upper()}_CODEX") for tier in _common_tiers(bound)} - {None}
         if isinstance(model, str):
             agent_model[target] = model
         if not isinstance(model, str) or model not in allowed:
@@ -364,7 +368,7 @@ def _check_copilot_agents(
         if not fields.get("description"):
             problems.append(f"{_COPILOT_AGENTS}/{target}.agent.md: front matter has no description")
         model = fields.get("model")
-        allowed = {tiers_conf.get(f"{tier.upper()}_COPILOT") for role in bound for tier in role.tiers} - {None}
+        allowed = {tiers_conf.get(f"{tier.upper()}_COPILOT") for tier in _common_tiers(bound)} - {None}
         if model is not None:
             agent_model[target] = model
         if model is None or model not in allowed:

--- a/tests/test_agent_roles_check.py
+++ b/tests/test_agent_roles_check.py
@@ -472,6 +472,7 @@ def test_shared_bindings_use_each_roles_tier_intersection(tmp_path: Path) -> Non
     _assert_flags(problems, ".claude/workflows/check.js pins 'claude-top-x' (top tier), outside tier(s) small")
     _assert_flags(problems, ".codex/agents/checker-top.toml model 'codex-top' is not a Codex model")
     _assert_flags(problems, ".github/agents/checker-top.agent.md model 'copilot-top' is not a Copilot model")
+    assert len(problems) == 3, problems
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_agent_roles_check.py
+++ b/tests/test_agent_roles_check.py
@@ -461,6 +461,19 @@ def test_codex_luna_reviewer_rejects_xhigh(tmp_path: Path) -> None:
     )
 
 
+def test_shared_bindings_use_each_roles_tier_intersection(tmp_path: Path) -> None:
+    rows = (
+        *_ROWS,
+        "| auditor | small | read-only | yes | workflow:check "
+        "| agent:checker, agent:checker-top | agent:checker, agent:checker-top |",
+    )
+    make_tree(tmp_path, doc=_doc(rows=rows, sections=(*_ROLE_NAMES, "auditor")))
+    problems = _problems(tmp_path)
+    _assert_flags(problems, ".claude/workflows/check.js pins 'claude-top-x' (top tier), outside tier(s) small")
+    _assert_flags(problems, ".codex/agents/checker-top.toml model 'codex-top' is not a Codex model")
+    _assert_flags(problems, ".github/agents/checker-top.agent.md model 'copilot-top' is not a Copilot model")
+
+
 # --------------------------------------------------------------------------- #
 # Skill / policy bindings and orphaned vendor definitions
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- Validate shared Claude workflows, Codex agents, and Copilot agents against the
  tier intersection of every bound role.
- Preserve each role's separate primary-tier coverage requirement.
- Add one hostile shared-binding fixture covering all three model-pinned vendor
  surfaces; Grok remains non-applicable because it has no committed model-pinned
  agent or workflow surface.

## Verification

- RED: the frozen regression test failed because the checker returned no
  problems for the shared top-tier definitions.
- GREEN: the unchanged test passed; frozen blob
  `039ba7020a24ad4ed8481e438a718b35da28dea5`.
- `uv run pytest tests/test_agent_roles_check.py tests/test_agent_review_effort_check.py -q`
  — 84 passed.
- `scripts/agent/run-gates.sh --diff origin/devel` — pytest, Ruff check, Ruff
  format, and mypy passed.
- Independent small-tier verification re-executed the scratch RED/GREEN proof,
  reran all canonical gates, and reported no findings at
  `bc22f2f8b764fb70368fce77fe8e103d0560aa18`.

Fixes #2583

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected model validation for Claude workflows, Codex agents, and Copilot agents with multiple role bindings.
  * Models must now meet the tier requirements shared by every applicable role, preventing unsupported model selections.

* **Tests**
  * Added coverage to verify validation across shared role bindings and reject out-of-tier or invalid models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->