### PR TITLE
ci: serialize release mutations

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,3 +6,9 @@ paths:
   .github/workflows/release-published.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/pkg-republish.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/release.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,6 +3,9 @@ paths:
     ignore:
       # GitHub added lossless concurrency queues before actionlint 1.7.12.
       - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/pkg-render-site.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'
   .github/workflows/release-published.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -478,6 +478,7 @@ jobs:
     uses: ./.github/workflows/pkg-render-site.yml
     with:
       source_ref: "${{ needs.prepare.outputs.tools_sha }}"
+      caller_holds_pkg_lock: true
     secrets:
       PKG_GITHUB_APP_ID: ${{ secrets.PKG_GITHUB_APP_ID }}
       PKG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: nightly-snapshot
+  group: pkg-repository-mutation
   queue: max
   cancel-in-progress: false
 

--- a/.github/workflows/pkg-render-site.yml
+++ b/.github/workflows/pkg-render-site.yml
@@ -15,6 +15,10 @@ on:
         description: pfBlockerNG ref providing scripts/gen_landing.py + pkg-site/
         required: true
         type: string
+      caller_holds_pkg_lock:
+        description: Caller already owns the shared pfBlockerNG/pkg mutation lock
+        required: true
+        type: boolean
     secrets:
       PKG_GITHUB_APP_ID:
         required: true
@@ -32,13 +36,17 @@ permissions:
   packages: read
   contents: read
 
+# Direct dispatches take the repository lock. Reusable callers already hold it,
+# so their callee gets a run-unique group rather than deadlocking behind itself.
+concurrency:
+  group: ${{ inputs.caller_holds_pkg_lock && format('pkg-render-site-{0}', github.run_id) || 'pkg-repository-mutation' }}
+  queue: max
+  cancel-in-progress: false
+
 jobs:
   render:
     name: Render the pkg website
     runs-on: ubuntu-latest
-    concurrency:
-      group: pkg-render-site
-      cancel-in-progress: false
     steps:
       - name: Checkout pfBlockerNG (the engine + orchestration scripts)
         uses: actions/checkout@v6

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -28,6 +28,11 @@ permissions:
   packages: read
   contents: read
 
+concurrency:
+  group: pkg-repository-mutation
+  queue: max
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Publish the pkg catalogue

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -197,6 +197,7 @@ jobs:
     uses: ./.github/workflows/pkg-render-site.yml
     with:
       source_ref: "${{ github.workflow_sha }}"
+      caller_holds_pkg_lock: true
     secrets:
       PKG_GITHUB_APP_ID: ${{ secrets.PKG_GITHUB_APP_ID }}
       PKG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -634,6 +634,7 @@ jobs:
     uses: ./.github/workflows/pkg-render-site.yml
     with:
       source_ref: "${{ github.workflow_sha }}"
+      caller_holds_pkg_lock: true
     secrets:
       PKG_GITHUB_APP_ID: ${{ secrets.PKG_GITHUB_APP_ID }}
       PKG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -21,14 +21,11 @@ permissions:
   packages: read
   contents: read
 
-# issue #2389 / #2391: two publishes racing would both stage under docs/staging
-# and stomp each other's promote/discard — serialize the whole pipeline (stage
-# through promote) rather than just the push at the end.
-# Keep every published release queued: the default single pending run replaces an
-# earlier pending release when a third arrives. queue:max retains up to 100 pending
-# runs; cancel-in-progress:false preserves the one already running.
+# issue #2389 / #2391: serialize every workflow that can mutate pfBlockerNG/pkg
+# across stage, validation, promote/discard, and site rendering. Keep every run
+# queued and preserve the one already running.
 concurrency:
-  group: release-published-pkg-repo
+  group: pkg-repository-mutation
   queue: max
   cancel-in-progress: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,11 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: release-${{ github.event.inputs.dry_run == 'true' && format('dry-run-{0}', github.run_id) || github.event.inputs.channel }}
+  queue: max
+  cancel-in-progress: false
+
 jobs:
   # ── 0. Prepare release (real publish only) ───────────────────────────────
   # PINS the release SHA and mints the annotated tag LOCALLY — it commits nothing,

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -38,5 +38,7 @@ def test_actionlint_exception_is_narrowly_scoped_to_workflows_using_queue_max() 
         "paths": {
             ".github/workflows/nightly.yml": {"ignore": [queue_error]},
             ".github/workflows/release-published.yml": {"ignore": [queue_error]},
+            ".github/workflows/pkg-republish.yml": {"ignore": [queue_error]},
+            ".github/workflows/release.yml": {"ignore": [queue_error]},
         }
     }

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -37,6 +37,7 @@ def test_actionlint_exception_is_narrowly_scoped_to_workflows_using_queue_max() 
     assert yaml.safe_load(ACTIONLINT_CONFIG.read_text(encoding="utf-8")) == {
         "paths": {
             ".github/workflows/nightly.yml": {"ignore": [queue_error]},
+            ".github/workflows/pkg-render-site.yml": {"ignore": [queue_error]},
             ".github/workflows/release-published.yml": {"ignore": [queue_error]},
             ".github/workflows/pkg-republish.yml": {"ignore": [queue_error]},
             ".github/workflows/release.yml": {"ignore": [queue_error]},

--- a/tests/test_issue2450_render_site_workflow.py
+++ b/tests/test_issue2450_render_site_workflow.py
@@ -14,6 +14,8 @@ import importlib.util
 import re
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
@@ -72,9 +74,18 @@ def test_render_site_job_pins_source_ref_and_credentials() -> None:
     assert "persist-credentials: true" in job
 
 
-def test_render_site_job_serialises_via_job_level_concurrency() -> None:
-    job = _extract_job(RENDER, "render")
-    assert re.search(r"^\s+concurrency:\n\s+group: \S+\n\s+cancel-in-progress: false\s*$", job, re.MULTILINE), job
+def test_render_site_workflow_serialises_without_deadlocking_reusable_callers() -> None:
+    workflow = yaml.safe_load(RENDER)
+    concurrency = workflow["concurrency"]
+    assert concurrency == {
+        "group": (
+            "${{ inputs.caller_holds_pkg_lock "
+            "&& format('pkg-render-site-{0}', github.run_id) || 'pkg-repository-mutation' }}"
+        ),
+        "queue": "max",
+        "cancel-in-progress": False,
+    }
+    assert "concurrency:" not in _extract_job(RENDER, "render")
 
 
 def test_render_site_workflow_declares_an_explicit_secrets_contract() -> None:

--- a/tests/test_issue2450_render_site_workflow.py
+++ b/tests/test_issue2450_render_site_workflow.py
@@ -14,8 +14,6 @@ import importlib.util
 import re
 from pathlib import Path
 
-import yaml
-
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
@@ -74,17 +72,7 @@ def test_render_site_job_pins_source_ref_and_credentials() -> None:
     assert "persist-credentials: true" in job
 
 
-def test_render_site_workflow_serialises_without_deadlocking_reusable_callers() -> None:
-    workflow = yaml.safe_load(RENDER)
-    concurrency = workflow["concurrency"]
-    assert concurrency == {
-        "group": (
-            "${{ inputs.caller_holds_pkg_lock "
-            "&& format('pkg-render-site-{0}', github.run_id) || 'pkg-repository-mutation' }}"
-        ),
-        "queue": "max",
-        "cancel-in-progress": False,
-    }
+def test_render_site_job_has_no_second_concurrency_lock() -> None:
     assert "concurrency:" not in _extract_job(RENDER, "render")
 
 

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -1,4 +1,4 @@
-"""Keep release CI fallback exclusions aligned with workflow path filters."""
+"""Keep release CI fallback exclusions and workflow concurrency contracts aligned."""
 
 from __future__ import annotations
 
@@ -264,3 +264,149 @@ on:
 
     with pytest.raises(AssertionError, match="unparsed paths-ignore entry"):
         _workflow_paths_from_source(source, "push")
+
+
+_RELEASE_GROUP_RE = re.compile(
+    r"release-\$\{\{ github\.event\.inputs\.dry_run == '(?P<dry>true)' "
+    r"&& format\('(?P<template>dry-run-\{0\})', github\.run_id\) "
+    r"\|\| github\.event\.inputs\.channel \}\}"
+)
+_RELEASE_GROUP = (
+    "release-${{ github.event.inputs.dry_run == 'true' "
+    "&& format('dry-run-{0}', github.run_id) || github.event.inputs.channel }}"
+)
+_PKG_REPO_MUTATION_GROUP = "pkg-repository-mutation"
+
+
+def _top_level_concurrency(source: str) -> dict[str, str]:
+    lines = source.splitlines()
+    try:
+        start = lines.index("concurrency:")
+    except ValueError as exc:
+        raise AssertionError("missing top-level concurrency block") from exc
+    end = next(
+        (index for index in range(start + 1, len(lines)) if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*:", lines[index])),
+        len(lines),
+    )
+    values: dict[str, str] = {}
+    for line in lines[start + 1 : end]:
+        if not line or line.lstrip().startswith("#"):
+            continue
+        match = re.fullmatch(r"  ([A-Za-z][A-Za-z0-9_-]*):[ \t]+(.+)", line)
+        assert match is not None, f"unparsed top-level concurrency entry: {line!r}"
+        key, value = match.groups()
+        assert key not in values, f"duplicate top-level concurrency key: {key}"
+        values[key] = value
+    return values
+
+
+def _assert_release_concurrency(source: str) -> None:
+    concurrency = _top_level_concurrency(source)
+    assert concurrency.get("queue") == "max", "real cuts must retain every queued dispatch"
+    assert concurrency.get("cancel-in-progress") == "false", "a running cut must never be cancelled"
+    group = concurrency.get("group", "")
+    assert _RELEASE_GROUP_RE.fullmatch(group), f"release concurrency group has the wrong ownership: {group!r}"
+
+
+def _release_group(source: str, *, dry_run: str, channel: str, run_id: int) -> str:
+    _assert_release_concurrency(source)
+    match = _RELEASE_GROUP_RE.fullmatch(_top_level_concurrency(source)["group"])
+    assert match is not None
+    suffix = match.group("template").format(run_id) if dry_run == match.group("dry") else channel
+    return f"release-{suffix}"
+
+
+def _assert_pkg_repository_concurrency(source: str) -> None:
+    concurrency = _top_level_concurrency(source)
+    assert concurrency.get("group") == _PKG_REPO_MUTATION_GROUP
+    assert concurrency.get("queue") == "max"
+    assert concurrency.get("cancel-in-progress") == "false"
+
+
+def test_issue_2391_real_release_cuts_are_channel_serialized_and_dry_runs_are_unique() -> None:
+    source = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    assert _release_group(source, dry_run="false", channel="stable", run_id=101) == "release-stable"
+    assert _release_group(source, dry_run="false", channel="stable", run_id=102) == "release-stable"
+    assert _release_group(source, dry_run="false", channel="testing", run_id=101) == "release-testing"
+    assert _release_group(source, dry_run="true", channel="stable", run_id=101) == "release-dry-run-101"
+    assert _release_group(source, dry_run="true", channel="stable", run_id=102) == "release-dry-run-102"
+
+
+@pytest.mark.parametrize(
+    "offence",
+    (
+        "missing-block",
+        "missing-group",
+        "wrong-group",
+        "missing-queue",
+        "wrong-queue",
+        "missing-cancel",
+        "wrong-cancel",
+    ),
+)
+def test_issue_2391_release_concurrency_planted_offences_go_red(offence: str) -> None:
+    valid = (
+        "name: Release\n"
+        "concurrency:\n"
+        f"  group: {_RELEASE_GROUP}\n"
+        "  queue: max\n"
+        "  cancel-in-progress: false\n"
+        "jobs:\n"
+        "  build:\n"
+    )
+    _assert_release_concurrency(valid)
+    mutations = {
+        "missing-block": valid.replace(
+            f"concurrency:\n  group: {_RELEASE_GROUP}\n  queue: max\n  cancel-in-progress: false\n",
+            "",
+        ),
+        "missing-group": valid.replace(f"  group: {_RELEASE_GROUP}\n", ""),
+        "wrong-group": valid.replace("github.event.inputs.channel", "github.run_id"),
+        "missing-queue": valid.replace("  queue: max\n", ""),
+        "wrong-queue": valid.replace("  queue: max", "  queue: latest"),
+        "missing-cancel": valid.replace("  cancel-in-progress: false\n", ""),
+        "wrong-cancel": valid.replace("  cancel-in-progress: false", "  cancel-in-progress: true"),
+    }
+    with pytest.raises(AssertionError):
+        _assert_release_concurrency(mutations[offence])
+
+
+def test_issue_2391_every_external_pkg_repository_mutator_shares_one_queue() -> None:
+    workflows = ROOT / ".github/workflows"
+    mutators: dict[str, str] = {}
+    for path in workflows.glob("*.yml"):
+        source = path.read_text(encoding="utf-8")
+        if (
+            re.search(r"^\s+repository: pfBlockerNG/pkg$", source, re.MULTILINE)
+            and "\n  workflow_call:" not in source.split("\njobs:\n", 1)[0]
+        ):
+            mutators[path.name] = source
+    assert set(mutators) == {"nightly.yml", "release-published.yml", "pkg-republish.yml"}
+    for source in mutators.values():
+        _assert_pkg_repository_concurrency(source)
+
+
+@pytest.mark.parametrize(
+    ("key", "wrong_value"),
+    (
+        ("group", "tagged-publish-only"),
+        ("queue", "latest"),
+        ("cancel-in-progress", "true"),
+    ),
+)
+def test_issue_2391_pkg_repository_concurrency_planted_offences_go_red(key: str, wrong_value: str) -> None:
+    valid = f"""\
+name: Mutator
+concurrency:
+  group: {_PKG_REPO_MUTATION_GROUP}
+  queue: max
+  cancel-in-progress: false
+jobs:
+  publish:
+"""
+    _assert_pkg_repository_concurrency(valid)
+    current_value = _top_level_concurrency(valid)[key]
+    mutated = valid.replace(f"  {key}: {current_value}\n", f"  {key}: {wrong_value}\n")
+    with pytest.raises(AssertionError):
+        _assert_pkg_repository_concurrency(mutated)

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -8,8 +8,10 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import cast
 
 import pytest
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -276,41 +278,70 @@ _RELEASE_GROUP = (
     "&& format('dry-run-{0}', github.run_id) || github.event.inputs.channel }}"
 )
 _PKG_REPO_MUTATION_GROUP = "pkg-repository-mutation"
+_RENDER_GROUP = (
+    "${{ inputs.caller_holds_pkg_lock && format('pkg-render-site-{0}', github.run_id) || 'pkg-repository-mutation' }}"
+)
+_RENDER_WORKFLOW = "./.github/workflows/pkg-render-site.yml"
 
 
-def _top_level_concurrency(source: str) -> dict[str, str]:
-    lines = source.splitlines()
-    try:
-        start = lines.index("concurrency:")
-    except ValueError as exc:
-        raise AssertionError("missing top-level concurrency block") from exc
-    end = next(
-        (index for index in range(start + 1, len(lines)) if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*:", lines[index])),
-        len(lines),
-    )
-    values: dict[str, str] = {}
-    for line in lines[start + 1 : end]:
-        if not line or line.lstrip().startswith("#"):
-            continue
-        match = re.fullmatch(r"  ([A-Za-z][A-Za-z0-9_-]*):[ \t]+(.+)", line)
-        assert match is not None, f"unparsed top-level concurrency entry: {line!r}"
-        key, value = match.groups()
-        assert key not in values, f"duplicate top-level concurrency key: {key}"
-        values[key] = value
-    return values
+def _workflow_document(source: str) -> dict[object, object]:
+    document: object = yaml.safe_load(source)
+    assert isinstance(document, dict), "workflow must be a YAML mapping"
+    return document
+
+
+def _contains_mapping_value(value: object, key: str, expected: str) -> bool:
+    if isinstance(value, dict):
+        return any(
+            (item_key == key and item_value == expected) or _contains_mapping_value(item_value, key, expected)
+            for item_key, item_value in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_mapping_value(item, key, expected) for item in value)
+    return False
+
+
+def _external_workflow(document: dict[object, object]) -> bool:
+    triggers = document.get(True)  # PyYAML 1.1 resolves the plain `on` key to True.
+    assert isinstance(triggers, dict), "workflow must declare an on mapping"
+    return any(trigger != "workflow_call" for trigger in triggers)
+
+
+def _render_call(document: dict[object, object]) -> dict[object, object] | None:
+    jobs = document.get("jobs")
+    assert isinstance(jobs, dict)
+    for job in jobs.values():
+        if isinstance(job, dict) and job.get("uses") == _RENDER_WORKFLOW:
+            return job
+    return None
+
+
+def _workflow_sources(directory: Path) -> dict[str, str]:
+    paths = {path.name: path for pattern in ("*.yml", "*.yaml") for path in directory.glob(pattern)}
+    return {name: paths[name].read_text(encoding="utf-8") for name in sorted(paths)}
+
+
+def _top_level_concurrency(source: str) -> dict[str, object]:
+    concurrency = _workflow_document(source).get("concurrency")
+    assert isinstance(concurrency, dict), "missing top-level concurrency block"
+    assert all(isinstance(key, str) for key in concurrency)
+    return cast(dict[str, object], concurrency)
 
 
 def _assert_release_concurrency(source: str) -> None:
     concurrency = _top_level_concurrency(source)
     assert concurrency.get("queue") == "max", "real cuts must retain every queued dispatch"
-    assert concurrency.get("cancel-in-progress") == "false", "a running cut must never be cancelled"
+    assert concurrency.get("cancel-in-progress") is False, "a running cut must never be cancelled"
     group = concurrency.get("group", "")
+    assert isinstance(group, str)
     assert _RELEASE_GROUP_RE.fullmatch(group), f"release concurrency group has the wrong ownership: {group!r}"
 
 
 def _release_group(source: str, *, dry_run: str, channel: str, run_id: int) -> str:
     _assert_release_concurrency(source)
-    match = _RELEASE_GROUP_RE.fullmatch(_top_level_concurrency(source)["group"])
+    group = _top_level_concurrency(source)["group"]
+    assert isinstance(group, str)
+    match = _RELEASE_GROUP_RE.fullmatch(group)
     assert match is not None
     suffix = match.group("template").format(run_id) if dry_run == match.group("dry") else channel
     return f"release-{suffix}"
@@ -320,7 +351,19 @@ def _assert_pkg_repository_concurrency(source: str) -> None:
     concurrency = _top_level_concurrency(source)
     assert concurrency.get("group") == _PKG_REPO_MUTATION_GROUP
     assert concurrency.get("queue") == "max"
-    assert concurrency.get("cancel-in-progress") == "false"
+    assert concurrency.get("cancel-in-progress") is False
+
+
+def _assert_render_site_concurrency(source: str) -> None:
+    concurrency = _top_level_concurrency(source)
+    assert concurrency.get("group") == _RENDER_GROUP
+    assert concurrency.get("queue") == "max"
+    assert concurrency.get("cancel-in-progress") is False
+
+
+def _render_group(source: str, *, caller_holds_pkg_lock: bool, run_id: int) -> str:
+    _assert_render_site_concurrency(source)
+    return f"pkg-render-site-{run_id}" if caller_holds_pkg_lock else _PKG_REPO_MUTATION_GROUP
 
 
 def test_issue_2391_real_release_cuts_are_channel_serialized_and_dry_runs_are_unique() -> None:
@@ -373,18 +416,57 @@ def test_issue_2391_release_concurrency_planted_offences_go_red(offence: str) ->
 
 
 def test_issue_2391_every_external_pkg_repository_mutator_shares_one_queue() -> None:
-    workflows = ROOT / ".github/workflows"
-    mutators: dict[str, str] = {}
-    for path in workflows.glob("*.yml"):
-        source = path.read_text(encoding="utf-8")
-        if (
-            re.search(r"^\s+repository: pfBlockerNG/pkg$", source, re.MULTILINE)
-            and "\n  workflow_call:" not in source.split("\njobs:\n", 1)[0]
-        ):
-            mutators[path.name] = source
-    assert set(mutators) == {"nightly.yml", "release-published.yml", "pkg-republish.yml"}
-    for source in mutators.values():
+    sources = _workflow_sources(ROOT / ".github/workflows")
+    mutators = {
+        name: source
+        for name, source in sources.items()
+        if _contains_mapping_value(_workflow_document(source), "repository", "pfBlockerNG/pkg")
+        and _external_workflow(_workflow_document(source))
+    }
+    assert set(mutators) == {
+        "nightly.yml",
+        "pkg-render-site.yml",
+        "pkg-republish.yml",
+        "release-published.yml",
+    }
+    for name, source in mutators.items():
+        if name == "pkg-render-site.yml":
+            _assert_render_site_concurrency(source)
+        else:
+            _assert_pkg_repository_concurrency(source)
+
+
+def test_issue_2391_render_callers_own_the_pkg_lock_without_deadlocking_the_callee() -> None:
+    sources = _workflow_sources(ROOT / ".github/workflows")
+    callers = {
+        name: (source, call)
+        for name, source in sources.items()
+        if (call := _render_call(_workflow_document(source))) is not None
+    }
+    assert set(callers) == {"nightly.yml", "pkg-republish.yml", "release-published.yml"}
+    for source, call in callers.values():
         _assert_pkg_repository_concurrency(source)
+        inputs = call.get("with")
+        assert isinstance(inputs, dict)
+        assert inputs.get("caller_holds_pkg_lock") is True
+
+    render = sources["pkg-render-site.yml"]
+    assert _render_group(render, caller_holds_pkg_lock=False, run_id=101) == _PKG_REPO_MUTATION_GROUP
+    assert _render_group(render, caller_holds_pkg_lock=True, run_id=101) == "pkg-render-site-101"
+
+
+@pytest.mark.parametrize(
+    "repository",
+    (
+        "repository: pfBlockerNG/pkg # valid inline YAML comment",
+        'repository: "pfBlockerNG/pkg"',
+    ),
+)
+def test_issue_2391_pkg_mutator_inventory_uses_yaml_values(repository: str) -> None:
+    source = f"on:\n  workflow_dispatch:\njobs:\n  mutate:\n    steps:\n      - with:\n          {repository}\n"
+    document = _workflow_document(source)
+    assert _external_workflow(document)
+    assert _contains_mapping_value(document, "repository", "pfBlockerNG/pkg")
 
 
 @pytest.mark.parametrize(
@@ -406,7 +488,11 @@ jobs:
   publish:
 """
     _assert_pkg_repository_concurrency(valid)
-    current_value = _top_level_concurrency(valid)[key]
+    current_value = {
+        "group": _PKG_REPO_MUTATION_GROUP,
+        "queue": "max",
+        "cancel-in-progress": "false",
+    }[key]
     mutated = valid.replace(f"  {key}: {current_value}\n", f"  {key}: {wrong_value}\n")
     with pytest.raises(AssertionError):
         _assert_pkg_repository_concurrency(mutated)

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -361,11 +361,6 @@ def _assert_render_site_concurrency(source: str) -> None:
     assert concurrency.get("cancel-in-progress") is False
 
 
-def _render_group(source: str, *, caller_holds_pkg_lock: bool, run_id: int) -> str:
-    _assert_render_site_concurrency(source)
-    return f"pkg-render-site-{run_id}" if caller_holds_pkg_lock else _PKG_REPO_MUTATION_GROUP
-
-
 def test_issue_2391_real_release_cuts_are_channel_serialized_and_dry_runs_are_unique() -> None:
     source = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
 
@@ -450,9 +445,17 @@ def test_issue_2391_render_callers_own_the_pkg_lock_without_deadlocking_the_call
         assert isinstance(inputs, dict)
         assert inputs.get("caller_holds_pkg_lock") is True
 
-    render = sources["pkg-render-site.yml"]
-    assert _render_group(render, caller_holds_pkg_lock=False, run_id=101) == _PKG_REPO_MUTATION_GROUP
-    assert _render_group(render, caller_holds_pkg_lock=True, run_id=101) == "pkg-render-site-101"
+    render = _workflow_document(sources["pkg-render-site.yml"])
+    triggers = render.get(True)
+    assert isinstance(triggers, dict)
+    workflow_call = triggers.get("workflow_call")
+    assert isinstance(workflow_call, dict)
+    call_inputs = workflow_call.get("inputs")
+    assert isinstance(call_inputs, dict)
+    lock_input = call_inputs.get("caller_holds_pkg_lock")
+    assert isinstance(lock_input, dict)
+    assert lock_input.get("required") is True
+    assert lock_input.get("type") == "boolean"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- serialize real tagged cuts per release channel without cancelling the running cut
- keep dry-run builds independent by grouping them with the workflow run ID
- serialize Nightly, published-release, and manual-republish mutations of `pfBlockerNG/pkg`
- add structural and mutation-tested workflow concurrency contracts

## Verification

- `uv run pytest tests/test_release_ci_path_consistency.py -q` — 19 passed
- `uv run pytest tests/test_release_ci_path_consistency.py tests/test_issue2245_stateless_nightly.py -q` — 22 passed
- `actionlint .github/workflows/release.yml .github/workflows/release-published.yml .github/workflows/pkg-republish.yml .github/workflows/nightly.yml` — passed
- `scripts/agent/run-gates.sh --diff origin/devel` — all gates passed
- independent verifier — PASS; frozen test hash `07e7148c6f13c18a8d867bd95eae70069fe38eef`

Fixes #2391

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved release and package repository workflow coordination to prevent conflicting updates.
  - Release runs are now serialized by channel, while dry runs can proceed independently.
  - In-progress workflows are no longer cancelled when newer runs are queued.
  - Package repository changes are queued consistently across nightly builds, republishing, site rendering, and published releases.
- **Reliability**
  - Added safeguards and validation to ensure workflow concurrency settings remain consistent and prevent deadlocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->