### PR TITLE
www: reword the Package Manager origin help on the Software page

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5103,6 +5103,43 @@ function pfb_software_uninstall_href(string $pkgname, string $repo): string {
 }
 
 /*
+ * Help text under the Update / Uninstall controls, escaped for direct rendering.
+ *
+ * On a non-Netgate origin the controls are inert, and the help says why. The reason is
+ * the scope of the Package Manager UI -- get_pkg_info() only enumerates packages whose
+ * %R is 'pfSense' (issue #2380) -- NOT a repository that is broken or unreachable. The
+ * retired wording ("Package Manager cannot see this origin") said the second thing, one
+ * sentence away from a note about a TLS error, and read as a failed install on a box
+ * where nothing had failed (issue #2648).
+ *
+ * An unidentified install (sideload: no readable %R, possibly no name) still gets a
+ * command a reader can complete by hand, so the placeholders are rendered, not omitted.
+ */
+function pfb_software_update_help(string $pkgname, string $repo): string {
+	if (pfb_software_pkgmgr_usable($repo)) {
+		return 'Install the latest version via the pfSense Package Manager. Available only when an update is found.';
+	}
+	return 'The pfSense Package Manager only manages packages from Netgate\'s own repository, '
+		. 'so it does not check for pfBlockerNG updates.'
+		. ' To update, run <code>pkg install -y -r '
+		. htmlspecialchars($repo !== '' ? $repo : '<repo>')
+		. ' ' . htmlspecialchars($pkgname !== '' ? $pkgname : 'pfSense-pkg-pfBlockerNG')
+		. '</code> from the shell. That command fetches from the repository, so on pfSense Plus it '
+		. 'can fail with a TLS error until "Carry the system CA store into pkg" above is enabled.';
+}
+
+function pfb_software_uninstall_help(string $pkgname, string $repo): string {
+	if (pfb_software_pkgmgr_usable($repo)) {
+		return 'Remove pfBlockerNG from this firewall via the pfSense Package Manager (it will ask you to confirm).';
+	}
+	return 'The pfSense Package Manager only manages packages from Netgate\'s own repository, '
+		. 'so it cannot remove this install.'
+		. ' To uninstall, run <code>pkg delete '
+		. htmlspecialchars($pkgname !== '' ? $pkgname : 'pfSense-pkg-pfBlockerNG')
+		. '</code> from the shell.';
+}
+
+/*
  * TRUE when $latest is strictly newer than $installed, via pfSense pkg_version_compare()
  * (never a string compare — it returns '<' | '=' | '>'). Empty/invalid inputs -> FALSE
  * (no update): a missing installed or latest version is never "an update is available".

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -266,11 +266,8 @@ $section->addInput(new Form_StaticText(null, $btn_check))
 // Update / Uninstall. Package Manager only sees %R=pfSense (issue #2380). A pfblockerng-*
 // origin is disabled here with the repo-qualified pkg CLI; never emit pkg_mgr_install.php
 // for that origin (those pages hide the package and a reinstall can resolve against -r pfSense).
-$pfb_sw_pkgmgr		= pfb_software_pkgmgr_usable($pfb_sw_repo);
 $pfb_sw_update_href	= pfb_software_update_href($pfb_sw_pkgname, $pfb_sw_repo, $update_available);
 $pfb_sw_uninstall_href	= pfb_software_uninstall_href($pfb_sw_pkgname, $pfb_sw_repo);
-$pfb_sw_cli_pkg		= ($pfb_sw_pkgname !== '') ? $pfb_sw_pkgname : 'pfSense-pkg-pfBlockerNG';
-$pfb_sw_cli_repo	= ($pfb_sw_repo !== '') ? $pfb_sw_repo : '<repo>';
 
 $btn_update = new Form_Button(
 	'pfb_sw_update',
@@ -282,16 +279,8 @@ $btn_update->removeClass('btn-primary')->addClass('btn-warning btn-xs')->setWidt
 if ($pfb_sw_update_href === '#') {
 	$btn_update->addClass('disabled')->setAttribute('disabled', 'disabled')->setAttribute('aria-disabled', 'true');
 }
-if ($pfb_sw_pkgmgr) {
-	$pfb_sw_update_help = 'Install the latest version via the pfSense Package Manager. Available only when an update is found.';
-} else {
-	$pfb_sw_update_help = 'Package Manager cannot see this origin. To update, run <code>pkg install -y -r '
-		. htmlspecialchars($pfb_sw_cli_repo) . ' ' . htmlspecialchars($pfb_sw_cli_pkg)
-		. '</code> from the shell. On pfSense Plus, that can fail with a TLS error until '
-		. '"Carry the system CA store into pkg" above is enabled.';
-}
 $section->addInput(new Form_StaticText(null, $btn_update))
-	->setHelp($pfb_sw_update_help);
+	->setHelp(pfb_software_update_help($pfb_sw_pkgname, $pfb_sw_repo));
 
 // Uninstall. #697: a `pkg delete` is a removal (pre-deinstall tears down). Package Manager
 // delete is only offered for a Netgate-origin install.
@@ -305,14 +294,8 @@ $btn_uninstall->removeClass('btn-primary')->addClass('btn-danger btn-xs')->setWi
 if ($pfb_sw_uninstall_href === '#') {
 	$btn_uninstall->addClass('disabled')->setAttribute('disabled', 'disabled')->setAttribute('aria-disabled', 'true');
 }
-if ($pfb_sw_pkgmgr) {
-	$pfb_sw_uninstall_help = 'Remove pfBlockerNG from this firewall via the pfSense Package Manager (it will ask you to confirm).';
-} else {
-	$pfb_sw_uninstall_help = 'Package Manager cannot see this origin. To uninstall, run <code>pkg delete '
-		. htmlspecialchars($pfb_sw_cli_pkg) . '</code> from the shell.';
-}
 $section->addInput(new Form_StaticText(null, $btn_uninstall))
-	->setHelp($pfb_sw_uninstall_help);
+	->setHelp(pfb_software_uninstall_help($pfb_sw_pkgname, $pfb_sw_repo));
 $form->add($section);
 
 print($form);

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -27,6 +27,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_software_pkgmgr_usable')]
 #[CoversFunction('pfb_software_update_href')]
 #[CoversFunction('pfb_software_uninstall_href')]
+#[CoversFunction('pfb_software_update_help')]
+#[CoversFunction('pfb_software_uninstall_help')]
 #[CoversFunction('pfb_update_available')]
 #[CoversFunction('pfb_software_check_enabled')]
 #[CoversFunction('pfb_should_notify')]
@@ -246,6 +248,93 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	public function testSoftwareUninstallHref(string $pkgname, string $repo, string $expected): void
 	{
 		$this->assertSame($expected, pfb_software_uninstall_href($pkgname, $repo));
+	}
+
+	/*
+	 * ---- pfb_software_update_help() / pfb_software_uninstall_help() (issue #2648) ----
+	 * The help under each control explains WHY the Package Manager is not offered. The
+	 * reason is the Package Manager UI's own scope -- it only manages packages whose %R
+	 * is Netgate's 'pfSense' (issue #2380) -- and NOT a broken repository or an
+	 * unreachable origin. The retired wording ("Package Manager cannot see this origin")
+	 * read as the latter, next to a sentence about a TLS error, and is pinned as gone.
+	 */
+	public function testUpdateHelpOnNetgateOriginPointsAtThePackageManager(): void
+	{
+		$help = pfb_software_update_help('pfSense-pkg-pfBlockerNG', 'pfSense');
+
+		$this->assertStringContainsString('pfSense Package Manager', $help);
+		$this->assertStringNotContainsString('pkg install', $help, 'a Netgate-origin box is never sent to the CLI');
+	}
+
+	public function testUpdateHelpOnChannelOriginGivesTheRepoQualifiedCommand(): void
+	{
+		$help = pfb_software_update_help('pfSense-pkg-pfBlockerNG', 'pfblockerng-nightly');
+
+		$this->assertStringContainsString(
+			'pkg install -y -r pfblockerng-nightly pfSense-pkg-pfBlockerNG',
+			$help,
+			'the CLI fallback must stay repository-qualified'
+		);
+		$this->assertStringContainsString(
+			"only manages packages from Netgate's own repository, so it does not check for pfBlockerNG updates",
+			$help,
+			'the help must name the Package Manager UI scope as the reason, in terms of the control it sits under'
+		);
+		$this->assertStringNotContainsString(
+			'cannot see this origin',
+			$help,
+			'retired wording: it reads as a broken or unreachable repository (issue #2648)'
+		);
+		$this->assertStringContainsString('Carry the system CA store into pkg', $help);
+	}
+
+	public function testUninstallHelpOnChannelOriginGivesThePkgDeleteCommand(): void
+	{
+		$help = pfb_software_uninstall_help('pfSense-pkg-pfBlockerNG', 'pfblockerng-stable');
+
+		$this->assertStringContainsString('pkg delete pfSense-pkg-pfBlockerNG', $help);
+		$this->assertStringContainsString(
+			"only manages packages from Netgate's own repository, so it cannot remove this install",
+			$help,
+			'the uninstall help states the consequence for uninstalling, not for update checks'
+		);
+		$this->assertStringNotContainsString(
+			'check for pfBlockerNG updates',
+			$help,
+			'update-check wording belongs under the Update control only'
+		);
+		$this->assertStringNotContainsString('cannot see this origin', $help);
+		$this->assertStringNotContainsString(
+			'Carry the system CA store into pkg',
+			$help,
+			'the CA consent caveat belongs to the fetch that update performs, not to a local delete'
+		);
+	}
+
+	public function testUninstallHelpOnNetgateOriginPointsAtThePackageManager(): void
+	{
+		$help = pfb_software_uninstall_help('pfSense-pkg-pfBlockerNG', 'pfSense');
+
+		$this->assertStringContainsString('pfSense Package Manager', $help);
+		$this->assertStringNotContainsString('pkg delete', $help);
+	}
+
+	public function testHelpFallsBackToPlaceholdersWhenTheInstallIsUnidentified(): void
+	{
+		// A sideload leaves %R empty and can leave the name unreadable; the command still
+		// has to render as something a reader can complete by hand.
+		$help = pfb_software_update_help('', '');
+
+		$this->assertStringContainsString('pkg install -y -r &lt;repo&gt; pfSense-pkg-pfBlockerNG', $help);
+	}
+
+	public function testHelpEscapesTheRepositoryAndPackageNames(): void
+	{
+		$help = pfb_software_update_help('pfSense-pkg-pfBlockerNG"<script>', 'pfblockerng-<b>');
+
+		$this->assertStringNotContainsString('<script>', $help);
+		$this->assertStringNotContainsString('pfblockerng-<b>', $help);
+		$this->assertStringContainsString('pfblockerng-&lt;b&gt;', $help);
 	}
 
 	public function testSoftwarePageDoesNotHardcodePkgMgrForAllOrigins(): void

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10756,6 +10756,26 @@
         "returnType": "array",
         "params": []
     },
+    "pfb_software_uninstall_help": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_software_uninstall_href": {
         "returnsRef": false,
         "returnType": "string",
@@ -10793,6 +10813,26 @@
                 "variadic": false,
                 "type": "?array",
                 "default": "NULL"
+            }
+        ]
+    },
+    "pfb_software_update_help": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "pkgname",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "repo",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
             }
         ]
     },

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2881,7 +2881,15 @@ def test_software_actions_link_to_package_manager(
             assert re.search(r'href=["\']#["\']', un_tag.group(0)), (
                 f"channel/sideload Uninstall href must be inert ('#'): {un_tag.group(0)!r}"
             )
-            assert "pkg_mgr_install.php" not in body or "Package Manager cannot see this origin" in body
+            # Why the controls are inert: the Package Manager UI only enumerates %R=pfSense
+            # packages (#2380). Asserted without the apostrophe so the check does not depend
+            # on how the form layer renders it (#2648).
+            assert "only manages packages from Netgate" in body, (
+                "channel/sideload Software page must say why the Package Manager controls are inert (issue #2648)"
+            )
+            assert "Package Manager cannot see this origin" not in body, (
+                "retired wording: it read as a broken or unreachable repository (issue #2648)"
+            )
         assert "?do=uninstall" not in un_tag.group(0), (
             "Uninstall must NOT route through the removed ?do=uninstall handler (#697)"
         )


### PR DESCRIPTION
## What

Rewords the help text under the Update and Uninstall controls on the Software page for
a non-Netgate origin, and moves both strings into `pfb_software_update_help()` /
`pfb_software_uninstall_help()` in `pfblockerng.inc`.

Before:

> Package Manager cannot see this origin. To update, run `pkg install -y -r pfblockerng-nightly pfSense-pkg-pfBlockerNG` from the shell. On pfSense Plus, that can fail with a TLS error until "Carry the system CA store into pkg" above is enabled.

After:

> The pfSense Package Manager only manages packages from Netgate's own repository, so it does not check for pfBlockerNG updates. To update, run `pkg install -y -r pfblockerng-nightly pfSense-pkg-pfBlockerNG` from the shell. That command fetches from the repository, so on pfSense Plus it can fail with a TLS error until "Carry the system CA store into pkg" above is enabled.

and the Uninstall string states its own consequence rather than sharing the update one:

> The pfSense Package Manager only manages packages from Netgate's own repository, so it cannot remove this install. To uninstall, run `pkg delete pfSense-pkg-pfBlockerNG` from the shell.

## Why

"Package Manager cannot see this origin" describes a broken or unreachable repository,
and the very next sentence mentions a TLS error — so the pair reads as a failed install
on a box where nothing failed. The actual reason the controls are inert is narrower and
permanent: `get_pkg_info()` only enumerates packages whose `%R` is `pfSense`, so
routing a channel install through `pkg_mgr_install.php` would hide the package or
resolve a reinstall against `-r pfSense` (issue #2380). That is every install that came
from `install.sh`, on any channel.

The uninstall string carried the pfSense Plus CA caveat too. `pkg delete` fetches
nothing, so that sentence could never apply there; it now appears only on the update
command, explicitly attached to the fetch that command performs.

No behaviour change: the same controls stay disabled under the same condition
(`pfb_software_pkgmgr_usable()`), and the hrefs are untouched.

## Structure

Both strings now live beside the `pfb_software_*_href()` deciders they pair with. That
puts every branch — Netgate origin, channel origin, unidentified sideload, and HTML
escaping of the repository and package names — under hermetic PHPUnit coverage that
runs in PR CI, where previously the text was reachable only from the live UI tier. The
page no longer branches on origin itself; it calls the two helpers.

## Test

Red/green with the test file frozen at blob
`c028e4832a2fb628e287e68cda39a1d14659b8d4` across both runs
(`vendor/bin/phpunit --filter Help tests/php/SoftwareUpdateDecisionTest.php`):

- RED: `Tests: 6, Assertions: 12, Failures: 2` — neither string carried its per-control consequence clause
- GREEN: `OK (6 tests, 17 assertions)`

(The first cut of this branch went through the same cycle against the helpers not
existing at all: `Errors: 6`, `Call to undefined function pfb_software_update_help()`.)

Six cases: Package-Manager branch for both controls (and that neither sends a
Netgate-origin box to the CLI), channel branch for both (repo-qualified command
present, retired wording absent, per-control consequence clause present, update-check
wording pinned out of the uninstall string, CA caveat present on update and absent on
uninstall),
the unidentified-sideload placeholder rendering, and escaping of a hostile repository
and package name.

Tier A (`tests/smoke/ui/test_render_smoke.py`) keeps the live coverage and is tightened:
it now requires the new sentence in the channel/sideload body instead of tolerating its
absence, and pins the retired wording as gone. The assertion deliberately matches on a
substring without the apostrophe so it does not depend on how the form layer renders it.

`tests/php/fixtures/function_inventory.json` is regenerated for the two new functions
(`PFB_UPDATE_FUNCTION_INVENTORY=1`).

`scripts/agent/run-gates.sh`: `GATES: PASS`.

Part of #2648
