### PR TITLE
agent: release the Graphify store lock before CodeGraph indexing

### DIFF
--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -203,6 +203,12 @@ main() {
 		}
 		exit 1
 	fi
+	# issue #2609: the Graphify store is not touched again from here -- CodeGraph writes
+	# only into the new worktree's own .codegraph. Drop the lock before indexing so a
+	# concurrent caller cutting its own worktree does not queue behind an unrelated index.
+	if [ "$graphify_store_active" -eq 1 ]; then
+		exec 9>&-
+	fi
 	if ! sh "$(dirname "$0")/ensure-codegraph.sh" "$path"; then
 		echo "work-branch.sh: removing worktree and branch after CodeGraph initialization failure" >&2
 		git worktree remove "$path" >/dev/null 2>&1 || {

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -83,10 +83,27 @@ Describe 'work-branch.sh Graphify store integration'
       --store-root "$primary/.git/graphify-store" --builder "$primary" --branch devel --sha "$sha" || return 1
     stubdir="$fixture/bin"; mkdir -p "$stubdir"
     codegraph_log="$fixture/codegraph.log"
+    lock_probe_log="$fixture/lock-probe.log"
+    # Records, at a named step, whether the Graphify store lock is free RIGHT THEN --
+    # a direct, instantaneous read of the critical section's extent, so the ordering
+    # invariant never rides on wall-clock or on one process out-racing another.
+    cat > "$stubdir/wb-probe-lock" <<'PROBE'
+#!/bin/sh
+if [ -n "$WB_REAL_FLOCK" ]; then
+  if "$WB_REAL_FLOCK" -n "$WB_LOCK_PATH" true 2>/dev/null; then state=lock-free; else state=lock-held; fi
+elif [ -n "$WB_REAL_LOCKF" ]; then
+  if "$WB_REAL_LOCKF" -t 0 "$WB_LOCK_PATH" true 2>/dev/null; then state=lock-free; else state=lock-held; fi
+else
+  state=lock-tool-missing
+fi
+printf '%s:%s\n' "$1" "$state" >> "$WB_LOCK_PROBE_LOG"
+PROBE
+    chmod +x "$stubdir/wb-probe-lock"
     cat > "$stubdir/codegraph" <<'CODEGRAPH'
 #!/bin/sh
 case "$1" in
   init|index)
+    [ -n "$WB_LOCK_PROBE_LOG" ] && wb-probe-lock codegraph
     printf '%s\n' "$*" >> "$WB_CODEGRAPH_LOG"
     mkdir -p "$2/.codegraph"
     true > "$2/.codegraph/codegraph.db"
@@ -98,7 +115,21 @@ case "$1" in
 esac
 CODEGRAPH
     chmod +x "$stubdir/codegraph"
+    # Transparent python3 wrapper: probes the lock as the store step runs, then hands
+    # off to the real interpreter, so graphify-store.py itself stays the real script.
+    cat > "$stubdir/python3" <<'PYTHON3'
+#!/bin/sh
+case "$2" in
+  restore-exact|has-exact) [ -n "$WB_LOCK_PROBE_LOG" ] && wb-probe-lock "$2" ;;
+esac
+exec "$WB_REAL_PYTHON3" "$@"
+PYTHON3
+    chmod +x "$stubdir/python3"
     export WB_CODEGRAPH_LOG="$codegraph_log"
+    export WB_LOCK_PATH="$primary/.git/graphify-store.lock"
+    export WB_REAL_FLOCK="$(command -v flock 2>/dev/null || true)"
+    export WB_REAL_LOCKF="$(command -v lockf 2>/dev/null || true)"
+    export WB_REAL_PYTHON3="$(command -v python3)"
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }
@@ -171,65 +202,27 @@ FLOCK
     Assert [ -z "$(git_fixture -C "$primary" branch --list 'issue/34-graph')" ]
   End
 
-  It 'serializes concurrent callers across the worktree and CodeGraph sequence'
-    release_fifo="$fixture/release.fifo"
-    started_fifo="$fixture/started.fifo"
-    second_fifo="$fixture/second.fifo"
-    mkfifo "$release_fifo" "$started_fifo" "$second_fifo"
-    events="$fixture/events"
-    cat > "$stubdir/codegraph" <<'CODEGRAPH'
-#!/bin/sh
-case "$1" in
-  init)
-    mkdir -p "$2/.codegraph"
-    case "$2" in
-      *work-31) printf '%s\n' first-start >> "$WB_EVENTS"; printf '%s\n' first-start > "$WB_STARTED_FIFO"; read release_token < "$WB_RELEASE_FIFO"; printf '%s\n' first-end >> "$WB_EVENTS" ;;
-      *work-32) printf '%s\n' second-start >> "$WB_EVENTS" ;;
-    esac
-    true > "$2/.codegraph/codegraph.db"
-    ;;
-  status) printf '%s\n' '{"initialized":true,"worktreeMismatch":null,"index":{"reindexRecommended":false,"state":"complete","pendingRefs":0}}' ;;
-  *) exit 9 ;;
-esac
-CODEGRAPH
-    chmod +x "$stubdir/codegraph"
-    real_lockf=$(command -v lockf 2>/dev/null || true)
-    real_flock=$(command -v flock 2>/dev/null || true)
-    cat > "$stubdir/lockf" <<'LOCKF'
-#!/bin/sh
-if [ "$WB_CALLER" = second ]; then
-  printf '%s\n' second-attempt > "$WB_SECOND_FIFO"
-fi
-if [ -n "$WB_REAL_LOCKF" ]; then
-  exec "$WB_REAL_LOCKF" -k 9
-fi
-exec "$WB_REAL_FLOCK" 9
-LOCKF
-    cat > "$stubdir/flock" <<'FLOCK'
-#!/bin/sh
-if [ "$WB_CALLER" = second ]; then
-  printf '%s\n' second-attempt > "$WB_SECOND_FIFO"
-fi
-exec "$WB_REAL_FLOCK" 9
-FLOCK
-    chmod +x "$stubdir/lockf" "$stubdir/flock"
-    export WB_RELEASE_FIFO="$release_fifo" WB_STARTED_FIFO="$started_fifo" WB_SECOND_FIFO="$second_fifo"
-    export WB_REAL_LOCKF="$real_lockf" WB_REAL_FLOCK="$real_flock" WB_EVENTS="$events"
-    (cd "$primary" && WB_CALLER=first sh "$script_abs" issue 31 graph --worktree --base HEAD --path "$fixture/work-31" >"$fixture/out1" 2>"$fixture/err1"; printf '%s\n' "$?" >"$fixture/status1") &
-    first_pid=$!
-    read started_token < "$started_fifo"
-    Assert [ "$started_token" = first-start ]
-    (cd "$primary" && WB_CALLER=second sh "$script_abs" issue 32 graph --worktree --base HEAD --path "$fixture/work-32" >"$fixture/out2" 2>"$fixture/err2"; printf '%s\n' "$?" >"$fixture/status2") &
-    second_pid=$!
-    read second_token < "$second_fifo"
-    Assert [ "$second_token" = second-attempt ]
-    The contents of file "$events" should equal "first-start"
-    printf '%s\n' release > "$release_fifo"
-    wait "$first_pid"
-    wait "$second_pid"
-    The contents of file "$events" should equal "$(printf 'first-start\nfirst-end\nsecond-start')"
-    The contents of file "$fixture/status1" should equal 0
-    The contents of file "$fixture/status2" should equal 0
+  # issue #2609: the lock guards .git/graphify-store, and the store is untouched once
+  # restore-exact has copied the snapshot into the new worktree -- CodeGraph writes only
+  # <worktree>/.codegraph. Holding the lock across a full index made every waiting agent
+  # queue behind an unrelated indexing run. These two pin the critical section's extent
+  # by reading the lock's state at each step, never by racing two callers.
+  It 'holds the Graphify store lock across the snapshot restore'
+    export WB_LOCK_PROBE_LOG="$lock_probe_log"
+    When run sh -c 'cd "$1" && exec sh "$2" issue 37 graph --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/held"
+    The status should equal 0
+    The output should equal "$(printf 'issue/37-graph\t%s/held' "$fixture")"
+    The stderr should include 'Preparing worktree'
+    The contents of file "$lock_probe_log" should include 'restore-exact:lock-held'
+  End
+
+  It 'releases the Graphify store lock before CodeGraph initialization'
+    export WB_LOCK_PROBE_LOG="$lock_probe_log"
+    When run sh -c 'cd "$1" && exec sh "$2" issue 38 graph --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/released"
+    The status should equal 0
+    The output should equal "$(printf 'issue/38-graph\t%s/released' "$fixture")"
+    The stderr should include 'Preparing worktree'
+    The contents of file "$lock_probe_log" should include 'codegraph:lock-free'
   End
 End
 

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -89,10 +89,12 @@ Describe 'work-branch.sh Graphify store integration'
     # invariant never rides on wall-clock or on one process out-racing another.
     cat > "$stubdir/wb-probe-lock" <<'PROBE'
 #!/bin/sh
-if [ -n "$WB_REAL_FLOCK" ]; then
+# -k / -n keep the probe read-only: without -k, a SUCCESSFUL lockf unlinks the very
+# lock file under inspection. Tool preference mirrors work-branch.sh's own order.
+if [ -n "$WB_REAL_LOCKF" ]; then
+  if "$WB_REAL_LOCKF" -k -t 0 "$WB_LOCK_PATH" true 2>/dev/null; then state=lock-free; else state=lock-held; fi
+elif [ -n "$WB_REAL_FLOCK" ]; then
   if "$WB_REAL_FLOCK" -n "$WB_LOCK_PATH" true 2>/dev/null; then state=lock-free; else state=lock-held; fi
-elif [ -n "$WB_REAL_LOCKF" ]; then
-  if "$WB_REAL_LOCKF" -t 0 "$WB_LOCK_PATH" true 2>/dev/null; then state=lock-free; else state=lock-held; fi
 else
   state=lock-tool-missing
 fi
@@ -205,24 +207,36 @@ FLOCK
   # issue #2609: the lock guards .git/graphify-store, and the store is untouched once
   # restore-exact has copied the snapshot into the new worktree -- CodeGraph writes only
   # <worktree>/.codegraph. Holding the lock across a full index made every waiting agent
-  # queue behind an unrelated indexing run. These two pin the critical section's extent
-  # by reading the lock's state at each step, never by racing two callers.
-  It 'holds the Graphify store lock across the snapshot restore'
+  # queue behind an unrelated indexing run. The extent is read off the lock itself at each
+  # step, never inferred from one caller out-racing another.
+  It 'holds the Graphify store lock across the snapshot restore and drops it before indexing'
     export WB_LOCK_PROBE_LOG="$lock_probe_log"
     When run sh -c 'cd "$1" && exec sh "$2" issue 37 graph --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/held"
     The status should equal 0
     The output should equal "$(printf 'issue/37-graph\t%s/held' "$fixture")"
     The stderr should include 'Preparing worktree'
-    The contents of file "$lock_probe_log" should include 'restore-exact:lock-held'
+    The contents of file "$lock_probe_log" should equal "$(printf 'has-exact:lock-held\nrestore-exact:lock-held\ncodegraph:lock-free')"
   End
 
-  It 'releases the Graphify store lock before CodeGraph initialization'
+  # The window this widens is concurrency, so the concurrent case stays covered: two
+  # callers racing through the same store must both come out with their own worktree.
+  # No ordering is asserted -- which one indexes first is not a contract.
+  It 'lets concurrent callers each complete with their own worktree'
     export WB_LOCK_PROBE_LOG="$lock_probe_log"
-    When run sh -c 'cd "$1" && exec sh "$2" issue 38 graph --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/released"
-    The status should equal 0
-    The output should equal "$(printf 'issue/38-graph\t%s/released' "$fixture")"
-    The stderr should include 'Preparing worktree'
-    The contents of file "$lock_probe_log" should include 'codegraph:lock-free'
+    (cd "$primary" && sh "$script_abs" issue 39 graph --worktree --base HEAD --path "$fixture/race-a" >"$fixture/out-a" 2>"$fixture/err-a"; printf '%s\n' "$?" >"$fixture/status-a") &
+    a_pid=$!
+    (cd "$primary" && sh "$script_abs" issue 40 graph --worktree --base HEAD --path "$fixture/race-b" >"$fixture/out-b" 2>"$fixture/err-b"; printf '%s\n' "$?" >"$fixture/status-b") &
+    b_pid=$!
+    wait "$a_pid"
+    wait "$b_pid"
+    The contents of file "$fixture/status-a" should equal 0
+    The contents of file "$fixture/status-b" should equal 0
+    The contents of file "$fixture/out-a" should equal "$(printf 'issue/39-graph\t%s/race-a' "$fixture")"
+    The contents of file "$fixture/out-b" should equal "$(printf 'issue/40-graph\t%s/race-b' "$fixture")"
+    Assert [ -f "$fixture/race-a/graphify-out/cache/payload.txt" ]
+    Assert [ -f "$fixture/race-b/graphify-out/cache/payload.txt" ]
+    Assert [ -f "$fixture/race-a/.codegraph/codegraph.db" ]
+    Assert [ -f "$fixture/race-b/.codegraph/codegraph.db" ]
   End
 End
 


### PR DESCRIPTION
Fixes #2609.

## What was wrong

`work-branch.sh --worktree` opened the Graphify store lock on fd 9 and held it for the whole of `main`, so `ensure-codegraph.sh` — a full CodeGraph index of the new worktree — ran inside the critical section. The lock exists to guard `.git/graphify-store` across `has-exact` / `restore-exact`; once the snapshot has been copied into the worktree the store is never touched again, and indexing writes only `<worktree>/.codegraph`. Two agents cutting worktrees at the same time therefore serialized on each other's indexing for no reason.

Probed on the branch before the fix (each step reports whether the lock is free at that moment):

```
has-exact:lock-held
restore-exact:lock-held
codegraph:lock-held
```

## What changed

`exec 9>&-` right after the restore completes, before `ensure-codegraph.sh`. Store access stays serialized exactly as it is today. Failure paths are unchanged: a restore failure still removes the worktree and branch while holding the lock, and a CodeGraph failure needs no store access to do its own cleanup.

## About the replaced spec

`It 'serializes concurrent callers across the worktree and CodeGraph sequence'` pinned the old extent by racing two callers through three fifos and asserting `first-start, first-end, second-start`. That expectation *is* the behaviour being changed, so it could not survive; and rewriting it in place would have meant asserting a concurrency ordering, which is a wall-clock race dressed as an oracle (`testing.md`: "duration never an assertion").

Its two successors observe the invariant directly instead of timing it — a probe that tries the lock non-blockingly at each step and records `lock-held` / `lock-free`:

- `holds the Graphify store lock across the snapshot restore` — `restore-exact:lock-held`, green before and after (the half that must not change).
- `releases the Graphify store lock before CodeGraph initialization` — `codegraph:lock-free`, the new behaviour.

Both are deterministic and instantaneous: no fifos, no `wait`, no sleep. The probe works with either kernel lock tool (`flock -n` on Linux, `lockf -t 0` on FreeBSD/macOS), matching what the script itself selects between.

## Tests

Test-first: spec rewritten and run RED before touching `work-branch.sh`, frozen byte-identical, green after with zero edits.

`shellspec tests/shell/agent_work_branch_spec.sh`

- RED: `expected "has-exact:lock-held\nrestore-exact:lock-held\ncodegraph:lock-held" to include "codegraph:lock-free"` — 37 examples, 1 failure.
- Frozen: `37cd6589bafbffcdf1b7dd75cf589f79b1650804`.
- GREEN: 37 examples, 0 failures, same hash.

Review fixes changed the spec afterwards, so the mutation proof was re-executed against the current tree under `dash`: reverting the `exec 9>&-` hunk alone gives 37 examples / 1 failure on `holds the Graphify store lock across the snapshot restore and drops it before indexing` (`codegraph:lock-held`), and restoring it returns 37/0. The concurrency example stays green under the mutant, as it must — it pins behaviour this branch does not change.

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (`sh -n`, ShellCheck, full shellspec run).

Toolchain note: local runs graded under `dash` (`/opt/homebrew/bin/dash`) with `lockf`; CI grades under `dash` with `flock`, which exercises the probe's other branch and remains the authoritative verdict for the POSIX gate.

Correction to an earlier revision of this body, which claimed there was no `dash` on this host: that was wrong. `dash` is installed; the shell the claim was probed from lacked `/opt/homebrew/bin` on its `PATH`, and the `GATES: PASS` cited alongside it was already a `dash` verdict (`run-gates.sh` selects `shellspec --shell $(command -v dash || command -v sh)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Graphify worktree setup by releasing the store lock before indexing begins.
  * Prevented unnecessary lock retention during CodeGraph initialization, allowing concurrent worktree operations to proceed independently.

* **Tests**
  * Added coverage verifying lock behavior during snapshot lookup, restoration, and indexing.
  * Updated integration tests to confirm locks remain protected during restoration but are released before indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->