### PR TITLE
download: stop offering Accept-Encoding and fetch UT1 over HTTPS (3.3 backport)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3901,7 +3901,9 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				curl_setopt_array($ch, $pfb['curl_defaults']);	// Load curl default settings
 				curl_setopt($ch, CURLOPT_FILE, $fhandle);	// Add $fhandle setting to cURL
 				curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);	// Set cURL download timeout
-				curl_setopt($ch, CURLOPT_ENCODING, 'gzip');	// Request 'gzip' encoding from server if available
+				// No Accept-Encoding is offered: an origin that labels an archive
+				// 'Content-Encoding: gzip' would otherwise have libcurl decode it in
+				// flight, leaving the inner bytes on disk and the archive unextracted.
 				if ($srcint) {
 					curl_setopt($ch, CURLOPT_INTERFACE, $srcint);	// Use a specific interface when downloading lists
 					pfb_logger("\nList: {$header} will be downloaded via interface: {$srcint}\n", 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3904,6 +3904,8 @@ function pfb_download($list_url, $file_dwn, $pflex=FALSE, $header, $format, $log
 				// No Accept-Encoding is offered: an origin that labels an archive
 				// 'Content-Encoding: gzip' would otherwise have libcurl decode it in
 				// flight, leaving the inner bytes on disk and the archive unextracted.
+				// Text feeds therefore transfer uncompressed; do not re-add the offer
+				// without solving that first.
 				if ($srcint) {
 					curl_setopt($ch, CURLOPT_INTERFACE, $srcint);	// Use a specific interface when downloading lists
 					pfb_logger("\nList: {$header} will be downloaded via interface: {$srcint}\n", 1);

--- a/src/usr/local/pkg/pfblockerng/ut1_global_usage
+++ b/src/usr/local/pkg/pfblockerng/ut1_global_usage
@@ -39,7 +39,7 @@
 XML:	ut1
 TITLE:	UT1
 DESCR:	Universit&#xE9; Toulouse 1 Capitole - UT1
-FEED:	ftp://ftp.ut-capitole.fr/pub/reseau/cache/squidguard_contrib/blacklists.tar.gz
+FEED:	https://dsi.ut-capitole.fr/blacklists/download/blacklists.tar.gz
 SIZE:	8.5
 WEBSITE:https://dsi.ut-capitole.fr/blacklists/index_en.php
 LICENSE:https://creativecommons.org/licenses/by-sa/4.0/

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -159,8 +159,10 @@ if ($argv[1] == 'bl' || $argv[1] == 'bls') {
 					$pfb['extras'][$next_key]['password'] = $item['password'];
 				}
 
-				// Patch UT1 filename
-				if ($item['feed'] == 'ftp://ftp.ut-capitole.fr/pub/reseau/cache/squidguard_contrib/blacklists.tar.gz') {
+				// Patch UT1 filename. Keyed on the provider id, never its feed URL: the
+				// download name decides the category filenames, so a URL change would
+				// otherwise rename the whole category set.
+				if ($item['xml'] == 'ut1') {
 					$pfb['extras'][$next_key]['file_dwn'] = $pfb['extras'][$next_key]['file'] = 'ut1.tar.gz';
 				}
 				$next_key++;

--- a/tests/php/assert_feed_transport_3_3.php
+++ b/tests/php/assert_feed_transport_3_3.php
@@ -76,8 +76,10 @@ check(
 	"the shipped UT1 feed is fetched over HTTPS (found: {$feed})"
 );
 
+/* Tolerant of quote style and of == vs ===, so a harmless reformat does not read as a
+   regression; still strict about WHAT is compared, which is the contract. */
 check(
-	preg_match("/if\s*\(\s*\\\$item\['xml'\]\s*==\s*'ut1'\s*\)/", $php_src) === 1,
+	preg_match('/\$item\[[\x27"]xml[\x27"]\]\s*===?\s*[\x27"]ut1[\x27"]/', $php_src) === 1,
 	'the ut1.tar.gz filename patch keys on the provider id'
 );
 check(

--- a/tests/php/assert_feed_transport_3_3.php
+++ b/tests/php/assert_feed_transport_3_3.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Feed transport assertions backported from the development line.
+ *
+ * Two contracts, both reported from the field (a UT1 archive that downloaded but
+ * never unpacked):
+ *
+ *  1. The download must not request a transfer encoding. An origin that labels an
+ *     archive "Content-Encoding: gzip" -- the Apache AddEncoding misconfiguration --
+ *     otherwise has libcurl decode it in flight, so what lands on disk is the inner
+ *     tar. On this line application/x-tar is allow-listed, so the decoded body passes
+ *     MIME validation and the Blacklist branch reports a successful update having
+ *     extracted nothing.
+ *  2. The shipped UT1 provider must fetch over an authenticated transport, and the
+ *     patch that names its download must key on the provider id rather than a feed
+ *     URL literal -- the download name decides every category filename, so a
+ *     URL-literal match renames the whole category set the day the URL moves.
+ *
+ * Source-level assertions: this line ships no PHPUnit, no composer and no live-VM
+ * suite, and pfb_download() has no off-appliance double for its curl/exec surface.
+ */
+
+$root = dirname(__DIR__, 2);
+$inc = $root . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+$php = $root . '/src/usr/local/www/pfblockerng/pfblockerng.php';
+$provider = $root . '/src/usr/local/pkg/pfblockerng/ut1_global_usage';
+
+$failures = 0;
+function check(bool $cond, string $label): void
+{
+	global $failures;
+	if ($cond) {
+		echo "PASS {$label}\n";
+		return;
+	}
+	$failures++;
+	echo "FAIL {$label}\n";
+}
+
+foreach (array($inc, $php, $provider) as $path) {
+	if (!is_file($path)) {
+		echo "FAIL missing source: {$path}\n";
+		exit(1);
+	}
+}
+
+$inc_src = (string) file_get_contents($inc);
+$php_src = (string) file_get_contents($php);
+
+check(
+	strpos($inc_src, 'CURLOPT_ENCODING') === FALSE,
+	'the download requests no transfer encoding'
+);
+
+/* Read FEED exactly as the shipped discovery loop does (pfblockerng_blacklist.php):
+   skip comments and blanks, split once on ':', trim, first match wins -- a later
+   duplicate is ignored there, so this must not invent a uniqueness rule. */
+$feed = '';
+foreach ((array) file($provider, FILE_SKIP_EMPTY_LINES | FILE_IGNORE_NEW_LINES) as $line) {
+	$line = trim($line);
+	if ($line === '' || strpos($line, '#') === 0) {
+		continue;
+	}
+	if (strpos($line, 'FEED:') !== FALSE) {
+		$feed = trim(explode(':', $line, 2)[1]);
+		break;
+	}
+}
+
+check($feed !== '', 'ut1_global_usage declares a FEED');
+check(
+	strpos($feed, 'https://') === 0,
+	"the shipped UT1 feed is fetched over HTTPS (found: {$feed})"
+);
+
+check(
+	preg_match("/if\s*\(\s*\\\$item\['xml'\]\s*==\s*'ut1'\s*\)/", $php_src) === 1,
+	'the ut1.tar.gz filename patch keys on the provider id'
+);
+check(
+	strpos($php_src, 'ftp://ftp.ut-capitole.fr') === FALSE,
+	'the filename patch does not key on a feed URL literal'
+);
+
+if ($failures > 0) {
+	echo "{$failures} FAILURE(S)\n";
+	exit(1);
+}
+
+echo "ALL PASS\n";

--- a/tests/test_feed_transport_3_3.py
+++ b/tests/test_feed_transport_3_3.py
@@ -1,0 +1,18 @@
+"""Feed transport assertions backported from the development line."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_php_assertion_runner() -> None:
+    runner = Path(__file__).with_name("php") / "assert_feed_transport_3_3.php"
+    result = subprocess.run(
+        ["php", str(runner)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL PASS" in result.stdout


### PR DESCRIPTION
Backport to `release/3.3` of two development-line fixes. Ruled in #2640.

## Why this line needs both

**Accept-Encoding.** This branch requests gzip transfer encoding per curl handle:

```text
src/usr/local/pkg/pfblockerng/pfblockerng.inc:3904   curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
```

An origin that labels an archive `Content-Encoding: gzip` (Apache's `AddEncoding x-gzip .gz`) therefore has libcurl decode it in flight, and the bytes that reach disk are the inner tar rather than the published archive.

The consequence is worse here than on `devel`. This line still allow-lists `application/x-tar` (`pfblockerng.inc:272`), so the decoded tar passes MIME validation, falls into the uncompressed branch, and the Blacklist arm there reports a **successful update having extracted nothing** — the silent failure reported in #2632, rather than the loud MIME rejection `devel` now gives.

**UT1 over FTP.** The shipped feed is fetched in the clear with no server authentication. The HTTPS endpoint serves a byte-identical archive (verified on the development line: sha256 `f655a2ae39b53f3058febfaa6ebb702593862a09ea927dfc7b7d332f2b1f2dd0`, 25,391,699 bytes, same `Last-Modified`), so this changes the transport only.

The patch that names the download `ut1.tar.gz` matched the literal FTP URL, so moving the URL alone would have stopped it firing and renamed every UT1 category file after the URL's basename. It now keys on the provider id — available at that point on this branch too, since the selection gate already reads `$item['xml']`.

## Not a cherry-pick

Both hunks were hand-applied: `devel` carries the encoding option in the shared `$pfb['curl_defaults']` array, while this line sets it per handle, so the upstream diff does not apply. The resulting behaviour is the same.

## Red → green

This line ships no PHPUnit, no composer and no live-VM suite — its idiom is a standalone PHP assertion script driven by a thin pytest wrapper — so the cover follows that idiom, and the assertions are source-level rather than executed: `pfb_download()` has no off-appliance double for its curl/exec surface here.

RED at `04657e7f9` (tests only, no production edit):

```text
FAIL the download requests no transfer encoding
PASS ut1_global_usage declares a FEED
FAIL the shipped UT1 feed is fetched over HTTPS (found: ftp://ftp.ut-capitole.fr/...)
FAIL the ut1.tar.gz filename patch keys on the provider id
FAIL the filename patch does not key on a feed URL literal
4 FAILURE(S)
```

GREEN at `a1a930534`, assertion files byte-identical (`git hash-object`: `9e59ccda8…` for the PHP runner, `14640d195…` for the wrapper — identical at red and green), whole suite:

```text
============================== 40 passed in 3.47s ==============================
```

`php -l` clean on both changed PHP sources.

## When the URL change takes effect

`item[].feed` is refreshed from the provider file only when the DNSBL Category page is saved, so an existing installation keeps the FTP URL until its next save rather than switching at upgrade. That endpoint is still live, and the id-keyed rename fires for a stored FTP URL exactly as for the new one, so nothing breaks in the interval.

## Scope held

`#2635` (a non-archive Blacklist body reporting success) and `#2638` (accepting and extracting the tar family) stay `devel`-only. With this change a `.tar.gz` feed on this line arrives as published and extracts normally — correct behaviour restored, no new capability.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed downloads to preserve archive compression and support reliable extraction.
  * Updated the UT1 blacklist feed to use its secure HTTPS download endpoint.
  * Improved UT1 provider filename handling for more reliable feed updates.

* **Tests**
  * Added automated checks validating feed transport settings, secure URLs, and UT1 filename handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->