### PR TITLE
dnsbl: queue the manifest rebuild when a pass finds it gone

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9549,10 +9549,8 @@ function pfb_unbound_py_teardown_raw_set(): bool {
 	try {
 		unlink_if_exists($pfb['unbound_py_sources']);
 		// issue #2607: every Python-emitted artifact describes the generation this manifest
-		// defines, and Python rewrites them only for a build that produced a snapshot -- so
-		// they die with it, or they are read back as live (the entry total by the update log
-		// and by pfb_unbound_py_swap_fits_ram()'s RAM projection, the reject tally by
-		// pfb_emit_entry_reject_stats(), the regex total by the DNSBL_Regex alias count).
+		// defines and is rewritten only for a build that produced a snapshot, so each one
+		// left behind is read back as live by the update log, the RAM gate or the alias count.
 		foreach (array('unbound_py_count', 'unbound_py_regex_count', 'unbound_py_reject_stats') as $emitted) {
 			if (!empty($pfb[$emitted])) {
 				unlink_if_exists($pfb[$emitted]);
@@ -11230,9 +11228,8 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython, array $dnsbl_tld_grou
 	// count meant 'entries removed by subdomain collapse') no longer applies; just
 	// report both numbers for visibility.
 	$loaded_cnt = trim((string) @file_get_contents($pfb['unbound_py_count']));
-	// issue #2607: no emitted count means nothing is loaded -- Python writes the artifact
-	// only for a build that produced a snapshot, and the teardown removes it with the
-	// manifest it describes. Report that as 0 rather than an empty field.
+	// issue #2607: no emitted count means nothing is loaded -- Python writes it only for a
+	// build that produced a snapshot, and the teardown removes it with its manifest.
 	if ($loaded_cnt === '') {
 		$loaded_cnt = '0';
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9548,11 +9548,16 @@ function pfb_unbound_py_teardown_raw_set(): bool {
 	}
 	try {
 		unlink_if_exists($pfb['unbound_py_sources']);
-		// issue #2607: the Python-emitted entry total describes the generation the manifest
-		// defines, so it dies with it. Left behind it is read back as live by the update log
-		// and by pfb_unbound_py_swap_fits_ram(), which sizes the zero-downtime swap's RAM
-		// projection from a snapshot that is no longer loaded.
-		unlink_if_exists($pfb['unbound_py_count'] ?? '/var/unbound/pfb_py_count');
+		// issue #2607: every Python-emitted artifact describes the generation this manifest
+		// defines, and Python rewrites them only for a build that produced a snapshot -- so
+		// they die with it, or they are read back as live (the entry total by the update log
+		// and by pfb_unbound_py_swap_fits_ram()'s RAM projection, the reject tally by
+		// pfb_emit_entry_reject_stats(), the regex total by the DNSBL_Regex alias count).
+		foreach (array('unbound_py_count', 'unbound_py_regex_count', 'unbound_py_reject_stats') as $emitted) {
+			if (!empty($pfb[$emitted])) {
+				unlink_if_exists($pfb[$emitted]);
+			}
+		}
 		pfb_unbound_py_remove_raw_artifact($pfb['unbound_py_rawdir']);
 		$ok = TRUE;
 		foreach (pfb_unbound_py_raw_artifacts($pfb) as $artifact) {
@@ -11238,16 +11243,6 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython, array $dnsbl_tld_grou
 	// parse-stage ledger entry (absent/unparseable/build-failed manifest) here, the
 	// same per-update-pass cadence the MaxMind/VIP notices already use.
 	if (pfb_unbound_py_mode_active()) {
-		// issue #2607: the manifest is GONE, not merely unparseable -- a real `pkg delete`
-		// (a channel switch is one) tears it down, and the reinstall's resync is a
-		// config-save pass, whose feed section (and with it the pfb_dnsbl_manifest_missing()
-		// rebuild gate) is guarded by !$pfb['save']. Nothing else would rebuild it until a
-		// feed next fell due, which on a daily/weekly schedule leaves the resolver empty for
-		// hours. Queue the rebuild for the next tick instead; running a DNSBL pass inline
-		// from the package lifecycle path is what hung the uninstall in issue #682.
-		if (!file_exists($pfb['unbound_py_sources'])) {
-			pfb_due_ledger_set_pending('cron', $pfb['dbdir']);
-		}
 		pfb_dnsbl_manifest_failure_notice();
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -9548,6 +9548,11 @@ function pfb_unbound_py_teardown_raw_set(): bool {
 	}
 	try {
 		unlink_if_exists($pfb['unbound_py_sources']);
+		// issue #2607: the Python-emitted entry total describes the generation the manifest
+		// defines, so it dies with it. Left behind it is read back as live by the update log
+		// and by pfb_unbound_py_swap_fits_ram(), which sizes the zero-downtime swap's RAM
+		// projection from a snapshot that is no longer loaded.
+		unlink_if_exists($pfb['unbound_py_count'] ?? '/var/unbound/pfb_py_count');
 		pfb_unbound_py_remove_raw_artifact($pfb['unbound_py_rawdir']);
 		$ok = TRUE;
 		foreach (pfb_unbound_py_raw_artifacts($pfb) as $artifact) {
@@ -11220,6 +11225,12 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython, array $dnsbl_tld_grou
 	// count meant 'entries removed by subdomain collapse') no longer applies; just
 	// report both numbers for visibility.
 	$loaded_cnt = trim((string) @file_get_contents($pfb['unbound_py_count']));
+	// issue #2607: no emitted count means nothing is loaded -- Python writes the artifact
+	// only for a build that produced a snapshot, and the teardown removes it with the
+	// manifest it describes. Report that as 0 rather than an empty field.
+	if ($loaded_cnt === '') {
+		$loaded_cnt = '0';
+	}
 	$log = "\nDNSBL update [ feed lines: {$dnsbl_cnt} | loaded entries: {$loaded_cnt} ]... completed";
 	pfb_logger("{$log}", 1);
 
@@ -11227,6 +11238,16 @@ function pfb_update_unbound($mode, $pfbupdate, $pfbpython, array $dnsbl_tld_grou
 	// parse-stage ledger entry (absent/unparseable/build-failed manifest) here, the
 	// same per-update-pass cadence the MaxMind/VIP notices already use.
 	if (pfb_unbound_py_mode_active()) {
+		// issue #2607: the manifest is GONE, not merely unparseable -- a real `pkg delete`
+		// (a channel switch is one) tears it down, and the reinstall's resync is a
+		// config-save pass, whose feed section (and with it the pfb_dnsbl_manifest_missing()
+		// rebuild gate) is guarded by !$pfb['save']. Nothing else would rebuild it until a
+		// feed next fell due, which on a daily/weekly schedule leaves the resolver empty for
+		// hours. Queue the rebuild for the next tick instead; running a DNSBL pass inline
+		// from the package lifecycle path is what hung the uninstall in issue #682.
+		if (!file_exists($pfb['unbound_py_sources'])) {
+			pfb_due_ledger_set_pending('cron', $pfb['dbdir']);
+		}
 		pfb_dnsbl_manifest_failure_notice();
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -5835,11 +5835,13 @@ function pfblockerng_tick(
 	// (ADR-65), so it dispatches like a *.fail marker -- same scheduled-updates gate,
 	// but no apply window, which defers changes and must not extend an outage.
 	$manifest_path = (string) ($pfb['unbound_py_sources'] ?? '');
-	// Only a pass that can publish a manifest may be dispatched for a missing one: DNSBL
-	// off takes the disable branch and publishes nothing, and an empty path is a broken
-	// setting, so either would retry every tick forever without repairing anything.
+	// Only a pass that can publish a manifest may be dispatched for a missing one: DNSBL off
+	// takes the disable branch and publishes nothing, and an empty path is a broken setting,
+	// so either would retry every tick forever without repairing anything. The DNSBL state
+	// read here is the EFFECTIVE one -- a manual-mode VIP failure disables it at runtime
+	// (issue #331) while the stored setting still says enabled.
 	$manifest_due = $runtime_ready && $runtime_model !== NULL && $runtime_model['scheduled']
-		&& PfbConfig::read('dnsbl/pfb_dnsbl') === PfbToggle::On
+		&& ($pfb['dnsbl'] ?? PfbToggle::Off) === PfbToggle::On
 		&& pfb_unbound_py_mode_active()
 		&& $manifest_path !== '' && !file_exists($manifest_path);
 	$scheduled_due = $runtime_ready && $cache_ready && $runtime_model !== NULL

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -5831,17 +5831,12 @@ function pfblockerng_tick(
 			}
 		}
 	}
-	// issue #2607: the DNSBL manifest is Python's sole blocklist source (ADR-65), and a
-	// real `pkg delete` tears it down while the reinstall's config-save resync cannot
-	// rebuild it -- so its absence means the resolver is matching nothing. That is a
-	// failure, like a *.fail marker, not a change waiting for a convenient moment:
-	// dispatch on the same footing, apply window included (owner ruling, 2026-08-21).
-	$manifest_due = pfb_unbound_py_mode_active()
+	// issue #2607: an absent manifest means the Python resolver is matching nothing
+	// (ADR-65), so it dispatches like a *.fail marker -- same scheduled-updates gate,
+	// but no apply window, which defers changes and must not extend an outage.
+	$manifest_due = $runtime_ready && $runtime_model !== NULL && $runtime_model['scheduled']
+		&& pfb_unbound_py_mode_active()
 		&& !file_exists((string) ($pfb['unbound_py_sources'] ?? ''));
-	if ($manifest_due) {
-		logger(LOG_NOTICE, localize_text('Tick: DNSBL manifest absent - dispatching a rebuild pass.'),
-			LOG_PREFIX_PKG_PFBLOCKERNG);
-	}
 	$scheduled_due = $runtime_ready && $cache_ready && $runtime_model !== NULL
 		&& $runtime_model['scheduled'] && $cron_due;
 	$scheduled_due = $scheduled_due || ($runtime_ready && $runtime_model !== NULL
@@ -6030,6 +6025,10 @@ function pfblockerng_tick(
 					pfb_due_ledger_set_pending('cron', $dbdir);
 				}
 				if ($feed_due) {
+					if ($manifest_due) {
+						logger(LOG_NOTICE, localize_text('Tick: DNSBL manifest absent - this pass rebuilds it.'),
+							LOG_PREFIX_PKG_PFBLOCKERNG);
+					}
 					logger(LOG_NOTICE, localize_text('Tick: running scheduled feed pass.'), LOG_PREFIX_PKG_PFBLOCKERNG);
 					try {
 						$pending_change = $dcc_changed || ($cron_pending && !$manual_due);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -5831,6 +5831,17 @@ function pfblockerng_tick(
 			}
 		}
 	}
+	// issue #2607: the DNSBL manifest is Python's sole blocklist source (ADR-65), and a
+	// real `pkg delete` tears it down while the reinstall's config-save resync cannot
+	// rebuild it -- so its absence means the resolver is matching nothing. That is a
+	// failure, like a *.fail marker, not a change waiting for a convenient moment:
+	// dispatch on the same footing, apply window included (owner ruling, 2026-08-21).
+	$manifest_due = pfb_unbound_py_mode_active()
+		&& !file_exists((string) ($pfb['unbound_py_sources'] ?? ''));
+	if ($manifest_due) {
+		logger(LOG_NOTICE, localize_text('Tick: DNSBL manifest absent - dispatching a rebuild pass.'),
+			LOG_PREFIX_PKG_PFBLOCKERNG);
+	}
 	$scheduled_due = $runtime_ready && $cache_ready && $runtime_model !== NULL
 		&& $runtime_model['scheduled'] && $cron_due;
 	$scheduled_due = $scheduled_due || ($runtime_ready && $runtime_model !== NULL
@@ -5854,7 +5865,8 @@ function pfblockerng_tick(
 
 	// Active schedule cache and durable markers have one owner: the scheduled process.
 	// Hold both locks through Extras, feed checks, apply work, and final cache publication.
-	if ($manual_due || $scheduled_due || $extras_due || $runtime_pending || ($runtime_ready && !$cache_ready)) {
+	if ($manual_due || $scheduled_due || $extras_due || $runtime_pending || $manifest_due
+		|| ($runtime_ready && !$cache_ready)) {
 		$dispatch_owner = !isset($GLOBALS['pfb_schedule_dispatch_lock'])
 			|| !is_resource($GLOBALS['pfb_schedule_dispatch_lock']);
 		$feed_pass_owner = !isset($GLOBALS['pfb_feed_pass_lock'])
@@ -6012,7 +6024,7 @@ function pfblockerng_tick(
 						}
 					}
 				}
-				$feed_due = $feed_due || $fail_due;
+				$feed_due = $feed_due || $fail_due || $manifest_due;
 				if ($dcc_changed && !$in_win) {
 					pfb_mark_pending_changes();
 					pfb_due_ledger_set_pending('cron', $dbdir);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -5834,9 +5834,14 @@ function pfblockerng_tick(
 	// issue #2607: an absent manifest means the Python resolver is matching nothing
 	// (ADR-65), so it dispatches like a *.fail marker -- same scheduled-updates gate,
 	// but no apply window, which defers changes and must not extend an outage.
+	$manifest_path = (string) ($pfb['unbound_py_sources'] ?? '');
+	// Only a pass that can publish a manifest may be dispatched for a missing one: DNSBL
+	// off takes the disable branch and publishes nothing, and an empty path is a broken
+	// setting, so either would retry every tick forever without repairing anything.
 	$manifest_due = $runtime_ready && $runtime_model !== NULL && $runtime_model['scheduled']
+		&& PfbConfig::read('dnsbl/pfb_dnsbl') === PfbToggle::On
 		&& pfb_unbound_py_mode_active()
-		&& !file_exists((string) ($pfb['unbound_py_sources'] ?? ''));
+		&& $manifest_path !== '' && !file_exists($manifest_path);
 	$scheduled_due = $runtime_ready && $cache_ready && $runtime_model !== NULL
 		&& $runtime_model['scheduled'] && $cron_due;
 	$scheduled_due = $scheduled_due || ($runtime_ready && $runtime_model !== NULL

--- a/tests/php/DnsblLoadedCountTest.php
+++ b/tests/php/DnsblLoadedCountTest.php
@@ -6,47 +6,59 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * issue #2607 — a DNSBL pass that finds the per-feed manifest GONE must leave the
- * rebuild queued for the next tick, and must never report a loaded-entry total it
- * no longer has.
+ * issue #2607 — the loaded-entry total a DNSBL pass reports must belong to the
+ * generation that pass is looking at, never to a previous one.
  *
- * The defect this pins: a real `pkg delete` (a channel switch is one) tears the
- * manifest down, and the reinstall's resync runs as a config-save pass, whose
- * DNSBL feed section — including the pfb_dnsbl_manifest_missing() rebuild gate —
- * is guarded by !$pfb['save']. Unbound comes back up in Python mode with an empty
- * matcher and nothing scheduled the rebuild, so the box blocked nothing until its
- * next DUE FEED pass happened to run (hours, on a daily/weekly feed schedule).
+ * pfb_py_count is written by Python only for a build that produced a snapshot, and
+ * the manifest teardown now removes it along with everything else Python emits. So
+ * "no emitted count" means "nothing is loaded", and the pass says 0. Before this, a
+ * reinstall printed the pre-uninstall total on the line directly above
+ * "DNSBL manifest not loaded: … DNSBL not loaded".
  *
- * The rebuild is deliberately NOT run inline here: heavy work inside the package
- * lifecycle path is what hung the uninstall in issue #682. Queuing it for the
- * 15-minute tick is the whole contract.
+ * The same artifact is the RAM basis pfb_unbound_py_swap_fits_ram() projects the
+ * zero-downtime swap from, so a stale value is not merely a cosmetic log lie.
  */
 #[CoversFunction('pfb_update_unbound')]
-final class DnsblManifestRebuildScheduleTest extends TestCase
+final class DnsblLoadedCountTest extends TestCase
 {
+	private const PFB_KEYS = [
+		'dnsbldir', 'dbdir', 'dnsbl_file', 'dnsdir', 'dnsbl_cache', 'unbound_py_count',
+		'unbound_py_sources', 'unbound_py_rawdir', 'unbound_py_reject_stats', 'chroot_cmd',
+		'dnsbl_python_unmount', 'dnsbl_res_cache', 'dnsbl_cache_flush',
+		'enable', 'dnsbl', 'save', 'dnsbl_tld_wildcard', 'domain_update', 'reuse_dnsbl',
+		'dnsbl_unlock', 'keep', 'install', 'errlog', 'log',
+	];
+
 	private string $dir;
+	/** @var array<string, array{0: bool, 1: mixed}> key => [existed, value] */
 	private array $savedPfb = [];
-	private array $savedG = [];
-	private array $savedConfig = [];
-	private bool $hadConfig = FALSE;
+	/** @var array{0: bool, 1: mixed} */
+	private array $savedVarrun = [FALSE, NULL];
+	/** @var array{0: bool, 1: mixed} */
+	private array $savedUnboundConfig = [FALSE, NULL];
 
 	protected function setUp(): void
 	{
-		$this->dir = sys_get_temp_dir() . '/pfb_manifest_rebuild_' . getmypid() . '_' . uniqid();
+		$this->dir = sys_get_temp_dir() . '/pfb_loaded_count_' . getmypid() . '_' . uniqid();
 		mkdir($this->dir, 0777, TRUE);
-		foreach ([
-			'dnsbldir', 'dbdir', 'dnsbl_file', 'dnsdir', 'dnsbl_cache', 'unbound_py_count',
-			'unbound_py_sources', 'unbound_py_rawdir', 'unbound_py_reject_stats', 'chroot_cmd',
-			'dnsbl_python_unmount', 'dnsbl_res_cache', 'dnsbl_cache_flush',
-			'enable', 'dnsbl', 'save', 'dnsbl_tld_wildcard', 'domain_update', 'reuse_dnsbl',
-			'dnsbl_unlock', 'keep', 'install', 'errlog', 'log',
-		] as $key) {
-			$this->savedPfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : FALSE;
+
+		// Track key EXISTENCE separately from value: several keys below are legitimately
+		// boolean FALSE, so a FALSE sentinel would unset a sibling suite's real value on
+		// teardown instead of restoring it.
+		foreach (self::PFB_KEYS as $key) {
+			$this->savedPfb[$key] = [
+				array_key_exists($key, $GLOBALS['pfb'] ?? []),
+				$GLOBALS['pfb'][$key] ?? NULL,
+			];
 		}
-		$this->savedG['varrun_path'] = array_key_exists('varrun_path', $GLOBALS['g'] ?? [])
-			? $GLOBALS['g']['varrun_path'] : FALSE;
-		$this->hadConfig = array_key_exists('unbound', $GLOBALS['config'] ?? []);
-		$this->savedConfig = $GLOBALS['config']['unbound'] ?? [];
+		$this->savedVarrun = [
+			array_key_exists('varrun_path', $GLOBALS['g'] ?? []),
+			$GLOBALS['g']['varrun_path'] ?? NULL,
+		];
+		$this->savedUnboundConfig = [
+			array_key_exists('unbound', $GLOBALS['config'] ?? []),
+			$GLOBALS['config']['unbound'] ?? NULL,
+		];
 
 		$dnsdir = "{$this->dir}/dnsdir";
 		mkdir($dnsdir);
@@ -79,11 +91,19 @@ final class DnsblManifestRebuildScheduleTest extends TestCase
 		]);
 		$GLOBALS['g']['varrun_path'] = $this->dir;
 		$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];
-		$GLOBALS['pfb_test_process_running'] = ['unbound' => TRUE];
+
+		// Unbound answers "running" once, then reports gone. Without the second half, a
+		// pass that takes the restart fallback (which is exactly what an absent count
+		// forces, the RAM gate failing closed) sits in a real 30-second stop-wait loop.
+		$checks = 0;
+		$GLOBALS['pfb_test_process_running'] = ['unbound' => static function () use (&$checks): bool {
+			$checks++;
+			return $checks === 1;
+		}];
 
 		// A live, healthy generation: manifest published, Python's emitted count on disk.
 		file_put_contents($GLOBALS['pfb']['unbound_py_count'], "11732\n");
-		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], '{"feeds":[]}');
+		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], '{"version":1,"config":{},"feeds":[]}');
 		file_put_contents($GLOBALS['pfb']['unbound_py_reject_stats'], '[]');
 		file_put_contents("{$this->dir}/unbound.conf", "python-script: pfb_unbound.py\n");
 		file_put_contents("{$this->dir}/pfb_py_reload", "1\n");
@@ -97,22 +117,22 @@ final class DnsblManifestRebuildScheduleTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach ($this->savedPfb as $key => $value) {
-			if ($value === FALSE) {
-				unset($GLOBALS['pfb'][$key]);
-			} else {
+		foreach ($this->savedPfb as $key => [$existed, $value]) {
+			if ($existed) {
 				$GLOBALS['pfb'][$key] = $value;
-			}
-		}
-		foreach ($this->savedG as $key => $value) {
-			if ($value === FALSE) {
-				unset($GLOBALS['g'][$key]);
 			} else {
-				$GLOBALS['g'][$key] = $value;
+				unset($GLOBALS['pfb'][$key]);
 			}
 		}
-		if ($this->hadConfig) {
-			$GLOBALS['config']['unbound'] = $this->savedConfig;
+		[$existed, $value] = $this->savedVarrun;
+		if ($existed) {
+			$GLOBALS['g']['varrun_path'] = $value;
+		} else {
+			unset($GLOBALS['g']['varrun_path']);
+		}
+		[$existed, $value] = $this->savedUnboundConfig;
+		if ($existed) {
+			$GLOBALS['config']['unbound'] = $value;
 		} else {
 			unset($GLOBALS['config']['unbound']);
 		}
@@ -148,53 +168,10 @@ final class DnsblManifestRebuildScheduleTest extends TestCase
 	}
 
 	/**
-	 * Scenario: the manifest is gone when a config-save pass runs (the reinstall).
-	 *   Given a healthy pass with a published manifest, nothing is queued;
-	 *   When the manifest has been torn down and the same pass runs again,
-	 *   Then the rebuild is queued for the next tick.
-	 */
-	public function testAbsentManifestQueuesTheRebuildForTheNextTick(): void
-	{
-		$this->runUpdate();
-		$this->assertFalse(
-			pfb_due_ledger_is_pending('cron', $GLOBALS['pfb']['dbdir']),
-			'before-state: a pass over a published manifest must queue no rebuild'
-		);
-
-		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']), 'the teardown removes the manifest');
-		$this->runUpdate();
-
-		$this->assertTrue(
-			pfb_due_ledger_is_pending('cron', $GLOBALS['pfb']['dbdir']),
-			'a pass that finds the manifest gone must queue the DNSBL rebuild for the next tick, '
-			. 'instead of leaving the resolver empty until a feed happens to fall due'
-		);
-	}
-
-	/**
-	 * The rebuild is queued, never performed inline: the package lifecycle path must not
-	 * run a DNSBL pass (issue #682). The queued marker is the only effect.
-	 */
-	public function testAbsentManifestDoesNotRebuildTheManifestInline(): void
-	{
-		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']));
-
-		$this->runUpdate();
-
-		$this->assertFileDoesNotExist(
-			$GLOBALS['pfb']['unbound_py_sources'],
-			'the manifest rebuild belongs to the next tick, not to this config-save pass'
-		);
-	}
-
-	/**
 	 * Scenario: the emitted count must not outlive the generation it describes.
 	 *   Given a published manifest and Python's emitted count, the pass reports that count;
 	 *   When both are gone (Python emits no count for a build that produced nothing),
 	 *   Then the pass reports 0 loaded entries — never the previous generation's total.
-	 *
-	 * The stale value is not only a log lie: pfb_unbound_py_swap_fits_ram() sizes the
-	 * zero-downtime swap's RAM projection from the same artifact.
 	 */
 	public function testLoadedCountIsNotCarriedOverFromAPreviousGeneration(): void
 	{

--- a/tests/php/DnsblManifestRebuildScheduleTest.php
+++ b/tests/php/DnsblManifestRebuildScheduleTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2607 — a DNSBL pass that finds the per-feed manifest GONE must leave the
+ * rebuild queued for the next tick, and must never report a loaded-entry total it
+ * no longer has.
+ *
+ * The defect this pins: a real `pkg delete` (a channel switch is one) tears the
+ * manifest down, and the reinstall's resync runs as a config-save pass, whose
+ * DNSBL feed section — including the pfb_dnsbl_manifest_missing() rebuild gate —
+ * is guarded by !$pfb['save']. Unbound comes back up in Python mode with an empty
+ * matcher and nothing scheduled the rebuild, so the box blocked nothing until its
+ * next DUE FEED pass happened to run (hours, on a daily/weekly feed schedule).
+ *
+ * The rebuild is deliberately NOT run inline here: heavy work inside the package
+ * lifecycle path is what hung the uninstall in issue #682. Queuing it for the
+ * 15-minute tick is the whole contract.
+ */
+#[CoversFunction('pfb_update_unbound')]
+final class DnsblManifestRebuildScheduleTest extends TestCase
+{
+	private string $dir;
+	private array $savedPfb = [];
+	private array $savedG = [];
+	private array $savedConfig = [];
+	private bool $hadConfig = FALSE;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_manifest_rebuild_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0777, TRUE);
+		foreach ([
+			'dnsbldir', 'dbdir', 'dnsbl_file', 'dnsdir', 'dnsbl_cache', 'unbound_py_count',
+			'unbound_py_sources', 'unbound_py_rawdir', 'unbound_py_reject_stats', 'chroot_cmd',
+			'dnsbl_python_unmount', 'dnsbl_res_cache', 'dnsbl_cache_flush',
+			'enable', 'dnsbl', 'save', 'dnsbl_tld_wildcard', 'domain_update', 'reuse_dnsbl',
+			'dnsbl_unlock', 'keep', 'install', 'errlog', 'log',
+		] as $key) {
+			$this->savedPfb[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$key] : FALSE;
+		}
+		$this->savedG['varrun_path'] = array_key_exists('varrun_path', $GLOBALS['g'] ?? [])
+			? $GLOBALS['g']['varrun_path'] : FALSE;
+		$this->hadConfig = array_key_exists('unbound', $GLOBALS['config'] ?? []);
+		$this->savedConfig = $GLOBALS['config']['unbound'] ?? [];
+
+		$dnsdir = "{$this->dir}/dnsdir";
+		mkdir($dnsdir);
+		$GLOBALS['pfb'] = array_replace($GLOBALS['pfb'], [
+			'dnsbldir' => $this->dir,
+			'dbdir' => $this->dir,
+			'dnsbl_file' => "{$this->dir}/pfb_dnsbl",
+			'dnsdir' => $dnsdir,
+			'dnsbl_cache' => "{$this->dir}/pfb_py_cache.sqlite",
+			'unbound_py_count' => "{$this->dir}/pfb_py_count",
+			'unbound_py_sources' => "{$this->dir}/pfb_py_sources.json",
+			'unbound_py_rawdir' => "{$this->dir}/pfb_py_raw",
+			'unbound_py_reject_stats' => "{$this->dir}/pfb_py_reject_stats.json",
+			'chroot_cmd' => "{$this->dir}/unbound-control-recorder",
+			'dnsbl_python_unmount' => FALSE,
+			'dnsbl_res_cache' => PfbToggle::On,
+			'dnsbl_cache_flush' => PfbToggle::Off,
+			'enable' => PfbToggle::On,
+			'dnsbl' => PfbToggle::On,
+			// The install/uninstall resync pass: config-save only, no feed processing.
+			'save' => TRUE,
+			'dnsbl_tld_wildcard' => FALSE,
+			'domain_update' => FALSE,
+			'reuse_dnsbl' => '',
+			'dnsbl_unlock' => "{$this->dir}/dnsbl_unlock",
+			'keep' => PfbToggle::On,
+			'install' => FALSE,
+			'errlog' => "{$this->dir}/error.log",
+			'log' => "{$this->dir}/pfblockerng.log",
+		]);
+		$GLOBALS['g']['varrun_path'] = $this->dir;
+		$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];
+		$GLOBALS['pfb_test_process_running'] = ['unbound' => TRUE];
+
+		// A live, healthy generation: manifest published, Python's emitted count on disk.
+		file_put_contents($GLOBALS['pfb']['unbound_py_count'], "11732\n");
+		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], '{"feeds":[]}');
+		file_put_contents($GLOBALS['pfb']['unbound_py_reject_stats'], '[]');
+		file_put_contents("{$this->dir}/unbound.conf", "python-script: pfb_unbound.py\n");
+		file_put_contents("{$this->dir}/pfb_py_reload", "1\n");
+		file_put_contents("{$this->dir}/pfb_py_reload.applied", "1\n");
+		file_put_contents($GLOBALS['pfb']['chroot_cmd'], "#!/bin/sh\nexit 0\n");
+		chmod($GLOBALS['pfb']['chroot_cmd'], 0755);
+		$GLOBALS['pfb_test_unbound_py_sentinel_published'] = static function (string $path, int $generation): void {
+			file_put_contents("{$path}.applied", "{$generation}\n");
+		};
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedPfb as $key => $value) {
+			if ($value === FALSE) {
+				unset($GLOBALS['pfb'][$key]);
+			} else {
+				$GLOBALS['pfb'][$key] = $value;
+			}
+		}
+		foreach ($this->savedG as $key => $value) {
+			if ($value === FALSE) {
+				unset($GLOBALS['g'][$key]);
+			} else {
+				$GLOBALS['g'][$key] = $value;
+			}
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config']['unbound'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']['unbound']);
+		}
+		unset(
+			$GLOBALS['pfb_test_process_running'],
+			$GLOBALS['pfb_test_sysctl'],
+			$GLOBALS['pfb_test_unbound_py_sentinel_published']
+		);
+		rmdir_recursive($this->dir);
+	}
+
+	/** macOS tempnam() emits an E_NOTICE the atomic writer cannot avoid; it is not under test. */
+	private function runUpdate(): void
+	{
+		set_error_handler(static function (int $severity, string $message): bool {
+			return $severity === E_NOTICE && str_contains($message, 'tempnam(): file created in the system');
+		});
+		try {
+			pfb_update_unbound('enabled', FALSE, FALSE);
+		} finally {
+			restore_error_handler();
+		}
+	}
+
+	/** The last "DNSBL update [ ... ]" line the pass appended to the runtime log. */
+	private function lastUpdateLine(): string
+	{
+		$log = (string) @file_get_contents($GLOBALS['pfb']['log']);
+		$matches = [];
+		$this->assertNotSame(0, preg_match_all('/DNSBL update \[[^\]]*\]/', $log, $matches),
+			"the pass must log its DNSBL update line; log was:\n{$log}");
+		return (string) end($matches[0]);
+	}
+
+	/**
+	 * Scenario: the manifest is gone when a config-save pass runs (the reinstall).
+	 *   Given a healthy pass with a published manifest, nothing is queued;
+	 *   When the manifest has been torn down and the same pass runs again,
+	 *   Then the rebuild is queued for the next tick.
+	 */
+	public function testAbsentManifestQueuesTheRebuildForTheNextTick(): void
+	{
+		$this->runUpdate();
+		$this->assertFalse(
+			pfb_due_ledger_is_pending('cron', $GLOBALS['pfb']['dbdir']),
+			'before-state: a pass over a published manifest must queue no rebuild'
+		);
+
+		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']), 'the teardown removes the manifest');
+		$this->runUpdate();
+
+		$this->assertTrue(
+			pfb_due_ledger_is_pending('cron', $GLOBALS['pfb']['dbdir']),
+			'a pass that finds the manifest gone must queue the DNSBL rebuild for the next tick, '
+			. 'instead of leaving the resolver empty until a feed happens to fall due'
+		);
+	}
+
+	/**
+	 * The rebuild is queued, never performed inline: the package lifecycle path must not
+	 * run a DNSBL pass (issue #682). The queued marker is the only effect.
+	 */
+	public function testAbsentManifestDoesNotRebuildTheManifestInline(): void
+	{
+		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']));
+
+		$this->runUpdate();
+
+		$this->assertFileDoesNotExist(
+			$GLOBALS['pfb']['unbound_py_sources'],
+			'the manifest rebuild belongs to the next tick, not to this config-save pass'
+		);
+	}
+
+	/**
+	 * Scenario: the emitted count must not outlive the generation it describes.
+	 *   Given a published manifest and Python's emitted count, the pass reports that count;
+	 *   When both are gone (Python emits no count for a build that produced nothing),
+	 *   Then the pass reports 0 loaded entries — never the previous generation's total.
+	 *
+	 * The stale value is not only a log lie: pfb_unbound_py_swap_fits_ram() sizes the
+	 * zero-downtime swap's RAM projection from the same artifact.
+	 */
+	public function testLoadedCountIsNotCarriedOverFromAPreviousGeneration(): void
+	{
+		$this->runUpdate();
+		$this->assertStringContainsString('loaded entries: 11732', $this->lastUpdateLine(),
+			'before-state: the pass reports the emitted count while the generation is live');
+
+		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']));
+		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_count']));
+		$this->runUpdate();
+
+		$line = $this->lastUpdateLine();
+		$this->assertStringNotContainsString('11732', $line,
+			'a pass with nothing loaded must not report the previous generation\'s entry total');
+		$this->assertStringContainsString('loaded entries: 0', $line,
+			'no emitted count means nothing is loaded, and the log must say so');
+	}
+}

--- a/tests/php/DnsblManifestTickRecoveryTest.php
+++ b/tests/php/DnsblManifestTickRecoveryTest.php
@@ -237,6 +237,24 @@ final class DnsblManifestTickRecoveryTest extends TestCase
 	}
 
 	/**
+	 * Scheduled Feed Updates OFF is an explicit opt-out of automatic dispatch, and the
+	 * *.fail marker this recovery is modelled on honours it (its due-condition is gated on
+	 * $runtime_model['scheduled']). A missing manifest gets the same treatment: the operator
+	 * is still told through the DNSBL notice, and the rebuild waits for their own Update.
+	 */
+	public function testMissingManifestIsIgnoredWhenScheduledFeedUpdatesAreOff(): void
+	{
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_scheduled_feed_updates', '');
+		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']));
+
+		$this->tick();
+
+		$this->assertSame(0, $this->feedRuns,
+			'with scheduled feed updates opted out, a missing manifest must not force an '
+			. 'automatic pass -- the same gate the *.fail dispatch respects');
+	}
+
+	/**
 	 * The contract belongs to Python mode: with the resolver not wired to pfb_unbound.py
 	 * the manifest is not its blocklist source, so its absence dispatches nothing.
 	 */

--- a/tests/php/DnsblManifestTickRecoveryTest.php
+++ b/tests/php/DnsblManifestTickRecoveryTest.php
@@ -94,6 +94,7 @@ final class DnsblManifestTickRecoveryTest extends TestCase
 			config_set_path('installedpackages/pfblockerngdnsblsettings/config/0/' . $key, $value);
 		}
 		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+		PfbConfig::writeSystem('dnsbl/pfb_dnsbl', PfbToggle::On);
 		$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
 		config_set_path('installedpackages/pfblockernglistsv4/config', [[
 			'action' => 'Deny_Inbound',
@@ -261,6 +262,38 @@ final class DnsblManifestTickRecoveryTest extends TestCase
 		$this->assertSame(0, $this->feedRuns,
 			'with scheduled feed updates opted out, a missing manifest must not force an '
 			. 'automatic pass -- the same gate the *.fail dispatch respects');
+	}
+
+	/**
+	 * With DNSBL switched off, a dispatched pass takes the disable branch and publishes no
+	 * manifest — so dispatching on its absence would repeat every tick forever without ever
+	 * repairing anything. There is nothing to repair: DNSBL is off.
+	 */
+	public function testMissingManifestIsIgnoredWhenDnsblIsDisabled(): void
+	{
+		PfbConfig::writeSystem('dnsbl/pfb_dnsbl', PfbToggle::Off);
+		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']));
+
+		$this->tick();
+
+		$this->assertSame(0, $this->feedRuns,
+			'with DNSBL disabled no pass can publish a manifest, so dispatching on its absence '
+			. 'would be an unbounded retry loop');
+	}
+
+	/**
+	 * A manifest path that is empty rather than merely missing is a broken configuration,
+	 * not an empty resolver: file_exists('') is false, so without this guard every tick
+	 * would read it as "manifest gone" and dispatch forever.
+	 */
+	public function testEmptyManifestPathDoesNotDispatch(): void
+	{
+		$GLOBALS['pfb']['unbound_py_sources'] = '';
+
+		$this->tick();
+
+		$this->assertSame(0, $this->feedRuns,
+			'an unset manifest path must not be read as an absent manifest');
 	}
 
 	/**

--- a/tests/php/DnsblManifestTickRecoveryTest.php
+++ b/tests/php/DnsblManifestTickRecoveryTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2607 — a DNSBL manifest that is GONE must get an update pass from the very
+ * next tick, whatever else is or is not due, and whatever the apply window says.
+ *
+ * The manifest is Python's sole DNSBL source (ADR-65). A real `pkg delete` tears it
+ * down, and the reinstall's resync is a config-save pass, whose feed section — and
+ * with it the pfb_dnsbl_manifest_missing() rebuild gate — is guarded by !$pfb['save'].
+ * So the resolver comes back up matching nothing and stays that way until a feed
+ * happens to fall due: minutes on an hourly schedule, a day on a daily one.
+ *
+ * This is a failure condition, not a change waiting for a convenient moment, so it
+ * dispatches on the same footing as a *.fail marker — outside the quiet-hours window
+ * too (owner ruling, 2026-08-21: a box mid-upgrade has bigger concerns than deferring
+ * a feed download). Quiet hours defer things the operator chose to defer; they must
+ * not extend an outage.
+ */
+final class DnsblManifestTickRecoveryTest extends TestCase
+{
+	private string $dir = '';
+	private string $stateDir = '';
+	private mixed $originalPfb = NULL;
+	private mixed $originalConfig = NULL;
+	private mixed $originalG = NULL;
+	private int $feedRuns = 0;
+
+	protected function setUp(): void
+	{
+		$this->originalPfb = $GLOBALS['pfb'];
+		$this->originalConfig = $GLOBALS['config'] ?? NULL;
+		$this->originalG = $GLOBALS['g'] ?? NULL;
+		$this->dir = sys_get_temp_dir() . '/pfb_manifest_tick_' . getmypid() . '_' . uniqid();
+		$this->stateDir = $this->dir . '/state';
+		mkdir($this->stateDir, 0755, TRUE);
+		$GLOBALS['pfb']['dbdir'] = $this->dir;
+		$GLOBALS['pfb']['schedule_state_dir'] = $this->stateDir;
+		$GLOBALS['pfb']['runlog'] = $this->dir . '/run.log';
+		$GLOBALS['pfb']['extraslog'] = $this->dir . '/extras.log';
+		$GLOBALS['pfb']['log'] = $this->dir . '/pfb.log';
+		$GLOBALS['pfb']['logdir'] = $this->dir;
+		$GLOBALS['pfb']['errlog'] = $this->dir . '/error.log';
+		$GLOBALS['pfb']['denydir'] = $this->dir . '/deny';
+		$GLOBALS['pfb']['matchdir'] = $this->dir . '/match';
+		$GLOBALS['pfb']['permitdir'] = $this->dir . '/permit';
+		$GLOBALS['pfb']['nativedir'] = $this->dir . '/native';
+		$GLOBALS['pfb']['dnsdir'] = $this->dir . '/dnsbl';
+		foreach (['denydir', 'matchdir', 'permitdir', 'nativedir', 'dnsdir'] as $dir) {
+			mkdir($GLOBALS['pfb'][$dir], 0755, TRUE);
+		}
+		$GLOBALS['pfb']['enable'] = PfbToggle::On;
+		$GLOBALS['pfb']['blconfig'] = [];
+		$GLOBALS['pfb']['php'] = $this->recorder();
+		$GLOBALS['pfb']['unbound_py_sources'] = $this->dir . '/pfb_py_sources.json';
+		$GLOBALS['config'] = [];
+
+		// Live Python mode: the manifest is the resolver's only blocklist source.
+		$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];
+
+		// A schedule whose next occurrence is a day out: nothing is due this tick, so a
+		// dispatch can only have come from the missing manifest.
+		$now = new DateTimeImmutable('now', new DateTimeZone(date_default_timezone_get()));
+		$slot = $now->modify('+1 day');
+		$minute = intdiv((int) $slot->format('i'), 15) * 15;
+
+		// An apply window that does NOT contain now, so a queued manual apply would be
+		// deferred out of this tick entirely.
+		$closed_from = $now->modify('+2 hours');
+		$closed_to = $now->modify('+3 hours');
+		$quiet_hours = $closed_from->format('H:i') . '-' . $closed_to->format('H:i');
+
+		$general = [
+			'pfb_scheduled_feed_updates' => 'on',
+			'pfb_schedule_weekday' => $slot->format('N'),
+			'pfb_schedule_hour' => $slot->format('G'),
+			'pfb_schedule_minute' => (string) $minute,
+			'pfb_quiet_hours' => $quiet_hours,
+			'skipfeed' => '0',
+		];
+		foreach ($general as $key => $value) {
+			config_set_path('installedpackages/pfblockerng/config/0/' . $key, $value);
+		}
+		foreach (['suppression' => '', 'database_cc' => '', 'maxmind_locale' => 'en',
+			'asn_reporting' => 'disabled', 'asn_token' => '', 'maxmind_account' => '',
+			'maxmind_key' => ''] as $key => $value) {
+			config_set_path('installedpackages/pfblockerngipsettings/config/0/' . $key, $value);
+		}
+		foreach (['pfb_dnsvip4' => '', 'pfb_dnsvip6' => '', 'pfb_dnsport' => '8081',
+			'pfb_dnsport_ssl' => '8443'] as $key => $value) {
+			config_set_path('installedpackages/pfblockerngdnsblsettings/config/0/' . $key, $value);
+		}
+		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
+		$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
+		config_set_path('installedpackages/pfblockernglistsv4/config', [[
+			'action' => 'Deny_Inbound',
+			'cron' => 'EveryDay',
+			'schedule_override' => '',
+			'row' => [['header' => 'runtime', 'url' => 'https://example.test/feed', 'state' => 'Enabled']],
+		]]);
+		config_set_path('installedpackages/pfblockernglistsv6/config', []);
+		config_set_path('installedpackages/pfblockerngdnsbl/config', []);
+
+		$model = pfb_schedule_runtime_model(
+			[
+				'pfb_scheduled_feed_updates' => 'on',
+				'pfb_schedule_weekday' => $slot->format('N'),
+				'pfb_schedule_hour' => $slot->format('G'),
+				'pfb_schedule_minute' => (string) $minute,
+			],
+			[
+				'ipv4' => config_get_path('installedpackages/pfblockernglistsv4/config', []),
+				'ipv6' => [],
+				'dnsbl' => [],
+			]
+		);
+		$this->assertIsArray($model);
+		$future = time() + 86400;
+		$this->assertTrue(pfb_due_ledger_write_cache([
+			'cron' => ['last_run' => time(), 'next_due' => $future, 'jitter' => 0],
+			'dcc' => ['last_run' => $future - 1, 'next_due' => $future, 'jitter' => 0],
+			'bl' => ['last_run' => $future - 1, 'next_due' => $future, 'jitter' => 0],
+			'ss_refresh' => ['last_run' => $future - 1, 'next_due' => $future, 'jitter' => 0],
+			'apply_reconcile' => ['last_run' => $future - 1, 'next_due' => $future, 'jitter' => 0],
+		], $model['config_hash'], $this->dir));
+
+		// A published manifest is the healthy baseline every test starts from.
+		file_put_contents($GLOBALS['pfb']['unbound_py_sources'], '{"version":1,"config":{},"feeds":[]}');
+
+		// Settle the schedule: a feed that has never run counts its current occurrence as
+		// pending, which would dispatch on its own and mask what these tests measure. One
+		// warm-up tick completes it, leaving a steady state with nothing outstanding.
+		$this->warmUp();
+		$GLOBALS['pfb_test_logger_calls'] = [];
+	}
+
+	/** Drive one tick that completes every pending occurrence, then reset the counters. */
+	private function warmUp(): void
+	{
+		pfblockerng_tick(
+			[], NULL, NULL, 5.0, static fn (): bool => TRUE, NULL, 5.0,
+			static fn (string $_job, string $_argument = ''): bool => TRUE,
+			function (): void {
+				$state = pfb_schedule_state_read($this->stateDir);
+				foreach ($state['items'] ?? [] as $id => $item) {
+					if (!str_starts_with($id, 'extra:') && isset($item['pending_occurrence'])) {
+						pfb_schedule_state_record_outcome(
+							$id, PfbScheduleTerminalResult::Success, $this->stateDir
+						);
+					}
+				}
+			},
+			static fn (): bool => TRUE
+		);
+		$this->feedRuns = 0;
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['pfb'] = $this->originalPfb;
+		$GLOBALS['config'] = $this->originalConfig;
+		$GLOBALS['g'] = $this->originalG;
+		unset($GLOBALS['pfb_test_logger_calls']);
+		$this->remove($this->dir);
+	}
+
+	/** Neutered $pfb['php'] so any real dispatch branch records instead of spawning. */
+	private function recorder(): string
+	{
+		$path = $this->dir . '/php-recorder';
+		file_put_contents($path, "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> " . escapeshellarg($this->dir . '/spawns') . "\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	private function remove(string $path): void
+	{
+		if (is_dir($path) && !is_link($path)) {
+			foreach (scandir($path) ?: [] as $entry) {
+				if ($entry !== '.' && $entry !== '..') {
+					$this->remove("{$path}/{$entry}");
+				}
+			}
+			@rmdir($path);
+			return;
+		}
+		@unlink($path);
+	}
+
+	private function tick(): void
+	{
+		pfblockerng_tick(
+			[], NULL, NULL, 5.0, static fn (): bool => TRUE, NULL, 5.0,
+			static fn (string $_job, string $_argument = ''): bool => TRUE,
+			function (): void {
+				$this->feedRuns++;
+			},
+			static fn (): bool => TRUE
+		);
+	}
+
+	/** The window really is shut, so a dispatch cannot be the window letting work through. */
+	public function testTheApplyWindowIsClosedForTheseTests(): void
+	{
+		$this->assertFalse(
+			pfb_quiet_hours_in_window(time(), (string) PfbConfig::read('gen/pfb_quiet_hours')),
+			'fixture precondition: now must sit outside the configured apply window'
+		);
+	}
+
+	/**
+	 * Scenario: nothing is due and the window is shut.
+	 *   Given a published manifest, the tick dispatches nothing;
+	 *   When the manifest is gone (the teardown of a real `pkg delete`),
+	 *   Then the very next tick runs an update pass anyway.
+	 */
+	public function testMissingManifestDispatchesAnUpdatePassOutsideTheApplyWindow(): void
+	{
+		$this->tick();
+		$this->assertSame(0, $this->feedRuns,
+			'before-state: with the manifest published and nothing due, a shut window dispatches nothing');
+
+		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']));
+		$this->tick();
+
+		$this->assertSame(1, $this->feedRuns,
+			'a missing DNSBL manifest must dispatch an update pass on the next tick, rather than leaving '
+			. 'the resolver matching nothing until a feed falls due');
+		$this->assertContains(
+			'Tick: running scheduled feed pass.',
+			array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'),
+			'the recovery pass must be visible in the log, not silent'
+		);
+	}
+
+	/**
+	 * The contract belongs to Python mode: with the resolver not wired to pfb_unbound.py
+	 * the manifest is not its blocklist source, so its absence dispatches nothing.
+	 */
+	public function testMissingManifestIsIgnoredWhenPythonModeIsNotLive(): void
+	{
+		$GLOBALS['config']['unbound'] = ['python' => '', 'python_script' => ''];
+		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']));
+
+		$this->tick();
+
+		$this->assertSame(0, $this->feedRuns,
+			'without the Python integration live there is no manifest contract to repair');
+	}
+}

--- a/tests/php/DnsblManifestTickRecoveryTest.php
+++ b/tests/php/DnsblManifestTickRecoveryTest.php
@@ -229,18 +229,27 @@ final class DnsblManifestTickRecoveryTest extends TestCase
 		$this->assertSame(1, $this->feedRuns,
 			'a missing DNSBL manifest must dispatch an update pass on the next tick, rather than leaving '
 			. 'the resolver matching nothing until a feed falls due');
+		$messages = array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message');
 		$this->assertContains(
 			'Tick: running scheduled feed pass.',
-			array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'),
+			$messages,
 			'the recovery pass must be visible in the log, not silent'
+		);
+		$this->assertContains(
+			'Tick: DNSBL manifest absent - this pass rebuilds it.',
+			$messages,
+			'an out-of-window pass needs its reason on the record, or the operator sees only '
+			. 'an update that ran when they asked for none to'
 		);
 	}
 
 	/**
 	 * Scheduled Feed Updates OFF is an explicit opt-out of automatic dispatch, and the
 	 * *.fail marker this recovery is modelled on honours it (its due-condition is gated on
-	 * $runtime_model['scheduled']). A missing manifest gets the same treatment: the operator
-	 * is still told through the DNSBL notice, and the rebuild waits for their own Update.
+	 * $runtime_model['scheduled']). A missing manifest gets the same treatment, and the box
+	 * is not left silent about it: the GUI notice pfb_dnsbl_manifest_failure_notice() raises
+	 * from the pass that found the manifest gone is independent of both the tick and this
+	 * toggle. Only the automatic rebuild waits for the Update the operator runs themselves.
 	 */
 	public function testMissingManifestIsIgnoredWhenScheduledFeedUpdatesAreOff(): void
 	{

--- a/tests/php/DnsblManifestTickRecoveryTest.php
+++ b/tests/php/DnsblManifestTickRecoveryTest.php
@@ -95,6 +95,10 @@ final class DnsblManifestTickRecoveryTest extends TestCase
 		}
 		config_set_path('installedpackages/pfblockerngglobal/pfbextdns', '8.8.8.8');
 		PfbConfig::writeSystem('dnsbl/pfb_dnsbl', PfbToggle::On);
+		// ADR-13 auto-VIP: without it, pfb_global()'s manual-mode VIP validation force-disables
+		// DNSBL at runtime for these VIP-less fixtures, so the box under test would not be one
+		// where DNSBL is actually live.
+		PfbConfig::writeSystem('dnsbl/pfb_dnsvip_auto', PfbToggle::On);
 		$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
 		config_set_path('installedpackages/pfblockernglistsv4/config', [[
 			'action' => 'Deny_Inbound',
@@ -272,6 +276,7 @@ final class DnsblManifestTickRecoveryTest extends TestCase
 	public function testMissingManifestIsIgnoredWhenDnsblIsDisabled(): void
 	{
 		PfbConfig::writeSystem('dnsbl/pfb_dnsbl', PfbToggle::Off);
+		$GLOBALS['pfb']['dnsbl'] = PfbToggle::Off;
 		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']));
 
 		$this->tick();
@@ -279,6 +284,27 @@ final class DnsblManifestTickRecoveryTest extends TestCase
 		$this->assertSame(0, $this->feedRuns,
 			'with DNSBL disabled no pass can publish a manifest, so dispatching on its absence '
 			. 'would be an unbounded retry loop');
+	}
+
+	/**
+	 * DNSBL can be enabled in the configuration and still be OFF at runtime: manual VIP mode
+	 * with a missing or invalid sinkhole VIP makes pfb_global() force-disable it (issue #331).
+	 * A pass dispatched in that state publishes no manifest either, so the gate has to read
+	 * the effective value, not the stored one.
+	 */
+	public function testMissingManifestIsIgnoredWhenAnInvalidVipDisablesDnsblAtRuntime(): void
+	{
+		PfbConfig::writeSystem('dnsbl/pfb_dnsvip_auto', PfbToggle::Off);
+		$GLOBALS['pfb']['dnsbl'] = PfbToggle::Off;
+		$this->assertSame(PfbToggle::On, PfbConfig::read('dnsbl/pfb_dnsbl'),
+			'before-state: the stored setting still says DNSBL is enabled');
+		$this->assertTrue(unlink($GLOBALS['pfb']['unbound_py_sources']));
+
+		$this->tick();
+
+		$this->assertSame(0, $this->feedRuns,
+			'a runtime-disabled DNSBL publishes no manifest, so dispatching on its absence '
+			. 'would retry every tick forever -- the gate must read the effective state');
 	}
 
 	/**

--- a/tests/php/Top1mTeardownDirectoryTest.php
+++ b/tests/php/Top1mTeardownDirectoryTest.php
@@ -24,6 +24,8 @@ final class Top1mTeardownDirectoryTest extends TestCase
 			'errlog'             => "{$this->tmp}/error.log",
 			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
 			'unbound_py_count'   => "{$this->tmp}/pfb_py_count",
+			'unbound_py_regex_count' => "{$this->tmp}/pfb_py_regex_count",
+			'unbound_py_reject_stats' => "{$this->tmp}/pfb_py_reject_stats.json",
 			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
 			'unbound_py_top1m'   => "{$this->tmp}/unbound/pfb_py_top1m.txt",
 			'dbdir'              => "{$this->tmp}/db",
@@ -102,24 +104,38 @@ final class Top1mTeardownDirectoryTest extends TestCase
 	}
 
 	/**
-	 * issue #2607: pfb_py_count is Python's emitted total for the generation the manifest
-	 * describes, so it cannot survive the manifest's teardown. Left behind, it is read back
-	 * as a live figure by the update log AND by pfb_unbound_py_swap_fits_ram(), which sizes
-	 * the zero-downtime swap's RAM projection from it — after a `pkg delete` + reinstall that
-	 * is a snapshot no longer loaded.
+	 * issue #2607: every pfb_py_* artifact Python emits describes the generation the manifest
+	 * defines, and Python rewrites them only for a build that produced a snapshot — so none of
+	 * them may survive the manifest's teardown. Left behind, each is read back as live:
+	 * pfb_py_count by the update log and by pfb_unbound_py_swap_fits_ram(), which sizes the
+	 * zero-downtime swap's RAM projection from it; pfb_py_reject_stats by
+	 * pfb_emit_entry_reject_stats(), which replays a dead generation's stage=entries lines;
+	 * pfb_py_regex_count by the DNSBL_Regex alias count. After a `pkg delete` + reinstall all
+	 * three describe a snapshot that is no longer loaded.
 	 */
-	public function testTeardownRemovesTheEmittedCountAlongsideTheManifest(): void
+	public function testTeardownRemovesEveryEmittedArtifactAlongsideTheManifest(): void
 	{
 		$manifest = $GLOBALS['pfb']['unbound_py_sources'];
-		$count = $GLOBALS['pfb']['unbound_py_count'];
+		$emitted = [
+			'count' => $GLOBALS['pfb']['unbound_py_count'],
+			'regex count' => $GLOBALS['pfb']['unbound_py_regex_count'],
+			'reject tally' => $GLOBALS['pfb']['unbound_py_reject_stats'],
+		];
 		$this->assertNotFalse(file_put_contents($manifest, '{"feeds":[]}'), "seed {$manifest}");
-		$this->assertNotFalse(file_put_contents($count, "11732\n"), "seed {$count}");
+		$this->assertNotFalse(file_put_contents($emitted['count'], "11732\n"));
+		$this->assertNotFalse(file_put_contents($emitted['regex count'], "4\n"));
+		$this->assertNotFalse(file_put_contents($emitted['reject tally'],
+			'[{"feed":"StaleFeed","group":"StaleGroup","shape":3}]'));
 
-		$this->assertFileExists($count, 'before-state: the emitted count is on disk');
+		foreach ($emitted as $label => $path) {
+			$this->assertFileExists($path, "before-state: the emitted {$label} is on disk");
+		}
 		$this->assertTrue(pfb_unbound_py_teardown_raw_set());
 
 		$this->assertFileDoesNotExist($manifest, 'the teardown removes the manifest');
-		$this->assertFileDoesNotExist($count,
-			'the emitted count must not outlive the manifest generation it describes');
+		foreach ($emitted as $label => $path) {
+			$this->assertFileDoesNotExist($path,
+				"the emitted {$label} must not outlive the manifest generation it describes");
+		}
 	}
 }

--- a/tests/php/Top1mTeardownDirectoryTest.php
+++ b/tests/php/Top1mTeardownDirectoryTest.php
@@ -23,6 +23,7 @@ final class Top1mTeardownDirectoryTest extends TestCase
 			'log'                => "{$this->tmp}/pfblockerng.log",
 			'errlog'             => "{$this->tmp}/error.log",
 			'unbound_py_sources' => "{$this->tmp}/pfb_py_sources.json",
+			'unbound_py_count'   => "{$this->tmp}/pfb_py_count",
 			'unbound_py_rawdir'  => "{$this->tmp}/pfb_py_raw",
 			'unbound_py_top1m'   => "{$this->tmp}/unbound/pfb_py_top1m.txt",
 			'dbdir'              => "{$this->tmp}/db",
@@ -98,5 +99,27 @@ final class Top1mTeardownDirectoryTest extends TestCase
 			$this->assertSame('keep', file_get_contents($path), "preserved {$path}");
 		}
 		$this->assertTrue(pfb_unbound_py_teardown_raw_set(), 'second teardown is idempotent');
+	}
+
+	/**
+	 * issue #2607: pfb_py_count is Python's emitted total for the generation the manifest
+	 * describes, so it cannot survive the manifest's teardown. Left behind, it is read back
+	 * as a live figure by the update log AND by pfb_unbound_py_swap_fits_ram(), which sizes
+	 * the zero-downtime swap's RAM projection from it — after a `pkg delete` + reinstall that
+	 * is a snapshot no longer loaded.
+	 */
+	public function testTeardownRemovesTheEmittedCountAlongsideTheManifest(): void
+	{
+		$manifest = $GLOBALS['pfb']['unbound_py_sources'];
+		$count = $GLOBALS['pfb']['unbound_py_count'];
+		$this->assertNotFalse(file_put_contents($manifest, '{"feeds":[]}'), "seed {$manifest}");
+		$this->assertNotFalse(file_put_contents($count, "11732\n"), "seed {$count}");
+
+		$this->assertFileExists($count, 'before-state: the emitted count is on disk');
+		$this->assertTrue(pfb_unbound_py_teardown_raw_set());
+
+		$this->assertFileDoesNotExist($manifest, 'the teardown removes the manifest');
+		$this->assertFileDoesNotExist($count,
+			'the emitted count must not outlive the manifest generation it describes');
 	}
 }


### PR DESCRIPTION
Fixes #2607.

## What was wrong

A channel switch (`install.sh --channel nightly`) is a real `pkg delete` followed by a `pkg install`. The delete takes the teardown branch of `pfblockerng_php_pre_deinstall_command()`, which removes `/var/unbound/pfb_py_sources.json` and the per-feed raw set — correct for an uninstall. The reinstall then runs its resync as a config-save pass (`$pfb['save'] = TRUE`), and the DNSBL feed section of that pass — including the `pfb_dnsbl_manifest_missing()` rebuild gate — is guarded by `!$pfb['save']`. So Unbound came back up in Python mode with an empty matcher, the ADR-65 parse ledger opened, the notice fired, and nothing scheduled a rebuild.

Recovery was therefore whenever a feed next fell due — not the 15-minute tick, whose reconciler only retries `stage === 'apply'` entries. On the reporting box that was 4m43s (hourly feeds); on a daily or weekly feed schedule it is hours of a resolver that blocks nothing while the service reports itself running.

Observed on pfSense Plus 26.03.1, package `20260820093730.09a5cff`:

```
2026-08-21 08:56:13 DNSBL update [ feed lines: 11737 | loaded entries: 11732 ]... completed
2026-08-21 08:56:13 DNSBL manifest not loaded: DNSBL manifest absent: pfb_py_sources.json -- DNSBL not loaded
2026-08-21 09:00:55  Missing DNSBL stats and/or Unbound DNSBL files - Rebuilding
```

## What changed

**1. The tick dispatches on a missing manifest.** `pfblockerng_tick()` treats an absent manifest as a due condition alongside the existing `*.fail` marker, and like it, ignores the quiet-hours apply window. Quiet hours defer changes the operator chose to defer; they must not extend an outage (owner ruling, 2026-08-21). Recovery is bounded by the tick's 15 minutes.

Nothing is queued in a ledger, so nothing can clear it: an earlier revision set `pending_apply` from `pfb_update_unbound()`, which review showed was both window-gated and self-clearing at the end of any real update pass.

The condition dispatches **only when a pass could actually publish a manifest**, because a dispatch that cannot repair anything is an unbounded retry loop. That means all of: scheduled feed updates enabled (the same `$runtime_model['scheduled']` gate `*.fail` carries — an explicit opt-out stays honoured), DNSBL live in its **effective** runtime state, Python mode wired, and a non-empty manifest path. "Effective" matters: DNSBL can be enabled in configuration and force-disabled at runtime by `pfb_global()` when manual VIP mode has a missing or invalid sinkhole VIP (issue #331), and a pass in that state publishes nothing either.

**2. The teardown removes every artifact Python emits**, not just the manifest. `pfb_py_count`, `pfb_py_regex_count` and `pfb_py_reject_stats` all describe the generation the manifest defines, and Python rewrites them only for a build that produced a snapshot. Left behind, each is read back as live — the entry total by the update log *and* by `pfb_unbound_py_swap_fits_ram()`, which sizes the zero-downtime swap's RAM projection from it; the reject tally by `pfb_emit_entry_reject_stats()`, which then replays a dead generation's `stage=entries` lines; the regex total by the DNSBL_Regex alias count.

**3. A pass with no emitted count reports `0`**, not an empty field — which is why the log above printed the previous generation's `11732` directly over `DNSBL not loaded`.

## Tests

Test-first throughout: each behaviour's test executed RED before its production edit, frozen byte-identical, GREEN after with zero edits. Later review rounds changed the tick condition three times; each change carried its own red→green cycle, so the hashes below are the final frozen values.

| Test | Latest RED | Frozen |
| --- | --- | --- |
| `DnsblManifestTickRecoveryTest` | `Failed asserting that 1 is identical to 0` — a runtime-disabled DNSBL still dispatched | `8b449206e75f6bdf61e331c9aff4c592a832f77f` |
| `Top1mTeardownDirectoryTest` (extended) | `Failed asserting that file "…/pfb_py_regex_count" does not exist` | `0af1bd7c789386a1fb51be6f83397155c0bf58a5` |
| `DnsblLoadedCountTest` | `'…loaded entries:  ]' contains "loaded entries: 0"` | `060425adc312170c4c717a0af5d6dad470807494` |

Every behaviour test asserts the before-state first. The tick suite covers six branches: window shut with the manifest present (no dispatch) and gone (dispatch, with the reason logged); scheduled updates opted out; DNSBL disabled in configuration; DNSBL enabled in configuration but force-disabled at runtime by VIP validation; and an empty manifest path. Its fixture asserts its own preconditions — that `pfb_quiet_hours_in_window()` really is false, and that the stored DNSBL setting really is on where the runtime one is off — so a dispatch can never be the window or a mis-seeded toggle letting work through.

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (full PHPUnit suite, PHPStan, PHPCS).

## Not in scope

- A corrupt-but-present manifest leaves the emitted artifacts in place (no teardown runs there). Not observed; noted in #2607.
- pfBlockerNG notices never auto-clear once a condition heals — there is no `close_notice` call anywhere in `src/`. Pre-existing and repo-wide.
- Review findings about the test environment, tracked rather than fixed here: #2613 (unit tests can reach the real `exec("/usr/local/sbin/unbound …")` via the restart fallback) and #2612 (`LintEndpointWiringTest` leaks PID-keyed temp shims, which caused two unrelated failures during this PR's gate runs).

Note for reviewers of the fallback path: removing the stale count makes `pfb_unbound_py_swap_fits_ram()` fail closed on the first apply after a teardown, so that one pass takes a full Unbound restart instead of the zero-downtime swap. That is the intended direction — the alternative is projecting RAM from a snapshot that is no longer loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
