### PR TITLE
install: stream pkg output live during converge

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,18 +160,35 @@ _pkg() {
     fi
 }
 
+# _pkg_mutate_drain FILE — print what FILE has grown by since this shell last drained
+# it, carrying the position in _drain_seen. Addressed by LINE, so a half-written line is
+# never split across two prints; a final line with no newline is left for the
+# read-to-end-of-file drain that runs once pkg has exited.
+_pkg_mutate_drain() {
+    _drain_lines=$(wc -l <"$1" 2>/dev/null || printf '0')
+    _drain_lines=$((_drain_lines + 0))
+    if [ "${_drain_lines}" -gt "${_drain_seen}" ]; then
+        sed -n "$((_drain_seen + 1)),${_drain_lines}p" "$1"
+        _drain_seen=${_drain_lines}
+    fi
+}
+
 # _pkg_mutate DIE_CODE DIE_MSG ARGS... — mutating pkg verbs (install/delete).
-# Stream output live, then die if pkg rc != 0 OR a line is
+# Stream output while pkg runs, then die if pkg rc != 0 OR a line is
 # `pkg: * script failed` (pkg(8) can exit 0 after POST-INSTALL/DEINSTALL
 # still failed — the files are already in place; issue #2575).
 #
-# The copy on disk exists only for that rescan, so it goes through tee(1) rather than
-# a plain redirect: the converge step is the last slow step in this script, so
-# replaying the capture after pkg exits delivered the whole install log — pkg's own
-# lines AND every package script's lines — in one burst immediately before
-# `==> Done`, with nothing on the terminal while the install ran (issue #2644).
-# pkg's own C-side stdout is block-buffered into a pipe, so its lines still arrive in
-# chunks; the package scripts (PHP CLI writes unbuffered) arrive as they are printed.
+# pkg writes to a capture FILE and a reader prints what that file grows by, rather than
+# pkg writing down a pipe. A pipe outlives pkg: every process a package script leaves
+# running inherits the write end, and a reader sees no EOF until the last holder closes
+# it — the hazard pfblockerng.inc states as "LOG FILE, never a pipe" for its own
+# capture (issue #662). Our POST-INSTALL starts unbound, so that risk is not theoretical,
+# and a hang after a completed install is worse than the burst it would replace. A
+# regular file cannot stall the run, and the foreground pkg hands back its own status
+# with no side channel to read it out of (issue #2644).
+#
+# What a reader can show is bounded by what pkg flushes and when; the package scripts
+# (PHP CLI writes unbuffered) appear as they print.
 _pkg_mutate() {
     _mut_code="$1"
     shift
@@ -179,26 +196,34 @@ _pkg_mutate() {
     shift
     if [ -n "${ROOT}" ]; then
         mkdir -p "${ROOT}/tmp" || die "${_mut_code}" "could not create ${ROOT}/tmp"
-        _mut_log=$(mktemp "${ROOT}/tmp/pfb-install-pkg.XXXXXX") ||
-            die "${_mut_code}" "mktemp failed while capturing pkg output"
+        _mut_dir="${ROOT}/tmp"
     else
-        _mut_log=$(mktemp "${TMPDIR:-/tmp}/pfb-install-pkg.XXXXXX") ||
-            die "${_mut_code}" "mktemp failed while capturing pkg output"
+        _mut_dir="${TMPDIR:-/tmp}"
     fi
+    # mktemp for BOTH files: a derived name is a name an attacker can predict from the
+    # first one and pre-create as a symlink, and this runs as root.
+    _mut_log=$(mktemp "${_mut_dir}/pfb-install-pkg.XXXXXX") ||
+        die "${_mut_code}" "mktemp failed while capturing pkg output"
+    _mut_done=$(mktemp "${_mut_dir}/pfb-install-pkg.XXXXXX") ||
+        die "${_mut_code}" "mktemp failed while capturing pkg output"
     # die() exits the script; EXIT trap removes the files on that path too.
     # /tmp on pfSense is a small RAM disk.
-    trap 'rm -f "${_mut_log}" "${_mut_log}.rc"' EXIT
-    # POSIX sh has no PIPESTATUS, so pkg's own status leaves the pipeline through a
-    # side file. `|| _mut_rc=$?` also keeps `set -e` from killing the subshell before
-    # that status is recorded.
-    { _mut_rc=0; _pkg "$@" || _mut_rc=$?; printf '%s\n' "${_mut_rc}" >"${_mut_log}.rc"; } 2>&1 |
-        tee "${_mut_log}"
-    _mut_rc="$(cat "${_mut_log}.rc" 2>/dev/null || true)"
-    case "${_mut_rc}" in
-        '' | *[!0-9]*)
-            die "${_mut_code}" "could not read the exit status of pkg — ${_mut_msg}"
-            ;;
-    esac
+    trap 'rm -f "${_mut_log}" "${_mut_done}"' EXIT
+    # The reader runs in the background and stops when pkg is done: mktemp already
+    # created the done-file, so the flag is CONTENT, not existence.
+    (
+        _drain_seen=0
+        while [ ! -s "${_mut_done}" ]; do
+            _pkg_mutate_drain "${_mut_log}"
+            sleep 1
+        done
+        sed -n "$((_drain_seen + 1)),\$p" "${_mut_log}"
+    ) &
+    _mut_reader=$!
+    _mut_rc=0
+    _pkg "$@" >"${_mut_log}" 2>&1 || _mut_rc=$?
+    printf 'done\n' >"${_mut_done}"
+    wait "${_mut_reader}" 2>/dev/null || true
     if [ "${_mut_rc}" -ne 0 ]; then
         die "${_mut_code}" "${_mut_msg}"
     fi
@@ -212,8 +237,8 @@ _pkg_mutate() {
         esac
     done < "${_mut_log}"
     trap - EXIT
-    rm -f "${_mut_log}" "${_mut_log}.rc"
-    unset _mut_code _mut_msg _mut_log _mut_rc _mut_line
+    rm -f "${_mut_log}" "${_mut_done}"
+    unset _mut_code _mut_msg _mut_dir _mut_log _mut_done _mut_reader _mut_rc _mut_line
 }
 
 usage() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -161,9 +161,17 @@ _pkg() {
 }
 
 # _pkg_mutate DIE_CODE DIE_MSG ARGS... — mutating pkg verbs (install/delete).
-# Stream captured output, then die if pkg rc != 0 OR a line is
+# Stream output live, then die if pkg rc != 0 OR a line is
 # `pkg: * script failed` (pkg(8) can exit 0 after POST-INSTALL/DEINSTALL
 # still failed — the files are already in place; issue #2575).
+#
+# The copy on disk exists only for that rescan, so it goes through tee(1) rather than
+# a plain redirect: the converge step is the last slow step in this script, so
+# replaying the capture after pkg exits delivered the whole install log — pkg's own
+# lines AND every package script's lines — in one burst immediately before
+# `==> Done`, with nothing on the terminal while the install ran (issue #2644).
+# pkg's own C-side stdout is block-buffered into a pipe, so its lines still arrive in
+# chunks; the package scripts (PHP CLI writes unbuffered) arrive as they are printed.
 _pkg_mutate() {
     _mut_code="$1"
     shift
@@ -177,12 +185,20 @@ _pkg_mutate() {
         _mut_log=$(mktemp "${TMPDIR:-/tmp}/pfb-install-pkg.XXXXXX") ||
             die "${_mut_code}" "mktemp failed while capturing pkg output"
     fi
-    # die() exits the script; EXIT trap removes the file on that path too.
+    # die() exits the script; EXIT trap removes the files on that path too.
     # /tmp on pfSense is a small RAM disk.
-    trap 'rm -f "${_mut_log}"' EXIT
-    _mut_rc=0
-    _pkg "$@" >"${_mut_log}" 2>&1 || _mut_rc=$?
-    cat "${_mut_log}"
+    trap 'rm -f "${_mut_log}" "${_mut_log}.rc"' EXIT
+    # POSIX sh has no PIPESTATUS, so pkg's own status leaves the pipeline through a
+    # side file. `|| _mut_rc=$?` also keeps `set -e` from killing the subshell before
+    # that status is recorded.
+    { _mut_rc=0; _pkg "$@" || _mut_rc=$?; printf '%s\n' "${_mut_rc}" >"${_mut_log}.rc"; } 2>&1 |
+        tee "${_mut_log}"
+    _mut_rc="$(cat "${_mut_log}.rc" 2>/dev/null || true)"
+    case "${_mut_rc}" in
+        '' | *[!0-9]*)
+            die "${_mut_code}" "could not read the exit status of pkg — ${_mut_msg}"
+            ;;
+    esac
     if [ "${_mut_rc}" -ne 0 ]; then
         die "${_mut_code}" "${_mut_msg}"
     fi
@@ -196,7 +212,7 @@ _pkg_mutate() {
         esac
     done < "${_mut_log}"
     trap - EXIT
-    rm -f "${_mut_log}"
+    rm -f "${_mut_log}" "${_mut_log}.rc"
     unset _mut_code _mut_msg _mut_log _mut_rc _mut_line
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,6 +160,34 @@ _pkg() {
     fi
 }
 
+# Hard cap on the reader's polling below: 6 hours at one tick a second. An install that
+# has not finished by then is not one this script can still narrate.
+_PFB_DRAIN_MAX_TICKS=21600
+
+# _pkg_mutate_cleanup — reap the background reader and drop both capture files. Runs from
+# the EXIT trap and from every signal trap _pkg_mutate installs; safe to run twice, and
+# safe before either name is set.
+_pkg_mutate_cleanup() {
+    if [ -n "${_mut_reader:-}" ]; then
+        kill "${_mut_reader}" 2>/dev/null || true
+        wait "${_mut_reader}" 2>/dev/null || true
+    fi
+    rm -f "${_mut_log:-}" "${_mut_done:-}"
+}
+
+# _pfb_parent_gone PID — TRUE once PID can no longer be the running parent of this
+# reader: either it is gone, or it is a zombie. The zombie half matters because a killed
+# parent stays in the table until whatever started it reaps it, and `kill -0` succeeds
+# against a zombie the whole time — so `kill -0` alone would keep a reader polling long
+# after the run it belongs to died.
+_pfb_parent_gone() {
+    kill -0 "$1" 2>/dev/null || return 0
+    case "$(ps -o state= -p "$1" 2>/dev/null | tr -d ' ')" in
+        Z*) return 0 ;;
+    esac
+    return 1
+}
+
 # _pkg_mutate_drain FILE — print what FILE has grown by since this shell last drained
 # it, carrying the position in _drain_seen. Addressed by LINE, so a half-written line is
 # never split across two prints; a final line with no newline is left for the
@@ -181,11 +209,12 @@ _pkg_mutate_drain() {
 # pkg writes to a capture FILE and a reader prints what that file grows by, rather than
 # pkg writing down a pipe. A pipe outlives pkg: every process a package script leaves
 # running inherits the write end, and a reader sees no EOF until the last holder closes
-# it — the hazard pfblockerng.inc states as "LOG FILE, never a pipe" for its own
-# capture (issue #662). Our POST-INSTALL starts unbound, so that risk is not theoretical,
-# and a hang after a completed install is worse than the burst it would replace. A
-# regular file cannot stall the run, and the foreground pkg hands back its own status
-# with no side channel to read it out of (issue #2644).
+# it — the hazard pfblockerng.inc states as "LOG FILE, never a pipe" for its own capture
+# (issue #662), and solves the same way its own hook mirror does (issue #693). Our
+# POST-INSTALL starts unbound, so that risk is not theoretical, and a hang after a
+# completed install is worse than the burst it would replace. A regular file cannot stall
+# the run, and the foreground pkg hands back its own status with no side channel to read
+# it out of (issue #2644).
 #
 # What a reader can show is bounded by what pkg flushes and when; the package scripts
 # (PHP CLI writes unbuffered) appear as they print.
@@ -204,17 +233,38 @@ _pkg_mutate() {
     # first one and pre-create as a symlink, and this runs as root.
     _mut_log=$(mktemp "${_mut_dir}/pfb-install-pkg.XXXXXX") ||
         die "${_mut_code}" "mktemp failed while capturing pkg output"
+    # Armed before the SECOND mktemp, so its failure cannot leak the first file. Every
+    # path is read as `:-` because `set -u` makes an unset name in a trap fatal AND
+    # replaces the exit status the trap fired on; `rm -f ""` is a no-op. die() exits the
+    # script, so the EXIT trap runs on that path too. /tmp on pfSense is a small RAM disk.
+    #
+    # The signal traps exist because the reader below is a background job: a bare EXIT
+    # trap never runs on an untrapped INT/TERM/HUP, which would leave the reader
+    # reparented to PID 1 polling forever and both files behind. Each re-raises the
+    # conventional 128+signal status rather than swallowing the interrupt.
+    trap '_pkg_mutate_cleanup' EXIT
+    trap '_pkg_mutate_cleanup; exit 130' INT
+    trap '_pkg_mutate_cleanup; exit 143' TERM
+    trap '_pkg_mutate_cleanup; exit 129' HUP
     _mut_done=$(mktemp "${_mut_dir}/pfb-install-pkg.XXXXXX") ||
         die "${_mut_code}" "mktemp failed while capturing pkg output"
-    # die() exits the script; EXIT trap removes the files on that path too.
-    # /tmp on pfSense is a small RAM disk.
-    trap 'rm -f "${_mut_log}" "${_mut_done}"' EXIT
     # The reader runs in the background and stops when pkg is done: mktemp already
     # created the done-file, so the flag is CONTENT, not existence.
+    #
+    # It also dies with its task rather than only on being told to. `$$` stays the
+    # parent's pid inside a subshell, so the liveness test ends the loop even when the
+    # parent is killed outright and no trap can fire; the counter is the backstop for the
+    # case where the pid outlives the run some other way, i.e. a hard cap and a deadline
+    # on a wait nothing else is tracking (AGENTS.md "No orphaned waits").
+    _mut_parent=$$
     (
         _drain_seen=0
-        while [ ! -s "${_mut_done}" ]; do
+        _drain_ticks=0
+        while [ ! -s "${_mut_done}" ] &&
+            ! _pfb_parent_gone "${_mut_parent}" &&
+            [ "${_drain_ticks}" -lt "${_PFB_DRAIN_MAX_TICKS}" ]; do
             _pkg_mutate_drain "${_mut_log}"
+            _drain_ticks=$((_drain_ticks + 1))
             sleep 1
         done
         sed -n "$((_drain_seen + 1)),\$p" "${_mut_log}"
@@ -236,9 +286,9 @@ _pkg_mutate() {
                 ;;
         esac
     done < "${_mut_log}"
-    trap - EXIT
+    trap - EXIT INT TERM HUP
     rm -f "${_mut_log}" "${_mut_done}"
-    unset _mut_code _mut_msg _mut_dir _mut_log _mut_done _mut_reader _mut_rc _mut_line
+    unset _mut_code _mut_msg _mut_dir _mut_log _mut_done _mut_parent _mut_reader _mut_rc _mut_line
 }
 
 usage() {

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -19,7 +19,10 @@ import os
 import re
 import subprocess
 import tempfile
+import threading
+import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -133,6 +136,16 @@ delete)
     exit 0
     ;;
 install)
+    if [ -n "${PFB_STUB_STREAM_BLOCK:-}" ]; then
+        # An external echo(1): a builtin's stdio buffer is not guaranteed to reach
+        # the caller before this stub's own exit, which is exactly what is under test.
+        /bin/echo "${PFB_STUB_STREAM_MARKER:-pkg-stream-marker}"
+        _wait_i=0
+        while [ ! -f "${PFB_STUB_STREAM_BLOCK}" ] && [ "${_wait_i}" -lt 300 ]; do
+            sleep 0.1
+            _wait_i=$((_wait_i + 1))
+        done
+    fi
     _repo=""
     _spec=""
     _prev=""
@@ -318,7 +331,7 @@ def _seed_info_manifest(root: str, paths: tuple[str, ...]) -> str:
     return manifest
 
 
-def _run_install(
+def _prepare_install(
     root: str,
     channel: str,
     *,
@@ -330,9 +343,9 @@ def _run_install(
     update_fails: bool = False,
     version_t_broken: bool = False,
     extra_env: dict[str, str] | None = None,
-) -> subprocess.CompletedProcess[str]:
-    """Run install.sh --channel <channel> with PFBLOCKERNG_ROOT=root and the fake pkg
-    stub.
+) -> tuple[list[str], dict[str, str]]:
+    """Build the argv + environment that runs install.sh --channel <channel> with
+    PFBLOCKERNG_ROOT=root and the fake pkg stub.
 
     Re-seeds the box fixture, catalogue, and info manifest on every call (idempotent
     to call twice), but never touches pkgstate/ or repo confs — those persist across
@@ -373,6 +386,12 @@ def _run_install(
 
     channel_args = [f"--channel={channel}"] if channel_style == "equals" else ["--channel", channel]
     argv = ["sh", str(_SCRIPT), *channel_args, *args]
+    return argv, env
+
+
+def _run_install(*a: Any, **kw: Any) -> subprocess.CompletedProcess[str]:
+    """Run install.sh to completion with the fixture _prepare_install builds."""
+    argv, env = _prepare_install(*a, **kw)
     return subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
 
 
@@ -1752,3 +1771,67 @@ def test_non_executable_restart_knob_is_a_silent_skip(tmp_path: Path) -> None:
     assert "restarting the webConfigurator" not in proc.stdout, (
         "a non-executable restart knob must be a SILENT skip, not an announced failed exec"
     )
+
+
+# --------------------------------------------------------------------------- #
+# 21. pkg output reaches the terminal while pkg is still running (issue #2644)
+# --------------------------------------------------------------------------- #
+
+
+_STREAM_MARKER = "pfb-stream-marker-2644"
+
+
+def test_pkg_output_is_streamed_while_pkg_still_runs() -> None:
+    """The capture that lets install.sh rescan for ``pkg: <script> script failed``
+    (issue #2575) must not withhold pkg's output until pkg exits: on a real box the
+    converge step is the last slow step, so a replay-at-the-end lands the whole
+    install log — pkg's lines and every package script's lines — in one burst right
+    before ``==> Done`` (issue #2644).
+
+    The fake pkg prints a marker and then blocks on a sentinel file; the marker has
+    to be readable on install.sh's stdout while pkg is still blocked.
+    """
+    with tempfile.TemporaryDirectory() as root:
+        sentinel = Path(root) / "unblock-pkg"
+        argv, env = _prepare_install(
+            root,
+            "stable",
+            extra_env={
+                "PFB_STUB_STREAM_BLOCK": str(sentinel),
+                "PFB_STUB_STREAM_MARKER": _STREAM_MARKER,
+            },
+        )
+
+        proc = subprocess.Popen(
+            argv,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        seen: list[str] = []
+        stream = proc.stdout
+        assert stream is not None
+        reader = threading.Thread(target=lambda: seen.extend(stream), daemon=True)
+        reader.start()
+        try:
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline and not any(_STREAM_MARKER in ln for ln in seen):
+                time.sleep(0.05)
+            streamed = any(_STREAM_MARKER in ln for ln in seen)
+            blocked_still = proc.poll() is None
+        finally:
+            sentinel.write_text("")
+            try:
+                proc.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=30)
+            reader.join(timeout=10)
+
+        output = "".join(seen)
+        assert proc.returncode == 0, output
+        assert blocked_still, "fixture broken: pkg had already exited, so nothing about streaming was proven"
+        assert streamed, f"pkg output was withheld until pkg exited; got:\n{output}"
+        assert "Done" in output

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -15,8 +15,10 @@ logged line starting with ``install`` or ``delete``.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import re
+import signal
 import subprocess
 import tempfile
 import threading
@@ -1907,3 +1909,79 @@ def test_nonzero_pkg_delete_exit_is_fatal() -> None:
         assert proc.returncode == 5, proc.stdout + proc.stderr
         assert "Done" not in proc.stdout
         assert "pkg delete" in proc.stderr, proc.stderr
+
+
+# --------------------------------------------------------------------------- #
+# 23. the output reader dies with the run (issue #2647 review)
+# --------------------------------------------------------------------------- #
+
+
+def _install_sh_pids(pgid: int) -> list[str]:
+    """PIDs in process group ``pgid`` still running install.sh."""
+    found = subprocess.run(
+        ["pgrep", "-g", str(pgid), "-f", "install.sh"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return [line for line in found.stdout.split() if line]
+
+
+def test_output_reader_does_not_outlive_the_run() -> None:
+    """install.sh streams pkg's output from a background reader. A background reader is
+    an untracked wait, so it has to die with its task -- not reparent to PID 1 and poll
+    on. SIGKILL is the case no trap can cover, which is exactly why the reader tests its
+    parent itself (AGENTS.md "No orphaned waits")."""
+    with tempfile.TemporaryDirectory() as root:
+        sentinel = Path(root) / "unblock-pkg"
+        argv, env = _prepare_install(
+            root,
+            "stable",
+            extra_env={"PFB_STUB_STREAM_BLOCK": str(sentinel)},
+        )
+        # Own session, so the group holds this run and nothing else.
+        proc = subprocess.Popen(
+            argv,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            start_new_session=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        try:
+            seen: list[str] = []
+            stream = proc.stdout
+            assert stream is not None
+            reader = threading.Thread(target=lambda: seen.extend(stream), daemon=True)
+            reader.start()
+
+            deadline = time.monotonic() + 15.0
+            while time.monotonic() < deadline and not any(_STREAM_MARKER in ln for ln in seen):
+                time.sleep(0.05)
+            assert any(_STREAM_MARKER in ln for ln in seen), (
+                f"fixture broken: the run never reached the streaming pkg call; got {seen!r}"
+            )
+            # The run is mid-install: install.sh itself plus its reader are both live.
+            assert len(_install_sh_pids(pgid)) >= 2, (
+                "fixture broken: no background reader was running, so killing the parent proves nothing about orphans"
+            )
+
+            os.kill(proc.pid, signal.SIGKILL)
+
+            deadline = time.monotonic() + 20.0
+            while time.monotonic() < deadline and _install_sh_pids(pgid):
+                time.sleep(0.25)
+            survivors = _install_sh_pids(pgid)
+            assert not survivors, (
+                f"the output reader outlived install.sh (pids {survivors}); it must stop when its parent is gone"
+            )
+        finally:
+            sentinel.write_text("")
+            for pid in _install_sh_pids(pgid):
+                with contextlib.suppress(ProcessLookupError, ValueError):
+                    os.kill(int(pid), signal.SIGKILL)
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(proc.pid, signal.SIGKILL)
+            proc.wait(timeout=30)

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -22,7 +22,6 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -119,6 +118,10 @@ query)
     exit 0
     ;;
 delete)
+    if [ -n "${PFB_STUB_MUTATE_RC:-}" ]; then
+        printf 'pkg: some transport failure\n' >&2
+        exit "${PFB_STUB_MUTATE_RC}"
+    fi
     _name="$3"
     rm -rf "${STATE:?}/${_name}"
     if [ -n "${PFB_STUB_DEINSTALL_FAIL:-}" ]; then
@@ -136,10 +139,14 @@ delete)
     exit 0
     ;;
 install)
+    if [ -n "${PFB_STUB_MUTATE_RC:-}" ]; then
+        printf 'pkg: some transport failure\n' >&2
+        exit "${PFB_STUB_MUTATE_RC}"
+    fi
     if [ -n "${PFB_STUB_STREAM_BLOCK:-}" ]; then
         # An external echo(1): a builtin's stdio buffer is not guaranteed to reach
         # the caller before this stub's own exit, which is exactly what is under test.
-        /bin/echo "${PFB_STUB_STREAM_MARKER:-pkg-stream-marker}"
+        /bin/echo "pfb-stream-marker-2644"
         _wait_i=0
         while [ ! -f "${PFB_STUB_STREAM_BLOCK}" ] && [ "${_wait_i}" -lt 300 ]; do
             sleep 0.1
@@ -389,9 +396,37 @@ def _prepare_install(
     return argv, env
 
 
-def _run_install(*a: Any, **kw: Any) -> subprocess.CompletedProcess[str]:
-    """Run install.sh to completion with the fixture _prepare_install builds."""
-    argv, env = _prepare_install(*a, **kw)
+def _run_install(
+    root: str,
+    channel: str,
+    *,
+    args: tuple[str, ...] = (),
+    channel_style: str = "space",
+    catalog: tuple[str, ...] = ("4.0.0",),
+    info_paths: tuple[str, ...] = (_DEFAULT_PAYLOAD_PATH,),
+    create_info_paths: bool = True,
+    update_fails: bool = False,
+    version_t_broken: bool = False,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run install.sh to completion with the fixture _prepare_install builds.
+
+    The parameters are spelled out rather than forwarded as ``*args, **kwargs``: every
+    call in this module goes through here, and ``Any`` would opt all of them out of the
+    ``mypy tests/`` gate.
+    """
+    argv, env = _prepare_install(
+        root,
+        channel,
+        args=args,
+        channel_style=channel_style,
+        catalog=catalog,
+        info_paths=info_paths,
+        create_info_paths=create_info_paths,
+        update_fails=update_fails,
+        version_t_broken=version_t_broken,
+        extra_env=extra_env,
+    )
     return subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
 
 
@@ -1796,10 +1831,7 @@ def test_pkg_output_is_streamed_while_pkg_still_runs() -> None:
         argv, env = _prepare_install(
             root,
             "stable",
-            extra_env={
-                "PFB_STUB_STREAM_BLOCK": str(sentinel),
-                "PFB_STUB_STREAM_MARKER": _STREAM_MARKER,
-            },
+            extra_env={"PFB_STUB_STREAM_BLOCK": str(sentinel)},
         )
 
         proc = subprocess.Popen(
@@ -1820,7 +1852,7 @@ def test_pkg_output_is_streamed_while_pkg_still_runs() -> None:
             while time.monotonic() < deadline and not any(_STREAM_MARKER in ln for ln in seen):
                 time.sleep(0.05)
             streamed = any(_STREAM_MARKER in ln for ln in seen)
-            blocked_still = proc.poll() is None
+            still_running = proc.poll() is None
         finally:
             sentinel.write_text("")
             try:
@@ -1832,6 +1864,46 @@ def test_pkg_output_is_streamed_while_pkg_still_runs() -> None:
 
         output = "".join(seen)
         assert proc.returncode == 0, output
-        assert blocked_still, "fixture broken: pkg had already exited, so nothing about streaming was proven"
+        assert still_running, (
+            "fixture broken: install.sh had already finished, so a replay-at-the-end would "
+            "have satisfied the marker check too"
+        )
         assert streamed, f"pkg output was withheld until pkg exited; got:\n{output}"
         assert "Done" in output
+
+
+# --------------------------------------------------------------------------- #
+# 22. pkg's own non-zero exit is still fatal (issue #2647 review)
+# --------------------------------------------------------------------------- #
+
+
+def test_nonzero_pkg_install_exit_is_fatal() -> None:
+    """A mutating pkg call that exits non-zero must stop the run with the caller's
+    message and no ``==> Done``.
+
+    Distinct from the #2575 cases, which are pkg exiting ZERO after a package script
+    failed. Nothing else in this suite makes ``pkg install`` itself fail, so without
+    this the status hand-off out of the streaming reader could report success for a
+    failed install and every test would stay green."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(root, "stable", extra_env={"PFB_STUB_MUTATE_RC": "7"})
+
+        assert proc.returncode == 5, proc.stdout + proc.stderr
+        assert "Done" not in proc.stdout
+        assert "pkg install -r pfblockerng-stable" in proc.stderr, proc.stderr
+        # The failing call's own output still reaches the operator.
+        assert "pkg: some transport failure" in proc.stdout + proc.stderr
+
+
+def test_nonzero_pkg_delete_exit_is_fatal() -> None:
+    """Same contract on the delete verb, which runs from step 9a when a legacy
+    identity has to go before the canonical package can be installed."""
+    with tempfile.TemporaryDirectory() as root:
+        _seed_installed(root, f"{_CANONICAL}-devel", "3.2.14_2", "pfblockerng")
+        _seed_conf_file(root, _LEGACY_CONF, "# legacy release conf\n")
+
+        proc = _run_install(root, "stable", extra_env={"PFB_STUB_MUTATE_RC": "7"})
+
+        assert proc.returncode == 5, proc.stdout + proc.stderr
+        assert "Done" not in proc.stdout
+        assert "pkg delete" in proc.stderr, proc.stderr


### PR DESCRIPTION
## What

`_pkg_mutate()` in `scripts/install.sh` (published as `pkg-site/install.sh`) now prints
pkg's output while pkg is still running, instead of replaying the capture after pkg
exits.

## Why

The capture exists so the run can be rescanned for `pkg: <script> script failed` —
pkg(8) can exit 0 after a POST-INSTALL/DEINSTALL script failed (issue #2575). But the
converge step is the last slow step in the script, so replaying after pkg exited put the
entire install log — pkg's own lines and every package script's lines — into one burst
immediately before `==> Done`, with nothing on the terminal for the whole install.
Reported against a live nightly channel run (issue #2644).

`pkg update -f -r <repo>` was never wrapped and already streamed, which is why only the
install/delete output looked withheld.

## How

pkg still writes to the mktemp'd capture file, in the foreground. A background reader
prints what that file has grown by, once a second, and a final read takes whatever is
left after pkg exits.

**Not a pipe, deliberately.** The first cut of this PR piped pkg through `tee`. Review
killed that: a pipe on pkg's stdout outlives pkg, because every process a package script
leaves running inherits the write end and the reader sees no EOF until the last holder
closes it. `pfblockerng.inc` already states this rule for its own capture — "LOG FILE,
never a pipe" (issue #662) — and our POST-INSTALL starts unbound, so it is not a
theoretical risk. A probe showed the shape plainly: a file capture returns in
milliseconds where the equivalent pipeline blocks for a backgrounded daemon's entire
life. A hang after a completed install is worse than the burst this PR set out to fix.

Consequences of reading from a file instead:

- pkg's exit status needs no side channel — the foreground call yields it directly.
- Both temp files come from `mktemp`. The `tee` version carried a status file at the
  *derived* path `"${capture}.rc"`, which review exploited: the capture is listable, so
  the second name is derived rather than guessed, and this script runs as root in /tmp.
- The reader addresses the file by line, so a half-written line is never split across
  two prints. The final read goes to end-of-file, so a last line with no newline — the
  glued `thrown</pre>pkg: POST-INSTALL script failed` case #2575 depends on — still
  arrives.

Ceiling, stated plainly: what a reader can show is bounded by what pkg flushes and when,
and the poll interval is one second. The package scripts (PHP CLI writes unbuffered)
appear as they print. This is not a pty and does not claim to be one.

## Test

Test file frozen at blob `e7e0adce235a80bd225242b4035992f2d1381180` across every run below.

**Streaming** — `test_pkg_output_is_streamed_while_pkg_still_runs`. The fake pkg prints a
marker and blocks on a sentinel file (capped at 30s inside the stub); the test reads
install.sh's stdout through a pipe and requires the marker while pkg is still blocked. It
also asserts install.sh was still running, so a fixture that collapsed early cannot pass
it vacuously.

- RED against `origin/devel`: `1 failed`
- GREEN at head: `79 passed`

**Exit status** — `test_nonzero_pkg_install_exit_is_fatal` and
`test_nonzero_pkg_delete_exit_is_fatal`, added because review found the status hand-off
had no coverage at all: mutating it to swallow pkg's status left all 77 tests green.
Nothing else in the suite makes `pkg install` or `pkg delete` itself fail — the #2575
cases are pkg exiting *zero* after a script failed.

- RED with `|| _mut_rc=$?` mutated to `|| true`: both fail
- GREEN unmutated: `79 passed`

`scripts/agent/run-gates.sh`: `GATES: PASS` (pytest, ruff check, ruff format, mypy,
`sh -n`, shellcheck, shellspec).

Note: this file's suite runs slower now (~23s to ~90s). Each mutating call costs about
one poll interval, and most tests make one.

Part of #2644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package installation and removal output is now displayed as it is produced, improving visibility during long-running operations.
  * Installation processes detect termination and extended inactivity and shut down cleanly.

* **Bug Fixes**
  * Failed installation or removal commands now correctly report failure without displaying a misleading completion message.
  * Temporary resources and background processes are cleaned up after completion, errors, or termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->