### PR TITLE
fix: reject NUL in IPv4 validation

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11949,6 +11949,9 @@ function pfb_sanitize_ipaddr_v6($ipaddr, $custom, $pfbcidr, PfbToggle $supp): ar
 
 // Validate IPv4 IP addresses
 function validate_ipv4($ipaddr) {
+	if (str_contains($ipaddr, "\0")) {
+		return FALSE;
+	}
 	if (strpos($ipaddr, '/') !== FALSE) {
 		return is_subnetv4($ipaddr);
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -389,7 +389,7 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 	if ($vtype == '_v4' && $pftype == 'auto') {
 		if (strpos($line, '-') !== FALSE) {
 			$matches = explode('-', $line);
-			if (count($matches) == 2) {
+			if (count($matches) == 2 && validate_ipv4($matches[0]) && validate_ipv4($matches[1])) {
 				$a_cidr = ip_range_to_subnet_array($matches[0], $matches[1]);
 				if (!empty($a_cidr)) {
 					foreach ($a_cidr as $cidr) {

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -283,6 +283,21 @@ final class IpParseLineTest extends TestCase
 		));
 	}
 
+	public function testIpv4AutoNulRangeEndpointsFallThroughToRegex(): void
+	{
+		$config = $this->config('_v4', 'auto', FALSE);
+		$lines = [
+			"5.61.209.0\0-5.61.209.255",
+			"5.61.209.0-" . "\0" . "5.61.209.255",
+		];
+		foreach ($lines as $line) {
+			$this->assertLine($line, $config, $this->expectedResult(
+				$line,
+				['entries' => ['5.61.209.0', '5.61.209.255']]
+			));
+		}
+	}
+
 	public function testIpv6EmptyAndInvalidRangesDoNotEmitEntries(): void
 	{
 		$config = $this->config('_v6');

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -392,6 +392,17 @@ final class IpParseLineTest extends TestCase
 		$this->assertLine($ipTabText, $config, $this->expectedResult($ipTabText, ['entries' => ['8.8.8.8']]));
 	}
 
+	public function testIpv4AutoDshieldTabNulEndpointsFallThrough(): void
+	{
+		$config = $this->config('_v4', 'auto', FALSE);
+		foreach (["5.61.209.0\0\t5.61.209.255\t24", "5.61.209.0\t5.61.209.255\0\t24"] as $line) {
+			$this->assertLine($line, $config, $this->expectedResult(
+				$line,
+				['entries' => ['5.61.209.0', '5.61.209.255']]
+			));
+		}
+	}
+
 	/**
 	 * Scenario: a tab-delimited source contains rows from both address families.
 	 *   Given matching IPv4 and IPv6 alias passes over the same rows


### PR DESCRIPTION
Fixes #2610.

## Intent

Make IPv4 feed parsing reject NUL-bearing validation candidates instead of letting pfSense `is_ipaddrv4()` call `ip2long()` and abort the alias update pass.

## Implementation

- Reject NUL before IPv4 address or subnet validation reaches pfSense.
- Validate raw auto-range endpoints before calling pfSense's range helper.
- Preserve existing fallback extraction: NUL in either DShield or hyphen-range endpoint yields the two valid IPv4 tokens with unchanged parse-failure accounting.
- Cover both endpoint positions through the public `pfb_ip_parse_line()` seam.

## Red to green

Initial frozen regression hash: `8162a32d41909bf4c4464876ca914f8d21b33aa1`.

- RED on untouched `devel`: `ValueError: ip2long(): Argument #1 ($ip) must not contain any null bytes` (`1 test`, `1 error`).
- GREEN after the shared validation guard: `OK (1 test, 2 assertions)`.

Review-fix frozen regression hash: `cbcc0c856a1311b3f4270eb4d4c24d6b8d826e80`.

- RED on the first review head: the auto hyphen-range path bypassed the guard and threw the same `ValueError` (`1 test`, `1 error`).
- GREEN after guarding both raw range endpoints: `OK (1 test, 2 assertions)`.
- The final parser suite passed `OK (28 tests, 70 assertions)` and the committed test matches the review-fix frozen hash.

## Verification

- Canonical gate: Composer vendor, all changed-file PHP syntax checks, PHPStan, and PHPCS passed.
- Full PHPUnit executed `5449` tests; one unrelated macOS-only baseline failure expected SIGXFSZ status 153 but observed status 1. It reproduced in a fresh byte-identical `origin/devel` worktree and is tracked by #2685.
- After the final rebase onto `68f4b8e656b7ba89516b9b7a160a2d0699c07f7b`, Linux CI passed every applicable check on head `f59d936a978de09c089d6f8d22bebac20a6c6256`.
- Diff static scan: Semgrep and Gitleaks clean; no kept findings.

Authorship: implemented by Oh My Pi; committed with the repository's configured human identity and signing policy.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
