### PR TITLE
alerts: show whitelist plus on unlocked panel rows

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2203,6 +2203,60 @@ function dnsbl_whitelist_type($fields, $clists, $isExclusion, $isTLD, $qdomain) 
 }
 
 
+/**
+ * Action icons for one Unlocked IPs/Domains panel row (Alerts tab).
+ * Temporary unlock and permanent whitelist/suppression stay independent (issue #1526).
+ *
+ * @return array{alert: string, unlock: string, supp: string}
+ */
+function pfb_alerts_unlocked_entry_actions(string $kind, string $entry, string $type, array $clists): array
+{
+	$h_entry = pfb_hsc($entry);
+	$h_type  = pfb_hsc($type);
+
+	if ($kind === 'ip') {
+		$unlock = '<i class="fa-solid fa-unlock text-primary" id="IPLCK|' . $h_entry . '|' . $h_type
+			. '" title="Re-Lock IP: [ ' . $h_entry . ' ] back into Aliastable [ '
+			. $h_type . ' ]? "></i>';
+		$alert = '<a class="fa-solid fa-info icon-pointer" target="_blank" rel="noopener noreferrer"'
+			. ' href="/pfblockerng/pfblockerng_threats.php?host='
+			. $h_entry . '" title="Click for Threat source IP Lookup for [ ' . $h_entry . ' ]"></a>';
+		$vtype = (strpos($entry, ':') !== FALSE) ? '6' : '4';
+		$permit_option = '';
+		$wl = $clists['ipwhitelist' . $vtype] ?? NULL;
+		if (is_array($wl) && !empty($wl['options']) && is_array($wl['options'])) {
+			$permit_option = '|' . implode('|', $wl['options']);
+		}
+		$supp_txt = "Note:&emsp;The following IPv{$vtype} is temporarily unlocked:\n\n"
+			. "IP:&emsp;[ {$h_entry} ]\n"
+			. "IP Aliasname:&emsp;[ {$h_type} ]\n\n"
+			. "Whitelisting Options:\n\n"
+			. "1) Suppress the IP.\n"
+			. "2) Whitelist the IP to an existing 'Permit' Alias customlist.\n\n"
+			. "Click 'OK' to continue";
+		$supp = '<i class="fa-solid fa-plus icon-pointer" id="PFBIPSUP|' . 'add|' . $h_entry
+			. '|' . $h_type . $permit_option
+			. '" title="' . $supp_txt . '"></i>';
+	} else {
+		$unlock = '<i class="fa-solid fa-unlock text-primary" id="DNSBL_LCK|' . $h_entry . '|' . $h_type
+			. '" title="Re-Lock Domain: [ ' . $h_entry . ' ] back into DNSBL? "></i>';
+		$alert = '<a class="fa-solid fa-info icon-pointer" target="_blank" rel="noopener noreferrer"'
+			. ' href="/pfblockerng/pfblockerng_threats.php?domain='
+			. $h_entry . '" title="Click for Threat source Domain Lookup for [ ' . $h_entry . ' ]"></a>';
+		$supp_txt = "Whitelist [ {$h_entry} ]\n\n"
+			. "Note:&emsp;This will immediately remove the blocked Domain\n"
+			. "&emsp;&emsp;&emsp;&nbsp;and associated CNAMES from DNSBL.\n\n"
+			. "Whitelisting Options:\n\n"
+			. "1) Wildcard whitelist [ .{$h_entry} ]\n"
+			. "2) Whitelist only [ {$h_entry} ]\n";
+		$supp = '<i class="fa-solid fa-plus icon-pointer" id="DNSBLWT|' . 'add|'
+			. $h_entry . '|' . $h_type . '" title="' . $supp_txt . '"></i>';
+	}
+
+	return array('alert' => $alert, 'unlock' => $unlock, 'supp' => $supp);
+}
+
+
 // Function to convert dnsbl.log -> Reports Tab
 function convert_dnsbl_log($mode, $fields) {
 	global $pfb, $local_hosts, $dnsbl_int, $filterfieldsarray, $clists, $dnsbl_unlock, $dup, $counter,
@@ -3990,24 +4044,13 @@ if (!$alert_summary):
 			<tbody>
 	<?php
 			foreach ($data[0] as $entry => $type) {
-				if ($key == 0) {
-					$unlock = '<i class="fa-solid fa-unlock text-primary" id="IPLCK|' . htmlspecialchars($entry) . '|' . $type
-							. '" title="Re-Lock ' . htmlspecialchars($data[1]) . ': [ ' . htmlspecialchars($entry) . ' ] back into Aliastable [ '
-							. htmlspecialchars($type) . ' ]? "></i>';
+				$kind = ($key == 0) ? 'ip' : 'dnsbl';
+				$actions = pfb_alerts_unlocked_entry_actions($kind, (string) $entry, (string) $type, $clists);
+				$alert = $actions['alert'];
+				$unlock = $actions['unlock'];
+				$supp = $actions['supp'];
 
-					$alert = '<a class="fa-solid fa-info icon-pointer" target="_blank" rel="noopener noreferrer"'
-							. ' href="/pfblockerng/pfblockerng_threats.php?host='
-							. htmlspecialchars($entry) . '" title="Click for Threat source IP Lookup for [ ' . htmlspecialchars($entry) . ' ]"></a>';
-				} else {
-					$unlock = '<i class="fa-solid fa-unlock text-primary" id="DNSBL_LCK|' . htmlspecialchars($entry) . '|' . htmlspecialchars($type)
-							. '" title="Re-Lock ' . htmlspecialchars($data[1]) . ': [ ' . htmlspecialchars($entry) . ' ] back into DNSBL? "></i>';
-
-					$alert = '<a class="fa-solid fa-info icon-pointer" target="_blank" rel="noopener noreferrer"'
-							. ' href="/pfblockerng/pfblockerng_threats.php?domain='
-							. htmlspecialchars($entry) . '" title="Click for Threat source Domain Lookup for [ ' . htmlspecialchars($entry) . ' ]"></a>';
-				}
-
-				print ("<tr><td>&nbsp;{$alert}&emsp;{$unlock}&emsp;" . htmlspecialchars($entry) . "</td><td>" . htmlspecialchars($type) . "</td></tr>");
+				print ("<tr><td>&nbsp;{$alert}&emsp;{$unlock}&emsp;{$supp}&emsp;" . htmlspecialchars($entry) . "</td><td>" . htmlspecialchars($type) . "</td></tr>");
 			}
 	?>
 			</tbody>

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2204,8 +2204,25 @@ function dnsbl_whitelist_type($fields, $clists, $isExclusion, $isTLD, $qdomain) 
 
 
 /**
+ * `|alias…` suffix for PFBIPSUP / PFBIPWHITE ids from one family's `$clists` entry.
+ * Shared by the event-table suppression icon and the Unlocked panel.
+ */
+function pfb_alerts_permit_option_suffix($family): string
+{
+	if (!is_array($family) || empty($family['options']) || !is_array($family['options'])) {
+		return '';
+	}
+	return '|' . implode('|', $family['options']);
+}
+
+
+/**
  * Action icons for one Unlocked IPs/Domains panel row (Alerts tab).
  * Temporary unlock and permanent whitelist/suppression stay independent (issue #1526).
+ *
+ * Confirm-dialog titles shadow the event-table copies in convert_ip_log()
+ * `$supp_ip_txt` and dnsbl_whitelist_type() `$s_txt`, shortened for the panel
+ * (no feed/eval-IP, no Force-Update / CNAME parenthetical).
  *
  * @return array{alert: string, unlock: string, supp: string}
  */
@@ -2222,11 +2239,7 @@ function pfb_alerts_unlocked_entry_actions(string $kind, string $entry, string $
 			. ' href="/pfblockerng/pfblockerng_threats.php?host='
 			. $h_entry . '" title="Click for Threat source IP Lookup for [ ' . $h_entry . ' ]"></a>';
 		$vtype = (strpos($entry, ':') !== FALSE) ? '6' : '4';
-		$permit_option = '';
-		$wl = $clists['ipwhitelist' . $vtype] ?? NULL;
-		if (is_array($wl) && !empty($wl['options']) && is_array($wl['options'])) {
-			$permit_option = '|' . implode('|', $wl['options']);
-		}
+		$permit_option = pfb_alerts_permit_option_suffix($clists['ipwhitelist' . $vtype] ?? NULL);
 		$supp_txt = "Note:&emsp;The following IPv{$vtype} is temporarily unlocked:\n\n"
 			. "IP:&emsp;[ {$h_entry} ]\n"
 			. "IP Aliasname:&emsp;[ {$h_type} ]\n\n"
@@ -2249,8 +2262,9 @@ function pfb_alerts_unlocked_entry_actions(string $kind, string $entry, string $
 			. "Whitelisting Options:\n\n"
 			. "1) Wildcard whitelist [ .{$h_entry} ]\n"
 			. "2) Whitelist only [ {$h_entry} ]\n";
+		$tld_field = (strpos($type, 'TLD') !== FALSE) ? '|TLD' : '';
 		$supp = '<i class="fa-solid fa-plus icon-pointer" id="DNSBLWT|' . 'add|'
-			. $h_entry . '|' . $h_type . '" title="' . $supp_txt . '"></i>';
+			. $h_entry . '|' . $h_type . $tld_field . '" title="' . $supp_txt . '"></i>';
 	}
 
 	return array('alert' => $alert, 'unlock' => $unlock, 'supp' => $supp);
@@ -3037,10 +3051,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 
 			// Add Suppression/Whitelist Icon
 			if ($supp_ip_wl === NULL) {
-				$permit_option = '';
-				if ($clists['ipwhitelist' . $vtype]) {
-					$permit_option = '|' . implode('|', $clists['ipwhitelist' . $vtype]['options']);
-				}
+				$permit_option = pfb_alerts_permit_option_suffix($clists['ipwhitelist' . $vtype] ?? NULL);
 
 				$supp_ip_txt  = "Note:&emsp;The following IPv{$vtype} was blocked:\n\n"
 						. "Blocked IP:&emsp;&emsp;[ {$h_host} ]\n"
@@ -3130,7 +3141,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 						. "Click 'OK' to continue";
 
 				$supp_ip = '<i class="fa-solid fa-plus-circle icon-pointer" id="PFBIPWHITE|' . $h_host
-						. '|' . implode('|', $clists['ipwhitelist' . $vtype]['options'])
+						. pfb_alerts_permit_option_suffix($clists['ipwhitelist' . $vtype] ?? NULL)
 						. '" title="' . $supp_ip_txt . '"></i>';
 			}
 		}

--- a/tests/php/AlertsUnlockedRowWhitelistIconTest.php
+++ b/tests/php/AlertsUnlockedRowWhitelistIconTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('convert_dnsbl_log')]
 #[CoversFunction('dnsbl_whitelist_type')]
 #[CoversFunction('pfb_alerts_unlocked_entry_actions')]
+#[CoversFunction('pfb_alerts_permit_option_suffix')]
 final class AlertsUnlockedRowWhitelistIconTest extends TestCase
 {
 	private string $tmpDir;
@@ -313,6 +314,76 @@ final class AlertsUnlockedRowWhitelistIconTest extends TestCase
 			'DNSBLWT|add|' . $domain . '|DNSBL',
 			$html,
 			"issue #1526: Unlocked panel DNSBL row must show whitelist '+' next to Re-Lock, got:\n{$html}"
+		);
+		$this->assertStringNotContainsString(
+			'|TLD"',
+			$html,
+			"non-TLD unlock type must not add the TLD-exclusion id field, got:\n{$html}"
+		);
+	}
+
+	public function testUnlockedIpv6PanelRowUsesIpwhitelist6PermitOptions(): void
+	{
+		$GLOBALS['clists']['ipwhitelist6'] = [
+			'options' => ['Create new pfB_Whitelist_v6', 'pfB_Permit_v6'],
+		];
+		$host = '2001:db8::5';
+		$html = implode('', pfb_alerts_unlocked_entry_actions(
+			'ip',
+			$host,
+			'pfB_Deny_v6',
+			$GLOBALS['clists']
+		));
+
+		$this->assertStringContainsString(
+			'IPLCK|' . $host . '|pfB_Deny_v6',
+			$html,
+			"Unlocked panel v6 row must keep Re-Lock, got:\n{$html}"
+		);
+		$this->assertStringContainsString(
+			'PFBIPSUP|add|' . $host . '|pfB_Deny_v6|Create new pfB_Whitelist_v6|pfB_Permit_v6',
+			$html,
+			"v6 panel '+' must read ipwhitelist6 options (the live never-empty branch), got:\n{$html}"
+		);
+		$this->assertStringNotContainsString(
+			'ipwhitelist4',
+			$html,
+		);
+	}
+
+	public function testUnlockedIpv4PanelRowIncludesLivePermitOptions(): void
+	{
+		$GLOBALS['clists']['ipwhitelist4'] = [
+			'options' => ['Create new pfB_Whitelist_v4', 'pfB_Permit_v4'],
+		];
+		$html = implode('', pfb_alerts_unlocked_entry_actions(
+			'ip',
+			'192.0.2.11',
+			'pfB_Exact_v4',
+			$GLOBALS['clists']
+		));
+
+		$this->assertStringContainsString(
+			'PFBIPSUP|add|192.0.2.11|pfB_Exact_v4|Create new pfB_Whitelist_v4|pfB_Permit_v4',
+			$html,
+			"v4 panel '+' must carry the live permit-options suffix, got:\n{$html}"
+		);
+	}
+
+	public function testUnlockedTldPanelRowAddsTldExclusionIdField(): void
+	{
+		$domain = 'blocked.tld-unlock.example';
+		$html = implode('', pfb_alerts_unlocked_entry_actions(
+			'dnsbl',
+			$domain,
+			'DNSBL_TLD',
+			$GLOBALS['clists']
+		));
+
+		$this->assertStringContainsString(
+			'DNSBLWT|add|' . $domain . '|DNSBL_TLD|TLD',
+			$html,
+			"TLD unlock type must emit the 5th id field so JS offers TLD Exclusion, got:\n{$html}"
 		);
 	}
 }

--- a/tests/php/AlertsUnlockedRowWhitelistIconTest.php
+++ b/tests/php/AlertsUnlockedRowWhitelistIconTest.php
@@ -336,6 +336,9 @@ final class AlertsUnlockedRowWhitelistIconTest extends TestCase
 
 	public function testUnlockedIpv6PanelRowUsesIpwhitelist6PermitOptions(): void
 	{
+		$GLOBALS['clists']['ipwhitelist4'] = [
+			'options' => ['wrong-family-v4-sentinel'],
+		];
 		$GLOBALS['clists']['ipwhitelist6'] = [
 			'options' => ['Create new pfB_Whitelist_v6', 'pfB_Permit_v6'],
 		];
@@ -358,8 +361,9 @@ final class AlertsUnlockedRowWhitelistIconTest extends TestCase
 			"v6 panel '+' must read ipwhitelist6 options (the live never-empty branch), got:\n{$html}"
 		);
 		$this->assertStringNotContainsString(
-			'ipwhitelist4',
+			'wrong-family-v4-sentinel',
 			$html,
+			"v6 panel '+' must not pick ipwhitelist4 options, got:\n{$html}"
 		);
 	}
 

--- a/tests/php/AlertsUnlockedRowWhitelistIconTest.php
+++ b/tests/php/AlertsUnlockedRowWhitelistIconTest.php
@@ -315,6 +315,18 @@ final class AlertsUnlockedRowWhitelistIconTest extends TestCase
 			$html,
 			"issue #1526: Unlocked panel DNSBL row must show whitelist '+' next to Re-Lock, got:\n{$html}"
 		);
+	}
+
+	public function testUnlockedNonTldPanelRowOmitsTldExclusionIdField(): void
+	{
+		$domain = 'unlocked-panel.example.com';
+		$html = implode('', pfb_alerts_unlocked_entry_actions(
+			'dnsbl',
+			$domain,
+			'DNSBL',
+			$GLOBALS['clists']
+		));
+
 		$this->assertStringNotContainsString(
 			'|TLD"',
 			$html,

--- a/tests/php/AlertsUnlockedRowWhitelistIconTest.php
+++ b/tests/php/AlertsUnlockedRowWhitelistIconTest.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #1526: an Alerts-table row that is temporarily unlocked must still
+ * render the permanent whitelist/suppression "+" next to the lock/unlock
+ * icon. Temporary bypass and permanent whitelist are independent actions;
+ * unlocking must not hide "+".
+ *
+ * Harness: AlertsPageLoader off-appliance load of convert_ip_log() /
+ * convert_dnsbl_log() (same shape as AlertsIpUnlockIconTest /
+ * AlertsDnsblLoggedFieldsRenderTest). IP rows seed a deny-folder feed file
+ * so convert_ip_log() does not strip "+" via the 'Not listed!' gate.
+ */
+#[CoversFunction('convert_ip_log')]
+#[CoversFunction('convert_dnsbl_log')]
+#[CoversFunction('dnsbl_whitelist_type')]
+#[CoversFunction('pfb_alerts_unlocked_entry_actions')]
+final class AlertsUnlockedRowWhitelistIconTest extends TestCase
+{
+	private string $tmpDir;
+	private string $denydir;
+	private string $nativedir;
+	private string $ccdir;
+	private string $etdir;
+	private string $aliasdir;
+	private string $matchdir;
+	private string $matchgendir;
+
+	/** @var array<string, mixed> */
+	private array $savedGlobals = [];
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/AlertsPageLoader.php';
+		pfb_test_load_alerts_page_functions();
+	}
+
+	protected function setUp(): void
+	{
+		foreach ([
+			'pfb', 'continents', 'filterfieldsarray', 'clists', 'ip_unlock',
+			'dnsbl_unlock', 'local_hosts', 'dnsbl_int', 'counter', 'pfbentries',
+			'skipcount', 'dup', 'ipfilterlimit', 'ipfilterlimitentries',
+			'dnsblfilterlimit', 'dnsblfilterlimitentries', 'config',
+		] as $g) {
+			$this->savedGlobals[$g] = $GLOBALS[$g] ?? null;
+		}
+
+		$this->tmpDir      = sys_get_temp_dir() . '/pfb_unlock_wl_icon_' . bin2hex(random_bytes(6));
+		$this->denydir     = "{$this->tmpDir}/deny";
+		$this->nativedir   = "{$this->tmpDir}/native";
+		$this->ccdir       = "{$this->tmpDir}/geoip";
+		$this->etdir       = "{$this->tmpDir}/et";
+		$this->aliasdir    = "{$this->tmpDir}/alias";
+		$this->matchdir    = "{$this->tmpDir}/match";
+		$this->matchgendir = "{$this->matchdir}/generated";
+		foreach ([
+			$this->denydir, $this->nativedir, $this->ccdir, $this->etdir,
+			$this->aliasdir, $this->matchdir, $this->matchgendir,
+		] as $d) {
+			mkdir($d, 0777, TRUE);
+		}
+		file_put_contents("{$this->nativedir}/NativePlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchdir}/MatchPlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->matchgendir}/MatchGenPlaceholder.txt", "placeholder\n");
+		file_put_contents("{$this->aliasdir}/AliasPlaceholder.txt", "10.0.0.3\n");
+
+		$GLOBALS['pfb'] = [
+			'grep'             => '/usr/bin/grep',
+			'denydir'          => $this->denydir,
+			'nativedir'        => $this->nativedir,
+			'permitdir'        => "{$this->tmpDir}/permit",
+			'matchdir'         => $this->matchdir,
+			'matchgendir'      => $this->matchgendir,
+			'etdir'            => $this->etdir,
+			'ccdir'            => $this->ccdir,
+			'aliasdir'         => $this->aliasdir,
+			'filterlogentries' => FALSE,
+			'asn_reporting'    => 'disabled',
+			'supp'             => '',
+			'unidnsbl'         => '#f0f0f0',
+			'unidnsbl2'        => '#202020',
+			'uniupstream'      => '#f0f0f0',
+			'uniupstream2'     => '#202020',
+		];
+		$GLOBALS['continents'] = array_flip(array(
+			'pfB_Africa', 'pfB_Antarctica', 'pfB_Asia', 'pfB_Europe',
+			'pfB_NAmerica', 'pfB_Oceania', 'pfB_SAmerica', 'pfB_Top',
+		));
+		$GLOBALS['filterfieldsarray']     = [];
+		$GLOBALS['clists']               = [
+			'ipwhitelist4'   => [],
+			'ipwhitelist6'   => [],
+			'dnsbl'          => ['options' => []],
+			'dnsblwhitelist' => ['data' => []],
+		];
+		$GLOBALS['ip_unlock']            = [];
+		$GLOBALS['dnsbl_unlock']         = [];
+		$GLOBALS['local_hosts']          = [];
+		$GLOBALS['dnsbl_int']            = [];
+		$GLOBALS['counter']              = ['Block' => 0, 'DNSBL' => 0, 'Unified' => 0];
+		$GLOBALS['pfbentries']           = 1000;
+		$GLOBALS['skipcount']            = 0;
+		$GLOBALS['dup']                  = ['Block' => 0, 'DNSBL' => 0];
+		$GLOBALS['ipfilterlimit']        = FALSE;
+		$GLOBALS['ipfilterlimitentries'] = 0;
+		$GLOBALS['dnsblfilterlimit']     = FALSE;
+		$GLOBALS['dnsblfilterlimitentries'] = 100;
+		$GLOBALS['config']               = ['system' => ['webgui' => ['webguicss' => '']]];
+
+		pfb_ip_render_memos_reset();
+	}
+
+	protected function tearDown(): void
+	{
+		pfb_ip_render_memos_reset();
+
+		foreach ($this->savedGlobals as $g => $v) {
+			if ($v === null) {
+				unset($GLOBALS[$g]);
+			} else {
+				$GLOBALS[$g] = $v;
+			}
+		}
+
+		rmdir_recursive($this->tmpDir);
+	}
+
+	/** @param array<int, mixed> $overrides */
+	private function rawIpFields(array $overrides): array
+	{
+		$base = [
+			0  => '2026-07-17 00:00:00',
+			1  => 'rule1',
+			2  => 'em0',
+			3  => 'WAN',
+			4  => 'block',
+			5  => 4,
+			6  => 'tcp',
+			7  => 'TCP',
+			8  => '192.0.2.11',
+			9  => '198.51.100.1',
+			10 => '12345',
+			11 => '443',
+			12 => 'in',
+			13 => 'US',
+			14 => 'pfB_Default_v4',
+			15 => '192.0.2.11',
+			16 => 'DefaultFeed',
+			17 => '',
+			18 => '',
+			19 => 'Unknown',
+			20 => '',
+			21 => '',
+		];
+		return array_replace($base, $overrides);
+	}
+
+	/** @param array<int, mixed> $rawFields */
+	private function renderIp(array $rawFields): string
+	{
+		$GLOBALS['dup']['Block']     = 0;
+		$GLOBALS['counter']['Block'] = 0;
+		$GLOBALS['ipfilterlimit']    = FALSE;
+
+		ob_start();
+		convert_ip_log('non_unified', $rawFields, '', 'Block');
+		return (string) ob_get_clean();
+	}
+
+	/** @return array<int, mixed> */
+	private function dnsblFields(string $domain): array
+	{
+		return [
+			0  => 'DNSBL-Full',
+			1  => '2026-01-01 00:00:00',
+			2  => $domain,
+			3  => '10.0.0.5',
+			4  => '',
+			5  => 'DNSBL',
+			6  => 'LoggedGroup',
+			7  => $domain,
+			8  => 'LoggedFeed',
+			9  => 0,
+			10 => 'A',
+		];
+	}
+
+	/** @param array<int, mixed> $fields */
+	private function renderDnsbl(array $fields): string
+	{
+		$GLOBALS['dup']['DNSBL']         = 0;
+		$GLOBALS['counter']['DNSBL']     = 0;
+		$GLOBALS['dnsblfilterlimit']     = FALSE;
+
+		ob_start();
+		convert_dnsbl_log('non_unified', $fields);
+		return (string) ob_get_clean();
+	}
+
+	public function testLockedIpBlockRowRendersSuppressionPlus(): void
+	{
+		file_put_contents("{$this->denydir}/ExactFeed.txt", "192.0.2.11\n");
+		$fields = $this->rawIpFields([
+			8 => '192.0.2.11', 15 => '192.0.2.11',
+			14 => 'pfB_Exact_v4', 16 => 'ExactFeed',
+		]);
+
+		$html = $this->renderIp($fields);
+
+		$this->assertStringContainsString(
+			'PFBIPSUP|add|192.0.2.11|pfB_Exact_v4',
+			$html,
+			"locked Block row must keep the suppression '+' (baseline), got:\n{$html}"
+		);
+	}
+
+	public function testUnlockedIpBlockRowStillRendersSuppressionPlusBesideRelock(): void
+	{
+		file_put_contents("{$this->denydir}/ExactFeed.txt", "192.0.2.11\n");
+		$GLOBALS['ip_unlock'] = ['192.0.2.11' => 'pfB_Exact_v4'];
+		$fields = $this->rawIpFields([
+			8 => '192.0.2.11', 15 => '192.0.2.11',
+			14 => 'pfB_Exact_v4', 16 => 'ExactFeed',
+		]);
+
+		$html = $this->renderIp($fields);
+
+		$this->assertStringContainsString(
+			'IPLCK|192.0.2.11|pfB_Exact_v4',
+			$html,
+			"unlocked Block row must show Re-Lock, got:\n{$html}"
+		);
+		$this->assertStringContainsString(
+			'PFBIPSUP|add|192.0.2.11|pfB_Exact_v4',
+			$html,
+			"issue #1526: unlocked Block row must still show suppression '+' next to Re-Lock, got:\n{$html}"
+		);
+	}
+
+	public function testLockedDnsblRowRendersWhitelistPlus(): void
+	{
+		$domain = 'locked-wl.example.com';
+		$html   = $this->renderDnsbl($this->dnsblFields($domain));
+
+		$this->assertStringContainsString(
+			'DNSBLWT|add|' . $domain,
+			$html,
+			"locked DNSBL row must keep whitelist '+', got:\n{$html}"
+		);
+	}
+
+	public function testUnlockedDnsblRowStillRendersWhitelistPlusBesideRelock(): void
+	{
+		$domain = 'unlocked-wl.example.com';
+		$GLOBALS['dnsbl_unlock'] = [$domain => 'DNSBL'];
+		$html = $this->renderDnsbl($this->dnsblFields($domain));
+
+		$this->assertStringContainsString(
+			'DNSBL_LCK|' . $domain . '|DNSBL',
+			$html,
+			"unlocked DNSBL row must show Re-Lock, got:\n{$html}"
+		);
+		$this->assertStringContainsString(
+			'DNSBLWT|add|' . $domain,
+			$html,
+			"issue #1526: unlocked DNSBL row must still show whitelist '+' next to Re-Lock, got:\n{$html}"
+		);
+	}
+
+	public function testUnlockedIpPanelRowRendersSuppressionPlusBesideRelock(): void
+	{
+		$html = implode('', pfb_alerts_unlocked_entry_actions(
+			'ip',
+			'192.0.2.11',
+			'pfB_Exact_v4',
+			$GLOBALS['clists']
+		));
+
+		$this->assertStringContainsString(
+			'IPLCK|192.0.2.11|pfB_Exact_v4',
+			$html,
+			"Unlocked panel IP row must keep Re-Lock, got:\n{$html}"
+		);
+		$this->assertStringContainsString(
+			'PFBIPSUP|add|192.0.2.11|pfB_Exact_v4',
+			$html,
+			"issue #1526: Unlocked panel IP row must show suppression '+' next to Re-Lock, got:\n{$html}"
+		);
+	}
+
+	public function testUnlockedDnsblPanelRowRendersWhitelistPlusBesideRelock(): void
+	{
+		$domain = 'unlocked-panel.example.com';
+		$html = implode('', pfb_alerts_unlocked_entry_actions(
+			'dnsbl',
+			$domain,
+			'DNSBL',
+			$GLOBALS['clists']
+		));
+
+		$this->assertStringContainsString(
+			'DNSBL_LCK|' . $domain . '|DNSBL',
+			$html,
+			"Unlocked panel DNSBL row must keep Re-Lock, got:\n{$html}"
+		);
+		$this->assertStringContainsString(
+			'DNSBLWT|add|' . $domain . '|DNSBL',
+			$html,
+			"issue #1526: Unlocked panel DNSBL row must show whitelist '+' next to Re-Lock, got:\n{$html}"
+		);
+	}
+}

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -2448,3 +2448,93 @@ def test_ipv6_alert_external_host_attribution(
             f"Failed to restore {ip_block_log!r} to size={original_size!r}: "
             f"rc={truncate_result.returncode}, stderr={truncate_result.stderr!r}"
         )
+
+
+def _read_guest_file(vm: helpers.SmokeVM, path: str) -> str | None:
+    result = vm.ssh("cat", path)
+    if result.returncode == 0:
+        return result.stdout
+    if vm.ssh("test", "!", "-e", path).returncode == 0:
+        return None
+    raise RuntimeError(f"failed to read {path}: {result.stderr!r}")
+
+
+def _write_or_remove_guest_file(vm: helpers.SmokeVM, path: str, content: str | None) -> None:
+    if content is None:
+        result = vm.ssh("rm", "-f", path)
+        if result.returncode != 0:
+            raise RuntimeError(f"failed to remove {path}: {result.stderr!r}")
+        return
+    result = subprocess.run(
+        vm.ssh_argv("tee", path),
+        input=content,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"failed to write {path}: {result.stderr!r}")
+
+
+def _unlocked_panel_html(page_html: str) -> str:
+    """Slice the Unlocked IP(s) & Domain(s) panel out of an Alerts GET body.
+
+    The panel is the page-template print() this PR changed; helper-only PHPUnit
+    does not execute it. Missing heading means the panel did not render.
+    """
+    marker = "Unlocked IP(s) & Domain(s)"
+    idx = page_html.find(marker)
+    assert idx != -1, "Unlocked panel heading missing from Alerts GET"
+    return page_html[idx : idx + 8000]
+
+
+def test_unlocked_panel_renders_whitelist_plus_next_to_relock(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """issue #1526: Unlocked panel rows show suppression/whitelist plus beside re-lock.
+
+    The panel reads only the unlock stores. Seed both stores (the state after a
+    successful unlock POST), GET Alerts so the page-template print() runs, isolate
+    that panel, and assert plus + re-lock ids for one IP and one domain.
+
+    Given: unlock stores do not list the test host/domain.
+    When: the stores record them and Alerts is GET-ted.
+    Then: the Unlocked panel HTML contains IPLCK + PFBIPSUP for the host and
+        DNSBL_LCK + DNSBLWT|add for the domain.
+    """
+    vm = smoke_vm
+    host = "198.51.100.77"
+    table = "pfB_Deny_v4"
+    domain = "ui1526panel.example.com"
+    dnsbl_type = "python"
+
+    ip_before = _read_guest_file(vm, IP_UNLOCK_STORE)
+    dnsbl_before = _read_guest_file(vm, DNSBL_UNLOCK_STORE)
+    try:
+        pre = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(pre.text), "alerts GET returned login form before seeding (session lost)"
+        assert f"PFBIPSUP|add|{host}|{table}" not in pre.text, (
+            f"Precondition failed: panel plus for {host} already present"
+        )
+        assert f"DNSBLWT|add|{domain}" not in pre.text, f"Precondition failed: panel plus for {domain} already present"
+
+        _write_or_remove_guest_file(vm, IP_UNLOCK_STORE, f"{host},{table}\n")
+        _write_or_remove_guest_file(vm, DNSBL_UNLOCK_STORE, f"{domain},{dnsbl_type}\n")
+
+        resp = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(resp.text), "alerts GET returned login form after seeding (session lost)"
+        panel = _unlocked_panel_html(resp.text)
+
+        assert f"IPLCK|{host}|{table}" in panel, f"Unlocked panel missing Re-Lock for {host}: {panel!r}"
+        assert f"PFBIPSUP|add|{host}|{table}" in panel, (
+            f"issue #1526: Unlocked panel missing suppression plus for {host}: {panel!r}"
+        )
+        assert f"DNSBL_LCK|{domain}|{dnsbl_type}" in panel, f"Unlocked panel missing Re-Lock for {domain}: {panel!r}"
+        assert f"DNSBLWT|add|{domain}|{dnsbl_type}" in panel, (
+            f"issue #1526: Unlocked panel missing whitelist plus for {domain}: {panel!r}"
+        )
+    finally:
+        _write_or_remove_guest_file(vm, IP_UNLOCK_STORE, ip_before)
+        _write_or_remove_guest_file(vm, DNSBL_UNLOCK_STORE, dnsbl_before)

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -2489,6 +2489,7 @@ def _unlocked_panel_html(page_html: str) -> str:
     return page_html[idx : idx + 8000]
 
 
+@pytest.mark.ui_render
 def test_unlocked_panel_renders_whitelist_plus_next_to_relock(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
@@ -2505,8 +2506,8 @@ def test_unlocked_panel_renders_whitelist_plus_next_to_relock(
         DNSBL_LCK + DNSBLWT|add for the domain.
     """
     vm = smoke_vm
-    host = "198.51.100.77"
-    table = "pfB_Deny_v4"
+    host = "203.0.113.77"
+    table = "pfB_Exact_v4"
     domain = "ui1526panel.example.com"
     dnsbl_type = "python"
 


### PR DESCRIPTION
Fixes #1526.

## Problem

Unlocking an IP or domain on Alerts hid the permanent whitelist/suppression `+` until the entry was relocked. Event-row converters already drew `+` next to lock/unlock. After unlock, the **Unlocked IP(s) & Domain(s)** panel at the top of the page only rendered info + re-lock, so that was the row operators used next.

Temporary bypass and permanent whitelist are independent actions.

## Change

- Add `pfb_alerts_unlocked_entry_actions()` for Unlocked-panel row icons.
- Panel rows emit `PFBIPSUP|add|<host>|<table>[|<permit aliases>…]` and `DNSBLWT|add|<domain>|<unlock type>[|TLD]`.
- DNSBL panel 4th id field is the **unlock block type** (python / DNSBL / DNSBL_TLD), not the event-table feed name. `addwhitelistdom` only presence-validates that field. TLD types also emit a 5th `TLD` field so the existing click handler offers TLD Exclusion.
- `pfb_alerts_permit_option_suffix()` is shared with the event-table suppression/whitelist ids.

## Tests

- `tests/php/AlertsUnlockedRowWhitelistIconTest.php` — panel helper (including v6 and live permit-options) plus converter pins that event rows already kept `+` while unlocked.
- `tests/smoke/ui/test_alerts.py::test_unlocked_panel_renders_whitelist_plus_next_to_relock` — GET Alerts after seeding unlock stores; asserts plus + re-lock **inside the Unlocked panel HTML** (executes the page-template `print()`, not only the helper).

Live-VM smoke is run outside this session.

## Review

Adversarial review is for Claude. Do not request Copilot code review.

🤖 Generated by Grok and posted on behalf of @BBcan177.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added suppression and whitelist actions to unlocked IP and domain entries alongside re-lock controls.
  * Added support for IPv4, IPv6, and TLD-specific permit options.

* **Bug Fixes**
  * Preserved suppression and whitelist controls when entries are unlocked.
  * Ensured TLD exclusion fields appear only for applicable entries.

* **Tests**
  * Added automated coverage for locked and unlocked alert rows and panels.
  * Added end-to-end validation of the updated Alerts panel controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->