### PR TITLE
fix: guard IPv6 ranges from NUL input

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -480,8 +480,7 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 
 		if (strpos($line, '-') !== FALSE && strpos($line, ':') !== FALSE) {
 			$matches = explode('-', $line);
-			if (count($matches) == 2 &&
-				!str_contains($matches[0], "\0") && !str_contains($matches[1], "\0")) {
+			if (count($matches) == 2 && !str_contains($raw_line, "\0")) {
 				$a_cidr = ip_range_to_subnet_array($matches[0], $matches[1]);
 				if (!empty($a_cidr)) {
 					foreach ($a_cidr as $cidr) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -480,7 +480,8 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 
 		if (strpos($line, '-') !== FALSE && strpos($line, ':') !== FALSE) {
 			$matches = explode('-', $line);
-			if (count($matches) == 2) {
+			if (count($matches) == 2 &&
+				!str_contains($matches[0], "\0") && !str_contains($matches[1], "\0")) {
 				$a_cidr = ip_range_to_subnet_array($matches[0], $matches[1]);
 				if (!empty($a_cidr)) {
 					foreach ($a_cidr as $cidr) {

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -316,6 +316,24 @@ final class IpParseLineTest extends TestCase
 		));
 	}
 
+	public function testIpv6RegexNulFirstRangeEndpointFallsThrough(): void
+	{
+		$line = "2001:4860:4860::\0-2001:4860:4860::3";
+		$this->assertLine($line, $this->config('_v6', 'regex', FALSE), $this->expectedResult(
+			$line,
+			['entries' => ['2001:4860:4860::', '2001:4860:4860::3']]
+		));
+	}
+
+	public function testIpv6RegexNulSecondRangeEndpointFallsThrough(): void
+	{
+		$line = "2001:4860:4860::-" . "\0" . "2001:4860:4860::3";
+		$this->assertLine($line, $this->config('_v6', 'regex', FALSE), $this->expectedResult(
+			$line,
+			['entries' => ['2001:4860:4860::', '2001:4860:4860::3']]
+		));
+	}
+
 	public function testIpv6AutoMixedNulRangeSafelyExtractsIpv6(): void
 	{
 		$line = "192.0.2.1-" . "\0" . "2001:4860:4860::3";
@@ -323,6 +341,23 @@ final class IpParseLineTest extends TestCase
 			$line,
 			['entries' => ['2001:4860:4860::3']]
 		));
+	}
+
+	public function testIpv6AutoOuterNulMixedRangesFallThroughToRegex(): void
+	{
+		$config = $this->config('_v6', 'auto', FALSE);
+		$rows = [
+			["\0" . "2001:4860:4860::3-192.0.2.1", '2001:4860:4860::3'],
+			["2001:4860:4860::3-192.0.2.1" . "\0", '2001:4860:4860::3'],
+			["\0" . "192.0.2.1-2001:4860:4860::3", '2001:4860:4860::3'],
+			["192.0.2.1-2001:4860:4860::3" . "\0", '2001:4860:4860::3'],
+		];
+		foreach ($rows as [$line, $entry]) {
+			$this->assertLine($line, $config, $this->expectedResult(
+				trim($line),
+				['entries' => [$entry]]
+			));
+		}
 	}
 
 	public function testIpv6EmptyAndInvalidRangesDoNotEmitEntries(): void

--- a/tests/php/IpParseLineTest.php
+++ b/tests/php/IpParseLineTest.php
@@ -298,6 +298,33 @@ final class IpParseLineTest extends TestCase
 		}
 	}
 
+	public function testIpv6AutoNulFirstRangeEndpointFallsThroughToRegex(): void
+	{
+		$line = "2001:4860:4860::\0-2001:4860:4860::3";
+		$this->assertLine($line, $this->config('_v6', 'auto', FALSE), $this->expectedResult(
+			$line,
+			['entries' => ['2001:4860:4860::', '2001:4860:4860::3']]
+		));
+	}
+
+	public function testIpv6AutoNulSecondRangeEndpointFallsThroughToRegex(): void
+	{
+		$line = "2001:4860:4860::-" . "\0" . "2001:4860:4860::3";
+		$this->assertLine($line, $this->config('_v6', 'auto', FALSE), $this->expectedResult(
+			$line,
+			['entries' => ['2001:4860:4860::', '2001:4860:4860::3']]
+		));
+	}
+
+	public function testIpv6AutoMixedNulRangeSafelyExtractsIpv6(): void
+	{
+		$line = "192.0.2.1-" . "\0" . "2001:4860:4860::3";
+		$this->assertLine($line, $this->config('_v6', 'auto', FALSE), $this->expectedResult(
+			$line,
+			['entries' => ['2001:4860:4860::3']]
+		));
+	}
+
 	public function testIpv6EmptyAndInvalidRangesDoNotEmitEntries(): void
 	{
 		$config = $this->config('_v6');


### PR DESCRIPTION
Fixes #2688.

## Intent

Prevent NUL-bearing IPv6 hyphen ranges from reaching pfSense's IPv4-first range helper while preserving valid ranges, fallback extraction, opposite-family behavior, and parse-failure accounting.

## Implementation

- Preserve the raw NUL signal when deciding whether the IPv6 range helper may run, including NUL stripped from `$line` by `trim()`.
- Let rejected NUL ranges continue into the existing IPv6 regex fallback.
- Cover both endpoint positions, mixed-family orderings, outer boundaries, and auto/regex modes through the public `pfb_ip_parse_line()` seam.

## Red to green

Frozen regression test hash: `b00b96fc336a35e8653ac14cf00113bcfac6c59d`.

On untouched `devel`:

- NUL after the first IPv6 endpoint: `ValueError: ip2long(): Argument #1 ($ip) must not contain any null bytes`.
- NUL before the second IPv6 endpoint: assertion failure; expected two fallback entries, observed none.
- Valid IPv4 first endpoint plus NUL-bearing IPv6 second endpoint: the same `ip2long()` `ValueError`.

After the initial endpoint guard, all three frozen tests passed. The parser suite passed `OK (31 tests, 73 assertions)`, and the test file matched the initial frozen hash.

A broader initial endpoint-validity guard changed the pre-existing malformed-range accounting test from silent/zero to detailed failure. The NUL-only guard kept that test unchanged.

Review-fix frozen hash: `036ea50a660e59e0d074c73b30b766c7d82dc07e`.

- On untouched `devel`, regex-mode first-endpoint NUL reproduced the `ip2long()` error and second-endpoint NUL reproduced the empty-result mismatch.
- On the first PR head, leading/trailing endpoint NUL was removed by `trim()` and four mixed-family rows returned no entries instead of regex fallback.
- The final raw-input guard makes all review regressions pass. The parser suite passes `OK (34 tests, 79 assertions)`, and the committed test matches the review-fix hash.

## Verification

- Focused parser suite: `OK (34 tests, 79 assertions)`.
- Canonical gate: Composer vendor, changed-file PHP syntax, PHPStan, and PHPCS passed.
- Full PHPUnit executed `5456` tests; its sole failure is the unchanged macOS SIGXFSZ-status mismatch tracked by #2685.
- Linux CI passed every applicable check on final reviewed head `4ca9acd78792834f13b0a2a3401b41285a12fca4`.

Authorship: implemented by Oh My Pi; committed with the repository's configured human identity and signing policy.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv6 range parsing to safely reject malformed entries containing NUL characters.
  * Preserved valid IPv6 addresses when malformed data is mixed with IPv4 or other ranges.
  * Prevented malformed entries from being generated during automatic and regex-based parsing.

* **Tests**
  * Added coverage for NUL characters in IPv6 range endpoints and mixed-range fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->