### PR TITLE
www: restore the Package Manager Update and Uninstall controls

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5064,31 +5064,32 @@ function pfb_software_is_our_build(?string $installed_repo): bool {
 }
 
 /*
- * TRUE only when pfSense Package Manager can see this origin (issue #2380).
- * get_pkg_info() skips any pfSense-pkg-* whose %R is not exactly 'pfSense', so
- * pkg_mgr_install.php reinstall/delete are dead on pfblockerng-* (and empty) origins.
- */
-function pfb_software_pkgmgr_usable(?string $repo): bool {
-	return $repo === 'pfSense';
-}
-
-/*
- * Update-now href. Package Manager only when %R is pfSense AND an update is available;
- * otherwise '#' (the Software page disables the control and prints the CLI instead).
+ * Update-now / Uninstall hrefs into pfSense's Package Manager, for every origin.
+ *
+ * The deep link carries the package NAME and pkg_mgr_install.php acts on that name: it
+ * validates pkg_valid_name() and runs pfSense-upgrade with -i <pkg> -f (reinstall) or
+ * -r <pkg> (delete). The %R filter that keeps a channel install out of the Package
+ * Manager tables lives in get_pkg_info(), which drives the LISTING pages only. So the
+ * origin decides whether Package Manager can show or announce the package -- it does not
+ * decide whether these two operations work (issue #2653; #2380 gated them on
+ * %R === 'pfSense' and disabled both controls on every channel install).
+ *
+ * Which repository the reinstall then resolves against is a repository-priority
+ * question: the generated conf sets priority 100 above the Netgate repo for exactly
+ * that reason (ADR-17, ADR-39).
+ *
+ * $repo is still taken so callers keep passing the origin they read, and so the pair
+ * stays one decision surface if origin ever does gate something here again.
  */
 function pfb_software_update_href(string $pkgname, string $repo, bool $update_available): string {
-	if (!$update_available || $pkgname === '' || !pfb_software_pkgmgr_usable($repo)) {
+	if (!$update_available || $pkgname === '') {
 		return '#';
 	}
 	return '/pkg_mgr_install.php?mode=reinstallpkg&pkg=' . rawurlencode($pkgname);
 }
 
-/*
- * Uninstall href. Same origin gate as Update: never send a pfblockerng-* install to
- * pkg_mgr_install.php?mode=delete (issue #2380).
- */
 function pfb_software_uninstall_href(string $pkgname, string $repo): string {
-	if ($pkgname === '' || !pfb_software_pkgmgr_usable($repo)) {
+	if ($pkgname === '') {
 		return '#';
 	}
 	return '/pkg_mgr_install.php?mode=delete&pkg=' . rawurlencode($pkgname);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5078,17 +5078,17 @@ function pfb_software_is_our_build(?string $installed_repo): bool {
  * question: the generated conf sets priority 100 above the Netgate repo for exactly
  * that reason (ADR-17, ADR-39).
  *
- * $repo is still taken so callers keep passing the origin they read, and so the pair
- * stays one decision surface if origin ever does gate something here again.
+ * Neither function takes the origin, so #2380's gate is not merely off here: it cannot
+ * be expressed without re-adding a parameter and every call site that feeds it.
  */
-function pfb_software_update_href(string $pkgname, string $repo, bool $update_available): string {
+function pfb_software_update_href(string $pkgname, bool $update_available): string {
 	if (!$update_available || $pkgname === '') {
 		return '#';
 	}
 	return '/pkg_mgr_install.php?mode=reinstallpkg&pkg=' . rawurlencode($pkgname);
 }
 
-function pfb_software_uninstall_href(string $pkgname, string $repo): string {
+function pfb_software_uninstall_href(string $pkgname): string {
 	if ($pkgname === '') {
 		return '#';
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -267,8 +267,8 @@ $section->addInput(new Form_StaticText(null, $btn_check))
 
 // Update / Uninstall. Enabled by what the operation needs -- an update to install, and a
 // known package name -- never by the origin (issue #2653).
-$pfb_sw_update_href	= pfb_software_update_href($pfb_sw_pkgname, $pfb_sw_repo, $update_available);
-$pfb_sw_uninstall_href	= pfb_software_uninstall_href($pfb_sw_pkgname, $pfb_sw_repo);
+$pfb_sw_update_href	= pfb_software_update_href($pfb_sw_pkgname, $update_available);
+$pfb_sw_uninstall_href	= pfb_software_uninstall_href($pfb_sw_pkgname);
 
 $btn_update = new Form_Button(
 	'pfb_sw_update',
@@ -306,7 +306,7 @@ print($form);
 events.push(function() {
 
 	// Check now is the only in-page action — a cache refresh POSTed back to this page.
-	// Update / Uninstall are plain links to the Package Manager only when %R is pfSense.
+	// Update / Uninstall are plain links to the Package Manager (no JS, no POST).
 	$('#pfb_sw_check').click(function(e) {
 		e.preventDefault();
 		var f = document.forms[0];

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -22,9 +22,11 @@
 
 // ADR-19: the "Software" page — show the installed pfBlockerNG channel/version vs our-repo
 // latest (from the cron-maintained cache), toggle the "Check for new versions" setting, and
-// offer Check / Update / Uninstall. Update and Uninstall link to pfSense Package Manager
-// ONLY when %R is pfSense (Netgate). A pfblockerng-* origin is invisible there (issue #2380),
-// so those controls are disabled and the page prints the repo-qualified pkg CLI instead.
+// offer Check / Update / Uninstall. Update and Uninstall link to pfSense Package Manager for
+// every origin: those deep links carry the package name, which pkg_mgr_install.php acts on
+// directly. Package Manager cannot LIST a pfblockerng-* install or announce its updates
+// (get_pkg_info() skips a foreign %R, issue #2380) -- checking and announcing are this page's
+// own job, which is why it exists (issue #2653).
 
 require_once('guiconfig.inc');
 require_once('globals.inc');
@@ -263,14 +265,10 @@ $btn_check->removeClass('btn-primary')->addClass('btn-primary btn-xs')->setWidth
 $section->addInput(new Form_StaticText(null, $btn_check))
 	->setHelp('Check for a new version now.');
 
-// Update / Uninstall. Package Manager only sees %R=pfSense (issue #2380). A pfblockerng-*
-// origin is disabled here with the repo-qualified pkg CLI; never emit pkg_mgr_install.php
-// for that origin (those pages hide the package and a reinstall can resolve against -r pfSense).
-$pfb_sw_pkgmgr		= pfb_software_pkgmgr_usable($pfb_sw_repo);
+// Update / Uninstall. Enabled by what the operation needs -- an update to install, and a
+// known package name -- never by the origin (issue #2653).
 $pfb_sw_update_href	= pfb_software_update_href($pfb_sw_pkgname, $pfb_sw_repo, $update_available);
 $pfb_sw_uninstall_href	= pfb_software_uninstall_href($pfb_sw_pkgname, $pfb_sw_repo);
-$pfb_sw_cli_pkg		= ($pfb_sw_pkgname !== '') ? $pfb_sw_pkgname : 'pfSense-pkg-pfBlockerNG';
-$pfb_sw_cli_repo	= ($pfb_sw_repo !== '') ? $pfb_sw_repo : '<repo>';
 
 $btn_update = new Form_Button(
 	'pfb_sw_update',
@@ -282,19 +280,10 @@ $btn_update->removeClass('btn-primary')->addClass('btn-warning btn-xs')->setWidt
 if ($pfb_sw_update_href === '#') {
 	$btn_update->addClass('disabled')->setAttribute('disabled', 'disabled')->setAttribute('aria-disabled', 'true');
 }
-if ($pfb_sw_pkgmgr) {
-	$pfb_sw_update_help = 'Install the latest version via the pfSense Package Manager. Available only when an update is found.';
-} else {
-	$pfb_sw_update_help = 'Package Manager cannot see this origin. To update, run <code>pkg install -y -r '
-		. htmlspecialchars($pfb_sw_cli_repo) . ' ' . htmlspecialchars($pfb_sw_cli_pkg)
-		. '</code> from the shell. On pfSense Plus, that can fail with a TLS error until '
-		. '"Carry the system CA store into pkg" above is enabled.';
-}
 $section->addInput(new Form_StaticText(null, $btn_update))
-	->setHelp($pfb_sw_update_help);
+	->setHelp('Install the latest version via the pfSense Package Manager. Available only when an update is found.');
 
-// Uninstall. #697: a `pkg delete` is a removal (pre-deinstall tears down). Package Manager
-// delete is only offered for a Netgate-origin install.
+// Uninstall. #697: a `pkg delete` is a removal (pre-deinstall tears down).
 $btn_uninstall = new Form_Button(
 	'pfb_sw_uninstall',
 	'Uninstall',
@@ -305,14 +294,8 @@ $btn_uninstall->removeClass('btn-primary')->addClass('btn-danger btn-xs')->setWi
 if ($pfb_sw_uninstall_href === '#') {
 	$btn_uninstall->addClass('disabled')->setAttribute('disabled', 'disabled')->setAttribute('aria-disabled', 'true');
 }
-if ($pfb_sw_pkgmgr) {
-	$pfb_sw_uninstall_help = 'Remove pfBlockerNG from this firewall via the pfSense Package Manager (it will ask you to confirm).';
-} else {
-	$pfb_sw_uninstall_help = 'Package Manager cannot see this origin. To uninstall, run <code>pkg delete '
-		. htmlspecialchars($pfb_sw_cli_pkg) . '</code> from the shell.';
-}
 $section->addInput(new Form_StaticText(null, $btn_uninstall))
-	->setHelp($pfb_sw_uninstall_help);
+	->setHelp('Remove pfBlockerNG from this firewall via the pfSense Package Manager (it will ask you to confirm).');
 $form->add($section);
 
 print($form);

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -24,7 +24,6 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_pkg_newest_version')]
 #[CoversFunction('pfb_software_cache_matches_install')]
 #[CoversFunction('pfb_software_is_our_build')]
-#[CoversFunction('pfb_software_pkgmgr_usable')]
 #[CoversFunction('pfb_software_update_href')]
 #[CoversFunction('pfb_software_uninstall_href')]
 #[CoversFunction('pfb_update_available')]
@@ -205,8 +204,18 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	}
 
 	/*
-	 * ---- Software-page action hrefs (issue #2380) ----
-	 * pkg_mgr_install.php only when %R is pfSense. Channel origins stay on '#'.
+	 * ---- Software-page action hrefs (issue #2653) ----
+	 * The deep link carries the package NAME, and pkg_mgr_install.php acts on that name:
+	 * it validates pkg_valid_name() and then runs pfSense-upgrade with -i <pkg> -f
+	 * (reinstall) or -r <pkg> (delete). The %R filter that hides a channel install lives
+	 * in get_pkg_info(), which drives only the listing pages -- so the origin never
+	 * decides the href. What gates it is what the operation itself needs: an update to
+	 * install, and a package name to name.
+	 *
+	 * #2380 gated both hrefs on %R === 'pfSense', on the premise that a Package Manager
+	 * reinstall would resolve against -r pfSense. The generated repo conf sets priority
+	 * 100 above the Netgate repo precisely so cross-repo resolution picks the
+	 * pfBlockerNG build.
 	 */
 	public static function updateHrefProvider(): array
 	{
@@ -215,11 +224,13 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		return [
 			'Netgate + update'            => [$pkg, 'pfSense', true, $pm],
 			'Netgate + no update'         => [$pkg, 'pfSense', false, '#'],
-			'channel-stable + update'     => [$pkg, 'pfblockerng-stable', true, '#'],
-			'channel-testing + update'    => [$pkg, 'pfblockerng-testing', true, '#'],
-			'legacy pfblockerng + update' => [$pkg, 'pfblockerng', true, '#'],
-			'empty repo + update'         => [$pkg, '', true, '#'],
+			'channel-stable + update'     => [$pkg, 'pfblockerng-stable', true, $pm],
+			'channel-testing + update'    => [$pkg, 'pfblockerng-testing', true, $pm],
+			'channel-stable + no update'  => [$pkg, 'pfblockerng-stable', false, '#'],
+			'legacy pfblockerng + update' => [$pkg, 'pfblockerng', true, $pm],
+			'sideload: empty repo'        => [$pkg, '', true, $pm],
 			'empty pkgname'               => ['', 'pfSense', true, '#'],
+			'empty pkgname, channel'      => ['', 'pfblockerng-stable', true, '#'],
 		];
 	}
 
@@ -234,11 +245,12 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		$pkg = 'pfSense-pkg-pfBlockerNG';
 		$pm = '/pkg_mgr_install.php?mode=delete&pkg=' . rawurlencode($pkg);
 		return [
-			'Netgate'         => [$pkg, 'pfSense', $pm],
-			'channel-stable'  => [$pkg, 'pfblockerng-stable', '#'],
-			'channel-edge'    => [$pkg, 'pfblockerng-edge', '#'],
-			'empty repo'      => [$pkg, '', '#'],
-			'empty pkgname'   => ['', 'pfSense', '#'],
+			'Netgate'                => [$pkg, 'pfSense', $pm],
+			'channel-stable'         => [$pkg, 'pfblockerng-stable', $pm],
+			'channel-edge'           => [$pkg, 'pfblockerng-edge', $pm],
+			'sideload: empty repo'   => [$pkg, '', $pm],
+			'empty pkgname'          => ['', 'pfSense', '#'],
+			'empty pkgname, channel' => ['', 'pfblockerng-stable', '#'],
 		];
 	}
 

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -252,22 +252,50 @@ final class SoftwareUpdateDecisionTest extends TestCase
 	}
 
 	/*
-	 * The origin cannot change either answer because neither function can see it: #2380's
-	 * gate is not merely off, it is unrepresentable without re-adding a parameter. That is
-	 * the regression oracle the per-origin data rows used to carry (issue #2653).
+	 * The origin must not gate either href (issue #2653). The per-origin data rows that
+	 * used to carry that oracle are gone with the $repo parameter, so it is pinned at both
+	 * doors an origin could come back through: the signature, and a read from inside the
+	 * body. A parameter is the obvious one; a global or a fresh pfb_pkg_installed_repo()
+	 * call inside the function would restore #2380 with every behavioural assertion still
+	 * green, which is exactly what a reviewer demonstrated against the signature check
+	 * alone.
 	 */
-	public function testHrefsTakeNoOriginArgument(): void
+	public static function originFreeHrefProvider(): array
 	{
-		$update = new ReflectionFunction('pfb_software_update_href');
-		$uninstall = new ReflectionFunction('pfb_software_uninstall_href');
+		return [
+			'update'    => ['pfb_software_update_href', ['pkgname', 'update_available']],
+			'uninstall' => ['pfb_software_uninstall_href', ['pkgname']],
+		];
+	}
 
-		$names = static fn (ReflectionFunction $f): array => array_map(
-			static fn (ReflectionParameter $p): string => $p->getName(),
-			$f->getParameters()
+	#[DataProvider('originFreeHrefProvider')]
+	public function testHrefIsBlindToTheInstallOrigin(string $function, array $expected_params): void
+	{
+		$reflected = new ReflectionFunction($function);
+
+		$this->assertSame(
+			$expected_params,
+			array_map(
+				static fn (ReflectionParameter $p): string => $p->getName(),
+				$reflected->getParameters()
+			),
+			"{$function}() must take no origin argument"
 		);
 
-		$this->assertSame(['pkgname', 'update_available'], $names($update));
-		$this->assertSame(['pkgname'], $names($uninstall));
+		$file = (array) file((string) $reflected->getFileName());
+		$body = implode('', array_slice(
+			$file,
+			(int) $reflected->getStartLine() - 1,
+			(int) $reflected->getEndLine() - (int) $reflected->getStartLine() + 1
+		));
+
+		foreach (['global', 'pfb_pkg_installed_repo', 'pfb_software_pkgmgr_usable', '%R'] as $side_channel) {
+			$this->assertStringNotContainsString(
+				$side_channel,
+				$body,
+				"{$function}() must not reach for the origin from inside its body ({$side_channel})"
+			);
+		}
 	}
 
 	public function testSoftwarePageDoesNotHardcodePkgMgrForAllOrigins(): void

--- a/tests/php/SoftwareUpdateDecisionTest.php
+++ b/tests/php/SoftwareUpdateDecisionTest.php
@@ -222,22 +222,17 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		$pkg = 'pfSense-pkg-pfBlockerNG';
 		$pm = '/pkg_mgr_install.php?mode=reinstallpkg&pkg=' . rawurlencode($pkg);
 		return [
-			'Netgate + update'            => [$pkg, 'pfSense', true, $pm],
-			'Netgate + no update'         => [$pkg, 'pfSense', false, '#'],
-			'channel-stable + update'     => [$pkg, 'pfblockerng-stable', true, $pm],
-			'channel-testing + update'    => [$pkg, 'pfblockerng-testing', true, $pm],
-			'channel-stable + no update'  => [$pkg, 'pfblockerng-stable', false, '#'],
-			'legacy pfblockerng + update' => [$pkg, 'pfblockerng', true, $pm],
-			'sideload: empty repo'        => [$pkg, '', true, $pm],
-			'empty pkgname'               => ['', 'pfSense', true, '#'],
-			'empty pkgname, channel'      => ['', 'pfblockerng-stable', true, '#'],
+			'update available'    => [$pkg, true, $pm],
+			'no update'           => [$pkg, false, '#'],
+			'empty pkgname'       => ['', true, '#'],
+			'empty pkgname, none' => ['', false, '#'],
 		];
 	}
 
 	#[DataProvider('updateHrefProvider')]
-	public function testSoftwareUpdateHref(string $pkgname, string $repo, bool $available, string $expected): void
+	public function testSoftwareUpdateHref(string $pkgname, bool $available, string $expected): void
 	{
-		$this->assertSame($expected, pfb_software_update_href($pkgname, $repo, $available));
+		$this->assertSame($expected, pfb_software_update_href($pkgname, $available));
 	}
 
 	public static function uninstallHrefProvider(): array
@@ -245,19 +240,34 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		$pkg = 'pfSense-pkg-pfBlockerNG';
 		$pm = '/pkg_mgr_install.php?mode=delete&pkg=' . rawurlencode($pkg);
 		return [
-			'Netgate'                => [$pkg, 'pfSense', $pm],
-			'channel-stable'         => [$pkg, 'pfblockerng-stable', $pm],
-			'channel-edge'           => [$pkg, 'pfblockerng-edge', $pm],
-			'sideload: empty repo'   => [$pkg, '', $pm],
-			'empty pkgname'          => ['', 'pfSense', '#'],
-			'empty pkgname, channel' => ['', 'pfblockerng-stable', '#'],
+			'installed'     => [$pkg, $pm],
+			'empty pkgname' => ['', '#'],
 		];
 	}
 
 	#[DataProvider('uninstallHrefProvider')]
-	public function testSoftwareUninstallHref(string $pkgname, string $repo, string $expected): void
+	public function testSoftwareUninstallHref(string $pkgname, string $expected): void
 	{
-		$this->assertSame($expected, pfb_software_uninstall_href($pkgname, $repo));
+		$this->assertSame($expected, pfb_software_uninstall_href($pkgname));
+	}
+
+	/*
+	 * The origin cannot change either answer because neither function can see it: #2380's
+	 * gate is not merely off, it is unrepresentable without re-adding a parameter. That is
+	 * the regression oracle the per-origin data rows used to carry (issue #2653).
+	 */
+	public function testHrefsTakeNoOriginArgument(): void
+	{
+		$update = new ReflectionFunction('pfb_software_update_href');
+		$uninstall = new ReflectionFunction('pfb_software_uninstall_href');
+
+		$names = static fn (ReflectionFunction $f): array => array_map(
+			static fn (ReflectionParameter $p): string => $p->getName(),
+			$f->getParameters()
+		);
+
+		$this->assertSame(['pkgname', 'update_available'], $names($update));
+		$this->assertSame(['pkgname'], $names($uninstall));
 	}
 
 	public function testSoftwarePageDoesNotHardcodePkgMgrForAllOrigins(): void
@@ -270,12 +280,12 @@ final class SoftwareUpdateDecisionTest extends TestCase
 		$this->assertStringNotContainsString(
 			'mode=reinstallpkg&pkg={$pfb_pkg_arg}',
 			$src,
-			'channel-origin installs must not emit a hardcoded Package Manager reinstall href'
+			'the reinstall href must come from the tested decider, not be rebuilt inline on the page'
 		);
 		$this->assertStringNotContainsString(
 			'mode=delete&pkg={$pfb_pkg_arg}',
 			$src,
-			'channel-origin installs must not emit a hardcoded Package Manager delete href'
+			'the delete href must come from the tested decider, not be rebuilt inline on the page'
 		);
 	}
 

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10791,13 +10791,6 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
-            },
-            {
-                "name": "repo",
-                "byRef": false,
-                "variadic": false,
-                "type": "string",
-                "default": null
             }
         ]
     },
@@ -10827,13 +10820,6 @@
         "params": [
             {
                 "name": "pkgname",
-                "byRef": false,
-                "variadic": false,
-                "type": "string",
-                "default": null
-            },
-            {
-                "name": "repo",
                 "byRef": false,
                 "variadic": false,
                 "type": "string",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10771,19 +10771,6 @@
             }
         ]
     },
-    "pfb_software_pkgmgr_usable": {
-        "returnsRef": false,
-        "returnType": "bool",
-        "params": [
-            {
-                "name": "repo",
-                "byRef": false,
-                "variadic": false,
-                "type": "?string",
-                "default": null
-            }
-        ]
-    },
     "pfb_software_provenance_ok": {
         "returnsRef": false,
         "returnType": "bool",

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2879,6 +2879,14 @@ def test_software_actions_link_to_package_manager(
         assert "cannot see this origin" not in body, (
             "retired #2380 copy: the controls are no longer disabled by origin (issue #2653)"
         )
+        # Pinned positively too: an emptied or rewritten help string would otherwise pass
+        # on the negative assertion alone. These are the pre-#2380 strings (#684).
+        assert "Install the latest version via the pfSense Package Manager" in body, (
+            "the Update control must carry its pre-#2380 help text (issue #2653)"
+        )
+        assert "Remove pfBlockerNG from this firewall via the pfSense Package Manager" in body, (
+            "the Uninstall control must carry its pre-#2380 help text (issue #2653)"
+        )
         assert "?do=uninstall" not in un_tag.group(0), (
             "Uninstall must NOT route through the removed ?do=uninstall handler (#697)"
         )

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2819,19 +2819,21 @@ def test_software_check_checkbox_posts_a_token_the_save_path_accepts(
 def test_software_actions_link_to_package_manager(
     smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:
-    """Update/Uninstall reach Package Manager only when ``%R`` is ``pfSense`` (issue #2380).
+    """Update/Uninstall reach Package Manager on EVERY origin (issue #2653).
 
-    pfSense ``get_pkg_info()`` skips any ``pfSense-pkg-*`` whose origin is not exactly
-    ``pfSense``. A ``pfblockerng-*`` (or empty sideload) origin therefore must not emit
-    ``pkg_mgr_install.php?mode=reinstallpkg|delete``. Netgate-origin installs keep the
-    #684 shortcuts.
+    The deep link carries the package name and ``pkg_mgr_install.php`` acts on that name.
+    ``get_pkg_info()``'s ``%R`` filter governs the listing pages, so it decides whether
+    Package Manager can show or announce a channel install — not whether these two
+    operations work. #2380 read it as the latter and disabled both controls on every
+    channel install; #684's shortcuts are restored for all of them.
 
     Scenario:
       Given the override sentinel set to 'on' (so the provenance gate passes),
       When the Software page is GET,
-      Then Update's href is inert ('#') when no update is cached;
-      And Uninstall / Update never point at ``pkg_mgr_install.php`` unless ``%R`` is
-          ``pfSense``;
+      Then Update's href is inert ('#') when no update is cached, whatever the origin;
+      And Uninstall points at ``pkg_mgr_install.php?mode=delete`` whatever the origin;
+      And Update points at ``pkg_mgr_install.php?mode=reinstallpkg`` once an update is
+          cached, whatever the origin;
       And the page carries NO in-page pkg machinery — no ``?ajax=tail`` poller, no
           ``pfb_output`` textarea;
       And the clean render oracle (200, no Fatal/Warning/Notice, marker present) holds.
@@ -2839,8 +2841,9 @@ def test_software_actions_link_to_package_manager(
     software_cache = "/var/db/pfblockerng/software_update.json"
     pkgname = pkg_identity.branch_pkg_name(os.environ.get("SMOKE_PKG"))
     repo_probe = smoke_vm.ssh("/usr/local/sbin/pkg", "query", "%R", pkgname)
+    # Recorded for failure messages only: the origin no longer changes any expectation
+    # here, and asserting the same thing for every origin is the point (issue #2653).
     installed_repo = repo_probe.stdout.strip() if repo_probe.returncode == 0 else ""
-    pkgmgr_ok = installed_repo == "pfSense"
 
     def _update_anchor(body: str) -> str:
         tag = re.search(r'<a\b[^>]*id=["\']pfb_sw_update["\'][^>]*>', body)
@@ -2869,19 +2872,13 @@ def test_software_actions_link_to_package_manager(
 
         un_tag = re.search(r'<a\b[^>]*id=["\']pfb_sw_uninstall["\'][^>]*>', body)
         assert un_tag is not None, f"Uninstall control is not an <a> link in {_SOFTWARE_PAGE} body"
-        if pkgmgr_ok:
-            assert _has_pkgmgr_href(un_tag.group(0), "delete"), (
-                f"Netgate-origin Uninstall must target pkg_mgr_install.php?mode=delete, got: {un_tag.group(0)!r}"
-            )
-        else:
-            assert not _has_pkgmgr_href(un_tag.group(0), "delete"), (
-                f"channel/sideload Uninstall must not emit pkg_mgr_install.php (issue #2380), "
-                f"%R={installed_repo!r}, got: {un_tag.group(0)!r}"
-            )
-            assert re.search(r'href=["\']#["\']', un_tag.group(0)), (
-                f"channel/sideload Uninstall href must be inert ('#'): {un_tag.group(0)!r}"
-            )
-            assert "pkg_mgr_install.php" not in body or "Package Manager cannot see this origin" in body
+        assert _has_pkgmgr_href(un_tag.group(0), "delete"), (
+            f"Uninstall must target pkg_mgr_install.php?mode=delete on any origin (issue #2653), "
+            f"%R={installed_repo!r}, got: {un_tag.group(0)!r}"
+        )
+        assert "cannot see this origin" not in body, (
+            "retired #2380 copy: the controls are no longer disabled by origin (issue #2653)"
+        )
         assert "?do=uninstall" not in un_tag.group(0), (
             "Uninstall must NOT route through the removed ?do=uninstall handler (#697)"
         )
@@ -2893,8 +2890,8 @@ def test_software_actions_link_to_package_manager(
         assert "?ajax=tail" not in body, "Software page must no longer host the ?ajax=tail poller"
         assert 'name="pfb_output"' not in body, "Software page must no longer render the pfb_output textarea"
 
-        # (B) Seed a newer cached 'latest' → update available. Package Manager reinstall is
-        #     only for %R=pfSense; a channel/sideload origin stays on '#' (issue #2380).
+        # (B) Seed a newer cached 'latest' → update available. The reinstall deep link is
+        #     emitted for every origin (issue #2653).
         try:
             smoke_vm.ssh("/bin/rm", "-f", software_cache)
             seed = json.dumps(
@@ -2906,16 +2903,10 @@ def test_software_actions_link_to_package_manager(
             )
             _seed_vm_file(smoke_vm, software_cache, seed)
             up_tag2 = _update_anchor(webui.get(_SOFTWARE_PAGE).text)
-            if pkgmgr_ok:
-                assert _has_pkgmgr_href(up_tag2, "reinstallpkg"), (
-                    f"Netgate-origin Update must target pkg_mgr_install.php?mode=reinstallpkg "
-                    f"when an update exists: {up_tag2!r}"
-                )
-            else:
-                assert not _has_pkgmgr_href(up_tag2, "reinstallpkg"), (
-                    f"channel/sideload Update must not emit pkg_mgr_install.php (issue #2380), "
-                    f"%R={installed_repo!r}, got: {up_tag2!r}"
-                )
+            assert _has_pkgmgr_href(up_tag2, "reinstallpkg"), (
+                f"Update must target pkg_mgr_install.php?mode=reinstallpkg once an update exists, "
+                f"on any origin (issue #2653), %R={installed_repo!r}, got: {up_tag2!r}"
+            )
         finally:
             smoke_vm.ssh("/bin/rm", "-f", software_cache)
 


### PR DESCRIPTION
## What

Restores **Update now** and **Uninstall** on **Firewall → pfBlockerNG → Software** for
every origin, and returns the help under both controls to its pre-#2380 wording.

## Why

#2380 gated both hrefs on `pkg query '%R' === 'pfSense'` — true only for a Netgate-repo
install, so every channel install got two disabled buttons and CLI instructions instead.
Its stated reason was that a Package Manager reinstall "will not install 3.3.2 from our
repo; **if anything** it talks to `-r pfSense`". That inference was never probed, and it
conflicts with how the two pfSense code paths actually split:

- **Listing** — `get_pkg_info()` skips any `pfSense-pkg-*` whose `%R` is not `pfSense`.
  This is real and unchanged: Package Manager cannot list a channel install, cannot check
  for its updates, and cannot announce them. Everything #2380 documented about
  visibility stands.
- **Acting** — `pkg_mgr_install.php` never calls `get_pkg_info()` for the operation. It
  validates `pkg_valid_name($pkgname)`, then runs
  `pfSense-upgrade -y -l <log> -p <sock>` with `-i <pkgname> -f` for `mode=reinstallpkg`
  and `-r <pkgname>` for `mode=delete`. A deep link that carries the package name is
  therefore unaffected by the `%R` filter.

Which repository the reinstall resolves against is a repository-priority question, and
the generated conf answers it deliberately: `scripts/rc.d/pfblockerng_repo_generate.sh`
writes `priority: 100` with the comment "sits above the base Netgate `pfSense` repo so
cross-repo resolution (pkg install/upgrade, GUI Install) selects the pfBlockerNG build".

## Changes

- `pfb_software_update_href()` gates on `$update_available` and a known package name;
  `pfb_software_uninstall_href()` gates on a known package name. Neither takes the
  origin at all: after review, `$repo` was dropped from both signatures, so #2380's gate
  is not merely off but unrepresentable without re-adding a parameter and every call
  site that feeds it. A reflection test pins both signatures.
- `pfb_software_pkgmgr_usable()` is removed with its last caller.
- The page no longer branches on origin: the help strings are the pre-#2380 text from
  commit `b3d74ff06` (issue #684) — "Install the latest version via the pfSense Package
  Manager. Available only when an update is found." and "Remove pfBlockerNG from this
  firewall via the pfSense Package Manager (it will ask you to confirm)." No CLI command
  and no CA caveat: the "Carry the system CA store into pkg" checkbox on the same page
  documents that already.
- Checking for new versions is untouched — it has always been pfBlockerNG's own
  repo-qualified check, never Package Manager's.

## Test

Two red/green cycles, each with the test file frozen byte-identical across its runs
(`vendor/bin/phpunit --filter SoftwareUpdateDecisionTest`):

- The restore, blob `97257406fde31dba8ca524d6a6d0eb082fe45f82`: RED
  `Tests: 121, Assertions: 128, Failures: 7` → GREEN `OK (121 tests, 128 assertions)`.
- The review round's signature change, blob `3e30e6821329a51b744fcd99cdd8b68ea8440a5e`:
  RED `Tests: 113, Assertions: 114, Errors: 6, Failures: 1` → GREEN
  `OK (113 tests, 121 assertions)`.

The providers keep `'#'` for the two things that genuinely block the operation — no
update available, and no package name — and `testHrefsTakeNoOriginArgument()` asserts
neither function can see the origin at all, which is what the per-origin rows were
standing in for before `$repo` was removed.

Tier A (`tests/smoke/ui/test_render_smoke.py::test_software_actions_link_to_package_manager`)
is flipped the same way: Uninstall must emit `mode=delete` on any origin, Update must
emit `mode=reinstallpkg` once an update is cached on any origin, Update stays inert with
no cached update, the retired "cannot see this origin" copy is pinned as gone, and both
restored help strings are pinned positively so emptying them cannot pass.

`tests/php/fixtures/function_inventory.json` regenerated for the removed function
(`PFB_UPDATE_FUNCTION_INVENTORY=1`).

`scripts/agent/run-gates.sh`: `GATES: PASS`.

## Not verified here

That `pfSense-upgrade -i <pkg> -f` lands on the pfBlockerNG repository rather than
Netgate's is being confirmed on a live box by the owner. This PR changes no repository
conf and no priority.

Part of #2653


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package Manager Update and Uninstall links now work consistently for installed packages, regardless of package origin.
  * Reinstall links appear when an update is available.
  * Removed outdated fallback instructions and origin-specific warning messages.
  * Updated help text to accurately describe available Package Manager actions.

* **Tests**
  * Expanded coverage for origin-independent Update and Uninstall behavior.
  * Updated UI smoke tests to verify the revised links and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->