### PR TITLE
ci: pin tagged release publication inputs

### DIFF
--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -99,6 +99,7 @@ jobs:
           PY
           )
           echo "destinations=${DESTINATIONS}" >> "$GITHUB_OUTPUT"
+          echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
       - name: Generate GitHub App token (pkg)
         id: app-token
         # Mint a short-lived installation token from the PKG GitHub App, scoped to
@@ -123,18 +124,13 @@ jobs:
           path: pkg-repo
           fetch-depth: 1
 
-      - name: Download release .pkg assets + build the digest sidecar
-        # ASSUMED: the GitHub Releases API asset object carries a `digest` field
-        # (`sha256:<hex>`) — an INDEPENDENT checksum from the CDN download itself,
-        # never recomputed from the same bytes it is meant to check. CI must confirm
-        # the live API response actually includes it; a missing digest fails this
-        # run closed. publish_release.py reads this sidecar as
-        # <assets-dir>/digests.json.
+      - name: Download release assets + build the digest sidecar
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           RELEASE_ID: ${{ inputs.release_id }}
           RELEASE_TAG: ${{ inputs.release_tag }}
+          HANDOFF_NAME: pfblockerng-release-handoff.json
         run: |
           set -eu
           mkdir -p "${RUNNER_TEMP}/assets"
@@ -145,19 +141,22 @@ jobs:
           BAD=$(printf '%s' "$PKG_ASSETS" | jq '[.[] | select((.digest // "") | startswith("sha256:") | not)] | length')
           [ "$BAD" -eq 0 ] || {
             echo "::error::one or more .pkg release assets have no sha256 digest from the GitHub API"; exit 1; }
+          HANDOFF_ASSET=$(printf '%s' "$META" | jq -c --arg name "$HANDOFF_NAME" '[.assets[] | select(.name == $name)]')
+          [ "$(printf '%s' "$HANDOFF_ASSET" | jq 'length')" -eq 1 ] || {
+            echo "::error::release ${RELEASE_TAG} must carry exactly one ${HANDOFF_NAME}"; exit 1; }
+          HANDOFF_DIGEST=$(printf '%s' "$HANDOFF_ASSET" | jq -r '.[0].digest // ""')
+          case "$HANDOFF_DIGEST" in
+            sha256:[0-9a-f][0-9a-f]*) ;;
+            *) echo "::error::${HANDOFF_NAME} has no sha256 digest from the GitHub API"; exit 1 ;;
+          esac
           printf '%s' "$PKG_ASSETS" \
             | jq 'map({(.name): (.digest | ltrimstr("sha256:"))}) | add' \
             > "${RUNNER_TEMP}/assets/digests.json"
           gh release download "$RELEASE_TAG" -R "$REPOSITORY" --pattern '*.pkg' --dir "${RUNNER_TEMP}/assets"
-
-      - name: Read the pinned ROUTE matrix
-        id: route
-        run: |
-          set -eu
-          git fetch --no-tags --depth 1 origin \
-            "+refs/heads/ci-metadata:refs/remotes/origin/ci-metadata"
-          ROUTE_MATRIX=$(sh scripts/read-version-matrix.sh --print-route | jq -c .)
-          echo "route_matrix=${ROUTE_MATRIX}" >> "$GITHUB_OUTPUT"
+          gh release download "$RELEASE_TAG" -R "$REPOSITORY" --pattern "$HANDOFF_NAME" --dir "${RUNNER_TEMP}/assets"
+          ACTUAL_HANDOFF_DIGEST=$(sha256sum "${RUNNER_TEMP}/assets/${HANDOFF_NAME}" | cut -d' ' -f1)
+          [ "sha256:${ACTUAL_HANDOFF_DIGEST}" = "$HANDOFF_DIGEST" ] || {
+            echo "::error::${HANDOFF_NAME} digest does not match the Release API"; exit 1; }
 
       - name: Materialise the catalogue signing key
         env:
@@ -171,9 +170,9 @@ jobs:
           SOURCE_REPOSITORY: ${{ github.repository }}
           RELEASE_ID: ${{ inputs.release_id }}
           RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_SHA: ${{ steps.resolve.outputs.source_sha }}
           DESTINATIONS: ${{ steps.resolve.outputs.destinations }}
           SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
-          ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}
         # Path env vars are exported HERE, not in the env: map above — GitHub
         # Actions never shell-expands env-map values, so `$GITHUB_WORKSPACE`
         # there reaches the job as a literal dollar-string (issue #2231). The
@@ -183,6 +182,7 @@ jobs:
           export PFB_SRC="$GITHUB_WORKSPACE"
           export PKG_REPO="$GITHUB_WORKSPACE/pkg-repo"
           export ASSETS_DIR="$RUNNER_TEMP/assets"
+          export HANDOFF_FILE="$RUNNER_TEMP/assets/pfblockerng-release-handoff.json"
           export PFB_SIGN_KEY="${RUNNER_TEMP}/pfb-pkg-signing.key"
           sh scripts/publish-pkg-repo.sh
 

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -366,19 +366,13 @@ jobs:
           path: pkg-repo
           fetch-depth: 1
 
-      - name: Download release .pkg assets + build the digest sidecar
-        # ASSUMED: the GitHub Releases API asset object carries a `digest` field
-        # (`sha256:<hex>`) — an INDEPENDENT checksum from the CDN download itself,
-        # never recomputed from the same bytes it is meant to check. CI must confirm
-        # the live API response for pfBlockerNG/pfBlockerNG actually includes it; a
-        # missing digest fails this run closed rather than silently trusting the
-        # download. publish_release.py reads this sidecar as
-        # <assets-dir>/digests.json.
+      - name: Download release assets + build the digest sidecar
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ needs.resolve.outputs.source_repository }}
           RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          HANDOFF_NAME: pfblockerng-release-handoff.json
         run: |
           set -eu
           [ -n "$RELEASE_ID" ] || { echo "::error::release_id is empty — the resolve job produced none for this Release"; exit 1; }
@@ -391,19 +385,22 @@ jobs:
           BAD=$(printf '%s' "$PKG_ASSETS" | jq '[.[] | select((.digest // "") | startswith("sha256:") | not)] | length')
           [ "$BAD" -eq 0 ] || {
             echo "::error::one or more .pkg release assets have no sha256 digest from the GitHub API"; exit 1; }
+          HANDOFF_ASSET=$(printf '%s' "$META" | jq -c --arg name "$HANDOFF_NAME" '[.assets[] | select(.name == $name)]')
+          [ "$(printf '%s' "$HANDOFF_ASSET" | jq 'length')" -eq 1 ] || {
+            echo "::error::release ${RELEASE_TAG} must carry exactly one ${HANDOFF_NAME}"; exit 1; }
+          HANDOFF_DIGEST=$(printf '%s' "$HANDOFF_ASSET" | jq -r '.[0].digest // ""')
+          case "$HANDOFF_DIGEST" in
+            sha256:[0-9a-f][0-9a-f]*) ;;
+            *) echo "::error::${HANDOFF_NAME} has no sha256 digest from the GitHub API"; exit 1 ;;
+          esac
           printf '%s' "$PKG_ASSETS" \
             | jq 'map({(.name): (.digest | ltrimstr("sha256:"))}) | add' \
             > "${RUNNER_TEMP}/assets/digests.json"
           gh release download "$RELEASE_TAG" -R "$REPOSITORY" --pattern '*.pkg' --dir "${RUNNER_TEMP}/assets"
-
-      - name: Read the pinned ROUTE matrix
-        id: route
-        run: |
-          set -eu
-          git fetch --no-tags --depth 1 origin \
-            "+refs/heads/ci-metadata:refs/remotes/origin/ci-metadata"
-          ROUTE_MATRIX=$(sh scripts/read-version-matrix.sh --print-route | jq -c .)
-          echo "route_matrix=${ROUTE_MATRIX}" >> "$GITHUB_OUTPUT"
+          gh release download "$RELEASE_TAG" -R "$REPOSITORY" --pattern "$HANDOFF_NAME" --dir "${RUNNER_TEMP}/assets"
+          ACTUAL_HANDOFF_DIGEST=$(sha256sum "${RUNNER_TEMP}/assets/${HANDOFF_NAME}" | cut -d' ' -f1)
+          [ "sha256:${ACTUAL_HANDOFF_DIGEST}" = "$HANDOFF_DIGEST" ] || {
+            echo "::error::${HANDOFF_NAME} digest does not match the Release API"; exit 1; }
 
       - name: Materialise the catalogue signing key
         env:
@@ -418,9 +415,9 @@ jobs:
           SOURCE_REPOSITORY: ${{ needs.resolve.outputs.source_repository }}
           RELEASE_ID: ${{ needs.resolve.outputs.release_id }}
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
           DESTINATIONS: ${{ needs.resolve.outputs.destinations }}
           SOURCE_RUN_ID: ${{ github.run_id }}:${{ github.run_attempt }}
-          ROUTE_MATRIX: ${{ steps.route.outputs.route_matrix }}
           # issue #2389: stage under docs/staging/<seg>/<channel>/<varver> instead
           # of publishing directly — nothing is visible under <channel>/<varver>
           # until promote-pkg-repo runs the SAME script in `promote` mode, after a
@@ -435,6 +432,7 @@ jobs:
           export PFB_SRC="$GITHUB_WORKSPACE"
           export PKG_REPO="$GITHUB_WORKSPACE/pkg-repo"
           export ASSETS_DIR="$RUNNER_TEMP/assets"
+          export HANDOFF_FILE="$RUNNER_TEMP/assets/pfblockerng-release-handoff.json"
           export PFB_SIGN_KEY="${RUNNER_TEMP}/pfb-pkg-signing.key"
           sh scripts/publish-pkg-repo.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1016,16 +1016,21 @@ jobs:
       - name: Create tagged release handoff
         env:
           ROUTE_MATRIX: ${{ needs.read-matrix.outputs.route_matrix }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          SOURCE_SHA: ${{ needs.prepare-release.outputs.sha }}
+          CI_METADATA_SHA: ${{ needs.read-matrix.outputs.ci_metadata_sha }}
+          PORTS_SHA: ${{ needs.read-matrix.outputs.ports_sha }}
         run: |
           set -eu
           RELEASE_HANDOFF="$RUNNER_TEMP/pfblockerng-release-handoff.json"
-          printf '%s\n' "$ROUTE_MATRIX" > "${{ runner.temp }}/route-matrix.json"
+          ROUTE_MATRIX_FILE="$RUNNER_TEMP/route-matrix.json"
+          printf '%s\n' "$ROUTE_MATRIX" > "$ROUTE_MATRIX_FILE"
           python3 "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/tagged_release_handoff.py" \
-            --release-tag ${{ needs.prepare-release.outputs.tag }} \
-            --source-sha ${{ needs.prepare-release.outputs.sha }} \
-            --ci-metadata-sha ${{ needs.read-matrix.outputs.ci_metadata_sha }} \
-            --ports-sha ${{ needs.read-matrix.outputs.ports_sha }} \
-            --route-matrix ${{ runner.temp }}/route-matrix.json \
+            --release-tag "$RELEASE_TAG" \
+            --source-sha "$SOURCE_SHA" \
+            --ci-metadata-sha "$CI_METADATA_SHA" \
+            --ports-sha "$PORTS_SHA" \
+            --route-matrix "$ROUTE_MATRIX_FILE" \
             --output "$RELEASE_HANDOFF"
           echo "RELEASE_HANDOFF=${RELEASE_HANDOFF}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,6 +478,9 @@ jobs:
     if: ${{ always() && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped') }}
     outputs:
       release_matrix: ${{ steps.matrices.outputs.release_matrix }}
+      route_matrix: ${{ steps.pins.outputs.route_matrix }}
+      ci_metadata_sha: ${{ steps.pins.outputs.ci_metadata_sha }}
+      ports_sha: ${{ steps.pins.outputs.ports_sha }}
       pkg_channel:  ${{ steps.channel.outputs.pkg_channel }}
       portversion:  ${{ steps.channel.outputs.portversion }}
       release_stage: ${{ steps.channel.outputs.release_stage }}
@@ -568,9 +571,37 @@ jobs:
           PY
           echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
 
+      - name: Pin ci-metadata, ROUTE, and Ports identities
+        id: pins
+        run: |
+          set -eu
+          git fetch --no-tags origin \
+            "+refs/heads/ci-metadata:refs/remotes/origin/ci-metadata"
+          CI_METADATA_SHA=$(git rev-parse "refs/remotes/origin/ci-metadata^{commit}")
+          PORTS_SHA=$(git ls-remote https://github.com/pfBlockerNG/FreeBSD-ports \
+            refs/heads/pfblockerng/use-github | awk 'NR == 1 { print $1 }')
+          for PIN in "$CI_METADATA_SHA" "$PORTS_SHA"; do
+            case "$PIN" in
+              ''|*[!0-9a-f]*) echo "::error::resolved release identity is not a lowercase Git SHA"; exit 1 ;;
+            esac
+            case "${#PIN}" in
+              40|64) ;;
+              *) echo "::error::resolved release identity is not a 40- or 64-character Git SHA"; exit 1 ;;
+            esac
+          done
+          ROUTE_MATRIX=$(git show "${CI_METADATA_SHA}:supported-versions.json" \
+            | jq -ce '.versions | select(type == "array")')
+          {
+            echo "ci_metadata_sha=${CI_METADATA_SHA}"
+            echo "ports_sha=${PORTS_SHA}"
+            echo "route_matrix=${ROUTE_MATRIX}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Read matrix from ci-metadata
         id: matrices
         uses: ./.github/actions/read-version-matrix
+        with:
+          ref: ${{ steps.pins.outputs.ci_metadata_sha }}
 
   # ── 1d. Resolve build stamp ──────────────────────────────────────────────
   # Checks out the SAME ref as build-pkgs-portable so that `created` (epoch of the
@@ -982,6 +1013,22 @@ jobs:
             src/
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
+      - name: Create tagged release handoff
+        env:
+          ROUTE_MATRIX: ${{ needs.read-matrix.outputs.route_matrix }}
+        run: |
+          set -eu
+          RELEASE_HANDOFF="$RUNNER_TEMP/pfblockerng-release-handoff.json"
+          printf '%s\n' "$ROUTE_MATRIX" > "${{ runner.temp }}/route-matrix.json"
+          python3 "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/tagged_release_handoff.py" \
+            --release-tag ${{ needs.prepare-release.outputs.tag }} \
+            --source-sha ${{ needs.prepare-release.outputs.sha }} \
+            --ci-metadata-sha ${{ needs.read-matrix.outputs.ci_metadata_sha }} \
+            --ports-sha ${{ needs.read-matrix.outputs.ports_sha }} \
+            --route-matrix ${{ runner.temp }}/route-matrix.json \
+            --output "$RELEASE_HANDOFF"
+          echo "RELEASE_HANDOFF=${RELEASE_HANDOFF}" >> "$GITHUB_ENV"
+
       - name: Create the GitHub Release as a DRAFT
         # This repo has IMMUTABLE RELEASES enabled: once a release is PUBLISHED its
         # assets are frozen, so assets can only be added while it is still a draft.
@@ -998,10 +1045,11 @@ jobs:
           body: ${{ steps.changelog.outputs.body }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
           draft: true
-          # Idempotent on re-run: update the existing draft and replace its source
-          # archive rather than erroring or duplicating it.
+          # Idempotent on re-run: replace both build-time identity assets.
           overwrite_files: true
-          files: ${{ env.ARCHIVE }}
+          files: |
+            ${{ env.ARCHIVE }}
+            ${{ env.RELEASE_HANDOFF }}
 
   # ── 2b. Build .pkg artifacts (portable Linux builder) ────────────────────
   # Builds ONE .pkg per build-role version/variant row. The release_matrix is
@@ -1105,13 +1153,9 @@ jobs:
           COMMIT:        ${{ needs.resolve-stamp.outputs.commit }}
           CREATED:       ${{ needs.resolve-stamp.outputs.created }}
           MATRIX_ROW:    ${{ toJson(matrix) }}
+          PORTS_SHA:     ${{ needs.read-matrix.outputs.ports_sha }}
         run: |
           set -eu
-          PORTS_SHA=$(git ls-remote https://github.com/pfBlockerNG/FreeBSD-ports refs/heads/pfblockerng/use-github | awk 'NR == 1 { print $1 }')
-          [ -n "$PORTS_SHA" ] || { echo "::error::FreeBSD-ports branch has no resolvable SHA"; exit 1; }
-          # The heredoc below runs in a child process; $GITHUB_ENV only reaches LATER steps.
-          export PORTS_SHA
-          echo "PORTS_SHA=${PORTS_SHA}" >> "$GITHUB_ENV"
           python3 - <<'PY'
           import json
           import os
@@ -1165,6 +1209,7 @@ jobs:
           VARIANT:      ${{ matrix.variant }}
           PFSENSE_VERSION: ${{ matrix.pfsense_version }}
           EXTRA_PKGS:   ${{ steps.extras.outputs.extra_pkgs }}
+          PORTS_SHA: ${{ needs.read-matrix.outputs.ports_sha }}
         run: |
           set -eu
           # Keep generated Ports and package trees outside the pinned source checkout.
@@ -1422,13 +1467,15 @@ jobs:
           EXPECTED_PKGS=$(printf '%s' "$ASSET_MATRIX" | jq '(length) + ([.[] | (.extra_pkgs // []) | length] | add // 0)')
           PKG_COUNT=$(printf '%s' "$META" | jq '[.assets[] | select(.name | endswith(".pkg"))] | length')
           SRC_COUNT=$(printf '%s' "$META" | jq '[.assets[] | select(.name | endswith(".tar.gz"))] | length')
+          HANDOFF_COUNT=$(printf '%s' "$META" | jq '[.assets[] | select(.name == "pfblockerng-release-handoff.json")] | length')
 
           echo "Draft assets:"
           printf '%s' "$META" | jq -r '.assets[].name' | sort | sed 's/^/  - /'
-          echo "Expected .pkg: ${EXPECTED_PKGS} | found .pkg: ${PKG_COUNT} | source archives: ${SRC_COUNT}"
+          echo "Expected .pkg: ${EXPECTED_PKGS} | found .pkg: ${PKG_COUNT} | source archives: ${SRC_COUNT} | handoffs: ${HANDOFF_COUNT}"
 
           FAIL=0
           [ "$SRC_COUNT" -ge 1 ] || { echo "::error::no source archive (.tar.gz) attached to the draft"; FAIL=1; }
+          [ "$HANDOFF_COUNT" -eq 1 ] || { echo "::error::expected exactly one pfblockerng-release-handoff.json asset"; FAIL=1; }
           [ "$EXPECTED_PKGS" -ge 1 ] || { echo "::error::build matrix is empty"; FAIL=1; }
           [ "$PKG_COUNT" -eq "$EXPECTED_PKGS" ] || { echo "::error::expected ${EXPECTED_PKGS} .pkg assets, found ${PKG_COUNT} — the draft is incomplete"; FAIL=1; }
 

--- a/scripts/publish-pkg-repo.sh
+++ b/scripts/publish-pkg-repo.sh
@@ -93,14 +93,14 @@
 #                        noop=true|false.
 #
 # Required environment — PUBLISH_KIND=tagged, PUBLISH_STAGE=direct|stage only:
-#   SOURCE_REPOSITORY, RELEASE_ID, RELEASE_TAG, DESTINATIONS
+#   SOURCE_REPOSITORY, RELEASE_ID, RELEASE_TAG, SOURCE_SHA, DESTINATIONS
 #                        the rest of the publish_release.py intake — see its --help
 #   ASSETS_DIR             directory of downloaded .pkg assets + digests.json sidecar
-#   ROUTE_MATRIX           the pinned ROUTE matrix, compact JSON array text
+#   HANDOFF_FILE           durable build-time tagged release handoff JSON
 #
 # Required environment — PUBLISH_KIND=tagged, PUBLISH_STAGE=promote only:
 #   RELEASE_TAG, DESTINATIONS  the promote commit message's own trailers
-#                        Never ASSETS_DIR/ROUTE_MATRIX — promote never runs
+#                        Never ASSETS_DIR/HANDOFF_FILE — promote never runs
 #                        publish_release.py or any renderer, and the workflow's
 #                        promote-pkg-repo job does not export ASSETS_DIR (issue
 #                        #2389).
@@ -156,9 +156,10 @@ case "$PUBLISH_KIND" in
                 : "${SOURCE_REPOSITORY:?SOURCE_REPOSITORY is required}"
                 : "${RELEASE_ID:?RELEASE_ID is required}"
                 : "${RELEASE_TAG:?RELEASE_TAG is required}"
+                : "${SOURCE_SHA:?SOURCE_SHA is required}"
                 : "${DESTINATIONS:?DESTINATIONS is required}"
                 : "${ASSETS_DIR:?ASSETS_DIR is required}"
-                : "${ROUTE_MATRIX:?ROUTE_MATRIX is required}"
+                : "${HANDOFF_FILE:?HANDOFF_FILE is required}"
                 ;;
             promote)
                 : "${RELEASE_TAG:?RELEASE_TAG is required}"
@@ -495,11 +496,12 @@ while [ "$attempt" -le "$MAX_PUSH_ATTEMPTS" ]; do
                         --source-repository "$SOURCE_REPOSITORY" \
                         --release-id "$RELEASE_ID" \
                         --release-tag "$RELEASE_TAG" \
+                        --source-sha "$SOURCE_SHA" \
                         --destinations "$DESTINATIONS" \
                         --source-run-id "$SOURCE_RUN_ID" \
                         --assets-dir "$ASSETS_DIR" \
                         --pkg-repo "$PKG_REPO" \
-                        --route-matrix "$ROUTE_MATRIX"
+                        --handoff "$HANDOFF_FILE"
                     ;;
                 nightly)
                     set -- \

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -65,6 +65,7 @@ import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import cast
 
 # scripts/ is not a package (no __init__.py); catalogue_assembly.py itself imports
 # publish_catalogues with a bare `from publish_catalogues import Engine`, so every
@@ -79,6 +80,7 @@ if str(_SCRIPTS_DIR) not in sys.path:
 import catalogue_assembly as ca
 import catalogue_sig_only as cso
 import publish_catalogues as pc
+import tagged_release_handoff as trh
 
 _SITE_SUBDIR = "docs"
 _DIGESTS_FILENAME = "digests.json"
@@ -420,11 +422,12 @@ def run(
     source_repository: str,
     release_id: str,
     release_tag: str,
+    source_sha: str,
     destinations: str,
     source_run_id: str,
     assets_dir: str | Path,
     pkg_repo: str | Path,
-    route_matrix: str,
+    handoff_file: str | Path,
     engine: pc.Engine | None = None,
     sign_key: Path | None = None,
 ) -> PublishReport:
@@ -435,13 +438,12 @@ def run(
             "Nightly publishing is not implemented here"
         )
 
-    try:
-        route_matrix_rows = json.loads(route_matrix)
-    except json.JSONDecodeError as exc:
-        raise PublishReleaseError(f"--route-matrix is not valid JSON: {exc}") from exc
-    if not isinstance(route_matrix_rows, list) or not route_matrix_rows:
-        raise PublishReleaseError("--route-matrix must be a non-empty JSON array")
-
+    handoff = trh.load_handoff(
+        handoff_file,
+        expected_release_tag=release_tag,
+        expected_source_sha=source_sha,
+    )
+    route_matrix_rows = cast(list[Mapping[str, object]], handoff["route_matrix"])
     engine = engine if engine is not None else pc.load_engine()
 
     assets_dir = Path(assets_dir)
@@ -450,6 +452,21 @@ def run(
     with tempfile.TemporaryDirectory(prefix="publish-release-verify-") as work_dir:
         verified_assets = _verify_all_assets(engine, intake, assets_dir, digests, Path(work_dir))
         run_result = pc.verify_run(engine, intake, verified_assets, route_matrix_rows)
+        try:
+            trh.validate_build_records(
+                handoff,
+                [cast(Mapping[str, object], asset.record) for asset in run_result.canonical_assets],
+            )
+        except trh.BuildRecordIdentityError as exc:
+            if exc.field == "source_sha":
+                site_root = Path(pkg_repo) / _SITE_SUBDIR
+                for varver, target in _build_targets(engine, run_result).items():
+                    for channel in intake.destinations:
+                        existing = site_root / channel / varver / target.canonical.canonical_name
+                        if existing.is_file():
+                            raise DestinationConflictError(f"{existing}: {exc}") from exc
+                raise DestinationConflictError(str(exc)) from exc
+            raise
         return publish(engine, run_result, pkg_repo, sign_key=sign_key)
 
 
@@ -463,6 +480,7 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument("--source-repository", required=True)
     parser.add_argument("--release-id", required=True)
     parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--source-sha", required=True)
     parser.add_argument("--destinations", required=True, help="compact JSON array")
     parser.add_argument("--source-run-id", required=True)
     parser.add_argument(
@@ -475,7 +493,7 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         required=True,
         help="the checked-out pfBlockerNG/pkg working tree (site is <pkg-repo>/docs)",
     )
-    parser.add_argument("--route-matrix", required=True, help="compact JSON array")
+    parser.add_argument("--handoff", required=True, help="build-time tagged release handoff JSON")
     parser.add_argument(
         "--sign-key",
         default="",
@@ -502,16 +520,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_repository=args.source_repository,
             release_id=args.release_id,
             release_tag=args.release_tag,
+            source_sha=args.source_sha,
             destinations=args.destinations,
             source_run_id=args.source_run_id,
             assets_dir=args.assets_dir,
             pkg_repo=args.pkg_repo,
-            route_matrix=args.route_matrix,
+            handoff_file=args.handoff,
             engine=engine,
             sign_key=Path(args.sign_key) if args.sign_key else None,
         )
     except (
         PublishReleaseError,
+        trh.HandoffError,
         pc.PublishError,
         ca.CatalogueAssemblyError,
         engine.pfb_pkg.PkgError,

--- a/scripts/tagged_release_handoff.py
+++ b/scripts/tagged_release_handoff.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import re
 import sys
@@ -12,7 +11,6 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 _GIT_SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
-_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _RELEASE_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+(?:\.[abr][1-9][0-9]*)?$")
 _FIELDS = {
     "schema",
@@ -21,7 +19,6 @@ _FIELDS = {
     "source_sha",
     "ci_metadata_sha",
     "ports_sha",
-    "route_matrix_sha256",
     "route_matrix",
 }
 
@@ -56,11 +53,6 @@ def _route_matrix(value: object) -> list[dict[str, object]]:
     return normalized
 
 
-def _route_digest(route_matrix: Sequence[Mapping[str, object]]) -> str:
-    canonical = json.dumps(route_matrix, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(canonical.encode()).hexdigest()
-
-
 def build_handoff(
     *,
     release_tag: str,
@@ -83,7 +75,6 @@ def build_handoff(
         "source_sha": source_sha,
         "ci_metadata_sha": ci_metadata_sha,
         "ports_sha": ports_sha,
-        "route_matrix_sha256": _route_digest(rows),
         "route_matrix": rows,
     }
 
@@ -106,7 +97,7 @@ def load_handoff(
         raise HandoffError("tagged release handoff must be a JSON object")
     if set(raw) != _FIELDS:
         raise HandoffError("tagged release handoff has unexpected fields")
-    if raw["schema"] != 1 or raw["kind"] != "tagged-release-handoff":
+    if type(raw["schema"]) is not int or raw["schema"] != 1 or raw["kind"] != "tagged-release-handoff":
         raise HandoffError("tagged release handoff schema or kind is unsupported")
 
     validated = build_handoff(
@@ -116,9 +107,6 @@ def load_handoff(
         ports_sha=raw["ports_sha"],
         route_matrix=raw["route_matrix"],
     )
-    digest = raw["route_matrix_sha256"]
-    if not isinstance(digest, str) or not _DIGEST_RE.fullmatch(digest) or digest != validated["route_matrix_sha256"]:
-        raise HandoffError("route_matrix_sha256 does not match route_matrix")
     if validated["release_tag"] != expected_release_tag:
         raise HandoffError("release_tag does not match the selected Release")
     if validated["source_sha"] != _git_sha(expected_source_sha, "expected source_sha"):

--- a/scripts/tagged_release_handoff.py
+++ b/scripts/tagged_release_handoff.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Create and validate the immutable tagged-release publisher handoff."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+_GIT_SHA_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_RELEASE_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+(?:\.[abr][1-9][0-9]*)?$")
+_FIELDS = {
+    "schema",
+    "kind",
+    "release_tag",
+    "source_sha",
+    "ci_metadata_sha",
+    "ports_sha",
+    "route_matrix_sha256",
+    "route_matrix",
+}
+
+
+class HandoffError(ValueError):
+    """The tagged release handoff is absent, malformed, or inconsistent."""
+
+
+class BuildRecordIdentityError(HandoffError):
+    """A canonical package record disagrees with one handoff identity."""
+
+    def __init__(self, index: int, field: str) -> None:
+        self.field = field
+        super().__init__(f"build record {index} {field} does not match tagged release handoff")
+
+
+def _git_sha(value: object, name: str) -> str:
+    if not isinstance(value, str) or not _GIT_SHA_RE.fullmatch(value):
+        raise HandoffError(f"{name} must be lowercase 40- or 64-character hex")
+    return value
+
+
+def _route_matrix(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list) or not value:
+        raise HandoffError("route_matrix must be a non-empty JSON array")
+    if any(not isinstance(row, Mapping) for row in value):
+        raise HandoffError("route_matrix rows must be JSON objects")
+    try:
+        normalized = json.loads(json.dumps(value, ensure_ascii=False))
+    except (TypeError, ValueError) as exc:
+        raise HandoffError(f"route_matrix is not JSON-serializable: {exc}") from exc
+    return normalized
+
+
+def _route_digest(route_matrix: Sequence[Mapping[str, object]]) -> str:
+    canonical = json.dumps(route_matrix, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def build_handoff(
+    *,
+    release_tag: str,
+    source_sha: str,
+    ci_metadata_sha: str,
+    ports_sha: str,
+    route_matrix: object,
+) -> dict[str, object]:
+    """Build the canonical handoff attached to a draft tagged release."""
+    if not isinstance(release_tag, str) or not _RELEASE_TAG_RE.fullmatch(release_tag):
+        raise HandoffError("release_tag is malformed")
+    source_sha = _git_sha(source_sha, "source_sha")
+    ci_metadata_sha = _git_sha(ci_metadata_sha, "ci_metadata_sha")
+    ports_sha = _git_sha(ports_sha, "ports_sha")
+    rows = _route_matrix(route_matrix)
+    return {
+        "schema": 1,
+        "kind": "tagged-release-handoff",
+        "release_tag": release_tag,
+        "source_sha": source_sha,
+        "ci_metadata_sha": ci_metadata_sha,
+        "ports_sha": ports_sha,
+        "route_matrix_sha256": _route_digest(rows),
+        "route_matrix": rows,
+    }
+
+
+def load_handoff(
+    path: str | Path,
+    *,
+    expected_release_tag: str,
+    expected_source_sha: str,
+) -> dict[str, object]:
+    """Load a handoff and bind it to the selected Release tag and source commit."""
+    path = Path(path)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise HandoffError(f"cannot read tagged release handoff {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise HandoffError(f"tagged release handoff is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise HandoffError("tagged release handoff must be a JSON object")
+    if set(raw) != _FIELDS:
+        raise HandoffError("tagged release handoff has unexpected fields")
+    if raw["schema"] != 1 or raw["kind"] != "tagged-release-handoff":
+        raise HandoffError("tagged release handoff schema or kind is unsupported")
+
+    validated = build_handoff(
+        release_tag=raw["release_tag"],
+        source_sha=raw["source_sha"],
+        ci_metadata_sha=raw["ci_metadata_sha"],
+        ports_sha=raw["ports_sha"],
+        route_matrix=raw["route_matrix"],
+    )
+    digest = raw["route_matrix_sha256"]
+    if not isinstance(digest, str) or not _DIGEST_RE.fullmatch(digest) or digest != validated["route_matrix_sha256"]:
+        raise HandoffError("route_matrix_sha256 does not match route_matrix")
+    if validated["release_tag"] != expected_release_tag:
+        raise HandoffError("release_tag does not match the selected Release")
+    if validated["source_sha"] != _git_sha(expected_source_sha, "expected source_sha"):
+        raise HandoffError("source_sha does not match the selected Release tag")
+    return validated
+
+
+def validate_build_records(handoff: Mapping[str, object], records: Sequence[Mapping[str, object]]) -> None:
+    """Require every canonical package record to carry the handoff identities."""
+    if not records:
+        raise HandoffError("tagged release has no canonical build records")
+    expected = {
+        "source_tag": handoff.get("release_tag"),
+        "source_sha": handoff.get("source_sha"),
+        "freebsd_ports_sha": handoff.get("ports_sha"),
+    }
+    for index, record in enumerate(records):
+        if not isinstance(record, Mapping):
+            raise HandoffError(f"build record {index} must be an object")
+        for name, value in expected.items():
+            if record.get(name) != value:
+                raise BuildRecordIdentityError(index, name)
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--ci-metadata-sha", required=True)
+    parser.add_argument("--ports-sha", required=True)
+    parser.add_argument("--route-matrix", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        route_matrix = json.loads(args.route_matrix.read_text(encoding="utf-8"))
+        handoff = build_handoff(
+            release_tag=args.release_tag,
+            source_sha=args.source_sha,
+            ci_metadata_sha=args.ci_metadata_sha,
+            ports_sha=args.ports_sha,
+            route_matrix=route_matrix,
+        )
+        args.output.write_text(
+            json.dumps(handoff, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+    except (OSError, json.JSONDecodeError, HandoffError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/shell/publish_pkg_repo_spec.sh
+++ b/tests/shell/publish_pkg_repo_spec.sh
@@ -53,6 +53,7 @@ Describe 'publish-pkg-repo.sh'
     # python calls are doubled here rather than re-verified.
     mkdir -p "${base}/fake-src/scripts"
     cat >"${base}/fake-src/scripts/publish_release.py" <<'PY'
+import json
 import os
 import sys
 
@@ -64,6 +65,14 @@ def _arg(name, argv):
 def main():
     argv = sys.argv[1:]
     pkg_repo = _arg("--pkg-repo", argv)
+    handoff_path = _arg("--handoff", argv)
+    _arg("--source-sha", argv)
+    try:
+        with open(handoff_path, encoding="utf-8") as fh:
+            json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"::error::simulated tagged handoff read/parse failure: {exc}", file=sys.stderr)
+        return 1
     mode = os.environ.get("FAKE_MODE", "success")
 
     # Records the exact argv this invocation received, for the spec's own
@@ -229,11 +238,13 @@ PY
         SOURCE_REPOSITORY=pfBlockerNG/pfBlockerNG
         RELEASE_ID=1
         RELEASE_TAG=v4.0.0.b1
+        SOURCE_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         DESTINATIONS='["edge"]'
         SOURCE_RUN_ID=10:1
         ASSETS_DIR="${base}/assets"
-        ROUTE_MATRIX='[{"freebsd_major":"15","pfsense_version":"2.8","variant":"CE","php_version":"8.3","py_flavor":"py311"}]'
-        export PFB_SRC PKG_REPO SOURCE_REPOSITORY RELEASE_ID RELEASE_TAG DESTINATIONS SOURCE_RUN_ID ASSETS_DIR ROUTE_MATRIX
+        HANDOFF_FILE="${base}/tagged-release-handoff.json"
+        printf '%s\n' '{"release_tag":"v4.0.0.b1","source_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' > "$HANDOFF_FILE"
+        export PFB_SRC PKG_REPO SOURCE_REPOSITORY RELEASE_ID RELEASE_TAG SOURCE_SHA DESTINATIONS SOURCE_RUN_ID ASSETS_DIR HANDOFF_FILE
     }
     common_env
     mkdir -p "${base}/assets"
@@ -600,6 +611,44 @@ HOOK
     The result of function remote_head_now should equal "$original_remote_head"
   End
 
+  # --- Tagged durable handoff (issue #2387) ---------------------------------
+
+  It 't1: tagged mode forwards the immutable source and handoff instead of ROUTE text'
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    export FAKE_INVOCATION_RECORD="${base}/tagged-invocation.txt"
+    When run script "$script"
+    The status should equal 0
+    The output should include 'ADVANCE'
+    The stderr should include 'main'
+    invocation="$(cat "${base}/tagged-invocation.txt")"
+    The variable invocation should include '--source-sha'
+    The variable invocation should include "$SOURCE_SHA"
+    The variable invocation should include '--handoff'
+    The variable invocation should include "$HANDOFF_FILE"
+    The variable invocation should not include '--route-matrix'
+  End
+
+  It 't2: malformed tagged handoff aborts before any package-repository mutation'
+    printf '%s\n' 'not json' > "$HANDOFF_FILE"
+    export FAKE_MODE=success
+    export FAKE_TOUCHED=edge/ce-2.8
+    When run script "$script"
+    The status should equal 1
+    The stderr should include 'simulated tagged handoff read/parse failure'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
+  It 't3: missing tagged HANDOFF_FILE fails before any git call'
+    unset HANDOFF_FILE
+    When run script "$script"
+    The status should not equal 0
+    The stderr should include 'HANDOFF_FILE is required'
+    The result of function local_head_now should equal "$original_head"
+    The result of function remote_head_now should equal "$original_remote_head"
+  End
+
   # --- PFB_SIGN_KEY threading (issue #2675 step 1) --------------------------
 
   It 'sk1: tagged mode passes --sign-key to the publisher when PFB_SIGN_KEY is set and non-empty'
@@ -763,7 +812,7 @@ HOOK
 
   It 'n3: nightly mode does not require any tagged-only env var'
     nightly_env
-    unset SOURCE_REPOSITORY RELEASE_ID RELEASE_TAG DESTINATIONS ASSETS_DIR ROUTE_MATRIX
+    unset SOURCE_REPOSITORY RELEASE_ID RELEASE_TAG SOURCE_SHA DESTINATIONS ASSETS_DIR
     export FAKE_MODE=success
     export FAKE_TOUCHED=nightly/ce-2.8
     When run script "$script"
@@ -1193,7 +1242,7 @@ PY
 
   It 'd3: discard succeeds with none of the tagged-only vars set — discard needs only STAGING_PREFIX + SOURCE_RUN_ID'
     seed_staged_tree
-    unset ASSETS_DIR SOURCE_REPOSITORY RELEASE_ID RELEASE_TAG DESTINATIONS ROUTE_MATRIX
+    unset ASSETS_DIR SOURCE_REPOSITORY RELEASE_ID RELEASE_TAG SOURCE_SHA DESTINATIONS HANDOFF_FILE
     export PUBLISH_STAGE=discard
     export STAGING_PREFIX=staging/10-1
     When run script "$script"

--- a/tests/test_issue2143_republish_workflow.py
+++ b/tests/test_issue2143_republish_workflow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import subprocess
 import sys
@@ -151,3 +153,90 @@ def test_manual_republish_rejects_release_selector_before_api(tmp_path: Path) ->
     )
     assert completed.returncode != 0
     assert not marker.exists()
+
+
+def test_tagged_callbacks_execute_handoff_asset_checks(tmp_path: Path) -> None:
+    handoff = tmp_path / _HANDOFF_NAME
+    handoff.write_text('{"schema":1}\n', encoding="utf-8")
+    digest = hashlib.sha256(handoff.read_bytes()).hexdigest()
+    gh = tmp_path / "gh"
+    gh.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            if [ "$1" = api ]; then
+              cat "$META_FILE"
+              exit
+            fi
+            shift 3
+            pattern=
+            destination=
+            while [ "$#" -gt 0 ]; do
+              case "$1" in
+                --pattern) pattern=$2; shift 2 ;;
+                --dir) destination=$2; shift 2 ;;
+                *) shift ;;
+              esac
+            done
+            mkdir -p "$destination"
+            case "$pattern" in
+              '*.pkg') printf pkg > "$destination/test.pkg" ;;
+              *) cp "$HANDOFF_SOURCE" "$destination/$pattern" ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+
+    for workflow, job_name in _SIGN_KEY_JOBS.items():
+        script = textwrap.dedent(
+            extract_step(extract_job(workflow, job_name), "Download release assets + build the digest sidecar").split(
+                "run: |\n", 1
+            )[1]
+        )
+        for handoff_assets, expected in (
+            ([], 1),
+            ([{"name": _HANDOFF_NAME, "digest": f"sha256:{digest}"}], 0),
+            (
+                [
+                    {"name": _HANDOFF_NAME, "digest": f"sha256:{digest}"},
+                    {"name": _HANDOFF_NAME, "digest": f"sha256:{digest}"},
+                ],
+                1,
+            ),
+            ([{"name": _HANDOFF_NAME, "digest": "sha256:" + "0" * 64}], 1),
+        ):
+            meta = tmp_path / "meta.json"
+            meta.write_text(
+                json.dumps(
+                    {
+                        "assets": [
+                            {"name": "test.pkg", "digest": "sha256:" + "1" * 64},
+                            *handoff_assets,
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            runner_temp = tmp_path / f"runner-{len(handoff_assets)}-{expected}"
+            completed = subprocess.run(
+                ["sh", "-c", script],
+                cwd=ROOT,
+                env=os.environ
+                | {
+                    "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}",
+                    "GH_TOKEN": "token",
+                    "REPOSITORY": "pfBlockerNG/pfBlockerNG",
+                    "RELEASE_ID": "1",
+                    "RELEASE_TAG": "v4.0.0",
+                    "HANDOFF_NAME": _HANDOFF_NAME,
+                    "HANDOFF_SOURCE": str(handoff),
+                    "META_FILE": str(meta),
+                    "RUNNER_TEMP": str(runner_temp),
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert (completed.returncode == 0) == (expected == 0), completed.stdout + completed.stderr

--- a/tests/test_issue2143_republish_workflow.py
+++ b/tests/test_issue2143_republish_workflow.py
@@ -47,6 +47,11 @@ _IDENTITY_VALUES = {
     },
 }
 _SOURCE_RUN_ID_VALUE = "${{ github.run_id }}:${{ github.run_attempt }}"
+_SOURCE_SHA_VALUES = {
+    PUBLISHED: "${{ needs.resolve.outputs.source_sha }}",
+    REPUBLISH: "${{ steps.resolve.outputs.source_sha }}",
+}
+_HANDOFF_NAME = "pfblockerng-release-handoff.json"
 
 # issue #2675 step 1: PFB_PKG_SIGNING_KEY (the Actions secret) is materialised to
 # this exact path, then handed to publish-pkg-repo.sh as PFB_SIGN_KEY — never
@@ -72,6 +77,23 @@ def test_republish_and_published_callbacks_forward_exact_run_identity() -> None:
             assert f"{key}: {value}" in step
         assert f"SOURCE_RUN_ID: {_SOURCE_RUN_ID_VALUE}" in step
         assert "gh release list" not in workflow
+
+
+def test_tagged_publishers_consume_the_release_handoff_not_live_ci_metadata() -> None:
+    for workflow, job_name in _SIGN_KEY_JOBS.items():
+        job = extract_job(workflow, job_name)
+        assert "refs/heads/ci-metadata" not in job
+        assert "read-version-matrix.sh --print-route" not in job
+
+        download = extract_step(job, "Download release assets + build the digest sidecar")
+        assert f"HANDOFF_NAME: {_HANDOFF_NAME}" in download
+        assert "gh release download" in download
+        assert '--pattern "$HANDOFF_NAME"' in download
+
+        publish = extract_step(job, _STEP_NAMES[workflow])
+        assert f"SOURCE_SHA: {_SOURCE_SHA_VALUES[workflow]}" in publish
+        assert "ROUTE_MATRIX:" not in publish
+        assert f'export HANDOFF_FILE="$RUNNER_TEMP/assets/{_HANDOFF_NAME}"' in publish
 
 
 def test_publish_step_wires_pfb_sign_key_from_materialised_secret() -> None:

--- a/tests/test_issue2143_republish_workflow.py
+++ b/tests/test_issue2143_republish_workflow.py
@@ -220,7 +220,7 @@ def test_tagged_callbacks_execute_handoff_asset_checks(tmp_path: Path) -> None:
                 ),
                 encoding="utf-8",
             )
-            runner_temp = tmp_path / f"runner-{len(handoff_assets)}-{expected}"
+            runner_temp = tmp_path / f"runner-{job_name}-{len(handoff_assets)}-{expected}"
             gh_log = tmp_path / "gh.log"
             gh_log.write_text("", encoding="utf-8")
             completed = subprocess.run(

--- a/tests/test_issue2143_republish_workflow.py
+++ b/tests/test_issue2143_republish_workflow.py
@@ -164,6 +164,7 @@ def test_tagged_callbacks_execute_handoff_asset_checks(tmp_path: Path) -> None:
         textwrap.dedent(
             """\
             #!/bin/sh
+            printf '%s\n' "$*" >> "$GH_LOG"
             if [ "$1" = api ]; then
               cat "$META_FILE"
               exit
@@ -220,6 +221,8 @@ def test_tagged_callbacks_execute_handoff_asset_checks(tmp_path: Path) -> None:
                 encoding="utf-8",
             )
             runner_temp = tmp_path / f"runner-{len(handoff_assets)}-{expected}"
+            gh_log = tmp_path / "gh.log"
+            gh_log.write_text("", encoding="utf-8")
             completed = subprocess.run(
                 ["sh", "-c", script],
                 cwd=ROOT,
@@ -233,6 +236,7 @@ def test_tagged_callbacks_execute_handoff_asset_checks(tmp_path: Path) -> None:
                     "HANDOFF_NAME": _HANDOFF_NAME,
                     "HANDOFF_SOURCE": str(handoff),
                     "META_FILE": str(meta),
+                    "GH_LOG": str(gh_log),
                     "RUNNER_TEMP": str(runner_temp),
                 },
                 capture_output=True,
@@ -240,3 +244,7 @@ def test_tagged_callbacks_execute_handoff_asset_checks(tmp_path: Path) -> None:
                 check=False,
             )
             assert (completed.returncode == 0) == (expected == 0), completed.stdout + completed.stderr
+            if expected == 0:
+                calls = gh_log.read_text(encoding="utf-8")
+                assert "api repos/pfBlockerNG/pfBlockerNG/releases/1" in calls
+                assert "release download v4.0.0 -R pfBlockerNG/pfBlockerNG" in calls

--- a/tests/test_issue2143_review_round2.py
+++ b/tests/test_issue2143_review_round2.py
@@ -24,28 +24,19 @@ def _republish_validate_script() -> str:
     return textwrap.dedent(REPUBLISH.split("        run: |\n", 1)[1].split("      - uses:", 1)[0])
 
 
-def test_build_record_step_exports_ports_sha_to_the_python_child(tmp_path: Path) -> None:
-    """The record step resolves PORTS_SHA in the shell and reads it from a python child."""
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    fake_git = fake_bin / "git"
-    fake_git.write_text(
-        "#!/bin/sh\nprintf '%s\\t%s\\n' deadbeefdeadbeefdeadbeefdeadbeefdeadbeef refs/heads/x\n",
-        encoding="utf-8",
-    )
-    fake_git.chmod(0o755)
+def test_build_record_step_uses_pinned_ports_sha_in_python_child(tmp_path: Path) -> None:
+    """The record step reads the pre-fan-out PORTS_SHA pin from its environment."""
     workdir = tmp_path / "work"
     workdir.mkdir()
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
+    ports_sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
     completed = subprocess.run(
         ["sh", "-c", _build_record_script()],
         cwd=workdir,
         env=os.environ
         | {
-            "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
             "PYTHONPATH": str(ROOT),
-            "GITHUB_ENV": str(tmp_path / "github-env"),
             "RUNNER_TEMP": str(runner_temp),
             "TAG": "v4.0.0",
             "CHANNEL": "stable",
@@ -55,6 +46,7 @@ def test_build_record_step_exports_ports_sha_to_the_python_child(tmp_path: Path)
             "COMMIT": "0" * 40,
             "CREATED": "1700000000",
             "MATRIX_ROW": '{"variant":"CE","pfsense_version":"2.8"}',
+            "PORTS_SHA": ports_sha,
         },
         capture_output=True,
         text=True,
@@ -63,7 +55,7 @@ def test_build_record_step_exports_ports_sha_to_the_python_child(tmp_path: Path)
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert not (workdir / "build-record.json").exists()
     record = json.loads((runner_temp / "build-record.json").read_text(encoding="utf-8"))
-    assert record["freebsd_ports_sha"] == "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    assert record["freebsd_ports_sha"] == ports_sha
 
 
 @pytest.mark.parametrize(

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -40,6 +40,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import catalogue_assembly as ca
 import publish_catalogues as pc
 import publish_release as pr
+import tagged_release_handoff as trh
 import test_build_repo_portable as tbrp
 from _srcrepo import SourceRepoError, resolve_src_root
 
@@ -389,18 +390,13 @@ def _write_handoff(
     source_sha: str = "a" * 40,
     ports_sha: str = "b" * 64,
 ) -> Path:
-    route_matrix = list(rows)
-    canonical_route = json.dumps(route_matrix, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    payload = {
-        "schema": 1,
-        "kind": "tagged-release-handoff",
-        "release_tag": tag,
-        "source_sha": source_sha,
-        "ci_metadata_sha": "c" * 40,
-        "ports_sha": ports_sha,
-        "route_matrix_sha256": hashlib.sha256(canonical_route.encode()).hexdigest(),
-        "route_matrix": route_matrix,
-    }
+    payload = trh.build_handoff(
+        release_tag=tag,
+        source_sha=source_sha,
+        ci_metadata_sha="c" * 40,
+        ports_sha=ports_sha,
+        route_matrix=list(rows),
+    )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
@@ -628,9 +624,12 @@ class IntakeAndHandoffTests(_TempDirTestCase):
         _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1", include_dependency=False)
         handoff = _write_handoff(
             assets_dir / "pfblockerng-release-handoff.json",
-            rows=(),
+            rows=(ROW_CE,),
             tag="v4.0.0.b1",
         )
+        payload = json.loads(handoff.read_text(encoding="utf-8"))
+        payload["route_matrix"] = []
+        handoff.write_text(json.dumps(payload), encoding="utf-8")
         with self.assertRaises(ValueError) as ctx:
             pr.run(
                 source_repository=_REPO,

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -381,6 +381,31 @@ def _populate_assets_dir(
     return digests
 
 
+def _write_handoff(
+    path: Path,
+    *,
+    rows: Sequence[dict[str, object]],
+    tag: str,
+    source_sha: str = "a" * 40,
+    ports_sha: str = "b" * 64,
+) -> Path:
+    route_matrix = list(rows)
+    canonical_route = json.dumps(route_matrix, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    payload = {
+        "schema": 1,
+        "kind": "tagged-release-handoff",
+        "release_tag": tag,
+        "source_sha": source_sha,
+        "ci_metadata_sha": "c" * 40,
+        "ports_sha": ports_sha,
+        "route_matrix_sha256": hashlib.sha256(canonical_route.encode()).hexdigest(),
+        "route_matrix": route_matrix,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
 def _run(
     *,
     pkg_repo: Path,
@@ -391,17 +416,25 @@ def _run(
     tag: str,
     release_id: str = "1",
     source_run_id: str = "10:1",
+    source_sha: str = "a" * 40,
     sign_key: Path | None = None,
 ) -> pr.PublishReport:
+    handoff = _write_handoff(
+        assets_dir / "pfblockerng-release-handoff.json",
+        rows=rows,
+        tag=tag,
+        source_sha=source_sha,
+    )
     return pr.run(
         source_repository=_REPO,
         release_id=release_id,
         release_tag=tag,
+        source_sha=source_sha,
         destinations=destinations,
         source_run_id=source_run_id,
         assets_dir=assets_dir,
         pkg_repo=pkg_repo,
-        route_matrix=json.dumps(list(rows)),
+        handoff_file=handoff,
         engine=_ENGINE,
         sign_key=sign_key,
     )
@@ -532,11 +565,10 @@ class AssetDiscoveryTests(_TempDirTestCase):
 
 
 # --------------------------------------------------------------------------- #
-# Intake / ROUTE-matrix wiring rejections.
-# --------------------------------------------------------------------------- #
+# Intake / tagged-handoff wiring rejections.
 
 
-class IntakeAndRouteMatrixTests(_TempDirTestCase):
+class IntakeAndHandoffTests(_TempDirTestCase):
     @_requires_engine
     def test_nightly_intake_rejected(self) -> None:
         assets_dir = self.new_assets_dir()
@@ -547,11 +579,12 @@ class IntakeAndRouteMatrixTests(_TempDirTestCase):
                 source_repository=_REPO,
                 release_id="",
                 release_tag="",
+                source_sha="",
                 destinations='["nightly"]',
                 source_run_id="10:1",
                 assets_dir=assets_dir,
                 pkg_repo=self.pkg_repo,
-                route_matrix=json.dumps([ROW_CE]),
+                handoff_file=assets_dir / "missing-handoff.json",
                 engine=_ENGINE,
             )
         self.assertIn("only handles tagged intake", str(ctx.exception))
@@ -569,40 +602,49 @@ class IntakeAndRouteMatrixTests(_TempDirTestCase):
             )
 
     @_requires_engine
-    def test_route_matrix_not_json_rejected(self) -> None:
+    def test_handoff_not_json_rejected(self) -> None:
         assets_dir = self.new_assets_dir()
         _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1", include_dependency=False)
-        with self.assertRaises(pr.PublishReleaseError) as ctx:
+        handoff = assets_dir / "pfblockerng-release-handoff.json"
+        handoff.write_text("not json", encoding="utf-8")
+        with self.assertRaises(ValueError) as ctx:
             pr.run(
                 source_repository=_REPO,
                 release_id="1",
                 release_tag="v4.0.0.b1",
+                source_sha="a" * 40,
                 destinations='["edge"]',
                 source_run_id="10:1",
                 assets_dir=assets_dir,
                 pkg_repo=self.pkg_repo,
-                route_matrix="not json",
+                handoff_file=handoff,
                 engine=_ENGINE,
             )
-        self.assertIn("not valid JSON", str(ctx.exception))
+        self.assertIn("valid JSON", str(ctx.exception))
 
     @_requires_engine
-    def test_route_matrix_empty_array_rejected(self) -> None:
+    def test_handoff_route_matrix_empty_array_rejected(self) -> None:
         assets_dir = self.new_assets_dir()
         _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1", include_dependency=False)
-        with self.assertRaises(pr.PublishReleaseError) as ctx:
+        handoff = _write_handoff(
+            assets_dir / "pfblockerng-release-handoff.json",
+            rows=(),
+            tag="v4.0.0.b1",
+        )
+        with self.assertRaises(ValueError) as ctx:
             pr.run(
                 source_repository=_REPO,
                 release_id="1",
                 release_tag="v4.0.0.b1",
+                source_sha="a" * 40,
                 destinations='["edge"]',
                 source_run_id="10:1",
                 assets_dir=assets_dir,
                 pkg_repo=self.pkg_repo,
-                route_matrix="[]",
+                handoff_file=handoff,
                 engine=_ENGINE,
             )
-        self.assertIn("non-empty JSON array", str(ctx.exception))
+        self.assertIn("route_matrix must be a non-empty JSON array", str(ctx.exception))
 
 
 # --------------------------------------------------------------------------- #
@@ -652,6 +694,34 @@ class RejectionPropagationTests(_TempDirTestCase):
                 tag="v4.0.0.b1",
             )
         self.assertIn("not a build-role ROUTE row", str(ctx.exception))
+
+    @_requires_engine
+    def test_handoff_ports_identity_disagrees_with_build_record_before_publish(self) -> None:
+        assets_dir = self.new_assets_dir()
+        _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1", include_dependency=False)
+        handoff = _write_handoff(
+            assets_dir / "pfblockerng-release-handoff.json",
+            rows=(ROW_CE,),
+            tag="v4.0.0.b1",
+            ports_sha="d" * 40,
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            pr.run(
+                source_repository=_REPO,
+                release_id="1",
+                release_tag="v4.0.0.b1",
+                source_sha="a" * 40,
+                destinations='["edge"]',
+                source_run_id="10:1",
+                assets_dir=assets_dir,
+                pkg_repo=self.pkg_repo,
+                handoff_file=handoff,
+                engine=_ENGINE,
+            )
+
+        self.assertIn("freebsd_ports_sha", str(ctx.exception))
+        self.assertFalse(self.pkg_repo.exists())
 
 
 # --------------------------------------------------------------------------- #
@@ -1525,6 +1595,7 @@ class SignKeyThreadingTests(_TempDirTestCase):
     def test_main_sign_key_flag_reaches_regenerate_catalogue(self) -> None:
         assets_dir = self.new_assets_dir()
         _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1", include_dependency=False)
+        handoff = _write_handoff(assets_dir / "pfblockerng-release-handoff.json", rows=(ROW_CE,), tag="v4.0.0.b1")
         # A REAL key: publish() derives its public half up front, so a placeholder
         # would abort the run before the threading this test is about.
         key = tbrp._gen_key(self.tmp / "repo.key")
@@ -1543,8 +1614,10 @@ class SignKeyThreadingTests(_TempDirTestCase):
             str(assets_dir),
             "--pkg-repo",
             str(self.pkg_repo),
-            "--route-matrix",
-            json.dumps([ROW_CE]),
+            "--source-sha",
+            "a" * 40,
+            "--handoff",
+            str(handoff),
             "--sign-key",
             str(key),
         ]
@@ -1558,6 +1631,7 @@ class SignKeyThreadingTests(_TempDirTestCase):
     def test_main_without_sign_key_flag_passes_none(self) -> None:
         assets_dir = self.new_assets_dir()
         _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1", include_dependency=False)
+        handoff = _write_handoff(assets_dir / "pfblockerng-release-handoff.json", rows=(ROW_CE,), tag="v4.0.0.b1")
         argv = [
             "--source-repository",
             _REPO,
@@ -1573,8 +1647,10 @@ class SignKeyThreadingTests(_TempDirTestCase):
             str(assets_dir),
             "--pkg-repo",
             str(self.pkg_repo),
-            "--route-matrix",
-            json.dumps([ROW_CE]),
+            "--source-sha",
+            "a" * 40,
+            "--handoff",
+            str(handoff),
         ]
         patcher, seen = self._capture_sign_key()
         with patcher, mock.patch.dict(os.environ, {"PFB_SRC": str(_SRC_ROOT)}):
@@ -1593,6 +1669,7 @@ class MainCliTests(_TempDirTestCase):
     def test_main_success_prints_touched_and_returns_zero(self) -> None:
         assets_dir = self.new_assets_dir()
         _populate_assets_dir(assets_dir, rows=(ROW_CE,), source_tag="v4.0.0.b1", include_dependency=False)
+        handoff = _write_handoff(assets_dir / "pfblockerng-release-handoff.json", rows=(ROW_CE,), tag="v4.0.0.b1")
         argv = [
             "--source-repository",
             _REPO,
@@ -1608,8 +1685,10 @@ class MainCliTests(_TempDirTestCase):
             str(assets_dir),
             "--pkg-repo",
             str(self.pkg_repo),
-            "--route-matrix",
-            json.dumps([ROW_CE]),
+            "--source-sha",
+            "a" * 40,
+            "--handoff",
+            str(handoff),
         ]
         with (
             mock.patch.dict(os.environ, {"PFB_SRC": str(_SRC_ROOT)}),
@@ -1623,6 +1702,7 @@ class MainCliTests(_TempDirTestCase):
     def test_main_failure_prints_error_and_returns_one(self) -> None:
         assets_dir = self.new_assets_dir()
         assets_dir.mkdir()
+        handoff = _write_handoff(assets_dir / "pfblockerng-release-handoff.json", rows=(ROW_CE,), tag="v4.0.0.b1")
         argv = [
             "--source-repository",
             _REPO,
@@ -1638,8 +1718,10 @@ class MainCliTests(_TempDirTestCase):
             str(assets_dir),
             "--pkg-repo",
             str(self.pkg_repo),
-            "--route-matrix",
-            json.dumps([ROW_CE]),
+            "--source-sha",
+            "a" * 40,
+            "--handoff",
+            str(handoff),
         ]
         with (
             mock.patch.dict(os.environ, {"PFB_SRC": str(_SRC_ROOT)}),

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _workflow_steps import extract_step
 
 _JOB_HEADER_RE = re.compile(r"^  ([A-Za-z][A-Za-z0-9_-]*):[ \t]*$")
 
@@ -116,6 +123,113 @@ def test_issue_2388_ports_sync_runs_only_after_published_release_resolution() ->
             resolve,
             re.MULTILINE,
         ), f"resolve must expose {output} for sync-ports-fork"
+
+
+def test_issue_2387_tagged_build_uses_one_pinned_route_and_ports_identity() -> None:
+    release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    jobs = _workflow_jobs(ROOT / ".github/workflows/release.yml")
+    read_matrix = "\n".join(jobs["read-matrix"])
+    build = "\n".join(jobs["build-pkgs-portable"])
+
+    for output in ("route_matrix", "ci_metadata_sha", "ports_sha"):
+        assert re.search(
+            rf"^      {output}:\s+\$\{{\{{ steps\.pins\.outputs\.{output} \}}\}}$",
+            read_matrix,
+            re.MULTILINE,
+        ), f"read-matrix must expose the build-time {output}"
+    assert "ref: ${{ steps.pins.outputs.ci_metadata_sha }}" in read_matrix
+    assert read_matrix.count("git ls-remote https://github.com/pfBlockerNG/FreeBSD-ports") == 1
+
+    assert "git ls-remote" not in build
+    build_step = extract_step(release, "Build the .pkg via build-leg.sh")
+    assert "PORTS_SHA: ${{ needs.read-matrix.outputs.ports_sha }}" in build_step
+    assert build_step.count("sh scripts/build-leg.sh") == 1
+    assert build_step.count('--ports-ref  "$PORTS_SHA"') == 1
+
+
+def test_issue_2387_pin_step_executes_against_exact_ci_metadata_sha(tmp_path: Path) -> None:
+    release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    script = textwrap.dedent(
+        extract_step(release, "Pin ci-metadata, ROUTE, and Ports identities").split("run: |\n", 1)[1]
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    git_log = tmp_path / "git.log"
+    matrix = tmp_path / "supported-versions.json"
+    output = tmp_path / "github-output"
+    ci_sha = "a" * 40
+    ports_sha = "b" * 40
+    matrix.write_text(
+        '{"versions":[{"pfsense_version":"2.8","channel":"CE",'
+        '"freebsd_version":"15.0-RELEASE","freebsd_major":"15",'
+        '"php_version":"8.3","py_flavor":"py311","variant":"CE",'
+        '"status":"active","extra_pkgs":[]}]}\n',
+        encoding="utf-8",
+    )
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            printf '%s\\n' "$*" >> "$GIT_LOG"
+            case "$1" in
+              fetch) exit 0 ;;
+              rev-parse) printf '%s\\n' "$CI_SHA" ;;
+              ls-remote) printf '%s\\trefs/heads/pfblockerng/use-github\\n' "$PORTS_SHA" ;;
+              show) cat "$MATRIX_FIXTURE" ;;
+              *) printf 'unexpected git command: %s\\n' "$*" >&2; exit 1 ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+
+    completed = subprocess.run(
+        ["sh", "-c", script],
+        cwd=ROOT,
+        env=os.environ
+        | {
+            "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+            "GITHUB_OUTPUT": str(output),
+            "GITHUB_WORKSPACE": str(ROOT),
+            "GIT_LOG": str(git_log),
+            "MATRIX_FIXTURE": str(matrix),
+            "CI_SHA": ci_sha,
+            "PORTS_SHA": ports_sha,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    emitted = output.read_text(encoding="utf-8")
+    assert f"ci_metadata_sha={ci_sha}" in emitted
+    assert f"ports_sha={ports_sha}" in emitted
+    assert '"pfsense_version":"2.8"' in emitted
+    commands = git_log.read_text(encoding="utf-8")
+    assert f"show {ci_sha}:supported-versions.json" in commands
+    assert commands.count("ls-remote ") == 1
+
+
+def test_issue_2387_draft_persists_the_exact_tagged_handoff_asset() -> None:
+    release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    create = extract_step(release, "Create tagged release handoff")
+    for value in (
+        "--release-tag ${{ needs.prepare-release.outputs.tag }}",
+        "--source-sha ${{ needs.prepare-release.outputs.sha }}",
+        "--ci-metadata-sha ${{ needs.read-matrix.outputs.ci_metadata_sha }}",
+        "--ports-sha ${{ needs.read-matrix.outputs.ports_sha }}",
+        "--route-matrix ${{ runner.temp }}/route-matrix.json",
+    ):
+        assert value in create
+    draft = extract_step(release, "Create the GitHub Release as a DRAFT")
+    assert "${{ env.RELEASE_HANDOFF }}" in draft
+    healthcheck = extract_step(release, "Health-check the draft release is complete")
+    assert "pfblockerng-release-handoff.json" in healthcheck
+    assert "HANDOFF_COUNT" in healthcheck
+    assert 'HANDOFF_COUNT" -eq 1' in healthcheck
 
 
 def test_workflow_parser_does_not_cross_trigger_boundaries() -> None:

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -219,11 +219,16 @@ def test_issue_2387_draft_persists_the_exact_tagged_handoff_asset() -> None:
     release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     create = extract_step(release, "Create tagged release handoff")
     for value in (
-        "--release-tag ${{ needs.prepare-release.outputs.tag }}",
-        "--source-sha ${{ needs.prepare-release.outputs.sha }}",
-        "--ci-metadata-sha ${{ needs.read-matrix.outputs.ci_metadata_sha }}",
-        "--ports-sha ${{ needs.read-matrix.outputs.ports_sha }}",
-        "--route-matrix ${{ runner.temp }}/route-matrix.json",
+        "RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}",
+        "SOURCE_SHA: ${{ needs.prepare-release.outputs.sha }}",
+        "CI_METADATA_SHA: ${{ needs.read-matrix.outputs.ci_metadata_sha }}",
+        "PORTS_SHA: ${{ needs.read-matrix.outputs.ports_sha }}",
+        '--release-tag "$RELEASE_TAG"',
+        '--source-sha "$SOURCE_SHA"',
+        '--ci-metadata-sha "$CI_METADATA_SHA"',
+        '--ports-sha "$PORTS_SHA"',
+        'ROUTE_MATRIX_FILE="$RUNNER_TEMP/route-matrix.json"',
+        '--route-matrix "$ROUTE_MATRIX_FILE"',
     ):
         assert value in create
     draft = extract_step(release, "Create the GitHub Release as a DRAFT")

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -209,6 +209,8 @@ def test_issue_2387_pin_step_executes_against_exact_ci_metadata_sha(tmp_path: Pa
     assert f"ports_sha={ports_sha}" in emitted
     assert '"pfsense_version":"2.8"' in emitted
     commands = git_log.read_text(encoding="utf-8")
+    assert "fetch --no-tags origin +refs/heads/ci-metadata:refs/remotes/origin/ci-metadata" in commands
+    assert "rev-parse refs/remotes/origin/ci-metadata^{commit}" in commands
     assert f"show {ci_sha}:supported-versions.json" in commands
     assert commands.count("ls-remote ") == 1
 

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -884,6 +884,7 @@ def test_build_record_keeps_the_original_release_33_matrix_row(tmp_path: Path) -
             "COMMIT": "b" * 40,
             "CREATED": "1",
             "MATRIX_ROW": json.dumps(row),
+            "PORTS_SHA": "a" * 40,
             "RUNNER_TEMP": str(tmp_path),
             "GITHUB_ENV": str(github_env),
         },

--- a/tests/test_tagged_release_handoff.py
+++ b/tests/test_tagged_release_handoff.py
@@ -88,7 +88,6 @@ def test_cli_creates_canonical_build_time_handoff(tmp_path: Path) -> None:
     assert payload["ci_metadata_sha"] == CI_METADATA_SHA
     assert payload["ports_sha"] == PORTS_SHA
     assert payload["route_matrix"] == [ROW]
-    assert len(payload["route_matrix_sha256"]) == 64
 
 
 def test_load_accepts_exact_release_and_source(tmp_path: Path) -> None:
@@ -106,10 +105,11 @@ def test_load_accepts_exact_release_and_source(tmp_path: Path) -> None:
     [
         ("missing", "cannot read"),
         ("malformed", "valid JSON"),
+        ("schema-bool", "schema"),
+        ("schema-float", "schema"),
         ("wrong-release", "release_tag"),
         ("wrong-source", "source_sha"),
         ("wrong-ci-shape", "ci_metadata_sha"),
-        ("inconsistent-route-digest", "route_matrix_sha256"),
         ("extra-field", "unexpected fields"),
     ],
 )
@@ -124,14 +124,16 @@ def test_load_fails_closed_on_invalid_handoff(tmp_path: Path, case: str, message
         path.write_text("not json", encoding="utf-8")
     else:
         payload = _payload()
-        if case == "wrong-release":
+        if case == "schema-bool":
+            payload["schema"] = True
+        elif case == "schema-float":
+            payload["schema"] = 1.0
+        elif case == "wrong-release":
             expected_tag = "v4.0.0.b2"
         elif case == "wrong-source":
             expected_source = "d" * 40
         elif case == "wrong-ci-shape":
             payload["ci_metadata_sha"] = "not-a-sha"
-        elif case == "inconsistent-route-digest":
-            payload["route_matrix_sha256"] = "0" * 64
         elif case == "extra-field":
             payload["live_route"] = []
         _write(path, payload)

--- a/tests/test_tagged_release_handoff.py
+++ b/tests/test_tagged_release_handoff.py
@@ -82,6 +82,15 @@ def test_cli_creates_canonical_build_time_handoff(tmp_path: Path) -> None:
 
     assert completed.returncode == 0, completed.stderr
     payload = json.loads(output.read_text(encoding="utf-8"))
+    assert set(payload) == {
+        "schema",
+        "kind",
+        "release_tag",
+        "source_sha",
+        "ci_metadata_sha",
+        "ports_sha",
+        "route_matrix",
+    }
     assert payload["kind"] == "tagged-release-handoff"
     assert payload["release_tag"] == TAG
     assert payload["source_sha"] == SOURCE_SHA

--- a/tests/test_tagged_release_handoff.py
+++ b/tests/test_tagged_release_handoff.py
@@ -1,0 +1,171 @@
+"""Tagged release handoff identity and fail-closed validation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/tagged_release_handoff.py"
+TAG = "v4.0.0.b1"
+SOURCE_SHA = "a" * 40
+CI_METADATA_SHA = "b" * 40
+PORTS_SHA = "c" * 40
+ROW = {
+    "pfsense_version": "2.8",
+    "channel": "CE",
+    "freebsd_version": "15.0-RELEASE",
+    "freebsd_major": "15",
+    "php_version": "8.3",
+    "py_flavor": "py311",
+    "variant": "CE",
+    "status": "active",
+    "extra_pkgs": [],
+}
+
+
+def _module() -> Any:
+    spec = importlib.util.spec_from_file_location("tagged_release_handoff", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _payload() -> dict[str, object]:
+    return _module().build_handoff(
+        release_tag=TAG,
+        source_sha=SOURCE_SHA,
+        ci_metadata_sha=CI_METADATA_SHA,
+        ports_sha=PORTS_SHA,
+        route_matrix=[ROW],
+    )
+
+
+def _write(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_cli_creates_canonical_build_time_handoff(tmp_path: Path) -> None:
+    route = tmp_path / "route.json"
+    output = tmp_path / "handoff.json"
+    _write(route, [ROW])
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--release-tag",
+            TAG,
+            "--source-sha",
+            SOURCE_SHA,
+            "--ci-metadata-sha",
+            CI_METADATA_SHA,
+            "--ports-sha",
+            PORTS_SHA,
+            "--route-matrix",
+            str(route),
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["kind"] == "tagged-release-handoff"
+    assert payload["release_tag"] == TAG
+    assert payload["source_sha"] == SOURCE_SHA
+    assert payload["ci_metadata_sha"] == CI_METADATA_SHA
+    assert payload["ports_sha"] == PORTS_SHA
+    assert payload["route_matrix"] == [ROW]
+    assert len(payload["route_matrix_sha256"]) == 64
+
+
+def test_load_accepts_exact_release_and_source(tmp_path: Path) -> None:
+    path = tmp_path / "handoff.json"
+    _write(path, _payload())
+
+    handoff = _module().load_handoff(path, expected_release_tag=TAG, expected_source_sha=SOURCE_SHA)
+
+    assert handoff["route_matrix"] == [ROW]
+    assert handoff["ports_sha"] == PORTS_SHA
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("missing", "cannot read"),
+        ("malformed", "valid JSON"),
+        ("wrong-release", "release_tag"),
+        ("wrong-source", "source_sha"),
+        ("wrong-ci-shape", "ci_metadata_sha"),
+        ("inconsistent-route-digest", "route_matrix_sha256"),
+        ("extra-field", "unexpected fields"),
+    ],
+)
+def test_load_fails_closed_on_invalid_handoff(tmp_path: Path, case: str, message: str) -> None:
+    module = _module()
+    path = tmp_path / "handoff.json"
+    expected_tag = TAG
+    expected_source = SOURCE_SHA
+    if case == "missing":
+        pass
+    elif case == "malformed":
+        path.write_text("not json", encoding="utf-8")
+    else:
+        payload = _payload()
+        if case == "wrong-release":
+            expected_tag = "v4.0.0.b2"
+        elif case == "wrong-source":
+            expected_source = "d" * 40
+        elif case == "wrong-ci-shape":
+            payload["ci_metadata_sha"] = "not-a-sha"
+        elif case == "inconsistent-route-digest":
+            payload["route_matrix_sha256"] = "0" * 64
+        elif case == "extra-field":
+            payload["live_route"] = []
+        _write(path, payload)
+
+    with pytest.raises(module.HandoffError, match=message):
+        module.load_handoff(path, expected_release_tag=expected_tag, expected_source_sha=expected_source)
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"source_tag": "v4.0.0.b2"}, "source_tag"),
+        ({"source_sha": "d" * 40}, "source_sha"),
+        ({"freebsd_ports_sha": "e" * 40}, "freebsd_ports_sha"),
+    ],
+)
+def test_build_records_must_match_handoff_identities(changes: dict[str, str], message: str) -> None:
+    module = _module()
+    record = {
+        "source_tag": TAG,
+        "source_sha": SOURCE_SHA,
+        "freebsd_ports_sha": PORTS_SHA,
+        **changes,
+    }
+
+    with pytest.raises(module.HandoffError, match=message):
+        module.validate_build_records(_payload(), [record])
+
+
+def test_build_records_accept_exact_handoff_identities() -> None:
+    module = _module()
+    records = [
+        {"source_tag": TAG, "source_sha": SOURCE_SHA, "freebsd_ports_sha": PORTS_SHA},
+        {"source_tag": TAG, "source_sha": SOURCE_SHA, "freebsd_ports_sha": PORTS_SHA},
+    ]
+
+    module.validate_build_records(_payload(), records)

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -1035,6 +1035,9 @@ def _run_healthcheck(
     source: str = "release/4.0",
 ) -> subprocess.CompletedProcess[str]:
     script = _healthcheck_script()
+    assets = json.loads(assets_json)
+    assets.append({"name": "pfblockerng-release-handoff.json"})
+    assets_json = json.dumps(assets, separators=(",", ":"))
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
     gh_stub = bin_dir / "gh"

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -1033,10 +1033,11 @@ def _run_healthcheck(
     *,
     is_draft: bool = True,
     source: str = "release/4.0",
+    handoff_count: int = 1,
 ) -> subprocess.CompletedProcess[str]:
     script = _healthcheck_script()
     assets = json.loads(assets_json)
-    assets.append({"name": "pfblockerng-release-handoff.json"})
+    assets.extend({"name": "pfblockerng-release-handoff.json"} for _ in range(handoff_count))
     assets_json = json.dumps(assets, separators=(",", ":"))
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
@@ -1078,6 +1079,17 @@ def test_healthcheck_rejects_published_stale_release(tmp_path: Path) -> None:
         build_matrix='[{"variant":"CE","pfsense_version":"2.8"}]',
         assets_json='[{"name":"pfBlockerNG-src.tar.gz"},{"name":"pfSense-pkg-pfBlockerNG-4.0.0-CE-2.8.pkg"}]',
         is_draft=False,
+    )
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.parametrize("handoff_count", [0, 2])
+def test_healthcheck_requires_exactly_one_tagged_handoff(tmp_path: Path, handoff_count: int) -> None:
+    completed = _run_healthcheck(
+        tmp_path,
+        build_matrix='[{"variant":"CE","pfsense_version":"2.8"}]',
+        assets_json='[{"name":"pfBlockerNG-src.tar.gz"},{"name":"pfSense-pkg-pfBlockerNG-4.0.0-CE-2.8.pkg"}]',
+        handoff_count=handoff_count,
     )
     assert completed.returncode != 0, completed.stdout + completed.stderr
 


### PR DESCRIPTION
## Summary

- resolve one `ci-metadata` SHA, ROUTE matrix, and FreeBSD Ports SHA before tagged build fan-out
- attach `pfblockerng-release-handoff.json` to the draft and consume it from both publication callbacks
- authenticate the handoff against the GitHub Release API asset digest, then validate exact release tag, source SHA, Ports SHA, and every canonical build record before catalogue mutation
- leave Nightly and the publisher state machine unchanged

## Evidence

- Initial production change: frozen focused tests failed on untouched `devel` for the missing handoff and live-input paths, then passed unchanged (`80 passed`; POSIX shellspec `73 examples, 0 failures`).
- Initial RED-time hashes, unchanged through production commit `ef299edcab569cf5c33f3c033f1745a9d47ebc0f`:
  - `tests/test_tagged_release_handoff.py` `1c8489015e9eab2e3045815ff1fc94fc19b2fbab`
  - `tests/test_release_ci_path_consistency.py` `0a7f98274c61eb87a528c573108f8b42a8c7e866`
  - `tests/test_issue2143_republish_workflow.py` `6c99aa6decbc1209301ff6a3e0d36b008e6b79ea`
  - `tests/test_publish_release.py` `9b07e3a3cadf899014d07a2f8286f5d50d1297d1`
  - `tests/shell/publish_pkg_repo_spec.sh` `319eab947e285cb9d5ad01b7016bb28414664fcf`
- Review fix: strict integer schema cases failed before the production edit and passed after (`2 passed`) with frozen hash `ad1bbbc8a198ff41a861919ea7cee0f6b480bbb0`.
- Review hardening: callback fixture isolation kills a missing-download mutation; safe workflow `env:` wiring failed before the production edit and passed after (`2 passed`) with frozen hash `a6eb910df2508f8190cf2cfc3daeb6d3af9888c7`.
- Final head `9dbffcd9fc2bbcc5490f21cbd3a1fe91bad0d3a6` regression hashes:
  - `tests/test_tagged_release_handoff.py` `a70fbc5cf69aa8682a8ab527e33272e8f61cc54c`
  - `tests/test_release_ci_path_consistency.py` `a6eb910df2508f8190cf2cfc3daeb6d3af9888c7`
  - `tests/test_issue2143_republish_workflow.py` `153ebfc3c470ca98064ee9b2a7dc541c529c56a0`
  - `tests/test_publish_release.py` `4de43d50416dcf30343030b20ea0a96ec12ee598`
  - `tests/shell/publish_pkg_repo_spec.sh` `319eab947e285cb9d5ad01b7016bb28414664fcf`
- Final exact-head canonical gates: `GATES: PASS` (`uv run --locked pytest`, ruff lint/format, mypy, `sh -n`, ShellCheck, dash shellspec).

Fixes #2387

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
