### PR TITLE
test: retire two UI assertions that cannot pass

### DIFF
--- a/tests/smoke/ui/test_category_truncation_gate_render.py
+++ b/tests/smoke/ui/test_category_truncation_gate_render.py
@@ -88,7 +88,8 @@ def test_entity_heavy_short_values_render_without_an_ellipsis(
     guard.snapshot()
 
     resp = webui.get(CATEGORY_PAGE)
-    result = evaluate_render(CATEGORY_PAGE, resp.status_code, resp.text, ("Category",))
+    # ?type=ipv4 never renders "Category" — the word reaches the body only from the DNSBL branch.
+    result = evaluate_render(CATEGORY_PAGE, resp.status_code, resp.text, ("IPv4 Summary",))
     assert result.ok, f"Tier-A render oracle failed for the Category page: {result.detail}"
 
     body = resp.text

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2713,12 +2713,6 @@ def test_software_page_renders_when_override_forces_on(
       And no new php_error.log line (php_error_log_guard sweeps).
     """
     with software_panel_forced(smoke_vm, "on"):
-        shipped = smoke_vm.ssh("cat", _PKG_CONF_PATH)
-        assert shipped.returncode == 0, f"failed to read {_PKG_CONF_PATH}: {shipped.stderr.strip()}"
-        assert "PKG_ENV" not in shipped.stdout, (
-            "precondition: the guest's shipped pkg.conf must carry no PKG_ENV block; "
-            "a leaked seed from an earlier test invalidates this case"
-        )
         resp = webui.get(_SOFTWARE_PAGE)
         result = evaluate_render(_SOFTWARE_PAGE, resp.status_code, resp.text, (_SOFTWARE_PANEL_MARKER,))
         assert result.ok, f"forced-on Software page render failed: {result.detail}"
@@ -3005,9 +2999,6 @@ def test_software_page_hidden_when_override_forces_off(
         )
         assert resp.headers.get("Location", "").endswith("/index.php")
         assert _SOFTWARE_PANEL_MARKER not in resp.text, "forced-off must NOT render the Software panel"
-
-
-_PKG_CONF_PATH = "/usr/local/etc/pkg.conf"
 
 
 def test_log_settings_section_redesign_render(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:  # noqa: ARG001


### PR DESCRIPTION
## What

Two UI assertions that cannot pass, both invisible at reduced scope, red on every full-scope
fan-out since ~2026-08-19.

- `test_category_truncation_gate_render.py` asked the render oracle for the marker `Category`
  on `pfblockerng_category.php?type=ipv4`. That word reaches the body only from the `dnsbl`
  branch, so no `ipv4` render can carry it. It now asks for `IPv4 Summary`, the panel title
  that view emits (`pfblockerng_category.php:382`). The oracle matches ANY marker in the set,
  so one body-level literal is a stronger gate than a set containing page chrome.
- `test_software_page_renders_when_override_forces_on` required the guest's `pkg.conf` to carry
  no `PKG_ENV` block. That block is Netgate's, written by `pfSense-repo-setup`, and every stock
  Plus image ships it — which is why the two Plus legs failed and the CE legs did not. The guard
  was aimed at a leaked seed from the era when pfBlockerNG patched `pkg.conf` itself (#2518);
  that patcher is retired and nothing in the tree writes one, so the guard has no subject.

Neither test's subject changes. The truncation gate still asserts no ellipsis on an
entity-heavy short value, and the forced-on Software page still asserts a clean render, the
panel marker, the retired CA-consent surface staying absent, and the tab appearing.

## Proof

Red, before this branch — full-scope fan-out
[`32812614803`](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/32812614803) at
`d70f46301`:

```
render / CE-2.8      -> test_entity_heavy_short_values_render_without_an_ellipsis
render / CE-2.9      -> test_entity_heavy_short_values_render_without_an_ellipsis
render / Plus-26.03  -> test_entity_heavy_short_values_render_without_an_ellipsis
                        test_software_page_renders_when_override_forces_on
render / Plus-26.07  -> test_entity_heavy_short_values_render_without_an_ellipsis
                        test_software_page_renders_when_override_forces_on
```

Green: full-scope `tier=render` fan-out on this branch at head `8866b93a4`, all four ci:true
legs — run [`32877552141`](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/32877552141):

```
render / CE-2.8      success
render / CE-2.9      success
render / Plus-26.03  success
render / Plus-26.07  success
All UI legs passed (AND gate)
```

CE-only scope is exactly what hid both of these, so the verification has to be all four legs.

Local gates: `GATES: PASS`.

Part of #2695
