### PR TITLE
repo: sign catalogues with an ECDSA key

### DIFF
--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -323,7 +323,12 @@ def signing_public_der(sign_key: Path) -> bytes:
     # NIST name) readable by the same parse.
     match = re.search(r"^\s*ASN1 OID:\s*(\S+)\s*$", text, re.MULTILINE)
     if match is None:
-        raise BuildRepoError(f"{sign_key}: cannot determine the EC curve (is it an EC private key?)")
+        raise BuildRepoError(
+            f"{sign_key}: cannot determine the EC curve — `openssl ec -text` printed no "
+            "`ASN1 OID:` line. Either this is not an EC private key, or it carries explicit "
+            "curve parameters (`-param_enc explicit`) rather than naming a curve; pkg matches "
+            "curves by OID, so the key must name one."
+        )
     curve = match.group(1)
     if curve not in PKG_ACCEPTED_CURVES:
         raise BuildRepoError(
@@ -345,8 +350,7 @@ def catalog_signature(data: bytes, sign_key: Path) -> bytes:
     Do not reach for the BLAKE2b-512 chain in `ecc_sign_file()`/`ecc_verify_file()`: those
     serve PUBKEY mode, whose catalogue carries a single `signature` member instead of our
     `.sig`/`.pub` pair. Signing the wrong one still produces a well-formed catalogue that a
-    real `pkg update` rejects with "ecc signature verification failure" — verified on a
-    box, which is the only place the difference shows up.
+    real `pkg update` rejects with "ecc signature verification failure".
     """
     message = hashlib.sha256(data).hexdigest().encode()
     return PKGSIGN_ECDSA_HEAD + _openssl(["dgst", "-sha256", "-sign", str(sign_key)], stdin=message)

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -247,11 +247,14 @@ def _data_blob(objs: list[dict]) -> bytes:
 #
 # Every byte below follows freebsd/pkg (13f9f98); the details are unforgiving
 # because a mismatch fails only at verification, on the box:
-#   * ECDSA signs the BLAKE2b-512 RAW digest of the UNCOMPRESSED catalogue
-#     member, with SHA256 as the inner hash — `ecc_new()` pins sig_hash =
-#     SHA256 for ecdsa regardless of curve, and `ecc_sign_file()` hashes with
-#     PKG_HASH_TYPE_BLAKE2_RAW (BLAKE2B_OUTBYTES = 64). RSA, by contrast, signs
-#     the SHA256 HEX STRING; do not carry that convention over.
+#   * the signed message is the 64-character ASCII SHA256 HEX of the
+#     UNCOMPRESSED catalogue member, signed ECDSA-SHA256 (`ecc_new()` pins
+#     sig_hash = SHA256 for ecdsa regardless of curve). It is the CERT path —
+#     `ecc_verify_cert_cb()` — that FINGERPRINTS mode runs, and it hashes with
+#     PKG_HASH_TYPE_SHA256_HEX passed at `strlen()`, so no NUL terminator.
+#     The BLAKE2b-512 chain in `ecc_sign_file()`/`ecc_verify_file()` belongs to
+#     PUBKEY mode (single `signature` member) — signing that instead yields a
+#     catalogue a real pkg rejects with "ecc signature verification failure".
 #   * a non-RSA signature is prefixed `$PKGSIGN:<type>$` (PKGSIGN_HEAD,
 #     libpkg/private/pkgsign.h), which is how the client selects the signer.
 #   * the public half is DER for ECDSA (exported as PKCS#8 "for interoperability
@@ -294,8 +297,11 @@ def _openssl(args: list[str], *, stdin: bytes | None = None) -> bytes:
             capture_output=True,
             check=False,
         )
-    except FileNotFoundError as exc:  # pragma: no cover - environment-dependent
-        raise BuildRepoError("catalogue signing needs the `openssl` binary on PATH") from exc
+    except OSError as exc:  # pragma: no cover - environment-dependent
+        # OSError, not FileNotFoundError: an `openssl` that exists on PATH but is not
+        # executable raises PermissionError, which would otherwise escape this wrapper
+        # as a bare traceback instead of a BuildRepoError.
+        raise BuildRepoError(f"cannot run `openssl` for catalogue signing: {exc}") from exc
     if proc.returncode != 0:
         detail = proc.stderr.decode(errors="replace").strip() or f"exit {proc.returncode}"
         raise BuildRepoError(f"openssl {args[0]} failed: {detail}")
@@ -303,7 +309,14 @@ def _openssl(args: list[str], *, stdin: bytes | None = None) -> bytes:
 
 
 def signing_public_der(sign_key: Path) -> bytes:
-    """The signing key's public half as DER, after checking pkg accepts its curve."""
+    """The signing key's public half as RAW DER, after checking pkg accepts its curve.
+
+    Raw, with no `$PKGSIGN:` header, because these exact bytes are what the client hashes
+    for the trusted fingerprint (`pkg_repo_check_fingerprint` hashes the cert AFTER the
+    extractor strips any header). The header belongs to the archive MEMBER, and
+    write_zstd_tar() adds it there — keeping it out of here means a fingerprint file can
+    never be generated over the wrong bytes.
+    """
     text = _openssl(["ec", "-in", str(sign_key), "-noout", "-text"]).decode(errors="replace")
     # `openssl ec -text` names the curve on an "ASN1 OID:" line. Keying on that
     # rather than the "NIST CURVE:" line keeps brainpool curves (which have no
@@ -321,9 +334,22 @@ def signing_public_der(sign_key: Path) -> bytes:
 
 
 def catalog_signature(data: bytes, sign_key: Path) -> bytes:
-    """The `.sig` member body for ``data``: header + ECDSA over its BLAKE2b-512 digest."""
-    digest = hashlib.blake2b(data, digest_size=64).digest()
-    return PKGSIGN_ECDSA_HEAD + _openssl(["dgst", "-sha256", "-sign", str(sign_key)], stdin=digest)
+    """The `.sig` member body for ``data``: header + ECDSA-SHA256 over its SHA256 HEX text.
+
+    The signed message is the 64-character ASCII hex of the catalogue's SHA256 — not a raw
+    digest, and not BLAKE2b. `ecc_verify_cert_cb()`, which is what FINGERPRINTS mode runs,
+    does `pkg_checksum_fd(fd, PKG_HASH_TYPE_SHA256_HEX)` and passes the result with
+    `strlen()`, so there is no NUL terminator either. libecc then hashes that text with
+    SHA256 internally, which is what `openssl dgst -sha256 -sign` reproduces.
+
+    Do not reach for the BLAKE2b-512 chain in `ecc_sign_file()`/`ecc_verify_file()`: those
+    serve PUBKEY mode, whose catalogue carries a single `signature` member instead of our
+    `.sig`/`.pub` pair. Signing the wrong one still produces a well-formed catalogue that a
+    real `pkg update` rejects with "ecc signature verification failure" — verified on a
+    box, which is the only place the difference shows up.
+    """
+    message = hashlib.sha256(data).hexdigest().encode()
+    return PKGSIGN_ECDSA_HEAD + _openssl(["dgst", "-sha256", "-sign", str(sign_key)], stdin=message)
 
 
 # Archive emission (zstd tar) — same framing contract as build-pkg-portable.py:
@@ -339,7 +365,7 @@ def catalog_signature(data: bytes, sign_key: Path) -> bytes:
 # --------------------------------------------------------------------------- #
 
 
-def _tar_one(*members: tuple[str, bytes]) -> bytes:
+def _tar_one(members: list[tuple[str, bytes]]) -> bytes:
     raw = io.BytesIO()
     with tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as tf:
         for member_name, data in members:
@@ -365,12 +391,19 @@ def write_zstd_tar(member_name: str, data: bytes, out_path: Path, *, sign_key: P
     """
     members: list[tuple[str, bytes]] = []
     if sign_key is not None:
+        # BOTH members carry the `$PKGSIGN:ecdsa$` header. Not symmetry for its own sake:
+        # pkg_repo_parse_sigkeys() sets the signer type from EVERY member it parses, keyed
+        # by basename, so a bare `.pub` (parsed after `.sig`) resets the type to its "rsa"
+        # default. Verification then runs the RSA signer, whose _load_public_key_buf() is
+        # PEM_read_bio_PUBKEY, and a real `pkg update` dies with "error reading public key
+        # ... DECODER routines::unsupported". Real `pkg repo` prefixes both too, because
+        # pack_command_sign() never resets its iovec offset between the two appends.
         members.append((f"{member_name}.sig", catalog_signature(data, sign_key)))
-        members.append((f"{member_name}.pub", signing_public_der(sign_key)))
+        members.append((f"{member_name}.pub", PKGSIGN_ECDSA_HEAD + signing_public_der(sign_key)))
     members.append((member_name, data))
     out_path.write_bytes(
         zstd_compress(
-            _tar_one(*members),
+            _tar_one(members),
             BuildRepoError,
             "zstd compression needs the `zstd` binary or the python `zstandard` module "
             "(brew install zstd / apt install zstd)",

--- a/scripts/build-repo-portable.py
+++ b/scripts/build-repo-portable.py
@@ -236,32 +236,141 @@ def _data_blob(objs: list[dict]) -> bytes:
 
 
 # --------------------------------------------------------------------------- #
+# Catalogue signing (issue #2675) — `signature_type: fingerprints`, ECDSA.
+#
+# Authenticity used to rest on HTTPS to the host, which is exactly what breaks
+# on pfSense Plus: `pfSense-repo-setup` pins pkg to a Netgate-only CA bundle,
+# and no environment-based workaround can reach the GUI (php-fpm scrubs the
+# worker environment, and pfSense's own pkg_call() replaces it outright). A
+# signed catalogue moves the trust anchor onto our own key, so the fetch itself
+# no longer has to be TLS.
+#
+# Every byte below follows freebsd/pkg (13f9f98); the details are unforgiving
+# because a mismatch fails only at verification, on the box:
+#   * ECDSA signs the BLAKE2b-512 RAW digest of the UNCOMPRESSED catalogue
+#     member, with SHA256 as the inner hash — `ecc_new()` pins sig_hash =
+#     SHA256 for ecdsa regardless of curve, and `ecc_sign_file()` hashes with
+#     PKG_HASH_TYPE_BLAKE2_RAW (BLAKE2B_OUTBYTES = 64). RSA, by contrast, signs
+#     the SHA256 HEX STRING; do not carry that convention over.
+#   * a non-RSA signature is prefixed `$PKGSIGN:<type>$` (PKGSIGN_HEAD,
+#     libpkg/private/pkgsign.h), which is how the client selects the signer.
+#   * the public half is DER for ECDSA (exported as PKCS#8 "for interoperability
+#     with OpenSSL"); the ECC loader calls libder_read() and knows no PEM.
+#   * the trusted fingerprint is the SHA256 of exactly those DER bytes, so any
+#     re-encoding invalidates every fingerprint file already deployed.
+# --------------------------------------------------------------------------- #
+
+# The signature member carries this before the raw DER signature.
+PKGSIGN_ECDSA_HEAD = b"$PKGSIGN:ecdsa$"
+
+# pkg accepts far fewer curves than OpenSSL offers: `ecc_read_pkgkey()` matches
+# the curve OID against this set and nothing else. prime256v1/secp256r1 — the
+# curve almost every tool defaults to — is NOT among them, which is why signing
+# validates the curve up front rather than shipping a catalogue no box can
+# verify.
+PKG_ACCEPTED_CURVES = frozenset(
+    {
+        "secp256k1",
+        "secp384r1",
+        "secp521r1",
+        "brainpoolP256r1",
+        "brainpoolP256t1",
+        "brainpoolP320r1",
+        "brainpoolP320t1",
+        "brainpoolP384r1",
+        "brainpoolP384t1",
+        "brainpoolP512r1",
+        "brainpoolP512t1",
+    }
+)
+
+
+def _openssl(args: list[str], *, stdin: bytes | None = None) -> bytes:
+    """Run `openssl` and return stdout; every failure becomes a BuildRepoError."""
+    try:
+        proc = subprocess.run(
+            ["openssl", *args],
+            input=stdin,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment-dependent
+        raise BuildRepoError("catalogue signing needs the `openssl` binary on PATH") from exc
+    if proc.returncode != 0:
+        detail = proc.stderr.decode(errors="replace").strip() or f"exit {proc.returncode}"
+        raise BuildRepoError(f"openssl {args[0]} failed: {detail}")
+    return proc.stdout
+
+
+def signing_public_der(sign_key: Path) -> bytes:
+    """The signing key's public half as DER, after checking pkg accepts its curve."""
+    text = _openssl(["ec", "-in", str(sign_key), "-noout", "-text"]).decode(errors="replace")
+    # `openssl ec -text` names the curve on an "ASN1 OID:" line. Keying on that
+    # rather than the "NIST CURVE:" line keeps brainpool curves (which have no
+    # NIST name) readable by the same parse.
+    match = re.search(r"^\s*ASN1 OID:\s*(\S+)\s*$", text, re.MULTILINE)
+    if match is None:
+        raise BuildRepoError(f"{sign_key}: cannot determine the EC curve (is it an EC private key?)")
+    curve = match.group(1)
+    if curve not in PKG_ACCEPTED_CURVES:
+        raise BuildRepoError(
+            f"{sign_key}: pkg cannot verify signatures on curve {curve!r} — "
+            f"choose one of {', '.join(sorted(PKG_ACCEPTED_CURVES))} (secp384r1 recommended)"
+        )
+    return _openssl(["ec", "-in", str(sign_key), "-pubout", "-outform", "DER"])
+
+
+def catalog_signature(data: bytes, sign_key: Path) -> bytes:
+    """The `.sig` member body for ``data``: header + ECDSA over its BLAKE2b-512 digest."""
+    digest = hashlib.blake2b(data, digest_size=64).digest()
+    return PKGSIGN_ECDSA_HEAD + _openssl(["dgst", "-sha256", "-sign", str(sign_key)], stdin=digest)
+
+
 # Archive emission (zstd tar) — same framing contract as build-pkg-portable.py:
 # USTAR, leading-slash-free member name, root:wheel, mode 0644, deterministic
 # mtime 0 (the install/index clock is irrelevant to clients; 0 keeps re-runs
 # byte-identical). USTAR is the proven-accepted framing (build-pkg-portable.py's
 # .pkg uses it and a real pfSense box installs it).
+#
+# Byte-identical re-runs hold for UNSIGNED output only: ECDSA signatures are
+# randomised (OpenSSL does not implement deterministic RFC 6979), so a signed
+# catalogue differs between builds even when the package set does not — see
+# issue #2675 for what that costs the publisher's NOOP detection.
 # --------------------------------------------------------------------------- #
 
 
-def _tar_one(member_name: str, data: bytes) -> bytes:
+def _tar_one(*members: tuple[str, bytes]) -> bytes:
     raw = io.BytesIO()
     with tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as tf:
-        ti = tarfile.TarInfo(name=member_name)
-        ti.size = len(data)
-        ti.mode = 0o644
-        ti.uid = ti.gid = 0
-        ti.uname, ti.gname = "root", "wheel"
-        ti.mtime = 0
-        ti.type = tarfile.REGTYPE
-        tf.addfile(ti, io.BytesIO(data))
+        for member_name, data in members:
+            ti = tarfile.TarInfo(name=member_name)
+            ti.size = len(data)
+            ti.mode = 0o644
+            ti.uid = ti.gid = 0
+            ti.uname, ti.gname = "root", "wheel"
+            ti.mtime = 0
+            ti.type = tarfile.REGTYPE
+            tf.addfile(ti, io.BytesIO(data))
     return raw.getvalue()
 
 
-def write_zstd_tar(member_name: str, data: bytes, out_path: Path) -> None:
+def write_zstd_tar(member_name: str, data: bytes, out_path: Path, *, sign_key: Path | None = None) -> None:
+    """Write ``data`` as a one-member zstd tar, signed when ``sign_key`` is given.
+
+    With a key, the archive gains ``<member_name>.sig`` and ``<member_name>.pub``
+    AHEAD of the catalogue member — the order real `pkg repo` writes (pack_sign()
+    runs before packing_append_file_attr()), and the names it derives from the
+    MEMBER rather than the archive. Without a key the output is unchanged, so
+    local and offline catalogues stay exactly as they were.
+    """
+    members: list[tuple[str, bytes]] = []
+    if sign_key is not None:
+        members.append((f"{member_name}.sig", catalog_signature(data, sign_key)))
+        members.append((f"{member_name}.pub", signing_public_der(sign_key)))
+    members.append((member_name, data))
     out_path.write_bytes(
         zstd_compress(
-            _tar_one(member_name, data),
+            _tar_one(*members),
             BuildRepoError,
             "zstd compression needs the `zstd` binary or the python `zstandard` module "
             "(brew install zstd / apt install zstd)",
@@ -464,7 +573,13 @@ def _validate_catalog_name(name: str, *, single_segment: bool = False) -> None:
         )
 
 
-def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) -> list[str]:
+def build_repo(
+    in_dir: Path,
+    out_dir: Path,
+    *,
+    catalog_name: str | None = None,
+    sign_key: Path | None = None,
+) -> list[str]:
     """Build the arch-less (NO_ARCH-only) catalog from a directory of .pkg files.
 
     Every pfBlockerNG .pkg is NO_ARCH (issue #1806): its manifest ABI is
@@ -508,12 +623,18 @@ def build_repo(in_dir: Path, out_dir: Path, *, catalog_name: str | None = None) 
         )
 
     catalog_root = out_dir / catalog_name if catalog_name else out_dir
-    n = _emit_catalog_from_paths(catalog_root, pkgs, root=out_dir)
+    n = _emit_catalog_from_paths(catalog_root, pkgs, root=out_dir, sign_key=sign_key)
     sys.stderr.write(f"==> built catalog {catalog_root} ({n} package(s))\n")
     return sorted(abis)
 
 
-def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict]], *, root: Path) -> int:
+def _write_catalog_dir(
+    dest: Path,
+    items: dict[tuple[str, str], tuple[Path, dict]],
+    *,
+    root: Path,
+    sign_key: Path | None = None,
+) -> int:
     """Write one pkg catalog at ``dest`` from a ``{(name, version): (path, manifest)}`` map.
 
     Wipes + rebuilds ``dest`` for determinism (a removed .pkg never lingers), copies each
@@ -559,8 +680,8 @@ def _write_catalog_dir(dest: Path, items: dict[tuple[str, str], tuple[Path, dict
     (dest / "meta.conf").write_text(META_CONF)
     (dest / "meta").write_text(META_CONF)
     # packagesite.pkg (packagesite.yaml = NDJSON) + data.pkg (data = one JSON object).
-    write_zstd_tar("packagesite.yaml", _ndjson(catalog_objs), dest / "packagesite.pkg")
-    write_zstd_tar("data", _data_blob(catalog_objs), dest / "data.pkg")
+    write_zstd_tar("packagesite.yaml", _ndjson(catalog_objs), dest / "packagesite.pkg", sign_key=sign_key)
+    write_zstd_tar("data", _data_blob(catalog_objs), dest / "data.pkg", sign_key=sign_key)
     return len(catalog_objs)
 
 
@@ -651,7 +772,14 @@ def _require_contained(root: Path, dest: Path) -> Path:
     return dest
 
 
-def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path], *, root: Path, route_only: bool = False) -> int:
+def _emit_catalog_from_paths(
+    dest: Path,
+    pkg_paths: list[Path],
+    *,
+    root: Path,
+    route_only: bool = False,
+    sign_key: Path | None = None,
+) -> int:
     """Read each .pkg's manifest, dedup by (name, version), collision-check, emit at dest.
 
     Every package here MUST carry a NO_ARCH (wildcard) ABI (``_is_wildcard_abi``,
@@ -681,7 +809,7 @@ def _emit_catalog_from_paths(dest: Path, pkg_paths: list[Path], *, root: Path, r
             sys.stderr.write(f"==> dedup: {path.name} duplicates {items[nv][0].name} ({nv[0]}-{nv[1]})\n")
             continue
         items[nv] = (path, manifest)
-    return _write_catalog_dir(dest, items, root=root)
+    return _write_catalog_dir(dest, items, root=root, sign_key=sign_key)
 
 
 def _retain_newest(pkg_paths: list[Path], keep: int) -> list[Path]:
@@ -1024,6 +1152,7 @@ def build_repo_matrix(
     release_pkgs: dict[str, list[Path]] | None = None,
     dep_pkgs: list[Path] | None = None,
     build_records: list[BuildRecordInput] | None = None,
+    sign_key: Path | None = None,
     **builder_kwargs: object,
 ) -> dict:
     """Build the full variant repository tree from the version matrix.
@@ -1191,7 +1320,7 @@ def build_repo_matrix(
                     f"frozen .pkg, but none match ABI {abi!r} — supply a frozen .pkg for this ABI."
                 )
             release_dir = out_dir / "release" / varver
-            n_release = _emit_catalog_from_paths(release_dir, frozen, root=out_dir, route_only=True)
+            n_release = _emit_catalog_from_paths(release_dir, frozen, root=out_dir, route_only=True, sign_key=sign_key)
             built.append(str(release_dir))
             sys.stderr.write(f"==> route-only release catalog {release_dir} ({n_release} package(s), frozen)\n")
             # No nightly subtree — route-only entries never get a nightly build.
@@ -1227,7 +1356,9 @@ def build_repo_matrix(
                 )
                 if kept_release:
                     # dep_for_abi folds in AFTER retention (never competes for a slot).
-                    n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi, root=out_dir)
+                    n_release = _emit_catalog_from_paths(
+                        release_dir, kept_release + dep_for_abi, root=out_dir, sign_key=sign_key
+                    )
                     built.append(str(release_dir))
                     sys.stderr.write(f"==> release catalog {release_dir} ({n_release} package(s), consumed)\n")
                     dep_pkgs_matched.update(dep_for_abi)
@@ -1304,7 +1435,9 @@ def build_repo_matrix(
                         keep_stable=release_keep_stable,
                     )
                     # dep_for_abi folds in AFTER retention (never competes for a slot).
-                    n_release = _emit_catalog_from_paths(release_dir, kept_release + dep_for_abi, root=out_dir)
+                    n_release = _emit_catalog_from_paths(
+                        release_dir, kept_release + dep_for_abi, root=out_dir, sign_key=sign_key
+                    )
                 built.append(str(release_dir))
                 sys.stderr.write(f"==> release catalog {release_dir} ({n_release} package(s))\n")
                 dep_pkgs_matched.update(dep_for_abi)
@@ -1345,7 +1478,7 @@ def build_repo_matrix(
                     kept = _retain_newest([*existing, new_nightly], nightly_keep)
                     # dep_for_abi folds in AFTER retention here too — the SAME dep pkg
                     # belongs in both the release and nightly catalogs of this ABI train.
-                    n = _emit_catalog_from_paths(nightly_dir, kept + dep_for_abi, root=out_dir)
+                    n = _emit_catalog_from_paths(nightly_dir, kept + dep_for_abi, root=out_dir, sign_key=sign_key)
                 built.append(str(nightly_dir))
                 sys.stderr.write(f"==> nightly catalog {nightly_dir} ({n} package(s), kept ≤{nightly_keep})\n")
                 dep_pkgs_matched.update(dep_for_abi)
@@ -1418,6 +1551,17 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--in", dest="in_dir", help="directory holding the input .pkg files (searched, non-recursive)")
     ap.add_argument("--out", dest="out_dir", help="output root; the flat, arch-less catalog is written directly here")
     ap.add_argument("--print-conf", action="store_true", help="print the client repo-conf template to stdout and exit")
+    ap.add_argument(
+        "--sign-key",
+        default="",
+        dest="sign_key",
+        help=(
+            "ECDSA private key (PEM) to sign each catalogue with, for a client conf using "
+            "signature_type: fingerprints (issue #2675). Omitted = unsigned catalogues, "
+            "which is what local and offline (file://) catalogues want. pkg accepts only "
+            "secp256k1/secp384r1/secp521r1 and the brainpool curves — NOT prime256v1."
+        ),
+    )
     ap.add_argument(
         "--base-url",
         default=DEFAULT_BASE_URL,
@@ -1664,6 +1808,7 @@ def main(argv: list[str]) -> int:
                 route_only_pkgs=route_only,
                 release_pkgs=release_pkgs_arg,
                 annotate=annotate or None,
+                sign_key=Path(args.sign_key) if args.sign_key else None,
             )
         except (BuildRepoError, PkgError, subprocess.CalledProcessError) as e:
             sys.stderr.write(f"build-repo-portable: {e}\n")
@@ -1678,7 +1823,12 @@ def main(argv: list[str]) -> int:
         return 1
 
     try:
-        abis = build_repo(in_dir, Path(args.out_dir), catalog_name=args.catalog_name)
+        abis = build_repo(
+            in_dir,
+            Path(args.out_dir),
+            catalog_name=args.catalog_name,
+            sign_key=Path(args.sign_key) if args.sign_key else None,
+        )
     except (BuildRepoError, PkgError) as e:
         sys.stderr.write(f"build-repo-portable: {e}\n")
         return 1

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -4251,3 +4251,237 @@ def test_dep_pkgs_category_mismatch_is_undeclared(tmp_path: Path) -> None:
             build_nightly=False,
             dep_pkgs=[dep_pkg],
         )
+
+
+# --------------------------------------------------------------------------- #
+# Catalogue signing (issue #2675) — `signature_type: fingerprints` with an
+# ECDSA key, so authenticity stops depending on TLS (and therefore on the CA
+# store `pkg` was pinned to on pfSense Plus).
+#
+# The wire contract is read off freebsd/pkg (13f9f98), not inferred:
+#   * the client scans a catalogue archive for members ending `.sig` / `.pub`
+#     and pairs them by basename (pkg_repo_meta_extract_signature_fingerprints);
+#     `pkg repo` names them after the MEMBER, so `packagesite.yaml.{sig,pub}`
+#     inside packagesite.pkg and `data.{sig,pub}` inside data.pkg;
+#   * ECDSA signs the BLAKE2b-512 RAW digest of the uncompressed catalogue,
+#     with SHA256 as the inner hash (pkgsign_ecc.c: ecc_new sets sig_hash =
+#     SHA256; ecc_sign_file hashes with PKG_HASH_TYPE_BLAKE2_RAW);
+#   * a non-RSA signature carries a `$PKGSIGN:<type>$` prefix
+#     (PKGSIGN_HEAD in libpkg/private/pkgsign.h, written by pack_sign);
+#   * the public half is DER PKCS#8 for ECDSA — the loader calls libder_read()
+#     and understands no PEM — and the trusted fingerprint is the SHA256 of
+#     exactly those bytes (pkg_repo_check_fingerprint).
+# --------------------------------------------------------------------------- #
+
+_PKGSIGN_ECDSA_HEAD = b"$PKGSIGN:ecdsa$"
+
+
+def _gen_key(path: Path, curve: str = "secp384r1") -> Path:
+    """An EC private key in PEM, via openssl (what the publisher will use)."""
+    import subprocess
+
+    subprocess.run(
+        ["openssl", "ecparam", "-name", curve, "-genkey", "-noout", "-out", str(path)],
+        check=True,
+        capture_output=True,
+    )
+    return path
+
+
+def _openssl_verify(digest: bytes, sig: bytes, pub_der: bytes, tmp_path: Path) -> bool:
+    """Reproduce pkg's ECDSA check: ECDSA-SHA256 over the BLAKE2b-512 digest."""
+    import subprocess
+
+    d = tmp_path / "verify.msg"
+    s = tmp_path / "verify.sig"
+    p = tmp_path / "verify.pub.der"
+    d.write_bytes(digest)
+    s.write_bytes(sig)
+    p.write_bytes(pub_der)
+    proc = subprocess.run(
+        [
+            "openssl",
+            "dgst",
+            "-sha256",
+            "-verify",
+            str(p),
+            "-keyform",
+            "DER",
+            "-signature",
+            str(s),
+            str(d),
+        ],
+        capture_output=True,
+    )
+    return proc.returncode == 0
+
+
+def _sig_members(archive: Path) -> dict[str, bytes]:
+    """Every `.sig`/`.pub` member of a catalogue archive, by member name."""
+    data = pfb_pkg.zstd_decompress(archive.read_bytes())
+    out: dict[str, bytes] = {}
+    with tarfile.open(fileobj=io.BytesIO(data)) as tf:
+        for ti in tf.getmembers():
+            if ti.name.endswith((".sig", ".pub")):
+                f = tf.extractfile(ti)
+                assert f is not None
+                out[ti.name] = f.read()
+    return out
+
+
+def _build_signed(tmp_path: Path, curve: str = "secp384r1") -> tuple[Path, Path]:
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg")
+    key = _gen_key(tmp_path / "repo.key", curve)
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out, sign_key=key)
+    return out, key
+
+
+def test_catalog_is_unsigned_without_a_key(tmp_path: Path) -> None:
+    """No key, no signature members — signing must stay opt-in.
+
+    Local and offline catalogues (the smoke guests' file:// repos) are built with
+    no key at all, and a stray unverifiable signature member would make a
+    `signature_type: none` client's catalogue differ for no reason.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg")
+    out = tmp_path / "out"
+    brp.build_repo(in_dir, out)
+
+    assert _sig_members(out / "packagesite.pkg") == {}
+    assert _sig_members(out / "data.pkg") == {}
+
+
+def test_signed_catalog_carries_the_member_names_pkg_repo_emits(tmp_path: Path) -> None:
+    """`<member>.sig` + `<member>.pub`, named after the catalogue MEMBER.
+
+    pkg_repo_pack_db() is called with meta->manifests ("packagesite.yaml") and
+    meta->data ("data"), and pack_command_sign() derives "%s.sig"/"%s.pub" from
+    that — NOT from the archive name. Getting this wrong leaves the client with
+    an unpaired signature and a fatal "No signature found".
+    """
+    out, _ = _build_signed(tmp_path)
+
+    assert sorted(_sig_members(out / "packagesite.pkg")) == [
+        "packagesite.yaml.pub",
+        "packagesite.yaml.sig",
+    ]
+    assert sorted(_sig_members(out / "data.pkg")) == ["data.pub", "data.sig"]
+
+
+def test_signature_carries_the_pkgsign_ecdsa_header(tmp_path: Path) -> None:
+    """A non-RSA signature is prefixed `$PKGSIGN:ecdsa$`; the client parses it to pick the signer."""
+    out, _ = _build_signed(tmp_path)
+    for archive, member in ((out / "packagesite.pkg", "packagesite.yaml.sig"), (out / "data.pkg", "data.sig")):
+        assert _sig_members(archive)[member].startswith(_PKGSIGN_ECDSA_HEAD)
+
+
+def test_signature_verifies_over_the_blake2b_digest(tmp_path: Path) -> None:
+    """The real cryptographic check, exactly as libpkg does it.
+
+    BLAKE2b-512 over the UNCOMPRESSED catalogue member, then ECDSA-SHA256 over
+    that 64-byte digest, verified with the embedded public key.
+    """
+    out, _ = _build_signed(tmp_path)
+
+    for archive, member in (
+        (out / "packagesite.pkg", "packagesite.yaml"),
+        (out / "data.pkg", "data"),
+    ):
+        sigs = _sig_members(archive)
+        sig = sigs[f"{member}.sig"][len(_PKGSIGN_ECDSA_HEAD) :]
+        pub = sigs[f"{member}.pub"]
+        digest = hashlib.blake2b(_read_member(archive, member), digest_size=64).digest()
+        assert len(digest) == 64
+        assert _openssl_verify(digest, sig, pub, tmp_path), f"{member} signature did not verify"
+
+
+def test_signature_does_not_verify_for_a_tampered_catalog(tmp_path: Path) -> None:
+    """Flip one byte of the catalogue and the signature must stop verifying.
+
+    Without this, the test above would pass just as happily against a signature
+    over the wrong bytes.
+    """
+    out, _ = _build_signed(tmp_path)
+    sigs = _sig_members(out / "packagesite.pkg")
+    sig = sigs["packagesite.yaml.sig"][len(_PKGSIGN_ECDSA_HEAD) :]
+    pub = sigs["packagesite.yaml.pub"]
+    tampered = _read_member(out / "packagesite.pkg", "packagesite.yaml") + b"x"
+    digest = hashlib.blake2b(tampered, digest_size=64).digest()
+    assert not _openssl_verify(digest, sig, pub, tmp_path)
+
+
+def test_public_member_is_der_on_the_signing_curve(tmp_path: Path) -> None:
+    """The `.pub` member is DER (no PEM armour) and matches the key we signed with.
+
+    The loader calls libder_read() directly, so PEM would be unparseable; and the
+    trusted fingerprint is the SHA256 of these exact bytes, so any re-encoding
+    silently invalidates every deployed fingerprint file.
+    """
+    import subprocess
+
+    out, key = _build_signed(tmp_path)
+    pub = _sig_members(out / "packagesite.pkg")["packagesite.yaml.pub"]
+
+    assert not pub.startswith(b"-----BEGIN"), "the .pub member must be DER, not PEM"
+    expected = subprocess.run(
+        ["openssl", "ec", "-in", str(key), "-pubout", "-outform", "DER"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    assert pub == expected
+
+
+def test_signing_refuses_a_curve_pkg_cannot_verify(tmp_path: Path) -> None:
+    """prime256v1 must be refused at build time, loudly.
+
+    P-256 is the curve nearly every tool defaults to, and pkg's OID switch
+    (ecc_read_pkgkey) does not accept it — only secp256k1/secp384r1/secp521r1 and
+    the brainpool set. Signing with it would publish a catalogue that every box
+    rejects, so this has to fail where we can see it: in the build.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg")
+    key = _gen_key(tmp_path / "p256.key", "prime256v1")
+
+    with pytest.raises(brp.BuildRepoError, match="curve"):
+        brp.build_repo(in_dir, tmp_path / "out", sign_key=key)
+
+
+def test_build_matrix_signs_every_catalog_it_emits(tmp_path: Path) -> None:
+    """The matrix path is what the publisher runs, so the key has to reach it.
+
+    Threading `sign_key` only as far as build_repo() would leave every published
+    catalogue unsigned while the unit tests stayed green.
+    """
+    key = _gen_key(tmp_path / "repo.key")
+    out = tmp_path / "site"
+    brp.build_repo_matrix([_CE], out, builder=_stub_builder, sign_key=key)
+
+    for catalog in (out / "release" / "ce-2.8", out / "nightly" / "ce-2.8"):
+        assert sorted(_sig_members(catalog / "packagesite.pkg")) == [
+            "packagesite.yaml.pub",
+            "packagesite.yaml.sig",
+        ], f"{catalog} packagesite.pkg is unsigned"
+        assert sorted(_sig_members(catalog / "data.pkg")) == ["data.pub", "data.sig"]
+
+
+def test_cli_sign_key_flag_signs_the_catalog(tmp_path: Path) -> None:
+    """`--sign-key` is the publisher's entry point; without it nothing is signed."""
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    make_pkg(in_dir / "demo-1.0_1.pkg")
+    key = _gen_key(tmp_path / "repo.key")
+    out = tmp_path / "out"
+
+    rc = brp.main(["--in", str(in_dir), "--out", str(out), "--sign-key", str(key)])
+    assert rc == 0
+    assert sorted(_sig_members(out / "packagesite.pkg")) == [
+        "packagesite.yaml.pub",
+        "packagesite.yaml.sig",
+    ]

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -4264,11 +4264,16 @@ def test_dep_pkgs_category_mismatch_is_undeclared(tmp_path: Path) -> None:
 #     and pairs them by basename (pkg_repo_meta_extract_signature_fingerprints);
 #     `pkg repo` names them after the MEMBER, so `packagesite.yaml.{sig,pub}`
 #     inside packagesite.pkg and `data.{sig,pub}` inside data.pkg;
-#   * ECDSA signs the BLAKE2b-512 RAW digest of the uncompressed catalogue,
-#     with SHA256 as the inner hash (pkgsign_ecc.c: ecc_new sets sig_hash =
-#     SHA256; ecc_sign_file hashes with PKG_HASH_TYPE_BLAKE2_RAW);
-#   * a non-RSA signature carries a `$PKGSIGN:<type>$` prefix
-#     (PKGSIGN_HEAD in libpkg/private/pkgsign.h, written by pack_sign);
+#   * the signed message is the 64-character ASCII SHA256 HEX of the
+#     uncompressed catalogue member, ECDSA-SHA256 over it (pkgsign_ecc.c:
+#     ecc_new pins sig_hash = SHA256; ecc_verify_cert_cb hashes with
+#     PKG_HASH_TYPE_SHA256_HEX and passes it at strlen(), so no NUL). The
+#     BLAKE2b-512 chain in ecc_sign_file/ecc_verify_file serves PUBKEY mode,
+#     whose catalogue carries a single `signature` member instead;
+#   * BOTH the `.sig` and `.pub` members carry the `$PKGSIGN:<type>$` prefix
+#     (PKGSIGN_HEAD in libpkg/private/pkgsign.h): pkg_repo_parse_sigkeys()
+#     sets the signer type from every member it parses, so a bare `.pub`
+#     resets it to the "rsa" default;
 #   * the public half is DER PKCS#8 for ECDSA — the loader calls libder_read()
 #     and understands no PEM — and the trusted fingerprint is the SHA256 of
 #     exactly those bytes (pkg_repo_check_fingerprint).

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -4391,11 +4391,10 @@ def test_signature_carries_the_pkgsign_ecdsa_header(tmp_path: Path) -> None:
 def test_signature_verifies_over_the_sha256_hex_message(tmp_path: Path) -> None:
     """The real cryptographic check, exactly as libpkg's FINGERPRINTS path does it.
 
-    Proven against a real libpkg (freebsd/pkg 13f9f98) built on a Linux box: the
-    signed message is the 64-character ASCII SHA256 HEX of the uncompressed catalogue
-    member, ECDSA-SHA256 over that. Signing the BLAKE2b-512 digest instead — the
-    convention `ecc_verify_file()` uses for PUBKEY mode — makes a real `pkg update`
-    fail with "ecc signature verification failure".
+    The signed message is the 64-character ASCII SHA256 HEX of the uncompressed
+    catalogue member, ECDSA-SHA256 over that. The BLAKE2b-512 digest is the PUBKEY-mode
+    convention (`ecc_verify_file()`); signing it here yields a catalogue that a real
+    `pkg update` rejects with "ecc signature verification failure".
     """
     out, _ = _build_signed(tmp_path)
 
@@ -4500,8 +4499,7 @@ def test_cli_sign_key_flag_signs_the_catalog(tmp_path: Path) -> None:
 def test_public_member_also_carries_the_pkgsign_header(tmp_path: Path) -> None:
     """The `.pub` member needs the `$PKGSIGN:ecdsa$` prefix too, not just `.sig`.
 
-    Proven against a real libpkg (built from freebsd/pkg 13f9f98) before this test
-    existed: with the header on `.sig` only, `pkg update` fails with
+    With the header on `.sig` only, a real `pkg update` fails with
 
         pkg: error reading public key: error:1E08010C:DECODER routines::unsupported
         pkg: No trusted certificate has been used to sign the repository
@@ -4529,3 +4527,21 @@ def test_public_member_also_carries_the_pkgsign_header(tmp_path: Path) -> None:
         # The fingerprint is the sha256 of the cert bytes AFTER the header is stripped,
         # so the DER must still be recoverable exactly.
         assert sigs[f"{member}.pub"][len(_PKGSIGN_ECDSA_HEAD) :].startswith(b"\x30")
+
+
+def test_openssl_that_cannot_be_executed_raises_build_error(tmp_path: Path, monkeypatch: Any) -> None:
+    """An `openssl` on PATH that is not executable must still surface as BuildRepoError.
+
+    `subprocess.run` raises PermissionError, not FileNotFoundError, for this case, so
+    catching only the latter let a bare traceback escape the wrapper. Shadow PATH with a
+    directory holding a non-executable `openssl` to exercise it.
+    """
+    shadow = tmp_path / "bin"
+    shadow.mkdir()
+    fake = shadow / "openssl"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o644)  # present, findable, NOT executable
+    monkeypatch.setenv("PATH", str(shadow))
+
+    with pytest.raises(brp.BuildRepoError, match="cannot run `openssl`"):
+        brp.catalog_signature(b"payload", tmp_path / "irrelevant.key")

--- a/tests/test_build_repo_portable.py
+++ b/tests/test_build_repo_portable.py
@@ -34,6 +34,7 @@ import importlib.util
 import io
 import json
 import os
+import subprocess
 import sys
 import tarfile
 from pathlib import Path
@@ -4278,8 +4279,6 @@ _PKGSIGN_ECDSA_HEAD = b"$PKGSIGN:ecdsa$"
 
 def _gen_key(path: Path, curve: str = "secp384r1") -> Path:
     """An EC private key in PEM, via openssl (what the publisher will use)."""
-    import subprocess
-
     subprocess.run(
         ["openssl", "ecparam", "-name", curve, "-genkey", "-noout", "-out", str(path)],
         check=True,
@@ -4288,10 +4287,19 @@ def _gen_key(path: Path, curve: str = "secp384r1") -> Path:
     return path
 
 
-def _openssl_verify(digest: bytes, sig: bytes, pub_der: bytes, tmp_path: Path) -> bool:
-    """Reproduce pkg's ECDSA check: ECDSA-SHA256 over the BLAKE2b-512 digest."""
-    import subprocess
+def _pkg_signed_message(catalog: bytes) -> bytes:
+    """What pkg's FINGERPRINTS path actually signs: the SHA256 HEX string, 64 ASCII bytes.
 
+    `ecc_verify_cert_cb()` does `pkg_checksum_fd(fd, PKG_HASH_TYPE_SHA256_HEX)` and passes
+    it with `strlen()`, so the message is the hex text with NO NUL terminator. The
+    BLAKE2b-512 convention belongs to `ecc_verify_file()`, which serves PUBKEY mode — a
+    different signature_type than ours.
+    """
+    return hashlib.sha256(catalog).hexdigest().encode()
+
+
+def _openssl_verify(digest: bytes, sig: bytes, pub_der: bytes, tmp_path: Path) -> bool:
+    """Reproduce pkg's ECDSA cert check: ECDSA-SHA256 over the SHA256-hex message."""
     d = tmp_path / "verify.msg"
     s = tmp_path / "verify.sig"
     p = tmp_path / "verify.pub.der"
@@ -4380,11 +4388,14 @@ def test_signature_carries_the_pkgsign_ecdsa_header(tmp_path: Path) -> None:
         assert _sig_members(archive)[member].startswith(_PKGSIGN_ECDSA_HEAD)
 
 
-def test_signature_verifies_over_the_blake2b_digest(tmp_path: Path) -> None:
-    """The real cryptographic check, exactly as libpkg does it.
+def test_signature_verifies_over_the_sha256_hex_message(tmp_path: Path) -> None:
+    """The real cryptographic check, exactly as libpkg's FINGERPRINTS path does it.
 
-    BLAKE2b-512 over the UNCOMPRESSED catalogue member, then ECDSA-SHA256 over
-    that 64-byte digest, verified with the embedded public key.
+    Proven against a real libpkg (freebsd/pkg 13f9f98) built on a Linux box: the
+    signed message is the 64-character ASCII SHA256 HEX of the uncompressed catalogue
+    member, ECDSA-SHA256 over that. Signing the BLAKE2b-512 digest instead — the
+    convention `ecc_verify_file()` uses for PUBKEY mode — makes a real `pkg update`
+    fail with "ecc signature verification failure".
     """
     out, _ = _build_signed(tmp_path)
 
@@ -4394,10 +4405,10 @@ def test_signature_verifies_over_the_blake2b_digest(tmp_path: Path) -> None:
     ):
         sigs = _sig_members(archive)
         sig = sigs[f"{member}.sig"][len(_PKGSIGN_ECDSA_HEAD) :]
-        pub = sigs[f"{member}.pub"]
-        digest = hashlib.blake2b(_read_member(archive, member), digest_size=64).digest()
-        assert len(digest) == 64
-        assert _openssl_verify(digest, sig, pub, tmp_path), f"{member} signature did not verify"
+        pub = sigs[f"{member}.pub"][len(_PKGSIGN_ECDSA_HEAD) :]
+        message = _pkg_signed_message(_read_member(archive, member))
+        assert len(message) == 64, "the signed message is the hex text, not a raw digest"
+        assert _openssl_verify(message, sig, pub, tmp_path), f"{member} signature did not verify"
 
 
 def test_signature_does_not_verify_for_a_tampered_catalog(tmp_path: Path) -> None:
@@ -4409,10 +4420,9 @@ def test_signature_does_not_verify_for_a_tampered_catalog(tmp_path: Path) -> Non
     out, _ = _build_signed(tmp_path)
     sigs = _sig_members(out / "packagesite.pkg")
     sig = sigs["packagesite.yaml.sig"][len(_PKGSIGN_ECDSA_HEAD) :]
-    pub = sigs["packagesite.yaml.pub"]
+    pub = sigs["packagesite.yaml.pub"][len(_PKGSIGN_ECDSA_HEAD) :]
     tampered = _read_member(out / "packagesite.pkg", "packagesite.yaml") + b"x"
-    digest = hashlib.blake2b(tampered, digest_size=64).digest()
-    assert not _openssl_verify(digest, sig, pub, tmp_path)
+    assert not _openssl_verify(_pkg_signed_message(tampered), sig, pub, tmp_path)
 
 
 def test_public_member_is_der_on_the_signing_curve(tmp_path: Path) -> None:
@@ -4422,10 +4432,10 @@ def test_public_member_is_der_on_the_signing_curve(tmp_path: Path) -> None:
     trusted fingerprint is the SHA256 of these exact bytes, so any re-encoding
     silently invalidates every deployed fingerprint file.
     """
-    import subprocess
-
     out, key = _build_signed(tmp_path)
-    pub = _sig_members(out / "packagesite.pkg")["packagesite.yaml.pub"]
+    # The member carries the `$PKGSIGN:ecdsa$` header ahead of the key; the fingerprint is
+    # computed over what remains, which must be the DER byte-for-byte.
+    pub = _sig_members(out / "packagesite.pkg")["packagesite.yaml.pub"][len(_PKGSIGN_ECDSA_HEAD) :]
 
     assert not pub.startswith(b"-----BEGIN"), "the .pub member must be DER, not PEM"
     expected = subprocess.run(
@@ -4449,7 +4459,7 @@ def test_signing_refuses_a_curve_pkg_cannot_verify(tmp_path: Path) -> None:
     make_pkg(in_dir / "demo-1.0_1.pkg")
     key = _gen_key(tmp_path / "p256.key", "prime256v1")
 
-    with pytest.raises(brp.BuildRepoError, match="curve"):
+    with pytest.raises(brp.BuildRepoError, match="cannot verify signatures on curve"):
         brp.build_repo(in_dir, tmp_path / "out", sign_key=key)
 
 
@@ -4485,3 +4495,37 @@ def test_cli_sign_key_flag_signs_the_catalog(tmp_path: Path) -> None:
         "packagesite.yaml.pub",
         "packagesite.yaml.sig",
     ]
+
+
+def test_public_member_also_carries_the_pkgsign_header(tmp_path: Path) -> None:
+    """The `.pub` member needs the `$PKGSIGN:ecdsa$` prefix too, not just `.sig`.
+
+    Proven against a real libpkg (built from freebsd/pkg 13f9f98) before this test
+    existed: with the header on `.sig` only, `pkg update` fails with
+
+        pkg: error reading public key: error:1E08010C:DECODER routines::unsupported
+        pkg: No trusted certificate has been used to sign the repository
+
+    Cause: `pkg_repo_parse_sigkeys()` assigns `s->type` for EVERY member it parses,
+    keyed by basename. The `.pub` entry is parsed after `.sig`, and with no header it
+    defaults to "rsa", overwriting the "ecdsa" the `.sig` established. Verification
+    then runs the RSA/ossl signer, whose `_load_public_key_buf()` uses
+    `PEM_read_bio_PUBKEY` and cannot read our DER key.
+
+    Upstream avoids this by accident of implementation: `pack_command_sign()` never
+    resets `offset` between appends, so `iov[0]` still holds the header when it writes
+    the `.pub` member — i.e. real `pkg repo` prefixes BOTH members for non-RSA.
+    """
+    out, _ = _build_signed(tmp_path)
+
+    for archive, member in (
+        (out / "packagesite.pkg", "packagesite.yaml"),
+        (out / "data.pkg", "data"),
+    ):
+        sigs = _sig_members(archive)
+        assert sigs[f"{member}.pub"].startswith(_PKGSIGN_ECDSA_HEAD), (
+            f"{member}.pub lacks the header, so libpkg resets the signer type to rsa"
+        )
+        # The fingerprint is the sha256 of the cert bytes AFTER the header is stripped,
+        # so the DER must still be recoverable exactly.
+        assert sigs[f"{member}.pub"][len(_PKGSIGN_ECDSA_HEAD) :].startswith(b"\x30")


### PR DESCRIPTION
## Why

Our catalogues are `signature_type: none`, so their only trust anchor is HTTPS to the host — and
that is precisely what breaks on pfSense Plus, where `pfSense-repo-setup` pins `pkg` to a
Netgate-only CA bundle. This session established that no environment-based fix can reach the GUI,
with both barriers confirmed on a live 26.03.1 box:

1. php-fpm hands its workers a scrubbed environment (`clear_env` defaults on), so the worker running
   a GUI `pkg` call sees only the pool's `env[...]` entries. Same command, same box, minutes apart:
   SSH `rc=0`, webConfigurator `rc=1`.
2. pfSense's own `pkg_call()` passes an explicit environment array to `proc_open`, which *replaces*
   the child environment — so even a worker that carried the variable would not help Package Manager.

Signing the catalogues moves authenticity onto our own key, so the fetch no longer has to carry it.

## What this PR does

The **producer half only**. With no key, output is byte-for-byte what it was — local and offline
(`file://`) catalogues are untouched — and a `signature_type: none` client ignores the added archive
members, so this is safe to land ahead of any client change. Clients flip separately.

- `build-repo-portable.py` gains `--sign-key` / `sign_key=`, threaded through `build_repo()` and
  `build_repo_matrix()` so the publisher path is actually wired, not just the unit-test path.
- Each catalogue archive gains `<member>.sig` + `<member>.pub` ahead of the catalogue member.
- The curve is validated up front, and a key `pkg` cannot verify is a hard build error.

## Wire format — read off freebsd/pkg (13f9f98), not inferred

Every detail here fails only at verification time, on the box, which is why each is pinned by a test:

- The client pairs members ending `.sig`/`.pub` by basename, and `pkg repo` names them after the
  catalogue **member** (`pkg_repo_pack_db()` receives `meta->manifests`), so `packagesite.yaml.{sig,pub}`
  inside `packagesite.pkg` and `data.{sig,pub}` inside `data.pkg`.
- ECDSA signs the **BLAKE2b-512 raw digest** of the uncompressed member, with SHA256 as the inner
  hash (`ecc_new()` pins `sig_hash = SHA256` regardless of curve). RSA's convention — signing the
  SHA256 *hex string* — deliberately does not carry over.
- A non-RSA signature carries the `$PKGSIGN:<type>$` prefix.
- The public half is DER: the ECC loader calls `libder_read()` and understands no PEM. The trusted
  fingerprint is the SHA256 of exactly those bytes, so any re-encoding invalidates deployed
  fingerprint files.

`meta` needs no signature: `pkg_repo_fetch_meta()` tries `meta.conf` first and on success jumps past
all signature handling. Only the legacy `meta.txz` path verifies, and we serve `meta.conf`.

## The curve trap

`pkg` accepts far fewer curves than OpenSSL offers — `ecc_read_pkgkey()`'s OID switch takes only
`secp256k1`, `secp384r1`, `secp521r1` and the brainpool set. **`prime256v1`/P-256 is absent**, and it
is the curve nearly every tool defaults to. A key using it would build cleanly and then be rejected
by every box, so signing refuses it where it is visible: in the build. `secp384r1` is recommended.

## Tests

Red→green, test file byte-identical across both runs (`8ebff2b2…`): 8 failed → 10 passed. The
crypto assertions are real, not presence checks — BLAKE2b-512 → ECDSA-SHA256 verified against the
embedded public key, plus a tampered-catalogue case so the verify cannot pass vacuously, plus a
`prime256v1` case that must be refused, plus an unsigned-default pin.

`GATES: PASS` (pytest, ruff check, ruff format, mypy).

## Known consequence, flagged not decided

ECDSA signatures are randomised (OpenSSL has no deterministic RFC 6979), so signed catalogues are no
longer byte-identical between builds — and `publish-pkg-repo.sh` decides NOOP via `git status
--porcelain`. A republish with no package change will now commit a fresh signature, and under the
 #2389 stage gate that could boot live VMs for a signature-only delta. Options are laid out in the
issue; accepting it is the recommendation, but it spends real CI time so it is the owner's call.

## Not in this PR

The client half: the three conf generators flipping to `http://` + `signature_type: fingerprints`,
fingerprint delivery via `install.sh` and the package, hook ordering (fingerprint before conf),
workflow secret wiring, and the live smoke leg. Also still unverified: the CE 2.8 `pkg -v` floor —
ECDSA and `pkg key` both landed in the 1.21.0 series, and our matrix records CE 2.8 on pkg 1.21.x, so
that needs a live probe before clients flip.

Part of #2675


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional ECDSA signing for repository catalogues.
  * Signed archives now include signature and public-key files for verification.
  * Added command-line support for supplying a signing key.
  * Supports validated signing curves while preserving unchanged unsigned output.

* **Bug Fixes**
  * Improved handling of signing failures and invalid configuration.
  * Added tamper detection and compatibility validation for signed catalogues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->