### PR TITLE
repo: stop internal git work inheriting the caller's git environment

### DIFF
--- a/scripts/agent/graphify-store.py
+++ b/scripts/agent/graphify-store.py
@@ -23,11 +23,28 @@ class StoreError(RuntimeError):
     """A caller-actionable Graphify store failure."""
 
 
+def _git_env() -> dict[str, str]:
+    """The environment for every store `git` call: no inherited config, no inherited GIT_*.
+
+    The store pins its own identity at init, so an inherited scope only adds hazard —
+    `tag.gpgsign` promotes a snapshot tag to annotated and it aborts with `fatal: no tag
+    message?` (issue #2700). `GIT_DIR` and friends outrank `git -C` and would point the
+    whole store at whatever repository the caller happened to be inside.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    return env
+
+
 def _run(root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
-        ["git", "-C", str(root), *args],
+        # `safe.directory` is readable from the scopes above and nowhere else, so name the
+        # path this call was asked to work on rather than lose the exemption with them.
+        ["git", "-c", f"safe.directory={root}", "-C", str(root), *args],
         text=True,
         capture_output=True,
+        env=_git_env(),
     )
     if check and result.returncode:
         detail = result.stderr.strip() or result.stdout.strip() or "git failed"

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -26,6 +26,8 @@ from typing import Any
 import pfb_pkg
 import pytest
 
+from tests.gitenv import scrubbed_git_env
+
 _TOOL = Path(__file__).resolve().parent.parent / "scripts" / "build-frozen-v3.py"
 _spec = importlib.util.spec_from_file_location("build_frozen_v3", _TOOL)
 assert _spec is not None and _spec.loader is not None
@@ -314,7 +316,7 @@ def test_derive_deps_shape() -> None:
 
 
 def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True, env=scrubbed_git_env())
 
 
 @pytest.fixture

--- a/tests/test_gitenv.py
+++ b/tests/test_gitenv.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -23,7 +24,10 @@ import pytest
 
 from tests.gitenv import scrubbed_git_env
 
-_HOSTILE = "[commit]\n\tgpgsign = true\n[gpg]\n\tformat = ssh\n[user]\n\tsigningkey = /nonexistent/key\n"
+_HOSTILE = (
+    "[commit]\n\tgpgsign = true\n[tag]\n\tgpgsign = true\n"
+    "[gpg]\n\tformat = ssh\n[user]\n\tsigningkey = /nonexistent/key\n"
+)
 
 # Every module owning a scratch-repo helper of the shape ``_git(repo, *args)``.
 _GIT_HELPER_MODULES = (
@@ -124,6 +128,106 @@ def test_context_budget_scratch_commit_survives_a_hostile_config(
         env=scrubbed_git_env(),
     ).stdout.strip()
     assert len(head) == 40, f"context-budget scratch commit produced no HEAD ({head!r})"
+
+
+def test_frozen_build_scratch_repo_tags_under_a_hostile_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``test_build_frozen_v3`` tags its scratch repo — a commit-only pin never signs a tag."""
+    _hostile_config(tmp_path, monkeypatch)
+    git = importlib.import_module("tests.test_build_frozen_v3")._git
+
+    repo = tmp_path / "frozen"
+    repo.mkdir()
+    git("init", "-q", "-b", "devel", cwd=repo)
+    git("config", "user.email", "t@example.invalid", cwd=repo)
+    git("config", "user.name", "t", cwd=repo)
+    (repo / "a.txt").write_text("one\n")
+    git("add", "a.txt", cwd=repo)
+    git("commit", "-qm", "base", cwd=repo)
+    git("tag", "v9.9.9", cwd=repo)
+
+    assert git("tag", "--list", cwd=repo).stdout.split() == ["v9.9.9"]
+
+
+def test_graphify_store_publishes_under_a_hostile_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The store script scrubs for itself: ``publish`` tags every snapshot in the store repo."""
+    _hostile_config(tmp_path, monkeypatch)
+    mod = importlib.import_module("tests.test_graphify_store")
+
+    builder = tmp_path / "builder"
+    sha = mod.make_repo(builder)
+    result = mod.run_store(
+        "publish",
+        "--store-root",
+        str(tmp_path / "store"),
+        "--builder",
+        str(builder),
+        "--branch",
+        "devel",
+        "--sha",
+        sha,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_graphify_store_publish_ignores_an_inherited_git_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``GIT_DIR`` beats ``git -C``, so an inherited one aims the store at the wrong repository."""
+    mod = importlib.import_module("tests.test_graphify_store")
+
+    builder = tmp_path / "builder"
+    sha = mod.make_repo(builder)
+    decoy = tmp_path / "decoy"
+    mod.make_repo(decoy)
+    monkeypatch.setenv("GIT_DIR", str(decoy / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(decoy))
+
+    result = mod.run_store(
+        "publish",
+        "--store-root",
+        str(tmp_path / "store"),
+        "--builder",
+        str(builder),
+        "--branch",
+        "devel",
+        "--sha",
+        sha,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_graphify_store_pins_safe_directory_on_every_repository_it_touches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neutralising the global scope also hides ``safe.directory``, which git reads nowhere else.
+
+    A checkout owned by another uid — bind-mounted into a container, or touched under sudo —
+    is refused as dubious ownership, and repo-local config cannot grant the exemption. The
+    store names the path it was asked to work on instead.
+    """
+    real_git = shutil.which("git")
+    assert real_git
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    log = tmp_path / "git-argv.log"
+    shim = shim_dir / "git"
+    shim.write_text(f'#!/bin/sh\nprintf "%s\\n" "$*" >>"{log}"\nexec {real_git} "$@"\n')
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ['PATH']}")
+
+    mod = importlib.import_module("tests.test_graphify_store")
+    builder = tmp_path / "builder"
+    sha = mod.make_repo(builder)
+    store = tmp_path / "store"
+    result = mod.run_store(
+        "publish", "--store-root", str(store), "--builder", str(builder), "--branch", "devel", "--sha", sha
+    )
+    assert result.returncode == 0, result.stderr
+
+    invocations = [line for line in log.read_text().splitlines() if "-C " in line]
+    assert invocations, "the store made no git calls through the shim"
+    for target in (builder, store):
+        assert any(f"safe.directory={target} -C {target}" in line for line in invocations), (
+            f"no invocation pinned safe.directory for {target}: {invocations}"
+        )
 
 
 def test_read_version_matrix_env_neutralises_config_too(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_graphify_store.py
+++ b/tests/test_graphify_store.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.gitenv import scrubbed_git_env
+
 SCRIPT = Path(__file__).parents[1] / "scripts" / "agent" / "graphify-store.py"
 SPEC = importlib.util.spec_from_file_location("graphify_store", SCRIPT)
 assert SPEC and SPEC.loader
@@ -24,6 +26,7 @@ def git(path: Path, *args: str) -> str:
         check=True,
         text=True,
         capture_output=True,
+        env=scrubbed_git_env(),
     )
     return result.stdout.strip()
 


### PR DESCRIPTION
## What

A global `tag.gpgsign = true` broke every local gate run and blocked worktree creation
outright: signing promotes a lightweight tag to an annotated one, which then demands a
message nobody passes.

- `scripts/agent/graphify-store.py` now runs every git call with both config scopes
  neutralised, no inherited `GIT_*`, and `safe.directory` named for the path that call was
  asked to work on. The store under `.git/graphify-store` is a private snapshot cache that
  already pins its identity at init; the developer's config reaching it is pure hazard.
  `GIT_DIR` outranks `git -C`, so an inherited one silently aimed the store's own
  `rev-parse` at the caller's repository — `work-branch.sh` scrubs before calling, but the
  script no longer depends on that. The ownership exemption is readable from the two scopes
  and nowhere else, so a checkout owned by another uid (bind-mounted, or touched under
  sudo) would have been refused as dubious once they were neutralised.
- `tests/test_build_frozen_v3.py` and the graphify-store suite's scratch helper use
  `tests/gitenv.scrubbed_git_env()`, the fix issue #1967 introduced for exactly this.

Release tags are unaffected: `release.yml` mints them annotated with an explicit message,
which is what a signing config would have forced anyway.

## Proof

Four pins in `tests/test_gitenv.py`: two against a config demanding a signature from an
unusable key, one against a hijacked `GIT_DIR`, one against the git command line itself
through a PATH shim. Removing a scrub reddens that file on a clean machine too.

Red with the fix reverted, `tests/test_gitenv.py` frozen at
`0547ac961bae4fdda5ef2f21524e75406cfa48e4`:

```
$ git checkout origin/devel -- scripts/agent/graphify-store.py tests/test_build_frozen_v3.py tests/test_graphify_store.py
$ uv run --frozen python -m pytest tests/test_gitenv.py -q -p no:randomly
FAILED tests/test_gitenv.py::test_graphify_store_publishes_under_a_hostile_config
FAILED tests/test_gitenv.py::test_frozen_build_scratch_repo_tags_under_a_hostile_config
FAILED tests/test_gitenv.py::test_graphify_store_publish_ignores_an_inherited_git_dir
FAILED tests/test_gitenv.py::test_graphify_store_pins_safe_directory_on_every_repository_it_touches
4 failed, 8 passed
```

Green with the same file, on the machine whose config caused the 23 collateral failures:

```
$ scripts/agent/run-gates.sh
GATE PASS: uv run --locked pytest
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
GATES: PASS
```

`graphify-store.py publish` also completes again outside the suite, which is what unblocks
`work-branch.sh --worktree`.

Part of #2700
