### PR TITLE
trigger: a deferred trigger=cron pass exits cleanly; deferrals reach syslog

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -659,10 +659,14 @@ function sync_package_pfblockerng($cron=''): bool {
 	// API. A lock deferral is benign ONLY for the unattended tick dispatch
 	// (trigger=cron force=false — what pfblockerng_tick()'s due job execs through
 	// `pfblockerng.php pfb_trigger`): the pass stands down with its durable retry
-	// state intact (pending marker / due ledger) and the next tick retries, so
-	// pfblockerng.php:285 must exit 0. Every operator-initiated request — trigger=
-	// manual/force, any force=true, the GUI Save '' string path, the deprecated
-	// string verbs — keeps reporting the deferral (SyncFeedPassDeferralTest pins '').
+	// state intact (pending marker / due ledger) and the next tick retries, so the
+	// pfb_trigger case in pfblockerng.php must exit 0. Every operator-initiated
+	// request — trigger=manual/force, any force=true, the GUI Save '' string path,
+	// the deprecated string verbs — keeps reporting the deferral
+	// (SyncFeedPassDeferralTest pins ''). Only the two LOCK guards below return
+	// this: stage/publish recovery failure is a genuine failure and the GeoIP-swap
+	// guard is out of #2505's scope, so both keep FALSE. Escalation signal is one
+	// syslog notice per deferred pass, no counter — matches the feed-pass guard.
 	$pfb_deferral_benign = is_array($cron)
 		&& ($cron['trigger'] ?? '') === 'cron'
 		&& empty($cron['force']);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -655,6 +655,18 @@ function sync_package_pfblockerng($cron=''): bool {
 	global $g, $pfb, $pfbarr;
 	pfb_global();
 
+	// issue #2505: mirror the cron verb's issue #2491 semantics for the ADR-43 array
+	// API. A lock deferral is benign ONLY for the unattended tick dispatch
+	// (trigger=cron force=false — what pfblockerng_tick()'s due job execs through
+	// `pfblockerng.php pfb_trigger`): the pass stands down with its durable retry
+	// state intact (pending marker / due ledger) and the next tick retries, so
+	// pfblockerng.php:285 must exit 0. Every operator-initiated request — trigger=
+	// manual/force, any force=true, the GUI Save '' string path, the deprecated
+	// string verbs — keeps reporting the deferral (SyncFeedPassDeferralTest pins '').
+	$pfb_deferral_benign = is_array($cron)
+		&& ($cron['trigger'] ?? '') === 'cron'
+		&& empty($cron['force']);
+
 	// The update owns scheduler state from before feed selection through final publication.
 	// Nested calls made by a scheduled tick reuse its existing dispatcher hold.
 	$pfb_dispatch_owner = !isset($GLOBALS['pfb_schedule_dispatch_lock'])
@@ -663,8 +675,12 @@ function sync_package_pfblockerng($cron=''): bool {
 		// issue #2496: pfblockerng.php exits 1 on a FALSE from this function with no
 		// other output, so every guard must name itself or the failure is undiagnosable.
 		pfb_logger("\n sync aborted: dispatcher lock unavailable; pending changes retained.\n", 1);
+		// issue #2505: feed-pass parity (pfb_feed_pass_begin() raises LOG_NOTICE) --
+		// a live wedged lock holder must be visible outside /var/log/pfblockerng.
+		logger(LOG_NOTICE, localize_text('Feed pass [ sync ] deferred - the scheduler dispatcher lock is unavailable.'),
+			LOG_PREFIX_PKG_PFBLOCKERNG);
 		pfb_mark_pending_changes();
-		return FALSE;
+		return $pfb_deferral_benign;
 	}
 
 	// issue #1175: serialize feed passes. Capture ownership BEFORE acquiring -- only the
@@ -678,7 +694,7 @@ function sync_package_pfblockerng($cron=''): bool {
 		if ($pfb_dispatch_owner) {
 			pfb_schedule_dispatch_release();
 		}
-		return FALSE;
+		return $pfb_deferral_benign;
 	}
 	if (!pfb_stage_publish_dir_recover($pfb['dbdir'])) {
 		pfb_logger("\n sync aborted: stage/publish recovery failed in {$pfb['dbdir']}; pending changes retained.\n", 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
@@ -264,6 +264,10 @@ function pfblockerng_sync_cron(
 		|| !is_resource($GLOBALS['pfb_schedule_dispatch_lock']);
 	if (!pfb_schedule_dispatch_begin()) {
 		pfb_logger("\n Scheduled feed pass deferred: dispatcher lock unavailable; durable pending occurrences retained.\n", 1);
+		// issue #2505: feed-pass parity (pfb_feed_pass_begin() raises LOG_NOTICE) --
+		// a live wedged lock holder must be visible outside /var/log/pfblockerng.
+		logger(LOG_NOTICE, localize_text('Feed pass [ %s ] deferred - the scheduler dispatcher lock is unavailable.',
+			$force_all ? 'forcecheck' : 'cron'), LOG_PREFIX_PKG_PFBLOCKERNG);
 		// issue #2491: a deferral is benign for the UNATTENDED cron verb and a real
 		// non-event for Force Check. Both reach here; only $force_all separates them
 		// (pfblockerng.php:255 passes nothing, :304 passes TRUE).

--- a/tests/php/TriggerFunnelDeferralExitCodeTest.php
+++ b/tests/php/TriggerFunnelDeferralExitCodeTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/SyncPrereqSeedTrait.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2505: the pfb_trigger funnel (ADR-43 array API into
+ * sync_package_pfblockerng()) must carry the same deferral semantics issue #2491
+ * gave the deprecated `cron` verb — otherwise the DEPRECATED funnel has the
+ * considered exit code and the modern, documented one does not.
+ *
+ * The unattended dispatch is `pfblockerng.php pfb_trigger ... trigger=cron
+ * force=false` (what pfblockerng_tick()'s due job execs). When such a pass loses
+ * the dispatcher or feed-pass lock race it stands down with its durable retry
+ * state intact (pending marker / due ledger) and the next tick retries — nothing
+ * failed, so `pfblockerng.php:285` must exit 0, not 1.
+ *
+ * Every operator-initiated request stays observable: trigger=manual / trigger=force,
+ * any force=true request, the GUI Save '' string path, and the deprecated string
+ * verbs (SyncFeedPassDeferralTest pins the '' path's FALSE).
+ *
+ * Also pinned here (the #2504 review nitpick): a dispatcher-lock deferral was
+ * quiet on syslog — one pfb_logger() line only, unlike the feed-pass guard
+ * (pfb_feed_pass_begin() raises LOG_NOTICE) — so a live wedged lock holder was
+ * invisible outside /var/log/pfblockerng. Both sync funnels' dispatcher guards
+ * must raise a syslog notice (captured via the pfsense_doubles logger() double).
+ *
+ * The trigger=cron rows are RED before the fix (the guards return FALSE and no
+ * syslog notice exists); the operator rows are the before-state guards that keep
+ * the fix honest and pass both before and after.
+ */
+final class TriggerFunnelDeferralExitCodeTest extends TestCase
+{
+	use SyncPrereqSeedTrait;
+
+	private string $dbdir = '';
+	private bool $hadPfb = FALSE;
+	private array $originalPfb = [];
+	private bool $hadConfig = FALSE;
+	private mixed $originalConfig = NULL;
+	private bool $hadChrootPath = FALSE;
+	private mixed $originalChrootPath = NULL;
+
+	/** Raw fds simulating ANOTHER process holding a lock. */
+	private $feedLockFp = NULL;
+	private $dispatchLockFp = NULL;
+
+	protected function setUp(): void
+	{
+		$this->hadPfb             = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb        = $GLOBALS['pfb'] ?? [];
+		$this->hadConfig          = array_key_exists('config', $GLOBALS);
+		$this->originalConfig     = $GLOBALS['config'] ?? NULL;
+		$this->hadChrootPath      = array_key_exists('unbound_chroot_path', $GLOBALS['g'] ?? []);
+		$this->originalChrootPath = $GLOBALS['g']['unbound_chroot_path'] ?? NULL;
+
+		$this->dbdir = sys_get_temp_dir() . '/pfb_trigger_defer_' . uniqid('', TRUE);
+		mkdir($this->dbdir, 0755, TRUE);
+
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dbdir'              => $this->dbdir,
+			'schedule_state_dir' => $this->dbdir,
+			'log'                => "{$this->dbdir}/pfblockerng.log",
+			'errlog'             => "{$this->dbdir}/error.log",
+			'runlog'             => "{$this->dbdir}/run.log",
+			'pending_marker'     => "{$this->dbdir}/pfb_pending_changes",
+		]);
+		$GLOBALS['config'] = [];
+		$this->seedSyncPrereqs();
+
+		// Safety net: were a guard regression to let the pass continue, the
+		// boot/install early-return stops it before real feed work. The
+		// before-state log assertions below prove the deferral path was taken,
+		// so no row can go green through this early-return.
+		$GLOBALS['g']['pfblockerng_install'] = TRUE;
+
+		// No inherited locks: a leaked handle would make a deferral row pass
+		// vacuously (the reentrancy short-circuit never reaches the guard).
+		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+
+		// Fresh syslog capture (pfsense_doubles.php logger() double).
+		$GLOBALS['pfb_test_logger_calls'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ([$this->feedLockFp, $this->dispatchLockFp] as $fp) {
+			if (is_resource($fp)) {
+				@flock($fp, LOCK_UN);
+				@fclose($fp);
+			}
+		}
+		$this->feedLockFp = $this->dispatchLockFp = NULL;
+
+		pfb_feed_pass_release();
+		pfb_schedule_dispatch_release();
+		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		unset($GLOBALS['g']['pfblockerng_install']);
+		unset($GLOBALS['pfb_test_logger_calls']);
+
+		foreach (glob("{$this->dbdir}/*") ?: [] as $path) {
+			is_dir($path) ? @rmdir($path) : @unlink($path);
+		}
+		@rmdir($this->dbdir);
+
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+		if ($this->hadChrootPath) {
+			$GLOBALS['g']['unbound_chroot_path'] = $this->originalChrootPath;
+		} else {
+			unset($GLOBALS['g']['unbound_chroot_path']);
+		}
+	}
+
+	private function mainLog(): string
+	{
+		$log = $GLOBALS['pfb']['log'];
+		return is_file($log) ? (string) file_get_contents($log) : '';
+	}
+
+	private function holdDispatcherLock(): void
+	{
+		$this->dispatchLockFp = fopen("{$this->dbdir}/pfb_schedule_dispatch.lock", 'c');
+		$this->assertIsResource($this->dispatchLockFp, 'test setup: could not open the dispatcher lock');
+		$this->assertTrue(flock($this->dispatchLockFp, LOCK_EX), 'test setup: could not hold the dispatcher lock');
+	}
+
+	private function holdFeedPassLock(): void
+	{
+		$this->feedLockFp = fopen("{$this->dbdir}/pfb_feed_pass.lock", 'c');
+		$this->assertIsResource($this->feedLockFp, 'test setup: could not open the feed-pass lock');
+		$this->assertTrue(flock($this->feedLockFp, LOCK_EX), 'test setup: could not hold the feed-pass lock');
+	}
+
+	/** The syslog messages captured by the logger() double, one per line. */
+	private function syslogMessages(): string
+	{
+		return implode("\n", array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'));
+	}
+
+	private static function cronTrigger(): array
+	{
+		return ['scope' => 'both', 'force' => FALSE, 'trigger' => 'cron'];
+	}
+
+	// -----------------------------------------------------------------------
+	// RED rows: the unattended tick dispatch must exit cleanly on deferral.
+	// -----------------------------------------------------------------------
+
+	public function testCronTriggerDispatcherDeferralExitsCleanly(): void
+	{
+		$this->holdDispatcherLock();
+
+		$result = sync_package_pfblockerng(self::cronTrigger());
+
+		$this->assertStringContainsString('dispatcher lock unavailable', $this->mainLog(),
+			'before-state: the run must actually have taken the dispatcher-deferral path');
+		$this->assertTrue(pfb_pending_changes(),
+			'the durable retry marker must survive the benign deferral (the next tick retries)');
+		$this->assertTrue($result,
+			'a deferred trigger=cron pass retains its retry state — pfb_trigger must exit 0 (issue #2505)');
+	}
+
+	public function testCronTriggerFeedPassDeferralExitsCleanly(): void
+	{
+		$this->holdFeedPassLock();
+
+		$result = sync_package_pfblockerng(self::cronTrigger());
+
+		$this->assertStringContainsString('Feed pass [ sync ] skipped', $this->mainLog(),
+			'before-state: the run must actually have taken the feed-pass deferral path');
+		$this->assertTrue(pfb_pending_changes(),
+			'the durable retry marker must survive the benign deferral (the next tick retries)');
+		$this->assertTrue($result,
+			'a deferred trigger=cron pass retains its retry state — pfb_trigger must exit 0 (issue #2505)');
+	}
+
+	// -----------------------------------------------------------------------
+	// RED rows: a dispatcher-lock deferral must raise a syslog notice
+	// (feed-pass parity — pfb_feed_pass_begin() already does).
+	// -----------------------------------------------------------------------
+
+	public function testSyncFunnelDispatcherDeferralRaisesSyslogNotice(): void
+	{
+		$this->holdDispatcherLock();
+
+		sync_package_pfblockerng(self::cronTrigger());
+
+		$this->assertStringContainsString('dispatcher lock', $this->syslogMessages(),
+			'a wedged dispatcher-lock holder must be visible on syslog, not only in pfblockerng.log (issue #2505)');
+	}
+
+	public function testCronFunnelDispatcherDeferralRaisesSyslogNotice(): void
+	{
+		$this->holdDispatcherLock();
+
+		$this->assertTrue(pfblockerng_sync_cron(),
+			'before-state sanity: the cron verb already exits cleanly on this deferral (issue #2491)');
+		$this->assertStringContainsString('dispatcher lock unavailable', $this->mainLog(),
+			'before-state: the run must actually have taken the dispatcher-deferral path');
+		$this->assertStringContainsString('dispatcher lock', $this->syslogMessages(),
+			'a wedged dispatcher-lock holder must be visible on syslog, not only in pfblockerng.log (issue #2505)');
+	}
+
+	// -----------------------------------------------------------------------
+	// Guard rows (green before AND after): operator-initiated requests keep
+	// reporting the deferral.
+	// -----------------------------------------------------------------------
+
+	public function testManualTriggerDispatcherDeferralStaysObservable(): void
+	{
+		$this->holdDispatcherLock();
+
+		$result = sync_package_pfblockerng(['scope' => 'both', 'force' => FALSE, 'trigger' => 'manual']);
+
+		$this->assertStringContainsString('dispatcher lock unavailable', $this->mainLog(),
+			'before-state: the run must actually have taken the dispatcher-deferral path');
+		$this->assertFalse($result,
+			'an operator-initiated request that got no pass must keep exiting 1');
+	}
+
+	public function testForcedCronTriggerFeedPassDeferralStaysObservable(): void
+	{
+		$this->holdFeedPassLock();
+
+		$result = sync_package_pfblockerng(['scope' => 'both', 'force' => TRUE, 'trigger' => 'cron']);
+
+		$this->assertStringContainsString('Feed pass [ sync ] skipped', $this->mainLog(),
+			'before-state: the run must actually have taken the feed-pass deferral path');
+		$this->assertFalse($result,
+			'force=true means an operator asked for work NOW — a deferral must keep exiting 1');
+	}
+}

--- a/tests/php/TriggerFunnelDeferralExitCodeTest.php
+++ b/tests/php/TriggerFunnelDeferralExitCodeTest.php
@@ -149,6 +149,26 @@ final class TriggerFunnelDeferralExitCodeTest extends TestCase
 		return implode("\n", array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'));
 	}
 
+	/**
+	 * Assert one captured syslog entry matches the dispatcher-deferral notice —
+	 * message AND priority, so a LOG_NOTICE -> other-priority regression fails too
+	 * (feed-pass parity is specifically LOG_NOTICE, per pfb_feed_pass_begin()).
+	 */
+	private function assertDispatcherDeferralNotice(): void
+	{
+		$this->assertStringContainsString('dispatcher lock', $this->syslogMessages(),
+			'a wedged dispatcher-lock holder must be visible on syslog, not only in pfblockerng.log (issue #2505)');
+		$priorities = [];
+		foreach ($GLOBALS['pfb_test_logger_calls'] ?? [] as $call) {
+			if (str_contains($call['message'], 'dispatcher lock')) {
+				$priorities[] = $call['priority'];
+			}
+		}
+		$this->assertContains(LOG_NOTICE, $priorities,
+			'the dispatcher-lock deferral notice must be LOG_NOTICE (feed-pass parity) — got priorities: '
+			. var_export($priorities, TRUE));
+	}
+
 	private static function cronTrigger(): array
 	{
 		return ['scope' => 'both', 'force' => FALSE, 'trigger' => 'cron'];
@@ -197,8 +217,7 @@ final class TriggerFunnelDeferralExitCodeTest extends TestCase
 
 		sync_package_pfblockerng(self::cronTrigger());
 
-		$this->assertStringContainsString('dispatcher lock', $this->syslogMessages(),
-			'a wedged dispatcher-lock holder must be visible on syslog, not only in pfblockerng.log (issue #2505)');
+		$this->assertDispatcherDeferralNotice();
 	}
 
 	public function testCronFunnelDispatcherDeferralRaisesSyslogNotice(): void
@@ -209,8 +228,7 @@ final class TriggerFunnelDeferralExitCodeTest extends TestCase
 			'before-state sanity: the cron verb already exits cleanly on this deferral (issue #2491)');
 		$this->assertStringContainsString('dispatcher lock unavailable', $this->mainLog(),
 			'before-state: the run must actually have taken the dispatcher-deferral path');
-		$this->assertStringContainsString('dispatcher lock', $this->syslogMessages(),
-			'a wedged dispatcher-lock holder must be visible on syslog, not only in pfblockerng.log (issue #2505)');
+		$this->assertDispatcherDeferralNotice();
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2505. Follow-up to PR #2504 (issue #2491).

## Problem

PR #2504 made the deprecated `cron` verb report a benign lock deferral as success while Force Check keeps reporting it. The modern, ADR-43-documented `pfb_trigger` funnel was left behind: its identical deferral guards in `sync_package_pfblockerng()` still returned `FALSE`, which `pfblockerng.php` turns into `exit 1` — so the unattended tick dispatch (`pfb_trigger scope=... force=false trigger=cron`) reported failure whenever another pass held the dispatcher or feed-pass lock, even though the pass stood down with its durable retry state intact and the next tick retries.

Additionally (the #2504 review nitpick), a dispatcher-lock deferral wrote one line to `/var/log/pfblockerng/pfblockerng.log` and nothing to syslog — unlike the feed-pass guard (`pfb_feed_pass_begin()` raises `LOG_NOTICE`) — so a live wedged lock holder was quiet on that path.

## Decision (owner-directed: "fix and land 2505")

- The caller's intent is expressed by the explicit request already threaded through the array API: a deferral is benign **only** for `trigger === 'cron' && !force` — the tick's own dispatch shape. Both lock-deferral guards in `sync_package_pfblockerng()` now return that discriminator instead of a hard `FALSE`.
- Everything operator-initiated keeps reporting the deferral: `trigger=manual`, `trigger=force`, any `force=true`, the GUI Save `''` string path (pinned by `SyncFeedPassDeferralTest`, unchanged), and the deprecated string verbs.
- Escalation signal: both sync funnels' dispatcher-lock deferrals now raise a `LOG_NOTICE` syslog line (feed-pass parity). No escalation counter — one visible notice per deferred pass matches the existing feed-pass guard's behaviour.

## Changes

- `src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc` — compute the benign-deferral discriminator from the array request; both lock guards return it; dispatcher guard gains the syslog notice.
- `src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc` — dispatcher-lock deferral gains the syslog notice (`cron`/`forcecheck` labelled).
- `tests/php/TriggerFunnelDeferralExitCodeTest.php` — new; 6 rows.

## Red→green proof

`tests/php/TriggerFunnelDeferralExitCodeTest.php` executed RED on untouched code (`git hash-object` = `d97ac3426a62217111c071a4b5d4774d542b7584`):

```
1) testCronTriggerDispatcherDeferralExitsCleanly — Failed asserting that false is true.
2) testCronTriggerFeedPassDeferralExitsCleanly — Failed asserting that false is true.
3) testSyncFunnelDispatcherDeferralRaisesSyslogNotice — '' does not contain "dispatcher lock"
4) testCronFunnelDispatcherDeferralRaisesSyslogNotice — '' does not contain "dispatcher lock"
Tests: 6, Assertions: 26, Failures: 4.
```

Frozen byte-identical (hash re-verified at green), then GREEN together with the sibling deferral suites (`SyncFeedPassDeferralTest`, `CronDeferralExitCodeTest`, `SyncCronFeedPassDeferralTest`, `TickFeedPassDeferralTest`): `OK (21 tests, 91 assertions)`. The two operator rows are before-state guards, green on both sides; every deferral row also asserts the deferral log line so no row can pass through the boot/install early-return.

Gates: `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (phpunit, phpstan, phpcs, php -l).

No `www/` surface touched; exit-code and syslog behaviour only, covered by the PHPUnit rows above.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled feed synchronization when another process is already running.
  * Deferred unattended scheduled runs now exit successfully while preserving a retry marker for the next opportunity.
  * Manual and forced requests continue to report deferrals as failures for visibility.
  * Added system notices identifying deferred scheduled passes, including forced checks and regular cron runs.
  * Recovery, publishing, and GeoIP generation failures continue to be reported unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->