### PR TITLE
ci: pytest-xdist -n auto; keep the #140 --cov split

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,12 @@ permissions:
   contents: read
   packages: read
 
+# Cancel superseded Tests runs of the same PR. Do not cancel devel pushes:
+# a merge landing must not kill the run that tells us devel is green (#2673).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Derive the pytest + PHP test matrices from the single-source-of-truth
   # supported-versions matrix (ci-metadata orphan branch). The pytest matrix is
@@ -93,6 +99,7 @@ jobs:
     name: pytest / Python ${{ matrix.python-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -420,6 +427,7 @@ jobs:
   shell-tests:
     name: shellspec (POSIX sh)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     # kcov v43 — the commit that tag pointed at when the pin was taken. Job-level so the
     # cache keys below can carry it: a tag is a moving reference, so re-pinning kcov has
@@ -653,6 +661,7 @@ jobs:
     name: PHPStan static analysis / PHP ${{ matrix.php-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
@@ -753,6 +762,7 @@ jobs:
     name: PHPUnit unit tests / PHP ${{ matrix.php-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dev = [
     "mypy==2.3.0",
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
+    # Parallel unit suite (CI wall-clock is this job). Smoke/UI override
+    # addopts and stay serial. Pin exact like the rest of the group.
+    "pytest-xdist==3.8.0",
     # Import-time deps that decide whether tests RUN or importorskip-skip:
     # dnspython gates the shard-splitter oracle (#861), charset-normalizer the
     # feed-encoding converter test (#1797), PyYAML the workflow-structure specs.
@@ -65,7 +68,7 @@ testpaths = ["tests"]
 # `-p no:cacheprovider tests/smoke -m smoke`); see tests/smoke/conftest.py.
 # --durations=25 surfaces the 25 slowest setup/call/teardown phases each run (issue
 # #605 Layer A) — cheap signal on which unit tests/fixtures dominate, no plugin.
-addopts   = "-v --ignore=tests/smoke --durations=25"
+addopts   = "-v --ignore=tests/smoke --durations=25 -n auto"
 markers = [
     "smoke: live-VM end-to-end smoke test (ADR-04); needs KVM + the GHCR pfSense image; deselected from the default run",
     "ui_render: live-VM Web-UI render-smoke (ADR-14 Tier A); authenticated HTTP; deselected from the default run",

--- a/tests/test_issue2673_xdist_ci.py
+++ b/tests/test_issue2673_xdist_ci.py
@@ -1,0 +1,58 @@
+"""Issue #2673: default pytest is xdist; Tests cancel is pull_request only.
+
+A revert of `-n auto` or `cancel-in-progress: true` on devel pushes would
+otherwise stay green: skip-allowlist and smoke argv tests do not pin these.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+TEST_YML = ROOT / ".github" / "workflows" / "test.yml"
+
+
+def _pyproject() -> dict:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _addopts_tokens() -> list[str]:
+    return _pyproject()["tool"]["pytest"]["ini_options"]["addopts"].split()
+
+
+def test_dev_group_pins_pytest_xdist_exactly() -> None:
+    specs = _pyproject()["dependency-groups"]["dev"]
+    assert "pytest-xdist==3.8.0" in specs
+    smoke = _pyproject()["dependency-groups"]["smoke"]
+    assert not any("pytest-xdist" in spec for spec in smoke)
+
+
+def test_default_addopts_is_xdist_and_still_ignores_smoke() -> None:
+    tokens = _addopts_tokens()
+    assert "--ignore=tests/smoke" in tokens
+    # `-n auto` is two tokens; a fused `-nauto` would not be what CI runs.
+    n = tokens.index("-n")
+    assert tokens[n + 1] == "auto"
+
+
+def test_tests_workflow_cancels_in_progress_pull_requests_only() -> None:
+    text = TEST_YML.read_text(encoding="utf-8")
+    match = re.search(r"^concurrency:\n((?:  .+\n)+)", text, re.MULTILINE)
+    assert match is not None, "Tests workflow must declare workflow-level concurrency"
+    body = match.group(1)
+    assert "github.event.pull_request.number || github.ref" in body
+    # Literal true on devel pushes would cancel the run that grades the merge.
+    assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in body
+    assert re.search(r"cancel-in-progress:\s*true\s*$", body, re.MULTILINE) is None
+
+
+def test_informational_cov_is_still_a_second_pytest_run() -> None:
+    text = TEST_YML.read_text(encoding="utf-8")
+    junit = "uv run pytest --junitxml=/tmp/pytest-junit.xml"
+    cov = "uv run pytest --cov=pfb_unbound --cov-branch"
+    assert text.count(junit) == 1
+    assert text.count(cov) == 1
+    assert text.index(junit) < text.index(cov)

--- a/uv.lock
+++ b/uv.lock
@@ -125,6 +125,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -250,6 +259,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "ruff" },
 ]
@@ -276,6 +286,7 @@ dev = [
     { name = "mypy", specifier = "==2.3.0" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "ruff", specifier = "==0.16.0" },
 ]
@@ -411,6 +422,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #2673.

## What this is

Agreed slice from #2673 **after** the comments (including Andre’s flake count).

1. `pytest-xdist==3.8.0` and `addopts += -n auto`. Smoke/UI stay serial via the existing `--override-ini="addopts="` override (ADR-04).
2. `timeout-minutes` on the slow Tests jobs (they inherited GitHub’s 6h default).
3. Tests `concurrency` with `cancel-in-progress` **only** for `pull_request`. A `devel` push must not cancel the run that grades `devel`.

## What this is not

- **Not** a fold of the informational `--cov` re-run. #140’s split stays. Both runs pick up `-n auto` from addopts. Predicted Tests wait **~3 min**, pytest remains the pole — re-measure on Actions after merge.
- **Not** PHPStan result cache, **not** #2671, **not** collapsing the ~20 Checks-tab jobs.
- **Not** assigning `andrebrait` at open. Agent reviews + CodeRabbit first; then he is asked to merge.

The issue title/body as filed still describe the withdrawn fold. Comments (and this PR) supersede that. Issue body should be edited to match.

## Evidence (do not re-time on a workstation to “update” this)

- Actions `devel` run `32682038300`: pytest job **372s** = 174s gate + 179s `--cov`.
- Local 4-core xdist, `--ignore=tests/smoke`, five repeats: 87 / 88 / 94 / 90 / 89s. Skip-allowlist exit 0; skip set matched serial.
- xdist + `--cov`: 94s, same skip set.
- Last ~day of Tests logs: 39 dual-suite jobs, **0** cov-only fails, **0** fails in either position. That retires “extra serial `--cov` flake” as a reason. It does **not** justify stacking xdist workers *and* coverage on the gating process. Split stays for ~33s of wall-clock, not an unnamed flake.

## Review order

1. Independent agent review (this PR).
2. CI green on the head SHA.
3. CodeRabbit once (`@coderabbitai review`; automatic review is off).
4. Then request review from **@andrebrait** for merge (rebase-only).

Please do not merge until that sequence is done unless you intend to skip it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Pull request checks now cancel superseded runs while allowing push checks to run concurrently.
  * Added time limits to test and analysis jobs.

* **Performance**
  * Python tests now run in parallel by default for faster feedback.

* **Tests**
  * Added regression coverage for parallel test execution, smoke-test handling, workflow cancellation, and coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->