### PR TITLE
graphify-store: take the store lock in the writer

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -20,14 +20,14 @@ Load when: every agent session, from `AGENTS.md`.
   available—for exact symbols, definitions, references, implementations,
   call/type hierarchy, diagnostics, and diagnostic-aware refactoring.
 - `work-branch.sh --worktree` restores an exact source-SHA snapshot from the local
-  Graphify store. `GRAPHIFY-REFRESH-REQUIRED` means hold `.git/graphify-store.lock`
-  in one harness-tracked `lockf`/`flock` session; create a temporary detached builder
+  Graphify store. `GRAPHIFY-REFRESH-REQUIRED` means create a temporary detached builder
   at the reported source SHA; run `graphify-store.py seed`, then
   `graphify-store.py validate-builder --builder .`, then refresh with Graphify 0.9.48
   using `PYTHONHASHSEED=0 GRAPHIFY_VIZ_NODE_LIMIT=0 graphify extract . --code-only --force`;
   run
-  `graphify cluster-only . --no-viz --no-label`, then run `graphify-store.py publish`;
-  release/remove the builder and retry. The store
+  `graphify cluster-only . --no-viz --no-label`, then run `graphify-store.py publish`,
+  which takes `.git/graphify-store.lock` itself for the store mutation, so the refresh
+  needs no hand-held lock; remove the builder and retry. The store
   archives exactly `graph.json` and `GRAPH_REPORT.md` and rejects a refresh when
   `graphify-out/memory` is present; other non-canonical roots are filtered out.
 - Canonical refreshes use `PYTHONHASHSEED=0 GRAPHIFY_VIZ_NODE_LIMIT=0 graphify

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -26,8 +26,10 @@ Load when: every agent session, from `AGENTS.md`.
   using `PYTHONHASHSEED=0 GRAPHIFY_VIZ_NODE_LIMIT=0 graphify extract . --code-only --force`;
   run
   `graphify cluster-only . --no-viz --no-label`, then run `graphify-store.py publish`,
-  which takes `.git/graphify-store.lock` itself for the store mutation, so the refresh
-  needs no hand-held lock; remove the builder and retry. The store
+  which takes `.git/graphify-store.lock` itself, so the refresh needs no hand-held lock.
+  Only that mutation is serialised: a `work-branch.sh --worktree` started mid-refresh
+  reports `GRAPHIFY-REFRESH-REQUIRED` rather than waiting, and refreshes in parallel.
+  Remove the builder and retry. The store
   archives exactly `graph.json` and `GRAPH_REPORT.md` and rejects a refresh when
   `graphify-out/memory` is present; other non-canonical roots are filtered out.
 - Canonical refreshes use `PYTHONHASHSEED=0 GRAPHIFY_VIZ_NODE_LIMIT=0 graphify

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -26,10 +26,10 @@ Load when: every agent session, from `AGENTS.md`.
   using `PYTHONHASHSEED=0 GRAPHIFY_VIZ_NODE_LIMIT=0 graphify extract . --code-only --force`;
   run
   `graphify cluster-only . --no-viz --no-label`, then run `graphify-store.py publish`,
-  which takes `.git/graphify-store.lock` itself, so the refresh needs no hand-held lock.
-  Only that mutation is serialised: a `work-branch.sh --worktree` started mid-refresh
-  reports `GRAPHIFY-REFRESH-REQUIRED` rather than waiting, and refreshes in parallel.
-  Remove the builder and retry. The store
+  which takes `.git/graphify-store.lock` itself, so the refresh needs no hand-held lock;
+  a `work-branch.sh --worktree` started while the extract runs reports
+  `GRAPHIFY-REFRESH-REQUIRED` and refreshes in parallel, and one that lands inside
+  `publish` waits on that lock. Remove the builder and retry. The store
   archives exactly `graph.json` and `GRAPH_REPORT.md` and rejects a refresh when
   `graphify-out/memory` is present; other non-canonical roots are filtered out.
 - Canonical refreshes use `PYTHONHASHSEED=0 GRAPHIFY_VIZ_NODE_LIMIT=0 graphify

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import contextlib
 import fcntl
 import os
 import re
@@ -14,7 +13,6 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-from collections.abc import Iterator
 from pathlib import Path
 
 SHA_RE = re.compile(r"^[0-9a-fA-F]{40,64}$")
@@ -64,7 +62,6 @@ def _store_root(path: Path) -> Path:
 
 
 def _ensure_store(path: Path) -> Path:
-    path = _store_root(path)
     if path.exists() and not path.is_dir():
         raise StoreError(f"Graphify store root is not a directory: {path}")
     if not path.exists():
@@ -76,30 +73,6 @@ def _ensure_store(path: Path) -> Path:
     if not path.is_dir() or _run(path, "rev-parse", "--is-inside-work-tree", check=False).stdout.strip() != "true":
         raise StoreError(f"not a normal Git repository: {path}")
     return path
-
-
-@contextlib.contextmanager
-def _store_lock(store_root: Path) -> Iterator[None]:
-    """Serialise store mutation against every other caller of the same store.
-
-    The lock is the store root's sibling `<store-root>.lock`, which is the very
-    `.git/graphify-store.lock` that `work-branch.sh` takes, so a self-locking publish and
-    a locking caller exclude each other. Only the writer takes it: the read paths run
-    *under* a caller's own hold of that same lock, and flock(2) ties a lock to the open
-    file description, so a second one taken there would deadlock against its own caller.
-    """
-    lock = store_root.parent / f"{store_root.name}.lock"
-    lock.parent.mkdir(parents=True, exist_ok=True)
-    handle = os.open(lock, os.O_CREAT | os.O_RDWR | os.O_CLOEXEC, 0o644)
-    try:
-        try:
-            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            print(f"graphify-store: waiting for the store lock {lock}", file=sys.stderr)
-            fcntl.flock(handle, fcntl.LOCK_EX)
-        yield
-    finally:
-        os.close(handle)
 
 
 def _source_payload(builder: Path) -> Path:
@@ -276,7 +249,25 @@ def publish(store_root: Path, builder: Path, branch: str, sha: str) -> None:
     if head != sha:
         raise StoreError(f"builder HEAD {head} does not match source SHA {sha}")
     store_root = _store_root(store_root)
-    with _store_lock(store_root):
+    # Serialise the one command that mutates the store. The lock is the store root's sibling
+    # `<store-root>.lock`, which is the `.git/graphify-store.lock` that `work-branch.sh` takes,
+    # so a publish and a locking caller exclude each other. The read paths stay lock-free:
+    # `git archive <commit>` reads the object database, never the store's worktree or index.
+    # `has-exact` and `restore-exact` must also stay lock-free because `work-branch.sh` invokes
+    # them while holding this lock, and flock(2) binds a lock to the open file description, so
+    # a second one taken there would block against their own caller for ever.
+    lock = store_root.parent / f"{store_root.name}.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        handle = os.open(lock, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o644)
+    except OSError as error:
+        raise StoreError(f"cannot open the Graphify store lock: {lock}") from error
+    try:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print(f"graphify-store: waiting for the store lock {lock}", file=sys.stderr)
+            fcntl.flock(handle, fcntl.LOCK_EX)
         store = _ensure_store(store_root)
         _valid_branch(store, branch)
         if _branch_exists(store, branch):
@@ -291,6 +282,8 @@ def publish(store_root: Path, builder: Path, branch: str, sha: str) -> None:
         if _run(store, "diff", "--cached", "--quiet", check=False).returncode:
             _run(store, "commit", "--quiet", "-m", sha)
         _run(store, "tag", "--force", _tag(branch, sha), branch)
+    finally:
+        os.close(handle)
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -257,8 +257,8 @@ def publish(store_root: Path, builder: Path, branch: str, sha: str) -> None:
     # them while holding this lock, and flock(2) binds a lock to the open file description, so
     # a second one taken there would block against their own caller for ever.
     lock = store_root.parent / f"{store_root.name}.lock"
-    lock.parent.mkdir(parents=True, exist_ok=True)
     try:
+        lock.parent.mkdir(parents=True, exist_ok=True)
         handle = os.open(lock, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o644)
     except OSError as error:
         raise StoreError(f"cannot open the Graphify store lock: {lock}") from error

--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import os
 import re
 import shutil
@@ -12,6 +14,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 
 SHA_RE = re.compile(r"^[0-9a-fA-F]{40,64}$")
@@ -73,6 +76,30 @@ def _ensure_store(path: Path) -> Path:
     if not path.is_dir() or _run(path, "rev-parse", "--is-inside-work-tree", check=False).stdout.strip() != "true":
         raise StoreError(f"not a normal Git repository: {path}")
     return path
+
+
+@contextlib.contextmanager
+def _store_lock(store_root: Path) -> Iterator[None]:
+    """Serialise store mutation against every other caller of the same store.
+
+    The lock is the store root's sibling `<store-root>.lock`, which is the very
+    `.git/graphify-store.lock` that `work-branch.sh` takes, so a self-locking publish and
+    a locking caller exclude each other. Only the writer takes it: the read paths run
+    *under* a caller's own hold of that same lock, and flock(2) ties a lock to the open
+    file description, so a second one taken there would deadlock against its own caller.
+    """
+    lock = store_root.parent / f"{store_root.name}.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    handle = os.open(lock, os.O_CREAT | os.O_RDWR | os.O_CLOEXEC, 0o644)
+    try:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print(f"graphify-store: waiting for the store lock {lock}", file=sys.stderr)
+            fcntl.flock(handle, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(handle)
 
 
 def _source_payload(builder: Path) -> Path:
@@ -248,20 +275,22 @@ def publish(store_root: Path, builder: Path, branch: str, sha: str) -> None:
     head = _run(builder, "rev-parse", "HEAD").stdout.strip()
     if head != sha:
         raise StoreError(f"builder HEAD {head} does not match source SHA {sha}")
-    store = _ensure_store(store_root)
-    _valid_branch(store, branch)
-    if _branch_exists(store, branch):
-        _run(store, "switch", "--quiet", branch)
-    else:
-        _run(store, "switch", "--quiet", "--create", branch)
-    target = store / "graphify-out"
-    if target.is_symlink() or (target.exists() and not target.is_dir()):
-        raise StoreError(f"refusing unmanaged store payload: {target}")
-    _swap_payload(artifacts, target)
-    _run(store, "add", "-A", "--", "graphify-out")
-    if _run(store, "diff", "--cached", "--quiet", check=False).returncode:
-        _run(store, "commit", "--quiet", "-m", sha)
-    _run(store, "tag", "--force", _tag(branch, sha), branch)
+    store_root = _store_root(store_root)
+    with _store_lock(store_root):
+        store = _ensure_store(store_root)
+        _valid_branch(store, branch)
+        if _branch_exists(store, branch):
+            _run(store, "switch", "--quiet", branch)
+        else:
+            _run(store, "switch", "--quiet", "--create", branch)
+        target = store / "graphify-out"
+        if target.is_symlink() or (target.exists() and not target.is_dir()):
+            raise StoreError(f"refusing unmanaged store payload: {target}")
+        _swap_payload(artifacts, target)
+        _run(store, "add", "-A", "--", "graphify-out")
+        if _run(store, "diff", "--cached", "--quiet", check=False).returncode:
+            _run(store, "commit", "--quiet", "-m", sha)
+        _run(store, "tag", "--force", _tag(branch, sha), branch)
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -188,6 +188,7 @@ def test_repository_intelligence_routes_worktrees_through_exact_graph_seeds() ->
         "graphify-store.py seed",
         "graphify-store.py validate-builder --builder .",
         "graphify-store.py publish",
+        "takes `.git/graphify-store.lock` itself",
         "source SHA",
         "graphify-out/graph.json",
         "graphify-out/GRAPH_REPORT.md",
@@ -205,7 +206,7 @@ def test_repository_intelligence_routes_worktrees_through_exact_graph_seeds() ->
         "ignored and untracked",
     ):
         assert contract in routing, f"Graphify worktree routing lost {contract}"
-    recipe = routing.split("`GRAPHIFY-REFRESH-REQUIRED`", 1)[1].split("release/remove", 1)[0]
+    recipe = routing.split("`GRAPHIFY-REFRESH-REQUIRED`", 1)[1].split("remove the builder", 1)[0]
     steps = (
         "graphify-store.py seed",
         "graphify-store.py validate-builder --builder .",

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -206,7 +206,11 @@ def test_repository_intelligence_routes_worktrees_through_exact_graph_seeds() ->
         "ignored and untracked",
     ):
         assert contract in routing, f"Graphify worktree routing lost {contract}"
-    recipe = routing.split("`GRAPHIFY-REFRESH-REQUIRED`", 1)[1].split("remove the builder", 1)[0]
+    tail = routing.split("`GRAPHIFY-REFRESH-REQUIRED`", 1)[1]
+    # index(), not split(): a split on a terminator the doc no longer spells this way returns
+    # the whole tail and silently stops bounding the recipe, which is how the terminator
+    # drifted out of the assertion once already.
+    recipe = tail[: tail.index("Remove the builder")]
     steps = (
         "graphify-store.py seed",
         "graphify-store.py validate-builder --builder .",

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -820,3 +820,91 @@ def test_reads_never_block_on_the_store_lock_their_caller_holds(tmp_path: Path) 
     assert has_exact.returncode == 0, has_exact.stderr
     assert restore.returncode == 0, restore.stderr
     assert (target / "graphify-out" / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "report\n"
+
+
+def test_a_second_publish_waits_for_the_lock_instead_of_racing_or_dying(tmp_path: Path) -> None:
+    """Scenario: a publish starts while another caller already holds the store lock.
+
+    Given `work-branch.sh`'s own idiom -- an exclusive hold on `.git/graphify-store.lock` --
+    When a second caller publishes into that store,
+    Then it announces the wait and leaves the store untouched until the hold is released,
+    and only then completes; it neither races the holder nor dies on contention (#2657).
+    """
+    source = tmp_path / "source"
+    sha = make_repo(source)
+    store_root = tmp_path / ".git" / "graphify-store"
+    lock = tmp_path / ".git" / "graphify-store.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+
+    handle = os.open(lock, os.O_CREAT | os.O_RDWR, 0o644)
+    fcntl.flock(handle, fcntl.LOCK_EX)
+    waiting = subprocess.Popen(
+        [
+            "python3",
+            str(SCRIPT),
+            "publish",
+            "--store-root",
+            str(store_root),
+            "--builder",
+            str(source),
+            "--branch",
+            "devel",
+            "--sha",
+            sha,
+        ],
+        text=True,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert waiting.stderr is not None
+        # The announcement IS the synchronisation event: it is emitted from the contended
+        # branch itself, so consuming it proves the second caller reached the wait. An
+        # unblocked publish exits instead and readline() returns "" at EOF.
+        announced = waiting.stderr.readline()
+        assert "waiting for the store lock" in announced, f"second publish did not wait: {announced!r}"
+        assert not store_root.exists(), "the second publish mutated the store under a foreign hold"
+    finally:
+        fcntl.flock(handle, fcntl.LOCK_UN)
+        os.close(handle)
+
+    # The timeout is a salvage cap for a hang, never the assertion.
+    assert waiting.wait(timeout=60) == 0, waiting.stderr.read()
+    waiting.stderr.close()
+    assert (store_root / "graphify-out" / "graph.json").exists()
+    assert lock_state(lock) == "free", "the lock outlived the publish that took it"
+
+
+@pytest.mark.parametrize("lock_kind", ["directory", "symlink"])
+def test_an_unusable_store_lock_is_reported_without_a_traceback(tmp_path: Path, lock_kind: str) -> None:
+    """The lock open is the one path in this module that could follow a symlink out of the
+    store or crash on a stray directory; both must fail the way every other rejection here
+    does -- one `graphify-store:` line, no traceback (#2657).
+    """
+    source = tmp_path / "source"
+    sha = make_repo(source)
+    store_root = tmp_path / ".git" / "graphify-store"
+    lock = tmp_path / ".git" / "graphify-store.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside"
+    if lock_kind == "directory":
+        lock.mkdir()
+    else:
+        lock.symlink_to(outside)
+
+    result = run_store(
+        "publish",
+        "--store-root",
+        str(store_root),
+        "--builder",
+        str(source),
+        "--branch",
+        "devel",
+        "--sha",
+        sha,
+    )
+
+    assert result.returncode == 1, result.stdout
+    assert result.stderr.startswith("graphify-store: "), result.stderr
+    assert "Traceback" not in result.stderr, result.stderr
+    assert not store_root.exists(), "a rejected publish must not create the store"
+    assert not outside.exists(), "the lock open must not follow a symlink out of the store"

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import fcntl
 import importlib.util
 import os
+import select
 import stat
 import subprocess
 import tarfile
@@ -855,41 +856,53 @@ def test_a_second_publish_waits_for_the_lock_instead_of_racing_or_dying(tmp_path
         text=True,
         stderr=subprocess.PIPE,
     )
+    stderr = waiting.stderr
+    assert stderr is not None
     try:
-        assert waiting.stderr is not None
-        # The announcement IS the synchronisation event: it is emitted from the contended
-        # branch itself, so consuming it proves the second caller reached the wait. An
-        # unblocked publish exits instead and readline() returns "" at EOF.
-        announced = waiting.stderr.readline()
-        assert "waiting for the store lock" in announced, f"second publish did not wait: {announced!r}"
-        assert not store_root.exists(), "the second publish mutated the store under a foreign hold"
+        try:
+            # The announcement IS the synchronisation event: it is emitted from the contended
+            # branch itself, so consuming it proves the second caller reached the wait. An
+            # unblocked publish exits instead and readline() returns "" at EOF. select() only
+            # caps the read so a publish that neither announces nor exits reports "stuck"
+            # instead of hanging the suite; it never stands in for an assertion.
+            if not select.select([stderr], [], [], 60)[0]:
+                raise AssertionError("the second publish neither announced a wait nor exited: stuck")
+            announced = stderr.readline()
+            assert "waiting for the store lock" in announced, f"second publish did not wait: {announced!r}"
+            assert not store_root.exists(), "the second publish mutated the store under a foreign hold"
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+            os.close(handle)
+        assert waiting.wait(timeout=60) == 0, stderr.read()
     finally:
-        fcntl.flock(handle, fcntl.LOCK_UN)
-        os.close(handle)
+        if waiting.poll() is None:
+            waiting.kill()
+            waiting.wait(timeout=60)
+        stderr.close()
 
-    # The timeout is a salvage cap for a hang, never the assertion.
-    assert waiting.wait(timeout=60) == 0, waiting.stderr.read()
-    waiting.stderr.close()
     assert (store_root / "graphify-out" / "graph.json").exists()
-    assert lock_state(lock) == "free", "the lock outlived the publish that took it"
 
 
-@pytest.mark.parametrize("lock_kind", ["directory", "symlink"])
+@pytest.mark.parametrize("lock_kind", ["directory", "symlink", "unusable-parent"])
 def test_an_unusable_store_lock_is_reported_without_a_traceback(tmp_path: Path, lock_kind: str) -> None:
-    """The lock open is the one path in this module that could follow a symlink out of the
-    store or crash on a stray directory; both must fail the way every other rejection here
-    does -- one `graphify-store:` line, no traceback (#2657).
+    """Taking the lock is the one path in this module that could follow a symlink out of the
+    store, crash on a stray directory, or crash creating the directory it lives in; each must
+    fail the way every other rejection here does -- one `graphify-store:` line, no traceback
+    (#2657).
     """
     source = tmp_path / "source"
     sha = make_repo(source)
     store_root = tmp_path / ".git" / "graphify-store"
     lock = tmp_path / ".git" / "graphify-store.lock"
-    lock.parent.mkdir(parents=True, exist_ok=True)
     outside = tmp_path / "outside"
-    if lock_kind == "directory":
-        lock.mkdir()
+    if lock_kind == "unusable-parent":
+        lock.parent.write_text("not a directory\n", encoding="utf-8")
     else:
-        lock.symlink_to(outside)
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        if lock_kind == "directory":
+            lock.mkdir()
+        else:
+            lock.symlink_to(outside)
 
     result = run_store(
         "publish",

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import importlib.util
 import os
 import stat
@@ -109,6 +110,28 @@ def assert_previous_payload_intact(target_root: Path) -> None:
     assert (payload / "graph.json").read_text(encoding="utf-8") == '{"version":"previous"}\n'
     assert (payload / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "previous report\n"
     assert sorted(entry.name for entry in target_root.iterdir()) == ["graphify-out"]
+
+
+def lock_state(lock: Path) -> str:
+    """Report whether the Graphify store lock is free at this instant.
+
+    flock(2) ties the lock to the open file description, so a descriptor opened here
+    conflicts with a hold taken through another one even inside this same process --
+    the probe therefore reads the real extent of the critical section rather than
+    inferring it from one caller out-racing another.
+    """
+    if not lock.exists():
+        return "absent"
+    handle = os.open(lock, os.O_RDWR)
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return "held"
+    else:
+        fcntl.flock(handle, fcntl.LOCK_UN)
+        return "free"
+    finally:
+        os.close(handle)
 
 
 def test_publish_and_restore_keep_only_canonical_artifacts_and_source_tag(tmp_path: Path) -> None:
@@ -731,3 +754,69 @@ def test_scratch_removal_survives_an_unreadable_directory(tmp_path: Path) -> Non
             unreadable.chmod(0o700)
 
     assert not scratch.exists()
+
+
+def test_publish_holds_the_store_lock_while_it_mutates_the_store(tmp_path: Path) -> None:
+    """Scenario: two agents publish into the one store a primary checkout shares.
+
+    Given the store lock is the sibling `.lock` file `work-branch.sh` already takes,
+    When publish swaps the new payload into the store,
+    Then the lock is held for that window, so the second agent waits instead of
+    racing the swap (issue #2657).
+    """
+    source = tmp_path / "source"
+    sha = make_repo(source)
+    store_root = tmp_path / ".git" / "graphify-store"
+    lock = tmp_path / ".git" / "graphify-store.lock"
+    observed: list[str] = []
+    swap_payload = store._swap_payload
+
+    def probing_swap(artifacts: tuple[Path, ...], target: Path) -> None:
+        observed.append(lock_state(lock))
+        swap_payload(artifacts, target)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(store, "_swap_payload", probing_swap)
+        store.publish(store_root, source, "devel", sha)
+
+    assert observed == ["held"], f"store lock during the publish swap: {observed}"
+
+
+def test_reads_never_block_on_the_store_lock_their_caller_holds(tmp_path: Path) -> None:
+    """`work-branch.sh` holds the store lock across has-exact and restore-exact, so a
+    second flock(2) taken from inside those commands would deadlock against their own
+    caller. They must stay lock-free (issue #2657).
+    """
+    source = tmp_path / "source"
+    sha = make_repo(source)
+    store_root = tmp_path / ".git" / "graphify-store"
+    publish(source, store_root, "devel", sha)
+    target = tmp_path / "worktree"
+    target.mkdir()
+
+    lock = tmp_path / ".git" / "graphify-store.lock"
+    handle = os.open(lock, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        assert lock_state(lock) == "held", "the probe must see the caller's own hold"
+        common = ("--store-root", str(store_root), "--branch", "devel", "--sha", sha)
+        # The timeout is a salvage cap for a deadlock, never the assertion: a blocked
+        # read raises TimeoutExpired, which reads as "stuck", not as a wrong result.
+        has_exact = subprocess.run(
+            ["python3", str(SCRIPT), "has-exact", *common],
+            text=True,
+            capture_output=True,
+            timeout=60,
+        )
+        restore = subprocess.run(
+            ["python3", str(SCRIPT), "restore-exact", *common, "--target", str(target)],
+            text=True,
+            capture_output=True,
+            timeout=60,
+        )
+    finally:
+        os.close(handle)
+
+    assert has_exact.returncode == 0, has_exact.stderr
+    assert restore.returncode == 0, restore.stderr
+    assert (target / "graphify-out" / "GRAPH_REPORT.md").read_text(encoding="utf-8") == "report\n"


### PR DESCRIPTION
## What

`scripts/agent/graphify-store.py publish` now takes the Graphify store lock itself.

The store is shared per primary checkout (`<primary>/.git/graphify-store`), and `publish`
is the only entry point that mutates it (`git switch`, the payload swap, the commit, the
tag). Until now the lock guarding it was held only by callers — `work-branch.sh` around
`has-exact`/`restore-exact`, and the operator by hand around the documented manual
refresh — so a direct CLI `publish`, which is exactly what the refresh procedure's final
step tells an operator to run, was unserialised against a concurrent `work-branch.sh
--worktree`, against another agent's refresh, and against a parallel session doing the
same thing.

`publish` now takes the store root's sibling `<store-root>.lock`. For the everyday store
that path *is* `.git/graphify-store.lock`, the same file `work-branch.sh` locks, so a
self-locking `publish` and a locking caller exclude each other rather than each holding a
private lock. When the lock is busy the wait is announced once on stderr instead of
hanging silently.

The read paths (`has-exact`, `restore-exact`, `seed`) deliberately stay lock-free. They
are store readers: `git archive <commit>` reads the object database and never the store's
working tree or index, so a concurrent `publish` cannot corrupt them. `has-exact` and
`restore-exact` additionally *must* stay lock-free, because `work-branch.sh` invokes them
while holding this same lock and `flock(2)` ties a lock to the open file description, so a
second lock taken from inside those commands would block against their own caller forever.
(`seed` has no such caller — its only invocation is the manual refresh, which this PR
stops hand-holding the lock for.)

`.agents/context/repository-intelligence.md` drops the hand-held lock from the refresh
procedure and records both that `publish` takes it and what that does *not* cover: only
the mutation is serialised, so a `work-branch.sh --worktree` started while the extract
runs reports `GRAPHIFY-REFRESH-REQUIRED` and refreshes in parallel instead of waiting the
way the hand-held lock used to make it. One that lands inside `publish` still waits, on
the same lock.

The lock open itself is held to the same discipline as every other path in the module: it
uses `O_NOFOLLOW`, so it cannot follow a symlink out of the store, and an unusable lock
path is reported as a one-line `graphify-store:` failure rather than a traceback.

Adversarial review rounds 1 and 2 and their findings ledgers are in the PR comments; the
review-round fixes are in `36ff18ba9` and `435698a23`.

## Tests

Both new tests were written and executed RED before the production edit, frozen
byte-identical (`git hash-object tests/test_graphify_store.py` =
`4fe96aded4771af8a66418aa141aa404ecaa92c3`, `tests/test_cross_agent_tooling.py` =
`c982aec466ebe0d1f4902d69aa5a9cfa838b87a5` at both the red and the green run), and re-run
GREEN unchanged.

The lock probe reads the critical section's real extent: `flock(2)` associates a lock with
the open file description, so a descriptor opened by the probe conflicts with a hold taken
through another one even inside the same process. No ordering rides on wall-clock, and the
one timeout in the suite is a salvage cap for a deadlock (it reports "stuck", never a
verdict).

RED, before the edit:

```
$ uv run pytest tests/test_graphify_store.py -k "publish_holds" -q
>       assert observed == ["held"], f"store lock during the publish swap: {observed}"
E       AssertionError: store lock during the publish swap: ['absent']
E       assert ['absent'] == ['held']
FAILED tests/test_graphify_store.py::test_publish_holds_the_store_lock_while_it_mutates_the_store
```

`'absent'` is the defect itself: there was no lock file at all while `publish` swapped the
payload in.

GREEN, same test files, zero edits:

```
$ git hash-object tests/test_graphify_store.py tests/test_cross_agent_tooling.py
4fe96aded4771af8a66418aa141aa404ecaa92c3
c982aec466ebe0d1f4902d69aa5a9cfa838b87a5
$ uv run pytest tests/test_graphify_store.py tests/test_cross_agent_tooling.py -q
52 passed in 14.23s
```

The second test pins the other side of the branch — the read paths must NOT block on a
lock their caller already holds, which is the deadlock this design has to avoid. It holds
the lock in-process, then runs `has-exact` and `restore-exact` as subprocesses and asserts
both complete and restore the payload.

Gates and the shell suite that exercises the real caller:

```
$ sh scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: uv run --locked pytest
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
GATE PASS: npx markdownlint-cli2
GATES: PASS

$ shellspec --shell sh tests/shell/agent_work_branch_spec.sh
37 examples, 0 failures
```

`work-branch.sh` is unchanged: its lock is now redundant with respect to store mutation
rather than the only thing providing it, and issue #2609's contract (the lock is held
across the snapshot restore and dropped before indexing) still holds.

Part of #2657

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added exclusive locking during store publishing to prevent concurrent updates from racing.
  * Publishing now waits safely when another process is using the store.
  * Improved handling of invalid lock paths, symlinks, and nested read operations.
  * Prevented store changes when lock acquisition fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->