### PR TITLE
smoke: bootstrap ports clone into an empty pre-created dir

### DIFF
--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -31,9 +31,11 @@ Pool is `pfb-box-1` … `pfb-box-8`, Debian 13 (trixie), x86_64.
   Boxes currently carry **uv 0.12.3** and **oras 1.3.3** — the same oras pin the
   workflows use, so a box and a runner agree.
 - Guest SSH key (baked into smoke images) at `/root/smoke-ssh-key`.
-- pfBlockerNG clone at `/root/pfBlockerNG`. The orchestrator's bootstrap only
-  `cd`s into it, fetches `--ref`, and checks out `FETCH_HEAD` — it never clones, so a
-  fresh box needs a one-time `git clone https://github.com/pfBlockerNG/pfBlockerNG
+- pfBlockerNG clone at `/root/pfBlockerNG`, with its remote named `origin` (the
+  default unless `--git-remote`/`PFB_GIT_REMOTE` says otherwise). The orchestrator's
+  bootstrap only `cd`s into it, narrows the sparse checkout, fetches `--ref` plus the
+  `ci-metadata` ref, and checks out `FETCH_HEAD` — it never clones, so a fresh box
+  needs a one-time `git clone https://github.com/pfBlockerNG/pfBlockerNG
   /root/pfBlockerNG` (any branch; every run re-points it at the ref under test).
 - FreeBSD-ports checkout under `/root/FreeBSD-ports` (auto-cloned/updated by
   `smoke-on-box.sh`; an absent — or empty — directory self-bootstraps via

--- a/docs/misc/local-smoke-debian.md
+++ b/docs/misc/local-smoke-debian.md
@@ -31,7 +31,13 @@ Pool is `pfb-box-1` … `pfb-box-8`, Debian 13 (trixie), x86_64.
   Boxes currently carry **uv 0.12.3** and **oras 1.3.3** — the same oras pin the
   workflows use, so a box and a runner agree.
 - Guest SSH key (baked into smoke images) at `/root/smoke-ssh-key`.
-- FreeBSD-ports checkout under `/root/FreeBSD-ports` (auto-cloned/updated by `smoke-on-box.sh`).
+- pfBlockerNG clone at `/root/pfBlockerNG`. The orchestrator's bootstrap only
+  `cd`s into it, fetches `--ref`, and checks out `FETCH_HEAD` — it never clones, so a
+  fresh box needs a one-time `git clone https://github.com/pfBlockerNG/pfBlockerNG
+  /root/pfBlockerNG` (any branch; every run re-points it at the ref under test).
+- FreeBSD-ports checkout under `/root/FreeBSD-ports` (auto-cloned/updated by
+  `smoke-on-box.sh`; an absent — or empty — directory self-bootstraps via
+  `sparse-clone-ports.sh`, issue #2490).
 
 Image storage is not a box prerequisite. Each workload clears and pulls its selected
 pfSense image (and civm image unless `--no-two-vm`) into

--- a/scripts/sparse-clone-ports.sh
+++ b/scripts/sparse-clone-ports.sh
@@ -13,7 +13,8 @@
 #   REF        branch, tag, or full 40-hex commit SHA to fetch (e.g. pfblockerng/use-github)
 #   DEST       destination directory — created (fresh clone) if absent or an empty
 #              directory; an EXISTING git work-tree is fetched + checked out at REF
-#              (idempotent reuse); a non-empty non-git DEST is refused
+#              (idempotent reuse); any other existing DEST (non-empty directory,
+#              or a non-directory of any kind) is refused
 #   CHANNEL    build-pkg-portable --channel value (stable|testing|edge|nightly)
 #   PHP        build-pkg-portable --php value (e.g. 8.3)
 #   PYFLAVOR   build-pkg-portable --py-flavor value (e.g. py311)

--- a/scripts/sparse-clone-ports.sh
+++ b/scripts/sparse-clone-ports.sh
@@ -11,8 +11,9 @@
 #
 #   URL        FreeBSD-ports HTTPS clone URL
 #   REF        branch, tag, or full 40-hex commit SHA to fetch (e.g. pfblockerng/use-github)
-#   DEST       destination directory — created (fresh clone) if absent; an EXISTING
-#              git work-tree is fetched + checked out at REF (idempotent reuse)
+#   DEST       destination directory — created (fresh clone) if absent or an empty
+#              directory; an EXISTING git work-tree is fetched + checked out at REF
+#              (idempotent reuse); a non-empty non-git DEST is refused
 #   CHANNEL    build-pkg-portable --channel value (stable|testing|edge|nightly)
 #   PHP        build-pkg-portable --php value (e.g. 8.3)
 #   PYFLAVOR   build-pkg-portable --py-flavor value (e.g. py311)
@@ -77,7 +78,11 @@ if [ -e "${DEST}/.git" ]; then
 	git -C "$DEST" remote set-url origin "$URL" 2>/dev/null || git -C "$DEST" remote add origin "$URL"
 	git -C "$DEST" fetch --depth 1 --filter=blob:none origin "$REF"
 	co_target=FETCH_HEAD
-elif [ -e "$DEST" ]; then
+elif [ -e "$DEST" ] && { [ ! -d "$DEST" ] || [ -n "$(ls -A "$DEST")" ]; }; then
+	# Refuse only when there is something to protect. An EMPTY directory (issue #2490:
+	# historically Docker's bind-mount side effect, generally any mkdir that beat the
+	# first run) falls through to the fresh-clone branches below, which both tolerate
+	# an existing empty DEST.
 	printf '%s: %s exists but is not a git work-tree — refusing to overwrite\n' "$0" "$DEST" >&2
 	exit 1
 elif _pfb_is_full_sha "$REF"; then

--- a/tests/shell/sparse_clone_ports_spec.sh
+++ b/tests/shell/sparse_clone_ports_spec.sh
@@ -179,6 +179,20 @@ PYEOF
     The output should include 'not a git work-tree'
   End
 
+  # issue #2490: an EMPTY pre-created DEST (historically Docker's bind-mount side effect,
+  # generally any `mkdir` that beat the first run) carries nothing to protect — it must take
+  # the fresh-clone path, not the refuse-foreign one, or a fresh box can never self-bootstrap.
+  empty_dir_result() {
+    mkdir -p "$DEST"
+    run_clone >/dev/null 2>&1 || { echo "script-failed=$?"; return 1; }
+    if is_build_input_variant; then echo 'variant=usegithub'; else echo 'variant=stub'; fi
+  }
+  It 'fresh-clone-into-empty: an empty pre-created DEST clones as if absent (issue #2490)'
+    When call empty_dir_result
+    The status should be success
+    The output should equal 'variant=usegithub'
+  End
+
   # ── REF-shape hostile inputs (issue #1676) ────────────────────────────────
   #
   # None of these REF values may be misclassified as a full 40-hex SHA — each must take


### PR DESCRIPTION
## Problem

Issue #2490: `scripts/sparse-clone-ports.sh` refuses any existing non-git `DEST`, including an **empty** pre-created directory. At the time the issue was filed, `local-smoke.sh` bind-mounted `/root/FreeBSD-ports` into the smoke container, and Docker creates a missing bind-mount source as an empty directory — so on a fresh box the fresh-clone branch was unreachable and the first run always died with:

```
scripts/sparse-clone-ports.sh: /root/FreeBSD-ports exists but is not a git work-tree — refusing to overwrite
```

The bind mount has since been removed by the de-containerisation work (#2513), so the *automatic* producer of the empty directory is gone — but the refusal itself remains wrong for an empty directory (any `mkdir` that beats the first run reproduces the dead end), and the issue's suggested fix stands.

## Fix

Treat an existing but **empty** directory as absent: it carries nothing to protect, and both fresh-clone branches (`git clone` and the fetch-by-oid path) already tolerate an existing empty `DEST`. A non-empty non-git `DEST` is still refused, unchanged.

## Docs

`docs/misc/local-smoke-debian.md` box-prerequisites: the issue also notes the `/root/pfBlockerNG` clone is assumed but never documented — the orchestrator bootstrap only `cd`s into it and fetches; it never clones. Added that prerequisite, and noted that `/root/FreeBSD-ports` now truly self-bootstraps (absent or empty).

## Tests

New `fresh-clone-into-empty` example in `tests/shell/sparse_clone_ports_spec.sh`: executed RED on the unmodified script (`script-failed=1`, refusal branch), spec frozen byte-identical (sha256 `d79e8864217c…`), GREEN after the fix (19 examples, 0 failures). The pre-existing `refuse-foreign` example pins that the non-empty refusal survives.

Part of #2490

🤖 Generated with [Claude Code](https://claude.com/claude-code)
