### PR TITLE
site: stack the channel cards at every width

### DIFF
--- a/scripts/gen_landing.py
+++ b/scripts/gen_landing.py
@@ -361,7 +361,7 @@ _CSS = """
 .pkg-section>h2{margin:0 0 1.6rem;font-size:clamp(1.9rem,4vw,3.2rem);letter-spacing:-.04em;line-height:1.05}
 .pkg-section h3{margin:2rem 0 .6rem;font-size:1.25rem}
 .pkg-section h4{margin:1.4rem 0 .45rem;color:var(--muted);font-size:.82rem;letter-spacing:.1em;text-transform:uppercase}
-.cards{display:grid;gap:1rem;grid-template-columns:repeat(2,minmax(0,1fr))}
+.cards{display:grid;gap:1rem;grid-template-columns:1fr}
 .card{--channel:var(--line);min-width:0;padding:clamp(1.25rem,3vw,2rem);border:1px solid var(--line);
   border-top:4px solid var(--channel);border-radius:var(--radius);background:var(--bg-elevated);
   box-shadow:0 1px 0 rgb(255 255 255 / 70%) inset}
@@ -403,7 +403,7 @@ table.autoindex td.num{white-space:nowrap}
   padding:.3rem .5rem;cursor:pointer}
 .copy:hover{color:white;border-color:white}
 .copy.copied{color:#56d364;border-color:#56d364}
-@media(max-width:820px){.cards{grid-template-columns:1fr}.pkg-shell{padding-bottom:4rem}}
+@media(max-width:820px){.pkg-shell{padding-bottom:4rem}}
 @media(prefers-color-scheme:dark){.card{background:rgb(27 26 30 / 72%);box-shadow:none}}
 """
 

--- a/tests/test_gen_landing.py
+++ b/tests/test_gen_landing.py
@@ -1408,7 +1408,8 @@ def test_generated_pages_share_the_main_site_chrome_and_keep_channel_accents(tmp
         assert '<a href="https://pkg.pfblockerng.com/" aria-current="page">Packages</a>' in rendered
         assert '<main id="main-content" class="pkg-shell">' in rendered
         assert '<footer class="site-footer">' in rendered
-        assert "@media(max-width:820px){.cards{grid-template-columns:1fr}" in rendered
+        assert ".cards{display:grid;gap:1rem;grid-template-columns:1fr}" in rendered
+        assert "@media(max-width:820px){.pkg-shell{padding-bottom:4rem}}" in rendered
         assert "@media(prefers-color-scheme:dark){.card{" in rendered
 
     assert '<section class="pkg-hero">' in page


### PR DESCRIPTION
## What

The Stable/Testing/Edge/Nightly cards on the package site sat two per row once the viewport
passed 820px. One column is now the only layout, so the channels read top to bottom at every
width:

```diff
-.cards{display:grid;gap:1rem;grid-template-columns:repeat(2,minmax(0,1fr))}
+.cards{display:grid;gap:1rem;grid-template-columns:1fr}
-@media(max-width:820px){.cards{grid-template-columns:1fr}.pkg-shell{padding-bottom:4rem}}
+@media(max-width:820px){.pkg-shell{padding-bottom:4rem}}
```

The breakpoint keeps its unrelated `.pkg-shell` padding rule. Card content, order, colours
and the section heading are untouched.

## Proof

The chrome test already pinned the media query verbatim, so it moves with the rule. Red with
`tests/test_gen_landing.py` frozen at `9481fcd77ee5250fc5b80c1c9a0794f5c94f5c3e`:

```
$ uv run --frozen python -m pytest tests/test_gen_landing.py -x -q
FAILED tests/test_gen_landing.py::test_generated_pages_share_the_main_site_chrome_and_keep_channel_accents
1 failed, 121 passed
```

Green with the same file after the change, and the full gate run:

```
$ uv run --frozen python -m pytest tests/test_gen_landing.py -q
123 passed

$ scripts/agent/run-gates.sh
GATES: PASS
```

The live page picks this up at the next site render.

Part of #2699
