### PR TITLE
alerts: clear the unlock store on suppress and whitelist

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -7491,6 +7491,32 @@ function pfb_alerts_unlock_drop(string $type, array $store, array $tokens): arra
 }
 
 /**
+ * Unlock-store tokens that match what addwhitelistdom actually wrote.
+ *
+ * Non-wildcard whitelist writes domain + www.domain (+ each CNAME). Wildcard
+ * writes .domain (covers www). TLD exclusion writes the exact domain/CNAME
+ * only — tld_wildcard_classify matches exact strings, so dropping www.domain
+ * there would re-lock an unlocked name the exclusion does not cover.
+ *
+ * @param list<string> $cnames
+ * @return list<string>
+ */
+function pfb_alerts_whitelist_unlock_tokens(string $posted, string $stripped, bool $wildcard, bool $exclude, array $cnames): array
+{
+	$tokens = array($posted, $stripped);
+	if (!$exclude && !$wildcard) {
+		$tokens[] = 'www.'.$stripped;
+	}
+	foreach ($cnames as $cname) {
+		if ($cname === '') {
+			continue;
+		}
+		$tokens[] = $cname;
+	}
+	return $tokens;
+}
+
+/**
  * Apply an Alerts IP mutation after the page has filtered its inputs.
  *
  * @return array{redirect: bool, savemsg: string}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -7494,20 +7494,22 @@ function pfb_alerts_unlock_drop(string $type, array $store, array $tokens): arra
  * Unlock-store tokens that match what addwhitelistdom actually wrote.
  *
  * Non-wildcard whitelist writes domain + www.domain (+ each CNAME). Wildcard
- * writes .domain (covers www). TLD exclusion writes the exact domain/CNAME
- * only — tld_wildcard_classify matches exact strings, so dropping www.domain
- * there would re-lock an unlocked name the exclusion does not cover.
+ * writes .domain; the matcher covers www.domain, so that unlock row must drop.
+ * TLD exclusion writes the exact domain/CNAME only — classify is exact-string,
+ * so dropping www.domain there would re-lock an unlocked name the exclusion
+ * does not cover.
  *
- * @param list<string> $cnames
+ * @param array<int, string> $cnames
  * @return list<string>
  */
 function pfb_alerts_whitelist_unlock_tokens(string $posted, string $stripped, bool $wildcard, bool $exclude, array $cnames): array
 {
 	$tokens = array($posted, $stripped);
-	if (!$exclude && !$wildcard) {
+	if (!$exclude) {
 		$tokens[] = 'www.'.$stripped;
 	}
-	foreach ($cnames as $cname) {
+	foreach (array_values($cnames) as $cname) {
+		$cname = trim((string) $cname);
 		if ($cname === '') {
 			continue;
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -7495,13 +7495,13 @@ function pfb_alerts_unlock_drop(string $type, array $store, array $tokens): arra
  *
  * For every written token, also drop www.<token> — the whitelist matcher
  * strips a leading www. unconditionally. TLD exclusion is the exception:
- * classify is exact-string, so the drop-set is stripped + cnames only
- * (posted is included only when it equals stripped).
+ * classify is exact-string, so the drop-set starts as stripped + cnames
+ * (the pre-strip posted form is not added).
  *
  * @param array<int, string> $cnames
  * @return list<string>
  */
-function pfb_alerts_whitelist_unlock_tokens(string $posted, string $stripped, bool $wildcard, bool $exclude, array $cnames): array
+function pfb_alerts_whitelist_unlock_tokens(string $posted, string $stripped, bool $exclude, array $cnames): array
 {
 	$tokens = $exclude ? array($stripped) : array($posted, $stripped);
 	foreach (array_values($cnames) as $cname) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -7530,6 +7530,8 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 			$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'] ?? '';
 			pfb_create_suppression_file();
 		}
+		// issue #2670: durable suppress replaces the temporary unlock row
+		pfb_unlock('lock', 'ip', $ip_unlock, $ip, $table);
 		return $result;
 	}
 
@@ -7574,6 +7576,8 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 		}
 		$data = isset($metadata['data']) && is_array($metadata['data']) ? $metadata['data'] : [];
 		if (isset($data[$ip])) {
+			// issue #2670: already permitted — still drop the stale unlock row
+			pfb_unlock('lock', 'ip', $ip_unlock, $ip, $table);
 			$result['redirect'] = FALSE;
 			return $result;
 		}
@@ -7599,6 +7603,8 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 		$aname = substr(substr($table, 4), 0, -3);
 		touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");
 		$result['savemsg'] = "The IP [ {$ip} ] has been added to the [ {$table} ] Permit Alias customlist.";
+		// issue #2670: durable permit replaces the temporary unlock row
+		pfb_unlock('lock', 'ip', $ip_unlock, $ip, $table);
 		return $result;
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -7466,6 +7466,31 @@ function pfb_live_punch_run(string $pfctl, string $aliasdir, string $dbdir, stri
 }
 
 /**
+ * Drop Alerts unlock-store tokens.
+ *
+ * pfb_unlock('lock') rewrites the file from the in-memory array and does not
+ * unset; a later lock of another token would restore an earlier one unless
+ * this unsets between writes (issue #2670 www. sibling).
+ *
+ * @param array<string, string> $store
+ * @param list<string> $tokens
+ * @return array<string, string>
+ */
+function pfb_alerts_unlock_drop(string $type, array $store, array $tokens): array
+{
+	$seen = array();
+	foreach ($tokens as $token) {
+		if ($token === '' || isset($seen[$token])) {
+			continue;
+		}
+		$seen[$token] = TRUE;
+		pfb_unlock('lock', $type, $store, $token, '');
+		unset($store[$token]);
+	}
+	return $store;
+}
+
+/**
  * Apply an Alerts IP mutation after the page has filtered its inputs.
  *
  * @return array{redirect: bool, savemsg: string}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -7495,15 +7495,15 @@ function pfb_alerts_unlock_drop(string $type, array $store, array $tokens): arra
  *
  * For every written token, also drop www.<token> — the whitelist matcher
  * strips a leading www. unconditionally. TLD exclusion is the exception:
- * classify is exact-string, so dropping www.<token> would re-lock an unlocked
- * name the exclusion does not cover.
+ * classify is exact-string, so the drop-set is stripped + cnames only
+ * (posted is included only when it equals stripped).
  *
  * @param array<int, string> $cnames
  * @return list<string>
  */
 function pfb_alerts_whitelist_unlock_tokens(string $posted, string $stripped, bool $wildcard, bool $exclude, array $cnames): array
 {
-	$tokens = array($posted, $stripped);
+	$tokens = $exclude ? array($stripped) : array($posted, $stripped);
 	foreach (array_values($cnames) as $cname) {
 		$cname = trim((string) $cname);
 		if ($cname === '') {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -7493,11 +7493,10 @@ function pfb_alerts_unlock_drop(string $type, array $store, array $tokens): arra
 /**
  * Unlock-store tokens that match what addwhitelistdom actually wrote.
  *
- * Non-wildcard whitelist writes domain + www.domain (+ each CNAME). Wildcard
- * writes .domain; the matcher covers www.domain, so that unlock row must drop.
- * TLD exclusion writes the exact domain/CNAME only — classify is exact-string,
- * so dropping www.domain there would re-lock an unlocked name the exclusion
- * does not cover.
+ * For every written token, also drop www.<token> — the whitelist matcher
+ * strips a leading www. unconditionally. TLD exclusion is the exception:
+ * classify is exact-string, so dropping www.<token> would re-lock an unlocked
+ * name the exclusion does not cover.
  *
  * @param array<int, string> $cnames
  * @return list<string>
@@ -7505,15 +7504,20 @@ function pfb_alerts_unlock_drop(string $type, array $store, array $tokens): arra
 function pfb_alerts_whitelist_unlock_tokens(string $posted, string $stripped, bool $wildcard, bool $exclude, array $cnames): array
 {
 	$tokens = array($posted, $stripped);
-	if (!$exclude) {
-		$tokens[] = 'www.'.$stripped;
-	}
 	foreach (array_values($cnames) as $cname) {
 		$cname = trim((string) $cname);
 		if ($cname === '') {
 			continue;
 		}
 		$tokens[] = $cname;
+	}
+	if (!$exclude) {
+		foreach ($tokens as $token) {
+			if ($token === '' || str_starts_with($token, 'www.')) {
+				continue;
+			}
+			$tokens[] = 'www.'.$token;
+		}
 	}
 	return $tokens;
 }

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -936,6 +936,8 @@ if (isset($_POST) && !empty($_POST)) {
 			header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 			exit;
 		}
+		// issue #2670: unlock store is keyed by the posted token; www. is stripped below
+		$domain_unlock = $domain;
 
 		$descr = '';
 		if (isset($_POST['descr']) && !empty($_POST['descr'])) {
@@ -1160,6 +1162,14 @@ if (isset($_POST) && !empty($_POST)) {
 				PfbConfig::write('dnsbl/tld_wildcard_exclusion', $clists['tld_wildcard_exclusion']['base64']);
 				write_config("pfBlockerNG: Added [ {$domain} ] to DNSBL TLD Exclusion customlist.", FALSE);
 			}
+		}
+		// issue #2670: durable whitelist/TLD exclusion replaces the temporary unlock row.
+		// pfb_unlock('lock') does not update the in-memory array; unset between tokens
+		// so a www. strip cannot write the first key back.
+		pfb_unlock('lock', 'dnsbl', $dnsbl_unlock, $domain_unlock, '');
+		unset($dnsbl_unlock[$domain_unlock]);
+		if ($domain !== $domain_unlock) {
+			pfb_unlock('lock', 'dnsbl', $dnsbl_unlock, $domain, '');
 		}
 		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 		exit;

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1164,9 +1164,17 @@ if (isset($_POST) && !empty($_POST)) {
 			}
 		}
 		// issue #2670: durable whitelist/TLD exclusion replaces the temporary unlock row.
-		// Posted token, www.-stripped form, and www.<stripped> (the non-wildcard
-		// whitelist writes both domain and www.domain).
-		$dnsbl_unlock = pfb_alerts_unlock_drop('dnsbl', $dnsbl_unlock, array($domain_unlock, $domain, 'www.'.$domain));
+		// Posted token, www.-stripped form, www.<stripped>, and every CNAME the
+		// same POST writes into the whitelist / TLD exclusion (plus www.<CNAME>).
+		$unlock_drop = array($domain_unlock, $domain, 'www.'.$domain);
+		foreach ($cname_list as $cname) {
+			if ($cname === '') {
+				continue;
+			}
+			$unlock_drop[] = $cname;
+			$unlock_drop[] = 'www.'.$cname;
+		}
+		$dnsbl_unlock = pfb_alerts_unlock_drop('dnsbl', $dnsbl_unlock, $unlock_drop);
 		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 		exit;
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1164,16 +1164,7 @@ if (isset($_POST) && !empty($_POST)) {
 			}
 		}
 		// issue #2670: durable whitelist/TLD exclusion replaces the temporary unlock row.
-		// Posted token, www.-stripped form, www.<stripped>, and every CNAME the
-		// same POST writes into the whitelist / TLD exclusion (plus www.<CNAME>).
-		$unlock_drop = array($domain_unlock, $domain, 'www.'.$domain);
-		foreach ($cname_list as $cname) {
-			if ($cname === '') {
-				continue;
-			}
-			$unlock_drop[] = $cname;
-			$unlock_drop[] = 'www.'.$cname;
-		}
+		$unlock_drop = pfb_alerts_whitelist_unlock_tokens($domain_unlock, $domain, $wildcard, $dnsbl_exclude, $cname_list);
 		$dnsbl_unlock = pfb_alerts_unlock_drop('dnsbl', $dnsbl_unlock, $unlock_drop);
 		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 		exit;

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1164,7 +1164,7 @@ if (isset($_POST) && !empty($_POST)) {
 			}
 		}
 		// issue #2670: durable whitelist/TLD exclusion replaces the temporary unlock row.
-		$unlock_drop = pfb_alerts_whitelist_unlock_tokens($domain_unlock, $domain, $wildcard, $dnsbl_exclude, $cname_list);
+		$unlock_drop = pfb_alerts_whitelist_unlock_tokens($domain_unlock, $domain, $dnsbl_exclude, $cname_list);
 		$dnsbl_unlock = pfb_alerts_unlock_drop('dnsbl', $dnsbl_unlock, $unlock_drop);
 		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 		exit;

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1164,13 +1164,9 @@ if (isset($_POST) && !empty($_POST)) {
 			}
 		}
 		// issue #2670: durable whitelist/TLD exclusion replaces the temporary unlock row.
-		// pfb_unlock('lock') does not update the in-memory array; unset between tokens
-		// so a www. strip cannot write the first key back.
-		pfb_unlock('lock', 'dnsbl', $dnsbl_unlock, $domain_unlock, '');
-		unset($dnsbl_unlock[$domain_unlock]);
-		if ($domain !== $domain_unlock) {
-			pfb_unlock('lock', 'dnsbl', $dnsbl_unlock, $domain, '');
-		}
+		// Posted token, www.-stripped form, and www.<stripped> (the non-wildcard
+		// whitelist writes both domain and www.domain).
+		$dnsbl_unlock = pfb_alerts_unlock_drop('dnsbl', $dnsbl_unlock, array($domain_unlock, $domain, 'www.'.$domain));
 		header("Location: /pfblockerng/pfblockerng_alerts.php?savemsg={$savemsg}");
 		exit;
 	}

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -781,6 +781,152 @@ SH
 		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? []);
 	}
 
+	// =====================================================================
+	// issue #2670: successful suppress / whitelist must drop the unlock store
+	// =====================================================================
+
+	public function testAddSuppressNotBlockedClearsMatchingUnlockStoreKeepsOthers(): void
+	{
+		$ip = '198.51.100.40';
+		$table = 'pfB_Deny_v4';
+		$ip_unlock = [$ip => $table, 'keepme.example' => 'pfB_Keep_v4'];
+		file_put_contents($GLOBALS['pfb']['ip_unlock'], "{$ip},{$table}\nkeepme.example,pfB_Keep_v4\n");
+
+		$result = pfb_alerts_ip_action('addsuppress', $ip, $table, 'note', ['ipsuppression' => ['data' => []]], $ip_unlock);
+
+		$this->assertStringContainsString('Not currently blocked', $result['savemsg']);
+		$content = (string) file_get_contents($GLOBALS['pfb']['ip_unlock']);
+		$this->assertStringContainsString('keepme.example', $content, 'unrelated unlock entries must survive suppress');
+		$this->assertStringNotContainsString($ip, $content, 'issue #2670: suppress must drop the matching unlock-store row');
+	}
+
+	public function testAddSuppressAlreadyExistsStillClearsUnlockStore(): void
+	{
+		$ip = '198.51.100.41';
+		$table = 'pfB_Deny_v4';
+		$host_line = "{$ip}/32";
+		$ip_unlock = [$ip => $table, 'keepme.example' => 'pfB_Keep_v4'];
+		file_put_contents($GLOBALS['pfb']['ip_unlock'], "{$ip},{$table}\nkeepme.example,pfB_Keep_v4\n");
+
+		$result = pfb_alerts_ip_action(
+			'addsuppress',
+			$ip,
+			$table,
+			'',
+			['ipsuppression' => ['data' => [$host_line => "{$host_line}\r\n"], 'base64' => base64_encode("{$host_line}\r\n")]],
+			$ip_unlock
+		);
+
+		$this->assertStringContainsString('already exists', $result['savemsg']);
+		$content = (string) file_get_contents($GLOBALS['pfb']['ip_unlock']);
+		$this->assertStringContainsString('keepme.example', $content);
+		$this->assertStringNotContainsString($ip, $content, 'issue #2670: already-suppressed still drops the unlock-store row');
+	}
+
+	public function testAddSuppressAlreadyCoveredClearsUnlockStore(): void
+	{
+		$ip = '198.51.100.41';
+		$table = 'pfB_Deny_v4';
+		$ip_unlock = [$ip => $table, 'keepme.example' => 'pfB_Keep_v4'];
+		file_put_contents($GLOBALS['pfb']['ip_unlock'], "{$ip},{$table}\nkeepme.example,pfB_Keep_v4\n");
+		$line = "198.51.100.0/24\r\n";
+
+		$result = pfb_alerts_ip_action(
+			'addsuppress',
+			$ip,
+			$table,
+			'',
+			['ipsuppression' => ['data' => ['198.51.100.0/24' => $line], 'base64' => base64_encode($line)]],
+			$ip_unlock
+		);
+
+		$this->assertStringContainsString('already covered', $result['savemsg']);
+		$content = (string) file_get_contents($GLOBALS['pfb']['ip_unlock']);
+		$this->assertStringContainsString('keepme.example', $content);
+		$this->assertStringNotContainsString($ip, $content, 'issue #2670: already-covered still drops the unlock-store row');
+	}
+
+	public function testIpWhiteSuccessClearsMatchingUnlockStore(): void
+	{
+		$ip = '198.51.100.31';
+		$table = 'pfB_Whitelist_v4';
+		$ip_unlock = [$ip => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
+		file_put_contents($GLOBALS['pfb']['ip_unlock'], "{$ip},pfB_Deny_v4\nkeepme.example,pfB_Keep_v4\n");
+
+		$result = pfb_alerts_ip_action(
+			'ip_white',
+			$ip,
+			$table,
+			'',
+			['ipwhitelist4' => [$table => ['base64_idx' => 0, 'data' => []]]],
+			$ip_unlock
+		);
+
+		$this->assertStringContainsString('added', $result['savemsg']);
+		$content = (string) file_get_contents($GLOBALS['pfb']['ip_unlock']);
+		$this->assertStringContainsString('keepme.example', $content);
+		$this->assertStringNotContainsString($ip, $content, 'issue #2670: permit whitelist must drop the matching unlock-store row');
+	}
+
+	public function testIpWhiteDuplicateStillClearsUnlockStore(): void
+	{
+		$ip = '198.51.100.32';
+		$table = 'pfB_Whitelist_v4';
+		$ip_unlock = [$ip => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
+		file_put_contents($GLOBALS['pfb']['ip_unlock'], "{$ip},pfB_Deny_v4\nkeepme.example,pfB_Keep_v4\n");
+
+		$result = pfb_alerts_ip_action(
+			'ip_white',
+			$ip,
+			$table,
+			'',
+			['ipwhitelist4' => [$table => ['base64_idx' => 0, 'data' => [$ip => "{$ip}\r\n"]]]],
+			$ip_unlock
+		);
+
+		$this->assertFalse($result['redirect']);
+		$content = (string) file_get_contents($GLOBALS['pfb']['ip_unlock']);
+		$this->assertStringContainsString('keepme.example', $content);
+		$this->assertStringNotContainsString($ip, $content, 'issue #2670: already-whitelisted still drops the unlock-store row');
+	}
+
+	public function testIpWhiteFailureLeavesUnlockStoreUnchanged(): void
+	{
+		$ip = '198.51.100.30';
+		$table = 'pfB_Whitelist_v4';
+		$before = "{$ip},pfB_Deny_v4\nkeepme.example,pfB_Keep_v4\n";
+		$ip_unlock = [$ip => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
+		file_put_contents($GLOBALS['pfb']['ip_unlock'], $before);
+		$this->scriptFailure('add', $ip);
+
+		$result = pfb_alerts_ip_action(
+			'ip_white',
+			$ip,
+			$table,
+			'',
+			['ipwhitelist4' => [$table => ['base64_idx' => 0, 'data' => []]]],
+			$ip_unlock
+		);
+
+		$this->assertStringContainsString('failed', $result['savemsg']);
+		$this->assertSame($before, file_get_contents($GLOBALS['pfb']['ip_unlock']), 'a failed permit add must not touch the unlock store');
+	}
+
+	public function testAddwhitelistdomDispatchClearsUnlockStore(): void
+	{
+		$src = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php');
+		$start = strpos($src, "elseif (isset(\$_POST['addwhitelistdom'])");
+		$end = strpos($src, "elseif (isset(\$_POST['entry_delete'])", $start === FALSE ? 0 : $start);
+		$this->assertNotFalse($start, 'addwhitelistdom handler must exist');
+		$this->assertNotFalse($end, 'entry_delete must follow addwhitelistdom');
+		$region = substr($src, $start, $end - $start);
+		$this->assertStringContainsString(
+			"pfb_unlock('lock', 'dnsbl'",
+			$region,
+			'issue #2670: addwhitelistdom success must pfb_unlock lock the matching DNSBL unlock-store token'
+		);
+	}
+
 	public function testAlertsPageDispatchKeepsFiltersNavigationAndStrictIpActions(): void
 	{
 		// Top-level POST dispatch has no off-appliance callable seam; this retained

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -115,7 +115,7 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 		// issue #1666: save every $pfb key this test overrides below, before
 		// overriding them, so tearDown() can restore them once $this->tmp (which
 		// most of them point inside) is deleted.
-		foreach (['pfctl', 'aliasdir', 'dbdir', 'permitdir', 'ip_unlock', 'supptxt',
+		foreach (['pfctl', 'aliasdir', 'dbdir', 'permitdir', 'ip_unlock', 'dnsbl_unlock', 'supptxt',
 			  'supptxt_v6', 'ipconfig', 'logdir', 'log', 'errlog'] as $k) {
 			$this->hadPfb[$k]   = array_key_exists($k, $GLOBALS['pfb'] ?? []);
 			$this->savedPfb[$k] = $GLOBALS['pfb'][$k] ?? NULL;
@@ -128,6 +128,7 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 		$pfb['dbdir']     = "{$this->tmp}/db";
 		$pfb['permitdir'] = "{$this->tmp}/permit";
 		$pfb['ip_unlock'] = "{$this->tmp}/ip_unlock.txt";
+		$pfb['dnsbl_unlock'] = "{$this->tmp}/dnsbl_unlock.txt";
 		$pfb['supptxt']    = "{$this->tmp}/pfbsuppression.txt";
 		$pfb['supptxt_v6'] = "{$this->tmp}/pfbsuppression_v6.txt";
 		$pfb['ipconfig']   = ['v4suppression' => '', 'v6suppression' => ''];
@@ -921,10 +922,43 @@ SH
 		$this->assertNotFalse($end, 'entry_delete must follow addwhitelistdom');
 		$region = substr($src, $start, $end - $start);
 		$this->assertStringContainsString(
-			"pfb_unlock('lock', 'dnsbl'",
+			"pfb_alerts_unlock_drop('dnsbl', \$dnsbl_unlock, array(\$domain_unlock, \$domain, 'www.'.\$domain))",
 			$region,
-			'issue #2670: addwhitelistdom success must pfb_unlock lock the matching DNSBL unlock-store token'
+			'issue #2670: addwhitelistdom must drop posted, stripped, and www.<stripped> unlock tokens'
 		);
+	}
+
+	public function testUnlockDropBareDomainAlsoClearsWwwUnlockRow(): void
+	{
+		$store = ['www.example.com' => 'TLD', 'keepme.example' => 'python'];
+		file_put_contents($GLOBALS['pfb']['dnsbl_unlock'], "www.example.com,TLD\nkeepme.example,python\n");
+
+		$store = pfb_alerts_unlock_drop('dnsbl', $store, ['example.com', 'example.com', 'www.example.com']);
+
+		$content = (string) file_get_contents($GLOBALS['pfb']['dnsbl_unlock']);
+		$this->assertStringContainsString('keepme.example', $content, 'unrelated unlock rows must survive');
+		$this->assertStringNotContainsString(
+			'www.example.com',
+			$content,
+			'issue #2670: locking the bare domain must also drop the www.<domain> unlock row'
+		);
+		$this->assertArrayNotHasKey('www.example.com', $store);
+		$this->assertArrayNotHasKey('example.com', $store);
+	}
+
+	public function testUnlockDropUnsetsBetweenTokensSoTheFirstKeyCannotReturn(): void
+	{
+		$store = ['example.com' => 'python', 'www.example.com' => 'python'];
+		file_put_contents(
+			$GLOBALS['pfb']['dnsbl_unlock'],
+			"example.com,python\nwww.example.com,python\n"
+		);
+
+		$store = pfb_alerts_unlock_drop('dnsbl', $store, ['example.com', 'www.example.com']);
+
+		$content = (string) file_get_contents($GLOBALS['pfb']['dnsbl_unlock']);
+		$this->assertSame('', trim($content), 'both tokens must be gone after sequential lock+unset');
+		$this->assertSame([], $store);
 	}
 
 	public function testAlertsPageDispatchKeepsFiltersNavigationAndStrictIpActions(): void

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -922,9 +922,9 @@ SH
 		$this->assertNotFalse($end, 'entry_delete must follow addwhitelistdom');
 		$region = substr($src, $start, $end - $start);
 		$this->assertStringContainsString(
-			"pfb_alerts_whitelist_unlock_tokens(\$domain_unlock, \$domain, \$wildcard, \$dnsbl_exclude, \$cname_list)",
+			"pfb_alerts_whitelist_unlock_tokens(\$domain_unlock, \$domain, \$dnsbl_exclude, \$cname_list)",
 			$region,
-			'issue #2670: addwhitelistdom token list must follow the write-set (www. only on non-wildcard whitelist)'
+			'issue #2670: addwhitelistdom token list must follow the write-set (www. except on TLD exclusion)'
 		);
 		$this->assertStringContainsString(
 			"pfb_alerts_unlock_drop('dnsbl', \$dnsbl_unlock, \$unlock_drop)",
@@ -996,7 +996,6 @@ SH
 			'www.example.com',
 			'example.com',
 			FALSE,
-			FALSE,
 			['alias.example.net', '', 'alias.example.net']
 		);
 		$this->assertSame(
@@ -1010,7 +1009,7 @@ SH
 
 	public function testWhitelistUnlockTokensWildcardDropsWwwBecauseDotDomainCoversIt(): void
 	{
-		$tokens = pfb_alerts_whitelist_unlock_tokens('example.com', 'example.com', TRUE, FALSE, ['alias.example.net']);
+		$tokens = pfb_alerts_whitelist_unlock_tokens('example.com', 'example.com', FALSE, ['alias.example.net']);
 		$this->assertContains(
 			'www.example.com',
 			$tokens,
@@ -1023,7 +1022,7 @@ SH
 
 	public function testWhitelistUnlockTokensExclusionOmitsWwwKeepsCname(): void
 	{
-		$tokens = pfb_alerts_whitelist_unlock_tokens('example.com', 'example.com', FALSE, TRUE, ['alias.example.net']);
+		$tokens = pfb_alerts_whitelist_unlock_tokens('example.com', 'example.com', TRUE, ['alias.example.net']);
 		$this->assertNotContains(
 			'www.example.com',
 			$tokens,
@@ -1039,7 +1038,6 @@ SH
 		$tokens = pfb_alerts_whitelist_unlock_tokens(
 			'www.example.com',
 			'example.com',
-			FALSE,
 			TRUE,
 			['alias.example.net']
 		);

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -922,19 +922,14 @@ SH
 		$this->assertNotFalse($end, 'entry_delete must follow addwhitelistdom');
 		$region = substr($src, $start, $end - $start);
 		$this->assertStringContainsString(
+			"pfb_alerts_whitelist_unlock_tokens(\$domain_unlock, \$domain, \$wildcard, \$dnsbl_exclude, \$cname_list)",
+			$region,
+			'issue #2670: addwhitelistdom token list must follow the write-set (www. only on non-wildcard whitelist)'
+		);
+		$this->assertStringContainsString(
 			"pfb_alerts_unlock_drop('dnsbl', \$dnsbl_unlock, \$unlock_drop)",
 			$region,
 			'issue #2670: addwhitelistdom must drop unlock tokens via \$unlock_drop'
-		);
-		$this->assertStringContainsString(
-			"\$unlock_drop[] = \$cname",
-			$region,
-			'issue #2670: CNAME whitelist entries must be unlock-drop tokens'
-		);
-		$this->assertStringContainsString(
-			"\$unlock_drop[] = 'www.'.\$cname",
-			$region,
-			'issue #2670: www.<CNAME> must be unlock-drop tokens too'
 		);
 	}
 
@@ -993,6 +988,44 @@ SH
 		$this->assertStringNotContainsString('alias.example.net', $content, 'issue #2670: a CNAME written to the whitelist must leave the unlock store');
 		$this->assertStringNotContainsString('www.alias.example.net', $content);
 		$this->assertArrayNotHasKey('alias.example.net', $store);
+	}
+
+	public function testWhitelistUnlockTokensNonWildcardIncludesWwwAndCnames(): void
+	{
+		$tokens = pfb_alerts_whitelist_unlock_tokens(
+			'www.example.com',
+			'example.com',
+			FALSE,
+			FALSE,
+			['alias.example.net', '', 'alias.example.net']
+		);
+		$this->assertSame(
+			['www.example.com', 'example.com', 'alias.example.net'],
+			array_values(array_unique($tokens)),
+			'non-wildcard whitelist writes domain, www.domain, and each CNAME — not www.<CNAME>'
+		);
+		$this->assertContains('www.example.com', $tokens);
+		$this->assertNotContains('www.alias.example.net', $tokens);
+	}
+
+	public function testWhitelistUnlockTokensWildcardOmitsWww(): void
+	{
+		$tokens = pfb_alerts_whitelist_unlock_tokens('example.com', 'example.com', TRUE, FALSE, ['alias.example.net']);
+		$this->assertNotContains('www.example.com', $tokens, 'wildcard writes .domain which already covers www');
+		$this->assertContains('example.com', $tokens);
+		$this->assertContains('alias.example.net', $tokens);
+	}
+
+	public function testWhitelistUnlockTokensExclusionOmitsWwwKeepsCname(): void
+	{
+		$tokens = pfb_alerts_whitelist_unlock_tokens('example.com', 'example.com', FALSE, TRUE, ['alias.example.net']);
+		$this->assertNotContains(
+			'www.example.com',
+			$tokens,
+			'round-2 blocking: TLD exclusion writes example.com only; dropping www.example.com would re-lock an unlocked name the exclusion does not cover'
+		);
+		$this->assertContains('example.com', $tokens);
+		$this->assertContains('alias.example.net', $tokens);
 	}
 
 	public function testAlertsPageDispatchKeepsFiltersNavigationAndStrictIpActions(): void

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -1034,6 +1034,25 @@ SH
 		$this->assertContains('alias.example.net', $tokens);
 	}
 
+	public function testWhitelistUnlockTokensExclusionPostedWwwDoesNotDropWww(): void
+	{
+		$tokens = pfb_alerts_whitelist_unlock_tokens(
+			'www.example.com',
+			'example.com',
+			FALSE,
+			TRUE,
+			['alias.example.net']
+		);
+		$this->assertNotContains(
+			'www.example.com',
+			$tokens,
+			'exclusion writes foo.com only; a www.foo.com POST must not revoke the www. unlock row'
+		);
+		$this->assertContains('example.com', $tokens);
+		$this->assertContains('alias.example.net', $tokens);
+		$this->assertNotContains('www.alias.example.net', $tokens);
+	}
+
 	public function testAlertsPageDispatchKeepsFiltersNavigationAndStrictIpActions(): void
 	{
 		// Top-level POST dispatch has no off-appliance callable seam; this retained

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -1008,10 +1008,14 @@ SH
 		$this->assertNotContains('www.alias.example.net', $tokens);
 	}
 
-	public function testWhitelistUnlockTokensWildcardOmitsWww(): void
+	public function testWhitelistUnlockTokensWildcardDropsWwwBecauseDotDomainCoversIt(): void
 	{
 		$tokens = pfb_alerts_whitelist_unlock_tokens('example.com', 'example.com', TRUE, FALSE, ['alias.example.net']);
-		$this->assertNotContains('www.example.com', $tokens, 'wildcard writes .domain which already covers www');
+		$this->assertContains(
+			'www.example.com',
+			$tokens,
+			'wildcard writes .domain; the matcher covers www.domain, so the unlock row must drop or the Unlocked panel stays stale'
+		);
 		$this->assertContains('example.com', $tokens);
 		$this->assertContains('alias.example.net', $tokens);
 	}

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -922,9 +922,19 @@ SH
 		$this->assertNotFalse($end, 'entry_delete must follow addwhitelistdom');
 		$region = substr($src, $start, $end - $start);
 		$this->assertStringContainsString(
-			"pfb_alerts_unlock_drop('dnsbl', \$dnsbl_unlock, array(\$domain_unlock, \$domain, 'www.'.\$domain))",
+			"pfb_alerts_unlock_drop('dnsbl', \$dnsbl_unlock, \$unlock_drop)",
 			$region,
-			'issue #2670: addwhitelistdom must drop posted, stripped, and www.<stripped> unlock tokens'
+			'issue #2670: addwhitelistdom must drop unlock tokens via \$unlock_drop'
+		);
+		$this->assertStringContainsString(
+			"\$unlock_drop[] = \$cname",
+			$region,
+			'issue #2670: CNAME whitelist entries must be unlock-drop tokens'
+		);
+		$this->assertStringContainsString(
+			"\$unlock_drop[] = 'www.'.\$cname",
+			$region,
+			'issue #2670: www.<CNAME> must be unlock-drop tokens too'
 		);
 	}
 
@@ -959,6 +969,30 @@ SH
 		$content = (string) file_get_contents($GLOBALS['pfb']['dnsbl_unlock']);
 		$this->assertSame('', trim($content), 'both tokens must be gone after sequential lock+unset');
 		$this->assertSame([], $store);
+	}
+
+	public function testUnlockDropClearsWhitelistedCnameAndWwwSibling(): void
+	{
+		$store = [
+			'alias.example.net' => 'python',
+			'www.alias.example.net' => 'python',
+			'keepme.example' => 'python',
+		];
+		file_put_contents(
+			$GLOBALS['pfb']['dnsbl_unlock'],
+			"alias.example.net,python\nwww.alias.example.net,python\nkeepme.example,python\n"
+		);
+
+		$store = pfb_alerts_unlock_drop('dnsbl', $store, [
+			'example.com', 'www.example.com',
+			'alias.example.net', 'www.alias.example.net',
+		]);
+
+		$content = (string) file_get_contents($GLOBALS['pfb']['dnsbl_unlock']);
+		$this->assertStringContainsString('keepme.example', $content);
+		$this->assertStringNotContainsString('alias.example.net', $content, 'issue #2670: a CNAME written to the whitelist must leave the unlock store');
+		$this->assertStringNotContainsString('www.alias.example.net', $content);
+		$this->assertArrayNotHasKey('alias.example.net', $store);
 	}
 
 	public function testAlertsPageDispatchKeepsFiltersNavigationAndStrictIpActions(): void

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -1000,12 +1000,12 @@ SH
 			['alias.example.net', '', 'alias.example.net']
 		);
 		$this->assertSame(
-			['www.example.com', 'example.com', 'alias.example.net'],
+			['www.example.com', 'example.com', 'alias.example.net', 'www.alias.example.net'],
 			array_values(array_unique($tokens)),
-			'non-wildcard whitelist writes domain, www.domain, and each CNAME — not www.<CNAME>'
+			'whitelist matcher www-strips unconditionally, so every token also drops www.<token>'
 		);
 		$this->assertContains('www.example.com', $tokens);
-		$this->assertNotContains('www.alias.example.net', $tokens);
+		$this->assertContains('www.alias.example.net', $tokens);
 	}
 
 	public function testWhitelistUnlockTokensWildcardDropsWwwBecauseDotDomainCoversIt(): void
@@ -1018,6 +1018,7 @@ SH
 		);
 		$this->assertContains('example.com', $tokens);
 		$this->assertContains('alias.example.net', $tokens);
+		$this->assertContains('www.alias.example.net', $tokens);
 	}
 
 	public function testWhitelistUnlockTokensExclusionOmitsWwwKeepsCname(): void
@@ -1026,8 +1027,9 @@ SH
 		$this->assertNotContains(
 			'www.example.com',
 			$tokens,
-			'round-2 blocking: TLD exclusion writes example.com only; dropping www.example.com would re-lock an unlocked name the exclusion does not cover'
+			'TLD exclusion classify is exact-string; dropping www.example.com would re-lock an unlocked name the exclusion does not cover'
 		);
+		$this->assertNotContains('www.alias.example.net', $tokens);
 		$this->assertContains('example.com', $tokens);
 		$this->assertContains('alias.example.net', $tokens);
 	}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -340,13 +340,6 @@
                 "default": null
             },
             {
-                "name": "wildcard",
-                "byRef": false,
-                "variadic": false,
-                "type": "bool",
-                "default": null
-            },
-            {
                 "name": "exclude",
                 "byRef": false,
                 "variadic": false,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -321,6 +321,47 @@
             }
         ]
     },
+    "pfb_alerts_whitelist_unlock_tokens": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "posted",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "stripped",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "wildcard",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "exclude",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "cnames",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_alias_autocomplete_lists": {
         "returnsRef": false,
         "returnType": "array",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -294,6 +294,33 @@
             }
         ]
     },
+    "pfb_alerts_unlock_drop": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "store",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "tokens",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_alias_autocomplete_lists": {
         "returnsRef": false,
         "returnType": "array",

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -2539,3 +2539,63 @@ def test_unlocked_panel_renders_whitelist_plus_next_to_relock(
     finally:
         _write_or_remove_guest_file(vm, IP_UNLOCK_STORE, ip_before)
         _write_or_remove_guest_file(vm, DNSBL_UNLOCK_STORE, dnsbl_before)
+
+
+@pytest.mark.ui_render
+def test_addwhitelistdom_clears_unlock_store_and_drops_unlocked_panel_row(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """issue #2670: whitelisting an unlocked domain must drop the unlock-store row.
+
+    Given: the DNSBL unlock store lists a unique domain (Unlocked-panel state).
+    When: addwhitelistdom POSTs that same domain (the panel plus click).
+    Then: the domain is in the DNSBL whitelist, gone from the unlock store, and
+        absent from the Unlocked panel on the next GET.
+    """
+    vm = smoke_vm
+    domain = helpers.unique_domain("ui2670")
+    dnsbl_type = "python"
+    original = helpers.config_get(vm, CFG_WHITELIST)
+    dnsbl_before = _read_guest_file(vm, DNSBL_UNLOCK_STORE)
+    try:
+        assert domain not in _suppression_entries(vm, CFG_WHITELIST), (
+            f"Precondition failed: {domain} already in the DNSBL whitelist"
+        )
+        _write_or_remove_guest_file(vm, DNSBL_UNLOCK_STORE, f"{domain},{dnsbl_type}\n")
+
+        pre = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(pre.text), "alerts GET returned login form before whitelist (session lost)"
+        panel = _unlocked_panel_html(pre.text)
+        assert f"DNSBLWT|add|{domain}|{dnsbl_type}" in panel, (
+            f"Precondition failed: Unlocked panel missing plus for {domain}: {panel!r}"
+        )
+
+        resp = _post_action(
+            webui,
+            {
+                "addwhitelistdom": "true",
+                "domain": domain,
+                "table": dnsbl_type,
+                "dnsbl_wildcard": "false",
+                "dnsbl_exclude": "false",
+            },
+        )
+        assert not looks_like_login_page(resp.text), "addwhitelistdom POST returned the login form (session lost)"
+        assert domain in _suppression_entries(vm, CFG_WHITELIST), (
+            f"{domain} not written to the DNSBL whitelist after addwhitelistdom"
+        )
+
+        store_after = _read_guest_file(vm, DNSBL_UNLOCK_STORE) or ""
+        assert domain not in store_after, (
+            f"issue #2670: {domain} still in dnsbl_unlock after whitelist: {store_after!r}"
+        )
+
+        after = webui.get(ALERTS_PAGE)
+        assert not looks_like_login_page(after.text), "alerts GET returned login form after whitelist (session lost)"
+        assert f"DNSBL_LCK|{domain}" not in after.text, (
+            f"issue #2670: Unlocked panel still shows {domain} after whitelist"
+        )
+    finally:
+        helpers.config_set(vm, CFG_WHITELIST, original if original is not None else "")
+        _write_or_remove_guest_file(vm, DNSBL_UNLOCK_STORE, dnsbl_before)


### PR DESCRIPTION
Fixes #2670.

## Problem

Unlocking an IP or domain is temporary. Suppress and whitelist are durable. After #2662 the Unlocked panel exposes those durable actions, but `addsuppress`, `ip_white`, and `addwhitelistdom` never called `pfb_unlock('lock', …)`. The matching unlock-store row stayed until a separate re-lock, so the panel disagreed with the allow and cron/force could treat the entry as still temporarily unlocked.

## Change

- `pfb_alerts_ip_action('addsuppress')` drops the IP from the unlock store after a successful suppress (including already-exists / already-covered).
- `ip_white` drops it after a successful permit add, and on the already-in-list dup-guard. A failed pfctl add still leaves the store alone.
- `addwhitelistdom` drops the posted DNSBL token (and the `www.`-stripped form when they differ) after whitelist or TLD exclusion. `pfb_unlock('lock')` does not update the in-memory array, so the second token is applied after `unset`.

## Tests

Red→green, tests frozen byte-identical:

- `tests/php/AlertsPfctlCheckedSitesTest.php` `7c252a2c4c7c2ec990f8f7d4a9f3980f3df8f4b3`
- `tests/smoke/ui/test_alerts.py` `34bb3aff71083cc03400e4699cdc51557ceb18bd`

PHPUnit on this host (PHP 8.4.24): `OK (46 tests, 201 assertions)` for `AlertsPfctlCheckedSitesTest`.

Live clone (nightly + this overlay): Playwright click of Unlocked-panel plus for `unlock-wl-2670.example.com` wrote the DNSBL whitelist and left `/tmp/dnsbl_unlock` empty.

## Review

Adversarial review is for Claude. Do not request Copilot code review.

🤖 Generated by Grok and posted on behalf of @BBcan177.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary DNSBL unlock entries are now removed when domains or IPs are suppressed or added to a whitelist.
  * Whitelist handling now correctly accounts for `www.` variants, CNAMEs, wildcard domains, and exclusions.
  * Unrelated unlock entries remain preserved, while failed whitelist operations leave existing entries unchanged.

* **Tests**
  * Added coverage for unlock-store cleanup and whitelist behavior across domain, IP, CNAME, wildcard, and UI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->