### PR TITLE
Keep semantic Graphify state separate from views

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -21,9 +21,11 @@ Load when: every agent session, from `AGENTS.md`.
   the reported source SHA; run `graphify-store.py seed`, the full Graphify update
   skill, then `graphify-store.py publish`; release/remove the builder and retry
   `work-branch.sh`. Each agent worktree receives its own snapshot copy.
-- After relevant classified-source changes, run `update_graphify_views.py` in that
-  worktree. Query `graphify-out/current/graph.json` (investigation) by default;
-  use `current/runtime/graph.json` for ownership and `current/agent-context/graph.json`
+- The full semantic Graphify update remains skill-owned at `graphify-out/` (and in
+  the opaque local Graphify store). After relevant classified-source changes, run
+  `update_graphify_views.py` in that worktree. Query
+  `graphify-out/views/current/graph.json` (investigation) by default; use
+  `current/runtime/graph.json` for ownership and `current/agent-context/graph.json`
   for process improvement; follow `target_view`/`source_file` references.
 - LSP/Serena language-semantic relationships override structurally inferred
   CodeGraph edges. Compiler, static analysis, tests, CI, and live smoke remain final.

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,7 +3,7 @@
   // `.markdownlint.jsonc`. Run from the repo root: `npx markdownlint-cli2`
   // (add `--fix` to auto-fix). Lints maintained Markdown and skips historical,
   // dependency/virtualenv trees and duplicate adapter paths.
-  "globs": ["**/*.md"],
+  "globs": ["**/*.md", "!graphify-out/**"],
   "ignores": [
     "node_modules",
     "**/node_modules/**",

--- a/scripts/agent/update_graphify_views.py
+++ b/scripts/agent/update_graphify_views.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build Graphify's ownership-separated views from one extraction.
+"""Build Graphify's ownership-separated views from an existing semantic graph.
 
 The ownership map is deliberately data, not Python.  Classification is first-match
 ordered, while bridge and investigation graphs are derived from the same namespaced
@@ -12,7 +12,6 @@ import argparse
 import ast
 import contextlib
 import fnmatch
-import importlib.util
 import json
 import os
 import re
@@ -22,7 +21,7 @@ import sys
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 ROOT = Path(__file__).resolve().parents[2]
 CONFIG_PATH = Path(__file__).with_name("graphify-views.json")
@@ -33,10 +32,6 @@ ALL_VIEWS = SOURCE_VIEWS + ("unclassified",) + DERIVED_VIEWS
 
 class GraphifyViewsError(ValueError):
     """Invalid ownership input or graph data."""
-
-
-class BootstrapError(RuntimeError):
-    """Graphify is not available for extraction."""
 
 
 def _path(value: str | Path) -> str:
@@ -921,56 +916,21 @@ def _read_sources(root: Path, paths: Iterable[str]) -> dict[str, str]:
     return result
 
 
-def _reexec_graphify_python() -> None:
-    """Use the per-graph virtualenv when the host interpreter lacks Graphify."""
+def _semantic_graph(root: Path, explicit_input: Path | None) -> dict[str, Any]:
+    """Load Graphify's full semantic graph without invoking Graphify extraction."""
 
-    if os.environ.get("PFB_GRAPHIFY_REEXEC") == "1":
-        return
-    if importlib.util.find_spec("graphify") is not None:
-        return
-    pointer = ROOT / "graphify-out" / ".graphify_python"
-    if pointer.exists():
-        executable = pointer.read_text(encoding="utf-8").strip()
-        if executable and Path(executable).is_file():
-            environment = dict(os.environ, PFB_GRAPHIFY_REEXEC="1")
-            os.execve(executable, [executable, str(Path(__file__).resolve()), *sys.argv[1:]], environment)
-    raise BootstrapError(
-        "Graphify is unavailable. Bootstrap graphify-out/.graphify_python or install Graphify, then rerun "
-        "scripts/agent/update_graphify_views.py"
-    )
-
-
-def _collect_graphify_paths(
-    root: Path,
-    tracked_paths: Iterable[str],
-    config: Mapping[str, Any],
-    collector: Callable[..., list[Path]] | None = None,
-) -> list[Path]:
-    """Collect only already-classified tracked files for one Graphify pass."""
-
-    if collector is None:
-        from graphify import collect_files
-
-        collector = collect_files
-    collected: set[Path] = set()
-    accepted = (path for path in tracked_paths if _classify_path_unchecked(path, config) in SOURCE_VIEWS)
-    for relative in accepted:
-        target = root / relative
-        collected.update(collector(target, root=root))
-    return sorted(collected)
-
-
-def _extract_graph(
-    root: Path,
-    tracked_paths: Sequence[str],
-    config: Mapping[str, Any],
-    cache_root: Path,
-) -> dict[str, Any]:
-    _reexec_graphify_python()
-    from graphify.extract import extract
-
-    paths = _collect_graphify_paths(root, tracked_paths, config)
-    return extract(paths, root=root, cache_root=cache_root, parallel=False)
+    path = explicit_input or root / "graphify-out" / "graph.json"
+    if explicit_input is None and not path.is_file():
+        raise GraphifyViewsError(
+            f"semantic Graphify graph is missing at {path}; run the full Graphify skill before updating views"
+        )
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GraphifyViewsError(f"cannot read semantic Graphify graph {path}: {exc}") from exc
+    if not isinstance(value, Mapping):
+        raise GraphifyViewsError(f"semantic Graphify graph must be a JSON object: {path}")
+    return dict(value)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -978,18 +938,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--repo-root", type=Path, default=ROOT)
     parser.add_argument("--config", type=Path, default=CONFIG_PATH)
     parser.add_argument("--output", type=Path, default=None)
-    parser.add_argument("--input", type=Path, help="use an existing Graphify JSON extraction")
+    parser.add_argument("--input", type=Path, help="use an explicit existing Graphify JSON graph")
     args = parser.parse_args(argv)
     config = load_config(args.config)
     root = args.repo_root.resolve()
+    graph = _semantic_graph(root, args.input)
     tracked = _tracked_paths(root, config)
-    output_root = args.output or root / "graphify-out"
-    cache_root = output_root / "cache"
-    graph = (
-        json.loads(args.input.read_text(encoding="utf-8"))
-        if args.input
-        else _extract_graph(root, tracked, config, cache_root)
-    )
+    output_root = args.output or root / "graphify-out" / "views"
     source_texts = _read_sources(root, tracked)
     commit = subprocess.run(
         ["git", "-C", str(root), "rev-parse", "HEAD"],
@@ -1006,6 +961,6 @@ def main(argv: Sequence[str] | None = None) -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
-    except (BootstrapError, GraphifyViewsError, OSError, subprocess.CalledProcessError) as exc:
+    except (GraphifyViewsError, OSError, subprocess.CalledProcessError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         raise SystemExit(2)

--- a/scripts/agent/update_graphify_views.py
+++ b/scripts/agent/update_graphify_views.py
@@ -946,10 +946,15 @@ def _semantic_graph(root: Path, explicit_input: Path | None, commit: str) -> dic
     for index, edge in enumerate(links):
         if not isinstance(edge, Mapping):
             raise GraphifyViewsError(f"semantic graph edge {index} must be an object")
-        for endpoint in ("source", "target"):
+
+        def usable(endpoint: str) -> bool:
             endpoint_value = edge.get(endpoint)
-            if endpoint_value is None or isinstance(endpoint_value, (Mapping, list)) or not str(endpoint_value).strip():
-                raise GraphifyViewsError(f"semantic graph edge {index} has no usable {endpoint}")
+            return not (
+                endpoint_value is None or isinstance(endpoint_value, (Mapping, list)) or not str(endpoint_value).strip()
+            )
+
+        if not ((usable("source") and usable("target")) or (usable("from") and usable("to"))):
+            raise GraphifyViewsError(f"semantic graph edge {index} requires source/target or from/to")
     if value.get("built_at_commit") != commit:
         raise GraphifyViewsError(
             "semantic graph provenance does not match current HEAD; run the full Graphify skill before updating views"
@@ -966,6 +971,15 @@ def _current_commit(root: Path) -> str:
     ).stdout.strip()
 
 
+def _require_clean_tracked_tree(root: Path) -> None:
+    for diff_args in (("diff", "--quiet"), ("diff", "--cached", "--quiet")):
+        result = subprocess.run(["git", "-C", str(root), *diff_args], check=False)
+        if result.returncode == 1:
+            raise GraphifyViewsError("tracked Git tree is dirty; commit or stash tracked changes before updating views")
+        if result.returncode != 0:
+            raise subprocess.CalledProcessError(result.returncode, ["git", "-C", str(root), *diff_args])
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path, default=ROOT)
@@ -976,10 +990,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     config = load_config(args.config)
     root = args.repo_root.resolve()
     output_root = args.output or root / "graphify-out" / "views"
+    canonical_input = (root / "graphify-out" / "graph.json").resolve(strict=False)
     semantic_input = (args.input or root / "graphify-out" / "graph.json").resolve(strict=False)
     commit = _current_commit(root)
+    _require_clean_tracked_tree(root)
     graph = _semantic_graph(root, args.input, commit)
-    if (output_root / "graph.json").resolve(strict=False) == semantic_input:
+    output_graph = (output_root / "graph.json").resolve(strict=False)
+    if output_graph in {semantic_input, canonical_input}:
         raise GraphifyViewsError(f"output {output_root} overlaps semantic graph {semantic_input}")
     tracked = _tracked_paths(root, config)
     source_texts = _read_sources(root, tracked)

--- a/scripts/agent/update_graphify_views.py
+++ b/scripts/agent/update_graphify_views.py
@@ -189,6 +189,11 @@ def _endpoint(edge: Mapping[str, Any], side: str) -> str | None:
     return str(value) if value is not None else None
 
 
+def _usable_endpoint(edge: Mapping[str, Any], key: str) -> bool:
+    value = edge.get(key)
+    return not (value is None or isinstance(value, (Mapping, list)) or not str(value).strip())
+
+
 def _graph(
     nodes: Iterable[Mapping[str, Any]],
     links: Iterable[Mapping[str, Any]],
@@ -916,10 +921,14 @@ def _read_sources(root: Path, paths: Iterable[str]) -> dict[str, str]:
     return result
 
 
+def _canonical_graph_path(root: Path) -> Path:
+    return root / "graphify-out" / "graph.json"
+
+
 def _semantic_graph(root: Path, explicit_input: Path | None, commit: str) -> dict[str, Any]:
     """Load Graphify's full semantic graph without invoking Graphify extraction."""
 
-    path = explicit_input or root / "graphify-out" / "graph.json"
+    path = explicit_input or _canonical_graph_path(root)
     if explicit_input is None and not path.is_file():
         raise GraphifyViewsError(
             f"semantic Graphify graph is missing at {path}; run the full Graphify skill before updating views"
@@ -947,13 +956,10 @@ def _semantic_graph(root: Path, explicit_input: Path | None, commit: str) -> dic
         if not isinstance(edge, Mapping):
             raise GraphifyViewsError(f"semantic graph edge {index} must be an object")
 
-        def usable(endpoint: str) -> bool:
-            endpoint_value = edge.get(endpoint)
-            return not (
-                endpoint_value is None or isinstance(endpoint_value, (Mapping, list)) or not str(endpoint_value).strip()
-            )
-
-        if not ((usable("source") and usable("target")) or (usable("from") and usable("to"))):
+        if not (
+            (_usable_endpoint(edge, "source") and _usable_endpoint(edge, "target"))
+            or (_usable_endpoint(edge, "from") and _usable_endpoint(edge, "to"))
+        ):
             raise GraphifyViewsError(f"semantic graph edge {index} requires source/target or from/to")
     if value.get("built_at_commit") != commit:
         raise GraphifyViewsError(
@@ -989,14 +995,21 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     config = load_config(args.config)
     root = args.repo_root.resolve()
+    canonical_input = _canonical_graph_path(root).resolve(strict=False)
     output_root = args.output or root / "graphify-out" / "views"
-    canonical_input = (root / "graphify-out" / "graph.json").resolve(strict=False)
-    semantic_input = (args.input or root / "graphify-out" / "graph.json").resolve(strict=False)
+    semantic_input = (args.input or _canonical_graph_path(root)).resolve(strict=False)
     commit = _current_commit(root)
     _require_clean_tracked_tree(root)
     graph = _semantic_graph(root, args.input, commit)
     output_graph = (output_root / "graph.json").resolve(strict=False)
-    if output_graph in {semantic_input, canonical_input}:
+    canonical_root = canonical_input.parent
+    canonical_views = (canonical_root / "views").resolve(strict=False)
+    resolved_output = output_root.resolve(strict=False)
+    output_inside_canonical = canonical_root == resolved_output or canonical_root in resolved_output.parents
+    output_ancestor_of_canonical = resolved_output in canonical_root.parents
+    if output_graph in {semantic_input, canonical_input} or (
+        resolved_output != canonical_views and (output_inside_canonical or output_ancestor_of_canonical)
+    ):
         raise GraphifyViewsError(f"output {output_root} overlaps semantic graph {semantic_input}")
     tracked = _tracked_paths(root, config)
     source_texts = _read_sources(root, tracked)

--- a/scripts/agent/update_graphify_views.py
+++ b/scripts/agent/update_graphify_views.py
@@ -916,7 +916,7 @@ def _read_sources(root: Path, paths: Iterable[str]) -> dict[str, str]:
     return result
 
 
-def _semantic_graph(root: Path, explicit_input: Path | None) -> dict[str, Any]:
+def _semantic_graph(root: Path, explicit_input: Path | None, commit: str) -> dict[str, Any]:
     """Load Graphify's full semantic graph without invoking Graphify extraction."""
 
     path = explicit_input or root / "graphify-out" / "graph.json"
@@ -929,8 +929,41 @@ def _semantic_graph(root: Path, explicit_input: Path | None) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError) as exc:
         raise GraphifyViewsError(f"cannot read semantic Graphify graph {path}: {exc}") from exc
     if not isinstance(value, Mapping):
-        raise GraphifyViewsError(f"semantic Graphify graph must be a JSON object: {path}")
+        raise GraphifyViewsError(f"semantic graph must be a JSON object: {path}")
+    nodes = value.get("nodes")
+    if not isinstance(nodes, list):
+        raise GraphifyViewsError("semantic graph nodes must be a list")
+    for index, node in enumerate(nodes):
+        if not isinstance(node, Mapping):
+            raise GraphifyViewsError(f"semantic graph node {index} must be an object")
+        node_id = node.get("id")
+        if node_id is None or isinstance(node_id, (Mapping, list)) or not str(node_id).strip():
+            raise GraphifyViewsError(f"semantic graph node {index} has no usable id")
+    link_key = "links" if "links" in value else "edges" if "edges" in value else None
+    links = value.get(link_key) if link_key else None
+    if not isinstance(links, list):
+        raise GraphifyViewsError("semantic graph requires a links or edges list")
+    for index, edge in enumerate(links):
+        if not isinstance(edge, Mapping):
+            raise GraphifyViewsError(f"semantic graph edge {index} must be an object")
+        for endpoint in ("source", "target"):
+            endpoint_value = edge.get(endpoint)
+            if endpoint_value is None or isinstance(endpoint_value, (Mapping, list)) or not str(endpoint_value).strip():
+                raise GraphifyViewsError(f"semantic graph edge {index} has no usable {endpoint}")
+    if value.get("built_at_commit") != commit:
+        raise GraphifyViewsError(
+            "semantic graph provenance does not match current HEAD; run the full Graphify skill before updating views"
+        )
     return dict(value)
+
+
+def _current_commit(root: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -942,16 +975,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     config = load_config(args.config)
     root = args.repo_root.resolve()
-    graph = _semantic_graph(root, args.input)
-    tracked = _tracked_paths(root, config)
     output_root = args.output or root / "graphify-out" / "views"
+    semantic_input = (args.input or root / "graphify-out" / "graph.json").resolve(strict=False)
+    commit = _current_commit(root)
+    graph = _semantic_graph(root, args.input, commit)
+    if (output_root / "graph.json").resolve(strict=False) == semantic_input:
+        raise GraphifyViewsError(f"output {output_root} overlaps semantic graph {semantic_input}")
+    tracked = _tracked_paths(root, config)
     source_texts = _read_sources(root, tracked)
-    commit = subprocess.run(
-        ["git", "-C", str(root), "rev-parse", "HEAD"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
     views = build_views(graph, config, tracked_paths=tracked, source_texts=source_texts, built_at_commit=commit)
     write_outputs(output_root, views, config)
     print(f"updated {len(views)} Graphify views under {output_root}")

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -195,6 +195,11 @@ def test_repository_intelligence_routes_worktrees_through_exact_graph_seeds() ->
     assert "graphify-out/current/graph.json" not in routing
 
 
+def test_markdownlint_excludes_generated_graphify_reports() -> None:
+    config = (ROOT / ".markdownlint-cli2.jsonc").read_text(encoding="utf-8")
+    assert '"!graphify-out/**"' in config
+
+
 def test_codegraph_generated_state_is_ignored_by_its_own_tracked_contract() -> None:
     local_ignore = (ROOT / ".codegraph/.gitignore").read_text(encoding="utf-8").splitlines()
     assert "*" in local_ignore

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -187,8 +187,12 @@ def test_repository_intelligence_routes_worktrees_through_exact_graph_seeds() ->
         "graphify-store.py seed",
         "graphify-store.py publish",
         "source SHA",
+        "graphify-out/views/current/graph.json",
+        "graphify-out/",
+        "opaque local Graphify store",
     ):
         assert contract in routing, f"Graphify worktree routing lost {contract}"
+    assert "graphify-out/current/graph.json" not in routing
 
 
 def test_codegraph_generated_state_is_ignored_by_its_own_tracked_contract() -> None:

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -188,7 +188,7 @@ def test_repository_intelligence_routes_worktrees_through_exact_graph_seeds() ->
         "graphify-store.py publish",
         "source SHA",
         "graphify-out/views/current/graph.json",
-        "graphify-out/",
+        "skill-owned at `graphify-out/`",
         "opaque local Graphify store",
     ):
         assert contract in routing, f"Graphify worktree routing lost {contract}"

--- a/tests/test_update_graphify_views.py
+++ b/tests/test_update_graphify_views.py
@@ -471,9 +471,6 @@ def _semantic_repo(tmp_path: Path, graph: dict | None = None) -> tuple[Path, str
     (repo / "src/app.py").write_text("print('runtime')\n", encoding="utf-8")
     graph_root = repo / "graphify-out"
     graph_root.mkdir()
-    (graph_root / "graph.json").write_bytes(
-        (json.dumps(graph or {"nodes": [], "links": []}, sort_keys=True) + "\n").encode()
-    )
     (graph_root / "manifest.json").write_bytes(b"semantic-manifest\n")
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.name", "Graphify test"], cwd=repo, check=True)
@@ -483,6 +480,9 @@ def _semantic_repo(tmp_path: Path, graph: dict | None = None) -> tuple[Path, str
     commit = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
     ).stdout.strip()
+    semantic_graph = dict(graph or {"nodes": [], "links": []})
+    semantic_graph["built_at_commit"] = commit
+    (graph_root / "graph.json").write_bytes((json.dumps(semantic_graph, sort_keys=True) + "\n").encode())
     return repo, commit
 
 
@@ -516,6 +516,7 @@ def test_main_explicit_input_and_output_override_defaults(tmp_path: Path) -> Non
     explicit_graph = {
         "nodes": [{"id": "runtime", "label": "explicit-input", "source_file": "src/app.py"}],
         "links": [],
+        "built_at_commit": commit,
     }
     explicit_input.write_text(json.dumps(explicit_graph), encoding="utf-8")
     output = tmp_path / "explicit-output"
@@ -536,6 +537,67 @@ def test_main_missing_default_semantic_graph_fails_before_output(tmp_path: Path)
     (repo / "graphify-out/graph.json").unlink()
 
     with pytest.raises(views.GraphifyViewsError, match="run the full Graphify skill"):
+        views.main(["--repo-root", str(repo)])
+
+    assert not (repo / "graphify-out/views").exists()
+
+
+@pytest.mark.parametrize("symlink_default", [False, True])
+def test_main_rejects_output_that_aliases_semantic_graph(tmp_path: Path, symlink_default: bool) -> None:
+    repo, _ = _semantic_repo(tmp_path)
+    semantic_graph = repo / "graphify-out/graph.json"
+    manifest = repo / "graphify-out/manifest.json"
+    before = (semantic_graph.read_bytes(), manifest.read_bytes())
+    if symlink_default:
+        (repo / "graphify-out/views").symlink_to(".")
+        args = ["--repo-root", str(repo)]
+    else:
+        args = ["--repo-root", str(repo), "--output", str(repo / "graphify-out")]
+
+    with pytest.raises(views.GraphifyViewsError, match="overlaps semantic graph"):
+        views.main(args)
+
+    assert (semantic_graph.read_bytes(), manifest.read_bytes()) == before
+    assert not (repo / "graphify-out/current").exists()
+    assert not (repo / "graphify-out/views/current").exists()
+
+
+@pytest.mark.parametrize("provenance", [None, "stale"])
+def test_main_rejects_missing_or_stale_semantic_provenance(tmp_path: Path, provenance: str | None) -> None:
+    repo, commit = _semantic_repo(tmp_path)
+    graph_path = repo / "graphify-out/graph.json"
+    graph = json.loads(graph_path.read_text())
+    if provenance is None:
+        graph.pop("built_at_commit")
+    else:
+        graph["built_at_commit"] = provenance
+    graph_path.write_text(json.dumps(graph), encoding="utf-8")
+
+    with pytest.raises(views.GraphifyViewsError, match="run the full Graphify skill"):
+        views.main(["--repo-root", str(repo)])
+
+    assert graph_path.is_file()
+    assert not (repo / "graphify-out/views").exists()
+
+
+@pytest.mark.parametrize(
+    "graph",
+    [
+        {"built_at_commit": "current", "manifest": {}},
+        {"built_at_commit": "current", "nodes": {}, "links": []},
+        {"built_at_commit": "current", "nodes": [None], "links": []},
+        {"built_at_commit": "current", "nodes": [{"id": "node"}], "links": [None]},
+        {"built_at_commit": "current", "nodes": [{"id": ""}], "links": []},
+        {"built_at_commit": "current", "nodes": [{"id": "node"}], "links": [{"source": "node"}]},
+    ],
+)
+def test_main_rejects_non_graph_semantic_inputs(tmp_path: Path, graph: dict) -> None:
+    repo, commit = _semantic_repo(tmp_path)
+    graph["built_at_commit"] = commit
+    graph_path = repo / "graphify-out/graph.json"
+    graph_path.write_text(json.dumps(graph), encoding="utf-8")
+
+    with pytest.raises(views.GraphifyViewsError, match="semantic graph"):
         views.main(["--repo-root", str(repo)])
 
     assert not (repo / "graphify-out/views").exists()

--- a/tests/test_update_graphify_views.py
+++ b/tests/test_update_graphify_views.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -117,7 +118,7 @@ def test_source_view_order_and_ambiguous_prefixes_fail_closed() -> None:
     assert not any(node["id"].endswith("unowned") for node in built["runtime"]["nodes"])
 
 
-def test_extraction_input_excludes_unclassified_files_and_keeps_artifact_nodes(tmp_path: Path) -> None:
+def test_partition_excludes_unclassified_files_and_keeps_artifact_nodes() -> None:
     config = _config()
     accepted = [
         "src/app.py",
@@ -128,19 +129,9 @@ def test_extraction_input_excludes_unclassified_files_and_keeps_artifact_nodes(t
         "uv.lock",
     ]
     unclassified = "misc/unclassified_code.py"
-    for relative in (*accepted, unclassified):
-        path = tmp_path / relative
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("placeholder", encoding="utf-8")
-    calls: list[Path] = []
-
-    def collect(target: Path, *, root: Path) -> list[Path]:
-        calls.append(target)
-        return [target]
-
-    extracted = views._collect_graphify_paths(tmp_path, [*accepted, unclassified], config, collector=collect)
-    assert extracted == sorted(tmp_path / relative for relative in accepted)
-    assert unclassified not in {path.relative_to(tmp_path).as_posix() for path in calls}
+    partition = views.partition_paths(accepted, config)
+    assert sorted(path for paths in partition.values() for path in paths) == sorted(accepted)
+    assert views.classify_path(unclassified, config) is None
     built = views.build_views({}, config, tracked_paths=accepted)
     assert all(unclassified not in node.get("source_file", "") for node in built["whole-repository"]["nodes"])
     assert {node["source_file"] for node in built["whole-repository"]["nodes"]} >= set(accepted)
@@ -471,6 +462,83 @@ def _generation_paths(root: Path) -> set[str]:
     if not generations.exists():
         return set()
     return {path.name for path in generations.iterdir() if path.is_dir() and not path.name.startswith(".stage-")}
+
+
+def _semantic_repo(tmp_path: Path, graph: dict | None = None) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "src/app.py").write_text("print('runtime')\n", encoding="utf-8")
+    graph_root = repo / "graphify-out"
+    graph_root.mkdir()
+    (graph_root / "graph.json").write_bytes(
+        (json.dumps(graph or {"nodes": [], "links": []}, sort_keys=True) + "\n").encode()
+    )
+    (graph_root / "manifest.json").write_bytes(b"semantic-manifest\n")
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Graphify test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "graphify-test@example.invalid"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "src/app.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "seed"], cwd=repo, check=True)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    return repo, commit
+
+
+def _view_output_names() -> set[str]:
+    return set(views.SOURCE_VIEWS + views.DERIVED_VIEWS)
+
+
+def test_main_uses_semantic_root_and_publishes_views_without_mutating_semantic_state(tmp_path: Path) -> None:
+    repo, commit = _semantic_repo(
+        tmp_path,
+        {"nodes": [{"id": "runtime", "label": "runtime", "source_file": "src/app.py"}], "links": []},
+    )
+    graph_path = repo / "graphify-out/graph.json"
+    manifest_path = repo / "graphify-out/manifest.json"
+    semantic_before = (graph_path.read_bytes(), manifest_path.read_bytes())
+
+    assert views.main(["--repo-root", str(repo)]) == 0
+
+    assert (graph_path.read_bytes(), manifest_path.read_bytes()) == semantic_before
+    output = repo / "graphify-out/views"
+    assert (output / "current/graph.json").is_file()
+    assert (output / "current/VIEW.json").is_file()
+    assert {path.name for path in (output / "current").iterdir()} >= _view_output_names() - {"investigation"}
+    assert json.loads((output / "current/graph.json").read_text())["built_at_commit"] == commit
+    assert not (repo / "graphify-out/current").exists()
+
+
+def test_main_explicit_input_and_output_override_defaults(tmp_path: Path) -> None:
+    repo, commit = _semantic_repo(tmp_path)
+    explicit_input = tmp_path / "input.json"
+    explicit_graph = {
+        "nodes": [{"id": "runtime", "label": "explicit-input", "source_file": "src/app.py"}],
+        "links": [],
+    }
+    explicit_input.write_text(json.dumps(explicit_graph), encoding="utf-8")
+    output = tmp_path / "explicit-output"
+
+    assert views.main(["--repo-root", str(repo), "--input", str(explicit_input), "--output", str(output)]) == 0
+
+    assert (output / "current/graph.json").is_file()
+    assert json.loads((output / "current/graph.json").read_text())["built_at_commit"] == commit
+    assert any(
+        node.get("label") == "explicit-input"
+        for node in json.loads((output / "current/runtime/graph.json").read_text())["nodes"]
+    )
+    assert not (repo / "graphify-out/views").exists()
+
+
+def test_main_missing_default_semantic_graph_fails_before_output(tmp_path: Path) -> None:
+    repo, _ = _semantic_repo(tmp_path)
+    (repo / "graphify-out/graph.json").unlink()
+
+    with pytest.raises(views.GraphifyViewsError, match="run the full Graphify skill"):
+        views.main(["--repo-root", str(repo)])
+
+    assert not (repo / "graphify-out/views").exists()
 
 
 def test_write_outputs_switches_one_generation_and_malformed_config_preserves_it(tmp_path: Path) -> None:

--- a/tests/test_update_graphify_views.py
+++ b/tests/test_update_graphify_views.py
@@ -562,6 +562,45 @@ def test_main_rejects_output_that_aliases_semantic_graph(tmp_path: Path, symlink
     assert not (repo / "graphify-out/views/current").exists()
 
 
+def test_main_rejects_canonical_output_alias_with_external_input(tmp_path: Path) -> None:
+    repo, commit = _semantic_repo(tmp_path)
+    canonical_graph = repo / "graphify-out/graph.json"
+    manifest = repo / "graphify-out/manifest.json"
+    explicit_input = tmp_path / "semantic-input.json"
+    explicit_graph = {
+        "nodes": [{"id": "runtime", "source_file": "src/app.py"}],
+        "links": [],
+        "built_at_commit": commit,
+    }
+    explicit_input.write_text(json.dumps(explicit_graph), encoding="utf-8")
+    before = (canonical_graph.read_bytes(), manifest.read_bytes(), explicit_input.read_bytes())
+
+    with pytest.raises(views.GraphifyViewsError, match="overlaps semantic graph"):
+        views.main(["--repo-root", str(repo), "--input", str(explicit_input), "--output", str(repo / "graphify-out")])
+
+    assert (canonical_graph.read_bytes(), manifest.read_bytes(), explicit_input.read_bytes()) == before
+    assert not (repo / "graphify-out/current").exists()
+    assert not (repo / "graphify-out/views").exists()
+
+
+@pytest.mark.parametrize("staged", [False, True])
+def test_main_rejects_dirty_tracked_tree_before_publication(tmp_path: Path, staged: bool) -> None:
+    repo, _ = _semantic_repo(tmp_path)
+    canonical_graph = repo / "graphify-out/graph.json"
+    manifest = repo / "graphify-out/manifest.json"
+    before = (canonical_graph.read_bytes(), manifest.read_bytes())
+    source = repo / "src/app.py"
+    source.write_text("print('dirty')\n", encoding="utf-8")
+    if staged:
+        subprocess.run(["git", "add", "src/app.py"], cwd=repo, check=True)
+
+    with pytest.raises(views.GraphifyViewsError, match="tracked Git tree is dirty"):
+        views.main(["--repo-root", str(repo)])
+
+    assert (canonical_graph.read_bytes(), manifest.read_bytes()) == before
+    assert not (repo / "graphify-out/views").exists()
+
+
 @pytest.mark.parametrize("provenance", [None, "stale"])
 def test_main_rejects_missing_or_stale_semantic_provenance(tmp_path: Path, provenance: str | None) -> None:
     repo, commit = _semantic_repo(tmp_path)
@@ -589,6 +628,9 @@ def test_main_rejects_missing_or_stale_semantic_provenance(tmp_path: Path, prove
         {"built_at_commit": "current", "nodes": [{"id": "node"}], "links": [None]},
         {"built_at_commit": "current", "nodes": [{"id": ""}], "links": []},
         {"built_at_commit": "current", "nodes": [{"id": "node"}], "links": [{"source": "node"}]},
+        {"built_at_commit": "current", "nodes": [{"id": "node"}], "links": [{"from": "node"}]},
+        {"built_at_commit": "current", "nodes": [{"id": "node"}], "links": [{"source": "node", "to": "node"}]},
+        {"built_at_commit": "current", "nodes": [{"id": "node"}], "links": [{"from": "node", "target": "node"}]},
     ],
 )
 def test_main_rejects_non_graph_semantic_inputs(tmp_path: Path, graph: dict) -> None:
@@ -601,6 +643,22 @@ def test_main_rejects_non_graph_semantic_inputs(tmp_path: Path, graph: dict) -> 
         views.main(["--repo-root", str(repo)])
 
     assert not (repo / "graphify-out/views").exists()
+
+
+def test_main_accepts_from_to_semantic_edges(tmp_path: Path) -> None:
+    repo, _ = _semantic_repo(
+        tmp_path,
+        {
+            "nodes": [
+                {"id": "runtime", "source_file": "src/app.py"},
+                {"id": "support", "source_file": "tests/standins/support.py"},
+            ],
+            "links": [{"from": "runtime", "to": "support"}],
+        },
+    )
+
+    assert views.main(["--repo-root", str(repo)]) == 0
+    assert (repo / "graphify-out/views/current/graph.json").is_file()
 
 
 def test_write_outputs_switches_one_generation_and_malformed_config_preserves_it(tmp_path: Path) -> None:

--- a/tests/test_update_graphify_views.py
+++ b/tests/test_update_graphify_views.py
@@ -472,9 +472,11 @@ def _semantic_repo(tmp_path: Path, graph: dict | None = None) -> tuple[Path, str
     graph_root = repo / "graphify-out"
     graph_root.mkdir()
     (graph_root / "manifest.json").write_bytes(b"semantic-manifest\n")
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "-c", "init.defaultBranch=main", "init", "-q"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.name", "Graphify test"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.email", "graphify-test@example.invalid"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "core.hooksPath", "/dev/null"], cwd=repo, check=True)
     subprocess.run(["git", "add", "src/app.py"], cwd=repo, check=True)
     subprocess.run(["git", "commit", "-qm", "seed"], cwd=repo, check=True)
     commit = subprocess.run(
@@ -581,6 +583,27 @@ def test_main_rejects_canonical_output_alias_with_external_input(tmp_path: Path)
     assert (canonical_graph.read_bytes(), manifest.read_bytes(), explicit_input.read_bytes()) == before
     assert not (repo / "graphify-out/current").exists()
     assert not (repo / "graphify-out/views").exists()
+
+
+@pytest.mark.parametrize("output_kind", ["cache", "repo", "cache-link"])
+def test_main_rejects_output_containing_or_inside_canonical_graphify_root(tmp_path: Path, output_kind: str) -> None:
+    repo, _ = _semantic_repo(tmp_path)
+    canonical_graph = repo / "graphify-out/graph.json"
+    manifest = repo / "graphify-out/manifest.json"
+    before = (canonical_graph.read_bytes(), manifest.read_bytes())
+    if output_kind == "cache":
+        output = repo / "graphify-out/cache"
+    elif output_kind == "repo":
+        output = repo
+    else:
+        output = repo / "cache-link"
+        output.symlink_to(repo / "graphify-out/cache", target_is_directory=True)
+
+    with pytest.raises(views.GraphifyViewsError, match="overlaps semantic graph"):
+        views.main(["--repo-root", str(repo), "--output", str(output)])
+
+    assert (canonical_graph.read_bytes(), manifest.read_bytes()) == before
+    assert not (repo / "graphify-out/views/current").exists()
 
 
 @pytest.mark.parametrize("staged", [False, True])


### PR DESCRIPTION
## Summary

- Keep Graphify's full semantic graph, manifest, caches, reports, and memory at `graphify-out/`.
- Make the ownership updater read that semantic graph by default and publish its atomic generations under `graphify-out/views/`.
- Remove the updater's direct structural-extraction fallback; a missing semantic graph now fails with an instruction to run the full Graphify skill.
- Route agents to `graphify-out/views/current/graph.json` while the local store continues copying the complete opaque `graphify-out` state.
- Exclude generated Graphify Markdown from repository Markdown linting so graph-seeded worktrees can commit maintained docs normally.

## Verification

- Integration test preserved semantic `graph.json` and `manifest.json` byte-for-byte while publishing all nine views and 18 current artifacts.
- Explicit input/output overrides and missing-semantic failure are covered.
- Actual updater run produced `graphify-out/views/current` with every `built_at_commit` at the issue head; semantic hashes remained unchanged.
- Focused suite: 55 tests passed.
- Full pytest: 5,566 passed, 2 skipped, 9 subtests passed.
- Ruff, formatting, mypy, and Markdown lint passed with generated `graphify-out/**` present.
- `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS`.
- Independent step gate: PASS.

Final test hashes are `58c3dbe6de7bc10967e3386314481586a2863f6d` and `18391d0617a0a72508af857ad8b4624d28dd71a2`. Initial separation proof failed on obsolete extraction behavior; the provenance/shape review proof was 4 failed against pre-fix production and 52 passed after. CodeRabbit's output-containment proof added 3 failing cases and finished at 55 green tests.

Fixes #2590.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.
