### PR TITLE
agent: aggregate live Serena metrics

### DIFF
--- a/scripts/agent/serena-metrics.py
+++ b/scripts/agent/serena-metrics.py
@@ -266,7 +266,8 @@ class AggregatorHandler(http.server.BaseHTTPRequestHandler):
         raise AttributeError(name)
 
     def do_GET(self) -> None:
-        if not _trusted_host(self.headers.get("Host")):
+        host_headers = self.headers.get_all("Host", [])
+        if len(host_headers) != 1 or not _trusted_host(host_headers[0]):
             self._send(421, b"misdirected request\n", "text/plain; charset=utf-8")
             return
         if self.path == "/":

--- a/scripts/agent/serena-metrics.py
+++ b/scripts/agent/serena-metrics.py
@@ -9,6 +9,9 @@ import html
 import http.client
 import http.server
 import json
+import socket
+import time
+import urllib.parse
 from collections.abc import Mapping
 from typing import Any
 
@@ -22,9 +25,33 @@ MAX_WORKERS = 8
 COUNTERS = ("num_times_called", "input_tokens", "output_tokens")
 
 
+class _DeadlineSocket(socket.socket):
+    def __init__(self, deadline: float) -> None:
+        super().__init__(socket.AF_INET, socket.SOCK_STREAM)
+        self._deadline = deadline
+
+    def _apply_deadline(self) -> None:
+        remaining = self._deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("Serena request deadline exceeded")
+        self.settimeout(remaining)
+
+    def connect_with_deadline(self, address: tuple[str, int]) -> None:
+        self._apply_deadline()
+        self.connect(address)
+
+    def recv_into(self, buffer: Any, nbytes: int = 0, flags: int = 0) -> int:
+        self._apply_deadline()
+        return super().recv_into(buffer, nbytes, flags)
+
+
 def _request_json(port: int, path: str) -> object | None:
+    deadline_socket = _DeadlineSocket(time.monotonic() + REQUEST_TIMEOUT)
     connection = http.client.HTTPConnection(HOST, port, timeout=REQUEST_TIMEOUT)
     try:
+        deadline_socket.connect_with_deadline((HOST, port))
+        connection.sock = deadline_socket
+        deadline_socket._apply_deadline()
         connection.request("GET", path, headers={"Accept": "application/json"})
         response = connection.getresponse()
         if response.status != http.client.OK:
@@ -47,6 +74,7 @@ def _request_json(port: int, path: str) -> object | None:
         return None
     finally:
         connection.close()
+        deadline_socket.close()
 
 
 def _strings(
@@ -140,9 +168,20 @@ def _html_text(value: object) -> str:
 
 
 def _trusted_host(value: str | None) -> bool:
-    if value is None:
+    if (
+        value is None
+        or value != value.strip()
+        or any(not character.isprintable() or character.isspace() for character in value)
+    ):
         return False
-    hostname = value.lower().partition(":")[0].rstrip(".")
+    try:
+        parsed = urllib.parse.urlsplit(f"//{value}")
+        parsed.port
+    except ValueError:
+        return False
+    if parsed.username is not None or parsed.password is not None or parsed.path or parsed.query or parsed.fragment:
+        return False
+    hostname = (parsed.hostname or "").lower().rstrip(".")
     return hostname in {"127.0.0.1", "localhost"} or hostname.endswith(".ts.net")
 
 
@@ -188,7 +227,8 @@ class AggregatorHandler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def _reject_method(self) -> None:
-        self._send(405, b"method not allowed\n", "text/plain; charset=utf-8", "GET")
+        body = b"" if self.command == "HEAD" else b"method not allowed\n"
+        self._send(405, body, "text/plain; charset=utf-8", "GET")
 
     def do_GET(self) -> None:
         if not _trusted_host(self.headers.get("Host")):
@@ -203,20 +243,14 @@ class AggregatorHandler(http.server.BaseHTTPRequestHandler):
         else:
             self._send(404, b"not found\n", "text/plain; charset=utf-8")
 
-    def do_DELETE(self) -> None:
-        self._reject_method()
-
-    def do_OPTIONS(self) -> None:
-        self._reject_method()
-
-    def do_PATCH(self) -> None:
-        self._reject_method()
-
-    def do_POST(self) -> None:
-        self._reject_method()
-
-    def do_PUT(self) -> None:
-        self._reject_method()
+    do_CONNECT = _reject_method
+    do_DELETE = _reject_method
+    do_HEAD = _reject_method
+    do_OPTIONS = _reject_method
+    do_PATCH = _reject_method
+    do_POST = _reject_method
+    do_PUT = _reject_method
+    do_TRACE = _reject_method
 
     def log_message(self, format: str, *args: object) -> None:
         pass

--- a/scripts/agent/serena-metrics.py
+++ b/scripts/agent/serena-metrics.py
@@ -179,10 +179,29 @@ def _trusted_host(value: str | None) -> bool:
         parsed.port
     except ValueError:
         return False
-    if parsed.username is not None or parsed.password is not None or parsed.path or parsed.query or parsed.fragment:
+    if (
+        parsed.username is not None
+        or parsed.password is not None
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+        or parsed.netloc.endswith(":")
+    ):
         return False
     hostname = (parsed.hostname or "").lower().rstrip(".")
-    return hostname in {"127.0.0.1", "localhost"} or hostname.endswith(".ts.net")
+    if hostname in {"127.0.0.1", "localhost"}:
+        return True
+    labels = hostname.split(".")
+    valid_labels = all(
+        0 < len(label) <= 63
+        and label[0].isascii()
+        and label[0].isalnum()
+        and label[-1].isascii()
+        and label[-1].isalnum()
+        and all(character.isascii() and (character.isalnum() or character == "-") for character in label)
+        for label in labels
+    )
+    return valid_labels and hostname.endswith(".ts.net")
 
 
 def render_html(instances: list[dict[str, Any]]) -> str:
@@ -229,6 +248,11 @@ class AggregatorHandler(http.server.BaseHTTPRequestHandler):
     def _reject_method(self) -> None:
         body = b"" if self.command == "HEAD" else b"method not allowed\n"
         self._send(405, body, "text/plain; charset=utf-8", "GET")
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("do_"):
+            return self._reject_method
+        raise AttributeError(name)
 
     def do_GET(self) -> None:
         if not _trusted_host(self.headers.get("Host")):

--- a/scripts/agent/serena-metrics.py
+++ b/scripts/agent/serena-metrics.py
@@ -219,6 +219,7 @@ def render_html(instances: list[dict[str, Any]]) -> str:
     rows: list[str] = []
     for instance in instances:
         project = instance["active_project"]
+        totals = instance["totals"]
         tools = "".join(
             f"<li>{_html_text(name)}: calls={values['num_times_called']}, "
             f"input={values['input_tokens']}, output={values['output_tokens']}</li>"
@@ -230,7 +231,8 @@ def render_html(instances: list[dict[str, Any]]) -> str:
             f"<p>Path: {_html_text(project['path'])}; language: {_html_text(project['language'])}; "
             f"client: {_html_text(instance['current_client'])}; Serena: {_html_text(instance['serena_version'])}; "
             f"estimator: {_html_text(instance['token_count_estimator_name'])}</p>"
-            f"<p>Totals: {_html_text(instance['totals'])}</p><ul>{tools}</ul></section>"
+            f"<p>Totals: calls={totals['num_times_called']}, input={totals['input_tokens']}, "
+            f"output={totals['output_tokens']}</p><ul>{tools}</ul></section>"
         )
     return (
         "<!doctype html><html><head><meta charset='utf-8'><title>Serena metrics</title></head>"

--- a/scripts/agent/serena-metrics.py
+++ b/scripts/agent/serena-metrics.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Aggregate live Serena dashboard metrics for a local Tailscale Serve backend."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import html
+import http.client
+import http.server
+import json
+from collections.abc import Mapping
+from typing import Any
+
+HOST = "127.0.0.1"
+DEFAULT_PORT = 24182
+SCAN_START = 24282
+SCAN_END = 24345
+REQUEST_TIMEOUT = 0.5
+READ_LIMIT = 64 * 1024
+MAX_WORKERS = 8
+COUNTERS = ("num_times_called", "input_tokens", "output_tokens")
+
+
+def _request_json(port: int, path: str) -> object | None:
+    connection = http.client.HTTPConnection(HOST, port, timeout=REQUEST_TIMEOUT)
+    try:
+        connection.request("GET", path, headers={"Accept": "application/json"})
+        response = connection.getresponse()
+        if response.status != http.client.OK:
+            return None
+        content_type = response.getheader("Content-Type", "").split(";", 1)[0].strip().lower()
+        if content_type != "application/json":
+            return None
+        content_length = response.getheader("Content-Length")
+        if content_length is not None:
+            try:
+                if int(content_length) > READ_LIMIT:
+                    return None
+            except ValueError:
+                return None
+        body = response.read(READ_LIMIT + 1)
+        if len(body) > READ_LIMIT:
+            return None
+        return json.loads(body.decode("utf-8"))
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+        return None
+    finally:
+        connection.close()
+
+
+def _strings(
+    value: object,
+    keys: tuple[str, ...],
+    nullable: tuple[str, ...] = (),
+) -> dict[str, str | None] | None:
+    if not isinstance(value, Mapping):
+        return None
+    strings: dict[str, str | None] = {}
+    for key in keys:
+        item = value.get(key)
+        if not isinstance(item, str) and not (item is None and key in nullable):
+            return None
+        strings[key] = item
+    return strings
+
+
+def _counter_values(value: object) -> dict[str, int] | None:
+    if not isinstance(value, Mapping):
+        return None
+    counters: dict[str, int] = {}
+    for key in COUNTERS:
+        counter = value.get(key)
+        if type(counter) is not int or counter < 0:
+            return None
+        counters[key] = counter
+    return counters
+
+
+def _project_stats(value: object) -> dict[str, dict[str, int]] | None:
+    if not isinstance(value, Mapping):
+        return None
+    stats = value.get("stats")
+    if not isinstance(stats, Mapping):
+        return None
+    projected: dict[str, dict[str, int]] = {}
+    for name, counters in stats.items():
+        if not isinstance(name, str):
+            return None
+        parsed = _counter_values(counters)
+        if parsed is None:
+            return None
+        projected[name] = parsed
+    return dict(sorted(projected.items()))
+
+
+def _totals(tools: Mapping[str, Mapping[str, int]]) -> dict[str, int]:
+    return {key: sum(tool[key] for tool in tools.values()) for key in COUNTERS}
+
+
+def _discover_port(port: int) -> dict[str, Any] | None:
+    if _request_json(port, "/heartbeat") != {"status": "alive"}:
+        return None
+    config = _request_json(port, "/get_config_overview")
+    if not isinstance(config, Mapping):
+        return None
+    project_keys = ("name", "path", "language")
+    project = _strings(config.get("active_project"), project_keys, nullable=project_keys)
+    identity = _strings(config, ("current_client", "serena_version"), nullable=("current_client",))
+    stats = _project_stats(_request_json(port, "/get_tool_stats"))
+    estimator = _strings(_request_json(port, "/get_token_count_estimator_name"), ("token_count_estimator_name",))
+    if project is None or identity is None or stats is None or estimator is None:
+        return None
+    return {
+        "port": port,
+        "active_project": project,
+        **identity,
+        **estimator,
+        "tools": stats,
+        "totals": _totals(stats),
+    }
+
+
+def discover_instances() -> list[dict[str, Any]]:
+    ports = range(SCAN_START, SCAN_END + 1)
+    workers = min(MAX_WORKERS, len(ports))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        instances = [instance for instance in executor.map(_discover_port, ports) if instance is not None]
+    return sorted(instances, key=lambda instance: instance["port"])
+
+
+def aggregate(instances: list[dict[str, Any]]) -> dict[str, Any]:
+    totals = _totals({str(index): instance["totals"] for index, instance in enumerate(instances)})
+    return {"instances": instances, "totals": totals}
+
+
+def _html_text(value: object) -> str:
+    text = "unknown" if value is None else str(value)
+    return html.escape("".join(character if character.isprintable() else " " for character in text), quote=True)
+
+
+def _trusted_host(value: str | None) -> bool:
+    if value is None:
+        return False
+    hostname = value.lower().partition(":")[0].rstrip(".")
+    return hostname in {"127.0.0.1", "localhost"} or hostname.endswith(".ts.net")
+
+
+def render_html(instances: list[dict[str, Any]]) -> str:
+    rows: list[str] = []
+    for instance in instances:
+        project = instance["active_project"]
+        tools = "".join(
+            f"<li>{_html_text(name)}: calls={values['num_times_called']}, "
+            f"input={values['input_tokens']}, output={values['output_tokens']}</li>"
+            for name, values in instance["tools"].items()
+        )
+        rows.append(
+            "<section>"
+            f"<h2>Port {_html_text(instance['port'])}: {_html_text(project['name'])}</h2>"
+            f"<p>Path: {_html_text(project['path'])}; language: {_html_text(project['language'])}; "
+            f"client: {_html_text(instance['current_client'])}; Serena: {_html_text(instance['serena_version'])}; "
+            f"estimator: {_html_text(instance['token_count_estimator_name'])}</p>"
+            f"<p>Totals: {_html_text(instance['totals'])}</p><ul>{tools}</ul></section>"
+        )
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'><title>Serena metrics</title></head>"
+        "<body><h1>Live Serena metrics</h1>"
+        + ("".join(rows) or "<p>No healthy Serena dashboards found.</p>")
+        + "</body></html>"
+    )
+
+
+class AggregatorHandler(http.server.BaseHTTPRequestHandler):
+    server_version = "SerenaMetrics/1"
+
+    def _send(self, status: int, body: bytes, content_type: str, allow: str | None = None) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Security-Policy", "default-src 'none'; base-uri 'none'; frame-ancestors 'none'")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        if allow is not None:
+            self.send_header("Allow", allow)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _reject_method(self) -> None:
+        self._send(405, b"method not allowed\n", "text/plain; charset=utf-8", "GET")
+
+    def do_GET(self) -> None:
+        if not _trusted_host(self.headers.get("Host")):
+            self._send(421, b"misdirected request\n", "text/plain; charset=utf-8")
+            return
+        if self.path == "/":
+            body = render_html(discover_instances()).encode("utf-8")
+            self._send(200, body, "text/html; charset=utf-8")
+        elif self.path == "/api/instances":
+            body = json.dumps(aggregate(discover_instances()), ensure_ascii=True, separators=(",", ":")).encode()
+            self._send(200, body, "application/json; charset=utf-8")
+        else:
+            self._send(404, b"not found\n", "text/plain; charset=utf-8")
+
+    def do_DELETE(self) -> None:
+        self._reject_method()
+
+    def do_OPTIONS(self) -> None:
+        self._reject_method()
+
+    def do_PATCH(self) -> None:
+        self._reject_method()
+
+    def do_POST(self) -> None:
+        self._reject_method()
+
+    def do_PUT(self) -> None:
+        self._reject_method()
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+class AggregatorServer(http.server.ThreadingHTTPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def make_server(port: int = DEFAULT_PORT) -> AggregatorServer:
+    return AggregatorServer((HOST, port), AggregatorHandler)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only local Serena metrics aggregator.",
+        epilog=f"Tailscale Serve: tailscale serve --bg http://{HOST}:{DEFAULT_PORT}",
+    )
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"aggregate port (default: {DEFAULT_PORT})")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as error:
+        return int(error.code)
+    server = make_server(args.port)
+    print(f"Serena metrics listening on http://{HOST}:{server.server_address[1]}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent/serena-metrics.py
+++ b/scripts/agent/serena-metrics.py
@@ -18,7 +18,8 @@ from typing import Any
 HOST = "127.0.0.1"
 DEFAULT_PORT = 24182
 SCAN_START = 24282
-SCAN_END = 24345
+SCAN_END = 65535
+SCAN_BATCH = 256
 REQUEST_TIMEOUT = 0.5
 READ_LIMIT = 64 * 1024
 MAX_WORKERS = 8
@@ -59,18 +60,20 @@ def _request_json(port: int, path: str) -> object | None:
         content_type = response.getheader("Content-Type", "").split(";", 1)[0].strip().lower()
         if content_type != "application/json":
             return None
-        content_length = response.getheader("Content-Length")
-        if content_length is not None:
+        content_length_header = response.getheader("Content-Length")
+        content_length = None
+        if content_length_header is not None:
             try:
-                if int(content_length) > READ_LIMIT:
+                content_length = int(content_length_header)
+                if content_length < 0 or content_length > READ_LIMIT:
                     return None
             except ValueError:
                 return None
         body = response.read(READ_LIMIT + 1)
-        if len(body) > READ_LIMIT:
+        if len(body) > READ_LIMIT or (content_length is not None and len(body) != content_length):
             return None
         return json.loads(body.decode("utf-8"))
-    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+    except (OSError, UnicodeError, ValueError, RecursionError, http.client.HTTPException, json.JSONDecodeError):
         return None
     finally:
         connection.close()
@@ -150,10 +153,12 @@ def _discover_port(port: int) -> dict[str, Any] | None:
 
 
 def discover_instances() -> list[dict[str, Any]]:
-    ports = range(SCAN_START, SCAN_END + 1)
-    workers = min(MAX_WORKERS, len(ports))
+    workers = min(MAX_WORKERS, SCAN_END - SCAN_START + 1)
+    instances: list[dict[str, Any]] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-        instances = [instance for instance in executor.map(_discover_port, ports) if instance is not None]
+        for batch_start in range(SCAN_START, SCAN_END + 1, SCAN_BATCH):
+            ports = range(batch_start, min(batch_start + SCAN_BATCH, SCAN_END + 1))
+            instances.extend(instance for instance in executor.map(_discover_port, ports) if instance is not None)
     return sorted(instances, key=lambda instance: instance["port"])
 
 
@@ -188,7 +193,13 @@ def _trusted_host(value: str | None) -> bool:
         or parsed.netloc.endswith(":")
     ):
         return False
-    hostname = (parsed.hostname or "").lower().rstrip(".")
+    hostname = (parsed.hostname or "").lower()
+    if hostname.endswith("."):
+        hostname = hostname[:-1]
+        if hostname.endswith("."):
+            return False
+    if len(hostname) > 253:
+        return False
     if hostname in {"127.0.0.1", "localhost"}:
         return True
     labels = hostname.split(".")

--- a/tests/test_serena_metrics.py
+++ b/tests/test_serena_metrics.py
@@ -233,23 +233,24 @@ def test_slow_listener_is_bounded_and_ignored(metrics: Any) -> None:
     responses = healthy()
 
     def slow(handler: SerenaHandler) -> None:
-        body = json.dumps({"status": "alive"}).encode()
+        body = b"{}"
         handler.send_response(200)
         handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", str(len(body)))
         handler.end_headers()
+        handler.wfile.flush()
         try:
             for byte in body:
+                time.sleep(0.04)
                 handler.wfile.write(bytes((byte,)))
                 handler.wfile.flush()
-                time.sleep(0.02)
         except BrokenPipeError:
             pass
 
     responses["/heartbeat"] = slow
     with listener(responses) as (port, _):
-        configure_scan(metrics, port, port)
         metrics.REQUEST_TIMEOUT = 0.05
-        assert metrics.discover_instances() == []
+        assert metrics._request_json(port, "/heartbeat") is None
 
 
 def test_html_escapes_metacharacters_and_removes_controls(metrics: Any) -> None:
@@ -379,7 +380,16 @@ def test_http_surface_rejects_untrusted_host_and_accepts_tailnet_host(metrics: A
 
 @pytest.mark.parametrize(
     "host",
-    ["foo.ts.net:bad", "foo.ts.net:443@evil", "127.0.0.1:bad", "foo.ts.net:443:evil", "evil@foo.ts.net"],
+    [
+        ".ts.net",
+        "foo..ts.net",
+        "foo.ts.net:",
+        "foo.ts.net:bad",
+        "foo.ts.net:443@evil",
+        "127.0.0.1:bad",
+        "foo.ts.net:443:evil",
+        "evil@foo.ts.net",
+    ],
 )
 def test_http_surface_rejects_malformed_host(metrics: Any, host: str) -> None:
     server = metrics.make_server(0)
@@ -400,7 +410,7 @@ def test_http_surface_rejects_malformed_host(metrics: Any, host: str) -> None:
         server.server_close()
 
 
-@pytest.mark.parametrize("method", ["HEAD", "TRACE", "CONNECT", "DELETE", "OPTIONS", "PATCH", "POST", "PUT"])
+@pytest.mark.parametrize("method", ["HEAD", "TRACE", "CONNECT", "DELETE", "OPTIONS", "PATCH", "POST", "PUT", "FOO"])
 def test_http_surface_rejects_every_non_get_method(metrics: Any, method: str) -> None:
     server = metrics.make_server(0)
     thread = threading.Thread(target=server.serve_forever)

--- a/tests/test_serena_metrics.py
+++ b/tests/test_serena_metrics.py
@@ -416,7 +416,9 @@ def test_http_surface_is_json_html_loopback_and_get_only(metrics: Any) -> None:
             page = connection.getresponse()
             assert page.status == 200
             assert page.getheader("Content-Type") == "text/html; charset=utf-8"
-            assert "pfBlockerNG" in page.read().decode()
+            page_body = page.read().decode()
+            assert "pfBlockerNG" in page_body
+            assert "Totals: calls=3, input=16, output=10" in page_body
             connection.request("GET", "/missing")
             assert connection.getresponse().status == 404
             connection.request("POST", "/api/instances")

--- a/tests/test_serena_metrics.py
+++ b/tests/test_serena_metrics.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import http.client
+import http.server
+import importlib.util
+import json
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "agent" / "serena-metrics.py"
+
+
+@pytest.fixture
+def metrics() -> Any:
+    assert SCRIPT.exists(), f"production script is missing: {SCRIPT}"
+    spec = importlib.util.spec_from_file_location("serena_metrics", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SerenaHandler(http.server.BaseHTTPRequestHandler):
+    response_map: dict[str, Any] = {}
+    requests: list[str] = []
+
+    def do_GET(self) -> None:
+        self.__class__.requests.append(self.path)
+        response = self.__class__.response_map.get(self.path)
+        if callable(response):
+            response(self)
+            return
+        if response is None:
+            self.send_error(404)
+            return
+        status, body, content_type = response
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+@contextmanager
+def listener(responses: dict[str, Any], port: int = 0) -> Iterator[tuple[int, type[SerenaHandler]]]:
+    handler = type("TestSerenaHandler", (SerenaHandler,), {"response_map": responses, "requests": []})
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", port), handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield server.server_address[1], handler
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def response(value: object, content_type: str = "application/json") -> tuple[int, bytes, str]:
+    return 200, json.dumps(value).encode(), content_type
+
+
+def healthy(project: str = "pfBlockerNG") -> dict[str, Any]:
+    return {
+        "/heartbeat": response({"status": "alive"}),
+        "/get_config_overview": response(
+            {
+                "active_project": {"name": project, "path": "/repo", "language": "Python"},
+                "current_client": "codex",
+                "serena_version": "1.7.0",
+            }
+        ),
+        "/get_tool_stats": response(
+            {
+                "stats": {
+                    "find_symbol": {"num_times_called": 2, "input_tokens": 11, "output_tokens": 7},
+                    "replace_symbol": {"num_times_called": 1, "input_tokens": 5, "output_tokens": 3},
+                }
+            }
+        ),
+        "/get_token_count_estimator_name": response({"token_count_estimator_name": "tiktoken"}),
+    }
+
+
+def configure_scan(metrics: Any, start: int, end: int) -> None:
+    metrics.SCAN_START = start
+    metrics.SCAN_END = end
+    metrics.REQUEST_TIMEOUT = 0.1
+
+
+def test_healthy_instance_is_projected_with_tools_and_totals(metrics: Any) -> None:
+    with listener(healthy()) as (port, _):
+        configure_scan(metrics, port, port)
+        instances = metrics.discover_instances()
+
+    assert instances == [
+        {
+            "port": port,
+            "active_project": {"name": "pfBlockerNG", "path": "/repo", "language": "Python"},
+            "current_client": "codex",
+            "serena_version": "1.7.0",
+            "token_count_estimator_name": "tiktoken",
+            "tools": {
+                "find_symbol": {"num_times_called": 2, "input_tokens": 11, "output_tokens": 7},
+                "replace_symbol": {"num_times_called": 1, "input_tokens": 5, "output_tokens": 3},
+            },
+            "totals": {"num_times_called": 3, "input_tokens": 16, "output_tokens": 10},
+        }
+    ]
+
+
+def test_instance_without_project_or_client_is_still_listed(metrics: Any) -> None:
+    responses = healthy()
+    responses["/get_config_overview"] = response(
+        {
+            "active_project": {"name": None, "path": None, "language": None},
+            "current_client": None,
+            "serena_version": "1.7.0",
+        }
+    )
+    responses["/get_tool_stats"] = response({"stats": {}})
+    with listener(responses) as (port, _):
+        configure_scan(metrics, port, port)
+        instances = metrics.discover_instances()
+        page = metrics.render_html(instances)
+
+    assert instances == [
+        {
+            "port": port,
+            "active_project": {"name": None, "path": None, "language": None},
+            "current_client": None,
+            "serena_version": "1.7.0",
+            "token_count_estimator_name": "tiktoken",
+            "tools": {},
+            "totals": {"num_times_called": 0, "input_tokens": 0, "output_tokens": 0},
+        }
+    ]
+    assert "unknown" in page
+
+
+def test_multiple_instances_are_sorted_and_have_aggregate_totals(metrics: Any) -> None:
+    with listener(healthy("second")) as (first_port, _):
+        with listener(healthy("first")) as (second_port, _):
+            low, high = sorted((first_port, second_port))
+            configure_scan(metrics, low, high)
+            instances = metrics.discover_instances()
+            assert [instance["port"] for instance in instances] == sorted((first_port, second_port))
+            aggregate = metrics.aggregate(instances)
+
+    assert aggregate["totals"] == {"num_times_called": 6, "input_tokens": 32, "output_tokens": 20}
+
+
+def test_closed_port_is_ignored(metrics: Any) -> None:
+    with listener(healthy()) as (port, _):
+        configure_scan(metrics, port, port + 1)
+        instances = metrics.discover_instances()
+
+    assert [instance["port"] for instance in instances] == [port]
+
+
+def test_non_serena_listener_requires_exact_heartbeat_shape(metrics: Any) -> None:
+    responses = healthy()
+    responses["/heartbeat"] = response({"status": "alive", "service": "other"})
+    with listener(responses) as (port, _):
+        configure_scan(metrics, port, port)
+        assert metrics.discover_instances() == []
+
+
+def test_listener_that_fails_after_heartbeat_is_ignored(metrics: Any) -> None:
+    responses = healthy()
+
+    def fail(_: SerenaHandler) -> None:
+        raise OSError("listener disappeared")
+
+    responses["/get_config_overview"] = fail
+    with listener(responses) as (port, _):
+        configure_scan(metrics, port, port)
+        assert metrics.discover_instances() == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, [], {"status": "alive"}, {"stats": {"tool": {"num_times_called": 1}}}],
+    ids=["null", "array", "incomplete-config", "incomplete-stats"],
+)
+def test_invalid_or_incomplete_json_is_ignored(metrics: Any, payload: object) -> None:
+    responses = healthy()
+    responses["/get_config_overview"] = response(payload)
+    with listener(responses) as (port, _):
+        configure_scan(metrics, port, port)
+        assert metrics.discover_instances() == []
+
+
+def test_malformed_and_oversized_responses_are_ignored(metrics: Any) -> None:
+    responses = healthy()
+    responses["/get_config_overview"] = (200, b"{not-json", "application/json")
+    with listener(responses) as (port, _):
+        configure_scan(metrics, port, port)
+        assert metrics.discover_instances() == []
+
+    oversized = healthy()
+    oversized["/get_config_overview"] = (200, b"x" * (metrics.READ_LIMIT + 1), "application/json")
+    with listener(oversized) as (port, _):
+        configure_scan(metrics, port, port)
+        assert metrics.discover_instances() == []
+
+
+def test_slow_listener_is_bounded_and_ignored(metrics: Any) -> None:
+    responses = healthy()
+
+    def slow(handler: SerenaHandler) -> None:
+        time.sleep(0.3)
+        handler.send_response(200)
+        handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", "2")
+        handler.end_headers()
+        handler.wfile.write(b"{}")
+
+    responses["/heartbeat"] = slow
+    with listener(responses) as (port, _):
+        metrics.REQUEST_TIMEOUT = 0.01
+        configure_scan(metrics, port, port)
+        assert metrics.discover_instances() == []
+
+
+def test_html_escapes_metacharacters_and_removes_controls(metrics: Any) -> None:
+    dangerous = healthy('<script>alert("x")</script> & "quoted"\x01')
+    dangerous["/get_config_overview"] = response(
+        {
+            "active_project": {
+                "name": '<script>alert("x")</script> & "quoted"\x01',
+                "path": "/repo",
+                "language": "Python",
+            },
+            "current_client": "client\x02",
+            "serena_version": "1.7.0",
+        }
+    )
+    with listener(dangerous) as (port, _):
+        configure_scan(metrics, port, port)
+        html = metrics.render_html(metrics.discover_instances())
+
+    assert "<script>" not in html
+    assert "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;" in html
+    assert "\x01" not in html and "\x02" not in html
+
+
+def test_redirect_is_not_followed(metrics: Any) -> None:
+    responses = healthy()
+    responses["/heartbeat"] = (302, b"", "text/plain")
+    target_hit = False
+
+    def redirect(handler: SerenaHandler) -> None:
+        handler.send_response(302)
+        handler.send_header("Location", "http://127.0.0.1:1/heartbeat")
+        handler.send_header("Content-Length", "0")
+        handler.end_headers()
+
+    responses["/heartbeat"] = redirect
+    with listener(responses) as (port, handler):
+        configure_scan(metrics, port, port)
+        assert metrics.discover_instances() == []
+        target_hit = "/heartbeat" in handler.requests
+
+    assert target_hit
+
+
+@pytest.mark.parametrize(
+    "counter",
+    [-1, 1.5, True],
+    ids=["negative", "float", "bool"],
+)
+def test_negative_and_non_integer_counters_are_ignored(metrics: Any, counter: object) -> None:
+    responses = healthy()
+    responses["/get_tool_stats"] = response(
+        {"stats": {"find_symbol": {"num_times_called": counter, "input_tokens": 1, "output_tokens": 1}}}
+    )
+    with listener(responses) as (port, _):
+        configure_scan(metrics, port, port)
+        assert metrics.discover_instances() == []
+
+
+def test_http_surface_is_json_html_loopback_and_get_only(metrics: Any) -> None:
+    with listener(healthy()) as (port, _):
+        configure_scan(metrics, port, port)
+        server = metrics.make_server(0)
+        assert server.server_address[0] == "127.0.0.1"
+        thread = threading.Thread(target=server.serve_forever)
+        thread.start()
+        try:
+            connection = http.client.HTTPConnection("127.0.0.1", server.server_address[1])
+            connection.request("GET", "/api/instances")
+            api = connection.getresponse()
+            assert api.status == 200
+            assert api.getheader("Content-Type") == "application/json; charset=utf-8"
+            content_security_policy = api.getheader("Content-Security-Policy")
+            assert content_security_policy is not None
+            assert "frame-ancestors 'none'" in content_security_policy
+            assert json.loads(api.read())["instances"][0]["port"] == port
+            connection.request("GET", "/")
+            page = connection.getresponse()
+            assert page.status == 200
+            assert page.getheader("Content-Type") == "text/html; charset=utf-8"
+            assert "pfBlockerNG" in page.read().decode()
+            connection.request("GET", "/missing")
+            assert connection.getresponse().status == 404
+            connection.request("POST", "/api/instances")
+            rejected = connection.getresponse()
+            assert rejected.status == 405
+            assert rejected.getheader("Allow") == "GET"
+        finally:
+            connection.close()
+            server.shutdown()
+            thread.join()
+            server.server_close()
+
+
+def test_http_surface_rejects_untrusted_host_and_accepts_tailnet_host(metrics: Any) -> None:
+    with listener(healthy()) as (port, _):
+        configure_scan(metrics, port, port)
+        server = metrics.make_server(0)
+        thread = threading.Thread(target=server.serve_forever)
+        thread.start()
+        try:
+            connection = http.client.HTTPConnection("127.0.0.1", server.server_address[1])
+            connection.putrequest("GET", "/api/instances", skip_host=True)
+            connection.putheader("Host", "attacker.example")
+            connection.endheaders()
+            rejected = connection.getresponse()
+            assert rejected.status == 421
+            rejected.read()
+
+            connection.putrequest("GET", "/api/instances", skip_host=True)
+            connection.putheader("Host", "serena.private-tailnet.ts.net")
+            connection.endheaders()
+            accepted = connection.getresponse()
+            assert accepted.status == 200
+            accepted.read()
+        finally:
+            connection.close()
+            server.shutdown()
+            thread.join()
+            server.server_close()
+
+
+def test_help_describes_loopback_and_tailscale_serve(metrics: Any, capsys: pytest.CaptureFixture[str]) -> None:
+    assert metrics.main(["--help"]) == 0
+    output = capsys.readouterr().out
+    assert "127.0.0.1" in output
+    assert "tailscale serve --bg" in output

--- a/tests/test_serena_metrics.py
+++ b/tests/test_serena_metrics.py
@@ -168,12 +168,23 @@ def test_instance_without_project_or_client_is_still_listed(metrics: Any) -> Non
     assert "unknown" in page
 
 
-def test_default_scan_covers_serena_allocator_range(metrics: Any) -> None:
+def test_default_scan_covers_serena_allocator_range(metrics: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     assert metrics.SCAN_START == 24282
     assert metrics.SCAN_END == 65535
-    with listener(healthy()) as (port, _):
-        assert port > 24345, f"ephemeral fixture port must exercise the former ceiling, got {port}"
-        assert metrics._discover_port(port) is not None
+    visited: set[int] = set()
+    lock = threading.Lock()
+
+    def discover(port: int) -> dict[str, int] | None:
+        with lock:
+            visited.add(port)
+        return {"port": port} if port in {24346, 65535} else None
+
+    monkeypatch.setattr(metrics, "_discover_port", discover)
+    instances = metrics.discover_instances()
+
+    assert len(visited) == metrics.SCAN_END - metrics.SCAN_START + 1
+    assert min(visited) == 24282 and max(visited) == 65535
+    assert [instance["port"] for instance in instances] == [24346, 65535]
 
 
 def test_multiple_instances_are_sorted_and_have_aggregate_totals(metrics: Any) -> None:
@@ -243,7 +254,14 @@ def test_malformed_and_oversized_responses_are_ignored(metrics: Any) -> None:
         assert metrics.discover_instances() == []
 
     without_length = healthy()
-    valid_oversized_json = json.dumps({"padding": "x" * metrics.READ_LIMIT}).encode()
+    valid_oversized_json = json.dumps(
+        {
+            "active_project": {"name": "pfBlockerNG", "path": "/repo", "language": "Python"},
+            "current_client": "codex",
+            "serena_version": "1.7.0",
+            "padding": "x" * metrics.READ_LIMIT,
+        }
+    ).encode()
 
     def oversized_without_length(handler: SerenaHandler) -> None:
         handler.send_response(200)
@@ -262,7 +280,6 @@ def test_malformed_and_oversized_responses_are_ignored(metrics: Any) -> None:
 
 def test_malformed_http_and_deep_json_are_ignored(metrics: Any) -> None:
     deep_json = b"[" * 1100 + b"0" + b"]" * 1100
-    valid_json = b'{"status":"alive"}'
     payloads = [
         b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\n\r\nZZ\r\n{}\r\n0\r\n\r\n",
         b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nX-Large: " + b"x" * 65537 + b"\r\n\r\n{}",
@@ -271,15 +288,26 @@ def test_malformed_http_and_deep_json_are_ignored(metrics: Any) -> None:
         + str(len(deep_json)).encode()
         + b"\r\n\r\n"
         + deep_json,
-        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
-        + str(len(valid_json) + 100).encode()
-        + b"\r\n\r\n"
-        + valid_json,
     ]
     for payload in payloads:
         with raw_listener(payload) as port:
-            configure_scan(metrics, port, port)
-            assert metrics.discover_instances() == []
+            assert metrics._request_json(port, "/heartbeat") is None
+
+    valid_config = json.dumps(
+        {
+            "active_project": {"name": "pfBlockerNG", "path": "/repo", "language": "Python"},
+            "current_client": "codex",
+            "serena_version": "1.7.0",
+        }
+    ).encode()
+    truncated = (
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
+        + str(len(valid_config) + 100).encode()
+        + b"\r\n\r\n"
+        + valid_config
+    )
+    with raw_listener(truncated) as port:
+        assert metrics._request_json(port, "/get_config_overview") is None
 
 
 def test_slow_listener_is_bounded_and_ignored(metrics: Any) -> None:
@@ -421,6 +449,14 @@ def test_http_surface_rejects_untrusted_host_and_accepts_tailnet_host(metrics: A
             accepted = connection.getresponse()
             assert accepted.status == 200
             accepted.read()
+
+            connection.putrequest("GET", "/api/instances", skip_host=True)
+            connection.putheader("Host", "localhost")
+            connection.putheader("Host", "attacker.example")
+            connection.endheaders()
+            duplicate = connection.getresponse()
+            assert duplicate.status == 421
+            duplicate.read()
         finally:
             connection.close()
             server.shutdown()

--- a/tests/test_serena_metrics.py
+++ b/tests/test_serena_metrics.py
@@ -254,14 +254,16 @@ def test_malformed_and_oversized_responses_are_ignored(metrics: Any) -> None:
         assert metrics.discover_instances() == []
 
     without_length = healthy()
-    valid_oversized_json = json.dumps(
-        {
-            "active_project": {"name": "pfBlockerNG", "path": "/repo", "language": "Python"},
-            "current_client": "codex",
-            "serena_version": "1.7.0",
-            "padding": "x" * metrics.READ_LIMIT,
-        }
-    ).encode()
+    valid_oversized_json = (
+        json.dumps(
+            {
+                "active_project": {"name": "pfBlockerNG", "path": "/repo", "language": "Python"},
+                "current_client": "codex",
+                "serena_version": "1.7.0",
+            }
+        ).encode()
+        + b" " * metrics.READ_LIMIT
+    )
 
     def oversized_without_length(handler: SerenaHandler) -> None:
         handler.send_response(200)

--- a/tests/test_serena_metrics.py
+++ b/tests/test_serena_metrics.py
@@ -212,22 +212,43 @@ def test_malformed_and_oversized_responses_are_ignored(metrics: Any) -> None:
         configure_scan(metrics, port, port)
         assert metrics.discover_instances() == []
 
+    without_length = healthy()
+
+    def oversized_without_length(handler: SerenaHandler) -> None:
+        handler.send_response(200)
+        handler.send_header("Content-Type", "application/json")
+        handler.end_headers()
+        try:
+            handler.wfile.write(b"x" * (metrics.READ_LIMIT + 1))
+        except BrokenPipeError:
+            pass
+
+    without_length["/get_config_overview"] = oversized_without_length
+    with listener(without_length) as (port, _):
+        configure_scan(metrics, port, port)
+        assert metrics.discover_instances() == []
+
 
 def test_slow_listener_is_bounded_and_ignored(metrics: Any) -> None:
     responses = healthy()
 
     def slow(handler: SerenaHandler) -> None:
-        time.sleep(0.3)
+        body = json.dumps({"status": "alive"}).encode()
         handler.send_response(200)
         handler.send_header("Content-Type", "application/json")
-        handler.send_header("Content-Length", "2")
         handler.end_headers()
-        handler.wfile.write(b"{}")
+        try:
+            for byte in body:
+                handler.wfile.write(bytes((byte,)))
+                handler.wfile.flush()
+                time.sleep(0.02)
+        except BrokenPipeError:
+            pass
 
     responses["/heartbeat"] = slow
     with listener(responses) as (port, _):
-        metrics.REQUEST_TIMEOUT = 0.01
         configure_scan(metrics, port, port)
+        metrics.REQUEST_TIMEOUT = 0.05
         assert metrics.discover_instances() == []
 
 
@@ -237,40 +258,45 @@ def test_html_escapes_metacharacters_and_removes_controls(metrics: Any) -> None:
         {
             "active_project": {
                 "name": '<script>alert("x")</script> & "quoted"\x01',
-                "path": "/repo",
-                "language": "Python",
+                "path": '<img src=x onerror="path">\x03',
+                "language": "Python & <b>language</b>",
             },
             "current_client": "client\x02",
-            "serena_version": "1.7.0",
+            "serena_version": "<svg onload=version>",
         }
+    )
+    dangerous["/get_tool_stats"] = response(
+        {"stats": {"<script>tool</script>\x04": {"num_times_called": 1, "input_tokens": 2, "output_tokens": 3}}}
+    )
+    dangerous["/get_token_count_estimator_name"] = response(
+        {"token_count_estimator_name": "<iframe>estimator</iframe>\x05"}
     )
     with listener(dangerous) as (port, _):
         configure_scan(metrics, port, port)
         html = metrics.render_html(metrics.discover_instances())
 
     assert "<script>" not in html
+    assert "<img" not in html and "<b>" not in html and "<svg" not in html and "<iframe>" not in html
     assert "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;" in html
-    assert "\x01" not in html and "\x02" not in html
+    assert all(control not in html for control in ("\x01", "\x02", "\x03", "\x04", "\x05"))
 
 
 def test_redirect_is_not_followed(metrics: Any) -> None:
     responses = healthy()
-    responses["/heartbeat"] = (302, b"", "text/plain")
-    target_hit = False
+    with listener(healthy()) as (target_port, target_handler):
 
-    def redirect(handler: SerenaHandler) -> None:
-        handler.send_response(302)
-        handler.send_header("Location", "http://127.0.0.1:1/heartbeat")
-        handler.send_header("Content-Length", "0")
-        handler.end_headers()
+        def redirect(handler: SerenaHandler) -> None:
+            handler.send_response(302)
+            handler.send_header("Location", f"http://127.0.0.1:{target_port}/heartbeat")
+            handler.send_header("Content-Length", "0")
+            handler.end_headers()
 
-    responses["/heartbeat"] = redirect
-    with listener(responses) as (port, handler):
-        configure_scan(metrics, port, port)
-        assert metrics.discover_instances() == []
-        target_hit = "/heartbeat" in handler.requests
+        responses["/heartbeat"] = redirect
+        with listener(responses) as (port, _):
+            configure_scan(metrics, port, port)
+            assert metrics.discover_instances() == []
 
-    assert target_hit
+    assert target_handler.requests == []
 
 
 @pytest.mark.parametrize(
@@ -349,6 +375,48 @@ def test_http_surface_rejects_untrusted_host_and_accepts_tailnet_host(metrics: A
             server.shutdown()
             thread.join()
             server.server_close()
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["foo.ts.net:bad", "foo.ts.net:443@evil", "127.0.0.1:bad", "foo.ts.net:443:evil", "evil@foo.ts.net"],
+)
+def test_http_surface_rejects_malformed_host(metrics: Any, host: str) -> None:
+    server = metrics.make_server(0)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        connection = http.client.HTTPConnection("127.0.0.1", server.server_address[1])
+        connection.putrequest("GET", "/api/instances", skip_host=True)
+        connection.putheader("Host", host)
+        connection.endheaders()
+        response = connection.getresponse()
+        assert response.status == 421
+        response.read()
+    finally:
+        connection.close()
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+@pytest.mark.parametrize("method", ["HEAD", "TRACE", "CONNECT", "DELETE", "OPTIONS", "PATCH", "POST", "PUT"])
+def test_http_surface_rejects_every_non_get_method(metrics: Any, method: str) -> None:
+    server = metrics.make_server(0)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        connection = http.client.HTTPConnection("127.0.0.1", server.server_address[1])
+        connection.request(method, "/api/instances")
+        response = connection.getresponse()
+        assert response.status == 405
+        assert response.getheader("Allow") == "GET"
+        response.read()
+    finally:
+        connection.close()
+        server.shutdown()
+        thread.join()
+        server.server_close()
 
 
 def test_help_describes_loopback_and_tailscale_serve(metrics: Any, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_serena_metrics.py
+++ b/tests/test_serena_metrics.py
@@ -4,6 +4,7 @@ import http.client
 import http.server
 import importlib.util
 import json
+import socketserver
 import threading
 import time
 from collections.abc import Iterator
@@ -58,6 +59,27 @@ def listener(responses: dict[str, Any], port: int = 0) -> Iterator[tuple[int, ty
     thread.start()
     try:
         yield server.server_address[1], handler
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+@contextmanager
+def raw_listener(payload: bytes) -> Iterator[int]:
+    class RawHandler(socketserver.BaseRequestHandler):
+        def handle(self) -> None:
+            self.request.recv(4096)
+            try:
+                self.request.sendall(payload)
+            except OSError:
+                pass
+
+    server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), RawHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield server.server_address[1]
     finally:
         server.shutdown()
         thread.join()
@@ -146,6 +168,14 @@ def test_instance_without_project_or_client_is_still_listed(metrics: Any) -> Non
     assert "unknown" in page
 
 
+def test_default_scan_covers_serena_allocator_range(metrics: Any) -> None:
+    assert metrics.SCAN_START == 24282
+    assert metrics.SCAN_END == 65535
+    with listener(healthy()) as (port, _):
+        assert port > 24345, f"ephemeral fixture port must exercise the former ceiling, got {port}"
+        assert metrics._discover_port(port) is not None
+
+
 def test_multiple_instances_are_sorted_and_have_aggregate_totals(metrics: Any) -> None:
     with listener(healthy("second")) as (first_port, _):
         with listener(healthy("first")) as (second_port, _):
@@ -213,13 +243,14 @@ def test_malformed_and_oversized_responses_are_ignored(metrics: Any) -> None:
         assert metrics.discover_instances() == []
 
     without_length = healthy()
+    valid_oversized_json = json.dumps({"padding": "x" * metrics.READ_LIMIT}).encode()
 
     def oversized_without_length(handler: SerenaHandler) -> None:
         handler.send_response(200)
         handler.send_header("Content-Type", "application/json")
         handler.end_headers()
         try:
-            handler.wfile.write(b"x" * (metrics.READ_LIMIT + 1))
+            handler.wfile.write(valid_oversized_json)
         except BrokenPipeError:
             pass
 
@@ -227,6 +258,28 @@ def test_malformed_and_oversized_responses_are_ignored(metrics: Any) -> None:
     with listener(without_length) as (port, _):
         configure_scan(metrics, port, port)
         assert metrics.discover_instances() == []
+
+
+def test_malformed_http_and_deep_json_are_ignored(metrics: Any) -> None:
+    deep_json = b"[" * 1100 + b"0" + b"]" * 1100
+    valid_json = b'{"status":"alive"}'
+    payloads = [
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\n\r\nZZ\r\n{}\r\n0\r\n\r\n",
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nX-Large: " + b"x" * 65537 + b"\r\n\r\n{}",
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n" + b"X: y\r\n" * 101 + b"\r\n{}",
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
+        + str(len(deep_json)).encode()
+        + b"\r\n\r\n"
+        + deep_json,
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
+        + str(len(valid_json) + 100).encode()
+        + b"\r\n\r\n"
+        + valid_json,
+    ]
+    for payload in payloads:
+        with raw_listener(payload) as port:
+            configure_scan(metrics, port, port)
+            assert metrics.discover_instances() == []
 
 
 def test_slow_listener_is_bounded_and_ignored(metrics: Any) -> None:
@@ -300,16 +353,13 @@ def test_redirect_is_not_followed(metrics: Any) -> None:
     assert target_handler.requests == []
 
 
-@pytest.mark.parametrize(
-    "counter",
-    [-1, 1.5, True],
-    ids=["negative", "float", "bool"],
-)
-def test_negative_and_non_integer_counters_are_ignored(metrics: Any, counter: object) -> None:
+@pytest.mark.parametrize("counter_name", ["num_times_called", "input_tokens", "output_tokens"])
+@pytest.mark.parametrize("counter", [-1, 1.5, True], ids=["negative", "float", "bool"])
+def test_negative_and_non_integer_counters_are_ignored(metrics: Any, counter_name: str, counter: object) -> None:
     responses = healthy()
-    responses["/get_tool_stats"] = response(
-        {"stats": {"find_symbol": {"num_times_called": counter, "input_tokens": 1, "output_tokens": 1}}}
-    )
+    counters: dict[str, object] = {"num_times_called": 1, "input_tokens": 1, "output_tokens": 1}
+    counters[counter_name] = counter
+    responses["/get_tool_stats"] = response({"stats": {"find_symbol": counters}})
     with listener(responses) as (port, _):
         configure_scan(metrics, port, port)
         assert metrics.discover_instances() == []
@@ -387,8 +437,11 @@ def test_http_surface_rejects_untrusted_host_and_accepts_tailnet_host(metrics: A
         "foo.ts.net:bad",
         "foo.ts.net:443@evil",
         "127.0.0.1:bad",
+        "foo.ts.net..",
+        "127.0.0.1..",
         "foo.ts.net:443:evil",
         "evil@foo.ts.net",
+        ".".join(["a" * 63] * 4) + ".ts.net",
     ],
 )
 def test_http_surface_rejects_malformed_host(metrics: Any, host: str) -> None:


### PR DESCRIPTION
## Summary

- discover live Serena dashboards through their bounded localhost HTTP contract;
- aggregate validated per-tool call and token estimates into read-only HTML and JSON;
- keep the backend on loopback for private publication through Tailscale Serve;
- reject redirects, malformed payloads, oversized/slow responses, malformed Hosts, and every non-GET method.

## Verification

- Frozen initial RED: 20 intentional missing-production errors.
- Preserved pre-hardening RED: 3 failures for nullable Serena state, CSP, and Host validation.
- Frozen review RED at `448c9ee0`: duplicate-Host rejection failed while the other 47 rows passed.
- Final focused GREEN: 48 passed; final test hash `31c5b27a372256b2780c53941a1b2fe1a10e4186`.
- `scripts/agent/run-gates.sh --diff origin/devel`: pytest, Ruff check/format, and mypy passed.
- Independent three-leg review converged cleanly after hostile HTTP/JSON, full-port-range, Host grammar, response-cap, counter-matrix, and arbitrary-method probes.
- Live full-range probe: Serena dashboards discovered across `24282..65535` in 4.16 seconds; tailnet Host accepted and arbitrary/duplicate Hosts rejected with 421.

Fixes #2600

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local metrics dashboard that discovers active Serena instances and aggregates project, identity, estimator, and tool statistics.
  * Added HTML and JSON endpoints for viewing collected metrics.
  * Added configurable startup port support and graceful shutdown handling.

* **Security & Reliability**
  * Added request validation, security headers, safe HTML rendering, input validation, and handling for unavailable or malformed metric sources.

* **Tests**
  * Added comprehensive coverage for discovery, aggregation, HTTP behavior, validation, security, rendering, and command-line usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->