### PR TITLE
software: speak the installed hook's generation for the CA carry (issue #2630)

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.githooks-exempt
+++ b/.githooks-exempt
@@ -1,0 +1,19 @@
+# Explicit pre-commit opt-out for the release/3.3 family (issue #2633).
+#
+# Every worktree runs the primary checkout's .githooks/pre-commit (core.hooksPath
+# is absolute in the shared .git/config), but this legacy branch does not ship
+# the devel checker corpus. The hook skips a repo-script gate ONLY when the
+# checker is absent from this tree AND its exact path is listed here; a missing
+# checker with no listed exemption stays a hard failure. This is a deliberate,
+# documented limitation of the 3.3 family: these gates are enforced on devel,
+# and release/3.3 changes get their equivalent scrutiny in PR review and the
+# branch pytest suite.
+scripts/check_agent_roles.py
+scripts/check_appliance_python.py
+scripts/check_comment_narration.py
+scripts/check_composer_vendor.py
+scripts/check_context_budget.py
+scripts/check_noopener.py
+scripts/check_url_encoding.py
+scripts/check_version_literals.py
+scripts/agent/check-agent-config-parity.sh

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ venv/
 *.tar.gz
 *.tar.bz2
 *.zip
+
+# ── Agent tooling artefacts (repository intelligence; never shipped) ──────────
+graphify-out/

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
@@ -233,7 +233,13 @@ function pfb_software_check_enabled(): bool {
 }
 
 function pfb_pkg_ca_consent_enabled(): bool {
-	return PfbConfig::read('gen/pfb_pkg_ca_consent') === 'on';
+	$token = PfbConfig::read('gen/pfb_pkg_ca_consent');
+	// Login generation defaults ON (absent key = consented; a present empty token is
+	// the explicit opt-out), matching the on-box hook's own boot reconcile semantics.
+	if (pfb_pkgconf_ca_hook_is_login()) {
+		return $token === NULL || $token === 'on';
+	}
+	return $token === 'on';
 }
 
 function pfb_pkg_ca_is_plus(string $product_label = '/etc/product_label'): bool {
@@ -285,8 +291,24 @@ if (!defined('PFB_PKG_TIMEOUT')) {
 	define('PFB_PKG_TIMEOUT', '/usr/bin/timeout -s TERM -k 5 60');
 }
 
+/*
+ * TRUE when the installed hook is the login.conf generation (issue #2630): the
+ * published installer's current hook carries the login-ca-sync/login-ca-revoke
+ * verbs and retired ca-sync/ca-revoke; a box that never re-ran the installer
+ * still has the pkg.conf-generation hook. The probe reads the hook body -- the
+ * verbs are literal case labels there -- so the page always speaks the verbs
+ * the on-box hook actually has.
+ */
+function pfb_pkgconf_ca_hook_is_login(): bool {
+	$body = @file_get_contents(PFB_REPO_GENERATE_HOOK);
+	return $body !== FALSE && strpos($body, 'login-ca-sync') !== FALSE;
+}
+
 function pfb_pkgconf_ca_command(string $action): bool {
-	if (!in_array($action, ['ca-sync', 'ca-revoke'], TRUE) || !is_executable(PFB_REPO_GENERATE_HOOK)) {
+	$verbs = pfb_pkgconf_ca_hook_is_login()
+		? ['login-ca-sync', 'login-ca-revoke']
+		: ['ca-sync', 'ca-revoke'];
+	if (!in_array($action, $verbs, TRUE) || !is_executable(PFB_REPO_GENERATE_HOOK)) {
 		return FALSE;
 	}
 	$out = [];
@@ -298,6 +320,13 @@ function pfb_pkgconf_ca_command(string $action): bool {
 function pfb_pkg_exec(string $command, array &$out = [], int &$ret = -1): void {
 	$out = [];
 	$ret = -1;
+	// Login generation: the hook's boot reconcile and the installer's webConfigurator
+	// restart own the environment, and login-ca-sync is consent-independent -- calling
+	// it per check would re-add the carry against a recorded opt-out. Plain exec.
+	if (pfb_pkgconf_ca_hook_is_login()) {
+		exec($command, $out, $ret);
+		return;
+	}
 	if (pfb_pkgconf_ca_command('ca-sync')) {
 		exec($command, $out, $ret);
 	}
@@ -421,14 +450,19 @@ function pfb_pkgconf_ca_apply(
 	string $token,
 	bool $was_consented
 ): bool {
+	$login = pfb_pkgconf_ca_hook_is_login();
 	if ($token === 'on') {
-		return pfb_pkgconf_ca_command('ca-sync');
+		return pfb_pkgconf_ca_command($login ? 'login-ca-sync' : 'ca-sync');
 	}
-	return !$was_consented || pfb_pkgconf_ca_command('ca-revoke');
+	return !$was_consented || pfb_pkgconf_ca_command($login ? 'login-ca-revoke' : 'ca-revoke');
 }
 
 /* Add the Plus-only Software-page consent controls through the shipped Form API. */
 function pfb_pkgconf_ca_add_form_controls($form, bool $consent): void {
+	if (pfb_pkgconf_ca_hook_is_login()) {
+		pfb_logincap_ca_add_form_controls($form, $consent);
+		return;
+	}
 	$help = sprintf(
 		gettext('This control adds or removes exactly one SSL_CA_CERT_PATH=/etc/ssl/certs line in %s. '),
 		PFB_PKG_CONF
@@ -454,6 +488,30 @@ function pfb_pkgconf_ca_add_form_controls($form, bool $consent): void {
 	$section->addInput(new Form_Checkbox(
 		'pfb_pkg_ca_consent',
 		gettext('Allow pfBlockerNG to manage the pkg.conf CA path'),
+		gettext('Enabled'),
+		$consent,
+		'on'
+	))->setHelp($help);
+	$form->add($section);
+	$form->addGlobal(new Form_Input('pfb_pkg_ca_consent_shown', 'pfb_pkg_ca_consent_shown', 'hidden', '1'));
+}
+
+/* Login-generation consent controls (issue #2630): the installed hook carries
+ * SSL_CA_CERT_PATH in /etc/login.conf's default class setenv, on by default. */
+function pfb_logincap_ca_add_form_controls($form, bool $consent): void {
+	$help = gettext(
+		'pfSense Plus pins pkg to a Netgate-only CA bundle, which blocks third-party '
+		. 'package repositories. When enabled, pfBlockerNG keeps '
+		. 'SSL_CA_CERT_PATH=/etc/ssl/certs in the default login class setenv list in '
+		. '/etc/login.conf, so every process started from then on hands pkg the system '
+		. 'trust store; a reboot applies it everywhere. On CE the value is harmless. '
+		. 'This is on by default. Unchecking it removes only pfBlockerNG\'s value and '
+		. 'leaves the rest of the file untouched.'
+	);
+	$section = new Form_Section(gettext('Package manager CA trust'));
+	$section->addInput(new Form_Checkbox(
+		'pfb_pkg_ca_consent',
+		gettext('Carry the system CA store into pkg'),
 		gettext('Enabled'),
 		$consent,
 		'on'

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_software.inc
@@ -236,8 +236,10 @@ function pfb_pkg_ca_consent_enabled(): bool {
 	$token = PfbConfig::read('gen/pfb_pkg_ca_consent');
 	// Login generation defaults ON (absent key = consented; a present empty token is
 	// the explicit opt-out), matching the on-box hook's own boot reconcile semantics.
+	// The hook's own reconcile matches the token case-insensitively, so a restored
+	// backup's 'On' must not read here as an opt-out while boot keeps adding the carry.
 	if (pfb_pkgconf_ca_hook_is_login()) {
-		return $token === NULL || $token === 'on';
+		return $token === NULL || strtolower(trim((string) $token)) === 'on';
 	}
 	return $token === 'on';
 }
@@ -300,7 +302,7 @@ if (!defined('PFB_PKG_TIMEOUT')) {
  * the on-box hook actually has.
  */
 function pfb_pkgconf_ca_hook_is_login(): bool {
-	$body = @file_get_contents(PFB_REPO_GENERATE_HOOK);
+	$body = @file_get_contents(PFB_REPO_GENERATE_HOOK, FALSE, NULL, 0, 65536);
 	return $body !== FALSE && strpos($body, 'login-ca-sync') !== FALSE;
 }
 
@@ -438,7 +440,11 @@ function pfb_pkg_latest(string $pkgname, string $reponame): string {
 /* Persist consent only when the conditional Software-page section was rendered. */
 function pfb_pkgconf_ca_save(array $post): string {
 	if (!isset($post['pfb_pkg_ca_consent_shown'])) {
-		return (string) (PfbConfig::read('gen/pfb_pkg_ca_consent') ?? '');
+		// Login generation: an absent key means consented, so answering '' here would
+		// make pfb_pkgconf_ca_apply() revoke with no recorded opt-out. Old generation:
+		// enabled is exactly token === 'on', so this stays value-identical to the
+		// shipped raw-token fallback on every path apply() distinguishes.
+		return pfb_pkg_ca_consent_enabled() ? 'on' : '';
 	}
 	$token = pfb_filter($post['pfb_pkg_ca_consent'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '';
 	PfbConfig::write('gen/pfb_pkg_ca_consent', $token);
@@ -457,10 +463,10 @@ function pfb_pkgconf_ca_apply(
 	return !$was_consented || pfb_pkgconf_ca_command($login ? 'login-ca-revoke' : 'ca-revoke');
 }
 
-/* Add the Plus-only Software-page consent controls through the shipped Form API. */
+/* Add the Software-page consent controls for the installed hook generation. */
 function pfb_pkgconf_ca_add_form_controls($form, bool $consent): void {
 	if (pfb_pkgconf_ca_hook_is_login()) {
-		pfb_logincap_ca_add_form_controls($form, $consent);
+		pfb_login_ca_add_form_controls($form, $consent);
 		return;
 	}
 	$help = sprintf(
@@ -498,7 +504,7 @@ function pfb_pkgconf_ca_add_form_controls($form, bool $consent): void {
 
 /* Login-generation consent controls (issue #2630): the installed hook carries
  * SSL_CA_CERT_PATH in /etc/login.conf's default class setenv, on by default. */
-function pfb_logincap_ca_add_form_controls($form, bool $consent): void {
+function pfb_login_ca_add_form_controls($form, bool $consent): void {
 	$help = gettext(
 		'pfSense Plus pins pkg to a Netgate-only CA bundle, which blocks third-party '
 		. 'package repositories. When enabled, pfBlockerNG keeps '

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -104,7 +104,7 @@ if ($_POST && isset($_POST['save'])) {
 			. 'certificate directory may be missing or empty -- try running `certctl rehash` '
 			. 'from the shell). pfBlockerNG will retry at the next boot or package check.'
 		),
-		PFB_PKG_CONF
+		pfb_pkgconf_ca_hook_is_login() ? '/etc/login.conf' : PFB_PKG_CONF
 	);
 }
 
@@ -211,7 +211,9 @@ $section->addInput(new Form_Checkbox(
 $form->add($section);
 
 // The installed repository hook owns pkg.conf; Plus is the only edition with the vendor pin.
-if (pfb_pkg_ca_is_plus()) {
+// Login-generation hooks apply on every edition (issue #2630); the pkg.conf
+// generation stays Plus-only as shipped.
+if (pfb_pkg_ca_is_plus() || pfb_pkgconf_ca_hook_is_login()) {
 	pfb_pkgconf_ca_add_form_controls($form, pfb_pkg_ca_consent_enabled());
 }
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -98,14 +98,32 @@ if ($_POST && isset($_POST['save'])) {
 		header('Location: /pfblockerng/pfblockerng_software.php');
 		exit;
 	}
-	$input_errors[] = sprintf(
-		gettext(
-			'The setting was saved, but pfBlockerNG could not update %s right now (its CA '
-			. 'certificate directory may be missing or empty -- try running `certctl rehash` '
-			. 'from the shell). pfBlockerNG will retry at the next boot or package check.'
-		),
-		pfb_pkgconf_ca_hook_is_login() ? '/etc/login.conf' : PFB_PKG_CONF
-	);
+	// Diagnose per verb under the login hook (a failed sync is almost always the
+	// unpopulated-CA-dir guard; a failed revoke has no CA-dir dependency, so its causes
+	// are the file's) and promise only the boot reconcile -- the login generation has no
+	// per-check reapply. The old generation keeps the shipped 3.3.3 sentence.
+	if (pfb_pkgconf_ca_hook_is_login()) {
+		$input_errors[] = $pfb_ca_token === 'on'
+			? gettext(
+				'The setting was saved, but pfBlockerNG could not update /etc/login.conf right now '
+				. '(the CA certificate directory may be missing or empty -- try running `certctl '
+				. 'rehash` from the shell); it will retry at the next boot.'
+			)
+			: gettext(
+				'The setting was saved, but pfBlockerNG could not update /etc/login.conf right now '
+				. '(the file may be a symlink, or have a shape pfBlockerNG does not edit); '
+				. 'it will retry at the next boot.'
+			);
+	} else {
+		$input_errors[] = sprintf(
+			gettext(
+				'The setting was saved, but pfBlockerNG could not update %s right now (its CA '
+				. 'certificate directory may be missing or empty -- try running `certctl rehash` '
+				. 'from the shell). pfBlockerNG will retry at the next boot or package check.'
+			),
+			PFB_PKG_CONF
+		);
+	}
 }
 
 // Read after the save block so a failed CA sync re-render shows the just-posted software choice.
@@ -210,9 +228,9 @@ $section->addInput(new Form_Checkbox(
 ))->setHelp('Periodically check for a new version and notify when one is available.');
 $form->add($section);
 
-// The installed repository hook owns pkg.conf; Plus is the only edition with the vendor pin.
-// Login-generation hooks apply on every edition (issue #2630); the pkg.conf
-// generation stays Plus-only as shipped.
+// Login-generation hooks own /etc/login.conf and apply on every edition (issue
+// #2630); the pkg.conf generation stays Plus-only as shipped -- Plus is the only
+// edition with the vendor pin.
 if (pfb_pkg_ca_is_plus() || pfb_pkgconf_ca_hook_is_login()) {
 	pfb_pkgconf_ca_add_form_controls($form, pfb_pkg_ca_consent_enabled());
 }

--- a/tests/php/assert_pkg_ca_core_3_3.php
+++ b/tests/php/assert_pkg_ca_core_3_3.php
@@ -200,6 +200,28 @@ row('old generation: consent stays opt-in', static function (): void {
 	check(!pfb_pkg_ca_consent_enabled(), 'absent key stays off under the old hook');
 });
 
+// issue #2631 review round: a save POST that lacks the rendered-section marker must
+// never manufacture an opt-out. Under the login hook an absent key means consented,
+// so the fallback has to answer 'on' -- returning '' here made pfb_pkgconf_ca_apply()
+// fire login-ca-revoke with no recorded opt-out.
+row('login generation: a marker-absent save never turns default consent into a revoke', static function (): void {
+	file_put_contents(PFB_REPO_GENERATE_HOOK, "#!/bin/sh\n# verbs: login-ca-sync login-ca-revoke\nexit 0\n");
+	chmod(PFB_REPO_GENERATE_HOOK, 0700);
+	config_set_path('installedpackages/pfblockerng/config/0', []);
+	same('on', pfb_pkgconf_ca_save(['save' => '1']), 'absent key keeps the default-on consent');
+	config_set_path('installedpackages/pfblockerng/config/0/pfb_pkg_ca_consent', '');
+	same('', pfb_pkgconf_ca_save(['save' => '1']), 'a recorded opt-out survives the marker-absent path');
+});
+
+row('login generation: consent token is case-insensitive like the hook', static function (): void {
+	file_put_contents(PFB_REPO_GENERATE_HOOK, "#!/bin/sh\n# verbs: login-ca-sync login-ca-revoke\nexit 0\n");
+	chmod(PFB_REPO_GENERATE_HOOK, 0700);
+	config_set_path('installedpackages/pfblockerng/config/0/pfb_pkg_ca_consent', 'On');
+	check(pfb_pkg_ca_consent_enabled(), 'case-variant On reads as consented under the login hook');
+	file_put_contents(PFB_REPO_GENERATE_HOOK, "#!/bin/sh\nexit 0\n");
+	check(!pfb_pkg_ca_consent_enabled(), 'the old generation keeps its strict token');
+});
+
 @unlink(PFB_REPO_GENERATE_HOOK);
 @unlink($hook_log);
 

--- a/tests/php/assert_pkg_ca_core_3_3.php
+++ b/tests/php/assert_pkg_ca_core_3_3.php
@@ -163,9 +163,14 @@ row('both pkg commands delegate to the hook immediately before execution', stati
 	$wrapper_end = strpos($source, 'function pfb_pkg_installed_name', $wrapper_start);
 	check($wrapper_start !== false && $wrapper_end !== false, 'pkg wrapper slice');
 	$wrapper = substr($source, $wrapper_start, $wrapper_end - $wrapper_start);
+	// issue #2630: the login-generation branch returns early with a plain exec;
+	// the OLD-generation exec (the last one in the wrapper) must still sit behind
+	// the ca-sync gate.
+	$login_pos = strpos($wrapper, 'pfb_pkgconf_ca_hook_is_login()');
 	$sync_pos = strpos($wrapper, "pfb_pkgconf_ca_command('ca-sync')");
-	$exec_pos = strpos($wrapper, 'exec($command');
-	check($sync_pos !== false && $exec_pos !== false && $sync_pos < $exec_pos, 'hook before pkg exec');
+	$exec_pos = strrpos($wrapper, 'exec($command');
+	check($login_pos !== false, 'login-generation early return present');
+	check($sync_pos !== false && $exec_pos !== false && $sync_pos < $exec_pos, 'old-generation exec stays behind the ca-sync gate');
 	$start = strpos($source, 'function pfb_pkg_latest');
 	$end = strpos($source, 'function pfb_pkgconf_ca_save', $start);
 	check($start !== false && $end !== false, 'latest slice');
@@ -173,6 +178,26 @@ row('both pkg commands delegate to the hook immediately before execution', stati
 	check(substr_count($latest, 'pfb_pkg_exec("{$tmo}{$bin}') === 2, 'both latest calls use wrapper');
 	check(substr_count($source, 'pfb_pkg_exec(') === 6, 'all five pkg calls use the wrapper');
 	check(!str_contains($latest, 'SSL_CA_CERT_PATH='), 'no PHP environment decoration');
+});
+
+// -- login-generation semantics (issue #2630): under the installer's new hook the
+// consent defaults ON (absent key = on; a present empty token = explicit opt-out).
+row('login generation: consent defaults on, present-empty opts out', static function (): void {
+	file_put_contents(PFB_REPO_GENERATE_HOOK, "#!/bin/sh\n# verbs: login-ca-sync login-ca-revoke\nexit 0\n");
+	chmod(PFB_REPO_GENERATE_HOOK, 0700);
+	config_set_path('installedpackages/pfblockerng/config/0', []);
+	check(pfb_pkg_ca_consent_enabled(), 'absent key reads as consented under the login hook');
+	config_set_path('installedpackages/pfblockerng/config/0/pfb_pkg_ca_consent', '');
+	check(!pfb_pkg_ca_consent_enabled(), 'present empty token is the explicit opt-out');
+	config_set_path('installedpackages/pfblockerng/config/0/pfb_pkg_ca_consent', 'on');
+	check(pfb_pkg_ca_consent_enabled(), 'explicit on stays on');
+});
+
+row('old generation: consent stays opt-in', static function (): void {
+	file_put_contents(PFB_REPO_GENERATE_HOOK, "#!/bin/sh\nexit 0\n");
+	chmod(PFB_REPO_GENERATE_HOOK, 0700);
+	config_set_path('installedpackages/pfblockerng/config/0', []);
+	check(!pfb_pkg_ca_consent_enabled(), 'absent key stays off under the old hook');
 });
 
 @unlink(PFB_REPO_GENERATE_HOOK);

--- a/tests/php/assert_pkg_ca_delegate_3_3.php
+++ b/tests/php/assert_pkg_ca_delegate_3_3.php
@@ -110,6 +110,8 @@ row('probe detects the login-generation hook, and old-generation before it', sta
 	check(pfb_pkgconf_ca_hook_is_login(), 'login marker in the hook body reads as the new generation');
 	file_put_contents($hook, "#!/bin/sh\nprintf '%s\\n' \"\$1\" >> " . escapeshellarg($log) . "\nexit 0\n");
 	check(!pfb_pkgconf_ca_hook_is_login(), 'no marker reads as the old generation');
+	unlink($hook);
+	check(!pfb_pkgconf_ca_hook_is_login(), 'an absent hook reads as the old generation');
 	file_put_contents($hook, "#!/bin/sh\n# verbs: login-ca-sync login-ca-revoke\nprintf '%s\\n' \"\$1\" >> " . escapeshellarg($log) . "\nexit \${PFB_HOOK_STATUS:-0}\n");
 	chmod($hook, 0700);
 });

--- a/tests/php/assert_pkg_ca_delegate_3_3.php
+++ b/tests/php/assert_pkg_ca_delegate_3_3.php
@@ -100,6 +100,46 @@ row('delegate bounds a hanging hook', static function (): void {
 	putenv('PFB_HOOK_SLEEP');
 });
 
+// -- login-generation hook (issue #2630): the published installer now ships a hook
+// whose verbs are login-ca-sync/login-ca-revoke; the page probes the hook body and
+// switches verbs. Rewrite the stub so the probe reads the new generation.
+file_put_contents($hook, "#!/bin/sh\n# verbs: login-ca-sync login-ca-revoke\nprintf '%s\\n' \"\$1\" >> " . escapeshellarg($log) . "\nexit \${PFB_HOOK_STATUS:-0}\n");
+chmod($hook, 0700);
+
+row('probe detects the login-generation hook, and old-generation before it', static function () use ($hook, $log): void {
+	check(pfb_pkgconf_ca_hook_is_login(), 'login marker in the hook body reads as the new generation');
+	file_put_contents($hook, "#!/bin/sh\nprintf '%s\\n' \"\$1\" >> " . escapeshellarg($log) . "\nexit 0\n");
+	check(!pfb_pkgconf_ca_hook_is_login(), 'no marker reads as the old generation');
+	file_put_contents($hook, "#!/bin/sh\n# verbs: login-ca-sync login-ca-revoke\nprintf '%s\\n' \"\$1\" >> " . escapeshellarg($log) . "\nexit \${PFB_HOOK_STATUS:-0}\n");
+	chmod($hook, 0700);
+});
+
+row('login generation: delegate speaks login verbs and refuses the retired ones', static function () use ($log): void {
+	file_put_contents($log, '');
+	check(pfb_pkgconf_ca_command('login-ca-sync'), 'login sync succeeds');
+	check(pfb_pkgconf_ca_command('login-ca-revoke'), 'login revoke succeeds');
+	check(!pfb_pkgconf_ca_command('ca-sync'), 'retired sync verb refused under the login hook');
+	same(file_get_contents($log), "login-ca-sync\nlogin-ca-revoke\n", 'hook saw only login verbs');
+});
+
+row('login generation: pfb_pkg_exec is a plain exec, never a per-check sync', static function () use ($log): void {
+	file_put_contents($log, '');
+	$out = [];
+	$ret = -1;
+	pfb_pkg_exec('printf greeting', $out, $ret);
+	same(0, $ret, 'command executed');
+	same(['greeting'], $out, 'command output captured');
+	same('', file_get_contents($log), 'the hook was never invoked -- login-ca-sync is consent-independent and must not run per check');
+});
+
+row('login generation: apply maps consent to the login verbs', static function () use ($log): void {
+	file_put_contents($log, '');
+	check(pfb_pkgconf_ca_apply('on', false), 'consent on applies');
+	check(pfb_pkgconf_ca_apply('', true), 'opt-out revokes');
+	check(pfb_pkgconf_ca_apply('', false), 'never-consented opt-out is a no-op');
+	same(file_get_contents($log), "login-ca-sync\nlogin-ca-revoke\n", 'verb order and count');
+});
+
 @unlink($hook);
 @unlink($log);
 @rmdir($root);

--- a/tests/php/assert_pkg_ca_ui_render_3_3.php
+++ b/tests/php/assert_pkg_ca_ui_render_3_3.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+define('PFB_REPO_GENERATE_HOOK', sys_get_temp_dir() . '/pfb-ca-ui-hook-' . bin2hex(random_bytes(4)));
+
 if (!function_exists('gettext')) {
 	function gettext(string $text): string
 	{
@@ -121,6 +123,19 @@ row('consent controls execute through the shipped form helper', static function 
 	pfb_pkgconf_ca_add_form_controls($enabled, true);
 	check($enabled->sections[0]->inputs[0]->checked, 'enabled consent renders checked');
 	check(str_contains($enabled->sections[0]->inputs[0]->help, 'before each package check'), 'runtime hook help');
+});
+
+row('login generation: help names login.conf, never pkg.conf; old generation unchanged', static function (): void {
+	file_put_contents(PFB_REPO_GENERATE_HOOK, "#!/bin/sh\n# verbs: login-ca-sync login-ca-revoke\nexit 0\n");
+	$form = new Form();
+	pfb_pkgconf_ca_add_form_controls($form, true);
+	$help = $form->sections[0]->inputs[0]->help;
+	check(str_contains($help, '/etc/login.conf'), 'login-generation help names /etc/login.conf');
+	check(!str_contains($help, 'pkg.conf'), 'login-generation help does not name pkg.conf');
+	unlink(PFB_REPO_GENERATE_HOOK);
+	$legacy = new Form();
+	pfb_pkgconf_ca_add_form_controls($legacy, false);
+	check(str_contains($legacy->sections[0]->inputs[0]->help, 'pkg.conf'), 'old-generation help still names pkg.conf');
 });
 
 row('package PHP exposes only the hook delegation boundary', static function (): void {

--- a/tests/php/assert_pkg_ca_ui_render_3_3.php
+++ b/tests/php/assert_pkg_ca_ui_render_3_3.php
@@ -157,5 +157,7 @@ row('package PHP exposes only the hook delegation boundary', static function ():
 	@unlink($product);
 });
 
+@unlink(PFB_REPO_GENERATE_HOOK);
+
 echo $failures === 0 ? "ALL PASS\n" : "{$failures} FAILURES\n";
 exit($failures === 0 ? 0 : 1);

--- a/tests/test_pkg_ca_integration_3_3.py
+++ b/tests/test_pkg_ca_integration_3_3.py
@@ -52,7 +52,9 @@ def test_ui_is_conditional_and_posts_an_explicit_consent_token() -> None:
         "re-applies the line at boot and before package checks",
     ):
         assert token in source
-    assert "if (pfb_pkg_ca_is_plus()) {" in page
+    # issue #2630: the login-generation hook applies on every edition; the pkg.conf
+    # generation stays Plus-only.
+    assert "if (pfb_pkg_ca_is_plus() || pfb_pkgconf_ca_hook_is_login()) {" in page
     assert "config_get_path" not in page
     assert "gen/pfb_pkg_ca_consent" not in page
 

--- a/tests/test_pkg_ca_integration_3_3.py
+++ b/tests/test_pkg_ca_integration_3_3.py
@@ -36,6 +36,17 @@ def test_save_persists_consent_before_applying_pkg_conf() -> None:
     assert "pfb_software_check_config_write(" in save
     assert "if ($pfb_ca_ok)" in save
     assert "$input_errors[]" in save
+    # issue #2631 review round: the failure notice speaks the installed generation.
+    # Login hook: per-verb diagnosis naming /etc/login.conf, boot-only retry (there
+    # is no per-check reapply to promise). Old hook: the shipped 3.3.3 sentence,
+    # byte-preserved, naming pkg.conf.
+    assert "if (pfb_pkgconf_ca_hook_is_login()) {" in save
+    assert save.count("could not update /etc/login.conf right now") == 2
+    assert "the file may be a symlink, or have a shape pfBlockerNG does not edit" in save
+    assert save.count("it will retry at the next boot.") == 2
+    assert "pfBlockerNG will retry at the next boot or package check." in save
+    assert "PFB_PKG_CONF" in save
+    assert "/etc/login.conf' : PFB_PKG_CONF" not in save
 
 
 def test_ui_is_conditional_and_posts_an_explicit_consent_token() -> None:


### PR DESCRIPTION
Backport of the issue #2617 login.conf CA carry semantics to the `release/3.3` line (issue #2630).

## Problem

The published installer now ships the login.conf-generation repo hook (verbs `login-ca-sync`/`login-ca-revoke`, consent on by default, the old `ca-sync`/`ca-revoke` verbs retired). A 3.3 box runs whichever hook generation its installer left behind, but the 3.3 Software page only speaks the old pkg.conf dialect: it sends retired verbs, re-applies `ca-sync` on every check, treats consent as opt-in, renders Plus-only, and points its help text and failure notices at `pkg.conf`.

## Change

`pfb_pkgconf_ca_hook_is_login()` probes the installed hook body once per call and the page speaks the matching dialect:

- **Old generation:** byte-for-byte the shipped 3.3.3 behaviour. Zero change.
- **Login generation:** save/apply map to `login-ca-sync`/`login-ca-revoke`; `pfb_pkg_exec()` becomes a plain exec (the hook's boot reconcile owns the environment, and `login-ca-sync` is consent-independent by design — a per-check call would re-add the carry against a recorded opt-out); consent defaults ON with a present-empty token as the explicit opt-out; the control renders on every edition with login.conf help text; the save-failure notice names `/etc/login.conf`.

Also carries devel's agent-tooling ignore pattern onto this branch (`graphify-out/` top-level, committed self-ignoring `.codegraph/.gitignore`).

## Tests

Test-first per the branch idiom: seven new assert rows across `assert_pkg_ca_{delegate,core,ui_render}_3_3.php`, six of them executed RED against the untouched sources and GREEN unchanged after (the seventh pins the old generation's opt-in default, passing on both sides by design) — red-time blob hashes `a6c5155c` (delegate), `57075786` (core), `e2b0cee4` (ui_render). The core file's pre-existing wrapper-shape row and the page-gating pytest anchor were updated to the new shape with their invariants preserved (the old-generation exec still sits behind the ca-sync gate; core's frozen hash moved to `3f738c58` with that pin edit).

Branch suite: 39 pytest passed; all pkg-ca asserts ALL PASS under docker `php:8.3-cli`. `assert_logger_shim_3_3.php` throws on the UNTOUCHED base in the same container (pre-existing, unrelated).

## Review round (commit `bb840f75d`)

Four-leg adversarial review + independent verifier gate; the round fixes a MAJOR (a save POST lacking the rendered-section marker collapsed the login generation's default-ON consent into an unrecorded revoke), adds coverage for the failure notice, splits that notice per generation (per-verb text under the login hook, boot-only retry promise; the old sentence byte-preserved), accepts a case-variant `On` token under the login generation, bounds the probe read, renames the form helper for devel parity, and refreshes two stale comments. Full ledger in the review comment below.

## Hook manifest (commit `d2e658fe`)

This branch also gains the `.githooks-exempt` manifest (issue #2633, devel PR #2637) listing the nine devel checkers the 3.3 family does not ship. Its commit ran the merged pre-commit hook with no bypass and passed with per-gate exempt notices — the live proof of the opt-out mechanism.

Part of #2617. Part of #2630. Part of #2633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for login-generation CA hooks, including synchronization and revocation actions.
  - Added consent controls for installations using login-generation hooks.
  - Expanded CA configuration support beyond Plus editions when applicable.
- **Bug Fixes**
  - Improved save-error messages with clearer enable/disable guidance and retry timing.
  - Updated help text and validation to distinguish login-generation and legacy configurations.
- **Tests**
  - Added coverage for consent behavior, hook detection, command execution, UI rendering, and integration error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->