### PR TITLE
download: stop offering Accept-Encoding on feed fetches

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -898,8 +898,8 @@ auto-registers every file in `tests/smoke/fixtures/` when it starts; individual 
 `mock_feeds.feed_url("<name>")` to get the guest URL.
 
 **How `_MockFeedServer.register()` works.** `register(name, body)` stores the body in an
-in-memory dict; the HTTP handler serves it verbatim (plain body, no `Content-Encoding`, no
-`Content-Disposition`) at `GET /<name>`. The fixture directory variant
+in-memory dict; the HTTP handler serves it verbatim (plain body, no `Content-Encoding` by
+default, no `Content-Disposition`) at `GET /<name>`. The fixture directory variant
 (`mock_feeds.feed_url("<filename>")`) reads the file on first access and registers it under its
 basename. Conditional-GET behaviour is opt-in per name — `enable_etag()` (ETag +
 `If-None-Match` 304), `enable_lastmod_304()` (RFC-conformant `If-Modified-Since`),
@@ -1452,6 +1452,14 @@ sibling of ADR-40 (which gates IP **pf-table** reloads on radix-tree set members
 *not* file hashing) — different data, different mechanism; cross-reference only, no overlap. The
 deferred DNSBL structure-reuse ADR will build on this convention (persist each loaded file's hash
 to reuse an unchanged file's in-memory structure on a swap) but is out of scope here.
+
+**Transfer encoding — feed fetches offer no `Accept-Encoding`** (issue #2634). The digest above
+covers the RAW fetched bytes, and extraction dispatches on the same bytes' detected MIME type, so
+the body on disk must be what the origin published. Offering gzip let an origin that labels an
+archive `Content-Encoding: gzip` (Apache's `AddEncoding x-gzip .gz`) have libcurl decode it in
+flight: a digest of different bytes, and a `.tar.gz` arriving as `application/x-tar`. Transfers
+are therefore uncompressed for plain-text feeds too — re-introducing negotiated compression
+requires solving the raw-digest contract first, not just the extraction branch.
 
 **Per-side hash algorithm** — each side uses a hash native to it and compares only its own
 digests; **no cross-language digest is ever produced or compared**:

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -901,8 +901,12 @@ auto-registers every file in `tests/smoke/fixtures/` when it starts; individual 
 in-memory dict; the HTTP handler serves it verbatim (plain body, no `Content-Encoding`, no
 `Content-Disposition`) at `GET /<name>`. The fixture directory variant
 (`mock_feeds.feed_url("<filename>")`) reads the file on first access and registers it under its
-basename. `curl` does not send `Accept-Encoding: gzip` nor `If-Modified-Since`, so the mock
-needs no compression or ETag/304 logic — plain body is fine.
+basename. Conditional-GET behaviour is opt-in per name — `enable_etag()` (ETag +
+`If-None-Match` 304), `enable_lastmod_304()` (RFC-conformant `If-Modified-Since`),
+`disable_lastmod()` (no validator at all) — so a case picks the branch it means to exercise.
+`enable_content_encoding_gzip()` (issue #2634) labels a response `Content-Encoding: gzip`
+without touching the body, reproducing the Apache `AddEncoding` origin; pfBlockerNG offers no
+`Accept-Encoding`, so the published bytes must survive that label untouched.
 
 **Adding a new format fixture.**
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -369,12 +369,9 @@ $pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'pfSense/pfBlockerNG cURL d
 				CURLOPT_FORBID_REUSE	=> TRUE,
 				CURLOPT_SSL_ENABLE_ALPN	=> TRUE,
 				CURLOPT_SSL_ENABLE_NPN	=> TRUE,
-				// issue #2634: NO Accept-Encoding is offered. A feed body is a hashed artifact
-				// (ADR-42 stores a digest of the RAW fetched bytes and the conditional-GET
-				// compare rides on it) and extraction dispatches on that body's detected MIME
-				// type. An origin that labels an archive 'Content-Encoding: gzip' (Apache's
-				// AddEncoding) would have libcurl decode it in flight, so what reached disk
-				// was the archive's inner bytes -- a different digest and the wrong branch.
+				// issue #2634: no Accept-Encoding is offered -- a decoded body breaks both the
+				// ADR-42 raw-byte digest and MIME dispatch (architecture-notes, "Transfer
+				// encoding").
 				// Constrain libcurl to the schemes pfBlockerNG fetches feeds over (http/https/ftp;
 				// rsync uses exec separately) — an independent backstop to the PFB_FILTER_URL scheme
 				// allowlist, since PHP parse_url and libcurl can disagree on crafted input.
@@ -13649,7 +13646,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				}
 
 				// Load curl default settings — incl. the CURLOPT_PROTOCOLS scheme allow-list
-				// (an independent libcurl-layer backstop to PFB_FILTER_URL) and gzip encoding.
+				// (an independent libcurl-layer backstop to PFB_FILTER_URL).
 				curl_setopt_array($ch, $pfb['curl_defaults']);
 
 				curl_setopt($ch, CURLOPT_FILE, $fhandle);	// Add $fhandle setting to cURL

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -369,7 +369,12 @@ $pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'pfSense/pfBlockerNG cURL d
 				CURLOPT_FORBID_REUSE	=> TRUE,
 				CURLOPT_SSL_ENABLE_ALPN	=> TRUE,
 				CURLOPT_SSL_ENABLE_NPN	=> TRUE,
-				CURLOPT_ENCODING	=> 'gzip',	// Request 'gzip' response encoding when the server offers it
+				// issue #2634: NO Accept-Encoding is offered. A feed body is a hashed artifact
+				// (ADR-42 stores a digest of the RAW fetched bytes and the conditional-GET
+				// compare rides on it) and extraction dispatches on that body's detected MIME
+				// type. An origin that labels an archive 'Content-Encoding: gzip' (Apache's
+				// AddEncoding) would have libcurl decode it in flight, so what reached disk
+				// was the archive's inner bytes -- a different digest and the wrong branch.
 				// Constrain libcurl to the schemes pfBlockerNG fetches feeds over (http/https/ftp;
 				// rsync uses exec separately) — an independent backstop to the PFB_FILTER_URL scheme
 				// allowlist, since PHP parse_url and libcurl can disagree on crafted input.

--- a/tests/php/DownloadTransferEncodingTest.php
+++ b/tests/php/DownloadTransferEncodingTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2634 — feed fetches offer no Accept-Encoding.
+ *
+ * The end-to-end proof is a live-VM smoke case, and the smoke workflow is dispatch-only,
+ * so nothing PR-gating would notice the option coming back. The digest ADR-42 stores
+ * covers the RAW fetched bytes and extraction dispatches on those same bytes' MIME type,
+ * so a body libcurl decoded in flight is both the wrong digest and the wrong branch.
+ */
+final class DownloadTransferEncodingTest extends TestCase
+{
+	/**
+	 *  GIVEN the curl defaults every feed fetch loads;
+	 *   WHEN they are inspected;
+	 *   THEN no transfer-encoding is requested, so libcurl performs no content decoding
+	 *        and the body written to disk is the one the origin served.
+	 */
+	public function testCurlDefaultsRequestNoTransferEncoding(): void
+	{
+		global $pfb;
+
+		$this->assertIsArray($pfb['curl_defaults'], 'pfb_global() must publish the curl defaults');
+		$this->assertArrayNotHasKey(
+			CURLOPT_ENCODING,
+			$pfb['curl_defaults'],
+			'requesting a transfer encoding lets an origin that labels an archive '
+			. 'Content-Encoding: gzip have libcurl decode it in flight (issue #2634)'
+		);
+	}
+}

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -924,11 +924,18 @@ class _MockFeedServer:
         # issue #722: names in this set get a real If-Modified-Since responder
         # (RFC 9110 §13.1.3) instead of the fixed header being ignored.
         self._ims_304: set[str] = set()
+        # issue #2634: names in this set are served with a Content-Encoding: gzip
+        # response header over an already-gzip body -- the Apache `AddEncoding
+        # x-gzip .gz` misconfiguration. A client that requests gzip transfer
+        # encoding decodes such a response in flight, so what reaches disk is the
+        # archive's INNER bytes rather than the archive the origin published.
+        self._content_encoding_gzip: set[str] = set()
         self._lock = threading.Lock()
         registered = self._registered
         etag_map = self._etag_map
         no_lastmod = self._no_lastmod
         ims_304 = self._ims_304
+        content_encoding_gzip = self._content_encoding_gzip
         lock = self._lock
 
         class Handler(SimpleHTTPRequestHandler):
@@ -940,6 +947,7 @@ class _MockFeedServer:
                     etag = etag_map.get(name)
                     emit_lastmod = name not in no_lastmod
                     honour_ims = name in ims_304
+                    label_gzip_encoded = name in content_encoding_gzip
                 if body is None:
                     super().do_GET()
                     return
@@ -970,6 +978,11 @@ class _MockFeedServer:
                 self.send_response(200)
                 self.send_header("Content-Type", "text/plain")
                 self.send_header("Content-Length", str(len(body)))
+                if label_gzip_encoded:
+                    # issue #2634: the body is served verbatim; only the label claims it
+                    # is gzip-ENCODED. Whether the bytes on the client's disk end up
+                    # decoded is decided entirely by whether the client asked for gzip.
+                    self.send_header("Content-Encoding", "gzip")
                 if etag is not None:
                     self.send_header("ETag", etag)
                 if emit_lastmod:
@@ -1064,6 +1077,18 @@ class _MockFeedServer:
         """
         with self._lock:
             self._ims_304.add(name)
+
+    def enable_content_encoding_gzip(self, name: str) -> None:
+        """Serve a registered feed with a ``Content-Encoding: gzip`` response header.
+
+        issue #2634: an origin that labels an already-compressed archive as
+        gzip-*encoded* (Apache's ``AddEncoding x-gzip .gz``) is common in the wild.
+        The body is still served verbatim -- only the label changes -- so a client
+        that does not offer ``Accept-Encoding: gzip`` receives the published archive
+        untouched, while one that does receives it decoded by its HTTP library.
+        """
+        with self._lock:
+            self._content_encoding_gzip.add(name)
 
     def feed_url(self, name: str) -> str:
         """The URL the GUEST uses to fetch ``name`` (via the SLIRP host alias)."""

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -924,11 +924,8 @@ class _MockFeedServer:
         # issue #722: names in this set get a real If-Modified-Since responder
         # (RFC 9110 §13.1.3) instead of the fixed header being ignored.
         self._ims_304: set[str] = set()
-        # issue #2634: names in this set are served with a Content-Encoding: gzip
-        # response header over an already-gzip body -- the Apache `AddEncoding
-        # x-gzip .gz` misconfiguration. A client that requests gzip transfer
-        # encoding decodes such a response in flight, so what reaches disk is the
-        # archive's INNER bytes rather than the archive the origin published.
+        # issue #2634: names in this set get a Content-Encoding: gzip header over an
+        # unchanged body (the Apache AddEncoding origin).
         self._content_encoding_gzip: set[str] = set()
         self._lock = threading.Lock()
         registered = self._registered
@@ -979,9 +976,6 @@ class _MockFeedServer:
                 self.send_header("Content-Type", "text/plain")
                 self.send_header("Content-Length", str(len(body)))
                 if label_gzip_encoded:
-                    # issue #2634: the body is served verbatim; only the label claims it
-                    # is gzip-ENCODED. Whether the bytes on the client's disk end up
-                    # decoded is decided entirely by whether the client asked for gzip.
                     self.send_header("Content-Encoding", "gzip")
                 if etag is not None:
                     self.send_header("ETag", etag)

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3882,13 +3882,6 @@ def _blacklist_tar_gz(top: str, category: str, domain: str) -> bytes:
 def test_blacklist_archive_survives_gzip_content_encoding(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """issue #2634: a feed labelled Content-Encoding: gzip still ingests as the PUBLISHED archive.
 
-    An origin that serves ``.tar.gz`` with ``Content-Encoding: gzip`` (Apache's
-    ``AddEncoding x-gzip .gz``) is common in the wild. What must never happen is the
-    download deciding, on the strength of that label, to store something other than
-    what the origin published: pfBlockerNG hashes the fetched body (ADR-42) and
-    dispatches extraction on its detected type, so a body decoded in flight is both a
-    different digest and a different branch.
-
     Given an origin serving a valid UT1-shaped ``.tar.gz`` under a
       ``Content-Encoding: gzip`` label,
     When  pfb_download() fetches it as type='blacklist',
@@ -3914,7 +3907,7 @@ def test_blacklist_archive_survives_gzip_content_encoding(deployed_vm: SmokeVM, 
             f"expected pfb_download success on a valid .tar.gz served with Content-Encoding: gzip; got stdout: {out!r}"
         )
         stored = deployed_vm.ssh(f"/usr/bin/file -b --mime-type {archive} 2>&1").stdout.strip()
-        assert stored == "application/gzip", (
+        assert stored in {"application/gzip", "application/x-gzip"}, (
             f"expected the stored archive to still be the PUBLISHED gzip, not its "
             f"decoded inner tar; /usr/bin/file reported {stored!r} for {archive}"
         )

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -54,6 +54,7 @@ import ipaddress
 import os
 import shlex
 import subprocess
+import tarfile
 import zipfile
 from collections.abc import Iterator
 
@@ -3860,6 +3861,72 @@ def test_adr46_hostile_member_blacklist_rejected(deployed_vm: SmokeVM, mock_feed
         )
     finally:
         deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir} {escape_file}")
+
+
+def _blacklist_tar_gz(top: str, category: str, domain: str) -> bytes:
+    """A UT1-shaped blacklist archive: gzip(tar) holding ``<top>/<category>/domains``.
+
+    Mirrors the real UT1 layout the blacklist branch's ``-s`` rewrite rules expect,
+    so the extracted category file lands at ``{dbdir}/<top>/<top>_<category>``.
+    """
+    payload = f"{domain}\n".encode()
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tar:
+        info = tarfile.TarInfo(f"{top}/{category}/domains")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    return gzip.compress(raw.getvalue(), mtime=0)
+
+
+@pytest.mark.timeout(120)
+def test_blacklist_archive_survives_gzip_content_encoding(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """issue #2634: a feed labelled Content-Encoding: gzip still ingests as the PUBLISHED archive.
+
+    An origin that serves ``.tar.gz`` with ``Content-Encoding: gzip`` (Apache's
+    ``AddEncoding x-gzip .gz``) is common in the wild. What must never happen is the
+    download deciding, on the strength of that label, to store something other than
+    what the origin published: pfBlockerNG hashes the fetched body (ADR-42) and
+    dispatches extraction on its detected type, so a body decoded in flight is both a
+    different digest and a different branch.
+
+    Given an origin serving a valid UT1-shaped ``.tar.gz`` under a
+      ``Content-Encoding: gzip`` label,
+    When  pfb_download() fetches it as type='blacklist',
+    Then  the download succeeds, the stored archive is still gzip (not its inner tar),
+      and the category file is extracted from it.
+    """
+    domain = h.unique_domain("pfb2634")
+    name = "pfb2634.tar.gz"
+    workdir = f"{_ADR46_WORKDIR}_2634"
+    category_dir = f"{h.PFB_DBDIR}/pfb2634"
+    archive = f"{workdir}/pfb2634.tar.gz"
+    try:
+        # Given -- clean slate; the origin labels the archive as gzip-encoded.
+        deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir} && /bin/mkdir -p {workdir}")
+        feed_url = mock_feeds.register(name, _blacklist_tar_gz("pfb2634", "testcat", domain))
+        mock_feeds.enable_content_encoding_gzip(name)
+
+        # When -- the blacklist branch fetches it.
+        out = _adr46_download(deployed_vm, feed_url, archive, "pfb2634", "blacklist")
+
+        # Then -- success, the published bytes on disk, and the category extracted from them.
+        assert "PFB_DL_TRUE" in out, (
+            f"expected pfb_download success on a valid .tar.gz served with Content-Encoding: gzip; got stdout: {out!r}"
+        )
+        stored = deployed_vm.ssh(f"/usr/bin/file -b --mime-type {archive} 2>&1").stdout.strip()
+        assert stored == "application/gzip", (
+            f"expected the stored archive to still be the PUBLISHED gzip, not its "
+            f"decoded inner tar; /usr/bin/file reported {stored!r} for {archive}"
+        )
+        extracted = deployed_vm.ssh(f"/bin/cat {category_dir}/pfb2634_testcat 2>&1").stdout
+        assert domain in extracted, (
+            f"expected {domain!r} in the extracted category file "
+            f"{category_dir}/pfb2634_testcat; got: {extracted!r}\n"
+            f"category dir now holds: "
+            f"{deployed_vm.ssh(f'/bin/ls -A {category_dir} 2>&1').stdout!r}"
+        )
+    finally:
+        deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir}")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Fixes #2634.

## What was wrong

`$pfb['curl_defaults']` offered `CURLOPT_ENCODING => 'gzip'` on every feed fetch. An origin that labels an already-compressed archive `Content-Encoding: gzip` — Apache's `AddEncoding x-gzip .gz`, common in the wild — then has libcurl decode the response in flight, so the bytes written to `{feed}.raw` are the archive's *inner* tar rather than what the origin published.

That breaks two contracts at once:

- ADR-42 stores a digest of the **raw fetched bytes** and the conditional-GET compare rides on it, so the stored digest no longer describes the published resource.
- Extraction dispatches on `/usr/bin/file -b --mime-type` of those same bytes, so a `.tar.gz` feed arrives as `application/x-tar` and never reaches the archive branch.

This is the mechanism behind the field report in #2632: a 147,107,840-byte `ut1.tar.gz.raw` where the origin published a ~24 MB gzip.

## The change

One production line: the encoding option is gone, with the reason recorded in place. No `Accept-Encoding` is offered, so libcurl performs no content decoding and the body on disk is what the origin sent.

`docs/misc/architecture-notes.md` claimed `curl` sends no `Accept-Encoding: gzip` — untrue since the option was added, true again now. The same paragraph also predated the issue-#722 conditional-GET opt-ins; it now describes them.

## Red → green (executed on a leased smoke box, CE 2.8.1 guest)

New case `test_blacklist_archive_survives_gzip_content_encoding`: the mock origin serves a valid UT1-shaped `.tar.gz` under a `Content-Encoding: gzip` label (new per-name opt-in `enable_content_encoding_gzip()`), driven through `pfb_download(type='blacklist')`.

RED at `033ffd66d` (test only, no production edit):

```
2026-08-22 13:53:07 pfb_validate: REJECT feed=pfb2634 stage=mime reason=mime_not_allowed detected=application/x-tar rc=0
FAILED tests/smoke/test_smoke_feeds.py::test_blacklist_archive_survives_gzip_content_encoding
================ 1 failed, 1002 deselected in 92.03s (0:01:32) =================
```

GREEN at `7ddfb6429`, same test files byte-identical (`git hash-object`: `e22eeae450facbbd037b87d2c3dde6445170faa9` for `test_smoke_feeds.py`, `ca0727426f5ccbf5ea462d505133b5245edde0cb` for `conftest.py` — identical at red and green), run together with the ADR-46 member-guard cases and `test_gzip_feed_imports` so the removal is shown not to disturb the existing gzip paths:

```
================= 6 passed, 997 deselected in 89.48s (0:01:29) =================
```

The case asserts three things, each failable on its own: the download succeeds, the stored archive is still `application/gzip` rather than its decoded inner tar, and the category file is extracted from it. The middle assertion is what keeps the case honest once #2638 accepts `application/x-tar` — a decoded body would then extract, but it still would not be the published bytes.

## Gates

```
GATES: PASS
```

(`scripts/agent/run-gates.sh --diff origin/devel` — pytest, ruff, mypy, composer vendor, php -l, phpunit, phpstan, phpcs, markdownlint.)

## Not in scope

- #2635 — a non-gzip Blacklist body still reports a successful update and extracts nothing.
- #2638 — accepting `application/x-tar` as a first-class archive type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved gzip-compressed feed archives during downloads, preventing premature decoding.
  * Ensured compressed blacklist archives are stored and extracted successfully.
  * Improved handling of raw downloaded content for feed processing.

* **Tests**
  * Added regression coverage for gzip-encoded downloads and archive extraction.
  * Added validation that download settings do not automatically decode compressed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->