### PR TITLE
fix: parse DShield tab CIDRs by family

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -350,9 +350,10 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 	// issue #2604: DShield start<TAB>end<TAB>prefix rows declare their own
 	// family; accept only one exact CIDR and leave opposite-family rows alone.
 	if ($pftype == 'auto' && strpos($line, "\t") !== FALSE) {
-		$pfb_tab = explode("\t", $line, 4);
+		$pfb_tab = explode("\t", $line);
 		$pfb_tab_family = NULL;
-		if (count($pfb_tab) >= 3 && ctype_digit($pfb_tab[2])) {
+		if (count($pfb_tab) >= 3 && ctype_digit($pfb_tab[2]) &&
+			!str_contains($pfb_tab[0], "\0") && !str_contains($pfb_tab[1], "\0")) {
 			if (validate_ipv4($pfb_tab[0]) && validate_ipv4($pfb_tab[1])) {
 				$pfb_tab_family = '_v4';
 			} elseif (validate_ipv6($pfb_tab[0]) && validate_ipv6($pfb_tab[1])) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -345,29 +345,46 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 			$line = str_replace('#', '', strstr($line, '#', TRUE));
 		}
 		$line = trim($line);
+	}
 
-		// issue #2602: DShield-style start<TAB>end<TAB>prefix. Cheap tab
-		// gate, then a narrow second regex — do not widen $config['range']
-		// (hyphen). Accept only when the derived range is exactly
-		// "{start}/{prefix}"; otherwise fall through (legacy two-host
-		// extract). A reversed start/end is rejected, not swapped:
-		// ip_range_to_subnet_array would swap, so start/prefix cannot
-		// equal the derived cidr.
-		if (strpos($line, "\t") !== FALSE && strpos($line, '.') !== FALSE &&
-			preg_match('/^((?:\d{1,3}\.){3}\d{1,3})\t((?:\d{1,3}\.){3}\d{1,3})\t(\d{1,2})\b/', $line, $pfb_tab)) {
-			$pfb_tab_declared = $pfb_tab[1] . '/' . $pfb_tab[3];
-			$a_cidr = ip_range_to_subnet_array($pfb_tab[1], $pfb_tab[2]);
-			if (count($a_cidr) === 1 && $a_cidr[0] === $pfb_tab_declared) {
-				$sanitized = pfb_sanitize_ipaddr($pfb_tab_declared, $custom, $pfbcidr, $suppression);
-				$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
-				if (!pfb_is_empty($sanitized['address']) && validate_ipv4($sanitized['address'])) {
-					$result['entries'][] = $sanitized['address'];
-				}
+	// issue #2604: DShield start<TAB>end<TAB>prefix rows declare their own
+	// family; accept only one exact CIDR and leave opposite-family rows alone.
+	if ($pftype == 'auto' && strpos($line, "\t") !== FALSE) {
+		$pfb_tab = explode("\t", $line, 4);
+		$pfb_tab_family = NULL;
+		if (count($pfb_tab) >= 3 && ctype_digit($pfb_tab[2])) {
+			if (validate_ipv4($pfb_tab[0]) && validate_ipv4($pfb_tab[1])) {
+				$pfb_tab_family = '_v4';
+			} elseif (validate_ipv6($pfb_tab[0]) && validate_ipv6($pfb_tab[1])) {
+				$pfb_tab_family = '_v6';
+			}
+		}
+		if ($pfb_tab_family !== NULL) {
+			$a_cidr = ip_range_to_subnet_array($pfb_tab[0], $pfb_tab[1]);
+			$pfb_tab_cidr = count($a_cidr) === 1 ? explode('/', $a_cidr[0], 2) : [];
+			if (count($pfb_tab_cidr) === 2 && $pfb_tab_cidr[1] === $pfb_tab[2] &&
+				inet_pton($pfb_tab_cidr[0]) === inet_pton($pfb_tab[0])) {
 				$result['line'] = $line;
+				if ($pfb_tab_family !== $vtype) {
+					return $result;
+				}
+				$sanitized = $vtype == '_v4'
+					? pfb_sanitize_ipaddr($a_cidr[0], $custom, $pfbcidr, $suppression)
+					: pfb_sanitize_ipaddr_v6($a_cidr[0], $custom, $pfbcidr_v6, $suppression);
+				$result['messages'] = array_merge($result['messages'], $sanitized['messages']);
+				if (!pfb_is_empty($sanitized['address']) &&
+					(($vtype == '_v4' && validate_ipv4($sanitized['address'])) ||
+					($vtype == '_v6' && validate_ipv6($sanitized['address'])))) {
+					$result['entries'][] = $sanitized['address'];
+				} elseif ($vtype == '_v6') {
+					$result['suppressed'] = TRUE;
+				}
 				return $result;
 			}
 		}
+	}
 
+	if ($vtype == '_v4' && $pftype == 'auto') {
 		if (strpos($line, '-') !== FALSE) {
 			$matches = explode('-', $line);
 			if (count($matches) == 2) {

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -417,6 +417,32 @@ final class IpParseLineTest extends TestCase
 			$v6Config,
 			$this->expectedResult($v6Row, ['entries' => ['2001:4860:4860::/126']])
 		);
+		$this->assertLine(
+			$v6Row,
+			$this->config('_v6', 'regex', FALSE),
+			$this->expectedResult($v6Row, ['entries' => ['2001:4860:4860::', '2001:4860:4860::3']])
+		);
+	}
+
+	/** DShield tab rows retain the selected family's sanitizer side effects. */
+	public function testAutoDshieldTabRangeReplaysSanitizerSideEffects(): void
+	{
+		$v4Row = "5.61.209.0\t5.61.209.255\t24";
+		$this->assertLine(
+			$v4Row,
+			$this->config('_v4', 'auto', FALSE, 'on', 25),
+			$this->expectedResult($v4Row, [
+				'entries'  => ['5.61.209.0/32'],
+				'messages' => ["\n  Suppression CIDR Limit: 5.61.209.0/24"],
+			])
+		);
+
+		$v6Row = "fd00::\tfd00::3\t126";
+		$this->assertLine(
+			$v6Row,
+			$this->config('_v6', 'auto', FALSE, 'on'),
+			$this->expectedResult($v6Row, ['suppressed' => TRUE])
+		);
 	}
 
 	/**
@@ -459,6 +485,12 @@ final class IpParseLineTest extends TestCase
 		$numericThirdColumn = "2001:4860:4860::\t2001:4860:4860::3\t80\tpayload";
 		$this->assertLine($numericThirdColumn, $config, $this->expectedResult(
 			$numericThirdColumn,
+			$legacyTwo('2001:4860:4860::', '2001:4860:4860::3')
+		));
+
+		$nulEndpoint = "2001:4860:4860::\0\t2001:4860:4860::3\t126";
+		$this->assertLine($nulEndpoint, $config, $this->expectedResult(
+			$nulEndpoint,
 			$legacyTwo('2001:4860:4860::', '2001:4860:4860::3')
 		));
 	}

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -391,4 +391,75 @@ final class IpParseLineTest extends TestCase
 		$ipTabText = "8.8.8.8\tnot-an-address";
 		$this->assertLine($ipTabText, $config, $this->expectedResult($ipTabText, ['entries' => ['8.8.8.8']]));
 	}
+
+	/**
+	 * Scenario: a tab-delimited source contains rows from both address families.
+	 *   Given matching IPv4 and IPv6 alias passes over the same rows
+	 *   When each row is parsed independently
+	 *   Then each pass emits only its family's declared CIDR and ignores the other.
+	 */
+	public function testAutoDshieldTabRangeUsesMatchingFamilyPerLine(): void
+	{
+		$v4Config = $this->config('_v4', 'auto', FALSE);
+		$v6Config = $this->config('_v6', 'auto', FALSE);
+		$v4Row = "5.61.209.0\t5.61.209.255\t24\t339\tASN\tUS\tNone";
+		$v6Row = "2001:4860:4860:0:0:0:0:0\t2001:4860:4860::3\t126\t339\tASN\tUS\tNone";
+
+		$this->assertLine(
+			$v4Row,
+			$v4Config,
+			$this->expectedResult($v4Row, ['entries' => ['5.61.209.0/24']])
+		);
+		$this->assertLine($v6Row, $v4Config, $this->expectedResult($v6Row));
+		$this->assertLine($v4Row, $v6Config, $this->expectedResult($v4Row));
+		$this->assertLine(
+			$v6Row,
+			$v6Config,
+			$this->expectedResult($v6Row, ['entries' => ['2001:4860:4860::/126']])
+		);
+	}
+
+	/**
+	 * Scenario: IPv6 tab rows do not describe exactly one declared CIDR.
+	 *   Given reversed, invalid, contradictory, or overlong rows
+	 *   When parsed by an IPv6 alias pass
+	 *   Then the tab path falls through without silently widening the range.
+	 */
+	public function testIpv6AutoDshieldTabInconsistentPrefixFallsThrough(): void
+	{
+		$config = $this->config('_v6', 'auto', FALSE);
+		$legacyTwo = static function (string $a, string $b): array {
+			return ['entries' => [$a, $b]];
+		};
+
+		$reversed = "2001:4860:4860::3\t2001:4860:4860::\t126";
+		$this->assertLine($reversed, $config, $this->expectedResult(
+			$reversed,
+			$legacyTwo('2001:4860:4860::3', '2001:4860:4860::')
+		));
+
+		$prefix129 = "2001:4860:4860::\t2001:4860:4860::3\t129";
+		$this->assertLine($prefix129, $config, $this->expectedResult(
+			$prefix129,
+			$legacyTwo('2001:4860:4860::', '2001:4860:4860::3')
+		));
+
+		$contradict = "2001:4860:4860::\t2001:4860:4860::3\t127";
+		$this->assertLine($contradict, $config, $this->expectedResult(
+			$contradict,
+			$legacyTwo('2001:4860:4860::', '2001:4860:4860::3')
+		));
+
+		$overlong = "2001:4860:4860::\t2001:4860:4860::4\t126";
+		$this->assertLine($overlong, $config, $this->expectedResult(
+			$overlong,
+			$legacyTwo('2001:4860:4860::', '2001:4860:4860::4')
+		));
+
+		$numericThirdColumn = "2001:4860:4860::\t2001:4860:4860::3\t80\tpayload";
+		$this->assertLine($numericThirdColumn, $config, $this->expectedResult(
+			$numericThirdColumn,
+			$legacyTwo('2001:4860:4860::', '2001:4860:4860::3')
+		));
+	}
 }


### PR DESCRIPTION
Fixes #2604.

## Intent

Parse DShield-style `start<TAB>end<TAB>prefix` rows according to the row's actual address family. IPv4 and IPv6 alias passes can consume a mixed source independently without treating a valid opposite-family row as a parse failure.

## Implementation

- Detect the family by validating both endpoints per row.
- Reuse `ip_range_to_subnet_array()` and accept only one derived CIDR whose prefix and binary network address match the declaration.
- Reuse the existing family sanitizer and preserve family-specific suppression behavior.
- Avoid the new IPv6 first-endpoint NUL fatal before pfSense family validation; pre-existing IPv4 NUL handling remains outside this change and is tracked by #2610.

## Red to green

- Initial frozen test blob: `13d633727be4643cfe25ae77bd70c620b7a6b609`; unchanged `devel` production failed because IPv6 TSV yielded two hosts instead of `/126`.
- Review-fix frozen test blob: `6a172e90183393d759c3087ffa09c111f18fdc88`; prior head errored on a NUL-bearing IPv6 endpoint before the guard was added.
- GREEN on `bd7639e1`: `OK (26 tests, 66 assertions)`.
- Independent verification reproduced the initial RED/GREEN pair; round-two review rechecks both frozen proofs.

## Verification

`scripts/agent/run-gates.sh --diff origin/devel`:

- composer vendor: pass
- PHP syntax: pass
- full PHPUnit: pass
- PHPStan: pass
- PHPCS: pass

Hostile probes covered the IPv6 first-endpoint NUL regression, reversed endpoints, prefix 129, contradictory and overlong ranges, numeric inconsistent prefixes, empty/mixed-family columns, padded prefixes, and a valid IPv6 `/80`. No widened CIDR or amplification was observed. The pre-existing IPv4 NUL fatal is deferred to #2610.

Authorship: implemented by OpenAI Codex; committed with the repository's configured human identity and signing policy.

🤖 Generated by OpenAI Codex and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of auto-format DShield tab-delimited IPv4 and IPv6 address ranges.
  * Validates address families, prefixes, and ranges before accepting CIDR results.
  * Suppresses entries from the opposite configured address family.
  * Falls back safely when ranges are malformed, inconsistent, reversed, or unsupported.
* **Tests**
  * Added coverage for valid IPv4/IPv6 ranges, invalid input, family filtering, and sanitization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->