### PR TITLE
graphify-store: swap the payload transactionally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ test-results/
 .grok/worktrees/
 .codex/local-notes.md
 graphify-out/
+.graphify-swap-*/
 .ua/
 
 # Per-machine Claude Code / Grok overrides — never committed

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 SHA_RE = re.compile(r"^[0-9a-fA-F]{40,64}$")
@@ -119,6 +120,20 @@ def _canonical_files(payload: Path) -> tuple[Path, ...]:
     return tuple(files)
 
 
+def _remove_scratch(scratch: Path) -> None:
+    """Remove a swap scratch directory, never raising; residue would block `git worktree remove`."""
+
+    def retry(function: Callable[[str], object], path: str, _excinfo: object) -> None:
+        try:
+            os.chmod(os.path.dirname(path), stat.S_IRWXU)  # an unwritable parent is what blocks the unlink
+            os.chmod(path, stat.S_IRWXU)
+            function(path)
+        except OSError:
+            pass
+
+    shutil.rmtree(scratch, onerror=retry)
+
+
 def _swap_payload(artifacts: tuple[Path, ...], target: Path) -> None:
     """Stage the canonical artifacts, then swap them in, keeping the old payload on failure."""
     scratch = Path(tempfile.mkdtemp(dir=target.parent, prefix=".graphify-swap-"))
@@ -139,9 +154,9 @@ def _swap_payload(artifacts: tuple[Path, ...], target: Path) -> None:
     except OSError as error:
         if previous.exists():
             raise StoreError(f"the previous Graphify payload is kept at {previous}") from error
-        shutil.rmtree(scratch, ignore_errors=True)
+        _remove_scratch(scratch)
         raise
-    shutil.rmtree(scratch, ignore_errors=True)
+    _remove_scratch(scratch)
 
 
 def _replace_payload(source: Path, target_root: Path) -> None:

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -129,7 +129,9 @@ def _remove_scratch(scratch: Path) -> None:
                 # An unwritable parent is what blocks the unlink -- but the scratch's own
                 # parent belongs to the caller, so leave residue rather than widen it.
                 os.chmod(os.path.dirname(path), stat.S_IRWXU)
-            os.chmod(path, stat.S_IRWXU)
+            if not os.path.islink(path):
+                # chmod follows symlinks, and a link inside the scratch can point anywhere.
+                os.chmod(path, stat.S_IRWXU)
             function(path)
         except OSError:
             pass

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -121,12 +121,13 @@ def _canonical_files(payload: Path) -> tuple[Path, ...]:
 
 def _swap_payload(artifacts: tuple[Path, ...], target: Path) -> None:
     """Stage the canonical artifacts, then swap them in, keeping the old payload on failure."""
-    with tempfile.TemporaryDirectory(dir=target.parent, prefix=".graphify-swap-") as scratch:
-        staged = Path(scratch) / "graphify-out"
+    scratch = Path(tempfile.mkdtemp(dir=target.parent, prefix=".graphify-swap-"))
+    staged = scratch / "graphify-out"
+    previous = scratch / "previous"
+    try:
         staged.mkdir()
         for source_file in artifacts:
             shutil.copy2(source_file, staged / source_file.name)
-        previous = Path(scratch) / "previous"
         if target.exists():
             os.replace(target, previous)
         try:
@@ -135,6 +136,12 @@ def _swap_payload(artifacts: tuple[Path, ...], target: Path) -> None:
             if previous.exists():
                 os.replace(previous, target)
             raise
+    except OSError as error:
+        if previous.exists():
+            raise StoreError(f"the previous Graphify payload is kept at {previous}") from error
+        shutil.rmtree(scratch, ignore_errors=True)
+        raise
+    shutil.rmtree(scratch, ignore_errors=True)
 
 
 def _replace_payload(source: Path, target_root: Path) -> None:

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-from collections.abc import Callable
 from pathlib import Path
 
 SHA_RE = re.compile(r"^[0-9a-fA-F]{40,64}$")
@@ -122,21 +121,15 @@ def _canonical_files(payload: Path) -> tuple[Path, ...]:
 
 def _remove_scratch(scratch: Path) -> None:
     """Remove a swap scratch directory, never raising; residue would block `git worktree remove`."""
-
-    def retry(function: Callable[[str], object], path: str, _excinfo: object) -> None:
-        try:
-            if os.fspath(path) != os.fspath(scratch):
-                # An unwritable parent is what blocks the unlink -- but the scratch's own
-                # parent belongs to the caller, so leave residue rather than widen it.
-                os.chmod(os.path.dirname(path), stat.S_IRWXU)
-            if not os.path.islink(path):
-                # chmod follows symlinks, and a link inside the scratch can point anywhere.
-                os.chmod(path, stat.S_IRWXU)
-            function(path)
-        except OSError:
-            pass
-
-    shutil.rmtree(scratch, onerror=retry)
+    for directory, subdirectories, _files in os.walk(scratch):
+        for path in (directory, *(os.path.join(directory, name) for name in subdirectories)):
+            if os.path.islink(path):
+                continue  # chmod follows symlinks, and a link inside the scratch can point anywhere
+            try:
+                os.chmod(path, stat.S_IRWXU)  # an unwritable directory is what blocks the unlink
+            except OSError:
+                pass
+    shutil.rmtree(scratch, ignore_errors=True)
 
 
 def _swap_payload(artifacts: tuple[Path, ...], target: Path) -> None:

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -119,6 +119,24 @@ def _canonical_files(payload: Path) -> tuple[Path, ...]:
     return tuple(files)
 
 
+def _swap_payload(artifacts: tuple[Path, ...], target: Path) -> None:
+    """Stage the canonical artifacts, then swap them in, keeping the old payload on failure."""
+    with tempfile.TemporaryDirectory(dir=target.parent, prefix=".graphify-swap-") as scratch:
+        staged = Path(scratch) / "graphify-out"
+        staged.mkdir()
+        for source_file in artifacts:
+            shutil.copy2(source_file, staged / source_file.name)
+        previous = Path(scratch) / "previous"
+        if target.exists():
+            os.replace(target, previous)
+        try:
+            os.replace(staged, target)
+        except OSError:
+            if previous.exists():
+                os.replace(previous, target)
+            raise
+
+
 def _replace_payload(source: Path, target_root: Path) -> None:
     target_root = _physical_path(target_root, "restore target")
     if not target_root.is_dir() or target_root.is_symlink():
@@ -128,11 +146,7 @@ def _replace_payload(source: Path, target_root: Path) -> None:
     target = target_root / "graphify-out"
     if target.is_symlink() or (target.exists() and not target.is_dir()):
         raise StoreError(f"refusing unmanaged graphify-out target: {target}")
-    if target.exists():
-        shutil.rmtree(target)
-    target.mkdir()
-    for source_file in artifacts:
-        shutil.copy2(source_file, target / source_file.name)
+    _swap_payload(artifacts, target)
 
 
 def _branch_exists(store: Path, branch: str) -> bool:
@@ -219,11 +233,7 @@ def publish(store_root: Path, builder: Path, branch: str, sha: str) -> None:
     target = store / "graphify-out"
     if target.is_symlink() or (target.exists() and not target.is_dir()):
         raise StoreError(f"refusing unmanaged store payload: {target}")
-    if target.exists():
-        shutil.rmtree(target)
-    target.mkdir()
-    for source_file in artifacts:
-        shutil.copy2(source_file, target / source_file.name)
+    _swap_payload(artifacts, target)
     _run(store, "add", "-A", "--", "graphify-out")
     if _run(store, "diff", "--cached", "--quiet", check=False).returncode:
         _run(store, "commit", "--quiet", "-m", sha)

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -125,7 +125,10 @@ def _remove_scratch(scratch: Path) -> None:
 
     def retry(function: Callable[[str], object], path: str, _excinfo: object) -> None:
         try:
-            os.chmod(os.path.dirname(path), stat.S_IRWXU)  # an unwritable parent is what blocks the unlink
+            if os.fspath(path) != os.fspath(scratch):
+                # An unwritable parent is what blocks the unlink -- but the scratch's own
+                # parent belongs to the caller, so leave residue rather than widen it.
+                os.chmod(os.path.dirname(path), stat.S_IRWXU)
             os.chmod(path, stat.S_IRWXU)
             function(path)
         except OSError:

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -120,7 +120,11 @@ def _canonical_files(payload: Path) -> tuple[Path, ...]:
 
 
 def _remove_scratch(scratch: Path) -> None:
-    """Remove a swap scratch directory, never raising; residue would block `git worktree remove`."""
+    """Remove a swap scratch directory, never raising; residue would block `git worktree remove`.
+
+    A scratch whose own root is unreadable cannot be walked, so its contents stay; the callers
+    always mint the scratch themselves and never narrow its mode.
+    """
     for directory, subdirectories, _files in os.walk(scratch):
         for path in (directory, *(os.path.join(directory, name) for name in subdirectories)):
             if os.path.islink(path):

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import tarfile
 from pathlib import Path
@@ -613,7 +614,7 @@ def test_replace_keeps_the_previous_payload_recoverable_when_the_rollback_fails(
     with pytest.raises(store.StoreError, match="previous Graphify payload is kept at") as failure:
         store._replace_payload(source, target_root)
 
-    kept = Path(str(failure.value).rsplit(" ", 1)[-1])
+    kept = Path(str(failure.value).split("kept at ", 1)[1])
     assert (kept / "graph.json").read_text(encoding="utf-8") == '{"version":"previous"}\n'
     assert (kept / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "previous report\n"
 
@@ -638,3 +639,20 @@ def test_publish_keeps_previous_store_payload_when_a_canonical_copy_fails(
     assert (payload / "graph.json").read_text(encoding="utf-8") == '{"version":1}\n'
     assert (payload / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "report\n"
     assert git(store_root, "status", "--porcelain") == ""
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses the directory permissions this test revokes")
+def test_scratch_removal_survives_an_unwritable_directory(tmp_path: Path) -> None:
+    scratch = tmp_path / "scratch"
+    locked = scratch / "previous"
+    locked.mkdir(parents=True)
+    (locked / "graph.json").write_text("previous\n", encoding="utf-8")
+    locked.chmod(0o500)
+
+    try:
+        store._remove_scratch(scratch)
+    finally:
+        if locked.exists():
+            locked.chmod(0o700)
+
+    assert not scratch.exists()

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -680,21 +680,22 @@ def test_scratch_removal_never_widens_the_directory_it_sits_in(tmp_path: Path) -
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses the directory permissions this test revokes")
 def test_scratch_removal_never_follows_a_symlink_out_of_the_scratch(tmp_path: Path) -> None:
-    external = tmp_path / "external"
+    enclosing = tmp_path / "enclosing"  # a mode of its own, so widening it to S_IRWXU is visible
+    enclosing.mkdir()
+    external = enclosing / "external"
     external.mkdir()
     external.chmod(0o755)
+    enclosing.chmod(0o755)
     scratch = tmp_path / "scratch"
     locked = scratch / "previous"
     locked.mkdir(parents=True)
     (locked / "link").symlink_to(external)
     locked.chmod(0o500)
 
-    enclosing = stat.S_IMODE(tmp_path.lstat().st_mode)
-
     store._remove_scratch(scratch)
 
     assert stat.S_IMODE(external.lstat().st_mode) == 0o755
-    assert stat.S_IMODE(tmp_path.lstat().st_mode) == enclosing  # nor anything above the link's target
+    assert stat.S_IMODE(enclosing.lstat().st_mode) == 0o755  # nor anything above the link's target
     assert not scratch.exists()
 
 

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -675,3 +675,21 @@ def test_scratch_removal_never_widens_the_directory_it_sits_in(tmp_path: Path) -
         parent.chmod(0o700)
 
     assert mode == 0o500
+    assert not (scratch / "graph.json").exists()  # the cleanup ran; it just could not remove the root
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses the directory permissions this test revokes")
+def test_scratch_removal_never_follows_a_symlink_out_of_the_scratch(tmp_path: Path) -> None:
+    external = tmp_path / "external"
+    external.mkdir()
+    external.chmod(0o755)
+    scratch = tmp_path / "scratch"
+    locked = scratch / "previous"
+    locked.mkdir(parents=True)
+    (locked / "link").symlink_to(external)
+    locked.chmod(0o500)
+
+    store._remove_scratch(scratch)
+
+    assert stat.S_IMODE(external.lstat().st_mode) == 0o755
+    assert not scratch.exists()

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import stat
 import subprocess
 import tarfile
 from pathlib import Path
@@ -656,3 +657,21 @@ def test_scratch_removal_survives_an_unwritable_directory(tmp_path: Path) -> Non
             locked.chmod(0o700)
 
     assert not scratch.exists()
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses the directory permissions this test revokes")
+def test_scratch_removal_never_widens_the_directory_it_sits_in(tmp_path: Path) -> None:
+    parent = tmp_path / "worktree"
+    parent.mkdir()
+    scratch = parent / ".graphify-swap-probe"
+    scratch.mkdir()
+    (scratch / "graph.json").write_text("previous\n", encoding="utf-8")
+    parent.chmod(0o500)
+
+    try:
+        store._remove_scratch(scratch)
+        mode = stat.S_IMODE(parent.lstat().st_mode)
+    finally:
+        parent.chmod(0o700)
+
+    assert mode == 0o500

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -60,6 +60,55 @@ def publish(source: Path, store_root: Path, branch: str, sha: str) -> None:
     assert result.returncode == 0, result.stderr
 
 
+def make_target(root: Path) -> Path:
+    """A restore target whose graphify-out already holds a previous payload."""
+    root.mkdir()
+    payload = root / "graphify-out"
+    payload.mkdir()
+    (payload / "graph.json").write_text('{"version":"previous"}\n', encoding="utf-8")
+    (payload / "GRAPH_REPORT.md").write_text("previous report\n", encoding="utf-8")
+    return payload
+
+
+def make_payload(path: Path) -> Path:
+    """A canonical replacement payload."""
+    path.mkdir()
+    (path / "graph.json").write_text('{"version":"next"}\n', encoding="utf-8")
+    (path / "GRAPH_REPORT.md").write_text("next report\n", encoding="utf-8")
+    return path
+
+
+def fail_copy_of(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    """Fail the canonical copy of `name`, the way a full disk or a revoked permission would."""
+    original_copy2 = store.shutil.copy2
+
+    def failing_copy2(src: object, dst: object, **kwargs: object) -> object:
+        if Path(str(dst)).name == name:
+            raise OSError("injected copy failure")
+        return original_copy2(src, dst, **kwargs)
+
+    monkeypatch.setattr(store.shutil, "copy2", failing_copy2)
+
+
+def fail_replace_into(monkeypatch: pytest.MonkeyPatch, target: Path, sources: tuple[str, ...]) -> None:
+    """Fail the renames of `sources` into `target`, the way a concurrent writer would."""
+    original_replace = store.os.replace
+
+    def failing_replace(src: object, dst: object, **kwargs: object) -> object:
+        if Path(str(dst)) == target and Path(str(src)).name in sources:
+            raise OSError("injected replacement failure")
+        return original_replace(src, dst, **kwargs)
+
+    monkeypatch.setattr(store.os, "replace", failing_replace)
+
+
+def assert_previous_payload_intact(target_root: Path) -> None:
+    payload = target_root / "graphify-out"
+    assert (payload / "graph.json").read_text(encoding="utf-8") == '{"version":"previous"}\n'
+    assert (payload / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "previous report\n"
+    assert sorted(entry.name for entry in target_root.iterdir()) == ["graphify-out"]
+
+
 def test_publish_and_restore_keep_only_canonical_artifacts_and_source_tag(tmp_path: Path) -> None:
     source = tmp_path / "source tree"
     sha = make_repo(source)
@@ -527,45 +576,13 @@ def test_store_accepts_branch_names_as_opaque_refs(tmp_path: Path, branch: str) 
     )
 
 
-def make_target(root: Path) -> Path:
-    """A restore target whose graphify-out already holds a previous payload."""
-    root.mkdir()
-    payload = root / "graphify-out"
-    payload.mkdir()
-    (payload / "graph.json").write_text('{"version":"previous"}\n', encoding="utf-8")
-    (payload / "GRAPH_REPORT.md").write_text("previous report\n", encoding="utf-8")
-    return payload
-
-
-def make_payload(path: Path) -> Path:
-    """A canonical replacement payload."""
-    path.mkdir()
-    (path / "graph.json").write_text('{"version":"next"}\n', encoding="utf-8")
-    (path / "GRAPH_REPORT.md").write_text("next report\n", encoding="utf-8")
-    return path
-
-
-def assert_previous_payload_intact(target_root: Path) -> None:
-    payload = target_root / "graphify-out"
-    assert (payload / "graph.json").read_text(encoding="utf-8") == '{"version":"previous"}\n'
-    assert (payload / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "previous report\n"
-    assert sorted(entry.name for entry in target_root.iterdir()) == ["graphify-out"]
-
-
 def test_replace_keeps_previous_payload_when_a_canonical_copy_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     source = make_payload(tmp_path / "payload")
     target_root = tmp_path / "target"
     make_target(target_root)
-    original_copy2 = store.shutil.copy2
-
-    def failing_copy2(src: object, dst: object, **kwargs: object) -> object:
-        if Path(str(dst)).name == "GRAPH_REPORT.md":
-            raise OSError("injected copy failure")
-        return original_copy2(src, dst, **kwargs)
-
-    monkeypatch.setattr(store.shutil, "copy2", failing_copy2)
+    fail_copy_of(monkeypatch, "GRAPH_REPORT.md")
 
     with pytest.raises(OSError, match="injected copy failure"):
         store._replace_payload(source, target_root)
@@ -577,21 +594,28 @@ def test_replace_keeps_previous_payload_when_the_swap_fails(tmp_path: Path, monk
     source = make_payload(tmp_path / "payload")
     target_root = tmp_path / "target"
     target = make_target(target_root)
-    original_replace = store.os.replace
-    pending = {"failure": True}
-
-    def failing_replace(src: object, dst: object, **kwargs: object) -> object:
-        if pending["failure"] and Path(str(dst)) == target:
-            pending["failure"] = False
-            raise OSError("injected replacement failure")
-        return original_replace(src, dst, **kwargs)
-
-    monkeypatch.setattr(store.os, "replace", failing_replace)
+    fail_replace_into(monkeypatch, target, ("graphify-out",))
 
     with pytest.raises(OSError, match="injected replacement failure"):
         store._replace_payload(source, target_root)
 
     assert_previous_payload_intact(target_root)
+
+
+def test_replace_keeps_the_previous_payload_recoverable_when_the_rollback_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = make_payload(tmp_path / "payload")
+    target_root = tmp_path / "target"
+    target = make_target(target_root)
+    fail_replace_into(monkeypatch, target, ("graphify-out", "previous"))
+
+    with pytest.raises(store.StoreError, match="previous Graphify payload is kept at") as failure:
+        store._replace_payload(source, target_root)
+
+    kept = Path(str(failure.value).rsplit(" ", 1)[-1])
+    assert (kept / "graph.json").read_text(encoding="utf-8") == '{"version":"previous"}\n'
+    assert (kept / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "previous report\n"
 
 
 def test_publish_keeps_previous_store_payload_when_a_canonical_copy_fails(
@@ -605,14 +629,7 @@ def test_publish_keeps_previous_store_payload_when_a_canonical_copy_fails(
     (source / "graphify-out" / "GRAPH_REPORT.md").write_text("next report\n", encoding="utf-8")
     git(source, "commit", "-q", "-a", "-m", "next")
     next_sha = git(source, "rev-parse", "HEAD")
-    original_copy2 = store.shutil.copy2
-
-    def failing_copy2(src: object, dst: object, **kwargs: object) -> object:
-        if Path(str(dst)).name == "GRAPH_REPORT.md":
-            raise OSError("injected copy failure")
-        return original_copy2(src, dst, **kwargs)
-
-    monkeypatch.setattr(store.shutil, "copy2", failing_copy2)
+    fail_copy_of(monkeypatch, "GRAPH_REPORT.md")
 
     with pytest.raises(OSError, match="injected copy failure"):
         store.publish(store_root, source, "devel", next_sha)

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -689,7 +689,44 @@ def test_scratch_removal_never_follows_a_symlink_out_of_the_scratch(tmp_path: Pa
     (locked / "link").symlink_to(external)
     locked.chmod(0o500)
 
+    enclosing = stat.S_IMODE(tmp_path.lstat().st_mode)
+
     store._remove_scratch(scratch)
 
     assert stat.S_IMODE(external.lstat().st_mode) == 0o755
+    assert stat.S_IMODE(tmp_path.lstat().st_mode) == enclosing  # nor anything above the link's target
+    assert not scratch.exists()
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses the directory permissions this test revokes")
+def test_scratch_removal_never_chmods_a_hardlinked_file(tmp_path: Path) -> None:
+    external = tmp_path / "external.txt"
+    external.write_text("external\n", encoding="utf-8")
+    external.chmod(0o644)
+    scratch = tmp_path / "scratch"
+    locked = scratch / "previous"
+    locked.mkdir(parents=True)
+    os.link(external, locked / "link")
+    locked.chmod(0o500)
+
+    store._remove_scratch(scratch)
+
+    assert stat.S_IMODE(external.lstat().st_mode) == 0o644
+    assert not scratch.exists()
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses the directory permissions this test revokes")
+def test_scratch_removal_survives_an_unreadable_directory(tmp_path: Path) -> None:
+    scratch = tmp_path / "scratch"
+    unreadable = scratch / "previous"
+    unreadable.mkdir(parents=True)
+    (unreadable / "graph.json").write_text("previous\n", encoding="utf-8")
+    unreadable.chmod(0o000)
+
+    try:
+        store._remove_scratch(scratch)
+    finally:
+        if unreadable.exists():
+            unreadable.chmod(0o700)
+
     assert not scratch.exists()

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -525,3 +525,99 @@ def test_store_accepts_branch_names_as_opaque_refs(tmp_path: Path, branch: str) 
     assert (
         run_store("has-exact", "--store-root", str(store_root), "--branch", graph_branch, "--sha", sha).returncode == 0
     )
+
+
+def make_target(root: Path) -> Path:
+    """A restore target whose graphify-out already holds a previous payload."""
+    root.mkdir()
+    payload = root / "graphify-out"
+    payload.mkdir()
+    (payload / "graph.json").write_text('{"version":"previous"}\n', encoding="utf-8")
+    (payload / "GRAPH_REPORT.md").write_text("previous report\n", encoding="utf-8")
+    return payload
+
+
+def make_payload(path: Path) -> Path:
+    """A canonical replacement payload."""
+    path.mkdir()
+    (path / "graph.json").write_text('{"version":"next"}\n', encoding="utf-8")
+    (path / "GRAPH_REPORT.md").write_text("next report\n", encoding="utf-8")
+    return path
+
+
+def assert_previous_payload_intact(target_root: Path) -> None:
+    payload = target_root / "graphify-out"
+    assert (payload / "graph.json").read_text(encoding="utf-8") == '{"version":"previous"}\n'
+    assert (payload / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "previous report\n"
+    assert sorted(entry.name for entry in target_root.iterdir()) == ["graphify-out"]
+
+
+def test_replace_keeps_previous_payload_when_a_canonical_copy_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = make_payload(tmp_path / "payload")
+    target_root = tmp_path / "target"
+    make_target(target_root)
+    original_copy2 = store.shutil.copy2
+
+    def failing_copy2(src: object, dst: object, **kwargs: object) -> object:
+        if Path(str(dst)).name == "GRAPH_REPORT.md":
+            raise OSError("injected copy failure")
+        return original_copy2(src, dst, **kwargs)
+
+    monkeypatch.setattr(store.shutil, "copy2", failing_copy2)
+
+    with pytest.raises(OSError, match="injected copy failure"):
+        store._replace_payload(source, target_root)
+
+    assert_previous_payload_intact(target_root)
+
+
+def test_replace_keeps_previous_payload_when_the_swap_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = make_payload(tmp_path / "payload")
+    target_root = tmp_path / "target"
+    target = make_target(target_root)
+    original_replace = store.os.replace
+    pending = {"failure": True}
+
+    def failing_replace(src: object, dst: object, **kwargs: object) -> object:
+        if pending["failure"] and Path(str(dst)) == target:
+            pending["failure"] = False
+            raise OSError("injected replacement failure")
+        return original_replace(src, dst, **kwargs)
+
+    monkeypatch.setattr(store.os, "replace", failing_replace)
+
+    with pytest.raises(OSError, match="injected replacement failure"):
+        store._replace_payload(source, target_root)
+
+    assert_previous_payload_intact(target_root)
+
+
+def test_publish_keeps_previous_store_payload_when_a_canonical_copy_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    sha = make_repo(source)
+    store_root = tmp_path / "store"
+    publish(source, store_root, "devel", sha)
+    (source / "graphify-out" / "graph.json").write_text('{"version":"next"}\n', encoding="utf-8")
+    (source / "graphify-out" / "GRAPH_REPORT.md").write_text("next report\n", encoding="utf-8")
+    git(source, "commit", "-q", "-a", "-m", "next")
+    next_sha = git(source, "rev-parse", "HEAD")
+    original_copy2 = store.shutil.copy2
+
+    def failing_copy2(src: object, dst: object, **kwargs: object) -> object:
+        if Path(str(dst)).name == "GRAPH_REPORT.md":
+            raise OSError("injected copy failure")
+        return original_copy2(src, dst, **kwargs)
+
+    monkeypatch.setattr(store.shutil, "copy2", failing_copy2)
+
+    with pytest.raises(OSError, match="injected copy failure"):
+        store.publish(store_root, source, "devel", next_sha)
+
+    payload = store_root / "graphify-out"
+    assert (payload / "graph.json").read_text(encoding="utf-8") == '{"version":1}\n'
+    assert (payload / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "report\n"
+    assert git(store_root, "status", "--porcelain") == ""


### PR DESCRIPTION
## What

`scripts/agent/graphify-store.py` replaced the `graphify-out` payload destructively: it deleted the target directory, recreated it, and copied the canonical artifacts in one at a time. A failure partway through that copy loop destroyed the previous snapshot and left the target half-populated — reproduced in the issue by injecting a failure on the second `shutil.copy2` call.

This adds a single `_swap_payload()` primitive that stages the complete canonical payload in a scratch directory next to the target, moves the previous payload aside, and only then renames the staged payload into place. `restore-exact`, `seed` (both via `_replace_payload`) and `publish` all route through it, so the store's write path is transactional everywhere.

Failure handling, in the shape the adversarial review drove it to:

- A staging failure raises before the target is touched at all.
- A failed swap moves the previous payload back and re-raises the original error.
- If that rollback rename *also* fails, the scratch directory is deliberately **not** removed and a `StoreError` names the path where the previous payload is kept, chained to the original error so the real cause is not masked.
- On every other path the scratch is removed. Residue would otherwise make `git worktree remove` fail, which is exactly what `work-branch.sh` runs to roll back a failed restore, so the cleanup first walks the scratch and resets the permissions of the directories inside it — never a file, never a symlink, never anything outside the scratch — and then removes it with `ignore_errors=True`, so it can clear a mangled scratch without ever raising or touching the caller's directory. `.gitignore` also gained `.graphify-swap-*/` so a killed run cannot leave an untracked directory behind.

Scratch and target always share a parent directory, so the rename is same-filesystem.

## Acceptance criteria

- **Stage the complete canonical payload before replacing the target** — `_swap_payload()` copies every canonical artifact into the scratch payload before any rename touches the target.
- **Preserve the previous payload if staging or replacement fails** — covered for all three failure points above, including the rollback-fails case.
- **Cover copy failure and replacement failure with hostile tests** — nine new fault-injection tests, listed below.
- **Keep the store restricted to `graph.json` and `GRAPH_REPORT.md`** — the artifact list still comes from `_canonical_files()`; the existing canonical-artifact tests are unchanged and still pass.
- **Apply the same safe replacement primitive to restore/seed and publish** — all three call `_swap_payload()`; no other copy/delete path remains.

## Tests

New in `tests/test_graphify_store.py`:

- `test_replace_keeps_previous_payload_when_a_canonical_copy_fails` — fails the `GRAPH_REPORT.md` copy; asserts the previous payload's contents survive and no scratch directory is left behind.
- `test_replace_keeps_previous_payload_when_the_swap_fails` — fails the rename of the staged payload into the target; asserts the previous payload is moved back.
- `test_replace_keeps_the_previous_payload_recoverable_when_the_rollback_fails` — fails both renames; asserts the raised `StoreError` names a directory that still holds the previous payload.
- `test_publish_keeps_previous_store_payload_when_a_canonical_copy_fails` — fails the same copy during `publish`; asserts the store still holds the previously committed payload and that its working tree is clean.
- `test_scratch_removal_survives_an_unwritable_directory` — revokes write permission on a scratch subdirectory; asserts the cleanup still removes it (skipped under root, which bypasses the permission being tested).
- `test_scratch_removal_never_widens_the_directory_it_sits_in` — makes the scratch's own parent read-only; asserts the cleanup leaves that parent's mode untouched instead of widening it to reach the scratch, and that it still removed what it could (also skipped under root).
- `test_scratch_removal_never_follows_a_symlink_out_of_the_scratch` — puts a symlink to an external directory inside a permission-locked scratch subdirectory; asserts neither the external directory's mode nor its enclosing directory's is touched and the scratch is still removed (also skipped under root).
- `test_scratch_removal_never_chmods_a_hardlinked_file` — hardlinks an external file into a permission-locked scratch subdirectory; asserts the shared inode's mode is untouched (also skipped under root).
- `test_scratch_removal_survives_an_unreadable_directory` — makes a scratch subdirectory unreadable; asserts the cleanup still removes it instead of raising (also skipped under root).

Red→green proof, run with the final test file (byte-identical across both runs, sha256 `8f9a4afa7451ed48280b4c1849dec0a5eb749f1077b42e0e7cf3028f3056fac6`), against `origin/devel`'s `scripts/agent/graphify-store.py` and then against this branch's:

```
# pre-PR production file
$ uv run pytest tests/test_graphify_store.py -q
FAILED tests/test_graphify_store.py::test_replace_keeps_previous_payload_when_a_canonical_copy_fails
FAILED tests/test_graphify_store.py::test_replace_keeps_previous_payload_when_the_swap_fails
FAILED tests/test_graphify_store.py::test_replace_keeps_the_previous_payload_recoverable_when_the_rollback_fails
FAILED tests/test_graphify_store.py::test_publish_keeps_previous_store_payload_when_a_canonical_copy_fails
FAILED tests/test_graphify_store.py::test_scratch_removal_survives_an_unwritable_directory
FAILED tests/test_graphify_store.py::test_scratch_removal_never_widens_the_directory_it_sits_in
FAILED tests/test_graphify_store.py::test_scratch_removal_never_follows_a_symlink_out_of_the_scratch
FAILED tests/test_graphify_store.py::test_scratch_removal_never_chmods_a_hardlinked_file
FAILED tests/test_graphify_store.py::test_scratch_removal_survives_an_unreadable_directory
9 failed, 29 passed in 12.78s

# with the fix
$ uv run pytest tests/test_graphify_store.py -q
38 passed in 13.22s
```

`sh scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS`.

## Out of scope

The review also found that `graphify-store.py` never takes the store lock it depends on — the lock is held only by `work-branch.sh` and by the operator during the documented manual refresh. That is pre-existing and orthogonal; tracked in #2657.

Part of #2643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when restoring or publishing stored data by replacing payloads atomically.
  - Preserves the previous data if an update fails, reducing the risk of corruption or data loss.
  - Improved cleanup of temporary files and directories, including cases involving restricted permissions or filesystem links.

- **Chores**
  - Temporary swap files are now excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->