### PR TITLE
githooks: explicit legacy-branch opt-out for absent repo checkers (issue #2633)

### DIFF
--- a/.agents/policy/git.md
+++ b/.agents/policy/git.md
@@ -59,7 +59,9 @@ exact-root index. Any GitHub Actions workflow that commits code runs it after ch
   shellcheck; PHP → `php -l` + PHPCS; URL-encoding check when
   `*.sh`/`*.md` staged). NOT unit suites — run `python3 -m pytest` yourself while
   iterating; tests and static analysis run in CI only. Missing tool = reported + skipped.
-  `--no-verify` bypass is for humans, not agents.
+  `--no-verify` bypass is for humans, not agents. Release-line trees lacking the
+  checker corpus opt out per gate via a committed root `.githooks-exempt`
+  manifest (issue #2633) instead of bypassing.
 - **`prepare-commit-msg`** — first aborts agent commit (`CLAUDECODE=1`,
   `CODEX_THREAD_ID`, Copilot, Grok, or OMP marker set) in **primary checkout**
   (agents commit only in linked worktrees — issue #1262; state-checked via

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -48,6 +48,18 @@ step() { printf '[pre-commit] %s\n' "$1"; }
 failed() { printf '[pre-commit] FAILED: %s\n' "$1" >&2; fail=1; }
 skip() { skipped="${skipped}${skipped:+,} $1"; }
 
+# Explicit legacy-branch opt-out (issue #2633): every worktree runs THIS hook via the
+# absolute shared core.hooksPath, but release-line trees never shipped the devel
+# checker corpus. A repo-script gate whose checker is absent from the tree is skipped
+# only when the tree explicitly commits that exact script path in .githooks-exempt.
+# A missing checker with no listed exemption stays a hard failure -- deleting a
+# checker on devel can never silently open its gate (devel commits no manifest) --
+# and a listed checker that IS present still runs.
+exempted() {
+	[ ! -f "$1" ] && [ -f .githooks-exempt ] && grep -qxF -e "$1" .githooks-exempt
+}
+exempt() { printf '[pre-commit] exempt (checker not shipped on this branch; listed in .githooks-exempt): %s\n' "$1"; }
+
 # --- Stage classification: run a language's gates ONLY when this commit stages a
 #     file of that type. (diff-filter ACMR = added/copied/modified/renamed; a pure
 #     deletion stages nothing to lint.) Nothing staged -> nothing to do.
@@ -160,7 +172,9 @@ fi
 #     Relevant to shell scripts AND Markdown shell fences, so it runs when either
 #     is staged. Reuses the python resolved above (CI is the hard gate when absent). ---
 if [ "$staged_sh" = 1 ] || [ "$staged_md" = 1 ]; then
-	if [ -n "$py_bin" ]; then
+	if exempted scripts/check_url_encoding.py; then
+		exempt url-encoding
+	elif [ -n "$py_bin" ]; then
 		step 'url-encoding (no naked $var in curl URLs)'
 		"$py_bin" scripts/check_url_encoding.py || failed 'url-encoding'
 	else
@@ -172,7 +186,9 @@ fi
 #     (issue #1217, reverse-tabnabbing defence). Relevant to the Web UI surface:
 #     PHP/inc pages and the wizard XML under src/usr/local/www. ---
 if [ "$staged_php" = 1 ] || [ "$staged_xml" = 1 ]; then
-	if [ -n "$py_bin" ]; then
+	if exempted scripts/check_noopener.py; then
+		exempt noopener
+	elif [ -n "$py_bin" ]; then
 		step 'noopener (target=_blank needs adjacent rel=noopener noreferrer)'
 		"$py_bin" scripts/check_noopener.py || failed 'noopener'
 	else
@@ -183,7 +199,9 @@ fi
 # --- Forbid direct Python interpreter paths ON the pfSense appliance. Consumers
 #     invoke pfb_python.sh, the sole dependency-derived resolver. ---
 if [ "$staged_py" = 1 ] || [ "$staged_php" = 1 ] || [ "$staged_sh" = 1 ]; then
-	if [ -n "$py_bin" ]; then
+	if exempted scripts/check_appliance_python.py; then
+		exempt no-appliance-python
+	elif [ -n "$py_bin" ]; then
 		step 'no-direct-appliance-python'
 		"$py_bin" scripts/check_appliance_python.py || failed 'no-appliance-python'
 	else
@@ -198,7 +216,9 @@ fi
 #     py/php/sh/yaml). Scans the whole tracked set; escape a real one-off inline
 #     with `# version-literal-ok: <reason>`. ---
 if [ "$staged_py" = 1 ] || [ "$staged_php" = 1 ] || [ "$staged_sh" = 1 ] || [ "$staged_yaml" = 1 ]; then
-	if [ -n "$py_bin" ]; then
+	if exempted scripts/check_version_literals.py; then
+		exempt version-literals
+	elif [ -n "$py_bin" ]; then
 		step 'version-literals (no hardcoded version tokens)'
 		"$py_bin" scripts/check_version_literals.py || failed 'version-literals'
 	else
@@ -210,7 +230,9 @@ fi
 #     archaeology) in ADDED comment lines under src/ + scripts/. Diff-scoped:
 #     judges only the staged diff, so pre-existing narration is grandfathered
 #     until its cleanup lands. Escape inline with `# narration-ok: <reason>`. ---
-if [ -n "$py_bin" ]; then
+if exempted scripts/check_comment_narration.py; then
+	exempt comment-narration
+elif [ -n "$py_bin" ]; then
 	step 'comment-narration (no process narration in new comments)'
 	"$py_bin" scripts/check_comment_narration.py --staged || failed 'comment-narration'
 else
@@ -222,7 +244,9 @@ fi
 #     checker self-scopes: it validates iff the staged diff touches a role
 #     surface (.agents/policy/, model-tiers.conf, .codex/agents/,
 #     .claude/workflows/, .agents/skills/); otherwise it reports the skip. ---
-if [ -n "$py_bin" ]; then
+if exempted scripts/check_agent_roles.py; then
+	exempt agent-roles
+elif [ -n "$py_bin" ]; then
 	step 'agent-roles (role registry vs vendor role definitions)'
 	"$py_bin" scripts/check_agent_roles.py --staged || failed 'agent-roles'
 else
@@ -234,7 +258,9 @@ fi
 #     their byte budgets, and every AGENTS.md routing-table target keeps its
 #     Scope/Load-when header. Self-scopes: validates iff the staged diff
 #     touches a context surface; otherwise reports the skip. ---
-if [ -n "$py_bin" ]; then
+if exempted scripts/check_context_budget.py; then
+	exempt context-budget
+elif [ -n "$py_bin" ]; then
 	step 'context-budget (bootstrap/policy byte budgets + routing headers)'
 	"$py_bin" scripts/check_context_budget.py --staged || failed 'context-budget'
 else
@@ -244,7 +270,9 @@ fi
 # =============================== PHP (*.php, *.inc) ========================== #
 if [ "$staged_php" = 1 ]; then
 	composer_vendor_ok=1
-	if [ -n "$py_bin" ]; then
+	if exempted scripts/check_composer_vendor.py; then
+		exempt 'composer vendor'
+	elif [ -n "$py_bin" ]; then
 		step 'composer vendor'
 		"$py_bin" scripts/check_composer_vendor.py || {
 			failed 'composer vendor'

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -51,17 +51,22 @@ skip() { skipped="${skipped}${skipped:+,} $1"; }
 # Explicit legacy-branch opt-out (issue #2633): every worktree runs THIS hook via the
 # absolute shared core.hooksPath, but release-line trees never shipped the devel
 # checker corpus. A repo-script gate whose checker is absent from the tree is skipped
-# only when the tree explicitly commits that exact script path in .githooks-exempt:
-# the manifest must be git-tracked (an untracked file is invisible to review and
-# exempts nothing). A missing checker with no listed exemption stays a hard failure
-# -- deleting a checker on devel can never silently open its gate (devel commits no
-# manifest) -- and a listed checker that IS present still runs; -e also counts a
-# directory at the path as present, so it runs (and fails) rather than exempts.
-# Manifest comment lines are inert: with grep -x a '# ...' line never equals a path.
+# only when the tree explicitly commits that exact script path in .githooks-exempt.
+# The manifest is graded from the STAGED index blob, never the working tree: an
+# untracked file or an unstaged edit is invisible to review and exempts nothing,
+# and a symlinked manifest (index mode 120000) is rejected outright. A missing
+# checker with no listed exemption stays a hard failure -- deleting a checker on
+# devel can never silently open its gate (devel commits no manifest) -- and a
+# listed checker that IS present still runs; -e also counts a directory at the
+# path as present, so it runs (and fails) rather than exempts. Manifest comment
+# lines are inert: with grep -x a '# ...' line never equals a path.
 exempted() {
-	[ ! -e "$1" ] && [ -f .githooks-exempt ] \
-		&& git ls-files --error-unmatch -- .githooks-exempt >/dev/null 2>&1 \
-		&& grep -qxF -e "$1" .githooks-exempt
+	[ ! -e "$1" ] || return 1
+	case $(git ls-files --stage -- .githooks-exempt 2>/dev/null) in
+	100*) ;;
+	*) return 1 ;;
+	esac
+	git show :.githooks-exempt 2>/dev/null | grep -qxF -e "$1"
 }
 exempt() { printf '[pre-commit] exempt (checker not shipped on this branch; listed in .githooks-exempt): %s\n' "$1"; }
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -51,12 +51,17 @@ skip() { skipped="${skipped}${skipped:+,} $1"; }
 # Explicit legacy-branch opt-out (issue #2633): every worktree runs THIS hook via the
 # absolute shared core.hooksPath, but release-line trees never shipped the devel
 # checker corpus. A repo-script gate whose checker is absent from the tree is skipped
-# only when the tree explicitly commits that exact script path in .githooks-exempt.
-# A missing checker with no listed exemption stays a hard failure -- deleting a
-# checker on devel can never silently open its gate (devel commits no manifest) --
-# and a listed checker that IS present still runs.
+# only when the tree explicitly commits that exact script path in .githooks-exempt:
+# the manifest must be git-tracked (an untracked file is invisible to review and
+# exempts nothing). A missing checker with no listed exemption stays a hard failure
+# -- deleting a checker on devel can never silently open its gate (devel commits no
+# manifest) -- and a listed checker that IS present still runs; -e also counts a
+# directory at the path as present, so it runs (and fails) rather than exempts.
+# Manifest comment lines are inert: with grep -x a '# ...' line never equals a path.
 exempted() {
-	[ ! -f "$1" ] && [ -f .githooks-exempt ] && grep -qxF -e "$1" .githooks-exempt
+	[ ! -e "$1" ] && [ -f .githooks-exempt ] \
+		&& git ls-files --error-unmatch -- .githooks-exempt >/dev/null 2>&1 \
+		&& grep -qxF -e "$1" .githooks-exempt
 }
 exempt() { printf '[pre-commit] exempt (checker not shipped on this branch; listed in .githooks-exempt): %s\n' "$1"; }
 
@@ -84,8 +89,12 @@ printf '%s\n' "$staged_all" | grep -qE \
 # The detailed policy/procedures have one canonical source. Codex files are
 # discovery/runtime adapters only; catch a new or removed source with no mapping.
 if [ "$staged_agentcfg" = 1 ]; then
-	step 'agent-config parity (shared sources, adapters, and model tiers)'
-	sh scripts/agent/check-agent-config-parity.sh || failed 'agent-config parity'
+	if exempted scripts/agent/check-agent-config-parity.sh; then
+		exempt 'agent-config parity'
+	else
+		step 'agent-config parity (shared sources, adapters, and model tiers)'
+		sh scripts/agent/check-agent-config-parity.sh || failed 'agent-config parity'
+	fi
 fi
 
 # =============================== Python (*.py) =============================== #
@@ -270,6 +279,11 @@ fi
 # =============================== PHP (*.php, *.inc) ========================== #
 if [ "$staged_php" = 1 ]; then
 	composer_vendor_ok=1
+	# An exempted vendor check deliberately leaves the style gates enabled: php -l
+	# grades against the host interpreter regardless of vendor state, and phpcs
+	# self-skips when vendor/bin/phpcs is absent (the release-line case), so the
+	# fail-closed rationale (grading against wrong Composer tool versions) cannot
+	# bite on a tree that ships no Composer machinery at all.
 	if exempted scripts/check_composer_vendor.py; then
 		exempt 'composer vendor'
 	elif [ -n "$py_bin" ]; then

--- a/tests/shell/precommit_githooks_exempt_spec.sh
+++ b/tests/shell/precommit_githooks_exempt_spec.sh
@@ -1,0 +1,76 @@
+#shellcheck shell=sh
+# .githooks/pre-commit legacy-branch opt-out (issue #2633): a repo-script gate whose
+# checker is absent from the tree is skipped ONLY when the tree explicitly commits
+# that exact script path in .githooks-exempt; a missing checker with no listed
+# exemption stays a hard failure, and a listed checker that IS present still runs.
+
+Describe '.githooks/pre-commit .githooks-exempt legacy opt-out'
+  gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
+  # The sandbox stages a PHP file so the hook wants all seven repo checkers, none
+  # of which exist in the sandbox scripts/ dir -- the release-line situation. The
+  # REAL host python runs, so a missing checker fails exactly as it does live.
+  ALL_CHECKERS='scripts/check_noopener.py
+scripts/check_appliance_python.py
+scripts/check_version_literals.py
+scripts/check_comment_narration.py
+scripts/check_agent_roles.py
+scripts/check_context_budget.py
+scripts/check_composer_vendor.py'
+  make_repo() {
+    scrub_git_env
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitexempt.XXXXXX")"
+    git_fixture -C "$repo" init -q
+    gitc config commit.gpgsign false
+    mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
+    cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+    printf '<?php echo 1;\n' > "$repo/src/a.php"
+    gitc add src/a.php
+
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitexemptstub.XXXXXX")"
+    checker_marker="$stubdir/checker-ran"
+    printf '#!/bin/sh\nexit 0\n' > "$stubdir/php"
+    printf '#!/bin/sh\nexit 0\n' > "$repo/vendor/bin/phpcs"
+    chmod +x "$stubdir/php" "$repo/vendor/bin/phpcs"
+    PATH="$stubdir:$PATH"
+  }
+  cleanup() { rm -rf "$repo" "$stubdir"; }
+  Before 'make_repo'
+  After 'cleanup'
+
+  It 'skips an absent checker only through the committed manifest and passes'
+    printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include 'listed in .githooks-exempt): composer vendor'
+    The output should include 'listed in .githooks-exempt): noopener'
+    The output should include '[pre-commit] php -l'
+    The output should include '[pre-commit] phpcs'
+    The stderr should not include 'FAILED'
+  End
+
+  It 'still hard-fails a missing checker when no manifest exists'
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should include '[pre-commit] composer vendor'
+    The stderr should include '[pre-commit] FAILED: composer vendor'
+  End
+
+  It 'still hard-fails a missing checker the manifest does not list'
+    printf 'scripts/check_noopener.py\n' > "$repo/.githooks-exempt"
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should include 'listed in .githooks-exempt): noopener'
+    The stderr should include '[pre-commit] FAILED: composer vendor'
+  End
+
+  It 'runs a checker that is present even when the manifest lists it'
+    printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    printf 'import pathlib, sys\npathlib.Path(%s).touch()\nsys.exit(0)\n' "'$checker_marker'" \
+      > "$repo/scripts/check_composer_vendor.py"
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include '[pre-commit] composer vendor'
+    The output should not include 'listed in .githooks-exempt): composer vendor'
+    Assert [ -e "$checker_marker" ]
+  End
+End

--- a/tests/shell/precommit_githooks_exempt_spec.sh
+++ b/tests/shell/precommit_githooks_exempt_spec.sh
@@ -6,16 +6,18 @@
 
 Describe '.githooks/pre-commit .githooks-exempt legacy opt-out'
   gitc() { git_fixture -C "$repo" -c user.email=t@t -c user.name=t "$@"; }
-  # The sandbox stages a PHP file so the hook wants all seven repo checkers, none
-  # of which exist in the sandbox scripts/ dir -- the release-line situation. The
-  # REAL host python runs, so a missing checker fails exactly as it does live.
+  # The sandbox stages PHP and shell files so the hook wants the repo checkers,
+  # none of which exist in the sandbox scripts/ dir -- the release-line situation.
+  # The REAL host python runs, so a missing checker fails exactly as it does live.
   ALL_CHECKERS='scripts/check_noopener.py
 scripts/check_appliance_python.py
 scripts/check_version_literals.py
 scripts/check_comment_narration.py
 scripts/check_agent_roles.py
 scripts/check_context_budget.py
-scripts/check_composer_vendor.py'
+scripts/check_composer_vendor.py
+scripts/check_url_encoding.py
+scripts/agent/check-agent-config-parity.sh'
   make_repo() {
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitexempt.XXXXXX")"
@@ -39,12 +41,39 @@ scripts/check_composer_vendor.py'
 
   It 'skips an absent checker only through the committed manifest and passes'
     printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    printf '#!/bin/sh\nexit 0\n' > "$repo/src/b.sh"
+    gitc add src/b.sh
     When run sh -c "cd '$repo' && sh .githooks/pre-commit"
     The status should equal 0
     The output should include 'listed in .githooks-exempt): composer vendor'
     The output should include 'listed in .githooks-exempt): noopener'
+    The output should include 'listed in .githooks-exempt): url-encoding'
     The output should include '[pre-commit] php -l'
     The output should include '[pre-commit] phpcs'
+    The stderr should not include 'FAILED'
+  End
+
+  It 'ignores a manifest that is not tracked by git'
+    printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should include '[pre-commit] composer vendor'
+    The output should not include 'listed in .githooks-exempt'
+    The stderr should include '[pre-commit] FAILED: composer vendor'
+  End
+
+  It 'exempts the agent-config parity gate only through the manifest'
+    printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    printf '# sandbox agent adapter\n' > "$repo/CLAUDE.md"
+    gitc add CLAUDE.md
+    # markdownlint would shell out through npx for the staged .md; stub it.
+    printf '#!/bin/sh\nexit 0\n' > "$stubdir/npx"
+    chmod +x "$stubdir/npx"
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include 'listed in .githooks-exempt): agent-config parity'
     The stderr should not include 'FAILED'
   End
 
@@ -57,6 +86,7 @@ scripts/check_composer_vendor.py'
 
   It 'still hard-fails a missing checker the manifest does not list'
     printf 'scripts/check_noopener.py\n' > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
     When run sh -c "cd '$repo' && sh .githooks/pre-commit"
     The status should equal 1
     The output should include 'listed in .githooks-exempt): noopener'
@@ -65,6 +95,7 @@ scripts/check_composer_vendor.py'
 
   It 'runs a checker that is present even when the manifest lists it'
     printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
     printf 'import pathlib, sys\npathlib.Path(%s).touch()\nsys.exit(0)\n' "'$checker_marker'" \
       > "$repo/scripts/check_composer_vendor.py"
     When run sh -c "cd '$repo' && sh .githooks/pre-commit"
@@ -72,5 +103,15 @@ scripts/check_composer_vendor.py'
     The output should include '[pre-commit] composer vendor'
     The output should not include 'listed in .githooks-exempt): composer vendor'
     Assert [ -e "$checker_marker" ]
+  End
+
+  It 'treats a directory at a listed checker path as present and fails closed'
+    printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    mkdir "$repo/scripts/check_composer_vendor.py"
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should not include 'listed in .githooks-exempt): composer vendor'
+    The stderr should include '[pre-commit] FAILED: composer vendor'
   End
 End

--- a/tests/shell/precommit_githooks_exempt_spec.sh
+++ b/tests/shell/precommit_githooks_exempt_spec.sh
@@ -74,9 +74,11 @@ scripts/agent/check-agent-config-parity.sh'
     The stderr should include '[pre-commit] FAILED: composer vendor'
   End
 
-  It 'rejects a symlinked manifest even when its target lists the checkers'
-    printf '%s\n' "$ALL_CHECKERS" > "$stubdir/exempt-target"
-    ln -s "$stubdir/exempt-target" "$repo/.githooks-exempt"
+  It 'rejects a symlinked manifest whose target text names a checker'
+    # The discriminating construction for the index-mode guard: a staged symlink's
+    # blob IS its target path text, so this one reads back as exactly the composer
+    # checker's path and would exempt it if only blob content were graded.
+    ln -s scripts/check_composer_vendor.py "$repo/.githooks-exempt"
     gitc add .githooks-exempt
     When run sh -c "cd '$repo' && sh .githooks/pre-commit"
     The status should equal 1

--- a/tests/shell/precommit_githooks_exempt_spec.sh
+++ b/tests/shell/precommit_githooks_exempt_spec.sh
@@ -63,6 +63,27 @@ scripts/agent/check-agent-config-parity.sh'
     The stderr should include '[pre-commit] FAILED: composer vendor'
   End
 
+  It 'grades exemptions against the staged manifest, not working-tree edits'
+    printf 'scripts/check_noopener.py\n' > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should include 'listed in .githooks-exempt): noopener'
+    The output should not include 'listed in .githooks-exempt): composer vendor'
+    The stderr should include '[pre-commit] FAILED: composer vendor'
+  End
+
+  It 'rejects a symlinked manifest even when its target lists the checkers'
+    printf '%s\n' "$ALL_CHECKERS" > "$stubdir/exempt-target"
+    ln -s "$stubdir/exempt-target" "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should not include 'listed in .githooks-exempt'
+    The stderr should include '[pre-commit] FAILED: composer vendor'
+  End
+
   It 'exempts the agent-config parity gate only through the manifest'
     printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
     gitc add .githooks-exempt


### PR DESCRIPTION
## Problem

`core.hooksPath` is an absolute path in the shared `.git/config`, so every worktree — including release-line worktrees — runs devel's `.githooks/pre-commit`. Release/3.3 does not ship the `scripts/check_*.py` checker corpus, so any commit staging PHP there fails seven repo-script gates with `can't open file` (probed live on the 3.3 worktree) and forces `--no-verify`.

Making the shared hook tolerate absent checkers was rejected by the owner: a checker deleted on devel by mistake would then silently open its gate — failure by omission.

## Change

The opt-out is an explicit committed artifact instead. `.githooks/pre-commit` skips a repo-script gate, with a loud per-gate notice, only when BOTH hold: the checker script is absent from the tree, and the tree commits that exact path in a root `.githooks-exempt` manifest. A missing checker with no listed exemption stays a hard failure (devel commits no manifest, so devel keeps today's fully fail-closed behaviour), and a listed checker that IS present still runs its gate, so a manifest cannot disable a live checker. A gate added on devel later is not silently skipped on a legacy branch until that branch's manifest is consciously amended.

All nine repo-script call sites (url-encoding, noopener, appliance-python, version-literals, comment-narration, agent-roles, context-budget, composer vendor, and — added in the review round — the agent-config parity shell checker) get the same `exempted`/`exempt` prelude; the gates themselves are unchanged. The review round also requires the manifest to be git-tracked (`git ls-files --error-unmatch`): an untracked `.githooks-exempt` is invisible to review and exempts nothing, while the bootstrapping commit that first stages the manifest still passes. `release/3.3` will gain the manifest listing its nine absent checkers on PR #2631, and that commit passing the hook without `--no-verify` will be the live proof.

## Review round (commit `28c85603`)

Four legs (contract, correctness+hostile, test-honesty, ponytail) + independent verifier. Fixed: the ninth gate above (MAJOR); the tracked-manifest requirement (MAJOR); url-encoding was the one unexercised exemption site — row one now stages a shell file and pins its notice (MINOR); `[ ! -e ]` over `[ ! -f ]` so a directory at a listed checker path runs and fails closed (NIT); comments now state the tracked requirement, manifest comment-line inertness, and the composer-exempt exception; `.agents/policy/git.md` points `--no-verify` readers at the manifest mechanism. Recorded, not changed: a committed symlinked manifest is honoured (same trust boundary as editing the hook); subdirectory invocation correct via the hook's `cd` to the git top level (probed live); the eight-fold prelude kept over a wrapper (ponytail: wrapper = bigger diff, same behaviour). New rows executed RED against the round-one hook (spec blob `9acbbf42`, byte-identical after) and GREEN (7 examples, 0 failures); correctness leg's hostile-manifest matrix (CRLF, BOM, trailing space, globs, comments, directory, unreadable, symlink) fails closed throughout; test-honesty leg: 5/5 mutation kills, 1543-example shell suite clean.

## Tests

`tests/shell/precommit_githooks_exempt_spec.sh` (sandbox repo, real host python, staged PHP): executed RED against the unmodified hook — manifest-skip, unlisted-miss, and present-but-listed rows all failed (spec blob `810ba0d1`, byte-identical after) — and GREEN after the hook edit (4 examples, 0 failures). The no-manifest fail-closed row is a pin passing on both sides by design. `scripts/agent/run-gates.sh`: GATES: PASS. `shellcheck --severity=info` reports no findings beyond the two pre-existing SC2016 infos already present in the baseline hook.

Closes #2633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opting out of selected repository checks when their checker scripts are unavailable on legacy branches.
  * Exemptions are accepted only through a tracked manifest with exact checker paths.
  * Available checks continue to run, including PHP style checks when applicable.

* **Bug Fixes**
  * Invalid, incomplete, untracked, or unsafe exemption configurations now fail safely.

* **Tests**
  * Added coverage for valid exemptions, missing manifests, present checkers, and invalid checker paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->