### PR TITLE
download: give processxlsx() an exit contract so the XLSX path can carry the extraction ceiling

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14701,15 +14701,17 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// Check if ZIP archive contains xlsx files
 			$xlsxtest = exec("/usr/bin/tar -tf {$file_dwn_esc}");
 			if (strpos($xlsxtest, '.xlsx') !== FALSE) {
-				unlink_if_exists("{$orig_download}");
-				// issue #2658: deliberately NOT capped. processxlsx() decides success by the
-				// output file existing, never by an exit status, so a child killed at the
-				// ceiling would publish a truncated feed as a successful ingest -- strictly
-				// worse than no cap. Capping it needs an exit gate in the shell function
-				// first (issue #2666).
-				exec("{$pfb['script']} xlsx {$header_esc} {$elog}");
-				if (file_exists("{$orig_download}")) {
-					$retval = 0;
+				// issue #2666: processxlsx() now carries an exit contract and stages its
+				// own publication, so the ingest is decided by its status rather than by
+				// the output file existing -- which is what lets issue #2658's ceiling
+				// ride along here like it does on every other extraction. A child killed
+				// at the ceiling exits non-zero, this refuses the feed, and the '.orig'
+				// already in service is left untouched (hence no unlink up front).
+				exec(pfb_extract_cmd("{$pfb['script']} xlsx {$header_esc} {$elog}"), $output, $retval);
+				if (!pfb_download_extraction_succeeded($retval)) {
+					pfb_logger("\n[pfb_download] xlsx extraction failed (script exit {$retval})" . pfb_extract_cap_note($retval), 2);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
 				}
 			} else {
 				pfb_logger('.', 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14701,12 +14701,10 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// Check if ZIP archive contains xlsx files
 			$xlsxtest = exec("/usr/bin/tar -tf {$file_dwn_esc}");
 			if (strpos($xlsxtest, '.xlsx') !== FALSE) {
-				// issue #2666: processxlsx() now carries an exit contract and stages its
-				// own publication, so the ingest is decided by its status rather than by
-				// the output file existing -- which is what lets issue #2658's ceiling
-				// ride along here like it does on every other extraction. A child killed
-				// at the ceiling exits non-zero, this refuses the feed, and the '.orig'
-				// already in service is left untouched (hence no unlink up front).
+				// issue #2666: processxlsx() carries an exit contract and stages its own
+				// publication, so the ingest is decided by its status -- which is what
+				// lets issue #2658's ceiling ride along here. No unlink up front: the
+				// '.orig' already in service must survive a refused refresh.
 				exec(pfb_extract_cmd("{$pfb['script']} xlsx {$header_esc} {$elog}"), $output, $retval);
 				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] xlsx extraction failed (script exit {$retval})" . pfb_extract_cap_note($retval), 2);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14701,9 +14701,8 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// Check if ZIP archive contains xlsx files
 			$xlsxtest = exec("/usr/bin/tar -tf {$file_dwn_esc}");
 			if (strpos($xlsxtest, '.xlsx') !== FALSE) {
-				// issue #2666: processxlsx() carries an exit contract and stages its own
-				// publication, so the ingest is decided by its status -- which is what
-				// lets issue #2658's ceiling ride along here. No unlink up front: the
+				// issue #2666: the helper's exit status decides the ingest, which is what
+				// lets issue #2658's ceiling ride along. No unlink up front -- the
 				// '.orig' already in service must survive a refused refresh.
 				exec(pfb_extract_cmd("{$pfb['script']} xlsx {$header_esc} {$elog}"), $output, $retval);
 				if (!pfb_download_extraction_succeeded($retval)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2013,15 +2013,9 @@ processet() {
 
 # Function to extract IP addresses from XLSX files.
 #
-# issue #2666: every step reports, and the publication is staged. Neither tar's
-# status was read before, and the writing pipeline's status was read by nobody at
-# all, so the function's own status was its closing `echo`'s -- always 0 -- and
-# the caller had nothing to gate on but the output file existing. The two
-# extractions are therefore run one per step with the status carried forward, and
-# the addresses land on a staged path that only replaces the live ".orig" once
-# every step has succeeded. A failing status is returned verbatim (rather than
-# collapsed to 1) so a child killed at issue #2658's extraction ceiling still
-# reaches the caller as the 153 that names that ceiling.
+# issue #2666: the exit contract pfb_download() gates on. A failing status is
+# returned verbatim rather than collapsed to 1, so a child killed at issue
+# #2658's extraction ceiling reaches the caller as the 153 that names it.
 processxlsx() {
 	if [ ! -x "${pathtar}" ]; then
 		log='Application [ TAR ] Not found, cannot proceed.'
@@ -2038,38 +2032,37 @@ processxlsx() {
 	xlsxshared="${tmpxlsx}sharedStrings.xml"
 	xlsxstage="${pfborig}${alias}.orig.tmp"
 
-	# The container holds the workbook; the workbook holds the shared-strings
-	# part the addresses are read out of. `tar -xOf` writes that part to its own
-	# file instead of straight into the pipe: POSIX sh has no pipefail, so piped
-	# it would report only the trailing `sort`'s status and a workbook that could
-	# not be read at all would still "succeed" with an empty publication.
+	# `tar -xOf` writes the shared-strings part to its own file instead of into
+	# the pipe: POSIX sh has no pipefail, so piped it would report only the
+	# trailing `sort`'s status and an unreadable workbook would still publish an
+	# empty feed.
 	"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}"
 	xlsxrc=$?
 	if [ "${xlsxrc}" -eq 0 ]; then
-		"${pathtar}" -xOf "${tmpxlsx}"*.[xX][lL][sS][xX] "xl/sharedStrings.xml" > "${xlsxshared}"
-		xlsxrc=$?
-	fi
-	if [ "${xlsxrc}" -eq 0 ]; then
-		grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" "${xlsxshared}" | LC_ALL=C sort -u > "${xlsxstage}"
-		# `sort` is the stage that writes the publication, so its status is the
-		# one the ceiling shows up in; `grep`'s 1 for a workbook carrying no
-		# address is not a failure and never was.
+		# Only the FIRST workbook. The glob splats into tar's argument list, where
+		# every match after the first is read as a member selector rather than a
+		# second archive -- so a multi-workbook container extracts correctly but
+		# exits non-zero, which was invisible while the status was discarded.
+		set -- "${tmpxlsx}"*.[xX][lL][sS][xX]
+		"${pathtar}" -xOf "$1" "xl/sharedStrings.xml" > "${xlsxshared}" &&
+			grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" "${xlsxshared}" | LC_ALL=C sort -u > "${xlsxstage}"
 		xlsxrc=$?
 	fi
 	rm -rf "${tmpxlsx}"*
 
-	if [ "${xlsxrc}" -ne 0 ]; then
-		rm -f "${xlsxstage}"
-		echo 'XLSX extraction failed'
-		echo " [ ${alias} ] XLSX extraction failed, exit ${xlsxrc}; keeping existing [ ${now} ]" >> "${errorlog}"
-		return "${xlsxrc}"
+	if [ "${xlsxrc}" -eq 0 ]; then
+		# Published feeds have unprivileged readers, and replacing the live file by
+		# rename hands it the run's umask instead of the mode it replaces -- the
+		# reason pfb_stage_publish() chmods its staged file too.
+		chmod 644 "${xlsxstage}" && mv -f "${xlsxstage}" "${pfborig}${alias}.orig"
+		xlsxrc=$?
 	fi
 
-	if ! mv -f "${xlsxstage}" "${pfborig}${alias}.orig"; then
+	if [ "${xlsxrc}" -ne 0 ]; then
 		rm -f "${xlsxstage}"
-		echo 'XLSX publish failed'
-		echo " [ ${alias} ] XLSX publish failed; keeping existing [ ${now} ]" >> "${errorlog}"
-		return 1
+		echo 'XLSX processing failed'
+		echo " [ ${alias} ] XLSX processing failed, exit ${xlsxrc}; keeping existing [ ${now} ]" >> "${errorlog}"
+		return "${xlsxrc}"
 	fi
 
 	countf="$(grep -cv "^${ip_placeholder2}$" "${pfborig}${alias}.orig")"
@@ -2239,9 +2232,8 @@ case "${1}" in
 		processet
 		;;
 	xlsx)
-		# issue #2666: the tail's bare `exitnow` defaults to 0, so processxlsx()'s
-		# status has to be threaded through here (as `recompute` does) or the
-		# caller's exit gate reads success for every run.
+		# issue #2666: the tail's bare `exitnow` defaults to 0, so the status has to
+		# be threaded through here (as `recompute` does).
 		processxlsx
 		exitnow "$?"
 		;;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2012,25 +2012,69 @@ processet() {
 
 
 # Function to extract IP addresses from XLSX files.
+#
+# issue #2666: every step reports, and the publication is staged. Neither tar's
+# status was read before, and the writing pipeline's status was read by nobody at
+# all, so the function's own status was its closing `echo`'s -- always 0 -- and
+# the caller had nothing to gate on but the output file existing. The two
+# extractions are therefore run one per step with the status carried forward, and
+# the addresses land on a staged path that only replaces the live ".orig" once
+# every step has succeeded. A failing status is returned verbatim (rather than
+# collapsed to 1) so a child killed at issue #2658's extraction ceiling still
+# reaches the caller as the 153 that names that ceiling.
 processxlsx() {
 	if [ ! -x "${pathtar}" ]; then
 		log='Application [ TAR ] Not found, cannot proceed.'
 		echo "${log}" | tee -a "${errorlog}"
-		return
+		return 1
 	fi
 
-	if [ -s "${pfborig}${alias}.raw" ]; then
-		"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}"
-		"${pathtar}" -xOf "${tmpxlsx}"*.[xX][lL][sS][xX] "xl/sharedStrings.xml" | \
-			grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" | LC_ALL=C sort -u > "${pfborig}${alias}.orig"
-		rm -r "${tmpxlsx}"*
-
-		countf="$(grep -cv "^${ip_placeholder2}$" "${pfborig}${alias}.orig")"
-		echo; echo "Final count [ ${countf} ]"
-	else
+	if [ ! -s "${pfborig}${alias}.raw" ]; then
 		echo 'XLSX download file missing'
 		echo " [ ${alias} ] XLSX download file missing [ ${now} ]" >> "${errorlog}"
+		return 1
 	fi
+
+	xlsxshared="${tmpxlsx}sharedStrings.xml"
+	xlsxstage="${pfborig}${alias}.orig.tmp"
+
+	# The container holds the workbook; the workbook holds the shared-strings
+	# part the addresses are read out of. `tar -xOf` writes that part to its own
+	# file instead of straight into the pipe: POSIX sh has no pipefail, so piped
+	# it would report only the trailing `sort`'s status and a workbook that could
+	# not be read at all would still "succeed" with an empty publication.
+	"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}"
+	xlsxrc=$?
+	if [ "${xlsxrc}" -eq 0 ]; then
+		"${pathtar}" -xOf "${tmpxlsx}"*.[xX][lL][sS][xX] "xl/sharedStrings.xml" > "${xlsxshared}"
+		xlsxrc=$?
+	fi
+	if [ "${xlsxrc}" -eq 0 ]; then
+		grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" "${xlsxshared}" | LC_ALL=C sort -u > "${xlsxstage}"
+		# `sort` is the stage that writes the publication, so its status is the
+		# one the ceiling shows up in; `grep`'s 1 for a workbook carrying no
+		# address is not a failure and never was.
+		xlsxrc=$?
+	fi
+	rm -rf "${tmpxlsx}"*
+
+	if [ "${xlsxrc}" -ne 0 ]; then
+		rm -f "${xlsxstage}"
+		echo 'XLSX extraction failed'
+		echo " [ ${alias} ] XLSX extraction failed, exit ${xlsxrc}; keeping existing [ ${now} ]" >> "${errorlog}"
+		return "${xlsxrc}"
+	fi
+
+	if ! mv -f "${xlsxstage}" "${pfborig}${alias}.orig"; then
+		rm -f "${xlsxstage}"
+		echo 'XLSX publish failed'
+		echo " [ ${alias} ] XLSX publish failed; keeping existing [ ${now} ]" >> "${errorlog}"
+		return 1
+	fi
+
+	countf="$(grep -cv "^${ip_placeholder2}$" "${pfborig}${alias}.orig")"
+	echo; echo "Final count [ ${countf} ]"
+	return 0
 }
 
 
@@ -2195,7 +2239,11 @@ case "${1}" in
 		processet
 		;;
 	xlsx)
+		# issue #2666: the tail's bare `exitnow` defaults to 0, so processxlsx()'s
+		# status has to be threaded through here (as `recompute` does) or the
+		# caller's exit gate reads success for every run.
 		processxlsx
+		exitnow "$?"
 		;;
 	remove)
 		remove

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2032,34 +2032,25 @@ processxlsx() {
 	xlsxshared="${tmpxlsx}sharedStrings.xml"
 	xlsxstage="${pfborig}${alias}.orig.tmp"
 
-	# `tar -xOf` writes the shared-strings part to its own file instead of into
-	# the pipe: POSIX sh has no pipefail, so piped it would report only the
-	# trailing `sort`'s status and an unreadable workbook would still publish an
-	# empty feed.
-	"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}"
-	xlsxrc=$?
-	if [ "${xlsxrc}" -eq 0 ]; then
-		# Only the FIRST workbook. The glob splats into tar's argument list, where
-		# every match after the first is read as a member selector rather than a
-		# second archive -- so a multi-workbook container extracts correctly but
-		# exits non-zero, which was invisible while the status was discarded.
-		set -- "${tmpxlsx}"*.[xX][lL][sS][xX]
+	# `tar -xOf` writes to a file, not into the pipe: POSIX sh has no pipefail, so
+	# piped it would report only the trailing `sort`'s status.
+	# `set --` names ONE workbook: the glob splats into tar's argument list, where
+	# every match after the first is a member selector, not a second archive.
+	# `chmod` before the rename because published feeds have unprivileged readers
+	# and a rename would hand the file the run's umask (as pfb_stage_publish()).
+	"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}" &&
+		set -- "${tmpxlsx}"*.[xX][lL][sS][xX] &&
 		"${pathtar}" -xOf "$1" "xl/sharedStrings.xml" > "${xlsxshared}" &&
-			grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" "${xlsxshared}" | LC_ALL=C sort -u > "${xlsxstage}"
-		xlsxrc=$?
-	fi
+		grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" "${xlsxshared}" | LC_ALL=C sort -u > "${xlsxstage}" &&
+		chmod 644 "${xlsxstage}" &&
+		mv -f "${xlsxstage}" "${pfborig}${alias}.orig"
+	xlsxrc=$?
 	rm -rf "${tmpxlsx}"*
 
-	if [ "${xlsxrc}" -eq 0 ]; then
-		# Published feeds have unprivileged readers, and replacing the live file by
-		# rename hands it the run's umask instead of the mode it replaces -- the
-		# reason pfb_stage_publish() chmods its staged file too.
-		chmod 644 "${xlsxstage}" && mv -f "${xlsxstage}" "${pfborig}${alias}.orig"
-		xlsxrc=$?
-	fi
-
 	if [ "${xlsxrc}" -ne 0 ]; then
-		rm -f "${xlsxstage}"
+		# -rf, not -f: crash-leftover DIRECTORY debris here would otherwise survive
+		# every later run and keep refusing the feed.
+		rm -rf "${xlsxstage}"
 		echo 'XLSX processing failed'
 		echo " [ ${alias} ] XLSX processing failed, exit ${xlsxrc}; keeping existing [ ${now} ]" >> "${errorlog}"
 		return "${xlsxrc}"

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -175,4 +175,27 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
+
+	/**
+	 * pfb_download() hands the XLSX container to the shell helper, which extracts
+	 * it; issue #2666 gave that helper an exit contract, so this branch is pinned
+	 * like its siblings — captured exec, nonzero-exit gate, and the ceiling wrap
+	 * that only an exit gate makes safe. The absent assertions matter as much as
+	 * the present ones: deciding the ingest by the output file existing, or
+	 * unlinking the live publication before the helper runs, both republish a
+	 * truncated feed as a success.
+	 */
+	public function testXlsxBodyCapturesAndChecksHelperExit(): void
+	{
+		$xlsx = strpos(self::$source, "if (strpos(\$xlsxtest, '.xlsx') !== FALSE) {");
+		$this->assertNotFalse($xlsx);
+		$zipBranch = strpos(self::$source, '} else {', $xlsx);
+		$this->assertNotFalse($zipBranch);
+		$scope = substr(self::$source, $xlsx, $zipBranch - $xlsx);
+		$this->assertStringContainsString(
+			'exec(pfb_extract_cmd("{$pfb[\'script\']} xlsx {$header_esc} {$elog}"), $output, $retval);', $scope);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
+		$this->assertStringNotContainsString('file_exists("{$orig_download}")', $scope);
+		$this->assertStringNotContainsString('unlink_if_exists("{$orig_download}")', $scope);
+	}
 }

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * The helper assertions below exercise the pure exit-code decision directly.
- * The six outer pins retain the destructive/live orchestration coverage:
+ * The eight outer pins retain the destructive/live orchestration coverage:
  * pfb_download() executes archive tools and writes appliance paths, so driving
  * those branches here would mutate real state. php_strip_whitespace() bounds
  * each code branch; comments and docblocks are never extraction boundaries.

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -284,7 +284,7 @@ final class DownloadSizeCeilingTest extends TestCase
 	 *
 	 * The allow-list holds each exempt call's WHOLE statement, terminator included,
 	 * not a prefix of it. A prefix would exempt everything that merely starts the
-	 * same way, so `exec("{$pfb['script']} xlsx" . $anything)` -- a genuinely
+	 * same way, so `exec("{$pfb['script']} et" . $anything)` -- a genuinely
 	 * unguarded extraction wearing an exempt call's opening -- would pass. Changing
 	 * an exempt call means updating its entry here, which is the point: the
 	 * exemption is for that call as written, not for its first few characters.
@@ -299,11 +299,6 @@ final class DownloadSizeCeilingTest extends TestCase
 			'exec("{$pfb[\'script\']} whoisconvert {$header_esc} {$vtype} {$list_url_esc} {$elog}");',
 			'exec("{$pfb[\'script\']} asn_table {$elog}");',
 			'exec("{$pfb[\'script\']} et {$header_esc} x x x x x {$pfb[\'etblock\']} {$pfb[\'etmatch\']} {$elog}");',
-			// processxlsx() reports success by the output file existing rather than by
-			// an exit status, so a child killed at the ceiling would publish a
-			// truncated feed as a success. Capping it needs an exit gate first
-			// (issue #2666).
-			'exec("{$pfb[\'script\']} xlsx {$header_esc} {$elog}");',
 			// Lists an archive; extracts nothing.
 			'exec("/usr/bin/tar -tf {$file_dwn_esc}");',
 			// Capped. This one stays a prefix: it covers ten call sites with ten
@@ -382,6 +377,34 @@ final class DownloadSizeCeilingTest extends TestCase
 		}
 		$this->assertGreaterThan(1, $seen,
 			'the sweep must actually find extraction calls — a pattern that matches nothing proves nothing');
+	}
+
+	/**
+	 * Scenario: the XLSX ingest is decided by an exit status
+	 *
+	 * Given  the XLSX branch of pfb_download()
+	 * When   the source is read
+	 * Then   the helper script runs under the extraction ceiling and its own exit
+	 *        status decides the ingest, instead of the output file's existence
+	 *        deciding it (issue #2666) -- a helper killed at the ceiling has to
+	 *        refuse the feed, not publish the truncated remains of one. And with
+	 *        the status deciding, the live publication is no longer unlinked up
+	 *        front, so a refused refresh leaves the feed already in service.
+	 */
+	public function test_xlsx_ingest_gates_on_the_helper_exit_status(): void
+	{
+		$start = strpos(self::$downloadBody, "if (strpos(\$xlsxtest, '.xlsx') !== FALSE) {");
+		$this->assertNotFalse($start, 'the XLSX branch must still be in pfb_download()');
+		$end = strpos(self::$downloadBody, '} else {', $start);
+		$this->assertNotFalse($end);
+		$branch = substr(self::$downloadBody, $start, $end - $start);
+
+		$this->assertStringContainsString(
+			'exec(pfb_extract_cmd("{$pfb[\'script\']} xlsx {$header_esc} {$elog}"), $output, $retval);',
+			$branch);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $branch);
+		$this->assertStringNotContainsString('file_exists("{$orig_download}")', $branch);
+		$this->assertStringNotContainsString('unlink_if_exists("{$orig_download}")', $branch);
 	}
 
 	/**

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -380,34 +380,6 @@ final class DownloadSizeCeilingTest extends TestCase
 	}
 
 	/**
-	 * Scenario: the XLSX ingest is decided by an exit status
-	 *
-	 * Given  the XLSX branch of pfb_download()
-	 * When   the source is read
-	 * Then   the helper script runs under the extraction ceiling and its own exit
-	 *        status decides the ingest, instead of the output file's existence
-	 *        deciding it (issue #2666) -- a helper killed at the ceiling has to
-	 *        refuse the feed, not publish the truncated remains of one. And with
-	 *        the status deciding, the live publication is no longer unlinked up
-	 *        front, so a refused refresh leaves the feed already in service.
-	 */
-	public function test_xlsx_ingest_gates_on_the_helper_exit_status(): void
-	{
-		$start = strpos(self::$downloadBody, "if (strpos(\$xlsxtest, '.xlsx') !== FALSE) {");
-		$this->assertNotFalse($start, 'the XLSX branch must still be in pfb_download()');
-		$end = strpos(self::$downloadBody, '} else {', $start);
-		$this->assertNotFalse($end);
-		$branch = substr(self::$downloadBody, $start, $end - $start);
-
-		$this->assertStringContainsString(
-			'exec(pfb_extract_cmd("{$pfb[\'script\']} xlsx {$header_esc} {$elog}"), $output, $retval);',
-			$branch);
-		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $branch);
-		$this->assertStringNotContainsString('file_exists("{$orig_download}")', $branch);
-		$this->assertStringNotContainsString('unlink_if_exists("{$orig_download}")', $branch);
-	}
-
-	/**
 	 * Scenario: an over-large body is refused, not retried
 	 *
 	 * Given  the download retry loop

--- a/tests/shell/pfblockerng_adr26_locale_spec.sh
+++ b/tests/shell/pfblockerng_adr26_locale_spec.sh
@@ -74,8 +74,11 @@ Describe 'ADR-26 — pfblockerng.sh locale/portability source invariants (Phases
   # ONLY in duplicate()'s single-alias-masterfile check -- issue #1084 deleted the whole
   # function (the batch recompute verb owns cross-feed dedup now), so the call site the
   # LC_ALL=C prefix protected is gone, not reverted. Nothing left to pin here.
+  # issue #2666 staged this sink: the addresses are sorted onto "${xlsxstage}" and
+  # only moved onto "${pfborig}${alias}.orig" once every extraction step reported
+  # success. Same sink, same collation requirement, one filename earlier.
   It 'prefixes the extracted-IP .orig sink with LC_ALL=C'
-    When call has 'LC_ALL=C sort -u > "${pfborig}${alias}.orig"'
+    When call has 'LC_ALL=C sort -u > "${xlsxstage}"'
     The status should be success
   End
   It 'prefixes the masterfile order (sort -o) with LC_ALL=C'

--- a/tests/shell/pfblockerng_processxlsx_exit_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_exit_spec.sh
@@ -78,7 +78,9 @@ RUNNER
 			When run sh "${runner}"
 			The status should be success
 			The contents of file "${orig}${alias}.orig" should equal "${expected}"
-			# The staged path is an artifact of the publish, never left as debris.
+			# The one context where this can fail: the staged file really was
+			# written here, so a publish that copied instead of renaming, or
+			# forgot to clean up, would leave it behind.
 			The path "${orig}${alias}.orig.tmp" should not be exist
 			The output should include 'Final count'
 		End
@@ -96,8 +98,28 @@ RUNNER
 			When run sh "${runner}"
 			The status should be failure
 			The contents of file "${orig}${alias}.orig" should equal "${prior}"
-			The path "${orig}${alias}.orig.tmp" should not be exist
-			The stdout should be present
+			The output should include 'XLSX processing failed'
+			The contents of file "${errorlog}" should include 'keeping existing'
+			The stderr should be present
+		End
+	End
+
+	Context 'when the container is truncated mid-stream'
+		# The shape a child killed at the extraction ceiling leaves behind, and the
+		# one issue #2666 names by hand: a container whose bytes simply stop.
+		plant_truncated_raw() {
+			plant_healthy_raw
+			dd if="${orig}${alias}.raw" of="${work}/cut" bs=1 count=600 2>/dev/null
+			mv -f "${work}/cut" "${orig}${alias}.raw"
+		}
+		Before 'plant_prior_publication'
+		Before 'plant_truncated_raw'
+
+		It 'fails and keeps the live publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The output should include 'XLSX processing failed'
 			The stderr should be present
 		End
 	End
@@ -117,8 +139,26 @@ RUNNER
 			When run sh "${runner}"
 			The status should be failure
 			The contents of file "${orig}${alias}.orig" should equal "${prior}"
-			The path "${orig}${alias}.orig.tmp" should not be exist
-			The stdout should be present
+			The output should include 'XLSX processing failed'
+			The stderr should be present
+		End
+	End
+
+	Context 'when the publication cannot be staged'
+		# Crash-leftover DIRECTORY at the staged path, the issue #1172 fixture
+		# class. This is the only example whose failure lands on the pipeline that
+		# WRITES the publication -- the stage the extraction ceiling would kill --
+		# rather than on one of the two tars ahead of it.
+		plant_stage_debris() { mkdir "${orig}${alias}.orig.tmp"; }
+		Before 'plant_healthy_raw'
+		Before 'plant_prior_publication'
+		Before 'plant_stage_debris'
+
+		It 'fails and keeps the live publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The output should include 'XLSX processing failed'
 			The stderr should be present
 		End
 	End
@@ -147,6 +187,45 @@ RUNNER
 		End
 	End
 
+	Context 'on a container holding more than one workbook'
+		# The glob splats into tar's argument list, where every match after the
+		# first is read as a MEMBER selector rather than a second archive -- so tar
+		# reports "not found in archive" and exits non-zero while still writing the
+		# first workbook's part correctly. Harmless while the status was discarded;
+		# once it is read, only reading the first workbook keeps such a feed
+		# ingesting exactly as it did before.
+		plant_two_workbooks() {
+			plant_healthy_raw
+			cp "${work}/build/${alias}.xlsx" "${work}/build/second.xlsx"
+			( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" second.xlsx )
+		}
+		Before 'plant_two_workbooks'
+
+		It 'publishes the first workbook rather than refusing the feed'
+			When run sh "${runner}"
+			The status should be success
+			The contents of file "${orig}${alias}.orig" should equal "${expected}"
+			The output should include 'Final count'
+			# Naming one archive also silences tar's "not found in archive" complaint
+			# about the workbooks it was reading as member selectors.
+			The stderr should equal ''
+		End
+	End
+
+	Context 'under a restrictive umask'
+		# Published feeds have unprivileged readers. Truncating the live file in
+		# place used to keep its mode; replacing it by rename hands it whatever the
+		# run's umask allows, so the publish sets the mode explicitly (the reason
+		# pfb_stage_publish() chmods its staged file too).
+		Before 'plant_healthy_raw'
+
+		It 'publishes a world-readable file regardless of the run umask'
+			When run sh -c "umask 077; sh '${runner}' >/dev/null 2>&1; ls -l '${orig}${alias}.orig' | cut -c1-10"
+			The status should be success
+			The output should equal '-rw-r--r--'
+		End
+	End
+
 	Context 'when the extraction ceiling fires'
 		# issue #2658's ceiling (pfb_extract_cmd() -> `ulimit -f`) is what the
 		# caller wraps this helper in: RLIMIT_FSIZE is inherited by every
@@ -162,7 +241,6 @@ RUNNER
 			When run sh -c "ulimit -f 1 || exit 1; sh '${runner}' >/dev/null 2>&1"
 			The status should be failure
 			The contents of file "${orig}${alias}.orig" should equal "${prior}"
-			The path "${orig}${alias}.orig.tmp" should not be exist
 		End
 	End
 End

--- a/tests/shell/pfblockerng_processxlsx_exit_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_exit_spec.sh
@@ -146,8 +146,7 @@ RUNNER
 
 	Context 'when the publication cannot be staged'
 		# Crash-leftover DIRECTORY at the staged path, the issue #1172 fixture
-		# class. This is the only example whose failure lands on the pipeline that
-		# WRITES the publication -- the stage the extraction ceiling would kill --
+		# class: the failure lands on the pipeline that WRITES the publication
 		# rather than on one of the two tars ahead of it.
 		plant_stage_debris() { mkdir "${orig}${alias}.orig.tmp"; }
 		Before 'plant_healthy_raw'
@@ -160,6 +159,43 @@ RUNNER
 			The contents of file "${orig}${alias}.orig" should equal "${prior}"
 			The output should include 'XLSX processing failed'
 			The stderr should be present
+		End
+
+		It 'clears the debris, so the next healthy run is not refused too'
+			# The cleanup has to remove a directory, not just a file. Leaving it
+			# makes every later run fail against the same leftover: one crash mid
+			# publish would take the feed down until someone cleaned up by hand.
+			When run sh -c "sh '${runner}' >/dev/null 2>&1; sh '${runner}'"
+			The status should be success
+			The contents of file "${orig}${alias}.orig" should equal "${expected}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'Final count'
+		End
+	End
+
+	Context 'when the stage that writes the publication is killed'
+		# What the extraction ceiling does, modelled at the one stage the two tars
+		# ahead of it cannot mask: SIGXFSZ kills whichever child writes past the
+		# limit, and the shell reports that as 128 + 25. The status has to come
+		# back verbatim, because pfb_extract_cap_note() reads exactly 153 to tell
+		# the operator "too large" instead of printing a bare exit code.
+		plant_killed_sort() {
+			mkdir -p "${work}/shim"
+			printf '#!/bin/sh\nhead -c 32 > "%s"\nexit 153\n' "${orig}${alias}.orig.tmp" \
+				> "${work}/shim/sort"
+			chmod +x "${work}/shim/sort"
+		}
+		Before 'plant_healthy_raw'
+		Before 'plant_prior_publication'
+		Before 'plant_killed_sort'
+
+		It 'returns the kill status verbatim and keeps the live publication'
+			When run sh -c "PATH='${work}/shim:${PATH}' sh '${runner}'"
+			The status should equal 153
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'XLSX processing failed'
+			The contents of file "${errorlog}" should include 'exit 153'
 		End
 	End
 

--- a/tests/shell/pfblockerng_processxlsx_exit_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_exit_spec.sh
@@ -1,0 +1,188 @@
+#shellcheck shell=sh
+# issue #2666: processxlsx() had no exit contract. It ran two unchecked `tar`
+# invocations and a pipeline whose status nobody read, then ended on an `echo`,
+# so its exit status was that `echo`'s -- always 0. Its caller in pfb_download()
+# therefore decided the ingest had succeeded by testing that the output file
+# existed, which a half-written file satisfies just as well as a complete one.
+#
+# These examples pin the contract the caller now gates on: every failing step
+# reports non-zero, and the publication is staged so a failed run leaves the
+# ".orig" already in service byte-unchanged instead of overwriting it with the
+# empty or partial remains of the attempt.
+#
+# Fixture shape: the downloaded ".raw" container holds one "*.xlsx" member, and
+# that member is itself an archive holding "xl/sharedStrings.xml" -- the two
+# layers processxlsx() opens. Real feeds ship ZIP containers; these fixtures are
+# tars because the function only ever calls ${pathtar} with -xf/-xOf and the
+# statuses under test are the same either way, while GNU tar (the CI runner's
+# /usr/bin/tar) cannot read a ZIP at all -- a ZIP fixture would silently reduce
+# this whole file to a macOS-only test.
+
+Describe 'processxlsx() exit contract (issue #2666)'
+	setup() {
+		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/xlsxexit.XXXXXX")"
+		orig="${work}/orig/"
+		alias='XlsxFeed'
+		errorlog="${work}/error.log"
+		runner="${work}/run.sh"
+		mkdir -p "${orig}" "${work}/scratch" "${work}/build" "${work}/inner/xl"
+		# The two addresses the fixture's shared-strings part carries, in the
+		# LC_ALL=C sorted -u order processxlsx() publishes them in.
+		expected="$(printf '%s\n' '192.0.2.10' '198.51.100.20')"
+		# What a live publication looks like before a failed refresh: a failure
+		# must leave exactly this behind.
+		prior="$(printf '%s\n' '203.0.113.7' 'PRIOR-MARKER')"
+
+		# processxlsx() reads its inputs from the top-level init's globals, which
+		# never resolve off-appliance. Source the script as a library, point those
+		# globals at the fixture, and call the function -- from a real child
+		# process, so an example may impose an RLIMIT_FSIZE without the shellspec
+		# harness itself then writing under it. $1 overrides the tar path.
+		cat > "${runner}" <<RUNNER
+#!/bin/sh
+PFB_SOURCED=1
+. "${PFB_PKGDIR}/pfblockerng.sh"
+pathtar="\${1:-$(command -v tar)}"
+pfborig="${orig}"
+alias="${alias}"
+tmpxlsx="${work}/scratch/"
+errorlog="${errorlog}"
+now='2026-01-01 00:00:00'
+ip_placeholder2='127\.1\.7\.7'
+processxlsx
+RUNNER
+		chmod +x "${runner}"
+	}
+	cleanup() { rm -rf "$work"; }
+	Before 'setup'
+	After 'cleanup'
+
+	# A healthy container: outer archive holding an inner archive holding the
+	# shared-strings part the addresses are read out of.
+	plant_healthy_raw() {
+		printf '<si><t>192.0.2.10</t></si><si><t>198.51.100.20</t></si>\n' \
+			> "${work}/inner/xl/sharedStrings.xml"
+		( cd "${work}/inner" && tar -cf "${work}/build/${alias}.xlsx" xl )
+		( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
+	}
+
+	# A live publication left by a previous, successful run.
+	plant_prior_publication() {
+		printf '%s\n' "${prior}" > "${orig}${alias}.orig"
+	}
+
+	Context 'on a healthy container'
+		Before 'plant_healthy_raw'
+
+		It 'publishes the extracted addresses and reports success'
+			When run sh "${runner}"
+			The status should be success
+			The contents of file "${orig}${alias}.orig" should equal "${expected}"
+			# The staged path is an artifact of the publish, never left as debris.
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'Final count'
+		End
+	End
+
+	Context 'when the outer container is corrupt'
+		# The first tar's status was never read: extraction failed, the scratch
+		# directory stayed empty, and the pipeline still truncated the live .orig
+		# to nothing while the function returned 0.
+		plant_corrupt_raw() { printf 'this is not an archive\n' > "${orig}${alias}.raw"; }
+		Before 'plant_prior_publication'
+		Before 'plant_corrupt_raw'
+
+		It 'fails and keeps the live publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The stdout should be present
+			The stderr should be present
+		End
+	End
+
+	Context 'when the inner .xlsx member is not an archive'
+		# The second tar's status was masked by the pipeline it fed: with nothing
+		# on its stdin the grep matched nothing and `sort -u` still exited 0, so a
+		# feed whose payload could not be read published as an EMPTY success.
+		plant_bad_member() {
+			printf 'not an archive either\n' > "${work}/build/${alias}.xlsx"
+			( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
+		}
+		Before 'plant_prior_publication'
+		Before 'plant_bad_member'
+
+		It 'fails and keeps the live publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The stdout should be present
+			The stderr should be present
+		End
+	End
+
+	Context 'when the download is missing'
+		Before 'plant_prior_publication'
+
+		It 'fails and keeps the live publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'XLSX download file missing'
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The contents of file "${errorlog}" should include 'XLSX download file missing'
+		End
+	End
+
+	Context 'when tar is not executable'
+		plant_no_tar() { printf 'not executable\n' > "${work}/notar"; }
+		Before 'plant_healthy_raw'
+		Before 'plant_no_tar'
+
+		It 'fails instead of falling through to the extraction'
+			When run sh "${runner}" "${work}/notar"
+			The status should be failure
+			The output should include 'Application [ TAR ] Not found'
+		End
+	End
+
+	Context 'when the extraction ceiling fires'
+		# issue #2658's ceiling (pfb_extract_cmd() -> `ulimit -f`) is what the
+		# caller wraps this helper in: RLIMIT_FSIZE is inherited by every
+		# descendant, so a write past the ceiling kills whichever child is doing
+		# it. Before the exit contract that kill was invisible -- the function
+		# still returned 0 with a truncated file in place, which is exactly why
+		# this call site was left uncapped. One 512-byte block is far below the
+		# fixture, so a child is guaranteed to be killed.
+		Before 'plant_healthy_raw'
+		Before 'plant_prior_publication'
+
+		It 'refuses the feed instead of publishing the truncated remains of one'
+			When run sh -c "ulimit -f 1 || exit 1; sh '${runner}' >/dev/null 2>&1"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+		End
+	End
+End
+
+Describe 'pfblockerng.sh xlsx dispatch arm (issue #2666)'
+	# The script tail's bare `exitnow` defaults to 0, so processxlsx()'s status
+	# would be discarded at the process boundary even once the function reports
+	# one -- the same wiring bug the `recompute` arm fixed in issue #1084. Runs
+	# the REAL entrypoint: the propagation lives in the dispatch, not in the
+	# function.
+	It 'exits non-zero when the feed has no downloaded container'
+		# Off-appliance /var/db/pfblockerng/original/ holds nothing, so the
+		# missing-download branch is the one reached, before any appliance-only
+		# tool is needed.
+		When run sh "${PFB_PKGDIR}/pfblockerng.sh" xlsx NoSuchFeed x
+		The status should be failure
+		The stdout should include 'XLSX download file missing'
+		# The top-level init spews unrelated noise off-appliance (missing
+		# read_xml_tag.sh, /cf/conf/config.xml, unwritable /var/db) -- real but
+		# incidental here, so only asserted as present.
+		The stderr should not equal ''
+	End
+End


### PR DESCRIPTION
## What this changes

`processxlsx()` in `pfblockerng.sh` had no exit contract. It ran two unchecked `tar` invocations and a pipeline whose status nobody read, then ended on an `echo`, so its own exit status was that `echo`'s — always 0. Its caller in `pfb_download()` therefore decided the ingest had succeeded by testing that the output file existed, which a half-written file satisfies exactly as well as a complete one.

That is why this was the one extraction site issue #2658 deliberately left uncapped: a child killed at the ceiling truncates its output and exits non-zero, but "the file exists" would have published those truncated remains as a successful ingest — strictly worse than no cap.

1. **The shell function reports.** The extractions now run with the status carried forward; the addresses are sorted onto a staged path and moved onto the live `.orig` only once every step has succeeded, so a failed refresh leaves the feed already in service byte-unchanged. `tar -xOf` writes the shared-strings part to its own file instead of straight into the pipe — POSIX sh has no `pipefail`, so piped it would report only the trailing `sort`'s status and a workbook that could not be read at all would still "succeed" with an empty publication. A failing status is returned verbatim rather than collapsed to 1, so a `SIGXFSZ` kill still reaches the caller as the 153 that names the ceiling.
2. **The dispatch arm threads it through.** The script tail's bare `exitnow` defaults to 0, so the `xlsx` arm now does `exitnow "$?"` the way the `recompute` arm already does (the issue #1084 wiring bug).
3. **The caller gates on the status.** `pfb_download()` runs the helper under `pfb_extract_cmd()` and refuses the feed on a non-zero exit, logging the ceiling by name via `pfb_extract_cap_note()`. It no longer unlinks the live publication up front — that unlink only existed to stop a stale file from faking success, which the exit status now decides instead.

Two properties came out of review, because reading a status that used to be discarded changes what the function accepts and what it leaves behind:

4. **Only the first workbook is read.** The glob splats into `tar`'s argument list, where every match after the first is a *member selector*, not a second archive — so a multi-workbook container extracted its first workbook correctly and exited non-zero anyway. Harmless while the status was thrown away; a hard refusal of a previously-working feed once it is read. Naming one archive keeps such a feed ingesting exactly as it did, and silences `tar`'s "not found in archive" complaint.
5. **The published mode is set explicitly.** Truncating the live file in place kept its mode; replacing it by rename hands it whatever the run's umask allows, which could take read access away from a feed's unprivileged readers. `chmod 644` before the rename, the same reason `pfb_stage_publish()` chmods its staged file.

## Tests

`tests/shell/pfblockerng_processxlsx_exit_spec.sh` (new) pins the contract end to end. A healthy container publishes and reports success; a corrupt outer container, a truncated container, an inner `.xlsx` member that is not an archive, a crash-leftover directory at the staged path, a missing download, and a non-executable `tar` each fail and leave the live `.orig` byte-unchanged; that same crash-leftover directory is then cleared, so a healthy container run afterwards publishes rather than failing against the debris the previous run caused; a two-workbook container still publishes; a run under `umask 077` still publishes `0644`; a `sort` killed the way the ceiling kills one comes back as **153** rather than a generic failure, because `pfb_extract_cap_note()` reads exactly that status to say "too large" instead of printing a bare exit code; and under `ulimit -f 1` — the shape `pfb_extract_cmd()` imposes — the feed is refused rather than published truncated. A second `Describe` runs the real entrypoint to pin the dispatch arm's status propagation.

Two of those reach the stage that *writes* the publication rather than one of the `tar`s ahead of it: the staged-path directory and the killed `sort`. The `.orig.tmp` debris assertion sits only where the staged file is genuinely written; in the failure contexts where it could not have failed, it is gone.

The fixtures are tars rather than ZIPs: the function only ever calls `${pathtar}` with `-xf`/`-xOf` and the statuses under test are identical either way, while GNU tar (the CI runner's `/usr/bin/tar`) cannot read a ZIP at all — a ZIP fixture would have silently reduced the whole file to a macOS-only test.

`tests/php/DownloadSizeCeilingTest.php` stops allow-listing this call site in `test_every_extraction_exec_runs_under_the_ceiling` — it is capped now, so the sweep must see it capped. `DownloadExtractionExitCodeTest::testXlsxBodyCapturesAndChecksHelperExit` pins the branch's shape beside the seven sibling extraction branches already pinned there. `tests/shell/pfblockerng_adr26_locale_spec.sh` follows the `LC_ALL=C` sink to its staged filename — same sink, same collation requirement, one filename earlier.

### Red → green

Test-first, and re-executed at `c2fb3fcc4` against the production files reverted to `origin/devel` with the committed test files untouched. Their `git hash-object` is identical across both runs:

```
tests/shell/pfblockerng_processxlsx_exit_spec.sh  6957f24396e9719ea79850f415f152028bb952b9
tests/php/DownloadSizeCeilingTest.php             59a45628ac997ce56c05f5990749fc0ba37c8aa2
tests/php/DownloadExtractionExitCodeTest.php      5d38fa8037d7daf872b78e318ada1887633425d3
```

RED — `git checkout origin/devel -- src/usr/local/pkg/pfblockerng/pfblockerng.{sh,inc}`:

```
$ shellspec --shell "$(command -v dash)" tests/shell/pfblockerng_processxlsx_exit_spec.sh
13 examples, 12 failures
$ vendor/bin/phpunit --filter 'DownloadSizeCeilingTest|DownloadExtractionExitCodeTest'
Tests: 25, Assertions: 105, Failures: 2.
```

The failures name the defect directly — e.g. the live publication after a corrupt container:

```
The contents of file .../XlsxFeed.orig should equal 203.0.113.7
PRIOR-MARKER
    expected: "203.0.113.7
    PRIOR-MARKER"
         got: ""
```

GREEN — production restored, same test bytes:

```
$ shellspec --shell "$(command -v dash)" tests/shell/pfblockerng_processxlsx_exit_spec.sh
13 examples, 0 failures
$ vendor/bin/phpunit --filter 'DownloadSizeCeilingTest|DownloadExtractionExitCodeTest'
OK (25 tests, 116 assertions)
```

### Gates

```
$ scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc
GATE PASS: php -l tests/php/DownloadExtractionExitCodeTest.php
GATE PASS: php -l tests/php/DownloadSizeCeilingTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATE PASS: sh -n src/usr/local/pkg/pfblockerng/pfblockerng.sh
GATE PASS: shellcheck src/usr/local/pkg/pfblockerng/pfblockerng.sh
GATE PASS: sh -n tests/shell/pfblockerng_adr26_locale_spec.sh
GATE PASS: sh -n tests/shell/pfblockerng_processxlsx_exit_spec.sh
GATE PASS: shellspec --shell $(command -v dash || command -v sh)
GATES: PASS
```

### Deferred

Three findings from review are real but outside this issue's scope and have their own issues:

- **#2682** — a workbook that parses fine but carries no IPv4 literal publishes an empty feed over the last-good one. Pre-existing, byte-identical on `devel`.
- **#2683** — `processet()` has the same missing-exit-status shape one dispatch arm over.
- **#2684** — reading `tar`'s own status meant writing the shared-strings part to a file instead of streaming it, and that part decompresses about 410× (measured: 25,398 bytes on disk, 10,400,000 decompressed), which lands in a RAM-disk `/tmp` on a default `use_mfs_tmpvar` install. Fail-safe — the write failing refuses the feed and keeps the live publication — but a large XLSX feed that used to ingest on a small `/tmp` may now be refused, and the free-space precheck never probes `${tmpdir}`. Introduced here, so it is written up with the options rather than left implicit.

Fixes #2666

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @andrebrait's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XLSX feed downloads by validating extraction results before publishing files.
  - Preserved the existing feed when downloads are missing, corrupt, incomplete, or exceed extraction limits.
  - Failed downloads now report errors accurately and return a non-success status instead of appearing successful.
  - Updated file handling to publish completed feeds atomically with appropriate permissions.
- **Tests**
  - Added coverage for extraction failures, cleanup, status propagation, size limits, and restrictive permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->