### PR TITLE
githooks: let a branch decline a tool gate, not just a missing checker

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -70,6 +70,21 @@ exempted() {
 }
 exempt() { printf '[pre-commit] exempt (checker not shipped on this branch; listed in .githooks-exempt): %s\n' "$1"; }
 
+# A branch may also decline a TOOL gate -- ruff, shellcheck, phpcs -- with a
+# `gate:<name>` line in the same manifest (issue #2696). Every worktree runs the
+# PRIMARY checkout's hook (core.hooksPath is absolute), so without this a
+# maintenance line is graded by rules it never adopted: release/3.3 runs pytest
+# alone in CI, has no ruff config of its own -- ruff then walks up out of the
+# worktree and uses devel's -- and carries legacy shell that devel's shellcheck
+# sweep rejects. The escapes otherwise are --no-verify, or adopting the gate with
+# an allowlist for its pre-existing findings; both are worse than recording that
+# the line's contract is narrower.
+#
+# Graded from the STAGED blob by exempted(), exactly like a checker path: an
+# untracked or unstaged manifest declines nothing.
+gate_exempted() { exempted "gate:$1"; }
+gate_exempt() { printf '[pre-commit] exempt (gate not adopted on this branch; listed in .githooks-exempt): %s\n' "$1"; }
+
 # --- Stage classification: run a language's gates ONLY when this commit stages a
 #     file of that type. (diff-filter ACMR = added/copied/modified/renamed; a pure
 #     deletion stages nothing to lint.) Nothing staged -> nothing to do.
@@ -110,6 +125,10 @@ if [ "$staged_py" = 1 ]; then
 		ruff_bin=.venv/bin/ruff
 	elif have ruff; then
 		ruff_bin=ruff
+	fi
+	if gate_exempted ruff; then
+		gate_exempt ruff
+		ruff_bin=''
 	fi
 	if [ -n "$ruff_bin" ]; then
 		step 'ruff check'
@@ -173,7 +192,9 @@ if [ "$staged_sh" = 1 ]; then
 
 	# ShellCheck (src + scripts only; tests/ shellspec specs trip SC2034
 	# false-positives — tracked as a separate cleanup).
-	if have shellcheck; then
+	if gate_exempted shellcheck; then
+		gate_exempt shellcheck
+	elif have shellcheck; then
 		step 'shellcheck'
 		find src scripts .claude/hooks -name '*.sh' | sort \
 			| xargs shellcheck --severity=info || failed 'shellcheck'

--- a/tests/shell/precommit_githooks_exempt_spec.sh
+++ b/tests/shell/precommit_githooks_exempt_spec.sh
@@ -137,4 +137,51 @@ scripts/agent/check-agent-config-parity.sh'
     The output should not include 'listed in .githooks-exempt): composer vendor'
     The stderr should include '[pre-commit] FAILED: composer vendor'
   End
+
+  It 'skips a tool gate this branch declines, and says so'
+    # issue #2696: a maintenance line runs a narrower CI contract than devel (3.3 is
+    # pytest-only), but every worktree runs the PRIMARY checkout's hook. Without a way
+    # to decline a TOOL gate, that line is graded by rules it never adopted -- and the
+    # only escapes are --no-verify or adopting the gate with an allowlist for its
+    # pre-existing findings.
+    printf '%s\ngate:shellcheck\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    printf '#!/bin/sh\nif [ "$x" == 1 ]; then :; fi\n' > "$repo/src/bad.sh"
+    gitc add src/bad.sh
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include 'gate not adopted on this branch; listed in .githooks-exempt): shellcheck'
+    The stderr should not include 'FAILED'
+  End
+
+  It 'still runs a tool gate the manifest does not decline'
+    # The same tree, the same bad script, without the gate line: the sweep runs and the
+    # commit fails. This is what makes the example above evidence rather than decoration.
+    printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    printf '#!/bin/sh\nif [ "$x" == 1 ]; then :; fi\n' > "$repo/src/bad.sh"
+    gitc add src/bad.sh
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should include '[pre-commit] shellcheck'
+    The stderr should include 'FAILED'
+  End
+
+  It 'ignores a gate line that is only in the working tree'
+    # Keyed on the STAGED blob like every other entry: an unstaged edit exempts nothing,
+    # so a gate cannot be dropped by a change reviewers never see.
+    printf '%s\ngate:shellcheck\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    gitc commit -q -m seed --no-verify
+    printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    printf 'gate:shellcheck\n' >> "$repo/.githooks-exempt"
+    printf '#!/bin/sh\nif [ "$x" == 1 ]; then :; fi\n' > "$repo/src/bad.sh"
+    gitc add src/bad.sh
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The output should include '[pre-commit] shellcheck'
+    The output should not include 'gate not adopted'
+    The stderr should include 'FAILED'
+  End
 End


### PR DESCRIPTION
## Why

Every worktree runs the primary checkout's `.githooks/pre-commit` — `core.hooksPath` is absolute
in the shared config — so a commit made from a maintenance-line worktree is graded by **devel's**
gates. `.githooks-exempt` (#2633) exists for exactly that mismatch, but it can only excuse a repo
checker script *absent from the tree*. It has no way to say "this branch does not adopt the ruff
gate", because ruff is a tool, not a shipped script.

Landing #2694 hit it twice on `release/3.3`, a line whose CI runs **pytest alone**:

- **ruff** — 3.3 has no ruff config, so ruff walks up out of the worktree and applies devel's rule
  set: 157 findings, none of them the change being committed. The gate also only fires when a
  `ruff` binary happens to exist in the worktree, so whether it runs depends on whether someone
  ran `uv sync` there.
- **shellcheck** — the sweep is whole-tree, and 3.3's legacy `ip_pre_AWS_*.sh` trip `SC3014`
  (`==` in POSIX sh). Fifteen-plus files, untouched by the commit.

Neither is fixable from the branch. The escapes were `--no-verify` (a bypass needing authorization
every time) or adopting the gate with an allowlist for 276 pre-existing findings.

## What this adds

A `gate:<name>` line in the same manifest declines a tool gate exactly as a script path declines a
checker:

```
gate:ruff
gate:shellcheck
```

- **graded from the STAGED blob**, like every existing entry — an untracked or unstaged manifest
  declines nothing, so a gate cannot be dropped by a change reviewers never see
- prints `[pre-commit] exempt (gate not adopted on this branch; listed in .githooks-exempt): ruff`,
  so a skipped gate is visible rather than silent
- devel lists none, so devel's behaviour is unchanged

## Tests

Three examples in `tests/shell/precommit_githooks_exempt_spec.sh`, and the pairing is the point:

1. a declined gate skips — on a tree containing a script that *would* fail it
2. the **same tree** without the line still runs the gate and still fails
3. a `gate:` line present only in the working tree declines nothing

(3) is mutation-proven: pointing `gate_exempted()` at the working tree instead of the staged blob
turns exactly that example red.

`GATES: PASS`.

## What this is not

Not a way to skip gates on devel, and not a licence to leave a branch unlinted. It records that a
line's CI contract is narrower than devel's — which for 3.3 is simply true — instead of pretending
otherwise and bypassing the hook by hand each time.

Closes #2696
