### PR TITLE
ut1: fetch the shipped feed over HTTPS

### DIFF
--- a/src/usr/local/pkg/pfblockerng/ut1_global_usage
+++ b/src/usr/local/pkg/pfblockerng/ut1_global_usage
@@ -39,7 +39,7 @@
 XML:	ut1
 TITLE:	UT1
 DESCR:	Universit&#xE9; Toulouse 1 Capitole - UT1
-FEED:	ftp://ftp.ut-capitole.fr/pub/reseau/cache/squidguard_contrib/blacklists.tar.gz
+FEED:	https://dsi.ut-capitole.fr/blacklists/download/blacklists.tar.gz
 SIZE:	8.5
 WEBSITE:https://dsi.ut-capitole.fr/blacklists/index_en.php
 LICENSE:https://creativecommons.org/licenses/by-sa/4.0/

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -232,8 +232,10 @@ if (isset($argv[1]) && ($argv[1] == 'bl' || $argv[1] == 'bls')) {
 					$pfb['extras'][$next_key]['password'] = $item['password'];
 				}
 
-				// Patch UT1 filename
-				if ($item['feed'] == 'ftp://ftp.ut-capitole.fr/pub/reseau/cache/squidguard_contrib/blacklists.tar.gz') {
+				// Patch UT1 filename. Keyed on the provider id, never its feed URL: the
+				// download name decides the category filenames, so a URL change would
+				// otherwise rename the whole category set (issue #2636).
+				if ($item['xml'] == 'ut1') {
 					$pfb['extras'][$next_key]['file_dwn'] = $pfb['extras'][$next_key]['file'] = 'ut1.tar.gz';
 				}
 				$next_key++;

--- a/tests/php/BlacklistLangFallbackTest.php
+++ b/tests/php/BlacklistLangFallbackTest.php
@@ -105,9 +105,10 @@ final class BlacklistLangFallbackTest extends TestCase
 		$this->assertNotFalse($raw, 'test bootstrap: failed to read ut1_global_usage');
 		$this->assertSame(
 			1,
-			preg_match('/^FEED:\s*(\S+)$/m', $raw, $matches),
+			preg_match_all('/^FEED:\s*(\S+)$/m', $raw, $matches),
 			'ut1_global_usage must declare exactly one FEED line'
 		);
+		$matches = array(1 => $matches[1][0]);
 		$this->assertStringStartsWith(
 			'https://',
 			$matches[1],

--- a/tests/php/BlacklistLangFallbackTest.php
+++ b/tests/php/BlacklistLangFallbackTest.php
@@ -91,6 +91,31 @@ final class BlacklistLangFallbackTest extends TestCase
 		}
 	}
 
+	/**
+	 * issue #2636: the shipped UT1 provider fetches over an authenticated transport.
+	 *
+	 * The feed URL decides how a blocklist archive reaches the firewall, and FTP
+	 * neither authenticates the server nor protects the payload. Nothing else in the
+	 * suite reads the shipped FEED line -- the live-VM case drives a mock origin -- so
+	 * a revert to ftp:// would otherwise pass every gate.
+	 */
+	public function testShippedUt1FeedUsesHttps(): void
+	{
+		$raw = file_get_contents(self::UT1_FILE);
+		$this->assertNotFalse($raw, 'test bootstrap: failed to read ut1_global_usage');
+		$this->assertSame(
+			1,
+			preg_match('/^FEED:\s*(\S+)$/m', $raw, $matches),
+			'ut1_global_usage must declare exactly one FEED line'
+		);
+		$this->assertStringStartsWith(
+			'https://',
+			$matches[1],
+			"the shipped UT1 feed must be fetched over HTTPS; found: {$matches[1]}"
+		);
+	}
+
+
 	public function testParseExtractionStartsAtExecutableCodeNotProductionComment(): void
 	{
 		$this->assertStringStartsWith('$data', self::$parseRegion);

--- a/tests/php/BlacklistLangFallbackTest.php
+++ b/tests/php/BlacklistLangFallbackTest.php
@@ -101,18 +101,30 @@ final class BlacklistLangFallbackTest extends TestCase
 	 */
 	public function testShippedUt1FeedUsesHttps(): void
 	{
-		$raw = file_get_contents(self::UT1_FILE);
+		$raw = file(self::UT1_FILE, FILE_SKIP_EMPTY_LINES | FILE_IGNORE_NEW_LINES);
 		$this->assertNotFalse($raw, 'test bootstrap: failed to read ut1_global_usage');
-		$this->assertSame(
-			1,
-			preg_match_all('/^FEED:\s*(\S+)$/m', $raw, $matches),
-			'ut1_global_usage must declare exactly one FEED line'
-		);
-		$matches = array(1 => $matches[1][0]);
+
+		// Read FEED exactly as the shipped discovery loop does
+		// (pfblockerng_blacklist.php): skip comments/blanks, split once on ':', trim,
+		// and take the FIRST match -- a later duplicate is ignored there, so this must
+		// not invent a uniqueness rule the parser does not have.
+		$feed = '';
+		foreach ($raw as $line) {
+			$line = trim($line);
+			if ($line === '' || str_starts_with($line, '#')) {
+				continue;
+			}
+			if (strpos($line, 'FEED:') !== FALSE) {
+				$feed = trim(explode(':', $line, 2)[1]);
+				break;
+			}
+		}
+
+		$this->assertNotSame('', $feed, 'ut1_global_usage must declare a FEED line');
 		$this->assertStringStartsWith(
 			'https://',
-			$matches[1],
-			"the shipped UT1 feed must be fetched over HTTPS; found: {$matches[1]}"
+			$feed,
+			"the shipped UT1 feed must be fetched over HTTPS; found: {$feed}"
 		);
 	}
 

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3966,6 +3966,10 @@ def test_blacklist_download_name_keys_on_provider_id(deployed_vm: SmokeVM, mock_
             f"expected the category file 'ut1_testcat' in {provider_dir}; got: {listing!r}\n"
             f"{stray_dir} holds: {deployed_vm.ssh(f'/bin/ls -A {stray_dir} 2>&1').stdout!r}"
         )
+        archive = deployed_vm.ssh(f"/bin/ls -A {h.PFB_DBDIR}/ut1.tar.gz 2>&1").stdout.strip()
+        assert archive.endswith("ut1.tar.gz"), (
+            f"expected the download itself to be named for the provider at {h.PFB_DBDIR}/ut1.tar.gz; got: {archive!r}"
+        )
         extracted = deployed_vm.ssh(f"/bin/cat {provider_dir}/ut1_testcat 2>&1").stdout
         assert domain in extracted, f"expected {domain!r} in {provider_dir}/ut1_testcat; got: {extracted!r}"
     finally:

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3926,11 +3926,6 @@ def test_blacklist_archive_survives_gzip_content_encoding(deployed_vm: SmokeVM, 
 def test_blacklist_download_name_keys_on_provider_id(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """issue #2636: the UT1 download name comes from the provider id, not from a literal feed URL.
 
-    The category files a Blacklist provider publishes are named after the DOWNLOAD file
-    name, so whatever decides that name decides the on-disk layout. Deriving it from a
-    hardcoded feed URL means the provider silently renames its whole category set the day
-    its URL changes; deriving it from the provider id keeps the layout stable.
-
     Given a UT1 provider whose feed URL is NOT the historical FTP one,
     When  the Blacklist download runs for it,
     Then  its archive is named for the provider and the categories land in the provider's
@@ -3941,18 +3936,23 @@ def test_blacklist_download_name_keys_on_provider_id(deployed_vm: SmokeVM, mock_
     feed_url = mock_feeds.register("blacklists.tar.gz", _blacklist_tar_gz("blacklists", "testcat", domain))
     provider_dir = f"{h.PFB_DBDIR}/ut1"
     stray_dir = f"{h.PFB_DBDIR}/blacklists"
+    # Snapshotted OUTSIDE the try so teardown restores what was there rather than deleting
+    # it, and so a failure here surfaces as itself instead of an undefined name in finally.
+    before = h.php_eval(
+        deployed_vm,
+        "echo base64_encode(serialize(config_get_path('installedpackages/pfblockerngblacklist', NULL)));",
+    ).stdout.strip()
     try:
         # Given -- a UT1 provider pointed at that URL, one category selected.
         deployed_vm.ssh(f"/bin/rm -rf {provider_dir} {stray_dir}")
+        provider = h._php_kv_array(  # noqa: SLF001
+            {"title": "UT1", "xml": "ut1", "feed": feed_url, "selected": "testcat"}
+        )
         h.php_eval(
             deployed_vm,
             "config_set_path('installedpackages/pfblockerngblacklist', array("
             "'blacklist_enable' => 'on', 'blacklist_selected' => 'ut1', "
-            "'item' => array(array("
-            "'title' => 'UT1', 'xml' => 'ut1', "
-            f"'feed' => {h._php_str(feed_url)}, "  # noqa: SLF001
-            "'size' => '8.5', 'selected' => 'testcat'"
-            "))));\n"
+            f"'item' => array({provider})));\n"
             "write_config('pfBlockerNG smoke: issue #2636 provider fixture');\n"
             "echo 'OK';",
         )
@@ -3972,7 +3972,10 @@ def test_blacklist_download_name_keys_on_provider_id(deployed_vm: SmokeVM, mock_
         deployed_vm.ssh(f"/bin/rm -rf {provider_dir} {stray_dir}")
         h.php_eval(
             deployed_vm,
-            "config_del_path('installedpackages/pfblockerngblacklist');\n"
+            f"$before = unserialize(base64_decode({h._php_str(before)}));\n"  # noqa: SLF001
+            "$before === NULL\n"
+            "    ? config_del_path('installedpackages/pfblockerngblacklist')\n"
+            "    : config_set_path('installedpackages/pfblockerngblacklist', $before);\n"
             "write_config('pfBlockerNG smoke: issue #2636 fixture teardown');\n"
             "echo 'OK';",
         )

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -3922,6 +3922,62 @@ def test_blacklist_archive_survives_gzip_content_encoding(deployed_vm: SmokeVM, 
         deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir}")
 
 
+@pytest.mark.timeout(180)
+def test_blacklist_download_name_keys_on_provider_id(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """issue #2636: the UT1 download name comes from the provider id, not from a literal feed URL.
+
+    The category files a Blacklist provider publishes are named after the DOWNLOAD file
+    name, so whatever decides that name decides the on-disk layout. Deriving it from a
+    hardcoded feed URL means the provider silently renames its whole category set the day
+    its URL changes; deriving it from the provider id keeps the layout stable.
+
+    Given a UT1 provider whose feed URL is NOT the historical FTP one,
+    When  the Blacklist download runs for it,
+    Then  its archive is named for the provider and the categories land in the provider's
+      own directory.
+    """
+    domain = h.unique_domain("pfb2636")
+    # The published basename, exactly as the origin serves it -- deliberately not 'ut1'.
+    feed_url = mock_feeds.register("blacklists.tar.gz", _blacklist_tar_gz("blacklists", "testcat", domain))
+    provider_dir = f"{h.PFB_DBDIR}/ut1"
+    stray_dir = f"{h.PFB_DBDIR}/blacklists"
+    try:
+        # Given -- a UT1 provider pointed at that URL, one category selected.
+        deployed_vm.ssh(f"/bin/rm -rf {provider_dir} {stray_dir}")
+        h.php_eval(
+            deployed_vm,
+            "config_set_path('installedpackages/pfblockerngblacklist', array("
+            "'blacklist_enable' => 'on', 'blacklist_selected' => 'ut1', "
+            "'item' => array(array("
+            "'title' => 'UT1', 'xml' => 'ut1', "
+            f"'feed' => {h._php_str(feed_url)}, "  # noqa: SLF001
+            "'size' => '8.5', 'selected' => 'testcat'"
+            "))));\n"
+            "write_config('pfBlockerNG smoke: issue #2636 provider fixture');\n"
+            "echo 'OK';",
+        )
+
+        # When -- the Blacklist download path runs.
+        deployed_vm.ssh(f"/usr/local/bin/php -f {h.PFB_CLI} bls ut1", timeout=180)
+
+        # Then -- named for the provider, not for the URL's basename.
+        listing = deployed_vm.ssh(f"/bin/ls -A {provider_dir} 2>&1").stdout
+        assert "ut1_testcat" in listing, (
+            f"expected the category file 'ut1_testcat' in {provider_dir}; got: {listing!r}\n"
+            f"{stray_dir} holds: {deployed_vm.ssh(f'/bin/ls -A {stray_dir} 2>&1').stdout!r}"
+        )
+        extracted = deployed_vm.ssh(f"/bin/cat {provider_dir}/ut1_testcat 2>&1").stdout
+        assert domain in extracted, f"expected {domain!r} in {provider_dir}/ut1_testcat; got: {extracted!r}"
+    finally:
+        deployed_vm.ssh(f"/bin/rm -rf {provider_dir} {stray_dir}")
+        h.php_eval(
+            deployed_vm,
+            "config_del_path('installedpackages/pfblockerngblacklist');\n"
+            "write_config('pfBlockerNG smoke: issue #2636 fixture teardown');\n"
+            "echo 'OK';",
+        )
+
+
 # --------------------------------------------------------------------------- #
 # Structured-text feed shapes + the reject path (issue #2511)
 #

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -3211,6 +3211,27 @@ def test_page_table_covers_every_pfblockerng_page() -> None:
     assert "dnsbl_vip_sinkhole_pages" in excluded_names
 
 
+def test_blacklist_download_name_keys_on_provider_id() -> None:
+    """Pin the CLI-only provider-naming contract that Tier-A HTTP rendering cannot execute.
+
+    A Blacklist provider's category filenames are derived from its download file name, so
+    keying that name on a feed URL literal renames the whole category set the day the URL
+    moves. Same reasoning as the sibling pins above: ``pfblockerng.php`` is the CLI
+    dispatcher and is never served, so the contract is asserted at the source rather than
+    through an HTTP render (issue #2636).
+    """
+    source_path = helpers.SMOKE_DIR.parent.parent / "src/usr/local/www/pfblockerng/pfblockerng.php"
+    source = source_path.read_text(encoding="utf-8")
+
+    assert re.search(r"if\s*\(\s*\$item\['xml'\]\s*==\s*'ut1'\s*\)", source), (
+        "the ut1.tar.gz filename patch must key on the provider id"
+    )
+    assert "ftp://ftp.ut-capitole.fr" not in source, (
+        "the filename patch must not key on a feed URL literal -- a URL change would "
+        "silently rename every UT1 category file"
+    )
+
+
 def test_pfblockerng_download_extras_uses_typed_download_result() -> None:
     """Pin the CLI-only download contract that Tier-A HTTP rendering cannot execute.
 


### PR DESCRIPTION

Fixes #2636.

## What changes

Two lines.

1. `ut1_global_usage` — the shipped UT1 feed URL moves from `ftp://ftp.ut-capitole.fr/…` to `https://dsi.ut-capitole.fr/blacklists/download/blacklists.tar.gz`.
2. `pfblockerng.php` — the patch that names the download `ut1.tar.gz` matched the literal FTP URL. It now keys on the provider id (`$item['xml'] == 'ut1'`).

The second is what makes the first safe: a Blacklist provider's category filenames are derived from its download file name, so leaving a URL-literal match in place would have stopped it firing the moment the URL moved, renaming every UT1 category file after the URL basename.

## Why HTTPS

The archive is byte-identical on both endpoints — fetched in full and compared:

```text
$ shasum -a 256 https.tar.gz ftp.tar.gz
f655a2ae39b53f3058febfaa6ebb702593862a09ea927dfc7b7d332f2b1f2dd0  https.tar.gz
f655a2ae39b53f3058febfaa6ebb702593862a09ea927dfc7b7d332f2b1f2dd0  ftp.tar.gz
$ cmp https.tar.gz ftp.tar.gz && echo IDENTICAL
IDENTICAL
```

25,391,699 bytes on both, same `Last-Modified`. So this changes the transport only: HTTPS authenticates the server and protects the payload in transit; FTP does neither, and a blocklist archive decides what the firewall resolves and blocks.

## No config migration

`pfblockerng_blacklist.php` re-reads `TITLE`/`XML`/`FEED`/`SIZE` from the provider file on every save and writes them into `installedpackages/pfblockerngblacklist/item`, so the stored `feed` is a refreshed copy rather than user data. An installation that has not saved since upgrading keeps the FTP URL and keeps working — that endpoint is live — and the id-keyed rename fires for it exactly as before.

## Red → green (executed on a leased smoke box, CE 2.8.1 guest)

New case `test_blacklist_download_name_keys_on_provider_id` seeds an `xml=ut1` provider whose feed is served by the mock origin as `blacklists.tar.gz`, runs the real `pfblockerng.php bls ut1` path, and asserts the category file lands in the provider's own directory.

RED at `769dfb899` (test only, no production edit):

```text
AssertionError: expected the category file 'ut1_testcat' in /var/db/pfblockerng/ut1; got:
  'ls: /var/db/pfblockerng/ut1: No such file or directory\n'
  /var/db/pfblockerng/blacklists holds: 'blacklists.update\nblacklists_testcat\n'
================ 1 failed, 1003 deselected in 85.63s (0:01:25) =================
```

The stray directory in the failure message is the defect itself: the whole category set named after the URL basename.

GREEN at `e405a6cdb`, test file byte-identical (`git hash-object` = `40489e9b616b56429e626e41483ece6017a8de12` at both), run together with the content-encoding case since both ride the blacklist path:

```text
================ 2 passed, 1002 deselected in 85.56s (0:01:25) =================
```

## Gates

```text
GATES: PASS
```

## Deliberately not done

- **No extracted download-name helper.** One call site, one provider special-case; the live-VM case pins the observable behaviour, and an abstraction here would have a single implementation and a single caller.
- **Not generalised to name every provider after its id.** That would rename categories for anyone using the documented `*_global_usage` drop-in extension point.
- `shallalist_global_usage` still carries an `http://` URL; Shallalist is already terminated in code, so it is out of scope.

## Follow-up

Backport to `release/3.3` is ruled and tracked in #2640, together with #2634. That line carries both sites unchanged.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the UT1 blacklist feed to use a secure HTTPS download endpoint.
  * Improved UT1 blacklist download and extraction handling by consistently using the provider identifier, ensuring the expected filename and category are retained.
  * Added safeguards to prevent feed URL changes from disrupting UT1 blacklist processing.

* **Tests**
  * Added coverage confirming secure feed URLs and reliable UT1 download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->