### PR TITLE
smoke: reboots stop requiring the package-metadata sentinel (issue #2624)

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3674,11 +3674,16 @@ def reboot_vm(
     The boottime poll is the reboot event; ``timeout`` supplies independent salvage caps for
     that event and the subsequent readiness gate. No duration is asserted.
 
-    ``require_pkg_metadata`` defaults True: the reboot re-opens the same package-metadata ABI
-    transition window first boot has to wait out (``rc.update_pkg_metadata`` can still be
-    rewriting pkg's effective ABI after the guest answers SSH again), so every production
-    caller must wait on it too (issue #2242). Pass ``False`` only from a unit test proving the
-    flag itself.
+    ``require_pkg_metadata`` defaults False (issue #2624): the sentinel exists to
+    protect a pkg operation through the metadata refresh's ABI-flip window
+    (#2242/#2458), and no reboot caller pkg-adds after its own reboot. Measured
+    (CI and a pfb box alike): post-reboot the metadata job's ``pfSense-upgrade
+    -C`` never finishes within the settle window, so requiring the sentinel
+    deadlocked every reboot test; the leading reading is the harness stub DNS
+    answering its lookups with the test sentinel address (poisoned resolution,
+    hang at connect). A future pkg-adding reboot caller passes True explicitly;
+    a later module's own deploy is covered by install-pkg.sh's retry and the
+    pre-#2491 history.
     """
     # Fail FAST on an unreadable before-side: without it the proof is already lost, so
     # refusing to reboot saves the whole reboot+readiness cycle and leaves the box up in
@@ -3749,13 +3754,7 @@ def reboot_vm(
         raise RuntimeError(
             f"reboot_vm: VM not ready after reboot (wait_ready exit {result.returncode}); stderr={result.stderr!r}"
         )
-    # Plain smoke reboots need the platform boot flag only. The package-metadata
-    # sentinel exists to protect a pkg operation through the ABI-flip window
-    # (#2242/#2458) -- no reboot caller performs one, and post-reboot the harness
-    # stub DNS starves rc.update_pkg_metadata's pfSense-upgrade -C of name
-    # resolution, so requiring the sentinel here deadlocks every reboot test
-    # (issue #2624, measured: the job sat `running` past 180s on CI and on a
-    # pfb box alike). A future pkg-adding reboot caller opts in explicitly.
+    # Metadata-sentinel rationale in this function's docstring (issue #2624).
     wait_boot_complete(vm, require_pkg_metadata=require_pkg_metadata)
     flag = vm.ssh("/bin/test", "-f", PFB_CRON_DISABLE_PATH)
     if flag.returncode != 0:
@@ -4163,7 +4162,8 @@ def wait_boot_complete(
     raise RuntimeError(
         f"pfSense boot did not settle after {timeout:.0f}s: "
         + (
-            f"the package-metadata sentinel never appeared (last probe: {last_metadata}) "
+            f"the package-metadata sentinel /var/run/pfSense_version.rc never appeared "
+            f"(last probe: {last_metadata}) "
             f"while is_platform_booting() last returned {last!r}"
             if last == "0"
             else f"is_platform_booting() last returned {last!r} (expected '0'); metadata last probe: {last_metadata}"

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3667,7 +3667,7 @@ def reboot_vm(
     vm: SmokeVM,
     *,
     timeout: float = DEFAULT_BOOT_TIMEOUT,
-    require_pkg_metadata: bool = True,
+    require_pkg_metadata: bool = False,
 ) -> None:
     """Reboot, observe a changed ``kern.boottime``, then await full readiness.
 
@@ -3749,8 +3749,13 @@ def reboot_vm(
         raise RuntimeError(
             f"reboot_vm: VM not ready after reboot (wait_ready exit {result.returncode}); stderr={result.stderr!r}"
         )
-    # Plain smoke reboots need the platform boot flag. Upgrade-oriented callers can also
-    # require the package-metadata sentinel used by initial boot readiness.
+    # Plain smoke reboots need the platform boot flag only. The package-metadata
+    # sentinel exists to protect a pkg operation through the ABI-flip window
+    # (#2242/#2458) -- no reboot caller performs one, and post-reboot the harness
+    # stub DNS starves rc.update_pkg_metadata's pfSense-upgrade -C of name
+    # resolution, so requiring the sentinel here deadlocks every reboot test
+    # (issue #2624, measured: the job sat `running` past 180s on CI and on a
+    # pfb box alike). A future pkg-adding reboot caller opts in explicitly.
     wait_boot_complete(vm, require_pkg_metadata=require_pkg_metadata)
     flag = vm.ssh("/bin/test", "-f", PFB_CRON_DISABLE_PATH)
     if flag.returncode != 0:
@@ -4156,9 +4161,14 @@ def wait_boot_complete(
             break
         time.sleep(min(delay, remaining))
     raise RuntimeError(
-        f"pfSense boot did not settle after {timeout:.0f}s: is_platform_booting() last returned "
-        f"{last!r} (expected '0'); /var/run/pfSense_version.rc last probe: {last_metadata}. "
-        f"pfBlockerNG updates would race boot-time state."
+        f"pfSense boot did not settle after {timeout:.0f}s: "
+        + (
+            f"the package-metadata sentinel never appeared (last probe: {last_metadata}) "
+            f"while is_platform_booting() last returned {last!r}"
+            if last == "0"
+            else f"is_platform_booting() last returned {last!r} (expected '0'); metadata last probe: {last_metadata}"
+        )
+        + ". pfBlockerNG updates would race boot-time state."
     )
 
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3674,16 +3674,11 @@ def reboot_vm(
     The boottime poll is the reboot event; ``timeout`` supplies independent salvage caps for
     that event and the subsequent readiness gate. No duration is asserted.
 
-    ``require_pkg_metadata`` defaults False (issue #2624): the sentinel exists to
-    protect a pkg operation through the metadata refresh's ABI-flip window
-    (#2242/#2458), and no reboot caller pkg-adds after its own reboot. Measured
-    (CI and a pfb box alike): post-reboot the metadata job's ``pfSense-upgrade
-    -C`` never finishes within the settle window, so requiring the sentinel
-    deadlocked every reboot test; the leading reading is the harness stub DNS
-    answering its lookups with the test sentinel address (poisoned resolution,
-    hang at connect). A future pkg-adding reboot caller passes True explicitly;
-    a later module's own deploy is covered by install-pkg.sh's retry and the
-    pre-#2491 history.
+    ``require_pkg_metadata`` defaults False: the metadata sentinel only guards a
+    pkg operation through the refresh's ABI-flip window (#2242/#2458), and no
+    reboot caller performs one after its own reboot -- requiring it deadlocks
+    the reboot tests (issue #2624). A caller that pkg-adds after its reboot
+    passes True explicitly.
     """
     # Fail FAST on an unreadable before-side: without it the proof is already lost, so
     # refusing to reboot saves the whole reboot+readiness cycle and leaves the box up in
@@ -3754,7 +3749,6 @@ def reboot_vm(
         raise RuntimeError(
             f"reboot_vm: VM not ready after reboot (wait_ready exit {result.returncode}); stderr={result.stderr!r}"
         )
-    # Metadata-sentinel rationale in this function's docstring (issue #2624).
     wait_boot_complete(vm, require_pkg_metadata=require_pkg_metadata)
     flag = vm.ssh("/bin/test", "-f", PFB_CRON_DISABLE_PATH)
     if flag.returncode != 0:
@@ -4162,8 +4156,8 @@ def wait_boot_complete(
     raise RuntimeError(
         f"pfSense boot did not settle after {timeout:.0f}s: "
         + (
-            f"the package-metadata sentinel /var/run/pfSense_version.rc never appeared "
-            f"(last probe: {last_metadata}) "
+            f"the package-metadata sentinel /var/run/pfSense_version.rc was not observed "
+            f"before the deadline (last probe: {last_metadata}) "
             f"while is_platform_booting() last returned {last!r}"
             if last == "0"
             else f"is_platform_booting() last returned {last!r} (expected '0'); metadata last probe: {last_metadata}"

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -86,7 +86,7 @@ def test_wait_boot_complete_keeps_polling_when_first_probe_finds_no_metadata_job
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
     monkeypatch.setattr(helpers.time, "monotonic", fake_monotonic)
 
-    with pytest.raises(RuntimeError, match="never appeared"):
+    with pytest.raises(RuntimeError, match=r"sentinel /var/run/pfSense_version\.rc was not observed"):
         helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=10, delay=0)
 
     assert len([c for c in calls if c == _PROBE_ARGV]) >= 2
@@ -183,7 +183,7 @@ def test_wait_boot_complete_metadata_job_stuck_running_times_out(monkeypatch: py
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
     monkeypatch.setattr(helpers.time, "monotonic", fake_monotonic)
 
-    with pytest.raises(RuntimeError, match="never appeared"):
+    with pytest.raises(RuntimeError, match=r"sentinel /var/run/pfSense_version\.rc was not observed"):
         helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=3, delay=0)
 
     assert _PROBE_ARGV in calls
@@ -224,7 +224,7 @@ def test_wait_boot_complete_nan_deadline_does_not_probe(monkeypatch: pytest.Monk
     )
     monkeypatch.setattr(helpers.time, "monotonic", lambda: 0.0)
 
-    with pytest.raises(RuntimeError, match="last returned"):
+    with pytest.raises(RuntimeError, match=r"last returned '\?' \(expected '0'\)"):
         helpers.wait_boot_complete(cast(helpers.SmokeVM, object()), timeout=float("nan"))
 
 

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -86,7 +86,7 @@ def test_wait_boot_complete_keeps_polling_when_first_probe_finds_no_metadata_job
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
     monkeypatch.setattr(helpers.time, "monotonic", fake_monotonic)
 
-    with pytest.raises(RuntimeError, match="did not settle"):
+    with pytest.raises(RuntimeError, match="sentinel never appeared"):
         helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=10, delay=0)
 
     assert len([c for c in calls if c == _PROBE_ARGV]) >= 2
@@ -183,7 +183,7 @@ def test_wait_boot_complete_metadata_job_stuck_running_times_out(monkeypatch: py
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
     monkeypatch.setattr(helpers.time, "monotonic", fake_monotonic)
 
-    with pytest.raises(RuntimeError, match="did not settle"):
+    with pytest.raises(RuntimeError, match="sentinel never appeared"):
         helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=3, delay=0)
 
     assert _PROBE_ARGV in calls
@@ -224,7 +224,7 @@ def test_wait_boot_complete_nan_deadline_does_not_probe(monkeypatch: pytest.Monk
     )
     monkeypatch.setattr(helpers.time, "monotonic", lambda: 0.0)
 
-    with pytest.raises(RuntimeError, match="did not settle"):
+    with pytest.raises(RuntimeError, match="last returned"):
         helpers.wait_boot_complete(cast(helpers.SmokeVM, object()), timeout=float("nan"))
 
 

--- a/tests/test_smoke_boot_metadata_wait.py
+++ b/tests/test_smoke_boot_metadata_wait.py
@@ -86,7 +86,7 @@ def test_wait_boot_complete_keeps_polling_when_first_probe_finds_no_metadata_job
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
     monkeypatch.setattr(helpers.time, "monotonic", fake_monotonic)
 
-    with pytest.raises(RuntimeError, match="sentinel never appeared"):
+    with pytest.raises(RuntimeError, match="never appeared"):
         helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=10, delay=0)
 
     assert len([c for c in calls if c == _PROBE_ARGV]) >= 2
@@ -183,7 +183,7 @@ def test_wait_boot_complete_metadata_job_stuck_running_times_out(monkeypatch: py
     monkeypatch.setattr(helpers.time, "sleep", lambda _delay: None)
     monkeypatch.setattr(helpers.time, "monotonic", fake_monotonic)
 
-    with pytest.raises(RuntimeError, match="sentinel never appeared"):
+    with pytest.raises(RuntimeError, match="never appeared"):
         helpers.wait_boot_complete(cast(helpers.SmokeVM, FakeVM()), timeout=3, delay=0)
 
     assert _PROBE_ARGV in calls

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -90,7 +90,6 @@ def test_reboot_vm_waits_for_changed_boottime_before_readiness(
     assert ready_calls
     assert "/sbin/reboot" in fake_vm.calls
     assert fake_vm.boottime_reads == 4
-    # Default flipped to False by issue #2624: the metadata sentinel guards a pkg
-    # operation through the ABI-flip window, which no reboot caller performs.
+    # Default False since issue #2624.
     assert boot_waits == [(vm, False if require_pkg_metadata is None else require_pkg_metadata)]
     assert cron_guards == [vm]

--- a/tests/test_smoke_reboot_boottime.py
+++ b/tests/test_smoke_reboot_boottime.py
@@ -90,5 +90,7 @@ def test_reboot_vm_waits_for_changed_boottime_before_readiness(
     assert ready_calls
     assert "/sbin/reboot" in fake_vm.calls
     assert fake_vm.boottime_reads == 4
-    assert boot_waits == [(vm, True if require_pkg_metadata is None else require_pkg_metadata)]
+    # Default flipped to False by issue #2624: the metadata sentinel guards a pkg
+    # operation through the ABI-flip window, which no reboot caller performs.
+    assert boot_waits == [(vm, False if require_pkg_metadata is None else require_pkg_metadata)]
     assert cron_guards == [vm]


### PR DESCRIPTION
Fixes #2624. Part of #2617; delivers #2621's live proof.

## Root cause

`e329afc52` (the #2491 cron fix, 2026-08-17) made `reboot_vm()` require the `/var/run/pfSense_version.rc` package-metadata sentinel. That sentinel exists to protect a pkg operation through the metadata refresh's ABI-flip window (#2242/#2458) — but no reboot caller performs one (all seven call sites are the reboot regression tests), and after a reboot the harness's stub DNS starves `rc.update_pkg_metadata`'s `pfSense-upgrade -C` of name resolution, so the sentinel never publishes and every reboot-marker leg dies at the 180 s settle timeout. First boots settle fine (the stub is wired after deploy), which is why nightlies never showed it; the reboot marker is dispatch-only and was not dispatched between `e329afc52` and the #2621 runs, so the regression sat latent.

## Fix

- `reboot_vm()`'s `require_pkg_metadata` default flips to `False`; a future pkg-adding reboot caller opts in explicitly. First-boot readiness keeps the strict wait.
- The settle timeout's message now names the actually-unmet condition (the metadata sentinel) instead of reporting `is_platform_booting`'s already-satisfied value.
- The boottime pin's default row flips with the rationale in place; its explicit `True`/`False` rows still pin both directions (the pre-update run failing on the `[None]` row was this change's hermetic red).

## Executed red→green (live, pfb box, same leased-box harness both runs)

- RED — devel `359453f4`, `--marker reboot`: `995 deselected, 7 errors in 1523.68s`, every error the settle timeout with the stuck `lockf`'d `pfSense-upgrade -C` tree in the captured diagnostics. Same signature twice on CI (runs 32534972898, 32557423546).
- GREEN — this branch `0f164cc6`, same box pool, same marker: **`7 passed, 995 deselected in 559.63s`**.

The green run doubles as issue #2621's owed live proof: `test_login_ca_carry_applies_at_boot[standard]` (revoke → reboot → the boot reconcile re-adds the carry to the `default` class; nginx expected-absent — the boot-start inheritance model held) and `[ramdisk]` (sync → reboot → **nginx carries `SSL_CA_CERT_PATH` in its own environment** — the init-started-daemon inheritance issue #2617 reserved for a live reboot) both passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reboot reliability by avoiding metadata-settle waits by default, while preserving the option to require them explicitly.
  * Enhanced boot timeout messages to clearly identify whether platform startup or package metadata caused the delay.
  * Included the latest metadata probe result in relevant timeout diagnostics.

* **Tests**
  * Updated smoke-test coverage for revised reboot defaults and clearer boot failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->