### PR TITLE
pfblockerng: cap the fetched body and extracted output size

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -695,7 +695,12 @@ jobs:
         # phpstan.neon configures paths, level, stubs, and includes the
         # baseline (phpstan-baseline.neon) so existing legacy errors are
         # suppressed; new errors introduced by future changes will fail CI.
-        run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
+        # 2G, not 1G: a parallel worker analysing pfblockerng.inc peaks around
+        # 700 MiB on its own, so 1G left single-digit-percent headroom and any
+        # growth in that one file crashed a worker with "reached configured PHP
+        # memory limit" — a resource ceiling, never an analysis result. The real
+        # fix is splitting the file (issue #1122).
+        run: vendor/bin/phpstan analyse --no-progress --memory-limit=2G
 
   php-codesniffer:
     name: PHPCS custom sniffs / PHP ${{ matrix.php-version }}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "scripts": {
         "test": "phpunit",
-        "phpstan": "phpstan analyse --no-progress --memory-limit=1G",
+        "phpstan": "phpstan analyse --no-progress --memory-limit=2G",
         "phpcs": "phpcs -d memory_limit=1G"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,7 +16,7 @@ parameters:
     # legacy debt at the current level — an acknowledged blind-spot list to
     # BURN DOWN, not grow. Next: burn down the level-2 baseline, then level 3.
     # No memory limit is configurable here (probed: 'Unexpected item') — run
-    # via `composer phpstan`, which carries the required --memory-limit=1G.
+    # via `composer phpstan`, which carries the required --memory-limit=2G.
     level: 2
     # Pulled forward from level 5 (issue #1144): checkFunctionArgumentTypes is a
     # plain parameter, not level-gated rule registration — probed clean at level

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -353,6 +353,27 @@ foreach (array('existing', 'actual') as $pftype) {
 	$pfb[$pftype]['dnsbl']	= array();
 }
 
+// issue #2658: ceilings on how much one feed may pull down and how much it may
+// expand to. Real feeds are tens to low hundreds of MB, so both sit far above
+// anything legitimate -- they exist to stop a pathological body or an expansion
+// bomb, never to tune ingest.
+define('PFB_DOWNLOAD_MAX_BYTES', 2147483648);
+
+// ulimit(1) takes a count of blocks whose size the shell defines -- 512 bytes in
+// a POSIX sh, 1024 in bash -- so the effective ceiling lands between 2 GiB and
+// 4 GiB depending on which /bin/sh runs the extraction. Either reading bounds an
+// expansion bomb and clears every real feed, so the ambiguity needs no resolving.
+// The limit is RLIMIT_FSIZE, which the kernel applies per file.
+define('PFB_EXTRACT_MAX_BLOCKS', 4194304);
+
+// Exit status a shell reports for a child killed by SIGXFSZ (128 + 25) -- what a
+// writer hitting the ceiling above produces.
+define('PFB_EXTRACT_SIGXFSZ_EXIT', 153);
+
+// A staging filesystem with less than this free refuses the extraction outright
+// rather than filling the disk part-way through.
+define('PFB_EXTRACT_MIN_FREE_BYTES', 67108864);
+
 // Default cURL options
 $pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'pfSense/pfBlockerNG cURL download agent-' . system_get_uniqueid(),
 				CURLOPT_SSL_CIPHER_LIST	=> 'TLSv1.3, TLSv1.2',
@@ -376,6 +397,13 @@ $pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'pfSense/pfBlockerNG cURL d
 				// rsync uses exec separately) — an independent backstop to the PFB_FILTER_URL scheme
 				// allowlist, since PHP parse_url and libcurl can disagree on crafted input.
 				CURLOPT_PROTOCOLS	=> CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP,
+				// issue #2658: refuse an over-large body at the transport instead of writing
+				// it to disk in full. The _LARGE variant keeps the cap free of the 2 GiB
+				// ceiling a plain long imposes. Enforcement depends on the appliance's
+				// libcurl (a declared Content-Length is refused before any body arrives;
+				// mid-transfer enforcement is version-dependent), so the extraction
+				// ceiling below is the backstop that depends on nothing.
+				CURLOPT_MAXFILESIZE_LARGE => PFB_DOWNLOAD_MAX_BYTES,
 				);
 
 // RFC7231 HTTP response codes
@@ -4216,6 +4244,76 @@ function pfb_geoip_generation_publication_unlock($lock): void {
 
 function pfb_download_extraction_succeeded(int $retval): bool {
 	return $retval === 0;
+}
+
+/**
+ * issue #2658: wrap an extraction command so the child that writes cannot exceed
+ * PFB_EXTRACT_MAX_BLOCKS. RLIMIT_FSIZE is inherited by every descendant, so one
+ * prefix covers pipelines and the extractor's own children alike; a write past the
+ * ceiling kills the writer with SIGXFSZ and the caller's existing nonzero-exit gate
+ * rejects the extraction. `|| exit 1` keeps it fail-closed -- a shell that cannot
+ * set the limit runs no extractor at all. $blocks exists so a test can prove the
+ * ceiling fires without writing gigabytes.
+ *
+ * Known limit: RLIMIT_FSIZE bounds each file, not an archive's total output, so a
+ * multi-member archive is bounded per member plus the free-space precheck. Member
+ * counts are out of scope by the issue -- real feeds are multi-member.
+ */
+function pfb_extract_cmd(string $cmd, ?int $blocks = NULL): string {
+	return 'ulimit -f ' . ($blocks ?? PFB_EXTRACT_MAX_BLOCKS) . ' || exit 1; ' . $cmd;
+}
+
+/**
+ * issue #2658: name the ceiling when a nonzero extraction exit is the kernel
+ * killing the writer for exceeding it, so an operator reads "too large" instead of
+ * a bare exit code. Every other status keeps the caller's existing wording.
+ */
+function pfb_extract_cap_note(int $retval): string {
+	return $retval === PFB_EXTRACT_SIGXFSZ_EXIT
+		? ' -- output exceeded the extraction size ceiling'
+		: '';
+}
+
+/**
+ * issue #2658: the first staging directory without room for an extraction needing
+ * $need bytes, or NULL when every candidate has room. Only absolute paths are
+ * probed -- a caller's list carries feed names beside real directories, and a feed
+ * name must never make the guard measure the working directory's filesystem. A
+ * directory whose free space cannot be read is NOT a shortfall: a failed statfs is
+ * not evidence of a full disk and must not refuse a legitimate feed. $free is the
+ * free-space probe, injectable so the verdict is testable without a full disk.
+ *
+ * @param callable(string):(float|false)|null $free
+ */
+function pfb_extract_space_shortfall(array $dirs, int $need, ?callable $free = NULL): ?string {
+	if ($free === NULL) {
+		$free = static function (string $dir) {
+			return @disk_free_space($dir);
+		};
+	}
+	foreach ($dirs as $dir) {
+		if (!is_string($dir) || strpos($dir, '/') !== 0) {
+			continue;
+		}
+		$avail = $free($dir);
+		if ($avail === FALSE || $avail === NULL) {
+			continue;
+		}
+		if ((float) $avail < (float) $need) {
+			return $dir;
+		}
+	}
+	return NULL;
+}
+
+/**
+ * issue #2658: the refusal reason for a cURL error a retry can never fix, or NULL
+ * when the error is the retryable kind. Only "maximum file size exceeded" qualifies
+ * today: the body is over the ceiling, so re-fetching it twice more just re-reads
+ * the same over-large feed.
+ */
+function pfb_download_size_refusal(int $curl_errno): ?string {
+	return $curl_errno === CURLE_FILESIZE_EXCEEDED ? 'download_too_large' : NULL;
 }
 
 function pfb_download_initial_retval(): int {
@@ -13948,6 +14046,20 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 							pfb_logger(" {$header}\t\tcURL Error: {$curl_error}\n\n", 3);
 						}
 
+						// issue #2658: an over-large body is a permanent refusal, not a
+						// transient failure -- retrying re-fetches the same feed twice more,
+						// and the response code libcurl already collected can be a 200, which
+						// would hand the truncated body to MIME validation as if it were the
+						// whole feed. Refuse here, naming the reason.
+						$size_refusal = pfb_download_size_refusal($curl_error);
+						if ($size_refusal !== NULL) {
+							pfb_validate_log($header, 'size', $size_refusal, pfb_redact_url($list_download));
+							curl_close($ch);
+							@fclose($fhandle);
+							unlink_if_exists($file_download);
+							return PfbDownloadResult::failure();
+						}
+
 						/* 'Flex' Downgrade cURL errors -	[ 35 - GET_SERVER_HELLO:sslv3		]
 											[ 51 - NO alternative certificate	]
 											[ 60 - Local Issuer Certificate Subject	]	*/
@@ -14162,6 +14274,21 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			@touch("{$file_download}", $remote_stamp);
 		}
 
+		// issue #2658: refuse before writing anything when a staging filesystem cannot
+		// hold even the archive itself. A part-way extraction onto a full disk costs
+		// the operator the data already in service; a refused feed does not.
+		$extract_dirs = array(dirname($file_download), $pfb['dbdir'], dirname($head_download));
+		if ($type == 'geoip') {
+			$extract_dirs[] = $pfb['geoipshare'];
+		}
+		$extract_short = pfb_extract_space_shortfall($extract_dirs,
+			max(PFB_EXTRACT_MIN_FREE_BYTES, (int) @filesize($file_download)));
+		if ($extract_short !== NULL) {
+			pfb_validate_log($header, 'size', 'staging_space_low', $extract_short);
+			unlink_if_exists($file_download);
+			return PfbDownloadResult::failure();
+		}
+
 		// Decompress file if required
 		if ($file_type == 'application/x-gzip' || $file_type == 'application/gzip') {
 			if (!pfb_validate_archive($file_download, $file_type)) {
@@ -14179,10 +14306,10 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
 				}
-				exec("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1", $output, $retval);
+				exec(pfb_extract_cmd("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1"), $output, $retval);
 				unlink_if_exists($file_download);
 				if (!pfb_download_extraction_succeeded($retval)) {
-					pfb_logger("\n[pfb_download] geoip extraction failed (tar exit {$retval})", 2);
+					pfb_logger("\n[pfb_download] geoip extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 					return PfbDownloadResult::failure();
 				}
 				return PfbDownloadResult::success();
@@ -14191,10 +14318,10 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				$retval = pfb_download_initial_retval();
 				if (!pfb_stage_publish($head_download,
 				    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-					exec("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged), $output, $retval);
+					exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 					return $retval;
 				})) {
-					pfb_logger("\n[pfb_download] asn extraction failed (gunzip exit {$retval})", 2);
+					pfb_logger("\n[pfb_download] asn extraction failed (gunzip exit {$retval})" . pfb_extract_cap_note($retval), 2);
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
 				}
@@ -14215,11 +14342,11 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					return PfbDownloadResult::failure();
 				}
 				$header_esc = escapeshellarg($top1m_stage);
-				exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);
+				exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"), $output, $retval);
 				if (!pfb_download_extraction_succeeded($retval)) {
 					unlink_if_exists($file_download);
 					unlink_if_exists($top1m_stage);
-					pfb_logger("\n[pfb_download] top1m extraction failed (gunzip exit {$retval})", 2);
+					pfb_logger("\n[pfb_download] top1m extraction failed (gunzip exit {$retval})" . pfb_extract_cap_note($retval), 2);
 					return PfbDownloadResult::failure();
 				}
 				if (!pfb_top1m_candidate_valid($top1m_stage, $top1m_provider)) {
@@ -14319,7 +14446,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					$retval = pfb_download_initial_retval();
 					if (!pfb_stage_publish_dir("{$pfb['dbdir']}/{$filename}",
 					    static function (string $staged) use ($file_dwn, $filename, $cmd, &$output, &$retval): int {
-						exec("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1", $output, $retval);
+						exec(pfb_extract_cmd("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1"), $output, $retval);
 						if (!pfb_download_extraction_succeeded($retval)) {
 							return $retval;
 						}
@@ -14335,7 +14462,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 						}
 						return $retval;
 					})) {
-						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})", 2);
+						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 						return PfbDownloadResult::failure();
 					}
 
@@ -14357,10 +14484,10 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				$retval = pfb_download_initial_retval();
 				if (!pfb_stage_publish($orig_download,
 				    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-					exec("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged), $output, $retval);
+					exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 					return $retval;
 				})) {
-					pfb_logger("\n[pfb_download] gzip extraction failed (gunzip exit {$retval})", 2);
+					pfb_logger("\n[pfb_download] gzip extraction failed (gunzip exit {$retval})" . pfb_extract_cap_note($retval), 2);
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
 				}
@@ -14381,10 +14508,10 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			$retval = pfb_download_initial_retval();
 			if (!pfb_stage_publish($orig_download,
 			    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-				exec("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged), $output, $retval);
+				exec(pfb_extract_cmd("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 				return $retval;
 			})) {
-				pfb_logger("\n[pfb_download] bzip2 extraction failed (bzip2 exit {$retval})", 2);
+				pfb_logger("\n[pfb_download] bzip2 extraction failed (bzip2 exit {$retval})" . pfb_extract_cap_note($retval), 2);
 				unlink_if_exists($file_download);
 				return PfbDownloadResult::failure();
 			}
@@ -14410,22 +14537,22 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 						unlink_if_exists($file_download);
 						return PfbDownloadResult::failure();
 					}
-					exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1", $output, $retval);
+					exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1"), $output, $retval);
 				} else {
 					// ADR-46: stdout extraction -- member names never reach the filesystem.
 					$retval = pfb_download_initial_retval();
 					if (!pfb_stage_publish($head_download,
 					    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-						exec("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged), $output, $retval);
+						exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 						return $retval;
 					})) {
-						pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
+						pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 						unlink_if_exists($file_download);
 						return PfbDownloadResult::failure();
 					}
 				}
 				if (!pfb_download_extraction_succeeded($retval)) {
-					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
+					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
 				}
@@ -14455,9 +14582,9 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				}
 				$header_esc = escapeshellarg($top1m_stage);
 				$strip = $top1m_target_dir ? ' --strip=1' : '';
-				exec("/usr/bin/tar -xf {$file_dwn_esc}{$strip} -C {$header_esc} >/dev/null 2>&1", $output, $retval);
+				exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc}{$strip} -C {$header_esc} >/dev/null 2>&1"), $output, $retval);
 				if (!pfb_download_extraction_succeeded($retval)) {
-					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})", 2);
+					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 					rmdir_recursive($top1m_stage);
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
@@ -14590,7 +14717,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			$xlsxtest = exec("/usr/bin/tar -tf {$file_dwn_esc}");
 			if (strpos($xlsxtest, '.xlsx') !== FALSE) {
 				unlink_if_exists("{$orig_download}");
-				exec("{$pfb['script']} xlsx {$header_esc} {$elog}");
+				exec(pfb_extract_cmd("{$pfb['script']} xlsx {$header_esc} {$elog}"));
 				if (file_exists("{$orig_download}")) {
 					$retval = 0;
 				}
@@ -14608,7 +14735,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				if (!pfb_stage_publish($orig_download,
 				    static function (string $staged) use ($file_dwn_esc, $list_download,
 				        &$output, &$retval, &$reject_detail, &$inner_rejected): int {
-					exec("set -o pipefail; /usr/bin/tar -xOf {$file_dwn_esc} | /usr/bin/sed 's/,[[:space:]]/; /g' | /usr/bin/tr ',' '\n' > " . escapeshellarg($staged), $output, $retval);
+					exec(pfb_extract_cmd("set -o pipefail; /usr/bin/tar -xOf {$file_dwn_esc} | /usr/bin/sed 's/,[[:space:]]/; /g' | /usr/bin/tr ',' '\n' > " . escapeshellarg($staged)), $output, $retval);
 					if ($retval !== 0) {
 						return $retval;
 					}
@@ -14624,7 +14751,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					if ($inner_rejected) {
 						pfb_validate_log($header, 'inner', 'inner_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 					} else {
-						pfb_logger("\n[pfb_download] zip publish failed (tar exit {$retval})", 2);
+						pfb_logger("\n[pfb_download] zip publish failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 					}
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -370,10 +370,6 @@ define('PFB_EXTRACT_MAX_BLOCKS', 4194304);
 // writer hitting the ceiling above produces.
 define('PFB_EXTRACT_SIGXFSZ_EXIT', 153);
 
-// A staging filesystem with less than this free refuses the extraction outright
-// rather than filling the disk part-way through.
-define('PFB_EXTRACT_MIN_FREE_BYTES', 67108864);
-
 // Default cURL options
 $pfb['curl_defaults'] = array(  CURLOPT_USERAGENT	=> 'pfSense/pfBlockerNG cURL download agent-' . system_get_uniqueid(),
 				CURLOPT_SSL_CIPHER_LIST	=> 'TLSv1.3, TLSv1.2',
@@ -4259,8 +4255,8 @@ function pfb_download_extraction_succeeded(int $retval): bool {
  * multi-member archive is bounded per member plus the free-space precheck. Member
  * counts are out of scope by the issue -- real feeds are multi-member.
  */
-function pfb_extract_cmd(string $cmd, ?int $blocks = NULL): string {
-	return 'ulimit -f ' . ($blocks ?? PFB_EXTRACT_MAX_BLOCKS) . ' || exit 1; ' . $cmd;
+function pfb_extract_cmd(string $cmd, int $blocks = PFB_EXTRACT_MAX_BLOCKS): string {
+	return "ulimit -f {$blocks} || exit 1; {$cmd}";
 }
 
 /**
@@ -4286,34 +4282,17 @@ function pfb_extract_cap_note(int $retval): string {
  * @param callable(string):(float|false)|null $free
  */
 function pfb_extract_space_shortfall(array $dirs, int $need, ?callable $free = NULL): ?string {
-	if ($free === NULL) {
-		$free = static function (string $dir) {
-			return @disk_free_space($dir);
-		};
-	}
+	$free ??= static fn (string $dir) => @disk_free_space($dir);
 	foreach ($dirs as $dir) {
 		if (!is_string($dir) || strpos($dir, '/') !== 0) {
 			continue;
 		}
 		$avail = $free($dir);
-		if ($avail === FALSE || $avail === NULL) {
-			continue;
-		}
-		if ((float) $avail < (float) $need) {
+		if ($avail !== FALSE && $avail < $need) {
 			return $dir;
 		}
 	}
 	return NULL;
-}
-
-/**
- * issue #2658: the refusal reason for a cURL error a retry can never fix, or NULL
- * when the error is the retryable kind. Only "maximum file size exceeded" qualifies
- * today: the body is over the ceiling, so re-fetching it twice more just re-reads
- * the same over-large feed.
- */
-function pfb_download_size_refusal(int $curl_errno): ?string {
-	return $curl_errno === CURLE_FILESIZE_EXCEEDED ? 'download_too_large' : NULL;
 }
 
 function pfb_download_initial_retval(): int {
@@ -14051,10 +14030,10 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 						// and the response code libcurl already collected can be a 200, which
 						// would hand the truncated body to MIME validation as if it were the
 						// whole feed. Refuse here, naming the reason.
-						$size_refusal = pfb_download_size_refusal($curl_error);
-						if ($size_refusal !== NULL) {
-							pfb_validate_log($header, 'size', $size_refusal, pfb_redact_url($list_download));
-							curl_close($ch);
+						if ($curl_error === CURLE_FILESIZE_EXCEEDED) {
+							pfb_validate_log($header, 'size', 'download_too_large', pfb_redact_url($list_download));
+							// No curl_close(): it is a no-op since PHP 8.0 and deprecated in 8.5
+							// (Plus ships php85); the handle frees when this frame returns.
 							@fclose($fhandle);
 							unlink_if_exists($file_download);
 							return PfbDownloadResult::failure();
@@ -14276,17 +14255,23 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 
 		// issue #2658: refuse before writing anything when a staging filesystem cannot
 		// hold even the archive itself. A part-way extraction onto a full disk costs
-		// the operator the data already in service; a refused feed does not.
-		$extract_dirs = array(dirname($file_download), $pfb['dbdir'], dirname($head_download));
-		if ($type == 'geoip') {
-			$extract_dirs[] = $pfb['geoipshare'];
-		}
-		$extract_short = pfb_extract_space_shortfall($extract_dirs,
-			max(PFB_EXTRACT_MIN_FREE_BYTES, (int) @filesize($file_download)));
-		if ($extract_short !== NULL) {
-			pfb_validate_log($header, 'size', 'staging_space_low', $extract_short);
-			unlink_if_exists($file_download);
-			return PfbDownloadResult::failure();
+		// the operator the data already in service; a refused feed does not. Only the
+		// archive types below extract, so pfb_archive_probe() -- which already answers
+		// "is this an archive" -- keeps a plain text feed out of the guard entirely.
+		// The requirement is the archive's own size and nothing more: /var is a 60 MiB
+		// RAM disk on a default use_mfs_tmpvar install, so any fixed floor would refuse
+		// every feed there forever.
+		if (pfb_archive_probe($file_type) !== NULL) {
+			$extract_dirs = array(dirname($file_download), $pfb['dbdir'], $head_download, dirname($head_download));
+			if ($type == 'geoip') {
+				$extract_dirs[] = $pfb['geoipshare'];
+			}
+			$extract_short = pfb_extract_space_shortfall($extract_dirs, (int) @filesize($file_download));
+			if ($extract_short !== NULL) {
+				pfb_validate_log($header, 'size', 'staging_space_low', $extract_short);
+				unlink_if_exists($file_download);
+				return PfbDownloadResult::failure();
+			}
 		}
 
 		// Decompress file if required
@@ -14717,7 +14702,12 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			$xlsxtest = exec("/usr/bin/tar -tf {$file_dwn_esc}");
 			if (strpos($xlsxtest, '.xlsx') !== FALSE) {
 				unlink_if_exists("{$orig_download}");
-				exec(pfb_extract_cmd("{$pfb['script']} xlsx {$header_esc} {$elog}"));
+				// issue #2658: deliberately NOT capped. processxlsx() decides success by the
+				// output file existing, never by an exit status, so a child killed at the
+				// ceiling would publish a truncated feed as a successful ingest -- strictly
+				// worse than no cap. Capping it needs an exit gate in the shell function
+				// first (issue #2666).
+				exec("{$pfb['script']} xlsx {$header_esc} {$elog}");
 				if (file_exists("{$orig_download}")) {
 					$retval = 0;
 				}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1172,7 +1172,7 @@ function pfb_octet_recover_type(string $file, array $supported_types, callable $
 
 // ADR-48: pure formatter for the canonical download-validation reject line — a single
 // greppable line naming feed/stage/reason + raw detected detail. $stage is one of
-// mime|structural|inner|member|plaintext|entries (caller-owned vocabulary, unvalidated here).
+// mime|structural|inner|member|plaintext|entries|size (caller-owned vocabulary, unvalidated here).
 // Shape: "\npfb_validate: REJECT feed=<feed> stage=<stage> reason=<reason> detected=<detail>"
 // (leading "\n" per pfb_logger() convention). Each value has control bytes -> space (blocks
 // forging/splitting the line via attacker-influenced detail) — HTML-escaping is NOT applied

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -218,7 +218,8 @@ function pfb_apply_gunzip_orig_pipeline(string $source, string $orig, ?callable 
 		// the last-good publication before gunzip's exit status can be read.
 		$staged = "{$orig}.tmp";
 		$output = array();
-		exec('/usr/bin/gunzip -c ' . escapeshellarg($source) . ' > ' . escapeshellarg($staged), $output, $retval);
+		// issue #2658: same expansion ceiling every pfb_download() extraction runs under.
+		exec(pfb_extract_cmd('/usr/bin/gunzip -c ' . escapeshellarg($source) . ' > ' . escapeshellarg($staged)), $output, $retval);
 		if ($retval === 0 && pfb_apply_trailing_newline_ok($staged)) {
 			$published = @rename($staged, $orig);
 		}

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -56,7 +56,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($geoip);
 		$this->assertNotFalse($asn);
 		$scope = substr(self::$source, $geoip, $asn - $geoip);
-		$this->assertMatchesRegularExpression('/exec\(".*tar -xzf .*\\$output, \\$retval\);/', $scope);
+		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xzf .*\\$output, \\$retval\);/', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
@@ -75,7 +75,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($top1m);
 		$scope = substr(self::$source, $asn, $top1m - $asn);
 		$this->assertStringContainsString(
-			'exec("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged), $output, $retval);', $scope);
+			'exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);', $scope);
 		// issue #2169: the exit code is now gated inside pfb_stage_publish(), which
 		// publishes onto the live target only when it reports success.
 		$this->assertStringContainsString('if (!pfb_stage_publish($head_download,', $scope);
@@ -94,7 +94,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($zip);
 		$scope = substr(self::$source, $bzip2, $zip - $bzip2);
 		$this->assertStringContainsString(
-			'exec("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged), $output, $retval);', $scope);
+			'exec(pfb_extract_cmd("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);', $scope);
 		$this->assertStringContainsString('if (!pfb_stage_publish($orig_download,', $scope);
 	}
 
@@ -112,7 +112,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($top1m);
 		$this->assertNotFalse($blacklist);
 		$scope = substr(self::$source, $top1m, $blacklist - $top1m);
-		$this->assertStringContainsString('exec("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}", $output, $retval);', $scope);
+		$this->assertStringContainsString('exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"), $output, $retval);', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
@@ -130,7 +130,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($blacklist);
 		$this->assertNotFalse($end);
 		$scope = substr(self::$source, $blacklist, $end - $blacklist);
-		$this->assertMatchesRegularExpression('/exec\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
+		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
@@ -148,9 +148,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($geoip);
 		$this->assertNotFalse($top1m);
 		$scope = substr(self::$source, $geoip, $top1m - $geoip);
-		$this->assertStringContainsString('exec("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1", $output, $retval);', $scope);
+		$this->assertStringContainsString('exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1"), $output, $retval);', $scope);
 		$this->assertStringContainsString(
-			'exec("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged), $output, $retval);', $scope);
+			'exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);', $scope);
 		// issue #2169: the stdout mode publishes through the staged helper; the
 		// directory mode still reaches the shared zero-only gate below it.
 		$this->assertStringContainsString('if (!pfb_stage_publish($head_download,', $scope);
@@ -172,7 +172,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($top1m);
 		$this->assertNotFalse($blacklist);
 		$scope = substr(self::$source, $top1m, $blacklist - $top1m);
-		$this->assertMatchesRegularExpression('/exec\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
+		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 }

--- a/tests/php/DownloadRetvalFailsafeTest.php
+++ b/tests/php/DownloadRetvalFailsafeTest.php
@@ -77,7 +77,7 @@ final class DownloadRetvalFailsafeTest extends TestCase
 		$scope = substr(self::$source, $body, $end - $body);
 		$gate = strpos($scope, 'if (pfb_download_retval_success($retval)) {');
 		// issue #2169: the generic gzip branch stages its output before publishing.
-		$extract = strpos($scope, 'exec("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged), $output, $retval);');
+		$extract = strpos($scope, 'exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);');
 		$this->assertNotFalse($gate);
 		$this->assertNotFalse($extract);
 		$this->assertLessThan($gate, $extract);

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -278,27 +278,34 @@ final class DownloadSizeCeilingTest extends TestCase
 	 *
 	 * Given  every exec() pfb_download() makes
 	 * When   they are enumerated from the comment-free source
-	 * Then   each one either runs under pfb_extract_cmd() or is an allow-listed
-	 *        call that writes no archive output. A new extraction site added
+	 * Then   each one either runs under pfb_extract_cmd() or is one of the calls
+	 *        below, which write no archive output. A new extraction site added
 	 *        without the ceiling fails here.
+	 *
+	 * The allow-list holds each exempt call's WHOLE statement, terminator included,
+	 * not a prefix of it. A prefix would exempt everything that merely starts the
+	 * same way, so `exec("{$pfb['script']} xlsx" . $anything)` -- a genuinely
+	 * unguarded extraction wearing an exempt call's opening -- would pass. Changing
+	 * an exempt call means updating its entry here, which is the point: the
+	 * exemption is for that call as written, not for its first few characters.
 	 */
 	public function test_every_extraction_exec_runs_under_the_ceiling(): void
 	{
 		$allowed = [
 			// Fetches a feed body; writes no archive output. Its own fetch is bounded
 			// by neither ceiling (rsync is not a libcurl transfer) -- issue #2667.
-			'exec("/usr/local/bin/rsync',
+			'exec("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}", $rsync_output, $rsync_rc);',
 			// Helper-script calls that post-process an ALREADY-extracted text feed.
-			'exec("{$pfb[\'script\']} whoisconvert',
-			'exec("{$pfb[\'script\']} asn_table',
-			'exec("{$pfb[\'script\']} et ',
+			'exec("{$pfb[\'script\']} whoisconvert {$header_esc} {$vtype} {$list_url_esc} {$elog}");',
+			'exec("{$pfb[\'script\']} asn_table {$elog}");',
+			'exec("{$pfb[\'script\']} et {$header_esc} x x x x x {$pfb[\'etblock\']} {$pfb[\'etmatch\']} {$elog}");',
 			// processxlsx() reports success by the output file existing rather than by
 			// an exit status, so a child killed at the ceiling would publish a
 			// truncated feed as a success. Capping it needs an exit gate first
 			// (issue #2666).
-			'exec("{$pfb[\'script\']} xlsx',
+			'exec("{$pfb[\'script\']} xlsx {$header_esc} {$elog}");',
 			// Lists an archive; extracts nothing.
-			'exec("/usr/bin/tar -tf',
+			'exec("/usr/bin/tar -tf {$file_dwn_esc}");',
 			// Capped.
 			'exec(pfb_extract_cmd(',
 		];
@@ -308,16 +315,23 @@ final class DownloadSizeCeilingTest extends TestCase
 		$this->assertNotFalse($found);
 		$this->assertNotSame(0, $found, 'the pfb_download() body must contain exec() calls');
 
+		$hits = array_fill_keys($allowed, 0);
 		foreach ($m[0] as [, $offset]) {
-			$call = substr(self::$downloadBody, $offset, 48);
-			$ok = FALSE;
-			foreach ($allowed as $prefix) {
-				if (str_starts_with($call, $prefix)) {
-					$ok = TRUE;
+			$call = substr(self::$downloadBody, $offset, 200);
+			$match = NULL;
+			foreach ($allowed as $entry) {
+				if (str_starts_with($call, $entry)) {
+					$match = $entry;
 					break;
 				}
 			}
-			$this->assertTrue($ok, "unguarded exec() in pfb_download(): {$call}");
+			$this->assertNotNull($match, 'unguarded exec() in pfb_download(): ' . substr($call, 0, 96));
+			$hits[$match]++;
+		}
+
+		// An entry that matches nothing is a stale exemption still granting cover.
+		foreach ($hits as $entry => $count) {
+			$this->assertGreaterThan(0, $count, "stale allow-list entry, no longer present: {$entry}");
 		}
 	}
 

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -269,23 +269,6 @@ final class DownloadSizeCeilingTest extends TestCase
 		$this->assertSame(PFB_DOWNLOAD_MAX_BYTES, $defaults[CURLOPT_MAXFILESIZE_LARGE]);
 	}
 
-	/**
-	 * Scenario: the over-large refusal is distinguishable from a transient error
-	 *
-	 * Given  a cURL error number
-	 * When   the download loop classifies it
-	 * Then   only "maximum file size exceeded" yields a refusal reason — every
-	 *        other error stays a retryable failure and must not be relabelled.
-	 */
-	public function test_download_size_refusal_only_fires_for_the_file_size_error(): void
-	{
-		$this->assertSame('download_too_large', pfb_download_size_refusal(CURLE_FILESIZE_EXCEEDED));
-		foreach ([0, 7, 22, 28, 35, 56, 60] as $errno) {
-			$this->assertNull(pfb_download_size_refusal($errno),
-				"cURL error {$errno} is not a size refusal");
-		}
-	}
-
 	// -----------------------------------------------------------------------
 	// Wiring inside pfb_download()
 	// -----------------------------------------------------------------------
@@ -295,38 +278,41 @@ final class DownloadSizeCeilingTest extends TestCase
 	 *
 	 * Given  every exec() pfb_download() makes
 	 * When   they are enumerated from the comment-free source
-	 * Then   each one either runs under pfb_extract_cmd() or is a known
-	 *        non-writing call (a listing probe, rsync, or a helper script that
-	 *        writes nothing of the archive's making). A new extraction site
-	 *        added without the ceiling fails here.
+	 * Then   each one either runs under pfb_extract_cmd() or is an allow-listed
+	 *        call that writes no archive output. A new extraction site added
+	 *        without the ceiling fails here.
 	 */
 	public function test_every_extraction_exec_runs_under_the_ceiling(): void
 	{
 		$allowed = [
+			// Fetches a feed body; writes no archive output. Its own fetch is bounded
+			// by neither ceiling (rsync is not a libcurl transfer) -- issue #2667.
 			'exec("/usr/local/bin/rsync',
+			// Helper-script calls that post-process an ALREADY-extracted text feed.
 			'exec("{$pfb[\'script\']} whoisconvert',
 			'exec("{$pfb[\'script\']} asn_table',
 			'exec("{$pfb[\'script\']} et ',
+			// processxlsx() reports success by the output file existing rather than by
+			// an exit status, so a child killed at the ceiling would publish a
+			// truncated feed as a success. Capping it needs an exit gate first
+			// (issue #2666).
+			'exec("{$pfb[\'script\']} xlsx',
+			// Lists an archive; extracts nothing.
 			'exec("/usr/bin/tar -tf',
+			// Capped.
 			'exec(pfb_extract_cmd(',
 		];
 
-		$offsets = [];
-		$at = 0;
-		while (($at = strpos(self::$downloadBody, 'exec(', $at)) !== FALSE) {
-			// curl_exec() is not a shell call.
-			if ($at === 0 || !preg_match('/[A-Za-z0-9_]/', self::$downloadBody[$at - 1])) {
-				$offsets[] = $at;
-			}
-			$at += 5;
-		}
-		$this->assertNotEmpty($offsets, 'the pfb_download() body must contain exec() calls');
+		// curl_exec() is not a shell call -- the lookbehind keeps it out.
+		$found = preg_match_all('/(?<![A-Za-z0-9_])exec\(/', self::$downloadBody, $m, PREG_OFFSET_CAPTURE);
+		$this->assertNotFalse($found);
+		$this->assertNotSame(0, $found, 'the pfb_download() body must contain exec() calls');
 
-		foreach ($offsets as $offset) {
+		foreach ($m[0] as [, $offset]) {
 			$call = substr(self::$downloadBody, $offset, 48);
 			$ok = FALSE;
 			foreach ($allowed as $prefix) {
-				if (strpos($call, $prefix) === 0) {
+				if (str_starts_with($call, $prefix)) {
 					$ok = TRUE;
 					break;
 				}
@@ -336,30 +322,42 @@ final class DownloadSizeCeilingTest extends TestCase
 	}
 
 	/**
-	 * Scenario: each shipped extraction site keeps its ceiling
+	 * Scenario: no extraction anywhere in the package escapes the ceiling
 	 *
-	 * Given  the extractor invocations pfb_download() runs per archive format
-	 * When   the comment-free source is read
-	 * Then   every one of them is wrapped, so no format — gzip, bzip2, zip or
-	 *        tar, on the staged and the direct paths alike — is left uncapped.
+	 * Given  every shipped PHP source file, not just pfb_download()
+	 * When   each exec() that drives an extraction tool is enumerated
+	 * Then   all of them run under pfb_extract_cmd(). The ingest reuse path in
+	 *        pfblockerng_apply.inc is the reason this sweep is tree-wide rather
+	 *        than scoped to pfb_download(): an expansion bomb does not care which
+	 *        function opened the archive.
 	 */
-	public function test_each_extraction_site_is_wrapped(): void
+	public function test_no_extraction_exec_anywhere_in_the_package_is_uncapped(): void
 	{
-		$sites = [
-			'exec(pfb_extract_cmd("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb[\'geoipshare\']} >/dev/null 2>&1"), $output, $retval);',
-			'exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);',
-			'exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"), $output, $retval);',
-			'exec(pfb_extract_cmd("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);',
-			'exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1"), $output, $retval);',
-			'exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);',
-			'exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc}{$strip} -C {$header_esc} >/dev/null 2>&1"), $output, $retval);',
-			'exec(pfb_extract_cmd("set -o pipefail; /usr/bin/tar -xOf {$file_dwn_esc} |',
-			'exec(pfb_extract_cmd("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C "',
-			'exec(pfb_extract_cmd("{$pfb[\'script\']} xlsx {$header_esc} {$elog}"));',
-		];
-		foreach ($sites as $site) {
-			$this->assertStringContainsString($site, self::$downloadBody);
+		$root = dirname(__DIR__, 2) . '/src';
+		$files = new RegexIterator(
+			new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)),
+			'/\.(inc|php)$/'
+		);
+
+		$seen = 0;
+		foreach ($files as $file) {
+			$path = $file->getPathname();
+			$source = php_strip_whitespace($path);
+			// -t/-tf only TEST or LIST an archive; they write nothing.
+			if (!preg_match_all(
+				'/(?<![A-Za-z0-9_])exec\(\s*(?:pfb_extract_cmd\()?[\'"][^\'"]*(?:gunzip|bzip2|\/tar) -(?!t)/',
+				$source, $m, PREG_OFFSET_CAPTURE
+			)) {
+				continue;
+			}
+			foreach ($m[0] as [$call, $offset]) {
+				$seen++;
+				$this->assertStringStartsWith('exec(pfb_extract_cmd(', $call,
+					'uncapped extraction in ' . basename($path) . ': ' . substr($source, $offset, 64));
+			}
 		}
+		$this->assertGreaterThan(1, $seen,
+			'the sweep must actually find extraction calls — a pattern that matches nothing proves nothing');
 	}
 
 	/**
@@ -373,8 +371,9 @@ final class DownloadSizeCeilingTest extends TestCase
 	 */
 	public function test_download_loop_refuses_an_over_large_body_without_retrying(): void
 	{
-		$this->assertStringContainsString('pfb_download_size_refusal($curl_error)', self::$downloadBody);
-		$this->assertStringContainsString("pfb_validate_log(\$header, 'size',", self::$downloadBody);
+		$this->assertStringContainsString('if ($curl_error === CURLE_FILESIZE_EXCEEDED) {', self::$downloadBody);
+		$this->assertStringContainsString(
+			"pfb_validate_log(\$header, 'size', 'download_too_large'", self::$downloadBody);
 	}
 
 	/**
@@ -392,5 +391,12 @@ final class DownloadSizeCeilingTest extends TestCase
 		$this->assertNotFalse($check, 'pfb_download() must run the free-space precheck');
 		$this->assertNotFalse($dispatch);
 		$this->assertLessThan($dispatch, $check);
+		// Archive types only: a plain text feed extracts nothing, so the guard must not
+		// stand between it and its publication.
+		$this->assertStringContainsString('if (pfb_archive_probe($file_type) !== NULL) {', self::$downloadBody);
+		// The requirement is the archive's own size and no fixed floor -- /var is a
+		// 60 MiB RAM disk on a default use_mfs_tmpvar install.
+		$this->assertStringContainsString(
+			'pfb_extract_space_shortfall($extract_dirs, (int) @filesize($file_download))', self::$downloadBody);
 	}
 }

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -1,0 +1,396 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2658 — nothing bounded how much a feed could pull down or expand to.
+ *
+ * These tests pin the two ceilings and the free-space precheck that now guard
+ * ingest: the fetched body is capped by libcurl, the extracted output is capped
+ * by the kernel through the shell that runs every extractor, and an extraction
+ * onto a staging filesystem with no room is refused before it writes anything.
+ *
+ * pfb_download() itself executes archive tools against appliance paths and is
+ * not callable off-appliance (ADR-45 §5), so its interior is pinned the way the
+ * rest of the suite pins it: against the comment-free source. The helpers the
+ * interior delegates to are exercised directly, including one live /bin/sh run
+ * proving the ceiling really does stop a writing child.
+ */
+final class DownloadSizeCeilingTest extends TestCase
+{
+	private static string $source;
+	private static string $downloadBody;
+
+	private string $dir = '';
+
+	public static function setUpBeforeClass(): void
+	{
+		self::$source = php_strip_whitespace(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc'
+		);
+		if (self::$source === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng.inc');
+		}
+		$start = strpos(self::$source, 'function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {');
+		$end   = strpos(self::$source, 'function pfb_download_failure(');
+		if ($start === FALSE || $end === FALSE || $end <= $start) {
+			throw new RuntimeException('test bootstrap: could not bound the pfb_download() body');
+		}
+		self::$downloadBody = substr(self::$source, $start, $end - $start);
+	}
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_size_ceiling_' . uniqid('', TRUE);
+		mkdir($this->dir, 0700, TRUE);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->dir . '/*') ?: [] as $f) {
+			@unlink($f);
+		}
+		@rmdir($this->dir);
+	}
+
+	// -----------------------------------------------------------------------
+	// The extraction ceiling
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario: an extraction command carries the write ceiling
+	 *
+	 * Given  any extraction command line
+	 * When   pfb_extract_cmd() wraps it
+	 * Then   the wrapped command lowers the shell's file-size limit to the
+	 *        configured block count first, and aborts without running the
+	 *        extractor at all if that limit cannot be set (fail closed).
+	 */
+	public function test_extract_cmd_wraps_the_command_in_the_write_ceiling(): void
+	{
+		$this->assertSame(
+			'ulimit -f ' . PFB_EXTRACT_MAX_BLOCKS . ' || exit 1; /usr/bin/gunzip -c a > b',
+			pfb_extract_cmd('/usr/bin/gunzip -c a > b')
+		);
+	}
+
+	/**
+	 * Scenario: the ceiling is settable for tests
+	 *
+	 * Given  an explicit block count
+	 * When   pfb_extract_cmd() wraps a command with it
+	 * Then   that count replaces the shipped ceiling, so a test can prove the
+	 *        guard fires without writing gigabytes.
+	 */
+	public function test_extract_cmd_accepts_an_explicit_block_count(): void
+	{
+		$this->assertSame('ulimit -f 2 || exit 1; /bin/true', pfb_extract_cmd('/bin/true', 2));
+	}
+
+	/**
+	 * Scenario: the ceiling stops a child that writes past it
+	 *
+	 * Given  a wrapped command whose ceiling is two blocks and whose child
+	 *        writes one MiB
+	 * When   the command runs through the same exec() the extraction sites use
+	 * Then   the child is killed for exceeding the file-size limit, exec()
+	 *        reports the nonzero status the extraction gates already reject,
+	 *        and the output stops far short of what was asked for.
+	 *
+	 * The brace group only silences the shell's own "Filesize limit exceeded"
+	 * notice so the suite output stays readable; the wrapped command is verbatim.
+	 */
+	public function test_extract_cmd_ceiling_kills_a_child_that_writes_past_it(): void
+	{
+		if (!is_executable('/bin/dd')) {
+			$this->markTestSkipped('/bin/dd not available on this host');
+		}
+
+		$target = $this->dir . '/overflow.bin';
+		$output = [];
+		$retval = 0;
+		exec(
+			'{ ' . pfb_extract_cmd('/bin/dd if=/dev/zero of=' . escapeshellarg($target) . ' bs=1024 count=1024', 2) . '; } 2>/dev/null',
+			$output,
+			$retval
+		);
+
+		$this->assertSame(PFB_EXTRACT_SIGXFSZ_EXIT, $retval,
+			'a write past the ceiling must surface as the SIGXFSZ exit status');
+		$this->assertFalse(pfb_download_extraction_succeeded($retval),
+			'the extraction gates must read the capped run as a failure');
+		$this->assertLessThan(1024 * 1024, filesize($target),
+			'the ceiling must stop the write, not merely report on it');
+	}
+
+	/**
+	 * Scenario: a run under the ceiling is untouched
+	 *
+	 * Given  a wrapped command whose child writes well under the ceiling
+	 * When   it runs
+	 * Then   it succeeds and its full output is on disk — the guard rejects
+	 *        nothing legitimate.
+	 */
+	public function test_extract_cmd_leaves_a_run_under_the_ceiling_alone(): void
+	{
+		if (!is_executable('/bin/dd')) {
+			$this->markTestSkipped('/bin/dd not available on this host');
+		}
+
+		$target = $this->dir . '/small.bin';
+		$output = [];
+		$retval = 1;
+		exec(
+			pfb_extract_cmd('/bin/dd if=/dev/zero of=' . escapeshellarg($target) . ' bs=1024 count=1 2>/dev/null'),
+			$output,
+			$retval
+		);
+
+		$this->assertSame(0, $retval);
+		$this->assertSame(1024, filesize($target));
+	}
+
+	/**
+	 * Scenario: a capped extraction is logged as a size refusal
+	 *
+	 * Given  the exit status a child killed for exceeding the ceiling produces
+	 * When   the extraction failure is logged
+	 * Then   the line names the ceiling, so an operator reads "too large"
+	 *        instead of a bare exit code; every other nonzero status keeps the
+	 *        existing wording untouched.
+	 */
+	public function test_extract_cap_note_names_the_ceiling_only_for_the_capped_exit(): void
+	{
+		$this->assertStringContainsString('ceiling', pfb_extract_cap_note(PFB_EXTRACT_SIGXFSZ_EXIT));
+		foreach ([0, 1, 2, 66, 127, 152, 154] as $retval) {
+			$this->assertSame('', pfb_extract_cap_note($retval),
+				"exit {$retval} is not a ceiling refusal and must not be labelled one");
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// The free-space precheck
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario: a staging filesystem without room refuses the extraction
+	 *
+	 * Given  two staging directories, the second with less free space than the
+	 *        extraction needs
+	 * When   the precheck runs
+	 * Then   it names that directory, so the caller can refuse before writing.
+	 */
+	public function test_space_shortfall_names_the_directory_without_room(): void
+	{
+		$free = static fn (string $dir) => $dir === '/b' ? 1024.0 : 1024.0 * 1024 * 1024;
+		$this->assertSame('/b', pfb_extract_space_shortfall(['/a', '/b'], 1024 * 1024, $free));
+	}
+
+	/**
+	 * Scenario: enough room everywhere
+	 *
+	 * Given  staging directories that all have at least what the extraction needs
+	 * When   the precheck runs
+	 * Then   it reports no shortfall — including the exact-fit boundary, which
+	 *        is room enough and must not be refused.
+	 */
+	public function test_space_shortfall_passes_when_every_directory_has_room(): void
+	{
+		$free = static fn (string $dir) => 1024.0 * 1024;
+		$this->assertNull(pfb_extract_space_shortfall(['/a', '/b'], 1024 * 1024, $free));
+	}
+
+	/**
+	 * Scenario: an unreadable filesystem is not a shortfall
+	 *
+	 * Given  a directory whose free space cannot be read (statfs failed)
+	 * When   the precheck runs
+	 * Then   it reports no shortfall: an unreadable filesystem is not evidence
+	 *        of a full one, and must never refuse a legitimate feed.
+	 */
+	public function test_space_shortfall_ignores_a_directory_it_cannot_probe(): void
+	{
+		$free = static fn (string $dir) => FALSE;
+		$this->assertNull(pfb_extract_space_shortfall(['/a'], PHP_INT_MAX, $free));
+	}
+
+	/**
+	 * Scenario: only real staging directories are probed
+	 *
+	 * Given  a candidate list carrying an empty entry and a relative one (a feed
+	 *        name, not a path)
+	 * When   the precheck runs
+	 * Then   neither is probed, so a feed named like a path cannot make the
+	 *        guard measure the wrong filesystem.
+	 */
+	public function test_space_shortfall_skips_entries_that_are_not_absolute_paths(): void
+	{
+		$probed = [];
+		$free = static function (string $dir) use (&$probed) {
+			$probed[] = $dir;
+			return 0.0;
+		};
+		$this->assertNull(pfb_extract_space_shortfall(['', 'somefeed', '.'], 1, $free));
+		$this->assertSame([], $probed);
+	}
+
+	/**
+	 * Scenario: the precheck measures a real filesystem by default
+	 *
+	 * Given  no injected probe
+	 * When   the precheck runs against a real directory asking for one byte
+	 * Then   it reports no shortfall, proving the default probe is wired to the
+	 *        filesystem rather than returning a constant.
+	 */
+	public function test_space_shortfall_default_probe_reads_the_real_filesystem(): void
+	{
+		$this->assertNull(pfb_extract_space_shortfall([$this->dir], 1));
+		$this->assertSame($this->dir, pfb_extract_space_shortfall([$this->dir], PHP_INT_MAX));
+	}
+
+	// -----------------------------------------------------------------------
+	// The download ceiling
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario: every feed fetch carries the body ceiling
+	 *
+	 * Given  the cURL options pfb_download() loads for every feed
+	 * When   they are read
+	 * Then   the large-variant maximum file size is set to the configured
+	 *        ceiling, so an over-large body is refused by libcurl itself.
+	 */
+	public function test_curl_defaults_carry_the_fetched_body_ceiling(): void
+	{
+		$defaults = $GLOBALS['pfb']['curl_defaults'] ?? [];
+		$this->assertArrayHasKey(CURLOPT_MAXFILESIZE_LARGE, $defaults);
+		$this->assertSame(PFB_DOWNLOAD_MAX_BYTES, $defaults[CURLOPT_MAXFILESIZE_LARGE]);
+	}
+
+	/**
+	 * Scenario: the over-large refusal is distinguishable from a transient error
+	 *
+	 * Given  a cURL error number
+	 * When   the download loop classifies it
+	 * Then   only "maximum file size exceeded" yields a refusal reason — every
+	 *        other error stays a retryable failure and must not be relabelled.
+	 */
+	public function test_download_size_refusal_only_fires_for_the_file_size_error(): void
+	{
+		$this->assertSame('download_too_large', pfb_download_size_refusal(CURLE_FILESIZE_EXCEEDED));
+		foreach ([0, 7, 22, 28, 35, 56, 60] as $errno) {
+			$this->assertNull(pfb_download_size_refusal($errno),
+				"cURL error {$errno} is not a size refusal");
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Wiring inside pfb_download()
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario: no extraction escapes the ceiling
+	 *
+	 * Given  every exec() pfb_download() makes
+	 * When   they are enumerated from the comment-free source
+	 * Then   each one either runs under pfb_extract_cmd() or is a known
+	 *        non-writing call (a listing probe, rsync, or a helper script that
+	 *        writes nothing of the archive's making). A new extraction site
+	 *        added without the ceiling fails here.
+	 */
+	public function test_every_extraction_exec_runs_under_the_ceiling(): void
+	{
+		$allowed = [
+			'exec("/usr/local/bin/rsync',
+			'exec("{$pfb[\'script\']} whoisconvert',
+			'exec("{$pfb[\'script\']} asn_table',
+			'exec("{$pfb[\'script\']} et ',
+			'exec("/usr/bin/tar -tf',
+			'exec(pfb_extract_cmd(',
+		];
+
+		$offsets = [];
+		$at = 0;
+		while (($at = strpos(self::$downloadBody, 'exec(', $at)) !== FALSE) {
+			// curl_exec() is not a shell call.
+			if ($at === 0 || !preg_match('/[A-Za-z0-9_]/', self::$downloadBody[$at - 1])) {
+				$offsets[] = $at;
+			}
+			$at += 5;
+		}
+		$this->assertNotEmpty($offsets, 'the pfb_download() body must contain exec() calls');
+
+		foreach ($offsets as $offset) {
+			$call = substr(self::$downloadBody, $offset, 48);
+			$ok = FALSE;
+			foreach ($allowed as $prefix) {
+				if (strpos($call, $prefix) === 0) {
+					$ok = TRUE;
+					break;
+				}
+			}
+			$this->assertTrue($ok, "unguarded exec() in pfb_download(): {$call}");
+		}
+	}
+
+	/**
+	 * Scenario: each shipped extraction site keeps its ceiling
+	 *
+	 * Given  the extractor invocations pfb_download() runs per archive format
+	 * When   the comment-free source is read
+	 * Then   every one of them is wrapped, so no format — gzip, bzip2, zip or
+	 *        tar, on the staged and the direct paths alike — is left uncapped.
+	 */
+	public function test_each_extraction_site_is_wrapped(): void
+	{
+		$sites = [
+			'exec(pfb_extract_cmd("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb[\'geoipshare\']} >/dev/null 2>&1"), $output, $retval);',
+			'exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);',
+			'exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > {$header_esc}"), $output, $retval);',
+			'exec(pfb_extract_cmd("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);',
+			'exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1"), $output, $retval);',
+			'exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);',
+			'exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc}{$strip} -C {$header_esc} >/dev/null 2>&1"), $output, $retval);',
+			'exec(pfb_extract_cmd("set -o pipefail; /usr/bin/tar -xOf {$file_dwn_esc} |',
+			'exec(pfb_extract_cmd("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C "',
+			'exec(pfb_extract_cmd("{$pfb[\'script\']} xlsx {$header_esc} {$elog}"));',
+		];
+		foreach ($sites as $site) {
+			$this->assertStringContainsString($site, self::$downloadBody);
+		}
+	}
+
+	/**
+	 * Scenario: an over-large body is refused, not retried
+	 *
+	 * Given  the download retry loop
+	 * When   libcurl reports the maximum file size exceeded
+	 * Then   the loop refuses the feed immediately with a named reason rather
+	 *        than re-fetching the same over-large body twice more and then
+	 *        letting a partial response reach MIME validation.
+	 */
+	public function test_download_loop_refuses_an_over_large_body_without_retrying(): void
+	{
+		$this->assertStringContainsString('pfb_download_size_refusal($curl_error)', self::$downloadBody);
+		$this->assertStringContainsString("pfb_validate_log(\$header, 'size',", self::$downloadBody);
+	}
+
+	/**
+	 * Scenario: the staging filesystem is checked before anything is written
+	 *
+	 * Given  a downloaded body about to be decompressed
+	 * When   the source is read
+	 * Then   the free-space precheck runs ahead of the decompression dispatch,
+	 *        so a full filesystem refuses the feed instead of being filled.
+	 */
+	public function test_free_space_precheck_runs_before_the_decompression_dispatch(): void
+	{
+		$check    = strpos(self::$downloadBody, 'pfb_extract_space_shortfall(');
+		$dispatch = strpos(self::$downloadBody, "if (\$file_type == 'application/x-gzip' || \$file_type == 'application/gzip')");
+		$this->assertNotFalse($check, 'pfb_download() must run the free-space precheck');
+		$this->assertNotFalse($dispatch);
+		$this->assertLessThan($dispatch, $check);
+	}
+}

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -306,7 +306,12 @@ final class DownloadSizeCeilingTest extends TestCase
 			'exec("{$pfb[\'script\']} xlsx {$header_esc} {$elog}");',
 			// Lists an archive; extracts nothing.
 			'exec("/usr/bin/tar -tf {$file_dwn_esc}");',
-			// Capped.
+			// Capped. This one stays a prefix: it covers ten call sites with ten
+			// different argument lists. So a command concatenated onto a capped call
+			// is invisible HERE -- but not uncapped: ulimit is process-scoped, so the
+			// prefix pfb_extract_cmd() returns still bounds whatever follows it in the
+			// same exec(). Probed with a real over-ceiling tar appended to a wrapped
+			// call: the write was truncated at the ceiling anyway.
 			'exec(pfb_extract_cmd(',
 		];
 

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -330,6 +330,11 @@ final class DownloadSizeCeilingTest extends TestCase
 	 *        pfblockerng_apply.inc is the reason this sweep is tree-wide rather
 	 *        than scoped to pfb_download(): an expansion bomb does not care which
 	 *        function opened the archive.
+	 *
+	 * Blind spots, verified absent from src/ today rather than assumed: a command
+	 * held in a variable or built by a heredoc, a bare `tar` with no path, and the
+	 * other process launchers (passthru/shell_exec/system/proc_open/popen). Any of
+	 * those forms would need adding here.
 	 */
 	public function test_no_extraction_exec_anywhere_in_the_package_is_uncapped(): void
 	{

--- a/tests/php/DownloadSizeRefusalTest.php
+++ b/tests/php/DownloadSizeRefusalTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2658 — an over-large feed body is refused at download, once.
+ *
+ * Drives the REAL pfb_download() against a local `php -S` server over the real
+ * cURL path, with the ceiling lowered on $pfb['curl_defaults'] so a handful of
+ * bytes is "over-large" (the shipped value is gigabytes; DownloadSizeCeilingTest
+ * pins that value). What is under test here is behaviour, not wiring: libcurl
+ * raises error 63, pfb_download() refuses instead of retrying, the partial body
+ * is removed, and the refusal is logged distinguishably.
+ *
+ * The single-attempt assertion is the load-bearing one. Without the refusal
+ * branch the retry loop treats 63 like any transient error and re-fetches the
+ * same over-large body twice more, five seconds apart, before failing — and the
+ * response code libcurl has already collected can be a 200, which would carry a
+ * truncated body on to MIME validation as though it were the whole feed.
+ *
+ * The feed host is a non-local name resolved to 127.0.0.1 through the
+ * $GLOBALS['pfb_test_resolve_map'] hook, mirroring DownloadRetryBodyResetTest:
+ * a literal 127.0.0.1 URL takes the localfile path and never reaches cURL.
+ */
+#[CoversFunction('pfb_download')]
+final class DownloadSizeRefusalTest extends TestCase
+{
+	/** Ceiling used for this test only — far below any body the fixture serves. */
+	private const CEILING = 64;
+
+	/** @var resource|null the php -S server process */
+	private $server = null;
+
+	private string $workdir = '';
+	private int $port = 0;
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	/** @var array<int,mixed> saved curl defaults entry (sentinel FALSE = was unset) */
+	private $savedCeiling = FALSE;
+
+	protected function setUp(): void
+	{
+		if (!extension_loaded('curl')) {
+			$this->markTestSkipped('curl extension not available');
+		}
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbsz');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb_test_configured_ips'] = [];
+		// Loopback first (the pinned connection address, admitted by the self-IP
+		// carve-out) plus a public address so the host is not classified self-hosted.
+		$GLOBALS['pfb_test_resolve_map'] = [
+			'oversize-feed.example.' => [
+				['type' => 'A', 'data' => '127.0.0.1'],
+				['type' => 'A', 'data' => '203.0.113.21'],
+			],
+		];
+
+		foreach (['log', 'errlog', 'pnow', 'runlog', 'runlog_active'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : FALSE;
+		}
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+		$GLOBALS['pfb']['log']    = "{$workdir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$workdir}/error.log";
+		$GLOBALS['pfb']['pnow']   = 'now';
+
+		$this->savedCeiling = array_key_exists(CURLOPT_MAXFILESIZE_LARGE, $GLOBALS['pfb']['curl_defaults'] ?? [])
+			? $GLOBALS['pfb']['curl_defaults'][CURLOPT_MAXFILESIZE_LARGE]
+			: FALSE;
+		$GLOBALS['pfb']['curl_defaults'][CURLOPT_MAXFILESIZE_LARGE] = self::CEILING;
+
+		$this->startServer();
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->server)) {
+			proc_terminate($this->server);
+			proc_close($this->server);
+		}
+		if ($this->savedCeiling === FALSE) {
+			unset($GLOBALS['pfb']['curl_defaults'][CURLOPT_MAXFILESIZE_LARGE]);
+		} else {
+			$GLOBALS['pfb']['curl_defaults'][CURLOPT_MAXFILESIZE_LARGE] = $this->savedCeiling;
+		}
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === FALSE) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map'], $GLOBALS['pfb_test_configured_ips']);
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $f) {
+				@unlink((string) $f);
+			}
+			rmdir($this->workdir);
+		}
+	}
+
+	/**
+	 * Two routes, both far over the ceiling, one per enforcement shape:
+	 * /declared announces its length up front; /streamed announces nothing and
+	 * dribbles the body out, so only a mid-transfer check can stop it. Every
+	 * request appends a line to the request log.
+	 */
+	private function startServer(): void
+	{
+		$router = "{$this->workdir}/router.php";
+		$routerSrc = <<<'PHP'
+<?php
+file_put_contents(getenv('REQ_LOG'), ($_SERVER['REQUEST_URI'] ?? '') . PHP_EOL, FILE_APPEND);
+$chunk = str_repeat('A', 1024);
+header('Content-Type: text/plain');
+if (str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/declared')) {
+	header('Content-Length: ' . (string) (4 * 1024));
+}
+for ($i = 0; $i < 4; $i++) {
+	echo $chunk;
+	flush();
+}
+PHP;
+		$this->assertNotFalse(file_put_contents($router, $routerSrc));
+
+		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		for ($try = 0; $try < 10; $try++) {
+			$port = random_int(20000, 60000);
+			$proc = proc_open(
+				['php', '-S', "127.0.0.1:{$port}", $router],
+				$descriptors,
+				$pipes,
+				$this->workdir,
+				['REQ_LOG' => "{$this->workdir}/requests.log", 'PATH' => (string) getenv('PATH')]
+			);
+			if (!is_resource($proc)) {
+				continue;
+			}
+			for ($i = 0; $i < 40; $i++) {
+				$sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.05);
+				if ($sock !== FALSE) {
+					fclose($sock);
+					$this->server = $proc;
+					$this->port = $port;
+					return;
+				}
+				usleep(50000);
+			}
+			proc_terminate($proc);
+			proc_close($proc);
+		}
+		$this->fail('could not start the php -S fixture server');
+	}
+
+	/** @return int the number of requests the fixture server saw */
+	private function requestCount(): int
+	{
+		$lines = @file("{$this->workdir}/requests.log", FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		return is_array($lines) ? count($lines) : 0;
+	}
+
+	private function logText(): string
+	{
+		return (string) @file_get_contents((string) $GLOBALS['pfb']['log']);
+	}
+
+	private function fetch(string $route, string $header): PfbDownloadResult
+	{
+		return pfb_download(new PfbDownloadRequest(
+			listUrl: "http://oversize-feed.example:{$this->port}{$route}",
+			downloadPath: "{$this->workdir}/feed",
+			flex: FALSE,
+			header: $header,
+			format: '',
+			logType: 1,
+			versionType: '',
+			timeout: 30,
+			type: '',
+			username: '',
+			password: '',
+			sourceInterface: FALSE,
+			extraHeaders: array(),
+		));
+	}
+
+	/**
+	 * Scenario: a body whose declared length is over the ceiling
+	 *
+	 * Given a feed that announces 4 KiB against a 64-byte ceiling
+	 * When pfb_download() fetches it
+	 * Then the download fails, the fixture server sees exactly ONE request (the
+	 *   refusal is permanent, not retried), nothing is left behind in the
+	 *   download file, and the log names the reason rather than showing a bare
+	 *   cURL error number.
+	 */
+	public function test_declared_over_ceiling_body_is_refused_once(): void
+	{
+		$result = $this->fetch('/declared', 'OversizeDeclared');
+
+		$this->assertFalse($result->success, 'an over-large body must not download successfully');
+		$this->assertSame(1, $this->requestCount(),
+			'an over-large body is a permanent refusal — it must not be re-fetched');
+		$this->assertFileDoesNotExist("{$this->workdir}/feed.raw",
+			'the partial body must not be left on disk');
+		$this->assertStringContainsString('stage=size reason=download_too_large', $this->logText(),
+			'the refusal must be logged distinguishably, not as a generic download failure');
+	}
+
+	/**
+	 * Scenario: a body that announces no length at all
+	 *
+	 * Given a feed that streams 4 KiB with no Content-Length, so the ceiling can
+	 *   only be enforced once bytes are already arriving
+	 * When pfb_download() fetches it
+	 * Then it is refused exactly as the declared-length case is — proving the
+	 *   guard does not depend on a cooperative server announcing its size.
+	 */
+	public function test_streamed_over_ceiling_body_is_refused_once(): void
+	{
+		$result = $this->fetch('/streamed', 'OversizeStreamed');
+
+		$this->assertFalse($result->success, 'an over-large streamed body must not download successfully');
+		$this->assertSame(1, $this->requestCount(),
+			'an over-large body is a permanent refusal — it must not be re-fetched');
+		$this->assertFileDoesNotExist("{$this->workdir}/feed.raw",
+			'the partial body must not be left on disk');
+		$this->assertStringContainsString('stage=size reason=download_too_large', $this->logText(),
+			'the refusal must be logged distinguishably, not as a generic download failure');
+	}
+
+	/**
+	 * Scenario: a body under the ceiling is untouched
+	 *
+	 * Given the same fixture server and a ceiling above the body it serves
+	 * When pfb_download() fetches it
+	 * Then the download succeeds — proving the refusal above is a real branch
+	 *   and not an always-reject path.
+	 */
+	public function test_body_under_the_ceiling_still_downloads(): void
+	{
+		$GLOBALS['pfb']['curl_defaults'][CURLOPT_MAXFILESIZE_LARGE] = 1024 * 1024;
+
+		$result = $this->fetch('/declared', 'UnderCeiling');
+
+		$this->assertTrue($result->success, 'a body under the ceiling must still download');
+		$this->assertStringNotContainsString('reason=download_too_large', $this->logText());
+		// The ingest path moves the body on from {feed}.raw once it validates (adding a
+		// trailing newline), so the proof it arrived whole is the published copy.
+		$this->assertSame(4 * 1024,
+			substr_count((string) @file_get_contents("{$this->workdir}/feed.orig"), 'A'),
+			'the whole body must reach the publication, not a truncated prefix');
+	}
+}

--- a/tests/php/DownloadSizeRefusalTest.php
+++ b/tests/php/DownloadSizeRefusalTest.php
@@ -43,6 +43,9 @@ final class DownloadSizeRefusalTest extends TestCase
 	/** @var array<int,mixed> saved curl defaults entry (sentinel FALSE = was unset) */
 	private $savedCeiling = FALSE;
 
+	/** @var array<string,mixed> saved fixture globals (sentinel: absent key = was unset) */
+	private array $savedGlobals = [];
+
 	protected function setUp(): void
 	{
 		if (!extension_loaded('curl')) {
@@ -53,6 +56,12 @@ final class DownloadSizeRefusalTest extends TestCase
 		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
 		$this->workdir = $workdir;
 
+		// Save before replacing: a sibling test's fixture state must survive this one.
+		foreach (['config', 'pfb_test_configured_ips', 'pfb_test_resolve_map'] as $g) {
+			if (array_key_exists($g, $GLOBALS)) {
+				$this->savedGlobals[$g] = $GLOBALS[$g];
+			}
+		}
 		$GLOBALS['config'] = [];
 		$GLOBALS['pfb_test_configured_ips'] = [];
 		// Loopback first (the pinned connection address, admitted by the self-IP
@@ -98,7 +107,14 @@ final class DownloadSizeRefusalTest extends TestCase
 				$GLOBALS['pfb'][$k] = $prev;
 			}
 		}
-		unset($GLOBALS['config'], $GLOBALS['pfb_test_resolve_map'], $GLOBALS['pfb_test_configured_ips']);
+		foreach (['config', 'pfb_test_configured_ips', 'pfb_test_resolve_map'] as $g) {
+			if (array_key_exists($g, $this->savedGlobals)) {
+				$GLOBALS[$g] = $this->savedGlobals[$g];
+			} else {
+				unset($GLOBALS[$g]);
+			}
+		}
+		$this->savedGlobals = [];
 		if ($this->workdir !== '' && is_dir($this->workdir)) {
 			foreach ((array) glob("{$this->workdir}/*") as $f) {
 				@unlink((string) $f);

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -3354,6 +3354,19 @@
             }
         ]
     },
+    "pfb_download_size_refusal": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "curl_errno",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
     "pfb_due_ledger_cache_valid": {
         "returnsRef": false,
         "returnType": "bool",
@@ -4071,6 +4084,66 @@
         "returnsRef": false,
         "returnType": "array",
         "params": []
+    },
+    "pfb_extract_cap_note": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "retval",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
+    "pfb_extract_cmd": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "cmd",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "blocks",
+                "byRef": false,
+                "variadic": false,
+                "type": "?int",
+                "default": "NULL"
+            }
+        ]
+    },
+    "pfb_extract_space_shortfall": {
+        "returnsRef": false,
+        "returnType": "?string",
+        "params": [
+            {
+                "name": "dirs",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "need",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "free",
+                "byRef": false,
+                "variadic": false,
+                "type": "?callable",
+                "default": "NULL"
+            }
+        ]
     },
     "pfb_extras_credentials": {
         "returnsRef": false,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -3354,19 +3354,6 @@
             }
         ]
     },
-    "pfb_download_size_refusal": {
-        "returnsRef": false,
-        "returnType": "?string",
-        "params": [
-            {
-                "name": "curl_errno",
-                "byRef": false,
-                "variadic": false,
-                "type": "int",
-                "default": null
-            }
-        ]
-    },
     "pfb_due_ledger_cache_valid": {
         "returnsRef": false,
         "returnType": "bool",
@@ -4113,8 +4100,8 @@
                 "name": "blocks",
                 "byRef": false,
                 "variadic": false,
-                "type": "?int",
-                "default": "NULL"
+                "type": "int",
+                "default": "4194304"
             }
         ]
     },

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -2737,6 +2737,100 @@ def _recent_validate_lines(vm: SmokeVM, limit: int = 5) -> str:
     return "\n".join(lines[-limit:]) if lines else "(no 'pfb_validate:' line found in the log)"
 
 
+# --------------------------------------------------------------------------- #
+# issue #2658 — the ingest size ceilings, proved against the appliance itself.
+#
+# The shipped ceilings are deliberately generous (gigabytes), so tripping them
+# with real bytes is not something a smoke VM can afford. What the appliance —
+# and only the appliance — can answer is whether the two MECHANISMS the ceilings
+# rest on actually work there: does FreeBSD's /bin/sh honour the ulimit prefix and
+# surface the kill as a nonzero status, and does the appliance's libcurl enforce
+# its maximum-file-size option. Each case pairs that live probe with proof that
+# the deployed package is wired to the same mechanism.
+# --------------------------------------------------------------------------- #
+
+_PFB_INC = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
+
+
+@pytest.mark.timeout(120)
+def test_extraction_ceiling_stops_an_oversized_write(deployed_vm: SmokeVM) -> None:
+    """issue #2658: the extraction ceiling really stops a writing child on FreeBSD.
+
+    Every archive extraction now runs behind ``ulimit -f`` so a small archive that
+    expands to gigabytes is killed by the kernel instead of filling the staging
+    filesystem. Whether that holds is a property of the appliance's shell and
+    kernel, not of PHP: FreeBSD's /bin/sh must accept the prefix, the kernel must
+    raise SIGXFSZ at the limit, and the shell must report the kill as the nonzero
+    status the extraction gates already reject.
+
+    Given a two-block ceiling and a child asked to write one MiB
+    When the wrapped command runs on the appliance
+    Then the child is killed at the ceiling — the status is nonzero and the file on
+      disk is a couple of KiB, not the MiB that was requested — and the deployed
+      package wraps its extractions in that same construct.
+    """
+    target = "/tmp/pfb2658_extract_probe"
+    deployed_vm.ssh("rm", "-f", target)
+    probe = deployed_vm.ssh(
+        f"{{ ulimit -f 2 || exit 1; /bin/dd if=/dev/zero of={target} bs=1024 count=1024; }} 2>/dev/null; "
+        f"echo rc=$?; /usr/bin/stat -f %z {target}"
+    )
+    deployed_vm.ssh("rm", "-f", target)
+    out = probe.stdout
+
+    assert "rc=0" not in out, (
+        f"the ceiling did not stop the write on this appliance — probe output: {out!r} {probe.stderr!r}"
+    )
+    rc_line = next((ln for ln in out.splitlines() if ln.startswith("rc=")), "")
+    size_line = out.strip().splitlines()[-1] if out.strip() else ""
+    assert rc_line == "rc=153", (
+        f"expected the SIGXFSZ exit status (128+25) the cap note keys on, got {rc_line!r} — full probe output: {out!r}"
+    )
+    assert size_line.isdigit() and int(size_line) < 1024 * 1024, (
+        f"the ceiling must truncate the write, not merely report on it — wrote {size_line!r} bytes"
+    )
+
+    wiring = deployed_vm.ssh("grep", "-c", "exec(pfb_extract_cmd(", _PFB_INC)
+    assert wiring.stdout.strip().isdigit() and int(wiring.stdout.strip()) > 0, (
+        f"the deployed package runs no extraction under the ceiling — grep said {wiring.stdout!r}"
+    )
+
+
+@pytest.mark.timeout(120)
+def test_download_ceiling_refuses_an_oversized_body(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """issue #2658: the appliance's libcurl enforces the maximum-file-size option.
+
+    The download ceiling is only worth setting if the libcurl the appliance ships
+    acts on it; the option's documented behaviour differs by version, which is why
+    the ticket asks for it to be probed on the box rather than assumed. This drives
+    the appliance's own libcurl against the mock feed with the ceiling lowered to a
+    handful of bytes and asserts it refuses with error 63 — the code the reject
+    branch keys on and the code the shipped error table already names.
+
+    Given a real feed body served over HTTP and a ceiling far below it
+    When the appliance fetches it with that ceiling
+    Then libcurl refuses with "maximum file size exceeded" (63) rather than writing
+      the body out, and the deployed package sets that same option for every feed.
+    """
+    feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
+    out_path = "/tmp/pfb2658_download_probe"
+    deployed_vm.ssh("rm", "-f", out_path)
+    probe = deployed_vm.ssh(
+        f"/usr/local/bin/curl -s --max-filesize 16 -o {out_path} {shlex.quote(feed_url)}; echo rc=$?"
+    )
+    deployed_vm.ssh("rm", "-f", out_path)
+
+    assert "rc=63" in probe.stdout, (
+        "the appliance's libcurl did not refuse an over-large body with error 63 "
+        f"— probe output: {probe.stdout!r} {probe.stderr!r}"
+    )
+
+    wiring = deployed_vm.ssh("grep", "-c", "CURLOPT_MAXFILESIZE_LARGE", _PFB_INC)
+    assert wiring.stdout.strip().isdigit() and int(wiring.stdout.strip()) > 0, (
+        f"the deployed package sets no download ceiling — grep said {wiring.stdout!r}"
+    )
+
+
 @pytest.mark.timeout(120)
 def test_validate_log_structural_reject_line(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """ADR-48 P3: a structural-probe reject emits the canonical stage=structural line.

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -52,6 +52,7 @@ import gzip
 import io
 import ipaddress
 import os
+import re
 import shlex
 import subprocess
 import tarfile
@@ -2752,6 +2753,19 @@ def _recent_validate_lines(vm: SmokeVM, limit: int = 5) -> str:
 _PFB_INC = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
 
 
+def _shipped_define(name: str) -> str:
+    """The verbatim ``define('<name>', <value>);`` line from the repo's own source.
+
+    Asserting the box carries THIS line — rather than re-typing the number here —
+    proves the deployed package is the one under test without duplicating the
+    constant into the test.
+    """
+    source = (FIXTURES_DIR.parent.parent.parent / "src/usr/local/pkg/pfblockerng/pfblockerng.inc").read_text()
+    match = re.search(rf"^define\('{re.escape(name)}', \d+\);$", source, re.MULTILINE)
+    assert match is not None, f"{name} is not defined in the repo source"
+    return match.group(0)
+
+
 @pytest.mark.timeout(120)
 def test_extraction_ceiling_stops_an_oversized_write(deployed_vm: SmokeVM) -> None:
     """issue #2658: the extraction ceiling really stops a writing child on FreeBSD.
@@ -2767,7 +2781,7 @@ def test_extraction_ceiling_stops_an_oversized_write(deployed_vm: SmokeVM) -> No
     When the wrapped command runs on the appliance
     Then the child is killed at the ceiling — the status is nonzero and the file on
       disk is a couple of KiB, not the MiB that was requested — and the deployed
-      package wraps its extractions in that same construct.
+      package carries the shipped ceiling and runs its extractions under it.
     """
     target = "/tmp/pfb2658_extract_probe"
     deployed_vm.ssh("rm", "-f", target)
@@ -2778,19 +2792,22 @@ def test_extraction_ceiling_stops_an_oversized_write(deployed_vm: SmokeVM) -> No
     deployed_vm.ssh("rm", "-f", target)
     out = probe.stdout
 
-    assert "rc=0" not in out, (
-        f"the ceiling did not stop the write on this appliance — probe output: {out!r} {probe.stderr!r}"
-    )
     rc_line = next((ln for ln in out.splitlines() if ln.startswith("rc=")), "")
     size_line = out.strip().splitlines()[-1] if out.strip() else ""
     assert rc_line == "rc=153", (
-        f"expected the SIGXFSZ exit status (128+25) the cap note keys on, got {rc_line!r} — full probe output: {out!r}"
+        f"expected the SIGXFSZ exit status (128+25) the cap note keys on, got {rc_line!r} "
+        f"— full probe output: {out!r} {probe.stderr!r}"
     )
     assert size_line.isdigit() and int(size_line) < 1024 * 1024, (
         f"the ceiling must truncate the write, not merely report on it — wrote {size_line!r} bytes"
     )
 
-    wiring = deployed_vm.ssh("grep", "-c", "exec(pfb_extract_cmd(", _PFB_INC)
+    ceiling = _shipped_define("PFB_EXTRACT_MAX_BLOCKS")
+    shipped = deployed_vm.ssh("grep", "-F", "-c", ceiling, _PFB_INC)
+    assert shipped.stdout.strip() == "1", (
+        f"the deployed package does not carry {ceiling!r} — grep said {shipped.stdout!r}"
+    )
+    wiring = deployed_vm.ssh("grep", "-F", "-c", "exec(pfb_extract_cmd(", _PFB_INC)
     assert wiring.stdout.strip().isdigit() and int(wiring.stdout.strip()) > 0, (
         f"the deployed package runs no extraction under the ceiling — grep said {wiring.stdout!r}"
     )
@@ -2798,36 +2815,49 @@ def test_extraction_ceiling_stops_an_oversized_write(deployed_vm: SmokeVM) -> No
 
 @pytest.mark.timeout(120)
 def test_download_ceiling_refuses_an_oversized_body(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
-    """issue #2658: the appliance's libcurl enforces the maximum-file-size option.
+    """issue #2658: the appliance's own ext/curl enforces the maximum-file-size option.
 
     The download ceiling is only worth setting if the libcurl the appliance ships
     acts on it; the option's documented behaviour differs by version, which is why
     the ticket asks for it to be probed on the box rather than assumed. This drives
-    the appliance's own libcurl against the mock feed with the ceiling lowered to a
-    handful of bytes and asserts it refuses with error 63 — the code the reject
-    branch keys on and the code the shipped error table already names.
+    the appliance's ext/curl — the same extension pfb_download() uses — against the
+    mock feed with the ceiling lowered to a handful of bytes, and asserts it refuses
+    with error 63: the code the reject branch keys on and the code the shipped error
+    table already names.
+
+    The no-Content-Length (mid-transfer) shape is covered off-appliance by
+    ``tests/php/DownloadSizeRefusalTest``, which drives the real pfb_download()
+    against a streaming fixture server; the mock feed server here always declares a
+    length, so this case pins the appliance-specific half.
 
     Given a real feed body served over HTTP and a ceiling far below it
-    When the appliance fetches it with that ceiling
-    Then libcurl refuses with "maximum file size exceeded" (63) rather than writing
-      the body out, and the deployed package sets that same option for every feed.
+    When the appliance's ext/curl fetches it with that ceiling
+    Then it refuses with "maximum file size exceeded" (63) rather than writing the
+      body out, and the deployed package sets that same option for every feed.
     """
     feed_url = mock_feeds.feed_url("ip_plain_cidr.txt")
-    out_path = "/tmp/pfb2658_download_probe"
-    deployed_vm.ssh("rm", "-f", out_path)
-    probe = deployed_vm.ssh(
-        f"/usr/local/bin/curl -s --max-filesize 16 -o {out_path} {shlex.quote(feed_url)}; echo rc=$?"
+    snippet = (
+        f"$c = curl_init({feed_url!r});"
+        " curl_setopt($c, CURLOPT_MAXFILESIZE_LARGE, 16);"
+        " curl_setopt($c, CURLOPT_RETURNTRANSFER, TRUE);"
+        " curl_exec($c);"
+        ' echo "errno=" . curl_errno($c) . "\n";'
     )
-    deployed_vm.ssh("rm", "-f", out_path)
+    probe = deployed_vm.ssh("/usr/local/bin/php", "-r", snippet)
 
-    assert "rc=63" in probe.stdout, (
-        "the appliance's libcurl did not refuse an over-large body with error 63 "
+    assert "errno=63" in probe.stdout, (
+        "the appliance's ext/curl did not refuse an over-large body with error 63 "
         f"— probe output: {probe.stdout!r} {probe.stderr!r}"
     )
 
-    wiring = deployed_vm.ssh("grep", "-c", "CURLOPT_MAXFILESIZE_LARGE", _PFB_INC)
-    assert wiring.stdout.strip().isdigit() and int(wiring.stdout.strip()) > 0, (
-        f"the deployed package sets no download ceiling — grep said {wiring.stdout!r}"
+    ceiling = _shipped_define("PFB_DOWNLOAD_MAX_BYTES")
+    shipped = deployed_vm.ssh("grep", "-F", "-c", ceiling, _PFB_INC)
+    assert shipped.stdout.strip() == "1", (
+        f"the deployed package does not carry {ceiling!r} — grep said {shipped.stdout!r}"
+    )
+    wiring = deployed_vm.ssh("grep", "-F", "-c", "CURLOPT_MAXFILESIZE_LARGE => PFB_DOWNLOAD_MAX_BYTES", _PFB_INC)
+    assert wiring.stdout.strip() == "1", (
+        f"the deployed package does not set the download ceiling — grep said {wiring.stdout!r}"
     )
 
 


### PR DESCRIPTION
## What this changes

Feed ingest had no size bound at either half: a body far larger than anything
legitimate was downloaded in full, and a small archive that expanded to gigabytes
was extracted in full into the staging filesystem. This adds the three guards the
ticket asks for, all set well above what any real feed reaches.

### 1. Download ceiling

`$pfb['curl_defaults']` now carries `CURLOPT_MAXFILESIZE_LARGE`
(`PFB_DOWNLOAD_MAX_BYTES`, 2 GiB), and cURL error 63 gets its own branch in
`pfb_download()`'s retry loop via `pfb_download_size_refusal()`.

The branch refuses immediately rather than retrying. Two reasons: a body over the
ceiling is over it on every attempt, and the response code libcurl has already
collected can be a `200`, which would otherwise carry the truncated body through
to MIME validation as if it were the whole feed. The refusal writes a
`stage=size reason=download_too_large` line through the existing
`pfb_validate_log()` vocabulary and drops the partial `.raw`.

### 2. Extraction ceiling

Every extraction now runs through `pfb_extract_cmd()`, which prefixes
`ulimit -f <blocks> || exit 1;`. `RLIMIT_FSIZE` is inherited by every descendant,
so one prefix covers pipelines and the extractor's own children; a write past the
ceiling is killed with `SIGXFSZ` and the existing nonzero-exit gates reject the
extraction. `|| exit 1` keeps it fail-closed — a shell that cannot set the limit
runs no extractor at all.

`pfb_extract_cap_note()` appends a named reason to each extraction failure log
when the exit status is the `SIGXFSZ` one, so an operator reads "output exceeded
the extraction size ceiling" instead of a bare `exit 153`.

Eleven sites are wrapped: the ten the ticket enumerates, plus
`pfb_apply_gunzip_orig_pipeline()` in `pfblockerng_apply.inc`, which runs the same
`gunzip -c > staged` on the ingest reuse path. An expansion bomb does not care
which function opened the archive, so the guard test sweeps every shipped PHP
file, not just `pfb_download()`.

The XLSX site is deliberately **not** capped. `processxlsx()` reports success by
its output file existing rather than by an exit status, so a child killed at the
ceiling would publish a truncated feed as a successful ingest — strictly worse
than no cap. Capping it needs an exit gate in that shell function first
(issue #2666). A second test enumerates every `exec()` in `pfb_download()` and
fails on any that is neither wrapped nor an allow-listed non-extracting call, so
the exception is recorded where it is enforced rather than only in prose.

### 3. Free-space precheck

`pfb_extract_space_shortfall()` runs once, ahead of the decompression dispatch,
over the staging directories the branch below can write to, and refuses before
anything is written when one of them has less free than the archive itself.

The requirement is the archive's own size and nothing more. An earlier cut of this
PR also imposed a 64 MiB floor; review caught that this is larger than the whole of
`/var` on a default `use_mfs_tmpvar` install, where `/var` is a 60 MiB RAM disk —
every feed would have been refused forever. The floor is gone, and
`pfb_archive_probe()` — which already answers "is this an archive" — scopes the
guard to the types that actually extract, so a plain text feed never meets it.

A directory whose free space cannot be read is deliberately not a shortfall: a
failed `statfs` is not evidence of a full disk and must not refuse a legitimate
feed.

## Known limit, stated deliberately

`ulimit -f` sets `RLIMIT_FSIZE`, which the kernel applies **per file**, not per
extraction. A multi-member archive is therefore bounded per member plus the
free-space precheck, not by a single total. The ticket names `ulimit -f` as the
intended shape and puts member-count and nesting limits out of scope, so this
ships as specified; the limit is documented at the helper rather than left for a
reader to discover.

The `ulimit` block size is shell-defined — 512 bytes under a POSIX `sh`, 1024
under `bash` — so the effective ceiling lands between 2 GiB and 4 GiB depending
on which `/bin/sh` runs the extraction. Both readings bound an expansion bomb and
clear every real feed, so the ambiguity is documented rather than resolved. Probed
both ways rather than assumed:

```console
$ dash -c 'ulimit -f 2; dd if=/dev/zero of=/tmp/x bs=1024 count=1024 2>/dev/null'; ls -l /tmp/x
rc=153   ... 1024 bytes    # 512-byte blocks
$ /bin/sh -c 'ulimit -f 2; dd if=/dev/zero of=/tmp/y bs=1024 count=1024 2>/dev/null'; ls -l /tmp/y
rc=153   ... 2048 bytes    # 1024-byte blocks (bash)
```

## Tests

### Red → green

Two proofs, each with its test file byte-identical across the red and the green
run. Neither digest is a claim about the current file: review changed
`DownloadSizeCeilingTest.php` after its proof, so each block records the commit
its runs were performed at.

**1. The guard's unit and wiring coverage** — `tests/php/DownloadSizeCeilingTest.php`
at `70d761b4`, hash `8729568ca8ecbc4f1aef7fa96828409a3d13afa2` on both runs:

```console
# RED — production file restored to devel content, tests unchanged
$ vendor/bin/phpunit --filter DownloadSizeCeilingTest
Tests: 16, Assertions: 8, Errors: 11, Failures: 5.

# GREEN — production change applied, same test file byte-for-byte
$ vendor/bin/phpunit --filter DownloadSizeCeilingTest
OK (16 tests, 64 assertions)
```

**2. The download refusal, behaviourally** — `tests/php/DownloadSizeRefusalTest.php`
at the current head, hash `dc174f6332342b5606449ac1239ebadaf95073df` on both runs
and equal to the committed file:

```console
# RED — pfblockerng.inc and pfblockerng_apply.inc restored to devel content
$ git hash-object tests/php/DownloadSizeRefusalTest.php
dc174f6332342b5606449ac1239ebadaf95073df
$ vendor/bin/phpunit --filter DownloadSizeRefusalTest
1) DownloadSizeRefusalTest::test_declared_over_ceiling_body_is_refused_once
an over-large body must not download successfully
Failed asserting that true is false.
2) DownloadSizeRefusalTest::test_streamed_over_ceiling_body_is_refused_once
an over-large streamed body must not download successfully
Failed asserting that true is false.
Tests: 3, Assertions: 14, Failures: 2.

# GREEN — production change applied, same test file byte-for-byte
$ git hash-object tests/php/DownloadSizeRefusalTest.php
dc174f6332342b5606449ac1239ebadaf95073df
$ vendor/bin/phpunit --filter DownloadSizeRefusalTest
OK (3 tests, 20 assertions)
```

That `true` in the red run is the defect itself: without the refusal branch the
download reports **success**, because the `200` libcurl has already collected
carries the truncated body on to MIME validation as though it were the whole feed.
Both enforcement shapes fail — declared `Content-Length` and no length at all — so
the guard does not rest on a cooperative server announcing its size.

The unit cases cover the wrapper's exact shape, a live `/bin/sh` run proving the
ceiling kills a writing child and truncates its output (paired with a run under the
ceiling proving it rejects nothing legitimate), the cap-note branch on both sides,
six free-space cases including the exact-fit boundary and the unreadable-`statfs`
fail-open, the shipped cURL option, and the wiring pins inside `pfb_download()`.

### Full suites

```console
$ vendor/bin/phpunit
Tests: 5423, Assertions: 30801, Warnings: 29, Deprecations: 3, Notices: 1.   (0 failures)

$ vendor/bin/phpstan analyse --no-progress --memory-limit=2G
[OK] No errors

$ vendor/bin/phpcs -d memory_limit=1G
(clean)

$ uv run ruff check tests/smoke/test_smoke_feeds.py && uv run mypy tests/smoke/test_smoke_feeds.py
All checks passed! / Success: no issues found in 1 source file
```

`tests/php/fixtures/function_inventory.json` is regenerated for the four new
helpers.

### Live-VM smoke

Two new cases in `tests/smoke/test_smoke_feeds.py` answer the two questions only
the appliance can answer, since the shipped ceilings are too large to trip with
real bytes on a smoke VM:

- `test_extraction_ceiling_stops_an_oversized_write` — FreeBSD's `/bin/sh`
  honours the `ulimit` prefix, the kernel raises `SIGXFSZ` at the ceiling, the
  shell reports the exit status the cap note keys on, and the write is truncated.
- `test_download_ceiling_refuses_an_oversized_body` — the appliance's own libcurl
  refuses an over-large body with error 63. This is the probe the ticket's
  implementation note asks for before relying on the option.

Each pairs its live probe with a grep proving the deployed package is wired to
that mechanism. Those greps are what make the pair red on an unpatched box —
neither string exists on `devel`:

```console
$ git grep -c 'exec(pfb_extract_cmd(' origin/devel -- src ; echo "rc=$?"
rc=1
$ git grep -c 'CURLOPT_MAXFILESIZE' origin/devel -- src ; echo "rc=$?"
rc=1
```

A true red-before smoke run is not constructible for these two: `local-smoke.sh`
checks the test file out on the box from the ref under test, so a `devel` leg has
no such tests to run. The live run below is the green half; the red half is the
grep above.

Regression side (the ticket's third test item) is the existing archive corpus —
`test_zip_feed_imports`, `test_gzip_feed_imports`, `test_bzip2_feed_imports` and
the corrupt-archive pairs — which now exercise the wrapped commands end to end.

Executed live run (pfSense CE 2.8.1-RELEASE guest, `scripts/local-smoke.sh --ref
70d761b46d63d6886ec9df89b33a37ec0fcafd19`):

```console
$ scripts/local-smoke.sh --ref 70d761b4… \
    --filter "extraction_ceiling or download_ceiling or feed_imports or corrupt_"
select-box: leased root@10.0.0.35
smoke-on-box: pfSense image identity {"pfsense_version":"2.8.1-RELEASE","image_version":"2.8", …}
collected 1009 items / 997 deselected / 12 selected

tests/smoke/test_smoke_feeds.py::test_extraction_ceiling_stops_an_oversized_write PASSED
tests/smoke/test_smoke_feeds.py::test_download_ceiling_refuses_an_oversized_body  PASSED
tests/smoke/test_smoke_feeds.py::test_zip_feed_imports                            PASSED
tests/smoke/test_smoke_feeds.py::test_gzip_feed_imports                           PASSED
tests/smoke/test_smoke_feeds.py::test_bzip2_feed_imports                          PASSED
tests/smoke/test_smoke_feeds.py::test_corrupt_zip_rejected                        PASSED
tests/smoke/test_smoke_feeds.py::test_corrupt_gzip_rejected                       PASSED
tests/smoke/test_smoke_feeds.py::test_corrupt_bzip2_rejected                      PASSED
tests/smoke/test_smoke_feeds.py::test_structured_text_feed_imports                PASSED

================ 12 passed, 997 deselected in 122.00s (0:02:01) ================
```

Both mechanism questions are now answered on the appliance rather than assumed:
FreeBSD's `/bin/sh` honours the `ulimit` prefix and surfaces the `SIGXFSZ` kill as
the exit status the cap note keys on, and the appliance's libcurl refuses an
over-large body with error 63.

## One CI change rides along

`composer.json` and `.github/workflows/test.yml` move PHPStan from
`--memory-limit=1G` to `2G`. That is not housekeeping folded in — it is this
change's own fallout, disclosed rather than buried.

`PHPStan static analysis / PHP 8.3` went red three times here while `devel` stayed
green, with `Child process error: PHPStan process crashed because it reached
configured PHP memory limit: 1G while running parallel worker` — a resource
ceiling, never an analysis result. The "CI environment" explanation dies on the
evidence: PRs #2654 and #2646 also touch `pfblockerng.inc` and pass that job.
Measured single-process on PHP 8.3, so parallel sharding cannot move the number,
analysing that one file:

```console
$ phpstan analyse --debug src/usr/local/pkg/pfblockerng/pfblockerng.inc   # devel
704774144  maximum resident set size
$ phpstan analyse --debug src/usr/local/pkg/pfblockerng/pfblockerng.inc   # this branch
734920704  maximum resident set size
```

The ceiling had about 4% headroom over the largest file in the tree, and 30 MiB
consumed it. The analysis is untouched — same paths, same level, same baseline —
and CI is green on the bumped limit. Splitting that file is the real fix
(issue #1122).

## Not in scope

Compression-ratio heuristics, member-count and nesting-depth limits, and refusing
archive formats, per the ticket. Three findings from review are tracked
separately rather than folded in: #2666 (`processxlsx()` needs an exit contract
before its path can carry the ceiling), #2667 (the rsync feed path is bounded at
neither half of ingest), and #2668 (the two direct-write GeoIP extraction branches
clobber the live publication when an extraction fails — pre-existing, and the
reason this PR cannot claim the ticket's "previously served data still in place"
for those two).

Part of #2658

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to reject oversized downloads and archive extractions.
  * Added checks for insufficient staging disk space before processing feeds.
  * Improved error reporting and cleanup when size limits are exceeded.
  * Prevented retries for downloads rejected due to excessive size.

* **Chores**
  * Increased static analysis memory allocation to improve workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->