### PR TITLE
test: pin Tests job timeouts; drop gate-facing comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,7 @@ permissions:
   contents: read
   packages: read
 
-# Cancel superseded Tests runs of the same PR. Do not cancel devel pushes:
-# a merge landing must not kill the run that tells us devel is green (#2673).
+# Cancel in-progress Tests runs on pull_request events only (#2673).
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/tests/test_issue2673_xdist_ci.py
+++ b/tests/test_issue2673_xdist_ci.py
@@ -1,8 +1,4 @@
-"""Issue #2673: default pytest is xdist; Tests cancel is pull_request only.
-
-A revert of `-n auto` or `cancel-in-progress: true` on devel pushes would
-otherwise stay green: skip-allowlist and smoke argv tests do not pin these.
-"""
+"""Issue #2673: default pytest is xdist; Tests cancel is pull_request only."""
 
 from __future__ import annotations
 
@@ -38,15 +34,38 @@ def test_default_addopts_is_xdist_and_still_ignores_smoke() -> None:
     assert tokens[n + 1] == "auto"
 
 
+def _extract_job(text: str, job_name: str) -> str:
+    match = re.search(rf"^  {re.escape(job_name)}:\n", text, re.MULTILINE)
+    assert match is not None, f"job {job_name!r} not found"
+    start = match.end()
+    nxt = re.search(r"^  [A-Za-z0-9_-]+:\n", text[start:], re.MULTILINE)
+    end = start + nxt.start() if nxt else len(text)
+    return text[start:end]
+
+
 def test_tests_workflow_cancels_in_progress_pull_requests_only() -> None:
     text = TEST_YML.read_text(encoding="utf-8")
     match = re.search(r"^concurrency:\n((?:  .+\n)+)", text, re.MULTILINE)
     assert match is not None, "Tests workflow must declare workflow-level concurrency"
     body = match.group(1)
     assert "github.event.pull_request.number || github.ref" in body
-    # Literal true on devel pushes would cancel the run that grades the merge.
     assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in body
     assert re.search(r"cancel-in-progress:\s*true\s*$", body, re.MULTILINE) is None
+
+
+def test_slow_tests_jobs_pin_timeout_minutes() -> None:
+    text = TEST_YML.read_text(encoding="utf-8")
+    expected = {
+        "test": 20,
+        "shell-tests": 20,
+        "php-static-analysis": 10,
+        "php-unit": 15,
+    }
+    for name, minutes in expected.items():
+        job = _extract_job(text, name)
+        hit = re.search(r"^    timeout-minutes: (\d+)\s*$", job, re.MULTILINE)
+        assert hit is not None, f"{name} missing job-level timeout-minutes:\n{job[:200]}"
+        assert int(hit.group(1)) == minutes, f"{name}: {hit.group(1)} != {minutes}"
 
 
 def test_informational_cov_is_still_a_second_pytest_run() -> None:


### PR DESCRIPTION
Follow-up to the two review-bot notes on #2677 (merged as `66353d0c`).

1. `tests/test_issue2673_xdist_ci.py` now asserts job-level `timeout-minutes` for `test` 20, `shell-tests` 20, `php-static-analysis` 10, `php-unit` 15.
2. Module docstring no longer explains revert/green-gate. `test.yml` concurrency comment is the behavior contract only: cancel in-progress Tests runs on `pull_request` events (#2673).

Local: `pytest --override-ini=addopts= tests/test_issue2673_xdist_ci.py` — 5 passed.